### PR TITLE
feat(admin-client): OAuth bearer auth to admin (dual-auth fallback)

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1,14 +1,20 @@
 """HTTPS client for the Jarvis admin (jarvis_admin) app.
 
-Authenticated calls use Frappe's native api_key:api_secret. The customer's
-bench reads both from Jarvis Settings (set at signup) and sends them as
-`Authorization: token <api_key>:<api_secret>`.
+Authenticated calls prefer a short-lived OAuth bearer token: the bench
+exchanges the customer's password (Jarvis Settings.jarvis_admin_customer_password,
+username = jarvis_admin_customer_email) for an access token at admin's native
+Frappe OAuth endpoint using the shared public client id `jarvis-bench`, caches
+it in Redis, and sends `Authorization: Bearer <access_token>`. Customers
+onboarded before OAuth (no password stored) fall back to the legacy native
+api_key:api_secret (`Authorization: token <api_key>:<api_secret>`) - admin
+accepts both during the migration window.
 
 Guest calls (signup, get_plans) skip the header entirely; their admin
 endpoints are @frappe.whitelist(allow_guest=True).
 """
 
 import re
+import time
 
 import frappe
 import requests
@@ -24,6 +30,25 @@ from jarvis.exceptions import (
 # Admin's provision_healthz_timeout_s defaults to 60s for restart operations;
 # 90s leaves 30s buffer for network round-trip + handler overhead.
 DEFAULT_TIMEOUT_S = 90
+
+# OAuth password-grant config. The bench exchanges the customer's password
+# (Jarvis Settings.jarvis_admin_customer_password) for short-lived bearer
+# tokens against admin's native Frappe OAuth token endpoint, using the shared
+# public client id. Authenticated calls prefer the bearer; calls fall back to
+# the legacy api_key:api_secret when no password is stored (pre-OAuth
+# customers, dual-auth migration window).
+_OAUTH_CLIENT_ID = "jarvis-bench"
+_OAUTH_TOKEN_PATH = "/api/method/frappe.integrations.oauth2.get_token"
+_OAUTH_SCOPE = "all openid"
+# Site-scoped Redis cache for the access/refresh tokens (frappe.cache() is
+# per-site). Admin credentials are a per-site singleton, so one key suffices.
+_OAUTH_CACHE_KEY = "jarvis:admin_oauth_token"
+# Re-mint this many seconds before the cached access token's stated expiry so
+# a request can't race past the boundary.
+_OAUTH_EXPIRY_SKEW_S = 60
+# Upper bound the cache entry lives, so the refresh token outlives the
+# (~15min) access token; on entry expiry we re-mint with the password grant.
+_OAUTH_CACHE_TTL_S = 24 * 60 * 60
 
 # Cap on the cross-boundary message length. Long messages (e.g. a Frappe
 # 500 with a 10KB traceback that happens to embed a token mid-frame) get
@@ -351,23 +376,140 @@ def start_upgrade(target_plan: str) -> dict:
 	)
 
 
+def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
+	"""POST a form-encoded grant to admin's OAuth token endpoint. Returns the
+	token dict ({access_token, refresh_token, expires_in, ...}) on success, or
+	None on any failure (network, non-JSON, non-200, missing access_token) so
+	the caller can fall back. Never raises; never logs token material.
+
+	Form-encoded (not JSON): Frappe's get_token reads ``request.form``.
+	"""
+	payload = {**grant, "client_id": _OAUTH_CLIENT_ID, "scope": _OAUTH_SCOPE}
+	try:
+		resp = requests.post(
+			admin_url + _OAUTH_TOKEN_PATH,
+			data=payload,
+			headers={"Content-Type": "application/x-www-form-urlencoded"},
+			timeout=DEFAULT_TIMEOUT_S,
+		)
+	except (requests.ConnectionError, requests.Timeout) as e:
+		frappe.log_error(
+			title="admin_client: oauth token network error",
+			message=f"grant={grant.get('grant_type')!r} error={e!r}",
+		)
+		return None
+	try:
+		token = resp.json()
+	except ValueError:
+		frappe.log_error(
+			title="admin_client: oauth token non-JSON response",
+			message=f"grant={grant.get('grant_type')!r} status={resp.status_code}",
+		)
+		return None
+	if resp.status_code != 200 or not isinstance(token, dict) or not token.get("access_token"):
+		# invalid_grant / invalid_client / expired-or-revoked refresh, etc.
+		# Log the error code only (never the credentials) for triage.
+		err = token.get("error") if isinstance(token, dict) else None
+		frappe.log_error(
+			title="admin_client: oauth token request rejected",
+			message=(
+				f"grant={grant.get('grant_type')!r} "
+				f"status={resp.status_code} error={err!r}"
+			),
+		)
+		return None
+	return token
+
+
+def _cache_oauth_token(token: dict) -> None:
+	frappe.cache().set_value(
+		_OAUTH_CACHE_KEY,
+		{
+			"access_token": token["access_token"],
+			"refresh_token": token.get("refresh_token"),
+			"access_expires_at": time.time() + int(token.get("expires_in") or 0),
+		},
+		expires_in_sec=_OAUTH_CACHE_TTL_S,
+	)
+
+
+def _admin_access_token(settings, admin_url: str, *,
+						force_refresh: bool = False) -> str | None:
+	"""Return a valid OAuth bearer access token for admin, or None when the
+	bench has no OAuth credentials stored (pre-OAuth customer -> caller falls
+	back to api_key:api_secret).
+
+	Serves a cached access token until shortly before expiry. On a miss, tries
+	the refresh token (best-effort), then the password grant (the durable
+	bootstrap). ``force_refresh`` bypasses the cache to re-mint after a 401.
+	"""
+	username = (settings.jarvis_admin_customer_email or "").strip()
+	# Password field -> get_password decrypts the real value out of __Auth.
+	password = (settings.get_password(
+		"jarvis_admin_customer_password", raise_exception=False
+	) or "").strip()
+	if not username or not password:
+		return None
+
+	cache = frappe.cache()
+	cached = {} if force_refresh else (cache.get_value(_OAUTH_CACHE_KEY) or {})
+	access = cached.get("access_token")
+	if access and (cached.get("access_expires_at", 0) - _OAUTH_EXPIRY_SKEW_S) > time.time():
+		return access
+
+	token = None
+	refresh = cached.get("refresh_token")
+	if refresh:
+		token = _oauth_token_request(admin_url, {
+			"grant_type": "refresh_token", "refresh_token": refresh,
+		})
+	if not token:
+		token = _oauth_token_request(admin_url, {
+			"grant_type": "password", "username": username, "password": password,
+		})
+	if not token:
+		return None
+	_cache_oauth_token(token)
+	return token["access_token"]
+
+
 def _post(path: str, body: dict, *,
 		  timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
-	"""Authenticated POST. Reads native api_key + api_secret + the admin URL
-	override from Jarvis Settings. Raises AdminAuthError early if either
-	credential is empty.
+	"""Authenticated POST. Prefers a short-lived OAuth bearer token (password
+	grant, cached in Redis) and falls back to the legacy native
+	api_key:api_secret for customers onboarded before OAuth. Raises
+	AdminAuthError when neither credential set is available.
 
-	Previously each public wrapper open-coded
-	``settings = frappe.get_single(...)`` + ``_admin_url(settings)`` before
-	calling _post (which then re-fetched Settings internally for the
-	credentials). Folding the settings read here means callers shrink to
-	``return _post(path=..., body=...)`` - one Settings load per call
-	instead of two. Punch-list item from the 2026-06-16 review.
+	Folds the Settings + admin-URL read here so public wrappers stay one-liners
+	(one Settings load per call).
 	"""
 	settings = frappe.get_single("Jarvis Settings")
-	# Both credential fields are Password fields - attribute access would
-	# return the masked "*****" placeholder Frappe stores in the row.
-	# get_password decrypts the real value out of __Auth.
+	admin_url = _admin_url(settings)
+
+	# Preferred path: OAuth bearer. Retry once on a token rejection (revoked,
+	# or raced past the ~15min cap) by re-minting; if both attempts are
+	# rejected, fall through to the legacy credential below.
+	access_token = _admin_access_token(settings, admin_url)
+	for attempt in range(2):
+		if not access_token:
+			break
+		headers = {
+			"Authorization": f"Bearer {access_token}",
+			"Content-Type": "application/json",
+		}
+		try:
+			return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
+		except AdminAuthError:
+			if attempt == 0:
+				access_token = _admin_access_token(
+					settings, admin_url, force_refresh=True,
+				)
+				continue
+			break
+
+	# Legacy native api_key:api_secret (pre-OAuth customers / OAuth fallback).
+	# Both are Password fields - attribute access returns the masked "*****"
+	# placeholder; get_password decrypts the real value out of __Auth.
 	api_key = (settings.get_password(
 		"jarvis_admin_api_key", raise_exception=False
 	) or "").strip()
@@ -376,9 +518,8 @@ def _post(path: str, body: dict, *,
 	) or ""
 	if not api_key or not api_secret:
 		raise AdminAuthError(
-			"not onboarded (Jarvis Settings: admin api_key + api_secret empty)"
+			"not onboarded (Jarvis Settings: no OAuth password and no api_key/secret)"
 		)
-	admin_url = _admin_url(settings)
 	headers = {
 		"Authorization": f"token {api_key}:{api_secret}",
 		"Content-Type": "application/json",

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -385,17 +385,21 @@ def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
 	Form-encoded (not JSON): Frappe's get_token reads ``request.form``.
 	"""
 	payload = {**grant, "client_id": _OAUTH_CLIENT_ID, "scope": _OAUTH_SCOPE}
+	url = admin_url + _OAUTH_TOKEN_PATH
 	try:
 		resp = requests.post(
-			admin_url + _OAUTH_TOKEN_PATH,
+			url,
 			data=payload,
 			headers={"Content-Type": "application/x-www-form-urlencoded"},
 			timeout=DEFAULT_TIMEOUT_S,
 		)
-	except (requests.ConnectionError, requests.Timeout) as e:
+	except requests.RequestException as e:
+		# Broad catch (not just ConnectionError/Timeout) so SSL errors, redirect
+		# loops, etc. return None and the caller falls back rather than crashing.
+		# A requests exception repr carries url/host, never the POST body.
 		frappe.log_error(
 			title="admin_client: oauth token network error",
-			message=f"grant={grant.get('grant_type')!r} error={e!r}",
+			message=f"url={url!r} grant={grant.get('grant_type')!r} error={e!r}",
 		)
 		return None
 	try:
@@ -422,12 +426,18 @@ def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
 
 
 def _cache_oauth_token(token: dict) -> None:
+	ttl = int(token.get("expires_in") or 0)
+	if ttl <= 0:
+		# No usable lifetime advertised. Don't cache an instantly-stale token:
+		# the freshness check would always miss and re-mint on every call,
+		# storming the token endpoint. The caller still uses this token once.
+		return
 	frappe.cache().set_value(
 		_OAUTH_CACHE_KEY,
 		{
 			"access_token": token["access_token"],
 			"refresh_token": token.get("refresh_token"),
-			"access_expires_at": time.time() + int(token.get("expires_in") or 0),
+			"access_expires_at": time.time() + ttl,
 		},
 		expires_in_sec=_OAUTH_CACHE_TTL_S,
 	)
@@ -487,12 +497,12 @@ def _post(path: str, body: dict, *,
 	admin_url = _admin_url(settings)
 
 	# Preferred path: OAuth bearer. Retry once on a token rejection (revoked,
-	# or raced past the ~15min cap) by re-minting; if both attempts are
-	# rejected, fall through to the legacy credential below.
+	# or raced past the ~15min cap) by re-minting. If the retry is still
+	# rejected, drop the cached token so the next call re-mints cleanly
+	# instead of replaying the poisoned one, then fall through to the legacy
+	# credential below.
 	access_token = _admin_access_token(settings, admin_url)
-	for attempt in range(2):
-		if not access_token:
-			break
+	if access_token:
 		headers = {
 			"Authorization": f"Bearer {access_token}",
 			"Content-Type": "application/json",
@@ -500,12 +510,16 @@ def _post(path: str, body: dict, *,
 		try:
 			return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
 		except AdminAuthError:
-			if attempt == 0:
-				access_token = _admin_access_token(
-					settings, admin_url, force_refresh=True,
-				)
-				continue
-			break
+			access_token = _admin_access_token(settings, admin_url, force_refresh=True)
+			if access_token:
+				headers["Authorization"] = f"Bearer {access_token}"
+				try:
+					return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
+				except AdminAuthError:
+					pass
+			# Both bearer attempts rejected (or re-mint failed) - clear the
+			# cache and fall through to legacy.
+			frappe.cache().delete_value(_OAUTH_CACHE_KEY)
 
 	# Legacy native api_key:api_secret (pre-OAuth customers / OAuth fallback).
 	# Both are Password fields - attribute access returns the masked "*****"
@@ -513,9 +527,9 @@ def _post(path: str, body: dict, *,
 	api_key = (settings.get_password(
 		"jarvis_admin_api_key", raise_exception=False
 	) or "").strip()
-	api_secret = settings.get_password(
+	api_secret = (settings.get_password(
 		"jarvis_admin_api_secret", raise_exception=False
-	) or ""
+	) or "").strip()
 	if not api_key or not api_secret:
 		raise AdminAuthError(
 			"not onboarded (Jarvis Settings: no OAuth password and no api_key/secret)"

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -509,14 +509,25 @@ def _post(path: str, body: dict, *,
 		}
 		try:
 			return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
-		except AdminAuthError:
+		except AdminAuthError as token_err:
+			# A 403 is an authorization denial, not a stale token. Re-minting
+			# would yield a token for the same customer principal (which backs
+			# both the bearer and the legacy api_key:api_secret), so the retry
+			# and the legacy fallback would just replay into the same 403 while
+			# storming the token endpoint and evicting the cache on every call.
+			# Surface it as-is; only a 401 (revoked / over-cap token) re-mints.
+			if token_err.status_code == 403:
+				raise
 			access_token = _admin_access_token(settings, admin_url, force_refresh=True)
 			if access_token:
 				headers["Authorization"] = f"Bearer {access_token}"
 				try:
 					return _do_post(admin_url + path, body, headers, timeout_s, admin_url)
-				except AdminAuthError:
-					pass
+				except AdminAuthError as retry_err:
+					# Same rule on the retry: a 403 is terminal; a 401 falls
+					# through to the legacy credential below.
+					if retry_err.status_code == 403:
+						raise
 			# Both bearer attempts rejected (or re-mint failed) - clear the
 			# cache and fall through to legacy.
 			frappe.cache().delete_value(_OAUTH_CACHE_KEY)
@@ -648,7 +659,10 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	# fell through to AdminUnreachableError - losing the rate-limit
 	# category entirely. 401/403/429 always win.
 	if resp.status_code in (401, 403):
-		raise AdminAuthError(_envelope_message() or f"admin returned {resp.status_code}")
+		raise AdminAuthError(
+			_envelope_message() or f"admin returned {resp.status_code}",
+			status_code=resp.status_code,
+		)
 	if resp.status_code == 429:
 		err = (envelope or {}).get("error", {}) if isinstance(envelope, dict) else {}
 		raise AdminRateLimitedError(
@@ -662,8 +676,13 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	if exc_type:
 		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
 			raise AdminValidationError(clean)
-		if exc_type in ("AuthenticationError", "PermissionError"):
-			raise AdminAuthError(clean)
+		# AuthenticationError ~ a token/credential failure (retry-eligible, 401);
+		# PermissionError ~ an authorization denial (terminal, 403). Tag the
+		# status so _post re-mints on the former but surfaces the latter as-is.
+		if exc_type == "AuthenticationError":
+			raise AdminAuthError(clean, status_code=401)
+		if exc_type == "PermissionError":
+			raise AdminAuthError(clean, status_code=403)
 		# Unknown exc_type. Log it (so we learn what other admin error
 		# classes to add to the allowlist) but don't embed admin_url +
 		# raw exception class in the user-facing message.

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -40,7 +40,19 @@ class AdminUnreachableError(JarvisError):
 
 
 class AdminAuthError(JarvisError):
-	"""jarvis_admin rejected the token / site (401 / 403)."""
+	"""jarvis_admin rejected the token / site (401 / 403).
+
+	``status_code`` carries the rejecting HTTP status (401 or 403) when known.
+	The bench uses it to tell a *token* rejection (401 - revoked or raced past
+	the ~15min cap; re-minting and retrying helps) apart from an
+	*authorization* denial (403 - the same customer principal backs both the
+	bearer and the legacy api_key:api_secret, so re-minting and the legacy
+	fallback would just replay into the same 403 while storming the token
+	endpoint). None when the status isn't known."""
+
+	def __init__(self, message: str, *, status_code: int | None = None):
+		super().__init__(message)
+		self.status_code = status_code
 
 
 class AdminValidationError(JarvisError):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -28,6 +28,8 @@
     "jarvis_admin_url",
     "jarvis_admin_api_key",
     "jarvis_admin_api_secret",
+    "jarvis_admin_customer_email",
+    "jarvis_admin_customer_password",
     "operator_section",
     "agent_url",
     "agent_token",
@@ -181,6 +183,20 @@
       "label": "Jarvis Admin API Secret",
       "read_only": 1,
       "description": "Native Frappe api_secret paired with the API Key. Set automatically at onboarding."
+    },
+    {
+      "fieldname": "jarvis_admin_customer_email",
+      "fieldtype": "Data",
+      "label": "Jarvis Admin Customer Email",
+      "read_only": 1,
+      "description": "The customer's login (email) on the admin site. Used as the OAuth password-grant username. Set automatically at onboarding."
+    },
+    {
+      "fieldname": "jarvis_admin_customer_password",
+      "fieldtype": "Password",
+      "label": "Jarvis Admin Customer Password",
+      "read_only": 1,
+      "description": "The customer's password on the admin site, exchanged for short-lived OAuth bearer tokens (client_id `jarvis-bench`). Set automatically once the email is verified. Empty for pre-OAuth customers, which fall back to api_key:api_secret."
     },
     {
       "fieldname": "operator_section",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -81,6 +81,15 @@ def write_connection(data: dict) -> None:
 		s.db_set("jarvis_admin_api_key", data["api_key"])
 	if data.get("api_secret"):
 		s.db_set("jarvis_admin_api_secret", data["api_secret"])
+	# OAuth password-grant credentials. ``customer`` is the admin-side login
+	# (email, the grant username); ``customer_password`` is the durable secret
+	# the bench exchanges for short-lived bearer tokens. The email arrives in
+	# the signup response; the password arrives later (verified poll / flag-off
+	# signup), so each is persisted independently when present.
+	if data.get("customer"):
+		s.db_set("jarvis_admin_customer_email", data["customer"])
+	if data.get("customer_password"):
+		s.db_set("jarvis_admin_customer_password", data["customer_password"])
 	if data.get("agent_url"):
 		s.db_set("agent_url", data["agent_url"])
 	if data.get("agent_token"):
@@ -147,6 +156,10 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 		write_connection({
 			"api_key": data.get("api_key", ""),
 			"api_secret": data.get("api_secret", ""),
+			# customer (email) is always present; customer_password is present
+			# only on the flag-off path (verify-on defers it to the poll).
+			"customer": data.get("customer", ""),
+			"customer_password": data.get("customer_password", ""),
 		})
 	return data
 
@@ -166,7 +179,13 @@ def check_signup_payment_state() -> dict:
 	"""
 	frappe.only_for("System Manager")
 	_require_admin_url()
-	return _surface(admin_client.get_signup_payment_state)
+	data = _surface(admin_client.get_signup_payment_state)
+	# On the verified poll (email confirmed) admin delivers the customer's
+	# OAuth password once. Persist it so subsequent admin calls use bearer
+	# auth. Absent on the not-yet-verified poll and on the flag-off path.
+	if isinstance(data, dict) and data.get("customer_password"):
+		write_connection({"customer_password": data["customer_password"]})
+	return data
 
 
 @frappe.whitelist()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -152,12 +152,15 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 	frappe.only_for("System Manager")
 	_require_admin_url()
 	data = _surface(admin_client.signup, email, company, plan)
-	if data.get("api_key") or data.get("api_secret"):
+	# Persist whatever credentials the response carries. The guard also fires
+	# on ``customer`` so the OAuth grant username is stored even if a future
+	# admin response shape omits api_key/api_secret. write_connection skips
+	# empty fields individually. customer_password is present only on the
+	# flag-off path (verify-on defers it to the poll).
+	if data.get("api_key") or data.get("api_secret") or data.get("customer"):
 		write_connection({
 			"api_key": data.get("api_key", ""),
 			"api_secret": data.get("api_secret", ""),
-			# customer (email) is always present; customer_password is present
-			# only on the flag-off path (verify-on defers it to the poll).
 			"customer": data.get("customer", ""),
 			"customer_password": data.get("customer_password", ""),
 		})

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -798,6 +798,42 @@ class TestOAuthBearer(FrappeTestCase):
 		self.assertEqual(len(cap["api_headers"]), 2)
 		self.assertEqual(cap["api_headers"][1]["Authorization"], "Bearer ACCESS-1")
 
+	def test_uses_refresh_token_when_access_expired_but_refresh_present(self):
+		# Cache holds a live refresh token but the access token has expired.
+		# The next call must renew via grant_type=refresh_token (the cheap
+		# path) instead of replaying the password grant, and must carry the
+		# freshly minted access token on the API call. Exercises the
+		# refresh-first branch in _admin_access_token (the password grant is
+		# only the durable bootstrap fallback). 2026-06-21 review follow-up.
+		_settings_for_oauth()
+		# Seed AFTER _settings_for_oauth (it clears the cache): a stale access
+		# token (expires_at in the past) plus a still-valid refresh token.
+		frappe.cache().set_value(admin_client._OAUTH_CACHE_KEY, {
+			"access_token": "STALE-ACCESS",
+			"refresh_token": "REFRESH-1",
+			"access_expires_at": 0,
+		})
+		cap = {}
+		token_resp = _mock_response(200, json_body={
+			"access_token": "ACCESS-2", "refresh_token": "REFRESH-2",
+			"token_type": "Bearer", "expires_in": 900,
+		})
+		with patch("requests.post", side_effect=self._route(
+				token_response=token_resp, api_capture=cap)):
+			admin_client.get_connection()
+		# Exactly one token call, and it was the refresh grant - never password.
+		self.assertEqual(len(cap["token_calls"]), 1)
+		grant = cap["token_calls"][0]
+		self.assertEqual(grant["grant_type"], "refresh_token")
+		self.assertEqual(grant["refresh_token"], "REFRESH-1")
+		self.assertNotIn("username", grant)
+		self.assertNotIn("password", grant)
+		# Public client: client_id present, no client_secret.
+		self.assertEqual(grant["client_id"], "jarvis-bench")
+		self.assertNotIn("client_secret", grant)
+		# The API call carried the access token minted off the refresh grant.
+		self.assertEqual(cap["api_headers"][0]["Authorization"], "Bearer ACCESS-2")
+
 	def test_falls_back_to_legacy_without_password(self):
 		# No customer_password -> legacy api_key:api_secret path.
 		_settings_for_admin(api_key="legacy-key", api_secret="legacy-secret")

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -32,15 +32,34 @@ def _settings_for_admin(admin_url="https://admin.example.com",
 	frappe.db.commit()
 
 
+def _settings_for_oauth(admin_url="https://admin.example.com",
+						email="cust@example.com", password="pw-secret",
+						api_key="", api_secret=""):
+	"""Configure Jarvis Settings for the OAuth bearer path. By default no
+	api_key/secret so the bearer path is exercised in isolation; pass them to
+	test the 401 -> legacy fallback."""
+	settings = frappe.get_single("Jarvis Settings")
+	settings.db_set("jarvis_admin_url", admin_url)
+	settings.db_set("jarvis_admin_customer_email", email)
+	settings.db_set("jarvis_admin_customer_password", password)
+	settings.db_set("jarvis_admin_api_key", api_key)
+	settings.db_set("jarvis_admin_api_secret", api_secret)
+	frappe.db.commit()
+	frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
+
+
 def _settings_clear_admin():
 	from frappe.utils.password import remove_encrypted_password
 	settings = frappe.get_single("Jarvis Settings")
 	settings.db_set("jarvis_admin_url", "")
+	settings.db_set("jarvis_admin_customer_email", "")
 	# Password fields need __Auth cleared too, not just the column.
-	for f in ("jarvis_admin_api_key", "jarvis_admin_api_secret"):
+	for f in ("jarvis_admin_api_key", "jarvis_admin_api_secret",
+			  "jarvis_admin_customer_password"):
 		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", f)
 		settings.db_set(f, "")
 	frappe.db.commit()
+	frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
 
 
 def _mock_response(status_code: int, json_body=None, text: str = ""):
@@ -712,3 +731,105 @@ class TestPairChatDevice(FrappeTestCase):
 				public_key="pk", device_id="did", request_timeout_s=75,
 			)
 		self.assertEqual(captured["body"]["request_timeout_s"], 75)
+
+
+class TestOAuthBearer(FrappeTestCase):
+	"""Bench-side OAuth password-grant: prefer a cached bearer token, fall back
+	to legacy api_key:api_secret when no password is stored."""
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def _route(self, *, token_response, api_capture, api_response=None):
+		"""Build a requests.post stand-in that routes the OAuth token endpoint
+		vs the real API call by URL. ``api_capture`` records the API call's
+		headers; ``token_response``/``api_response`` are _mock_response objects
+		(or callables returning one, for stateful tests)."""
+		# A _mock_response is itself a MagicMock (callable); only treat a real
+		# function as a stateful factory, never a mock response object.
+		def _resolve(r, arg):
+			if callable(r) and not isinstance(r, MagicMock):
+				return r(arg)
+			return r
+
+		def _fake_post(url, data=None, json=None, headers=None, timeout=None):
+			if url.endswith(admin_client._OAUTH_TOKEN_PATH):
+				api_capture.setdefault("token_calls", []).append(data)
+				return _resolve(token_response, data)
+			api_capture.setdefault("api_headers", []).append(headers)
+			api_capture["json"] = json
+			r = _resolve(api_response, headers)
+			return r or _mock_response(200, json_body={"message": {"ok": True, "data": {"x": 1}}})
+		return _fake_post
+
+	def test_prefers_bearer_and_omits_client_secret(self):
+		_settings_for_oauth()
+		cap = {}
+		token_resp = _mock_response(200, json_body={
+			"access_token": "ACCESS-1", "refresh_token": "REFRESH-1",
+			"token_type": "Bearer", "expires_in": 900,
+		})
+		with patch("requests.post", side_effect=self._route(
+				token_response=token_resp, api_capture=cap)):
+			admin_client.get_connection()
+		# Token requested via password grant, public-client (no client_secret).
+		grant = cap["token_calls"][0]
+		self.assertEqual(grant["grant_type"], "password")
+		self.assertEqual(grant["username"], "cust@example.com")
+		self.assertEqual(grant["password"], "pw-secret")
+		self.assertEqual(grant["client_id"], "jarvis-bench")
+		self.assertNotIn("client_secret", grant)
+		# API call carried the bearer, not a token key:secret header.
+		self.assertEqual(cap["api_headers"][0]["Authorization"], "Bearer ACCESS-1")
+
+	def test_caches_access_token_across_calls(self):
+		_settings_for_oauth()
+		cap = {}
+		token_resp = _mock_response(200, json_body={
+			"access_token": "ACCESS-1", "refresh_token": "REFRESH-1",
+			"token_type": "Bearer", "expires_in": 900,
+		})
+		with patch("requests.post", side_effect=self._route(
+				token_response=token_resp, api_capture=cap)):
+			admin_client.get_connection()
+			admin_client.get_connection()
+		# Two API calls, but the token endpoint was hit only once (cached).
+		self.assertEqual(len(cap["token_calls"]), 1)
+		self.assertEqual(len(cap["api_headers"]), 2)
+		self.assertEqual(cap["api_headers"][1]["Authorization"], "Bearer ACCESS-1")
+
+	def test_falls_back_to_legacy_without_password(self):
+		# No customer_password -> legacy api_key:api_secret path.
+		_settings_for_admin(api_key="legacy-key", api_secret="legacy-secret")
+		cap = {}
+		def _fake_post(url, data=None, json=None, headers=None, timeout=None):
+			cap["headers"] = headers
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"x": 1}}})
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.get_connection()
+		self.assertEqual(cap["headers"]["Authorization"], "token legacy-key:legacy-secret")
+
+	def test_bearer_401_remints_then_falls_back_to_legacy(self):
+		# Password present (bearer preferred) AND legacy creds present. The API
+		# rejects the bearer twice (revoked); after a re-mint it still 401s, so
+		# the call falls back to the legacy header and succeeds.
+		_settings_for_oauth(api_key="legacy-key", api_secret="legacy-secret")
+		cap = {}
+		token_resp = _mock_response(200, json_body={
+			"access_token": "ACCESS-1", "token_type": "Bearer", "expires_in": 900,
+		})
+		def _api_response(headers):
+			auth = headers["Authorization"]
+			if auth.startswith("Bearer "):
+				return _mock_response(401, json_body={"message": {
+					"ok": False, "error": {"code": "AuthError", "message": "bad token"}}})
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"ok": 1}}})
+		with patch("requests.post", side_effect=self._route(
+				token_response=token_resp, api_capture=cap, api_response=_api_response)):
+			result = admin_client.get_connection()
+		self.assertEqual(result, {"ok": 1})
+		# Two bearer attempts (initial + re-mint) then the legacy header.
+		auths = [h["Authorization"] for h in cap["api_headers"]]
+		self.assertEqual(auths[0], "Bearer ACCESS-1")
+		self.assertEqual(auths[-1], "token legacy-key:legacy-secret")
+		self.assertGreaterEqual(len(cap["token_calls"]), 2)

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -836,6 +836,35 @@ class TestOAuthBearer(FrappeTestCase):
 		# The poisoned token must be evicted so the next call re-mints clean.
 		self.assertIsNone(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY))
 
+	def test_bearer_403_is_terminal_no_remint_no_fallback(self):
+		# A 403 is an authorization denial, not a stale token. The bearer call
+		# must NOT re-mint, NOT fall back to legacy, and NOT evict the cached
+		# token - doing so would storm the token endpoint on every call and
+		# mask the real "forbidden" behind a generic auth retry. Both the
+		# bearer and the legacy api_key:api_secret back the same customer
+		# principal, so the fallback would 403 again anyway.
+		_settings_for_oauth(api_key="legacy-key", api_secret="legacy-secret")
+		cap = {}
+		token_resp = _mock_response(200, json_body={
+			"access_token": "ACCESS-1", "token_type": "Bearer", "expires_in": 900,
+		})
+		def _api_response(headers):
+			return _mock_response(403, json_body={"message": {
+				"ok": False, "error": {"code": "Forbidden", "message": "not allowed"}}})
+		with patch("requests.post", side_effect=self._route(
+				token_response=token_resp, api_capture=cap, api_response=_api_response)):
+			with self.assertRaises(AdminAuthError) as ctx:
+				admin_client.get_connection()
+		# The real 403 is surfaced (status tagged), not retried away.
+		self.assertEqual(ctx.exception.status_code, 403)
+		# Exactly one bearer attempt: no force-refresh, no legacy header.
+		auths = [h["Authorization"] for h in cap["api_headers"]]
+		self.assertEqual(auths, ["Bearer ACCESS-1"])
+		# Token endpoint hit once (initial mint only) - no re-mint storm.
+		self.assertEqual(len(cap["token_calls"]), 1)
+		# Cache retained (not evicted) so the next call reuses the valid token.
+		self.assertIsNotNone(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY))
+
 	def test_zero_expiry_token_is_not_cached(self):
 		# A token with no usable lifetime must not be cached (else every call
 		# would miss and storm the token endpoint).

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -833,3 +833,15 @@ class TestOAuthBearer(FrappeTestCase):
 		self.assertEqual(auths[0], "Bearer ACCESS-1")
 		self.assertEqual(auths[-1], "token legacy-key:legacy-secret")
 		self.assertGreaterEqual(len(cap["token_calls"]), 2)
+		# The poisoned token must be evicted so the next call re-mints clean.
+		self.assertIsNone(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY))
+
+	def test_zero_expiry_token_is_not_cached(self):
+		# A token with no usable lifetime must not be cached (else every call
+		# would miss and storm the token endpoint).
+		admin_client._cache_oauth_token({"access_token": "A", "expires_in": 0})
+		self.assertIsNone(frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY))
+		admin_client._cache_oauth_token({"access_token": "B", "expires_in": 900})
+		self.assertEqual(
+			frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY)["access_token"], "B")
+		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -24,6 +24,7 @@ def _set_token(value, secret="secret"):
 # rolled back between tests.
 _SNAPSHOTTED_FIELDS = (
 	"jarvis_admin_url", "jarvis_admin_api_key", "jarvis_admin_api_secret",
+	"jarvis_admin_customer_email", "jarvis_admin_customer_password",
 	"agent_url", "agent_token",
 )
 
@@ -33,7 +34,7 @@ def _snapshot_settings() -> dict:
 	snap = {}
 	for f in _SNAPSHOTTED_FIELDS:
 		# Password fields → get_password; plain → attribute. Both safe.
-		v = s.get_password(f, raise_exception=False) if f.endswith(("_key", "_secret", "_token")) else s.get(f)
+		v = s.get_password(f, raise_exception=False) if f.endswith(("_key", "_secret", "_token", "_password")) else s.get(f)
 		snap[f] = v or ""
 	return snap
 
@@ -245,6 +246,13 @@ class TestSignupEmailVerification(FrappeTestCase):
 			s.get_password("jarvis_admin_api_secret", raise_exception=False),
 			"verify-secret",
 		)
+		# The customer email (OAuth grant username) is persisted now; the
+		# password is deliberately absent on the verify-on response (admin
+		# defers it to the verified poll).
+		self.assertEqual(s.get("jarvis_admin_customer_email"), "alice@example.com")
+		self.assertFalse(
+			s.get_password("jarvis_admin_customer_password", raise_exception=False) or ""
+		)
 
 	def test_start_signup_legacy_response_still_persists_key_secret(self):
 		# Regression pin: the flag-off (legacy) response shape must keep
@@ -257,6 +265,7 @@ class TestSignupEmailVerification(FrappeTestCase):
 		               "api_key": "legacy-key",
 		               "api_secret": "legacy-secret",
 		               "customer": "bob@example.com",
+		               "customer_password": "bob-pw",
 		               "razorpay_key_id": "rzp_test_X",
 		               "razorpay_order_id": "order_LEGACY",
 		               "amount_inr": 12000,
@@ -269,6 +278,13 @@ class TestSignupEmailVerification(FrappeTestCase):
 		self.assertEqual(
 			s.get_password("jarvis_admin_api_key", raise_exception=False),
 			"legacy-key",
+		)
+		# Flag-off path carries the OAuth password in the signup response; the
+		# bench persists it (+ the email) for bearer auth on subsequent calls.
+		self.assertEqual(s.get("jarvis_admin_customer_email"), "bob@example.com")
+		self.assertEqual(
+			s.get_password("jarvis_admin_customer_password", raise_exception=False),
+			"bob-pw",
 		)
 
 	def test_check_signup_payment_state_returns_pending(self):
@@ -293,6 +309,25 @@ class TestSignupEmailVerification(FrappeTestCase):
 			out = onboarding.check_signup_payment_state()
 		self.assertFalse(out["pending_verification"])
 		self.assertEqual(out["razorpay_order_id"], "order_VERIFIED")
+
+	def test_check_signup_payment_state_persists_customer_password(self):
+		# On the verified poll admin delivers the OAuth password once. The
+		# bench must persist it so later admin calls use bearer auth.
+		with patch("jarvis.onboarding.admin_client.get_signup_payment_state",
+		           return_value={
+		               "pending_verification": False,
+		               "razorpay_order_id": "order_VERIFIED",
+		               "razorpay_key_id": "rzp_test_X",
+		               "amount_inr": 12000,
+		               "customer_password": "verified-pw",
+		           }):
+			out = onboarding.check_signup_payment_state()
+		self.assertFalse(out["pending_verification"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("jarvis_admin_customer_password", raise_exception=False),
+			"verified-pw",
+		)
 
 	def test_check_signup_payment_state_requires_admin_url(self):
 		# Same pre-flight guard as start_signup - misconfigured bench


### PR DESCRIPTION
## What & why

Bench-side counterpart to admin PR **Aerele-RnD/jarvis-admin#139** (bench→admin OAuth). The customer bench now authenticates to the admin control plane with **short-lived OAuth bearer tokens** instead of the static `api_key:api_secret`, shrinking the blast radius of a leaked bench credential.

## How it works

`admin_client._post` now:
1. **Prefers OAuth.** Exchanges the customer's password for an access token at admin's native `…/oauth2.get_token` (**password grant**, public client `jarvis-bench`, **no `client_secret`**), caches it in Redis (`frappe.cache()`, site-scoped), and sends `Authorization: Bearer <token>`.
2. **Reuses the cached token** until ~1 min before expiry; on a miss, **refreshes** (best-effort) then **re-mints** via the password grant. A bearer **401 re-mints once**, then falls back.
3. **Falls back to legacy** `token <api_key>:<api_secret>` when no password is stored — existing customers keep working (admin accepts both during migration).

### Credential storage
New `Jarvis Settings` fields (read-only, populated at onboarding):
- `jarvis_admin_customer_email` (Data) — the OAuth grant username.
- `jarvis_admin_customer_password` (Password) — exchanged for bearer tokens.

`onboarding.py` persists these via `write_connection` on the signup response, and captures the password admin delivers on the **verified signup poll** (`check_signup_payment_state`) — matching the admin-side change that defers the password until the email is verified.

## Testing

- `test_admin_client` (43, incl. 4 new): bearer preferred + omits `client_secret`, token caching across calls, legacy fallback without password, bearer-401 → re-mint → legacy.
- `test_onboarding_sync` (22, incl. extended): email/password persisted on verify-on + flag-off signup shapes, and password captured on the verified poll.
- All HTTP mocked, following the existing `_fake_post` pattern. Ran on `site.jarvis`.

## Deploy notes

- `bench migrate` adds the two `Jarvis Settings` fields.
- Depends on admin PR #139 (the `jarvis-bench` OAuth client + verified-poll password delivery) being deployed for the OAuth path to activate; until then, benches use the legacy fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)