### PR TITLE
fix: customer-bench Minor batch 3 - subscription-model canonical + on…

### DIFF
--- a/jarvis/_subscription_models.py
+++ b/jarvis/_subscription_models.py
@@ -1,0 +1,39 @@
+"""Canonical subscription-tier model catalogue.
+
+Two modules used to declare this independently (chat/api.py as
+dicts of lists, oauth/api.py as dicts of sets) and the resulting
+list-vs-set drift was a punch-list item from the 2026-06-16
+review. Centralizing here means one declaration, no drift.
+
+Each entry maps a customer-facing provider label to the list of
+model ids accepted by that provider's codex / gemini-cli auth
+tunnel. Note: these are CLI-specific names (NOT OpenAI's public
+API names like "gpt-4o"); see customer-app/chat-subscription-
+onboarding.md "Why these model names look weird" for the
+rationale.
+
+Mirrors in JS: jarvis_chat.js / jarvis_account.js /
+jarvis_onboarding.js. Keep all three JS files in sync with this
+Python catalogue. The fleet-agent's
+verify-openclaw-assumptions.sh asserts at image-bump time that
+the openclaw catalog still contains "gpt-5.5"; update the JS
+mirrors atomically with this list and re-run that script
+before bumping the image pin.
+
+Lists (not sets) so the dict is JSON-serializable when
+chat/api.py returns it to the browser. The ``in`` membership
+checks oauth/api.py needs are O(N) on a 3-item list rather
+than O(1) on a set, but N=3 makes the perf difference
+meaningless.
+"""
+from __future__ import annotations
+
+SUBSCRIPTION_MODELS: dict[str, list[str]] = {
+	"OpenAI": ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
+	"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
+}
+
+DEFAULT_MODEL: dict[str, str] = {
+	"OpenAI": "gpt-5.5",
+	"Google Gemini": "gemini-2.0-pro",
+}

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -49,14 +49,12 @@ def _get_build_id() -> str:
 	return value
 
 # Subscription-tier model IDs accepted by codex / gemini-cli's auth tunnel.
-# These are CLI-specific names (NOT OpenAI's API names like "gpt-4o").
-# Mirrors SUBSCRIPTION_MODELS in jarvis_chat.js / jarvis_account.js / jarvis_onboarding.js.
-# Keep all three in sync; see customer-app/chat-subscription-onboarding.md
-# "Why these model names look weird" for why.
-_SUBSCRIPTION_MODELS = {
-	"OpenAI":        ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
-	"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
-}
+# Catalogue lives in jarvis/_subscription_models.py (shared with oauth/api.py
+# - the two used to declare it independently, see 2026-06-16 punch-list).
+# Mirrors SUBSCRIPTION_MODELS in jarvis_chat.js / jarvis_account.js /
+# jarvis_onboarding.js; keep all three JS files in sync with the Python
+# catalogue.
+from jarvis._subscription_models import SUBSCRIPTION_MODELS as _SUBSCRIPTION_MODELS
 
 
 @frappe.whitelist()

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -65,34 +65,28 @@ _NONCE_TTL_SECS = 600
 _HTTP_TIMEOUT = 30
 _REDIRECT_URI = "http://localhost:1455/auth/callback"
 # Codex/gemini-cli's CLI-specific model IDs (not OpenAI/Google's standard
-# API model names). Mirrors the SUBSCRIPTION_MODELS dict in
-# jarvis_onboarding.js / jarvis_account.js - keep both in sync. Customer-
-# supplied models outside this set get coerced to _DEFAULT_MODEL before
-# being cached: sending a standard-API model (e.g. "gpt-4o") through the
-# codex auth tunnel makes openclaw's codex extension fail every chat turn
-# with ProviderAuthError: "No API key found for provider openai" (it
-# treats model-mismatch as auth failure, not as a clearer model error).
-# Live-confirmed 2026-06-11 on jarvis-pool-05b704.
+# API model names). Catalogue lives in jarvis/_subscription_models.py and
+# is imported here so the chat-tier and oauth-tier validators agree on
+# the same set of accepted models (previously this module declared sets
+# and chat/api.py declared lists - 2026-06-16 punch-list drift item).
 #
-# Catalog sync: these values must match openclaw 2026.6.4's bundled
-# codex catalog (the version pinned by jarvis_admin.host_setup.
+# Catalog sync constraints: these values must match openclaw 2026.6.4's
+# bundled codex catalog (the version pinned by jarvis_admin.host_setup.
 # DEFAULT_OPENCLAW_IMAGE). The script at
 # jarvis-fleet-agent/scripts/verify-openclaw-assumptions.sh asserts at
 # image-bump time that the catalog still contains "gpt-5.5"; if it ever
-# fails because the catalog drifted, update this set + the JS mirrors
-# atomically and re-run the script before bumping the image pin.
-_SUBSCRIPTION_MODELS = {
-	"OpenAI": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini"},
-	"Google Gemini": {"gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"},
-}
-_DEFAULT_MODEL = {"OpenAI": "gpt-5.5", "Google Gemini": "gemini-2.0-pro"}
+# fails because the catalog drifted, update jarvis/_subscription_models.py
+# + the JS mirrors atomically and re-run the script before bumping the
+# image pin.
+from jarvis._subscription_models import DEFAULT_MODEL as _DEFAULT_MODEL
+from jarvis._subscription_models import SUBSCRIPTION_MODELS as _SUBSCRIPTION_MODELS
 
 
 def _coerce_subscription_model(provider: str, model: str) -> str:
 	"""Return ``model`` if valid for ``provider``'s subscription mode,
 	else fall back to ``_DEFAULT_MODEL[provider]``. Empty string for an
 	unknown provider (begin_paste_signin already rejects those upstream)."""
-	valid = _SUBSCRIPTION_MODELS.get(provider, set())
+	valid = _SUBSCRIPTION_MODELS.get(provider, [])
 	if model and model in valid:
 		return model
 	return _DEFAULT_MODEL.get(provider, "")

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -189,10 +189,18 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 		s.flags.force_admin_sync = True
 	s.save(ignore_permissions=True)
 	frappe.db.commit()
-	s = frappe.get_single("Jarvis Settings")
+	# on_update writes last_sync_* via frappe.db.set_value so the
+	# in-memory ``s`` doc is stale. Fetch JUST the two fields we
+	# need rather than reloading the entire Singles doc (the previous
+	# shape was ``frappe.get_single(...)`` then ``.get(...)`` on
+	# every field - pointless re-fetch from the 2026-06-16 review).
+	row = frappe.db.get_value(
+		"Jarvis Settings", "Jarvis Settings",
+		["last_sync_at", "last_sync_status"], as_dict=True,
+	) or {}
 	return {
-		"last_sync_at": str(s.get("last_sync_at") or ""),
-		"last_sync_status": s.get("last_sync_status") or "",
+		"last_sync_at": str(row.get("last_sync_at") or ""),
+		"last_sync_status": row.get("last_sync_status") or "",
 	}
 
 


### PR DESCRIPTION
…boarding refetch

Two named items from the 2026-06-16 punch list.

1. Subscription allowlist drifts list vs set (chat/api.py:56) chat/api.py declared the catalogue as ``{provider: list[str]}`` (so it could be JSON-serialised when returned to the browser at the ``subscription_models`` boot key) while oauth/api.py declared it as ``{provider: set[str]}`` (for O(1) membership checks). Same provider keys, same model values, two representations - the kind of drift that costs you the next time a new model needs adding.

   Now: canonical catalogue lives in jarvis/_subscription_models.py as lists (JSON-serialisable, and ``in`` on a 3-item list is indistinguishable from set on real data). Both callers import from there. Adding / removing a model is now one edit.

   Also pulled the ``DEFAULT_MODEL`` mapping into the same module since it has the same per-provider key set.

2. Pointless re-fetch after save in save_llm_creds (onboarding.py:131) ``s.save() + frappe.db.commit() + frappe.get_single(...)`` was reloading the full Jarvis Settings Singles doc just to read two fields (``last_sync_at`` + ``last_sync_status``) that on_update writes via ``frappe.db.set_value``. Replaced the get_single with a focused ``frappe.db.get_value(..., ["last_sync_at", "last_sync_status"], as_dict=True)``. The full doc reload decrypted ``llm_api_key`` via Frappe's secret-field path every time - wasted work in a function that doesn't read the secret.

Verified: jarvis app suite 304 tests, same 2 pre-existing TestSyncConnection failures as on stashed-main. No new errors.