### PR TITLE
Chat relay hardening: recovery watermark, widget resync, gray-zone docs

### DIFF
--- a/jarvis/chat/events.py
+++ b/jarvis/chat/events.py
@@ -22,7 +22,9 @@ CHANNEL = "jarvis:event"
 def parse_event(payload: dict[str, Any]) -> dict[str, Any] | None:
 	"""Normalize an openclaw WS frame to a flat dict, or return None to drop it."""
 	stream = payload.get("stream")
-	data = payload.get("data") or {}
+	data = payload.get("data")
+	if not isinstance(data, dict):
+		data = {}
 
 	if stream == "lifecycle":
 		out: dict[str, Any] = {"kind": "lifecycle", "phase": data.get("phase")}

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -567,6 +567,28 @@ def handle_chat_send(payload: dict) -> None:
 								title="chat: model override patch failed",
 								message=frappe.get_traceback(),
 							)
+					# Watermark BEFORE the send: recovery must never stamp a
+					# previous turn's answer onto this row (a run that dies
+					# with zero output leaves the prior reply as the newest
+					# transcript message). Best-effort: on failure the
+					# watermark stays 0 and recovery behaves as before.
+					try:
+						_wm_msgs = sess.get_session_messages(conv.session_key, limit=5)
+						watermark = max(
+							(((m or {}).get("__openclaw") or {}).get("seq", 0) for m in _wm_msgs),
+							default=0,
+						)
+						if watermark:
+							frappe.db.set_value(
+								MSG, assistant_msg.name, "openclaw_seq_watermark", watermark,
+								update_modified=False,
+							)
+							frappe.db.commit()
+					except Exception:
+						frappe.log_error(
+							title="chat: seq watermark capture failed",
+							message=frappe.get_traceback(),
+						)
 					ack = sess.chat_send(
 						conv.session_key, user_message, run_id,
 						thinking=(conv.thinking_override or "").strip() or None,
@@ -576,16 +598,26 @@ def handle_chat_send(payload: dict) -> None:
 						# Cached replay of a completed run (same run_id
 						# re-enqueued after the worker died post-completion).
 						# No events will follow; finalize from the durable
-						# transcript instead.
-						_mark_recovering(assistant_msg.name)
-						_try_recover_now(conversation_id)
-						return
-					terminal = _consume_relay(sess.relay_turn_events(
-						conv.session_key, ack.get("runId") or run_id,
-					))
+						# transcript instead. Routed through the same
+						# relay:interrupted handling as a dropped stream
+						# (below, AFTER this pool checkout releases the
+						# per-gateway lock) so the park+recover round-trip
+						# never holds the lock other turns are waiting on.
+						terminal = {"kind": "relay:interrupted", "reason": "completed-replay"}
+					else:
+						terminal = _consume_relay(sess.relay_turn_events(
+							conv.session_key, ack.get("runId") or run_id,
+						))
 			except OpenclawUnreachableError as e:
-				# Pre-ack only (relay_turn_events never raises): the run
-				# never started, so this is a real, retriable error.
+				# Pre-ack only (relay_turn_events never raises): the run never
+				# started, so this is a real, retriable error. Gray zone: a
+				# DELIVERED send whose ack was lost lands here too and a user
+				# retry then re-runs under a fresh run_id - deliberate. Reusing
+				# the old run_id would make openclaw REPLAY the cached outcome
+				# (dedupe semantics), never re-run; and while a ghost run is
+				# still active, openclaw's content-based dedupe already returns
+				# in_flight for the identical resend, so true double-runs are
+				# confined to the ghost-run-already-finished case.
 				_publish_run_error(str(e))
 				_advance_macro(conversation_id, errored=True)
 				return

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -55,14 +55,23 @@ def _age_minutes(dt) -> float:
 	return delta.total_seconds() / 60.0
 
 
-def _latest_assistant_text(messages: list) -> str:
+def _latest_assistant_text(messages: list, *, min_seq: int = 0) -> str:
 	"""Newest assistant message text from a raw transcript. Handles a
 	plain-string content and the {type:"text", text} block list. Sorted by the
-	transcript seq so the latest turn wins. Every text source is type-guarded."""
+	transcript seq so the latest turn wins. Every text source is type-guarded.
+
+	``min_seq`` is the transcript-seq watermark captured before this turn's
+	chat.send: a message whose seq is <= min_seq predates this turn (or is a
+	previous turn's reply left over from a run that died server-side with
+	zero output), so it is skipped even if it is the newest assistant message
+	in the transcript. A message with no seq (0) is treated as predating the
+	turn whenever a watermark is in force (min_seq > 0)."""
 	def seq(m):
 		return ((m or {}).get("__openclaw") or {}).get("seq", 0)
 
 	for m in sorted(messages or [], key=seq, reverse=True):
+		if min_seq > 0 and seq(m) <= min_seq:
+			continue
 		if (m.get("role") or "").lower() != "assistant":
 			continue
 		c = m.get("content")
@@ -174,7 +183,7 @@ def recover_pending_turns(limit: int = 20) -> dict:
 	rows = frappe.db.sql(
 		"""
 		SELECT m.name, m.conversation, c.session_key, c.owner,
-			   m.recovery_started_at, m.seq
+			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark
 		FROM `tabJarvis Chat Message` m
 		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
 		WHERE m.streaming = 1 AND m.recovering = 1
@@ -250,7 +259,7 @@ def _recover_one(sess: OpenclawSession, row: dict, active: dict) -> str:
 		return "active"
 	# Raw transcript (sessions.get), NOT chat.history -> no max_chars truncation (#1).
 	messages = sess.get_session_messages(session_key, limit=50)
-	text = _latest_assistant_text(messages)
+	text = _latest_assistant_text(messages, min_seq=row.get("openclaw_seq_watermark") or 0)
 	if text:
 		_finalize(row, text)
 		return "finalized"
@@ -270,7 +279,7 @@ def recover_now(conversation_id: str) -> str:
 	rows = frappe.db.sql(
 		"""
 		SELECT m.name, m.conversation, c.session_key, c.owner,
-			   m.recovery_started_at, m.seq
+			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark
 		FROM `tabJarvis Chat Message` m
 		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
 		WHERE m.streaming = 1 AND m.recovering = 1

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -15,6 +15,7 @@
     "error",
     "recovering",
     "recovery_started_at",
+    "openclaw_seq_watermark",
     "tool_name",
     "tool_args",
     "tool_result",
@@ -75,6 +76,14 @@
       "fieldtype": "Datetime",
       "label": "Recovery Started At",
       "description": "When this row entered the recovering state. Bounds the recovery window against an absolute ceiling."
+    },
+    {
+      "fieldname": "openclaw_seq_watermark",
+      "fieldtype": "Int",
+      "label": "Openclaw Seq Watermark",
+      "read_only": 1,
+      "hidden": 1,
+      "description": "Highest openclaw transcript seq observed before this turn's chat.send; snapshot recovery only finalizes from strictly newer assistant messages."
     },
     {
       "fieldname": "tool_name",

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -229,6 +229,12 @@ function submitDraft() {
 async function boot() {
 	booted.value = true;
 	frappe.realtime.on("jarvis:event", onEvent);
+	// frappe.realtime.socket is the underlying socket.io client instance
+	// (a public field on RealTimeClient, not a private internal). Its
+	// "connect" event fires on the initial connect and on every
+	// reconnect, both of which can hide a gap in delivered events.
+	frappe.realtime.socket?.on("connect", onResync);
+	document.addEventListener("visibilitychange", onVisibility);
 	try {
 		const convs = await api.listConversations();
 		if (convs && convs.length) {
@@ -312,6 +318,23 @@ async function reload() {
 	scrollBottom();
 }
 
+// Resync from durable state after any gap in the socket stream. Socketio
+// has no replay: events published while the tab was asleep or the socket
+// was disconnected are gone, so on every (re)connect and on tab-wake we
+// refetch instead of trusting the stream. reload() already re-derives the
+// full message list from the server.
+let _lastResync = 0;
+function onResync() {
+	if (!conversationId.value) return;
+	const now = Date.now();
+	if (now - _lastResync < 2000) return; // connect + visibility often co-fire
+	_lastResync = now;
+	reload();
+}
+function onVisibility() {
+	if (document.visibilityState === "visible") onResync();
+}
+
 function onRouteChange() {
 	readContext();
 }
@@ -332,9 +355,11 @@ onMounted(() => {
 onBeforeUnmount(() => {
 	try {
 		frappe.realtime.off("jarvis:event", onEvent);
+		frappe.realtime.socket?.off("connect", onResync);
 	} catch (e) {
 		/* not registered */
 	}
+	document.removeEventListener("visibilitychange", onVisibility);
 });
 
 defineExpose({ openPanel });

--- a/jarvis/tests/test_chat_events.py
+++ b/jarvis/tests/test_chat_events.py
@@ -75,6 +75,20 @@ class TestParseEvent(FrappeTestCase):
 		ev = parse_event({"stream": None, "data": {}})
 		self.assertIsNone(ev)
 
+	def test_assistant_with_non_dict_data_returns_empty_shape(self):
+		# A malformed frame where payload["data"] is a string (not a dict)
+		# must not raise inside the relay's never-raises generator - that
+		# would escape to the worker backstop as a false run:error.
+		ev = parse_event({"stream": "assistant", "data": "garbage"})
+		self.assertEqual(ev["kind"], "assistant")
+		self.assertEqual(ev["text"], "")
+		self.assertEqual(ev["delta"], "")
+
+	def test_lifecycle_with_none_data_returns_phase_none(self):
+		ev = parse_event({"stream": "lifecycle", "data": None})
+		self.assertEqual(ev["kind"], "lifecycle")
+		self.assertIsNone(ev["phase"])
+
 
 class TestPublishToUser(FrappeTestCase):
 	def test_publishes_to_jarvis_event_channel_scoped_to_user(self):

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -873,6 +873,30 @@ class TestRunAgentTurnRelayTerminals(FrappeTestCase):
 		row = self._assistant_row("content")
 		self.assertEqual(row, "authoritative final text")
 
+	def test_watermark_captured_before_send_and_stamped_on_assistant_row(self):
+		# Watermark must be read (best-effort, via get_session_messages) BEFORE
+		# chat_send hands the turn to openclaw, and stamped onto the assistant
+		# row as the highest seq seen - so a run that later dies server-side
+		# with zero output can never have recovery finalize from the PREVIOUS
+		# turn's reply (that reply is already in the transcript at this point).
+		fake_sess = self._fake_sess([{"kind": "relay:final", "text": "hi"}])
+		fake_sess.get_session_messages.return_value = [
+			{"role": "assistant", "content": "old", "__openclaw": {"seq": 3}},
+			{"role": "user", "content": "q", "__openclaw": {"seq": 4}},
+		]
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		call_names = [
+			c[0] for c in fake_sess.mock_calls
+			if c[0] in ("get_session_messages", "chat_send")
+		]
+		self.assertEqual(call_names, ["get_session_messages", "chat_send"])
+
+		row = self._assistant_row("openclaw_seq_watermark")
+		self.assertEqual(row, 4)
+
 
 class TestRunAgentTurnRelayStreamTelemetry(FrappeTestCase):
 	"""Follow-up (2026-07 review): the old ``_consume`` populated the

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -324,6 +324,62 @@ class TestTurnRecovery(FrappeTestCase):
 		self.assertIn("assistant:delta", kinds)
 		self.assertIn("run:end", kinds)
 
+	# --- transcript-seq watermark: never stamp a previous turn's answer ----
+	def test_watermark_ignores_older_assistant_message(self):
+		# Transcript's newest assistant message (seq 5) is OLDER than the
+		# watermark (7) captured before this turn's send - a run that died
+		# server-side with zero output must not have the previous reply
+		# wrongly stamped onto this row.
+		frappe.db.set_value(MSG_DT, self.msg.name, "openclaw_seq_watermark", 7)
+		frappe.db.commit()
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the OLD reply", "__openclaw": {"seq": 5}},
+		]})
+		_, pub = self._run(sess)
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+		self.assertFalse(row.error)
+		self.assertNotIn("run:end", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	def test_watermark_finalizes_from_strictly_newer_message(self):
+		frappe.db.set_value(MSG_DT, self.msg.name, "openclaw_seq_watermark", 7)
+		frappe.db.commit()
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the NEW reply", "__openclaw": {"seq": 9}},
+		]})
+		_, pub = self._run(sess)
+		row = self._row()
+		self.assertEqual(row.content, "the NEW reply")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		self.assertIn("run:end", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	def test_watermark_zero_behaves_as_before(self):
+		# Default watermark (0, i.e. never captured) must not change any
+		# pre-existing recovery behavior.
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		_, pub = self._run(sess)
+		row = self._row()
+		self.assertEqual(row.content, "the full answer")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+
+	def test_latest_assistant_text_min_seq_filters_out_older_message(self):
+		text = turn_recovery._latest_assistant_text([
+			{"role": "assistant", "__openclaw": {"seq": 5}, "content": "old"},
+		], min_seq=7)
+		self.assertEqual(text, "")
+
+	def test_latest_assistant_text_min_seq_keeps_strictly_newer_message(self):
+		text = turn_recovery._latest_assistant_text([
+			{"role": "assistant", "__openclaw": {"seq": 5}, "content": "old"},
+			{"role": "assistant", "__openclaw": {"seq": 9}, "content": "new"},
+		], min_seq=7)
+		self.assertEqual(text, "new")
+
 	def test_recover_now_idempotent_after_finalize_no_double_publish(self):
 		sess = self._fake_sess(messages_by_key={SK: [
 			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},


### PR DESCRIPTION
## Summary

Follow-up batch from the post-relay assessment:

- **Recovery seq watermark** (the tracked Important): a hidden `openclaw_seq_watermark` on Jarvis Chat Message, captured from the session transcript just before every `chat.send`; snapshot recovery now finalizes only from strictly newer assistant messages, so a run that dies producing nothing can never be stamped with the previous turn's reply. Waits instead; the 60-minute ceiling still bounds output-less runs (review-traced). Watermark 0 (capture failure / legacy rows) = exactly the old behavior.
- **Widget resync**: the embeddable chat widget gets the same stale-tab treatment the SPA got - refetch via its existing `reload()` on `frappe.realtime.socket` reconnect and on tab-wake (throttled). Closes the last surface where replies appeared only after refresh.
- **Retry idempotency decision, documented**: retries keep minting fresh run_ids - deliberately, since reusing a key makes openclaw replay the cached outcome rather than re-run, and content-dedup already guards the active-ghost window. Comment on the pre-ack branch.
- **parse_event guard**: malformed frames (non-dict data) can no longer raise inside the never-raises relay generator.
- **Lock hygiene**: the cached-replay ack path now parks/recovers after the pool checkout releases, matching the interrupted path.

## Testing
74 green across test_turn_recovery (25), test_chat_worker (26), test_chat_events (12), test_relay_consumer (11); branch review hand-traced watermark end-to-end, RPC ordering, lock release, ceiling interplay, and the widget mount model - zero blocking findings.

Follow-up noted: the watermark RPC adds one small sync round-trip pre-send that isn't in the _lat telemetry yet - add a field if the latency probe shows it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)