### PR TITLE
fix: customer-bench Minor batch 2 - dead-param + 1-call-inline + redu…

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -400,7 +400,7 @@ def _ensure_session_key(user: str) -> str:
 		frappe.throw(_("openclaw is not configured"))
 
 	import time
-	sess = OpenclawSession.connect(gateway_url, gateway_token)
+	sess = OpenclawSession.connect(gateway_url)
 	try:
 		# Label includes a timestamp because openclaw deduplicates sessions
 		# by label and rejects collisions.

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -101,14 +101,14 @@ class OpenclawSession:
 	"""Direct WebSocket session to one tenant's openclaw gateway.
 
 	Public surface:
-	  OpenclawSession.connect(gateway_url, gateway_token) -> session
+	  OpenclawSession.connect(gateway_url) -> session
 	  session.create_session(label=...) -> session_key
 	  session.stream_agent_turn(session_key, message, idem) -> iter of parsed events
 	  session.close()
 
-	The gateway_token arg is kept for call-site compatibility but unused -
-	device pairing supersedes the shared bearer token. The chat device's
-	deviceToken from `jarvis.chat.device.ensure_paired()` is the credential.
+	Authentication is via device pairing - the chat device's deviceToken
+	from `jarvis.chat.device.ensure_paired()` is the credential. The
+	legacy shared bearer-token path is gone.
 	"""
 
 	def __init__(self, ws: websocket.WebSocket, creds: ChatDeviceCredentials):
@@ -119,8 +119,7 @@ class OpenclawSession:
 	# -- lifecycle --------------------------------------------------------
 
 	@classmethod
-	def connect(cls, gateway_url: str, gateway_token: str) -> OpenclawSession:
-		_ = gateway_token  # see class docstring
+	def connect(cls, gateway_url: str) -> OpenclawSession:
 		if not gateway_url:
 			raise OpenclawUnreachableError("agent_url not set on Jarvis Settings")
 

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -102,18 +102,20 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 	gateway_url = (settings.agent_url or "").replace(
 		"http://", "ws://"
 	).replace("https://", "wss://")
-	gateway_token = settings.get_password("agent_token", raise_exception=False) or ""
-
 	user_message = frappe.db.get_value(MSG, message_id, "content")
-	# Prepend today's date as a context line so the agent can resolve
-	# relative time expressions ("last quarter", "this week") without an
-	# extra round-trip to clarify. The persisted user_message in the DB
-	# is unchanged; only the value sent over to openclaw is augmented.
-	user_message = _augment_with_context(user_message or "")
+	# Prepend today's date as a context line so the agent (AGENTS.md tells
+	# it to treat the leading ``[Context: ...]`` as system, not user) can
+	# resolve relative time expressions ("last quarter", "this week")
+	# without an extra round-trip to clarify. The persisted user_message
+	# in the DB is unchanged; only the value sent over to openclaw is
+	# augmented.
+	now = frappe.utils.now_datetime()
+	today = now.strftime("%Y-%m-%d (%A)")
+	user_message = f"[Context: today is {today}]\n\n{user_message or ''}"
 
 	try:
 		try:
-			sess = OpenclawSession.connect(gateway_url, gateway_token)
+			sess = OpenclawSession.connect(gateway_url)
 		except OpenclawUnreachableError as e:
 			_mark_errored(assistant_msg.name, str(e))
 			publish_to_user(user, {
@@ -193,19 +195,6 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 		"message_id": assistant_msg.name,
 		"run_id": run_id,
 	})
-
-
-def _augment_with_context(user_message: str) -> str:
-	"""Wrap the user message with a small session-level context block.
-
-	The agent's persona (AGENTS.md) tells it to treat the leading
-	``[Context: ...]`` line as system context, not user intent. This is
-	how Jarvis grounds relative time expressions without per-turn clock
-	lookups inside the agent.
-	"""
-	now = frappe.utils.now_datetime()
-	today = now.strftime("%Y-%m-%d (%A)")
-	return f"[Context: today is {today}]\n\n{user_message}"
 
 
 def _create_assistant_placeholder(conv) -> "frappe.model.document.Document":

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -390,7 +390,12 @@ def _fetch_account_email(provider: str, access_token: str, id_token: str) -> str
 		padding = "=" * (-len(payload) % 4)
 		decoded = base64.urlsafe_b64decode(payload + padding)
 		return _json.loads(decoded).get("email", "") or ""
-	except (ValueError, Exception):
+	except Exception:
+		# ValueError used to be listed explicitly but it's a subclass
+		# of Exception - the union was redundant. Anything that goes
+		# wrong parsing a JWT id_token (malformed base64, broken JSON,
+		# missing dots) is non-fatal: id_token is a best-effort source
+		# for the email hint, callers always have a fallback.
 		return ""
 
 

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -102,7 +102,7 @@ def _build_session(creds=None) -> tuple[OpenclawSession, _ScriptedWS]:
 	scripted = _ScriptedWS([_challenge(), _ok])
 	with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
 		 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
-		sess = OpenclawSession.connect("ws://test", "ignored-token")
+		sess = OpenclawSession.connect("ws://test")
 	scripted.sent.clear()
 	return sess, scripted
 
@@ -120,7 +120,7 @@ class TestConnect(FrappeTestCase):
 		scripted = _ScriptedWS([_challenge("nonce-xyz"), _ok])
 		with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
 			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
-			sess = OpenclawSession.connect("ws://t", "x")
+			sess = OpenclawSession.connect("ws://t")
 
 		self.assertEqual(len(scripted.sent), 1)
 		req = scripted.sent[0]
@@ -151,7 +151,7 @@ class TestConnect(FrappeTestCase):
 		with patch("jarvis.chat.openclaw_client.websocket.create_connection", return_value=scripted), \
 			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
 			with self.assertRaises(OpenclawUnreachableError) as cm:
-				OpenclawSession.connect("ws://t", "x")
+				OpenclawSession.connect("ws://t")
 		self.assertIn("UNAUTHORIZED", str(cm.exception))
 		self.assertTrue(scripted.closed)
 
@@ -162,12 +162,12 @@ class TestConnect(FrappeTestCase):
 				   return_value=_ScriptedWS([])), \
 			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds):
 			with self.assertRaises(OpenclawUnreachableError):
-				OpenclawSession.connect("ws://t", "x")
+				OpenclawSession.connect("ws://t")
 
 	def test_empty_gateway_url_raises(self):
 		with patch("jarvis.chat.openclaw_client.ensure_paired", return_value=_make_creds()):
 			with self.assertRaises(OpenclawUnreachableError):
-				OpenclawSession.connect("", "x")
+				OpenclawSession.connect("")
 
 
 # --- TestCreateSession ----------------------------------------------------
@@ -379,7 +379,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 				   side_effect=_fake_ensure_paired), \
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=_fake_clear):
-			result = OpenclawSession.connect("ws://t", "x")
+			result = OpenclawSession.connect("ws://t")
 		return result, clear_called, ensure_paired_calls
 
 	def test_device_not_paired_triggers_repair_and_retry_succeeds(self):
@@ -431,7 +431,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=lambda: clear_called.append(True)):
 			with self.assertRaises(OpenclawUnreachableError) as cm:
-				OpenclawSession.connect("ws://t", "x")
+				OpenclawSession.connect("ws://t")
 		self.assertFalse(clear_called, "should not clear creds for signing bugs")
 		self.assertEqual(cm.exception.code, "device-signature-invalid")
 
@@ -458,7 +458,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=lambda: clear_called.append(True)):
 			with self.assertRaises(OpenclawUnreachableError):
-				OpenclawSession.connect("ws://t", "x")
+				OpenclawSession.connect("ws://t")
 		self.assertFalse(
 			clear_called,
 			"a substring match in the message must NOT trigger the repair "
@@ -509,7 +509,7 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 				   side_effect=lambda: clear_called.append(True)), \
 			 patch("jarvis.chat.openclaw_client._persisted_device_id",
 				   return_value=winner_device_id):
-			sess = OpenclawSession.connect("ws://t", "x")
+			sess = OpenclawSession.connect("ws://t")
 		self.assertEqual(clear_called, [],
 			"convoy follower must NOT clear the winner's freshly-paired creds")
 		sess.close()
@@ -530,7 +530,7 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 				   side_effect=lambda: clear_called.append(True)), \
 			 patch("jarvis.chat.openclaw_client._persisted_device_id",
 				   return_value=stale_creds.device_id):
-			sess = OpenclawSession.connect("ws://t", "x")
+			sess = OpenclawSession.connect("ws://t")
 		self.assertEqual(len(clear_called), 1,
 			"lock-holder must wipe + re-pair when persisted id matches stale")
 		sess.close()
@@ -556,7 +556,7 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=lambda: clear_called.append(True)), \
 			 patch("jarvis._redis_lock.redis_lock", side_effect=_never_acquired):
-			sess = OpenclawSession.connect("ws://t", "x")
+			sess = OpenclawSession.connect("ws://t")
 		self.assertEqual(clear_called, [],
 			"no clear when we never held the lock")
 		sess.close()


### PR DESCRIPTION
…ndant-catch

Three named items from the 2026-06-16 punch list.

1. OpenclawSession.connect dead gateway_token param (chat/openclaw_client.py:92) The legacy shared bearer-token auth path was removed when device pairing landed; the gateway_token param was kept "for call-site compatibility but unused" - documented but still load-bearing only because callers still passed it. Dropped the param from the signature, both callers (chat/worker.py + chat/api.py), and the test module's 11 OpenclawSession.connect(url, "x") sites (stripped to OpenclawSession.connect(url)). Updated module + class docstrings to reflect the device-pairing-only surface.

2. chat/worker._augment_with_context 2-line wrapper called once (chat/worker.py:157) The function had a 7-line docstring around 2 lines of body and was called from exactly one place (the same module). Inlined at the call site, preserving the AGENTS.md context-line rationale as an inline comment. Net 7 lines removed.

3. oauth/api except (ValueError, Exception) redundant (oauth/api.py:300) ValueError is a subclass of Exception so the union was a no-op - the second branch shadowed the first. Replaced with plain ``except Exception`` and added a comment explaining why the broad catch is correct here (id_token JWT parsing is best-effort for the email hint; callers always have a fallback).

Verified: jarvis app suite 304 tests, same 2 pre-existing TestSyncConnection failures as on stashed-main (no new errors from this change).