### PR TITLE
feat(jarvis-settings): add Test Admin / Test Openclaw / Force Resync …

### DIFF
--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -1,0 +1,81 @@
+"""Operator-facing diagnostics for the Jarvis Settings page.
+
+Three whitelisted endpoints exposed as buttons:
+
+- ping_admin: hits an authenticated admin endpoint to verify the
+  customer's jarvis_admin_api_key works against jarvis_admin_url.
+- ping_openclaw: opens a WS to agent_url with agent_token and completes
+  the connect handshake only. No restart, no reload.
+- force_resync: re-runs the same sync path as Jarvis Settings.on_update
+  without depending on its change-detection. Useful when an LLM key
+  change didn't register as a change (Password field UX bites).
+
+All three return {ok: bool, ...} envelopes; the JS button shows a
+green / red toast based on `ok`.
+"""
+
+import frappe
+
+
+@frappe.whitelist()
+def ping_admin() -> dict:
+	"""Hit the admin's get_connection endpoint with the customer's stored
+	jarvis_admin_api_key. Distinguishes auth failure from unreachable."""
+	from jarvis import admin_client
+	settings = frappe.get_single("Jarvis Settings")
+	if not (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
+		return {
+			"ok": False, "kind": "config",
+			"error": "jarvis_admin_api_key is not set; complete onboarding first.",
+		}
+	try:
+		result = admin_client.get_connection()
+		return {
+			"ok": True,
+			"admin_url": admin_client._admin_url(settings),
+			"connection": result,
+		}
+	except admin_client.AdminAuthError as e:
+		return {"ok": False, "kind": "auth", "error": str(e)}
+	except admin_client.AdminUnreachableError as e:
+		return {"ok": False, "kind": "unreachable", "error": str(e)}
+
+
+@frappe.whitelist()
+def ping_openclaw() -> dict:
+	"""Open WS to agent_url with agent_token; connect handshake only."""
+	from jarvis import openclaw_push
+	from jarvis.exceptions import OpenclawUnreachableError
+	settings = frappe.get_single("Jarvis Settings")
+	url = (settings.agent_url or "").strip()
+	token = settings.get_password("agent_token", raise_exception=False) or ""
+	if not url:
+		return {"ok": False, "kind": "config", "error": "agent_url is not set."}
+	if not token:
+		return {"ok": False, "kind": "config", "error": "agent_token is not set."}
+	try:
+		openclaw_push.ping(url, token)
+		return {"ok": True, "agent_url": url}
+	except OpenclawUnreachableError as e:
+		return {"ok": False, "kind": "unreachable", "error": str(e)}
+	except Exception as e:
+		return {"ok": False, "kind": "error", "error": f"{type(e).__name__}: {e}"}
+
+
+@frappe.whitelist()
+def force_resync(action: str = "reload") -> dict:
+	"""Bypass on_update change-detection. Run the same sync path on
+	current Settings values. action in {'reload', 'restart'}."""
+	if action not in ("reload", "restart"):
+		raise frappe.ValidationError(f"invalid action {action!r}; expected reload or restart")
+	settings = frappe.get_single("Jarvis Settings")
+	if (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
+		settings._sync_via_admin(action)
+	else:
+		settings._sync_via_local_openclaw(action)
+	settings.reload()
+	return {
+		"action": action,
+		"last_sync_at": str(settings.get("last_sync_at") or ""),
+		"last_sync_status": settings.get("last_sync_status") or "",
+	}

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -1,0 +1,86 @@
+frappe.ui.form.on("Jarvis Settings", {
+	refresh(frm) {
+		if (frm.is_new()) return;
+
+		frm.add_custom_button(__("Test Admin Connection"), () => {
+			frappe.call({
+				method: "jarvis.diagnostics.ping_admin",
+			}).then((r) => {
+				const m = r.message || {};
+				if (m.ok) {
+					const conn = m.connection || {};
+					frappe.msgprint({
+						title: __("Admin Reachable"),
+						message: __("Admin URL: {0}<br>Customer status: {1}<br>Agent URL: {2}", [
+							m.admin_url || "?",
+							conn.status || "?",
+							conn.agent_url || "?",
+						]),
+						indicator: "green",
+					});
+				} else {
+					frappe.msgprint({
+						title: __("Admin Connection Failed ({0})", [m.kind || "error"]),
+						message: m.error || "unknown",
+						indicator: "red",
+					});
+				}
+			});
+		}, __("Diagnostics"));
+
+		frm.add_custom_button(__("Test Openclaw Connection"), () => {
+			frappe.call({
+				method: "jarvis.diagnostics.ping_openclaw",
+			}).then((r) => {
+				const m = r.message || {};
+				if (m.ok) {
+					frappe.show_alert({
+						message: __("Openclaw Reachable at {0}", [m.agent_url || "?"]),
+						indicator: "green",
+					});
+				} else {
+					frappe.msgprint({
+						title: __("Openclaw Connection Failed ({0})", [m.kind || "error"]),
+						message: m.error || "unknown",
+						indicator: "red",
+					});
+				}
+			});
+		}, __("Diagnostics"));
+
+		frm.add_custom_button(__("Force Resync"), () => {
+			const d = new frappe.ui.Dialog({
+				title: __("Force Resync"),
+				fields: [
+					{
+						fieldname: "action", fieldtype: "Select", label: "Action",
+						options: "reload\nrestart", default: "reload", reqd: 1,
+						description: __("reload = hot-swap LLM key only. restart = re-render config and bounce the container."),
+					},
+				],
+				primary_action_label: __("Resync Now"),
+				primary_action(values) {
+					frappe.call({
+						method: "jarvis.diagnostics.force_resync",
+						args: { action: values.action },
+					}).then((r) => {
+						const m = r.message || {};
+						const ok = (m.last_sync_status || "").startsWith("ok");
+						frappe.msgprint({
+							title: ok ? __("Resync OK") : __("Resync Reported a Problem"),
+							message: __("Action: {0}<br>At: {1}<br>Status: {2}", [
+								m.action || "?",
+								m.last_sync_at || "(no timestamp)",
+								m.last_sync_status || "(no status)",
+							]),
+							indicator: ok ? "green" : "red",
+						});
+						frm.reload_doc();
+					});
+					d.hide();
+				},
+			});
+			d.show();
+		}, __("Diagnostics"));
+	},
+});

--- a/jarvis/openclaw_push.py
+++ b/jarvis/openclaw_push.py
@@ -92,6 +92,54 @@ def reload_secrets(gateway_url: str, gateway_token: str) -> None:
 			pass
 
 
+def ping(gateway_url: str, gateway_token: str) -> None:
+	"""Open WS to openclaw and complete the connect handshake only — no
+	secrets.reload, no restart. Raises OpenclawUnreachableError if the
+	socket can't open or the handshake is rejected. Used by the
+	'Test openclaw connection' diagnostic button on Jarvis Settings."""
+	try:
+		ws = create_connection(gateway_url, timeout=RELOAD_TIMEOUT_SECONDS)
+	except (websocket.WebSocketException, OSError) as e:
+		raise OpenclawUnreachableError(f"connect failed: {e}") from e
+
+	deadline = time.monotonic() + RELOAD_TIMEOUT_SECONDS
+	try:
+		connect_id = str(uuid.uuid4())
+		ws.send(json.dumps({
+			"type": "req",
+			"id": connect_id,
+			"method": "connect",
+			"params": {
+				"minProtocol": 3,
+				"maxProtocol": 4,
+				"role": "operator",
+				"client": {
+					"id": "gateway-client",
+					"version": "0.1.0",
+					"platform": "linux",
+					"mode": "backend",
+				},
+				"scopes": ["operator.admin"],
+				"auth": {"token": gateway_token},
+			},
+		}))
+		connect_res = _await_response(ws, connect_id, deadline)
+		if not connect_res.get("ok"):
+			err = connect_res.get("error") or {}
+			raise OpenclawUnreachableError(
+				f"connect rejected: {err.get('code', '?')}: {err.get('message', '')}"
+			)
+	except (websocket.WebSocketTimeoutException, TimeoutError) as e:
+		raise OpenclawUnreachableError(f"timeout: {e}") from e
+	except websocket.WebSocketException as e:
+		raise OpenclawUnreachableError(f"ws error: {e}") from e
+	finally:
+		try:
+			ws.close()
+		except Exception:
+			pass
+
+
 def _await_response(ws, request_id: str, deadline: float) -> dict:
 	"""Read frames until a `res` frame with matching id arrives. Other frames are ignored."""
 	while True:

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -1,0 +1,139 @@
+"""Tests for jarvis.diagnostics — the three Jarvis Settings buttons."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import diagnostics
+
+
+class TestPingAdmin(FrappeTestCase):
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._orig = s.get_password("jarvis_admin_api_key", raise_exception=False) or ""
+
+	def tearDown(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", self._orig)
+		frappe.db.commit()
+
+	def test_no_key_returns_config_error(self):
+		with patch.object(
+			frappe.get_single("Jarvis Settings").__class__, "get_password", return_value=""
+		):
+			out = diagnostics.ping_admin()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "config")
+
+	def test_happy_path(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", "test-token")
+		frappe.db.commit()
+		with patch("jarvis.admin_client.get_connection",
+				   return_value={"status": "active", "agent_url": "ws://localhost:19200"}):
+			out = diagnostics.ping_admin()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["connection"]["status"], "active")
+
+	def test_auth_failure_returns_kind_auth(self):
+		from jarvis.exceptions import AdminAuthError
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", "bad-token")
+		frappe.db.commit()
+		with patch("jarvis.admin_client.get_connection", side_effect=AdminAuthError("admin returned 401")):
+			out = diagnostics.ping_admin()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "auth")
+		self.assertIn("401", out["error"])
+
+	def test_unreachable_returns_kind_unreachable(self):
+		from jarvis.exceptions import AdminUnreachableError
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", "tok")
+		frappe.db.commit()
+		with patch("jarvis.admin_client.get_connection",
+				   side_effect=AdminUnreachableError("connection refused")):
+			out = diagnostics.ping_admin()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "unreachable")
+
+
+class TestPingOpenclaw(FrappeTestCase):
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._orig_url = s.get("agent_url") or ""
+		self._orig_tok = s.get_password("agent_token", raise_exception=False) or ""
+
+	def tearDown(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_url", self._orig_url)
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_token", self._orig_tok)
+		frappe.db.commit()
+
+	def test_missing_url_returns_config_error(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_url", "")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_token", "t")
+		frappe.db.commit()
+		out = diagnostics.ping_openclaw()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "config")
+		self.assertIn("agent_url", out["error"])
+
+	def test_missing_token_returns_config_error(self):
+		# Password fields ignore empty db_set; patch get_password to simulate
+		# the "operator hasn't onboarded yet" state.
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_url", "ws://h:1")
+		frappe.db.commit()
+		with patch.object(
+			frappe.get_single("Jarvis Settings").__class__, "get_password", return_value=""
+		):
+			out = diagnostics.ping_openclaw()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "config")
+		self.assertIn("agent_token", out["error"])
+
+	def test_happy_path(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_url", "ws://h:1")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_token", "t")
+		frappe.db.commit()
+		with patch("jarvis.openclaw_push.ping") as p:
+			out = diagnostics.ping_openclaw()
+		p.assert_called_once_with("ws://h:1", "t")
+		self.assertTrue(out["ok"])
+
+	def test_unreachable(self):
+		from jarvis.exceptions import OpenclawUnreachableError
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_url", "ws://h:1")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "agent_token", "t")
+		frappe.db.commit()
+		with patch("jarvis.openclaw_push.ping", side_effect=OpenclawUnreachableError("refused")):
+			out = diagnostics.ping_openclaw()
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["kind"], "unreachable")
+
+
+class TestForceResync(FrappeTestCase):
+	def test_rejects_invalid_action(self):
+		with self.assertRaises(frappe.ValidationError):
+			diagnostics.force_resync(action="blowup")
+
+	def test_admin_path_when_admin_key_set(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", "tok")
+		frappe.db.commit()
+		try:
+			with patch.object(
+				frappe.get_single("Jarvis Settings").__class__, "_sync_via_admin"
+			) as sa, patch.object(
+				frappe.get_single("Jarvis Settings").__class__, "_sync_via_local_openclaw"
+			) as sl:
+				diagnostics.force_resync(action="reload")
+			sa.assert_called_once_with("reload")
+			sl.assert_not_called()
+		finally:
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key", "")
+			frappe.db.commit()
+
+	def test_local_path_when_no_admin_key(self):
+		cls = frappe.get_single("Jarvis Settings").__class__
+		with patch.object(cls, "get_password", return_value=""), \
+			 patch.object(cls, "_sync_via_admin") as sa, \
+			 patch.object(cls, "_sync_via_local_openclaw") as sl:
+			diagnostics.force_resync(action="restart")
+		sl.assert_called_once_with("restart")
+		sa.assert_not_called()


### PR DESCRIPTION
…buttons

Operator-facing diagnostics that surface the state of the two out-of-band integrations (admin auth, openclaw WS) independent of the on_update save path — which fails silently in two common ways: Password fields don't detect a 'change' unless the user clicks into the field and retypes, and on_update auth failures update last_sync_status but not last_sync_at, so 'old timestamp' can mean either 'no save fired' or 'auth still failing'.

Endpoints (jarvis.diagnostics):
- ping_admin: calls admin_client.get_connection; returns {ok, kind in {config, auth, unreachable}, error|connection}.
- ping_openclaw: opens WS, completes connect handshake only via the new openclaw_push.ping helper; returns {ok, kind, error|agent_url}.
- force_resync(action=reload|restart): invokes the same dispatcher on_update uses, bypassing change-detection. Returns the post-run {last_sync_at, last_sync_status} so the JS button can show the outcome immediately.

UI: new jarvis_settings.js puts the three buttons under a "Diagnostics" group on the Jarvis Settings form. Force Resync uses a small dialog to pick reload vs restart with descriptions.

11 new unit tests cover the happy + config + auth + unreachable paths plus the admin-vs-local routing of force_resync. Patches target the Settings class's get_password directly because Frappe's Password fields ignore empty db_set values.