### PR TITLE
docs(api): drop removed IP-allowlist step from call_tool pipeline

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -36,8 +36,8 @@ def call_tool(tool: str, args: dict | str | None = None) -> dict:
 	failures are reported with the corresponding HTTP status code.
 	"""
 	# Plugin auth mode - detected by presence of X-Jarvis-Token header.
-	# Goes through the C2 hardening pipeline (IP allowlist → bearer →
-	# session → optional HMAC signature → rate limit) implemented in
+	# Goes through the C2 hardening pipeline (bearer → session →
+	# optional HMAC signature → rate limit) implemented in
 	# jarvis._plugin_auth. PluginAuthError carries the correct status
 	# code; any other exception bubbles as a 500 (logged by Frappe).
 	if _get_header("X-Jarvis-Token"):


### PR DESCRIPTION
The plugin-auth IP allowlist was removed from _plugin_auth.py (the unmigrated plugin_ip_allowlist field fell back to the hardcoded RFC1918 default and 403'd every public-IP callback on Frappe Cloud / remote fleet hosts). call_tool's docstring still listed "IP allowlist ->" as the first pipeline step; align it with the code: the pipeline is now bearer -> session -> optional HMAC -> rate limit.