### PR TITLE
refactor: move DEFAULT_ADMIN_URL to hooks.py

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -18,8 +18,11 @@ from jarvis.exceptions import AdminAuthError, AdminUnreachableError, AdminValida
 # 90s leaves 30s buffer for network round-trip + handler overhead.
 DEFAULT_TIMEOUT_S = 90
 
-# Hardcoded prod admin URL; override via Jarvis Settings.jarvis_admin_url (dev/staging).
-DEFAULT_ADMIN_URL = "https://admin.jarvis.aerele.in"
+# DEFAULT_ADMIN_URL lives in hooks.py as a single source of truth for
+# deployment-level constants; re-exported here so existing
+# ``from jarvis.admin_client import DEFAULT_ADMIN_URL`` callers keep working.
+# Override per-customer via ``Jarvis Settings.jarvis_admin_url``.
+from jarvis.hooks import DEFAULT_ADMIN_URL  # noqa: E402, F401
 
 
 def _admin_url(settings) -> str:

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -5,6 +5,18 @@ app_description = "AI superpowers for Frappe/ERPNext"
 app_email = "navin@aerele.in"
 app_license = "MIT"
 
+# ---------------------------------------------------------------------------
+# Deployment constants
+# ---------------------------------------------------------------------------
+# Default URL of the Jarvis Cloud control plane the customer bench targets
+# for signup, billing, plan list, container connection, and account summary.
+# A per-customer override at ``Jarvis Settings.jarvis_admin_url`` wins; this
+# is the bench-wide fallback for fresh installs.
+#
+# Rebranding the deployment? Change this string + ship a new release.
+# (Re-exported by ``jarvis.admin_client`` so existing imports keep working.)
+DEFAULT_ADMIN_URL = "https://admin.jarvis.aerele.in"
+
 # Apps
 # ------------------
 


### PR DESCRIPTION
Single source of truth for deployment-level constants. admin_client.py re-exports it so the existing
``from jarvis.admin_client import DEFAULT_ADMIN_URL`` import path (used by tests) keeps working — no caller change required. Same hardcoded value; rebranding the deployment is now a one-line edit in hooks.py instead of being buried in a transport module.