### PR TITLE
Recovery completeness + visibility: rich outputs on recovered turns, stats, spike alarm

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -65,6 +65,76 @@ _ASSISTANT_BATCH_SIZE = 10
 _ASSISTANT_BATCH_INTERVAL_MS = 250
 
 
+def persist_rich_outputs(
+	assistant_msg_name: str, conversation_id: str, user: str, run_id: str,
+	turn_start_ms: int,
+) -> None:
+	"""Best-effort canvas + generated-image persistence and publish for one
+	finished turn. Shared by the worker's clean exit and snapshot recovery
+	(a recovered long turn is exactly the kind that produced charts).
+	Managed mode only; never raises."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		return
+
+	settings = frappe.get_single("Jarvis Settings")
+
+	# Rich outputs: detect any canvas/chart artifact the agent produced this
+	# turn (HTML or SVG), fetch it from the gateway, persist it as a private
+	# File, and publish a 'canvas' event so the UI renders it inline. Managed
+	# mode only; self-hosted chats over the HTTP surface have no gateway
+	# canvas route. Failure here never fails the turn.
+	try:
+		from jarvis.chat import canvas as canvas_mod
+
+		final_content = frappe.db.get_value(MSG, assistant_msg_name, "content") or ""
+		canvas_token = settings.get_password("agent_token", raise_exception=False) or ""
+		canvas_items = canvas_mod.persist_canvases(
+			assistant_msg_name, final_content, settings.agent_url or "", canvas_token,
+		)
+		if canvas_items:
+			_publish_to_user(user, {
+				"kind": "canvas",
+				"conversation_id": conversation_id,
+				"message_id": assistant_msg_name,
+				"run_id": run_id,
+				"items": canvas_items,
+			})
+	except Exception:
+		frappe.log_error(
+			title="chat worker: canvas persist failed",
+			message=frappe.get_traceback(),
+		)
+
+	# Generated images: codex imagegen writes them on the container disk (not
+	# the canvas dir, and openclaw neither streams nor serves them), so pull
+	# any produced this turn via the fleet agent + persist as ERP Files so
+	# they show inline. Gated on the imagegen skill badge to avoid a fleet
+	# round-trip on every turn. Failure never fails a turn.
+	try:
+		final_content = frappe.db.get_value(MSG, assistant_msg_name, "content") or ""
+		if "imagegen" in final_content:
+			from jarvis.chat import generated_media as gen_media
+
+			gen_items = gen_media.persist_generated_images(
+				assistant_msg_name, conversation_id, turn_start_ms,
+			)
+			if gen_items:
+				_publish_to_user(user, {
+					"kind": "canvas",
+					"conversation_id": conversation_id,
+					"message_id": assistant_msg_name,
+					"run_id": run_id,
+					"items": gen_items,
+				})
+	except Exception:
+		frappe.log_error(
+			title="chat worker: generated-image persist failed",
+			message=frappe.get_traceback(),
+		)
+
+
 def _publish_to_user(user, payload):
 	"""Indirection so existing tests that patch
 	``jarvis.chat.worker.publish_to_user`` still take effect.
@@ -641,60 +711,10 @@ def handle_chat_send(payload: dict) -> None:
 		frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
 		frappe.db.commit()
 
-		# Rich outputs: detect any canvas/chart artifact the agent produced
-		# this turn (HTML or SVG), fetch it from the gateway, persist it as a
-		# private File, and publish a 'canvas' event so the UI renders it
-		# inline. Managed mode only; self-hosted chats over the HTTP surface
-		# have no gateway canvas route. Failure here never fails the turn.
-		if not selfhost.is_self_hosted():
-			try:
-				from jarvis.chat import canvas as canvas_mod
-
-				final_content = frappe.db.get_value(MSG, assistant_msg.name, "content") or ""
-				canvas_token = settings.get_password("agent_token", raise_exception=False) or ""
-				canvas_items = canvas_mod.persist_canvases(
-					assistant_msg.name, final_content, settings.agent_url or "", canvas_token,
-				)
-				if canvas_items:
-					_publish_to_user(user, {
-						"kind": "canvas",
-						"conversation_id": conversation_id,
-						"message_id": assistant_msg.name,
-						"run_id": run_id,
-						"items": canvas_items,
-					})
-			except Exception:
-				frappe.log_error(
-					title="chat worker: canvas persist failed",
-					message=frappe.get_traceback(),
-				)
-
-			# Generated images: codex imagegen writes them on the container disk
-			# (not the canvas dir, and openclaw neither streams nor serves them),
-			# so pull any produced this turn via the fleet agent + persist as ERP
-			# Files so they show inline. Gated on the imagegen skill badge to
-			# avoid a fleet round-trip on every turn. Failure never fails a turn.
-			try:
-				final_content = frappe.db.get_value(MSG, assistant_msg.name, "content") or ""
-				if "imagegen" in final_content:
-					from jarvis.chat import generated_media as gen_media
-
-					gen_items = gen_media.persist_generated_images(
-						assistant_msg.name, conversation_id, turn_start_ms,
-					)
-					if gen_items:
-						_publish_to_user(user, {
-							"kind": "canvas",
-							"conversation_id": conversation_id,
-							"message_id": assistant_msg.name,
-							"run_id": run_id,
-							"items": gen_items,
-						})
-			except Exception:
-				frappe.log_error(
-					title="chat worker: generated-image persist failed",
-					message=frappe.get_traceback(),
-				)
+		# Canvas + generated-image persistence and publish (extracted so
+		# snapshot recovery can deliver the same rich outputs for a turn
+		# that finished via _finalize instead of this clean exit).
+		persist_rich_outputs(assistant_msg.name, conversation_id, user, run_id, turn_start_ms)
 
 	except Exception as e:
 		# Last-resort backstop. Any exception that wasn't an

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -36,6 +36,22 @@ CONV = "Jarvis Conversation"
 # time-based stale_scan error path.
 _RECOVERY_CEILING_MINUTES = 60
 
+# Exact text stamped by the unconditional ceiling backstop below. Named so
+# jarvis.diagnostics.chat_recovery_stats can count ceiling errors without
+# duplicating (and risking drift from) the literal string.
+CEILING_ERROR_MESSAGE = "Run did not finish within the recovery window."
+
+# Spike-alarm thresholds (recovery_rate_watch): a sustained high recovered
+# rate over the last 24h means the never-error machinery is quietly
+# compensating for a sick gateway. Both must hold - the count guard (>=5)
+# keeps a quiet bench (e.g. 1 recovered out of 2 turns = 50%) from alarming
+# on noise.
+_RATE_WATCH_MIN_RECOVERED = 5
+_RATE_WATCH_MIN_RATE = 0.2
+# Dedupe window: a sustained problem alarms roughly once a day, not once an
+# hour, even though this is hooked hourly.
+_RATE_WATCH_DEDUPE_HOURS = 20
+
 
 @contextlib.contextmanager
 def _recovery_connection(gateway_url: str) -> Iterator[OpenclawSession]:
@@ -133,6 +149,7 @@ def _finalize(row: dict, text: str) -> None:
 	from the raw snapshot, clear the flags, then publish for any live viewer."""
 	if not _conditional_clear(row["name"], {
 		"content": text, "streaming": 0, "recovering": 0, "error": "",
+		"was_recovered": 1,
 	}):
 		return  # another cycle already finalized this row
 	conv, owner, name = row["conversation"], row["owner"], row["name"]
@@ -146,10 +163,29 @@ def _finalize(row: dict, text: str) -> None:
 	})
 	_advance_macro(conv, errored=False)
 
+	# Best-effort: a recovered long turn is exactly the kind that produced
+	# charts / generated images, so it deserves the same rich-output
+	# persistence as the worker's clean-exit path. Lazy import (codebase
+	# pattern - avoids any import-cycle question between turn_recovery and
+	# turn_handler).
+	try:
+		from jarvis.chat import turn_handler
+
+		turn_handler.persist_rich_outputs(
+			name, conv, row["owner"], "recovered",
+			int(frappe.utils.get_datetime(row["creation"]).timestamp() * 1000)
+			if row.get("creation") else 0,
+		)
+	except Exception:
+		frappe.log_error(
+			title="turn_recovery: rich-output persist failed",
+			message=frappe.get_traceback(),
+		)
+
 
 def _error(row: dict, message: str) -> None:
 	if not _conditional_clear(row["name"], {
-		"streaming": 0, "recovering": 0, "error": message,
+		"streaming": 0, "recovering": 0, "error": message, "was_recovered": 1,
 	}):
 		return
 	publish_to_user(row["owner"], {
@@ -183,7 +219,7 @@ def recover_pending_turns(limit: int = 20) -> dict:
 	rows = frappe.db.sql(
 		"""
 		SELECT m.name, m.conversation, c.session_key, c.owner,
-			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark
+			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark, m.creation
 		FROM `tabJarvis Chat Message` m
 		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
 		WHERE m.streaming = 1 AND m.recovering = 1
@@ -204,7 +240,7 @@ def recover_pending_turns(limit: int = 20) -> dict:
 	live = []
 	for r in rows:
 		if _age_minutes(r["recovery_started_at"]) > _RECOVERY_CEILING_MINUTES:
-			_error(r, "Run did not finish within the recovery window.")
+			_error(r, CEILING_ERROR_MESSAGE)
 			counts["errored"] += 1
 		else:
 			live.append(r)
@@ -279,7 +315,7 @@ def recover_now(conversation_id: str) -> str:
 	rows = frappe.db.sql(
 		"""
 		SELECT m.name, m.conversation, c.session_key, c.owner,
-			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark
+			   m.recovery_started_at, m.seq, m.openclaw_seq_watermark, m.creation
 		FROM `tabJarvis Chat Message` m
 		JOIN `tabJarvis Conversation` c ON c.name = m.conversation
 		WHERE m.streaming = 1 AND m.recovering = 1
@@ -309,3 +345,61 @@ def recover_now(conversation_id: str) -> str:
 			message=frappe.get_traceback(),
 		)
 		return "skipped"
+
+
+def recovery_rate_watch() -> None:
+	"""Hourly scheduler entry: spike alarm for the recovered-turn rate.
+
+	Snapshot recovery is designed to be invisible to the user (never-error),
+	which means a sick gateway that is forcing MOST turns through recovery
+	would otherwise go unnoticed. If at least _RATE_WATCH_MIN_RECOVERED turns
+	were recovered in the last 24h AND they are more than _RATE_WATCH_MIN_RATE
+	of all assistant turns in that window, log an Error Log so operators see
+	it - deduped against an existing Error Log with the same title in the
+	last _RATE_WATCH_DEDUPE_HOURS hours, so a sustained problem alarms
+	roughly once a day rather than every hour this cron fires."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		return
+
+	since_24h = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-24)
+	row = frappe.db.sql(
+		"""
+		SELECT COUNT(*) AS total,
+			   SUM(CASE WHEN was_recovered = 1 THEN 1 ELSE 0 END) AS recovered
+		FROM `tabJarvis Chat Message`
+		WHERE role = 'assistant' AND creation >= %(since)s
+		""",
+		{"since": since_24h},
+		as_dict=True,
+	)[0]
+	total = row.total or 0
+	recovered = row.recovered or 0
+	rate = (recovered / total) if total else 0
+	if recovered < _RATE_WATCH_MIN_RECOVERED or rate <= _RATE_WATCH_MIN_RATE:
+		return
+
+	title = "chat: high recovered-turn rate"
+	since_dedupe = frappe.utils.add_to_date(
+		frappe.utils.now_datetime(), hours=-_RATE_WATCH_DEDUPE_HOURS
+	)
+	existing = frappe.db.sql(
+		"""
+		SELECT name FROM `tabError Log`
+		WHERE method = %(title)s AND creation >= %(since)s
+		LIMIT 1
+		""",
+		{"title": title, "since": since_dedupe},
+	)
+	if existing:
+		return
+	frappe.log_error(
+		title=title,
+		message=(
+			f"Recovered {recovered}/{total} assistant turns ({rate:.0%}) in "
+			"the last 24h via snapshot recovery. The never-error machinery "
+			"is compensating for turns that never completed live - check "
+			"gateway health."
+		),
+	)

--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -69,15 +69,66 @@ def force_resync(action: str = "reload") -> dict:
 	if action not in ("reload", "restart"):
 		raise frappe.ValidationError(f"invalid action {action!r}; expected reload or restart")
 	settings = frappe.get_single("Jarvis Settings")
-	if (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
-		settings._sync_via_admin(action)
-	else:
-		settings._sync_via_local_openclaw(action)
+	# Always the admin path: the legacy local-openclaw sync was retired with
+	# the managed fleet (its method no longer exists), and _sync_via_admin
+	# surfaces its own clear error on an unconfigured bench.
+	settings._sync_via_admin(action)
 	settings.reload()
 	return {
 		"action": action,
 		"last_sync_at": str(settings.get("last_sync_at") or ""),
 		"last_sync_status": settings.get("last_sync_status") or "",
+	}
+
+
+@frappe.whitelist()
+def chat_recovery_stats() -> dict:
+	"""Operator-facing visibility into snapshot recovery (turn_recovery):
+	how often the never-error machinery is quietly compensating for a
+	gateway/turn that never completed live. currently_recovering is a live,
+	un-windowed snapshot (streaming=1 AND recovering=1 right now); the other
+	counts are windowed over 24h and 7d."""
+	from jarvis.chat.turn_recovery import CEILING_ERROR_MESSAGE
+
+	currently_recovering = frappe.db.sql(
+		"""
+		SELECT COUNT(*) FROM `tabJarvis Chat Message`
+		WHERE role = 'assistant' AND streaming = 1 AND recovering = 1
+		"""
+	)[0][0]
+
+	def _window(hours: int) -> dict:
+		row = frappe.db.sql(
+			"""
+			SELECT
+				COUNT(*) AS total,
+				SUM(CASE WHEN was_recovered = 1 THEN 1 ELSE 0 END) AS recovered,
+				SUM(CASE WHEN error = %(ceiling_msg)s THEN 1 ELSE 0 END) AS ceiling_errored
+			FROM `tabJarvis Chat Message`
+			WHERE role = 'assistant' AND creation >= %(since)s
+			""",
+			{
+				"ceiling_msg": CEILING_ERROR_MESSAGE,
+				"since": frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-hours),
+			},
+			as_dict=True,
+		)[0]
+		return {
+			"total": row.total or 0,
+			"recovered": row.recovered or 0,
+			"currently_recovering": currently_recovering,
+			"ceiling_errored": row.ceiling_errored or 0,
+		}
+
+	win_24h = _window(24)
+	win_7d = _window(24 * 7)
+	recovered_rate_24h = (
+		(win_24h["recovered"] / win_24h["total"]) if win_24h["total"] else 0
+	)
+	return {
+		"24h": win_24h,
+		"7d": win_7d,
+		"recovered_rate_24h": recovered_rate_24h,
 	}
 
 

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -180,6 +180,10 @@ scheduler_events = {
 		"jarvis.oauth.cron.poll_oauth_refresh_status",
 		# Fire any scheduled macros whose next_run_at has passed.
 		"jarvis.chat.macro_scheduler.run_due_macros",
+		# Recovery-completeness batch: spike alarm if the 24h recovered-turn
+		# rate is high enough to suggest a sick gateway (deduped to roughly
+		# once a day inside the function).
+		"jarvis.chat.turn_recovery.recovery_rate_watch",
 	],
 	"daily": [
 		"jarvis.onboarding.sync_connection",

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -16,6 +16,7 @@
     "recovering",
     "recovery_started_at",
     "openclaw_seq_watermark",
+    "was_recovered",
     "tool_name",
     "tool_args",
     "tool_result",
@@ -84,6 +85,15 @@
       "read_only": 1,
       "hidden": 1,
       "description": "Highest openclaw transcript seq observed before this turn's chat.send; snapshot recovery only finalizes from strictly newer assistant messages."
+    },
+    {
+      "fieldname": "was_recovered",
+      "fieldtype": "Check",
+      "label": "Was Recovered",
+      "default": 0,
+      "read_only": 1,
+      "hidden": 1,
+      "description": "Set when this turn was finalized or errored by snapshot recovery rather than its live worker - the never-error machinery's fingerprint."
     },
     {
       "fieldname": "tool_name",

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -996,3 +996,71 @@ class TestRunAgentTurnThinkingDirective(FrappeTestCase):
 		args, kwargs = stream_mock.call_args
 		message_sent = args[2]
 		self.assertTrue(message_sent.startswith("/think high\n"))
+
+
+class TestRichOutputsRouting(FrappeTestCase):
+	"""Recovery-completeness batch: the clean-exit path routes canvas +
+	generated-image persistence through the shared
+	``persist_rich_outputs`` function (extracted so snapshot recovery can
+	call the same code). Pin that the worker actually calls it, with the
+	right args, rather than re-testing canvas/generated-image behavior
+	itself (covered by test_canvas.py and generated_media's own tests)."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def test_clean_exit_calls_persist_rich_outputs_with_int_turn_start_ms(self):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "Hello", "delta": "Hello"},
+			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				with patch("jarvis.chat.turn_handler.persist_rich_outputs") as rich:
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		rich.assert_called_once()
+		args = rich.call_args.args
+		assistant_name = frappe.db.get_value(
+			MSG, {"conversation": self.conv, "role": "assistant"}, "name",
+		)
+		self.assertEqual(args[0], assistant_name)
+		self.assertEqual(args[1], self.conv)
+		self.assertEqual(args[2], TEST_USER)
+		self.assertEqual(args[3], "r1")
+		self.assertIsInstance(args[4], int)
+
+	def test_clean_exit_leaves_was_recovered_unset(self):
+		# was_recovered is snapshot recovery's fingerprint - a turn that
+		# finishes via the live worker's clean exit must NOT carry it.
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {"runId": idem, "status": "started"}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream([
+			{"kind": "lifecycle", "phase": "start"},
+			{"kind": "assistant", "text": "Hello", "delta": "Hello"},
+			{"kind": "lifecycle", "phase": "end"},
+			{"kind": "relay:final", "text": None},
+		])
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user"):
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+
+		row = frappe.db.get_value(
+			MSG, {"conversation": self.conv, "role": "assistant"},
+			["streaming", "was_recovered"], as_dict=True,
+		)
+		self.assertEqual(row["streaming"], 0)  # the turn did finish cleanly
+		self.assertEqual(row["was_recovered"], 0)

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -120,3 +120,63 @@ class TestForceResync(FrappeTestCase):
 		with patch.object(cls, "_sync_via_admin") as sa:
 			diagnostics.force_resync(action="reload")
 		sa.assert_called_once_with("reload")
+
+
+class TestChatRecoveryStats(FrappeTestCase):
+	"""jarvis.diagnostics.chat_recovery_stats - operator visibility into
+	how often snapshot recovery is rescuing turns."""
+
+	MSG = "Jarvis Chat Message"
+	CONV = "Jarvis Conversation"
+
+	def setUp(self):
+		self.conv = frappe.get_doc({
+			"doctype": self.CONV, "title": "diag-stats",
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete(self.MSG, {"conversation": self.conv.name})
+		frappe.db.delete(self.CONV, {"name": self.conv.name})
+		frappe.db.commit()
+
+	def _add(self, *, was_recovered=0, streaming=0, recovering=0, error=""):
+		frappe.get_doc({
+			"doctype": self.MSG, "conversation": self.conv.name, "seq": 1,
+			"role": "assistant", "content": "x",
+			"streaming": streaming, "recovering": recovering,
+			"was_recovered": was_recovered, "error": error,
+		}).insert(ignore_permissions=True)
+
+	def test_shape_and_zero_rate_with_no_turns(self):
+		out = diagnostics.chat_recovery_stats()
+		for window in ("24h", "7d"):
+			self.assertIn(window, out)
+			for key in ("total", "recovered", "currently_recovering", "ceiling_errored"):
+				self.assertIn(key, out[window])
+		self.assertEqual(out["recovered_rate_24h"], 0)
+
+	def test_counts_move_after_a_finalize(self):
+		before = diagnostics.chat_recovery_stats()
+		self._add(was_recovered=0)
+		self._add(was_recovered=1)
+		self._add(
+			was_recovered=1, error="Run did not finish within the recovery window.",
+		)
+		self._add(streaming=1, recovering=1)
+		frappe.db.commit()
+		after = diagnostics.chat_recovery_stats()
+
+		self.assertEqual(after["24h"]["total"], before["24h"]["total"] + 4)
+		self.assertEqual(after["24h"]["recovered"], before["24h"]["recovered"] + 2)
+		self.assertEqual(
+			after["24h"]["currently_recovering"],
+			before["24h"]["currently_recovering"] + 1,
+		)
+		self.assertEqual(
+			after["24h"]["ceiling_errored"], before["24h"]["ceiling_errored"] + 1,
+		)
+		# 7d window includes the same new rows.
+		self.assertEqual(after["7d"]["total"], before["7d"]["total"] + 4)
+		self.assertEqual(after["7d"]["recovered"], before["7d"]["recovered"] + 2)
+		self.assertGreater(after["recovered_rate_24h"], 0)

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -394,3 +394,201 @@ class TestTurnRecovery(FrappeTestCase):
 		out2, pub2 = self._run_now(sess2)
 		self.assertEqual(out2, "skipped")
 		pub2.assert_not_called()
+
+
+class TestRecoveryRichOutputsAndWasRecovered(FrappeTestCase):
+	"""Recovery-completeness batch: _finalize routes the recovered turn's
+	canvas/generated-image outputs through the same persist_rich_outputs
+	the worker's clean exit calls, and both _finalize and _error stamp
+	was_recovered=1 (the never-error machinery's fingerprint).
+
+	Deliberately does NOT subclass TestTurnRecovery (that would re-run its
+	whole suite under this class name too) - the small amount of shared
+	setup is duplicated instead."""
+
+	def setUp(self):
+		self.conv = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "rec2", "session_key": SK,
+		}).insert(ignore_permissions=True)
+		self.msg = self._add_msg(seq=1, started_min=-10)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete(MSG_DT, {"conversation": self.conv.name})
+		frappe.db.delete(turn_recovery.CONV, {"name": self.conv.name})
+		frappe.db.commit()
+
+	def _add_msg(self, seq, started_min, content="partial..."):
+		return frappe.get_doc({
+			"doctype": "Jarvis Chat Message",
+			"conversation": self.conv.name, "seq": seq, "role": "assistant",
+			"content": content, "streaming": 1, "recovering": 1,
+			"recovery_started_at": frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), minutes=started_min),
+		}).insert(ignore_permissions=True)
+
+	def _fake_sess(self, *, active=None, messages_by_key=None):
+		active = active or set()
+		messages_by_key = messages_by_key or {}
+		sess = MagicMock()
+
+		def _request(method, params, *, timeout_s):
+			if method == "sessions.list":
+				return {"payload": {"sessions": [
+					{"key": k, "hasActiveRun": True} for k in active]}}
+			return {"payload": {}}
+
+		sess._request = _request
+		sess.get_session_messages = lambda key, limit=50: messages_by_key.get(key, [])
+		sess.is_run_active = lambda key, timeout_s=None: key in active
+		return sess
+
+	def _run(self, sess):
+		@contextlib.contextmanager
+		def fake_conn(_gateway_url):
+			yield sess
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", fake_conn), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user") as pub:
+			out = turn_recovery.recover_pending_turns()
+		return out, pub
+
+	def _row(self, name=None):
+		return frappe.db.get_value(
+			MSG_DT, name or self.msg.name,
+			["content", "streaming", "recovering", "error"], as_dict=True)
+
+	def test_finalize_calls_persist_rich_outputs_best_effort(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		with patch("jarvis.chat.turn_handler.persist_rich_outputs") as rich:
+			self._run(sess)
+		rich.assert_called_once()
+		args = rich.call_args.args
+		self.assertEqual(args[0], self.msg.name)
+		self.assertEqual(args[1], self.conv.name)
+		self.assertEqual(args[3], "recovered")
+
+	def test_finalize_survives_persist_rich_outputs_raising(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		with patch(
+			"jarvis.chat.turn_handler.persist_rich_outputs",
+			side_effect=RuntimeError("canvas fetch exploded"),
+		), patch("frappe.log_error") as log_err:
+			_, pub = self._run(sess)
+		log_err.assert_called()
+		row = self._row()
+		self.assertEqual(row.content, "the full answer")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("assistant:delta", kinds)
+		self.assertIn("run:end", kinds)
+
+	def test_finalize_stamps_was_recovered(self):
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},
+		]})
+		with patch("jarvis.chat.turn_handler.persist_rich_outputs"):
+			self._run(sess)
+		self.assertEqual(
+			frappe.db.get_value(MSG_DT, self.msg.name, "was_recovered"), 1,
+		)
+
+	def test_error_stamps_was_recovered(self):
+		old = self._add_msg(seq=2, started_min=-120)  # past the ceiling -> _error
+		frappe.db.commit()
+
+		def boom(_url):
+			raise RuntimeError("gateway down")
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.chat.turn_recovery.frappe.get_single", return_value=settings), \
+			 patch("jarvis.chat.turn_recovery._recovery_connection", boom), \
+			 patch("jarvis.chat.turn_recovery.publish_to_user"):
+			turn_recovery.recover_pending_turns()
+		self.assertEqual(
+			frappe.db.get_value(MSG_DT, old.name, "was_recovered"), 1,
+		)
+
+
+class TestRecoveryRateWatch(FrappeTestCase):
+	"""Hourly spike alarm: high 24h recovered-turn rate -> one Error Log,
+	deduped for _RATE_WATCH_DEDUPE_HOURS so a sustained problem alarms
+	roughly once a day rather than every hour."""
+
+	TITLE = "chat: high recovered-turn rate"
+
+	def setUp(self):
+		# Neutralize residue: the watch is site-global over the last 24h, so
+		# stray recovered rows or a stray alarm left by an aborted earlier
+		# run would make these deterministic threshold tests flaky.
+		frappe.db.sql(
+			"UPDATE `tabJarvis Chat Message` SET was_recovered = 0 WHERE was_recovered = 1"
+		)
+		frappe.db.delete("Error Log", {"method": self.TITLE})
+		self.conv = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "rate-watch",
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete(MSG_DT, {"conversation": self.conv.name})
+		frappe.db.delete(turn_recovery.CONV, {"name": self.conv.name})
+		frappe.db.delete("Error Log", {"method": self.TITLE})
+		frappe.db.commit()
+
+	def _add_assistant(self, *, recovered):
+		frappe.get_doc({
+			"doctype": MSG_DT, "conversation": self.conv.name, "seq": 1,
+			"role": "assistant", "content": "x", "streaming": 0,
+			"was_recovered": 1 if recovered else 0,
+		}).insert(ignore_permissions=True)
+
+	def test_below_threshold_no_error_log(self):
+		# 1 recovered out of 2: rate 50% but recovered count (1) below the
+		# minimum (5), so no alarm.
+		self._add_assistant(recovered=True)
+		self._add_assistant(recovered=False)
+		frappe.db.commit()
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False):
+			turn_recovery.recovery_rate_watch()
+		self.assertEqual(frappe.db.count("Error Log", {"method": self.TITLE}), 0)
+
+	def test_above_threshold_logs_exactly_one(self):
+		for _ in range(6):
+			self._add_assistant(recovered=True)
+		for _ in range(2):
+			self._add_assistant(recovered=False)
+		frappe.db.commit()
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False):
+			turn_recovery.recovery_rate_watch()
+		self.assertEqual(frappe.db.count("Error Log", {"method": self.TITLE}), 1)
+
+	def test_second_run_within_20h_still_exactly_one(self):
+		for _ in range(6):
+			self._add_assistant(recovered=True)
+		for _ in range(2):
+			self._add_assistant(recovered=False)
+		frappe.db.commit()
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False):
+			turn_recovery.recovery_rate_watch()
+			turn_recovery.recovery_rate_watch()
+		self.assertEqual(frappe.db.count("Error Log", {"method": self.TITLE}), 1)
+
+	def test_self_hosted_returns_early_no_query(self):
+		for _ in range(6):
+			self._add_assistant(recovered=True)
+		frappe.db.commit()
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True):
+			turn_recovery.recovery_rate_watch()
+		self.assertEqual(frappe.db.count("Error Log", {"method": self.TITLE}), 0)


### PR DESCRIPTION
## Summary

Closes the two real gaps from the full-cycle bridge review:

- **Recovered turns keep their rich outputs**: the worker's canvas/generated-image persistence is now a shared `persist_rich_outputs()` that snapshot recovery's finalize also calls (best-effort, after the conditional-clear win + publishes + macro advance, so a persist failure can never un-finalize a turn). A long turn that produced a chart and then parked finally renders it.
- **Recovery is visible**: `was_recovered` fingerprint stamped on every recovery-finalized/errored row; `jarvis.diagnostics.chat_recovery_stats` (24h/7d totals, recovered counts, live recovering snapshot, ceiling errors, rate); hourly `recovery_rate_watch` raising a ~daily-deduped Error Log when >=5 turns and >20% of the last 24h needed recovery - a sick gateway can no longer hide behind the never-error machinery.
- **Bonus pre-existing fix** (verified broken at base, own commit): the Force Resync button crashed with AttributeError on benches without an admin API key - its no-key branch called `_sync_via_local_openclaw`, removed with the managed-fleet transition. Always the admin path now, matching the pre-existing pinned test.

## Testing
All green on the test site: test_turn_recovery (33), test_chat_worker, test_diagnostics (12), test_relay_consumer. Review hand-traced extraction parity (byte-identical move), recovery call ordering, threshold boundary math, Error Log dedupe against real frappe semantics (title lands in `method`), and endpoint gating conventions - zero functional findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)