### PR TITLE
fix(settings): don't require llm_api_key on an unconfigured fresh site

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -70,12 +70,37 @@ class JarvisSettings(Document):
 
         self._validate_auth_mode_requirements()
 
+    def _llm_is_configured(self) -> bool:
+        """True once the tenant has actually chosen an LLM.
+
+        Configured via ANY of: the unified ``models`` table, a ``preset``, a
+        legacy direct ``llm_model``, or a connected OAuth account. A fresh
+        site with none of these is *unconfigured* - LLM gets set up later,
+        through onboarding - so credential validation must not fire yet.
+        """
+        return bool(
+            getattr(self, "models", None)
+            or getattr(self, "preset", None)
+            or (getattr(self, "llm_model", None) or "")
+            or (getattr(self, "llm_oauth_account_email", None) or "")
+        )
+
     def _validate_auth_mode_requirements(self):
         """Each auth mode requires its own credential field.
 
         REV-1: oauth/subscription mode has no bench-side credential
         requirement - openclaw owns the credential blob on the container.
+
+        Skipped entirely for an unconfigured/pre-onboarding Settings: on a
+        brand-new site ``llm_auth_mode`` DEFAULTS to ``api_key`` before any
+        model is chosen, so enforcing a key here would wrongly block
+        unrelated saves (e.g. enabling sandbox mode) that a customer must
+        make during onboarding. The credential is enforced the moment LLM
+        is actually configured (a model/preset/oauth account present).
         """
+        if not self._llm_is_configured():
+            return
+
         def is_password_set(fieldname: str) -> bool:
             in_memory = getattr(self, fieldname, None) or ""
             if in_memory and not self.is_dummy_password(in_memory):

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -70,35 +70,42 @@ class JarvisSettings(Document):
 
         self._validate_auth_mode_requirements()
 
-    def _llm_is_configured(self) -> bool:
-        """True once the tenant has actually chosen an LLM.
-
-        Configured via ANY of: the unified ``models`` table, a ``preset``, a
-        legacy direct ``llm_model``, or a connected OAuth account. A fresh
-        site with none of these is *unconfigured* - LLM gets set up later,
-        through onboarding - so credential validation must not fire yet.
-        """
-        return bool(
-            getattr(self, "models", None)
-            or getattr(self, "preset", None)
-            or (getattr(self, "llm_model", None) or "")
-            or (getattr(self, "llm_oauth_account_email", None) or "")
-        )
-
     def _validate_auth_mode_requirements(self):
         """Each auth mode requires its own credential field.
 
         REV-1: oauth/subscription mode has no bench-side credential
         requirement - openclaw owns the credential blob on the container.
 
-        Skipped entirely for an unconfigured/pre-onboarding Settings: on a
-        brand-new site ``llm_auth_mode`` DEFAULTS to ``api_key`` before any
-        model is chosen, so enforcing a key here would wrongly block
-        unrelated saves (e.g. enabling sandbox mode) that a customer must
-        make during onboarding. The credential is enforced the moment LLM
-        is actually configured (a model/preset/oauth account present).
+        Scope: this validates ONLY the legacy single-model DIRECT path (the
+        flat ``llm_*`` fields, with no ``models`` rows and no ``preset``).
+        When the models table or a preset is present the config is unified -
+        ``validate_models()`` (run in ``on_update``) owns credential
+        validation, and the flat ``llm_*`` fields are only a derived mirror
+        that ``before_validate`` populates for an ENABLED row. Re-checking that
+        mirror here would race it and throw spuriously for a disabled-only
+        table, a bare preset, or a ``models[0]`` decrypt error.
+
+        For the legacy path, an unconfigured/pre-onboarding Settings (no model,
+        no base_url, no connected oauth account) is skipped so unrelated saves
+        (e.g. enabling sandbox mode during onboarding) aren't blocked - even
+        though ``llm_auth_mode`` DEFAULTS to ``api_key`` before anything is
+        chosen. ``reset_onboarding`` leaves ``llm_provider`` at a default but
+        clears model/base_url/key, so it correctly reads as unconfigured.
         """
-        if not self._llm_is_configured():
+        # Unified config (any models rows or a preset) -> validate_models owns it.
+        if getattr(self, "models", None) or getattr(self, "preset", None):
+            return
+
+        # Legacy direct path: only enforce once a real direct config exists.
+        # llm_base_url covers custom-endpoint configs where llm_model is blank;
+        # llm_oauth_connected_at is the canonical oauth signal (is_ready_for_chat
+        # keys off it too), not the display-only llm_oauth_account_email.
+        configured = bool(
+            (getattr(self, "llm_model", None) or "")
+            or (getattr(self, "llm_base_url", None) or "")
+            or getattr(self, "llm_oauth_connected_at", None)
+        )
+        if not configured:
             return
 
         def is_password_set(fieldname: str) -> bool:
@@ -109,12 +116,11 @@ class JarvisSettings(Document):
             return bool(db_value)
 
         mode = getattr(self, "llm_auth_mode", None) or "api_key"
-        if mode == "api_key":
-            if not is_password_set("llm_api_key"):
-                frappe.throw(
-                    "API-key auth mode requires llm_api_key",
-                    frappe.ValidationError,
-                )
+        if mode == "api_key" and not is_password_set("llm_api_key"):
+            frappe.throw(
+                "API-key auth mode requires llm_api_key",
+                frappe.ValidationError,
+            )
 
     def _resolve_llm_secret_for_push(self) -> str:
         """Return the bytes to push to openclaw's llm.key.

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -290,6 +290,27 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
         settings.llm_model = "gpt-4o"
         settings.validate()  # should not raise
 
+    def test_unconfigured_fresh_settings_does_not_require_api_key(self):
+        """Fresh/pre-onboarding Settings - no models, no preset, no direct
+        model, no oauth account - must validate even though llm_auth_mode
+        DEFAULTS to 'api_key' with no key set.
+
+        Regression for the fresh-start save deadlock: on a brand-new site the
+        customer must save Jarvis Settings (e.g. to enable sandbox mode)
+        BEFORE onboarding configures an LLM. Enforcing the api_key credential
+        on that defaulted mirror made the whole settings form unsaveable, so
+        onboarding could never start. The credential is enforced the moment
+        LLM is actually configured (see the api_key/oauth tests above)."""
+        settings = frappe.get_single("Jarvis Settings")
+        settings.set("models", [])
+        settings.preset = ""
+        settings.llm_auth_mode = "api_key"
+        settings.llm_api_key = ""
+        settings.llm_provider = ""
+        settings.llm_model = ""
+        settings.llm_oauth_account_email = ""
+        settings.validate()  # must NOT raise - nothing is configured yet
+
 
 class TestClassifyAuthModeSwitch(_SettingsSingletonTestCase):
     """Mode-switch is structural - always triggers restart."""

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -245,12 +245,31 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
     subscription modes (oauth / legacy subscription) keep credentials on
     the container, so the bench's validate() has no check for them."""
 
+    @classmethod
+    def tearDownClass(cls):
+        # Tests here mutate models/preset/oauth signals the base snapshot
+        # doesn't cover; clear them so this class leaves no footprint on the
+        # shared Jarvis Settings singleton (test-pollution guard).
+        frappe.db.delete("Jarvis LLM Pool Model",
+                         {"parenttype": "Jarvis Settings", "parent": "Jarvis Settings"})
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("preset", "", update_modified=False)
+        settings.db_set("llm_oauth_connected_at", None, update_modified=False)
+        frappe.db.commit()
+        super().tearDownClass()
+
     def setUp(self):
         from frappe.utils.password import remove_encrypted_password
         _reset_settings()
         remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "llm_api_key")
+        # Start each test from a clean LEGACY-direct state: no models rows, no
+        # preset, no oauth connection (the base snapshot doesn't cover these).
+        frappe.db.delete("Jarvis LLM Pool Model",
+                         {"parenttype": "Jarvis Settings", "parent": "Jarvis Settings"})
         settings = frappe.get_single("Jarvis Settings")
         settings.db_set("llm_auth_mode", "api_key", update_modified=False)
+        settings.db_set("preset", "", update_modified=False)
+        settings.db_set("llm_oauth_connected_at", None, update_modified=False)
         frappe.db.commit()
 
     def test_api_key_mode_requires_api_key(self):
@@ -292,15 +311,13 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
 
     def test_unconfigured_fresh_settings_does_not_require_api_key(self):
         """Fresh/pre-onboarding Settings - no models, no preset, no direct
-        model, no oauth account - must validate even though llm_auth_mode
-        DEFAULTS to 'api_key' with no key set.
+        model/base_url, no connected oauth account - must validate even though
+        llm_auth_mode DEFAULTS to 'api_key' with no key set.
 
         Regression for the fresh-start save deadlock: on a brand-new site the
-        customer must save Jarvis Settings (e.g. to enable sandbox mode)
-        BEFORE onboarding configures an LLM. Enforcing the api_key credential
-        on that defaulted mirror made the whole settings form unsaveable, so
-        onboarding could never start. The credential is enforced the moment
-        LLM is actually configured (see the api_key/oauth tests above)."""
+        customer must save Jarvis Settings (e.g. to enable sandbox mode) BEFORE
+        onboarding configures an LLM. The credential is enforced the moment LLM
+        is actually configured (see the api_key/oauth tests above)."""
         settings = frappe.get_single("Jarvis Settings")
         settings.set("models", [])
         settings.preset = ""
@@ -308,8 +325,44 @@ class TestValidateAuthMode(_SettingsSingletonTestCase):
         settings.llm_api_key = ""
         settings.llm_provider = ""
         settings.llm_model = ""
-        settings.llm_oauth_account_email = ""
+        settings.llm_base_url = ""
+        settings.llm_oauth_connected_at = None
         settings.validate()  # must NOT raise - nothing is configured yet
+
+    def test_legacy_direct_base_url_without_key_still_raises(self):
+        """A real legacy-direct api_key config (custom base_url set) with the
+        key cleared must still raise even when llm_model is blank - it is a
+        configured tenant, not a fresh/unconfigured site. Guards the boundary
+        so narrowing the fresh-start gate doesn't let a keyless credential push
+        through (review finding: keyless-direct bypass)."""
+        settings = frappe.get_single("Jarvis Settings")
+        settings.set("models", [])
+        settings.preset = ""
+        settings.llm_auth_mode = "api_key"
+        settings.llm_api_key = ""
+        settings.llm_provider = "Custom"
+        settings.llm_model = ""
+        settings.llm_base_url = "https://llm.internal.example.com/v1"
+        with self.assertRaises(frappe.ValidationError):
+            settings.validate()
+
+    def test_models_table_present_skips_flat_api_key_check(self):
+        """When the models table drives config, validate_models() (in
+        on_update) owns credential validation; the flat llm_* guard must NOT
+        fire against the derived mirror. A models row present (even disabled,
+        which before_validate won't mirror) with a stale/empty legacy
+        llm_api_key + api_key mode must not raise from validate() - otherwise
+        disabled-only tables / decrypt errors produce spurious throws that
+        re-block saves (review findings: disabled-only, decrypt-error)."""
+        settings = frappe.get_single("Jarvis Settings")
+        settings.llm_auth_mode = "api_key"
+        settings.llm_api_key = ""
+        settings.append("models", {
+            "provider": "openai_compat", "model": "gpt-4o",
+            "credential_type": "api_key", "api_key": "",
+            "tier": "strong", "order": 0, "enabled": 0,
+        })
+        settings.validate()  # must NOT raise the flat 'requires llm_api_key'
 
 
 class TestClassifyAuthModeSwitch(_SettingsSingletonTestCase):


### PR DESCRIPTION
## Problem

On a freshly installed / reset `site.jarvis`, **any** save of `Jarvis Settings` throws:

> API-key auth mode requires llm_api_key

`Jarvis Settings.validate()` → `_validate_auth_mode_requirements()` reads `llm_auth_mode`, which **defaults to `api_key`**, and demands a key — even when no LLM has been configured yet and the save is unrelated to LLM config (e.g. toggling **Enable Sandbox Mode** during onboarding).

Net effect: a customer on a fresh site can't save `Jarvis Settings` at all, so onboarding can never enable sandbox mode and never starts. Under the unified LLM config (#155) the `models` table is the source of truth and starts empty, so the legacy `llm_auth_mode` mirror's `api_key` default becomes a hard blocker.

## Fix

`jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py`

- Add `_llm_is_configured()` — true when any of `models` / `preset` / `llm_model` / `llm_oauth_account_email` is set.
- `_validate_auth_mode_requirements()` now early-returns when the tenant is unconfigured (pre-onboarding). The api-key requirement is still enforced the moment an LLM is actually configured (a model / preset / oauth account is present), so no real misconfiguration slips through.

This treats "no LLM configured yet" as a valid pre-onboarding state, consistent with the unified-config design where onboarding is the canonical path that writes `models[0]`.

## Tests

- New regression `test_unconfigured_fresh_settings_does_not_require_api_key` (`jarvis/tests/test_settings_on_update.py`) — a bare `Jarvis Settings` validates without a key.
- Existing `test_api_key_mode_requires_api_key` still passes: a *configured* api-key model without a key still throws.

```
bench --site <site> run-tests --module jarvis.tests.test_settings_on_update   # 34 passed
bench --site <site> run-tests --module jarvis.tests.test_unified_llm_config    # 32 passed
```

## Context

Found during a from-scratch onboarding e2e on a reinstalled site, on top of the unified LLM config (#155). Companion fix for the same onboarding flow: #178 (OAuth-connect doctor ordering).
