### PR TITLE
feat(gating): send installed apps to admin for per-tenant skill/tool scoping

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -201,12 +201,15 @@ def post_update_llm_creds(
 	source-compatible. Subscription-mode callers pass ``"subscription"`` and
 	pass the OAuth access token as ``api_key``.
 	"""
+	# Ship the site's installed apps so admin persists them and the fleet-agent
+	# scopes the tenant's persona skill families (e.g. no hrms app -> no hrms-*).
 	return _post(
 		path="/api/method/jarvis_admin.api.tenant.update_llm_creds",
 		body={
 			"provider": provider, "model": model,
 			"base_url": base_url, "api_key": api_key,
 			"auth_mode": auth_mode,
+			"installed_apps": frappe.get_installed_apps(),
 		},
 	)
 

--- a/jarvis/openclaw_templates/openclaw.json.j2
+++ b/jarvis/openclaw_templates/openclaw.json.j2
@@ -47,7 +47,7 @@
   {# NOTE: the template fleet-agent actually renders lives in jarvis-fleet-agent
      (jarvis_fleet_agent/templates/openclaw.json.j2). This copy is a reference —
      keep it in sync. Progressive tool disclosure for the "pi" runtime: #}
-  "tools": { "toolSearch": { "mode": "directory" } },
+  "tools": { "toolSearch": { "mode": "directory" }, "deny": {{ tool_deny | tojson }} },
   "secrets": {
     "providers": {
       "llm_key": {


### PR DESCRIPTION
admin_client.post_update_llm_creds ships frappe.get_installed_apps() so admin persists it and the fleet-agent scopes the tenant's persona skill families (agents.defaults.skills) and the app-specific tool deny. Mirror the openclaw config reference template (authoritative copy lives in jarvis-fleet-agent).