### PR TITLE
fix(oauth): coerce subscription model to codex-CLI set before OAuth +…

### DIFF
--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -70,7 +70,13 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const ui = {
 		aiTab: "api_key",
 		subProvider: "OpenAI",
-		subModel: "gpt-4o",
+		// Subscription default MUST be a codex-CLI model (not a standard
+		// API model like "gpt-4o"). The codex auth tunnel rejects
+		// standard-API names, surfacing as a generic
+		// ProviderAuthError "No API key found for provider openai".
+		// Keep in sync with SUBSCRIPTION_MODELS["OpenAI"][0] above +
+		// _DEFAULT_MODEL["OpenAI"] in jarvis/oauth/api.py.
+		subModel: "gpt-5.5",
 		subNonce: null,
 		subAuthorizeUrl: null,   // shown to the customer in Screen 2
 		subExpiresAt: null,
@@ -127,11 +133,26 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					ui.aiTab = settingsLocal.llm_auth_mode === "oauth" ? "subscription" : "api_key";
 					// In oauth mode, seed sub-state from the saved provider/model so
 					// a Re-authorize click uses THIS customer's provider (e.g.
-					// "Google Gemini") instead of the hardcoded "OpenAI"/"gpt-4o"
-					// defaults that the api_key→subscription wizard path uses.
+					// "Google Gemini") instead of the hardcoded default that the
+					// api_key→subscription wizard path uses.
+					// Carry-over guards: only adopt llm_provider if it's still a
+					// known subscription provider, and only adopt llm_model if it
+					// matches a codex-CLI model for that provider. A standard-API
+					// model (e.g. "gpt-4o") going through codex auth makes
+					// openclaw fail every chat turn with "No API key found".
+					// jarvis.oauth.api._coerce_subscription_model server-side
+					// catches this too; this is just so the dropdown + the
+					// "Sign in with ..." button label stay consistent.
 					if (settingsLocal.llm_auth_mode === "oauth") {
-						if (settingsLocal.llm_provider) ui.subProvider = settingsLocal.llm_provider;
-						if (settingsLocal.llm_model) ui.subModel = settingsLocal.llm_model;
+						if (settingsLocal.llm_provider && SUBSCRIPTION_MODELS[settingsLocal.llm_provider]) {
+							ui.subProvider = settingsLocal.llm_provider;
+						}
+						const valid = SUBSCRIPTION_MODELS[ui.subProvider] || [];
+						if (settingsLocal.llm_model && valid.includes(settingsLocal.llm_model)) {
+							ui.subModel = settingsLocal.llm_model;
+						} else {
+							ui.subModel = valid[0] || ui.subModel;
+						}
 					}
 					render();
 				});

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -15,7 +15,13 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		// step 4 inputs - chat subscription path (REV-3 paste-back)
 		authMode: "api_key", // "api_key" | "subscription"
 		subProvider: "OpenAI",
-		subModel: "gpt-4o",
+		// Subscription default MUST be a codex-CLI model (not a standard
+		// API model like "gpt-4o"). The codex auth tunnel rejects
+		// standard-API names, surfacing as a generic
+		// ProviderAuthError "No API key found for provider openai".
+		// Keep in sync with the first entry of SUBSCRIPTION_MODELS["OpenAI"]
+		// below + _DEFAULT_MODEL["OpenAI"] in jarvis/oauth/api.py.
+		subModel: "gpt-5.5",
 		subNonce: null,
 		subAuthorizeUrl: null,   // shown to the customer in Screen 2
 		subExpiresAt: null,

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -29,10 +29,30 @@ _CACHE_KEY = "jarvis.oauth.codex_signin"
 _NONCE_TTL_SECS = 600
 _HTTP_TIMEOUT = 30
 _REDIRECT_URI = "http://localhost:1455/auth/callback"
-# Defaults for subscription mode - these are codex/gemini-cli's CLI-specific
-# model IDs, not OpenAI/Google's standard API model names. Mirrors the
-# SUBSCRIPTION_MODELS dict in jarvis_onboarding.js / jarvis_account.js.
+# Codex/gemini-cli's CLI-specific model IDs (not OpenAI/Google's standard
+# API model names). Mirrors the SUBSCRIPTION_MODELS dict in
+# jarvis_onboarding.js / jarvis_account.js - keep both in sync. Customer-
+# supplied models outside this set get coerced to _DEFAULT_MODEL before
+# being cached: sending a standard-API model (e.g. "gpt-4o") through the
+# codex auth tunnel makes openclaw's codex extension fail every chat turn
+# with ProviderAuthError: "No API key found for provider openai" (it
+# treats model-mismatch as auth failure, not as a clearer model error).
+# Live-confirmed 2026-06-11 on jarvis-pool-05b704.
+_SUBSCRIPTION_MODELS = {
+	"OpenAI": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
+	"Google Gemini": {"gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"},
+}
 _DEFAULT_MODEL = {"OpenAI": "gpt-5.5", "Google Gemini": "gemini-2.0-pro"}
+
+
+def _coerce_subscription_model(provider: str, model: str) -> str:
+	"""Return ``model`` if valid for ``provider``'s subscription mode,
+	else fall back to ``_DEFAULT_MODEL[provider]``. Empty string for an
+	unknown provider (begin_paste_signin already rejects those upstream)."""
+	valid = _SUBSCRIPTION_MODELS.get(provider, set())
+	if model and model in valid:
+		return model
+	return _DEFAULT_MODEL.get(provider, "")
 
 
 def _ok(data: dict) -> dict:
@@ -74,7 +94,7 @@ def begin_paste_signin(provider: str, model: str) -> dict:
 
 	frappe.cache.hset(_CACHE_KEY, nonce, {
 		"provider": provider,
-		"model": model or _DEFAULT_MODEL.get(provider, ""),
+		"model": _coerce_subscription_model(provider, model),
 		"status": "pending",
 		"expires_at_ts": int(time.time()) + _NONCE_TTL_SECS,
 		"verifier": verifier,
@@ -140,7 +160,12 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 		            "regenerate the sign-in URL and try again")
 
 	provider = entry["provider"]
-	model = entry["model"]
+	# Re-coerce belt-and-suspenders: nonces live up to 10 min, so
+	# _SUBSCRIPTION_MODELS could in principle be tightened mid-flight
+	# (e.g. a codex model deprecated). begin_paste_signin already coerced
+	# at cache time; doing it again here means the cached model can never
+	# escape the codex-valid set even across config reloads.
+	model = _coerce_subscription_model(provider, entry["model"])
 
 	try:
 		tokens = _exchange_code(

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -66,10 +66,10 @@ class TestBeginPasteSignin(_OAuthApiBase):
 		self.assertIn("redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback", url)
 
 	def test_caches_verifier_state_provider_model(self):
-		out = oauth_api.begin_paste_signin("OpenAI", "gpt-4o")
+		out = oauth_api.begin_paste_signin("OpenAI", "gpt-5.5")
 		entry = frappe.cache.hget(_CACHE_KEY, out["data"]["nonce"])
 		self.assertEqual(entry["provider"], "OpenAI")
-		self.assertEqual(entry["model"], "gpt-4o")
+		self.assertEqual(entry["model"], "gpt-5.5")
 		self.assertEqual(entry["status"], "pending")
 		self.assertIn("verifier", entry)
 		self.assertIn("state", entry)
@@ -84,13 +84,47 @@ class TestBeginPasteSignin(_OAuthApiBase):
 		self.assertFalse(out["ok"])
 		self.assertEqual(out["error"]["code"], "unknown_provider")
 
+	def test_standard_api_model_coerced_to_codex_default(self):
+		"""Customer-supplied models that aren't in the codex subscription list
+		(e.g. "gpt-4o" carried over from api_key mode) get rewritten to the
+		default codex model. Otherwise the openclaw codex extension fails
+		every chat turn with ProviderAuthError "No API key found for provider
+		openai" - treats model-mismatch as auth failure. Confirmed live on
+		jarvis-pool-05b704 (2026-06-11)."""
+		out = oauth_api.begin_paste_signin("OpenAI", "gpt-4o")
+		entry = frappe.cache.hget(_CACHE_KEY, out["data"]["nonce"])
+		self.assertEqual(entry["model"], "gpt-5.5")
+
+	def test_empty_model_coerced_to_default(self):
+		out = oauth_api.begin_paste_signin("OpenAI", "")
+		entry = frappe.cache.hget(_CACHE_KEY, out["data"]["nonce"])
+		self.assertEqual(entry["model"], "gpt-5.5")
+
+	def test_valid_codex_model_passed_through(self):
+		for model in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"):
+			out = oauth_api.begin_paste_signin("OpenAI", model)
+			entry = frappe.cache.hget(_CACHE_KEY, out["data"]["nonce"])
+			self.assertEqual(entry["model"], model, f"valid codex model {model!r} should pass through unchanged")
+
+	def test_gemini_standard_api_model_coerced_to_cli_default(self):
+		"""Same hazard on the Gemini side: a gemini-pro / gemini-1.0-pro from
+		the api_key catalog has to be rewritten to a gemini-cli model before
+		entering the OAuth nonce cache."""
+		out = oauth_api.begin_paste_signin("Google Gemini", "gemini-pro")
+		entry = frappe.cache.hget(_CACHE_KEY, out["data"]["nonce"])
+		self.assertEqual(entry["model"], "gemini-2.0-pro")
+
 
 class TestCompletePasteSigninParsing(_OAuthApiBase):
 	def _seed(self, **overrides):
 		nonce = "n_" + ("a" * 46)
 		entry = {
 			"provider": "OpenAI",
-			"model": "gpt-4o",
+			# Seed with a codex-CLI model - in production begin_paste_signin
+			# has already coerced the customer-supplied model via
+			# _coerce_subscription_model before caching, so any nonce
+			# complete_paste_signin sees holds a valid codex model.
+			"model": "gpt-5.5",
 			"status": "pending",
 			"expires_at_ts": int(time.time()) + 600,
 			"verifier": "test-verifier",
@@ -162,7 +196,7 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 
 
 class TestCompletePasteSigninFlow(_OAuthApiBase):
-	def _seed(self, provider="OpenAI", model="gpt-4o"):
+	def _seed(self, provider="OpenAI", model="gpt-5.5"):
 		nonce = "k_" + ("d" * 46)
 		frappe.cache.hset(_CACHE_KEY, nonce, {
 			"provider": provider, "model": model,
@@ -232,7 +266,7 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 		mock_save.assert_called_once()
 		sk = mock_save.call_args.kwargs
 		self.assertEqual(sk["provider"], "OpenAI")
-		self.assertEqual(sk["model"], "gpt-4o")
+		self.assertEqual(sk["model"], "gpt-5.5")
 		self.assertEqual(sk["api_key"], "")
 		self.assertEqual(sk["auth_mode"], "oauth")
 
@@ -241,6 +275,41 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 		self.assertIsNotNone(settings.llm_oauth_connected_at)
 
 		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))
+
+	@patch("jarvis.oauth.api.onboarding.save_llm_creds")
+	@patch("jarvis.oauth.api.admin_client.post_push_oauth_blob")
+	@patch("jarvis.oauth.api._exchange_code")
+	def test_stale_nonce_model_recoerced_at_complete_time(
+		self, mock_exchange, mock_push, mock_save,
+	):
+		"""Belt-and-suspenders: if a nonce somehow holds a non-codex model
+		(e.g. _SUBSCRIPTION_MODELS tightened mid-flight, or a manually
+		seeded cache row), complete_paste_signin must re-coerce before
+		writing to the blob and save_llm_creds. Otherwise the customer's
+		container ends up rendering openclaw.json with the bad model and
+		every chat turn fails."""
+		jwt = _jwt({
+			"https://api.openai.com/auth": {
+				"chatgpt_account_id": "acct-test",
+			},
+		})
+		mock_exchange.return_value = {
+			"access_token": jwt, "refresh_token": "RT", "expires_in": 3600,
+			"id_token": "", "email": "manager@acme.com",
+		}
+		mock_save.return_value = {"last_sync_status": "ok"}
+		nonce = self._seed(model="gpt-4o")  # bypasses begin_paste_signin's coercion
+
+		oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="?code=ABC&state=test-state",
+		)
+
+		self.assertEqual(mock_save.call_args.kwargs["model"], "gpt-5.5",
+			"complete_paste_signin must re-coerce a stale-cached non-codex model")
+		# Blob doesn't carry the model field today, but the push provider id
+		# remains tied to OAuth flow, not to the model.
+		self.assertEqual(mock_push.call_args.args[0], "openai")
 
 	@patch("jarvis.oauth.api._exchange_code",
 	       side_effect=Exception("provider 400"))


### PR DESCRIPTION
… cache

Customers re-authenticating via /jarvis-account hit ProviderAuthError "No API key found for provider openai" on every chat turn after the accountId fix (PR #76) shipped. Root cause: the JS state default `subModel: "gpt-4o"` in both jarvis_onboarding.js and jarvis_account.js got sent to begin_paste_signin even though the dropdown DOM displayed "gpt-5.5" - the in-memory state never matched a selected option.

openclaw's codex extension treats "use codex auth with a standard-API model name" (gpt-4o, gpt-4o-mini, ...) as auth failure, not as a clearer model-mismatch error. Live-confirmed via container logs on jarvis-pool-05b704: `[model-fallback/decision] requested=openai/gpt-4o reason=auth detail=No API key found for provider "openai"`.

Three layers:

- jarvis/oauth/api.py: new _SUBSCRIPTION_MODELS set + helper _coerce_subscription_model. begin_paste_signin coerces at cache time; complete_paste_signin re-coerces at complete time (belt-and-suspenders against tightening _SUBSCRIPTION_MODELS while a nonce is in flight - they live up to 10 min).
- jarvis_onboarding.js + jarvis_account.js: state default subModel: "gpt-4o" -> "gpt-5.5".
- jarvis_account.js: carry-over guard - only adopt saved llm_provider/llm_model if both are still in SUBSCRIPTION_MODELS, else snap to the codex default. This recovers existing customers whose Jarvis Settings holds "gpt-4o" on next /jarvis-account visit.

Tests: 20 pass. 4 new coercion tests + 1 belt-and-suspenders test + fixture default updated.

Recovery: existing broken customers hit Re-authorize on /jarvis-account. Coercion rewrites the model server-side, fleet-agent re-renders openclaw.json correctly, chat works.