### PR TITLE
feat(query): expression DSL Phases 2-4 - NULL/arithmetic, CASE WHEN, strings

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -1372,3 +1372,380 @@ class TestQueryExprDSLPhase1Dates(FrappeTestCase):
 					}],
 				})
 			self.assertIn("expr", str(cm.exception).lower())
+
+
+class TestQueryExprDSLPhase2NullAndArithmetic(FrappeTestCase):
+	"""Expression DSL Phase 2: NULL handling + arithmetic."""
+
+	def _build_sql(self, spec: dict) -> str:
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				result = query(spec)
+		return result["sql"]
+
+	def test_coalesce_two_args(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "coalesce",
+					"args": [{"field": "dt.module"}, {"literal": "(unset)"}],
+				},
+				"as": "module_or_unset",
+			}],
+		})
+		self.assertIn("COALESCE", sql.upper())
+
+	def test_coalesce_variadic_three_args(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "coalesce",
+					"args": [
+						{"field": "dt.module"},
+						{"field": "dt.name"},
+						{"literal": "fallback"},
+					],
+				},
+				"as": "x",
+			}],
+		})
+		self.assertIn("COALESCE", sql.upper())
+
+	def test_ifnull(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "ifnull",
+					"args": [{"field": "dt.module"}, {"literal": "Other"}],
+				},
+				"as": "module",
+			}],
+		})
+		self.assertIn("COALESCE", sql.upper())
+
+	def test_arithmetic_mul(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {"fn": "mul", "args": [{"field": "dt.idx"}, {"literal": 100}]},
+				"as": "scaled",
+			}],
+		})
+		self.assertIn("*", sql)
+		self.assertIn("100", sql)
+
+	def test_arithmetic_add_sub_div(self):
+		for op_name, op_sym in [("add", "+"), ("sub", "-"), ("div", "/")]:
+			sql = self._build_sql({
+				"from": "DocType", "alias": "dt",
+				"select": [{
+					"expr": {"fn": op_name, "args": [{"field": "dt.idx"}, {"literal": 2}]},
+					"as": "x",
+				}],
+			})
+			self.assertIn(op_sym, sql, f"{op_name} should emit {op_sym!r}")
+
+	def test_neg_emits_unary_negation(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {"fn": "neg", "args": [{"field": "dt.idx"}]},
+				"as": "x",
+			}],
+		})
+		self.assertIn("0", sql)
+
+	def test_abs(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{"expr": {"fn": "abs", "args": [{"field": "dt.idx"}]}, "as": "x"}],
+		})
+		self.assertIn("ABS", sql.upper())
+
+	def test_round(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {"fn": "round", "args": [{"field": "dt.idx"}, {"literal": 2}]},
+				"as": "x",
+			}],
+		})
+		self.assertIn("ROUND", sql.upper())
+
+	def test_round_rejects_non_literal_digits(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType",
+					"select": [{
+						"expr": {"fn": "round", "args": [{"field": "x"}, {"field": "y"}]},
+						"as": "x",
+					}],
+				})
+
+	def test_ceil_and_floor(self):
+		for fn_name, expected in [("ceil", "CEIL"), ("floor", "FLOOR")]:
+			sql = self._build_sql({
+				"from": "DocType", "alias": "dt",
+				"select": [{"expr": {"fn": fn_name, "args": [{"field": "dt.idx"}]}, "as": "x"}],
+			})
+			self.assertIn(expected, sql.upper())
+
+	def test_nested_arithmetic_in_aggregate(self):
+		"""SUM(qty * rate) - the flagship combination."""
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"agg": "sum",
+				"expr": {"fn": "mul", "args": [{"field": "dt.idx"}, {"literal": 10}]},
+				"as": "total",
+			}],
+		})
+		self.assertIn("SUM", sql.upper())
+		self.assertIn("*", sql)
+
+
+class TestQueryExprDSLPhase3CaseWhen(FrappeTestCase):
+	"""Expression DSL Phase 3: CASE WHEN conditional aggregation."""
+
+	def _build_sql(self, spec: dict) -> str:
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				result = query(spec)
+		return result["sql"]
+
+	def test_case_when_with_else(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "case",
+					"args": [
+						{"when": {"field": "dt.module", "op": "=", "value": "Core"},
+						 "then": {"literal": "core"}},
+						{"else": {"literal": "other"}},
+					],
+				},
+				"as": "bucket",
+			}],
+		})
+		upper = sql.upper()
+		self.assertIn("CASE", upper)
+		self.assertIn("WHEN", upper)
+		self.assertIn("ELSE", upper)
+		self.assertIn("END", upper)
+
+	def test_case_when_only_no_else(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "case",
+					"args": [
+						{"when": {"field": "dt.module", "op": "=", "value": "Core"},
+						 "then": {"literal": "core"}},
+					],
+				},
+				"as": "bucket",
+			}],
+		})
+		self.assertIn("CASE", sql.upper())
+		self.assertIn("WHEN", sql.upper())
+
+	def test_case_inside_sum_for_conditional_aggregate(self):
+		"""SUM(CASE WHEN ... THEN ... ELSE 0) - killer use case."""
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"agg": "sum",
+				"expr": {
+					"fn": "case",
+					"args": [
+						{"when": {"field": "dt.module", "op": "=", "value": "Core"},
+						 "then": {"field": "dt.idx"}},
+						{"else": {"literal": 0}},
+					],
+				},
+				"as": "core_idx_total",
+			}],
+		})
+		upper = sql.upper()
+		self.assertIn("SUM", upper)
+		self.assertIn("CASE", upper)
+		self.assertIn("WHEN", upper)
+
+	def test_case_rejects_empty_clauses(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType",
+					"select": [{"expr": {"fn": "case", "args": []}, "as": "x"}],
+				})
+			self.assertIn("case", str(cm.exception).lower())
+
+	def test_case_rejects_multiple_else(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType",
+					"select": [{
+						"expr": {
+							"fn": "case",
+							"args": [
+								{"else": {"literal": 1}},
+								{"else": {"literal": 2}},
+							],
+						},
+						"as": "x",
+					}],
+				})
+			self.assertIn("else", str(cm.exception).lower())
+
+	def test_case_rejects_else_not_last(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType",
+					"select": [{
+						"expr": {
+							"fn": "case",
+							"args": [
+								{"else": {"literal": 0}},
+								{"when": {"field": "module", "op": "=", "value": "Core"},
+								 "then": {"literal": 1}},
+							],
+						},
+						"as": "x",
+					}],
+				})
+			self.assertIn("last", str(cm.exception).lower())
+
+	def test_case_rejects_when_without_then(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType",
+					"select": [{
+						"expr": {
+							"fn": "case",
+							"args": [{"when": {"field": "module", "op": "=", "value": "Core"}}],
+						},
+						"as": "x",
+					}],
+				})
+			self.assertIn("when", str(cm.exception).lower())
+
+	def test_case_rejects_exists_in_when(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": [{
+						"expr": {
+							"fn": "case",
+							"args": [{
+								"when": {"op": "exists", "value": {"from": "DocField"}},
+								"then": {"literal": 1},
+							}],
+						},
+						"as": "x",
+					}],
+				})
+			self.assertIn("exists", str(cm.exception).lower())
+
+
+class TestQueryExprDSLPhase4StringHelpers(FrappeTestCase):
+	"""Expression DSL Phase 4: string + numeric helpers."""
+
+	def _build_sql(self, spec: dict) -> str:
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				result = query(spec)
+		return result["sql"]
+
+	def test_concat_two_args(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {"fn": "concat", "args": [{"field": "dt.module"}, {"literal": "/"}]},
+				"as": "labelled",
+			}],
+		})
+		self.assertIn("CONCAT", sql.upper())
+
+	def test_concat_variadic_three_args(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "concat",
+					"args": [
+						{"field": "dt.module"},
+						{"literal": "/"},
+						{"field": "dt.name"},
+					],
+				},
+				"as": "full",
+			}],
+		})
+		self.assertIn("CONCAT", sql.upper())
+
+	def test_lower_for_case_insensitive_match(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": ["dt.name"],
+			"where": [{
+				"expr": {"fn": "lower", "args": [{"field": "dt.name"}]},
+				"op": "like",
+				"value": "%customer%",
+			}],
+		})
+		self.assertIn("LOWER", sql.upper())
+		self.assertIn("LIKE", sql.upper())
+
+	def test_upper_trim_length(self):
+		for fn_name, expected in [("upper", "UPPER"), ("trim", "TRIM"), ("length", "LENGTH")]:
+			sql = self._build_sql({
+				"from": "DocType", "alias": "dt",
+				"select": [{
+					"expr": {"fn": fn_name, "args": [{"field": "dt.module"}]},
+					"as": "x",
+				}],
+			})
+			self.assertIn(expected, sql.upper())
+
+	def test_substring(self):
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [{
+				"expr": {
+					"fn": "substring",
+					"args": [{"field": "dt.module"}, {"literal": 1}, {"literal": 3}],
+				},
+				"as": "prefix",
+			}],
+		})
+		self.assertIn("SUBSTRING", sql.upper())
+
+	def test_substring_rejects_non_literal_offsets(self):
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType",
+					"select": [{
+						"expr": {
+							"fn": "substring",
+							"args": [{"field": "x"}, {"field": "y"}, {"literal": 3}],
+						},
+						"as": "x",
+					}],
+				})

--- a/jarvis/tools/_expr.py
+++ b/jarvis/tools/_expr.py
@@ -254,6 +254,203 @@ _register(
 )
 
 
+# ---- Phase 2: NULL handling + arithmetic ----------------------------
+
+
+def _build_coalesce(args: list, dialect: str) -> Term:
+	"""COALESCE returns the first non-NULL arg. pypika.Coalesce
+	accepts a variable number of positional args and emits standard
+	SQL across all three dialects."""
+	return fn.Coalesce(*args)
+
+
+def _build_ifnull(args: list, dialect: str) -> Term:
+	"""IFNULL(x, default) is the 2-arg sibling of COALESCE. Postgres
+	calls it COALESCE; SQLite calls it IFNULL natively; MariaDB has
+	both. pypika emits IFNULL on MariaDB/SQLite and COALESCE on
+	Postgres via the fn.IfNull class - or rather, fn.IfNull always
+	emits IFNULL which Postgres doesn't have. Safer to route through
+	Coalesce uniformly."""
+	x, default = args
+	return fn.Coalesce(x, default)
+
+
+def _build_binop(op: str):
+	"""Factory for binary arithmetic builders. pypika.Field supports
+	Python operators, so the build is just ``a OP b``. Order of
+	args matches the spec (a, b)."""
+	def _b(args: list, dialect: str) -> Term:
+		a, b = args
+		if op == "+":
+			return a + b
+		if op == "-":
+			return a - b
+		if op == "*":
+			return a * b
+		if op == "/":
+			return a / b
+		raise RuntimeError(f"unreachable binop {op!r}")
+	return _b
+
+
+def _build_neg(args: list, dialect: str) -> Term:
+	(x,) = args
+	# pypika supports unary negation as `0 - x` portable across
+	# dialects; using `-x` requires Term.__neg__ which pypika
+	# doesn't always wire up consistently across versions.
+	return 0 - x
+
+
+def _build_abs(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Abs(x)
+
+
+def _build_round(args: list, dialect: str) -> Term:
+	"""ROUND(x, digits). pypika has no Round class; use the generic
+	Function constructor. ROUND is uniform across MariaDB / Postgres
+	/ SQLite (all accept the same 2-arg signature)."""
+	x, digits = args
+	from pypika.terms import Function
+	return Function("ROUND", x, digits)
+
+
+def _build_ceil(args: list, dialect: str) -> Term:
+	(x,) = args
+	from pypika.terms import Function
+	# MariaDB/Postgres use CEIL; SQLite uses CEIL via the math
+	# extension (loaded by default in 3.35+). Stick with CEIL across
+	# the board; production is MariaDB anyway.
+	return Function("CEIL", x)
+
+
+def _build_floor(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Floor(x)
+
+
+_register(
+	"coalesce",
+	arity=(2, None),
+	args_uniform="expr",
+	builder=_build_coalesce,
+)
+_register(
+	"ifnull",
+	arity=(2, 2),
+	args=["expr", "expr"],
+	builder=_build_ifnull,
+)
+_register("add", arity=(2, 2), args=["expr", "expr"], builder=_build_binop("+"))
+_register("sub", arity=(2, 2), args=["expr", "expr"], builder=_build_binop("-"))
+_register("mul", arity=(2, 2), args=["expr", "expr"], builder=_build_binop("*"))
+_register("div", arity=(2, 2), args=["expr", "expr"], builder=_build_binop("/"))
+_register("neg", arity=(1, 1), args=["expr"], builder=_build_neg)
+_register("abs", arity=(1, 1), args=["expr"], builder=_build_abs)
+_register(
+	"round",
+	arity=(2, 2),
+	args=["expr", "literal"],
+	builder=_build_round,
+)
+_register("ceil", arity=(1, 1), args=["expr"], builder=_build_ceil)
+_register("floor", arity=(1, 1), args=["expr"], builder=_build_floor)
+
+
+# ---- Phase 3: CASE WHEN ---------------------------------------------
+
+
+# CASE breaks the "args are expressions" pattern. Its args are clauses:
+# ``{"when": <predicate>, "then": <expr>}`` and one optional
+# ``{"else": <expr>}`` terminator. The validator and translator both
+# special-case ``case`` to walk the clauses, with the ``when``
+# predicate handed off to ``query.py``'s ``_build_predicate`` machinery
+# via the ``build_predicate`` callback (same pattern as
+# ``resolve_field``, to avoid a circular import).
+#
+# The case builder is registered with a stub builder; ``build_expr``
+# checks for ``name == "case"`` and routes to the case-specific
+# translator instead of calling the registry's builder directly.
+def _build_case_stub(args: list, dialect: str) -> Term:
+	raise RuntimeError(
+		"_build_case_stub should be unreachable - build_expr routes "
+		"the 'case' function to its own translator"
+	)
+
+
+_register(
+	"case",
+	# Arity is on clauses; 1+ clauses (at least one when/then or one
+	# else). The validator (case branch) enforces the shape more
+	# tightly than the generic arity check.
+	arity=(1, None),
+	# args_uniform marks each clause as a "case_clause" - a special
+	# kind validated by the case-specific branch in validate_expr,
+	# not by _check_arg_kind.
+	args_uniform="case_clause",
+	builder=_build_case_stub,
+)
+
+
+# ---- Phase 4: string + numeric helpers ------------------------------
+
+
+def _build_concat(args: list, dialect: str) -> Term:
+	"""CONCAT(a, b, ...) returns a string concatenation. pypika.Concat
+	works on MariaDB and SQLite natively; Postgres CONCAT also exists
+	but treats NULL as empty (unlike `||` which propagates NULL).
+	Use the function form across the board."""
+	return fn.Concat(*args)
+
+
+def _build_lower(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Lower(x)
+
+
+def _build_upper(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Upper(x)
+
+
+def _build_trim(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Trim(x)
+
+
+def _build_length(args: list, dialect: str) -> Term:
+	(x,) = args
+	return fn.Length(x)
+
+
+def _build_substring(args: list, dialect: str) -> Term:
+	"""SUBSTRING(x, start, length). pypika.Substring expects keyword
+	args in some versions; use the generic Function constructor for
+	stability. SUBSTRING is SQL-standard and supported by all three
+	dialects."""
+	x, start, length = args
+	from pypika.terms import Function
+	return Function("SUBSTRING", x, start, length)
+
+
+_register(
+	"concat",
+	arity=(2, None),
+	args_uniform="expr",
+	builder=_build_concat,
+)
+_register("lower", arity=(1, 1), args=["expr"], builder=_build_lower)
+_register("upper", arity=(1, 1), args=["expr"], builder=_build_upper)
+_register("trim", arity=(1, 1), args=["expr"], builder=_build_trim)
+_register("length", arity=(1, 1), args=["expr"], builder=_build_length)
+_register(
+	"substring",
+	arity=(3, 3),
+	args=["expr", "literal", "literal"],
+	builder=_build_substring,
+)
+
+
 # ---- Public API: validate + build ------------------------------------
 
 
@@ -349,7 +546,13 @@ def validate_expr(node: Any, depth: int = 1) -> None:
 			f"expression {name!r} takes {arity_min}..{max_s} args, "
 			f"got {len(args)}"
 		)
-	# Per-arg kind check.
+	# CASE special shape: args are clause dicts, not expression nodes.
+	# Each clause is either {"when": <pred>, "then": <expr>} OR
+	# {"else": <expr>}. At most one "else", and it must be terminal.
+	if name == "case":
+		_validate_case_clauses(args, depth=depth)
+		return
+	# Per-arg kind check (generic function path).
 	expected_kinds = entry.get("args", [])
 	uniform = entry.get("args_uniform")
 	for i, a in enumerate(args):
@@ -373,6 +576,72 @@ def validate_expr(node: Any, depth: int = 1) -> None:
 				)
 		# Recurse for sub-expressions.
 		validate_expr(a, depth=depth + 1)
+
+
+def _validate_case_clauses(clauses: list, depth: int) -> None:
+	"""Validate the special-shape CASE clause list. Each clause is
+	either ``{"when": <predicate>, "then": <expr>}`` or
+	``{"else": <expr>}``. Rules:
+
+	- At most one ``"else"`` clause, and if present it must be the last
+	  entry (matches SQL CASE semantics).
+	- ``when`` predicates are validated structurally here; full
+	  alias-aware validation happens at translate time via the
+	  ``build_predicate`` callback (predicates can carry expressions
+	  themselves, but we don't validate those at this layer).
+	- ``then`` / ``else`` values are expressions; recurse.
+	- The ``op`` inside ``when`` cannot be ``exists`` / ``not exists``;
+	  CASE-inside-EXISTS would be a recursion sink and is not a
+	  realistic shape for v1.
+	"""
+	if not clauses:
+		raise InvalidArgumentError(
+			"case requires at least one clause "
+			"({when: ..., then: ...} or {else: ...})"
+		)
+	seen_else = False
+	for i, clause in enumerate(clauses):
+		if not isinstance(clause, dict):
+			raise InvalidArgumentError(
+				f"case clause {i} must be a dict, got {type(clause).__name__}"
+			)
+		if "else" in clause:
+			if seen_else:
+				raise InvalidArgumentError("case can have at most one 'else'")
+			if i != len(clauses) - 1:
+				raise InvalidArgumentError(
+					"case 'else' clause must be the last entry"
+				)
+			seen_else = True
+			other = set(clause) - {"else"}
+			if other:
+				raise InvalidArgumentError(
+					f"case 'else' clause cannot also carry {sorted(other)!r}"
+				)
+			validate_expr(clause["else"], depth=depth + 1)
+			continue
+		# Otherwise expect when/then.
+		if "when" not in clause or "then" not in clause:
+			raise InvalidArgumentError(
+				f"case clause {i} must carry both 'when' and 'then' "
+				f"(or be a terminal {{else: ...}} clause)"
+			)
+		other = set(clause) - {"when", "then"}
+		if other:
+			raise InvalidArgumentError(
+				f"case clause {i} cannot also carry {sorted(other)!r}"
+			)
+		pred = clause["when"]
+		if not isinstance(pred, dict):
+			raise InvalidArgumentError(
+				f"case clause {i} 'when' must be a predicate dict"
+			)
+		if pred.get("op") in ("exists", "not exists"):
+			raise InvalidArgumentError(
+				f"case clause {i} 'when' cannot use 'exists'/'not exists' "
+				f"(sub-queries inside CASE are not supported)"
+			)
+		validate_expr(clause["then"], depth=depth + 1)
 
 
 def _check_arg_kind(fn_name: str, idx: int, expected_kind: str, node: Any) -> None:
@@ -410,13 +679,23 @@ def _check_arg_kind(fn_name: str, idx: int, expected_kind: str, node: Any) -> No
 	raise RuntimeError(f"unreachable: bad expected_kind {expected_kind!r}")
 
 
-def build_expr(node: dict, resolve_field: Callable[[str], Term]) -> Term:
+def build_expr(
+	node: dict,
+	resolve_field: Callable[[str], Term],
+	build_predicate: Callable[[dict], Term] | None = None,
+) -> Term:
 	"""Translate a validated expression tree to a pypika Term.
 
 	``resolve_field`` is the field-resolution callback - in practice
 	this is ``lambda ref: _resolve_field(ref, alias_map)`` from
 	query.py, but we keep this module decoupled from query.py to
 	avoid circular imports.
+
+	``build_predicate`` is the predicate-translation callback,
+	required only when the tree contains a ``case`` node (CASE WHEN
+	clauses carry predicate dicts as their ``when`` values). Callers
+	in query.py pass ``lambda p: _build_predicate(p, alias_map)``.
+	If absent and a ``case`` node is encountered, raises.
 
 	Validation must have run first; this builder assumes well-formed
 	input and emits AttributeError on misuse rather than user-facing
@@ -434,6 +713,14 @@ def build_expr(node: dict, resolve_field: Callable[[str], Term]) -> Term:
 		return _literal_term(v)
 	# Function call.
 	name = node["fn"]
+	# CASE special path: args are clause dicts, not expression nodes.
+	if name == "case":
+		if build_predicate is None:
+			raise RuntimeError(
+				"build_expr requires a build_predicate callback when the "
+				"tree contains a 'case' node"
+			)
+		return _build_case(node.get("args") or [], resolve_field, build_predicate)
 	entry = _REGISTRY[name]
 	dialect = _current_dialect()
 	# Translate each arg first.
@@ -444,8 +731,32 @@ def build_expr(node: dict, resolve_field: Callable[[str], Term]) -> Term:
 			# need them as ints / strings rather than pypika Terms.
 			translated.append(a["literal"])
 		else:
-			translated.append(build_expr(a, resolve_field))
+			translated.append(build_expr(a, resolve_field, build_predicate))
 	return entry["builder"](translated, dialect)
+
+
+def _build_case(
+	clauses: list,
+	resolve_field: Callable[[str], Term],
+	build_predicate: Callable[[dict], Term],
+) -> Term:
+	"""Translate a validated CASE clause list to a pypika.Case Term.
+
+	pypika exposes Case() with a fluent .when(criterion, value).else_
+	(value) API. Iterate clauses; for each ``{"when": pred, "then":
+	expr}`` call .when(build_predicate(pred), build_expr(expr)); for
+	the terminal ``{"else": expr}`` call .else_(build_expr(expr))."""
+	from pypika.terms import Case
+	case = Case()
+	for clause in clauses:
+		if "else" in clause:
+			else_term = build_expr(clause["else"], resolve_field, build_predicate)
+			case = case.else_(else_term)
+			continue
+		criterion = build_predicate(clause["when"])
+		then_term = build_expr(clause["then"], resolve_field, build_predicate)
+		case = case.when(criterion, then_term)
+	return case
 
 
 def _literal_term(v: Any) -> Term:

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -604,6 +604,7 @@ def _build_select(select_spec: list, alias_map: dict) -> list:
 				built = _expr.build_expr(
 					item["expr"],
 					lambda ref: _resolve_field(ref, alias_map),
+					lambda pr: _build_predicate(pr, alias_map),
 				)
 				out.append(built.as_(item["as"]))
 			else:
@@ -655,6 +656,7 @@ def _build_aggregate(spec: dict, alias_map: dict):
 		inner = _expr.build_expr(
 			agg_expr,
 			lambda ref: _resolve_field(ref, alias_map),
+			lambda pr: _build_predicate(pr, alias_map),
 		)
 		expr = _AGGREGATES[agg_name](inner)
 	else:
@@ -717,6 +719,7 @@ def _build_predicate(p: dict, alias_map: dict, depth: int = 1) -> Criterion:
 		lhs = _expr.build_expr(
 			p["expr"],
 			lambda ref: _resolve_field(ref, alias_map),
+			lambda pr: _build_predicate(pr, alias_map),
 		)
 	else:
 		field_ref = p.get("field")


### PR DESCRIPTION
## Summary

Completes the expression DSL rollout (Phase 1 shipped earlier as #145). Three additive function packs bundled for review coherence; each works through the same registry pattern Phase 1 established.

| Phase | Functions |
|---|---|
| **Phase 2 — NULL + arithmetic** | \`coalesce(a, b, ...)\`, \`ifnull(x, default)\`, \`add\`/\`sub\`/\`mul\`/\`div\`, \`neg(x)\`, \`abs(x)\`, \`round(x, digits)\`, \`ceil(x)\`, \`floor(x)\` |
| **Phase 3 — CASE WHEN** | Special clause shape: \`{when: <predicate>, then: <expr>}\` + optional \`{else: <expr>}\` |
| **Phase 4 — String + numeric** | \`concat(a, b, ...)\`, \`lower\`, \`upper\`, \`trim\`, \`substring(x, start, len)\`, \`length\` |

## CASE handling

The special shape needed two architectural additions:
- \`_validate_case_clauses\` — clause-shape validator (called from \`validate_expr\` when fn == "case")
- \`build_expr\` gained an optional \`build_predicate\` callback so the \`when\` predicates inside CASE can route through query.py's existing \`_build_predicate\` machinery without a circular import

\`exists\` / \`not exists\` are explicitly rejected inside CASE's \`when\` (recursion sink prevention). At most one \`else\`, must be the terminal clause.

## What this unlocks

| Question | Before | After |
|---|---|---|
| Paid vs unpaid totals in one row | 2 queries + response sum | 1 query with \`SUM(CASE WHEN ...)\` |
| Customer's primary OR contact email | Pull then post-filter | 1 query with \`coalesce(...)\` |
| Top items by line total (qty × rate) | Pull raw rows + sort in response | 1 query with \`mul(qty, rate)\` in select |
| Case-insensitive name lookup | Pull all + filter in response | 1 query with \`lower()\` in WHERE |

## Test plan

- [x] \`bench run-tests --module jarvis.tests.test_query\` — 107/107 (82 prior + 25 new across \`TestQueryExprDSLPhase2NullAndArithmetic\` / \`Phase3CaseWhen\` / \`Phase4StringHelpers\`)
- [ ] Live smoke once plugin + persona land:
  - "Paid vs unpaid sales invoice totals this year" → 1 \`query\` with \`SUM(CASE WHEN status='Paid' ...)\`
  - "Top 5 invoice line items by line total" → 1 \`query\` with \`mul(qty, rate)\` projection
  - "Find customers with 'acme' in name (case-insensitive)" → 1 \`query\` with \`lower\` in WHERE

🤖 Generated with [Claude Code](https://claude.com/claude-code)