### PR TITLE
Chat: type-annotate whitelisted args + Reset Agent Pairing button

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -255,7 +255,7 @@ def rename_conversation(conversation: str, title: str) -> dict:
 
 
 @frappe.whitelist()
-def set_star(conversation: str, starred) -> dict:
+def set_star(conversation: str, starred: str | int | bool) -> dict:
 	"""Star/unstar a conversation (owner-gated via get_doc). Starred chats are
 	listed first and grouped under 'Starred' in the sidebar."""
 	on = 1 if str(starred) in ("1", "true", "True", "on", "yes") else 0
@@ -462,7 +462,7 @@ def get_chat_ui_settings() -> dict:
 
 
 @frappe.whitelist()
-def set_auto_apply(value) -> dict:
+def set_auto_apply(value: str | int | bool) -> dict:
 	"""Toggle the per-site 'auto-apply changes (skip confirmation)' setting.
 
 	OFF (default) = the agent confirms every ERP-mutating action before running

--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -79,3 +79,40 @@ def force_resync(action: str = "reload") -> dict:
 		"last_sync_at": str(settings.get("last_sync_at") or ""),
 		"last_sync_status": settings.get("last_sync_status") or "",
 	}
+
+
+@frappe.whitelist()
+def reset_agent_pairing() -> dict:
+	"""Clear the cached chat-device pairing and re-pair from scratch.
+
+	Use when openclaw rejects the existing pairing (e.g. 'device token
+	mismatch') and the automatic repair did not fire because openclaw
+	returned a generic error code. Clears the chat-device creds, drops any
+	pooled connection, then opens a fresh device-paired connection (which
+	re-pairs via the ops bench + fleet-agent) to verify. System Manager only.
+	"""
+	frappe.only_for("System Manager")
+	from jarvis.chat import openclaw_session_pool
+	from jarvis.chat.device import clear_credentials
+	from jarvis.chat.openclaw_client import OpenclawSession
+	from jarvis.exceptions import OpenclawUnreachableError
+
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").strip().replace(
+		"http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return {"ok": False, "kind": "config", "error": "agent_url is not set."}
+
+	clear_credentials()
+	try:
+		openclaw_session_pool.drain_all()
+	except Exception:
+		pass
+	try:
+		sess = OpenclawSession.connect(gateway_url)
+		sess.close()
+		return {"ok": True, "message": "Cleared the old pairing and reconnected to the agent."}
+	except OpenclawUnreachableError as e:
+		return {"ok": False, "kind": "unreachable", "error": str(e)}
+	except Exception as e:
+		return {"ok": False, "kind": "error", "error": f"{type(e).__name__}: {e}"}

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -48,6 +48,35 @@ frappe.ui.form.on("Jarvis Settings", {
 			});
 		}, __("Diagnostics"));
 
+		frm.add_custom_button(__("Reset Agent Pairing"), () => {
+			frappe.confirm(
+				__("Clear the cached agent pairing and re-pair from scratch? Use this if chat fails with a device/token mismatch error."),
+				() => {
+					frappe.call({
+						method: "jarvis.diagnostics.reset_agent_pairing",
+						freeze: true,
+						freeze_message: __("Clearing pairing and reconnecting to the agent…"),
+					}).then((r) => {
+						const m = r.message || {};
+						if (m.ok) {
+							frappe.msgprint({
+								title: __("Reconnected"),
+								message: m.message || __("Re-paired with the agent."),
+								indicator: "green",
+							});
+							frm.reload_doc();
+						} else {
+							frappe.msgprint({
+								title: __("Re-pair Failed ({0})", [m.kind || "error"]),
+								message: m.error || "unknown",
+								indicator: "red",
+							});
+						}
+					});
+				},
+			);
+		}, __("Diagnostics"));
+
 		// DEV-only reset: visible when sandbox mode is on AND caller is
 		// System Manager. The server re-checks both gates - is_dev_mode_active
 		// resolves "sandbox mode" through jarvis.dev.is_sandbox_mode (which


### PR DESCRIPTION
Two small chat fixes surfaced during a debugging session.

## 1. Type-annotate whitelisted args (bug)

Frappe rejects whitelisted methods with un-annotated arguments when type checking is enforced, so `set_star(starred)` and `set_auto_apply(value)` threw at call time (starring a chat / toggling auto-apply failed). Both coerce via `str(x)`, so they now accept `str | int | bool`. Part of a cross-repo type-annotation sweep - the ops bench had the same bug in `update_llm_creds` / `update_llm_pool` (fixed in the jarvis-admin PR), where it broke LLM credential pushes for every tenant.

## 2. Reset Agent Pairing button (operator tool)

A System-Manager Diagnostics button on Jarvis Settings that clears the cached chat-device pairing, drains the session pool, re-pairs from scratch, and verifies with a fresh connect. Use it when openclaw rejects a stale pairing (e.g. "device token mismatch") and the automatic repair does not fire because openclaw returns a generic `INVALID_REQUEST` code that `_is_stale_pairing` does not classify as re-pairable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
