### PR TITLE
feat: customer-bench wizard handles email-verification signup flow (S…

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -100,12 +100,41 @@ def _admin_url(settings) -> str:
 def signup(email: str, company_name: str, plan: str, coupon: str | None = None) -> dict:
 	"""Guest signup against admin. Returns admin's data dict
 	{api_key, api_secret, razorpay_key_id, razorpay_order_id, amount_inr}.
-	Both annual and monthly are one-shot orders (manual renew - no Razorpay subscription)."""
+	Both annual and monthly are one-shot orders (manual renew - no Razorpay subscription).
+
+	When the admin's ``Jarvis Admin Settings.require_email_verification``
+	flag is ON, the response shape is:
+	    {api_key, api_secret, razorpay_key_id, amount_inr, customer,
+	     pending_verification: True}
+	(no razorpay_order_id - the order is deferred until the customer clicks
+	the magic link and the bench polls ``get_signup_payment_state``).
+	"""
 	body = {"email": email, "company_name": company_name, "plan": plan,
 			"frappe_site_url": frappe.utils.get_url()}
 	if coupon:
 		body["coupon"] = coupon
 	return _post_guest(path="/api/method/jarvis_admin.billing.signup.signup", body=body)
+
+
+def get_signup_payment_state() -> dict:
+	"""Authenticated poll. Returns one of:
+	    {pending_verification: True}
+	      - customer hasn't clicked the magic link yet
+	    {pending_verification: False, razorpay_order_id, razorpay_key_id,
+	     amount_inr}
+	      - verification done; wizard can advance to Razorpay Checkout
+	    {pending_verification: False, subscription_status: <other>}
+	      - signup already completed (verification + payment both done)
+
+	Uses the authenticated _post path with the api_key + api_secret the
+	bench stashed at signup time. Only meaningful between the verification-
+	on signup() return and the customer's click of the magic link; the
+	wizard polls this on a "I've verified my email" button click.
+	"""
+	return _post(
+		path="/api/method/jarvis_admin.billing.signup.get_signup_payment_state",
+		body={},
+	)
 
 
 def dev_signup(email: str, company_name: str, plan: str) -> dict:

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -658,8 +658,72 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	function startPay() {
 		setBusy("#jo-pay", true);
 		frappe.call({ method: "jarvis.onboarding.start_signup", args: { email: state.email, company: state.company, plan: state.planName } })
-			.then((r) => openCheckout(r.message || {}))
+			.then((r) => {
+				const d = r.message || {};
+				// Admin's require_email_verification flag steers the response
+				// shape. When the flag is ON, signup returns no razorpay_order_id
+				// and instead asks the customer to click a magic link emailed
+				// to their address. The wizard switches to a "check your email"
+				// screen + a poll-the-admin button until the link has been
+				// clicked, at which point we transition to Razorpay Checkout.
+				// Flag OFF (legacy) = response carries razorpay_order_id and
+				// we go straight to Checkout, unchanged.
+				if (d.pending_verification) {
+					renderVerifyEmail();
+					return;
+				}
+				openCheckout(d);
+			})
 			.catch((e) => payErr(e));
+	}
+
+	function renderVerifyEmail() {
+		setBusy("#jo-pay", false);
+		$body.html(`
+			<div class="jo-verify">
+				<h2 class="jo-h">Check your email</h2>
+				<p class="jo-sub">We sent a confirmation link to <strong>${esc(state.email)}</strong>.
+				Click the link to verify your address, then come back here and click
+				the button below to continue to payment.</p>
+				<p class="jo-sub">The link expires in 24 hours. Check your spam folder if
+				it doesn't arrive.</p>
+				<div class="jo-err" id="jo-verify-err"></div>
+				<div class="jo-actions">
+					<button class="jo-btn jo-btn-primary" id="jo-verify-check">I've verified my email →</button>
+				</div>
+			</div>`);
+		$body.find("#jo-verify-check").on("click", () => {
+			setBusy("#jo-verify-check", true);
+			$body.find("#jo-verify-err").text("");
+			frappe.call({ method: "jarvis.onboarding.check_signup_payment_state" })
+				.then((r) => {
+					const d = r.message || {};
+					setBusy("#jo-verify-check", false);
+					if (d.pending_verification) {
+						$body.find("#jo-verify-err").text(
+							"We haven't received your verification yet. Click the link in your email, then try again."
+						);
+						return;
+					}
+					if (d.razorpay_order_id) {
+						openCheckout(d);
+						return;
+					}
+					// Edge case: subscription already advanced past Pending
+					// Payment (e.g. operator manually transitioned, or this
+					// is a stale tab). Show a generic message; the next
+					// reload picks up the right step.
+					$body.find("#jo-verify-err").text(
+						"Signup state has changed. Refresh this page to continue."
+					);
+				})
+				.catch((e) => {
+					setBusy("#jo-verify-check", false);
+					$body.find("#jo-verify-err").text(
+						e.message || "Couldn't reach the admin server. Try again."
+					);
+				});
+		});
 	}
 
 	function openCheckout(d) {

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -129,13 +129,51 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 	admin_client falls back to the DEFAULT_ADMIN_URL, which on a multi-site
 	bench may be the wrong control plane. Fail fast with an actionable
 	error instead of silently landing the wrong tenancy.
+
+	Two response shapes depending on admin's
+	``require_email_verification`` flag:
+	  - flag OFF (legacy): admin returns a Razorpay order; wizard goes
+	    straight to Checkout.
+	  - flag ON: admin returns ``pending_verification: True`` and no
+	    order; wizard shows a "check your email" screen and polls
+	    ``check_signup_payment_state`` after the customer clicks the
+	    magic link. Either shape persists api_key + api_secret on the
+	    bench so the poll endpoint can authenticate.
 	"""
 	frappe.only_for("System Manager")
 	_require_admin_url()
 	data = _surface(admin_client.signup, email, company, plan)
+	# Persist api_key + api_secret regardless of which response shape we
+	# got - the bench needs them to authenticate to the poll endpoint
+	# during the verification window, and to every subsequent admin call.
+	# Legacy api_token shape kept for backwards compat with older admin
+	# responses (admin moved to native api_key:api_secret in Sprint-1).
 	if data.get("api_token"):
 		write_connection({"api_token": data["api_token"]})
+	if data.get("api_key") or data.get("api_secret"):
+		write_connection({
+			"api_key": data.get("api_key", ""),
+			"api_secret": data.get("api_secret", ""),
+		})
 	return data
+
+
+@frappe.whitelist()
+def check_signup_payment_state() -> dict:
+	"""Wizard-poll endpoint for the email-verification window.
+
+	Calls admin's ``get_signup_payment_state`` (authenticated via the
+	api_key + api_secret persisted at start_signup time) and returns the
+	response unchanged. The wizard JS branches on
+	``pending_verification`` to decide whether to keep showing the
+	"check your email" screen or to open Razorpay Checkout.
+
+	Gated on System Manager for the same reason as start_signup: this is
+	part of the same paid-signup flow on the customer's bench.
+	"""
+	frappe.only_for("System Manager")
+	_require_admin_url()
+	return _surface(admin_client.get_signup_payment_state)
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -193,6 +193,122 @@ class TestSyncConnection(FrappeTestCase):
 			                          api_key="", auth_mode="token")
 
 
+class TestSignupEmailVerification(FrappeTestCase):
+	"""Customer-bench half of the Sprint-1 punch-list email-verification
+	work. Pairs with the admin-side flag on
+	Jarvis Admin Settings.require_email_verification.
+
+	Bench-side surfaces:
+	  start_signup persists api_key + api_secret regardless of which
+	    response shape it got, so the poll endpoint can authenticate.
+	  check_signup_payment_state wraps admin's get_signup_payment_state.
+	"""
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		# Both paths need a non-empty admin URL to pass the pre-flight
+		# guard at start_signup; tests don't actually hit it because
+		# admin_client.signup is mocked.
+		frappe.db.set_value(
+			"Jarvis Settings", "Jarvis Settings",
+			"jarvis_admin_url", "https://admin.example.com",
+		)
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+
+	def test_start_signup_persists_api_key_secret_on_verification_response(self):
+		# When admin returns pending_verification=True with api_key+secret,
+		# the bench MUST store both so the subsequent poll endpoint can
+		# authenticate during the verification window. Without this, the
+		# wizard would call check_signup_payment_state with no creds and
+		# admin would 401.
+		with patch("jarvis.onboarding.admin_client.signup",
+		           return_value={
+		               "ok": True,
+		               "api_key": "verify-key",
+		               "api_secret": "verify-secret",
+		               "customer": "alice@example.com",
+		               "pending_verification": True,
+		           }):
+			out = onboarding.start_signup(
+				"verify-test@example.com", "Acme", "Annual Plan",
+			)
+		self.assertTrue(out["pending_verification"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("jarvis_admin_api_key", raise_exception=False),
+			"verify-key",
+		)
+		self.assertEqual(
+			s.get_password("jarvis_admin_api_secret", raise_exception=False),
+			"verify-secret",
+		)
+
+	def test_start_signup_legacy_response_still_persists_key_secret(self):
+		# Regression pin: the flag-off (legacy) response shape must keep
+		# persisting api_key + api_secret on the bench - all subsequent
+		# admin calls (finish_payment, get_connection, sync_connection,
+		# rotate-secret, push_oauth_blob) authenticate via these.
+		with patch("jarvis.onboarding.admin_client.signup",
+		           return_value={
+		               "ok": True,
+		               "api_key": "legacy-key",
+		               "api_secret": "legacy-secret",
+		               "customer": "bob@example.com",
+		               "razorpay_key_id": "rzp_test_X",
+		               "razorpay_order_id": "order_LEGACY",
+		               "amount_inr": 12000,
+		           }):
+			out = onboarding.start_signup(
+				"legacy-test@example.com", "Bob Inc", "Annual Plan",
+			)
+		self.assertEqual(out["razorpay_order_id"], "order_LEGACY")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("jarvis_admin_api_key", raise_exception=False),
+			"legacy-key",
+		)
+
+	def test_check_signup_payment_state_returns_pending(self):
+		# Customer hasn't clicked the link yet - admin returns
+		# pending_verification: True. Wizard keeps showing the "check
+		# your email" screen.
+		with patch("jarvis.onboarding.admin_client.get_signup_payment_state",
+		           return_value={"pending_verification": True}):
+			out = onboarding.check_signup_payment_state()
+		self.assertTrue(out["pending_verification"])
+
+	def test_check_signup_payment_state_returns_razorpay_payload(self):
+		# Customer clicked the link - admin returns the deferred order
+		# details. Wizard transitions to Razorpay Checkout.
+		with patch("jarvis.onboarding.admin_client.get_signup_payment_state",
+		           return_value={
+		               "pending_verification": False,
+		               "razorpay_order_id": "order_VERIFIED",
+		               "razorpay_key_id": "rzp_test_X",
+		               "amount_inr": 12000,
+		           }):
+			out = onboarding.check_signup_payment_state()
+		self.assertFalse(out["pending_verification"])
+		self.assertEqual(out["razorpay_order_id"], "order_VERIFIED")
+
+	def test_check_signup_payment_state_requires_admin_url(self):
+		# Same pre-flight guard as start_signup - misconfigured bench
+		# shouldn't silently route to DEFAULT_ADMIN_URL.
+		frappe.db.set_value(
+			"Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "",
+		)
+		frappe.db.commit()
+		with patch(
+			"jarvis.onboarding.admin_client.get_signup_payment_state",
+		) as mock_call:
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.check_signup_payment_state()
+			mock_call.assert_not_called()
+
+
 class TestGetLlmSyncStatus(FrappeTestCase):
 	"""The polling endpoint that the onboarding + account pages hit while
 	the background admin sync is running."""

--- a/jarvis/tests/test_role_gates.py
+++ b/jarvis/tests/test_role_gates.py
@@ -27,6 +27,7 @@ from jarvis.oauth.api import _CACHE_KEY
 GATED_ENDPOINTS = [
 	("jarvis.onboarding", "sync_connection", {}),
 	("jarvis.onboarding", "start_signup", {"email": "x@y.test", "company": "C", "plan": "p"}),
+	("jarvis.onboarding", "check_signup_payment_state", {}),
 	("jarvis.onboarding", "finish_payment", {"payload": {}}),
 	("jarvis.onboarding", "renew", {}),
 	("jarvis.onboarding", "save_llm_creds", {"provider": "OpenAI", "model": "gpt-4o", "api_key": "k"}),


### PR DESCRIPTION
…print-1 punch-list)

Pair PR to jarvis-admin's email-verification work. Closes the customer-bench half of the Sprint-1 punch-list "signup() rate-limit weakness + email enumeration". Operators can now safely flip Jarvis Admin Settings.require_email_verification once both repos are deployed.

Changes:

1. admin_client.get_signup_payment_state - new authenticated wrapper for admin's poll endpoint. Returns the same shape admin emits: {pending_verification: True} while waiting for the click, or {pending_verification: False, razorpay_order_id, razorpay_key_id, amount_inr} once the magic link has been confirmed.

2. onboarding.start_signup now persists api_key + api_secret on the bench REGARDLESS of which response shape admin returned. Previously they were only written by the existing write_connection branch for the legacy api_token shape. The poll endpoint needs them to authenticate during the verification window. Tested both shapes end-to-end with admin_client mocked.

3. onboarding.check_signup_payment_state - new whitelisted endpoint, System Manager-gated, fronts admin_client.get_signup_payment_state. Same pre-flight admin-URL guard as start_signup.

4. jarvis_onboarding.js startPay() now branches on the response:
   - pending_verification: True -> show "Check your email" screen with a "I've verified my email" button that polls the new check_signup_payment_state endpoint; on success transitions to Razorpay Checkout, on "still pending" keeps the screen and surfaces a "we haven't received your verification yet" inline error.
   - razorpay_order_id present (legacy / flag-off) -> openCheckout directly, byte-identical to the previous behaviour.

5. test_role_gates: check_signup_payment_state added to the gated- endpoints parametric list so the System Manager + Guest gate stays pinned.

Tests: 5 new in TestSignupEmailVerification covering both response shapes, both poll outcomes (pending + ready), and the admin-URL pre-flight guard. 136 jarvis tests pass.