### PR TITLE
fix(chat): document sends always errored “chat.send timed out” — scale the ack window with attachments

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -675,10 +675,21 @@ def handle_chat_send(payload: dict) -> None:
 							title="chat: seq watermark capture failed",
 							message=frappe.get_traceback(),
 						)
+					managed_attachments = (
+						_to_managed_attachments(vision_parts) if vision_parts else None
+					)
+					# openclaw preprocesses attachments BEFORE acking chat.send
+					# (each PDF page is rasterized + resized inside the RPC:
+					# measured 22s for a 4-page invoice). The default 10s ack
+					# timeout made every document send fail with
+					# "chat.send timed out" while the gateway completed the
+					# turn anyway. Scale the ack window with the payload.
+					ack_timeout = 10.0 + (30.0 * len(managed_attachments) if managed_attachments else 0.0)
 					ack = sess.chat_send(
 						conv.session_key, user_message, run_id,
 						thinking=(conv.thinking_override or "").strip() or None,
-						attachments=_to_managed_attachments(vision_parts) if vision_parts else None,
+						attachments=managed_attachments,
+						timeout_s=min(ack_timeout, 180.0),
 					) or {}
 					if ack.get("status") == "ok":
 						# Cached replay of a completed run (same run_id

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -1099,3 +1099,18 @@ class TestOverflowParksForRecovery(FrappeTestCase):
 		self.assertFalse(out["recovering"])
 		self.assertTrue(out["errored"])
 		self.assertEqual(out["kinds"], ["run:error"])
+
+
+class TestChatSendAttachmentTimeout(FrappeTestCase):
+	"""openclaw preprocesses attachments (PDF page raster + resize) BEFORE
+	acking chat.send - 22s measured for a 4-page invoice vs the 10s default
+	ack timeout, so every document send errored 'chat.send timed out' while
+	the gateway ran the turn anyway. The ack window must scale with the
+	attachment count (and stay default without attachments)."""
+
+	def test_ack_timeout_scales_with_attachments(self):
+		src = open(
+			frappe.get_app_path("jarvis", "chat", "turn_handler.py")
+		).read()
+		self.assertIn("ack_timeout = 10.0 + (30.0 * len(managed_attachments)", src)
+		self.assertIn("timeout_s=min(ack_timeout, 180.0)", src)


### PR DESCRIPTION
## Reported
Sending a chat **with a document** always shows "Something went wrong: chat.send timed out" — and clicking **retry works like usual**.

## Root cause (gateway log)
```
13:48:39 [ws] ⇄ res ✓ chat.send 22196ms   ← ack took 22.2s
13:48:47-50 [agents/tool-images] Image resized to fit limits: … (×4 pages)
```
openclaw preprocesses attachments **inside the `chat.send` RPC** — every PDF page is rasterized + resized before the ack. The bench waits only `CONNECT_TIMEOUT_SECONDS = 10` for that ack → every first document send times out client-side while the gateway completes the turn anyway. Retry succeeds because the pages are already rasterized (and the idempotency key can return the cached-replay ack), so the second ack fits in 10s.

## Fix
The ack window scales with the payload: `10s + 30s × attachments`, capped at 180s. Text-only turns keep the tight 10s ack (fast failure detection unchanged).

## Tests
Worker module: 29/29 (incl. a guard pinning the scaled window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)