### PR TITLE
docs: merge convention (never merge a red PR)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Pre-merge checklist
+
+> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
+> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
+> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
+- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
+- [ ] New/changed behavior has tests (the coverage gate still passes)
+- [ ] I self-reviewed the diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Merge policy — please read
+
+These repositories are **private on the GitHub Free plan**, where branch protection and
+rulesets are **not enforced**. GitHub will *not* stop a pull request with a failing check
+from being merged, so this rule is on us, not the tooling:
+
+> **Never merge a pull request while its CI check is red.**
+
+Every PR runs the **`tests`** job (test suite + a coverage gate). Before you click
+**Merge**:
+
+1. Confirm **`tests`** is ✅ green on the PR.
+2. Make sure the branch is **up to date with `main`** — merge/rebase the latest `main`
+   in first. Testing against a stale `main` is what let cross-instance drift break UAT.
+3. If the check is ❌ or still running, **wait or fix first**. A red merge is exactly how
+   a broken change reaches UAT.
+
+That is the whole convention. If we later move to GitHub Team/Enterprise, the same rule
+becomes automatically enforced and this file just documents it.


### PR DESCRIPTION
Adds `CONTRIBUTING.md` + a PR template documenting our merge convention.

**Why:** these repos are private on the GitHub **Free** plan, where branch protection /
rulesets are **not enforced** — GitHub won't block a merge on a red check. So the rule
lives with us: **never merge a PR while its `tests` check is red, and keep the branch up
to date with `main`.** The PR template surfaces this as a pre-merge checklist.

Docs-only; no code changes. Pairs with the CI in #187 (kept separate so it lands
independently of that PR's rebase).