### PR TITLE
feat(chat): include chat user in the per-turn context prefix

### DIFF
--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -183,16 +183,34 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 	gateway_url = (settings.agent_url or "").replace(
 		"http://", "ws://"
 	).replace("https://", "wss://")
-	user_message = frappe.db.get_value(MSG, message_id, "content")
-	# Prepend today's date as a context line so the agent (AGENTS.md tells
-	# it to treat the leading ``[Context: ...]`` as system, not user) can
-	# resolve relative time expressions ("last quarter", "this week")
-	# without an extra round-trip to clarify. The persisted user_message
-	# in the DB is unchanged; only the value sent over to openclaw is
-	# augmented.
+	# Fetch content + sender of THIS user message in one round-trip.
+	# msg_row.owner is the Frappe user who sent this turn, set by Frappe
+	# at insert time in send_message (jarvis/chat/api.py). We use it
+	# rather than conv.owner for the context bracket because the bench-
+	# side dispatcher (_dispatch_from_session in jarvis/api.py:118) also
+	# acts on the per-request identity, not the conversation creator -
+	# the bracket and the tool-call's frappe.session.user stay in lock-
+	# step. Today these are equal for single-owner conversations; the
+	# distinction matters the moment we ship shared conversations.
+	msg_row = (
+		frappe.db.get_value(MSG, message_id, ["content", "owner"], as_dict=True)
+		or {}
+	)
+	user_message = msg_row.get("content")
+	chat_user = msg_row.get("owner") or user
+	# Prepend today's date AND the chat user's Frappe id as a context line so
+	# the agent (AGENTS.md tells it to treat the leading ``[Context: ...]``
+	# as system, not user) can (a) resolve relative time expressions
+	# ("last quarter", "this week") and (b) answer "who am I" / "what
+	# perms do I have" without a clarifying round-trip or a doomed
+	# get_list on User. The persisted user_message in the DB is
+	# unchanged; only the value sent over to openclaw is augmented.
 	now = frappe.utils.now_datetime()
 	today = now.strftime("%Y-%m-%d (%A)")
-	user_message = f"[Context: today is {today}]\n\n{user_message or ''}"
+	user_message = (
+		f"[Context: today is {today}; chat user: {chat_user}]"
+		f"\n\n{user_message or ''}"
+	)
 
 	try:
 		try:

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -244,6 +244,9 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 		)
 		self.assertIsNotNone(message_sent)
 		self.assertIn("[Context: today is ", message_sent)
+		# Chat user (conv.owner) is in the same bracket so the agent can
+		# answer "who am I" / "what perms do I have" without round-tripping.
+		self.assertIn(f"chat user: {TEST_USER}", message_sent)
 		self.assertIn("how many invoices last quarter?", message_sent)
 		# The DB-persisted user message stays untouched (no prefix)
 		original = frappe.db.get_value(MSG, self.user_msg, "content")


### PR DESCRIPTION
The agent inside the openclaw container never received the Frappe identity for the chat user. When a customer (logged in as Administrator) asked "what doctype permissions do I have?", the agent called the generic openclaw session_status (which returns the container session, not a Frappe user), got nothing useful, then brute-forced get_list on User (41 rows) and bailed by asking "send me your login email". Every piece of information was on the bench in the first 200ms; the container just had no way to see it.

The cheapest fix is here: the worker already prepends a ``[Context: today is YYYY-MM-DD (Weekday)]`` line to every user message before forwarding to openclaw, and TOOLS.md tells the agent to treat that bracket as system context. Extend the bracket to also carry the chat user's Frappe id:

  [Context: today is 2026-06-20 (Saturday); chat user: navin@aerele.in]

We use ``msg.owner`` (the user-message row's Frappe owner, set at insert time in send_message) rather than ``conv.owner``:

- ``msg.owner`` is the per-turn speaker. ``conv.owner`` is the conversation's creator. They match for single-owner conversations (today's model) but diverge if we ever ship shared conversations.
- The bench-side dispatcher (_dispatch_from_session in jarvis/api.py:118) acts on the per-request identity, not the conversation creator. Using ``msg.owner`` keeps the bracket and the tool-call's frappe.session.user in lock-step.
- We can NOT use frappe.session.user directly here: the RQ worker context is the worker daemon's identity (Administrator-ish), not the human who queued the job.

Content + owner are fetched in one round-trip
(frappe.db.get_value(..., ["content", "owner"], as_dict=True)) so the switch costs no extra query. The DB-persisted user_message row is unchanged; only the over-the-wire envelope to openclaw is augmented.