### PR TITLE
fix(security): C2 - time-bounded agent_token with operator-configurab…

### DIFF
--- a/jarvis/_plugin_auth.py
+++ b/jarvis/_plugin_auth.py
@@ -109,6 +109,21 @@ def validate_plugin_request(body_bytes: bytes) -> str:
 			message="invalid X-Jarvis-Token",
 		)
 
+	# 3a. C2 (2026-06-16 review) - time-bounded token. Operators
+	# configure ``Jarvis Settings.agent_token_max_age_days`` (default 90)
+	# and the rotate_agent_token endpoint stamps issued_at = now. Past
+	# the configured age the token is rejected with a distinct code so
+	# the bench's UI can render a "rotate now" CTA instead of a generic
+	# 401. max_age=0 disables expiry (legacy escape hatch).
+	if _agent_token_expired():
+		_audit_log("plugin_auth: agent_token past max-age",
+		           "agent_token is older than agent_token_max_age_days; "
+		           "operator must call rotate_agent_token to refresh")
+		raise PluginAuthError(
+			http_status=401, code="AgentTokenExpired",
+			message="agent_token past configured max age; operator must rotate",
+		)
+
 	# 3. Session header required.
 	session_key = (headers.get("X-Jarvis-Session") or "").strip()
 	if not session_key:
@@ -236,6 +251,43 @@ def _configured_allowlist() -> tuple[str, ...]:
 def _agent_token() -> str:
 	settings = frappe.get_single("Jarvis Settings")
 	return settings.get_password("agent_token", raise_exception=False) or ""
+
+
+def _agent_token_expired() -> bool:
+	"""Return True iff the bench's agent_token is past its operator-
+	configured max age.
+
+	Fields driving this:
+	  - agent_token_issued_at: Datetime (set by rotate_agent_token)
+	  - agent_token_max_age_days: Int (default 90, 0 disables)
+
+	A token with no issued_at is treated as not-expired (legacy
+	deployments that pre-date this field; operator must run a one-time
+	rotate to set the timestamp going forward). Backwards compat with
+	pre-migration benches that don't have the column yet: any read
+	failure is treated as "not expired" so call_tool doesn't 500 on a
+	deploy where the JSON shipped but bench migrate hasn't run.
+	"""
+	try:
+		settings = frappe.get_single("Jarvis Settings")
+		max_age_days = int(getattr(settings, "agent_token_max_age_days", 0) or 0)
+		if max_age_days <= 0:
+			return False
+		issued_at = getattr(settings, "agent_token_issued_at", None)
+	except Exception:
+		return False
+	if not issued_at:
+		# Legacy token (issued before this field existed) - don't break
+		# the bench by expiring it; surface via the cron-side warning
+		# instead so operators can do a one-time rotate at their leisure.
+		return False
+	try:
+		import datetime as _dt
+		issued = frappe.utils.get_datetime(issued_at)
+		age = (_dt.datetime.now(issued.tzinfo) if issued.tzinfo else _dt.datetime.now()) - issued
+		return age.days >= max_age_days
+	except Exception:
+		return False
 
 
 def _canonical_request(*, session_key: str, body_bytes: bytes,

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -371,7 +371,15 @@ def rotate_agent_token() -> dict:
 	# Persist it locally so the bench's future plugin-auth validations
 	# match what the container holds.
 	settings = frappe.get_single("Jarvis Settings")
+	now = frappe.utils.now()
 	settings.db_set("agent_token", new_token)
+	# C2 time-bound: stamp issued_at so plugin_auth's expiry check has
+	# a reference point. Tolerate the column not existing yet on a
+	# pre-migration deploy state.
+	try:
+		settings.db_set("agent_token_issued_at", now)
+	except Exception:
+		pass
 	frappe.db.commit()
 
-	return {"ok": True, "data": {"rotated_at": frappe.utils.now()}}
+	return {"ok": True, "data": {"rotated_at": now}}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -332,6 +332,10 @@ scheduler_events = {
 	],
 	"daily": [
 		"jarvis.onboarding.sync_connection",
+		# C2 (2026-06-16 review): nudge operators when the bench's
+		# agent_token is approaching or past its configured max age.
+		# Daily is plenty - the warning window is 7 days.
+		"jarvis.oauth.cron.check_agent_token_age",
 	],
 }
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -31,6 +31,8 @@
     "operator_section",
     "agent_url",
     "agent_token",
+    "agent_token_issued_at",
+    "agent_token_max_age_days",
     "chat_device_id",
     "chat_device_public_key",
     "chat_device_private_key",
@@ -197,6 +199,20 @@
       "label": "Agent Token",
       "read_only": 1,
       "description": "Bearer token used to authenticate the secrets.reload RPC and the chat worker's WebSocket session"
+    },
+    {
+      "fieldname": "agent_token_issued_at",
+      "fieldtype": "Datetime",
+      "label": "Agent Token Issued At",
+      "read_only": 1,
+      "description": "Timestamp of the last rotate_agent_token. C2 (2026-06-16 review): combined with agent_token_max_age_days, lets the bench enforce periodic rotation hygiene like SSH host-key / TLS-cert rotation. Empty == unbounded (legacy)."
+    },
+    {
+      "fieldname": "agent_token_max_age_days",
+      "fieldtype": "Int",
+      "label": "Agent Token Max Age (days)",
+      "default": 90,
+      "description": "Reject the bearer token if issued_at + this many days < now. Default 90 days. Set to 0 to disable expiry (not recommended). Operator rotates via the rotate_agent_token endpoint."
     },
     {
       "fieldname": "chat_device_id",

--- a/jarvis/oauth/cron.py
+++ b/jarvis/oauth/cron.py
@@ -99,3 +99,73 @@ def poll_oauth_refresh_status() -> None:
 		"flipped last_sync_status %r -> %r",
 		current_status, _LAST_SYNC_OAUTH_EXPIRED,
 	)
+
+
+# Warning thresholds for the agent_token age check below. Tune via the
+# Jarvis Settings.agent_token_max_age_days field, not these constants.
+_AGENT_TOKEN_WARN_WITHIN_DAYS = 7
+
+
+def check_agent_token_age() -> None:
+	"""Daily scheduled job: warn the operator when the bench's
+	agent_token is approaching or past its configured max age.
+
+	C2 (2026-06-16 review): the plugin_auth validator HARD-rejects past
+	max-age tokens so the bench doesn't keep accepting stale credentials.
+	The cron's job is observability + nudge - operators see the warning
+	in Error Log before the hard cutoff lands.
+
+	Decision tree:
+	  - max_age_days unset / <= 0: no-op (expiry disabled)
+	  - no issued_at recorded: log once per day (legacy token; nudge to
+	    do a one-time rotate so the timestamp is captured going forward)
+	  - issued_at + max_age <= now: error-log (token IS expired right now)
+	  - issued_at + (max_age - warn_within_days) <= now: warn-log (about
+	    to expire; rotate in the next few days)
+	  - otherwise: no-op
+	"""
+	try:
+		settings = frappe.get_single("Jarvis Settings")
+		max_age_days = int(getattr(settings, "agent_token_max_age_days", 0) or 0)
+	except Exception:
+		return
+	if max_age_days <= 0:
+		return
+
+	issued_at = getattr(settings, "agent_token_issued_at", None)
+	if not issued_at:
+		frappe.logger().warning(
+			"check_agent_token_age: agent_token has no issued_at "
+			"timestamp; rotate via /api/method/jarvis.api.rotate_agent_token "
+			"so the expiry check can apply going forward",
+		)
+		return
+
+	try:
+		import datetime as _dt
+		issued = frappe.utils.get_datetime(issued_at)
+		now = (_dt.datetime.now(issued.tzinfo) if issued.tzinfo
+		       else _dt.datetime.now())
+		age_days = (now - issued).days
+	except Exception:
+		return
+
+	if age_days >= max_age_days:
+		# Hard expiry. plugin_auth is already rejecting; just shout.
+		frappe.log_error(
+			title="agent_token past max age",
+			message=(
+				f"agent_token is {age_days}d old (max {max_age_days}d). "
+				"All plugin call_tool requests now fail with "
+				"AgentTokenExpired. Rotate immediately via "
+				"/api/method/jarvis.api.rotate_agent_token."
+			),
+		)
+		return
+
+	if age_days >= max_age_days - _AGENT_TOKEN_WARN_WITHIN_DAYS:
+		frappe.logger().warning(
+			"check_agent_token_age: agent_token is %dd old "
+			"(max %dd; %dd remaining before hard rejection)",
+			age_days, max_age_days, max_age_days - age_days,
+		)

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -646,3 +646,68 @@ class TestRotateAgentTokenEndpoint(FrappeTestCase):
 			frappe.set_user("Administrator")
 			frappe.delete_doc("User", user_email, force=True, ignore_permissions=True)
 			frappe.db.commit()
+
+
+class TestC2AgentTokenExpiry(_PluginAuthTestBase):
+	"""C2 (2026-06-16 review): time-bounded agent_token.
+
+	Tokens older than ``Jarvis Settings.agent_token_max_age_days``
+	are rejected with AgentTokenExpired so the bench enforces periodic
+	rotation hygiene. max_age=0 disables (legacy escape hatch).
+	"""
+
+	def _patch_settings(self, *, max_age_days: int, age_days: int | None):
+		"""Patch _plugin_auth's view of Jarvis Settings: max_age + issued_at.
+
+		``age_days=None`` simulates a legacy token with no issued_at field
+		(must NOT expire - returning False from _agent_token_expired)."""
+		import datetime as _dt
+		from unittest.mock import MagicMock
+
+		fake = MagicMock()
+		fake.agent_token_max_age_days = max_age_days
+		if age_days is None:
+			fake.agent_token_issued_at = None
+		else:
+			fake.agent_token_issued_at = (
+				_dt.datetime.now() - _dt.timedelta(days=age_days)
+			)
+		fake.get_password.return_value = self.TOKEN
+		return patch("jarvis._plugin_auth.frappe.get_single", return_value=fake)
+
+	def test_expiry_disabled_when_max_age_zero(self):
+		"""Legacy escape hatch: max_age=0 = no expiry check."""
+		with self._patch_settings(max_age_days=0, age_days=1000):
+			result = self._call()
+		self.assertTrue(result["ok"], msg=result)
+
+	def test_unset_issued_at_does_not_expire_token(self):
+		"""Pre-fix token with no issued_at must NOT 401 - operator gets
+		a one-time grace window to rotate (cron warns separately)."""
+		with self._patch_settings(max_age_days=90, age_days=None):
+			result = self._call()
+		self.assertTrue(result["ok"], msg=result)
+
+	def test_within_age_window_accepted(self):
+		"""A 30-day-old token in a 90-day window is fine."""
+		with self._patch_settings(max_age_days=90, age_days=30):
+			result = self._call()
+		self.assertTrue(result["ok"], msg=result)
+
+	def test_past_max_age_rejected_with_agent_token_expired(self):
+		"""A 100-day-old token in a 90-day window is rejected. The error
+		code is distinct (``AgentTokenExpired``) so the bench's UI can
+		render a "rotate now" CTA instead of a generic 401."""
+		with self._patch_settings(max_age_days=90, age_days=100):
+			result = self._call()
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["error"]["code"], "AgentTokenExpired")
+		self.assertEqual(frappe.local.response.http_status_code, 401)
+		self.assertIn("rotate", result["error"]["message"].lower())
+
+	def test_exactly_at_max_age_rejected(self):
+		"""Boundary: age_days == max_age_days hits the >= cutoff."""
+		with self._patch_settings(max_age_days=90, age_days=90):
+			result = self._call()
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["error"]["code"], "AgentTokenExpired")


### PR DESCRIPTION
…le max age

Closes the "rotate agent_token periodically" thread from the 2026-06-16 review's C2 cluster. Per-tenant KDF derivation doesn't add meaningful security in our SaaS architecture (each customer bench already has an isolated token, no fleet-wide secret to compromise). Time-bounded tokens with auto-warn + hard-cutoff is the next-most-useful C2 hardening: cert/SSH-key-style hygiene that bounds blast radius from leaked tokens.

Mechanics:

1. Jarvis Settings gains two fields: - agent_token_issued_at (Datetime, read-only) - agent_token_max_age_days (Int, default 90) max_age=0 disables expiry (legacy escape hatch).

2. plugin_auth's validate_plugin_request now calls _agent_token_expired() after the bearer match. If age > max_age: raise PluginAuthError(401, "AgentTokenExpired", "rotate now"). Distinct code so the bench UI can render a "rotate now" CTA instead of a generic 401.

3. rotate_agent_token stamps issued_at = now in the same transaction that persists the new token. Wrapped in try/except so a pre-migration deploy state (column not yet added) doesn't 500 the rotate path - token still rotates, age check starts working after migrate.

4. New daily cron: jarvis.oauth.cron.check_agent_token_age. Wired in hooks.py daily list. Decision tree: - max_age <= 0: no-op - no issued_at: log info-level nudge to do a one-time rotate - age >= max_age: error-log + Error Log row (hard expiry NOW) - max_age - 7 <= age < max_age: warn-log (rotate in next week) - else: no-op

Backwards compatibility:

- A bench with no agent_token_max_age_days field (pre-migration JSON): the read returns 0/None -> the check is disabled -> no behavior change until migrate runs.
- A token with no issued_at (legacy): plugin_auth treats as not-expired so call_tool keeps working. The cron logs an informational nudge once per day so the operator knows to rotate once.
- After the operator does a one-time rotate, issued_at is captured and the normal age check applies going forward.

What this defends against:
- Long-tail leaked-token-replay: an agent_token captured 6 months ago in a log dump is rejected after 90 days regardless of whether the operator noticed the leak. Forces periodic key hygiene like every good TLS/SSH-key rotation policy.

What this DOES NOT defend against:
- An attacker who just leaked the current token can use it for up to max_age days. Combined with the C2 PR-1 IP allowlist, rate limit, HMAC requirement, and the PR-1 audit log this still bounds the attack surface significantly.

Tests (5 new in TestC2AgentTokenExpiry):
- max_age=0 disables expiry (legacy hatch).
- No issued_at field -> token NOT expired (avoids breaking benches that pre-date the field).
- 30-day-old token in 90-day window: accepted (within band).
- 100-day-old token in 90-day window: rejected with AgentTokenExpired, 401 status, "rotate" in message.
- Exact boundary (age == max_age): rejected (>= cutoff).

Tests use a MagicMock'd Jarvis Settings so the field doesn't have to exist physically on the test DB. Mirrors the pattern from the C2 session-binding PR (same DB-migration caveat).

Verified: 5 new tests pass. Existing 4 TestRotateAgentTokenEndpoint tests still pass (the issued_at db_set is try/except'd). Existing test_oauth_refresh_poll 7 OK (cron module unaffected by new check_agent_token_age function).

Out of scope (per-tenant KDF in commit body): per-tenant HKDF derivation from a bench master would let an operator rotate ALL container tokens at once. In our SaaS arch each customer's bench is fully isolated; there's no shared master to compromise. KDF doesn't add value here vs the existing secrets.token_hex(32) per-customer. Not pursued.