### PR TITLE
feat(account): /jarvis-account page — plan + LLM creds + upgrade/renew

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -1,0 +1,52 @@
+"""Customer-side wrappers for the /jarvis-account page.
+
+Thin shims over admin_client (so the browser never holds admin api_key /
+api_secret). Errors are normalized via the shared ``_surface`` helper from
+onboarding so admin ValidationErrors arrive as clean ``frappe.throw`` toasts.
+
+The page also reuses these existing onboarding endpoints directly under
+their published names — no duplicates:
+
+  - jarvis.onboarding.save_llm_creds  (LLM section save)
+  - jarvis.onboarding.renew           (renew / reactivate / resume CTAs)
+  - jarvis.onboarding.finish_payment  (post-Razorpay confirm)
+"""
+
+import frappe
+
+from jarvis import admin_client
+from jarvis.onboarding import _surface
+
+
+@frappe.whitelist()
+def is_onboarded() -> dict:
+	"""True iff Jarvis Settings holds an admin api_key. The wizard's
+	completion-card branch and the account page's redirect guard share this.
+
+	Pool-pending customers (paid but no tenant yet) still count as onboarded —
+	they've completed signup; the agent_url just hasn't been wired up. The
+	account page handles that state via tenant_status: pending.
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+	api_key = (settings.get_password(
+		"jarvis_admin_api_key", raise_exception=False,
+	) or "").strip()
+	return {"onboarded": bool(api_key)}
+
+
+@frappe.whitelist()
+def get_account() -> dict:
+	"""Plan + validity + upgrade-eligible plans for the account page."""
+	return _surface(admin_client.get_account_summary)
+
+
+@frappe.whitelist()
+def preview_upgrade(target_plan: str) -> dict:
+	"""Prorated amount for the upgrade modal's per-plan cards."""
+	return _surface(admin_client.preview_upgrade, target_plan)
+
+
+@frappe.whitelist()
+def start_upgrade(target_plan: str) -> dict:
+	"""Create the prorated Razorpay order; the page then opens Checkout."""
+	return _surface(admin_client.start_upgrade, target_plan)

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -103,6 +103,39 @@ def pair_chat_device(public_key: str, device_id: str) -> dict:
 	)
 
 
+def get_account_summary() -> dict:
+	"""Fetch the customer's plan + validity + upgrade-eligible plans. Used by
+	the /jarvis-account page to render plan summary and the upgrade picker."""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.account.get_account_summary",
+		body={}, admin_url=_admin_url(settings),
+	)
+
+
+def preview_upgrade(target_plan: str) -> dict:
+	"""Get the prorated amount for upgrading to ``target_plan`` (no order
+	created). Used by the upgrade plan picker so each plan card shows the
+	live-computed amount before the customer commits."""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.account.preview_upgrade",
+		body={"target_plan": target_plan}, admin_url=_admin_url(settings),
+	)
+
+
+def start_upgrade(target_plan: str) -> dict:
+	"""Create a prorated Razorpay order for the upgrade and return the
+	Razorpay handles ({razorpay_order_id, razorpay_key_id, amount_inr,
+	target_plan}). The order's notes carry the upgrade intent for
+	confirm_payment to pick up after Razorpay Checkout completes."""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.account.start_upgrade",
+		body={"target_plan": target_plan}, admin_url=_admin_url(settings),
+	)
+
+
 def _post(path: str, body: dict, admin_url: str,
 		  timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	"""Authenticated POST. Reads native api_key + api_secret from Jarvis

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -1,0 +1,511 @@
+frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
+	const page = frappe.ui.make_app_page({ parent: wrapper, title: "My Jarvis Account", single_column: true });
+	if (!window.Razorpay) {
+		frappe.require("https://checkout.razorpay.com/v1/checkout.js");
+	}
+
+	injectStyles();
+
+	const esc = frappe.utils.escape_html;
+	const inr = (n) => "₹" + Number(n || 0).toLocaleString("en-IN");
+	const cycleLabel = (c) => (String(c).toLowerCase() === "annual" ? "/year" : "/month");
+
+	// LLM provider defaults — mirror the onboarding wizard's PROVIDER_DEFAULTS
+	// so the section behaves identically there and here.
+	const PROVIDER_DEFAULTS = {
+		"Anthropic":          { model: "claude-sonnet-4-6",                 baseUrl: "https://api.anthropic.com" },
+		"OpenAI":             { model: "gpt-4o",                            baseUrl: "https://api.openai.com/v1" },
+		"Google Gemini":      { model: "gemini-1.5-pro",                    baseUrl: "https://generativelanguage.googleapis.com" },
+		"Mistral":            { model: "mistral-large-latest",              baseUrl: "https://api.mistral.ai/v1" },
+		"Groq":               { model: "llama-3.3-70b-versatile",           baseUrl: "https://api.groq.com/openai/v1" },
+		"Together AI":        { model: "meta-llama/Llama-3.3-70B-Instruct-Turbo", baseUrl: "https://api.together.xyz/v1" },
+		"DeepSeek":           { model: "deepseek-chat",                     baseUrl: "https://api.deepseek.com" },
+		"Moonshot (Kimi)":    { model: "kimi-k2.6",                         baseUrl: "https://api.moonshot.ai/v1" },
+		"OpenRouter":         { model: "anthropic/claude-sonnet-4-6",       baseUrl: "https://openrouter.ai/api/v1" },
+		"Ollama (local)":     { model: "llama3",                            baseUrl: "http://host.docker.internal:11434/v1" },
+		"vLLM (local)":       { model: "",                                  baseUrl: "" },
+		"OpenAI-Compatible":  { model: "",                                  baseUrl: "" },
+	};
+	const PROVIDERS = Object.keys(PROVIDER_DEFAULTS);
+
+	// Subscription states that allow LLM credential changes. The others all
+	// imply "service is paused" so the form is read-only.
+	const EDITABLE_STATES = new Set(["Active", "Cancelled"]);
+
+	const $root = $(`
+		<div class="ja">
+		  <div class="ja-brand">
+		    <div class="ja-logo">✦</div>
+		    <div class="ja-brand-name">Jarvis</div>
+		    <div class="ja-brand-tag">Your AI workspace for ERPNext.</div>
+		    <div class="ja-brand-foot">Manage your plan, credentials, and billing here.</div>
+		  </div>
+		  <div class="ja-panel">
+		    <div class="ja-body"></div>
+		  </div>
+		</div>`);
+	const $bg = $(`<div class="ja-bg"></div>`).appendTo(page.main);
+	$root.appendTo($bg);
+	const $body = $root.find(".ja-body");
+
+	// ---- state -------------------------------------------------------------
+	let account = null;       // payload from get_account
+	let settingsLocal = null; // local Jarvis Settings LLM fields snapshot
+
+	// ---- boot --------------------------------------------------------------
+	loadInitial();
+
+	function loadInitial() {
+		$body.html(`<div class="ja-loading">Loading your account…</div>`);
+		frappe.call({ method: "jarvis.account.is_onboarded" })
+			.then((r) => {
+				if (!r.message || !r.message.onboarded) {
+					// Not onboarded — wizard owns this customer.
+					window.location.assign("/app/jarvis-onboarding");
+					return;
+				}
+				return Promise.all([
+					frappe.call({ method: "jarvis.account.get_account" }),
+					frappe.db.get_doc("Jarvis Settings"),
+				]).then(([acc, settings]) => {
+					account = (acc && acc.message) || {};
+					settingsLocal = settings || {};
+					render();
+				});
+			})
+			.catch((e) => {
+				$body.html(`<div class="ja-err">Couldn't load account info.
+					${esc(e.message || "")}
+					<button class="ja-btn ja-btn-ghost" id="ja-retry">Retry</button></div>`);
+				$body.find("#ja-retry").on("click", loadInitial);
+			});
+	}
+
+	function render() {
+		const sub = account.subscription_status || "none";
+		const editable = EDITABLE_STATES.has(sub);
+		$body.html(`
+			${renderPlanSection()}
+			${renderLlmSection(editable)}
+			${renderBillingSection()}
+		`);
+		bindLlm(editable);
+		bindBilling();
+	}
+
+	// ---- plan & validity section ------------------------------------------
+	function renderPlanSection() {
+		const sub = account.subscription_status || "none";
+		const plan = account.plan || {};
+		if (!plan || !plan.name) {
+			return `<div class="ja-card">
+				<h2 class="ja-h">No plan</h2>
+				<p class="ja-sub">You don't have an active subscription yet.</p>
+			</div>`;
+		}
+		const banner = renderPlanBanner(sub);
+		return `<div class="ja-card">
+			<div class="ja-card-head">
+				<div>
+					<div class="ja-eyebrow">Plan</div>
+					<h2 class="ja-h">${esc(plan.plan_name || plan.name)}</h2>
+					<div class="ja-plan-meta">${inr(plan.price_inr)} <span class="jo-plan-cycle">${cycleLabel(plan.billing_cycle)}</span></div>
+				</div>
+				${renderStatusPill(sub)}
+			</div>
+			${banner}
+		</div>`;
+	}
+
+	function renderStatusPill(sub) {
+		const tone = {
+			"Active": "ok", "Cancelled": "warn", "Past Due": "warn",
+			"Expired": "bad", "Pending Payment": "warn",
+		}[sub] || "muted";
+		return `<span class="ja-pill ja-pill-${tone}">${esc(sub)}</span>`;
+	}
+
+	function renderPlanBanner(sub) {
+		const end = account.current_period_end ? frappe.datetime.str_to_user(account.current_period_end) : "";
+		const days = account.days_remaining || 0;
+		switch (sub) {
+			case "Active":
+				return `<div class="ja-banner ja-banner-ok">Renews on <b>${esc(end)}</b> · ${days} day${days === 1 ? "" : "s"} left.</div>`;
+			case "Cancelled":
+				return `<div class="ja-banner ja-banner-warn">Cancelled · runs until <b>${esc(end)}</b>.</div>`;
+			case "Past Due":
+				return `<div class="ja-banner ja-banner-warn">Plan past due — expired on <b>${esc(end)}</b>. Reactivate to resume service.</div>`;
+			case "Expired":
+				return `<div class="ja-banner ja-banner-bad">Plan expired on <b>${esc(end)}</b>. Reactivate to resume service.</div>`;
+			case "Pending Payment":
+				return `<div class="ja-banner ja-banner-warn">Payment incomplete · finish to activate.</div>`;
+			default:
+				return "";
+		}
+	}
+
+	// ---- LLM credentials section ------------------------------------------
+	function renderLlmSection(editable) {
+		const provider = settingsLocal.llm_provider || "Anthropic";
+		const model = settingsLocal.llm_model || (PROVIDER_DEFAULTS[provider] || {}).model || "";
+		const base = settingsLocal.llm_base_url || (PROVIDER_DEFAULTS[provider] || {}).baseUrl || "";
+		const sync = settingsLocal.last_sync_status || "";
+		const dis = editable ? "" : "disabled";
+		const tip = editable ? "" : `title="Reactivate your plan to update LLM credentials"`;
+		const sel = PROVIDERS.map((p) => `<option value="${esc(p)}" ${p === provider ? "selected" : ""}>${esc(p)}</option>`).join("");
+		return `<div class="ja-card" ${tip}>
+			<div class="ja-eyebrow">AI provider</div>
+			<h2 class="ja-h">LLM Credentials</h2>
+			<p class="ja-sub">Your API key is sent directly to the provider — Jarvis only relays prompts.</p>
+			<div class="ja-row2">
+				<div class="ja-field">
+					<label>Provider</label>
+					<select class="ja-input" id="ja-prov" ${dis}>${sel}</select>
+				</div>
+				<div class="ja-field">
+					<label>Model</label>
+					<input class="ja-input" id="ja-model" value="${esc(model)}" ${dis}>
+				</div>
+			</div>
+			<div class="ja-row2">
+				<div class="ja-field">
+					<label>API Key</label>
+					<input class="ja-input" id="ja-key" type="password" placeholder="${settingsLocal.llm_api_key ? "•••••••• (unchanged)" : "Enter your API key"}" ${dis}>
+				</div>
+				<div class="ja-field">
+					<label>Base URL <span class="ja-hint-inline">(optional)</span></label>
+					<input class="ja-input" id="ja-base" value="${esc(base)}" ${dis}>
+				</div>
+			</div>
+			<div class="ja-actions">
+				<button class="ja-btn ja-btn-primary" id="ja-llm-save" ${dis}>Save credentials</button>
+				<span class="ja-llm-status">${sync ? "Last sync: " + esc(sync) : ""}</span>
+			</div>
+			<div class="ja-err" id="ja-llm-err"></div>
+		</div>`;
+	}
+
+	function bindLlm(editable) {
+		if (!editable) return;
+		const $prov = $body.find("#ja-prov");
+		$prov.on("change", () => {
+			const p = $prov.val();
+			const d = PROVIDER_DEFAULTS[p] || {};
+			$body.find("#ja-model").val(d.model || "");
+			$body.find("#ja-base").val(d.baseUrl || "");
+		});
+		$body.find("#ja-llm-save").on("click", () => {
+			const provider = $prov.val();
+			const model = $body.find("#ja-model").val().trim();
+			const key = $body.find("#ja-key").val().trim();
+			const base = $body.find("#ja-base").val().trim();
+			if (!provider || !model) {
+				return $body.find("#ja-llm-err").text("Provider and model are required.");
+			}
+			if (!key && !settingsLocal.llm_api_key) {
+				return $body.find("#ja-llm-err").text("API key is required.");
+			}
+			$body.find("#ja-llm-err").text("");
+			setBusy("#ja-llm-save", true);
+			frappe.call({
+				method: "jarvis.onboarding.save_llm_creds",
+				args: { provider, model, api_key: key || "", base_url: base },
+			}).then((r) => {
+				setBusy("#ja-llm-save", false);
+				const status = (r.message && r.message.last_sync_status) || "";
+				$body.find(".ja-llm-status").text(status ? "Last sync: " + status : "Saved.");
+				settingsLocal.llm_provider = provider;
+				settingsLocal.llm_model = model;
+				settingsLocal.llm_base_url = base;
+				settingsLocal.llm_api_key = key || settingsLocal.llm_api_key;
+				settingsLocal.last_sync_status = status;
+				// Clear the entered key from the input now that it's persisted.
+				$body.find("#ja-key").val("");
+			}).catch((e) => {
+				setBusy("#ja-llm-save", false);
+				$body.find("#ja-llm-err").text(e.message || "Save failed.");
+			});
+		});
+	}
+
+	// ---- billing section --------------------------------------------------
+	function renderBillingSection() {
+		const sub = account.subscription_status || "none";
+		const upgrade = (account.upgrade_plans || []).length > 0;
+		const ctaPrimary = primaryCta(sub);
+		const ctaSecondary = secondaryCta(sub, upgrade);
+		return `<div class="ja-card">
+			<div class="ja-eyebrow">Billing</div>
+			<h2 class="ja-h">${esc(ctaPrimary.heading)}</h2>
+			<p class="ja-sub">${esc(ctaPrimary.subtitle)}</p>
+			<div class="ja-actions">
+				${ctaPrimary ? `<button class="ja-btn ja-btn-primary" id="ja-cta-primary" data-action="${ctaPrimary.action}">${esc(ctaPrimary.label)}</button>` : ""}
+				${ctaSecondary ? `<button class="ja-btn ja-btn-ghost" id="ja-cta-secondary" data-action="${ctaSecondary.action}">${esc(ctaSecondary.label)}</button>` : ""}
+			</div>
+			<div class="ja-err" id="ja-billing-err"></div>
+		</div>`;
+	}
+
+	function primaryCta(sub) {
+		const upgrade = (account.upgrade_plans || []).length > 0;
+		switch (sub) {
+			case "Active":
+				return upgrade
+					? { action: "upgrade", label: "Upgrade plan",
+						heading: "Want more capacity?", subtitle: "Move to a higher plan — you only pay the prorated difference for the remaining period." }
+					: { action: "renew", label: "Renew now",
+						heading: "Renew early", subtitle: "Add another billing cycle to your current plan." };
+			case "Cancelled":
+				return { action: "renew", label: "Resume / Renew",
+						 heading: "Resume your plan", subtitle: "Pay now to keep service running past the current period end." };
+			case "Past Due":
+			case "Expired":
+				return { action: "renew", label: "Reactivate",
+						 heading: "Reactivate your plan", subtitle: "Pay now to restore service and bring your container back online." };
+			case "Pending Payment":
+				return { action: "renew", label: "Complete payment",
+						 heading: "Finish signing up", subtitle: "Complete payment to activate your plan." };
+			default:
+				return { action: "renew", label: "Subscribe", heading: "Subscribe", subtitle: "" };
+		}
+	}
+
+	function secondaryCta(sub, hasUpgrade) {
+		if (sub === "Active" && hasUpgrade) return { action: "renew", label: "Renew now" };
+		if (sub === "Cancelled" && hasUpgrade) return { action: "upgrade", label: "Upgrade plan" };
+		return null;
+	}
+
+	function bindBilling() {
+		$body.find("#ja-cta-primary, #ja-cta-secondary").on("click", function () {
+			const action = $(this).data("action");
+			if (action === "upgrade") return openUpgradeModal();
+			if (action === "renew") return startRenew();
+		});
+	}
+
+	// ---- renew flow -------------------------------------------------------
+	function startRenew() {
+		setBusy("#ja-cta-primary", true);
+		setBusy("#ja-cta-secondary", true);
+		frappe.call({ method: "jarvis.onboarding.renew" })
+			.then((r) => {
+				setBusy("#ja-cta-primary", false);
+				setBusy("#ja-cta-secondary", false);
+				const data = (r.message && r.message.data) || r.message || {};
+				openCheckout(data, /*upgrade=*/false);
+			}).catch((e) => {
+				setBusy("#ja-cta-primary", false);
+				setBusy("#ja-cta-secondary", false);
+				$body.find("#ja-billing-err").text(e.message || "Couldn't start payment.");
+			});
+	}
+
+	// ---- upgrade flow + modal --------------------------------------------
+	function openUpgradeModal() {
+		const plans = account.upgrade_plans || [];
+		const cards = plans.map((p) => `
+			<div class="ja-up-card" data-plan="${esc(p.name)}">
+				<div class="ja-up-card-head">
+					<div class="ja-up-card-name">${esc(p.plan_name || p.name)}</div>
+					<div class="ja-up-card-price">${inr(p.price_inr)} <span class="jo-plan-cycle">${cycleLabel(p.billing_cycle)}</span></div>
+				</div>
+				<div class="ja-up-card-prorate" data-plan-prorate="${esc(p.name)}">Calculating prorated amount…</div>
+				<button class="ja-btn ja-btn-primary ja-up-pick" data-plan="${esc(p.name)}" disabled>Loading…</button>
+			</div>`).join("");
+		const html = `<div class="ja-modal-bg">
+			<div class="ja-modal">
+				<div class="ja-modal-head">
+					<h2 class="ja-h">Choose an upgrade</h2>
+					<button class="ja-modal-close" id="ja-modal-close">✕</button>
+				</div>
+				<p class="ja-sub">You only pay the prorated difference for the days remaining in your current billing period.</p>
+				<div class="ja-up-list">${cards || `<div class="ja-empty">No upgrade plans available.</div>`}</div>
+				<div class="ja-err" id="ja-up-err"></div>
+			</div>
+		</div>`;
+		const $m = $(html).appendTo(document.body);
+		$m.find("#ja-modal-close, .ja-modal-bg").on("click", function (e) {
+			if (e.target === this) $m.remove();
+		});
+		// Fetch prorated amount per plan in parallel.
+		plans.forEach((p) => {
+			frappe.call({ method: "jarvis.account.preview_upgrade", args: { target_plan: p.name } })
+				.then((r) => {
+					const d = (r.message && r.message.data) || r.message || {};
+					$m.find(`[data-plan-prorate="${p.name}"]`).text(`Pay ${inr(d.prorated_inr)} now`);
+					$m.find(`.ja-up-pick[data-plan="${p.name}"]`)
+						.text(`Pay ${inr(d.prorated_inr)}`).prop("disabled", false)
+						.on("click", () => startUpgrade(p.name, $m));
+				}).catch((e) => {
+					$m.find(`[data-plan-prorate="${p.name}"]`).text(e.message || "Couldn't compute amount.");
+				});
+		});
+	}
+
+	function startUpgrade(target_plan, $modal) {
+		const $btn = $modal.find(`.ja-up-pick[data-plan="${target_plan}"]`);
+		setBusy($btn, true);
+		frappe.call({ method: "jarvis.account.start_upgrade", args: { target_plan } })
+			.then((r) => {
+				setBusy($btn, false);
+				const data = (r.message && r.message.data) || r.message || {};
+				$modal.remove();
+				openCheckout(data, /*upgrade=*/true);
+			}).catch((e) => {
+				setBusy($btn, false);
+				$modal.find("#ja-up-err").text(e.message || "Couldn't start upgrade.");
+			});
+	}
+
+	// ---- Razorpay Checkout (shared) ---------------------------------------
+	function openCheckout(handles, isUpgrade) {
+		const opts = {
+			key: handles.razorpay_key_id,
+			amount: Math.round((handles.amount_inr || 0) * 100),
+			currency: "INR",
+			order_id: handles.razorpay_order_id,
+			name: "Jarvis",
+			description: isUpgrade ? "Plan upgrade" : "Subscription payment",
+			handler: function (res) {
+				confirmAndRefresh({
+					razorpay_payment_id: res.razorpay_payment_id,
+					razorpay_order_id: res.razorpay_order_id,
+					razorpay_signature: res.razorpay_signature,
+				});
+			},
+		};
+		new Razorpay(opts).open();
+	}
+
+	// finish_payment + self-healing fallback (idempotent confirm + polling)
+	function confirmAndRefresh(payload) {
+		showOverlay("Finalizing your payment…");
+		frappe.call({ method: "jarvis.onboarding.finish_payment", args: { payload } })
+			.then(() => { hideOverlay(); loadInitial(); })
+			.catch(() => pollForApplied());
+	}
+
+	function pollForApplied() {
+		showOverlay("Payment received — finalizing your account…");
+		const before = JSON.stringify({
+			plan: (account.plan || {}).name || "",
+			end: account.current_period_end || "",
+			status: account.subscription_status || "",
+		});
+		let elapsed = 0;
+		const tick = setInterval(() => {
+			elapsed += 3;
+			frappe.call({ method: "jarvis.account.get_account" }).then((r) => {
+				const a = (r && r.message) || {};
+				const now = JSON.stringify({
+					plan: (a.plan || {}).name || "",
+					end: a.current_period_end || "",
+					status: a.subscription_status || "",
+				});
+				if (now !== before) {
+					clearInterval(tick); hideOverlay(); loadInitial();
+				} else if (elapsed >= 30) {
+					clearInterval(tick); hideOverlay();
+					frappe.msgprint({
+						title: "Plan update pending",
+						message: "Your payment was received. The page should update within a minute — refresh to view, or contact support if it doesn't.",
+						indicator: "blue",
+					});
+				}
+			}).catch(() => {
+				if (elapsed >= 30) {
+					clearInterval(tick); hideOverlay();
+				}
+			});
+		}, 3000);
+	}
+
+	// ---- small helpers ----------------------------------------------------
+	function setBusy(sel, on) {
+		const $b = typeof sel === "string" ? $body.find(sel) : sel;
+		if (on) { $b.prop("disabled", true).attr("data-label", $b.html()).html(`<span class="ja-spin"></span> Working…`); }
+		else if ($b.attr("data-label")) { $b.prop("disabled", false).html($b.attr("data-label")); }
+	}
+
+	function showOverlay(text) {
+		hideOverlay();
+		$(`<div class="ja-overlay"><div class="ja-overlay-card"><span class="ja-spin"></span> ${esc(text)}</div></div>`).appendTo(document.body);
+	}
+	function hideOverlay() { $(".ja-overlay").remove(); }
+
+	function injectStyles() {
+		if (document.getElementById("ja-styles")) return;
+		const css = `
+		.ja-bg{position:fixed;inset:0;z-index:1;display:flex;align-items:flex-start;justify-content:center;
+			overflow:hidden auto;padding:48px 20px;background-color:var(--bg-color)}
+		.ja-bg::before{content:"";position:absolute;inset:-25%;z-index:0;will-change:transform;
+			animation:ja-aurora 26s ease-in-out infinite alternate;
+			background-image:
+			  radial-gradient(at 16% 20%, color-mix(in srgb, var(--primary,#4a47e5) 26%, transparent) 0, transparent 46%),
+			  radial-gradient(at 84% 16%, color-mix(in srgb, #7c3aed 22%, transparent) 0, transparent 46%),
+			  radial-gradient(at 78% 84%, color-mix(in srgb, #06b6d4 18%, transparent) 0, transparent 44%),
+			  radial-gradient(at 22% 82%, color-mix(in srgb, var(--primary,#4a47e5) 16%, transparent) 0, transparent 46%)}
+		@keyframes ja-aurora{0%{transform:translate3d(0,0,0) scale(1) rotate(0deg)}
+			50%{transform:translate3d(2.5%,-2%,0) scale(1.08) rotate(1.2deg)}
+			100%{transform:translate3d(-2%,2.5%,0) scale(1.05) rotate(-1.2deg)}}
+		@media(prefers-reduced-motion:reduce){.ja-bg::before{animation:none}}
+		.ja{position:relative;z-index:1;display:flex;gap:0;width:100%;max-width:1080px;margin:auto;border:1px solid var(--border-color);
+			border-radius:var(--border-radius-lg,14px);overflow:hidden;box-shadow:0 20px 50px -20px rgba(20,20,50,.45),var(--shadow-md);background:var(--card-bg)}
+		.ja-brand{flex:0 0 34%;padding:36px 32px;color:#fff;background:linear-gradient(160deg,var(--primary,#4a47e5) 0%,#6d28d9 100%);display:flex;flex-direction:column}
+		.ja-logo{font-size:34px;line-height:1}
+		.ja-brand-name{font-size:30px;font-weight:700;margin-top:10px;letter-spacing:-.5px}
+		.ja-brand-tag{font-size:15px;opacity:.92;margin-top:6px;line-height:1.45}
+		.ja-brand-foot{margin-top:auto;padding-top:24px;font-size:12px;opacity:.8}
+		.ja-panel{flex:1;padding:34px 36px;min-width:0;display:flex;flex-direction:column;gap:18px}
+		.ja-loading,.ja-empty{color:var(--text-muted);padding:18px 0}
+		.ja-card{border:1px solid var(--border-color);border-radius:12px;padding:20px;background:var(--card-bg)}
+		.ja-card-head{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
+		.ja-eyebrow{font-size:11.5px;letter-spacing:.6px;font-weight:600;color:var(--text-muted);text-transform:uppercase}
+		.ja-h{font-size:20px;font-weight:700;margin:2px 0 4px;color:var(--text-color)}
+		.ja-sub{font-size:13.5px;color:var(--text-muted);margin:0 0 14px}
+		.ja-plan-meta{font-size:14px;color:var(--text-color);margin-top:4px}
+		.ja-pill{padding:4px 10px;border-radius:999px;font-size:12px;font-weight:600;letter-spacing:.3px;border:1px solid transparent;white-space:nowrap}
+		.ja-pill-ok{background:rgba(46,189,89,.12);color:var(--green-700,#1f8d3a);border-color:rgba(46,189,89,.25)}
+		.ja-pill-warn{background:rgba(245,159,0,.14);color:var(--yellow-700,#a06200);border-color:rgba(245,159,0,.28)}
+		.ja-pill-bad{background:rgba(226,76,76,.12);color:var(--red-600,#c0392b);border-color:rgba(226,76,76,.25)}
+		.ja-pill-muted{background:var(--bg-color);color:var(--text-muted);border-color:var(--border-color)}
+		.ja-banner{margin-top:14px;padding:10px 12px;border-radius:8px;font-size:13px}
+		.ja-banner-ok{background:rgba(46,189,89,.08);color:var(--text-color)}
+		.ja-banner-warn{background:rgba(245,159,0,.10);color:var(--text-color)}
+		.ja-banner-bad{background:rgba(226,76,76,.10);color:var(--text-color)}
+		.ja-row2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+		.ja-field{margin-bottom:6px}
+		.ja-field label{display:block;font-size:12.5px;font-weight:600;color:var(--text-color);margin-bottom:6px}
+		.ja-input{width:100%;padding:10px 12px;font-size:14px;border:1px solid var(--border-color);border-radius:var(--border-radius,8px);background:var(--control-bg,var(--bg-color));color:var(--text-color)}
+		.ja-input:focus{outline:none;border-color:var(--primary,#4a47e5);box-shadow:0 0 0 2px rgba(74,71,229,.18)}
+		.ja-input:disabled{opacity:.6;cursor:not-allowed}
+		.ja-actions{margin-top:14px;display:flex;align-items:center;gap:10px}
+		.ja-btn{padding:9px 18px;font-size:14px;font-weight:600;border-radius:var(--border-radius,8px);border:1px solid transparent;cursor:pointer}
+		.ja-btn-primary{background:var(--primary,#4a47e5);color:#fff}
+		.ja-btn-primary:hover{filter:brightness(1.06)}
+		.ja-btn-primary:disabled{opacity:.5;cursor:not-allowed}
+		.ja-btn-ghost{background:transparent;border-color:var(--border-color);color:var(--text-color)}
+		.ja-btn-ghost:hover{border-color:var(--primary,#4a47e5);color:var(--primary,#4a47e5)}
+		.ja-err{color:var(--red-500,#e24c4c);font-size:12.5px;margin-top:8px;min-height:1px}
+		.ja-llm-status{color:var(--text-muted);font-size:12.5px;margin-left:8px}
+		.ja-spin{display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,.5);border-top-color:#fff;border-radius:50%;animation:ja-spin .6s linear infinite;vertical-align:-1px}
+		@keyframes ja-spin{to{transform:rotate(360deg)}}
+		.ja-modal-bg{position:fixed;inset:0;background:rgba(20,20,40,.55);z-index:1000;display:flex;align-items:center;justify-content:center;padding:20px}
+		.ja-modal{background:var(--card-bg);border-radius:14px;max-width:600px;width:100%;padding:28px;box-shadow:0 20px 60px -20px rgba(0,0,0,.5)}
+		.ja-modal-head{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px}
+		.ja-modal-close{background:transparent;border:0;font-size:18px;cursor:pointer;color:var(--text-muted)}
+		.ja-up-list{display:flex;flex-direction:column;gap:10px;margin-top:12px}
+		.ja-up-card{border:1px solid var(--border-color);border-radius:10px;padding:14px 16px}
+		.ja-up-card-head{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:6px}
+		.ja-up-card-name{font-size:14px;font-weight:600;color:var(--text-color)}
+		.ja-up-card-price{font-size:16px;font-weight:700;color:var(--text-color)}
+		.ja-up-card-prorate{font-size:13px;color:var(--text-muted);margin-bottom:10px}
+		.ja-overlay{position:fixed;inset:0;z-index:2000;background:rgba(20,20,40,.45);display:flex;align-items:center;justify-content:center}
+		.ja-overlay-card{background:var(--card-bg);padding:18px 22px;border-radius:10px;font-size:14px;color:var(--text-color);box-shadow:0 12px 40px -12px rgba(0,0,0,.4)}
+		.ja-overlay .ja-spin{border-color:rgba(74,71,229,.3);border-top-color:var(--primary,#4a47e5)}
+		@media(max-width:760px){.ja{flex-direction:column}.ja-brand{flex-basis:auto}.ja-panel{padding:24px 22px}.ja-row2{grid-template-columns:1fr}}
+		`;
+		$(`<style id="ja-styles">${css}</style>`).appendTo(document.head);
+	}
+};

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.json
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.json
@@ -1,0 +1,10 @@
+{
+ "doctype": "Page",
+ "name": "jarvis-account",
+ "page_name": "jarvis-account",
+ "title": "My Jarvis Account",
+ "module": "Jarvis",
+ "standard": "Yes",
+ "system_page": 0,
+ "roles": [{ "role": "System Manager" }]
+}

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -341,7 +341,37 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 
 	// ---- boot --------------------------------------------------------------
 	footLink();
-	render();
+	bootRender();
+
+	function bootRender() {
+		// Returning customers who already finished signup get the completion
+		// card instead of the create-account form. On RPC failure (e.g. site
+		// just spun up, scheduler not running), fall back to the wizard so
+		// the page is never stuck.
+		frappe.call({ method: "jarvis.account.is_onboarded" })
+			.then((r) => {
+				if (r && r.message && r.message.onboarded) renderCompletionCard();
+				else render();
+			})
+			.catch(() => render());
+	}
+
+	function renderCompletionCard() {
+		$steps.empty();
+		$footLink.empty();
+		$body.html(`
+			<div class="jo-success">
+				<div class="jo-success-ring">✓</div>
+				<h2 class="jo-h">You're all set up</h2>
+				<p class="jo-sub">Your Jarvis account is connected. Manage your plan, billing, and LLM credentials from My Account.</p>
+				<div class="jo-actions">
+					<button class="jo-btn jo-btn-primary" id="jo-go-account">Go to My Account →</button>
+				</div>
+			</div>`);
+		$body.find("#jo-go-account").on("click", () => {
+			window.location.assign("/app/jarvis-account");
+		});
+	}
 
 	function injectStyles() {
 		if (document.getElementById("jo-styles")) return;

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -1,0 +1,98 @@
+"""Tests for jarvis.account wrappers and admin_client shims for the
+/jarvis-account page. admin_client is mocked — these are unit tests of
+the customer-side glue, not of the admin endpoints themselves."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import account, admin_client
+from jarvis.exceptions import AdminValidationError
+
+
+_SNAPSHOTTED_FIELDS = (
+	"jarvis_admin_url", "jarvis_admin_api_key", "jarvis_admin_api_secret",
+	"agent_url", "agent_token",
+)
+
+
+def _snapshot_settings() -> dict:
+	s = frappe.get_single("Jarvis Settings")
+	snap = {}
+	for f in _SNAPSHOTTED_FIELDS:
+		v = (s.get_password(f, raise_exception=False)
+			 if f.endswith(("_key", "_secret", "_token")) else s.get(f))
+		snap[f] = v or ""
+	return snap
+
+
+def _restore_settings(snap: dict) -> None:
+	s = frappe.get_single("Jarvis Settings")
+	for f, v in snap.items():
+		s.db_set(f, v)
+	frappe.db.commit()
+
+
+class TestIsOnboarded(FrappeTestCase):
+	def setUp(self):
+		self._snap = _snapshot_settings()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+
+	def test_true_when_admin_key_set(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_api_key", "ak-abc")
+		s.db_set("jarvis_admin_api_secret", "as-abc")
+		frappe.db.commit()
+		self.assertEqual(account.is_onboarded(), {"onboarded": True})
+
+	def test_false_when_admin_key_blank(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_api_key", "")
+		s.db_set("jarvis_admin_api_secret", "")
+		frappe.db.commit()
+		self.assertEqual(account.is_onboarded(), {"onboarded": False})
+
+
+class TestAccountWrappers(FrappeTestCase):
+	def test_get_account_returns_admin_payload(self):
+		fake = {"subscription_status": "Active", "plan": {"name": "p1"},
+				"days_remaining": 12, "upgrade_plans": []}
+		with patch.object(admin_client, "get_account_summary", return_value=fake) as m:
+			out = account.get_account()
+		m.assert_called_once_with()
+		self.assertEqual(out, fake)
+
+	def test_preview_upgrade_passes_target_plan_through(self):
+		fake = {"prorated_inr": 500, "diff_per_day": 50.0,
+				"days_remaining": 10, "total_period_days": 30}
+		with patch.object(admin_client, "preview_upgrade", return_value=fake) as m:
+			out = account.preview_upgrade("plan-pro")
+		m.assert_called_once_with("plan-pro")
+		self.assertEqual(out, fake)
+
+	def test_start_upgrade_passes_target_plan_through(self):
+		fake = {"razorpay_order_id": "order_X", "razorpay_key_id": "k",
+				"amount_inr": 500, "target_plan": "plan-pro"}
+		with patch.object(admin_client, "start_upgrade", return_value=fake) as m:
+			out = account.start_upgrade("plan-pro")
+		m.assert_called_once_with("plan-pro")
+		self.assertEqual(out, fake)
+
+	def test_get_account_surfaces_admin_validation_error_as_frappe_throw(self):
+		"""_surface() converts AdminValidationError to frappe.throw so the
+		page sees Frappe's standard red toast text instead of a traceback."""
+		with patch.object(admin_client, "get_account_summary",
+						  side_effect=AdminValidationError("plan disabled")):
+			with self.assertRaises(frappe.ValidationError) as cm:
+				account.get_account()
+		self.assertIn("plan disabled", str(cm.exception))
+
+	def test_preview_upgrade_surfaces_validation_error(self):
+		with patch.object(admin_client, "preview_upgrade",
+						  side_effect=AdminValidationError("downgrade not supported")):
+			with self.assertRaises(frappe.ValidationError) as cm:
+				account.preview_upgrade("plan-cheap")
+		self.assertIn("downgrade not supported", str(cm.exception))


### PR DESCRIPTION
New post-onboarding home for returning customers. Three sections:

  - Plan & Validity      — name, price, status pill, days remaining
  - LLM Credentials      — provider/model/key/base (Save → save_llm_creds)
  - Billing Actions      — Upgrade (prorated picker) / Renew / Reactivate

CTAs adapt to subscription state. LLM section is read-only when the plan is lapsed (Past Due / Expired / Pending Payment); editable in Active / Cancelled. Upgrade picker fetches per-plan prorated amounts in parallel via preview_upgrade; pay routes through start_upgrade -> Razorpay Checkout -> finish_payment with a polling self-heal fallback on confirm failure (idempotent on payment_id, webhook backstops the rest).

The onboarding wizard now checks is_onboarded on boot — returning customers see a "you're all set up" card with a button to this page instead of the create-account form. Not-onboarded customers hitting /jarvis-account get bounced to /jarvis-onboarding client-side.