### PR TITLE
feat(chat): show error + retry button when agent run fails

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -183,6 +183,55 @@ def send_message(conversation: str, message: str) -> dict:
 	return {"ok": True, "run_id": run_id, "message_id": msg_doc.name}
 
 
+@frappe.whitelist()
+def retry_message(message: str) -> dict:
+	"""Re-run the agent turn that produced an errored assistant message.
+
+	Finds the user message that immediately precedes ``message`` in the same
+	conversation, then enqueues ``run_agent_turn`` against it. The original
+	errored placeholder stays in the conversation as history — the new turn
+	creates its own assistant placeholder, so the chat reads "user → (errored
+	turn) → (retried turn)".
+
+	Returns ``{ok: True, run_id}`` on success or ``{ok: False, reason}`` on
+	validation failure. Raises ``frappe.DoesNotExistError`` if the caller
+	doesn't own the message.
+	"""
+	doc = frappe.get_doc(MSG, message)  # owner-only perm
+	if doc.role != "assistant":
+		return {"ok": False, "reason": _("only assistant messages can be retried")}
+	if not doc.error:
+		return {"ok": False, "reason": _("message did not error")}
+
+	# Find the most recent user message that came BEFORE this assistant in
+	# the same conversation. That's the turn we want to re-run.
+	prev_user = frappe.db.sql(
+		"""SELECT name FROM `tabJarvis Chat Message`
+		WHERE conversation = %s AND role = 'user' AND seq < %s
+		ORDER BY seq DESC LIMIT 1""",
+		(doc.conversation, doc.seq),
+	)
+	if not prev_user:
+		return {"ok": False, "reason": _("no preceding user message to retry")}
+	user_msg_id = prev_user[0][0]
+
+	# Bump the conversation's last_active_at so the sidebar surfaces it.
+	frappe.db.set_value(
+		CONV, doc.conversation, "last_active_at", frappe.utils.now()
+	)
+
+	run_id = uuid.uuid4().hex[:12]
+	frappe.enqueue(
+		method="jarvis.chat.worker.run_agent_turn",
+		queue="default",
+		timeout=200,
+		conversation_id=doc.conversation,
+		message_id=user_msg_id,
+		run_id=run_id,
+	)
+	return {"ok": True, "run_id": run_id}
+
+
 def _next_seq(conversation: str) -> int:
 	"""Return the next seq value for a conversation (max+1, or 1 if empty)."""
 	current_max = frappe.db.sql(

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -563,6 +563,66 @@
 	cursor: help;
 }
 
+/* ---- Errored assistant turn --------------------------------- */
+/* Rendered inside the assistant bubble when the agent run errored
+ * (rate limit, transport failure, etc.). The user clicks Retry to
+ * re-enqueue the worker for the preceding user turn. */
+
+.jarvis-bubble-errored {
+	background: var(--alert-bg-danger, #fbe5e5);
+	border: 1px solid var(--red-300, #f0a8a8);
+}
+
+.jarvis-error-block {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	margin-top: 2px;
+}
+
+.jarvis-error-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	font-size: 13px;
+	line-height: 1.4;
+}
+
+.jarvis-error-icon {
+	color: var(--red-600, #dc3545);
+	font-size: 16px;
+	line-height: 1.2;
+	flex-shrink: 0;
+}
+
+.jarvis-error-text {
+	color: var(--text-color);
+	word-break: break-word;
+}
+
+.jarvis-error-foot {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.jarvis-error-when {
+	font-size: 11px;
+	color: var(--text-muted);
+}
+
+.jarvis-retry-btn {
+	font-size: 11px;
+	line-height: 1;
+	padding: 4px 10px;
+}
+
+.jarvis-retry-btn:disabled {
+	opacity: 0.6;
+	cursor: wait;
+}
+
 /* ---- Streaming cursor --------------------------------------- */
 
 .jarvis-cursor {

--- a/jarvis/public/js/jarvis_chat/api.js
+++ b/jarvis/public/js/jarvis_chat/api.js
@@ -38,3 +38,11 @@ export async function sendMessage(conversation, message) {
 	});
 	return r.message;
 }
+
+export async function retryMessage(messageId) {
+	const r = await frappe.call({
+		method: "jarvis.chat.api.retry_message",
+		args: { message: messageId },
+	});
+	return r.message;
+}

--- a/jarvis/public/js/jarvis_chat/index.js
+++ b/jarvis/public/js/jarvis_chat/index.js
@@ -269,6 +269,35 @@ export function init(wrapper) {
 		sendMessage(prompt);
 	});
 
+	root.on("click", ".jarvis-retry-btn", async function () {
+		const $btn = $(this);
+		if ($btn.prop("disabled")) return;
+		const msgId = $btn.data("msg");
+		const originalLabel = $btn.text();
+		$btn.prop("disabled", true).text(__("Retrying…"));
+		try {
+			const result = await api.retryMessage(msgId);
+			if (!result.ok) {
+				frappe.show_alert({
+					message: result.reason || __("Retry failed"),
+					indicator: "red",
+				});
+				$btn.prop("disabled", false).text(originalLabel);
+				return;
+			}
+			showThinking($thinking);
+			await loadConversation(state.current_conversation, {
+				keepWelcomeHidden: true,
+			});
+		} catch (err) {
+			frappe.show_alert({
+				message: __("Retry failed: ") + (err.message || err),
+				indicator: "red",
+			});
+			$btn.prop("disabled", false).text(originalLabel);
+		}
+	});
+
 	attachRealtime({ $list, $thinking, scrollToBottom, loadConversation });
 
 	// ---- Bootstrap ------------------------------------------------------

--- a/jarvis/public/js/jarvis_chat/messages.js
+++ b/jarvis/public/js/jarvis_chat/messages.js
@@ -124,9 +124,16 @@ export function updateMessage($el, msg) {
 		bindToolToggles($el);
 	} else if (msg.role === "assistant") {
 		const html = renderMarkdown(msg.content || "");
+		const errorBlock = msg.error ? renderAssistantError(msg) : "";
+		const cursor = msg.streaming
+			? '<span class="jarvis-cursor"></span>'
+			: "";
+		const bubbleClass = msg.error
+			? "jarvis-bubble jarvis-bubble-errored"
+			: "jarvis-bubble";
 		$el.html(`
-			<div class="jarvis-bubble">
-				${html}${msg.streaming ? '<span class="jarvis-cursor"></span>' : ""}
+			<div class="${bubbleClass}">
+				${html}${cursor}${errorBlock}
 			</div>
 			${timestampHtml($el, msg)}
 		`);
@@ -136,6 +143,36 @@ export function updateMessage($el, msg) {
 			${timestampHtml($el, msg)}
 		`);
 	}
+}
+
+// ---- Errored assistant turn ------------------------------------------
+//
+// When an agent run fails (rate limit, transport error, etc.) the worker
+// marks the assistant message with `error` and stops streaming. We render
+// an inline error block with the failure reason, a relative timestamp
+// (auto-refreshing via frappe-timestamp), and a Retry button bound to
+// the message id so the click handler in index.js can re-enqueue the
+// worker for the preceding user turn.
+
+function renderAssistantError(msg) {
+	const errored = msg.creation
+		? frappe.datetime.comment_when(msg.creation)
+		: "just now";
+	return `
+		<div class="jarvis-error-block">
+			<div class="jarvis-error-row">
+				<span class="jarvis-error-icon">⚠</span>
+				<span class="jarvis-error-text">${frappe.utils.escape_html(msg.error)}</span>
+			</div>
+			<div class="jarvis-error-foot">
+				<span class="jarvis-error-when">Failed ${errored}</span>
+				<button class="btn btn-xs btn-default jarvis-retry-btn"
+				        data-msg="${frappe.utils.escape_html(msg.name)}">
+					Retry
+				</button>
+			</div>
+		</div>
+	`;
 }
 
 function timestampHtml($el, msg) {

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -17,6 +17,7 @@ from jarvis.chat.api import (
 	create_or_focus_empty,
 	get_conversation,
 	list_conversations,
+	retry_message,
 )
 
 CONV = "Jarvis Conversation"
@@ -275,6 +276,111 @@ class TestSendMessage(_ChatTestCase):
 		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
 			with patch("frappe.enqueue"):
 				send_message(self.conv, "hi")
+		after = frappe.utils.get_datetime(frappe.get_value(
+			CONV, self.conv, "last_active_at"
+		))
+		self.assertGreaterEqual(after, before)
+
+
+class TestRetryMessage(_ChatTestCase):
+	"""retry_message re-runs the worker for the user turn that preceded an
+	errored assistant message.
+	"""
+
+	def _make_turn(self, conv: str, user_text: str = "list 3 customers", with_error: bool = False) -> tuple[str, str]:
+		"""Seed a conversation with a user message + assistant message at the
+		next two seq values. Returns (user_message_name, assistant_message_name).
+		"""
+		base_seq = frappe.db.sql(
+			"SELECT COALESCE(MAX(seq), 0) FROM `tabJarvis Chat Message` WHERE conversation = %s",
+			(conv,),
+		)[0][0]
+		user_doc = frappe.get_doc({
+			"doctype": MSG, "conversation": conv, "seq": base_seq + 1,
+			"role": "user", "content": user_text,
+		})
+		user_doc.insert()
+		asst_payload = {
+			"doctype": MSG, "conversation": conv, "seq": base_seq + 2,
+			"role": "assistant", "content": "",
+		}
+		if with_error:
+			asst_payload["error"] = "rate limit"
+		asst_doc = frappe.get_doc(asst_payload)
+		asst_doc.insert()
+		frappe.db.commit()
+		return user_doc.name, asst_doc.name
+
+	def setUp(self):
+		super().setUp()
+		self.conv = create_conversation()
+
+	def test_enqueues_worker_against_preceding_user_message(self):
+		user_id, asst_id = self._make_turn(self.conv, with_error=True)
+		with patch("frappe.enqueue") as enqueue:
+			result = retry_message(asst_id)
+		self.assertTrue(result["ok"])
+		self.assertIn("run_id", result)
+		enqueue.assert_called_once()
+		_, kwargs = enqueue.call_args
+		self.assertEqual(kwargs["method"], "jarvis.chat.worker.run_agent_turn")
+		self.assertEqual(kwargs["conversation_id"], self.conv)
+		self.assertEqual(kwargs["message_id"], user_id)
+
+	def test_rejects_non_assistant_message(self):
+		user_id, _asst_id = self._make_turn(self.conv, with_error=True)
+		result = retry_message(user_id)
+		self.assertFalse(result["ok"])
+		self.assertIn("assistant", result["reason"].lower())
+
+	def test_rejects_message_without_error(self):
+		_user_id, asst_id = self._make_turn(self.conv, with_error=False)
+		result = retry_message(asst_id)
+		self.assertFalse(result["ok"])
+		self.assertIn("error", result["reason"].lower())
+
+	def test_rejects_if_no_preceding_user_message(self):
+		"""An orphan errored assistant (somehow inserted without a user) — refuse."""
+		asst_doc = frappe.get_doc({
+			"doctype": MSG, "conversation": self.conv, "seq": 1,
+			"role": "assistant", "content": "", "error": "boom",
+		})
+		asst_doc.insert()
+		frappe.db.commit()
+		result = retry_message(asst_doc.name)
+		self.assertFalse(result["ok"])
+		self.assertIn("preceding", result["reason"].lower())
+
+	def test_picks_immediately_preceding_user_message(self):
+		"""When a conversation has multiple user turns, retry should target the
+		one right before the errored assistant, not an older one.
+		"""
+		_u1, _a1 = self._make_turn(self.conv, user_text="first turn", with_error=False)
+		u2, _a2 = self._make_turn(self.conv, user_text="second turn", with_error=False)
+		# Insert a fresh errored assistant after u2
+		seq_max = frappe.db.sql(
+			"SELECT MAX(seq) FROM `tabJarvis Chat Message` WHERE conversation = %s",
+			(self.conv,),
+		)[0][0]
+		errored = frappe.get_doc({
+			"doctype": MSG, "conversation": self.conv, "seq": seq_max + 1,
+			"role": "assistant", "content": "", "error": "rate limit",
+		})
+		errored.insert()
+		frappe.db.commit()
+
+		with patch("frappe.enqueue") as enqueue:
+			retry_message(errored.name)
+		_, kwargs = enqueue.call_args
+		self.assertEqual(kwargs["message_id"], u2)
+
+	def test_bumps_conversation_last_active_at(self):
+		_u, asst_id = self._make_turn(self.conv, with_error=True)
+		before = frappe.utils.get_datetime(frappe.get_value(
+			CONV, self.conv, "last_active_at"
+		))
+		with patch("frappe.enqueue"):
+			retry_message(asst_id)
 		after = frappe.utils.get_datetime(frappe.get_value(
 			CONV, self.conv, "last_active_at"
 		))


### PR DESCRIPTION
When an agent turn errors (rate limit, transport failure, etc.) the worker marks the assistant message with `error` and stops streaming. Until now the chat UI displayed an empty bubble + a transient show_alert toast that vanished after 7s — easy to miss after a long turn, leaving the user staring at silence.

Now: errored bubbles render an inline error block with the failure reason, an auto-refreshing relative timestamp ("Failed 2 min ago"), and a Retry button. Click → POST to a new retry_message endpoint → worker re-enqueued against the same user turn → new assistant placeholder streams.

Backend
- jarvis.chat.api.retry_message(message) validates the target is an errored assistant, walks back to the most recent user message in the same conversation, and enqueues run_agent_turn against it
- The original errored row stays as history; the retry turn appears below it. Multiple retries → multiple errored rows + one (eventual) success row.

Frontend
- messages.js: renderAssistantError when msg.error is set, with warning icon, error text, relative timestamp, Retry button
- index.js: click handler invokes the retry API, locks the button during the round-trip, falls back to show_alert on validation failures
- CSS: bubble background flips to danger tint when errored; button styled as a small secondary action

Tests
- 6 new TestRetryMessage cases: happy path enqueues correct user message, non-assistant rejected, no-error rejected, no-preceding-user rejected, picks the *immediately* preceding user not an older one, bumps last_active_at
- Suite: 204 → 210, all green