### PR TITLE
feat(admin-url): fall back to site config when Jarvis Settings URL is blank

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -119,7 +119,13 @@ from jarvis.hooks import DEFAULT_ADMIN_URL  # noqa: E402  - used by _admin_url()
 
 
 def _admin_url(settings) -> str:
-	return ((settings.jarvis_admin_url or "").rstrip("/")) or DEFAULT_ADMIN_URL
+	# Per-customer override wins; otherwise fall through to the bench-wide
+	# default - site/common config ``jarvis_admin_url`` then the hardcoded
+	# fallback - resolved FRESH via get_default_admin_url() so a config value
+	# added after worker start is honored without a restart (the module-level
+	# DEFAULT_ADMIN_URL import binds once and would miss late config changes).
+	from jarvis.hooks import get_default_admin_url
+	return ((settings.jarvis_admin_url or "").rstrip("/")) or get_default_admin_url().rstrip("/")
 
 
 def signup(email: str, company_name: str, plan: str, coupon: str | None = None) -> dict:

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -14,23 +14,26 @@ from jarvis.exceptions import (
 
 
 def _require_admin_url() -> None:
-	"""Raise ValidationError if Jarvis Settings.jarvis_admin_url is blank.
+	"""Raise ValidationError if no admin URL is configured deliberately.
 
-	dev_onboard and start_signup both depend on this field being set
-	deliberately. The bench's admin_client falls back to the
-	DEFAULT_ADMIN_URL constant when the override is empty, which on a
-	multi-site bench may resolve to the wrong control plane and silently
-	land the wrong tenancy. Fail fast here with a message the operator
-	can act on (open Jarvis Settings, paste the URL) instead of letting
-	the request reach admin under the default.
+	dev_onboard and start_signup must target a deliberately-chosen control
+	plane. The admin URL resolves (admin_client._admin_url ->
+	hooks.get_default_admin_url) in this order: (1) Jarvis Settings.
+	jarvis_admin_url per-customer override, (2) ``jarvis_admin_url`` in
+	site_config / common_site_config (via frappe.conf), (3) the hardcoded
+	fallback for fresh installs. Silently falling through to (3) on a
+	multi-site bench may land the wrong tenancy, so require (1) or (2) to be
+	set - only (3)-alone is the fail-fast case. (1) wins when both are set.
 	"""
-	url = (
-		frappe.db.get_single_value("Jarvis Settings", "jarvis_admin_url") or ""
-	).strip()
-	if not url:
+	configured = (
+		(frappe.db.get_single_value("Jarvis Settings", "jarvis_admin_url") or "").strip()
+		or (frappe.conf.get("jarvis_admin_url") or "").strip()
+	)
+	if not configured:
 		raise frappe.ValidationError(
-			"Jarvis Settings -> Jarvis Admin URL is blank. "
-			"Set it before continuing onboarding."
+			"No Jarvis Admin URL configured. Set Jarvis Settings -> Jarvis "
+			"Admin URL, or 'jarvis_admin_url' in site_config.json, before "
+			"continuing onboarding."
 		)
 
 

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -914,3 +914,28 @@ class TestOAuthBearer(FrappeTestCase):
 		self.assertEqual(
 			frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY)["access_token"], "B")
 		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
+
+
+class TestAdminUrlResolution(FrappeTestCase):
+	"""_admin_url resolution order: Jarvis Settings override -> site/common
+	config (frappe.conf jarvis_admin_url) -> hardcoded fallback, all resolved
+	FRESH per call so a config value added after worker start is honored."""
+
+	def test_settings_override_wins_over_config(self):
+		s = MagicMock()
+		s.jarvis_admin_url = "https://override.example.com/"
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": "https://conf.example.com"}):
+			self.assertEqual(admin_client._admin_url(s), "https://override.example.com")
+
+	def test_falls_back_to_config_when_field_blank(self):
+		s = MagicMock()
+		s.jarvis_admin_url = ""
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": "https://conf.example.com/"}):
+			self.assertEqual(admin_client._admin_url(s), "https://conf.example.com")
+
+	def test_falls_back_to_hardcoded_when_field_and_config_blank(self):
+		from jarvis.hooks import _DEFAULT_ADMIN_URL_FALLBACK
+		s = MagicMock()
+		s.jarvis_admin_url = ""
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}):
+			self.assertEqual(admin_client._admin_url(s), _DEFAULT_ADMIN_URL_FALLBACK)

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -102,10 +102,26 @@ class TestSyncConnection(FrappeTestCase):
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
 		frappe.db.commit()
-		with patch("jarvis.onboarding.admin_client.dev_signup") as mock_signup:
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}), \
+			 patch("jarvis.onboarding.admin_client.dev_signup") as mock_signup:
 			with self.assertRaises(frappe.ValidationError):
 				onboarding.dev_onboard("e2@x.com", "Co", "Annual Plan")
 			mock_signup.assert_not_called()
+
+	def test_dev_onboard_uses_config_admin_url_when_field_blank(self):
+		"""Blank Jarvis Settings.jarvis_admin_url but site/common config
+		provides jarvis_admin_url: the guard treats config as a deliberate
+		source, so onboarding proceeds instead of failing fast."""
+		_set_token("")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", 1)
+		frappe.db.commit()
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": "http://conf-admin.local"}), \
+			 patch("jarvis.onboarding.admin_client.dev_signup",
+				   return_value={"api_key": "k", "api_secret": "s",
+								 "agent_url": "ws://h:1", "agent_token": "t"}) as mock_signup:
+			onboarding.dev_onboard("e5@x.com", "Co", "Annual Plan")
+			mock_signup.assert_called_once()
 
 	def test_dev_onboard_preserves_existing_admin_url(self):
 		"""Pre-set jarvis_admin_url stays untouched - dev_onboard never
@@ -131,7 +147,8 @@ class TestSyncConnection(FrappeTestCase):
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
 		frappe.db.commit()
-		with patch("jarvis.onboarding.admin_client.signup") as mock_signup:
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}), \
+			 patch("jarvis.onboarding.admin_client.signup") as mock_signup:
 			with self.assertRaises(frappe.ValidationError):
 				onboarding.start_signup("e4@x.com", "Co", "Annual Plan")
 			mock_signup.assert_not_called()
@@ -336,7 +353,7 @@ class TestSignupEmailVerification(FrappeTestCase):
 			"Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "",
 		)
 		frappe.db.commit()
-		with patch(
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}), patch(
 			"jarvis.onboarding.admin_client.get_signup_payment_state",
 		) as mock_call:
 			with self.assertRaises(frappe.ValidationError):


### PR DESCRIPTION
The admin-URL guard (_require_admin_url) and resolver (_admin_url) read the URL only from Jarvis Settings.jarvis_admin_url, so onboarding failed even when jarvis_admin_url was set in site_config / common_site_config (which the operator may prefer - declarative + survives the migration patches that wipe the DB field).

- _require_admin_url: pass when EITHER Jarvis Settings.jarvis_admin_url OR frappe.conf['jarvis_admin_url'] is set; fail-fast only when neither is (would otherwise silently use the hardcoded DEFAULT_ADMIN_URL).
- _admin_url: resolve via hooks.get_default_admin_url() FRESH (Settings -> conf -> hardcoded) instead of the frozen DEFAULT_ADMIN_URL import, so a config value added after worker start is honored without a restart.

Resolution order: Jarvis Settings override -> site/common config -> hardcoded. Tests: 3 _admin_url resolution units; onboarding throw-tests now clear conf too; new test for onboarding proceeding off the config URL.