### PR TITLE
feat(chat): Path B dispatch + in-process subscriber (chat-bridge Phase 2)

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -389,20 +389,29 @@ def send_message(
 				}
 		except Exception:
 			pass
-	# Route to the ``long`` queue rather than ``default``: chat turns can run
-	# up to ``_AGENT_TURN_WORKER_TIMEOUT`` (720s, far above the 300s default
-	# cap), and ``default`` is shared with provisioning + OAuth-refresh jobs
+	# Dispatch the turn. On the default Node socketio backend we route to
+	# the ``long`` RQ queue (chat turns can run up to
+	# ``_AGENT_TURN_WORKER_TIMEOUT`` = 720s, far above the 300s default
+	# cap; ``default`` is shared with provisioning + OAuth-refresh jobs
 	# which would otherwise block interactive chat behind 30s+ pieces of
-	# infrastructure work. ``at_front=True`` pushes interactive chat to the
-	# head of the long queue so a scheduled long-running job (backup, big
-	# import) doesn't make a user wait for it to finish.
-	frappe.enqueue(
-		method="jarvis.chat.worker.run_agent_turn",
-		queue="long",
-		timeout=_AGENT_TURN_WORKER_TIMEOUT,
-		at_front=True,
-		**enqueue_kwargs,
-	)
+	# infrastructure work; ``at_front=True`` keeps interactive chat ahead
+	# of any scheduled long-running job). When the bench is on the Python
+	# socketio backend, dispatch goes through Redis pub/sub instead: an
+	# in-process subscriber inside Frappe's existing Python realtime
+	# process (see ``jarvis.realtime.handlers``) picks it up and runs the
+	# turn via gevent, removing the RQ-worker concurrency cap.
+	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
+		from jarvis.chat.dispatch import publish_chat_send
+
+		publish_chat_send(enqueue_kwargs)
+	else:
+		frappe.enqueue(
+			method="jarvis.chat.worker.run_agent_turn",
+			queue="long",
+			timeout=_AGENT_TURN_WORKER_TIMEOUT,
+			at_front=True,
+			**enqueue_kwargs,
+		)
 
 	return {"ok": True, "run_id": run_id, "message_id": msg_doc.name}
 
@@ -581,17 +590,26 @@ def retry_message(message: str) -> dict:
 	)
 
 	run_id = uuid.uuid4().hex[:12]
-	# Same routing as send_message: long queue + push to the front so the
-	# retry doesn't wait behind unrelated long-queue work.
-	frappe.enqueue(
-		method="jarvis.chat.worker.run_agent_turn",
-		queue="long",
-		timeout=_AGENT_TURN_WORKER_TIMEOUT,
-		at_front=True,
-		conversation_id=doc.conversation,
-		message_id=user_msg_id,
-		run_id=run_id,
-	)
+	# Same dispatch branch as send_message: Path B (Python socketio backend)
+	# publishes onto Redis pub/sub for the in-process realtime subscriber;
+	# default Node backend keeps using the long RQ queue with at_front=True.
+	payload = {
+		"conversation_id": doc.conversation,
+		"message_id": user_msg_id,
+		"run_id": run_id,
+	}
+	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
+		from jarvis.chat.dispatch import publish_chat_send
+
+		publish_chat_send(payload)
+	else:
+		frappe.enqueue(
+			method="jarvis.chat.worker.run_agent_turn",
+			queue="long",
+			timeout=_AGENT_TURN_WORKER_TIMEOUT,
+			at_front=True,
+			**payload,
+		)
 	return {"ok": True, "run_id": run_id}
 
 

--- a/jarvis/chat/dispatch.py
+++ b/jarvis/chat/dispatch.py
@@ -1,0 +1,44 @@
+"""Path B dispatch helper: publish a chat-send event onto Redis pub/sub.
+
+The default chat path (Node socketio backend, the standard Frappe Cloud setup)
+keeps using ``frappe.enqueue(...)`` to hand a turn off to an RQ worker; this
+helper is the alternate dispatch used when the bench has been switched to the
+Python socketio backend (``socketio_backend: "python"`` in
+``common_site_config.json``). In that mode an in-process subscriber inside
+Frappe's existing Python realtime process picks up the published payload and
+runs ``handle_chat_send`` directly via gevent (see
+``jarvis.realtime.handlers``).
+
+The two paths live side by side: ``jarvis.chat.api.send_message`` and
+``retry_message`` branch on the same config value to choose between them.
+This module is only loaded along the Path B branch, so on Node-backend
+benches it has no operational effect.
+
+Channel name is site-scoped: ``jarvis:chat:send:<site>``. Site scoping
+lets the realtime process (which serves all sites on the bench) keep one
+subscription per active site without cross-site bleed.
+"""
+from __future__ import annotations
+
+import json
+
+import frappe
+
+
+def _channel(site: str) -> str:
+	"""Single source of truth for the pub/sub channel name. Used by the
+	publisher here and by the subscriber in ``jarvis.realtime.handlers``;
+	any change must land in both call sites."""
+	return f"jarvis:chat:send:{site}"
+
+
+def publish_chat_send(payload: dict) -> None:
+	"""Publish a chat turn onto the site-scoped Path B channel.
+
+	``payload`` mirrors the kwargs ``jarvis.chat.worker.run_agent_turn``
+	accepts (conversation_id, message_id, run_id, attachments?, context?);
+	the subscriber rehydrates it and calls ``handle_chat_send`` with the
+	same dict, so the two dispatch paths produce identical turn behaviour.
+	"""
+	conn = frappe.cache().get_redis_connection()
+	conn.publish(_channel(frappe.local.site), json.dumps(payload))

--- a/jarvis/realtime/handlers.py
+++ b/jarvis/realtime/handlers.py
@@ -1,0 +1,166 @@
+"""Frappe realtime handlers for jarvis.
+
+Frappe's Python realtime process (frappe/realtime/server.py) discovers and
+imports ``<app>/realtime/handlers.py`` from every installed app at startup
+via ``discover_app_handlers()``. The realtime process is the **only** Frappe
+process that imports this module; gunicorn / RQ workers / the scheduler
+never reach this code.
+
+What this module does on import:
+
+- If the bench has ``socketio_backend: "python"`` set in
+  ``common_site_config.json``, spawn a long-lived gevent greenlet that
+  subscribes to ``jarvis:chat:send:<site>`` on Redis pub/sub and dispatches
+  each message to ``jarvis.chat.turn_handler.handle_chat_send`` in its own
+  greenlet (so many concurrent turns share the one realtime process). The
+  outer greenlet wraps the subscribe loop in a watchdog: any uncaught
+  exception inside the loop is logged and the loop is respawned after a
+  short backoff so a single bad turn does not silently disable chat for
+  the whole bench.
+
+- If the bench is on the default Node socketio backend (or any value other
+  than ``"python"``), this module is still imported but the subscriber is
+  **never spawned**. The Path B code path is dormant. Chat continues to go
+  through ``jarvis.chat.api.send_message -> frappe.enqueue ->
+  jarvis.chat.worker.run_agent_turn`` exactly as before. There is no
+  feature-flag toggle inside jarvis to flip; the ``socketio_backend``
+  config value is the single source of truth.
+
+The matching publisher lives at ``jarvis.chat.dispatch.publish_chat_send``;
+both sides use ``_channel(site)`` (private to dispatch.py) to keep the
+channel name in one place.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import frappe
+
+_SUBSCRIBER_SPAWNED = False
+
+# How long the watchdog sleeps before restarting the subscribe loop after an
+# unhandled exception. Short enough that chat recovers on the next turn, long
+# enough that a hard-failure tight loop does not spam logs.
+_WATCHDOG_BACKOFF_S = 5
+
+# Site-scoped channel format. Must match jarvis.chat.dispatch._channel.
+_CHANNEL_TEMPLATE = "jarvis:chat:send:{site}"
+
+
+def _python_backend_active() -> bool:
+	"""True iff the bench has opted into the Python socketio backend.
+
+	The realtime process is one-per-bench, so reading ``frappe.conf`` here
+	(populated from common_site_config.json) is the correct check; per-site
+	overrides do not apply at this layer.
+	"""
+	return (frappe.conf.get("socketio_backend") or "").strip().lower() == "python"
+
+
+def _site_name() -> str:
+	"""Best-effort current site name for channel scoping.
+
+	``frappe.local.site`` is the canonical answer once a request context is
+	open; at realtime startup we may be outside any site context, in which
+	case ``frappe.conf.get('default_site')`` is the closest equivalent.
+	Returning an empty string from here would publish/subscribe on
+	``jarvis:chat:send:`` (no site), which is wrong; raise instead so a
+	misconfigured bench fails loudly at boot.
+	"""
+	site = getattr(frappe.local, "site", None) or frappe.conf.get("default_site") or ""
+	if not site:
+		raise RuntimeError(
+			"jarvis.realtime.handlers: cannot determine site name for chat "
+			"subscriber channel; set default_site in common_site_config.json "
+			"or run under a site context"
+		)
+	return site
+
+
+def _run_one(raw: bytes | str) -> None:
+	"""Decode one pub/sub message and dispatch it to the shared turn
+	handler. Exceptions are logged and swallowed so one bad payload does
+	not take down the subscribe loop (a swallowed-here exception also
+	swallows itself out of the watchdog's reach, which is intentional;
+	the watchdog only kicks in on subscribe-side failures)."""
+	# Late import to avoid pulling the heavy chat-turn module into every
+	# realtime-process startup when the Python backend is not active.
+	from jarvis.chat.turn_handler import handle_chat_send
+
+	try:
+		body = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+		payload = json.loads(body)
+		if not isinstance(payload, dict):
+			raise ValueError(f"expected dict payload, got {type(payload).__name__}")
+		handle_chat_send(payload)
+	except Exception:
+		frappe.log_error(
+			title="jarvis chat subscriber: handler failed",
+			message=frappe.get_traceback(),
+		)
+
+
+def _subscribe_loop_once() -> None:
+	"""Open one Redis pub/sub subscription and dispatch every message
+	until the connection drops. The watchdog wrapping this function is
+	responsible for restarting it; this function itself never retries."""
+	import gevent
+
+	channel = _CHANNEL_TEMPLATE.format(site=_site_name())
+	conn = frappe.cache().get_redis_connection()
+	pubsub = conn.pubsub()
+	pubsub.subscribe(channel)
+	frappe.logger().info(f"jarvis chat subscriber: listening on {channel}")
+	for message in pubsub.listen():
+		if message.get("type") != "message":
+			continue
+		gevent.spawn(_run_one, message.get("data"))
+
+
+def _watchdog_loop() -> None:
+	"""Forever-loop wrapper: run the subscribe loop, and on any unhandled
+	exception log it and restart after a short backoff. The realtime
+	process supervisor will only restart THIS file's import, not the
+	module-level subscribe greenlet, so a crashed loop without this
+	watchdog would silently disable chat until the next bench restart."""
+	while True:
+		try:
+			_subscribe_loop_once()
+		except Exception:
+			frappe.log_error(
+				title="jarvis chat subscriber: subscribe loop crashed",
+				message=frappe.get_traceback(),
+			)
+		# Backoff before reconnect. Use time.sleep (gevent monkey-patches it)
+		# rather than gevent.sleep so this module stays import-time safe
+		# under both backends; the realtime process has monkey.patch_all()
+		# called before discover_app_handlers, so time.sleep yields the hub.
+		time.sleep(_WATCHDOG_BACKOFF_S)
+
+
+def maybe_start_chat_subscriber() -> bool:
+	"""Spawn the chat-send subscriber if the Python socketio backend is
+	active. Idempotent (a second call is a no-op). Returns True iff a new
+	greenlet was spawned by this call (mostly useful for tests; production
+	code calls it for the side effect)."""
+	global _SUBSCRIBER_SPAWNED
+	if _SUBSCRIBER_SPAWNED:
+		return False
+	if not _python_backend_active():
+		return False
+	import gevent
+
+	gevent.spawn(_watchdog_loop)
+	_SUBSCRIBER_SPAWNED = True
+	frappe.logger().info(
+		"jarvis chat subscriber: watchdog greenlet spawned "
+		"(socketio_backend=python)"
+	)
+	return True
+
+
+# Fire on module import. Frappe's realtime process imports this module via
+# discover_app_handlers() during boot, after gevent.monkey.patch_all() has
+# already run, so spawning a greenlet here is safe.
+maybe_start_chat_subscriber()

--- a/jarvis/tests/test_realtime_handlers.py
+++ b/jarvis/tests/test_realtime_handlers.py
@@ -1,0 +1,155 @@
+"""Tests for jarvis.realtime.handlers (Path B chat subscriber).
+
+The module's job is to spawn a gevent greenlet at import time iff
+``socketio_backend == "python"`` is set in common_site_config.json. The
+greenlet subscribes to ``jarvis:chat:send:<site>`` on Redis pub/sub and
+dispatches each message to ``jarvis.chat.turn_handler.handle_chat_send``
+in its own greenlet (so many concurrent turns share one realtime process).
+
+Tests cover:
+- spawning is gated correctly on the backend config
+- maybe_start_chat_subscriber is idempotent (a second call is a no-op)
+- the per-message dispatch decodes JSON, calls the shared handler, and
+  swallows exceptions instead of taking down the loop
+- the channel name format matches dispatch.publish_chat_send
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.realtime import handlers
+
+
+class _FakeConf:
+	"""Minimal stand-in for frappe.conf in tests. The handler only reads
+	via ``frappe.conf.get(key)``, so we just need a .get implementation."""
+
+	def __init__(self, mapping):
+		self._d = dict(mapping)
+
+	def get(self, key, default=None):
+		return self._d.get(key, default)
+
+
+class TestMaybeStartChatSubscriber(FrappeTestCase):
+	"""maybe_start_chat_subscriber is the gate; every other behaviour
+	flows from whether it spawns or not."""
+
+	def setUp(self):
+		# Each test exercises a fresh start state.
+		handlers._SUBSCRIBER_SPAWNED = False
+
+	def test_no_spawn_when_socketio_backend_unset(self):
+		with patch.object(frappe, "conf", _FakeConf({})), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertFalse(spawned)
+		spawn.assert_not_called()
+		self.assertFalse(handlers._SUBSCRIBER_SPAWNED)
+
+	def test_no_spawn_when_socketio_backend_is_node(self):
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "node"})), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertFalse(spawned)
+		spawn.assert_not_called()
+		self.assertFalse(handlers._SUBSCRIBER_SPAWNED)
+
+	def test_spawn_when_socketio_backend_is_python(self):
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertTrue(spawned)
+		spawn.assert_called_once_with(handlers._watchdog_loop)
+		self.assertTrue(handlers._SUBSCRIBER_SPAWNED)
+
+	def test_python_backend_match_is_case_insensitive(self):
+		"""Operators may type 'Python' or 'PYTHON' in the config; the
+		gate normalises before comparing."""
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "PYTHON"})), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertTrue(spawned)
+		spawn.assert_called_once()
+
+	def test_second_call_is_noop(self):
+		"""Idempotent: once the watchdog is running, a second call must
+		not spawn a duplicate greenlet (which would double-subscribe to
+		Redis and cause every chat turn to run twice)."""
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch("gevent.spawn") as spawn:
+			first = handlers.maybe_start_chat_subscriber()
+			second = handlers.maybe_start_chat_subscriber()
+		self.assertTrue(first)
+		self.assertFalse(second)
+		spawn.assert_called_once()
+
+
+class TestRunOne(FrappeTestCase):
+	"""_run_one is the per-message dispatcher: it decodes the JSON
+	payload, calls handle_chat_send, and swallows any exception so one
+	bad turn doesn't kill the loop."""
+
+	def test_dispatches_decoded_payload_to_handle_chat_send(self):
+		payload = {"conversation_id": "c1", "message_id": "m1", "run_id": "r1"}
+		raw = json.dumps(payload).encode("utf-8")
+		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
+			handlers._run_one(raw)
+		mock_handle.assert_called_once_with(payload)
+
+	def test_accepts_str_payload_as_well_as_bytes(self):
+		"""Redis usually returns bytes but some configurations decode
+		strings; accept both."""
+		payload = {"conversation_id": "c2", "message_id": "m2", "run_id": "r2"}
+		raw = json.dumps(payload)
+		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
+			handlers._run_one(raw)
+		mock_handle.assert_called_once_with(payload)
+
+	def test_swallows_handler_exception(self):
+		"""A crashed turn must not propagate out of _run_one - else the
+		watchdog would restart the loop and we'd lose pending messages.
+		The exception is logged via frappe.log_error instead."""
+		payload = {"conversation_id": "c", "message_id": "m", "run_id": "r"}
+		raw = json.dumps(payload).encode("utf-8")
+		with patch("jarvis.chat.turn_handler.handle_chat_send",
+		           side_effect=RuntimeError("boom")), \
+		     patch("frappe.log_error") as mock_log:
+			handlers._run_one(raw)  # must not raise
+		mock_log.assert_called_once()
+
+	def test_swallows_invalid_json(self):
+		"""A malformed payload (corrupt publish, schema drift) must not
+		take down the loop. Log and move on."""
+		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
+		     patch("frappe.log_error") as mock_log:
+			handlers._run_one(b"not-json")  # must not raise
+		mock_handle.assert_not_called()
+		mock_log.assert_called_once()
+
+	def test_swallows_non_dict_payload(self):
+		"""Defensive: a JSON value that isn't an object can't be a turn
+		payload. Reject + log."""
+		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
+		     patch("frappe.log_error") as mock_log:
+			handlers._run_one(b'["not", "a", "dict"]')
+		mock_handle.assert_not_called()
+		mock_log.assert_called_once()
+
+
+class TestChannelFormat(FrappeTestCase):
+	"""The publisher (jarvis.chat.dispatch) and subscriber (this module)
+	must agree on the channel name verbatim, else messages drop on the
+	floor with no error. Pin the format here."""
+
+	def test_subscriber_and_publisher_use_same_channel(self):
+		from jarvis.chat import dispatch
+
+		self.assertEqual(
+			handlers._CHANNEL_TEMPLATE.format(site="site.example.com"),
+			dispatch._channel("site.example.com"),
+		)


### PR DESCRIPTION
## Summary

Phase 2 of the dual-mode chat refactor approved in `docs/superpowers/specs/2026-06-24-chat-bridge-architecture-design.md`. **Dormant by default** — activates only when an operator sets `socketio_backend: "python"` in `common_site_config.json`.

## What this does

Default (Node socketio backend, every bench today):
- Chat path is **unchanged**. `send_message` / `retry_message` still enqueue onto the long RQ queue, RQ worker calls `worker.run_agent_turn` -> `handle_chat_send` (Phase 1).

When operator flips `socketio_backend: \"python\"` and restarts:
- `jarvis.chat.api.send_message` and `retry_message` branch: they publish onto Redis pub/sub channel `jarvis:chat:send:<site>` via the new `jarvis.chat.dispatch.publish_chat_send` helper, instead of `frappe.enqueue`.
- `jarvis.realtime.handlers` (loaded by Frappe's Python realtime process during `discover_app_handlers()`) spawns one watchdog gevent greenlet that subscribes to that channel and dispatches each message to `handle_chat_send` in its own greenlet.
- Many concurrent turns share one realtime process via cooperative I/O instead of one-job-per-RQ-worker.

## What this does NOT do

- No SPA changes.
- No Procfile changes.
- No `common_site_config.json` defaults shipped — the operator opts in.
- No changes to the RQ worker, the WS pool, the chat-turn body, `publish_realtime`, or any other downstream path.

## File map

| File | Change | LOC |
|---|---|---|
| `jarvis/chat/dispatch.py` (new) | `publish_chat_send(payload)` Redis publisher + site-scoped channel name | +44 |
| `jarvis/realtime/__init__.py` (new) | Empty package init | 0 |
| `jarvis/realtime/handlers.py` (new) | `maybe_start_chat_subscriber` (gated on `socketio_backend == \"python\"`), `_watchdog_loop`, `_subscribe_loop_once`, `_run_one`. Fires at module-import time. | +166 |
| `jarvis/chat/api.py` | `send_message` + `retry_message` branch on `socketio_backend`; existing RQ path preserved verbatim under \"node\" / unset | +42 / -24 |
| `jarvis/tests/test_realtime_handlers.py` (new) | 11 tests: gate states, idempotency, JSON + dict validation, exception swallowing, publisher/subscriber channel agreement | +155 |

## Verification

```
bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_realtime_handlers
-> Ran 11 tests in 0.068s, OK

bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_turn_handler
-> Ran 4 tests in 0.248s, OK

bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_chat_worker
-> 13/15 pass, 2 pre-existing failures (also fail on bare origin/main, confirmed by stash + check)
```

## Activation procedure (NOT part of this PR)

When ready to test Path B on a specific bench:
1. Set `\"socketio_backend\": \"python\"` in `common_site_config.json`.
2. `bench restart`.
3. The realtime process boots in Python mode; on import it logs `jarvis chat subscriber: watchdog greenlet spawned (socketio_backend=python)` and immediately `jarvis chat subscriber: listening on jarvis:chat:send:<site>`.
4. Send a chat. The RQ chat lane stays empty; the turn streams via the realtime process instead.

To roll back: revert the config + bench restart. No code change.

## Risks + mitigations

| Risk | Mitigation |
|---|---|
| Operator flips backend without restart | Subscriber only spawns at module import time (realtime process boot). A flip-without-restart leaves Path B inactive but the dispatch branch in api.py will publish onto a channel no one's listening to — messages drop on the floor. We log a clear \"subscriber spawned\" line on successful boot so ops can verify before sending traffic. |
| Subscribe loop crashes silently | Watchdog respawn after a 5s backoff. Per-message exceptions are swallowed at `_run_one` so they don't escalate to the watchdog and trigger an unnecessary reconnect. |
| FC denies the `socketio_backend` flip | Path B stays dormant forever. Zero behavioural regression for any current bench. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)