### PR TITLE
chore: drop em-dashes (project-wide style preference)

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -5,7 +5,7 @@ api_secret). Errors are normalized via the shared ``_surface`` helper from
 onboarding so admin ValidationErrors arrive as clean ``frappe.throw`` toasts.
 
 The page also reuses these existing onboarding endpoints directly under
-their published names — no duplicates:
+their published names - no duplicates:
 
   - jarvis.onboarding.save_llm_creds  (LLM section save)
   - jarvis.onboarding.renew           (renew / reactivate / resume CTAs)
@@ -23,7 +23,7 @@ def is_onboarded() -> dict:
 	"""True iff Jarvis Settings holds an admin api_key. The wizard's
 	completion-card branch and the account page's redirect guard share this.
 
-	Pool-pending customers (paid but no tenant yet) still count as onboarded —
+	Pool-pending customers (paid but no tenant yet) still count as onboarded -
 	they've completed signup; the agent_url just hasn't been wired up. The
 	account page handles that state via tenant_status: pending.
 	"""

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -37,7 +37,7 @@ def _admin_url(settings) -> str:
 def signup(email: str, company_name: str, plan: str, coupon: str | None = None) -> dict:
 	"""Guest signup against admin. Returns admin's data dict
 	{api_key, api_secret, razorpay_key_id, razorpay_order_id, amount_inr}.
-	Both annual and monthly are one-shot orders (manual renew — no Razorpay subscription)."""
+	Both annual and monthly are one-shot orders (manual renew - no Razorpay subscription)."""
 	settings = frappe.get_single("Jarvis Settings")
 	body = {"email": email, "company_name": company_name, "plan": plan,
 			"frappe_site_url": frappe.utils.get_url()}
@@ -146,7 +146,7 @@ def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 def post_subscription_disconnect() -> dict:
 	"""POST to admin to clear the customer's OAuth profile on the container.
 
-	Idempotent — a tenant in api_key mode is a no-op success.
+	Idempotent - a tenant in api_key mode is a no-op success.
 	"""
 	settings = frappe.get_single("Jarvis Settings")
 	return _post(
@@ -206,7 +206,7 @@ def _post(path: str, body: dict, admin_url: str,
 	"""Authenticated POST. Reads native api_key + api_secret from Jarvis
 	Settings. Raises AdminAuthError early if either is empty."""
 	settings = frappe.get_single("Jarvis Settings")
-	# Both are Password fields — attribute access would return the masked
+	# Both are Password fields - attribute access would return the masked
 	# "*****" placeholder Frappe stores in the row. get_password decrypts
 	# the real value out of __Auth.
 	api_key = (settings.get_password(

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -21,9 +21,9 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 	2. **Plugin auth** (``jarvis-openclaw-plugin`` Path A): two custom headers
 	   are presented together:
 
-	   - ``X-Jarvis-Token`` — the shared ``agent_token`` secret
+	   - ``X-Jarvis-Token`` - the shared ``agent_token`` secret
 	     (proves the request originated inside the openclaw container)
-	   - ``X-Jarvis-Session`` — the openclaw sessionKey for this conversation
+	   - ``X-Jarvis-Session`` - the openclaw sessionKey for this conversation
 
 	   The token is validated, then the user is resolved from
 	   ``Jarvis Chat Session`` (the row inserted at session-create time maps
@@ -34,7 +34,7 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 	``{ok: False, error: {code, message}}`` on tool-level error. Auth
 	failures are reported with the corresponding HTTP status code.
 	"""
-	# Plugin auth mode — detected by presence of X-Jarvis-Token header.
+	# Plugin auth mode - detected by presence of X-Jarvis-Token header.
 	if _get_header("X-Jarvis-Token"):
 		if not _validate_bearer():
 			frappe.local.response.http_status_code = 401
@@ -67,7 +67,7 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 
 		return _dispatch_from_session(plugin_user, session_key, tool, args)
 
-	# Standard Frappe auth path — Guest is rejected; everything else dispatches
+	# Standard Frappe auth path - Guest is rejected; everything else dispatches
 	# under the current Frappe session user.
 	if frappe.session.user == "Guest":
 		frappe.local.response.http_status_code = 401
@@ -196,7 +196,7 @@ def _parse_args(args: dict | str | None) -> dict:
 	# old MCP design used them as in-band identity carriers; Path A moved
 	# identity to HTTPS headers. If the LLM has been trained on the older
 	# convention it may emit these even though our tool schemas don't list
-	# them — dropping them silently keeps such calls dispatching cleanly.
+	# them - dropping them silently keeps such calls dispatching cleanly.
 	if isinstance(args, dict):
 		for legacy in ("_user", "_session", "_session_key"):
 			args.pop(legacy, None)

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -220,7 +220,7 @@ def get_chat_ui_settings() -> dict:
 	model picker (provider label, current default model, auth mode, and the
 	allowlist of subscription-mode models per provider).
 
-	Picker is shown only when auth_mode == "oauth" — api_key customers
+	Picker is shown only when auth_mode == "oauth" - api_key customers
 	register a single model at signup and there's no multi-model UI
 	for them yet (see spec § Out of scope).
 	"""
@@ -243,7 +243,7 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 	Jarvis Settings.llm_model).
 
 	Returns {"ok": True, "data": {"effective_model": <model>}} where
-	effective_model is what will be sent for the next turn — either
+	effective_model is what will be sent for the next turn - either
 	the override or the settings default.
 	"""
 	if not frappe.db.exists(CONV, conversation):
@@ -281,7 +281,7 @@ def retry_message(message: str) -> dict:
 
 	Finds the user message that immediately precedes ``message`` in the same
 	conversation, then enqueues ``run_agent_turn`` against it. The original
-	errored placeholder stays in the conversation as history — the new turn
+	errored placeholder stays in the conversation as history - the new turn
 	creates its own assistant placeholder, so the chat reads "user → (errored
 	turn) → (retried turn)".
 

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -85,7 +85,7 @@ def _read_credentials() -> ChatDeviceCredentials | None:
 	try:
 		priv = _load_private_key(private_key_b64u)
 	except (ValueError, TypeError):
-		# Corrupted private-key bytes — treat as unpaired so caller re-pairs.
+		# Corrupted private-key bytes - treat as unpaired so caller re-pairs.
 		return None
 	return ChatDeviceCredentials(
 		device_id=device_id,
@@ -100,7 +100,7 @@ def ensure_paired() -> ChatDeviceCredentials:
 	if missing. Idempotent: a fully-populated Settings row is reused as-is.
 
 	Raises OpenclawUnreachableError if pairing fails (no creds to fall back
-	to — the caller has no way to chat without them, so we surface the error
+	to - the caller has no way to chat without them, so we surface the error
 	cleanly instead of half-persisting an unusable state)."""
 	existing = _read_credentials()
 	if existing is not None:
@@ -163,7 +163,7 @@ def build_payload_v3(
 	"""Byte-for-byte mirror of openclaw's buildDeviceAuthPayloadV3.
 
 	If openclaw rev-bumps the payload format we discover it as a
-	'device-signature' rejection on connect — the only fragile spot in
+	'device-signature' rejection on connect - the only fragile spot in
 	the whole transport rewrite, hence the explicit comment + the
 	corresponding test in tests/test_chat_device.py."""
 	return "|".join([

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -1,7 +1,7 @@
-"""Openclaw gateway client — direct WebSocket with device-paired auth.
+"""Openclaw gateway client - direct WebSocket with device-paired auth.
 
 Previously this module shelled out to `docker compose exec ... node -e <script>`
-so the WS connection would appear as loopback inside the container — openclaw
+so the WS connection would appear as loopback inside the container - openclaw
 strips self-declared `operator.write` scopes from non-loopback token-only
 clients, and the chat worker needed write scope for sessions.create.
 
@@ -10,7 +10,7 @@ a device once (via jarvis.chat.device.ensure_paired → admin → fleet-agent),
 and present an Ed25519-signed v3 device-auth envelope at every connect.
 openclaw verifies the signature against the registered public key, grants
 the requested scopes, and the rest of the protocol (sessions.create, agent,
-event streaming) is identical to what the Node script used to do — only the
+event streaming) is identical to what the Node script used to do - only the
 transport changed from subprocess-pipes to direct WS frames.
 
 The public surface (OpenclawSession.connect / create_session /
@@ -52,7 +52,7 @@ _PLATFORM = "linux"  # informational; only affects the v3 signature payload
 # because admin re-provisioned the tenant and the new container has no record
 # of this deviceId). In those cases we wipe + re-pair once. Other rejection
 # reasons (signature-invalid, scope-mismatch) are programming bugs and must
-# NOT trigger a retry — that'd hide the bug behind silent re-pair attempts.
+# NOT trigger a retry - that'd hide the bug behind silent re-pair attempts.
 _STALE_PAIRING_MARKERS = (
 	"device-not-paired",
 	"token-mismatch",
@@ -75,7 +75,7 @@ class OpenclawSession:
 	  session.stream_agent_turn(session_key, message, idem) -> iter of parsed events
 	  session.close()
 
-	The gateway_token arg is kept for call-site compatibility but unused —
+	The gateway_token arg is kept for call-site compatibility but unused -
 	device pairing supersedes the shared bearer token. The chat device's
 	deviceToken from `jarvis.chat.device.ensure_paired()` is the credential.
 	"""
@@ -96,7 +96,7 @@ class OpenclawSession:
 		# Two-shot self-heal for tenant re-provisioning: on the first attempt
 		# we use whatever paired creds the customer has; if openclaw rejects
 		# with a "your pairing is stale" marker (typical when admin replaced
-		# the container under us — new container has empty pairing state),
+		# the container under us - new container has empty pairing state),
 		# we wipe + re-pair once and try again. A second stale signal is a
 		# real failure, not a retry candidate.
 		return cls._attempt_connect(gateway_url, allow_repair=True)
@@ -160,7 +160,7 @@ class OpenclawSession:
 
 		Yields the same parsed-event shape the worker used to consume from
 		the subprocess. Raises OpenclawUnreachableError on WS drop, agent
-		errors, or timeout — all the failure modes worker.py already maps to
+		errors, or timeout - all the failure modes worker.py already maps to
 		assistant-message error rows."""
 		params = {
 			"message": message,
@@ -297,7 +297,7 @@ class OpenclawSession:
 	def _request(self, method: str, params: dict, *, timeout_s: float) -> dict:
 		"""Send a request and wait for the matching response frame.
 
-		Drops out-of-order event frames silently — the caller is RPC-style
+		Drops out-of-order event frames silently - the caller is RPC-style
 		and doesn't need them. stream_agent_turn handles its own framing."""
 		req_id = self._send(method, params)
 		deadline = time.monotonic() + timeout_s

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -19,7 +19,7 @@ CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 
 # Provider label → openclaw provider id. Mirrors _PROVIDER_LABEL_TO_OPENCLAW
-# in jarvis.oauth.api. Only used in oauth mode — api_key mode has no
+# in jarvis.oauth.api. Only used in oauth mode - api_key mode has no
 # per-tenant codex/gemini-cli provider to override against, so we leave
 # the provider param off the WS frame and openclaw falls back to its
 # single registered models.providers.<id> entry.

--- a/jarvis/demo.py
+++ b/jarvis/demo.py
@@ -36,7 +36,7 @@ DEFAULT_TIMEOUT = 120  # seconds for the whole exchange
 # lifecycle / tool / assistant events until the run ends. Output is
 # line-delimited JSON so Python can parse it.
 #
-# The sessions.pluginPatch step has been removed — identity is now propagated
+# The sessions.pluginPatch step has been removed - identity is now propagated
 # via the Frappe database (Jarvis Chat Session row) + HTTP lookup in the plugin.
 _NODE_SCRIPT = r"""
 const ws = new (require('ws'))('ws://127.0.0.1:18789');
@@ -261,7 +261,7 @@ def ask_one(user: str, message: str, timeout: int = DEFAULT_TIMEOUT) -> dict:
 						print(f"\n[lifecycle] run errored: {data.get('error')}")
 
 				elif stream == "item":
-					# openclaw's unified item stream — kind discriminates between
+					# openclaw's unified item stream - kind discriminates between
 					# tool calls, model messages, etc.
 					kind = data.get("kind")
 					phase = data.get("phase")
@@ -302,12 +302,12 @@ def ask_one(user: str, message: str, timeout: int = DEFAULT_TIMEOUT) -> dict:
 					if delta:
 						print(delta, end="", flush=True)
 					if isinstance(full_text, str):
-						# Replace, not append — `text` is cumulative across deltas.
+						# Replace, not append - `text` is cumulative across deltas.
 						final_text_parts.clear()
 						final_text_parts.append(full_text)
 
 				elif stream is None:
-					# Empty / heartbeat frames — silent.
+					# Empty / heartbeat frames - silent.
 					continue
 
 				else:

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -4,7 +4,7 @@ Gated by ``frappe.conf.developer_mode`` + the System Manager role. Used by
 the Jarvis Settings form to wipe local state so the operator can run the
 onboarding wizard fresh without manual DB surgery.
 
-Companion to ``jarvis_admin.api.dev.purge_customer`` on the admin side —
+Companion to ``jarvis_admin.api.dev.purge_customer`` on the admin side -
 the admin button wipes admin-side records; this clears the customer bench.
 """
 
@@ -78,9 +78,9 @@ def reset_onboarding() -> dict:
 	  - enabled, token_budget_monthly
 	  - sampling: llm_temperature, llm_max_output_tokens
 	  - llm_provider (reset to the doctype default "Anthropic" so the form
-	    stays valid — it's a Select field, can't be blank)
+	    stays valid - it's a Select field, can't be blank)
 
-	Does NOT call the admin-side purge — use
+	Does NOT call the admin-side purge - use
 	``jarvis_admin.api.dev.purge_customer`` on admin for that. Both buttons
 	together give a clean two-step reset; this one alone is enough when the
 	admin record was already removed or never created.
@@ -91,7 +91,7 @@ def reset_onboarding() -> dict:
 		s.db_set(field, "")
 		if field in _PASSWORD_FIELDS:
 			remove_encrypted_password(SETTINGS, SETTINGS, field)
-	# Select field — must hold a valid option; reset to default.
+	# Select field - must hold a valid option; reset to default.
 	s.db_set("llm_provider", "Anthropic")
 	frappe.db.commit()
 	return {"ok": True, "data": {"cleared_fields": list(_RESET_CLEAR_FIELDS) + ["llm_provider"]}}

--- a/jarvis/docs/README.md
+++ b/jarvis/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation has moved
 
-Jarvis documentation is now maintained in one place — the **`jarvis_admin`**
+Jarvis documentation is now maintained in one place - the **`jarvis_admin`**
 repo, under **`jarvis_admin/docs/`**:
 
 - Customer-app docs (this app): `jarvis_admin/docs/customer-app/`

--- a/jarvis/docs/decisions/2026-05-25-customer-auth-native-frappe.md
+++ b/jarvis/docs/decisions/2026-05-25-customer-auth-native-frappe.md
@@ -16,15 +16,15 @@ Subscription + Tenant via the `customer` Link field).
 - **Custom Bearer token + `@customer_auth_required` decorator (previous design).**
   Worked but required `allow_guest=True` on every endpoint (caught us twice
   in one day after Frappe 17's OAuth-strict change). Isolation lived in
-  endpoint code — a new endpoint forgetting `customer.name` filter would leak.
+  endpoint code - a new endpoint forgetting `customer.name` filter would leak.
 - **Helper-only fix (`customer_owned(doctype, name)`).** Smaller PR but still
-  relies on developers using the helper — a missed call still leaks.
+  relies on developers using the helper - a missed call still leaks.
 
 ## Why this won
 
 - Frappe enforces auth at `validate_auth()` time, before any of our code.
 - `frappe.has_permission(...)` from a customer session reports False for
-  cross-customer rows — that's the signal protecting the HTTP API surface.
+  cross-customer rows - that's the signal protecting the HTTP API surface.
 - We already create the Frappe User per customer (`v1_4` patch); native
   auth just uses what's already there.
 
@@ -34,7 +34,7 @@ Subscription + Tenant via the `customer` Link field).
   token. Slight ergonomic cost; documented in configuration.md.
 - Site-binding (`X-Jarvis-Site` header) is dropped. User Permission gives
   stronger per-customer isolation than a soft header check.
-- Existing customers re-onboard at cutover (greenfield) — acceptable today
+- Existing customers re-onboard at cutover (greenfield) - acceptable today
   with one local-dev customer; would require coordination at scale.
 - Frappe's User Permission propagation enforces at the **request boundary**
   (REST API, form loads). Internal Python `frappe.get_doc(...)` and
@@ -47,6 +47,6 @@ Subscription + Tenant via the `customer` Link field).
 - If we add customer-facing OAuth/OIDC for SSO.
 - If a leaked api_key:api_secret causes a real incident and we need
   short-lived tokens.
-- If a future endpoint pattern accepts user-supplied resource IDs — that
+- If a future endpoint pattern accepts user-supplied resource IDs - that
   surface needs explicit ownership checks, since framework-level User
   Permission doesn't catch internal Python calls.

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -37,11 +37,11 @@ class AdminAuthError(JarvisError):
 class AdminValidationError(JarvisError):
 	"""jarvis_admin raised a Frappe ValidationError (or similar user-input
 	error) inside a whitelisted endpoint. Carries the clean operator-facing
-	message — never the traceback dump."""
+	message - never the traceback dump."""
 
 
 class AdminRateLimitedError(JarvisError):
-	"""jarvis_admin returned HTTP 429 — caller should back off and retry later.
+	"""jarvis_admin returned HTTP 429 - caller should back off and retry later.
 
 	``retry_after_seconds`` carries the body's hint when the admin provides
 	one (0 if absent)."""

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -18,18 +18,18 @@ app_license = "MIT"
 DEFAULT_ADMIN_URL = "https://admin.jarvis.aerele.in"
 
 # ---------------------------------------------------------------------------
-# OAuth client IDs — one per supported chat-subscription provider
+# OAuth client IDs - one per supported chat-subscription provider
 # ---------------------------------------------------------------------------
 # These are openclaw's hardcoded CLI client IDs. We use them (not Aerele-owned
 # PKCE clients) so the refresh tokens our device flow issues are compatible
-# with pi-ai's refresh path inside the container — openclaw's codex provider
+# with pi-ai's refresh path inside the container - openclaw's codex provider
 # refreshes against the same client_id we used to mint.
 #
 # Source:
 #   OpenAI: openclaw/extensions/openai/openai-codex-device-code.ts:5
 #   Google Gemini: bundled with @google/gemini-cli; override via env if it drifts.
 #
-# Anthropic Claude is deliberately absent — openclaw has no compatible
+# Anthropic Claude is deliberately absent - openclaw has no compatible
 # adapter for Claude Pro/Max subscriptions.
 def _env_or_default(name: str, default: str) -> str:
 	import os

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.py
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.py
@@ -12,7 +12,7 @@ from frappe.model.document import Document
 
 
 class JarvisChatSession(Document):
-    # Minimal controller — all validation is handled by field constraints.
+    # Minimal controller - all validation is handled by field constraints.
     # session_key is unique+mandatory; user is a mandatory Link to User.
 
     def before_insert(self):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -109,7 +109,7 @@ function confirmAndReset(frm) {
 				  <li>Last sync timestamp + status</li>
 				</ul>
 				<p>Preserved: Admin URL, monthly budget, sampling settings.</p>
-				<p>Does NOT touch admin-side records — use the admin's
+				<p>Does NOT touch admin-side records - use the admin's
 				<i>Purge customer (DEV)</i> button for that.</p>
 				<p>Type <b>RESET</b> to confirm:</p>` },
 			{ fieldtype: "Data", fieldname: "confirm", label: __("Confirm"), reqd: 1 },
@@ -125,7 +125,7 @@ function confirmAndReset(frm) {
 				d.hide();
 				const n = ((r && r.message && r.message.data && r.message.data.cleared_fields) || []).length;
 				frappe.show_alert({
-					message: __("Onboarding reset — cleared {0} field(s). Go to /app/jarvis-onboarding to start fresh.", [n]),
+					message: __("Onboarding reset - cleared {0} field(s). Go to /app/jarvis-onboarding to start fresh.", [n]),
 					indicator: "green",
 				});
 				frm.reload_doc();

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -180,7 +180,7 @@
       "fieldname": "operator_section",
       "fieldtype": "Section Break",
       "label": "Agent Operator",
-      "description": "Operator config — populated by jarvis.openclaw_bootstrap.start (dev) or the Jarvis admin signup response (prod)."
+      "description": "Operator config - populated by jarvis.openclaw_bootstrap.start (dev) or the Jarvis admin signup response (prod)."
     },
     {
       "fieldname": "agent_url",
@@ -201,7 +201,7 @@
       "fieldtype": "Data",
       "label": "Chat Device ID",
       "read_only": 1,
-      "description": "sha256(rawPublicKey).hex — openclaw deviceId this bench was paired as. Set lazily on first chat; cleared on re-pair."
+      "description": "sha256(rawPublicKey).hex - openclaw deviceId this bench was paired as. Set lazily on first chat; cleared on re-pair."
     },
     {
       "fieldname": "chat_device_public_key",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -9,7 +9,7 @@ LLM_FIELDS_TRIGGERING_SYNC = (
 )
 
 
-# Subscription-mode auth modes — the container owns credentials, so the
+# Subscription-mode auth modes - the container owns credentials, so the
 # bench's classifier treats a save with no structural change as a no-op.
 # We accept both "oauth" (REV-1 canonical) and the legacy "subscription"
 # value migrated tenants might still carry.
@@ -27,7 +27,7 @@ class JarvisSettings(Document):
             old_key = (getattr(old, "llm_api_key", None) or "") if old else ""
             self.flags.llm_api_key_changed = current_key != old_key
 
-        # Plain Select field — direct change comparison via has_value_changed.
+        # Plain Select field - direct change comparison via has_value_changed.
         self.flags.llm_auth_mode_changed = bool(self.has_value_changed("llm_auth_mode"))
 
         self._validate_auth_mode_requirements()
@@ -36,7 +36,7 @@ class JarvisSettings(Document):
         """Each auth mode requires its own credential field.
 
         REV-1: oauth/subscription mode has no bench-side credential
-        requirement — openclaw owns the credential blob on the container.
+        requirement - openclaw owns the credential blob on the container.
         """
         def is_password_set(fieldname: str) -> bool:
             in_memory = getattr(self, fieldname, None) or ""
@@ -57,7 +57,7 @@ class JarvisSettings(Document):
         """Return the bytes to push to openclaw's llm.key.
 
         REV-1: only api_key mode pushes a secret. Oauth mode's credentials
-        live in the container's auth-profiles.json — pushed via the separate
+        live in the container's auth-profiles.json - pushed via the separate
         push_oauth_blob path, not through this resolver.
         """
         return self.get_password("llm_api_key", raise_exception=False) or ""
@@ -70,7 +70,7 @@ class JarvisSettings(Document):
         # through admin → fleet-agent → container. Local-dev runs admin +
         # fleet-agent on the same machine; there is no longer a bench-
         # local push shortcut. If admin isn't configured, _sync_via_admin
-        # fails with AdminAuthError — the right error for "this workspace
+        # fails with AdminAuthError - the right error for "this workspace
         # isn't set up; run bootstrap_host then dev_onboard."
         self._sync_via_admin(action)
 
@@ -81,7 +81,7 @@ class JarvisSettings(Document):
         - "reload" calls post_rotate_llm_secret (hot-rotate /secrets/llm.key
           for api-key rotation; no restart).
         - "restart" calls post_update_llm_creds (re-render openclaw.json
-          and restart container) — used for mode switches and
+          and restart container) - used for mode switches and
           provider/model/base_url changes.
         """
         from jarvis import admin_client
@@ -91,7 +91,7 @@ class JarvisSettings(Document):
                 result = admin_client.post_rotate_llm_secret(secret=secret) or {}
                 resolved_action = result.get("action", "reload")
             else:  # "restart"
-                # In oauth mode the api_key body is empty — container reads
+                # In oauth mode the api_key body is empty - container reads
                 # credentials from auth-profiles.json instead.
                 secret = self._resolve_llm_secret_for_push()
                 result = admin_client.post_update_llm_creds(
@@ -127,7 +127,7 @@ class JarvisSettings(Document):
         """Return one of: None | 'reload' | 'restart'.
 
         - None: no LLM field changed; no action needed (in oauth mode this
-          is the common case — openclaw owns refresh).
+          is the common case - openclaw owns refresh).
         - 'reload': api_key rotation only; hot-reload via rotate-secret.
         - 'restart': structural change (mode switch, provider/model/base_url).
         """
@@ -153,7 +153,7 @@ class JarvisSettings(Document):
         if structural_changed:
             return "restart"
 
-        # Credential-only rotations — api_key only in REV-1. OAuth tokens
+        # Credential-only rotations - api_key only in REV-1. OAuth tokens
         # are openclaw-owned and don't trip the classifier.
         if self.flags.get("llm_api_key_changed"):
             return "reload"

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -10,7 +10,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const inr = (n) => "₹" + Number(n || 0).toLocaleString("en-IN");
 	const cycleLabel = (c) => (String(c).toLowerCase() === "annual" ? "/year" : "/month");
 
-	// LLM provider defaults — mirror the onboarding wizard's PROVIDER_DEFAULTS
+	// LLM provider defaults - mirror the onboarding wizard's PROVIDER_DEFAULTS
 	// so the section behaves identically there and here.
 	const PROVIDER_DEFAULTS = {
 		"Anthropic":          { model: "claude-sonnet-4-6",                 baseUrl: "https://api.anthropic.com" },
@@ -54,7 +54,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 
 	// Subscription providers + models (chat-subscription OAuth path).
 	// REV-3: server holds the verifier; UI offers a model picker at start.
-	// Subscription-tier model IDs — these go through codex/gemini-cli's
+	// Subscription-tier model IDs - these go through codex/gemini-cli's
 	// auth tunnel rather than the standard API, so the valid set is
 	// CLI-specific (not OpenAI/Google's public API model names).
 	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
@@ -84,7 +84,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		frappe.call({ method: "jarvis.account.is_onboarded" })
 			.then((r) => {
 				if (!r.message || !r.message.onboarded) {
-					// Not onboarded — wizard owns this customer.
+					// Not onboarded - wizard owns this customer.
 					window.location.assign("/app/jarvis-onboarding");
 					return;
 				}
@@ -119,7 +119,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	}
 
 	// ---- AI provider card (tabbed: API key | Chat subscription) ----------
-	// Segmented-control style — full-width container, sliding thumb between
+	// Segmented-control style - full-width container, sliding thumb between
 	// the two halves, equal-width buttons. Click handler swaps only the
 	// panel body so the slide animation isn't interrupted by a full
 	// re-render of the tabs DOM.
@@ -127,7 +127,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const ICON_CHAT = `<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`;
 
 	function renderAiProviderCard(editable) {
-		const provider = settingsLocal.llm_provider || "—";
+		const provider = settingsLocal.llm_provider || "-";
 		const inApiKeyMode = settingsLocal.llm_auth_mode !== "oauth";
 		const tabs = `
 			<label class="ja-tabs-label">Authentication mode</label>
@@ -167,7 +167,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 			? `<div class="ja-banner ja-banner-warn">You're currently using a chat subscription. Saving credentials here will switch you to API-key mode and disconnect the subscription.</div>`
 			: "";
 		return `
-			<p class="ja-sub">Your API key is sent directly to the provider — Jarvis only relays prompts.</p>
+			<p class="ja-sub">Your API key is sent directly to the provider - Jarvis only relays prompts.</p>
 			${notice}
 			<div class="ja-row2">
 				<div class="ja-field">
@@ -203,17 +203,17 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	}
 
 	function renderSubscriptionPanel(editable, isActiveMode) {
-		// Screen 3 — already connected (oauth mode)
+		// Screen 3 - already connected (oauth mode)
 		if (isActiveMode) {
-			const provider = settingsLocal.llm_provider || "—";
-			const model = settingsLocal.llm_model || "—";
-			const email = settingsLocal.llm_oauth_account_email || "—";
+			const provider = settingsLocal.llm_provider || "-";
+			const model = settingsLocal.llm_model || "-";
+			const email = settingsLocal.llm_oauth_account_email || "-";
 			// frappe.datetime.comment_when returns a <span class="frappe-timestamp">
-			// HTML widget (with hover tooltip). DON'T escape — let it render
+			// HTML widget (with hover tooltip). DON'T escape - let it render
 			// as live HTML. Other fields are plain strings; keep esc() on them.
 			const connectedAtHtml = settingsLocal.llm_oauth_connected_at
 				? frappe.datetime.comment_when(settingsLocal.llm_oauth_connected_at)
-				: "—";
+				: "-";
 			return `
 				<p class="ja-sub">Refresh and account state live inside your Jarvis container. If chat starts failing, click Re-authorize to mint fresh tokens.</p>
 				<table class="ja-kv">
@@ -227,11 +227,11 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					<button class="ja-btn ja-btn-primary" id="ja-sub-reauth">Re-authorize</button>
 				</div>`;
 		}
-		// Screen 2 — authorize URL shown, awaiting paste-back
+		// Screen 2 - authorize URL shown, awaiting paste-back
 		if (ui.subAuthorizeUrl) {
 			const minsLeft = Math.max(0, Math.floor((ui.subExpiresAt - Date.now()) / 60000));
 			return `
-				<p class="ja-sub"><strong>Step 1</strong> — Sign in with your ${esc(ui.subProvider)} account in a new tab.</p>
+				<p class="ja-sub"><strong>Step 1</strong> - Sign in with your ${esc(ui.subProvider)} account in a new tab.</p>
 				<div class="ja-actions" style="margin-bottom:10px">
 					<button class="ja-btn ja-btn-primary" id="ja-sub-open-url">Open Sign-in URL →</button>
 				</div>
@@ -239,7 +239,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					<code class="ja-url-text" id="ja-sub-url-text" title="${esc(ui.subAuthorizeUrl)}">${esc(ui.subAuthorizeUrl)}</code>
 					<button type="button" class="ja-btn ja-btn-ghost ja-btn-small" id="ja-sub-copy-url" title="Copy URL">Copy</button>
 				</div>
-				<p class="ja-sub"><strong>Step 2</strong> — After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
+				<p class="ja-sub"><strong>Step 2</strong> - After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
 				<div class="ja-field">
 					<textarea class="ja-input" id="ja-sub-pasted-url" rows="3" placeholder="Paste the URL from the error page here"></textarea>
 				</div>
@@ -250,7 +250,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				<div class="ja-hint" style="margin-top:14px;font-size:12px;color:var(--text-muted)">Link valid for ~${minsLeft} minute${minsLeft === 1 ? "" : "s"}.</div>
 				<div class="ja-err" id="ja-sub-err"></div>`;
 		}
-		// Screen 1 — provider + model picker (not yet started)
+		// Screen 1 - provider + model picker (not yet started)
 		const provOptions = Object.keys(SUBSCRIPTION_MODELS).map(
 			(p) => `<option value="${esc(p)}" ${p === ui.subProvider ? "selected" : ""}>${esc(p)}</option>`
 		).join("");
@@ -259,7 +259,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		).join("");
 		const dis = editable ? "" : "disabled";
 		return `
-			<p class="ja-sub">Sign in with your existing ChatGPT Plus / Pro or Gemini Advanced account — no developer key needed.</p>
+			<p class="ja-sub">Sign in with your existing ChatGPT Plus / Pro or Gemini Advanced account - no developer key needed.</p>
 			<div class="ja-row2">
 				<div class="ja-field">
 					<label>Provider</label>
@@ -483,7 +483,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 			case "Cancelled":
 				return `<div class="ja-banner ja-banner-warn">Cancelled · runs until <b>${esc(end)}</b>.</div>`;
 			case "Past Due":
-				return `<div class="ja-banner ja-banner-warn">Plan past due — expired on <b>${esc(end)}</b>. Reactivate to resume service.</div>`;
+				return `<div class="ja-banner ja-banner-warn">Plan past due - expired on <b>${esc(end)}</b>. Reactivate to resume service.</div>`;
 			case "Expired":
 				return `<div class="ja-banner ja-banner-bad">Plan expired on <b>${esc(end)}</b>. Reactivate to resume service.</div>`;
 			case "Pending Payment":
@@ -572,7 +572,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 			case "Active":
 				return upgrade
 					? { action: "upgrade", label: "Upgrade plan",
-						heading: "Want more capacity?", subtitle: "Move to a higher plan — you only pay the prorated difference for the remaining period." }
+						heading: "Want more capacity?", subtitle: "Move to a higher plan - you only pay the prorated difference for the remaining period." }
 					: { action: "renew", label: "Renew now",
 						heading: "Renew early", subtitle: "Add another billing cycle to your current plan." };
 			case "Cancelled":
@@ -707,7 +707,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	}
 
 	function pollForApplied() {
-		showOverlay("Payment received — finalizing your account…");
+		showOverlay("Payment received - finalizing your account…");
 		const before = JSON.stringify({
 			plan: (account.plan || {}).name || "",
 			end: account.current_period_end || "",
@@ -729,7 +729,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					clearInterval(tick); hideOverlay();
 					frappe.msgprint({
 						title: "Plan update pending",
-						message: "Your payment was received. The page should update within a minute — refresh to view, or contact support if it doesn't.",
+						message: "Your payment was received. The page should update within a minute - refresh to view, or contact support if it doesn't.",
 						indicator: "blue",
 					});
 				}
@@ -780,7 +780,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		.ja-panel{flex:1;padding:34px 36px;min-width:0;display:flex;flex-direction:column;gap:18px}
 		.ja-loading,.ja-empty{color:var(--text-muted);padding:18px 0}
 		.ja-card{border:1px solid var(--border-color);border-radius:12px;padding:20px;background:var(--card-bg)}
-		/* Segmented control — full-width two-up tab picker with sliding thumb */
+		/* Segmented control - full-width two-up tab picker with sliding thumb */
 		.ja-tabs-label{display:block;font-size:11.5px;letter-spacing:.6px;font-weight:600;
 			color:var(--text-muted);text-transform:uppercase;margin-bottom:8px}
 		.ja-tabs{position:relative;display:flex;width:100%;padding:4px;margin-bottom:18px;

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -1,5 +1,5 @@
 /* =============================================================
- * Jarvis Chat — page styles
+ * Jarvis Chat - page styles
  * Tokens follow Frappe Desk CSS variables so dark mode "just works".
  * ============================================================= */
 
@@ -47,7 +47,7 @@
 /* ---- Layout ------------------------------------------------- */
 
 /* Use Frappe's page-body as the layout container so we fill exactly the
- * space the Desk gave us — no magic number for navbar/header height. The
+ * space the Desk gave us - no magic number for navbar/header height. The
  * 100dvh fallback handles mobile chrome (URL bar) collapsing. */
 .jarvis-chat-page {
 	position: relative;
@@ -132,7 +132,7 @@
 	min-width: 0;
 }
 
-/* Delete (trash) icon — hidden by default, revealed on row hover.
+/* Delete (trash) icon - hidden by default, revealed on row hover.
    Active row's icon stays visible too, so deleting the current
    conversation doesn't require hover-hunting. */
 .jarvis-conv-delete {
@@ -464,7 +464,7 @@
 	font-style: italic;
 }
 
-/* Nested "Raw JSON" toggle inside the table details — smaller +
+/* Nested "Raw JSON" toggle inside the table details - smaller +
  * de-emphasised since the table is the primary view. */
 .jarvis-tool-raw {
 	margin-top: 8px;
@@ -563,7 +563,7 @@
 	margin-bottom: 0;
 }
 
-/* Inside a group, tool heads use a slightly lighter background — the group
+/* Inside a group, tool heads use a slightly lighter background - the group
  * itself already conveys "this is the agent's work area". */
 .jarvis-tool-group-body .jarvis-tool-head {
 	background: var(--bg-light-gray);

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.py
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.py
@@ -1,4 +1,4 @@
-"""Jarvis Chat Desk page — controller stub.
+"""Jarvis Chat Desk page - controller stub.
 
 Most of the page logic lives in jarvis_chat.js (browser) and the
 jarvis.chat.api endpoints (server). This controller is intentionally

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -10,9 +10,9 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	// ---- state -------------------------------------------------------------
 	const state = {
 		step: 1, email: "", company: "", planName: null, plans: [], busy: false,
-		// step 4 inputs — API key path
+		// step 4 inputs - API key path
 		llmProvider: "Anthropic", llmModel: "", llmApiKey: "", llmBaseUrl: "",
-		// step 4 inputs — chat subscription path (REV-3 paste-back)
+		// step 4 inputs - chat subscription path (REV-3 paste-back)
 		authMode: "api_key", // "api_key" | "subscription"
 		subProvider: "OpenAI",
 		subModel: "gpt-4o",
@@ -24,8 +24,8 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	};
 
 	// Providers + models for chat-subscription. Mirrors
-	// jarvis.oauth.providers — keep in sync.
-	// Subscription-tier model IDs — these go through codex/gemini-cli's
+	// jarvis.oauth.providers - keep in sync.
+	// Subscription-tier model IDs - these go through codex/gemini-cli's
 	// auth tunnel rather than the standard API, so the valid set is
 	// CLI-specific (not OpenAI/Google's public API model names).
 	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
@@ -59,10 +59,10 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		  <div class="jo-brand">
 		    <div class="jo-logo">✦</div>
 		    <div class="jo-brand-name">Jarvis</div>
-		    <div class="jo-brand-tag">Ask your ERP anything — in plain English.</div>
+		    <div class="jo-brand-tag">Ask your ERP anything - in plain English.</div>
 		    <ul class="jo-props">
 		      <li><span class="jo-tick">✓</span> Permission-aware answers over <b>your own</b> data</li>
-		      <li><span class="jo-tick">✓</span> Reads schemas, docs, lists &amp; reports — and acts, with approval</li>
+		      <li><span class="jo-tick">✓</span> Reads schemas, docs, lists &amp; reports - and acts, with approval</li>
 		      <li><span class="jo-tick">✓</span> Your data stays on your bench; the AI runs in a managed container</li>
 		      <li><span class="jo-tick">✓</span> Set up in under a minute</li>
 		    </ul>
@@ -172,7 +172,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		}).join("");
 		$body.html(`
 			<h2 class="jo-h">Choose your plan</h2>
-			<p class="jo-sub">Pay as you go — no auto-renewal. Extend anytime.</p>
+			<p class="jo-sub">Pay as you go - no auto-renewal. Extend anytime.</p>
 			<div class="jo-plans">${cards}</div>
 			<div class="jo-actions jo-actions-split">
 			  <button class="jo-btn jo-btn-ghost" id="jo-back">← Back</button>
@@ -198,7 +198,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 			  <div class="jo-row"><span>Plan</span><b>${esc(p.plan_name || "")}</b></div>
 			  <div class="jo-row jo-row-total"><span>Due now</span><b>${inr(p.price_inr)}<span class="jo-plan-cycle">${cycleLabel(p.billing_cycle)}</span></b></div>
 			</div>
-			${dev ? `<div class="jo-devnote">Developer mode — payment is skipped (dev signup).</div>` : ""}
+			${dev ? `<div class="jo-devnote">Developer mode - payment is skipped (dev signup).</div>` : ""}
 			<div class="jo-err" id="jo-pay-err"></div>
 			<div class="jo-actions jo-actions-split">
 			  <button class="jo-btn jo-btn-ghost" id="jo-back">← Back</button>
@@ -231,7 +231,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 			$body.html(`
 				<h2 class="jo-h">Connect your AI</h2>
 				<p class="jo-sub">Sign in once with your existing ChatGPT Plus or Gemini Advanced
-				   account — no API key, no extra cost. Jarvis will use your subscription quota.</p>
+				   account - no API key, no extra cost. Jarvis will use your subscription quota.</p>
 				${authModeHtml}
 				${renderSubscriptionPanel()}
 				<div class="jo-err" id="jo-llm-err"></div>`);
@@ -307,11 +307,11 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	}
 
 	function renderSubscriptionPanel() {
-		// Screen 2 — authorize URL shown, awaiting paste-back
+		// Screen 2 - authorize URL shown, awaiting paste-back
 		if (state.subAuthorizeUrl) {
 			const minsLeft = Math.max(0, Math.floor((state.subExpiresAt - Date.now()) / 60000));
 			return `
-				<p class="jo-hint" style="margin-bottom:14px"><strong>Step 1</strong> — Sign in with your ${esc(state.subProvider)} account in a new tab.</p>
+				<p class="jo-hint" style="margin-bottom:14px"><strong>Step 1</strong> - Sign in with your ${esc(state.subProvider)} account in a new tab.</p>
 				<div class="jo-actions" style="margin-bottom:10px">
 				  <button class="jo-btn jo-btn-primary" id="jo-sub-open-url">Open Sign-in URL →</button>
 				</div>
@@ -319,7 +319,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 				  <code class="jo-url-text" id="jo-sub-url-text" title="${esc(state.subAuthorizeUrl)}">${esc(state.subAuthorizeUrl)}</code>
 				  <button type="button" class="jo-btn jo-btn-ghost jo-btn-small" id="jo-sub-copy-url" title="Copy URL">Copy</button>
 				</div>
-				<p class="jo-hint"><strong>Step 2</strong> — After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
+				<p class="jo-hint"><strong>Step 2</strong> - After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
 				<div class="jo-field">
 				  <textarea class="jo-input" id="jo-sub-pasted-url" rows="3" placeholder="Paste the URL from the error page here"></textarea>
 				</div>
@@ -329,7 +329,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 				</div>
 				<div class="jo-hint" style="margin-top:14px;font-size:12px">Link valid for ~${minsLeft} minute${minsLeft === 1 ? "" : "s"}.</div>`;
 		}
-		// Screen 1 — provider + model picker (not yet started)
+		// Screen 1 - provider + model picker (not yet started)
 		const provOptions = Object.keys(SUBSCRIPTION_MODELS).map(
 			(p) => `<option value="${esc(p)}" ${p === state.subProvider ? "selected" : ""}>${esc(p)}</option>`
 		).join("");
@@ -482,11 +482,11 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		const syncSkippedNoCreds = !sync;  // came in via "Skip for now"
 		let agentLine;
 		if (!url) {
-			agentLine = "Your container is being prepared — it'll be ready shortly.";
+			agentLine = "Your container is being prepared - it'll be ready shortly.";
 		} else if (syncOk) {
 			agentLine = "Your agent is ready.";
 		} else if (syncSkippedNoCreds) {
-			agentLine = "Your agent is ready — finish connecting your AI in Jarvis Settings to start chatting.";
+			agentLine = "Your agent is ready - finish connecting your AI in Jarvis Settings to start chatting.";
 		} else {
 			agentLine = `Your agent is set up, but the AI connection didn't sync just now (<i>${esc(sync)}</i>). Open Jarvis Settings → Force Resync to retry.`;
 		}

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -29,7 +29,7 @@ _CACHE_KEY = "jarvis.oauth.codex_signin"
 _NONCE_TTL_SECS = 600
 _HTTP_TIMEOUT = 30
 _REDIRECT_URI = "http://localhost:1455/auth/callback"
-# Defaults for subscription mode — these are codex/gemini-cli's CLI-specific
+# Defaults for subscription mode - these are codex/gemini-cli's CLI-specific
 # model IDs, not OpenAI/Google's standard API model names. Mirrors the
 # SUBSCRIPTION_MODELS dict in jarvis_onboarding.js / jarvis_account.js.
 _DEFAULT_MODEL = {"OpenAI": "gpt-5.5", "Google Gemini": "gemini-2.0-pro"}
@@ -237,7 +237,7 @@ def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str
 		except requests.RequestException:
 			pass
 		return ""
-	# Gemini path — parse JWT payload for email claim
+	# Gemini path - parse JWT payload for email claim
 	if not id_token or id_token.count(".") < 2:
 		return ""
 	try:

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -21,7 +21,7 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		"userinfo":  "https://api.openai.com/v1/userinfo",
 		"scope":     "openid profile email offline_access api.connectors.read api.connectors.invoke",
 		"openclaw_provider": "openai-codex",
-		# codex-cli-specific authorize params — auth.openai.com returns a
+		# codex-cli-specific authorize params - auth.openai.com returns a
 		# generic "unknown_error" page mid-flow without these.
 		"extra_authorize_params": {
 			"id_token_add_organizations": "true",
@@ -32,7 +32,7 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 	"Google Gemini": {
 		"authorize": "https://accounts.google.com/o/oauth2/v2/auth",
 		"token":     "https://oauth2.googleapis.com/token",
-		# Gemini's id_token carries the email claim — no separate userinfo.
+		# Gemini's id_token carries the email claim - no separate userinfo.
 		"userinfo":  None,
 		"scope":     "openid email profile https://www.googleapis.com/auth/generative-language",
 		"openclaw_provider": "google-gemini-cli",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -1,4 +1,4 @@
-"""Onboarding — store the admin token + container connection into Jarvis
+"""Onboarding - store the admin token + container connection into Jarvis
 Settings, and thin server wrappers the onboarding page calls (so the browser
 never holds admin creds). admin_client returns already-unwrapped admin data."""
 
@@ -93,7 +93,7 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 	agent is fully ready.
 
 	REV-1: ``auth_mode="oauth"`` lets the OAuth poll-success path save
-	without requiring an api_key — credentials live in the container's
+	without requiring an api_key - credentials live in the container's
 	auth-profiles.json (pushed via the separate push_oauth_blob path)."""
 	if not provider or not model:
 		raise frappe.ValidationError("provider and model are required")

--- a/jarvis/openclaw_workspace_seeds/AGENTS.md
+++ b/jarvis/openclaw_workspace_seeds/AGENTS.md
@@ -21,7 +21,7 @@ All tools come from the `jarvis-openclaw-plugin`:
 | `jarvis__amend_doc` | **MUTATING.** Create a new Draft from a Cancelled doc. The only true "undo" path for submitted docs. |
 
 These dispatch through `jarvis.api.call_tool` and run under the user's
-Frappe identity. Permissions are enforced server-side — if the user can't
+Frappe identity. Permissions are enforced server-side - if the user can't
 see it, neither can you.
 
 ## Per-turn context
@@ -59,7 +59,7 @@ exact name, `get_list` first with a filter, then `get_doc` on the result.
 
 ### Line-item / child-row questions
 
-Frappe child tables are real DocTypes. Query them directly — do NOT fetch
+Frappe child tables are real DocTypes. Query them directly - do NOT fetch
 each parent doc and walk its `items` table.
 
 ```
@@ -75,8 +75,8 @@ each) is wrong for this class of question.
 
 ### Joins / aggregations / group-by
 
-When `get_list` can't express the question — e.g. "total revenue by item
-in Q1" or "customers with more than 10 unpaid invoices" — fall back to
+When `get_list` can't express the question - e.g. "total revenue by item
+in Q1" or "customers with more than 10 unpaid invoices" - fall back to
 `jarvis__run_query` with explicit SQL:
 
 ```sql
@@ -93,7 +93,7 @@ Rules of `run_query`:
 - One SELECT statement. No comments. Tables in `tab<DocType>` form.
 - Add explicit `AS` aliases on aggregate columns.
 - Prefer `get_list` first if the query is record-scoped (no aggregation,
-  no join) — `run_query` doesn't enforce User Permissions / record-level
+  no join) - `run_query` doesn't enforce User Permissions / record-level
   filters, only DocType-level read.
 
 ## Discipline
@@ -105,7 +105,7 @@ Rules of `run_query`:
   bury the answer.
 - For long results, show first 5–10 rows in a table and offer "show more".
 
-## Mutating tools — confirmation discipline
+## Mutating tools - confirmation discipline
 
 You have two mutating tools today: `jarvis__update_doc` and
 `jarvis__create_doc`. **Never call either without explicit user
@@ -157,13 +157,13 @@ in ERPNext is where business side effects live:
 
 **Once submitted, the document is immutable.** Changes require
 cancellation (which creates reversal entries and leaves an audit
-trail — it's not a clean undo).
+trail - it's not a clean undo).
 
 Pattern:
 
 1. User asks to submit. Example: "Submit Sales Invoice SINV-2026-00042".
 2. **Fetch the current state** with `get_doc` so you can summarise what's
-   being submitted — at minimum: party (customer/supplier), total amount,
+   being submitted - at minimum: party (customer/supplier), total amount,
    posting date, and item count if applicable.
 3. **Show the user, in plain English, what will happen:**
    > Submitting `Sales Invoice / SINV-2026-00042`:
@@ -174,7 +174,7 @@ Pattern:
    >
    > This will post the invoice to the General Ledger and update Acme's
    > outstanding balance. **Confirm submit?**
-4. Only after explicit "yes" / "submit it" / "go" — call
+4. Only after explicit "yes" / "submit it" / "go" - call
    `submit_doc(doctype="Sales Invoice", name="SINV-2026-00042")`.
 5. After submit, show what happened (return value, including new
    `docstatus: 1`) and remind the user the doc is now immutable.
@@ -200,7 +200,7 @@ create **reversal entries** rather than deleting anything:
 - **Sales/Purchase Order** cancel → releases reserved stock
 
 The doc + history stay; the operation is reversible only via **Amend**
-(creates a new Draft copy — not yet built; direct the user to Desk if
+(creates a new Draft copy - not yet built; direct the user to Desk if
 they want to amend).
 
 Pattern:
@@ -249,7 +249,7 @@ Pattern:
 
 If other records reference this one (e.g., a Customer with open Sales
 Invoices), Frappe raises `LinkExistsError`. Tell the user honestly
-which records are blocking — they'll need to delete or de-link those
+which records are blocking - they'll need to delete or de-link those
 first.
 
 ### Amending a cancelled record
@@ -259,7 +259,7 @@ document and creates a **new Draft copy** (with `amended_from` linking
 back to the original). The user then edits the Draft and re-submits.
 The Cancelled original stays as audit history.
 
-This is the only way to "edit" a document that has been submitted —
+This is the only way to "edit" a document that has been submitted -
 direct field changes on submitted docs are refused by Frappe.
 
 Pattern:
@@ -287,7 +287,7 @@ before the amend can succeed.
 ### Hard rules (apply to all six mutating tools)
 
 - **One record per call.** Bulk operations should be staged one at a time
-  with confirmation each — there are no bulk tools, and that's deliberate.
+  with confirmation each - there are no bulk tools, and that's deliberate.
 - **Never assume.** If the user says "update Acme" or "create a customer
   like Acme" or "submit yesterday's invoice", search / list / ask before
   acting. Two customers named "Acme Corp" → ask which.
@@ -295,17 +295,17 @@ before the amend can succeed.
   `doctype`, `docstatus`, `idx`, `parent*`; plus `name` for updates).
   The tools refuse them, but you shouldn't even try.
 - **Cancellation and amendment** are not implemented yet. If the user
-  asks to cancel a submitted doc, say so plainly — "I can't cancel yet;
+  asks to cancel a submitted doc, say so plainly - "I can't cancel yet;
   do it in Desk and I can help with anything afterward."
 - **For creates, get_schema first** when you don't already know the
   DocType. Required fields and field types matter; guessing is worse
   than asking. Same goes for submits when you don't recognise what the
-  DocType's `on_submit` does — better to say "submitting this triggers
-  workflow X — confirm?" than to surprise the user.
+  DocType's `on_submit` does - better to say "submitting this triggers
+  workflow X - confirm?" than to surprise the user.
 
 ## What's NOT in scope right now
 
-- Bulk operations or background jobs — every mutation is one record at a time.
+- Bulk operations or background jobs - every mutation is one record at a time.
 - Anything outside this Frappe site (no email, no Slack, no web fetch).
 
 If the user asks for one of these, say so and offer the alternative

--- a/jarvis/openclaw_workspace_seeds/IDENTITY.md
+++ b/jarvis/openclaw_workspace_seeds/IDENTITY.md
@@ -6,7 +6,7 @@
 - **Emoji:** ✦
 
 You live inside a Frappe site and talk to operators through the
-**Jarvis Chat** Desk page. The user is whoever sent the message — your tools
+**Jarvis Chat** Desk page. The user is whoever sent the message - your tools
 already run under their identity and permissions, so you only ever see what
 they can see.
 

--- a/jarvis/openclaw_workspace_seeds/SOUL.md
+++ b/jarvis/openclaw_workspace_seeds/SOUL.md
@@ -1,18 +1,18 @@
 # SOUL
 
-You are Jarvis — a Frappe and ERPNext expert. Treat the user's data with
+You are Jarvis - a Frappe and ERPNext expert. Treat the user's data with
 respect and the user's time with care.
 
 ## How you sound
 
-- **Direct.** Skip "Great question!" and "I'd be happy to help!" — just answer.
+- **Direct.** Skip "Great question!" and "I'd be happy to help!" - just answer.
 - **Terse by default.** A two-line answer beats a six-paragraph one. Expand
   when the user asks for detail.
 - **Confident, never bluffy.** If a tool returned 3 customers, say "3
   customers." If you don't have data, say so and offer to fetch it.
 - **Markdown when it helps.** Tables for list data. Bullets for summaries.
   Inline code for DocType / field names (`Sales Invoice`, `customer`).
-  Use **real** markdown table syntax — pipes and a separator row — not
+  Use **real** markdown table syntax - pipes and a separator row - not
   tab-separated text. Renderers won't render whitespace-separated columns
   as a table.
 
@@ -48,24 +48,24 @@ respect and the user's time with care.
 ## What you don't do
 
 - You have **six** mutating tools spanning the complete lifecycle:
-  1. `jarvis__create_doc` — create a new record
-  2. `jarvis__update_doc` — change fields on an existing record
-  3. `jarvis__submit_doc` — submit a Draft (Draft → Submitted; fires
+  1. `jarvis__create_doc` - create a new record
+  2. `jarvis__update_doc` - change fields on an existing record
+  3. `jarvis__submit_doc` - submit a Draft (Draft → Submitted; fires
      ledger / stock / payment side effects)
-  4. `jarvis__cancel_doc` — cancel a Submitted (creates reversal entries)
-  5. `jarvis__amend_doc` — amend a Cancelled doc (creates a new Draft
+  4. `jarvis__cancel_doc` - cancel a Submitted (creates reversal entries)
+  5. `jarvis__amend_doc` - amend a Cancelled doc (creates a new Draft
      copy linked back to the original)
-  6. `jarvis__delete_doc` — outright remove a row (most destructive)
+  6. `jarvis__delete_doc` - outright remove a row (most destructive)
 
   Use them only after showing the user a clear picture of what's about to
   change and getting explicit confirmation. The full discipline lives in
-  AGENTS.md — re-read it every time you're about to write. Read tools
+  AGENTS.md - re-read it every time you're about to write. Read tools
   (`get_doc`, `get_list`, etc.) can be called freely; writes are deliberate,
   one at a time, confirmed.
 - **Submit and cancel are heavy.** Both trigger DocType hooks with real-
   world side effects (ledger postings, stock balances, reversal entries).
   Always summarise the side effects before calling and demand explicit "yes".
-- **Delete is destructive.** Once deleted, the row is gone — audit trail
+- **Delete is destructive.** Once deleted, the row is gone - audit trail
   varies by DocType. Treat as irreversible from the user's perspective.
   Refuse Submitted docs; tell the user to cancel first.
 - For amendment (creating a Draft copy from a Cancelled doc) and bulk
@@ -77,11 +77,11 @@ respect and the user's time with care.
 ## On permissions
 
 The tools enforce per-user Frappe permissions. If `get_doc` returns a
-`PermissionDeniedError`, the user genuinely doesn't have access — relay that
+`PermissionDeniedError`, the user genuinely doesn't have access - relay that
 plainly, don't moralize.
 
 ## On uncertainty
 
 If a tool fails, summarize the error and offer the most useful next step.
-"`get_list` failed because `doctype` is required — which DocType did you mean?"
+"`get_list` failed because `doctype` is required - which DocType did you mean?"
 beats a wall of stack trace.

--- a/jarvis/openclaw_workspace_seeds/USER.md
+++ b/jarvis/openclaw_workspace_seeds/USER.md
@@ -1,13 +1,13 @@
 # USER
 
 The person sending you messages is a Frappe / ERPNext operator. They could
-be an admin, a sales rep, an accountant, or any other role — the Frappe
+be an admin, a sales rep, an accountant, or any other role - the Frappe
 permission system controls what they can actually see, and your tools
 inherit that.
 
 You don't know their name from this file alone; you learn it from context
 (the Desk session header, the way they greet you, what they ask about).
-That's fine — address them naturally without inventing details.
+That's fine - address them naturally without inventing details.
 
 ## What they usually want
 

--- a/jarvis/openclaw_ws.py
+++ b/jarvis/openclaw_ws.py
@@ -7,7 +7,7 @@ and closes. No secrets.reload, no restart.
 
 In production the WS endpoint is the customer's `agent_url`
 (`wss://<slug>.jarvis.aerele.in`), which the bench can reach directly
-without going through admin. In local-dev the same code paths apply —
+without going through admin. In local-dev the same code paths apply -
 the WS happens to terminate on a local container, but the bench's role
 is the same.
 """

--- a/jarvis/patches/v1_0_rename_openclaw_to_agent.py
+++ b/jarvis/patches/v1_0_rename_openclaw_to_agent.py
@@ -7,7 +7,7 @@ names. The operator-tab fields (gateway URL/token/paths) get brand-
 neutral `agent_*` names so customers never see "openclaw" in the UI.
 
 Module file names (openclaw_bootstrap.py, etc.) are intentionally NOT
-renamed — they're implementation detail, not customer-visible.
+renamed - they're implementation detail, not customer-visible.
 
 Implementation note: Jarvis Settings is a Single DocType. Single DocTypes
 store data as key/value rows in `tabSingles` rather than columns on a

--- a/jarvis/patches/v1_4_drop_llm_oauth_fields.py
+++ b/jarvis/patches/v1_4_drop_llm_oauth_fields.py
@@ -1,7 +1,7 @@
 """Drop legacy bench-side OAuth fields (now owned by openclaw inside the container).
 
 REV-1 of the openclaw subscription work moves OAuth credential state into
-the container's auth-profiles.json — openclaw refreshes tokens internally
+the container's auth-profiles.json - openclaw refreshes tokens internally
 via pi-ai. The bench no longer keeps refresh_token / access_token / expiry
 on Jarvis Settings.
 

--- a/jarvis/public/js/jarvis_chat/index.js
+++ b/jarvis/public/js/jarvis_chat/index.js
@@ -96,7 +96,7 @@ export function init(wrapper) {
 	}
 
 	// Reflect the active conversation in the URL so refresh / share / back
-	// land on the same chat. Uses replaceState — we don't want every sidebar
+	// land on the same chat. Uses replaceState - we don't want every sidebar
 	// click to push a history entry.
 	function syncUrl(name) {
 		const target = name ? `/app/jarvis-chat/${encodeURIComponent(name)}` : "/app/jarvis-chat";
@@ -112,10 +112,10 @@ export function init(wrapper) {
 	function rebuildModelPickerOptions() {
 		// Source of truth for "what models can the customer pick?" is the
 		// SUBSCRIPTION_MODELS map fetched on init. First option is "Default
-		// — <settings.llm_model>" which clears the override.
+		// - <settings.llm_model>" which clears the override.
 		const allowed = (state.subscription_models || {})[state.llm_provider] || [];
 		const defaultLabel =
-			__("Default") + " — " + (state.llm_model || "(unset)");
+			__("Default") + " - " + (state.llm_model || "(unset)");
 		const opts = [
 			`<option value="">${frappe.utils.escape_html(defaultLabel)}</option>`,
 			...allowed.map(
@@ -130,7 +130,7 @@ export function init(wrapper) {
 
 	function refreshModelPickerVisibility() {
 		// Shown in oauth mode (api_key mode has no multi-model picker).
-		// Visible on the welcome screen too — the picked value gets applied
+		// Visible on the welcome screen too - the picked value gets applied
 		// to whichever conversation receives the first send_message.
 		const show = state.llm_auth_mode === "oauth";
 		$convToolbar.prop("hidden", !show);
@@ -207,12 +207,12 @@ export function init(wrapper) {
 			syncModelPickerToConversation(data.conversation?.model_override);
 			await refreshSidebar($sidebar, $sidebarEmpty, loadConversation, archive);
 		} catch (err) {
-			// Conv missing / archived / not permitted — clean up and fall back
+			// Conv missing / archived / not permitted - clean up and fall back
 			// to welcome so a stale URL doesn't trap the user.
 			state.current_conversation = null;
 			if (opts.fromUrl) {
 				frappe.show_alert({
-					message: __("Conversation not found — opened a fresh view."),
+					message: __("Conversation not found - opened a fresh view."),
 					indicator: "orange",
 				});
 			}
@@ -274,7 +274,7 @@ export function init(wrapper) {
 	function renderEmptyConvHint() {
 		$list.append(`
 			<div class="jarvis-empty-conv">
-				<p>No messages yet — ask Jarvis something to get started.</p>
+				<p>No messages yet - ask Jarvis something to get started.</p>
 			</div>
 		`);
 	}
@@ -295,7 +295,7 @@ export function init(wrapper) {
 		if (state.is_sending || state.is_loading_conv) return;
 
 		// Client-side fast path: if the current conversation has zero messages,
-		// just focus the input — no need to round-trip.
+		// just focus the input - no need to round-trip.
 		if (state.current_conversation) {
 			const current = state.conversations.find(
 				(c) => c.name === state.current_conversation
@@ -314,7 +314,7 @@ export function init(wrapper) {
 			return;
 		}
 
-		// Server-side guarantee — won't create a duplicate empty even under a
+		// Server-side guarantee - won't create a duplicate empty even under a
 		// race with another tab.
 		const name = await api.createOrFocusEmpty();
 		await loadConversation(name);
@@ -341,7 +341,7 @@ export function init(wrapper) {
 			autoGrowInput();
 
 			// Pass the picker's current value (if any) so the new
-			// conversation lands on it atomically — no race against the worker.
+			// conversation lands on it atomically - no race against the worker.
 			const result = await api.sendMessage(
 				conv, text, state.current_model_override || null,
 			);
@@ -422,7 +422,7 @@ export function init(wrapper) {
 	const urlConv = route[1] ? decodeURIComponent(route[1]) : null;
 
 	(async () => {
-		// Load LLM settings first — picker rendering + visibility depend on them.
+		// Load LLM settings first - picker rendering + visibility depend on them.
 		try {
 			const s = await api.getChatUiSettings();
 			state.llm_auth_mode = s.llm_auth_mode || "api_key";

--- a/jarvis/public/js/jarvis_chat/messages.js
+++ b/jarvis/public/js/jarvis_chat/messages.js
@@ -1,4 +1,4 @@
-// Rendering helpers for individual chat messages. Stateless on purpose —
+// Rendering helpers for individual chat messages. Stateless on purpose -
 // they receive a message dict and return a DOM element. The realtime layer
 // patches existing elements via updateMessage().
 
@@ -21,7 +21,7 @@ export function renderMarkdown(text) {
  *
  * LLMs frequently emit tables as space-separated columns despite SOUL.md
  * asking for pipes. This client-side fallback makes the renderer robust
- * against that — every model, every prompt — without depending on the
+ * against that - every model, every prompt - without depending on the
  * agent to follow instructions.
  *
  * Heuristic: any run of 2+ consecutive non-blank lines where each line
@@ -78,7 +78,7 @@ function autoTablify(text) {
 
 function looksLikeTableRow(line) {
 	if (!line || !line.trim()) return false;
-	// Already pipe-formatted — let Showdown handle it directly.
+	// Already pipe-formatted - let Showdown handle it directly.
 	if (/^\s*\|/.test(line)) return false;
 	// Skip markdown structures that might have multi-space gaps for
 	// stylistic reasons but aren't actually tables.
@@ -178,7 +178,7 @@ function renderAssistantError(msg) {
 function timestampHtml($el, msg) {
 	// Read from the data attribute first (set by buildMessageEl on initial
 	// render from the DB-backed conversation). Realtime delta payloads don't
-	// carry a creation field — fall back to "just now" so the assistant
+	// carry a creation field - fall back to "just now" so the assistant
 	// bubble has a meaningful stamp while streaming.
 	const creation = $el.attr("data-creation");
 	if (!creation) {
@@ -224,7 +224,7 @@ function renderToolBody(msg) {
 //   - run_query envelope:  {sql: "...", rows: [...]}
 //   - get_schema envelope: {doctype, fields: [...]}
 //   - get_list envelope:   data is a bare array
-// When we can find a row array, render it as an HTML table — drastically
+// When we can find a row array, render it as an HTML table - drastically
 // more readable than the equivalent JSON for an LLM-driven UI. Fall back
 // to <pre> JSON for unstructured shapes.
 
@@ -276,7 +276,7 @@ function extractTable(result) {
 		return extractTable(result.data);
 	}
 
-	// Direct array — most get_list responses.
+	// Direct array - most get_list responses.
 	if (Array.isArray(result)) return tablify(result);
 
 	if (typeof result === "object") {
@@ -286,7 +286,7 @@ function extractTable(result) {
 		if (Array.isArray(result.fields)) return tablify(result.fields);
 		// Frappe Report shape: {columns: [...], result: [...]}
 		if (Array.isArray(result.result)) return tablify(result.result);
-		// Single record (e.g. get_doc) — render the doc's fields as a
+		// Single record (e.g. get_doc) - render the doc's fields as a
 		// 2-column key/value table.
 		return tablifyObject(result);
 	}
@@ -298,7 +298,7 @@ function extractTable(result) {
  * so the existing renderTable can produce a 2-column key/value view. Used
  * for get_doc results where the agent fetched a single record.
  *
- * `name` is hoisted to the top if present — for Frappe docs it's the
+ * `name` is hoisted to the top if present - for Frappe docs it's the
  * primary key and almost always the first thing a reader wants to see.
  */
 function tablifyObject(obj) {
@@ -351,7 +351,7 @@ function renderTable({ keys, rows }) {
 				const v = row[k];
 				let cell;
 				if (v === null || v === undefined) {
-					cell = '<span class="jarvis-tool-null">—</span>';
+					cell = '<span class="jarvis-tool-null">-</span>';
 				} else if (typeof v === "object") {
 					// Nested objects/arrays don't fit a flat table; show their
 					// JSON in the cell with a tooltip for the full value.

--- a/jarvis/public/js/jarvis_chat/realtime.js
+++ b/jarvis/public/js/jarvis_chat/realtime.js
@@ -37,7 +37,7 @@ function ensureCurrentTurnGroup($list) {
 	// assistant even when the assistant placeholder DOM-ed in first).
 	let $turn = $list.find(".jarvis-turn").last();
 	if (!$turn.length) {
-		// Realtime event arrived before any turn was rendered — fall back to
+		// Realtime event arrived before any turn was rendered - fall back to
 		// a top-level group. The next loadConversation() will reorganize.
 		$turn = $('<div class="jarvis-turn jarvis-turn-orphan"></div>');
 		$list.append($turn);
@@ -137,7 +137,7 @@ export function attachRealtime({ $list, $thinking, scrollToBottom, loadConversat
 					$el.attr("data-msg", payload.tool_message_id);
 					updateToolGroupCount($el.closest(".jarvis-tool-group"));
 				} else {
-					// No matching openclaw row — first-render path (e.g.
+					// No matching openclaw row - first-render path (e.g.
 					// call_tool dispatched outside an openclaw turn).
 					const $group = ensureCurrentTurnGroup($list);
 					$group.find(".jarvis-tool-group-body").append(

--- a/jarvis/public/js/jarvis_chat/sidebar.js
+++ b/jarvis/public/js/jarvis_chat/sidebar.js
@@ -49,7 +49,7 @@ export async function refreshSidebar($sidebar, $empty, onSelect, onArchive) {
 
 		$item.on("click", () => onSelect(c.name));
 
-		// Per-row delete (soft-delete via archive — sidebar's list query
+		// Per-row delete (soft-delete via archive - sidebar's list query
 		// filters status='Active', so archived rows fall out of view).
 		// Delegates the API call + cleanup to onArchive (the controller in
 		// index.js) so this stays a pure UI affordance.

--- a/jarvis/public/js/jarvis_chat/state.js
+++ b/jarvis/public/js/jarvis_chat/state.js
@@ -1,4 +1,4 @@
-// Shared mutable state for the page. Kept tiny on purpose — the source of
+// Shared mutable state for the page. Kept tiny on purpose - the source of
 // truth for messages/conversations is the server; this object only tracks
 // what the UI is currently looking at.
 
@@ -17,7 +17,7 @@ export const state = {
 	llm_model: "",
 	subscription_models: {},    // { "OpenAI": [...], "Google Gemini": [...] }
 
-	// Per-conversation model override mirror — refreshed each loadConversation.
+	// Per-conversation model override mirror - refreshed each loadConversation.
 	// Empty string means "use llm_model default".
 	current_model_override: "",
 };

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -1,5 +1,5 @@
 """Tests for jarvis.account wrappers and admin_client shims for the
-/jarvis-account page. admin_client is mocked — these are unit tests of
+/jarvis-account page. admin_client is mocked - these are unit tests of
 the customer-side glue, not of the admin endpoints themselves."""
 
 from unittest.mock import patch

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.admin_client — HTTPS wrapper for jarvis_admin calls.
+"""Tests for jarvis.admin_client - HTTPS wrapper for jarvis_admin calls.
 
 All HTTP is mocked. Tests verify header construction, error mapping,
 envelope unwrapping, and missing-config handling.
@@ -374,7 +374,7 @@ class TestOnboardingClient(FrappeTestCase):
 		self.assertEqual(captured["headers"]["Authorization"], "token renew-key:renew-secret")
 
 	def test_guest_call_omits_authorization_header(self):
-		# get_plans is a guest endpoint — no auth header is sent.
+		# get_plans is a guest endpoint - no auth header is sent.
 		_settings_clear_admin()
 		captured = {}
 

--- a/jarvis/tests/test_amend_doc.py
+++ b/jarvis/tests/test_amend_doc.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.amend_doc — closes the mutation lifecycle.
+"""Tests for jarvis.tools.amend_doc - closes the mutation lifecycle.
 
 Mock-heavy like submit/cancel: ``frappe.copy_doc`` and the ``amended_from``
 machinery are Frappe-owned. We verify our orchestration:

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -42,7 +42,7 @@ class TestCallToolPluginAuth(FrappeTestCase):
 
 	(The earlier shape required an X-Jarvis-User header which the plugin
 	resolved via a separate HTTPS call. That round-trip was removed
-	2026-05-18 — Frappe owns the session→user mapping, so it looks the
+	2026-05-18 - Frappe owns the session→user mapping, so it looks the
 	user up itself. See architecture.md ‘Path A v2'.)
 	"""
 
@@ -53,7 +53,7 @@ class TestCallToolPluginAuth(FrappeTestCase):
 		super().setUpClass()
 		settings = frappe.get_single("Jarvis Settings")
 		# Use a dedicated token for plugin-auth tests so we don't depend on
-		# real openclaw config. db_set bypasses on_update — the value persists
+		# real openclaw config. db_set bypasses on_update - the value persists
 		# only for this test class.
 		cls._original_token = settings.get_password("agent_token", raise_exception=False) or ""
 		settings.db_set("agent_token", "plugin-auth-test-token")
@@ -125,7 +125,7 @@ class TestCallToolPluginAuth(FrappeTestCase):
 		self.assertIn("unknown session", result["error"]["message"])
 
 	def test_session_user_restored_after_dispatch(self):
-		"""set_user is wrapped in try/finally — the calling user is preserved."""
+		"""set_user is wrapped in try/finally - the calling user is preserved."""
 		original = frappe.session.user
 		with self._with_headers({
 			"X-Jarvis-Token": "plugin-auth-test-token",

--- a/jarvis/tests/test_api_chat_session_header.py
+++ b/jarvis/tests/test_api_chat_session_header.py
@@ -101,7 +101,7 @@ class TestCallToolWithSessionHeader(FrappeTestCase):
 		self.assertEqual(kwargs["status"], "completed")
 
 	def test_missing_session_header_now_rejected(self):
-		"""Path A v2 requires X-Jarvis-Session — there is no user header any
+		"""Path A v2 requires X-Jarvis-Session - there is no user header any
 		more, so without a session we cannot resolve identity."""
 		req = _FakeRequest({"X-Jarvis-Token": PLUGIN_TOKEN})
 		with patch.object(frappe, "request", req, create=True):
@@ -111,7 +111,7 @@ class TestCallToolWithSessionHeader(FrappeTestCase):
 		self.assertIn("X-Jarvis-Session", result["error"]["message"])
 
 	def test_unknown_session_now_rejected(self):
-		"""Without a Chat Session row we have no user to dispatch as — fail
+		"""Without a Chat Session row we have no user to dispatch as - fail
 		fast rather than silently fall back to a different identity."""
 		req = _FakeRequest({
 			"X-Jarvis-Token": PLUGIN_TOKEN,

--- a/jarvis/tests/test_cancel_doc.py
+++ b/jarvis/tests/test_cancel_doc.py
@@ -1,6 +1,6 @@
-"""Tests for jarvis.tools.cancel_doc — fourth mutating tool.
+"""Tests for jarvis.tools.cancel_doc - fourth mutating tool.
 
-Mirror of test_submit_doc.py — cancel is the inverse state transition
+Mirror of test_submit_doc.py - cancel is the inverse state transition
 (docstatus 1 → 2). Same mock-heavy approach: on_cancel hooks belong to
 the DocType, not us.
 """
@@ -106,7 +106,7 @@ class TestCancelDocHappyPath(FrappeTestCase):
 		self.assertEqual(result["docstatus"], 2)
 
 	def test_propagates_validation_error_from_cancel(self):
-		"""on_cancel hooks may reject — e.g. invoice partly paid → can't
+		"""on_cancel hooks may reject - e.g. invoice partly paid → can't
 		cancel without first reversing payment. Let the real reason surface."""
 		doc = _fake_doc(docstatus=1)
 		doc.cancel.side_effect = frappe.ValidationError(

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.chat.api — whitelisted endpoints.
+"""Tests for jarvis.chat.api - whitelisted endpoints.
 
 These tests run as a **dedicated test user** (``TEST_USER``) so they never
 touch Administrator's data. Running the suite against a dev site that has
@@ -48,7 +48,7 @@ def _ensure_test_user(user: str = TEST_USER) -> None:
 def _cleanup_user_conversations(user: str = TEST_USER) -> None:
 	"""Delete all conversations owned by `user` (and their messages).
 
-	Defaults to the test fixture user — callers should NOT pass
+	Defaults to the test fixture user - callers should NOT pass
 	``Administrator`` here; doing so wipes real chat history on the dev site.
 	"""
 	names = frappe.get_all(CONV, filters={"owner": user}, pluck="name")
@@ -341,7 +341,7 @@ class TestRetryMessage(_ChatTestCase):
 		self.assertIn("error", result["reason"].lower())
 
 	def test_rejects_if_no_preceding_user_message(self):
-		"""An orphan errored assistant (somehow inserted without a user) — refuse."""
+		"""An orphan errored assistant (somehow inserted without a user) - refuse."""
 		asst_doc = frappe.get_doc({
 			"doctype": MSG, "conversation": self.conv, "seq": 1,
 			"role": "assistant", "content": "", "error": "boom",
@@ -459,7 +459,7 @@ class TestSetConversationModel(_ChatTestCase):
 
 class TestSendMessageWithModelOverride(_ChatTestCase):
 	"""send_message accepts an optional model_override that gets applied
-	to the conversation BEFORE the worker is enqueued — so the first
+	to the conversation BEFORE the worker is enqueued - so the first
 	turn lands on the picked model without a race against the worker."""
 
 	@classmethod

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.chat.device — chat keypair + pairing + v3 signing.
+"""Tests for jarvis.chat.device - chat keypair + pairing + v3 signing.
 
 Two surface areas to cover:
 1. ensure_paired: generates a keypair if missing, calls admin to register the
@@ -6,7 +6,7 @@ Two surface areas to cover:
    present; surfaces admin failures as OpenclawUnreachableError without
    half-persisting a broken state.
 2. build_payload_v3 / sign_payload: the byte-exact mirror of openclaw's
-   device-auth.ts:36 — if openclaw rev-bumps the format, this is the test
+   device-auth.ts:36 - if openclaw rev-bumps the format, this is the test
    that catches it before chat goes live.
 """
 
@@ -88,7 +88,7 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 		self.assertEqual(creds.device_token, "tok-from-admin")
 		self.assertEqual(creds.public_key, captured["public_key"])
 		self.assertEqual(creds.device_id, captured["device_id"])
-		# deviceId must match sha256(rawPublicKey) — same invariant openclaw enforces.
+		# deviceId must match sha256(rawPublicKey) - same invariant openclaw enforces.
 		raw = base64.urlsafe_b64decode(captured["public_key"] + "=" * (-len(captured["public_key"]) % 4))
 		self.assertEqual(creds.device_id, hashlib.sha256(raw).hexdigest())
 		# Persisted in Settings.
@@ -137,7 +137,7 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 
 	def test_partial_state_triggers_repair(self):
 		"""If only some fields are set, treat the whole pairing as missing
-		so the next call re-pairs atomically — protects against half-failed
+		so the next call re-pairs atomically - protects against half-failed
 		writes from a previous deploy/migration."""
 		s = frappe.get_single("Jarvis Settings")
 		s.db_set("chat_device_id", "abc")

--- a/jarvis/tests/test_chat_events.py
+++ b/jarvis/tests/test_chat_events.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.chat.events — openclaw event parsing + realtime publish wrapper."""
+"""Tests for jarvis.chat.events - openclaw event parsing + realtime publish wrapper."""
 
 from unittest.mock import patch
 

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -12,7 +12,7 @@ What's verified here:
 - stream_agent_turn yields parsed events between agent ack and lifecycle end.
 - Close is forgiving (no raise on already-closed sockets).
 
-Pairing itself is mocked here — see test_chat_device.py for the device.py
+Pairing itself is mocked here - see test_chat_device.py for the device.py
 half of the integration (keypair + admin call).
 """
 
@@ -214,7 +214,7 @@ class TestStreamAgentTurn(FrappeTestCase):
 								  "payload": {"runId": "run-1", "stream": "lifecycle",
 											  "data": {"phase": "end"}}}))
 		# Streams to completion (no items required to be yielded for the
-		# completion-path test — parse_event filters its own shapes).
+		# completion-path test - parse_event filters its own shapes).
 		list(sess.stream_agent_turn("session-x", "hi", "idem-1"))
 
 	def test_agent_rejection_raises(self):
@@ -396,7 +396,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 
 	def test_second_failure_does_not_loop(self):
 		"""After one repair attempt, a second stale-pairing signal must
-		propagate as a real failure — not a third retry."""
+		propagate as a real failure - not a third retry."""
 		first_ws, second_ws = self._build_two_ws("device-not-paired", second_ok=False)
 		with self.assertRaises(OpenclawUnreachableError):
 			self._connect_with_two_ws(first_ws, second_ws)

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.chat.policy — the subscription/credits validation seam."""
+"""Tests for jarvis.chat.policy - the subscription/credits validation seam."""
 
 from frappe.tests.utils import FrappeTestCase
 

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -1,7 +1,7 @@
 """Tests for jarvis.chat.worker.run_agent_turn.
 
-Like test_chat_api, these run as the fixture user ``TEST_USER`` — never as
-Administrator — so the test suite cannot wipe real chat history when run
+Like test_chat_api, these run as the fixture user ``TEST_USER`` - never as
+Administrator - so the test suite cannot wipe real chat history when run
 against a dev site.
 """
 
@@ -198,7 +198,7 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 		# stream_agent_turn was called with (session_key, message_text, idem)
 		fake_sess.stream_agent_turn.assert_called_once()
 		_, kwargs = fake_sess.stream_agent_turn.call_args
-		# args may be either positional or keyword — handle both
+		# args may be either positional or keyword - handle both
 		positional = fake_sess.stream_agent_turn.call_args.args
 		message_sent = (
 			positional[1] if len(positional) >= 2
@@ -280,7 +280,7 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 
 class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
 	"""In api_key mode (not oauth), the worker should NOT thread the
-	provider param — there's no per-tenant codex provider to override
+	provider param - there's no per-tenant codex provider to override
 	to; api-key-mode customers have one provider registered."""
 
 	@classmethod

--- a/jarvis/tests/test_create_doc.py
+++ b/jarvis/tests/test_create_doc.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.create_doc — second mutating tool.
+"""Tests for jarvis.tools.create_doc - second mutating tool.
 
 Uses ``Note`` as the fixture DocType (same reasoning as test_update_doc):
 exists on every Frappe site, simple writeable fields, no side effects on
@@ -45,7 +45,7 @@ class TestCreateDocValidation(FrappeTestCase):
 
 	def test_rejects_protected_system_fields(self):
 		"""`owner`, `creation`, `docstatus`, etc. are Frappe-managed.
-		`name` is intentionally NOT protected — autoname=prompt DocTypes
+		`name` is intentionally NOT protected - autoname=prompt DocTypes
 		need it."""
 		for protected in ["owner", "creation", "modified", "doctype", "docstatus", "parent"]:
 			with self.assertRaises(InvalidArgumentError, msg=f"should reject {protected}"):
@@ -55,7 +55,7 @@ class TestCreateDocValidation(FrappeTestCase):
 				)
 
 	def test_does_not_reject_name(self):
-		"""autoname=prompt DocTypes pass `name` in values — don't refuse it
+		"""autoname=prompt DocTypes pass `name` in values - don't refuse it
 		at the validation layer. (Note doesn't use prompt-autoname, so this
 		ends up auto-generated, but the validation must not throw.)"""
 		def fake_perm(*a, **kw):
@@ -95,7 +95,7 @@ class TestCreateDocPermissions(FrappeTestCase):
 				)
 
 	def test_checks_create_ptype_at_doctype_level(self):
-		"""Unlike update_doc, create has no record yet — perm check is
+		"""Unlike update_doc, create has no record yet - perm check is
 		DocType-level only (no doc= arg)."""
 		called_with = {}
 
@@ -117,7 +117,7 @@ class TestCreateDocPermissions(FrappeTestCase):
 
 		self.assertEqual(called_with["doctype"], NOTE_DT)
 		self.assertEqual(called_with["ptype"], "create")
-		# Record-level doc arg is NOT passed — record doesn't exist yet
+		# Record-level doc arg is NOT passed - record doesn't exist yet
 		self.assertIsNone(called_with["doc"])
 
 
@@ -146,7 +146,7 @@ class TestCreateDocHappyPath(FrappeTestCase):
 
 	def test_validate_hooks_still_fire(self):
 		"""Required fields enforced by the DocType's validate() must still
-		reject — we don't bypass DocType rules."""
+		reject - we don't bypass DocType rules."""
 		# Note has no required fields by default, so we can't easily test
 		# a validate failure without a fixture DocType. Just confirm that
 		# doc.insert() is what we call (it's the validate path).

--- a/jarvis/tests/test_delete_doc.py
+++ b/jarvis/tests/test_delete_doc.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.delete_doc — the destructive tool.
+"""Tests for jarvis.tools.delete_doc - the destructive tool.
 
 End-to-end uses ``Note`` as the fixture DocType (same as create/update):
 delete on Note works without side effects, and we get to exercise the

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.dev — the customer-side reset_onboarding endpoint."""
+"""Tests for jarvis.dev - the customer-side reset_onboarding endpoint."""
 
 import frappe
 from frappe.tests.utils import FrappeTestCase

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.diagnostics — the three Jarvis Settings buttons."""
+"""Tests for jarvis.diagnostics - the three Jarvis Settings buttons."""
 
 from unittest.mock import patch
 

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -222,7 +222,7 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 	@patch("jarvis.oauth.api._exchange_code",
 	       side_effect=Exception("provider 400"))
 	def test_token_exchange_failure_returns_error(self, _):
-		"""Generic exception path — actual TokenExchangeError covered by
+		"""Generic exception path - actual TokenExchangeError covered by
 		the inner _exchange_code function's own tests. Here we just check
 		that the endpoint surfaces the failure cleanly."""
 		from jarvis.oauth import api as oa

--- a/jarvis/tests/test_oauth_providers.py
+++ b/jarvis/tests/test_oauth_providers.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.oauth.providers — provider OAuth metadata."""
+"""Tests for jarvis.oauth.providers - provider OAuth metadata."""
 import unittest
 from urllib.parse import urlparse, parse_qs
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -20,7 +20,7 @@ def _set_token(value, secret="secret"):
 
 # Fields these tests write to. Snapshot in setUp, restore in tearDown so
 # tests run against a real site (e.g. jarvis.localhost) don't clobber the
-# operator's actual onboarded state — Frappe Singles aren't transactionally
+# operator's actual onboarded state - Frappe Singles aren't transactionally
 # rolled back between tests.
 _SNAPSHOTTED_FIELDS = (
 	"jarvis_admin_url", "jarvis_admin_api_key", "jarvis_admin_api_secret",
@@ -117,7 +117,7 @@ class TestSyncConnection(FrappeTestCase):
 
 	def test_write_connection_ignores_legacy_api_token(self):
 		"""If admin returns the old api_token key, write_connection should NOT
-		write it (no accidental cross-population — that field is gone now)."""
+		write it (no accidental cross-population - that field is gone now)."""
 		_set_token("")
 		onboarding.write_connection({"api_token": "legacy", "agent_url": "ws://h:1"})
 		s = frappe.get_single("Jarvis Settings")
@@ -128,7 +128,7 @@ class TestSyncConnection(FrappeTestCase):
 		"""Step 4 of onboarding: provider/model/api_key land in Jarvis Settings
 		and the save triggers the push pipeline (post-unification 2026-05-29:
 		always via admin; admin call mocked here, may AdminAuthError if no
-		api_key on settings — both paths set last_sync_status)."""
+		api_key on settings - both paths set last_sync_status)."""
 		_set_token("")
 		with patch("jarvis.admin_client.post_update_llm_creds",
 				   return_value={"action": "restart", "result": "ok"}):
@@ -152,7 +152,7 @@ class TestSyncConnection(FrappeTestCase):
 			onboarding.save_llm_creds(provider="Anthropic", model="m", api_key="")
 
 	def test_save_llm_creds_oauth_mode_allows_empty_api_key(self):
-		"""REV-1: auth_mode=oauth doesn't require api_key — credentials live in
+		"""REV-1: auth_mode=oauth doesn't require api_key - credentials live in
 		the container's auth-profiles.json (pushed separately)."""
 		_set_token("")
 		with patch("jarvis.admin_client.post_update_llm_creds",

--- a/jarvis/tests/test_run_query.py
+++ b/jarvis/tests/test_run_query.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.run_query — read-only SQL with safety bounds."""
+"""Tests for jarvis.tools.run_query - read-only SQL with safety bounds."""
 
 from unittest.mock import patch
 
@@ -10,7 +10,7 @@ from jarvis.tools.run_query import run_query
 
 
 class TestRunQueryValidation(FrappeTestCase):
-	"""The defensive validation layer — failures should never reach
+	"""The defensive validation layer - failures should never reach
 	``frappe.db.sql``. Each test asserts on the *type* of rejection, not the
 	wording of the message, so the error copy can evolve.
 	"""
@@ -89,7 +89,7 @@ class TestRunQueryPermissions(FrappeTestCase):
 			return True
 
 		with patch("frappe.has_permission", side_effect=fake_has_perm):
-			# Patch sql so we don't actually execute the SELECT — only care
+			# Patch sql so we don't actually execute the SELECT - only care
 			# about the perm-check side effect.
 			with patch("frappe.db.sql", return_value=[]):
 				run_query(
@@ -102,7 +102,7 @@ class TestRunQueryPermissions(FrappeTestCase):
 
 
 class TestRunQueryLimitInjection(FrappeTestCase):
-	"""LIMIT is the only bound on result size — it must always be present
+	"""LIMIT is the only bound on result size - it must always be present
 	and never exceed the cap. Test the rewriter, not the SQL execution.
 	"""
 
@@ -169,7 +169,7 @@ class TestRunQueryHappyPath(FrappeTestCase):
 
 	def test_rejects_query_returning_unnamed_columns(self):
 		# Without a column alias on the count() expression, frappe.db.sql
-		# returns the column under a generated name — we accept that.
+		# returns the column under a generated name - we accept that.
 		# This test is here as documentation: as_dict=True does give us
 		# names back, so the validation in the code is defensive only.
 		result = run_query("SELECT COUNT(*) AS n FROM tabDocType", limit=1)

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -23,7 +23,7 @@ _SNAPSHOT_PASSWORD_FIELDS = (
 class _SettingsSnapshotTestCase(FrappeTestCase):
 	"""Snapshot the Jarvis Settings singleton at class entry; restore at exit.
 
-	Password fields are read via get_password() (cleartext) — settings.get(...)
+	Password fields are read via get_password() (cleartext) - settings.get(...)
 	returns the masked "*****" string for those and would round-trip wrong.
 	"""
 

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -1,13 +1,13 @@
 """Tests for Jarvis Settings on_update classification + admin dispatch.
 
-`Jarvis Settings` is a Single — there's exactly one row in the whole DB,
+`Jarvis Settings` is a Single - there's exactly one row in the whole DB,
 shared by tests and the live UI. `_SettingsSingletonTestCase` snapshots
 the pre-test field values in setUpClass and restores them in
 tearDownClass so the suite leaves no footprint on the user's real
 credentials.
 
 Post-unification (2026-05-29): on_update always dispatches via
-`_sync_via_admin` — there is no longer a bench-local push shortcut. All
+`_sync_via_admin` - there is no longer a bench-local push shortcut. All
 tests mock `jarvis.admin_client.*` accordingly.
 """
 
@@ -157,7 +157,7 @@ class TestOnUpdateClassification(_SettingsSingletonTestCase):
 class TestOnUpdateAlwaysAdminPath(_SettingsSingletonTestCase):
     """Unified architecture: on_update always uses `_sync_via_admin`,
     regardless of whether the admin api_key is configured. If admin isn't
-    configured, the call fails with AdminAuthError (which we don't mock —
+    configured, the call fails with AdminAuthError (which we don't mock -
     the test only verifies the path is taken)."""
 
     def setUp(self):
@@ -269,7 +269,7 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
 
     def test_legacy_subscription_mode_no_bench_credential_required(self):
         """Migrated tenants on the legacy 'subscription' value are treated
-        the same as oauth — no bench-side credential required."""
+        the same as oauth - no bench-side credential required."""
         settings = frappe.get_single("Jarvis Settings")
         settings.llm_auth_mode = "subscription"
         settings.llm_provider = "OpenAI"
@@ -278,7 +278,7 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
 
 
 class TestClassifyAuthModeSwitch(_SettingsSingletonTestCase):
-    """Mode-switch is structural — always triggers restart."""
+    """Mode-switch is structural - always triggers restart."""
 
     def setUp(self):
         _reset_settings()

--- a/jarvis/tests/test_submit_doc.py
+++ b/jarvis/tests/test_submit_doc.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.submit_doc — third mutating tool.
+"""Tests for jarvis.tools.submit_doc - third mutating tool.
 
 Most of these are mock-based because submit's side effects (ledger
 postings, stock moves, etc.) live in DocType ``on_submit`` hooks owned

--- a/jarvis/tests/test_update_doc.py
+++ b/jarvis/tests/test_update_doc.py
@@ -1,4 +1,4 @@
-"""Tests for jarvis.tools.update_doc — the first mutating tool.
+"""Tests for jarvis.tools.update_doc - the first mutating tool.
 
 Uses ``Note`` as the fixture DocType because it exists on every Frappe
 site, has simple writeable fields, and modifying test rows can't break
@@ -55,7 +55,7 @@ class TestUpdateDocValidation(FrappeTestCase):
 			update_doc(doctype=NOTE_DT, name="anything", changes="not a dict")
 
 	def test_rejects_protected_system_fields(self):
-		"""Writing `name`, `owner`, `creation`, etc. is refused outright —
+		"""Writing `name`, `owner`, `creation`, etc. is refused outright -
 		Frappe maintains these and an LLM shouldn't be touching them."""
 		for protected in ["name", "owner", "creation", "modified", "doctype", "docstatus", "idx"]:
 			with self.assertRaises(InvalidArgumentError, msg=f"should reject {protected}"):
@@ -143,7 +143,7 @@ class TestUpdateDocHappyPath(FrappeTestCase):
 
 	def test_returns_full_saved_doc(self):
 		"""Caller (the agent) needs the post-save state so it can confirm
-		what happened — include all fields, not just the changed ones."""
+		what happened - include all fields, not just the changed ones."""
 		result = update_doc(
 			doctype=NOTE_DT,
 			name=self.note,

--- a/jarvis/tools/amend_doc.py
+++ b/jarvis/tools/amend_doc.py
@@ -1,4 +1,4 @@
-"""Amend a cancelled Frappe document — the lifecycle's only true "undo".
+"""Amend a cancelled Frappe document - the lifecycle's only true "undo".
 
 Amendment is Frappe's mechanism for editing a Submitted record AFTER it
 has been Cancelled. It does NOT modify the Cancelled row; it creates a
@@ -17,7 +17,7 @@ Safety bounds:
 - DocType must be submittable.
 - Calling user must have **amend** permission on the source record
   (``frappe.has_permission(doctype, ptype="amend", doc=name)``). Plus
-  the implicit ``create`` perm on the DocType — Frappe's
+  the implicit ``create`` perm on the DocType - Frappe's
   ``copy_doc().insert()`` checks that for us.
 - Source doc must be Cancelled (``docstatus == 2``). Draft and Submitted
   refuse with state-aware messages.
@@ -55,7 +55,7 @@ def amend_doc(doctype: str, name: str) -> dict:
     meta = frappe.get_meta(doctype)
     if not meta.is_submittable:
         raise InvalidArgumentError(
-            f"{doctype} is not submittable — amendment only applies to "
+            f"{doctype} is not submittable - amendment only applies to "
             f"docstatus-tracked DocTypes"
         )
 

--- a/jarvis/tools/cancel_doc.py
+++ b/jarvis/tools/cancel_doc.py
@@ -50,7 +50,7 @@ def cancel_doc(doctype: str, name: str) -> dict:
     meta = frappe.get_meta(doctype)
     if not meta.is_submittable:
         raise InvalidArgumentError(
-            f"{doctype} is not submittable — cancellation only applies to "
+            f"{doctype} is not submittable - cancellation only applies to "
             f"docstatus-tracked DocTypes"
         )
 

--- a/jarvis/tools/create_doc.py
+++ b/jarvis/tools/create_doc.py
@@ -7,13 +7,13 @@ Safety bounds (same shape as update_doc, adapted for create):
 
 - Calling user must have ``create`` permission on the target DocType
   (``frappe.has_permission(doctype, ptype="create")``). Record-level
-  perms don't apply yet — no record exists.
+  perms don't apply yet - no record exists.
 - System fields are refused: ``owner``, ``creation``, ``modified``,
   ``modified_by``, ``doctype``, ``docstatus``, ``idx``, ``parent``,
   ``parentfield``, ``parenttype``. ``name`` is **allowed** so DocTypes
-  with autoname=prompt / field-derived autoname work — Frappe's autoname
+  with autoname=prompt / field-derived autoname work - Frappe's autoname
   machinery decides whether to honour it.
-- Empty ``values`` dict is refused — agents shouldn't create blank rows.
+- Empty ``values`` dict is refused - agents shouldn't create blank rows.
 - The DocType's validate() and on_insert() hooks fire via ``doc.insert()``,
   so required fields, link integrity, and business rules apply.
 """

--- a/jarvis/tools/delete_doc.py
+++ b/jarvis/tools/delete_doc.py
@@ -1,7 +1,7 @@
 """Delete a Frappe document.
 
-The **most destructive** mutating tool. Unlike cancel — which keeps the
-row and adds a reversal entry — delete removes the row outright. Some
+The **most destructive** mutating tool. Unlike cancel - which keeps the
+row and adds a reversal entry - delete removes the row outright. Some
 DocTypes retain an audit trail via the ``Version`` DocType; many don't.
 Treat every delete as irreversible from the user's perspective.
 
@@ -9,7 +9,7 @@ Safety bounds:
 
 - Calling user must have ``delete`` permission on the record.
 - For submittable DocTypes: only Draft (0) or Cancelled (2) docs are
-  deletable. Submitted (1) is refused — the user must cancel first
+  deletable. Submitted (1) is refused - the user must cancel first
   (Frappe enforces this too; we pre-check for a clearer error).
 - Some DocTypes block delete entirely via ``allow_delete = 0`` on their
   meta; Frappe's ``delete_doc`` will raise in that case and the error
@@ -17,7 +17,7 @@ Safety bounds:
 - Linked records: if other docs reference this one (e.g. a Customer with
   Sales Invoices), Frappe raises ``LinkExistsError``. Let it propagate so
   the agent can tell the user "X cannot be deleted because Y references
-  it" — clearer than a generic "delete failed".
+  it" - clearer than a generic "delete failed".
 """
 
 import frappe
@@ -46,7 +46,7 @@ def delete_doc(doctype: str, name: str) -> dict:
             f"no delete permission on {doctype} '{name}'"
         )
 
-    # Pre-load the doc to check docstatus — gives a clearer error than
+    # Pre-load the doc to check docstatus - gives a clearer error than
     # Frappe's "cannot delete a submitted document" for the agent to
     # explain to the user.
     doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -18,7 +18,7 @@ def _field_record(f) -> dict:
 def get_schema(doctype: str) -> dict:
 	"""Return meta for a DocType: name and field list.
 
-	Child tables are expanded inline — each Table / Table MultiSelect field carries
+	Child tables are expanded inline - each Table / Table MultiSelect field carries
 	a `child_fields` list with the schema of the linked child DocType, so the agent
 	gets the full hierarchy in one call. Frappe doesn't allow nested tables, so
 	expansion depth is bounded at 1.

--- a/jarvis/tools/run_query.py
+++ b/jarvis/tools/run_query.py
@@ -1,7 +1,7 @@
 """Read-only SQL select against Frappe DocType tables.
 
-For complex requests the LLM struggles to express through ``get_list`` —
-joins, aggregations, group-by, cross-DocType analytics — this tool lets the
+For complex requests the LLM struggles to express through ``get_list`` -
+joins, aggregations, group-by, cross-DocType analytics - this tool lets the
 agent compose a SELECT and execute it. Safety is enforced through query
 parsing, not just trust:
 
@@ -32,7 +32,7 @@ from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 MAX_LIMIT = 1000
 DEFAULT_LIMIT = 100
 
-# Identifiers we refuse outright in any token stream — covers single-line
+# Identifiers we refuse outright in any token stream - covers single-line
 # comments (--), block comments (/* */), and forbidden statement types that
 # might slip past sqlparse's get_type() in edge cases (subqueries, CTEs).
 _FORBIDDEN_TOKENS = {
@@ -119,7 +119,7 @@ def _parse_single_select(query: str):
 
 def _reject_forbidden_keywords(stmt) -> None:
 	"""Walk the token stream and refuse known dangerous keywords. sqlparse's
-	``get_type()`` only inspects the leading keyword — a SELECT containing a
+	``get_type()`` only inspects the leading keyword - a SELECT containing a
 	subquery DELETE would slip past."""
 	for token in stmt.flatten():
 		if token.ttype in (DDL, DML):
@@ -181,5 +181,5 @@ def _enforce_limit(query: str, limit: int) -> str:
 
 # sqlparse imports above are intentionally module-level so we fail fast on
 # missing dep at import time (Frappe ships with sqlparse, so this should
-# always be present — but the import is the contract).
+# always be present - but the import is the contract).
 _ = IdentifierList, Identifier  # silence "unused import" when reading

--- a/jarvis/tools/submit_doc.py
+++ b/jarvis/tools/submit_doc.py
@@ -1,7 +1,7 @@
 """Submit a Frappe document.
 
 The third mutating tool. ``submit`` is qualitatively bigger than
-``update`` / ``create`` — it moves the doc from Draft (docstatus=0) to
+``update`` / ``create`` - it moves the doc from Draft (docstatus=0) to
 Submitted (docstatus=1), which triggers the DocType's ``on_submit``
 hooks. For ERPNext that's where the real-world side effects live:
 
@@ -10,21 +10,21 @@ hooks. For ERPNext that's where the real-world side effects live:
 - Payment Entry → moves money on the books
 - Sales Order / Purchase Order → reserves stock, opens fulfilment
 
-Submitted documents are generally **immutable** — changes require
+Submitted documents are generally **immutable** - changes require
 cancellation (which creates reversal entries, leaving an audit trail
 rather than a clean undo). The persona must emphasise that ``submit_doc``
 is one of the consequential actions and demand explicit confirmation.
 
 Safety bounds:
 
-- DocType must be submittable (``meta.is_submittable``) — otherwise
+- DocType must be submittable (``meta.is_submittable``) - otherwise
   ``submit`` is a no-op concept on that DocType and we refuse with a
   clear error instead of a confusing Frappe traceback.
 - Calling user must have ``submit`` permission on the record (record-level
   via ``frappe.has_permission(doctype, ptype="submit", doc=name)``).
 - Doc must be in Draft state (``docstatus == 0``). Already-submitted and
   cancelled docs are refused.
-- ``doc.submit()`` re-runs validate() — DocType business rules still apply,
+- ``doc.submit()`` re-runs validate() - DocType business rules still apply,
   and a missing required field or broken link will reject the submission.
 """
 
@@ -52,7 +52,7 @@ def submit_doc(doctype: str, name: str) -> dict:
     meta = frappe.get_meta(doctype)
     if not meta.is_submittable:
         raise InvalidArgumentError(
-            f"{doctype} is not submittable — submit only applies to "
+            f"{doctype} is not submittable - submit only applies to "
             f"docstatus-tracked DocTypes"
         )
 

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -2,20 +2,20 @@
 
 This is the first **mutating** tool in Jarvis. Every guarantee that the
 read tools rely on (per-user permissions, no leakage, etc.) carries over
-to writes — Frappe's permission engine checks ``write`` on the target
+to writes - Frappe's permission engine checks ``write`` on the target
 DocType + record, not just ``read``.
 
 Safety bounds enforced here (on top of Frappe's standard validation):
 
 - Calling user must have ``write`` permission on the target record
   (``frappe.has_permission(doctype, ptype="write", doc=name)``)
-- A small allow-list of mutable fields is NOT used — Frappe itself
+- A small allow-list of mutable fields is NOT used - Frappe itself
   enforces field-level permissions and DocType-level read_only flags
 - System fields (``name``, ``owner``, ``creation``, ``modified``,
   ``modified_by``, ``doctype``, ``docstatus``, ``idx``, ``parent``,
-  ``parentfield``, ``parenttype``) are refused — they're maintained by
+  ``parentfield``, ``parenttype``) are refused - they're maintained by
   Frappe, not user-editable, and an LLM shouldn't be poking at them
-- ``docstatus`` changes are refused — submit/cancel/amend go through
+- ``docstatus`` changes are refused - submit/cancel/amend go through
   dedicated workflows (future tools), not raw field writes
 - Empty ``changes`` dict is refused so the agent doesn't accidentally
   call this with no-op intent


### PR DESCRIPTION
Mechanical replace of U+2014 (em-dash) -> hyphen across the jarvis app: docstrings, comments, customer-app/* docs (light review pass on those), JS strings, CSS comments, doctype field descriptions, all of it.

68 files touched, no behavior change. Tests still 85/85 green.

Why: project-wide style preference logged in auto-memory 2026-06-02.