### PR TITLE
feat(api): Sprint-2 - bench plumbs request_timeout_s into pair_chat_d…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -226,14 +226,29 @@ def post_llm_auth_status() -> dict:
 	)
 
 
-def pair_chat_device(public_key: str, device_id: str) -> dict:
+def pair_chat_device(public_key: str, device_id: str,
+                     *, request_timeout_s: int = 30) -> dict:
 	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
 	to write a PairedDevice record into the customer's openclaw container and
-	returns the issued bearer device-token. Customer keeps the private key."""
+	returns the issued bearer device-token. Customer keeps the private key.
+
+	Sprint-2 plumb-through (2026-06-16 review): ``request_timeout_s`` is
+	the budget the bench asks admin to allow for its admin -> fleet-agent
+	leg. Defaults to 30s (matches admin's prior hardcoded value). Admin
+	clamps to [5, 90] on its side so an over-large value can't push the
+	overall HTTPS round-trip past the bench's outer DEFAULT_TIMEOUT_S=90.
+
+	The outer HTTPS round-trip timeout (bench -> admin) stays at
+	DEFAULT_TIMEOUT_S=90s; that's the absolute upper bound on this call.
+	"""
 	settings = frappe.get_single("Jarvis Settings")
 	return _post(
 		path="/api/method/jarvis_admin.api.tenant.pair_chat_device",
-		body={"public_key": public_key, "device_id": device_id},
+		body={
+			"public_key": public_key,
+			"device_id": device_id,
+			"request_timeout_s": request_timeout_s,
+		},
 		admin_url=_admin_url(settings),
 	)
 

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -555,3 +555,45 @@ class TestPostSubscriptionDisconnect(FrappeTestCase):
 		self.assertEqual(result, {"ok": True})
 		self.assertIn("subscription_disconnect", captured["url"])
 		self.assertEqual(captured["body"], {})
+
+
+class TestPairChatDevice(FrappeTestCase):
+	"""Sprint-2 plumb-through (2026-06-16 review): bench's pair_chat_device
+	now accepts request_timeout_s and forwards it as a body field so admin
+	can configure its admin -> fleet-agent leg accordingly."""
+
+	def setUp(self):
+		_settings_for_admin()
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_default_timeout_sent_as_30(self):
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["body"] = json
+			return _mock_response(200, json_body={"message": {
+				"ok": True, "data": {"device_token": "tok"},
+			}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.pair_chat_device(public_key="pk", device_id="did")
+		self.assertEqual(captured["body"]["request_timeout_s"], 30)
+		self.assertEqual(captured["body"]["public_key"], "pk")
+		self.assertEqual(captured["body"]["device_id"], "did")
+
+	def test_caller_supplied_timeout_forwarded(self):
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["body"] = json
+			return _mock_response(200, json_body={"message": {
+				"ok": True, "data": {"device_token": "tok"},
+			}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.pair_chat_device(
+				public_key="pk", device_id="did", request_timeout_s=75,
+			)
+		self.assertEqual(captured["body"]["request_timeout_s"], 75)


### PR DESCRIPTION
…evice

Top of the "timeouts don't compose" chain (2026-06-16 review). Completes the Sprint-2 plumb-through that's now in place across all three layers:

  bench admin_client.pair_chat_device(*, request_timeout_s=30)
    -> admin api.tenant.pair_chat_device(request_timeout_s=...) [clamped 5-90]
       -> admin agent_client.pair(*, request_timeout_s=...)
          -> requests.request(timeout=...)

Default 30s preserves the pre-plumb-through behavior. Advanced callers on a slow network path (VPN/proxy chains) can opt into a longer value
- admin clamps to [5, 90] so an over-large value can't push the overall HTTPS round-trip past the bench's outer DEFAULT_TIMEOUT_S=90.

ensure_paired() in jarvis/chat/device.py is unchanged - it uses the default 30s. Callers that know they're on a slow path can opt in by passing the kwarg directly; this PR keeps that as a future tuning knob rather than threading it through every call site.

Out of scope (called out for follow-up): the punch list also asked for "on bench-side admin timeout, query admin for the just-paired device_id" - that's an idempotency feature requiring a new "get-already-paired" admin endpoint. Deferred to a separate effort.

Tests (2 new in TestPairChatDevice):
- pair_chat_device() with no kwarg sends request_timeout_s=30 in the body.
- pair_chat_device(request_timeout_s=75) forwards the value verbatim.

Verified: test_admin_client 34 OK (32 prior + 2 new), test_chat_device 8 OK (unchanged - default kwarg means call shape preserved).