### PR TITLE
feat(chat): banner the user to refresh after a bench build

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -5,10 +5,48 @@ The browser talks to these from the /app/jarvis-chat Desk page.
 
 from __future__ import annotations
 
+import json
+import os
+
 import frappe
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
+
+# Process-local cache for the chat bundle hash. Invalidated by mtime so a
+# `bench build` is picked up without restarting workers.
+_BUILD_ID_CACHE: dict = {"mtime": 0.0, "value": ""}
+
+
+def _get_build_id() -> str:
+	"""Return the current chat bundle hash (e.g. "PY42KOXK").
+
+	Reads sites/assets/assets.json and pulls the hashed filename for
+	jarvis_chat.bundle.js. The hash changes on every `bench build`, so a
+	mismatch with what the browser captured at page load means the bundle
+	has been rebuilt - banner the user to refresh.
+
+	Returns "" if the asset map is missing (dev bench before first build).
+	"""
+	path = os.path.join(frappe.utils.get_bench_path(), "sites", "assets", "assets.json")
+	try:
+		mtime = os.path.getmtime(path)
+	except OSError:
+		return ""
+	if mtime == _BUILD_ID_CACHE["mtime"] and _BUILD_ID_CACHE["value"]:
+		return _BUILD_ID_CACHE["value"]
+	try:
+		with open(path) as f:
+			data = json.load(f)
+	except (OSError, ValueError):
+		return ""
+	# Entry looks like "/assets/jarvis/dist/js/jarvis_chat.bundle.PY42KOXK.js".
+	entry = data.get("jarvis_chat.bundle.js") or ""
+	# Last path component, drop the .js suffix.
+	value = os.path.basename(entry).removesuffix(".js")
+	_BUILD_ID_CACHE["mtime"] = mtime
+	_BUILD_ID_CACHE["value"] = value
+	return value
 
 # Subscription-tier model IDs accepted by codex / gemini-cli's auth tunnel.
 # These are CLI-specific names (NOT OpenAI's API names like "gpt-4o").
@@ -230,7 +268,16 @@ def get_chat_ui_settings() -> dict:
 		"llm_provider": settings.llm_provider or "",
 		"llm_model": settings.llm_model or "",
 		"subscription_models": _SUBSCRIPTION_MODELS,
+		"build_id": _get_build_id(),
 	}
+
+
+@frappe.whitelist()
+def get_build_id() -> dict:
+	"""Cheap endpoint the chat UI polls on tab refocus to detect a stale
+	JS bundle after a `bench build`. Returns {"build_id": "<hash>"}.
+	"""
+	return {"build_id": _get_build_id()}
 
 
 @frappe.whitelist()

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -768,6 +768,24 @@
 	to { transform: rotate(360deg); }
 }
 
+/* ---- Stale-bundle banner ------------------------------------ */
+
+.jarvis-stale-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 8px 16px;
+	background: var(--yellow-50, #fef7e0);
+	border-bottom: 1px solid var(--yellow-200, #f4d35e);
+	color: var(--text-color);
+	font-size: 13px;
+}
+
+.jarvis-stale-banner[hidden] { display: none; }
+
+.jarvis-stale-banner-text { flex: 1; }
+
 /* ---- Conversation toolbar (model picker) -------------------- */
 
 .jarvis-conv-toolbar {

--- a/jarvis/public/js/jarvis_chat/api.js
+++ b/jarvis/public/js/jarvis_chat/api.js
@@ -54,6 +54,11 @@ export async function getChatUiSettings() {
 	return r.message || {};
 }
 
+export async function getBuildId() {
+	const r = await frappe.call({ method: "jarvis.chat.api.get_build_id" });
+	return (r.message && r.message.build_id) || "";
+}
+
 export async function setConversationModel(conversation, model) {
 	const r = await frappe.call({
 		method: "jarvis.chat.api.set_conversation_model",

--- a/jarvis/public/js/jarvis_chat/index.js
+++ b/jarvis/public/js/jarvis_chat/index.js
@@ -414,6 +414,30 @@ export function init(wrapper) {
 
 	attachRealtime({ $list, $thinking, scrollToBottom, loadConversation });
 
+	// ---- Stale-bundle detection ----------------------------------------
+	//
+	// Captured build_id arrives via getChatUiSettings() below. When the tab
+	// regains focus we re-fetch and, if the server is now shipping a
+	// different bundle, banner the user. Refresh is a one-click resolution.
+	const $staleBanner = root.find(".jarvis-stale-banner");
+	root.find(".jarvis-stale-refresh").on("click", () => window.location.reload());
+
+	async function checkBuildFreshness() {
+		if (!state.build_id) return; // didn't capture a baseline yet
+		try {
+			const current = await api.getBuildId();
+			if (current && current !== state.build_id) {
+				$staleBanner.prop("hidden", false);
+			}
+		} catch (_) {
+			// Transient failure - silently retry next refocus.
+		}
+	}
+
+	document.addEventListener("visibilitychange", () => {
+		if (document.visibilityState === "visible") checkBuildFreshness();
+	});
+
 	// ---- Bootstrap ------------------------------------------------------
 
 	// Deep-link: if the URL carries a conversation name (e.g.
@@ -429,6 +453,7 @@ export function init(wrapper) {
 			state.llm_provider = s.llm_provider || "";
 			state.llm_model = s.llm_model || "";
 			state.subscription_models = s.subscription_models || {};
+			state.build_id = s.build_id || "";
 			rebuildModelPickerOptions();
 			refreshModelPickerVisibility();
 		} catch (e) {

--- a/jarvis/public/js/jarvis_chat/state.js
+++ b/jarvis/public/js/jarvis_chat/state.js
@@ -20,4 +20,9 @@ export const state = {
 	// Per-conversation model override mirror - refreshed each loadConversation.
 	// Empty string means "use llm_model default".
 	current_model_override: "",
+
+	// Bundle hash captured at page load. When a re-check on tab refocus
+	// returns a different hash, the JS the user is running is older than
+	// what the server now ships - banner asks for a refresh.
+	build_id: "",
 };

--- a/jarvis/public/js/jarvis_chat/template.js
+++ b/jarvis/public/js/jarvis_chat/template.js
@@ -15,6 +15,12 @@ export const PAGE_HTML = `
   </aside>
 
   <main class="jarvis-chat-main">
+    <div class="jarvis-stale-banner" hidden>
+      <span class="jarvis-stale-banner-text">
+        Jarvis has been updated. Refresh to load the latest version.
+      </span>
+      <button class="btn btn-xs btn-primary jarvis-stale-refresh">Refresh</button>
+    </div>
     <div class="jarvis-conv-toolbar" hidden>
       <label class="jarvis-model-picker-label" for="jarvis-model-picker">Model</label>
       <select id="jarvis-model-picker" class="jarvis-model-picker"></select>

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -526,3 +526,48 @@ class TestSendMessageWithModelOverride(_ChatTestCase):
 			frappe.db.get_value(CONV, self.conv, "model_override"),
 			"gpt-5.4",
 		)
+
+
+class TestBuildId(FrappeTestCase):
+	"""build_id powers the stale-bundle banner: chat UI captures it on
+	load, refetches on tab refocus, banners on mismatch."""
+
+	def test_get_build_id_returns_string(self):
+		from jarvis.chat.api import get_build_id
+		r = get_build_id()
+		self.assertIn("build_id", r)
+		self.assertIsInstance(r["build_id"], str)
+
+	def test_get_chat_ui_settings_includes_build_id(self):
+		from jarvis.chat.api import get_chat_ui_settings
+		s = get_chat_ui_settings()
+		self.assertIn("build_id", s)
+		self.assertIsInstance(s["build_id"], str)
+
+	def test_build_id_matches_assets_json(self):
+		"""When sites/assets/assets.json exists, build_id is derived from
+		the hashed jarvis_chat.bundle.js filename (no extension)."""
+		import json
+		import os
+		from jarvis.chat.api import _get_build_id, _BUILD_ID_CACHE
+		path = os.path.join(
+			frappe.utils.get_bench_path(), "sites", "assets", "assets.json"
+		)
+		if not os.path.exists(path):
+			self.skipTest("assets.json missing (build hasn't run)")
+		with open(path) as f:
+			data = json.load(f)
+		entry = data.get("jarvis_chat.bundle.js") or ""
+		if not entry:
+			self.skipTest("jarvis_chat bundle not in asset map")
+		_BUILD_ID_CACHE["mtime"] = 0.0  # force re-read
+		expected = os.path.basename(entry).removesuffix(".js")
+		self.assertEqual(_get_build_id(), expected)
+
+	def test_get_build_id_returns_empty_when_assets_missing(self):
+		"""Graceful degradation: if assets.json is unreadable, return ""
+		so the UI just doesn't enable the banner (rather than crashing)."""
+		from jarvis.chat.api import _get_build_id, _BUILD_ID_CACHE
+		with patch("os.path.getmtime", side_effect=OSError):
+			_BUILD_ID_CACHE["mtime"] = 0.0
+			self.assertEqual(_get_build_id(), "")


### PR DESCRIPTION
When `bench build` ships a new jarvis_chat bundle the open browser tab is still running the old JS, which yesterday's debugging showed up as "I sent a message and got no response" - the worker had written the reply, but the stale bundle's realtime wiring didn't render it.

This adds a cheap freshness check:
- get_chat_ui_settings now returns build_id (the hashed bundle filename from sites/assets/assets.json, e.g. "jarvis_chat.bundle.PY42KOXK")
- New whitelisted endpoint get_build_id() returns just the hash; cached in-process with mtime invalidation so calls are near-free
- Chat UI captures build_id on init, re-fetches on `visibilitychange` to visible, and shows a non-dismissible yellow banner with a Refresh button when the hash differs

Graceful degradation: if assets.json is missing or unreadable (dev bench pre-first-build), build_id is "" and the banner stays disabled.

Tests: 4 new (TestBuildId), 89/89 green.