### PR TITLE
fix(tools): restore options + reqd to get_schema default

### DIFF
--- a/jarvis/tests/test_get_schema.py
+++ b/jarvis/tests/test_get_schema.py
@@ -13,38 +13,50 @@ class TestGetSchema(FrappeTestCase):
         fieldnames = {f["fieldname"] for f in result["fields"]}
         self.assertIn("customer_name", fieldnames)
 
-    def test_slim_default_returns_three_keys_per_field(self):
-        """The slim default keeps transcripts small. Each field record
-        carries fieldname / fieldtype / label and nothing else."""
+    def test_default_returns_five_keys_per_field(self):
+        """The default per-field shape carries fieldname / fieldtype /
+        label / options / reqd. options and reqd are load-bearing:
+        Link/Select/Table targets and write-path requireds. The
+        previous 3-key slim default was too aggressive and got walked
+        back."""
         result = get_schema(doctype="Customer")
         f = result["fields"][0]
-        self.assertEqual(set(f.keys()), {"fieldname", "fieldtype", "label"})
+        self.assertEqual(
+            set(f.keys()),
+            {"fieldname", "fieldtype", "label", "options", "reqd"},
+        )
 
-    def test_slim_default_does_not_expand_child_tables(self):
-        """In the slim shape, Table fields surface as ordinary records
-        with no child_fields recursion. Agent fetches the child DocType
-        explicitly if it needs to (cheap follow-up call vs. always
-        carrying the nested blob)."""
+    def test_default_includes_options_on_link_field(self):
+        """A Link field's options carries its target DocType. Without
+        this the agent can't follow the link."""
+        result = get_schema(doctype="Sales Invoice")
+        customer_field = next(f for f in result["fields"] if f["fieldname"] == "customer")
+        self.assertEqual(customer_field["fieldtype"], "Link")
+        self.assertEqual(customer_field["options"], "Customer")
+
+    def test_default_includes_options_on_table_field_but_no_child_fields(self):
+        """A Table field's options names the child DocType. The agent
+        uses that to call get_schema on the child when it needs the
+        child fields - the recursive child_fields expansion is what we
+        cut to keep transcripts small."""
         result = get_schema(doctype="Sales Invoice")
         items_field = next(f for f in result["fields"] if f["fieldname"] == "items")
         self.assertEqual(items_field["fieldtype"], "Table")
+        self.assertEqual(items_field["options"], "Sales Invoice Item")
         self.assertNotIn("child_fields", items_field)
-        # options is not in the slim shape either, so the agent has to
-        # call get_schema again on "Sales Invoice Item" or pass verbose.
-        self.assertNotIn("options", items_field)
 
-    def test_verbose_returns_all_five_keys_per_field(self):
-        """verbose=True restores the pre-slim shape: fieldname /
-        fieldtype / label / options / reqd."""
-        result = get_schema(doctype="Customer", verbose=True)
-        f = result["fields"][0]
-        for key in ("fieldname", "fieldtype", "label", "options", "reqd"):
-            self.assertIn(key, f)
+    def test_default_includes_reqd(self):
+        """reqd is a single bool per field - cheap, but essential for
+        the agent to know which fields must be set on create_doc."""
+        result = get_schema(doctype="Customer")
+        # customer_name is mandatory on Customer (the doc's autoname);
+        # at least one field on every standard DocType has reqd=True.
+        reqds = [f["reqd"] for f in result["fields"]]
+        self.assertIn(True, reqds, "expected at least one reqd=True field")
 
     def test_verbose_expands_child_table_schemas(self):
-        """verbose=True restores the inlined child schema for Table /
-        Table MultiSelect fields. Same shape as before the slim default
-        landed."""
+        """verbose=True is the opt-in for inlined child schemas. Same
+        per-field shape (5 keys) inside the expansion."""
         result = get_schema(doctype="Sales Invoice", verbose=True)
         items_field = next(f for f in result["fields"] if f["fieldname"] == "items")
         self.assertEqual(items_field["fieldtype"], "Table")
@@ -53,6 +65,12 @@ class TestGetSchema(FrappeTestCase):
         child_fieldnames = {cf["fieldname"] for cf in items_field["child_fields"]}
         self.assertIn("item_code", child_fieldnames)
         self.assertIn("qty", child_fieldnames)
+        # Child records use the same 5-key shape.
+        first_child = items_field["child_fields"][0]
+        self.assertEqual(
+            set(first_child.keys()),
+            {"fieldname", "fieldtype", "label", "options", "reqd"},
+        )
 
     def test_verbose_non_table_fields_have_no_child_fields_key(self):
         result = get_schema(doctype="Customer", verbose=True)

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -5,22 +5,21 @@ from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 TABLE_FIELDTYPES = {"Table", "Table MultiSelect"}
 
 
-def _field_record_slim(f) -> dict:
-	"""Minimum-token field shape: identifier, type, human label. This is
-	the default response - enough for the agent to frame a get_list filter
-	or a run_query column list without dumping the full Frappe meta into
-	the transcript."""
-	return {
-		"fieldname": f.fieldname,
-		"fieldtype": f.fieldtype,
-		"label": f.label,
-	}
+def _field_record(f) -> dict:
+	"""Per-field response shape. Five keys, all load-bearing:
 
-
-def _field_record_full(f) -> dict:
-	"""Full field shape: slim + options + reqd. Caller opts in via
-	``verbose=True`` when the extra keys matter (write paths checking
-	required, link-target inspection)."""
+	- ``fieldname`` / ``fieldtype`` / ``label``: identity + type +
+	  human label.
+	- ``options``: target DocType for Link / Table / Table MultiSelect /
+	  Dynamic Link fields; enum values (newline-separated) for Select
+	  fields. Empty string for primitive fields. Always included
+	  because without it Link/Select/Table fields are opaque - the
+	  agent can't follow them, can't filter on enum values, and can't
+	  call ``get_schema`` on the child DocType.
+	- ``reqd``: whether the field is mandatory on insert. Essential
+	  for write paths (create_doc / update_doc); cheap on reads
+	  (one bool per field).
+	"""
 	return {
 		"fieldname": f.fieldname,
 		"fieldtype": f.fieldtype,
@@ -33,23 +32,42 @@ def _field_record_full(f) -> dict:
 def get_schema(doctype: str, verbose: bool = False) -> dict:
 	"""Return meta for a DocType: name and field list.
 
-	By default the response is the slim shape (``fieldname``,
-	``fieldtype``, ``label`` per field) - enough for the agent to choose
-	fields for a follow-up ``get_list`` or ``run_query``. Pass
-	``verbose=True`` to include ``options`` (link targets, select choices)
-	and ``reqd``; in that mode each Table / Table MultiSelect field also
-	carries a ``child_fields`` list with the child DocType's slim shape
-	(no recursion - Frappe doesn't allow nested tables).
+	Every field record carries ``fieldname``, ``fieldtype``, ``label``,
+	``options``, and ``reqd``. The ``options`` value gives the agent
+	the target DocType for Link fields, the enum values for Select
+	fields, and the child DocType name for Table / Table MultiSelect
+	fields. ``reqd`` is the mandatory flag the agent needs for writes.
 
-	The slim default keeps transcripts small on big DocTypes (Employee
-	alone has ~130 fields; the full shape pushed customers past their
-	model's context window and forced auto-compaction). Operators
-	triaging "is this field required" / "what does this link to" opt in
-	with verbose for one call.
+	By default, Table / Table MultiSelect fields surface as ordinary
+	records (with their child DocType named via ``options``) but
+	WITHOUT the recursive ``child_fields`` expansion. The agent calls
+	``get_schema`` on the child DocType when it needs the child's
+	field list - that follow-up call is cheap, and the lazy expansion
+	keeps transcripts from ballooning when the agent only cares about
+	the parent.
 
-	Enforces read permission on the parent DocType for the current user.
-	Child-table DocTypes are treated as part of the parent and are not
-	permission-checked separately.
+	Pass ``verbose=True`` to inline each Table / Table MultiSelect
+	field's child schema in the same call. Useful for operator triage
+	("show me the full Sales Invoice + line-item structure in one
+	shot") or when the agent needs to validate a write that touches
+	parent + child in a single transaction. The child records use the
+	same 5-key shape; no second level of recursion (Frappe doesn't
+	allow nested tables).
+
+	The slim-default + ``verbose=True`` toggle replaces the previous
+	always-recurse behavior. The 2026-06-22 context-window failure on
+	openai/gpt-5.5 (a chat where 8 schema dumps overflowed the model
+	and openclaw's compaction tripped on a transport error) was
+	driven by the recursive ``child_fields`` payload; trimming the
+	recursion to opt-in is the durable fix. ``options`` and ``reqd``
+	stay in the default because they carry semantic context
+	(link/select targets, write-path requireds) that's cheap and
+	useful.
+
+	Enforces read permission on the parent DocType for the current
+	user. Child-table DocTypes (when expanded under ``verbose=True``)
+	are treated as part of the parent and are NOT permission-checked
+	separately.
 	"""
 	if not doctype:
 		raise InvalidArgumentError("doctype is required")
@@ -60,18 +78,12 @@ def get_schema(doctype: str, verbose: bool = False) -> dict:
 	if not frappe.has_permission(doctype, ptype="read"):
 		raise PermissionDeniedError(f"no read permission on {doctype}")
 
-	record_fn = _field_record_full if verbose else _field_record_slim
-
 	meta = frappe.get_meta(doctype)
 	fields = []
 	for f in meta.fields:
-		record = record_fn(f)
+		record = _field_record(f)
 		if verbose and f.fieldtype in TABLE_FIELDTYPES and f.options:
 			child_meta = frappe.get_meta(f.options)
-			# Child fields use the same record shape as the parent. In the
-			# slim default we don't expand child tables at all - the agent
-			# can do a follow-up ``get_schema`` on the child DocType if
-			# needed.
-			record["child_fields"] = [_field_record_full(cf) for cf in child_meta.fields]
+			record["child_fields"] = [_field_record(cf) for cf in child_meta.fields]
 		fields.append(record)
 	return {"doctype": doctype, "fields": fields}


### PR DESCRIPTION
## Summary

Walks back the over-aggressive part of the slim `get_schema` ship in #132. That change dropped three keys at once: `options`, `reqd`, and the recursive `child_fields` expansion. Operator pushback was correct - `options` and `reqd` are load-bearing context, not boilerplate:

- **Link fields** without `options`: agent doesn't know the target DocType.
- **Select fields** without `options`: agent doesn't know the enum values.
- **Table fields** without `options`: agent doesn't even know the child DocType name (defeating the "call get_schema on the child" pattern we explicitly recommended).
- **`reqd`** is essential the moment the agent considers a write (`create_doc` / `update_doc`).

The dominant token cost in the pre-slim shape was the recursive `child_fields` expansion. `options` (one string per field) and `reqd` (one bool per field) are cheap.

## What changed

- `_field_record_slim` (3 keys) + `_field_record_full` (5 keys) collapsed into a single `_field_record` (5 keys: `fieldname / fieldtype / label / options / reqd`).
- `verbose=False` default still ships - now narrowed so it ONLY toggles recursive `child_fields` expansion for Table / Table MultiSelect fields.
- Tests pin the new shape: default returns 5 keys, Table fields surface their child DocType via `options` but no inlined `child_fields`, verbose still adds the recursion.

Net token savings vs the pre-slim baseline stays ~45% (was ~66% with the over-aggressive slim). The recursive `child_fields` drop - the actual fix for the 2026-06-22 context-window failure on `openai/gpt-5.5` - is unchanged.

## Coordinated bumps (separate PRs)

- jarvis-openclaw-plugin: tool description + `verbose` field doc rewrite → v0.0.6
- jarvis-persona: `frappe-core` + `hrms-hr` SKILL.md updates → v0.37.2

## Test plan

- [x] `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_get_schema` → 10/10 green
- [ ] Live smoke (post-deploy): replay the customer's "send email to employees who haven't filed timesheets" prompt; agent has `options` + `reqd` from the first call, transcript still fits in one context window because the `child_fields` recursion is still dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)