### PR TITLE
fix(chat): sidebar conversation list scrolls when many conversations

### DIFF
--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.css
@@ -86,6 +86,7 @@
 	display: flex;
 	flex-direction: column;
 	min-width: 0;
+	min-height: 0;  /* required so .jarvis-conversation-list (overflow:auto) can scroll when there are many conversations */
 }
 
 .jarvis-sidebar-header {


### PR DESCRIPTION
.jarvis-chat-sidebar was missing min-height: 0. CSS grid items default to min-height: auto, which lets the sidebar expand to fit its content (the conversation list) instead of constraining it to the grid row's height. The flex:1 + overflow-y:auto on .jarvis-conversation-list never triggered because the parent had no max height.

.jarvis-chat-main already had this fix (with the same explanatory comment); the sidebar was just inconsistent. One-line addition.