### PR TITLE
fix(oauth-ui): codex-compatible subscription model list for OpenAI

### DIFF
--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -54,8 +54,12 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 
 	// Subscription providers + models (chat-subscription OAuth path).
 	// REV-3: server holds the verifier; UI offers a model picker at start.
+	// Subscription-tier model IDs — these go through codex/gemini-cli's
+	// auth tunnel rather than the standard API, so the valid set is
+	// CLI-specific (not OpenAI/Google's public API model names).
+	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
 	const SUBSCRIPTION_MODELS = {
-		"OpenAI":        ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o1", "o1-mini"],
+		"OpenAI":        ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
 		"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
 	};
 

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -25,8 +25,12 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 
 	// Providers + models for chat-subscription. Mirrors
 	// jarvis.oauth.providers — keep in sync.
+	// Subscription-tier model IDs — these go through codex/gemini-cli's
+	// auth tunnel rather than the standard API, so the valid set is
+	// CLI-specific (not OpenAI/Google's public API model names).
+	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
 	const SUBSCRIPTION_MODELS = {
-		"OpenAI":        ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o1", "o1-mini"],
+		"OpenAI":        ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
 		"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
 	};
 

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -29,7 +29,10 @@ _CACHE_KEY = "jarvis.oauth.codex_signin"
 _NONCE_TTL_SECS = 600
 _HTTP_TIMEOUT = 30
 _REDIRECT_URI = "http://localhost:1455/auth/callback"
-_DEFAULT_MODEL = {"OpenAI": "gpt-4o", "Google Gemini": "gemini-2.0-pro"}
+# Defaults for subscription mode — these are codex/gemini-cli's CLI-specific
+# model IDs, not OpenAI/Google's standard API model names. Mirrors the
+# SUBSCRIPTION_MODELS dict in jarvis_onboarding.js / jarvis_account.js.
+_DEFAULT_MODEL = {"OpenAI": "gpt-5.5", "Google Gemini": "gemini-2.0-pro"}
 
 
 def _ok(data: dict) -> dict:


### PR DESCRIPTION
The previous OpenAI subscription dropdown ("gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o1", "o1-mini") used OpenAI's standard API model names. But codex's ChatGPT-account auth tunnel doesn't accept those — it returns:

  The 'gpt-4o' model is not supported when using Codex with a
  ChatGPT account.

Codex's CLI uses a different namespace: codex-internal model IDs like "gpt-5.5", "gpt-5.4", "gpt-5.4-mini". Verified against a real ChatGPT-prolite account 2026-06-02 — these three return successful chat completions through codex's responses-websocket endpoint.

Updates the dropdown options on /jarvis-onboarding step 4 + the same on /jarvis-account → Chat subscription tab. Also bumps the bench-side _DEFAULT_MODEL fallback in oauth/api.py from "gpt-4o" → "gpt-5.5".

Gemini's list is unchanged for now — needs separate live verification against a Gemini Advanced account, since gemini-cli's auth tunnel likely has its own model-name namespace too.

(Fleet-agent fix that adds models.providers registration goes in a separate PR on the jarvis-fleet-agent repo.)