### PR TITLE
perf(chat): fold the current fiscal year into the per-turn context line

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -312,6 +312,21 @@ def _org_locale_clause() -> str:
 		parts.append(f"org: {name}" + (f" ({region})" if region else ""))
 	elif region:
 		parts.append(f"region: {region}")
+	# Current fiscal year, so accounting turns don't burn a provider
+	# round trip on jarvis__get_fiscal_year (observed 3 calls in one P&L
+	# turn on the fleet transcript, ~6s each on the codex runtime). Its
+	# own guard: no ERPNext / no Fiscal Year record degrades to no clause.
+	fiscal = ""
+	try:
+		from erpnext.accounts.utils import get_fiscal_year
+
+		fy = get_fiscal_year(frappe.utils.nowdate(), company=company or None, as_dict=True)
+		if fy and fy.get("name"):
+			fiscal = f"fy {fy.get('name')} ({fy.get('year_start_date')}..{fy.get('year_end_date')})"
+	except Exception:
+		fiscal = ""
+	if fiscal:
+		parts.append(fiscal)
 	if date_format:
 		parts.append(f"dates {date_format}")
 	if number_format:

--- a/jarvis/tests/test_turn_handler.py
+++ b/jarvis/tests/test_turn_handler.py
@@ -153,13 +153,18 @@ class TestOrgLocaleClause(unittest.TestCase):
 	date / number / timezone formats into the context line so the agent
 	stops defaulting to US conventions; any read failure degrades to ''."""
 
-	def _run(self, *, company, cached=None, singles=None, default=None):
+	def _run(self, *, company, cached=None, singles=None, default=None, fiscal=None):
 		cached = cached or {}
 		singles = singles or {}
+		# get_fiscal_year is patched in ALL cases so the base locale tests stay
+		# deterministic on sites that carry a real Fiscal Year; pass ``fiscal``
+		# (a dict) to opt into a mocked FY, default raises -> no fy clause.
+		fy_kwargs = {"return_value": fiscal} if fiscal is not None else {"side_effect": RuntimeError("no fy")}
 		with patch("frappe.defaults.get_global_default", return_value=company), \
 			patch("frappe.get_cached_value", side_effect=lambda dt, name, field: cached.get(field, "")), \
 			patch("frappe.db.get_single_value", side_effect=lambda dt, field: singles.get(field, "")), \
-			patch("frappe.db.get_default", return_value=default):
+			patch("frappe.db.get_default", return_value=default), \
+			patch("erpnext.accounts.utils.get_fiscal_year", **fy_kwargs):
 			return turn_handler._org_locale_clause()
 
 	def test_full_company_locale(self):
@@ -193,6 +198,25 @@ class TestOrgLocaleClause(unittest.TestCase):
 		self.assertIn("...", clause)  # truncation marker
 		self.assertNotIn("Private Limited", clause)  # long tail dropped
 		self.assertIn("(India, INR)", clause)
+
+	def test_fiscal_year_folded_in(self):
+		"""The current fiscal year rides the locale clause so accounting
+		turns don't spend a provider round trip on jarvis__get_fiscal_year."""
+		clause = self._run(
+			company="Acme Ltd",
+			cached={"country": "India", "default_currency": "INR"},
+			fiscal={"name": "2026-2027", "year_start_date": "2026-04-01", "year_end_date": "2027-03-31"},
+		)
+		self.assertIn("fy 2026-2027 (2026-04-01..2027-03-31)", clause)
+
+	def test_fiscal_year_failure_degrades_silently(self):
+		"""No Fiscal Year record (or no ERPNext) must not break the clause."""
+		clause = self._run(
+			company="Acme Ltd",
+			cached={"country": "India", "default_currency": "INR"},
+		)
+		self.assertIn("org: Acme Ltd (India, INR)", clause)
+		self.assertNotIn("fy ", clause)
 
 	def test_read_failure_yields_empty_clause(self):
 		with patch("frappe.defaults.get_global_default", side_effect=RuntimeError("db down")):


### PR DESCRIPTION
## Why
Fleet-transcript review of a 210s P&L turn (codex runtime) showed the agent calling `jarvis__get_fiscal_year` up to **three times in one accounting turn** — each one a full provider round trip (6–8s each observed; up to ~30s with cold context). The information is static per site/day.

## What
The per-turn `[Context: …]` line (already carrying today, org, locale, tz) now also carries the current fiscal year:

```
[Context: today is 2026-07-03 (Friday); org: Aerele Technologies... (India, INR); fy 2026-2027 (2026-04-01..2027-03-31); dates dd-mm-yyyy; ...]
```

via `erpnext.accounts.utils.get_fiscal_year`, guarded by its own try/except: no ERPNext or no Fiscal Year record degrades to no clause, never a broken turn.

## Tests
- `test_fiscal_year_folded_in`, `test_fiscal_year_failure_degrades_silently`
- The `_run` helper now pins `get_fiscal_year` deterministically — the base locale tests were silently exercising the live site's real Fiscal Year.
- `TestOrgLocaleClause`: 7/7 pass. (The unrelated `TestHandleChatSendAcceptsPayloadDict` failure is pre-existing on main — verified identical on a clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)