### PR TITLE
feat(chat): show timestamps under user/assistant bubbles

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -77,6 +77,7 @@ def get_conversation(conversation: str) -> dict:
 		fields=[
 			"name", "seq", "role", "content", "streaming", "error",
 			"tool_name", "tool_args", "tool_result", "tool_status",
+			"creation",
 		],
 		order_by="seq asc",
 	)

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -250,6 +250,7 @@
 .jarvis-message {
 	margin-bottom: 16px;
 	display: flex;
+	flex-direction: column;
 	max-width: 100%;
 }
 
@@ -262,7 +263,7 @@
 }
 
 .jarvis-message-user {
-	justify-content: flex-end;
+	align-items: flex-end;
 }
 
 .jarvis-message-user .jarvis-bubble {
@@ -272,7 +273,7 @@
 }
 
 .jarvis-message-assistant {
-	justify-content: flex-start;
+	align-items: flex-start;
 }
 
 .jarvis-message-assistant .jarvis-bubble {
@@ -455,6 +456,33 @@
  * itself already conveys "this is the agent's work area". */
 .jarvis-tool-group-body .jarvis-tool-head {
 	background: var(--bg-light-gray);
+}
+
+/* ---- Message timestamp -------------------------------------- */
+
+.jarvis-msg-time {
+	font-size: 10.5px;
+	color: var(--text-muted);
+	margin-top: 3px;
+	line-height: 1;
+	letter-spacing: 0.02em;
+}
+
+/* Align timestamp to match its bubble (user right, assistant left). */
+.jarvis-message-user .jarvis-msg-time {
+	text-align: right;
+	padding-right: 6px;
+}
+
+.jarvis-message-assistant .jarvis-msg-time {
+	text-align: left;
+	padding-left: 6px;
+}
+
+/* The frappe-timestamp span renders inline; ensure its title-on-hover
+ * tooltip behavior isn't overridden by anything. */
+.jarvis-msg-time .frappe-timestamp {
+	cursor: help;
 }
 
 /* ---- Streaming cursor --------------------------------------- */

--- a/jarvis/public/js/jarvis_chat/messages.js
+++ b/jarvis/public/js/jarvis_chat/messages.js
@@ -18,11 +18,18 @@ export function buildMessageEl(msg) {
 	const $m = $(
 		`<div class="jarvis-message jarvis-message-${msg.role}" data-msg="${msg.name}"></div>`
 	);
+	if (msg.creation) $m.attr("data-creation", msg.creation);
 	updateMessage($m, msg);
 	return $m;
 }
 
 export function updateMessage($el, msg) {
+	// Persist the creation timestamp on the element so subsequent realtime
+	// updates (which carry no `creation` field) can still render it.
+	if (msg.creation && !$el.attr("data-creation")) {
+		$el.attr("data-creation", msg.creation);
+	}
+
 	if (msg.role === "tool") {
 		$el.html(renderToolBody(msg));
 		bindToolToggles($el);
@@ -32,12 +39,32 @@ export function updateMessage($el, msg) {
 			<div class="jarvis-bubble">
 				${html}${msg.streaming ? '<span class="jarvis-cursor"></span>' : ""}
 			</div>
+			${timestampHtml($el, msg)}
 		`);
 	} else {
 		$el.html(`
 			<div class="jarvis-bubble">${frappe.utils.escape_html(msg.content || "")}</div>
+			${timestampHtml($el, msg)}
 		`);
 	}
+}
+
+function timestampHtml($el, msg) {
+	// Read from the data attribute first (set by buildMessageEl on initial
+	// render from the DB-backed conversation). Realtime delta payloads don't
+	// carry a creation field — fall back to "just now" so the assistant
+	// bubble has a meaningful stamp while streaming.
+	const creation = $el.attr("data-creation");
+	if (!creation) {
+		return msg.streaming
+			? '<div class="jarvis-msg-time">just now</div>'
+			: "";
+	}
+	// frappe.datetime.comment_when returns an HTML span that auto-refreshes
+	// (e.g. "just now" → "1 min ago"); the title attribute holds the
+	// absolute timestamp for hover.
+	const rendered = frappe.datetime.comment_when(creation);
+	return `<div class="jarvis-msg-time">${rendered}</div>`;
 }
 
 function renderToolBody(msg) {


### PR DESCRIPTION
Small muted relative time below each message ("just now", "2 min ago", auto-refreshing via frappe.datetime.comment_when). Hover for the absolute timestamp.

- get_conversation now returns `creation` in the message rows
- buildMessageEl stashes `creation` as a data attribute so realtime delta updates can re-render the timestamp without needing the field in every payload
- streaming assistant bubbles fall back to "just now" until the run ends and the conversation reloads with the persisted creation
- message container is now flex-column so timestamp stacks beneath the bubble; aligned right for user, left for assistant
- tool messages skipped — they already live inside the collapsable agent-loop group where per-row timestamps would just be noise