### PR TITLE
fix(chat): render agent xychart-beta as ECharts + dark-theme charts

### DIFF
--- a/frontend/src/charts/chartTheme.js
+++ b/frontend/src/charts/chartTheme.js
@@ -28,13 +28,14 @@ function axisOption(spec, series, { text, grid, title }) {
 	const opts = spec.options || {}
 	const cat = {
 		type: "category", data: x, axisTick: { show: false },
-		axisLine: { lineStyle: { color: grid } }, axisLabel: { color: text },
+		axisLine: { lineStyle: { color: grid } }, axisLabel: { color: text, hideOverlap: true },
 	}
 	const val = {
 		type: "value", axisLabel: { color: text },
 		splitLine: { lineStyle: { type: "dashed", color: grid } },
 	}
 	return {
+		backgroundColor: "transparent",
 		color: PALETTE,
 		title,
 		grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 8, containLabel: true },
@@ -79,6 +80,7 @@ function pieOption(spec, series, text, title) {
 	const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
 	const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: Number(v) || 0 }))
 	return {
+		backgroundColor: "transparent",
 		color: PALETTE,
 		title,
 		tooltip: { trigger: "item", confine: true },

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1225,6 +1225,47 @@ const _SKILL_RE = /```jarvis-skill[ \t]*\n([\s\S]*?)```/
 // ECharts (themed by chartTheme; the agent never sends raw ECharts options).
 const _CHART_RE = /```jarvis-chart[ \t]*\n([\s\S]*?)```/g
 const _CHART_TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+// The agent keeps emitting ```mermaid xychart-beta for DATA charts instead of
+// jarvis-chart. Mermaid renders xychart unstyled and crams the axis labels, so
+// we intercept those blocks, parse the fixed xychart-beta grammar into a
+// jarvis-chart spec, and render them through the themed ECharts path instead.
+const _XYCHART_RE = /```mermaid[ \t]*\n([\s\S]*?)```/g
+function _xySplit(s) {
+	const out = []
+	const re = /"([^"]*)"|'([^']*)'|([^,]+)/g
+	let m
+	while ((m = re.exec(s))) {
+		const v = (m[1] ?? m[2] ?? m[3] ?? "").trim().replace(/^["']|["']$/g, "")
+		if (v) out.push(v)
+	}
+	return out
+}
+function parseXychart(body) {
+	const text = String(body || "")
+	if (!/^\s*xychart-beta\b/.test(text)) return null
+	const horizontal = /xychart-beta[ \t]+horizontal\b/.test(text)
+	const tM = text.match(/title[ \t]+"([^"]*)"/)
+	const yM = text.match(/y-axis[ \t]+"([^"]*)"/)
+	const yLabel = yM ? yM[1].trim() : undefined
+	let x = []
+	const xM = text.match(/x-axis[ \t]+\[([^\]]*)\]/)
+	if (xM) x = _xySplit(xM[1])
+	const series = []
+	let anyBar = false
+	const re = /\b(bar|line)[ \t]+(?:"([^"]*)"[ \t]+)?\[([^\]]*)\]/g
+	let m
+	while ((m = re.exec(text))) {
+		const data = _xySplit(m[3]).map(Number).filter((n) => !Number.isNaN(n))
+		if (!data.length) continue
+		if (m[1] === "bar") anyBar = true
+		series.push({ name: m[2] || yLabel || "Value", data })
+	}
+	if (!series.length) return null
+	const spec = { type: anyBar ? "bar" : "line", x, series }
+	if (tM) spec.title = tM[1].trim()
+	if (horizontal) spec.options = { horizontal: true }
+	return spec
+}
 function stripBlocks(text) {
 	return (text || "")
 		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
@@ -1233,6 +1274,7 @@ function stripBlocks(text) {
 		.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, "")
 		.replace(/```jarvis-skill[ \t]*\n[\s\S]*?```/g, "")
 		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g, "")
 		.replace(/\n{3,}/g, "\n\n")
 		.trim()
 }
@@ -1288,7 +1330,7 @@ function cardsOf(m) {
 const _chartsCache = new Map()
 function chartsOf(m) {
 	const content = (m && m.content) || ""
-	if (!content.includes("jarvis-chart")) return []
+	if (!content.includes("jarvis-chart") && !content.includes("xychart-beta")) return []
 	if (_chartsCache.has(content)) return _chartsCache.get(content)
 	const specs = []
 	for (const mt of content.matchAll(_CHART_RE)) {
@@ -1300,6 +1342,10 @@ function chartsOf(m) {
 		} catch (e) {
 			/* incomplete mid-stream JSON: skip until the closing fence arrives */
 		}
+	}
+	for (const mt of content.matchAll(_XYCHART_RE)) {
+		const s = parseXychart(mt[1])
+		if (s) specs.push(s)
 	}
 	_chartsCache.set(content, specs)
 	return specs
@@ -1852,7 +1898,7 @@ async function _renderMermaid() {
 			primaryBorderColor: dark ? "#3a3a45" : "#d6e2fb",
 			primaryTextColor: dark ? "#ededf2" : "#171717",
 			lineColor: dark ? "#5b7cfa" : "#3b82f6",
-			textColor: dark ? "#b6b6c0" : "#4a4a4f",
+			textColor: dark ? "#b6b6c0" : "#4a4a4f", xyChart: { backgroundColor: dark ? "#16161a" : "#ffffff", titleColor: dark ? "#ededf2" : "#171717", xAxisLabelColor: dark ? "#b6b6c0" : "#4a4a4f", xAxisTitleColor: dark ? "#b6b6c0" : "#4a4a4f", xAxisTickColor: dark ? "#3a3a45" : "#d6e2fb", xAxisLineColor: dark ? "#3a3a45" : "#d6e2fb", yAxisLabelColor: dark ? "#b6b6c0" : "#4a4a4f", yAxisTitleColor: dark ? "#b6b6c0" : "#4a4a4f", yAxisTickColor: dark ? "#3a3a45" : "#d6e2fb", yAxisLineColor: dark ? "#3a3a45" : "#d6e2fb", plotColorPalette: MERMAID_PALETTE.join(",") },
 		},
 	})
 	let n = 0


### PR DESCRIPTION
Data charts rendered as white/unstyled boxes in dark mode with cramped, overlapping axis labels. Root cause: the agent emits `mermaid xychart-beta` for data (not jarvis-chart), and mermaid renders xychart on a light background with crammed labels regardless of the app theme.

- Intercept `mermaid xychart-beta` blocks in ChatView: parse the fixed grammar (title / x-axis / y-axis / bar|line) into a jarvis-chart spec and render through the themed ECharts JvChart path (dark/light theme, palette, tooltips) instead of mermaid.
- chartTheme: backgroundColor transparent (bar + pie) so the chart shows the chat surface instead of ECharts' default white; hideOverlap on the category axis so 12-month labels don't cram.
- mermaid init: xyChart theme block as a fallback for any xychart variant the intercept regex doesn't catch.