### PR TITLE
cleanup: drop dead api_token branch in start_signup

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -143,13 +143,6 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 	frappe.only_for("System Manager")
 	_require_admin_url()
 	data = _surface(admin_client.signup, email, company, plan)
-	# Persist api_key + api_secret regardless of which response shape we
-	# got - the bench needs them to authenticate to the poll endpoint
-	# during the verification window, and to every subsequent admin call.
-	# Legacy api_token shape kept for backwards compat with older admin
-	# responses (admin moved to native api_key:api_secret in Sprint-1).
-	if data.get("api_token"):
-		write_connection({"api_token": data["api_token"]})
 	if data.get("api_key") or data.get("api_secret"):
 		write_connection({
 			"api_key": data.get("api_key", ""),


### PR DESCRIPTION
admin_client.signup() docstring + admin's signup endpoint both return {api_key, api_secret, razorpay_*}. The api_token branch wired in start_signup never fires; on top of that write_connection silently ignores api_token (covered by test_write_connection_ignores_legacy_api_token).

Punch-list "start_signup writes api_token but write_connection ignores it" from the 2026-06-16 cross-repo review. Aligns with the Sprint-1 sweep that moved the bench to native api_key:api_secret.