### PR TITLE
security(query): close sub-spec self-join perm bypass + set engine.doctype

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -809,3 +809,167 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 		}
 		collected = _collect_doctypes(spec)
 		self.assertEqual(set(collected), {"DocType", "DocField", "DocPerm"})
+
+	# ---- v0.2.2 fixes from code-review workflow ---------------------
+
+	def test_subspec_self_join_perm_gates_every_alias(self):
+		"""Sub-spec self-joining the same doctype under two aliases
+		must apply ``get_permission_conditions`` to BOTH aliases, not
+		just the first. The pre-fix code deduplicated by doctype and
+		silently bypassed perms on the second alias - a side-channel
+		identical in shape to the v0.2.1 outer/sub-spec gap."""
+		from pypika import Field
+		# Distinct sentinel per call so we can verify both calls
+		# landed in the resolved SQL (not just the first).
+		sentinels = [
+			Field("name") == "SELF_JOIN_SENTINEL_FIRST",
+			Field("name") == "SELF_JOIN_SENTINEL_SECOND",
+		]
+
+		def _perm_conds(dt, table):
+			# Outer DocType call (perm conditions are returned None so
+			# we don't conflate the outer perm-weave with the sub-spec
+			# self-join one).
+			if dt == "DocType":
+				return None
+			# Sub-spec DocField calls - one per alias. Return a
+			# different sentinel each time so we can prove both
+			# landed.
+			if dt == "DocField":
+				return sentinels.pop(0) if sentinels else None
+			return None
+
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine_cls:
+			fake_engine_cls.return_value.get_permission_conditions.side_effect = \
+				_perm_conds
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				result = query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"where": [{
+						"op": "exists",
+						"value": {
+							"from": "DocField", "alias": "df",
+							"joins": [{
+								"type": "inner", "doctype": "DocField",
+								"alias": "df2",
+								"on": {"df2.parent": "df.parent"},
+							}],
+							"where": [{
+								"field": "df.parent", "op": "=",
+								"value": {"$field": "dt.name"},
+							}],
+						},
+					}],
+				})
+		sql = result["sql"]
+		# Both sentinels must appear in the resolved SQL.
+		self.assertIn(
+			"SELF_JOIN_SENTINEL_FIRST", sql,
+			"sub-spec perm gate skipped the first alias - regression",
+		)
+		self.assertIn(
+			"SELF_JOIN_SENTINEL_SECOND", sql,
+			"sub-spec perm gate skipped the second alias - v0.2.1 "
+			"side-channel still open",
+		)
+		# Both sentinels are inside the EXISTS subquery, not at the
+		# outer WHERE level.
+		exists_idx = sql.upper().find("EXISTS")
+		first_idx = sql.find("SELF_JOIN_SENTINEL_FIRST")
+		second_idx = sql.find("SELF_JOIN_SENTINEL_SECOND")
+		self.assertGreater(first_idx, exists_idx)
+		self.assertGreater(second_idx, exists_idx)
+
+	def test_outer_engine_has_doctype_attribute_set(self):
+		"""Frappe's ``permission_query_conditions`` hooks read
+		``engine.doctype`` to format the main table name (e.g.
+		``f"tab{self.doctype}"``). Without it, the first hook with a
+		permission_query_conditions entry crashes with AttributeError.
+		Verify the outer Engine has ``.doctype`` set to ``spec["from"]``
+		before ``get_permission_conditions`` is called."""
+		captured = []
+
+		def _capture(dt, table):
+			# Capture the Engine instance's doctype attribute at
+			# call time.
+			engine_instance = fake_engine_cls.return_value
+			captured.append({
+				"dt": dt,
+				"engine_doctype": getattr(
+					engine_instance, "doctype", "<UNSET>"
+				),
+			})
+			return None
+
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine_cls:
+			fake_engine_cls.return_value.get_permission_conditions.side_effect = \
+				_capture
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				query({
+					"from": "DocType",
+					"select": ["name"],
+				})
+		self.assertTrue(captured, "engine.get_permission_conditions never called")
+		for c in captured:
+			self.assertEqual(
+				c["engine_doctype"], "DocType",
+				f"engine.doctype not set when querying {c['dt']!r}: "
+				f"{c['engine_doctype']!r}",
+			)
+
+	def test_subspec_engine_has_doctype_attribute_set(self):
+		"""Same fix applied to the sub-spec engine. Without it, an
+		EXISTS sub-query whose sub-spec's primary DocType has a
+		permission_query_conditions hook crashes the same way."""
+		captured = []
+
+		def _capture(dt, table):
+			engine_instance = fake_engine_cls.return_value
+			captured.append({
+				"dt": dt,
+				"engine_doctype": getattr(
+					engine_instance, "doctype", "<UNSET>"
+				),
+			})
+			return None
+
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine_cls:
+			fake_engine_cls.return_value.get_permission_conditions.side_effect = \
+				_capture
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"where": [{
+						"op": "exists",
+						"value": {
+							"from": "DocField", "alias": "df",
+							"where": [{
+								"field": "df.parent", "op": "=",
+								"value": {"$field": "dt.name"},
+							}],
+						},
+					}],
+				})
+		# Find the sub-spec calls (dt == "DocField") and check the
+		# engine's doctype was the sub-spec's "from" value.
+		subspec_calls = [c for c in captured if c["dt"] == "DocField"]
+		self.assertTrue(
+			subspec_calls,
+			"sub-spec get_permission_conditions never called",
+		)
+		# Note: because we share a single mock Engine across outer
+		# and sub-spec, the *last* assignment to engine.doctype wins
+		# in this captured snapshot. The mock's doctype attribute at
+		# capture time reflects the most-recent setter. For the
+		# sub-spec calls, that setter was for the sub-spec's "from"
+		# value (DocField).
+		for c in subspec_calls:
+			self.assertEqual(
+				c["engine_doctype"], "DocField",
+				f"sub_engine.doctype not set: {c['engine_doctype']!r}",
+			)

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -283,6 +283,13 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	# Some permission_query_conditions hooks consult ``self.tables``;
 	# pre-populate it from our alias_map.
 	engine.tables = [table for (_, table) in alias_map.values()]
+	# ``permission_query_conditions`` hooks read ``self.doctype`` to
+	# format the main table name (e.g. ``f"tab{self.doctype}"``). Frappe's
+	# normal entry point ``Engine.get_query(dt)`` sets this internally;
+	# we don't go through that path, so set it explicitly to the primary
+	# doctype. Otherwise the first hook with a permission_query_conditions
+	# entry crashes with AttributeError.
+	engine.doctype = spec["from"]
 	for dt in doctypes:
 		# Find the table object we built for this doctype. If the spec
 		# has multiple references to the same doctype (rare; usually
@@ -814,14 +821,19 @@ def _build_exists_criterion(sub_spec: dict, outer_alias_map: dict,
 		if a not in outer_alias_map
 	}
 	sub_engine.tables = [table for (_, table) in sub_local_aliases.values()]
-	sub_doctypes_seen: set[str] = set()
+	# Same reason as the outer engine: permission_query_conditions hooks
+	# read ``self.doctype`` to build the main table name. Set it to the
+	# sub-spec's primary doctype.
+	sub_engine.doctype = sub_spec["from"]
+	# Apply ``get_permission_conditions`` to every alias's table object.
+	# Earlier code de-duplicated by doctype on the assumption that the
+	# returned criterion was scoped to a canonical table; that's wrong —
+	# ``get_permission_conditions(dt, table)`` builds the predicate
+	# against the specific table object it's handed, so a self-join under
+	# two aliases needs the gate applied twice (once per alias) or the
+	# second alias bypasses User Permissions / DocShare entirely. Mirror
+	# the outer loop's per-alias iteration.
 	for alias, (resolved_dt, table) in sub_local_aliases.items():
-		if resolved_dt in sub_doctypes_seen:
-			# Same doctype joined under multiple aliases — only the
-			# first occurrence weaves; the engine's predicate is
-			# scoped to the canonical table object regardless.
-			continue
-		sub_doctypes_seen.add(resolved_dt)
 		cond = sub_engine.get_permission_conditions(resolved_dt, table)
 		if cond is not None:
 			sub_q = sub_q.where(cond)


### PR DESCRIPTION
## Summary

Two critical fixes from the code-review max-effort sweep of the run_query → query transition.

### Fix 1 — Sub-spec self-join permission bypass (SECURITY)

\`_build_exists_criterion\` was deduplicating aliases by doctype before applying \`Engine.get_permission_conditions\`, on the mistaken assumption that the engine's returned criterion was scoped to a "canonical" table object. It's not — \`get_permission_conditions(dt, table)\` builds the predicate against the specific table object it's handed. A sub-spec self-join under two aliases (e.g. \`DocField df\` + \`DocField df2\`) was getting the gate applied only to the first alias; the second bypassed User Permissions / DocShare / role-based filters entirely.

Same side-channel shape as the v0.2.1 bug, just between aliases within the sub-spec instead of between outer and sub-spec.

**Fix:** drop the \`sub_doctypes_seen\` dedup; iterate every entry in \`sub_local_aliases\` and apply the condition per alias. Matches the outer-query loop pattern at lines 286-294.

### Fix 2 — Engine.doctype attribute missing (CRASH on perm hooks)

Both the outer query() and \`_build_exists_criterion\` instantiate Engine bare. Frappe's permission machinery (in \`get_permission_query_conditions\` at \`frappe/database/query.py:1683\`) accesses \`self.doctype\` to format the main table name as \`f\"tab{self.doctype}\"\`. On JOIN queries where any referenced DocType has a \`permission_query_conditions\` hook installed → AttributeError.

Fires on any customer with custom perm hooks (common in ERPNext with HR/Sales territory restrictions).

**Fix:** set \`engine.doctype = spec[\"from\"]\` before iterating, on both outer and sub-spec engines. Matches what Frappe's normal \`Engine.get_query(dt)\` entry point sets internally.

## Tests

Three new in \`TestQueryV03ExistsSubquerySecurityHardening\`:

- \`test_subspec_self_join_perm_gates_every_alias\` — sub-spec self-joins DocField under two aliases; mock returns a distinct sentinel per call; assert both land inside the EXISTS subquery's WHERE.
- \`test_outer_engine_has_doctype_attribute_set\` — capture \`engine.doctype\` at perm-conds call time; assert \`== spec[\"from\"]\`.
- \`test_subspec_engine_has_doctype_attribute_set\` — same for the sub-spec engine.

57/57 tests green (54 prior + 3 new).

## What's NOT in this PR

- **Depth-cap off-by-one (workflow finding #2)** — REFUTED on re-verification. The check \`depth + 1 > _MAX_SUBSPEC_DEPTH\` correctly allows outer + one nest and rejects outer + two nests.
- **Robustness findings (#4–#15)** — input validation, type duplication, cleanup — separate "robustness" PR; not security-critical.
- Plugin / persona changes — none. Wire format unchanged; bench-internal enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)