### PR TITLE
feat(tools): slim get_schema default + verbose opt-in

### DIFF
--- a/jarvis/tests/test_get_schema.py
+++ b/jarvis/tests/test_get_schema.py
@@ -13,24 +13,39 @@ class TestGetSchema(FrappeTestCase):
         fieldnames = {f["fieldname"] for f in result["fields"]}
         self.assertIn("customer_name", fieldnames)
 
-    def test_field_records_have_expected_keys(self):
+    def test_slim_default_returns_three_keys_per_field(self):
+        """The slim default keeps transcripts small. Each field record
+        carries fieldname / fieldtype / label and nothing else."""
         result = get_schema(doctype="Customer")
         f = result["fields"][0]
-        for key in ("fieldname", "fieldtype", "label"):
+        self.assertEqual(set(f.keys()), {"fieldname", "fieldtype", "label"})
+
+    def test_slim_default_does_not_expand_child_tables(self):
+        """In the slim shape, Table fields surface as ordinary records
+        with no child_fields recursion. Agent fetches the child DocType
+        explicitly if it needs to (cheap follow-up call vs. always
+        carrying the nested blob)."""
+        result = get_schema(doctype="Sales Invoice")
+        items_field = next(f for f in result["fields"] if f["fieldname"] == "items")
+        self.assertEqual(items_field["fieldtype"], "Table")
+        self.assertNotIn("child_fields", items_field)
+        # options is not in the slim shape either, so the agent has to
+        # call get_schema again on "Sales Invoice Item" or pass verbose.
+        self.assertNotIn("options", items_field)
+
+    def test_verbose_returns_all_five_keys_per_field(self):
+        """verbose=True restores the pre-slim shape: fieldname /
+        fieldtype / label / options / reqd."""
+        result = get_schema(doctype="Customer", verbose=True)
+        f = result["fields"][0]
+        for key in ("fieldname", "fieldtype", "label", "options", "reqd"):
             self.assertIn(key, f)
 
-    def test_rejects_unknown_doctype(self):
-        with self.assertRaises(InvalidArgumentError):
-            get_schema(doctype="Definitely Not A DocType")
-
-    def test_rejects_missing_argument(self):
-        with self.assertRaises(InvalidArgumentError):
-            get_schema(doctype="")
-
-    def test_expands_child_table_schemas(self):
-        # Sales Invoice has an `items` table pointing at Sales Invoice Item;
-        # the child schema should be inlined under `child_fields`.
-        result = get_schema(doctype="Sales Invoice")
+    def test_verbose_expands_child_table_schemas(self):
+        """verbose=True restores the inlined child schema for Table /
+        Table MultiSelect fields. Same shape as before the slim default
+        landed."""
+        result = get_schema(doctype="Sales Invoice", verbose=True)
         items_field = next(f for f in result["fields"] if f["fieldname"] == "items")
         self.assertEqual(items_field["fieldtype"], "Table")
         self.assertEqual(items_field["options"], "Sales Invoice Item")
@@ -39,10 +54,18 @@ class TestGetSchema(FrappeTestCase):
         self.assertIn("item_code", child_fieldnames)
         self.assertIn("qty", child_fieldnames)
 
-    def test_non_table_fields_have_no_child_fields_key(self):
-        result = get_schema(doctype="Customer")
+    def test_verbose_non_table_fields_have_no_child_fields_key(self):
+        result = get_schema(doctype="Customer", verbose=True)
         customer_name = next(f for f in result["fields"] if f["fieldname"] == "customer_name")
         self.assertNotIn("child_fields", customer_name)
+
+    def test_rejects_unknown_doctype(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_schema(doctype="Definitely Not A DocType")
+
+    def test_rejects_missing_argument(self):
+        with self.assertRaises(InvalidArgumentError):
+            get_schema(doctype="")
 
     def test_permission_check_blocks_unauthorized_user(self):
         # Create a user with no roles and switch to them.

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -5,7 +5,22 @@ from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 TABLE_FIELDTYPES = {"Table", "Table MultiSelect"}
 
 
-def _field_record(f) -> dict:
+def _field_record_slim(f) -> dict:
+	"""Minimum-token field shape: identifier, type, human label. This is
+	the default response - enough for the agent to frame a get_list filter
+	or a run_query column list without dumping the full Frappe meta into
+	the transcript."""
+	return {
+		"fieldname": f.fieldname,
+		"fieldtype": f.fieldtype,
+		"label": f.label,
+	}
+
+
+def _field_record_full(f) -> dict:
+	"""Full field shape: slim + options + reqd. Caller opts in via
+	``verbose=True`` when the extra keys matter (write paths checking
+	required, link-target inspection)."""
 	return {
 		"fieldname": f.fieldname,
 		"fieldtype": f.fieldtype,
@@ -15,17 +30,26 @@ def _field_record(f) -> dict:
 	}
 
 
-def get_schema(doctype: str) -> dict:
+def get_schema(doctype: str, verbose: bool = False) -> dict:
 	"""Return meta for a DocType: name and field list.
 
-	Child tables are expanded inline - each Table / Table MultiSelect field carries
-	a `child_fields` list with the schema of the linked child DocType, so the agent
-	gets the full hierarchy in one call. Frappe doesn't allow nested tables, so
-	expansion depth is bounded at 1.
+	By default the response is the slim shape (``fieldname``,
+	``fieldtype``, ``label`` per field) - enough for the agent to choose
+	fields for a follow-up ``get_list`` or ``run_query``. Pass
+	``verbose=True`` to include ``options`` (link targets, select choices)
+	and ``reqd``; in that mode each Table / Table MultiSelect field also
+	carries a ``child_fields`` list with the child DocType's slim shape
+	(no recursion - Frappe doesn't allow nested tables).
 
-	Enforces read permission on the parent DocType for the current user. Child-table
-	DocTypes are treated as part of the parent and are not permission-checked
-	separately.
+	The slim default keeps transcripts small on big DocTypes (Employee
+	alone has ~130 fields; the full shape pushed customers past their
+	model's context window and forced auto-compaction). Operators
+	triaging "is this field required" / "what does this link to" opt in
+	with verbose for one call.
+
+	Enforces read permission on the parent DocType for the current user.
+	Child-table DocTypes are treated as part of the parent and are not
+	permission-checked separately.
 	"""
 	if not doctype:
 		raise InvalidArgumentError("doctype is required")
@@ -36,12 +60,18 @@ def get_schema(doctype: str) -> dict:
 	if not frappe.has_permission(doctype, ptype="read"):
 		raise PermissionDeniedError(f"no read permission on {doctype}")
 
+	record_fn = _field_record_full if verbose else _field_record_slim
+
 	meta = frappe.get_meta(doctype)
 	fields = []
 	for f in meta.fields:
-		record = _field_record(f)
-		if f.fieldtype in TABLE_FIELDTYPES and f.options:
+		record = record_fn(f)
+		if verbose and f.fieldtype in TABLE_FIELDTYPES and f.options:
 			child_meta = frappe.get_meta(f.options)
-			record["child_fields"] = [_field_record(cf) for cf in child_meta.fields]
+			# Child fields use the same record shape as the parent. In the
+			# slim default we don't expand child tables at all - the agent
+			# can do a follow-up ``get_schema`` on the child DocType if
+			# needed.
+			record["child_fields"] = [_field_record_full(cf) for cf in child_meta.fields]
 		fields.append(record)
 	return {"doctype": doctype, "fields": fields}


### PR DESCRIPTION
A customer chat died mid-turn with "CLI transcript compaction failed for openai/gpt-5.5: Summarization failed: Connection error" when the agent fetched 8x get_schema (Employee + Timesheet + Timesheet Detail + Attendance + Communication + Email Queue + Email Queue Recipient + Email Account) for a "send email to employees who haven't filed timesheets" task. Each schema dump was the full Frappe meta (5 keys per field + recursive child_fields for tables); Employee alone has ~130 fields, so the transcript bloated past the model's context window and forced openclaw's auto-compaction. The summarization call hit a transport error and the whole turn died with no output.

The full meta is rarely what the agent actually needs. To frame a get_list filter or a run_query column list, the agent needs fieldname + fieldtype + label per field. That's it. options (link targets, select choices) and reqd matter only on write paths (create_doc, update_doc) and in operator-triage queries. Recursive child_fields nearly doubles the payload for any DocType with one or more Table fields, but the agent can do a follow-up get_schema on the child DocType if it needs to.

Change:

- get_schema(doctype, verbose=False) now returns the slim shape {fieldname, fieldtype, label} per field by default. No child_fields expansion in the slim path - Table fields surface as ordinary records with their fieldtype, the agent does a separate get_schema on the child DocType when needed.
- verbose=True restores the previous shape: 5 keys per field plus the inlined child_fields list for Table / Table MultiSelect.
- Split the _field_record helper into _field_record_slim (3 keys) and _field_record_full (5 keys); the loop picks the right one based on verbose.

This is a wire-shape change to the get_schema tool result. Callers that depend on options/reqd/child_fields must pass verbose=True (the persona is being updated in a paired change to make this discoverable).

Tests rewritten to pin both branches:
- slim default: 3 keys, no child_fields even on Table fields
- verbose: 5 keys, child_fields expanded for Table fields
- existing rejections (unknown DocType, empty arg, no perm) unchanged

9 tests pass (was 7). The registry's _accepted_params filter threads the new optional verbose kwarg through without registry changes.

Expected effect on the customer's failing prompt: ~70% reduction in the per-get_schema tool-result size, the transcript fits in one context window, compaction never fires, and the agent actually composes + sends the email this time.