### PR TITLE
fix(oauth): push OAuth blob under the mapped model-provider name

### DIFF
--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -20,7 +20,14 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		"token":     "https://auth.openai.com/oauth/token",
 		"userinfo":  "https://api.openai.com/v1/userinfo",
 		"scope":     "openid profile email offline_access api.connectors.read api.connectors.invoke",
-		"openclaw_provider": "openai-codex",
+		# openclaw_provider keys the auth-profiles.json entry that openclaw
+		# looks up at request time. After fix/oauth-model-provider-key on
+		# fleet-agent + fix/chat-worker-mapped-model-provider on this app,
+		# openclaw queries by the MODEL-provider key ("openai"), not the
+		# OAuth flow id ("openai-codex"). The OAuth login flow itself uses
+		# the metadata above (authorize URL, scopes, codex-cli params); only
+		# the storage/lookup identity is the mapped name.
+		"openclaw_provider": "openai",
 		# codex-cli-specific authorize params - auth.openai.com returns a
 		# generic "unknown_error" page mid-flow without these.
 		"extra_authorize_params": {
@@ -43,7 +50,10 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		# Google OAuth scope - Google returns Error 403 restricted_client
 		# "Unregistered scope(s) in the request" if anything else is sent.
 		"scope":     "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
-		"openclaw_provider": "google-gemini-cli",
+		# Same rationale as the OpenAI entry above: openclaw queries by the
+		# mapped model-provider key ("google"), not the OAuth flow id
+		# ("google-gemini-cli").
+		"openclaw_provider": "google",
 		"extra_authorize_params": {
 			"access_type": "offline",
 			"prompt":      "consent",

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -197,10 +197,13 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 
 		mock_push.assert_called_once()
 		args = mock_push.call_args.args
-		self.assertEqual(args[0], "openai-codex")
+		# Blob is keyed by the mapped model-provider name so openclaw's
+		# request-time auth lookup hits. The OAuth flow itself (authorize
+		# URL, client_id, codex-cli params) still uses the OpenAI metadata.
+		self.assertEqual(args[0], "openai")
 		blob = args[1]
 		self.assertEqual(blob["type"], "oauth")
-		self.assertEqual(blob["provider"], "openai-codex")
+		self.assertEqual(blob["provider"], "openai")
 		self.assertEqual(blob["access"], "AT-123")
 		self.assertEqual(blob["refresh"], "RT-456")
 		self.assertEqual(blob["email"], "manager@acme.com")

--- a/jarvis/tests/test_oauth_providers.py
+++ b/jarvis/tests/test_oauth_providers.py
@@ -12,7 +12,9 @@ class TestGetProvider(unittest.TestCase):
 		self.assertEqual(p["token"], "https://auth.openai.com/oauth/token")
 		self.assertEqual(p["userinfo"], "https://api.openai.com/v1/userinfo")
 		self.assertEqual(p["client_id"], "app_EMoamEEZ73f0CkXaXp7hrann")
-		self.assertEqual(p["openclaw_provider"], "openai-codex")
+		# Storage/lookup identity is the mapped model-provider key, not the
+		# OAuth flow id. See providers.py for rationale.
+		self.assertEqual(p["openclaw_provider"], "openai")
 		self.assertIn("openid", p["scope"])
 		self.assertIn("api.connectors.read", p["scope"])
 		self.assertIn("api.connectors.invoke", p["scope"])
@@ -20,7 +22,7 @@ class TestGetProvider(unittest.TestCase):
 	def test_gemini_returns_gemini_cli_metadata(self):
 		p = providers.get_provider("Google Gemini")
 		self.assertEqual(p["authorize"], "https://accounts.google.com/o/oauth2/v2/auth")
-		self.assertEqual(p["openclaw_provider"], "google-gemini-cli")
+		self.assertEqual(p["openclaw_provider"], "google")
 		# Userinfo flipped from None to the Google v1 endpoint after the
 		# scope drift bug fix - the bundled gemini-cli OAuth client doesn't
 		# have `openid` registered, so no id_token comes back and email is


### PR DESCRIPTION
Openclaw queries its auth store by the MODEL-provider key at request time (after fix/oauth-model-provider-key on fleet-agent: "openai" / "google"). We were keying the stored OAuth blob by the OAuth flow id ("openai-codex" / "google-gemini-cli"), so the lookup missed and openclaw failed dispatch with:

  No API key found for provider "openai".
  Auth store: /home/node/.openclaw/agents/main/agent/openclaw-agent.sqlite

Switch the `openclaw_provider` field in oauth/providers.py to the mapped model-provider name. Tests updated. The OAuth login flow itself
- authorize URL, client_id, codex-cli params - is unchanged; only the storage/lookup identity changes.