### PR TITLE
fix(tools): address high-effort code-review findings

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -392,6 +392,16 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 		return _error(type(e).__name__, str(e))
 	except frappe.PermissionError as e:
 		return _error("PermissionDeniedError", str(e) or "permission denied")
+	except (frappe.ValidationError, frappe.DuplicateEntryError) as e:
+		# Bad-input errors a tool surfaces from doc.insert()/get_doc/link
+		# validation - DuplicateEntryError (a NameError subclass, NOT a
+		# ValidationError), MandatoryError, LinkValidationError,
+		# DoesNotExistError, UniqueValidationError, plus app-level
+		# ValidationError business rules. These are the user's fault, not a
+		# bug, so translate to the envelope instead of leaking Frappe's
+		# native 500/404. The message carries the specifics; the code stays
+		# in the known JarvisError set the bench client branches on.
+		return _error("InvalidArgumentError", str(e) or type(e).__name__)
 	return {"ok": True, "data": data}
 
 

--- a/jarvis/tests/test_dashboard_tools.py
+++ b/jarvis/tests/test_dashboard_tools.py
@@ -45,6 +45,20 @@ class TestCreateDashboardChart(FrappeTestCase):
 				chart_name="x", document_type="ToDo", chart_type="Sum", based_on="creation",
 			)
 
+	def test_duplicate_chart_name_returns_clean_error(self):
+		# Dashboard Chart autonames on chart_name -> a repeat raises Frappe's
+		# DuplicateEntryError (a NameError). _run_tool must translate it to the
+		# {ok: False, error} envelope, not let it escape as an HTTP 500.
+		from jarvis.api import _run_tool
+
+		name = _h("JT Dup")
+		args = {"chart_name": name, "document_type": "ToDo", "chart_type": "Count",
+				"based_on": "creation"}
+		create_dashboard_chart(**args)
+		res = _run_tool("create_dashboard_chart", dict(args))
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "InvalidArgumentError")
+
 
 class TestCreateDashboard(FrappeTestCase):
 	def test_dashboard_links_a_chart(self):

--- a/jarvis/tests/test_summarize_dataset.py
+++ b/jarvis/tests/test_summarize_dataset.py
@@ -1,5 +1,6 @@
 """Unit tests for jarvis.tools.summarize_dataset (pure-Python, no DB)."""
 
+import math
 import unittest
 
 from jarvis.exceptions import InvalidArgumentError
@@ -51,6 +52,29 @@ class TestSummarizeDataset(unittest.TestCase):
 		out = summarize_dataset(rows, top_n=3)
 		self.assertEqual(out["columns"]["k"]["type"], "categorical")
 		self.assertEqual(len(out["columns"]["k"]["top"]), 3)
+
+	def test_nan_inf_strings_do_not_poison_numeric(self):
+		# 'nan'/'inf' must NOT coerce to float and turn the column numeric with
+		# NaN/inf stats; they are non-numeric tokens here -> column is mixed.
+		out = summarize_dataset([{"x": 1}, {"x": 2}, {"x": "nan"}, {"x": "inf"}])
+		col = out["columns"]["x"]
+		self.assertEqual(col["type"], "mixed")
+		for v in col.values():
+			if isinstance(v, float):
+				self.assertTrue(math.isfinite(v))
+
+	def test_real_nan_float_excluded(self):
+		out = summarize_dataset([{"x": 1.0}, {"x": 2.0}, {"x": float("nan")}])
+		self.assertEqual(out["columns"]["x"]["type"], "mixed")  # the nan float is not numeric
+
+	def test_long_strings_not_conflated(self):
+		a = "x" * 300 + "A"
+		b = "x" * 300 + "B"  # shares a 300-char prefix; differs only at the end
+		out = summarize_dataset([{"u": a}, {"u": b}, {"u": a}])
+		col = out["columns"]["u"]
+		self.assertEqual(col["distinct"], 2)  # full-value key, not a 200-char prefix
+		self.assertEqual(col["top"][0]["count"], 2)
+		self.assertLessEqual(len(col["top"][0]["value"]), 84)  # display truncated
 
 
 if __name__ == "__main__":

--- a/jarvis/tools/read_file.py
+++ b/jarvis/tools/read_file.py
@@ -41,6 +41,17 @@ _OCR_MAX_PIXELS = 25_000_000
 _OCR_MAX_BYTES = 25 * 1024 * 1024
 _OCR_TIMEOUT = 25
 
+# Lower PIL's decompression-bomb ceiling once at import (a process-global), so a
+# crafted image is rejected before it is decoded. Set here rather than per-call
+# so the limit is deterministic for every PIL consumer in the worker instead of
+# being re-mutated on each read_file image read.
+try:
+    from PIL import Image as _PILImage
+
+    _PILImage.MAX_IMAGE_PIXELS = _OCR_MAX_PIXELS
+except Exception:
+    pass
+
 
 def read_file(
     file_url: str | None = None,
@@ -115,25 +126,23 @@ def _read_pdf(content: bytes, max_chars: int, ocr: bool | None = None) -> dict:
 
     reader = PdfReader(io.BytesIO(content))
     pages = []
-    total = 0
     for page in reader.pages:
         try:
-            txt = page.extract_text() or ""
+            pages.append(page.extract_text() or "")
         except Exception:
-            txt = ""
-        pages.append(txt)
-        total += len(txt)
-        if total >= max_chars:
-            break
+            pages.append("")
     text = "\n\n".join(pages)
     page_count = len(reader.pages)
     used_ocr = False
 
-    # Scanned PDFs carry no embedded text, so pypdf returns ~nothing. Fall back
-    # to OCR when the extraction is essentially empty, the caller didn't disable
-    # it (ocr is not False), and a tesseract engine is actually available.
+    # A scanned page yields ~no embedded text. OCR when at least half the pages
+    # are empty - this catches fully-scanned PDFs AND mixed ones (a short text
+    # layer on a page or two otherwise masks a scanned majority and the scanned
+    # pages get silently dropped). Per-page emptiness, not total text length.
+    empty_pages = sum(1 for p in pages if len(p.strip()) < 10)
+    mostly_scanned = page_count > 0 and empty_pages >= max(1, page_count // 2)
     if (ocr is not False and len(content) <= _OCR_MAX_BYTES
-            and len(text.strip()) < 10 * max(1, page_count) and _ocr_available()):
+            and mostly_scanned and _ocr_available()):
         try:
             ocr_text = _ocr_pdf(content, max_chars)
         except Exception:
@@ -197,41 +206,52 @@ def _read_image(content: bytes, ext: str, ocr: bool | None = None) -> dict:
     try:
         from PIL import Image
 
-        Image.MAX_IMAGE_PIXELS = _OCR_MAX_PIXELS  # PIL raises past this (decompression bomb)
         im = Image.open(io.BytesIO(content))
         out["width"], out["height"] = im.size
         out["mode"] = im.mode
     except Exception:
         im = None
 
-    # Image OCR is opt-in (ocr=True): it's costly and most images aren't text.
-    if ocr is True and im is not None and len(content) <= _OCR_MAX_BYTES and _ocr_available():
-        try:
-            out["text"] = _ocr_pil(im)
-            out["ocr"] = True
-            out["note"] = (
-                "Text extracted via OCR. Visual/diagram content (not text) still "
-                "needs a vision model, not this tool."
-            )
-            return out
-        except Exception:
-            pass
-    out["note"] = (
-        "Image metadata only. Pixel/visual content can't be extracted as text by a "
-        "tool - to analyse what the image shows it needs a vision model as an image "
-        "input, not read here. Pass ocr=true to OCR any text in the image."
-    )
-    return out
+    try:
+        # Image OCR is opt-in (ocr=True): it's costly and most images aren't text.
+        if ocr is True and im is not None and len(content) <= _OCR_MAX_BYTES and _ocr_available():
+            try:
+                out["text"] = _ocr_pil(im)
+                out["ocr"] = True
+                out["note"] = (
+                    "Text extracted via OCR. Visual/diagram content (not text) still "
+                    "needs a vision model, not this tool."
+                )
+                return out
+            except Exception:
+                pass
+        out["note"] = (
+            "Image metadata only. Pixel/visual content can't be extracted as text by a "
+            "tool - to analyse what the image shows it needs a vision model as an image "
+            "input, not read here. Pass ocr=true to OCR any text in the image."
+        )
+        return out
+    finally:
+        if im is not None:
+            try:
+                im.close()
+            except Exception:
+                pass
 
 
 _OCR_OK = None
 
 
 def _ocr_available() -> bool:
-    """True iff pytesseract + a working tesseract binary are present (memoized)."""
+    """True iff pytesseract + tesseract + pypdfium2 are all present (memoized).
+
+    pypdfium2 (the PDF rasterizer) is checked too so a server missing only that
+    wheel reports OCR honestly unavailable, rather than passing the gate and
+    then silently swallowing the pypdfium2 ImportError inside _ocr_pdf."""
     global _OCR_OK
     if _OCR_OK is None:
         try:
+            import pypdfium2  # noqa: F401
             import pytesseract
 
             pytesseract.get_tesseract_version()

--- a/jarvis/tools/summarize_dataset.py
+++ b/jarvis/tools/summarize_dataset.py
@@ -10,6 +10,8 @@ Pure-Python (``statistics`` stdlib); no pandas, no subprocess. It only
 summarizes data passed in (no DB access of its own), so it inherits whatever
 permission scoping produced that data.
 """
+import hashlib
+import math
 import statistics
 from collections import Counter
 
@@ -18,6 +20,8 @@ from jarvis.exceptions import InvalidArgumentError
 _MAX_ROWS = 100_000
 _MAX_COLS = 200
 _DEFAULT_TOP_N = 5
+_KEY_MAX = 256      # strings longer than this are hashed for the counting key
+_DISPLAY_MAX = 80   # but a `top` value is shown truncated to keep output small
 
 
 def summarize_dataset(rows: list, columns: list | None = None, top_n: int = 5) -> dict:
@@ -37,18 +41,18 @@ def summarize_dataset(rows: list, columns: list | None = None, top_n: int = 5) -
 	first = rows[0]
 	if isinstance(first, dict):
 		cols = list(columns) if columns else list(first.keys())
-		records = [r for r in rows if isinstance(r, dict)]
 
 		def get(r, c):
-			return r.get(c)
+			return r.get(c) if isinstance(r, dict) else None
 	elif isinstance(first, (list, tuple)):
 		if not columns:
 			raise InvalidArgumentError("list-of-lists rows require a 'columns' list")
 		cols = list(columns)
-		records = [r for r in rows if isinstance(r, (list, tuple))]
 		idx = {c: i for i, c in enumerate(cols)}
 
 		def get(r, c):
+			if not isinstance(r, (list, tuple)):
+				return None
 			i = idx[c]
 			return r[i] if i < len(r) else None
 	else:
@@ -57,18 +61,17 @@ def summarize_dataset(rows: list, columns: list | None = None, top_n: int = 5) -
 	if len(cols) > _MAX_COLS:
 		raise InvalidArgumentError(f"too many columns ({len(cols)}); cap is {_MAX_COLS}")
 
+	# One row set throughout: the cap above, row_count below, and every column
+	# loop all iterate `rows`. (A non-matching row contributes nulls via get().)
 	out = {}
 	for c in cols:
-		vals = [get(r, c) for r in records]
+		vals = [get(r, c) for r in rows]
 		non_null = [v for v in vals if v is not None and v != ""]
 		nums = [n for n in (_num(v) for v in non_null) if n is not None]
-		col = {
-			"count": len(non_null),
-			"null_count": len(vals) - len(non_null),
-			"distinct": len({_hashable(v) for v in non_null}),
-		}
+		col = {"count": len(non_null), "null_count": len(vals) - len(non_null)}
 		if non_null and len(nums) == len(non_null):
 			col["type"] = "numeric"
+			col["distinct"] = len(set(nums))
 			col["min"] = min(nums)
 			col["max"] = max(nums)
 			col["sum"] = sum(nums)
@@ -77,29 +80,49 @@ def summarize_dataset(rows: list, columns: list | None = None, top_n: int = 5) -
 			col["stdev"] = statistics.pstdev(nums) if len(nums) > 1 else 0.0
 		else:
 			col["type"] = "mixed" if nums else "categorical"
-			counts = Counter(_hashable(v) for v in non_null)
-			col["top"] = [{"value": v, "count": n} for v, n in counts.most_common(top_n)]
+			# One pass: Counter (keyed by the collision-safe key) gives both the
+			# top values and distinct (= len(counts)); `display` maps each key
+			# back to a readable, length-bounded value for output.
+			counts = Counter()
+			display = {}
+			for v in non_null:
+				k = _key(v)
+				counts[k] += 1
+				if k not in display:
+					s = v if isinstance(v, str) else str(v)
+					display[k] = s if len(s) <= _DISPLAY_MAX else s[:_DISPLAY_MAX] + "..."
+			col["distinct"] = len(counts)
+			col["top"] = [{"value": display[k], "count": n} for k, n in counts.most_common(top_n)]
 		out[c] = col
-	return {"row_count": len(records), "columns": out}
+	return {"row_count": len(rows), "columns": out}
 
 
 def _num(v):
-	"""Coerce a value to a number, or None. Booleans are NOT numbers here."""
+	"""Coerce to a finite number, or None. Booleans and non-finite values
+	(``nan`` / ``inf``, including the strings ``"nan"``/``"inf"``) are NOT
+	numbers here - they would otherwise poison a whole column's stats."""
 	if isinstance(v, bool):
 		return None
 	if isinstance(v, (int, float)):
-		return v
+		return v if math.isfinite(v) else None
 	if isinstance(v, str):
 		try:
-			return float(v)
+			n = float(v)
 		except ValueError:
 			return None
+		return n if math.isfinite(n) else None
 	return None
 
 
-def _hashable(v):
-	if isinstance(v, str):
-		return v[:200]
+def _key(v):
+	"""Hashable, memory-bounded, collision-safe key for distinct/top counting.
+
+	Scalars key as themselves; a long string hashes to a fixed-size digest so
+	distinct stays accurate (no conflating values that share a long prefix)
+	without holding multi-KB strings as dict keys."""
 	if isinstance(v, (int, float, bool)):
 		return v
-	return str(v)[:200]
+	s = v if isinstance(v, str) else str(v)
+	if len(s) <= _KEY_MAX:
+		return s
+	return "#" + hashlib.sha1(s.encode("utf-8", "replace")).hexdigest()


### PR DESCRIPTION
From the workflow code review of the FAC-gap tools:
- api._run_tool: translate the frappe.ValidationError family + DuplicateEntryError (a NameError) to the {ok,error} envelope, so a duplicate chart name / bad link / missing doc returns a clean error instead of an opaque HTTP 500 (applies to every tool, e.g. create_doc too).
- summarize_dataset: reject non-finite in _num ('nan'/'inf' strings no longer poison a column to NaN); hash long strings for the distinct/top key instead of truncating to 200 chars (no more conflating values sharing a prefix); count categorical values once (Counter; distinct=len); iterate one consistent row set so the cap and row_count agree.
- read_file: detect scanned PDFs per-page (>= half empty) not by total text length, so a mixed text+scan PDF no longer skips OCR and silently drops pages; set Image.MAX_IMAGE_PIXELS once at import (not a per-call process-global mutation); close the PIL image; include pypdfium2 in the OCR-availability check. Tests: +3 summarize (nan/inf, real-nan, long-string distinct), +1 dashboard (duplicate name -> clean envelope).