### PR TITLE
fix(chat): self-heal stale device pairing on connect failure

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -29,7 +29,8 @@ from typing import Any
 import websocket
 
 from jarvis.chat.device import (
-	ChatDeviceCredentials, build_payload_v3, ensure_paired, sign_payload,
+	ChatDeviceCredentials, build_payload_v3, clear_credentials,
+	ensure_paired, sign_payload,
 )
 from jarvis.chat.events import parse_event
 from jarvis.exceptions import OpenclawUnreachableError
@@ -45,6 +46,24 @@ _CLIENT_ID = "gateway-client"
 _CLIENT_MODE = "backend"
 _ROLE = "operator"
 _PLATFORM = "linux"  # informational; only affects the v3 signature payload
+
+# Substrings in openclaw's connect-rejection error message that indicate the
+# customer's stored pairing is stale for the current container (typically
+# because admin re-provisioned the tenant and the new container has no record
+# of this deviceId). In those cases we wipe + re-pair once. Other rejection
+# reasons (signature-invalid, scope-mismatch) are programming bugs and must
+# NOT trigger a retry — that'd hide the bug behind silent re-pair attempts.
+_STALE_PAIRING_MARKERS = (
+	"device-not-paired",
+	"token-mismatch",
+	"token-revoked",
+	"device-id-mismatch",
+)
+
+
+def _is_stale_pairing(err: Exception) -> bool:
+	msg = str(err).lower()
+	return any(marker in msg for marker in _STALE_PAIRING_MARKERS)
 
 
 class OpenclawSession:
@@ -74,6 +93,16 @@ class OpenclawSession:
 		if not gateway_url:
 			raise OpenclawUnreachableError("agent_url not set on Jarvis Settings")
 
+		# Two-shot self-heal for tenant re-provisioning: on the first attempt
+		# we use whatever paired creds the customer has; if openclaw rejects
+		# with a "your pairing is stale" marker (typical when admin replaced
+		# the container under us — new container has empty pairing state),
+		# we wipe + re-pair once and try again. A second stale signal is a
+		# real failure, not a retry candidate.
+		return cls._attempt_connect(gateway_url, allow_repair=True)
+
+	@classmethod
+	def _attempt_connect(cls, gateway_url: str, *, allow_repair: bool) -> OpenclawSession:
 		creds = ensure_paired()
 		try:
 			ws = websocket.create_connection(
@@ -88,6 +117,13 @@ class OpenclawSession:
 
 		try:
 			cls._handshake(ws, creds)
+		except OpenclawUnreachableError as e:
+			try: ws.close()
+			except Exception: pass
+			if allow_repair and _is_stale_pairing(e):
+				clear_credentials()
+				return cls._attempt_connect(gateway_url, allow_repair=False)
+			raise
 		except Exception:
 			try: ws.close()
 			except Exception: pass

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -256,3 +256,108 @@ class TestClose(FrappeTestCase):
 		sess.close()
 		sess.close()
 		self.assertTrue(ws.closed)
+
+
+# --- TestSelfHeal ---------------------------------------------------------
+
+class TestSelfHealOnStalePairing(FrappeTestCase):
+	"""When admin re-provisions a tenant, the new container has no record of
+	the customer's existing chat_device_*. The first WS connect fails with
+	one of openclaw's pairing-stale errors. openclaw_client should detect
+	that, clear local creds, re-pair via ensure_paired, and retry the WS
+	once. A second stale signal is a real failure (no infinite loop)."""
+
+	def _build_two_ws(self, first_reject_marker: str, second_ok: bool):
+		"""Return two scripted WS instances: first one rejects connect with
+		`first_reject_marker` in the error message; second one accepts."""
+		first_sent: list = []
+		second_sent: list = []
+
+		def _first_nack():
+			req_id = first.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "UNAUTHORIZED", "message": first_reject_marker}})
+
+		def _second_ok():
+			req_id = second.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True, "payload": {}})
+
+		def _second_nack():
+			req_id = second.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "UNAUTHORIZED", "message": first_reject_marker}})
+
+		first = _ScriptedWS([_challenge(), _first_nack])
+		second_response = _second_ok if second_ok else _second_nack
+		second = _ScriptedWS([_challenge(), second_response])
+		return first, second
+
+	def _connect_with_two_ws(self, first_ws, second_ws):
+		ws_iter = iter([first_ws, second_ws])
+		clear_called: list = []
+
+		def _fake_clear():
+			clear_called.append(True)
+
+		creds = _make_creds()
+		ensure_paired_calls: list = []
+
+		def _fake_ensure_paired():
+			ensure_paired_calls.append(True)
+			return creds
+
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   side_effect=lambda *a, **kw: next(ws_iter)), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired",
+				   side_effect=_fake_ensure_paired), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=_fake_clear):
+			result = OpenclawSession.connect("ws://t", "x")
+		return result, clear_called, ensure_paired_calls
+
+	def test_device_not_paired_triggers_repair_and_retry_succeeds(self):
+		first_ws, second_ws = self._build_two_ws("device-not-paired", second_ok=True)
+		sess, clears, ensure_calls = self._connect_with_two_ws(first_ws, second_ws)
+		# clear_credentials was called once between the two attempts.
+		self.assertEqual(len(clears), 1)
+		# ensure_paired was called twice (once per attempt).
+		self.assertEqual(len(ensure_calls), 2)
+		self.assertTrue(first_ws.closed)
+		self.assertFalse(second_ws.closed)
+		sess.close()
+
+	def test_token_revoked_also_triggers_repair(self):
+		first_ws, second_ws = self._build_two_ws("token-revoked", second_ok=True)
+		sess, clears, _ = self._connect_with_two_ws(first_ws, second_ws)
+		self.assertEqual(len(clears), 1)
+		sess.close()
+
+	def test_second_failure_does_not_loop(self):
+		"""After one repair attempt, a second stale-pairing signal must
+		propagate as a real failure — not a third retry."""
+		first_ws, second_ws = self._build_two_ws("device-not-paired", second_ok=False)
+		with self.assertRaises(OpenclawUnreachableError):
+			self._connect_with_two_ws(first_ws, second_ws)
+
+	def test_signature_invalid_does_not_trigger_repair(self):
+		"""A signing bug must surface, not get masked by a silent re-pair.
+		signature-invalid means our client code is broken; clearing creds
+		won't help and the operator needs to see the original error."""
+		creds = _make_creds()
+
+		def _nack():
+			req_id = first_ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "UNAUTHORIZED", "message": "device-signature-invalid"}})
+
+		first_ws = _ScriptedWS([_challenge(), _nack])
+		clear_called: list = []
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   return_value=first_ws), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)):
+			with self.assertRaises(OpenclawUnreachableError) as cm:
+				OpenclawSession.connect("ws://t", "x")
+		self.assertFalse(clear_called, "should not clear creds for signing bugs")
+		self.assertIn("signature-invalid", str(cm.exception))


### PR DESCRIPTION
When admin re-provisions a tenant (destroy + reassign-from-pool), the customer's existing chat_device_* creds point at a container that no longer exists; the new container has no record of this deviceId, so the first WS connect handshake gets rejected by openclaw with reasons like "device-not-paired" or "token-revoked". Previously this just bubbled up as OpenclawUnreachableError and the customer was stuck until they manually wiped Jarvis Settings.

OpenclawSession.connect now does a two-shot self-heal: if the first handshake fails with a stale-pairing marker, wipe the local creds and re-pair once (ensure_paired regenerates a keypair + asks admin to register it with the current container). A second failure propagates as a real error — no retry loop.

Self-heal markers are scoped to errors that mean "the server has forgotten about this device":
- device-not-paired
- token-mismatch
- token-revoked
- device-id-mismatch

Signing bugs (device-signature-invalid, etc.) explicitly do NOT trigger re-pair — they'd be hidden behind a silent retry instead of surfacing the actual client-side bug.

Four new tests cover: happy-path repair, revoked-token repair, no-infinite-loop on persistent failure, signing-bug not masked.