### PR TITLE
feat(chat): per-conversation thinking effort (/think directive)

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -36,6 +36,8 @@ from jarvis._subscription_models import (
 	SUBSCRIPTION_MODELS as _SUBSCRIPTION_MODELS,
 )
 
+_ALLOWED_THINKING = {"", "low", "medium", "high"}
+
 
 @frappe.whitelist()
 def list_conversations() -> list[dict]:
@@ -276,6 +278,7 @@ from jarvis.chat.openclaw_client import OpenclawSession
 def send_message(
 	conversation: str, message: str, model_override: str | None = None,
 	attachments: str | None = None, context: str | None = None,
+	thinking_override: str | None = None,
 ) -> dict:
 	"""Validate, persist the user message, ensure session_key, enqueue the worker.
 
@@ -325,6 +328,12 @@ def send_message(
 			        f"model {model_override!r} is not valid for "
 			        f"{settings.llm_provider!r}"}
 		conv_doc.model_override = model_override
+
+	if thinking_override is not None:
+		level = (thinking_override or "").strip().lower()
+		if level not in _ALLOWED_THINKING:
+			return {"ok": False, "reason": f"invalid thinking level {thinking_override!r}"}
+		conv_doc.thinking_override = level
 
 	# Visible message keeps the typed text plus a compact attachment marker;
 	# the file bytes are inlined for the agent in the worker, not stored here.
@@ -550,6 +559,30 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 	frappe.db.set_value(CONV, conversation, "model_override", model, update_modified=False)
 	frappe.db.commit()
 	return {"ok": True, "data": {"effective_model": model}}
+
+
+@frappe.whitelist()
+def set_conversation_thinking(conversation: str, thinking: str | None = None) -> dict:
+	"""Set or clear the per-conversation thinking effort (low/medium/high).
+
+	Empty / None clears it, so turns fall back to openclaw's default. The
+	value is plumbed as an inline /think directive in the user message, so it
+	never affects the cacheable system prefix. Returns the effective level
+	(empty resolves to "medium" for display)."""
+	if not frappe.db.exists(CONV, conversation):
+		return {"ok": False, "error": {
+			"code": "unknown_conversation",
+			"message": f"conversation {conversation!r} not found",
+		}}
+	level = (thinking or "").strip().lower()
+	if level not in _ALLOWED_THINKING:
+		return {"ok": False, "error": {
+			"code": "unknown_thinking",
+			"message": f"{thinking!r} is not a valid thinking level. Allowed: low, medium, high",
+		}}
+	frappe.db.set_value(CONV, conversation, "thinking_override", level, update_modified=False)
+	frappe.db.commit()
+	return {"ok": True, "data": {"effective_thinking": level or "medium"}}
 
 
 @frappe.whitelist()

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -288,6 +288,13 @@ def send_message(
 	Validated against the same allowlist set_conversation_model uses.
 	Empty string / None leaves the existing override alone.
 
+	`thinking_override` (optional): per-conversation Claude thinking effort
+	level to set BEFORE enqueueing the worker. Valid values: "low", "medium",
+	"high", or "" (empty string). An empty string clears the override, which
+	resets to the model default. None leaves the existing value unchanged.
+	Note: this differs from `model_override`, which treats both None and empty
+	string as "leave the existing value alone".
+
 	Returns {ok: True, run_id, message_id} on success or
 	{ok: False, reason: str} on validation failure. Raises
 	frappe.DoesNotExistError if the conversation does not exist or the

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -284,7 +284,6 @@ def handle_chat_send(payload: dict) -> None:
 
 	skill_clause = invoked_skill_clause(msg_row.get("content") or "")
 	user_message = (
-		f"{_thinking_prefix(conv.thinking_override)}"
 		f"[Context: today is {today}; chat user: {chat_user}{auto_apply}{skill_clause}]"
 		f"\n\n{user_message or ''}"
 	)
@@ -304,6 +303,12 @@ def handle_chat_send(payload: dict) -> None:
 		and vision.supports_vision(settings.llm_provider)
 	)
 	user_message, vision_parts = _prepare_attachments(user_message, attachments, vision_ok)
+	# Apply the /think directive as the FIRST bytes of the final message so
+	# openclaw's leading-directive parser always sees it, even when
+	# _prepend_doc_context prepended a [Viewing: ...] line and
+	# _prepare_attachments appended attachment text. Cache-safe: the
+	# directive stays in the user message, never the system prompt.
+	user_message = _thinking_prefix(conv.thinking_override) + user_message
 
 	def _publish_run_error(err: str) -> None:
 		_mark_errored(assistant_msg.name, err)

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -181,6 +181,16 @@ def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
 	return effective_model, provider
 
 
+def _thinking_prefix(thinking_override: str | None) -> str:
+	"""Inline openclaw /think directive for this turn, or '' when unset.
+
+	openclaw reads a leading /think directive from the MESSAGE BODY and
+	strips it. We keep it in the user message (after the static system
+	prefix), so it never busts the prefix cache the warm-up populates."""
+	level = (thinking_override or "").strip().lower()
+	return f"/think {level}\n" if level in ("low", "medium", "high") else ""
+
+
 def handle_chat_send(payload: dict) -> None:
 	"""Drive one agent turn end to end.
 
@@ -274,6 +284,7 @@ def handle_chat_send(payload: dict) -> None:
 
 	skill_clause = invoked_skill_clause(msg_row.get("content") or "")
 	user_message = (
+		f"{_thinking_prefix(conv.thinking_override)}"
 		f"[Context: today is {today}; chat user: {chat_user}{auto_apply}{skill_clause}]"
 		f"\n\n{user_message or ''}"
 	)

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -10,6 +10,7 @@
     "title",
     "session_key",
     "model_override",
+    "thinking_override",
     "status",
     "last_active_at",
     "starred"
@@ -35,6 +36,13 @@
       "fieldtype": "Data",
       "label": "Model Override",
       "description": "Bare model id (no provider prefix) used for chat turns in this conversation. Null/empty falls back to Jarvis Settings.llm_model. Validated against the SUBSCRIPTION_MODELS allowlist at write time."
+    },
+    {
+      "fieldname": "thinking_override",
+      "fieldtype": "Select",
+      "label": "Thinking Effort",
+      "options": "\nlow\nmedium\nhigh",
+      "description": "Per-conversation reasoning effort sent to openclaw via an inline /think directive in the user message. Empty falls back to openclaw's default (medium). Maps to the Fast/Balanced/Deep UI selector."
     },
     {
       "fieldname": "status",

--- a/jarvis/public/js/jarvis_chat/api.js
+++ b/jarvis/public/js/jarvis_chat/api.js
@@ -69,3 +69,11 @@ export async function setConversationModel(conversation, model) {
 	});
 	return r.message;
 }
+
+export async function setConversationThinking(conversation, thinking) {
+	const r = await frappe.call({
+		method: "jarvis.chat.api.set_conversation_thinking",
+		args: { conversation, thinking: thinking || "" },
+	});
+	return r.message;
+}

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -277,12 +277,17 @@ class TestSendMessage(_ChatTestCase):
 		)
 		self.assertEqual([r["seq"] for r in seqs], [1, 2])
 
-	def test_first_message_sets_conversation_title(self):
+	def test_first_message_does_not_title_from_raw_text(self):
+		"""send_message must NOT set the conversation title from the raw first
+		message. The title stays "New chat"; the worker generates a concise
+		LLM-summarised title after the first substantive turn and pushes it via
+		a conversation:renamed event, so the sidebar never flashes the raw prompt.
+		"""
 		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
 			with patch("frappe.enqueue"):
 				send_message(self.conv, "How many invoices last quarter?")
 		doc = frappe.get_doc(CONV, self.conv)
-		self.assertEqual(doc.title, "How many invoices last quarter?")
+		self.assertEqual(doc.title, "New chat")
 
 	def test_bumps_last_active_at(self):
 		before = frappe.utils.get_datetime(frappe.get_value(

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -544,9 +544,68 @@ class TestSendMessageWithModelOverride(_ChatTestCase):
 		)
 
 
+class TestSendMessageThinkingOverride(_ChatTestCase):
+	"""send_message accepts an optional thinking_override that persists to
+	conv.thinking_override BEFORE the worker is enqueued - mirroring the
+	model_override path."""
+
+	def setUp(self):
+		super().setUp()
+		self.conv = create_conversation()
+
+	def test_valid_thinking_override_persists_before_enqueue(self):
+		"""thinking_override='low' is written to conv before frappe.enqueue fires."""
+		from jarvis.chat.api import send_message
+		written = {}
+		def capture(*a, **kw):
+			written["thinking"] = frappe.db.get_value(CONV, self.conv, "thinking_override")
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue", side_effect=capture):
+			result = send_message(self.conv, "hi", thinking_override="low")
+		self.assertTrue(result["ok"])
+		self.assertEqual(written["thinking"], "low")
+
+	def test_empty_string_clears_thinking_override(self):
+		"""An empty string clears thinking_override (unlike model_override which
+		ignores empty strings)."""
+		from jarvis.chat.api import send_message
+		frappe.db.set_value(CONV, self.conv, "thinking_override", "high")
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue"):
+			result = send_message(self.conv, "hi", thinking_override="")
+		self.assertTrue(result["ok"])
+		self.assertEqual(frappe.db.get_value(CONV, self.conv, "thinking_override"), "")
+
+	def test_none_keeps_existing_thinking_override(self):
+		"""None for thinking_override does not touch conv.thinking_override."""
+		from jarvis.chat.api import send_message
+		frappe.db.set_value(CONV, self.conv, "thinking_override", "medium")
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue"):
+			result = send_message(self.conv, "hi")
+		self.assertTrue(result["ok"])
+		self.assertEqual(
+			frappe.db.get_value(CONV, self.conv, "thinking_override"),
+			"medium",
+		)
+
+	def test_invalid_thinking_override_rejected(self):
+		"""Invalid thinking level yields ok:false with no DB write or enqueue."""
+		from jarvis.chat.api import send_message
+		with patch("frappe.enqueue") as enqueue:
+			result = send_message(self.conv, "hi", thinking_override="ultra")
+		self.assertFalse(result["ok"])
+		self.assertIn("ultra", result["reason"])
+		enqueue.assert_not_called()
+
+
 class TestThinkingOverride(FrappeTestCase):
 	def setUp(self):
 		self.conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "t"}).insert()
+
+	def tearDown(self):
+		frappe.delete_doc("Jarvis Conversation", self.conv.name, ignore_permissions=True, force=True)
+		frappe.db.commit()
 
 	def test_set_thinking_persists_valid_level(self):
 		from jarvis.chat import api

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -544,6 +544,37 @@ class TestSendMessageWithModelOverride(_ChatTestCase):
 		)
 
 
+class TestThinkingOverride(FrappeTestCase):
+	def setUp(self):
+		self.conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "t"}).insert()
+
+	def test_set_thinking_persists_valid_level(self):
+		from jarvis.chat import api
+
+		out = api.set_conversation_thinking(self.conv.name, "low")
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"]["effective_thinking"], "low")
+		self.assertEqual(
+			frappe.db.get_value("Jarvis Conversation", self.conv.name, "thinking_override"),
+			"low",
+		)
+
+	def test_set_thinking_rejects_invalid_level(self):
+		from jarvis.chat import api
+
+		out = api.set_conversation_thinking(self.conv.name, "ultra")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "unknown_thinking")
+
+	def test_set_thinking_empty_clears(self):
+		from jarvis.chat import api
+
+		api.set_conversation_thinking(self.conv.name, "high")
+		out = api.set_conversation_thinking(self.conv.name, "")
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"]["effective_thinking"], "medium")
+
+
 class TestChatUiSettings(FrappeTestCase):
 	"""get_chat_ui_settings serves the canonical subscription catalogue +
 	per-provider defaults so the JS pages don't duplicate them."""

--- a/jarvis/tests/test_turn_handler_thinking.py
+++ b/jarvis/tests/test_turn_handler_thinking.py
@@ -1,0 +1,15 @@
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.turn_handler import _thinking_prefix
+
+
+class TestThinkingPrefix(FrappeTestCase):
+    def test_levels_emit_directive(self):
+        self.assertEqual(_thinking_prefix("low"), "/think low\n")
+        self.assertEqual(_thinking_prefix("MEDIUM"), "/think medium\n")
+        self.assertEqual(_thinking_prefix("high"), "/think high\n")
+
+    def test_empty_or_invalid_emits_nothing(self):
+        self.assertEqual(_thinking_prefix(""), "")
+        self.assertEqual(_thinking_prefix(None), "")
+        self.assertEqual(_thinking_prefix("ultra"), "")

--- a/jarvis/tests/test_turn_handler_thinking.py
+++ b/jarvis/tests/test_turn_handler_thinking.py
@@ -1,15 +1,130 @@
+"""Tests for per-conversation thinking effort (Phase 2).
+
+Covers _thinking_prefix (pure unit) and the directive-leading invariant
+that holds even when _prepend_doc_context prefixes a [Viewing: ...] line
+(spec section 7.3, verification item 10.3).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis.chat import openclaw_session_pool
+from jarvis.chat.api import create_conversation, send_message
 from jarvis.chat.turn_handler import _thinking_prefix
+from jarvis.chat.worker import run_agent_turn
+from jarvis.tests.test_chat_api import (
+	TEST_USER,
+	_cleanup_user_conversations,
+	_ensure_test_user,
+)
 
 
 class TestThinkingPrefix(FrappeTestCase):
-    def test_levels_emit_directive(self):
-        self.assertEqual(_thinking_prefix("low"), "/think low\n")
-        self.assertEqual(_thinking_prefix("MEDIUM"), "/think medium\n")
-        self.assertEqual(_thinking_prefix("high"), "/think high\n")
+	def test_levels_emit_directive(self):
+		self.assertEqual(_thinking_prefix("low"), "/think low\n")
+		self.assertEqual(_thinking_prefix("MEDIUM"), "/think medium\n")
+		self.assertEqual(_thinking_prefix("high"), "/think high\n")
 
-    def test_empty_or_invalid_emits_nothing(self):
-        self.assertEqual(_thinking_prefix(""), "")
-        self.assertEqual(_thinking_prefix(None), "")
-        self.assertEqual(_thinking_prefix("ultra"), "")
+	def test_empty_or_invalid_emits_nothing(self):
+		self.assertEqual(_thinking_prefix(""), "")
+		self.assertEqual(_thinking_prefix(None), "")
+		self.assertEqual(_thinking_prefix("ultra"), "")
+
+
+class TestThinkingDirectiveLeading(FrappeTestCase):
+	"""The /think directive must be the FIRST bytes sent to openclaw
+	even when _prepend_doc_context prepends a [Viewing: ...] line for
+	floating-widget auto-context (spec 7.3, verification 10.3).
+
+	These tests call run_agent_turn with a mocked openclaw session and
+	capture the message argument actually passed to stream_agent_turn.
+
+	test_directive_leads_with_doc_context is the RED-before / GREEN-after
+	test: before the relocation fix in handle_chat_send it fails because
+	_thinking_prefix was applied before _prepend_doc_context (so [Viewing:]
+	displaced the directive); after the fix it passes.
+	"""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		conv = create_conversation()
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
+			with patch("frappe.enqueue"):
+				result = send_message(
+					conv, "what is the status?", thinking_override="high",
+				)
+		self.conv = conv
+		self.user_msg = result["message_id"]
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _capture_message_sent(self, context=None):
+		"""Run one agent turn and return the message arg passed to stream_agent_turn.
+
+		Uses call_args_list[0] (the FIRST call) to capture the user turn message.
+		The second call, if any, is the auto-title prompt and must be ignored.
+		"""
+		fake_sess = MagicMock()
+		fake_sess.stream_agent_turn.side_effect = lambda *a, **kw: iter([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "lifecycle", "phase": "end"},
+		])
+		with patch(
+			"jarvis.chat.openclaw_session_pool.OpenclawSession.connect",
+			return_value=fake_sess,
+		):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(
+					self.conv, self.user_msg, run_id="r1", context=context,
+				)
+		first_call = fake_sess.stream_agent_turn.call_args_list[0]
+		pos = first_call.args
+		kw = first_call.kwargs
+		return pos[1] if len(pos) >= 2 else kw.get("message")
+
+	def test_directive_leads_with_doc_context(self):
+		"""RED before fix / GREEN after: /think is first even with [Viewing: ...].
+
+		Before the relocation fix the message was:
+		  '[Viewing: Sales Order SO-001...]\n\n/think high\n[Context: ...]'
+		After the fix:
+		  '/think high\n[Viewing: Sales Order SO-001...]\n\n[Context: ...]'
+		"""
+		msg = self._capture_message_sent(
+			context={"doctype": "Sales Order", "name": "SO-001"},
+		)
+		self.assertIsNotNone(msg)
+		self.assertTrue(
+			msg.startswith("/think high\n"),
+			f"expected /think high as first bytes; got: {msg[:120]!r}",
+		)
+		self.assertIn("[Viewing: Sales Order SO-001", msg)
+		self.assertIn("[Context:", msg)
+		self.assertIn("what is the status?", msg)
+
+	def test_context_text_preserved(self):
+		"""[Viewing: ...] and [Context: ...] text is not mutated by the fix."""
+		msg = self._capture_message_sent(
+			context={"doctype": "Purchase Invoice", "name": "PINV-0001"},
+		)
+		self.assertIn(
+			"[Viewing: Purchase Invoice PINV-0001; resolve 'this'/'here' against it]",
+			msg,
+		)
+		self.assertIn("[Context:", msg)
+
+	def test_directive_leads_without_doc_context(self):
+		"""Baseline: /think is first even without doc-context (no regression)."""
+		msg = self._capture_message_sent(context=None)
+		self.assertTrue(
+			msg.startswith("/think high\n"),
+			f"expected /think high at start without doc-context; got: {msg[:120]!r}",
+		)


### PR DESCRIPTION
## Summary

Phase 2: per-conversation Claude thinking-effort control for the Jarvis Frappe chat. A conversation can carry a `thinking_override` (`low`/`medium`/`high`, or empty to clear) that is emitted as an inline openclaw `/think <level>` directive on each turn.

Cache-safety is the core constraint: the directive lives in the USER message (never the system prompt), so it never busts the static-prefix cache that the warm-up populates.

## What changed

- **Doctype:** `thinking_override` field added to Jarvis Conversation.
- **API:** `set_conversation_thinking` endpoint + `send_message(..., thinking_override=...)` accept path (applies before enqueue, mirroring `model_override`). Empty string clears the override (documented divergence from `model_override`, which leaves empty alone).
- **Turn handler:** `_thinking_prefix` emits the `/think` directive, applied as the FIRST bytes of the final assembled message.
- **JS:** `api.js` wrapper for the new endpoint.

## Final-review fix wave (commits 89222ce, 5e3f5ea)

- **Latent bug fixed:** the `/think` directive was applied in the early message build, then displaced from the leading position by `_prepend_doc_context` (the floating-widget `[Viewing: ...]` line). openclaw only strips a LEADING directive, so the effort silently did not apply on doc-context turns and `/think high` could leak into the prompt. The directive is now applied after `_prepend_doc_context` and `_prepare_attachments`, guaranteeing it is the first bytes even with doc-context present.
- **Tests:** `TestThinkingDirectiveLeading` (integration via `run_agent_turn` + mocked session, asserts directive-leading WITH doc-context and that `[Viewing:]`/`[Context:]` text is preserved); `TestSendMessageThinkingOverride` (4 tests mirroring model_override coverage).
- **Docs + hygiene:** `thinking_override` documented in `send_message`; `tearDown` added to `TestThinkingOverride`; rewrote the stale `test_first_message_sets_conversation_title` (asserted removed raw-prompt-title behavior) to assert the title stays "New chat".

## Test results

- `jarvis.tests.test_turn_handler_thinking`: 5/5 green
- `jarvis.tests.test_chat_api`: 44/44 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)