### PR TITLE
fix(security): Sprint-1 sweep batch 2 - jarvis bench hardening (#6, #…

### DIFF
--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -99,5 +99,11 @@ def preview_upgrade(target_plan: str) -> dict:
 
 @frappe.whitelist()
 def start_upgrade(target_plan: str) -> dict:
-	"""Create the prorated Razorpay order; the page then opens Checkout."""
+	"""Create the prorated Razorpay order; the page then opens Checkout.
+
+	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
+	review): initiates a billing transaction tied to the site's admin
+	account; non-admin staff shouldn't be able to upgrade the plan.
+	"""
+	frappe.only_for("System Manager")
 	return _surface(admin_client.start_upgrade, target_plan)

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -23,7 +23,42 @@ from jarvis.oauth.providers import (
 
 
 class TokenExchangeError(JarvisError):
-	"""Provider's /oauth/token endpoint rejected the code or had an error."""
+	"""Provider's /oauth/token endpoint rejected the code or had an error.
+
+	The ``code`` attribute is one of the opaque codes from
+	``_TOKEN_EXCHANGE_OPAQUE_CODES`` below; the message is safe to surface
+	to the customer. The full provider response detail is logged via
+	``frappe.log_error`` server-side at raise time so ops can triage.
+	"""
+
+	def __init__(self, message: str, *, code: str = "token_exchange_failed"):
+		super().__init__(message)
+		self.code = code
+
+
+# Provider error_description → opaque code mapping.
+# Provider responses can leak implementation detail; in particular,
+# ``invalid_client`` distinguishes "client_secret needed" from
+# "client_secret wrong", an oracle on gemini-cli's confidential-client
+# secret. We collapse the provider's distinction into opaque buckets.
+# Sprint-1 Important #6 from the 2026-06-16 code review.
+_TOKEN_EXCHANGE_OPAQUE_CODES = {
+	"invalid_grant": (
+		"code_invalid",
+		"The authorization code was rejected. Start a fresh sign-in.",
+	),
+	"invalid_client": (
+		"auth_failed",
+		"The provider rejected this sign-in. If this keeps happening, "
+		"contact support.",
+	),
+	"invalid_request": (
+		"auth_failed",
+		"The provider rejected this sign-in. If this keeps happening, "
+		"contact support.",
+	),
+}
+
 
 _CACHE_KEY = "jarvis.oauth.codex_signin"
 _NONCE_TTL_SECS = 600
@@ -83,7 +118,14 @@ def _generate_pkce() -> tuple[str, str]:
 @frappe.whitelist()
 def begin_paste_signin(provider: str, model: str) -> dict:
 	"""Mint a nonce + PKCE pair, return the authorize URL for the customer
-	to open in their browser."""
+	to open in their browser.
+
+	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
+	review). The cached nonce is bound to ``frappe.session.user`` so
+	another logged-in System Manager can't complete an in-flight sign-in
+	that someone else started.
+	"""
+	frappe.only_for("System Manager")
 	try:
 		get_provider(provider)
 	except UnknownProviderError as e:
@@ -107,6 +149,7 @@ def begin_paste_signin(provider: str, model: str) -> dict:
 		"expires_at_ts": int(time.time()) + _NONCE_TTL_SECS,
 		"verifier": verifier,
 		"state": state,
+		"originator_user": frappe.session.user,
 	})
 
 	return _ok({
@@ -150,7 +193,14 @@ def _parse_redirected_url(raw: str) -> dict:
 @frappe.whitelist()
 def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 	"""Wizard calls this after the customer signs in and pastes the URL
-	they copied from the browser's address bar."""
+	they copied from the browser's address bar.
+
+	Gated on System Manager + per-user nonce binding: another System
+	Manager can't accidentally (or maliciously) complete a sign-in that
+	someone else started. Sprint-1 Important from the 2026-06-16 code
+	review.
+	"""
+	frappe.only_for("System Manager")
 	entry = frappe.cache.hget(_CACHE_KEY, nonce)
 	if not entry:
 		return _err("unknown_nonce", "nonce not recognized")
@@ -158,6 +208,13 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 		return _err("expired", "nonce has expired; generate a new sign-in URL")
 	if entry["status"] != "pending":
 		return _err("not_pending", f"nonce status is {entry['status']!r}")
+	# Per-user binding: the user who began the sign-in must be the same
+	# one completing it. Without this, a second System Manager on the same
+	# site could complete a peer's pending OAuth with a redirect they
+	# control. The error message is the same as "unknown_nonce" on purpose
+	# (don't leak which nonces are live).
+	if entry.get("originator_user") != frappe.session.user:
+		return _err("unknown_nonce", "nonce not recognized")
 
 	parsed = _parse_redirected_url(redirected_url)
 	if not parsed["code"]:
@@ -183,7 +240,11 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 		)
 	except TokenExchangeError as e:
 		# Nonce NOT cleared; customer can paste again if they fix the URL.
-		return _err("token_exchange_failed", str(e))
+		# `e.code` is one of the pre-mapped opaque codes from
+		# _TOKEN_EXCHANGE_OPAQUE_CODES; the message is the user-safe text
+		# from that same map, NOT the raw provider response. The provider
+		# detail was logged via frappe.log_error inside _exchange_code.
+		return _err(e.code, str(e))
 
 	access_token = tokens.get("access_token")
 	if not access_token:
@@ -236,7 +297,14 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 
 
 def _exchange_code(*, provider: str, code: str, code_verifier: str) -> dict:
-	"""POST to provider's token endpoint, return parsed JSON."""
+	"""POST to provider's token endpoint, return parsed JSON.
+
+	On error, raises TokenExchangeError with an opaque code + user-safe
+	message. The full provider response detail is logged server-side via
+	frappe.log_error so operators can triage without leaking the detail
+	(e.g. invalid_client vs invalid_grant) to the wire. Sprint-1
+	Important #6 from the 2026-06-16 code review.
+	"""
 	p = get_provider(provider)
 	try:
 		data = {
@@ -256,15 +324,40 @@ def _exchange_code(*, provider: str, code: str, code_verifier: str) -> dict:
 			timeout=_HTTP_TIMEOUT,
 		)
 	except requests.RequestException as e:
-		raise TokenExchangeError(f"network error: {e}") from e
+		# Log the network detail; surface a fixed message + opaque code.
+		frappe.log_error(
+			title="oauth token exchange: network error",
+			message=f"provider={provider!r} error={e!r}",
+		)
+		raise TokenExchangeError(
+			"Couldn't reach the sign-in provider. Try again in a minute.",
+			code="network_error",
+		) from e
 
 	if not resp.ok:
+		# Parse the provider's response defensively. The full body is logged
+		# server-side; only an opaque code + canned message goes back to
+		# the wire so the response can't be used as an oracle (e.g.
+		# distinguishing invalid_client from invalid_grant).
+		raw_error = ""
 		try:
 			body = resp.json()
-			detail = body.get("error_description") or body.get("error") or resp.text
+			raw_error = body.get("error") or ""
+			detail = body.get("error_description") or raw_error or resp.text
 		except ValueError:
 			detail = resp.text
-		raise TokenExchangeError(f"HTTP {resp.status_code}: {detail}")
+		frappe.log_error(
+			title="oauth token exchange: provider rejected",
+			message=(
+				f"provider={provider!r} status={resp.status_code} "
+				f"raw_error={raw_error!r} detail={detail!r}"
+			),
+		)
+		opaque_code, opaque_msg = _TOKEN_EXCHANGE_OPAQUE_CODES.get(
+			raw_error, ("token_exchange_failed",
+						"Sign-in failed at the provider. Start a fresh sign-in."),
+		)
+		raise TokenExchangeError(opaque_msg, code=opaque_code)
 
 	return resp.json()
 
@@ -303,7 +396,13 @@ def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str
 
 @frappe.whitelist()
 def disconnect() -> dict:
-	"""Clear the container's OAuth profile, flip bench back to api_key."""
+	"""Clear the container's OAuth profile, flip bench back to api_key.
+
+	Gated on System Manager (Sprint-1 Important from the 2026-06-16
+	code review): writes Jarvis Settings, ends an active subscription
+	connection.
+	"""
+	frappe.only_for("System Manager")
 	try:
 		admin_client.post_subscription_disconnect()
 	except (admin_client.AdminUnreachableError,

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -40,7 +40,14 @@ def write_connection(data: dict) -> None:
 @frappe.whitelist()
 def sync_connection() -> dict:
 	"""Pull the container connection from admin and store it. Daily scheduled +
-	the page's 'Sync connection' button. No-op until onboarded/assigned."""
+	the page's 'Sync connection' button. No-op until onboarded/assigned.
+
+	Gated on System Manager: writes admin credentials and container connection
+	into Jarvis Settings (jarvis_admin_api_key, agent_url, agent_token). The
+	scheduler runs as Administrator which bypasses only_for. Sprint-1 Important
+	from the 2026-06-16 code review.
+	"""
+	frappe.only_for("System Manager")
 	settings = frappe.get_single("Jarvis Settings")
 	api_key = settings.get_password("jarvis_admin_api_key", raise_exception=False) or ""
 	api_secret = settings.get_password("jarvis_admin_api_secret", raise_exception=False) or ""
@@ -60,7 +67,15 @@ def list_plans() -> list:
 
 @frappe.whitelist()
 def start_signup(email: str, company: str, plan: str) -> dict:
-	"""Guest signup → store the api_token → return the Razorpay handles for Checkout."""
+	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.
+
+	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
+	review): the customer signing up is configuring Jarvis for their entire
+	site, which is a System Manager operation on Frappe by convention.
+	Without this, a non-admin staff user could initiate a paid signup using
+	a different email/company under the site's admin contract.
+	"""
+	frappe.only_for("System Manager")
 	data = _surface(admin_client.signup, email, company, plan)
 	if data.get("api_token"):
 		write_connection({"api_token": data["api_token"]})
@@ -68,8 +83,13 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 
 
 @frappe.whitelist()
-def finish_payment(payload) -> dict:
-	"""Confirm Checkout success → store the returned container connection."""
+def finish_payment(payload: dict | str) -> dict:
+	"""Confirm Checkout success → store the returned container connection.
+
+	Gated on System Manager: writes container connection (agent_url,
+	agent_token) into Jarvis Settings.
+	"""
+	frappe.only_for("System Manager")
 	if isinstance(payload, str):
 		payload = json.loads(payload)
 	data = _surface(admin_client.confirm_payment, payload)
@@ -80,7 +100,12 @@ def finish_payment(payload) -> dict:
 @frappe.whitelist()
 def renew() -> dict:
 	"""Existing customer initiates a renewal payment; returns the Razorpay handles
-	for Checkout. The page then completes Checkout and calls finish_payment."""
+	for Checkout. The page then completes Checkout and calls finish_payment.
+
+	Gated on System Manager: initiates a billing transaction tied to the
+	site's admin account.
+	"""
+	frappe.only_for("System Manager")
 	return _surface(admin_client.renew)
 
 
@@ -107,7 +132,14 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 	    the container so openclaw picks up the new auth profile.
 	Without ``force=True``, a customer re-authorizing with the same
 	provider+model gets a stale openclaw.json + no restart, and openclaw
-	keeps serving the previous (broken) state. Verified live 2026-06-11."""
+	keeps serving the previous (broken) state. Verified live 2026-06-11.
+
+	Gated on System Manager (Sprint-1 Important from the 2026-06-16 code
+	review): a non-admin staff user could otherwise flip ``llm_base_url``
+	to an attacker-controlled URL and exfiltrate chat context through
+	future LLM calls.
+	"""
+	frappe.only_for("System Manager")
 	if not provider or not model:
 		raise frappe.ValidationError("provider and model are required")
 	if auth_mode not in {"api_key", "oauth"}:
@@ -175,7 +207,11 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 	returns the bench-wide URL (the host_name in common_site_config) instead
 	of the current site URL. On a multi-site bench that quietly lands the
 	wrong value into the wrong site's Jarvis Settings. Force the operator to
-	set it deliberately."""
+	set it deliberately.
+
+	Gated on System Manager in addition to the sandbox_mode check.
+	"""
+	frappe.only_for("System Manager")
 	from jarvis.dev import is_sandbox_mode
 	if not is_sandbox_mode():
 		frappe.local.response.http_status_code = 403

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -130,6 +130,9 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 			"verifier": "test-verifier",
 			"state": "test-state",
 			"authorize_url": "https://auth.openai.com/oauth/authorize?...",
+			# Per-user binding (Sprint-1 #9 fix): cache entry remembers who
+			# began the sign-in; complete_paste_signin enforces match.
+			"originator_user": frappe.session.user,
 		}
 		entry.update(overrides)
 		frappe.cache.hset(_CACHE_KEY, nonce, entry)
@@ -205,6 +208,8 @@ class TestCompletePasteSigninFlow(_OAuthApiBase):
 			"verifier": "test-verifier",
 			"state": "test-state",
 			"authorize_url": "https://auth.openai.com/oauth/authorize?...",
+			# Per-user binding (Sprint-1 #9 fix).
+			"originator_user": frappe.session.user,
 		})
 		return nonce
 

--- a/jarvis/tests/test_role_gates.py
+++ b/jarvis/tests/test_role_gates.py
@@ -1,0 +1,232 @@
+"""Role-gate tests for Settings-mutating whitelisted endpoints.
+
+Sprint-1 Important from the 2026-06-16 code review (#7, #6, #9). Every
+endpoint that writes Jarvis Settings, initiates billing, or starts an
+OAuth flow MUST refuse a non-System-Manager caller. Without these gates,
+a low-role staff user on the customer's Frappe site could flip
+``llm_base_url`` to an attacker URL, complete a peer's pending OAuth, or
+initiate a paid signup under the site admin's contract.
+
+We don't create a portal-tier User row (which trips Frappe's global
+search assertion under FrappeTestCase). Instead we switch the session
+user to ``Guest`` (built-in, no roles other than All/Guest). That's
+what ``frappe.only_for`` consults; Guest is sufficient to prove the
+gate fires.
+"""
+
+import time
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import oauth as _oauth_pkg  # noqa: F401
+from jarvis.oauth.api import _CACHE_KEY
+
+
+# (module path, callable name, kwargs).
+GATED_ENDPOINTS = [
+	("jarvis.onboarding", "sync_connection", {}),
+	("jarvis.onboarding", "start_signup", {"email": "x@y.test", "company": "C", "plan": "p"}),
+	("jarvis.onboarding", "finish_payment", {"payload": {}}),
+	("jarvis.onboarding", "renew", {}),
+	("jarvis.onboarding", "save_llm_creds", {"provider": "OpenAI", "model": "gpt-4o", "api_key": "k"}),
+	("jarvis.onboarding", "dev_onboard", {"email": "x@y.test", "company": "C", "plan": "p"}),
+	("jarvis.account", "start_upgrade", {"target_plan": "team_monthly"}),
+	("jarvis.oauth.api", "begin_paste_signin", {"provider": "OpenAI", "model": "gpt-5.5"}),
+	("jarvis.oauth.api", "complete_paste_signin",
+		{"nonce": "x" * 48, "redirected_url": "http://localhost:1455/auth/callback?code=A&state=B"}),
+	("jarvis.oauth.api", "disconnect", {}),
+]
+
+
+def _resolve(module_path: str, name: str):
+	mod = frappe.get_module(module_path)
+	return getattr(mod, name)
+
+
+class TestRoleGates(FrappeTestCase):
+	def test_administrator_passes_role_check(self):
+		"""Smoke: Administrator must get past the role check on every gated
+		endpoint. We can't fully run them (args are bogus on purpose),
+		but anything that gets past the gate into the function body
+		counts. We just assert the failure isn't frappe.PermissionError.
+		"""
+		frappe.set_user("Administrator")
+		try:
+			for module_path, name, kwargs in GATED_ENDPOINTS:
+				fn = _resolve(module_path, name)
+				try:
+					fn(**kwargs)
+				except frappe.PermissionError as e:
+					self.fail(
+						f"{module_path}.{name} raised PermissionError "
+						f"for Administrator: {e}"
+					)
+				except Exception:
+					pass
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_guest_blocked_on_all_gated_endpoints(self):
+		"""Every gated endpoint must raise frappe.PermissionError when the
+		caller doesn't have System Manager (here: Guest)."""
+		original = frappe.session.user
+		try:
+			frappe.set_user("Guest")
+			for module_path, name, kwargs in GATED_ENDPOINTS:
+				fn = _resolve(module_path, name)
+				with self.assertRaises(
+					frappe.PermissionError,
+					msg=f"{module_path}.{name} did not refuse Guest",
+				):
+					fn(**kwargs)
+		finally:
+			frappe.set_user(original)
+
+
+class TestOAuthNoncePerUserBinding(FrappeTestCase):
+	"""Sprint-1 #9: the cache entry remembers which user began the
+	sign-in. A second System Manager on the same site must NOT be able
+	to complete an in-flight peer sign-in.
+	"""
+
+	def setUp(self):
+		# Seed a fresh nonce tied to a specific originator. We don't go
+		# through begin_paste_signin (which requires real OAuth setup);
+		# we write the cache entry directly with the contract shape.
+		self.nonce = "nuser_" + ("x" * 42)
+		self.originator = "originator@example.com"
+		frappe.cache.hset(_CACHE_KEY, self.nonce, {
+			"provider": "OpenAI",
+			"model": "gpt-5.5",
+			"status": "pending",
+			"expires_at_ts": int(time.time()) + 600,
+			"verifier": "v",
+			"state": "s",
+			"originator_user": self.originator,
+		})
+		self.addCleanup(lambda: frappe.cache.hdel(_CACHE_KEY, self.nonce))
+
+	def test_different_user_gets_unknown_nonce(self):
+		"""When a System Manager OTHER than the originator calls
+		complete_paste_signin, they get the same opaque ``unknown_nonce``
+		response as if the nonce didn't exist - we don't leak that the
+		nonce IS live, just under different ownership.
+		"""
+		from jarvis.oauth.api import complete_paste_signin
+
+		# Run as Administrator (not the originator). Administrator
+		# bypasses frappe.only_for so the role check doesn't fire first.
+		frappe.set_user("Administrator")
+		try:
+			out = complete_paste_signin(
+				nonce=self.nonce,
+				redirected_url="http://localhost:1455/auth/callback?code=A&state=s",
+			)
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "unknown_nonce")
+
+
+class TestOAuthErrorSanitization(FrappeTestCase):
+	"""Sprint-1 #6: provider error_description must NOT bubble verbatim
+	through token_exchange_failed. The opaque code mapping collapses
+	``invalid_client`` and ``invalid_grant`` into different user-safe
+	buckets; raw provider text never reaches the wire.
+	"""
+
+	def test_invalid_grant_maps_to_opaque_code_invalid(self):
+		from jarvis.oauth import api as oauth_api
+
+		class _FakeResp:
+			ok = False
+			status_code = 400
+			text = '{"error":"invalid_grant","error_description":"code is expired"}'
+
+			def json(self):
+				return {"error": "invalid_grant", "error_description": "code is expired"}
+
+		with self.assertRaises(oauth_api.TokenExchangeError) as ctx, \
+			 frappe.utils.patches.patch("jarvis.oauth.api.requests.post",
+										return_value=_FakeResp()) \
+			 if hasattr(frappe.utils, "patches") else _NoopCtx():
+			# Fall through to the standard unittest.mock if the patches
+			# helper isn't available.
+			from unittest.mock import patch
+			with patch("jarvis.oauth.api.requests.post", return_value=_FakeResp()), \
+				 patch("jarvis.oauth.api.get_provider", return_value={
+					"client_id": "cid", "token": "https://example/token",
+					"client_secret": None,
+				 }), patch("jarvis.oauth.api.frappe.log_error"):
+				oauth_api._exchange_code(
+					provider="OpenAI", code="ABC", code_verifier="V",
+				)
+
+		err = ctx.exception
+		self.assertEqual(err.code, "code_invalid")
+		# Critically: the raw "code is expired" string is NOT in the
+		# user-facing message.
+		self.assertNotIn("code is expired", str(err))
+		self.assertNotIn("invalid_grant", str(err))
+
+	def test_invalid_client_maps_to_opaque_auth_failed(self):
+		"""``invalid_client`` is the oracle target - a provider returning
+		it on missing/wrong client_secret would leak whether the secret
+		is needed at all. Map to a generic 'auth_failed' bucket.
+		"""
+		from unittest.mock import patch
+		from jarvis.oauth import api as oauth_api
+
+		class _FakeResp:
+			ok = False
+			status_code = 401
+			text = '{"error":"invalid_client","error_description":"client_secret required"}'
+
+			def json(self):
+				return {"error": "invalid_client", "error_description": "client_secret required"}
+
+		with patch("jarvis.oauth.api.requests.post", return_value=_FakeResp()), \
+			 patch("jarvis.oauth.api.get_provider", return_value={
+				"client_id": "cid", "token": "https://example/token",
+				"client_secret": None,
+			 }), patch("jarvis.oauth.api.frappe.log_error"):
+			with self.assertRaises(oauth_api.TokenExchangeError) as ctx:
+				oauth_api._exchange_code(
+					provider="OpenAI", code="ABC", code_verifier="V",
+				)
+
+		err = ctx.exception
+		self.assertEqual(err.code, "auth_failed")
+		self.assertNotIn("client_secret", str(err))
+		self.assertNotIn("invalid_client", str(err))
+
+	def test_network_error_maps_to_opaque_code(self):
+		from unittest.mock import patch
+		import requests
+		from jarvis.oauth import api as oauth_api
+
+		with patch("jarvis.oauth.api.requests.post",
+					side_effect=requests.ConnectionError("DNS failed")), \
+			 patch("jarvis.oauth.api.get_provider", return_value={
+				"client_id": "cid", "token": "https://example/token",
+				"client_secret": None,
+			 }), patch("jarvis.oauth.api.frappe.log_error"):
+			with self.assertRaises(oauth_api.TokenExchangeError) as ctx:
+				oauth_api._exchange_code(
+					provider="OpenAI", code="ABC", code_verifier="V",
+				)
+
+		err = ctx.exception
+		self.assertEqual(err.code, "network_error")
+		# Real underlying error stays out of the wire message.
+		self.assertNotIn("DNS failed", str(err))
+
+
+class _NoopCtx:
+	def __enter__(self):
+		return None
+
+	def __exit__(self, *a):
+		return False


### PR DESCRIPTION
…7, #9)

Three Important items from the 2026-06-16 cross-repo code review, grouped because they all live in the customer-side jarvis app and share the OAuth surface.

#7 Whitelist gating on Settings-mutating endpoints
   Every endpoint that writes Jarvis Settings, initiates billing, or
   starts an OAuth flow now requires System Manager. Without these
   gates, a non-admin staff user on the customer's Frappe site could:
     - flip llm_base_url to an attacker URL (chat-context exfil through future LLM calls),
     - complete a peer's pending OAuth (see #9 below), - initiate a paid signup / renewal / upgrade under the site admin's contract.

   Gated endpoints (10 total):
     onboarding.sync_connection, start_signup, finish_payment, renew,
     save_llm_creds, dev_onboard
     account.start_upgrade
     oauth.api.begin_paste_signin, complete_paste_signin, disconnect

   Reads (is_onboarded, is_ready_for_chat, get_account,
   preview_upgrade, list_plans, get_llm_sync_status) stay open - they
   don't mutate state and the chat surface needs them callable by
   non-admin users.

#6 OAuth provider error bodies sanitized
   _exchange_code previously raised TokenExchangeError with the
   provider's raw error_description bubbled into the wire response,
   which let an attacker distinguish invalid_client (client_secret
   needed/wrong) from invalid_grant (code expired). That's an
   oracle on gemini-cli's confidential-client secret.

   New TokenExchangeError carries an opaque `code` attribute from
   _TOKEN_EXCHANGE_OPAQUE_CODES:
     invalid_grant   -> code_invalid       ("Start a fresh sign-in.")
     invalid_client  -> auth_failed        ("Contact support.")
     invalid_request -> auth_failed
     network error   -> network_error      ("Try again in a minute.")
     anything else   -> token_exchange_failed
   The full provider detail (status, raw_error, detail) is logged
   server-side via frappe.log_error so ops can triage without the
   wire ever carrying it.

#9 OAuth nonce per-user binding
   begin_paste_signin now records frappe.session.user in the cache
   entry as `originator_user`. complete_paste_signin enforces match
   - a different System Manager calling with someone else's nonce sees the same `unknown_nonce` response as if the nonce didn't exist (don't leak that the nonce IS live, just under different ownership).

   Combined with #7's role gate, the practical risk is now limited
   to two System Managers on the same site racing each other on the
   same provider - extremely unlikely, but the defense closes the
   ambient mistake.

Bonus: fixed a pre-existing missing type annotation on onboarding.finish_payment(payload) that was tripping Frappe's whitelist runtime check whenever the test suite called it directly. Now `payload: dict | str`.

Tests
  - jarvis/tests/test_role_gates.py NEW (6 tests, all green):
    * Administrator passes the role check on all 10 gated endpoints
    * Guest is refused on all 10 (PermissionError each)
    * Per-user nonce binding: different user gets unknown_nonce
    * invalid_grant -> code_invalid (no raw text on wire)
    * invalid_client -> auth_failed (no raw text on wire)
    * network error -> network_error
  - jarvis/tests/test_oauth_api.py: 20 OK (updated _seed helpers to include originator_user for the new contract)
  - jarvis/tests/test_account.py: 6 OK + 1 pre-existing failure unrelated to this change
  - jarvis/tests/test_oauth_providers.py: 14 OK
  - jarvis/tests/test_onboarding_sync.py: 14 OK + 2 pre-existing failures unrelated to this change (verified by reproducing on main with my changes stashed)