### PR TITLE
Chore: gitignore local venvs and logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ frontend/components.d.ts
 # Brainstorm mockups + design specs (local working docs — never commit)
 .superpowers/
 docs/superpowers/
+
+# Local virtualenvs + logs
+.venv/
+logs/
+*.log


### PR DESCRIPTION
Adds .venv/, logs/, *.log to the already-comprehensive ignore set (graphify-out/, .superpowers/, build outputs were covered). No tracked files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)