### PR TITLE
feat(tools): row guard on get_list + run_query

### DIFF
--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -14,6 +14,48 @@ class InvalidArgumentError(JarvisError):
     """Raised when tool arguments fail validation."""
 
 
+class ResultTooLargeError(InvalidArgumentError):
+    """Raised when a row-dumping tool's result exceeds the guard threshold
+    and the caller did not opt in with ``confirm_large=True``.
+
+    Background: the 2026-06-22 customer outage on openai/gpt-5.5 traced to
+    a single chat turn that accumulated 800+ row Timesheet Detail dumps
+    and 776-row joined query results into the agent transcript. Openclaw
+    tried to auto-compact and the upstream summarization call hit a
+    transport error - the whole turn died. The slim-`get_schema` walk-back
+    (PR #133) cut the schema side of the bloat; the row guard handles the
+    other axis (query result size).
+
+    The guard is per-call, not per-turn. It blocks the wasteful payload
+    from ever reaching the transcript by raising at the bench layer, with
+    a structured error the agent can act on. Three actions the agent
+    can take (in priority order): narrow the filter, aggregate with
+    GROUP BY / COUNT / SUM, or pass ``confirm_large=True`` for the rare
+    workflows where every row IS the answer (audit exports, bulk
+    reconciliation).
+
+    Inherits from InvalidArgumentError so existing error envelopes route
+    it the same way; the ``row_count`` / ``limit`` / ``tool`` attributes
+    let downstream classifiers branch on it specifically if needed.
+    """
+
+    def __init__(self, row_count: int, limit: int, tool: str):
+        self.row_count = row_count
+        self.limit = limit
+        self.tool = tool
+        message = (
+            f"{tool} returned {row_count} rows, which exceeds the "
+            f"{limit}-row default. To resolve: (a) narrow the filter "
+            f"to match fewer rows, (b) aggregate with GROUP BY / "
+            f"COUNT / SUM if you need a summary, or (c) pass "
+            f"confirm_large=True if you genuinely need every row "
+            f"(rare; usually means export, not chat answer). The "
+            f"{limit}-row limit exists because large row sets in the "
+            f"agent transcript cause context-window failures."
+        )
+        super().__init__(message)
+
+
 class OpenclawUnreachableError(JarvisError):
     """Raised when the openclaw gateway can't be reached (WS handshake
     failed, container down).

--- a/jarvis/tests/test_get_list.py
+++ b/jarvis/tests/test_get_list.py
@@ -1,8 +1,12 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools.get_list import get_list
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+    ResultTooLargeError,
+)
+from jarvis.tools.get_list import ROW_GUARD, get_list
 
 
 def _ensure_master_data():
@@ -78,6 +82,41 @@ class TestGetList(FrappeTestCase):
     def test_rejects_missing_doctype(self):
         with self.assertRaises(InvalidArgumentError):
             get_list(doctype="", fields=["name"])
+
+    def test_row_guard_fires_above_threshold(self):
+        """A get_list call that returns more than ROW_GUARD rows must
+        raise ResultTooLargeError when confirm_large is not set. DocType
+        is a stable, populated system table on any Frappe site - hundreds
+        of rows guaranteed - so we use it as the fixture and don't need
+        to seed."""
+        with self.assertRaises(ResultTooLargeError) as cm:
+            get_list(
+                doctype="DocType",
+                fields=["name"],
+                limit=ROW_GUARD + 50,
+            )
+        err = cm.exception
+        self.assertGreater(err.row_count, ROW_GUARD)
+        self.assertEqual(err.limit, ROW_GUARD)
+        self.assertEqual(err.tool, "get_list")
+        self.assertIn("confirm_large", str(err))
+
+    def test_row_guard_silent_under_threshold(self):
+        rows = get_list(
+            doctype="DocType",
+            fields=["name"],
+            limit=ROW_GUARD - 50,
+        )
+        self.assertLessEqual(len(rows), ROW_GUARD - 50)
+
+    def test_row_guard_opt_in_bypasses(self):
+        rows = get_list(
+            doctype="DocType",
+            fields=["name"],
+            limit=ROW_GUARD + 50,
+            confirm_large=True,
+        )
+        self.assertGreater(len(rows), ROW_GUARD)
 
     def test_permission_check_blocks_unauthorized_user(self):
         user_email = "listless@example.com"

--- a/jarvis/tests/test_run_query.py
+++ b/jarvis/tests/test_run_query.py
@@ -5,8 +5,12 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools.run_query import run_query
+from jarvis.exceptions import (
+	InvalidArgumentError,
+	PermissionDeniedError,
+	ResultTooLargeError,
+)
+from jarvis.tools.run_query import ROW_GUARD, run_query
 
 
 class TestRunQueryValidation(FrappeTestCase):
@@ -383,3 +387,49 @@ class TestRunQueryHappyPath(FrappeTestCase):
 		result = run_query("SELECT COUNT(*) AS n FROM tabDocType", limit=1)
 		self.assertEqual(len(result["rows"]), 1)
 		self.assertIn("n", result["rows"][0])
+
+
+class TestRunQueryRowGuard(FrappeTestCase):
+	"""The row guard refuses to return more than ``ROW_GUARD`` rows unless
+	the caller opts in with ``confirm_large=True``. ``tabDocType`` has
+	hundreds of rows on every Frappe site, so it makes a stable fixture
+	for the over-threshold case.
+	"""
+
+	def test_guard_fires_above_threshold(self):
+		with self.assertRaises(ResultTooLargeError) as cm:
+			run_query(
+				"SELECT name FROM tabDocType",
+				limit=ROW_GUARD + 50,
+			)
+		err = cm.exception
+		self.assertGreater(err.row_count, ROW_GUARD)
+		self.assertEqual(err.limit, ROW_GUARD)
+		self.assertEqual(err.tool, "run_query")
+		self.assertIn("confirm_large", str(err))
+
+	def test_guard_silent_under_threshold(self):
+		result = run_query(
+			"SELECT name FROM tabDocType",
+			limit=ROW_GUARD - 50,
+		)
+		self.assertLessEqual(len(result["rows"]), ROW_GUARD - 50)
+
+	def test_guard_opt_in_bypasses(self):
+		result = run_query(
+			"SELECT name FROM tabDocType",
+			limit=ROW_GUARD + 50,
+			confirm_large=True,
+		)
+		self.assertGreater(len(result["rows"]), ROW_GUARD)
+
+	def test_guard_message_carries_actionable_hints(self):
+		"""The error message must mention narrowing, aggregating, and the
+		confirm_large opt-in - that's what the agent uses to retry. If we
+		ever change the wording, this test pins the actionable triple."""
+		with self.assertRaises(ResultTooLargeError) as cm:
+			run_query("SELECT name FROM tabDocType", limit=ROW_GUARD + 10)
+		msg = str(cm.exception).lower()
+		self.assertIn("narrow", msg)
+		self.assertIn("aggregate", msg)
+		self.assertIn("confirm_large", msg)

--- a/jarvis/tools/get_list.py
+++ b/jarvis/tools/get_list.py
@@ -1,8 +1,20 @@
 import frappe
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.exceptions import (
+    InvalidArgumentError,
+    PermissionDeniedError,
+    ResultTooLargeError,
+)
 
 MAX_LIMIT = 1000
+
+# Row guard: refuse a result over this size unless the caller passes
+# ``confirm_large=True``. Sits below ``MAX_LIMIT`` (the hard ceiling on
+# Frappe's ``limit`` parameter) and above the default ``limit=20`` so
+# narrow queries fit silently and only the agent's wide ``limit=N``
+# calls trigger the guard. See ``ResultTooLargeError`` for the
+# 2026-06-22 outage that motivated this.
+ROW_GUARD = 200
 
 
 def get_list(
@@ -11,11 +23,18 @@ def get_list(
     filters: dict | list | None = None,
     order_by: str | None = None,
     limit: int = 20,
+    confirm_large: bool = False,
 ) -> list[dict]:
     """List documents with filters.
 
     Frappe's get_list applies per-user record permissions automatically.
     We additionally enforce DocType-level read permission and cap the limit.
+
+    Row guard: results above ``ROW_GUARD`` (200) rows raise
+    ``ResultTooLargeError`` unless ``confirm_large=True``. The agent
+    should respond by narrowing the filter, aggregating the question
+    via ``run_query``, or - for genuine export workflows - retrying
+    with ``confirm_large=True``.
     """
     if not doctype:
         raise InvalidArgumentError("doctype is required")
@@ -25,10 +44,17 @@ def get_list(
     if not frappe.has_permission(doctype, ptype="read"):
         raise PermissionDeniedError(f"no read permission on {doctype}")
 
-    return frappe.get_list(
+    rows = frappe.get_list(
         doctype,
         fields=fields or ["name"],
         filters=filters or {},
         order_by=order_by,
         limit=limit,
     )
+    if len(rows) > ROW_GUARD and not confirm_large:
+        raise ResultTooLargeError(
+            row_count=len(rows),
+            limit=ROW_GUARD,
+            tool="get_list",
+        )
+    return rows

--- a/jarvis/tools/run_query.py
+++ b/jarvis/tools/run_query.py
@@ -27,10 +27,23 @@ import sqlparse
 from sqlparse.sql import Identifier, IdentifierList
 from sqlparse.tokens import DDL, DML, Keyword
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.exceptions import (
+	InvalidArgumentError,
+	PermissionDeniedError,
+	ResultTooLargeError,
+)
 
 MAX_LIMIT = 1000
 DEFAULT_LIMIT = 100
+
+# Row guard: refuse a result over this size unless the caller passes
+# ``confirm_large=True``. Sits below ``MAX_LIMIT`` (the hard ceiling on
+# the SQL ``LIMIT`` clause) and above the default ``DEFAULT_LIMIT`` so
+# that ordinary queries with no explicit limit fit silently and only
+# the agent's wide ``limit=N`` calls trigger the guard. See the
+# ``ResultTooLargeError`` docstring for the load-bearing rationale (the
+# 2026-06-22 outage on openai/gpt-5.5).
+ROW_GUARD = 200
 
 # Identifiers we refuse outright in any token stream - covers single-line
 # comments (--), block comments (/* */), and forbidden statement types that
@@ -79,12 +92,24 @@ _TABLE_RE = re.compile(
 )
 
 
-def run_query(query: str, limit: int = DEFAULT_LIMIT) -> dict:
+def run_query(
+	query: str,
+	limit: int = DEFAULT_LIMIT,
+	confirm_large: bool = False,
+) -> dict:
 	"""Execute a validated read-only SELECT and return rows + the executed SQL.
 
 	Returns ``{"sql": <final query with limit>, "rows": [...]}``. The
 	executed SQL is included so the model can show the user what ran and so
 	debugging is straightforward.
+
+	Row guard: results above ``ROW_GUARD`` (200) rows raise
+	``ResultTooLargeError`` unless ``confirm_large=True``. The agent should
+	respond to that error by narrowing the filter, aggregating the query
+	(``GROUP BY``/``COUNT``/``SUM``), or - when a row dump genuinely IS the
+	answer (export, audit) - retrying with ``confirm_large=True``. See the
+	``ResultTooLargeError`` docstring for the 2026-06-22 outage that
+	motivated this guard.
 	"""
 	if not query or not query.strip():
 		raise InvalidArgumentError("query is required")
@@ -135,6 +160,12 @@ def run_query(query: str, limit: int = DEFAULT_LIMIT) -> dict:
 	if rows and not isinstance(rows[0], dict):
 		raise InvalidArgumentError(
 			"query did not return named columns; add explicit column aliases"
+		)
+	if len(rows) > ROW_GUARD and not confirm_large:
+		raise ResultTooLargeError(
+			row_count=len(rows),
+			limit=ROW_GUARD,
+			tool="run_query",
 		)
 	return {"sql": final, "rows": rows}
 


### PR DESCRIPTION
## Summary

Add a 200-row guard to the two row-dumping tools. Results above the threshold raise `ResultTooLargeError` unless the agent opts in with `confirm_large=True`. The error message names the three remediation paths: narrow the filter, aggregate, or opt in.

## Motivation

Live smoke of the slim-`get_schema` walk-back (#133) revealed a second axis of transcript bloat - the agent's query strategy. The timesheet prompt pulled 803 rows of Timesheet Detail names + 776 rows of joined time-log data, both intermediate exploration the final 199-row missing-date answer never used. Even with slim schemas, that much row-dump per turn pushes openclaw's auto-compact toward the model's context ceiling, and the turn timed out.

The guard sits at the bench layer (before openclaw sees the result) and forces the agent to either narrow/aggregate (the correct answer for chat questions) or explicitly confirm (the right escape hatch for export or audit workflows).

## Design choices

- **Threshold 200**: above the typical chat-answer row count, below the 1000-row hard ceiling. Tunable from a single constant per tool if telemetry surfaces a tighter or looser need.
- `ResultTooLargeError` inherits from `InvalidArgumentError` so the existing tool-error envelope routes it without code changes.
- `confirm_large` is per-call, not a session flag - keeps the safe default sticky.
- Guard is per-tool (`run_query.ROW_GUARD` + `get_list.ROW_GUARD`) rather than a shared global so each can evolve independently.
- The error message lists the three actionable retries explicitly so the agent has a stable contract to act on.

## Failure case before vs. after

**Before** (the timesheet outage):
```
run_query("SELECT ... time_logs JOIN ...", limit=1000)
→ 776 rows returned silently
→ payload enters openclaw transcript
→ next compaction pass tries to summarize; model context wall
→ turn timed out
```

**After**:
```
run_query("SELECT ... time_logs JOIN ...", limit=1000)
→ ResultTooLargeError: run_query returned 776 rows, exceeds 200-row default.
  Narrow / aggregate / pass confirm_large=True
→ agent retries with GROUP BY employee, DATE(from_time)
→ ~80 rows back, fits comfortably
→ turn completes
```

## Test plan

- [x] `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_get_list` → 8/8 green (3 new row-guard tests + existing 5).
- [x] `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_run_query` → 38/38 green (4 new row-guard tests + existing 34).
- [ ] Live smoke after deploy: replay the timesheet prompt, expect the agent to bounce off the guard on its wasteful 776-row query and retry with a GROUP BY shape that fits.

## Coordinated PRs

- Plugin (`jarvis-openclaw-plugin`): add `confirm_large` to `GetListSchema` and `RunQuerySchema`, update tool descriptions to reference the guard. Plugin v0.0.7. (next)
- Persona (`jarvis-persona`): one-paragraph principle in `frappe-core/SKILL.md` pointing the agent at the guard semantics. v0.37.3. (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)