### PR TITLE
fix(chat): relay-path context overflow parks for recovery — completes #206 for the production driver

### DIFF
--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -720,7 +720,28 @@ def handle_chat_send(payload: dict) -> None:
 				return
 
 			if terminal["kind"] == "relay:error":
-				_publish_run_error(terminal.get("error") or "agent error")
+				err_text = terminal.get("error") or "agent error"
+				# Context overflow is NOT terminal on openclaw: it emits the
+				# error, then auto-compacts and RETRIES the prompt (observed
+				# live: 'auto-compaction succeeded; retrying prompt' ~45s
+				# after the error; the retried run completes in the session).
+				# Park for snapshot recovery instead of erroring - the
+				# recovery cron finalizes the retried answer; if the retry
+				# ALSO dies, the recovery ceiling errors it honestly. This
+				# holds for ANY plan/context-window size: openclaw derives
+				# the window from the model catalog, so smaller-plan windows
+				# just compact sooner - the customer never sees the raw
+				# overflow either way.
+				if "context overflow" in err_text.lower():
+					_mark_recovering(assistant_msg.name)
+					_publish_to_user(user, {
+						"kind": "run:recovering",
+						"conversation_id": conversation_id,
+						"message_id": assistant_msg.name,
+						"run_id": run_id,
+					})
+					return
+				_publish_run_error(err_text)
 				_advance_macro(conversation_id, errored=True)
 				return
 			if terminal["kind"] == "relay:interrupted":

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -1114,3 +1114,18 @@ class TestChatSendAttachmentTimeout(FrappeTestCase):
 		).read()
 		self.assertIn("ack_timeout = 10.0 + (30.0 * len(managed_attachments)", src)
 		self.assertIn("timeout_s=min(ack_timeout, 180.0)", src)
+
+
+class TestRelayOverflowParks(FrappeTestCase):
+	"""relay:error carrying a context overflow must PARK the turn (openclaw
+	auto-compacts + retries; recovery finalizes the retried answer) - the
+	raw overflow error must never reach the chat regardless of the
+	customer plan's context-window size."""
+
+	def test_relay_error_overflow_branch_parks(self):
+		src = open(frappe.get_app_path("jarvis", "chat", "turn_handler.py")).read()
+		i = src.index('terminal["kind"] == "relay:error"')
+		branch = src[i:i + 900]
+		self.assertIn('"context overflow" in err_text.lower()', branch)
+		self.assertIn("_mark_recovering(assistant_msg.name)", branch)
+		self.assertIn('"kind": "run:recovering"', branch)


### PR DESCRIPTION
Completes #206. The user hit the raw overflow error AGAIN after #206 because managed turns are driven by **`chat.send` + `relay_turn_events`**, whose failures surface as **`relay:error` terminals** — a different branch from the lifecycle-error path #206 patched. Gateway log confirmed the same recoverable pattern (error → `auto-compaction succeeded; retrying prompt` → retried run completes in the session) while the chat showed the dead error.

`relay:error` carrying a context overflow now parks the turn (`_mark_recovering` + `run:recovering`, same as `relay:interrupted`); recovery finalizes the retried answer; a retry that also dies hits the recovery ceiling and errors honestly.

**Plan-agnostic by design:** customers on $20/$100/$200 plans get different context windows, but openclaw derives the window from the model catalog and auto-compacts within it — smaller windows simply compact sooner. With both surfacing paths parked, no plan ever sees the raw overflow error; the visible behavior is a longer "working" state, then the answer.

Worker module 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)