### PR TITLE
docs(openclaw): mirror Tool Search directory config in reference template

### DIFF
--- a/jarvis/openclaw_templates/openclaw.json.j2
+++ b/jarvis/openclaw_templates/openclaw.json.j2
@@ -44,6 +44,10 @@
     }
   },
   "channels": {},
+  {# NOTE: the template fleet-agent actually renders lives in jarvis-fleet-agent
+     (jarvis_fleet_agent/templates/openclaw.json.j2). This copy is a reference —
+     keep it in sync. Progressive tool disclosure for the "pi" runtime: #}
+  "tools": { "toolSearch": { "mode": "directory" } },
   "secrets": {
     "providers": {
       "llm_key": {


### PR DESCRIPTION
Adds the pi-runtime tools.toolSearch block plus a note marking the fleet-agent copy as authoritative.