### PR TITLE
fix(security): pin @google/gemini-cli to an exact version (SEC-008)

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -109,8 +109,12 @@ def get_oauth_client_id(provider: str) -> str:
 #   1. JARVIS_GEMINI_CLI_OAUTH_CLIENT_SECRET env var (operator override)
 #   2. Extract from the gemini-cli npm package shipped as a runtime dep of
 #      this app (see apps/jarvis/package.json - install with `npm install`
-#      inside that dir after bench-getting the app). This auto-tracks
-#      upstream rotations.
+#      inside that dir after bench-getting the app). NOTE: the dep is pinned
+#      to an EXACT version (SEC-008, Aerele-RnD/jarvis-admin#192), so this
+#      no longer auto-tracks upstream rotations - when Google rotates the
+#      embedded secret, either set the env override (step 1) or deliberately
+#      bump the pin in package.json + package-lock.json (keep it in lockstep
+#      with the fleet-agent entrypoint's GEMINI_CLI_VERSION pin).
 #   3. Empty -> the token exchange fails with the explicit
 #      `client_secret is missing` so the operator knows to install + restart.
 OAUTH_CLIENT_SECRETS = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,168 @@
+{
+	"name": "jarvis",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "jarvis",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@google/gemini-cli": "0.49.0"
+			}
+		},
+		"node_modules/@github/keytar": {
+			"version": "7.10.6",
+			"resolved": "https://registry.npmjs.org/@github/keytar/-/keytar-7.10.6.tgz",
+			"integrity": "sha512-mRW6cUsSG+nj4jp5gp8e91zPySaT73r+2JM6VyMZfrEgksjPmjSMr+tPGNOK3HUHV+GUU9B1LAiiYy/wmAnIxA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"node-addon-api": "^8.3.0"
+			}
+		},
+		"node_modules/@google/gemini-cli": {
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.49.0.tgz",
+			"integrity": "sha512-S0b6nfAf+lHbSPMKRuQziU1/710a7f/Jag2mZ7N1J1b48qxoCmjwNCJJ7XPEv/ropvDqkCjJupE32qcw+ym3jQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"gemini": "bundle/gemini.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"@github/keytar": "7.10.6",
+				"@lydell/node-pty": "1.1.0",
+				"@lydell/node-pty-darwin-arm64": "1.1.0",
+				"@lydell/node-pty-darwin-x64": "1.1.0",
+				"@lydell/node-pty-linux-x64": "1.1.0",
+				"@lydell/node-pty-win32-arm64": "1.1.0",
+				"@lydell/node-pty-win32-x64": "1.1.0",
+				"node-pty": "1.0.0"
+			}
+		},
+		"node_modules/@lydell/node-pty": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.1.0.tgz",
+			"integrity": "sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==",
+			"license": "MIT",
+			"optional": true,
+			"optionalDependencies": {
+				"@lydell/node-pty-darwin-arm64": "1.1.0",
+				"@lydell/node-pty-darwin-x64": "1.1.0",
+				"@lydell/node-pty-linux-arm64": "1.1.0",
+				"@lydell/node-pty-linux-x64": "1.1.0",
+				"@lydell/node-pty-win32-arm64": "1.1.0",
+				"@lydell/node-pty-win32-x64": "1.1.0"
+			}
+		},
+		"node_modules/@lydell/node-pty-darwin-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.1.0.tgz",
+			"integrity": "sha512-7kFD+owAA61qmhJCtoMbqj3Uvff3YHDiU+4on5F2vQdcMI3MuwGi7dM6MkFG/yuzpw8LF2xULpL71tOPUfxs0w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lydell/node-pty-darwin-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.1.0.tgz",
+			"integrity": "sha512-XZdvqj5FjAMjH8bdp0YfaZjur5DrCIDD1VYiE9EkkYVMDQqRUPHYV3U8BVEQVT9hYfjmpr7dNaELF2KyISWSNA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@lydell/node-pty-linux-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.1.0.tgz",
+			"integrity": "sha512-yyDBmalCfHpLiQMT2zyLcqL2Fay4Xy7rIs8GH4dqKLnEviMvPGOK7LADVkKAsbsyXBSISL3Lt1m1MtxhPH6ckg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lydell/node-pty-linux-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.1.0.tgz",
+			"integrity": "sha512-NcNqRTD14QT+vXcEuqSSvmWY+0+WUBn2uRE8EN0zKtDpIEr9d+YiFj16Uqds6QfcLCHfZmC+Ls7YzwTaqDnanA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@lydell/node-pty-win32-arm64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.1.0.tgz",
+			"integrity": "sha512-JOMbCou+0fA7d/m97faIIfIU0jOv8sn2OR7tI45u3AmldKoKoLP8zHY6SAvDDnI3fccO1R2HeR1doVjpS7HM0w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@lydell/node-pty-win32-x64": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.1.0.tgz",
+			"integrity": "sha512-3N56BZ+WDFnUMYRtsrr7Ky2mhWGl9xXcyqR6cexfuCqcz9RNWL+KoXRv/nZylY5dYaXkft4JaR1uVu+roiZDAw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/nan": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-addon-api": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+			"integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/node-pty": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+			"integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"nan": "^2.17.0"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
 		"build-frontend": "cd frontend && npm run build"
 	},
 	"dependencies": {
-		"@google/gemini-cli": "*"
+		"@google/gemini-cli": "0.49.0"
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the jarvis-app half of **SEC-008** (Aerele-RnD/jarvis-admin#192): the root `package.json` declared `@google/gemini-cli` as `"*"`, so every deploy's root `npm install` (the Frappe Cloud build contract documented in the package description) pulled whatever version was most recently published to npm, with no integrity verification — a typosquat, maintainer takeover, or malicious release would execute in the build/runtime environment.

## Changes

- **`package.json`**: `@google/gemini-cli` pinned to the exact version `0.49.0` (npm `latest` dist-tag, verified against the registry on 2026-07-06). No `^`/`~`/`*` range — bumps are now deliberate.
- **`package-lock.json` (new, root)**: generated with `npm install --package-lock-only --ignore-scripts`; locks gemini-cli and its optionalDependencies (13 packages) with sha512 integrity hashes, so npm-based installs verify the tarball against a *committed* hash instead of trusting the registry response. (The `frontend/` SPA already had its own lockfile; this only covers the root manifest.)

## Notes

- Companion PR pinning the boot-time install in the tenant-container entrypoint: Aerele-RnD/jarvis-fleet-agent#119.
- `@google/gemini-cli@0.49.0` declares no lifecycle scripts of its own (bin is the self-contained `bundle/gemini.js`); only optional native deps (node-pty, keytar) carry scripts, and gemini-cli tolerates their absence by design.
- Follow-up recommended on Aerele-RnD/jarvis-admin#192: bake a pinned, integrity-verified gemini-cli into the openclaw image build (external to these repos) so no npm install runs at tenant-container boot at all.

Refs Aerele-RnD/jarvis-admin#192 (SEC-008).

## Code-review findings (self-review)

1. **Fixed in this PR**: `jarvis/hooks.py`'s client_secret resolution comment claimed the npm dep "auto-tracks upstream rotations" — true under `"*"`, false under the pin. Comment updated to point operators at the `JARVIS_GEMINI_CLI_OAUTH_CLIENT_SECRET` override or a deliberate lockstep pin bump when Google rotates the embedded secret.
2. **Coverage note**: the lockfile's integrity guarantees apply to npm-driven installs (the documented FC contract). Bench-managed installs use yarn, which ignores `package-lock.json` — the direct exact pin still holds there; only transitive ranges under gemini-cli's *optional* native deps float on that path.
3. **Lockstep coupling**: this pin must be bumped together with the fleet-agent entrypoint's `GEMINI_CLI_VERSION` (Aerele-RnD/jarvis-fleet-agent#119); now recorded in the hooks.py comment.

Lockfile verification: byte-reproducible regeneration, all-platform prebuilds included, gemini-cli sha512 matches the registry's `dist.integrity` for 0.49.0, `npm ci --dry-run --ignore-scripts` passes, and no root `npm ci` exists in CI.
