### PR TITLE
fix(security): enforce conversation ownership on chat endpoints (SEC-002)

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -724,12 +724,18 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 	Returns {"ok": True, "data": {"effective_model": <model>}} where
 	effective_model is what will be sent for the next turn - either
 	the override or the settings default.
+
+	Owner-only (SEC-002): mutates the conversation via ``db.set_value`` (which
+	bypasses permission checks), so ownership is asserted explicitly here.
 	"""
-	if not frappe.db.exists(CONV, conversation):
+	owner = frappe.db.get_value(CONV, conversation, "owner")
+	if owner is None:
 		return {"ok": False, "error": {
 			"code": "unknown_conversation",
 			"message": f"conversation {conversation!r} not found",
 		}}
+	if owner != frappe.session.user:
+		raise frappe.PermissionError("not your conversation")
 
 	settings = frappe.get_single("Jarvis Settings")
 
@@ -774,12 +780,18 @@ def set_conversation_thinking(conversation: str, thinking: str | None = None) ->
 	Empty / None clears it, so turns fall back to openclaw's default. The
 	value is plumbed as an inline /think directive in the user message, so it
 	never affects the cacheable system prefix. Returns the effective level
-	(empty resolves to "medium" for display)."""
-	if not frappe.db.exists(CONV, conversation):
+	(empty resolves to "medium" for display).
+
+	Owner-only (SEC-002): mutates the conversation via ``db.set_value`` (which
+	bypasses permission checks), so ownership is asserted explicitly here."""
+	owner = frappe.db.get_value(CONV, conversation, "owner")
+	if owner is None:
 		return {"ok": False, "error": {
 			"code": "unknown_conversation",
 			"message": f"conversation {conversation!r} not found",
 		}}
+	if owner != frappe.session.user:
+		raise frappe.PermissionError("not your conversation")
 	level = (thinking or "").strip().lower()
 	if level not in _ALLOWED_THINKING:
 		return {"ok": False, "error": {

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -10,6 +10,21 @@ import frappe
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 
+
+def _get_owned_conversation(conversation: str):
+	"""Load a conversation, enforcing that the caller owns it (SEC-002).
+
+	``frappe.get_doc`` performs NO permission check, so ownership is asserted
+	explicitly here. Conversations are strictly private: read and write access
+	are both owner-only. Raises ``frappe.DoesNotExistError`` when the
+	conversation does not exist and ``frappe.PermissionError`` when it belongs
+	to another user.
+	"""
+	doc = frappe.get_doc(CONV, conversation)
+	if doc.owner != frappe.session.user:
+		raise frappe.PermissionError("not your conversation")
+	return doc
+
 # Image attachments are stored as canvas items on the user message so the SPA
 # renders them inline as clickable thumbnails (same preview path as generated
 # images) instead of a bare "📎 name" marker.
@@ -165,10 +180,10 @@ def create_or_focus_empty() -> str:
 def get_conversation(conversation: str) -> dict:
 	"""Return conversation metadata + ordered messages.
 
-	Raises frappe.DoesNotExistError if the conversation does not exist or
-	the caller is not the owner.
+	Raises frappe.DoesNotExistError if the conversation does not exist, or
+	frappe.PermissionError if the caller is not the owner.
 	"""
-	doc = frappe.get_doc(CONV, conversation)  # respects owner-only permission
+	doc = _get_owned_conversation(conversation)
 
 	messages = frappe.get_all(
 		MSG,
@@ -216,7 +231,7 @@ def get_canvas(message: str, name: str | None = None, dark: int = 0) -> dict:
 	row = frappe.db.get_value(MSG, message, ["conversation", "canvas"], as_dict=True)
 	if not row:
 		frappe.throw(_t("message not found"), frappe.DoesNotExistError)
-	frappe.get_doc(CONV, row.conversation)  # owner-only permission check
+	_get_owned_conversation(row.conversation)  # non-owner: PermissionError
 
 	items = frappe.parse_json(row.canvas) if row.canvas else []
 	if not isinstance(items, list) or not items:
@@ -312,8 +327,8 @@ def create_conversation() -> str:
 
 @frappe.whitelist()
 def archive_conversation(conversation: str) -> dict:
-	"""Set status to archived. The openclaw-side session is left in place."""
-	doc = frappe.get_doc(CONV, conversation)
+	"""Set status to archived (owner-only). The openclaw-side session is left in place."""
+	doc = _get_owned_conversation(conversation)
 	doc.status = "Archived"
 	doc.save()
 	frappe.db.commit()
@@ -346,11 +361,11 @@ def clear_chat_history() -> dict:
 
 @frappe.whitelist()
 def rename_conversation(conversation: str, title: str) -> dict:
-	"""Rename a conversation. ``get_doc`` enforces the owner-only permission."""
+	"""Rename a conversation (owner-only, enforced explicitly)."""
 	title = (title or "").strip()[:140]
 	if not title:
 		return {"ok": False, "reason": _("title is empty")}
-	doc = frappe.get_doc(CONV, conversation)
+	doc = _get_owned_conversation(conversation)
 	doc.title = title
 	doc.save()
 	frappe.db.commit()
@@ -359,10 +374,10 @@ def rename_conversation(conversation: str, title: str) -> dict:
 
 @frappe.whitelist()
 def set_star(conversation: str, starred: str | int | bool) -> dict:
-	"""Star/unstar a conversation (owner-gated via get_doc). Starred chats are
-	listed first and grouped under 'Starred' in the sidebar."""
+	"""Star/unstar a conversation (owner-only, enforced explicitly). Starred
+	chats are listed first and grouped under 'Starred' in the sidebar."""
 	on = 1 if str(starred) in ("1", "true", "True", "on", "yes") else 0
-	doc = frappe.get_doc(CONV, conversation)
+	doc = _get_owned_conversation(conversation)
 	doc.starred = on
 	doc.save()
 	frappe.db.commit()
@@ -414,8 +429,8 @@ def send_message(
 
 	Returns {ok: True, run_id, message_id, conversation_id} on success or
 	{ok: False, reason: str} on validation failure. Raises
-	frappe.DoesNotExistError if the conversation does not exist or the
-	caller is not the owner.
+	frappe.DoesNotExistError if the conversation does not exist, or
+	frappe.PermissionError if the caller is not the owner.
 	"""
 	t0 = time.monotonic()
 	user = frappe.session.user
@@ -446,7 +461,7 @@ def send_message(
 	if (not message or not message.strip()) and not atts:
 		return {"ok": False, "reason": _("message is empty")}
 
-	conv_doc = frappe.get_doc(CONV, conversation)  # respects perms
+	conv_doc = _get_owned_conversation(conversation)
 
 	# Apply model override BEFORE enqueueing so the worker sees the new value
 	# when it loads the conversation. (If we set this after the enqueue, the
@@ -787,10 +802,15 @@ def retry_message(message: str) -> dict:
 	turn) → (retried turn)".
 
 	Returns ``{ok: True, run_id}`` on success or ``{ok: False, reason}`` on
-	validation failure. Raises ``frappe.DoesNotExistError`` if the caller
-	doesn't own the message.
+	validation failure. Raises ``frappe.DoesNotExistError`` if the message
+	does not exist, or ``frappe.PermissionError`` if the caller does not own
+	the parent conversation.
 	"""
-	doc = frappe.get_doc(MSG, message)  # owner-only perm
+	doc = frappe.get_doc(MSG, message)
+	# Ownership is enforced on the PARENT conversation: message rows can be
+	# inserted by the RQ worker under a different session user, so the
+	# conversation's owner is the authority, not the message row's owner.
+	_get_owned_conversation(doc.conversation)
 	if doc.role != "assistant":
 		return {"ok": False, "reason": _("only assistant messages can be retried")}
 	if not doc.error:

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -349,9 +349,21 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 			)
 		# The decision is durably recorded above; a resume failure must
 		# not 500 the endpoint (the SPA would re-show a decided row).
+		# send_message is owner-only (SEC-002). A System Manager may decide
+		# another user's approval (``_may_act_on`` gates that above), so the
+		# resume runs AS the conversation owner - the same identity hinge
+		# agents_api.run_agent_now uses. The decision itself stays attributed
+		# to the approver via decided_by on the Approval Request row.
+		conv_owner = frappe.db.get_value("Jarvis Conversation", doc.conversation, "owner")
+		original_user = frappe.session.user
 		try:
+			if conv_owner and conv_owner != original_user:
+				frappe.set_user(conv_owner)
 			res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
 			resumed = bool(res.get("ok"))
 		except Exception:
 			frappe.log_error(title="approval resume failed", message=frappe.get_traceback())
+		finally:
+			if frappe.session.user != original_user:
+				frappe.set_user(original_user)
 	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -354,16 +354,37 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 		# resume runs AS the conversation owner - the same identity hinge
 		# agents_api.run_agent_now uses. The decision itself stays attributed
 		# to the approver via decided_by on the Approval Request row.
+		from jarvis.chat.agent_scheduler import _valid_owner
+
 		conv_owner = frappe.db.get_value("Jarvis Conversation", doc.conversation, "owner")
 		original_user = frappe.session.user
-		try:
-			if conv_owner and conv_owner != original_user:
-				frappe.set_user(conv_owner)
-			res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
-			resumed = bool(res.get("ok"))
-		except Exception:
-			frappe.log_error(title="approval resume failed", message=frappe.get_traceback())
-		finally:
-			if frappe.session.user != original_user:
-				frappe.set_user(original_user)
+		# Fail-closed identity guard (mirrors agents_api.run_agent_now): never
+		# resume AS Administrator / Guest / a disabled user on someone else's
+		# behalf - that would run an unattended agent turn with elevated
+		# rights. A self-owned resume (owner == approver) always proceeds.
+		switch_to = conv_owner if (conv_owner and conv_owner != original_user) else None
+		if switch_to and not _valid_owner(switch_to):
+			frappe.log_error(
+				title="approval resume skipped (owner not an eligible run identity)",
+				message=(
+					f"Approval {doc.name}: conversation owner {switch_to!r} is not an "
+					f"eligible run identity (Administrator/Guest/disabled); the decision "
+					f"is recorded but the turn was not resumed."
+				),
+			)
+		else:
+			try:
+				if switch_to:
+					frappe.set_user(switch_to)
+				res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
+				resumed = bool(res.get("ok"))
+			except Exception:
+				# Restore BEFORE logging so the Error Log is attributed to the
+				# approver, not the impersonated conversation owner.
+				if frappe.session.user != original_user:
+					frappe.set_user(original_user)
+				frappe.log_error(title="approval resume failed", message=frappe.get_traceback())
+			finally:
+				if frappe.session.user != original_user:
+					frappe.set_user(original_user)
 	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -22,6 +22,7 @@ from jarvis.chat.api import (
 	rename_conversation,
 	retry_message,
 	set_conversation_model,
+	set_conversation_thinking,
 	set_star,
 )
 
@@ -788,6 +789,27 @@ class TestConversationOwnershipEnforcement(_ChatTestCase):
 			with self.assertRaises(frappe.PermissionError):
 				retry_message(self.asst_msg)
 		dispatch.assert_not_called()
+
+	def test_non_owner_cannot_set_model(self):
+		# set_conversation_model mutates the row via db.set_value (bypasses
+		# perms), so it must assert ownership explicitly (same IDOR class).
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			set_conversation_model(self.conv, "gpt-5.5")
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "model_override"))
+
+	def test_non_owner_cannot_set_thinking(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			set_conversation_thinking(self.conv, "high")
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "thinking_override"))
+
+	def test_unknown_conversation_still_soft_errors_for_model(self):
+		# A missing conversation must keep returning the structured
+		# unknown_conversation error (not PermissionError) for the owner.
+		out = set_conversation_model("missing-conv-xyz", "gpt-5.5")
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["error"]["code"], "unknown_conversation")
 
 	# ---- owner is not over-blocked ----------------------------------- #
 

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -16,10 +16,13 @@ from jarvis.chat.api import (
 	archive_conversation,
 	create_conversation,
 	create_or_focus_empty,
+	get_canvas,
 	get_conversation,
 	list_conversations,
+	rename_conversation,
 	retry_message,
 	set_conversation_model,
+	set_star,
 )
 
 CONV = "Jarvis Conversation"
@@ -695,3 +698,110 @@ class TestWarmSessionEndpoint(FrappeTestCase):
 		# warm_prefix must NOT have been called inline in the web worker.
 		wp.assert_not_called()
 		self.assertEqual(out, {"ok": True, "enqueued": True})
+
+
+INTRUDER_USER = "jarvis-test-intruder@example.com"
+
+
+class TestConversationOwnershipEnforcement(_ChatTestCase):
+	"""SEC-002 regression: every conversation-scoped endpoint must reject a
+	caller who does not own the conversation with ``frappe.PermissionError``
+	— and keep working for the legitimate owner.
+
+	``frappe.get_doc`` performs NO permission check, so the endpoints assert
+	ownership explicitly (``api._get_owned_conversation``); these tests pin
+	that gate for both the read and the write paths. The intruder fixture
+	deliberately holds System Manager (via ``_ensure_test_user``): even an
+	admin-role tenant user must not reach another user's chat through these
+	endpoints.
+	"""
+
+	def setUp(self):
+		super().setUp()  # runs as TEST_USER — the legitimate owner
+		_ensure_test_user(INTRUDER_USER)
+		self.conv = create_conversation()
+		# Seed one user turn + one errored assistant turn so the message-id
+		# endpoints (get_canvas, retry_message) have targets.
+		user_msg = frappe.get_doc({
+			"doctype": MSG, "conversation": self.conv, "seq": 1,
+			"role": "user", "content": "what is our payroll?",
+		})
+		user_msg.insert(ignore_permissions=True)
+		asst_msg = frappe.get_doc({
+			"doctype": MSG, "conversation": self.conv, "seq": 2,
+			"role": "assistant", "content": "", "error": "rate limit",
+		})
+		asst_msg.insert(ignore_permissions=True)
+		frappe.db.commit()
+		self.user_msg = user_msg.name
+		self.asst_msg = asst_msg.name
+
+	def _as_intruder(self):
+		frappe.set_user(INTRUDER_USER)
+
+	# ---- read paths -------------------------------------------------- #
+
+	def test_non_owner_cannot_read_conversation(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			get_conversation(self.conv)
+
+	def test_non_owner_cannot_read_canvas(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			get_canvas(self.asst_msg)
+
+	# ---- write paths ------------------------------------------------- #
+
+	def test_non_owner_cannot_archive(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			archive_conversation(self.conv)
+		self.assertEqual(frappe.db.get_value(CONV, self.conv, "status"), "Active")
+
+	def test_non_owner_cannot_rename(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			rename_conversation(self.conv, "pwned")
+		self.assertEqual(frappe.db.get_value(CONV, self.conv, "title"), "New chat")
+
+	def test_non_owner_cannot_star(self):
+		self._as_intruder()
+		with self.assertRaises(frappe.PermissionError):
+			set_star(self.conv, 1)
+		self.assertFalse(frappe.db.get_value(CONV, self.conv, "starred"))
+
+	def test_non_owner_cannot_send_message(self):
+		self._as_intruder()
+		with patch("jarvis.chat.api._dispatch_turn") as dispatch:
+			with self.assertRaises(frappe.PermissionError):
+				send_message(self.conv, "hijack this thread")
+		dispatch.assert_not_called()
+		# No message row was injected into the victim's conversation.
+		self.assertEqual(
+			len(frappe.get_all(MSG, filters={"conversation": self.conv})), 2
+		)
+
+	def test_non_owner_cannot_retry_message(self):
+		self._as_intruder()
+		with patch("jarvis.chat.api._dispatch_turn") as dispatch:
+			with self.assertRaises(frappe.PermissionError):
+				retry_message(self.asst_msg)
+		dispatch.assert_not_called()
+
+	# ---- owner is not over-blocked ----------------------------------- #
+
+	def test_owner_still_allowed(self):
+		"""The ownership gate must not lock out the legitimate owner."""
+		out = get_conversation(self.conv)
+		self.assertEqual(out["conversation"]["name"], self.conv)
+		# get_canvas passes the ownership gate for the owner: a message with
+		# no canvas fails LATER with DoesNotExistError, never PermissionError.
+		with self.assertRaises(frappe.DoesNotExistError):
+			get_canvas(self.asst_msg)
+		self.assertTrue(rename_conversation(self.conv, "my chat")["ok"])
+		self.assertTrue(set_star(self.conv, 1)["ok"])
+		with patch("jarvis.chat.api._dispatch_turn"):
+			self.assertTrue(send_message(self.conv, "hello")["ok"])
+			self.assertTrue(retry_message(self.asst_msg)["ok"])
+		self.assertTrue(archive_conversation(self.conv)["ok"])


### PR DESCRIPTION
## Summary

Fixes SEC-002 (HIGH, cross-user IDOR): whitelisted chat endpoints loaded/mutated a conversation by id with **no** ownership check — `frappe.get_doc(...)` performs no permission check, and `frappe.db.set_value(...)` bypasses permissions entirely — while comments falsely claimed "owner-only permission". Any authenticated user who obtained a conversation id could read another user's full transcript and mutate/hijack their conversations.

Every conversation-scoped endpoint now asserts ownership explicitly (`doc.owner == frappe.session.user`, else `frappe.PermissionError`; missing docs still raise `DoesNotExistError` / return the existing `unknown_conversation` soft error). The false comments are replaced with accurate ones.

## Endpoints now enforced (intent)

The 7 endpoints named in the issue (all used bare `frappe.get_doc`), gated via the new `_get_owned_conversation()` helper:

| Endpoint | Intent | Enforcement |
|---|---|---|
| `get_conversation` | read | owner assertion on the conversation |
| `get_canvas` | read | owner assertion on the message's parent conversation |
| `archive_conversation` | write | owner assertion on the conversation |
| `rename_conversation` | write | owner assertion on the conversation |
| `set_star` | write | owner assertion on the conversation |
| `send_message` | write | owner assertion on the conversation |
| `retry_message` | write | owner assertion on the **parent conversation** of the message (message rows can be inserted by the RQ worker under a different session user, so the conversation owner is the authority) |

Plus **two sibling endpoints a code review caught with the identical IDOR class** (they mutate via `frappe.db.set_value`, which bypasses permissions — not `get_doc`, so they weren't in the issue's evidence line but are the same vulnerability). Now owner-gated with the same `get_value`-based pattern `set_auto_apply` already uses:

| Endpoint | Intent | Enforcement |
|---|---|---|
| `set_conversation_model` | write | owner assertion (missing → `unknown_conversation`, non-owner → `PermissionError`) |
| `set_conversation_thinking` | write | owner assertion (same) |

Conversations are strictly private, so read and write intents collapse to the same owner-only assertion.

## Why an explicit owner check instead of `doc.check_permission(...)`

Both `Jarvis Conversation` and `Jarvis Chat Message` carry only a `role: All, if_owner: 1` permission rule, so `check_permission` would owner-scope **today** — but that guarantee is contingent: a future permission rule without `if_owner`, a DocShare grant, or a change in `if_owner` semantics would silently reopen the hole, and `db.set_value` (used by the two `set_conversation_*` endpoints) ignores `check_permission` entirely. The explicit assertion is unconditional and matches the enforcement pattern this file already established in `set_auto_apply` (#186). It has no role bypass: even System Manager cannot reach another user's chat through these endpoints.

## Internal callers audited (no regressions)

- `agent_scheduler._launch_audit` / `agents_api.run_agent_now`: already run under `frappe.set_user(owner)` before sending — unaffected.
- `filebox` drop path: creates and sends under the same session user — unaffected.
- `approvals_api.decide`: a System Manager may decide another user's approval by design (`_may_act_on`), and the resume goes through the now-owner-only `send_message`. The resume now runs **as the conversation owner** (same identity hinge `run_agent_now` uses, restored in `finally`), with a **fail-closed `_valid_owner` guard** so it never resumes as Administrator/Guest/a disabled user on another user's behalf, and the session is restored before any error is logged so failures are attributed to the approver. The decision itself stays attributed to the approver via `decided_by`.
- The two SPA frontends drive these endpoints only for the caller's own conversations; their error handling is generic (no dependence on 404-vs-403).

## Tests

`jarvis/tests/test_chat_api.py::TestConversationOwnershipEnforcement` — as user A creates a conversation (with seeded user + errored-assistant messages), then as user B (who deliberately holds System Manager) asserts `frappe.PermissionError` on all nine conversation-scoped endpoints and that no message row was injected / no turn dispatched; a final test asserts user A still succeeds on every endpoint (no over-blocking), and that a missing conversation still returns the structured `unknown_conversation` error rather than 403.

CI: green (tests pass).

Closes Aerele-RnD/jarvis-admin#187
