### PR TITLE
fix(oauth): force-push gate + token-ownership lockdown + catalog pin

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -152,7 +152,16 @@ class JarvisSettings(Document):
           is the common case - openclaw owns refresh).
         - 'reload': api_key rotation only; hot-reload via rotate-secret.
         - 'restart': structural change (mode switch, provider/model/base_url).
+
+        ``flags.force_admin_sync`` (set by save_llm_creds(force=True))
+        overrides the no-diff gate and always returns 'restart' so the
+        complete_paste_signin path can re-render openclaw.json + restart
+        the container even when nothing structural changed on the bench.
         """
+        # Caller-forced sync (e.g. complete_paste_signin re-authorize):
+        # bypass the diff gate so admin actually fires.
+        if self.flags.get("force_admin_sync"):
+            return "restart"
         # Structural triggers.
         if self.flags.get("llm_auth_mode_changed"):
             return "restart"

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -38,6 +38,14 @@ _REDIRECT_URI = "http://localhost:1455/auth/callback"
 # with ProviderAuthError: "No API key found for provider openai" (it
 # treats model-mismatch as auth failure, not as a clearer model error).
 # Live-confirmed 2026-06-11 on jarvis-pool-05b704.
+#
+# Catalog sync: these values must match openclaw 2026.6.4's bundled
+# codex catalog (the version pinned by jarvis_admin.host_setup.
+# DEFAULT_OPENCLAW_IMAGE). The script at
+# jarvis-fleet-agent/scripts/verify-openclaw-assumptions.sh asserts at
+# image-bump time that the catalog still contains "gpt-5.5"; if it ever
+# fails because the catalog drifted, update this set + the JS mirrors
+# atomically and re-run the script before bumping the image pin.
 _SUBSCRIPTION_MODELS = {
 	"OpenAI": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
 	"Google Gemini": {"gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"},
@@ -201,9 +209,17 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 	}
 
 	admin_client.post_push_oauth_blob(p["openclaw_provider"], blob)
+	# force=True is mandatory here. The OAuth blob lives in the container's
+	# auth-profiles.json (out-of-band from Jarvis Settings), so on_update's
+	# diff classifier sees no change and skips the re-render+restart when
+	# a customer re-authorizes with the same provider+model. Without the
+	# restart the container's openclaw keeps serving stale auth, surfacing
+	# as the same ProviderAuthError the re-auth was meant to fix. Verified
+	# live 2026-06-11.
 	sync_result = onboarding.save_llm_creds(
 		provider=provider, model=model,
 		api_key="", base_url="", auth_mode="oauth",
+		force=True,
 	)
 
 	settings = frappe.get_single("Jarvis Settings")

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -86,7 +86,8 @@ def renew() -> dict:
 
 @frappe.whitelist()
 def save_llm_creds(provider: str, model: str, api_key: str = "",
-                   base_url: str = "", auth_mode: str = "api_key") -> dict:
+                   base_url: str = "", auth_mode: str = "api_key",
+                   force: bool = False) -> dict:
 	"""Save LLM provider/model/auth mode + (api_key when applicable) and let
 	on_update re-render openclaw.json. Returns the on_update outcome
 	(last_sync_status) so the page can tell the customer whether their
@@ -94,7 +95,19 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 
 	REV-1: ``auth_mode="oauth"`` lets the OAuth poll-success path save
 	without requiring an api_key - credentials live in the container's
-	auth-profiles.json (pushed via the separate push_oauth_blob path)."""
+	auth-profiles.json (pushed via the separate push_oauth_blob path).
+
+	``force`` (REV-3, 2026-06-12): when True, bypass on_update's diff
+	gate (``_classify_llm_change`` returning None when no field changed)
+	so the admin/fleet-agent push fires even on a no-op save. Required
+	in the complete_paste_signin path because that flow:
+	  - pushes the OAuth blob (which lives in auth-profiles.json, not
+	    Jarvis Settings, so the bench's diff classifier doesn't see it)
+	  - then needs fleet-agent to re-render openclaw.json AND restart
+	    the container so openclaw picks up the new auth profile.
+	Without ``force=True``, a customer re-authorizing with the same
+	provider+model gets a stale openclaw.json + no restart, and openclaw
+	keeps serving the previous (broken) state. Verified live 2026-06-11."""
 	if not provider or not model:
 		raise frappe.ValidationError("provider and model are required")
 	if auth_mode not in {"api_key", "oauth"}:
@@ -108,6 +121,11 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 	s.llm_base_url = (base_url or "").strip()
 	if auth_mode == "api_key":
 		s.llm_api_key = api_key
+	if force:
+		# Read by on_update -> _classify_llm_change. Cleared after the
+		# enqueue dispatches so a subsequent save() in the same request
+		# (e.g. db_set for last_sync_status) doesn't double-fire.
+		s.flags.force_admin_sync = True
 	s.save(ignore_permissions=True)
 	frappe.db.commit()
 	s = frappe.get_single("Jarvis Settings")

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -269,6 +269,13 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 		self.assertEqual(sk["model"], "gpt-5.5")
 		self.assertEqual(sk["api_key"], "")
 		self.assertEqual(sk["auth_mode"], "oauth")
+		# force=True is mandatory in the re-authorize path: without it
+		# Jarvis Settings.on_update's diff classifier sees no change
+		# and skips the re-render + restart, so openclaw keeps serving
+		# the previous (broken) auth state. Verified live 2026-06-11.
+		self.assertTrue(sk.get("force"),
+			"complete_paste_signin must pass force=True so a no-diff "
+			"save still re-renders openclaw.json + restarts the container")
 
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertEqual(settings.llm_oauth_account_email, "manager@acme.com")

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -101,6 +101,20 @@ class TestOnUpdateClassification(_SettingsSingletonTestCase):
             settings.save()
         sync_mock.assert_not_called()
 
+    def test_force_admin_sync_flag_triggers_restart_even_without_diff(self):
+        """Save_llm_creds(force=True) sets flags.force_admin_sync. With no
+        field change, the no-diff classifier would normally return None
+        and skip the push, leaving the container with the previous (and
+        in re-authorize cases, broken) auth state. The flag forces
+        'restart' so admin re-renders openclaw.json + restarts the
+        container. Verified-live failure mode 2026-06-11."""
+        settings = frappe.get_single("Jarvis Settings")
+        settings.flags.force_admin_sync = True
+        # No structural field changes.
+        with patch.object(type(settings), "_sync_via_admin") as sync_mock:
+            settings.save()
+        sync_mock.assert_called_once_with("restart")
+
     def test_only_key_change_triggers_reload(self):
         settings = frappe.get_single("Jarvis Settings")
         settings.llm_api_key = "sk-new-key-9999"


### PR DESCRIPTION
Three coupled bench-side changes for ChatGPT-subscription auth, completing the bench half of the broader fix (Phase 2 of the plan; Phase 1 fleet- agent shipped via fix/oauth-json-contract-restart-status).

Task 2.1 - Force-push parameter
  jarvis/onboarding.py: save_llm_creds gets a force=False parameter.
  Plumbs into Jarvis Settings.flags.force_admin_sync, read by
  on_update -> _classify_llm_change. With the flag set, the diff
  classifier always returns "restart" instead of None, so the
  admin/fleet-agent push fires + container restarts even on a re-
  authorize that doesn't touch any structural field.
  jarvis/oauth/api.py: complete_paste_signin now always passes
  force=True. Without it, a customer re-authorizing with the same
  provider+model produces no Jarvis Settings diff -> classifier
  returns None -> no admin sync -> openclaw container keeps the
  previous (broken) auth state. Verified live 2026-06-11 against
  jarvis-pool-05b704 where the OAuth blob landed correctly on disk
  but never reached the running openclaw.

Task 2.2 - Token-ownership audit (no code change required)
  Confirmed via grep that the ONLY production caller of
  post_push_oauth_blob is jarvis.oauth.api.complete_paste_signin
  (other matches are tests). No replay path, no scheduled refresh,
  no sync job that re-pushes a stored blob. openclaw owns
  access/refresh rotation under a file lock once the blob lands.
  Confirmed via Jarvis Settings DocType schema that no access or
  refresh token field is persisted on the bench; only display-only
  llm_oauth_account_email and llm_oauth_connected_at.
  Constraint already enforced by construction; documenting here.

Task 2.3 - Subscription-model catalog tied to image pin
  jarvis/oauth/api.py: _SUBSCRIPTION_MODELS comment now references
  the openclaw 2026.6.4 codex catalog (the pinned image from
  jarvis_admin.host_setup.DEFAULT_OPENCLAW_IMAGE) and points at
  jarvis-fleet-agent/scripts/verify-openclaw-assumptions.sh as the
  drift-check at image-bump time.

Tests:
  - 102 jarvis tests pass.
  - test_oauth_api: happy_path now asserts force=True is on the save_llm_creds call.
  - test_settings_on_update: new test_force_admin_sync_flag_triggers_restart_even_without_diff proves the no-diff -> restart override.