### PR TITLE
feat(chat): redirect to /jarvis-onboarding when not configured

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -35,6 +35,57 @@ def is_onboarded() -> dict:
 
 
 @frappe.whitelist()
+def is_ready_for_chat() -> dict:
+	"""Pre-flight check used by /jarvis-chat's page load to decide whether to
+	render the chat surface or redirect the customer to /jarvis-onboarding.
+
+	Stricter than ``is_onboarded`` - signup (admin api_key) AND a usable LLM
+	credential for the active ``llm_auth_mode`` must be in place. Pool-pending
+	customers count as ready here (the chat surface has its own waiting state
+	while the tenant is being provisioned).
+
+	Returns ``{ready: bool, reason: str | None}`` where ``reason`` is one of:
+
+	- ``"signup"`` - jarvis_admin_api_key is empty (customer hasn't completed
+	  the wizard's signup step).
+	- ``"llm_credentials"`` - signup done, but LLM creds for the active
+	  auth mode are missing. api_key mode needs llm_api_key + llm_provider +
+	  llm_model; subscription / oauth modes need llm_oauth_connected_at
+	  (the timestamp set when the oauth grant completes).
+	- ``None`` when ``ready`` is True.
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+
+	admin_api_key = (settings.get_password(
+		"jarvis_admin_api_key", raise_exception=False,
+	) or "").strip()
+	if not admin_api_key:
+		return {"ready": False, "reason": "signup"}
+
+	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
+
+	if auth_mode == "api_key":
+		llm_key = (settings.get_password(
+			"llm_api_key", raise_exception=False,
+		) or "").strip()
+		provider = (getattr(settings, "llm_provider", "") or "").strip()
+		model = (getattr(settings, "llm_model", "") or "").strip()
+		if not (llm_key and provider and model):
+			return {"ready": False, "reason": "llm_credentials"}
+	elif auth_mode in ("subscription", "oauth"):
+		# Both modes use the same local signal: llm_oauth_connected_at is
+		# set (read-only) when the oauth grant completes and the admin
+		# pushes the auth-profile blob to the container.
+		if not getattr(settings, "llm_oauth_connected_at", None):
+			return {"ready": False, "reason": "llm_credentials"}
+	else:
+		# Unknown auth_mode - treat as misconfigured; the wizard owns it.
+		return {"ready": False, "reason": "llm_credentials"}
+
+	return {"ready": True, "reason": None}
+
+
+@frappe.whitelist()
 def get_account() -> dict:
 	"""Plan + validity + upgrade-eligible plans for the account page."""
 	return _surface(admin_client.get_account_summary)

--- a/jarvis/jarvis/page/jarvis_chat/jarvis_chat.js
+++ b/jarvis/jarvis/page/jarvis_chat/jarvis_chat.js
@@ -1,12 +1,42 @@
 // Thin Desk-page entrypoint. The real implementation lives in the
 // jarvis_chat bundle so it can be split into modules.
+//
+// Before loading the chat bundle, gate on jarvis.account.is_ready_for_chat:
+// if the customer hasn't completed signup OR hasn't configured their LLM
+// credentials for the active auth mode, redirect to /jarvis-onboarding so the
+// wizard can collect what's missing. The chat surface assumes both signup
+// and LLM credentials are in place, so failing the check would just produce
+// confusing errors at first-message time.
+//
+// Network failures fetching the check are NOT trapped here - we fall through
+// to loading the bundle so a transient blip doesn't trap users on the
+// onboarding page.
 
 frappe.pages["jarvis-chat"].on_page_load = function (wrapper) {
-	frappe.require("jarvis_chat.bundle.js").then(() => {
-		if (!window.JarvisChat || typeof window.JarvisChat.init !== "function") {
-			frappe.msgprint(__("Jarvis chat bundle failed to load. Run `bench build`."));
-			return;
-		}
-		window.JarvisChat.init(wrapper);
-	});
+	frappe.call({ method: "jarvis.account.is_ready_for_chat" })
+		.then((r) => {
+			if (r && r.message && r.message.ready === false) {
+				window.location.assign("/app/jarvis-onboarding");
+				return null;
+			}
+			return frappe.require("jarvis_chat.bundle.js").then(() => {
+				if (!window.JarvisChat || typeof window.JarvisChat.init !== "function") {
+					frappe.msgprint(__("Jarvis chat bundle failed to load. Run `bench build`."));
+					return;
+				}
+				window.JarvisChat.init(wrapper);
+			});
+		})
+		.catch(() => {
+			// Network / server hiccup on the preflight. Fall through to the
+			// chat bundle - if the customer really isn't set up the chat code
+			// will surface a friendlier error than an opaque redirect.
+			return frappe.require("jarvis_chat.bundle.js").then(() => {
+				if (!window.JarvisChat || typeof window.JarvisChat.init !== "function") {
+					frappe.msgprint(__("Jarvis chat bundle failed to load. Run `bench build`."));
+					return;
+				}
+				window.JarvisChat.init(wrapper);
+			});
+		});
 };


### PR DESCRIPTION
When the customer opens /app/jarvis-chat without having completed signup OR without LLM credentials configured for their active auth_mode, the chat page fails awkwardly at first-message time (no API key, no oauth profile, etc.). Detect the situation up front and redirect to /jarvis-onboarding so the wizard collects what's missing - mirrors the existing redirect pattern in /jarvis-account.

Server side: new whitelisted method jarvis.account.is_ready_for_chat() returns {ready, reason}. The check is local-only (no admin round-trip) and covers all three llm_auth_mode values:

- api_key mode: requires llm_api_key + llm_provider + llm_model
- subscription / oauth modes: require llm_oauth_connected_at (the read-only timestamp set when the oauth grant completes)
- unknown auth_mode: treat as misconfigured (the wizard owns it)

Pool-pending customers (signup + LLM done but no tenant yet) count as ready - the chat surface has its own waiting state for that transient state; a redirect to onboarding wouldn't help.

is_ready_for_chat is stricter than the existing is_onboarded (which checks only the admin api_key for signup completion). Kept the two endpoints separate rather than overloading is_onboarded - the account page's redirect semantics shouldn't change with this PR.

Client side: jarvis_chat.js gains a preflight frappe.call before loading the chat bundle. On a false result -> window.location to /app/jarvis-onboarding. On a network / server error fetching the preflight, fall through to loading the bundle (don't trap users on a transient hiccup).