### PR TITLE
feat(onboarding): async container provisioning + polling UI

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -66,13 +66,35 @@ class JarvisSettings(Document):
         action = self._classify_llm_change()
         if action is None:
             return
-        # Unified architecture (post-2026-05-29): on_update always routes
-        # through admin → fleet-agent → container. Local-dev runs admin +
-        # fleet-agent on the same machine; there is no longer a bench-
-        # local push shortcut. If admin isn't configured, _sync_via_admin
-        # fails with AdminAuthError - the right error for "this workspace
-        # isn't set up; run bootstrap_host then dev_onboard."
-        self._sync_via_admin(action)
+        # Async path (2026-06-09): a container restart can take 30-60s on
+        # the admin side waiting for healthz to come back up. Blocking the
+        # save call for that long stalls the onboarding UI and feels
+        # broken. Instead, mark the status as "pending: ..." synchronously
+        # so the UI can render a "provisioning..." state, then enqueue the
+        # real admin call on the long queue. The UI polls
+        # ``onboarding.get_llm_sync_status`` until the status flips from
+        # ``pending:`` to ``ok ...`` or ``failed: ...``.
+        pending_label = (
+            "pending: provisioning container"
+            if action == "restart"
+            else "pending: rotating credentials"
+        )
+        self.db_set("last_sync_status", pending_label, update_modified=False)
+        # In tests, run inline so existing assertions on the final status
+        # don't have to poll. Set ``frappe.flags.run_admin_sync_inline``
+        # from app code that needs the synchronous behavior (rare).
+        run_inline = bool(
+            frappe.flags.in_test or frappe.flags.run_admin_sync_inline
+        )
+        frappe.enqueue(
+            "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+            "._enqueued_sync_via_admin",
+            queue="long",
+            timeout=120,
+            enqueue_after_commit=not run_inline,
+            now=run_inline,
+            action=action,
+        )
 
     def _sync_via_admin(self, action: str) -> None:
         """Prod path: route LLM creds through admin → fleet → openclaw container.
@@ -159,3 +181,18 @@ class JarvisSettings(Document):
             return "reload"
 
         return None
+
+
+def _enqueued_sync_via_admin(action: str) -> None:
+    """Background-queue wrapper: re-load Jarvis Settings + run _sync_via_admin.
+
+    Loading a fresh Single is necessary because the queue worker runs in a
+    separate request context - we can't pass the Document instance across
+    the queue boundary safely.
+
+    Updates ``last_sync_status`` from ``pending: ...`` to either
+    ``ok (... via admin)`` or ``failed: ...`` - the UI polls
+    ``onboarding.get_llm_sync_status`` to observe the transition.
+    """
+    settings = frappe.get_single("Jarvis Settings")
+    settings._sync_via_admin(action)

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -560,9 +560,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				method: "jarvis.onboarding.save_llm_creds",
 				args: { provider, model, api_key: key || "", base_url: base, auth_mode: "api_key" },
 			}).then((r) => {
-				setBusy("#ja-llm-save", false);
 				const status = (r.message && r.message.last_sync_status) || "";
-				$body.find(".ja-llm-status").text(status ? "Last sync: " + status : "Saved.");
 				const wasOauth = settingsLocal.llm_auth_mode === "oauth";
 				settingsLocal.llm_provider = provider;
 				settingsLocal.llm_model = model;
@@ -571,14 +569,62 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				settingsLocal.llm_auth_mode = "api_key";
 				settingsLocal.last_sync_status = status;
 				$body.find("#ja-key").val("");
-				// If we just flipped out of oauth mode, re-render so the
-				// "current mode" pill and notice banner update correctly.
-				if (wasOauth) render();
+				// 2026-06-09: on_update is async - the save returns
+				// "pending: ..." while the admin restart runs in the
+				// background. Poll until the status flips to ok/failed.
+				if (status.startsWith("pending:")) {
+					$body.find(".ja-llm-status").text("Provisioning... " + status.replace(/^pending:\s*/i, ""));
+					pollLlmSyncStatus({ wasOauth });
+				} else {
+					setBusy("#ja-llm-save", false);
+					$body.find(".ja-llm-status").text(status ? "Last sync: " + status : "Saved.");
+					// If we just flipped out of oauth mode, re-render so the
+					// "current mode" pill and notice banner update correctly.
+					if (wasOauth) render();
+				}
 			}).catch((e) => {
 				setBusy("#ja-llm-save", false);
 				$body.find("#ja-llm-err").text(e.message || "Save failed.");
 			});
 		});
+	}
+
+	function pollLlmSyncStatus({ wasOauth }) {
+		// On_update is async - poll get_llm_sync_status until the status
+		// flips from "pending: ..." to "ok ..." / "failed: ...". Admin's
+		// healthz timeout is 60s; we cap at 150s for slack.
+		const startedAt = Date.now();
+		const TIMEOUT_MS = 150 * 1000;
+		const tick = () => {
+			frappe.call({ method: "jarvis.onboarding.get_llm_sync_status" })
+				.then((r) => {
+					const m = r.message || {};
+					const status = (m.last_sync_status || "").trim();
+					settingsLocal.last_sync_status = status;
+					if (!m.pending) {
+						setBusy("#ja-llm-save", false);
+						$body.find(".ja-llm-status").text(status ? "Last sync: " + status : "Saved.");
+						if (wasOauth) render();
+						return;
+					}
+					if (Date.now() - startedAt > TIMEOUT_MS) {
+						setBusy("#ja-llm-save", false);
+						$body.find(".ja-llm-status").text("Still provisioning - check back in a moment.");
+						return;
+					}
+					$body.find(".ja-llm-status").text("Provisioning... " + status.replace(/^pending:\s*/i, ""));
+					setTimeout(tick, 2500);
+				})
+				.catch(() => {
+					if (Date.now() - startedAt > TIMEOUT_MS) {
+						setBusy("#ja-llm-save", false);
+						$body.find(".ja-llm-status").text("Lost contact while provisioning - refresh later.");
+						return;
+					}
+					setTimeout(tick, 2500);
+				});
+		};
+		setTimeout(tick, 2500);
 	}
 
 	// ---- billing section --------------------------------------------------

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -496,13 +496,71 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 				base_url: state.llmBaseUrl.trim(),
 			},
 		}).then((r) => {
-			setBusy("#jo-llm-save", false);
 			const m = r.message || {};
-			renderSuccess(state.successData || {}, m.last_sync_status || "");
+			const status = (m.last_sync_status || "").trim();
+			// 2026-06-09: on_update is now async - the save call returns
+			// immediately with "pending: ..." while the admin restart
+			// runs in the background. Poll for the final status.
+			if (status.startsWith("pending:")) {
+				pollSyncStatus(status);
+			} else {
+				setBusy("#jo-llm-save", false);
+				renderSuccess(state.successData || {}, status);
+			}
 		}).catch((e) => {
 			setBusy("#jo-llm-save", false);
 			$err.text(e.message || "Couldn't save LLM settings. Please try again.");
 		});
+	}
+
+	function pollSyncStatus(initialStatus) {
+		// Render an in-place "provisioning" panel before polling. Keep the
+		// save button busy throughout so the user can't double-submit.
+		renderProvisioning(initialStatus);
+		const startedAt = Date.now();
+		// Admin's healthz timeout is 60s; bench round-trip + buffer ≈ 90s.
+		// Cap at 150s so we surface a graceful "still working" state even
+		// if the container is unusually slow to come back up.
+		const TIMEOUT_MS = 150 * 1000;
+		const tick = () => {
+			frappe.call({ method: "jarvis.onboarding.get_llm_sync_status" })
+				.then((r) => {
+					const m = r.message || {};
+					const status = (m.last_sync_status || "").trim();
+					if (!m.pending) {
+						setBusy("#jo-llm-save", false);
+						renderSuccess(state.successData || {}, status);
+						return;
+					}
+					if (Date.now() - startedAt > TIMEOUT_MS) {
+						setBusy("#jo-llm-save", false);
+						renderSuccess(state.successData || {}, status || "pending: container still provisioning");
+						return;
+					}
+					setTimeout(tick, 2500);
+				})
+				.catch(() => {
+					// Polling failure is transient - keep trying until timeout.
+					if (Date.now() - startedAt > TIMEOUT_MS) {
+						setBusy("#jo-llm-save", false);
+						renderSuccess(state.successData || {}, "pending: lost contact while provisioning");
+						return;
+					}
+					setTimeout(tick, 2500);
+				});
+		};
+		setTimeout(tick, 2500);
+	}
+
+	function renderProvisioning(status) {
+		const label = (status || "").replace(/^pending:\s*/i, "") || "provisioning your agent";
+		$body.html(`
+			<div class="jo-success">
+			  <div class="jo-success-ring jo-spinner-ring">↻</div>
+			  <h2 class="jo-h">Spinning up your Jarvis agent...</h2>
+			  <p class="jo-sub">${esc(label.charAt(0).toUpperCase() + label.slice(1))}. This usually takes around 30 seconds.</p>
+			  <p class="jo-sub" style="margin-top:8px;font-size:12px;opacity:.7">Don't close this tab.</p>
+			</div>`);
 	}
 
 	function renderSuccess(data, syncStatus, extra) {
@@ -708,6 +766,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		.jo-success{text-align:center;padding:18px 0}
 		.jo-success-ring{width:64px;height:64px;border-radius:50%;background:rgba(46,189,89,.14);color:var(--green-600,#28a745);
 			font-size:30px;display:flex;align-items:center;justify-content:center;margin:0 auto 16px}
+		.jo-spinner-ring{background:rgba(99,102,241,.14);color:var(--jarvis-primary,#5b6bff);animation:jo-spin 1.4s linear infinite}
 		.jo-success .jo-actions{justify-content:center}
 		.jo-spin{display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,.5);border-top-color:#fff;
 			border-radius:50%;animation:jo-spin .6s linear infinite;vertical-align:-1px}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -118,6 +118,31 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 
 
 @frappe.whitelist()
+def get_llm_sync_status() -> dict:
+	"""Lightweight poller for the onboarding + account pages.
+
+	``Jarvis Settings.on_update`` writes ``last_sync_status = 'pending: ...'``
+	synchronously, then enqueues the heavy admin call. When the background
+	job finishes, the status flips to ``ok (... via admin)`` or
+	``failed: ...``. The UI polls this method every few seconds to observe
+	that transition.
+
+	Returns:
+	    A dict with ``last_sync_at`` (ISO string or ""), ``last_sync_status``
+	    (e.g. ``pending: provisioning container``, ``ok (restart via admin)``,
+	    ``failed: admin unreachable: ...``), and a convenience boolean
+	    ``pending`` for client-side branching.
+	"""
+	s = frappe.get_single("Jarvis Settings")
+	status = s.get("last_sync_status") or ""
+	return {
+		"last_sync_at": str(s.get("last_sync_at") or ""),
+		"last_sync_status": status,
+		"pending": status.startswith("pending:"),
+	}
+
+
+@frappe.whitelist()
 def dev_onboard(email: str, company: str, plan: str) -> dict:
 	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection.
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -171,3 +171,46 @@ class TestSyncConnection(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			onboarding.save_llm_creds(provider="OpenAI", model="gpt-4o",
 			                          api_key="", auth_mode="token")
+
+
+class TestGetLlmSyncStatus(FrappeTestCase):
+	"""The polling endpoint that the onboarding + account pages hit while
+	the background admin sync is running."""
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		_set_token("admin-key")
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+
+	def test_returns_pending_true_when_status_starts_with_pending(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "pending: provisioning container",
+		         update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(out["last_sync_status"], "pending: provisioning container")
+		self.assertTrue(out["pending"])
+
+	def test_returns_pending_false_for_ok_status(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "ok (restart via admin)",
+		         update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertFalse(out["pending"])
+
+	def test_returns_pending_false_for_failed_status(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", "failed: admin unreachable: boom",
+		         update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertFalse(out["pending"])
+
+	def test_shape_has_expected_keys(self):
+		out = onboarding.get_llm_sync_status()
+		self.assertIn("last_sync_at", out)
+		self.assertIn("last_sync_status", out)
+		self.assertIn("pending", out)

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -416,3 +416,63 @@ class TestSyncViaAdminDispatch(_SettingsSingletonTestCase):
         settings.reload()
         self.assertIn("failed", settings.last_sync_status or "")
         self.assertIn("auth", settings.last_sync_status or "")
+
+
+class TestOnUpdateAsyncPending(_SettingsSingletonTestCase):
+    """The async path writes ``last_sync_status = 'pending: ...'``
+    synchronously, then enqueues the admin call. In tests we normally run
+    the enqueue inline (via ``frappe.flags.in_test``), so the final status
+    overwrites the pending marker. This class explicitly stops the inline
+    behavior to verify the intermediate "pending:" write happens BEFORE
+    ``_sync_via_admin`` fires."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_settings()
+
+    def test_pending_status_written_before_enqueue_for_reload(self):
+        seen = []
+
+        def capture_pending(*args, **kwargs):
+            # Called from _enqueued_sync_via_admin via frappe.enqueue(now=True).
+            # By the time this runs, the synchronous "pending:" db_set in
+            # on_update should already be persisted.
+            settings = frappe.get_single("Jarvis Settings")
+            seen.append(settings.last_sync_status)
+            # Now simulate the admin call's final status write.
+            settings.db_set("last_sync_status", "ok (reload via admin)",
+                            update_modified=False)
+            return {"action": "reload"}
+
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_api_key = "sk-rotation"
+        with patch("jarvis.admin_client.post_rotate_llm_secret",
+                   side_effect=capture_pending):
+            settings.save()
+        self.assertEqual(len(seen), 1)
+        self.assertTrue(
+            (seen[0] or "").startswith("pending: rotating credentials"),
+            f"expected 'pending: rotating credentials', got {seen[0]!r}",
+        )
+
+    def test_pending_status_written_before_enqueue_for_restart(self):
+        seen = []
+
+        def capture_pending(*args, **kwargs):
+            settings = frappe.get_single("Jarvis Settings")
+            seen.append(settings.last_sync_status)
+            settings.db_set("last_sync_status", "ok (restart via admin)",
+                            update_modified=False)
+            return {"action": "restart"}
+
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_provider = "Anthropic"
+        settings.llm_model = "claude-sonnet-4-6"
+        with patch("jarvis.admin_client.post_update_llm_creds",
+                   side_effect=capture_pending):
+            settings.save()
+        self.assertEqual(len(seen), 1)
+        self.assertTrue(
+            (seen[0] or "").startswith("pending: provisioning container"),
+            f"expected 'pending: provisioning container', got {seen[0]!r}",
+        )


### PR DESCRIPTION
Submitting an API key in onboarding was blocking the UI for 30-60s while admin restarted the openclaw container and waited for healthz to come back up. The HTTP request would appear to hang, with no progress affordance.

Backend (jarvis_settings.JarvisSettings.on_update):
- Writes ``last_sync_status = "pending: provisioning container"`` (restart action) or ``"pending: rotating credentials"`` (reload action) synchronously via db_set.
- Enqueues the real admin call (``_sync_via_admin``) on the long queue with ``enqueue_after_commit=True``. The worker loads a fresh Jarvis Settings Single and updates ``last_sync_status`` to ``ok (... via admin)`` or ``failed: ...`` when admin responds.
- Tests still see synchronous behavior via ``frappe.flags.in_test`` -> ``now=True`` on enqueue. New ``frappe.flags.run_admin_sync_inline`` flag for any future callers that need the sync semantics explicitly.

Polling endpoint (jarvis.onboarding.get_llm_sync_status):
- Lightweight whitelisted method that returns ``{last_sync_at, last_sync_status, pending}`` from the Single. The ``pending`` boolean is true iff ``last_sync_status`` starts with ``"pending:"``.

Onboarding UI (jarvis_onboarding.js):
- After saveLlm returns ``pending: ...``, render a "Spinning up your Jarvis agent..." panel and start polling every 2.5s. When the status flips, transition into the existing renderSuccess flow.
- 150s timeout cap (60s admin healthz + ~90s slack) shows a graceful "still provisioning" message if the container is unusually slow.
- New ``.jo-spinner-ring`` class reuses the existing jo-success-ring shape with a rotation animation.

Account UI (jarvis_account.js):
- Same polling pattern on the LLM credential save. The status line text becomes "Provisioning... <reason>" while pending, then "Last sync: ok (...)" or the failure when done. Defers the oauth-mode re-render until polling completes so the "current mode" pill doesn't flip prematurely.

Tests:
- 4 new tests for get_llm_sync_status (pending/ok/failed shapes + key presence).
- 2 new tests for on_update writing "pending: ..." synchronously before _sync_via_admin runs. These use the side_effect of the mocked admin client to peek at last_sync_status mid-flight.
- All existing on_update tests pass without modification - in_test mode runs the enqueue inline so assertions on final status still see "ok (...)".