### PR TITLE
fix(admin_client): decrypt api_key via get_password, not attribute ac…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -96,7 +96,12 @@ def _post(path: str, body: dict, admin_url: str,
 	"""Authenticated POST. Reads native api_key + api_secret from Jarvis
 	Settings. Raises AdminAuthError early if either is empty."""
 	settings = frappe.get_single("Jarvis Settings")
-	api_key = (settings.jarvis_admin_api_key or "").strip()
+	# Both are Password fields — attribute access would return the masked
+	# "*****" placeholder Frappe stores in the row. get_password decrypts
+	# the real value out of __Auth.
+	api_key = (settings.get_password(
+		"jarvis_admin_api_key", raise_exception=False
+	) or "").strip()
 	api_secret = settings.get_password(
 		"jarvis_admin_api_secret", raise_exception=False
 	) or ""

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -115,6 +115,36 @@ class TestHeaders(FrappeTestCase):
 		with self.assertRaises(AdminAuthError):
 			post_update_llm_creds("p", "m", "b", "k")
 
+	def test_api_key_decrypted_via_get_password_not_attribute(self):
+		"""Regression: jarvis_admin_api_key is a Password field. Attribute
+		access on the settings doc returns Frappe's masked "*****" placeholder;
+		only get_password() decrypts the real value out of __Auth. The previous
+		bug read the attribute and shipped "*****" as the api_key, which admin
+		rejected with 401 (see signup flow last_sync_status leakage)."""
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["headers"] = headers
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"action": "reload"}}})
+
+		fake_settings = MagicMock()
+		# Mimic the production load: attribute is the masked placeholder.
+		fake_settings.jarvis_admin_api_key = "*****"
+		fake_settings.jarvis_admin_url = "https://admin.example.com"
+		# get_password returns the decrypted real value.
+		def _get_password(field, raise_exception=False):
+			return {"jarvis_admin_api_key": "real-key-xyz",
+					"jarvis_admin_api_secret": "real-secret-abc"}.get(field, "")
+		fake_settings.get_password.side_effect = _get_password
+
+		with patch("frappe.get_single", return_value=fake_settings), \
+			 patch("requests.post", side_effect=_fake_post):
+			post_update_llm_creds("p", "m", "b", "k")
+
+		self.assertEqual(captured["headers"]["Authorization"],
+						 "token real-key-xyz:real-secret-abc")
+		self.assertNotIn("*", captured["headers"]["Authorization"])
+
 
 class TestNetworkErrors(FrappeTestCase):
 	def setUp(self):


### PR DESCRIPTION
…cess

jarvis_admin_api_key is a Password field. Reading it as a plain attribute returns Frappe's masked "*****" placeholder; only get_password() pulls the decrypted value out of __Auth. The previous code did get_password for the secret but attribute access for the key, so every authenticated admin request shipped
"Authorization: token *****:<real_secret>" and admin rejected it with 401.

User-visible symptoms this resolves on the customer side:
- Test Admin Connection → "Admin Connection Failed (auth)" / 401
- Jarvis Settings save → last_sync_status = "failed: auth: admin returned 401" → openclaw.json never rendered in the new container → Test Agent Connection then hits openclaw's "origin not allowed" because the container is still on --allow-unconfigured defaults

Adds a regression test that patches the settings doc so attribute access returns "*****" while get_password returns the real value, and asserts the Authorization header contains the real key.