### PR TITLE
feat(chat): /jarvis UI overhaul — return types, artifact panel, action cards, confirm/auto-apply, sidebar + settings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,27 @@
 			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;700&display=swap"
 			rel="stylesheet"
 		/>
+		<!-- Paint the saved theme BEFORE the app mounts so a refresh doesn't flash
+		     white (FOUC) on the way to dark, and fade the app in smoothly. -->
+		<style>
+			html, body { margin: 0; background: #ffffff; }
+			html.jv-preload-dark, html.jv-preload-dark body { background: #16161a; }
+			#app { animation: jv-appin 0.24s ease both; }
+			@keyframes jv-appin { from { opacity: 0; } to { opacity: 1; } }
+		</style>
+		<script>
+			(function () {
+				try {
+					var t = localStorage.getItem("jarvis-theme") || "system"
+					var dark =
+						t === "dark" ||
+						(t === "system" &&
+							window.matchMedia &&
+							window.matchMedia("(prefers-color-scheme: dark)").matches)
+					if (dark) document.documentElement.classList.add("jv-preload-dark")
+				} catch (e) {}
+			})()
+		</script>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -11,11 +11,20 @@ export const getConversation = (conversation) =>
 // when a message has several.
 export const getCanvas = (message, name) =>
 	call("jarvis.chat.api.get_canvas", { message, name: name || "" })
+// Tabular/text preview for the artifact side panel (xlsx/csv → sheets, txt → text).
+export const previewFile = (fileUrl) =>
+	call("jarvis.chat.api.preview_file", { file_url: fileUrl })
 export const createOrFocusEmpty = () => call("jarvis.chat.api.create_or_focus_empty")
 export const archiveConversation = (conversation) =>
 	call("jarvis.chat.api.archive_conversation", { conversation })
+export const renameConversation = (conversation, title) =>
+	call("jarvis.chat.api.rename_conversation", { conversation, title })
 export const retryMessage = (message) => call("jarvis.chat.api.retry_message", { message })
 export const getChatUiSettings = () => call("jarvis.chat.api.get_chat_ui_settings")
+// Toggle "auto-apply changes" (skip the agent's confirmation step before
+// mutating ERP data). Off = confirm every change (default).
+export const setAutoApply = (value) =>
+	call("jarvis.chat.api.set_auto_apply", { value: value ? 1 : 0 })
 // Estimated token usage (this chat / this month / total + monthly budget).
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -39,11 +39,16 @@
 						:key="c.name"
 						class="jv-conv"
 						:class="{ on: c.name === currentId }"
-						@click="selectConversation(c.name)"
-						style="display:flex;align-items:center;gap:9px;padding:7px 9px;border-radius:6px;cursor:pointer;margin-bottom:1px;"
-					>
-						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" :stroke="c.name === currentId ? 'var(--text-2)' : 'var(--text-3)'" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
-						<span :style="{ fontSize: '13px', color: c.name === currentId ? 'var(--text)' : 'var(--text-2)', fontWeight: c.name === currentId ? 500 : 400, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }">{{ c.title || "New chat" }}</span>
+						@click="renamingId === c.name ? null : selectConversation(c.name)"
+>
+						<svg class="jv-conv-ic" width="14" height="14" viewBox="0 0 24 24" fill="none" :stroke="c.name === currentId ? 'var(--text-2)' : 'var(--text-3)'" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+						<input v-if="renamingId === c.name" class="jv-rename-input" v-model="renameText" @click.stop @keydown.enter.stop="commitRename(c)" @keydown.esc.stop="cancelRename()" @blur="commitRename(c)" />
+						<span v-else class="jv-conv-title">{{ c.title || "New chat" }}</span>
+						<button v-if="renamingId !== c.name" class="jv-conv-more" @click.stop="toggleConvMenu(c.name)" title="Options"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="12" r="1" /><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /></svg></button>
+						<div v-if="convMenuFor === c.name" class="jv-conv-menu" @click.stop>
+							<button class="jv-menuitem" @click="startRename(c)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg><span>Rename</span></button>
+							<button class="jv-menuitem jv-menuitem-danger" @click="deleteConv(c)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m2 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /></svg><span>Delete</span></button>
+						</div>
 					</div>
 				</template>
 				<div v-if="!conversations.length" style="padding:18px 10px;text-align:center;font-size:12.5px;color:var(--text-3);">No chats yet</div>
@@ -51,6 +56,10 @@
 
 			<div class="jv-usermenu-wrap" style="position:relative;border-top:1px solid var(--border);">
 				<div v-if="userMenuOpen" style="position:absolute;bottom:calc(100% + 6px);left:12px;right:12px;background:var(--surface);border:1px solid var(--border-2);border-radius:10px;box-shadow:0 10px 28px rgba(20,20,30,.16);padding:5px;z-index:20;">
+					<button class="jv-menuitem" @click="openSettings(); userMenuOpen = false">
+						<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+						<span>Settings</span>
+					</button>
 					<button class="jv-menuitem" @click="goDesk">
 						<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /></svg>
 						<span>Switch to Desk</span>
@@ -60,13 +69,13 @@
 						<span style="color:var(--red);">Log out</span>
 					</button>
 				</div>
-				<div style="padding:10px 12px;display:flex;align-items:center;gap:9px;">
+				<div class="jv-usercard" @click="userMenuOpen = !userMenuOpen" style="padding:10px 12px;display:flex;align-items:center;gap:9px;cursor:pointer;">
 					<div style="width:28px;height:28px;border-radius:50%;background:#e7ddcf;color:#8a6d3b;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;flex:none;">{{ initials }}</div>
 					<div style="display:flex;flex-direction:column;line-height:1.2;min-width:0;">
 						<span style="font-size:12.5px;font-weight:550;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ fullName }}</span>
 						<span style="font-size:11px;color:var(--text-3);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ session.user }}</span>
 					</div>
-					<button class="jv-iconbtn" @click="userMenuOpen = !userMenuOpen" title="Account" style="margin-left:auto;flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:6px;cursor:pointer;">
+					<button class="jv-iconbtn" tabindex="-1" title="Account" style="margin-left:auto;flex:none;width:26px;height:26px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:6px;cursor:pointer;pointer-events:none;">
 						<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4zM12 20a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" /></svg>
 					</button>
 				</div>
@@ -90,23 +99,33 @@
 						</button>
 						<div v-if="modelMenuOpen && availableModels.length" style="position:absolute;top:calc(100% + 6px);right:0;min-width:184px;background:var(--surface);border:1px solid var(--border-2);border-radius:10px;box-shadow:0 8px 24px rgba(20,20,30,.14);padding:5px;z-index:30;">
 							<div style="padding:5px 9px 6px;font-size:10px;color:var(--text-3);font-weight:600;text-transform:uppercase;letter-spacing:.03em;">Model · {{ ui.llm_provider }}</div>
+							<button class="jv-menuitem" @click="selectModel('')">
+								<span style="flex:1;">Auto <span style="color:var(--text-3);font-weight:450;">· {{ ui.llm_model || "default" }}</span></span>
+								<svg v-if="!modelOverride" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+							</button>
 							<button v-for="m in availableModels" :key="m" class="jv-menuitem" @click="selectModel(m)">
 								<span style="flex:1;">{{ m }}</span>
-								<svg v-if="m === modelLabel" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+								<svg v-if="m === modelOverride" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
 							</button>
 						</div>
 					</div>
-					<button class="jv-iconbtn-bd" @click="openSettings" title="Settings" style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:var(--surface);border:1px solid var(--border);border-radius:7px;cursor:pointer;">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+					<button class="jv-iconbtn-bd" @click="toggleTheme" :title="effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'" style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:var(--surface);border:1px solid var(--border);border-radius:7px;cursor:pointer;">
+						<svg v-if="effectiveDark" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
+						<svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" /></svg>
 					</button>
 					<button class="jv-iconbtn-bd" @click="openErpDesk" title="Open ERPNext Desk (new tab)" style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:var(--surface);border:1px solid var(--border);border-radius:7px;cursor:pointer;">
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" /></svg>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><path d="M15 3h6v6M10 14 21 3" /></svg>
 					</button>
 				</div>
 			</header>
 
+			<!-- initial load: a quiet spinner so the welcome screen doesn't flash
+			     before the open conversation finishes loading on refresh -->
+			<div v-if="booting" style="flex:1;display:flex;align-items:center;justify-content:center;">
+				<svg class="jv-spin" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="2.4" stroke-linecap="round"><path d="M12 3a9 9 0 1 0 9 9" /></svg>
+			</div>
 			<!-- ===== WELCOME ===== -->
-			<div v-if="showWelcome" style="flex:1;overflow-y:auto;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:32px;">
+			<div v-else-if="showWelcome" style="flex:1;overflow-y:auto;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:32px;">
 				<div style="width:100%;max-width:680px;text-align:center;">
 					<div style="width:52px;height:52px;border-radius:13px;background:var(--blue);display:flex;align-items:center;justify-content:center;margin:0 auto 18px;box-shadow:0 4px 14px rgba(37,99,235,.28);">
 						<svg width="28" height="28" viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
@@ -148,29 +167,58 @@
 									</div>
 								</div>
 								<div v-else class="jv-md" style="font-size:14px;line-height:1.6;color:var(--text);" v-html="render(m.content)"></div>
-								<!-- rich outputs: agent artifacts rendered by type (sandboxed) -->
-								<div v-for="cv in (m.canvas || [])" :key="cv.name" class="jv-canvas">
-									<div class="jv-canvas-bar">
-										<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18" /><path d="M18 9l-5 5-3-3-4 4" /></svg>
-										<span>{{ cv.title }}</span>
-										<span class="jv-canvas-type">{{ cv.type }}</span>
-										<a v-if="cvOf(m, cv) && cv.type !== 'html' && cv.type !== 'svg'" :href="cvOf(m, cv)" :download="cvFile(cv)" class="jv-canvas-dl">Download</a>
+								<!-- rich action card the agent emits (doc confirm / email draft) -->
+								<template v-if="actionFor === m.name && activeAction">
+									<!-- email draft -->
+									<div v-if="activeAction.kind === 'email'" class="jv-email">
+										<div class="jv-email-head">
+											<div class="jv-email-line"><span class="jv-email-k">To</span><span class="jv-email-v">{{ activeAction.to }}</span></div>
+											<div class="jv-email-line"><span class="jv-email-k">Subject</span><span class="jv-email-v jv-email-subj">{{ activeAction.subject }}</span></div>
+										</div>
+										<div class="jv-email-body">{{ activeAction.body }}</div>
+										<div class="jv-action-foot">
+											<button class="jv-action-primary" @click="actionSend('Yes, send it.')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4 20-7z" /></svg>Send email</button>
+											<button class="jv-action-2nd" @click="copyText(activeAction.body)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>Copy</button>
+											<button class="jv-action-2nd" @click="actionSend('Regenerate that email, please.')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 2v6h6M21 12a9 9 0 1 1-3-6.7L21 8" /></svg>Regenerate</button>
+										</div>
 									</div>
-									<template v-if="cvOf(m, cv)">
-										<!-- html / svg → sandboxed iframe srcdoc -->
-										<iframe v-if="cv.type === 'html' || cv.type === 'svg'" :srcdoc="cvOf(m, cv)" sandbox="allow-scripts allow-popups" class="jv-canvas-frame" loading="lazy" title="Jarvis artifact"></iframe>
-										<!-- pdf → browser viewer -->
-										<iframe v-else-if="cv.type === 'pdf'" :src="cvOf(m, cv)" class="jv-canvas-frame jv-canvas-pdf" loading="lazy" title="PDF"></iframe>
-										<!-- image -->
-										<img v-else-if="cv.type === 'image'" :src="cvOf(m, cv)" class="jv-canvas-img" :alt="cv.title" />
-										<!-- other files (xlsx/csv/…) → download card -->
-										<a v-else :href="cvOf(m, cv)" :download="cvFile(cv)" class="jv-canvas-file">
-											<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M12 18v-6M9 15l3 3 3-3" /></svg>
-											<span>Download <b>{{ cvFile(cv) }}</b></span>
-										</a>
-									</template>
-									<div v-else class="jv-canvas-loading">Loading {{ cv.title }}…</div>
+									<!-- doc create / update / delete confirm -->
+									<div v-else class="jv-action">
+										<div class="jv-action-head">
+											<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /></svg>
+											<span class="jv-action-title">{{ actionVerb(activeAction) }} <b>{{ activeAction.doctype }}</b><template v-if="activeAction.title"> · {{ activeAction.title }}</template></span>
+										</div>
+										<div class="jv-action-fields">
+											<div v-for="(f, fi) in (activeAction.fields || [])" :key="fi" class="jv-action-row">
+												<span class="jv-action-k">{{ f.label }}</span>
+												<span class="jv-action-v">{{ f.value }}</span>
+											</div>
+										</div>
+										<div class="jv-action-foot">
+											<button class="jv-action-primary" @click="actionSend('Yes, go ahead.')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>{{ actionCta(activeAction) }}</button>
+											<button class="jv-action-2nd" @click="actionSend('I want to change something before you create it.')"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>Edit</button>
+											<button class="jv-action-discard" @click="actionSend('No, cancel that.')">Discard</button>
+										</div>
+									</div>
+								</template>
+								<!-- confirm / cancel (fallback, simple label) -->
+								<div v-else-if="confirmFor === m.name" class="jv-confirm">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><path d="M12 9v4M12 17h.01" /></svg>
+									<span class="jv-confirm-label">{{ confirmLabel(m) || "Apply this change?" }}</span>
+									<button class="jv-confirm-no" @click="answerConfirm(false)">Cancel</button>
+									<button class="jv-confirm-yes" @click="answerConfirm(true)">Confirm</button>
 								</div>
+								<!-- rich outputs: agent artifacts rendered by type (sandboxed) -->
+								<button v-for="cv in (m.canvas || [])" :key="cv.name" class="jv-artifact" @click="openArtifact(m, cv)" :title="'Open ' + cv.title">
+									<span class="jv-artifact-ic" :class="'t-' + cv.type">
+										<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /></svg>
+									</span>
+									<span class="jv-artifact-txt">
+										<span class="jv-artifact-title">{{ cv.title }}</span>
+										<span class="jv-artifact-sub">{{ (cv.type || "file").toUpperCase() }} · open preview</span>
+									</span>
+									<svg class="jv-artifact-go" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6" /></svg>
+								</button>
 								<div v-if="runMeta[m.name] && !m.error" class="jv-meta">
 									<span :title="(runMeta[m.name].names || []).join(', ')"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 1 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" /></svg>{{ runMeta[m.name].tools }} tool{{ runMeta[m.name].tools === 1 ? "" : "s" }}</span>
 									<span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" /></svg>{{ (runMeta[m.name].ms / 1000).toFixed(1) }}s</span>
@@ -248,18 +296,29 @@
 		<transition name="jv-fade">
 			<div v-if="settingsOpen" class="jv-settings-overlay" @click.self="settingsOpen = false">
 				<div class="jv-settings">
-					<div class="jv-settings-head">
-						<span style="font-size:15px;font-weight:600;">Settings</span>
-						<button class="jv-iconbtn" @click="settingsOpen = false" title="Close" style="width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:7px;cursor:pointer;color:var(--text-3);">
-							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+					<div class="jv-settings-nav">
+						<div class="jv-settings-nav-title">Settings</div>
+						<button class="jv-settings-navitem" :class="{ on: settingsTab === 'overview' }" @click="settingsTab = 'overview'">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+							<span>General</span>
+						</button>
+						<button class="jv-settings-navitem" :class="{ on: settingsTab === 'appearance' }" @click="settingsTab = 'appearance'">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
+							<span>Appearance</span>
+						</button>
+						<button class="jv-settings-navitem" :class="{ on: settingsTab === 'activity' }" @click="settingsTab = 'activity'">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>
+							<span>Activity</span>
 						</button>
 					</div>
-					<div class="jv-settings-tabs">
-						<button :class="{ on: settingsTab === 'overview' }" @click="settingsTab = 'overview'">Overview</button>
-						<button :class="{ on: settingsTab === 'activity' }" @click="settingsTab = 'activity'">Activity</button>
-						<button :class="{ on: settingsTab === 'appearance' }" @click="settingsTab = 'appearance'">Appearance</button>
-					</div>
-					<div class="jv-settings-body">
+					<div class="jv-settings-main">
+						<div class="jv-settings-head">
+							<span style="font-size:15px;font-weight:600;">{{ settingsTab === "appearance" ? "Appearance" : settingsTab === "activity" ? "Activity" : "General" }}</span>
+							<button class="jv-iconbtn" @click="settingsOpen = false" title="Close" style="width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:7px;cursor:pointer;color:var(--text-3);">
+								<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+							</button>
+						</div>
+						<div class="jv-settings-body">
 						<!-- OVERVIEW -->
 						<template v-if="settingsTab === 'overview'">
 							<div class="jv-set-sec">Connection</div>
@@ -267,6 +326,13 @@
 							<div class="jv-set-row"><span>Provider</span><b>{{ ui.llm_provider || "—" }}</b></div>
 							<div class="jv-set-row"><span>Auth mode</span><b>{{ ui.llm_auth_mode || "—" }}</b></div>
 							<div class="jv-set-row"><span>Status</span><b style="color:var(--green);">Live</b></div>
+								<div class="jv-set-sec" style="margin-top:18px;">Behavior</div>
+								<div class="jv-set-row">
+									<span>Confirm before changes<br /><span style="font-size:11px;color:var(--text-3);font-weight:400;">Ask before any create, update, or delete</span></span>
+									<button class="jv-switch" :class="{ on: !ui.auto_apply_changes }" @click="toggleAutoApply" role="switch" :aria-checked="String(!ui.auto_apply_changes)" :title="ui.auto_apply_changes ? 'Auto mode — changes apply without asking' : 'Confirm each change before it runs'">
+										<span class="jv-switch-knob"></span>
+									</button>
+								</div>
 							<div class="jv-set-sec" style="margin-top:18px;">Workspace</div>
 							<div class="jv-set-row"><span>Conversations</span><b>{{ convCount }}</b></div>
 							<div class="jv-set-row"><span>Messages in this chat</span><b>{{ msgCount }}</b></div>
@@ -314,17 +380,56 @@
 							</div>
 							<div class="jv-set-hint">{{ theme === "system" ? (effectiveDark ? "Following system · dark" : "Following system · light") : "Saved on this device" }}</div>
 
-							<div class="jv-set-sec" style="margin-top:22px;">Conversation</div>
-							<button class="jv-danger" @click="deleteChat" :disabled="!currentId">
-								<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6M10 11v6M14 11v6" /></svg>
-								Delete this chat
-							</button>
-
 							<div class="jv-set-sec" style="margin-top:22px;">About</div>
 							<div class="jv-set-row"><span>Jarvis</span><b>ERPNext Assistant</b></div>
 						</template>
 					</div>
 				</div>
+				</div>
+			</div>
+		</transition>
+
+		<!-- Artifact preview panel — slides in from the right (PDF in a viewer, Excel as a table) -->
+		<transition name="jv-slide">
+			<div v-if="artifact" class="jv-artifact-overlay" @click.self="closeArtifact">
+				<aside class="jv-artifact-panel">
+					<div class="jv-artifact-head">
+						<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /></svg>
+						<span class="jv-artifact-head-title">{{ artifact.cv.title }}</span>
+						<span class="jv-canvas-type">{{ artifact.cv.type }}</span>
+						<a class="jv-iconbtn" :href="artifact.url" target="_blank" rel="noopener" title="Open in new tab" style="width:30px;height:30px;display:flex;align-items:center;justify-content:center;color:var(--text-3);text-decoration:none;border-radius:7px;">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14 21 3" /></svg>
+						</a>
+						<a class="jv-iconbtn" :href="artifact.url" :download="cvFile(artifact.cv)" title="Download" style="width:30px;height:30px;display:flex;align-items:center;justify-content:center;color:var(--text-3);text-decoration:none;border-radius:7px;">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>
+						</a>
+						<button class="jv-iconbtn" @click="closeArtifact" title="Close" style="width:30px;height:30px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;cursor:pointer;color:var(--text-3);border-radius:7px;">
+							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+						</button>
+					</div>
+					<div class="jv-artifact-body">
+						<iframe v-if="artifact.kind === 'pdf'" :src="artifact.url" class="jv-artifact-frame" title="PDF preview"></iframe>
+						<img v-else-if="artifact.kind === 'image'" :src="artifact.url" class="jv-artifact-img" :alt="artifact.cv.title" />
+						<iframe v-else-if="artifact.kind === 'html' || artifact.kind === 'svg'" :srcdoc="artifact.content" sandbox="allow-scripts allow-popups" class="jv-artifact-frame" title="Artifact preview"></iframe>
+						<template v-else-if="artifact.kind === 'table'">
+							<div v-if="artifact.sheets.length > 1" class="jv-sheet-tabs">
+								<button v-for="(sh, si) in artifact.sheets" :key="si" :class="{ on: si === artifact.sheetIdx }" @click="setSheet(si)">{{ sh.name }}</button>
+							</div>
+							<div class="jv-sheet-scroll">
+								<table class="jv-sheet">
+									<thead v-if="curSheet.rows.length"><tr><th v-for="(c, ci) in curSheet.rows[0]" :key="ci">{{ c }}</th></tr></thead>
+									<tbody><tr v-for="(row, ri) in curSheet.rows.slice(1)" :key="ri"><td v-for="(c, ci) in row" :key="ci">{{ c }}</td></tr></tbody>
+								</table>
+							</div>
+						</template>
+						<pre v-else-if="artifact.kind === 'text'" class="jv-artifact-text">{{ artifact.text }}</pre>
+						<div v-else-if="artifact.kind === 'loading'" class="jv-artifact-loading">Loading preview…</div>
+						<div v-else class="jv-artifact-nopreview">
+							<p>No inline preview for this file type.</p>
+							<a :href="artifact.url" :download="cvFile(artifact.cv)" class="jv-canvas-dl">Download {{ cvFile(artifact.cv) }}</a>
+						</div>
+					</div>
+				</aside>
 			</div>
 		</transition>
 	</div>
@@ -353,6 +458,55 @@ const threadEl = ref(null)
 const rootEl = ref(null)
 const userMenuOpen = ref(false)
 const modelMenuOpen = ref(false)
+// per-conversation ⋯ menu + inline rename (sidebar)
+const convMenuFor = ref(null)
+const renamingId = ref(null)
+const renameText = ref("")
+function toggleConvMenu(id) {
+	convMenuFor.value = convMenuFor.value === id ? null : id
+}
+function startRename(c) {
+	convMenuFor.value = null
+	renamingId.value = c.name
+	renameText.value = c.title || ""
+	nextTick(() => {
+		const el = document.querySelector(".jv-rename-input")
+		if (el) {
+			el.focus()
+			el.select()
+		}
+	})
+}
+function cancelRename() {
+	renamingId.value = null
+}
+async function commitRename(c) {
+	if (renamingId.value !== c.name) return
+	const t = renameText.value.trim()
+	renamingId.value = null
+	if (!t || t === (c.title || "")) return
+	const conv = conversations.value.find((x) => x.name === c.name)
+	if (conv) conv.title = t // optimistic
+	try {
+		await api.renameConversation(c.name, t)
+	} catch (e) {
+		loadConversations()
+	}
+}
+async function deleteConv(c) {
+	convMenuFor.value = null
+	if (!window.confirm(`Delete "${c.title || "this chat"}"? This can't be undone.`)) return
+	try {
+		await api.archiveConversation(c.name)
+	} catch (e) {
+		/* ignore */
+	}
+	if (currentId.value === c.name) {
+		currentId.value = null
+		messages.value = []
+	}
+	loadConversations()
+}
 const modelOverride = ref("")
 
 // ---- settings panel + theme (openclaw-style console) ----
@@ -410,6 +564,10 @@ function setTheme(t) {
 		/* private mode / storage disabled — keep the in-memory choice */
 	}
 }
+// Quick header toggle: flip between light and dark (drops out of 'system').
+function toggleTheme() {
+	setTheme(effectiveDark.value ? "light" : "dark")
+}
 async function openSettings() {
 	userMenuOpen.value = false
 	modelMenuOpen.value = false
@@ -418,6 +576,17 @@ async function openSettings() {
 		usage.value = await api.getUsage(currentId.value)
 	} catch (e) {
 		/* usage stays null → the section shows a dash */
+	}
+}
+// Flip "confirm before changes" (server-side, per site). Optimistic; reverts on
+// failure. Stored as auto_apply_changes (1 = skip confirmation / auto mode).
+async function toggleAutoApply() {
+	const next = ui.value.auto_apply_changes ? 0 : 1
+	ui.value = { ...ui.value, auto_apply_changes: next }
+	try {
+		await api.setAutoApply(next)
+	} catch (e) {
+		ui.value = { ...ui.value, auto_apply_changes: next ? 0 : 1 } // revert
 	}
 }
 async function deleteChat() {
@@ -475,7 +644,8 @@ const greeting = computed(() => {
 	const h = new Date().getHours()
 	return h < 12 ? "Good morning" : h < 17 ? "Good afternoon" : "Good evening"
 })
-const modelLabel = computed(() => modelOverride.value || ui.value.llm_model || "gpt-5.5")
+// Empty override = "Auto": the backend falls back to Jarvis Settings.llm_model.
+const modelLabel = computed(() => modelOverride.value || "Auto")
 const availableModels = computed(() => ui.value.subscription_models?.[ui.value.llm_provider] || [])
 
 const currentTitle = computed(
@@ -484,7 +654,12 @@ const currentTitle = computed(
 const visibleMessages = computed(() =>
 	messages.value.filter((m) => m.role === "user" || m.role === "assistant"),
 )
-const showWelcome = computed(() => !currentId.value || visibleMessages.value.length === 0)
+// True only until the initial conversation load finishes — keeps the welcome
+// screen from flashing on refresh before the open chat appears.
+const booting = ref(true)
+const showWelcome = computed(
+	() => !booting.value && (!currentId.value || visibleMessages.value.length === 0),
+)
 
 // settings/overview derived metrics (all from data we already hold)
 const convCount = computed(() => conversations.value.length)
@@ -545,23 +720,152 @@ const suggestions = [
 	{ title: "Draft content", prompt: "Write a follow-up email to a lead", bg: "#f3eefe", icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>' },
 ]
 
+// Inline action blocks the agent emits: a rich ```jarvis-action JSON card (a doc
+// create/update confirm, or an email draft), or a simple ```confirm label as a
+// fallback. The chat renders them as cards with buttons and strips the raw block
+// from the visible prose.
+const _ACTION_RE = /```jarvis-action[ \t]*\n([\s\S]*?)```/
+const _CONFIRM_RE = /```confirm[ \t]*\n([\s\S]*?)```/
+function stripBlocks(text) {
+	return (text || "")
+		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```confirm[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim()
+}
+function actionOf(m) {
+	const mt = ((m && m.content) || "").match(_ACTION_RE)
+	if (!mt) return null
+	try {
+		const a = JSON.parse(mt[1].trim())
+		return a && typeof a === "object" ? a : null
+	} catch (e) {
+		return null
+	}
+}
+function confirmLabel(m) {
+	const mt = ((m && m.content) || "").match(_CONFIRM_RE)
+	return mt ? mt[1].trim() : ""
+}
 function render(text) {
-	return renderMarkdown(text || "")
+	return renderMarkdown(stripBlocks(text))
+}
+// The last assistant message (finished, turn idle) decides which card is live —
+// once the user clicks, a new message lands and the card retires automatically.
+const _lastAssistant = computed(() => {
+	if (busy.value) return null
+	// visibleMessages excludes tool rows; the assistant reply has a LOWER seq than
+	// the tool calls it spawned, so the raw messages array ends on a tool message.
+	const vm = visibleMessages.value
+	const last = vm[vm.length - 1]
+	return last && last.role === "assistant" && !last.streaming ? last : null
+})
+const activeAction = computed(() => (_lastAssistant.value ? actionOf(_lastAssistant.value) : null))
+const actionFor = computed(() => (activeAction.value ? _lastAssistant.value.name : null))
+const confirmFor = computed(() =>
+	_lastAssistant.value && !activeAction.value && confirmLabel(_lastAssistant.value)
+		? _lastAssistant.value.name
+		: null,
+)
+function actionSend(text) {
+	send(text)
+}
+function answerConfirm(ok) {
+	send(ok ? "Yes, go ahead." : "No, cancel that.")
+}
+function copyText(t) {
+	try {
+		navigator.clipboard?.writeText(t || "")
+	} catch (e) {
+		/* clipboard blocked */
+	}
+}
+const _VERB = { create: "Create", update: "Update", submit: "Submit", cancel: "Cancel", delete: "Delete", amend: "Amend" }
+function actionVerb(a) {
+	return _VERB[a && a.verb] || "Review"
+}
+function actionCta(a) {
+	const v = a && a.verb
+	if (v === "delete") return "Confirm & delete"
+	if (v === "submit") return "Confirm & submit"
+	if (v === "cancel") return "Confirm & cancel"
+	if (v === "update" || v === "amend") return "Confirm & save"
+	return "Confirm & create"
 }
 // Cached render payload for an artifact: HTML srcdoc (html/svg) or a base64
 // data-url (pdf/image/file). Keyed by `${msgName}::${canvasName}`.
 function cvOf(m, cv) {
 	return canvasContent.value[m.name + "::" + cv.name]
 }
+// What to feed the renderer. html/svg need the fetched srcdoc content (sandboxed
+// iframe). pdf / image / file render straight from the on-site file_url instead:
+// Chrome won't render a base64 data: PDF inline, and a real same-origin URL also
+// avoids holding big files as base64 in memory. Every canvas item carries
+// file_url (private File on this site, auth-gated by the session cookie).
+function cvSrc(m, cv) {
+	if (cv.type === "html" || cv.type === "svg") return cvOf(m, cv)
+	return cv.file_url || cvOf(m, cv)
+}
 // Basename (with extension) for a download filename / file card label.
 function cvFile(cv) {
 	return (cv.name || "file").split("/").pop()
+}
+// ---- artifact preview side panel (ChatGPT/Claude-style: click a card → slide-
+// in panel on the right; PDF/image render directly, xlsx/csv as a table) ----
+const artifact = ref(null) // { m, cv, url, kind, content?, sheets?, sheetIdx?, text? }
+const curSheet = computed(() => {
+	const a = artifact.value
+	if (!a || a.kind !== "table" || !a.sheets?.length) return { rows: [] }
+	return a.sheets[a.sheetIdx] || { rows: [] }
+})
+function closeArtifact() {
+	artifact.value = null
+}
+function setSheet(si) {
+	if (artifact.value) artifact.value = { ...artifact.value, sheetIdx: si }
+}
+async function openArtifact(m, cv) {
+	const url = cv.file_url || cvOf(m, cv)
+	const t = cv.type
+	if (t === "pdf" || t === "image") {
+		artifact.value = { m, cv, url, kind: t }
+		return
+	}
+	if (t === "html" || t === "svg") {
+		let content = cvOf(m, cv)
+		if (!content) {
+			artifact.value = { m, cv, url, kind: "loading" }
+			await ensureCanvas(m)
+			content = cvOf(m, cv)
+		}
+		artifact.value = { m, cv, url, kind: content ? t : "nopreview", content }
+		return
+	}
+	// "file" (xlsx / csv / txt / …) → ask the backend for a tabular/text preview.
+	artifact.value = { m, cv, url, kind: "loading" }
+	try {
+		const r = await api.previewFile(cv.file_url)
+		if (r && r.kind === "table" && Array.isArray(r.sheets) && r.sheets.length) {
+			artifact.value = { m, cv, url, kind: "table", sheets: r.sheets, sheetIdx: 0 }
+			return
+		}
+		if (r && r.kind === "text") {
+			artifact.value = { m, cv, url, kind: "text", text: r.text || "" }
+			return
+		}
+	} catch (e) {
+		/* fall through to download-only */
+	}
+	artifact.value = { m, cv, url, kind: "nopreview" }
 }
 // Lazily fetch each artifact's render payload (srcdoc content for html/svg, a
 // data-url for pdf/image/file) and cache it.
 async function ensureCanvas(m) {
 	if (!m || !Array.isArray(m.canvas) || !m.canvas.length) return
 	for (const cv of m.canvas) {
+		// pdf / image / file render from file_url directly — only html/svg need
+		// the fetched srcdoc content.
+		if (cv.file_url && cv.type !== "html" && cv.type !== "svg") continue
 		const key = m.name + "::" + cv.name
 		if (canvasContent.value[key]) continue
 		try {
@@ -638,30 +942,138 @@ async function loadConversation(id) {
 // Lazy-loads mermaid so it never bloats the initial bundle; only runs on
 // finalized messages (mid-stream mermaid source is incomplete and would error).
 let _mermaid = null
+// Vibrant, high-contrast categorical palette for pie/bar slices — distinct
+// hues that stay legible with white section labels in both light and dark.
+// (The app's own palette is near-monochrome, which is why the old "neutral"
+// mermaid theme rendered charts as washed-out grays.)
+const MERMAID_PALETTE = [
+	"#6366f1", "#06b6d4", "#f59e0b", "#ec4899", "#10b981", "#8b5cf6",
+	"#ef4444", "#14b8a6", "#f97316", "#3b82f6", "#65a30d", "#f43f5e",
+]
+// Guard against overlapping runs: mermaid's render mutates a shared temp DOM
+// node, so two concurrent passes can clobber each other and leave a chart as
+// raw source. _mmQueued re-runs once if a trigger fires mid-pass.
+let _mmRunning = false
+let _mmQueued = false
 async function processMermaid() {
+	if (_mmRunning) {
+		_mmQueued = true
+		return
+	}
+	_mmRunning = true
+	try {
+		await _renderMermaid()
+	} finally {
+		_mmRunning = false
+		if (_mmQueued) {
+			_mmQueued = false
+			setTimeout(processMermaid, 0)
+		}
+	}
+}
+async function _renderMermaid() {
 	const nodes = rootEl.value?.querySelectorAll?.(".jv-mermaid:not([data-rendered])")
 	if (!nodes || !nodes.length) return
 	try {
-		if (!_mermaid) {
-			_mermaid = (await import("mermaid")).default
-			_mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "neutral" })
-		}
+		if (!_mermaid) _mermaid = (await import("mermaid")).default
 	} catch (e) {
 		return
 	}
+	// Re-initialize each run so the palette tracks the active light/dark theme —
+	// mermaid snapshots its theme at init, so a one-time init would freeze it.
+	const dark = effectiveDark.value
+	const pie = Object.fromEntries(MERMAID_PALETTE.map((c, i) => [`pie${i + 1}`, c]))
+	_mermaid.initialize({
+		startOnLoad: false,
+		securityLevel: "strict",
+		theme: "base",
+		fontFamily: "inherit",
+		themeVariables: {
+			...pie,
+			pieStrokeColor: dark ? "#16161a" : "#ffffff",
+			pieStrokeWidth: "2px",
+			pieOuterStrokeColor: dark ? "#16161a" : "#ffffff",
+			pieOuterStrokeWidth: "2px",
+			pieSectionTextColor: "#ffffff",
+			pieSectionTextSize: "14px",
+			pieTitleTextColor: dark ? "#ededf2" : "#171717",
+			pieLegendTextColor: dark ? "#b6b6c0" : "#4a4a4f",
+			// flow / sequence / line charts, if the agent emits those
+			primaryColor: dark ? "#1d1d22" : "#f7f7f8",
+			primaryBorderColor: dark ? "#3a3a45" : "#d6e2fb",
+			primaryTextColor: dark ? "#ededf2" : "#171717",
+			lineColor: dark ? "#5b7cfa" : "#3b82f6",
+			textColor: dark ? "#b6b6c0" : "#4a4a4f",
+		},
+	})
 	let n = 0
 	for (const el of nodes) {
 		const src = (el.textContent || "").trim()
-		el.setAttribute("data-rendered", "1")
-		if (!src) continue
+		if (!src) {
+			el.setAttribute("data-rendered", "1")
+			continue
+		}
 		try {
 			const { svg } = await _mermaid.render(`jvmmd-${n++}-${Math.floor(performance.now())}`, src)
 			el.innerHTML = svg
+			el.setAttribute("data-rendered", "1") // mark only AFTER a successful render
+			_addChartDownload(el) // hover button to save the chart as PNG
 		} catch (e) {
-			el.setAttribute("data-rendered", "err") // leave source visible on parse error
+			// Retry transient failures on a later pass; give up (show source) after 3.
+			const t = (parseInt(el.getAttribute("data-try") || "0", 10) || 0) + 1
+			if (t >= 3) el.setAttribute("data-rendered", "err")
+			else el.setAttribute("data-try", String(t))
 		}
 	}
 	nextTick(scrollBottom)
+}
+// Drop a hover "download PNG" button onto a rendered chart. The chart is raw
+// (markdown-rendered) HTML, not a Vue node, so we wire the button imperatively.
+function _addChartDownload(el) {
+	if (el.querySelector(".jv-chart-dl")) return
+	const btn = document.createElement("button")
+	btn.className = "jv-chart-dl"
+	btn.type = "button"
+	btn.title = "Download chart as PNG"
+	btn.setAttribute("aria-label", "Download chart as PNG")
+	btn.innerHTML =
+		'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>'
+	btn.addEventListener("click", () => downloadSvgAsPng(el.querySelector("svg")))
+	el.appendChild(btn)
+}
+// Rasterize an inline SVG (the chart) to a 2x PNG and trigger a download. The
+// SVG is same-origin inline markup with no external refs, so the canvas isn't
+// tainted and toBlob works.
+function downloadSvgAsPng(svgEl) {
+	if (!svgEl) return
+	const vb = svgEl.viewBox && svgEl.viewBox.baseVal
+	const w = (vb && vb.width) || svgEl.clientWidth || 640
+	const h = (vb && vb.height) || svgEl.clientHeight || 420
+	const xml = new XMLSerializer().serializeToString(svgEl)
+	const img = new Image()
+	img.onload = () => {
+		const scale = 2
+		const canvas = document.createElement("canvas")
+		canvas.width = Math.ceil(w * scale)
+		canvas.height = Math.ceil(h * scale)
+		const ctx = canvas.getContext("2d")
+		ctx.fillStyle = effectiveDark.value ? "#16161a" : "#ffffff"
+		ctx.fillRect(0, 0, canvas.width, canvas.height)
+		ctx.setTransform(scale, 0, 0, scale, 0, 0)
+		ctx.drawImage(img, 0, 0, w, h)
+		canvas.toBlob((blob) => {
+			if (!blob) return
+			const url = URL.createObjectURL(blob)
+			const a = document.createElement("a")
+			a.href = url
+			a.download = "chart.png"
+			document.body.appendChild(a)
+			a.click()
+			a.remove()
+			setTimeout(() => URL.revokeObjectURL(url), 1000)
+		}, "image/png")
+	}
+	img.src = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(xml)))
 }
 async function selectConversation(id) {
 	if (id === currentId.value) return
@@ -707,6 +1119,7 @@ function onDocClick(e) {
 	if (!e.target.closest(".jv-usermenu-wrap")) userMenuOpen.value = false
 	if (!e.target.closest(".jv-modelmenu-wrap")) modelMenuOpen.value = false
 	if (!e.target.closest(".jv-composer")) mention.value = { ...mention.value, open: false }
+	if (!e.target.closest(".jv-conv-menu") && !e.target.closest(".jv-conv-more")) convMenuFor.value = null
 }
 async function retry(messageId) {
 	sending.value = true
@@ -816,6 +1229,11 @@ function onEvent(p) {
 			currentRunId.value = null
 			loadConversations()
 			loadConversation(currentId.value)
+			// Re-render charts after the reload settles — late re-renders can swap a
+			// freshly-rendered mermaid node back to raw source; these idle passes
+			// (mutex-guarded, no-op when nothing's pending) catch that race.
+			setTimeout(processMermaid, 300)
+			setTimeout(processMermaid, 900)
 			break
 		}
 		case "run:error":
@@ -945,13 +1363,21 @@ onMounted(async () => {
 	} catch (e) {
 		/* ignore */
 	}
-	await loadConversations()
-	const first = route.params.id || conversations.value[0]?.name
-	if (first) {
-		currentId.value = first
-		await loadConversation(first)
+	try {
+		await loadConversations()
+		const first = route.params.id || conversations.value[0]?.name
+		if (first) {
+			currentId.value = first
+			await loadConversation(first)
+		}
+	} finally {
+		booting.value = false // reveal welcome/thread only after the first load
 	}
+	// The thread (and its chart skeletons) only enter the DOM now that booting is
+	// false — loadConversation's earlier processMermaid pass ran against an empty
+	// thread, so render the charts here once they're actually mounted.
 	await nextTick()
+	processMermaid()
 	inputEl.value?.focus()
 })
 onBeforeUnmount(() => {
@@ -963,8 +1389,20 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .jv-newchat:hover { filter: brightness(0.9); }
+.jv-conv { position: relative; display: flex; align-items: center; gap: 9px; padding: 7px 9px; border-radius: 6px; cursor: pointer; margin-bottom: 1px; }
 .jv-conv:hover { background: var(--surface-2); }
 .jv-conv.on { background: var(--surface-3); }
+.jv-conv-ic { flex: none; }
+.jv-conv-title { flex: 1; min-width: 0; font-size: 13px; color: var(--text-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.jv-conv.on .jv-conv-title { color: var(--text); font-weight: 500; }
+.jv-conv-more { flex: none; width: 22px; height: 22px; display: flex; align-items: center; justify-content: center; border: none; background: transparent; border-radius: 5px; color: var(--text-3); cursor: pointer; opacity: 0; }
+.jv-conv:hover .jv-conv-more, .jv-conv-more:focus { opacity: 1; }
+.jv-conv-more:hover { background: var(--surface-3); color: var(--text); }
+.jv-conv-menu { position: absolute; top: calc(100% - 2px); right: 6px; z-index: 25; min-width: 150px; background: var(--surface); border: 1px solid var(--border-2); border-radius: 9px; box-shadow: 0 10px 28px rgba(20, 20, 30, 0.18); padding: 5px; }
+.jv-menuitem-danger { color: var(--red); }
+.jv-menuitem-danger svg { color: var(--red); }
+.jv-menuitem-danger:hover { background: var(--red-bg); }
+.jv-rename-input { flex: 1; min-width: 0; font-family: inherit; font-size: 13px; color: var(--text); background: var(--surface); border: 1px solid var(--blue); border-radius: 5px; padding: 3px 6px; outline: none; }
 .jv-suggest:hover { border-color: var(--border-2); background: var(--surface-1); }
 .jv-iconbtn:hover { background: var(--surface-2); color: var(--text-2); }
 .jv-iconbtn-bd:hover { background: var(--surface-1); }
@@ -973,6 +1411,8 @@ onBeforeUnmount(() => {
 .jv-modelpill:hover { background: var(--surface-2); }
 .jv-menuitem { display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 9px; border: none; background: transparent; border-radius: 7px; font-family: inherit; font-size: 12.5px; color: var(--text); cursor: pointer; text-align: left; }
 .jv-menuitem:hover, .jv-menuitem.on { background: var(--surface-1); }
+.jv-usercard { transition: background 0.12s; }
+.jv-usercard:hover { background: var(--surface-2); }
 /* black focus highlight on the composer */
 .jv-composer:focus-within { border-color: var(--text); box-shadow: 0 0 0 3px rgba(23, 23, 23, 0.07); }
 /* response metrics (tools · time) */
@@ -1001,8 +1441,21 @@ onBeforeUnmount(() => {
 .jv-canvas-file:hover { background: var(--surface-1); }
 .jv-canvas-file b { font-weight: 600; color: var(--text); }
 /* mermaid diagrams + fenced code blocks in markdown */
-.jv-md :deep(.jv-mermaid) { margin: 8px 0 12px; text-align: center; overflow-x: auto; }
+.jv-md :deep(.jv-mermaid) { position: relative; margin: 8px 0 12px; text-align: center; overflow-x: auto; }
 .jv-md :deep(.jv-mermaid svg) { max-width: 100%; height: auto; }
+/* skeleton shimmer while a chart hasn't rendered to SVG yet (no data-rendered) —
+   hides the raw mermaid source so the user never sees the markup flash. */
+.jv-md :deep(.jv-mermaid:not([data-rendered])) { min-height: 196px; color: transparent !important; user-select: none; overflow: hidden; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-1); }
+.jv-md :deep(.jv-mermaid:not([data-rendered])) * { color: transparent !important; }
+.jv-md :deep(.jv-mermaid:not([data-rendered]))::after { content: ""; position: absolute; inset: 0; background: linear-gradient(100deg, transparent 20%, var(--surface-2) 50%, transparent 80%); background-size: 220% 100%; animation: jv-shimmer 1.25s ease-in-out infinite; }
+@keyframes jv-shimmer { 0% { background-position: 180% 0; } 100% { background-position: -180% 0; } }
+.jv-md :deep(.jv-chart-dl) { position: absolute; top: 6px; right: 6px; width: 26px; height: 26px; display: inline-flex; align-items: center; justify-content: center; padding: 0; background: var(--surface); color: var(--text-3); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; opacity: 0; transition: opacity .12s, color .12s, background .12s; }
+.jv-md :deep(.jv-mermaid:hover .jv-chart-dl) { opacity: 1; }
+.jv-md :deep(.jv-chart-dl:hover) { color: var(--text); background: var(--surface-1); border-color: var(--border-2); }
+.jv-switch { width: 38px; height: 22px; flex: none; border: none; border-radius: 11px; background: var(--surface-3); position: relative; cursor: pointer; padding: 0; transition: background .15s; }
+.jv-switch.on { background: var(--green); }
+.jv-switch-knob { position: absolute; top: 2px; left: 2px; width: 18px; height: 18px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0, 0, 0, .25); transition: left .15s; }
+.jv-switch.on .jv-switch-knob { left: 18px; }
 .jv-md :deep(.jv-md-pre) { margin: 6px 0 12px; padding: 12px 14px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 8px; overflow-x: auto; }
 .jv-md :deep(.jv-md-pre code) { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--text); white-space: pre; }
 
@@ -1020,16 +1473,21 @@ onBeforeUnmount(() => {
 .jv-md :deep(.jv-md-table tr:last-child td) { border-bottom: 0; }
 
 /* ===== settings panel (slide-over console) ===== */
-.jv-settings-overlay { position: absolute; inset: 0; z-index: 60; background: rgba(15, 15, 22, 0.32); display: flex; justify-content: flex-end; }
-.jv-dark .jv-settings-overlay { background: rgba(0, 0, 0, 0.5); }
-.jv-settings { width: 372px; max-width: 92vw; height: 100%; background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; box-shadow: -12px 0 40px rgba(20, 20, 30, 0.16); animation: jv-slidein 0.18s ease; }
-@keyframes jv-slidein { from { transform: translateX(24px); opacity: 0.4; } to { transform: translateX(0); opacity: 1; } }
-.jv-settings-head { display: flex; align-items: center; justify-content: space-between; padding: 15px 18px; border-bottom: 1px solid var(--border); }
-.jv-settings-tabs { display: flex; gap: 2px; padding: 8px 12px 0; border-bottom: 1px solid var(--border); }
-.jv-settings-tabs button { flex: 1; padding: 8px 6px 10px; background: transparent; border: none; border-bottom: 2px solid transparent; font-family: inherit; font-size: 12.5px; font-weight: 550; color: var(--text-3); cursor: pointer; }
-.jv-settings-tabs button:hover { color: var(--text-2); }
-.jv-settings-tabs button.on { color: var(--text); border-bottom-color: var(--blue); }
-.jv-settings-body { flex: 1; overflow-y: auto; padding: 16px 18px 28px; }
+/* settings: centered modal (Claude-style) with a left section nav */
+.jv-settings-overlay { position: absolute; inset: 0; z-index: 60; background: rgba(15, 15, 22, 0.34); display: flex; align-items: center; justify-content: center; padding: 24px; }
+.jv-dark .jv-settings-overlay { background: rgba(0, 0, 0, 0.55); }
+.jv-settings { width: 760px; max-width: 100%; height: 560px; max-height: 88vh; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; display: flex; overflow: hidden; box-shadow: 0 24px 70px rgba(20, 20, 30, 0.28); animation: jv-popin 0.16s ease; }
+@keyframes jv-popin { from { transform: scale(0.97); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+.jv-settings-nav { width: 196px; flex: none; background: var(--surface-1); border-right: 1px solid var(--border); padding: 14px 10px; display: flex; flex-direction: column; gap: 2px; }
+.jv-settings-nav-title { font-size: 15px; font-weight: 700; color: var(--text); padding: 4px 10px 12px; }
+.jv-settings-navitem { display: flex; align-items: center; gap: 9px; width: 100%; padding: 8px 10px; border: none; background: transparent; border-radius: 8px; font-family: inherit; font-size: 13px; font-weight: 500; color: var(--text-2); cursor: pointer; text-align: left; }
+.jv-settings-navitem svg { color: var(--text-3); flex: none; }
+.jv-settings-navitem:hover { background: var(--surface-2); color: var(--text); }
+.jv-settings-navitem.on { background: var(--surface-3); color: var(--text); }
+.jv-settings-navitem.on svg { color: var(--text); }
+.jv-settings-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.jv-settings-head { display: flex; align-items: center; justify-content: space-between; padding: 15px 18px; border-bottom: 1px solid var(--border); flex: none; }
+.jv-settings-body { flex: 1; overflow-y: auto; padding: 18px 22px 28px; }
 .jv-set-sec { font-size: 11px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 8px; }
 .jv-set-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 0; border-bottom: 1px solid var(--border); font-size: 13px; color: var(--text-2); }
 .jv-set-row:last-child { border-bottom: 0; }
@@ -1059,4 +1517,79 @@ onBeforeUnmount(() => {
 /* fade for the overlay */
 .jv-fade-enter-active, .jv-fade-leave-active { transition: opacity .16s ease; }
 .jv-fade-enter-from, .jv-fade-leave-to { opacity: 0; }
+
+/* artifact card (in the message) */
+.jv-artifact { display: flex; align-items: center; gap: 11px; width: 100%; margin-top: 12px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); cursor: pointer; text-align: left; font-family: inherit; transition: border-color .12s, background .12s; }
+.jv-artifact:hover { border-color: var(--border-2); background: var(--surface-1); }
+.jv-artifact-ic { flex: none; width: 34px; height: 34px; border-radius: 8px; display: flex; align-items: center; justify-content: center; background: var(--blue-bg); color: var(--blue); }
+.jv-artifact-ic.t-pdf { background: var(--red-bg); color: var(--red); }
+.jv-artifact-ic.t-image { background: var(--green-bg); color: var(--green); }
+.jv-artifact-ic.t-html, .jv-artifact-ic.t-svg { background: var(--amber-bg); color: var(--amber); }
+.jv-artifact-txt { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.jv-artifact-title { font-size: 13px; font-weight: 550; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.jv-artifact-sub { font-size: 10px; color: var(--text-3); text-transform: uppercase; letter-spacing: .04em; }
+.jv-artifact-go { color: var(--text-3); flex: none; }
+
+/* confirm / cancel card for a pending ERP-mutating action */
+.jv-confirm { display: flex; align-items: center; gap: 10px; margin-top: 12px; padding: 10px 12px; border: 1px solid var(--amber-bd); background: var(--amber-bg); border-radius: 10px; }
+.jv-confirm > svg { flex: none; }
+.jv-confirm-label { flex: 1; min-width: 0; font-size: 13px; font-weight: 550; color: var(--text); }
+.jv-confirm-no, .jv-confirm-yes { font-family: inherit; font-size: 12.5px; font-weight: 600; padding: 6px 14px; border-radius: 7px; cursor: pointer; border: 1px solid var(--border-2); flex: none; }
+.jv-confirm-no { background: var(--surface); color: var(--text-2); }
+.jv-confirm-no:hover { background: var(--surface-1); }
+.jv-confirm-yes { background: var(--blue); color: #fff; border-color: var(--blue); }
+.jv-confirm-yes:hover { filter: brightness(0.95); }
+
+/* rich action cards (doc confirm / email draft) */
+.jv-action, .jv-email { margin-top: 12px; border: 1px solid var(--border); border-radius: 11px; overflow: hidden; background: var(--surface); }
+.jv-action-head { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-bottom: 1px solid var(--border); }
+.jv-action-head svg { flex: none; }
+.jv-action-title { font-size: 13px; font-weight: 600; color: var(--text); }
+.jv-action-title b { font-weight: 700; }
+.jv-action-fields { padding: 4px 0; }
+.jv-action-row { display: flex; gap: 12px; padding: 6px 14px; font-size: 13px; }
+.jv-action-row:not(:last-child) { border-bottom: 1px solid var(--surface-2); }
+.jv-action-k { flex: none; width: 140px; color: var(--text-3); font-family: ui-monospace, Menlo, monospace; font-size: 12px; }
+.jv-action-v { flex: 1; min-width: 0; color: var(--text); word-break: break-word; }
+.jv-action-foot { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--border); background: var(--surface-1); }
+.jv-action-primary { display: inline-flex; align-items: center; gap: 7px; font-family: inherit; font-size: 13px; font-weight: 600; padding: 8px 14px; border-radius: 8px; cursor: pointer; background: var(--blue); color: #fff; border: 1px solid var(--blue); }
+.jv-action-primary:hover { filter: brightness(0.95); }
+.jv-action-2nd { display: inline-flex; align-items: center; gap: 7px; font-family: inherit; font-size: 13px; font-weight: 550; padding: 8px 13px; border-radius: 8px; cursor: pointer; background: var(--surface); color: var(--text-2); border: 1px solid var(--border-2); }
+.jv-action-2nd:hover { background: var(--surface-2); color: var(--text); }
+.jv-action-discard { margin-left: auto; font-family: inherit; font-size: 12.5px; font-weight: 550; padding: 8px 10px; border: none; background: transparent; color: var(--text-3); cursor: pointer; }
+.jv-action-discard:hover { color: var(--red); }
+.jv-email-head { padding: 12px 14px 6px; }
+.jv-email-line { display: flex; gap: 10px; font-size: 13px; padding: 2px 0; }
+.jv-email-k { flex: none; width: 54px; color: var(--text-3); }
+.jv-email-v { color: var(--text-2); word-break: break-word; }
+.jv-email-subj { color: var(--text); font-weight: 600; }
+.jv-email-body { padding: 12px 14px 14px; font-size: 13px; line-height: 1.6; color: var(--text); white-space: pre-wrap; word-break: break-word; border-top: 1px solid var(--surface-2); }
+
+/* artifact preview panel (right side-over) */
+.jv-artifact-overlay { position: absolute; inset: 0; z-index: 60; background: rgba(15, 15, 22, 0.32); display: flex; justify-content: flex-end; }
+.jv-dark .jv-artifact-overlay { background: rgba(0, 0, 0, 0.5); }
+.jv-artifact-panel { width: min(720px, 82%); height: 100%; background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; box-shadow: -14px 0 44px rgba(20, 20, 30, 0.14); }
+.jv-artifact-head { display: flex; align-items: center; gap: 9px; padding: 11px 12px 11px 14px; border-bottom: 1px solid var(--border); flex: none; }
+.jv-artifact-head svg { color: var(--text-3); flex: none; }
+.jv-artifact-head-title { font-size: 14px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
+.jv-artifact-head .jv-iconbtn:hover { background: var(--surface-1); color: var(--text-2); }
+.jv-artifact-body { flex: 1; min-height: 0; overflow: auto; background: var(--surface-1); display: flex; flex-direction: column; }
+.jv-artifact-frame { flex: 1; width: 100%; border: 0; background: #fff; }
+.jv-artifact-img { max-width: 100%; height: auto; margin: auto; padding: 16px; }
+.jv-artifact-text { margin: 0; padding: 16px; font-size: 12.5px; line-height: 1.55; white-space: pre-wrap; word-break: break-word; color: var(--text); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+.jv-artifact-loading, .jv-artifact-nopreview { margin: auto; padding: 30px; text-align: center; color: var(--text-3); font-size: 13px; display: flex; flex-direction: column; gap: 12px; align-items: center; }
+.jv-sheet-tabs { display: flex; gap: 4px; padding: 8px 10px; border-bottom: 1px solid var(--border); background: var(--surface); flex: none; overflow-x: auto; }
+.jv-sheet-tabs button { font-family: inherit; font-size: 12px; padding: 4px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface-1); color: var(--text-2); cursor: pointer; white-space: nowrap; }
+.jv-sheet-tabs button.on { background: var(--blue); color: #fff; border-color: var(--blue); }
+.jv-sheet-scroll { flex: 1; min-height: 0; overflow: auto; }
+.jv-sheet { border-collapse: collapse; font-size: 12.5px; width: max-content; min-width: 100%; }
+.jv-sheet th, .jv-sheet td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; white-space: nowrap; }
+.jv-sheet th { background: var(--surface-2); font-weight: 600; color: var(--text); position: sticky; top: 0; z-index: 1; }
+.jv-sheet td { color: var(--text-2); }
+.jv-sheet tbody tr:nth-child(even) td { background: var(--surface); }
+
+.jv-slide-enter-active, .jv-slide-leave-active { transition: opacity .18s ease; }
+.jv-slide-enter-active .jv-artifact-panel, .jv-slide-leave-active .jv-artifact-panel { transition: transform .24s cubic-bezier(.4, 0, .2, 1); }
+.jv-slide-enter-from, .jv-slide-leave-to { opacity: 0; }
+.jv-slide-enter-from .jv-artifact-panel, .jv-slide-leave-to .jv-artifact-panel { transform: translateX(100%); }
 </style>

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -239,6 +239,19 @@ def archive_conversation(conversation: str) -> dict:
 	return {"ok": True}
 
 
+@frappe.whitelist()
+def rename_conversation(conversation: str, title: str) -> dict:
+	"""Rename a conversation. ``get_doc`` enforces the owner-only permission."""
+	title = (title or "").strip()[:140]
+	if not title:
+		return {"ok": False, "reason": _("title is empty")}
+	doc = frappe.get_doc(CONV, conversation)
+	doc.title = title
+	doc.save()
+	frappe.db.commit()
+	return {"ok": True, "data": {"title": title}}
+
+
 import uuid
 
 from frappe import _

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -377,7 +377,23 @@ def get_chat_ui_settings() -> dict:
 		"llm_model": settings.llm_model or "",
 		"subscription_models": _SUBSCRIPTION_MODELS,
 		"default_models": _DEFAULT_MODEL,
+		# When 1, the agent applies mutating changes without confirming (auto mode).
+		"auto_apply_changes": int(settings.auto_apply_changes or 0),
 	}
+
+
+@frappe.whitelist()
+def set_auto_apply(value) -> dict:
+	"""Toggle the per-site 'auto-apply changes (skip confirmation)' setting.
+
+	OFF (default) = the agent confirms every ERP-mutating action before running
+	it; ON = it applies changes immediately. Read by the chat worker and folded
+	into the turn's [Context: ...] line so the agent knows which mode it's in.
+	"""
+	on = 1 if str(value) in ("1", "true", "True", "on", "yes") else 0
+	frappe.db.set_single_value("Jarvis Settings", "auto_apply_changes", on)
+	frappe.db.commit()
+	return {"ok": True, "data": {"auto_apply_changes": on}}
 
 
 def _est_tokens(text: str | None) -> int:

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -191,6 +191,32 @@ def _artifact_mime(item: dict) -> str:
 
 
 @frappe.whitelist()
+def preview_file(file_url: str) -> dict:
+	"""Render-ready preview for the artifact side panel.
+
+	Tabular files (xlsx / csv) → ``{kind:"table", sheets:[{name, rows}]}``; plain
+	text/json/md → ``{kind:"text", text}``. PDFs, images and html/svg are
+	rendered by the panel directly from the file URL, so this is only called for
+	the non-inline ("file") types. Permission-gated through ``read_file`` (needs
+	File read perm on the private File — the user's own chat artifact)."""
+	if not file_url:
+		return {"kind": "binary"}
+	from jarvis.tools.read_file import read_file
+
+	data = read_file(file_url=file_url, max_rows=300, max_chars=8000)
+	kind = data.get("kind")
+	if kind == "table":
+		sheets = [
+			{"name": s.get("name") or "Sheet", "rows": (s.get("rows") or [])}
+			for s in (data.get("sheets") or [])
+		]
+		return {"kind": "table", "sheets": sheets, "filename": data.get("filename")}
+	if kind == "text":
+		return {"kind": "text", "text": data.get("text") or ""}
+	return {"kind": kind or "binary"}
+
+
+@frappe.whitelist()
 def create_conversation() -> str:
 	"""Create an empty conversation owned by the current user; return its name."""
 	doc = frappe.get_doc({

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -216,8 +216,12 @@ def run_agent_turn(
 	# unchanged; only the value sent over to openclaw is augmented.
 	now = frappe.utils.now_datetime()
 	today = now.strftime("%Y-%m-%d (%A)")
+	# Fold the auto-apply preference into the system context line so the agent
+	# knows whether to confirm mutating ops. Default (off) = confirm; the persona
+	# confirms by default, so we only signal the non-default "auto" mode.
+	auto_apply = "; auto-apply changes: ON" if settings.auto_apply_changes else ""
 	user_message = (
-		f"[Context: today is {today}; chat user: {chat_user}]"
+		f"[Context: today is {today}; chat user: {chat_user}{auto_apply}]"
 		f"\n\n{user_message or ''}"
 	)
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -50,6 +50,7 @@
     "last_sync_status",
     "agent_tools_section",
     "run_query_doctype_allowlist",
+    "auto_apply_changes",
     "developer_section",
     "sandbox_mode"
   ],
@@ -338,6 +339,13 @@
       "fieldtype": "Small Text",
       "label": "run_query DocType Allowlist",
       "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
+    },
+    {
+      "fieldname": "auto_apply_changes",
+      "fieldtype": "Check",
+      "label": "Auto-apply changes (skip confirmation)",
+      "default": "0",
+      "description": "When OFF (default), the agent shows a plain-English summary and waits for your explicit confirmation before any create/update/submit/cancel/delete/amend that changes ERP data. When ON, it applies changes immediately without asking (auto mode)."
     },
     {
       "fieldname": "developer_section",


### PR DESCRIPTION
## What

A broad overhaul of the `/jarvis` chat UI and the backend endpoints behind it. Builds on the canvas / return-type work in #149.

### Return types — render every type cleanly
- **Charts** — colorful, theme-aware mermaid (vibrant pie/flow palette that tracks light/dark), hover **download as PNG**, concurrency-safe render with retry, and a **shimmer skeleton** so raw markup never flashes.
- **Files** — produced via `export_excel` / `download_pdf` land as a **private File on the user's own site** and show as a download card; no container paths or raw URLs leak into prose.
- **Tables** — real pipe markdown.

### Artifact preview panel (ChatGPT / Claude style)
- A PDF/Excel card opens a **right side-panel**: PDF in a viewer (real file URL → renders inline in Chrome), images inline, **xlsx/csv rendered as a table** via the new `preview_file` endpoint.

### Action cards — the agent decides when
- A fenced ` ```jarvis-action ` JSON block renders as a **doc card** (Confirm & create / Edit / Discard) or an **email card** (Send / Copy / Regenerate); the block is stripped from the visible prose. Simple ` ```confirm ` bar as a fallback.
- **Confirm before changes** — a per-site `auto_apply_changes` setting (default off = confirm every create/update/submit/cancel/delete/amend). The worker folds it into the turn `[Context: …]`; on = auto mode, applies directly.

### Sidebar & settings
- Per-chat **⋯ menu** with inline **Rename** (`rename_conversation`) + **Delete**; the whole user card is clickable.
- Settings moved into the user card and reworked into a **centered modal** with a left section nav (General / Appearance / Activity).

### Header & load
- Quick **theme toggle** (sun/moon), an external-link **Desk** icon, and an **Auto** model option.
- **No flash on refresh** — theme painted in `<head>` before mount, app fade-in, and a `booting` flag so the welcome screen doesn't flash before the open chat loads.

## Commits (feature-wise)
1. per-site auto-apply (skip-confirmation) setting
2. inline file-preview endpoint for the artifact panel
3. rename conversations
4. /jarvis UI overhaul — charts, artifact panel, action cards, sidebar + settings
5. smoother page load — theme preload + fade-in

## Companion change
Agent behaviour (emit `jarvis-action` / mermaid, never paste paths, confirm CRUD) lives in **jarvis-persona** — sibling PR linked in the comments.

## Testing
Verified on the local stack: a single reply with table + colorful mermaid + Excel download card + PDF preview; the confirm card stops before `create_doc` and auto-mode runs it; `preview_file` returns sheet rows.