### PR TITLE
feat(chat): capture query-report route context for the LLM prompt

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -488,15 +488,25 @@ def send_message(
 	if atts:
 		enqueue_kwargs["attachments"] = atts
 	# Floating-widget auto-context: {doctype, name, label} of the doc the user
-	# is viewing. Only forwarded when present, for the same not-yet-reloaded
-	# worker safety as attachments above.
+	# is viewing, OR {report_name, filters} when the user is on a
+	# query-report route. Only forwarded when present, for the same
+	# not-yet-reloaded worker safety as attachments above. The narrowing
+	# here is deliberate (allow-list, not passthrough) so a compromised /
+	# stale frontend can't smuggle arbitrary keys into the worker payload;
+	# every key the prompt-side actually consumes must be listed here.
 	if context:
 		try:
 			ctx = frappe.parse_json(context)
-			if isinstance(ctx, dict) and ctx.get("doctype"):
+			if isinstance(ctx, dict) and (ctx.get("doctype") or ctx.get("report_name")):
 				enqueue_kwargs["context"] = {
-					"doctype": ctx.get("doctype"),
+					"doctype": ctx.get("doctype") or "",
 					"name": ctx.get("name") or "",
+					"report_name": ctx.get("report_name") or "",
+					# filters is a dict of Frappe filter values (scalars,
+					# lists, or ``["op", "value"]`` pairs). Kept as-is;
+					# the prompt-side helper caps the rendered string
+					# length so a huge dict can't blow the context.
+					"filters": ctx.get("filters") if isinstance(ctx.get("filters"), dict) else None,
 				}
 		except Exception:
 			pass

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -845,14 +845,51 @@ def handle_chat_send(payload: dict) -> None:
 			)
 
 
+_REPORT_FILTER_LINE_CAP = 400
+
+
+def _format_report_filters(filters: dict) -> str:
+	"""Compact one-line ``with filters {k=v, k=v}`` summary of a report's
+	active filter dict. Falsy values (None / "" / [] / {}) are skipped so
+	an unset optional filter doesn't clutter the line. Truncates at
+	``_REPORT_FILTER_LINE_CAP`` characters with a "(truncated; N total)"
+	suffix so a pathological filter dict (e.g. 100 keys, or a filter that
+	itself is a huge nested structure) can't blow the prompt budget.
+	Returns "" (empty string) when there are no meaningful filter values,
+	so the caller can concatenate it directly."""
+	pairs = [
+		f"{k}={v!r}"
+		for k, v in filters.items()
+		if v not in (None, "", [], {})
+	]
+	if not pairs:
+		return ""
+	body = ", ".join(pairs)
+	if len(body) > _REPORT_FILTER_LINE_CAP:
+		body = body[:_REPORT_FILTER_LINE_CAP] + f"... (truncated; {len(pairs)} filters total)"
+	return f" with filters {{{body}}}"
+
+
 def _prepend_doc_context(user_message: str, context) -> str:
-	"""Prepend the ERP doc the user was viewing (floating-widget auto-context)
-	as a leading ``[Viewing: ...]`` line, so questions like "is this overdue?"
-	resolve against the right record without the user naming it. Prompt-only;
-	the stored message is untouched. Defensive: a malformed context is ignored.
+	"""Prepend the ERP doc / report the user was viewing (floating-widget
+	auto-context) as a leading ``[Viewing: ...]`` line, so questions like
+	"is this overdue?" or "why is this row missing?" resolve against the
+	right record without the user naming it. Prompt-only; the stored
+	message is untouched. Defensive: a malformed context is ignored.
+
+	Report branch (added 2026-07-06): when ``context.report_name`` is set,
+	emits ``[Viewing: <Report Name> report with filters {k=v, ...}]`` so
+	the model can answer questions about the current filter set + call
+	``run_report`` with the same filters without asking. The filter line
+	is length-capped via ``_format_report_filters`` above.
 	"""
 	if not isinstance(context, dict):
 		return user_message
+	report_name = (context.get("report_name") or "").strip()
+	if report_name:
+		filters = context.get("filters") if isinstance(context.get("filters"), dict) else {}
+		filter_line = _format_report_filters(filters) if filters else ""
+		return f"[Viewing: {report_name} report{filter_line}; resolve 'this'/'here' against it]\n\n{user_message}"
 	doctype = (context.get("doctype") or "").strip()
 	if not doctype:
 		return user_message

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -164,6 +164,41 @@ function readContext() {
 				doctypeLabel: `${r[1].toLowerCase()} list`,
 				label: `${r[1]} (list)`,
 			};
+		} else if (r[0] === "query-report" && r[1]) {
+			// query-report route was a dead branch pre-2026-07-06: the widget
+			// treated it like "unknown page" and stripped the context to
+			// null, so the model had to re-derive the filter set from the
+			// user's natural-language message. Capture report_name + the
+			// live filter dict from frappe.query_report (the currently-
+			// active report instance) so the backend can prepend a
+			// "[Viewing: <report> with filters {...}]" line. Defensive
+			// against report_doc being partially loaded during the SPA's
+			// initial route: falls back to just the name if get_values()
+			// isn't ready.
+			const reportName = r[1];
+			let filters = {};
+			let refDoctype = "";
+			try {
+				if (window.frappe && frappe.query_report
+					&& typeof frappe.query_report.get_values === "function") {
+					filters = frappe.query_report.get_values() || {};
+				}
+				const meta = window.frappe && frappe.query_reports
+					&& frappe.query_reports[reportName];
+				if (meta && meta.report_doc && meta.report_doc.ref_doctype) {
+					refDoctype = meta.report_doc.ref_doctype;
+				}
+			} catch (e) {
+				// keep whatever we captured; empty filters is still useful
+			}
+			context.value = {
+				doctype: refDoctype,
+				name: "",
+				report_name: reportName,
+				filters,
+				doctypeLabel: `${reportName} report`,
+				label: `Report: ${reportName}`,
+			};
 		} else {
 			context.value = null;
 		}

--- a/jarvis/tests/test_turn_handler_report_context.py
+++ b/jarvis/tests/test_turn_handler_report_context.py
@@ -1,0 +1,189 @@
+"""Tests for the query-report branch of ``_prepend_doc_context`` and its
+sibling helper ``_format_report_filters``.
+
+Both were added 2026-07-06 to close the gap where the Desk chat widget's
+``readContext()`` had no branch for ``/app/query-report/*`` - the LLM
+received zero filter context, so the model had to re-derive filters from
+the user's natural-language message. The frontend now captures
+``{report_name, filters}`` for query-report routes; these tests pin the
+backend half of the round-trip.
+"""
+
+from __future__ import annotations
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.turn_handler import (
+	_REPORT_FILTER_LINE_CAP,
+	_format_report_filters,
+	_prepend_doc_context,
+)
+
+
+class TestFormatReportFilters(FrappeTestCase):
+	def test_empty_dict_returns_empty_string(self):
+		self.assertEqual(_format_report_filters({}), "")
+
+	def test_all_falsy_values_returns_empty_string(self):
+		"""None / "" / [] / {} are all "unset" from the operator's
+		perspective - dropping them keeps the prompt line tight."""
+		self.assertEqual(
+			_format_report_filters({
+				"customer": None,
+				"company": "",
+				"cost_centers": [],
+				"tag_filters": {},
+			}),
+			"",
+		)
+
+	def test_scalar_values_render_as_key_repr_pairs(self):
+		out = _format_report_filters({
+			"company": "Acme Ltd",
+			"from_date": "2026-01-01",
+			"show_opening_entries": 1,
+		})
+		self.assertTrue(out.startswith(" with filters {"))
+		self.assertIn("company='Acme Ltd'", out)
+		self.assertIn("from_date='2026-01-01'", out)
+		self.assertIn("show_opening_entries=1", out)
+		self.assertTrue(out.endswith("}"))
+
+	def test_list_and_operator_pair_values_survive(self):
+		"""Frappe filters can be lists (multi-select) or ``["op", "value"]``
+		pairs (negation, ranges). Both must render as-is so the model
+		can call ``run_report`` with the same shape."""
+		out = _format_report_filters({
+			"account": ["Debtors", "Creditors"],
+			"posting_date": ["between", ["2026-01-01", "2026-01-31"]],
+		})
+		self.assertIn("account=['Debtors', 'Creditors']", out)
+		self.assertIn("posting_date=['between', ['2026-01-01', '2026-01-31']]", out)
+
+	def test_truncates_at_cap_with_total_count(self):
+		"""A pathological filter dict (many keys, or a single huge value)
+		must not blow the prompt budget. Cap kicks in with a marker so
+		the model knows more filters exist than what's shown."""
+		# Build a filter dict whose rendered body clearly exceeds the cap.
+		huge = {f"filter_{i}": "x" * 40 for i in range(20)}
+		out = _format_report_filters(huge)
+		# The prefix ' with filters {' + suffix '}' surround the body,
+		# so the whole line will be > cap. What matters is that the body
+		# is truncated and the count marker is present.
+		self.assertIn("(truncated;", out)
+		self.assertIn("20 filters total)", out)
+		# The full body would be ~ 20 * (len("filter_XX='xxx...xx'") + 2)
+		# = well over the cap; the truncation shortens it.
+		self.assertLess(len(out), 800)  # generous upper bound; cap is 400
+
+	def test_truncation_marker_matches_actual_key_count(self):
+		"""Sanity: the "N filters total" number is derived from the input
+		length, so it must equal the number of *non-falsy* keys."""
+		filters = dict.fromkeys([f"k{i}" for i in range(50)], "value_" + "x" * 30)
+		# Also add some falsy entries that must NOT be counted.
+		filters["skip_a"] = None
+		filters["skip_b"] = ""
+		out = _format_report_filters(filters)
+		self.assertIn("(truncated;", out)
+		self.assertIn("50 filters total)", out)
+
+	def test_line_cap_is_400(self):
+		"""Pin the cap constant so a future change is a deliberate opt-in,
+		not an accidental prompt-budget blowout."""
+		self.assertEqual(_REPORT_FILTER_LINE_CAP, 400)
+
+
+class TestPrependDocContextReportBranch(FrappeTestCase):
+	"""Pin the query-report branch of ``_prepend_doc_context``. The
+	pre-existing doctype / list branches are covered indirectly by
+	``test_turn_handler_thinking.py`` (which pins that ``/think`` leads
+	even when ``[Viewing: ...]`` prefixes); this class only exercises
+	the report path added 2026-07-06."""
+
+	def test_report_name_with_no_filters(self):
+		out = _prepend_doc_context(
+			"why zero rows?",
+			{"report_name": "General Ledger", "filters": {}},
+		)
+		self.assertEqual(
+			out,
+			"[Viewing: General Ledger report; resolve 'this'/'here' against it]"
+			"\n\nwhy zero rows?",
+		)
+
+	def test_report_name_with_filters(self):
+		out = _prepend_doc_context(
+			"widen the date range by a month",
+			{
+				"report_name": "General Ledger",
+				"filters": {
+					"company": "Acme Ltd",
+					"from_date": "2026-01-01",
+					"to_date": "2026-01-31",
+				},
+			},
+		)
+		self.assertIn(
+			"[Viewing: General Ledger report with filters {",
+			out,
+		)
+		self.assertIn("company='Acme Ltd'", out)
+		self.assertIn("from_date='2026-01-01'", out)
+		self.assertTrue(out.endswith("widen the date range by a month"))
+
+	def test_report_name_takes_precedence_over_doctype(self):
+		"""The report route also carries ``ref_doctype`` (e.g. General
+		Ledger -> GL Entry). When both fields are set we want the report
+		phrasing (with filter context), not the doctype phrasing."""
+		out = _prepend_doc_context(
+			"what is this?",
+			{
+				"report_name": "General Ledger",
+				"filters": {"company": "Acme Ltd"},
+				"doctype": "GL Entry",
+				"name": "",
+			},
+		)
+		self.assertIn("General Ledger report", out)
+		self.assertNotIn("GL Entry", out)
+
+	def test_missing_report_name_falls_through_to_doctype_branch(self):
+		"""Regression check: the pre-existing doctype path must not
+		break for a plain Form/List capture that has no report_name."""
+		out = _prepend_doc_context(
+			"is this overdue?",
+			{"doctype": "Sales Invoice", "name": "SINV-0001"},
+		)
+		self.assertEqual(
+			out,
+			"[Viewing: Sales Invoice SINV-0001; resolve 'this'/'here' against it]"
+			"\n\nis this overdue?",
+		)
+
+	def test_empty_context_returns_unchanged(self):
+		"""Regression: no context still returns the raw user message."""
+		self.assertEqual(_prepend_doc_context("hello", None), "hello")
+		self.assertEqual(_prepend_doc_context("hello", {}), "hello")
+
+	def test_report_name_whitespace_only_is_ignored(self):
+		"""Whitespace-only report_name isn't a real report - fall through
+		to the doctype branch (or return unchanged if that's empty too)."""
+		out = _prepend_doc_context(
+			"any updates?",
+			{"report_name": "   ", "filters": {"x": 1}},
+		)
+		self.assertEqual(out, "any updates?")
+
+	def test_filters_that_are_not_a_dict_are_dropped(self):
+		"""If the frontend somehow ships a non-dict filters value (bad
+		JSON, stale schema, etc.) the report line still renders - just
+		without a "with filters" clause."""
+		out = _prepend_doc_context(
+			"tell me about this",
+			{"report_name": "Stock Ledger", "filters": "oops-a-string"},
+		)
+		self.assertEqual(
+			out,
+			"[Viewing: Stock Ledger report; resolve 'this'/'here' against it]"
+			"\n\ntell me about this",
+		)


### PR DESCRIPTION
## Phase 0 of the per-report-skills goal

The Desk floating-widget's `readContext()` had branches for `Form` and `List` routes but **nothing for `/app/query-report/*`** - reports fell into the `else` and stripped context to `null`. The LLM saw zero filter context, so it had to re-derive filters from the user's natural-language message every time.

This PR captures `{report_name, filters}` on the frontend and prepends them on the backend, so:
- The model knows which report the user is currently viewing.
- The model sees the live filter dict without asking or re-running the report.
- Once the per-module report skills land (Phase 1 onward), the model both knows the report's shape (from the skill) and its current filter state (from this capture).

## Three thin edits + one new test file

### `jarvis/public/js/jarvis_chat/widget/Widget.vue` — new capture branch

```js
} else if (r[0] === "query-report" && r[1]) {
    const reportName = r[1];
    let filters = {};
    let refDoctype = "";
    try {
        if (frappe.query_report && typeof frappe.query_report.get_values === "function") {
            filters = frappe.query_report.get_values() || {};
        }
        const meta = frappe.query_reports && frappe.query_reports[reportName];
        if (meta && meta.report_doc && meta.report_doc.ref_doctype) {
            refDoctype = meta.report_doc.ref_doctype;
        }
    } catch (e) { /* keep whatever we captured */ }
    context.value = {
        doctype: refDoctype, name: "",
        report_name: reportName, filters,
        doctypeLabel: `${reportName} report`,
        label: `Report: ${reportName}`,
    };
}
```

### `jarvis/chat/api.py` — widen the enqueue allow-list

The narrowing is preserved as an allow-list (not passthrough) so a stale/compromised frontend can't smuggle arbitrary keys into the worker payload. `filters` is only accepted when it's actually a dict.

### `jarvis/chat/turn_handler.py::_prepend_doc_context` — new report branch

Emits `[Viewing: <Report Name> report with filters {k=v, k=v}; resolve 'this'/'here' against it]`. Report branch takes precedence over doctype (the query-report route also carries `ref_doctype`, but the model should think about the report, not the underlying table).

New sibling `_format_report_filters` helper:
- Skips falsy values (`None / \"\" / [] / {}`) so unset optional filters don't clutter the line.
- Caps the rendered line at 400 chars with a `(truncated; N filters total)` marker so a pathological dict can't blow the prompt budget.

## Verification

```
bench --site jarvis-test.localhost run-tests --module jarvis.tests.test_turn_handler_report_context
-> Ran 14 tests in 0.003s, OK
```

Coverage:
- `test_format_report_filters` (7 tests): empty, all-falsy, scalars, lists, operator-pairs, truncation shape, cap-value pin.
- `test_prepend_doc_context_report_branch` (7 tests): with/without filters, precedence over doctype, whitespace-only fallthrough, non-dict filters, empty-context regression.

## What this enables

Before this PR, asking \"why zero rows?\" while viewing General Ledger with a company + date range set → model asked back \"which report? which filters?\"

After this PR, the model sees:
```
[Viewing: General Ledger report with filters {company='Acme Ltd', from_date='2026-01-01', to_date='2026-01-31'}; resolve 'this'/'here' against it]

why zero rows?
```

And can call `run_report` with the same filters or reason about the filter set directly.

## Notes

- **Frontend bundle** is not rebuilt in this commit. `bench build --app jarvis` regenerates `jarvis_widget.bundle.js` on deploy; the gitignored `jarvis/public/dist/` never lives in git.
- **Pre-existing test errors** in `test_turn_handler_thinking` (3 errors in `setUp` calling `create_conversation`) are baseline dev-bench fixture failures on the parent commit; verified by stashing changes and re-running against origin/main. Not touched by this PR.
- **Phase 1** (ERPNext Accounts report skills as Batch 1) starts once you've reviewed + merged this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)