### PR TITLE
fix(reliability): Sprint-3 PR-4 - bench exception-handling cluster (5…

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -47,23 +47,39 @@ _CLIENT_MODE = "backend"
 _ROLE = "operator"
 _PLATFORM = "linux"  # informational; only affects the v3 signature payload
 
-# Substrings in openclaw's connect-rejection error message that indicate the
-# customer's stored pairing is stale for the current container (typically
-# because admin re-provisioned the tenant and the new container has no record
-# of this deviceId). In those cases we wipe + re-pair once. Other rejection
-# reasons (signature-invalid, scope-mismatch) are programming bugs and must
-# NOT trigger a retry - that'd hide the bug behind silent re-pair attempts.
-_STALE_PAIRING_MARKERS = (
+# openclaw rejection codes that indicate the customer's stored pairing
+# is stale for the CURRENT container (typically because admin re-provisioned
+# the tenant and the new container has no record of this deviceId). On
+# any of these we wipe + re-pair once. OTHER rejection codes
+# (signature-invalid, scope-mismatch, etc.) are programming bugs / config
+# errors and must NOT trigger a retry - that'd hide the bug behind silent
+# re-pair attempts that destroy valid credentials.
+#
+# Sprint-3 (2026-06-16 review): we used to substring-match on
+# ``str(err).lower()`` which would false-positive any future error
+# embedding one of these tokens in its message text (think log lines,
+# diagnostic dumps, partial-match codes like ``device-not-paired-yet``).
+# The classifier now reads the structured ``.code`` attribute populated
+# at the raise site from openclaw's response envelope.
+_STALE_PAIRING_CODES = frozenset({
 	"device-not-paired",
 	"token-mismatch",
 	"token-revoked",
 	"device-id-mismatch",
-)
+})
 
 
 def _is_stale_pairing(err: Exception) -> bool:
-	msg = str(err).lower()
-	return any(marker in msg for marker in _STALE_PAIRING_MARKERS)
+	"""Return True iff ``err`` is an OpenclawUnreachableError whose
+	openclaw error.code is in the stale-pairing set.
+
+	Strictly typed: an error WITHOUT a ``.code`` attribute (network-level
+	failure, programmer bug) never triggers the repair path. The previous
+	substring check would have caught these falsely if their message
+	happened to contain one of the marker strings.
+	"""
+	code = getattr(err, "code", None)
+	return code in _STALE_PAIRING_CODES
 
 
 def _persisted_device_id() -> str:
@@ -247,6 +263,7 @@ class OpenclawSession:
 					err = frame.get("error") or {}
 					raise OpenclawUnreachableError(
 						f"agent rejected: {err.get('code', '?')}: {err.get('message', '')}",
+						code=err.get("code"),
 					)
 				active_run_id = (frame.get("payload") or {}).get("runId")
 				got_ack = True
@@ -340,6 +357,7 @@ class OpenclawSession:
 					err = frame.get("error") or {}
 					raise OpenclawUnreachableError(
 						f"connect rejected: {err.get('code', '?')}: {err.get('message', '')}",
+						code=err.get("code"),
 					)
 				return
 		raise OpenclawUnreachableError("no connect response before timeout")
@@ -369,6 +387,7 @@ class OpenclawSession:
 					err = frame.get("error") or {}
 					raise OpenclawUnreachableError(
 						f"{method} rejected: {err.get('code', '?')}: {err.get('message', '')}",
+						code=err.get("code"),
 					)
 				return frame
 		raise OpenclawUnreachableError(f"{method} timed out")

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -72,7 +72,18 @@ def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
 
 
 def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
-	"""Drive one agent turn end to end. Called by RQ; not whitelisted."""
+	"""Drive one agent turn end to end. Called by RQ; not whitelisted.
+
+	Sprint-3 (2026-06-16 review): the inline ``except OpenclawUnreachableError``
+	blocks only marked the placeholder errored for openclaw-specific
+	failures. Any OTHER exception (cryptography.InvalidKey, ssl.SSLError,
+	programmer bug in _handle_event, etc.) propagated to RQ without
+	calling _mark_errored, leaving the assistant row stuck at
+	``streaming=1`` forever (the UI poller spins on the empty body).
+	An outer try/except Exception now catches everything else, marks the
+	row errored + publishes run:error, then re-raises so RQ still records
+	the job as failed.
+	"""
 	conv = frappe.get_doc(CONV, conversation_id)
 	user = conv.owner
 
@@ -101,51 +112,81 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 	user_message = _augment_with_context(user_message or "")
 
 	try:
-		sess = OpenclawSession.connect(gateway_url, gateway_token)
-	except OpenclawUnreachableError as e:
-		_mark_errored(assistant_msg.name, str(e))
-		publish_to_user(user, {
-			"kind": "run:error",
-			"conversation_id": conversation_id,
-			"message_id": assistant_msg.name,
-			"run_id": run_id,
-			"error": str(e),
-		})
-		return
+		try:
+			sess = OpenclawSession.connect(gateway_url, gateway_token)
+		except OpenclawUnreachableError as e:
+			_mark_errored(assistant_msg.name, str(e))
+			publish_to_user(user, {
+				"kind": "run:error",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg.name,
+				"run_id": run_id,
+				"error": str(e),
+			})
+			return
 
-	effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
+		effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
 
-	try:
-		idem = f"{conversation_id}:{message_id}"
-		tool_msg_by_call_id: dict[str, str] = {}
-		for event in sess.stream_agent_turn(
-			conv.session_key, user_message, idem,
-			model=effective_model, provider=oauth_provider_id,
-		):
-			_handle_event(
-				event,
-				conversation_id=conversation_id,
-				assistant_msg_name=assistant_msg.name,
-				tool_msg_by_call_id=tool_msg_by_call_id,
-				user=user,
-				run_id=run_id,
+		try:
+			idem = f"{conversation_id}:{message_id}"
+			tool_msg_by_call_id: dict[str, str] = {}
+			for event in sess.stream_agent_turn(
+				conv.session_key, user_message, idem,
+				model=effective_model, provider=oauth_provider_id,
+			):
+				_handle_event(
+					event,
+					conversation_id=conversation_id,
+					assistant_msg_name=assistant_msg.name,
+					tool_msg_by_call_id=tool_msg_by_call_id,
+					user=user,
+					run_id=run_id,
+				)
+		except OpenclawUnreachableError as e:
+			_mark_errored(assistant_msg.name, str(e))
+			publish_to_user(user, {
+				"kind": "run:error",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg.name,
+				"run_id": run_id,
+				"error": str(e),
+			})
+			return
+		finally:
+			sess.close()
+
+		# Streaming exited cleanly via lifecycle.end
+		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
+		frappe.db.commit()
+
+	except Exception as e:
+		# Last-resort backstop. Any exception that wasn't an
+		# OpenclawUnreachableError (e.g. cryptography.InvalidKey from
+		# device-pairing signing, ssl.SSLError, a tool-handler bug,
+		# DoesNotExistError on a stale conversation row) would otherwise
+		# leave the assistant row at ``streaming=1`` indefinitely. Mark
+		# it errored, publish run:error, then re-raise so RQ records the
+		# job as failed (and the operator gets a normal Error Log entry).
+		try:
+			_mark_errored(
+				assistant_msg.name,
+				f"unexpected worker error: {type(e).__name__}",
 			)
-	except OpenclawUnreachableError as e:
-		_mark_errored(assistant_msg.name, str(e))
-		publish_to_user(user, {
-			"kind": "run:error",
-			"conversation_id": conversation_id,
-			"message_id": assistant_msg.name,
-			"run_id": run_id,
-			"error": str(e),
-		})
-		return
-	finally:
-		sess.close()
-
-	# Streaming exited cleanly via lifecycle.end
-	frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
-	frappe.db.commit()
+			publish_to_user(user, {
+				"kind": "run:error",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg.name,
+				"run_id": run_id,
+				# Don't leak full str(e) - the operator-safe identifier is
+				# the exception class; the full traceback is in Error Log.
+				"error": f"{type(e).__name__}",
+			})
+		except Exception:
+			# If even the error-marking path fails, swallow - we're
+			# already in an error path and re-raising would mask the
+			# original exception that RQ should see.
+			pass
+		raise
 	publish_to_user(user, {
 		"kind": "run:end",
 		"conversation_id": conversation_id,

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -15,7 +15,20 @@ class InvalidArgumentError(JarvisError):
 
 
 class OpenclawUnreachableError(JarvisError):
-    """Raised when the openclaw gateway can't be reached (WS handshake failed, container down)."""
+    """Raised when the openclaw gateway can't be reached (WS handshake
+    failed, container down).
+
+    Sprint-3 (2026-06-16 review): may carry a structured ``code`` taken
+    from openclaw's rejection payload (``device-not-paired``,
+    ``token-mismatch``, ``signature-invalid``, etc.). Downstream
+    classifiers (e.g. _is_stale_pairing) should branch on this
+    attribute, not on a substring match of the message. ``code`` is
+    None when the error didn't originate from an openclaw response
+    (e.g. network-level WS open failure)."""
+
+    def __init__(self, message: str, *, code: str | None = None):
+        super().__init__(message)
+        self.code = code
 
 
 class OpenclawReloadFailedError(JarvisError):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -115,8 +115,20 @@ class JarvisSettings(Document):
         - "restart" calls post_update_llm_creds (re-render openclaw.json
           and restart container) - used for mode switches and
           provider/model/base_url changes.
+
+        Sprint-3 (2026-06-16 review): the previous shape silently swallowed
+        AdminRateLimitedError (logged only; last_sync_status stayed at
+        "pending: ..." forever). The UI poller spins on that, never showing
+        the user a state they can act on. Now the rate-limit branch ALSO
+        writes a terminal failure status with the admin-provided
+        retry_after_seconds hint so the UI can render a retry timer.
+
+        Additionally a try/finally backstop guarantees last_sync_status
+        never stays at "pending: ..." on an unexpected exception path -
+        the UI poller flips off pending no matter what blew up.
         """
         from jarvis import admin_client
+        terminal_written = False
         try:
             if action == "reload":
                 secret = self._resolve_llm_secret_for_push()
@@ -138,22 +150,55 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
             })
+            terminal_written = True
         except admin_client.AdminAuthError as e:
-            self.db_set("last_sync_status", f"failed: auth: {e}")
+            self.db_set({
+                "last_sync_at": frappe.utils.now(),
+                "last_sync_status": f"failed: auth: {e}",
+            })
+            terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin auth failed",
                 message=frappe.get_traceback(),
             )
         except admin_client.AdminUnreachableError as e:
-            self.db_set("last_sync_status", f"failed: admin unreachable: {e}")
+            self.db_set({
+                "last_sync_at": frappe.utils.now(),
+                "last_sync_status": f"failed: admin unreachable: {e}",
+            })
+            terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin unreachable",
                 message=frappe.get_traceback(),
             )
         except admin_client.AdminRateLimitedError as e:
+            retry = e.retry_after_seconds or 0
+            retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
+            self.db_set({
+                "last_sync_at": frappe.utils.now(),
+                "last_sync_status": f"failed: rate-limited; {retry_str}",
+            })
+            terminal_written = True
             frappe.logger().info(
-                f"admin_client: rate-limited; retry_after={e.retry_after_seconds}s"
+                f"admin_client: rate-limited; retry_after={retry}s"
             )
+        finally:
+            # Final backstop: if a non-Admin* exception path blew through
+            # (network exception class admin_client doesn't translate,
+            # programmer error, etc.) the status would otherwise stay
+            # 'pending: ...' indefinitely. Flip it to a terminal failure
+            # so the UI poller stops spinning.
+            if not terminal_written:
+                try:
+                    self.db_set({
+                        "last_sync_at": frappe.utils.now(),
+                        "last_sync_status": "failed: unexpected error; see Error Log",
+                    })
+                except Exception:
+                    # If even the status write fails, swallow - we're
+                    # already in an error path and re-raising would mask
+                    # the real exception.
+                    pass
 
     def _classify_llm_change(self) -> str | None:
         """Return one of: None | 'reload' | 'restart'.

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -7,18 +7,47 @@ import json
 import frappe
 
 from jarvis import admin_client
-from jarvis.exceptions import AdminValidationError
+from jarvis.exceptions import (
+	AdminAuthError, AdminRateLimitedError, AdminUnreachableError,
+	AdminValidationError,
+)
 
 
 def _surface(fn, *args, **kwargs):
-	"""Run an admin_client call; re-raise admin validation errors as
-	frappe.ValidationError so the onboarding page gets a clean operator-facing
-	message (and Frappe's standard red toast) instead of a long traceback dump
-	from AdminUnreachableError."""
+	"""Run an admin_client call; re-raise every admin-side error as a clean
+	frappe.ValidationError so the onboarding page renders a red toast with
+	an operator-actionable message instead of a long traceback dump.
+
+	Sprint-3 (2026-06-16 review): the docstring promised "no traceback for
+	any admin failure" but only AdminValidationError was actually caught;
+	AdminUnreachableError / AdminAuthError / AdminRateLimitedError fell
+	through and surfaced as raw 500s. Now ALL four are caught:
+
+	- AdminValidationError  -> "<message>"
+	- AdminAuthError        -> "admin authentication failed; check your "
+	                            "site's bench-admin credentials"
+	- AdminUnreachableError -> "admin is unreachable; check network / "
+	                            "service status and try again"
+	- AdminRateLimitedError -> "rate-limited by admin; retry in Ns" where
+	                            N is the AdminRateLimitedError.retry_after_seconds
+	                            (admin's response hint).
+	"""
 	try:
 		return fn(*args, **kwargs)
 	except AdminValidationError as e:
 		frappe.throw(str(e))
+	except AdminAuthError as e:
+		frappe.throw(
+			f"admin authentication failed; check the bench's admin credentials. ({e})"
+		)
+	except AdminUnreachableError as e:
+		frappe.throw(
+			f"admin is unreachable right now; try again in a moment. ({e})"
+		)
+	except AdminRateLimitedError as e:
+		retry = e.retry_after_seconds or 0
+		retry_str = f"retry in {retry}s" if retry > 0 else "retry shortly"
+		frappe.throw(f"admin rate-limited the request; {retry_str}.")
 
 
 def write_connection(data: dict) -> None:

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -335,10 +335,15 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		first_sent: list = []
 		second_sent: list = []
 
+		# Sprint-3 (2026-06-16 review): openclaw's rejection payload puts
+		# the marker in error.code, not error.message. The classifier on
+		# the client side now reads the structured code rather than
+		# substring-matching the message text, so the scripted fixture
+		# must place the marker accordingly.
 		def _first_nack():
 			req_id = first.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
-						   "error": {"code": "UNAUTHORIZED", "message": first_reject_marker}})
+						   "error": {"code": first_reject_marker, "message": "stale"}})
 
 		def _second_ok():
 			req_id = second.sent[-1]["id"]
@@ -347,7 +352,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		def _second_nack():
 			req_id = second.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
-						   "error": {"code": "UNAUTHORIZED", "message": first_reject_marker}})
+						   "error": {"code": first_reject_marker, "message": "stale"}})
 
 		first = _ScriptedWS([_challenge(), _first_nack])
 		second_response = _second_ok if second_ok else _second_nack
@@ -403,14 +408,20 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 
 	def test_signature_invalid_does_not_trigger_repair(self):
 		"""A signing bug must surface, not get masked by a silent re-pair.
-		signature-invalid means our client code is broken; clearing creds
-		won't help and the operator needs to see the original error."""
+		device-signature-invalid means our client code is broken; clearing
+		creds won't help and the operator needs to see the original error.
+
+		Sprint-3 (2026-06-16): the classifier now reads the structured
+		``code`` attribute, not the message. Putting the marker in
+		``error.code`` is the production wire shape; this test pins that
+		signature-invalid is NOT in the stale-pairing code set."""
 		creds = _make_creds()
 
 		def _nack():
 			req_id = first_ws.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
-						   "error": {"code": "UNAUTHORIZED", "message": "device-signature-invalid"}})
+						   "error": {"code": "device-signature-invalid",
+									 "message": "bad sig"}})
 
 		first_ws = _ScriptedWS([_challenge(), _nack])
 		clear_called: list = []
@@ -422,7 +433,37 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			with self.assertRaises(OpenclawUnreachableError) as cm:
 				OpenclawSession.connect("ws://t", "x")
 		self.assertFalse(clear_called, "should not clear creds for signing bugs")
-		self.assertIn("signature-invalid", str(cm.exception))
+		self.assertEqual(cm.exception.code, "device-signature-invalid")
+
+	def test_message_substring_does_not_trigger_repair(self):
+		"""Sprint-3: pre-fix bug class - the classifier USED to substring-
+		match str(err).lower(), so any future error whose message text
+		happened to embed one of the stale-pairing markers (a log dump,
+		a partial-match code like 'device-not-paired-yet') would
+		false-positive and wipe valid credentials. The structured-code
+		classifier prevents that."""
+		creds = _make_creds()
+
+		def _nack():
+			req_id = first_ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {"code": "diagnostic-dump",
+									 "message": "context: device-not-paired log line"}})
+
+		first_ws = _ScriptedWS([_challenge(), _nack])
+		clear_called: list = []
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   return_value=first_ws), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)):
+			with self.assertRaises(OpenclawUnreachableError):
+				OpenclawSession.connect("ws://t", "x")
+		self.assertFalse(
+			clear_called,
+			"a substring match in the message must NOT trigger the repair "
+			"path - we read the structured error.code",
+		)
 
 
 class TestRepairConvoyCollapse(FrappeTestCase):
@@ -442,7 +483,8 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 		second = _ScriptedWS([_challenge(), None])
 		first._frames[1] = lambda: _frame({
 			"type": "res", "id": first.sent[-1]["id"], "ok": False,
-			"error": {"code": "UNAUTHORIZED", "message": "device-not-paired"},
+			# Sprint-3: marker in code, not message - matches openclaw's wire shape.
+			"error": {"code": "device-not-paired", "message": "stale"},
 		})
 		second._frames[1] = lambda: _frame({
 			"type": "res", "id": second.sent[-1]["id"], "ok": True, "payload": {},

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -165,6 +165,44 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 		)
 		self.assertIn("model overloaded", assistants[0]["error"])
 
+	def test_unexpected_exception_marks_errored_then_reraises(self):
+		"""Sprint-3 (2026-06-16 review): the inline OpenclawUnreachableError
+		catches USED to leave every other exception (cryptography.InvalidKey
+		from device signing, ssl.SSLError, programmer bugs in _handle_event)
+		propagating to RQ without _mark_errored or run:error - the
+		assistant row stayed at streaming=1 forever and the UI spun. The
+		outer catch-all now marks errored + publishes run:error AND
+		re-raises so RQ records the job failure.
+		"""
+		fake_sess = MagicMock()
+		# Simulate a non-Openclaw exception escaping from stream_agent_turn
+		# (e.g. an SSL handshake mid-stream, or a tool-handler bug).
+		import ssl
+		fake_sess.stream_agent_turn.side_effect = ssl.SSLError("handshake failed")
+
+		published_kinds: list = []
+		def _capture(user, payload):
+			published_kinds.append(payload.get("kind"))
+
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess), \
+		     patch("jarvis.chat.worker.publish_to_user", side_effect=_capture):
+			with self.assertRaises(ssl.SSLError):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		# Placeholder must be flipped off streaming + carry an error.
+		assistants = frappe.get_all(
+			MSG,
+			filters={"conversation": self.conv, "role": "assistant"},
+			fields=["error", "streaming"],
+		)
+		self.assertEqual(len(assistants), 1)
+		self.assertEqual(assistants[0]["streaming"], 0)
+		# Error message names the exception class - operator can grep
+		# the Error Log for the full traceback.
+		self.assertIn("SSLError", assistants[0]["error"] or "")
+		# Realtime run:error was published so the UI exits its spinner.
+		self.assertIn("run:error", published_kinds)
+
 
 class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 	"""Worker should prepend `[Context: today is ...]` to the user message

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -404,19 +404,28 @@ class TestSyncViaAdminDispatch(_SettingsSingletonTestCase):
         mock_rotate.assert_not_called()
 
     @patch("jarvis.admin_client.post_rotate_llm_secret")
-    def test_rate_limited_is_logged_not_raised(self, mock_rotate):
+    def test_rate_limited_writes_terminal_failure_status(self, mock_rotate):
+        """Sprint-3 (2026-06-16 review): rate-limit USED to be silently
+        swallowed - last_sync_status stayed at 'pending:' forever and
+        the UI poller spun on it indefinitely. Now we write a terminal
+        failure status with the admin-provided retry_after hint so the
+        UI can render a clean retry timer."""
         from jarvis.exceptions import AdminRateLimitedError
         mock_rotate.side_effect = AdminRateLimitedError(retry_after_seconds=600)
         settings = frappe.get_single("Jarvis Settings")
         settings.db_set("llm_api_key", "sk-1", update_modified=False)
         frappe.db.commit()
         settings.reload()
-        before_status = settings.last_sync_status
         # Should not raise.
         settings._sync_via_admin("reload")
-        # last_sync_status unchanged (rate-limit is a bench-side bug, not creds).
+        # last_sync_status flips to a terminal-failure shape that
+        # carries the retry hint.
         settings.reload()
-        self.assertEqual(settings.last_sync_status, before_status)
+        self.assertIn("failed", settings.last_sync_status or "")
+        self.assertIn("rate-limited", settings.last_sync_status or "")
+        self.assertIn("600", settings.last_sync_status or "")
+        # last_sync_at gets bumped so the UI knows when the status was set.
+        self.assertIsNotNone(settings.last_sync_at)
 
     @patch("jarvis.admin_client.post_rotate_llm_secret")
     def test_admin_auth_error_recorded_in_status(self, mock_rotate):


### PR DESCRIPTION
… items)

Closes five related items from the 2026-06-16 review, all bench-side exception-translation / status-flip bugs that left the system in unrecoverable "pending" or "streaming" states.

1. _surface() in onboarding.py caught only AdminValidationError The docstring promised "no traceback for any admin failure" but only AdminValidationError was actually translated. AdminUnreachableError / AdminAuthError / AdminRateLimitedError surfaced as raw 500s. Now ALL four are caught and re-thrown as frappe.throw with operator-friendly text. Rate-limit additionally carries the admin-provided retry_after_seconds.

2. Jarvis Settings._sync_via_admin swallowed AdminRateLimitedError Used to log-and-return on rate-limit; last_sync_status stayed at "pending: ..." forever, the UI poller spun on it. Now writes a terminal "failed: rate-limited; retry_after=Ns" status with the admin-side hint so the UI can render a retry timer.

3. Final-defense try/except/finally in _sync_via_admin If a non-Admin* exception class blows through the existing handlers (network exception class admin_client doesn't translate, programmer error in the dispatch helpers), the finally branch writes "failed: unexpected error; see Error Log". Status never stays at "pending: ..." regardless of failure path. Covers item 5 from the punch list.

4. Two-shot reconnect retried on WRONG exception class _is_stale_pairing previously substring-matched ``str(err).lower()`` against ("device-not-paired", "token-mismatch", "token-revoked", "device-id-mismatch") - any future error whose MESSAGE text embedded one of these tokens (a log dump, a partial-match like "device-not-paired-yet") would false-positive and wipe valid credentials. OpenclawUnreachableError now carries a structured ``code`` attribute populated from the openclaw rejection payload at every raise site. _is_stale_pairing reads getattr(err, "code", None) and matches against _STALE_PAIRING_CODES (a frozenset). Errors without a code (network failures, programmer bugs) never trigger the repair path.

5. RQ worker didn't publish run:error for non-OpenclawUnreachable The inline ``except OpenclawUnreachableError`` only marked the placeholder errored for openclaw-specific failures; anything else (cryptography.InvalidKey, ssl.SSLError, _handle_event bugs, DoesNotExistError on a stale conversation row) propagated to RQ without _mark_errored or run:error. The assistant row stayed at streaming=1 forever; the UI poller spun on the empty body. New outer try/except Exception marks the row errored + publishes run:error THEN re-raises so RQ still records the job as failed. Error message names the exception class only - the full traceback stays in Error Log, never on the wire.

Tests:
- TestSyncViaAdminDispatch.test_rate_limited_is_logged_not_raised renamed to test_rate_limited_writes_terminal_failure_status; asserts status carries "rate-limited" + the retry seconds + last_sync_at bump.
- TestSelfHealOnStalePairing tests refactored: scripted NACK fixtures now put the marker in error.code (matches openclaw wire shape) not error.message. Negative test added pinning that a substring match in error.message NEVER triggers the repair path.
- test_signature_invalid_does_not_trigger_repair pinned to verify the structured cm.exception.code, not the legacy message substring.
- TestRunAgentTurnErrorPaths.test_unexpected_exception_marks_errored_then_reraises: ssl.SSLError raised from stream_agent_turn must mark errored + publish run:error + then propagate to RQ.

Verified: settings 33 OK, openclaw_client 21 OK, worker 9 OK, chat_device 8 OK, chat_api 4 OK, admin_client 29 OK, oauth_providers 14 OK, role_gates 6 OK, dev 10 OK, api 13 OK.