### PR TITLE
security: harden canvas relay against skill exfil (traversal + size cap)

### DIFF
--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -24,6 +24,10 @@ MSG = "Jarvis Chat Message"
 
 # Cap how many artifacts we'll fetch per turn (defensive).
 _MAX_CANVAS_PER_TURN = 8
+# Per-artifact byte cap. Legit charts/PDFs/xlsx are well under this; the cap
+# bounds how much can leave via a file staged in canvas/ and named with an
+# allowlisted extension (the extension check alone trusts the filename).
+_MAX_CANVAS_BYTES = 25 * 1024 * 1024
 
 # Supported artifact extension -> render type.
 #   html/svg -> sandboxed iframe srcdoc
@@ -113,14 +117,32 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:
+		# Stream so an oversized artifact is capped mid-download, not after a
+		# full read into memory. A chart/PDF/xlsx is well under this; the cap
+		# only bites bulk dumps staged as a renamed canvas file.
 		r = requests.get(
-			url, headers={"Authorization": f"Bearer {token}"}, timeout=20
+			url, headers={"Authorization": f"Bearer {token}"}, timeout=20,
+			stream=True,
 		)
+		if r.status_code != 200:
+			return None
+		chunks, total = [], 0
+		for chunk in r.iter_content(64 * 1024):
+			total += len(chunk)
+			if total > _MAX_CANVAS_BYTES:
+				return None
+			chunks.append(chunk)
 	except Exception:
 		return None
-	if r.status_code != 200 or not r.content:
+	finally:
+		try:
+			r.close()
+		except Exception:
+			pass
+	content = b"".join(chunks)
+	if not content:
 		return None
-	return r.content, _type_for(name)
+	return content, _type_for(name)
 
 
 def _title_for(name: str, content: bytes | None, typ: str) -> str:

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -53,17 +53,34 @@ _CANVAS_LINK = re.compile(
 _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORECASE)
 
 
+def _is_safe_canvas_path(name: str) -> bool:
+	"""Reject anything that could escape the gateway's canvas/ root.
+
+	The reference regex allows subdirs and the ``.``/``-`` chars, so a crafted
+	reply like ``canvas/../skills/erpnext-accounts/SKILL.md`` matches and would
+	otherwise be fetched and saved to the user's site as a download - a
+	traversal that exfiltrates our proprietary skills. The gateway may or may
+	not normalise ``..`` itself; the bench must not depend on that.
+	"""
+	if not name or name.startswith("/") or "\\" in name or "\x00" in name:
+		return False
+	# No segment may be empty (//) or a parent ref (.. / ...).
+	return all(seg not in ("", ".", "..") and set(seg) != {"."} for seg in name.split("/"))
+
+
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
 	Paths keep their subdir (e.g. ``charts/sales.html``) so the gateway fetch
-	hits the right URL.
+	hits the right URL. Traversal paths are dropped (see _is_safe_canvas_path).
 	"""
 	if not text:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
-		seen.setdefault(m.group(1), None)
+		name = m.group(1)
+		if _is_safe_canvas_path(name):
+			seen.setdefault(name, None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]
 
 
@@ -89,6 +106,10 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 
 	base = _http_base(agent_url)
 	if not base or not token:
+		return None
+	# Belt-and-suspenders: never issue a fetch for a traversal path even if a
+	# caller reaches fetch_canvas directly (detect_canvas_names already filters).
+	if not _is_safe_canvas_path(name):
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:


### PR DESCRIPTION
## Why
A customer tried to make the agent zip and hand over its (proprietary) skills. Auditing the artifact-delivery path found the canvas relay would fetch and save to the user's site any `canvas/<path>.<ext>` reference the agent writes, gated only by a filename **extension allowlist**.

## Two holes closed in `jarvis/chat/canvas.py`
1. **Path traversal** — the path regex allows `.` and `/`, so `canvas/../skills/erpnext-accounts/SKILL.md` matched and would be fetched from the gateway and saved as a user download, regardless of whether the gateway normalizes `..`. `detect_canvas_names` now drops any traversal path (empty / `.` / `..` / all-dots segment, leading slash, backslash, NUL); `fetch_canvas` re-checks as a direct-call backstop. Unit-tested.
2. **No size/content bound** — `fetch_canvas` trusted the extension only (no magic-byte, no size cap), so bulk bytes staged as `canvas/x.xlsx` would be delivered. Now streams with a **25MB** per-artifact cap.

## Scope
Part of a defense-in-depth set: persona "skills are internal" refusal rule (jarvis-persona main), fleet native-tool deny trim (jarvis-fleet-agent#110), and this relay hardening. Network egress control and an optional plugin guardrail remain product decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)