### PR TITLE
fix(chat/worker): send openclaw's mapped model-provider key, not the

### DIFF
--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -18,14 +18,28 @@ from jarvis.exceptions import OpenclawUnreachableError
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 
-# Provider label → openclaw provider id. Mirrors _PROVIDER_LABEL_TO_OPENCLAW
-# in jarvis.oauth.api. Only used in oauth mode - api_key mode has no
-# per-tenant codex/gemini-cli provider to override against, so we leave
-# the provider param off the WS frame and openclaw falls back to its
-# single registered models.providers.<id> entry.
+# Provider label → openclaw MODEL-provider id (the key under
+# models.providers.<id> in the container's openclaw.json).
+#
+# This is distinct from the OAuth flow identifier (openai-codex /
+# google-gemini-cli) used in auth.profiles[].provider. Openclaw's codex
+# and gemini agent runtimes accept only their respective allowlists for
+# the model-provider key ({codex, openai} / {google, gemini}) - passing
+# the OAuth flow id at request time yields:
+#   "Run error: Unknown model: openai-codex/<model>" or
+#   "Requested agent harness 'codex' does not support openai-codex/<model>"
+#
+# The fleet-agent's openclaw.json template (since
+# fix/oauth-model-provider-key) emits the mapped key in models.providers,
+# so the chat WS frame must use the same name.
+#
+# Only used in oauth mode - api_key mode has no per-tenant
+# codex/gemini-cli provider to override against, so we leave the provider
+# param off the WS frame and openclaw falls back to its single registered
+# models.providers.<id> entry.
 _PROVIDER_LABEL_TO_OPENCLAW_ID = {
-	"OpenAI": "openai-codex",
-	"Google Gemini": "google-gemini-cli",
+	"OpenAI": "openai",
+	"Google Gemini": "google",
 }
 
 

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -266,7 +266,10 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 		call = self._run_and_capture()
 		kwargs = call.kwargs
 		self.assertEqual(kwargs.get("model"), "gpt-5.5")
-		self.assertEqual(kwargs.get("provider"), "openai-codex")
+		# Maps to openclaw's model-provider key, not the OAuth flow id
+		# (which is "openai-codex"). See _PROVIDER_LABEL_TO_OPENCLAW_ID
+		# in chat/worker.py for the rationale.
+		self.assertEqual(kwargs.get("provider"), "openai")
 
 	def test_override_used_when_set(self):
 		"""conv.model_override = gpt-5.4-mini → effective_model = gpt-5.4-mini."""
@@ -275,7 +278,10 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 		call = self._run_and_capture()
 		kwargs = call.kwargs
 		self.assertEqual(kwargs.get("model"), "gpt-5.4-mini")
-		self.assertEqual(kwargs.get("provider"), "openai-codex")
+		# Maps to openclaw's model-provider key, not the OAuth flow id
+		# (which is "openai-codex"). See _PROVIDER_LABEL_TO_OPENCLAW_ID
+		# in chat/worker.py for the rationale.
+		self.assertEqual(kwargs.get("provider"), "openai")
 
 
 class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):


### PR DESCRIPTION
OAuth flow id

Openclaw's codex agent runtime accepts only {codex, openai} as the model-provider; passing the OAuth flow id ("openai-codex") yields:

  Run error: Unknown model: openai-codex/gpt-4o
  (or "harness 'codex' does not support openai-codex/<model>")

The fleet-agent's openclaw.json template (since
fix/oauth-model-provider-key) already emits the mapped key in models.providers.<openai>. The chat WS frame must use the same name, so update the customer-side label→openclaw map:

  OpenAI         → "openai"  (was "openai-codex")
  Google Gemini  → "google"  (was "google-gemini-cli")

The OAuth flow itself (provider login, auth.profiles[].provider on admin/fleet-agent side) still uses "openai-codex" / "google-gemini-cli"
- that's a separate identifier with a different purpose.