### PR TITLE
feat(chat): add 7 more jarvis-chart types (scatter/bubble/heatmap/boxplot/radar/funnel/gauge)

### DIFF
--- a/frontend/src/charts/chartTheme.js
+++ b/frontend/src/charts/chartTheme.js
@@ -1,14 +1,19 @@
 // Safe high-level chart spec -> themed ECharts option. Mirrors Frappe Insights'
 // look (palette, dashed gridlines, no ticks, rounded bars, smooth/gradient).
-// PURE: no echarts import (gradients use plain colorStops objects), so it is
-// unit-testable under `node --test`. The chat owns the theme; the agent never
-// sends raw ECharts options.
+// PURE: no echarts import (gradients use plain colorStops objects, bubble sizing
+// uses a plain function), so it is unit-testable under `node --test`. The chat
+// owns the theme; the agent never sends raw ECharts options.
 
 const PALETTE = [
 	"#2490ef", "#48bb74", "#f6ad55", "#fc8181", "#9f7aea",
 	"#38b2ac", "#ed64a6", "#ecc94b", "#667eea", "#a0aec0",
 ]
-const TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+const TYPES = new Set([
+	"bar", "line", "area", "pie", "donut",
+	"scatter", "bubble", "heatmap", "boxplot", "radar", "funnel", "gauge",
+])
+
+const num = (v) => Number(v) || 0
 
 export function buildOption(spec, dark = false) {
 	if (!spec || typeof spec !== "object" || !TYPES.has(spec.type)) return null
@@ -19,8 +24,18 @@ export function buildOption(spec, dark = false) {
 	const title = spec.title
 		? { text: String(spec.title), left: 8, top: 4, textStyle: { fontSize: 13, color: text } }
 		: undefined
-	if (spec.type === "pie" || spec.type === "donut") return pieOption(spec, series, text, title)
-	return axisOption(spec, series, { text, grid, title })
+	switch (spec.type) {
+		case "pie":
+		case "donut": return pieOption(spec, series, text, title)
+		case "scatter": return scatterOption(spec, series, { text, grid, title }, false)
+		case "bubble": return scatterOption(spec, series, { text, grid, title }, true)
+		case "heatmap": return heatmapOption(spec, series, { text, grid, title, dark })
+		case "boxplot": return boxplotOption(spec, series, { text, grid, title })
+		case "radar": return radarOption(spec, series, { text, grid, title })
+		case "funnel": return funnelOption(spec, series, { text, title })
+		case "gauge": return gaugeOption(spec, series, { text, title })
+		default: return axisOption(spec, series, { text, grid, title })
+	}
 }
 
 function axisOption(spec, series, { text, grid, title }) {
@@ -78,7 +93,7 @@ function makeSeries(spec, s, i) {
 function pieOption(spec, series, text, title) {
 	const labels = Array.isArray(spec.x) ? spec.x.map(String) : []
 	const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
-	const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: Number(v) || 0 }))
+	const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: num(v) }))
 	return {
 		backgroundColor: "transparent",
 		color: PALETTE,
@@ -92,6 +107,166 @@ function pieOption(spec, series, text, title) {
 			data,
 			label: { color: text },
 			itemStyle: { borderRadius: 4, borderColor: text === "#333333" ? "#fff" : "#1a202c", borderWidth: 1 },
+		}],
+	}
+}
+
+// scatter: series data is [[x, y], ...]; bubble adds a 3rd magnitude value
+// [[x, y, size], ...] mapped to the symbol radius. Both use value axes.
+function scatterOption(spec, series, { text, grid, title }, bubble) {
+	const opts = spec.options || {}
+	const valAxis = (name) => ({
+		type: "value", name: name || undefined, nameTextStyle: { color: text },
+		axisLabel: { color: text }, axisLine: { lineStyle: { color: grid } },
+		splitLine: { lineStyle: { type: "dashed", color: grid } },
+	})
+	let maxSize = 1
+	if (bubble) {
+		for (const s of series) for (const d of (Array.isArray(s.data) ? s.data : [])) maxSize = Math.max(maxSize, num(d && d[2]))
+	}
+	return {
+		backgroundColor: "transparent",
+		color: PALETTE,
+		title,
+		grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 8, containLabel: true },
+		tooltip: { trigger: "item", confine: true },
+		legend: series.length > 1 ? { type: "scroll", top: title ? 4 : 0, right: 8, textStyle: { color: text } } : undefined,
+		xAxis: valAxis(opts.xName),
+		yAxis: valAxis(opts.yName),
+		series: series.map((s, i) => ({
+			name: s.name, type: "scatter",
+			data: Array.isArray(s.data) ? s.data : [],
+			symbolSize: bubble ? ((d) => 8 + Math.sqrt(num(d && d[2]) / maxSize) * 38) : 10,
+			itemStyle: { color: PALETTE[i % PALETTE.length], opacity: 0.75 },
+		})),
+	}
+}
+
+// heatmap: category x + category y grids; series[0].data is [[xIndex, yIndex,
+// value], ...]. A visualMap colours cells by value.
+function heatmapOption(spec, series, { text, grid, title, dark }) {
+	const xs = Array.isArray(spec.x) ? spec.x.map(String) : []
+	const ys = Array.isArray(spec.y) ? spec.y.map(String) : []
+	const data = Array.isArray(series[0] && series[0].data) ? series[0].data : []
+	let min = Infinity, max = -Infinity
+	for (const d of data) { const v = num(d && d[2]); if (v < min) min = v; if (v > max) max = v }
+	if (!isFinite(min)) { min = 0; max = 1 }
+	return {
+		backgroundColor: "transparent",
+		title,
+		tooltip: { position: "top", confine: true },
+		grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 56, containLabel: true },
+		xAxis: { type: "category", data: xs, splitArea: { show: true }, axisLabel: { color: text, hideOverlap: true }, axisLine: { lineStyle: { color: grid } } },
+		yAxis: { type: "category", data: ys, splitArea: { show: true }, axisLabel: { color: text }, axisLine: { lineStyle: { color: grid } } },
+		visualMap: {
+			min, max, calculable: true, orient: "horizontal", left: "center", bottom: 0,
+			textStyle: { color: text },
+			inRange: { color: dark ? ["#1e3a5f", "#2490ef", "#63b3ed"] : ["#e6f0fb", "#2490ef", "#1a56a0"] },
+		},
+		series: [{
+			type: "heatmap", data, label: { show: false },
+			emphasis: { itemStyle: { shadowBlur: 8, shadowColor: "rgba(0,0,0,0.3)" } },
+		}],
+	}
+}
+
+// boxplot: category x; each series data item is [min, q1, median, q3, max].
+function boxplotOption(spec, series, { text, grid, title }) {
+	const x = Array.isArray(spec.x) ? spec.x.map(String) : []
+	return {
+		backgroundColor: "transparent",
+		color: PALETTE,
+		title,
+		grid: { left: 8, right: 16, top: title ? 36 : 20, bottom: 8, containLabel: true },
+		tooltip: { trigger: "item", confine: true },
+		legend: series.length > 1 ? { type: "scroll", top: title ? 4 : 0, right: 8, textStyle: { color: text } } : undefined,
+		xAxis: { type: "category", data: x, axisTick: { show: false }, axisLine: { lineStyle: { color: grid } }, axisLabel: { color: text, hideOverlap: true } },
+		yAxis: { type: "value", axisLabel: { color: text }, splitLine: { lineStyle: { type: "dashed", color: grid } } },
+		series: series.map((s, i) => ({
+			name: s.name, type: "boxplot",
+			data: Array.isArray(s.data) ? s.data : [],
+			itemStyle: { color: PALETTE[i % PALETTE.length] + "33", borderColor: PALETTE[i % PALETTE.length] },
+		})),
+	}
+}
+
+// radar: spec.x names the spokes; each series data is one value per spoke. The
+// per-spoke max is 1.1x the largest value seen there so shapes fill the web.
+function radarOption(spec, series, { text, grid, title }) {
+	const names = Array.isArray(spec.x) ? spec.x.map(String) : []
+	const maxes = names.map((_, j) => {
+		let m = 0
+		for (const s of series) m = Math.max(m, num((s.data || [])[j]))
+		return m > 0 ? m * 1.1 : 1
+	})
+	return {
+		backgroundColor: "transparent",
+		color: PALETTE,
+		title,
+		tooltip: { trigger: "item", confine: true },
+		legend: series.length > 1 ? { type: "scroll", bottom: 0, textStyle: { color: text } } : undefined,
+		radar: {
+			indicator: names.map((name, j) => ({ name, max: maxes[j] })),
+			axisName: { color: text },
+			splitLine: { lineStyle: { color: grid } },
+			splitArea: { show: false },
+			axisLine: { lineStyle: { color: grid } },
+		},
+		series: [{
+			type: "radar",
+			data: series.map((s, i) => ({
+				name: s.name,
+				value: (Array.isArray(s.data) ? s.data : []).map(num),
+				areaStyle: { opacity: 0.1 },
+				lineStyle: { color: PALETTE[i % PALETTE.length] },
+				itemStyle: { color: PALETTE[i % PALETTE.length] },
+			})),
+		}],
+	}
+}
+
+// funnel: spec.x names the stages; series[0].data is the value per stage.
+function funnelOption(spec, series, { text, title }) {
+	const labels = Array.isArray(spec.x) ? spec.x.map(String) : []
+	const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
+	const data = d0.map((v, i) => ({ name: labels[i] != null ? labels[i] : `#${i + 1}`, value: num(v) }))
+	return {
+		backgroundColor: "transparent",
+		color: PALETTE,
+		title,
+		tooltip: { trigger: "item", confine: true },
+		legend: { type: "scroll", bottom: 0, textStyle: { color: text } },
+		series: [{
+			type: "funnel", left: "10%", right: "10%", top: title ? 40 : 24, bottom: 28,
+			minSize: "0%", maxSize: "100%", sort: "descending", gap: 2,
+			label: { show: true, position: "inside", color: "#fff" },
+			data,
+		}],
+	}
+}
+
+// gauge: a single value (series[0].data[0]) against a max (options.max, else
+// 1.25x the value).
+function gaugeOption(spec, series, { text, title }) {
+	const opts = spec.options || {}
+	const d0 = Array.isArray(series[0] && series[0].data) ? series[0].data : []
+	const value = num(d0[0])
+	const max = num(opts.max) || (value > 0 ? Math.ceil(value * 1.25) : 100)
+	return {
+		backgroundColor: "transparent",
+		color: PALETTE,
+		title,
+		series: [{
+			type: "gauge", min: 0, max,
+			progress: { show: true, width: 12 },
+			axisLine: { lineStyle: { width: 12 } },
+			axisTick: { show: false },
+			splitLine: { length: 10, lineStyle: { color: "auto" } },
+			axisLabel: { color: text, distance: 14 },
+			pointer: { width: 5 },
+			detail: { valueAnimation: true, color: text, fontSize: 22, offsetCenter: [0, "70%"] },
+			title: { color: text, offsetCenter: [0, "92%"] },
+			data: [{ value, name: (series[0] && series[0].name) || "" }],
 		}],
 	}
 }

--- a/frontend/src/charts/chartTheme.test.js
+++ b/frontend/src/charts/chartTheme.test.js
@@ -55,3 +55,61 @@ test("legend only when >1 series; dark text differs from light", () => {
 	const light = buildOption({ type: "bar", x: ["A"], series: [{ data: [1] }], title: "t" }, false)
 	assert.notEqual(dark.xAxis.axisLabel.color, light.xAxis.axisLabel.color)
 })
+
+test("every chart type sets a transparent background (dark-mode safe)", () => {
+	const specs = [
+		{ type: "bar", x: ["A"], series: [{ data: [1] }] },
+		{ type: "pie", x: ["A"], series: [{ data: [1] }] },
+		{ type: "scatter", series: [{ data: [[1, 2]] }] },
+		{ type: "heatmap", x: ["A"], y: ["B"], series: [{ data: [[0, 0, 5]] }] },
+		{ type: "boxplot", x: ["A"], series: [{ data: [[1, 2, 3, 4, 5]] }] },
+		{ type: "radar", x: ["A", "B"], series: [{ data: [1, 2] }] },
+		{ type: "funnel", x: ["A"], series: [{ data: [1] }] },
+		{ type: "gauge", series: [{ data: [42] }] },
+	]
+	for (const s of specs) assert.equal(buildOption(s).backgroundColor, "transparent", s.type)
+})
+
+test("scatter/bubble: value axes; bubble sizes the symbol from the 3rd value", () => {
+	const sc = buildOption({ type: "scatter", series: [{ name: "S", data: [[1, 2], [3, 4]] }] })
+	assert.equal(sc.xAxis.type, "value")
+	assert.equal(sc.yAxis.type, "value")
+	assert.equal(sc.series[0].type, "scatter")
+	assert.equal(typeof sc.series[0].symbolSize, "number")
+	const bub = buildOption({ type: "bubble", series: [{ data: [[1, 2, 10], [3, 4, 40]] }] })
+	assert.equal(typeof bub.series[0].symbolSize, "function")
+	assert.ok(bub.series[0].symbolSize([3, 4, 40]) > bub.series[0].symbolSize([1, 2, 10]))
+})
+
+test("heatmap: category x+y and a visualMap scaled to the data range", () => {
+	const o = buildOption({ type: "heatmap", x: ["Mon", "Tue"], y: ["AM", "PM"], series: [{ data: [[0, 0, 3], [1, 1, 9]] }] })
+	assert.equal(o.xAxis.type, "category")
+	assert.equal(o.yAxis.type, "category")
+	assert.equal(o.series[0].type, "heatmap")
+	assert.equal(o.visualMap.min, 3)
+	assert.equal(o.visualMap.max, 9)
+})
+
+test("boxplot: category x, five-number data passes through", () => {
+	const o = buildOption({ type: "boxplot", x: ["A"], series: [{ data: [[1, 2, 3, 4, 5]] }] })
+	assert.equal(o.series[0].type, "boxplot")
+	assert.deepEqual(o.series[0].data, [[1, 2, 3, 4, 5]])
+})
+
+test("radar: indicators from x with per-spoke max headroom", () => {
+	const o = buildOption({ type: "radar", x: ["Speed", "Cost"], series: [{ name: "P", data: [10, 20] }] })
+	assert.equal(o.series[0].type, "radar")
+	assert.equal(o.radar.indicator[0].name, "Speed")
+	assert.ok(o.radar.indicator[1].max >= 20)
+	assert.deepEqual(o.series[0].data[0].value, [10, 20])
+})
+
+test("funnel maps x+series[0] to stages; gauge reads a single value + options.max", () => {
+	const fn = buildOption({ type: "funnel", x: ["Lead", "Won"], series: [{ data: [100, 20] }] })
+	assert.equal(fn.series[0].type, "funnel")
+	assert.deepEqual(fn.series[0].data, [{ name: "Lead", value: 100 }, { name: "Won", value: 20 }])
+	const g = buildOption({ type: "gauge", series: [{ name: "SLA", data: [87] }], options: { max: 100 } })
+	assert.equal(g.series[0].type, "gauge")
+	assert.equal(g.series[0].max, 100)
+	assert.equal(g.series[0].data[0].value, 87)
+})

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1224,7 +1224,7 @@ const _SKILL_RE = /```jarvis-skill[ \t]*\n([\s\S]*?)```/
 // A ```jarvis-chart block: a high-level chart spec the chat renders inline with
 // ECharts (themed by chartTheme; the agent never sends raw ECharts options).
 const _CHART_RE = /```jarvis-chart[ \t]*\n([\s\S]*?)```/g
-const _CHART_TYPES = new Set(["bar", "line", "area", "pie", "donut"])
+const _CHART_TYPES = new Set(["bar", "line", "area", "pie", "donut", "scatter", "bubble", "heatmap", "boxplot", "radar", "funnel", "gauge"])
 // The agent keeps emitting ```mermaid xychart-beta for DATA charts instead of
 // jarvis-chart. Mermaid renders xychart unstyled and crams the axis labels, so
 // we intercept those blocks, parse the fixed xychart-beta grammar into a


### PR DESCRIPTION
Expand jarvis-chart beyond bar/line/area/pie/donut to the full ECharts-native palette: scatter (correlation), bubble (+magnitude), heatmap (2-D grid), boxplot (spread/outliers), radar (multi-dimension), funnel (stage drop-off), gauge (metric vs target) - 12 types total. Each is themed for dark/light with a transparent background and hideOverlap axis labels.

chartTheme.buildOption dispatches to per-type builders; the SPA's _CHART_TYPES validation set is widened to match. 13/13 chartTheme unit tests pass.