### PR TITLE
fix: customer-bench Minor batch 7 - envelope helpers shared + orphan …

### DIFF
--- a/jarvis/_responses.py
+++ b/jarvis/_responses.py
@@ -1,0 +1,37 @@
+"""Customer-facing envelope helpers.
+
+The bench's whitelisted endpoints all return one of two shapes:
+
+  success:  {"ok": True, "data": {...}}
+  failure:  {"ok": False, "error": {"code": <str>, "message": <str>}}
+
+This used to be open-coded in three places (oauth/api.py had ``_ok``
++ ``_err``, jarvis/api.py had ``_error`` + inline ``{"ok": True,
+"data": ...}``, plus a handful of inline literals across the
+module). The 2026-06-16 review's "two-helper boilerplate" item asked
+for one source of truth so the shape can't drift across endpoints.
+
+Lives at jarvis/_responses.py rather than a per-subpackage file
+because customer endpoints span multiple subpackages (api,
+oauth.api, onboarding, etc.) and a leading underscore signals
+"internal helper".
+
+Module-local helpers that wrap these (e.g. ``_surface`` in
+onboarding.py adding sync-status fields) are fine - they layer on
+top of the canonical shape rather than diverging from it.
+"""
+from __future__ import annotations
+
+
+def ok(data: dict | list | None) -> dict:
+	"""Success envelope. ``data`` is the typed payload; pass {} for
+	"action completed, nothing to report"."""
+	return {"ok": True, "data": data}
+
+
+def err(code: str, message: str) -> dict:
+	"""Failure envelope. ``code`` is the stable identifier the bench
+	client maps onto a Python exception (FleetError, InvalidArgument,
+	NoRunningTenant, etc.). ``message`` is short user-safe text - NEVER
+	include traceback content or secrets (token bytes, paths)."""
+	return {"ok": False, "error": {"code": code, "message": message}}

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -248,8 +248,12 @@ def _dispatch_safe(tool: str, args: dict) -> dict:
 	return {"ok": True, "data": data}
 
 
-def _error(code: str, message: str) -> dict:
-	return {"ok": False, "error": {"code": code, "message": message}}
+# _error lives in jarvis/_responses.py - single source of truth for the
+# customer-facing envelope shape, shared with jarvis/oauth/api.py. The
+# success envelope (returned inline at lines like
+# ``{"ok": True, "data": data}``) is the matching ``ok()`` there if a
+# caller wants it explicitly.
+from jarvis._responses import err as _error  # noqa: E402
 
 
 def _get_header(name: str) -> str:

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -291,7 +291,24 @@ def _handle_event(
 		elif phase == "end":
 			name = tool_msg_by_call_id.get(tool_call_id)
 			if not name:
-				return  # shouldn't happen, but ignore orphaned end events
+				# Orphan: openclaw emitted a tool 'end' event for a
+				# tool_call_id we never logged a 'start' for. Shouldn't
+				# happen, but the previous shape silently returned and
+				# left no operator trace - so a real recurring orphan
+				# (would point at an openclaw event-ordering regression)
+				# would be invisible. Log it as a warning so it shows
+				# up in Error Log triage.
+				frappe.log_error(
+					title="chat worker: orphan tool 'end' event",
+					message=(
+						f"conversation_id={conversation_id!r} "
+						f"run_id={run_id!r} "
+						f"tool_call_id={tool_call_id!r} "
+						f"tool_name={tool_name!r} "
+						f"event_status={event.get('status')!r}"
+					),
+				)
+				return
 			frappe.db.set_value(MSG, name, {
 				"tool_status": event.get("status") or "completed",
 				"streaming": 0,

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -92,12 +92,11 @@ def _coerce_subscription_model(provider: str, model: str) -> str:
 	return _DEFAULT_MODEL.get(provider, "")
 
 
-def _ok(data: dict) -> dict:
-	return {"ok": True, "data": data}
-
-
-def _err(code: str, message: str) -> dict:
-	return {"ok": False, "error": {"code": code, "message": message}}
+# _ok / _err live in jarvis/_responses.py - single source of truth for the
+# customer-facing envelope shape, shared with jarvis/api.py and any future
+# bench endpoint. Punch-list item from the 2026-06-16 review.
+from jarvis._responses import err as _err
+from jarvis._responses import ok as _ok
 
 
 def _generate_pkce() -> tuple[str, str]:


### PR DESCRIPTION
…tool log

Two named items from the 2026-06-16 punch list.

1. Two-helper boilerplate _ok / _err (oauth/api.py:66) oauth/api.py defined ``_ok(data) -> {"ok": True, "data": data}`` and ``_err(code, message) -> {"ok": False, "error": {...}}`` used 26 times in that one module. jarvis/api.py had the same _error helper inline plus open-coded ``{"ok": True, "data": ...}`` returns at several sites. The envelope shape was identical but declared in two places - the drift hazard the reviewer named.

   New jarvis/_responses.py owns the canonical ``ok()`` + ``err()``. oauth/api.py imports them as ``_ok`` / ``_err`` to preserve the 26 call sites without renames; jarvis/api.py imports ``err`` as ``_error``. Shape changes (e.g. adding a request_id field) now land in one file instead of two.

   Modules with deliberately-different shapes (diagnostics.py adds a ``kind`` field for its three failure classes; dev.py's is_dev_mode_active intentionally returns the success envelope when sandbox is OFF so the form treats it as a "yes/no probe" not an auth failure) keep their inline returns - the canonical helpers are for the typical case, not a forced common form.

2. Silent drop on orphan tool 'end' events (chat/worker.py:263) The handler for ``phase=="end"`` looked up the tool_call_id in the live message map and ``return``-ed silently when the start event hadn't been logged. Comment said "shouldn't happen" but the silent drop meant a real recurring orphan - which would point at an openclaw event-ordering regression - was invisible. Now logs an Error Log entry with the conversation/run/tool context before returning so operator triage has something to grep.

Verified: jarvis app suite 304 tests, same 2 pre-existing TestSyncConnection failures as on stashed-main.