### PR TITLE
fix(test): order-independent test_apply_learned_skills_delegates_to_compiler

### DIFF
--- a/jarvis/tests/test_learned_api.py
+++ b/jarvis/tests/test_learned_api.py
@@ -479,11 +479,21 @@ class TestLearnedApi(unittest.TestCase):
 	# apply delegation + status proxy
 	# ------------------------------------------------------------------ #
 	def test_apply_learned_skills_delegates_to_compiler(self):
-		stub = types.ModuleType("jarvis.learning.compiler")
-		stub.apply_learned_skills = lambda: {"ok": True, "sentinel": "compiled"}
-		with mock.patch.dict(sys.modules, {"jarvis.learning.compiler": stub}):
+		# Patch the delegated function directly, NOT the whole module via
+		# sys.modules. apply_learned_skills() reaches the compiler with
+		# ``from jarvis.learning import compiler`` (a package-attribute bind that
+		# returns the REAL module once it has been imported anywhere), so a
+		# sys.modules stub is bypassed for the top-level call yet still shadows
+		# the deep ``from jarvis.learning.compiler import build_learned_push_payload``
+		# in enqueue_learned_skills_push -> ImportError "(unknown location)".
+		# That made the test order-dependent (green alone, red in the full suite/CI).
+		with mock.patch(
+			"jarvis.learning.compiler.apply_learned_skills",
+			return_value={"ok": True, "sentinel": "compiled"},
+		) as m:
 			out = learned_api.apply_learned_skills()
 		self.assertEqual(out["sentinel"], "compiled")
+		self.assertTrue(m.called)
 
 	def test_get_learned_apply_status_proxies_sync(self):
 		out = learned_api.get_learned_apply_status()


### PR DESCRIPTION
## Problem
main's CI (and #221's) fails with a single error:
```
ERROR test_apply_learned_skills_delegates_to_compiler
ImportError: cannot import name 'build_learned_push_payload' from 'jarvis.learning.compiler' (unknown location)
```
Green when the module runs alone, red in the full suite — an **order-dependent test bug**.

## Root cause
The test swapped the whole `jarvis.learning.compiler` module via `mock.patch.dict(sys.modules, …)` with a bare `types.ModuleType` (no `__file__` → "unknown location"). But `learned_api.apply_learned_skills()` reaches the compiler through `from jarvis.learning import compiler`, which binds the **real** module (package attribute) once compiler has been imported anywhere. So the stub was bypassed for the top-level delegation, yet still shadowed the deep `from jarvis.learning.compiler import build_learned_push_payload` inside `enqueue_learned_skills_push` → ImportError. Whether it triggers depends on whether the real compiler was imported earlier (yes in the full suite/CI, no in isolation).

## Fix
Patch the delegated function directly (`mock.patch("jarvis.learning.compiler.apply_learned_skills", …)`) instead of swapping the module. **Test-only change — no production code touched.**

## Verification
Deterministically reproduced the old failure (real compiler pre-imported) and confirmed the fix returns the sentinel without descending into the push path; `test_learned_api` module 59/59 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)