### PR TITLE
fix(oauth): correct _app_root() so gemini-cli client_secret is found

### DIFF
--- a/jarvis/oauth/gemini_cli_secret.py
+++ b/jarvis/oauth/gemini_cli_secret.py
@@ -21,8 +21,17 @@ SECRET_PATTERN = re.compile(rb'"(GOCSPX-[A-Za-z0-9_-]+)"')
 
 
 def _app_root() -> str:
-    """Return the customer-bench app root (``apps/jarvis/``)."""
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    """Return the customer-bench app root (``apps/jarvis/``).
+
+    This file is ``apps/jarvis/jarvis/oauth/gemini_cli_secret.py``, so the app
+    root that holds ``package.json`` + ``node_modules`` is THREE levels up
+    (oauth -> jarvis module -> apps/jarvis), not two. Walking up only two
+    levels pointed pkg_root at a non-existent ``apps/jarvis/jarvis/node_modules``
+    and made the extractor silently return "".
+    """
+    return os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
 
 
 def extract_gemini_cli_secret(app_root: str | None = None) -> str:

--- a/jarvis/tests/test_gemini_cli_secret.py
+++ b/jarvis/tests/test_gemini_cli_secret.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from jarvis import hooks
 from jarvis.oauth.gemini_cli_secret import (
     PACKAGE_REL_PATH,
+    _app_root,
     extract_gemini_cli_secret,
 )
 
@@ -93,6 +94,25 @@ class TestExtractGeminiCliSecret(unittest.TestCase):
                 self.assertEqual(extract_gemini_cli_secret(tmp), "GOCSPX-fromfallback")
             finally:
                 os.chmod(bad, 0o644)
+
+
+class TestAppRootResolution(unittest.TestCase):
+    def test_app_root_is_app_root_not_module_dir(self):
+        # _app_root() must resolve to apps/jarvis (the app root holding the npm
+        # package.json + node_modules + the inner jarvis module dir), NOT the
+        # inner apps/jarvis/jarvis module dir. The regression returned the
+        # module dir, so pkg_root pointed at a non-existent
+        # apps/jarvis/jarvis/node_modules and extraction silently returned "",
+        # surfacing as Google's "client_secret is missing" token-exchange error.
+        root = _app_root()
+        self.assertTrue(
+            os.path.isfile(os.path.join(root, "package.json")),
+            f"_app_root() {root!r} should contain apps/jarvis/package.json",
+        )
+        self.assertTrue(
+            os.path.isdir(os.path.join(root, "jarvis", "oauth")),
+            f"_app_root() {root!r} should contain the inner jarvis/oauth module",
+        )
 
 
 class TestGetOauthClientSecretPrecedence(unittest.TestCase):


### PR DESCRIPTION
_app_root() walked up two levels (apps/jarvis/jarvis) instead of three (apps/jarvis), so pkg_root pointed at a non-existent node_modules and the gemini-cli OAuth client_secret extractor always returned empty - surfacing downstream as Google's 'client_secret is missing' on the Gemini token exchange. Add the missing dirname; add a regression test for the default _app_root() path (existing tests only exercised an injected app_root).