### PR TITLE
feat(dev): reset_onboarding endpoint + Jarvis Settings form action

### DIFF
--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -1,0 +1,98 @@
+"""Dev-only helpers for the customer bench.
+
+Gated by ``frappe.conf.developer_mode`` + the System Manager role. Used by
+the Jarvis Settings form to wipe local state so the operator can run the
+onboarding wizard fresh without manual DB surgery.
+
+Companion to ``jarvis_admin.api.dev.purge_customer`` on the admin side —
+the admin button wipes admin-side records; this clears the customer bench.
+"""
+
+import frappe
+from frappe.utils.password import remove_encrypted_password
+
+
+SETTINGS = "Jarvis Settings"
+
+# Password fieldtype stores the real value in __Auth, not the doctype row.
+# db_set("") only blanks the row's masked placeholder; __Auth retains the
+# prior secret, so get_password() keeps returning it. We explicitly drop
+# the __Auth row for these fields.
+_PASSWORD_FIELDS = {
+	"jarvis_admin_api_key", "jarvis_admin_api_secret",
+	"agent_token",
+	"chat_device_private_key", "chat_device_token",
+	"llm_api_key",
+}
+
+
+def _dev_guard():
+	"""Reject unless developer_mode is enabled AND the caller is a System
+	Manager. Sets HTTP 403 + throws so the form action surfaces the standard
+	red dialog."""
+	if not frappe.conf.get("developer_mode"):
+		frappe.local.response.http_status_code = 403
+		frappe.throw("developer_mode is not enabled in site_config")
+	if "System Manager" not in frappe.get_roles():
+		frappe.local.response.http_status_code = 403
+		frappe.throw("System Manager role required")
+
+
+@frappe.whitelist()
+def is_dev_mode_active() -> dict:
+	"""Cheap probe so the Jarvis Settings form JS can decide whether to
+	surface the reset button. Returns ``{active: True}`` iff both gates
+	(developer_mode + System Manager) pass for the current user."""
+	try:
+		_dev_guard()
+		return {"ok": True, "data": {"active": True}}
+	except frappe.ValidationError:
+		frappe.local.response.http_status_code = 200
+		return {"ok": True, "data": {"active": False}}
+
+
+# Fields cleared by reset_onboarding(). Grouped here so tests can iterate
+# without re-listing field names.
+_RESET_CLEAR_FIELDS = (
+	# Admin connection
+	"jarvis_admin_api_key", "jarvis_admin_api_secret",
+	# Agent / container
+	"agent_url", "agent_token",
+	"agent_llm_key_path", "agent_config_path", "agent_compose_dir",
+	# Chat device pairing
+	"chat_device_id", "chat_device_public_key",
+	"chat_device_private_key", "chat_device_token",
+	# Last sync trace
+	"last_sync_at", "last_sync_status",
+	# LLM credentials (caller asked for a clean slate)
+	"llm_model", "llm_api_key", "llm_base_url",
+)
+
+
+@frappe.whitelist()
+def reset_onboarding() -> dict:
+	"""Wipe local Jarvis Settings connection + LLM credentials so the
+	customer bench can run the onboarding wizard from step 1 again.
+
+	Preserved (these are settings, not onboarded session state):
+	  - jarvis_admin_url        (so the bench remembers which admin to point at)
+	  - enabled, token_budget_monthly
+	  - sampling: llm_temperature, llm_max_output_tokens
+	  - llm_provider (reset to the doctype default "Anthropic" so the form
+	    stays valid — it's a Select field, can't be blank)
+
+	Does NOT call the admin-side purge — use
+	``jarvis_admin.api.dev.purge_customer`` on admin for that. Both buttons
+	together give a clean two-step reset; this one alone is enough when the
+	admin record was already removed or never created.
+	"""
+	_dev_guard()
+	s = frappe.get_single(SETTINGS)
+	for field in _RESET_CLEAR_FIELDS:
+		s.db_set(field, "")
+		if field in _PASSWORD_FIELDS:
+			remove_encrypted_password(SETTINGS, SETTINGS, field)
+	# Select field — must hold a valid option; reset to default.
+	s.db_set("llm_provider", "Anthropic")
+	frappe.db.commit()
+	return {"ok": True, "data": {"cleared_fields": list(_RESET_CLEAR_FIELDS) + ["llm_provider"]}}

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -48,6 +48,15 @@ frappe.ui.form.on("Jarvis Settings", {
 			});
 		}, __("Diagnostics"));
 
+		// DEV-only reset: visible when developer_mode is on AND caller is
+		// System Manager. The server re-checks both gates.
+		frappe.call({ method: "jarvis.dev.is_dev_mode_active" }).then((r) => {
+			if (!(r && r.message && r.message.data && r.message.data.active)) return;
+			frm.add_custom_button(__("Reset onboarding (DEV)"), () => {
+				confirmAndReset(frm);
+			}, __("Diagnostics"));
+		});
+
 		frm.add_custom_button(__("Force Resync"), () => {
 			const d = new frappe.ui.Dialog({
 				title: __("Force Resync"),
@@ -84,3 +93,46 @@ frappe.ui.form.on("Jarvis Settings", {
 		}, __("Diagnostics"));
 	},
 });
+
+function confirmAndReset(frm) {
+	const d = new frappe.ui.Dialog({
+		title: __("Reset onboarding (irreversible)"),
+		fields: [
+			{ fieldtype: "HTML", fieldname: "warn",
+			  options: `<p>This clears local connection + LLM credentials so the onboarding
+				wizard restarts from step 1:</p>
+				<ul>
+				  <li>Admin API key &amp; secret</li>
+				  <li>Agent URL, token, container paths</li>
+				  <li>Chat device pairing (keys + token)</li>
+				  <li>LLM model / API key / base URL (provider resets to Anthropic)</li>
+				  <li>Last sync timestamp + status</li>
+				</ul>
+				<p>Preserved: Admin URL, monthly budget, sampling settings.</p>
+				<p>Does NOT touch admin-side records — use the admin's
+				<i>Purge customer (DEV)</i> button for that.</p>
+				<p>Type <b>RESET</b> to confirm:</p>` },
+			{ fieldtype: "Data", fieldname: "confirm", label: __("Confirm"), reqd: 1 },
+		],
+		primary_action_label: __("Reset"),
+		primary_action(values) {
+			if ((values.confirm || "").trim() !== "RESET") {
+				frappe.msgprint({ message: __("Type RESET exactly to confirm."), indicator: "red" });
+				return;
+			}
+			d.disable_primary_action();
+			frappe.call({ method: "jarvis.dev.reset_onboarding" }).then((r) => {
+				d.hide();
+				const n = ((r && r.message && r.message.data && r.message.data.cleared_fields) || []).length;
+				frappe.show_alert({
+					message: __("Onboarding reset — cleared {0} field(s). Go to /app/jarvis-onboarding to start fresh.", [n]),
+					indicator: "green",
+				});
+				frm.reload_doc();
+			}).catch(() => {
+				d.enable_primary_action();
+			});
+		},
+	});
+	d.show();
+}

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -1,0 +1,136 @@
+"""Tests for jarvis.dev — the customer-side reset_onboarding endpoint."""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.dev import is_dev_mode_active, reset_onboarding, _RESET_CLEAR_FIELDS
+
+
+SETTINGS = "Jarvis Settings"
+
+
+_PASSWORD_FIELDS = {
+	"jarvis_admin_api_key", "jarvis_admin_api_secret", "agent_token",
+	"chat_device_private_key", "chat_device_token", "llm_api_key",
+}
+
+
+def _read(s, field):
+	"""Read a Jarvis Settings field, password-safe."""
+	if field in _PASSWORD_FIELDS:
+		return (s.get_password(field, raise_exception=False) or "")
+	return (s.get(field) or "")
+
+
+def _snapshot():
+	"""Snapshot every reset-affected field so tests run against a real site
+	(not test_site) don't trash the operator's actual onboarded state."""
+	s = frappe.get_single(SETTINGS)
+	snap = {f: _read(s, f) for f in (*_RESET_CLEAR_FIELDS, "llm_provider")}
+	return snap
+
+
+def _restore(snap):
+	s = frappe.get_single(SETTINGS)
+	for f, v in snap.items():
+		s.db_set(f, v)
+	frappe.db.commit()
+
+
+def _seed_onboarded_state():
+	"""Plant non-empty values in every field reset_onboarding will clear."""
+	s = frappe.get_single(SETTINGS)
+	for f in _RESET_CLEAR_FIELDS:
+		s.db_set(f, f"seed-{f}")
+	s.db_set("llm_provider", "OpenAI")
+	frappe.db.commit()
+
+
+class _GuardSwap:
+	"""Force developer_mode on for the duration of a test."""
+	def __enter__(self):
+		self._prior = frappe.conf.get("developer_mode") or 0
+		frappe.conf.developer_mode = 1
+		return self
+
+	def __exit__(self, *exc):
+		frappe.conf.developer_mode = self._prior
+
+
+class TestResetOnboarding(FrappeTestCase):
+	def setUp(self):
+		self._snap = _snapshot()
+		_seed_onboarded_state()
+
+	def tearDown(self):
+		_restore(self._snap)
+
+	def test_clears_all_targeted_fields(self):
+		with _GuardSwap():
+			out = reset_onboarding()
+		self.assertTrue(out["ok"])
+		s = frappe.get_single(SETTINGS)
+		for f in _RESET_CLEAR_FIELDS:
+			self.assertEqual(_read(s, f), "", f"{f} should be blank after reset")
+		# llm_provider resets to default rather than going blank (Select).
+		self.assertEqual(s.llm_provider, "Anthropic")
+
+	def test_preserves_unrelated_settings(self):
+		s = frappe.get_single(SETTINGS)
+		s.db_set("jarvis_admin_url", "https://admin.example.com")
+		s.db_set("token_budget_monthly", 50000)
+		s.db_set("llm_temperature", 0.4)
+		frappe.db.commit()
+		with _GuardSwap():
+			reset_onboarding()
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.jarvis_admin_url, "https://admin.example.com")
+		self.assertEqual(int(s.token_budget_monthly), 50000)
+		self.assertAlmostEqual(float(s.llm_temperature), 0.4)
+
+
+class TestResetOnboardingGuards(FrappeTestCase):
+	def setUp(self):
+		self._snap = _snapshot()
+		self._prior_dev_mode = frappe.conf.get("developer_mode") or 0
+
+	def tearDown(self):
+		frappe.conf.developer_mode = self._prior_dev_mode
+		_restore(self._snap)
+
+	def test_rejects_when_developer_mode_off(self):
+		frappe.conf.developer_mode = 0
+		with self.assertRaises(frappe.ValidationError) as cm:
+			reset_onboarding()
+		self.assertEqual(frappe.local.response.http_status_code, 403)
+		self.assertIn("developer_mode", str(cm.exception))
+
+	def test_rejects_when_non_system_manager(self):
+		frappe.conf.developer_mode = 1
+		# Use a Guest who lacks System Manager role.
+		frappe.set_user("Guest")
+		self.addCleanup(frappe.set_user, "Administrator")
+		with self.assertRaises(frappe.ValidationError) as cm:
+			reset_onboarding()
+		self.assertEqual(frappe.local.response.http_status_code, 403)
+		self.assertIn("System Manager", str(cm.exception))
+
+
+class TestIsDevModeActive(FrappeTestCase):
+	def setUp(self):
+		self._prior = frappe.conf.get("developer_mode") or 0
+
+	def tearDown(self):
+		frappe.conf.developer_mode = self._prior
+
+	def test_true_when_developer_mode_on(self):
+		frappe.conf.developer_mode = 1
+		out = is_dev_mode_active()
+		self.assertEqual(out["data"]["active"], True)
+		self.assertEqual(frappe.local.response.http_status_code, 200)
+
+	def test_false_when_developer_mode_off(self):
+		frappe.conf.developer_mode = 0
+		out = is_dev_mode_active()
+		self.assertEqual(out["data"]["active"], False)
+		self.assertEqual(frappe.local.response.http_status_code, 200)


### PR DESCRIPTION
Companion to the admin-side purge_customer button. Clears the customer bench's Jarvis Settings connection + LLM credentials so the onboarding wizard restarts from step 1.

Wiped:
  - Admin api_key / api_secret
  - Agent URL, token, container paths
  - Chat device pairing (id, public/private key, token)
  - LLM model, api_key, base_url (provider resets to default)
  - last_sync_at / last_sync_status

Preserved: jarvis_admin_url, monthly budget, sampling settings.

Password fields clear via remove_encrypted_password to drop the __Auth row; db_set('') alone only blanks the masked placeholder, so get_password would otherwise keep returning the prior secret.

Double-gated (developer_mode + System Manager); button visible only when both pass via the is_dev_mode_active probe. Typed 'RESET' confirmation in the dialog before fire.