### PR TITLE
fix(deploy): build the /jarvis SPA on Frappe Cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
 	"name": "jarvis",
 	"private": true,
-	"description": "Node-side dependencies required at runtime by jarvis customer app. Currently only @google/gemini-cli, used solely to source the gemini-cli OAuth client_secret needed by the confidential-client token exchange flow (jarvis/oauth/api.py). Install with `npm install` in this directory after bench-getting the app.",
+	"description": "Server-side node deps (gemini-cli for the OAuth confidential-client flow in jarvis/oauth/api.py) + Vue SPA build orchestration (the chat UI under frontend/, served at /jarvis). The scripts below are the contract Frappe Cloud's deploy pipeline picks up: `npm install` at this root triggers `postinstall` which installs the SPA's own deps, then `npm run build` delegates to the SPA's Vite build, dropping the bundle into jarvis/public/frontend/ + jarvis/www/jarvis.html. Without these scripts FC pulls the repo and never builds the SPA, so /jarvis 404s in production.",
+	"scripts": {
+		"postinstall": "npm run install-frontend",
+		"install-frontend": "cd frontend && npm install",
+		"dev-frontend": "cd frontend && npm run dev",
+		"build": "npm run build-frontend",
+		"build-frontend": "cd frontend && npm run build"
+	},
 	"dependencies": {
 		"@google/gemini-cli": "*"
 	}


### PR DESCRIPTION
## Summary

The /jarvis chat SPA built into `jarvis/public/frontend/` + `jarvis/www/jarvis.html` is gitignored — regenerated on each deploy from `frontend/` (Vite source). On Frappe Cloud, the deploy pipeline runs `npm install` + `npm run build` **at each app's root, not inside `frontend/`**, so the SPA was never built on FC and `/jarvis` returned 404 in production.

Wire the build the way `frappe/hrms` does it:

- `postinstall` → installs `frontend/`'s own deps after the root `npm install`
- `build` → delegates to `cd frontend && npm run build`

Verified locally:
```
rm -rf jarvis/public/frontend jarvis/www/jarvis.html
npm run build   # at app root
# → both artifacts regenerated; vite reports ✓ built in 4.68s
```

## Reference

`frappe/hrms` ships its PWA the same way — `apps/hrms/package.json` has root-level `build` / `build-pwa` / `postinstall` scripts that delegate to `frontend/`. FC's deploy pipeline picks them up.

## Test plan

- [x] Local: `npm run build` at root rebuilds the SPA cleanly
- [ ] FC deploy: push to main, watch the deploy log for the `npm run build` line, verify /jarvis loads the SPA in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)