### PR TITLE
fix(onboarding): dev_onboard sets jarvis_admin_url; test isolation

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -70,7 +70,15 @@ def renew() -> dict:
 
 @frappe.whitelist()
 def dev_onboard(email: str, company: str, plan: str) -> dict:
-	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection."""
+	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection.
+
+	Single-bench dev shortcut: if jarvis_admin_url isn't already set, default
+	it to this site's URL (customer site == admin site in local dev). Without
+	this, admin_client._admin_url falls back to the hardcoded prod URL and the
+	call DNS-fails immediately."""
+	settings = frappe.get_single("Jarvis Settings")
+	if not (settings.jarvis_admin_url or "").strip():
+		settings.db_set("jarvis_admin_url", frappe.utils.get_url())
 	data = admin_client.dev_signup(email, company, plan)
 	write_connection(data)
 	return data

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -15,9 +15,37 @@ def _set_token(value):
 	frappe.db.commit()
 
 
+# Fields these tests write to. Snapshot in setUp, restore in tearDown so
+# tests run against a real site (e.g. jarvis.localhost) don't clobber the
+# operator's actual onboarded state — Frappe Singles aren't transactionally
+# rolled back between tests.
+_SNAPSHOTTED_FIELDS = (
+	"jarvis_admin_url", "jarvis_admin_api_key", "agent_url", "agent_token",
+)
+
+
+def _snapshot_settings() -> dict:
+	s = frappe.get_single("Jarvis Settings")
+	snap = {}
+	for f in _SNAPSHOTTED_FIELDS:
+		# Password fields → get_password; plain → attribute. Both safe.
+		v = s.get_password(f, raise_exception=False) if f.endswith(("_key", "_token")) else s.get(f)
+		snap[f] = v or ""
+	return snap
+
+
+def _restore_settings(snap: dict) -> None:
+	for f, v in snap.items():
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v)
+	frappe.db.commit()
+
+
 class TestSyncConnection(FrappeTestCase):
+	def setUp(self):
+		self._snap = _snapshot_settings()
+
 	def tearDown(self):
-		_set_token("")
+		_restore_settings(self._snap)
 
 	def test_sync_writes_connection_when_assigned(self):
 		_set_token("tok")
@@ -51,3 +79,32 @@ class TestSyncConnection(FrappeTestCase):
 		s = frappe.get_single("Jarvis Settings")
 		self.assertEqual(s.get_password("jarvis_admin_api_key"), "devtok")
 		self.assertEqual(s.agent_url, "ws://localhost:19002")
+
+	def test_dev_onboard_defaults_admin_url_when_empty(self):
+		"""Single-bench dev: dev_onboard should auto-set jarvis_admin_url to the
+		current site URL so admin_client doesn't fall back to the prod default."""
+		_set_token("")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
+		frappe.db.commit()
+		with patch("jarvis.onboarding.admin_client.dev_signup",
+				   return_value={"api_token": "t", "agent_url": "ws://h:1", "agent_token": "k"}):
+			onboarding.dev_onboard("e2@x.com", "Co", "Annual Plan")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.jarvis_admin_url, frappe.utils.get_url())
+
+	def test_dev_onboard_preserves_existing_admin_url(self):
+		"""If operator has already set jarvis_admin_url (e.g. multi-bench dev),
+		don't overwrite it."""
+		_set_token("")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings",
+							"jarvis_admin_url", "http://other-admin.local")
+		frappe.db.commit()
+		try:
+			with patch("jarvis.onboarding.admin_client.dev_signup",
+					   return_value={"api_token": "t", "agent_url": "ws://h:1", "agent_token": "k"}):
+				onboarding.dev_onboard("e3@x.com", "Co", "Annual Plan")
+			s = frappe.get_single("Jarvis Settings")
+			self.assertEqual(s.jarvis_admin_url, "http://other-admin.local")
+		finally:
+			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
+			frappe.db.commit()


### PR DESCRIPTION
Two real bugs surfaced by dev signup on a fresh single-bench setup:

1. dev_onboard never set jarvis_admin_url, so admin_client._admin_url fell back to the hardcoded prod URL (https://admin.jarvis.aerele.in) on the very first dev_signup call. DNS-fail → write_connection never ran → settings stayed empty. dev_onboard now defaults the URL to frappe.utils.get_url() when it's not already set (preserves any multi-bench operator override).

2. The existing test_onboarding_sync tests wrote into the real Jarvis Settings Singles row (no Frappe-side rollback) and clobbered the operator's onboarded values whenever the suite ran against a real site. Now snapshot jarvis_admin_url/_api_key/agent_url/_token in setUp and restore them in tearDown.

Two new tests verify the URL default + the multi-bench preservation case.