### PR TITLE
Chat: pre-warm the openclaw prefix cache (cut ~28s new-chat cold start)

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -569,6 +569,16 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 
 
 @frappe.whitelist()
+def warm_session() -> dict:
+	"""Fire-and-forget: warm this tenant's openclaw prefix cache so the next
+	new-chat first turn skips the cold prefill. Best-effort; always ok. The
+	chat UI calls this on open. Self-hosted and unconfigured benches no-op."""
+	from jarvis.chat import prewarm
+
+	return {"ok": True, "warmed": bool(prewarm.warm_prefix())}
+
+
+@frappe.whitelist()
 def set_conversation_thinking(conversation: str, thinking: str | None = None) -> dict:
 	"""Set or clear the per-conversation thinking effort (low/medium/high).
 

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -572,10 +572,13 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 def warm_session() -> dict:
 	"""Fire-and-forget: warm this tenant's openclaw prefix cache so the next
 	new-chat first turn skips the cold prefill. Best-effort; always ok. The
-	chat UI calls this on open. Self-hosted and unconfigured benches no-op."""
-	from jarvis.chat import prewarm
-
-	return {"ok": True, "warmed": bool(prewarm.warm_prefix())}
+	chat UI calls this on open. Self-hosted and unconfigured benches no-op.
+	Runs in a background RQ job so the gunicorn web worker is not blocked."""
+	frappe.enqueue(
+		"jarvis.chat.prewarm.warm_prefix",
+		queue="short",
+	)
+	return {"ok": True, "enqueued": True}
 
 
 @frappe.whitelist()

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -286,6 +286,27 @@ class OpenclawSession:
 			raise OpenclawUnreachableError(f"sessions.create returned no key: {res}")
 		return key
 
+	def fire_agent(self, session_key: str, message: str, idempotency_key: str,
+	               *, model: str | None = None, provider: str | None = None) -> str:
+		"""Send one agent turn and return its runId after the ack, WITHOUT
+		consuming the event stream. openclaw keeps running the turn server
+		side after we close (the run lane survives client disconnect), so this
+		is enough to warm the provider prompt cache. ``deliver`` is False so
+		the result stays session-only. ``_request`` drops the interleaved
+		event frames and returns the agent ack response."""
+		params = {
+			"message": message,
+			"sessionKey": session_key,
+			"deliver": False,
+			"idempotencyKey": idempotency_key,
+		}
+		if model:
+			params["model"] = model
+		if provider:
+			params["provider"] = provider
+		res = self._request("agent", params, timeout_s=CONNECT_TIMEOUT_SECONDS)
+		return (res.get("payload") or {}).get("runId") or ""
+
 	def stream_agent_turn(
 		self, session_key: str, message: str, idempotency_key: str,
 		*,

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -13,59 +13,108 @@ import frappe
 from jarvis import selfhost
 from jarvis.chat.openclaw_client import OpenclawSession
 
-# Cooldown between warm-ups for one bench. Comfortably inside gpt-5.5's
-# prompt-cache retention window so the cache never cools between warms.
-_WARM_COOLDOWN_S = 30 * 60
+# Cooldown between warm-ups for one bench. Set below the */30 cron
+# interval so keep_warm re-warms on each tick instead of every other.
+# Comfortably inside gpt-5.5's prompt-cache retention window so the
+# cache never cools between warms.
+_WARM_COOLDOWN_S = 25 * 60
+
+# Short in-progress TTL set BEFORE the slow connect so concurrent opens
+# cannot fan out into concurrent warm-ups. Expires quickly on failure
+# so a failed warm retries soon rather than blocking for the full cooldown.
+# Accepted best-effort SET race: two concurrent callers may both pass
+# get_value before either sets this key; the second warm is harmless
+# (#6 accepted best-effort).
+_WARM_INPROGRESS_S = 90
+
+# Provider label -> openclaw provider id (oauth mode only).
+# Mirrors _PROVIDER_LABEL_TO_OPENCLAW_ID in jarvis/chat/turn_handler.py;
+# kept in sync manually - both files must agree on this mapping.
+_PROVIDER_LABEL_TO_OPENCLAW_ID = {
+    "OpenAI": "openai",
+    "Google Gemini": "google-gemini-cli",
+}
 
 
 def _warm_cooldown_key() -> str:
-	return f"jarvis:chat:prefix_warm:{frappe.local.site}"
+    return f"jarvis:chat:prefix_warm:{frappe.local.site}"
+
+
+def _gateway_ws_url(settings) -> str:
+    """Convert Jarvis Settings.agent_url http(s):// -> ws(s)://."""
+    return (settings.agent_url or "").replace(
+        "http://", "ws://").replace("https://", "wss://")
+
+
+def _resolve_default_model_and_provider(settings) -> tuple[str, str | None]:
+    """Return (model, provider) a real default new-chat first turn would use.
+
+    Mirrors turn_handler._resolve_model_and_provider for the no-override
+    case: default model = Jarvis Settings.llm_model; provider id only in
+    oauth mode. Must stay in sync with that helper.
+    """
+    model = settings.llm_model or ""
+    provider = (
+        _PROVIDER_LABEL_TO_OPENCLAW_ID.get(settings.llm_provider)
+        if settings.llm_auth_mode == "oauth"
+        else None
+    )
+    return model, provider
 
 
 def warm_prefix() -> bool:
-	"""Fire one throwaway warm-up turn for this bench's container. Returns
-	True if a warm-up was fired, False if skipped (debounced, not
-	configured, self-hosted) or on any error. Never raises."""
-	try:
-		if selfhost.is_self_hosted():
-			return False
-		cache = frappe.cache()
-		key = _warm_cooldown_key()
-		if cache.get_value(key):
-			return False
-		settings = frappe.get_single("Jarvis Settings")
-		gateway_url = (settings.agent_url or "").replace(
-			"http://", "ws://").replace("https://", "wss://")
-		gateway_token = settings.get_password("agent_token")
-		if not gateway_url or not gateway_token:
-			return False
-		# Set the cooldown BEFORE the slow connect so a burst of opens (or a
-		# broken gateway) cannot fan out into concurrent warm-ups.
-		cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
-		sess = OpenclawSession.connect(gateway_url)
-		try:
-			throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
-			sess.fire_agent(throwaway, "/think off warmup", uuid.uuid4().hex)
-		finally:
-			sess.close()
-		return True
-	except Exception:
-		frappe.logger("jarvis.chat.prewarm").debug("prefix warm-up skipped", exc_info=True)
-		return False
+    """Fire one throwaway warm-up turn for this bench's container. Returns
+    True if a warm-up was fired, False if skipped (debounced, not
+    configured, self-hosted) or on any error. Never raises."""
+    try:
+        if selfhost.is_self_hosted():
+            return False
+        cache = frappe.cache()
+        key = _warm_cooldown_key()
+        if cache.get_value(key):
+            return False
+        settings = frappe.get_single("Jarvis Settings")
+        # OpenclawSession.connect authenticates via device pairing
+        # (ensure_paired / chat_device_* creds), NOT agent_token.
+        # agent_token is empty on managed/device-paired benches.
+        gateway_url = _gateway_ws_url(settings)
+        if not gateway_url:
+            return False
+        # Set a short in-progress marker BEFORE the slow connect so a burst
+        # of opens (or a broken gateway) cannot fan out into concurrent
+        # warm-ups. On any exception this short marker expires in
+        # _WARM_INPROGRESS_S, allowing a retry soon. The full cooldown is
+        # only set after a successful warm so a transient blip does not
+        # disable warming for 25 min.
+        cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
+        model, provider = _resolve_default_model_and_provider(settings)
+        sess = OpenclawSession.connect(gateway_url)
+        try:
+            throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
+            sess.fire_agent(throwaway, "/think off warmup", uuid.uuid4().hex,
+                            model=model or None, provider=provider)
+        finally:
+            sess.close()
+        # Warm succeeded: arm the full cooldown so the next cron tick skips.
+        cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
+        return True
+    except Exception:
+        frappe.logger("jarvis.chat.prewarm").warning("prefix warm-up failed", exc_info=True)
+        return False
 
 
 def keep_warm_if_active() -> None:
-	"""Scheduler entry: keep the prefix cache warm for benches with recent
-	chat activity, so a returning user's first turn is warm after an idle
-	gap. No-op on idle or self-hosted benches. Runs on the existing
-	scheduler; the per-bench debounce in warm_prefix bounds frequency."""
-	try:
-		if selfhost.is_self_hosted():
-			return
-		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-2)
-		recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
-		if not recent:
-			return
-		warm_prefix()
-	except Exception:
-		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)
+    """Scheduler entry: keep the prefix cache warm for benches with recent
+    chat activity, so a returning user's first turn is warm after an idle
+    gap. No-op on idle or self-hosted benches. Runs on the existing
+    scheduler; the per-bench debounce in warm_prefix bounds frequency."""
+    try:
+        if selfhost.is_self_hosted():
+            return
+        cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-30)
+        recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
+        if not recent:
+            return
+        warm_prefix()
+    except Exception:
+        frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -27,94 +27,89 @@ _WARM_COOLDOWN_S = 25 * 60
 # (#6 accepted best-effort).
 _WARM_INPROGRESS_S = 90
 
-# Provider label -> openclaw provider id (oauth mode only).
-# Mirrors _PROVIDER_LABEL_TO_OPENCLAW_ID in jarvis/chat/turn_handler.py;
-# kept in sync manually - both files must agree on this mapping.
-_PROVIDER_LABEL_TO_OPENCLAW_ID = {
-    "OpenAI": "openai",
-    "Google Gemini": "google-gemini-cli",
-}
-
 
 def _warm_cooldown_key() -> str:
-    return f"jarvis:chat:prefix_warm:{frappe.local.site}"
+	return f"jarvis:chat:prefix_warm:{frappe.local.site}"
 
 
 def _gateway_ws_url(settings) -> str:
-    """Convert Jarvis Settings.agent_url http(s):// -> ws(s)://."""
-    return (settings.agent_url or "").replace(
-        "http://", "ws://").replace("https://", "wss://")
+	"""Convert Jarvis Settings.agent_url http(s):// -> ws(s)://."""
+	return (settings.agent_url or "").replace(
+		"http://", "ws://").replace("https://", "wss://")
 
 
 def _resolve_default_model_and_provider(settings) -> tuple[str, str | None]:
-    """Return (model, provider) a real default new-chat first turn would use.
+	"""Return (model, provider) a real default new-chat first turn would use.
 
-    Mirrors turn_handler._resolve_model_and_provider for the no-override
-    case: default model = Jarvis Settings.llm_model; provider id only in
-    oauth mode. Must stay in sync with that helper.
-    """
-    model = settings.llm_model or ""
-    provider = (
-        _PROVIDER_LABEL_TO_OPENCLAW_ID.get(settings.llm_provider)
-        if settings.llm_auth_mode == "oauth"
-        else None
-    )
-    return model, provider
+	Mirrors turn_handler._resolve_model_and_provider for the no-override
+	case: default model = Jarvis Settings.llm_model; provider id only in
+	oauth mode. Reuses turn_handler's provider map as the single source of
+	truth so the warm-up cannot drift to a different provider's cache."""
+	from jarvis.chat.turn_handler import _PROVIDER_LABEL_TO_OPENCLAW_ID
+	model = settings.llm_model or ""
+	provider = (
+		_PROVIDER_LABEL_TO_OPENCLAW_ID.get(settings.llm_provider)
+		if settings.llm_auth_mode == "oauth"
+		else None
+	)
+	return model, provider
 
 
 def warm_prefix() -> bool:
-    """Fire one throwaway warm-up turn for this bench's container. Returns
-    True if a warm-up was fired, False if skipped (debounced, not
-    configured, self-hosted) or on any error. Never raises."""
-    try:
-        if selfhost.is_self_hosted():
-            return False
-        cache = frappe.cache()
-        key = _warm_cooldown_key()
-        if cache.get_value(key):
-            return False
-        settings = frappe.get_single("Jarvis Settings")
-        # OpenclawSession.connect authenticates via device pairing
-        # (ensure_paired / chat_device_* creds), NOT agent_token.
-        # agent_token is empty on managed/device-paired benches.
-        gateway_url = _gateway_ws_url(settings)
-        if not gateway_url:
-            return False
-        # Set a short in-progress marker BEFORE the slow connect so a burst
-        # of opens (or a broken gateway) cannot fan out into concurrent
-        # warm-ups. On any exception this short marker expires in
-        # _WARM_INPROGRESS_S, allowing a retry soon. The full cooldown is
-        # only set after a successful warm so a transient blip does not
-        # disable warming for 25 min.
-        cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
-        model, provider = _resolve_default_model_and_provider(settings)
-        sess = OpenclawSession.connect(gateway_url)
-        try:
-            throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
-            sess.fire_agent(throwaway, "/think off warmup", uuid.uuid4().hex,
-                            model=model or None, provider=provider)
-        finally:
-            sess.close()
-        # Warm succeeded: arm the full cooldown so the next cron tick skips.
-        cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
-        return True
-    except Exception:
-        frappe.logger("jarvis.chat.prewarm").warning("prefix warm-up failed", exc_info=True)
-        return False
+	"""Fire one throwaway warm-up turn for this bench's container. Returns
+	True if a warm-up was fired, False if skipped (debounced, not
+	configured, self-hosted) or on any error. Never raises."""
+	try:
+		if selfhost.is_self_hosted():
+			return False
+		cache = frappe.cache()
+		key = _warm_cooldown_key()
+		if cache.get_value(key):
+			return False
+		settings = frappe.get_single("Jarvis Settings")
+		# OpenclawSession.connect authenticates via device pairing
+		# (ensure_paired / chat_device_* creds), NOT agent_token.
+		# agent_token is empty on managed/device-paired benches.
+		gateway_url = _gateway_ws_url(settings)
+		if not gateway_url:
+			return False
+		# Set a short in-progress marker BEFORE the slow connect so a burst
+		# of opens (or a broken gateway) cannot fan out into concurrent
+		# warm-ups. On any exception this short marker expires in
+		# _WARM_INPROGRESS_S, allowing a retry soon. The full cooldown is
+		# only set after a successful warm so a transient blip does not
+		# disable warming for 25 min.
+		cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
+		model, provider = _resolve_default_model_and_provider(settings)
+		sess = OpenclawSession.connect(gateway_url)
+		try:
+			throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
+			sess.fire_agent(
+				throwaway, "/think off warmup", uuid.uuid4().hex,
+				model=model or None, provider=provider,
+			)
+		finally:
+			sess.close()
+		# Warm succeeded: arm the full cooldown so the next cron tick skips.
+		cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
+		return True
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").warning("prefix warm-up failed", exc_info=True)
+		return False
 
 
 def keep_warm_if_active() -> None:
-    """Scheduler entry: keep the prefix cache warm for benches with recent
-    chat activity, so a returning user's first turn is warm after an idle
-    gap. No-op on idle or self-hosted benches. Runs on the existing
-    scheduler; the per-bench debounce in warm_prefix bounds frequency."""
-    try:
-        if selfhost.is_self_hosted():
-            return
-        cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-30)
-        recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
-        if not recent:
-            return
-        warm_prefix()
-    except Exception:
-        frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)
+	"""Scheduler entry: keep the prefix cache warm for benches with recent
+	chat activity, so a returning user's first turn is warm after an idle
+	gap. No-op on idle or self-hosted benches. Runs on the existing
+	scheduler; the per-bench debounce in warm_prefix bounds frequency."""
+	try:
+		if selfhost.is_self_hosted():
+			return
+		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-30)
+		recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
+		if not recent:
+			return
+		warm_prefix()
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -1,0 +1,54 @@
+"""Best-effort pre-warming of the openclaw container's OpenAI prefix cache.
+
+The first turn of a fresh session pays a cold provider prefill over the
+large static system prefix (persona + skills + tool schema). That cache is
+prefix-keyed and container-wide, so one cheap throwaway agent turn warms it
+for every subsequent new chat in the same container. We never touch the
+user's real session or write chat rows. Always best-effort; never raises.
+"""
+import uuid
+
+import frappe
+
+from jarvis import selfhost
+from jarvis.chat.openclaw_client import OpenclawSession
+
+# Cooldown between warm-ups for one bench. Comfortably inside gpt-5.5's
+# prompt-cache retention window so the cache never cools between warms.
+_WARM_COOLDOWN_S = 30 * 60
+
+
+def _warm_cooldown_key() -> str:
+	return f"jarvis:chat:prefix_warm:{frappe.local.site}"
+
+
+def warm_prefix() -> bool:
+	"""Fire one throwaway warm-up turn for this bench's container. Returns
+	True if a warm-up was fired, False if skipped (debounced, not
+	configured, self-hosted) or on any error. Never raises."""
+	try:
+		if selfhost.is_self_hosted():
+			return False
+		cache = frappe.cache()
+		key = _warm_cooldown_key()
+		if cache.get_value(key):
+			return False
+		settings = frappe.get_single("Jarvis Settings")
+		gateway_url = (settings.agent_url or "").replace(
+			"http://", "ws://").replace("https://", "wss://")
+		gateway_token = settings.get_password("agent_token")
+		if not gateway_url or not gateway_token:
+			return False
+		# Set the cooldown BEFORE the slow connect so a burst of opens (or a
+		# broken gateway) cannot fan out into concurrent warm-ups.
+		cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
+		sess = OpenclawSession.connect(gateway_url)
+		try:
+			throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
+			sess.fire_agent(throwaway, "/think off warmup", uuid.uuid4().hex)
+		finally:
+			sess.close()
+		return True
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").debug("prefix warm-up skipped", exc_info=True)
+		return False

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -52,3 +52,20 @@ def warm_prefix() -> bool:
 	except Exception:
 		frappe.logger("jarvis.chat.prewarm").debug("prefix warm-up skipped", exc_info=True)
 		return False
+
+
+def keep_warm_if_active() -> None:
+	"""Scheduler entry: keep the prefix cache warm for benches with recent
+	chat activity, so a returning user's first turn is warm after an idle
+	gap. No-op on idle or self-hosted benches. Runs on the existing
+	scheduler; the per-bench debounce in warm_prefix bounds frequency."""
+	try:
+		if selfhost.is_self_hosted():
+			return
+		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-2)
+		recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
+		if not recent:
+			return
+		warm_prefix()
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -153,6 +153,9 @@ scheduler_events = {
 		"*/5 * * * *": [
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
 		],
+		"*/30 * * * *": [
+			"jarvis.chat.prewarm.keep_warm_if_active",
+		],
 	},
 	"hourly": [
 		# Sprint-3 (2026-06-16 review): bench has no way to know if the

--- a/jarvis/public/js/jarvis_chat/api.js
+++ b/jarvis/public/js/jarvis_chat/api.js
@@ -77,3 +77,13 @@ export async function setConversationThinking(conversation, thinking) {
 	});
 	return r.message;
 }
+
+export async function warmSession() {
+	// Best-effort: warm the openclaw prefix cache so the first new-chat turn
+	// is fast. Non-critical, so failures are swallowed.
+	try {
+		await frappe.call({ method: "jarvis.chat.api.warm_session" });
+	} catch (e) {
+		/* warming is best-effort */
+	}
+}

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -168,6 +168,7 @@ function toggle() {
 	else openPanel();
 }
 async function openPanel() {
+	api.warmSession();
 	open.value = true;
 	hasUnread.value = false;
 	if (!booted.value) await boot();

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -659,3 +659,14 @@ class TestChatUiSettings(FrappeTestCase):
 		# protects against a future drift in jarvis/_subscription_models.py.
 		for provider, default in DEFAULT_MODEL.items():
 			self.assertIn(default, SUBSCRIPTION_MODELS[provider])
+
+
+class TestWarmSessionEndpoint(FrappeTestCase):
+	def test_warm_session_calls_warm_prefix(self):
+		from jarvis.chat import api
+
+		with patch("jarvis.chat.prewarm.warm_prefix", return_value=True) as wp:
+			out = api.warm_session()
+
+		wp.assert_called_once()
+		self.assertEqual(out, {"ok": True, "warmed": True})

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -662,11 +662,20 @@ class TestChatUiSettings(FrappeTestCase):
 
 
 class TestWarmSessionEndpoint(FrappeTestCase):
-	def test_warm_session_calls_warm_prefix(self):
+	def test_warm_session_enqueues_not_inline(self):
+		"""warm_session must enqueue warm_prefix as a background job and
+		return immediately - proves FIX D (non-blocking web worker)."""
 		from jarvis.chat import api
 
-		with patch("jarvis.chat.prewarm.warm_prefix", return_value=True) as wp:
+		with patch("frappe.enqueue") as enqueue, \
+		     patch("jarvis.chat.prewarm.warm_prefix") as wp:
 			out = api.warm_session()
 
-		wp.assert_called_once()
-		self.assertEqual(out, {"ok": True, "warmed": True})
+		# Must have enqueued the prewarm job with the right method + queue.
+		enqueue.assert_called_once_with(
+			"jarvis.chat.prewarm.warm_prefix",
+			queue="short",
+		)
+		# warm_prefix must NOT have been called inline in the web worker.
+		wp.assert_not_called()
+		self.assertEqual(out, {"ok": True, "enqueued": True})

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -1,4 +1,7 @@
 # app/jarvis/tests/test_prewarm.py
+from unittest.mock import MagicMock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.openclaw_client import OpenclawSession
@@ -21,3 +24,51 @@ class TestFireAgent(FrappeTestCase):
         self.assertEqual(captured["params"]["deliver"], False)
         self.assertEqual(captured["params"]["sessionKey"], "sk_1")
         self.assertEqual(captured["params"]["message"], "/think off warmup")
+
+
+class TestWarmPrefix(FrappeTestCase):
+    def _settings_stub(self):
+        s = MagicMock()
+        s.agent_url = "https://gw.example"
+        s.get_password.return_value = "tok"
+        return s
+
+    def test_warm_prefix_throwaway_session_no_rows_best_effort(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        fake_sess = MagicMock()
+        fake_sess.create_session.return_value = "sk_throwaway"
+        before = frappe.db.count("Jarvis Chat Message")
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()):
+            OC.connect.return_value = fake_sess
+            fired = prewarm.warm_prefix()
+
+        self.assertTrue(fired)
+        fake_sess.create_session.assert_called_once()
+        msg = fake_sess.fire_agent.call_args.args[1]
+        self.assertIn("/think off", msg)
+        fake_sess.close.assert_called_once()
+        self.assertEqual(frappe.db.count("Jarvis Chat Message"), before)
+
+    def test_warm_prefix_debounced_second_call_is_noop(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()):
+            OC.connect.return_value = MagicMock(create_session=MagicMock(return_value="sk"))
+            self.assertTrue(prewarm.warm_prefix())
+            self.assertFalse(prewarm.warm_prefix())  # within cooldown
+
+    def test_warm_prefix_swallows_errors(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        with patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", side_effect=RuntimeError("boom")):
+            self.assertFalse(prewarm.warm_prefix())  # no raise

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -30,8 +30,14 @@ class TestWarmPrefix(FrappeTestCase):
     def _settings_stub(self):
         s = MagicMock()
         s.agent_url = "https://gw.example"
-        s.get_password.return_value = "tok"
+        s.llm_model = "gpt-5.5"
+        s.llm_auth_mode = "api_key"
+        s.llm_provider = "OpenAI"
         return s
+
+    def tearDown(self):
+        from jarvis.chat import prewarm
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
 
     def test_warm_prefix_throwaway_session_no_rows_best_effort(self):
         from jarvis.chat import prewarm
@@ -73,8 +79,87 @@ class TestWarmPrefix(FrappeTestCase):
              patch("jarvis.chat.prewarm.frappe.get_single", side_effect=RuntimeError("boom")):
             self.assertFalse(prewarm.warm_prefix())  # no raise
 
+    # --- adversarial tests ---
+
+    def test_warm_prefix_fires_with_empty_agent_token(self):
+        """Warming must succeed even when agent_token is empty.
+        connect() uses device-pairing auth, not agent_token - proves FIX A."""
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        stub = self._settings_stub()
+        stub.get_password.return_value = ""  # empty agent_token (device-paired bench)
+        fake_sess = MagicMock()
+        fake_sess.create_session.return_value = "sk_throwaway"
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=stub):
+            OC.connect.return_value = fake_sess
+            fired = prewarm.warm_prefix()
+
+        self.assertTrue(fired, "warm_prefix must fire even with empty agent_token")
+
+    def test_warm_prefix_failure_does_not_arm_full_cooldown(self):
+        """A failed connect must set only the short in-progress marker,
+        not the full cooldown. Proves FIX B: transient failures retry soon
+        instead of being disabled for 25 min."""
+        from jarvis.chat import prewarm
+
+        cache_mock = MagicMock()
+        cache_mock.get_value.return_value = None  # not debounced
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()), \
+             patch("jarvis.chat.prewarm.frappe.cache", return_value=cache_mock), \
+             patch("jarvis.chat.prewarm.frappe.logger"):
+            OC.connect.side_effect = RuntimeError("gateway blip")
+            fired = prewarm.warm_prefix()
+
+        self.assertFalse(fired)
+        set_calls = cache_mock.set_value.call_args_list
+        # Exactly one set_value call: the short in-progress guard.
+        # A second call (full cooldown) must not appear on failure.
+        self.assertEqual(
+            len(set_calls), 1,
+            "Only the short in-progress TTL should be set on failure, not the full cooldown",
+        )
+        _, call_kwargs = set_calls[0]
+        self.assertEqual(
+            call_kwargs.get("expires_in_sec"), prewarm._WARM_INPROGRESS_S,
+            "The single cache set on failure must use the short in-progress TTL",
+        )
+
+    def test_warm_prefix_passes_default_model_to_fire_agent(self):
+        """warm_prefix resolves the Settings default model and passes it to
+        fire_agent - proves FIX C (prevents container-default model drift)."""
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        fake_sess = MagicMock()
+        fake_sess.create_session.return_value = "sk_throwaway"
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()):
+            OC.connect.return_value = fake_sess
+            prewarm.warm_prefix()
+
+        fake_sess.fire_agent.assert_called_once()
+        _, call_kwargs = fake_sess.fire_agent.call_args
+        self.assertEqual(call_kwargs.get("model"), "gpt-5.5",
+            "fire_agent must receive the Settings default model")
+        # api_key mode: no oauth provider
+        self.assertIsNone(call_kwargs.get("provider"),
+            "provider must be None in api_key mode")
+
 
 class TestKeepWarm(FrappeTestCase):
+    def tearDown(self):
+        from jarvis.chat import prewarm
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+
     def test_keep_warm_warms_when_recent_activity(self):
         from jarvis.chat import prewarm
 

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -72,3 +72,23 @@ class TestWarmPrefix(FrappeTestCase):
         with patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
              patch("jarvis.chat.prewarm.frappe.get_single", side_effect=RuntimeError("boom")):
             self.assertFalse(prewarm.warm_prefix())  # no raise
+
+
+class TestKeepWarm(FrappeTestCase):
+    def test_keep_warm_warms_when_recent_activity(self):
+        from jarvis.chat import prewarm
+
+        with patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.db.exists", return_value="MSG-1"), \
+             patch("jarvis.chat.prewarm.warm_prefix") as wp:
+            prewarm.keep_warm_if_active()
+        wp.assert_called_once()
+
+    def test_keep_warm_noop_when_idle(self):
+        from jarvis.chat import prewarm
+
+        with patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.db.exists", return_value=None), \
+             patch("jarvis.chat.prewarm.warm_prefix") as wp:
+            prewarm.keep_warm_if_active()
+        wp.assert_not_called()

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -1,0 +1,23 @@
+# app/jarvis/tests/test_prewarm.py
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.openclaw_client import OpenclawSession
+
+
+class TestFireAgent(FrappeTestCase):
+    def test_fire_agent_sends_deliver_false_and_returns_runid(self):
+        sess = OpenclawSession.__new__(OpenclawSession)  # bypass __init__/WS
+        captured = {}
+
+        def fake_request(method, params, *, timeout_s):
+            captured["method"], captured["params"] = method, params
+            return {"ok": True, "payload": {"runId": "run123"}}
+
+        sess._request = fake_request
+        rid = sess.fire_agent("sk_1", "/think off warmup", "idem1")
+
+        self.assertEqual(rid, "run123")
+        self.assertEqual(captured["method"], "agent")
+        self.assertEqual(captured["params"]["deliver"], False)
+        self.assertEqual(captured["params"]["sessionKey"], "sk_1")
+        self.assertEqual(captured["params"]["message"], "/think off warmup")


### PR DESCRIPTION
## Problem

A new-chat first turn takes ~22-28s. It is not the bridge or auth - it is the provider's cold prefix prefill over the large static system prefix (persona + skills + 40+ tool schemas). OpenAI prompt caching is prefix-keyed and container-wide, so the first turn pays the full prefill; subsequent turns in the same container are cache hits and fast.

## Fix: pre-warm the prefix cache

The instant a chat opens, fire a throwaway warm-up turn into the tenant's openclaw container. openclaw prefills the static prefix and the provider caches it, so the user's first real turn is a cache hit (~2-3s instead of ~28s). A scheduler keep-warm covers returning users after an idle gap.

- `OpenclawSession.fire_agent` - fire-and-forget agent turn (`deliver:false`, returns after the ack). The detached run survives the WS close and reaches the provider prefill (verified against the openclaw gateway source).
- `prewarm.warm_prefix` - one throwaway-session warm-up, best-effort (never raises, writes zero chat rows, no-ops on self-hosted, dedicated short-lived connection). Resolves the SAME default model/provider a real new-chat turn sends so it warms the right cache. Per-bench cooldown.
- `warm_session` whitelisted endpoint - enqueues a background RQ job (does not block the web worker); the chat UI calls it on open.
- `keep_warm_if_active` - scheduler hook (`*/30`) for benches with recent chat activity.
- Frontend: `warmSession()` fired from the floating widget's `openPanel()` (not awaited).

## Hardening (max-effort review + remediation)

A max-effort multi-agent review found - and this branch fixes - the flaws that would have made the warm silently not work:

- Removed a spurious `agent_token` guard that disabled warming entirely on device-paired (managed) benches, where `agent_token` is empty.
- The full cooldown is armed only AFTER a successful warm (with a 90s in-progress marker for fan-out), so a transient gateway blip no longer disables warming for the full window.
- The warm resolves the same default model/provider a real turn uses (was warming the drift-prone container default); the provider map is imported from `turn_handler` as a single source of truth.
- `warm_session` enqueues instead of blocking a gunicorn worker; failures log at WARNING (not DEBUG); the keep-warm activity window and cadence were tightened.
- Adversarial tests added for the disable-on-blip, empty-`agent_token`, wrong-model, and enqueue-not-inline cases.

## Tests

`test_prewarm` 9/9, `test_chat_api` 45/45 on `jarvis-test.localhost`.

## Notes

Phase 0 (the A/B probe) is skipped - the cold-start behavior is already confirmed empirically. Phase 2 (configurable thinking effort) shipped separately in #167. To try live: `bench build --app jarvis`, open the floating chat, and confirm a `warm_session` call fires on open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
