### PR TITLE
fix(oauth): pool sign-ins request the codex-CLI scope (no connectors)

### DIFF
--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -183,6 +183,10 @@ def _begin_signin(provider: str, model: str, *, pool: bool) -> dict:
 		redirect_uri=_REDIRECT_URI,
 		code_challenge=challenge,
 		state=state,
+		# Pool accounts feed cli-proxy-api, which needs the codex-scope
+		# token audience; the direct flow keeps the connectors scope for
+		# openclaw's own codex path. See providers.py pool_scope.
+		pool=pool,
 	)
 
 	entry = {

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -22,6 +22,16 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		"token":     "https://auth.openai.com/oauth/token",
 		"userinfo":  "https://api.openai.com/v1/userinfo",
 		"scope":     "openid profile email offline_access api.connectors.read api.connectors.invoke",
+		# POOL sign-ins (CLIProxyAPI subscription accounts) MUST use the
+		# codex-CLI scope set - no connectors scopes. The connectors scope
+		# yields an access_token with aud=https://api.openai.com/v1 (fine for
+		# openclaw's codex app-server, which is why the DIRECT flow keeps it),
+		# but cli-proxy-api's codex backend needs aud=chatgpt.com/backend-api
+		# and rejects the connectors-audience token: the account loads, then
+		# /v1/models returns [] and every call 502s "unknown provider".
+		# Live-verified 2026-07-03; this scope set is exactly what
+		# cli-proxy-api's own --codex-login requests.
+		"pool_scope": "openid email profile offline_access",
 		# openclaw_provider keys the auth-profiles.json entry that openclaw
 		# looks up at request time. After fix/oauth-model-provider-key on
 		# fleet-agent + fix/chat-worker-mapped-model-provider on this app,
@@ -117,14 +127,20 @@ def extract_account_id(provider: str, access_token: str) -> str:
 
 
 def build_authorize_url(*, provider: str, redirect_uri: str,
-                         code_challenge: str, state: str) -> str:
-	"""Construct the /oauth/authorize URL with all required parameters."""
+                         code_challenge: str, state: str,
+                         pool: bool = False) -> str:
+	"""Construct the /oauth/authorize URL with all required parameters.
+
+	``pool=True`` selects the provider's ``pool_scope`` when it defines one
+	(subscription-pool accounts consumed by cli-proxy-api need a different
+	token audience than the direct openclaw flow - see the OpenAI entry).
+	"""
 	p = get_provider(provider)
 	params = {
 		"response_type": "code",
 		"client_id": p["client_id"],
 		"redirect_uri": redirect_uri,
-		"scope": p["scope"],
+		"scope": (p.get("pool_scope") or p["scope"]) if pool else p["scope"],
 		"code_challenge": code_challenge,
 		"code_challenge_method": "S256",
 		"state": state,

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -734,3 +734,34 @@ class TestCompletePoolAccountSignin(_OAuthApiBase):
 		self.assertEqual(len(refs), 5)
 
 
+
+
+class TestPoolSigninScope(_OAuthApiBase):
+	"""Pool sign-ins must request the codex-CLI scope set (no connectors).
+
+	The connectors scope yields an access_token with
+	aud=https://api.openai.com/v1 - openclaw's codex app-server accepts it
+	(so the DIRECT flow keeps it), but cli-proxy-api's codex backend needs
+	aud=chatgpt.com/backend-api and rejects the connectors-audience token:
+	the account loads, /v1/models returns [], every call 502s "unknown
+	provider". Live-verified 2026-07-03. The pool scope set matches
+	cli-proxy-api's own --codex-login."""
+
+	def test_pool_signin_uses_codex_scope_without_connectors(self):
+		out = oauth_api.begin_pool_account_signin("OpenAI", "gpt-5.5")
+		url = out["data"]["authorize_url"]
+		self.assertIn("scope=openid+email+profile+offline_access", url)
+		self.assertNotIn("api.connectors", url)
+
+	def test_direct_signin_keeps_connectors_scope(self):
+		out = oauth_api.begin_paste_signin("OpenAI", "gpt-5.5")
+		url = out["data"]["authorize_url"]
+		self.assertIn("api.connectors.read", url)
+		self.assertIn("api.connectors.invoke", url)
+
+	def test_pool_signin_provider_without_pool_scope_falls_back(self):
+		# Google Gemini defines no pool_scope -> pool flow uses the normal
+		# scope (the gemini-cli scope set is what its pool path needs too).
+		out = oauth_api.begin_pool_account_signin("Google Gemini", "gemini-2.5-pro")
+		url = out["data"]["authorize_url"]
+		self.assertIn("cloud-platform", url)  # the normal gemini-cli scope set


### PR DESCRIPTION
Stacked on #200 (targets `feat/llm-proxy-ui`).

## Problem
`begin_pool_account_signin` reuses the direct flow's scope set — including `api.connectors.read/invoke`. That yields an access token with **`aud=https://api.openai.com/v1`**, which openclaw's codex app-server accepts (so the direct flow is fine), but **cli-proxy-api's codex backend requires `aud=chatgpt.com/backend-api`** and rejects the connectors-audience token: the account loads (`1 auth entries`), `/v1/models` returns `[]`, and every call 502s `unknown provider` through Bifrost. Live-debugged on the full local stack (2026-07-03) — this was the last failure standing between a pooled ChatGPT subscription and the pi runtime.

## Fix
- `pool_scope` on the OpenAI provider entry: `openid email profile offline_access` — exactly what cli-proxy-api's own `--codex-login` requests.
- `build_authorize_url(pool=True)` selects it; the direct flow is untouched; providers without a `pool_scope` (Google Gemini) fall back to their normal scope.

With the `id_token` already retained in the pool blob on this branch (and verified to pass through admin `update_llm_pool` and fleet-agent's pool validator untouched, then consumed by `_to_codex_token_storage`, fleet-agent PR #103), this completes the subscription → Bifrost+cliproxy → pi-runtime plumbing.

## Tests
`test_oauth_api`: 42 ran, my 3 new scope tests pass (pool scope has no connectors; direct keeps connectors; no-pool_scope providers fall back). The 1 failure (`test_gemini_standard_api_model_coerced_to_cli_default`) is pre-existing on `feat/llm-proxy-ui` — verified on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)