### PR TITLE
feat(run_query): refuse when User Permissions restrict referenced DocTypes

### DIFF
--- a/jarvis/tests/test_run_query.py
+++ b/jarvis/tests/test_run_query.py
@@ -433,3 +433,127 @@ class TestRunQueryRowGuard(FrappeTestCase):
 		self.assertIn("narrow", msg)
 		self.assertIn("aggregate", msg)
 		self.assertIn("confirm_large", msg)
+
+
+class TestRunQueryUserPermissions(FrappeTestCase):
+	"""User Permissions gate: when the calling user has User Permission
+	rows that restrict their view of a referenced DocType (directly or
+	via a Link field on the referenced DocType), refuse the query and
+	route the agent to ``get_list`` instead. See ``run_query.py`` module
+	docstring for the rationale - we can't weave record-level WHERE
+	predicates into arbitrary operator-authored SQL, so we refuse
+	cleanly rather than silently bypassing.
+
+	Uses ``frappe.set_user`` to switch identity (rather than patching
+	``frappe.session.user`` directly - it's a thread-local proxy and
+	doesn't unittest.patch cleanly). The teardown resets to
+	Administrator so other tests aren't affected.
+	"""
+
+	USER_EMAIL = "run-query-up-test@example.com"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("User", cls.USER_EMAIL):
+			frappe.get_doc({
+				"doctype": "User",
+				"email": cls.USER_EMAIL,
+				"first_name": "RQ UP",
+				"send_welcome_email": 0,
+			}).insert(ignore_permissions=True)
+		# Give the test user broad doctype read so the DocType-level
+		# gate doesn't fire first and short-circuit the User-Permissions
+		# check we're trying to exercise.
+		user = frappe.get_doc("User", cls.USER_EMAIL)
+		if "System Manager" not in [r.role for r in user.get("roles", [])]:
+			user.append("roles", {"role": "System Manager"})
+			user.save(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	def test_administrator_bypasses_user_permission_gate(self):
+		"""Administrator never has User Permissions applied; the gate is
+		a no-op. Confirms the hot path stays fast for the dominant user."""
+		from unittest.mock import patch
+		frappe.set_user("Administrator")
+		with patch("frappe.db.sql", return_value=[]):
+			run_query("SELECT name FROM tabDocType")
+		# No PermissionDeniedError raised; happy path.
+
+	def test_user_with_no_user_permissions_can_run(self):
+		"""Helper returns an empty restricted set when the user has no
+		User Permission rows. Tests the helper directly rather than the
+		full run_query path because that path also reaches Frappe's
+		permission internals (which touch Meta cache lookups that don't
+		matter for the gate's contract)."""
+		from unittest.mock import patch
+		from jarvis.tools.run_query import _restricted_by_user_permissions
+		with patch("frappe.permissions.get_user_permissions", return_value={}):
+			result = _restricted_by_user_permissions("alice@example.com",
+													  ["Sales Invoice", "Customer", "Item"])
+		self.assertEqual(result, set())
+
+	def test_direct_user_permission_on_referenced_doctype_refused(self):
+		"""User has User Permission on Customer; agent queries
+		``tabCustomer`` directly. Refuse - the SQL would return all
+		customers including ones the user can't see.
+
+		Patches ``frappe.has_permission`` to True so the DocType-level
+		gate (which has its own dedicated tests in
+		TestRunQueryPermissions) doesn't short-circuit first - we want
+		to exercise the User-Permissions branch in isolation."""
+		from unittest.mock import patch
+		frappe.set_user(self.USER_EMAIL)
+		with patch("frappe.has_permission", return_value=True), \
+			 patch(
+				 "frappe.permissions.get_user_permissions",
+				 return_value={"Customer": [{"doc": "ACME"}]},
+			 ):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				run_query("SELECT name FROM tabCustomer")
+			msg = str(cm.exception)
+			self.assertIn("Customer", msg)
+			self.assertIn("get_list", msg)
+
+	def test_transitive_user_permission_via_link_refused(self):
+		"""User has User Permission on Customer; agent queries
+		``tabSales Invoice`` (which has a Link field ``customer`` ->
+		Customer). The user's restriction transitively limits which SI
+		rows they should see; refuse to weave WHERE that we can't."""
+		from unittest.mock import patch, MagicMock
+		frappe.set_user(self.USER_EMAIL)
+		# Stub a meta with one Link field pointing at Customer.
+		fake_meta = MagicMock()
+		fake_link = MagicMock()
+		fake_link.options = "Customer"
+		fake_meta.get_link_fields.return_value = [fake_link]
+		with patch("frappe.has_permission", return_value=True), \
+			 patch(
+				 "frappe.permissions.get_user_permissions",
+				 return_value={"Customer": [{"doc": "ACME"}]},
+			 ), patch("frappe.get_meta", return_value=fake_meta):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				run_query("SELECT name FROM `tabSales Invoice`")
+			self.assertIn("Sales Invoice", str(cm.exception))
+
+	def test_unrelated_user_permission_does_not_refuse(self):
+		"""User has User Permission on Customer; agent queries
+		``tabDocType`` (no Link to Customer). Don't refuse - the
+		restriction doesn't affect this query."""
+		from unittest.mock import patch, MagicMock
+		frappe.set_user(self.USER_EMAIL)
+		# DocType has no Link to Customer.
+		fake_meta = MagicMock()
+		fake_meta.get_link_fields.return_value = []
+		with patch("frappe.has_permission", return_value=True), \
+			 patch(
+				 "frappe.permissions.get_user_permissions",
+				 return_value={"Customer": [{"doc": "ACME"}]},
+			 ), patch("frappe.get_meta", return_value=fake_meta), \
+			 patch("frappe.db.sql", return_value=[]):
+			# Should NOT raise.
+			run_query("SELECT name FROM tabDocType")

--- a/jarvis/tools/run_query.py
+++ b/jarvis/tools/run_query.py
@@ -12,10 +12,17 @@ parsing, not just trust:
   referenced DocType.
 - A row cap is enforced; the tool injects ``LIMIT`` if missing.
 
-**Caveat:** DocType-level perms only. User Permissions and record-level
-share/role filters are NOT enforced (Frappe's permission engine doesn't
-have a public hook for arbitrary SQL). Document this in the tool
-description so the model picks ``get_list`` for record-scoped queries.
+**Caveat:** DocType-level perms are checked. User Permissions are
+**refused-not-bypassed**: when the calling user has User Permission
+rows that would restrict their view of a referenced DocType (directly
+OR transitively via a Link field), run_query raises
+PermissionDeniedError and the agent must fall back to ``get_list``,
+which weaves the record-level filter into the query at build time.
+DocShare records and controller ``has_permission`` hooks remain
+unenforced - those are dynamic per-doc Python checks that can't be
+statically detected from the SQL shape. The operator-configured
+DocType allowlist (Jarvis Settings.run_query_doctype_allowlist) is
+the safety net for environments where those matter.
 """
 
 from __future__ import annotations
@@ -135,6 +142,31 @@ def run_query(
 				f"no read permission on referenced DocType: {doctype}"
 			)
 
+	# User Permissions gate. Frappe's permission engine enforces User
+	# Permissions (record-level "you can only see Customer ACME") on
+	# get_list / get_doc by weaving WHERE fragments into the query at
+	# build time. There's no public hook to do the same to arbitrary
+	# operator-authored SQL, so the historical behavior was: run_query
+	# enforces DocType-level read perms ONLY and User Permissions are
+	# silently bypassed. That's a real record-level data-leak vector
+	# for users whose access is shaped by User Permissions.
+	#
+	# Rather than fake an enforcement we can't deliver, refuse the
+	# query when any referenced DocType is restricted for this user.
+	# Clean error -> agent retries via get_list, which weaves the
+	# permission filter in correctly. Administrator + users with no
+	# User Permission rows are unaffected (the dominant case).
+	doctypes = [tbl[len("tab"):] for tbl in tables]
+	restricted = _restricted_by_user_permissions(frappe.session.user, doctypes)
+	if restricted:
+		raise PermissionDeniedError(
+			f"User Permissions restrict your access on: "
+			f"{', '.join(sorted(restricted))}. run_query cannot weave "
+			f"record-level filters into arbitrary SQL; use get_list "
+			f"(which auto-applies User Permissions) for record-scoped "
+			f"questions."
+		)
+
 	# Operator-configured defense-in-depth: a per-site DocType allowlist on
 	# top of the Frappe permission system. If set, run_query refuses any
 	# DocType not on the list - even when the calling user has read perm.
@@ -210,6 +242,67 @@ def _load_doctype_allowlist() -> set[str] | None:
 	parts = re.split(r"[,\n]", raw)
 	cleaned = {p.strip() for p in parts if p.strip()}
 	return cleaned if cleaned else None
+
+
+def _restricted_by_user_permissions(user: str, doctypes: list[str]) -> set[str]:
+	"""Return the subset of ``doctypes`` for which ``user`` has User
+	Permission rows that would restrict their view.
+
+	A User Permission row of the form ``(user=U, allow=Customer,
+	for_value=ACME)`` restricts U to only seeing Customer ACME, AND
+	(when ``applicable_for`` is empty or matches) also restricts U to
+	only seeing records on OTHER doctypes that Link to Customer ACME.
+	So when the agent's SQL touches ``tabSales Invoice`` (which has a
+	Link-typed ``customer`` field pointing at Customer), U's User
+	Permission on Customer transitively restricts what Sales Invoice
+	rows they should see. Our raw SQL doesn't enforce that transit;
+	this helper flags the case so the caller can refuse cleanly.
+
+	Returns the set of restricted doctypes (subset of ``doctypes``).
+	Empty set when ``user`` has no relevant User Permissions - the
+	common case for System Manager / unrestricted users; the early
+	return on that branch keeps the hot path fast.
+
+	Note: doesn't enforce controller has_permission hooks or DocShare
+	records - those are dynamic, per-doc Python checks that can't be
+	statically detected from the SQL shape. They remain unenforced for
+	run_query; the operator-configured DocType allowlist is the safety
+	net for environments where those matter.
+	"""
+	if user == "Administrator":
+		# Administrator bypasses User Permissions site-wide; no need
+		# to walk the rows.
+		return set()
+	try:
+		user_perms = frappe.permissions.get_user_permissions(user) or {}
+	except Exception:
+		# If the perm lookup itself fails (very rare; usually means
+		# the user row is broken), fail closed - refuse the query
+		# rather than letting it through with no checks.
+		return set(doctypes)
+	if not user_perms:
+		return set()
+	restricted: set[str] = set()
+	for doctype in doctypes:
+		# Direct restriction: a User Permission ON the doctype itself.
+		if doctype in user_perms:
+			restricted.add(doctype)
+			continue
+		# Transitive restriction: a Link-typed field on this doctype
+		# points at a DocType the user has a User Permission for.
+		# ``get_meta`` is cached after the first read so this is cheap.
+		try:
+			meta = frappe.get_meta(doctype)
+		except Exception:
+			# Bench misconfig / missing DocType. Fail closed.
+			restricted.add(doctype)
+			continue
+		for link_field in meta.get_link_fields():
+			target = link_field.options
+			if target and target in user_perms:
+				restricted.add(doctype)
+				break
+	return restricted
 
 
 def _reject_comments(query: str) -> None:


### PR DESCRIPTION
## Summary

Closes the long-standing User-Permissions bypass in \`run_query\`. The tool used to enforce DocType-level perms only; users with User Permission rows (e.g. \"you can only see Customer ACME\") could run SQL that exposed records the \`get_list\` path would have filtered out.

## Why refuse, not enforce

Frappe's \`get_list\` weaves WHERE predicates from User Permissions into the query at build time. There's **no public hook to do the same for arbitrary operator-authored SQL**:

- Injecting predicates into free-form SQL via regex would be fragile (aliases, subqueries, JOINs) and create false confidence
- Post-filtering rows by re-checking per-doc permissions would silently lose results from aggregate queries — a SUM that returns wrong numbers is worse than no SUM at all

So: **refuse cleanly** when the calling user's User Permissions would matter, and route the agent to \`get_list\`.

## New helper - \`_restricted_by_user_permissions\`

Walks \`frappe.permissions.get_user_permissions(user)\`. Two restriction paths:

1. **Direct:** User Permission ON the referenced DocType itself
2. **Transitive:** any Link-typed field on the referenced DocType points at a DocType the user has User Permissions for (e.g. Sales Invoice → Link to Customer → if user has UP on Customer, SI queries are restricted)

Returns the set of restricted doctypes. Empty for Administrator + users with no UP rows (the dominant case). Fails closed on unexpected exceptions.

## Wired into run_query

Right after the existing DocType-level read check. Non-empty restriction set → \`PermissionDeniedError\`:

> User Permissions restrict your access on: Customer. run_query cannot weave record-level filters into arbitrary SQL; use get_list (which auto-applies User Permissions) for record-scoped questions.

## What this doesn't enforce

Documented in the module docstring:
- **DocShare** records (per-record sharing)
- **Controller \`has_permission\` hooks** (custom Python predicates)

Both are dynamic per-doc checks that can't be statically detected from SQL. The operator-configured per-site DocType allowlist (\`Jarvis Settings.run_query_doctype_allowlist\`) remains the safety net.

## Tests (5 new)

- Administrator bypasses the gate
- User with no User Permissions runs unaffected
- Direct: UP on Customer + query of \`tabCustomer\` → refused
- Transitive: UP on Customer + query of \`tabSales Invoice\` (Link to Customer) → refused
- Unrelated: UP on Customer + query of \`tabDocType\` (no Link) → allowed

**43/43 module tests green** (was 38/38).

## Out of scope

Tier-2 helpers (\`get_stock_balance\`, \`get_balance_on\`, \`get_leave_balance_on\`, etc.) still bypass User Permissions because they wrap ERPNext/HRMS utility functions that compute aggregates across raw DB. Filtering rows there produces incorrect aggregates; a per-tool allowlist or pre-call gate is the right shape. **Separate workstream.**

## Persona follow-up

One-paragraph addition to \`frappe-core/SKILL.md\`: \"run_query may refuse for users with User Permissions; reach for get_list in that case.\" Will land as a separate persona PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)