### PR TITLE
fix(oauth): render config before pushing the OAuth blob (fixes doctor_failed on subscription connect)

### DIFF
--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -321,19 +321,25 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 		"clientId": p["client_id"],
 	}
 
-	admin_client.post_push_oauth_blob(p["openclaw_provider"], blob)
-	# force=True is mandatory here. The OAuth blob lives in the container's
-	# auth-profiles.json (out-of-band from Jarvis Settings), so on_update's
-	# diff classifier sees no change and skips the re-render+restart when
-	# a customer re-authorizes with the same provider+model. Without the
-	# restart the container's openclaw keeps serving stale auth, surfacing
-	# as the same ProviderAuthError the re-auth was meant to fix. Verified
-	# live 2026-06-11.
+	# Render the OAuth config BEFORE pushing the credential blob. save_llm_creds
+	# re-renders openclaw.json (provider/model + gateway.mode) and restarts the
+	# container; push_oauth_blob then writes the blob and runs `openclaw doctor
+	# --fix` to migrate the auth-profile store. A bare pool member has NO
+	# rendered openclaw.json, so if the blob push (doctor) runs first, doctor
+	# exits non-zero on "gateway.mode is unset" and the whole apply fails with
+	# doctor_failed. Rendering creds first guarantees gateway.mode is present
+	# when doctor runs, so the migration's exit code is clean.
+	#
+	# force=True bypasses on_update's no-diff gate (_classify_llm_change returns
+	# None when no Jarvis Settings field changed) so the re-render+restart fires
+	# even on a same-provider re-authorize. The blob lives in auth-profiles.json,
+	# out-of-band from Jarvis Settings, so the diff classifier can't see it.
 	sync_result = onboarding.save_llm_creds(
 		provider=provider, model=model,
 		api_key="", base_url="", auth_mode="oauth",
 		force=True,
 	)
+	admin_client.post_push_oauth_blob(p["openclaw_provider"], blob)
 
 	settings = frappe.get_single("Jarvis Settings")
 	settings.db_set("llm_oauth_account_email", email, update_modified=False)


### PR DESCRIPTION
## Problem

Connecting a chat **subscription** during onboarding (`complete_paste_signin`) fails at the final step with:

> admin returned a 502 error: doctor_failed: openclaw doctor could not migrate the auth-profile store

The OAuth code exchange itself succeeds — the failure is applying the credential to the container. The flow was:

1. `admin_client.post_push_oauth_blob(...)` → fleet-agent `PUT /auth-profile` → `openclaw doctor --fix` migrates `auth-profiles.json` → SQLite, **then**
2. `onboarding.save_llm_creds(auth_mode="oauth", force=True)` → renders `openclaw.json`.

A freshly-assigned **warm pool container has no rendered `openclaw.json`** — it runs on openclaw's built-in defaults, and the full config is only written when creds are applied. So when `openclaw doctor` runs in step 1, `gateway.mode` is unset and doctor exits non-zero (`"gateway.mode is unset; run openclaw setup first"`) — even though the auth-profile migration itself succeeds (`"Migrated auth profile JSON … into SQLite"`). The fleet-agent's `auth_profile_apply._doctor_and_restart` treats any non-zero doctor exit as `doctor_failed`, so the whole connect fails.

## Fix

`jarvis/oauth/api.py::complete_paste_signin`

Swap the order: call `save_llm_creds(...)` **before** `post_push_oauth_blob(...)`. `save_llm_creds` renders `openclaw.json` (which includes `"gateway": {"mode": "local", …}`) and restarts the container, so by the time `openclaw doctor` runs the config is complete and doctor exits 0.

This is also the more correct sequencing — configure the provider, *then* inject its credential. `save_llm_creds(oauth)` doesn't depend on the blob being present (the credential lives in `auth-profiles.json`, applied in the next step), and `force=True` is retained so the re-render + restart still fires on a same-provider re-authorize.

## Verified live

Full direct single-subscription path now works end-to-end through the real UI:

- `PUT /auth-profile → 200` (was `502 doctor_failed`)
- Container `openclaw.json` rendered with `gateway.mode: local` + the oauth-codex block (`agents.defaults.model.primary = openai/gpt-5.5`)
- auth-profiles migrated to SQLite (`openclaw-agent.sqlite` present)
- Chat replies, and **ERP tools execute**: `[jarvis-openclaw-plugin] tool=get_list … call=call_… result=ok`

## Tests

```
bench --site <site> run-tests --module jarvis.tests.test_oauth_api
# 28 passed, 1 PRE-EXISTING unrelated failure:
#   test_gemini_standard_api_model_coerced_to_cli_default asserts 'gemini-2.0-pro'
#   but the catalog default is 'gemini-2.5-pro' — a stale begin_paste_signin
#   assertion, not touched by this PR.
```

## Related follow-ups (not in this PR)

- **jarvis_admin** — the free plan's `memory_limit_mb=512` OOM-kills (`exit 137`) the `openclaw doctor` migration on the OAuth path; it needs ≥~1 GB. Bump the plan default (or reduce the doctor's footprint).
- **jarvis-fleet-agent** — `auth_profile_apply._doctor_and_restart` gates on doctor's *global* exit code; making it tolerant of non-migration gripes (or using a targeted migrate command) would harden this regardless of config completeness.

## Context

Found during a from-scratch subscription onboarding e2e, on top of the unified LLM config (#155). Companion fix for the same onboarding flow: #177 (fresh-start settings save).
