### PR TITLE
fix(oauth): include accountId in ChatGPT subscription OAuth blob

### DIFF
--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -18,7 +18,7 @@ import requests
 from jarvis import admin_client, onboarding
 from jarvis.exceptions import JarvisError
 from jarvis.oauth.providers import (
-	UnknownProviderError, build_authorize_url, get_provider,
+	UnknownProviderError, build_authorize_url, extract_account_id, get_provider,
 )
 
 
@@ -171,6 +171,7 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 		"refresh": tokens.get("refresh_token") or "",
 		"expires": expires_ms,
 		"email": email,
+		"accountId": extract_account_id(provider, access_token),
 		"clientId": p["client_id"],
 	}
 

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -4,6 +4,8 @@ Used by jarvis.oauth.api to drive the paste-back OAuth flow against
 the provider's own /oauth/authorize endpoint, with the codex-CLI-specific
 parameter set that auth.openai.com requires for codex's client_id.
 """
+import base64
+import json
 from urllib.parse import urlencode
 
 from jarvis.exceptions import JarvisError
@@ -77,6 +79,41 @@ def get_provider(label: str) -> dict:
 	entry["client_id"] = OAUTH_CLIENT_IDS[label]
 	entry["client_secret"] = get_oauth_client_secret(label)
 	return entry
+
+
+def extract_account_id(provider: str, access_token: str) -> str:
+	"""Pull openclaw's `accountId` claim out of the access JWT.
+
+	openclaw's codex auth resolver gates on this field: profiles without
+	an accountId are treated as unusable and chat fails with "No API key
+	found for provider openai". See openclaw/docs/concepts/oauth.md step
+	6 of the codex OAuth exchange.
+
+	OpenAI codex: ``payload["https://api.openai.com/auth"]["chatgpt_account_id"]``.
+	Gemini: claim shape not yet verified against a real Gemini Advanced
+	account; returns ``""`` until that lands (per the live-verification
+	caveat in oauth-implementation.md).
+
+	Best-effort: returns ``""`` on any parse / claim-lookup failure,
+	mirroring ``_fetch_account_email``'s never-raise contract.
+	"""
+	if provider != "OpenAI":
+		return ""
+	if not access_token or access_token.count(".") < 2:
+		return ""
+	try:
+		_, payload_b64, _ = access_token.split(".", 2)
+		padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+		claims = json.loads(base64.urlsafe_b64decode(padded))
+	except (ValueError, TypeError):
+		return ""
+	if not isinstance(claims, dict):
+		return ""
+	namespace = claims.get("https://api.openai.com/auth")
+	if not isinstance(namespace, dict):
+		return ""
+	value = namespace.get("chatgpt_account_id")
+	return value if isinstance(value, str) else ""
 
 
 def build_authorize_url(*, provider: str, redirect_uri: str,

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -1,6 +1,8 @@
 """REV-3 OAuth API tests. Bench owns the full OAuth flow (PKCE gen +
 token exchange + blob push). Customer's laptop just hosts a browser
 session that pastes the redirected URL back."""
+import base64
+import json
 import time
 from unittest.mock import patch
 
@@ -8,6 +10,14 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.oauth import api as oauth_api
+
+
+def _jwt(payload: dict) -> str:
+	"""Build a fake JWT for tests. Header + signature are bogus; the
+	bench never verifies the signature - TLS to the provider is the
+	trust root for token-derived claims."""
+	payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+	return f"header.{payload_b64}.signature"
 
 _CACHE_KEY = "jarvis.oauth.codex_signin"
 
@@ -170,8 +180,17 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 	def test_happy_path_pushes_blob_and_saves_creds(
 		self, mock_exchange, mock_push, mock_save,
 	):
+		# Realistic JWT shape: openclaw's codex auth resolver pulls accountId
+		# from the access token's `https://api.openai.com/auth.chatgpt_account_id`
+		# claim; without that field the OAuth profile is treated as unusable
+		# and chat surfaces "No API key found for provider openai".
+		access_jwt = _jwt({
+			"https://api.openai.com/auth": {
+				"chatgpt_account_id": "9151840e-6317-4e8c-a575-8ea33beda869",
+			},
+		})
 		mock_exchange.return_value = {
-			"access_token": "AT-123",
+			"access_token": access_jwt,
 			"refresh_token": "RT-456",
 			"expires_in": 3600,
 			"id_token": "",
@@ -204,9 +223,10 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 		blob = args[1]
 		self.assertEqual(blob["type"], "oauth")
 		self.assertEqual(blob["provider"], "openai")
-		self.assertEqual(blob["access"], "AT-123")
+		self.assertEqual(blob["access"], access_jwt)
 		self.assertEqual(blob["refresh"], "RT-456")
 		self.assertEqual(blob["email"], "manager@acme.com")
+		self.assertEqual(blob["accountId"], "9151840e-6317-4e8c-a575-8ea33beda869")
 		self.assertEqual(blob["clientId"], "app_EMoamEEZ73f0CkXaXp7hrann")
 
 		mock_save.assert_called_once()

--- a/jarvis/tests/test_oauth_providers.py
+++ b/jarvis/tests/test_oauth_providers.py
@@ -1,8 +1,16 @@
 """Tests for jarvis.oauth.providers - provider OAuth metadata."""
+import base64
+import json
 import unittest
 from urllib.parse import urlparse, parse_qs
 
 from jarvis.oauth import providers
+
+
+def _jwt(payload: dict) -> str:
+	"""Build a fake JWT with the given payload. Header + signature are bogus."""
+	payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+	return f"header.{payload_b64}.signature"
 
 
 class TestGetProvider(unittest.TestCase):
@@ -45,6 +53,63 @@ class TestGetProvider(unittest.TestCase):
 	def test_unknown_provider_raises(self):
 		with self.assertRaises(providers.UnknownProviderError):
 			providers.get_provider("Anthropic")
+
+
+class TestExtractAccountId(unittest.TestCase):
+	"""openclaw's codex auth resolver requires `accountId` on the OAuth
+	profile; without it the credential is treated as unusable and the
+	chat surfaces 'No API key found for provider openai'. See
+	openclaw/docs/concepts/oauth.md step 6 of the codex OAuth exchange."""
+
+	def test_openai_pulls_chatgpt_account_id_from_jwt(self):
+		jwt = _jwt({
+			"https://api.openai.com/auth": {
+				"chatgpt_account_id": "9151840e-6317-4e8c-a575-8ea33beda869",
+			},
+		})
+		self.assertEqual(
+			providers.extract_account_id("OpenAI", jwt),
+			"9151840e-6317-4e8c-a575-8ea33beda869",
+		)
+
+	def test_openai_returns_empty_when_claim_missing(self):
+		jwt = _jwt({"https://api.openai.com/auth": {}})
+		self.assertEqual(providers.extract_account_id("OpenAI", jwt), "")
+
+	def test_openai_returns_empty_when_namespace_missing(self):
+		jwt = _jwt({"sub": "user-1"})
+		self.assertEqual(providers.extract_account_id("OpenAI", jwt), "")
+
+	def test_returns_empty_on_malformed_jwt(self):
+		for bad in ["", "not-a-jwt", "only.one.dot", "x.!!notb64!!.y"]:
+			self.assertEqual(providers.extract_account_id("OpenAI", bad), "")
+
+	def test_returns_empty_when_payload_is_not_a_dict(self):
+		# OpenAI's JWT spec requires the payload be a JSON object, but if the
+		# spec ever drifts (or a custom provider sends a list/string), the
+		# helper must not raise - it's called inline from complete_paste_signin
+		# where any exception would 500 the wizard.
+		for bad_payload in [[1, 2, 3], "just-a-string", 42, None]:
+			jwt = _jwt(bad_payload)
+			self.assertEqual(providers.extract_account_id("OpenAI", jwt), "")
+
+	def test_returns_empty_when_namespace_value_is_not_a_dict(self):
+		jwt = _jwt({"https://api.openai.com/auth": "unexpected-string"})
+		self.assertEqual(providers.extract_account_id("OpenAI", jwt), "")
+
+	def test_returns_empty_when_account_id_is_not_a_string(self):
+		jwt = _jwt({"https://api.openai.com/auth": {"chatgpt_account_id": 12345}})
+		self.assertEqual(providers.extract_account_id("OpenAI", jwt), "")
+
+	def test_gemini_returns_empty_until_verified_live(self):
+		# Per oauth-implementation.md, Gemini's account-id claim hasn't been
+		# verified against a real account; helper returns "" defensively.
+		jwt = _jwt({"sub": "google-oauth2|123"})
+		self.assertEqual(providers.extract_account_id("Google Gemini", jwt), "")
+
+	def test_unknown_provider_returns_empty(self):
+		jwt = _jwt({"sub": "x"})
+		self.assertEqual(providers.extract_account_id("Anthropic", jwt), "")
 
 
 class TestBuildAuthorizeUrl(unittest.TestCase):


### PR DESCRIPTION
openclaw's codex auth resolver gates on the `accountId` field per its own OAuth contract (openclaw/docs/concepts/oauth.md step 6 of the codex OAuth exchange). Without it, profiles in auth-profiles.json are treated as unusable, the resolver falls through to the api-key path, and chat surfaces "No API key found for provider openai" - even though valid access and refresh tokens are present on disk.

We were packing 7 fields (type, provider, access, refresh, expires, email, clientId) and omitting accountId entirely. Two customers in two days hit this after onboarding via the chat-subscription wizard.

Adds a provider-aware `extract_account_id` helper that decodes the JWT payload (no signature verification - TLS to the provider is the trust root, same pattern as `_fetch_account_email`) and pulls the `chatgpt_account_id` claim from OpenAI's `https://api.openai.com/auth` namespace. Best-effort: returns "" on any parse/shape failure so the wizard never 500s on a malformed token. Gemini stub returns "" until we have a real account to verify the claim shape against.

Recovery for existing broken customers: re-authenticate via the account page - the new blob path includes accountId on the next push.