### PR TITLE
chat: bump turn + RQ-envelope timeouts for FC + Hetzner WAN

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -16,13 +16,18 @@ MSG = "Jarvis Chat Message"
 # Wall-clock budget for the RQ worker that runs one agent turn.
 #
 # Covers worst case end-to-end: pair (<=90s admin round-trip) +
-# WS connect (10s) + TURN_TIMEOUT_SECONDS (180s) = 280s. 300s gives
-# 20s headroom. Previously this was hardcoded as ``timeout=300``
-# at both enqueue sites (send_message + retry_message) so a bump
-# had to land in two places - the 2026-06-16 review caught a
-# previous 200s ceiling that had drifted to 300s in one site but
-# stayed 200s in the other.
-_AGENT_TURN_WORKER_TIMEOUT = 300
+# WS connect (10s) + TURN_TIMEOUT_SECONDS (600s) = 700s. 720s gives
+# 20s headroom. Bumped from 300s in lockstep with the
+# TURN_TIMEOUT_SECONDS bump to 600s (see openclaw_client.py for the
+# Frappe-Cloud + Hetzner WAN rationale - the bench RQ envelope has
+# to be larger than the WS turn cap or the worker dies first and
+# the WS cap never gets a chance to enforce). Previously this was
+# hardcoded as ``timeout=300`` at both enqueue sites (send_message
+# + retry_message) so a bump had to land in two places - the
+# 2026-06-16 review caught a previous 200s ceiling that had drifted
+# to 300s in one site but stayed 200s in the other; consolidating
+# behind this constant prevents that drift.
+_AGENT_TURN_WORKER_TIMEOUT = 720
 
 # Process-local cache for the chat bundle hash. Invalidated by mtime so a
 # `bench build` is picked up without restarting workers.

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -65,7 +65,22 @@ def _is_response_frame(frame: dict, req_id: str) -> bool:
 from jarvis.exceptions import OpenclawUnreachableError
 
 CONNECT_TIMEOUT_SECONDS = 10
-TURN_TIMEOUT_SECONDS = 180
+# Wall-clock cap on one agent turn waiting for the WS lifecycle to
+# complete (final lifecycle "end" frame from openclaw). Was 180s when
+# the bench + openclaw container ran on the same host (sub-ms WS
+# RTT); bumped to 600s after a Frappe-Cloud-hosted bench + Hetzner-
+# hosted openclaw deploy hit the 180s cap on multi-recipient
+# announcement turns. Each tool call now crosses the public internet
+# (~50-200ms WAN RTT depending on FC↔Hetzner region pairing); a
+# typical multi-step turn with ~30 tool calls + a 26-recipient batch
+# send hit ~4-8s of pure network overhead alone, then ran past the
+# 180s ceiling before openclaw emitted lifecycle-end. The row-guard
+# walk-back (jarvis#134) cut the tool-call count meaningfully but
+# WAN latency is a structural floor; the timeout has to absorb it.
+# The matching RQ envelope ``_AGENT_TURN_WORKER_TIMEOUT`` in
+# jarvis/chat/api.py was bumped in lockstep so the worker has room
+# for this turn + pair + WS connect overhead.
+TURN_TIMEOUT_SECONDS = 600
 
 # Scopes the chat path needs: operator.write for sessions.create + agent;
 # operator.admin so the same connection can also read state (status snapshots,


### PR DESCRIPTION
## Summary

The customer-side test on Frappe Cloud (bench) + Hetzner (openclaw container) hit `Run abandoned (worker did not finish within the timeout)` on a multi-recipient announcement turn. The agent produced the correct answer (26 employees, missing-day counts, confirmation prompt) but the bench didn't deliver it before either the WS turn cap or the RQ worker cap fired.

## Diagnosis

When bench and openclaw are co-located the WS RTT is sub-millisecond and the prior 180s/300s pair was generous. On FC + Hetzner each tool call crosses the public internet (~50-200ms WAN RTT depending on region pairing). A ~30-tool-call multi-step turn plus a 26-recipient send batch piles up several seconds of pure network overhead on top of model thinking time, pushing the wall-clock past the old 180s WS turn cap before openclaw emits lifecycle-end.

## What changed

| Constant | Old | New | Reason |
|---|---|---|---|
| `TURN_TIMEOUT_SECONDS` (`openclaw_client.py`) | 180s | 600s | The outer WS-side wait for lifecycle-end. This is the cap that actually fired first under WAN. |
| `_AGENT_TURN_WORKER_TIMEOUT` (`api.py`) | 300s | 720s | RQ envelope around the WS turn. Must exceed WS cap + pair (90s) + WS-connect (10s) + 20s headroom, else the worker dies first. |

## Why both have to move together

If only the WS cap bumps, the RQ worker still dies at 300s and the bench gives up via a different error path (the one we just saw). If only the RQ cap bumps, the WS turn still dies at 180s. They form a budget ladder - the WS cap is the actual agent-turn ceiling, the RQ cap is the envelope around the whole job. The envelope must be larger than the inner cap + the pre-turn overhead.

## What this fix doesn't do

The WAN latency itself is structural - this PR absorbs it into the budget rather than removing it. The follow-up move that actually removes the WAN amplification is a **batch `send_email` tool**: collapses 26 sequential send_email round-trips into 1, saves ~4s of WAN overhead on every multi-recipient announcement. Composes cleanly with this timeout bump - the timeouts give breathing room now; the batch tool removes the breathing-room debt later.

## Test plan

- [x] `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_get_list` → 8/8 green
- [x] `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_run_query` → 38/38 green
- No test pins the old timeout values
- [ ] Live customer-site smoke after deploy: replay the timesheet announcement prompt; expect the agent to produce + deliver the response within the new budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)