### PR TITLE
Streamline onboarding: single-model Connect-AI + Account reconnect

### DIFF
--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -9,9 +9,10 @@
          role="button" tabindex="0" :aria-expanded="open"
          @click="onFieldClick" @keydown.down.prevent="openAnd(0)" @keydown.enter.prevent="onEnter" @keydown.esc="open = false">
       <input v-if="allowCustom" ref="inputEl" class="jvc-input" :value="modelValue"
-             :placeholder="placeholder" :disabled="!editable"
+             :id="id" :placeholder="placeholder" :disabled="!editable"
+             :autocomplete="autocomplete" :aria-required="ariaRequired ? 'true' : undefined"
              @input="onInput" @focus="open = true"
-             @keydown.down.prevent="move(1)" @keydown.up.prevent="move(-1)" @keydown.enter.prevent="onEnter" @keydown.esc="open = false" />
+             @keydown.down.prevent.stop="move(1)" @keydown.up.prevent.stop="move(-1)" @keydown.enter.prevent.stop="onEnter" @keydown.esc.stop="open = false" />
       <span v-else class="jvc-val" :class="{ 'jvc-ph': !displayLabel }">{{ displayLabel || placeholder }}</span>
       <svg class="jvc-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
     </div>
@@ -34,8 +35,16 @@ const props = defineProps({
   placeholder: { type: String, default: "" },
   editable: { type: Boolean, default: true },
   allowCustom: { type: Boolean, default: false },
+  // Passthroughs so a JvCombo can stand in for a labelled/native form field:
+  // `id` lets an external <label for> + aria-required target the input, and
+  // `autocomplete` preserves the browser's saved-value hints.
+  id: { type: String, default: undefined },
+  autocomplete: { type: String, default: undefined },
+  ariaRequired: { type: Boolean, default: false },
 })
-const emit = defineEmits(["update:modelValue"])
+// "enter" fires when the user presses Enter without picking a suggestion, so a
+// host can wire Enter-to-submit (the native <input> it replaces had that).
+const emit = defineEmits(["update:modelValue", "enter"])
 const root = ref(null)
 const inputEl = ref(null)
 const open = ref(false)
@@ -59,7 +68,9 @@ function onFieldClick() {
   if (props.allowCustom) { inputEl.value && inputEl.value.focus(); open.value = true }
   else open.value = !open.value
 }
-function onInput(e) { emit("update:modelValue", e.target.value); open.value = true }
+// Reset the highlight on every keystroke: the filtered list is recomputed from
+// the new text, so a stale `hi` would make Enter pick an unrelated option.
+function onInput(e) { emit("update:modelValue", e.target.value); open.value = true; hi.value = -1 }
 function choose(o) { emit("update:modelValue", o.value); open.value = false; hi.value = -1 }
 function move(d) {
   if (!open.value) { open.value = true; return }
@@ -67,8 +78,10 @@ function move(d) {
   if (n) hi.value = (hi.value + d + n) % n
 }
 function onEnter() {
-  if (open.value && hi.value >= 0 && filtered.value[hi.value]) choose(filtered.value[hi.value])
-  else open.value = false
+  if (open.value && hi.value >= 0 && filtered.value[hi.value]) { choose(filtered.value[hi.value]); return }
+  // No suggestion picked — keep whatever the user typed and let the host act on Enter.
+  open.value = false
+  emit("enter")
 }
 function openAnd(i) { if (props.editable) { open.value = true; hi.value = i } }
 

--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -1,0 +1,111 @@
+<!-- Themed select / combobox — a CSS-styleable replacement for native <select>
+     and <input list=datalist>, whose popups can't be styled to match the app.
+     `options` accepts strings or {value,label}. `allowCustom` makes it a
+     free-text combobox (type your own value, filtered suggestions); otherwise
+     it's a plain picker. Emits update:modelValue with the chosen value. -->
+<template>
+  <div class="jvc" ref="root">
+    <div class="jvc-field" :class="{ 'jvc-open': open, 'jvc-dis': !editable }"
+         role="button" tabindex="0" :aria-expanded="open"
+         @click="onFieldClick" @keydown.down.prevent="openAnd(0)" @keydown.enter.prevent="onEnter" @keydown.esc="open = false">
+      <input v-if="allowCustom" ref="inputEl" class="jvc-input" :value="modelValue"
+             :placeholder="placeholder" :disabled="!editable"
+             @input="onInput" @focus="open = true"
+             @keydown.down.prevent="move(1)" @keydown.up.prevent="move(-1)" @keydown.enter.prevent="onEnter" @keydown.esc="open = false" />
+      <span v-else class="jvc-val" :class="{ 'jvc-ph': !displayLabel }">{{ displayLabel || placeholder }}</span>
+      <svg class="jvc-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+    </div>
+    <ul v-if="open && editable && filtered.length" class="jvc-menu" role="listbox">
+      <li v-for="(o, idx) in filtered" :key="o.value" role="option" :aria-selected="o.value === modelValue"
+          class="jvc-opt" :class="{ 'jvc-on': o.value === modelValue, 'jvc-hi': idx === hi }"
+          @mousedown.prevent="choose(o)" @mousemove="hi = idx">
+        <span class="jvc-opt-l">{{ o.label }}</span>
+        <svg v-if="o.value === modelValue" class="jvc-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onBeforeUnmount } from "vue"
+const props = defineProps({
+  modelValue: { type: String, default: "" },
+  options: { type: Array, default: () => [] },
+  placeholder: { type: String, default: "" },
+  editable: { type: Boolean, default: true },
+  allowCustom: { type: Boolean, default: false },
+})
+const emit = defineEmits(["update:modelValue"])
+const root = ref(null)
+const inputEl = ref(null)
+const open = ref(false)
+const hi = ref(-1)
+
+const norm = computed(() => (props.options || []).map((o) => (typeof o === "string" ? { value: o, label: o } : o)))
+const displayLabel = computed(() => {
+  const f = norm.value.find((o) => o.value === props.modelValue)
+  return f ? f.label : (props.allowCustom ? props.modelValue : "")
+})
+const filtered = computed(() => {
+  if (!props.allowCustom) return norm.value
+  const q = (props.modelValue || "").trim().toLowerCase()
+  if (!q) return norm.value
+  const hit = norm.value.filter((o) => o.label.toLowerCase().includes(q))
+  return hit.length ? hit : norm.value // never blank the list while typing a custom id
+})
+
+function onFieldClick() {
+  if (!props.editable) return
+  if (props.allowCustom) { inputEl.value && inputEl.value.focus(); open.value = true }
+  else open.value = !open.value
+}
+function onInput(e) { emit("update:modelValue", e.target.value); open.value = true }
+function choose(o) { emit("update:modelValue", o.value); open.value = false; hi.value = -1 }
+function move(d) {
+  if (!open.value) { open.value = true; return }
+  const n = filtered.value.length
+  if (n) hi.value = (hi.value + d + n) % n
+}
+function onEnter() {
+  if (open.value && hi.value >= 0 && filtered.value[hi.value]) choose(filtered.value[hi.value])
+  else open.value = false
+}
+function openAnd(i) { if (props.editable) { open.value = true; hi.value = i } }
+
+function onDocClick(e) { if (root.value && !root.value.contains(e.target)) open.value = false }
+watch(open, (v) => {
+  if (v) document.addEventListener("mousedown", onDocClick)
+  else document.removeEventListener("mousedown", onDocClick)
+})
+onBeforeUnmount(() => document.removeEventListener("mousedown", onDocClick))
+</script>
+
+<style scoped>
+.jvc { position: relative; width: 100%; }
+.jvc-field {
+  display: flex; align-items: center; gap: 8px; width: 100%; min-height: 40px;
+  padding: 9px 12px; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface); color: var(--text); font-size: 14px; font-family: inherit;
+  cursor: pointer; box-sizing: border-box;
+}
+.jvc-field:hover { border-color: var(--border-2); }
+.jvc-open { border-color: var(--blue-bd); }
+.jvc-dis { cursor: default; opacity: .7; }
+.jvc-input { flex: 1; min-width: 0; border: 0; outline: none; background: transparent; color: inherit; font: inherit; padding: 0; }
+.jvc-val { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.jvc-ph { color: var(--text-3); }
+.jvc-chev { width: 16px; height: 16px; flex: none; color: var(--text-3); }
+.jvc-menu {
+  position: absolute; z-index: 30; top: calc(100% + 4px); left: 0; right: 0;
+  margin: 0; padding: 5px; list-style: none;
+  background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+  box-shadow: 0 12px 32px -8px rgba(15, 23, 42, .25); max-height: 258px; overflow-y: auto;
+}
+.jvc-opt {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 8px 10px; border-radius: 7px; font-size: 14px; cursor: pointer; color: var(--text);
+}
+.jvc-hi, .jvc-opt:hover { background: var(--surface-2); }
+.jvc-on { font-weight: 600; }
+.jvc-check { width: 15px; height: 15px; color: var(--blue); flex: none; }
+</style>

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -155,7 +155,7 @@
               <span style="font-size:14px;color:var(--text);">{{ accountLabel(a) }}</span>
               <span style="font-size:12px;color:var(--text-3);">{{ a.upstream || 'openai' }}</span>
               <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
-                <button v-if="editable && !singleMode" @click="startConnect(m)" title="Re-authorize this subscription — mint fresh tokens"
+                <button v-if="editable && !singleMode" @click="startConnect(m, ai)" title="Re-authorize this subscription — mint fresh tokens"
                         style="border:1px solid var(--border-2);background:var(--surface);color:var(--blue);border-radius:5px;padding:3px 9px;cursor:pointer;font-size:12px;">Reconnect</button>
                 <button v-if="editable" @click="removeAccount(m, ai)" title="Remove account"
                         style="border:1px solid var(--red-bd);background:var(--red-bg);color:var(--red);border-radius:5px;width:22px;height:22px;cursor:pointer;font-size:12px;">✕</button>
@@ -193,7 +193,10 @@
             <div v-if="m._connect.error" style="margin-top:6px;font-size:13px;color:var(--red);">{{ m._connect.error }}</div>
           </div>
 
-          <button v-if="editable" @click="startConnect(m)"
+          <!-- Simplified onboarding editor hides rotation, so it also caps the row
+               at a single account (no unusable multi-account-without-rotation state):
+               hide "+ Connect account" once one is connected. -->
+          <button v-if="editable && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
                   style="font-size:14px;color:var(--blue);background:transparent;border:1px dashed var(--border-2);border-radius:7px;padding:9px 16px;cursor:pointer;">
             + Connect account
@@ -228,7 +231,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
 import * as api from "@/api"
 import {
   deriveMode, reorder, presetToModels, missingVendorKeys, validatePool,
-  PROVIDER_LABELS, providerLabel, seedRowsFromConfig, defaultSubscriptionModel,
+  PROVIDER_LABELS, providerLabel, seedRowsFromConfig, defaultSubscriptionModel, SUB_MODEL_SUGGESTIONS,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
 
@@ -298,7 +301,6 @@ const STATIC_MODEL_SUGGESTIONS = {
   "Ollama (local)": ["qwen2.5:3b", "qwen2.5:0.5b", "llama3"],
   "OpenAI-Compatible": ["claude-sonnet-4-6", "gpt-4o", "qwen2.5:3b", "llama3"],
 }
-const SUB_MODEL_SUGGESTIONS = { openai: ["gpt-5.5", "gpt-5.4"], google: ["gemini-2.5-pro", "gemini-3.5-flash"] }
 const PROVIDER_DEFAULTS = {
   "Anthropic": { model: "claude-sonnet-4-6", baseUrl: "https://api.anthropic.com" },
   "OpenAI": { model: "gpt-4o", baseUrl: "https://api.openai.com/v1" },
@@ -364,7 +366,7 @@ const syncLabel = computed(() => {
 })
 
 // ---- helpers -------------------------------------------------------------
-function blankConnect() { return { open: false, loading: false, error: "", copied: false, nonce: "", authorizeUrl: "", pastedUrl: "" } }
+function blankConnect() { return { open: false, loading: false, error: "", copied: false, nonce: "", authorizeUrl: "", pastedUrl: "", reconnectIdx: null } }
 function presetCardStyle(entry) {
   const on = selectedPreset.value === entry.key
   return {
@@ -418,6 +420,11 @@ function setCredType(m, type) {
     // Onboarding hides the model field — default it from the chosen provider so
     // validatePool + save still have a model id.
     if (singleMode.value) m.model = defaultSubscriptionModel(m.upstream)
+  } else if (singleMode.value) {
+    // Toggling back to API key in the simplified editor: drop the subscription
+    // model id (hidden while on the subscription tab) so it doesn't linger under
+    // an API-key provider it doesn't belong to.
+    m.model = (PROVIDER_DEFAULTS[m.provider] || {}).model || ""
   }
 }
 function onProviderChange(m) {
@@ -425,10 +432,16 @@ function onProviderChange(m) {
   if (!(m.model || "").trim() && d.model) m.model = d.model
   if (!(m.baseUrl || "").trim() && d.baseUrl) m.baseUrl = d.baseUrl
 }
-// Keep the (hidden) subscription model in sync with the provider in the
-// simplified onboarding editor; a no-op elsewhere (model is user-entered).
+// Provider switch on a subscription row in the simplified onboarding editor:
+// re-default the (hidden) model AND drop any already-connected account, which is
+// provider-specific — otherwise we'd save a model bound to the wrong provider's
+// OAuth credential. A no-op elsewhere (full editor manages model/accounts itself).
 function onUpstreamChange(m) {
-  if (singleMode.value && m.credentialType === "subscription") m.model = defaultSubscriptionModel(m.upstream)
+  if (singleMode.value && m.credentialType === "subscription") {
+    m.model = defaultSubscriptionModel(m.upstream)
+    m.accounts = []
+    m._connect = blankConnect()
+  }
 }
 function move(i, d) { rows.value = reorder(rows.value, i, i + d) }
 function remove(i) { rows.value = rows.value.filter((_, j) => j !== i) }
@@ -454,13 +467,18 @@ function accountLabel(a) {
   if (l && !/^SUB_/i.test(l)) return l
   return (a && a.account_email) || "Account connected"
 }
-async function startConnect(m) {
+async function startConnect(m, reconnectIdx = null) {
   if (!m._connect) m._connect = blankConnect()
+  // Simplified editor hides the model field — make sure a subscription row always
+  // carries a model id so the connect flow never dead-ends on an unfillable field.
+  if (singleMode.value && m.credentialType === "subscription" && !(m.model || "").trim()) {
+    m.model = defaultSubscriptionModel(m.upstream)
+  }
   if (!(m.model || "").trim()) {
     m._connect = { ...blankConnect(), open: true, error: "Enter a model id before connecting an account." }
     return
   }
-  m._connect = { ...blankConnect(), open: true, loading: true }
+  m._connect = { ...blankConnect(), open: true, loading: true, reconnectIdx }
   try {
     const provider = m.upstream === "google" ? "Google" : "OpenAI"
     const res = await api.beginPoolAccountSignin(provider, m.model.trim())
@@ -496,13 +514,20 @@ async function finishConnect(m) {
       upstream: m.upstream || "openai",
       account_ref: d.account_ref,
       label: d.label || d.account_email || d.account_ref,
+      account_email: d.account_email || "",
       oauth_blob: d.oauth_blob || "",
       connected: true,
     }
-    // Re-authorizing the same account (same account_ref) refreshes it in place
-    // rather than adding a duplicate row.
-    const existing = m.accounts.findIndex((a) => a.account_ref && a.account_ref === acct.account_ref)
-    if (existing >= 0) m.accounts.splice(existing, 1, acct)
+    // Place the (re)connected account. The backend mints a fresh account_ref on
+    // every sign-in, so it can't be a dedupe key: a per-account Reconnect refreshes
+    // that exact slot (reconnectIdx); otherwise fold onto an existing account with
+    // the same email; otherwise append a new one.
+    const ri = m._connect.reconnectIdx
+    const byEmail = acct.account_email
+      ? m.accounts.findIndex((a) => a.account_email && a.account_email.toLowerCase() === acct.account_email.toLowerCase())
+      : -1
+    if (ri != null && ri >= 0 && ri < m.accounts.length) m.accounts.splice(ri, 1, acct)
+    else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
     else m.accounts.push(acct)
     m._connect = blankConnect()
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e) }
@@ -542,9 +567,15 @@ async function load() {
     if (selectedPreset.value) llmMode.value = "preset"
     else if (rows.value.length >= 2 || rows.value.some((r) => r.credentialType === "subscription")) llmMode.value = "custom"
     else { llmMode.value = "quick"; if (!rows.value.length) rows.value = [newRow()] }
-    // Never land on a mode the host didn't allow (onboarding = quick-only): clamp
-    // to the first allowed mode and ensure it has a row to edit.
-    if (!props.modes.includes(llmMode.value)) {
+    // Onboarding is quick-only (singleMode): collapse to a single editable row so
+    // the editor is WYSIWYG. Quick-mode Save persists only rows[0], so keeping the
+    // rest of a seeded multi-model/preset pool around would silently drop it. Also
+    // clear any stored preset — quick can't represent one.
+    if (singleMode.value) {
+      llmMode.value = props.modes[0] || "quick"
+      selectedPreset.value = ""
+      rows.value = rows.value.length ? [rows.value[0]] : [newRow()]
+    } else if (!props.modes.includes(llmMode.value)) {
       llmMode.value = props.modes[0] || "quick"
       selectedPreset.value = ""
       if (!rows.value.length) rows.value = [newRow()]
@@ -592,6 +623,17 @@ async function save() {
     // Quick saves a single-model pool (rows[0]); Custom saves the full pool.
     saveModels = buildSaveModels(llmMode.value === "quick" ? rows.value.slice(0, 1) : rows.value)
     savePreset = null
+  }
+  // Simplified editor hides the model id, so validatePool's "Model <id> needs a
+  // connected account" would name a value the user never saw. Pre-check with a
+  // clear message instead.
+  if (singleMode.value && llmMode.value !== "preset") {
+    const r0 = rows.value[0]
+    if (r0 && r0.credentialType === "subscription" &&
+        !((r0.accounts || []).some((a) => a && (a.oauth_blob || a.account_ref)))) {
+      err.value = "Connect your account to continue."
+      return
+    }
   }
   const v = validatePool(saveModels, savePreset)
   if (!v.ok) { err.value = v.error; return }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -235,7 +235,7 @@
           <button v-if="editable && !(m._connect && m._connect.open) && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
                   style="font-size:14px;font-weight:600;color:var(--blue);background:var(--blue-bg);border:1px solid var(--blue-bd);border-radius:8px;padding:10px 16px;cursor:pointer;">
-            {{ singleMode ? 'Connect →' : '+ Connect account' }}
+            {{ singleMode ? 'Sign in →' : '+ Connect account' }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -88,8 +88,30 @@
       <div v-for="(m,i) in editorRows" :key="i"
            style="border:1px solid var(--border);border-radius:9px;padding:10px;margin-bottom:8px;background:var(--surface-1);">
 
+        <!-- Onboarding: two self-describing credential cards so the choice reads
+             at a glance without extra copy. The compact toggle stays for the
+             full (Account) editor's denser rows. -->
+        <div v-if="singleMode" class="jv-ct">
+          <div class="jv-ct-q">How do you want to connect?</div>
+          <div class="jv-ct-cards">
+            <button v-for="opt in credTypes" :key="opt.value" type="button"
+                    class="jv-ct-card" :class="{ on: m.credentialType===opt.value }"
+                    @click="setCredType(m, opt.value)" :disabled="!editable"
+                    :aria-pressed="m.credentialType===opt.value">
+              <span class="jv-ct-ic">
+                <svg v-if="opt.value==='api_key'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+              </span>
+              <span class="jv-ct-tx">
+                <span class="jv-ct-t">{{ opt.label }}</span>
+                <span class="jv-ct-d">{{ opt.desc }}</span>
+              </span>
+            </button>
+          </div>
+        </div>
+
         <!-- Row head: credential-type toggle (+ reorder/remove in Custom) -->
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+        <div v-if="!singleMode" style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
           <div style="display:inline-flex;border:1px solid var(--border);border-radius:7px;overflow:hidden;">
             <button v-for="opt in credTypes" :key="opt.value" @click="setCredType(m, opt.value)" :disabled="!editable"
                     :style="{fontSize:'12px',padding:'5px 11px',border:'none',cursor: editable ? 'pointer' : 'default',
@@ -271,8 +293,8 @@ const singleMode = computed(() => modeTabs.value.length <= 1)
 // copy so it never points at tabs that aren't there.
 const canPool = computed(() => props.modes.includes("preset") || props.modes.includes("custom"))
 const credTypes = [
-  { value: "api_key", label: "API key" },
-  { value: "subscription", label: "Chat subscription" },
+  { value: "api_key", label: "API key", desc: "Use your own provider key — Anthropic, OpenAI, and more." },
+  { value: "subscription", label: "Chat subscription", desc: "Sign in with your ChatGPT or Gemini account." },
 ]
 const rotationOpts = [
   { value: "sticky", label: "Sticky" },
@@ -669,3 +691,32 @@ watch(keysByVendor, () => {
 onMounted(load)
 onBeforeUnmount(stopPolling)
 </script>
+
+<style scoped>
+/* Onboarding credential-type cards — self-describing "API key vs Chat
+   subscription" choice. Selected state mirrors the wizard's plan cards
+   (var(--blue) ring), so it's consistent with the rest of onboarding. */
+.jv-ct { margin-bottom: 16px; }
+.jv-ct-q { font-size: 13px; font-weight: 600; color: var(--text-2); margin-bottom: 8px; }
+.jv-ct-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.jv-ct-card {
+  display: flex; align-items: flex-start; gap: 11px; text-align: left;
+  padding: 13px 14px; border: 1px solid var(--border); border-radius: 11px;
+  background: var(--surface); cursor: pointer; font: inherit; color: var(--text);
+  transition: border-color .12s, box-shadow .12s;
+}
+.jv-ct-card:hover { border-color: var(--border-2); }
+.jv-ct-card.on { border-color: var(--blue); box-shadow: 0 0 0 1px var(--blue); }
+.jv-ct-card:disabled { cursor: default; }
+.jv-ct-ic {
+  flex: none; width: 34px; height: 34px; border-radius: 9px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--surface-2); color: var(--text-2);
+}
+.jv-ct-card.on .jv-ct-ic { background: var(--blue); color: var(--surface); }
+.jv-ct-ic svg { width: 18px; height: 18px; }
+.jv-ct-tx { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.jv-ct-t { font-size: 14px; font-weight: 650; }
+.jv-ct-d { font-size: 12px; color: var(--text-3); line-height: 1.4; }
+@media (max-width: 560px) { .jv-ct-cards { grid-template-columns: 1fr; } }
+</style>

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -129,22 +129,35 @@
           </div>
         </div>
 
-        <!-- API-key credential: provider (select) / model (datalist) / api_key / base_url -->
-        <div v-if="m.credentialType!=='subscription'" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-          <select v-model="m.provider" @change="onProviderChange(m)" :disabled="!editable" title="Provider"
-                  style="flex:1;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;">
-            <option v-for="p in providerOptions" :key="p" :value="p">{{ p }}</option>
-          </select>
-          <input v-model="m.model" :list="'jv-dl-'+i" :disabled="!editable" placeholder="Model ID (e.g. gpt-4o)"
-                 style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
-          <datalist :id="'jv-dl-'+i">
-            <option v-for="s in modelSuggestionsForProvider(m.provider)" :key="s" :value="s"></option>
-          </datalist>
-          <input v-model="m.apiKey" :disabled="!editable" type="password"
-                 :placeholder="m.hasKey ? 'key set — re-enter to change' : 'API key'"
-                 style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
-          <input v-model="m.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)"
-                 style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
+        <!-- API-key credential. Onboarding (singleMode) lays the four fields out as
+             a 2×2 grid so this view's height sits close to the subscription view —
+             no jarring resize when toggling. The Account editor keeps the dense row. -->
+        <div v-if="m.credentialType!=='subscription'">
+          <div v-if="singleMode" class="jv-ak-grid">
+            <JvCombo :model-value="m.provider" @update:model-value="(v) => { m.provider = v; onProviderChange(m) }"
+                     :options="providerOptions" :editable="editable" placeholder="Provider" />
+            <JvCombo :model-value="m.model" @update:model-value="(v) => { m.model = v }" allow-custom
+                     :options="modelSuggestionsForProvider(m.provider)" :editable="editable" placeholder="Model ID (e.g. gpt-4o)" />
+            <input v-model="m.apiKey" :disabled="!editable" type="password"
+                   :placeholder="m.hasKey ? 'key set — re-enter to change' : 'API key'" />
+            <input v-model="m.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)" />
+          </div>
+          <div v-else style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+            <select v-model="m.provider" @change="onProviderChange(m)" :disabled="!editable" title="Provider"
+                    style="flex:1;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;">
+              <option v-for="p in providerOptions" :key="p" :value="p">{{ p }}</option>
+            </select>
+            <input v-model="m.model" :list="'jv-dl-'+i" :disabled="!editable" placeholder="Model ID (e.g. gpt-4o)"
+                   style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
+            <datalist :id="'jv-dl-'+i">
+              <option v-for="s in modelSuggestionsForProvider(m.provider)" :key="s" :value="s"></option>
+            </datalist>
+            <input v-model="m.apiKey" :disabled="!editable" type="password"
+                   :placeholder="m.hasKey ? 'key set — re-enter to change' : 'API key'"
+                   style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
+            <input v-model="m.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)"
+                   style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
+          </div>
         </div>
 
         <!-- Chat-subscription credential. In the simplified (onboarding) editor
@@ -159,7 +172,9 @@
             <datalist v-if="!singleMode" :id="'jv-subdl-'+i">
               <option v-for="s in (SUB_MODEL_SUGGESTIONS[m.upstream] || [])" :key="s" :value="s"></option>
             </datalist>
-            <select v-model="m.upstream" @change="onUpstreamChange(m)" :disabled="!editable" title="Provider"
+            <JvCombo v-if="singleMode" style="flex:1;" :model-value="m.upstream" @update:model-value="(v) => { m.upstream = v; onUpstreamChange(m) }"
+                     :options="upstreamOpts" :editable="editable" placeholder="Provider" />
+            <select v-else v-model="m.upstream" @change="onUpstreamChange(m)" :disabled="!editable" title="Provider"
                     style="flex:1;min-width:100px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;">
               <option v-for="o in upstreamOpts" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
@@ -232,8 +247,8 @@
       </button>
     </section>
 
-    <!-- Save bar + sync status -->
-    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+    <!-- Save bar + sync status — hidden when a host renders its own footer. -->
+    <div v-if="!footerless" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
       <button v-if="editable" @click="save" :disabled="saving || saveBlocked"
               :style="{padding:'12px 24px',background: saveBlocked ? 'var(--surface-3)' : 'var(--blue)',
                        color: saveBlocked ? 'var(--text-3)' : '#fff',border:'none',borderRadius:'9px',
@@ -256,6 +271,7 @@ import {
   PROVIDER_LABELS, providerLabel, seedRowsFromConfig, defaultSubscriptionModel, SUB_MODEL_SUGGESTIONS,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
+import JvCombo from "@/components/JvCombo.vue"
 
 const props = defineProps({
   editable: { type: Boolean, default: true },
@@ -264,6 +280,9 @@ const props = defineProps({
   // proxy-pool Preset/Custom tabs + the Direct/Proxy badge — faster signup, no
   // failover/pooling decisions up front (users configure that later in Account).
   modes: { type: Array, default: () => ["quick", "preset", "custom"] },
+  // Hide the built-in Save bar so a host (onboarding) can render its own footer
+  // and trigger save() via a template ref (exposed below).
+  footerless: { type: Boolean, default: false },
 })
 const emit = defineEmits(["saved"])
 
@@ -690,6 +709,9 @@ watch(keysByVendor, () => {
 
 onMounted(load)
 onBeforeUnmount(stopPolling)
+
+// Let a host (onboarding, footerless) drive Save from its own footer.
+defineExpose({ save })
 </script>
 
 <style scoped>
@@ -718,5 +740,12 @@ onBeforeUnmount(stopPolling)
 .jv-ct-tx { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .jv-ct-t { font-size: 14px; font-weight: 650; }
 .jv-ct-d { font-size: 12px; color: var(--text-3); line-height: 1.4; }
-@media (max-width: 560px) { .jv-ct-cards { grid-template-columns: 1fr; } }
+/* API-key fields as a 2×2 grid in onboarding — keeps this view's height close to
+   the subscription view so toggling doesn't resize the card. */
+.jv-ak-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
+.jv-ak-grid select, .jv-ak-grid input {
+  width: 100%; padding: 10px 12px; font-size: 14px; border: 1px solid var(--border);
+  border-radius: 8px; background: var(--surface); color: var(--text); font-family: inherit; box-sizing: border-box;
+}
+@media (max-width: 560px) { .jv-ct-cards, .jv-ak-grid { grid-template-columns: 1fr; } }
 </style>

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -132,7 +132,7 @@
         <!-- API-key credential. Onboarding (singleMode) lays the four fields out as
              a 2×2 grid so this view's height sits close to the subscription view —
              no jarring resize when toggling. The Account editor keeps the dense row. -->
-        <div v-if="m.credentialType!=='subscription'">
+        <div v-if="m.credentialType!=='subscription'" :class="{ 'jv-single-body': singleMode }">
           <div v-if="singleMode" class="jv-ak-grid">
             <JvCombo :model-value="m.provider" @update:model-value="(v) => { m.provider = v; onProviderChange(m) }"
                      :options="providerOptions" :editable="editable" placeholder="Provider" />
@@ -164,8 +164,7 @@
              the provider is enough: the Model ID field + rotation dropdown are
              hidden (model auto-defaults per provider), leaving just the provider
              picker + connect. The full account editor keeps all three. -->
-        <div v-else>
-          <label v-if="singleMode" style="display:block;font-size:12px;color:var(--text-2);margin-bottom:4px;">Chat subscription provider</label>
+        <div v-else :class="{ 'jv-single-body': singleMode }">
           <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap;">
             <input v-if="!singleMode" v-model="m.model" :list="'jv-subdl-'+i" :disabled="!editable" placeholder="Model ID (e.g. gpt-5.5)"
                    style="flex:2;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
@@ -188,7 +187,9 @@
           <div v-if="m.accounts && m.accounts.length" style="display:flex;flex-direction:column;gap:5px;margin-bottom:8px;">
             <div v-for="(a, ai) in m.accounts" :key="a.account_ref || ai"
                  style="display:flex;align-items:center;gap:8px;padding:5px 9px;border:1px solid var(--green-bd);background:var(--green-bg);border-radius:6px;">
-              <span style="font-size:12px;font-weight:600;color:var(--green);">connected</span>
+              <span style="display:flex;align-items:center;gap:5px;font-size:12.5px;font-weight:700;color:var(--green);">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>Connected
+              </span>
               <span style="font-size:14px;color:var(--text);">{{ accountLabel(a) }}</span>
               <span style="font-size:12px;color:var(--text-3);">{{ a.upstream || 'openai' }}</span>
               <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
@@ -199,7 +200,7 @@
               </span>
             </div>
           </div>
-          <div v-else style="font-size:13px;color:var(--text-3);margin-bottom:8px;">No accounts connected yet.</div>
+          <div v-else-if="!singleMode" style="font-size:13px;color:var(--text-3);margin-bottom:8px;">No accounts connected yet.</div>
 
           <!-- Inline paste-back connect flow -->
           <div v-if="m._connect && m._connect.open"
@@ -235,8 +236,8 @@
                hide "+ Connect account" once one is connected. -->
           <button v-if="editable && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
-                  style="font-size:14px;color:var(--blue);background:transparent;border:1px dashed var(--border-2);border-radius:7px;padding:9px 16px;cursor:pointer;">
-            + Connect account
+                  style="font-size:14px;font-weight:600;color:var(--blue);background:var(--blue-bg);border:1px solid var(--blue-bd);border-radius:8px;padding:10px 16px;cursor:pointer;">
+            {{ singleMode ? 'Connect account →' : '+ Connect account' }}
           </button>
         </div>
       </div>
@@ -312,8 +313,8 @@ const singleMode = computed(() => modeTabs.value.length <= 1)
 // copy so it never points at tabs that aren't there.
 const canPool = computed(() => props.modes.includes("preset") || props.modes.includes("custom"))
 const credTypes = [
-  { value: "api_key", label: "API key", desc: "Use your own provider key — Anthropic, OpenAI, and more." },
   { value: "subscription", label: "Chat subscription", desc: "Sign in with your ChatGPT or Gemini account." },
+  { value: "api_key", label: "API key", desc: "Use your own provider key — Anthropic, OpenAI, and more." },
 ]
 const rotationOpts = [
   { value: "sticky", label: "Sticky" },
@@ -616,6 +617,13 @@ async function load() {
       llmMode.value = props.modes[0] || "quick"
       selectedPreset.value = ""
       rows.value = rows.value.length ? [rows.value[0]] : [newRow()]
+      // Onboarding default = Chat subscription (the common path). Only flip a
+      // pristine row so a returning customer's saved API-key setup is preserved.
+      const r0 = rows.value[0]
+      if (r0 && r0.credentialType === "api_key" && !(r0.model || "").trim() &&
+          !(r0.apiKey || "").trim() && !r0.hasKey && !(r0.accounts && r0.accounts.length)) {
+        setCredType(r0, "subscription")
+      }
     } else if (!props.modes.includes(llmMode.value)) {
       llmMode.value = props.modes[0] || "quick"
       selectedPreset.value = ""
@@ -740,6 +748,9 @@ defineExpose({ save })
 .jv-ct-tx { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .jv-ct-t { font-size: 14px; font-weight: 650; }
 .jv-ct-d { font-size: 12px; color: var(--text-3); line-height: 1.4; }
+/* Lock both credential modes to the same body height in onboarding so toggling
+   API key ↔ Chat subscription never resizes the card (first-impression polish). */
+.jv-single-body { min-height: 96px; }
 /* API-key fields as a 2×2 grid in onboarding — keeps this view's height close to
    the subscription view so toggling doesn't resize the card. */
 .jv-ak-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -576,8 +576,12 @@ async function finishConnect(m) {
     const byEmail = acct.account_email
       ? m.accounts.findIndex((a) => a.account_email && a.account_email.toLowerCase() === acct.account_email.toLowerCase())
       : -1
-    if (ri != null && ri >= 0 && ri < m.accounts.length) m.accounts.splice(ri, 1, acct)
-    else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
+    if (ri != null && ri >= 0 && ri < m.accounts.length) {
+      m.accounts.splice(ri, 1, acct)
+      // Reconnecting one slot but signing in as an account already held by a
+      // DIFFERENT slot would leave two identical accounts — drop the duplicate.
+      if (byEmail >= 0 && byEmail !== ri) m.accounts.splice(byEmail, 1)
+    } else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
     else m.accounts.push(acct)
     m._connect = blankConnect()
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e) }
@@ -617,14 +621,15 @@ async function load() {
     if (selectedPreset.value) llmMode.value = "preset"
     else if (rows.value.length >= 2 || rows.value.some((r) => r.credentialType === "subscription")) llmMode.value = "custom"
     else { llmMode.value = "quick"; if (!rows.value.length) rows.value = [newRow()] }
-    // Onboarding is quick-only (singleMode): collapse to a single editable row so
-    // the editor is WYSIWYG. Quick-mode Save persists only rows[0], so keeping the
-    // rest of a seeded multi-model/preset pool around would silently drop it. Also
-    // clear any stored preset — quick can't represent one.
+    // Onboarding is quick-only (singleMode): the editor shows a single editable
+    // row (editorRows renders rows[0]) but we KEEP any seeded tail rows so a
+    // returning customer's existing failover pool round-trips through save()
+    // instead of being silently dropped. Only the preset (which quick can't
+    // represent) is cleared.
     if (singleMode.value) {
       llmMode.value = props.modes[0] || "quick"
       selectedPreset.value = ""
-      rows.value = rows.value.length ? [rows.value[0]] : [newRow()]
+      if (!rows.value.length) rows.value = [newRow()]
       // Onboarding default = Chat subscription (the common path). Only flip a
       // pristine row so a returning customer's saved API-key setup is preserved.
       const r0 = rows.value[0]
@@ -678,7 +683,9 @@ async function save() {
     savePreset = selectedPreset.value || null
   } else {
     // Quick saves a single-model pool (rows[0]); Custom saves the full pool.
-    saveModels = buildSaveModels(llmMode.value === "quick" ? rows.value.slice(0, 1) : rows.value)
+    // Exception: onboarding's singleMode keeps seeded tail rows (editorRows only
+    // renders the first) so a returning customer's existing pool isn't dropped.
+    saveModels = buildSaveModels(llmMode.value === "quick" && !singleMode.value ? rows.value.slice(0, 1) : rows.value)
     savePreset = null
   }
   // Simplified editor hides the model id, so validatePool's "Model <id> needs a

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -30,7 +30,7 @@
     <!-- ===================== PRESET ===================== -->
     <section v-if="llmMode==='preset'" style="margin-bottom:18px;">
       <p v-if="!catalog.length" style="font-size:14px;color:var(--text-3);margin:0 0 12px;">
-        Couldn't load presets — use <b>Quick</b> or <b>Custom</b>.
+        Couldn't load presets. Use <b>Quick</b> or <b>Custom</b>.
       </p>
       <div v-else style="max-height:440px;overflow-y:auto;padding-right:4px;">
         <!-- single_vendor presets -->
@@ -83,7 +83,7 @@
         Custom failover pool
       </div>
 
-      <div v-if="!editorRows.length" style="font-size:13px;color:var(--text-3);padding:8px 0;">No models yet — add one below.</div>
+      <div v-if="!editorRows.length" style="font-size:13px;color:var(--text-3);padding:8px 0;">No models yet. Add one below.</div>
 
       <div v-for="(m,i) in editorRows" :key="i"
            style="border:1px solid var(--border);border-radius:9px;padding:10px;margin-bottom:8px;background:var(--surface-1);">
@@ -139,7 +139,7 @@
             <JvCombo :model-value="m.model" @update:model-value="(v) => { m.model = v }" allow-custom
                      :options="modelSuggestionsForProvider(m.provider)" :editable="editable" placeholder="Model ID (e.g. gpt-4o)" />
             <input v-model="m.apiKey" :disabled="!editable" type="password"
-                   :placeholder="m.hasKey ? 'key set — re-enter to change' : 'API key'" />
+                   :placeholder="m.hasKey ? 'key set, re-enter to change' : 'API key'" />
             <input v-model="m.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)" />
           </div>
           <div v-else style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
@@ -153,7 +153,7 @@
               <option v-for="s in modelSuggestionsForProvider(m.provider)" :key="s" :value="s"></option>
             </datalist>
             <input v-model="m.apiKey" :disabled="!editable" type="password"
-                   :placeholder="m.hasKey ? 'key set — re-enter to change' : 'API key'"
+                   :placeholder="m.hasKey ? 'key set, re-enter to change' : 'API key'"
                    style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
             <input v-model="m.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)"
                    style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
@@ -189,7 +189,7 @@
               <span class="jv-status-ic"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/></svg></span>
               <span class="jv-status-tx"><b>Connected</b> · {{ accountLabel(a) }}</span>
               <span class="jv-status-acts">
-                <button v-if="editable && !singleMode" class="jv-status-act" @click="startConnect(m, ai)" title="Re-authorize — mint fresh tokens">Reconnect</button>
+                <button v-if="editable && !singleMode" class="jv-status-act" @click="startConnect(m, ai)" title="Re-authorize to mint fresh tokens">Reconnect</button>
                 <button v-if="editable" class="jv-status-act" @click="removeAccount(m, ai)">Disconnect</button>
               </span>
             </div>
@@ -214,7 +214,7 @@
                 <span class="jv-cn-num">2</span>
                 <div class="jv-cn-body">
                   <div class="jv-cn-t">Paste the callback URL</div>
-                  <div class="jv-cn-hint">After signing in you'll see a “This site can't be reached” page — that's expected. Copy that page's full URL and paste it below.</div>
+                  <div class="jv-cn-hint">After signing in you'll see a “This site can't be reached” page. Copy that page's full URL and paste it below.</div>
                   <input v-model="m._connect.pastedUrl" class="jv-cn-input" placeholder="http://localhost:1455/auth/callback?code=…" @keydown.enter="finishConnect(m)" />
                 </div>
               </div>
@@ -322,7 +322,7 @@ const ready = computed(() => {
 })
 const credTypes = [
   { value: "subscription", label: "Chat subscription", desc: "Sign in with your ChatGPT or Gemini account." },
-  { value: "api_key", label: "API key", desc: "Use your own provider key — Anthropic, OpenAI, and more." },
+  { value: "api_key", label: "API key", desc: "Use your own provider key from Anthropic, OpenAI, and more." },
 ]
 const rotationOpts = [
   { value: "sticky", label: "Sticky" },
@@ -331,7 +331,7 @@ const rotationOpts = [
 ]
 const upstreamOpts = [
   { value: "openai", label: "OpenAI" },
-  { value: "google", label: "Google" },
+  { value: "google", label: "Google Gemini" },
 ]
 // Provider dropdown fed by the shared PROVIDER_LABELS (id⇄label). Rows store the
 // display LABEL as `provider` (matches seedRowsFromConfig + the desk page).
@@ -341,7 +341,7 @@ const providerOptions = PROVIDER_LABELS.map((p) => p.label)
 const STATIC_MODEL_SUGGESTIONS = {
   "Anthropic": ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
   "OpenAI": ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-4o"],
-  "Google Gemini": ["gemini-2.5-pro", "gemini-3.5-flash", "gemini-3.1-flash-lite"],
+  "Google Gemini": ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"],
   "Mistral": ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
   "Groq": ["llama-3.3-70b-versatile"],
   "Together AI": ["meta-llama/Llama-3.3-70B-Instruct-Turbo"],
@@ -530,14 +530,14 @@ async function startConnect(m, reconnectIdx = null) {
   }
   m._connect = { ...blankConnect(), open: true, loading: true, reconnectIdx }
   try {
-    const provider = m.upstream === "google" ? "Google" : "OpenAI"
+    const provider = m.upstream === "google" ? "Google Gemini" : "OpenAI"
     const res = await api.beginPoolAccountSignin(provider, m.model.trim())
     // Backend returns an envelope: {ok:true, data:{nonce, authorize_url, …}} or
     // {ok:false, error:{code, message}}. Unwrap data; surface errors instead of
     // hanging on "Starting sign-in…".
     if (!res || res.ok === false) {
       m._connect.loading = false
-      m._connect.error = (res && res.error && res.error.message) || "Couldn't start sign-in — try again."
+      m._connect.error = (res && res.error && res.error.message) || "Couldn't start sign-in. Try again."
       return
     }
     const d = res.data || {}
@@ -555,7 +555,7 @@ async function finishConnect(m) {
     // Same {ok, data} envelope as begin — unwrap + surface errors.
     if (!res || res.ok === false) {
       m._connect.loading = false
-      m._connect.error = (res && res.error && res.error.message) || "Couldn't connect the account — check the pasted URL and try again."
+      m._connect.error = (res && res.error && res.error.message) || "Couldn't connect the account. Check the pasted URL and try again."
       return
     }
     const d = res.data || {}
@@ -589,7 +589,7 @@ function copyAuthorizeUrl(m) {
   copyTextWithFallback(url).then(() => {
     m._connect.copied = true
     setTimeout(() => { if (m._connect) m._connect.copied = false }, 1400)
-  }).catch(() => { m._connect.error = "Could not copy — select the URL above and copy manually." })
+  }).catch(() => { m._connect.error = "Could not copy. Select the URL above and copy manually." })
 }
 
 // ---- load / save ---------------------------------------------------------

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -234,7 +234,7 @@
                hide "+ Connect account" once one is connected. -->
           <button v-if="editable && !(m._connect && m._connect.open) && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
-                  style="font-size:14px;font-weight:600;color:var(--blue);background:var(--blue-bg);border:1px solid var(--blue-bd);border-radius:8px;padding:10px 16px;cursor:pointer;">
+                  style="font-size:14px;font-weight:600;color:var(--surface);background:var(--blue);border:0;border-radius:8px;padding:11px 17px;cursor:pointer;">
             {{ singleMode ? 'Sign in →' : '+ Connect account' }}
           </button>
         </div>
@@ -782,7 +782,7 @@ defineExpose({ save })
 .jv-cn-body { flex: 1; min-width: 0; }
 .jv-cn-t { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 7px; }
 .jv-cn-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-.jv-cn-open { font-size: 13px; font-weight: 600; color: var(--blue); text-decoration: none; padding: 7px 13px; border: 1px solid var(--blue-bd); background: var(--blue-bg); border-radius: 8px; }
+.jv-cn-open { font-size: 13px; font-weight: 600; color: var(--surface); text-decoration: none; padding: 8px 14px; border: 0; background: var(--blue); border-radius: 8px; }
 .jv-cn-copy { font-size: 12.5px; padding: 7px 12px; border: 1px solid var(--border); border-radius: 8px; cursor: pointer; background: var(--surface); color: var(--text-2); }
 .jv-cn-copy:hover { color: var(--text); }
 .jv-cn-hint { font-size: 12px; color: var(--text-3); line-height: 1.5; margin-bottom: 8px; }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -185,18 +185,12 @@
 
           <!-- Connected accounts -->
           <div v-if="m.accounts && m.accounts.length" style="display:flex;flex-direction:column;gap:5px;margin-bottom:8px;">
-            <div v-for="(a, ai) in m.accounts" :key="a.account_ref || ai"
-                 style="display:flex;align-items:center;gap:8px;padding:5px 9px;border:1px solid var(--green-bd);background:var(--green-bg);border-radius:6px;">
-              <span style="display:flex;align-items:center;gap:5px;font-size:12.5px;font-weight:700;color:var(--green);">
-                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>Connected
-              </span>
-              <span style="font-size:14px;color:var(--text);">{{ accountLabel(a) }}</span>
-              <span style="font-size:12px;color:var(--text-3);">{{ a.upstream || 'openai' }}</span>
-              <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
-                <button v-if="editable && !singleMode" @click="startConnect(m, ai)" title="Re-authorize this subscription — mint fresh tokens"
-                        style="border:1px solid var(--border-2);background:var(--surface);color:var(--blue);border-radius:5px;padding:3px 9px;cursor:pointer;font-size:12px;">Reconnect</button>
-                <button v-if="editable" @click="removeAccount(m, ai)" title="Remove account"
-                        style="border:1px solid var(--red-bd);background:var(--red-bg);color:var(--red);border-radius:5px;width:22px;height:22px;cursor:pointer;font-size:12px;">✕</button>
+            <div v-for="(a, ai) in m.accounts" :key="a.account_ref || ai" class="jv-status jv-status-ok">
+              <span class="jv-status-ic"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4L12 14.01l-3-3"/></svg></span>
+              <span class="jv-status-tx"><b>Connected</b> · {{ accountLabel(a) }}</span>
+              <span class="jv-status-acts">
+                <button v-if="editable && !singleMode" class="jv-status-act" @click="startConnect(m, ai)" title="Re-authorize — mint fresh tokens">Reconnect</button>
+                <button v-if="editable" class="jv-status-act" @click="removeAccount(m, ai)">Disconnect</button>
               </span>
             </div>
           </div>
@@ -762,6 +756,20 @@ defineExpose({ save })
 .jv-ct-tx { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .jv-ct-t { font-size: 14px; font-weight: 650; }
 .jv-ct-d { font-size: 12px; color: var(--text-3); line-height: 1.4; }
+/* Clean status pill — connected (ok) / failed (bad). Reused by the subscription
+   connected row and (later) the API-key verify result. No red ✕ — a subtle text
+   action handles disconnect. */
+.jv-status { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: 9px; font-size: 13.5px; margin-bottom: 8px; }
+.jv-status-ok { border: 1px solid var(--green-bd); background: var(--green-bg); }
+.jv-status-bad { border: 1px solid var(--red-bd); background: var(--red-bg); }
+.jv-status-ic { flex: none; display: flex; color: var(--green); }
+.jv-status-bad .jv-status-ic { color: var(--red); }
+.jv-status-tx { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); }
+.jv-status-tx b { color: var(--green); font-weight: 600; }
+.jv-status-bad .jv-status-tx b { color: var(--red); }
+.jv-status-acts { margin-left: auto; display: flex; gap: 12px; flex: none; }
+.jv-status-act { background: transparent; border: 0; color: var(--text-3); font-size: 12.5px; cursor: pointer; padding: 0; }
+.jv-status-act:hover { color: var(--text); text-decoration: underline; text-underline-offset: 2px; }
 /* Lock both credential modes to the same body height in onboarding so toggling
    API key ↔ Chat subscription never resizes the card (first-impression polish). */
 .jv-single-body { min-height: 96px; }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -196,39 +196,43 @@
           </div>
           <div v-else-if="!singleMode" style="font-size:13px;color:var(--text-3);margin-bottom:8px;">No accounts connected yet.</div>
 
-          <!-- Inline paste-back connect flow -->
-          <div v-if="m._connect && m._connect.open"
-               style="padding:10px;background:var(--surface-2);border:1px solid var(--border);border-radius:8px;margin-bottom:8px;">
-            <div v-if="m._connect.authorizeUrl" style="display:flex;flex-direction:column;gap:8px;">
-              <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-                <a :href="m._connect.authorizeUrl" target="_blank" rel="noopener noreferrer"
-                   style="font-size:14px;color:var(--blue);text-decoration:none;font-weight:600;">Open sign-in ↗</a>
-                <button @click="copyAuthorizeUrl(m)" title="Copy URL"
-                        style="font-size:13px;padding:4px 10px;border:1px solid var(--border);border-radius:6px;cursor:pointer;background:var(--surface);color:var(--text-2);">
-                  {{ m._connect.copied ? 'Copied ✓' : 'Copy' }}
-                </button>
+          <!-- Inline paste-back OAuth flow — two clear steps: open the sign-in
+               (OAuth) URL, then paste the callback URL you're redirected to. -->
+          <div v-if="m._connect && m._connect.open" class="jv-cn">
+            <div v-if="m._connect.authorizeUrl">
+              <div class="jv-cn-step">
+                <span class="jv-cn-num">1</span>
+                <div class="jv-cn-body">
+                  <div class="jv-cn-t">Sign in with your {{ m.upstream === 'google' ? 'Google' : 'OpenAI' }} account</div>
+                  <div class="jv-cn-row">
+                    <a :href="m._connect.authorizeUrl" target="_blank" rel="noopener noreferrer" class="jv-cn-open">Open sign-in ↗</a>
+                    <button @click="copyAuthorizeUrl(m)" class="jv-cn-copy">{{ m._connect.copied ? 'Copied ✓' : 'Copy link' }}</button>
+                  </div>
+                </div>
               </div>
-              <input v-model="m._connect.pastedUrl" placeholder="Paste the URL after you sign in"
-                     style="width:100%;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;box-sizing:border-box;" />
-              <div style="display:flex;gap:8px;">
-                <button @click="finishConnect(m)" :disabled="m._connect.loading"
-                        :style="{padding:'6px 14px',fontSize:'12.5px',border:'none',borderRadius:'6px',
-                                 cursor: m._connect.loading ? 'not-allowed' : 'pointer',
-                                 background:'var(--blue)',color:'#fff',opacity: m._connect.loading ? '0.6' : '1'}">
+              <div class="jv-cn-step">
+                <span class="jv-cn-num">2</span>
+                <div class="jv-cn-body">
+                  <div class="jv-cn-t">Paste the callback URL</div>
+                  <div class="jv-cn-hint">After signing in you'll see a “This site can't be reached” page — that's expected. Copy that page's full URL and paste it below.</div>
+                  <input v-model="m._connect.pastedUrl" class="jv-cn-input" placeholder="http://localhost:1455/auth/callback?code=…" @keydown.enter="finishConnect(m)" />
+                </div>
+              </div>
+              <div class="jv-cn-acts">
+                <button @click="closeConnect(m)" class="jv-cn-cancel">Cancel</button>
+                <button @click="finishConnect(m)" :disabled="m._connect.loading" class="jv-cn-connect">
                   {{ m._connect.loading ? 'Connecting…' : 'Connect' }}
                 </button>
-                <button @click="closeConnect(m)"
-                        style="padding:9px 16px;font-size:14px;border:1px solid var(--border);border-radius:6px;cursor:pointer;background:var(--surface);color:var(--text-2);">Cancel</button>
               </div>
             </div>
-            <div v-else style="font-size:13px;color:var(--text-2);">Starting sign-in…</div>
-            <div v-if="m._connect.error" style="margin-top:6px;font-size:13px;color:var(--red);">{{ m._connect.error }}</div>
+            <div v-else class="jv-cn-loading">Starting sign-in…</div>
+            <div v-if="m._connect.error" class="jv-cn-err">{{ m._connect.error }}</div>
           </div>
 
           <!-- Simplified onboarding editor hides rotation, so it also caps the row
                at a single account (no unusable multi-account-without-rotation state):
                hide "+ Connect account" once one is connected. -->
-          <button v-if="editable && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
+          <button v-if="editable && !(m._connect && m._connect.open) && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
                   style="font-size:14px;font-weight:600;color:var(--blue);background:var(--blue-bg);border:1px solid var(--blue-bd);border-radius:8px;padding:10px 16px;cursor:pointer;">
             {{ singleMode ? 'Connect →' : '+ Connect account' }}
@@ -770,6 +774,26 @@ defineExpose({ save })
 .jv-status-acts { margin-left: auto; display: flex; gap: 12px; flex: none; }
 .jv-status-act { background: transparent; border: 0; color: var(--text-3); font-size: 12.5px; cursor: pointer; padding: 0; }
 .jv-status-act:hover { color: var(--text); text-decoration: underline; text-underline-offset: 2px; }
+/* Paste-back OAuth connect panel — two numbered steps (open sign-in URL / paste
+   the callback URL), styled to match the rest of the onboarding editor. */
+.jv-cn { margin-top: 8px; padding: 15px; background: var(--surface-1); border: 1px solid var(--border); border-radius: 11px; }
+.jv-cn-step { display: flex; gap: 10px; margin-bottom: 13px; }
+.jv-cn-num { flex: none; width: 21px; height: 21px; border-radius: 50%; background: var(--blue); color: var(--surface); font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; margin-top: 1px; }
+.jv-cn-body { flex: 1; min-width: 0; }
+.jv-cn-t { font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: 7px; }
+.jv-cn-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.jv-cn-open { font-size: 13px; font-weight: 600; color: var(--blue); text-decoration: none; padding: 7px 13px; border: 1px solid var(--blue-bd); background: var(--blue-bg); border-radius: 8px; }
+.jv-cn-copy { font-size: 12.5px; padding: 7px 12px; border: 1px solid var(--border); border-radius: 8px; cursor: pointer; background: var(--surface); color: var(--text-2); }
+.jv-cn-copy:hover { color: var(--text); }
+.jv-cn-hint { font-size: 12px; color: var(--text-3); line-height: 1.5; margin-bottom: 8px; }
+.jv-cn-input { width: 100%; padding: 9px 12px; font-size: 13.5px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); font-family: inherit; box-sizing: border-box; }
+.jv-cn-input:focus { outline: none; border-color: var(--blue-bd); }
+.jv-cn-acts { display: flex; justify-content: flex-end; gap: 8px; }
+.jv-cn-cancel { padding: 8px 15px; font-size: 13px; border: 1px solid var(--border); border-radius: 8px; cursor: pointer; background: var(--surface); color: var(--text-2); }
+.jv-cn-connect { padding: 8px 17px; font-size: 13px; font-weight: 600; border: 0; border-radius: 8px; cursor: pointer; background: var(--blue); color: var(--surface); }
+.jv-cn-connect:disabled { opacity: .6; cursor: not-allowed; }
+.jv-cn-loading { font-size: 13px; color: var(--text-2); }
+.jv-cn-err { margin-top: 9px; font-size: 13px; color: var(--red); }
 /* Lock both credential modes to the same body height in onboarding so toggling
    API key ↔ Chat subscription never resizes the card (first-impression polish). */
 .jv-single-body { min-height: 96px; }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -237,7 +237,7 @@
           <button v-if="editable && (!singleMode || !(m.accounts && m.accounts.length))" @click="startConnect(m)"
                   :disabled="m._connect && m._connect.loading && !m._connect.authorizeUrl"
                   style="font-size:14px;font-weight:600;color:var(--blue);background:var(--blue-bg);border:1px solid var(--blue-bd);border-radius:8px;padding:10px 16px;cursor:pointer;">
-            {{ singleMode ? 'Connect account →' : '+ Connect account' }}
+            {{ singleMode ? 'Connect →' : '+ Connect account' }}
           </button>
         </div>
       </div>
@@ -285,7 +285,7 @@ const props = defineProps({
   // and trigger save() via a template ref (exposed below).
   footerless: { type: Boolean, default: false },
 })
-const emit = defineEmits(["saved"])
+const emit = defineEmits(["saved", "ready"])
 
 // ---- state ---------------------------------------------------------------
 const cfg = ref({ models: [], preset: "", routing_mode: "failover", proxy_active: false })
@@ -312,6 +312,16 @@ const singleMode = computed(() => modeTabs.value.length <= 1)
 // Whether any proxy-pool tab (Preset/Custom) is reachable — gates the Quick hint
 // copy so it never points at tabs that aren't there.
 const canPool = computed(() => props.modes.includes("preset") || props.modes.includes("custom"))
+// Whether the single-mode (onboarding) row is savable — an account is connected,
+// or an API key + provider/model are filled. Emitted so the host footer can
+// invite the final "Onboard Jarvis" click once the user is ready.
+const ready = computed(() => {
+  if (!singleMode.value) return false
+  const r = rows.value[0]
+  if (!r) return false
+  if (r.credentialType === "subscription") return (r.accounts || []).some((a) => a && (a.oauth_blob || a.account_ref))
+  return !!((r.provider || "").trim() && (r.model || "").trim() && ((r.apiKey || "").trim() || r.hasKey))
+})
 const credTypes = [
   { value: "subscription", label: "Chat subscription", desc: "Sign in with your ChatGPT or Gemini account." },
   { value: "api_key", label: "API key", desc: "Use your own provider key — Anthropic, OpenAI, and more." },
@@ -714,6 +724,10 @@ watch(keysByVendor, () => {
     if (e) rows.value = seedFromPreset(e)
   }
 }, { deep: true })
+
+// Tell the host (onboarding footer) when the config becomes savable so it can
+// highlight the "Onboard Jarvis" CTA.
+watch(ready, (v) => emit("ready", v), { immediate: true })
 
 onMounted(load)
 onBeforeUnmount(stopPolling)

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -8,8 +8,9 @@
   <div class="jv-llm-editor" style="font-family:inherit;color:var(--text);">
     <div v-if="err" style="color:var(--red);font-size:13px;margin-bottom:12px;">{{ err }}</div>
 
-    <!-- Setup mode tabs + derived Direct/Proxy badge -->
-    <div style="display:flex;align-items:center;gap:12px;margin-bottom:14px;flex-wrap:wrap;">
+    <!-- Setup mode tabs + derived Direct/Proxy badge — hidden when the host
+         allows only one mode (onboarding's quick-only editor). -->
+    <div v-if="!singleMode" style="display:flex;align-items:center;gap:12px;margin-bottom:14px;flex-wrap:wrap;">
       <div role="tablist" style="display:inline-flex;border:1px solid var(--border);border-radius:9px;overflow:hidden;">
         <button v-for="t in modeTabs" :key="t.value" role="tab" :aria-selected="llmMode===t.value"
                 @click="setMode(t.value)" :disabled="!editable"
@@ -76,7 +77,7 @@
     <!-- ================ QUICK / CUSTOM (shared rows) ================ -->
     <section v-else style="margin-bottom:18px;">
       <p v-if="llmMode==='quick'" style="font-size:14px;color:var(--text-3);margin:0 0 12px;">
-        A single model, sent directly to the provider. Need multiple models with failover? Use <b>Preset</b> or <b>Custom</b>.
+        A single model, sent directly to the provider.<template v-if="canPool"> Need multiple models with failover? Use <b>Preset</b> or <b>Custom</b>.</template><template v-else> You can add more models and automatic failover later from My Account.</template>
       </p>
       <div v-else style="font-size:13px;font-weight:600;color:var(--text-2);margin-bottom:8px;letter-spacing:.03em;text-transform:uppercase;">
         Custom failover pool
@@ -124,19 +125,23 @@
                  style="flex:1.5;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
         </div>
 
-        <!-- Chat-subscription credential: model + upstream + rotation + accounts + connect -->
+        <!-- Chat-subscription credential. In the simplified (onboarding) editor
+             the provider is enough: the Model ID field + rotation dropdown are
+             hidden (model auto-defaults per provider), leaving just the provider
+             picker + connect. The full account editor keeps all three. -->
         <div v-else>
+          <label v-if="singleMode" style="display:block;font-size:12px;color:var(--text-2);margin-bottom:4px;">Chat subscription provider</label>
           <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap;">
-            <input v-model="m.model" :list="'jv-subdl-'+i" :disabled="!editable" placeholder="Model ID (e.g. gpt-5.5)"
+            <input v-if="!singleMode" v-model="m.model" :list="'jv-subdl-'+i" :disabled="!editable" placeholder="Model ID (e.g. gpt-5.5)"
                    style="flex:2;min-width:120px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;" />
-            <datalist :id="'jv-subdl-'+i">
+            <datalist v-if="!singleMode" :id="'jv-subdl-'+i">
               <option v-for="s in (SUB_MODEL_SUGGESTIONS[m.upstream] || [])" :key="s" :value="s"></option>
             </datalist>
-            <select v-model="m.upstream" :disabled="!editable" title="Upstream"
+            <select v-model="m.upstream" @change="onUpstreamChange(m)" :disabled="!editable" title="Provider"
                     style="flex:1;min-width:100px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;">
               <option v-for="o in upstreamOpts" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
-            <select v-model="m.rotation" :disabled="!editable" title="Account rotation"
+            <select v-if="!singleMode" v-model="m.rotation" :disabled="!editable" title="Account rotation"
                     style="flex:1.2;min-width:110px;padding:9px 12px;font-size:14px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-family:inherit;">
               <option v-for="o in rotationOpts" :key="o.value" :value="o.value">{{ o.label }}</option>
             </select>
@@ -149,8 +154,12 @@
               <span style="font-size:12px;font-weight:600;color:var(--green);">connected</span>
               <span style="font-size:14px;color:var(--text);">{{ accountLabel(a) }}</span>
               <span style="font-size:12px;color:var(--text-3);">{{ a.upstream || 'openai' }}</span>
-              <button v-if="editable" @click="removeAccount(m, ai)" title="Remove account"
-                      style="margin-left:auto;border:1px solid var(--red-bd);background:var(--red-bg);color:var(--red);border-radius:5px;width:22px;height:22px;cursor:pointer;font-size:12px;">✕</button>
+              <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
+                <button v-if="editable && !singleMode" @click="startConnect(m)" title="Re-authorize this subscription — mint fresh tokens"
+                        style="border:1px solid var(--border-2);background:var(--surface);color:var(--blue);border-radius:5px;padding:3px 9px;cursor:pointer;font-size:12px;">Reconnect</button>
+                <button v-if="editable" @click="removeAccount(m, ai)" title="Remove account"
+                        style="border:1px solid var(--red-bd);background:var(--red-bg);color:var(--red);border-radius:5px;width:22px;height:22px;cursor:pointer;font-size:12px;">✕</button>
+              </span>
             </div>
           </div>
           <div v-else style="font-size:13px;color:var(--text-3);margin-bottom:8px;">No accounts connected yet.</div>
@@ -219,11 +228,18 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
 import * as api from "@/api"
 import {
   deriveMode, reorder, presetToModels, missingVendorKeys, validatePool,
-  PROVIDER_LABELS, providerLabel, seedRowsFromConfig,
+  PROVIDER_LABELS, providerLabel, seedRowsFromConfig, defaultSubscriptionModel,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
 
-const props = defineProps({ editable: { type: Boolean, default: true } })
+const props = defineProps({
+  editable: { type: Boolean, default: true },
+  // Which setup tabs to expose. Default = the full 3-mode editor (Account page).
+  // Onboarding passes ["quick"] to offer a single direct model and hide the
+  // proxy-pool Preset/Custom tabs + the Direct/Proxy badge — faster signup, no
+  // failover/pooling decisions up front (users configure that later in Account).
+  modes: { type: Array, default: () => ["quick", "preset", "custom"] },
+})
 const emit = defineEmits(["saved"])
 
 // ---- state ---------------------------------------------------------------
@@ -238,11 +254,19 @@ const saving = ref(false)
 const sync = ref({ last_sync_status: "", pending: false })
 let pollTimer = null
 
-const modeTabs = [
+const ALL_MODE_TABS = [
   { value: "quick", label: "Quick" },
   { value: "preset", label: "Preset" },
   { value: "custom", label: "Custom" },
 ]
+// Only the tabs the host allows, in canonical order.
+const modeTabs = computed(() => ALL_MODE_TABS.filter((t) => props.modes.includes(t.value)))
+// With a single allowed mode the tab bar + Direct/Proxy badge are just noise —
+// hide them and render that mode's body directly (onboarding's quick-only editor).
+const singleMode = computed(() => modeTabs.value.length <= 1)
+// Whether any proxy-pool tab (Preset/Custom) is reachable — gates the Quick hint
+// copy so it never points at tabs that aren't there.
+const canPool = computed(() => props.modes.includes("preset") || props.modes.includes("custom"))
 const credTypes = [
   { value: "api_key", label: "API key" },
   { value: "subscription", label: "Chat subscription" },
@@ -391,12 +415,20 @@ function setCredType(m, type) {
     if (!m.upstream) m.upstream = "openai"
     if (!Array.isArray(m.accounts)) m.accounts = []
     if (!m._connect) m._connect = blankConnect()
+    // Onboarding hides the model field — default it from the chosen provider so
+    // validatePool + save still have a model id.
+    if (singleMode.value) m.model = defaultSubscriptionModel(m.upstream)
   }
 }
 function onProviderChange(m) {
   const d = PROVIDER_DEFAULTS[m.provider] || {}
   if (!(m.model || "").trim() && d.model) m.model = d.model
   if (!(m.baseUrl || "").trim() && d.baseUrl) m.baseUrl = d.baseUrl
+}
+// Keep the (hidden) subscription model in sync with the provider in the
+// simplified onboarding editor; a no-op elsewhere (model is user-entered).
+function onUpstreamChange(m) {
+  if (singleMode.value && m.credentialType === "subscription") m.model = defaultSubscriptionModel(m.upstream)
 }
 function move(i, d) { rows.value = reorder(rows.value, i, i + d) }
 function remove(i) { rows.value = rows.value.filter((_, j) => j !== i) }
@@ -460,13 +492,18 @@ async function finishConnect(m) {
     }
     const d = res.data || {}
     if (!Array.isArray(m.accounts)) m.accounts = []
-    m.accounts.push({
+    const acct = {
       upstream: m.upstream || "openai",
       account_ref: d.account_ref,
       label: d.label || d.account_email || d.account_ref,
       oauth_blob: d.oauth_blob || "",
       connected: true,
-    })
+    }
+    // Re-authorizing the same account (same account_ref) refreshes it in place
+    // rather than adding a duplicate row.
+    const existing = m.accounts.findIndex((a) => a.account_ref && a.account_ref === acct.account_ref)
+    if (existing >= 0) m.accounts.splice(existing, 1, acct)
+    else m.accounts.push(acct)
     m._connect = blankConnect()
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e) }
 }
@@ -505,6 +542,13 @@ async function load() {
     if (selectedPreset.value) llmMode.value = "preset"
     else if (rows.value.length >= 2 || rows.value.some((r) => r.credentialType === "subscription")) llmMode.value = "custom"
     else { llmMode.value = "quick"; if (!rows.value.length) rows.value = [newRow()] }
+    // Never land on a mode the host didn't allow (onboarding = quick-only): clamp
+    // to the first allowed mode and ensure it has a row to edit.
+    if (!props.modes.includes(llmMode.value)) {
+      llmMode.value = props.modes[0] || "quick"
+      selectedPreset.value = ""
+      if (!rows.value.length) rows.value = [newRow()]
+    }
   } catch (e) { err.value = _err(e) }
   try { sync.value = (await api.getLlmSyncStatus()) || sync.value } catch (e) { /* non-fatal */ }
   try { catalog.value = (await api.getPresetCatalog()) || [] } catch (e) { /* backend bundled fallback */ }

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -1,7 +1,9 @@
 <template>
 	<FrappeUIProvider>
 		<div class="flex h-screen w-screen">
-			<div class="h-full border-r bg-surface-gray-1">
+			<!-- Chrome-less routes (onboarding) drop the sidebar entirely — a
+			     not-yet-onboarded customer has no app to navigate. -->
+			<div v-if="!route.meta.chromeless" class="h-full border-r bg-surface-gray-1">
 				<Sidebar />
 			</div>
 			<div class="flex flex-1 flex-col h-full overflow-auto bg-surface-white">
@@ -11,7 +13,7 @@
 				     uniform across pages and never displaces the page's primary
 				     action from the rightmost corner; chat has its own header button
 				     (ChatView openErpDesk), styled to match. -->
-				<div v-if="!route.meta.chat" class="flex border-b">
+				<div v-if="!route.meta.chat && !route.meta.chromeless" class="flex border-b">
 					<div id="app-header" class="flex-1" />
 				</div>
 				<router-view v-if="booted" />

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -39,7 +39,7 @@ export function reorder(list, from, to) {
 // Suggested chat-subscription model ids per upstream (index 0 = the default the
 // onboarding editor uses when it hides the model field). Single source of truth,
 // shared with LlmPoolEditor's datalist so the default + suggestions can't drift.
-export const SUB_MODEL_SUGGESTIONS = { openai: ["gpt-5.5", "gpt-5.4"], google: ["gemini-2.5-pro", "gemini-3.5-flash"] }
+export const SUB_MODEL_SUGGESTIONS = { openai: ["gpt-5.5", "gpt-5.4"], google: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"] }
 // Default chat-subscription model for an upstream (SUB_MODEL_SUGGESTIONS[0], with
 // an openai fallback for unmapped upstreams). Onboarding hides the model field
 // (provider is enough), so the row still needs a model id for validatePool + save.

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -36,12 +36,16 @@ export function buildCustomModels(rows) {
 export function reorder(list, from, to) {
   const a = list.slice(); const [x] = a.splice(from, 1); a.splice(to, 0, x); return a
 }
-// Default chat-subscription model for an upstream. Onboarding hides the model
-// field (provider is enough), so the row still needs a model id for validatePool
-// + save — this supplies a sensible one. Pure + exported for unit tests.
+// Suggested chat-subscription model ids per upstream (index 0 = the default the
+// onboarding editor uses when it hides the model field). Single source of truth,
+// shared with LlmPoolEditor's datalist so the default + suggestions can't drift.
+export const SUB_MODEL_SUGGESTIONS = { openai: ["gpt-5.5", "gpt-5.4"], google: ["gemini-2.5-pro", "gemini-3.5-flash"] }
+// Default chat-subscription model for an upstream (SUB_MODEL_SUGGESTIONS[0], with
+// an openai fallback for unmapped upstreams). Onboarding hides the model field
+// (provider is enough), so the row still needs a model id for validatePool + save.
+// Pure + exported for unit tests.
 export function defaultSubscriptionModel(upstream) {
-  const map = { openai: "gpt-5.5", google: "gemini-2.5-pro" }
-  return map[upstream] || map.openai
+  return (SUB_MODEL_SUGGESTIONS[upstream] || SUB_MODEL_SUGGESTIONS.openai)[0]
 }
 export function validatePool(models, preset) {
   if (!Array.isArray(models) || models.length === 0) return { ok: false, error: "Add at least one model." }

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -36,6 +36,13 @@ export function buildCustomModels(rows) {
 export function reorder(list, from, to) {
   const a = list.slice(); const [x] = a.splice(from, 1); a.splice(to, 0, x); return a
 }
+// Default chat-subscription model for an upstream. Onboarding hides the model
+// field (provider is enough), so the row still needs a model id for validatePool
+// + save — this supplies a sensible one. Pure + exported for unit tests.
+export function defaultSubscriptionModel(upstream) {
+  const map = { openai: "gpt-5.5", google: "gemini-2.5-pro" }
+  return map[upstream] || map.openai
+}
 export function validatePool(models, preset) {
   if (!Array.isArray(models) || models.length === 0) return { ok: false, error: "Add at least one model." }
   for (const m of models) {

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -2,6 +2,14 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 import { deriveMode, uniqueVendors, missingVendorKeys, presetToModels, buildCustomModels, reorder, validatePool } from "./pool.js"
 import { PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig } from "./pool.js"
+import { defaultSubscriptionModel } from "./pool.js"
+
+test("defaultSubscriptionModel: per-upstream default, openai fallback", () => {
+  assert.equal(defaultSubscriptionModel("openai"), "gpt-5.5")
+  assert.equal(defaultSubscriptionModel("google"), "gemini-2.5-pro")
+  assert.equal(defaultSubscriptionModel("unknown"), "gpt-5.5")
+  assert.equal(defaultSubscriptionModel(undefined), "gpt-5.5")
+})
 
 const LADDER = { key: "anthropic-resilient", kind: "single_vendor", vendors: ["anthropic"],
   models: [{ provider: "anthropic", model: "claude-opus-4-8", order: 0 },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -40,6 +40,9 @@ const routes = [
 		path: "/onboarding",
 		name: "Onboarding",
 		component: () => import("@/views/OnboardingView.vue"),
+		// Chrome-less: a first-run customer hasn't onboarded yet, so the full app
+		// sidebar/header (Chat/Skills/Macros/…) is noise — AppShell hides them.
+		meta: { chromeless: true },
 		beforeEnter: (to, from, next) => { next(window.is_system_manager ? undefined : { name: "Chat" }) },
 	},
 	// Usage dashboard (moved out of the old /ai shell) — System-Manager only;

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1,12 +1,13 @@
 <template>
 	<div class="jv-ob-root" :class="{ 'jv-dark': dark }" :style="paletteVars">
 
-		<!-- Ambient brand backdrop: a soft blue aura + a large blurred spark mark,
-			 fixed behind the wizard so the card reads as a focused, floating panel.
-			 Decorative only (aria-hidden, no pointer events, theme-aware opacity). -->
+		<!-- Framing orbs: two quiet deep-blue orbs settle into the empty corners and
+			 frame the wizard without touching it. Decorative only (aria-hidden, no
+			 pointer events); deep navy in light for a calm, monochrome-consistent
+			 look, brighter on dark so they still read. -->
 		<div class="jv-ob-bg" aria-hidden="true">
-			<div class="jv-ob-glow"></div>
-			<svg class="jv-ob-mark" viewBox="0 0 24 24"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+			<div class="jv-ob-orb jv-ob-orb-tl"></div>
+			<div class="jv-ob-orb jv-ob-orb-br"></div>
 		</div>
 
 		<!-- Branded header — a centered wizard reads better than a full-height
@@ -749,23 +750,14 @@ onMounted(() => {
 	flex-direction: column;
 	position: relative;
 }
-/* Ambient brand backdrop — fixed behind everything, decorative only. */
+/* Framing orbs — fixed behind everything, decorative only. Deep navy/indigo in
+   light (consistent with the black/white primary), brighter blue on dark. */
 .jv-ob-bg { position: fixed; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
-.jv-ob-glow {
-	position: absolute; left: 50%; top: 42%; transform: translate(-50%, -50%);
-	width: min(1300px, 135vw); aspect-ratio: 1;
-	background: radial-gradient(circle, color-mix(in srgb, var(--blue) 24%, transparent) 0%, transparent 62%);
-	opacity: .7;
-}
-/* Large enough to bleed past the card edges so the blurred spark reads as a
-   brand mark framing the wizard, not a watermark hidden behind it. */
-.jv-ob-mark {
-	position: absolute; left: 50%; top: 38%; transform: translate(-50%, -50%);
-	width: min(1120px, 116vw); height: min(1120px, 116vw); fill: var(--blue);
-	filter: blur(54px); opacity: .17;
-}
-.jv-dark .jv-ob-glow { opacity: .6; }
-.jv-dark .jv-ob-mark { opacity: .28; }
+.jv-ob-orb { position: absolute; width: min(760px, 66vw); aspect-ratio: 1; border-radius: 50%; filter: blur(14px); }
+.jv-ob-orb-tl { left: -180px; top: -170px; background: radial-gradient(circle, rgba(30, 58, 138, .17) 0%, transparent 60%); }
+.jv-ob-orb-br { right: -190px; bottom: -190px; background: radial-gradient(circle, rgba(49, 46, 129, .14) 0%, transparent 60%); }
+.jv-dark .jv-ob-orb-tl { background: radial-gradient(circle, rgba(59, 130, 246, .22) 0%, transparent 60%); }
+.jv-dark .jv-ob-orb-br { background: radial-gradient(circle, rgba(99, 102, 241, .18) 0%, transparent 60%); }
 .jv-ob-header {
 	position: relative;
 	z-index: 1;
@@ -967,7 +959,7 @@ onMounted(() => {
 	.jv-ob-body { padding: 26px 20px; border-radius: 14px; }
 	.jv-ob-h1 { font-size: 25px; }
 	.jv-ob-sub { font-size: 15px; margin-bottom: 26px; }
-	.jv-ob-mark { width: 340px; height: 340px; }
+	.jv-ob-orb { width: min(520px, 90vw); }
 	.jv-ob-modes { grid-template-columns: 1fr; }
 	.jv-ob-plans { grid-template-columns: 1fr; }
 }

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -145,6 +145,13 @@
 								</button>
 							</div>
 						</template>
+						<template v-else-if="state.successData">
+							<h1 class="jv-ob-h1">Payment complete</h1>
+							<p class="jv-ob-sub">You're all set — continue to connect your AI.</p>
+							<div class="jv-ob-placeholder-actions">
+								<button class="jv-ob-btn jv-ob-btn-primary" @click="goNext">Continue →</button>
+							</div>
+						</template>
 						<template v-else>
 							<h1 class="jv-ob-h1">Review &amp; {{ state.devActive ? "connect" : "pay" }}</h1>
 							<div class="jv-ob-summary">
@@ -170,9 +177,9 @@
 						 proxy-pool tabs + Direct/Proxy badge are intentionally hidden here to
 						 keep signup fast and decision-free; advanced pooling/failover stays
 						 available on the Account page. The component owns save_llm_pool.
-						 Desk's renderLlm has no "Back" button (only Skip/Save); mirrored here
-						 by omitting one too, since stepping back to "pay" post-payment would
-						 read as re-triggering checkout. ===== -->
+						 A "Back" button here returns to Pay; that step guards against a
+						 second charge by showing a "Payment complete → Continue" state once
+						 payment has gone through (state.successData). ===== -->
 					<div v-else-if="state.step === 'connect'">
 						<h1 class="jv-ob-h1">Connect your AI</h1>
 						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
@@ -181,6 +188,9 @@
 						<div v-else-if="state.finishNote" class="jv-ob-note">
 							<span>{{ state.finishNote }}</span>
 							<button class="jv-ob-btn jv-ob-btn-primary" @click="forceContinue">Continue to Jarvis →</button>
+						</div>
+						<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
+							<button class="jv-ob-btn" @click="goBack">← Back</button>
 						</div>
 					</div>
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -77,12 +77,7 @@
 							   placeholder="you@company.com" autocomplete="email" required aria-required="true"
 							   @keydown.enter="onAccountSubmit">
 						<label class="jv-ob-label" for="jv-ob-company">Company</label>
-						<input id="jv-ob-company" class="jv-ob-input" type="text" v-model="state.company"
-							   placeholder="Acme Inc." autocomplete="organization" list="jv-ob-company-list" required aria-required="true"
-							   @keydown.enter="onAccountSubmit">
-						<datalist id="jv-ob-company-list">
-								<option v-for="c in state.companies" :key="c" :value="c" />
-							</datalist>
+						<JvCombo :model-value="state.company" @update:model-value="(v) => state.company = v" allow-custom :options="state.companies" placeholder="Acme Inc." />
 							<div class="jv-ob-err" role="alert" aria-live="polite">{{ state.accountErr }}</div>
 						<div class="jv-ob-placeholder-actions">
 							<button class="jv-ob-btn" :disabled="accountBusy" @click="goBack">← Back</button>
@@ -181,7 +176,7 @@
 						 second charge by showing a "Payment complete → Continue" state once
 						 payment has gone through (state.successData). ===== -->
 					<div v-else-if="state.step === 'connect'">
-						<h1 class="jv-ob-h1">Connect your AI</h1>
+						<h1 class="jv-ob-h1">Give Jarvis a brain</h1>
 						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
 						<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" @ready="connectReady = $event" />
 						<div v-if="state.finishing" class="jv-ob-note">Finishing setup…</div>
@@ -253,6 +248,7 @@ import { reactive, ref, computed, onMounted, watch } from "vue"
 import { call } from "frappe-ui"
 import { useTheme } from "@/composables/useTheme"
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue"
+import JvCombo from "@/components/JvCombo.vue"
 import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep, stepIndex } from "@/onboarding/steps"
 import {
 	checkSignupPaymentState, isReadyForChat,
@@ -267,7 +263,7 @@ const { effectiveDark: dark, paletteVars } = useTheme()
 
 // Mirrors jarvis_onboarding.js's STEP_NAMES (~line 212) — the 4 named steps
 // shown in managed mode. "mode" and "selfhost" have no header entry.
-const STEP_NAMES = ["Account", "Plan", "Pay", "Connect AI"]
+const STEP_NAMES = ["Account", "Plan", "Pay", "Brain"]
 
 // ---- step machine -----------------------------------------------------------
 // `state.step` is one of STEPS_MANAGED/STEPS_SELFHOST depending on `state.mode`.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -95,7 +95,7 @@
 					<!-- ===== Plan — ported from desk renderPlan (jarvis_onboarding.js ~481). ===== -->
 					<div v-else-if="state.step === 'plan'">
 						<h1 class="jv-ob-h1">Choose your plan</h1>
-						<p class="jv-ob-sub">Pay as you go, no auto-renewal. Extend anytime.</p>
+						<p class="jv-ob-sub">No auto-renewal, extend anytime.</p>
 						<div v-if="state.plansLoading" class="jv-ob-placeholder">Loading plans…</div>
 						<div v-else-if="state.plansErr" class="jv-ob-err">{{ state.plansErr }}</div>
 						<div v-else-if="!state.plans.length" class="jv-ob-placeholder">No plans are available right now. Please contact support.</div>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -191,7 +191,7 @@
 						</div>
 						<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
 							<button class="jv-ob-btn" @click="goBack">← Back</button>
-							<button class="jv-ob-btn jv-ob-btn-primary" :class="{ 'jv-ob-cta-ready': connectReady && !savingConnect }" :disabled="savingConnect" @click="saveConnect">
+							<button v-if="connectReady || savingConnect" class="jv-ob-btn jv-ob-btn-primary" :class="{ 'jv-ob-cta-ready': connectReady && !savingConnect }" :disabled="savingConnect" @click="saveConnect">
 								{{ savingConnect ? "Onboarding…" : "Onboard Jarvis" }}
 							</button>
 						</div>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -176,20 +176,29 @@
 						 second charge by showing a "Payment complete → Continue" state once
 						 payment has gone through (state.successData). ===== -->
 					<div v-else-if="state.step === 'connect'">
-						<h1 class="jv-ob-h1">Give Jarvis a brain</h1>
-						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
-						<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" @ready="connectReady = $event" />
-						<div v-if="state.finishing" class="jv-ob-note">Finishing setup…</div>
-						<div v-else-if="state.finishNote" class="jv-ob-note">
-							<span>{{ state.finishNote }}</span>
-							<button class="jv-ob-btn jv-ob-btn-primary" @click="forceContinue">Continue to Jarvis →</button>
-						</div>
-						<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
-							<button class="jv-ob-btn" @click="goBack">← Back</button>
-							<button v-if="connectReady || savingConnect" class="jv-ob-btn jv-ob-btn-primary" :class="{ 'jv-ob-cta-ready': connectReady && !savingConnect }" :disabled="savingConnect" @click="saveConnect">
-								{{ savingConnect ? "Onboarding…" : "Onboard Jarvis" }}
-							</button>
-						</div>
+						<!-- Once onboarding succeeds we hard-reload to /jarvis/ (fresh readiness
+							 state). Show a clean full-step "setting up" screen through that
+							 transition so the reload reads as intentional, not a flicker. -->
+						<template v-if="state.finishing">
+							<h1 class="jv-ob-h1">Setting up Jarvis</h1>
+							<p class="jv-ob-sub">Bringing your workspace online, taking you to chat…</p>
+							<div class="jv-ob-spinner" aria-hidden="true"></div>
+						</template>
+						<template v-else>
+							<h1 class="jv-ob-h1">Give Jarvis a brain</h1>
+							<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
+							<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" @ready="connectReady = $event" />
+							<div v-if="state.finishNote" class="jv-ob-note">
+								<span>{{ state.finishNote }}</span>
+								<button class="jv-ob-btn jv-ob-btn-primary" @click="forceContinue">Continue to Jarvis →</button>
+							</div>
+							<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
+								<button class="jv-ob-btn" @click="goBack">← Back</button>
+								<button v-if="connectReady || savingConnect" class="jv-ob-btn jv-ob-btn-primary" :class="{ 'jv-ob-cta-ready': connectReady && !savingConnect }" :disabled="savingConnect" @click="saveConnect">
+									{{ savingConnect ? "Onboarding…" : "Onboard Jarvis" }}
+								</button>
+							</div>
+						</template>
 					</div>
 
 					<!-- ===== Self-host — ported from desk renderSelfHost + renderShResults
@@ -896,6 +905,10 @@ onMounted(() => {
 .jv-ob-cta-ready { border-color: var(--blue); animation: jvObCtaPulse 1.5s ease-out infinite; }
 .jv-ob-cta-ready:hover { animation-play-state: paused; }
 @media (prefers-reduced-motion: reduce) { .jv-ob-cta-ready { animation: none; } }
+/* "Setting up Jarvis" transition spinner (connect step, during the hard reload). */
+.jv-ob-spinner { width: 34px; height: 34px; margin: 10px auto 0; border-radius: 50%; border: 3px solid var(--border-2); border-top-color: var(--blue); animation: jvObSpin .8s linear infinite; }
+@keyframes jvObSpin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .jv-ob-spinner { animation: none; } }
 
 /* ---- mode-choice cards — ported from desk .jo-mode* (jarvis_onboarding.js
    ~1889-1898), theme tokens standing in for the desk's --jarvis-primary /

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -754,8 +754,8 @@ onMounted(() => {
    light (consistent with the black/white primary), brighter blue on dark. */
 .jv-ob-bg { position: fixed; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
 .jv-ob-orb { position: absolute; width: min(760px, 66vw); aspect-ratio: 1; border-radius: 50%; filter: blur(14px); }
-.jv-ob-orb-tl { left: -180px; top: -170px; background: radial-gradient(circle, rgba(30, 58, 138, .17) 0%, transparent 60%); }
-.jv-ob-orb-br { right: -190px; bottom: -190px; background: radial-gradient(circle, rgba(49, 46, 129, .14) 0%, transparent 60%); }
+.jv-ob-orb-tl { left: -180px; top: -170px; background: radial-gradient(circle, rgba(30, 58, 138, .24) 0%, transparent 62%); }
+.jv-ob-orb-br { right: -190px; bottom: -190px; background: radial-gradient(circle, rgba(49, 46, 129, .20) 0%, transparent 62%); }
 .jv-dark .jv-ob-orb-tl { background: radial-gradient(circle, rgba(59, 130, 246, .22) 0%, transparent 60%); }
 .jv-dark .jv-ob-orb-br { background: radial-gradient(circle, rgba(99, 102, 241, .18) 0%, transparent 60%); }
 .jv-ob-header {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -183,7 +183,7 @@
 					<div v-else-if="state.step === 'connect'">
 						<h1 class="jv-ob-h1">Connect your AI</h1>
 						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
-						<LlmPoolEditor :editable="true" :modes="['quick']" @saved="onConnected" />
+						<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" />
 						<div v-if="state.finishing" class="jv-ob-note">Finishing setup…</div>
 						<div v-else-if="state.finishNote" class="jv-ob-note">
 							<span>{{ state.finishNote }}</span>
@@ -191,6 +191,9 @@
 						</div>
 						<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
 							<button class="jv-ob-btn" @click="goBack">← Back</button>
+							<button class="jv-ob-btn jv-ob-btn-primary" :disabled="savingConnect" @click="saveConnect">
+								{{ savingConnect ? "Saving…" : "Save configuration" }}
+							</button>
 						</div>
 					</div>
 
@@ -662,6 +665,17 @@ function onConnected(sync) {
 	afterSaveRecheckReady()
 }
 
+// The Connect-AI footer (Back + Save) lives here, not inside LlmPoolEditor
+// (:footerless), so it matches every other step's footer. Save is triggered on
+// the editor via its exposed save() method.
+const poolRef = ref(null)
+const savingConnect = ref(false)
+async function saveConnect() {
+	if (!poolRef.value) return
+	savingConnect.value = true
+	try { await poolRef.value.save() } finally { savingConnect.value = false }
+}
+
 // ---- Self-host (renderSelfHost / renderShResults / runSelfHostTest /
 // saveSelfHost, jarvis_onboarding.js ~296-376) --------------------------------
 async function runSelfHostTest() {
@@ -857,7 +871,10 @@ onMounted(() => {
 }
 .jv-dark .jv-ob-body { border-color: var(--border-2); box-shadow: 0 24px 60px -24px rgba(0, 0, 0, .6); }
 .jv-ob-placeholder { font-size: 13.5px; color: var(--text-3); margin: 0 0 20px; }
-.jv-ob-placeholder-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+/* Uniform step footer: primary action bottom-right (forward = right in an LTR
+   wizard), Back pushed to the left. Single-button footers right-align too. */
+.jv-ob-placeholder-actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: flex-end; align-items: center; }
+.jv-ob-placeholder-actions .jv-ob-btn:not(.jv-ob-btn-primary) { margin-right: auto; }
 .jv-ob-btn {
 	font-family: inherit;
 	font-size: 13px;

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -156,16 +156,18 @@
 					</div>
 
 					<!-- ===== Connect AI (managed) — embeds the shared LlmPoolEditor component
-						 (same one AiView/AccountView use). Replaces desk renderLlm's entire
-						 Quick/Preset/Custom implementation (jarvis_onboarding.js ~559-1080)
-						 verbatim — the component already owns that UI + save_llm_pool call.
+						 (same one AccountView uses), restricted to :modes="['quick']" so
+						 onboarding shows only a single direct model. The Preset/Custom
+						 proxy-pool tabs + Direct/Proxy badge are intentionally hidden here to
+						 keep signup fast and decision-free; advanced pooling/failover stays
+						 available on the Account page. The component owns save_llm_pool.
 						 Desk's renderLlm has no "Back" button (only Skip/Save); mirrored here
 						 by omitting one too, since stepping back to "pay" post-payment would
 						 read as re-triggering checkout. ===== -->
 					<div v-else-if="state.step === 'connect'">
 						<h1 class="jv-ob-h1">Connect your AI</h1>
 						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
-						<LlmPoolEditor :editable="true" @saved="onConnected" />
+						<LlmPoolEditor :editable="true" :modes="['quick']" @saved="onConnected" />
 						<div v-if="state.finishing" class="jv-ob-note">Finishing setup…</div>
 						<div v-else-if="state.finishNote" class="jv-ob-note">
 							<span>{{ state.finishNote }}</span>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1,6 +1,14 @@
 <template>
 	<div class="jv-ob-root" :class="{ 'jv-dark': dark }" :style="paletteVars">
 
+		<!-- Ambient brand backdrop: a soft blue aura + a large blurred spark mark,
+			 fixed behind the wizard so the card reads as a focused, floating panel.
+			 Decorative only (aria-hidden, no pointer events, theme-aware opacity). -->
+		<div class="jv-ob-bg" aria-hidden="true">
+			<div class="jv-ob-glow"></div>
+			<svg class="jv-ob-mark" viewBox="0 0 24 24"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+		</div>
+
 		<!-- Branded header — a centered wizard reads better than a full-height
 			 empty sidebar; the logo mark keeps it unmistakably Jarvis. -->
 		<header class="jv-ob-header">
@@ -739,13 +747,32 @@ onMounted(() => {
 	color: var(--text);
 	display: flex;
 	flex-direction: column;
+	position: relative;
 }
+/* Ambient brand backdrop — fixed behind everything, decorative only. */
+.jv-ob-bg { position: fixed; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
+.jv-ob-glow {
+	position: absolute; left: 50%; top: 42%; transform: translate(-50%, -50%);
+	width: min(1300px, 135vw); aspect-ratio: 1;
+	background: radial-gradient(circle, color-mix(in srgb, var(--blue) 24%, transparent) 0%, transparent 62%);
+	opacity: .7;
+}
+/* Large enough to bleed past the card edges so the blurred spark reads as a
+   brand mark framing the wizard, not a watermark hidden behind it. */
+.jv-ob-mark {
+	position: absolute; left: 50%; top: 38%; transform: translate(-50%, -50%);
+	width: min(1120px, 116vw); height: min(1120px, 116vw); fill: var(--blue);
+	filter: blur(54px); opacity: .17;
+}
+.jv-dark .jv-ob-glow { opacity: .6; }
+.jv-dark .jv-ob-mark { opacity: .28; }
 .jv-ob-header {
+	position: relative;
+	z-index: 1;
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	padding: 16px 24px;
-	border-bottom: 1px solid var(--border);
+	padding: 18px 26px;
 	flex: none;
 }
 .jv-ob-logo {
@@ -757,6 +784,8 @@ onMounted(() => {
 .jv-ob-brand { font-size: 14px; font-weight: 600; letter-spacing: -.01em; }
 .jv-ob-setup { font-size: 12.5px; color: var(--text-3); border-left: 1px solid var(--border); padding-left: 10px; }
 .jv-ob-main {
+	position: relative;
+	z-index: 1;
 	flex: 1;
 	min-width: 0;
 	overflow-y: auto;
@@ -773,11 +802,11 @@ onMounted(() => {
 	padding: 40px 24px 64px;
 }
 .jv-ob-wrap {
-	max-width: 920px;
+	max-width: 1000px;
 	width: 100%;
 }
-.jv-ob-h1 { font-size: 28px; font-weight: 650; margin: 0 0 10px; text-align: center; }
-.jv-ob-sub { font-size: 15.5px; color: var(--text-3); margin: 0 0 30px; text-align: center; }
+.jv-ob-h1 { font-size: 32px; font-weight: 650; letter-spacing: -.02em; margin: 0 0 12px; text-align: center; }
+.jv-ob-sub { font-size: 16.5px; color: var(--text-3); margin: 0 0 34px; text-align: center; }
 
 .jv-ob-steps {
 	display: flex;
@@ -819,10 +848,12 @@ onMounted(() => {
 
 .jv-ob-body {
 	border: 1px solid var(--border);
-	border-radius: 14px;
-	padding: 48px 44px;
+	border-radius: 18px;
+	padding: 52px 56px;
 	background: var(--surface);
+	box-shadow: 0 20px 50px -24px rgba(15, 23, 42, .28), 0 4px 12px -6px rgba(15, 23, 42, .10);
 }
+.jv-dark .jv-ob-body { border-color: var(--border-2); box-shadow: 0 24px 60px -24px rgba(0, 0, 0, .6); }
 .jv-ob-placeholder { font-size: 13.5px; color: var(--text-3); margin: 0 0 20px; }
 .jv-ob-placeholder-actions { display: flex; gap: 10px; flex-wrap: wrap; }
 .jv-ob-btn {
@@ -933,8 +964,14 @@ onMounted(() => {
 
 @media (max-width: 520px) {
 	.jv-ob-main { padding: 28px 16px 48px; }
-	.jv-ob-body { padding: 18px; }
+	.jv-ob-body { padding: 26px 20px; border-radius: 14px; }
+	.jv-ob-h1 { font-size: 25px; }
+	.jv-ob-sub { font-size: 15px; margin-bottom: 26px; }
+	.jv-ob-mark { width: 340px; height: 340px; }
 	.jv-ob-modes { grid-template-columns: 1fr; }
 	.jv-ob-plans { grid-template-columns: 1fr; }
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-ob-mode, .jv-ob-plan { transition: none; }
 }
 </style>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -47,7 +47,7 @@
 								<ul class="jv-ob-mode-feats">
 									<li><span class="jv-ob-tick">✓</span>We host the openclaw agent for you</li>
 									<li><span class="jv-ob-tick">✓</span>Includes the Jarvis persona + Frappe skills</li>
-									<li><span class="jv-ob-tick">✓</span>Managed LLM proxy — pool your API keys &amp; chat subscriptions, with automatic failover</li>
+									<li><span class="jv-ob-tick">✓</span>Managed LLM proxy: pool your API keys &amp; chat subscriptions, with automatic failover</li>
 									<li><span class="jv-ob-tick">✓</span>Simple plan &amp; billing</li>
 								</ul>
 								<button class="jv-ob-btn jv-ob-btn-primary jv-ob-mode-btn" @click="setMode('managed')">Choose →</button>
@@ -95,7 +95,7 @@
 					<!-- ===== Plan — ported from desk renderPlan (jarvis_onboarding.js ~481). ===== -->
 					<div v-else-if="state.step === 'plan'">
 						<h1 class="jv-ob-h1">Choose your plan</h1>
-						<p class="jv-ob-sub">Pay as you go — no auto-renewal. Extend anytime.</p>
+						<p class="jv-ob-sub">Pay as you go, no auto-renewal. Extend anytime.</p>
 						<div v-if="state.plansLoading" class="jv-ob-placeholder">Loading plans…</div>
 						<div v-else-if="state.plansErr" class="jv-ob-err">{{ state.plansErr }}</div>
 						<div v-else-if="!state.plans.length" class="jv-ob-placeholder">No plans are available right now. Please contact support.</div>
@@ -126,7 +126,7 @@
 					<div v-else-if="state.step === 'pay'">
 						<template v-if="state.provisioning || state.provisionErr">
 								<h1 class="jv-ob-h1">Setting up your workspace</h1>
-								<p v-if="state.provisioning" class="jv-ob-sub">Payment received — we're provisioning your Jarvis workspace. This usually takes under a minute…</p>
+								<p v-if="state.provisioning" class="jv-ob-sub">Payment received. We're provisioning your Jarvis workspace. This usually takes under a minute…</p>
 								<p v-if="state.provisionErr" class="jv-ob-err" role="alert">{{ state.provisionErr }}</p>
 								<div v-if="state.provisionErr" class="jv-ob-placeholder-actions">
 									<button class="jv-ob-btn jv-ob-btn-primary" @click="proceedAfterPay">Retry</button>
@@ -147,7 +147,7 @@
 						</template>
 						<template v-else-if="state.successData">
 							<h1 class="jv-ob-h1">Payment complete</h1>
-							<p class="jv-ob-sub">You're all set — continue to connect your AI.</p>
+							<p class="jv-ob-sub">You're all set. Continue to connect your AI.</p>
 							<div class="jv-ob-placeholder-actions">
 								<button class="jv-ob-btn jv-ob-btn-primary" @click="goNext">Continue →</button>
 							</div>
@@ -160,7 +160,7 @@
 								<div class="jv-ob-row"><span>Plan</span><b>{{ selectedPlan.plan_name || "" }}</b></div>
 								<div class="jv-ob-row jv-ob-row-total"><span>Due now</span><b>{{ planPriceLabel(selectedPlan.price_inr, selectedPlan.billing_cycle) }}</b></div>
 							</div>
-							<div v-if="state.devActive" class="jv-ob-devnote">Developer mode — payment is skipped (dev signup).</div>
+							<div v-if="state.devActive" class="jv-ob-devnote">Developer mode: payment is skipped (dev signup).</div>
 							<div class="jv-ob-err">{{ state.payErr }}</div>
 							<div class="jv-ob-placeholder-actions">
 								<button class="jv-ob-btn" :disabled="state.payBusy" @click="goBack">← Back</button>
@@ -204,7 +204,7 @@
 					<div v-else-if="state.step === 'selfhost'">
 						<h1 class="jv-ob-h1">Connect your openclaw</h1>
 						<p class="jv-ob-sub">Point Jarvis at <b>your own</b> openclaw server. Jarvis connects over HTTP
-							with a bearer token — no Aerele persona/skills. Validate first, then connect.</p>
+							with a bearer token. No Aerele persona/skills. Validate first, then connect.</p>
 						<label class="jv-ob-label" for="jv-ob-sh-url">openclaw URL</label>
 						<input id="jv-ob-sh-url" class="jv-ob-input" type="text" v-model="state.shUrl"
 							   placeholder="http://host.docker.internal:19060">
@@ -212,7 +212,7 @@
 						<input id="jv-ob-sh-token" class="jv-ob-input" type="password" v-model="state.shToken"
 							   placeholder="paste your openclaw gateway token" autocomplete="off">
 						<label class="jv-ob-check"><input type="checkbox" v-model="state.shStream"> Stream responses token-by-token (recommended)</label>
-						<label class="jv-ob-check"><input type="checkbox" v-model="state.shDeep"> Run deep chat test (slower — sends one message)</label>
+						<label class="jv-ob-check"><input type="checkbox" v-model="state.shDeep"> Run deep chat test (slower, sends one message)</label>
 						<div class="jv-ob-placeholder-actions" style="margin-top:14px;justify-content:flex-start">
 							<button class="jv-ob-btn" :disabled="state.shTestBusy" @click="runSelfHostTest">
 								{{ state.shTestBusy ? "Testing…" : "Test connection" }}
@@ -221,10 +221,10 @@
 						<div v-if="state.shTestBusy" class="jv-ob-note">Testing…</div>
 						<div v-else-if="state.shTestResult" class="jv-ob-sh-results">
 							<div :class="state.shTestResult.ok ? 'jv-ob-sh-ok' : 'jv-ob-sh-bad'">
-								{{ state.shTestResult.ok ? "All required checks passed." : "Some checks failed — fix them and retry." }}
+								{{ state.shTestResult.ok ? "All required checks passed." : "Some checks failed. Fix them and retry." }}
 							</div>
 							<div v-for="(c, i) in (state.shTestResult.checks || [])" :key="i" class="jv-ob-sh-check" :class="{ 'jv-ob-sh-check-adv': c.advisory }">
-								{{ c.ok ? "✅" : (c.advisory ? "⚠️" : "❌") }} <b>{{ c.check }}</b> — {{ c.detail || "" }}<span v-if="c.advisory" class="jv-ob-sh-adv-tag"> · advisory</span>
+								{{ c.ok ? "✅" : (c.advisory ? "⚠️" : "❌") }} <b>{{ c.check }}</b> · {{ c.detail || "" }}<span v-if="c.advisory" class="jv-ob-sh-adv-tag"> · advisory</span>
 							</div>
 						</div>
 						<div v-if="state.shWarning" class="jv-ob-devnote">{{ state.shWarning }}</div>
@@ -518,7 +518,7 @@ async function proceedAfterPay() {
 		await _sleep(2000)
 	}
 	state.provisioning = false
-	state.provisionErr = "Your workspace is still being set up — this can take a minute. Retry when you're ready."
+	state.provisionErr = "Your workspace is still being set up. This can take a minute. Retry when you're ready."
 }
 
 async function runStartPay() {
@@ -655,7 +655,7 @@ async function afterSaveRecheckReady() {
 		window.location.assign("/jarvis/")
 		return
 	}
-	state.finishNote = "Still finishing setup — this can take a few seconds. You can continue to Jarvis now, or wait and try again."
+	state.finishNote = "Still finishing setup. This can take a few seconds. You can continue to Jarvis now, or wait and try again."
 }
 
 // ---- Connect AI (renders <LlmPoolEditor>, jarvis_onboarding.js ~559-1080
@@ -728,7 +728,7 @@ async function onSelfHostSave() {
 			await afterSaveRecheckReady()
 		} else {
 			state.shTestResult = m.result || {}
-			state.shErr = "Validation failed — fix the checks above, then retry."
+			state.shErr = "Validation failed. Fix the checks above, then retry."
 		}
 	} catch (e) {
 		state.shSaveBusy = false

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -880,9 +880,22 @@ onMounted(() => {
 .jv-ob-mode-name { font-size: 18px; font-weight: 700; color: var(--text); margin: 10px 0 12px; }
 .jv-ob-mode-feats { list-style: none; padding: 0; margin: 0 0 16px; flex: 1; }
 .jv-ob-mode-feats li { display: flex; gap: 7px; font-size: 13.5px; color: var(--text-2); line-height: 1.55; margin-bottom: 9px; }
-.jv-ob-tick { color: var(--blue); font-size: 11px; margin-top: 2px; flex: none; }
-.jv-ob-mode-warn { color: var(--red); margin-top: 8px; }
-.jv-ob-warn-icon { margin-right: 4px; flex: none; }
+/* Ticks get a real blue accent (the theme's --blue is near-black by design). */
+.jv-ob-tick { color: #2563eb; font-size: 11px; font-weight: 700; margin-top: 2px; flex: none; }
+.jv-dark .jv-ob-tick { color: var(--blue); }
+/* "Not included" note → danger highlight. The li.jv-ob-mode-warn selector
+   out-specifies `.jv-ob-mode-feats li` so the red actually lands (before, the
+   feats-li colour silently overrode it). */
+.jv-ob-mode-feats li.jv-ob-mode-warn {
+	color: var(--red);
+	background: var(--red-bg);
+	border: 1px solid var(--red-bd);
+	border-radius: 9px;
+	padding: 9px 11px;
+	margin-top: 12px;
+	align-items: flex-start;
+}
+.jv-ob-warn-icon { color: var(--red); margin-right: 4px; flex: none; }
 .jv-ob-mode-btn { width: 100%; margin-top: auto; }
 
 /* ---- Account — ported from desk .jo-label/.jo-input (jarvis_onboarding.js

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -77,7 +77,9 @@
 							   placeholder="you@company.com" autocomplete="email" required aria-required="true"
 							   @keydown.enter="onAccountSubmit">
 						<label class="jv-ob-label" for="jv-ob-company">Company</label>
-						<JvCombo :model-value="state.company" @update:model-value="(v) => state.company = v" allow-custom :options="state.companies" placeholder="Acme Inc." />
+						<JvCombo id="jv-ob-company" :model-value="state.company" @update:model-value="(v) => state.company = v"
+								 allow-custom aria-required autocomplete="organization" :options="state.companies"
+								 placeholder="Acme Inc." @enter="onAccountSubmit" />
 							<div class="jv-ob-err" role="alert" aria-live="polite">{{ state.accountErr }}</div>
 						<div class="jv-ob-placeholder-actions">
 							<button class="jv-ob-btn" :disabled="accountBusy" @click="goBack">← Back</button>
@@ -178,13 +180,16 @@
 					<div v-else-if="state.step === 'connect'">
 						<!-- Once onboarding succeeds we hard-reload to /jarvis/ (fresh readiness
 							 state). Show a clean full-step "setting up" screen through that
-							 transition so the reload reads as intentional, not a flicker. -->
-						<template v-if="state.finishing">
+							 transition so the reload reads as intentional, not a flicker.
+							 v-show (not v-if) so the editor stays MOUNTED while its own save()
+							 is still awaiting — a v-if here would tear it down mid-save and, on
+							 a not-ready poll, remount + refetch with a visible flash. -->
+						<div v-show="state.finishing">
 							<h1 class="jv-ob-h1">Setting up Jarvis</h1>
 							<p class="jv-ob-sub">Bringing your workspace online, taking you to chat…</p>
 							<div class="jv-ob-spinner" aria-hidden="true"></div>
-						</template>
-						<template v-else>
+						</div>
+						<div v-show="!state.finishing">
 							<h1 class="jv-ob-h1">Give Jarvis a brain</h1>
 							<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
 							<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" @ready="connectReady = $event" />
@@ -198,7 +203,7 @@
 									{{ savingConnect ? "Onboarding…" : "Onboard Jarvis" }}
 								</button>
 							</div>
-						</template>
+						</div>
 					</div>
 
 					<!-- ===== Self-host — ported from desk renderSelfHost + renderShResults

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -183,7 +183,7 @@
 					<div v-else-if="state.step === 'connect'">
 						<h1 class="jv-ob-h1">Connect your AI</h1>
 						<p class="jv-ob-sub">Pick which model Jarvis should use. You can change this anytime from My Account.</p>
-						<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" />
+						<LlmPoolEditor ref="poolRef" :editable="true" :modes="['quick']" :footerless="true" @saved="onConnected" @ready="connectReady = $event" />
 						<div v-if="state.finishing" class="jv-ob-note">Finishing setup…</div>
 						<div v-else-if="state.finishNote" class="jv-ob-note">
 							<span>{{ state.finishNote }}</span>
@@ -191,8 +191,8 @@
 						</div>
 						<div class="jv-ob-placeholder-actions" style="margin-top:18px;">
 							<button class="jv-ob-btn" @click="goBack">← Back</button>
-							<button class="jv-ob-btn jv-ob-btn-primary" :disabled="savingConnect" @click="saveConnect">
-								{{ savingConnect ? "Saving…" : "Save configuration" }}
+							<button class="jv-ob-btn jv-ob-btn-primary" :class="{ 'jv-ob-cta-ready': connectReady && !savingConnect }" :disabled="savingConnect" @click="saveConnect">
+								{{ savingConnect ? "Onboarding…" : "Onboard Jarvis" }}
 							</button>
 						</div>
 					</div>
@@ -670,6 +670,9 @@ function onConnected(sync) {
 // the editor via its exposed save() method.
 const poolRef = ref(null)
 const savingConnect = ref(false)
+// True once the embedded editor reports a savable config (account connected, or
+// API key filled) — drives the "Onboard Jarvis" attention pulse.
+const connectReady = ref(false)
 async function saveConnect() {
 	if (!poolRef.value) return
 	savingConnect.value = true
@@ -888,6 +891,15 @@ onMounted(() => {
 }
 .jv-ob-btn:hover { background: var(--surface-2); }
 .jv-ob-btn-primary { border-color: var(--blue-bd); background: var(--blue-bg); color: var(--blue); }
+/* Attention pulse on the final CTA once the config is ready — a soft expanding
+   ring that invites the click. Pauses on hover; off for reduced-motion. */
+@keyframes jvObCtaPulse {
+	0% { box-shadow: 0 0 0 0 rgba(37, 99, 235, .38); }
+	70%, 100% { box-shadow: 0 0 0 7px rgba(37, 99, 235, 0); }
+}
+.jv-ob-cta-ready { border-color: var(--blue); animation: jvObCtaPulse 1.5s ease-out infinite; }
+.jv-ob-cta-ready:hover { animation-play-state: paused; }
+@media (prefers-reduced-motion: reduce) { .jv-ob-cta-ready { animation: none; } }
 
 /* ---- mode-choice cards — ported from desk .jo-mode* (jarvis_onboarding.js
    ~1889-1898), theme tokens standing in for the desk's --jarvis-primary /

--- a/jarvis/docs/superpowers/plans/2026-07-07-chat-subscription-providers-backlog.md
+++ b/jarvis/docs/superpowers/plans/2026-07-07-chat-subscription-providers-backlog.md
@@ -1,0 +1,92 @@
+# Chat-subscription (CLI-OAuth) providers — integration & test backlog
+
+> Goal: offer **all** integrable chat-subscription providers in onboarding (OpenAI,
+> Google, Grok, Qwen, …), not just OpenAI. This is the backlog + per-provider
+> plan. Date: 2026-07-07. Prompted by the onboarding review (PR #231), where the
+> dropdown offered "Google" but the backend returned *"OAuth not supported for
+> provider 'Google'"*.
+
+## Two credential paths (a provider must be supported on the path we ship)
+
+- **openclaw-direct (live today).** The OAuth runtime lives in the openclaw image;
+  adding a provider needs (a) an openclaw runtime/CLI-backend for it, and (b) a
+  branch in the fleet-agent template. Template
+  `jarvis-fleet-agent/.../templates/openclaw.json.j2` has exactly 3 branches:
+  `openai-codex`, `google-gemini-cli`, and an API-key `else`. Blob writer
+  `auth_profiles.py` is provider-generic except the hardcoded `gemini_cli.py`
+  bridge (writes gemini-cli's own `~/.gemini/oauth_creds.json`). Any CLI-backend
+  provider that reads creds from its own file needs an analogous bridge.
+- **cliproxy / CLIProxyAPI (managed pool, newer — the "all providers" enabler).**
+  A CLIProxyAPI sidecar auto-discovers OAuth blobs and load-balances them; Bifrost
+  fronts it. Upstream **CLIProxyAPI supports 8 CLI subscriptions** (Codex, Gemini
+  CLI, Antigravity, Claude Code, Qwen Code, iFlow, Kimi, Grok/xAI). But Jarvis's
+  `llm-proxy` renderer is narrower — `src/llm_proxy/schema.py` hard-codes
+  `upstream: Literal["openai","anthropic","google"]` and
+  `render/subscription.py` `_AUTH_PREFIX = {openai:"codex-", google:"antigravity-",
+  anthropic:"claude-"}`. **This Literal is the single choke point** — generalize
+  it once and Grok/Qwen/Kimi/iFlow all become expressible.
+
+**Allowlists to edit per provider (customer side):**
+`jarvis/oauth/providers.py` `_PROVIDER_OAUTH_MAP` · `jarvis/_subscription_models.py`
+`SUBSCRIPTION_MODELS`/`DEFAULT_MODEL` (+ JS mirrors in `LlmPoolEditor.vue`) ·
+admin `jarvis_admin/fleet/llm_providers.py` `SUBSCRIPTION_PROVIDERS` ·
+`jarvis/hooks.py` `OAUTH_CLIENT_IDS` + secret.
+
+## Already fixed in PR #231
+- Google label bug: frontend sent `"Google"`; backend key is `"Google Gemini"`.
+  Dropdown label + `startConnect` now send `"Google Gemini"`.
+- Gemini model-suggestion drift: now `gemini-2.5-pro / gemini-2.5-flash /
+  gemini-3.1-flash` (backend-valid set).
+
+## Backlog
+
+| Provider | CLI-OAuth sub? | Supportable via | Jarvis status | Models | Blockers / notes |
+|---|---|---|---|---|---|
+| **OpenAI / ChatGPT Codex** | Yes (paid; free ≈ useless) | cliproxy ✅ + openclaw ✅ | **Integrated & live-verified** | gpt-5.5, gpt-5.4, gpt-5.4-mini | chatgpt.com throttling has no clean 429 |
+| **Google Gemini** | Yes | openclaw ✅ (gemini-cli); cliproxy ✅ (as **Antigravity**) | **Coded (openclaw); cliproxy leg unverified** | gemini-2.5-pro/flash, gemini-3.1-flash | `accountId` extraction returns "" for non-OpenAI; **gemini-cli vs Antigravity are different Google creds** — pick one for the pool |
+| **xAI / Grok** | **Yes** (SuperGrok / X Premium+) | cliproxy ✅ (`--xai-login`) + openclaw ✅ (`xai`) | **Not started (recommended #1)** | grok-4.3, grok-build-0.1 | OAuth may be tier-gated even with active sub; api.x.ai/v1 |
+| **Qwen** | Yes | cliproxy ✅ (`--qwen-login`) + openclaw ✅ (`qwen-oauth`) | **Not started (recommended #2)** | qwen3.5-plus, qwen3-coder | schema Literal lacks `qwen`; cheap/coding tier |
+| **Kimi / Moonshot** | Yes | cliproxy ✅ only (openclaw = API-key) | **Not started (defer)** | kimi-k2.6 | cliproxy-only for subscription |
+| **iFlow** | Yes | cliproxy ✅ only | **Not started (defer)** | — | niche; openclaw-direct unsupported |
+| **Anthropic / Claude** | Yes (Claude Code) | tech-possible | **BLOCKED — ToS** | — | **Do NOT pool** (Anthropic ToS, suspensions enforced 2026-04-04; already banned in `llm_proxy/validate.py`). Claude = API-key only. |
+
+Auth-dir filename prefixes for xai/qwen/kimi/iflow are inferred from CLIProxyAPI's
+`<flag-stem>-<ref>.json` convention — **verify against a real login before wiring**
+(only `codex-`/`antigravity-`/`claude-` are confirmed in Jarvis today).
+
+## Tasks (in priority order)
+
+- [ ] **Grok / xAI (#1).** openclaw.json.j2: add an `xai` renderer branch (mirror
+      gemini-cli; base `api.x.ai/v1`); add a `grok_cli.py` bridge if the image's
+      `xai` runtime reads `~/.grok/auth.json`. Customer allowlists: add `"xAI"` to
+      `_PROVIDER_OAUTH_MAP` (accounts.x.ai device-code), `SUBSCRIPTION_MODELS`
+      (`grok-4.3`), admin `SUBSCRIPTION_PROVIDERS`, `OAUTH_CLIENT_IDS`, JS mirrors.
+      cliproxy (optional): extend schema Literal + `_AUTH_PREFIX["xai"]`.
+      **Test:** `--xai-login` (or openclaw `models auth login --provider xai`) with
+      a real SuperGrok account in a scratch container → non-empty `/v1/models` →
+      one e2e chat turn (e2e-feature skill). Watch for tier-gated-OAuth 403.
+- [ ] **Qwen (#2).** Same shape; openclaw provider `qwen-oauth` (base
+      portal.qwen.ai/v1). Low ToS risk, good cheap-tier complement.
+- [ ] **Finish Google Gemini managed-pool leg (#3).** Decide pooled Google =
+      gemini-cli or Antigravity; either change `_AUTH_PREFIX["google"]` to
+      `gemini-` or add `--antigravity-login` provisioning. Verify one Gemini turn
+      through Bifrost→CLIProxyAPI + validate `accountId` handling.
+- [ ] **Generalize `llm_proxy` `upstream` Literal** (cross-cutting prerequisite):
+      Literal → validated set + per-upstream `_AUTH_PREFIX`, so new providers don't
+      each need a schema edit.
+- [ ] **Kimi / iFlow (#4, defer).** cliproxy-only; add opportunistically after the
+      schema is generalized.
+- [ ] **Onboarding UX:** surface that a **paid** subscription tier is required
+      (free ChatGPT accounts were empirically near-useless).
+
+## Key references
+- openclaw-direct: `jarvis-fleet-agent/.../templates/openclaw.json.j2`, `auth_profiles.py`, `gemini_cli.py`
+- managed-pool: `llm-proxy/src/llm_proxy/{schema.py, validate.py, render/subscription.py}`, `docs/reference/spike-findings-subscription.md`
+- allowlists: `jarvis/oauth/providers.py`, `jarvis/_subscription_models.py`, `jarvis/hooks.py`, `jarvis_admin/fleet/llm_providers.py`
+- upstream: CLIProxyAPI (github.com/router-for-me/CLIProxyAPI), docs.openclaw.ai/providers/{xai,qwen}, x.ai/news/grok-openclaw
+
+**Honesty note:** only the Codex leg is proven live in Jarvis; the Gemini
+managed-pool leg and every other provider are unverified in Jarvis. CLIProxyAPI's
+provider support is confirmed from upstream docs; openclaw Grok/Qwen support is in
+openclaw docs but not tested against Jarvis's pinned image — check the pinned
+image's runtime registry first.

--- a/jarvis/docs/superpowers/reviews/2026-07-07-onboarding-account-ux-review.md
+++ b/jarvis/docs/superpowers/reviews/2026-07-07-onboarding-account-ux-review.md
@@ -1,0 +1,133 @@
+# Onboarding & Account — UX/UI review
+
+> Human-reviewer pass over the Jarvis customer SPA (`frontend/src`). Reviewed the
+> live `LlmPoolEditor` + `AccountView` in the browser (site.jarvis:8002) and the
+> full source/CSS of `OnboardingView.vue`, `LlmPoolEditor.vue`, `AccountView.vue`,
+> `AppShell.vue`. Date: 2026-07-07. Branch: `enhancing-onboarding-process`.
+
+Legend: **[V]** visually confirmed in browser · **[C]** from code/CSS review.
+
+---
+
+## Part A — Onboarding wizard (`OnboardingView.vue`)
+
+### A1. Connect-AI step shows the full 3-tab proxy editor (primary change)
+**[V/C]** The final "Connect your AI" step embeds the shared `LlmPoolEditor`,
+which exposes **Quick | Preset | Custom** tabs plus a **Direct / Proxy (failover)**
+badge. For a first-run user this is a lot of surface:
+- *Preset* = a technical catalog ("Single-vendor resilience", "Cross-vendor
+  strategies": Balanced / Cost-saver / Max-reliability) — pooling/failover concepts.
+- *Custom* = an add/remove/reorder failover pool with per-row credential toggles,
+  base-URL, rotation strategy, etc.
+- The *Direct / Proxy* badge is jargon at signup time.
+
+**Action (this PR):** remove Preset + Custom from onboarding; leave a single
+Quick model. Advanced pooling stays available on the Account page. Fastens
+signup and removes decision-paralysis — matches the requested change.
+
+### A2. Quick hint text pushes users toward the complex tabs
+**[V/C]** Quick tab copy: *"A single model, sent directly to the provider. Need
+multiple models with failover? Use **Preset** or **Custom**."* During onboarding
+this actively steers new users into the surface we're trying to hide. Must drop
+the Preset/Custom reference when those tabs aren't present.
+
+### A3. Editor's "Save configuration" button breaks the wizard's button language
+**[V]** Inside the wizard card, the embedded editor's primary button is a solid
+dark **"Save configuration"** button, while every other wizard button uses the
+lighter `.jv-ob-btn-primary` (blue-tinted outline) style. Two different primary
+styles on the same screen. Also the label "Save configuration" reads like a
+settings screen, not a signup step ("Connect", "Finish", "Continue" would fit).
+
+### A4. Wizard renders with the full app sidebar (not chrome-less)
+**[C]** `AppShell` renders the global `Sidebar` around **every** route, including
+`/onboarding`. So the "Set up your workspace" wizard shows the whole app nav rail
+(Chat / Skills / Macros / …) beside it. A first-run signup flow reads better as a
+focused, chrome-less page. (Defensible since onboarding is now "invited" from
+inside the app, but worth revisiting.) — *noted, not in this PR's scope.*
+
+### A5. Self-host card uses error-red for an informational note
+**[C]** The "Not included: persona, skills, managed proxy…" line on the
+Self-hosted mode card is styled with `var(--red)` (the danger color). It's
+informational, not an error; amber/muted would be less alarming.
+
+### A6. Mode cards use emoji icons (☁ / 🖥)
+**[C]** The header uses a crisp SVG brand mark, but the two mode cards use OS
+emoji, which render inconsistently across platforms and clash with the brand
+mark. Minor/cosmetic.
+
+### A7. Step indicator omits the mode-choice + self-host steps
+**[C]** The 4-dot stepper (Account/Plan/Pay/Connect AI) is hidden on the
+mode-choice screen and entirely absent for the self-host track (single step), so
+those paths have no "where am I" cue. Minor.
+
+---
+
+## Part B — The change shipped in this PR
+
+Add an opt-in `modes` prop to `LlmPoolEditor` (default = all three tabs, so
+`AccountView` is unchanged). Onboarding passes `:modes="['quick']"`. When only
+one mode is allowed:
+- hide the mode-tab bar and the Direct/Proxy badge (both meaningless with one mode);
+- force `llmMode` to the single allowed mode (never auto-switch to preset/custom);
+- drop the "Use Preset or Custom" sentence from the Quick hint and point users to
+  Account for advanced setup instead.
+
+Only two consumers exist (`OnboardingView`, `AccountView`), so the prop is safe.
+The Quick credential toggle (API key ↔ Chat subscription) stays — a single model
+of either kind is still "quick/direct", not proxy config.
+
+**B2 — Simplify the onboarding chat-subscription path.** In the quick-only editor
+(`singleMode`), the chat-subscription row now hides the **Model ID** field and the
+**rotation** dropdown (Sticky / Round-robin / Least-used) — the provider is
+enough at signup. The model auto-defaults per provider via a new pure
+`defaultSubscriptionModel(upstream)` helper (openai→`gpt-5.5`, google→
+`gemini-2.5-pro`), so `validatePool`/save still get a model id. The full Account
+editor is unchanged (keeps model + rotation for real pools).
+
+**B3 — Restore "Reconnect" (re-authorize) on the Account page.** The old desk
+page had a *Re-authorize* button on a connected subscription ("If chat starts
+failing, click Re-authorize to mint fresh tokens"); the SPA dropped it. Added a
+per-account **Reconnect** button (shown when the full editor is used, i.e. not in
+the simplified onboarding view) that re-runs the paste-back OAuth flow. Connected
+accounts now dedupe by `account_ref` on finish, so re-authorizing the same
+account refreshes it in place instead of adding a duplicate row.
+
+### Verification
+- `node --test` — 28/28 pass, incl. a new `defaultSubscriptionModel` case.
+- `vite build` — exit 0; `OnboardingView`, `AccountView`, `LlmPoolEditor` all
+  compile cleanly.
+- Live human-reviewer pass over the *current* `AccountView` + `LlmPoolEditor`
+  (Quick/Preset/Custom) in the browser.
+- Live render of the *new* onboarding wizard was blocked by the SPA's server-side
+  boot injection (dev server can't mint `is_system_manager`/CSRF for the deep
+  worktree; a real render needs a Frappe-served build). Flagged as a follow-up.
+
+---
+
+## Part C — Account page (`AccountView.vue`) — review for /goal
+
+### C1. Double sidebar (highest-impact) [V/C]
+`AppShell` already wraps the route in the global `Sidebar`; `AccountView` (and
+`MonitorView`) *additionally* render their own `<AppSidebar>` (Jarvis · Chat /
+Account / Usage). Result: **two stacked nav rails** on the account page. Redundant
+and inconsistent with the rest of the app (ChatView uses only the shell sidebar).
+
+### C2. Raw backend exception leaked to the user [V]
+Plan & billing rendered: *"admin authentication failed; check the bench's admin
+credentials. **(frappe.exceptions.AuthenticationError)**"* — the internal
+exception class is shown verbatim. Error copy should be human ("We couldn't reach
+billing right now — try again shortly.") and never expose exception types.
+
+### C3. Inconsistent primary-button / card language across pages [V/C]
+Onboarding (`.jv-ob-*`), the editor (inline styles), and Account (`.jv-acct-*`)
+each define their own button + card treatments over the same theme tokens. The
+"Save configuration" (solid dark) vs "Upgrade →" (small blue outline) vs wizard
+primary (blue-tinted) buttons don't share one primary style. Worth a shared
+button/card primitive.
+
+### C4. Heading scale differs across surfaces [C]
+Onboarding H1 = 28px, Account H1 = 20px, card H2 = 14px. Expected wizard-vs-
+settings contrast, but flag for a cohesive type scale.
+
+> C1–C2 are concrete bugs; C3–C4 are consistency debt. To be confirmed/expanded
+> in the Account-focused pass after the onboarding change lands.

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -15,7 +15,6 @@
 	var DISMISS_KEY = "jarvis_onboarding_nudge_dismissed";
 	var NUDGE_ID = "jarvis-onboarding-nudge";
 	var STYLE_ID = "jarvis-onboarding-nudge-style";
-	var BLUE = "#2563eb";
 	// No point nagging a user already mid-setup on the legacy desk page.
 	var HIDE_ON_ROUTES = ["jarvis-onboarding"];
 
@@ -47,41 +46,28 @@
 		if (document.getElementById(STYLE_ID)) return;
 		var st = document.createElement("style");
 		st.id = STYLE_ID;
+		// Colors come from the Desk's own theme tokens so the popup follows the
+		// desk light/dark automatically (bubbles white↔dark; the CTA flips
+		// black↔white via --text-color bg / --fg-color text). Hardcoded fallbacks
+		// keep it sane if a token is ever missing.
 		st.textContent =
 			"@keyframes jvNudgeIn{from{opacity:0;transform:translateY(8px) scale(.98)}to{opacity:1;transform:none}}" +
-			"#" + NUDGE_ID + "{position:fixed;right:24px;bottom:92px;z-index:1050;width:328px;max-width:calc(100vw - 40px);" +
+			"#" + NUDGE_ID + "{position:fixed;right:24px;bottom:92px;z-index:1050;width:320px;max-width:calc(100vw - 40px);" +
 			"font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:flex;flex-direction:column;gap:8px;}" +
-			"#" + NUDGE_ID + " .jvn-row{display:flex;align-items:flex-end;gap:8px;opacity:0;animation:jvNudgeIn .32s cubic-bezier(.2,.7,.3,1) forwards;}" +
+			"#" + NUDGE_ID + " .jvn-row{display:flex;opacity:0;animation:jvNudgeIn .32s cubic-bezier(.2,.7,.3,1) forwards;}" +
 			"#" + NUDGE_ID + " .jvn-row.r1{animation-delay:.05s;}" +
 			"#" + NUDGE_ID + " .jvn-row.r2{animation-delay:.42s;}" +   // staggered — feels like a 2nd message
-			"#" + NUDGE_ID + " .jvn-av{width:24px;height:24px;flex:none;border-radius:7px;background:" + BLUE + ";display:flex;align-items:center;justify-content:center;box-shadow:0 1px 2px rgba(37,99,235,.35);}" +
-			"#" + NUDGE_ID + " .jvn-bubble{position:relative;background:#fff;border:1px solid #e6e6ee;border-radius:14px;padding:10px 13px;font-size:13px;line-height:1.45;color:#20232e;box-shadow:0 6px 22px -8px rgba(20,20,40,.22);}" +
-			"#" + NUDGE_ID + " .jvn-name{font-size:11px;font-weight:600;color:#8a8aa0;margin-bottom:3px;}" +
-			"#" + NUDGE_ID + " .jvn-btn{display:inline-flex;align-items:center;gap:6px;margin-top:10px;background:" + BLUE + ";color:#fff;border:0;border-radius:8px;padding:7px 13px;font-size:12.5px;font-weight:600;text-decoration:none;cursor:pointer;}" +
-			"#" + NUDGE_ID + " .jvn-x{position:absolute;top:-9px;right:-9px;width:22px;height:22px;border-radius:50%;background:#fff;border:1px solid #e6e6ee;color:#6b6b80;font-size:13px;line-height:1;cursor:pointer;box-shadow:0 2px 6px rgba(20,20,40,.14);display:flex;align-items:center;justify-content:center;}" +
-			"#" + NUDGE_ID + " .jvn-tail{align-self:flex-end;margin:-2px 16px 0 0;width:14px;height:14px;background:#fff;border-right:1px solid #e6e6ee;border-bottom:1px solid #e6e6ee;transform:rotate(45deg);opacity:0;animation:jvNudgeIn .32s ease .5s forwards;}";
+			"#" + NUDGE_ID + " .jvn-bubble{position:relative;background:var(--card-bg,#fff);border:1px solid var(--border-color,#e6e6ee);border-radius:14px;padding:10px 13px;font-size:13px;line-height:1.45;color:var(--text-color,#20232e);box-shadow:0 6px 22px -8px rgba(20,20,40,.22);}" +
+			"#" + NUDGE_ID + " .jvn-name{font-size:11px;font-weight:600;color:var(--text-muted,#8a8aa0);margin-bottom:3px;}" +
+			"#" + NUDGE_ID + " .jvn-btn{display:inline-flex;align-items:center;gap:6px;margin-top:10px;background:var(--text-color,#16181d);color:var(--fg-color,#fff);border:0;border-radius:8px;padding:7px 13px;font-size:12.5px;font-weight:600;text-decoration:none;cursor:pointer;}" +
+			"#" + NUDGE_ID + " .jvn-x{position:absolute;top:-9px;right:-9px;width:22px;height:22px;border-radius:50%;background:var(--card-bg,#fff);border:1px solid var(--border-color,#e6e6ee);color:var(--text-muted,#6b6b80);font-size:13px;line-height:1;cursor:pointer;box-shadow:0 2px 6px rgba(20,20,40,.14);display:flex;align-items:center;justify-content:center;}" +
+			"#" + NUDGE_ID + " .jvn-tail{align-self:flex-end;margin:-2px 16px 0 0;width:14px;height:14px;background:var(--card-bg,#fff);border-right:1px solid var(--border-color,#e6e6ee);border-bottom:1px solid var(--border-color,#e6e6ee);transform:rotate(45deg);opacity:0;animation:jvNudgeIn .32s ease .5s forwards;}";
 		document.head.appendChild(st);
-	}
-
-	function avatar() {
-		var a = document.createElement("div");
-		a.className = "jvn-av";
-		// Build the Jarvis star mark via SVG DOM (no innerHTML) — XSS-safe by construction.
-		var NS = "http://www.w3.org/2000/svg";
-		var svg = document.createElementNS(NS, "svg");
-		svg.setAttribute("width", "14"); svg.setAttribute("height", "14");
-		svg.setAttribute("viewBox", "0 0 24 24"); svg.setAttribute("fill", "#fff");
-		var path = document.createElementNS(NS, "path");
-		path.setAttribute("d", "M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z");
-		svg.appendChild(path);
-		a.appendChild(svg);
-		return a;
 	}
 
 	function bubbleRow(cls, buildBubble) {
 		var row = document.createElement("div");
 		row.className = "jvn-row " + cls;
-		row.appendChild(avatar());
 		row.appendChild(buildBubble());
 		return row;
 	}


### PR DESCRIPTION
## Summary
Streamlines the onboarding **Connect your AI** step and restores a missing Account affordance. Advanced pooling/failover stays fully available on the Account page — nothing is removed from there.

### Changes
1. **Onboarding shows a single quick model.** Added an opt-in `modes` prop to `LlmPoolEditor` (default = all 3 tabs → `AccountView` unchanged). Onboarding passes `["quick"]`, which hides the **Preset**/**Custom** tabs + the Direct/Proxy badge, drops the "Use Preset or Custom" hint (points users to Account instead), and clamps the editor so it never auto-selects a hidden mode.
2. **Simpler onboarding chat-subscription.** In the quick-only editor the **Model ID** field and the **rotation** dropdown (Sticky/Round-robin/Least-used) are hidden — the provider is enough at signup. Model auto-defaults per provider via a new pure `defaultSubscriptionModel(upstream)` helper.
3. **Restore Account "Reconnect".** Re-added the per-account **Reconnect** (re-authorize) button that the desk→SPA migration dropped. Connected accounts now dedupe by `account_ref`, so re-auth refreshes in place instead of duplicating.

### Verification
- `node --test` — **28/28** pass (incl. new `defaultSubscriptionModel`).
- `vite build` — exit 0; `OnboardingView` / `AccountView` / `LlmPoolEditor` compile clean.
- Human-reviewer pass over the current live UI; full write-up in `jarvis/docs/superpowers/reviews/2026-07-07-onboarding-account-ux-review.md`.
- ⚠️ Live render of the *new* onboarding wizard wasn't captured — the SPA relies on server-side boot injection (`is_system_manager`/CSRF), which a dev server run from the deep worktree can't mint. Needs a Frappe-served build to screenshot.

### Open follow-ups (from the review, not in this PR)
- **Account: double sidebar** — `AppShell`'s global rail + `AccountView`/`MonitorView`'s own `AppSidebar`.
- **Account: raw exception leaked** — Plan & billing shows `(frappe.exceptions.AuthenticationError)` verbatim.
- Inconsistent primary-button / card language across onboarding, editor, and account.
- Onboarding wizard renders with the full app sidebar (not chrome-less); self-host "not included" note uses error-red; mode cards use emoji.

🤖 Draft for review — not for merge yet.