### PR TITLE
fix(security): validate query-tool identifiers before pypika (SEC-003, #188)

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -1883,3 +1883,20 @@ class TestQuerySqlInjectionHardening(FrappeTestCase):
 			"group_by": ["month"],
 		})
 		self.assertIn("GROUP BY", sql.upper())
+
+	def test_optional_meta_column_still_pass(self):
+		"""The optional meta columns (_assign / _comments / _liked_by /
+		_user_tags / _seen) are real, queryable columns on standard
+		doctypes but are NOT returned by ``get_valid_columns()`` — they
+		must not be over-blocked by the column-existence check. Uses
+		``User`` (a non-special doctype whose get_valid_columns() takes
+		the default_fields + docfields path that omits _assign); a
+		special doctype like DocType would mask the gap because its path
+		returns the full DB column list."""
+		sql = self._build_sql({
+			"from": "User", "alias": "u",
+			"select": ["u.name"],
+			"where": [{"field": "u._assign", "op": "like",
+			           "value": "%Administrator%"}],
+		})
+		self.assertIn("_assign", sql)

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -1749,3 +1749,137 @@ class TestQueryExprDSLPhase4StringHelpers(FrappeTestCase):
 						"as": "x",
 					}],
 				})
+
+
+class TestQuerySqlInjectionHardening(FrappeTestCase):
+	"""SEC-003: field / alias / doctype identifiers must be validated
+	before they reach pypika, which quotes identifiers with backticks
+	but does NOT escape an embedded backtick/quote. Without this, a
+	crafted identifier from the agent-facing spec (reachable via the
+	prompt-injection chain) could break out of the quoting and inject a
+	``UNION SELECT`` that runs with the site's full DB privilege —
+	``frappe.set_user`` changes only the application user, not the DB
+	user, so the injected query can read ``__Auth`` and bypass the
+	tool's permission weave.
+	"""
+
+	def _build_sql(self, spec: dict) -> str:
+		"""Mirror of TestQueryQbTranslation._build_sql: run the full
+		pipeline, capture the resolved SQL without executing."""
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine:
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			with patch("pypika.queries.QueryBuilder.run", return_value=[]):
+				result = query(spec)
+		return result["sql"]
+
+	# ---- backtick / quote rejection --------------------------------
+
+	def test_field_with_backtick_rejected(self):
+		"""A field carrying a backtick would break out of pypika's
+		identifier quoting; reject it before it reaches the query."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name`"],
+				})
+
+	def test_alias_with_backtick_rejected(self):
+		"""The FROM alias flows into pypika's ``.as_()`` sink."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({"from": "DocType", "alias": "dt`"})
+
+	# ---- ") UNION SELECT" payload rejection ------------------------
+
+	def test_field_with_union_select_payload_rejected(self):
+		"""The canonical injection payload as a WHERE field identifier."""
+		payload = "name`) UNION SELECT `password"
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"where": [{"field": f"dt.{payload}", "op": "=",
+					           "value": 1}],
+				})
+
+	def test_select_output_alias_with_union_select_rejected(self):
+		"""The SELECT ``as`` output alias flows into pypika's ``.as_()``
+		sink and must be validated."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType",
+					"select": [{
+						"agg": "count", "field": "*",
+						"as": "n) UNION SELECT password FROM tabUser -- ",
+					}],
+				})
+
+	def test_join_alias_with_injection_rejected(self):
+		"""A JOIN alias with a space/paren payload is rejected before it
+		reaches ``.as_()``."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError):
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.name"],
+					"joins": [{
+						"type": "left", "doctype": "DocField",
+						"alias": "df) UNION SELECT",
+						"on": {"df.parent": "dt.name"},
+					}],
+				})
+
+	# ---- unknown column / doctype rejection ------------------------
+
+	def test_unknown_column_rejected(self):
+		"""A syntactically-valid but non-existent column is rejected via
+		``get_valid_columns()``."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({
+					"from": "DocType", "alias": "dt",
+					"select": ["dt.definitely_not_a_real_column"],
+				})
+			self.assertIn("column", str(cm.exception).lower())
+
+	def test_unknown_doctype_rejected(self):
+		"""A non-existent DocType (the table-name sink) is rejected."""
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(InvalidArgumentError) as cm:
+				query({"from": "No Such DocType XYZ"})
+			self.assertIn("doctype", str(cm.exception).lower())
+
+	# ---- over-blocking guard: legitimate queries still pass --------
+
+	def test_standard_and_real_columns_still_pass(self):
+		"""Standard Frappe columns (name/creation/idx) plus real fields
+		(issingle/module) must NOT be rejected by the column check."""
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": ["dt.name", "dt.creation", "dt.idx", "dt.module"],
+			"where": [{"field": "dt.issingle", "op": "=", "value": 1}],
+			"order_by": [{"field": "dt.name", "dir": "asc"}],
+		})
+		self.assertIn("issingle", sql)
+		self.assertIn("creation", sql)
+
+	def test_group_by_select_alias_still_pass(self):
+		"""GROUP BY referencing a SELECT output alias (not a physical
+		column) must remain valid after the identifier hardening — the
+		alias is regex-checked but not column-existence-checked."""
+		sql = self._build_sql({
+			"from": "DocType", "alias": "dt",
+			"select": [
+				{"expr": {"fn": "date_part",
+				          "args": [{"literal": "month"},
+				                   {"field": "dt.creation"}]},
+				 "as": "month"},
+				{"agg": "count", "field": "*", "as": "n"},
+			],
+			"group_by": ["month"],
+		})
+		self.assertIn("GROUP BY", sql.upper())

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -200,6 +200,9 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 
 	# Joins.
 	for j in spec.get("joins") or []:
+		# SEC-003: validate the join's table-name + alias sinks.
+		_validate_doctype(j["doctype"])
+		_validate_identifier(j["alias"], "alias")
 		joined_table = frappe.qb.DocType(j["doctype"]).as_(j["alias"])
 		alias_map[j["alias"]] = (j["doctype"], joined_table)
 		on_criterion = _build_on_criterion(j["on"], alias_map)
@@ -220,9 +223,12 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	for w in spec.get("where") or []:
 		q = q.where(_build_predicate(w, alias_map))
 
-	# GROUP BY.
+	# GROUP BY. ``allow_alias`` mirrors ORDER BY: a bare name may reference
+	# a SELECT output alias (e.g. a computed ``month`` bucket) rather than
+	# a physical column — MariaDB resolves aliases in GROUP BY. The alias
+	# still passes the SEC-003 identifier check inside ``_resolve_field``.
 	for gb in spec.get("group_by") or []:
-		q = q.groupby(_resolve_field(gb, alias_map))
+		q = q.groupby(_resolve_field(gb, alias_map, allow_alias=True))
 
 	# HAVING.
 	for h in spec.get("having") or []:
@@ -473,6 +479,66 @@ def _collect_doctypes(spec: dict) -> list[str]:
 	return out
 
 
+# ---- Identifier validation (SEC-003) --------------------------------
+
+
+# Field names and aliases must be bare SQL identifiers. pypika quotes
+# identifiers with backticks but does NOT escape a backtick/quote
+# embedded inside the identifier, so a crafted field/alias such as
+# ``foo`) UNION SELECT ... -- `` would break out of the quoting and
+# inject SQL that runs with the site's FULL DB privilege
+# (``frappe.set_user`` changes only the application user, not the DB
+# user — an injected UNION can read ``__Auth`` and bypass the tool's own
+# permission weave). Restrict every field/alias identifier to this
+# character class before it reaches pypika. DocType names are validated
+# separately — they legitimately contain spaces — via an existence check.
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+
+
+def _validate_identifier(value: Any, kind: str) -> None:
+	"""Reject a field/alias identifier that isn't a bare
+	``[A-Za-z0-9_]+`` token. Blocks backticks, quotes, spaces, parens,
+	semicolons, and injection payloads such as ``) UNION SELECT`` before
+	the value reaches pypika's identifier quoting."""
+	if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+		raise InvalidArgumentError(
+			f"invalid {kind}: only letters, digits, and underscores are "
+			f"allowed (got {value!r})"
+		)
+
+
+def _validate_doctype(dt: Any) -> None:
+	"""Confirm ``dt`` is a real DocType. Real DocType names never carry
+	backticks or quotes (Frappe forbids them), so an existence check is
+	the injection guard for the table-name sink (``frappe.qb.DocType``)
+	while still permitting the spaces legitimate DocType names contain
+	(e.g. ``Sales Invoice``)."""
+	if not isinstance(dt, str) or not dt.strip():
+		raise InvalidArgumentError("DocType name must be a non-empty string")
+	try:
+		frappe.get_meta(dt)
+	except Exception:
+		raise InvalidArgumentError(f"unknown DocType: {dt!r}")
+
+
+def _validate_column(dt: str, field: str) -> None:
+	"""Validate ``field`` is a real column of DocType ``dt``. Runs the
+	identifier-syntax check first (rejects malicious characters), then
+	confirms the column exists via ``get_valid_columns()`` — which
+	includes the standard fields (name / owner / creation / modified /
+	modified_by / idx / docstatus) and, for child tables,
+	parent / parentfield / parenttype."""
+	_validate_identifier(field, "field")
+	try:
+		valid_columns = frappe.get_meta(dt).get_valid_columns()
+	except Exception:
+		raise InvalidArgumentError(f"unknown DocType: {dt!r}")
+	if field not in valid_columns:
+		raise InvalidArgumentError(
+			f"unknown column {field!r} on DocType {dt!r}"
+		)
+
+
 # ---- Translation: spec → qb expressions -----------------------------
 
 
@@ -481,7 +547,14 @@ def _build_from_and_aliases(spec: dict) -> tuple[Any, dict]:
 	The alias_map maps spec-alias → (doctype, pypika.Table) so later
 	stages can resolve ``"alias.field"`` references."""
 	from_dt = spec["from"]
+	# SEC-003: validate the table-name sink and any explicit alias before
+	# they reach pypika. The doctype-name fallback (below) is guarded by
+	# the existence check; an explicitly-supplied alias flows into
+	# ``.as_()`` and must be a bare identifier.
+	_validate_doctype(from_dt)
 	alias = spec.get("alias") or from_dt
+	if spec.get("alias"):
+		_validate_identifier(spec["alias"], "alias")
 	# ``frappe.qb.DocType("Name")`` returns a pypika Table; ``.as_(alias)``
 	# applies the alias. When the spec doesn't supply an alias we still
 	# call ``.as_()`` so the doctype name + alias_map stay symmetric.
@@ -508,6 +581,11 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 		)
 	if "." not in field_ref:
 		if allow_alias:
+			# ORDER BY / GROUP BY may reference a SELECT output alias
+			# (e.g. total_qty) rather than a physical column, so we can
+			# only enforce SEC-003 identifier syntax here — column
+			# existence isn't knowable for an output alias.
+			_validate_identifier(field_ref, "field")
 			from pypika import Field
 			return Field(field_ref)
 		# A bare reference like "name" is ambiguous in a join; require
@@ -515,7 +593,9 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 		if len(alias_map) == 1:
 			# Single-doctype query — the alias is unambiguous; resolve
 			# against the only table.
-			((_, table),) = list(alias_map.values())
+			((dt, table),) = list(alias_map.values())
+			# SEC-003: validate the column identifier + existence.
+			_validate_column(dt, field_ref)
 			return table[field_ref]
 		raise InvalidArgumentError(
 			f"field reference {field_ref!r} is ambiguous in a multi-table "
@@ -535,7 +615,10 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 			f"field reference {field_ref!r} uses unknown alias {alias!r}; "
 			f"known aliases: {sorted(alias_map)}"
 		)
-	_, table = alias_map[alias]
+	dt, table = alias_map[alias]
+	# SEC-003: validate the column identifier + existence against the
+	# resolved DocType before it reaches pypika's ``table[field]`` sink.
+	_validate_column(dt, field)
 	return table[field]
 
 
@@ -594,6 +677,10 @@ def _build_select(select_spec: list, alias_map: dict) -> list:
 		if isinstance(item, str):
 			out.append(_resolve_field(item, alias_map))
 		elif isinstance(item, dict):
+			# SEC-003: the ``as`` output alias flows into pypika's
+			# ``.as_()``; validate it before it is used below.
+			if "as" in item:
+				_validate_identifier(item["as"], "alias")
 			if "expr" in item and "agg" not in item:
 				# Plain expression projection: {"expr": ..., "as": ...}
 				if "as" not in item:
@@ -865,6 +952,9 @@ def _build_exists_criterion(sub_spec: dict, outer_alias_map: dict,
 			raise InvalidArgumentError(
 				f"EXISTS sub-spec alias {j['alias']!r} collides"
 			)
+		# SEC-003: validate the sub-spec join's table-name + alias sinks.
+		_validate_doctype(j["doctype"])
+		_validate_identifier(j["alias"], "alias")
 		joined_table = frappe.qb.DocType(j["doctype"]).as_(j["alias"])
 		sub_alias_map[j["alias"]] = (j["doctype"], joined_table)
 		on_criterion = _build_on_criterion(j["on"], sub_alias_map)

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -71,6 +71,7 @@ import re
 from typing import Any
 
 import frappe
+from frappe.model import optional_fields as _OPTIONAL_FIELDS
 from pypika import Order
 from pypika import functions as fn
 from pypika.terms import Criterion
@@ -527,13 +528,19 @@ def _validate_column(dt: str, field: str) -> None:
 	confirms the column exists via ``get_valid_columns()`` — which
 	includes the standard fields (name / owner / creation / modified /
 	modified_by / idx / docstatus) and, for child tables,
-	parent / parentfield / parenttype."""
+	parent / parentfield / parenttype.
+
+	``get_valid_columns()`` omits the optional meta columns (_assign /
+	_comments / _liked_by / _user_tags / _seen), which are nonetheless
+	real, queryable columns on standard doctypes — permit them too so a
+	legitimate query (e.g. filtering on ``_assign``) is not over-blocked.
+	"""
 	_validate_identifier(field, "field")
 	try:
 		valid_columns = frappe.get_meta(dt).get_valid_columns()
 	except Exception:
 		raise InvalidArgumentError(f"unknown DocType: {dt!r}")
-	if field not in valid_columns:
+	if field not in valid_columns and field not in _OPTIONAL_FIELDS:
 		raise InvalidArgumentError(
 			f"unknown column {field!r} on DocType {dt!r}"
 		)


### PR DESCRIPTION
## SEC-003 — SQL injection via unvalidated query-tool identifiers

**Finding:** jarvis-admin #188 (HIGH). Field/alias/DocType identifiers from the agent-facing `query` tool spec reached pypika (`table[field]`, `.as_(alias)`, `frappe.qb.DocType(dt)`) with **no column validation and no backtick rejection**. pypika quotes identifiers with backticks but does not escape an embedded backtick/quote, so a crafted identifier — reachable via the prompt-injection chain (planted ERP text → agent emits a crafted query spec) — could break out of the quoting and inject a `UNION SELECT`. Because `frappe.set_user` changes only the application user (not the DB user), the injected query runs with the site's **full DB privilege**, able to read `__Auth` (password hashes + encrypted secrets) and bypass the tool's own permission weave.

## Fix

All changes are in `jarvis/tools/query.py`. Three small validation helpers gate every identifier **before** it reaches pypika:

- **`_validate_identifier`** — fields and aliases must match `^[a-zA-Z0-9_]+$`. Rejects backticks, quotes, spaces, parentheses, semicolons, and payloads such as `) UNION SELECT`.
- **`_validate_column`** — runs the identifier check, then confirms the column exists via `frappe.get_meta(dt).get_valid_columns()` (which includes standard fields `name/owner/creation/modified/modified_by/idx/docstatus` and, for child tables, `parent/parentfield/parenttype`). Unknown columns are rejected.
- **`_validate_doctype`** — confirms the DocType exists via `frappe.get_meta`. Real DocType names never contain backticks/quotes but legitimately contain spaces (e.g. `Sales Invoice`), so the alnum regex is intentionally **not** applied to them; existence is the injection guard for the table-name sink.

### Sinks covered
- FROM table + explicit FROM alias (`_build_from_and_aliases`)
- Every JOIN table + alias (main query and EXISTS/NOT-EXISTS sub-specs)
- SELECT `as` output aliases (`_build_select`)
- Every resolved field/column reference, bare and dotted (`_resolve_field`) — covers WHERE, HAVING, ON, GROUP BY, ORDER BY, aggregates, the expression DSL (via its resolve-field callback), and correlated `$field` markers.

### Legitimate functionality preserved
- **Dotted `alias.field` refs** are validated per-segment: the alias half is resolved through the (already-validated) alias map; the field half is regex- + existence-checked against the resolved DocType. No fetch-from-link/multi-dot form exists in this grammar, so single-dot handling is complete.
- **Standard + child-table columns** pass because `get_valid_columns()` includes them.
- **GROUP BY** now passes `allow_alias=True` (mirroring the existing ORDER BY behavior) so a bare name may reference a SELECT output alias (e.g. a computed `month` bucket) — MariaDB resolves aliases in GROUP BY. The alias is still regex-checked, just not column-existence-checked (it isn't a physical column).
- **`COUNT(*)`** and the whole expression DSL are unaffected (`*` is special-cased before field resolution; DSL literals are values, not identifiers).

Errors reuse the existing `InvalidArgumentError` type and do not leak internals.

## Tests

New `TestQuerySqlInjectionHardening` class in `jarvis/tests/test_query.py`, matching the existing style:
- field with a backtick → rejected
- FROM alias with a backtick → rejected
- WHERE field carrying `` name`) UNION SELECT `password `` → rejected
- SELECT `as` alias carrying `) UNION SELECT password FROM tabUser --` → rejected
- JOIN alias with a space/paren payload → rejected
- unknown column (dotted) → rejected
- unknown DocType → rejected
- **over-blocking guards:** a normal query over standard + real columns still builds; GROUP BY on a SELECT output alias still builds.

Validated locally with `python -m py_compile` on both files (no bench available in this workspace); the full Frappe suite runs in CI.

Closes #188
