### PR TITLE
chore: replace browser confirm() with frappe.confirm() in customer UI

### DIFF
--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -355,36 +355,47 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		const currentMode = settingsLocal.llm_auth_mode === "oauth" ? "subscription" : "api_key";
 		// Switching to a tab that diverges from the active mode → preview-only,
 		// no destructive action until the user actively confirms (Save / Confirm switch).
-		if (targetTab === "api_key" && currentMode === "subscription") {
-			if (!confirm("Switch to API-key mode? Your chat subscription will be disconnected when you save credentials.")) return;
-		}
-		ui.aiTab = targetTab;
-		if (targetTab !== "subscription") cancelSubscriptionFlow();
+		// frappe.confirm is callback-based, so the actual switch lives in an
+		// inner function called from either the on-yes branch or the no-
+		// confirm-needed direct path.
+		const applySwitch = () => {
+			ui.aiTab = targetTab;
+			if (targetTab !== "subscription") cancelSubscriptionFlow();
 
-		// Drive the slide animation by updating data-active on the persistent
-		// tabs node. Swap only the panel body (fade out → swap → fade in)
-		// instead of re-rendering the whole card, so the slide isn't
-		// interrupted by a DOM rebuild.
-		const sub = account.subscription_status || "none";
-		const editable = EDITABLE_STATES.has(sub);
-		const $tabs = $body.find(".ja-tabs");
-		$tabs.attr("data-active", targetTab);
-		$tabs.find(".ja-tab").each(function () {
-			const isActive = $(this).data("tab") === targetTab;
-			$(this).toggleClass("ja-tab-active", isActive).attr("aria-selected", isActive);
-		});
-		const inApiKeyMode = settingsLocal.llm_auth_mode !== "oauth";
-		const newBody = targetTab === "api_key"
-			? renderApiKeyPanel(editable, inApiKeyMode)
-			: renderSubscriptionPanel(editable, !inApiKeyMode);
-		const $panel = $body.find(".ja-tab-body");
-		$panel.addClass("ja-tab-body-swap");
-		setTimeout(() => {
-			$panel.html(newBody);
-			$panel.removeClass("ja-tab-body-swap");
-			if (targetTab === "api_key") bindLlm(editable);
-			else bindSubscriptionPanel(editable);
-		}, 160);
+			// Drive the slide animation by updating data-active on the persistent
+			// tabs node. Swap only the panel body (fade out → swap → fade in)
+			// instead of re-rendering the whole card, so the slide isn't
+			// interrupted by a DOM rebuild.
+			const sub = account.subscription_status || "none";
+			const editable = EDITABLE_STATES.has(sub);
+			const $tabs = $body.find(".ja-tabs");
+			$tabs.attr("data-active", targetTab);
+			$tabs.find(".ja-tab").each(function () {
+				const isActive = $(this).data("tab") === targetTab;
+				$(this).toggleClass("ja-tab-active", isActive).attr("aria-selected", isActive);
+			});
+			const inApiKeyMode = settingsLocal.llm_auth_mode !== "oauth";
+			const newBody = targetTab === "api_key"
+				? renderApiKeyPanel(editable, inApiKeyMode)
+				: renderSubscriptionPanel(editable, !inApiKeyMode);
+			const $panel = $body.find(".ja-tab-body");
+			$panel.addClass("ja-tab-body-swap");
+			setTimeout(() => {
+				$panel.html(newBody);
+				$panel.removeClass("ja-tab-body-swap");
+				if (targetTab === "api_key") bindLlm(editable);
+				else bindSubscriptionPanel(editable);
+			}, 160);
+		};
+
+		if (targetTab === "api_key" && currentMode === "subscription") {
+			frappe.confirm(
+				__("Switch to API-key mode? Your chat subscription will be disconnected when you save credentials."),
+				applySwitch,
+			);
+			return;
+		}
+		applySwitch();
 	}
 
 	function bindSubscriptionPanel(editable) {
@@ -400,16 +411,23 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		}
 		if (isActiveMode) {
 			$body.find("#ja-sub-disconnect").on("click", () => {
-				if (!confirm("Disconnect the LLM subscription? Jarvis chat will stop working until you reconnect.")) return;
-				frappe.call({ method: "jarvis.oauth.api.disconnect" }).then((r) => {
-					const m = r.message || {};
-					if (m.ok) {
-						frappe.show_alert({ message: "Disconnected.", indicator: "orange" });
-						loadInitial();
-					} else {
-						frappe.show_alert({ message: (m.error && m.error.message) || "Disconnect failed.", indicator: "red" });
-					}
-				});
+				frappe.confirm(
+					__("Disconnect the LLM subscription? Jarvis chat will stop working until you reconnect."),
+					() => {
+						frappe.call({ method: "jarvis.oauth.api.disconnect" }).then((r) => {
+							const m = r.message || {};
+							if (m.ok) {
+								frappe.show_alert({ message: __("Disconnected."), indicator: "orange" });
+								loadInitial();
+							} else {
+								frappe.show_alert({
+									message: (m.error && m.error.message) || __("Disconnect failed."),
+									indicator: "red",
+								});
+							}
+						});
+					},
+				);
 			});
 			$body.find("#ja-sub-reauth").on("click", () => {
 				cancelSubscriptionFlow();

--- a/jarvis/public/js/jarvis_chat/sidebar.js
+++ b/jarvis/public/js/jarvis_chat/sidebar.js
@@ -53,29 +53,33 @@ export async function refreshSidebar($sidebar, $empty, onSelect, onArchive) {
 		// filters status='Active', so archived rows fall out of view).
 		// Delegates the API call + cleanup to onArchive (the controller in
 		// index.js) so this stays a pure UI affordance.
-		$item.find(".jarvis-conv-delete").on("click", async (e) => {
+		$item.find(".jarvis-conv-delete").on("click", (e) => {
 			e.stopPropagation();   // don't trigger onSelect on the row
-			const ok = window.confirm(
-				`Delete "${title}"?\n\nThis can't be undone.`
-			);
-			if (!ok) return;
-			try {
-				if (typeof onArchive === "function") {
-					await onArchive(c.name);
-				} else {
-					// Fallback if no callback is wired (shouldn't happen).
-					await api.archiveConversation(c.name);
+			// frappe.confirm is callback-based (not boolean) so the work
+			// has to live inside the on-yes branch. on-no = no-op.
+			frappe.confirm(
+				__("Delete {0}?", [`<b>${frappe.utils.escape_html(title)}</b>`])
+				+ "<br><br>" + __("This can't be undone."),
+				async () => {
+					try {
+						if (typeof onArchive === "function") {
+							await onArchive(c.name);
+						} else {
+							// Fallback if no callback is wired (shouldn't happen).
+							await api.archiveConversation(c.name);
+						}
+						frappe.show_alert({
+							message: __("Deleted") + ` "${title}"`,
+							indicator: "orange",
+						});
+					} catch (err) {
+						frappe.show_alert({
+							message: __("Couldn't delete: ") + (err.message || err),
+							indicator: "red",
+						});
+					}
 				}
-				frappe.show_alert({
-					message: __("Deleted") + ` "${title}"`,
-					indicator: "orange",
-				});
-			} catch (err) {
-				frappe.show_alert({
-					message: __("Couldn't delete: ") + (err.message || err),
-					indicator: "red",
-				});
-			}
+			);
 		});
 
 		$sidebar.append($item);


### PR DESCRIPTION
Browser-native confirm dialogs render outside Frappe's chrome (no theme, no Esc/Enter affordances, no i18n via __()) and look like a phishing prompt from the customer's perspective. Switch all three sites to frappe.confirm so the dialog inherits Frappe's modal styling and __() covers the strings.

frappe.confirm is callback-based (not boolean), so the post-confirm work has to live inside the on-yes branch instead of after an `if (!confirm()) return`. Where the post-confirm body is long enough that inlining would be ugly, it's extracted into a small inner function and called from both the confirm callback and the no-confirm-needed direct path.

Sites changed:
  - public/js/jarvis_chat/sidebar.js: per-conversation delete affordance ("Delete <title>? This can't be undone.")
  - jarvis/page/jarvis_account/jarvis_account.js (2 sites):
    - tab switch from Chat subscription -> API key mode (warns the customer that saving credentials disconnects the subscription; extracted body into `applySwitch` so both confirm-yes and the no-confirm direct path call it)
    - subscription disconnect button (warns that chat stops working until reconnect)

Built artifacts (`jarvis/public/dist/`) are not tracked - `bench build` regenerates them at deploy time. Local rebuild verified:
  grep -c 'frappe.confirm' jarvis/public/dist/js/jarvis_chat.bundle.*.js
  -> 1
  grep -c 'window.confirm' jarvis/public/dist/js/jarvis_chat.bundle.*.js
  -> 0