### PR TITLE
fix(concurrency): Sprint-2 batch E - bench-side concurrency hardening

### DIFF
--- a/jarvis/_redis_lock.py
+++ b/jarvis/_redis_lock.py
@@ -1,0 +1,75 @@
+"""Redis-backed advisory mutex used by Sprint-2 concurrency fixes.
+
+Two call sites today:
+
+  jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._enqueued_sync_via_admin
+      Two close saves enqueue two workers; without the lock both call
+      admin -> fleet -> openclaw in parallel and either clobber each
+      other's last_sync_status writes or fire two redundant container
+      restarts. The lock serializes one-at-a-time per bench.
+
+  jarvis.chat.openclaw_client.OpenclawSession._attempt_connect
+      After a tenant re-provision, N RQ workers concurrently observe
+      "stale pairing" rejections and all race to clear_credentials() +
+      re-pair. Each ensure_paired() generates a different Ed25519 keypair;
+      Jarvis Settings's chat_device_* fields are last-write-wins, so all
+      but one worker end up with creds that don't match what admin
+      stored. The lock makes the clear+re-pair sequence one-at-a-time;
+      the late arrivals re-read fresh creds and reuse the winner's pair.
+
+Both call sites tolerate "lock held elsewhere" via a bounded wait + check
+of the now-current state (so they're not strict mutual-exclusion, more
+"convoy collapse"). For the small number of expected contenders (<=N
+chat workers, <=2 settings savers) Redis lock latency is negligible.
+
+frappe.cache() returns a RedisWrapper that subclasses redis.Redis, so
+the standard redis-py Lock primitive is available - it handles the
+token-tracked release Lua script so a slow holder won't accidentally
+delete a lock that has since been re-acquired by another worker.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+
+import frappe
+
+LOCK_PREFIX = "jarvis:lock:"
+
+
+@contextlib.contextmanager
+def redis_lock(name: str, *, timeout_s: int = 60, blocking_timeout_s: float = 0.0) -> Iterator[bool]:
+	"""Acquire a Redis advisory lock named ``name``.
+
+	Args:
+		timeout_s: TTL on the underlying Redis key. A crashed holder
+			automatically releases after this many seconds, so the lock
+			can never permanently deadlock the system.
+		blocking_timeout_s: Time the caller is willing to wait to
+			acquire. 0 == try-once (non-blocking).
+
+	Yields:
+		True if the lock was acquired (caller is the holder), False
+		otherwise. Callers SHOULD branch on the yielded value and may
+		choose to no-op (coalesce-and-move-on) or re-poll fresh state.
+
+	Never raises on contention - that's a normal flow. Real Redis
+	errors (connection refused etc.) propagate.
+	"""
+	cache = frappe.cache()
+	key = LOCK_PREFIX + name
+	lock = cache.lock(key, timeout=timeout_s, blocking_timeout=blocking_timeout_s or None)
+	acquired = False
+	try:
+		acquired = bool(lock.acquire(blocking=bool(blocking_timeout_s)))
+		yield acquired
+	finally:
+		if acquired:
+			try:
+				lock.release()
+			except Exception:
+				# The TTL is the backstop - if release fails (e.g. lock
+				# already expired and re-acquired by someone else)
+				# don't surface the noise to the caller.
+				pass

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -240,10 +240,16 @@ def send_message(
 
 	# Enqueue the worker. Returns immediately; worker runs async.
 	run_id = uuid.uuid4().hex[:12]
+	# RQ worker budget covers worst-case: pair (<=90s admin round-trip) +
+	# WS connect (10s) + TURN_TIMEOUT_SECONDS (180s). The previous 200s
+	# ceiling fell under that 280s envelope, so a SIGKILL on timeout
+	# bypassed run_agent_turn's try/finally and stranded the placeholder
+	# row with ``streaming=1`` forever. 300s gives 20s headroom on the
+	# nominal worst case. Sprint-2 review item.
 	frappe.enqueue(
 		method="jarvis.chat.worker.run_agent_turn",
 		queue="default",
-		timeout=200,
+		timeout=300,
 		conversation_id=conversation,
 		message_id=msg_doc.name,
 		run_id=run_id,
@@ -360,10 +366,12 @@ def retry_message(message: str) -> dict:
 	)
 
 	run_id = uuid.uuid4().hex[:12]
+	# Parity with send_message: 300s covers pair (<=90s) + connect (10s)
+	# + turn (180s). See note at the send_message enqueue site.
 	frappe.enqueue(
 		method="jarvis.chat.worker.run_agent_turn",
 		queue="default",
-		timeout=200,
+		timeout=300,
 		conversation_id=doc.conversation,
 		message_id=user_msg_id,
 		run_id=run_id,

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -66,6 +66,21 @@ def _is_stale_pairing(err: Exception) -> bool:
 	return any(marker in msg for marker in _STALE_PAIRING_MARKERS)
 
 
+def _persisted_device_id() -> str:
+	"""Cheap unauthenticated read of Jarvis Settings.chat_device_id.
+
+	Used by the repair convoy-collapse path to detect "someone else
+	already re-paired" without re-running the whole ensure_paired flow.
+	Returns "" if Settings is unreadable for any reason (the caller
+	treats empty as "no winner yet, proceed").
+	"""
+	import frappe
+	try:
+		return (frappe.db.get_single_value("Jarvis Settings", "chat_device_id") or "").strip()
+	except Exception:
+		return ""
+
+
 class OpenclawSession:
 	"""Direct WebSocket session to one tenant's openclaw gateway.
 
@@ -121,7 +136,7 @@ class OpenclawSession:
 			try: ws.close()
 			except Exception: pass
 			if allow_repair and _is_stale_pairing(e):
-				clear_credentials()
+				cls._repair_and_reconnect(gateway_url, stale_device_id=creds.device_id)
 				return cls._attempt_connect(gateway_url, allow_repair=False)
 			raise
 		except Exception:
@@ -129,6 +144,50 @@ class OpenclawSession:
 			except Exception: pass
 			raise
 		return cls(ws, creds)
+
+	@classmethod
+	def _repair_and_reconnect(cls, gateway_url: str, *, stale_device_id: str) -> None:
+		"""Serialize the clear+re-pair window after a stale-pairing rejection.
+
+		Sprint-2 (2026-06-16 review): with N concurrent chat workers
+		racing after a tenant re-provision, every one observes the same
+		"stale pairing" error, every one called ``clear_credentials() +
+		ensure_paired()``, every one generated a different Ed25519
+		keypair, and only the last writer's keypair survived in Jarvis
+		Settings - the other N-1 workers held in-memory creds the admin
+		side didn't know about, then EACH of them re-paired again,
+		flapping admin/openclaw state. The Redis lock collapses the
+		convoy: one worker re-pairs, the rest wait, then read the fresh
+		keypair from Settings.
+
+		``stale_device_id`` is the device_id we just observed as stale.
+		If by the time we acquire the lock the persisted device_id no
+		longer matches, the winning worker already re-paired - we skip
+		the wipe entirely and the caller's next ``ensure_paired`` reads
+		the new creds.
+		"""
+		from jarvis._redis_lock import redis_lock
+
+		with redis_lock(
+			"chat_device_pair_repair", timeout_s=120, blocking_timeout_s=60.0,
+		) as acquired:
+			# Even if we lost the lock race, we still want to retry the
+			# connect once with fresh creds - the holder may have already
+			# repaired. Let the caller re-read on its next attempt.
+			if not acquired:
+				return
+			current = _persisted_device_id()
+			if current and current != stale_device_id:
+				# Another worker already re-paired while we waited. Don't
+				# wipe their work; let the caller re-read.
+				return
+			clear_credentials()
+			# Don't prime ensure_paired() here: the caller's next
+			# _attempt_connect(allow_repair=False) calls ensure_paired
+			# on its own which is what generates+persists the new
+			# keypair under our lock. Late convoy followers also call
+			# ensure_paired on their own next attempt and see the
+			# newly-persisted creds without re-pairing.
 
 	def close(self) -> None:
 		try: self._ws.close()

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -86,6 +86,14 @@ class JarvisSettings(Document):
         run_inline = bool(
             frappe.flags.in_test or frappe.flags.run_admin_sync_inline
         )
+        # Coalesce duplicate close-together saves: enqueue under a fixed
+        # job_id keyed by the action. Two saves that produce the same
+        # action within the worker-poll window resolve to one job. The
+        # worker re-reads the doc fresh so it always sees the latest
+        # committed state, not whatever was in flight when each save
+        # fired. Different actions still both enqueue (one "reload" and
+        # one "restart" are not the same op) but the in-worker Redis
+        # lock makes them run serially, not interleaved.
         frappe.enqueue(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
             "._enqueued_sync_via_admin",
@@ -93,6 +101,8 @@ class JarvisSettings(Document):
             timeout=120,
             enqueue_after_commit=not run_inline,
             now=run_inline,
+            job_id=f"jarvis_settings_sync:{action}",
+            deduplicate=True,
             action=action,
         )
 
@@ -202,6 +212,34 @@ def _enqueued_sync_via_admin(action: str) -> None:
     Updates ``last_sync_status`` from ``pending: ...`` to either
     ``ok (... via admin)`` or ``failed: ...`` - the UI polls
     ``onboarding.get_llm_sync_status`` to observe the transition.
+
+    Sprint-2 (2026-06-16 review): serialize concurrent sync workers
+    with a Redis lock. Two close saves on the same Single can still
+    enqueue two jobs with different actions ("reload" then "restart");
+    both must run, but they must NOT run in parallel - one calling
+    post_rotate_llm_secret while the other calls post_update_llm_creds
+    crosses container state in unpredictable ways. The lock yields one
+    serial run; the late arrival waits up to 60s for the early one to
+    finish, then runs against the now-current doc state.
     """
-    settings = frappe.get_single("Jarvis Settings")
-    settings._sync_via_admin(action)
+    from jarvis._redis_lock import redis_lock
+
+    with redis_lock("jarvis_settings_admin_sync", timeout_s=120, blocking_timeout_s=60.0) as acquired:
+        if not acquired:
+            # Couldn't get the lock within 60s: an earlier sync is
+            # apparently stuck. Log + bail; the failed status field
+            # carries the diagnostic. Don't fight the holder.
+            frappe.logger().warning(
+                "jarvis_settings: skipping admin sync (action=%s); "
+                "another worker held the lock past blocking timeout",
+                action,
+            )
+            settings = frappe.get_single("Jarvis Settings")
+            settings.db_set(
+                "last_sync_status",
+                "failed: skipped (concurrent sync did not finish in time)",
+                update_modified=False,
+            )
+            return
+        settings = frappe.get_single("Jarvis Settings")
+        settings._sync_via_admin(action)

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -250,6 +250,19 @@ class TestSendMessage(_ChatTestCase):
 		self.assertEqual(kwargs["conversation_id"], self.conv)
 		self.assertEqual(kwargs["message_id"], result["message_id"])
 
+	def test_enqueues_with_300s_timeout(self):
+		"""Sprint-2: worst-case worker budget = pair (<=90s) + WS connect
+		(10s) + turn (180s) = 280s. The previous 200s timeout caused
+		RQ SIGKILL bypassing the worker's try/finally, stranding the
+		placeholder row with streaming=1 forever. Pin the new 300s
+		budget so a future "cleanup" cannot regress it back."""
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
+			with patch("frappe.enqueue") as enqueue:
+				send_message(self.conv, "hi")
+		_, kwargs = enqueue.call_args
+		self.assertEqual(kwargs["timeout"], 300,
+			"RQ worker budget must cover pair+connect+turn worst case")
+
 	def test_seq_increments_across_calls(self):
 		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
 			with patch("frappe.enqueue"):
@@ -327,6 +340,8 @@ class TestRetryMessage(_ChatTestCase):
 		self.assertEqual(kwargs["method"], "jarvis.chat.worker.run_agent_turn")
 		self.assertEqual(kwargs["conversation_id"], self.conv)
 		self.assertEqual(kwargs["message_id"], user_id)
+		# Sprint-2: parity with send_message - 300s covers worst case.
+		self.assertEqual(kwargs["timeout"], 300)
 
 	def test_rejects_non_assistant_message(self):
 		user_id, _asst_id = self._make_turn(self.conv, with_error=True)

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -423,3 +423,98 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 				OpenclawSession.connect("ws://t", "x")
 		self.assertFalse(clear_called, "should not clear creds for signing bugs")
 		self.assertIn("signature-invalid", str(cm.exception))
+
+
+class TestRepairConvoyCollapse(FrappeTestCase):
+	"""Sprint-2 (2026-06-16): N concurrent workers all observe a stale
+	pairing after tenant re-provision. Without the Redis lock, every
+	worker calls clear_credentials() + ensure_paired() independently,
+	each generating a different Ed25519 keypair, and only the last
+	writer's keypair survives in Jarvis Settings - the others hold
+	in-memory creds the admin side doesn't know about. The lock
+	collapses the convoy: one worker pairs, the rest detect the new
+	device_id on disk and skip the wipe."""
+
+	def _build_stale_then_ok(self) -> tuple[_ScriptedWS, _ScriptedWS]:
+		"""Two scripted WS: first rejects with device-not-paired, second
+		accepts. Caller wires per-test patches on top."""
+		first = _ScriptedWS([_challenge(), None])
+		second = _ScriptedWS([_challenge(), None])
+		first._frames[1] = lambda: _frame({
+			"type": "res", "id": first.sent[-1]["id"], "ok": False,
+			"error": {"code": "UNAUTHORIZED", "message": "device-not-paired"},
+		})
+		second._frames[1] = lambda: _frame({
+			"type": "res", "id": second.sent[-1]["id"], "ok": True, "payload": {},
+		})
+		return first, second
+
+	def test_repair_skipped_when_persisted_device_id_diverges(self):
+		"""Late arrival: the lock-holder already re-paired and wrote a
+		new device_id to Settings. The convoy follower sees current !=
+		its stale_device_id and SHOULD NOT wipe the winner's work."""
+		stale_creds = _make_creds()
+		winner_device_id = "winner-device-id-from-other-worker"
+		clear_called: list = []
+
+		first_ws, second_ws = self._build_stale_then_ok()
+		ws_iter = iter([first_ws, second_ws])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   side_effect=lambda *a, **kw: next(ws_iter)), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired",
+				   return_value=stale_creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_id",
+				   return_value=winner_device_id):
+			sess = OpenclawSession.connect("ws://t", "x")
+		self.assertEqual(clear_called, [],
+			"convoy follower must NOT clear the winner's freshly-paired creds")
+		sess.close()
+
+	def test_repair_proceeds_when_persisted_id_matches_stale(self):
+		"""Lock-holder path: nobody else has re-paired yet (current ==
+		stale OR current empty). Standard wipe + re-pair."""
+		stale_creds = _make_creds()
+		clear_called: list = []
+
+		first_ws, second_ws = self._build_stale_then_ok()
+		ws_iter = iter([first_ws, second_ws])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   side_effect=lambda *a, **kw: next(ws_iter)), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired",
+				   return_value=stale_creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_id",
+				   return_value=stale_creds.device_id):
+			sess = OpenclawSession.connect("ws://t", "x")
+		self.assertEqual(len(clear_called), 1,
+			"lock-holder must wipe + re-pair when persisted id matches stale")
+		sess.close()
+
+	def test_repair_skipped_when_redis_lock_unavailable(self):
+		"""Defensive: if the lock acquire times out (Redis down,
+		extreme contention), we DON'T wipe creds blindly. The caller
+		retries once with allow_repair=False against the same gateway."""
+		from contextlib import contextmanager
+		stale_creds = _make_creds()
+		clear_called: list = []
+
+		@contextmanager
+		def _never_acquired(*_a, **_kw):
+			yield False
+
+		first_ws, second_ws = self._build_stale_then_ok()
+		ws_iter = iter([first_ws, second_ws])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   side_effect=lambda *a, **kw: next(ws_iter)), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired",
+				   return_value=stale_creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)), \
+			 patch("jarvis._redis_lock.redis_lock", side_effect=_never_acquired):
+			sess = OpenclawSession.connect("ws://t", "x")
+		self.assertEqual(clear_called, [],
+			"no clear when we never held the lock")
+		sess.close()

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -490,3 +490,95 @@ class TestOnUpdateAsyncPending(_SettingsSingletonTestCase):
             (seen[0] or "").startswith("pending: provisioning container"),
             f"expected 'pending: provisioning container', got {seen[0]!r}",
         )
+
+
+class TestEnqueueDedupAndJobId(_SettingsSingletonTestCase):
+    """Sprint-2 (2026-06-16): two close-together saves with the same
+    action collapse into one enqueued job via job_id + deduplicate=True.
+    Without this, two `reload` saves landed as two redundant rotate-
+    secret round trips (or worse: stale-snapshot interleaved actions)."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_settings()
+        # The async path runs inline under in_test - we need to peek at
+        # the kwargs before the inline call collapses them, so stop the
+        # inline shortcut just for this class.
+        frappe.flags.in_test = False
+        self.addCleanup(lambda: setattr(frappe.flags, "in_test", True))
+
+    def test_enqueue_carries_action_keyed_job_id_and_dedupe_flag(self):
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_api_key = "sk-rotation-1"
+        with patch("frappe.enqueue") as enqueue:
+            settings.save()
+        enqueue.assert_called_once()
+        _, kwargs = enqueue.call_args
+        self.assertEqual(
+            kwargs.get("job_id"), "jarvis_settings_sync:reload",
+            "job_id must encode the action so identical-action saves dedup "
+            "and different-action saves don't",
+        )
+        self.assertTrue(
+            kwargs.get("deduplicate"),
+            "deduplicate=True must be set so the second enqueue is a no-op",
+        )
+
+    def test_restart_action_uses_distinct_job_id(self):
+        """A restart save must NOT collapse into an in-flight reload save -
+        they're different operations on the container side."""
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_provider = "Anthropic"
+        settings.llm_model = "claude-sonnet-4-6"
+        with patch("frappe.enqueue") as enqueue:
+            settings.save()
+        _, kwargs = enqueue.call_args
+        self.assertEqual(kwargs.get("job_id"), "jarvis_settings_sync:restart")
+
+
+class TestEnqueuedSyncRedisLock(_SettingsSingletonTestCase):
+    """_enqueued_sync_via_admin must run under a Redis lock so two queued
+    jobs with different actions don't fire admin/fleet calls in parallel."""
+
+    def setUp(self):
+        super().setUp()
+        _reset_settings()
+
+    def test_lock_acquired_and_released_around_sync(self):
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _enqueued_sync_via_admin,
+        )
+        sync_called = []
+
+        def _fake_sync(action):
+            sync_called.append(action)
+
+        with patch("jarvis.admin_client.post_rotate_llm_secret",
+                   side_effect=lambda **kw: sync_called.append("reload") or {"action": "reload"}):
+            _enqueued_sync_via_admin("reload")
+        # The admin call ran exactly once - confirms the lock acquired
+        # the happy path and yielded into the sync.
+        self.assertEqual(len(sync_called), 1)
+
+    def test_lock_contention_writes_skipped_status_and_no_admin_call(self):
+        """If a prior worker is still holding the lock past blocking timeout,
+        the late arrival logs + writes a 'failed: skipped' status. It must
+        NOT call admin (the in-flight one is in charge)."""
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _enqueued_sync_via_admin,
+        )
+        # Patch the lock helper to simulate contention - context manager
+        # yields False without ever acquiring.
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _held(*_a, **_kw):
+            yield False
+
+        with patch("jarvis._redis_lock.redis_lock", side_effect=_held), \
+             patch("jarvis.admin_client.post_rotate_llm_secret") as admin_mock:
+            _enqueued_sync_via_admin("reload")
+        admin_mock.assert_not_called()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertIn("failed", settings.last_sync_status or "")
+        self.assertIn("skipped", settings.last_sync_status or "")


### PR DESCRIPTION
Closes three Sprint-2 items from the 2026-06-16 review on the customer bench (jarvis/) repo:

1. Jarvis Settings concurrent saves enqueue racing admin syncs (jarvis/doctype/jarvis_settings/jarvis_settings.py) Two close-together saves both fired on_update, both classified an action against possibly-stale snapshots, both enqueued workers. The workers then ran admin -> fleet -> openclaw in parallel: one calling post_rotate_llm_secret while the other called post_update_llm_creds crossed container state unpredictably.

   Two-layer fix:
   - enqueue carries job_id=f"jarvis_settings_sync:{action}" with deduplicate=True so identical-action saves within the worker-poll window resolve to one job.
   - _enqueued_sync_via_admin runs under a Redis advisory lock (timeout 120s, blocking_timeout 60s). Different-action saves still both enqueue but run serially. If the lock can't be acquired within the blocking budget, the late arrival writes last_sync_status="failed: skipped (...)" and returns without calling admin.

2. Stale-pair self-heal can ping-pong under N concurrent workers (jarvis/chat/openclaw_client.py) After a tenant re-provision, N RQ workers concurrently observe the same "device-not-paired" rejection and all race to clear_credentials() + ensure_paired(). Each generates a different Ed25519 keypair; Jarvis Settings's chat_device_* fields are last-write-wins, so all but one worker held in-memory creds the admin side didn't know about, then EACH of them re-paired again, flapping admin/openclaw state.

   New _repair_and_reconnect collapses the convoy under a Redis lock. The convoy follower also consults _persisted_device_id() under the lock: if a winner has already re-paired (current != stale), we skip the wipe entirely so the follower's next ensure_paired reads the winner's fresh creds. If the lock acquire fails (Redis down, extreme contention), we skip the wipe too - the caller falls through to its allow_repair=False retry which may succeed against another worker's already-published pairing.

3. RQ worker timeout 200s -> 300s (jarvis/chat/api.py) Worst-case worker budget: pair (<=90s admin round-trip) + WS connect (10s) + TURN_TIMEOUT_SECONDS (180s) = 280s. The previous 200s ceiling was below that envelope, so a SIGKILL on RQ timeout bypassed run_agent_turn's try/finally and stranded the placeholder row with streaming=1 forever. Raised at both send_message and retry_message enqueue sites.

New shared helper: jarvis/_redis_lock.py with redis_lock() context manager wrapping frappe.cache().lock() (Lua-script-tracked release so slow holders don't accidentally delete a re-acquired lock). TTL is the backstop; a crashed holder auto-releases.

Tests:
- test_chat_api: 2 new pins (timeout=300 at both enqueue sites).
- test_settings_on_update: TestEnqueueDedupAndJobId (2 tests) + TestEnqueuedSyncRedisLock (2 tests) - dedupe key + skipped-status path.
- test_chat_openclaw_client: TestRepairConvoyCollapse (3 tests) - follower skips when winner-pair already in Settings; holder wipes when persisted id matches stale; lock-unavailable path skips wipe.

Verified: test_chat_api 4 OK, test_chat_openclaw_client 20 OK, test_settings_on_update 33 OK, test_chat_worker 8 OK, test_chat_device 8 OK. test_onboarding_sync 2 failures are pre-existing on main (admin_url validation tests), confirmed by stashing this batch and re-running.