### PR TITLE
fix: customer-bench Minor batch 8 - openclaw_ws exc type + admin erro…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -343,30 +343,46 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			f"admin {admin_url} returned non-JSON (status {resp.status_code})"
 		)
 
-	# Frappe wraps any exception raised inside a whitelisted endpoint into an
-	# envelope with `exc_type`. We surface those before the generic 4xx/5xx
-	# branches so user-input errors (ValidationError, DuplicateEntryError,
-	# DoesNotExistError) reach the page as clean text instead of a traceback dump.
-	if isinstance(payload, dict) and payload.get("exc_type"):
-		clean = _extract_frappe_message(payload)
-		exc_type = payload.get("exc_type", "")
+	envelope = payload.get("message", payload) if isinstance(payload, dict) else payload
+
+	# Pre-extract the clean message + exc_type if Frappe wrapped a raised
+	# exception. The status-based branches below prefer this clean text
+	# over the raw envelope when available.
+	exc_type = (
+		payload.get("exc_type", "") if isinstance(payload, dict) else ""
+	)
+	clean = _extract_frappe_message(payload) if (
+		isinstance(payload, dict) and (exc_type or payload.get("_server_messages"))
+	) else ""
+
+	def _envelope_message() -> str:
+		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
+		return err.get("message") or clean or ""
+
+	# Status-based routing for the three unambiguous wire signals.
+	# The 2026-06-16 review caught that the previous shape ran the
+	# exc_type allowlist BEFORE the status check, so a 429 admin
+	# response with exc_type="RateLimitedError" (not in the allowlist)
+	# fell through to AdminUnreachableError - losing the rate-limit
+	# category entirely. 401/403/429 always win.
+	if resp.status_code in (401, 403):
+		raise AdminAuthError(_envelope_message() or f"admin returned {resp.status_code}")
+	if resp.status_code == 429:
+		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
+		raise AdminRateLimitedError(
+			err.get("message") or clean or "rate_limited",
+			retry_after_seconds=int(err.get("retry_after_seconds") or 0),
+		)
+
+	# Frappe-wrapped raised exception with no unambiguous status. Route
+	# by exc_type allowlist; default to AdminUnreachableError when the
+	# class isn't recognised.
+	if exc_type:
 		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
 			raise AdminValidationError(clean)
 		if exc_type in ("AuthenticationError", "PermissionError"):
 			raise AdminAuthError(clean)
 		raise AdminUnreachableError(f"admin {admin_url}: {clean}")
-
-	envelope = payload.get("message", payload) if isinstance(payload, dict) else payload
-
-	if resp.status_code in (401, 403):
-		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
-		raise AdminAuthError(err.get("message") or f"admin returned {resp.status_code}")
-	if resp.status_code == 429:
-		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
-		raise AdminRateLimitedError(
-			err.get("message") or "rate_limited",
-			retry_after_seconds=int(err.get("retry_after_seconds") or 0),
-		)
 	# Sprint-3 PR-8 (2026-06-16 review): a 4xx response with the
 	# structured envelope ({"ok": false, "error": {...}}) is a
 	# user-input / business-rule error, NOT an "admin is unreachable"

--- a/jarvis/openclaw_ws.py
+++ b/jarvis/openclaw_ws.py
@@ -18,7 +18,7 @@ import uuid
 import websocket
 from websocket import create_connection
 
-from jarvis.exceptions import OpenclawReloadFailedError, OpenclawUnreachableError
+from jarvis.exceptions import OpenclawUnreachableError
 
 
 PING_TIMEOUT_SECONDS = 10
@@ -75,11 +75,19 @@ def ping(gateway_url: str, gateway_token: str) -> None:
 
 def _await_response(ws, request_id: str, deadline: float) -> dict:
 	"""Read frames until a `res` frame with matching id arrives. Other
-	frames (events, challenges) are skipped."""
+	frames (events, challenges) are skipped.
+
+	Timeout here surfaces as ``OpenclawUnreachableError`` - the module
+	docstring is explicit that this is a connect-only ping (no
+	secrets.reload, no restart), so the previous
+	``OpenclawReloadFailedError`` was the wrong category and confused
+	the diagnostics UI's branching on the exception type. Punch-list
+	item from the 2026-06-16 review.
+	"""
 	while True:
 		remaining = deadline - time.monotonic()
 		if remaining <= 0:
-			raise OpenclawReloadFailedError("timeout waiting for response")
+			raise OpenclawUnreachableError("timeout waiting for response")
 		ws.settimeout(remaining)
 		raw = ws.recv()
 		if not raw:


### PR DESCRIPTION
…r routing

Two named items from the 2026-06-16 punch list.

1. openclaw_ws._await_response raises ReloadFailed from connect-only ping (openclaw_ws.py:82) The module docstring is explicit: "Single use: the Test Agent Connection diagnostic button... opens a WS, completes the connect handshake, and closes. No secrets.reload, no restart."

   But on response timeout it raised OpenclawReloadFailedError - the wrong category given there's no reload here at all. The diagnostics UI branches on the exception type to render contextual hints ("agent unreachable - check tenant up") so the wrong class produced a misleading error message.

   Changed to OpenclawUnreachableError (matches the other ws-error sites in this module). Dropped the now-unused OpenclawReloadFailedError import.

2. admin_client error mapping loses RateLimited / validation categories (admin_client.py:321) The previous shape ran the exc_type allowlist BEFORE the HTTP status check, so:
     - 429 admin response with exc_type="RateLimitedError" (not in the allowlist) fell through to AdminUnreachableError, losing the rate-limit category entirely. - A 403 with exc_type="PermissionError" would have routed correctly via the exc_type branch, but only because it ran first - if exc_type were ever absent, the status-403 branch had no clean-message fallback.

   Restructured to:
   1. Pre-extract clean message + exc_type from the payload.
   2. Run status-based routing FIRST (401/403 -> auth, 429 -> rate), using the clean message as the body text.
   3. Then run the exc_type allowlist as a fallback for non- unambiguous statuses.

   Verified by running the existing test_frappe_permission_error_
   routes_to_auth_error test (which broke briefly during the
   first-cut reorder + caught the missing clean-message fallback).

Verified: jarvis app suite 304 tests, same 2 pre-existing TestSyncConnection failures.