### PR TITLE
cleanup: JS pulls subscription catalogue from get_chat_ui_settings

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -65,7 +65,10 @@ def _get_build_id() -> str:
 # Mirrors SUBSCRIPTION_MODELS in jarvis_chat.js / jarvis_account.js /
 # jarvis_onboarding.js; keep all three JS files in sync with the Python
 # catalogue.
-from jarvis._subscription_models import SUBSCRIPTION_MODELS as _SUBSCRIPTION_MODELS
+from jarvis._subscription_models import (
+	DEFAULT_MODEL as _DEFAULT_MODEL,
+	SUBSCRIPTION_MODELS as _SUBSCRIPTION_MODELS,
+)
 
 
 @frappe.whitelist()
@@ -272,11 +275,19 @@ def get_chat_ui_settings() -> dict:
 	for them yet (see spec § Out of scope).
 	"""
 	settings = frappe.get_single("Jarvis Settings")
+	# default_models lets callers (jarvis_onboarding.js,
+	# jarvis_account.js subscription-tab) skip duplicating the
+	# canonical "what's the safe default model id per provider"
+	# table. Together with subscription_models this turns the JS
+	# pages into pure consumers of jarvis/_subscription_models.py.
+	# Punch-list "_SUBSCRIPTION_MODELS duplicated 4-5 times" from
+	# the 2026-06-16 cross-repo review.
 	return {
 		"llm_auth_mode": settings.llm_auth_mode or "api_key",
 		"llm_provider": settings.llm_provider or "",
 		"llm_model": settings.llm_model or "",
 		"subscription_models": _SUBSCRIPTION_MODELS,
+		"default_models": _DEFAULT_MODEL,
 		"build_id": _get_build_id(),
 	}
 

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -53,15 +53,15 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	let settingsLocal = null; // local Jarvis Settings LLM fields snapshot
 
 	// Subscription providers + models (chat-subscription OAuth path).
-	// REV-3: server holds the verifier; UI offers a model picker at start.
-	// Subscription-tier model IDs - these go through codex/gemini-cli's
-	// auth tunnel rather than the standard API, so the valid set is
-	// CLI-specific (not OpenAI/Google's public API model names).
-	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
-	const SUBSCRIPTION_MODELS = {
-		"OpenAI":        ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
-		"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
-	};
+	// Populated by loadInitial() via jarvis.chat.api.get_chat_ui_settings -
+	// the canonical catalogue lives in jarvis/_subscription_models.py, so
+	// the JS side is a pure consumer and never drifts from the Python /
+	// security allowlist (jarvis.oauth.api validates against the same dict).
+	// Until the fetch lands, the maps are empty and renderSubscriptionPanel
+	// renders the loading placeholder. Punch-list "_SUBSCRIPTION_MODELS
+	// duplicated 4-5 times" from the 2026-06-16 cross-repo review.
+	let subscriptionModels = {};
+	let defaultModels = {};
 
 	// AI provider card state.
 	// aiTab follows llm_auth_mode by default; can diverge briefly while
@@ -70,13 +70,11 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const ui = {
 		aiTab: "api_key",
 		subProvider: "OpenAI",
-		// Subscription default MUST be a codex-CLI model (not a standard
-		// API model like "gpt-4o"). The codex auth tunnel rejects
-		// standard-API names, surfacing as a generic
-		// ProviderAuthError "No API key found for provider openai".
-		// Keep in sync with SUBSCRIPTION_MODELS["OpenAI"][0] above +
-		// _DEFAULT_MODEL["OpenAI"] in jarvis/oauth/api.py.
-		subModel: "gpt-5.5",
+		// Populated from defaultModels[subProvider] once
+		// loadInitial fetches the catalogue. Empty until then so a
+		// stale ui.subModel can't sneak into a paste-back signin
+		// before the canonical Python set has been confirmed.
+		subModel: "",
 		subNonce: null,
 		subAuthorizeUrl: null,   // shown to the customer in Screen 2
 		subExpiresAt: null,
@@ -127,9 +125,19 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				return Promise.all([
 					frappe.call({ method: "jarvis.account.get_account" }),
 					frappe.db.get_doc("Jarvis Settings"),
-				]).then(([acc, settings]) => {
+					frappe.call({ method: "jarvis.chat.api.get_chat_ui_settings" }),
+				]).then(([acc, settings, chatUi]) => {
 					account = (acc && acc.message) || {};
 					settingsLocal = settings || {};
+					const cui = (chatUi && chatUi.message) || {};
+					subscriptionModels = cui.subscription_models || {};
+					defaultModels = cui.default_models || {};
+					// First-paint seed: pick the canonical default for the
+					// initial subProvider so render() doesn't show an empty
+					// model dropdown before the user has touched anything.
+					ui.subModel = defaultModels[ui.subProvider]
+						|| (subscriptionModels[ui.subProvider] || [])[0]
+						|| "";
 					ui.aiTab = settingsLocal.llm_auth_mode === "oauth" ? "subscription" : "api_key";
 					// In oauth mode, seed sub-state from the saved provider/model so
 					// a Re-authorize click uses THIS customer's provider (e.g.
@@ -144,10 +152,10 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					// catches this too; this is just so the dropdown + the
 					// "Sign in with ..." button label stay consistent.
 					if (settingsLocal.llm_auth_mode === "oauth") {
-						if (settingsLocal.llm_provider && SUBSCRIPTION_MODELS[settingsLocal.llm_provider]) {
+						if (settingsLocal.llm_provider && subscriptionModels[settingsLocal.llm_provider]) {
 							ui.subProvider = settingsLocal.llm_provider;
 						}
-						const valid = SUBSCRIPTION_MODELS[ui.subProvider] || [];
+						const valid = subscriptionModels[ui.subProvider] || [];
 						if (settingsLocal.llm_model && valid.includes(settingsLocal.llm_model)) {
 							ui.subModel = settingsLocal.llm_model;
 						} else {
@@ -329,10 +337,10 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				</div>`;
 		}
 		// Screen 1 - provider + model picker (not yet started)
-		const provOptions = Object.keys(SUBSCRIPTION_MODELS).map(
+		const provOptions = Object.keys(subscriptionModels).map(
 			(p) => `<option value="${esc(p)}" ${p === ui.subProvider ? "selected" : ""}>${esc(p)}</option>`
 		).join("");
-		const modelOptions = (SUBSCRIPTION_MODELS[ui.subProvider] || []).map(
+		const modelOptions = (subscriptionModels[ui.subProvider] || []).map(
 			(m) => `<option value="${esc(m)}" ${m === ui.subModel ? "selected" : ""}>${esc(m)}</option>`
 		).join("");
 		const dis = editable ? "" : "disabled";
@@ -452,7 +460,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		// Screen 1 wiring
 		$body.find("#ja-sub-provider").on("change", (e) => {
 			ui.subProvider = e.target.value;
-			ui.subModel = (SUBSCRIPTION_MODELS[ui.subProvider] || [])[0] || "";
+			ui.subModel = (subscriptionModels[ui.subProvider] || [])[0] || "";
 			render();
 		});
 		$body.find("#ja-sub-model").on("change", (e) => {

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -29,13 +29,11 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		// step 4 inputs - chat subscription path (REV-3 paste-back)
 		authMode: "api_key", // "api_key" | "subscription"
 		subProvider: "OpenAI",
-		// Subscription default MUST be a codex-CLI model (not a standard
-		// API model like "gpt-4o"). The codex auth tunnel rejects
-		// standard-API names, surfacing as a generic
-		// ProviderAuthError "No API key found for provider openai".
-		// Keep in sync with the first entry of SUBSCRIPTION_MODELS["OpenAI"]
-		// below + _DEFAULT_MODEL["OpenAI"] in jarvis/oauth/api.py.
-		subModel: "gpt-5.5",
+		// Populated from defaultModels[subProvider] once bootRender
+		// fetches the catalogue. Empty until then so a stale value
+		// can't sneak into a paste-back signin before the canonical
+		// Python set has been confirmed.
+		subModel: "",
 		subNonce: null,
 		subAuthorizeUrl: null,   // shown to the customer in Screen 2
 		subExpiresAt: null,
@@ -43,16 +41,17 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		successData: null,
 	};
 
-	// Providers + models for chat-subscription. Mirrors
-	// jarvis.oauth.providers - keep in sync.
-	// Subscription-tier model IDs - these go through codex/gemini-cli's
-	// auth tunnel rather than the standard API, so the valid set is
-	// CLI-specific (not OpenAI/Google's public API model names).
-	// Verified live against ChatGPT-prolite + Gemini Advanced 2026-06-02.
-	const SUBSCRIPTION_MODELS = {
-		"OpenAI":        ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
-		"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
-	};
+	// Providers + models for chat-subscription. Populated by bootRender
+	// via jarvis.chat.api.get_chat_ui_settings - the canonical
+	// catalogue lives in jarvis/_subscription_models.py, so the JS
+	// side is a pure consumer and never drifts from the Python /
+	// security allowlist (jarvis.oauth.api validates against the
+	// same dict). Until the fetch lands the maps are empty and
+	// renderSubscriptionPanel falls through to a "Loading…" state.
+	// Punch-list "_SUBSCRIPTION_MODELS duplicated 4-5 times" from
+	// the 2026-06-16 cross-repo review.
+	let subscriptionModels = {};
+	let defaultModels = {};
 
 	// Default model + baseUrl per provider, surfaced as autofilled hints on step 4.
 	// Customers can override both in the form (and later in Jarvis Settings).
@@ -444,10 +443,10 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 				<div class="jo-hint" id="jo-sub-countdown" style="margin-top:14px;font-size:12px" aria-live="polite">Link valid for ~${minsLeft} minute${minsLeft === 1 ? "" : "s"}.</div>`;
 		}
 		// Screen 1 - provider + model picker (not yet started)
-		const provOptions = Object.keys(SUBSCRIPTION_MODELS).map(
+		const provOptions = Object.keys(subscriptionModels).map(
 			(p) => `<option value="${esc(p)}" ${p === state.subProvider ? "selected" : ""}>${esc(p)}</option>`
 		).join("");
-		const modelOptions = (SUBSCRIPTION_MODELS[state.subProvider] || []).map(
+		const modelOptions = (subscriptionModels[state.subProvider] || []).map(
 			(m) => `<option value="${esc(m)}" ${m === state.subModel ? "selected" : ""}>${esc(m)}</option>`
 		).join("");
 		return `
@@ -468,7 +467,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		// Screen 1 wiring
 		$body.find("#jo-sub-provider").on("change", (e) => {
 			state.subProvider = e.target.value;
-			state.subModel = (SUBSCRIPTION_MODELS[state.subProvider] || [])[0] || "";
+			state.subModel = (subscriptionModels[state.subProvider] || [])[0] || "";
 			renderLlm();
 		});
 		$body.find("#jo-sub-model").on("change", (e) => {
@@ -948,12 +947,34 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 		// card instead of the create-account form. On RPC failure (e.g. site
 		// just spun up, scheduler not running), fall back to the wizard so
 		// the page is never stuck.
-		frappe.call({ method: "jarvis.account.is_onboarded" })
-			.then((r) => {
-				if (r && r.message && r.message.onboarded) renderCompletionCard();
-				else render();
-			})
-			.catch(() => render());
+		//
+		// The chat-ui settings call carries the subscription catalogue +
+		// per-provider defaults (jarvis/_subscription_models.py). Fired
+		// alongside is_onboarded so the picker is populated before the
+		// customer ever lands on the Connect AI step. If it fails (rare;
+		// frappe.call retries 3xx + auth), the maps stay empty and
+		// renderSubscriptionPanel shows the Loading… placeholder, which
+		// is preferable to silently mounting a hardcoded fallback that
+		// could drift from the Python allowlist.
+		Promise.all([
+			frappe.call({ method: "jarvis.account.is_onboarded" }),
+			frappe.call({ method: "jarvis.chat.api.get_chat_ui_settings" })
+				.catch(() => ({ message: {} })),
+		]).then(([onboarded, chatUi]) => {
+			const cui = (chatUi && chatUi.message) || {};
+			subscriptionModels = cui.subscription_models || {};
+			defaultModels = cui.default_models || {};
+			// Seed the default for the initial subProvider so the AI
+			// step doesn't open with an empty model dropdown.
+			state.subModel = defaultModels[state.subProvider]
+				|| (subscriptionModels[state.subProvider] || [])[0]
+				|| "";
+			if (onboarded && onboarded.message && onboarded.message.onboarded) {
+				renderCompletionCard();
+			} else {
+				render();
+			}
+		}).catch(() => render());
 	}
 
 	function renderCompletionCard() {

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -559,6 +559,23 @@ class TestBuildId(FrappeTestCase):
 		self.assertIn("build_id", s)
 		self.assertIsInstance(s["build_id"], str)
 
+	def test_get_chat_ui_settings_exposes_subscription_catalogue(self):
+		# Regression pin for "_SUBSCRIPTION_MODELS duplicated 4-5
+		# times" - the catalogue + per-provider defaults are now
+		# served from the single Python source so jarvis_onboarding.js
+		# and jarvis_account.js can drop their hand-maintained copies.
+		from jarvis.chat.api import get_chat_ui_settings
+		from jarvis._subscription_models import (
+			DEFAULT_MODEL, SUBSCRIPTION_MODELS,
+		)
+		s = get_chat_ui_settings()
+		self.assertEqual(s["subscription_models"], SUBSCRIPTION_MODELS)
+		self.assertEqual(s["default_models"], DEFAULT_MODEL)
+		# Every default must be a member of its provider's allow-list -
+		# protects against a future drift in jarvis/_subscription_models.py.
+		for provider, default in DEFAULT_MODEL.items():
+			self.assertIn(default, SUBSCRIPTION_MODELS[provider])
+
 	def test_build_id_matches_assets_json(self):
 		"""When sites/assets/assets.json exists, build_id is derived from
 		the hashed jarvis_chat.bundle.js filename (no extension)."""


### PR DESCRIPTION
jarvis/_subscription_models.py is already the single Python source for SUBSCRIPTION_MODELS + DEFAULT_MODEL (consumed by chat/api.py and oauth/api.py for the security allowlist). The two customer-facing JS pages (jarvis_onboarding + jarvis_account) still carried their own hand-maintained mirrors of the catalogue + their own hardcoded "first valid model" default, with "Keep in sync" comments pointing at the Python source.

Both pages now fetch the canonical maps from
jarvis.chat.api.get_chat_ui_settings (which already returned subscription_models; extended here with default_models) and use module-level `subscriptionModels` / `defaultModels` consumers. The fetch fires at page boot (alongside is_onboarded / get_account), so the picker is populated before the customer reaches the AI step. On RPC failure the maps stay empty and the panel renders nothing rather than mounting a stale fallback that could drift from the allowlist.

`state.subModel` / `ui.subModel` start as "" and get seeded from the fetched default after boot - prevents a stale hardcoded "gpt-5.5" from sneaking into a paste-back signin if the OpenAI catalogue ever rolls to a different default in Python.

Test plan:
  - test_get_chat_ui_settings_exposes_subscription_catalogue pins the new return shape + asserts every DEFAULT_MODEL value is a member of its provider's allow-list (future-drift guard).
  - All 5 TestBuildId tests pass.
  - Both JS files pass `node --check`.

Punch-list "_SUBSCRIPTION_MODELS duplicated 4-5 times (Python + JS, list vs set)" from the 2026-06-16 cross-repo review.