### PR TITLE
chore(tools): introduce desk_action decorator; consolidate 9 desk tools

### DIFF
--- a/jarvis/tools/__init__.py
+++ b/jarvis/tools/__init__.py
@@ -7,6 +7,10 @@ Shared helpers go here so per-tool files don't repeat them.
 
 from __future__ import annotations
 
+from functools import wraps
+
+import frappe
+
 from jarvis.exceptions import InvalidArgumentError
 
 
@@ -24,3 +28,43 @@ def require_doctype_and_name(doctype: str, name: str) -> None:
 		raise InvalidArgumentError("doctype is required")
 	if not name:
 		raise InvalidArgumentError("name is required")
+
+
+def desk_action(check_user_arg: str | None = None):
+	"""Decorator for desk-action tools that take ``(doctype, name, ...)``.
+
+	Hoists the three repeated guards each tool would otherwise inline:
+	1. ``require_doctype_and_name(doctype, name)`` - reject empty inputs
+	2. ``frappe.db.exists(doctype, name)`` - reject phantom doc references
+	3. (optional) ``frappe.db.exists("User", <arg>)`` - reject phantom
+	   User refs when the tool takes a user-id arg (assign_to, share_doc,
+	   follow_document, etc.). Pass the arg name as ``check_user_arg``;
+	   the decorator looks it up positionally or by keyword.
+
+	Used by add_comment / add_tag / remove_tag / assign_to / unassign_from
+	/ share_doc / unshare_doc / follow_document / unfollow_document /
+	attach_to_doc. Other tools (update_comment) have a different
+	signature and don't fit.
+	"""
+	def _deco(fn):
+		@wraps(fn)
+		def _wrapped(doctype: str, name: str, *args, **kwargs):
+			require_doctype_and_name(doctype, name)
+			if not frappe.db.exists(doctype, name):
+				raise InvalidArgumentError(f"unknown {doctype}: {name}")
+			if check_user_arg:
+				# Look up the user-id arg positionally or by keyword.
+				# Per-tool signatures put it at varying positions
+				# (assign_to: user is 3rd positional; share_doc: user is
+				# 3rd; follow_document: user is optional kwarg), so we
+				# bind via the wrapped function's argspec.
+				import inspect
+				sig = inspect.signature(fn)
+				bound = sig.bind_partial(doctype, name, *args, **kwargs)
+				bound.apply_defaults()
+				user = bound.arguments.get(check_user_arg)
+				if user and not frappe.db.exists("User", user):
+					raise InvalidArgumentError(f"unknown User: {user}")
+			return fn(doctype, name, *args, **kwargs)
+		return _wrapped
+	return _deco

--- a/jarvis/tools/add_comment.py
+++ b/jarvis/tools/add_comment.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action()
 def add_comment(doctype: str, name: str, content: str) -> dict:
     """Add a Comment to ``doctype/name`` with ``content`` as the body.
 
@@ -29,11 +30,8 @@ def add_comment(doctype: str, name: str, content: str) -> dict:
     ``comment_name`` is the new Comment doc id (so a follow-up
     update_comment can target it).
     """
-    require_doctype_and_name(doctype, name)
     if content is None or content == "":
         raise InvalidArgumentError("content is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
 
     from frappe.desk.form.utils import add_comment as _ac
 

--- a/jarvis/tools/add_tag.py
+++ b/jarvis/tools/add_tag.py
@@ -16,9 +16,10 @@ from jarvis.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
 )
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action()
 def add_tag(
     doctype: str,
     name: str,
@@ -28,11 +29,8 @@ def add_tag(
     """Add ``tag`` to ``doctype/name``. ``color`` is an optional hex
     code (e.g. ``#ff0000``) for the Tag record. Returns
     ``{doctype, name, tag}``."""
-    require_doctype_and_name(doctype, name)
     if not tag:
         raise InvalidArgumentError("tag is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
     if not frappe.has_permission(doctype, "write", doc=name):
         raise PermissionDeniedError(
             f"no write permission on {doctype} {name}",

--- a/jarvis/tools/assign_to.py
+++ b/jarvis/tools/assign_to.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def assign_to(
     doctype: str,
     name: str,
@@ -30,13 +31,8 @@ def assign_to(
 ) -> dict:
     """Open a ToDo for ``user`` assigned to ``doctype/name``. Returns
     ``{doctype, name, user, description, notify, priority, date}``."""
-    require_doctype_and_name(doctype, name)
     if not user:
         raise InvalidArgumentError("user is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
-    if not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.desk.form.assign_to import add as _assign_add
 

--- a/jarvis/tools/follow_document.py
+++ b/jarvis/tools/follow_document.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 import frappe
 
-from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def follow_document(
     doctype: str,
     name: str,
@@ -25,12 +25,7 @@ def follow_document(
     Returns ``{doctype, name, user, followed}`` where ``followed`` is
     True on the wire path that actually inserted a follow row, False
     when the doc was already being followed (idempotent)."""
-    require_doctype_and_name(doctype, name)
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
     target_user = user or frappe.session.user
-    if user and not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.desk.form.document_follow import (
         follow_document as _follow,

--- a/jarvis/tools/remove_tag.py
+++ b/jarvis/tools/remove_tag.py
@@ -11,17 +11,15 @@ from jarvis.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
 )
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action()
 def remove_tag(doctype: str, name: str, tag: str) -> dict:
     """Remove ``tag`` from ``doctype/name``. Returns
     ``{doctype, name, tag}``."""
-    require_doctype_and_name(doctype, name)
     if not tag:
         raise InvalidArgumentError("tag is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
     if not frappe.has_permission(doctype, "write", doc=name):
         raise PermissionDeniedError(
             f"no write permission on {doctype} {name}",

--- a/jarvis/tools/share_doc.py
+++ b/jarvis/tools/share_doc.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def share_doc(
     doctype: str,
     name: str,
@@ -32,15 +33,10 @@ def share_doc(
     (or to every user when ``everyone=True``). Returns
     ``{doctype, name, user, everyone, read, write, submit, share}``.
     """
-    require_doctype_and_name(doctype, name)
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
     if not everyone and not user:
         raise InvalidArgumentError(
             "either user or everyone=True is required",
         )
-    if user and not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.share import add as _share_add
 

--- a/jarvis/tools/unassign_from.py
+++ b/jarvis/tools/unassign_from.py
@@ -10,19 +10,15 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def unassign_from(doctype: str, name: str, user: str) -> dict:
     """Close the ToDo assigning ``user`` to ``doctype/name``. Returns
     ``{doctype, name, user}``."""
-    require_doctype_and_name(doctype, name)
     if not user:
         raise InvalidArgumentError("user is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
-    if not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.desk.form.assign_to import remove as _assign_remove
 

--- a/jarvis/tools/unfollow_document.py
+++ b/jarvis/tools/unfollow_document.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import frappe
 
-from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def unfollow_document(
     doctype: str,
     name: str,
@@ -18,12 +18,7 @@ def unfollow_document(
 ) -> dict:
     """Unsubscribe ``user`` (or the session user) from
     ``doctype/name``. Returns ``{doctype, name, user, unfollowed}``."""
-    require_doctype_and_name(doctype, name)
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
     target_user = user or frappe.session.user
-    if user and not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.desk.form.document_follow import (
         unfollow_document as _unfollow,

--- a/jarvis/tools/unshare_doc.py
+++ b/jarvis/tools/unshare_doc.py
@@ -9,19 +9,15 @@ from __future__ import annotations
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import desk_action
 
 
+@desk_action(check_user_arg="user")
 def unshare_doc(doctype: str, name: str, user: str) -> dict:
     """Remove the DocShare granting ``user`` access to ``doctype/name``.
     Returns ``{doctype, name, user}``."""
-    require_doctype_and_name(doctype, name)
     if not user:
         raise InvalidArgumentError("user is required")
-    if not frappe.db.exists(doctype, name):
-        raise InvalidArgumentError(f"unknown {doctype}: {name}")
-    if not frappe.db.exists("User", user):
-        raise InvalidArgumentError(f"unknown User: {user}")
 
     from frappe.share import remove as _share_remove
 


### PR DESCRIPTION
## Summary

ponytail-audit follow-up. Each desk-action tool opened with the same three guards:
1. \`require_doctype_and_name(doctype, name)\`
2. \`frappe.db.exists(doctype, name)\`
3. Optional \`frappe.db.exists(\"User\", user)\` (for tools that take a user-id arg)

Factored into a single \`desk_action\` decorator at \`jarvis.tools\`.

## Applies to

\`add_comment\`, \`add_tag\`, \`remove_tag\`, \`assign_to\`, \`unassign_from\`, \`share_doc\`, \`unshare_doc\`, \`follow_document\`, \`unfollow_document\`.

## Skipped (different signature shape)

- \`attach_to_doc\` takes \`(file_url, target_doctype, target_name)\` — the (doctype, name) pair is not first
- \`update_comment\` takes \`(name, content)\` only

## Honest line accounting

Net: +12 LOC. The decorator adds 44 lines; saves ~32 across 9 tools. **Not a line-shrink win** — it's a cohesion win: one place to change boilerplate, future tools in the same family ship lean.

## Test plan

- [x] \`bench run-tests --module jarvis.tests.test_tier3_desk_actions\` — 28/28 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)