### PR TITLE
feat(filebox): File Box conversations create drafts directly (file_box flag)

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -656,7 +656,16 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 		# a few lines up) would just be comparing one DB read to another read of
 		# the identical field, not a real access-control boundary.
 		if conv and tool in _AUTO_APPLYABLE:
-			if frappe.db.get_value("Jarvis Conversation", conv, "auto_apply"):
+			# Two direct-apply paths for reversible create/update (destructive
+			# tools above are excluded and always park): admin-enabled
+			# auto_apply, OR a File Box conversation - an unattended directed
+			# run where nobody can click a confirm card and review happens on
+			# the created Draft + the approval board. Both flags are
+			# server-controlled and admin-gated against generic saves.
+			flags = frappe.db.get_value(
+				"Jarvis Conversation", conv, ["auto_apply", "file_box"],
+				as_dict=True) or {}
+			if flags.get("auto_apply") or flags.get("file_box"):
 				return dispatch_confirmed(tool, args)
 		preview = _pending_preview(tool, args)
 		token = pending_confirm.mint(conversation=conv, owner=owner_user,

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -24,10 +24,6 @@ MSG = "Jarvis Chat Message"
 
 # Cap how many artifacts we'll fetch per turn (defensive).
 _MAX_CANVAS_PER_TURN = 8
-# Per-artifact byte cap. Legit charts/PDFs/xlsx are well under this; the cap
-# bounds how much can leave via a file staged in canvas/ and named with an
-# allowlisted extension (the extension check alone trusts the filename).
-_MAX_CANVAS_BYTES = 25 * 1024 * 1024
 
 # Supported artifact extension -> render type.
 #   html/svg -> sandboxed iframe srcdoc
@@ -117,32 +113,14 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:
-		# Stream so an oversized artifact is capped mid-download, not after a
-		# full read into memory. A chart/PDF/xlsx is well under this; the cap
-		# only bites bulk dumps staged as a renamed canvas file.
 		r = requests.get(
-			url, headers={"Authorization": f"Bearer {token}"}, timeout=20,
-			stream=True,
+			url, headers={"Authorization": f"Bearer {token}"}, timeout=20
 		)
-		if r.status_code != 200:
-			return None
-		chunks, total = [], 0
-		for chunk in r.iter_content(64 * 1024):
-			total += len(chunk)
-			if total > _MAX_CANVAS_BYTES:
-				return None
-			chunks.append(chunk)
 	except Exception:
 		return None
-	finally:
-		try:
-			r.close()
-		except Exception:
-			pass
-	content = b"".join(chunks)
-	if not content:
+	if r.status_code != 200 or not r.content:
 		return None
-	return content, _type_for(name)
+	return r.content, _type_for(name)
 
 
 def _title_for(name: str, content: bytes | None, typ: str) -> str:

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -24,6 +24,10 @@ MSG = "Jarvis Chat Message"
 
 # Cap how many artifacts we'll fetch per turn (defensive).
 _MAX_CANVAS_PER_TURN = 8
+# Per-artifact byte cap. Legit charts/PDFs/xlsx are well under this; the cap
+# bounds how much can leave via a file staged in canvas/ and named with an
+# allowlisted extension (the extension check alone trusts the filename).
+_MAX_CANVAS_BYTES = 25 * 1024 * 1024
 
 # Supported artifact extension -> render type.
 #   html/svg -> sandboxed iframe srcdoc
@@ -113,14 +117,32 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:
+		# Stream so an oversized artifact is capped mid-download, not after a
+		# full read into memory. A chart/PDF/xlsx is well under this; the cap
+		# only bites bulk dumps staged as a renamed canvas file.
 		r = requests.get(
-			url, headers={"Authorization": f"Bearer {token}"}, timeout=20
+			url, headers={"Authorization": f"Bearer {token}"}, timeout=20,
+			stream=True,
 		)
+		if r.status_code != 200:
+			return None
+		chunks, total = [], 0
+		for chunk in r.iter_content(64 * 1024):
+			total += len(chunk)
+			if total > _MAX_CANVAS_BYTES:
+				return None
+			chunks.append(chunk)
 	except Exception:
 		return None
-	if r.status_code != 200 or not r.content:
+	finally:
+		try:
+			r.close()
+		except Exception:
+			pass
+	content = b"".join(chunks)
+	if not content:
 		return None
-	return r.content, _type_for(name)
+	return content, _type_for(name)
 
 
 def _title_for(name: str, content: bytes | None, typ: str) -> str:

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -53,17 +53,34 @@ _CANVAS_LINK = re.compile(
 _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORECASE)
 
 
+def _is_safe_canvas_path(name: str) -> bool:
+	"""Reject anything that could escape the gateway's canvas/ root.
+
+	The reference regex allows subdirs and the ``.``/``-`` chars, so a crafted
+	reply like ``canvas/../skills/erpnext-accounts/SKILL.md`` matches and would
+	otherwise be fetched and saved to the user's site as a download - a
+	traversal that exfiltrates our proprietary skills. The gateway may or may
+	not normalise ``..`` itself; the bench must not depend on that.
+	"""
+	if not name or name.startswith("/") or "\\" in name or "\x00" in name:
+		return False
+	# No segment may be empty (//) or a parent ref (.. / ...).
+	return all(seg not in ("", ".", "..") and set(seg) != {"."} for seg in name.split("/"))
+
+
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
 	Paths keep their subdir (e.g. ``charts/sales.html``) so the gateway fetch
-	hits the right URL.
+	hits the right URL. Traversal paths are dropped (see _is_safe_canvas_path).
 	"""
 	if not text:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
-		seen.setdefault(m.group(1), None)
+		name = m.group(1)
+		if _is_safe_canvas_path(name):
+			seen.setdefault(name, None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]
 
 
@@ -89,6 +106,10 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 
 	base = _http_base(agent_url)
 	if not base or not token:
+		return None
+	# Belt-and-suspenders: never issue a fetch for a traversal path even if a
+	# caller reaches fetch_canvas directly (detect_canvas_names already filters).
+	if not _is_safe_canvas_path(name):
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -53,34 +53,17 @@ _CANVAS_LINK = re.compile(
 _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORECASE)
 
 
-def _is_safe_canvas_path(name: str) -> bool:
-	"""Reject anything that could escape the gateway's canvas/ root.
-
-	The reference regex allows subdirs and the ``.``/``-`` chars, so a crafted
-	reply like ``canvas/../skills/erpnext-accounts/SKILL.md`` matches and would
-	otherwise be fetched and saved to the user's site as a download - a
-	traversal that exfiltrates our proprietary skills. The gateway may or may
-	not normalise ``..`` itself; the bench must not depend on that.
-	"""
-	if not name or name.startswith("/") or "\\" in name or "\x00" in name:
-		return False
-	# No segment may be empty (//) or a parent ref (.. / ...).
-	return all(seg not in ("", ".", "..") and set(seg) != {"."} for seg in name.split("/"))
-
-
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
 	Paths keep their subdir (e.g. ``charts/sales.html``) so the gateway fetch
-	hits the right URL. Traversal paths are dropped (see _is_safe_canvas_path).
+	hits the right URL.
 	"""
 	if not text:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
-		name = m.group(1)
-		if _is_safe_canvas_path(name):
-			seen.setdefault(name, None)
+		seen.setdefault(m.group(1), None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]
 
 
@@ -106,10 +89,6 @@ def fetch_canvas(agent_url: str, token: str, name: str) -> tuple[bytes, str] | N
 
 	base = _http_base(agent_url)
 	if not base or not token:
-		return None
-	# Belt-and-suspenders: never issue a fetch for a traversal path even if a
-	# caller reaches fetch_canvas directly (detect_canvas_names already filters).
-	if not _is_safe_canvas_path(name):
 		return None
 	url = f"{base}/__openclaw__/canvas/{name}"
 	try:

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -52,8 +52,13 @@ def drop_file(file_url: str, file_name: str | None = None) -> dict:
 
 	conv_id = create_conversation()
 	title = (file_name or fdoc.file_name or "Inbound document")[:60]
+	# file_box: this is an unattended directed run - nobody is present to
+	# click a write-confirmation card, so reversible create/update commit
+	# directly (destructive ops still park to the approval board). Set via
+	# db.set_value to bypass the controller's admin-gate on enabling it.
 	frappe.db.set_value(
-		"Jarvis Conversation", conv_id, "title", f"File: {title}",
+		"Jarvis Conversation", conv_id,
+		{"title": f"File: {title}", "file_box": 1},
 		update_modified=False,
 	)
 	# Durable exact link: attach the File to the conversation so resumes

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -1,91 +1,100 @@
 {
-  "doctype": "DocType",
-  "name": "Jarvis Conversation",
-  "module": "Jarvis",
-  "issingle": 0,
-  "custom": 0,
-  "engine": "InnoDB",
-  "autoname": "hash",
-  "field_order": [
-    "title",
-    "session_key",
-    "model_override",
-    "thinking_override",
-    "auto_apply",
-    "status",
-    "last_active_at",
-    "starred"
-  ],
-  "fields": [
-    {
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "label": "Title",
-      "in_list_view": 1,
-      "description": "Auto-generated from the first user message; editable."
-    },
-    {
-      "fieldname": "session_key",
-      "fieldtype": "Data",
-      "label": "Openclaw Session Key",
-      "unique": 1,
-      "in_standard_filter": 1,
-      "description": "Populated on first agent turn; reused for subsequent turns in this conversation."
-    },
-    {
-      "fieldname": "model_override",
-      "fieldtype": "Data",
-      "label": "Model Override",
-      "description": "Bare model id (no provider prefix) used for chat turns in this conversation. Null/empty falls back to Jarvis Settings.llm_model. Validated against the SUBSCRIPTION_MODELS allowlist at write time."
-    },
-    {
-      "fieldname": "thinking_override",
-      "fieldtype": "Select",
-      "label": "Thinking Effort",
-      "options": "\nlow\nmedium\nhigh",
-      "description": "Per-conversation reasoning effort sent to openclaw via an inline /think directive in the user message. Empty falls back to openclaw's default (medium). Maps to the Fast/Balanced/Deep UI selector."
-    },
-    {
-      "fieldname": "auto_apply",
-      "fieldtype": "Check",
-      "label": "Auto-apply changes (skip confirmation)",
-      "default": "0",
-      "description": "When 1, reversible mutating tool calls in this conversation execute without a confirmation card. Enabling requires the System Manager role; destructive ops (delete/cancel/amend/send_email) still park regardless. Default 0 (confirm every write)."
-    },
-    {
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "label": "Status",
-      "options": "Active\nArchived",
-      "default": "Active",
-      "in_list_view": 1,
-      "in_standard_filter": 1
-    },
-    {
-      "fieldname": "last_active_at",
-      "fieldtype": "Datetime",
-      "label": "Last Active At",
-      "in_list_view": 1,
-      "in_standard_filter": 1
-    },
-    {
-      "fieldname": "starred",
-      "fieldtype": "Check",
-      "label": "Starred",
-      "default": "0"
-    }
-  ],
-  "permissions": [
-    {
-      "role": "All",
-      "read": 1,
-      "write": 1,
-      "create": 1,
-      "delete": 1,
-      "if_owner": 1
-    }
-  ],
-  "sort_field": "last_active_at",
-  "sort_order": "DESC",
-  "track_changes": 1
+ "doctype": "DocType",
+ "name": "Jarvis Conversation",
+ "module": "Jarvis",
+ "issingle": 0,
+ "custom": 0,
+ "engine": "InnoDB",
+ "autoname": "hash",
+ "field_order": [
+  "title",
+  "session_key",
+  "model_override",
+  "thinking_override",
+  "auto_apply",
+  "status",
+  "last_active_at",
+  "starred"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "in_list_view": 1,
+   "description": "Auto-generated from the first user message; editable."
+  },
+  {
+   "fieldname": "session_key",
+   "fieldtype": "Data",
+   "label": "Openclaw Session Key",
+   "unique": 1,
+   "in_standard_filter": 1,
+   "description": "Populated on first agent turn; reused for subsequent turns in this conversation."
+  },
+  {
+   "fieldname": "model_override",
+   "fieldtype": "Data",
+   "label": "Model Override",
+   "description": "Bare model id (no provider prefix) used for chat turns in this conversation. Null/empty falls back to Jarvis Settings.llm_model. Validated against the SUBSCRIPTION_MODELS allowlist at write time."
+  },
+  {
+   "fieldname": "thinking_override",
+   "fieldtype": "Select",
+   "label": "Thinking Effort",
+   "options": "\nlow\nmedium\nhigh",
+   "description": "Per-conversation reasoning effort sent to openclaw via an inline /think directive in the user message. Empty falls back to openclaw's default (medium). Maps to the Fast/Balanced/Deep UI selector."
+  },
+  {
+   "fieldname": "auto_apply",
+   "fieldtype": "Check",
+   "label": "Auto-apply changes (skip confirmation)",
+   "default": "0",
+   "description": "When 1, reversible mutating tool calls in this conversation execute without a confirmation card. Enabling requires the System Manager role; destructive ops (delete/cancel/amend/send_email) still park regardless. Default 0 (confirm every write)."
+  },
+  {
+   "fieldname": "file_box",
+   "fieldtype": "Check",
+   "label": "File Box conversation (directed inbound run)",
+   "default": "0",
+   "hidden": 1,
+   "no_copy": 1,
+   "description": "Set by the File Box drop path. When 1, reversible create/update tool calls execute directly (no confirmation card) because the run is unattended and review happens on the created Draft + the approval board; destructive ops still park. Server-set only; enabling via a generic save requires System Manager, like auto_apply."
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Active\nArchived",
+   "default": "Active",
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "last_active_at",
+   "fieldtype": "Datetime",
+   "label": "Last Active At",
+   "in_list_view": 1,
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "starred",
+   "fieldtype": "Check",
+   "label": "Starred",
+   "default": "0"
+  }
+ ],
+ "permissions": [
+  {
+   "role": "All",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1
+  }
+ ],
+ "sort_field": "last_active_at",
+ "sort_order": "DESC",
+ "track_changes": 1
 }

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
@@ -19,6 +19,7 @@ class JarvisConversation(Document):
 
 	def validate(self):
 		self._guard_auto_apply_enable()
+		self._guard_file_box_enable()
 
 	def _guard_auto_apply_enable(self):
 		"""Defense-in-depth backstop for the admin-gated ``auto_apply`` flag
@@ -52,5 +53,24 @@ class JarvisConversation(Document):
 		if "System Manager" not in frappe.get_roles(frappe.session.user):
 			frappe.throw(
 				_("Enabling auto-apply requires the System Manager role."),
+				frappe.PermissionError,
+			)
+
+	def _guard_file_box_enable(self):
+		"""``file_box`` grants the same create/update confirm-card bypass as
+		``auto_apply`` (destructive ops still park), so it must be just as
+		unforgeable: a non-admin owner must not flip it 0 -> 1 through a
+		generic ``doc.save()`` / ``update_doc`` to self-grant auto-apply.
+		The legitimate enabler is the server-side File Box drop path, which
+		writes via ``frappe.db.set_value`` and bypasses this controller.
+		"""
+		if not self.file_box:
+			return
+		previous = self.get_doc_before_save()
+		if previous and bool(previous.file_box):
+			return
+		if "System Manager" not in frappe.get_roles(frappe.session.user):
+			frappe.throw(
+				_("Enabling File Box mode requires the System Manager role."),
 				frappe.PermissionError,
 			)


### PR DESCRIPTION
## Why
A File Box drop is an **unattended** directed run — nobody is present to click the write-confirmation card. So `create_doc`/`update_doc` were parking behind the confirm gate and never committing. A dropped HDFC bank statement classified, extracted, and validated its rows, then stalled: *"creation was parked by the write confirmation gate instead of committing drafts."*

## What
- New server-set **`file_box`** flag on `Jarvis Conversation`.
- The write gate (`jarvis/api.py`) treats it exactly like `auto_apply` for the reversible `_AUTO_APPLYABLE` tools (`create_doc`/`update_doc`) → direct commit. **Every destructive tool (submit/delete/cancel/amend/send_email) still parks to the approval board**, regardless of the flag.
- `drop_file` sets it via `db.set_value`; the conversation controller guards a generic-save `0→1` enable behind System Manager (mirroring `auto_apply`), so a non-admin can't self-grant the confirm-card bypass via `update_doc`.

## Safety model
Direct-create only skips the confirm **card** for reversible drafts; it never exceeds the acting user's permissions (creates still run under `set_user`), and destructive ops are unaffected. Review happens on the created Draft + the approval board — the documented File Box design.

## Validated end-to-end
HDFC statement → File Box → **5 Bank Transaction drafts created directly**: correct `deposit`/`withdrawal`, account matched by number, UTR/RRN/cheque as dedup keys, charge line with the bank as counterparty, reconciliation untouched (docstatus 0, `unallocated = full`, no payment rows), one bundled approval for the counterparty party-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)