### PR TITLE
refactor(settings): brand-neutral labels + lock auto-filled fields + …

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -6,10 +6,8 @@
   "custom": 0,
   "engine": "InnoDB",
   "field_order": [
-    "openclaw_section",
-    "jarvis_admin_url",
-    "jarvis_admin_api_key",
-    "column_break_1",
+    "config_tab",
+    "account_section",
     "token_budget_monthly",
     "enabled",
     "llm_section",
@@ -21,7 +19,10 @@
     "llm_advanced_section",
     "llm_temperature",
     "llm_max_output_tokens",
-    "operator_tab",
+    "system_tab",
+    "admin_connection_section",
+    "jarvis_admin_url",
+    "jarvis_admin_api_key",
     "operator_section",
     "agent_url",
     "agent_token",
@@ -34,25 +35,14 @@
   ],
   "fields": [
     {
-      "fieldname": "openclaw_section",
+      "fieldname": "config_tab",
+      "fieldtype": "Tab Break",
+      "label": "Configuration"
+    },
+    {
+      "fieldname": "account_section",
       "fieldtype": "Section Break",
-      "label": "Aerele Admin Connection"
-    },
-    {
-      "fieldname": "jarvis_admin_url",
-      "fieldtype": "Data",
-      "label": "Aerele Admin URL",
-      "description": "HTTPS URL of the Aerele Jarvis admin (e.g. https://admin.aerele.in). Used for signup, billing, subscription state."
-    },
-    {
-      "fieldname": "jarvis_admin_api_key",
-      "fieldtype": "Password",
-      "label": "Aerele Admin API Key",
-      "description": "Bearer token issued at signup; authenticates this customer's bench when calling the Aerele admin API."
-    },
-    {
-      "fieldname": "column_break_1",
-      "fieldtype": "Column Break"
+      "label": "Account"
     },
     {
       "fieldname": "token_budget_monthly",
@@ -121,44 +111,69 @@
       "default": "4096"
     },
     {
-      "fieldname": "operator_tab",
+      "fieldname": "system_tab",
       "fieldtype": "Tab Break",
-      "label": "Operator"
+      "label": "System"
+    },
+    {
+      "fieldname": "admin_connection_section",
+      "fieldtype": "Section Break",
+      "label": "Jarvis Admin Connection",
+      "description": "Populated by the signup wizard; not customer-editable."
+    },
+    {
+      "fieldname": "jarvis_admin_url",
+      "fieldtype": "Data",
+      "label": "Jarvis Admin URL",
+      "read_only": 1,
+      "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
+    },
+    {
+      "fieldname": "jarvis_admin_api_key",
+      "fieldtype": "Password",
+      "label": "Jarvis Admin API Key",
+      "read_only": 1,
+      "description": "Bearer token issued at signup; authenticates this customer's bench when calling the Jarvis admin API."
     },
     {
       "fieldname": "operator_section",
       "fieldtype": "Section Break",
       "label": "Agent Operator",
-      "description": "Operator config — populated by jarvis.openclaw_bootstrap.start (dev) or the Aerele admin signup response (prod). Do not show to end users in production."
+      "description": "Operator config — populated by jarvis.openclaw_bootstrap.start (dev) or the Jarvis admin signup response (prod)."
     },
     {
       "fieldname": "agent_url",
       "fieldtype": "Data",
       "label": "Agent URL",
-      "description": "WebSocket URL for the customer's openclaw agent (e.g. ws://127.0.0.1:18789 in dev; wss://<subdomain>.jarvis.aerele.in:443 in prod)"
+      "read_only": 1,
+      "description": "WebSocket URL for the customer's openclaw agent (e.g. ws://127.0.0.1:18789 in dev; wss://<subdomain>.<admin-host>:443 in prod)"
     },
     {
       "fieldname": "agent_token",
       "fieldtype": "Password",
       "label": "Agent Token",
+      "read_only": 1,
       "description": "Bearer token used to authenticate the secrets.reload RPC and the chat worker's WebSocket session"
     },
     {
       "fieldname": "agent_llm_key_path",
       "fieldtype": "Data",
       "label": "Agent LLM Key Path",
+      "read_only": 1,
       "description": "Absolute host path to the SecretRef'd LLM key file (auto-populated by jarvis.openclaw_bootstrap.start in dev; by admin signup response in prod)"
     },
     {
       "fieldname": "agent_config_path",
       "fieldtype": "Data",
       "label": "Agent Config Path",
+      "read_only": 1,
       "description": "Absolute host path to the rendered openclaw.json (auto-populated by jarvis.openclaw_bootstrap.start in dev; by admin signup response in prod)"
     },
     {
       "fieldname": "agent_compose_dir",
       "fieldtype": "Data",
       "label": "Agent Compose Directory",
+      "read_only": 1,
       "description": "Directory containing docker-compose.yml (auto-populated by jarvis.openclaw_bootstrap.start in dev; by admin signup response in prod)"
     },
     {

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -46,6 +46,16 @@ class TestJarvisSettings(FrappeTestCase):
             field = next(f for f in meta.fields if f.fieldname == fieldname)
             self.assertEqual(field.fieldtype, "Password", f"{fieldname} must be Password")
 
+    def test_jarvis_admin_fields_are_readonly(self):
+        """Populated by the signup wizard / staff; never customer-edited."""
+        meta = frappe.get_meta("Jarvis Settings")
+        for fieldname in ("jarvis_admin_url", "jarvis_admin_api_key"):
+            field = next(f for f in meta.fields if f.fieldname == fieldname)
+            self.assertTrue(
+                field.read_only,
+                f"{fieldname} must be read-only (populated by signup wizard)",
+            )
+
     def test_llm_provider_options_cover_paid_and_open_weight(self):
         meta = frappe.get_meta("Jarvis Settings")
         provider_field = next(f for f in meta.fields if f.fieldname == "llm_provider")
@@ -54,23 +64,54 @@ class TestJarvisSettings(FrappeTestCase):
         missing = EXPECTED_PROVIDERS - options
         self.assertFalse(missing, f"llm_provider missing options: {missing}")
 
-    def test_operator_tab_fields(self):
+    def test_tab_structure(self):
+        """Two tabs: Configuration (editable) and System (read-only)."""
         meta = frappe.get_meta("Jarvis Settings")
         fields_by_name = {f.fieldname: f for f in meta.fields}
 
-        # Tab break + section break
-        self.assertEqual(fields_by_name["operator_tab"].fieldtype, "Tab Break")
-        self.assertEqual(fields_by_name["operator_section"].fieldtype, "Section Break")
-        self.assertEqual(fields_by_name["last_sync_section"].fieldtype, "Section Break")
+        self.assertEqual(fields_by_name["config_tab"].fieldtype, "Tab Break")
+        self.assertEqual(fields_by_name["config_tab"].label, "Configuration")
+        self.assertEqual(fields_by_name["system_tab"].fieldtype, "Tab Break")
+        self.assertEqual(fields_by_name["system_tab"].label, "System")
 
-        # Operator fields
-        self.assertEqual(fields_by_name["agent_url"].fieldtype, "Data")
-        self.assertEqual(fields_by_name["agent_token"].fieldtype, "Password")
-        self.assertEqual(fields_by_name["agent_llm_key_path"].fieldtype, "Data")
-        self.assertEqual(fields_by_name["agent_config_path"].fieldtype, "Data")
-        self.assertEqual(fields_by_name["agent_compose_dir"].fieldtype, "Data")
+    def test_configuration_tab_sections(self):
+        """Configuration tab has Account, Language Model, Sampling sections."""
+        meta = frappe.get_meta("Jarvis Settings")
+        fields_by_name = {f.fieldname: f for f in meta.fields}
 
-        # Readonly status fields
+        for fieldname in ("account_section", "llm_section", "llm_advanced_section"):
+            self.assertEqual(fields_by_name[fieldname].fieldtype, "Section Break")
+
+    def test_system_tab_sections(self):
+        """System tab has Jarvis Admin Connection, Agent Operator, Last Sync sections."""
+        meta = frappe.get_meta("Jarvis Settings")
+        fields_by_name = {f.fieldname: f for f in meta.fields}
+
+        for fieldname in ("admin_connection_section", "operator_section", "last_sync_section"):
+            self.assertEqual(fields_by_name[fieldname].fieldtype, "Section Break")
+
+    def test_operator_fields_are_readonly(self):
+        """All 5 operator fields are system-populated and must be read-only."""
+        meta = frappe.get_meta("Jarvis Settings")
+        fields_by_name = {f.fieldname: f for f in meta.fields}
+
+        for fieldname, expected_type in (
+            ("agent_url", "Data"),
+            ("agent_token", "Password"),
+            ("agent_llm_key_path", "Data"),
+            ("agent_config_path", "Data"),
+            ("agent_compose_dir", "Data"),
+        ):
+            self.assertEqual(fields_by_name[fieldname].fieldtype, expected_type)
+            self.assertTrue(
+                fields_by_name[fieldname].read_only,
+                f"{fieldname} must be read-only (system-populated by openclaw_bootstrap / admin signup)",
+            )
+
+    def test_last_sync_fields_are_readonly(self):
+        meta = frappe.get_meta("Jarvis Settings")
+        fields_by_name = {f.fieldname: f for f in meta.fields}
+
         self.assertEqual(fields_by_name["last_sync_at"].fieldtype, "Datetime")
         self.assertTrue(fields_by_name["last_sync_at"].read_only)
         self.assertEqual(fields_by_name["last_sync_status"].fieldtype, "Long Text")


### PR DESCRIPTION
…tab reorg

Three small UI changes to Jarvis Settings:
1. Replace "Aerele" with "Jarvis" in all user-visible labels/descriptions
2. Mark all system-populated fields read-only (admin URL/key, agent_*)
3. Restructure tabs by visibility: Configuration (editable) + System (read-only)

Tests updated accordingly.