### PR TITLE
Chat: warm the prefix cache on chat-page load (reaches the main ChatView)

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -56,6 +56,11 @@ def list_conversations() -> list[dict]:
 	Each row includes ``message_count`` so the UI can identify empty
 	conversations (used by ``create_or_focus_empty``).
 	"""
+	# Chat page loaded: warm the openclaw prefix cache in the background
+	# (best-effort, debounced) so the first turn of a new chat skips the cold
+	# provider prefill. Never blocks or fails this read.
+	from jarvis.chat import prewarm
+	prewarm.enqueue_warm_if_due()
 	user = frappe.session.user
 	rows = frappe.db.sql(
 		"""

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -113,3 +113,20 @@ def keep_warm_if_active() -> None:
 		warm_prefix()
 	except Exception:
 		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)
+
+
+def enqueue_warm_if_due() -> None:
+	"""Warm-on-chat-load: enqueue a prefix warm-up in a background job if the
+	per-bench cooldown has lapsed. Called from list_conversations (which every
+	chat surface hits on load), so the first turn of a new chat gets a warm
+	prefix without a frontend change. Just a cheap cache read on the request
+	path - the connect + warm runs off the web worker. Best-effort, never
+	raises, and debounced so repeated calls do not fan out into jobs."""
+	try:
+		if selfhost.is_self_hosted():
+			return
+		if frappe.cache().get_value(_warm_cooldown_key()):
+			return
+		frappe.enqueue("jarvis.chat.prewarm.warm_prefix", queue="short")
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").debug("enqueue_warm_if_due skipped", exc_info=True)

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -177,3 +177,50 @@ class TestKeepWarm(FrappeTestCase):
              patch("jarvis.chat.prewarm.warm_prefix") as wp:
             prewarm.keep_warm_if_active()
         wp.assert_not_called()
+
+
+class TestEnqueueWarmIfDue(FrappeTestCase):
+    def tearDown(self):
+        from jarvis.chat import prewarm
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+
+    def test_enqueues_warm_when_not_on_cooldown(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.enqueue") as enq:
+            prewarm.enqueue_warm_if_due()
+        enq.assert_called_once()
+        self.assertEqual(enq.call_args.args[0], "jarvis.chat.prewarm.warm_prefix")
+
+    def test_skips_enqueue_when_on_cooldown(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().set_value(prewarm._warm_cooldown_key(), "1", expires_in_sec=60)
+        with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.enqueue") as enq:
+            prewarm.enqueue_warm_if_due()
+        enq.assert_not_called()
+
+    def test_skips_enqueue_self_hosted(self):
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        with patch("jarvis.selfhost.is_self_hosted", return_value=True), \
+             patch("jarvis.chat.prewarm.frappe.enqueue") as enq:
+            prewarm.enqueue_warm_if_due()
+        enq.assert_not_called()
+
+
+class TestListConversationsWarms(FrappeTestCase):
+    def tearDown(self):
+        from jarvis.chat import prewarm
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+
+    def test_list_conversations_triggers_warm_on_load(self):
+        from jarvis.chat import api
+
+        with patch("jarvis.chat.prewarm.enqueue_warm_if_due") as w:
+            api.list_conversations()
+        w.assert_called_once()


### PR DESCRIPTION
## Problem

The prefix pre-warm (merged in #174) fires a warm-up when a chat opens - but that trigger only lives in the **floating widget** (`Widget.vue` `openPanel`). The main `/jarvis-chat` **ChatView** SPA warms on mount too, but that part is in a separate frontend repo and is not deployed. So opening a new chat in the main UI never warms, and the first turn still pays the ~20s cold prefix prefill (confirmed live: a fresh "hi" took 20s; the cached repeat took 8s).

## Fix

Trigger the warm from the **backend** on chat-page load, so it reaches every UI (widget and ChatView) with no frontend change.

- `prewarm.enqueue_warm_if_due()` - a cheap cache read on the request path; enqueues `warm_prefix` in a background RQ job only if the per-bench cooldown has lapsed. Best-effort, never raises, debounced.
- Called from `list_conversations`, which every chat surface hits on load - giving lead time between page-load and the user's first message.

The heavy work (connect + warm) still runs off the web worker via `frappe.enqueue`; the request path only does a Redis GET.

## Deliberately not doing

Not lowering default thinking effort - a user may send a real query as their first message, and low reasoning would degrade it. Pre-warm handles the prefix (the ~12s cold prefill); reasoning stays user-controlled via the Fast/Balanced/Deep selector.

## Tests

`test_prewarm` 13/13 (added: enqueues-when-due, skips-on-cooldown, skips-self-hosted, list_conversations-triggers-warm). `test_chat_api` 45/45 (existing `list_conversations` callers unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
