### PR TITLE
fix(admin_client): surface admin ValidationErrors as clean messages

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -11,7 +11,7 @@ endpoints are @frappe.whitelist(allow_guest=True).
 import frappe
 import requests
 
-from jarvis.exceptions import AdminAuthError, AdminUnreachableError
+from jarvis.exceptions import AdminAuthError, AdminUnreachableError, AdminValidationError
 
 
 # Admin's provision_healthz_timeout_s defaults to 60s for restart operations;
@@ -123,6 +123,31 @@ def _post_guest(path: str, body: dict, admin_url: str,
 	return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
 
 
+def _extract_frappe_message(payload: dict) -> str:
+	"""Pull the user-facing message out of a Frappe exception envelope.
+
+	Frappe encodes user-visible alerts under `_server_messages` (a JSON-encoded
+	list of JSON-encoded dicts with a `message` key). When that's empty, fall
+	back to the `exception` string and strip the leading `module.path.ClassName: `
+	prefix so we don't leak Python internals to the operator."""
+	import json as _json
+	raw = (payload.get("_server_messages") or "").strip()
+	if raw:
+		try:
+			messages = _json.loads(raw)
+			if messages:
+				first = _json.loads(messages[0]) if isinstance(messages[0], str) else messages[0]
+				msg = (first or {}).get("message") or ""
+				if msg:
+					return msg
+		except (ValueError, TypeError):
+			pass
+	exc = (payload.get("exception") or "").strip()
+	if ":" in exc:
+		return exc.split(":", 1)[1].strip()
+	return exc or payload.get("exc_type") or "unknown admin error"
+
+
 def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str) -> dict:
 	try:
 		resp = requests.post(url, json=body, headers=headers, timeout=timeout_s)
@@ -135,6 +160,19 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 		raise AdminUnreachableError(
 			f"admin {admin_url} returned non-JSON (status {resp.status_code})"
 		)
+
+	# Frappe wraps any exception raised inside a whitelisted endpoint into an
+	# envelope with `exc_type`. We surface those before the generic 4xx/5xx
+	# branches so user-input errors (ValidationError, DuplicateEntryError,
+	# DoesNotExistError) reach the page as clean text instead of a traceback dump.
+	if isinstance(payload, dict) and payload.get("exc_type"):
+		clean = _extract_frappe_message(payload)
+		exc_type = payload.get("exc_type", "")
+		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
+			raise AdminValidationError(clean)
+		if exc_type in ("AuthenticationError", "PermissionError"):
+			raise AdminAuthError(clean)
+		raise AdminUnreachableError(f"admin {admin_url}: {clean}")
 
 	envelope = payload.get("message", payload) if isinstance(payload, dict) else payload
 

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -32,3 +32,9 @@ class AdminUnreachableError(JarvisError):
 
 class AdminAuthError(JarvisError):
 	"""jarvis_admin rejected the token / site (401 / 403)."""
+
+
+class AdminValidationError(JarvisError):
+	"""jarvis_admin raised a Frappe ValidationError (or similar user-input
+	error) inside a whitelisted endpoint. Carries the clean operator-facing
+	message — never the traceback dump."""

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -7,6 +7,18 @@ import json
 import frappe
 
 from jarvis import admin_client
+from jarvis.exceptions import AdminValidationError
+
+
+def _surface(fn, *args, **kwargs):
+	"""Run an admin_client call; re-raise admin validation errors as
+	frappe.ValidationError so the onboarding page gets a clean operator-facing
+	message (and Frappe's standard red toast) instead of a long traceback dump
+	from AdminUnreachableError."""
+	try:
+		return fn(*args, **kwargs)
+	except AdminValidationError as e:
+		frappe.throw(str(e))
 
 
 def write_connection(data: dict) -> None:
@@ -49,7 +61,7 @@ def list_plans() -> list:
 @frappe.whitelist()
 def start_signup(email: str, company: str, plan: str) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout."""
-	data = admin_client.signup(email, company, plan)
+	data = _surface(admin_client.signup, email, company, plan)
 	if data.get("api_token"):
 		write_connection({"api_token": data["api_token"]})
 	return data
@@ -60,7 +72,7 @@ def finish_payment(payload) -> dict:
 	"""Confirm Checkout success → store the returned container connection."""
 	if isinstance(payload, str):
 		payload = json.loads(payload)
-	data = admin_client.confirm_payment(payload)
+	data = _surface(admin_client.confirm_payment, payload)
 	write_connection(data)
 	return data
 
@@ -69,7 +81,7 @@ def finish_payment(payload) -> dict:
 def renew() -> dict:
 	"""Existing customer initiates a renewal payment; returns the Razorpay handles
 	for Checkout. The page then completes Checkout and calls finish_payment."""
-	return admin_client.renew()
+	return _surface(admin_client.renew)
 
 
 @frappe.whitelist()
@@ -105,6 +117,6 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	if not (settings.jarvis_admin_url or "").strip():
 		settings.db_set("jarvis_admin_url", frappe.utils.get_url())
-	data = admin_client.dev_signup(email, company, plan)
+	data = _surface(admin_client.dev_signup, email, company, plan)
 	write_connection(data)
 	return data

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -16,6 +16,7 @@ from jarvis.admin_client import (
 	DEFAULT_TIMEOUT_S,
 	AdminAuthError,
 	AdminUnreachableError,
+	AdminValidationError,
 	post_update_llm_creds,
 )
 
@@ -204,6 +205,57 @@ class TestAdminErrorResponses(FrappeTestCase):
 			with self.assertRaises(AdminUnreachableError) as cm:
 				post_update_llm_creds("p", "m", "b", "k")
 		self.assertIn("NoRunningTenant", str(cm.exception))
+
+	def test_frappe_validation_error_surfaces_clean_message(self):
+		"""When admin raises frappe.ValidationError inside a whitelisted endpoint
+		(e.g. dev_force_signup → _reject_duplicate_email), the response body has
+		Frappe's exc_type/_server_messages envelope, not the {ok, error} shape.
+		We extract the user-facing message and raise AdminValidationError."""
+		mock_post = MagicMock(return_value=_mock_response(
+			417,
+			json_body={
+				"exception": "frappe.exceptions.ValidationError: An active account already exists for venkat@aerele.in",
+				"exc_type": "ValidationError",
+				"_server_messages": '["{\\"message\\": \\"An active account already exists for venkat@aerele.in\\", \\"indicator\\": \\"red\\"}"]',
+				"exc": "[\"Traceback (most recent call last):\\n...\"]",
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception),
+						 "An active account already exists for venkat@aerele.in")
+		# No traceback dump should leak into the message.
+		self.assertNotIn("Traceback", str(cm.exception))
+		self.assertNotIn("frappe.exceptions.", str(cm.exception))
+
+	def test_frappe_validation_error_falls_back_to_exception_string(self):
+		"""If _server_messages is missing/empty, parse the message from the
+		`exception` field by stripping the class prefix."""
+		mock_post = MagicMock(return_value=_mock_response(
+			417,
+			json_body={
+				"exception": "frappe.exceptions.DuplicateEntryError: Customer C-001 already exists",
+				"exc_type": "DuplicateEntryError",
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception), "Customer C-001 already exists")
+
+	def test_frappe_permission_error_routes_to_auth_error(self):
+		mock_post = MagicMock(return_value=_mock_response(
+			403,
+			json_body={
+				"exception": "frappe.exceptions.PermissionError: customer status: Suspended",
+				"exc_type": "PermissionError",
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminAuthError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception), "customer status: Suspended")
 
 
 class TestNonJsonResponse(FrappeTestCase):


### PR DESCRIPTION
When admin raised frappe.ValidationError inside a whitelisted endpoint (e.g. dev_force_signup → _reject_duplicate_email), the response body used Frappe's exception envelope (exc_type / _server_messages / exception) — not the {ok, error: {code, message}} shape _do_post expected. The fallback ran resp.text[:200], which dumped a truncated traceback into the page error toast.

- _do_post now detects exc_type and routes:
  - ValidationError / DuplicateEntryError / DoesNotExistError → new AdminValidationError with just the user-facing message, extracted from _server_messages (or, if absent, by stripping the "module.path.ClassName: " prefix off `exception`).
  - AuthenticationError / PermissionError → AdminAuthError.
  - Anything else → AdminUnreachableError with a clean message.
- onboarding endpoints (dev_onboard, start_signup, finish_payment, renew) now wrap admin_client calls in _surface(), which re-raises AdminValidationError as frappe.throw — that triggers Frappe's standard red toast on the onboarding page instead of the long AdminUnreachableError traceback dump.

Adds 3 regression tests covering the envelope parser (with _server_messages, without, and the PermissionError route).