### PR TITLE
test(admin-client): assert installed_apps in the update_llm_creds payload

### DIFF
--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -129,6 +129,10 @@ class TestHeaders(FrappeTestCase):
 		self.assertEqual(captured["json"], {
 			"provider": "p", "model": "m", "base_url": "b", "api_key": "k",
 			"auth_mode": "api_key",
+			# Gating: the client sends the tenant's installed apps so the admin
+			# can scope per-tenant skills/tools. Assert against the same source
+			# the client reads, so this stays correct as apps change.
+			"installed_apps": frappe.get_installed_apps(),
 		})
 		self.assertTrue(captured["url"].startswith("https://admin.example.com/api/method/"))
 		self.assertIn("jarvis_admin.api.tenant.update_llm_creds", captured["url"])


### PR DESCRIPTION
The gating change (2c8a019) added installed_apps to the admin payload but left test_sends_native_token_header's expected dict unchanged, so it failed on main. Assert against frappe.get_installed_apps() - the same source the client reads - so it stays correct as the tenant's apps change.