### PR TITLE
fix: customer-bench Minor batch 12 - drop developer_mode backwards-co…

### DIFF
--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -1,10 +1,9 @@
 """Dev-only helpers for the customer bench.
 
-Gated by sandbox mode (Jarvis Settings.sandbox_mode, with legacy
-frappe.conf.developer_mode as a one-release backwards-compat fallback)
-+ the System Manager role. Used by the Jarvis Settings form to wipe local
-state so the operator can run the onboarding wizard fresh without manual
-DB surgery.
+Gated by sandbox mode (Jarvis Settings.sandbox_mode) + the System
+Manager role. Used by the Jarvis Settings form to wipe local state so
+the operator can run the onboarding wizard fresh without manual DB
+surgery.
 
 Companion to ``jarvis_admin.api.dev.purge_customer`` on the admin side -
 the admin button wipes admin-side records; this clears the customer bench.
@@ -29,28 +28,25 @@ _PASSWORD_FIELDS = {
 
 
 def is_sandbox_mode() -> bool:
-	"""Return True iff this site is in sandbox mode.
+	"""Return True iff ``Jarvis Settings.sandbox_mode`` is enabled.
 
-	Resolution:
-	  1. ``Jarvis Settings.sandbox_mode = 1`` (the canonical flag)
-	  2. legacy fallback: ``frappe.conf.developer_mode`` is truthy
-	     (kept for one release so existing dev installs don't break;
-	     remove this branch in the release after this one)
+	Opens the dev surface (dev_onboard, reset_onboarding, the DEV-only
+	reset button in Jarvis Settings). Customer responsibility: flip this
+	only on dev/test benches. The trust model is self-attested - this is
+	a UX improvement (discoverable in the settings form, doesn't bleed
+	across apps, doesn't require a bench restart), not a security
+	hardening.
 
-	Either condition opens the dev surface (dev_onboard, reset_onboarding,
-	the DEV-only reset button in Jarvis Settings). Customer responsibility:
-	flip this only on dev/test benches. The trust model is self-attested -
-	same as the legacy developer_mode behavior - so this is not a security
-	hardening, just a UX improvement (discoverable in the settings form,
-	doesn't bleed across apps, doesn't require a bench restart)."""
+	The legacy ``frappe.conf.developer_mode`` fallback was dropped in
+	this batch (2026-06-16 punch-list "scheduled for removal" item).
+	Operators on benches that previously relied on developer_mode in
+	site_config need to flip ``Jarvis Settings -> Enable Sandbox Mode``
+	once after migration."""
 	try:
-		if frappe.get_single_value(SETTINGS, "sandbox_mode"):
-			return True
+		return bool(frappe.get_single_value(SETTINGS, "sandbox_mode"))
 	except Exception:
-		# DocType may not be migrated yet on a fresh install; fall through
-		# to the legacy check rather than crashing.
-		pass
-	return bool(frappe.conf.get("developer_mode"))
+		# DocType may not be migrated yet on a fresh install.
+		return False
 
 
 def _dev_guard():
@@ -61,7 +57,7 @@ def _dev_guard():
 		frappe.local.response.http_status_code = 403
 		frappe.throw(
 			"Sandbox mode is not enabled. Set Jarvis Settings -> "
-			"Enable Sandbox Mode (or, legacy: developer_mode in site_config)."
+			"Enable Sandbox Mode."
 		)
 	if "System Manager" not in frappe.get_roles():
 		frappe.local.response.http_status_code = 403

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -47,14 +47,17 @@ def _seed_onboarded_state():
 
 
 class _GuardSwap:
-	"""Force developer_mode on for the duration of a test."""
+	"""Force sandbox_mode on for the duration of a test."""
 	def __enter__(self):
-		self._prior = frappe.conf.get("developer_mode") or 0
-		frappe.conf.developer_mode = 1
+		s = frappe.get_single("Jarvis Settings")
+		self._prior = s.get("sandbox_mode") or 0
+		s.db_set("sandbox_mode", 1)
+		frappe.db.commit()
 		return self
 
 	def __exit__(self, *exc):
-		frappe.conf.developer_mode = self._prior
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", self._prior)
+		frappe.db.commit()
 
 
 class TestResetOnboarding(FrappeTestCase):
@@ -92,27 +95,24 @@ class TestResetOnboarding(FrappeTestCase):
 class TestResetOnboardingGuards(FrappeTestCase):
 	def setUp(self):
 		self._snap = _snapshot()
-		self._prior_dev_mode = frappe.conf.get("developer_mode") or 0
+		self._prior_sandbox = frappe.get_single("Jarvis Settings").get("sandbox_mode") or 0
 
 	def tearDown(self):
-		frappe.conf.developer_mode = self._prior_dev_mode
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", self._prior_sandbox)
+		frappe.db.commit()
 		_restore(self._snap)
 
 	def test_rejects_when_sandbox_mode_off(self):
-		frappe.conf.developer_mode = 0
-		# Make sure Jarvis Settings.sandbox_mode is also off (the doctype
-		# field is the new canonical source; conf.developer_mode is the
-		# one-release legacy fallback).
 		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
 		frappe.db.commit()
 		with self.assertRaises(frappe.ValidationError) as cm:
 			reset_onboarding()
 		self.assertEqual(frappe.local.response.http_status_code, 403)
-		# Error message references the new flag name + the legacy fallback.
 		self.assertIn("sandbox", str(cm.exception).lower())
 
 	def test_rejects_when_non_system_manager(self):
-		frappe.conf.developer_mode = 1
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
+		frappe.db.commit()
 		# Use a Guest who lacks System Manager role.
 		frappe.set_user("Guest")
 		self.addCleanup(frappe.set_user, "Administrator")
@@ -124,21 +124,20 @@ class TestResetOnboardingGuards(FrappeTestCase):
 
 class TestIsDevModeActive(FrappeTestCase):
 	def setUp(self):
-		self._prior = frappe.conf.get("developer_mode") or 0
+		self._prior = frappe.get_single("Jarvis Settings").get("sandbox_mode") or 0
 
 	def tearDown(self):
-		frappe.conf.developer_mode = self._prior
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", self._prior)
+		frappe.db.commit()
 
-	def test_true_when_developer_mode_on(self):
-		frappe.conf.developer_mode = 1
+	def test_true_when_sandbox_mode_on(self):
+		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
+		frappe.db.commit()
 		out = is_dev_mode_active()
 		self.assertEqual(out["data"]["active"], True)
 		self.assertEqual(frappe.local.response.http_status_code, 200)
 
-	def test_false_when_developer_mode_off(self):
-		frappe.conf.developer_mode = 0
-		# Belt-and-suspenders: also make sure Jarvis Settings.sandbox_mode
-		# is off; otherwise it would also flip is_dev_mode_active to True.
+	def test_false_when_sandbox_mode_off(self):
 		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
 		frappe.db.commit()
 		out = is_dev_mode_active()
@@ -147,43 +146,26 @@ class TestIsDevModeActive(FrappeTestCase):
 
 
 class TestIsSandboxMode(FrappeTestCase):
-	"""is_sandbox_mode resolution: Jarvis Settings.sandbox_mode wins, then
-	the legacy frappe.conf.developer_mode fallback (one release only)."""
+	"""is_sandbox_mode resolves from Jarvis Settings.sandbox_mode only.
+
+	The legacy frappe.conf.developer_mode fallback was dropped in
+	customer-bench Minor batch 12. Operators on benches that previously
+	relied on developer_mode in site_config need to flip the Jarvis
+	Settings field once after migration."""
 
 	def setUp(self):
-		self._prior_dev_mode = frappe.conf.get("developer_mode") or 0
 		self._prior_sandbox = frappe.get_single("Jarvis Settings").get("sandbox_mode") or 0
 
 	def tearDown(self):
-		frappe.conf.developer_mode = self._prior_dev_mode
 		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", self._prior_sandbox)
 		frappe.db.commit()
 
 	def test_true_when_sandbox_field_set(self):
-		frappe.conf.developer_mode = 0
 		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
 		frappe.db.commit()
 		self.assertTrue(is_sandbox_mode())
 
-	def test_true_when_only_legacy_developer_mode_set(self):
-		# Backwards-compat fallback: existing dev installs that have
-		# developer_mode in site_config but never migrated their
-		# Jarvis Settings to the new flag still get the dev surface.
-		frappe.conf.developer_mode = 1
-		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
-		frappe.db.commit()
-		self.assertTrue(is_sandbox_mode())
-
-	def test_false_when_both_off(self):
-		frappe.conf.developer_mode = 0
+	def test_false_when_sandbox_field_off(self):
 		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 0)
 		frappe.db.commit()
 		self.assertFalse(is_sandbox_mode())
-
-	def test_sandbox_field_wins_over_legacy_off(self):
-		# The new flag is the canonical source - legacy off + new on
-		# should still report sandbox active.
-		frappe.conf.developer_mode = 0
-		frappe.get_single("Jarvis Settings").db_set("sandbox_mode", 1)
-		frappe.db.commit()
-		self.assertTrue(is_sandbox_mode())

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -79,6 +79,7 @@ class TestSyncConnection(FrappeTestCase):
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings",
 							"jarvis_admin_url", "http://admin.example.com")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", 1)
 		frappe.db.commit()
 		with patch("jarvis.onboarding.admin_client.dev_signup",
 				   return_value={"customer": "C1", "api_key": "k2", "api_secret": "s2",
@@ -111,6 +112,7 @@ class TestSyncConnection(FrappeTestCase):
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings",
 							"jarvis_admin_url", "http://other-admin.local")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", 1)
 		frappe.db.commit()
 		try:
 			with patch("jarvis.onboarding.admin_client.dev_signup",


### PR DESCRIPTION
…mpat fallback

Named item: developer_mode backwards-compat fallback scheduled for removal (dev.py:53).

The previous shape resolved sandbox via:
  1. Jarvis Settings.sandbox_mode field (canonical)
  2. frappe.conf.get("developer_mode") fallback (legacy)

Removed branch 2. The legacy fallback was added when sandbox_mode was introduced "one release ago" - the comment said "remove this branch in the release after this one" and we're now at v0.14.x, well past that line. Operators who previously relied on developer_mode in site_config flip Jarvis Settings -> Enable Sandbox Mode once after migration; the bench restart isn't required (it's a Singles field read, not a conf import).

dev.py changes:
- is_sandbox_mode: collapsed to a single get_single_value read. Migration-not-yet-run case still returns False rather than crashing.
- _dev_guard error message: dropped the "(or, legacy: developer_mode in site_config)" hint - operators only see the canonical path.
- Module + function docstrings: dropped the "one-release fallback" caveats.

Test updates (no behaviour change in tests, just adjusting fixtures to the new contract):
- _GuardSwap: now sets sandbox_mode=1 directly on Jarvis Settings instead of flipping frappe.conf.developer_mode.
- TestResetOnboardingGuards: same swap pattern; non-System-Manager test now seeds sandbox_mode=1 before flipping to Guest.
- TestIsDevModeActive / TestIsSandboxMode: renamed tests to reflect the sandbox_mode-only resolution, dropped the test_true_when_only_legacy_developer_mode_set / test_sandbox_ field_wins_over_legacy_off cases that pinned the old two-source behaviour.
- test_onboarding_sync.py: two TestSyncConnection tests that exercised dev_onboard's success path now set sandbox_mode=1 alongside jarvis_admin_url.

Verified: 302 OK + 131 OK. Full green baseline maintained from batch 11.