### PR TITLE
feat(chat): model picker on welcome screen + atomic first-turn override

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -136,8 +136,16 @@ from jarvis.chat.openclaw_client import OpenclawSession
 
 
 @frappe.whitelist()
-def send_message(conversation: str, message: str) -> dict:
+def send_message(
+	conversation: str, message: str, model_override: str | None = None,
+) -> dict:
 	"""Validate, persist the user message, ensure session_key, enqueue the worker.
+
+	`model_override` (optional): bare model id to apply to this conversation
+	BEFORE enqueueing the worker. Used from the welcome screen so the first
+	turn lands on the picker-chosen model without a race against the worker.
+	Validated against the same allowlist set_conversation_model uses.
+	Empty string / None leaves the existing override alone.
 
 	Returns {ok: True, run_id, message_id} on success or
 	{ok: False, reason: str} on validation failure. Raises
@@ -154,6 +162,18 @@ def send_message(conversation: str, message: str) -> dict:
 		return {"ok": False, "reason": _("message is empty")}
 
 	conv_doc = frappe.get_doc(CONV, conversation)  # respects perms
+
+	# Apply model override BEFORE enqueueing so the worker sees the new value
+	# when it loads the conversation. (If we set this after the enqueue, the
+	# worker may pick up the run before the DB write commits.)
+	if model_override:
+		settings = frappe.get_single("Jarvis Settings")
+		allowed = _SUBSCRIPTION_MODELS.get(settings.llm_provider, [])
+		if model_override not in allowed:
+			return {"ok": False, "reason":
+			        f"model {model_override!r} is not valid for "
+			        f"{settings.llm_provider!r}"}
+		conv_doc.model_override = model_override
 
 	# Persist the user message with next seq value
 	seq = _next_seq(conversation)

--- a/jarvis/public/js/jarvis_chat/api.js
+++ b/jarvis/public/js/jarvis_chat/api.js
@@ -31,10 +31,12 @@ export async function archiveConversation(name) {
 	});
 }
 
-export async function sendMessage(conversation, message) {
+export async function sendMessage(conversation, message, model_override) {
+	const args = { conversation, message };
+	if (model_override) args.model_override = model_override;
 	const r = await frappe.call({
 		method: "jarvis.chat.api.send_message",
-		args: { conversation, message },
+		args,
 	});
 	return r.message;
 }

--- a/jarvis/public/js/jarvis_chat/index.js
+++ b/jarvis/public/js/jarvis_chat/index.js
@@ -86,10 +86,13 @@ export function init(wrapper) {
 		$welcome.show();
 		page.set_title(__("Jarvis Chat"));
 		syncUrl(null);
-		// No conversation open → hide the model picker.
+		// Welcome screen still shows the picker (oauth mode) so the customer
+		// can choose a model for the next conversation. Keep
+		// current_model_override in state so the next send_message threads it.
 		state.current_conversation = null;
-		state.current_model_override = "";
 		refreshModelPickerVisibility?.();
+		// Reflect the current (possibly preserved) override in the dropdown.
+		$modelPicker?.val(state.current_model_override || "");
 	}
 
 	// Reflect the active conversation in the URL so refresh / share / back
@@ -126,10 +129,10 @@ export function init(wrapper) {
 	}
 
 	function refreshModelPickerVisibility() {
-		// Hidden in api_key mode (per spec § Out of scope).
-		// Hidden when there's no current conversation (welcome screen).
-		const show =
-			state.llm_auth_mode === "oauth" && !!state.current_conversation;
+		// Shown in oauth mode (api_key mode has no multi-model picker).
+		// Visible on the welcome screen too — the picked value gets applied
+		// to whichever conversation receives the first send_message.
+		const show = state.llm_auth_mode === "oauth";
 		$convToolbar.prop("hidden", !show);
 	}
 
@@ -140,9 +143,21 @@ export function init(wrapper) {
 	}
 
 	$modelPicker.on("change", async function () {
-		const conv = state.current_conversation;
-		if (!conv) return;
 		const newModel = this.value || null;
+		const conv = state.current_conversation;
+
+		// On the welcome screen (no conversation yet), just stash the choice
+		// in local state. It'll be applied to whichever conversation gets
+		// the first send_message via the model_override arg.
+		if (!conv) {
+			state.current_model_override = newModel || "";
+			frappe.show_alert({
+				message: __("Model for next chat: ") + (newModel || state.llm_model),
+				indicator: "blue",
+			});
+			return;
+		}
+
 		try {
 			const r = await api.setConversationModel(conv, newModel);
 			if (!r || !r.ok) {
@@ -325,7 +340,11 @@ export function init(wrapper) {
 			$input.val("");
 			autoGrowInput();
 
-			const result = await api.sendMessage(conv, text);
+			// Pass the picker's current value (if any) so the new
+			// conversation lands on it atomically — no race against the worker.
+			const result = await api.sendMessage(
+				conv, text, state.current_model_override || null,
+			);
 			if (!result.ok) {
 				frappe.show_alert({ message: result.reason, indicator: "red" });
 				return;

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -455,3 +455,74 @@ class TestSetConversationModel(_ChatTestCase):
 		out = set_conversation_model("missing-conv-id-xyz", "gpt-5.5")
 		self.assertFalse(out["ok"])
 		self.assertEqual(out["error"]["code"], "unknown_conversation")
+
+
+class TestSendMessageWithModelOverride(_ChatTestCase):
+	"""send_message accepts an optional model_override that gets applied
+	to the conversation BEFORE the worker is enqueued — so the first
+	turn lands on the picked model without a race against the worker."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		settings = frappe.get_single("Jarvis Settings")
+		cls._settings_snap = {
+			"llm_auth_mode": settings.llm_auth_mode,
+			"llm_provider": settings.llm_provider,
+			"llm_model": settings.llm_model,
+		}
+		settings.db_set("llm_auth_mode", "oauth", update_modified=False)
+		settings.db_set("llm_provider", "OpenAI", update_modified=False)
+		settings.db_set("llm_model", "gpt-5.5", update_modified=False)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		settings = frappe.get_single("Jarvis Settings")
+		for k, v in cls._settings_snap.items():
+			settings.db_set(k, v, update_modified=False)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		self.conv = create_conversation()
+
+	def test_valid_override_persists_before_enqueue(self):
+		"""When model_override is passed, conv.model_override is set
+		before frappe.enqueue is called (so the worker sees the right value)."""
+		from jarvis.chat.api import send_message
+		written = {}
+		def capture(*a, **kw):
+			# Snapshot the DB value at the moment enqueue is called
+			written["override"] = frappe.db.get_value(CONV, self.conv, "model_override")
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue", side_effect=capture):
+			result = send_message(self.conv, "hi", model_override="gpt-5.4-mini")
+		self.assertTrue(result["ok"])
+		self.assertEqual(written["override"], "gpt-5.4-mini")
+
+	def test_unknown_override_rejected(self):
+		"""Invalid model name yields ok:false with no DB write or enqueue."""
+		from jarvis.chat.api import send_message
+		with patch("frappe.enqueue") as enqueue:
+			result = send_message(self.conv, "hi", model_override="gpt-4o")
+		self.assertFalse(result["ok"])
+		self.assertIn("gpt-4o", result["reason"])
+		enqueue.assert_not_called()
+		# Conversation unchanged
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "model_override"))
+
+	def test_no_override_keeps_existing(self):
+		"""Calling send_message without model_override doesn't touch
+		conv.model_override (so per-conversation settings persist)."""
+		from jarvis.chat.api import send_message
+		# Pre-set an override
+		frappe.db.set_value(CONV, self.conv, "model_override", "gpt-5.4")
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue"):
+			send_message(self.conv, "hi")
+		self.assertEqual(
+			frappe.db.get_value(CONV, self.conv, "model_override"),
+			"gpt-5.4",
+		)


### PR DESCRIPTION
Previously the picker was hidden until a conversation was loaded — wrong UX. Customers want to pick the model BEFORE sending the first message so the first turn uses it. This change:

UI (oauth mode):
- Picker is visible on the welcome screen too.
- Selecting a model when no conversation exists stashes it in state.current_model_override locally (toast: "Model for next chat: <X>") — no API call yet because there's no conv to write to.
- On the first send, sendMessage passes state.current_model_override to the bench so the new conversation lands on it atomically.

Backend (chat/api.py):
- send_message accepts an optional model_override kwarg.
- If provided, validated against _SUBSCRIPTION_MODELS allowlist + set on conv_doc BEFORE the worker is enqueued.
- This avoids the race where the worker would otherwise read conv.model_override before the client's separate set_conversation_model call commits.

Tests: +3 in test_chat_api covering valid override persists before enqueue, unknown override rejected, no-override keeps existing. 35 chat_api tests green.