### PR TITLE
feat(tools): get_file_pages - render a File's pages as vision images

### DIFF
--- a/jarvis/chat/vision.py
+++ b/jarvis/chat/vision.py
@@ -68,9 +68,13 @@ def image_part(content: bytes, file_name: str) -> dict | None:
 			pass
 
 
-def pdf_parts(content: bytes, file_name: str) -> tuple[list[dict], int]:
+def pdf_parts(
+	content: bytes, file_name: str, first_page: int = 1, max_pages: int | None = None
+) -> tuple[list[dict], int]:
 	"""Rasterize up to _MAX_PDF_PAGES pages to JPEG image parts. Returns
-	``(parts, total_pages)`` so the caller can note truncation. Uses pypdfium2
+	``(parts, total_pages)`` so the caller can note truncation; each part
+	carries its 1-based ``page`` number. ``first_page``/``max_pages`` select a
+	window (defaults keep the from-the-start behaviour). Uses pypdfium2
 	(Apache/BSD) - NOT PyMuPDF (AGPL)."""
 	import pypdfium2 as pdfium
 
@@ -78,7 +82,9 @@ def pdf_parts(content: bytes, file_name: str) -> tuple[list[dict], int]:
 	pdf = pdfium.PdfDocument(content)
 	try:
 		total = len(pdf)
-		for i in range(min(total, _MAX_PDF_PAGES)):
+		limit = _MAX_PDF_PAGES if max_pages is None else max(1, min(max_pages, _MAX_PDF_PAGES))
+		start = max(0, int(first_page or 1) - 1)
+		for i in range(start, min(total, start + limit)):
 			page = pdf[i]
 			scale = _RASTER_SCALE
 			try:
@@ -93,6 +99,7 @@ def pdf_parts(content: bytes, file_name: str) -> tuple[list[dict], int]:
 				continue
 			part = _encode_under_caps(pil, f"{file_name}-p{i + 1}.jpg")
 			if part:
+				part["page"] = i + 1
 				parts.append(part)
 		return parts, total
 	finally:

--- a/jarvis/tools/get_file_pages.py
+++ b/jarvis/tools/get_file_pages.py
@@ -1,0 +1,82 @@
+"""Render a server-side File's pages as images the model can SEE.
+
+``read_file`` returns extracted text, which is empty for a scanned PDF - the
+agent then had no way to read a private File mid-conversation and had to ask
+the customer to re-attach it in chat (chat attachments arrive as vision).
+This tool closes that gap: it rasterizes the File's pages (pypdfium2, same
+caps as the chat vision path) and returns them base64-encoded; the openclaw
+plugin lifts ``pages[]`` into image blocks on the tool result, so the model
+reads the pages exactly like chat-attached ones.
+
+Permission contract: same as ``read_file`` - the calling user must have read
+permission on the File.
+"""
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+
+_DEFAULT_PAGES = 4
+_MAX_PAGES_PER_CALL = 6
+_IMAGE_EXT = {"png", "jpg", "jpeg", "gif", "webp", "bmp"}
+
+
+def get_file_pages(
+    file_url: str | None = None,
+    filename: str | None = None,
+    first_page: int = 1,
+    max_pages: int = _DEFAULT_PAGES,
+) -> dict:
+    """Return a File's pages as images (for scanned PDFs and image files).
+
+    Identify the file by ``file_url`` (preferred) or ``filename`` (most recent
+    readable match). ``first_page`` (1-based) + ``max_pages`` (<= 6 per call)
+    window a long document - call again with a higher ``first_page`` for the
+    rest. Use when ``read_file`` reports no extractable text; for text PDFs
+    and spreadsheets prefer ``read_file`` (cheaper than pixels).
+    """
+    from jarvis.chat.vision import image_part, pdf_parts
+    from jarvis.tools.read_file import _resolve_file
+
+    fdoc = _resolve_file(file_url, filename)
+    if not frappe.has_permission("File", "read", doc=fdoc.name):
+        raise PermissionDeniedError(f"no read permission on file {fdoc.file_name!r}")
+
+    first_page = max(1, int(first_page or 1))
+    max_pages = max(1, min(int(max_pages or _DEFAULT_PAGES), _MAX_PAGES_PER_CALL))
+    content = fdoc.get_content()
+    if isinstance(content, str):
+        content = content.encode()
+
+    ext = (fdoc.file_name or "").rsplit(".", 1)[-1].lower()
+    if ext == "pdf":
+        parts, total = pdf_parts(content, fdoc.file_name, first_page=first_page, max_pages=max_pages)
+        if not parts:
+            raise InvalidArgumentError(
+                f"no renderable pages (document has {total} pages; first_page={first_page})"
+            )
+        pages = [{"page": p["page"], "mime": p["mime"], "data_b64": p["data_b64"]} for p in parts]
+        last = pages[-1]["page"]
+        return {
+            "kind": "file_pages",
+            "file_name": fdoc.file_name,
+            "page_count": total,
+            "pages": pages,
+            "has_more": last < total,
+            "note": "pages are attached to this tool result as images"
+            + (f"; call again with first_page={last + 1} for the rest" if last < total else ""),
+        }
+    if ext in _IMAGE_EXT:
+        part = image_part(content, fdoc.file_name)
+        if not part:
+            raise InvalidArgumentError(f"could not decode image {fdoc.file_name!r}")
+        return {
+            "kind": "file_pages",
+            "file_name": fdoc.file_name,
+            "page_count": 1,
+            "pages": [{"page": 1, "mime": part["mime"], "data_b64": part["data_b64"]}],
+            "has_more": False,
+            "note": "image is attached to this tool result",
+        }
+    raise InvalidArgumentError(
+        f"{fdoc.file_name!r} is not a PDF or image; use read_file for text/spreadsheet content"
+    )

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -39,6 +39,7 @@ _TOOL_NAMES: tuple[str, ...] = (
     "download_pdf",
     "export_excel",
     "read_file",
+    "get_file_pages",
     "attach_to_doc",
     "download_vcard",
     # Tier 2a ERPNext computed reads: numbers the LLM keeps hallucinating


### PR DESCRIPTION
A scanned PDF already on the site was unreadable mid-conversation: read_file returns no text and the chat vision path only covers chat-time attachments, so the agent had to ask the customer to re-upload. get_file_pages rasterizes the File's pages (pypdfium2, same caps as chat vision) and returns them base64-encoded; the openclaw plugin lifts pages[] into image blocks on the tool result, so the model reads the pages directly. Windowed via first_page/max_pages (<=6/call). vision.pdf_parts gains a backwards-compatible page window + per-part page numbers. Registry: 50 tools.