### PR TITLE
fix(chat): show the live tool count, not a hardcoded list of 11

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,6 +4,7 @@
 import { call } from "frappe-ui"
 
 export const listConversations = () => call("jarvis.chat.api.list_conversations")
+export const listTools = () => call("jarvis.chat.api.list_tools")
 export const getConversation = (conversation) =>
 	call("jarvis.chat.api.get_conversation", { conversation })
 // Rich outputs: fetch one canvas/chart artifact's render-ready HTML for an

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1034,10 +1034,14 @@ const pendingFiles = ref([]) // [{ file_url, file_name }] attachments to send
 const uploading = ref(false)
 const fileInput = ref(null)
 const mention = ref({ open: false, type: "", query: "", start: 0, items: [], index: 0 })
-const JARVIS_TOOLS = [
-	"get_list", "get_doc", "get_schema", "run_query", "run_report",
+// Tool names for the "Tools available" count + the /tool autocomplete. Seeded
+// with the core set as a fallback, then replaced on mount with the live bench
+// registry (jarvis.chat.api.list_tools) so it reflects every registered tool
+// instead of drifting from a hardcoded list.
+const jarvisTools = ref([
+	"get_list", "get_doc", "get_schema", "query", "run_report",
 	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc", "delete_doc",
-]
+])
 
 function cookie(name) {
 	return new URLSearchParams(document.cookie.split("; ").join("&")).get(name)
@@ -1136,7 +1140,7 @@ const showWelcome = computed(
 // settings/overview derived metrics (all from data we already hold)
 const convCount = computed(() => conversations.value.length)
 const msgCount = computed(() => visibleMessages.value.length)
-const toolCount = computed(() => JARVIS_TOOLS.length)
+const toolCount = computed(() => jarvisTools.value.length)
 const sessionToolCalls = computed(() =>
 	Object.values(runMeta.value).reduce((s, r) => s + (r.tools || 0), 0),
 )
@@ -2356,7 +2360,7 @@ async function queryMentions(type, query) {
 			const skills = customSkills.value
 				.filter((s) => s.enabled && (s.skill_name || "").includes(q))
 				.map((s) => ({ value: s.skill_name, sub: "skill" }))
-			const tools = JARVIS_TOOLS.filter((t) => t.includes(q)).map((t) => ({ value: t, sub: "tool" }))
+			const tools = jarvisTools.value.filter((t) => t.includes(q)).map((t) => ({ value: t, sub: "tool" }))
 			const r = await api.searchLink("DocType", query)
 			const dts = (r || []).map((x) => ({ value: x.value, sub: "doctype" }))
 			items = [...skills, ...tools, ...dts].slice(0, 8)
@@ -2399,6 +2403,9 @@ onMounted(async () => {
 		/* fall through */
 	}
 	socket?.on("jarvis:event", onEvent)
+	// Live tool list for the "Tools available" count + /tool autocomplete
+	// (best-effort; falls back to the seeded core set on failure).
+	api.listTools().then((t) => { if (Array.isArray(t) && t.length) jarvisTools.value = t }).catch(() => {})
 	document.addEventListener("pointerdown", onDocClick)
 	window.addEventListener("keydown", onGlobalKey)
 	_thinkTimer = setInterval(() => { thinkTick.value = busy.value ? thinkTick.value + 1 : 0 }, 2200)

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -50,6 +50,16 @@ _ALLOWED_THINKING = {"", "low", "medium", "high"}
 
 
 @frappe.whitelist()
+def list_tools() -> list[str]:
+	"""Tool names the agent can call, from the bench registry (the openclaw
+	plugin registers one ``jarvis__<name>`` per entry). Drives the chat's
+	"Tools available" count + the ``/tool`` autocomplete so they track the
+	registry instead of a hardcoded SPA list that drifts."""
+	from jarvis.tools.registry import list_tools as _registry_list_tools
+	return _registry_list_tools()
+
+
+@frappe.whitelist()
 def list_conversations() -> list[dict]:
 	"""Return active conversations owned by the current user, newest first.
 


### PR DESCRIPTION
"Tools available" and the /tool autocomplete read a hardcoded JARVIS_TOOLS array of 11 names in ChatView, so the UI showed "11" while the gateway actually registers 49 tools - and the list had drifted ("run_query" vs the real "query"). The agent was never limited to 11; only the display was.

- Add whitelisted jarvis.chat.api.list_tools returning the bench registry tool names (registry.list_tools()).
- The SPA fetches it on mount into a jarvisTools ref (seeded with the core set as a fallback), so the count + autocomplete track the registry (49) and never drift as tools are added/renamed.