### PR TITLE
feat(tools): Tier-2a ERPNext computed reads (9 tools)

### DIFF
--- a/jarvis/tests/test_registry.py
+++ b/jarvis/tests/test_registry.py
@@ -24,6 +24,15 @@ class TestRegistry(FrappeTestCase):
                 "download_pdf",
                 "attach_to_doc",
                 "download_vcard",
+                "get_stock_balance",
+                "get_valuation_rate",
+                "scan_barcode",
+                "get_balance_on",
+                "get_customer_outstanding",
+                "get_party_dashboard_info",
+                "get_exchange_rate",
+                "get_fiscal_year",
+                "get_itemised_tax_breakup",
             },
         )
 

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -1,0 +1,290 @@
+"""Validation + envelope tests for the Tier-2a ERPNext computed-read
+tools: get_stock_balance, get_valuation_rate, scan_barcode,
+get_balance_on, get_customer_outstanding, get_party_dashboard_info,
+get_exchange_rate, get_fiscal_year, get_itemised_tax_breakup.
+
+These tools wrap ERPNext helpers that depend on fully-configured
+company / chart-of-accounts / item master / fiscal year records.
+Seeding all of that for unit tests is heavy and brittle (the master-
+data defaults differ across ERPNext releases). The tests here pin
+the boundary contract - arg validation, envelope shape, perm gating -
+by patching:
+
+  - ``frappe.db.exists`` for the existence checks (so tests don't
+    care whether the bench is seeded)
+  - the underlying ERPNext helper itself (so we assert the wrapper
+    forwards args + reshapes the return correctly)
+
+The ERPNext computations themselves are tested upstream.
+"""
+from __future__ import annotations
+
+from datetime import date as _date
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.get_balance_on import get_balance_on
+from jarvis.tools.get_customer_outstanding import get_customer_outstanding
+from jarvis.tools.get_exchange_rate import get_exchange_rate
+from jarvis.tools.get_fiscal_year import get_fiscal_year
+from jarvis.tools.get_itemised_tax_breakup import get_itemised_tax_breakup
+from jarvis.tools.get_party_dashboard_info import get_party_dashboard_info
+from jarvis.tools.get_stock_balance import get_stock_balance
+from jarvis.tools.get_valuation_rate import get_valuation_rate
+from jarvis.tools.scan_barcode import scan_barcode
+
+
+def _all_exist():
+    """Patch ``frappe.db.exists`` to return True for every check.
+
+    Used by happy-path tests where the test doesn't care whether the
+    bench actually has the named master record - only whether the
+    wrapper forwards correct args to the underlying helper.
+    """
+    return patch("frappe.db.exists", return_value=True)
+
+
+def _no_exists():
+    """Inverse of ``_all_exist`` - drives the InvalidArgumentError
+    branches for "unknown <doctype>" without depending on the bench
+    being unseeded."""
+    return patch("frappe.db.exists", return_value=False)
+
+
+def _allow_perm():
+    """Patch ``frappe.has_permission`` to return True so the wrappers
+    don't bail at the perm gate during happy-path envelope tests."""
+    return patch("frappe.has_permission", return_value=True)
+
+
+# ---------------------------------------------------------------------
+# get_stock_balance
+# ---------------------------------------------------------------------
+
+
+class TestGetStockBalance(FrappeTestCase):
+    def test_rejects_empty_item_code(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_stock_balance("", "_T-Warehouse")
+
+    def test_rejects_empty_warehouse(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_stock_balance("_T-Item", "")
+
+    def test_rejects_unknown_item(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            get_stock_balance("Definitely-Not-An-Item", "_T-Warehouse")
+
+    def test_returns_qty_envelope_without_rate(self):
+        with _all_exist(), patch(
+            "erpnext.stock.utils.get_stock_balance", return_value=42.5,
+        ):
+            out = get_stock_balance("_T-Item", "_T-Warehouse")
+        self.assertEqual(out, {"qty": 42.5})
+
+    def test_returns_qty_and_rate_envelope_when_requested(self):
+        with _all_exist(), patch(
+            "erpnext.stock.utils.get_stock_balance", return_value=(42.5, 12.75),
+        ):
+            out = get_stock_balance(
+                "_T-Item", "_T-Warehouse", with_valuation_rate=True,
+            )
+        self.assertEqual(out, {"qty": 42.5, "rate": 12.75})
+
+
+# ---------------------------------------------------------------------
+# get_valuation_rate
+# ---------------------------------------------------------------------
+
+
+class TestGetValuationRate(FrappeTestCase):
+    def test_rejects_empty_item(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_valuation_rate("", "_T-Co")
+
+    def test_rejects_empty_company(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_valuation_rate("_T-Item", "")
+
+    def test_returns_rate_envelope_from_bare_number(self):
+        with _all_exist(), _allow_perm(), patch(
+            "erpnext.stock.get_item_details.get_valuation_rate",
+            return_value=99.5,
+        ):
+            out = get_valuation_rate("_T-Item", "_T-Co")
+        self.assertEqual(out, {"rate": 99.5})
+
+    def test_returns_rate_envelope_from_dict(self):
+        with _all_exist(), _allow_perm(), patch(
+            "erpnext.stock.get_item_details.get_valuation_rate",
+            return_value={"valuation_rate": 88.0},
+        ):
+            out = get_valuation_rate("_T-Item", "_T-Co")
+        self.assertEqual(out, {"rate": 88.0})
+
+
+# ---------------------------------------------------------------------
+# scan_barcode
+# ---------------------------------------------------------------------
+
+
+class TestScanBarcode(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            scan_barcode("")
+
+    def test_returns_dict_envelope_when_helper_returns_dict(self):
+        with patch(
+            "erpnext.stock.utils.scan_barcode",
+            return_value={"item_code": "X", "barcode": "012"},
+        ):
+            out = scan_barcode("012")
+        self.assertEqual(out, {"item_code": "X", "barcode": "012"})
+
+
+# ---------------------------------------------------------------------
+# get_balance_on
+# ---------------------------------------------------------------------
+
+
+class TestGetBalanceOn(FrappeTestCase):
+    def test_rejects_when_no_account_or_party(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_balance_on()
+
+    def test_returns_envelope_for_account_only(self):
+        with _all_exist(), patch(
+            "erpnext.accounts.utils.get_balance_on", return_value=1500.0,
+        ):
+            out = get_balance_on(account="_T-Acct", date="2026-06-18")
+        self.assertEqual(out["balance"], 1500.0)
+        self.assertEqual(out["account"], "_T-Acct")
+        self.assertEqual(out["date"], "2026-06-18")
+
+
+# ---------------------------------------------------------------------
+# get_customer_outstanding
+# ---------------------------------------------------------------------
+
+
+class TestGetCustomerOutstanding(FrappeTestCase):
+    def test_rejects_empty_customer(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_customer_outstanding("", "Any-Co")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "erpnext.selling.doctype.customer.customer.get_customer_outstanding",
+            return_value=2500.0,
+        ):
+            out = get_customer_outstanding("_T-Customer", "_T-Co")
+        self.assertEqual(out["outstanding"], 2500.0)
+        self.assertEqual(out["customer"], "_T-Customer")
+        self.assertEqual(out["company"], "_T-Co")
+
+
+# ---------------------------------------------------------------------
+# get_party_dashboard_info
+# ---------------------------------------------------------------------
+
+
+class TestGetPartyDashboardInfo(FrappeTestCase):
+    def test_rejects_invalid_party_type(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_party_dashboard_info("Employee", "any")
+
+    def test_rejects_empty_party(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_party_dashboard_info("Customer", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "erpnext.accounts.party.get_dashboard_info",
+            return_value=[{"company": "X", "total_unpaid": 100}],
+        ):
+            out = get_party_dashboard_info("Customer", "_T-Customer")
+        self.assertEqual(out["party_type"], "Customer")
+        self.assertEqual(out["party"], "_T-Customer")
+        self.assertEqual(out["dashboard"], [{"company": "X", "total_unpaid": 100}])
+
+
+# ---------------------------------------------------------------------
+# get_exchange_rate
+# ---------------------------------------------------------------------
+
+
+class TestGetExchangeRate(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_exchange_rate("", "INR")
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "erpnext.setup.utils.get_exchange_rate", return_value=83.25,
+        ):
+            out = get_exchange_rate("USD", "INR", "2026-06-18")
+        self.assertEqual(out["rate"], 83.25)
+        self.assertEqual(out["from_currency"], "USD")
+        self.assertEqual(out["to_currency"], "INR")
+        self.assertEqual(out["transaction_date"], "2026-06-18")
+
+
+# ---------------------------------------------------------------------
+# get_fiscal_year
+# ---------------------------------------------------------------------
+
+
+class TestGetFiscalYear(FrappeTestCase):
+    def test_rejects_when_neither_date_nor_fiscal_year(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_fiscal_year()
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "erpnext.accounts.utils.get_fiscal_year",
+            return_value=("FY26", _date(2025, 4, 1), _date(2026, 3, 31)),
+        ):
+            out = get_fiscal_year(date="2025-12-15")
+        self.assertEqual(out["fiscal_year"], "FY26")
+        self.assertEqual(out["year_start_date"], "2025-04-01")
+        self.assertEqual(out["year_end_date"], "2026-03-31")
+
+
+# ---------------------------------------------------------------------
+# get_itemised_tax_breakup
+# ---------------------------------------------------------------------
+
+
+class TestGetItemisedTaxBreakup(FrappeTestCase):
+    def test_rejects_unsupported_doctype(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_itemised_tax_breakup("Address", "x")
+
+    def test_rejects_empty_name(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_itemised_tax_breakup("Sales Invoice", "")
+
+    def test_rejects_unknown_doc(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            get_itemised_tax_breakup("Sales Invoice", "SINV-not-a-real-doc")
+
+    def test_returns_envelope(self):
+        # The wrapper calls frappe.get_doc to load the source; rather
+        # than seed a Sales Invoice (heavy + brittle across releases)
+        # we patch get_doc to return a sentinel and assert
+        # get_itemised_tax was called with it.
+        sentinel_doc = object()
+        with _all_exist(), _allow_perm(), patch(
+            "frappe.get_doc", return_value=sentinel_doc,
+        ), patch(
+            "erpnext.controllers.taxes_and_totals.get_itemised_tax",
+            return_value={"_T-Item": {"VAT - X": 18.0}},
+        ) as git:
+            out = get_itemised_tax_breakup("Sales Invoice", "SINV-001")
+        git.assert_called_once()
+        self.assertIs(git.call_args.args[0], sentinel_doc)
+        self.assertEqual(out["doctype"], "Sales Invoice")
+        self.assertEqual(out["name"], "SINV-001")
+        self.assertEqual(out["itemised_tax"], {"_T-Item": {"VAT - X": 18.0}})

--- a/jarvis/tools/get_balance_on.py
+++ b/jarvis/tools/get_balance_on.py
@@ -1,0 +1,64 @@
+"""GL account balance as of a date, optionally narrowed by party /
+cost-center / finance book.
+
+Wraps ``erpnext.accounts.utils.get_balance_on``. This is the same code
+path that powers ERPNext's General Ledger report, so the answer is
+canonical - including handling for in-account-currency, default finance
+book inclusion, and reverse-charge subtleties an LLM walking GL Entry
+rows by hand will miss.
+
+Permission gating: the underlying helper checks Account read perm
+internally unless ``ignore_account_permission`` is set, which we do
+NOT expose to the agent (callers can't override perm checks).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def get_balance_on(
+    account: str | None = None,
+    date: str | None = None,
+    party_type: str | None = None,
+    party: str | None = None,
+    company: str | None = None,
+    cost_center: str | None = None,
+) -> dict:
+    """Return ``{balance, account, date}`` where ``balance`` is the
+    account balance as of ``date`` (defaults to today).
+
+    Either ``account`` or (``party_type`` + ``party``) must be supplied.
+    Party-only queries return the party's net receivable / payable
+    across all linked GL accounts.
+    """
+    if not account and not (party_type and party):
+        raise InvalidArgumentError(
+            "either account or (party_type + party) is required",
+        )
+    if account and not frappe.db.exists("Account", account):
+        raise InvalidArgumentError(f"unknown Account: {account}")
+    if company and not frappe.db.exists("Company", company):
+        raise InvalidArgumentError(f"unknown Company: {company}")
+    if party and party_type and not frappe.db.exists(party_type, party):
+        raise InvalidArgumentError(f"unknown {party_type}: {party}")
+
+    from erpnext.accounts.utils import get_balance_on as _gbo
+
+    balance = _gbo(
+        account=account,
+        date=date,
+        party_type=party_type,
+        party=party,
+        company=company,
+        cost_center=cost_center,
+    )
+    return {
+        "balance": float(balance or 0),
+        "account": account,
+        "date": date,
+        "party_type": party_type,
+        "party": party,
+        "company": company,
+    }

--- a/jarvis/tools/get_customer_outstanding.py
+++ b/jarvis/tools/get_customer_outstanding.py
@@ -1,0 +1,56 @@
+"""Net outstanding receivable for a customer at a company.
+
+Wraps ``erpnext.selling.doctype.customer.customer.get_customer_outstanding``.
+The underlying helper sums GL entries against the customer's
+receivable accounts and optionally adds open Sales Orders' invoiceable
+balance - the same calculation as the Customer Credit Limit check.
+
+Customer read perm is enforced before delegating so a user who can't
+read the customer can't probe their outstanding balance.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_customer_outstanding(
+    customer: str,
+    company: str,
+    cost_center: str | None = None,
+    ignore_outstanding_sales_order: bool = False,
+) -> dict:
+    """Return ``{outstanding, customer, company}`` where ``outstanding``
+    is the net receivable from ``customer`` at ``company``. If
+    ``ignore_outstanding_sales_order=True``, exclude open Sales Orders
+    from the calculation."""
+    if not customer:
+        raise InvalidArgumentError("customer is required")
+    if not company:
+        raise InvalidArgumentError("company is required")
+    if not frappe.db.exists("Customer", customer):
+        raise InvalidArgumentError(f"unknown Customer: {customer}")
+    if not frappe.db.exists("Company", company):
+        raise InvalidArgumentError(f"unknown Company: {company}")
+    if not frappe.has_permission("Customer", "read", doc=customer):
+        raise PermissionDeniedError(f"no read permission on Customer {customer}")
+
+    from erpnext.selling.doctype.customer.customer import (
+        get_customer_outstanding as _gco,
+    )
+
+    outstanding = _gco(
+        customer=customer,
+        company=company,
+        ignore_outstanding_sales_order=bool(ignore_outstanding_sales_order),
+        cost_center=cost_center,
+    )
+    return {
+        "outstanding": float(outstanding or 0),
+        "customer": customer,
+        "company": company,
+    }

--- a/jarvis/tools/get_exchange_rate.py
+++ b/jarvis/tools/get_exchange_rate.py
@@ -1,0 +1,47 @@
+"""Currency exchange rate as of a date.
+
+Wraps ``erpnext.setup.utils.get_exchange_rate``. The underlying helper
+consults Currency Exchange records first, then optionally fetches a
+live rate from the configured provider. Lets the agent answer
+"what's USD-INR today?" or "convert 1000 GBP to AED for the 2026-01
+fiscal close" without manual lookups.
+
+Read-only. ERPNext's helper rejects unknown currencies internally;
+we surface that as InvalidArgumentError at the boundary.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def get_exchange_rate(
+    from_currency: str,
+    to_currency: str,
+    transaction_date: str | None = None,
+) -> dict:
+    """Return ``{rate, from_currency, to_currency, transaction_date}``
+    for the rate as of ``transaction_date`` (defaults to today)."""
+    if not from_currency:
+        raise InvalidArgumentError("from_currency is required")
+    if not to_currency:
+        raise InvalidArgumentError("to_currency is required")
+    if not frappe.db.exists("Currency", from_currency):
+        raise InvalidArgumentError(f"unknown Currency: {from_currency}")
+    if not frappe.db.exists("Currency", to_currency):
+        raise InvalidArgumentError(f"unknown Currency: {to_currency}")
+
+    from erpnext.setup.utils import get_exchange_rate as _ger
+
+    rate = _ger(
+        from_currency=from_currency,
+        to_currency=to_currency,
+        transaction_date=transaction_date,
+    )
+    return {
+        "rate": float(rate or 0),
+        "from_currency": from_currency,
+        "to_currency": to_currency,
+        "transaction_date": transaction_date,
+    }

--- a/jarvis/tools/get_fiscal_year.py
+++ b/jarvis/tools/get_fiscal_year.py
@@ -1,0 +1,49 @@
+"""Resolve a date (or a fiscal year name) to the matching Fiscal Year
+record for a company, with start / end dates.
+
+Wraps ``erpnext.accounts.utils.get_fiscal_year``. Critical for GL range
+queries the agent composes from natural language ("show me Q3 FY26
+sales"): without this the agent invents fiscal-year boundaries based
+on calendar year, which is wrong for any tenant whose FY isn't
+Jan-Dec.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def get_fiscal_year(
+    date: str | None = None,
+    company: str | None = None,
+    fiscal_year: str | None = None,
+) -> dict:
+    """Return ``{fiscal_year, year_start_date, year_end_date}``.
+
+    Pass ``date`` to resolve "what FY does this date land in?", or
+    ``fiscal_year`` to look the named year up directly. ``company`` is
+    required when multiple FYs overlap for the date (multi-company
+    benches).
+    """
+    if not date and not fiscal_year:
+        raise InvalidArgumentError("either date or fiscal_year is required")
+    if company and not frappe.db.exists("Company", company):
+        raise InvalidArgumentError(f"unknown Company: {company}")
+    if fiscal_year and not frappe.db.exists("Fiscal Year", fiscal_year):
+        raise InvalidArgumentError(f"unknown Fiscal Year: {fiscal_year}")
+
+    from erpnext.accounts.utils import get_fiscal_year as _gfy
+
+    fy_name, year_start_date, year_end_date = _gfy(
+        date=date,
+        fiscal_year=fiscal_year,
+        company=company,
+        verbose=0,  # suppress the UI error helper
+        as_dict=False,
+    )
+    return {
+        "fiscal_year": fy_name,
+        "year_start_date": str(year_start_date) if year_start_date else None,
+        "year_end_date": str(year_end_date) if year_end_date else None,
+    }

--- a/jarvis/tools/get_itemised_tax_breakup.py
+++ b/jarvis/tools/get_itemised_tax_breakup.py
@@ -1,0 +1,52 @@
+"""Per-line-item tax breakup for a Sales / Purchase Invoice.
+
+Wraps ``erpnext.controllers.taxes_and_totals.get_itemised_tax``. That
+function takes a Document object; we accept (doctype, name), load the
+doc with permission checks, then delegate. Returns the same per-item
+tax map the standard ERPNext print formats render in their tax tables.
+
+Useful when the agent is asked to explain "why is the tax on this
+invoice $X?" - the LLM consistently miscomputes by re-applying tax
+rates to the wrong base when it tries to derive from the invoice
+fields alone.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+from jarvis.tools import require_doctype_and_name
+
+_VALID_DOCTYPES = (
+    "Sales Invoice", "Purchase Invoice", "Sales Order", "Purchase Order",
+    "Delivery Note", "Purchase Receipt", "Quotation", "Supplier Quotation",
+)
+
+
+def get_itemised_tax_breakup(doctype: str, name: str) -> dict:
+    """Return ``{doctype, name, itemised_tax}`` where ``itemised_tax``
+    is a map keyed by item code (or item row index) to the per-line
+    tax account contributions.
+    """
+    require_doctype_and_name(doctype, name)
+    if doctype not in _VALID_DOCTYPES:
+        raise InvalidArgumentError(
+            f"doctype must be one of {list(_VALID_DOCTYPES)}",
+        )
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.has_permission(doctype, "read", doc=name):
+        raise PermissionDeniedError(f"no read permission on {doctype} {name}")
+
+    from erpnext.controllers.taxes_and_totals import get_itemised_tax
+
+    doc = frappe.get_doc(doctype, name)
+    itemised_tax = get_itemised_tax(doc, with_tax_account=True)
+    return {
+        "doctype": doctype,
+        "name": name,
+        "itemised_tax": itemised_tax,
+    }

--- a/jarvis/tools/get_party_dashboard_info.py
+++ b/jarvis/tools/get_party_dashboard_info.py
@@ -1,0 +1,54 @@
+"""Per-company sales / billing / payment totals for a Customer or
+Supplier - the same scalar bag that powers the dashboard cards on the
+Customer / Supplier form in Desk.
+
+Wraps ``erpnext.accounts.party.get_dashboard_info``. Useful for
+"give me a quick read on Acme" questions where the agent would
+otherwise have to assemble totals from five different reports.
+
+Tool exposed as ``get_party_dashboard_info`` (more descriptive than the
+underlying ``get_dashboard_info``) so the agent doesn't confuse this
+with any future per-doc dashboard helper.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+_VALID_PARTY_TYPES = ("Customer", "Supplier")
+
+
+def get_party_dashboard_info(
+    party_type: str,
+    party: str,
+    loyalty_program: str | None = None,
+) -> dict:
+    """Return ``{dashboard, party_type, party}`` where ``dashboard`` is
+    the raw per-company list ERPNext renders on the form (each entry
+    has billing_this_year, total_unpaid, currency, etc.).
+    """
+    if party_type not in _VALID_PARTY_TYPES:
+        raise InvalidArgumentError(
+            f"party_type must be one of {list(_VALID_PARTY_TYPES)}",
+        )
+    if not party:
+        raise InvalidArgumentError("party is required")
+    if not frappe.db.exists(party_type, party):
+        raise InvalidArgumentError(f"unknown {party_type}: {party}")
+    if not frappe.has_permission(party_type, "read", doc=party):
+        raise PermissionDeniedError(f"no read permission on {party_type} {party}")
+
+    from erpnext.accounts.party import get_dashboard_info as _gdi
+
+    dashboard = _gdi(
+        party_type=party_type, party=party, loyalty_program=loyalty_program,
+    )
+    return {
+        "dashboard": dashboard,
+        "party_type": party_type,
+        "party": party,
+    }

--- a/jarvis/tools/get_stock_balance.py
+++ b/jarvis/tools/get_stock_balance.py
@@ -1,0 +1,54 @@
+"""Stock quantity for an item at a warehouse as of a given date.
+
+Wraps ``erpnext.stock.utils.get_stock_balance``. That function enforces
+``frappe.has_permission("Item", "read", throw=True)`` internally before
+querying the stock ledger, so this wrapper just translates argument
+shape; permission gating is owned by the underlying ERPNext helper.
+
+This is one of the "computed-truth" reads LLMs hallucinate when forced
+to derive from raw Stock Ledger Entry rows: the right answer depends on
+posting date + valuation method + inventory dimensions, and an agent
+walking the ledger by hand will silently miss in-flight cancellations,
+batch / serial reservations, and FIFO chains.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def get_stock_balance(
+    item_code: str,
+    warehouse: str,
+    posting_date: str | None = None,
+    with_valuation_rate: bool = False,
+) -> dict:
+    """Return current stock for ``item_code`` at ``warehouse``.
+
+    ``posting_date`` defaults to today when omitted. Returns
+    ``{qty}`` by default; with ``with_valuation_rate=True`` returns
+    ``{qty, rate}`` where ``rate`` is the FIFO/moving-average rate
+    ERPNext computes alongside the qty (no extra DB pass).
+    """
+    if not item_code:
+        raise InvalidArgumentError("item_code is required")
+    if not warehouse:
+        raise InvalidArgumentError("warehouse is required")
+    if not frappe.db.exists("Item", item_code):
+        raise InvalidArgumentError(f"unknown Item: {item_code}")
+    if not frappe.db.exists("Warehouse", warehouse):
+        raise InvalidArgumentError(f"unknown Warehouse: {warehouse}")
+
+    from erpnext.stock.utils import get_stock_balance as _gsb
+
+    result = _gsb(
+        item_code=item_code,
+        warehouse=warehouse,
+        posting_date=posting_date,
+        with_valuation_rate=bool(with_valuation_rate),
+    )
+    if with_valuation_rate:
+        qty, rate = result
+        return {"qty": float(qty or 0), "rate": float(rate or 0)}
+    return {"qty": float(result or 0)}

--- a/jarvis/tools/get_valuation_rate.py
+++ b/jarvis/tools/get_valuation_rate.py
@@ -1,0 +1,51 @@
+"""Per-unit valuation rate for an item under a given company /
+warehouse, computed using the company's configured valuation method
+(FIFO / Moving Average / LIFO).
+
+Wraps ``erpnext.stock.get_item_details.get_valuation_rate``. Used by
+margin / costing questions where the LLM keeps trying to derive cost
+basis from arithmetic on Stock Ledger Entry rows; the underlying
+helper applies the company's valuation method correctly and is the
+same code path the standard ERPNext valuation reports use.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_valuation_rate(
+    item_code: str,
+    company: str,
+    warehouse: str | None = None,
+) -> dict:
+    """Return ``{rate}`` where ``rate`` is the valuation rate for
+    ``item_code`` under ``company`` (optionally narrowed to ``warehouse``).
+    """
+    if not item_code:
+        raise InvalidArgumentError("item_code is required")
+    if not company:
+        raise InvalidArgumentError("company is required")
+    if not frappe.db.exists("Item", item_code):
+        raise InvalidArgumentError(f"unknown Item: {item_code}")
+    if not frappe.db.exists("Company", company):
+        raise InvalidArgumentError(f"unknown Company: {company}")
+    if warehouse and not frappe.db.exists("Warehouse", warehouse):
+        raise InvalidArgumentError(f"unknown Warehouse: {warehouse}")
+    if not frappe.has_permission("Item", "read", doc=item_code):
+        raise PermissionDeniedError(f"no read permission on Item {item_code}")
+
+    from erpnext.stock.get_item_details import get_valuation_rate as _gvr
+
+    result = _gvr(item_code=item_code, company=company, warehouse=warehouse)
+    # ERPNext returns a dict {valuation_rate: <float>} or a bare number
+    # depending on the call site; normalise to a single shape.
+    if isinstance(result, dict):
+        rate = result.get("valuation_rate") or 0
+    else:
+        rate = result or 0
+    return {"rate": float(rate)}

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -37,6 +37,18 @@ _TOOL_NAMES: tuple[str, ...] = (
     "download_pdf",
     "attach_to_doc",
     "download_vcard",
+    # Tier 2a ERPNext computed reads: numbers the LLM keeps hallucinating
+    # because they need business-logic-aware math (FIFO/Moving-Avg,
+    # fiscal-year boundaries, party-level GL aggregation).
+    "get_stock_balance",
+    "get_valuation_rate",
+    "scan_barcode",
+    "get_balance_on",
+    "get_customer_outstanding",
+    "get_party_dashboard_info",
+    "get_exchange_rate",
+    "get_fiscal_year",
+    "get_itemised_tax_breakup",
 )
 
 

--- a/jarvis/tools/scan_barcode.py
+++ b/jarvis/tools/scan_barcode.py
@@ -1,0 +1,35 @@
+"""Resolve a barcode (or serial / batch number) to its Item context.
+
+Wraps ``erpnext.stock.utils.scan_barcode``. Used in mobile / kiosk
+workflows where the agent receives a raw scanned value and needs to
+know what item it is, what serial / batch is implied, and what
+warehouse the scan happened in.
+
+Read-only - no DB writes, just a lookup. Permission gating is the
+underlying helper's responsibility (it consults Item / Serial No /
+Batch read perms).
+"""
+from __future__ import annotations
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def scan_barcode(search_value: str) -> dict:
+    """Look ``search_value`` up across Barcode, Serial No, and Batch
+    No tables. Returns whatever ERPNext's resolver finds, typically
+    ``{item_code, barcode, serial_no, batch_no, ...}`` - shape varies
+    by what the scanner matched."""
+    if not search_value:
+        raise InvalidArgumentError("search_value is required")
+
+    from erpnext.stock.utils import scan_barcode as _scan
+
+    result = _scan(search_value=search_value)
+    # The underlying helper returns a typed dataclass (BarcodeScanResult)
+    # or a dict depending on the ERPNext release; normalise to a JSON-
+    # friendly dict either way.
+    if hasattr(result, "__dict__"):
+        return {k: v for k, v in vars(result).items() if not k.startswith("_")}
+    if isinstance(result, dict):
+        return result
+    return {"raw": result}


### PR DESCRIPTION
Nine new read-only tools wrapping ERPNext helpers the LLM keeps hallucinating because the answer needs business-logic-aware math (FIFO/Moving-Avg, fiscal-year boundaries, party-level GL aggregation, tax-account partitioning):

  Stock (4):
    get_stock_balance(item_code, warehouse, posting_date?,
                      with_valuation_rate?)
      -> wraps erpnext.stock.utils.get_stock_balance
    get_valuation_rate(item_code, company, warehouse?)
      -> wraps erpnext.stock.get_item_details.get_valuation_rate
    scan_barcode(search_value)
      -> wraps erpnext.stock.utils.scan_barcode (resolves barcode /
         serial / batch -> item context for mobile/kiosk flows)
    (get_item_details + get_price_list_rate_for deferred to PR-C -
     their ItemDetailsCtx shape needs careful schema work)

  Accounting (5):
    get_balance_on(account?, date?, party_type?, party?, company?,
                   cost_center?)
      -> wraps erpnext.accounts.utils.get_balance_on
    get_customer_outstanding(customer, company, cost_center?,
                             ignore_outstanding_sales_order?)
      -> wraps customer.get_customer_outstanding
    get_party_dashboard_info(party_type, party, loyalty_program?)
      -> wraps party.get_dashboard_info (renamed from
         get_dashboard_info so it's not confused with any future
         per-doc dashboard helper)
    get_exchange_rate(from_currency, to_currency, transaction_date?)
      -> wraps erpnext.setup.utils.get_exchange_rate
    get_fiscal_year(date?, company?, fiscal_year?)
      -> wraps erpnext.accounts.utils.get_fiscal_year (resolves
         dates to FY boundaries the LLM can't invent)
    get_itemised_tax_breakup(doctype, name)
      -> wraps erpnext.controllers.taxes_and_totals.get_itemised_tax
         (loads the source doc with perm check, returns per-item
         tax map)

Registry: 9 new entries in _TOOL_NAMES; test_registry pinned to match.

Tests (+26 in test_tier2a_erpnext_reads.py):
  Validation tests (empty / unknown args) use a small _no_exists
  helper to patch frappe.db.exists so they don't depend on the
  test bench having ERPNext masters seeded.

  Happy-path envelope tests patch BOTH frappe.db.exists AND the
  underlying ERPNext helper. That isolates the test from
  release-specific ERPNext master-data defaults (Item Group / UoM /
  Chart of Accounts vary across versions) while still pinning the
  wrapper's argument-forwarding + return-shape contract.

  26/26 new pass; registry tests pass; full suite green.

Paired with the openclaw-plugin PR that adds 9 typebox schemas + 9 TOOL_DESCRIPTORS + 9 openclaw.plugin.json entries + 9 table-driven test rows. Without the plugin half the agent can list these via run_query but can't call them.