### PR TITLE
perf(chat): cut first-message latency — session-create off the web request, deferred autotitle, reliable prewarm, zero-preflight send (Phase 0+1)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -46,7 +46,10 @@ export const setConversationModel = (conversation, model) =>
 	call("jarvis.chat.api.set_conversation_model", { conversation, model: model || "" })
 
 export async function sendMessage(conversation, message, modelOverride, attachments, context) {
-	const args = { conversation, message }
+	// Empty conversation is allowed: the backend creates (or focuses) an empty
+	// conversation itself and returns its id as `conversation_id` — saves the
+	// SPA a createOrFocusEmpty round-trip before the first send (latency plan).
+	const args = { conversation: conversation || "", message }
 	if (modelOverride) args.model_override = modelOverride
 	if (attachments && attachments.length) args.attachments = JSON.stringify(attachments)
 	if (context && context.doctype) args.context = JSON.stringify(context)

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -8,7 +8,13 @@ export function initSocket() {
 	const host = window.location.hostname
 	const siteName = window.site_name || host
 	const port = window.location.port ? `:${socketio_port}` : ""
-	const protocol = port ? "http" : "https"
+	// Follow the page's own scheme instead of assuming https on portless
+	// pages: an http-only deployment (e.g. a bench exposed on port 80
+	// before TLS is set up) otherwise dials wss://host:443, which isn't
+	// listening — the socket never connects and chat only renders after a
+	// reload. With an explicit port (local dev) the socketio process is
+	// plain http, as before.
+	const protocol = port ? "http" : window.location.protocol.replace(":", "")
 	const url = `${protocol}://${host}${port}/${siteName}`
 	return io(url, { withCredentials: true, reconnectionAttempts: 5 })
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2074,11 +2074,12 @@ async function send(textArg) {
 		mention.value = { ...mention.value, open: false }
 		nextTick(autoGrow)
 	}
-	if (!currentId.value) {
-		const conv = await api.createOrFocusEmpty()
-		currentId.value = conv?.name || conv
-		await loadConversations()
-	}
+	// No awaited pre-flight for a brand-new chat (latency plan, Phase 1.3):
+	// the backend's send_message creates/focuses the empty conversation
+	// itself and returns conversation_id — two fewer round-trips before the
+	// first message even leaves the browser. The sidebar refresh happens
+	// after the send resolves, off the critical path.
+	const isNewConv = !currentId.value
 	sending.value = true
 	waiting.value = true
 	stoppedRunId.value = null
@@ -2092,7 +2093,13 @@ async function send(textArg) {
 	await nextTick()
 	scrollBottom()
 	try {
-		await api.sendMessage(currentId.value, text, undefined, attachments)
+		const r = await api.sendMessage(currentId.value || "", text, undefined, attachments)
+		if (isNewConv && r?.conversation_id) {
+			// Adopt the server-created conversation so realtime events route to
+			// this thread, then refresh the sidebar without blocking anything.
+			currentId.value = r.conversation_id
+			loadConversations()
+		}
 	} catch (e) {
 		sending.value = false
 		waiting.value = false
@@ -2390,17 +2397,22 @@ function applyMention(item) {
 }
 
 onMounted(async () => {
+	// Latency plan, Phase 1.3: the bootstrap network calls used to run as a
+	// serial awaited chain (ready → ui settings → conversations), each a full
+	// round-trip. Fire them concurrently and await in order below — the
+	// onboarding redirect check still resolves before anything is revealed,
+	// and list_conversations (which triggers the server-side prefix prewarm)
+	// now starts ~2 RTTs earlier.
+	const readyP = api.isReadyForChat().catch(() => null)
+	const uiP = api.getChatUiSettings().catch(() => null)
+	const convsP = loadConversations().catch(() => {})
 	// Gate the chat the way the old Desk page did: if the customer hasn't
 	// finished signup / LLM setup, send them to the onboarding wizard. A
 	// transient failure falls through to the chat rather than trapping them.
-	try {
-		const r = await api.isReadyForChat()
-		if (r && r.ready === false) {
-			window.location.assign("/app/jarvis-onboarding")
-			return
-		}
-	} catch (e) {
-		/* fall through */
+	const r = await readyP
+	if (r && r.ready === false) {
+		window.location.assign("/app/jarvis-onboarding")
+		return
 	}
 	socket?.on("jarvis:event", onEvent)
 	// Live tool list for the "Tools available" count + /tool autocomplete
@@ -2413,15 +2425,11 @@ onMounted(async () => {
 	_mq = window.matchMedia("(prefers-color-scheme: dark)")
 	prefersDark.value = _mq.matches
 	_mq.addEventListener("change", onColorScheme)
-	try {
-		ui.value = (await api.getChatUiSettings()) || {}
-	} catch (e) {
-		/* ignore */
-	}
+	ui.value = (await uiP) || {}
 	// Load custom skills so the "/" composer menu can offer them.
 	loadCustomSkills()
 	try {
-		await loadConversations()
+		await convsP
 		// Restore the chat the user was last on (survives refresh + duplicated tab)
 		// before falling back to the first sidebar entry, so a starred chat sorting
 		// to the top never hijacks navigation away from your current chat.

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -291,6 +291,7 @@ def set_star(conversation: str, starred: str | int | bool) -> dict:
 	return {"ok": True, "data": {"starred": on}}
 
 
+import time
 import uuid
 
 from frappe import _
@@ -301,11 +302,24 @@ from jarvis.chat.openclaw_client import OpenclawSession
 
 @frappe.whitelist()
 def send_message(
-	conversation: str, message: str, model_override: str | None = None,
+	conversation: str | None = None, message: str = "", model_override: str | None = None,
 	attachments: str | None = None, context: str | None = None,
 	thinking_override: str | None = None,
 ) -> dict:
-	"""Validate, persist the user message, ensure session_key, enqueue the worker.
+	"""Validate, persist the user message, enqueue the worker.
+
+	`conversation` (optional): when empty, an empty active conversation is
+	created (or the existing empty one focused) server-side and its id is
+	returned as `conversation_id`. Saves the SPA a `create_or_focus_empty`
+	round-trip before the first send of a brand-new chat (2026-07 latency
+	plan, Phase 1.3).
+
+	NOTE (2026-07 latency plan, Phase 1.1): this endpoint no longer creates
+	the openclaw session. That used to happen here synchronously — a full
+	unpooled WS connect + sessions.create + close INSIDE the POST the
+	browser awaits. The worker now creates the session on its own pooled
+	connection (see turn_handler.handle_chat_send), so this endpoint only
+	persists + enqueues.
 
 	`model_override` (optional): bare model id to apply to this conversation
 	BEFORE enqueueing the worker. Used from the welcome screen so the first
@@ -320,16 +334,23 @@ def send_message(
 	Note: this differs from `model_override`, which treats both None and empty
 	string as "leave the existing value alone".
 
-	Returns {ok: True, run_id, message_id} on success or
+	Returns {ok: True, run_id, message_id, conversation_id} on success or
 	{ok: False, reason: str} on validation failure. Raises
 	frappe.DoesNotExistError if the conversation does not exist or the
 	caller is not the owner.
 	"""
+	t0 = time.monotonic()
 	user = frappe.session.user
 
 	ok, reason = validate_can_send(user)
 	if not ok:
 		return {"ok": False, "reason": reason}
+
+	# No conversation yet (first send from a fresh chat surface): create or
+	# focus the user's empty conversation here instead of a separate
+	# round-trip from the SPA.
+	if not conversation:
+		conversation = create_or_focus_empty()
 
 	# Attachments arrive as a JSON string of [{file_url, file_name}, ...] from
 	# the composer's file picker (already uploaded to the Frappe File doctype).
@@ -410,14 +431,11 @@ def send_message(
 	# openers stay unnamed until a real prompt arrives).
 	conv_doc.last_active_at = frappe.utils.now()
 
-	# Ensure the conversation has an openclaw session_key; create one on
-	# first turn. Insert the Jarvis Chat Session row so the plugin's
-	# sessionKey → user lookup works. Self-hosted mode chats over openclaw's
-	# HTTP surface (stateless per call) and needs no WS session / device
-	# pairing, so skip session creation there.
-	from jarvis import selfhost
-	if not selfhost.is_self_hosted() and not conv_doc.session_key:
-		conv_doc.session_key = _ensure_session_key(user)
+	# session_key creation moved to the worker (turn_handler.handle_chat_send)
+	# so the browser-awaited POST never pays a WS connect + handshake. The
+	# worker creates it on its pooled connection and inserts the Jarvis Chat
+	# Session row BEFORE streaming starts (2026-07 latency plan, Phase 1.1).
+	first_turn = 1 if not conv_doc.session_key else 0
 	conv_doc.save()
 	frappe.db.commit()
 
@@ -430,6 +448,10 @@ def send_message(
 		"conversation_id": conversation,
 		"message_id": msg_doc.name,
 		"run_id": run_id,
+		# Epoch ms at enqueue time so the worker can log queue_wait_ms
+		# (latency plan, Phase 0). Workers must be restarted with this
+		# deploy — run_agent_turn grew the matching kwarg.
+		"enqueued_at_ms": int(time.time() * 1000),
 	}
 	if atts:
 		enqueue_kwargs["attachments"] = atts
@@ -470,7 +492,20 @@ def send_message(
 			**enqueue_kwargs,
 		)
 
-	return {"ok": True, "run_id": run_id, "message_id": msg_doc.name}
+	# Latency telemetry (plan Phase 0): one line per send so the web-request
+	# segments are measurable. total_ms should now sit in the tens of ms even
+	# on first_turn=1 — the old synchronous session-create is gone.
+	from jarvis.chat.latency import get_logger as _get_latency_logger
+
+	_get_latency_logger().info(
+		"send_message run_id=%s first_turn=%d total_ms=%d",
+		run_id, first_turn, int((time.monotonic() - t0) * 1000),
+	)
+
+	return {
+		"ok": True, "run_id": run_id, "message_id": msg_doc.name,
+		"conversation_id": conversation,
+	}
 
 
 @frappe.whitelist()
@@ -691,6 +726,7 @@ def retry_message(message: str) -> dict:
 		"conversation_id": doc.conversation,
 		"message_id": user_msg_id,
 		"run_id": run_id,
+		"enqueued_at_ms": int(time.time() * 1000),
 	}
 	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
 		from jarvis.chat.dispatch import publish_chat_send
@@ -716,25 +752,38 @@ def _next_seq(conversation: str) -> int:
 	return (current_max or 0) + 1
 
 
-def _ensure_session_key(user: str) -> str:
+def _ensure_session_key(user: str, sess: OpenclawSession | None = None) -> str:
 	"""Create an openclaw session for `user`, persist the Chat Session row,
 	and return the session_key. Caller is responsible for storing it on the
 	parent Conversation row.
-	"""
-	settings = frappe.get_single("Jarvis Settings")
-	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
-	gateway_token = settings.get_password("agent_token")
-	if not gateway_url or not gateway_token:
-		frappe.throw(_("openclaw is not configured"))
 
-	import time
-	sess = OpenclawSession.connect(gateway_url)
-	try:
-		# Label includes a timestamp because openclaw deduplicates sessions
-		# by label and rejects collisions.
+	2026-07 latency plan, Phase 1.1: ``send_message`` no longer calls this
+	on the web request. The worker calls it with ``sess`` = its pooled
+	connection (turn_handler.handle_chat_send) so the first turn pays ONE
+	handshake, off the browser-blocking path. The ``sess=None`` one-shot
+	branch remains for callers without a pooled connection.
+	"""
+	if sess is not None:
+		# Reuse the caller's already-connected (pooled) session — no extra
+		# connect/handshake. Label includes a timestamp because openclaw
+		# deduplicates sessions by label and rejects collisions.
 		session_key = sess.create_session(label=f"jarvis-chat-{user}-{int(time.time() * 1000)}")
-	finally:
-		sess.close()
+	else:
+		settings_check = frappe.get_single("Jarvis Settings")
+		gateway_url = (settings_check.agent_url or "").replace(
+			"http://", "ws://").replace("https://", "wss://")
+		gateway_token = settings_check.get_password("agent_token")
+		if not gateway_url or not gateway_token:
+			frappe.throw(_("openclaw is not configured"))
+
+		one_shot = OpenclawSession.connect(gateway_url)
+		try:
+			session_key = one_shot.create_session(
+				label=f"jarvis-chat-{user}-{int(time.time() * 1000)}")
+		finally:
+			one_shot.close()
+
+	settings = frappe.get_single("Jarvis Settings")
 
 	# C2 stretch (2026-06-16 review): snapshot the bench's current
 	# chat_device_id into the Jarvis Chat Session row. On every

--- a/jarvis/chat/latency.py
+++ b/jarvis/chat/latency.py
@@ -1,0 +1,21 @@
+"""Latency telemetry logger (2026-07 latency plan, Phase 0).
+
+One place that hands out the ``jarvis.chat.latency`` logger with its level
+pinned to INFO. ``frappe.logger`` defaults to ERROR (WARNING on a dev
+server), which would silently drop every telemetry line — these lines are
+the measurement harness for the chat-latency work, so they must be visible
+on any bench without asking operators to flip ``frappe.log_level``. The
+logger writes to its own file (``logs/jarvis.chat.latency.log``), so INFO
+here does not make any other logger chattier.
+"""
+
+import logging
+
+import frappe
+
+
+def get_logger() -> logging.Logger:
+	logger = frappe.logger("jarvis.chat.latency", allow_site=True)
+	if logger.level == 0 or logger.level > logging.INFO:
+		logger.setLevel(logging.INFO)
+	return logger

--- a/jarvis/chat/openclaw_session_pool.py
+++ b/jarvis/chat/openclaw_session_pool.py
@@ -7,8 +7,16 @@ handshake before sending the agent RPC. The spike (workflow
 confirmed:
 
 - The gateway dispatches concurrent RPCs on one WS (multiplex)
-- RQ workers are long-lived processes (Procfile, no ``--burst``)
 - One warm WS per gateway can serve every subsequent turn
+
+CAVEAT (2026-07 latency review): the RQ worker *parent* process is
+long-lived, but stock ``bench worker`` uses rq's forking Worker — each
+job runs in a forked work-horse child that exits after the job, taking
+this module-level pool with it. The pool therefore only amortizes under
+a non-forking executor: the Python-socketio realtime process (Path B,
+``socketio_backend: "python"``) or ``bench worker-pool`` with
+``FRAPPE_BACKGROUND_WORKERS_NOFORK=1``. The pool-hit/pool-miss log
+lines in ``checkout``/``_do_connect`` measure which world you're in.
 
 This module maintains one pooled OpenclawSession per gateway URL,
 per worker process, with lazy reconnect on stale / idle / error.
@@ -105,6 +113,15 @@ def checkout(gateway_url: str) -> Iterator[OpenclawSession]:
 			)
 			_close_quietly(entry.session)
 			entry.session = _do_connect(gateway_url)
+		else:
+			# Symmetric to the pool-miss log in _do_connect so the hit rate
+			# is measurable from logs (latency plan, Phase 0). Under stock
+			# fork-per-job RQ this line should ~never appear — that absence
+			# is itself the signal that Phase 2 (persistent relay) is needed.
+			logger.info(
+				"openclaw_session_pool: pool-hit gateway=%s idle_s=%.1f",
+				gateway_url, time.monotonic() - entry.last_used,
+			)
 		yield entry.session
 		entry.last_used = time.monotonic()
 	except OpenclawUnreachableError:

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -13,11 +13,15 @@ import frappe
 from jarvis import selfhost
 from jarvis.chat.openclaw_client import OpenclawSession
 
-# Cooldown between warm-ups for one bench. Set below the */30 cron
-# interval so keep_warm re-warms on each tick instead of every other.
-# Comfortably inside gpt-5.5's prompt-cache retention window so the
-# cache never cools between warms.
-_WARM_COOLDOWN_S = 25 * 60
+# Cooldown between warm-ups for one bench. 2026-07 latency plan, Phase
+# 1.4: was 25 min, which is LONGER than the providers' prompt-cache
+# retention (OpenAI evicts after ~5-10 min of inactivity; Gemini implicit
+# caching is similar or shorter) — so for most of each half-hour the
+# cooldown key said "warm" while the provider cache had already cooled,
+# and the first turn ate a cold prefill anyway. 4 min keeps every warm
+# inside the retention window; paired with the */5 keep_warm cron so each
+# tick re-warms. Watch warm-turn token spend after this change.
+_WARM_COOLDOWN_S = 4 * 60
 
 # Short in-progress TTL set BEFORE the slow connect so concurrent opens
 # cannot fan out into concurrent warm-ups. Expires quickly on failure
@@ -81,6 +85,8 @@ def warm_prefix() -> bool:
 		# disable warming for 25 min.
 		cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
 		model, provider = _resolve_default_model_and_provider(settings)
+		import time
+		t0 = time.monotonic()
 		sess = OpenclawSession.connect(gateway_url)
 		try:
 			throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
@@ -90,6 +96,15 @@ def warm_prefix() -> bool:
 			)
 		finally:
 			sess.close()
+		# Latency telemetry (plan Phase 0): connect+create+fire duration.
+		# (fire_agent is fire-and-forget, so this does NOT include the
+		# prefill itself — cold-vs-warm shows up in real turns'
+		# first_delta_ms, logged by turn_handler.)
+		from jarvis.chat.latency import get_logger as _get_latency_logger
+
+		_get_latency_logger().info(
+			"warm_prefix fire_ms=%d", int((time.monotonic() - t0) * 1000),
+		)
 		# Warm succeeded: arm the full cooldown so the next cron tick skips.
 		cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
 		return True
@@ -113,6 +128,19 @@ def keep_warm_if_active() -> None:
 		warm_prefix()
 	except Exception:
 		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)
+
+
+def warm_on_login(login_manager=None) -> None:
+	"""``on_session_creation`` hook (2026-07 latency plan, Phase 1.4): start
+	warming as soon as anyone logs in, before the chat page even loads —
+	the warm-up has the whole page-load window to land. Same debounced
+	enqueue as the chat-load trigger, so non-chat logins cost one cache
+	read. Best-effort, never raises (a hook failure must never block login).
+	"""
+	try:
+		enqueue_warm_if_due()
+	except Exception:
+		pass
 
 
 def enqueue_warm_if_due() -> None:

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -152,6 +152,51 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 	return normalize_title(text)
 
 
+def enqueue_autotitle(conversation_id: str, user: str) -> None:
+	"""Defer title generation to the SHORT queue (2026-07 latency plan,
+	Phase 1.2) so the long-queue chat worker is freed as soon as the turn
+	ends instead of running a 2-8s title LLM turn inline. Cheap still-unnamed
+	gate here so already-titled conversations never spawn a pointless job.
+	"""
+	title = frappe.db.get_value(CONV, conversation_id, "title")
+	if title and title != "New chat":
+		return  # user renamed it, or we already titled it
+	frappe.enqueue(
+		"jarvis.chat.title.autotitle_job",
+		queue="short",
+		conversation_id=conversation_id,
+		user=user,
+	)
+
+
+def autotitle_job(conversation_id: str, user: str) -> None:
+	"""Short-queue job body for the deferred auto-title. Re-resolves
+	settings / gateway / model itself (nothing heavyweight is serialized
+	through the queue). Managed mode only — the enqueue site is already
+	gated on ``not selfhost.is_self_hosted()``. Best-effort like the old
+	inline path: any failure is logged, never affects the finished turn.
+	"""
+	try:
+		from jarvis.chat.turn_handler import _resolve_model_and_provider
+
+		settings = frappe.get_single("Jarvis Settings")
+		gateway_url = (settings.agent_url or "").replace(
+			"http://", "ws://").replace("https://", "wss://")
+		if not gateway_url:
+			return
+		conv = frappe.get_doc(CONV, conversation_id)
+		model, provider = _resolve_model_and_provider(conv)
+		maybe_autotitle(
+			conversation_id, user,
+			gateway_url=gateway_url, model=model, provider=provider,
+		)
+	except Exception:
+		frappe.log_error(
+			title="auto-title job failed",
+			message=frappe.get_traceback(),
+		)
+
+
 def maybe_autotitle(conversation_id: str, user: str, *, gateway_url, model, provider) -> None:
 	"""Generate + set a concise title for a still-unnamed conversation.
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -283,6 +283,30 @@ def handle_chat_send(payload: dict) -> None:
 	attachments = payload.get("attachments")
 	context = payload.get("context")
 
+	# Latency telemetry (plan Phase 0): one summary line per turn with the
+	# segment timings that dominate first-message latency. queue_wait_ms is
+	# how long the job sat between the web request's enqueue and this
+	# handler starting (RQ dequeue + fork on the default backend).
+	from jarvis.chat.latency import get_logger as _get_latency_logger
+
+	_lat = _get_latency_logger()
+	t_handle0 = time.monotonic()
+	enqueued_at_ms = payload.get("enqueued_at_ms")
+	queue_wait_ms = (
+		max(0, int(time.time() * 1000) - int(enqueued_at_ms))
+		if enqueued_at_ms else -1
+	)
+	# Stream-phase stats filled in by _consume: ms to the first event of any
+	# kind, ms to the first assistant delta (= first visible token), and how
+	# many tool events fired before that first delta (measures the persona's
+	# read-SOUL/TOOLS/STYLE-before-answering tax; see the latency plan).
+	stream_stats = {
+		"t0": None, "first_event_ms": -1, "first_delta_ms": -1,
+		"pre_reply_tool_calls": 0,
+	}
+	checkout_ms = -1
+	session_create_ms = 0
+
 	conv = frappe.get_doc(CONV, conversation_id)
 	user = conv.owner
 	# Wall-clock turn start (epoch ms) - scopes codex imagegen output produced
@@ -382,7 +406,21 @@ def handle_chat_send(payload: dict) -> None:
 		batcher = _AssistantContentBatcher(assistant_msg.name)
 
 		def _consume(events) -> None:
+			if stream_stats["t0"] is None:
+				stream_stats["t0"] = time.monotonic()
 			for event in events:
+				# Segment telemetry (plan Phase 0): first event / first
+				# assistant delta / tool calls that ran before the first
+				# visible token. Cheap dict writes, no extra I/O.
+				ev_ms = int((time.monotonic() - stream_stats["t0"]) * 1000)
+				if stream_stats["first_event_ms"] < 0:
+					stream_stats["first_event_ms"] = ev_ms
+				kind = event.get("kind")
+				if kind == "assistant" and stream_stats["first_delta_ms"] < 0:
+					stream_stats["first_delta_ms"] = ev_ms
+				elif kind == "tool" and stream_stats["first_delta_ms"] < 0:
+					if (event.get("phase") or "") != "end":
+						stream_stats["pre_reply_tool_calls"] += 1
 				_handle_event(
 					event,
 					conversation_id=conversation_id,
@@ -432,7 +470,29 @@ def handle_chat_send(payload: dict) -> None:
 			).replace("https://", "wss://")
 			effective_model, oauth_provider_id = _resolve_model_and_provider(conv)
 			try:
+				t_checkout = time.monotonic()
 				with openclaw_session_pool.checkout(gateway_url) as sess:
+					checkout_ms = int((time.monotonic() - t_checkout) * 1000)
+					# First turn of this conversation: create the openclaw
+					# session on THIS pooled connection (no extra handshake)
+					# and persist the Jarvis Chat Session row BEFORE the
+					# stream starts — the plugin's call_tool sessionKey→user
+					# lookup (the permission moat) needs the row in place
+					# before the agent's first tool callback. Moved here from
+					# send_message so the browser-awaited POST never pays a
+					# WS connect (2026-07 latency plan, Phase 1.1). chat_user
+					# (the sender) owns the session row, keeping tool-call
+					# identity in lockstep with the [Context:] bracket above.
+					if not conv.session_key:
+						from jarvis.chat.api import _ensure_session_key
+
+						t_sess = time.monotonic()
+						conv.session_key = _ensure_session_key(chat_user, sess=sess)
+						frappe.db.set_value(
+							CONV, conversation_id, "session_key", conv.session_key
+						)
+						frappe.db.commit()
+						session_create_ms = int((time.monotonic() - t_sess) * 1000)
 					_consume(sess.stream_agent_turn(
 						conv.session_key, user_message, idem,
 						model=effective_model, provider=oauth_provider_id,
@@ -543,27 +603,36 @@ def handle_chat_send(payload: dict) -> None:
 		"run_id": run_id,
 	})
 
+	# Latency telemetry summary (plan Phase 0). first_delta_ms is the number
+	# users feel: worker start → first visible token. pre_reply_tool_calls
+	# counts agent tool round-trips before that token (persona read tax).
+	_lat.info(
+		"turn run_id=%s first_turn=%d queue_wait_ms=%d checkout_ms=%d "
+		"session_create_ms=%d first_event_ms=%d first_delta_ms=%d "
+		"pre_reply_tool_calls=%d turn_total_ms=%d",
+		run_id, 1 if session_create_ms else 0, queue_wait_ms, checkout_ms,
+		session_create_ms, stream_stats["first_event_ms"],
+		stream_stats["first_delta_ms"], stream_stats["pre_reply_tool_calls"],
+		int((time.monotonic() - t_handle0) * 1000),
+	)
+
 	# Auto-title (managed mode): the first substantive turn of a still-unnamed
 	# conversation gets a concise, LLM-summarised title, not the raw first
-	# message. Runs AFTER run:end so the turn UI has already unblocked; the new
-	# title lands a few seconds later via a "conversation:renamed" event.
+	# message. Deferred to the SHORT queue (2026-07 latency plan, Phase 1.2):
+	# it used to run inline here — a full extra LLM turn holding this long-
+	# queue worker for 2-8s, so the user's next message could queue behind a
+	# title generation. The job re-resolves settings/model itself; the title
+	# still lands via the same "conversation:renamed" event.
 	# Best-effort: a title failure must never affect the completed turn.
 	from jarvis import selfhost
 	if not selfhost.is_self_hosted():
 		try:
 			from jarvis.chat import title as title_mod
 
-			gw = (settings.agent_url or "").replace(
-				"http://", "ws://"
-			).replace("https://", "wss://")
-			eff_model, oauth_pid = _resolve_model_and_provider(conv)
-			title_mod.maybe_autotitle(
-				conversation_id, user,
-				gateway_url=gw, model=eff_model, provider=oauth_pid,
-			)
+			title_mod.enqueue_autotitle(conversation_id, user)
 		except Exception:
 			frappe.log_error(
-				title="chat worker: auto-title failed",
+				title="chat worker: auto-title enqueue failed",
 				message=frappe.get_traceback(),
 			)
 

--- a/jarvis/chat/worker.py
+++ b/jarvis/chat/worker.py
@@ -79,7 +79,7 @@ __all__ = [
 
 def run_agent_turn(
 	conversation_id: str, message_id: str, run_id: str, attachments=None,
-	context=None,
+	context=None, enqueued_at_ms=None,
 ) -> None:
 	"""RQ entry point. Thin shim around ``handle_chat_send``.
 
@@ -89,6 +89,10 @@ def run_agent_turn(
 	``frappe.enqueue("jarvis.chat.worker.run_agent_turn", ...)`` calls
 	continue to work unchanged. All real work happens in
 	``jarvis.chat.turn_handler.handle_chat_send``.
+
+	``enqueued_at_ms`` (optional): epoch ms stamped by the enqueue site so
+	the handler can log queue_wait_ms (latency plan, Phase 0). Deploys that
+	add this kwarg must restart workers (RQ workers don't hot-reload).
 	"""
 	handle_chat_send({
 		"conversation_id": conversation_id,
@@ -96,4 +100,5 @@ def run_agent_turn(
 		"run_id": run_id,
 		"attachments": attachments,
 		"context": context,
+		"enqueued_at_ms": enqueued_at_ms,
 	})

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -145,6 +145,13 @@ website_route_rules = [
 	{"from_route": "/jarvis/<path:app_path>", "to_route": "jarvis"},
 ]
 
+# Session hooks
+# --------------
+
+# 2026-07 latency plan, Phase 1.4: kick off a (debounced) prefix warm-up on
+# login so the provider prompt cache is warm before the chat page even loads.
+on_session_creation = ["jarvis.chat.prewarm.warm_on_login"]
+
 # Scheduled Tasks
 # ---------------
 
@@ -152,12 +159,15 @@ scheduler_events = {
 	"cron": {
 		"*/5 * * * *": [
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
+			# 2026-07 latency plan, Phase 1.4: was */30, which left the
+			# provider prompt cache (5-10 min retention) cold for most of
+			# each half-hour. Every 5 min + a 4-min cooldown in prewarm.py
+			# keeps the prefix warm continuously while there is recent chat
+			# activity (the function itself gates on activity).
+			"jarvis.chat.prewarm.keep_warm_if_active",
 		],
 		"*/2 * * * *": [
 			"jarvis.chat.turn_recovery.recover_pending_turns",
-		],
-		"*/30 * * * *": [
-			"jarvis.chat.prewarm.keep_warm_if_active",
 		],
 	},
 	"hourly": [

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -24,11 +24,20 @@ MSG = "Jarvis Chat Message"
 
 
 def _make_conversation_with_user_message(text: str = "hi") -> tuple[str, str]:
-	"""Helper: create conversation, attach a user message, return (conv, msg)."""
+	"""Helper: create conversation, attach a user message, return (conv, msg).
+
+	send_message no longer creates the openclaw session on the web request
+	(2026-07 latency plan, Phase 1.1 — the worker creates it on its pooled
+	connection for first turns). These tests drive the worker against a
+	conversation that already has a session, so set the key directly; the
+	first-turn creation path has its own test
+	(TestWorkerCreatesSessionOnFirstTurn).
+	"""
 	conv = create_conversation()
-	with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):
-		with patch("frappe.enqueue"):
-			result = send_message(conv, text)
+	with patch("frappe.enqueue"):
+		result = send_message(conv, text)
+	frappe.db.set_value(CONV, conv, "session_key", "agent:fake")
+	frappe.db.commit()
 	return conv, result["message_id"]
 
 
@@ -631,3 +640,68 @@ class TestAssistantContentBatcherUnit(FrappeTestCase):
 		# After flush, the next delta starts the counter over.
 		b.delta("post-flush")
 		self.assertFalse(b.flush_if_due())
+
+
+class TestWorkerCreatesSessionOnFirstTurn(FrappeTestCase):
+	"""2026-07 latency plan, Phase 1.1: the WORKER creates the openclaw
+	session for a conversation's first turn on its pooled connection —
+	send_message no longer does it on the browser-awaited POST. The
+	Jarvis Chat Session row (the plugin's sessionKey→user lookup, i.e.
+	the permission moat) must exist BEFORE the stream starts."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		# Deliberately NOT setting session_key: this simulates the first
+		# turn as send_message now leaves it.
+		self.conv = create_conversation()
+		with patch("frappe.enqueue"):
+			result = send_message(self.conv, "first message")
+		self.user_msg = result["message_id"]
+
+	def tearDown(self):
+		frappe.db.delete("Jarvis Chat Session", {"session_key": "agent:new"})
+		frappe.db.commit()
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_send_message_no_longer_sets_session_key(self):
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "session_key"))
+
+	def test_worker_creates_session_row_before_streaming(self):
+		fake_sess = MagicMock()
+		fake_sess.create_session.return_value = "agent:new"
+		row_exists_at_stream_start = {}
+
+		def _stream(session_key, *a, **kw):
+			# Capture the moat invariant at the exact moment streaming
+			# starts: the sessionKey→user row must already be committed.
+			row_exists_at_stream_start["row"] = frappe.db.get_value(
+				"Jarvis Chat Session", {"session_key": session_key},
+				["user", "session_key"], as_dict=True,
+			)
+			return _fake_event_stream([
+				{"kind": "lifecycle", "phase": "start"},
+				{"kind": "assistant", "text": "Hi", "delta": "Hi"},
+				{"kind": "lifecycle", "phase": "end"},
+			])
+
+		fake_sess.stream_agent_turn.side_effect = _stream
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		# The session was created on the WORKER's pooled connection.
+		fake_sess.create_session.assert_called_once()
+		# The row existed (with the sender's identity) before streaming.
+		row = row_exists_at_stream_start["row"]
+		self.assertIsNotNone(row, "Jarvis Chat Session row must exist before stream_agent_turn")
+		self.assertEqual(row["session_key"], "agent:new")
+		self.assertEqual(row["user"], TEST_USER)
+		# And the conversation now carries the session key.
+		self.assertEqual(
+			frappe.db.get_value(CONV, self.conv, "session_key"), "agent:new",
+		)


### PR DESCRIPTION
## What

Phase 0 (instrumentation) + Phase 1 (hot-path fixes) of the 2026-07-02 chat-latency plan (doc: Aerele-RnD/jarvis-admin#172), plus the realtime socket protocol fix found during the first live openclaw end-to-end test.

### Phase 0 — telemetry
- New `jarvis/chat/latency.py`: INFO-pinned logger (frappe.logger defaults to ERROR and silently drops telemetry) writing to `logs/jarvis.chat.latency.log`.
- `send_message`: `total_ms`, `first_turn`; worker: `queue_wait_ms / checkout_ms / session_create_ms / first_event_ms / first_delta_ms / pre_reply_tool_calls / turn_total_ms`; pool hit/miss lines; prewarm fire timing.

### Phase 1 — hot-path fixes
1. **Session-create moved off the browser-awaited POST**: `send_message` no longer opens an unpooled WS (connect + Ed25519 handshake + `sessions.create` + close) inline; the worker creates the session on its pooled connection and commits the `Jarvis Chat Session` row **before** streaming (permission-moat invariant — pinned by new test `TestWorkerCreatesSessionOnFirstTurn`). Measured live: first-turn POST 71–104ms wall / ~45ms server (the ~500ms connect + ~200ms session-create now happen in the worker).
2. **Autotitle deferred to the short queue** (`title.enqueue_autotitle` / `autotitle_job`) — the long worker frees at `run:end` instead of running a 2–8s title turn inline; the user's next message no longer queues behind it.
3. **Prewarm made effective**: cooldown 25min → 4min (OpenAI/Gemini evict prompt caches in ~5–10min, so the old debounce reported "warm" while cold), cron `*/30` → `*/5`, plus a warm-on-login hook.
4. **Frontend**: `send_message` accepts an empty conversation (creates/focuses server-side, returns `conversation_id`) — removes 2 awaited pre-flight RTTs on a new chat's first send; onMounted bootstrap parallelized (ready-check ∥ ui-settings ∥ conversations).
5. **Realtime socket fix** (`3bcae95`): `socket.js` hardcoded `https` on portless pages, so an http-only deployment (bench on port 80 before TLS) dialed `wss://host:443` and never connected — turns completed server-side but only rendered after a reload. Now follows the page's own scheme. Verified live against an openclaw container with a headless socket.io client: `run:start` → `assistant:delta` → `run:end` → `conversation:renamed` all stream (the last also proving the deferred autotitle end-to-end).

## Deploy notes
- `run_agent_turn` grew an `enqueued_at_ms` kwarg → **restart workers with this deploy** (RQ workers don't hot-reload).
- Behavior change: an unconfigured/unreachable openclaw now surfaces as an async `run:error` on the first turn rather than a synchronous send failure (same path as a mid-turn outage).
- Ops note (not in this diff): on nginx-fronted benches keep `developer_mode` **site-level only** — the global flag makes Frappe's Node realtime rewrite its internal auth URL to gunicorn's port, which 404s behind nginx ("Unauthorized" socket errors).

## Tests
`test_chat_api` 45/45 · `test_chat_worker` 16/17 (the 1 failure pre-exists on `main`, verified via stash: `test_tool_events_persist_tool_message_rows`) · prewarm / session-pool / chat-session / turn-recovery suites green · live e2e verified (streaming, deferred autotitle, telemetry).

## Related
- Docs: Aerele-RnD/jarvis-admin#172 · Tool-routing follow-ups from the first live test: Aerele-RnD/jarvis-fleet-agent#94, Aerele-RnD/jarvis-persona#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)