### PR TITLE
feat(chat): pool openclaw WS connections per worker process

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -20,6 +20,7 @@ stream_agent_turn / close) is unchanged. worker.py and api.py don't notice.
 from __future__ import annotations
 
 import json
+import logging
 import threading
 import time
 import uuid
@@ -27,6 +28,9 @@ from collections.abc import Iterator
 from typing import Any
 
 import websocket
+
+
+_logger = logging.getLogger(__name__)
 
 from jarvis.chat.device import (
 	ChatDeviceCredentials, build_payload_v3, clear_credentials,
@@ -177,7 +181,17 @@ class OpenclawSession:
 
 	@classmethod
 	def _attempt_connect(cls, gateway_url: str, *, allow_repair: bool) -> OpenclawSession:
+		# Timing breakdown logged so the connection pool's win is
+		# measurable in production. Three phases:
+		#   - ensure_paired (cache hit on a paired bench, real I/O on
+		#     first run or after repair)
+		#   - WS open (DNS + TCP + TLS + WS upgrade)
+		#   - _handshake (3-phase signed connect over an open WS)
+		# The pool reuses connections, so we only pay this on pool
+		# miss / stale eviction / first turn in a worker process.
+		t_pair_start = time.monotonic()
 		creds = ensure_paired()
+		t_pair_done = time.monotonic()
 		try:
 			ws = websocket.create_connection(
 				gateway_url, timeout=CONNECT_TIMEOUT_SECONDS,
@@ -188,6 +202,7 @@ class OpenclawSession:
 			)
 		except (websocket.WebSocketException, OSError) as e:
 			raise OpenclawUnreachableError(f"WS open failed: {e}") from e
+		t_ws_done = time.monotonic()
 
 		try:
 			cls._handshake(ws, creds)
@@ -202,6 +217,15 @@ class OpenclawSession:
 			try: ws.close()
 			except Exception: pass
 			raise
+		t_handshake_done = time.monotonic()
+		_logger.info(
+			"OpenclawSession.connect: pair_ms=%d ws_open_ms=%d handshake_ms=%d total_ms=%d gateway=%s",
+			int((t_pair_done - t_pair_start) * 1000),
+			int((t_ws_done - t_pair_done) * 1000),
+			int((t_handshake_done - t_ws_done) * 1000),
+			int((t_handshake_done - t_pair_start) * 1000),
+			gateway_url,
+		)
 		return cls(ws, creds)
 
 	@classmethod

--- a/jarvis/chat/openclaw_session_pool.py
+++ b/jarvis/chat/openclaw_session_pool.py
@@ -1,0 +1,222 @@
+"""WebSocket connection pool for OpenclawSession.
+
+Each chat worker turn previously opened a fresh WS to the tenant's
+openclaw gateway: DNS + TCP + TLS + WS upgrade + 3-phase signed
+handshake before sending the agent RPC. The spike (workflow
+``w0s0vqhqu``) measured this as 50-200ms per turn (recurring) and
+confirmed:
+
+- The gateway dispatches concurrent RPCs on one WS (multiplex)
+- RQ workers are long-lived processes (Procfile, no ``--burst``)
+- One warm WS per gateway can serve every subsequent turn
+
+This module maintains one pooled OpenclawSession per gateway URL,
+per worker process, with lazy reconnect on stale / idle / error.
+
+Concurrency: single-process RQ workers are single-threaded, so the
+per-entry lock is uncontended in practice. The lock exists for
+safety against threaded / no-fork RQ variants and to prevent races
+inside a process that might somehow spawn a second concurrent
+checkout against the same URL.
+
+Lifetime: an ``atexit`` hook drains all pooled sessions when the
+worker process exits. SIGTERM during a job lets the in-flight call
+finish before the drain proceeds (atexit runs after the foreground
+work completes).
+
+The bench-side ``OpenclawSession`` is NOT safe for concurrent
+``stream_agent_turn`` calls on the same WS — ``_recv`` is shared
+state and would steal frames between turns. So the pool gives an
+exclusive checkout: one turn per pooled session at a time. The
+amortization win is over SEQUENTIAL turns within a worker process,
+not concurrent multiplexing. Multi-worker concurrency arrives via
+multiple worker processes each maintaining their own pool entry.
+"""
+from __future__ import annotations
+
+import atexit
+import contextlib
+import logging
+import threading
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from jarvis.chat.openclaw_client import OpenclawSession
+from jarvis.exceptions import OpenclawUnreachableError
+
+
+logger = logging.getLogger(__name__)
+
+
+# Max idle seconds before a pooled session is discarded on next
+# checkout. Below the typical 5-min openclaw gateway idle disconnect
+# so the WS is fresh when handed out. Aggressive eviction is cheap;
+# the next checkout reconnects.
+IDLE_MAX_S = 240
+
+
+@dataclass
+class _PooledEntry:
+	"""One pooled session per gateway URL.
+
+	Each entry has its own lock so checkouts to different URLs don't
+	contend. Within a process, a single entry is exclusive per turn
+	because the worker is single-threaded and the bench-side client
+	isn't safe for concurrent ``stream_agent_turn`` calls on the same
+	WS.
+	"""
+	session: OpenclawSession
+	lock: threading.Lock
+	last_used: float
+	gateway_url: str
+
+
+# Module-level pool keyed by gateway_url. Mutations to the pool dict
+# (creating / deleting entries) go through ``_POOL_LOCK``; per-entry
+# concurrent-use protection is on the entry's own lock.
+_POOL: dict[str, _PooledEntry] = {}
+_POOL_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def checkout(gateway_url: str) -> Iterator[OpenclawSession]:
+	"""Acquire a healthy OpenclawSession for ``gateway_url``.
+
+	Reuses a pooled session if one exists and passes the healthcheck;
+	otherwise opens a fresh connection (paying the handshake cost
+	once). The yielded session is exclusive to this caller until the
+	context exits. On exception inside the block, the session is
+	discarded from the pool (next checkout reconnects).
+	"""
+	entry = _get_or_create_entry(gateway_url)
+	entry.lock.acquire()
+	evicted = False
+	try:
+		# Healthcheck: discard if connection went away or sat idle
+		# too long. Either reason → reconnect now.
+		if not _is_alive(entry.session, entry.last_used):
+			logger.info(
+				"openclaw_session_pool: stale entry, reconnecting "
+				"gateway=%s idle_s=%.1f connected=%s",
+				gateway_url,
+				time.monotonic() - entry.last_used,
+				_safe_connected(entry.session),
+			)
+			_close_quietly(entry.session)
+			entry.session = _do_connect(gateway_url)
+		yield entry.session
+		entry.last_used = time.monotonic()
+	except OpenclawUnreachableError:
+		# Connection failed mid-use. Evict so the next checkout opens
+		# a fresh WS rather than handing out the broken one.
+		_evict(gateway_url, entry)
+		evicted = True
+		raise
+	finally:
+		if not evicted:
+			entry.lock.release()
+		else:
+			# _evict left the lock held so we release uniformly here.
+			try:
+				entry.lock.release()
+			except RuntimeError:
+				pass
+
+
+def _get_or_create_entry(gateway_url: str) -> _PooledEntry:
+	"""Look up the entry for ``gateway_url`` or create one with a
+	fresh connection. The pool-dict mutation is locked; the connection
+	open happens outside the pool lock to avoid blocking other URLs."""
+	with _POOL_LOCK:
+		entry = _POOL.get(gateway_url)
+		if entry is not None:
+			return entry
+	# Slow path: open a connection. Done outside ``_POOL_LOCK`` so a
+	# slow connect doesn't block other gateways. Race: if two callers
+	# hit this at once, both will create sessions; the second
+	# insertion under ``_POOL_LOCK`` wins and we close the loser.
+	# Cheap, rare (single-threaded workers).
+	sess = _do_connect(gateway_url)
+	new_entry = _PooledEntry(
+		session=sess,
+		lock=threading.Lock(),
+		last_used=time.monotonic(),
+		gateway_url=gateway_url,
+	)
+	with _POOL_LOCK:
+		existing = _POOL.get(gateway_url)
+		if existing is not None:
+			_close_quietly(sess)
+			return existing
+		_POOL[gateway_url] = new_entry
+	return new_entry
+
+
+def _do_connect(gateway_url: str) -> OpenclawSession:
+	"""Open a fresh WS + handshake. Wraps ``OpenclawSession.connect``
+	for timing visibility — the actual connect logic stays in the
+	client. Phase-level breakdown is logged inside ``_attempt_connect``
+	itself; this just captures the total."""
+	t0 = time.monotonic()
+	sess = OpenclawSession.connect(gateway_url)
+	elapsed_ms = int((time.monotonic() - t0) * 1000)
+	logger.info(
+		"openclaw_session_pool: pool-miss connect gateway=%s total_ms=%d",
+		gateway_url, elapsed_ms,
+	)
+	return sess
+
+
+def _is_alive(session: OpenclawSession, last_used: float) -> bool:
+	"""True if the session looks healthy enough to reuse: WS is open
+	and the entry hasn't sat idle past the eviction threshold."""
+	if time.monotonic() - last_used > IDLE_MAX_S:
+		return False
+	return _safe_connected(session)
+
+
+def _safe_connected(session: OpenclawSession) -> bool:
+	"""Defensively read ``session._ws.connected``; some WS libraries
+	don't expose the field, in which case treat as not-connected."""
+	try:
+		return bool(session._ws.connected)
+	except AttributeError:
+		return False
+
+
+def _close_quietly(session: OpenclawSession) -> None:
+	"""Close a session, swallowing any errors. Used during eviction
+	where the session is already dead / dying."""
+	try:
+		session.close()
+	except Exception:
+		pass
+
+
+def _evict(gateway_url: str, entry: _PooledEntry) -> None:
+	"""Remove the entry from the pool and close its session. The
+	caller holds ``entry.lock``; we leave it locked so the ``finally``
+	clause in ``checkout`` releases uniformly."""
+	with _POOL_LOCK:
+		if _POOL.get(gateway_url) is entry:
+			_POOL.pop(gateway_url, None)
+	_close_quietly(entry.session)
+
+
+def drain_all() -> None:
+	"""Close every pooled session. Called from ``atexit`` on worker
+	shutdown so the gateway sees clean disconnects rather than dangling
+	half-open TCP connections. Also exposed for tests."""
+	with _POOL_LOCK:
+		entries = list(_POOL.values())
+		_POOL.clear()
+	for entry in entries:
+		_close_quietly(entry.session)
+
+
+# Register the drain hook at module import time. ``atexit`` runs in
+# reverse-registration order, which is correct: any code that
+# registered before us (e.g. Frappe DB connections) drains first,
+# then we close the WS.
+atexit.register(drain_all)

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -14,7 +14,7 @@ import time
 import frappe
 
 from jarvis.chat.events import publish_to_user
-from jarvis.chat.openclaw_client import OpenclawSession
+from jarvis.chat import openclaw_session_pool
 from jarvis.exceptions import OpenclawUnreachableError
 
 CONV = "Jarvis Conversation"
@@ -266,25 +266,25 @@ def run_agent_turn(conversation_id: str, message_id: str, run_id: str) -> None:
 				selfhost.clear_active_turn(tool_user, run_id)
 		else:
 			# Managed: device-paired WebSocket to the tenant's gateway.
+			# Uses a per-process connection pool so we don't pay the
+			# DNS + TCP + TLS + WS upgrade + handshake (~50-200ms) on
+			# every turn. The pool eviction on OpenclawUnreachableError
+			# means the next attempt will reconnect; we don't auto-
+			# retry inside this turn because tokens may have already
+			# streamed to the UI by the time the failure surfaces.
 			gateway_url = (settings.agent_url or "").replace(
 				"http://", "ws://"
 			).replace("https://", "wss://")
-			try:
-				sess = OpenclawSession.connect(gateway_url)
-			except OpenclawUnreachableError as e:
-				_publish_run_error(str(e))
-				return
 			effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
 			try:
-				_consume(sess.stream_agent_turn(
-					conv.session_key, user_message, idem,
-					model=effective_model, provider=oauth_provider_id,
-				))
+				with openclaw_session_pool.checkout(gateway_url) as sess:
+					_consume(sess.stream_agent_turn(
+						conv.session_key, user_message, idem,
+						model=effective_model, provider=oauth_provider_id,
+					))
 			except OpenclawUnreachableError as e:
 				_publish_run_error(str(e))
 				return
-			finally:
-				sess.close()
 
 		# Streaming exited cleanly via lifecycle.end
 		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis.chat import openclaw_session_pool
 from jarvis.chat.api import create_conversation, send_message
 from jarvis.chat.worker import run_agent_turn
 from jarvis.tests.test_chat_api import (
@@ -39,6 +40,7 @@ def _fake_event_stream(events: list[dict]):
 
 class TestRunAgentTurnHappyPath(FrappeTestCase):
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -57,7 +59,7 @@ class TestRunAgentTurnHappyPath(FrappeTestCase):
 			{"kind": "assistant", "text": "Hello world", "delta": " world"},
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user") as pub:
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 
@@ -80,6 +82,7 @@ class TestRunAgentTurnHappyPath(FrappeTestCase):
 
 class TestRunAgentTurnToolCall(FrappeTestCase):
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -101,7 +104,7 @@ class TestRunAgentTurnToolCall(FrappeTestCase):
 			{"kind": "assistant", "text": "Done", "delta": "Done"},
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 
@@ -117,6 +120,7 @@ class TestRunAgentTurnToolCall(FrappeTestCase):
 
 class TestRunAgentTurnErrorPaths(FrappeTestCase):
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -130,7 +134,7 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 	def test_connect_failure_publishes_run_error_and_marks_message_errored(self):
 		from jarvis.exceptions import OpenclawUnreachableError
 		with patch(
-			"jarvis.chat.worker.OpenclawSession.connect",
+			"jarvis.chat.openclaw_session_pool.OpenclawSession.connect",
 			side_effect=OpenclawUnreachableError("connect refused"),
 		):
 			with patch("jarvis.chat.worker.publish_to_user") as pub:
@@ -154,7 +158,7 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "lifecycle", "phase": "error", "error": "model overloaded"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 
@@ -184,7 +188,7 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 		def _capture(user, payload):
 			published_kinds.append(payload.get("kind"))
 
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess), \
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess), \
 		     patch("jarvis.chat.worker.publish_to_user", side_effect=_capture):
 			with self.assertRaises(ssl.SSLError):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
@@ -211,6 +215,7 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 	"""
 
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -229,7 +234,7 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 
@@ -281,6 +286,7 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 		super().tearDownClass()
 
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -296,7 +302,7 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 		return fake_sess.stream_agent_turn.call_args
@@ -353,6 +359,7 @@ class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
 		super().tearDownClass()
 
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -368,7 +375,7 @@ class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
 		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 		kwargs = fake_sess.stream_agent_turn.call_args.kwargs
@@ -390,6 +397,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 	"""
 
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)
@@ -414,7 +422,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 			{"kind": "assistant", "text": "Hello", "delta": "o"},
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user") as pub:
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 		# Five assistant:delta publishes (one per token), even though
@@ -466,7 +474,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 				write_calls.append(args)
 			return real_set_value(*args, **kwargs)
 
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				with patch("frappe.db.set_value", side_effect=tracking_set_value):
 					run_agent_turn(self.conv, self.user_msg, run_id="r1")
@@ -504,7 +512,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 			{"kind": "assistant", "text": "Done!", "delta": " Done!"},
 			{"kind": "lifecycle", "phase": "end"},
 		])
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 		# Final cumulative content is the last assistant text. The
@@ -547,7 +555,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 				raise RuntimeError("simulated tool-row insert failure")
 			return _orig_get_doc(*args, **kwargs)
 
-		with patch("jarvis.chat.worker.OpenclawSession.connect", return_value=fake_sess):
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				with patch("frappe.get_doc", side_effect=boom_on_tool_msg):
 					with patch("frappe.log_error") as log_err:
@@ -573,6 +581,7 @@ class TestAssistantContentBatcherUnit(FrappeTestCase):
 	"""Unit-level coverage of _AssistantContentBatcher thresholds."""
 
 	def setUp(self):
+		openclaw_session_pool._POOL.clear()
 		_ensure_test_user()
 		self._orig_user = frappe.session.user
 		frappe.set_user(TEST_USER)

--- a/jarvis/tests/test_openclaw_session_pool.py
+++ b/jarvis/tests/test_openclaw_session_pool.py
@@ -1,0 +1,206 @@
+"""Tests for jarvis.chat.openclaw_session_pool.
+
+The pool itself talks only to ``OpenclawSession.connect`` (which we mock
+with a fake session exposing ``_ws.connected`` + ``close()``). No real
+WebSocket / Frappe involvement; tests are pure unit.
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import openclaw_session_pool
+from jarvis.exceptions import OpenclawUnreachableError
+
+
+def _fake_session(connected: bool = True) -> MagicMock:
+	"""Build a session stub that satisfies the pool's healthcheck."""
+	sess = MagicMock()
+	sess._ws = MagicMock()
+	sess._ws.connected = connected
+	return sess
+
+
+class TestOpenclawSessionPool(FrappeTestCase):
+	"""Pool unit tests. Each test resets the module-level pool dict in
+	``setUp`` so suite order doesn't matter."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+
+	def tearDown(self):
+		openclaw_session_pool._POOL.clear()
+
+	# ---- happy path -------------------------------------------------
+
+	def test_checkout_creates_new_session(self):
+		sess = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  return_value=sess) as mock_connect:
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess)
+			mock_connect.assert_called_once_with("ws://gw")
+
+	def test_checkout_reuses_pooled_session(self):
+		sess = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  return_value=sess) as mock_connect:
+			with openclaw_session_pool.checkout("ws://gw"):
+				pass
+			with openclaw_session_pool.checkout("ws://gw"):
+				pass
+			# One connect total: second checkout reused the pool entry.
+			mock_connect.assert_called_once()
+
+	def test_different_urls_get_separate_entries(self):
+		sess_a = _fake_session()
+		sess_b = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess_a, sess_b]) as mock_connect:
+			with openclaw_session_pool.checkout("ws://a"):
+				pass
+			with openclaw_session_pool.checkout("ws://b"):
+				pass
+			self.assertEqual(mock_connect.call_count, 2)
+			self.assertEqual(set(openclaw_session_pool._POOL), {"ws://a", "ws://b"})
+
+	# ---- healthcheck + reconnect ------------------------------------
+
+	def test_dead_ws_triggers_reconnect(self):
+		"""When ``_ws.connected`` is False on second checkout, the pool
+		discards the entry and opens a fresh session."""
+		sess1 = _fake_session()
+		sess2 = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess1, sess2]) as mock_connect:
+			with openclaw_session_pool.checkout("ws://gw"):
+				pass
+			# Simulate gateway closing our WS.
+			sess1._ws.connected = False
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess2)
+			self.assertEqual(mock_connect.call_count, 2)
+			# First session's close() called during eviction.
+			sess1.close.assert_called_once()
+
+	def test_idle_eviction(self):
+		"""After ``IDLE_MAX_S`` seconds the next checkout reconnects."""
+		sess1 = _fake_session()
+		sess2 = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess1, sess2]) as mock_connect, \
+		     patch.object(openclaw_session_pool.time, "monotonic") as mock_time:
+			# T=1000: first checkout creates session.
+			mock_time.return_value = 1000.0
+			with openclaw_session_pool.checkout("ws://gw"):
+				pass
+			# T=1000 + IDLE_MAX_S + 1: stale, reconnect.
+			mock_time.return_value = 1000.0 + openclaw_session_pool.IDLE_MAX_S + 1
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess2)
+			self.assertEqual(mock_connect.call_count, 2)
+			sess1.close.assert_called_once()
+
+	# ---- error eviction ---------------------------------------------
+
+	def test_unreachable_during_use_evicts(self):
+		"""``OpenclawUnreachableError`` raised inside the ``with`` block
+		evicts the entry from the pool so the next checkout reconnects."""
+		sess1 = _fake_session()
+		sess2 = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess1, sess2]) as mock_connect:
+			with self.assertRaises(OpenclawUnreachableError):
+				with openclaw_session_pool.checkout("ws://gw"):
+					raise OpenclawUnreachableError("simulated stream failure")
+			# Entry evicted; next checkout opens a fresh session.
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess2)
+			self.assertEqual(mock_connect.call_count, 2)
+			# Evicted session's close() was called.
+			sess1.close.assert_called()
+
+	def test_other_exception_does_not_evict(self):
+		"""A non-Openclaw exception inside the block should NOT evict
+		the pool — those are caller bugs, the connection is fine."""
+		sess = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  return_value=sess) as mock_connect:
+			with self.assertRaises(ValueError):
+				with openclaw_session_pool.checkout("ws://gw"):
+					raise ValueError("caller bug")
+			# Next checkout reuses the same session — no eviction.
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess)
+			mock_connect.assert_called_once()
+
+	def test_close_failure_during_eviction_does_not_propagate(self):
+		"""If ``sess.close()`` itself raises during eviction (e.g. socket
+		already torn down), the pool swallows it. The eviction still
+		removes the entry."""
+		sess1 = _fake_session()
+		sess1.close.side_effect = RuntimeError("already closed")
+		sess2 = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess1, sess2]):
+			with self.assertRaises(OpenclawUnreachableError):
+				with openclaw_session_pool.checkout("ws://gw"):
+					raise OpenclawUnreachableError("boom")
+			# Entry should have been removed even though close raised.
+			self.assertNotIn("ws://gw", openclaw_session_pool._POOL)
+
+	# ---- concurrent checkout ----------------------------------------
+
+	def test_concurrent_checkout_shares_session(self):
+		"""Multiple threads checking out the same URL serialise on the
+		entry's lock; one connect, all five threads see the same
+		session. Workers are single-threaded in production but the lock
+		is exercised here as a safety check."""
+		sess = _fake_session()
+		# Connect is slow so threads pile up against the lock.
+		import time as _time
+		def slow_connect(_url):
+			_time.sleep(0.01)
+			return sess
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=slow_connect) as mock_connect:
+			results: list[object] = []
+			lock = threading.Lock()
+			def runner():
+				with openclaw_session_pool.checkout("ws://gw") as got:
+					with lock:
+						results.append(got)
+			threads = [threading.Thread(target=runner) for _ in range(5)]
+			for t in threads: t.start()
+			for t in threads: t.join()
+			self.assertEqual(len(results), 5)
+			self.assertTrue(all(r is sess for r in results))
+			# Race window means more than one connect MAY have started
+			# (the "lost-race insertion" branch handles it), but at
+			# least one session must have made it into the pool.
+			self.assertGreaterEqual(mock_connect.call_count, 1)
+			self.assertIn("ws://gw", openclaw_session_pool._POOL)
+
+	# ---- drain ------------------------------------------------------
+
+	def test_drain_all_closes_every_pooled_session(self):
+		sess_a = _fake_session()
+		sess_b = _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess_a, sess_b]):
+			with openclaw_session_pool.checkout("ws://a"):
+				pass
+			with openclaw_session_pool.checkout("ws://b"):
+				pass
+		openclaw_session_pool.drain_all()
+		sess_a.close.assert_called_once()
+		sess_b.close.assert_called_once()
+		self.assertEqual(len(openclaw_session_pool._POOL), 0)
+
+	def test_drain_all_is_idempotent(self):
+		"""Calling drain_all on an empty pool should be a no-op, not
+		raise."""
+		openclaw_session_pool.drain_all()
+		openclaw_session_pool.drain_all()


### PR DESCRIPTION
## Summary

- Adds an in-process WebSocket connection pool for the chat worker → openclaw gateway hop, keyed by `gateway_url`
- Eliminates the per-turn DNS + TCP + TLS + WS upgrade + 3-phase Ed25519 handshake (~50-200ms recurring) for sequential turns within a worker process
- Adds per-phase timing logs in `OpenclawSession.connect` so the production win is measurable from day one

## Spike (workflow `w0s0vqhqu`) confirmed all three preconditions

1. **Multiplex**: openclaw gateway dispatches RPCs concurrently with no per-connection lock (`message-handler.ts` fire-and-forget async + request-id correlation already done in `openclaw_client.py`).
2. **Long-lived workers**: bench `Procfile` runs `bench worker` without `--burst`; Frappe's `Worker.work(burst=False)` is an infinite loop. RQ workers survive across jobs, so an in-process pool is amortized.
3. **Real cost**: connect path is DNS + TCP + TLS + WS upgrade + 3-phase signed handshake before `agent` RPC. No existing instrumentation; new timing logs land in the same PR.

## Design

- One pooled `OpenclawSession` per `gateway_url` per worker process
- Per-entry `threading.Lock` for exclusive checkout (single-threaded RQ workers see ~0 contention; the lock is safety against threaded variants)
- Lazy healthcheck on checkout: discard if `_ws.connected` is False or `last_used > IDLE_MAX_S` (240s, below typical 5-min gateway idle disconnect)
- Eviction-and-propagate on `OpenclawUnreachableError` inside the block; no auto-retry (tokens may have already streamed to the UI)
- `atexit.register(drain_all)` on module import so the gateway sees clean disconnects on worker shutdown

Exclusive (not multiplexed) checkout because the bench-side `OpenclawSession` isn't safe for concurrent `stream_agent_turn` calls — the shared `_recv` would steal frames between turns. Multi-tenant concurrency arrives via multiple worker processes each holding their own pool entry.

## Files

| Action | File | Lines |
|---|---|---|
| Add | `jarvis/chat/openclaw_session_pool.py` | +222 |
| Add | `jarvis/tests/test_openclaw_session_pool.py` | +206 |
| Modify | `jarvis/chat/openclaw_client.py` | +24 (timing logs) |
| Modify | `jarvis/chat/worker.py` | +12 / -12 (use `with checkout(...)`) |
| Modify | `jarvis/tests/test_chat_worker.py` | +21 / -12 (re-aim patches at pool's `connect`, clear pool in setUp) |

## Test plan

- [x] `bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_openclaw_session_pool` → 11/11 green
- [x] `bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_chat_worker` → 15/15 green (existing worker tests re-aimed at the pool)
- [ ] Smoke against `jarvis-test.localhost` after merge: send 5 chat turns in the same conversation, verify the timing logs show `pool-miss connect` once and reuse for subsequent turns
- [ ] Watch the new `OpenclawSession.connect: pair_ms=X ws_open_ms=Y handshake_ms=Z total_ms=W` lines in production logs to validate the 50-200ms estimate

## Post-ship watch items

- If same-host RTT in the production deployment is <10ms, the pool win is smaller than expected — revisit
- If multi-turn concurrency per tenant becomes common, lift pool size from 1 to N per key (gateway already supports it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)