### PR TITLE
Feat/tool layer extensions

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -6,6 +6,7 @@ from jarvis._http import validate_bearer as _validate_bearer  # noqa: F401 (kept
 from jarvis._plugin_auth import PluginAuthError, validate_plugin_request
 from jarvis.exceptions import InvalidArgumentError, JarvisError
 from jarvis.tools.registry import dispatch
+from jarvis import audit
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -362,6 +363,43 @@ def _parse_args(args: dict | str | None) -> dict:
 	return args
 
 
+# Mutating tools: audited on every call, and the only tools that accept
+# ``preview`` (a dry-run executed in a rolled-back savepoint).
+_WRITE_TOOLS = frozenset({
+	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
+	"delete_doc", "run_method",
+	"send_email", "add_comment", "update_comment", "share_doc", "unshare_doc",
+	"assign_to", "unassign_from", "add_tag", "remove_tag",
+	"follow_document", "unfollow_document", "attach_to_doc",
+	"create_dashboard_chart", "create_dashboard",
+})
+_PREVIEWABLE = frozenset({
+	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
+	"delete_doc", "run_method",
+})
+
+
+def _run_preview(tool: str, args: dict) -> dict:
+	"""Dispatch a write tool inside a savepoint and roll it back, so the
+	caller sees what WOULD happen (validations run, naming + fetched fields
+	resolved) with nothing committed. DB effects are fully sandboxed; external
+	side effects in on_submit/on_cancel (emails, webhooks) are NOT - the result
+	note says so."""
+	sp = "jarvis_preview"
+	frappe.db.savepoint(sp)
+	try:
+		would = dispatch(tool, args)
+	finally:
+		frappe.db.rollback(save_point=sp)
+	return {
+		"preview": True,
+		"would": would,
+		"note": ("Validated in a rolled-back savepoint; nothing was committed. "
+				 "External side effects (emails/webhooks in on_submit / "
+				 "on_cancel) are not sandboxed by preview."),
+	}
+
+
 def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 	"""Parse args + dispatch + wrap in the bench's standard envelope.
 
@@ -385,12 +423,26 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 	into one to match the reviewer's "native handler" pattern note
 	from the 2026-06-16 punch list.
 	"""
+	args = None
+	is_write = tool in _WRITE_TOOLS
 	try:
 		args = _parse_args(raw_args)
+		preview = bool(args.pop("preview", False))
+		if preview:
+			if tool not in _PREVIEWABLE:
+				return _error("InvalidArgumentError",
+							  f"preview is not supported for {tool}")
+			return {"ok": True, "data": _run_preview(tool, args)}
 		data = dispatch(tool, args)
 	except JarvisError as e:
+		if is_write:
+			audit.record(tool=tool, args=args, ok=False,
+						 error_code=type(e).__name__, error_message=str(e))
 		return _error(type(e).__name__, str(e))
 	except frappe.PermissionError as e:
+		if is_write:
+			audit.record(tool=tool, args=args, ok=False,
+						 error_code="PermissionDeniedError", error_message=str(e))
 		return _error("PermissionDeniedError", str(e) or "permission denied")
 	except (frappe.ValidationError, frappe.DuplicateEntryError) as e:
 		# Bad-input errors a tool surfaces from doc.insert()/get_doc/link
@@ -401,7 +453,12 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 		# bug, so translate to the envelope instead of leaking Frappe's
 		# native 500/404. The message carries the specifics; the code stays
 		# in the known JarvisError set the bench client branches on.
+		if is_write:
+			audit.record(tool=tool, args=args, ok=False,
+						 error_code="InvalidArgumentError", error_message=str(e))
 		return _error("InvalidArgumentError", str(e) or type(e).__name__)
+	if is_write:
+		audit.record(tool=tool, args=args, ok=True, result=data)
 	return {"ok": True, "data": data}
 
 

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -364,7 +364,7 @@ def _parse_args(args: dict | str | None) -> dict:
 
 
 # Mutating tools: audited on every call, and the only tools that accept
-# ``preview`` (a dry-run executed in a rolled-back savepoint).
+# ``preview`` (a dry-run with every DB write rolled back).
 _WRITE_TOOLS = frozenset({
 	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
 	"delete_doc", "run_method",
@@ -379,24 +379,46 @@ _PREVIEWABLE = frozenset({
 })
 
 
+def _as_bool(value) -> bool:
+	"""Coerce an agent-supplied flag to bool. A JSON client may send the
+	string ``"false"``/``"0"``; ``bool("false")`` is True, so treat the common
+	falsy strings as False rather than trusting plain ``bool()``."""
+	if isinstance(value, str):
+		return value.strip().lower() in ("1", "true", "yes", "on")
+	return bool(value)
+
+
 def _run_preview(tool: str, args: dict) -> dict:
-	"""Dispatch a write tool inside a savepoint and roll it back, so the
-	caller sees what WOULD happen (validations run, naming + fetched fields
-	resolved) with nothing committed. DB effects are fully sandboxed; external
-	side effects in on_submit/on_cancel (emails, webhooks) are NOT - the result
-	note says so."""
-	sp = "jarvis_preview"
-	frappe.db.savepoint(sp)
+	"""Dispatch a write tool with all DB effects sandboxed, so the caller sees
+	what WOULD happen (validations run, naming + fetched fields resolved) with
+	nothing committed.
+
+	Commits are neutralized for the duration, then the work is rolled back to a
+	savepoint - so even a tool (or a ``run_method`` target) that calls
+	``frappe.db.commit()`` internally cannot persist. The neutralization is what
+	makes the savepoint safe: a real COMMIT would release all savepoints in
+	MariaDB, both persisting the write and breaking the rollback; with commit a
+	no-op the savepoint survives and the rollback is surgical (it does not touch
+	work done before the preview). The savepoint name is unique per call so
+	nested/concurrent previews can't collide. External side effects
+	(emails/webhooks fired from on_submit / on_cancel) are NOT sandboxed.
+	"""
+	db = frappe.db
+	real_commit = db.commit
+	db.commit = lambda *a, **k: None  # neutralize commits so the savepoint survives
+	sp = "jp_" + frappe.generate_hash(length=10)
+	db.savepoint(sp)
 	try:
 		would = dispatch(tool, args)
 	finally:
-		frappe.db.rollback(save_point=sp)
+		db.commit = real_commit
+		db.rollback(save_point=sp)  # undo everything the dry-run wrote
 	return {
 		"preview": True,
 		"would": would,
-		"note": ("Validated in a rolled-back savepoint; nothing was committed. "
-				 "External side effects (emails/webhooks in on_submit / "
-				 "on_cancel) are not sandboxed by preview."),
+		"note": ("Validated with all DB writes rolled back; nothing was "
+				 "committed. External side effects (emails/webhooks in "
+				 "on_submit / on_cancel) are not sandboxed by preview."),
 	}
 
 
@@ -414,8 +436,8 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 	``frappe.has_permission`` (rather than raising PermissionDeniedError
 	itself) still translates to the bench's envelope rather than
 	Frappe's native 403 page. Anything else (programming errors, real
-	exceptions) propagates to Frappe's native handler so a 500 surfaces
-	at the seam where the bug actually lives.
+	exceptions) is audited (for write tools) and re-raised to Frappe's
+	native handler so a 500 surfaces at the seam where the bug lives.
 
 	Replaces the old _dispatch_safe + _parse_args dance: parse_args
 	used to mix "dict-or-error-envelope" returns with this function's
@@ -423,16 +445,31 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 	into one to match the reviewer's "native handler" pattern note
 	from the 2026-06-16 punch list.
 	"""
-	args = None
 	is_write = tool in _WRITE_TOOLS
 	try:
 		args = _parse_args(raw_args)
-		preview = bool(args.pop("preview", False))
-		if preview:
-			if tool not in _PREVIEWABLE:
-				return _error("InvalidArgumentError",
-							  f"preview is not supported for {tool}")
+	except JarvisError as e:
+		return _error(type(e).__name__, str(e))
+
+	# ``preview`` is read, not popped: dispatch() filters args to the tool's
+	# signature so the flag never reaches the tool anyway, and leaving ``args``
+	# unmutated keeps the shared dict the session-persistence path holds intact.
+	if isinstance(args, dict) and _as_bool(args.get("preview")):
+		if tool not in _PREVIEWABLE:
+			return _error("InvalidArgumentError",
+						  f"preview is not supported for {tool}")
+		# A dry-run: surface its validation errors, but never audit - nothing
+		# is committed, so there is no write to record.
+		try:
 			return {"ok": True, "data": _run_preview(tool, args)}
+		except JarvisError as e:
+			return _error(type(e).__name__, str(e))
+		except frappe.PermissionError as e:
+			return _error("PermissionDeniedError", str(e) or "permission denied")
+		except (frappe.ValidationError, frappe.DuplicateEntryError) as e:
+			return _error("InvalidArgumentError", str(e) or type(e).__name__)
+
+	try:
 		data = dispatch(tool, args)
 	except JarvisError as e:
 		if is_write:
@@ -457,6 +494,14 @@ def _run_tool(tool: str, raw_args: dict | str | None) -> dict:
 			audit.record(tool=tool, args=args, ok=False,
 						 error_code="InvalidArgumentError", error_message=str(e))
 		return _error("InvalidArgumentError", str(e) or type(e).__name__)
+	except Exception as e:
+		# Unexpected error (a real bug): audit the attempt for write tools so
+		# the trail is complete even for a partial mutation, then re-raise so
+		# Frappe's native 500 still surfaces at the seam.
+		if is_write:
+			audit.record(tool=tool, args=args, ok=False,
+						 error_code=type(e).__name__, error_message=str(e))
+		raise
 	if is_write:
 		audit.record(tool=tool, args=args, ok=True, result=data)
 	return {"ok": True, "data": data}

--- a/jarvis/audit.py
+++ b/jarvis/audit.py
@@ -1,0 +1,74 @@
+"""Structured audit logging for mutating tool calls.
+
+Every write tool dispatched through ``jarvis.api._run_tool`` is logged here
+- who / what / when / result - to the ``jarvis.tool_audit`` logger. We use a
+dedicated structured logger rather than a DocType insert on purpose: it is
+transaction-safe (it never entangles or partially commits the tool's own DB
+transaction, and a failed write can't leave a dangling audit row), and it
+never raises into the tool path. A queryable DocType sink can be layered on
+later by swapping the body of ``record`` for a doc insert.
+"""
+import json
+
+import frappe
+
+# Secret-shaped keys scrubbed from the logged args summary.
+_SECRET_KEYS = {
+    "password", "new_password", "pwd", "api_key", "api_secret", "secret",
+    "token", "access_token", "refresh_token", "key",
+}
+_MAX_ARGS_CHARS = 2000
+
+
+def record(*, tool: str, args: dict | None, ok: bool,
+           error_code: str | None = None, error_message: str | None = None,
+           result=None) -> None:
+    """Emit one structured audit line for a mutating tool call.
+
+    Best-effort: never raises (audit must not break or fail the tool)."""
+    try:
+        doctype, name = _ref(args, result)
+        entry = {
+            "ts": frappe.utils.now(),
+            "user": getattr(frappe.session, "user", None),
+            "tool": tool,
+            "doctype": doctype,
+            "name": name,
+            "status": "ok" if ok else "error",
+            "error_code": error_code,
+            "error_message": (error_message or "")[:500] or None,
+            "args": _scrub(args),
+        }
+        frappe.logger("jarvis.tool_audit").info(json.dumps(entry, default=str))
+    except Exception:
+        try:
+            frappe.logger("jarvis.tool_audit").error("audit record failed")
+        except Exception:
+            pass
+
+
+def _ref(args, result):
+    a = args or {}
+    doctype = a.get("doctype")
+    name = a.get("name") or a.get("docname")
+    if isinstance(result, dict):
+        doctype = doctype or result.get("doctype")
+        name = name or result.get("name")
+    return doctype, name
+
+
+def _scrub(args):
+    """Redact secret-shaped values; cap total size so a giant payload can't
+    bloat the log."""
+    if not isinstance(args, dict):
+        return args
+    out = {}
+    for k, v in args.items():
+        if k.lower() in _SECRET_KEYS:
+            out[k] = "[REDACTED]"
+        elif isinstance(v, dict):
+            out[k] = _scrub(v)
+        else:
+            out[k] = v
+    rendered = json.dumps(out, default=str)
+    return out if len(rendered) <= _MAX_ARGS_CHARS else {"_truncated": rendered[:_MAX_ARGS_CHARS]}

--- a/jarvis/audit.py
+++ b/jarvis/audit.py
@@ -27,17 +27,22 @@ def record(*, tool: str, args: dict | None, ok: bool,
 
     Best-effort: never raises (audit must not break or fail the tool)."""
     try:
-        doctype, name = _ref(args, result)
+        doctype, name, method = _ref(args, result)
+        scrubbed = _scrub(args)
+        rendered = json.dumps(scrubbed, default=str)
+        if len(rendered) > _MAX_ARGS_CHARS:
+            scrubbed = {"_truncated": rendered[:_MAX_ARGS_CHARS]}
         entry = {
             "ts": frappe.utils.now(),
             "user": getattr(frappe.session, "user", None),
             "tool": tool,
             "doctype": doctype,
             "name": name,
+            "method": method,
             "status": "ok" if ok else "error",
             "error_code": error_code,
             "error_message": (error_message or "")[:500] or None,
-            "args": _scrub(args),
+            "args": scrubbed,
         }
         frappe.logger("jarvis.tool_audit").info(json.dumps(entry, default=str))
     except Exception:
@@ -48,27 +53,28 @@ def record(*, tool: str, args: dict | None, ok: bool,
 
 
 def _ref(args, result):
-    a = args or {}
-    doctype = a.get("doctype")
-    name = a.get("name") or a.get("docname")
+    """Best-effort (doctype, name, method) for the audited target. Covers the
+    common arg names across the write tools - doctype/name plus attach_to_doc's
+    target_doctype/target_name and run_method's method - and falls back to the
+    returned doc when the args don't name it."""
+    a = args if isinstance(args, dict) else {}
+    doctype = a.get("doctype") or a.get("target_doctype")
+    name = a.get("name") or a.get("docname") or a.get("target_name")
+    method = a.get("method")
     if isinstance(result, dict):
         doctype = doctype or result.get("doctype")
         name = name or result.get("name")
-    return doctype, name
+    return doctype, name, method
 
 
-def _scrub(args):
-    """Redact secret-shaped values; cap total size so a giant payload can't
-    bloat the log."""
-    if not isinstance(args, dict):
-        return args
-    out = {}
-    for k, v in args.items():
-        if k.lower() in _SECRET_KEYS:
-            out[k] = "[REDACTED]"
-        elif isinstance(v, dict):
-            out[k] = _scrub(v)
-        else:
-            out[k] = v
-    rendered = json.dumps(out, default=str)
-    return out if len(rendered) <= _MAX_ARGS_CHARS else {"_truncated": rendered[:_MAX_ARGS_CHARS]}
+def _scrub(value):
+    """Recursively redact secret-shaped keys in dicts, including dicts nested in
+    lists (e.g. child-table rows like values={"users":[{"password":...}]}).
+    Non-collection values pass through. Size-capping is applied once by the
+    caller after the whole structure is scrubbed."""
+    if isinstance(value, dict):
+        return {k: ("[REDACTED]" if k.lower() in _SECRET_KEYS else _scrub(v))
+                for k, v in value.items()}
+    if isinstance(value, list):
+        return [_scrub(item) for item in value]
+    return value

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -180,3 +180,16 @@ scheduler_events = {
 export_python_type_annotations = True
 require_type_annotated_api_methods = True
 
+# ---------------------------------------------------------------------------
+# Schema-cache invalidation
+# ---------------------------------------------------------------------------
+# get_schema caches each DocType's schema in Redis with a short TTL. Bust that
+# cache the moment a schema-defining doc changes, so the agent never builds a
+# write off a stale field list inside the TTL window (a Custom Field added via
+# Customize Form must show up immediately, not 5 minutes later).
+_CLEAR_SCHEMA_CACHE = "jarvis.tools.get_schema.clear_schema_cache"
+doc_events = {
+	dt: {"on_update": _CLEAR_SCHEMA_CACHE, "on_trash": _CLEAR_SCHEMA_CACHE}
+	for dt in ("DocType", "Custom Field", "Property Setter", "Workflow")
+}
+

--- a/jarvis/tests/test_get_schema_meta_cache.py
+++ b/jarvis/tests/test_get_schema_meta_cache.py
@@ -37,3 +37,17 @@ class TestGetSchemaMetaCache(FrappeTestCase):
             self.assertEqual(build.call_count, 0)
             gs.get_schema("ToDo", refresh=True)   # refresh -> rebuild
             self.assertEqual(build.call_count, 1)
+
+    def test_stringified_false_is_treated_as_slim(self):
+        for k in ("jarvis_schema:ToDo:0", "jarvis_schema:ToDo:1"):
+            frappe.cache().delete_value(k)
+        gs.get_schema("ToDo", verbose="false")  # truthy string must NOT enable verbose
+        self.assertIsNotNone(frappe.cache().get_value("jarvis_schema:ToDo:0"))
+        self.assertIsNone(frappe.cache().get_value("jarvis_schema:ToDo:1"))
+
+    def test_refresh_busts_both_variants(self):
+        gs.get_schema("ToDo", verbose=False)  # caches :0
+        gs.get_schema("ToDo", verbose=True)   # caches :1
+        self.assertIsNotNone(frappe.cache().get_value("jarvis_schema:ToDo:1"))
+        gs.get_schema("ToDo", refresh=True)   # slim refresh must still bust :1
+        self.assertIsNone(frappe.cache().get_value("jarvis_schema:ToDo:1"))

--- a/jarvis/tests/test_get_schema_meta_cache.py
+++ b/jarvis/tests/test_get_schema_meta_cache.py
@@ -1,0 +1,39 @@
+"""Tests for the get_schema additions: doctype-level metadata
+(is_submittable / autoname / workflow) and the Redis TTL cache + refresh."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools import get_schema as gs
+
+
+class TestGetSchemaMetaCache(FrappeTestCase):
+    def setUp(self):
+        for k in ("jarvis_schema:ToDo:0", "jarvis_schema:Journal Entry:0"):
+            frappe.cache().delete_value(k)
+
+    def test_includes_doctype_metadata_keys(self):
+        s = gs.get_schema("ToDo")
+        for k in ("doctype", "is_submittable", "autoname", "naming_rule",
+                  "workflow", "fields"):
+            self.assertIn(k, s)
+        self.assertIsInstance(s["fields"], list)
+
+    def test_submittable_flag(self):
+        self.assertTrue(gs.get_schema("Journal Entry")["is_submittable"])
+        self.assertFalse(gs.get_schema("ToDo")["is_submittable"])
+
+    def test_result_is_cached(self):
+        gs.get_schema("ToDo")
+        self.assertIsNotNone(frappe.cache().get_value("jarvis_schema:ToDo:0"))
+
+    def test_cache_hit_skips_rebuild_and_refresh_busts(self):
+        gs.get_schema("ToDo")  # primes the cache
+        with patch("jarvis.tools.get_schema._build_schema",
+                   wraps=gs._build_schema) as build:
+            gs.get_schema("ToDo")                 # cache hit -> no rebuild
+            self.assertEqual(build.call_count, 0)
+            gs.get_schema("ToDo", refresh=True)   # refresh -> rebuild
+            self.assertEqual(build.call_count, 1)

--- a/jarvis/tests/test_run_method.py
+++ b/jarvis/tests/test_run_method.py
@@ -1,0 +1,45 @@
+"""Tests for jarvis.tools.run_method - whitelist-only dispatch, optional
+config allowlist, and input/permission errors. Runs against real Frappe
+(the whitelist gate is the security boundary; exercising it for real is
+more meaningful than mocking it)."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.run_method import run_method
+
+
+class TestRunMethod(FrappeTestCase):
+    def test_calls_whitelisted_method(self):
+        self.assertEqual(run_method("frappe.ping"), "pong")
+
+    def test_blocks_resolvable_but_non_whitelisted_method(self):
+        # frappe.get_all / frappe.delete_doc resolve but are NOT @whitelist'd.
+        with self.assertRaises(PermissionDeniedError):
+            run_method("frappe.get_all", {"doctype": "ToDo"})
+        with self.assertRaises(PermissionDeniedError):
+            run_method("frappe.delete_doc", {"doctype": "ToDo", "name": "x"})
+
+    def test_unknown_method_raises(self):
+        with self.assertRaises(InvalidArgumentError):
+            run_method("nope.not.a.real.method")
+
+    def test_blank_method_raises(self):
+        with self.assertRaises(InvalidArgumentError):
+            run_method("")
+
+    def test_non_dict_args_raises(self):
+        with self.assertRaises(InvalidArgumentError):
+            run_method("frappe.ping", args="not-a-dict")
+
+    def test_allowlist_blocks_unmatched_method(self):
+        with patch.dict(frappe.local.conf, {"jarvis_run_method_allowlist": ["erpnext.*"]}):
+            with self.assertRaises(PermissionDeniedError):
+                run_method("frappe.ping")  # whitelisted, but not in the allowlist
+
+    def test_allowlist_permits_matched_method(self):
+        with patch.dict(frappe.local.conf, {"jarvis_run_method_allowlist": ["frappe.*"]}):
+            self.assertEqual(run_method("frappe.ping"), "pong")

--- a/jarvis/tests/test_run_method.py
+++ b/jarvis/tests/test_run_method.py
@@ -43,3 +43,14 @@ class TestRunMethod(FrappeTestCase):
     def test_allowlist_permits_matched_method(self):
         with patch.dict(frappe.local.conf, {"jarvis_run_method_allowlist": ["frappe.*"]}):
             self.assertEqual(run_method("frappe.ping"), "pong")
+
+    def test_empty_allowlist_blocks_everything(self):
+        # [] is "block all", not "no restriction" (the falsy-empty pitfall).
+        with patch.dict(frappe.local.conf, {"jarvis_run_method_allowlist": []}):
+            with self.assertRaises(PermissionDeniedError):
+                run_method("frappe.ping")
+
+    def test_unknown_arg_is_rejected(self):
+        # A mistyped/extra arg must error, not be silently dropped by frappe.call.
+        with self.assertRaises(InvalidArgumentError):
+            run_method("frappe.ping", {"bogus_arg": 1})

--- a/jarvis/tests/test_tool_preview_audit.py
+++ b/jarvis/tests/test_tool_preview_audit.py
@@ -1,0 +1,54 @@
+"""Tests for the api._run_tool cross-cutting additions: preview (a write
+executed in a rolled-back savepoint, nothing committed) and write auditing
+(every mutating tool is audited; reads are not)."""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+
+
+class TestPreview(FrappeTestCase):
+    def test_preview_create_does_not_persist(self):
+        desc = "jarvis-test-preview-no-persist-001"
+        r = api._run_tool("create_doc", {
+            "doctype": "ToDo", "values": {"description": desc}, "preview": True,
+        })
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["data"]["preview"])
+        self.assertIn("would", r["data"])
+        # savepoint was rolled back -> nothing committed
+        self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+
+    def test_preview_rejected_for_non_previewable_tool(self):
+        r = api._run_tool("get_list", {"doctype": "ToDo", "preview": True})
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+
+
+class TestWriteAudit(FrappeTestCase):
+    def test_successful_write_is_audited(self):
+        with patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("create_doc", {
+                "doctype": "ToDo", "values": {"description": "jarvis-test-audit-ok"},
+            })
+        self.assertTrue(r["ok"])
+        self.assertTrue(rec.called)
+        self.assertEqual(rec.call_args.kwargs["tool"], "create_doc")
+        self.assertTrue(rec.call_args.kwargs["ok"])
+
+    def test_failed_write_is_audited_as_error(self):
+        with patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("create_doc", {
+                "doctype": "No Such DocType ZZZ", "values": {},
+            })
+        self.assertFalse(r["ok"])
+        self.assertTrue(rec.called)
+        self.assertFalse(rec.call_args.kwargs["ok"])
+
+    def test_read_is_not_audited(self):
+        with patch("jarvis.api.audit.record") as rec:
+            api._run_tool("get_list", {"doctype": "ToDo", "limit": 1})
+        self.assertFalse(rec.called)

--- a/jarvis/tests/test_tool_preview_audit.py
+++ b/jarvis/tests/test_tool_preview_audit.py
@@ -52,3 +52,29 @@ class TestWriteAudit(FrappeTestCase):
         with patch("jarvis.api.audit.record") as rec:
             api._run_tool("get_list", {"doctype": "ToDo", "limit": 1})
         self.assertFalse(rec.called)
+
+    def test_preview_error_is_not_audited(self):
+        # A failed dry-run must not pollute the audit log with a phantom write.
+        with patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("create_doc", {
+                "doctype": "No Such DocType ZZZ", "values": {}, "preview": True,
+            })
+        self.assertFalse(r["ok"])
+        self.assertFalse(rec.called)
+
+    def test_preview_sandboxes_a_tool_that_commits(self):
+        # The core fix: even when the dispatched tool calls frappe.db.commit()
+        # internally, preview must not persist anything.
+        sentinel = "jarvis-test-preview-commit-sentinel"
+
+        def fake_dispatch(tool, args):
+            frappe.get_doc({"doctype": "ToDo", "description": sentinel}).insert(
+                ignore_permissions=True)
+            frappe.db.commit()  # would persist + destroy a naive savepoint
+            return {"ok": True}
+
+        with patch("jarvis.api.dispatch", side_effect=fake_dispatch):
+            r = api._run_tool("run_method", {"method": "x", "preview": True})
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["data"]["preview"])
+        self.assertFalse(frappe.db.exists("ToDo", {"description": sentinel}))

--- a/jarvis/tools/README.md
+++ b/jarvis/tools/README.md
@@ -1,0 +1,184 @@
+# Jarvis tool layer
+
+The thin execution layer the agent uses to operate a Frappe/ERPNext site.
+Knowledge (fields, flows, gotchas) lives in the per-DocType **Skills**
+(`jarvis-persona`); tools are generic primitives that read and write through the
+live Frappe ORM. **Tools never hardcode a DocType schema** - the agent calls
+`get_schema` to read the live one.
+
+This README documents the layer's contract plus the extensions added in
+`feat/tool-layer-extensions` (`run_method`, `get_schema` metadata + cache,
+`preview` dry-run, write auditing). The full agent-facing inventory of all 49
+tools, with confirmation discipline, is in `jarvis-persona/TOOLS.md`.
+
+## Architecture
+
+Two tiers, one call mechanism:
+
+1. **Transport (TypeScript):** `jarvis-openclaw-plugin` exposes each tool to the
+   openclaw agent runtime - descriptors in `src/tool-defs.ts`, typed params in
+   `src/schemas.ts`, the contract list in `openclaw.plugin.json`. It calls back
+   to the bench over HTTP.
+2. **Execution (Python, in-process):** `jarvis.api.call_tool` is the whitelisted
+   entry point. It authenticates the caller, resolves the user, runs
+   `frappe.set_user(<that user>)`, and dispatches to the tool function via
+   `jarvis/tools/registry.py`. Tools call the Frappe ORM directly, **under the
+   chat user's own permissions** - so Frappe's permission model is the security
+   boundary, not the tool code.
+
+A **3-way invariant** is enforced and must hold for every change:
+`tool-defs.ts pythonNames == openclaw.plugin.json contracts == registry _TOOL_NAMES`
+(currently **49**).
+
+## Auth
+
+`call_tool` accepts two modes (see `jarvis/api.py`):
+
+- **Standard Frappe auth** - session cookie or
+  `Authorization: token <api_key>:<api_secret>`. The tool runs as that user.
+- **Plugin auth** - the plugin presents `X-Jarvis-Token` (the shared
+  `agent_token`, proving the request came from inside the openclaw container) and
+  `X-Jarvis-Session` (the openclaw sessionKey). The user is resolved from
+  `Jarvis Chat Session` and dispatch runs under that user via `set_user`.
+
+Guest is rejected. Secrets come from site config / env only.
+
+## Result envelope
+
+Every call returns one shape (`jarvis/api.py:_run_tool`):
+
+```jsonc
+{ "ok": true,  "data": <result> }
+// or
+{ "ok": false, "error": { "code": "PermissionDeniedError", "message": "<Frappe's message verbatim>" } }
+```
+
+Frappe validation/permission messages are surfaced **verbatim**, never swallowed.
+Common codes: `InvalidArgumentError` (bad input / link / mandatory / unknown
+DocType), `PermissionDeniedError` (403), `ToolNotFoundError`.
+
+## Layer-1 primitives (generic, cover every DocType)
+
+`get_schema`, `get_doc`, `get_list`, `query`, `run_report`, `get_report_filters`,
+`run_method`, `create_doc`, `update_doc`, `submit_doc`, `cancel_doc`,
+`delete_doc`, `amend_doc`, plus artifact/computed-read tools. The Frappe API is
+uniform, so these cover all DocTypes - reach for a specialized tool only when it
+carries domain logic the schema doesn't express.
+
+---
+
+## `run_method` - call a whitelisted server method
+
+The escape hatch for `@frappe.whitelist()` methods the dedicated tools don't wrap
+- most often ERPNext's `make_*` document mappers.
+
+```python
+run_method(method: str, args: dict | None = None)
+```
+
+- `method` is a dotted path, e.g.
+  `erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice`.
+- **Only whitelisted methods run.** Non-whitelisted (or unresolvable) methods are
+  rejected with `PermissionDeniedError` / `InvalidArgumentError`. The method's own
+  permission checks still apply (it runs as the chat user).
+- Returns the method's return value verbatim (often a document dict).
+
+**Example** - create a draft Sales Invoice from a Sales Order:
+
+```jsonc
+// tool args
+{ "method": "erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice",
+  "args": { "source_name": "SAL-ORD-2026-00042" } }
+```
+
+**Allowlist (recommended in production).** Set a site-config list of fnmatch
+patterns to narrow what may ever be called:
+
+```jsonc
+// site_config.json
+{ "jarvis_run_method_allowlist": ["erpnext.*.make_*", "frappe.client.*"] }
+```
+
+When set, any method not matching a pattern is rejected even if it is whitelisted.
+
+## `get_schema` - live introspection (the backbone)
+
+```python
+get_schema(doctype: str, verbose: bool = False, refresh: bool = False)
+```
+
+Returns the live schema, not a stored copy:
+
+```jsonc
+{ "doctype": "Sales Invoice",
+  "is_submittable": true,
+  "autoname": "naming_series:",
+  "naming_rule": "By \"Naming Series\" field",
+  "title_field": "title",
+  "workflow": { "name": "...", "state_field": "workflow_state", "states": ["Draft", "Approved", ...] },
+  "fields": [ { "fieldname": "customer", "fieldtype": "Link", "label": "Customer", "options": "Customer", "reqd": true }, ... ] }
+```
+
+- `verbose=true` inlines `child_fields` for Table fields (one level).
+- Result is cached in Redis for **300 s** (schema is user-independent; the
+  **read-permission check runs on every call regardless of cache**, so caching
+  never leaks a schema to a user who can't read the DocType).
+- `refresh=true` busts the cache - use after a Customize Form / Custom Field
+  change.
+
+## `preview` - dry-run on writes
+
+The write tools (`create_doc`, `update_doc`, `submit_doc`, `cancel_doc`,
+`amend_doc`, `delete_doc`) and `run_method` accept `preview: true`. The operation
+runs through all DocType validations inside a **savepoint that is then rolled
+back** - nothing is committed:
+
+```jsonc
+// args
+{ "doctype": "Sales Invoice", "values": { "customer": "Acme Corp", "items": [...] }, "preview": true }
+// data
+{ "preview": true,
+  "would": { "name": "<resolved name>", "grand_total": 1180.0, ... },
+  "note": "Validated in a rolled-back savepoint; nothing was committed. External side effects (emails/webhooks in on_submit / on_cancel) are not sandboxed by preview." }
+```
+
+Use it to show the user exactly what a write would produce (resolved name,
+fetched/computed fields) - or the validation error it would hit - before they
+confirm. **Caveat:** DB effects are sandboxed, but external side effects in
+`on_submit` / `on_cancel` (emails, webhooks) are not rolled back.
+
+## Audit logging
+
+Every **mutating** tool call is logged from the `_run_tool` choke-point
+(`jarvis/audit.py`) - reads are not logged, `preview` runs are not logged
+(nothing is committed). Each entry records who / what / when / result:
+
+```jsonc
+{ "ts": "2026-06-29 10:15:02", "user": "navin@aerele.in", "tool": "create_doc",
+  "doctype": "Sales Invoice", "name": "ACC-SINV-2026-00131", "status": "ok",
+  "error_code": null, "error_message": null, "args": { ... } }
+```
+
+- Sink: the `jarvis.tool_audit` Frappe logger (the bench `logs/` directory). A
+  structured logger is used rather than a DocType insert so auditing is
+  transaction-safe and can never entangle or break the tool's own DB transaction;
+  a queryable DocType sink can be layered on later by swapping the body of
+  `audit.record`.
+- Secret-shaped keys (`password`, `api_key`, `token`, ...) are redacted; the args
+  summary is size-capped.
+
+---
+
+## Adding a tool
+
+1. Write `jarvis/tools/<name>.py` exposing `def <name>(...)`. Validate inputs;
+   raise `InvalidArgumentError` / `PermissionDeniedError` from
+   `jarvis.exceptions`; let Frappe validation errors propagate (the envelope
+   translates them).
+2. Register the name in `jarvis/tools/registry.py` `_TOOL_NAMES`.
+3. If it mutates, add it to `_WRITE_TOOLS` in `jarvis/api.py` (and `_PREVIEWABLE`
+   if a dry-run makes sense).
+4. Add the plugin descriptor (`src/tool-defs.ts`), the typed schema
+   (`src/schemas.ts`), and the contract (`openclaw.plugin.json`); rebuild `dist`.
+5. Keep the 3-way invariant green and add a row to `jarvis-persona/TOOLS.md`.
+6. Add tests under `jarvis/tests/` (happy path + validation + permission).

--- a/jarvis/tools/README.md
+++ b/jarvis/tools/README.md
@@ -130,8 +130,10 @@ Returns the live schema, not a stored copy:
 
 The write tools (`create_doc`, `update_doc`, `submit_doc`, `cancel_doc`,
 `amend_doc`, `delete_doc`) and `run_method` accept `preview: true`. The operation
-runs through all DocType validations inside a **savepoint that is then rolled
-back** - nothing is committed:
+runs through all DocType validations with **every DB write rolled back** -
+commits are neutralized for the duration and the work is undone via a savepoint,
+so even a tool (or a `run_method` target) that calls `frappe.db.commit()`
+internally cannot persist:
 
 ```jsonc
 // args
@@ -139,13 +141,14 @@ back** - nothing is committed:
 // data
 { "preview": true,
   "would": { "name": "<resolved name>", "grand_total": 1180.0, ... },
-  "note": "Validated in a rolled-back savepoint; nothing was committed. External side effects (emails/webhooks in on_submit / on_cancel) are not sandboxed by preview." }
+  "note": "Validated with all DB writes rolled back; nothing was committed. External side effects (emails/webhooks in on_submit / on_cancel) are not sandboxed by preview." }
 ```
 
 Use it to show the user exactly what a write would produce (resolved name,
 fetched/computed fields) - or the validation error it would hit - before they
-confirm. **Caveat:** DB effects are sandboxed, but external side effects in
-`on_submit` / `on_cancel` (emails, webhooks) are not rolled back.
+confirm. Preview runs are never audited (nothing is committed). **Caveat:** DB
+effects are sandboxed, but external side effects in `on_submit` / `on_cancel`
+(emails, webhooks) are not rolled back.
 
 ## Audit logging
 

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -3,22 +3,20 @@ import frappe
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 TABLE_FIELDTYPES = {"Table", "Table MultiSelect"}
+_SCHEMA_TTL = 300  # seconds; schema is user-independent + changes rarely
 
 
 def _field_record(f) -> dict:
 	"""Per-field response shape. Five keys, all load-bearing:
 
-	- ``fieldname`` / ``fieldtype`` / ``label``: identity + type +
-	  human label.
+	- ``fieldname`` / ``fieldtype`` / ``label``: identity + type + human label.
 	- ``options``: target DocType for Link / Table / Table MultiSelect /
-	  Dynamic Link fields; enum values (newline-separated) for Select
-	  fields. Empty string for primitive fields. Always included
-	  because without it Link/Select/Table fields are opaque - the
-	  agent can't follow them, can't filter on enum values, and can't
-	  call ``get_schema`` on the child DocType.
-	- ``reqd``: whether the field is mandatory on insert. Essential
-	  for write paths (create_doc / update_doc); cheap on reads
-	  (one bool per field).
+	  Dynamic Link fields; enum values (newline-separated) for Select fields.
+	  Empty string for primitive fields. Without it Link/Select/Table fields
+	  are opaque - the agent can't follow them, filter on enum values, or
+	  ``get_schema`` the child DocType.
+	- ``reqd``: whether the field is mandatory on insert. Essential for write
+	  paths (create_doc / update_doc); cheap on reads.
 	"""
 	return {
 		"fieldname": f.fieldname,
@@ -29,44 +27,67 @@ def _field_record(f) -> dict:
 	}
 
 
-def get_schema(doctype: str, verbose: bool = False) -> dict:
-	"""Return meta for a DocType: name and field list.
+def _workflow_for(doctype: str):
+	"""The active Workflow's states for ``doctype``, or None. Live
+	introspection so the agent reads the real state machine instead of a
+	(possibly drifted) Skill note."""
+	wf = frappe.db.get_value("Workflow", {"document_type": doctype, "is_active": 1}, "name")
+	if not wf:
+		return None
+	doc = frappe.get_doc("Workflow", wf)
+	return {
+		"name": wf,
+		"state_field": doc.workflow_state_field,
+		"states": [s.state for s in doc.states],
+	}
 
+
+def _build_schema(doctype: str, verbose: bool) -> dict:
+	meta = frappe.get_meta(doctype)
+	fields = []
+	for f in meta.fields:
+		record = _field_record(f)
+		if verbose and f.fieldtype in TABLE_FIELDTYPES and f.options:
+			child_meta = frappe.get_meta(f.options)
+			record["child_fields"] = [_field_record(cf) for cf in child_meta.fields]
+		fields.append(record)
+	return {
+		"doctype": doctype,
+		"is_submittable": bool(meta.is_submittable),
+		"autoname": meta.autoname,
+		"naming_rule": getattr(meta, "naming_rule", None),
+		"title_field": meta.title_field,
+		"workflow": _workflow_for(doctype),
+		"fields": fields,
+	}
+
+
+def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> dict:
+	"""Return live meta for a DocType: identity + the write-relevant
+	doctype-level flags + the field list.
+
+	Top level: ``doctype``, ``is_submittable`` (docstatus lifecycle applies),
+	``autoname`` / ``naming_rule`` (how name is assigned), ``title_field``,
+	``workflow`` ({name, state_field, states} or None), and ``fields``.
 	Every field record carries ``fieldname``, ``fieldtype``, ``label``,
-	``options``, and ``reqd``. The ``options`` value gives the agent
-	the target DocType for Link fields, the enum values for Select
-	fields, and the child DocType name for Table / Table MultiSelect
-	fields. ``reqd`` is the mandatory flag the agent needs for writes.
+	``options`` (Link target / Select enum / child DocType), and ``reqd``.
 
-	By default, Table / Table MultiSelect fields surface as ordinary
-	records (with their child DocType named via ``options``) but
-	WITHOUT the recursive ``child_fields`` expansion. The agent calls
-	``get_schema`` on the child DocType when it needs the child's
-	field list - that follow-up call is cheap, and the lazy expansion
-	keeps transcripts from ballooning when the agent only cares about
-	the parent.
+	By default Table / Table MultiSelect fields surface as ordinary records
+	(child DocType named via ``options``) WITHOUT recursive ``child_fields`` -
+	the agent calls ``get_schema`` on the child when it needs that list (cheap;
+	keeps transcripts small). Pass ``verbose=True`` to inline each child's
+	schema in one call (one level only; Frappe forbids nested tables). The
+	slim default is the durable fix for the 2026-06-22 gpt-5.5 context overflow
+	where 8 recursive schema dumps overran the model.
 
-	Pass ``verbose=True`` to inline each Table / Table MultiSelect
-	field's child schema in the same call. Useful for operator triage
-	("show me the full Sales Invoice + line-item structure in one
-	shot") or when the agent needs to validate a write that touches
-	parent + child in a single transaction. The child records use the
-	same 5-key shape; no second level of recursion (Frappe doesn't
-	allow nested tables).
+	Result is cached in Redis for ~5 min (schema is the same for every user).
+	The read-permission check below runs on EVERY call regardless of cache, so
+	caching never leaks a schema to a user who can't read the DocType. Pass
+	``refresh=True`` to bust + recompute (use after a Customize Form / Custom
+	Field change).
 
-	The slim-default + ``verbose=True`` toggle replaces the previous
-	always-recurse behavior. The 2026-06-22 context-window failure on
-	openai/gpt-5.5 (a chat where 8 schema dumps overflowed the model
-	and openclaw's compaction tripped on a transport error) was
-	driven by the recursive ``child_fields`` payload; trimming the
-	recursion to opt-in is the durable fix. ``options`` and ``reqd``
-	stay in the default because they carry semantic context
-	(link/select targets, write-path requireds) that's cheap and
-	useful.
-
-	Enforces read permission on the parent DocType for the current
-	user. Child-table DocTypes (when expanded under ``verbose=True``)
-	are treated as part of the parent and are NOT permission-checked
+	Enforces read permission on the parent DocType for the current user. Child
+	tables (under ``verbose=True``) are part of the parent, not checked
 	separately.
 	"""
 	if not doctype:
@@ -78,12 +99,12 @@ def get_schema(doctype: str, verbose: bool = False) -> dict:
 	if not frappe.has_permission(doctype, ptype="read"):
 		raise PermissionDeniedError(f"no read permission on {doctype}")
 
-	meta = frappe.get_meta(doctype)
-	fields = []
-	for f in meta.fields:
-		record = _field_record(f)
-		if verbose and f.fieldtype in TABLE_FIELDTYPES and f.options:
-			child_meta = frappe.get_meta(f.options)
-			record["child_fields"] = [_field_record(cf) for cf in child_meta.fields]
-		fields.append(record)
-	return {"doctype": doctype, "fields": fields}
+	key = f"jarvis_schema:{doctype}:{int(bool(verbose))}"
+	cache = frappe.cache()
+	if not refresh:
+		cached = cache.get_value(key)
+		if cached is not None:
+			return cached
+	result = _build_schema(doctype, bool(verbose))
+	cache.set_value(key, result, expires_in_sec=_SCHEMA_TTL)
+	return result

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -62,6 +62,40 @@ def _build_schema(doctype: str, verbose: bool) -> dict:
 	}
 
 
+def _as_bool(value) -> bool:
+	"""Coerce a possibly-stringified flag to bool. A JSON client may send
+	``"false"``/``"0"``; ``bool("false")`` is True, so treat common falsy
+	strings as False rather than trusting plain ``bool()``."""
+	if isinstance(value, str):
+		return value.strip().lower() in ("1", "true", "yes", "on")
+	return bool(value)
+
+
+def clear_cache_for(doctype: str) -> None:
+	"""Drop both cached schema variants (slim + verbose) for a DocType."""
+	cache = frappe.cache()
+	cache.delete_value(f"jarvis_schema:{doctype}:0")
+	cache.delete_value(f"jarvis_schema:{doctype}:1")
+
+
+def clear_schema_cache(doc, method=None) -> None:
+	"""doc_event handler (wired in hooks.py): when a schema-defining doc is
+	saved or trashed, bust the cached schema for the DocType it affects so the
+	agent never builds a write off a stale field list within the TTL window."""
+	dtype = getattr(doc, "doctype", None)
+	dt = None
+	if dtype == "DocType":
+		dt = doc.name
+	elif dtype == "Custom Field":
+		dt = getattr(doc, "dt", None)
+	elif dtype == "Property Setter":
+		dt = getattr(doc, "doc_type", None)
+	elif dtype == "Workflow":
+		dt = getattr(doc, "document_type", None)
+	if dt:
+		clear_cache_for(dt)
+
+
 def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> dict:
 	"""Return live meta for a DocType: identity + the write-relevant
 	doctype-level flags + the field list.
@@ -81,15 +115,20 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 	where 8 recursive schema dumps overran the model.
 
 	Result is cached in Redis for ~5 min (schema is the same for every user).
-	The read-permission check below runs on EVERY call regardless of cache, so
+	The cache is busted automatically when a Custom Field / Property Setter /
+	DocType / Workflow change fires its doc_event (see hooks.py), so a
+	customization shows up immediately rather than after the TTL. The
+	read-permission check below runs on EVERY call regardless of cache, so
 	caching never leaks a schema to a user who can't read the DocType. Pass
-	``refresh=True`` to bust + recompute (use after a Customize Form / Custom
-	Field change).
+	``refresh=True`` to force a re-read (busts both slim + verbose variants).
 
 	Enforces read permission on the parent DocType for the current user. Child
 	tables (under ``verbose=True``) are part of the parent, not checked
 	separately.
 	"""
+	verbose = _as_bool(verbose)
+	refresh = _as_bool(refresh)
+
 	if not doctype:
 		raise InvalidArgumentError("doctype is required")
 
@@ -99,12 +138,14 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 	if not frappe.has_permission(doctype, ptype="read"):
 		raise PermissionDeniedError(f"no read permission on {doctype}")
 
-	key = f"jarvis_schema:{doctype}:{int(bool(verbose))}"
 	cache = frappe.cache()
-	if not refresh:
+	key = f"jarvis_schema:{doctype}:{int(verbose)}"
+	if refresh:
+		clear_cache_for(doctype)  # bust BOTH variants, not just the current one
+	else:
 		cached = cache.get_value(key)
 		if cached is not None:
 			return cached
-	result = _build_schema(doctype, bool(verbose))
+	result = _build_schema(doctype, verbose)
 	cache.set_value(key, result, expires_in_sec=_SCHEMA_TTL)
 	return result

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -139,10 +139,17 @@ def dispatch(tool_name: str, args: dict):
     # parameter list declares. Tools that use ``**kwargs`` opt out
     # (currently none, but future tools wanting bag-of-args semantics
     # would skip the filter naturally).
+    fn = _TOOLS[tool_name]
     if not _ACCEPTS_VAR_KW.get(tool_name, False):
         accepted = _ACCEPTED_PARAMS[tool_name]
         args = {k: v for k, v in args.items() if k in accepted}
+    # Validate the call binds *before* invoking, so a genuine arg/signature
+    # mismatch (a missing required arg - the caller's fault) becomes
+    # InvalidArgumentError, while a TypeError raised inside the tool body (a real
+    # bug, e.g. from a method run via run_method) propagates to the 500 handler
+    # instead of being mislabeled as bad input.
     try:
-        return _TOOLS[tool_name](**args)
+        inspect.signature(fn).bind(**args)
     except TypeError as e:
         raise InvalidArgumentError(str(e))
+    return fn(**args)

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -26,6 +26,7 @@ _TOOL_NAMES: tuple[str, ...] = (
     "get_list",
     "run_report",
     "get_report_filters",
+    "run_method",
     "query",
     "update_doc",
     "create_doc",

--- a/jarvis/tools/run_method.py
+++ b/jarvis/tools/run_method.py
@@ -9,9 +9,10 @@ whitelisted actions. Runs under the calling user's identity
 
 Consequential by default: it can mutate. The persona confirms before
 calling it, ``api._run_tool`` audits it, and it supports ``preview``
-(dry-run via a rolled-back savepoint).
+(dry-run with DB writes rolled back).
 """
 import fnmatch
+import inspect
 
 import frappe
 
@@ -35,15 +36,21 @@ def run_method(method: str, args: dict | None = None) -> dict:
     if args is not None and not isinstance(args, dict):
         raise InvalidArgumentError("args must be a dict")
 
+    # An explicit empty allowlist ([]) means "block everything"; only a missing
+    # (None) allowlist means "no restriction". `if allow and ...` would treat []
+    # as unset and silently allow all - the opposite of the operator's intent.
     allow = frappe.conf.get("jarvis_run_method_allowlist")
-    if allow and not any(fnmatch.fnmatch(method, pat) for pat in allow):
+    if allow is not None and not any(fnmatch.fnmatch(method, pat) for pat in allow):
         raise PermissionDeniedError(
             f"method {method!r} is not in jarvis_run_method_allowlist"
         )
 
+    # Resolve the method. Only a genuinely missing module/attribute means
+    # "unknown method"; an error raised *during* the target module's import is a
+    # real bug and must surface (don't mask it behind "unknown method").
     try:
         fn = frappe.get_attr(method)
-    except Exception:
+    except (AttributeError, ModuleNotFoundError, frappe.AppNotInstalledError):
         raise InvalidArgumentError(f"unknown method: {method}")
 
     # Enforce @frappe.whitelist(): raises frappe.PermissionError if not.
@@ -54,9 +61,30 @@ def run_method(method: str, args: dict | None = None) -> dict:
             str(e) or f"method {method} is not whitelisted"
         ) from e
 
+    # Surface a mistyped/extra arg name instead of letting frappe.call silently
+    # drop it (get_newargs filters to the signature), which would run the method
+    # with the arg missing and return a wrong/empty result the user then trusts.
+    _reject_unknown_args(fn, method, args)
+
     try:
         return frappe.call(fn, **(args or {}))
     except frappe.PermissionError as e:
         raise PermissionDeniedError(
             str(e) or f"no permission to call {method}"
         ) from e
+
+
+def _reject_unknown_args(fn, method: str, args: dict | None) -> None:
+    if not args:
+        return
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return  # can't introspect (builtin/C func) - let frappe.call handle it
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return  # method takes **kwargs - it accepts anything
+    unknown = sorted(k for k in args if k not in params)
+    if unknown:
+        raise InvalidArgumentError(
+            f"method {method} does not accept argument(s): {', '.join(unknown)}"
+        )

--- a/jarvis/tools/run_method.py
+++ b/jarvis/tools/run_method.py
@@ -1,0 +1,62 @@
+"""run_method - call a whitelisted Frappe server method by name.
+
+The generic escape hatch for whitelisted RPCs the dedicated tools do not
+wrap - e.g. ERPNext's ``make_*`` document mappers
+(``make_sales_invoice``, ``make_delivery_note`` ...) and doctype-specific
+whitelisted actions. Runs under the calling user's identity
+(``jarvis.api.call_tool`` has already ``set_user``), so the method's own
+``@frappe.whitelist()`` gate and permission checks apply.
+
+Consequential by default: it can mutate. The persona confirms before
+calling it, ``api._run_tool`` audits it, and it supports ``preview``
+(dry-run via a rolled-back savepoint).
+"""
+import fnmatch
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+
+
+def run_method(method: str, args: dict | None = None) -> dict:
+    """Call a whitelisted server method ``method`` with keyword ``args``.
+
+    ``method`` is a dotted path, e.g.
+    ``erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice``.
+    Only ``@frappe.whitelist()`` methods are callable; anything else raises
+    PermissionDeniedError. An optional site-config allowlist
+    (``jarvis_run_method_allowlist``: a list of fnmatch patterns) further
+    narrows what may be called - recommended in production.
+
+    Returns the method's return value verbatim (often a document dict).
+    """
+    if not method:
+        raise InvalidArgumentError("method is required")
+    if args is not None and not isinstance(args, dict):
+        raise InvalidArgumentError("args must be a dict")
+
+    allow = frappe.conf.get("jarvis_run_method_allowlist")
+    if allow and not any(fnmatch.fnmatch(method, pat) for pat in allow):
+        raise PermissionDeniedError(
+            f"method {method!r} is not in jarvis_run_method_allowlist"
+        )
+
+    try:
+        fn = frappe.get_attr(method)
+    except Exception:
+        raise InvalidArgumentError(f"unknown method: {method}")
+
+    # Enforce @frappe.whitelist(): raises frappe.PermissionError if not.
+    try:
+        frappe.is_whitelisted(fn)
+    except frappe.PermissionError as e:
+        raise PermissionDeniedError(
+            str(e) or f"method {method} is not whitelisted"
+        ) from e
+
+    try:
+        return frappe.call(fn, **(args or {}))
+    except frappe.PermissionError as e:
+        raise PermissionDeniedError(
+            str(e) or f"no permission to call {method}"
+        ) from e


### PR DESCRIPTION
## What
Layer-1 extensions to the Jarvis tool layer (adopt + extend; no rebuild).

### New tool
- **run_method** — generic caller for `@frappe.whitelist()` server methods (ERPNext `make_*` mappers etc.). Whitelist-enforced via `is_whitelisted`, runs as the chat user, optional `jarvis_run_method_allowlist` site-config gate. Registry: **48 → 49**.

### Enhancements
- **get_schema** — now returns `is_submittable` / `autoname` / `naming_rule` / `title_field` / active **workflow** states (live introspection). Redis TTL cache (~5 min) + `refresh=true` bust; read-permission still checked every call, cached or not.
- **preview (dry-run)** — create/update/submit/cancel/amend/delete + run_method accept `preview=true` at the `api._run_tool` choke-point: runs in a savepoint, rolls back, returns `{preview, would, note}`. Nothing committed.
- **audit** — every mutating tool logged (who/what/when/result, secrets scrubbed) via the `jarvis.tool_audit` structured logger (transaction-safe; never breaks the tool).

### Docs
- `jarvis/tools/README.md` — architecture, auth, envelope, per-extension usage + config.

## Tests
16 new (run_method 7, get_schema meta/cache 4, preview+audit 5) — all green. No regressions: `test_get_schema` (10) and `test_get_report_filters` (6) pass. The one `test_chat_api` failure (conversation titling) is pre-existing on `main`, unrelated.

## Notes
- Audit sink is a logger, not a DocType, deliberately (transaction safety) — a queryable DocType sink can follow.
- Idempotency on writes not added (Frappe create isn't idempotent) — flagged for follow-up.