### PR TITLE
feat(chat): route chat turns to long queue + at_front

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -335,10 +335,18 @@ def send_message(
 				}
 		except Exception:
 			pass
+	# Route to the ``long`` queue rather than ``default``: chat turns can run
+	# up to ``_AGENT_TURN_WORKER_TIMEOUT`` (720s, far above the 300s default
+	# cap), and ``default`` is shared with provisioning + OAuth-refresh jobs
+	# which would otherwise block interactive chat behind 30s+ pieces of
+	# infrastructure work. ``at_front=True`` pushes interactive chat to the
+	# head of the long queue so a scheduled long-running job (backup, big
+	# import) doesn't make a user wait for it to finish.
 	frappe.enqueue(
 		method="jarvis.chat.worker.run_agent_turn",
-		queue="default",
+		queue="long",
 		timeout=_AGENT_TURN_WORKER_TIMEOUT,
+		at_front=True,
 		**enqueue_kwargs,
 	)
 
@@ -503,10 +511,13 @@ def retry_message(message: str) -> dict:
 	)
 
 	run_id = uuid.uuid4().hex[:12]
+	# Same routing as send_message: long queue + push to the front so the
+	# retry doesn't wait behind unrelated long-queue work.
 	frappe.enqueue(
 		method="jarvis.chat.worker.run_agent_turn",
-		queue="default",
+		queue="long",
 		timeout=_AGENT_TURN_WORKER_TIMEOUT,
+		at_front=True,
 		conversation_id=doc.conversation,
 		message_id=user_msg_id,
 		run_id=run_id,


### PR DESCRIPTION
## Summary

- Move both chat `frappe.enqueue` sites (`send_message` and `retry_message` in `jarvis/chat/api.py`) from `queue=\"default\"` to `queue=\"long\"`
- Add `at_front=True` so interactive chat jumps to the head of the long queue

## Why

The default queue is shared between chat, provisioning, and OAuth-refresh jobs. A burst of provisioning work could stall an interactive chat turn behind 30s+ infrastructure work, even though the customer is sitting there waiting for tokens. The default queue's stock RQ timeout (300s) is also lower than chat's 720s envelope — currently masked only by the explicit `timeout=` kwarg.

`long` queue is:
- Configured by default on Frappe Cloud (no support ticket needed to enable a custom queue)
- Has a 1500s default timeout — fits the 720s chat envelope cleanly with headroom
- Currently effectively unused by jarvis (no other long-running scheduled work)

`at_front=True` means: if a long-running job is already in the lane when a chat turn lands, the chat turn jumps to the front so it's the next thing picked up. Doesn't preempt the in-flight job, just reorders the wait.

## Trade-off

If jarvis later adds heavy long jobs (backups, scheduled exports, big imports), those will share the lane. `at_front=True` already mitigates this since chat keeps priority. If we ever see a chat turn waiting behind a real long job, the next step is opening a Frappe Cloud support ticket for a dedicated `chat` queue (see prior workflow exploration).

## Test plan

- [x] `bench run-tests --module jarvis.tests.test_chat_api` — passes
- [ ] Live smoke: send a chat turn; verify worker picks it up on the `long` queue
- [ ] Verify a queued provisioning job no longer delays chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)