### PR TITLE
robust(query): defensive validation for malformed-agent-input edge cases

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -973,3 +973,133 @@ class TestQueryV03ExistsSubquerySecurityHardening(FrappeTestCase):
 				c["engine_doctype"], "DocField",
 				f"sub_engine.doctype not set: {c['engine_doctype']!r}",
 			)
+
+
+class TestQueryRobustnessHardening(FrappeTestCase):
+	"""Defensive validation that turns malformed-agent-input crashes /
+	silently-bad-SQL into clean InvalidArgumentError. Catches what
+	TypeBox can't (Type.Unknown shapes, semantic edge cases)."""
+
+	def test_select_must_be_list_not_string(self):
+		"""``select: 'name'`` would iterate per-character and silently
+		produce table['n']/['a']/etc. Reject at validation time."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({"from": "DocType", "select": "name"})
+			self.assertIn("select", str(cm.exception).lower())
+
+	def test_limit_must_be_int_not_float(self):
+		"""``limit: 10.5`` would silently int-truncate to 10. Mirror
+		offset's existing isinstance(int) check."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({"from": "DocType", "limit": 10.5})
+			self.assertIn("limit", str(cm.exception).lower())
+
+	def test_limit_must_be_int_not_bool(self):
+		"""``isinstance(True, int)`` is True in Python; explicit bool
+		rejection keeps ``limit: true`` from sneaking through."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({"from": "DocType", "limit": True})
+			self.assertIn("limit", str(cm.exception).lower())
+
+	def test_field_ref_rejects_empty_string(self):
+		"""GROUP BY / ORDER BY paths could pass empty strings through
+		to _resolve_field, which would produce table['']."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType",
+					"select": ["name"],
+					"group_by": [""],
+				})
+			self.assertIn("non-empty", str(cm.exception).lower())
+
+	def test_field_ref_rejects_trailing_dot(self):
+		"""``alias.`` produces an empty field name after split;
+		generates broken SQL with empty column reference."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt."],
+				})
+			self.assertIn("alias.field", str(cm.exception).lower())
+
+	def test_field_ref_rejects_leading_dot(self):
+		"""``.field`` produces an empty alias half."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": [".name"],
+				})
+			self.assertIn("alias.field", str(cm.exception).lower())
+
+	def test_join_on_empty_dict_rejected(self):
+		"""Empty ``on`` dict would crash _build_on_criterion at
+		terms[0] with IndexError. Reject with a clear error."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"joins": [{
+						"type": "inner", "doctype": "DocField",
+						"alias": "df", "on": {},
+					}],
+					"select": ["dt.name"],
+				})
+			self.assertIn("on", str(cm.exception).lower())
+
+	def test_subspec_join_on_empty_dict_rejected(self):
+		"""Same guard inside a sub-spec join."""
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"where": [{
+						"op": "exists",
+						"value": {
+							"from": "DocField", "alias": "df",
+							"joins": [{
+								"type": "inner", "doctype": "DocPerm",
+								"alias": "dp", "on": {},
+							}],
+							"where": [{
+								"field": "df.parent", "op": "=",
+								"value": {"$field": "dt.name"},
+							}],
+						},
+					}],
+				})
+			self.assertIn("on", str(cm.exception).lower())
+
+	def test_nested_field_marker_rejected(self):
+		"""Buried ``{$field: ...}`` inside a nested dict value would
+		reach pypika as a raw dict. Reject with a clear message."""
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"where": [{
+						"op": "exists",
+						"value": {
+							"from": "DocField", "alias": "df",
+							"where": [{
+								"field": "df.parent", "op": "in",
+								"value": [
+									"foo",
+									{"nested": {"$field": "dt.name"}},
+								],
+							}],
+						},
+					}],
+				})
+			self.assertIn("$field", str(cm.exception))

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -338,6 +338,19 @@ def _validate_spec_shape(spec: dict) -> None:
 	if "offset" in spec and not isinstance(spec["offset"], int):
 		raise InvalidArgumentError("spec.offset must be an integer")
 
+	# ``select`` must be a list, not a string. A bare string passes the
+	# truthy check and then ``for item in 'name'`` yields per-character
+	# refs which the resolver silently turns into invalid SQL. Catch it
+	# here. Also reject ``limit`` as a non-int (mirrors offset's check;
+	# Python's ``int(10.5)`` would otherwise silently truncate to 10).
+	if "select" in spec and not isinstance(spec["select"], list):
+		raise InvalidArgumentError("spec.select must be a list")
+	# Note: ``isinstance(True, int)`` is True in Python, so we explicitly
+	# reject bools here - a stray ``limit: true`` would otherwise pass.
+	if "limit" in spec:
+		if isinstance(spec["limit"], bool) or not isinstance(spec["limit"], int):
+			raise InvalidArgumentError("spec.limit must be an integer")
+
 	if "joins" in spec:
 		if not isinstance(spec["joins"], list):
 			raise InvalidArgumentError("spec.joins must be a list")
@@ -483,6 +496,15 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 	returned as a pypika ``Field`` without table qualification — this
 	is the ORDER BY case where the operator may reference a SELECT
 	alias like ``total_qty``."""
+	# Reject empty / non-string / dot-only refs. Without this, callers
+	# producing accidental empty strings (e.g. GROUP BY with an empty
+	# entry, ORDER BY with an unset field) would silently produce
+	# ``table[""]`` which generates invalid SQL with an empty column
+	# reference.
+	if not isinstance(field_ref, str) or not field_ref.strip():
+		raise InvalidArgumentError(
+			f"field reference must be a non-empty string, got {field_ref!r}"
+		)
 	if "." not in field_ref:
 		if allow_alias:
 			from pypika import Field
@@ -499,6 +521,14 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 			f"query; prefix with the alias (e.g. 'si.name')"
 		)
 	alias, field = field_ref.split(".", 1)
+	# Both halves of an alias.field reference must be non-empty.
+	# ``"si."`` would otherwise produce ``table[""]`` and ``".name"``
+	# would look up an empty alias - both generate invalid SQL.
+	if not alias or not field:
+		raise InvalidArgumentError(
+			f"field reference {field_ref!r} must be of the form "
+			f"'alias.field' with both halves non-empty"
+		)
 	if alias not in alias_map:
 		raise InvalidArgumentError(
 			f"field reference {field_ref!r} uses unknown alias {alias!r}; "
@@ -517,6 +547,13 @@ def _build_on_criterion(on_spec: dict, alias_map: dict) -> Criterion:
 	conditions). We auto-detect: if the value resolves as a known
 	alias.field, treat it as column-equality; otherwise as a literal.
 	"""
+	# Empty ``on`` dict produces no equality terms; ``terms[0]`` below
+	# would IndexError. Surface a clear error instead.
+	if not isinstance(on_spec, dict) or not on_spec:
+		raise InvalidArgumentError(
+			"join.on must be a non-empty dict mapping lhs to rhs field "
+			"references (e.g. {'sii.parent': 'si.name'})"
+		)
 	terms = []
 	for lhs_ref, rhs_ref in on_spec.items():
 		lhs = _resolve_field(lhs_ref, alias_map)
@@ -791,9 +828,17 @@ def _build_exists_criterion(sub_spec: dict, outer_alias_map: dict,
 
 	# Sub-spec WHERE. Predicates may carry ``$field`` markers for
 	# correlated references; resolve those before handing to the
-	# regular predicate builder.
+	# regular predicate builder. Skip correlated-ref resolution for
+	# nested EXISTS / NOT EXISTS predicates - their ``value`` is a
+	# deeper sub-spec that gets its own recursive call through
+	# ``_build_exists_criterion``, and any ``$field`` markers inside
+	# that deeper level resolve against the deeper alias_map, not
+	# this one.
 	for w in sub_spec.get("where") or []:
-		resolved = _resolve_correlated_refs(w, sub_alias_map)
+		if w.get("op") in ("exists", "not exists"):
+			resolved = w
+		else:
+			resolved = _resolve_correlated_refs(w, sub_alias_map)
 		sub_q = sub_q.where(_build_predicate(resolved, sub_alias_map,
 		                                       depth=depth + 1))
 
@@ -903,6 +948,37 @@ def _resolve_correlated_refs(predicate: dict, alias_map: dict) -> dict:
 				new_value.append(_resolve_field(v["$field"], alias_map,
 				                                  allow_alias=False))
 			else:
+				# Reject unresolved $field markers buried inside nested
+				# structures - those would otherwise reach pypika as raw
+				# dicts and either fail opaquely or stringify into broken
+				# SQL. The supported shapes are a top-level marker or a
+				# direct list element; anything deeper is malformed.
+				_assert_no_unresolved_field_marker(v)
 				new_value.append(v)
 		return {**predicate, "value": new_value}
+	# Top-level value is neither a marker dict nor a list, but may still
+	# carry a buried marker (e.g. a dict literal the agent constructed
+	# by accident). Reject those too.
+	_assert_no_unresolved_field_marker(value)
 	return predicate
+
+
+def _assert_no_unresolved_field_marker(node) -> None:
+	"""Walk ``node`` recursively and raise if any nested dict still
+	carries the ``$field`` marker. Resolution only handles top-level
+	marker dicts and direct list elements; anywhere else means the
+	agent built a malformed value and pypika would receive a raw dict.
+	"""
+	if isinstance(node, dict):
+		if "$field" in node:
+			raise InvalidArgumentError(
+				"{'$field': ...} markers are only supported as a "
+				"predicate's top-level value or as a direct list element "
+				"in an 'in'/'not in' value; nested $field markers are "
+				"not resolved"
+			)
+		for v in node.values():
+			_assert_no_unresolved_field_marker(v)
+	elif isinstance(node, list):
+		for v in node:
+			_assert_no_unresolved_field_marker(v)


### PR DESCRIPTION
## Summary

Robustness fixes from the code-review max-effort sweep (workflow \`wapc2iiev\`). All five address the same pattern: malformed agent input was reaching pypika as something it couldn't serialize, producing either silent-bad-SQL or an opaque crash. Each now raises a clean \`InvalidArgumentError\` at the validation boundary.

| # | Bad input | Old behavior | New behavior |
|---|---|---|---|
| 1 | \`select: 'name'\` | Iterates per-char → \`table['n']\` etc. | \`InvalidArgumentError\` "spec.select must be a list" |
| 2 | \`limit: 10.5\` / \`limit: True\` | Silent truncation to 10 / accepted as 1 | \`InvalidArgumentError\` "spec.limit must be an integer" |
| 3 | \`"alias."\` / \`".field"\` / \`""\` field refs | \`table['']\` → broken SQL | \`InvalidArgumentError\` with shape requirement |
| 4 | Empty join \`on: {}\` | \`IndexError\` at \`terms[0]\` | \`InvalidArgumentError\` "on must be a non-empty dict" |
| 5 | Buried \`{\\$field: ...}\` markers inside nested dicts | Reaches pypika as raw dict | \`InvalidArgumentError\` "\\$field markers only at top level / direct list element" |

## Bonus call-site tightening

\`_build_exists_criterion\` now skips \`_resolve_correlated_refs\` for nested EXISTS predicates — their \`value\` is a deeper sub-spec that gets its own recursive resolution call. Prevents the new \`$field\` walker from descending into deeper sub-specs prematurely.

## Test plan

- [x] \`bench run-tests --module jarvis.tests.test_query\` — 66/66 pass (57 prior + 9 new in \`TestQueryRobustnessHardening\`)

## Skipped findings from workflow

| Workflow # | Why skipped |
|---|---|
| #2 depth-cap off-by-one | Refuted on re-verification - the check is correct |
| #6, #13 schema literal duplication (3×/2×) | Pure cleanup, no behavioral gain; deferred |
| #14 Engine init duplication | Same shape, 2 sites only; not worth abstraction churn |
| #15 stale fleet-agent test boot log | Different repo, mocked so no actual breakage |

🤖 Generated with [Claude Code](https://claude.com/claude-code)