### PR TITLE
Dispatch mismatch guard: fall back to RQ when no Path B subscriber is listening

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -739,23 +739,50 @@ def _dispatch_turn(enqueue_kwargs: dict) -> None:
 	removing the RQ concurrency cap. Shared by send_message, retry_message and the
 	macro engine so every turn dispatches identically."""
 	if (frappe.conf.get("socketio_backend") or "").strip().lower() == "python":
-		from jarvis.chat.dispatch import publish_chat_send
+		from jarvis.chat import dispatch
 
-		# Publish AFTER the request transaction commits. Pub/sub delivery is
-		# instant (unlike RQ dequeue latency), so publishing mid-transaction
-		# lets the subscriber greenlet start the turn before the conversation
-		# and user-message rows are visible - LinkValidationError on the
-		# placeholder insert. Mirrors enqueue-after-commit semantics; caught
-		# by the Stage A live smoke.
-		frappe.db.after_commit.add(lambda: publish_chat_send(enqueue_kwargs))
-	else:
-		frappe.enqueue(
-			method="jarvis.chat.worker.run_agent_turn",
-			queue="long",
-			timeout=_AGENT_TURN_WORKER_TIMEOUT,
-			at_front=True,
-			**enqueue_kwargs,
+		# Mismatch guard: pub/sub is fire-and-forget, so publishing with no
+		# live subscriber (config says python but the Node server is the one
+		# running - Frappe Cloud pins node in its supervisor template and
+		# does NOT blacklist this config key - or the realtime process is
+		# down) would strand the turn: hang, then ceiling-error. Verify a
+		# subscriber first; on zero, or any doubt (redis hiccup), fall back
+		# to the RQ path - both dispatch flows are first-class, so RQ is
+		# always a correct executor. The fallback logs loudly: it is a
+		# misconfiguration signal, not a normal mode.
+		listening = False
+		try:
+			listening = dispatch.subscriber_count() > 0
+		except Exception:
+			pass
+		if listening:
+			# Publish AFTER the request transaction commits. Pub/sub delivery
+			# is instant (unlike RQ dequeue latency), so publishing mid-
+			# transaction lets the subscriber greenlet start the turn before
+			# the conversation and user-message rows are visible -
+			# LinkValidationError on the placeholder insert. Mirrors enqueue-
+			# after-commit semantics; caught by the Stage A live smoke.
+			frappe.db.after_commit.add(
+				lambda: dispatch.publish_chat_send(enqueue_kwargs)
+			)
+			return
+		frappe.log_error(
+			title="chat: Path B subscriber missing - dispatched via RQ",
+			message=(
+				"socketio_backend=python but no live subscriber on the chat "
+				"channel (config/process mismatch, or the Python realtime "
+				"process is down). The turn was routed to the RQ worker "
+				"instead, so chat keeps working - but fix the mismatch or "
+				"unset socketio_backend."
+			),
 		)
+	frappe.enqueue(
+		method="jarvis.chat.worker.run_agent_turn",
+		queue="long",
+		timeout=_AGENT_TURN_WORKER_TIMEOUT,
+		at_front=True,
+		**enqueue_kwargs,
+	)
 
 
 def _enqueue_turn(

--- a/jarvis/chat/dispatch.py
+++ b/jarvis/chat/dispatch.py
@@ -32,6 +32,20 @@ def _channel(site: str) -> str:
 	return f"jarvis:chat:send:{site}"
 
 
+def subscriber_count() -> int:
+	"""Live subscriber count on this site's Path B channel (PUBSUB NUMSUB).
+
+	Zero means a publish would be fire-and-forget into nowhere: either the
+	config/process mismatch (``socketio_backend: python`` while the Node
+	server is the one running - e.g. Frappe Cloud, which pins node in its
+	supervisor template) or the Python realtime process is down. The
+	dispatcher uses this to fall back to the RQ path instead of stranding
+	the turn."""
+	res = frappe.cache().pubsub_numsub(_channel(frappe.local.site))
+	# redis returns a list of (channel, count) pairs.
+	return int(res[0][1]) if res else 0
+
+
 def publish_chat_send(payload: dict) -> None:
 	"""Publish a chat turn onto the site-scoped Path B channel.
 

--- a/jarvis/tests/test_realtime_handlers.py
+++ b/jarvis/tests/test_realtime_handlers.py
@@ -228,11 +228,65 @@ class TestDispatch(FrappeTestCase):
 
 		payload = {"conversation_id": "c1", "message_id": "m1", "run_id": "r1"}
 		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
-		     patch("jarvis.chat.dispatch.publish_chat_send") as mock_pub:
+		     patch("jarvis.chat.dispatch.subscriber_count", return_value=1), \
+		     patch("jarvis.chat.dispatch.publish_chat_send") as mock_pub, \
+		     patch("frappe.enqueue") as mock_enqueue:
 			chat_api._dispatch_turn(payload)
 			mock_pub.assert_not_called()  # nothing until the transaction lands
 			frappe.db.commit()
 		mock_pub.assert_called_once_with(payload)
+		mock_enqueue.assert_not_called()
+
+	def test_dispatch_turn_falls_back_to_rq_when_no_subscriber(self):
+		"""The mismatch guard: socketio_backend=python but zero live
+		subscribers (config/process mismatch - e.g. Frappe Cloud pins
+		node - or the realtime process died) must route the turn to RQ
+		and log loudly, never publish into the void."""
+		from jarvis.chat import api as chat_api
+
+		payload = {"conversation_id": "c2", "message_id": "m2", "run_id": "r2"}
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch("jarvis.chat.dispatch.subscriber_count", return_value=0), \
+		     patch("jarvis.chat.dispatch.publish_chat_send") as mock_pub, \
+		     patch("frappe.enqueue") as mock_enqueue, \
+		     patch("frappe.log_error") as mock_log:
+			chat_api._dispatch_turn(payload)
+			frappe.db.commit()  # even after commit: no publish was registered
+		mock_pub.assert_not_called()
+		mock_enqueue.assert_called_once()
+		self.assertEqual(
+			mock_enqueue.call_args.kwargs["method"],
+			"jarvis.chat.worker.run_agent_turn",
+		)
+		mock_log.assert_called_once()
+
+	def test_dispatch_turn_falls_back_to_rq_when_numsub_check_fails(self):
+		"""Any doubt (redis hiccup during the NUMSUB probe) also falls
+		back to RQ - both dispatch flows are first-class, so RQ is always
+		a correct executor."""
+		from jarvis.chat import api as chat_api
+
+		payload = {"conversation_id": "c3", "message_id": "m3", "run_id": "r3"}
+		with patch.object(frappe, "conf", _FakeConf({"socketio_backend": "python"})), \
+		     patch("jarvis.chat.dispatch.subscriber_count",
+		           side_effect=RuntimeError("redis hiccup")), \
+		     patch("jarvis.chat.dispatch.publish_chat_send") as mock_pub, \
+		     patch("frappe.enqueue") as mock_enqueue:
+			chat_api._dispatch_turn(payload)
+			frappe.db.commit()
+		mock_pub.assert_not_called()
+		mock_enqueue.assert_called_once()
+
+	def test_subscriber_count_reads_pubsub_numsub(self):
+		from jarvis.chat import dispatch
+
+		fake_cache = MagicMock()
+		fake_cache.pubsub_numsub.return_value = [(b"jarvis:chat:send:x", 2)]
+		with patch.object(frappe, "cache", return_value=fake_cache):
+			self.assertEqual(dispatch.subscriber_count(), 2)
+		fake_cache.pubsub_numsub.return_value = []
+		with patch.object(frappe, "cache", return_value=fake_cache):
+			self.assertEqual(dispatch.subscriber_count(), 0)
 
 
 class TestChannelFormat(FrappeTestCase):


### PR DESCRIPTION
## Summary

Closes the sharp edge the FC-gate investigation exposed: `socketio_backend: python` is settable anywhere (Frappe Cloud does not blacklist it) but only correct where a Python realtime process actually subscribes. Since pub/sub is fire-and-forget, the mismatch stranded every turn: hang, then ceiling-error.

`_dispatch_turn` now probes `PUBSUB NUMSUB` on the site channel before publishing. A live subscriber: after-commit publish exactly as before. Zero subscribers, or any doubt during the probe (redis hiccup): the turn routes to the RQ worker with a loud Error Log naming the misconfiguration. Both dispatch flows are first-class, so RQ is always a correct executor - the failure mode becomes 'chat works + operator alerted'. All turn sources (send, retry, macro) share the guard since they all route through `_dispatch_turn`.

## Testing
test_realtime_handlers green (after-commit path with subscriber present; zero-subscriber fallback asserts enqueue + Error Log + no publish even after commit; probe-failure fallback; `subscriber_count` NUMSUB parsing) and test_chat_api regression green. Live sanity on the Path B dev bench: turn still dispatches via publish (zero RQ involvement), no fallback logs - the guard does not misfire on a healthy bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)