### PR TITLE
Path B Stage A: the greenlet chat executor survives the real realtime process

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -751,7 +751,13 @@ def _dispatch_turn(enqueue_kwargs: dict) -> None:
 	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
 		from jarvis.chat.dispatch import publish_chat_send
 
-		publish_chat_send(enqueue_kwargs)
+		# Publish AFTER the request transaction commits. Pub/sub delivery is
+		# instant (unlike RQ dequeue latency), so publishing mid-transaction
+		# lets the subscriber greenlet start the turn before the conversation
+		# and user-message rows are visible - LinkValidationError on the
+		# placeholder insert. Mirrors enqueue-after-commit semantics; caught
+		# by the Stage A live smoke.
+		frappe.db.after_commit.add(lambda: publish_chat_send(enqueue_kwargs))
 	else:
 		frappe.enqueue(
 			method="jarvis.chat.worker.run_agent_turn",

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -706,27 +706,17 @@ def retry_message(message: str) -> dict:
 	)
 
 	run_id = uuid.uuid4().hex[:12]
-	# Same dispatch branch as send_message: Path B (Python socketio backend)
-	# publishes onto Redis pub/sub for the in-process realtime subscriber;
-	# default Node backend keeps using the long RQ queue with at_front=True.
+	# Route through the SHARED dispatcher (after-commit publish on Path B,
+	# RQ on the default backend) - retry previously duplicated this branch
+	# inline with a synchronous publish, keeping the mid-transaction race
+	# _dispatch_turn fixes for every other turn.
 	payload = {
 		"conversation_id": doc.conversation,
 		"message_id": user_msg_id,
 		"run_id": run_id,
 		"enqueued_at_ms": int(time.time() * 1000),
 	}
-	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
-		from jarvis.chat.dispatch import publish_chat_send
-
-		publish_chat_send(payload)
-	else:
-		frappe.enqueue(
-			method="jarvis.chat.worker.run_agent_turn",
-			queue="long",
-			timeout=_AGENT_TURN_WORKER_TIMEOUT,
-			at_front=True,
-			**payload,
-		)
+	_dispatch_turn(payload)
 	return {"ok": True, "run_id": run_id}
 
 

--- a/jarvis/chat/dispatch.py
+++ b/jarvis/chat/dispatch.py
@@ -40,5 +40,7 @@ def publish_chat_send(payload: dict) -> None:
 	the subscriber rehydrates it and calls ``handle_chat_send`` with the
 	same dict, so the two dispatch paths produce identical turn behaviour.
 	"""
-	conn = frappe.cache().get_redis_connection()
-	conn.publish(_channel(frappe.local.site), json.dumps(payload))
+	# frappe.cache() IS a redis.Redis subclass (RedisWrapper) - publish
+	# directly. (The previously-assumed .get_redis_connection() accessor
+	# does not exist on this frappe; caught by the Stage A live smoke.)
+	frappe.cache().publish(_channel(frappe.local.site), json.dumps(payload))

--- a/jarvis/realtime/handlers.py
+++ b/jarvis/realtime/handlers.py
@@ -1,4 +1,4 @@
-"""Frappe realtime handlers for jarvis.
+"""Frappe realtime handlers for jarvis - the Path B chat subscriber.
 
 Frappe's Python realtime process (frappe/realtime/server.py) discovers and
 imports ``<app>/realtime/handlers.py`` from every installed app at startup
@@ -26,16 +26,39 @@ What this module does on import:
   feature-flag toggle inside jarvis to flip; the ``socketio_backend``
   config value is the single source of truth.
 
+Context discipline (Stage A findings, 2026-07-03): the realtime process
+imports this module with NO site context, and gevent greenlets get a fresh
+``frappe.local`` - so nothing here may assume ``frappe.conf`` /
+``frappe.cache()`` / ``frappe.log_error`` are usable outside an explicit
+context.
+
+- Import/loop-level plumbing reads ``common_site_config.json`` directly and
+  talks to Redis through a raw client; failures log to the module logger
+  (the realtime process's stdout), never crash the server (a raised import
+  error would take down ALL realtime, Desk included - the registry
+  surfaces import errors loudly by design).
+- Each dispatched turn runs inside frappe's own
+  ``frappe.realtime.context.frappe_context(site, user)``: init -> forced
+  PyMySQL driver (mysqlclient's C socket would stall the gevent hub;
+  frappe enforces this per-context) -> connect -> commit/rollback ->
+  destroy. Turns run as Administrator, mirroring the RQ worker's
+  background-job semantics; ``handle_chat_send`` derives the actual chat
+  owner from the conversation row.
+
 The matching publisher lives at ``jarvis.chat.dispatch.publish_chat_send``;
-both sides use ``_channel(site)`` (private to dispatch.py) to keep the
-channel name in one place.
+both sides use the same site-scoped channel format (pinned by a test
+against dispatch._channel).
 """
 from __future__ import annotations
 
 import json
+import logging
+import os
 import time
 
 import frappe
+
+_logger = logging.getLogger("jarvis.realtime")
 
 _SUBSCRIBER_SPAWNED = False
 
@@ -48,77 +71,119 @@ _WATCHDOG_BACKOFF_S = 5
 _CHANNEL_TEMPLATE = "jarvis:chat:send:{site}"
 
 
-def _python_backend_active() -> bool:
-	"""True iff the bench has opted into the Python socketio backend.
+def _read_common_config() -> dict:
+	"""common_site_config.json, read directly off disk.
 
-	The realtime process is one-per-bench, so reading ``frappe.conf`` here
-	(populated from common_site_config.json) is the correct check; per-site
-	overrides do not apply at this layer.
-	"""
-	return (frappe.conf.get("socketio_backend") or "").strip().lower() == "python"
+	The realtime server chdirs into ``sites/`` before importing handlers,
+	so the bare filename is the normal hit; the ``sites/`` variant covers
+	being imported from the bench root (tests, tooling). Never raises -
+	config-file problems must not take down the realtime process."""
+	for path in ("common_site_config.json", os.path.join("sites", "common_site_config.json")):
+		try:
+			with open(path) as fh:
+				data = json.load(fh)
+			if isinstance(data, dict):
+				return data
+		except Exception:
+			continue
+	return {}
+
+
+def _conf_get(key: str) -> str:
+	"""A config value from frappe.conf when a context exists (tests, request
+	code), else from common_site_config.json (the realtime process's
+	context-free import/loop phases)."""
+	try:
+		val = frappe.conf.get(key)
+		if val:
+			return str(val)
+	except Exception:
+		pass
+	return str(_read_common_config().get(key) or "")
+
+
+def _python_backend_active() -> bool:
+	"""True iff the bench has opted into the Python socketio backend."""
+	return _conf_get("socketio_backend").strip().lower() == "python"
 
 
 def _site_name() -> str:
-	"""Best-effort current site name for channel scoping.
-
-	``frappe.local.site`` is the canonical answer once a request context is
-	open; at realtime startup we may be outside any site context, in which
-	case ``frappe.conf.get('default_site')`` is the closest equivalent.
-	Returning an empty string from here would publish/subscribe on
-	``jarvis:chat:send:`` (no site), which is wrong; raise instead so a
-	misconfigured bench fails loudly at boot.
-	"""
-	site = getattr(frappe.local, "site", None) or frappe.conf.get("default_site") or ""
-	if not site:
-		raise RuntimeError(
-			"jarvis.realtime.handlers: cannot determine site name for chat "
-			"subscriber channel; set default_site in common_site_config.json "
-			"or run under a site context"
-		)
-	return site
+	"""Site for channel scoping: the open context's site when there is one,
+	else ``default_site`` from common config. Empty string when neither
+	resolves - the caller decides how loudly to fail (an empty channel
+	name would silently drop every turn)."""
+	site = getattr(frappe.local, "site", None)
+	if site:
+		return site
+	return _conf_get("default_site")
 
 
-def _run_one(raw: bytes | str) -> None:
-	"""Decode one pub/sub message and dispatch it to the shared turn
-	handler. Exceptions are logged and swallowed so one bad payload does
-	not take down the subscribe loop (a swallowed-here exception also
-	swallows itself out of the watchdog's reach, which is intentional;
-	the watchdog only kicks in on subscribe-side failures)."""
-	# Late import to avoid pulling the heavy chat-turn module into every
-	# realtime-process startup when the Python backend is not active.
-	from jarvis.chat.turn_handler import handle_chat_send
+def _redis_url() -> str:
+	"""The cache Redis URL - the same instance frappe.cache() (and therefore
+	the publisher in jarvis.chat.dispatch) uses."""
+	return _conf_get("redis_cache") or "redis://127.0.0.1:13000"
 
+
+def _turn_context(site: str):
+	"""One turn's Frappe context: frappe's own realtime context manager
+	(init -> forced PyMySQL -> connect -> set_user -> commit/rollback ->
+	destroy). Indirection point so tests can substitute a null context."""
+	from frappe.realtime.context import frappe_context
+
+	return frappe_context(site, "Administrator")
+
+
+def _run_one(raw: bytes | str, site: str) -> None:
+	"""Decode one pub/sub message and run it through the shared turn
+	handler inside a full per-turn site context. All handler/payload
+	failures are logged (frappe.log_error - we have a context by then) and
+	swallowed so one bad turn cannot take down the subscribe loop;
+	context-bootstrap failures fall back to the module logger."""
 	try:
-		body = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
-		payload = json.loads(body)
-		if not isinstance(payload, dict):
-			raise ValueError(f"expected dict payload, got {type(payload).__name__}")
-		handle_chat_send(payload)
+		with _turn_context(site):
+			# Late import: keeps the heavy chat-turn module out of realtime
+			# startup when the Python backend is not active.
+			from jarvis.chat.turn_handler import handle_chat_send
+
+			try:
+				body = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+				payload = json.loads(body)
+				if not isinstance(payload, dict):
+					raise ValueError(f"expected dict payload, got {type(payload).__name__}")
+				handle_chat_send(payload)
+			except Exception:
+				frappe.log_error(
+					title="jarvis chat subscriber: handler failed",
+					message=frappe.get_traceback(),
+				)
 	except Exception:
-		frappe.log_error(
-			title="jarvis chat subscriber: handler failed",
-			message=frappe.get_traceback(),
+		_logger.exception(
+			"jarvis chat subscriber: turn context failed for site %s", site
 		)
 
 
-def _subscribe_loop_once() -> None:
+def _subscribe_loop_once(site: str) -> None:
 	"""Open one Redis pub/sub subscription and dispatch every message
-	until the connection drops. The watchdog wrapping this function is
-	responsible for restarting it; this function itself never retries."""
+	until the connection drops. Context-free by design: raw Redis client
+	(frappe.cache() needs a site context this process does not have), and
+	each message gets its own greenlet + its own site context inside
+	_run_one. The watchdog restarts this on failure; this function itself
+	never retries."""
 	import gevent
+	import redis
 
-	channel = _CHANNEL_TEMPLATE.format(site=_site_name())
-	conn = frappe.cache().get_redis_connection()
+	channel = _CHANNEL_TEMPLATE.format(site=site)
+	conn = redis.Redis.from_url(_redis_url())
 	pubsub = conn.pubsub()
 	pubsub.subscribe(channel)
-	frappe.logger().info(f"jarvis chat subscriber: listening on {channel}")
+	_logger.info("jarvis chat subscriber: listening on %s", channel)
 	for message in pubsub.listen():
 		if message.get("type") != "message":
 			continue
-		gevent.spawn(_run_one, message.get("data"))
+		gevent.spawn(_run_one, message.get("data"), site)
 
 
-def _watchdog_loop() -> None:
+def _watchdog_loop(site: str) -> None:
 	"""Forever-loop wrapper: run the subscribe loop, and on any unhandled
 	exception log it and restart after a short backoff. The realtime
 	process supervisor will only restart THIS file's import, not the
@@ -126,12 +191,9 @@ def _watchdog_loop() -> None:
 	watchdog would silently disable chat until the next bench restart."""
 	while True:
 		try:
-			_subscribe_loop_once()
+			_subscribe_loop_once(site)
 		except Exception:
-			frappe.log_error(
-				title="jarvis chat subscriber: subscribe loop crashed",
-				message=frappe.get_traceback(),
-			)
+			_logger.exception("jarvis chat subscriber: subscribe loop crashed")
 		# Backoff before reconnect. Use time.sleep (gevent monkey-patches it)
 		# rather than gevent.sleep so this module stays import-time safe
 		# under both backends; the realtime process has monkey.patch_all()
@@ -143,24 +205,42 @@ def maybe_start_chat_subscriber() -> bool:
 	"""Spawn the chat-send subscriber if the Python socketio backend is
 	active. Idempotent (a second call is a no-op). Returns True iff a new
 	greenlet was spawned by this call (mostly useful for tests; production
-	code calls it for the side effect)."""
+	code calls it for the side effect).
+
+	Resilient by design: a python-backend bench that cannot resolve its
+	site logs an ERROR and skips the spawn (chat dispatch would be broken,
+	visibly, in the realtime log) instead of raising - a raise here would
+	crash the whole realtime server, Desk realtime included."""
 	global _SUBSCRIBER_SPAWNED
 	if _SUBSCRIBER_SPAWNED:
 		return False
 	if not _python_backend_active():
 		return False
+	site = _site_name()
+	if not site:
+		_logger.error(
+			"jarvis chat subscriber: socketio_backend=python but no site "
+			"resolvable (set default_site in common_site_config.json); "
+			"chat dispatch will NOT be consumed"
+		)
+		return False
 	import gevent
 
-	gevent.spawn(_watchdog_loop)
+	gevent.spawn(_watchdog_loop, site)
 	_SUBSCRIBER_SPAWNED = True
-	frappe.logger().info(
-		"jarvis chat subscriber: watchdog greenlet spawned "
-		"(socketio_backend=python)"
+	_logger.info(
+		"jarvis chat subscriber: watchdog greenlet spawned for %s "
+		"(socketio_backend=python)", site,
 	)
 	return True
 
 
 # Fire on module import. Frappe's realtime process imports this module via
 # discover_app_handlers() during boot, after gevent.monkey.patch_all() has
-# already run, so spawning a greenlet here is safe.
-maybe_start_chat_subscriber()
+# already run, so spawning a greenlet here is safe. Never let a bootstrap
+# problem escape - the registry propagates import errors, which would take
+# down ALL realtime for the bench, not just chat.
+try:
+	maybe_start_chat_subscriber()
+except Exception:
+	_logger.exception("jarvis chat subscriber: startup failed")

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -335,6 +335,22 @@ class TestRetryMessage(_ChatTestCase):
 		super().setUp()
 		self.conv = create_conversation()
 
+	def test_routes_through_shared_dispatcher(self):
+		"""Retry must use the SAME dispatcher as send_message (after-commit
+		publish on Path B, RQ otherwise). It previously duplicated the
+		branch inline with a synchronous publish, keeping the
+		mid-transaction race the shared dispatcher fixes - both dispatch
+		flows must behave identically for every turn source."""
+		user_id, asst_id = self._make_turn(self.conv, with_error=True)
+		with patch("jarvis.chat.api._dispatch_turn") as dispatch:
+			result = retry_message(asst_id)
+		self.assertTrue(result["ok"])
+		dispatch.assert_called_once()
+		payload = dispatch.call_args[0][0]
+		self.assertEqual(payload["conversation_id"], self.conv)
+		self.assertEqual(payload["message_id"], user_id)
+		self.assertEqual(payload["run_id"], result["run_id"])
+
 	def test_enqueues_worker_against_preceding_user_message(self):
 		user_id, asst_id = self._make_turn(self.conv, with_error=True)
 		with patch("frappe.enqueue") as enqueue:

--- a/jarvis/tests/test_realtime_handlers.py
+++ b/jarvis/tests/test_realtime_handlers.py
@@ -64,8 +64,36 @@ class TestMaybeStartChatSubscriber(FrappeTestCase):
 		     patch("gevent.spawn") as spawn:
 			spawned = handlers.maybe_start_chat_subscriber()
 		self.assertTrue(spawned)
-		spawn.assert_called_once_with(handlers._watchdog_loop)
+		# The watchdog is bound to the site resolved at spawn time (the
+		# open test-site context here) so greenlets never re-resolve it.
+		spawn.assert_called_once_with(handlers._watchdog_loop, frappe.local.site)
 		self.assertTrue(handlers._SUBSCRIBER_SPAWNED)
+
+	def test_no_spawn_when_site_unresolvable(self):
+		"""socketio_backend=python but neither an open site context nor a
+		default_site: log an error and skip the spawn instead of raising -
+		a raise at import would take down the whole realtime server."""
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch.object(handlers, "_read_common_config", return_value={}), \
+		     patch.object(frappe.local, "site", None), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertFalse(spawned)
+		spawn.assert_not_called()
+		self.assertFalse(handlers._SUBSCRIBER_SPAWNED)
+
+	def test_backend_flag_falls_back_to_common_site_config(self):
+		"""The realtime process imports this module with no frappe context;
+		the gate must still see the flag via common_site_config.json."""
+		with patch.object(frappe, "conf", _FakeConf({})), \
+		     patch.object(
+		         handlers, "_read_common_config",
+		         return_value={"socketio_backend": "python"},
+		     ), \
+		     patch("gevent.spawn") as spawn:
+			spawned = handlers.maybe_start_chat_subscriber()
+		self.assertTrue(spawned)
+		spawn.assert_called_once()
 
 	def test_python_backend_match_is_case_insensitive(self):
 		"""Operators may type 'Python' or 'PYTHON' in the config; the
@@ -90,24 +118,39 @@ class TestMaybeStartChatSubscriber(FrappeTestCase):
 
 
 class TestRunOne(FrappeTestCase):
-	"""_run_one is the per-message dispatcher: it decodes the JSON
-	payload, calls handle_chat_send, and swallows any exception so one
-	bad turn doesn't kill the loop."""
+	"""_run_one is the per-message dispatcher: it opens a per-turn site
+	context, decodes the JSON payload, calls handle_chat_send, and
+	swallows any exception so one bad turn doesn't kill the loop.
+
+	Tests substitute a null context for _turn_context: the real
+	frappe_context would init/destroy the test runner's own connection.
+	The test process already has a site context, so frappe.log_error
+	behaves exactly as it does inside the real per-turn context."""
+
+	SITE = "site.example.com"
+
+	def _null_ctx(self):
+		from contextlib import nullcontext
+
+		return patch.object(handlers, "_turn_context", return_value=nullcontext())
 
 	def test_dispatches_decoded_payload_to_handle_chat_send(self):
 		payload = {"conversation_id": "c1", "message_id": "m1", "run_id": "r1"}
 		raw = json.dumps(payload).encode("utf-8")
-		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
-			handlers._run_one(raw)
+		with self._null_ctx() as ctx, \
+		     patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
+			handlers._run_one(raw, self.SITE)
 		mock_handle.assert_called_once_with(payload)
+		ctx.assert_called_once_with(self.SITE)
 
 	def test_accepts_str_payload_as_well_as_bytes(self):
 		"""Redis usually returns bytes but some configurations decode
 		strings; accept both."""
 		payload = {"conversation_id": "c2", "message_id": "m2", "run_id": "r2"}
 		raw = json.dumps(payload)
-		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
-			handlers._run_one(raw)
+		with self._null_ctx(), \
+		     patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
+			handlers._run_one(raw, self.SITE)
 		mock_handle.assert_called_once_with(payload)
 
 	def test_swallows_handler_exception(self):
@@ -116,29 +159,42 @@ class TestRunOne(FrappeTestCase):
 		The exception is logged via frappe.log_error instead."""
 		payload = {"conversation_id": "c", "message_id": "m", "run_id": "r"}
 		raw = json.dumps(payload).encode("utf-8")
-		with patch("jarvis.chat.turn_handler.handle_chat_send",
+		with self._null_ctx(), \
+		     patch("jarvis.chat.turn_handler.handle_chat_send",
 		           side_effect=RuntimeError("boom")), \
 		     patch("frappe.log_error") as mock_log:
-			handlers._run_one(raw)  # must not raise
+			handlers._run_one(raw, self.SITE)  # must not raise
 		mock_log.assert_called_once()
 
 	def test_swallows_invalid_json(self):
 		"""A malformed payload (corrupt publish, schema drift) must not
 		take down the loop. Log and move on."""
-		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
+		with self._null_ctx(), \
+		     patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
 		     patch("frappe.log_error") as mock_log:
-			handlers._run_one(b"not-json")  # must not raise
+			handlers._run_one(b"not-json", self.SITE)  # must not raise
 		mock_handle.assert_not_called()
 		mock_log.assert_called_once()
 
 	def test_swallows_non_dict_payload(self):
 		"""Defensive: a JSON value that isn't an object can't be a turn
 		payload. Reject + log."""
-		with patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
+		with self._null_ctx(), \
+		     patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle, \
 		     patch("frappe.log_error") as mock_log:
-			handlers._run_one(b'["not", "a", "dict"]')
+			handlers._run_one(b'["not", "a", "dict"]', self.SITE)
 		mock_handle.assert_not_called()
 		mock_log.assert_called_once()
+
+	def test_swallows_context_bootstrap_failure(self):
+		"""If the site context itself cannot open (bad site, db down), the
+		failure is logged to the module logger and swallowed - the loop
+		must survive."""
+		with patch.object(
+		     handlers, "_turn_context", side_effect=RuntimeError("no such site")
+		), patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
+			handlers._run_one(b"{}", self.SITE)  # must not raise
+		mock_handle.assert_not_called()
 
 
 class TestChannelFormat(FrappeTestCase):

--- a/jarvis/tests/test_realtime_handlers.py
+++ b/jarvis/tests/test_realtime_handlers.py
@@ -44,7 +44,11 @@ class TestMaybeStartChatSubscriber(FrappeTestCase):
 		handlers._SUBSCRIBER_SPAWNED = False
 
 	def test_no_spawn_when_socketio_backend_unset(self):
+		# _read_common_config patched: the gate falls back to the real
+		# common_site_config.json, which may legitimately have the flag on
+		# (it does on the Path B dev bench).
 		with patch.object(frappe, "conf", _FakeConf({})), \
+		     patch.object(handlers, "_read_common_config", return_value={}), \
 		     patch("gevent.spawn") as spawn:
 			spawned = handlers.maybe_start_chat_subscriber()
 		self.assertFalse(spawned)
@@ -195,6 +199,40 @@ class TestRunOne(FrappeTestCase):
 		), patch("jarvis.chat.turn_handler.handle_chat_send") as mock_handle:
 			handlers._run_one(b"{}", self.SITE)  # must not raise
 		mock_handle.assert_not_called()
+
+
+class TestDispatch(FrappeTestCase):
+	"""Path B publisher semantics - both caught by the Stage A live smoke.
+
+	1. frappe.cache() IS a redis.Redis subclass; publish directly (the
+	   previously-assumed .get_redis_connection() accessor does not exist).
+	2. _dispatch_turn must publish AFTER the request transaction commits:
+	   pub/sub delivery is instant, so a mid-transaction publish lets the
+	   subscriber greenlet start the turn before the conversation and
+	   user-message rows are visible (LinkValidationError on the
+	   placeholder insert)."""
+
+	def test_publish_goes_through_cache_client_directly(self):
+		from jarvis.chat import dispatch
+
+		fake_cache = MagicMock()
+		payload = {"conversation_id": "c1", "message_id": "m1", "run_id": "r1"}
+		with patch.object(frappe, "cache", return_value=fake_cache):
+			dispatch.publish_chat_send(payload)
+		fake_cache.publish.assert_called_once_with(
+			dispatch._channel(frappe.local.site), json.dumps(payload)
+		)
+
+	def test_dispatch_turn_publishes_only_after_commit(self):
+		from jarvis.chat import api as chat_api
+
+		payload = {"conversation_id": "c1", "message_id": "m1", "run_id": "r1"}
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch("jarvis.chat.dispatch.publish_chat_send") as mock_pub:
+			chat_api._dispatch_turn(payload)
+			mock_pub.assert_not_called()  # nothing until the transaction lands
+			frappe.db.commit()
+		mock_pub.assert_called_once_with(payload)
 
 
 class TestChannelFormat(FrappeTestCase):


### PR DESCRIPTION
## Summary

Stage A of the Path B activation: making the dormant greenlet chat executor work against frappe's ACTUAL Python realtime server, verified by a live smoke on the dev bench.

- **Subscriber context-safety** (`realtime/handlers.py`): the realtime process imports app handlers with no site context and greenlets get fresh `frappe.local` - the module now reads config straight from common_site_config.json, subscribes via a raw redis client, logs context-free failures to the module logger, resolves the site once at spawn, and runs every turn inside frappe's own `frappe_context(site, "Administrator")` (forced PyMySQL per context - frappe's sanctioned pattern for DB-touching handlers under gevent). A bootstrap failure can no longer take down Desk realtime.
- **Publisher fixes** (live-smoke catches): `frappe.cache().publish(...)` directly (the assumed `.get_redis_connection()` accessor does not exist on RedisWrapper), and dispatch is now an **after-commit callback** - instant pub/sub delivery beat the request transaction, letting the subscriber start turns before the conversation rows were committed (observed LinkValidationError).
- **retry_message unified onto the shared dispatcher** (review catch): it had an inline copy of the branch with a synchronous publish, keeping the exact race the dispatcher fixes - both dispatch flows now behave identically for every turn source (send, retry, macro).

## Live smoke (dev bench, Path B active)

Subscriber channel visible via `PUBSUB CHANNELS`; single turn dispatched after-commit, executed in a greenlet (RQ long-queue delta 0), streamed and finalized clean; two same-tenant turns serialized exactly on the session pool's per-gateway checkout (the documented Stage B target - measured: turn B's first content at the instant turn A finished) while the executor and gevent hub stayed healthy throughout.

## Testing
test_realtime_handlers 16/16 (subscriber gates incl. real-config isolation, per-turn context, dispatch semantics incl. the after-commit ordering test - verified non-vacuous against FrappeTestCase's transaction model), test_chat_api green incl. the new shared-dispatcher retry test. Branch review: all six hand-traces confirmed against frappe source (CallbackManager commit/rollback semantics, frappe_context error taxonomy, closure capture, config isolation).

The RQ path is untouched and remains the default: `socketio_backend` anything-but-python dispatches exactly as before. Runbook: chat-architecture.md section 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)