### PR TITLE
fix(security): Sprint-1 - close run_query SQL allowlist bypass surfaces

### DIFF
--- a/jarvis/tests/test_run_query.py
+++ b/jarvis/tests/test_run_query.py
@@ -69,6 +69,98 @@ class TestRunQueryValidation(FrappeTestCase):
 		with self.assertRaises(InvalidArgumentError):
 			run_query("SELECT 1")
 
+	# ----- Sprint-1 (2026-06-16) bypass surfaces ---------------------
+
+	def test_rejects_into_outfile(self):
+		"""SELECT ... INTO OUTFILE writes the result set to the MariaDB
+		server's filesystem. With FILE privilege, an attacker could exfil
+		whatever the bench's DB user can read into a path they later
+		fetch via another route."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT name FROM tabDocType INTO OUTFILE '/tmp/leak.txt'")
+		self.assertIn("INTO", str(cm.exception).upper())
+
+	def test_rejects_into_dumpfile(self):
+		with self.assertRaises(InvalidArgumentError):
+			run_query("SELECT name FROM tabDocType INTO DUMPFILE '/tmp/leak'")
+
+	def test_rejects_load_file(self):
+		"""LOAD_FILE('/etc/passwd') AS x - filesystem read in a column."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT LOAD_FILE('/etc/passwd') AS x FROM tabDocType")
+		self.assertIn("LOAD_FILE", str(cm.exception))
+
+	def test_rejects_sleep(self):
+		"""SLEEP(N) ties up a connection for N seconds; a few concurrent
+		calls saturate the Frappe DB pool."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT name FROM tabDocType WHERE SLEEP(10)")
+		self.assertIn("SLEEP", str(cm.exception))
+
+	def test_rejects_benchmark(self):
+		"""BENCHMARK(1e9, MD5('x')) - the family that SLEEP belongs to."""
+		with self.assertRaises(InvalidArgumentError):
+			run_query("SELECT BENCHMARK(1000000, MD5('x')) FROM tabDocType")
+
+	def test_rejects_get_lock(self):
+		"""GET_LOCK('jarvis-test', 0) holds a server-side named lock; a
+		conspiracy of stuck connections is a coordination DoS."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT GET_LOCK('x', 0) FROM tabDocType")
+		self.assertIn("GET_LOCK", str(cm.exception))
+
+	def test_rejects_release_lock(self):
+		with self.assertRaises(InvalidArgumentError):
+			run_query("SELECT RELEASE_LOCK('x') FROM tabDocType")
+
+	def test_rejects_comma_from_to_information_schema(self):
+		"""The leading-FROM regex catches the FIRST table after FROM, but
+		comma-continuations slip past: ``FROM tabDocType, information_schema.tables t``
+		grants access to internal schemas the agent has no business reading.
+		"""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query(
+				"SELECT name FROM tabDocType, information_schema.tables t WHERE 1=1"
+			)
+		self.assertIn("information_schema", str(cm.exception))
+
+	def test_rejects_backticked_information_schema(self):
+		with self.assertRaises(InvalidArgumentError):
+			run_query(
+				"SELECT name FROM tabDocType, `information_schema`.tables t WHERE 1=1"
+			)
+
+	def test_rejects_mysql_user_table(self):
+		"""``mysql.user`` carries password hashes. Same comma-FROM family."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT * FROM tabDocType, mysql.user u WHERE 1=1")
+		self.assertIn("mysql", str(cm.exception))
+
+	def test_rejects_comma_from_to_non_tab_table(self):
+		"""Even if the second table isn't in a forbidden schema, it must
+		still start with ``tab`` - the second comma slot was previously
+		unchecked."""
+		with self.assertRaises(InvalidArgumentError) as cm:
+			run_query("SELECT name FROM tabDocType, __Auth a WHERE 1=1")
+		# Error message should call out the bad identifier.
+		self.assertIn("__Auth", str(cm.exception))
+
+	def test_load_file_false_positive_when_used_as_column_name(self):
+		"""``load_file`` substring inside another identifier must NOT
+		trigger the function reject (word-boundary check)."""
+		# A column named ``upload_filename`` happens to contain "load_file";
+		# the function reject must use a word-boundary + open-paren so this
+		# benign case passes the function check. We don't actually run it
+		# (no such column / DocType), so we expect the table-not-found-flow
+		# error path, NOT an InvalidArgumentError about LOAD_FILE.
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("jarvis.tools.run_query.frappe.db.sql",
+		           return_value=[{"upload_filename": "x"}]):
+			result = run_query(
+				"SELECT upload_filename FROM tabDocType LIMIT 1"
+			)
+		self.assertTrue("rows" in result, msg=result)
+
 
 class TestRunQueryPermissions(FrappeTestCase):
 	"""DocType-level read permission is the only line of defense we provide.

--- a/jarvis/tools/run_query.py
+++ b/jarvis/tools/run_query.py
@@ -35,11 +35,41 @@ DEFAULT_LIMIT = 100
 # Identifiers we refuse outright in any token stream - covers single-line
 # comments (--), block comments (/* */), and forbidden statement types that
 # might slip past sqlparse's get_type() in edge cases (subqueries, CTEs).
+#
+# Sprint-1 (2026-06-16 review) extra entries: keywords that compose into
+# real attacks even from inside a SELECT:
+#   - INTO         dangerous in "SELECT ... INTO OUTFILE 'p'" (filesystem write)
+#   - OUTFILE      same
+#   - DUMPFILE     same
+#   - LOAD_FILE    function form of filesystem read
+#   - SLEEP        DoS via tied-up connections, also a timing oracle
+#   - BENCHMARK    same family
+#   - GET_LOCK     hold a named lock indefinitely -> DoS
+#   - RELEASE_LOCK release someone else's lock -> coordination DoS
+#   - IS_FREE_LOCK / IS_USED_LOCK probe for lock holders
 _FORBIDDEN_TOKENS = {
 	"INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE", "TRUNCATE",
 	"RENAME", "GRANT", "REVOKE", "REPLACE", "CALL", "EXEC", "EXECUTE",
 	"LOAD", "HANDLER", "LOCK", "UNLOCK", "USE", "SET",
+	"INTO", "OUTFILE", "DUMPFILE",
 }
+
+# Function-shaped attacks. sqlparse classifies these as Name (function call)
+# rather than Keyword, so the token-stream check above won't catch them.
+# We re-check via a case-insensitive substring search on the cleaned query.
+# Each entry is matched as a word boundary; ``LOAD_FILE`` alone would not
+# false-positive a column named ``upload_filename``.
+_FORBIDDEN_FUNCTIONS = (
+	"LOAD_FILE", "SLEEP", "BENCHMARK",
+	"GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS",
+	"IS_FREE_LOCK", "IS_USED_LOCK",
+)
+
+# Schemas that have no business being touched from an agent-driven SELECT.
+# Catching these specifically defends against the ``FROM tabUser,
+# information_schema.tables t`` comma-FROM trick the table extractor's
+# leading-FROM regex misses.
+_FORBIDDEN_SCHEMAS = ("information_schema", "mysql", "performance_schema", "sys")
 
 # Match `tab<DocType>` after FROM/JOIN. We accept backticks too:
 # `FROM \`tabSales Invoice\` AS si JOIN tabSales Invoice Item AS sii ...`
@@ -64,6 +94,8 @@ def run_query(query: str, limit: int = DEFAULT_LIMIT) -> dict:
 	clean = query.strip().rstrip(";").strip()
 	_reject_comments(clean)
 	_reject_multi_statement(clean)
+	_reject_forbidden_functions(clean)
+	_reject_forbidden_schemas(clean)
 	parsed = _parse_single_select(clean)
 	_reject_forbidden_keywords(parsed)
 	tables = _extract_tables(clean)
@@ -106,6 +138,46 @@ def _reject_multi_statement(query: str) -> None:
 		raise InvalidArgumentError("multiple statements are not allowed")
 
 
+def _reject_forbidden_functions(query: str) -> None:
+	"""Refuse MySQL function calls that compose into DoS / FS-read attacks
+	even from inside a SELECT. sqlparse tokenizes ``LOAD_FILE(`` as a Name
+	(function call) rather than a Keyword, so the token-stream
+	walker won't catch it.
+
+	Word-boundary regex so a benign column like ``upload_filename`` is not
+	false-matched against ``LOAD_FILE``.
+	"""
+	for fn in _FORBIDDEN_FUNCTIONS:
+		if re.search(rf"\b{re.escape(fn)}\s*\(", query, re.IGNORECASE):
+			raise InvalidArgumentError(
+				f"function not allowed: {fn} (DoS or filesystem-access surface)"
+			)
+
+
+def _reject_forbidden_schemas(query: str) -> None:
+	"""Catch the comma-FROM cross-schema trick:
+	``FROM tabUser, information_schema.tables t``. The leading-FROM table
+	extractor below only checks the first table after FROM/JOIN, so a
+	second comma-separated table referencing ``information_schema`` would
+	slip past the ``tab<DocType>`` requirement.
+
+	Schema-qualified identifiers in MySQL use ``schema.table``; an explicit
+	textual reject of the dangerous schemas closes the comma-FROM hole
+	regardless of how the LLM phrases it.
+	"""
+	for schema in _FORBIDDEN_SCHEMAS:
+		# Match ``information_schema.`` (case-insensitive, word-anchored
+		# before the dot). Also catch backtick-quoted form.
+		if re.search(rf"\b{re.escape(schema)}\s*\.", query, re.IGNORECASE):
+			raise InvalidArgumentError(
+				f"queries against schema {schema!r} are not allowed"
+			)
+		if re.search(rf"`{re.escape(schema)}`\s*\.", query, re.IGNORECASE):
+			raise InvalidArgumentError(
+				f"queries against schema {schema!r} are not allowed"
+			)
+
+
 def _parse_single_select(query: str):
 	"""Return the single sqlparse Statement object, ensuring it's a SELECT."""
 	statements = sqlparse.parse(query)
@@ -146,17 +218,68 @@ def _extract_tables(query: str) -> list[str]:
 		raw = (m.group(1) or m.group(2) or "").strip()
 		if raw and raw not in seen:
 			seen.append(raw)
-	# Any non-tab table reference is a smell: refuse rather than silently
-	# allow access to non-DocType tables (`__Auth`, internal tables, etc.).
-	for m in re.finditer(r"\b(?:FROM|JOIN)\s+(`?\w[^\s`,()]*`?)", query, re.IGNORECASE):
-		raw = m.group(1).strip("`").strip()
-		# Frappe table names always start with `tab` or are derived (`tabDocType`).
-		# Anything else means the query is touching a non-public table.
-		if raw and not raw.startswith("tab"):
+	# Walk every FROM/JOIN clause and tokenize comma-separated table lists.
+	# Defends against ``FROM tabUser, tabHidden`` (second table silently
+	# missing from the perm check) and ``FROM tabUser, secret_table t``
+	# (second table not a tab*). The leading-FROM regex above only checked
+	# the FIRST identifier after each FROM/JOIN.
+	for raw in _comma_from_table_list(query):
+		if not raw.startswith("tab"):
 			raise InvalidArgumentError(
 				f"only `tab<DocType>` tables are allowed; got: {raw}"
 			)
+		# Comma-separated tab tables are legal, but the leading-FROM
+		# extractor missed them; fold them in so the permission check
+		# below covers EVERY referenced DocType.
+		if raw not in seen:
+			seen.append(raw)
 	return seen
+
+
+# Words that terminate a FROM/JOIN table list in standard SQL. Lowercased
+# for case-insensitive matching after we lowercase the input.
+_FROM_TERMINATORS = (
+	"where", "group", "order", "limit", "having", "join", "on", "union",
+	"into", "for",
+)
+
+
+def _comma_from_table_list(query: str) -> list[str]:
+	"""Tokenize every FROM/JOIN clause's comma-separated table list.
+
+	For ``FROM tabUser u, information_schema.tables t WHERE ...`` returns
+	``["tabUser", "information_schema.tables"]``. Aliases stripped.
+
+	Returns lower-cased-input-derived raw identifiers; callers compare to
+	``tab`` (lowercase). Backticks stripped.
+	"""
+	out: list[str] = []
+	lowered = query.lower()
+	# Find every FROM/JOIN start.
+	for m in re.finditer(r"\b(?:from|join)\s+", lowered):
+		start = m.end()
+		# End of the clause = next terminator keyword OR end of string.
+		end = len(lowered)
+		for term in _FROM_TERMINATORS:
+			t_m = re.search(rf"\b{term}\b", lowered[start:])
+			if t_m:
+				end = min(end, start + t_m.start())
+		clause_lower = lowered[start:end]
+		clause_orig = query[start:end]
+		# Strip parenthesized subexpressions so a subquery's comma doesn't
+		# split the outer list. Naive paren-skip is fine here because we
+		# only care about table identifiers, not the subquery's contents.
+		clause_orig = re.sub(r"\([^()]*\)", "", clause_orig)
+		for piece in clause_orig.split(","):
+			ident = piece.strip().split()[0] if piece.strip() else ""
+			ident = ident.strip("`").strip()
+			if not ident:
+				continue
+			# Lowercase only the schema-prefix comparison; preserve the
+			# table-name case for the perm check downstream (Frappe
+			# DocTypes are mixed case: "Sales Invoice").
+			out.append(ident)
+	return out
 
 
 def _enforce_limit(query: str, limit: int) -> str:


### PR DESCRIPTION
The agent-facing run_query tool restricts itself to SELECTs over Frappe DocType tables (``tabSomething``) with per-DocType read perms. The 2026-06-16 review found five families of bypass the existing validator missed; this PR closes each.

1. Filesystem read/write via SELECT ... INTO {OUT,DUMP}FILE / LOAD_FILE New _FORBIDDEN_TOKENS entries: INTO, OUTFILE, DUMPFILE. LOAD_FILE is a function call sqlparse classifies as Name (not Keyword), so it goes through a separate _reject_forbidden_functions(query) pass using a word-boundary regex (so a benign column like ``upload_filename`` doesn't false-positive).

2. DoS / timing attacks via SLEEP, BENCHMARK Same _reject_forbidden_functions family. Even from inside a SELECT, ``WHERE SLEEP(10)`` ties up a DB connection long enough that a few parallel calls saturate Frappe's connection pool.

3. Coordination DoS via GET_LOCK / RELEASE_LOCK Server-side named locks the agent has no business touching. Added to the function reject list.

4. Comma-FROM cross-schema escape ``FROM tabUser, information_schema.tables t`` slipped past the leading-FROM regex (which only matched the FIRST identifier after FROM). Two defenses:
   - _reject_forbidden_schemas(query) explicitly rejects any reference to information_schema / mysql / performance_schema / sys.
   - _comma_from_table_list(query) tokenizes every FROM/JOIN clause by clause-terminator keywords, splits on commas, and verifies EVERY identifier (not just the first) starts with ``tab``. Aliases stripped; backtick-quoted forms handled. Subquery parentheses elided so an inner comma doesn't fool the outer split.

5. Comma-FROM to non-public-Frappe tables Same _comma_from_table_list pass catches ``FROM tabUser, __Auth a``. The error message names the bad identifier so the operator can tell what the agent attempted.

Tests (12 new in TestRunQueryValidation):
- INTO OUTFILE / INTO DUMPFILE / LOAD_FILE rejected
- SLEEP / BENCHMARK rejected
- GET_LOCK / RELEASE_LOCK rejected
- Comma-FROM to information_schema (plain + backticked)
- Comma-FROM to mysql.user
- Comma-FROM to __Auth (non-tab)
- Word-boundary negative: ``upload_filename`` column NOT falsely rejected by the LOAD_FILE pattern.

Verified: 28 tests OK (16 prior + 12 new).

Out of scope:
- Per-tenant DocType allowlist (significant change, separate plan)
- Running run_query under a minimal-privilege DB user (infra change)