### PR TITLE
fix(reliability): Sprint-3 PR-8 prerequisite - admin_client routes 4x…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -365,8 +365,30 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			err.get("message") or "rate_limited",
 			retry_after_seconds=int(err.get("retry_after_seconds") or 0),
 		)
-	if resp.status_code >= 400 or (isinstance(envelope, dict) and not envelope.get("ok", True)):
+	# Sprint-3 PR-8 (2026-06-16 review): a 4xx response with the
+	# structured envelope ({"ok": false, "error": {...}}) is a
+	# user-input / business-rule error, NOT an "admin is unreachable"
+	# condition. The previous shape raised AdminUnreachableError for
+	# both 4xx envelopes AND genuine 5xx / network failures, which
+	# made _surface() in onboarding.py show "admin is unreachable;
+	# try again" for things like "no subscription found" or
+	# "downgrade not supported" - misleading and unhelpful.
+	#
+	# Route by HTTP status:
+	#   4xx + envelope -> AdminValidationError (clean text to UI)
+	#   5xx + envelope -> AdminUnreachableError (network / admin-down)
+	#   200 with ok:false (rare; some endpoints inline failure) -> AdminUnreachableError
+	if resp.status_code >= 400:
 		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
+		msg = err.get("message") or resp.text[:200] or f"admin returned {resp.status_code}"
+		if 400 <= resp.status_code < 500:
+			raise AdminValidationError(msg)
+		raise AdminUnreachableError(
+			f"admin {admin_url} returned error: "
+			f"{err.get('code', '?')}: {msg}"
+		)
+	if isinstance(envelope, dict) and not envelope.get("ok", True):
+		err = envelope.get("error", {}) or {}
 		raise AdminUnreachableError(
 			f"admin {admin_url} returned error: "
 			f"{err.get('code', '?')}: {err.get('message', resp.text[:200])}"

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -210,6 +210,50 @@ class TestAdminErrorResponses(FrappeTestCase):
 				post_update_llm_creds("p", "m", "b", "k")
 		self.assertIn("NoRunningTenant", str(cm.exception))
 
+	# Sprint-3 PR-8: 4xx envelope responses route to AdminValidationError,
+	# not AdminUnreachableError. Used to be one bucket; UI showed
+	# "admin is unreachable" for things like NoRunningTenant or
+	# downgrade-not-supported.
+
+	def test_400_with_envelope_raises_validation_error(self):
+		"""InvalidArgument / InvalidToken / InvalidBlob etc. on tenant.py
+		now show up on the bench as AdminValidationError - operator-actionable
+		clean text, not "admin is unreachable; try again."""
+		mock_post = MagicMock(return_value=_mock_response(
+			400, json_body={"message": {
+				"ok": False, "error": {"code": "InvalidToken", "message": "token too short"},
+			}},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception), "token too short")
+
+	def test_409_with_envelope_raises_validation_error(self):
+		"""NoRunningTenant (409) is a business-rule error, not a network
+		failure - now routes to AdminValidationError so _surface() shows
+		the actual reason."""
+		mock_post = MagicMock(return_value=_mock_response(
+			409, json_body={"message": {
+				"ok": False, "error": {"code": "NoRunningTenant", "message": "no running tenant"},
+			}},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception), "no running tenant")
+
+	def test_5xx_envelope_still_raises_unreachable(self):
+		"""5xx is genuinely server-side; the unreachable class is correct."""
+		mock_post = MagicMock(return_value=_mock_response(
+			503, json_body={"message": {
+				"ok": False, "error": {"code": "ServiceUnavailable", "message": "down"},
+			}},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminUnreachableError):
+				post_update_llm_creds("p", "m", "b", "k")
+
 	def test_frappe_validation_error_surfaces_clean_message(self):
 		"""When admin raises frappe.ValidationError inside a whitelisted endpoint
 		(e.g. dev_force_signup → _reject_duplicate_email), the response body has


### PR DESCRIPTION
…x envelope to AdminValidationError

The bench's admin_client._post used to raise AdminUnreachableError for ANY non-200 response (including 4xx envelope responses from the admin's tenant.py / account.py endpoints). _surface() in onboarding.py then showed "admin is unreachable; try again" - misleading for things like NoRunningTenant (409), InvalidToken (400), downgrade-not-supported (400).

Route by HTTP status now:
  401 / 403  -> AdminAuthError       (unchanged)
  429        -> AdminRateLimitedError (unchanged, with retry_after_seconds)
  4xx + envelope  -> AdminValidationError (NEW; was AdminUnreachableError)
  5xx + envelope  -> AdminUnreachableError (unchanged)
  200 + ok:false  -> AdminUnreachableError (unchanged; some endpoints
                     inline failure without a status code)
  exc_type        -> existing routing (frappe.throw envelopes)

The error message piped through is the bench-side _surface() / _sync_via_admin catch already handle AdminValidationError as clean text. PR-4's _sync_via_admin shape (failed: ... messages with retry hints) is preserved.

This is a prerequisite for the upcoming Sprint-3 PR-8 (account.py migration to envelope shape). Without this routing change, migrating account.py would degrade UI error messages - account-page errors ("no upgrade charge") would render as "admin is unreachable" instead of the actual validation message.

The change is also a strict improvement for the existing tenant.py endpoints (NoRunningTenant 409, InvalidToken 400, InvalidBlob 400, UnknownProvider 400, etc.). Those already used the envelope shape from Sprint-3 PR-1; the bench just wasn't decoding the right class.

Tests (3 new in TestAdminErrorResponses):
- 400 with envelope -> AdminValidationError (clean message text)
- 409 with envelope -> AdminValidationError
- 5xx still raises AdminUnreachableError

Verified: test_admin_client 32 OK (was 29 + 3 new). Pre-existing Redis-down failures on this machine in test_settings_on_update / test_onboarding_sync / test_api are unrelated to this change (reproduce on stashed main).