### PR TITLE
fix(gemini): send "google-gemini-cli" so openclaw routes via CLI backend

### DIFF
--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -18,28 +18,40 @@ from jarvis.exceptions import OpenclawUnreachableError
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 
-# Provider label → openclaw MODEL-provider id (the key under
-# models.providers.<id> in the container's openclaw.json).
+# Provider label → openclaw provider id sent in the chat WS frame.
 #
-# This is distinct from the OAuth flow identifier (openai-codex /
-# google-gemini-cli) used in auth.profiles[].provider. Openclaw's codex
-# and gemini agent runtimes accept only their respective allowlists for
-# the model-provider key ({codex, openai} / {google, gemini}) - passing
-# the OAuth flow id at request time yields:
-#   "Run error: Unknown model: openai-codex/<model>" or
-#   "Requested agent harness 'codex' does not support openai-codex/<model>"
+# Openclaw has two dispatch paths chosen at request time
+# (openclaw/src/agents/model-selection-cli.ts:6-20):
 #
-# The fleet-agent's openclaw.json template (since
-# fix/oauth-model-provider-key) emits the mapped key in models.providers,
-# so the chat WS frame must use the same name.
+#   - CLI backend: taken when isCliProvider(provider) returns true.
+#     Routes dispatch to a registered CliBackend that spawns an external
+#     CLI binary. The CliBackend is keyed by the provider id (so the
+#     provider sent here must match the CliBackend's id).
 #
-# Only used in oauth mode - api_key mode has no per-tenant
-# codex/gemini-cli provider to override against, so we leave the provider
-# param off the WS frame and openclaw falls back to its single registered
-# models.providers.<id> entry.
+#   - Embedded runtime (codex / pi harness): taken otherwise. The codex
+#     harness has an allowlist of accepted providers; pi handles
+#     everything else but expects HTTP API auth (api key).
+#
+# The two providers we currently support resolve to two different paths:
+#
+#   - OpenAI codex: codex IS a registered plugin harness
+#     (openclaw/extensions/codex/index.ts:34) whose allowlist accepts
+#     "openai" as the model-provider key. Use "openai" for the chat WS
+#     frame and the embedded codex-harness path handles the dispatch.
+#
+#   - Google Gemini: gemini-cli is registered ONLY as a CliBackend
+#     (openclaw/extensions/google/cli-backend.ts:16 with id
+#     "google-gemini-cli"). Use "google-gemini-cli" verbatim so
+#     isCliProvider returns true and dispatch routes via the CLI backend
+#     to the gemini binary inside the container. Mapping it to "google"
+#     makes isCliProvider return false, dispatch falls into the embedded
+#     path, and openclaw errors "No API key found for provider 'google'".
+#
+# Only used in oauth mode - api_key mode skips this map and lets
+# openclaw resolve the single registered models.providers entry.
 _PROVIDER_LABEL_TO_OPENCLAW_ID = {
 	"OpenAI": "openai",
-	"Google Gemini": "google",
+	"Google Gemini": "google-gemini-cli",
 }
 
 

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -50,10 +50,13 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		# Google OAuth scope - Google returns Error 403 restricted_client
 		# "Unregistered scope(s) in the request" if anything else is sent.
 		"scope":     "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
-		# Same rationale as the OpenAI entry above: openclaw queries by the
-		# mapped model-provider key ("google"), not the OAuth flow id
-		# ("google-gemini-cli").
-		"openclaw_provider": "google",
+		# Gemini OAuth tokens are read by the `gemini` binary which
+		# openclaw spawns via the CliBackend registered at
+		# extensions/google/cli-backend.ts:16 (id "google-gemini-cli").
+		# auth-profiles.json must key the credential by this exact id -
+		# mapping to "google" makes openclaw's CLI dispatch path miss the
+		# stored credential (different lookup key).
+		"openclaw_provider": "google-gemini-cli",
 		"extra_authorize_params": {
 			"access_type": "offline",
 			"prompt":      "consent",

--- a/jarvis/tests/test_oauth_providers.py
+++ b/jarvis/tests/test_oauth_providers.py
@@ -22,7 +22,11 @@ class TestGetProvider(unittest.TestCase):
 	def test_gemini_returns_gemini_cli_metadata(self):
 		p = providers.get_provider("Google Gemini")
 		self.assertEqual(p["authorize"], "https://accounts.google.com/o/oauth2/v2/auth")
-		self.assertEqual(p["openclaw_provider"], "google")
+		# Auth storage key matches openclaw's registered CliBackend id so the
+		# gemini binary finds the OAuth token when openclaw routes dispatch
+		# via the CLI backend. Mapping to "google" makes openclaw's
+		# isCliProvider return false and the CLI dispatch path is missed.
+		self.assertEqual(p["openclaw_provider"], "google-gemini-cli")
 		# Userinfo flipped from None to the Google v1 endpoint after the
 		# scope drift bug fix - the bundled gemini-cli OAuth client doesn't
 		# have `openid` registered, so no id_token comes back and email is


### PR DESCRIPTION
Customer hit "No API key found for provider 'google'" on chat after the previous PR set the openclaw provider to "google" everywhere. Root cause: openclaw routes Gemini OAuth through its CLI-backend dispatch, not through the embedded harness path, and the CLI backend is keyed by the exact id "google-gemini-cli".

Source-verified architecture (openclaw at
/Users/venkatesh/bench/develop/jarvis/openclaw):

- isCliProvider(provider, cfg) at src/agents/model-selection-cli.ts:6-20 decides which path. When true: CLI backend dispatch (spawns external binary, harness selector bypassed). When false: embedded runtime (codex/pi harnesses, API-key auth required).
- "google-gemini-cli" is the registered CliBackend id at extensions/google/cli-backend.ts:16. "google" is just a model provider name, not a CliBackend.
- isCliProvider("google") returns false. So mapping the WS-frame's provider to "google" forced dispatch into the embedded path, which has no API key for OAuth Gemini -> error.

Two reverts:

- chat/worker.py: "Google Gemini" -> "google-gemini-cli" (was "google"). This is the provider sent in the chat WS frame. isCliProvider will now return true and dispatch routes via the CLI backend.

- oauth/providers.py: Google Gemini openclaw_provider ->
  "google-gemini-cli" (was "google"). This is the key under which the OAuth blob is stored in auth-profiles.json. The gemini binary reads it back keyed by this exact id - "google" doesn't match.

OpenAI Codex stays unchanged - it uses the codex plugin harness (extensions/codex/index.ts:34) whose allowlist accepts "openai" as the model-provider key, so the embedded harness path with provider "openai" is correct for codex.