### PR TITLE
feat(chat): per-row delete (soft-delete via archive)

### DIFF
--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -113,6 +113,9 @@
 	cursor: pointer;
 	transition: background 0.12s;
 	margin-bottom: 2px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .jarvis-conv-item:hover {
@@ -127,6 +130,36 @@
 .jarvis-conv-main {
 	flex: 1;
 	min-width: 0;
+}
+
+/* Delete (trash) icon — hidden by default, revealed on row hover.
+   Active row's icon stays visible too, so deleting the current
+   conversation doesn't require hover-hunting. */
+.jarvis-conv-delete {
+	flex: 0 0 auto;
+	width: 24px;
+	height: 24px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	border: 0;
+	border-radius: 4px;
+	color: var(--text-muted);
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease;
+}
+
+.jarvis-conv-item:hover .jarvis-conv-delete,
+.jarvis-conv-item.active .jarvis-conv-delete,
+.jarvis-conv-delete:focus-visible {
+	opacity: 1;
+}
+
+.jarvis-conv-delete:hover {
+	background: var(--red-50, rgba(220, 38, 38, 0.08));
+	color: var(--red-600, #dc2626);
 }
 
 .jarvis-conv-title {

--- a/jarvis/public/js/jarvis_chat/sidebar.js
+++ b/jarvis/public/js/jarvis_chat/sidebar.js
@@ -3,10 +3,18 @@
 import * as api from "./api.js";
 import { state } from "./state.js";
 
-export async function refreshSidebar($sidebar, $empty, onSelect, _onArchive) {
-	// Note: archive action intentionally not surfaced per-row. Conversations
-	// are durable from the sidebar; archive is reserved for a future menu so
-	// rows can't be removed by an accidental icon click.
+// Trash-can SVG (same stroke style as other icons in the page).
+const TRASH_ICON = `
+	<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"
+	     stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+		<polyline points="3 6 5 6 21 6"></polyline>
+		<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path>
+		<path d="M10 11v6"></path>
+		<path d="M14 11v6"></path>
+		<path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"></path>
+	</svg>`;
+
+export async function refreshSidebar($sidebar, $empty, onSelect, onArchive) {
 	const rows = await api.listConversations();
 	state.conversations = rows;
 	$sidebar.empty();
@@ -32,12 +40,43 @@ export async function refreshSidebar($sidebar, $empty, onSelect, _onArchive) {
 						isEmpty ? ' <span class="jarvis-empty-tag">empty</span>' : ""
 					}</div>
 				</div>
+				<button type="button" class="jarvis-conv-delete"
+				        aria-label="Delete conversation" title="Delete">${TRASH_ICON}</button>
 			</div>
 		`);
 
 		if (c.name === state.current_conversation) $item.addClass("active");
 
 		$item.on("click", () => onSelect(c.name));
+
+		// Per-row delete (soft-delete via archive — sidebar's list query
+		// filters status='Active', so archived rows fall out of view).
+		// Delegates the API call + cleanup to onArchive (the controller in
+		// index.js) so this stays a pure UI affordance.
+		$item.find(".jarvis-conv-delete").on("click", async (e) => {
+			e.stopPropagation();   // don't trigger onSelect on the row
+			const ok = window.confirm(
+				`Delete "${title}"?\n\nThis can't be undone.`
+			);
+			if (!ok) return;
+			try {
+				if (typeof onArchive === "function") {
+					await onArchive(c.name);
+				} else {
+					// Fallback if no callback is wired (shouldn't happen).
+					await api.archiveConversation(c.name);
+				}
+				frappe.show_alert({
+					message: __("Deleted") + ` "${title}"`,
+					indicator: "orange",
+				});
+			} catch (err) {
+				frappe.show_alert({
+					message: __("Couldn't delete: ") + (err.message || err),
+					indicator: "red",
+				});
+			}
+		});
 
 		$sidebar.append($item);
 	});


### PR DESCRIPTION
Trash-can icon appears on row hover (and stays visible on the active row) in the conversation sidebar. Click → native confirm dialog → calls the existing archive endpoint → row falls out of the sidebar list (list_conversations filters status='Active').

Soft delete via archive rather than hard delete: preserves the underlying conversation + messages + openclaw session_key in case we ever add a "View archived" or undo affordance. Customer-facing behavior is identical to "delete" — the row is gone.

Sidebar delegates the API call to the existing onArchive callback (controller in index.js) so this stays a pure UI affordance. Stops the row's click propagation so clicking the trash doesn't also trigger the conversation-open handler.

No backend changes — reuses archive_conversation endpoint.