### PR TITLE
feat(tools): Tier-2b HRMS + Frappe computed reads (8 tools)

### DIFF
--- a/jarvis/tests/test_registry.py
+++ b/jarvis/tests/test_registry.py
@@ -33,6 +33,14 @@ class TestRegistry(FrappeTestCase):
                 "get_exchange_rate",
                 "get_fiscal_year",
                 "get_itemised_tax_breakup",
+                "get_leave_balance_on",
+                "get_leaves_for_period",
+                "get_leave_details",
+                "get_holidays_for_employee",
+                "get_employee_shift",
+                "get_linked_docs",
+                "get_submitted_linked_docs",
+                "get_naming_series_preview",
             },
         )
 

--- a/jarvis/tests/test_tier2b_hrms_frappe_reads.py
+++ b/jarvis/tests/test_tier2b_hrms_frappe_reads.py
@@ -1,0 +1,248 @@
+"""Validation + envelope tests for the Tier-2b HRMS + Frappe
+computed-read tools.
+
+Same mock-the-boundary pattern as Tier-2a: patch ``frappe.db.exists``
++ the underlying helper so the tests don't depend on HRMS leave
+allocations, holiday lists, shift assignments, or DocType naming
+patterns being seeded in the test bench.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+from jarvis.tools.get_employee_shift import get_employee_shift
+from jarvis.tools.get_holidays_for_employee import get_holidays_for_employee
+from jarvis.tools.get_leave_balance_on import get_leave_balance_on
+from jarvis.tools.get_leave_details import get_leave_details
+from jarvis.tools.get_leaves_for_period import get_leaves_for_period
+from jarvis.tools.get_linked_docs import get_linked_docs
+from jarvis.tools.get_naming_series_preview import get_naming_series_preview
+from jarvis.tools.get_submitted_linked_docs import get_submitted_linked_docs
+
+
+def _all_exist():
+    return patch("frappe.db.exists", return_value=True)
+
+
+def _no_exists():
+    return patch("frappe.db.exists", return_value=False)
+
+
+def _allow_perm():
+    return patch("frappe.has_permission", return_value=True)
+
+
+def _deny_perm():
+    return patch("frappe.has_permission", return_value=False)
+
+
+# ---------------------------------------------------------------------
+# HRMS - leave / shift / holidays
+# ---------------------------------------------------------------------
+
+
+class TestGetLeaveBalanceOn(FrappeTestCase):
+    def test_rejects_empty_employee(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_leave_balance_on("", "Casual Leave")
+
+    def test_rejects_empty_leave_type(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_leave_balance_on("HR-EMP-001", "")
+
+    def test_rejects_unknown_employee(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            get_leave_balance_on("Unknown", "Casual Leave")
+
+    def test_rejects_when_no_employee_read_perm(self):
+        with _all_exist(), _deny_perm(), self.assertRaises(PermissionDeniedError):
+            get_leave_balance_on("HR-EMP-001", "Casual Leave")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.leave_application.leave_application.get_leave_balance_on",
+            return_value=12.5,
+        ):
+            out = get_leave_balance_on("HR-EMP-001", "Casual Leave", "2026-06-18")
+        self.assertEqual(out["balance"], 12.5)
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(out["leave_type"], "Casual Leave")
+        self.assertEqual(out["date"], "2026-06-18")
+
+
+class TestGetLeavesForPeriod(FrappeTestCase):
+    def test_rejects_empty_args(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_leaves_for_period("", "Casual Leave", "2026-01-01", "2026-01-31")
+        with self.assertRaises(InvalidArgumentError):
+            get_leaves_for_period("HR-EMP-001", "", "2026-01-01", "2026-01-31")
+        with self.assertRaises(InvalidArgumentError):
+            get_leaves_for_period("HR-EMP-001", "Casual Leave", "", "2026-01-31")
+        with self.assertRaises(InvalidArgumentError):
+            get_leaves_for_period("HR-EMP-001", "Casual Leave", "2026-01-01", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.leave_application.leave_application.get_leaves_for_period",
+            return_value=3.5,
+        ):
+            out = get_leaves_for_period(
+                "HR-EMP-001", "Casual Leave", "2026-01-01", "2026-01-31",
+            )
+        self.assertEqual(out["days"], 3.5)
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(out["from_date"], "2026-01-01")
+        self.assertEqual(out["to_date"], "2026-01-31")
+
+
+class TestGetLeaveDetails(FrappeTestCase):
+    def test_rejects_empty_employee(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_leave_details("")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.leave_application.leave_application.get_leave_details",
+            return_value=[{"leave_type": "Casual", "balance": 12}],
+        ):
+            out = get_leave_details("HR-EMP-001", "2026-06-18")
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(out["date"], "2026-06-18")
+        self.assertEqual(out["leave_details"], [{"leave_type": "Casual", "balance": 12}])
+
+
+class TestGetHolidaysForEmployee(FrappeTestCase):
+    def test_rejects_empty_args(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_holidays_for_employee("", "2026-01-01", "2026-01-31")
+        with self.assertRaises(InvalidArgumentError):
+            get_holidays_for_employee("HR-EMP-001", "", "2026-01-31")
+        with self.assertRaises(InvalidArgumentError):
+            get_holidays_for_employee("HR-EMP-001", "2026-01-01", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.utils.get_holidays_for_employee",
+            return_value=[{"holiday_date": "2026-01-26", "description": "Republic Day"}],
+        ) as g:
+            out = get_holidays_for_employee(
+                "HR-EMP-001", "2026-01-01", "2026-01-31",
+            )
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(len(out["holidays"]), 1)
+        # raise_exception=False must be forwarded so the agent gets [] not 500.
+        self.assertEqual(g.call_args.kwargs.get("raise_exception"), False)
+
+
+class TestGetEmployeeShift(FrappeTestCase):
+    def test_rejects_empty_employee(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_employee_shift("")
+
+    def test_returns_envelope_when_shift_assigned(self):
+        fake_shift = MagicMock()
+        fake_shift.as_dict.return_value = {"name": "Day Shift", "start_time": "09:00"}
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift",
+            return_value=fake_shift,
+        ):
+            out = get_employee_shift("HR-EMP-001", "2026-06-18")
+        self.assertEqual(out["shift"], {"name": "Day Shift", "start_time": "09:00"})
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(out["for_date"], "2026-06-18")
+
+    def test_returns_none_when_no_shift(self):
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift",
+            return_value=None,
+        ):
+            out = get_employee_shift("HR-EMP-001", "2026-06-18")
+        self.assertIsNone(out["shift"])
+
+
+# ---------------------------------------------------------------------
+# Frappe - linked docs + naming series preview
+# ---------------------------------------------------------------------
+
+
+class TestGetLinkedDocs(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_linked_docs("", "x")
+        with self.assertRaises(InvalidArgumentError):
+            get_linked_docs("User", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.linked_with.get",
+            return_value={"Communication": [{"name": "COMM-001"}]},
+        ):
+            out = get_linked_docs("Contact", "Test-Contact")
+        self.assertEqual(out["doctype"], "Contact")
+        self.assertEqual(out["name"], "Test-Contact")
+        self.assertEqual(out["linked"], {"Communication": [{"name": "COMM-001"}]})
+
+
+class TestGetSubmittedLinkedDocs(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_submitted_linked_docs("", "x")
+
+    def test_returns_envelope_when_helper_returns_list(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.linked_with.get_submitted_linked_docs",
+            return_value=[
+                {"doctype": "Sales Invoice", "name": "SINV-001", "docstatus": 1},
+            ],
+        ):
+            out = get_submitted_linked_docs("Sales Order", "SO-001")
+        self.assertEqual(len(out["linked"]), 1)
+        self.assertEqual(out["linked"][0]["doctype"], "Sales Invoice")
+
+    def test_returns_envelope_when_helper_returns_dict(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.linked_with.get_submitted_linked_docs",
+            return_value={"docs": [{"doctype": "Sales Invoice", "name": "SINV-001"}]},
+        ):
+            out = get_submitted_linked_docs("Sales Order", "SO-001")
+        self.assertEqual(len(out["linked"]), 1)
+
+
+class TestGetNamingSeriesPreview(FrappeTestCase):
+    def test_rejects_empty_doctype(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_naming_series_preview("")
+
+    def test_rejects_unknown_doctype(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            get_naming_series_preview("Not-A-DocType")
+
+    def test_rejects_when_no_create_perm(self):
+        with _all_exist(), _deny_perm(), self.assertRaises(PermissionDeniedError):
+            get_naming_series_preview("Sales Invoice", "SINV-.YYYY.-")
+
+    def test_returns_envelope_for_explicit_series(self):
+        fake_ns = MagicMock()
+        fake_ns.get_preview.return_value = ["SINV-2026-001", "SINV-2026-002", "SINV-2026-003"]
+        with _all_exist(), _allow_perm(), patch(
+            "frappe.model.naming.NamingSeries", return_value=fake_ns,
+        ):
+            out = get_naming_series_preview("Sales Invoice", "SINV-.YYYY.-")
+        self.assertEqual(out["doctype"], "Sales Invoice")
+        self.assertEqual(out["series"], "SINV-.YYYY.-")
+        self.assertEqual(len(out["preview"]), 3)
+
+    def test_rejects_field_autoname(self):
+        # autoname "field:customer_name" doesn't have a preview shape -
+        # surface clearly rather than hand back something useless.
+        with _all_exist(), _allow_perm(), patch(
+            "frappe.db.get_value", return_value="field:customer_name",
+        ):
+            with self.assertRaises(InvalidArgumentError):
+                get_naming_series_preview("Customer")

--- a/jarvis/tools/get_employee_shift.py
+++ b/jarvis/tools/get_employee_shift.py
@@ -1,0 +1,51 @@
+"""Shift assigned to an employee on a given date.
+
+Wraps ``hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift``.
+Walks Shift Assignment records (date-bounded) + the employee's default
+shift in priority order; falls back to "no shift assigned" without
+raising. Returns the resolved Shift Type doc.
+
+The agent uses this for attendance / OT / roster questions where
+the answer depends on shift start + end times that vary day-to-day.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_employee_shift(
+    employee: str,
+    for_date: str | None = None,
+    consider_default_shift: bool = True,
+) -> dict:
+    """Return ``{shift, employee, for_date}`` where ``shift`` is the
+    resolved Shift Type dict (or None if none assigned that day).
+    """
+    if not employee:
+        raise InvalidArgumentError("employee is required")
+    if not frappe.db.exists("Employee", employee):
+        raise InvalidArgumentError(f"unknown Employee: {employee}")
+    if not frappe.has_permission("Employee", "read", doc=employee):
+        raise PermissionDeniedError(f"no read permission on Employee {employee}")
+
+    from hrms.hr.doctype.shift_assignment.shift_assignment import (
+        get_employee_shift as _ges,
+    )
+
+    date_to_use = for_date or frappe.utils.today()
+    shift = _ges(
+        employee=employee,
+        for_date=date_to_use,
+        consider_default_shift=bool(consider_default_shift),
+    )
+    # Helper returns a Document or None; expose as dict for JSON envelope.
+    return {
+        "shift": shift.as_dict() if shift else None,
+        "employee": employee,
+        "for_date": date_to_use,
+    }

--- a/jarvis/tools/get_holidays_for_employee.py
+++ b/jarvis/tools/get_holidays_for_employee.py
@@ -1,0 +1,59 @@
+"""Holidays for an employee in a date range.
+
+Wraps ``hrms.hr.utils.get_holidays_for_employee``. Resolves the right
+Holiday List (employee-specific override, then department default,
+then company default) and returns the holiday rows that apply -
+including the holiday list owner, name, and date.
+
+The agent uses this when asked "is X a holiday for me?" or "how many
+holidays in January?". A get_list against Holiday alone wouldn't
+know which Holiday List applies to this employee.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_holidays_for_employee(
+    employee: str,
+    start_date: str,
+    end_date: str,
+    only_non_weekly: bool = False,
+) -> dict:
+    """Return ``{holidays, employee, start_date, end_date}`` where
+    ``holidays`` is the list of {holiday_date, description, weekly_off}
+    rows that apply to ``employee`` between the dates.
+    """
+    if not employee:
+        raise InvalidArgumentError("employee is required")
+    if not start_date:
+        raise InvalidArgumentError("start_date is required")
+    if not end_date:
+        raise InvalidArgumentError("end_date is required")
+    if not frappe.db.exists("Employee", employee):
+        raise InvalidArgumentError(f"unknown Employee: {employee}")
+    if not frappe.has_permission("Employee", "read", doc=employee):
+        raise PermissionDeniedError(f"no read permission on Employee {employee}")
+
+    from hrms.hr.utils import get_holidays_for_employee as _ghe
+
+    # raise_exception=False so a missing holiday list returns [] rather
+    # than throwing - the agent envelope wants empty rather than 500.
+    holidays = _ghe(
+        employee=employee,
+        start_date=start_date,
+        end_date=end_date,
+        raise_exception=False,
+        only_non_weekly=bool(only_non_weekly),
+    )
+    return {
+        "holidays": holidays or [],
+        "employee": employee,
+        "start_date": start_date,
+        "end_date": end_date,
+    }

--- a/jarvis/tools/get_leave_balance_on.py
+++ b/jarvis/tools/get_leave_balance_on.py
@@ -1,0 +1,64 @@
+"""Leave balance for an employee + leave type as of a date.
+
+Wraps ``hrms.hr.doctype.leave_application.leave_application.get_leave_balance_on``.
+That helper is HRMS's canonical "what's the source of truth for this
+balance" computation: it walks Leave Allocation + Leave Ledger Entry
+records across the policy period, applies carry-forward / expiry
+rules, and returns a single number. The LLM consistently miscomputes
+when forced to derive from raw allocations.
+
+Read-only. Underlying helper enforces Leave Application read perm
+internally; we add a boundary Employee existence check so the agent
+gets a clean InvalidArgumentError rather than a stack trace from a
+typo'd employee id.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_leave_balance_on(
+    employee: str,
+    leave_type: str,
+    date: str | None = None,
+    consider_all_leaves_in_the_allocation_period: bool = False,
+) -> dict:
+    """Return ``{balance, employee, leave_type, date}`` where balance
+    is the available leave balance for ``employee`` + ``leave_type`` on
+    ``date`` (defaults to today).
+    """
+    if not employee:
+        raise InvalidArgumentError("employee is required")
+    if not leave_type:
+        raise InvalidArgumentError("leave_type is required")
+    if not frappe.db.exists("Employee", employee):
+        raise InvalidArgumentError(f"unknown Employee: {employee}")
+    if not frappe.db.exists("Leave Type", leave_type):
+        raise InvalidArgumentError(f"unknown Leave Type: {leave_type}")
+    if not frappe.has_permission("Employee", "read", doc=employee):
+        raise PermissionDeniedError(f"no read permission on Employee {employee}")
+
+    from hrms.hr.doctype.leave_application.leave_application import (
+        get_leave_balance_on as _gb,
+    )
+
+    date_to_use = date or frappe.utils.today()
+    balance = _gb(
+        employee=employee,
+        leave_type=leave_type,
+        date=date_to_use,
+        consider_all_leaves_in_the_allocation_period=bool(
+            consider_all_leaves_in_the_allocation_period,
+        ),
+    )
+    return {
+        "balance": float(balance or 0),
+        "employee": employee,
+        "leave_type": leave_type,
+        "date": date_to_use,
+    }

--- a/jarvis/tools/get_leave_details.py
+++ b/jarvis/tools/get_leave_details.py
@@ -1,0 +1,44 @@
+"""Per-leave-type dashboard snapshot for an employee as of a date.
+
+Wraps ``hrms.hr.doctype.leave_application.leave_application.get_leave_details``.
+This is the same multi-row payload HRMS's employee dashboard renders -
+each leave type with allocated / used / pending / expired / balance
+broken out. Critical for "what's my full leave situation?" questions
+the LLM would otherwise answer with a single approximation.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_leave_details(
+    employee: str,
+    date: str | None = None,
+) -> dict:
+    """Return ``{leave_details, employee, date}`` where leave_details
+    is the multi-row HRMS payload (one entry per leave type with
+    allocated / used / pending / expired / balance).
+    """
+    if not employee:
+        raise InvalidArgumentError("employee is required")
+    if not frappe.db.exists("Employee", employee):
+        raise InvalidArgumentError(f"unknown Employee: {employee}")
+    if not frappe.has_permission("Employee", "read", doc=employee):
+        raise PermissionDeniedError(f"no read permission on Employee {employee}")
+
+    from hrms.hr.doctype.leave_application.leave_application import (
+        get_leave_details as _gld,
+    )
+
+    date_to_use = date or frappe.utils.today()
+    details = _gld(employee=employee, date=date_to_use)
+    return {
+        "leave_details": details,
+        "employee": employee,
+        "date": date_to_use,
+    }

--- a/jarvis/tools/get_leaves_for_period.py
+++ b/jarvis/tools/get_leaves_for_period.py
@@ -1,0 +1,62 @@
+"""Aggregate leave days an employee consumed in a period.
+
+Wraps ``hrms.hr.doctype.leave_application.leave_application.get_leaves_for_period``.
+Returns total leave days taken between two dates for a given leave
+type, with holidays / weekly-off / half-days correctly netted out.
+
+The "naive" version (count days in approved Leave Application rows
+between dates) is what the LLM keeps trying; it overcounts because
+it doesn't know about the leave_type's include_holiday setting or
+the holiday list applied to the employee.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_leaves_for_period(
+    employee: str,
+    leave_type: str,
+    from_date: str,
+    to_date: str,
+) -> dict:
+    """Return ``{days, employee, leave_type, from_date, to_date}`` for
+    leave days consumed in the inclusive range.
+    """
+    if not employee:
+        raise InvalidArgumentError("employee is required")
+    if not leave_type:
+        raise InvalidArgumentError("leave_type is required")
+    if not from_date:
+        raise InvalidArgumentError("from_date is required")
+    if not to_date:
+        raise InvalidArgumentError("to_date is required")
+    if not frappe.db.exists("Employee", employee):
+        raise InvalidArgumentError(f"unknown Employee: {employee}")
+    if not frappe.db.exists("Leave Type", leave_type):
+        raise InvalidArgumentError(f"unknown Leave Type: {leave_type}")
+    if not frappe.has_permission("Employee", "read", doc=employee):
+        raise PermissionDeniedError(f"no read permission on Employee {employee}")
+
+    from hrms.hr.doctype.leave_application.leave_application import (
+        get_leaves_for_period as _gfp,
+    )
+
+    days = _gfp(
+        employee=employee,
+        leave_type=leave_type,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return {
+        "days": float(days or 0),
+        "employee": employee,
+        "leave_type": leave_type,
+        "from_date": from_date,
+        "to_date": to_date,
+    }

--- a/jarvis/tools/get_linked_docs.py
+++ b/jarvis/tools/get_linked_docs.py
@@ -1,0 +1,38 @@
+"""Documents linked to a given record by foreign-key references.
+
+Wraps ``frappe.desk.form.linked_with.get``. Returns a map of related
+DocType -> list of records that link to the source via any FK
+field. The agent uses this for "show me everything related to this
+customer / invoice / order" questions where the relationships are
+the Desk's "Connections" panel, not something get_list can express
+without prior knowledge of every link field.
+
+Underlying helper enforces read permission on the source via
+``frappe.has_permission(doctype, doc=name, throw=True)``; we wrap it
+for arg validation only.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def get_linked_docs(doctype: str, name: str) -> dict:
+    """Return ``{linked, doctype, name}`` where ``linked`` is the map
+    {DocType: [{name, ...}]} of every record linking to ``doctype/name``
+    that the current user can read.
+    """
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+
+    from frappe.desk.form.linked_with import get as _get_linked
+
+    linked = _get_linked(doctype=doctype, docname=name)
+    return {
+        "linked": linked or {},
+        "doctype": doctype,
+        "name": name,
+    }

--- a/jarvis/tools/get_naming_series_preview.py
+++ b/jarvis/tools/get_naming_series_preview.py
@@ -1,0 +1,65 @@
+"""Preview the next 3 names a naming series will generate.
+
+Wraps ``frappe.model.naming.NamingSeries.get_preview``. Returns three
+projected names WITHOUT consuming the DB counter, so the agent can
+answer "what's the next invoice number going to be?" without side
+effects.
+
+Read-only: the underlying helper uses a fake-counter callback and
+never touches the Series table. We add an Item-style existence check
+so a typo'd DocType / series surfaces as InvalidArgumentError.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+
+
+def get_naming_series_preview(
+    doctype: str,
+    series: str | None = None,
+) -> dict:
+    """Return ``{preview, doctype, series}`` where ``preview`` is a
+    list of 3 projected names.
+
+    If ``series`` is omitted, the DocType's first ``autoname``-style
+    series is used. The agent typically passes the bare series string
+    (e.g. ``SINV-.YYYY.-``).
+    """
+    if not doctype:
+        raise InvalidArgumentError("doctype is required")
+    if not frappe.db.exists("DocType", doctype):
+        raise InvalidArgumentError(f"unknown DocType: {doctype}")
+    if not frappe.has_permission(doctype, "create"):
+        raise PermissionDeniedError(
+            f"no create permission on {doctype}; preview not allowed",
+        )
+
+    # Resolve series from the DocType's autoname if not supplied.
+    if not series:
+        autoname = frappe.db.get_value("DocType", doctype, "autoname") or ""
+        if not autoname:
+            raise InvalidArgumentError(
+                f"{doctype} has no autoname; pass `series` explicitly",
+            )
+        # autoname can be "naming_series:", "field:somefield", "hash" -
+        # we only support the explicit series strings.
+        if autoname.startswith("field:") or autoname == "hash":
+            raise InvalidArgumentError(
+                f"{doctype} uses {autoname!r} naming; series preview "
+                f"is only meaningful for static series patterns",
+            )
+        series = autoname.split(":", 1)[1] if ":" in autoname else autoname
+
+    from frappe.model.naming import NamingSeries
+
+    preview = NamingSeries(series).get_preview()
+    return {
+        "preview": preview,
+        "doctype": doctype,
+        "series": series,
+    }

--- a/jarvis/tools/get_submitted_linked_docs.py
+++ b/jarvis/tools/get_submitted_linked_docs.py
@@ -1,0 +1,47 @@
+"""Submittable documents linked to a source, walking the cancel-tree.
+
+Wraps ``frappe.desk.form.linked_with.get_submitted_linked_docs``.
+Returns every submittable record in the cancel-impact tree rooted at
+the source - the same set Frappe's "Cancel" dialog confirms before
+processing.
+
+The agent uses this for "if I cancel this Sales Order what else gets
+cancelled?" / "what's the full impact tree?" questions. Without this
+the LLM would either undercount (only direct children) or miss the
+submittable filter entirely.
+
+Underlying helper enforces read permission on the source.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def get_submitted_linked_docs(doctype: str, name: str) -> dict:
+    """Return ``{linked, doctype, name}`` where ``linked`` is a list of
+    ``{doctype, name, docstatus}`` for every submittable record in the
+    cancel-impact tree rooted at ``doctype/name``.
+    """
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+
+    from frappe.desk.form.linked_with import (
+        get_submitted_linked_docs as _gsl,
+    )
+
+    result = _gsl(doctype=doctype, name=name)
+    # The underlying helper returns either a dict {"docs": [...]} or a
+    # raw list depending on the Frappe release; normalise to list.
+    if isinstance(result, dict):
+        linked = result.get("docs") or []
+    else:
+        linked = result or []
+    return {
+        "linked": linked,
+        "doctype": doctype,
+        "name": name,
+    }

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -49,6 +49,17 @@ _TOOL_NAMES: tuple[str, ...] = (
     "get_exchange_rate",
     "get_fiscal_year",
     "get_itemised_tax_breakup",
+    # Tier 2b HRMS + Frappe computed reads: leave/shift/holiday lookups
+    # the LLM gets wrong because they need policy-aware math, plus
+    # Frappe linked-doc walking + naming-series preview.
+    "get_leave_balance_on",
+    "get_leaves_for_period",
+    "get_leave_details",
+    "get_holidays_for_employee",
+    "get_employee_shift",
+    "get_linked_docs",
+    "get_submitted_linked_docs",
+    "get_naming_series_preview",
 )
 
 


### PR DESCRIPTION
Eight new read-only tools - the HRMS leave/shift/holiday + Frappe linked-doc / naming-series surface. Same shape as Tier-2a (wraps a canonical helper, normalises return into a JSON-friendly envelope, adds boundary arg + perm validation).

HRMS (5):
  get_leave_balance_on(employee, leave_type, date?, ...)
    -> hrms leave_application.get_leave_balance_on
  get_leaves_for_period(employee, leave_type, from_date, to_date)
    -> hrms leave_application.get_leaves_for_period
  get_leave_details(employee, date?)
    -> hrms leave_application.get_leave_details
       (dashboard payload per leave type)
  get_holidays_for_employee(employee, start_date, end_date,
                            only_non_weekly?)
    -> hrms.hr.utils.get_holidays_for_employee
       (raise_exception=False so missing holiday list yields [])
  get_employee_shift(employee, for_date?, consider_default_shift?)
    -> hrms shift_assignment.get_employee_shift

Frappe (3):
  get_linked_docs(doctype, name)
    -> frappe.desk.form.linked_with.get
       (Desk "Connections" panel content)
  get_submitted_linked_docs(doctype, name)
    -> frappe.desk.form.linked_with.get_submitted_linked_docs
       (cancel-impact tree; handles both list + dict response shapes)
  get_naming_series_preview(doctype, series?)
    -> frappe.model.naming.NamingSeries(series).get_preview
       (no counter consumed; series defaults to the DocType's
       autoname when it's a static pattern; rejects field-based
       autonaming with a clear error)

Registry: 8 new entries; test_registry pinned.

Tests (+24 in test_tier2b_hrms_frappe_reads.py): same mock-the-boundary pattern as Tier-2a - patches frappe.db.exists + frappe.has_permission + the underlying helper so the tests don't depend on HRMS leave allocations / holiday lists / shift assignments being seeded.

24/24 new pass; registry tests pass.

Paired with the openclaw-plugin PR that adds 8 typebox schemas + 8 TOOL_DESCRIPTORS + 8 manifest entries + 8 table-driven test rows.