### PR TITLE
fix: customer-bench Minor batch 10 - onboarding UI dead-state fixes

### DIFF
--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -150,8 +150,20 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 			e.preventDefault();
 			frappe.call({ method: "jarvis.onboarding.sync_connection" }).then((r) => {
 				const m = r.message || {};
-				if (m.synced) frappe.show_alert({ message: __("Connection synced."), indicator: "green" });
-				else frappe.show_alert({ message: __("Nothing to sync yet ({0}).", [m.tenant_status || m.reason || "pending"]), indicator: "orange" });
+				if (m.synced) {
+					// Connection landed successfully - advance the wizard
+					// to the completion screen instead of leaving the
+					// customer staring at step 1 with a green toast.
+					// Punch-list item from the 2026-06-16 review: the
+					// previous shape showed "Connection synced." but
+					// left the wizard at whatever step they were on,
+					// which read as a dead state.
+					frappe.show_alert({ message: __("Connection synced."), indicator: "green" });
+					state.successData = state.successData || {};
+					go(4);
+				} else {
+					frappe.show_alert({ message: __("Nothing to sync yet ({0}).", [m.tenant_status || m.reason || "pending"]), indicator: "orange" });
+				}
 			});
 		});
 	}
@@ -664,7 +676,20 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 					args: { payload: { razorpay_payment_id: res.razorpay_payment_id, razorpay_order_id: res.razorpay_order_id, razorpay_signature: res.razorpay_signature } },
 				}).then((rr) => { state.successData = rr.message; go(4); }).catch((e) => payErr(e));
 			},
-			modal: { ondismiss: () => setBusy("#jo-pay", false) },
+			// Razorpay dismiss (customer closed Checkout without paying).
+			// Re-enable Pay AND surface why the wizard didn't advance -
+			// the previous shape just re-enabled the button silently,
+			// leaving the customer wondering if anything happened.
+			// Punch-list item from the 2026-06-16 review.
+			modal: {
+				ondismiss: () => {
+					setBusy("#jo-pay", false);
+					frappe.show_alert({
+						message: __("Payment cancelled. Click Pay to try again."),
+						indicator: "orange",
+					});
+				},
+			},
 		});
 		rz.open();
 	}


### PR DESCRIPTION
Two named items from the 2026-06-16 punch list (both in jarvis_onboarding.js).

1. Sync-connection footer link leaves dead state (jarvis_onboarding.js:149) The "Already connected? Sync your connection" footer link called sync_connection and only showed a toast on success. If the call succeeded (synced=true with a fresh agent_url), the customer was still looking at whatever wizard step they landed on - same step 1 input form, but now the bench was actually connected. Confusing as UX. Now: on synced=true, advance the wizard to the completion screen (step 4) so the UI reflects the actual server state.

2. Razorpay-dismissed footer leaves dead state (jarvis_onboarding.js:149) When the customer opened Razorpay Checkout and closed it without paying, the wizard re-enabled the Pay button via ``setBusy("#jo-pay", false)`` and went silent. No toast, no "try again" hint - the customer was left wondering whether something was happening behind the scenes. Now: surface an explanatory toast ("Payment cancelled. Click Pay to try again.") on dismiss so the silence isn't misread as the wizard being stuck.

Python suite still green (304 tests, same 2 pre-existing TestSyncConnection failures - this PR doesn't touch Python). JS-level smoke: the wizard's sync handler now resolves ``state.successData = state.successData || {}`` defensively before ``go(4)`` so the completion screen renders even when the customer arrives there via the footer link without ever having state.successData populated by signup/dev_onboard.