### PR TITLE
refactor(local-dev): drop dead llm_oauth_access_token references

### DIFF
--- a/jarvis/openclaw_config.py
+++ b/jarvis/openclaw_config.py
@@ -77,14 +77,13 @@ def render_config(settings, gateway_token: str) -> str:
 	customer_base_url = (getattr(settings, "llm_base_url", None) or "").strip() or None
 	auth_mode = getattr(settings, "llm_auth_mode", None) or "api_key"
 
-	# Subscription mode with no access token yet → fall through to stub so the
-	# container still boots; the cron / wizard will populate the token shortly.
-	if auth_mode == "subscription":
-		access_token = getattr(settings, "llm_oauth_access_token", None)
-		if not access_token:
-			provider_label = None
-			auth_mode = "api_key"  # stub uses api_key shape
-
+	# Local-dev (this code path) only supports api-key mode end-to-end. The
+	# subscription / oauth modes ship credentials via the admin → fleet-agent
+	# → auth-profiles.json path (REV-1), which isn't wired up in single-bench
+	# dev. We still render whatever auth_mode the customer set so the openclaw
+	# config matches expectations; the rendered container just won't have
+	# usable credentials for oauth mode without manual auth-profiles.json
+	# seeding.
 	if not provider_label or not model:
 		provider_id = STUB_DEFAULTS["provider_id"]
 		model = STUB_DEFAULTS["model"]

--- a/jarvis/openclaw_push.py
+++ b/jarvis/openclaw_push.py
@@ -21,14 +21,12 @@ HEALTHCHECK_INTERVAL_SECONDS = 1
 
 
 def _resolve_llm_secret(settings) -> str:
-	"""Return the bytes to write into /secrets/llm.key based on auth mode.
+	"""Return the bytes to write into /secrets/llm.key.
 
-	Subscription mode: the short-lived access token (refreshed by the cron).
-	API-key mode: the long-lived API key.
+	REV-1: only api_key mode writes a secret here. Subscription / oauth mode
+	credentials live in the container's auth-profiles.json (pushed via the
+	admin → fleet-agent path, not through this local-dev push code).
 	"""
-	mode = getattr(settings, "llm_auth_mode", None) or "api_key"
-	if mode == "subscription":
-		return settings.get_password("llm_oauth_access_token", raise_exception=False) or ""
 	return settings.get_password("llm_api_key", raise_exception=False) or ""
 
 

--- a/jarvis/tests/test_openclaw_config.py
+++ b/jarvis/tests/test_openclaw_config.py
@@ -14,7 +14,6 @@ class _FakeSettings:
         self.llm_model = kwargs.get("llm_model")
         self.llm_base_url = kwargs.get("llm_base_url")
         self.llm_auth_mode = kwargs.get("llm_auth_mode", "api_key")
-        self.llm_oauth_access_token = kwargs.get("llm_oauth_access_token")
 
 
 class TestProviderMap(FrappeTestCase):
@@ -233,25 +232,14 @@ class TestRenderConfigSubscription(FrappeTestCase):
         provider_block = out["models"]["providers"]["openai"]
         self.assertEqual(provider_block.get("authMode"), "api_key")
 
-    def test_subscription_mode_emits_subscription_auth(self):
+    def test_legacy_subscription_mode_emits_subscription_auth(self):
+        """Legacy `subscription` auth_mode passes through to the rendered config.
+        REV-1 production tenants use `oauth` instead; this verifies migrated
+        legacy values still render a valid config in the local-dev path."""
         out = self._render(
             llm_provider="OpenAI",
             llm_model="gpt-4o-mini",
             llm_auth_mode="subscription",
-            llm_oauth_access_token="AT-1",
         )
         provider_block = out["models"]["providers"]["openai"]
         self.assertEqual(provider_block.get("authMode"), "subscription")
-
-    def test_subscription_mode_empty_token_falls_back_to_stub(self):
-        out = self._render(
-            llm_provider="OpenAI",
-            llm_model="gpt-4o-mini",
-            llm_auth_mode="subscription",
-            llm_oauth_access_token=None,
-        )
-        # Falls back to STUB_DEFAULTS — moonshot per current stub
-        stub_id = STUB_DEFAULTS["provider_id"]
-        self.assertIn(stub_id, out["models"]["providers"])
-        # And the rendered mode reverts to api_key since the stub has no subscription
-        self.assertEqual(out["models"]["providers"][stub_id].get("authMode"), "api_key")

--- a/jarvis/tests/test_openclaw_push.py
+++ b/jarvis/tests/test_openclaw_push.py
@@ -218,7 +218,6 @@ class TestResolveLlmSecret(FrappeTestCase):
 		defaults = {
 			"llm_auth_mode": "api_key",
 			"_llm_api_key": None,
-			"_llm_oauth_access_token": None,
 		}
 		defaults.update(kw)
 		s = SimpleNamespace(**defaults)
@@ -232,14 +231,18 @@ class TestResolveLlmSecret(FrappeTestCase):
 		s = self._settings(llm_auth_mode="api_key", _llm_api_key="sk-xyz")
 		self.assertEqual(_resolve_llm_secret(s), "sk-xyz")
 
-	def test_subscription_mode_returns_access_token(self):
+	def test_oauth_mode_returns_empty_string(self):
+		"""REV-1: subscription / oauth modes don't push a secret through llm.key.
+		Credentials live in auth-profiles.json on the container."""
 		from jarvis.openclaw_push import _resolve_llm_secret
-		s = self._settings(llm_auth_mode="subscription", _llm_oauth_access_token="AT-1")
-		self.assertEqual(_resolve_llm_secret(s), "AT-1")
+		s = self._settings(llm_auth_mode="oauth", _llm_api_key=None)
+		self.assertEqual(_resolve_llm_secret(s), "")
 
-	def test_subscription_mode_empty_token_returns_empty(self):
+	def test_legacy_subscription_mode_returns_empty_string(self):
+		"""Legacy 'subscription' value (pre-REV-1 migrated tenants) also drops
+		any secret push — same as 'oauth'."""
 		from jarvis.openclaw_push import _resolve_llm_secret
-		s = self._settings(llm_auth_mode="subscription")
+		s = self._settings(llm_auth_mode="subscription", _llm_api_key=None)
 		self.assertEqual(_resolve_llm_secret(s), "")
 
 	def test_default_mode_treats_as_api_key(self):


### PR DESCRIPTION
The local-dev openclaw_bootstrap path had two functions that still read the now-deleted llm_oauth_access_token field on Jarvis Settings:

- openclaw_config.py render_config() had a "subscription with no access token → fall back to stub" branch using getattr() — always None now, so the branch was dead.
- openclaw_push.py _resolve_llm_secret() returned the access token via get_password() for subscription mode — always empty now.

REV-1 subscription credentials live on the container in auth-profiles.json (pushed via admin → fleet-agent), not in llm.key. The local-dev push path doesn't (and shouldn't) try to push OAuth blobs from the bench. Simplify both functions to api_key-only for the local push path; add comments explaining the boundary.

Tests updated to assert the new shape (oauth/subscription mode returns empty string from _resolve_llm_secret; legacy subscription value still renders authMode=subscription in the openclaw config).