### PR TITLE
fix(chat): context overflow parks the turn for recovery — the error bubble was a lie

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3651,6 +3651,13 @@ function onEvent(p) {
 	if (p.conversation_id !== currentId.value) return
 	if (p.run_id && p.run_id === stoppedRunId.value) return // user stopped this run
 	switch (p.kind) {
+		case "run:recovering":
+			// openclaw hit a context overflow and is auto-compacting + retrying;
+			// the worker parked the turn for snapshot recovery. Keep the
+			// indicator alive - the answer lands via recovery shortly.
+			waiting.value = true
+			statusPhase.value = "model"
+			break
 		case "run:start":
 			currentRunId.value = p.run_id
 			runStartMs.value = Date.now()

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1039,7 +1039,27 @@ def _handle_event_inner(
 		batcher.flush()
 		phase = event.get("phase")
 		if phase == "error":
-			_mark_errored(assistant_msg_name, event.get("error") or "lifecycle error")
+			err_text = event.get("error") or "lifecycle error"
+			# Context overflow is NOT terminal on openclaw: the runtime
+			# auto-compacts and retries the prompt right after emitting
+			# this error (observed live: error at t+0, "auto-compaction
+			# succeeded; retrying prompt" at t+45s, full answer ~2min
+			# later in the session transcript - while the chat showed a
+			# dead "Context overflow" bubble). Park the turn for snapshot
+			# recovery instead: spinner stays up and turn_recovery
+			# finalizes from the session once the retried run lands. A
+			# retry that ALSO overflows leaves the turn parked; the
+			# recovery cron's ceiling turns it into an error then.
+			if "context overflow" in err_text.lower():
+				_mark_recovering(assistant_msg_name)
+				_publish_to_user(user, {
+					"kind": "run:recovering",
+					"conversation_id": conversation_id,
+					"message_id": assistant_msg_name,
+					"run_id": run_id,
+				})
+				return
+			_mark_errored(assistant_msg_name, err_text)
 			_publish_to_user(user, {
 				"kind": "run:error",
 				"conversation_id": conversation_id,

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -1064,3 +1064,38 @@ class TestRichOutputsRouting(FrappeTestCase):
 		)
 		self.assertEqual(row["streaming"], 0)  # the turn did finish cleanly
 		self.assertEqual(row["was_recovered"], 0)
+
+
+class TestOverflowParksForRecovery(FrappeTestCase):
+	"""A 'Context overflow' lifecycle error must PARK the turn (openclaw
+	auto-compacts and retries; the answer lands in the session shortly
+	after), never surface a terminal run:error to the chat."""
+
+	def _run_event(self, error_text):
+		from jarvis.chat import turn_handler
+		calls = {}
+		with patch.object(turn_handler, "_mark_recovering") as rec, \
+			patch.object(turn_handler, "_mark_errored") as err, \
+			patch.object(turn_handler, "_publish_to_user") as pub:
+			turn_handler._handle_event_inner(
+				{"kind": "lifecycle", "phase": "error", "error": error_text},
+				conversation_id="c1", assistant_msg_name="m1",
+				tool_msg_by_call_id={}, user="u@x", run_id="r1",
+				batcher=MagicMock(),
+			)
+		calls["recovering"] = rec.called
+		calls["errored"] = err.called
+		calls["kinds"] = [c.args[1]["kind"] for c in pub.call_args_list]
+		return calls
+
+	def test_context_overflow_parks(self):
+		out = self._run_event("Context overflow: prompt too large for the model. Try /reset ...")
+		self.assertTrue(out["recovering"])
+		self.assertFalse(out["errored"])
+		self.assertEqual(out["kinds"], ["run:recovering"])
+
+	def test_other_errors_still_error(self):
+		out = self._run_event("provider returned 500")
+		self.assertFalse(out["recovering"])
+		self.assertTrue(out["errored"])
+		self.assertEqual(out["kinds"], ["run:error"])


### PR DESCRIPTION
## The reported bug
User saw **"Context overflow: prompt too large for the model. Try /reset (or /new)…"** in the chat — while the fleet transcript showed the same turn **still running and completing**.

## Root cause (gateway log, live)
```
13:19:17 embedded run agent end: isError=true error=Context overflow…
13:19:19 context overflow detected (attempt 1/3); attempting auto-compaction
13:20:02 auto-compaction succeeded for openai/gpt-5.5; retrying prompt
13:21:54 (retried run completes with the real answer)
```
openclaw treats overflow as **recoverable** — it emits the lifecycle error, then compacts and retries. The worker treated that error as terminal: dead error bubble, answer stranded in the session.

## Fix
Lifecycle errors matching context overflow now **park the turn** (`_mark_recovering` + a `run:recovering` event) instead of `run:error`: the spinner stays up, the live status line keeps narrating ("Talking to the model…"), and the existing `turn_recovery` machinery finalizes the answer from the session snapshot (immediate best-effort + */2 cron backstop). A retry that *also* overflows stays parked until the recovery ceiling errors it honestly. Every other lifecycle error keeps the immediate `run:error` path.

## Tests
Worker suite 30/30 (2 new: overflow parks + publishes only `run:recovering`; other errors still take `run:error`). Frontend builds clean.

Context: the overflow itself came from a long invoice-PDF session on the embedded runtime (growing tool-loop context, 75KB `verbose` schema results, no visible prompt caching on `chatgpt-responses`) — proactive-compaction headroom and tool-result size hygiene are tracked separately; this PR fixes the false terminal error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)