### PR TITLE
Openclaw-native chat relay: never-error turns + browser resync

### DIFF
--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -16,5 +16,5 @@ export function initSocket() {
 	// plain http, as before.
 	const protocol = port ? "http" : window.location.protocol.replace(":", "")
 	const url = `${protocol}://${host}${port}/${siteName}`
-	return io(url, { withCredentials: true, reconnectionAttempts: 5 })
+	return io(url, { withCredentials: true })
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3298,6 +3298,25 @@ function applyMention(item) {
 	})
 }
 
+// Resync from durable state after any gap in the socket stream. Socketio
+// has no replay: events published while disconnected or hidden are gone,
+// so on every (re)connect and on tab-wake we refetch instead of trusting
+// the stream. loadConversation already reconciles messages, restores the
+// spinner from streaming flags (freshness-guarded), and drops stale
+// responses.
+let _lastResync = 0
+function onResync() {
+	if (booting.value || !currentId.value) return
+	const now = Date.now()
+	if (now - _lastResync < 2000) return // connect + visibility often co-fire
+	_lastResync = now
+	loadConversations()
+	loadConversation(currentId.value)
+}
+function onVisibility() {
+	if (document.visibilityState === "visible") onResync()
+}
+
 onMounted(async () => {
 	// Latency plan, Phase 1.3: the bootstrap network calls used to run as a
 	// serial awaited chain (ready → ui settings → conversations), each a full
@@ -3317,6 +3336,8 @@ onMounted(async () => {
 		return
 	}
 	socket?.on("jarvis:event", onEvent)
+	socket?.on("connect", onResync)
+	document.addEventListener("visibilitychange", onVisibility)
 	// Live tool list for the "Tools available" count + /tool autocomplete
 	// (best-effort; falls back to the seeded core set on failure).
 	api.listTools().then((t) => { if (Array.isArray(t) && t.length) jarvisTools.value = t }).catch(() => {})
@@ -3355,6 +3376,8 @@ onMounted(async () => {
 })
 onBeforeUnmount(() => {
 	socket?.off("jarvis:event", onEvent)
+	socket?.off("connect", onResync)
+	document.removeEventListener("visibilitychange", onVisibility)
 	document.removeEventListener("pointerdown", onDocClick)
 	window.removeEventListener("keydown", onGlobalKey)
 	clearInterval(_thinkTimer)

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -13,8 +13,15 @@ the requested scopes, and the rest of the protocol (sessions.create, agent,
 event streaming) is identical to what the Node script used to do - only the
 transport changed from subprocess-pipes to direct WS frames.
 
-The public surface (OpenclawSession.connect / create_session /
-stream_agent_turn / close) is unchanged. worker.py and api.py don't notice.
+Public surface: OpenclawSession.connect / create_session / chat_send /
+relay_turn_events / set_session_model / subscribe_session / get_history /
+get_session_messages / is_run_active / fire_agent / stream_agent_turn /
+close. The managed chat path now uses the relay pair (chat_send +
+relay_turn_events): the turn is owned by openclaw after the chat.send ack,
+streaming rides the broadcast agent frames, completion comes from the
+run-scoped chat event, and relay_turn_events never raises after entry -
+interruptions degrade to snapshot recovery instead of errors.
+stream_agent_turn remains for auto-title; fire_agent for prewarm.
 """
 
 from __future__ import annotations

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -438,6 +438,15 @@ class OpenclawSession:
 			try:
 				frame = self._recv(remaining)
 			except OpenclawUnreachableError as e:
+				# Close the dead WS before yielding: this generator swallows
+				# the exception by design, so the pool's discard-on-exception
+				# contract never fires. Closing flips the connected flag the
+				# pool healthcheck reads, so the corpse is not handed to the
+				# next turn (which would fail pre-ack as a false run:error).
+				try:
+					self.close()
+				except Exception:
+					pass
 				yield {"kind": "relay:interrupted", "reason": "transport", "detail": str(e)}
 				return
 			if frame is None or frame.get("type") != "event":

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -130,6 +130,26 @@ def _is_stale_pairing(err: Exception) -> bool:
 	return code in _STALE_PAIRING_CODES
 
 
+def _chat_final_text(payload: dict) -> str | None:
+	"""Authoritative final text from a chat final event: joined text blocks
+	of payload.message.content; None for silent finals."""
+	msg = payload.get("message")
+	if not isinstance(msg, dict):
+		return None
+	c = msg.get("content")
+	if isinstance(c, str):
+		return c or None
+	if isinstance(c, list):
+		parts = [
+			b.get("text", "") for b in c
+			if isinstance(b, dict) and b.get("type") == "text"
+			and isinstance(b.get("text"), str)
+		]
+		joined = "\n".join(p for p in parts if p.strip())
+		return joined or None
+	return None
+
+
 def _persisted_device_id() -> str:
 	"""Cheap unauthenticated read of Jarvis Settings.chat_device_id.
 
@@ -370,6 +390,72 @@ class OpenclawSession:
 			if s.get("key") == session_key:
 				return bool(s.get("hasActiveRun"))
 		return False
+
+	def set_session_model(
+		self, session_key: str, model_ref: str,
+		*, timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> None:
+		"""Point the session at ``model_ref`` (``"<provider>/<model>"`` or
+		bare ``"<model>"``) via ``sessions.patch``. chat.send has no per-turn
+		model param, so per-conversation overrides are applied to the session
+		before the send."""
+		self._request(
+			"sessions.patch", {"key": session_key, "model": model_ref},
+			timeout_s=timeout_s,
+		)
+
+	def relay_turn_events(
+		self, session_key: str, run_id: str,
+		*, soft_deadline_s: float = TURN_TIMEOUT_SECONDS,
+	) -> Iterator[dict[str, Any]]:
+		"""Consume broadcast events for a chat.send run until a terminal
+		``chat`` event, the soft deadline, or a transport drop.
+
+		Mirror of openclaw's own UI model: token/tool streaming comes from
+		the broadcast ``agent`` frames (retagged with the chat.send
+		clientRunId == run_id); completion comes ONLY from the run-scoped
+		``chat`` event (state final|aborted|error). agent ``lifecycle``
+		frames are dropped so there is a single terminal path.
+
+		NEVER raises after entry. Terminal yields:
+		  {"kind": "relay:final", "text": str|None}
+		  {"kind": "relay:error", "state": "error"|"aborted", "error": str}
+		  {"kind": "relay:interrupted", "reason": "transport"|"deadline", ...}
+		"""
+		deadline = time.monotonic() + soft_deadline_s
+		while True:
+			remaining = deadline - time.monotonic()
+			if remaining <= 0:
+				yield {"kind": "relay:interrupted", "reason": "deadline"}
+				return
+			try:
+				frame = self._recv(remaining)
+			except OpenclawUnreachableError as e:
+				yield {"kind": "relay:interrupted", "reason": "transport", "detail": str(e)}
+				return
+			if frame is None or frame.get("type") != "event":
+				continue
+			payload = frame.get("payload") or {}
+			if frame.get("event") == "chat":
+				if payload.get("runId") != run_id or payload.get("sessionKey") != session_key:
+					continue
+				state = payload.get("state")
+				if state == "final":
+					yield {"kind": "relay:final", "text": _chat_final_text(payload)}
+					return
+				if state in ("error", "aborted"):
+					yield {
+						"kind": "relay:error", "state": state,
+						"error": payload.get("errorMessage") or state,
+					}
+					return
+				continue  # delta (150ms cumulative mirror) and unknown states: ignore
+			if payload.get("runId") != run_id:
+				continue
+			parsed = parse_event(payload)
+			if parsed is None or parsed.get("kind") == "lifecycle":
+				continue
+			yield parsed
 
 	def fire_agent(self, session_key: str, message: str, idempotency_key: str,
 	               *, model: str | None = None, provider: str | None = None) -> str:

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -2,6 +2,16 @@
 during one chat turn": DB writes, openclaw pool checkout, event
 streaming, canvas persist, auto-title.
 
+Managed transport is the openclaw-native relay (never-error discipline):
+chat.send with idempotencyKey = the bench run_id hands the turn to
+openclaw, relay_turn_events streams the broadcast frames, and the ONLY
+path to run:error after a successful ack is a genuine openclaw-reported
+terminal. Deadline expiry, transport drops, and exhausted streams park
+the row (_mark_recovering) and try recover_now immediately; the
+turn_recovery cron and its 60-minute ceiling are the backstop. See
+docs/superpowers/specs/2026-07-04-openclaw-native-chat-relay-design.md
+(jarvis repo root).
+
 Today this is called only by ``jarvis.chat.worker.run_agent_turn``,
 which is the RQ entry point invoked via
 ``frappe.enqueue("jarvis.chat.worker.run_agent_turn", ...)``. Phase 2 of

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -446,11 +446,25 @@ def handle_chat_send(payload: dict) -> None:
 			batcher.flush()
 
 		def _consume_relay(events) -> dict:
+			if stream_stats["t0"] is None:
+				stream_stats["t0"] = time.monotonic()
 			terminal = {"kind": "relay:interrupted", "reason": "stream-exhausted"}
 			for event in events:
-				if str(event.get("kind", "")).startswith("relay:"):
+				# Same segment telemetry as _consume (plan Phase 0), so managed
+				# (relay) turns keep feeding the latency summary below instead
+				# of logging -1s for every field.
+				ev_ms = int((time.monotonic() - stream_stats["t0"]) * 1000)
+				if stream_stats["first_event_ms"] < 0:
+					stream_stats["first_event_ms"] = ev_ms
+				kind = event.get("kind")
+				if str(kind or "").startswith("relay:"):
 					terminal = event
 					break
+				if kind == "assistant" and stream_stats["first_delta_ms"] < 0:
+					stream_stats["first_delta_ms"] = ev_ms
+				elif kind == "tool" and stream_stats["first_delta_ms"] < 0:
+					if (event.get("phase") or "") != "end":
+						stream_stats["pre_reply_tool_calls"] += 1
 				_handle_event(
 					event,
 					conversation_id=conversation_id,

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -397,12 +397,11 @@ def handle_chat_send(payload: dict) -> None:
 		and vision.supports_vision(settings.llm_provider)
 	)
 	user_message, vision_parts = _prepare_attachments(user_message, attachments, vision_ok)
-	# Apply the /think directive as the FIRST bytes of the final message so
-	# openclaw's leading-directive parser always sees it, even when
-	# _prepend_doc_context prepended a [Viewing: ...] line and
-	# _prepare_attachments appended attachment text. Cache-safe: the
-	# directive stays in the user message, never the system prompt.
-	user_message = _thinking_prefix(conv.thinking_override) + user_message
+	# The /think directive: self-hosted still inlines it as the FIRST bytes
+	# of the message body (openclaw's leading-directive parser strips it
+	# from there); managed sends it as the chat_send ``thinking`` param
+	# instead, so user_message stays unprefixed and the OpenAI prefix
+	# cache the warm-up populates is never busted by a varying prefix.
 
 	def _publish_run_error(err: str) -> None:
 		_mark_errored(assistant_msg.name, err)
@@ -415,7 +414,6 @@ def handle_chat_send(payload: dict) -> None:
 		})
 
 	try:
-		idem = f"{conversation_id}:{message_id}"
 		tool_msg_by_call_id: dict[str, str] = {}
 		batcher = _AssistantContentBatcher(assistant_msg.name)
 
@@ -447,6 +445,24 @@ def handle_chat_send(payload: dict) -> None:
 			# Drain buffered assistant deltas before the streaming=0 cleanup.
 			batcher.flush()
 
+		def _consume_relay(events) -> dict:
+			terminal = {"kind": "relay:interrupted", "reason": "stream-exhausted"}
+			for event in events:
+				if str(event.get("kind", "")).startswith("relay:"):
+					terminal = event
+					break
+				_handle_event(
+					event,
+					conversation_id=conversation_id,
+					assistant_msg_name=assistant_msg.name,
+					tool_msg_by_call_id=tool_msg_by_call_id,
+					user=user,
+					run_id=run_id,
+					batcher=batcher,
+				)
+			batcher.flush()
+			return terminal
+
 		if selfhost.is_self_hosted():
 			# Self-hosted: openclaw's HTTP OpenAI-compatible surface with a
 			# bearer token (full operator scope, no device pairing). agent_url
@@ -462,9 +478,14 @@ def handle_chat_send(payload: dict) -> None:
 			# Stream token-by-token unless the operator explicitly turned it
 			# off (a NULL field on a pre-existing config defaults to streaming).
 			stream_pref = (settings.selfhost_stream is None) or bool(settings.selfhost_stream)
+			# Self-hosted has no chat_send ``thinking`` param (it goes over the
+			# HTTP OpenAI-compatible surface, not chat.send), so the /think
+			# directive is inlined as the FIRST bytes of the message body here,
+			# same as before this refactor.
+			sh_message = _thinking_prefix(conv.thinking_override) + user_message
 			try:
 				_consume(openclaw_http_client.stream_agent_turn(
-					base_url, token, user_message, model="openclaw", stream=stream_pref,
+					base_url, token, sh_message, model="openclaw", stream=stream_pref,
 				))
 			except OpenclawUnreachableError as e:
 				_publish_run_error(str(e))
@@ -508,22 +529,57 @@ def handle_chat_send(payload: dict) -> None:
 						)
 						frappe.db.commit()
 						session_create_ms = int((time.monotonic() - t_sess) * 1000)
-					_consume(sess.stream_agent_turn(
-						conv.session_key, user_message, idem,
-						model=effective_model, provider=oauth_provider_id,
+					if effective_model:
+						model_ref = (
+							f"{oauth_provider_id}/{effective_model}"
+							if oauth_provider_id else effective_model
+						)
+						try:
+							sess.set_session_model(conv.session_key, model_ref)
+						except OpenclawUnreachableError:
+							raise
+						except Exception:
+							frappe.log_error(
+								title="chat: model override patch failed",
+								message=frappe.get_traceback(),
+							)
+					ack = sess.chat_send(
+						conv.session_key, user_message, run_id,
+						thinking=(conv.thinking_override or "").strip() or None,
 						attachments=_to_managed_attachments(vision_parts) if vision_parts else None,
+					) or {}
+					if ack.get("status") == "ok":
+						# Cached replay of a completed run (same run_id
+						# re-enqueued after the worker died post-completion).
+						# No events will follow; finalize from the durable
+						# transcript instead.
+						_mark_recovering(assistant_msg.name)
+						_try_recover_now(conversation_id)
+						return
+					terminal = _consume_relay(sess.relay_turn_events(
+						conv.session_key, ack.get("runId") or run_id,
 					))
 			except OpenclawUnreachableError as e:
-				if getattr(e, "code", None) == "turn-timeout":
-					# openclaw is still running this turn and persists the
-					# result; park the row for snapshot recovery instead of
-					# falsely erroring. Spinner stays up (streaming=1) and
-					# turn_recovery finalizes it from the gateway snapshot.
-					_mark_recovering(assistant_msg.name)
-					return
+				# Pre-ack only (relay_turn_events never raises): the run
+				# never started, so this is a real, retriable error.
 				_publish_run_error(str(e))
 				_advance_macro(conversation_id, errored=True)
 				return
+
+			if terminal["kind"] == "relay:error":
+				_publish_run_error(terminal.get("error") or "agent error")
+				_advance_macro(conversation_id, errored=True)
+				return
+			if terminal["kind"] == "relay:interrupted":
+				# Deadline, transport drop, or exhausted stream after a
+				# successful ack: openclaw still owns the turn and persists
+				# the result. Park for snapshot recovery. NEVER a false error.
+				_mark_recovering(assistant_msg.name)
+				_try_recover_now(conversation_id)
+				return
+			# relay:final - authoritative text beats the batcher tail.
+			if terminal.get("text"):
+				frappe.db.set_value(MSG, assistant_msg.name, "content", terminal["text"])
 
 		# Streaming exited cleanly via lifecycle.end
 		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
@@ -824,6 +880,19 @@ def _mark_recovering(assistant_msg_name: str) -> None:
 		"recovery_started_at": frappe.utils.now_datetime(),
 	})
 	frappe.db.commit()
+
+
+def _try_recover_now(conversation_id: str) -> None:
+	"""Best-effort immediate snapshot recovery after parking a turn; the
+	*/2 turn_recovery cron remains the backstop."""
+	try:
+		from jarvis.chat import turn_recovery
+		turn_recovery.recover_now(conversation_id)
+	except Exception:
+		frappe.log_error(
+			title="chat: recover_now failed (cron will retry)",
+			message=frappe.get_traceback(),
+		)
 
 
 def _handle_event(

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -235,3 +235,48 @@ def _recover_one(sess: OpenclawSession, row: dict, active: dict) -> str:
 		_finalize(row, text)
 		return "finalized"
 	return "waiting"  # no output yet; the ceiling backstop bounds the wait
+
+
+def recover_now(conversation_id: str) -> str:
+	"""In-worker immediate recovery for one conversation's latest recovering
+	row, so the common case (run already finished when the stream was lost)
+	does not wait for the cron. Dedicated connection - the pooled WS may be
+	the very thing that just died. Idempotent vs the cron via
+	_conditional_clear inside _finalize/_error."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		return "skipped"
+	rows = frappe.db.sql(
+		"""
+		SELECT m.name, m.conversation, c.session_key, c.owner,
+			   m.recovery_started_at, m.seq
+		FROM `tabJarvis Chat Message` m
+		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
+		WHERE m.streaming = 1 AND m.recovering = 1
+		  AND m.conversation = %(conv)s
+		  AND c.session_key IS NOT NULL AND c.session_key != ''
+		ORDER BY m.seq DESC
+		LIMIT 1
+		""",
+		{"conv": conversation_id},
+		as_dict=True,
+	)
+	if not rows:
+		return "skipped"
+	row = rows[0]
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace(
+		"http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return "skipped"
+	try:
+		with _recovery_connection(gateway_url) as sess:
+			active = {row["session_key"]: sess.is_run_active(row["session_key"])}
+			return _recover_one(sess, row, active)
+	except Exception:
+		frappe.log_error(
+			title="turn_recovery: recover_now failed",
+			message=frappe.get_traceback(),
+		)
+		return "skipped"

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -101,6 +101,24 @@ def _conditional_clear(name: str, fields: dict) -> bool:
 	return won
 
 
+def _advance_macro(conversation_id: str, *, errored: bool) -> None:
+	"""Chaining hook for the macro engine (mirrors turn_handler._advance_macro;
+	not imported from there to avoid a cycle risk between chat.turn_handler
+	and chat.turn_recovery). A macro chain that ends its turn via park-and-
+	recover (any post-ack interruption under the relay model) must still
+	step/terminate the macro, or the chain stalls forever. Best-effort: a
+	macro bug must never affect the recovery outcome."""
+	try:
+		from jarvis.chat import macros
+
+		macros.advance_after_turn(conversation_id, errored=errored)
+	except Exception:
+		frappe.log_error(
+			title="turn_recovery: macro advance hook failed",
+			message=frappe.get_traceback(),
+		)
+
+
 def _finalize(row: dict, text: str) -> None:
 	"""Authoritative completion (conditional + idempotent): overwrite content
 	from the raw snapshot, clear the flags, then publish for any live viewer."""
@@ -117,6 +135,7 @@ def _finalize(row: dict, text: str) -> None:
 		"kind": "run:end", "conversation_id": conv,
 		"message_id": name, "run_id": "recovered",
 	})
+	_advance_macro(conv, errored=False)
 
 
 def _error(row: dict, message: str) -> None:
@@ -128,6 +147,7 @@ def _error(row: dict, message: str) -> None:
 		"kind": "run:error", "conversation_id": row["conversation"],
 		"message_id": row["name"], "run_id": "recovered", "error": message,
 	})
+	_advance_macro(row["conversation"], errored=True)
 
 
 def _active_map(sess: OpenclawSession) -> dict:

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -62,11 +62,13 @@ class TestRunAgentTurnHappyPath(FrappeTestCase):
 
 	def test_streams_assistant_deltas_to_db_and_realtime(self):
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "assistant", "text": "Hello", "delta": "Hello"},
 			{"kind": "assistant", "text": "Hello world", "delta": " world"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user") as pub:
@@ -103,15 +105,25 @@ class TestRunAgentTurnToolCall(FrappeTestCase):
 		frappe.set_user(self._orig_user)
 
 	def test_tool_events_persist_tool_message_rows(self):
+		# Pre-existing (unrelated to the relay rewiring, reproduces on the
+		# base commit too): a jarvis__* tool_name is gated by `is_jarvis` in
+		# _handle_event_inner - the backend's call_tool path already
+		# persists that row, so this dispatch only drives the live activity
+		# indicator and does NOT insert a row for jarvis__ tools (see the
+		# "is_jarvis" comment in turn_handler.py). Use a built-in (non
+		# jarvis__) tool name so this test exercises the path that actually
+		# inserts a tool-message row.
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
-			{"kind": "tool", "phase": "start", "tool_name": "jarvis__get_list",
+			{"kind": "tool", "phase": "start", "tool_name": "browser_click",
 			 "tool_call_id": "tc-1"},
-			{"kind": "tool", "phase": "end", "tool_name": "jarvis__get_list",
+			{"kind": "tool", "phase": "end", "tool_name": "browser_click",
 			 "tool_call_id": "tc-1", "status": "completed"},
 			{"kind": "assistant", "text": "Done", "delta": "Done"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
@@ -123,7 +135,7 @@ class TestRunAgentTurnToolCall(FrappeTestCase):
 			fields=["tool_name", "tool_status"],
 		)
 		self.assertEqual(len(tools), 1)
-		self.assertEqual(tools[0]["tool_name"], "jarvis__get_list")
+		self.assertEqual(tools[0]["tool_name"], "browser_click")
 		self.assertEqual(tools[0]["tool_status"], "completed")
 
 
@@ -163,9 +175,16 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 
 	def test_lifecycle_error_marks_message_errored(self):
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		# A bare lifecycle:error frame (as opposed to a relay:error terminal)
+		# no longer occurs on the real managed path (relay_turn_events strips
+		# lifecycle frames), but _handle_event_inner's lifecycle-error branch
+		# is still live for self-hosted, so this pins that shared dispatch
+		# still marks the row errored regardless of which branch drove it.
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "lifecycle", "phase": "error", "error": "model overloaded"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
@@ -188,10 +207,10 @@ class TestRunAgentTurnErrorPaths(FrappeTestCase):
 		re-raises so RQ records the job failure.
 		"""
 		fake_sess = MagicMock()
-		# Simulate a non-Openclaw exception escaping from stream_agent_turn
+		# Simulate a non-Openclaw exception escaping from chat_send
 		# (e.g. an SSL handshake mid-stream, or a tool-handler bug).
 		import ssl
-		fake_sess.stream_agent_turn.side_effect = ssl.SSLError("handshake failed")
+		fake_sess.chat_send.side_effect = ssl.SSLError("handshake failed")
 
 		published_kinds: list = []
 		def _capture(user, payload):
@@ -239,19 +258,21 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 
 	def test_prepends_today_context_to_user_message(self):
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
 
-		# stream_agent_turn was called with (session_key, message_text, idem)
-		fake_sess.stream_agent_turn.assert_called_once()
-		_, kwargs = fake_sess.stream_agent_turn.call_args
+		# chat_send was called with (session_key, message_text, run_id)
+		fake_sess.chat_send.assert_called_once()
+		_, kwargs = fake_sess.chat_send.call_args
 		# args may be either positional or keyword - handle both
-		positional = fake_sess.stream_agent_turn.call_args.args
+		positional = fake_sess.chat_send.call_args.args
 		message_sent = (
 			positional[1] if len(positional) >= 2
 			else kwargs.get("message")
@@ -269,7 +290,8 @@ class TestRunAgentTurnAugmentsMessage(FrappeTestCase):
 
 class TestRunAgentTurnModelResolution(FrappeTestCase):
 	"""Worker resolves the effective model from conv.model_override → settings.llm_model
-	and threads it (with the openclaw provider id) into stream_agent_turn.
+	and threads it (with the openclaw provider id) into set_session_model
+	(sessions.patch) before chat_send.
 	"""
 
 	@classmethod
@@ -308,36 +330,39 @@ class TestRunAgentTurnModelResolution(FrappeTestCase):
 
 	def _run_and_capture(self):
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
-			{"kind": "lifecycle", "phase": "end"},
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
-		return fake_sess.stream_agent_turn.call_args
+		# Model overrides are applied to the SESSION (sessions.patch) before
+		# chat_send now - chat.send has no per-turn model param.
+		return fake_sess.set_session_model.call_args
 
 	def test_no_override_uses_settings_model_and_oauth_provider_id(self):
 		"""conv.model_override empty → effective_model = settings.llm_model;
 		provider id mapped from settings.llm_provider to openclaw provider id."""
 		call = self._run_and_capture()
-		kwargs = call.kwargs
-		self.assertEqual(kwargs.get("model"), "gpt-5.5")
+		args = call.args
+		self.assertEqual(args[0], "agent:fake")
 		# Maps to openclaw's model-provider key, not the OAuth flow id
 		# (which is "openai-codex"). See _PROVIDER_LABEL_TO_OPENCLAW_ID
 		# in chat/worker.py for the rationale.
-		self.assertEqual(kwargs.get("provider"), "openai")
+		self.assertEqual(args[1], "openai/gpt-5.5")
 
 	def test_override_used_when_set(self):
 		"""conv.model_override = gpt-5.4-mini → effective_model = gpt-5.4-mini."""
 		frappe.db.set_value(CONV, self.conv, "model_override", "gpt-5.4-mini")
 		frappe.db.commit()
 		call = self._run_and_capture()
-		kwargs = call.kwargs
-		self.assertEqual(kwargs.get("model"), "gpt-5.4-mini")
+		args = call.args
+		self.assertEqual(args[0], "agent:fake")
 		# Maps to openclaw's model-provider key, not the OAuth flow id
 		# (which is "openai-codex"). See _PROVIDER_LABEL_TO_OPENCLAW_ID
 		# in chat/worker.py for the rationale.
-		self.assertEqual(kwargs.get("provider"), "openai")
+		self.assertEqual(args[1], "openai/gpt-5.4-mini")
 
 
 class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
@@ -381,15 +406,18 @@ class TestRunAgentTurnApiKeyModeOmitsProvider(FrappeTestCase):
 
 	def test_provider_omitted_in_api_key_mode(self):
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
-			{"kind": "lifecycle", "phase": "end"},
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
-		kwargs = fake_sess.stream_agent_turn.call_args.kwargs
-		self.assertEqual(kwargs.get("model"), "claude-sonnet-4-6")
-		self.assertIsNone(kwargs.get("provider"))
+		# api_key mode has no oauth_provider_id, so the session model patch
+		# carries the bare model name (no "<provider>/" prefix).
+		args = fake_sess.set_session_model.call_args.args
+		self.assertEqual(args[0], "agent:fake")
+		self.assertEqual(args[1], "claude-sonnet-4-6")
 
 
 class TestAssistantContentBatching(FrappeTestCase):
@@ -422,7 +450,8 @@ class TestAssistantContentBatching(FrappeTestCase):
 		# realtime, so every assistant event must still publish an
 		# assistant:delta even though the DB write coalesces.
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "assistant", "text": "H", "delta": "H"},
 			{"kind": "assistant", "text": "He", "delta": "e"},
@@ -430,6 +459,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 			{"kind": "assistant", "text": "Hell", "delta": "l"},
 			{"kind": "assistant", "text": "Hello", "delta": "o"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user") as pub:
@@ -463,9 +493,11 @@ class TestAssistantContentBatching(FrappeTestCase):
 			cum += ch
 			events.append({"kind": "assistant", "text": cum, "delta": ch})
 		events.append({"kind": "lifecycle", "phase": "end"})
+		events.append({"kind": "relay:final", "text": None})
 
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream(events)
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream(events)
 
 		write_calls: list[tuple] = []
 		real_set_value = frappe.db.set_value
@@ -508,7 +540,8 @@ class TestAssistantContentBatching(FrappeTestCase):
 		# text -> tool call). Verify by checking the assistant row's
 		# content immediately after the tool event would have fired.
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			{"kind": "assistant", "text": "Looking it up", "delta": "Looking it up"},
 			# Tool event fires before the 10-event size threshold;
@@ -520,6 +553,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 			 "tool_call_id": "tc-1", "status": "completed"},
 			{"kind": "assistant", "text": "Done!", "delta": " Done!"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
@@ -543,7 +577,8 @@ class TestAssistantContentBatching(FrappeTestCase):
 		# not blow up the whole turn - it gets logged via
 		# frappe.log_error, then the next event runs.
 		fake_sess = MagicMock()
-		fake_sess.stream_agent_turn.return_value = _fake_event_stream([
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
 			{"kind": "lifecycle", "phase": "start"},
 			# A 'tool' end event with no matching start is the cleanest
 			# trigger for an internal log, but we want to assert the
@@ -554,6 +589,7 @@ class TestAssistantContentBatching(FrappeTestCase):
 			 "tool_call_id": "tc-x"},
 			{"kind": "assistant", "text": "Recovered", "delta": "Recovered"},
 			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
 		])
 		# Force the tool-start insert to fail; the assistant event
 		# after it must still land.
@@ -676,20 +712,23 @@ class TestWorkerCreatesSessionOnFirstTurn(FrappeTestCase):
 		fake_sess.create_session.return_value = "agent:new"
 		row_exists_at_stream_start = {}
 
-		def _stream(session_key, *a, **kw):
-			# Capture the moat invariant at the exact moment streaming
-			# starts: the sessionKey→user row must already be committed.
+		def _send(session_key, *a, **kw):
+			# Capture the moat invariant at the exact moment the turn
+			# starts (chat_send, the RPC that hands off to openclaw): the
+			# sessionKey→user row must already be committed.
 			row_exists_at_stream_start["row"] = frappe.db.get_value(
 				"Jarvis Chat Session", {"session_key": session_key},
 				["user", "session_key"], as_dict=True,
 			)
-			return _fake_event_stream([
-				{"kind": "lifecycle", "phase": "start"},
-				{"kind": "assistant", "text": "Hi", "delta": "Hi"},
-				{"kind": "lifecycle", "phase": "end"},
-			])
+			return {"runId": "r1", "status": "started"}
 
-		fake_sess.stream_agent_turn.side_effect = _stream
+		fake_sess.chat_send.side_effect = _send
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "Hi", "delta": "Hi"},
+			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
+		])
 		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
 			with patch("jarvis.chat.worker.publish_to_user"):
 				run_agent_turn(self.conv, self.user_msg, run_id="r1")
@@ -698,10 +737,189 @@ class TestWorkerCreatesSessionOnFirstTurn(FrappeTestCase):
 		fake_sess.create_session.assert_called_once()
 		# The row existed (with the sender's identity) before streaming.
 		row = row_exists_at_stream_start["row"]
-		self.assertIsNotNone(row, "Jarvis Chat Session row must exist before stream_agent_turn")
+		self.assertIsNotNone(row, "Jarvis Chat Session row must exist before chat_send")
 		self.assertEqual(row["session_key"], "agent:new")
 		self.assertEqual(row["user"], TEST_USER)
 		# And the conversation now carries the session key.
 		self.assertEqual(
 			frappe.db.get_value(CONV, self.conv, "session_key"), "agent:new",
 		)
+
+
+class TestRunAgentTurnRelayTerminals(FrappeTestCase):
+	"""Task 3 (openclaw-native relay transport): the managed branch now
+	drives chat_send + relay_turn_events instead of stream_agent_turn.
+
+	Never-error invariant: after a successful chat_send ack, NO code path
+	may publish run:error except a genuine relay:error terminal. A
+	relay:interrupted (deadline, transport drop, exhausted stream) or an
+	"ok" ack (cached replay of an already-completed run) parks the row via
+	_mark_recovering + best-effort recover_now and returns silently -
+	openclaw's durable transcript is the source of truth, not a guess made
+	from a lost stream.
+	"""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _fake_sess(self, relay_events, ack=None):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: (
+			dict(ack) if ack is not None else {"runId": idem, "status": "started"}
+		)
+		fake_sess.relay_turn_events.return_value = _fake_event_stream(relay_events)
+		return fake_sess
+
+	def _assistant_row(self, fields):
+		# A single field name returns the raw value; a list returns a dict -
+		# mirrors frappe.db.get_value's own as_dict semantics.
+		return frappe.db.get_value(
+			MSG, {"conversation": self.conv, "role": "assistant"}, fields,
+			as_dict=isinstance(fields, list),
+		)
+
+	def test_interrupted_terminal_parks_for_recovery_without_run_error(self):
+		fake_sess = self._fake_sess([
+			{"kind": "assistant", "text": "partial", "delta": "partial"},
+			{"kind": "relay:interrupted", "reason": "deadline"},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.turn_recovery.recover_now") as recover_now:
+				with patch("jarvis.chat.worker.publish_to_user") as pub:
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		recover_now.assert_called_once_with(self.conv)
+		row = self._assistant_row(["recovering", "recovery_started_at", "streaming", "error"])
+		self.assertEqual(row["recovering"], 1)
+		self.assertIsNotNone(row["recovery_started_at"])
+		# Spinner stays up - turn_recovery finalizes it later from the
+		# gateway snapshot, not this worker.
+		self.assertEqual(row["streaming"], 1)
+		self.assertFalse(row["error"])
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertNotIn("run:error", kinds)
+		# The clean-exit run:end never fires either - this turn isn't done.
+		self.assertNotIn("run:end", kinds)
+
+	def test_relay_error_terminal_marks_errored_and_publishes_run_error(self):
+		fake_sess = self._fake_sess([
+			{"kind": "assistant", "text": "oops", "delta": "oops"},
+			{"kind": "relay:error", "state": "error", "error": "provider quota exceeded"},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user") as pub:
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		row = self._assistant_row(["error", "streaming"])
+		self.assertIn("provider quota exceeded", row["error"])
+		self.assertEqual(row["streaming"], 0)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("run:error", kinds)
+
+	def test_ack_ok_skips_relay_consume_and_parks_for_recovery(self):
+		# Cached replay: chat_send returns status="ok" for an idempotency
+		# key that already completed (e.g. worker died post-completion,
+		# job re-enqueued). No events will follow - finalize from the
+		# durable transcript instead of calling relay_turn_events at all.
+		fake_sess = self._fake_sess([], ack={"runId": "r1", "status": "ok"})
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.turn_recovery.recover_now") as recover_now:
+				with patch("jarvis.chat.worker.publish_to_user"):
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		fake_sess.relay_turn_events.assert_not_called()
+		recover_now.assert_called_once_with(self.conv)
+		row = self._assistant_row(["recovering"])
+		self.assertEqual(row["recovering"], 1)
+
+	def test_ack_in_flight_with_different_run_id_is_honored(self):
+		# openclaw may hand back a DIFFERENT runId than our idempotency key
+		# (e.g. an in-flight run from a prior attempt); relay_turn_events
+		# must be driven with the server-assigned id, not ours.
+		fake_sess = self._fake_sess(
+			[{"kind": "relay:final", "text": None}],
+			ack={"runId": "server-assigned-run-id", "status": "in_flight"},
+		)
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		fake_sess.relay_turn_events.assert_called_once()
+		args, kwargs = fake_sess.relay_turn_events.call_args
+		run_id_used = args[1] if len(args) >= 2 else kwargs.get("run_id")
+		self.assertEqual(run_id_used, "server-assigned-run-id")
+
+	def test_relay_final_nonempty_text_overwrites_batcher_content(self):
+		# relay:final's text is authoritative over whatever the batcher
+		# last wrote (openclaw's durable transcript beats our in-flight
+		# delta tail).
+		fake_sess = self._fake_sess([
+			{"kind": "assistant", "text": "draft", "delta": "draft"},
+			{"kind": "relay:final", "text": "authoritative final text"},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		row = self._assistant_row("content")
+		self.assertEqual(row, "authoritative final text")
+
+
+class TestRunAgentTurnThinkingDirective(FrappeTestCase):
+	"""The /think directive is cache-unsafe as a message-body prefix on the
+	managed path (it would bust the OpenAI prefix cache the warm-up
+	populates), so managed sends it as the chat_send ``thinking`` param and
+	leaves user_message unprefixed. Self-hosted has no such param (it goes
+	over the HTTP OpenAI-compatible surface) so it keeps inlining the
+	directive as the first bytes of the message body."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message("hi")
+		frappe.db.set_value(CONV, self.conv, "thinking_override", "high")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_managed_message_unprefixed_thinking_sent_as_chat_send_param(self):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "relay:final", "text": None},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		args, kwargs = fake_sess.chat_send.call_args
+		message_sent = args[1]
+		self.assertNotIn("/think", message_sent)
+		self.assertEqual(kwargs.get("thinking"), "high")
+
+	def test_self_hosted_message_still_prefixed(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True):
+			with patch("jarvis.chat.openclaw_http_client.stream_agent_turn") as stream_mock:
+				stream_mock.return_value = _fake_event_stream([
+					{"kind": "lifecycle", "phase": "end"},
+				])
+				with patch("jarvis.chat.worker.publish_to_user"):
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		args, kwargs = stream_mock.call_args
+		message_sent = args[2]
+		self.assertTrue(message_sent.startswith("/think high\n"))

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -874,6 +874,55 @@ class TestRunAgentTurnRelayTerminals(FrappeTestCase):
 		self.assertEqual(row, "authoritative final text")
 
 
+class TestRunAgentTurnRelayStreamTelemetry(FrappeTestCase):
+	"""Follow-up (2026-07 review): the old ``_consume`` populated the
+	``stream_stats`` dict (first_event_ms, first_delta_ms,
+	pre_reply_tool_calls) that feeds the ``_lat.info`` latency summary
+	line. ``_consume_relay`` (the managed/relay path) never touched it, so
+	managed turns logged -1s for every field - dark telemetry for the
+	chat-latency investigation. ``_consume_relay`` must now stamp the same
+	stats for the events it dispatches."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_relay_turn_populates_stream_stats_for_latency_log(self):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "tool", "phase": "start", "tool_name": "browser_click",
+			 "tool_call_id": "tc-1"},
+			{"kind": "tool", "phase": "end", "tool_name": "browser_click",
+			 "tool_call_id": "tc-1", "status": "completed"},
+			{"kind": "assistant", "text": "Hi", "delta": "Hi"},
+			{"kind": "relay:final", "text": None},
+		])
+		fake_logger = MagicMock()
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				with patch("jarvis.chat.latency.get_logger", return_value=fake_logger):
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		fake_logger.info.assert_called_once()
+		# _lat.info(fmt, run_id, first_turn, queue_wait_ms, checkout_ms,
+		#           session_create_ms, first_event_ms, first_delta_ms,
+		#           pre_reply_tool_calls, turn_total_ms)
+		args = fake_logger.info.call_args.args
+		first_event_ms, first_delta_ms, pre_reply_tool_calls = args[6], args[7], args[8]
+		self.assertGreaterEqual(first_event_ms, 0)
+		self.assertGreaterEqual(first_delta_ms, 0)
+		self.assertEqual(pre_reply_tool_calls, 1)
+
+
 class TestRunAgentTurnThinkingDirective(FrappeTestCase):
 	"""The /think directive is cache-unsafe as a message-body prefix on the
 	managed path (it would bust the OpenAI prefix cache the warm-up

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -1,0 +1,158 @@
+"""Unit tests for OpenclawSession.relay_turn_events + set_session_model.
+
+Mirror of test_openclaw_native_rpcs.py's harness: bypass __init__ via
+OpenclawSession.__new__ and stub _recv (fed a scripted frame list; an
+Exception instance in the list is raised) / _request.
+
+relay_turn_events is the consumer half of the openclaw-native turn model:
+token/tool streaming comes from broadcast "agent" event frames retagged
+with the chat.send clientRunId == run_id; completion comes ONLY from the
+run-scoped "chat" event (state final|aborted|error). agent lifecycle
+frames are dropped.
+"""
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.openclaw_client import OpenclawSession
+from jarvis.exceptions import OpenclawUnreachableError
+
+
+def _agent_frame(run_id, stream, data):
+	return {"type": "event", "event": "agent", "payload": {
+		"runId": run_id, "stream": stream, "data": data,
+	}}
+
+
+def _chat_frame(run_id, session_key, state, **extra):
+	payload = {"runId": run_id, "sessionKey": session_key, "state": state}
+	payload.update(extra)
+	return {"type": "event", "event": "chat", "payload": payload}
+
+
+class TestRelayTurnEvents(FrappeTestCase):
+	def _sess(self, frames):
+		sess = OpenclawSession.__new__(OpenclawSession)  # bypass __init__/WS
+		queue = list(frames)
+
+		def fake_recv(_timeout):
+			frame = queue.pop(0)
+			if isinstance(frame, Exception):
+				raise frame
+			return frame
+
+		sess._recv = fake_recv
+		return sess
+
+	def test_assistant_and_tool_frames_then_final_joined_text(self):
+		sess = self._sess([
+			_agent_frame("r1", "assistant", {"text": "Hi there", "delta": "there"}),
+			_agent_frame("r1", "item", {
+				"kind": "tool", "phase": "start", "name": "read_file",
+				"toolCallId": "tc1",
+			}),
+			_chat_frame("r1", "sk", "final", message={
+				"content": [{"type": "text", "text": "Hi there"}],
+			}),
+		])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out[0], {"kind": "assistant", "text": "Hi there", "delta": "there"})
+		self.assertEqual(out[1], {
+			"kind": "tool", "phase": "start", "tool_name": "read_file", "tool_call_id": "tc1",
+		})
+		self.assertEqual(out[2], {"kind": "relay:final", "text": "Hi there"})
+		self.assertEqual(len(out), 3)
+
+	def test_discards_frames_for_other_run_or_session_and_non_event_frames(self):
+		sess = self._sess([
+			_agent_frame("other-run", "assistant", {"text": "nope", "delta": "nope"}),
+			{"type": "res", "id": "x", "ok": True},  # non-event frame
+			None,  # soft-timeout / non-JSON noise
+			_chat_frame("r1", "other-session", "final"),  # wrong sessionKey
+			_chat_frame("other-run", "sk", "final"),  # wrong runId
+			_agent_frame("r1", "assistant", {"text": "ok", "delta": "ok"}),
+			_chat_frame("r1", "sk", "final"),
+		])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [
+			{"kind": "assistant", "text": "ok", "delta": "ok"},
+			{"kind": "relay:final", "text": None},
+		])
+
+	def test_agent_lifecycle_frames_never_yielded(self):
+		sess = self._sess([
+			_agent_frame("r1", "lifecycle", {"phase": "start"}),
+			_agent_frame("r1", "lifecycle", {"phase": "end"}),
+			_chat_frame("r1", "sk", "final"),
+		])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
+
+	def test_chat_delta_state_ignored(self):
+		sess = self._sess([
+			_chat_frame("r1", "sk", "delta", message={"content": "partial"}),
+			_chat_frame("r1", "sk", "delta", message={"content": "partial partial"}),
+			_chat_frame("r1", "sk", "final", message={"content": "done"}),
+		])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": "done"}])
+
+	def test_final_with_no_message_yields_text_none(self):
+		sess = self._sess([_chat_frame("r1", "sk", "final")])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
+
+	def test_final_with_string_content_yields_text(self):
+		sess = self._sess([_chat_frame("r1", "sk", "final", message={"content": "plain text"})])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": "plain text"}])
+
+	def test_chat_error_state_yields_relay_error_with_message(self):
+		sess = self._sess([
+			_chat_frame("r1", "sk", "error", errorMessage="provider timed out"),
+		])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [
+			{"kind": "relay:error", "state": "error", "error": "provider timed out"},
+		])
+
+	def test_chat_aborted_state_falls_back_to_state_string(self):
+		sess = self._sess([_chat_frame("r1", "sk", "aborted")])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [
+			{"kind": "relay:error", "state": "aborted", "error": "aborted"},
+		])
+
+	def test_transport_drop_yields_interrupted_transport_and_does_not_raise(self):
+		sess = self._sess([OpenclawUnreachableError("ws closed mid-stream")])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(len(out), 1)
+		self.assertEqual(out[0]["kind"], "relay:interrupted")
+		self.assertEqual(out[0]["reason"], "transport")
+		self.assertIn("ws closed mid-stream", out[0]["detail"])
+
+	def test_deadline_yields_interrupted_deadline_on_stalling_recv(self):
+		sess = OpenclawSession.__new__(OpenclawSession)
+
+		def stalling_recv(_timeout):
+			import time
+			time.sleep(0.05)
+			return None
+
+		sess._recv = stalling_recv
+		out = list(sess.relay_turn_events("sk", "r1", soft_deadline_s=0.01))
+		self.assertEqual(out, [{"kind": "relay:interrupted", "reason": "deadline"}])
+
+
+class TestSetSessionModel(FrappeTestCase):
+	def test_sends_exact_sessions_patch_params(self):
+		sess = OpenclawSession.__new__(OpenclawSession)
+		captured = {}
+
+		def fake_request(method, params, *, timeout_s):
+			captured["method"] = method
+			captured["params"] = params
+			return {"ok": True, "payload": {}}
+
+		sess._request = fake_request
+		sess.set_session_model("sk", "openai/gpt-4o")
+		self.assertEqual(captured["method"], "sessions.patch")
+		self.assertEqual(captured["params"], {"key": "sk", "model": "openai/gpt-4o"})

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -123,11 +123,18 @@ class TestRelayTurnEvents(FrappeTestCase):
 
 	def test_transport_drop_yields_interrupted_transport_and_does_not_raise(self):
 		sess = self._sess([OpenclawUnreachableError("ws closed mid-stream")])
+		# The generator swallows the exception, so the pool's
+		# discard-on-exception contract never fires; the consumer must close
+		# the dead WS itself so the pool healthcheck evicts it instead of
+		# handing the corpse to the next turn.
+		closed = []
+		sess.close = lambda: closed.append(True)
 		out = list(sess.relay_turn_events("sk", "r1"))
 		self.assertEqual(len(out), 1)
 		self.assertEqual(out[0]["kind"], "relay:interrupted")
 		self.assertEqual(out[0]["reason"], "transport")
 		self.assertIn("ws closed mid-stream", out[0]["detail"])
+		self.assertEqual(closed, [True])
 
 	def test_deadline_yields_interrupted_deadline_on_stalling_recv(self):
 		sess = OpenclawSession.__new__(OpenclawSession)

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -266,6 +266,64 @@ class TestTurnRecovery(FrappeTestCase):
 		self.assertEqual(row.streaming, 1)
 		self.assertEqual(row.recovering, 1)
 
+	# --- macro chaining hook: finalize/error must advance a running macro ---
+	def test_finalize_advances_macro_with_errored_false(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		with patch("jarvis.chat.macros.advance_after_turn") as advance:
+			self._run(sess)
+		advance.assert_called_once_with(self.conv.name, errored=False)
+
+	def test_error_advances_macro_with_errored_true(self):
+		old = self._add_msg(seq=2, started_min=-120)  # past the ceiling -> _error
+		frappe.db.commit()
+
+		def boom(_url):
+			raise RuntimeError("gateway down")
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", boom), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user"), \
+			 patch("jarvis.chat.macros.advance_after_turn") as advance:
+			turn_recovery.recover_pending_turns()
+		advance.assert_called_once_with(old.conversation, errored=True)
+
+	def test_losing_conditional_clear_does_not_advance_macro(self):
+		# Row already cleared by another cycle: _conditional_clear returns
+		# False, so _finalize must return before ever touching the macro.
+		frappe.db.set_value(MSG_DT, self.msg.name, {"streaming": 0, "recovering": 0})
+		frappe.db.commit()
+		with patch("jarvis.chat.turn_recovery.publish_to_user"), \
+			 patch("jarvis.chat.macros.advance_after_turn") as advance:
+			turn_recovery._finalize(
+				{"name": self.msg.name, "conversation": self.conv.name, "owner": "x"},
+				"ignored")
+		advance.assert_not_called()
+
+	def test_macro_advance_exception_is_swallowed_row_still_finalized(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		with patch(
+			"jarvis.chat.macros.advance_after_turn",
+			side_effect=RuntimeError("macro engine bug"),
+		), patch("frappe.log_error") as log_err:
+			_, pub = self._run(sess)
+		# The macro exception was logged, not raised.
+		log_err.assert_called()
+		# The row still finalized and the publishes still happened.
+		row = self._row()
+		self.assertEqual(row.content, "the full answer")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("assistant:delta", kinds)
+		self.assertIn("run:end", kinds)
+
 	def test_recover_now_idempotent_after_finalize_no_double_publish(self):
 		sess = self._fake_sess(messages_by_key={SK: [
 			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -52,6 +52,7 @@ class TestTurnRecovery(FrappeTestCase):
 
 		sess._request = _request
 		sess.get_session_messages = lambda key, limit=50: messages_by_key.get(key, [])
+		sess.is_run_active = lambda key, timeout_s=None: key in active
 		return sess
 
 	def _run(self, sess):
@@ -66,6 +67,20 @@ class TestTurnRecovery(FrappeTestCase):
 			 patch("jarvis.chat.turn_recovery._recovery_connection", fake_conn), \
 			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
 			out = turn_recovery.recover_pending_turns()
+		return out, pub
+
+	def _run_now(self, sess, conv_id=None):
+		@contextlib.contextmanager
+		def fake_conn(_gateway_url):
+			yield sess
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", fake_conn), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
+			out = turn_recovery.recover_now(conv_id or self.conv.name)
 		return out, pub
 
 	def _row(self, name=None):
@@ -171,3 +186,97 @@ class TestTurnRecovery(FrappeTestCase):
 			{"role": "assistant", "__openclaw": {"seq": 5},
 			 "content": [{"type": "text", "text": {"unexpected": "dict"}}], "text": 123}])
 		self.assertEqual(text, "")
+
+	# --- recover_now: in-worker immediate recovery --------------------------
+	def test_recover_now_finalizes_when_run_done_with_text(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		out, pub = self._run_now(sess)
+		self.assertEqual(out, "finalized")
+		row = self._row()
+		self.assertEqual(row.content, "the full answer")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		self.assertFalse(row.error)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("assistant:delta", kinds)
+		self.assertIn("run:end", kinds)
+		run_ids = {c.args[1].get("run_id") for c in pub.call_args_list}
+		self.assertEqual(run_ids, {"recovered"})
+
+	def test_recover_now_leaves_active_run_untouched(self):
+		sess = self._fake_sess(active={SK}, messages_by_key={SK: [
+			{"role": "assistant", "content": "x", "__openclaw": {"seq": 1}}]})
+		out, pub = self._run_now(sess)
+		self.assertEqual(out, "active")
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+		pub.assert_not_called()
+
+	def test_recover_now_waits_when_transcript_empty(self):
+		sess = self._fake_sess(messages_by_key={SK: []})
+		out, pub = self._run_now(sess)
+		self.assertEqual(out, "waiting")
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+		pub.assert_not_called()
+
+	def test_recover_now_skipped_when_no_recovering_row(self):
+		other = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "rec-other",
+			"session_key": "sk_rec_other_test",
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+		try:
+			sess = self._fake_sess()
+			out, pub = self._run_now(sess, conv_id=other.name)
+			self.assertEqual(out, "skipped")
+			pub.assert_not_called()
+		finally:
+			frappe.db.delete(turn_recovery.CONV, {"name": other.name})
+			frappe.db.commit()
+
+	def test_recover_now_skipped_when_self_hosted(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
+			out = turn_recovery.recover_now(self.conv.name)
+		self.assertEqual(out, "skipped")
+		pub.assert_not_called()
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+
+	def test_recover_now_skipped_on_connect_failure(self):
+		def boom(_url):
+			raise RuntimeError("gateway down")
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", boom), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
+			out = turn_recovery.recover_now(self.conv.name)
+		self.assertEqual(out, "skipped")
+		pub.assert_not_called()
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+
+	def test_recover_now_idempotent_after_finalize_no_double_publish(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		out1, pub1 = self._run_now(sess)
+		self.assertEqual(out1, "finalized")
+		pub1.assert_called()
+
+		sess2 = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		out2, pub2 = self._run_now(sess2)
+		self.assertEqual(out2, "skipped")
+		pub2.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the two chat reliability defects at their shared root (streams treated as the source of truth):

- **Replies appearing only after refresh**: the SPA now resyncs from durable state on every socket reconnect and on tab-wake (2 s throttled), and the socket retries forever instead of giving up after 5 attempts. A slept/backgrounded tab catches up automatically.
- **Long turns falsely erroring**: the managed turn no longer holds openclaw's `agent` RPC stream under a 600 s cap. It mirrors openclaw's own UI model: `chat.send` (idempotencyKey = the bench run_id, so retries/dedup are safe by construction) hands the turn to openclaw, `relay_turn_events` consumes the broadcast frames (per-token agent frames for streaming, the run-scoped `chat` event for completion - the identical signal openclaw's UI keys on), and EVERY post-ack interruption (deadline, transport drop, exhausted stream, cached-replay ack) parks the row for snapshot recovery instead of erroring: immediate in-worker `recover_now`, the */2 cron as backstop, 60-min ceiling. A false error is no longer a reachable state - the only run:error paths are pre-ack failures and genuine openclaw-reported terminals.
- Recovery outcomes now advance macro chains (review-caught gap widened by the never-error model); managed-path latency telemetry preserved (feeds the prewarm investigation); dead WebSockets are closed before yielding the transport terminal so the session pool can never re-issue a corpse (final-review catch); model overrides move to `sessions.patch` (chat.send has no model param); /think becomes the `thinking` param on managed.

Wire contract verified against the openclaw source (ack statuses incl. `ok` cached-replay + `in_flight` runId reassignment, broadcast retagging with clientRunId, caps-gated inline tool events avoided deliberately). Design + failure-mode table: `docs/superpowers/specs/2026-07-04-openclaw-native-chat-relay-design.md` (jarvis repo).

Frozen surfaces: published event payloads, self-hosted branch (thinking-prefix relocation only, byte-identical on the wire), Path B dispatch, api.py, hooks.py, session pool semantics.

## Testing

- New: test_relay_consumer (12), recover_now suite (+7), never-error turn tests (+7 in test_chat_worker incl. interrupted-no-run:error, ack-ok, in_flight runId, final-text overwrite, thinking param)
- Green across test_chat_worker (25), test_turn_recovery (20), test_relay_consumer (12), test_chat_api (40+5), test_prewarm (13), test_chat_stale_scan (4), test_openclaw_native_rpcs (10), test_chat_openclaw_client (21)
- Frontend build clean; per-task gated reviews + final whole-branch review (all seams passed; one must-fix applied)
- Manual end-to-end pending (needs local fleet-agent + tenant container): checklist in the plan

Known follow-up (pre-existing, widened exposure, tracked): recovery can stamp a previous turn's text onto a parked row when a run dies server-side with zero output; fix = record transcript seq at send and require a strictly newer assistant message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)