### PR TITLE
chore: customer-bench Minor batch 1 - delete three dead-code sites

### DIFF
--- a/jarvis/_http.py
+++ b/jarvis/_http.py
@@ -1,15 +1,11 @@
 """Shared HTTP helpers for Jarvis whitelisted endpoints.
 
-Provides _validate_bearer() and _raw_json_response() so that both mcp.py
-and api.py can share the same auth logic and raw-response behaviour without
-duplication.
+Provides ``validate_bearer()`` for X-Jarvis-Token header auth.
 """
 
 import hmac
-import json
 
 import frappe
-from werkzeug.wrappers import Response as WerkzeugResponse
 
 
 def validate_bearer() -> bool:
@@ -28,20 +24,3 @@ def validate_bearer() -> bool:
         return False
     # Constant-time comparison to prevent timing-oracle attacks
     return hmac.compare_digest(presented, expected)
-
-
-def raw_json_response(data: dict, status_code: int = 200) -> WerkzeugResponse:
-    """Return ``data`` as a raw JSON Werkzeug response, bypassing Frappe's wrapper.
-
-    Frappe's ``@frappe.whitelist`` normally wraps return values in
-    ``{"message": <value>}``.  The MCP SDK validates the raw JSON-RPC envelope
-    and rejects the wrapper.  Returning a werkzeug ``Response`` object directly
-    from a whitelist function causes Frappe's API handler to pass it through
-    unchanged (see ``frappe.api.handle``: ``if isinstance(data, Response): return data``).
-    """
-    resp = WerkzeugResponse(
-        response=json.dumps(data),
-        status=status_code,
-        content_type="application/json",
-    )
-    return resp

--- a/jarvis/demo.py
+++ b/jarvis/demo.py
@@ -26,7 +26,6 @@ import subprocess
 from pathlib import Path
 
 import frappe
-import frappe.utils
 
 DEFAULT_TIMEOUT = 120  # seconds for the whole exchange
 

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -35,10 +35,6 @@ class OpenclawReloadFailedError(JarvisError):
     """Raised when secrets.reload returned ok=false or timed out."""
 
 
-class OpenclawRestartFailedError(JarvisError):
-    """Raised when docker compose restart failed or the gateway didn't come back healthy."""
-
-
 class AdminUnreachableError(JarvisError):
 	"""HTTPS call to jarvis_admin failed (network, timeout, 5xx, non-JSON)."""
 


### PR DESCRIPTION
Three drop-dead items from the 2026-06-16 punch list's customer-bench section.

1. exceptions.OpenclawRestartFailedError defined, never raised/caught class shipped in jarvis/exceptions.py but no Python file in the bench imports, raises, or catches it. Repository-wide grep confirms zero refs outside the definition itself. Deleted.

2. _http.raw_json_response dead, refs deleted in mcp.py When mcp.py moved off the raw Werkzeug response pattern, the helper became orphaned. Module docstring still listed it as part of the public surface. Deleted the function + werkzeug + json imports; updated module docstring to mention only validate_bearer (the actual remaining helper).

3. demo.py unused frappe.utils import The file imports both ``frappe`` and ``frappe.utils`` but only uses ``frappe`` (no ``frappe.utils.<x>`` reference anywhere in the module body). Dropped the redundant import.

Verified: jarvis app suite 304 tests, 2 pre-existing failures on stashed-main (TestSyncConnection - unrelated to this change), 131 tests OK in the second suite.