### PR TITLE
Long chat turns: worker-independent recovery (never lose, never error)

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -286,6 +286,91 @@ class OpenclawSession:
 			raise OpenclawUnreachableError(f"sessions.create returned no key: {res}")
 		return key
 
+	# -- openclaw-native turn model (chat.send + chat.history + sessions.*) --
+	# Mirrors openclaw's own UI gateway client so the bench can drive a turn
+	# and reconcile from the durable transcript instead of holding the agent
+	# RPC's request stream. Each method below is a plain request/response.
+
+	def chat_send(
+		self, session_key: str, message: str, idempotency_key: str,
+		*, thinking: str | None = None, deliver: bool = False,
+		attachments: list[dict] | None = None,
+		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> dict:
+		"""Start an agent turn via chat.send (openclaw's UI turn-start RPC).
+
+		Returns the ack payload, e.g. {"runId": ..., "status": "in_flight"}.
+		The turn's output is delivered as session-scoped "chat" events (consume
+		them via the relay after subscribe_session), NOT on this response.
+		deliver=False keeps the result session-only (no external channel
+		delivery), matching the current chat path."""
+		params: dict = {
+			"sessionKey": session_key,
+			"message": message,
+			"idempotencyKey": idempotency_key,
+			"deliver": deliver,
+		}
+		if thinking:
+			params["thinking"] = thinking
+		if attachments:
+			params["attachments"] = attachments
+		res = self._request("chat.send", params, timeout_s=timeout_s)
+		return res.get("payload") or {}
+
+	def subscribe_session(
+		self, session_key: str, *, timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> dict:
+		"""Subscribe THIS connection to a session's message events via
+		sessions.messages.subscribe. After this the WS receives the session's
+		message event frames going forward. openclaw keeps no per-run delta
+		buffer, so this yields only FUTURE events - catch up via get_history /
+		get_session_messages on (re)connect."""
+		res = self._request(
+			"sessions.messages.subscribe", {"key": session_key}, timeout_s=timeout_s,
+		)
+		return res.get("payload") or {}
+
+	def get_history(
+		self, session_key: str, *, limit: int = 100, max_chars: int = 4000,
+		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> dict:
+		"""Snapshot the session's DISPLAY transcript via chat.history. Returns
+		{"sessionId", "messages", "thinkingLevel"} - the same projected display
+		messages openclaw's UI renders. The authoritative source of truth used
+		to reconcile after a timeout / reconnect."""
+		res = self._request(
+			"chat.history",
+			{"sessionKey": session_key, "limit": limit, "maxChars": max_chars},
+			timeout_s=timeout_s,
+		)
+		return res.get("payload") or {}
+
+	def get_session_messages(
+		self, session_key: str, *, limit: int = 50,
+		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> list:
+		"""Raw recent transcript tail via sessions.get. Returns the messages
+		list (each: role, content, __openclaw:{seq,id}); [] for an unknown or
+		empty session."""
+		res = self._request(
+			"sessions.get", {"key": session_key, "limit": limit}, timeout_s=timeout_s,
+		)
+		return (res.get("payload") or {}).get("messages") or []
+
+	def is_run_active(
+		self, session_key: str, *, timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> bool:
+		"""Non-destructive done-signal: True iff the gateway is tracking an
+		in-flight run for session_key. Reads sessions.list and matches
+		hasActiveRun on the row whose key == session_key. (Do NOT use
+		sessions.abort for this - it kills the run.)"""
+		res = self._request("sessions.list", {}, timeout_s=timeout_s)
+		sessions = (res.get("payload") or {}).get("sessions") or []
+		for s in sessions:
+			if s.get("key") == session_key:
+				return bool(s.get("hasActiveRun"))
+		return False
+
 	def stream_agent_turn(
 		self, session_key: str, message: str, idempotency_key: str,
 		*,

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -451,7 +451,9 @@ class OpenclawSession:
 				phase = (payload.get("data") or {}).get("phase")
 				if phase in ("end", "error"):
 					return
-		raise OpenclawUnreachableError("agent turn timed out before lifecycle end")
+		raise OpenclawUnreachableError(
+			"agent turn timed out before lifecycle end", code="turn-timeout",
+		)
 
 	# -- internals --------------------------------------------------------
 

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -433,8 +433,16 @@ class OpenclawSession:
 			raise OpenclawUnreachableError("agent RPC never acknowledged")
 
 		# 2. Stream events for this run until lifecycle.end / .error.
+		# The run has started (we have the ack); a WS drop from here is
+		# RECOVERABLE - openclaw keeps running and persists the result - so tag
+		# it code="turn-timeout" to park for recovery, never a false error (#4).
 		while time.monotonic() < deadline:
-			frame = self._recv(deadline - time.monotonic())
+			try:
+				frame = self._recv(deadline - time.monotonic())
+			except OpenclawUnreachableError as e:
+				if getattr(e, "code", None):
+					raise
+				raise OpenclawUnreachableError(str(e), code="turn-timeout") from e
 			if frame is None:
 				continue
 			ftype = frame.get("type")

--- a/jarvis/chat/stale_scan.py
+++ b/jarvis/chat/stale_scan.py
@@ -1,11 +1,18 @@
-"""Scheduled job: mark abandoned streaming Jarvis Chat Messages as errored.
+"""Scheduled job: clean up abandoned streaming Jarvis Chat Messages.
 
 If an RQ worker is killed (OOM, deploy, host restart) mid-stream, its
-Jarvis Chat Message row stays at streaming=1 forever. This scan runs on
-Frappe's scheduler every 5 minutes and times out any streaming message
-older than the threshold, publishing a run:error so the browser can react.
-"""
+Jarvis Chat Message row stays at streaming=1. This scan runs on Frappe's
+scheduler every 5 minutes.
 
+Managed rows (with a gateway session_key, on a managed bench) are RECOVERABLE:
+openclaw persists the result. They are PROMOTED to the recovering state for
+turn_recovery to finalize from the snapshot, but only once they are definitely
+past any live worker (a live managed turn self-marks recovering at the WS cap
+and never reaches here), so a still-streaming turn is never flipped.
+
+Genuinely unrecoverable rows (self-hosted bench, or a row whose conversation /
+session_key is gone) are errored after the short threshold.
+"""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -15,54 +22,59 @@ from frappe.utils import now_datetime
 
 from jarvis.chat.events import publish_to_user
 
+# Error genuinely-abandoned rows (self-hosted / no session) after this.
 STALE_THRESHOLD_SECONDS = 120
+# Promote a managed row to recovering only once it is past the RQ worker cap,
+# so it is definitely orphaned (no live worker survives past the cap, and a
+# live turn self-marks recovering at the 600s WS cap well before this).
+MANAGED_RECOVER_AFTER_SECONDS = 720
 MSG = "Jarvis Chat Message"
 CONV = "Jarvis Conversation"
+_ABANDONED = "Run abandoned (worker did not finish within the timeout)."
 
 
 def scan_and_mark_errored() -> int:
-	"""Scan for stale streaming messages.
+	"""Scan stale streaming rows: promote recoverable managed rows to
+	recovering, error the rest. Returns the count of rows ERRORED."""
+	from jarvis import selfhost
 
-	Managed rows (with a gateway session_key) are RECOVERABLE - openclaw
-	persists the result - so instead of erroring we promote them to the
-	recovering state for turn_recovery to finalize from the snapshot. This
-	also catches workers hard-killed BEFORE they could mark recovering. Only
-	genuinely unrecoverable rows (self-hosted, no session_key) are errored
-	here; rows already recovering are skipped (turn_recovery owns them).
+	now = now_datetime()
+	self_hosted = selfhost.is_self_hosted()
+	managed_cutoff = now - timedelta(seconds=MANAGED_RECOVER_AFTER_SECONDS)
+	error_cutoff = now - timedelta(seconds=STALE_THRESHOLD_SECONDS)
 
-	Returns the count of rows ERRORED (not promoted).
-	"""
-	cutoff = now_datetime() - timedelta(seconds=STALE_THRESHOLD_SECONDS)
+	# LEFT JOIN so a streaming row whose conversation was deleted is still
+	# handled (session_key resolves NULL -> errored), not silently dropped.
 	rows = frappe.db.sql(
 		"""
-		SELECT m.name, m.conversation, c.owner, c.session_key
+		SELECT m.name, m.conversation, m.creation, c.owner, c.session_key
 		FROM `tabJarvis Chat Message` m
-		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
-		WHERE m.streaming = 1 AND m.recovering = 0 AND m.creation < %s
+		LEFT JOIN `tabJarvis Conversation` c ON c.name = m.conversation
+		WHERE m.streaming = 1 AND m.recovering = 0
 		""",
-		(cutoff,),
 		as_dict=True,
 	)
 
 	errored = 0
 	for r in rows:
-		if (r.get("session_key") or "").strip():
-			# Recoverable: hand off to turn_recovery rather than error.
-			frappe.db.set_value(MSG, r["name"], {
-				"recovering": 1,
-				"recovery_started_at": now_datetime(),
-			})
+		creation = r.get("creation")
+		recoverable = (not self_hosted) and bool((r.get("session_key") or "").strip())
+		if recoverable:
+			if creation and creation < managed_cutoff:
+				frappe.db.set_value(MSG, r["name"], {
+					"recovering": 1, "recovery_started_at": now,
+				})
 			continue
-		frappe.db.set_value(MSG, r["name"], {
-			"streaming": 0,
-			"error": "Run abandoned (worker did not finish within the timeout).",
-		})
-		publish_to_user(r["owner"], {
-			"kind": "run:error",
-			"conversation_id": r["conversation"],
-			"message_id": r["name"],
-			"error": "Run abandoned (worker did not finish within the timeout).",
-		})
-		errored += 1
+		# Self-hosted / orphaned / no session: genuinely unrecoverable.
+		if creation and creation < error_cutoff:
+			frappe.db.set_value(MSG, r["name"], {"streaming": 0, "error": _ABANDONED})
+			if r.get("owner"):
+				publish_to_user(r["owner"], {
+					"kind": "run:error",
+					"conversation_id": r["conversation"],
+					"message_id": r["name"],
+					"error": _ABANDONED,
+				})
+			errored += 1
 	frappe.db.commit()
 	return errored

--- a/jarvis/chat/stale_scan.py
+++ b/jarvis/chat/stale_scan.py
@@ -21,32 +21,48 @@ CONV = "Jarvis Conversation"
 
 
 def scan_and_mark_errored() -> int:
-	"""Scan for stale streaming messages; mark them errored and publish.
+	"""Scan for stale streaming messages.
 
-	Returns the count of messages marked.
+	Managed rows (with a gateway session_key) are RECOVERABLE - openclaw
+	persists the result - so instead of erroring we promote them to the
+	recovering state for turn_recovery to finalize from the snapshot. This
+	also catches workers hard-killed BEFORE they could mark recovering. Only
+	genuinely unrecoverable rows (self-hosted, no session_key) are errored
+	here; rows already recovering are skipped (turn_recovery owns them).
+
+	Returns the count of rows ERRORED (not promoted).
 	"""
 	cutoff = now_datetime() - timedelta(seconds=STALE_THRESHOLD_SECONDS)
-	stale_names = frappe.db.sql(
+	rows = frappe.db.sql(
 		"""
-		SELECT name FROM `tabJarvis Chat Message`
-		WHERE streaming = 1 AND creation < %s
+		SELECT m.name, m.conversation, c.owner, c.session_key
+		FROM `tabJarvis Chat Message` m
+		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
+		WHERE m.streaming = 1 AND m.recovering = 0 AND m.creation < %s
 		""",
 		(cutoff,),
-		as_dict=False,
+		as_dict=True,
 	)
 
-	for (name,) in stale_names:
-		conv_name = frappe.db.get_value(MSG, name, "conversation")
-		owner = frappe.db.get_value(CONV, conv_name, "owner")
-		frappe.db.set_value(MSG, name, {
+	errored = 0
+	for r in rows:
+		if (r.get("session_key") or "").strip():
+			# Recoverable: hand off to turn_recovery rather than error.
+			frappe.db.set_value(MSG, r["name"], {
+				"recovering": 1,
+				"recovery_started_at": now_datetime(),
+			})
+			continue
+		frappe.db.set_value(MSG, r["name"], {
 			"streaming": 0,
 			"error": "Run abandoned (worker did not finish within the timeout).",
 		})
-		publish_to_user(owner, {
+		publish_to_user(r["owner"], {
 			"kind": "run:error",
-			"conversation_id": conv_name,
-			"message_id": name,
+			"conversation_id": r["conversation"],
+			"message_id": r["name"],
 			"error": "Run abandoned (worker did not finish within the timeout).",
 		})
+		errored += 1
 	frappe.db.commit()
-	return len(stale_names)
+	return errored

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -383,6 +383,13 @@ def handle_chat_send(payload: dict) -> None:
 						attachments=_to_managed_attachments(vision_parts) if vision_parts else None,
 					))
 			except OpenclawUnreachableError as e:
+				if getattr(e, "code", None) == "turn-timeout":
+					# openclaw is still running this turn and persists the
+					# result; park the row for snapshot recovery instead of
+					# falsely erroring. Spinner stays up (streaming=1) and
+					# turn_recovery finalizes it from the gateway snapshot.
+					_mark_recovering(assistant_msg.name)
+					return
 				_publish_run_error(str(e))
 				return
 
@@ -627,6 +634,17 @@ def _mark_errored(assistant_msg_name: str, error: str) -> None:
 	frappe.db.set_value(MSG, assistant_msg_name, {
 		"streaming": 0,
 		"error": error,
+	})
+	frappe.db.commit()
+
+
+def _mark_recovering(assistant_msg_name: str) -> None:
+	"""Park a managed turn for snapshot recovery instead of erroring: openclaw
+	is still running/finished and turn_recovery will finalize it from the
+	gateway snapshot. streaming stays 1 (spinner up); no error, no run:error."""
+	frappe.db.set_value(MSG, assistant_msg_name, {
+		"recovering": 1,
+		"recovery_started_at": frappe.utils.now_datetime(),
 	})
 	frappe.db.commit()
 

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -1,0 +1,183 @@
+"""Scheduler-driven recovery for managed chat turns that the bench abandoned.
+
+A long turn can outrun the bench's WS cap, or its RQ worker can be hard-killed
+(SIGTERM at the 720s job cap, OOM, crash, deploy). openclaw keeps running the
+turn and persists the result regardless. So instead of falsely erroring, the
+turn is left `streaming=1, recovering=1` and this job finalizes it from the
+gateway's durable transcript.
+
+This is worker/process-INDEPENDENT: everything it needs survives a worker
+death (the row, conv.session_key, openclaw's transcript). Completion is the
+non-destructive `is_run_active` signal; content comes from `chat.history`.
+Mirrors how openclaw's own UI reconciles after a drop (snapshot, not deltas).
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+import frappe
+
+from jarvis.chat.events import publish_to_user
+from jarvis.chat.openclaw_client import OpenclawSession
+
+MSG = "Jarvis Chat Message"
+CONV = "Jarvis Conversation"
+
+# Absolute give-up: a run still "active" past this long is treated as stuck.
+_RECOVERY_CEILING_MINUTES = 60
+# One extra cycle of grace before declaring a finished-but-empty run a failure
+# (covers the brief window where the run just ended and the transcript final
+# message has not flushed yet).
+_EMPTY_GRACE_MINUTES = 3
+
+
+@contextlib.contextmanager
+def _recovery_connection(gateway_url: str) -> Iterator[OpenclawSession]:
+	"""A dedicated short-lived connection for recovery. NEVER the shared pool
+	(openclaw_session_pool is single-turn-exclusive and not concurrency-safe)."""
+	sess = OpenclawSession.connect(gateway_url)
+	try:
+		yield sess
+	finally:
+		sess.close()
+
+
+def _age_minutes(dt) -> float:
+	if not dt:
+		return 0.0
+	delta = frappe.utils.now_datetime() - frappe.utils.get_datetime(dt)
+	return delta.total_seconds() / 60.0
+
+
+def _latest_assistant_text(messages: list) -> str:
+	"""Newest assistant message text from a chat.history snapshot. Handles a
+	plain-string content and the {type:"text", text} block list. Sorted by the
+	transcript seq so the latest turn wins."""
+	def seq(m):
+		return ((m or {}).get("__openclaw") or {}).get("seq", 0)
+
+	for m in sorted(messages or [], key=seq, reverse=True):
+		if (m.get("role") or "").lower() != "assistant":
+			continue
+		c = m.get("content")
+		if isinstance(c, str) and c.strip():
+			return c
+		if isinstance(c, list):
+			parts = [
+				b.get("text", "") for b in c
+				if isinstance(b, dict) and b.get("type") == "text" and b.get("text")
+			]
+			joined = "\n".join(p for p in parts if p.strip())
+			if joined.strip():
+				return joined
+		if isinstance(m.get("text"), str) and m["text"].strip():
+			return m["text"]
+	return ""
+
+
+def _finalize(row: dict, text: str) -> None:
+	"""Authoritative completion: overwrite content from the snapshot (NOT
+	append, so partial streamed content is replaced with no duplication),
+	clear the streaming/recovering flags, then publish for any live viewer
+	using the existing jarvis:event kinds the SPA already renders."""
+	name = row["name"]
+	frappe.db.set_value(
+		MSG, name, {"content": text, "streaming": 0, "recovering": 0, "error": ""},
+	)
+	frappe.db.commit()
+	conv, owner = row["conversation"], row["owner"]
+	publish_to_user(owner, {
+		"kind": "assistant:delta", "conversation_id": conv,
+		"message_id": name, "text": text, "run_id": "recovered",
+	})
+	publish_to_user(owner, {
+		"kind": "run:end", "conversation_id": conv,
+		"message_id": name, "run_id": "recovered",
+	})
+
+
+def _error(row: dict, message: str) -> None:
+	name = row["name"]
+	frappe.db.set_value(
+		MSG, name, {"streaming": 0, "recovering": 0, "error": message},
+	)
+	frappe.db.commit()
+	publish_to_user(row["owner"], {
+		"kind": "run:error", "conversation_id": row["conversation"],
+		"message_id": name, "run_id": "recovered", "error": message,
+	})
+
+
+def _recover_one(sess: OpenclawSession, row: dict) -> str:
+	"""Drive one recovering row to a terminal state. Returns the outcome
+	('finalized' | 'active' | 'errored' | 'waiting')."""
+	session_key = row["session_key"]
+	if sess.is_run_active(session_key):
+		if _age_minutes(row["recovery_started_at"]) > _RECOVERY_CEILING_MINUTES:
+			_error(row, "Run exceeded the recovery ceiling.")
+			return "errored"
+		return "active"
+	# Not active: openclaw finished (or never started). Reconcile from snapshot.
+	hist = sess.get_history(session_key)
+	text = _latest_assistant_text(hist.get("messages") or [])
+	if text:
+		_finalize(row, text)
+		return "finalized"
+	if _age_minutes(row["recovery_started_at"]) > _EMPTY_GRACE_MINUTES:
+		_error(row, "Run finished with no assistant output.")
+		return "errored"
+	return "waiting"
+
+
+def recover_pending_turns(limit: int = 20) -> dict:
+	"""Scheduler entry: finalize managed turns stuck in the recovering state.
+	Self-hosted turns have no gateway transcript to recover from, so they are
+	left to stale_scan. Best-effort: a connect or per-row failure logs and the
+	next cycle retries."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		return {"skipped": "self-hosted"}
+
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace(
+		"http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return {"skipped": "no gateway"}
+
+	rows = frappe.db.sql(
+		"""
+		SELECT m.name, m.conversation, c.session_key, c.owner,
+			   m.recovery_started_at
+		FROM `tabJarvis Chat Message` m
+		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
+		WHERE m.streaming = 1 AND m.recovering = 1
+		  AND c.session_key IS NOT NULL AND c.session_key != ''
+		ORDER BY m.recovery_started_at ASC
+		LIMIT %(limit)s
+		""",
+		{"limit": limit},
+		as_dict=True,
+	)
+	if not rows:
+		return {"checked": 0}
+
+	counts = {"finalized": 0, "active": 0, "errored": 0, "waiting": 0}
+	try:
+		with _recovery_connection(gateway_url) as sess:
+			for row in rows:
+				try:
+					counts[_recover_one(sess, row)] += 1
+				except Exception:
+					frappe.log_error(
+						title="turn_recovery: row failed",
+						message=frappe.get_traceback(),
+					)
+	except Exception:
+		frappe.log_error(
+			title="turn_recovery: connect failed",
+			message=frappe.get_traceback(),
+		)
+		return {"checked": len(rows), "connect_failed": True}
+	return {"checked": len(rows), **counts}

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -6,10 +6,17 @@ turn and persists the result regardless. So instead of falsely erroring, the
 turn is left `streaming=1, recovering=1` and this job finalizes it from the
 gateway's durable transcript.
 
-This is worker/process-INDEPENDENT: everything it needs survives a worker
-death (the row, conv.session_key, openclaw's transcript). Completion is the
-non-destructive `is_run_active` signal; content comes from `chat.history`.
-Mirrors how openclaw's own UI reconciles after a drop (snapshot, not deltas).
+Design notes (from the 2026-06-30 review):
+- Content comes from the RAW transcript (sessions.get), never chat.history,
+  which truncates assistant text at max_chars.
+- Only the LATEST recovering row per conversation is snapshot-finalized, so the
+  session-wide "newest assistant message" can never bleed onto an older row.
+- There is an UNCONDITIONAL ceiling backstop: a row past the ceiling is errored
+  even when the gateway is unreachable, so a managed turn can never be stranded
+  at a perpetual spinner.
+- Finalize/error are conditional (only act on a row still streaming=1 AND
+  recovering=1), so overlapping cycles cannot double-deliver.
+- is_run_active is read ONCE per cycle (sessions.list is expensive), not per row.
 """
 from __future__ import annotations
 
@@ -24,12 +31,10 @@ from jarvis.chat.openclaw_client import OpenclawSession
 MSG = "Jarvis Chat Message"
 CONV = "Jarvis Conversation"
 
-# Absolute give-up: a run still "active" past this long is treated as stuck.
+# Absolute give-up: a row recovering longer than this is errored, gateway
+# reachable or not. The unconditional backstop that replaces the old
+# time-based stale_scan error path.
 _RECOVERY_CEILING_MINUTES = 60
-# One extra cycle of grace before declaring a finished-but-empty run a failure
-# (covers the brief window where the run just ended and the transcript final
-# message has not flushed yet).
-_EMPTY_GRACE_MINUTES = 3
 
 
 @contextlib.contextmanager
@@ -51,9 +56,9 @@ def _age_minutes(dt) -> float:
 
 
 def _latest_assistant_text(messages: list) -> str:
-	"""Newest assistant message text from a chat.history snapshot. Handles a
+	"""Newest assistant message text from a raw transcript. Handles a
 	plain-string content and the {type:"text", text} block list. Sorted by the
-	transcript seq so the latest turn wins."""
+	transcript seq so the latest turn wins. Every text source is type-guarded."""
 	def seq(m):
 		return ((m or {}).get("__openclaw") or {}).get("seq", 0)
 
@@ -66,27 +71,44 @@ def _latest_assistant_text(messages: list) -> str:
 		if isinstance(c, list):
 			parts = [
 				b.get("text", "") for b in c
-				if isinstance(b, dict) and b.get("type") == "text" and b.get("text")
+				if isinstance(b, dict) and b.get("type") == "text"
+				and isinstance(b.get("text"), str) and b.get("text")
 			]
 			joined = "\n".join(p for p in parts if p.strip())
 			if joined.strip():
 				return joined
-		if isinstance(m.get("text"), str) and m["text"].strip():
-			return m["text"]
+		t = m.get("text")
+		if isinstance(t, str) and t.strip():
+			return t
 	return ""
 
 
-def _finalize(row: dict, text: str) -> None:
-	"""Authoritative completion: overwrite content from the snapshot (NOT
-	append, so partial streamed content is replaced with no duplication),
-	clear the streaming/recovering flags, then publish for any live viewer
-	using the existing jarvis:event kinds the SPA already renders."""
-	name = row["name"]
-	frappe.db.set_value(
-		MSG, name, {"content": text, "streaming": 0, "recovering": 0, "error": ""},
+def _conditional_clear(name: str, fields: dict) -> bool:
+	"""Apply `fields` to a row ONLY if it is still streaming=1 AND recovering=1.
+	Returns True if this call won the row (so the caller publishes), False if
+	another cycle already finalized it. Idempotency guard for #8."""
+	set_clause = ", ".join(f"`{k}` = %({k})s" for k in fields)
+	params = dict(fields, name=name)
+	frappe.db.sql(
+		f"UPDATE `tab{MSG}` SET {set_clause} "
+		f"WHERE name = %(name)s AND streaming = 1 AND recovering = 1",
+		params,
 	)
+	# Read rowcount BEFORE commit (commit can reset the cursor).
+	cursor = getattr(frappe.db, "_cursor", None)
+	won = bool(cursor and cursor.rowcount)
 	frappe.db.commit()
-	conv, owner = row["conversation"], row["owner"]
+	return won
+
+
+def _finalize(row: dict, text: str) -> None:
+	"""Authoritative completion (conditional + idempotent): overwrite content
+	from the raw snapshot, clear the flags, then publish for any live viewer."""
+	if not _conditional_clear(row["name"], {
+		"content": text, "streaming": 0, "recovering": 0, "error": "",
+	}):
+		return  # another cycle already finalized this row
+	conv, owner, name = row["conversation"], row["owner"], row["name"]
 	publish_to_user(owner, {
 		"kind": "assistant:delta", "conversation_id": conv,
 		"message_id": name, "text": text, "run_id": "recovered",
@@ -98,63 +120,46 @@ def _finalize(row: dict, text: str) -> None:
 
 
 def _error(row: dict, message: str) -> None:
-	name = row["name"]
-	frappe.db.set_value(
-		MSG, name, {"streaming": 0, "recovering": 0, "error": message},
-	)
-	frappe.db.commit()
+	if not _conditional_clear(row["name"], {
+		"streaming": 0, "recovering": 0, "error": message,
+	}):
+		return
 	publish_to_user(row["owner"], {
 		"kind": "run:error", "conversation_id": row["conversation"],
-		"message_id": name, "run_id": "recovered", "error": message,
+		"message_id": row["name"], "run_id": "recovered", "error": message,
 	})
 
 
-def _recover_one(sess: OpenclawSession, row: dict) -> str:
-	"""Drive one recovering row to a terminal state. Returns the outcome
-	('finalized' | 'active' | 'errored' | 'waiting')."""
-	session_key = row["session_key"]
-	if sess.is_run_active(session_key):
-		if _age_minutes(row["recovery_started_at"]) > _RECOVERY_CEILING_MINUTES:
-			_error(row, "Run exceeded the recovery ceiling.")
-			return "errored"
-		return "active"
-	# Not active: openclaw finished (or never started). Reconcile from snapshot.
-	hist = sess.get_history(session_key)
-	text = _latest_assistant_text(hist.get("messages") or [])
-	if text:
-		_finalize(row, text)
-		return "finalized"
-	if _age_minutes(row["recovery_started_at"]) > _EMPTY_GRACE_MINUTES:
-		_error(row, "Run finished with no assistant output.")
-		return "errored"
-	return "waiting"
+def _active_map(sess: OpenclawSession) -> dict:
+	"""One sessions.list per cycle -> {session_key: hasActiveRun}. Replaces the
+	per-row is_run_active call (#13)."""
+	res = sess._request("sessions.list", {}, timeout_s=10)
+	out = {}
+	for s in (res.get("payload") or {}).get("sessions") or []:
+		if s.get("key"):
+			out[s["key"]] = bool(s.get("hasActiveRun"))
+	return out
 
 
 def recover_pending_turns(limit: int = 20) -> dict:
-	"""Scheduler entry: finalize managed turns stuck in the recovering state.
-	Self-hosted turns have no gateway transcript to recover from, so they are
-	left to stale_scan. Best-effort: a connect or per-row failure logs and the
-	next cycle retries."""
+	"""Scheduler entry: finalize managed turns stuck in the recovering state."""
 	from jarvis import selfhost
 
 	if selfhost.is_self_hosted():
 		return {"skipped": "self-hosted"}
 
-	settings = frappe.get_single("Jarvis Settings")
-	gateway_url = (settings.agent_url or "").replace(
-		"http://", "ws://").replace("https://", "wss://")
-	if not gateway_url:
-		return {"skipped": "no gateway"}
-
+	# Query rows FIRST (so we never load Settings on an empty bench, #14).
+	# Ordered conversation, seq DESC so the first row per conversation is the
+	# latest (used for the no-bleed dedup, #2).
 	rows = frappe.db.sql(
 		"""
 		SELECT m.name, m.conversation, c.session_key, c.owner,
-			   m.recovery_started_at
+			   m.recovery_started_at, m.seq
 		FROM `tabJarvis Chat Message` m
 		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
 		WHERE m.streaming = 1 AND m.recovering = 1
 		  AND c.session_key IS NOT NULL AND c.session_key != ''
-		ORDER BY m.recovery_started_at ASC
+		ORDER BY m.conversation ASC, m.seq DESC
 		LIMIT %(limit)s
 		""",
 		{"limit": limit},
@@ -164,20 +169,69 @@ def recover_pending_turns(limit: int = 20) -> dict:
 		return {"checked": 0}
 
 	counts = {"finalized": 0, "active": 0, "errored": 0, "waiting": 0}
+
+	# UNCONDITIONAL backstop FIRST (#3/#5): error anything past the ceiling,
+	# gateway reachable or not, so a row is never stranded at a spinner.
+	live = []
+	for r in rows:
+		if _age_minutes(r["recovery_started_at"]) > _RECOVERY_CEILING_MINUTES:
+			_error(r, "Run did not finish within the recovery window.")
+			counts["errored"] += 1
+		else:
+			live.append(r)
+	if not live:
+		return {"checked": len(rows), **counts}
+
+	# Only the LATEST recovering row per conversation is eligible for snapshot
+	# finalize (#2: never assign the session-wide newest answer to an older row).
+	# Older recovering rows ride the ceiling backstop above.
+	eligible = {}
+	for r in live:  # seq DESC, so first seen per conversation is the latest
+		eligible.setdefault(r["conversation"], r)
+	eligible = list(eligible.values())
+
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace(
+		"http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return {"checked": len(rows), **counts, "skipped": "no gateway"}
+
 	try:
 		with _recovery_connection(gateway_url) as sess:
-			for row in rows:
+			active = _active_map(sess)  # one sessions.list per cycle (#13)
+			for r in eligible:
 				try:
-					counts[_recover_one(sess, row)] += 1
+					counts[_recover_one(sess, r, active)] += 1
 				except Exception:
 					frappe.log_error(
 						title="turn_recovery: row failed",
 						message=frappe.get_traceback(),
 					)
 	except Exception:
+		# Gateway unreachable this cycle. The ceiling backstop already ran, so
+		# nothing is stranded; non-expired rows simply retry next cycle.
 		frappe.log_error(
 			title="turn_recovery: connect failed",
 			message=frappe.get_traceback(),
 		)
-		return {"checked": len(rows), "connect_failed": True}
+		return {"checked": len(rows), **counts, "connect_failed": True}
 	return {"checked": len(rows), **counts}
+
+
+def _recover_one(sess: OpenclawSession, row: dict, active: dict) -> str:
+	"""Drive one eligible (latest-per-conversation) recovering row. Returns
+	'finalized' | 'active' | 'waiting'. Ceiling/error is handled by the caller
+	and the unconditional backstop, not here."""
+	session_key = row["session_key"]
+	# Absent from sessions.list -> treat as not-active, but only finalize when
+	# the transcript actually has content (#9: never finalize from a stale
+	# snapshot just because a row vanished from the gateway's in-memory list).
+	if active.get(session_key, False):
+		return "active"
+	# Raw transcript (sessions.get), NOT chat.history -> no max_chars truncation (#1).
+	messages = sess.get_session_messages(session_key, limit=50)
+	text = _latest_assistant_text(messages)
+	if text:
+		_finalize(row, text)
+		return "finalized"
+	return "waiting"  # no output yet; the ceiling backstop bounds the wait

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -153,6 +153,9 @@ scheduler_events = {
 		"*/5 * * * *": [
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
 		],
+		"*/2 * * * *": [
+			"jarvis.chat.turn_recovery.recover_pending_turns",
+		],
 	},
 	"hourly": [
 		# Sprint-3 (2026-06-16 review): bench has no way to know if the

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -13,6 +13,8 @@
     "content",
     "streaming",
     "error",
+    "recovering",
+    "recovery_started_at",
     "tool_name",
     "tool_args",
     "tool_result",
@@ -60,6 +62,19 @@
       "fieldname": "error",
       "fieldtype": "Long Text",
       "label": "Error"
+    },
+    {
+      "fieldname": "recovering",
+      "fieldtype": "Check",
+      "label": "Recovering",
+      "default": 0,
+      "description": "True while a managed turn timed out or dropped on the bench but openclaw is presumed still working or finished. turn_recovery finalizes it from the gateway snapshot instead of erroring. streaming stays 1 so the UI keeps the spinner."
+    },
+    {
+      "fieldname": "recovery_started_at",
+      "fieldtype": "Datetime",
+      "label": "Recovery Started At",
+      "description": "When this row entered the recovering state. Bounds the recovery window against an absolute ceiling."
     },
     {
       "fieldname": "tool_name",

--- a/jarvis/tests/test_chat_stale_scan.py
+++ b/jarvis/tests/test_chat_stale_scan.py
@@ -93,10 +93,12 @@ class TestScanAndMarkErrored(FrappeTestCase):
 		# A stale streaming row whose conversation has a gateway session_key is
 		# recoverable: promoted to recovering (handed to turn_recovery), NOT
 		# errored. Covers a worker hard-killed before it could mark recovering.
+		# Past the 720s managed cap so it is definitely orphaned, not live.
 		frappe.db.set_value(CONV, self.conv, "session_key", "sk_managed")
 		frappe.db.commit()
-		name = self._insert_stale_streaming_message(age_seconds=300)
-		with patch("jarvis.chat.stale_scan.publish_to_user") as pub:
+		name = self._insert_stale_streaming_message(age_seconds=800)
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.stale_scan.publish_to_user") as pub:
 			scan_and_mark_errored()
 		doc = frappe.get_doc(MSG, name)
 		self.assertEqual(doc.streaming, 1)   # spinner stays up

--- a/jarvis/tests/test_chat_stale_scan.py
+++ b/jarvis/tests/test_chat_stale_scan.py
@@ -88,3 +88,18 @@ class TestScanAndMarkErrored(FrappeTestCase):
 		doc.reload()
 		self.assertEqual(doc.streaming, 0)
 		self.assertIsNone(doc.error)
+
+	def test_promotes_managed_streaming_to_recovering(self):
+		# A stale streaming row whose conversation has a gateway session_key is
+		# recoverable: promoted to recovering (handed to turn_recovery), NOT
+		# errored. Covers a worker hard-killed before it could mark recovering.
+		frappe.db.set_value(CONV, self.conv, "session_key", "sk_managed")
+		frappe.db.commit()
+		name = self._insert_stale_streaming_message(age_seconds=300)
+		with patch("jarvis.chat.stale_scan.publish_to_user") as pub:
+			scan_and_mark_errored()
+		doc = frappe.get_doc(MSG, name)
+		self.assertEqual(doc.streaming, 1)   # spinner stays up
+		self.assertEqual(doc.recovering, 1)  # handed to turn_recovery
+		self.assertIsNone(doc.error)
+		pub.assert_not_called()              # no false run:error

--- a/jarvis/tests/test_openclaw_native_rpcs.py
+++ b/jarvis/tests/test_openclaw_native_rpcs.py
@@ -83,3 +83,43 @@ class TestOpenclawNativeRpcs(FrappeTestCase):
 		self.assertFalse(sess.is_run_active("sk"))
 		cap["response"] = {"ok": True, "payload": {"sessions": []}}
 		self.assertFalse(sess.is_run_active("sk"))
+
+	def test_stream_agent_turn_tags_midstream_drop_as_turn_timeout(self):
+		# A WS drop AFTER the run is acked must surface code="turn-timeout" so
+		# turn_handler parks it for recovery instead of false-erroring (#4).
+		from jarvis.chat.openclaw_client import OpenclawUnreachableError
+		sess = OpenclawSession.__new__(OpenclawSession)
+		frames = [{"type": "res", "id": "a1", "ok": True, "payload": {"runId": "r1"}}]
+		sess._send = lambda method, params: "a1"
+
+		def fake_recv(_timeout):
+			if frames:
+				return frames.pop(0)
+			raise OpenclawUnreachableError("ws closed mid-stream")
+
+		sess._recv = fake_recv
+		with self.assertRaises(OpenclawUnreachableError) as ctx:
+			list(sess.stream_agent_turn("sk", "hi", "idem"))
+		self.assertEqual(getattr(ctx.exception, "code", None), "turn-timeout")
+
+	def test_stream_agent_turn_propagates_preack_failure_uncoded(self):
+		# A failure BEFORE the ack (run never started) must NOT be turn-timeout,
+		# so turn_handler errors it rather than parking a non-existent run.
+		from jarvis.chat.openclaw_client import OpenclawUnreachableError
+		sess = OpenclawSession.__new__(OpenclawSession)
+		sess._send = lambda method, params: "a1"
+
+		def fake_recv(_timeout):
+			raise OpenclawUnreachableError("ws closed before ack")
+
+		sess._recv = fake_recv
+		with self.assertRaises(OpenclawUnreachableError) as ctx:
+			list(sess.stream_agent_turn("sk", "hi", "idem"))
+		self.assertNotEqual(getattr(ctx.exception, "code", None), "turn-timeout")
+
+	def test_subscribe_session_params_and_payload(self):
+		sess, cap = self._sess({"ok": True, "payload": {"subscribed": True}})
+		out = sess.subscribe_session("sk")
+		self.assertEqual(cap["method"], "sessions.messages.subscribe")
+		self.assertEqual(cap["params"], {"key": "sk"})
+		self.assertEqual(out, {"subscribed": True})

--- a/jarvis/tests/test_openclaw_native_rpcs.py
+++ b/jarvis/tests/test_openclaw_native_rpcs.py
@@ -1,0 +1,85 @@
+"""Unit tests for the openclaw-native RPC methods on OpenclawSession.
+
+These mirror openclaw's own UI gateway model (chat.send + chat.history +
+sessions.list/get), so the bench can drive turns and reconcile from the
+durable transcript instead of holding the agent RPC's request stream.
+
+Each method is request/response, so we bypass __init__ and stub _request.
+"""
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.openclaw_client import OpenclawSession
+
+
+class TestOpenclawNativeRpcs(FrappeTestCase):
+	def _sess(self, response):
+		sess = OpenclawSession.__new__(OpenclawSession)  # bypass __init__/WS
+		captured = {"response": response}
+
+		def fake_request(method, params, *, timeout_s):
+			captured["method"] = method
+			captured["params"] = params
+			return captured["response"]
+
+		sess._request = fake_request
+		return sess, captured
+
+	def test_chat_send_required_params_and_returns_payload(self):
+		sess, cap = self._sess(
+			{"ok": True, "payload": {"runId": "r1", "status": "in_flight"}}
+		)
+		out = sess.chat_send("sk", "hi", "idem1", thinking="low")
+		self.assertEqual(cap["method"], "chat.send")
+		self.assertEqual(cap["params"]["sessionKey"], "sk")
+		self.assertEqual(cap["params"]["message"], "hi")
+		self.assertEqual(cap["params"]["idempotencyKey"], "idem1")
+		self.assertEqual(cap["params"]["deliver"], False)
+		self.assertEqual(cap["params"]["thinking"], "low")
+		self.assertEqual(out, {"runId": "r1", "status": "in_flight"})
+
+	def test_chat_send_omits_optional_when_unset(self):
+		sess, cap = self._sess({"ok": True, "payload": {"runId": "r2"}})
+		sess.chat_send("sk", "hi", "idem2")
+		self.assertNotIn("thinking", cap["params"])
+		self.assertNotIn("attachments", cap["params"])
+
+	def test_get_history_params_and_payload(self):
+		sess, cap = self._sess(
+			{"ok": True, "payload": {"sessionId": "s1",
+			 "messages": [{"role": "assistant"}], "thinkingLevel": "medium"}}
+		)
+		out = sess.get_history("sk", limit=50)
+		self.assertEqual(cap["method"], "chat.history")
+		self.assertEqual(cap["params"], {"sessionKey": "sk", "limit": 50, "maxChars": 4000})
+		self.assertEqual(out["messages"], [{"role": "assistant"}])
+		self.assertEqual(out["thinkingLevel"], "medium")
+
+	def test_get_session_messages_returns_messages_list(self):
+		sess, cap = self._sess(
+			{"ok": True, "payload": {"messages": [{"role": "assistant", "content": "x"}]}}
+		)
+		out = sess.get_session_messages("sk")
+		self.assertEqual(cap["method"], "sessions.get")
+		self.assertEqual(cap["params"]["key"], "sk")
+		self.assertEqual(out, [{"role": "assistant", "content": "x"}])
+
+	def test_get_session_messages_empty(self):
+		sess, _ = self._sess({"ok": True, "payload": {}})
+		self.assertEqual(sess.get_session_messages("sk"), [])
+
+	def test_is_run_active_matches_session_key(self):
+		sess, cap = self._sess(
+			{"ok": True, "payload": {"sessions": [
+				{"key": "other", "hasActiveRun": True},
+				{"key": "sk", "hasActiveRun": True},
+			]}}
+		)
+		self.assertTrue(sess.is_run_active("sk"))
+
+	def test_is_run_active_false_when_done_or_absent(self):
+		sess, cap = self._sess(
+			{"ok": True, "payload": {"sessions": [{"key": "sk", "hasActiveRun": False}]}}
+		)
+		self.assertFalse(sess.is_run_active("sk"))
+		cap["response"] = {"ok": True, "payload": {"sessions": []}}
+		self.assertFalse(sess.is_run_active("sk"))

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -1,0 +1,100 @@
+"""Tests for jarvis.chat.turn_recovery (scheduler-driven long-turn recovery)."""
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import turn_recovery
+from jarvis.chat.turn_recovery import MSG as MSG_DT
+
+
+class TestTurnRecovery(FrappeTestCase):
+	def setUp(self):
+		# Clean slate so the scan only sees our row (neutralise any leftovers).
+		frappe.db.sql(
+			"UPDATE `tabJarvis Chat Message` SET streaming=0, recovering=0 "
+			"WHERE streaming=1 OR recovering=1"
+		)
+		self.conv = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "rec", "session_key": "sk_rec",
+		}).insert(ignore_permissions=True)
+		self.msg = frappe.get_doc({
+			"doctype": "Jarvis Chat Message",
+			"conversation": self.conv.name, "seq": 1, "role": "assistant",
+			"content": "partial...", "streaming": 1, "recovering": 1,
+			"recovery_started_at": frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), minutes=-10),
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete(MSG_DT, {"conversation": self.conv.name})
+		frappe.db.delete(turn_recovery.CONV, {"name": self.conv.name})
+		frappe.db.commit()
+
+	def _run(self, sess):
+		@contextlib.contextmanager
+		def fake_conn(_gateway_url):
+			yield sess
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", fake_conn), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
+			out = turn_recovery.recover_pending_turns()
+		return out, pub
+
+	def _row(self):
+		return frappe.db.get_value(
+			MSG_DT, self.msg.name,
+			["content", "streaming", "recovering", "error"], as_dict=True,
+		)
+
+	def test_finalizes_when_run_done_with_text(self):
+		sess = MagicMock()
+		sess.is_run_active.return_value = False
+		sess.get_history.return_value = {"messages": [
+			{"role": "user", "content": "q", "__openclaw": {"seq": 1}},
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]}
+		out, pub = self._run(sess)
+		self.assertEqual(out.get("finalized"), 1)
+		row = self._row()
+		self.assertEqual(row.content, "the full answer")  # overwrite, not append
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		self.assertFalse(row.error)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("assistant:delta", kinds)
+		self.assertIn("run:end", kinds)
+
+	def test_leaves_active_run_untouched(self):
+		sess = MagicMock()
+		sess.is_run_active.return_value = True
+		out, _ = self._run(sess)
+		self.assertEqual(out.get("active"), 1)
+		row = self._row()
+		self.assertEqual(row.recovering, 1)
+		self.assertEqual(row.streaming, 1)
+
+	def test_errors_when_done_no_output_past_grace(self):
+		sess = MagicMock()
+		sess.is_run_active.return_value = False
+		sess.get_history.return_value = {"messages": []}
+		out, pub = self._run(sess)
+		self.assertEqual(out.get("errored"), 1)
+		row = self._row()
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		self.assertTrue(row.error)
+		self.assertIn("run:error", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	def test_extract_latest_assistant_text_handles_block_list(self):
+		text = turn_recovery._latest_assistant_text([
+			{"role": "assistant", "__openclaw": {"seq": 5},
+			 "content": [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}]},
+		])
+		self.assertEqual(text, "hello\nworld")

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -1,4 +1,10 @@
-"""Tests for jarvis.chat.turn_recovery (scheduler-driven long-turn recovery)."""
+"""Tests for jarvis.chat.turn_recovery (scheduler-driven long-turn recovery).
+
+Isolation note: the test conversation uses a UNIQUE session_key and the fake
+gateway returns transcript content only for that key, so any unrelated
+recovering rows on the test site are left in the waiting state untouched. No
+destructive global cleanup is needed.
+"""
 import contextlib
 from unittest.mock import MagicMock, patch
 
@@ -8,30 +14,45 @@ from frappe.tests.utils import FrappeTestCase
 from jarvis.chat import turn_recovery
 from jarvis.chat.turn_recovery import MSG as MSG_DT
 
+SK = "sk_rec_unique_test"
+
 
 class TestTurnRecovery(FrappeTestCase):
 	def setUp(self):
-		# Clean slate so the scan only sees our row (neutralise any leftovers).
-		frappe.db.sql(
-			"UPDATE `tabJarvis Chat Message` SET streaming=0, recovering=0 "
-			"WHERE streaming=1 OR recovering=1"
-		)
 		self.conv = frappe.get_doc({
-			"doctype": "Jarvis Conversation", "title": "rec", "session_key": "sk_rec",
+			"doctype": "Jarvis Conversation", "title": "rec", "session_key": SK,
 		}).insert(ignore_permissions=True)
-		self.msg = frappe.get_doc({
-			"doctype": "Jarvis Chat Message",
-			"conversation": self.conv.name, "seq": 1, "role": "assistant",
-			"content": "partial...", "streaming": 1, "recovering": 1,
-			"recovery_started_at": frappe.utils.add_to_date(
-				frappe.utils.now_datetime(), minutes=-10),
-		}).insert(ignore_permissions=True)
+		self.msg = self._add_msg(seq=1, started_min=-10)
 		frappe.db.commit()
 
 	def tearDown(self):
 		frappe.db.delete(MSG_DT, {"conversation": self.conv.name})
 		frappe.db.delete(turn_recovery.CONV, {"name": self.conv.name})
 		frappe.db.commit()
+
+	def _add_msg(self, seq, started_min, content="partial..."):
+		return frappe.get_doc({
+			"doctype": "Jarvis Chat Message",
+			"conversation": self.conv.name, "seq": seq, "role": "assistant",
+			"content": content, "streaming": 1, "recovering": 1,
+			"recovery_started_at": frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), minutes=started_min),
+		}).insert(ignore_permissions=True)
+
+	def _fake_sess(self, *, active=None, messages_by_key=None):
+		active = active or set()
+		messages_by_key = messages_by_key or {}
+		sess = MagicMock()
+
+		def _request(method, params, *, timeout_s):
+			if method == "sessions.list":
+				return {"payload": {"sessions": [
+					{"key": k, "hasActiveRun": True} for k in active]}}
+			return {"payload": {}}
+
+		sess._request = _request
+		sess.get_session_messages = lambda key, limit=50: messages_by_key.get(key, [])
+		return sess
 
 	def _run(self, sess):
 		@contextlib.contextmanager
@@ -47,21 +68,18 @@ class TestTurnRecovery(FrappeTestCase):
 			out = turn_recovery.recover_pending_turns()
 		return out, pub
 
-	def _row(self):
+	def _row(self, name=None):
 		return frappe.db.get_value(
-			MSG_DT, self.msg.name,
-			["content", "streaming", "recovering", "error"], as_dict=True,
-		)
+			MSG_DT, name or self.msg.name,
+			["content", "streaming", "recovering", "error"], as_dict=True)
 
+	# --- finalize from the RAW transcript (no truncation), overwrite ---------
 	def test_finalizes_when_run_done_with_text(self):
-		sess = MagicMock()
-		sess.is_run_active.return_value = False
-		sess.get_history.return_value = {"messages": [
+		sess = self._fake_sess(messages_by_key={SK: [
 			{"role": "user", "content": "q", "__openclaw": {"seq": 1}},
 			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
-		]}
-		out, pub = self._run(sess)
-		self.assertEqual(out.get("finalized"), 1)
+		]})
+		_, pub = self._run(sess)
 		row = self._row()
 		self.assertEqual(row.content, "the full answer")  # overwrite, not append
 		self.assertEqual(row.streaming, 0)
@@ -71,30 +89,85 @@ class TestTurnRecovery(FrappeTestCase):
 		self.assertIn("assistant:delta", kinds)
 		self.assertIn("run:end", kinds)
 
+	def test_uses_raw_session_messages_not_truncating_history(self):
+		# Content must come from get_session_messages (raw), never get_history (#1).
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "x", "__openclaw": {"seq": 1}}]})
+		self._run(sess)
+		sess.get_history.assert_not_called()
+
 	def test_leaves_active_run_untouched(self):
-		sess = MagicMock()
-		sess.is_run_active.return_value = True
-		out, _ = self._run(sess)
-		self.assertEqual(out.get("active"), 1)
+		sess = self._fake_sess(active={SK}, messages_by_key={SK: [
+			{"role": "assistant", "content": "x", "__openclaw": {"seq": 1}}]})
+		self._run(sess)
 		row = self._row()
 		self.assertEqual(row.recovering, 1)
 		self.assertEqual(row.streaming, 1)
 
-	def test_errors_when_done_no_output_past_grace(self):
-		sess = MagicMock()
-		sess.is_run_active.return_value = False
-		sess.get_history.return_value = {"messages": []}
-		out, pub = self._run(sess)
-		self.assertEqual(out.get("errored"), 1)
+	def test_waits_when_no_output_yet_does_not_error(self):
+		# Not active, no transcript content -> wait (NOT errored before ceiling).
+		sess = self._fake_sess(messages_by_key={SK: []})
+		_, pub = self._run(sess)
 		row = self._row()
-		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+		self.assertFalse(row.error)
+		self.assertNotIn("run:error", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	# --- #3/#5: unconditional ceiling backstop, even when gateway is down ----
+	def test_ceiling_errors_even_when_gateway_unreachable(self):
+		old = self._add_msg(seq=2, started_min=-120)  # 2h, past the 60min ceiling
+		frappe.db.commit()
+
+		def boom(_url):
+			raise RuntimeError("gateway down")
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", boom), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user"):
+			turn_recovery.recover_pending_turns()
+		row = self._row(old.name)
+		self.assertEqual(row.streaming, 0)  # errored despite gateway down
 		self.assertEqual(row.recovering, 0)
 		self.assertTrue(row.error)
-		self.assertIn("run:error", [c.args[1]["kind"] for c in pub.call_args_list])
 
+	# --- #2: no cross-row content bleed -------------------------------------
+	def test_no_cross_row_bleed_only_latest_finalized(self):
+		older = self.msg  # seq 1
+		newer = self._add_msg(seq=2, started_min=-10, content="partial2")
+		frappe.db.commit()
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "latest answer", "__openclaw": {"seq": 9}}]})
+		self._run(sess)
+		self.assertEqual(self._row(newer.name).content, "latest answer")
+		older_row = self._row(older.name)
+		self.assertNotEqual(older_row.content, "latest answer")  # no bleed
+		self.assertEqual(older_row.streaming, 1)  # older rides the ceiling backstop
+
+	# --- #8: conditional finalize is idempotent -----------------------------
+	def test_conditional_finalize_no_op_on_already_cleared_row(self):
+		frappe.db.set_value(MSG_DT, self.msg.name, {"streaming": 0, "recovering": 0})
+		frappe.db.commit()
+		pub = MagicMock()
+		with patch("jarvis.chat.turn_recovery.publish_to_user", pub):
+			turn_recovery._finalize(
+				{"name": self.msg.name, "conversation": self.conv.name, "owner": "x"},
+				"ignored")
+		pub.assert_not_called()
+		self.assertNotEqual(self._row().content, "ignored")
+
+	# --- #10: type-guarded extraction ---------------------------------------
 	def test_extract_latest_assistant_text_handles_block_list(self):
 		text = turn_recovery._latest_assistant_text([
 			{"role": "assistant", "__openclaw": {"seq": 5},
-			 "content": [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}]},
-		])
+			 "content": [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}]}])
 		self.assertEqual(text, "hello\nworld")
+
+	def test_extract_ignores_non_string_text(self):
+		text = turn_recovery._latest_assistant_text([
+			{"role": "assistant", "__openclaw": {"seq": 5},
+			 "content": [{"type": "text", "text": {"unexpected": "dict"}}], "text": 123}])
+		self.assertEqual(text, "")


### PR DESCRIPTION
## Problem

A long task completes inside openclaw, but the bench's background worker gives up first (the 600s WS cap fires before the 720s RQ cap), so the customer sees a false error even though openclaw finished and persisted the result. A latent `stale_scan` bug also clobbered any `streaming=1` row after 120s, erroring long turns mid-flight.

## Fix: worker-independent recovery (never lose, never error)

Mirror how openclaw's own UI stays seamless after a drop: reconcile from the durable transcript snapshot, never show an error for a recoverable interruption. The fix is backend-only; the customer SPA is unchanged (same `jarvis:event` contract).

- **Park, do not error.** On the WS-cap timeout (or any post-ack WS drop), the assistant row is marked `recovering` (spinner stays up, no error) instead of being failed.
- **`turn_recovery` scheduler (every 2 min)** finalizes parked rows from the gateway snapshot: `is_run_active` (non-destructive) then, when done, overwrite content from the raw transcript and publish `assistant:delta` + `run:end`.
- **`stale_scan` promotes** orphaned managed rows (hard-killed worker, OOM, deploy) to `recovering` instead of erroring them, so the result is still recovered.

This is process/worker-death independent: everything it needs (the row, `session_key`, openclaw's transcript) survives a worker kill.

## Hardening

A max-effort multi-agent code review found 15 real defects the happy-path tests missed; all are fixed in `ca533c8` with adversarial tests added:

- finalize from the RAW transcript (`sessions.get`), not `chat.history` which truncates at `max_chars` (recovered long answers were being cut)
- only the LATEST recovering row per conversation is snapshot-finalized (the session-wide newest answer was bleeding onto older rows)
- an UNCONDITIONAL ceiling backstop that errors a stuck row even when the gateway is unreachable (rows were stranded at a perpetual spinner)
- a WS drop AFTER the agent ack is tagged `turn-timeout` then routed to recovery (was false-erroring a turn openclaw is finishing)
- idempotent conditional finalize, self-host guard, `LEFT JOIN` for orphaned rows, a 720s managed promotion threshold so live turns are never flipped, one `sessions.list` per cycle, and more (see the commit body)

## Tests

Affected suites green on `jarvis-test.localhost`: native RPCs 10, turn_recovery 9, stale_scan 4, openclaw_client 21, session pool 11, thinking 5, chat_api 44. Adversarial cases added for truncation, cross-row no-bleed, gateway-down ceiling, idempotent finalize, mid-stream drop, and non-string transcript text.

## Deferred (not in this PR)

The live in-process relay (continue streaming live during a long turn, vs spinner-then-final) needs a live probe against a working container and is deferred. The recovery core here already guarantees correctness (the answer always lands, no false error).

## Commits

- `bd32594` openclaw-native RPC methods (chat.send / chat.history / sessions.list / sessions.get)
- `7a2af4b` `recovering` + `recovery_started_at` doctype fields
- `647f7c6` `turn_recovery` scheduler job
- `ca153ae` wiring (mark-recovering, stale_scan promote, cron)
- `ca533c8` remediate 15 review findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
