### PR TITLE
Recovery: bound the transcript window by the next turn's watermark

### DIFF
--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -71,7 +71,7 @@ def _age_minutes(dt) -> float:
 	return delta.total_seconds() / 60.0
 
 
-def _latest_assistant_text(messages: list, *, min_seq: int = 0) -> str:
+def _latest_assistant_text(messages: list, *, min_seq: int = 0, max_seq: int | None = None) -> str:
 	"""Newest assistant message text from a raw transcript. Handles a
 	plain-string content and the {type:"text", text} block list. Sorted by the
 	transcript seq so the latest turn wins. Every text source is type-guarded.
@@ -81,12 +81,21 @@ def _latest_assistant_text(messages: list, *, min_seq: int = 0) -> str:
 	previous turn's reply left over from a run that died server-side with
 	zero output), so it is skipped even if it is the newest assistant message
 	in the transcript. A message with no seq (0) is treated as predating the
-	turn whenever a watermark is in force (min_seq > 0)."""
+	turn whenever a watermark is in force (min_seq > 0).
+
+	``max_seq`` bounds the window from ABOVE: the next turn's watermark
+	(captured before ITS chat.send) marks where this turn's transcript slice
+	ends. Without it, recovering an older parked row after a NEWER turn
+	completed in the same conversation would steal the newer turn's answer
+	(observed live 2026-07-03: the parked row recovered with the next
+	question's reply). Messages with seq > max_seq belong to a later turn."""
 	def seq(m):
 		return ((m or {}).get("__openclaw") or {}).get("seq", 0)
 
 	for m in sorted(messages or [], key=seq, reverse=True):
 		if min_seq > 0 and seq(m) <= min_seq:
+			continue
+		if max_seq is not None and seq(m) > max_seq:
 			continue
 		if (m.get("role") or "").lower() != "assistant":
 			continue
@@ -295,11 +304,34 @@ def _recover_one(sess: OpenclawSession, row: dict, active: dict) -> str:
 		return "active"
 	# Raw transcript (sessions.get), NOT chat.history -> no max_chars truncation (#1).
 	messages = sess.get_session_messages(session_key, limit=50)
-	text = _latest_assistant_text(messages, min_seq=row.get("openclaw_seq_watermark") or 0)
+	text = _latest_assistant_text(
+		messages,
+		min_seq=row.get("openclaw_seq_watermark") or 0,
+		max_seq=_next_turn_watermark(row["conversation"], row["seq"]),
+	)
 	if text:
 		_finalize(row, text)
 		return "finalized"
 	return "waiting"  # no output yet; the ceiling backstop bounds the wait
+
+
+def _next_turn_watermark(conversation: str, seq: int) -> int | None:
+	"""Upper bound for a parked row's transcript window: the smallest
+	watermark among LATER assistant rows in the same conversation (each
+	captured just before that turn's chat.send, so transcript messages
+	past it belong to that later turn). None when there is no later turn
+	(or none with a usable watermark) - then the window stays open-ended,
+	which matches the common single-in-flight-turn case."""
+	val = frappe.db.sql(
+		"""
+		SELECT MIN(openclaw_seq_watermark)
+		FROM `tabJarvis Chat Message`
+		WHERE conversation = %(conv)s AND role = 'assistant'
+		  AND seq > %(seq)s AND openclaw_seq_watermark > 0
+		""",
+		{"conv": conversation, "seq": seq},
+	)[0][0]
+	return int(val) if val else None
 
 
 def recover_now(conversation_id: str) -> str:

--- a/jarvis/tests/test_turn_recovery.py
+++ b/jarvis/tests/test_turn_recovery.py
@@ -380,6 +380,79 @@ class TestTurnRecovery(FrappeTestCase):
 		], min_seq=7)
 		self.assertEqual(text, "new")
 
+	# --- upper bound: never steal a LATER turn's answer (live catch,
+	# --- 2026-07-03: a parked row recovered with the next question's reply)
+
+	def test_latest_assistant_text_max_seq_excludes_later_turns_message(self):
+		msgs = [
+			{"role": "assistant", "__openclaw": {"seq": 2}, "content": "GOLF"},
+			{"role": "assistant", "__openclaw": {"seq": 4}, "content": "HOTEL"},
+		]
+		self.assertEqual(
+			turn_recovery._latest_assistant_text(msgs, min_seq=0, max_seq=2), "GOLF"
+		)
+		self.assertEqual(
+			turn_recovery._latest_assistant_text(msgs, min_seq=0), "HOTEL"
+		)
+
+	def _add_later_assistant_row(self, watermark: int):
+		"""A completed later turn in the same conversation whose watermark
+		(captured before ITS send) caps the parked row's window."""
+		seq0 = frappe.db.get_value(MSG_DT, self.msg.name, "seq")
+		doc = frappe.get_doc({
+			"doctype": MSG_DT, "conversation": self.conv.name,
+			"seq": (seq0 or 0) + 2, "role": "assistant",
+			"content": "HOTEL", "streaming": 0,
+		})
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(MSG_DT, doc.name, "openclaw_seq_watermark", watermark)
+		frappe.db.commit()
+		return doc
+
+	def test_recovery_bounded_by_next_turns_watermark(self):
+		"""Parked row's own reply IS in the transcript window: recovery
+		must take it, not the later turn's newer reply."""
+		self._add_later_assistant_row(watermark=2)
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "GOLF", "__openclaw": {"seq": 2}},
+			{"role": "assistant", "content": "HOTEL", "__openclaw": {"seq": 4}},
+		]})
+		self._run(sess)
+		row = self._row()
+		self.assertEqual(row.content, "GOLF")
+		self.assertEqual(row.streaming, 0)
+		self.assertEqual(row.recovering, 0)
+
+	def test_recovery_waits_when_window_empty_instead_of_stealing(self):
+		"""Parked row's reply is genuinely lost (window empty); a later
+		turn's reply exists past the bound. Recovery must WAIT (ceiling
+		errors it later), never stamp the later answer onto this row."""
+		self._add_later_assistant_row(watermark=2)
+		sess = self._fake_sess(messages_by_key={SK: [
+			{"role": "assistant", "content": "HOTEL", "__openclaw": {"seq": 4}},
+		]})
+		_, pub = self._run(sess)
+		row = self._row()
+		self.assertEqual(row.streaming, 1)
+		self.assertEqual(row.recovering, 1)
+		self.assertNotEqual(row.content, "HOTEL")
+		self.assertNotIn("run:end", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	def test_next_turn_watermark_none_without_later_usable_row(self):
+		self.assertIsNone(
+			turn_recovery._next_turn_watermark(
+				self.conv.name,
+				frappe.db.get_value(MSG_DT, self.msg.name, "seq"),
+			)
+		)
+		self._add_later_assistant_row(watermark=0)  # unusable: never captured
+		self.assertIsNone(
+			turn_recovery._next_turn_watermark(
+				self.conv.name,
+				frappe.db.get_value(MSG_DT, self.msg.name, "seq"),
+			)
+		)
+
 	def test_recover_now_idempotent_after_finalize_no_double_publish(self):
 		sess = self._fake_sess(messages_by_key={SK: [
 			{"role": "assistant", "content": "the full answer", "__openclaw": {"seq": 2}},


### PR DESCRIPTION
## Summary

Live probe catch from the send-during-recovery verification: recovering an older parked row after a NEWER turn completed in the same conversation **stole the newer turn's answer** - `_latest_assistant_text` had a lower watermark bound but nothing above, so the latest transcript text always won. A user's stuck question would silently receive the answer to their next question.

The recovery window is now capped by the smallest watermark among later assistant rows in the conversation (each captured before its own `chat.send`, so it marks exactly where the parked turn's transcript slice ends). An empty window waits - the 60-minute ceiling errors it honestly - instead of stealing. The single-in-flight-turn case (no later row) is provably unchanged.

Verified live in both directions: the identical park-then-new-send scenario recovered the WRONG text before the fix and the parked turn's own text after it.

## Review
Approved, zero findings. Hand-traced: watermark monotonicity makes MIN the tightest correct bound; the `> 0` filter excludes failed captures with no silent-zero edge; both recovery entry points carry the needed fields; no other `_latest_assistant_text` caller needs the bound. The one inherent tradeoff (a genuinely-late server-side completion past a second turn's bound waits to the ceiling instead of finalizing) trades a rare bounded visible wait for eliminating a definite silent-wrong-answer bug.

## Testing
test_turn_recovery green including four new tests pinning the live scenario: bounded-take, empty-window-waits (with the no-publish assertion), unit `max_seq`, and unusable-watermark handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)