### PR TITLE
fix: cross-repo batch 2 - ensure_paired race + secret scrub at admin_…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -8,6 +8,8 @@ Guest calls (signup, get_plans) skip the header entirely; their admin
 endpoints are @frappe.whitelist(allow_guest=True).
 """
 
+import re
+
 import frappe
 import requests
 
@@ -22,6 +24,67 @@ from jarvis.exceptions import (
 # Admin's provision_healthz_timeout_s defaults to 60s for restart operations;
 # 90s leaves 30s buffer for network round-trip + handler overhead.
 DEFAULT_TIMEOUT_S = 90
+
+# Cap on the cross-boundary message length. Long messages (e.g. a Frappe
+# 500 with a 10KB traceback that happens to embed a token mid-frame) get
+# truncated at the admin_client edge so they can't blow up
+# ``last_sync_status`` (a Data field) or burn Error Log rows. Anything
+# longer than this lands in Error Log only.
+_MAX_MESSAGE_CHARS = 500
+
+# Patterns to redact before any admin response text is allowed to cross
+# the boundary into an Admin*Error message (which then becomes the body of
+# ``last_sync_status`` via jarvis_settings.py and the Error Log via
+# frappe.log_error). Even though admin's whitelisted endpoints are not
+# supposed to echo secrets, defense-in-depth: a future admin handler
+# raising ``frappe.throw("body was %s" % body)`` would otherwise reflect
+# the request's api_key / api_secret / refresh_token straight back into
+# the bench's status field. Punch-list "secret values can leak to
+# last_sync_status/Error Log via upstream passthrough" from the
+# 2026-06-16 cross-repo review.
+_SECRET_PATTERNS = (
+	# token=VALUE / api_key=VALUE / api_secret=VALUE / Bearer VALUE /
+	# Authorization: Bearer VALUE / etc. Captures the credential keyword
+	# + the (=|:) + the secret. We replace the whole tail with [REDACTED]
+	# so the keyword survives ("AuthenticationError: api_key=[REDACTED]
+	# is invalid").
+	re.compile(
+		r"(?i)\b("
+		r"api[_-]?key|api[_-]?secret|client[_-]?secret|"
+		r"access[_-]?token|refresh[_-]?token|"
+		r"authorization|bearer|password|secret"
+		r")\s*[=:]\s*\S+"
+	),
+	# OpenAI / Anthropic-style key prefixes (sk-..., sk-ant-..., etc.)
+	# without an explicit keyword. Conservative threshold (20+ chars)
+	# so we don't false-positive on short literals like "sk-1".
+	re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}\b"),
+	# RFC 7519 JWTs (id_token / access_token shapes).
+	re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b"),
+)
+
+
+def _scrub_secrets(text: str) -> str:
+	"""Strip token-shaped substrings from text crossing the admin_client
+	boundary. Truncate to ``_MAX_MESSAGE_CHARS`` so a 10KB Frappe traceback
+	can't pollute ``last_sync_status``.
+
+	Idempotent: scrubbing already-scrubbed text leaves [REDACTED] markers
+	intact (the patterns don't match the literal "[REDACTED]").
+	"""
+	if not text:
+		return text
+	out = text
+	for pat in _SECRET_PATTERNS:
+		out = pat.sub(lambda m: (
+			# Keyword + "=[REDACTED]" for the labeled-credential pattern;
+			# bare "[REDACTED]" for the prefix / JWT patterns (whole match
+			# IS the secret).
+			f"{m.group(1)}=[REDACTED]" if m.lastindex else "[REDACTED]"
+		), out)
+	if len(out) > _MAX_MESSAGE_CHARS:
+		out = out[:_MAX_MESSAGE_CHARS] + "...[truncated]"
+	return out
 
 # DEFAULT_ADMIN_URL lives in hooks.py as a single source of truth for
 # deployment-level constants; re-exported here so existing
@@ -311,7 +374,13 @@ def _extract_frappe_message(payload: dict) -> str:
 	Frappe encodes user-visible alerts under `_server_messages` (a JSON-encoded
 	list of JSON-encoded dicts with a `message` key). When that's empty, fall
 	back to the `exception` string and strip the leading `module.path.ClassName: `
-	prefix so we don't leak Python internals to the operator."""
+	prefix so we don't leak Python internals to the operator.
+
+	The return value is always scrubbed for token-shaped substrings before it
+	crosses the admin_client boundary - see _scrub_secrets for the patterns.
+	Punch-list "secret values can leak to last_sync_status/Error Log via
+	upstream passthrough" from the 2026-06-16 cross-repo review.
+	"""
 	import json as _json
 	raw = (payload.get("_server_messages") or "").strip()
 	if raw:
@@ -321,13 +390,24 @@ def _extract_frappe_message(payload: dict) -> str:
 				first = _json.loads(messages[0]) if isinstance(messages[0], str) else messages[0]
 				msg = (first or {}).get("message") or ""
 				if msg:
-					return msg
+					return _scrub_secrets(msg)
 		except (ValueError, TypeError):
 			pass
 	exc = (payload.get("exception") or "").strip()
 	if ":" in exc:
-		return exc.split(":", 1)[1].strip()
-	return exc or payload.get("exc_type") or "unknown admin error"
+		return _scrub_secrets(exc.split(":", 1)[1].strip())
+	return _scrub_secrets(exc or payload.get("exc_type") or "unknown admin error")
+
+
+def _envelope_error_message(envelope) -> str:
+	"""Pull ``error.message`` out of an admin envelope and run it through
+	_scrub_secrets. Single bottleneck for the err.get('message') paths -
+	every Admin*Error message we construct from upstream-controlled text
+	flows through here."""
+	if not isinstance(envelope, dict):
+		return ""
+	err = envelope.get("error", {}) or {}
+	return _scrub_secrets(err.get("message") or "")
 
 
 def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str) -> dict:
@@ -373,8 +453,9 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	) else ""
 
 	def _envelope_message() -> str:
-		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
-		return err.get("message") or clean or ""
+		# _envelope_error_message already scrubs; clean is already scrubbed
+		# (it came from _extract_frappe_message). Falling back to "" is fine.
+		return _envelope_error_message(envelope) or clean or ""
 
 	# Status-based routing for the three unambiguous wire signals.
 	# The 2026-06-16 review caught that the previous shape ran the
@@ -387,7 +468,7 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	if resp.status_code == 429:
 		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
 		raise AdminRateLimitedError(
-			err.get("message") or clean or "rate_limited",
+			_envelope_error_message(envelope) or clean or "rate_limited",
 			retry_after_seconds=int(err.get("retry_after_seconds") or 0),
 		)
 
@@ -423,8 +504,7 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	#   5xx + envelope -> AdminUnreachableError (network / admin-down)
 	#   200 with ok:false (rare; some endpoints inline failure) -> AdminUnreachableError
 	if resp.status_code >= 400:
-		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
-		msg = err.get("message")
+		msg = _envelope_error_message(envelope)
 		if not msg:
 			# No structured ``error.message`` -> log the raw body but
 			# don't include it in the user-facing exception.
@@ -441,7 +521,7 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	if isinstance(envelope, dict) and not envelope.get("ok", True):
 		err = envelope.get("error", {}) or {}
 		code = err.get("code") or "?"
-		msg = err.get("message")
+		msg = _envelope_error_message(envelope)
 		if not msg:
 			frappe.log_error(
 				title="admin_client: 200 with ok:false but no error.message",

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -101,11 +101,52 @@ def ensure_paired() -> ChatDeviceCredentials:
 
 	Raises OpenclawUnreachableError if pairing fails (no creds to fall back
 	to - the caller has no way to chat without them, so we surface the error
-	cleanly instead of half-persisting an unusable state)."""
+	cleanly instead of half-persisting an unusable state).
+
+	Cold-start concurrency: send_message (web) and the RQ worker (background)
+	both call ensure_paired before each turn. On a fresh bench (no
+	credentials persisted yet) two concurrent callers both observe
+	``_read_credentials() is None`` and both call ``_generate_and_pair``,
+	each generating a different Ed25519 keypair and each round-tripping to
+	admin.pair_chat_device. Last writer to Jarvis Settings wins; the other
+	caller holds in-memory creds that admin's PairedDevice row doesn't know
+	about. Cross-repo punch-list "Race: send_message + RQ worker both invoke
+	ensure_paired() concurrently" from the 2026-06-16 review.
+
+	Fix: serialize the generate+pair window under a Redis advisory lock.
+	Double-checked: re-read inside the lock so the second arrival finds the
+	winner's creds and skips the duplicate pair entirely. The lock has a
+	60s TTL backstop so a crashed holder can't deadlock cold-start forever;
+	on lock unavailability we fall through and pair anyway (better one
+	duplicate keypair than a permanently broken chat).
+	"""
 	existing = _read_credentials()
 	if existing is not None:
 		return existing
-	return _generate_and_pair()
+	return _generate_and_pair_under_lock()
+
+
+def _generate_and_pair_under_lock() -> ChatDeviceCredentials:
+	"""Convoy-collapse helper for the cold-start race. Acquires the
+	chat_device_initial_pair lock with a bounded wait; inside the lock,
+	re-reads to see if the winner already paired; if so, returns their
+	creds; if not, runs the actual pair flow."""
+	from jarvis._redis_lock import redis_lock
+
+	with redis_lock(
+		"chat_device_initial_pair", timeout_s=60, blocking_timeout_s=30.0,
+	) as acquired:
+		# Re-check inside the lock window. The winner of a contended cold-
+		# start has already populated Jarvis Settings; followers read those
+		# creds and return without a second pair_chat_device round-trip.
+		existing = _read_credentials()
+		if existing is not None:
+			return existing
+		# Lock-unavailable + no creds: a Redis outage during cold-start
+		# would otherwise block the bench's chat path indefinitely.
+		# Falling through accepts at-worst-one-duplicate-pair; that's a
+		# strictly better failure mode than chat-permanently-broken.
+		return _generate_and_pair()
 
 
 def _generate_and_pair() -> ChatDeviceCredentials:

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -306,6 +306,121 @@ class TestAdminErrorResponses(FrappeTestCase):
 		self.assertEqual(str(cm.exception), "customer status: Suspended")
 
 
+class TestSecretScrubbingAtBoundary(FrappeTestCase):
+	"""Cross-repo punch-list "secret values can leak to last_sync_status /
+	Error Log via upstream passthrough" from the 2026-06-16 review.
+
+	Defense-in-depth: even though admin's whitelisted endpoints shouldn't
+	echo secrets in error messages, a future admin handler raising
+	``frappe.throw("body was %s" % body)`` would reflect any token in the
+	request straight back to the bench. admin_client must scrub
+	token-shaped substrings BEFORE the Admin*Error reaches the caller,
+	since the caller f-strings ``{e}`` straight into ``last_sync_status``
+	(jarvis_settings.py:157) and frappe.log_error (Error Log doctype).
+	"""
+
+	def setUp(self):
+		_settings_for_admin()
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_api_key_value_redacted_from_validation_error(self):
+		mock_post = MagicMock(return_value=_mock_response(
+			500,
+			json_body={
+				"exc_type": "ValidationError",
+				"_server_messages": (
+					'["{\\"message\\": \\"upstream rejected: api_key=sk-AbCdEf1234567890abcdef is invalid\\"}"]'
+				),
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		msg = str(cm.exception)
+		self.assertNotIn("sk-AbCdEf1234567890abcdef", msg)
+		self.assertIn("[REDACTED]", msg)
+		# Keyword survives so operators can still see what kind of error
+		# this was - the secret is the only thing redacted.
+		self.assertIn("upstream rejected", msg)
+
+	def test_authorization_header_redacted_from_4xx_envelope(self):
+		# 4xx + structured envelope path (the most common cross-boundary
+		# shape for admin handler validation failures).
+		mock_post = MagicMock(return_value=_mock_response(
+			417,
+			json_body={
+				"message": {
+					"ok": False,
+					"error": {
+						"code": "BadAuth",
+						"message": "echoed Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload-stuff.sig-stuff",
+					},
+				},
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		msg = str(cm.exception)
+		self.assertNotIn("eyJhbGciOiJIUzI1NiJ9.payload-stuff.sig-stuff", msg)
+		self.assertIn("[REDACTED]", msg)
+
+	def test_jwt_in_exc_redacted_from_500_envelope(self):
+		# Frappe always pairs ``exception`` with ``exc_type`` for raised
+		# Python exceptions; the bench routes by exc_type allowlist into
+		# AdminUnreachableError (unknown class). The scrub applies before
+		# the exception class name is stripped.
+		mock_post = MagicMock(return_value=_mock_response(
+			500,
+			json_body={
+				"exc_type": "ValueError",
+				"exception": "ValueError: id_token rejected: eyJ0eXAiOiJKV1QifQ.abcde123.signature456",
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(admin_client.AdminUnreachableError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		msg = str(cm.exception)
+		self.assertNotIn("eyJ0eXAiOiJKV1QifQ.abcde123.signature456", msg)
+		self.assertIn("[REDACTED]", msg)
+
+	def test_oversized_message_truncated(self):
+		# A 10KB traceback embedded in _server_messages must not blow up
+		# the Data field that last_sync_status writes to.
+		giant = "x" * 5000
+		mock_post = MagicMock(return_value=_mock_response(
+			500,
+			json_body={
+				"exc_type": "ValidationError",
+				"_server_messages": f'["{{\\"message\\": \\"{giant}\\"}}"]',
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertLess(len(str(cm.exception)), 600)
+		self.assertIn("...[truncated]", str(cm.exception))
+
+	def test_clean_message_passes_through_unchanged(self):
+		# Negative case: a message with no token-shaped substring stays
+		# byte-identical (modulo the truncate cap).
+		mock_post = MagicMock(return_value=_mock_response(
+			417,
+			json_body={
+				"message": {
+					"ok": False,
+					"error": {"code": "no_subscription", "message": "no active subscription on this account"},
+				},
+			},
+		))
+		with patch("requests.post", mock_post):
+			with self.assertRaises(AdminValidationError) as cm:
+				post_update_llm_creds("p", "m", "b", "k")
+		self.assertEqual(str(cm.exception), "no active subscription on this account")
+
+
 class TestNonJsonResponse(FrappeTestCase):
 	def setUp(self):
 		_settings_for_admin()

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -135,6 +135,68 @@ class TestEnsurePaired(_SettingsSnapshotMixin, FrappeTestCase):
 			with self.assertRaises(OpenclawUnreachableError):
 				chat_device.ensure_paired()
 
+	def test_concurrent_callers_share_one_admin_pair_call(self):
+		"""Cold-start convoy collapse. Cross-repo punch-list "Race:
+		send_message + RQ worker both invoke ensure_paired() concurrently".
+
+		Before the fix: a fresh bench with no chat_device_* fields and
+		two concurrent callers (web request + RQ worker) BOTH observed
+		``_read_credentials() is None`` and BOTH called
+		``_generate_and_pair`` - last writer to Jarvis Settings wins;
+		the other caller holds in-memory creds that don't match what
+		admin saw.
+
+		After the fix: a Redis lock collapses the convoy. The first
+		caller pairs; the second waits on the lock, re-reads inside it,
+		and returns the winner's creds without a second admin call.
+
+		Real concurrency on a single-threaded test runner is tricky to
+		stage. We simulate the convoy by patching the lock context
+		manager so the "second" caller pre-populates Settings before
+		entering the lock body - the re-check inside the lock must
+		short-circuit on those existing creds.
+		"""
+		# First caller paints credentials into Settings as if it had won
+		# the lock race.
+		first_priv = Ed25519PrivateKey.generate()
+		first_pub_raw = first_priv.public_key().public_bytes(
+			serialization.Encoding.Raw, serialization.PublicFormat.Raw,
+		)
+		first_device_id = hashlib.sha256(first_pub_raw).hexdigest()
+
+		def _pre_populate_settings_inside_lock():
+			s = frappe.get_single("Jarvis Settings")
+			s.db_set("chat_device_id", first_device_id)
+			s.db_set("chat_device_public_key", _b64u(first_pub_raw))
+			s.db_set("chat_device_private_key", _b64u(first_priv.private_bytes(
+				serialization.Encoding.Raw, serialization.PrivateFormat.Raw,
+				serialization.NoEncryption(),
+			)))
+			s.db_set("chat_device_token", "tok-winner")
+			frappe.db.commit()
+
+		class _FakeLockCtx:
+			def __enter__(_self):
+				_pre_populate_settings_inside_lock()
+				return True
+			def __exit__(_self, *a):
+				return False
+
+		mock_pair = patch("jarvis.chat.device.admin_client.pair_chat_device").start()
+		mock_lock = patch("jarvis._redis_lock.redis_lock",
+		                  return_value=_FakeLockCtx()).start()
+		try:
+			creds = chat_device.ensure_paired()
+		finally:
+			patch.stopall()
+
+		# Second caller picked up the winner's creds; no admin pair call
+		# was made.
+		self.assertFalse(mock_pair.called)
+		self.assertEqual(creds.device_token, "tok-winner")
+		self.assertEqual(creds.device_id, first_device_id)
+		self.assertTrue(mock_lock.called)
+
 	def test_partial_state_triggers_repair(self):
 		"""If only some fields are set, treat the whole pairing as missing
 		so the next call re-pairs atomically - protects against half-failed


### PR DESCRIPTION
…client boundary

Closes two of the three remaining customer-bench cross-repo items:

1. "Race: send_message + RQ worker both invoke ensure_paired() concurrently" (chat/device.py:98)

   On a fresh bench (chat_device_* fields empty) two concurrent callers - the web request that fires off the chat turn and the RQ worker that picks it up - both observe ``_read_credentials() is None``, both call ``_generate_and_pair``, each generate a different Ed25519 keypair, and both round-trip to admin.pair_chat_device. Last writer to Jarvis Settings wins; the other holds in-memory creds admin's PairedDevice row doesn't know about, then chat fails with a "device-id-mismatch" until the stale-pair self-heal kicks in - which lights up the convoy-collapse log noise the Sprint-2 _repair_and_reconnect lock was added to address.

   Fix: wrap the pair flow in the same Redis advisory-lock pattern _repair_and_reconnect already uses. New _generate_and_pair_under_lock helper - 30s blocking timeout, 60s TTL backstop on the lock key, double-checked re-read inside the lock so followers reuse the winner's creds without a second admin call. On Redis outage we fall through (at-worst-one-duplicate-pair beats permanently-broken chat).

   Test: TestEnsurePaired.test_concurrent_callers_share_one_admin_pair_call stages the convoy by patching redis_lock so the "second" arrival's __enter__ pre-populates Settings before the lock body runs; the re-check must short-circuit on those creds without calling admin.pair_chat_device.

2. "secret values can leak to last_sync_status / Error Log via upstream passthrough" (admin_client.py:322)

   The bench f-strings ``{e}`` straight into ``last_sync_status`` (jarvis_settings.py:157,167,179). If admin's whitelisted endpoints ever raise ``frappe.throw("body was %s" % body)`` the request's api_key / api_secret / refresh_token / bearer flows back through _extract_frappe_message into the Admin*Error message and lands in the Data field plus Error Log. Defense-in-depth even if no admin handler does this today.

   Fix: _scrub_secrets() applied at the single bottleneck where upstream text crosses the boundary into Admin*Error - the return from _extract_frappe_message AND every err.get('message') read (factored into a new _envelope_error_message helper so the call sites can't accidentally regress to the raw shape). Patterns cover:
     - keyword=value (api_key, api_secret, client_secret, access_token, refresh_token, authorization, bearer, password, secret)
     - sk-* / sk-ant-* / etc. prefixed credentials - RFC 7519 JWTs Plus a 500-char cap with "...[truncated]" marker so a 10KB Frappe traceback can't blow up the Data field.

   5 new tests pin: api_key= in ValidationError, Bearer/JWT in 4xx
   envelope, JWT in 500 exc_type+exception, oversized message
   truncation, and a clean-message-passes-through-unchanged
   negative case.

## Closed indirectly by prior batches

Auditing the cross-repo (10) backlog against the post-Sprint-3 codebase, the second customer-bench item is already addressed:

  - "stale-pair markers substring-matched on error text" (chat/openclaw_client.py:56)

    Sprint-3 work rewrote ``_is_stale_pairing`` to read ``getattr(err, 'code', None) in _STALE_PAIRING_CODES`` (line 101)
    - structured ``.code`` lookup with a frozenset of known codes, no substring match. The previous shape did ``str(err).lower().contains(marker)`` which would have caught a "device-not-paired-yet" diagnostic dump from a future openclaw release falsely.

## Tests

39 admin_client tests pass (was 34 - +5 scrubbing). 11 chat_device tests pass (was 10 - +1 convoy collapse).