### PR TITLE
Stage B: N pooled sessions per gateway (same-tenant chat concurrency)

### DIFF
--- a/jarvis/chat/openclaw_session_pool.py
+++ b/jarvis/chat/openclaw_session_pool.py
@@ -18,27 +18,29 @@ a non-forking executor: the Python-socketio realtime process (Path B,
 ``FRAPPE_BACKGROUND_WORKERS_NOFORK=1``. The pool-hit/pool-miss log
 lines in ``checkout``/``_do_connect`` measure which world you're in.
 
-This module maintains one pooled OpenclawSession per gateway URL,
-per worker process, with lazy reconnect on stale / idle / error.
+Concurrency model (Stage B, 2026-07-03): the pool keeps UP TO
+``POOL_MAX_PER_GATEWAY`` sessions per gateway URL. ``checkout`` hands
+out any free healthy entry, opens a new connection while the gateway is
+below the cap, and blocks on a Condition once every slot is busy. The
+bench-side ``OpenclawSession`` is NOT safe for concurrent
+``stream_agent_turn``/``relay_turn_events`` on the same WS — ``_recv``
+is shared state and would steal frames between turns — so PER-ENTRY
+exclusivity is preserved: one turn per pooled session at a time. What
+Stage B removes is the per-GATEWAY exclusivity that made two
+same-tenant turns serialize end-to-end under Path B's greenlet
+executor (measured: turn B's first token landed exactly at turn A's
+finish). Under the default fork-per-job RQ executor the cap is
+irrelevant (one turn per process); the same code serves both executors
+unchanged — both dispatch flows are first-class.
 
-Concurrency: single-process RQ workers are single-threaded, so the
-per-entry lock is uncontended in practice. The lock exists for
-safety against threaded / no-fork RQ variants and to prevent races
-inside a process that might somehow spawn a second concurrent
-checkout against the same URL.
+Waiting is done on ``threading.Condition``, which the Path B realtime
+process monkey-patches (gevent) into a cooperative wait; under plain
+RQ threads it is a normal blocking wait. No gevent import here.
 
 Lifetime: an ``atexit`` hook drains all pooled sessions when the
 worker process exits. SIGTERM during a job lets the in-flight call
 finish before the drain proceeds (atexit runs after the foreground
 work completes).
-
-The bench-side ``OpenclawSession`` is NOT safe for concurrent
-``stream_agent_turn`` calls on the same WS — ``_recv`` is shared
-state and would steal frames between turns. So the pool gives an
-exclusive checkout: one turn per pooled session at a time. The
-amortization win is over SEQUENTIAL turns within a worker process,
-not concurrent multiplexing. Multi-worker concurrency arrives via
-multiple worker processes each maintaining their own pool entry.
 """
 from __future__ import annotations
 
@@ -48,7 +50,7 @@ import logging
 import threading
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from jarvis.chat.openclaw_client import OpenclawSession
 from jarvis.exceptions import OpenclawUnreachableError
@@ -63,27 +65,45 @@ logger = logging.getLogger(__name__)
 # the next checkout reconnects.
 IDLE_MAX_S = 240
 
+# Max concurrent pooled sessions per gateway. Small on purpose: each is
+# a live WS + handshake state on the tenant container, and >3 truly
+# simultaneous turns for ONE tenant is already unusual. The fourth
+# concurrent checkout blocks until a slot frees (bounded in practice by
+# the turn soft deadline). Recovery and prewarm use their own dedicated
+# connections and never draw from this pool.
+POOL_MAX_PER_GATEWAY = 3
+
 
 @dataclass
 class _PooledEntry:
-	"""One pooled session per gateway URL.
-
-	Each entry has its own lock so checkouts to different URLs don't
-	contend. Within a process, a single entry is exclusive per turn
-	because the worker is single-threaded and the bench-side client
-	isn't safe for concurrent ``stream_agent_turn`` calls on the same
-	WS.
-	"""
+	"""One pooled session. ``in_use`` is guarded by the owning group's
+	Condition; the session object itself is only ever touched by the
+	checkout that marked the entry in-use."""
 	session: OpenclawSession
-	lock: threading.Lock
 	last_used: float
 	gateway_url: str
+	in_use: bool = False
 
 
-# Module-level pool keyed by gateway_url. Mutations to the pool dict
-# (creating / deleting entries) go through ``_POOL_LOCK``; per-entry
-# concurrent-use protection is on the entry's own lock.
-_POOL: dict[str, _PooledEntry] = {}
+@dataclass
+class _GatewayGroup:
+	"""All pooled state for one gateway URL.
+
+	``cond`` guards ``entries`` membership, every entry's ``in_use``
+	flag, and ``connecting`` (slots reserved by in-flight connection
+	attempts so a burst of checkouts cannot overshoot the cap). Slow
+	work — connect, healthcheck, close — happens OUTSIDE the Condition,
+	on entries the caller owns."""
+	gateway_url: str
+	cond: threading.Condition = field(default_factory=threading.Condition)
+	entries: list[_PooledEntry] = field(default_factory=list)
+	connecting: int = 0
+
+
+# Module-level pool keyed by gateway_url. Group creation goes through
+# ``_POOL_LOCK`` (cheap, no I/O); everything inside a group is guarded
+# by the group's own Condition so gateways never contend.
+_POOL: dict[str, _GatewayGroup] = {}
 _POOL_LOCK = threading.Lock()
 
 
@@ -91,83 +111,126 @@ _POOL_LOCK = threading.Lock()
 def checkout(gateway_url: str) -> Iterator[OpenclawSession]:
 	"""Acquire a healthy OpenclawSession for ``gateway_url``.
 
-	Reuses a pooled session if one exists and passes the healthcheck;
-	otherwise opens a fresh connection (paying the handshake cost
-	once). The yielded session is exclusive to this caller until the
-	context exits. On exception inside the block, the session is
-	discarded from the pool (next checkout reconnects).
+	Hands out any free pooled session (healthchecked, reconnected in
+	place if stale), opens a new connection while the gateway is below
+	``POOL_MAX_PER_GATEWAY``, and blocks until a slot frees once at the
+	cap. The yielded session is exclusive to this caller until the
+	context exits. On ``OpenclawUnreachableError`` inside the block the
+	entry is evicted (next checkout reconnects); other exceptions
+	return the entry to the pool intact.
 	"""
-	entry = _get_or_create_entry(gateway_url)
-	entry.lock.acquire()
-	evicted = False
+	group = _get_or_create_group(gateway_url)
+	entry = _acquire_entry(group)
+	evict_on_exit = False
 	try:
-		# Healthcheck: discard if connection went away or sat idle
-		# too long. Either reason → reconnect now.
-		if not _is_alive(entry.session, entry.last_used):
-			logger.info(
-				"openclaw_session_pool: stale entry, reconnecting "
-				"gateway=%s idle_s=%.1f connected=%s",
-				gateway_url,
-				time.monotonic() - entry.last_used,
-				_safe_connected(entry.session),
-			)
-			_close_quietly(entry.session)
-			entry.session = _do_connect(gateway_url)
-		else:
-			# Symmetric to the pool-miss log in _do_connect so the hit rate
-			# is measurable from logs (latency plan, Phase 0). Under stock
-			# fork-per-job RQ this line should ~never appear — that absence
-			# is itself the signal that Phase 2 (persistent relay) is needed.
-			logger.info(
-				"openclaw_session_pool: pool-hit gateway=%s idle_s=%.1f",
-				gateway_url, time.monotonic() - entry.last_used,
-			)
 		yield entry.session
 		entry.last_used = time.monotonic()
 	except OpenclawUnreachableError:
 		# Connection failed mid-use. Evict so the next checkout opens
 		# a fresh WS rather than handing out the broken one.
-		_evict(gateway_url, entry)
-		evicted = True
+		evict_on_exit = True
 		raise
 	finally:
-		if not evicted:
-			entry.lock.release()
-		else:
-			# _evict left the lock held so we release uniformly here.
+		with group.cond:
+			if evict_on_exit:
+				_remove_entry(group, entry)
+			else:
+				entry.in_use = False
+			group.cond.notify()
+		if evict_on_exit:
+			_close_quietly(entry.session)
+
+
+def _acquire_entry(group: _GatewayGroup) -> _PooledEntry:
+	"""Claim a free entry, create one below the cap, or wait for a slot.
+
+	Returns an entry already marked ``in_use`` whose session passed the
+	healthcheck (reconnected in place when stale). Raises
+	``OpenclawUnreachableError`` if a needed connect fails — after
+	releasing the reserved slot so waiters retry."""
+	while True:
+		create_new = False
+		with group.cond:
+			entry = next((e for e in group.entries if not e.in_use), None)
+			if entry is not None:
+				entry.in_use = True
+			elif len(group.entries) + group.connecting < POOL_MAX_PER_GATEWAY:
+				group.connecting += 1
+				create_new = True
+			else:
+				group.cond.wait()
+				continue
+
+		if create_new:
 			try:
-				entry.lock.release()
-			except RuntimeError:
-				pass
+				sess = _do_connect(group.gateway_url)
+			except BaseException:
+				with group.cond:
+					group.connecting -= 1
+					group.cond.notify()
+				raise
+			new_entry = _PooledEntry(
+				session=sess,
+				last_used=time.monotonic(),
+				gateway_url=group.gateway_url,
+				in_use=True,
+			)
+			with group.cond:
+				group.connecting -= 1
+				group.entries.append(new_entry)
+			return new_entry
 
-
-def _get_or_create_entry(gateway_url: str) -> _PooledEntry:
-	"""Look up the entry for ``gateway_url`` or create one with a
-	fresh connection. The pool-dict mutation is locked; the connection
-	open happens outside the pool lock to avoid blocking other URLs."""
-	with _POOL_LOCK:
-		entry = _POOL.get(gateway_url)
-		if entry is not None:
+		# Healthcheck the claimed entry OUTSIDE the Condition — we own it
+		# (in_use=True), so the slow reconnect never blocks other slots.
+		if _is_alive(entry.session, entry.last_used):
+			# Symmetric to the pool-miss log in _do_connect so the hit rate
+			# is measurable from logs (latency plan, Phase 0). Under stock
+			# fork-per-job RQ this line should ~never appear — that absence
+			# is itself the signal that the persistent executor is needed.
+			logger.info(
+				"openclaw_session_pool: pool-hit gateway=%s idle_s=%.1f",
+				group.gateway_url, time.monotonic() - entry.last_used,
+			)
 			return entry
-	# Slow path: open a connection. Done outside ``_POOL_LOCK`` so a
-	# slow connect doesn't block other gateways. Race: if two callers
-	# hit this at once, both will create sessions; the second
-	# insertion under ``_POOL_LOCK`` wins and we close the loser.
-	# Cheap, rare (single-threaded workers).
-	sess = _do_connect(gateway_url)
-	new_entry = _PooledEntry(
-		session=sess,
-		lock=threading.Lock(),
-		last_used=time.monotonic(),
-		gateway_url=gateway_url,
-	)
+		logger.info(
+			"openclaw_session_pool: stale entry, reconnecting "
+			"gateway=%s idle_s=%.1f connected=%s",
+			group.gateway_url,
+			time.monotonic() - entry.last_used,
+			_safe_connected(entry.session),
+		)
+		_close_quietly(entry.session)
+		try:
+			entry.session = _do_connect(group.gateway_url)
+		except BaseException:
+			# Reconnect failed: drop the dead entry entirely and free the
+			# slot so a waiter (or retry) can attempt its own connect.
+			with group.cond:
+				_remove_entry(group, entry)
+				group.cond.notify()
+			raise
+		return entry
+
+
+def _get_or_create_group(gateway_url: str) -> _GatewayGroup:
+	"""Look up or create the group for ``gateway_url``. Group creation
+	is cheap (no I/O), so it happens under ``_POOL_LOCK`` directly."""
 	with _POOL_LOCK:
-		existing = _POOL.get(gateway_url)
-		if existing is not None:
-			_close_quietly(sess)
-			return existing
-		_POOL[gateway_url] = new_entry
-	return new_entry
+		group = _POOL.get(gateway_url)
+		if group is None:
+			group = _GatewayGroup(gateway_url=gateway_url)
+			_POOL[gateway_url] = group
+		return group
+
+
+def _remove_entry(group: _GatewayGroup, entry: _PooledEntry) -> None:
+	"""Drop ``entry`` from the group by identity. Caller holds
+	``group.cond``. Closing the session is the caller's job (outside
+	the Condition)."""
+	try:
+		group.entries.remove(entry)
+	except ValueError:
+		pass
 
 
 def _do_connect(gateway_url: str) -> OpenclawSession:
@@ -211,25 +274,22 @@ def _close_quietly(session: OpenclawSession) -> None:
 		pass
 
 
-def _evict(gateway_url: str, entry: _PooledEntry) -> None:
-	"""Remove the entry from the pool and close its session. The
-	caller holds ``entry.lock``; we leave it locked so the ``finally``
-	clause in ``checkout`` releases uniformly."""
-	with _POOL_LOCK:
-		if _POOL.get(gateway_url) is entry:
-			_POOL.pop(gateway_url, None)
-	_close_quietly(entry.session)
-
-
 def drain_all() -> None:
 	"""Close every pooled session. Called from ``atexit`` on worker
 	shutdown so the gateway sees clean disconnects rather than dangling
-	half-open TCP connections. Also exposed for tests."""
+	half-open TCP connections. Also exposed for tests. In-use entries
+	are closed too — this only runs at process exit (or from tests),
+	when no turn should still be live."""
 	with _POOL_LOCK:
-		entries = list(_POOL.values())
+		groups = list(_POOL.values())
 		_POOL.clear()
-	for entry in entries:
-		_close_quietly(entry.session)
+	for group in groups:
+		with group.cond:
+			entries = list(group.entries)
+			group.entries.clear()
+			group.cond.notify_all()
+		for entry in entries:
+			_close_quietly(entry.session)
 
 
 # Register the drain hook at module import time. ``atexit`` runs in

--- a/jarvis/chat/openclaw_session_pool.py
+++ b/jarvis/chat/openclaw_session_pool.py
@@ -199,8 +199,12 @@ def _acquire_entry(group: _GatewayGroup) -> _PooledEntry:
 			time.monotonic() - entry.last_used,
 			_safe_connected(entry.session),
 		)
-		_close_quietly(entry.session)
 		try:
+			# _close_quietly swallows Exception but not BaseException (a
+			# greenlet kill delivered inside close() would otherwise leak
+			# this slot forever: in_use stays True with no notify), so the
+			# close sits INSIDE the same guard as the reconnect.
+			_close_quietly(entry.session)
 			entry.session = _do_connect(group.gateway_url)
 		except BaseException:
 			# Reconnect failed: drop the dead entry entirely and free the

--- a/jarvis/chat/openclaw_session_pool.py
+++ b/jarvis/chat/openclaw_session_pool.py
@@ -10,7 +10,7 @@ confirmed:
 - One warm WS per gateway can serve every subsequent turn
 
 CAVEAT (2026-07 latency review): the RQ worker *parent* process is
-long-lived, but stock ``bench worker`` uses rq's forking Worker — each
+long-lived, but stock ``bench worker`` uses rq's forking Worker - each
 job runs in a forked work-horse child that exits after the job, taking
 this module-level pool with it. The pool therefore only amortizes under
 a non-forking executor: the Python-socketio realtime process (Path B,
@@ -23,15 +23,15 @@ Concurrency model (Stage B, 2026-07-03): the pool keeps UP TO
 out any free healthy entry, opens a new connection while the gateway is
 below the cap, and blocks on a Condition once every slot is busy. The
 bench-side ``OpenclawSession`` is NOT safe for concurrent
-``stream_agent_turn``/``relay_turn_events`` on the same WS — ``_recv``
-is shared state and would steal frames between turns — so PER-ENTRY
+``stream_agent_turn``/``relay_turn_events`` on the same WS - ``_recv``
+is shared state and would steal frames between turns - so PER-ENTRY
 exclusivity is preserved: one turn per pooled session at a time. What
 Stage B removes is the per-GATEWAY exclusivity that made two
 same-tenant turns serialize end-to-end under Path B's greenlet
 executor (measured: turn B's first token landed exactly at turn A's
 finish). Under the default fork-per-job RQ executor the cap is
 irrelevant (one turn per process); the same code serves both executors
-unchanged — both dispatch flows are first-class.
+unchanged - both dispatch flows are first-class.
 
 Waiting is done on ``threading.Condition``, which the Path B realtime
 process monkey-patches (gevent) into a cooperative wait; under plain
@@ -92,7 +92,7 @@ class _GatewayGroup:
 	``cond`` guards ``entries`` membership, every entry's ``in_use``
 	flag, and ``connecting`` (slots reserved by in-flight connection
 	attempts so a burst of checkouts cannot overshoot the cap). Slow
-	work — connect, healthcheck, close — happens OUTSIDE the Condition,
+	work - connect, healthcheck, close - happens OUTSIDE the Condition,
 	on entries the caller owns."""
 	gateway_url: str
 	cond: threading.Condition = field(default_factory=threading.Condition)
@@ -146,7 +146,7 @@ def _acquire_entry(group: _GatewayGroup) -> _PooledEntry:
 
 	Returns an entry already marked ``in_use`` whose session passed the
 	healthcheck (reconnected in place when stale). Raises
-	``OpenclawUnreachableError`` if a needed connect fails — after
+	``OpenclawUnreachableError`` if a needed connect fails - after
 	releasing the reserved slot so waiters retry."""
 	while True:
 		create_new = False
@@ -180,12 +180,12 @@ def _acquire_entry(group: _GatewayGroup) -> _PooledEntry:
 				group.entries.append(new_entry)
 			return new_entry
 
-		# Healthcheck the claimed entry OUTSIDE the Condition — we own it
+		# Healthcheck the claimed entry OUTSIDE the Condition - we own it
 		# (in_use=True), so the slow reconnect never blocks other slots.
 		if _is_alive(entry.session, entry.last_used):
 			# Symmetric to the pool-miss log in _do_connect so the hit rate
 			# is measurable from logs (latency plan, Phase 0). Under stock
-			# fork-per-job RQ this line should ~never appear — that absence
+			# fork-per-job RQ this line should ~never appear - that absence
 			# is itself the signal that the persistent executor is needed.
 			logger.info(
 				"openclaw_session_pool: pool-hit gateway=%s idle_s=%.1f",
@@ -235,7 +235,7 @@ def _remove_entry(group: _GatewayGroup, entry: _PooledEntry) -> None:
 
 def _do_connect(gateway_url: str) -> OpenclawSession:
 	"""Open a fresh WS + handshake. Wraps ``OpenclawSession.connect``
-	for timing visibility — the actual connect logic stays in the
+	for timing visibility - the actual connect logic stays in the
 	client. Phase-level breakdown is logged inside ``_attempt_connect``
 	itself; this just captures the total."""
 	t0 = time.monotonic()
@@ -278,7 +278,7 @@ def drain_all() -> None:
 	"""Close every pooled session. Called from ``atexit`` on worker
 	shutdown so the gateway sees clean disconnects rather than dangling
 	half-open TCP connections. Also exposed for tests. In-use entries
-	are closed too — this only runs at process exit (or from tests),
+	are closed too - this only runs at process exit (or from tests),
 	when no turn should still be live."""
 	with _POOL_LOCK:
 		groups = list(_POOL.values())

--- a/jarvis/tests/test_openclaw_session_pool.py
+++ b/jarvis/tests/test_openclaw_session_pool.py
@@ -149,39 +149,153 @@ class TestOpenclawSessionPool(FrappeTestCase):
 				with openclaw_session_pool.checkout("ws://gw"):
 					raise OpenclawUnreachableError("boom")
 			# Entry should have been removed even though close raised.
-			self.assertNotIn("ws://gw", openclaw_session_pool._POOL)
+			# (The gateway GROUP object stays in the dict; what matters
+			# is that no dead entry remains inside it.)
+			group = openclaw_session_pool._POOL["ws://gw"]
+			self.assertEqual(len(group.entries), 0)
 
-	# ---- concurrent checkout ----------------------------------------
+	# ---- concurrent checkout (Stage B: N entries per gateway) --------
 
-	def test_concurrent_checkout_shares_session(self):
-		"""Multiple threads checking out the same URL serialise on the
-		entry's lock; one connect, all five threads see the same
-		session. Workers are single-threaded in production but the lock
-		is exercised here as a safety check."""
-		sess = _fake_session()
-		# Connect is slow so threads pile up against the lock.
-		import time as _time
-		def slow_connect(_url):
-			_time.sleep(0.01)
-			return sess
+	def _held_checkout(self, url, acquired_evt, release_evt, out, errors):
+		"""Thread body: hold a checkout open until release_evt fires."""
+		try:
+			with openclaw_session_pool.checkout(url) as got:
+				out.append(got)
+				acquired_evt.set()
+				release_evt.wait(timeout=5)
+		except Exception as e:  # pragma: no cover - surfaced via assertion
+			errors.append(e)
+			acquired_evt.set()
+
+	def test_concurrent_checkouts_get_distinct_sessions(self):
+		"""Two checkouts held at the same time get two DIFFERENT pooled
+		sessions (per-entry exclusivity kept, per-gateway exclusivity
+		gone - the Stage B point)."""
+		sessions = [_fake_session(), _fake_session(), _fake_session()]
 		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
-		                  side_effect=slow_connect) as mock_connect:
-			results: list[object] = []
-			lock = threading.Lock()
-			def runner():
-				with openclaw_session_pool.checkout("ws://gw") as got:
-					with lock:
-						results.append(got)
-			threads = [threading.Thread(target=runner) for _ in range(5)]
-			for t in threads: t.start()
-			for t in threads: t.join()
-			self.assertEqual(len(results), 5)
-			self.assertTrue(all(r is sess for r in results))
-			# Race window means more than one connect MAY have started
-			# (the "lost-race insertion" branch handles it), but at
-			# least one session must have made it into the pool.
-			self.assertGreaterEqual(mock_connect.call_count, 1)
-			self.assertIn("ws://gw", openclaw_session_pool._POOL)
+		                  side_effect=sessions) as mock_connect:
+			out, errors = [], []
+			acq = [threading.Event() for _ in range(2)]
+			rel = threading.Event()
+			threads = [
+				threading.Thread(
+					target=self._held_checkout,
+					args=("ws://gw", acq[i], rel, out, errors),
+				)
+				for i in range(2)
+			]
+			for t in threads:
+				t.start()
+			for e in acq:
+				self.assertTrue(e.wait(timeout=5))
+			# Both hold a session simultaneously, and they are distinct.
+			self.assertEqual(len(out), 2)
+			self.assertIsNot(out[0], out[1])
+			self.assertEqual(mock_connect.call_count, 2)
+			rel.set()
+			for t in threads:
+				t.join(timeout=5)
+			self.assertEqual(errors, [])
+
+	def test_cap_blocks_fourth_concurrent_checkout(self):
+		"""With POOL_MAX_PER_GATEWAY sessions held, the next checkout
+		waits; releasing one slot unblocks it and it reuses that entry
+		(no fourth connect)."""
+		cap = openclaw_session_pool.POOL_MAX_PER_GATEWAY
+		sessions = [_fake_session() for _ in range(cap + 1)]
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=sessions) as mock_connect:
+			out, errors = [], []
+			acq = [threading.Event() for _ in range(cap)]
+			rels = [threading.Event() for _ in range(cap)]
+			holders = [
+				threading.Thread(
+					target=self._held_checkout,
+					args=("ws://gw", acq[i], rels[i], out, errors),
+				)
+				for i in range(cap)
+			]
+			for t in holders:
+				t.start()
+			for e in acq:
+				self.assertTrue(e.wait(timeout=5))
+			self.assertEqual(mock_connect.call_count, cap)
+
+			# Fourth checkout: must block while all slots are busy.
+			acq4, rel4 = threading.Event(), threading.Event()
+			fourth = threading.Thread(
+				target=self._held_checkout,
+				args=("ws://gw", acq4, rel4, out, errors),
+			)
+			fourth.start()
+			self.assertFalse(acq4.wait(timeout=0.3))  # still blocked
+
+			rels[0].set()  # free one slot
+			self.assertTrue(acq4.wait(timeout=5))  # now acquired
+			# Reused a pooled entry - no additional connect.
+			self.assertEqual(mock_connect.call_count, cap)
+			rel4.set()
+			for e in rels[1:]:
+				e.set()
+			for t in [*holders, fourth]:
+				t.join(timeout=5)
+			self.assertEqual(errors, [])
+
+	def test_eviction_of_one_entry_does_not_affect_others(self):
+		"""An OpenclawUnreachableError on one held session evicts ONLY
+		that entry; the concurrently-held sibling survives in the pool
+		and is reused by the next checkout."""
+		sess_a, sess_b = _fake_session(), _fake_session()
+		with patch.object(openclaw_session_pool.OpenclawSession, "connect",
+		                  side_effect=[sess_a, sess_b]) as mock_connect:
+			out, errors = [], []
+			acq_b, rel_b = threading.Event(), threading.Event()
+
+			def failing_holder():
+				try:
+					with openclaw_session_pool.checkout("ws://gw"):
+						# Hold until B has its own session, then die.
+						self.assertTrue(acq_b.wait(timeout=5))
+						raise OpenclawUnreachableError("stream died")
+				except OpenclawUnreachableError:
+					pass
+
+			holder_b = threading.Thread(
+				target=self._held_checkout,
+				args=("ws://gw", acq_b, rel_b, out, errors),
+			)
+			holder_a = threading.Thread(target=failing_holder)
+			holder_a.start()
+			holder_b.start()
+			holder_a.join(timeout=5)
+			rel_b.set()
+			holder_b.join(timeout=5)
+			self.assertEqual(errors, [])
+
+			group = openclaw_session_pool._POOL["ws://gw"]
+			self.assertEqual(len(group.entries), 1)  # one evicted, one kept
+			# Next checkout reuses the survivor - no third connect.
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIn(got, (sess_a, sess_b))
+			self.assertEqual(mock_connect.call_count, 2)
+
+	def test_connect_failure_frees_reserved_slot(self):
+		"""A failed connect must release its reserved slot so the pool
+		does not leak capacity (the 'connecting' counter)."""
+		sess = _fake_session()
+		with patch.object(
+			openclaw_session_pool.OpenclawSession, "connect",
+			side_effect=[OpenclawUnreachableError("refused"), sess],
+		) as mock_connect:
+			with self.assertRaises(OpenclawUnreachableError):
+				with openclaw_session_pool.checkout("ws://gw"):
+					pass  # pragma: no cover - never reached
+			group = openclaw_session_pool._POOL["ws://gw"]
+			self.assertEqual(group.connecting, 0)
+			# Retry succeeds and occupies a normal slot.
+			with openclaw_session_pool.checkout("ws://gw") as got:
+				self.assertIs(got, sess)
+			self.assertEqual(mock_connect.call_count, 2)
 
 	# ---- drain ------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Removes the last measured serialization point for same-tenant chat turns: the WS session pool was exclusive per gateway, so under Path B's greenlet executor two turns for the same tenant ran strictly back-to-back (Stage A measured turn B's first token at exactly turn A's finish, 17.1 s / 35.2 s).

Each gateway now keeps a group of up to `POOL_MAX_PER_GATEWAY = 3` sessions behind a Condition: checkout hands out any free healthy entry, opens new connections below the cap (with in-flight reservations so bursts cannot overshoot), and blocks cooperatively once full. Per-connection exclusivity is unchanged - the `_recv` single-reader constraint is per connection, which the review verified is genuinely instance-level. Eviction drops only the failed entry; failed connects release their reserved capacity; recovery/prewarm keep their dedicated non-pooled connections (verified unchanged). No gevent import: the Condition is monkey-patched cooperative under Path B, plain blocking under RQ - both dispatch flows share the code unchanged.

## Live smoke (dev bench, Path B)

Two same-tenant turns sent 0.01 s apart: **both streamed simultaneously** and finished 18.1 s / 19.1 s (previously 17.1 s / 35.2 s serialized). Single-turn path unchanged (clean finalize, zero RQ involvement).

## Review

Hand-traced: deadlock/lost-wakeup audit clean (monitor pattern, every capacity-freeing path notifies under the guarding Condition), cap accounting atomic (cannot overshoot, `connecting` cannot leak through GreenletExit), sequential-reuse parity kept (one connect for N sequential turns + pool-hit telemetry line intact). The one Important finding - a BaseException inside the pre-reconnect `close()` could permanently leak a slot - is fixed (`a33e34f`); the close now sits inside the same guard as the reconnect.

## Testing

test_openclaw_session_pool 14/14 including the spec's required scenarios: two concurrent checkouts get distinct sessions; the fourth blocks at the cap then reuses a freed entry without a new connect; eviction of one entry leaves its concurrently-held sibling pooled and reusable; failed connects free reserved capacity. Regression sweep green: test_chat_worker, test_relay_consumer, test_turn_recovery, test_prewarm, test_chat_openclaw_client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)