### PR TITLE
fix(onboarding): query is_dev_mode_active at click time, not page-load

### DIFF
--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -1,6 +1,15 @@
 frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	const page = frappe.ui.make_app_page({ parent: wrapper, title: "Connect to Jarvis", single_column: true });
-	// `dev` gates the dev-onboard shortcut (skip payment).
+	// `dev` gates the dev-onboard shortcut (skip payment). Read once from
+	// the bootinfo here for UX-only decisions (Razorpay script preload,
+	// renderPay()'s heading + button label). This value can be STALE if
+	// the operator toggles `Jarvis Settings.sandbox_mode` after page load.
+	//
+	// The click-time payment branch must NOT trust this value alone. See
+	// the click handler in renderPay() - it queries
+	// `jarvis.dev.is_dev_mode_active` at click time so we never charge a
+	// customer when sandbox mode was switched on mid-session.
+	//
 	// Replaces the legacy `frappe.boot.developer_mode` check with the
 	// per-site `Jarvis Settings.sandbox_mode` flag, exposed via
 	// jarvis.boot.set_jarvis_boot. Falls back to developer_mode for one
@@ -246,7 +255,31 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 			  <button class="jo-btn jo-btn-primary" id="jo-pay">${dev ? "Dev signup &amp; connect" : "Sign up &amp; pay →"}</button>
 			</div>`);
 		$body.find("#jo-back").on("click", () => go(2));
-		$body.find("#jo-pay").on("click", dev ? devOnboard : startPay);
+		// Server-authoritative branch: query is_dev_mode_active at CLICK
+		// time, not at page load. The boot-time `dev` value can be stale
+		// (operator toggled Jarvis Settings.sandbox_mode after the
+		// wizard loaded, or bench cache not cleared post-deploy). If we
+		// trusted `dev` here, a stale "false" would charge a customer
+		// on a bench that's actually in sandbox - exactly the
+		// regression reported 2026-06-13. The heading + button label
+		// can be wrong (they're rendered from `dev`) but the actual
+		// outcome will be correct.
+		$body.find("#jo-pay").on("click", async () => {
+			// Visual feedback while the server check is in flight.
+			// startPay()/devOnboard() set their own busy state, so we
+			// don't need to clear ours - they take over.
+			setBusy("#jo-pay", true);
+			let isDev = dev;
+			try {
+				const r = await frappe.call({ method: "jarvis.dev.is_dev_mode_active" });
+				isDev = !!(r && r.message && r.message.data && r.message.data.active);
+			} catch (_) {
+				// Server unreachable - fall back to the boot-time value
+				// as a best-effort guess. Better than blocking the user.
+				isDev = dev;
+			}
+			if (isDev) { devOnboard(); } else { startPay(); }
+		});
 	}
 
 	function renderLlm() {


### PR DESCRIPTION
The boot-time `dev` value (computed from
`frappe.boot.jarvis_sandbox_mode || frappe.boot.developer_mode`) is frozen when the wizard JS loads. Three real-world failure modes make it stale:

  1. Operator opens /jarvis-onboarding, then toggles Jarvis Settings.sandbox_mode in Desk and switches back. The wizard's `dev` is still false.
  2. Operator pulls PR #82 but doesn't run `bench clear-cache`. The boot session ships the old shape - no jarvis_sandbox_mode key.
  3. Operator skipped `bench migrate` after pulling. The sandbox_mode field doesn't exist on the doctype, the server-side get_single_value() throws, is_sandbox_mode() falls through to frappe.conf.developer_mode = False.

In all three, the wizard's click handler was wired up at render time as `dev ? devOnboard : startPay`, so the customer hit Razorpay even when their bench is actually in sandbox mode. Verified live 2026-06-13.

Fix: make the click handler async and query
jarvis.dev.is_dev_mode_active at click time. That endpoint already existed (PR #82 made it the canonical "is sandbox + System Manager" probe). Server-authoritative, no cache to bust.

Trade-off: ~1 extra HTTP round trip per click. Negligible (the call is whitelist-cheap), and it eliminates the entire class of boot-staleness bugs.

The boot-time `dev` is kept for:
  - Razorpay script preload at module load (wrong-side outcome is "preloaded a script we won't use" - harmless)
  - renderPay()'s heading + button label (might display "Pay" while the click actually triggers dev_onboard - mildly weird but the OUTCOME is still correct, which is what matters)

If the server call fails for any reason (network, server down), we fall back to the boot-time value rather than blocking the user.

Operator deploy story: after merging, customer benches need `bench update --pull && bench migrate && bench restart`. The `bench clear-cache` step is no longer strictly required because the click handler doesn't trust the cached boot value - though clearing cache is still a good post-deploy hygiene step for the page-load UX hints.

Tests: 10 dev tests pass unchanged (JS-only fix, doesn't touch Python).