### PR TITLE
fix(jarvis-settings): include agent_tools_section + run_query_doctype…

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -40,6 +40,8 @@
     "last_sync_section",
     "last_sync_at",
     "last_sync_status",
+    "agent_tools_section",
+    "run_query_doctype_allowlist",
     "developer_section",
     "sandbox_mode"
   ],


### PR DESCRIPTION
…_allowlist in field_order

Closes a regression introduced in cleanup/run-query-doctype-allowlist (commit 92c201c). That PR added a new Section Break + Small Text field to the Jarvis Settings doctype:

    {fieldname: "agent_tools_section", fieldtype: "Section Break", ...}
    {fieldname: "run_query_doctype_allowlist", fieldtype: "Small Text", ...}

but I only appended them to the ``fields[]`` array. Frappe renders form fields strictly in the order declared by ``field_order``; anything in ``fields[]`` but absent from ``field_order`` is stored in the DB but never shown in the Desk form.

Worse, because the missing ``agent_tools_section`` Section Break sits between ``last_sync_status`` and the next rendered section, every field after it on the same tab disappeared from the form too. The ``Developer / Sandbox`` section (and its ``sandbox_mode`` checkbox) was silently hidden as a result. Operator reported "I couldn't see anything after the last sync section" - exactly this.

Fix: add both fieldnames to ``field_order`` in the right slot (between last_sync_status and developer_section), restoring the visible layout:

    Last Sync section
      last_sync_at
      last_sync_status
    Agent Tool Restrictions section          ← now visible
      run_query_doctype_allowlist            ← now visible
    Developer / Sandbox section              ← now visible again
      sandbox_mode                           ← now visible again

No behaviour change beyond rendering - the underlying DB columns and the field validation logic are unchanged. ``bench migrate`` after pulling this picks up the new field_order on the next form load.