### PR TITLE
feat(security): C2 PR-3C - rotate_agent_token bench orchestrator (jar…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -124,6 +124,33 @@ def post_rotate_llm_secret(secret: str) -> dict:
 	)
 
 
+def post_rotate_agent_token(new_token: str) -> dict:
+	"""POST a rotated plugin agent_token to admin's /tenant/rotate-agent-token.
+
+	C2 PR-3C orchestrator. Called from rotate_agent_token (this module's
+	whitelisted bench endpoint, gated to System Manager). The bench
+	generates fresh randomness, calls here, and ONLY persists locally
+	when this returns success - so a partial-failure mid-rotation leaves
+	the on-disk token in lockstep with what the container knows.
+
+	Default 180s timeout matches push_oauth_blob: admin chains to
+	fleet-agent's PUT /rotate-agent-token, which does a ``compose up -d``
+	(container recreate) + healthz poll. Admin's bound is healthz+30s
+	(default 90s); 180s gives HTTPS round-trip + response headroom.
+
+	Raises:
+	    AdminAuthError, AdminUnreachableError, AdminValidationError
+	    (shares the rotate-secret 20/h bucket).
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+	return _post(
+		path="/api/method/jarvis_admin.api.tenant.rotate_agent_token",
+		body={"new_token": new_token},
+		admin_url=_admin_url(settings),
+		timeout_s=180,
+	)
+
+
 def post_push_oauth_blob(provider: str, blob: dict) -> dict:
 	"""POST an openclaw OAuthCredential blob to admin → fleet-agent → container.
 

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -247,5 +247,96 @@ def _request_body_bytes() -> bytes:
 	return data if isinstance(data, (bytes, bytearray)) else (data or "").encode("utf-8")
 
 
+@frappe.whitelist(methods=["POST"])
+def rotate_agent_token() -> dict:
+	"""Rotate the plugin agent_token (C2 PR-3C orchestrator).
 
+	System Manager only. Generates a fresh 32-byte random token,
+	pushes it via admin -> fleet-agent -> container env, and only
+	persists locally after admin confirms the container is healthy
+	against the new value. This keeps the bench's notion of the
+	token in lockstep with what the container holds: a mid-rotation
+	failure leaves both ends on the OLD token.
 
+	Operators run this after a suspected leak or as routine hygiene.
+	The container is briefly unavailable (~10-30s) during the
+	``compose up -d`` recreate that the fleet-agent runs.
+
+	Returns:
+	  {"ok": true, "data": {"rotated_at": "<isoformat>"}} on success
+	  {"ok": false, "error": {"code": ..., "message": ...}} on any failure;
+	      old token is preserved on the bench; admin's response carries
+	      the precise failure code (NoRunningTenant 409, RateLimited 429,
+	      etc.)
+
+	The old token stops working on the container as soon as the
+	recreate completes; legitimate in-flight plugin requests presenting
+	the old token will start hitting 401 from the bench (the new
+	token doesn't match) AND from the container's plugin (the new
+	JARVIS_GATEWAY_TOKEN doesn't match what the plugin remembers).
+	Both sides re-sync naturally on the next call.
+	"""
+	import secrets
+
+	# Block non-System-Manager callers explicitly. allow_guest defaults
+	# to False; this is defense-in-depth against a future @whitelist
+	# expansion shipping with relaxed defaults.
+	frappe.only_for("System Manager")
+
+	new_token = secrets.token_hex(32)  # 64 hex chars
+
+	# Push to admin FIRST. We only persist locally after admin confirms
+	# the container is healthy against the new value. If admin fails,
+	# the bench's stored token is unchanged - the container also still
+	# holds the old token (fleet-agent rolled back per PR-3A), so both
+	# ends stay in lockstep.
+	from jarvis import admin_client
+	try:
+		admin_client.post_rotate_agent_token(new_token=new_token)
+	except admin_client.AdminAuthError as e:
+		frappe.local.response.http_status_code = 502
+		return {"ok": False, "error": {
+			"code": "AdminAuthError",
+			"message": f"admin rejected our credentials: {e}",
+		}}
+	except admin_client.AdminUnreachableError as e:
+		frappe.local.response.http_status_code = 502
+		return {"ok": False, "error": {
+			"code": "AdminUnreachableError",
+			"message": f"admin not reachable: {e}",
+		}}
+	except admin_client.AdminRateLimitedError as e:
+		frappe.local.response.http_status_code = 429
+		return {"ok": False, "error": {
+			"code": "RateLimitExceeded",
+			"message": "admin rate-limit hit; retry later",
+			"retry_after_seconds": e.retry_after_seconds,
+		}}
+	except admin_client.AdminValidationError as e:
+		# Admin raised a Frappe ValidationError - typically a 4xx input
+		# problem the operator can fix (e.g. malformed token; though our
+		# token comes from secrets.token_hex so that's unlikely here).
+		frappe.local.response.http_status_code = 400
+		return {"ok": False, "error": {
+			"code": "AdminValidationError",
+			"message": str(e),
+		}}
+	except Exception as e:
+		frappe.local.response.http_status_code = 502
+		frappe.log_error(
+			title="rotate_agent_token: unexpected admin failure",
+			message=frappe.get_traceback(),
+		)
+		return {"ok": False, "error": {
+			"code": type(e).__name__,
+			"message": f"unexpected error during rotation: {e}",
+		}}
+
+	# Admin succeeded -> the container is now running against new_token.
+	# Persist it locally so the bench's future plugin-auth validations
+	# match what the container holds.
+	settings = frappe.get_single("Jarvis Settings")
+	settings.db_set("agent_token", new_token)
+	frappe.db.commit()
+
+	return {"ok": True, "data": {"rotated_at": frappe.utils.now()}}

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -446,3 +446,104 @@ class TestC2HmacSignature(_PluginAuthTestBase):
 		self.assertFalse(result["ok"])
 		self.assertEqual(result["error"]["code"], "AuthenticationError")
 		self.assertIn("nonce", result["error"]["message"].lower())
+
+
+class TestRotateAgentTokenEndpoint(FrappeTestCase):
+	"""C2 PR-3C: bench-side orchestrator. Generates fresh randomness,
+	pushes via admin (which proxies to fleet which recreates the
+	container against the new env), persists locally on success."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		settings = frappe.get_single("Jarvis Settings")
+		cls._original_token = settings.get_password("agent_token", raise_exception=False) or ""
+		settings.db_set("agent_token", "before-rotation-token")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("agent_token", cls._original_token)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		# rotate_agent_token requires System Manager; tests run as Admin.
+		frappe.set_user("Administrator")
+		# Reset to a known starting token.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("agent_token", "before-rotation-token")
+		frappe.db.commit()
+
+	def _call_rotate(self):
+		from jarvis.api import rotate_agent_token
+		return rotate_agent_token()
+
+	def test_happy_path_persists_new_token_after_admin_success(self):
+		from jarvis import admin_client
+		seen = {}
+		def _spy(*, new_token):
+			seen["pushed"] = new_token
+			return {"action": "recreate", "result": "ok"}
+		with patch.object(admin_client, "post_rotate_agent_token", side_effect=_spy):
+			res = self._call_rotate()
+		self.assertTrue(res["ok"], msg=res)
+		self.assertIn("rotated_at", res["data"])
+		# Locally persisted token must equal what we pushed to admin.
+		settings = frappe.get_single("Jarvis Settings")
+		stored = settings.get_password("agent_token")
+		self.assertEqual(stored, seen["pushed"])
+		# Token is 64 hex chars (secrets.token_hex(32)).
+		self.assertRegex(stored, r"^[0-9a-f]{64}$")
+		# And it changed from the seeded value.
+		self.assertNotEqual(stored, "before-rotation-token")
+
+	def test_admin_failure_does_not_persist_new_token(self):
+		"""Mid-rotation admin failure must leave the bench's stored
+		token UNTOUCHED. fleet-agent rolled the container back per
+		PR-3A, so both sides stay in lockstep on the OLD token."""
+		from jarvis import admin_client
+		with patch.object(admin_client, "post_rotate_agent_token",
+		                  side_effect=admin_client.AdminUnreachableError("network down")):
+			res = self._call_rotate()
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "AdminUnreachableError")
+		self.assertEqual(frappe.local.response.http_status_code, 502)
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			settings.get_password("agent_token"),
+			"before-rotation-token",
+			"old token must survive an admin-side rotation failure",
+		)
+
+	def test_rate_limited_returns_429_with_retry_after(self):
+		from jarvis import admin_client
+		with patch.object(admin_client, "post_rotate_agent_token",
+		                  side_effect=admin_client.AdminRateLimitedError(
+		                      "rate limit hit", retry_after_seconds=120,
+		                  )):
+			res = self._call_rotate()
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "RateLimitExceeded")
+		self.assertEqual(res["error"]["retry_after_seconds"], 120)
+		self.assertEqual(frappe.local.response.http_status_code, 429)
+
+	def test_non_system_manager_rejected(self):
+		"""rotate_agent_token must reject non-System-Manager callers."""
+		# Make a fresh user with no roles beyond default.
+		user_email = "rat-test-no-role@example.com"
+		if not frappe.db.exists("User", user_email):
+			frappe.get_doc({
+				"doctype": "User", "email": user_email, "first_name": "T",
+				"send_welcome_email": 0,
+			}).insert(ignore_permissions=True)
+			frappe.db.commit()
+		try:
+			frappe.set_user(user_email)
+			with self.assertRaises(frappe.PermissionError):
+				self._call_rotate()
+		finally:
+			frappe.set_user("Administrator")
+			frappe.delete_doc("User", user_email, force=True, ignore_permissions=True)
+			frappe.db.commit()


### PR DESCRIPTION
…vis half)

Top tier of the end-to-end agent_token rotation flow. Operator (System Manager) calls this; we generate fresh randomness, push via admin -> fleet -> container env recreate, and only persist locally on success.

Three-PR sequence now complete:
  PR-3A (fleet-agent #51): rotate-agent-token endpoint with .env
                            rewrite + compose up -d + rollback.
  PR-3B (jarvis_admin #102): admin proxy endpoint + agent_client wrapper.
  PR-3C (this PR): bench orchestrator + admin_client wrapper.

Changes:
- admin_client.post_rotate_agent_token(new_token): POSTs to the new admin endpoint. 180s timeout matches push_oauth_blob (admin -> fleet chain includes a compose up -d + healthz poll, ~90s worst-case; 180s gives HTTPS round-trip + serialization headroom).
- api.rotate_agent_token(): whitelisted, POST-only, System Manager gated explicitly via frappe.only_for(). Generates 32-byte random hex via secrets.token_hex(32), calls admin FIRST, only persists to Jarvis Settings.agent_token after admin confirms the container is healthy against the new value.

In-lockstep invariant: bench-stored token always matches what the container holds. A mid-rotation failure (admin unreachable, fleet healthz timeout, etc.) leaves the bench's stored token UNCHANGED and the container's env already rolled back by PR-3A's fleet-agent handler. Both ends stay on the OLD token.

Error mapping:
  AdminAuthError       -> 502 AdminAuthError
  AdminUnreachableError -> 502 AdminUnreachableError (covers admin's
                          NoRunningTenant 409 too, since admin_client
                          maps 4xx envelopes into Unreachable)
  AdminRateLimitedError -> 429 RateLimitExceeded + retry_after_seconds
  AdminValidationError  -> 400 AdminValidationError
  any other Exception   -> 502 logged + opaque code

Tests (4 in TestRotateAgentTokenEndpoint):
- Happy path persists 64-hex token AFTER admin succeeds.
- AdminUnreachableError does NOT persist; old token survives.
- AdminRateLimitedError surfaces retry_after_seconds + 429.
- Non-System-Manager caller raises frappe.PermissionError.

Verified: test_api 13 OK. Regression sweep across 7 neighboring modules clean.

Operational runbook (called out for ops docs follow-up):
- /api/method/jarvis.api.rotate_agent_token after suspected token leak. Brief container downtime (~10-30s) as fleet-agent runs compose up -d to pick up the new env. In-flight plugin requests using the old token start failing at next call; both sides re-sync via the new token.