### PR TITLE
fix: cross-repo batch 1 - OAuth cache hygiene + constant-time state c…

### DIFF
--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -62,6 +62,11 @@ _TOKEN_EXCHANGE_OPAQUE_CODES = {
 
 _CACHE_KEY = "jarvis.oauth.codex_signin"
 _NONCE_TTL_SECS = 600
+# Cap on how many cache fields the GC sweep visits per begin_paste_signin.
+# A misbehaving caller looping begin without complete could otherwise fill
+# the hash and make every subsequent begin pay an O(N) Redis trip. The cap
+# bounds the sweep cost; truly stale entries get cleaned next time.
+_GC_SWEEP_LIMIT = 256
 _HTTP_TIMEOUT = 30
 _REDIRECT_URI = "http://localhost:1455/auth/callback"
 # Codex/gemini-cli's CLI-specific model IDs (not OpenAI/Google's standard
@@ -108,6 +113,45 @@ def _generate_pkce() -> tuple[str, str]:
 	return verifier, challenge
 
 
+def _gc_expired_nonces() -> None:
+	"""Sweep ``_CACHE_KEY`` for entries past their ``expires_at_ts`` and drop
+	them.
+
+	The OAuth nonce cache is a Redis hash where each field is a per-flow
+	nonce. ``frappe.cache.hset`` doesn't honour per-field TTLs (Redis HSET
+	can't), so abandoned sign-ins (customer started the flow, closed the
+	tab, never pasted the URL) leave their PKCE verifier + state hanging
+	in the hash until the whole key gets wiped. Punch-list "stale PKCE
+	verifiers + unconsumed nonces never GC'd" from the 2026-06-16 review.
+
+	Called opportunistically from begin_paste_signin so the hash stays
+	bounded without a separate scheduled job. Cost is one HGETALL per
+	begin (~ms-cheap until N gets large; the sweep limit caps the
+	worst case).
+	"""
+	try:
+		entries = frappe.cache.hgetall(_CACHE_KEY) or {}
+	except Exception:
+		# Best-effort: a Redis hiccup mustn't block a fresh sign-in.
+		return
+	now_ts = int(time.time())
+	for i, (field, value) in enumerate(entries.items()):
+		if i >= _GC_SWEEP_LIMIT:
+			break
+		# hgetall on a freshly-wiped cache can return {} - any field shape
+		# that doesn't carry expires_at_ts is something we didn't write
+		# and shouldn't try to interpret.
+		try:
+			expires_at_ts = (value or {}).get("expires_at_ts")
+		except AttributeError:
+			continue
+		if not expires_at_ts or expires_at_ts < now_ts:
+			# Decode bytes-vs-str defensively - Frappe's redis hash returns
+			# bytes on some configs and str on others.
+			key = field.decode() if isinstance(field, bytes) else field
+			frappe.cache.hdel(_CACHE_KEY, key)
+
+
 @frappe.whitelist()
 def begin_paste_signin(provider: str, model: str) -> dict:
 	"""Mint a nonce + PKCE pair, return the authorize URL for the customer
@@ -123,6 +167,11 @@ def begin_paste_signin(provider: str, model: str) -> dict:
 		get_provider(provider)
 	except UnknownProviderError as e:
 		return _err("unknown_provider", str(e))
+
+	# GC abandoned sign-ins BEFORE writing the new nonce. Otherwise a
+	# user who loops begin without ever completing (e.g. wizard reload
+	# while debugging) grows the cache hash unboundedly.
+	_gc_expired_nonces()
 
 	nonce = secrets.token_hex(24)
 	verifier, challenge = _generate_pkce()
@@ -198,6 +247,10 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 	if not entry:
 		return _err("unknown_nonce", "nonce not recognized")
 	if entry["expires_at_ts"] < int(time.time()):
+		# Drop the expired field so the hash doesn't grow with dead
+		# entries waiting on the periodic GC sweep. Companion to the
+		# _gc_expired_nonces sweep on begin.
+		frappe.cache.hdel(_CACHE_KEY, nonce)
 		return _err("expired", "nonce has expired; generate a new sign-in URL")
 	if entry["status"] != "pending":
 		return _err("not_pending", f"nonce status is {entry['status']!r}")
@@ -212,7 +265,13 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 	parsed = _parse_redirected_url(redirected_url)
 	if not parsed["code"]:
 		return _err("missing_code", "no `code` parameter found in the pasted URL")
-	if parsed["state"] != entry["state"]:
+	# Constant-time compare on the state parameter. The state value is the
+	# OAuth CSRF nonce - if an attacker can observe how long the
+	# comparison takes, plain ``!=`` short-circuits on the first
+	# differing byte and leaks a prefix-recovery oracle. secrets.compare_digest
+	# runs in constant time over the longer of the two inputs.
+	# Punch-list "state comparison non-constant-time" from the 2026-06-16 review.
+	if not secrets.compare_digest(parsed["state"] or "", entry["state"] or ""):
 		return _err("state_mismatch",
 		            "the `state` parameter doesn't match; "
 		            "regenerate the sign-in URL and try again")
@@ -412,5 +471,12 @@ def disconnect() -> dict:
 	settings.db_set("last_sync_status", "disconnected", update_modified=False)
 	settings.db_set("llm_oauth_account_email", "", update_modified=False)
 	settings.db_set("llm_oauth_connected_at", None, update_modified=False)
-	frappe.cache.delete_key(_CACHE_KEY)
+	# DON'T wipe _CACHE_KEY here. The previous shape called
+	# frappe.cache.delete_key(_CACHE_KEY), which nukes every pending
+	# OAuth sign-in across the whole site - so a second System Manager
+	# mid-paste-signin would see their nonce vanish under them when a
+	# peer happened to click Disconnect. The cache holds only short-TTL
+	# (10 min) per-user-bound nonces; _gc_expired_nonces sweeps them on
+	# the next begin call. Punch-list "disconnect() wipes entire OAuth
+	# signin cache hash" from the 2026-06-16 review.
 	return _ok({})

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -48,6 +48,47 @@ class _OAuthApiBase(FrappeTestCase):
 		frappe.cache.delete_key(_CACHE_KEY)
 
 
+class TestGcExpiredNonces(_OAuthApiBase):
+	# Punch-list "stale PKCE verifiers + unconsumed nonces never GC'd"
+	# from the 2026-06-16 review. The cache stores per-nonce metadata
+	# in a Redis hash whose fields can't carry individual TTLs, so
+	# abandoned begin_paste_signin flows leave verifier+state hanging
+	# until something explicitly wipes them. Now that disconnect() no
+	# longer wipes the hash (its own punch-list fix), the GC sweep on
+	# begin is the only cleanup; pin its behaviour.
+
+	def test_begin_evicts_expired_peer_nonces(self):
+		# Seed a peer's pending nonce that's already past its TTL.
+		frappe.cache.hset(_CACHE_KEY, "expired_peer", {
+			"status": "pending",
+			"originator_user": "peer@example.com",
+			"expires_at_ts": int(time.time()) - 60,
+			"state": "old-state",
+			"verifier": "old-verifier",
+			"provider": "OpenAI",
+			"model": "gpt-5.5",
+		})
+		oauth_api.begin_paste_signin("OpenAI", "gpt-5.5")
+		# Sweep dropped the expired entry.
+		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, "expired_peer"))
+
+	def test_begin_keeps_unexpired_peer_nonces(self):
+		# Peer's nonce hasn't expired yet - sweep must not touch it.
+		frappe.cache.hset(_CACHE_KEY, "live_peer", {
+			"status": "pending",
+			"originator_user": "peer@example.com",
+			"expires_at_ts": int(time.time()) + 600,
+			"state": "live-state",
+			"verifier": "live-verifier",
+			"provider": "OpenAI",
+			"model": "gpt-5.5",
+		})
+		oauth_api.begin_paste_signin("OpenAI", "gpt-5.5")
+		survived = frappe.cache.hget(_CACHE_KEY, "live_peer")
+		self.assertIsNotNone(survived)
+		self.assertEqual(survived["originator_user"], "peer@example.com")
+
+
 class TestBeginPasteSignin(_OAuthApiBase):
 	def test_returns_nonce_authorize_url_expiry(self):
 		out = oauth_api.begin_paste_signin("OpenAI", "gpt-4o")
@@ -152,6 +193,9 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 			redirected_url="http://localhost:1455/auth/callback?code=A&state=test-state",
 		)
 		self.assertEqual(out["error"]["code"], "expired")
+		# Expired nonces get evicted on read so the hash doesn't accumulate
+		# dead PKCE verifiers waiting for the periodic GC sweep.
+		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))
 
 	def test_rejects_missing_code(self):
 		nonce = self._seed()
@@ -166,6 +210,34 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 		out = oauth_api.complete_paste_signin(
 			nonce=nonce,
 			redirected_url="http://localhost:1455/auth/callback?code=A&state=wrong",
+		)
+		self.assertEqual(out["error"]["code"], "state_mismatch")
+
+	def test_rejects_state_one_char_off_constant_time(self):
+		# Pins the constant-time compare on state. The previous shape
+		# used ``!=`` which short-circuits on the first differing byte and
+		# would leak a prefix-recovery oracle to an attacker who can
+		# measure complete_paste_signin's response time. Punch-list
+		# "state comparison non-constant-time" - this test pins the
+		# behaviour by asserting a single-char drift still rejects with
+		# the same opaque code.
+		nonce = self._seed()
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			# state seeded as "test-state"; flip last char.
+			redirected_url="http://localhost:1455/auth/callback?code=A&state=test-statf",
+		)
+		self.assertEqual(out["error"]["code"], "state_mismatch")
+
+	def test_rejects_missing_state_doesnt_crash(self):
+		# Defensive: secrets.compare_digest raises TypeError on None.
+		# Make sure the wrapper coerces both sides to "" before comparing,
+		# so a customer who pastes a code-only URL gets state_mismatch
+		# not a 500.
+		nonce = self._seed()
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="http://localhost:1455/auth/callback?code=A",
 		)
 		self.assertEqual(out["error"]["code"], "state_mismatch")
 
@@ -353,7 +425,6 @@ class TestDisconnect(_OAuthApiBase):
 		settings.db_set("llm_oauth_account_email", "x@y.com", update_modified=False)
 		settings.db_set("llm_oauth_connected_at",
 		                frappe.utils.now_datetime(), update_modified=False)
-		frappe.cache.hset(_CACHE_KEY, "leftover_nonce", {"status": "pending"})
 		frappe.db.commit()
 
 		out = oauth_api.disconnect()
@@ -364,7 +435,31 @@ class TestDisconnect(_OAuthApiBase):
 		self.assertEqual(settings.last_sync_status, "disconnected")
 		self.assertFalse(settings.llm_oauth_account_email)
 		self.assertIsNone(settings.llm_oauth_connected_at)
-		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, "leftover_nonce"))
+
+	@patch("jarvis.oauth.api.admin_client.post_subscription_disconnect")
+	def test_disconnect_preserves_peers_pending_signins(self, _):
+		# Punch-list "disconnect() wipes entire OAuth signin cache hash"
+		# from the 2026-06-16 review. The previous shape called
+		# frappe.cache.delete_key(_CACHE_KEY) on disconnect, which wipes
+		# every System Manager's pending sign-in - not just the caller's.
+		# Two co-admins on the same site: user A starts a paste-signin,
+		# user B clicks Disconnect, user A's nonce vanishes mid-flow.
+		# Disconnect must leave the (per-user-bound, short-TTL) nonce
+		# cache untouched.
+		frappe.cache.hset(_CACHE_KEY, "peer_pending_nonce", {
+			"status": "pending",
+			"originator_user": "peer@example.com",
+			"expires_at_ts": int(time.time()) + 600,
+			"state": "peer-state",
+			"verifier": "peer-verifier",
+			"provider": "OpenAI",
+			"model": "gpt-5.5",
+		})
+		out = oauth_api.disconnect()
+		self.assertTrue(out["ok"])
+		survived = frappe.cache.hget(_CACHE_KEY, "peer_pending_nonce")
+		self.assertIsNotNone(survived)
+		self.assertEqual(survived["originator_user"], "peer@example.com")
 
 	@patch("jarvis.oauth.api.admin_client.post_subscription_disconnect",
 	       side_effect=_admin_module.AdminUnreachableError("net"))


### PR DESCRIPTION
…ompare (3 punch-list items)

Three related items from the 2026-06-16 cross-repo review, all in jarvis/oauth/api.py:

1. "state comparison non-constant-time" (oauth/api.py:165) The OAuth state parameter is the CSRF nonce. The previous shape compared with ``!=`` which short-circuits on the first differing byte; an attacker who can measure complete_paste_signin's response time can recover the state prefix byte-by-byte. Switched to secrets.compare_digest (constant-time over max(len)), with defensive ``or ""`` coercion so a code-only paste yields state_mismatch instead of a TypeError 500.

2. "disconnect() wipes entire OAuth signin cache hash" (oauth/api.py:318) The cache key holds every System Manager's per-flow nonce. The previous shape called frappe.cache.delete_key(_CACHE_KEY) on disconnect, wiping ALL pending sign-ins across the site. Two co-admin scenario: user A is mid paste-signin, user B clicks Disconnect, A's nonce vanishes under them. Removed the cache wipe; per-user-bound nonces have a 10-min TTL and get swept by (3) anyway.

3. "stale PKCE verifiers + unconsumed nonces never GC'd" (oauth/api.py:103) Redis hash fields can't carry individual TTLs, so abandoned flows leave verifier+state hanging until the entire hash gets wiped. With (2) removing the wipe, this becomes worse. Added _gc_expired_nonces() opportunistic sweep called from begin_paste_signin (one HGETALL per begin; cap at 256 fields to bound worst-case). Also added eager eviction in complete_paste_signin's expired-nonce branch so dead entries don't linger waiting on the next begin.

Tests:
- 25/25 vitest pass (was 21; +4 new: GC sweep × 2, peer-survival × 1, state-one-char-off + missing-state cases × 2; existing 2 updated)
- TestDisconnect.test_disconnect_clears_state: trimmed the leftover- nonce assertion (was asserting the WRONG behaviour - that disconnect wipes peers' nonces); replaced with test_disconnect_preserves_peers_ pending_signins pinning the new correct behaviour
- TestCompletePasteSigninParsing.test_rejects_expired_nonce: now also asserts the expired entry is evicted from the cache