### PR TITLE
feat(oauth): surface account email + connected_at on Jarvis Settings

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -21,6 +21,8 @@
     "llm_max_output_tokens",
     "llm_auth_section",
     "llm_auth_mode",
+    "llm_oauth_account_email",
+    "llm_oauth_connected_at",
     "system_tab",
     "admin_connection_section",
     "jarvis_admin_url",
@@ -126,6 +128,21 @@
       "options": "api_key\nsubscription\noauth",
       "default": "api_key",
       "reqd": 1
+    },
+    {
+      "fieldname": "llm_oauth_account_email",
+      "fieldtype": "Data",
+      "label": "Connected Account",
+      "read_only": 1,
+      "depends_on": "eval:doc.llm_auth_mode == 'oauth'",
+      "description": "Email of the provider account whose subscription Jarvis is using. Populated on chat-subscription sign-in; cleared on Disconnect."
+    },
+    {
+      "fieldname": "llm_oauth_connected_at",
+      "fieldtype": "Datetime",
+      "label": "Connected At",
+      "read_only": 1,
+      "depends_on": "eval:doc.llm_auth_mode == 'oauth'"
     },
     {
       "fieldname": "system_tab",

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -188,11 +188,17 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		if (isActiveMode) {
 			const provider = settingsLocal.llm_provider || "—";
 			const model = settingsLocal.llm_model || "—";
+			const email = settingsLocal.llm_oauth_account_email || "—";
+			const connectedAt = settingsLocal.llm_oauth_connected_at
+				? frappe.datetime.comment_when(settingsLocal.llm_oauth_connected_at)
+				: "—";
 			return `
 				<p class="ja-sub">Refresh and account state live inside your Jarvis container. If chat starts failing, click Re-authorize to mint fresh tokens.</p>
 				<table class="ja-kv">
+					<tr><td>Account</td><td>${esc(email)}</td></tr>
 					<tr><td>Provider</td><td>${esc(provider)}</td></tr>
 					<tr><td>Model</td><td>${esc(model)}</td></tr>
+					<tr><td>Connected</td><td>${esc(connectedAt)}</td></tr>
 				</table>
 				<div class="ja-actions">
 					<button class="ja-btn ja-btn-ghost" id="ja-sub-disconnect">Disconnect</button>

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -149,6 +149,16 @@ def commit_signin(nonce: str) -> dict:
 		base_url="",
 		auth_mode="oauth",
 	)
+	# Surface display-only metadata so /jarvis-account and the Desk form
+	# can answer "which account am I connected to and since when?". These
+	# fields are readonly + depends_on auth_mode == "oauth".
+	settings = frappe.get_single("Jarvis Settings")
+	settings.db_set("llm_oauth_account_email",
+	                entry.get("account_email") or blob.get("email") or "",
+	                update_modified=False)
+	settings.db_set("llm_oauth_connected_at",
+	                frappe.utils.now_datetime(),
+	                update_modified=False)
 	frappe.cache.hdel(_CACHE_KEY, nonce)
 	return _ok({})
 
@@ -165,6 +175,8 @@ def disconnect() -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	settings.db_set("llm_auth_mode", "api_key", update_modified=False)
 	settings.db_set("last_sync_status", "disconnected", update_modified=False)
+	settings.db_set("llm_oauth_account_email", "", update_modified=False)
+	settings.db_set("llm_oauth_connected_at", None, update_modified=False)
 	frappe.cache.delete_key(_CACHE_KEY)
 	return _ok({})
 

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -20,6 +20,8 @@ class _OAuthApiBase(FrappeTestCase):
 		cls._snap = {
 			"llm_auth_mode": settings.llm_auth_mode,
 			"llm_provider": settings.llm_provider,
+			"llm_oauth_account_email": settings.llm_oauth_account_email,
+			"llm_oauth_connected_at": settings.llm_oauth_connected_at,
 		}
 
 	@classmethod
@@ -221,6 +223,10 @@ class TestCommitSignin(_OAuthApiBase):
 		self.assertEqual(kwargs["api_key"], "")
 		# nonce cleared
 		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))
+		# display-only metadata populated on Jarvis Settings
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.llm_oauth_account_email, "manager@acme.com")
+		self.assertIsNotNone(settings.llm_oauth_connected_at)
 
 	def test_unknown_nonce(self):
 		out = oauth_api.commit_signin(nonce="missing")
@@ -250,6 +256,8 @@ class TestDisconnect(_OAuthApiBase):
 		                   "blob": None, "account_email": None})
 		settings = frappe.get_single("Jarvis Settings")
 		settings.db_set("llm_auth_mode", "oauth", update_modified=False)
+		settings.db_set("llm_oauth_account_email", "manager@acme.com", update_modified=False)
+		settings.db_set("llm_oauth_connected_at", frappe.utils.now_datetime(), update_modified=False)
 		frappe.db.commit()
 
 		out = oauth_api.disconnect()
@@ -258,6 +266,9 @@ class TestDisconnect(_OAuthApiBase):
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertEqual(settings.llm_auth_mode, "api_key")
 		self.assertEqual(settings.last_sync_status, "disconnected")
+		# Display-only oauth metadata also cleared
+		self.assertFalse(settings.llm_oauth_account_email)
+		self.assertIsNone(settings.llm_oauth_connected_at)
 		# In-flight nonce cleared
 		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, "stale_nonce"))
 


### PR DESCRIPTION
Adds two display-only fields populated during commit_signin and cleared on disconnect:
- llm_oauth_account_email — captured from the helper-script blob
- llm_oauth_connected_at  — server timestamp at commit_signin

Surfaced in /jarvis-account → Chat subscription tab when in oauth mode, and in the Jarvis Settings desk form (depends_on auth_mode). Both fields are read_only; the bench treats them as informational metadata only — refresh + token state still live exclusively in the container's auth-profiles.json.

Answers the two most common "did sign-in actually work" questions without surfacing any token material bench-side.