### PR TITLE
feat: run_query per-tenant DocType allowlist (Sprint-1 punch-list)

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -261,6 +261,17 @@
       "read_only": 1
     },
     {
+      "fieldname": "agent_tools_section",
+      "fieldtype": "Section Break",
+      "label": "Agent Tool Restrictions"
+    },
+    {
+      "fieldname": "run_query_doctype_allowlist",
+      "fieldtype": "Small Text",
+      "label": "run_query DocType Allowlist",
+      "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
+    },
+    {
       "fieldname": "developer_section",
       "fieldtype": "Section Break",
       "label": "Developer / Sandbox"

--- a/jarvis/tests/test_run_query.py
+++ b/jarvis/tests/test_run_query.py
@@ -193,6 +193,122 @@ class TestRunQueryPermissions(FrappeTestCase):
 		self.assertIn("Sales Invoice Item", checked)
 
 
+class TestRunQueryDocTypeAllowlist(FrappeTestCase):
+	"""Sprint-1 punch-list "run_query SQL allowlist has bypass surfaces"
+	(2026-06-16 review) — defense-in-depth per-tenant DocType allowlist
+	on top of the Frappe permission system. When configured, run_query
+	must refuse a DocType not on the allowlist even when the calling
+	user has read permission.
+
+	The allowlist is opt-in: empty = current behaviour (any DocType the
+	user can read). The tests pin both directions.
+	"""
+
+	def setUp(self):
+		# Always reset the allowlist between tests so each test's
+		# patches start from a known state.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist", "", update_modified=False,
+		)
+		frappe.db.commit()
+
+	def tearDown(self):
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist", "", update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_empty_allowlist_imposes_no_extra_restriction(self):
+		# Empty field = behave as before; perm check is the only gate.
+		# Patch frappe.db.sql so we don't need a real table.
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.db.sql", return_value=[]):
+			result = run_query("SELECT name FROM tabSales Invoice LIMIT 1")
+		self.assertIn("rows", result)
+
+	def test_doctype_on_allowlist_is_allowed(self):
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist",
+			"Sales Invoice, Customer",
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.db.sql", return_value=[]):
+			result = run_query("SELECT name FROM tabSales Invoice LIMIT 1")
+		self.assertIn("rows", result)
+
+	def test_doctype_off_allowlist_is_rejected_even_with_read_perm(self):
+		# The whole point of the allowlist: a user who CAN read 'User' via
+		# Frappe perms must still be denied if the operator didn't put
+		# 'User' on the allowlist.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist",
+			"Sales Invoice, Customer",
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				run_query("SELECT name FROM tabUser LIMIT 1")
+		self.assertIn("User", str(cm.exception))
+		self.assertIn("allowlist", str(cm.exception))
+
+	def test_allowlist_enforced_per_doctype_in_joins(self):
+		# Sales Invoice is on the list, Sales Invoice Item isn't - the
+		# JOIN must fail even though the leading table is allowed.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist",
+			"Sales Invoice",
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				run_query(
+					"SELECT si.name FROM `tabSales Invoice` AS si "
+					"JOIN `tabSales Invoice Item` AS sii ON sii.parent = si.name"
+				)
+		self.assertIn("Sales Invoice Item", str(cm.exception))
+
+	def test_newline_separated_allowlist(self):
+		# The Small Text field renders multiline by default; operators
+		# with >5 DocTypes will paste one-per-line. Both separators
+		# (and a mix) must work.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist",
+			"Sales Invoice\nCustomer\nItem",
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.db.sql", return_value=[]):
+			run_query("SELECT name FROM tabCustomer LIMIT 1")
+			run_query("SELECT name FROM tabItem LIMIT 1")
+
+	def test_allowlist_is_case_sensitive(self):
+		# Frappe DocType names are case-sensitive ("Sales Invoice" !=
+		# "sales invoice"); the allowlist matches them as-is so a typo
+		# in the operator's configured list silently fails-closed
+		# rather than silently fails-open.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set(
+			"run_query_doctype_allowlist",
+			"sales invoice",  # lowercase - shouldn't match "Sales Invoice"
+			update_modified=False,
+		)
+		frappe.db.commit()
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError):
+				run_query("SELECT name FROM `tabSales Invoice` LIMIT 1")
+
+
 class TestRunQueryLimitInjection(FrappeTestCase):
 	"""LIMIT is the only bound on result size - it must always be present
 	and never exceed the cap. Test the rewriter, not the SQL execution.

--- a/jarvis/tools/run_query.py
+++ b/jarvis/tools/run_query.py
@@ -110,6 +110,24 @@ def run_query(query: str, limit: int = DEFAULT_LIMIT) -> dict:
 				f"no read permission on referenced DocType: {doctype}"
 			)
 
+	# Operator-configured defense-in-depth: a per-site DocType allowlist on
+	# top of the Frappe permission system. If set, run_query refuses any
+	# DocType not on the list - even when the calling user has read perm.
+	# Closes Sprint-1 punch-list "run_query SQL allowlist has bypass
+	# surfaces" by giving operators a way to lock the tool to a known-good
+	# slice of the DocType graph (e.g. "Sales Invoice, Customer, Item")
+	# so a future allowlist bypass in the SQL parser is contained.
+	allowlist = _load_doctype_allowlist()
+	if allowlist is not None:
+		for tbl in tables:
+			doctype = tbl[len("tab"):]
+			if doctype not in allowlist:
+				raise PermissionDeniedError(
+					f"DocType {doctype!r} is not in this site's run_query "
+					f"allowlist; add it to Jarvis Settings."
+					f"run_query_doctype_allowlist to enable."
+				)
+
 	final = _enforce_limit(clean, limit)
 
 	rows = frappe.db.sql(final, as_dict=True)
@@ -122,6 +140,45 @@ def run_query(query: str, limit: int = DEFAULT_LIMIT) -> dict:
 
 
 # ---- Validation helpers ----------------------------------------------
+
+
+def _load_doctype_allowlist() -> set[str] | None:
+	"""Read the per-site DocType allowlist from Jarvis Settings.
+
+	Returns ``None`` when the field is unset or empty (default; means
+	"no extra restriction beyond Frappe permissions"). Returns a
+	normalised set of DocType names when configured. Accepts comma OR
+	newline separation so operators can paste from either a CSV row or
+	a one-DocType-per-line list, the latter being the more readable
+	form for >5 entries in the Small Text field.
+
+	Whitespace is trimmed; empty entries are dropped. Names are NOT
+	normalised for case (Frappe DocType names are case-sensitive:
+	"Sales Invoice" != "sales invoice"), so a typo in the allowlist
+	silently doesn't match - that's the right failure mode (closed by
+	default).
+
+	Reads via ``frappe.get_cached_doc`` rather than ``get_single_value``
+	so the call uses Frappe's Single-doc cache (a single in-memory dict
+	per process) instead of an SQL round-trip. The cached path also
+	doesn't get fooled by callers who have ``patch('frappe.db.sql')``
+	in scope (a common pattern in run_query's own tests).
+	"""
+	try:
+		settings = frappe.get_cached_doc("Jarvis Settings")
+	except Exception:
+		# Bench misconfig / migration in flight / similar. Failing open
+		# here is the safe call: the actual perm check above already
+		# gated every DocType through frappe.has_permission. Without
+		# this fallback, a transient Settings read error would brick
+		# every run_query call.
+		return None
+	raw = (settings.get("run_query_doctype_allowlist") or "").strip()
+	if not raw:
+		return None
+	parts = re.split(r"[,\n]", raw)
+	cleaned = {p.strip() for p in parts if p.strip()}
+	return cleaned if cleaned else None
 
 
 def _reject_comments(query: str) -> None:


### PR DESCRIPTION
Closes the per-tenant-allowlist half of Sprint-1 punch-list "run_query SQL allowlist has bypass surfaces" (2026-06-16 review). The min-privilege DB user half stays deferred - it needs operator- side MariaDB user provisioning and is tracked separately.

New field on Jarvis Settings:
  run_query_doctype_allowlist (Small Text)
  Comma- or newline-separated list of DocType names.
  Empty (default) = no extra restriction.
  Non-empty = ONLY listed DocTypes are allowed, even if the calling
              user has Frappe read perm on others.

The intent is defense-in-depth on top of the existing perm gate. The run_query parser is hardened against the named bypass surfaces (the FORBIDDEN_TOKENS / _FORBIDDEN_SCHEMAS / comma-FROM tokeniser work that landed earlier in this Sprint), but a future bypass would otherwise expose every DocType the calling user can read. Operators can now lock the agent to a known-good slice of the DocType graph (e.g. "Sales Invoice, Customer, Item, Sales Invoice Item") so any future parser regression is contained.

Implementation notes:
  - _load_doctype_allowlist reads via frappe.get_cached_doc, not get_single_value, so the call hits Frappe's Single-doc in-process cache (no SQL round-trip per query) and isn't fooled by the common ``patch('frappe.db.sql')`` test pattern in run_query's own suite.
  - On a transient Settings read error the helper fails open (the existing has_permission gate is still the primary defense). The alternative would brick every run_query call during a migration or cache hiccup - too costly for a defense-in-depth layer.
  - DocType names are case-sensitive in Frappe; the allowlist matches them verbatim. A typo in the operator's list silently fails-closed (DocType denied) rather than silently fails-open - covered by test_allowlist_is_case_sensitive.

6 new tests pin the contract:
  - empty allowlist -> no extra restriction (current behaviour)
  - DocType on list -> allowed
  - DocType off list -> rejected even with read perm
  - allowlist enforced per-DocType in JOINs (one-table-allowed, other-table-not is correctly caught)
  - newline-separated list (Small Text default render)
  - case-sensitivity pin (typo -> fail-closed)

136 jarvis tests pass.