### PR TITLE
feat(gemini): expose active Gemini models via subscription catalogue

### DIFF
--- a/jarvis/_subscription_models.py
+++ b/jarvis/_subscription_models.py
@@ -30,10 +30,14 @@ from __future__ import annotations
 
 SUBSCRIPTION_MODELS: dict[str, list[str]] = {
 	"OpenAI": ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
-	"Google Gemini": ["gemini-2.0-pro", "gemini-1.5-pro", "gemini-1.5-flash"],
+	"Google Gemini": [
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+		"gemini-3.1-flash",
+	],
 }
 
 DEFAULT_MODEL: dict[str, str] = {
 	"OpenAI": "gpt-5.5",
-	"Google Gemini": "gemini-2.0-pro",
+	"Google Gemini": "gemini-2.5-pro",
 }

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -15,7 +15,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const PROVIDER_DEFAULTS = {
 		"Anthropic":          { model: "claude-sonnet-4-6",                 baseUrl: "https://api.anthropic.com" },
 		"OpenAI":             { model: "gpt-4o",                            baseUrl: "https://api.openai.com/v1" },
-		"Google Gemini":      { model: "gemini-1.5-pro",                    baseUrl: "https://generativelanguage.googleapis.com" },
+		"Google Gemini":      { model: "gemini-2.5-pro",                    baseUrl: "https://generativelanguage.googleapis.com" },
 		"Mistral":            { model: "mistral-large-latest",              baseUrl: "https://api.mistral.ai/v1" },
 		"Groq":               { model: "llama-3.3-70b-versatile",           baseUrl: "https://api.groq.com/openai/v1" },
 		"Together AI":        { model: "meta-llama/Llama-3.3-70B-Instruct-Turbo", baseUrl: "https://api.together.xyz/v1" },

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js
@@ -58,7 +58,7 @@ frappe.pages["jarvis-onboarding"].on_page_load = function (wrapper) {
 	const PROVIDER_DEFAULTS = {
 		"Anthropic":          { model: "claude-sonnet-4-6",                 baseUrl: "https://api.anthropic.com" },
 		"OpenAI":             { model: "gpt-4o",                            baseUrl: "https://api.openai.com/v1" },
-		"Google Gemini":      { model: "gemini-1.5-pro",                    baseUrl: "https://generativelanguage.googleapis.com" },
+		"Google Gemini":      { model: "gemini-2.5-pro",                    baseUrl: "https://generativelanguage.googleapis.com" },
 		"Mistral":            { model: "mistral-large-latest",              baseUrl: "https://api.mistral.ai/v1" },
 		"Groq":               { model: "llama-3.3-70b-versatile",           baseUrl: "https://api.groq.com/openai/v1" },
 		"Together AI":        { model: "meta-llama/Llama-3.3-70B-Instruct-Turbo", baseUrl: "https://api.together.xyz/v1" },

--- a/jarvis/tests/test_subscription_models.py
+++ b/jarvis/tests/test_subscription_models.py
@@ -1,0 +1,40 @@
+"""Tests for jarvis._subscription_models - the subscription model catalogue."""
+import json
+import unittest
+
+from jarvis import _subscription_models as cat
+from jarvis.oauth.api import _coerce_subscription_model
+
+GEMINI = "Google Gemini"
+EXPECTED_GEMINI = [
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-3.1-flash",
+]
+
+
+class TestSubscriptionCatalogue(unittest.TestCase):
+    def test_gemini_list_is_active_set(self):
+        self.assertEqual(cat.SUBSCRIPTION_MODELS[GEMINI], EXPECTED_GEMINI)
+
+    def test_gemini_default_is_in_list(self):
+        self.assertEqual(cat.DEFAULT_MODEL[GEMINI], "gemini-2.5-pro")
+        self.assertIn(cat.DEFAULT_MODEL[GEMINI], cat.SUBSCRIPTION_MODELS[GEMINI])
+
+    def test_catalogue_values_are_json_serializable_lists(self):
+        json.dumps(cat.SUBSCRIPTION_MODELS)  # must not raise
+        for value in cat.SUBSCRIPTION_MODELS.values():
+            self.assertIsInstance(value, list)
+
+    def test_coerce_accepts_every_active_gemini_model(self):
+        for model in EXPECTED_GEMINI:
+            self.assertEqual(_coerce_subscription_model(GEMINI, model), model)
+
+    def test_coerce_falls_back_to_default_for_bogus_and_empty(self):
+        self.assertEqual(_coerce_subscription_model(GEMINI, "nope"), "gemini-2.5-pro")
+        self.assertEqual(_coerce_subscription_model(GEMINI, ""), "gemini-2.5-pro")
+
+    def test_openai_entry_unchanged(self):
+        self.assertEqual(cat.SUBSCRIPTION_MODELS["OpenAI"],
+                         ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"])
+        self.assertEqual(cat.DEFAULT_MODEL["OpenAI"], "gpt-5.5")


### PR DESCRIPTION
Refresh SUBSCRIPTION_MODELS['Google Gemini'] to the active GA models (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-flash; default gemini-2.5-pro) and sync the two JS fallback defaults. Provider-generic consumers (chat/api, oauth/api, chat/worker) expose all of them with no further change, mirroring the existing OpenAI behaviour. Adds unit tests for the catalogue + coerce path.