### PR TITLE
fix(security): C2 stretch - bind session_key to chat_device_id, rejec…

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -65,6 +65,41 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 				f"session references unknown user: {plugin_user}",
 			)
 
+		# C2 stretch (2026-06-16 review): bind session_key -> bench's
+		# device_id at session-create time, verify on every call. If the
+		# bench has re-paired since this session was created (operator
+		# rotation, incident response, etc.) the snapshot won't match
+		# the current device_id and we reject. Bounds leaked-session
+		# replay to "until the next re-pair."
+		#
+		# Backwards-compat (two-fold):
+		#   1. A row without ``chat_device_id`` (pre-migration row from
+		#      before this column was added) passes through.
+		#   2. A bench whose Jarvis Chat Session DocType hasn't picked up
+		#      the new column yet (pre-bench-migrate state) also passes
+		#      through - we tolerate the AttributeError-ish read failure
+		#      so call_tool doesn't 500 on the first call after a deploy.
+		# Once everyone is migrated the strict check applies uniformly.
+		try:
+			row_device = (frappe.db.get_value(
+				"Jarvis Chat Session",
+				{"session_key": session_key},
+				"chat_device_id",
+			) or "").strip()
+		except Exception:
+			row_device = ""
+		if row_device:
+			current_device = (
+				frappe.db.get_single_value("Jarvis Settings", "chat_device_id") or ""
+			).strip()
+			if current_device and row_device != current_device:
+				frappe.local.response.http_status_code = 401
+				return _error(
+					"AuthenticationError",
+					"session is bound to a previous device pairing; "
+					"the bench has re-paired since this session was issued",
+				)
+
 		return _dispatch_from_session(plugin_user, session_key, tool, args)
 
 	# Standard Frappe auth path - Guest is rejected; everything else dispatches

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -408,11 +408,21 @@ def _ensure_session_key(user: str) -> str:
 	finally:
 		sess.close()
 
+	# C2 stretch (2026-06-16 review): snapshot the bench's current
+	# chat_device_id into the Jarvis Chat Session row. On every
+	# call_tool the plugin-auth validator re-checks that the row's
+	# device_id still matches the bench's current device_id; if not
+	# (because the bench re-paired - operator rotation or compromise
+	# response), the session_key is dead. This bounds the window for
+	# a leaked-session-key replay attack to "until the next re-pair."
+	current_device_id = (settings.chat_device_id or "").strip()
+
 	# Insert the Chat Session row (plugin's sessionKey → user lookup table)
 	frappe.get_doc({
 		"doctype": "Jarvis Chat Session",
 		"session_key": session_key,
 		"user": user,
+		"chat_device_id": current_device_id,
 	}).insert(ignore_permissions=True)
 	frappe.db.commit()
 

--- a/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_session/jarvis_chat_session.json
@@ -9,6 +9,7 @@
   "field_order": [
     "session_key",
     "user",
+    "chat_device_id",
     "created_at",
     "last_seen_at"
   ],
@@ -31,6 +32,13 @@
       "reqd": 1,
       "in_list_view": 1,
       "description": "Frappe user who owns this openclaw session"
+    },
+    {
+      "fieldname": "chat_device_id",
+      "fieldtype": "Data",
+      "label": "Chat Device ID",
+      "read_only": 1,
+      "description": "Snapshot of Jarvis Settings.chat_device_id at session-create time. C2 stretch: if the bench re-pairs (device_id changes), all prior session_keys become invalid - even a leaked session_key + leaked agent_token can no longer impersonate after a routine re-pair."
     },
     {
       "fieldname": "created_at",

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -172,6 +172,105 @@ class TestCallToolPluginAuth(FrappeTestCase):
 				call_tool(tool="get_schema", args={"doctype": "Customer"})
 		self.assertEqual(frappe.session.user, original)
 
+	def _patched_session_lookup(self, *, row_device: str, current_device: str):
+		"""Patch context that fakes:
+		  - The Chat Session row's user lookup returns "Administrator" so
+		    the existing user-resolution path succeeds.
+		  - The Chat Session row's chat_device_id lookup returns
+		    ``row_device`` (or "" to opt out of binding).
+		  - Jarvis Settings.chat_device_id returns ``current_device``.
+		Avoids requiring a real DB column (the JSON definition adds
+		``chat_device_id`` but the migration runs at deploy time).
+		"""
+		original_get_value = frappe.db.get_value
+		original_get_single_value = frappe.db.get_single_value
+
+		def _fake_get_value(*args, **kwargs):
+			# (doctype, filters, fieldname) positional OR kwargs.
+			doctype = args[0] if args else kwargs.get("doctype")
+			fieldname = args[2] if len(args) > 2 else kwargs.get("fieldname")
+			if doctype == "Jarvis Chat Session":
+				if fieldname == "user":
+					return "Administrator"
+				if fieldname == "chat_device_id":
+					return row_device
+			return original_get_value(*args, **kwargs)
+
+		def _fake_get_single_value(doctype, field, *a, **kw):
+			if doctype == "Jarvis Settings" and field == "chat_device_id":
+				return current_device
+			return original_get_single_value(doctype, field, *a, **kw)
+
+		return (
+			patch("jarvis.api.frappe.db.get_value", side_effect=_fake_get_value),
+			patch("jarvis.api.frappe.db.get_single_value",
+			      side_effect=_fake_get_single_value),
+		)
+
+	def test_session_bound_to_old_device_rejected_after_repair(self):
+		"""C2 stretch (2026-06-16 review): if the bench re-pairs the chat
+		device after a session was issued, that session's chat_device_id
+		snapshot won't match the current device id. The session is
+		rejected with 401 AuthenticationError - bounds leaked-session
+		replay to the window before the next operator re-pair."""
+		gv, gsv = self._patched_session_lookup(
+			row_device="old-device-id-from-before-repair",
+			current_device="current-device-id-after-repair",
+		)
+		with self._with_headers({
+			"X-Jarvis-Token": "plugin-auth-test-token",
+			"X-Jarvis-Session": "agent:test:any-session",
+		}):
+			with gv, gsv:
+				with patch("frappe.db.exists", return_value=True):
+					result = call_tool(tool="get_schema", args={"doctype": "Customer"})
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["error"]["code"], "AuthenticationError")
+		self.assertEqual(frappe.local.response.http_status_code, 401)
+		self.assertIn("previous device pairing", result["error"]["message"])
+
+	def test_session_bound_to_current_device_accepted(self):
+		"""Sanity check: a session whose chat_device_id matches the
+		current bench device_id dispatches normally. No regression for
+		the happy path."""
+		gv, gsv = self._patched_session_lookup(
+			row_device="matching-device-id",
+			current_device="matching-device-id",
+		)
+		with self._with_headers({
+			"X-Jarvis-Token": "plugin-auth-test-token",
+			"X-Jarvis-Session": "agent:test:any-session",
+		}):
+			with gv, gsv:
+				with patch("frappe.db.exists", return_value=True):
+					with patch("jarvis.api.dispatch",
+					           return_value={"doctype": "Customer", "fields": []}):
+						with patch("jarvis.api._persist_and_publish_tool_call"):
+							result = call_tool(tool="get_schema",
+							                    args={"doctype": "Customer"})
+		self.assertTrue(result["ok"], msg=result)
+
+	def test_pre_migration_row_without_device_id_passes(self):
+		"""Backwards-compat: a row without ``chat_device_id`` (pre-migration
+		session or pre-fix bench) must continue to dispatch normally so
+		call_tool doesn't 500 on the first call after a deploy."""
+		gv, gsv = self._patched_session_lookup(
+			row_device="",  # empty = pre-migration session
+			current_device="current-device-id",
+		)
+		with self._with_headers({
+			"X-Jarvis-Token": "plugin-auth-test-token",
+			"X-Jarvis-Session": "agent:test:any-session",
+		}):
+			with gv, gsv:
+				with patch("frappe.db.exists", return_value=True):
+					with patch("jarvis.api.dispatch",
+					           return_value={"doctype": "Customer", "fields": []}):
+						with patch("jarvis.api._persist_and_publish_tool_call"):
+							result = call_tool(tool="get_schema",
+							                    args={"doctype": "Customer"})
+		self.assertTrue(result["ok"], msg=result)
+
 
 def _cleanup_session(session_key: str) -> None:
 	names = frappe.get_all(


### PR DESCRIPTION
…t on re-pair

Closes the "bind session_key -> caller identity at pair time; verify on each call" item from the 2026-06-16 review's C2 thread. With this in place, a leaked agent_token + leaked X-Jarvis-Session cannot be replayed indefinitely - the window collapses to "until the next operator re-pair."

Mechanics:

1. Jarvis Chat Session DocType gains a ``chat_device_id`` field (Data, read-only). Description points future readers at this C2 stretch note so the relationship between the field and the auth check stays discoverable.

2. _ensure_session_key in jarvis/chat/api.py snapshots the bench's current Jarvis Settings.chat_device_id when it inserts the Chat Session row. The snapshot is wire-stable from then on - it lives in the row, not Jarvis Settings.

3. call_tool plugin-auth path (after the existing C2 PR-1 IP allowlist
   + bearer + HMAC checks pass) reads the row's chat_device_id and compares it to the bench's CURRENT chat_device_id. Mismatch -> 401 AuthenticationError with message "session is bound to a previous device pairing".

Why this is a meaningful defense:

- A leaked agent_token alone is already blunted by C2 PR-1's HMAC signature requirement (PR-2 made plugins emit signed requests).
- A leaked session_key alone never worked - the bench resolves the Frappe user from it.
- The remaining gap: a single attacker who has BOTH agent_token AND a valid session_key can impersonate forever. After this PR, the legitimate operator can rotate the bench's chat_device_id via the existing ``clear_credentials() -> ensure_paired()`` flow, and all prior session_keys (including the leaked one) instantly stop authenticating.

Backwards compatibility:

- Rows inserted BEFORE this PR have NULL chat_device_id; the check treats empty/missing as "skip binding" and dispatches normally.
- The bench-side read uses try/except so a pre-migration deployment state (DocType JSON shipped, migration not yet run) doesn't 500 - the call falls back to the legacy behavior.
- Operator deploy path: ``bench --site X migrate`` adds the column; new sessions get the snapshot; old ones eventually expire naturally through conversation archive flow.

Tests (3 new in TestCallToolPluginAuth):
- Session whose row's chat_device_id differs from the current bench device_id is rejected with 401 + "previous device pairing" message.
- Session whose row matches the current bench device_id dispatches normally (happy path regression pin).
- Pre-migration row (empty chat_device_id) passes through unchanged (backwards-compat pin).

Tests use a patched get_value/get_single_value pair so the DocType column doesn't have to physically exist on the test DB - the production read paths are exercised but the schema constraint is mocked. This matches the established pattern from the Sprint-3 PR-8 account.py migration which had the same DB-state caveat.

Verified: 3 new tests pass. Pre-existing Redis-down failures in TestC2HmacSignature/TestC2RateLimit unrelated.

Out of scope (called out for follow-up): the punch list also mentioned "add per-call nonce/signature instead of static shared secret" - already done in C2 PR-1/PR-2. "Rotate agent_token via per-tenant KDF" remains a stretch item (per-tenant HKDF derivation, separate effort).