### PR TITLE
refactor(chat): extract handle_chat_send from run_agent_turn (chat-bridge Phase 1)

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1,0 +1,794 @@
+"""Shared chat-turn body. The single source of truth for "what happens
+during one chat turn": DB writes, openclaw pool checkout, event
+streaming, canvas persist, auto-title.
+
+Today this is called only by ``jarvis.chat.worker.run_agent_turn``,
+which is the RQ entry point invoked via
+``frappe.enqueue("jarvis.chat.worker.run_agent_turn", ...)``. Phase 2 of
+the chat-bridge refactor will add a second caller (a gevent subscriber
+inside Frappe's Python realtime process) that activates only when
+``socketio_backend == "python"`` is set in ``common_site_config.json``.
+Both callers funnel through ``handle_chat_send`` so there is no duplicated
+turn logic. See ``docs/superpowers/specs/2026-06-24-chat-bridge-
+architecture-design.md`` for the bigger picture.
+
+Test compatibility: the legacy unit tests patch
+``jarvis.chat.worker.publish_to_user`` directly. To keep those tests
+passing without modification, the publish call here goes through
+``_publish_to_user`` which looks the name up on the worker module at
+call time, so the patch on the worker module still wins.
+"""
+
+from __future__ import annotations
+
+import time
+
+import frappe
+
+from jarvis.chat import openclaw_session_pool, vision
+from jarvis.exceptions import OpenclawUnreachableError
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+
+# Batch-commit thresholds for the assistant-content writes during a
+# streamed turn. Sprint-5 punch-list "Worker writes assistant.content on
+# every delta with full overwrite + commit per token" (2026-06-16
+# review): the previous shape called frappe.db.set_value + frappe.db.
+# commit() for every single token, so a 500-token response = 500
+# write+commit cycles. The DB write itself is cheap (one Singles row);
+# the commit is where the cost lives - it forces a per-token transaction
+# round-trip.
+#
+# Now: buffer the latest cumulative text in memory, flush (write+commit)
+# when EITHER threshold trips, AND flush before any tool/lifecycle event
+# fires so the on-disk message-row order matches the realtime channel.
+# Customer experience stays unchanged - the realtime
+# ``assistant:delta`` publish still fires on every token, so the UI
+# animates token-by-token. The DB just catches up in batches.
+#
+# Numbers picked for the punch-list "every N=10 events or 250ms" ask:
+# at typical chat throughputs (1-50 tokens/s) this means 1-2 commits
+# per second instead of 1-50, but at most ~10 tokens of unwritten
+# content if the worker crashes mid-batch (recoverable next stream).
+_ASSISTANT_BATCH_SIZE = 10
+_ASSISTANT_BATCH_INTERVAL_MS = 250
+
+
+def _publish_to_user(user, payload):
+	"""Indirection so existing tests that patch
+	``jarvis.chat.worker.publish_to_user`` still take effect.
+
+	We deliberately look the symbol up on the worker module at call time
+	rather than importing it directly here. The worker module re-exports
+	``publish_to_user`` from ``jarvis.chat.events`` (so the patch target
+	keeps working) and ``mock.patch("jarvis.chat.worker.publish_to_user")``
+	rebinds the attribute on the worker module, which this lookup picks
+	up. Without this indirection, a turn-handler-local
+	``from jarvis.chat.events import publish_to_user`` would bypass the
+	patch and the tests would call the real publish.
+	"""
+	from jarvis.chat import worker as _worker
+
+	return _worker.publish_to_user(user, payload)
+
+
+class _AssistantContentBatcher:
+	"""Coalesces per-token assistant-content writes into one DB
+	write+commit per batch.
+
+	Usage:
+	    batcher = _AssistantContentBatcher(assistant_msg.name)
+	    for event in stream:
+	        if event["kind"] == "assistant":
+	            batcher.delta(event["text"])
+	            batcher.flush_if_due()
+	            continue
+	        batcher.flush()  # ordering: flush before any non-delta event
+	        _handle_event(event, ...)
+	    batcher.flush()      # drain on stream end
+	"""
+
+	def __init__(self, msg_name: str):
+		self.msg_name = msg_name
+		self._pending_text: str | None = None
+		self._events_since_flush = 0
+		self._last_flush_ms = self._now_ms()
+
+	@staticmethod
+	def _now_ms() -> int:
+		return int(time.monotonic() * 1000)
+
+	def delta(self, text: str) -> None:
+		"""Record the latest cumulative assistant text. Caller decides
+		when to actually persist via flush / flush_if_due."""
+		self._pending_text = text
+		self._events_since_flush += 1
+
+	def flush_if_due(self) -> bool:
+		"""Flush iff the size or time threshold is hit. Returns True iff
+		a flush actually happened."""
+		if self._pending_text is None:
+			return False
+		if self._events_since_flush >= _ASSISTANT_BATCH_SIZE:
+			return self.flush()
+		if self._now_ms() - self._last_flush_ms >= _ASSISTANT_BATCH_INTERVAL_MS:
+			return self.flush()
+		return False
+
+	def flush(self) -> bool:
+		"""Flush immediately if any text is pending. Returns True iff a
+		flush happened (caller can use this for trace logging)."""
+		if self._pending_text is None:
+			return False
+		frappe.db.set_value(MSG, self.msg_name, "content", self._pending_text)
+		frappe.db.commit()
+		self._pending_text = None
+		self._events_since_flush = 0
+		self._last_flush_ms = self._now_ms()
+		return True
+
+# Provider label → openclaw provider id sent in the chat WS frame.
+#
+# Openclaw has two dispatch paths chosen at request time
+# (openclaw/src/agents/model-selection-cli.ts:6-20):
+#
+#   - CLI backend: taken when isCliProvider(provider) returns true.
+#     Routes dispatch to a registered CliBackend that spawns an external
+#     CLI binary. The CliBackend is keyed by the provider id (so the
+#     provider sent here must match the CliBackend's id).
+#
+#   - Embedded runtime (codex / pi harness): taken otherwise. The codex
+#     harness has an allowlist of accepted providers; pi handles
+#     everything else but expects HTTP API auth (api key).
+#
+# The two providers we currently support resolve to two different paths:
+#
+#   - OpenAI codex: codex IS a registered plugin harness
+#     (openclaw/extensions/codex/index.ts:34) whose allowlist accepts
+#     "openai" as the model-provider key. Use "openai" for the chat WS
+#     frame and the embedded codex-harness path handles the dispatch.
+#
+#   - Google Gemini: gemini-cli is registered ONLY as a CliBackend
+#     (openclaw/extensions/google/cli-backend.ts:16 with id
+#     "google-gemini-cli"). Use "google-gemini-cli" verbatim so
+#     isCliProvider returns true and dispatch routes via the CLI backend
+#     to the gemini binary inside the container. Mapping it to "google"
+#     makes isCliProvider return false, dispatch falls into the embedded
+#     path, and openclaw errors "No API key found for provider 'google'".
+#
+# Only used in oauth mode - api_key mode skips this map and lets
+# openclaw resolve the single registered models.providers entry.
+_PROVIDER_LABEL_TO_OPENCLAW_ID = {
+	"OpenAI": "openai",
+	"Google Gemini": "google-gemini-cli",
+}
+
+
+def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
+	"""Return (effective_model, openclaw_provider_id_or_None) for this conv.
+
+	- effective_model = conv.model_override or Jarvis Settings.llm_model
+	- provider id is set only in oauth mode (api_key mode keeps it None)
+	"""
+	settings = frappe.get_single("Jarvis Settings")
+	effective_model = (conv.model_override or settings.llm_model or "")
+	provider = (
+		_PROVIDER_LABEL_TO_OPENCLAW_ID.get(settings.llm_provider)
+		if settings.llm_auth_mode == "oauth"
+		else None
+	)
+	return effective_model, provider
+
+
+def handle_chat_send(payload: dict) -> None:
+	"""Drive one agent turn end to end.
+
+	Called by the RQ shim in ``jarvis.chat.worker.run_agent_turn`` today;
+	Phase 2 of the chat-bridge refactor will also call this from a gevent
+	subscriber inside the Python realtime process. Either way the payload
+	carries everything needed to execute one turn:
+
+	    {
+	        "conversation_id": str,
+	        "message_id": str,
+	        "run_id": str,
+	        "attachments": list[dict] | None,
+	        "context": dict | None,
+	    }
+
+	``attachments`` (optional): list of {file_url, file_name} dicts. Text files are
+	inlined into the prompt; images/PDFs are sent to the model as native vision
+	(managed pool + a vision-capable model) - see _prepare_attachments. The
+	persisted/visible user message keeps only the "📎 name" marker, so file
+	bytes never bloat the chat history.
+
+	``context`` (optional): {doctype, name} of the ERP document the user was
+	viewing when they asked (floating-widget auto-context). Prepended to the
+	agent prompt only; the persisted/visible user message is unchanged.
+
+	Sprint-3 (2026-06-16 review): the inline ``except OpenclawUnreachableError``
+	blocks only marked the placeholder errored for openclaw-specific
+	failures. Any OTHER exception (cryptography.InvalidKey, ssl.SSLError,
+	programmer bug in _handle_event, etc.) propagated to RQ without
+	calling _mark_errored, leaving the assistant row stuck at
+	``streaming=1`` forever (the UI poller spins on the empty body).
+	An outer try/except Exception now catches everything else, marks the
+	row errored + publishes run:error, then re-raises so RQ still records
+	the job as failed.
+	"""
+	conversation_id: str = payload["conversation_id"]
+	message_id: str = payload["message_id"]
+	run_id: str = payload["run_id"]
+	attachments = payload.get("attachments")
+	context = payload.get("context")
+
+	conv = frappe.get_doc(CONV, conversation_id)
+	user = conv.owner
+
+	# Create the assistant placeholder row up-front so the browser has a
+	# stable name to attach realtime events to.
+	assistant_msg = _create_assistant_placeholder(conv)
+
+	_publish_to_user(user, {
+		"kind": "run:start",
+		"conversation_id": conversation_id,
+		"message_id": assistant_msg.name,
+		"run_id": run_id,
+	})
+
+	settings = frappe.get_single("Jarvis Settings")
+	# Fetch content + sender of THIS user message in one round-trip.
+	# msg_row.owner is the Frappe user who sent this turn, set by Frappe
+	# at insert time in send_message (jarvis/chat/api.py). We use it
+	# rather than conv.owner for the context bracket because the bench-
+	# side dispatcher (_dispatch_from_session in jarvis/api.py:118) also
+	# acts on the per-request identity, not the conversation creator -
+	# the bracket and the tool-call's frappe.session.user stay in lock-
+	# step. Today these are equal for single-owner conversations; the
+	# distinction matters the moment we ship shared conversations.
+	msg_row = (
+		frappe.db.get_value(MSG, message_id, ["content", "owner"], as_dict=True)
+		or {}
+	)
+	user_message = msg_row.get("content")
+	chat_user = msg_row.get("owner") or user
+	# Prepend today's date AND the chat user's Frappe id as a context line so
+	# the agent (AGENTS.md tells it to treat the leading ``[Context: ...]``
+	# as system, not user) can (a) resolve relative time expressions
+	# ("last quarter", "this week") and (b) answer "who am I" / "what
+	# perms do I have" without a clarifying round-trip or a doomed
+	# get_list on User. The persisted user_message in the DB is
+	# unchanged; only the value sent over to openclaw is augmented.
+	now = frappe.utils.now_datetime()
+	today = now.strftime("%Y-%m-%d (%A)")
+	# Fold the auto-apply preference into the system context line so the agent
+	# knows whether to confirm mutating ops. Default (off) = confirm; the persona
+	# confirms by default, so we only signal the non-default "auto" mode.
+	auto_apply = "; auto-apply changes: ON" if settings.auto_apply_changes else ""
+	user_message = (
+		f"[Context: today is {today}; chat user: {chat_user}{auto_apply}]"
+		f"\n\n{user_message or ''}"
+	)
+
+	from jarvis import selfhost
+
+	# Floating-widget auto-context + file inputs layer onto the
+	# already date/user-augmented user_message built above. Prompt-only;
+	# the persisted/visible user message is unchanged.
+	user_message = _prepend_doc_context(user_message, context)
+	# Vision is managed-pool only (self-host vision is a follow-up), gated by the
+	# operator toggle and the model's provider being multimodal. When off, image/
+	# PDF attachments degrade to a short note (no OCR fallback any more).
+	vision_ok = (
+		not selfhost.is_self_hosted()
+		and _vision_enabled(settings)
+		and vision.supports_vision(settings.llm_provider)
+	)
+	user_message, vision_parts = _prepare_attachments(user_message, attachments, vision_ok)
+
+	def _publish_run_error(err: str) -> None:
+		_mark_errored(assistant_msg.name, err)
+		_publish_to_user(user, {
+			"kind": "run:error",
+			"conversation_id": conversation_id,
+			"message_id": assistant_msg.name,
+			"run_id": run_id,
+			"error": err,
+		})
+
+	try:
+		idem = f"{conversation_id}:{message_id}"
+		tool_msg_by_call_id: dict[str, str] = {}
+		batcher = _AssistantContentBatcher(assistant_msg.name)
+
+		def _consume(events) -> None:
+			for event in events:
+				_handle_event(
+					event,
+					conversation_id=conversation_id,
+					assistant_msg_name=assistant_msg.name,
+					tool_msg_by_call_id=tool_msg_by_call_id,
+					user=user,
+					run_id=run_id,
+					batcher=batcher,
+				)
+			# Drain buffered assistant deltas before the streaming=0 cleanup.
+			batcher.flush()
+
+		if selfhost.is_self_hosted():
+			# Self-hosted: openclaw's HTTP OpenAI-compatible surface with a
+			# bearer token (full operator scope, no device pairing). agent_url
+			# holds the http(s) base; the user's openclaw uses its own LLM.
+			from jarvis.chat import openclaw_http_client
+			base_url = (settings.agent_url or "").strip()
+			token = settings.get_password("agent_token", raise_exception=False) or ""
+			# Register this turn so the plugin's call_tool callback (which only
+			# carries the openclaw HTTP session key, not our conversation) can
+			# attribute tool calls back here and surface tool cards.
+			tool_user = (settings.selfhost_tool_user or "").strip()
+			selfhost.set_active_turn(tool_user, conversation=conversation_id, owner=user, run_id=run_id)
+			# Stream token-by-token unless the operator explicitly turned it
+			# off (a NULL field on a pre-existing config defaults to streaming).
+			stream_pref = (settings.selfhost_stream is None) or bool(settings.selfhost_stream)
+			try:
+				_consume(openclaw_http_client.stream_agent_turn(
+					base_url, token, user_message, model="openclaw", stream=stream_pref,
+				))
+			except OpenclawUnreachableError as e:
+				_publish_run_error(str(e))
+				return
+			finally:
+				selfhost.clear_active_turn(tool_user, run_id)
+		else:
+			# Managed: device-paired WebSocket to the tenant's gateway.
+			# Uses a per-process connection pool so we don't pay the
+			# DNS + TCP + TLS + WS upgrade + handshake (~50-200ms) on
+			# every turn. The pool eviction on OpenclawUnreachableError
+			# means the next attempt will reconnect; we don't auto-
+			# retry inside this turn because tokens may have already
+			# streamed to the UI by the time the failure surfaces.
+			gateway_url = (settings.agent_url or "").replace(
+				"http://", "ws://"
+			).replace("https://", "wss://")
+			effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
+			try:
+				with openclaw_session_pool.checkout(gateway_url) as sess:
+					_consume(sess.stream_agent_turn(
+						conv.session_key, user_message, idem,
+						model=effective_model, provider=oauth_provider_id,
+						attachments=_to_managed_attachments(vision_parts) if vision_parts else None,
+					))
+			except OpenclawUnreachableError as e:
+				_publish_run_error(str(e))
+				return
+
+		# Streaming exited cleanly via lifecycle.end
+		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
+		frappe.db.commit()
+
+		# Rich outputs: detect any canvas/chart artifact the agent produced
+		# this turn (HTML or SVG), fetch it from the gateway, persist it as a
+		# private File, and publish a 'canvas' event so the UI renders it
+		# inline. Managed mode only; self-hosted chats over the HTTP surface
+		# have no gateway canvas route. Failure here never fails the turn.
+		if not selfhost.is_self_hosted():
+			try:
+				from jarvis.chat import canvas as canvas_mod
+
+				final_content = frappe.db.get_value(MSG, assistant_msg.name, "content") or ""
+				canvas_token = settings.get_password("agent_token", raise_exception=False) or ""
+				canvas_items = canvas_mod.persist_canvases(
+					assistant_msg.name, final_content, settings.agent_url or "", canvas_token,
+				)
+				if canvas_items:
+					_publish_to_user(user, {
+						"kind": "canvas",
+						"conversation_id": conversation_id,
+						"message_id": assistant_msg.name,
+						"run_id": run_id,
+						"items": canvas_items,
+					})
+			except Exception:
+				frappe.log_error(
+					title="chat worker: canvas persist failed",
+					message=frappe.get_traceback(),
+				)
+
+	except Exception as e:
+		# Last-resort backstop. Any exception that wasn't an
+		# OpenclawUnreachableError (e.g. cryptography.InvalidKey from
+		# device-pairing signing, ssl.SSLError, a tool-handler bug,
+		# DoesNotExistError on a stale conversation row) would otherwise
+		# leave the assistant row at ``streaming=1`` indefinitely. Mark
+		# it errored, publish run:error, then re-raise so RQ records the
+		# job as failed (and the operator gets a normal Error Log entry).
+		try:
+			_mark_errored(
+				assistant_msg.name,
+				f"unexpected worker error: {type(e).__name__}",
+			)
+			_publish_to_user(user, {
+				"kind": "run:error",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg.name,
+				"run_id": run_id,
+				# Don't leak full str(e) - the operator-safe identifier is
+				# the exception class; the full traceback is in Error Log.
+				"error": f"{type(e).__name__}",
+			})
+		except Exception:
+			# If even the error-marking path fails, swallow - we're
+			# already in an error path and re-raising would mask the
+			# original exception that RQ should see.
+			pass
+		raise
+	_publish_to_user(user, {
+		"kind": "run:end",
+		"conversation_id": conversation_id,
+		"message_id": assistant_msg.name,
+		"run_id": run_id,
+	})
+
+	# Auto-title (managed mode): the first substantive turn of a still-unnamed
+	# conversation gets a concise, LLM-summarised title, not the raw first
+	# message. Runs AFTER run:end so the turn UI has already unblocked; the new
+	# title lands a few seconds later via a "conversation:renamed" event.
+	# Best-effort: a title failure must never affect the completed turn.
+	from jarvis import selfhost
+	if not selfhost.is_self_hosted():
+		try:
+			from jarvis.chat import title as title_mod
+
+			gw = (settings.agent_url or "").replace(
+				"http://", "ws://"
+			).replace("https://", "wss://")
+			eff_model, oauth_pid = _resolve_model_and_provider(conv)
+			title_mod.maybe_autotitle(
+				conversation_id, user,
+				gateway_url=gw, model=eff_model, provider=oauth_pid,
+			)
+		except Exception:
+			frappe.log_error(
+				title="chat worker: auto-title failed",
+				message=frappe.get_traceback(),
+			)
+
+
+def _prepend_doc_context(user_message: str, context) -> str:
+	"""Prepend the ERP doc the user was viewing (floating-widget auto-context)
+	as a leading ``[Viewing: ...]`` line, so questions like "is this overdue?"
+	resolve against the right record without the user naming it. Prompt-only;
+	the stored message is untouched. Defensive: a malformed context is ignored.
+	"""
+	if not isinstance(context, dict):
+		return user_message
+	doctype = (context.get("doctype") or "").strip()
+	if not doctype:
+		return user_message
+	name = (context.get("name") or "").strip()
+	ref = f"{doctype} {name}".strip() if name else f"the {doctype} list"
+	return f"[Viewing: {ref}; resolve 'this'/'here' against it]\n\n{user_message}"
+
+
+_MAX_INLINE_CHARS = 20000
+_IMAGE_EXT = {"png", "jpg", "jpeg", "gif", "webp", "bmp"}
+
+
+def _vision_enabled(settings) -> bool:
+	"""Operator toggle; NULL-safe (a pre-existing config without the field
+	defaults to ON), mirroring selfhost_stream."""
+	v = settings.vision_attachments_enabled
+	return v is None or bool(v)
+
+
+def _to_managed_attachments(vision_parts: list[dict]) -> list[dict]:
+	"""Map internal parts to the flat shape openclaw's gateway normalizer accepts
+	({type:"image", mimeType, fileName, content:<base64>})."""
+	return [
+		{"type": "image", "mimeType": p["mime"], "fileName": p["file_name"], "content": p["data_b64"]}
+		for p in vision_parts
+	]
+
+
+def _prepare_attachments(user_message: str, attachments, vision_ok: bool):
+	"""Build the prompt augmentation + the vision image parts for one turn.
+
+	Returns ``(user_message, vision_parts)``. Text files are inlined into the
+	prompt. When ``vision_ok``, images are sent to the model as native vision and
+	PDFs are rasterized to page-images; otherwise image/PDF attachments degrade
+	to a short note (there is no OCR fallback). Every file is gated by the chat
+	user's File read permission. Only the prompt is augmented - the stored,
+	visible user message is untouched.
+	"""
+	if not attachments:
+		return user_message, []
+	blocks: list[str] = []
+	vision_parts: list[dict] = []
+	for att in attachments:
+		if not isinstance(att, dict):
+			continue
+		url = att.get("file_url")
+		name = att.get("file_name") or url or "file"
+		if not url:
+			continue
+		try:
+			fdoc = frappe.get_doc("File", {"file_url": url})
+		except Exception:
+			blocks.append(f"[Could not read attached file `{name}`.]")
+			continue
+		# Same gate read_file enforces - never read bytes the chat user can't
+		# read (else vision/inlining is a private-File exfil bypass).
+		if not frappe.has_permission("File", "read", doc=fdoc.name):
+			blocks.append(f"[No permission to read attached file `{name}`.]")
+			continue
+		try:
+			# encodings=[] -> raw bytes; skip Frappe's text-encoding guess loop,
+			# which lossily decodes small binaries (e.g. a PNG) to a str.
+			raw = fdoc.get_content(encodings=[])
+		except Exception:
+			blocks.append(f"[Could not read attached file `{name}`.]")
+			continue
+		if isinstance(raw, str):
+			raw = raw.encode("utf-8", "replace")
+		ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+		if ext == "pdf":
+			if not vision_ok:
+				# Vision off: fall back to pypdf text extraction. Works for
+				# digital/text-layer PDFs; a scanned PDF has no text layer and
+				# needs vision (we no longer OCR), so it comes back empty.
+				from jarvis.tools.read_file import _read_pdf
+
+				try:
+					text = (_read_pdf(raw, _MAX_INLINE_CHARS).get("text") or "").strip()
+				except Exception:
+					text = ""
+				if text:
+					blocks.append(f"Attached PDF `{name}` (extracted text):\n```\n{text}\n```")
+				else:
+					blocks.append(
+						f"[Attached PDF `{name}`: no extractable text (looks scanned); "
+						"enable Send Image/PDF Attachments as Vision to read it.]"
+					)
+				continue
+			parts, total = vision.pdf_parts(raw, name)
+			if parts:
+				vision_parts.extend(parts)
+				shown = f"all {total} pages" if total <= len(parts) else f"first {len(parts)} of {total} pages"
+				blocks.append(f"[Attached PDF `{name}` - {shown} sent as images.]")
+			else:
+				blocks.append(f"[Attached PDF `{name}` could not be rendered.]")
+		elif ext in _IMAGE_EXT:
+			if not vision_ok:
+				blocks.append(f"[Attached image `{name}` couldn't be viewed (image input unavailable here).]")
+				continue
+			part = vision.image_part(raw, name)
+			if part:
+				vision_parts.append(part)
+				blocks.append(f"[Attached image `{name}` sent for viewing.]")
+			else:
+				blocks.append(f"[Attached image `{name}` could not be read.]")
+		else:
+			try:
+				text = raw.decode("utf-8")
+			except UnicodeDecodeError:
+				blocks.append(f"[Attached file `{name}` is binary ({len(raw)} bytes); not inlined.]")
+				continue
+			if len(text) > _MAX_INLINE_CHARS:
+				text = text[:_MAX_INLINE_CHARS] + "\n…[truncated]"
+			blocks.append(f"Attached file `{name}`:\n```\n{text}\n```")
+	if blocks:
+		user_message = user_message + "\n\n" + "\n\n".join(blocks)
+	return user_message, vision_parts
+
+
+def _create_assistant_placeholder(conv) -> "frappe.model.document.Document":
+	from jarvis.chat.api import _next_seq
+
+	seq = _next_seq(conv.name)
+	msg = frappe.get_doc({
+		"doctype": MSG,
+		"conversation": conv.name,
+		"seq": seq,
+		"role": "assistant",
+		"content": "",
+		"streaming": 1,
+	})
+	msg.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return msg
+
+
+def _mark_errored(assistant_msg_name: str, error: str) -> None:
+	frappe.db.set_value(MSG, assistant_msg_name, {
+		"streaming": 0,
+		"error": error,
+	})
+	frappe.db.commit()
+
+
+def _handle_event(
+	event: dict,
+	*,
+	conversation_id: str,
+	assistant_msg_name: str,
+	tool_msg_by_call_id: dict[str, str],
+	user: str,
+	run_id: str,
+	batcher: _AssistantContentBatcher,
+) -> None:
+	"""Per-event dispatch. Wrapped in a top-level try/except so a
+	programmer bug on one event (KeyError on a malformed openclaw frame,
+	a DB DoesNotExist on a stale row, etc.) doesn't kill the whole turn
+	and leave the assistant row stranded at streaming=1. Sprint-5
+	punch-list "Wrap _handle_event in try/except logging event kind +
+	tool_call_id + run_id". On failure we log the event metadata and
+	continue - the next event might be a clean recovery (e.g. the
+	turn's final lifecycle.end still flips streaming=0).
+	"""
+	try:
+		_handle_event_inner(
+			event,
+			conversation_id=conversation_id,
+			assistant_msg_name=assistant_msg_name,
+			tool_msg_by_call_id=tool_msg_by_call_id,
+			user=user,
+			run_id=run_id,
+			batcher=batcher,
+		)
+	except Exception:
+		frappe.log_error(
+			title="chat worker: _handle_event failed",
+			message=(
+				f"kind={event.get('kind')!r} "
+				f"phase={event.get('phase')!r} "
+				f"tool_call_id={event.get('tool_call_id')!r} "
+				f"tool_name={event.get('tool_name')!r} "
+				f"run_id={run_id!r} "
+				f"conversation_id={conversation_id!r}\n\n"
+				f"{frappe.get_traceback()}"
+			),
+		)
+		# Don't re-raise; the outer handle_chat_send loop catches Exception
+		# at its outermost layer for the streaming=1 cleanup. Per-event
+		# failures should let the stream continue (the next assistant
+		# delta might overwrite this bad row with good content).
+
+
+def _handle_event_inner(
+	event: dict,
+	*,
+	conversation_id: str,
+	assistant_msg_name: str,
+	tool_msg_by_call_id: dict[str, str],
+	user: str,
+	run_id: str,
+	batcher: _AssistantContentBatcher,
+) -> None:
+	kind = event.get("kind")
+
+	if kind == "lifecycle":
+		# Lifecycle events bracket the stream. Drain any pending
+		# assistant content before we write the lifecycle outcome so
+		# the on-disk row reflects whatever text was rendered up to
+		# this point (matters mostly for the error branch).
+		batcher.flush()
+		phase = event.get("phase")
+		if phase == "error":
+			_mark_errored(assistant_msg_name, event.get("error") or "lifecycle error")
+			_publish_to_user(user, {
+				"kind": "run:error",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg_name,
+				"run_id": run_id,
+				"error": event.get("error"),
+			})
+		# lifecycle start is a no-op (we already published run:start)
+		return
+
+	if kind == "assistant":
+		text = event.get("text", "")
+		# Hot path: buffer the cumulative text + maybe-flush. The
+		# realtime publish still fires on every token so the customer's
+		# UI animates without delay; the DB write coalesces.
+		batcher.delta(text)
+		batcher.flush_if_due()
+		_publish_to_user(user, {
+			"kind": "assistant:delta",
+			"conversation_id": conversation_id,
+			"message_id": assistant_msg_name,
+			"text": text,
+			"run_id": run_id,
+		})
+		return
+
+	if kind == "tool":
+		# Tool start/end events insert new rows. Drain pending assistant
+		# content first so the on-disk row order matches the realtime
+		# event order (assistant text the customer saw before this tool
+		# call is durable before the tool row appears).
+		batcher.flush()
+		phase = event.get("phase")
+		tool_call_id = event.get("tool_call_id")
+		tool_name = event.get("tool_name")
+		# jarvis__* tools execute through the backend call_tool path, which
+		# ALREADY persists a role=tool message carrying the full args + result
+		# (jarvis.api._persist_and_publish_tool_call). Persisting again here
+		# would double up every ERP tool call with an arg-less duplicate, so we
+		# only drive the live activity indicator for those and let the backend
+		# own the durable row. Built-in openclaw tools (browser/canvas/…) never
+		# hit call_tool, so we still persist those here.
+		is_jarvis = (tool_name or "").startswith("jarvis__")
+		if phase == "start":
+			if not is_jarvis:
+				from jarvis.chat.api import _next_seq
+				seq = _next_seq(conversation_id)
+				doc = frappe.get_doc({
+					"doctype": MSG,
+					"conversation": conversation_id,
+					"seq": seq,
+					"role": "tool",
+					"content": f"calling {tool_name}…",
+					"tool_name": tool_name,
+					"tool_status": "running",
+					"streaming": 1,
+				})
+				doc.insert(ignore_permissions=True)
+				frappe.db.commit()
+				tool_msg_by_call_id[tool_call_id] = doc.name
+			_publish_to_user(user, {
+				"kind": "tool:start",
+				"conversation_id": conversation_id,
+				"message_id": tool_msg_by_call_id.get(tool_call_id),
+				"tool_name": tool_name,
+				"tool_call_id": tool_call_id,
+				"run_id": run_id,
+			})
+		elif phase == "end":
+			if is_jarvis:
+				# No worker-side row for jarvis tools; just close the live card.
+				_publish_to_user(user, {
+					"kind": "tool:end",
+					"conversation_id": conversation_id,
+					"message_id": None,
+					"tool_name": tool_name,
+					"tool_call_id": tool_call_id,
+					"status": event.get("status"),
+					"run_id": run_id,
+				})
+				return
+			name = tool_msg_by_call_id.get(tool_call_id)
+			if not name:
+				# Orphan: openclaw emitted a tool 'end' event for a
+				# tool_call_id we never logged a 'start' for. Shouldn't
+				# happen, but the previous shape silently returned and
+				# left no operator trace - so a real recurring orphan
+				# (would point at an openclaw event-ordering regression)
+				# would be invisible. Log it as a warning so it shows
+				# up in Error Log triage.
+				frappe.log_error(
+					title="chat worker: orphan tool 'end' event",
+					message=(
+						f"conversation_id={conversation_id!r} "
+						f"run_id={run_id!r} "
+						f"tool_call_id={tool_call_id!r} "
+						f"tool_name={tool_name!r} "
+						f"event_status={event.get('status')!r}"
+					),
+				)
+				return
+			frappe.db.set_value(MSG, name, {
+				"tool_status": event.get("status") or "completed",
+				"streaming": 0,
+			})
+			frappe.db.commit()
+			_publish_to_user(user, {
+				"kind": "tool:end",
+				"conversation_id": conversation_id,
+				"message_id": name,
+				"tool_name": tool_name,
+				"tool_call_id": tool_call_id,
+				"status": event.get("status"),
+				"run_id": run_id,
+			})

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -1,749 +1,99 @@
 """RQ job: stream one agent turn from openclaw to DB + realtime.
 
-Spawned by jarvis.chat.api.send_message via frappe.enqueue. Holds a Python
-WebSocket connection to the openclaw gateway for the duration of the turn
-(typically 10-30s); the Frappe request handler returns in ~10ms and the
-worker streams events while the browser sees them token-by-token via
-socketio.
+Today this is the default chat path: ``jarvis.chat.api.send_message``
+enqueues, RQ workers pick up, this function runs. The actual turn
+logic lives in ``jarvis.chat.turn_handler.handle_chat_send`` so future
+non-RQ executors (the Phase 2 realtime-process subscriber gated on
+``socketio_backend == 'python'``) can call the same code without
+duplicating it. See
+``docs/superpowers/specs/2026-06-24-chat-bridge-architecture-design.md``
+for the bigger picture.
+
+Helpers historically defined here (``_AssistantContentBatcher``,
+``_handle_event``, ``_resolve_model_and_provider``, etc.) are
+re-exported below so existing tests that import them via this module
+keep working unchanged. ``publish_to_user`` is re-exported by name so
+``mock.patch("jarvis.chat.worker.publish_to_user")`` continues to
+patch the turn-handler's outbound publishes (the handler dereferences
+through the worker module at call time). New code should import from
+``jarvis.chat.turn_handler`` directly.
 """
 
 from __future__ import annotations
 
-import time
-
-import frappe
-
+# Re-exported patch target. test_chat_worker.py and any other test
+# suite that pre-existed the turn_handler split still calls
+# ``patch("jarvis.chat.worker.publish_to_user")``; the handler in
+# turn_handler.py looks the symbol up on this module at call time, so
+# rebinding it here is sufficient to redirect every outbound publish.
 from jarvis.chat.events import publish_to_user
-from jarvis.chat import openclaw_session_pool, vision
-from jarvis.exceptions import OpenclawUnreachableError
+
+# Re-export everything the legacy worker module used to expose. Tests
+# (test_chat_worker.py, test_vision_attachments.py) import these by name
+# from jarvis.chat.worker and must keep working.
+from jarvis.chat.turn_handler import (
+	_ASSISTANT_BATCH_INTERVAL_MS,
+	_ASSISTANT_BATCH_SIZE,
+	_AssistantContentBatcher,
+	_IMAGE_EXT,
+	_MAX_INLINE_CHARS,
+	_PROVIDER_LABEL_TO_OPENCLAW_ID,
+	_create_assistant_placeholder,
+	_handle_event,
+	_handle_event_inner,
+	_mark_errored,
+	_prepare_attachments,
+	_prepend_doc_context,
+	_resolve_model_and_provider,
+	_to_managed_attachments,
+	_vision_enabled,
+	handle_chat_send,
+)
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 
-# Batch-commit thresholds for the assistant-content writes during a
-# streamed turn. Sprint-5 punch-list "Worker writes assistant.content on
-# every delta with full overwrite + commit per token" (2026-06-16
-# review): the previous shape called frappe.db.set_value + frappe.db.
-# commit() for every single token, so a 500-token response = 500
-# write+commit cycles. The DB write itself is cheap (one Singles row);
-# the commit is where the cost lives - it forces a per-token transaction
-# round-trip.
-#
-# Now: buffer the latest cumulative text in memory, flush (write+commit)
-# when EITHER threshold trips, AND flush before any tool/lifecycle event
-# fires so the on-disk message-row order matches the realtime channel.
-# Customer experience stays unchanged - the realtime
-# ``assistant:delta`` publish still fires on every token, so the UI
-# animates token-by-token. The DB just catches up in batches.
-#
-# Numbers picked for the punch-list "every N=10 events or 250ms" ask:
-# at typical chat throughputs (1-50 tokens/s) this means 1-2 commits
-# per second instead of 1-50, but at most ~10 tokens of unwritten
-# content if the worker crashes mid-batch (recoverable next stream).
-_ASSISTANT_BATCH_SIZE = 10
-_ASSISTANT_BATCH_INTERVAL_MS = 250
-
-
-class _AssistantContentBatcher:
-	"""Coalesces per-token assistant-content writes into one DB
-	write+commit per batch.
-
-	Usage:
-	    batcher = _AssistantContentBatcher(assistant_msg.name)
-	    for event in stream:
-	        if event["kind"] == "assistant":
-	            batcher.delta(event["text"])
-	            batcher.flush_if_due()
-	            continue
-	        batcher.flush()  # ordering: flush before any non-delta event
-	        _handle_event(event, ...)
-	    batcher.flush()      # drain on stream end
-	"""
-
-	def __init__(self, msg_name: str):
-		self.msg_name = msg_name
-		self._pending_text: str | None = None
-		self._events_since_flush = 0
-		self._last_flush_ms = self._now_ms()
-
-	@staticmethod
-	def _now_ms() -> int:
-		return int(time.monotonic() * 1000)
-
-	def delta(self, text: str) -> None:
-		"""Record the latest cumulative assistant text. Caller decides
-		when to actually persist via flush / flush_if_due."""
-		self._pending_text = text
-		self._events_since_flush += 1
-
-	def flush_if_due(self) -> bool:
-		"""Flush iff the size or time threshold is hit. Returns True iff
-		a flush actually happened."""
-		if self._pending_text is None:
-			return False
-		if self._events_since_flush >= _ASSISTANT_BATCH_SIZE:
-			return self.flush()
-		if self._now_ms() - self._last_flush_ms >= _ASSISTANT_BATCH_INTERVAL_MS:
-			return self.flush()
-		return False
-
-	def flush(self) -> bool:
-		"""Flush immediately if any text is pending. Returns True iff a
-		flush happened (caller can use this for trace logging)."""
-		if self._pending_text is None:
-			return False
-		frappe.db.set_value(MSG, self.msg_name, "content", self._pending_text)
-		frappe.db.commit()
-		self._pending_text = None
-		self._events_since_flush = 0
-		self._last_flush_ms = self._now_ms()
-		return True
-
-# Provider label → openclaw provider id sent in the chat WS frame.
-#
-# Openclaw has two dispatch paths chosen at request time
-# (openclaw/src/agents/model-selection-cli.ts:6-20):
-#
-#   - CLI backend: taken when isCliProvider(provider) returns true.
-#     Routes dispatch to a registered CliBackend that spawns an external
-#     CLI binary. The CliBackend is keyed by the provider id (so the
-#     provider sent here must match the CliBackend's id).
-#
-#   - Embedded runtime (codex / pi harness): taken otherwise. The codex
-#     harness has an allowlist of accepted providers; pi handles
-#     everything else but expects HTTP API auth (api key).
-#
-# The two providers we currently support resolve to two different paths:
-#
-#   - OpenAI codex: codex IS a registered plugin harness
-#     (openclaw/extensions/codex/index.ts:34) whose allowlist accepts
-#     "openai" as the model-provider key. Use "openai" for the chat WS
-#     frame and the embedded codex-harness path handles the dispatch.
-#
-#   - Google Gemini: gemini-cli is registered ONLY as a CliBackend
-#     (openclaw/extensions/google/cli-backend.ts:16 with id
-#     "google-gemini-cli"). Use "google-gemini-cli" verbatim so
-#     isCliProvider returns true and dispatch routes via the CLI backend
-#     to the gemini binary inside the container. Mapping it to "google"
-#     makes isCliProvider return false, dispatch falls into the embedded
-#     path, and openclaw errors "No API key found for provider 'google'".
-#
-# Only used in oauth mode - api_key mode skips this map and lets
-# openclaw resolve the single registered models.providers entry.
-_PROVIDER_LABEL_TO_OPENCLAW_ID = {
-	"OpenAI": "openai",
-	"Google Gemini": "google-gemini-cli",
-}
-
-
-def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
-	"""Return (effective_model, openclaw_provider_id_or_None) for this conv.
-
-	- effective_model = conv.model_override or Jarvis Settings.llm_model
-	- provider id is set only in oauth mode (api_key mode keeps it None)
-	"""
-	settings = frappe.get_single("Jarvis Settings")
-	effective_model = (conv.model_override or settings.llm_model or "")
-	provider = (
-		_PROVIDER_LABEL_TO_OPENCLAW_ID.get(settings.llm_provider)
-		if settings.llm_auth_mode == "oauth"
-		else None
-	)
-	return effective_model, provider
+__all__ = [
+	"CONV",
+	"MSG",
+	"handle_chat_send",
+	"publish_to_user",
+	"run_agent_turn",
+	"_ASSISTANT_BATCH_INTERVAL_MS",
+	"_ASSISTANT_BATCH_SIZE",
+	"_AssistantContentBatcher",
+	"_IMAGE_EXT",
+	"_MAX_INLINE_CHARS",
+	"_PROVIDER_LABEL_TO_OPENCLAW_ID",
+	"_create_assistant_placeholder",
+	"_handle_event",
+	"_handle_event_inner",
+	"_mark_errored",
+	"_prepare_attachments",
+	"_prepend_doc_context",
+	"_resolve_model_and_provider",
+	"_to_managed_attachments",
+	"_vision_enabled",
+]
 
 
 def run_agent_turn(
 	conversation_id: str, message_id: str, run_id: str, attachments=None,
 	context=None,
 ) -> None:
-	"""Drive one agent turn end to end. Called by RQ; not whitelisted.
+	"""RQ entry point. Thin shim around ``handle_chat_send``.
 
-	`attachments` (optional): list of {file_url, file_name} dicts. Text files are
-	inlined into the prompt; images/PDFs are sent to the model as native vision
-	(managed pool + a vision-capable model) - see _prepare_attachments. The
-	persisted/visible user message keeps only the "📎 name" marker, so file
-	bytes never bloat the chat history.
-
-	`context` (optional): {doctype, name} of the ERP document the user was
-	viewing when they asked (floating-widget auto-context). Prepended to the
-	agent prompt only — the persisted/visible user message is unchanged.
-
-	Sprint-3 (2026-06-16 review): the inline ``except OpenclawUnreachableError``
-	blocks only marked the placeholder errored for openclaw-specific
-	failures. Any OTHER exception (cryptography.InvalidKey, ssl.SSLError,
-	programmer bug in _handle_event, etc.) propagated to RQ without
-	calling _mark_errored, leaving the assistant row stuck at
-	``streaming=1`` forever (the UI poller spins on the empty body).
-	An outer try/except Exception now catches everything else, marks the
-	row errored + publishes run:error, then re-raises so RQ still records
-	the job as failed.
+	Kept verbatim as the RQ contract so
+	``jarvis.chat.api.send_message`` /
+	``jarvis.chat.api.retry_message``'s
+	``frappe.enqueue("jarvis.chat.worker.run_agent_turn", ...)`` calls
+	continue to work unchanged. All real work happens in
+	``jarvis.chat.turn_handler.handle_chat_send``.
 	"""
-	conv = frappe.get_doc(CONV, conversation_id)
-	user = conv.owner
-
-	# Create the assistant placeholder row up-front so the browser has a
-	# stable name to attach realtime events to.
-	assistant_msg = _create_assistant_placeholder(conv)
-
-	publish_to_user(user, {
-		"kind": "run:start",
+	handle_chat_send({
 		"conversation_id": conversation_id,
-		"message_id": assistant_msg.name,
+		"message_id": message_id,
 		"run_id": run_id,
+		"attachments": attachments,
+		"context": context,
 	})
-
-	settings = frappe.get_single("Jarvis Settings")
-	# Fetch content + sender of THIS user message in one round-trip.
-	# msg_row.owner is the Frappe user who sent this turn, set by Frappe
-	# at insert time in send_message (jarvis/chat/api.py). We use it
-	# rather than conv.owner for the context bracket because the bench-
-	# side dispatcher (_dispatch_from_session in jarvis/api.py:118) also
-	# acts on the per-request identity, not the conversation creator -
-	# the bracket and the tool-call's frappe.session.user stay in lock-
-	# step. Today these are equal for single-owner conversations; the
-	# distinction matters the moment we ship shared conversations.
-	msg_row = (
-		frappe.db.get_value(MSG, message_id, ["content", "owner"], as_dict=True)
-		or {}
-	)
-	user_message = msg_row.get("content")
-	chat_user = msg_row.get("owner") or user
-	# Prepend today's date AND the chat user's Frappe id as a context line so
-	# the agent (AGENTS.md tells it to treat the leading ``[Context: ...]``
-	# as system, not user) can (a) resolve relative time expressions
-	# ("last quarter", "this week") and (b) answer "who am I" / "what
-	# perms do I have" without a clarifying round-trip or a doomed
-	# get_list on User. The persisted user_message in the DB is
-	# unchanged; only the value sent over to openclaw is augmented.
-	now = frappe.utils.now_datetime()
-	today = now.strftime("%Y-%m-%d (%A)")
-	# Fold the auto-apply preference into the system context line so the agent
-	# knows whether to confirm mutating ops. Default (off) = confirm; the persona
-	# confirms by default, so we only signal the non-default "auto" mode.
-	auto_apply = "; auto-apply changes: ON" if settings.auto_apply_changes else ""
-	user_message = (
-		f"[Context: today is {today}; chat user: {chat_user}{auto_apply}]"
-		f"\n\n{user_message or ''}"
-	)
-
-	from jarvis import selfhost
-
-	# Floating-widget auto-context + file inputs layer onto the
-	# already date/user-augmented user_message built above. Prompt-only;
-	# the persisted/visible user message is unchanged.
-	user_message = _prepend_doc_context(user_message, context)
-	# Vision is managed-pool only (self-host vision is a follow-up), gated by the
-	# operator toggle and the model's provider being multimodal. When off, image/
-	# PDF attachments degrade to a short note (no OCR fallback any more).
-	vision_ok = (
-		not selfhost.is_self_hosted()
-		and _vision_enabled(settings)
-		and vision.supports_vision(settings.llm_provider)
-	)
-	user_message, vision_parts = _prepare_attachments(user_message, attachments, vision_ok)
-
-	def _publish_run_error(err: str) -> None:
-		_mark_errored(assistant_msg.name, err)
-		publish_to_user(user, {
-			"kind": "run:error",
-			"conversation_id": conversation_id,
-			"message_id": assistant_msg.name,
-			"run_id": run_id,
-			"error": err,
-		})
-
-	try:
-		idem = f"{conversation_id}:{message_id}"
-		tool_msg_by_call_id: dict[str, str] = {}
-		batcher = _AssistantContentBatcher(assistant_msg.name)
-
-		def _consume(events) -> None:
-			for event in events:
-				_handle_event(
-					event,
-					conversation_id=conversation_id,
-					assistant_msg_name=assistant_msg.name,
-					tool_msg_by_call_id=tool_msg_by_call_id,
-					user=user,
-					run_id=run_id,
-					batcher=batcher,
-				)
-			# Drain buffered assistant deltas before the streaming=0 cleanup.
-			batcher.flush()
-
-		if selfhost.is_self_hosted():
-			# Self-hosted: openclaw's HTTP OpenAI-compatible surface with a
-			# bearer token (full operator scope, no device pairing). agent_url
-			# holds the http(s) base; the user's openclaw uses its own LLM.
-			from jarvis.chat import openclaw_http_client
-			base_url = (settings.agent_url or "").strip()
-			token = settings.get_password("agent_token", raise_exception=False) or ""
-			# Register this turn so the plugin's call_tool callback (which only
-			# carries the openclaw HTTP session key, not our conversation) can
-			# attribute tool calls back here and surface tool cards.
-			tool_user = (settings.selfhost_tool_user or "").strip()
-			selfhost.set_active_turn(tool_user, conversation=conversation_id, owner=user, run_id=run_id)
-			# Stream token-by-token unless the operator explicitly turned it
-			# off (a NULL field on a pre-existing config defaults to streaming).
-			stream_pref = (settings.selfhost_stream is None) or bool(settings.selfhost_stream)
-			try:
-				_consume(openclaw_http_client.stream_agent_turn(
-					base_url, token, user_message, model="openclaw", stream=stream_pref,
-				))
-			except OpenclawUnreachableError as e:
-				_publish_run_error(str(e))
-				return
-			finally:
-				selfhost.clear_active_turn(tool_user, run_id)
-		else:
-			# Managed: device-paired WebSocket to the tenant's gateway.
-			# Uses a per-process connection pool so we don't pay the
-			# DNS + TCP + TLS + WS upgrade + handshake (~50-200ms) on
-			# every turn. The pool eviction on OpenclawUnreachableError
-			# means the next attempt will reconnect; we don't auto-
-			# retry inside this turn because tokens may have already
-			# streamed to the UI by the time the failure surfaces.
-			gateway_url = (settings.agent_url or "").replace(
-				"http://", "ws://"
-			).replace("https://", "wss://")
-			effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
-			try:
-				with openclaw_session_pool.checkout(gateway_url) as sess:
-					_consume(sess.stream_agent_turn(
-						conv.session_key, user_message, idem,
-						model=effective_model, provider=oauth_provider_id,
-						attachments=_to_managed_attachments(vision_parts) if vision_parts else None,
-					))
-			except OpenclawUnreachableError as e:
-				_publish_run_error(str(e))
-				return
-
-		# Streaming exited cleanly via lifecycle.end
-		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
-		frappe.db.commit()
-
-		# Rich outputs: detect any canvas/chart artifact the agent produced
-		# this turn (HTML or SVG), fetch it from the gateway, persist it as a
-		# private File, and publish a 'canvas' event so the UI renders it
-		# inline. Managed mode only — self-hosted chats over the HTTP surface
-		# have no gateway canvas route. Failure here never fails the turn.
-		if not selfhost.is_self_hosted():
-			try:
-				from jarvis.chat import canvas as canvas_mod
-
-				final_content = frappe.db.get_value(MSG, assistant_msg.name, "content") or ""
-				canvas_token = settings.get_password("agent_token", raise_exception=False) or ""
-				canvas_items = canvas_mod.persist_canvases(
-					assistant_msg.name, final_content, settings.agent_url or "", canvas_token,
-				)
-				if canvas_items:
-					publish_to_user(user, {
-						"kind": "canvas",
-						"conversation_id": conversation_id,
-						"message_id": assistant_msg.name,
-						"run_id": run_id,
-						"items": canvas_items,
-					})
-			except Exception:
-				frappe.log_error(
-					title="chat worker: canvas persist failed",
-					message=frappe.get_traceback(),
-				)
-
-	except Exception as e:
-		# Last-resort backstop. Any exception that wasn't an
-		# OpenclawUnreachableError (e.g. cryptography.InvalidKey from
-		# device-pairing signing, ssl.SSLError, a tool-handler bug,
-		# DoesNotExistError on a stale conversation row) would otherwise
-		# leave the assistant row at ``streaming=1`` indefinitely. Mark
-		# it errored, publish run:error, then re-raise so RQ records the
-		# job as failed (and the operator gets a normal Error Log entry).
-		try:
-			_mark_errored(
-				assistant_msg.name,
-				f"unexpected worker error: {type(e).__name__}",
-			)
-			publish_to_user(user, {
-				"kind": "run:error",
-				"conversation_id": conversation_id,
-				"message_id": assistant_msg.name,
-				"run_id": run_id,
-				# Don't leak full str(e) - the operator-safe identifier is
-				# the exception class; the full traceback is in Error Log.
-				"error": f"{type(e).__name__}",
-			})
-		except Exception:
-			# If even the error-marking path fails, swallow - we're
-			# already in an error path and re-raising would mask the
-			# original exception that RQ should see.
-			pass
-		raise
-	publish_to_user(user, {
-		"kind": "run:end",
-		"conversation_id": conversation_id,
-		"message_id": assistant_msg.name,
-		"run_id": run_id,
-	})
-
-	# Auto-title (managed mode): the first substantive turn of a still-unnamed
-	# conversation gets a concise, LLM-summarised title — not the raw first
-	# message. Runs AFTER run:end so the turn UI has already unblocked; the new
-	# title lands a few seconds later via a "conversation:renamed" event.
-	# Best-effort — a title failure must never affect the completed turn.
-	from jarvis import selfhost
-	if not selfhost.is_self_hosted():
-		try:
-			from jarvis.chat import title as title_mod
-
-			gw = (settings.agent_url or "").replace(
-				"http://", "ws://"
-			).replace("https://", "wss://")
-			eff_model, oauth_pid = _resolve_model_and_provider(conv)
-			title_mod.maybe_autotitle(
-				conversation_id, user,
-				gateway_url=gw, model=eff_model, provider=oauth_pid,
-			)
-		except Exception:
-			frappe.log_error(
-				title="chat worker: auto-title failed",
-				message=frappe.get_traceback(),
-			)
-
-
-def _prepend_doc_context(user_message: str, context) -> str:
-	"""Prepend the ERP doc the user was viewing (floating-widget auto-context)
-	as a leading ``[Viewing: ...]`` line, so questions like "is this overdue?"
-	resolve against the right record without the user naming it. Prompt-only;
-	the stored message is untouched. Defensive: a malformed context is ignored.
-	"""
-	if not isinstance(context, dict):
-		return user_message
-	doctype = (context.get("doctype") or "").strip()
-	if not doctype:
-		return user_message
-	name = (context.get("name") or "").strip()
-	ref = f"{doctype} {name}".strip() if name else f"the {doctype} list"
-	return f"[Viewing: {ref} — resolve 'this'/'here' against it]\n\n{user_message}"
-
-
-_MAX_INLINE_CHARS = 20000
-_IMAGE_EXT = {"png", "jpg", "jpeg", "gif", "webp", "bmp"}
-
-
-def _vision_enabled(settings) -> bool:
-	"""Operator toggle; NULL-safe (a pre-existing config without the field
-	defaults to ON), mirroring selfhost_stream."""
-	v = settings.vision_attachments_enabled
-	return v is None or bool(v)
-
-
-def _to_managed_attachments(vision_parts: list[dict]) -> list[dict]:
-	"""Map internal parts to the flat shape openclaw's gateway normalizer accepts
-	({type:"image", mimeType, fileName, content:<base64>})."""
-	return [
-		{"type": "image", "mimeType": p["mime"], "fileName": p["file_name"], "content": p["data_b64"]}
-		for p in vision_parts
-	]
-
-
-def _prepare_attachments(user_message: str, attachments, vision_ok: bool):
-	"""Build the prompt augmentation + the vision image parts for one turn.
-
-	Returns ``(user_message, vision_parts)``. Text files are inlined into the
-	prompt. When ``vision_ok``, images are sent to the model as native vision and
-	PDFs are rasterized to page-images; otherwise image/PDF attachments degrade
-	to a short note (there is no OCR fallback). Every file is gated by the chat
-	user's File read permission. Only the prompt is augmented - the stored,
-	visible user message is untouched.
-	"""
-	if not attachments:
-		return user_message, []
-	blocks: list[str] = []
-	vision_parts: list[dict] = []
-	for att in attachments:
-		if not isinstance(att, dict):
-			continue
-		url = att.get("file_url")
-		name = att.get("file_name") or url or "file"
-		if not url:
-			continue
-		try:
-			fdoc = frappe.get_doc("File", {"file_url": url})
-		except Exception:
-			blocks.append(f"[Could not read attached file `{name}`.]")
-			continue
-		# Same gate read_file enforces - never read bytes the chat user can't
-		# read (else vision/inlining is a private-File exfil bypass).
-		if not frappe.has_permission("File", "read", doc=fdoc.name):
-			blocks.append(f"[No permission to read attached file `{name}`.]")
-			continue
-		try:
-			# encodings=[] -> raw bytes; skip Frappe's text-encoding guess loop,
-			# which lossily decodes small binaries (e.g. a PNG) to a str.
-			raw = fdoc.get_content(encodings=[])
-		except Exception:
-			blocks.append(f"[Could not read attached file `{name}`.]")
-			continue
-		if isinstance(raw, str):
-			raw = raw.encode("utf-8", "replace")
-		ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
-
-		if ext == "pdf":
-			if not vision_ok:
-				# Vision off: fall back to pypdf text extraction. Works for
-				# digital/text-layer PDFs; a scanned PDF has no text layer and
-				# needs vision (we no longer OCR), so it comes back empty.
-				from jarvis.tools.read_file import _read_pdf
-
-				try:
-					text = (_read_pdf(raw, _MAX_INLINE_CHARS).get("text") or "").strip()
-				except Exception:
-					text = ""
-				if text:
-					blocks.append(f"Attached PDF `{name}` (extracted text):\n```\n{text}\n```")
-				else:
-					blocks.append(
-						f"[Attached PDF `{name}`: no extractable text (looks scanned); "
-						"enable Send Image/PDF Attachments as Vision to read it.]"
-					)
-				continue
-			parts, total = vision.pdf_parts(raw, name)
-			if parts:
-				vision_parts.extend(parts)
-				shown = f"all {total} pages" if total <= len(parts) else f"first {len(parts)} of {total} pages"
-				blocks.append(f"[Attached PDF `{name}` - {shown} sent as images.]")
-			else:
-				blocks.append(f"[Attached PDF `{name}` could not be rendered.]")
-		elif ext in _IMAGE_EXT:
-			if not vision_ok:
-				blocks.append(f"[Attached image `{name}` couldn't be viewed (image input unavailable here).]")
-				continue
-			part = vision.image_part(raw, name)
-			if part:
-				vision_parts.append(part)
-				blocks.append(f"[Attached image `{name}` sent for viewing.]")
-			else:
-				blocks.append(f"[Attached image `{name}` could not be read.]")
-		else:
-			try:
-				text = raw.decode("utf-8")
-			except UnicodeDecodeError:
-				blocks.append(f"[Attached file `{name}` is binary ({len(raw)} bytes); not inlined.]")
-				continue
-			if len(text) > _MAX_INLINE_CHARS:
-				text = text[:_MAX_INLINE_CHARS] + "\n…[truncated]"
-			blocks.append(f"Attached file `{name}`:\n```\n{text}\n```")
-	if blocks:
-		user_message = user_message + "\n\n" + "\n\n".join(blocks)
-	return user_message, vision_parts
-
-
-def _create_assistant_placeholder(conv) -> "frappe.model.document.Document":
-	from jarvis.chat.api import _next_seq
-
-	seq = _next_seq(conv.name)
-	msg = frappe.get_doc({
-		"doctype": MSG,
-		"conversation": conv.name,
-		"seq": seq,
-		"role": "assistant",
-		"content": "",
-		"streaming": 1,
-	})
-	msg.insert(ignore_permissions=True)
-	frappe.db.commit()
-	return msg
-
-
-def _mark_errored(assistant_msg_name: str, error: str) -> None:
-	frappe.db.set_value(MSG, assistant_msg_name, {
-		"streaming": 0,
-		"error": error,
-	})
-	frappe.db.commit()
-
-
-def _handle_event(
-	event: dict,
-	*,
-	conversation_id: str,
-	assistant_msg_name: str,
-	tool_msg_by_call_id: dict[str, str],
-	user: str,
-	run_id: str,
-	batcher: _AssistantContentBatcher,
-) -> None:
-	"""Per-event dispatch. Wrapped in a top-level try/except so a
-	programmer bug on one event (KeyError on a malformed openclaw frame,
-	a DB DoesNotExist on a stale row, etc.) doesn't kill the whole turn
-	and leave the assistant row stranded at streaming=1. Sprint-5
-	punch-list "Wrap _handle_event in try/except logging event kind +
-	tool_call_id + run_id". On failure we log the event metadata and
-	continue - the next event might be a clean recovery (e.g. the
-	turn's final lifecycle.end still flips streaming=0).
-	"""
-	try:
-		_handle_event_inner(
-			event,
-			conversation_id=conversation_id,
-			assistant_msg_name=assistant_msg_name,
-			tool_msg_by_call_id=tool_msg_by_call_id,
-			user=user,
-			run_id=run_id,
-			batcher=batcher,
-		)
-	except Exception:
-		frappe.log_error(
-			title="chat worker: _handle_event failed",
-			message=(
-				f"kind={event.get('kind')!r} "
-				f"phase={event.get('phase')!r} "
-				f"tool_call_id={event.get('tool_call_id')!r} "
-				f"tool_name={event.get('tool_name')!r} "
-				f"run_id={run_id!r} "
-				f"conversation_id={conversation_id!r}\n\n"
-				f"{frappe.get_traceback()}"
-			),
-		)
-		# Don't re-raise; the outer run_agent_turn loop catches Exception
-		# at its outermost layer for the streaming=1 cleanup. Per-event
-		# failures should let the stream continue (the next assistant
-		# delta might overwrite this bad row with good content).
-
-
-def _handle_event_inner(
-	event: dict,
-	*,
-	conversation_id: str,
-	assistant_msg_name: str,
-	tool_msg_by_call_id: dict[str, str],
-	user: str,
-	run_id: str,
-	batcher: _AssistantContentBatcher,
-) -> None:
-	kind = event.get("kind")
-
-	if kind == "lifecycle":
-		# Lifecycle events bracket the stream. Drain any pending
-		# assistant content before we write the lifecycle outcome so
-		# the on-disk row reflects whatever text was rendered up to
-		# this point (matters mostly for the error branch).
-		batcher.flush()
-		phase = event.get("phase")
-		if phase == "error":
-			_mark_errored(assistant_msg_name, event.get("error") or "lifecycle error")
-			publish_to_user(user, {
-				"kind": "run:error",
-				"conversation_id": conversation_id,
-				"message_id": assistant_msg_name,
-				"run_id": run_id,
-				"error": event.get("error"),
-			})
-		# lifecycle start is a no-op (we already published run:start)
-		return
-
-	if kind == "assistant":
-		text = event.get("text", "")
-		# Hot path: buffer the cumulative text + maybe-flush. The
-		# realtime publish still fires on every token so the customer's
-		# UI animates without delay; the DB write coalesces.
-		batcher.delta(text)
-		batcher.flush_if_due()
-		publish_to_user(user, {
-			"kind": "assistant:delta",
-			"conversation_id": conversation_id,
-			"message_id": assistant_msg_name,
-			"text": text,
-			"run_id": run_id,
-		})
-		return
-
-	if kind == "tool":
-		# Tool start/end events insert new rows. Drain pending assistant
-		# content first so the on-disk row order matches the realtime
-		# event order (assistant text the customer saw before this tool
-		# call is durable before the tool row appears).
-		batcher.flush()
-		phase = event.get("phase")
-		tool_call_id = event.get("tool_call_id")
-		tool_name = event.get("tool_name")
-		# jarvis__* tools execute through the backend call_tool path, which
-		# ALREADY persists a role=tool message carrying the full args + result
-		# (jarvis.api._persist_and_publish_tool_call). Persisting again here
-		# would double up every ERP tool call with an arg-less duplicate, so we
-		# only drive the live activity indicator for those and let the backend
-		# own the durable row. Built-in openclaw tools (browser/canvas/…) never
-		# hit call_tool, so we still persist those here.
-		is_jarvis = (tool_name or "").startswith("jarvis__")
-		if phase == "start":
-			if not is_jarvis:
-				from jarvis.chat.api import _next_seq
-				seq = _next_seq(conversation_id)
-				doc = frappe.get_doc({
-					"doctype": MSG,
-					"conversation": conversation_id,
-					"seq": seq,
-					"role": "tool",
-					"content": f"calling {tool_name}…",
-					"tool_name": tool_name,
-					"tool_status": "running",
-					"streaming": 1,
-				})
-				doc.insert(ignore_permissions=True)
-				frappe.db.commit()
-				tool_msg_by_call_id[tool_call_id] = doc.name
-			publish_to_user(user, {
-				"kind": "tool:start",
-				"conversation_id": conversation_id,
-				"message_id": tool_msg_by_call_id.get(tool_call_id),
-				"tool_name": tool_name,
-				"tool_call_id": tool_call_id,
-				"run_id": run_id,
-			})
-		elif phase == "end":
-			if is_jarvis:
-				# No worker-side row for jarvis tools; just close the live card.
-				publish_to_user(user, {
-					"kind": "tool:end",
-					"conversation_id": conversation_id,
-					"message_id": None,
-					"tool_name": tool_name,
-					"tool_call_id": tool_call_id,
-					"status": event.get("status"),
-					"run_id": run_id,
-				})
-				return
-			name = tool_msg_by_call_id.get(tool_call_id)
-			if not name:
-				# Orphan: openclaw emitted a tool 'end' event for a
-				# tool_call_id we never logged a 'start' for. Shouldn't
-				# happen, but the previous shape silently returned and
-				# left no operator trace - so a real recurring orphan
-				# (would point at an openclaw event-ordering regression)
-				# would be invisible. Log it as a warning so it shows
-				# up in Error Log triage.
-				frappe.log_error(
-					title="chat worker: orphan tool 'end' event",
-					message=(
-						f"conversation_id={conversation_id!r} "
-						f"run_id={run_id!r} "
-						f"tool_call_id={tool_call_id!r} "
-						f"tool_name={tool_name!r} "
-						f"event_status={event.get('status')!r}"
-					),
-				)
-				return
-			frappe.db.set_value(MSG, name, {
-				"tool_status": event.get("status") or "completed",
-				"streaming": 0,
-			})
-			frappe.db.commit()
-			publish_to_user(user, {
-				"kind": "tool:end",
-				"conversation_id": conversation_id,
-				"message_id": name,
-				"tool_name": tool_name,
-				"tool_call_id": tool_call_id,
-				"status": event.get("status"),
-				"run_id": run_id,
-			})

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -1,0 +1,147 @@
+"""Tests for jarvis.chat.turn_handler.handle_chat_send.
+
+Phase 1 of the chat-bridge refactor extracts the turn body out of
+``jarvis.chat.worker.run_agent_turn`` into
+``jarvis.chat.turn_handler.handle_chat_send``. The worker function is
+preserved as a thin shim that builds the payload dict and calls
+``handle_chat_send``. The behavioural coverage is owned by
+``test_chat_worker.py`` (which must keep passing unchanged); these
+tests pin only the payload-mapping contract between the shim and the
+handler so a future refactor cannot silently change the payload shape.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import openclaw_session_pool
+from jarvis.chat import turn_handler, worker
+from jarvis.tests.test_chat_api import (
+	TEST_USER,
+	_cleanup_user_conversations,
+	_ensure_test_user,
+)
+from jarvis.tests.test_chat_worker import (
+	_fake_event_stream,
+	_make_conversation_with_user_message,
+)
+
+MSG = "Jarvis Chat Message"
+
+
+class TestHandleChatSendAcceptsPayloadDict(FrappeTestCase):
+	"""``handle_chat_send`` is the new entry point. It must accept a
+	payload dict with conversation_id/message_id/run_id and drive a
+	turn end-to-end with the same effect as the RQ shim.
+	"""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message("hello")
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_payload_dict_drives_a_full_turn(self):
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "ok", "delta": "ok"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch(
+			"jarvis.chat.openclaw_session_pool.OpenclawSession.connect",
+			return_value=fake_sess,
+		):
+			with patch("jarvis.chat.worker.publish_to_user") as pub:
+				turn_handler.handle_chat_send({
+					"conversation_id": self.conv,
+					"message_id": self.user_msg,
+					"run_id": "r-payload",
+				})
+
+		# The assistant placeholder was created, content was persisted,
+		# streaming flipped off. (Behavioural depth lives in
+		# test_chat_worker; we only need a smoke here.)
+		rows = frappe.get_all(
+			MSG,
+			filters={"conversation": self.conv, "role": "assistant"},
+			fields=["content", "streaming"],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["content"], "ok")
+		self.assertEqual(rows[0]["streaming"], 0)
+
+		# run:start ... run:end bracket was published via the worker-
+		# module indirection, confirming the patch path still wins for
+		# code that now lives in turn_handler.
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("run:start", kinds)
+		self.assertIn("run:end", kinds)
+
+	def test_attachments_and_context_default_to_none(self):
+		"""The payload omits ``attachments`` and ``context``; the handler
+		must treat them as None and not blow up on missing keys."""
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch(
+			"jarvis.chat.openclaw_session_pool.OpenclawSession.connect",
+			return_value=fake_sess,
+		):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				turn_handler.handle_chat_send({
+					"conversation_id": self.conv,
+					"message_id": self.user_msg,
+					"run_id": "r-optional",
+				})
+		# Reached this line without KeyError: the payload contract for
+		# the optional fields holds.
+		self.assertTrue(True)
+
+
+class TestRunAgentTurnShimForwardsToHandleChatSend(FrappeTestCase):
+	"""The RQ entry point ``worker.run_agent_turn`` is now a thin shim
+	that constructs the payload dict and calls ``handle_chat_send``.
+	Pin the payload shape so a future refactor can't drop a field.
+	"""
+
+	def test_shim_builds_expected_payload(self):
+		with patch("jarvis.chat.worker.handle_chat_send") as fake:
+			worker.run_agent_turn(
+				"conv-1",
+				"msg-1",
+				"run-1",
+				attachments=[{"file_url": "/private/files/x.txt", "file_name": "x.txt"}],
+				context={"doctype": "Sales Invoice", "name": "SINV-0001"},
+			)
+
+		fake.assert_called_once()
+		(payload,), _ = fake.call_args
+		self.assertEqual(payload["conversation_id"], "conv-1")
+		self.assertEqual(payload["message_id"], "msg-1")
+		self.assertEqual(payload["run_id"], "run-1")
+		self.assertEqual(
+			payload["attachments"],
+			[{"file_url": "/private/files/x.txt", "file_name": "x.txt"}],
+		)
+		self.assertEqual(
+			payload["context"],
+			{"doctype": "Sales Invoice", "name": "SINV-0001"},
+		)
+
+	def test_shim_defaults_attachments_and_context_to_none(self):
+		with patch("jarvis.chat.worker.handle_chat_send") as fake:
+			worker.run_agent_turn("conv-2", "msg-2", "run-2")
+
+		fake.assert_called_once()
+		(payload,), _ = fake.call_args
+		self.assertIsNone(payload["attachments"])
+		self.assertIsNone(payload["context"])


### PR DESCRIPTION
## Summary

Phase 1 of the dual-mode chat refactor approved in `docs/superpowers/specs/2026-06-24-chat-bridge-architecture-design.md`. Pure code-organisation change. **No behavioural change.**

## What this does

- Moves the body of `jarvis.chat.worker.run_agent_turn` and every helper it owns into a new module `jarvis.chat.turn_handler`.
- Exposes a single caller-context-agnostic entry point: `handle_chat_send(payload: dict) -> None`.
- Slims `jarvis.chat.worker` to a thin RQ shim (`run_agent_turn` builds the payload from RQ args and calls `handle_chat_send`), plus re-exports of every helper so existing tests keep working unchanged.

## What this does NOT do

- No SPA changes.
- No Procfile changes.
- No `common_site_config.json` changes.
- No new behaviour. The RQ path is still the only path that exercises `handle_chat_send` today.

## Why

Phase 2 (separate PR) will add the Path B subscriber inside Frappe's Python realtime process, gated on `socketio_backend == "python"`. That subscriber will call the same `handle_chat_send` function. By landing the extract first, Phase 2 can be a small additive change rather than a duplicate-the-turn-logic change.

## File map

| File | Change |
|---|---|
| `jarvis/chat/turn_handler.py` (new) | +794 LOC. Contains `handle_chat_send` + every helper that used to live in worker.py (`_AssistantContentBatcher`, `_resolve_model_and_provider`, `_create_assistant_placeholder`, `_mark_errored`, `_handle_event`, `_handle_event_inner`, `_prepend_doc_context`, `_vision_enabled`, `_to_managed_attachments`, `_prepare_attachments`, plus their module-level constants). |
| `jarvis/chat/worker.py` | -728 / +78 LOC. Becomes a small RQ shim plus re-exports for backward compat. |
| `jarvis/tests/test_turn_handler.py` (new) | +new tests covering the payload → args mapping and the shim contract. |

## Verification

```
bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_chat_worker
→ 13/15 pass, 2 fail.
```

The two failing tests (`test_prepends_today_context_to_user_message`, `test_tool_events_persist_tool_message_rows`) are **pre-existing failures on origin/main**. Confirmed by stashing the refactor and running the same suite on bare main — reproduces the same two failures with identical assertions. Not caused by this PR.

```
bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_turn_handler
→ 4/4 pass.
```

## Next phases

- Phase 2 (separate PR): add `jarvis/realtime/handlers.py` + `chat/dispatch.py` + `send_message` branch. Path B subscriber active only when an operator sets `socketio_backend: "python"`. Dormant by default.
- Activation (operational, not a PR): operator flips `socketio_backend` in `common_site_config.json` on a chosen bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)