### PR TITLE
feat(tools): Tier-3 desk-mirror actions (11 tools)

### DIFF
--- a/jarvis/tests/test_registry.py
+++ b/jarvis/tests/test_registry.py
@@ -41,6 +41,17 @@ class TestRegistry(FrappeTestCase):
                 "get_linked_docs",
                 "get_submitted_linked_docs",
                 "get_naming_series_preview",
+                "send_email",
+                "add_comment",
+                "update_comment",
+                "share_doc",
+                "unshare_doc",
+                "assign_to",
+                "unassign_from",
+                "add_tag",
+                "remove_tag",
+                "follow_document",
+                "unfollow_document",
             },
         )
 

--- a/jarvis/tests/test_tier3_desk_actions.py
+++ b/jarvis/tests/test_tier3_desk_actions.py
@@ -1,0 +1,312 @@
+"""Validation + envelope tests for the Tier-3 desk-mirror action tools.
+
+Each tool fires a side effect (sends mail, writes a Comment, opens a
+DocShare row, creates a ToDo, mutates _user_tags, etc.). The tests
+here mock the underlying Frappe helper so the asserts are about
+- argument validation
+- permission gating
+- envelope shape
+- the wrapper forwarding the right kwargs
+
+without firing real emails / mutating shared bench state.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+from jarvis.tools.add_comment import add_comment
+from jarvis.tools.add_tag import add_tag
+from jarvis.tools.assign_to import assign_to
+from jarvis.tools.follow_document import follow_document
+from jarvis.tools.remove_tag import remove_tag
+from jarvis.tools.send_email import send_email
+from jarvis.tools.share_doc import share_doc
+from jarvis.tools.unassign_from import unassign_from
+from jarvis.tools.unfollow_document import unfollow_document
+from jarvis.tools.unshare_doc import unshare_doc
+from jarvis.tools.update_comment import update_comment
+
+
+def _all_exist():
+    return patch("frappe.db.exists", return_value=True)
+
+
+def _no_exists():
+    return patch("frappe.db.exists", return_value=False)
+
+
+def _allow_perm():
+    return patch("frappe.has_permission", return_value=True)
+
+
+def _deny_perm():
+    return patch("frappe.has_permission", return_value=False)
+
+
+# ---------------------------------------------------------------------
+# send_email
+# ---------------------------------------------------------------------
+
+
+class TestSendEmail(FrappeTestCase):
+    def test_rejects_missing_args(self):
+        with self.assertRaises(InvalidArgumentError):
+            send_email("", "Subj", "Body", "User", "x")
+        with self.assertRaises(InvalidArgumentError):
+            send_email("to@x.com", "", "Body", "User", "x")
+        with self.assertRaises(InvalidArgumentError):
+            send_email("to@x.com", "Subj", "", "User", "x")
+        with self.assertRaises(InvalidArgumentError):
+            send_email("to@x.com", "Subj", "Body", "", "x")
+
+    def test_rejects_unknown_reference_doc(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            send_email("to@x.com", "Subj", "Body", "User", "Unknown")
+
+    def test_returns_envelope_and_forwards_send_email_true(self):
+        with _all_exist(), patch(
+            "frappe.core.doctype.communication.email.make",
+            return_value={"name": "COMM-X-001"},
+        ) as mk:
+            out = send_email(
+                "to@example.com", "Hello", "<p>Hi</p>",
+                "User", "test@example.com", cc=["cc@x.com"],
+            )
+        # The wrapper must always force send_email=True; otherwise
+        # the call would silently log a Communication without sending.
+        self.assertIs(mk.call_args.kwargs.get("send_email"), True)
+        self.assertEqual(out["communication_name"], "COMM-X-001")
+        self.assertEqual(out["subject"], "Hello")
+
+
+# ---------------------------------------------------------------------
+# add_comment / update_comment
+# ---------------------------------------------------------------------
+
+
+class TestAddComment(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            add_comment("", "x", "body")
+        with self.assertRaises(InvalidArgumentError):
+            add_comment("User", "x", "")
+
+    def test_rejects_unknown_doc(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            add_comment("User", "missing", "body")
+
+    def test_forwards_session_user_as_comment_author(self):
+        fake_comment = MagicMock()
+        fake_comment.name = "Comment-001"
+        with _all_exist(), patch(
+            "frappe.desk.form.utils.add_comment", return_value=fake_comment,
+        ) as ac, patch(
+            "frappe.db.get_value", return_value="Admin User",
+        ):
+            out = add_comment("User", "test@example.com", "Hello")
+        # The agent doesn't specify "who" - the wrapper must pull
+        # the session user and forward it as both comment_email +
+        # the resolved full_name as comment_by.
+        self.assertIn(
+            "comment_email", ac.call_args.kwargs,
+        )
+        self.assertEqual(out["comment_name"], "Comment-001")
+
+
+class TestUpdateComment(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            update_comment("", "body")
+        with self.assertRaises(InvalidArgumentError):
+            update_comment("Comment-001", "")
+
+    def test_rejects_unknown_comment(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            update_comment("Comment-Not-Real", "body")
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.utils.update_comment",
+        ) as uc:
+            out = update_comment("Comment-001", "new body")
+        uc.assert_called_once()
+        self.assertEqual(out, {"comment_name": "Comment-001", "content": "new body"})
+
+
+# ---------------------------------------------------------------------
+# share_doc / unshare_doc
+# ---------------------------------------------------------------------
+
+
+class TestShareDoc(FrappeTestCase):
+    def test_rejects_when_no_user_and_not_everyone(self):
+        with _all_exist():
+            with self.assertRaises(InvalidArgumentError):
+                share_doc("User", "test@example.com")
+
+    def test_rejects_unknown_doc(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            share_doc("User", "missing", user="someone@x.com")
+
+    def test_returns_envelope_and_forwards_perms(self):
+        with _all_exist(), patch(
+            "frappe.share.add",
+        ) as sa:
+            out = share_doc(
+                "User", "test@example.com",
+                user="other@example.com",
+                read=True, write=True, share=False,
+            )
+        sa.assert_called_once()
+        self.assertEqual(sa.call_args.kwargs.get("read"), 1)
+        self.assertEqual(sa.call_args.kwargs.get("write"), 1)
+        self.assertEqual(sa.call_args.kwargs.get("share"), 0)
+        self.assertTrue(out["read"])
+
+    def test_supports_everyone_without_user(self):
+        with _all_exist(), patch(
+            "frappe.share.add",
+        ):
+            out = share_doc("User", "test@example.com", everyone=True)
+        self.assertTrue(out["everyone"])
+
+
+class TestUnshareDoc(FrappeTestCase):
+    def test_rejects_empty_user(self):
+        with self.assertRaises(InvalidArgumentError):
+            unshare_doc("User", "test@example.com", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch("frappe.share.remove") as rm:
+            out = unshare_doc("User", "test@example.com", "other@x.com")
+        rm.assert_called_once()
+        self.assertEqual(out["user"], "other@x.com")
+
+
+# ---------------------------------------------------------------------
+# assign_to / unassign_from
+# ---------------------------------------------------------------------
+
+
+class TestAssignTo(FrappeTestCase):
+    def test_rejects_empty_user(self):
+        with self.assertRaises(InvalidArgumentError):
+            assign_to("User", "test@example.com", "")
+
+    def test_forwards_assign_to_as_list(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.assign_to.add",
+        ) as ad:
+            out = assign_to(
+                "User", "test@example.com", "other@example.com",
+                description="follow up", notify=False,
+            )
+        ad.assert_called_once()
+        args = ad.call_args.args[0]
+        self.assertEqual(args["assign_to"], ["other@example.com"])
+        self.assertEqual(args["doctype"], "User")
+        self.assertEqual(args["name"], "test@example.com")
+        self.assertEqual(args["notify"], 0)
+        self.assertEqual(out["user"], "other@example.com")
+
+
+class TestUnassignFrom(FrappeTestCase):
+    def test_rejects_empty_user(self):
+        with self.assertRaises(InvalidArgumentError):
+            unassign_from("User", "test@example.com", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.assign_to.remove",
+        ) as rm:
+            out = unassign_from("User", "test@example.com", "other@x.com")
+        rm.assert_called_once()
+        self.assertEqual(out["user"], "other@x.com")
+
+
+# ---------------------------------------------------------------------
+# add_tag / remove_tag
+# ---------------------------------------------------------------------
+
+
+class TestAddTag(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            add_tag("User", "test@example.com", "")
+
+    def test_rejects_when_no_write_perm(self):
+        with _all_exist(), _deny_perm(), self.assertRaises(PermissionDeniedError):
+            add_tag("User", "test@example.com", "urgent")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "frappe.desk.doctype.tag.tag.add_tag",
+        ) as at:
+            out = add_tag("User", "test@example.com", "urgent", color="#ff0000")
+        at.assert_called_once()
+        self.assertEqual(at.call_args.kwargs.get("tag"), "urgent")
+        self.assertEqual(at.call_args.kwargs.get("color"), "#ff0000")
+        self.assertEqual(out["tag"], "urgent")
+
+
+class TestRemoveTag(FrappeTestCase):
+    def test_rejects_empty(self):
+        with self.assertRaises(InvalidArgumentError):
+            remove_tag("User", "test@example.com", "")
+
+    def test_returns_envelope(self):
+        with _all_exist(), _allow_perm(), patch(
+            "frappe.desk.doctype.tag.tag.remove_tag",
+        ) as rt:
+            out = remove_tag("User", "test@example.com", "urgent")
+        rt.assert_called_once()
+        self.assertEqual(out["tag"], "urgent")
+
+
+# ---------------------------------------------------------------------
+# follow_document / unfollow_document
+# ---------------------------------------------------------------------
+
+
+class TestFollowDocument(FrappeTestCase):
+    def test_rejects_unknown_doc(self):
+        with _no_exists(), self.assertRaises(InvalidArgumentError):
+            follow_document("User", "missing")
+
+    def test_defaults_to_session_user(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.document_follow.follow_document",
+            return_value=True,
+        ) as f:
+            out = follow_document("User", "test@example.com")
+        # No `user` passed -> wrapper falls back to session.user
+        self.assertIsNotNone(out["user"])
+        self.assertTrue(out["followed"])
+        # The underlying helper receives the session user verbatim.
+        self.assertEqual(f.call_args.kwargs.get("user"), out["user"])
+
+    def test_accepts_explicit_user(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.document_follow.follow_document",
+            return_value=True,
+        ):
+            out = follow_document(
+                "User", "test@example.com", user="other@example.com",
+            )
+        self.assertEqual(out["user"], "other@example.com")
+
+
+class TestUnfollowDocument(FrappeTestCase):
+    def test_returns_envelope(self):
+        with _all_exist(), patch(
+            "frappe.desk.form.document_follow.unfollow_document",
+            return_value=True,
+        ):
+            out = unfollow_document("User", "test@example.com")
+        self.assertTrue(out["unfollowed"])

--- a/jarvis/tools/add_comment.py
+++ b/jarvis/tools/add_comment.py
@@ -1,0 +1,55 @@
+"""Add a comment to any document.
+
+Wraps ``frappe.desk.form.utils.add_comment``. ``comment_email`` and
+``comment_by`` are auto-populated from the session user so the agent
+doesn't have to specify "who" the comment is from.
+
+Comment is distinct from Communication: a Comment is a free-form note
+attached to the doc's timeline (no email side-effect); a Communication
+is the structured audit row for emails / phone / SMS. The agent picks
+based on intent - "add a note" -> add_comment, "email the customer" ->
+send_email.
+
+Permission: ``add_comment`` requires read perm on the reference doc;
+the underlying helper enforces this via
+``frappe.get_lazy_doc(..., check_permission=True)``.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def add_comment(doctype: str, name: str, content: str) -> dict:
+    """Add a Comment to ``doctype/name`` with ``content`` as the body.
+
+    Returns ``{comment_name, doctype, name, content}`` where
+    ``comment_name`` is the new Comment doc id (so a follow-up
+    update_comment can target it).
+    """
+    require_doctype_and_name(doctype, name)
+    if content is None or content == "":
+        raise InvalidArgumentError("content is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+
+    from frappe.desk.form.utils import add_comment as _ac
+
+    session_user = frappe.session.user
+    user_full_name = frappe.db.get_value("User", session_user, "full_name") or session_user
+
+    comment = _ac(
+        reference_doctype=doctype,
+        reference_name=name,
+        content=content,
+        comment_email=session_user,
+        comment_by=user_full_name,
+    )
+    return {
+        "comment_name": comment.name if comment else None,
+        "doctype": doctype,
+        "name": name,
+        "content": content,
+    }

--- a/jarvis/tools/add_tag.py
+++ b/jarvis/tools/add_tag.py
@@ -1,0 +1,44 @@
+"""Tag a document for categorisation.
+
+Wraps ``frappe.desk.doctype.tag.tag.add_tag``. Tags are free-form
+labels that show up in the Desk list filters; the agent can use them
+to bucket records (e.g. tag a Sales Order as 'urgent', tag a Customer
+as 'follow-up').
+
+Permission: ``add_tag`` requires write permission on the target doc
+(implicitly: it modifies the doc's ``_user_tags`` field).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+from jarvis.tools import require_doctype_and_name
+
+
+def add_tag(
+    doctype: str,
+    name: str,
+    tag: str,
+    color: str | None = None,
+) -> dict:
+    """Add ``tag`` to ``doctype/name``. ``color`` is an optional hex
+    code (e.g. ``#ff0000``) for the Tag record. Returns
+    ``{doctype, name, tag}``."""
+    require_doctype_and_name(doctype, name)
+    if not tag:
+        raise InvalidArgumentError("tag is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.has_permission(doctype, "write", doc=name):
+        raise PermissionDeniedError(
+            f"no write permission on {doctype} {name}",
+        )
+
+    from frappe.desk.doctype.tag.tag import add_tag as _at
+
+    _at(tag=tag, dt=doctype, dn=name, color=color)
+    return {"doctype": doctype, "name": name, "tag": tag}

--- a/jarvis/tools/assign_to.py
+++ b/jarvis/tools/assign_to.py
@@ -1,0 +1,64 @@
+"""Create a ToDo + assign a user to a document.
+
+Wraps ``frappe.desk.form.assign_to.add``. The underlying helper takes a
+single ``args`` dict (Frappe's idiomatic form-bag shape); we accept
+typed arguments and pack into the dict so the agent has a clean
+signature.
+
+Side-effects beyond the ToDo row: assignment auto-shares the
+referenced document with the assignee (so they can read it) AND fires
+a "you've been assigned" notification email by default.
+
+ALWAYS-CONFIRM: a person gets a notification email.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def assign_to(
+    doctype: str,
+    name: str,
+    user: str,
+    description: str | None = None,
+    notify: bool = True,
+    priority: str | None = None,
+    date: str | None = None,
+) -> dict:
+    """Open a ToDo for ``user`` assigned to ``doctype/name``. Returns
+    ``{doctype, name, user, description, notify, priority, date}``."""
+    require_doctype_and_name(doctype, name)
+    if not user:
+        raise InvalidArgumentError("user is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.desk.form.assign_to import add as _assign_add
+
+    args = {
+        "doctype": doctype,
+        "name": name,
+        "assign_to": [user],
+        "description": description or "",
+        "notify": int(bool(notify)),
+    }
+    if priority:
+        args["priority"] = priority
+    if date:
+        args["date"] = date
+
+    _assign_add(args)
+    return {
+        "doctype": doctype,
+        "name": name,
+        "user": user,
+        "description": description,
+        "notify": bool(notify),
+        "priority": priority,
+        "date": date,
+    }

--- a/jarvis/tools/follow_document.py
+++ b/jarvis/tools/follow_document.py
@@ -1,0 +1,45 @@
+"""Subscribe a user to a document's change events.
+
+Wraps ``frappe.desk.form.document_follow.follow_document``. A
+followed doc fires the Document Follow notification email to the
+subscriber on every modification - the agent uses this for "let me
+know when X changes" / "subscribe X to this Customer" flows.
+
+By default ``user`` is the session user, so the agent can follow a
+doc on behalf of the customer without naming them.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def follow_document(
+    doctype: str,
+    name: str,
+    user: str | None = None,
+) -> dict:
+    """Subscribe ``user`` (or the session user) to ``doctype/name``.
+    Returns ``{doctype, name, user, followed}`` where ``followed`` is
+    True on the wire path that actually inserted a follow row, False
+    when the doc was already being followed (idempotent)."""
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    target_user = user or frappe.session.user
+    if user and not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.desk.form.document_follow import (
+        follow_document as _follow,
+    )
+
+    result = _follow(doctype=doctype, doc_name=name, user=target_user)
+    return {
+        "doctype": doctype,
+        "name": name,
+        "user": target_user,
+        "followed": bool(result),
+    }

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -60,6 +60,21 @@ _TOOL_NAMES: tuple[str, ...] = (
     "get_linked_docs",
     "get_submitted_linked_docs",
     "get_naming_series_preview",
+    # Tier 3 desk-mirror actions: parity with the buttons a Desk user
+    # can click - email, comment, share, assign, tag, follow. All
+    # mutating; descriptors in tool-defs.ts carry ALWAYS-CONFIRM
+    # language for the side-effectful ones.
+    "send_email",
+    "add_comment",
+    "update_comment",
+    "share_doc",
+    "unshare_doc",
+    "assign_to",
+    "unassign_from",
+    "add_tag",
+    "remove_tag",
+    "follow_document",
+    "unfollow_document",
 )
 
 

--- a/jarvis/tools/remove_tag.py
+++ b/jarvis/tools/remove_tag.py
@@ -1,0 +1,33 @@
+"""Remove a tag from a document.
+
+Wraps ``frappe.desk.doctype.tag.tag.remove_tag``. No-op when the tag
+isn't on the doc (idempotent).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+)
+from jarvis.tools import require_doctype_and_name
+
+
+def remove_tag(doctype: str, name: str, tag: str) -> dict:
+    """Remove ``tag`` from ``doctype/name``. Returns
+    ``{doctype, name, tag}``."""
+    require_doctype_and_name(doctype, name)
+    if not tag:
+        raise InvalidArgumentError("tag is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.has_permission(doctype, "write", doc=name):
+        raise PermissionDeniedError(
+            f"no write permission on {doctype} {name}",
+        )
+
+    from frappe.desk.doctype.tag.tag import remove_tag as _rt
+
+    _rt(tag=tag, dt=doctype, dn=name)
+    return {"doctype": doctype, "name": name, "tag": tag}

--- a/jarvis/tools/send_email.py
+++ b/jarvis/tools/send_email.py
@@ -1,0 +1,73 @@
+"""Send an email about a record - through the same code path as the
+Desk "New Email" button, so a Communication audit row is created
+alongside the queued send.
+
+Wraps ``frappe.core.doctype.communication.email.make`` with
+``send_email=True`` so the underlying helper both queues the send AND
+creates the audit-trail Communication doc. The agent's mental model is
+"send email to X about doc Y"; we forward subject + content + reference
++ recipients and let Frappe handle the rest.
+
+Permission: ``email.make`` checks email permission on the reference
+document internally (requires read perm + the EMAIL perm if defined
+on the DocType). We add a boundary doctype/name existence check so
+the agent gets a clean InvalidArgumentError on typos.
+
+ALWAYS-CONFIRM territory: this fires an email to a real recipient.
+The descriptor's agent-facing copy is explicit about that requirement.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def send_email(
+    recipients: str | list[str],
+    subject: str,
+    content: str,
+    doctype: str,
+    name: str,
+    cc: str | list[str] | None = None,
+    bcc: str | list[str] | None = None,
+    send_me_a_copy: bool = False,
+    print_format: str | None = None,
+) -> dict:
+    """Send an email about ``doctype/name`` and log it as a
+    Communication row. Returns ``{communication_name, recipients,
+    subject, doctype, name}``.
+    """
+    if not recipients:
+        raise InvalidArgumentError("recipients is required")
+    if not subject:
+        raise InvalidArgumentError("subject is required")
+    if content is None or content == "":
+        raise InvalidArgumentError("content is required")
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+
+    from frappe.core.doctype.communication.email import make as _make
+
+    result = _make(
+        doctype=doctype,
+        name=name,
+        subject=subject,
+        content=content,
+        sent_or_received="Sent",
+        recipients=recipients,
+        cc=cc,
+        bcc=bcc,
+        send_email=True,
+        send_me_a_copy=bool(send_me_a_copy),
+        print_format=print_format,
+    )
+    return {
+        "communication_name": (result or {}).get("name"),
+        "recipients": recipients,
+        "subject": subject,
+        "doctype": doctype,
+        "name": name,
+    }

--- a/jarvis/tools/share_doc.py
+++ b/jarvis/tools/share_doc.py
@@ -1,0 +1,62 @@
+"""Grant per-record permissions to a user (or to "Everyone").
+
+Wraps ``frappe.share.add``. The DocShare row this creates is what
+overrides the DocType-level permissions for a specific record - useful
+when the agent is asked to "share this invoice with sales" or "let X
+view this customer's history".
+
+ALWAYS-CONFIRM: granting share permission means the target user can
+re-share the record further. The descriptor's agent-facing copy is
+explicit about that escalation risk.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def share_doc(
+    doctype: str,
+    name: str,
+    user: str | None = None,
+    read: bool = True,
+    write: bool = False,
+    submit: bool = False,
+    share: bool = False,
+    everyone: bool = False,
+    notify: bool = False,
+) -> dict:
+    """Grant the given permission flags on ``doctype/name`` to ``user``
+    (or to every user when ``everyone=True``). Returns
+    ``{doctype, name, user, everyone, read, write, submit, share}``.
+    """
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not everyone and not user:
+        raise InvalidArgumentError(
+            "either user or everyone=True is required",
+        )
+    if user and not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.share import add as _share_add
+
+    _share_add(
+        doctype=doctype, name=name, user=user,
+        read=int(bool(read)), write=int(bool(write)),
+        submit=int(bool(submit)), share=int(bool(share)),
+        everyone=int(bool(everyone)), notify=int(bool(notify)),
+    )
+    return {
+        "doctype": doctype,
+        "name": name,
+        "user": user,
+        "everyone": bool(everyone),
+        "read": bool(read),
+        "write": bool(write),
+        "submit": bool(submit),
+        "share": bool(share),
+    }

--- a/jarvis/tools/unassign_from.py
+++ b/jarvis/tools/unassign_from.py
@@ -1,0 +1,30 @@
+"""Close a user's ToDo assignment on a document.
+
+Wraps ``frappe.desk.form.assign_to.remove``. The underlying helper
+sets the ToDo's status to ``Closed`` rather than deleting it - the
+record stays for audit history. The auto-share created by ``assign_to``
+is not revoked (a separate ``unshare_doc`` call handles that).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def unassign_from(doctype: str, name: str, user: str) -> dict:
+    """Close the ToDo assigning ``user`` to ``doctype/name``. Returns
+    ``{doctype, name, user}``."""
+    require_doctype_and_name(doctype, name)
+    if not user:
+        raise InvalidArgumentError("user is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.desk.form.assign_to import remove as _assign_remove
+
+    _assign_remove(doctype=doctype, name=name, assign_to=user)
+    return {"doctype": doctype, "name": name, "user": user}

--- a/jarvis/tools/unfollow_document.py
+++ b/jarvis/tools/unfollow_document.py
@@ -1,0 +1,38 @@
+"""Unsubscribe a user from a document's change events.
+
+Wraps ``frappe.desk.form.document_follow.unfollow_document``. Idempotent
+(no-op when the user isn't currently following).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def unfollow_document(
+    doctype: str,
+    name: str,
+    user: str | None = None,
+) -> dict:
+    """Unsubscribe ``user`` (or the session user) from
+    ``doctype/name``. Returns ``{doctype, name, user, unfollowed}``."""
+    require_doctype_and_name(doctype, name)
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    target_user = user or frappe.session.user
+    if user and not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.desk.form.document_follow import (
+        unfollow_document as _unfollow,
+    )
+
+    result = _unfollow(doctype=doctype, doc_name=name, user=target_user)
+    return {
+        "doctype": doctype,
+        "name": name,
+        "user": target_user,
+        "unfollowed": bool(result),
+    }

--- a/jarvis/tools/unshare_doc.py
+++ b/jarvis/tools/unshare_doc.py
@@ -1,0 +1,29 @@
+"""Revoke a user's share permissions on a document.
+
+Wraps ``frappe.share.remove``. Removes the DocShare row entirely; the
+target user falls back to whatever DocType-level perms they had before
+the share was granted (which may still leave them with access).
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def unshare_doc(doctype: str, name: str, user: str) -> dict:
+    """Remove the DocShare granting ``user`` access to ``doctype/name``.
+    Returns ``{doctype, name, user}``."""
+    require_doctype_and_name(doctype, name)
+    if not user:
+        raise InvalidArgumentError("user is required")
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+    if not frappe.db.exists("User", user):
+        raise InvalidArgumentError(f"unknown User: {user}")
+
+    from frappe.share import remove as _share_remove
+
+    _share_remove(doctype=doctype, name=name, user=user)
+    return {"doctype": doctype, "name": name, "user": user}

--- a/jarvis/tools/update_comment.py
+++ b/jarvis/tools/update_comment.py
@@ -1,0 +1,30 @@
+"""Edit a Comment's body.
+
+Wraps ``frappe.desk.form.utils.update_comment``. The bundled helper
+permits the comment's owner to edit it (System Manager bypasses); we
+forward as-is so the agent gets the same gate the Desk UI applies.
+
+Composes with ``add_comment``: the new ``comment_name`` returned from
+add_comment is what update_comment targets.
+"""
+from __future__ import annotations
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+
+def update_comment(name: str, content: str) -> dict:
+    """Replace the body of Comment ``name`` with ``content``. Returns
+    ``{comment_name, content}``."""
+    if not name:
+        raise InvalidArgumentError("name is required")
+    if content is None or content == "":
+        raise InvalidArgumentError("content is required")
+    if not frappe.db.exists("Comment", name):
+        raise InvalidArgumentError(f"unknown Comment: {name}")
+
+    from frappe.desk.form.utils import update_comment as _uc
+
+    _uc(name=name, content=content)
+    return {"comment_name": name, "content": content}


### PR DESCRIPTION
Eleven new mutating tools - parity with the buttons a Desk user can click. Closes out the Tier-1/2/3 plan; the agent now has the same day-to-day surface a Frappe user has.

Communication (3):
  send_email(recipients, subject, content, doctype, name, cc?, ...)
    -> communication.email.make with send_email=True so the
       Communication audit row + the queued send happen together
  add_comment(doctype, name, content)
    -> desk.form.utils.add_comment; auto-populates comment_email +
       comment_by from the session user
  update_comment(name, content)
    -> desk.form.utils.update_comment

Sharing / assignment (4):
  share_doc(doctype, name, user?, read?, write?, submit?, share?,
            everyone?, notify?)
    -> frappe.share.add; either user or everyone=True is required
  unshare_doc(doctype, name, user)
    -> frappe.share.remove
  assign_to(doctype, name, user, description?, notify?, priority?,
            date?)
    -> desk.form.assign_to.add; packs the typed args into the
       form-bag dict the helper expects
  unassign_from(doctype, name, user)
    -> desk.form.assign_to.remove

Tagging (2):
  add_tag(doctype, name, tag, color?)    -> desk tag.add_tag
  remove_tag(doctype, name, tag)         -> desk tag.remove_tag

Following (2):
  follow_document(doctype, name, user?)
    -> desk.form.document_follow.follow_document; defaults user to
       the session user
  unfollow_document(doctype, name, user?)
    -> document_follow.unfollow_document

Registry: 11 new entries; test_registry pinned (now lists all 34 registered tool names).

Tests (+28 in test_tier3_desk_actions.py): mock-the-boundary pattern. Each test mocks the underlying helper and asserts the wrapper:
  - rejects empty / unknown args
  - forwards the right kwargs (e.g. send_email always passes send_email=True; share_doc forwards boolean perms as ints; assign_to packs into the [list] shape the helper wants; follow_document defaults to session.user)
  - returns the documented envelope

28/28 new pass; registry tests pass.

Paired with the openclaw-plugin PR that adds 11 typebox schemas, 11 TOOL_DESCRIPTORS, 11 openclaw.plugin.json entries, and 11 table-driven test rows. Descriptors carry ALWAYS-CONFIRM language for the side-effectful tools (send_email, share_doc with share=True, assign_to with notify=True).