### PR TITLE
feat(settings): Enable Sandbox Mode checkbox replaces frappe.conf.dev…

### DIFF
--- a/jarvis/boot.py
+++ b/jarvis/boot.py
@@ -1,0 +1,27 @@
+"""Frappe boot_session hook.
+
+Frappe builds the per-session ``bootinfo`` blob that the desk + page JS
+reads from ``frappe.boot`` at page load. Apps register a single hook
+function via ``hooks.boot_session`` to write their own keys onto that
+blob. This file is that function for jarvis.
+
+Today the only key we set is ``jarvis_sandbox_mode``, replacing the
+previous JS-side check on ``frappe.boot.developer_mode``. Sandbox mode
+controls whether the developer-onboarding shortcut + the Jarvis Settings
+DEV-only reset button are surfaced; see ``jarvis.dev.is_sandbox_mode``
+for the resolution rules.
+"""
+
+import frappe
+
+
+def set_jarvis_boot(bootinfo):
+	"""Run once per session at page load. Adds jarvis-specific keys to the
+	bootinfo blob so JS can branch on them without an extra round trip."""
+	from jarvis.dev import is_sandbox_mode
+	try:
+		bootinfo.jarvis_sandbox_mode = bool(is_sandbox_mode())
+	except Exception:
+		# Don't let a misconfigured doctype or missing migration break the
+		# session boot. JS treats the missing key as false (default off).
+		bootinfo.jarvis_sandbox_mode = False

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -1,8 +1,10 @@
 """Dev-only helpers for the customer bench.
 
-Gated by ``frappe.conf.developer_mode`` + the System Manager role. Used by
-the Jarvis Settings form to wipe local state so the operator can run the
-onboarding wizard fresh without manual DB surgery.
+Gated by sandbox mode (Jarvis Settings.sandbox_mode, with legacy
+frappe.conf.developer_mode as a one-release backwards-compat fallback)
++ the System Manager role. Used by the Jarvis Settings form to wipe local
+state so the operator can run the onboarding wizard fresh without manual
+DB surgery.
 
 Companion to ``jarvis_admin.api.dev.purge_customer`` on the admin side -
 the admin button wipes admin-side records; this clears the customer bench.
@@ -26,13 +28,41 @@ _PASSWORD_FIELDS = {
 }
 
 
+def is_sandbox_mode() -> bool:
+	"""Return True iff this site is in sandbox mode.
+
+	Resolution:
+	  1. ``Jarvis Settings.sandbox_mode = 1`` (the canonical flag)
+	  2. legacy fallback: ``frappe.conf.developer_mode`` is truthy
+	     (kept for one release so existing dev installs don't break;
+	     remove this branch in the release after this one)
+
+	Either condition opens the dev surface (dev_onboard, reset_onboarding,
+	the DEV-only reset button in Jarvis Settings). Customer responsibility:
+	flip this only on dev/test benches. The trust model is self-attested -
+	same as the legacy developer_mode behavior - so this is not a security
+	hardening, just a UX improvement (discoverable in the settings form,
+	doesn't bleed across apps, doesn't require a bench restart)."""
+	try:
+		if frappe.get_single_value(SETTINGS, "sandbox_mode"):
+			return True
+	except Exception:
+		# DocType may not be migrated yet on a fresh install; fall through
+		# to the legacy check rather than crashing.
+		pass
+	return bool(frappe.conf.get("developer_mode"))
+
+
 def _dev_guard():
-	"""Reject unless developer_mode is enabled AND the caller is a System
+	"""Reject unless sandbox mode is enabled AND the caller is a System
 	Manager. Sets HTTP 403 + throws so the form action surfaces the standard
 	red dialog."""
-	if not frappe.conf.get("developer_mode"):
+	if not is_sandbox_mode():
 		frappe.local.response.http_status_code = 403
-		frappe.throw("developer_mode is not enabled in site_config")
+		frappe.throw(
+			"Sandbox mode is not enabled. Set Jarvis Settings -> "
+			"Enable Sandbox Mode (or, legacy: developer_mode in site_config)."
+		)
 	if "System Manager" not in frappe.get_roles():
 		frappe.local.response.http_status_code = 403
 		frappe.throw("System Manager role required")
@@ -42,7 +72,7 @@ def _dev_guard():
 def is_dev_mode_active() -> dict:
 	"""Cheap probe so the Jarvis Settings form JS can decide whether to
 	surface the reset button. Returns ``{active: True}`` iff both gates
-	(developer_mode + System Manager) pass for the current user."""
+	(sandbox mode + System Manager) pass for the current user."""
 	try:
 		_dev_guard()
 		return {"ok": True, "data": {"active": True}}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -5,6 +5,15 @@ app_description = "AI superpowers for Frappe/ERPNext"
 app_email = "navin@aerele.in"
 app_license = "MIT"
 
+
+# ---------------------------------------------------------------------------
+# Per-session bootinfo
+# ---------------------------------------------------------------------------
+# Frappe calls this once per page load. We use it to expose
+# ``frappe.boot.jarvis_sandbox_mode`` so JS can branch on sandbox state
+# without a round-trip back to the server.
+boot_session = "jarvis.boot.set_jarvis_boot"
+
 # ---------------------------------------------------------------------------
 # Deployment constants
 # ---------------------------------------------------------------------------

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -48,8 +48,11 @@ frappe.ui.form.on("Jarvis Settings", {
 			});
 		}, __("Diagnostics"));
 
-		// DEV-only reset: visible when developer_mode is on AND caller is
-		// System Manager. The server re-checks both gates.
+		// DEV-only reset: visible when sandbox mode is on AND caller is
+		// System Manager. The server re-checks both gates - is_dev_mode_active
+		// resolves "sandbox mode" through jarvis.dev.is_sandbox_mode (which
+		// reads Jarvis Settings.sandbox_mode, with legacy frappe.conf.
+		// developer_mode as a one-release fallback).
 		frappe.call({ method: "jarvis.dev.is_dev_mode_active" }).then((r) => {
 			if (!(r && r.message && r.message.data && r.message.data.active)) return;
 			frm.add_custom_button(__("Reset onboarding (DEV)"), () => {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -37,7 +37,9 @@
     "chat_device_token",
     "last_sync_section",
     "last_sync_at",
-    "last_sync_status"
+    "last_sync_status",
+    "developer_section",
+    "sandbox_mode"
   ],
   "fields": [
     {
@@ -241,6 +243,18 @@
       "fieldtype": "Long Text",
       "label": "Last Sync Status",
       "read_only": 1
+    },
+    {
+      "fieldname": "developer_section",
+      "fieldtype": "Section Break",
+      "label": "Developer / Sandbox"
+    },
+    {
+      "fieldname": "sandbox_mode",
+      "fieldtype": "Check",
+      "label": "Enable Sandbox Mode",
+      "default": "0",
+      "description": "When enabled, skip payment + allow the developer-onboarding shortcut (jarvis.onboarding.dev_onboard) on this site. Customer's responsibility: only flip this on a dev/test bench. Replaces the legacy <code>frappe.conf.developer_mode</code> check; that flag still works as a backwards-compat fallback for one release."
     }
   ],
   "permissions": [

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -1,6 +1,11 @@
 frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	const page = frappe.ui.make_app_page({ parent: wrapper, title: "Connect to Jarvis", single_column: true });
-	const dev = !!frappe.boot.developer_mode;
+	// `dev` gates the dev-onboard shortcut (skip payment).
+	// Replaces the legacy `frappe.boot.developer_mode` check with the
+	// per-site `Jarvis Settings.sandbox_mode` flag, exposed via
+	// jarvis.boot.set_jarvis_boot. Falls back to developer_mode for one
+	// release so existing dev installs aren't disrupted.
+	const dev = !!(frappe.boot.jarvis_sandbox_mode || frappe.boot.developer_mode);
 	if (!dev && !window.Razorpay) {
 		frappe.require("https://checkout.razorpay.com/v1/checkout.js");
 	}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -164,12 +164,25 @@ def get_llm_sync_status() -> dict:
 def dev_onboard(email: str, company: str, plan: str) -> dict:
 	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection.
 
+	Server-side gated on sandbox mode (Jarvis Settings.sandbox_mode, with
+	legacy frappe.conf.developer_mode as a one-release backwards-compat
+	fallback). Without the gate, this whitelisted endpoint would let any
+	authenticated user skip payment - the JS-only check on
+	``frappe.boot.jarvis_sandbox_mode`` is just UX, not security.
+
 	Requires ``Jarvis Settings.jarvis_admin_url`` to be set first. Earlier
 	versions auto-populated it from ``frappe.utils.get_url()``, but that
 	returns the bench-wide URL (the host_name in common_site_config) instead
 	of the current site URL. On a multi-site bench that quietly lands the
 	wrong value into the wrong site's Jarvis Settings. Force the operator to
 	set it deliberately."""
+	from jarvis.dev import is_sandbox_mode
+	if not is_sandbox_mode():
+		frappe.local.response.http_status_code = 403
+		frappe.throw(
+			"dev_onboard requires sandbox mode. Enable it in Jarvis "
+			"Settings -> Enable Sandbox Mode before retrying."
+		)
 	data = _surface(admin_client.dev_signup, email, company, plan)
 	write_connection(data)
 	return data

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.dev import is_dev_mode_active, reset_onboarding, _RESET_CLEAR_FIELDS
+from jarvis.dev import is_dev_mode_active, is_sandbox_mode, reset_onboarding, _RESET_CLEAR_FIELDS
 
 
 SETTINGS = "Jarvis Settings"
@@ -98,12 +98,18 @@ class TestResetOnboardingGuards(FrappeTestCase):
 		frappe.conf.developer_mode = self._prior_dev_mode
 		_restore(self._snap)
 
-	def test_rejects_when_developer_mode_off(self):
+	def test_rejects_when_sandbox_mode_off(self):
 		frappe.conf.developer_mode = 0
+		# Make sure Jarvis Settings.sandbox_mode is also off (the doctype
+		# field is the new canonical source; conf.developer_mode is the
+		# one-release legacy fallback).
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
+		frappe.db.commit()
 		with self.assertRaises(frappe.ValidationError) as cm:
 			reset_onboarding()
 		self.assertEqual(frappe.local.response.http_status_code, 403)
-		self.assertIn("developer_mode", str(cm.exception))
+		# Error message references the new flag name + the legacy fallback.
+		self.assertIn("sandbox", str(cm.exception).lower())
 
 	def test_rejects_when_non_system_manager(self):
 		frappe.conf.developer_mode = 1
@@ -131,6 +137,53 @@ class TestIsDevModeActive(FrappeTestCase):
 
 	def test_false_when_developer_mode_off(self):
 		frappe.conf.developer_mode = 0
+		# Belt-and-suspenders: also make sure Jarvis Settings.sandbox_mode
+		# is off; otherwise it would also flip is_dev_mode_active to True.
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
+		frappe.db.commit()
 		out = is_dev_mode_active()
 		self.assertEqual(out["data"]["active"], False)
 		self.assertEqual(frappe.local.response.http_status_code, 200)
+
+
+class TestIsSandboxMode(FrappeTestCase):
+	"""is_sandbox_mode resolution: Jarvis Settings.sandbox_mode wins, then
+	the legacy frappe.conf.developer_mode fallback (one release only)."""
+
+	def setUp(self):
+		self._prior_dev_mode = frappe.conf.get("developer_mode") or 0
+		self._prior_sandbox = frappe.get_single("Jarvis Settings").get("sandbox_mode") or 0
+
+	def tearDown(self):
+		frappe.conf.developer_mode = self._prior_dev_mode
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", self._prior_sandbox)
+		frappe.db.commit()
+
+	def test_true_when_sandbox_field_set(self):
+		frappe.conf.developer_mode = 0
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
+		frappe.db.commit()
+		self.assertTrue(is_sandbox_mode())
+
+	def test_true_when_only_legacy_developer_mode_set(self):
+		# Backwards-compat fallback: existing dev installs that have
+		# developer_mode in site_config but never migrated their
+		# Jarvis Settings to the new flag still get the dev surface.
+		frappe.conf.developer_mode = 1
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
+		frappe.db.commit()
+		self.assertTrue(is_sandbox_mode())
+
+	def test_false_when_both_off(self):
+		frappe.conf.developer_mode = 0
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
+		frappe.db.commit()
+		self.assertFalse(is_sandbox_mode())
+
+	def test_sandbox_field_wins_over_legacy_off(self):
+		# The new flag is the canonical source - legacy off + new on
+		# should still report sandbox active.
+		frappe.conf.developer_mode = 0
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
+		frappe.db.commit()
+		self.assertTrue(is_sandbox_mode())


### PR DESCRIPTION
…eloper_mode

Adds Jarvis Settings -> "Enable Sandbox Mode" as the canonical flag for gating the developer-onboarding shortcut (skip Razorpay payment) + the DEV-only reset button on the Jarvis Settings form. Replaces direct reads of frappe.conf.developer_mode with jarvis.dev.is_sandbox_mode(), which:
  1. Returns True if Jarvis Settings.sandbox_mode is set (canonical).
  2. Falls back to frappe.conf.developer_mode for one release so existing dev installs keep working without a manual flip.

Why move off developer_mode:
  - It's a Frappe-wide flag; using it as a Jarvis feature flag bleeds behavior across apps and can flip unintentionally when a developer enables it for unrelated reasons.
  - It's stored in site_config.json, undiscoverable from the desk UI.
  - Flipping it sometimes requires a bench restart on certain Frappe versions; a doctype checkbox is live-toggleable.

Trust model is UNCHANGED - sandbox is self-attested on the customer bench, same as developer_mode was. This is a UX win, not a security hardening. The dev_onboard endpoint is now ALSO server-side guarded (previously whitelisted but ungated; only the JS UI hid the affordance).

Changes:
  - jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json: new "Developer / Sandbox" section + sandbox_mode Check field (default off, System Manager-writable per existing permissions).
  - jarvis/dev.py: new is_sandbox_mode() helper, _dev_guard uses it. Error message points operators at the new field with the legacy fallback called out.
  - jarvis/onboarding.py: dev_onboard now server-side gated on is_sandbox_mode() before calling admin_client.dev_signup.
  - jarvis/boot.py (new): hooks.boot_session entrypoint that writes frappe.boot.jarvis_sandbox_mode for JS to read without a round trip.
  - jarvis/hooks.py: registers boot_session = "jarvis.boot.set_jarvis_boot".
  - jarvis/page/jarvis_onboarding/jarvis_onboarding.js: reads the new boot key with legacy frappe.boot.developer_mode as fallback.
  - jarvis/doctype/jarvis_settings/jarvis_settings.js: comment refresh (the DEV-only button already calls is_dev_mode_active server-side, which now resolves through is_sandbox_mode).

Tests: 10 dev tests pass (4 new sandbox-mode tests + the existing 6 with the error-message assertion updated). 102 jarvis tests pass in total.

Existing dev installs with `developer_mode: 1` in site_config keep working unchanged due to the fallback. Migration story: flip the new checkbox in Jarvis Settings, then remove developer_mode from site_config when convenient. The fallback will be removed in the release after this one.