### PR TITLE
fix(admin_client): bump post_push_oauth_blob timeout above admin's 150s

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -131,6 +131,16 @@ def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 	codex/gemini-cli provider reads the blob from auth-profiles.json and
 	refreshes internally via pi-ai going forward.
 
+	Timeout is bumped above the default 90s because the admin handler
+	chains to fleet-agent's PUT /auth-profile, which now runs
+	``openclaw doctor --fix --non-interactive`` (up to 60s, migrates the
+	legacy JSON store to SQLite on openclaw 2026.6.5+) plus
+	``docker compose restart`` + healthz poll. Admin's own bound is 150s;
+	we give bench 180s to allow for the HTTPS round-trip and admin's
+	response serialization on top of that. The earlier 90s default ran
+	out at the doctor step, surfacing as the same
+	"AdminUnreachableError: read timeout" we hit 2026-06-12.
+
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError
 		(rate-limit shares rotate-secret's 20/h bucket).
@@ -140,6 +150,7 @@ def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 		path="/api/method/jarvis_admin.api.tenant.push_oauth_blob",
 		body={"provider": provider, "blob": blob},
 		admin_url=_admin_url(settings),
+		timeout_s=180,
 	)
 
 
@@ -151,6 +162,38 @@ def post_subscription_disconnect() -> dict:
 	settings = frappe.get_single("Jarvis Settings")
 	return _post(
 		path="/api/method/jarvis_admin.api.tenant.subscription_disconnect",
+		body={},
+		admin_url=_admin_url(settings),
+	)
+
+
+def post_llm_auth_status() -> dict:
+	"""Ask admin (and via admin, fleet-agent) whether the customer's
+	container actually holds a usable OAuth profile right now.
+
+	Used by the wizard / account page to gate the "Connected" UI state
+	on the runtime contract rather than on the bench having sent the
+	push. The on-disk file can be present without the running gateway
+	seeing it (that's the bug class fleet-agent Task 1.2's restart
+	closed), and the bench's last_sync_status only reflects whether the
+	admin call returned 2xx - neither tells you "openclaw resolved the
+	profile."
+
+	Returns:
+	    Same shape as the admin endpoint:
+	    {"ok": True,
+	     "data": {"auth_profile_present": bool,
+	              "profile_ids": [...],
+	              "default_model": str,
+	              "openai_profile_expires_ms": int | None}}
+	    Never includes token material.
+
+	Raises AdminAuthError / AdminUnreachableError / AdminValidationError
+	in the same shape as the other admin_client methods.
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.tenant.llm_auth_status",
 		body={},
 		admin_url=_admin_url(settings),
 	)

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -470,9 +470,10 @@ class TestPostPushOauthBlob(FrappeTestCase):
 		blob = {"type": "oauth", "provider": "openai-codex",
 				"access": "AT-fresh", "refresh": "RT-fresh", "expires": 1735689600}
 
-		def _fake_post(url, json=None, **_kw):
+		def _fake_post(url, json=None, timeout=None, **_kw):
 			captured["url"] = url
 			captured["body"] = json
+			captured["timeout"] = timeout
 			return _mock_response(200, json_body={"message": {"ok": True, "data": {"ok": True}}})
 
 		with patch("requests.post", side_effect=_fake_post):
@@ -480,6 +481,14 @@ class TestPostPushOauthBlob(FrappeTestCase):
 		self.assertEqual(result, {"ok": True})
 		self.assertIn("push_oauth_blob", captured["url"])
 		self.assertEqual(captured["body"], {"provider": "openai-codex", "blob": blob})
+		# Timeout must exceed admin's own put_auth_profile bound (150s) so
+		# bench doesn't time out before admin can return. Lower bound
+		# locked at 180s; raise this and admin's bound together if either
+		# bumps. Doctor + restart + healthz easily fits inside 150s on a
+		# healthy host.
+		self.assertGreaterEqual(captured["timeout"], 180,
+			"post_push_oauth_blob timeout must accommodate fleet-agent's "
+			"doctor + restart + healthz chain (~120s typical, 150s cap)")
 
 
 class TestPostSubscriptionDisconnect(FrappeTestCase):


### PR DESCRIPTION
Companion to admin PR fix/auth-profile-timeout-includes-doctor-restart. admin's put_auth_profile now allows up to 150s for fleet-agent's doctor + restart + healthz chain. Bench's _post default was 90s, which caps below admin's bound - bench would time out before admin could return even on a healthy push.

Bump post_push_oauth_blob's timeout to 180s (admin's 150s + ~30s for HTTPS round-trip + admin response serialization). Lock the lower bound in the happy-path test so future timeout regressions surface in CI instead of in production.

Verified live 2026-06-12: re-onboarding traceback was
  AdminUnreachableError: ... Read timed out. (read timeout=15)
That 15s was admin's internal timeout to fleet-agent (fixed in companion PR). 90s here would have hit at the next layer if admin's were already correct. Fixing both atomically avoids whack-a-mole.

Tests: 29 admin_client tests pass.