### PR TITLE
feat(chat): inline ECharts charts via jarvis-chart blocks

### DIFF
--- a/frontend/inline-charts.plan.md
+++ b/frontend/inline-charts.plan.md
@@ -1,0 +1,409 @@
+# Inline Chat Charts (ECharts) - Implementation Plan
+
+> Execute task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Render attractive, readable charts inline in the chat response - the agent emits a ` ```jarvis-chart ` block with a safe high-level spec; the chat draws it with Apache ECharts (the same engine + look as Frappe Insights), themed by the chat (never raw ECharts options from the model).
+
+**Architecture:** Mirror the existing ` ```jarvis-cards ` pattern in the chat SPA (`apps/jarvis/frontend`). A pure `chartTheme.js` maps the spec to a themed ECharts option (Insights-grade); a `JvChart.vue` component owns the echarts lifecycle; `ChatView.vue` parses ` ```jarvis-chart ` blocks (like `cardsOf`), strips them from the prose, and renders one `<JvChart>` per spec. The persona learns to emit the block after it has the data.
+
+**Tech stack:** Vue 3 + Vite, `echarts ^5.5.0` (same as Insights 3.3.1). No frontend test runner exists, so the pure builder is tested with Node's built-in `node:test`; the Vue glue is verified by `vite build` + a sample render.
+
+## Global Constraints
+
+- **Inline only.** Charts render as part of the assistant chat message - no separate page, no Desk dependency. The block lives in the message text, so it persists + re-renders on reload (like ` ```mermaid `).
+- **Same engine + look as Insights:** `echarts ^5.5.0`; SVG renderer; curated palette; dashed gridlines; no axis ticks; rounded bars; smooth/gradient lines.
+- **Safe spec, theme owned by the chat.** The agent sends a high-level spec (type / x / series / a few options) - NEVER raw ECharts option JSON (no formatters/functions/HTML over the wire). `buildOption` validates and returns `null` on anything malformed; the UI shows a small "couldn't render" note, never throws.
+- **Lazy-load echarts** (dynamic `import('echarts')` inside the component) so it never bloats first paint - mirror the mermaid lazy-load already in `ChatView.vue` (~line 1700).
+- **Dark-mode aware** - the chat already exposes `effectiveDark`; the theme switches on it.
+- **Two repos:** `apps/jarvis/frontend` (render) + `jarvis-persona` (agent emits the block). Frontend node: use the repo's node20 (`export PATH="$HOME/.nvm/versions/node/v20.19.6/bin:$PATH"`). Run frontend cmds from `apps/jarvis/frontend`.
+
+## Spec contract (the persona <-> frontend interface)
+
+```jsonc
+{
+  "type": "bar" | "line" | "area" | "pie" | "donut",   // required
+  "title": "string",                                    // optional
+  "x": ["Jan", "Feb", "Mar"],                           // category labels (also pie slice labels)
+  "series": [ { "name": "Revenue", "data": [12, 18, 15] } ],  // data aligned to x; pie uses series[0]
+  "options": { "stacked": false, "smooth": false, "horizontal": false }  // optional
+}
+```
+
+---
+
+### Task 1: `chartTheme.js` - safe spec -> themed ECharts option (pure, TDD)
+
+**Files:**
+- Create: `apps/jarvis/frontend/src/charts/chartTheme.js`
+- Test: `apps/jarvis/frontend/src/charts/chartTheme.test.js`
+- Modify: `apps/jarvis/frontend/package.json` (add `echarts`)
+
+**Interfaces:**
+- Produces: `buildOption(spec, dark = false) -> echartsOption | null`. `null` for any non-object / unknown `type` / structurally invalid spec.
+
+- [ ] **Step 1: Add the dep**
+
+Edit `package.json` dependencies: add `"echarts": "^5.5.0"`, then `npm install` (node20 PATH).
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+// apps/jarvis/frontend/src/charts/chartTheme.test.js
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { buildOption } from "./chartTheme.js"
+
+test("rejects malformed / unknown specs -> null", () => {
+  assert.equal(buildOption(null), null)
+  assert.equal(buildOption({}), null)
+  assert.equal(buildOption({ type: "pie3d" }), null)
+  assert.equal(buildOption("nope"), null)
+})
+
+test("bar: category x, rounded bars, palette, dashed value split", () => {
+  const o = buildOption({ type: "bar", x: ["A", "B"], series: [{ name: "R", data: [1, 2] }] })
+  assert.equal(o.xAxis.type, "category")
+  assert.deepEqual(o.xAxis.data, ["A", "B"])
+  assert.equal(o.xAxis.axisTick.show, false)
+  assert.equal(o.yAxis.splitLine.lineStyle.type, "dashed")
+  assert.equal(o.series[0].type, "bar")
+  assert.ok(Array.isArray(o.series[0].itemStyle.borderRadius))
+  assert.ok(Array.isArray(o.color) && o.color.length > 0)
+})
+
+test("horizontal bar swaps axes", () => {
+  const o = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], options: { horizontal: true } })
+  assert.equal(o.yAxis.type, "category")
+  assert.equal(o.xAxis.type, "value")
+})
+
+test("line + smooth + area gradient", () => {
+  const o = buildOption({ type: "area", x: ["A", "B"], series: [{ name: "R", data: [1, 2] }], options: { smooth: true } })
+  assert.equal(o.series[0].type, "line")
+  assert.equal(o.series[0].smooth, 0.4)
+  assert.equal(o.series[0].areaStyle.color.type, "linear")  // plain-object gradient, no echarts import
+})
+
+test("stacked sets a shared stack key on every series", () => {
+  const o = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }, { data: [2] }], options: { stacked: true } })
+  assert.equal(o.series[0].stack, o.series[1].stack)
+  assert.ok(o.series[0].stack)
+})
+
+test("pie maps x+series[0] to {name,value}; donut has inner radius", () => {
+  const pie = buildOption({ type: "pie", x: ["A", "B"], series: [{ data: [3, 7] }] })
+  assert.equal(pie.series[0].type, "pie")
+  assert.deepEqual(pie.series[0].data, [{ name: "A", value: 3 }, { name: "B", value: 7 }])
+  const donut = buildOption({ type: "donut", x: ["A"], series: [{ data: [1] }] })
+  assert.ok(Array.isArray(donut.series[0].radius))  // [inner, outer]
+})
+
+test("legend only when >1 series; dark text differs from light", () => {
+  const one = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }] })
+  assert.equal(one.legend, undefined)
+  const dark = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], title: "t" }, true)
+  const light = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], title: "t" }, false)
+  assert.notEqual(dark.xAxis.axisLabel.color, light.xAxis.axisLabel.color)
+})
+```
+
+- [ ] **Step 3: Run it; expect FAIL** (module missing)
+
+Run (node20 PATH, from `apps/jarvis/frontend`): `node --test src/charts/chartTheme.test.js`
+Expected: FAIL (cannot find `./chartTheme.js`).
+
+- [ ] **Step 4: Implement `chartTheme.js`**
+
+```js
+// apps/jarvis/frontend/src/charts/chartTheme.js
+// Safe high-level chart spec -> themed ECharts option. Mirrors Frappe Insights'
+// look (palette, dashed gridlines, no ticks, rounded bars, smooth/gradient).
+// PURE: no echarts import (gradients use plain colorStops objects), so it is
+// unit-testable under node --test. The chat owns the theme; the agent never
+// sends raw ECharts options.
+
+const PALETTE = [
+  "#2490ef", "#48bb74", "#f6ad55", "#fc8181", "#9f7aea",
+  "#38b2ac", "#ed64a6", "#ecc94b", "#667eea", "#a0aec0",
+]
+const TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+
+export function buildOption(spec, dark = false) {
+  if (!spec || typeof spec !== "object" || !TYPES.has(spec.type)) return null
+  const series = Array.isArray(spec.series) ? spec.series : []
+  if (!series.length) return null
+  const text = dark ? "#cbd5e0" : "#333333"
+  const grid = dark ? "#2d3748" : "#e2e8f0"
+  const title = spec.title
+    ? { text: String(spec.title), left: 8, top: 4, textStyle: { fontSize: 13, color: text } }
+    : undefined
+  if (spec.type === "pie" || spec.type === "donut") return pieOption(spec, series, text, title)
+  return axisOption(spec, series, { text, grid, title })
+}
+
+function axisOption(spec, series, { text, grid, title }) {
+  const x = Array.isArray(spec.x) ? spec.x.map(String) : []
+  const opts = spec.options || {}
+  const cat = {
+    type: "category", data: x, axisTick: { show: false },
+    axisLine: { lineStyle: { color: grid } }, axisLabel: { color: text },
+  }
+  const val = {
+    type: "value", axisLabel: { color: text },
+    splitLine: { lineStyle: { type: "dashed", color: grid } },
+  }
+  return {
+    color: PALETTE,
+    title,
+    grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 8, containLabel: true },
+    tooltip: { trigger: "axis", confine: true },
+    legend: series.length > 1 ? { type: "scroll", top: title ? 4 : 0, right: 8, textStyle: { color: text } } : undefined,
+    xAxis: opts.horizontal ? val : cat,
+    yAxis: opts.horizontal ? cat : val,
+    series: series.map((s, i) => makeSeries(spec, s, i)),
+  }
+}
+
+function makeSeries(spec, s, i) {
+  const data = Array.isArray(s.data) ? s.data : []
+  const color = PALETTE[i % PALETTE.length]
+  const opts = spec.options || {}
+  const stack = opts.stacked ? "total" : undefined
+  if (spec.type === "bar") {
+    const r = opts.horizontal ? [0, 4, 4, 0] : [4, 4, 0, 0]
+    return { name: s.name, type: "bar", data, stack, itemStyle: { borderRadius: r } }
+  }
+  const out = {
+    name: s.name, type: "line", data, stack,
+    smooth: opts.smooth ? 0.4 : false, smoothMonotone: "x",
+    showSymbol: false, lineStyle: { width: 2 }, itemStyle: { color },
+  }
+  if (spec.type === "area") {
+    out.areaStyle = {
+      opacity: 0.85,
+      color: { type: "linear", x: 0, y: 0, x2: 0, y2: 1,
+        colorStops: [{ offset: 0, color }, { offset: 1, color: "rgba(255,255,255,0)" }] },
+    }
+  }
+  return out
+}
+
+function pieOption(spec, series, text, title) {
+  const labels = Array.isArray(spec.x) ? spec.x.map(String) : []
+  const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
+  const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: Number(v) || 0 }))
+  return {
+    color: PALETTE,
+    title,
+    tooltip: { trigger: "item", confine: true },
+    legend: { type: "scroll", bottom: 0, textStyle: { color: text } },
+    series: [{
+      type: "pie",
+      radius: spec.type === "donut" ? ["45%", "70%"] : "65%",
+      center: ["50%", title ? "54%" : "48%"],
+      data,
+      label: { color: text },
+      itemStyle: { borderRadius: 4, borderColor: text === "#333333" ? "#fff" : "#1a202c", borderWidth: 1 },
+    }],
+  }
+}
+```
+
+- [ ] **Step 5: Run it; expect PASS**
+
+Run: `node --test src/charts/chartTheme.test.js` -> all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/jarvis/frontend/package.json apps/jarvis/frontend/package-lock.json apps/jarvis/frontend/src/charts/
+git commit -m "feat(chat): echarts + safe chart-spec -> Insights-grade option builder"
+```
+
+---
+
+### Task 2: `JvChart.vue` - the echarts lifecycle component
+
+**Files:**
+- Create: `apps/jarvis/frontend/src/charts/JvChart.vue`
+
+**Interfaces:**
+- Consumes: `buildOption` (Task 1).
+- Produces: `<JvChart :spec="Object" :dark="Boolean" />`. Lazy-imports echarts, inits an SVG chart, re-renders on spec/dark change, resizes with the container, disposes on unmount. Renders a small muted note when `buildOption` returns `null`.
+
+- [ ] **Step 1: Implement**
+
+```vue
+<!-- apps/jarvis/frontend/src/charts/JvChart.vue -->
+<template>
+  <div v-if="invalid" class="jv-chart-bad">Couldn't render this chart.</div>
+  <div v-else ref="el" class="jv-chart"></div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount, computed, nextTick } from "vue"
+import { buildOption } from "./chartTheme.js"
+
+const props = defineProps({ spec: { type: Object, required: true }, dark: { type: Boolean, default: false } })
+const el = ref(null)
+let chart = null
+let ro = null
+
+const option = computed(() => buildOption(props.spec, props.dark))
+const invalid = computed(() => option.value === null)
+
+async function ensure() {
+  if (invalid.value || !el.value) return
+  if (!chart) {
+    const echarts = await import("echarts")          // lazy: off the first-paint path
+    if (!el.value) return
+    chart = echarts.init(el.value, null, { renderer: "svg" })
+    ro = new ResizeObserver(() => chart && chart.resize())
+    ro.observe(el.value)
+  }
+  chart.setOption(option.value, true)
+}
+
+onMounted(() => nextTick(ensure))
+watch(option, ensure)
+onBeforeUnmount(() => {
+  if (ro && el.value) ro.unobserve(el.value)
+  if (chart) { chart.dispose(); chart = null }
+})
+</script>
+
+<style scoped>
+.jv-chart { width: 100%; height: 280px; }
+.jv-chart-bad { font-size: 13px; color: var(--text-3); padding: 8px 0; }
+</style>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build` (node20 PATH) -> build succeeds, `echarts` chunk emitted. (No component unit test - no harness; visual check happens in Task 4.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/jarvis/frontend/src/charts/JvChart.vue
+git commit -m "feat(chat): JvChart.vue - lazy echarts SVG component with resize/dispose"
+```
+
+---
+
+### Task 3: Wire ` ```jarvis-chart ` into `ChatView.vue`
+
+**Files:**
+- Modify: `apps/jarvis/frontend/src/views/ChatView.vue`
+
+**Interfaces:**
+- Consumes: `JvChart` (Task 2).
+- Mirrors the existing `cardsOf(m)` parse + the `stripBlocks` strip + the `jv-cards` template slot.
+
+- [ ] **Step 1: Parser + strip (script section, next to `cardsOf`)**
+
+Add the regex (near `_CARDS_RE`):
+```js
+// A ```jarvis-chart block: a high-level chart spec the chat renders inline with
+// ECharts (themed by chartTheme; the agent never sends raw ECharts options).
+const _CHART_RE = /```jarvis-chart[ \t]*\n([\s\S]*?)```/g
+const _CHART_TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+```
+Add `jarvis-chart` to `stripBlocks` (so it leaves the prose + the copy text):
+```js
+		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
+```
+Add `chartsOf(m)` (mirror `cardsOf`, but returns an array; cached):
+```js
+const _chartsCache = new Map()
+function chartsOf(m) {
+	const content = (m && m.content) || ""
+	if (!content.includes("jarvis-chart")) return []
+	if (_chartsCache.has(content)) return _chartsCache.get(content)
+	const specs = []
+	for (const mt of content.matchAll(_CHART_RE)) {
+		try {
+			const s = JSON.parse(mt[1].trim())
+			if (s && typeof s === "object" && _CHART_TYPES.has(s.type) && Array.isArray(s.series)) {
+				specs.push(s)
+			}
+		} catch (e) { /* incomplete mid-stream JSON -> skip until the block closes */ }
+	}
+	_chartsCache.set(content, specs)
+	return specs
+}
+```
+
+- [ ] **Step 2: Import + register `JvChart`**
+
+In the `<script setup>` imports (near `import { renderMarkdown } from "@/markdown"`):
+```js
+import JvChart from "@/charts/JvChart.vue"
+```
+
+- [ ] **Step 3: Template - render one chart per spec (next to the `jv-cards` block, ~line 312)**
+
+```html
+								<div v-for="(spec, ci) in chartsOf(m)" :key="'chart' + ci" class="jv-chartwrap">
+									<JvChart :spec="spec" :dark="effectiveDark" />
+								</div>
+```
+
+- [ ] **Step 4: CSS (in the component's `<style>`)**
+
+```css
+.jv-chartwrap { margin: 10px 0; border: 1px solid var(--border); border-radius: 10px; padding: 8px 10px; background: var(--surface); }
+```
+(Match the existing `--border` / `--surface` vars used by `jv-cards`.)
+
+- [ ] **Step 5: Build**
+
+Run: `npm run build` -> succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/jarvis/frontend/src/views/ChatView.vue
+git commit -m "feat(chat): render inline jarvis-chart blocks with JvChart"
+```
+
+---
+
+### Task 4: End-to-end visual verification (manual - no harness)
+
+- [ ] **Step 1:** `npm run dev` (node20 PATH), open the chat.
+- [ ] **Step 2:** In a conversation, have the assistant produce (or paste a test assistant message containing) each block and confirm it renders inline, themed, resizes, and toggles with dark mode:
+  - bar: `{"type":"bar","title":"Sales","x":["Jan","Feb","Mar"],"series":[{"name":"Revenue","data":[12,18,15]}]}`
+  - multi-series stacked + line smooth + pie + donut + horizontal bar (one each).
+  - a malformed block -> shows the muted "Couldn't render this chart." note, no console throw.
+- [ ] **Step 3:** Reload the conversation -> charts re-render from the persisted message (block lives in `content`).
+- [ ] **Step 4:** Capture a screenshot for the PR. No commit (verification only).
+
+---
+
+### Task 5 (persona repo): teach the agent to emit ` ```jarvis-chart `
+
+**Files:**
+- Modify: `jarvis-persona/TOOLS.md` (or a small `skills/frappe-core` analytics note) - document the block + spec contract.
+- Modify: `jarvis-persona/version.txt` (bump).
+
+**Interfaces:** the spec contract above; must match `chartsOf`/`buildOption` exactly (`type` in {bar,line,area,pie,donut}; `x`; `series:[{name,data}]`; `options`).
+
+- [ ] **Step 1:** Add a short "Inline charts" section: after gathering data (via `query`/`get_list`/`run_report`), for "chart/plot/visualize/trend X" requests, emit one ` ```jarvis-chart ` block with the spec (one worked example per type). State: prefer this over a ` ```mermaid ` chart for data; keep series small; the chat themes it.
+- [ ] **Step 2:** Bump `version.txt`.
+- [ ] **Step 3:** Run `./lint.sh` from `jarvis-persona` (ASCII/em-dash/validate.py) -> green. (`jarvis-chart` is not a tool, so validate.py's tool checks don't apply; the text-hygiene checks do.)
+- [ ] **Step 4: Commit**
+```bash
+git add TOOLS.md version.txt
+git commit -m "docs(persona): emit jarvis-chart blocks for inline data charts"
+```
+
+---
+
+## Self-review
+
+- **Coverage:** spec contract -> Task 1 (`buildOption`) + Task 5 (agent emits it) + Task 3 (`chartsOf` validates the same shape). Render lifecycle -> Task 2. Inline-in-chat + persistence -> Task 3 (parse from `content`, strip from prose) + Task 4 step 3. Insights look -> Task 1 theme. Safety -> Task 1 (`null` on bad spec, no raw options) + Task 3 (skip unparseable). Dark mode -> Tasks 1-3 (`effectiveDark`). Lazy bundle -> Task 2.
+- **No raw ECharts option crosses the wire** - the agent's `options` is a fixed allow-list of booleans (`stacked`/`smooth`/`horizontal`); everything else is built chat-side.
+- **Streaming-safe:** `chartsOf` skips a block whose JSON doesn't parse yet, so a half-streamed spec simply doesn't render until the closing fence arrives (same as `cardsOf`).
+- **Deferred (not v1):** scatter/heatmap/combo types; data-label toggles; per-series colors from the agent; exporting a chart as an image. Add once the v1 shape is in use.
+```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jarvis-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "echarts": "^5.5.0",
         "frappe-ui": "^0.1.105",
         "mermaid": "^11.15.0",
         "socket.io-client": "^4.7.5",
@@ -55,7 +56,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -496,7 +496,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1106,7 +1105,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
       "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1189,7 +1187,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
       "integrity": "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1385,7 +1382,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
       "integrity": "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1573,7 +1569,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz",
       "integrity": "sha512-J48WIl+6YDYTFPhWXUBQk+u7+AKVUqTdvrZOQyPYCGuQMgHrYzgWrI5+HeEifUgXJ5rMIWWP3qytp7KhVVqpDQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1613,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
       "integrity": "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1628,7 +1622,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
       "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -1690,7 +1683,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.27.1.tgz",
       "integrity": "sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2092,7 +2084,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
       "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@vue/compiler-core": "3.5.38",
@@ -2572,7 +2563,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2973,7 +2963,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3441,7 +3430,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3673,7 +3661,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -4526,13 +4513,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -4805,7 +4785,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4865,7 +4844,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",
@@ -4887,7 +4865,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "echarts": "^5.5.0",
     "frappe-ui": "^0.1.105",
     "mermaid": "^11.15.0",
     "socket.io-client": "^4.7.5",

--- a/frontend/src/charts/JvChart.vue
+++ b/frontend/src/charts/JvChart.vue
@@ -1,0 +1,56 @@
+<template>
+	<div v-if="invalid" class="jv-chart-bad">Couldn't render this chart.</div>
+	<div v-else ref="el" class="jv-chart"></div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount, computed, nextTick } from "vue"
+import { buildOption } from "./chartTheme.js"
+
+const props = defineProps({
+	spec: { type: Object, required: true },
+	dark: { type: Boolean, default: false },
+})
+
+const el = ref(null)
+let chart = null
+let ro = null
+
+const option = computed(() => buildOption(props.spec, props.dark))
+const invalid = computed(() => option.value === null)
+
+async function ensure() {
+	if (invalid.value || !el.value) return
+	if (!chart) {
+		// Lazy import: keep echarts off the first-paint path (mirrors mermaid).
+		const echarts = await import("echarts")
+		if (!el.value) return
+		chart = echarts.init(el.value, null, { renderer: "svg" })
+		ro = new ResizeObserver(() => chart && chart.resize())
+		ro.observe(el.value)
+	}
+	chart.setOption(option.value, true)
+}
+
+onMounted(() => nextTick(ensure))
+watch(option, ensure)
+onBeforeUnmount(() => {
+	if (ro && el.value) ro.unobserve(el.value)
+	if (chart) {
+		chart.dispose()
+		chart = null
+	}
+})
+</script>
+
+<style scoped>
+.jv-chart {
+	width: 100%;
+	height: 280px;
+}
+.jv-chart-bad {
+	font-size: 13px;
+	color: var(--text-3);
+	padding: 8px 0;
+}
+</style>

--- a/frontend/src/charts/chartTheme.js
+++ b/frontend/src/charts/chartTheme.js
@@ -1,0 +1,95 @@
+// Safe high-level chart spec -> themed ECharts option. Mirrors Frappe Insights'
+// look (palette, dashed gridlines, no ticks, rounded bars, smooth/gradient).
+// PURE: no echarts import (gradients use plain colorStops objects), so it is
+// unit-testable under `node --test`. The chat owns the theme; the agent never
+// sends raw ECharts options.
+
+const PALETTE = [
+	"#2490ef", "#48bb74", "#f6ad55", "#fc8181", "#9f7aea",
+	"#38b2ac", "#ed64a6", "#ecc94b", "#667eea", "#a0aec0",
+]
+const TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+
+export function buildOption(spec, dark = false) {
+	if (!spec || typeof spec !== "object" || !TYPES.has(spec.type)) return null
+	const series = Array.isArray(spec.series) ? spec.series : []
+	if (!series.length) return null
+	const text = dark ? "#cbd5e0" : "#333333"
+	const grid = dark ? "#2d3748" : "#e2e8f0"
+	const title = spec.title
+		? { text: String(spec.title), left: 8, top: 4, textStyle: { fontSize: 13, color: text } }
+		: undefined
+	if (spec.type === "pie" || spec.type === "donut") return pieOption(spec, series, text, title)
+	return axisOption(spec, series, { text, grid, title })
+}
+
+function axisOption(spec, series, { text, grid, title }) {
+	const x = Array.isArray(spec.x) ? spec.x.map(String) : []
+	const opts = spec.options || {}
+	const cat = {
+		type: "category", data: x, axisTick: { show: false },
+		axisLine: { lineStyle: { color: grid } }, axisLabel: { color: text },
+	}
+	const val = {
+		type: "value", axisLabel: { color: text },
+		splitLine: { lineStyle: { type: "dashed", color: grid } },
+	}
+	return {
+		color: PALETTE,
+		title,
+		grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 8, containLabel: true },
+		tooltip: { trigger: "axis", confine: true },
+		legend: series.length > 1
+			? { type: "scroll", top: title ? 4 : 0, right: 8, textStyle: { color: text } }
+			: undefined,
+		xAxis: opts.horizontal ? val : cat,
+		yAxis: opts.horizontal ? cat : val,
+		series: series.map((s, i) => makeSeries(spec, s, i)),
+	}
+}
+
+function makeSeries(spec, s, i) {
+	const data = Array.isArray(s.data) ? s.data : []
+	const color = PALETTE[i % PALETTE.length]
+	const opts = spec.options || {}
+	const stack = opts.stacked ? "total" : undefined
+	if (spec.type === "bar") {
+		const r = opts.horizontal ? [0, 4, 4, 0] : [4, 4, 0, 0]
+		return { name: s.name, type: "bar", data, stack, itemStyle: { borderRadius: r } }
+	}
+	const out = {
+		name: s.name, type: "line", data, stack,
+		smooth: opts.smooth ? 0.4 : false, smoothMonotone: "x",
+		showSymbol: false, lineStyle: { width: 2 }, itemStyle: { color },
+	}
+	if (spec.type === "area") {
+		out.areaStyle = {
+			opacity: 0.85,
+			color: {
+				type: "linear", x: 0, y: 0, x2: 0, y2: 1,
+				colorStops: [{ offset: 0, color }, { offset: 1, color: "rgba(255,255,255,0)" }],
+			},
+		}
+	}
+	return out
+}
+
+function pieOption(spec, series, text, title) {
+	const labels = Array.isArray(spec.x) ? spec.x.map(String) : []
+	const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
+	const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: Number(v) || 0 }))
+	return {
+		color: PALETTE,
+		title,
+		tooltip: { trigger: "item", confine: true },
+		legend: { type: "scroll", bottom: 0, textStyle: { color: text } },
+		series: [{
+			type: "pie",
+			radius: spec.type === "donut" ? ["45%", "70%"] : "65%",
+			center: ["50%", title ? "54%" : "48%"],
+			data,
+			label: { color: text },
+			itemStyle: { borderRadius: 4, borderColor: text === "#333333" ? "#fff" : "#1a202c", borderWidth: 1 },
+		}],
+	}
+}

--- a/frontend/src/charts/chartTheme.test.js
+++ b/frontend/src/charts/chartTheme.test.js
@@ -1,0 +1,57 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { buildOption } from "./chartTheme.js"
+
+test("rejects malformed / unknown specs -> null", () => {
+	assert.equal(buildOption(null), null)
+	assert.equal(buildOption({}), null)
+	assert.equal(buildOption({ type: "pie3d" }), null)
+	assert.equal(buildOption("nope"), null)
+	assert.equal(buildOption({ type: "bar", series: [] }), null)
+})
+
+test("bar: category x, rounded bars, palette, dashed value split", () => {
+	const o = buildOption({ type: "bar", x: ["A", "B"], series: [{ name: "R", data: [1, 2] }] })
+	assert.equal(o.xAxis.type, "category")
+	assert.deepEqual(o.xAxis.data, ["A", "B"])
+	assert.equal(o.xAxis.axisTick.show, false)
+	assert.equal(o.yAxis.splitLine.lineStyle.type, "dashed")
+	assert.equal(o.series[0].type, "bar")
+	assert.ok(Array.isArray(o.series[0].itemStyle.borderRadius))
+	assert.ok(Array.isArray(o.color) && o.color.length > 0)
+})
+
+test("horizontal bar swaps axes", () => {
+	const o = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], options: { horizontal: true } })
+	assert.equal(o.yAxis.type, "category")
+	assert.equal(o.xAxis.type, "value")
+})
+
+test("line + smooth + area gradient", () => {
+	const o = buildOption({ type: "area", x: ["A", "B"], series: [{ name: "R", data: [1, 2] }], options: { smooth: true } })
+	assert.equal(o.series[0].type, "line")
+	assert.equal(o.series[0].smooth, 0.4)
+	assert.equal(o.series[0].areaStyle.color.type, "linear")
+})
+
+test("stacked sets a shared stack key on every series", () => {
+	const o = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }, { data: [2] }], options: { stacked: true } })
+	assert.equal(o.series[0].stack, o.series[1].stack)
+	assert.ok(o.series[0].stack)
+})
+
+test("pie maps x+series[0] to {name,value}; donut has inner radius", () => {
+	const pie = buildOption({ type: "pie", x: ["A", "B"], series: [{ data: [3, 7] }] })
+	assert.equal(pie.series[0].type, "pie")
+	assert.deepEqual(pie.series[0].data, [{ name: "A", value: 3 }, { name: "B", value: 7 }])
+	const donut = buildOption({ type: "donut", x: ["A"], series: [{ data: [1] }] })
+	assert.ok(Array.isArray(donut.series[0].radius))
+})
+
+test("legend only when >1 series; dark text differs from light", () => {
+	const one = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }] })
+	assert.equal(one.legend, undefined)
+	const dark = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], title: "t" }, true)
+	const light = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], title: "t" }, false)
+	assert.notEqual(dark.xAxis.axisLabel.color, light.xAxis.axisLabel.color)
+})

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -320,6 +320,10 @@
 										</div>
 									</div>
 								</div>
+								<!-- inline charts: ECharts rendered from the agent's jarvis-chart spec -->
+								<div v-for="(spec, ci) in chartsOf(m)" :key="'chart' + ci" class="jv-chartwrap">
+									<JvChart :spec="spec" :dark="effectiveDark" />
+								</div>
 								<!-- rich outputs: agent artifacts rendered by type (sandboxed) -->
 								<template v-for="cv in (m.canvas || [])" :key="cv.name">
 									<!-- generated image → clickable thumbnail (click to enlarge) -->
@@ -699,6 +703,7 @@ import { ref, computed, inject, onMounted, onBeforeUnmount, nextTick, watch } fr
 import { useRoute } from "vue-router"
 import * as api from "@/api"
 import { renderMarkdown } from "@/markdown"
+import JvChart from "@/charts/JvChart.vue"
 
 const session = inject("$session")
 const socket = inject("$socket")
@@ -1168,6 +1173,10 @@ const _CARDS_RE = /```jarvis-cards[ \t]*\n([\s\S]*?)```/
 // The agent declares which skill(s) it used to shape a reply in a ```jarvis-skill
 // block; the chat shows a small chip and strips the raw block.
 const _SKILL_RE = /```jarvis-skill[ \t]*\n([\s\S]*?)```/
+// A ```jarvis-chart block: a high-level chart spec the chat renders inline with
+// ECharts (themed by chartTheme; the agent never sends raw ECharts options).
+const _CHART_RE = /```jarvis-chart[ \t]*\n([\s\S]*?)```/g
+const _CHART_TYPES = new Set(["bar", "line", "area", "pie", "donut"])
 function stripBlocks(text) {
 	return (text || "")
 		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
@@ -1175,6 +1184,7 @@ function stripBlocks(text) {
 		.replace(/```jarvis-ask[ \t]*\n[\s\S]*?```/g, "")
 		.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, "")
 		.replace(/```jarvis-skill[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
 		.replace(/\n{3,}/g, "\n\n")
 		.trim()
 }
@@ -1227,6 +1237,26 @@ function cardsOf(m) {
 	_cardsCache.set(content, res)
 	return res
 }
+const _chartsCache = new Map()
+function chartsOf(m) {
+	const content = (m && m.content) || ""
+	if (!content.includes("jarvis-chart")) return []
+	if (_chartsCache.has(content)) return _chartsCache.get(content)
+	const specs = []
+	for (const mt of content.matchAll(_CHART_RE)) {
+		try {
+			const s = JSON.parse(mt[1].trim())
+			if (s && typeof s === "object" && _CHART_TYPES.has(s.type) && Array.isArray(s.series)) {
+				specs.push(s)
+			}
+		} catch (e) {
+			/* incomplete mid-stream JSON: skip until the closing fence arrives */
+		}
+	}
+	_chartsCache.set(content, specs)
+	return specs
+}
+
 function askOf(m) {
 	const mt = ((m && m.content) || "").match(_ASK_RE)
 	if (!mt) return null
@@ -2306,6 +2336,7 @@ function onGlobalKey(e) {
 
 /* inline canvas/chart artifacts (rendered sandboxed) */
 .jv-canvas { margin-top: 12px; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: var(--surface); }
+.jv-chartwrap { margin: 10px 0; border: 1px solid var(--border); border-radius: 10px; padding: 8px 10px; background: var(--surface); }
 .jv-canvas-bar { display: flex; align-items: center; gap: 7px; padding: 8px 12px; font-size: 12.5px; font-weight: 550; color: var(--text-2); background: var(--surface-1); border-bottom: 1px solid var(--border); }
 .jv-canvas-bar svg { color: var(--text-3); flex: none; }
 .jv-canvas-type { margin-left: auto; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--text-3); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }


### PR DESCRIPTION
Adds echarts ^5.5.0 (same engine as Insights) + a pure chartTheme.js (safe high-level spec → Insights-grade themed option, 7/7 node --test), JvChart.vue (lazy echarts chunk, SVG, resize/dispose, graceful fallback), and ChatView wiring (chartsOf/stripBlocks/<JvChart>, dark-aware). Charts render inline in the assistant reply; the chat owns the theme (no raw ECharts options from the model). Build passes; echarts code-split off first paint.