### PR TITLE
fix: customer-bench Minor batch 16 - chat-device key rotation endpoint

### DIFF
--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -105,7 +105,20 @@ def ensure_paired() -> ChatDeviceCredentials:
 	existing = _read_credentials()
 	if existing is not None:
 		return existing
+	return _generate_and_pair()
 
+
+def _generate_and_pair() -> ChatDeviceCredentials:
+	"""Generate a fresh Ed25519 keypair, register it with admin (which
+	relays to the customer's openclaw container as a PairedDevice
+	record), and persist the resulting credentials.
+
+	Shared between ensure_paired (cold-start path) and
+	rotate_chat_device (operator-triggered rotation path). The two
+	previously share-and-fork happened inline; pulling it out lets
+	rotation reuse the validation + error surface without
+	duplicating the keypair generation logic.
+	"""
 	priv, _pub_raw, pub_b64u, device_id = _generate_keypair()
 	priv_b64u = _b64u(priv.private_bytes(
 		encoding=serialization.Encoding.Raw,
@@ -134,6 +147,42 @@ def ensure_paired() -> ChatDeviceCredentials:
 		device_id=device_id, public_key=pub_b64u,
 		private_key=priv, device_token=device_token,
 	)
+
+
+@frappe.whitelist(methods=["POST"])
+def rotate_chat_device() -> dict:
+	"""Force a fresh Ed25519 keypair + re-pair, overwriting any existing
+	chat-device credentials in Jarvis Settings.
+
+	System Manager only. Operators run this:
+	  - After a suspected leak of the private key (the Password field
+	    is encrypted at rest but operators with site DB access could
+	    read __Auth).
+	  - As routine hygiene on a schedule (annual rotation).
+	  - To recover from a corrupted PairedDevice record on the
+	    container side - admin's pair leg invalidates the previous
+	    PairedDevice for this device_id.
+
+	Atomicity: a new keypair is generated and admin-paired BEFORE the
+	old credentials are overwritten. If admin's pair_chat_device
+	fails (network, validation, rate-limit), the old credentials stay
+	intact so chat keeps working on the previous pairing. The new
+	credentials only land in Jarvis Settings on a successful
+	round-trip.
+
+	Returns ``{"ok": true, "data": {"device_id": "<new>"}}`` on
+	success; raises (translated to the {ok: false, error: {...}}
+	envelope at the @frappe.whitelist boundary) on any failure.
+
+	Punch-list item from the 2026-06-16 review: chat-device Ed25519
+	private key had no rotation surface.
+	"""
+	frappe.only_for("System Manager")
+	creds = _generate_and_pair()
+	frappe.logger().info(
+		"chat_device.rotate: new device_id=%s", creds.device_id,
+	)
+	return {"ok": True, "data": {"device_id": creds.device_id}}
 
 
 def clear_credentials() -> None:

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -153,6 +153,59 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 		self.assertNotEqual(creds.device_id, "abc")  # fresh keypair was generated
 
 
+class TestRotateChatDevice(_SettingsSnapshotMixin, FrappeTestCase):
+	def setUp(self):
+		_clear_settings()
+
+	def test_rotate_generates_fresh_keypair_even_when_pairing_exists(self):
+		# Seed Settings with valid pre-rotation creds.
+		priv = Ed25519PrivateKey.generate()
+		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw,
+												  serialization.PublicFormat.Raw)
+		old_device_id = hashlib.sha256(pub_raw).hexdigest()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", old_device_id)
+		s.db_set("chat_device_public_key", _b64u(pub_raw))
+		s.db_set("chat_device_private_key", _b64u(priv.private_bytes(
+			serialization.Encoding.Raw, serialization.PrivateFormat.Raw,
+			serialization.NoEncryption())))
+		s.db_set("chat_device_token", "tok-old")
+		frappe.db.commit()
+
+		with patch("jarvis.chat.device.admin_client.pair_chat_device",
+				   return_value={"device_token": "tok-new"}):
+			out = chat_device.rotate_chat_device()
+
+		# Wire-shape check + new device_id is fresh + token rotated.
+		self.assertTrue(out["ok"])
+		self.assertNotEqual(out["data"]["device_id"], old_device_id)
+		s2 = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s2.chat_device_id, out["data"]["device_id"])
+		self.assertEqual(s2.get_password("chat_device_token"), "tok-new")
+
+	def test_rotate_preserves_old_creds_on_admin_failure(self):
+		# Seed old creds.
+		priv = Ed25519PrivateKey.generate()
+		pub_raw = priv.public_key().public_bytes(serialization.Encoding.Raw,
+												  serialization.PublicFormat.Raw)
+		old_device_id = hashlib.sha256(pub_raw).hexdigest()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", old_device_id)
+		s.db_set("chat_device_public_key", _b64u(pub_raw))
+		s.db_set("chat_device_token", "tok-old")
+		frappe.db.commit()
+
+		with patch("jarvis.chat.device.admin_client.pair_chat_device",
+				   side_effect=RuntimeError("admin down")):
+			with self.assertRaises(OpenclawUnreachableError):
+				chat_device.rotate_chat_device()
+
+		# Old creds intact.
+		s2 = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s2.chat_device_id, old_device_id)
+		self.assertEqual(s2.get_password("chat_device_token"), "tok-old")
+
+
 class TestSigning(FrappeTestCase):
 	def test_build_payload_v3_format(self):
 		out = chat_device.build_payload_v3(


### PR DESCRIPTION
Last named item: chat-device Ed25519 private key Password field, no rotation (chat/device.py:110).

The chat-device keypair was generated once at first chat and lived forever in Jarvis Settings.chat_device_private_key (a Password field, encrypted at rest in __Auth). Operators had no way to rotate it short of manually clearing the four chat_device_* fields and waiting for ensure_paired to re-pair on the next chat turn.

Added @frappe.whitelist rotate_chat_device endpoint:
- Generates a fresh Ed25519 keypair
- Calls admin_client.pair_chat_device to register it (admin relays the public key + new device_id to the customer's openclaw container, which invalidates the previous PairedDevice record for this device_id and stores the new one)
- Persists the new credentials on success

Atomicity: pairing happens BEFORE the old credentials are overwritten. A failure mid-rotation (admin network down, validation reject, rate limit hit) leaves the old credentials intact so chat keeps working on the previous pairing. The new credentials only land in Jarvis Settings on a successful round-trip - matching the atomicity contract C2 PR-3C established for rotate_agent_token.

Refactor: extracted _generate_and_pair from inside ensure_paired so the rotation endpoint and the cold-start path share the same generate + pair + persist sequence without duplicating the keypair generation logic.

System Manager gated; emits an INFO log line on success (chat_device.rotate: new device_id=<hex>) for operator audit.

Two new tests in TestRotateChatDevice cover:
- Rotation generates fresh keypair + new device_token even when old pairing exists (device_id is different from the seeded value).
- Old credentials stay intact when admin_client.pair_chat_device raises (atomicity contract).

Verified: 304 OK (302 baseline + 2 new) + 131 OK. Full green baseline.