### PR TITLE
fix(settings): route on_update by admin api token, not jarvis_admin_url

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -44,9 +44,12 @@ class JarvisSettings(Document):
         action = self._classify_llm_change()
         if action is None:
             return
-        # Dispatch: admin path (prod) when jarvis_admin_url is set; otherwise
-        # the existing Phase 1 local-openclaw_push path (dev).
-        if (self.jarvis_admin_url or "").strip():
+        # Dispatch: admin path (prod) when the customer has an admin api token
+        # (set by onboarding); otherwise the Phase 1 local-openclaw_push path
+        # (dev). Keyed on the api token, not jarvis_admin_url — onboarding sets
+        # the token but leaves jarvis_admin_url blank (admin_client falls back to
+        # the hardcoded DEFAULT_ADMIN_URL).
+        if (self.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
             self._sync_via_admin(action)
         else:
             self._sync_via_local_openclaw(action)

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -57,13 +57,19 @@ _SNAPSHOT_PLAIN_FIELDS = (
 _SNAPSHOT_PASSWORD_FIELDS = (
     "agent_token",
     "llm_api_key",
+    "jarvis_admin_api_key",
 )
 
 
 def _reset_settings():
     settings = frappe.get_single("Jarvis Settings")
-    # Use db_set to set up state without triggering on_update
-    for field, value in {**OPERATOR_COMPLETE, **LLM_BASELINE, "last_sync_status": "", "last_sync_at": None}.items():
+    # Use db_set to set up state without triggering on_update.
+    # jarvis_admin_url/_api_key cleared so the default fixture exercises the
+    # local-openclaw (dev) branch; the admin-branch test sets the key itself.
+    base = {**OPERATOR_COMPLETE, **LLM_BASELINE,
+            "jarvis_admin_url": "", "jarvis_admin_api_key": "",
+            "last_sync_status": "", "last_sync_at": None}
+    for field, value in base.items():
         settings.db_set(field, value)
     frappe.db.commit()
 
@@ -219,6 +225,38 @@ class TestOnUpdateOperatorGate(_SettingsSingletonTestCase):
         with patch("jarvis.openclaw_push.push_creds_restart") as restart_mock:
             settings.save()
             self.assertFalse(restart_mock.called)
+
+
+class TestOnUpdateAdminBranch(_SettingsSingletonTestCase):
+    """The admin-vs-local dispatch keys on the presence of an admin api token
+    (set by onboarding), not on jarvis_admin_url (which onboarding never sets)."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_settings()
+
+    def test_admin_api_key_routes_to_admin_not_local(self):
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("jarvis_admin_api_key", "cust-token-xyz")  # as onboarding sets it
+        frappe.db.commit()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_api_key = "sk-new"
+        with patch("jarvis.admin_client.post_update_llm_creds",
+                   return_value={"action": "reload"}) as admin_mock, \
+             patch("jarvis.openclaw_push.push_creds_reload") as local_mock:
+            settings.save()
+        admin_mock.assert_called_once()
+        self.assertFalse(local_mock.called)
+
+    def test_no_admin_api_key_routes_to_local(self):
+        # _reset_settings cleared the key → local (dev) path.
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_api_key = "sk-new"
+        with patch("jarvis.admin_client.post_update_llm_creds") as admin_mock, \
+             patch("jarvis.openclaw_push.push_creds_reload") as local_mock:
+            settings.save()
+        local_mock.assert_called_once()
+        self.assertFalse(admin_mock.called)
 
 
 class TestOnUpdateStatus(_SettingsSingletonTestCase):


### PR DESCRIPTION
Onboarding sets jarvis_admin_api_key (and admin_client falls back to the hardcoded DEFAULT_ADMIN_URL) but never sets jarvis_admin_url, so a prod customer saving Settings took the local-openclaw path. Branch on the token.