### PR TITLE
fix(onboarding): require jarvis_admin_url explicitly; drop bench-URL …

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -61,6 +61,7 @@ def list_plans() -> list:
 @frappe.whitelist()
 def start_signup(email: str, company: str, plan: str) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout."""
+	_require_admin_url()
 	data = _surface(admin_client.signup, email, company, plan)
 	if data.get("api_token"):
 		write_connection({"api_token": data["api_token"]})
@@ -146,13 +147,29 @@ def get_llm_sync_status() -> dict:
 def dev_onboard(email: str, company: str, plan: str) -> dict:
 	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection.
 
-	Single-bench dev shortcut: if jarvis_admin_url isn't already set, default
-	it to this site's URL (customer site == admin site in local dev). Without
-	this, admin_client._admin_url falls back to the hardcoded prod URL and the
-	call DNS-fails immediately."""
-	settings = frappe.get_single("Jarvis Settings")
-	if not (settings.jarvis_admin_url or "").strip():
-		settings.db_set("jarvis_admin_url", frappe.utils.get_url())
+	Requires ``Jarvis Settings.jarvis_admin_url`` to be set first. Earlier
+	versions auto-populated it from ``frappe.utils.get_url()``, but that
+	returns the bench-wide URL (the host_name in common_site_config) instead
+	of the current site URL. On a multi-site bench that quietly lands the
+	wrong value into the wrong site's Jarvis Settings. Force the operator to
+	set it deliberately."""
+	_require_admin_url()
 	data = _surface(admin_client.dev_signup, email, company, plan)
 	write_connection(data)
 	return data
+
+
+def _require_admin_url() -> None:
+	"""Pre-flight guard for the customer→admin signup paths. Throws with an
+	actionable message when ``Jarvis Settings.jarvis_admin_url`` is blank so
+	the operator knows exactly which setting to populate."""
+	settings = frappe.get_single("Jarvis Settings")
+	if (settings.jarvis_admin_url or "").strip():
+		return
+	frappe.throw(
+		"Jarvis Settings.jarvis_admin_url is not set. Set it to the admin "
+		"server's URL (e.g. http://<server-ip>:8080) before signing up. "
+		"From bench: `bench --site <site> execute frappe.client.set_value "
+		"--kwargs '{\"doctype\":\"Jarvis Settings\",\"name\":\"Jarvis "
+		"Settings\",\"fieldname\":\"jarvis_admin_url\",\"value\":\"<url>\"}'`"
+	)

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -77,6 +77,9 @@ class TestSyncConnection(FrappeTestCase):
 
 	def test_dev_onboard_writes_native_credentials_and_connection(self):
 		_set_token("")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings",
+							"jarvis_admin_url", "http://admin.example.com")
+		frappe.db.commit()
 		with patch("jarvis.onboarding.admin_client.dev_signup",
 				   return_value={"customer": "C1", "api_key": "k2", "api_secret": "s2",
 								 "agent_url": "ws://localhost:19002", "agent_token": "tok"}):
@@ -86,21 +89,25 @@ class TestSyncConnection(FrappeTestCase):
 		self.assertEqual(s.get_password("jarvis_admin_api_secret"), "s2")
 		self.assertEqual(s.agent_url, "ws://localhost:19002")
 
-	def test_dev_onboard_defaults_admin_url_when_empty(self):
-		"""Single-bench dev: dev_onboard should auto-set jarvis_admin_url to the
-		current site URL so admin_client doesn't fall back to the prod default."""
+	def test_dev_onboard_throws_when_admin_url_blank(self):
+		"""dev_onboard no longer auto-populates jarvis_admin_url. Earlier
+		versions defaulted it to frappe.utils.get_url(), which on a multi-site
+		bench returns the bench default URL (host_name in
+		common_site_config) instead of the current site's URL - that quietly
+		landed the wrong value into the wrong site's Jarvis Settings. The
+		operator now sets the URL explicitly; a blank field fails fast with
+		an actionable error."""
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
 		frappe.db.commit()
-		with patch("jarvis.onboarding.admin_client.dev_signup",
-				   return_value={"api_key": "k", "api_secret": "s", "agent_url": "ws://h:1", "agent_token": "t"}):
-			onboarding.dev_onboard("e2@x.com", "Co", "Annual Plan")
-		s = frappe.get_single("Jarvis Settings")
-		self.assertEqual(s.jarvis_admin_url, frappe.utils.get_url())
+		with patch("jarvis.onboarding.admin_client.dev_signup") as mock_signup:
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.dev_onboard("e2@x.com", "Co", "Annual Plan")
+			mock_signup.assert_not_called()
 
 	def test_dev_onboard_preserves_existing_admin_url(self):
-		"""If operator has already set jarvis_admin_url (e.g. multi-bench dev),
-		don't overwrite it."""
+		"""Pre-set jarvis_admin_url stays untouched - dev_onboard never
+		writes to the field anymore."""
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings",
 							"jarvis_admin_url", "http://other-admin.local")
@@ -114,6 +121,17 @@ class TestSyncConnection(FrappeTestCase):
 		finally:
 			frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
 			frappe.db.commit()
+
+	def test_start_signup_throws_when_admin_url_blank(self):
+		"""start_signup gets the same pre-flight guard as dev_onboard - admin
+		URL must be set deliberately before any signup attempt."""
+		_set_token("")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
+		frappe.db.commit()
+		with patch("jarvis.onboarding.admin_client.signup") as mock_signup:
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.start_signup("e4@x.com", "Co", "Annual Plan")
+			mock_signup.assert_not_called()
 
 	def test_write_connection_ignores_legacy_api_token(self):
 		"""If admin returns the old api_token key, write_connection should NOT


### PR DESCRIPTION
…auto-set

dev_onboard() used to auto-populate Jarvis Settings.jarvis_admin_url from frappe.utils.get_url() when the field was empty. That function returns the bench-wide URL (host_name in common_site_config or the default-site setting), NOT the current site's URL.

On a multi-site bench (jarvis.localhost + jarvis.live) it landed `http://jarvis.localhost:8000` into jarvis.live's Jarvis Settings, and every subsequent admin call dialed the wrong place. The customer hit it in production while testing a remote admin server on Hetzner: the local jarvis.live bench's admin URL had been silently set to the bench default instead of the operator-intended server URL.

Stop guessing. Replace the auto-populate with a pre-flight guard that throws an actionable error pointing at the exact bench command to set the field. Apply the same guard to start_signup() so the real (non-dev) signup path is symmetric.