### PR TITLE
feat: File Box + Approvals — directed inbound-document entry

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -114,3 +114,16 @@ export async function uploadFile(file) {
 	const f = data.message || data
 	return { file_url: f.file_url, file_name: f.file_name || file.name }
 }
+
+// ── File Box: drop an inbound document, get a directed processing chat ──
+export const fileboxDrop = (file_url, file_name) =>
+	call("jarvis.chat.filebox.drop_file", { file_url, file_name })
+export const fileboxList = () => call("jarvis.chat.filebox.list_inbound", {})
+
+// ── Approvals: pending-decision queue + decide-and-resume ──
+export const listApprovals = (status = "Pending") =>
+	call("jarvis.chat.approvals_api.list_approvals", { status })
+export const approvalsPendingCount = () =>
+	call("jarvis.chat.approvals_api.pending_count", {})
+export const decideApproval = (name, decision, approve = 1) =>
+	call("jarvis.chat.approvals_api.decide", { name, decision, approve })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -669,6 +669,7 @@
 							<input ref="fileboxInput" type="file" multiple style="display:none" @change="onFileboxPick($event)" />
 						</div>
 						<div v-if="fileboxError" class="jv-skill-err">{{ fileboxError }}</div>
+						<div v-for="d in fileboxDropStatus.filter((x) => x.state === 'error')" :key="d.key" class="jv-skill-err" style="margin-bottom:6px;">{{ d.name }}: {{ d.error }}</div>
 						<div v-if="!fileboxItems.length" class="jv-set-empty" style="text-align:center;padding:10px 0;">Nothing processed yet.</div>
 						<div v-for="f in fileboxItems" :key="f.name" class="jv-skill-row" style="cursor:pointer;" @click="openFileboxItem(f)">
 							<div style="flex:1;min-width:0;">
@@ -703,6 +704,10 @@
 					</div>
 					<div class="jv-skills-body">
 						<div v-if="approvalsError" class="jv-skill-err">{{ approvalsError }}</div>
+						<div style="display:flex;gap:6px;margin-bottom:10px;">
+							<button class="jv-btn jv-btn--sm" :class="{ 'jv-btn--primary': approvalsView === 'Pending' }" @click="setApprovalsView('Pending')">Pending<span v-if="approvalsBadge"> ({{ approvalsBadge }})</span></button>
+							<button class="jv-btn jv-btn--sm" :class="{ 'jv-btn--primary': approvalsView === 'Decided' }" @click="setApprovalsView('Decided')">Decided</button>
+						</div>
 						<div v-if="approvalTabs.length > 1" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px;">
 							<button v-for="[tab, n] in approvalTabs" :key="tab" class="jv-btn jv-btn--sm"
 								:class="{ 'jv-btn--primary': approvalTab === tab }" @click="approvalTab = tab">
@@ -720,17 +725,25 @@
 								<summary style="font-size:11.5px;color:var(--text-3);cursor:pointer;">context</summary>
 								<pre style="font-size:11px;white-space:pre-wrap;max-height:180px;overflow:auto;background:var(--surface-2);border-radius:7px;padding:8px;">{{ a.context_md }}</pre>
 							</details>
-							<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px;">
+							<div v-if="a.status !== 'Pending'" style="font-size:12px;margin-bottom:4px;">
+								<b :style="a.status === 'Approved' ? 'color:var(--green,#30a46c);' : 'color:var(--red,#e5484d);'">{{ a.status }}</b>
+								— {{ a.decision }}
+								<span style="color:var(--text-3);"> · {{ a.decided_by }} · {{ a.decided_at ? new Date(a.decided_at).toLocaleString() : "" }}</span>
+							</div>
+							<div v-if="a.status === 'Pending'" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px;">
 								<button v-for="opt in a.options" :key="opt" class="jv-btn jv-btn--sm"
 									:class="{ 'jv-btn--primary': approvalDrafts[a.name] === opt }"
 									@click="approvalDrafts[a.name] = opt">{{ opt }}</button>
 							</div>
-							<div style="display:flex;gap:6px;">
+							<div v-if="a.status === 'Pending'" style="display:flex;gap:6px;">
 								<input v-model="approvalDrafts[a.name]" placeholder="Decision (pick an option or type)"
 									style="flex:1;font-size:12.5px;padding:6px 9px;border:1px solid var(--border);border-radius:7px;background:var(--surface-1);color:var(--text-1);" />
 								<button class="jv-btn jv-btn--primary jv-btn--sm" :disabled="!(approvalDrafts[a.name] || '').trim() || approvalsBusy" @click="doDecide(a, 1)">Approve</button>
 								<button class="jv-btn jv-btn--sm" :disabled="!(approvalDrafts[a.name] || '').trim() || approvalsBusy" @click="doDecide(a, 0)">Reject</button>
 								<button v-if="a.conversation" class="jv-btn jv-btn--sm" title="Open the chat" @click="openApprovalChat(a)">Chat</button>
+							</div>
+							<div v-if="a.status !== 'Pending' && a.conversation" style="display:flex;gap:6px;">
+								<button class="jv-btn jv-btn--sm" title="Open the chat" @click="openApprovalChat(a)">Chat</button>
 							</div>
 						</div>
 					</div>
@@ -1627,11 +1640,18 @@ const pageMode = ref(false)
 function _applyHashRoute() {
 	const h = (window.location.hash || "").replace("#", "")
 	pageMode.value = ["approvals", "filebox", "skills", "macros"].includes(h)
+	// State machine: exactly one surface per hash - close the others first
+	// (navigating #filebox -> #approvals used to stack both overlays).
+	fileboxOpen.value = false
+	approvalsOpen.value = false
+	skillsModalOpen.value = false
+	macrosModalOpen.value = false
 	if (h === "approvals") openApprovals()
 	else if (h === "filebox") openFilebox()
 	else if (h === "skills") openSkillsModal()
 	else if (h === "macros") openMacrosModal()
 }
+const _hashRouteHandler = () => _applyHashRoute()
 function openAsPage(name) {
 	window.location.hash = name
 }
@@ -1645,33 +1665,37 @@ function _clearPageHash() {
 async function refreshApprovalsBadge() {
 	try { approvalsBadge.value = (await api.approvalsPendingCount()) || 0 } catch (e) { /* badge is best-effort */ }
 }
-window.addEventListener("hashchange", () => _applyHashRoute())
-setTimeout(() => _applyHashRoute(), 0)
-
 async function openFilebox() {
 	fileboxOpen.value = true
 	fileboxError.value = ""
 	try { fileboxItems.value = (await api.fileboxList()) || [] } catch (e) { fileboxError.value = "Could not load the inbound list." }
 }
 const fileboxUploading = ref(0) // in-flight drops; the box stays open and accepts more
+const fileboxDropStatus = ref([]) // per-file: {key, name, state: uploading|ok|error, error}
 async function _fileboxProcess(file) {
 	// Background-first: each file is its own async pipeline. Keep dropping -
 	// nothing blocks, nothing navigates; items appear in the inbound list as
 	// "processing" and land in Approvals if they need you.
 	if (!file) return
 	fileboxUploading.value++
-	fileboxError.value = ""
+	const entry = { key: `${file.name}-${Date.now()}-${Math.random()}`, name: file.name, state: "uploading", error: "" }
+	fileboxDropStatus.value = [entry, ...fileboxDropStatus.value].slice(0, 8)
 	try {
 		const up = await api.uploadFile(file)
 		const res = await api.fileboxDrop(up.file_url, up.file_name)
 		if (!res || !res.ok) throw new Error((res && res.reason) || "drop failed")
+		entry.state = "ok"
 		fileboxItems.value = [
 			{ name: res.conversation_id, title: `File: ${up.file_name}`, creation: new Date().toISOString(), status: "processing", pending_approvals: 0 },
 			...fileboxItems.value.filter((x) => x.name !== res.conversation_id),
 		]
+		fileboxDropStatus.value = [...fileboxDropStatus.value]
 		loadConversations() // background refresh; no navigation
 	} catch (e) {
-		fileboxError.value = `Could not process ${file.name}: ${e.message || e}`
+		// Per-file error - concurrent drops no longer clobber each other.
+		entry.state = "error"
+		entry.error = e.message || String(e)
+		fileboxDropStatus.value = [...fileboxDropStatus.value]
 	} finally {
 		fileboxUploading.value--
 	}
@@ -1690,13 +1714,22 @@ async function openFileboxItem(f) {
 	fileboxOpen.value = false
 	await selectConversation(f.name)
 }
-async function openApprovals() {
-	approvalsOpen.value = true
+const approvalsView = ref("Pending") // "Pending" | "Decided"
+async function _loadApprovals() {
 	approvalsError.value = ""
 	try {
-		approvalItems.value = (await api.listApprovals("Pending")) || []
+		approvalItems.value = (await api.listApprovals(approvalsView.value)) || []
 	} catch (e) { approvalsError.value = "Could not load approvals." }
+}
+async function openApprovals() {
+	approvalsOpen.value = true
+	await _loadApprovals()
 	refreshApprovalsBadge()
+}
+async function setApprovalsView(v) {
+	approvalsView.value = v
+	approvalTab.value = "All"
+	await _loadApprovals()
 }
 async function doDecide(a, approve) {
 	const decision = (approvalDrafts.value[a.name] || "").trim()
@@ -3411,6 +3444,7 @@ watch(threadInnerEl, (el) => {
 	}
 })
 onBeforeUnmount(() => {
+	window.removeEventListener("hashchange", _hashRouteHandler)
 	if (threadRO) {
 		threadRO.disconnect()
 		threadRO = null
@@ -4170,6 +4204,10 @@ function onVisibility() {
 }
 
 onMounted(async () => {
+	// Hash page-routes: lifecycle-scoped (was a top-level anonymous listener
+	// that stacked on remount and fired before auth/bootstrap).
+	window.addEventListener("hashchange", _hashRouteHandler)
+	setTimeout(_hashRouteHandler, 400)
 	// Latency plan, Phase 1.3: the bootstrap network calls used to run as a
 	// serial awaited chain (ready → ui settings → conversations), each a full
 	// round-trip. Fire them concurrently and await in order below — the

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -504,7 +504,7 @@
 
 		<!-- ============ SKILLS POPUP (centered) ============ -->
 		<transition name="jv-fade">
-			<div v-if="skillsModalOpen" class="jv-skills-overlay" @click.self="closeSkillsModal">
+			<div v-if="skillsModalOpen" class="jv-skills-overlay" :class="{ 'jv-page-mode': pageMode }" @click.self="closeSkillsModal">
 				<div class="jv-skills-modal">
 					<div class="jv-skills-head">
 						<div style="min-width:0;">
@@ -640,14 +640,17 @@
 
 		<!-- ============ MACROS POPUP (centered) ============ -->
 		<transition name="jv-fade">
-			<div v-if="fileboxOpen" class="jv-skills-overlay" @click.self="fileboxOpen = false">
+			<div v-if="fileboxOpen" class="jv-skills-overlay" :class="{ 'jv-page-mode': pageMode }" @click.self="fileboxOpen = false; _clearPageHash()">
 				<div class="jv-skills-modal">
 					<div class="jv-skills-head">
 						<div style="min-width:0;">
 							<div class="jv-skills-title">File Box</div>
 							<div class="jv-skills-sub">Drop an inbound document — invoice, receipt, PO — and Jarvis drafts it for you.</div>
 						</div>
-						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="fileboxOpen = false">
+						<button v-if="!pageMode" class="jv-btn jv-btn--icon" title="Open as page" @click="openAsPage('filebox')">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" /></svg>
+						</button>
+						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="fileboxOpen = false; _clearPageHash()">
 							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
 						</button>
 					</div>
@@ -659,9 +662,11 @@
 							@dragover.prevent="fileboxDrag = true" @dragleave="fileboxDrag = false"
 							@drop.prevent="onFileboxDrop($event)"
 						>
-							<div v-if="fileboxBusy" style="font-size:13px;color:var(--text-2);">Uploading &amp; starting the draft…</div>
-							<div v-else style="font-size:13px;color:var(--text-2);">Drop a file here, or click to browse.<br /><span style="font-size:11.5px;color:var(--text-3);">One document per file works best. The draft opens as a chat.</span></div>
-							<input ref="fileboxInput" type="file" style="display:none" @change="onFileboxPick($event)" />
+							<div style="font-size:13px;color:var(--text-2);">
+								Drop files here, or click to browse<span v-if="fileboxUploading"> — {{ fileboxUploading }} uploading…</span>.<br />
+								<span style="font-size:11.5px;color:var(--text-3);">Keep adding — each file processes in the background and lands in Approvals if it needs you.</span>
+							</div>
+							<input ref="fileboxInput" type="file" multiple style="display:none" @change="onFileboxPick($event)" />
 						</div>
 						<div v-if="fileboxError" class="jv-skill-err">{{ fileboxError }}</div>
 						<div v-if="!fileboxItems.length" class="jv-set-empty" style="text-align:center;padding:10px 0;">Nothing processed yet.</div>
@@ -682,22 +687,34 @@
 				</div>
 			</div>
 
-			<div v-if="approvalsOpen" class="jv-skills-overlay" @click.self="approvalsOpen = false">
+			<div v-if="approvalsOpen" class="jv-skills-overlay" :class="{ 'jv-page-mode': pageMode }" @click.self="approvalsOpen = false; _clearPageHash()">
 				<div class="jv-skills-modal">
 					<div class="jv-skills-head">
 						<div style="min-width:0;">
 							<div class="jv-skills-title">Approvals</div>
 							<div class="jv-skills-sub">Decisions waiting on you. Deciding resumes the chat that asked.</div>
 						</div>
-						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="approvalsOpen = false">
+						<button v-if="!pageMode" class="jv-btn jv-btn--icon" title="Open as page" @click="openAsPage('approvals')">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" /></svg>
+						</button>
+						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="approvalsOpen = false; _clearPageHash()">
 							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
 						</button>
 					</div>
 					<div class="jv-skills-body">
 						<div v-if="approvalsError" class="jv-skill-err">{{ approvalsError }}</div>
-						<div v-if="!approvalItems.length" class="jv-set-empty" style="text-align:center;padding:26px 0;">Nothing waiting on you. 🎉</div>
-						<div v-for="a in approvalItems" :key="a.name" style="border:1px solid var(--border);border-radius:10px;padding:12px;margin-bottom:10px;">
-							<div style="font-size:13px;font-weight:600;">{{ a.title }}</div>
+						<div v-if="approvalTabs.length > 1" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px;">
+							<button v-for="[tab, n] in approvalTabs" :key="tab" class="jv-btn jv-btn--sm"
+								:class="{ 'jv-btn--primary': approvalTab === tab }" @click="approvalTab = tab">
+								{{ tab }} <span style="opacity:.65;">({{ n }})</span>
+							</button>
+						</div>
+						<div v-if="!approvalItemsShown.length" class="jv-set-empty" style="text-align:center;padding:26px 0;">Nothing waiting on you. 🎉</div>
+						<div v-for="a in approvalItemsShown" :key="a.name" style="border:1px solid var(--border);border-radius:10px;padding:12px;margin-bottom:10px;">
+							<div style="display:flex;gap:8px;align-items:center;">
+								<div style="font-size:13px;font-weight:600;flex:1;min-width:0;">{{ a.title }}</div>
+								<span style="font-size:10.5px;border-radius:7px;padding:2px 7px;background:var(--surface-2);color:var(--text-2);flex:none;">{{ (a.document_type || "").trim() || "Unclassified" }}</span>
+							</div>
 							<div style="font-size:12.5px;color:var(--text-2);margin:6px 0;">{{ a.question }}</div>
 							<details v-if="a.context_md" style="margin-bottom:8px;">
 								<summary style="font-size:11.5px;color:var(--text-3);cursor:pointer;">context</summary>
@@ -720,7 +737,7 @@
 				</div>
 			</div>
 
-			<div v-if="macrosModalOpen" class="jv-skills-overlay" @click.self="closeMacrosModal">
+			<div v-if="macrosModalOpen" class="jv-skills-overlay" :class="{ 'jv-page-mode': pageMode }" @click.self="closeMacrosModal">
 				<div class="jv-skills-modal">
 					<div class="jv-skills-head">
 						<div style="min-width:0;">
@@ -1603,41 +1620,71 @@ const approvalsError = ref("")
 const approvalItems = ref([])
 const approvalDrafts = ref({})
 const approvalsBadge = ref(0)
+// ── Page mode: #approvals / #filebox / #skills / #macros open the same
+// surface as a near-fullscreen page (more room for detail); the rail
+// buttons keep the quick popup. Closing clears the hash.
+const pageMode = ref(false)
+function _applyHashRoute() {
+	const h = (window.location.hash || "").replace("#", "")
+	pageMode.value = ["approvals", "filebox", "skills", "macros"].includes(h)
+	if (h === "approvals") openApprovals()
+	else if (h === "filebox") openFilebox()
+	else if (h === "skills") openSkillsModal()
+	else if (h === "macros") openMacrosModal()
+}
+function openAsPage(name) {
+	window.location.hash = name
+}
+function _clearPageHash() {
+	if (pageMode.value) {
+		pageMode.value = false
+		history.replaceState(null, "", window.location.pathname + window.location.search)
+	}
+}
 
 async function refreshApprovalsBadge() {
 	try { approvalsBadge.value = (await api.approvalsPendingCount()) || 0 } catch (e) { /* badge is best-effort */ }
 }
+window.addEventListener("hashchange", () => _applyHashRoute())
+setTimeout(() => _applyHashRoute(), 0)
+
 async function openFilebox() {
 	fileboxOpen.value = true
 	fileboxError.value = ""
 	try { fileboxItems.value = (await api.fileboxList()) || [] } catch (e) { fileboxError.value = "Could not load the inbound list." }
 }
+const fileboxUploading = ref(0) // in-flight drops; the box stays open and accepts more
 async function _fileboxProcess(file) {
-	if (!file || fileboxBusy.value) return
-	fileboxBusy.value = true
+	// Background-first: each file is its own async pipeline. Keep dropping -
+	// nothing blocks, nothing navigates; items appear in the inbound list as
+	// "processing" and land in Approvals if they need you.
+	if (!file) return
+	fileboxUploading.value++
 	fileboxError.value = ""
 	try {
 		const up = await api.uploadFile(file)
 		const res = await api.fileboxDrop(up.file_url, up.file_name)
 		if (!res || !res.ok) throw new Error((res && res.reason) || "drop failed")
-		fileboxOpen.value = false
-		await loadConversations()
-		await selectConversation(res.conversation_id)
+		fileboxItems.value = [
+			{ name: res.conversation_id, title: `File: ${up.file_name}`, creation: new Date().toISOString(), status: "processing", pending_approvals: 0 },
+			...fileboxItems.value.filter((x) => x.name !== res.conversation_id),
+		]
+		loadConversations() // background refresh; no navigation
 	} catch (e) {
-		fileboxError.value = `Could not process the file: ${e.message || e}`
+		fileboxError.value = `Could not process ${file.name}: ${e.message || e}`
 	} finally {
-		fileboxBusy.value = false
+		fileboxUploading.value--
 	}
 }
 function onFileboxDrop(ev) {
 	fileboxDrag.value = false
-	const f = ev.dataTransfer && ev.dataTransfer.files && ev.dataTransfer.files[0]
-	_fileboxProcess(f)
+	const files = (ev.dataTransfer && ev.dataTransfer.files) || []
+	for (const f of files) _fileboxProcess(f)
 }
 function onFileboxPick(ev) {
-	const f = ev.target.files && ev.target.files[0]
+	const files = ev.target.files || []
+	for (const f of files) _fileboxProcess(f)
 	ev.target.value = ""
-	_fileboxProcess(f)
 }
 async function openFileboxItem(f) {
 	fileboxOpen.value = false
@@ -1657,21 +1704,37 @@ async function doDecide(a, approve) {
 	approvalsBusy.value = true
 	try {
 		await api.decideApproval(a.name, decision, approve)
+		// Background-first: the decision resumes the chat over there; stay
+		// on the board so the next approval can be handled. The per-item
+		// "Chat" button is the opt-in way in.
 		approvalItems.value = approvalItems.value.filter((x) => x.name !== a.name)
 		delete approvalDrafts.value[a.name]
 		refreshApprovalsBadge()
-		// The decision resumed the linked chat - take the user there.
-		if (a.conversation) {
-			approvalsOpen.value = false
-			await loadConversations()
-			await selectConversation(a.conversation)
-		}
+		loadConversations()
 	} catch (e) {
 		approvalsError.value = `Could not record the decision: ${e.message || e}`
 	} finally {
 		approvalsBusy.value = false
 	}
 }
+// Internal tabs: group pending approvals by the business document type so a
+// busy queue can be triaged one type at a time. Empty document_type = the
+// classification itself needs deciding - its own tab.
+const approvalTab = ref("All")
+const approvalTabs = computed(() => {
+	const counts = {}
+	for (const a of approvalItems.value) {
+		const k = (a.document_type || "").trim() || "Unclassified"
+		counts[k] = (counts[k] || 0) + 1
+	}
+	return [["All", approvalItems.value.length], ...Object.entries(counts).sort((x, y) => y[1] - x[1])]
+})
+const approvalItemsShown = computed(() => {
+	if (approvalTab.value === "All") return approvalItems.value
+	return approvalItems.value.filter(
+		(a) => (((a.document_type || "").trim()) || "Unclassified") === approvalTab.value,
+	)
+})
 async function openApprovalChat(a) {
 	approvalsOpen.value = false
 	await selectConversation(a.conversation)
@@ -4926,4 +4989,10 @@ function onGlobalKey(e) {
 .jv-slide-enter-active .jv-artifact-panel, .jv-slide-leave-active .jv-artifact-panel { transition: transform .24s cubic-bezier(.4, 0, .2, 1); }
 .jv-slide-enter-from, .jv-slide-leave-to { opacity: 0; }
 .jv-slide-enter-from .jv-artifact-panel, .jv-slide-leave-to .jv-artifact-panel { transform: translateX(100%); }
+
+.jv-page-mode .jv-skills-modal {
+	width: min(1150px, 96vw);
+	height: 93vh;
+	max-height: 93vh;
+}
 </style>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -490,6 +490,15 @@
 					<svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M5 3l14 9-14 9V3z" /><path d="M3 5v14" /></svg>
 					<span class="jv-railtip">Macros</span>
 				</button>
+				<button class="jv-skillrail-btn" :class="{ active: fileboxOpen }" @click="openFilebox()">
+					<svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2" /><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" /></svg>
+					<span class="jv-railtip">File Box</span>
+				</button>
+				<button class="jv-skillrail-btn" :class="{ active: approvalsOpen }" @click="openApprovals()" style="position:relative;">
+					<svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4" /><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" /></svg>
+					<span v-if="approvalsBadge" style="position:absolute;top:2px;right:2px;background:var(--red,#e5484d);color:#fff;border-radius:8px;font-size:9px;line-height:1;padding:2px 4px;">{{ approvalsBadge }}</span>
+					<span class="jv-railtip">Approvals</span>
+				</button>
 			</div>
 		</aside>
 
@@ -631,6 +640,86 @@
 
 		<!-- ============ MACROS POPUP (centered) ============ -->
 		<transition name="jv-fade">
+			<div v-if="fileboxOpen" class="jv-skills-overlay" @click.self="fileboxOpen = false">
+				<div class="jv-skills-modal">
+					<div class="jv-skills-head">
+						<div style="min-width:0;">
+							<div class="jv-skills-title">File Box</div>
+							<div class="jv-skills-sub">Drop an inbound document — invoice, receipt, PO — and Jarvis drafts it for you.</div>
+						</div>
+						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="fileboxOpen = false">
+							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+						</button>
+					</div>
+					<div class="jv-skills-body">
+						<div
+							style="border:2px dashed var(--border);border-radius:10px;padding:26px;text-align:center;cursor:pointer;margin-bottom:14px;"
+							:style="fileboxDrag ? 'border-color:var(--blue);background:var(--surface-2);' : ''"
+							@click="$refs.fileboxInput.click()"
+							@dragover.prevent="fileboxDrag = true" @dragleave="fileboxDrag = false"
+							@drop.prevent="onFileboxDrop($event)"
+						>
+							<div v-if="fileboxBusy" style="font-size:13px;color:var(--text-2);">Uploading &amp; starting the draft…</div>
+							<div v-else style="font-size:13px;color:var(--text-2);">Drop a file here, or click to browse.<br /><span style="font-size:11.5px;color:var(--text-3);">One document per file works best. The draft opens as a chat.</span></div>
+							<input ref="fileboxInput" type="file" style="display:none" @change="onFileboxPick($event)" />
+						</div>
+						<div v-if="fileboxError" class="jv-skill-err">{{ fileboxError }}</div>
+						<div v-if="!fileboxItems.length" class="jv-set-empty" style="text-align:center;padding:10px 0;">Nothing processed yet.</div>
+						<div v-for="f in fileboxItems" :key="f.name" class="jv-skill-row" style="cursor:pointer;" @click="openFileboxItem(f)">
+							<div style="flex:1;min-width:0;">
+								<div style="font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{{ f.title.replace(/^File: /, "") }}</div>
+								<div style="font-size:11px;color:var(--text-3);">{{ new Date(f.creation).toLocaleString() }}</div>
+							</div>
+							<span style="font-size:10.5px;border-radius:7px;padding:2px 7px;flex:none;"
+								:style="f.status === 'processing' ? 'background:var(--surface-2);color:var(--text-2);'
+									: f.status === 'needs_approval' ? 'background:rgba(229,72,77,.12);color:var(--red,#e5484d);'
+									: f.status === 'error' ? 'background:rgba(229,72,77,.12);color:var(--red,#e5484d);'
+									: 'background:rgba(48,164,108,.12);color:var(--green,#30a46c);'">
+								{{ f.status === "needs_approval" ? (f.pending_approvals + " approval" + (f.pending_approvals > 1 ? "s" : "")) : f.status }}
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div v-if="approvalsOpen" class="jv-skills-overlay" @click.self="approvalsOpen = false">
+				<div class="jv-skills-modal">
+					<div class="jv-skills-head">
+						<div style="min-width:0;">
+							<div class="jv-skills-title">Approvals</div>
+							<div class="jv-skills-sub">Decisions waiting on you. Deciding resumes the chat that asked.</div>
+						</div>
+						<button class="jv-btn jv-btn--icon" title="Close (Esc)" @click="approvalsOpen = false">
+							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+						</button>
+					</div>
+					<div class="jv-skills-body">
+						<div v-if="approvalsError" class="jv-skill-err">{{ approvalsError }}</div>
+						<div v-if="!approvalItems.length" class="jv-set-empty" style="text-align:center;padding:26px 0;">Nothing waiting on you. 🎉</div>
+						<div v-for="a in approvalItems" :key="a.name" style="border:1px solid var(--border);border-radius:10px;padding:12px;margin-bottom:10px;">
+							<div style="font-size:13px;font-weight:600;">{{ a.title }}</div>
+							<div style="font-size:12.5px;color:var(--text-2);margin:6px 0;">{{ a.question }}</div>
+							<details v-if="a.context_md" style="margin-bottom:8px;">
+								<summary style="font-size:11.5px;color:var(--text-3);cursor:pointer;">context</summary>
+								<pre style="font-size:11px;white-space:pre-wrap;max-height:180px;overflow:auto;background:var(--surface-2);border-radius:7px;padding:8px;">{{ a.context_md }}</pre>
+							</details>
+							<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px;">
+								<button v-for="opt in a.options" :key="opt" class="jv-btn jv-btn--sm"
+									:class="{ 'jv-btn--primary': approvalDrafts[a.name] === opt }"
+									@click="approvalDrafts[a.name] = opt">{{ opt }}</button>
+							</div>
+							<div style="display:flex;gap:6px;">
+								<input v-model="approvalDrafts[a.name]" placeholder="Decision (pick an option or type)"
+									style="flex:1;font-size:12.5px;padding:6px 9px;border:1px solid var(--border);border-radius:7px;background:var(--surface-1);color:var(--text-1);" />
+								<button class="jv-btn jv-btn--primary jv-btn--sm" :disabled="!(approvalDrafts[a.name] || '').trim() || approvalsBusy" @click="doDecide(a, 1)">Approve</button>
+								<button class="jv-btn jv-btn--sm" :disabled="!(approvalDrafts[a.name] || '').trim() || approvalsBusy" @click="doDecide(a, 0)">Reject</button>
+								<button v-if="a.conversation" class="jv-btn jv-btn--sm" title="Open the chat" @click="openApprovalChat(a)">Chat</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
 			<div v-if="macrosModalOpen" class="jv-skills-overlay" @click.self="closeMacrosModal">
 				<div class="jv-skills-modal">
 					<div class="jv-skills-head">
@@ -1502,6 +1591,91 @@ async function removeSkill(s) {
 // --- Macros (customer-authored prompt sequences run as chained turns) ---
 const macros = ref([])
 const macrosModalOpen = ref(false)
+// ── File Box + Approvals panes ──────────────────────────────────────────────
+const fileboxOpen = ref(false)
+const fileboxDrag = ref(false)
+const fileboxBusy = ref(false)
+const fileboxError = ref("")
+const fileboxItems = ref([])
+const approvalsOpen = ref(false)
+const approvalsBusy = ref(false)
+const approvalsError = ref("")
+const approvalItems = ref([])
+const approvalDrafts = ref({})
+const approvalsBadge = ref(0)
+
+async function refreshApprovalsBadge() {
+	try { approvalsBadge.value = (await api.approvalsPendingCount()) || 0 } catch (e) { /* badge is best-effort */ }
+}
+async function openFilebox() {
+	fileboxOpen.value = true
+	fileboxError.value = ""
+	try { fileboxItems.value = (await api.fileboxList()) || [] } catch (e) { fileboxError.value = "Could not load the inbound list." }
+}
+async function _fileboxProcess(file) {
+	if (!file || fileboxBusy.value) return
+	fileboxBusy.value = true
+	fileboxError.value = ""
+	try {
+		const up = await api.uploadFile(file)
+		const res = await api.fileboxDrop(up.file_url, up.file_name)
+		if (!res || !res.ok) throw new Error((res && res.reason) || "drop failed")
+		fileboxOpen.value = false
+		await loadConversations()
+		await selectConversation(res.conversation_id)
+	} catch (e) {
+		fileboxError.value = `Could not process the file: ${e.message || e}`
+	} finally {
+		fileboxBusy.value = false
+	}
+}
+function onFileboxDrop(ev) {
+	fileboxDrag.value = false
+	const f = ev.dataTransfer && ev.dataTransfer.files && ev.dataTransfer.files[0]
+	_fileboxProcess(f)
+}
+function onFileboxPick(ev) {
+	const f = ev.target.files && ev.target.files[0]
+	ev.target.value = ""
+	_fileboxProcess(f)
+}
+async function openFileboxItem(f) {
+	fileboxOpen.value = false
+	await selectConversation(f.name)
+}
+async function openApprovals() {
+	approvalsOpen.value = true
+	approvalsError.value = ""
+	try {
+		approvalItems.value = (await api.listApprovals("Pending")) || []
+	} catch (e) { approvalsError.value = "Could not load approvals." }
+	refreshApprovalsBadge()
+}
+async function doDecide(a, approve) {
+	const decision = (approvalDrafts.value[a.name] || "").trim()
+	if (!decision) return
+	approvalsBusy.value = true
+	try {
+		await api.decideApproval(a.name, decision, approve)
+		approvalItems.value = approvalItems.value.filter((x) => x.name !== a.name)
+		delete approvalDrafts.value[a.name]
+		refreshApprovalsBadge()
+		// The decision resumed the linked chat - take the user there.
+		if (a.conversation) {
+			approvalsOpen.value = false
+			await loadConversations()
+			await selectConversation(a.conversation)
+		}
+	} catch (e) {
+		approvalsError.value = `Could not record the decision: ${e.message || e}`
+	} finally {
+		approvalsBusy.value = false
+	}
+}
+async function openApprovalChat(a) {
+	approvalsOpen.value = false
+	await selectConversation(a.conversation)
+}
 const macroEditorOpen = ref(false)
 const macroSaving = ref(false)
 const macroError = ref("")
@@ -3252,6 +3426,7 @@ function onKey(e) {
 }
 
 async function loadConversations() {
+	refreshApprovalsBadge()
 	conversations.value = await api.listConversations()
 }
 async function loadConversation(id) {

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -1,0 +1,95 @@
+"""Approvals pane API: pending-decision queue + decide-and-resume.
+
+The agent queues decisions it cannot take autonomously as ``Jarvis
+Approval`` rows (see the ocr-data-entry skill contract) and ends the
+turn. The customer decides from the SPA Approvals pane (or the Desk
+list); deciding posts the decision back into the linked conversation
+through the normal ``send_message`` path, so the agent resumes the flow
+in the same chat with full context - no separate notification plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+APPROVAL = "Jarvis Approval"
+
+
+def _parse_options(raw: str | None) -> list[str]:
+	try:
+		out = json.loads(raw or "[]")
+		return [str(o) for o in out] if isinstance(out, list) else []
+	except Exception:
+		return []
+
+
+@frappe.whitelist()
+def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
+	"""Approvals visible to the current user (owner of the linked
+	conversation, or any System Manager)."""
+	if status not in ("Pending", "Approved", "Rejected", "All"):
+		frappe.throw("Invalid status filter")
+	filters = {} if status == "All" else {"status": status}
+	rows = frappe.get_all(
+		APPROVAL, filters=filters,
+		fields=[
+			"name", "title", "status", "question", "context_md", "options",
+			"conversation", "ref_doctype", "ref_name", "decision",
+			"decided_by", "decided_at", "creation",
+		],
+		order_by="creation desc", limit_page_length=int(limit),
+	)
+	is_sm = "System Manager" in frappe.get_roles()
+	out = []
+	for r in rows:
+		if not is_sm:
+			conv_owner = (
+				frappe.db.get_value("Jarvis Conversation", r.conversation, "owner")
+				if r.conversation else None
+			)
+			if conv_owner != frappe.session.user:
+				continue
+		r["options"] = _parse_options(r.get("options"))
+		out.append(r)
+	return out
+
+
+@frappe.whitelist()
+def pending_count() -> int:
+	return frappe.db.count(APPROVAL, {"status": "Pending"})
+
+
+@frappe.whitelist()
+def decide(name: str, decision: str, approve: int = 1) -> dict:
+	"""Record the decision and resume the linked conversation.
+
+	``decision`` is the human's answer (an option or free text). The
+	resume message is a plain user message through send_message, so the
+	agent sees it exactly like any chat turn - same session, same context.
+	"""
+	decision = (decision or "").strip()
+	if not decision:
+		frappe.throw("Decision text is required")
+	doc = frappe.get_doc(APPROVAL, name)
+	if doc.status != "Pending":
+		frappe.throw(f"Approval {name} is already {doc.status}")
+	doc.status = "Approved" if int(approve) else "Rejected"
+	doc.decision = decision
+	doc.decided_by = frappe.session.user
+	doc.decided_at = frappe.utils.now_datetime()
+	doc.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	resumed = False
+	if doc.conversation and frappe.db.exists("Jarvis Conversation", doc.conversation):
+		from jarvis.chat.api import send_message
+		verdict = "APPROVED" if doc.status == "Approved" else "REJECTED"
+		msg = (
+			f"[Approval {doc.name} - {doc.title}] {verdict}: {decision}\n"
+			f"Continue the flow with this decision; do not re-ask."
+		)
+		res = send_message(conversation=doc.conversation, message=msg)
+		resumed = bool(res.get("ok"))
+	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -22,7 +22,23 @@ def _parse_options(raw: str | None) -> list[str]:
 		out = json.loads(raw or "[]")
 		return [str(o) for o in out] if isinstance(out, list) else []
 	except Exception:
-		return []
+		# The agent sometimes hands create_doc a real list, which Frappe
+		# coerces to str(list) with single quotes - salvage it.
+		try:
+			import ast
+			out = ast.literal_eval(raw or "[]")
+			return [str(o) for o in out] if isinstance(out, list) else []
+		except Exception:
+			return []
+
+
+def _may_act_on(conversation: str | None) -> bool:
+	# SM, or the owner of the linked conversation.
+	if "System Manager" in frappe.get_roles():
+		return True
+	if not conversation:
+		return False
+	return frappe.db.get_value("Jarvis Conversation", conversation, "owner") == frappe.session.user
 
 
 @frappe.whitelist()
@@ -58,7 +74,10 @@ def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 
 @frappe.whitelist()
 def pending_count() -> int:
-	return frappe.db.count(APPROVAL, {"status": "Pending"})
+	# Scoped like list_approvals: non-SM users count only their own.
+	if "System Manager" in frappe.get_roles():
+		return frappe.db.count(APPROVAL, {"status": "Pending"})
+	return len(list_approvals("Pending"))
 
 
 @frappe.whitelist()
@@ -73,6 +92,8 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 	if not decision:
 		frappe.throw("Decision text is required")
 	doc = frappe.get_doc(APPROVAL, name)
+	if not _may_act_on(doc.conversation):
+		frappe.throw("Not permitted", frappe.PermissionError)
 	if doc.status != "Pending":
 		frappe.throw(f"Approval {name} is already {doc.status}")
 	doc.status = "Approved" if int(approve) else "Rejected"
@@ -95,18 +116,24 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 		# no longer SEE the pages - observed live: the agent (correctly)
 		# refused to draft rather than fabricate lines it couldn't see.
 		attachments = None
-		title = frappe.db.get_value("Jarvis Conversation", doc.conversation, "title") or ""
-		if title.startswith("File: "):
-			fname = title[len("File: "):]
-			f = frappe.get_all(
-				"File", filters={"file_name": ["like", fname + "%"]},
-				fields=["file_url", "file_name"],
-				order_by="creation desc", limit_page_length=1,
+		f = frappe.get_all(
+			"File",
+			filters={
+				"attached_to_doctype": "Jarvis Conversation",
+				"attached_to_name": doc.conversation,
+			},
+			fields=["file_url", "file_name"],
+			order_by="creation desc", limit_page_length=1,
+		)
+		if f:
+			attachments = json.dumps(
+				[{"file_url": f[0].file_url, "file_name": f[0].file_name}]
 			)
-			if f:
-				attachments = json.dumps(
-					[{"file_url": f[0].file_url, "file_name": f[0].file_name}]
-				)
-		res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
-		resumed = bool(res.get("ok"))
+		# The decision is durably recorded above; a resume failure must
+		# not 500 the endpoint (the SPA would re-show a decided row).
+		try:
+			res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
+			resumed = bool(res.get("ok"))
+		except Exception:
+			frappe.log_error(title="approval resume failed", message=frappe.get_traceback())
 	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -90,6 +90,23 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 			f"[Approval {doc.name} - {doc.title}] {verdict}: {decision}\n"
 			f"Continue the flow with this decision; do not re-ask."
 		)
-		res = send_message(conversation=doc.conversation, message=msg)
+		# File-Box conversations: re-attach the source document. Attachments
+		# ride only the message they were sent with, so a resumed turn can
+		# no longer SEE the pages - observed live: the agent (correctly)
+		# refused to draft rather than fabricate lines it couldn't see.
+		attachments = None
+		title = frappe.db.get_value("Jarvis Conversation", doc.conversation, "title") or ""
+		if title.startswith("File: "):
+			fname = title[len("File: "):]
+			f = frappe.get_all(
+				"File", filters={"file_name": ["like", fname + "%"]},
+				fields=["file_url", "file_name"],
+				order_by="creation desc", limit_page_length=1,
+			)
+			if f:
+				attachments = json.dumps(
+					[{"file_url": f[0].file_url, "file_name": f[0].file_name}]
+				)
+		res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
 		resumed = bool(res.get("ok"))
 	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -48,6 +48,16 @@ def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 	if status not in ("Pending", "Approved", "Rejected", "All"):
 		frappe.throw("Invalid status filter")
 	filters = {} if status == "All" else {"status": status}
+	# Non-SM: filter by ownership IN the query so `limit` applies to the
+	# caller's rows, not to a mixed page that later shrinks (and no N+1).
+	if "System Manager" not in frappe.get_roles():
+		my_convs = frappe.get_all(
+			"Jarvis Conversation", filters={"owner": frappe.session.user},
+			pluck="name",
+		)
+		if not my_convs:
+			return []
+		filters["conversation"] = ["in", my_convs]
 	rows = frappe.get_all(
 		APPROVAL, filters=filters,
 		fields=[
@@ -57,19 +67,9 @@ def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 		],
 		order_by="creation desc", limit_page_length=int(limit),
 	)
-	is_sm = "System Manager" in frappe.get_roles()
-	out = []
 	for r in rows:
-		if not is_sm:
-			conv_owner = (
-				frappe.db.get_value("Jarvis Conversation", r.conversation, "owner")
-				if r.conversation else None
-			)
-			if conv_owner != frappe.session.user:
-				continue
 		r["options"] = _parse_options(r.get("options"))
-		out.append(r)
-	return out
+	return rows
 
 
 @frappe.whitelist()

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -35,9 +35,9 @@ def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 	rows = frappe.get_all(
 		APPROVAL, filters=filters,
 		fields=[
-			"name", "title", "status", "question", "context_md", "options",
-			"conversation", "ref_doctype", "ref_name", "decision",
-			"decided_by", "decided_at", "creation",
+			"name", "title", "status", "document_type", "question",
+			"context_md", "options", "conversation", "ref_doctype",
+			"ref_name", "decision", "decided_by", "decided_at", "creation",
 		],
 		order_by="creation desc", limit_page_length=int(limit),
 	)

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -1,7 +1,6 @@
 """Approvals pane API: pending-decision queue + decide-and-resume.
 
-The agent queues decisions it cannot take autonomously as ``Jarvis
-Approval`` rows (see the ocr-data-entry skill contract) and ends the
+The agent queues decisions it cannot take autonomously as ``Jarvis Approval Request`` rows (see the ocr-data-entry skill contract) and ends the
 turn. The customer decides from the SPA Approvals pane (or the Desk
 list); deciding posts the decision back into the linked conversation
 through the normal ``send_message`` path, so the agent resumes the flow
@@ -14,7 +13,7 @@ import json
 
 import frappe
 
-APPROVAL = "Jarvis Approval"
+APPROVAL = "Jarvis Approval Request"
 
 
 def _parse_options(raw: str | None) -> list[str]:
@@ -45,9 +44,14 @@ def _may_act_on(conversation: str | None) -> bool:
 def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 	"""Approvals visible to the current user (owner of the linked
 	conversation, or any System Manager)."""
-	if status not in ("Pending", "Approved", "Rejected", "All"):
+	if status not in ("Pending", "Approved", "Rejected", "Decided", "All"):
 		frappe.throw("Invalid status filter")
-	filters = {} if status == "All" else {"status": status}
+	if status == "All":
+		filters = {}
+	elif status == "Decided":
+		filters = {"status": ["in", ["Approved", "Rejected"]]}
+	else:
+		filters = {"status": status}
 	# Non-SM: filter by ownership IN the query so `limit` applies to the
 	# caller's rows, not to a mixed page that later shrinks (and no N+1).
 	if "System Manager" not in frappe.get_roles():
@@ -96,12 +100,24 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 		frappe.throw("Not permitted", frappe.PermissionError)
 	if doc.status != "Pending":
 		frappe.throw(f"Approval {name} is already {doc.status}")
-	doc.status = "Approved" if int(approve) else "Rejected"
-	doc.decision = decision
-	doc.decided_by = frappe.session.user
-	doc.decided_at = frappe.utils.now_datetime()
-	doc.save(ignore_permissions=True)
+	new_status = "Approved" if int(approve) else "Rejected"
+	# Conditional flip closes the double-decide race: only ONE concurrent
+	# caller wins the Pending -> decided transition.
+	changed = frappe.db.sql(
+		"""update `tabJarvis Approval Request`
+		set status=%s, decision=%s, decided_by=%s, decided_at=%s
+		where name=%s and status='Pending'""",
+		(new_status, decision, frappe.session.user, frappe.utils.now_datetime(), name),
+	)
+	if not frappe.db.sql(
+		"select 1 from `tabJarvis Approval Request` where name=%s and status=%s and decided_by=%s",
+		(name, new_status, frappe.session.user),
+	):
+		frappe.throw(f"Approval {name} was decided concurrently")
 	frappe.db.commit()
+	doc.reload()
+	# fire the trace-comment hook (db update bypasses on_update)
+	doc.run_method("on_update")
 
 	resumed = False
 	if doc.conversation and frappe.db.exists("Jarvis Conversation", doc.conversation):

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -25,7 +25,7 @@ INBOUND_PROMPT = (
 	"by the skill's convention ladder, and create the draft. Do NOT ask "
 	"me anything in this chat: I am not here. EVERY decision that needs "
 	"a human - including what document this is, or that the file is "
-	"unreadable - goes to a Jarvis Approval row (empty document_type for "
+	"unreadable - goes to a Jarvis Approval Request row (empty document_type for "
 	"classification decisions), then end the turn with a one-line summary."
 )
 
@@ -86,16 +86,34 @@ def list_inbound(limit: int = 30) -> list[dict]:
 		fields=["name", "title", "creation"],
 		order_by="creation desc", limit_page_length=int(limit),
 	)
+	conv_ids = [r.name for r in rows]
+	# Batched: one grouped query for pending approvals, one window query for
+	# each conversation's latest assistant message (was a 2xN loop).
+	pending_by_conv = {}
+	if conv_ids:
+		for row in frappe.get_all(
+			"Jarvis Approval Request",
+			filters={"conversation": ["in", conv_ids], "status": "Pending"},
+			fields=["conversation", "count(name) as n"],
+			group_by="conversation",
+		):
+			pending_by_conv[row.conversation] = row.n
+	last_by_conv = {}
+	if conv_ids:
+		for row in frappe.db.sql(
+			"""select m.conversation, m.streaming, m.error, m.recovering
+			from `tabJarvis Chat Message` m
+			join (select conversation, max(seq) mseq from `tabJarvis Chat Message`
+			      where conversation in %(convs)s and role='assistant'
+			      group by conversation) x
+			  on x.conversation = m.conversation and x.mseq = m.seq
+			where m.role='assistant'""",
+			{"convs": conv_ids}, as_dict=True,
+		):
+			last_by_conv[row.conversation] = row
 	for r in rows:
-		last = frappe.get_all(
-			"Jarvis Chat Message",
-			filters={"conversation": r.name, "role": "assistant"},
-			fields=["streaming", "error", "recovering"],
-			order_by="seq desc", limit_page_length=1,
-		)
-		pending = frappe.db.count(
-			"Jarvis Approval", {"conversation": r.name, "status": "Pending"}
-		)
+		last = [last_by_conv[r.name]] if r.name in last_by_conv else []
+		pending = pending_by_conv.get(r.name, 0)
 		if pending:
 			r["status"] = "needs_approval"
 		elif last and (last[0].streaming or last[0].recovering):

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -1,0 +1,95 @@
+"""File Box: drop an inbound business document, get a draft.
+
+The SPA's File Box pane uploads the file (standard Frappe upload_file),
+then calls ``drop_file``. That creates a conversation named after the
+file and sends ONE directed prompt through the normal send_message +
+attachments machinery: process via the ocr-data-entry skill, decide by
+convention, queue Jarvis Approval rows for real ambiguities, at most one
+consolidated question. The chat stays the execution surface - the File
+Box is just the directed entry point, so streaming, drafts, approvals
+and recovery all behave exactly like a hand-typed turn.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+INBOUND_PROMPT = (
+	"Process the attached file as an inbound business document using the "
+	"ocr-data-entry skill (read skills/ocr-data-entry/SKILL.md first and "
+	"follow its decision policy exactly). Classify the document type, "
+	"extract it fully - every line item verbatim, never a lump-sum "
+	"balancing line - resolve ambiguities by the skill's convention "
+	"ladder, create the draft, and queue a Jarvis Approval for anything "
+	"the ladder cannot resolve. Ask me at most ONE consolidated question, "
+	"and only if the skill's policy requires it."
+)
+
+
+@frappe.whitelist()
+def drop_file(file_url: str, file_name: str | None = None) -> dict:
+	"""Create a conversation for an uploaded file and kick off processing."""
+	file_url = (file_url or "").strip()
+	if not file_url:
+		frappe.throw("file_url is required")
+	# The URL must be a real uploaded File of this site (no external URLs).
+	fdoc = frappe.db.get_value(
+		"File", {"file_url": file_url},
+		["name", "file_name", "file_size", "is_private"], as_dict=True,
+	)
+	if not fdoc:
+		frappe.throw("Unknown file - upload it first")
+
+	from jarvis.chat.api import create_conversation, send_message
+
+	conv_id = create_conversation()
+	title = (file_name or fdoc.file_name or "Inbound document")[:60]
+	frappe.db.set_value(
+		"Jarvis Conversation", conv_id, "title", f"File: {title}",
+		update_modified=False,
+	)
+	frappe.db.commit()
+
+	attachments = json.dumps([{"file_url": file_url, "file_name": file_name or fdoc.file_name}])
+	res = send_message(conversation=conv_id, message=INBOUND_PROMPT, attachments=attachments)
+	return {
+		"ok": bool(res.get("ok")),
+		"conversation_id": conv_id,
+		"run_id": res.get("run_id"),
+		"reason": res.get("reason"),
+	}
+
+
+@frappe.whitelist()
+def list_inbound(limit: int = 30) -> list[dict]:
+	"""Recent File-Box conversations for the pane's inbound list, with a
+	coarse status derived from live chat state - no extra bookkeeping
+	doctype to drift out of sync."""
+	rows = frappe.get_all(
+		"Jarvis Conversation",
+		filters={"title": ["like", "File: %"], "owner": frappe.session.user},
+		fields=["name", "title", "creation"],
+		order_by="creation desc", limit_page_length=int(limit),
+	)
+	for r in rows:
+		last = frappe.get_all(
+			"Jarvis Chat Message",
+			filters={"conversation": r.name, "role": "assistant"},
+			fields=["streaming", "error", "recovering"],
+			order_by="seq desc", limit_page_length=1,
+		)
+		pending = frappe.db.count(
+			"Jarvis Approval", {"conversation": r.name, "status": "Pending"}
+		)
+		if pending:
+			r["status"] = "needs_approval"
+		elif last and (last[0].streaming or last[0].recovering):
+			r["status"] = "processing"
+		elif last and last[0].error:
+			r["status"] = "error"
+		else:
+			r["status"] = "done"
+		r["pending_approvals"] = pending
+	return rows

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -102,6 +102,10 @@ def list_inbound(limit: int = 30) -> list[dict]:
 			r["status"] = "processing"
 		elif last and last[0].error:
 			r["status"] = "error"
+		elif not last:
+			# Dropped but the worker hasn't inserted the assistant
+			# placeholder yet - queued, not done.
+			r["status"] = "processing"
 		else:
 			r["status"] = "done"
 		r["pending_approvals"] = pending

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -17,14 +17,16 @@ import json
 import frappe
 
 INBOUND_PROMPT = (
-	"Process the attached file as an inbound business document using the "
-	"ocr-data-entry skill (read skills/ocr-data-entry/SKILL.md first and "
-	"follow its decision policy exactly). Classify the document type, "
-	"extract it fully - every line item verbatim, never a lump-sum "
-	"balancing line - resolve ambiguities by the skill's convention "
-	"ladder, create the draft, and queue a Jarvis Approval for anything "
-	"the ladder cannot resolve. Ask me at most ONE consolidated question, "
-	"and only if the skill's policy requires it."
+	"This file arrived through the File Box - process it as an inbound "
+	"business document using the ocr-data-entry skill (read "
+	"skills/ocr-data-entry/SKILL.md first and follow its decision policy "
+	"exactly). Classify the document type, extract it fully - every line "
+	"item verbatim, never a lump-sum balancing line - resolve ambiguities "
+	"by the skill's convention ladder, and create the draft. Do NOT ask "
+	"me anything in this chat: I am not here. EVERY decision that needs "
+	"a human - including what document this is, or that the file is "
+	"unreadable - goes to a Jarvis Approval row (empty document_type for "
+	"classification decisions), then end the turn with a one-line summary."
 )
 
 

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -66,7 +66,12 @@ def drop_file(file_url: str, file_name: str | None = None) -> dict:
 	frappe.db.commit()
 
 	attachments = json.dumps([{"file_url": file_url, "file_name": file_name or fdoc.file_name}])
-	res = send_message(conversation=conv_id, message=INBOUND_PROMPT, attachments=attachments)
+	# background=1 (requires the dedicated-chat-queue PR): a batch of
+	# drops drains FIFO and never jumps ahead of a human's typed question.
+	res = send_message(
+		conversation=conv_id, message=INBOUND_PROMPT, attachments=attachments,
+		background=1,
+	)
 	return {
 		"ok": bool(res.get("ok")),
 		"conversation_id": conv_id,

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -91,11 +91,15 @@ def list_inbound(limit: int = 30) -> list[dict]:
 	# each conversation's latest assistant message (was a 2xN loop).
 	pending_by_conv = {}
 	if conv_ids:
-		for row in frappe.get_all(
-			"Jarvis Approval Request",
-			filters={"conversation": ["in", conv_ids], "status": "Pending"},
-			fields=["conversation", "count(name) as n"],
-			group_by="conversation",
+		# Raw SQL: v16's get_all rejects SQL-function strings in fields
+		# ("count(name) as n" -> ValidationError), which 500'd this whole
+		# endpoint for anyone with a File-Box conversation.
+		for row in frappe.db.sql(
+			"""select conversation, count(name) n
+			from `tabJarvis Approval Request`
+			where conversation in %(convs)s and status='Pending'
+			group by conversation""",
+			{"convs": conv_ids}, as_dict=True,
 		):
 			pending_by_conv[row.conversation] = row.n
 	last_by_conv = {}

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -43,6 +43,10 @@ def drop_file(file_url: str, file_name: str | None = None) -> dict:
 	)
 	if not fdoc:
 		frappe.throw("Unknown file - upload it first")
+	# Object-level auth: a caller must not be able to feed SOMEONE ELSE'S
+	# private file_url and have the agent OCR its contents back to them.
+	if not frappe.has_permission("File", doc=fdoc.name):
+		frappe.throw("Not permitted", frappe.PermissionError)
 
 	from jarvis.chat.api import create_conversation, send_message
 
@@ -50,6 +54,13 @@ def drop_file(file_url: str, file_name: str | None = None) -> dict:
 	title = (file_name or fdoc.file_name or "Inbound document")[:60]
 	frappe.db.set_value(
 		"Jarvis Conversation", conv_id, "title", f"File: {title}",
+		update_modified=False,
+	)
+	# Durable exact link: attach the File to the conversation so resumes
+	# re-attach THIS file (not a fragile filename-prefix LIKE match).
+	frappe.db.set_value(
+		"File", fdoc.name,
+		{"attached_to_doctype": "Jarvis Conversation", "attached_to_name": conv_id},
 		update_modified=False,
 	)
 	frappe.db.commit()

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -458,7 +458,10 @@ def handle_chat_send(payload: dict) -> None:
 	# agent formats for the org's region instead of defaulting to US conventions.
 	locale_clause = _org_locale_clause()
 	user_message = (
-		f"[Context: today is {today}{locale_clause}; chat user: {chat_user}{auto_apply}{skill_clause}]"
+		# conv:<id> lets the agent link rows it creates (e.g. Jarvis Approval)
+		# back to this conversation so deciding can resume the chat.
+		f"[Context: today is {today}{locale_clause}; chat user: {chat_user}"
+		f"; conv: {conversation_id}{auto_apply}{skill_clause}]"
 		f"\n\n{user_message or ''}"
 	)
 

--- a/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
+++ b/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
@@ -8,6 +8,7 @@
  "field_order": [
   "title",
   "status",
+  "document_type",
   "conversation",
   "question",
   "context_md",
@@ -16,7 +17,8 @@
   "ref_name",
   "decision",
   "decided_by",
-  "decided_at"
+  "decided_at",
+  "trace_comment_added"
  ],
  "fields": [
   {
@@ -34,6 +36,14 @@
    "in_standard_filter": 1,
    "label": "Status",
    "options": "Pending\nApproved\nRejected"
+  },
+  {
+   "description": "The business document type this decision concerns (e.g. Purchase Invoice). Blank = the document type itself is undetermined (Unclassified tab).",
+   "fieldname": "document_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Document Type"
   },
   {
    "fieldname": "conversation",
@@ -84,6 +94,13 @@
    "fieldname": "decided_at",
    "fieldtype": "Datetime",
    "label": "Decided At"
+  },
+  {
+   "default": "0",
+   "fieldname": "trace_comment_added",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Trace Comment Added"
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
+++ b/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
@@ -1,0 +1,115 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-04 20:30:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "status",
+  "conversation",
+  "question",
+  "context_md",
+  "options",
+  "ref_doctype",
+  "ref_name",
+  "decision",
+  "decided_by",
+  "decided_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending\nApproved\nRejected"
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Link",
+   "label": "Conversation",
+   "options": "Jarvis Conversation"
+  },
+  {
+   "fieldname": "question",
+   "fieldtype": "Small Text",
+   "label": "Question",
+   "reqd": 1
+  },
+  {
+   "description": "Markdown context the approver needs: extracted values, discrepancy notes, what was already checked.",
+   "fieldname": "context_md",
+   "fieldtype": "Long Text",
+   "label": "Context"
+  },
+  {
+   "description": "JSON array of suggested decisions, e.g. [\"Approve as drafted\", \"Reject\"]. Free-text decisions are always allowed.",
+   "fieldname": "options",
+   "fieldtype": "Small Text",
+   "label": "Options (JSON)"
+  },
+  {
+   "fieldname": "ref_doctype",
+   "fieldtype": "Data",
+   "label": "Reference DocType"
+  },
+  {
+   "fieldname": "ref_name",
+   "fieldtype": "Data",
+   "label": "Reference Name"
+  },
+  {
+   "fieldname": "decision",
+   "fieldtype": "Small Text",
+   "label": "Decision"
+  },
+  {
+   "fieldname": "decided_by",
+   "fieldtype": "Link",
+   "label": "Decided By",
+   "options": "User"
+  },
+  {
+   "fieldname": "decided_at",
+   "fieldtype": "Datetime",
+   "label": "Decided At"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-04 20:30:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Approval",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
+++ b/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.json
@@ -123,6 +123,13 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "write": 1,
+   "if_owner": 1,
+   "role": "All"
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.py
+++ b/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Aerele and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class JarvisApproval(Document):
+	"""A decision the agent needs a human for.
+
+	Created by the agent itself (via the generic ``jarvis__create_doc``
+	tool, per the ocr-data-entry skill contract) whenever a document flow
+	hits something conventions cannot resolve. The chat turn ENDS there -
+	the customer decides later from the Approvals pane (or the Desk list),
+	and the decision is posted back into the linked conversation so the
+	agent resumes with full context.
+	"""
+
+	def validate(self):
+		if self.status != "Pending" and not self.decision:
+			frappe.throw("A decided approval must carry the decision text.")

--- a/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.py
+++ b/jarvis/jarvis/doctype/jarvis_approval/jarvis_approval.py
@@ -9,13 +9,47 @@ class JarvisApproval(Document):
 	"""A decision the agent needs a human for.
 
 	Created by the agent itself (via the generic ``jarvis__create_doc``
-	tool, per the ocr-data-entry skill contract) whenever a document flow
-	hits something conventions cannot resolve. The chat turn ENDS there -
-	the customer decides later from the Approvals pane (or the Desk list),
-	and the decision is posted back into the linked conversation so the
+	tool, per the ocr-data-entry skill contract). The chat turn ENDS
+	there - the customer decides later from the Approvals pane/page, and
+	the decision is posted back into the linked conversation so the
 	agent resumes with full context.
 	"""
 
 	def validate(self):
 		if self.status != "Pending" and not self.decision:
 			frappe.throw("A decided approval must carry the decision text.")
+
+	def on_update(self):
+		self._leave_trace_comment()
+
+	def _leave_trace_comment(self):
+		"""Audit trail ON the business document: once this approval is
+		decided AND points at a real document, add a Comment to that
+		document in the name of the deciding user. Runs on every save so
+		it also fires when the agent fills ref_doctype/ref_name AFTER the
+		decision (the resumed flow creates the document later)."""
+		if (
+			self.status == "Pending"
+			or self.trace_comment_added
+			or not (self.ref_doctype and self.ref_name)
+			or not frappe.db.exists(self.ref_doctype, self.ref_name)
+		):
+			return
+		decider = self.decided_by or frappe.session.user
+		comment = frappe.get_doc({
+			"doctype": "Comment",
+			"comment_type": "Comment",
+			"reference_doctype": self.ref_doctype,
+			"reference_name": self.ref_name,
+			"content": (
+				f"Approval <b>{self.name}</b> ({frappe.utils.escape_html(self.title or '')}): "
+				f"<b>{self.status}</b> - {frappe.utils.escape_html(self.decision or '')}"
+			),
+			"comment_email": decider,
+			"comment_by": frappe.utils.get_fullname(decider),
+		})
+		comment.flags.ignore_permissions = True
+		comment.insert(ignore_permissions=True)
+		# owner = the approver, so the trace reads as their action.
+		frappe.db.set_value("Comment", comment.name, "owner", decider, update_modified=False)
+		self.db_set("trace_comment_added", 1, update_modified=False)

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
@@ -108,7 +108,7 @@
  "modified": "2026-07-04 20:30:00.000000",
  "modified_by": "Administrator",
  "module": "Jarvis",
- "name": "Jarvis Approval",
+ "name": "Jarvis Approval Request",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.model.document import Document
 
 
-class JarvisApproval(Document):
+class JarvisApprovalRequest(Document):
 	"""A decision the agent needs a human for.
 
 	Created by the agent itself (via the generic ``jarvis__create_doc``

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -11,3 +11,4 @@ jarvis.patches.v1_3_backfill_llm_auth_mode
 jarvis.patches.v1_4_drop_llm_oauth_fields
 jarvis.patches.v1_5_drop_dev_only_operator_fields
 jarvis.patches.v1_seed_llm_models
+jarvis.patches.v1_6_rename_jarvis_approval

--- a/jarvis/patches/v1_6_rename_jarvis_approval.py
+++ b/jarvis/patches/v1_6_rename_jarvis_approval.py
@@ -2,10 +2,26 @@ import frappe
 
 
 def execute():
-	"""Jarvis Approval -> Jarvis Approval Request: the old name read as
-	'an approved thing'; the doctype stores the whole request lifecycle
-	(Pending IS the queue, decided rows stay as the audit trail)."""
-	if frappe.db.exists("DocType", "Jarvis Approval") and not frappe.db.exists(
-		"DocType", "Jarvis Approval Request"
-	):
-		frappe.rename_doc("DocType", "Jarvis Approval", "Jarvis Approval Request", force=True)
+	"""Jarvis Approval -> Jarvis Approval Request.
+
+	Order-proof: when this runs BEFORE model sync, a straight rename_doc
+	works. When it runs AFTER sync (the new doctype already created from
+	files), move the rows across and drop the orphaned old doctype - the
+	two tables share an identical column set.
+	"""
+	old_dt, new_dt = "Jarvis Approval", "Jarvis Approval Request"
+	if not frappe.db.table_exists(old_dt):
+		return
+	if not frappe.db.exists("DocType", new_dt):
+		frappe.rename_doc("DocType", old_dt, new_dt, force=True)
+		return
+	# Sync won the race: copy rows (identical schema), then drop the old.
+	cols = [c for c in frappe.db.get_table_columns(old_dt)]
+	col_list = ", ".join(f"`{c}`" for c in cols)
+	frappe.db.sql(
+		f"insert ignore into `tab{new_dt}` ({col_list}) select {col_list} from `tab{old_dt}`"
+	)
+	if frappe.db.exists("DocType", old_dt):
+		frappe.delete_doc("DocType", old_dt, force=True, ignore_permissions=True)
+	elif frappe.db.table_exists(old_dt):
+		frappe.db.sql_ddl(f"drop table `tab{old_dt}`")

--- a/jarvis/patches/v1_6_rename_jarvis_approval.py
+++ b/jarvis/patches/v1_6_rename_jarvis_approval.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	"""Jarvis Approval -> Jarvis Approval Request: the old name read as
+	'an approved thing'; the doctype stores the whole request lifecycle
+	(Pending IS the queue, decided rows stay as the audit trail)."""
+	if frappe.db.exists("DocType", "Jarvis Approval") and not frappe.db.exists(
+		"DocType", "Jarvis Approval Request"
+	):
+		frappe.rename_doc("DocType", "Jarvis Approval", "Jarvis Approval Request", force=True)


### PR DESCRIPTION
Companion to jarvis-persona#110 (`ocr-data-entry` skill). Born from the "Book Draft Loreal Invoice" failure (one balancing line, 4+ interrogation rounds).

## What lands
- **`Jarvis Approval` doctype** — a decision the agent needs a human for. The agent creates it itself via the generic `jarvis__create_doc` (no new plugin tool), links it via the new `conv:` id in the per-turn context line, and ends the turn. **Deciding posts the decision back into the linked conversation** (normal `send_message`), so the agent resumes the same chat with full context — "if needed, taken to the same chat interface" by construction.
- **`approvals_api`** — `list_approvals` (conversation-owner or System-Manager scoped), `pending_count`, `decide`.
- **File Box** (`jarvis.chat.filebox`) — `drop_file`: creates a conversation named after the uploaded file and sends ONE directed prompt (process via the ocr-data-entry skill; decide by convention; queue approvals; ≤1 question) through the existing send_message+attachments machinery. `list_inbound` derives status (processing / needs approval / done / error) from live chat state — no bookkeeping doctype to drift out of sync.
- **SPA** — two new rail buttons beside Skills/Macros: **File Box** (drag-drop zone + inbound list with status chips; dropping opens the processing chat) and **Approvals** (pending queue: question, collapsible context, option buttons + free-text, Approve/Reject; deciding jumps into the resumed chat; pending-count badge on the rail, refreshed with the conversation list).

## Verified
- Approval roundtrip smoke-tested (create → list → decide → status/decision recorded → cleanup).
- Both endpoints HTTP-verified as the SPA calls them.
- Frontend builds clean.
- Migration creates the doctype (both sites migrated).
- End-to-end validation with the original Loreal PDF: see the follow-up comment on this PR after the live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)