### PR TITLE
perf(worker): batch assistant-content writes + wrap _handle_event in …

### DIFF
--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -9,6 +9,8 @@ socketio.
 
 from __future__ import annotations
 
+import time
+
 import frappe
 
 from jarvis.chat.events import publish_to_user
@@ -17,6 +19,85 @@ from jarvis.exceptions import OpenclawUnreachableError
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
+
+# Batch-commit thresholds for the assistant-content writes during a
+# streamed turn. Sprint-5 punch-list "Worker writes assistant.content on
+# every delta with full overwrite + commit per token" (2026-06-16
+# review): the previous shape called frappe.db.set_value + frappe.db.
+# commit() for every single token, so a 500-token response = 500
+# write+commit cycles. The DB write itself is cheap (one Singles row);
+# the commit is where the cost lives - it forces a per-token transaction
+# round-trip.
+#
+# Now: buffer the latest cumulative text in memory, flush (write+commit)
+# when EITHER threshold trips, AND flush before any tool/lifecycle event
+# fires so the on-disk message-row order matches the realtime channel.
+# Customer experience stays unchanged - the realtime
+# ``assistant:delta`` publish still fires on every token, so the UI
+# animates token-by-token. The DB just catches up in batches.
+#
+# Numbers picked for the punch-list "every N=10 events or 250ms" ask:
+# at typical chat throughputs (1-50 tokens/s) this means 1-2 commits
+# per second instead of 1-50, but at most ~10 tokens of unwritten
+# content if the worker crashes mid-batch (recoverable next stream).
+_ASSISTANT_BATCH_SIZE = 10
+_ASSISTANT_BATCH_INTERVAL_MS = 250
+
+
+class _AssistantContentBatcher:
+	"""Coalesces per-token assistant-content writes into one DB
+	write+commit per batch.
+
+	Usage:
+	    batcher = _AssistantContentBatcher(assistant_msg.name)
+	    for event in stream:
+	        if event["kind"] == "assistant":
+	            batcher.delta(event["text"])
+	            batcher.flush_if_due()
+	            continue
+	        batcher.flush()  # ordering: flush before any non-delta event
+	        _handle_event(event, ...)
+	    batcher.flush()      # drain on stream end
+	"""
+
+	def __init__(self, msg_name: str):
+		self.msg_name = msg_name
+		self._pending_text: str | None = None
+		self._events_since_flush = 0
+		self._last_flush_ms = self._now_ms()
+
+	@staticmethod
+	def _now_ms() -> int:
+		return int(time.monotonic() * 1000)
+
+	def delta(self, text: str) -> None:
+		"""Record the latest cumulative assistant text. Caller decides
+		when to actually persist via flush / flush_if_due."""
+		self._pending_text = text
+		self._events_since_flush += 1
+
+	def flush_if_due(self) -> bool:
+		"""Flush iff the size or time threshold is hit. Returns True iff
+		a flush actually happened."""
+		if self._pending_text is None:
+			return False
+		if self._events_since_flush >= _ASSISTANT_BATCH_SIZE:
+			return self.flush()
+		if self._now_ms() - self._last_flush_ms >= _ASSISTANT_BATCH_INTERVAL_MS:
+			return self.flush()
+		return False
+
+	def flush(self) -> bool:
+		"""Flush immediately if any text is pending. Returns True iff a
+		flush happened (caller can use this for trace logging)."""
+		if self._pending_text is None:
+			return False
+		frappe.db.set_value(MSG, self.msg_name, "content", self._pending_text)
+		frappe.db.commit()
+		self._pending_text = None
+		self._events_since_flush = 0
+		self._last_flush_ms = self._now_ms()
+		return True
 
 # Provider label → openclaw provider id sent in the chat WS frame.
 #
@@ -132,6 +213,7 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 		try:
 			idem = f"{conversation_id}:{message_id}"
 			tool_msg_by_call_id: dict[str, str] = {}
+			batcher = _AssistantContentBatcher(assistant_msg.name)
 			for event in sess.stream_agent_turn(
 				conv.session_key, user_message, idem,
 				model=effective_model, provider=oauth_provider_id,
@@ -143,7 +225,15 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 					tool_msg_by_call_id=tool_msg_by_call_id,
 					user=user,
 					run_id=run_id,
+					batcher=batcher,
 				)
+			# Drain any buffered assistant deltas before the cleanup
+			# write below stamps streaming=0. The previous shape wrote
+			# every token directly so this drain wasn't needed; the
+			# punch-list batching defers writes, so we explicitly
+			# persist the final cumulative content before the row
+			# transitions out of streaming.
+			batcher.flush()
 		except OpenclawUnreachableError as e:
 			_mark_errored(assistant_msg.name, str(e))
 			publish_to_user(user, {
@@ -230,10 +320,64 @@ def _handle_event(
 	tool_msg_by_call_id: dict[str, str],
 	user: str,
 	run_id: str,
+	batcher: _AssistantContentBatcher,
+) -> None:
+	"""Per-event dispatch. Wrapped in a top-level try/except so a
+	programmer bug on one event (KeyError on a malformed openclaw frame,
+	a DB DoesNotExist on a stale row, etc.) doesn't kill the whole turn
+	and leave the assistant row stranded at streaming=1. Sprint-5
+	punch-list "Wrap _handle_event in try/except logging event kind +
+	tool_call_id + run_id". On failure we log the event metadata and
+	continue - the next event might be a clean recovery (e.g. the
+	turn's final lifecycle.end still flips streaming=0).
+	"""
+	try:
+		_handle_event_inner(
+			event,
+			conversation_id=conversation_id,
+			assistant_msg_name=assistant_msg_name,
+			tool_msg_by_call_id=tool_msg_by_call_id,
+			user=user,
+			run_id=run_id,
+			batcher=batcher,
+		)
+	except Exception:
+		frappe.log_error(
+			title="chat worker: _handle_event failed",
+			message=(
+				f"kind={event.get('kind')!r} "
+				f"phase={event.get('phase')!r} "
+				f"tool_call_id={event.get('tool_call_id')!r} "
+				f"tool_name={event.get('tool_name')!r} "
+				f"run_id={run_id!r} "
+				f"conversation_id={conversation_id!r}\n\n"
+				f"{frappe.get_traceback()}"
+			),
+		)
+		# Don't re-raise; the outer run_agent_turn loop catches Exception
+		# at its outermost layer for the streaming=1 cleanup. Per-event
+		# failures should let the stream continue (the next assistant
+		# delta might overwrite this bad row with good content).
+
+
+def _handle_event_inner(
+	event: dict,
+	*,
+	conversation_id: str,
+	assistant_msg_name: str,
+	tool_msg_by_call_id: dict[str, str],
+	user: str,
+	run_id: str,
+	batcher: _AssistantContentBatcher,
 ) -> None:
 	kind = event.get("kind")
 
 	if kind == "lifecycle":
+		# Lifecycle events bracket the stream. Drain any pending
+		# assistant content before we write the lifecycle outcome so
+		# the on-disk row reflects whatever text was rendered up to
+		# this point (matters mostly for the error branch).
+		batcher.flush()
 		phase = event.get("phase")
 		if phase == "error":
 			_mark_errored(assistant_msg_name, event.get("error") or "lifecycle error")
@@ -249,8 +393,11 @@ def _handle_event(
 
 	if kind == "assistant":
 		text = event.get("text", "")
-		frappe.db.set_value(MSG, assistant_msg_name, "content", text)
-		frappe.db.commit()
+		# Hot path: buffer the cumulative text + maybe-flush. The
+		# realtime publish still fires on every token so the customer's
+		# UI animates without delay; the DB write coalesces.
+		batcher.delta(text)
+		batcher.flush_if_due()
 		publish_to_user(user, {
 			"kind": "assistant:delta",
 			"conversation_id": conversation_id,
@@ -261,6 +408,11 @@ def _handle_event(
 		return
 
 	if kind == "tool":
+		# Tool start/end events insert new rows. Drain pending assistant
+		# content first so the on-disk row order matches the realtime
+		# event order (assistant text the customer saw before this tool
+		# call is durable before the tool row appears).
+		batcher.flush()
 		phase = event.get("phase")
 		tool_call_id = event.get("tool_call_id")
 		tool_name = event.get("tool_name")

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -371,3 +371,251 @@ class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
 		kwargs = fake_sess.stream_agent_turn.call_args.kwargs
 		self.assertEqual(kwargs.get("model"), "claude-sonnet-4-6")
 		self.assertIsNone(kwargs.get("provider"))
+
+
+class TestAssistantContentBatching(FrappeTestCase):
+	"""Sprint-5 punch-list "Worker writes assistant.content on every
+	delta with full overwrite + commit per token" (2026-06-16 review).
+
+	The hot-path optimization buffers assistant-content writes and
+	flushes in batches instead of per-token. End-to-end observability
+	is unchanged - realtime publishes still fire on every token, and
+	the on-disk row holds the FINAL cumulative content at stream end -
+	but the wire shape now coalesces N=10 events or 250ms into one
+	commit, cutting hundreds of write+commit cycles to single digits
+	per turn.
+	"""
+
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_realtime_delta_fires_on_every_token(self):
+		# Customer experience pin: the UI animates token-by-token via
+		# realtime, so every assistant event must still publish an
+		# assistant:delta even though the DB write coalesces.
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "H", "delta": "H"},
+			{"kind": "assistant", "text": "He", "delta": "e"},
+			{"kind": "assistant", "text": "Hel", "delta": "l"},
+			{"kind": "assistant", "text": "Hell", "delta": "l"},
+			{"kind": "assistant", "text": "Hello", "delta": "o"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user") as pub:
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		# Five assistant:delta publishes (one per token), even though
+		# only 1-2 DB commits would have fired under batching.
+		delta_calls = [
+			c for c in pub.call_args_list
+			if c.args[1].get("kind") == "assistant:delta"
+		]
+		self.assertEqual(len(delta_calls), 5)
+		# Final on-disk content is the full cumulative text - the
+		# end-of-stream batcher.flush() persists whatever was buffered.
+		row = frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			["content", "streaming"],
+			as_dict=True,
+		)
+		self.assertEqual(row["content"], "Hello")
+		self.assertEqual(row["streaming"], 0)
+
+	def test_db_writes_coalesce_under_size_threshold(self):
+		# 12 assistant events should produce 1 write at the size
+		# threshold (10) + 1 final drain write = 2 set_value calls on
+		# the assistant row's content. Without batching this would be
+		# 12 set_value + 12 commit pairs.
+		events = [{"kind": "lifecycle", "phase": "start"}]
+		cum = ""
+		for ch in "abcdefghijkl":  # 12 chars
+			cum += ch
+			events.append({"kind": "assistant", "text": cum, "delta": ch})
+		events.append({"kind": "lifecycle", "phase": "end"})
+
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream(events)
+
+		write_calls: list[tuple] = []
+		real_set_value = frappe.db.set_value
+
+		def tracking_set_value(*args, **kwargs):
+			# args[0]=doctype, args[1]=name, args[2]=field or dict
+			if (
+				args
+				and args[0] == MSG
+				and (
+					(len(args) >= 3 and args[2] == "content")
+					or (len(args) >= 3 and isinstance(args[2], dict) and "content" in args[2])
+				)
+			):
+				write_calls.append(args)
+			return real_set_value(*args, **kwargs)
+
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				with patch("frappe.db.set_value", side_effect=tracking_set_value):
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		# At least 1 (the final drain) and at most 2 (size threshold +
+		# drain). Critically NOT 12 - that would mean batching broke
+		# and we're back to per-token commits.
+		self.assertGreaterEqual(len(write_calls), 1)
+		self.assertLessEqual(len(write_calls), 2)
+		# Final on-disk content is the full cumulative text.
+		row = frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			"content",
+		)
+		self.assertEqual(row, "abcdefghijkl")
+
+	def test_tool_event_flushes_pending_assistant_content_first(self):
+		# Ordering pin: a tool event inserts a new row. The assistant
+		# row's pending text must be persisted FIRST so the on-disk
+		# ordering matches the realtime channel (customer sees assistant
+		# text -> tool call). Verify by checking the assistant row's
+		# content immediately after the tool event would have fired.
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "Looking it up", "delta": "Looking it up"},
+			# Tool event fires before the 10-event size threshold;
+			# without the pre-tool flush the assistant row would be
+			# empty until the next assistant delta.
+			{"kind": "tool", "phase": "start", "tool_name": "jarvis__get_list",
+			 "tool_call_id": "tc-1"},
+			{"kind": "tool", "phase": "end", "tool_name": "jarvis__get_list",
+			 "tool_call_id": "tc-1", "status": "completed"},
+			{"kind": "assistant", "text": "Done!", "delta": " Done!"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		# Final cumulative content is the last assistant text. The
+		# important thing is that the tool row got inserted AFTER the
+		# "Looking it up" persist (which we can't directly observe in
+		# this snapshot test, but the ordering invariant means the
+		# final content is the LAST assistant text, not an arbitrary
+		# unflushed earlier one).
+		row = frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			"content",
+		)
+		self.assertEqual(row, "Done!")
+
+	def test_handle_event_failure_is_logged_and_stream_continues(self):
+		# Sprint-5 punch-list "Wrap _handle_event in try/except logging
+		# event kind + tool_call_id + run_id". A malformed event must
+		# not blow up the whole turn - it gets logged via
+		# frappe.log_error, then the next event runs.
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			# A 'tool' end event with no matching start is the cleanest
+			# trigger for an internal log, but we want to assert the
+			# _handle_event try/except path - so inject a guaranteed
+			# raise inside frappe.get_doc to break the tool-start
+			# write path.
+			{"kind": "tool", "phase": "start", "tool_name": "broken",
+			 "tool_call_id": "tc-x"},
+			{"kind": "assistant", "text": "Recovered", "delta": "Recovered"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		# Force the tool-start insert to fail; the assistant event
+		# after it must still land.
+		_orig_get_doc = frappe.get_doc
+
+		def boom_on_tool_msg(*args, **kwargs):
+			if args and isinstance(args[0], dict) and args[0].get("role") == "tool":
+				raise RuntimeError("simulated tool-row insert failure")
+			return _orig_get_doc(*args, **kwargs)
+
+		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				with patch("frappe.get_doc", side_effect=boom_on_tool_msg):
+					with patch("frappe.log_error") as log_err:
+						run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		# The tool-row failure was logged with the event kind + ids.
+		titles = [c.kwargs.get("title", "") for c in log_err.call_args_list]
+		self.assertTrue(
+			any("_handle_event failed" in t for t in titles),
+			f"expected '_handle_event failed' log; got {titles!r}",
+		)
+		# The assistant event AFTER the broken tool event still ran
+		# (stream didn't abort), and the assistant row's final content
+		# reflects the recovery delta.
+		row = frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			"content",
+		)
+		self.assertEqual(row, "Recovered")
+
+
+class TestAssistantContentBatcherUnit(FrappeTestCase):
+	"""Unit-level coverage of _AssistantContentBatcher thresholds."""
+
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+		# Find the assistant placeholder row created by the conversation.
+		self.assistant_name = frappe.get_doc({
+			"doctype": MSG,
+			"conversation": self.conv,
+			"seq": 99,
+			"role": "assistant",
+			"content": "",
+			"streaming": 1,
+		}).insert(ignore_permissions=True).name
+		frappe.db.commit()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_flush_persists_pending_text(self):
+		from jarvis.chat.worker import _AssistantContentBatcher
+		b = _AssistantContentBatcher(self.assistant_name)
+		b.delta("hello")
+		self.assertTrue(b.flush())
+		self.assertEqual(
+			frappe.db.get_value(MSG, self.assistant_name, "content"),
+			"hello",
+		)
+		# Second flush with no new text is a no-op.
+		self.assertFalse(b.flush())
+
+	def test_flush_if_due_respects_size_threshold(self):
+		from jarvis.chat.worker import (
+			_ASSISTANT_BATCH_SIZE,
+			_AssistantContentBatcher,
+		)
+		b = _AssistantContentBatcher(self.assistant_name)
+		# Below the size threshold: no flush (the time threshold is 250ms
+		# which this test runs well under).
+		for i in range(_ASSISTANT_BATCH_SIZE - 1):
+			b.delta(f"text-{i}")
+			self.assertFalse(b.flush_if_due())
+		# Hitting the size threshold flushes.
+		b.delta(f"text-{_ASSISTANT_BATCH_SIZE - 1}")
+		self.assertTrue(b.flush_if_due())
+		# After flush, the next delta starts the counter over.
+		b.delta("post-flush")
+		self.assertFalse(b.flush_if_due())


### PR DESCRIPTION
…try/except

Closes Sprint-5 punch-list "Worker writes assistant.content on every delta with full overwrite + commit per token" (2026-06-16 review). The last open punch-list item.

## Previous shape

run_agent_turn streamed openclaw events one token at a time. The "kind=assistant" branch called frappe.db.set_value(MSG, name, "content", text) followed by frappe.db.commit() for EVERY token. A 500-token response was 500 write+commit cycles. The set_value itself was cheap (one row, indexed by name), but frappe.db.commit() forced a per-token MariaDB transaction round-trip.

The previous shape also had no top-level try/except around _handle_event. A KeyError on a malformed openclaw frame, a DoesNotExist on a stale row, or any other per-event bug would crash the whole turn and leave the assistant row at streaming=1 indefinitely.

## Now

New _AssistantContentBatcher class buffers the latest cumulative text in memory. flush() persists + commits; flush_if_due() flushes only when EITHER threshold trips:
  - _ASSISTANT_BATCH_SIZE = 10 events buffered, OR
  - _ASSISTANT_BATCH_INTERVAL_MS = 250 ms elapsed since last flush.

Ordering invariants the batcher must respect:
  - Tool start / end events insert NEW rows. Flush pending assistant content FIRST so the on-disk row order matches the realtime channel (the customer sees assistant text, then tool call, then more text - the DB must hold the same order).
  - Lifecycle error events stamp _mark_errored on the assistant row. Flush first so the row's content reflects whatever was rendered up to the failure point.
  - End of the stream loop in run_agent_turn calls batcher.flush() to drain whatever's buffered (typically the tail of the response).

Customer experience is unchanged:
  - publish_to_user("assistant:delta", ...) STILL fires on every token. The realtime channel is what the UI animates against; the DB write coalescing only changes how often we flush to disk.
  - At ~1-50 tokens/s typical throughput, this drops commits from 1-50/s to 1-2/s, and at most ~10 tokens (or 250ms) of unwritten content is at risk on a worker crash mid-batch.

## _handle_event try/except wrap

Sprint-5 punch-list "Wrap _handle_event in try/except logging event kind + tool_call_id + run_id" piggybacks on the same PR since both fixes live in the same function. _handle_event is now a thin try/ except wrapper around the new _handle_event_inner. On per-event failure: frappe.log_error with the event metadata (kind, phase, tool_call_id, tool_name, run_id, conversation_id, full traceback) fires, then the loop continues. The next event might be a clean recovery (e.g. another assistant delta overwrites a partially-failed write). The outer run_agent_turn loop still catches Exception at its outermost layer for the streaming=1 cleanup so a fatal error doesn't strand the row.

## Tests

15/15 worker tests pass (was 9). 6 new:

  - test_realtime_delta_fires_on_every_token: 5 assistant events produce 5 publish_to_user calls, regardless of batching.
  - test_db_writes_coalesce_under_size_threshold: 12 assistant events produce 1-2 set_value calls on `content` (was 12).
  - test_tool_event_flushes_pending_assistant_content_first: the ordering pin - tool event between two assistant deltas + the final on-disk content reflects the post-tool delta.
  - test_handle_event_failure_is_logged_and_stream_continues: forcing a tool-start insert failure produces a frappe.log_error with "_handle_event failed" title; the assistant delta AFTER the broken event still lands.
  - test_flush_persists_pending_text: unit pin on the batcher.
  - test_flush_if_due_respects_size_threshold: unit pin on the BATCH_SIZE boundary.

136 jarvis tests pass overall.