### PR TITLE
fix(reliability): Sprint-3 - hourly OAuth refresh poll closes connect…

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -321,6 +321,15 @@ scheduler_events = {
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
 		],
 	},
+	"hourly": [
+		# Sprint-3 (2026-06-16 review): bench has no way to know if the
+		# container's OAuth profile silently went away (refresh-token
+		# failure, operator clear, re-provision without re-push). Hourly
+		# reconciliation keeps last_sync_status honest so the UI can
+		# render a "reconnect" banner instead of "Connected" until the
+		# user hits a ProviderAuthError mid-chat.
+		"jarvis.oauth.cron.poll_oauth_refresh_status",
+	],
 	"daily": [
 		"jarvis.onboarding.sync_connection",
 	],

--- a/jarvis/oauth/cron.py
+++ b/jarvis/oauth/cron.py
@@ -1,0 +1,101 @@
+"""Scheduled OAuth-status reconciliation between bench and container.
+
+Sprint-3 (2026-06-16 review): the previous flow set
+``llm_oauth_account_email`` + ``llm_oauth_connected_at`` ONCE at
+``complete_paste_signin`` and never re-checked. If the container's
+auth-profiles.json later loses the profile (refresh-token failure,
+operator manually cleared, container re-provisioned without the bench
+re-pushing), the bench UI keeps showing "Connected" until the user
+hits a chat-time ``ProviderAuthError`` mid-turn.
+
+This module's ``poll_oauth_refresh_status`` runs hourly. For tenants in
+``llm_auth_mode == "oauth"`` it asks admin/fleet whether the container
+actually holds a usable profile right now. If not, it flips
+``last_sync_status`` to ``"oauth_expired"`` and clears
+``llm_oauth_account_email`` so the UI can render a "reconnect" banner.
+
+Failure modes are noisy on purpose: an AdminUnreachableError is logged
+but does NOT flip the status (we can't tell the difference between
+"container forgot the profile" and "we can't reach the container").
+Only an authoritative ``auth_profile_present == False`` flips state.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+
+_LAST_SYNC_OAUTH_EXPIRED = "oauth_expired"
+
+
+def poll_oauth_refresh_status() -> None:
+	"""Hourly scheduled job: reconcile bench-side OAuth state with the
+	container's actual auth-profile presence.
+
+	No-op when:
+	  - llm_auth_mode != "oauth" (api-key tenants don't have a refresh path)
+	  - last_sync_status already reflects oauth_expired (avoid status flap)
+	  - admin is unreachable / auth fails (ambiguous; don't flip)
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+	if (settings.llm_auth_mode or "api_key") != "oauth":
+		return
+
+	# Cheap early-exit: if we never connected (or already flipped to
+	# expired), there's nothing to check.
+	if not (settings.llm_oauth_account_email or "").strip():
+		return
+
+	from jarvis import admin_client
+	try:
+		result = admin_client.post_llm_auth_status() or {}
+	except admin_client.AdminUnreachableError as e:
+		# Network blip - can't distinguish container-lost-profile from
+		# admin-down. Log once and skip; the next hourly tick will retry.
+		frappe.logger().info(
+			"oauth_refresh_poll: admin unreachable; skipping (%s)", e,
+		)
+		return
+	except admin_client.AdminAuthError as e:
+		# Bench credentials problem - flag in last_sync_status separately
+		# from oauth_expired so the operator can tell them apart.
+		settings.db_set({
+			"last_sync_status": f"failed: auth: {e}",
+			"last_sync_at": frappe.utils.now(),
+		})
+		frappe.log_error(
+			title="oauth_refresh_poll: admin auth failed",
+			message=frappe.get_traceback(),
+		)
+		return
+	except admin_client.AdminRateLimitedError as e:
+		retry = e.retry_after_seconds or 0
+		frappe.logger().info(
+			"oauth_refresh_poll: admin rate-limited (retry_after=%ds); skipping",
+			retry,
+		)
+		return
+
+	data = (result or {}).get("data") or result or {}
+	# Admin returns wrapped or unwrapped depending on the _post helper;
+	# the inner shape is the one we care about.
+	present = bool(data.get("auth_profile_present"))
+	if present:
+		# Still healthy. Don't touch last_sync_status - leave whatever
+		# the last legitimate save wrote there.
+		return
+
+	# Container reports the profile is absent. Flip to expired so the
+	# UI can show a reconnect banner. Clear the cached account email
+	# so the "Connected as <email>" UI element flips off.
+	current_status = settings.last_sync_status or ""
+	settings.db_set({
+		"last_sync_status": _LAST_SYNC_OAUTH_EXPIRED,
+		"last_sync_at": frappe.utils.now(),
+		"llm_oauth_account_email": "",
+	})
+	frappe.logger().info(
+		"oauth_refresh_poll: container reports auth profile absent; "
+		"flipped last_sync_status %r -> %r",
+		current_status, _LAST_SYNC_OAUTH_EXPIRED,
+	)

--- a/jarvis/tests/test_oauth_refresh_poll.py
+++ b/jarvis/tests/test_oauth_refresh_poll.py
@@ -1,0 +1,129 @@
+"""Tests for jarvis.oauth.cron.poll_oauth_refresh_status.
+
+Sprint-3 (2026-06-16 review): hourly reconciliation between the bench's
+cached OAuth state and what the container actually holds. Pins the
+state machine:
+
+  oauth + present  -> no-op (don't clobber a successful save's status)
+  oauth + absent   -> flip to oauth_expired, clear cached email
+  oauth + unreachable -> skip (ambiguous - don't false-flip)
+  oauth + admin auth -> log + write 'failed: auth: ...' (distinct from expired)
+  api_key mode     -> no-op (path doesn't exist for api-key tenants)
+  never connected  -> no-op (nothing to invalidate)
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.oauth.cron import poll_oauth_refresh_status
+
+
+class _PollTestCase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		s = frappe.get_single("Jarvis Settings")
+		cls._snap = {
+			"llm_auth_mode": s.get("llm_auth_mode"),
+			"llm_oauth_account_email": s.get("llm_oauth_account_email"),
+			"last_sync_status": s.get("last_sync_status"),
+			"last_sync_at": s.get("last_sync_at"),
+		}
+
+	@classmethod
+	def tearDownClass(cls):
+		s = frappe.get_single("Jarvis Settings")
+		for k, v in cls._snap.items():
+			s.db_set(k, v)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def _set(self, **kw):
+		s = frappe.get_single("Jarvis Settings")
+		for k, v in kw.items():
+			s.db_set(k, v, update_modified=False)
+		frappe.db.commit()
+
+
+class TestOauthRefreshPoll(_PollTestCase):
+	def setUp(self):
+		self._set(
+			llm_auth_mode="oauth",
+			llm_oauth_account_email="connected@example.com",
+			last_sync_status="ok (restart via admin)",
+		)
+
+	def test_skips_when_mode_is_api_key(self):
+		"""API-key tenants don't have a refresh path; cron must no-op."""
+		self._set(llm_auth_mode="api_key")
+		with patch("jarvis.admin_client.post_llm_auth_status") as admin:
+			poll_oauth_refresh_status()
+		admin.assert_not_called()
+
+	def test_skips_when_never_connected(self):
+		"""Empty llm_oauth_account_email -> nothing to invalidate."""
+		self._set(llm_oauth_account_email="")
+		with patch("jarvis.admin_client.post_llm_auth_status") as admin:
+			poll_oauth_refresh_status()
+		admin.assert_not_called()
+
+	def test_no_change_when_profile_present(self):
+		"""Container reports profile present -> leave last_sync_status
+		alone (don't clobber the legitimate save's 'ok' marker)."""
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           return_value={"data": {"auth_profile_present": True}}):
+			poll_oauth_refresh_status()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, "ok (restart via admin)")
+		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")
+
+	def test_flips_to_expired_when_profile_absent(self):
+		"""The core fix: container reports profile absent -> flip status
+		to oauth_expired AND clear the cached account email so the UI
+		can render 'reconnect'."""
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           return_value={"data": {"auth_profile_present": False}}):
+			poll_oauth_refresh_status()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.last_sync_status, "oauth_expired")
+		self.assertEqual(s.llm_oauth_account_email, "")
+		self.assertIsNotNone(s.last_sync_at)
+
+	def test_admin_unreachable_does_not_false_flip(self):
+		"""AdminUnreachable is ambiguous (could be admin down OR container
+		lost profile). Must NOT flip status - the next hour retries."""
+		from jarvis.exceptions import AdminUnreachableError
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           side_effect=AdminUnreachableError("connection refused")):
+			poll_oauth_refresh_status()
+		s = frappe.get_single("Jarvis Settings")
+		# Unchanged.
+		self.assertEqual(s.last_sync_status, "ok (restart via admin)")
+		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")
+
+	def test_admin_auth_error_writes_distinct_status(self):
+		"""AdminAuthError is a different failure mode from oauth_expired
+		(bench credentials wrong, not container state). Surface it
+		separately so the operator can act on the right thing."""
+		from jarvis.exceptions import AdminAuthError
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           side_effect=AdminAuthError("bad bench creds")):
+			poll_oauth_refresh_status()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertIn("failed", s.last_sync_status or "")
+		self.assertIn("auth", s.last_sync_status or "")
+		# Email NOT cleared - this isn't an oauth_expired flip.
+		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")
+
+	def test_admin_rate_limited_skips_without_flip(self):
+		"""Rate-limit is transient; skip + retry next tick."""
+		from jarvis.exceptions import AdminRateLimitedError
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           side_effect=AdminRateLimitedError(retry_after_seconds=600)):
+			poll_oauth_refresh_status()
+		s = frappe.get_single("Jarvis Settings")
+		# Unchanged.
+		self.assertEqual(s.last_sync_status, "ok (restart via admin)")
+		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")


### PR DESCRIPTION
…ed-state lie

Closes the "refresh-failure observability gap" item from the 2026-06-16 review. Previously ``complete_paste_signin`` set
``llm_oauth_account_email`` + ``llm_oauth_connected_at`` ONCE and the bench never re-checked. If the container later lost the auth profile (refresh-token failure, operator clear, re-provision without re-push), the bench UI kept showing "Connected" until the user hit ProviderAuthError mid-chat. Loud failure mode hidden behind a quiet success state.

New module: jarvis/oauth/cron.poll_oauth_refresh_status. Hourly cron (wired in hooks.py scheduler_events). For oauth-mode tenants with a cached email, asks admin/fleet whether the container actually holds a usable profile right now.

Decision tree (conservative: ambiguous failure modes never false-flip):
  api_key mode             -> no-op (no refresh path)
  never connected          -> no-op (nothing cached to invalidate)
  container reports present -> no-op (don't clobber legit 'ok' status)
  container reports absent  -> flip last_sync_status='oauth_expired',
                                clear llm_oauth_account_email,
                                update last_sync_at
  AdminUnreachable         -> log + skip (can't tell container-lost-profile
                                from admin-down; retry next hour)
  AdminAuthError           -> write 'failed: auth: ...' (distinct from
                                oauth_expired; different remediation)
  AdminRateLimitedError    -> log + skip (transient)

UI gets two distinct terminal states it can branch on:
  oauth_expired             -> "reconnect" banner
  failed: auth: ...         -> "check admin credentials" banner

Tests (7 new in test_oauth_refresh_poll.py):
- api_key mode no-op (admin client not called)
- never-connected no-op (admin client not called)
- profile-present preserves the existing status + email
- profile-absent flips to oauth_expired AND clears email AND bumps last_sync_at
- AdminUnreachable does NOT false-flip
- AdminAuthError writes a distinct 'failed: auth' status (NOT oauth_expired)
- AdminRateLimitedError skips without flip

Verified: 7 new pass, settings 33 OK, openclaw_client 21 OK, chat_worker 9 OK, oauth_providers 14 OK.