### PR TITLE
Session lifecycle Phase 1: dormant rotation + orphan sweep

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -398,6 +398,26 @@ class OpenclawSession:
 				return bool(s.get("hasActiveRun"))
 		return False
 
+	def list_sessions(
+		self, *, timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> list[dict]:
+		"""Every session the gateway is tracking (sessions.list rows:
+		key, hasActiveRun, updatedAt, label, ...). Used by the session
+		lifecycle sweep to find orphaned throwaway sessions."""
+		res = self._request("sessions.list", {}, timeout_s=timeout_s)
+		return (res.get("payload") or {}).get("sessions") or []
+
+	def delete_session(
+		self, session_key: str, *, timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> None:
+		"""Remove a session's gateway state via ``sessions.delete``
+		(transcript is archived gateway-side first; ``deleteTranscript``
+		defaults true there). The gateway refuses to delete the agent's
+		main session - callers treat that error as a skip, never retry."""
+		self._request(
+			"sessions.delete", {"key": session_key}, timeout_s=timeout_s,
+		)
+
 	def set_session_model(
 		self, session_key: str, model_ref: str,
 		*, timeout_s: float = CONNECT_TIMEOUT_SECONDS,

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -1,0 +1,201 @@
+"""Session lifecycle Phase 1: dormant-session rotation + orphan sweep.
+
+Every Jarvis Conversation maps to one openclaw session, created lazily on
+the first turn and - before this module - never rotated or deleted. Two
+kinds of gateway state accumulate forever:
+
+- Dormant conversation sessions: the user stopped chatting weeks ago but
+  the session (and its growing working context) sits on the container.
+- Orphaned throwaway sessions: every auto-title generation and every
+  prefix prewarm creates a single-use session, and deleted conversations
+  leave their sessions behind. The dev tenant had 81 session state files
+  after one month.
+
+The bench is the durable owner of chat history (Jarvis Chat Message
+rows); the openclaw session is a cache of working context, not the
+record. Deleting one is safe: the gateway archives the transcript first
+(sessions.delete deleteTranscript=true default), canvas/media artifacts
+were pulled to ERP Files at turn end, and the next message in a rotated
+conversation lazily creates a fresh session through the existing
+``_ensure_session_key`` path - same UX, empty working context.
+
+The daily ``rotate_dormant_sessions`` cron:
+
+1. DORMANT: conversations idle past ``DORMANT_DAYS`` with a session_key
+   and no in-flight rows -> delete the gateway session, clear
+   ``conv.session_key``, drop the ``Jarvis Chat Session`` lookup rows.
+2. ORPHANS: gateway sessions in the chat namespace that no conversation
+   references (title/prewarm throwaways, deleted conversations) and that
+   have been inactive past ``ORPHAN_GRACE_HOURS`` -> delete, plus any
+   stale lookup rows.
+
+Everything is best-effort on a dedicated connection (never the pool - a
+sweep must not contend with live turns), batch-capped so a backlog
+drains over days instead of stampeding a gateway, and managed-mode only.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+import frappe
+
+logger = logging.getLogger(__name__)
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+CHAT_SESSION = "Jarvis Chat Session"
+
+# A conversation idle this long gets its session rotated. Matches the
+# fleet's archive_retention_days default so there is one retention story.
+DORMANT_DAYS = 30
+
+# An unreferenced gateway session younger than this is skipped: it may be
+# an in-flight title/prewarm throwaway, or a conversation whose freshly
+# created session_key has not committed yet.
+ORPHAN_GRACE_HOURS = 24
+
+# Per-run cap across BOTH parts, so a month of backlog drains over a few
+# days instead of hammering the gateway in one cron tick.
+BATCH_MAX = 25
+
+# Only sessions in the chat namespace are ever considered for the orphan
+# sweep; the agent's main session is additionally refused server-side.
+_CHAT_NAMESPACE_MARKER = ":dashboard:"
+
+
+def rotate_dormant_sessions() -> dict:
+	"""Daily cron: rotate dormant conversation sessions and reap orphaned
+	throwaway sessions. Returns a summary dict (also logged) so a manual
+	``bench execute`` run shows what happened."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		return {"skipped": "self-hosted"}
+
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace(
+		"http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return {"skipped": "no agent_url"}
+
+	from jarvis.chat.openclaw_client import OpenclawSession
+
+	summary = {"dormant_rotated": 0, "orphans_reaped": 0, "skipped": 0, "errors": 0}
+	budget = BATCH_MAX
+	try:
+		sess = OpenclawSession.connect(gateway_url)
+	except Exception:
+		frappe.log_error(
+			title="session_lifecycle: connect failed",
+			message=frappe.get_traceback(),
+		)
+		return {"skipped": "connect failed"}
+	try:
+		budget = _rotate_dormant(sess, budget, summary)
+		if budget > 0:
+			_reap_orphans(sess, budget, summary)
+	finally:
+		try:
+			sess.close()
+		except Exception:
+			pass
+	logger.info("session_lifecycle: %s", summary)
+	return summary
+
+
+def _rotate_dormant(sess, budget: int, summary: dict) -> int:
+	"""Part 1: conversations idle past DORMANT_DAYS. Returns leftover
+	budget for the orphan sweep."""
+	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-DORMANT_DAYS)
+	rows = frappe.db.sql(
+		"""
+		SELECT c.name, c.session_key
+		FROM `tabJarvis Conversation` c
+		WHERE c.session_key IS NOT NULL AND c.session_key != ''
+		  AND c.last_active_at IS NOT NULL AND c.last_active_at < %(cutoff)s
+		  AND NOT EXISTS (
+			SELECT 1 FROM `tabJarvis Chat Message` m
+			WHERE m.conversation = c.name
+			  AND (m.streaming = 1 OR m.recovering = 1)
+		  )
+		ORDER BY c.last_active_at ASC
+		LIMIT %(limit)s
+		""",
+		{"cutoff": cutoff, "limit": budget},
+		as_dict=True,
+	)
+	for row in rows:
+		if budget <= 0:
+			break
+		budget -= 1
+		if _delete_gateway_session(sess, row.session_key, summary):
+			# Only detach the bench side once the gateway side is gone,
+			# so a failed delete retries on the next run. NULL, not "":
+			# session_key is UNIQUE and two "" rows would collide.
+			frappe.db.set_value(CONV, row.name, "session_key", None)
+			frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
+			frappe.db.commit()
+			summary["dormant_rotated"] += 1
+	return budget
+
+
+def _reap_orphans(sess, budget: int, summary: dict) -> None:
+	"""Part 2: chat-namespace gateway sessions no conversation references
+	(title/prewarm throwaways, deleted conversations), inactive past the
+	grace window and with no active run."""
+	try:
+		entries = sess.list_sessions()
+	except Exception:
+		frappe.log_error(
+			title="session_lifecycle: sessions.list failed",
+			message=frappe.get_traceback(),
+		)
+		summary["errors"] += 1
+		return
+	known = {
+		k for (k,) in frappe.db.sql(
+			"SELECT session_key FROM `tabJarvis Conversation` "
+			"WHERE session_key IS NOT NULL AND session_key != ''"
+		)
+	}
+	grace_ms = ORPHAN_GRACE_HOURS * 3600 * 1000
+	now_ms = int(time.time() * 1000)
+	for entry in entries:
+		if budget <= 0:
+			return
+		key = entry.get("key") or ""
+		if _CHAT_NAMESPACE_MARKER not in key or key in known:
+			continue
+		if entry.get("hasActiveRun"):
+			summary["skipped"] += 1
+			continue
+		updated = entry.get("updatedAt")
+		if not isinstance(updated, (int, float)) or (now_ms - updated) < grace_ms:
+			# No usable activity timestamp -> conservative skip; a fresh
+			# throwaway or a just-created conversation session survives.
+			summary["skipped"] += 1
+			continue
+		budget -= 1
+		if _delete_gateway_session(sess, key, summary):
+			# Deleted-conversation case: the lookup row may still exist.
+			frappe.db.delete(CHAT_SESSION, {"session_key": key})
+			frappe.db.commit()
+			summary["orphans_reaped"] += 1
+
+
+def _delete_gateway_session(sess, session_key: str, summary: dict) -> bool:
+	"""Best-effort sessions.delete. False (and an Error Log) on failure so
+	the caller leaves the bench pointers intact for a retry next run. The
+	gateway's refusal to delete the main session lands here as a normal
+	failure - logged once per run at most per key, never fatal."""
+	try:
+		sess.delete_session(session_key)
+		return True
+	except Exception:
+		frappe.log_error(
+			title="session_lifecycle: sessions.delete failed",
+			message=f"session_key={session_key}\n{frappe.get_traceback()}",
+		)
+		summary["errors"] += 1
+		return False

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -127,16 +127,28 @@ def _rotate_dormant(sess, budget: int, summary: dict) -> int:
 	)
 	for row in rows:
 		if budget <= 0:
-			break
+			break  # defensive; the SQL LIMIT already bounds rows to budget
 		budget -= 1
-		if _delete_gateway_session(sess, row.session_key, summary):
-			# Only detach the bench side once the gateway side is gone,
-			# so a failed delete retries on the next run. NULL, not "":
-			# session_key is UNIQUE and two "" rows would collide.
-			frappe.db.set_value(CONV, row.name, "session_key", None)
-			frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
-			frappe.db.commit()
-			summary["dormant_rotated"] += 1
+		# Per-row isolation (turn_recovery's loop pattern): one bad row
+		# must never abort the rest of the batch, and a failure between
+		# the gateway delete and the local commit must not strand the
+		# sweep - the idempotent not-found handling in
+		# _delete_gateway_session lets the next run finish the cleanup.
+		try:
+			if _delete_gateway_session(sess, row.session_key, summary):
+				# Only detach the bench side once the gateway side is
+				# gone. NULL, not "": session_key is UNIQUE and two ""
+				# rows would collide.
+				frappe.db.set_value(CONV, row.name, "session_key", None)
+				frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
+				frappe.db.commit()
+				summary["dormant_rotated"] += 1
+		except Exception:
+			frappe.log_error(
+				title="session_lifecycle: dormant row cleanup failed",
+				message=f"conversation={row.name}\n{frappe.get_traceback()}",
+			)
+			summary["errors"] += 1
 	return budget
 
 
@@ -177,11 +189,18 @@ def _reap_orphans(sess, budget: int, summary: dict) -> None:
 			summary["skipped"] += 1
 			continue
 		budget -= 1
-		if _delete_gateway_session(sess, key, summary):
-			# Deleted-conversation case: the lookup row may still exist.
-			frappe.db.delete(CHAT_SESSION, {"session_key": key})
-			frappe.db.commit()
-			summary["orphans_reaped"] += 1
+		try:
+			if _delete_gateway_session(sess, key, summary):
+				# Deleted-conversation case: the lookup row may still exist.
+				frappe.db.delete(CHAT_SESSION, {"session_key": key})
+				frappe.db.commit()
+				summary["orphans_reaped"] += 1
+		except Exception:
+			frappe.log_error(
+				title="session_lifecycle: orphan cleanup failed",
+				message=f"session_key={key}\n{frappe.get_traceback()}",
+			)
+			summary["errors"] += 1
 
 
 def _delete_gateway_session(sess, session_key: str, summary: dict) -> bool:
@@ -192,7 +211,13 @@ def _delete_gateway_session(sess, session_key: str, summary: dict) -> bool:
 	try:
 		sess.delete_session(session_key)
 		return True
-	except Exception:
+	except Exception as e:
+		# Idempotent: a session that is ALREADY gone counts as success.
+		# This self-heals the crashed-between-delete-and-commit window -
+		# the next run's delete "fails" as not-found and the bench
+		# pointers finally get cleared instead of sticking forever.
+		if "not found" in str(e).lower() or "unknown session" in str(e).lower():
+			return True
 		frappe.log_error(
 			title="session_lifecycle: sessions.delete failed",
 			message=f"session_key={session_key}\n{frappe.get_traceback()}",

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -186,6 +186,10 @@ scheduler_events = {
 		"jarvis.chat.turn_recovery.recovery_rate_watch",
 	],
 	"daily": [
+		# Session lifecycle Phase 1: rotate dormant conversations' openclaw
+		# sessions and reap orphaned throwaway sessions (title/prewarm,
+		# deleted conversations). Batch-capped; bench history untouched.
+		"jarvis.chat.session_lifecycle.rotate_dormant_sessions",
 		"jarvis.onboarding.sync_connection",
 		# C2 (2026-06-16 review): nudge operators when the bench's
 		# agent_token is approaching or past its configured max age.

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -1,0 +1,216 @@
+"""Tests for jarvis.chat.session_lifecycle (Phase 1: dormant rotation +
+orphan sweep).
+
+The sweep talks to the gateway only through OpenclawSession.connect (a
+dedicated connection, never the pool), so tests patch ``connect`` with a
+fake session exposing list_sessions/delete_session/close. Conversations
+and messages are real rows on the test site.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import session_lifecycle
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+CHAT_SESSION = "Jarvis Chat Session"
+
+NOW_MS = int(time.time() * 1000)
+OLD_MS = NOW_MS - (session_lifecycle.ORPHAN_GRACE_HOURS + 2) * 3600 * 1000
+
+
+def _fake_sess(entries=None):
+	sess = MagicMock()
+	sess.list_sessions.return_value = entries or []
+	return sess
+
+
+class TestSessionLifecycle(FrappeTestCase):
+	def setUp(self):
+		self._made = []
+		# The sweep is site-global: park every pre-existing candidate so
+		# only THIS test's fixtures are eligible (mirrors the recovery
+		# rate-watch tests' residue-neutralizing setUp).
+		frappe.db.sql(
+			"UPDATE `tabJarvis Conversation` SET session_key = NULL "
+			"WHERE session_key IS NOT NULL"
+		)
+		# Residue from aborted earlier runs would 1062 on re-insert.
+		frappe.db.delete(CHAT_SESSION, {"session_key": ["like", "test-lc-%"]})
+		# The sweep bails without an agent_url; pin one for the run.
+		self._orig_agent_url = frappe.db.get_single_value(
+			"Jarvis Settings", "agent_url")
+		frappe.db.set_single_value(
+			"Jarvis Settings", "agent_url", "http://gw.test:18789")
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		frappe.db.commit()
+
+	def tearDown(self):
+		for name in self._made:
+			frappe.db.delete(MSG, {"conversation": name})
+			frappe.db.delete(CONV, {"name": name})
+		frappe.db.delete(CHAT_SESSION, {"session_key": ["like", "test-lc-%"]})
+		frappe.db.set_single_value(
+			"Jarvis Settings", "agent_url", self._orig_agent_url or "")
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		frappe.db.commit()
+
+	def _conv(self, *, session_key: str, idle_days: int, streaming: bool = False):
+		doc = frappe.get_doc({
+			"doctype": CONV, "title": f"lc-{session_key}",
+		}).insert(ignore_permissions=True)
+		self._made.append(doc.name)
+		frappe.db.set_value(CONV, doc.name, {
+			"session_key": session_key,
+			"last_active_at": frappe.utils.add_to_date(
+				frappe.utils.now_datetime(), days=-idle_days),
+		})
+		if streaming:
+			frappe.get_doc({
+				"doctype": MSG, "conversation": doc.name, "seq": 1,
+				"role": "assistant", "content": "", "streaming": 1,
+			}).insert(ignore_permissions=True)
+		frappe.get_doc({
+			"doctype": CHAT_SESSION, "session_key": session_key,
+			"user": "Administrator", "chat_device_id": "d1",
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc.name
+
+	def _run(self, sess):
+		with patch(
+			"jarvis.chat.openclaw_client.OpenclawSession.connect",
+			return_value=sess,
+		), patch("jarvis.selfhost.is_self_hosted", return_value=False):
+			return session_lifecycle.rotate_dormant_sessions()
+
+	# ---- dormant rotation -------------------------------------------
+
+	def test_dormant_conversation_rotated(self):
+		name = self._conv(session_key="test-lc-dormant", idle_days=40)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 1)
+		sess.delete_session.assert_any_call("test-lc-dormant")
+		self.assertFalse(frappe.db.get_value(CONV, name, "session_key"))
+		self.assertFalse(
+			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-dormant"})
+		)
+
+	def test_fresh_conversation_untouched(self):
+		name = self._conv(session_key="test-lc-fresh", idle_days=2)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 0)
+		sess.delete_session.assert_not_called()
+		self.assertEqual(
+			frappe.db.get_value(CONV, name, "session_key"), "test-lc-fresh"
+		)
+
+	def test_dormant_with_inflight_row_skipped(self):
+		name = self._conv(
+			session_key="test-lc-busy", idle_days=40, streaming=True)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 0)
+		sess.delete_session.assert_not_called()
+		self.assertEqual(
+			frappe.db.get_value(CONV, name, "session_key"), "test-lc-busy"
+		)
+
+	def test_gateway_delete_failure_keeps_bench_pointers(self):
+		"""A failed sessions.delete must leave session_key and the lookup
+		row intact so the next run retries."""
+		name = self._conv(session_key="test-lc-fail", idle_days=40)
+		sess = _fake_sess()
+		sess.delete_session.side_effect = RuntimeError("gateway said no")
+		with patch("frappe.log_error"):
+			summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 0)
+		self.assertEqual(summary["errors"], 1)
+		self.assertEqual(
+			frappe.db.get_value(CONV, name, "session_key"), "test-lc-fail"
+		)
+		self.assertTrue(
+			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-fail"})
+		)
+
+	# ---- orphan sweep -----------------------------------------------
+
+	def test_orphan_throwaway_reaped(self):
+		sess = _fake_sess(entries=[{
+			"key": "test-lc-orph:dashboard:o1",
+			"hasActiveRun": False, "updatedAt": OLD_MS,
+		}])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 1)
+		sess.delete_session.assert_any_call("test-lc-orph:dashboard:o1")
+
+	def test_referenced_session_never_reaped(self):
+		self._conv(session_key="test-lc-ref:dashboard:live-1", idle_days=2)
+		sess = _fake_sess(entries=[{
+			"key": "test-lc-ref:dashboard:live-1",
+			"hasActiveRun": False, "updatedAt": OLD_MS,
+		}])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 0)
+		sess.delete_session.assert_not_called()
+
+	def test_recent_or_active_or_foreign_orphans_skipped(self):
+		sess = _fake_sess(entries=[
+			# Inside grace: may be an in-flight title/prewarm throwaway.
+			{"key": "test-lc-orph:dashboard:young", "hasActiveRun": False,
+			 "updatedAt": NOW_MS},
+			# Active run: never touch.
+			{"key": "test-lc-orph:dashboard:running", "hasActiveRun": True,
+			 "updatedAt": OLD_MS},
+			# No usable timestamp: conservative skip.
+			{"key": "test-lc-orph:dashboard:nots", "hasActiveRun": False},
+			# Outside the chat namespace: not ours to manage.
+			{"key": "agent:main:main", "hasActiveRun": False,
+			 "updatedAt": OLD_MS},
+		])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 0)
+		sess.delete_session.assert_not_called()
+
+	def test_batch_cap_bounds_total_work(self):
+		for i in range(3):
+			self._conv(session_key=f"test-lc-batch-{i}", idle_days=40)
+		entries = [{
+			"key": f"test-lc-orph:dashboard:b{i}",
+			"hasActiveRun": False, "updatedAt": OLD_MS,
+		} for i in range(3)]
+		sess = _fake_sess(entries=entries)
+		with patch.object(session_lifecycle, "BATCH_MAX", 4):
+			summary = self._run(sess)
+		# 3 dormant + only 1 orphan fit in the budget of 4.
+		self.assertEqual(summary["dormant_rotated"], 3)
+		self.assertEqual(summary["orphans_reaped"], 1)
+		self.assertEqual(sess.delete_session.call_count, 4)
+
+	# ---- gating ------------------------------------------------------
+
+	def test_self_hosted_early_return(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True), \
+		     patch(
+			"jarvis.chat.openclaw_client.OpenclawSession.connect",
+		) as connect:
+			summary = session_lifecycle.rotate_dormant_sessions()
+		self.assertEqual(summary, {"skipped": "self-hosted"})
+		connect.assert_not_called()
+
+	def test_connect_failure_is_a_clean_skip(self):
+		self._conv(session_key="test-lc-x", idle_days=40)
+		with patch(
+			"jarvis.chat.openclaw_client.OpenclawSession.connect",
+			side_effect=RuntimeError("refused"),
+		), patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+		     patch("frappe.log_error"):
+			summary = session_lifecycle.rotate_dormant_sessions()
+		self.assertEqual(summary, {"skipped": "connect failed"})

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -102,6 +102,16 @@ class TestSessionLifecycle(FrappeTestCase):
 			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-dormant"})
 		)
 
+	def test_two_rotations_in_one_run_no_unique_collision(self):
+		"""Regression: session_key is UNIQUE; clearing to '' (instead of
+		NULL) collided on the SECOND rotation of a run (1062)."""
+		a = self._conv(session_key="test-lc-two-a", idle_days=40)
+		b = self._conv(session_key="test-lc-two-b", idle_days=41)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["dormant_rotated"], 2)
+		self.assertFalse(frappe.db.get_value(CONV, a, "session_key"))
+		self.assertFalse(frappe.db.get_value(CONV, b, "session_key"))
+
 	def test_fresh_conversation_untouched(self):
 		name = self._conv(session_key="test-lc-fresh", idle_days=2)
 		sess = _fake_sess()

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -150,6 +150,41 @@ class TestSessionLifecycle(FrappeTestCase):
 			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-fail"})
 		)
 
+	def test_not_found_delete_treated_as_success(self):
+		"""Idempotent cleanup: a session already gone (e.g. a prior run
+		crashed between the gateway delete and the local commit) counts
+		as deleted, so the bench pointers finally clear instead of
+		retry-failing forever."""
+		name = self._conv(session_key="test-lc-gone", idle_days=40)
+		sess = _fake_sess()
+		sess.delete_session.side_effect = RuntimeError(
+			"gateway error: session not found: test-lc-gone")
+		summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 1)
+		self.assertEqual(summary["errors"], 0)
+		self.assertFalse(frappe.db.get_value(CONV, name, "session_key"))
+
+	def test_one_bad_row_does_not_abort_the_batch(self):
+		"""Per-row isolation (turn_recovery's loop pattern): a bench-side
+		cleanup failure on row 1 logs and continues to row 2."""
+		a = self._conv(session_key="test-lc-bad", idle_days=41)
+		b = self._conv(session_key="test-lc-good", idle_days=40)
+		sess = _fake_sess()
+		real_set_value = frappe.db.set_value
+
+		def flaky_set_value(dt, name, *args, **kwargs):
+			if name == a:
+				raise RuntimeError("simulated deadlock")
+			return real_set_value(dt, name, *args, **kwargs)
+
+		with patch("frappe.db.set_value", side_effect=flaky_set_value), \
+		     patch("frappe.log_error") as log_err:
+			summary = self._run(sess)
+		self.assertEqual(summary["dormant_rotated"], 1)
+		self.assertEqual(summary["errors"], 1)
+		log_err.assert_called()
+		self.assertFalse(frappe.db.get_value(CONV, b, "session_key"))
+
 	# ---- orphan sweep -----------------------------------------------
 
 	def test_orphan_throwaway_reaped(self):


### PR DESCRIPTION
## Summary

Implements Phase 1 of the session-lifecycle spec: openclaw sessions stop accumulating forever.

- **Dormant rotation** (daily cron): conversations idle past 30 days get their gateway session deleted (openclaw archives the transcript first - verified in source) and `session_key` cleared to NULL (UNIQUE column; the tests caught the `""` collision). The next message lazily creates a fresh session through the existing `_ensure_session_key` path - same UX, empty working context, bench history untouched.
- **Orphan sweep**: chat-namespace sessions nobody references (title/prewarm throwaways, deleted conversations) reaped after a 24 h grace, skipping active runs and entries without usable timestamps. The namespace rule and the main-session server-side refusal were both verified against openclaw source, not assumed.
- Batch-capped at 25/run on a dedicated connection (never the pool), managed-only, per-row failure isolation (one bad row logs and continues), idempotent not-found deletes (a crash between gateway delete and local commit self-heals next run), stale `Jarvis Chat Session` lookup rows dropped alongside.

## Live smoke (dev tenant)
One real run: **158 → 145 session files** (1 seeded-dormant + 12 genuine orphans; 55 younger orphans correctly grace-held), zero errors, exact arithmetic. The rotated conversation then streamed its next turn on a lazily-created fresh session.

## Review
Hand-traced budget math (total deletes provably <= cap), orphan-rule safety against openclaw's actual key formats (dashboard namespace vs main vs cron keys), NULL-consistency across every `session_key` consumer. Its one Important finding (per-row isolation + the stuck-pointer window) and both Minors are fixed in the follow-up commits.

## Testing
test_session_lifecycle 13/13: rotation, freshness/in-flight skips, delete-failure pointer retention, double-rotation UNIQUE regression, orphan reap + reference/grace/active/namespace guards, batch cap, not-found idempotency, one-bad-row batch continuation, self-hosted + connect-failure gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)