### PR TITLE
feat(chat): direct WebSocket with device-paired auth (drop docker-exec)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -91,6 +91,18 @@ def post_update_llm_creds(
 	)
 
 
+def pair_chat_device(public_key: str, device_id: str) -> dict:
+	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
+	to write a PairedDevice record into the customer's openclaw container and
+	returns the issued bearer device-token. Customer keeps the private key."""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.tenant.pair_chat_device",
+		body={"public_key": public_key, "device_id": device_id},
+		admin_url=_admin_url(settings),
+	)
+
+
 def _post(path: str, body: dict, admin_url: str,
 		  timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	"""Authenticated POST. Reads native api_key + api_secret from Jarvis

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -1,0 +1,187 @@
+"""Chat-device pairing + signing helpers.
+
+Owns the customer-side half of openclaw's device-paired auth:
+- Generates an Ed25519 keypair on first chat, persists it in Jarvis Settings.
+- Calls admin's pair_chat_device endpoint to register the public side with the
+  customer's openclaw container; persists the returned bearer token.
+- Builds and signs the v3 device-auth payload openclaw verifies at every WS
+  connect (mirrors openclaw src/gateway/device-auth.ts:36).
+
+The keypair never leaves this bench. Admin only ever sees the public key.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+
+import frappe
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from jarvis import admin_client
+from jarvis.exceptions import OpenclawUnreachableError
+
+
+@dataclass(frozen=True)
+class ChatDeviceCredentials:
+	device_id: str
+	public_key: str            # base64url, no padding
+	private_key: Ed25519PrivateKey
+	device_token: str          # bearer for auth.deviceToken at connect
+
+
+def _b64u(raw: bytes) -> str:
+	return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64u_decode(s: str) -> bytes:
+	pad = "=" * (-len(s) % 4)
+	return base64.urlsafe_b64decode(s + pad)
+
+
+def _derive_device_id(public_key_raw: bytes) -> str:
+	"""Mirrors openclaw's deriveDeviceIdFromPublicKey (sha256 hex)."""
+	return hashlib.sha256(public_key_raw).hexdigest()
+
+
+def _generate_keypair() -> tuple[Ed25519PrivateKey, bytes, str, str]:
+	"""Returns (private_key, public_key_raw, public_key_b64u, device_id)."""
+	priv = Ed25519PrivateKey.generate()
+	pub_raw = priv.public_key().public_bytes(
+		encoding=serialization.Encoding.Raw,
+		format=serialization.PublicFormat.Raw,
+	)
+	return priv, pub_raw, _b64u(pub_raw), _derive_device_id(pub_raw)
+
+
+def _load_private_key(b64u: str) -> Ed25519PrivateKey:
+	return Ed25519PrivateKey.from_private_bytes(_b64u_decode(b64u))
+
+
+def _save_credentials(*, settings_doc, private_key_b64u: str, public_key_b64u: str,
+					  device_id: str, device_token: str) -> None:
+	settings_doc.db_set("chat_device_id", device_id)
+	settings_doc.db_set("chat_device_public_key", public_key_b64u)
+	settings_doc.db_set("chat_device_private_key", private_key_b64u)
+	settings_doc.db_set("chat_device_token", device_token)
+	frappe.db.commit()
+
+
+def _read_credentials() -> ChatDeviceCredentials | None:
+	"""Load creds from Jarvis Settings, or None if any field is missing.
+
+	Each piece must be present for the pairing to be usable; treating a
+	partial state as 'not paired' so the next chat triggers a fresh
+	pair_chat_device call and overwrites everything atomically."""
+	s = frappe.get_single("Jarvis Settings")
+	device_id = (s.chat_device_id or "").strip()
+	public_key = (s.chat_device_public_key or "").strip()
+	private_key_b64u = (s.get_password("chat_device_private_key", raise_exception=False) or "").strip()
+	device_token = (s.get_password("chat_device_token", raise_exception=False) or "").strip()
+	if not (device_id and public_key and private_key_b64u and device_token):
+		return None
+	try:
+		priv = _load_private_key(private_key_b64u)
+	except (ValueError, TypeError):
+		# Corrupted private-key bytes — treat as unpaired so caller re-pairs.
+		return None
+	return ChatDeviceCredentials(
+		device_id=device_id,
+		public_key=public_key,
+		private_key=priv,
+		device_token=device_token,
+	)
+
+
+def ensure_paired() -> ChatDeviceCredentials:
+	"""Return current chat device credentials, generating + registering them
+	if missing. Idempotent: a fully-populated Settings row is reused as-is.
+
+	Raises OpenclawUnreachableError if pairing fails (no creds to fall back
+	to — the caller has no way to chat without them, so we surface the error
+	cleanly instead of half-persisting an unusable state)."""
+	existing = _read_credentials()
+	if existing is not None:
+		return existing
+
+	priv, _pub_raw, pub_b64u, device_id = _generate_keypair()
+	priv_b64u = _b64u(priv.private_bytes(
+		encoding=serialization.Encoding.Raw,
+		format=serialization.PrivateFormat.Raw,
+		encryption_algorithm=serialization.NoEncryption(),
+	))
+
+	try:
+		resp = admin_client.pair_chat_device(public_key=pub_b64u, device_id=device_id)
+	except Exception as e:
+		raise OpenclawUnreachableError(f"chat device pairing failed: {e}") from e
+
+	device_token = (resp or {}).get("device_token") or ""
+	if not device_token:
+		raise OpenclawUnreachableError("admin pair_chat_device returned no device_token")
+
+	settings = frappe.get_single("Jarvis Settings")
+	_save_credentials(
+		settings_doc=settings,
+		private_key_b64u=priv_b64u,
+		public_key_b64u=pub_b64u,
+		device_id=device_id,
+		device_token=device_token,
+	)
+	return ChatDeviceCredentials(
+		device_id=device_id, public_key=pub_b64u,
+		private_key=priv, device_token=device_token,
+	)
+
+
+def clear_credentials() -> None:
+	"""Wipe persisted chat-device creds. Called when openclaw rejects an
+	existing pairing (token revoked, device not paired, etc.) so the next
+	chat attempt regenerates."""
+	settings = frappe.get_single("Jarvis Settings")
+	for field in ("chat_device_id", "chat_device_public_key",
+				  "chat_device_private_key", "chat_device_token"):
+		settings.db_set(field, "")
+	frappe.db.commit()
+
+
+def _normalize_metadata(value: str) -> str:
+	"""Mirrors openclaw's normalizeDeviceMetadataForAuth: trim + ASCII lowercase
+	(only [A-Z] → [a-z]; Unicode left alone, matching the deterministic
+	cross-runtime normalization the gateway uses)."""
+	trimmed = (value or "").strip()
+	return "".join(c.lower() if "A" <= c <= "Z" else c for c in trimmed)
+
+
+def build_payload_v3(
+	*, device_id: str, client_id: str, client_mode: str, role: str,
+	scopes: list[str], signed_at_ms: int, device_token: str, nonce: str,
+	platform: str = "linux", device_family: str = "",
+) -> str:
+	"""Byte-for-byte mirror of openclaw's buildDeviceAuthPayloadV3.
+
+	If openclaw rev-bumps the payload format we discover it as a
+	'device-signature' rejection on connect — the only fragile spot in
+	the whole transport rewrite, hence the explicit comment + the
+	corresponding test in tests/test_chat_device.py."""
+	return "|".join([
+		"v3",
+		device_id,
+		client_id,
+		client_mode,
+		role,
+		",".join(scopes),
+		str(signed_at_ms),
+		device_token or "",
+		nonce,
+		_normalize_metadata(platform),
+		_normalize_metadata(device_family),
+	])
+
+
+def sign_payload(private_key: Ed25519PrivateKey, payload: str) -> str:
+	"""Ed25519-sign UTF-8 payload bytes; return base64url-no-padding signature."""
+	sig = private_key.sign(payload.encode("utf-8"))
+	return _b64u(sig)

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -1,303 +1,291 @@
-"""Openclaw gateway client — wraps the WebSocket protocol through `docker compose exec`.
+"""Openclaw gateway client — direct WebSocket with device-paired auth.
 
-Why subprocess + docker exec instead of a direct host-side WS connection:
-openclaw's gateway grants `operator.admin` to token-auth connections from
-non-loopback sources (LAN bind) but does NOT grant `operator.write`, which
-sessions.create requires. Demo.ask_one works around this by running its WS
-inside the container via `docker compose exec node -e <script>`; the
-connection then comes from container-local loopback, which gets full scopes.
+Previously this module shelled out to `docker compose exec ... node -e <script>`
+so the WS connection would appear as loopback inside the container — openclaw
+strips self-declared `operator.write` scopes from non-loopback token-only
+clients, and the chat worker needed write scope for sessions.create.
 
-We mirror that pattern here. The Python side spawns a Node WS script inside
-the container, pipes JSON commands in, reads line-delimited events out. From
-the caller's perspective the API is the same as a direct WS client.
+Now we do it the way openclaw was designed for: pair the customer bench as
+a device once (via jarvis.chat.device.ensure_paired → admin → fleet-agent),
+and present an Ed25519-signed v3 device-auth envelope at every connect.
+openclaw verifies the signature against the registered public key, grants
+the requested scopes, and the rest of the protocol (sessions.create, agent,
+event streaming) is identical to what the Node script used to do — only the
+transport changed from subprocess-pipes to direct WS frames.
 
-If openclaw later adds a non-loopback grant for operator.write (or per-device
-pairing produces a token with both scopes), this module can be reverted to a
-direct Python WS without changing the worker.
+The public surface (OpenclawSession.connect / create_session /
+stream_agent_turn / close) is unchanged. worker.py and api.py don't notice.
 """
 
 from __future__ import annotations
 
 import json
-import subprocess
 import threading
+import time
 import uuid
 from collections.abc import Iterator
 from typing import Any
 
-import frappe
+import websocket
 
+from jarvis.chat.device import (
+	ChatDeviceCredentials, build_payload_v3, ensure_paired, sign_payload,
+)
 from jarvis.chat.events import parse_event
 from jarvis.exceptions import OpenclawUnreachableError
 
 CONNECT_TIMEOUT_SECONDS = 10
 TURN_TIMEOUT_SECONDS = 180
 
-# Node script that runs inside the container. It speaks a tiny line-based JSON
-# protocol over stdin/stdout so the Python side can drive it:
-#   stdin commands:  {"cmd":"create_session","label":...} | {"cmd":"agent","sessionKey":...,"message":...,"idempotencyKey":...} | {"cmd":"close"}
-#   stdout events:   {"type":"connect","ok":bool,"error":?} | {"type":"create","ok":bool,"key":?,"error":?} | {"type":"event","payload":<openclaw frame>} | {"type":"runDone"} | {"type":"runErr","error":...}
-_NODE_SCRIPT = r"""
-// When stdout is piped (docker compose exec -T), Node block-buffers writes by
-// default — events accumulate until the buffer fills or the process exits, so
-// the Python side sees nothing until the agent turn finishes. Forcing the
-// handle to blocking mode makes every write synchronous, which lets each
-// `emit()` flush a single line through the pipe immediately.
-if (process.stdout._handle && typeof process.stdout._handle.setBlocking === 'function') {
-  process.stdout._handle.setBlocking(true);
-}
-if (process.stderr._handle && typeof process.stderr._handle.setBlocking === 'function') {
-  process.stderr._handle.setBlocking(true);
-}
-
-const readline = require('readline');
-const ws = new (require('ws'))('ws://127.0.0.1:18789');
-const args = JSON.parse(process.env.JARVIS_CHAT_ARGS);
-const { gatewayToken } = args;
-
-const pending = new Map();
-let activeRunId = null;
-
-function send(method, params) {
-  const id = Math.random().toString(36).slice(2);
-  const p = new Promise((res, rej) => pending.set(id, { res, rej }));
-  ws.send(JSON.stringify({ type: 'req', id, method, params }));
-  return p;
-}
-
-function emit(obj) {
-  process.stdout.write(JSON.stringify(obj) + '\n');
-}
-
-ws.on('open', async () => {
-  try {
-    const connectRes = await send('connect', {
-      minProtocol: 3, maxProtocol: 4, role: 'operator',
-      client: { id: 'gateway-client', version: '0.1.0', platform: 'linux', mode: 'backend' },
-      scopes: ['operator.admin'],
-      auth: { token: gatewayToken },
-    });
-    if (!connectRes.ok) {
-      emit({ type: 'connect', ok: false, error: JSON.stringify(connectRes.error) });
-      process.exit(1);
-    }
-    emit({ type: 'connect', ok: true });
-  } catch (err) {
-    emit({ type: 'connect', ok: false, error: err.message });
-    process.exit(1);
-  }
-});
-
-ws.on('message', (raw) => {
-  let frame;
-  try { frame = JSON.parse(raw); } catch { return; }
-  if (frame.type === 'res' && pending.has(frame.id)) {
-    const { res } = pending.get(frame.id);
-    pending.delete(frame.id);
-    res(frame);
-    return;
-  }
-  if (frame.type === 'event') {
-    if (activeRunId && frame.payload && frame.payload.runId === activeRunId) {
-      emit({ type: 'event', payload: frame.payload });
-      const p = frame.payload;
-      if (p.stream === 'lifecycle' && (p.data || {}).phase) {
-        const phase = p.data.phase;
-        if (phase === 'end' || phase === 'error') {
-          emit({ type: 'runDone' });
-          activeRunId = null;
-        }
-      }
-    }
-  }
-});
-
-ws.on('error', (err) => { emit({ type: 'wsError', error: err.message }); });
-ws.on('close', () => { emit({ type: 'wsClose' }); process.exit(0); });
-
-const rl = readline.createInterface({ input: process.stdin });
-rl.on('line', async (line) => {
-  let cmd;
-  try { cmd = JSON.parse(line); } catch { return; }
-  if (cmd.cmd === 'create_session') {
-    try {
-      const r = await send('sessions.create', { label: cmd.label });
-      if (r.ok) {
-        emit({ type: 'create', ok: true, key: r.payload.key });
-      } else {
-        emit({ type: 'create', ok: false, error: JSON.stringify(r.error) });
-      }
-    } catch (e) {
-      emit({ type: 'create', ok: false, error: e.message });
-    }
-  } else if (cmd.cmd === 'agent') {
-    try {
-      const r = await send('agent', {
-        message: cmd.message,
-        sessionKey: cmd.sessionKey,
-        deliver: false,
-        idempotencyKey: cmd.idempotencyKey,
-      });
-      if (r.ok) {
-        activeRunId = r.payload.runId;
-        emit({ type: 'agentAck', runId: r.payload.runId });
-      } else {
-        emit({ type: 'runErr', error: JSON.stringify(r.error) });
-      }
-    } catch (e) {
-      emit({ type: 'runErr', error: e.message });
-    }
-  } else if (cmd.cmd === 'close') {
-    try { ws.close(); } catch (_) {}
-    process.exit(0);
-  }
-});
-"""
+# Scopes the chat path needs: operator.write for sessions.create + agent;
+# operator.admin so the same connection can also read state (status snapshots,
+# etc.) without re-pairing.
+_REQUESTED_SCOPES = ["operator.write", "operator.admin"]
+_CLIENT_ID = "gateway-client"
+_CLIENT_MODE = "backend"
+_ROLE = "operator"
+_PLATFORM = "linux"  # informational; only affects the v3 signature payload
 
 
 class OpenclawSession:
-	"""Thin wrapper over a `docker compose exec` Node WS subprocess.
+	"""Direct WebSocket session to one tenant's openclaw gateway.
 
-	Public surface matches what the chat worker calls:
+	Public surface:
 	  OpenclawSession.connect(gateway_url, gateway_token) -> session
 	  session.create_session(label=...) -> session_key
 	  session.stream_agent_turn(session_key, message, idem) -> iter of parsed events
 	  session.close()
+
+	The gateway_token arg is kept for call-site compatibility but unused —
+	device pairing supersedes the shared bearer token. The chat device's
+	deviceToken from `jarvis.chat.device.ensure_paired()` is the credential.
 	"""
 
-	def __init__(self, proc: subprocess.Popen, compose_dir: str):
-		self._proc = proc
-		self._compose_dir = compose_dir
-		self._lock = threading.Lock()  # serialize stdin writes
+	def __init__(self, ws: websocket.WebSocket, creds: ChatDeviceCredentials):
+		self._ws = ws
+		self._creds = creds
+		self._lock = threading.Lock()  # serialize concurrent sends on same WS
+
+	# -- lifecycle --------------------------------------------------------
 
 	@classmethod
 	def connect(cls, gateway_url: str, gateway_token: str) -> OpenclawSession:
-		# gateway_url is ignored: we always connect to the container's
-		# loopback. Kept in the signature for backwards compat with the
-		# worker call site and tests.
-		_ = gateway_url
+		_ = gateway_token  # see class docstring
+		if not gateway_url:
+			raise OpenclawUnreachableError("agent_url not set on Jarvis Settings")
 
-		settings = frappe.get_single("Jarvis Settings")
-		compose_dir = settings.agent_compose_dir
-		if not compose_dir:
-			raise OpenclawUnreachableError("agent_compose_dir not set on Jarvis Settings")
-
-		args = json.dumps({"gatewayToken": gateway_token})
-		cmd = [
-			"docker", "compose",
-			"-f", f"{compose_dir}/docker-compose.yml",
-			"exec", "-T",  # -T: no TTY (we want clean pipes)
-			"-e", f"JARVIS_CHAT_ARGS={args}",
-			"openclaw-gateway",
-			"node", "-e", _NODE_SCRIPT,
-		]
+		creds = ensure_paired()
 		try:
-			proc = subprocess.Popen(
-				cmd,
-				stdin=subprocess.PIPE,
-				stdout=subprocess.PIPE,
-				stderr=subprocess.PIPE,
-				text=True,
-				bufsize=1,  # line-buffered
+			ws = websocket.create_connection(
+				gateway_url, timeout=CONNECT_TIMEOUT_SECONDS,
+				# Origin must be a valid http(s)://… URL; openclaw's controlUi
+				# allowedOrigins is "*" in our rendered config, but the
+				# Origin-parse path rejects empty/malformed values outright.
+				origin="http://localhost",
 			)
-		except FileNotFoundError as e:
-			raise OpenclawUnreachableError(f"docker not on PATH: {e}") from e
+		except (websocket.WebSocketException, OSError) as e:
+			raise OpenclawUnreachableError(f"WS open failed: {e}") from e
 
-		# Wait for the "connect" event
-		first = _read_event(proc, timeout=CONNECT_TIMEOUT_SECONDS)
-		if not first or first.get("type") != "connect" or not first.get("ok"):
-			err = (first or {}).get("error", "no response")
-			proc.kill()
-			raise OpenclawUnreachableError(f"connect failed: {err}")
+		try:
+			cls._handshake(ws, creds)
+		except Exception:
+			try: ws.close()
+			except Exception: pass
+			raise
+		return cls(ws, creds)
 
-		return cls(proc, compose_dir)
+	def close(self) -> None:
+		try: self._ws.close()
+		except Exception: pass
+
+	# -- protocol methods -------------------------------------------------
 
 	def create_session(self, label: str = "jarvis-chat") -> str:
-		self._send_cmd({"cmd": "create_session", "label": label})
-		ev = _read_event(self._proc, timeout=CONNECT_TIMEOUT_SECONDS)
-		if not ev or ev.get("type") != "create":
-			raise OpenclawUnreachableError(f"unexpected reply to create_session: {ev}")
-		if not ev.get("ok"):
-			raise OpenclawUnreachableError(f"sessions.create rejected: {ev.get('error')}")
-		key = ev.get("key")
+		res = self._request("sessions.create", {"label": label},
+							timeout_s=CONNECT_TIMEOUT_SECONDS)
+		key = (res.get("payload") or {}).get("key")
 		if not key:
-			raise OpenclawUnreachableError("sessions.create returned no key")
+			raise OpenclawUnreachableError(f"sessions.create returned no key: {res}")
 		return key
 
 	def stream_agent_turn(
-		self,
-		session_key: str,
-		message: str,
-		idempotency_key: str,
+		self, session_key: str, message: str, idempotency_key: str,
 	) -> Iterator[dict[str, Any]]:
-		self._send_cmd({
-			"cmd": "agent",
-			"sessionKey": session_key,
+		"""Send an `agent` request, then yield parsed events until lifecycle.end.
+
+		Yields the same parsed-event shape the worker used to consume from
+		the subprocess. Raises OpenclawUnreachableError on WS drop, agent
+		errors, or timeout — all the failure modes worker.py already maps to
+		assistant-message error rows."""
+		agent_id = self._send("agent", {
 			"message": message,
+			"sessionKey": session_key,
+			"deliver": False,
 			"idempotencyKey": idempotency_key,
 		})
-		# Expect agentAck first, then event/event/.../runDone
-		import time
 		deadline = time.monotonic() + TURN_TIMEOUT_SECONDS
+
+		# 1. Drain frames until we see the agent ack OR an error/event for our run.
+		active_run_id: str | None = None
 		got_ack = False
 		while time.monotonic() < deadline:
-			ev = _read_event(self._proc, timeout=TURN_TIMEOUT_SECONDS)
-			if ev is None:
-				break
-			t = ev.get("type")
-			if t == "agentAck":
+			frame = self._recv(deadline - time.monotonic())
+			if frame is None:
+				continue
+			ftype = frame.get("type")
+			if ftype == "res" and frame.get("id") == agent_id:
+				if not frame.get("ok"):
+					err = frame.get("error") or {}
+					raise OpenclawUnreachableError(
+						f"agent rejected: {err.get('code', '?')}: {err.get('message', '')}",
+					)
+				active_run_id = (frame.get("payload") or {}).get("runId")
 				got_ack = True
-				continue
-			if t == "runErr":
-				raise OpenclawUnreachableError(f"agent run errored: {ev.get('error')}")
-			if t == "event":
-				parsed = parse_event(ev.get("payload") or {})
-				if parsed is not None:
-					yield parsed
-				continue
-			if t == "runDone":
-				return
-			if t == "wsError" or t == "wsClose":
-				raise OpenclawUnreachableError(f"openclaw WS lost: {ev}")
+				break
+			# Pre-ack events can arrive; pass them through if they belong to us
+			# by lifecycle (no runId yet at this point, drop unrelated noise).
 		if not got_ack:
 			raise OpenclawUnreachableError("agent RPC never acknowledged")
+
+		# 2. Stream events for this run until lifecycle.end / .error.
+		while time.monotonic() < deadline:
+			frame = self._recv(deadline - time.monotonic())
+			if frame is None:
+				continue
+			ftype = frame.get("type")
+			if ftype != "event":
+				continue
+			payload = frame.get("payload") or {}
+			if active_run_id is not None and payload.get("runId") != active_run_id:
+				continue
+			parsed = parse_event(payload)
+			if parsed is not None:
+				yield parsed
+			# Same lifecycle-phase detection the Node script used.
+			if payload.get("stream") == "lifecycle":
+				phase = (payload.get("data") or {}).get("phase")
+				if phase in ("end", "error"):
+					return
 		raise OpenclawUnreachableError("agent turn timed out before lifecycle end")
 
-	def close(self) -> None:
-		try:
-			self._send_cmd({"cmd": "close"})
-		except Exception:
-			pass
-		try:
-			self._proc.terminate()
-			self._proc.wait(timeout=5)
-		except Exception:
-			try:
-				self._proc.kill()
-			except Exception:
-				pass
+	# -- internals --------------------------------------------------------
 
-	def _send_cmd(self, cmd: dict) -> None:
+	@classmethod
+	def _handshake(cls, ws: websocket.WebSocket, creds: ChatDeviceCredentials) -> None:
+		"""Receive connect.challenge → sign v3 payload → send connect → expect hello-ok."""
+		deadline = time.monotonic() + CONNECT_TIMEOUT_SECONDS
+
+		# 1. Wait for the challenge event.
+		nonce: str | None = None
+		while time.monotonic() < deadline:
+			frame = _recv_with_timeout(ws, deadline - time.monotonic())
+			if frame is None:
+				continue
+			if frame.get("type") == "event" and frame.get("event") == "connect.challenge":
+				nonce = (frame.get("payload") or {}).get("nonce")
+				break
+		if not nonce:
+			raise OpenclawUnreachableError("did not receive connect.challenge before timeout")
+
+		# 2. Sign + send the connect frame.
+		signed_at_ms = int(time.time() * 1000)
+		payload = build_payload_v3(
+			device_id=creds.device_id, client_id=_CLIENT_ID, client_mode=_CLIENT_MODE,
+			role=_ROLE, scopes=_REQUESTED_SCOPES, signed_at_ms=signed_at_ms,
+			device_token=creds.device_token, nonce=nonce,
+			platform=_PLATFORM, device_family="",
+		)
+		signature_b64u = sign_payload(creds.private_key, payload)
+		connect_id = uuid.uuid4().hex
+		ws.send(json.dumps({
+			"type": "req",
+			"id": connect_id,
+			"method": "connect",
+			"params": {
+				"minProtocol": 4,
+				"maxProtocol": 4,
+				"client": {
+					"id": _CLIENT_ID, "version": "0.1.0",
+					"platform": _PLATFORM, "mode": _CLIENT_MODE,
+				},
+				"role": _ROLE,
+				"scopes": _REQUESTED_SCOPES,
+				"auth": {"deviceToken": creds.device_token},
+				"device": {
+					"id": creds.device_id,
+					"publicKey": creds.public_key,
+					"signature": signature_b64u,
+					"signedAt": signed_at_ms,
+					"nonce": nonce,
+				},
+			},
+		}))
+
+		# 3. Wait for the connect response.
+		while time.monotonic() < deadline:
+			frame = _recv_with_timeout(ws, deadline - time.monotonic())
+			if frame is None:
+				continue
+			if frame.get("type") == "res" and frame.get("id") == connect_id:
+				if not frame.get("ok"):
+					err = frame.get("error") or {}
+					raise OpenclawUnreachableError(
+						f"connect rejected: {err.get('code', '?')}: {err.get('message', '')}",
+					)
+				return
+		raise OpenclawUnreachableError("no connect response before timeout")
+
+	def _send(self, method: str, params: dict) -> str:
+		"""Send a request frame; return the generated request id."""
+		req_id = uuid.uuid4().hex
 		with self._lock:
-			if self._proc.stdin is None or self._proc.stdin.closed:
-				raise OpenclawUnreachableError("subprocess stdin closed")
-			self._proc.stdin.write(json.dumps(cmd) + "\n")
-			self._proc.stdin.flush()
+			self._ws.send(json.dumps({
+				"type": "req", "id": req_id, "method": method, "params": params,
+			}))
+		return req_id
+
+	def _request(self, method: str, params: dict, *, timeout_s: float) -> dict:
+		"""Send a request and wait for the matching response frame.
+
+		Drops out-of-order event frames silently — the caller is RPC-style
+		and doesn't need them. stream_agent_turn handles its own framing."""
+		req_id = self._send(method, params)
+		deadline = time.monotonic() + timeout_s
+		while time.monotonic() < deadline:
+			frame = self._recv(deadline - time.monotonic())
+			if frame is None:
+				continue
+			if frame.get("type") == "res" and frame.get("id") == req_id:
+				if not frame.get("ok"):
+					err = frame.get("error") or {}
+					raise OpenclawUnreachableError(
+						f"{method} rejected: {err.get('code', '?')}: {err.get('message', '')}",
+					)
+				return frame
+		raise OpenclawUnreachableError(f"{method} timed out")
+
+	def _recv(self, timeout_s: float) -> dict | None:
+		"""Read one frame from the WS, parse JSON, or return None on a soft
+		timeout / non-JSON noise. Raises OpenclawUnreachableError on hard
+		close so the caller can wrap into an assistant-message error row."""
+		return _recv_with_timeout(self._ws, timeout_s)
 
 
-def _read_event(proc: subprocess.Popen, timeout: float) -> dict | None:
-	"""Read a single line-delimited JSON event from the subprocess stdout."""
-	import select
-	if proc.stdout is None:
+def _recv_with_timeout(ws: websocket.WebSocket, timeout_s: float) -> dict | None:
+	if timeout_s <= 0:
 		return None
-	# Wait for stdout readability
-	r, _, _ = select.select([proc.stdout], [], [], timeout)
-	if not r:
+	ws.settimeout(timeout_s)
+	try:
+		raw = ws.recv()
+	except websocket.WebSocketTimeoutException:
 		return None
-	line = proc.stdout.readline()
-	if not line:
+	except websocket.WebSocketConnectionClosedException as e:
+		raise OpenclawUnreachableError(f"openclaw WS closed: {e}") from e
+	except websocket.WebSocketException as e:
+		raise OpenclawUnreachableError(f"openclaw WS error: {e}") from e
+	if not raw:
 		return None
 	try:
-		return json.loads(line.strip())
+		return json.loads(raw)
 	except json.JSONDecodeError:
 		return None

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -30,6 +30,10 @@
     "agent_llm_key_path",
     "agent_config_path",
     "agent_compose_dir",
+    "chat_device_id",
+    "chat_device_public_key",
+    "chat_device_private_key",
+    "chat_device_token",
     "last_sync_section",
     "last_sync_at",
     "last_sync_status"
@@ -183,6 +187,34 @@
       "label": "Agent Compose Directory",
       "read_only": 1,
       "description": "Directory containing docker-compose.yml (auto-populated by jarvis.openclaw_bootstrap.start in dev; by admin signup response in prod)"
+    },
+    {
+      "fieldname": "chat_device_id",
+      "fieldtype": "Data",
+      "label": "Chat Device ID",
+      "read_only": 1,
+      "description": "sha256(rawPublicKey).hex — openclaw deviceId this bench was paired as. Set lazily on first chat; cleared on re-pair."
+    },
+    {
+      "fieldname": "chat_device_public_key",
+      "fieldtype": "Long Text",
+      "label": "Chat Device Public Key",
+      "read_only": 1,
+      "description": "Base64url-encoded Ed25519 public key registered with openclaw at pair time."
+    },
+    {
+      "fieldname": "chat_device_private_key",
+      "fieldtype": "Password",
+      "label": "Chat Device Private Key",
+      "read_only": 1,
+      "description": "Base64url-encoded Ed25519 private key. Never leaves this bench. Used to sign the connect challenge at every chat WS handshake."
+    },
+    {
+      "fieldname": "chat_device_token",
+      "fieldtype": "Password",
+      "label": "Chat Device Token",
+      "read_only": 1,
+      "description": "Bearer token openclaw issued at pair time. Sent in auth.deviceToken at every chat WS connect."
     },
     {
       "fieldname": "last_sync_section",

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -1,0 +1,190 @@
+"""Tests for jarvis.chat.device — chat keypair + pairing + v3 signing.
+
+Two surface areas to cover:
+1. ensure_paired: generates a keypair if missing, calls admin to register the
+   public side, persists everything atomically; reuses existing creds when
+   present; surfaces admin failures as OpenclawUnreachableError without
+   half-persisting a broken state.
+2. build_payload_v3 / sign_payload: the byte-exact mirror of openclaw's
+   device-auth.ts:36 — if openclaw rev-bumps the format, this is the test
+   that catches it before chat goes live.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from unittest.mock import patch
+
+import frappe
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import device as chat_device
+from jarvis.exceptions import OpenclawUnreachableError
+
+
+def _b64u(raw: bytes) -> str:
+	return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+_SNAPSHOT_PASSWORD_FIELDS = (
+	"chat_device_private_key", "chat_device_token",
+)
+_SNAPSHOT_PLAIN_FIELDS = (
+	"chat_device_id", "chat_device_public_key",
+)
+
+
+class _SettingsSnapshotMixin:
+	"""Save/restore the chat_device_* fields so the test suite leaves no
+	residue on whichever site bench picked. Mirrors test_settings.py."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		s = frappe.get_single("Jarvis Settings")
+		snap = {f: s.get(f) for f in _SNAPSHOT_PLAIN_FIELDS}
+		for f in _SNAPSHOT_PASSWORD_FIELDS:
+			snap[f] = s.get_password(f, raise_exception=False) or ""
+		cls._chat_device_snapshot = snap
+
+	@classmethod
+	def tearDownClass(cls):
+		try:
+			s = frappe.get_single("Jarvis Settings")
+			for f, v in cls._chat_device_snapshot.items():
+				s.db_set(f, v)
+			frappe.db.commit()
+		finally:
+			super().tearDownClass()
+
+
+def _clear_settings():
+	"""Wipe chat_device_* between tests so each one starts unpaired."""
+	s = frappe.get_single("Jarvis Settings")
+	for f in (*_SNAPSHOT_PLAIN_FIELDS, *_SNAPSHOT_PASSWORD_FIELDS):
+		s.db_set(f, "")
+	frappe.db.commit()
+
+
+class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
+	def setUp(self):
+		_clear_settings()
+
+	def test_generates_keypair_calls_admin_and_persists(self):
+		captured = {}
+
+		def _fake_pair(public_key, device_id):
+			captured["public_key"] = public_key
+			captured["device_id"] = device_id
+			return {"device_token": "tok-from-admin"}
+
+		with patch("jarvis.chat.device.admin_client.pair_chat_device", side_effect=_fake_pair):
+			creds = chat_device.ensure_paired()
+
+		# Returned object is internally consistent.
+		self.assertEqual(creds.device_token, "tok-from-admin")
+		self.assertEqual(creds.public_key, captured["public_key"])
+		self.assertEqual(creds.device_id, captured["device_id"])
+		# deviceId must match sha256(rawPublicKey) — same invariant openclaw enforces.
+		raw = base64.urlsafe_b64decode(captured["public_key"] + "=" * (-len(captured["public_key"]) % 4))
+		self.assertEqual(creds.device_id, hashlib.sha256(raw).hexdigest())
+		# Persisted in Settings.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.chat_device_id, creds.device_id)
+		self.assertEqual(s.chat_device_public_key, creds.public_key)
+		self.assertEqual(s.get_password("chat_device_token"), "tok-from-admin")
+		self.assertTrue(s.get_password("chat_device_private_key"))
+
+	def test_reuses_existing_creds_without_admin_call(self):
+		# Seed Settings with a valid keypair + token.
+		priv = Ed25519PrivateKey.generate()
+		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw,
+												  serialization.PublicFormat.Raw)
+		priv_raw = priv.private_bytes(serialization.Encoding.Raw,
+									   serialization.PrivateFormat.Raw,
+									   serialization.NoEncryption())
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", hashlib.sha256(pub_raw).hexdigest())
+		s.db_set("chat_device_public_key", _b64u(pub_raw))
+		s.db_set("chat_device_private_key", _b64u(priv_raw))
+		s.db_set("chat_device_token", "tok-existing")
+		frappe.db.commit()
+
+		with patch("jarvis.chat.device.admin_client.pair_chat_device") as mock_pair:
+			creds = chat_device.ensure_paired()
+		self.assertFalse(mock_pair.called)
+		self.assertEqual(creds.device_token, "tok-existing")
+		self.assertEqual(creds.device_id, hashlib.sha256(pub_raw).hexdigest())
+
+	def test_admin_failure_raises_and_does_not_persist(self):
+		with patch("jarvis.chat.device.admin_client.pair_chat_device",
+				   side_effect=RuntimeError("boom")):
+			with self.assertRaises(OpenclawUnreachableError):
+				chat_device.ensure_paired()
+		# Nothing persisted on failure.
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.chat_device_id)
+		self.assertFalse(s.get_password("chat_device_private_key", raise_exception=False))
+
+	def test_empty_device_token_raises_unreachable(self):
+		with patch("jarvis.chat.device.admin_client.pair_chat_device",
+				   return_value={"device_token": ""}):
+			with self.assertRaises(OpenclawUnreachableError):
+				chat_device.ensure_paired()
+
+	def test_partial_state_triggers_repair(self):
+		"""If only some fields are set, treat the whole pairing as missing
+		so the next call re-pairs atomically — protects against half-failed
+		writes from a previous deploy/migration."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", "abc")
+		s.db_set("chat_device_public_key", "")  # incomplete
+		s.db_set("chat_device_private_key", "")
+		s.db_set("chat_device_token", "")
+		frappe.db.commit()
+
+		with patch("jarvis.chat.device.admin_client.pair_chat_device",
+				   return_value={"device_token": "tok-repaired"}):
+			creds = chat_device.ensure_paired()
+		self.assertEqual(creds.device_token, "tok-repaired")
+		self.assertNotEqual(creds.device_id, "abc")  # fresh keypair was generated
+
+
+class TestSigning(FrappeTestCase):
+	def test_build_payload_v3_format(self):
+		out = chat_device.build_payload_v3(
+			device_id="DID", client_id="gateway-client", client_mode="backend",
+			role="operator", scopes=["operator.write", "operator.admin"],
+			signed_at_ms=12345, device_token="TOK", nonce="NONCE",
+			platform="Linux", device_family="",
+		)
+		# Mirror of openclaw's buildDeviceAuthPayloadV3 (device-auth.ts:36).
+		# Platform is normalized to ASCII lowercase ("linux"); device_family
+		# stays empty.
+		expected = "v3|DID|gateway-client|backend|operator|operator.write,operator.admin|12345|TOK|NONCE|linux|"
+		self.assertEqual(out, expected)
+
+	def test_sign_payload_verifies_with_public_key(self):
+		"""Round-trip: sign with private, verify with the matching public key
+		using the same Ed25519 raw scheme openclaw uses."""
+		priv = Ed25519PrivateKey.generate()
+		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw,
+												  serialization.PublicFormat.Raw)
+		payload = "v3|x|y|z|operator||0||n||"
+		sig_b64u = chat_device.sign_payload(priv, payload)
+		# Decode and verify.
+		sig = base64.urlsafe_b64decode(sig_b64u + "=" * (-len(sig_b64u) % 4))
+		pub = Ed25519PublicKey.from_public_bytes(pub_raw)
+		pub.verify(sig, payload.encode("utf-8"))  # raises if invalid
+
+	def test_metadata_normalization_lowercases_ascii_only(self):
+		out = chat_device.build_payload_v3(
+			device_id="x", client_id="c", client_mode="m", role="r",
+			scopes=["s"], signed_at_ms=0, device_token="", nonce="n",
+			platform="DarwinARM64", device_family="iPhone15",
+		)
+		# Trailing fields after the nonce: |<platform>|<device_family>
+		self.assertTrue(out.endswith("|darwinarm64|iphone15"))

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -1,184 +1,258 @@
-"""Tests for the openclaw subprocess client.
+"""Tests for the direct-WS chat client (jarvis.chat.openclaw_client).
 
-The client wraps `docker compose exec node -e <script>` to drive an
-openclaw WS connection from inside the container (where loopback grants
-full operator scopes). These tests mock subprocess.Popen and verify the
-JSON-line protocol between Python and the Node script.
+The transport is a real websocket-client connection to openclaw's gateway.
+Tests fake it out at the create_connection level: a scripted WS whose recv()
+returns a sequence of JSON frames and whose send() captures the client's
+outbound frames for assertion.
+
+What's verified here:
+- Connect handshake: receives connect.challenge, sends a v3-signed connect,
+  succeeds on a positive hello-ok response.
+- create_session round-trip.
+- stream_agent_turn yields parsed events between agent ack and lifecycle end.
+- Close is forgiving (no raise on already-closed sockets).
+
+Pairing itself is mocked here — see test_chat_device.py for the device.py
+half of the integration (keypair + admin call).
 """
 
-import json
-import subprocess
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
 
-import frappe
+import base64
+import json
+from unittest.mock import patch
+
+import websocket
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis.chat.device import ChatDeviceCredentials
 from jarvis.chat.openclaw_client import OpenclawSession
 from jarvis.exceptions import OpenclawUnreachableError
 
 
-def _settings_with_compose_dir():
-	"""Ensure Jarvis Settings has agent_compose_dir set for connect()."""
-	s = frappe.get_single("Jarvis Settings")
-	if not s.agent_compose_dir:
-		s.db_set("agent_compose_dir", "/tmp/fake-openclaw")
-		frappe.db.commit()
+# --- helpers --------------------------------------------------------------
+
+def _b64u(raw: bytes) -> str:
+	return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
-class _FakeStdout:
-	"""Provides line-by-line readline() from a queue of events."""
+def _make_creds() -> ChatDeviceCredentials:
+	import hashlib
+	priv = Ed25519PrivateKey.generate()
+	pub_raw = priv.public_key().public_bytes(
+		encoding=serialization.Encoding.Raw,
+		format=serialization.PublicFormat.Raw,
+	)
+	device_id = hashlib.sha256(pub_raw).hexdigest()
+	return ChatDeviceCredentials(
+		device_id=device_id, public_key=_b64u(pub_raw),
+		private_key=priv, device_token="tok-test",
+	)
 
-	def __init__(self, lines: list[str]):
-		self._iter = iter(lines)
+
+class _ScriptedWS:
+	"""Stand-in for a websocket.WebSocket.
+
+	frames_to_recv is a list of JSON-string frames OR callables that return
+	a JSON-string frame at recv time. Callables let a frame respond to the
+	id the client sends (which we can't know ahead of time)."""
+
+	def __init__(self, frames_to_recv: list):
+		self._frames = list(frames_to_recv)
+		self.sent: list[dict] = []
 		self.closed = False
 
-	def readline(self) -> str:
-		try:
-			return next(self._iter)
-		except StopIteration:
-			return ""
+	def settimeout(self, _seconds): pass
+
+	def recv(self):
+		if not self._frames:
+			raise websocket.WebSocketTimeoutException("no more frames")
+		item = self._frames.pop(0)
+		return item() if callable(item) else item
+
+	def send(self, raw):
+		self.sent.append(json.loads(raw))
+
+	def close(self): self.closed = True
 
 
-def _make_proc(stdout_lines: list[str]) -> MagicMock:
-	proc = MagicMock(spec=subprocess.Popen)
-	proc.stdout = _FakeStdout(stdout_lines)
-	proc.stdin = MagicMock()
-	proc.stdin.closed = False
-	proc.stderr = MagicMock()
-	return proc
+def _frame(d: dict) -> str:
+	return json.dumps(d)
 
 
-def _make_select_always_ready(*args, **kwargs):
-	"""Stub for select.select that says stdout is always readable."""
-	return ([args[0][0]] if args[0] else []), [], []
+def _challenge(nonce: str = "nonce-test") -> str:
+	return _frame({"type": "event", "event": "connect.challenge",
+				   "payload": {"nonce": nonce}})
 
+
+def _build_session(creds=None) -> tuple[OpenclawSession, _ScriptedWS]:
+	"""Spin up a fully-handshaken OpenclawSession with no real WS. Returns the
+	session and the underlying scripted WS so tests can extend its frames
+	and inspect sent frames."""
+	creds = creds or _make_creds()
+
+	def _ok():
+		req_id = scripted.sent[-1]["id"]
+		return _frame({"type": "res", "id": req_id, "ok": True, "payload": {
+			"auth": {"scopes": ["operator.write", "operator.admin"]},
+		}})
+
+	scripted = _ScriptedWS([_challenge(), _ok])
+	with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
+		 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
+		sess = OpenclawSession.connect("ws://test", "ignored-token")
+	scripted.sent.clear()
+	return sess, scripted
+
+
+# --- TestConnect ----------------------------------------------------------
 
 class TestConnect(FrappeTestCase):
-	def setUp(self):
-		_settings_with_compose_dir()
+	def test_handshake_sends_v3_signed_connect(self):
+		creds = _make_creds()
 
-	def test_connect_success(self):
-		proc = _make_proc([json.dumps({"type": "connect", "ok": True}) + "\n"])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-		self.assertIs(sess._proc, proc)
+		def _ok():
+			req_id = scripted.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True, "payload": {}})
 
-	def test_connect_failure_raises(self):
-		proc = _make_proc([
-			json.dumps({"type": "connect", "ok": False, "error": "bad token"}) + "\n",
-		])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				with self.assertRaises(OpenclawUnreachableError):
-					OpenclawSession.connect("ws://ignored", "tok-123")
+		scripted = _ScriptedWS([_challenge("nonce-xyz"), _ok])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
+			sess = OpenclawSession.connect("ws://t", "x")
 
-	def test_connect_docker_missing_raises(self):
-		with patch("subprocess.Popen", side_effect=FileNotFoundError("no docker")):
+		self.assertEqual(len(scripted.sent), 1)
+		req = scripted.sent[0]
+		self.assertEqual(req["type"], "req")
+		self.assertEqual(req["method"], "connect")
+		params = req["params"]
+		self.assertEqual(params["role"], "operator")
+		self.assertIn("operator.write", params["scopes"])
+		self.assertEqual(params["auth"]["deviceToken"], creds.device_token)
+		self.assertEqual(params["device"]["id"], creds.device_id)
+		self.assertEqual(params["device"]["nonce"], "nonce-xyz")
+		# Signature must be a non-empty base64url string (no padding).
+		self.assertTrue(params["device"]["signature"])
+		self.assertNotIn("=", params["device"]["signature"])
+		import time
+		self.assertGreater(params["device"]["signedAt"], int(time.time() * 1000) - 60_000)
+		sess.close()
+
+	def test_connect_rejection_raises_unreachable(self):
+		creds = _make_creds()
+
+		def _nack():
+			req_id = scripted.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "UNAUTHORIZED", "message": "bad token"}})
+
+		scripted = _ScriptedWS([_challenge(), _nack])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
+			with self.assertRaises(OpenclawUnreachableError) as cm:
+				OpenclawSession.connect("ws://t", "x")
+		self.assertIn("UNAUTHORIZED", str(cm.exception))
+		self.assertTrue(scripted.closed)
+
+	def test_missing_challenge_times_out(self):
+		creds = _make_creds()
+		with patch("jarvis.chat.openclaw_client.CONNECT_TIMEOUT_SECONDS", 0.05), \
+			 patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   return_value=_ScriptedWS([])), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
 			with self.assertRaises(OpenclawUnreachableError):
-				OpenclawSession.connect("ws://ignored", "tok-123")
+				OpenclawSession.connect("ws://t", "x")
 
+	def test_empty_gateway_url_raises(self):
+		with patch("jarvis.chat.openclaw_client.ensure_paired", return_value=_make_creds()):
+			with self.assertRaises(OpenclawUnreachableError):
+				OpenclawSession.connect("", "x")
+
+
+# --- TestCreateSession ----------------------------------------------------
 
 class TestCreateSession(FrappeTestCase):
-	def setUp(self):
-		_settings_with_compose_dir()
+	def test_returns_key_on_ok(self):
+		sess, ws = _build_session()
 
-	def test_create_session_returns_key(self):
-		proc = _make_proc([
-			json.dumps({"type": "connect", "ok": True}) + "\n",
-			json.dumps({"type": "create", "ok": True, "key": "agent:main:abc"}) + "\n",
-		])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-				key = sess.create_session(label="test")
-		self.assertEqual(key, "agent:main:abc")
-		# Verify create_session command was written to stdin
-		written = [c.args[0] for c in proc.stdin.write.call_args_list]
-		cmds = [json.loads(w.strip()) for w in written if w.strip()]
-		create_cmds = [c for c in cmds if c.get("cmd") == "create_session"]
-		self.assertEqual(len(create_cmds), 1)
-		self.assertEqual(create_cmds[0]["label"], "test")
+		def _resp():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True,
+						   "payload": {"key": "session-abc"}})
 
-	def test_create_session_rejected(self):
-		proc = _make_proc([
-			json.dumps({"type": "connect", "ok": True}) + "\n",
-			json.dumps({"type": "create", "ok": False, "error": "denied"}) + "\n",
-		])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-				with self.assertRaises(OpenclawUnreachableError):
-					sess.create_session()
+		ws._frames.append(_resp)
+		key = sess.create_session()
+		self.assertEqual(key, "session-abc")
 
+	def test_rejection_raises(self):
+		sess, ws = _build_session()
+
+		def _resp():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "BAD", "message": "no"}})
+
+		ws._frames.append(_resp)
+		with self.assertRaises(OpenclawUnreachableError):
+			sess.create_session()
+
+
+# --- TestStreamAgentTurn --------------------------------------------------
 
 class TestStreamAgentTurn(FrappeTestCase):
-	def setUp(self):
-		_settings_with_compose_dir()
+	def test_completes_on_lifecycle_end(self):
+		sess, ws = _build_session()
 
-	def test_streams_and_terminates_on_runDone(self):
-		proc = _make_proc([
-			json.dumps({"type": "connect", "ok": True}) + "\n",
-			json.dumps({"type": "agentAck", "runId": "r1"}) + "\n",
-			json.dumps({"type": "event", "payload": {
-				"runId": "r1", "stream": "lifecycle", "data": {"phase": "start"}
-			}}) + "\n",
-			json.dumps({"type": "event", "payload": {
-				"runId": "r1", "stream": "assistant",
-				"data": {"text": "Hi", "delta": "Hi"}
-			}}) + "\n",
-			json.dumps({"type": "event", "payload": {
-				"runId": "r1", "stream": "lifecycle", "data": {"phase": "end"}
-			}}) + "\n",
-			json.dumps({"type": "runDone"}) + "\n",
-		])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-				events = list(sess.stream_agent_turn("agent:x", "hi", "idem"))
-		kinds = [e["kind"] for e in events]
-		self.assertEqual(kinds, ["lifecycle", "assistant", "lifecycle"])
+		def _ack():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True,
+						   "payload": {"runId": "run-1"}})
 
-	def test_run_error_raises(self):
-		proc = _make_proc([
-			json.dumps({"type": "connect", "ok": True}) + "\n",
-			json.dumps({"type": "runErr", "error": "agent failed"}) + "\n",
-		])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-				with self.assertRaises(OpenclawUnreachableError):
-					list(sess.stream_agent_turn("agent:x", "hi", "idem"))
+		ws._frames.append(_ack)
+		ws._frames.append(_frame({"type": "event", "event": "agent.event",
+								  "payload": {"runId": "run-1", "stream": "lifecycle",
+											  "data": {"phase": "end"}}}))
+		# Streams to completion (no items required to be yielded for the
+		# completion-path test — parse_event filters its own shapes).
+		list(sess.stream_agent_turn("session-x", "hi", "idem-1"))
+
+	def test_agent_rejection_raises(self):
+		sess, ws = _build_session()
+
+		def _nack():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "BAD_REQ", "message": "x"}})
+
+		ws._frames.append(_nack)
+		with self.assertRaises(OpenclawUnreachableError):
+			list(sess.stream_agent_turn("s", "hi", "i"))
+
+	def test_other_runs_dropped_during_streaming(self):
+		sess, ws = _build_session()
+
+		def _ack():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True,
+						   "payload": {"runId": "run-A"}})
+
+		ws._frames.append(_ack)
+		ws._frames.append(_frame({"type": "event", "event": "agent.event",
+								  "payload": {"runId": "run-B", "stream": "text",
+											  "data": {"delta": "wrong run"}}}))
+		ws._frames.append(_frame({"type": "event", "event": "agent.event",
+								  "payload": {"runId": "run-A", "stream": "lifecycle",
+											  "data": {"phase": "end"}}}))
+		# Should terminate cleanly; cross-run event silently dropped.
+		list(sess.stream_agent_turn("s", "hi", "i"))
 
 
-class TestNodeScript(FrappeTestCase):
-	"""Guard the embedded Node script against losing critical buffering or
-	protocol behavior on future edits — these are the bits we discovered the
-	hard way and shouldn't regress.
-	"""
-
-	def test_forces_stdout_blocking_mode(self):
-		"""Without setBlocking(true), Node block-buffers piped stdout and the
-		Python side sees no events until the process exits — causing the
-		'thinking…' pill to stick through the entire turn.
-		"""
-		from jarvis.chat.openclaw_client import _NODE_SCRIPT
-		self.assertIn("setBlocking(true)", _NODE_SCRIPT)
-		self.assertIn("process.stdout._handle", _NODE_SCRIPT)
-
+# --- TestClose ------------------------------------------------------------
 
 class TestClose(FrappeTestCase):
-	def setUp(self):
-		_settings_with_compose_dir()
-
-	def test_close_sends_close_cmd_and_terminates(self):
-		proc = _make_proc([json.dumps({"type": "connect", "ok": True}) + "\n"])
-		with patch("subprocess.Popen", return_value=proc):
-			with patch("select.select", side_effect=_make_select_always_ready):
-				sess = OpenclawSession.connect("ws://ignored", "tok-123")
-				sess.close()
-		# A close command was written
-		written = [c.args[0] for c in proc.stdin.write.call_args_list]
-		cmds = [json.loads(w.strip()) for w in written if w.strip()]
-		self.assertTrue(any(c.get("cmd") == "close" for c in cmds))
-		proc.terminate.assert_called_once()
+	def test_close_is_safe_to_call_twice(self):
+		sess, ws = _build_session()
+		sess.close()
+		sess.close()
+		self.assertTrue(ws.closed)


### PR DESCRIPTION
Chat used to shell `docker compose exec node -e <script>` so its WS appeared as loopback inside the container — openclaw strips self-declared operator.write scopes from non-loopback token-only clients, and sessions.create requires write scope. The docker-exec workaround only works when the customer bench has docker access on the same machine as openclaw, which doesn't scale to a real fleet.

Now: customer bench owns an Ed25519 keypair, registers the public side once via admin (pair_chat_device → fleet-agent → openclaw), persists the bearer device-token, and signs a v3 device-auth envelope at every WS connect. openclaw verifies the signature against the registered public key, grants the requested scopes, and the rest of the chat protocol (sessions.create, agent, event streaming) runs identically — only the transport changed.

Public surface of OpenclawSession (connect / create_session / stream_agent_turn / close) is unchanged so worker.py and api.py need no edits.

What's added:
- chat/device.py: keypair generation, persistence to Jarvis Settings, ensure_paired() lazy-init, v3 payload + Ed25519 signer (mirrors openclaw src/gateway/device-auth.ts:36 byte-for-byte).
- chat/openclaw_client.py: direct websocket-client WS, signed connect handshake, RPC + event-streaming over a single shared socket.
- admin_client.pair_chat_device(): customer→admin wrapper.
- Jarvis Settings: chat_device_id, chat_device_public_key, chat_device_private_key, chat_device_token.

What's dropped:
- ~110 lines of embedded Node script (`_NODE_SCRIPT`).
- subprocess.Popen + select.select stdin/stdout plumbing.
- Dependency on agent_compose_dir for the chat path (Setting stays for openclaw_bootstrap; chat just stops reading it).

Protocol validated end-to-end in a PoC against the live container before any of this code was written. 18 new tests; suite green on the chat-touching modules.

Requires:
- jarvis-fleet-agent CONTRACT_VERSION >= 1.3 (POST /pair endpoint)
- jarvis-admin with feat/chat-device-pairing merged (pair_chat_device endpoint + Tenant fields)