### PR TITLE
fix(oauth): handle provider token-error `error` returned as an object

### DIFF
--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -392,12 +392,23 @@ def _exchange_code(*, provider: str, code: str, code_verifier: str) -> dict:
 		# the wire so the response can't be used as an oracle (e.g.
 		# distinguishing invalid_client from invalid_grant).
 		raw_error = ""
+		detail = resp.text
 		try:
 			body = resp.json()
-			raw_error = body.get("error") or ""
-			detail = body.get("error_description") or raw_error or resp.text
+			err = body.get("error")
+			# RFC-6749 says `error` is a STRING code, but some providers return
+			# it as an object. Only a string is a valid (hashable) opaque-code
+			# lookup key; for an object, pull a nested code if one is present,
+			# else fall through to the generic message. This guards the
+			# `unhashable type: 'dict'` crash from using `error` as a dict key.
+			if isinstance(err, str):
+				raw_error = err
+			elif isinstance(err, dict):
+				nested = err.get("type") or err.get("code") or err.get("error")
+				raw_error = nested if isinstance(nested, str) else ""
+			detail = body.get("error_description") or err or resp.text
 		except ValueError:
-			detail = resp.text
+			pass
 		frappe.log_error(
 			title="oauth token exchange: provider rejected",
 			message=(

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -469,3 +469,56 @@ class TestDisconnect(_OAuthApiBase):
 		self.assertEqual(out["error"]["code"], "disconnect_failed")
 
 
+class _FakeResp:
+	def __init__(self, *, ok, status=400, json_body=None, text=""):
+		self.ok = ok
+		self.status_code = status
+		self.text = text
+		self._body = json_body
+
+	def json(self):
+		if self._body is None:
+			raise ValueError("no json")
+		return self._body
+
+
+class TestExchangeCodeErrorParsing(_OAuthApiBase):
+	"""Regression for the prod crash: a provider that returns `error` as an
+	OBJECT made _exchange_code use a dict as a dict key
+	(_TOKEN_EXCHANGE_OPAQUE_CODES.get(<dict>)) -> TypeError: unhashable type.
+	The error path must surface a clean TokenExchangeError instead."""
+
+	_PROV = {"client_id": "cid", "token": "https://p.example/token", "client_secret": None}
+
+	def _exchange(self, json_body):
+		resp = _FakeResp(ok=False, status=400, json_body=json_body)
+		with patch("jarvis.oauth.api.get_provider", return_value=self._PROV), \
+		     patch("jarvis.oauth.api.requests.post", return_value=resp), \
+		     patch("jarvis.oauth.api.frappe.log_error"):
+			with self.assertRaises(oauth_api.TokenExchangeError) as ctx:
+				oauth_api._exchange_code(provider="openai", code="ac_x", code_verifier="v")
+		return ctx.exception
+
+	def test_object_error_does_not_crash_and_maps_nested_code(self):
+		# The exact prod shape: `error` is an object with a nested code.
+		exc = self._exchange({"error": {"type": "invalid_grant", "message": "bad code"}})
+		self.assertEqual(exc.code, "code_invalid")
+
+	def test_string_error_still_maps(self):
+		exc = self._exchange({"error": "invalid_client"})
+		self.assertEqual(exc.code, "auth_failed")
+
+	def test_unmappable_object_error_falls_back(self):
+		exc = self._exchange({"error": {"unexpected": "shape"}})
+		self.assertEqual(exc.code, "token_exchange_failed")
+
+	def test_non_json_error_body_falls_back(self):
+		resp = _FakeResp(ok=False, status=500, json_body=None, text="<html>502</html>")
+		with patch("jarvis.oauth.api.get_provider", return_value=self._PROV), \
+		     patch("jarvis.oauth.api.requests.post", return_value=resp), \
+		     patch("jarvis.oauth.api.frappe.log_error"):
+			with self.assertRaises(oauth_api.TokenExchangeError) as ctx:
+				oauth_api._exchange_code(provider="openai", code="ac_x", code_verifier="v")
+		self.assertEqual(ctx.exception.code, "token_exchange_failed")
+
+


### PR DESCRIPTION
The token-exchange error path assumed RFC-6749's `error` is a string and used it as a dict key: _TOKEN_EXCHANGE_OPAQUE_CODES.get(raw_error, ...). A provider that returns `error` as an object crashed onboarding sign-in with `TypeError: unhashable type: 'dict'` (HTTP 500), masking the real provider rejection.

Coerce the lookup key to a string: use it directly when `error` is a string, pull a nested type/code/error when it's an object, else fall through to the generic opaque code. The full provider error is still logged server-side, and the user gets the intended opaque message instead of a 500.

Regression: test_oauth_api.TestExchangeCodeErrorParsing - object error maps the nested code, string error still maps, unmappable object + non-JSON body fall back. 4/4 pass.