### PR TITLE
feat(chat): inject today's date as session context on every turn

### DIFF
--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -42,6 +42,11 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 	gateway_token = settings.get_password("openclaw_gateway_token")
 
 	user_message = frappe.db.get_value(MSG, message_id, "content")
+	# Prepend today's date as a context line so the agent can resolve
+	# relative time expressions ("last quarter", "this week") without an
+	# extra round-trip to clarify. The persisted user_message in the DB
+	# is unchanged; only the value sent over to openclaw is augmented.
+	user_message = _augment_with_context(user_message or "")
 
 	try:
 		sess = OpenclawSession.connect(gateway_url, gateway_token)
@@ -90,6 +95,19 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 		"message_id": assistant_msg.name,
 		"run_id": run_id,
 	})
+
+
+def _augment_with_context(user_message: str) -> str:
+	"""Wrap the user message with a small session-level context block.
+
+	The agent's persona (AGENTS.md) tells it to treat the leading
+	``[Context: ...]`` line as system context, not user intent. This is
+	how Jarvis grounds relative time expressions without per-turn clock
+	lookups inside the agent.
+	"""
+	now = frappe.utils.now_datetime()
+	today = now.strftime("%Y-%m-%d (%A)")
+	return f"[Context: today is {today}]\n\n{user_message}"
 
 
 def _create_assistant_placeholder(conv) -> "frappe.model.document.Document":

--- a/jarvis/openclaw_workspace_seeds/AGENTS.md
+++ b/jarvis/openclaw_workspace_seeds/AGENTS.md
@@ -18,6 +18,27 @@ These dispatch through `jarvis.api.call_tool` and run under the user's
 Frappe identity. Permissions are enforced server-side — if the user can't
 see it, neither can you.
 
+## Per-turn context
+
+Every user message arrives prefixed with a single bracketed line:
+
+```
+[Context: today is 2026-05-18 (Monday)]
+
+<the user's actual message>
+```
+
+That bracketed line is **system context, not user intent**. Use it to
+resolve relative time expressions:
+
+- "this week" / "last week" → start from the date in the prefix
+- "this quarter" / "last quarter" → derive from the prefix's month
+- "yesterday", "today", "tomorrow" → straightforward
+
+You don't need to echo "today is ..." back at the user; they already
+know. Just use the date silently when constructing filters or
+narrating time spans.
+
 ## Workflow patterns
 
 **"Show me X"** → `jarvis__get_list` with a sensible `limit` (5–10 by default).

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -164,3 +164,49 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 			fields=["error"],
 		)
 		self.assertIn("model overloaded", assistants[0]["error"])
+
+
+class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
+	"""Worker should prepend `[Context: today is ...]` to the user message
+	before sending it to openclaw, so the agent can resolve relative time
+	expressions ("last quarter") without a clarifying round-trip.
+	"""
+
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message(
+			"how many invoices last quarter?"
+		)
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_prepends_today_context_to_user_message(self):
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		# stream_agent_turn was called with (session_key, message_text, idem)
+		fake_sess.stream_agent_turn.assert_called_once()
+		_, kwargs = fake_sess.stream_agent_turn.call_args
+		# args may be either positional or keyword — handle both
+		positional = fake_sess.stream_agent_turn.call_args.args
+		message_sent = (
+			positional[1] if len(positional) >= 2
+			else kwargs.get("message")
+		)
+		self.assertIsNotNone(message_sent)
+		self.assertIn("[Context: today is ", message_sent)
+		self.assertIn("how many invoices last quarter?", message_sent)
+		# The DB-persisted user message stays untouched (no prefix)
+		original = frappe.db.get_value(MSG, self.user_msg, "content")
+		self.assertEqual(original, "how many invoices last quarter?")


### PR DESCRIPTION
The agent had no way to know what day it was, so relative time questions ("last quarter", "this week", "yesterday's invoices") round-tripped through clarification turns. Worker now prepends a small context line to the user message before sending it to openclaw:

  [Context: today is 2026-05-18 (Monday)]

  <the user's actual message>

The persisted user message in Jarvis Chat Message is unchanged — the DB still stores what the user typed; only the value sent over the WS is augmented. The bracketed line stays out of the chat UI entirely.

AGENTS.md tells the agent how to interpret the prefix:
- it's system context, not user intent
- use it silently to resolve "this week", "last quarter", etc.
- don't echo "today is..." back to the user

Bumps test_chat_worker by one case asserting the prefix is injected and the original DB content is untouched.

Note: existing workspaces won't pick up the AGENTS.md change until SOUL.md/AGENTS.md is deleted and bootstrap.start re-seeds. The worker prefix takes effect immediately on next chat turn regardless.