### PR TITLE
feat(wiki): three-tier knowledge scopes, Obsidian container mirror, Wiki tab, insights→skill, knowledge language

### DIFF
--- a/frontend/src/api/learning.js
+++ b/frontend/src/api/learning.js
@@ -60,6 +60,25 @@ export const flagLearnedDefault = (name, note = "") =>
 export const batchApprove = (names) =>
 	call(LR + "batch_approve", { names: JSON.stringify(Array.from(names || [])) })
 
+// ── insight → skill (wiki-v2 D5) ─────────────────────────────────────────────
+// B/C insights never compile into learned skills; "Apply to skill…" folds one
+// into an org custom skill instead. draft_* makes ONE LLM call server-side and
+// returns a verdict without writing ({worth_applying, reason, action:
+// "update"|"create"|"none", skill_name, before_instructions,
+// updated_instructions, new_skill}); apply_* performs the confirmed write and
+// marks the pattern acknowledged with an applied-to-skill note. The updated
+// skill rides the normal Skills-tab apply (no auto-push).
+export const draftInsightSkillUpdate = (patternName) =>
+	call(LR + "draft_insight_skill_update", { pattern_name: patternName })
+export const applyInsightSkillUpdate = (patternName, payload = {}) => {
+	const args = { pattern_name: patternName, action: payload.action || "" }
+	if (payload.skill_name) args.skill_name = payload.skill_name
+	if (payload.updated_instructions) args.updated_instructions = payload.updated_instructions
+	// dict arg JSON-encoded like batch_approve / setLearningSettings
+	if (payload.new_skill) args.new_skill = JSON.stringify(payload.new_skill)
+	return call(LR + "apply_insight_skill_update", args)
+}
+
 // ── apply / sync (learned skills ride the custom-skill push, §6.2) ───────────
 export const applyLearnedSkills = () => call(LR + "apply_learned_skills")
 // Proxies get_custom_skills_sync_status — same pill the Skills page polls.

--- a/frontend/src/api/voice.js
+++ b/frontend/src/api/voice.js
@@ -1,12 +1,11 @@
-// Voice + wiki API — thin wrappers around `jarvis.chat.voice`,
-// `jarvis.chat.voice_notes_api` and `jarvis.chat.wiki`. Mirrors
-// src/api/learning.js: one `call` per endpoint. The exception is
+// Voice API — thin wrappers around `jarvis.chat.voice` and
+// `jarvis.chat.voice_notes_api` (wiki endpoints live in src/api/wiki.js).
+// Mirrors src/api/learning.js: one `call` per endpoint. The exception is
 // `transcribeAudio`, which must POST a multipart body (the recorded blob), so
 // it uses a raw fetch like src/api.js uploadFile instead of frappe-ui `call`.
 import { call } from "frappe-ui"
 
 const VN = "jarvis.chat.voice_notes_api."
-const WK = "jarvis.chat.wiki."
 
 // Server maps the blob MIME to the model's audio format; the filename only
 // helps werkzeug pick a sane extension.
@@ -88,15 +87,6 @@ export const getBusinessStatus = () => call(VN + "get_business_status")
 export const processVoiceNotesNow = () => call(VN + "process_voice_notes_now")
 
 // ── wiki ─────────────────────────────────────────────────────────────────────
-export const dismissWikiNudge = (conversation) => call(WK + "dismiss_nudge", { conversation })
-export const listWikiPagesPage = (p = {}) =>
-	call(WK + "list_wiki_pages_page", {
-		search: p.search || "",
-		page_type: p.page_type || "",
-		start: p.start || 0,
-		page_length: p.page_length || 20,
-	})
-export const getWikiPage = (slug) => call(WK + "get_wiki_page", { slug })
-// patch: any of {body_md, summary, title} — only the provided fields change.
-export const saveWikiPage = (slug, patch = {}) => call(WK + "save_wiki_page", { slug, ...patch })
-export const archiveWikiPage = (slug) => call(WK + "archive_wiki_page", { slug })
+// Wiki wrappers moved to src/api/wiki.js with the Wiki tab; the nudge dismiss
+// is re-exported so ChatView's `voice.dismissWikiNudge` keeps working.
+export { dismissWikiNudge } from "./wiki"

--- a/frontend/src/api/wiki.js
+++ b/frontend/src/api/wiki.js
@@ -1,0 +1,58 @@
+// Wiki API — thin wrappers around `jarvis.chat.wiki.*`, the scope-aware wiki
+// endpoints behind the Skills-page "Wiki" tab. Mirrors src/api/learning.js:
+// one `call` per endpoint. The list endpoint paginates by page number (page,
+// page_length) — useListPage callers map their start offset onto `page` in
+// the fetchFn. Wiki wrappers used to live in src/api/voice.js; voice.js
+// re-exports `dismissWikiNudge` so ChatView's namespace import keeps working.
+import { call } from "frappe-ui"
+
+const WK = "jarvis.chat.wiki."
+
+// Envelope {rows, total, has_more, page, page_length}; rows carry scope +
+// stale/contradiction flags. scope_filter: all | org | role | mine.
+// attention=1 keeps only pages needing review (conflicting or stale).
+export const listWikiPagesPage = (p = {}) =>
+	call(WK + "list_wiki_pages_page", {
+		search: p.search || "",
+		page_type: p.page_type || "",
+		scope_filter: p.scope_filter || "all",
+		attention: p.attention ? 1 : 0,
+		page: p.page || 1,
+		page_length: p.page_length || 20,
+	})
+
+// {creatable_scopes, manageable_roles, is_sm, knowledge_language,
+//  wiki_lint_last_run_at, wiki_lint_summary} — the caller's capabilities +
+// the SM header extras. Any desk user may call it.
+export const getWikiCaps = () => call(WK + "get_wiki_caps")
+
+// Full page incl. body_md + the server-computed can_edit/can_archive flags
+// the dialog trusts (save/archive re-check the write matrix server-side).
+export const getWikiPage = (slug) => call(WK + "get_wiki_page", { slug })
+
+// → {ok: true, slug} | {ok: false, reason} (matrix denial / slug collision).
+// target_role only applies to Role scope; the server derives the slug.
+export const createWikiPage = (p = {}) =>
+	call(WK + "create_wiki_page", {
+		title: p.title || "",
+		page_type: p.page_type || "",
+		scope: p.scope || "Org",
+		...(p.target_role ? { target_role: p.target_role } : {}),
+		summary: p.summary || "",
+		body_md: p.body_md || "",
+	})
+
+// patch: any of {body_md, summary, title} — only the provided fields change.
+export const saveWikiPage = (slug, patch = {}) => call(WK + "save_wiki_page", { slug, ...patch })
+export const archiveWikiPage = (slug) => call(WK + "archive_wiki_page", { slug })
+
+// Chat nudge card: "don't ask again in this conversation" (7-day snooze).
+export const dismissWikiNudge = (conversation) => call(WK + "dismiss_nudge", { conversation })
+
+// ── SM-only header extras ─────────────────────────────────────────────────────
+export const setKnowledgeLanguage = (value) => call(WK + "set_knowledge_language", { value })
+// Queues a FULL org-wiki mirror sync into the agent workspace. → {ok: true}
+export const syncWikiMirrorNow = () => call(WK + "sync_wiki_mirror_now")
+// Runs the wiki health check synchronously. → {ok, summary} (summary also
+// persisted on Jarvis Settings; get_wiki_caps surfaces the last run).
+export const runWikiLintNow = () => call(WK + "run_wiki_lint_now")

--- a/frontend/src/api/wiki.js
+++ b/frontend/src/api/wiki.js
@@ -17,6 +17,7 @@ export const listWikiPagesPage = (p = {}) =>
 		page_type: p.page_type || "",
 		scope_filter: p.scope_filter || "all",
 		attention: p.attention ? 1 : 0,
+		archived: p.archived ? 1 : 0,
 		page: p.page || 1,
 		page_length: p.page_length || 20,
 	})
@@ -45,6 +46,8 @@ export const createWikiPage = (p = {}) =>
 // patch: any of {body_md, summary, title} — only the provided fields change.
 export const saveWikiPage = (slug, patch = {}) => call(WK + "save_wiki_page", { slug, ...patch })
 export const archiveWikiPage = (slug) => call(WK + "archive_wiki_page", { slug })
+// Undoes an accidental archive (same permission as archiving).
+export const restoreWikiPage = (slug) => call(WK + "restore_wiki_page", { slug })
 
 // Chat nudge card: "don't ask again in this conversation" (7-day snooze).
 export const dismissWikiNudge = (conversation) => call(WK + "dismiss_nudge", { conversation })

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -88,8 +88,8 @@
 				v-if="phase === 'update' || phase === 'create'"
 				class="mt-3 text-sm text-ink-gray-5"
 			>
-				Confirming saves the skill only — the Skills tab apply bar pushes it to your
-				assistant.
+				Confirming saves the skill only — it reaches your assistant with the next
+				skills push.
 			</p>
 		</template>
 
@@ -226,16 +226,26 @@ const newSkill = computed(() => draft.new_skill || {})
 // Cheap line-level diff: a line is highlighted when its trimmed text does not
 // appear anywhere on the other side. Not a real diff (moved/duplicated lines
 // read as changes) but enough to draw the eye to what the LLM touched.
+// Single-paragraph instructions (the common case) degrade to "everything
+// changed" under a line diff, so fall back to sentence segments there.
+function segments(text, splitSentences) {
+	const s = String(text || "")
+	if (!splitSentences) return s.split("\n")
+	return s.split(/(?<=[.!?])\s+/)
+}
 function diffLines(text, otherText) {
+	const bothMultiline =
+		String(text || "").trim().includes("\n") && String(otherText || "").trim().includes("\n")
+	const bySentence = !bothMultiline
 	const other = new Set(
-		String(otherText || "")
-			.split("\n")
+		segments(otherText, bySentence)
 			.map((l) => l.trim())
 			.filter(Boolean)
 	)
-	return String(text || "")
-		.split("\n")
-		.map((line) => ({ line, changed: !!line.trim() && !other.has(line.trim()) }))
+	return segments(text, bySentence).map((line) => ({
+		line,
+		changed: !!line.trim() && !other.has(line.trim()),
+	}))
 }
 const currentLines = computed(() =>
 	diffLines(draft.before_instructions, draft.updated_instructions)
@@ -265,8 +275,8 @@ async function confirmApply() {
 			(r && r.skill_name) || draft.skill_name || newSkill.value.skill_name || "skill"
 		toast.success(
 			phase.value === "create"
-				? `Skill “${skill}” created — apply it from the Skills tab to push it to your assistant.`
-				: `Skill “${skill}” updated — apply it from the Skills tab to push it to your assistant.`
+				? `Skill “${skill}” created. It reaches your assistant with the next skills push.`
+				: `Skill “${skill}” updated. The change reaches your assistant with the next skills push.`
 		)
 		emit("applied", { skill_name: skill })
 		emit("update:modelValue", false)

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -1,0 +1,296 @@
+<template>
+	<Dialog
+		:modelValue="modelValue"
+		:options="{ title: 'Apply insight to a skill', size: 'lg' }"
+		@update:modelValue="(v) => emit('update:modelValue', v)"
+	>
+		<template #body-content>
+			<!-- the insight being folded into a skill -->
+			<p v-if="pattern.pattern_statement" class="text-sm text-ink-gray-6">
+				{{ pattern.pattern_statement }}
+			</p>
+
+			<!-- drafting -->
+			<div
+				v-if="phase === 'loading'"
+				class="flex flex-col items-center gap-2 py-10 text-center"
+			>
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+				<span class="max-w-sm text-sm text-ink-gray-6">
+					Drafting — Jarvis is matching this insight against your custom skills and writing
+					the update. This takes a few seconds.
+				</span>
+			</div>
+
+			<!-- verdict: not worth applying -->
+			<div
+				v-else-if="phase === 'none'"
+				class="mt-3 flex items-start gap-2 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-7"
+			>
+				<FeatherIcon name="info" class="mt-0.5 size-4 shrink-0" />
+				<span>{{ draft.reason || "This insight is not worth folding into a skill." }}</span>
+			</div>
+
+			<!-- verdict: update an existing skill -->
+			<template v-else-if="phase === 'update'">
+				<div class="mt-3 flex flex-wrap items-center gap-1.5 text-sm">
+					<span class="text-ink-gray-5">Target skill:</span>
+					<Badge variant="subtle" theme="blue" :label="draft.skill_name" />
+				</div>
+				<p v-if="draft.reason" class="mt-2 text-sm text-ink-gray-6">{{ draft.reason }}</p>
+				<div class="mt-3">
+					<div class="mb-1 text-sm text-ink-gray-5">Current instructions</div>
+					<div
+						class="max-h-44 overflow-y-auto rounded border bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-8"
+					>
+						<div
+							v-for="(l, i) in currentLines"
+							:key="i"
+							class="whitespace-pre-wrap"
+							:class="l.changed ? 'rounded-sm bg-surface-red-1' : ''"
+						>{{ l.line || " " }}</div>
+					</div>
+				</div>
+				<div class="mt-3">
+					<div class="mb-1 text-sm text-ink-gray-5">Proposed instructions</div>
+					<div
+						class="max-h-44 overflow-y-auto rounded border bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-8"
+					>
+						<div
+							v-for="(l, i) in proposedLines"
+							:key="i"
+							class="whitespace-pre-wrap"
+							:class="l.changed ? 'rounded-sm bg-surface-green-1' : ''"
+						>{{ l.line || " " }}</div>
+					</div>
+				</div>
+			</template>
+
+			<!-- verdict: create a new skill -->
+			<template v-else-if="phase === 'create'">
+				<p v-if="draft.reason" class="mt-3 text-sm text-ink-gray-6">{{ draft.reason }}</p>
+				<div class="mt-3 flex flex-wrap items-center gap-1.5 text-sm">
+					<span class="text-ink-gray-5">New skill:</span>
+					<Badge variant="subtle" theme="blue" :label="newSkill.skill_name" />
+				</div>
+				<p v-if="newSkill.description" class="mt-2 text-sm text-ink-gray-7">
+					{{ newSkill.description }}
+				</p>
+				<div class="mt-3">
+					<div class="mb-1 text-sm text-ink-gray-5">Instructions</div>
+					<pre
+						class="max-h-56 overflow-y-auto whitespace-pre-wrap rounded border bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-8"
+					>{{ newSkill.instructions }}</pre>
+				</div>
+			</template>
+
+			<p
+				v-if="phase === 'update' || phase === 'create'"
+				class="mt-3 text-sm text-ink-gray-5"
+			>
+				Confirming saves the skill only — the Skills tab apply bar pushes it to your
+				assistant.
+			</p>
+		</template>
+
+		<template #actions>
+			<div class="flex items-center gap-2">
+				<Button
+					v-if="phase === 'none'"
+					variant="solid"
+					label="Acknowledge instead"
+					:loading="acknowledging"
+					@click="acknowledgeInstead"
+				/>
+				<Button
+					v-else-if="phase === 'update'"
+					variant="solid"
+					theme="green"
+					label="Update skill"
+					:loading="applying"
+					@click="confirmApply"
+				/>
+				<Button
+					v-else-if="phase === 'create'"
+					variant="solid"
+					theme="green"
+					label="Create skill"
+					:loading="applying"
+					@click="confirmApply"
+				/>
+				<Button
+					label="Cancel"
+					:disabled="applying || acknowledging"
+					@click="emit('update:modelValue', false)"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// InsightApplyDialog — the wiki-v2 D5 "Apply to skill…" flow for B/C
+// (insight-only) learned patterns. Opening drafts server-side (ONE LLM call
+// matching the insight against org custom skills) and returns a verdict:
+// update an existing skill (before/after comparison with a cheap line-diff
+// highlight), create a new one (preview), or not worth applying (reason +
+// the ordinary Acknowledge as a shortcut). Confirm calls
+// apply_insight_skill_update, which writes the skill and marks the pattern
+// acknowledged with an applied-to-skill note; the change then rides the
+// normal Skills-tab apply (no auto-push). Self-contained like ShareDialog:
+// owns its busy refs; the parent refreshes on @applied.
+import { reactive, ref, computed, watch } from "vue"
+import { Badge, Button, Dialog, FeatherIcon, LoadingIndicator, toast } from "frappe-ui"
+import {
+	draftInsightSkillUpdate,
+	applyInsightSkillUpdate,
+	acknowledgeLearnedPattern,
+} from "@/api/learning"
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	pattern: { type: Object, default: () => ({}) }, // board row: {name, pattern_statement, ...}
+})
+
+const emit = defineEmits(["update:modelValue", "applied"])
+
+const phase = ref("loading") // loading | none | update | create
+const applying = ref(false)
+const acknowledging = ref(false)
+const draft = reactive({
+	reason: "",
+	action: "",
+	skill_name: "",
+	before_instructions: "",
+	updated_instructions: "",
+	new_skill: null,
+})
+// monotonic open counter: a draft resolving after close (or a re-open) is dropped
+let loadSeq = 0
+
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (open) load()
+	}
+)
+
+async function load() {
+	const seq = ++loadSeq
+	phase.value = "loading"
+	applying.value = false
+	acknowledging.value = false
+	Object.assign(draft, {
+		reason: "",
+		action: "",
+		skill_name: "",
+		before_instructions: "",
+		updated_instructions: "",
+		new_skill: null,
+	})
+	try {
+		const r = await draftInsightSkillUpdate(props.pattern.name)
+		if (seq !== loadSeq || !props.modelValue) return
+		if (!r || r.ok === false) {
+			toast.error((r && r.reason) || "Could not draft a skill update.")
+			emit("update:modelValue", false)
+			return
+		}
+		Object.assign(draft, {
+			reason: r.reason || "",
+			action: r.action || "none",
+			skill_name: r.skill_name || "",
+			before_instructions: r.before_instructions || "",
+			updated_instructions: r.updated_instructions || "",
+			new_skill: r.new_skill || null,
+		})
+		phase.value =
+			!r.worth_applying || r.action === "none"
+				? "none"
+				: r.action === "create"
+					? "create"
+					: "update"
+	} catch (e) {
+		if (seq !== loadSeq) return
+		toast.error(errMsg(e))
+		emit("update:modelValue", false)
+	}
+}
+
+const newSkill = computed(() => draft.new_skill || {})
+
+// Cheap line-level diff: a line is highlighted when its trimmed text does not
+// appear anywhere on the other side. Not a real diff (moved/duplicated lines
+// read as changes) but enough to draw the eye to what the LLM touched.
+function diffLines(text, otherText) {
+	const other = new Set(
+		String(otherText || "")
+			.split("\n")
+			.map((l) => l.trim())
+			.filter(Boolean)
+	)
+	return String(text || "")
+		.split("\n")
+		.map((line) => ({ line, changed: !!line.trim() && !other.has(line.trim()) }))
+}
+const currentLines = computed(() =>
+	diffLines(draft.before_instructions, draft.updated_instructions)
+)
+const proposedLines = computed(() =>
+	diffLines(draft.updated_instructions, draft.before_instructions)
+)
+
+async function confirmApply() {
+	if (applying.value) return
+	applying.value = true
+	try {
+		const payload =
+			phase.value === "create"
+				? { action: "create", new_skill: draft.new_skill }
+				: {
+						action: "update",
+						skill_name: draft.skill_name,
+						updated_instructions: draft.updated_instructions,
+					}
+		const r = await applyInsightSkillUpdate(props.pattern.name, payload)
+		if (r && r.ok === false) {
+			toast.error(r.reason || "Could not apply the insight.")
+			return // dialog stays open
+		}
+		const skill =
+			(r && r.skill_name) || draft.skill_name || newSkill.value.skill_name || "skill"
+		toast.success(
+			phase.value === "create"
+				? `Skill “${skill}” created — apply it from the Skills tab to push it to your assistant.`
+				: `Skill “${skill}” updated — apply it from the Skills tab to push it to your assistant.`
+		)
+		emit("applied", { skill_name: skill })
+		emit("update:modelValue", false)
+	} catch (e) {
+		toast.error(errMsg(e)) // dialog stays open for retry / cancel
+	} finally {
+		applying.value = false
+	}
+}
+
+// The verdict said "not worth applying": offer the ordinary B/C disposition
+// without a round-trip back to the board.
+async function acknowledgeInstead() {
+	if (acknowledging.value) return
+	acknowledging.value = true
+	try {
+		await acknowledgeLearnedPattern(props.pattern.name)
+		toast.success("Acknowledged")
+		emit("applied", { acknowledged: true })
+		emit("update:modelValue", false)
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		acknowledging.value = false
+	}
+}
+</script>

--- a/frontend/src/components/list/ListPage.vue
+++ b/frontend/src/components/list/ListPage.vue
@@ -57,8 +57,13 @@
 		</div>
 
 		<!-- list body -->
+		<!-- !w-full: upstream's inner wrapper is `w-max min-w-full`, which sizes
+		     the grid to max-content — long cells push trailing columns past the
+		     viewport behind a subtle inner scrollbar. Pinning to the container
+		     lets the minmax(0, Nfr) tracks compress and truncation work. -->
 		<ListView
 			v-if="rows.length"
+			class="!w-full"
 			:columns="visibleColumns"
 			:rows="rows"
 			:row-key="rowKey"

--- a/frontend/src/components/list/ListPage.vue
+++ b/frontend/src/components/list/ListPage.vue
@@ -134,7 +134,26 @@
 			:options="{ rowCount: rows.length, totalCount: total }"
 			@update:modelValue="(v) => $emit('update:pageLength', v)"
 			@loadMore="$emit('loadMore')"
-		/>
+		>
+			<!-- own the right side: upstream ListFooter's Load More <Button> is a
+			     bare unregistered element in frappe-ui 0.1.278 (Button never
+			     imported), so paging beyond page 1 is otherwise unreachable -->
+			<template #right>
+				<div class="flex items-center">
+					<Button
+						v-if="rows.length < total"
+						label="Load More"
+						@click="$emit('loadMore')"
+					/>
+					<div v-if="rows.length < total" class="mx-3 h-[80%] border-l" />
+					<div class="flex items-center gap-1 text-base text-ink-gray-5">
+						<div>{{ rows.length }}</div>
+						<div>of</div>
+						<div>{{ total }}</div>
+					</div>
+				</div>
+			</template>
+		</ListFooter>
 	</div>
 </template>
 
@@ -196,7 +215,17 @@ const emit = defineEmits([
 // §14 F2 — ColumnsButton owns useStorage('jarvis-cols-'+storageKey) and pushes
 // the hidden-key list up; ListPage filters the visible columns from it.
 const hiddenKeys = ref([])
-const visibleColumns = computed(() => (props.columns || []).filter((c) => !hiddenKeys.value.includes(c.key)))
+// Numeric widths compile to bare `Nfr` grid tracks whose implicit minimum is
+// min-content, so one sentence-length cell stretches the whole list into
+// horizontal scroll and `truncate` never bites. minmax(0, Nfr) restores real
+// flexible tracks (and therefore working truncation) for every list.
+const visibleColumns = computed(() =>
+	(props.columns || [])
+		.filter((c) => !hiddenKeys.value.includes(c.key))
+		.map((c) =>
+			typeof c.width === "number" ? { ...c, width: `minmax(0, ${c.width}fr)` } : c
+		)
+)
 
 // ── quick filters (toolbar-left strip; selects apply immediately, text 500ms) ──
 function quickValue(qf) {

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -40,6 +40,19 @@
 					<Badge v-if="page.stale" variant="subtle" theme="orange" label="Stale" />
 				</div>
 
+				<!-- Conflicting gets the same treatment as Stale: a badge alone is
+				     a red dead-end with no explanation or resolution path -->
+				<div
+					v-if="page.contradiction_flag"
+					class="mt-3 rounded-lg border border-outline-red-2 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
+				>
+					People have reported conflicting facts — look for the "Contradiction
+					flagged" section in the body below.{{
+						page.can_edit
+							? " Edit the page to keep the correct version; saving marks the conflict resolved."
+							: " A wiki manager can edit the page to resolve it."
+					}}
+				</div>
 				<!-- mirrors the amber Stale badge on the list row -->
 				<div
 					v-if="page.stale"
@@ -65,12 +78,27 @@
 						@update:modelValue="(v) => (editSummary = v)"
 					/>
 					<FormControl
+						v-if="!previewing"
 						type="textarea"
 						class="mt-3"
 						label="Body (markdown)"
 						:rows="14"
 						:modelValue="editBody"
 						@update:modelValue="(v) => (editBody = v)"
+					/>
+					<template v-else>
+						<div class="mt-3 text-xs text-ink-gray-5">Preview</div>
+						<div
+							class="prose prose-sm mt-1 max-h-[24rem] max-w-none overflow-y-auto rounded border px-3 py-2"
+							v-html="previewHtml"
+						/>
+					</template>
+					<Button
+						class="mt-2"
+						variant="ghost"
+						:label="previewing ? 'Back to editing' : 'Preview'"
+						:iconLeft="previewing ? 'edit-2' : 'eye'"
+						@click="previewing = !previewing"
 					/>
 				</template>
 				<template v-else>
@@ -170,6 +198,7 @@ const show = computed({
 const page = ref(null)
 const loading = ref(false)
 const editing = ref(false)
+const previewing = ref(false)
 const editTitle = ref("")
 const editSummary = ref("")
 const editBody = ref("")
@@ -178,6 +207,11 @@ const archiving = ref(false)
 
 const bodyHtml = computed(() =>
 	page.value && page.value.body_md ? renderMarkdown(page.value.body_md) : ""
+)
+const previewHtml = computed(() =>
+	editBody.value
+		? renderMarkdown(editBody.value)
+		: '<p class="text-ink-gray-5">Nothing to preview yet.</p>'
 )
 const updatedAt = computed(
 	() => (page.value && (page.value.modified || page.value.last_confirmed_at)) || ""
@@ -226,6 +260,7 @@ async function load() {
 }
 
 function startEdit() {
+	previewing.value = false
 	editTitle.value = (page.value && page.value.title) || ""
 	editSummary.value = (page.value && page.value.summary) || ""
 	editBody.value = (page.value && page.value.body_md) || ""

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -1,0 +1,240 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{ title: (page && page.title) || 'Wiki page', size: 'lg' }"
+	>
+		<template #body-content>
+			<div v-if="loading" class="py-8 text-center">
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+			</div>
+			<template v-else-if="page">
+				<!-- metadata row: type · scope (+target) · slug · updated · flags -->
+				<div class="flex flex-wrap items-center gap-2 text-sm">
+					<Badge variant="outline" theme="gray" :label="page.page_type" />
+					<Badge
+						variant="subtle"
+						:theme="SCOPE_THEME[page.scope] || 'gray'"
+						:label="page.scope || 'Org'"
+					/>
+					<span v-if="scopeTarget" class="text-ink-gray-5">for {{ scopeTarget }}</span>
+					<Badge
+						v-if="page.status === 'Archived'"
+						variant="subtle"
+						theme="gray"
+						label="Archived"
+					/>
+					<span class="text-ink-gray-5">{{ page.slug }}</span>
+					<Tooltip v-if="updatedAt" :text="exactDate(updatedAt)">
+						<span class="text-ink-gray-5">· updated {{ timeAgo(updatedAt) }}</span>
+					</Tooltip>
+					<Badge
+						v-if="page.contradiction_flag"
+						variant="subtle"
+						theme="red"
+						label="Conflicting"
+					/>
+					<Badge v-if="page.stale" variant="subtle" theme="orange" label="Stale" />
+				</div>
+
+				<!-- mirrors the amber Stale badge on the list row -->
+				<div
+					v-if="page.stale"
+					class="mt-3 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
+				>
+					Not confirmed in 90+ days{{ page.can_edit ? " — saving an edit marks it reviewed." : "." }}
+				</div>
+
+				<template v-if="editing">
+					<FormControl
+						type="textarea"
+						class="mt-3"
+						label="Summary"
+						:rows="2"
+						:modelValue="editSummary"
+						@update:modelValue="(v) => (editSummary = v)"
+					/>
+					<FormControl
+						type="textarea"
+						class="mt-3"
+						label="Body (markdown)"
+						:rows="14"
+						:modelValue="editBody"
+						@update:modelValue="(v) => (editBody = v)"
+					/>
+				</template>
+				<template v-else>
+					<p v-if="page.summary" class="mt-3 text-sm text-ink-gray-6">
+						{{ page.summary }}
+					</p>
+					<!-- renderMarkdown from @/markdown (escapes HTML first — safe) -->
+					<div
+						v-if="page.body_md"
+						class="prose prose-sm mt-3 max-w-none"
+						v-html="bodyHtml"
+					/>
+					<p v-else class="mt-3 text-sm text-ink-gray-5">No content yet.</p>
+				</template>
+			</template>
+		</template>
+		<template #actions>
+			<div v-if="page" class="flex flex-wrap items-center gap-2">
+				<template v-if="editing">
+					<Button variant="solid" label="Save" :loading="saving" @click="save" />
+					<Button label="Cancel" @click="editing = false" />
+				</template>
+				<template v-else>
+					<Button
+						v-if="page.can_edit"
+						variant="subtle"
+						label="Edit"
+						iconLeft="edit-2"
+						@click="startEdit"
+					/>
+					<Button
+						v-if="page.can_archive && page.status !== 'Archived'"
+						variant="subtle"
+						theme="red"
+						label="Archive"
+						:loading="archiving"
+						@click="confirmArchive"
+					/>
+				</template>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// WikiPageDialog — the wiki page viewer/editor extracted from BusinessTab's
+// org-wiki dialog for the Wiki tab (design D4): rendered-markdown read view
+// with scope/attention metadata, an Edit toggle (summary + body) shown only
+// when the server-computed `can_edit` flag allows it, and Archive behind a
+// confirmDialog when `can_archive`. Fetches the page itself whenever it opens
+// (v-model true + slug); emits `refresh` after a save/archive so the owning
+// list refetches.
+import { ref, computed, watch } from "vue"
+import {
+	Badge,
+	Button,
+	Dialog,
+	FormControl,
+	LoadingIndicator,
+	Tooltip,
+	toast,
+	confirmDialog,
+} from "frappe-ui"
+import { renderMarkdown } from "@/markdown"
+import { timeAgo, exactDate } from "@/utils/datetime"
+import { getWikiPage, saveWikiPage, archiveWikiPage } from "@/api/wiki"
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	slug: { type: String, default: "" },
+})
+const emit = defineEmits(["update:modelValue", "refresh"])
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const SCOPE_THEME = { Org: "gray", Role: "blue", User: "green" }
+
+const show = computed({
+	get: () => props.modelValue,
+	set: (v) => emit("update:modelValue", v),
+})
+
+const page = ref(null)
+const loading = ref(false)
+const editing = ref(false)
+const editSummary = ref("")
+const editBody = ref("")
+const saving = ref(false)
+const archiving = ref(false)
+
+const bodyHtml = computed(() =>
+	page.value && page.value.body_md ? renderMarkdown(page.value.body_md) : ""
+)
+const updatedAt = computed(
+	() => (page.value && (page.value.modified || page.value.last_confirmed_at)) || ""
+)
+const scopeTarget = computed(() => {
+	if (!page.value) return ""
+	if (page.value.scope === "Role") return page.value.target_role || ""
+	if (page.value.scope === "User") return page.value.target_user || ""
+	return ""
+})
+
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (open) load()
+	}
+)
+
+async function load() {
+	page.value = null
+	editing.value = false
+	loading.value = true
+	try {
+		page.value = await getWikiPage(props.slug)
+	} catch (e) {
+		show.value = false
+		toast.error(errMsg(e))
+	} finally {
+		loading.value = false
+	}
+}
+
+function startEdit() {
+	editSummary.value = (page.value && page.value.summary) || ""
+	editBody.value = (page.value && page.value.body_md) || ""
+	editing.value = true
+}
+
+async function save() {
+	saving.value = true
+	try {
+		await saveWikiPage(props.slug, {
+			summary: editSummary.value,
+			body_md: editBody.value,
+		})
+		// a saved body counts as a review server-side — mirror that locally
+		if (page.value) {
+			page.value.summary = editSummary.value
+			page.value.body_md = editBody.value
+			page.value.contradiction_flag = 0
+			page.value.stale = false
+		}
+		editing.value = false
+		toast.success("Page saved")
+		emit("refresh")
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		saving.value = false
+	}
+}
+
+function confirmArchive() {
+	confirmDialog({
+		title: "Archive this page?",
+		message:
+			"Archived pages stop appearing in the list and are no longer used as chat context. The record is kept.",
+		onConfirm: async ({ hideDialog }) => {
+			archiving.value = true
+			try {
+				await archiveWikiPage(props.slug)
+				hideDialog()
+				show.value = false
+				toast.success("Page archived")
+				emit("refresh")
+			} catch (e) {
+				toast.error(errMsg(e))
+			} finally {
+				archiving.value = false
+			}
+		},
+	})
+}
+</script>

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -10,7 +10,11 @@
 			<template v-else-if="page">
 				<!-- metadata row: type · scope (+target) · slug · updated · flags -->
 				<div class="flex flex-wrap items-center gap-2 text-sm">
-					<Badge variant="outline" theme="gray" :label="page.page_type" />
+					<Badge
+						variant="outline"
+						theme="gray"
+						:label="page.page_type === 'Org' ? 'Org notes' : page.page_type"
+					/>
 					<Badge
 						variant="subtle"
 						:theme="SCOPE_THEME[page.scope] || 'gray'"
@@ -46,6 +50,13 @@
 
 				<template v-if="editing">
 					<FormControl
+						type="text"
+						class="mt-3"
+						label="Title"
+						:modelValue="editTitle"
+						@update:modelValue="(v) => (editTitle = v)"
+					/>
+					<FormControl
 						type="textarea"
 						class="mt-3"
 						label="Summary"
@@ -73,6 +84,10 @@
 						v-html="bodyHtml"
 					/>
 					<p v-else class="mt-3 text-sm text-ink-gray-5">No content yet.</p>
+					<!-- provenance: where Jarvis learned this — earns trust and edits -->
+					<p v-if="provenance" class="mt-3 border-t pt-2 text-p-sm text-ink-gray-5">
+						{{ provenance }}
+					</p>
 				</template>
 			</template>
 		</template>
@@ -97,6 +112,14 @@
 						label="Archive"
 						:loading="archiving"
 						@click="confirmArchive"
+					/>
+					<Button
+						v-if="page.can_archive && page.status === 'Archived'"
+						variant="subtle"
+						label="Restore"
+						iconLeft="rotate-ccw"
+						:loading="archiving"
+						@click="restore"
 					/>
 				</template>
 			</div>
@@ -125,7 +148,7 @@ import {
 } from "frappe-ui"
 import { renderMarkdown } from "@/markdown"
 import { timeAgo, exactDate } from "@/utils/datetime"
-import { getWikiPage, saveWikiPage, archiveWikiPage } from "@/api/wiki"
+import { getWikiPage, saveWikiPage, archiveWikiPage, restoreWikiPage } from "@/api/wiki"
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -147,6 +170,7 @@ const show = computed({
 const page = ref(null)
 const loading = ref(false)
 const editing = ref(false)
+const editTitle = ref("")
 const editSummary = ref("")
 const editBody = ref("")
 const saving = ref(false)
@@ -163,6 +187,21 @@ const scopeTarget = computed(() => {
 	if (page.value.scope === "Role") return page.value.target_role || ""
 	if (page.value.scope === "User") return page.value.target_user || ""
 	return ""
+})
+// "From a voice note by X, Jul 7" — the page's latest source entry. Pages a
+// pipeline wrote (not a person) earn trust by saying where they came from.
+const provenance = computed(() => {
+	const sources = (page.value && page.value.sources) || []
+	if (!Array.isArray(sources) || !sources.length) return ""
+	const s = sources[sources.length - 1] || {}
+	const kindLabel =
+		{ voice: "a voice note", chat: "a chat conversation", edit: "a manual edit" }[
+			s.kind
+		] || (s.kind ? String(s.kind) : "a recorded source")
+	const who = s.user ? ` by ${s.user}` : ""
+	const when = s.date ? `, ${s.date}` : ""
+	const count = sources.length > 1 ? ` · ${sources.length} sources in total` : ""
+	return `Latest source: ${kindLabel}${who}${when}${count}`
 })
 
 watch(
@@ -187,6 +226,7 @@ async function load() {
 }
 
 function startEdit() {
+	editTitle.value = (page.value && page.value.title) || ""
 	editSummary.value = (page.value && page.value.summary) || ""
 	editBody.value = (page.value && page.value.body_md) || ""
 	editing.value = true
@@ -196,11 +236,13 @@ async function save() {
 	saving.value = true
 	try {
 		await saveWikiPage(props.slug, {
+			title: editTitle.value.trim() || undefined,
 			summary: editSummary.value,
 			body_md: editBody.value,
 		})
 		// a saved body counts as a review server-side — mirror that locally
 		if (page.value) {
+			if (editTitle.value.trim()) page.value.title = editTitle.value.trim()
 			page.value.summary = editSummary.value
 			page.value.body_md = editBody.value
 			page.value.contradiction_flag = 0
@@ -213,6 +255,20 @@ async function save() {
 		toast.error(errMsg(e))
 	} finally {
 		saving.value = false
+	}
+}
+
+async function restore() {
+	archiving.value = true
+	try {
+		await restoreWikiPage(props.slug)
+		if (page.value) page.value.status = "Active"
+		toast.success("Page restored")
+		emit("refresh")
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		archiving.value = false
 	}
 }
 

--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -80,6 +80,17 @@ export function renderMarkdown(src) {
 			out.push(renderTable(tbl))
 			continue
 		}
+		// ATX headings (#–####): wiki page bodies lead with them, and a
+		// knowledge base that shows raw hashes reads as broken.
+		const heading = line.match(/^\s*(#{1,4})\s+(.*)/)
+		if (heading) {
+			flushPara()
+			flushList()
+			const level = Math.min(heading[1].length + 2, 6)
+			out.push(`<h${level} class="jv-md-h">${inline(heading[2])}</h${level}>`)
+			i++
+			continue
+		}
 		const ul = line.match(/^\s*[-*]\s+(.*)/)
 		const ol = line.match(/^\s*\d+\.\s+(.*)/)
 		if (ul || ol) {

--- a/frontend/src/pages/skills/BusinessTab.vue
+++ b/frontend/src/pages/skills/BusinessTab.vue
@@ -14,7 +14,7 @@
 					icon="refresh-cw"
 					variant="ghost"
 					:tooltip="'Refresh'"
-					:loading="notes.loading || wiki.loading"
+					:loading="notes.loading"
 					@click="reloadAll"
 				/>
 			</template>
@@ -180,183 +180,20 @@
 					</div>
 				</section>
 
-				<!-- ══════════════ Org wiki (SM only) ══════════════ -->
-				<section v-if="status.can_process" class="rounded-lg border p-4">
-					<div class="text-base font-semibold text-ink-gray-9">Org wiki</div>
-					<div class="mt-0.5 text-sm text-ink-gray-6">
-						Pages Jarvis maintains about your customers, suppliers, items and processes —
-						referenced automatically in chat.
-					</div>
-
-					<div class="mt-3 flex flex-wrap items-center gap-2">
-						<div class="min-w-48 flex-1">
-							<FormControl
-								type="text"
-								placeholder="Search pages"
-								:modelValue="wikiSearch"
-								@update:modelValue="setWikiSearch"
-							>
-								<template #prefix>
-									<FeatherIcon name="search" class="size-4 text-ink-gray-5" />
-								</template>
-							</FormControl>
-						</div>
-						<div class="w-44">
-							<FormControl
-								type="select"
-								:options="TYPE_OPTIONS"
-								:modelValue="wikiType"
-								@update:modelValue="setWikiType"
-							/>
-						</div>
-					</div>
-
-					<div v-if="wiki.loading && !wiki.rows.length" class="py-8 text-center">
-						<LoadingIndicator class="size-5 text-ink-gray-5" />
-					</div>
-					<div
-						v-else-if="!wiki.rows.length"
-						class="mt-3 flex flex-col items-center gap-1 rounded-lg border border-dashed py-10 text-center"
-					>
-						<FeatherIcon name="book-open" class="size-6 text-ink-gray-5" />
-						<span class="mt-1 text-base font-medium text-ink-gray-8">
-							{{ wikiSearch || wikiType ? "No pages match" : "No wiki pages yet" }}
-						</span>
-						<span class="text-p-base text-ink-gray-6">
-							{{
-								wikiSearch || wikiType
-									? "Try a different search or type filter."
-									: "Jarvis builds pages from voice notes and chat conversations over time."
-							}}
-						</span>
-					</div>
-					<div v-else class="mt-2 divide-y">
-						<button
-							v-for="row in wiki.rows"
-							:key="row.slug || row.name"
-							class="flex w-full items-center justify-between gap-3 py-2.5 text-left hover:bg-surface-gray-1"
-							@click="openWikiPage(row)"
-						>
-							<div class="min-w-0 flex-1">
-								<div class="flex items-center gap-1.5">
-									<Tooltip v-if="row.stale" text="Not confirmed in 90+ days">
-										<span
-											class="size-2 shrink-0 rounded-full bg-[color:var(--ink-amber-3)]"
-										/>
-									</Tooltip>
-									<span class="truncate text-sm font-medium text-ink-gray-8">
-										{{ row.title || row.slug }}
-									</span>
-									<Badge variant="outline" theme="gray" :label="row.page_type" />
-								</div>
-								<div class="mt-0.5 flex items-center gap-2 text-sm text-ink-gray-5">
-									<span class="truncate">{{ row.slug }}</span>
-									<Tooltip v-if="wikiUpdated(row)" :text="exactDate(wikiUpdated(row))">
-										<span class="shrink-0">· updated {{ timeAgo(wikiUpdated(row)) }}</span>
-									</Tooltip>
-								</div>
+				<!-- ══════════════ Org wiki pointer ══════════════ -->
+				<section class="rounded-lg border p-4">
+					<div class="flex flex-wrap items-center justify-between gap-3">
+						<div class="min-w-0">
+							<div class="text-base font-semibold text-ink-gray-9">Org wiki has moved</div>
+							<div class="mt-0.5 text-sm text-ink-gray-6">
+								Browse and edit the pages Jarvis keeps about your business on the Wiki tab.
 							</div>
-							<FeatherIcon name="chevron-right" class="size-4 shrink-0 text-ink-gray-4" />
-						</button>
-					</div>
-
-					<div v-if="wiki.hasMore" class="mt-2 flex justify-center">
-						<Button
-							variant="subtle"
-							label="Load more"
-							:loading="wiki.loading"
-							@click="fetchWiki('more')"
-						/>
+						</div>
+						<Button variant="subtle" label="Go to Wiki" iconLeft="book-open" @click="goToWiki" />
 					</div>
 				</section>
 			</div>
 		</div>
-
-		<!-- Wiki page dialog: read view (rendered markdown) with an Edit toggle -->
-		<Dialog
-			v-model="wikiDialog.show"
-			:options="{ title: (wikiDialog.page && wikiDialog.page.title) || 'Wiki page', size: 'lg' }"
-		>
-			<template #body-content>
-				<div v-if="wikiDialog.loading" class="py-8 text-center">
-					<LoadingIndicator class="size-5 text-ink-gray-5" />
-				</div>
-				<template v-else-if="wikiDialog.page">
-					<div class="flex flex-wrap items-center gap-2 text-sm">
-						<Badge variant="outline" theme="gray" :label="wikiDialog.page.page_type" />
-						<span class="text-ink-gray-5">{{ wikiDialog.page.slug }}</span>
-						<Tooltip
-							v-if="wikiDialog.page.last_confirmed_at"
-							:text="exactDate(wikiDialog.page.last_confirmed_at)"
-						>
-							<span class="text-ink-gray-5">
-								· confirmed {{ timeAgo(wikiDialog.page.last_confirmed_at) }}
-							</span>
-						</Tooltip>
-						<Badge
-							v-if="wikiDialog.page.contradiction_flag"
-							variant="subtle"
-							theme="orange"
-							label="Contradiction flagged"
-						/>
-					</div>
-
-					<!-- mirrors the amber stale dot on the list row -->
-					<div
-						v-if="wikiDialog.page.stale"
-						class="mt-3 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
-					>
-						Not confirmed in 90+ days
-					</div>
-
-					<p v-if="wikiDialog.page.summary" class="mt-3 text-sm text-ink-gray-6">
-						{{ wikiDialog.page.summary }}
-					</p>
-
-					<FormControl
-						v-if="wikiDialog.editing"
-						type="textarea"
-						class="mt-3"
-						label="Body (markdown)"
-						:rows="14"
-						:modelValue="wikiDialog.editBody"
-						@update:modelValue="(v) => (wikiDialog.editBody = v)"
-					/>
-					<template v-else>
-						<!-- renderMarkdown from @/markdown (escapes HTML first — safe) -->
-						<div
-							v-if="wikiDialog.page.body_md"
-							class="prose prose-sm mt-3 max-w-none"
-							v-html="wikiBodyHtml"
-						/>
-						<p v-else class="mt-3 text-sm text-ink-gray-5">No content yet.</p>
-					</template>
-				</template>
-			</template>
-			<template #actions>
-				<div v-if="wikiDialog.page" class="flex flex-wrap items-center gap-2">
-					<template v-if="wikiDialog.editing">
-						<Button
-							variant="solid"
-							label="Save"
-							:loading="wikiDialog.saving"
-							@click="saveWikiEdit"
-						/>
-						<Button label="Cancel" @click="wikiDialog.editing = false" />
-					</template>
-					<template v-else>
-						<Button variant="subtle" label="Edit" iconLeft="edit-2" @click="startWikiEdit" />
-						<Button
-							variant="subtle"
-							theme="red"
-							label="Archive"
-							:loading="wikiDialog.archiving"
-							@click="confirmArchiveWiki"
-						/>
-					</template>
-				</div>
-			</template>
-		</Dialog>
 	</div>
 </template>
 
@@ -364,15 +201,15 @@
 // BusinessTab — the "Business" tab inside the Skills page: record/type voice
 // notes about how the business runs (processed daily by the voice-facts
 // worker), review your own notes, and — for System Managers — trigger
-// processing now and browse/edit the org wiki Jarvis maintains. Access is
-// gated by the parent (SkillsPage probes get_business_status); can_process in
-// the same payload gates the two SM cards.
-import { ref, reactive, computed, onMounted, onBeforeUnmount } from "vue"
+// processing now. The org wiki moved to the Wiki tab (WikiTab.vue); a pointer
+// card links there. Access is gated by the parent (SkillsPage probes
+// get_business_status); can_process in the same payload gates the SM card.
+import { ref, reactive, computed, onMounted } from "vue"
+import { useRouter } from "vue-router"
 import {
 	Badge,
 	Breadcrumbs,
 	Button,
-	Dialog,
 	FeatherIcon,
 	FormControl,
 	LoadingIndicator,
@@ -382,7 +219,6 @@ import {
 } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import VoiceRecorder from "@/components/VoiceRecorder.vue"
-import { renderMarkdown } from "@/markdown"
 import { timeAgo, exactDate } from "@/utils/datetime"
 import {
 	saveVoiceNote,
@@ -390,11 +226,9 @@ import {
 	deleteVoiceNote,
 	getBusinessStatus,
 	processVoiceNotesNow,
-	listWikiPagesPage,
-	getWikiPage,
-	saveWikiPage,
-	archiveWikiPage,
 } from "@/api/voice"
+
+const router = useRouter()
 
 function errMsg(e) {
 	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
@@ -410,21 +244,6 @@ const SUGGESTIONS = [
 	"Vendor & customer quirks",
 ]
 const NOTE_THEME = { New: "blue", Processed: "green", Archived: "gray" }
-const WIKI_TYPES = [
-	"Customer",
-	"Supplier",
-	"Item",
-	"Process",
-	"Doctype",
-	"Exception",
-	"Integration",
-	"People",
-	"Org",
-]
-const TYPE_OPTIONS = [
-	{ label: "All types", value: "" },
-	...WIKI_TYPES.map((t) => ({ label: t, value: t })),
-]
 
 // ── state ────────────────────────────────────────────────────────────────────
 const status = reactive({
@@ -443,31 +262,8 @@ const deleting = ref("")
 const processing = ref(false)
 
 const notes = reactive({ rows: [], total: 0, hasMore: false, loading: false })
-const wiki = reactive({ rows: [], total: 0, hasMore: false, loading: false, loadedOnce: false })
-const wikiSearch = ref("")
-const wikiType = ref("")
-let searchTimer = null
-
-const wikiDialog = reactive({
-	show: false,
-	loading: false,
-	slug: "",
-	page: null,
-	editing: false,
-	editBody: "",
-	saving: false,
-	archiving: false,
-})
 
 const wordCount = computed(() => draft.value.trim().split(/\s+/).filter(Boolean).length)
-const wikiBodyHtml = computed(() =>
-	wikiDialog.page && wikiDialog.page.body_md ? renderMarkdown(wikiDialog.page.body_md) : ""
-)
-
-// list rows carry whichever recency field the server includes — be defensive
-function wikiUpdated(row) {
-	return row.modified || row.last_confirmed_at || row.creation || ""
-}
 
 // ── loaders ──────────────────────────────────────────────────────────────────
 async function loadStatus() {
@@ -480,7 +276,6 @@ async function loadStatus() {
 		status.last_process_status = st.last_process_status || ""
 		status.can_process = !!st.can_process
 		status.loaded = true
-		if (status.can_process && !wiki.loadedOnce) fetchWiki("reset")
 	} catch (e) {
 		// parent mounts this only after the same probe succeeded; a failure here
 		// is transient — the page stays usable (textarea + notes still load)
@@ -507,32 +302,9 @@ async function fetchNotes(mode = "reset") {
 	}
 }
 
-async function fetchWiki(mode = "reset") {
-	const append = mode === "more"
-	wiki.loading = true
-	wiki.loadedOnce = true
-	try {
-		const res = await listWikiPagesPage({
-			search: wikiSearch.value,
-			page_type: wikiType.value,
-			start: append ? wiki.rows.length : 0,
-			page_length: 20,
-		})
-		const rows = res.rows || []
-		wiki.rows = append ? [...wiki.rows, ...rows] : rows
-		wiki.total = res.total || 0
-		wiki.hasMore = !!res.has_more
-	} catch (e) {
-		toast.error(errMsg(e))
-	} finally {
-		wiki.loading = false
-	}
-}
-
 function reloadAll() {
 	loadStatus()
 	fetchNotes("reset")
-	if (status.can_process) fetchWiki("reset")
 }
 
 // ── note capture ─────────────────────────────────────────────────────────────
@@ -632,74 +404,10 @@ function processNow() {
 	})
 }
 
-// ── org wiki (SM) ────────────────────────────────────────────────────────────
-function setWikiSearch(v) {
-	wikiSearch.value = v
-	clearTimeout(searchTimer)
-	searchTimer = setTimeout(() => fetchWiki("reset"), 300)
-}
-function setWikiType(v) {
-	if (wikiType.value === v) return
-	wikiType.value = v
-	fetchWiki("reset")
-}
-
-async function openWikiPage(row) {
-	wikiDialog.slug = row.slug || row.name
-	wikiDialog.page = null
-	wikiDialog.editing = false
-	wikiDialog.loading = true
-	wikiDialog.show = true
-	try {
-		wikiDialog.page = await getWikiPage(wikiDialog.slug)
-	} catch (e) {
-		wikiDialog.show = false
-		toast.error(errMsg(e))
-	} finally {
-		wikiDialog.loading = false
-	}
-}
-
-function startWikiEdit() {
-	wikiDialog.editBody = (wikiDialog.page && wikiDialog.page.body_md) || ""
-	wikiDialog.editing = true
-}
-
-async function saveWikiEdit() {
-	wikiDialog.saving = true
-	try {
-		await saveWikiPage(wikiDialog.slug, { body_md: wikiDialog.editBody })
-		if (wikiDialog.page) wikiDialog.page.body_md = wikiDialog.editBody
-		wikiDialog.editing = false
-		toast.success("Page saved")
-		fetchWiki("reset")
-	} catch (e) {
-		toast.error(errMsg(e))
-	} finally {
-		wikiDialog.saving = false
-	}
-}
-
-function confirmArchiveWiki() {
-	confirmDialog({
-		title: "Archive this page?",
-		message:
-			"Archived pages stop appearing in this list and are no longer used as chat context. The record is kept.",
-		onConfirm: async ({ hideDialog }) => {
-			wikiDialog.archiving = true
-			try {
-				await archiveWikiPage(wikiDialog.slug)
-				hideDialog()
-				wikiDialog.show = false
-				toast.success("Page archived")
-				fetchWiki("reset")
-			} catch (e) {
-				toast.error(errMsg(e))
-			} finally {
-				wikiDialog.archiving = false
-			}
-		},
-	})
+// ── org wiki pointer ─────────────────────────────────────────────────────────
+function goToWiki() {
+	// hash swap on the same /skills route — SkillsPage's hash watcher flips the tab
+	router.push({ hash: "#wiki" })
 }
 
 // ── init ─────────────────────────────────────────────────────────────────────
@@ -707,5 +415,4 @@ onMounted(() => {
 	loadStatus()
 	fetchNotes("reset")
 })
-onBeforeUnmount(() => clearTimeout(searchTimer))
 </script>

--- a/frontend/src/pages/skills/BusinessTab.vue
+++ b/frontend/src/pages/skills/BusinessTab.vue
@@ -82,7 +82,15 @@
 				<section class="rounded-lg border p-4">
 					<div class="text-base font-semibold text-ink-gray-9">My notes</div>
 					<div class="mt-0.5 text-sm text-ink-gray-6">
-						Notes you've saved. Processed daily — proposals show up on the Learning tab.
+						<!-- the Learning tab is SM-only; pointing everyone at it is a dead end -->
+						<template v-if="status.can_process">
+							Notes you've saved. Usually processed within a day — proposals show up
+							on the Learning tab; wiki context may update sooner.
+						</template>
+						<template v-else>
+							Notes you've saved. Jarvis usually works them into its org knowledge
+							within a day — wiki pages may update sooner.
+						</template>
 					</div>
 
 					<div v-if="notes.loading && !notes.rows.length" class="py-8 text-center">
@@ -146,7 +154,8 @@
 					<div class="text-base font-semibold text-ink-gray-9">Processing</div>
 					<div class="mt-0.5 text-sm text-ink-gray-6">
 						Voice notes across the org are processed once a day into Learning proposals and
-						wiki updates.
+						wiki updates. Notes in any language are stored per the org's knowledge
+						language (set in the Wiki tab settings).
 					</div>
 
 					<div class="mt-3 flex flex-col gap-1.5 text-sm">
@@ -184,9 +193,9 @@
 				<section class="rounded-lg border p-4">
 					<div class="flex flex-wrap items-center justify-between gap-3">
 						<div class="min-w-0">
-							<div class="text-base font-semibold text-ink-gray-9">Org wiki has moved</div>
+							<div class="text-base font-semibold text-ink-gray-9">Browse the org wiki</div>
 							<div class="mt-0.5 text-sm text-ink-gray-6">
-								Browse and edit the pages Jarvis keeps about your business on the Wiki tab.
+								The pages Jarvis keeps about your business live on the Wiki tab.
 							</div>
 						</div>
 						<Button variant="subtle" label="Go to Wiki" iconLeft="book-open" @click="goToWiki" />

--- a/frontend/src/pages/skills/LearningTab.vue
+++ b/frontend/src/pages/skills/LearningTab.vue
@@ -504,7 +504,9 @@
 										/>
 									</template>
 									<!-- B/C: insight-only in Phase 1 (never compiled/pushed), so
-									     Acknowledge (records reviewed) replaces Approve. -->
+									     Acknowledge (records reviewed) replaces Approve. "Apply to
+									     skill…" (D5) folds the insight into an org custom skill via
+									     an LLM-drafted, SM-confirmed update instead. -->
 									<template v-else>
 										<Button
 											variant="subtle"
@@ -512,6 +514,12 @@
 											:loading="acting === row.name"
 											:disabled="!!acting"
 											@click="doAcknowledge(row)"
+										/>
+										<Button
+											variant="subtle"
+											label="Apply to skill…"
+											:disabled="!!acting"
+											@click="openInsightApply(row)"
 										/>
 										<Dropdown
 											v-if="row.status === 'Proposed'"
@@ -685,6 +693,16 @@
 				</div>
 			</template>
 		</Dialog>
+
+		<!-- Apply-insight-to-skill modal (D5): self-contained — drafts an LLM
+		     skill update for a B/C insight and applies it on confirm (the server
+		     marks the pattern acknowledged with an applied-to-skill note); the
+		     board only opens it and refreshes on completion. -->
+		<InsightApplyDialog
+			v-model="insightApplyDialog.show"
+			:pattern="insightApplyDialog.row || {}"
+			@applied="afterAction"
+		/>
 	</div>
 </template>
 
@@ -716,6 +734,7 @@ import {
 } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import SyncPill from "./SyncPill.vue"
+import InsightApplyDialog from "@/components/learning/InsightApplyDialog.vue"
 import { timeAgo, exactDate } from "@/utils/datetime"
 import {
 	listLearnedPatternsPage,
@@ -826,6 +845,7 @@ const activeChatCount = ref(null)
 const rejectDialog = reactive({ show: false, name: "", reason: "" })
 const editDialog = reactive({ show: false, name: "", draft: "" })
 const applyDialog = reactive({ show: false })
+const insightApplyDialog = reactive({ show: false, row: null })
 
 // ── display helpers ──────────────────────────────────────────────────────────
 function domainLabel(s) {
@@ -1142,6 +1162,14 @@ async function submitReject() {
 	} finally {
 		acting.value = ""
 	}
+}
+
+// insight → skill modal (D5): the dialog drafts, confirms and applies on its
+// own (incl. the "Acknowledge instead" shortcut); @applied → afterAction so
+// the board refetches and the parent badge updates.
+function openInsightApply(row) {
+	insightApplyDialog.row = row
+	insightApplyDialog.show = true
 }
 
 // edit-then-approve modal

--- a/frontend/src/pages/skills/LearningTab.vue
+++ b/frontend/src/pages/skills/LearningTab.vue
@@ -84,7 +84,7 @@
 						/>
 						<Button
 							variant="subtle"
-							label="Run first analysis now"
+							:label="status.latestRun ? 'Run analysis now' : 'Run first analysis now'"
 							iconLeft="play"
 							:loading="runningNow"
 							@click="runNow"
@@ -175,7 +175,8 @@
 						v-if="reviewActivity.total"
 						class="text-sm text-ink-gray-5"
 					>
-						{{ reviewActivity.decided }} of {{ reviewActivity.total }} decided<template
+						{{ reviewActivity.decided }} of {{ reviewActivity.total }} surfaced
+						proposals decided<template
 							v-if="reviewActivity.last_by_name"
 						>
 							· last by {{ reviewActivity.last_by_name }}</template
@@ -260,7 +261,13 @@
 									:label="sensBadge(row).label"
 								/>
 								<Badge
-									v-if="isAcknowledged(row)"
+									v-if="appliedSkill(row)"
+									variant="subtle"
+									theme="green"
+									:label="`Applied to skill: ${appliedSkill(row)}`"
+								/>
+								<Badge
+									v-else-if="isAcknowledged(row)"
 									variant="subtle"
 									theme="gray"
 									label="Acknowledged"
@@ -326,8 +333,10 @@
 							<!-- B-class exact-text disclosure banner (plan §6.6): learned skill
 							     files are bench-global, so role scoping steers activation but is
 							     not a confidentiality boundary. -->
+							<!-- shown only while the row is still decidable: on terminal rows
+							     the warning is wallpaper and trains banner blindness -->
 							<div
-								v-if="row.effective_sensitivity === 'B'"
+								v-if="row.effective_sensitivity === 'B' && ['Proposed', 'Stale', 'Snoozed'].includes(row.status)"
 								class="mt-2.5 flex items-start gap-2 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 							>
 								<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
@@ -358,8 +367,17 @@
 										{{ expanded[row.name].frozen_evidence_label }}
 									</div>
 
+									<!-- note-sourced insights have no table statistics; the zero
+									     grid reads as "no basis" when the basis is a voice note -->
+									<div
+										v-if="expanded[row.name].detector_id === 'voice-context'"
+										class="text-sm text-ink-gray-6"
+									>
+										From spoken or written business notes — table statistics don't
+										apply to this kind of insight.
+									</div>
 									<!-- raw stats -->
-									<div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm sm:grid-cols-3">
+									<div v-else class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm sm:grid-cols-3">
 										<div>
 											<span class="text-ink-gray-5">Confidence</span>
 											<span class="ml-1.5 text-ink-gray-8">{{ pct(expanded[row.name].confidence_pct) }}</span>
@@ -411,7 +429,9 @@
 
 									<!-- compiled bullet preview -->
 									<div v-if="expanded[row.name].compiled_preview" class="mt-3">
-										<div class="mb-1 text-sm text-ink-gray-5">Compiled rule</div>
+										<div class="mb-1 text-sm text-ink-gray-5">{{
+											row.effective_sensitivity === "A" ? "Compiled rule" : "Suggested instruction"
+										}}</div>
 										<pre
 											class="overflow-x-auto whitespace-pre-wrap rounded border bg-surface-gray-1 px-3 py-2 text-sm text-ink-gray-8"
 										>{{ expanded[row.name].compiled_preview }}</pre>
@@ -577,9 +597,13 @@
 
 					<div
 						v-if="boardStatus === 'Proposed' && queuedCount > 0"
-						class="text-sm text-ink-gray-5"
+						class="flex items-center gap-2 text-sm text-ink-gray-5"
 					>
-						{{ queuedCount }} more queued — not yet surfaced for review.
+						<span>
+							{{ queuedCount }} more queued — they surface after the next
+							analysis run.
+						</span>
+						<Button variant="ghost" label="Review them now" @click="setBoardStatus('All')" />
 					</div>
 				</section>
 			</div>
@@ -893,6 +917,15 @@ function bRoles(row) {
 function isAcknowledged(row) {
 	return (row.review_note || "") === ACK_NOTE
 }
+// Mirror learned_api.APPLIED_NOTE_PREFIX: an insight folded into a custom
+// skill is terminal-Rejected + this note; render the target, not "Rejected".
+const APPLIED_NOTE_PREFIX = "Acknowledged - applied to skill: "
+function appliedSkill(row) {
+	const note = row.review_note || ""
+	return note.startsWith(APPLIED_NOTE_PREFIX)
+		? note.slice(APPLIED_NOTE_PREFIX.length)
+		: ""
+}
 function pct(v) {
 	const n = Number(v || 0)
 	return `${Math.round(n * 10) / 10}%`
@@ -947,6 +980,8 @@ const emptyTitle = computed(() =>
 )
 const emptyDescription = computed(() => {
 	if (boardStatus.value === "Proposed") {
+		if (queuedCount.value > 0)
+			return `Nothing surfaced yet — ${queuedCount.value} queued. They surface after the next analysis run, or use "Review them now" below.`
 		return status.enabled
 			? "Proposals appear the morning after an analysis run."
 			: "Enable behavioural learning above, then run an analysis to see proposals."

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -41,6 +41,18 @@
 			<SyncPill ref="syncPill" class="mb-3" />
 		</template>
 
+		<template #cell-skill_name="{ row }">
+			<div class="flex items-center gap-2 overflow-hidden">
+				<div class="truncate text-base font-medium text-ink-gray-9">{{ row.skill_name }}</div>
+				<Tooltip
+					v-if="row.scope === 'Personal'"
+					text="Personal skill — only you; never pushed to the shared assistant"
+				>
+					<Badge variant="subtle" theme="green" label="Personal" />
+				</Tooltip>
+			</div>
+		</template>
+
 		<template #cell-owner_display="{ row }">
 			<div class="flex items-center gap-2 overflow-hidden">
 				<Avatar size="sm" :label="row.mine ? session.user || 'You' : row.shared_by || '?'" />
@@ -106,8 +118,10 @@ function errMsg(e) {
 }
 
 // ── list config ──────────────────────────────────────────────────────────────
-const SCOPE_OPTIONS = [
-	{ label: "All scopes", value: "" },
+// "Ownership", not "Scope": scope is the Org/Personal skill field (shown as a
+// badge on the Name column); this filter is about whose skills you're viewing.
+const OWNERSHIP_OPTIONS = [
+	{ label: "All skills", value: "" },
 	{ label: "Mine", value: "mine" },
 	{ label: "Shared with me", value: "shared" },
 ]
@@ -136,11 +150,11 @@ const columns = [
 // moves it onto the envelope's `search` param (§11 parity: skills search).
 const quickFilters = [
 	{ key: "search", label: "Search skills", type: "text" },
-	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
+	{ key: "scope", label: "Ownership", type: "select", options: OWNERSHIP_OPTIONS },
 	{ key: "enabled", label: "Status", type: "select", options: ENABLED_OPTIONS },
 ]
 const filterDefs = [
-	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
+	{ key: "scope", label: "Ownership", type: "select", options: OWNERSHIP_OPTIONS },
 	{ key: "enabled", label: "Status", type: "select", options: ENABLED_OPTIONS },
 	{ key: "user_invocable", label: "User invocable", type: "select", options: INVOCABLE_OPTIONS },
 ]

--- a/frontend/src/pages/skills/SkillsPage.vue
+++ b/frontend/src/pages/skills/SkillsPage.vue
@@ -1,8 +1,8 @@
 <template>
 	<div class="flex h-full flex-col overflow-hidden">
-		<!-- Tab strip renders for System Managers (Skills / Learning / Business)
-		     and for regular desk users who pass the Business probe (Skills /
-		     Business). Portal/guest-ish sessions that fail both probes see
+		<!-- Tab strip renders for System Managers (Skills / Learning / Business /
+		     Wiki) and for regular desk users who pass the Business probe (Skills /
+		     Business / Wiki). Portal/guest-ish sessions that fail both probes see
 		     exactly today's Skills list with no tab chrome (zero regression).
 		     The active tab stays "skills" until a probe lands, so SkillsList
 		     mounts once and is NOT remounted when the strip later appears —
@@ -23,6 +23,7 @@
 			class="min-h-0 flex-1"
 			@changed="refreshBadge"
 		/>
+		<WikiTab v-else-if="activeTab === 'wiki'" class="min-h-0 flex-1" />
 		<BusinessTab v-else class="min-h-0 flex-1" />
 	</div>
 </template>
@@ -32,17 +33,19 @@
 // wraps the existing Skills list in a hash-synced tab shell (mirrors the
 // Agents page). Tab "Skills" renders SkillsList.vue unchanged; tab "Learning"
 // (#learning) renders the pattern-learning review board + settings; tab
-// "Business" (#business) renders the voice-notes + org-wiki surface. Learning
-// is offered to System Managers only — get_learning_status is the SM probe
-// (it throws for everyone else). Business is offered to any desk user —
-// get_business_status is the probe (403s for portal users), so the strip
-// stays hidden for them and the page behaves exactly as before.
+// "Business" (#business) renders the voice-notes surface; tab "Wiki" (#wiki)
+// renders the scope-aware org wiki list. Learning is offered to System
+// Managers only — get_learning_status is the SM probe (it throws for everyone
+// else). Business and Wiki are offered to any desk user — get_business_status
+// is the probe (403s for portal users), so the strip stays hidden for them
+// and the page behaves exactly as before.
 import { ref, computed, onMounted, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import TabBar from "@/components/list/TabBar.vue"
 import SkillsList from "./SkillsList.vue"
 import LearningTab from "./LearningTab.vue"
 import BusinessTab from "./BusinessTab.vue"
+import WikiTab from "./WikiTab.vue"
 import { getLearningStatus, pendingLearnedCount } from "@/api/learning"
 import { getBusinessStatus } from "@/api/voice"
 
@@ -58,13 +61,19 @@ const tabs = computed(() => {
 	const t = [{ label: "Skills", value: "skills" }]
 	if (isSM.value)
 		t.push({ label: "Learning", value: "learning", count: learningPending.value || null })
-	if (isSM.value || businessAllowed.value) t.push({ label: "Business", value: "business" })
+	if (isSM.value || businessAllowed.value) {
+		// any desk user passes the Business probe — Wiki rides the same gate
+		// (no extra probe; portal/guest sessions never see the strip at all)
+		t.push({ label: "Business", value: "business" })
+		t.push({ label: "Wiki", value: "wiki" })
+	}
 	return t
 })
 
 // hash-synced tabs (Agents precedent; no hash = Skills). "#learning" only
-// resolves once we know the viewer is an SM and "#business" once a probe has
-// confirmed access — an unauthorized deep link falls back to the Skills tab.
+// resolves once we know the viewer is an SM, and "#business"/"#wiki" once a
+// probe has confirmed access — an unauthorized deep link falls back to the
+// Skills tab.
 // "#skills" is intentionally never used (the router keeps that legacy chat
 // deep-link mapping /jarvis/#skills → /skills untouched).
 function applyHash() {
@@ -72,12 +81,13 @@ function applyHash() {
 	if (h === "learning" && isSM.value) activeTab.value = "learning"
 	else if (h === "business" && (isSM.value || businessAllowed.value))
 		activeTab.value = "business"
+	else if (h === "wiki" && (isSM.value || businessAllowed.value)) activeTab.value = "wiki"
 	else activeTab.value = "skills"
 }
 function setTab(v) {
 	if (v === activeTab.value) return
 	if (v === "learning" && !isSM.value) return
-	if (v === "business" && !(isSM.value || businessAllowed.value)) return
+	if ((v === "business" || v === "wiki") && !(isSM.value || businessAllowed.value)) return
 	activeTab.value = v
 	router.push({ hash: v === "skills" ? "" : `#${v}` })
 }

--- a/frontend/src/pages/skills/SyncPill.vue
+++ b/frontend/src/pages/skills/SyncPill.vue
@@ -8,11 +8,18 @@
 				Applying skills…
 			</Badge>
 		</Tooltip>
-		<template v-else>
+		<!-- the failure + Retry belong to whoever can act on it; to everyone
+		     else an org-wide red "Apply failed" is an unfixable-looking error -->
+		<template v-else-if="isSM">
 			<Tooltip :text="failureReason || 'Applying skills to your assistant failed.'">
 				<Badge theme="red" variant="subtle" label="Apply failed" />
 			</Tooltip>
 			<Button variant="ghost" label="Retry" :loading="applying" @click="apply" />
+		</template>
+		<template v-else>
+			<Tooltip text="The last skills sync didn't complete. An administrator can retry it; your saved changes are safe.">
+				<Badge theme="orange" variant="subtle" label="Skills sync delayed" />
+			</Tooltip>
 		</template>
 	</div>
 </template>
@@ -38,6 +45,7 @@ function errMsg(e) {
 const status = ref("") // last_sync_status: "", "pending: …", "ok …", "failed: …"
 const pending = ref(false)
 const applying = ref(false)
+const isSM = !!window.is_system_manager
 
 const failed = computed(() => (status.value || "").startsWith("failed"))
 const failureReason = computed(() =>

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -46,7 +46,8 @@
 								@update:modelValue="changeLanguage"
 							/>
 							<p class="mt-1 text-p-sm text-ink-gray-5">
-								English translates non-English notes before they land in the wiki;
+								Applies org-wide: wiki pages, extracted business facts and
+								learned-skill drafts. English translates non-English input;
 								Original keeps the source's language.
 							</p>
 							<div class="mt-3 flex flex-col gap-2 border-t pt-3">
@@ -57,6 +58,16 @@
 									:loading="syncing"
 									@click="confirmSync"
 								/>
+								<p class="text-p-sm text-ink-gray-5">
+									<template v-if="caps.wiki_mirror_last_synced_at">
+										Last synced {{ timeAgo(caps.wiki_mirror_last_synced_at) }}<span
+											v-if="caps.wiki_mirror_last_sync_status"
+										>
+											— {{ caps.wiki_mirror_last_sync_status }}</span
+										>
+									</template>
+									<template v-else>Not synced yet.</template>
+								</p>
 								<Button
 									variant="subtle"
 									label="Run health check"
@@ -101,7 +112,7 @@
 			</template>
 
 			<template #cell-page_type="{ row }">
-				<Badge variant="outline" theme="gray" :label="row.page_type" />
+				<Badge variant="outline" theme="gray" :label="typeLabel(row.page_type)" />
 			</template>
 
 			<template #cell-scope="{ row }">
@@ -159,14 +170,17 @@
 						:modelValue="createDialog.scope"
 						@update:modelValue="(v) => (createDialog.scope = v)"
 					/>
-					<FormControl
-						v-if="createDialog.scope === 'Role'"
-						type="select"
-						label="Role"
-						:options="roleSelectOptions"
-						:modelValue="createDialog.target_role"
-						@update:modelValue="(v) => (createDialog.target_role = v)"
-					/>
+					<div v-if="createDialog.scope === 'Role'" class="flex flex-col gap-1">
+						<span class="block text-xs text-ink-gray-5">Role</span>
+						<!-- Autocomplete: SMs see every targetable role (~dozens);
+						     a plain select is unusable at that size -->
+						<Autocomplete
+							placeholder="Search roles"
+							:options="roleSelectOptions"
+							:modelValue="createDialog.target_role"
+							@update:modelValue="(v) => (createDialog.target_role = (v && v.value) || '')"
+						/>
+					</div>
 					<FormControl
 						type="textarea"
 						label="Summary (optional)"
@@ -175,21 +189,34 @@
 						:modelValue="createDialog.summary"
 						@update:modelValue="(v) => (createDialog.summary = v)"
 					/>
+					<FormControl
+						type="textarea"
+						label="Content (markdown, optional)"
+						:rows="5"
+						placeholder="What should this page say? You can also add content later."
+						:modelValue="createDialog.body_md"
+						@update:modelValue="(v) => (createDialog.body_md = v)"
+					/>
 					<p v-if="slugPreview" class="text-p-sm text-ink-gray-5">
 						Page id: {{ slugPreview }}
 					</p>
 				</div>
 			</template>
 			<template #actions>
-				<div class="flex items-center gap-2">
-					<Button
-						variant="solid"
-						label="Create"
-						:loading="createDialog.saving"
-						:disabled="!canCreate"
-						@click="doCreate"
-					/>
-					<Button label="Cancel" @click="createDialog.show = false" />
+				<div class="flex flex-col gap-1.5">
+					<div class="flex items-center gap-2">
+						<Button
+							variant="solid"
+							label="Create"
+							:loading="createDialog.saving"
+							:disabled="!canCreate"
+							@click="doCreate"
+						/>
+						<Button label="Cancel" @click="createDialog.show = false" />
+					</div>
+					<p v-if="!canCreate && createMissing" class="text-p-sm text-ink-gray-5">
+						{{ createMissing }}
+					</p>
 				</div>
 			</template>
 		</Dialog>
@@ -207,6 +234,7 @@
 // language, mirror sync, health check).
 import { reactive, ref, computed, onMounted } from "vue"
 import {
+	Autocomplete,
 	Badge,
 	Button,
 	Dialog,
@@ -216,6 +244,7 @@ import {
 	toast,
 	confirmDialog,
 } from "frappe-ui"
+import { sessionUser } from "@/data/session"
 import ListPage from "@/components/list/ListPage.vue"
 import WikiPageDialog from "@/components/wiki/WikiPageDialog.vue"
 import { useListPage } from "@/composables/useListPage"
@@ -247,11 +276,11 @@ const WIKI_TYPES = [
 ]
 const TYPE_OPTIONS = [
 	{ label: "All types", value: "" },
-	...WIKI_TYPES.map((t) => ({ label: t, value: t })),
+	...WIKI_TYPES.map((t) => ({ label: t === "Org" ? "Org notes" : t, value: t })),
 ]
 const TYPE_SELECT_OPTIONS = [
 	{ label: "Select a type", value: "" },
-	...WIKI_TYPES.map((t) => ({ label: t, value: t })),
+	...WIKI_TYPES.map((t) => ({ label: t === "Org" ? "Org notes" : t, value: t })),
 ]
 const SCOPE_THEME = { Org: "gray", Role: "blue", User: "green" }
 const SCOPE_OPTIONS = [
@@ -263,7 +292,14 @@ const SCOPE_OPTIONS = [
 const ATTENTION_OPTIONS = [
 	{ label: "All pages", value: "" },
 	{ label: "Needs attention", value: "1" },
+	{ label: "Archived", value: "archived" },
 ]
+// "Org" as a page TYPE collides visually with the "Org" scope badge one
+// column over; display it under a clearer name (stored value unchanged).
+const TYPE_LABELS = { Org: "Org notes" }
+function typeLabel(t) {
+	return TYPE_LABELS[t] || t
+}
 const LANGUAGE_OPTIONS = [
 	{ label: "English (recommended)", value: "English" },
 	{ label: "Original language", value: "Original" },
@@ -317,7 +353,8 @@ const {
 			search: f.search || p.search || "",
 			page_type: f.page_type || "",
 			scope_filter: f.scope || "all",
-			attention: f.attention ? 1 : 0,
+			attention: f.attention === "1" ? 1 : 0,
+			archived: f.attention === "archived" ? 1 : 0,
 			// kit sends a start offset; the endpoint takes a page number
 			page: Math.floor((p.start || 0) / pl) + 1,
 			page_length: pl,
@@ -327,6 +364,15 @@ const {
 })
 
 const emptyState = computed(() => {
+	if (filters.scope === "mine" && caps.creatable_scopes.includes("User"))
+		return {
+			icon: "book-open",
+			title: "No personal pages yet",
+			description:
+				'Personal pages are knowledge only you and Jarvis share — shortcuts, ' +
+				'preferences, your own working notes. Use "New page" and pick the ' +
+				'Personal scope to create your first one.',
+		}
 	if (Object.keys(filters).length)
 		return {
 			icon: "book-open",
@@ -358,6 +404,8 @@ const caps = reactive({
 	knowledge_language: "English",
 	wiki_lint_last_run_at: null,
 	wiki_lint_summary: "",
+	wiki_mirror_last_synced_at: null,
+	wiki_mirror_last_sync_status: "",
 })
 
 async function loadCaps() {
@@ -369,6 +417,8 @@ async function loadCaps() {
 		caps.knowledge_language = c.knowledge_language || "English"
 		caps.wiki_lint_last_run_at = c.wiki_lint_last_run_at || null
 		caps.wiki_lint_summary = c.wiki_lint_summary || ""
+		caps.wiki_mirror_last_synced_at = c.wiki_mirror_last_synced_at || null
+		caps.wiki_mirror_last_sync_status = c.wiki_mirror_last_sync_status || ""
 	} catch (e) {
 		// read-only view stays useful without caps (no create / SM chrome)
 	}
@@ -392,25 +442,33 @@ const createDialog = reactive({
 	scope: "Org",
 	target_role: "",
 	summary: "",
+	body_md: "",
 	saving: false,
 })
 
 const scopeSelectOptions = computed(() =>
 	(caps.creatable_scopes || []).map((s) => ({ label: SCOPE_LABELS[s] || s, value: s }))
 )
-const roleSelectOptions = computed(() => [
-	{ label: "Select a role", value: "" },
-	...(caps.manageable_roles || []).map((r) => ({ label: r, value: r })),
-])
-// Preview of the server-derived slug (`<type>--<scrubbed-title>`); the
-// controller suffixes non-Org slugs (--r-…/--u-…) so scopes never collide.
-const slugPreview = computed(() => {
-	const base = createDialog.title
+const roleSelectOptions = computed(() =>
+	(caps.manageable_roles || []).map((r) => ({ label: r, value: r }))
+)
+// Preview of the server-derived slug (`<type>--<scrubbed-title>` plus the
+// controller's audience suffix for non-Org scopes) — mirror it fully so the
+// preview never lies about the final page id.
+const scrub = (s) =>
+	String(s || "")
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-+|-+$/g, "")
+const slugPreview = computed(() => {
+	const base = scrub(createDialog.title)
 	if (!base || !createDialog.page_type) return ""
-	return `${createDialog.page_type.toLowerCase()}--${base}`
+	let slug = `${createDialog.page_type.toLowerCase()}--${base}`
+	if (createDialog.scope === "User")
+		slug += `--u-${scrub(String(sessionUser() || "").split("@")[0]) || "me"}`
+	else if (createDialog.scope === "Role" && createDialog.target_role)
+		slug += `--r-${scrub(createDialog.target_role)}`
+	return slug
 })
 const canCreate = computed(
 	() =>
@@ -419,6 +477,13 @@ const canCreate = computed(
 		!!createDialog.scope &&
 		(createDialog.scope !== "Role" || !!createDialog.target_role)
 )
+const createMissing = computed(() => {
+	const missing = []
+	if (!createDialog.title.trim()) missing.push("a title")
+	if (!createDialog.page_type) missing.push("a type")
+	if (createDialog.scope === "Role" && !createDialog.target_role) missing.push("a role")
+	return missing.length ? `Still needed: ${missing.join(", ")}.` : ""
+})
 
 function openCreate() {
 	createDialog.title = ""
@@ -426,6 +491,7 @@ function openCreate() {
 	createDialog.scope = caps.creatable_scopes[0] || "Org"
 	createDialog.target_role = ""
 	createDialog.summary = ""
+	createDialog.body_md = ""
 	createDialog.show = true
 }
 
@@ -438,6 +504,7 @@ async function doCreate() {
 			scope: createDialog.scope,
 			target_role: createDialog.scope === "Role" ? createDialog.target_role : "",
 			summary: createDialog.summary,
+			body_md: createDialog.body_md,
 		})
 		if (res && res.ok === false) {
 			toast.error(res.reason || "Could not create the page.")

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -1,0 +1,522 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<ListPage
+			:breadcrumbs="[
+				{ label: 'Skills', route: { name: 'SkillsList' } },
+				{ label: 'Wiki' },
+			]"
+			:columns="columns"
+			:rows="rows"
+			row-key="name"
+			:loading="loading"
+			:error="error"
+			:total="total"
+			:has-more="hasMore"
+			:quick-filters="quickFilters"
+			:filter-defs="filterDefs"
+			:filters="filters"
+			:page-length="pageLength"
+			:on-row-click="openRow"
+			storage-key="wiki"
+			:empty-state="emptyState"
+			@update:filters="setFilters"
+			@update:page-length="(v) => (pageLength = v)"
+			@load-more="loadMore"
+			@refresh="resetLoad"
+		>
+			<template #right-header>
+				<!-- SM extras: knowledge language + mirror sync + health check -->
+				<Popover v-if="caps.is_sm" placement="bottom-end">
+					<template #target="{ togglePopover }">
+						<Button
+							icon="settings"
+							:tooltip="'Wiki settings'"
+							@click="togglePopover()"
+						/>
+					</template>
+					<template #body>
+						<div
+							class="my-2 w-[320px] rounded-lg bg-surface-modal p-3 shadow-2xl ring-1 ring-black ring-opacity-5"
+						>
+							<FormControl
+								type="select"
+								label="Knowledge language"
+								:options="LANGUAGE_OPTIONS"
+								:modelValue="caps.knowledge_language"
+								@update:modelValue="changeLanguage"
+							/>
+							<p class="mt-1 text-p-sm text-ink-gray-5">
+								English translates non-English notes before they land in the wiki;
+								Original keeps the source's language.
+							</p>
+							<div class="mt-3 flex flex-col gap-2 border-t pt-3">
+								<Button
+									variant="subtle"
+									label="Sync to agent now"
+									iconLeft="upload-cloud"
+									:loading="syncing"
+									@click="confirmSync"
+								/>
+								<Button
+									variant="subtle"
+									label="Run health check"
+									iconLeft="activity"
+									:loading="linting"
+									@click="confirmLint"
+								/>
+							</div>
+							<p class="mt-2 text-p-sm text-ink-gray-5">
+								<template v-if="caps.wiki_lint_last_run_at">
+									Last health check {{ timeAgo(caps.wiki_lint_last_run_at) }}<span
+										v-if="caps.wiki_lint_summary"
+									>
+										— {{ caps.wiki_lint_summary }}</span
+									>
+								</template>
+								<template v-else>Health check hasn't run yet.</template>
+							</p>
+						</div>
+					</template>
+				</Popover>
+				<Button
+					v-if="caps.creatable_scopes.length"
+					variant="solid"
+					label="New page"
+					iconLeft="plus"
+					@click="openCreate"
+				/>
+			</template>
+
+			<template #cell-title="{ row }">
+				<div class="flex items-center gap-2 overflow-hidden">
+					<div class="truncate text-base">{{ row.title || row.slug }}</div>
+					<Badge
+						v-if="row.contradiction_flag"
+						variant="subtle"
+						theme="red"
+						label="Conflicting"
+					/>
+					<Badge v-if="row.stale" variant="subtle" theme="orange" label="Stale" />
+				</div>
+			</template>
+
+			<template #cell-page_type="{ row }">
+				<Badge variant="outline" theme="gray" :label="row.page_type" />
+			</template>
+
+			<template #cell-scope="{ row }">
+				<Tooltip :text="scopeTooltip(row)">
+					<Badge
+						variant="subtle"
+						:theme="SCOPE_THEME[row.scope] || 'gray'"
+						:label="row.scope || 'Org'"
+					/>
+				</Tooltip>
+			</template>
+
+			<template #cell-summary="{ row }">
+				<div class="truncate text-base text-ink-gray-6">{{ row.summary }}</div>
+			</template>
+
+			<template #cell-modified="{ row }">
+				<div class="flex w-full items-center justify-end">
+					<Tooltip :text="exactDate(row.modified)">
+						<div class="truncate text-base">{{ timeAgo(row.modified) }}</div>
+					</Tooltip>
+				</div>
+			</template>
+		</ListPage>
+
+		<WikiPageDialog
+			v-model="pageDialog.show"
+			:slug="pageDialog.slug"
+			@refresh="refreshKeep"
+		/>
+
+		<!-- New page dialog: scope options limited to what the caller may create;
+		     the server derives (and suffixes) the slug from type + title -->
+		<Dialog v-model="createDialog.show" :options="{ title: 'New wiki page', size: 'md' }">
+			<template #body-content>
+				<div class="flex flex-col gap-3">
+					<FormControl
+						type="text"
+						label="Title"
+						placeholder="e.g. Acme Industries payment terms"
+						:modelValue="createDialog.title"
+						@update:modelValue="(v) => (createDialog.title = v)"
+					/>
+					<FormControl
+						type="select"
+						label="Type"
+						:options="TYPE_SELECT_OPTIONS"
+						:modelValue="createDialog.page_type"
+						@update:modelValue="(v) => (createDialog.page_type = v)"
+					/>
+					<FormControl
+						type="select"
+						label="Scope"
+						:options="scopeSelectOptions"
+						:modelValue="createDialog.scope"
+						@update:modelValue="(v) => (createDialog.scope = v)"
+					/>
+					<FormControl
+						v-if="createDialog.scope === 'Role'"
+						type="select"
+						label="Role"
+						:options="roleSelectOptions"
+						:modelValue="createDialog.target_role"
+						@update:modelValue="(v) => (createDialog.target_role = v)"
+					/>
+					<FormControl
+						type="textarea"
+						label="Summary (optional)"
+						:rows="2"
+						placeholder="One or two lines Jarvis can cite in chat context"
+						:modelValue="createDialog.summary"
+						@update:modelValue="(v) => (createDialog.summary = v)"
+					/>
+					<p v-if="slugPreview" class="text-p-sm text-ink-gray-5">
+						Page id: {{ slugPreview }}
+					</p>
+				</div>
+			</template>
+			<template #actions>
+				<div class="flex items-center gap-2">
+					<Button
+						variant="solid"
+						label="Create"
+						:loading="createDialog.saving"
+						:disabled="!canCreate"
+						@click="doCreate"
+					/>
+					<Button label="Cancel" @click="createDialog.show = false" />
+				</div>
+			</template>
+		</Dialog>
+	</div>
+</template>
+
+<script setup>
+// WikiTab — the "Wiki" tab inside the Skills page (design D4): the org-wide
+// knowledge base Jarvis maintains, now scope-aware (Org / Role / User pages,
+// server-side visibility). Standard ListPage + useListPage kit (FilesList
+// precedent): server pagination, debounced search, scope / type / attention
+// quick filters. Rows open WikiPageDialog (view/edit/archive gated by the
+// server's can_edit/can_archive flags); "New page" shows for anyone whose
+// creatable_scopes isn't empty; SMs also get the settings popover (knowledge
+// language, mirror sync, health check).
+import { reactive, ref, computed, onMounted } from "vue"
+import {
+	Badge,
+	Button,
+	Dialog,
+	FormControl,
+	Popover,
+	Tooltip,
+	toast,
+	confirmDialog,
+} from "frappe-ui"
+import ListPage from "@/components/list/ListPage.vue"
+import WikiPageDialog from "@/components/wiki/WikiPageDialog.vue"
+import { useListPage } from "@/composables/useListPage"
+import { timeAgo, exactDate } from "@/utils/datetime"
+import {
+	listWikiPagesPage,
+	getWikiCaps,
+	createWikiPage,
+	setKnowledgeLanguage,
+	syncWikiMirrorNow,
+	runWikiLintNow,
+} from "@/api/wiki"
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+// ── static config ────────────────────────────────────────────────────────────
+const WIKI_TYPES = [
+	"Customer",
+	"Supplier",
+	"Item",
+	"Process",
+	"Doctype",
+	"Exception",
+	"Integration",
+	"People",
+	"Org",
+]
+const TYPE_OPTIONS = [
+	{ label: "All types", value: "" },
+	...WIKI_TYPES.map((t) => ({ label: t, value: t })),
+]
+const TYPE_SELECT_OPTIONS = [
+	{ label: "Select a type", value: "" },
+	...WIKI_TYPES.map((t) => ({ label: t, value: t })),
+]
+const SCOPE_THEME = { Org: "gray", Role: "blue", User: "green" }
+const SCOPE_OPTIONS = [
+	{ label: "All scopes", value: "" },
+	{ label: "Org", value: "org" },
+	{ label: "My role", value: "role" },
+	{ label: "Mine", value: "mine" },
+]
+const ATTENTION_OPTIONS = [
+	{ label: "All pages", value: "" },
+	{ label: "Needs attention", value: "1" },
+]
+const LANGUAGE_OPTIONS = [
+	{ label: "English (recommended)", value: "English" },
+	{ label: "Original language", value: "Original" },
+]
+const SCOPE_LABELS = {
+	Org: "Org — visible to everyone",
+	Role: "Role — people holding a role",
+	User: "Personal — just me",
+}
+
+const columns = [
+	{ label: "Title", key: "title", width: 3 },
+	{ label: "Type", key: "page_type", width: "8rem" },
+	{ label: "Scope", key: "scope", width: "6rem" },
+	{ label: "Summary", key: "summary", width: 4 },
+	{ label: "Updated", key: "modified", width: "8rem", align: "right" },
+]
+// search rides the quick-filter strip (FilesList precedent): it lives in the
+// filters object so the input stays controlled, and fetchFn moves it onto the
+// endpoint's `search` kwarg.
+const quickFilters = [
+	{ key: "search", label: "Search pages", type: "text" },
+	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
+	{ key: "page_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+	{ key: "attention", label: "Attention", type: "select", options: ATTENTION_OPTIONS },
+]
+const filterDefs = [
+	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
+	{ key: "page_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+	{ key: "attention", label: "Attention", type: "select", options: ATTENTION_OPTIONS },
+]
+
+// ── list state (server envelope; endpoint paginates by page number) ──────────
+const {
+	rows,
+	total,
+	hasMore,
+	loading,
+	error,
+	filters,
+	setFilters,
+	pageLength,
+	resetLoad,
+	loadMore,
+	refreshKeep,
+} = useListPage({
+	fetchFn: (p) => {
+		const f = p.filters || {}
+		const pl = p.page_length || 20
+		return listWikiPagesPage({
+			search: f.search || p.search || "",
+			page_type: f.page_type || "",
+			scope_filter: f.scope || "all",
+			attention: f.attention ? 1 : 0,
+			// kit sends a start offset; the endpoint takes a page number
+			page: Math.floor((p.start || 0) / pl) + 1,
+			page_length: pl,
+		})
+	},
+	storageKey: "wiki",
+})
+
+const emptyState = computed(() => {
+	if (Object.keys(filters).length)
+		return {
+			icon: "book-open",
+			title: "No pages match",
+			description: "Try a different search, scope or type filter.",
+		}
+	return {
+		icon: "book-open",
+		title: "No wiki pages yet",
+		description:
+			"The wiki is the knowledge base Jarvis keeps about your business — customers, " +
+			"suppliers, items and processes. It grows on its own as people answer chat " +
+			"nudges and record voice notes on the Business tab; pages appear here as " +
+			"Jarvis learns.",
+	}
+})
+
+function scopeTooltip(row) {
+	if (row.scope === "Role") return `Visible to people with role: ${row.target_role || "—"}`
+	if (row.scope === "User") return `Personal page — visible only to ${row.target_user || "its owner"}`
+	return "Visible to everyone"
+}
+
+// ── caps (creatable scopes + SM header extras) ───────────────────────────────
+const caps = reactive({
+	is_sm: false,
+	creatable_scopes: [],
+	manageable_roles: [],
+	knowledge_language: "English",
+	wiki_lint_last_run_at: null,
+	wiki_lint_summary: "",
+})
+
+async function loadCaps() {
+	try {
+		const c = await getWikiCaps()
+		caps.is_sm = !!c.is_sm
+		caps.creatable_scopes = c.creatable_scopes || []
+		caps.manageable_roles = c.manageable_roles || []
+		caps.knowledge_language = c.knowledge_language || "English"
+		caps.wiki_lint_last_run_at = c.wiki_lint_last_run_at || null
+		caps.wiki_lint_summary = c.wiki_lint_summary || ""
+	} catch (e) {
+		// read-only view stays useful without caps (no create / SM chrome)
+	}
+}
+
+// ── page viewer dialog ───────────────────────────────────────────────────────
+const pageDialog = reactive({ show: false, slug: "" })
+function openRow(row) {
+	openPage(row.slug || row.name)
+}
+function openPage(slug) {
+	pageDialog.slug = slug
+	pageDialog.show = true
+}
+
+// ── create dialog ────────────────────────────────────────────────────────────
+const createDialog = reactive({
+	show: false,
+	title: "",
+	page_type: "",
+	scope: "Org",
+	target_role: "",
+	summary: "",
+	saving: false,
+})
+
+const scopeSelectOptions = computed(() =>
+	(caps.creatable_scopes || []).map((s) => ({ label: SCOPE_LABELS[s] || s, value: s }))
+)
+const roleSelectOptions = computed(() => [
+	{ label: "Select a role", value: "" },
+	...(caps.manageable_roles || []).map((r) => ({ label: r, value: r })),
+])
+// Preview of the server-derived slug (`<type>--<scrubbed-title>`); the
+// controller suffixes non-Org slugs (--r-…/--u-…) so scopes never collide.
+const slugPreview = computed(() => {
+	const base = createDialog.title
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+	if (!base || !createDialog.page_type) return ""
+	return `${createDialog.page_type.toLowerCase()}--${base}`
+})
+const canCreate = computed(
+	() =>
+		!!createDialog.title.trim() &&
+		!!createDialog.page_type &&
+		!!createDialog.scope &&
+		(createDialog.scope !== "Role" || !!createDialog.target_role)
+)
+
+function openCreate() {
+	createDialog.title = ""
+	createDialog.page_type = ""
+	createDialog.scope = caps.creatable_scopes[0] || "Org"
+	createDialog.target_role = ""
+	createDialog.summary = ""
+	createDialog.show = true
+}
+
+async function doCreate() {
+	createDialog.saving = true
+	try {
+		const res = await createWikiPage({
+			title: createDialog.title.trim(),
+			page_type: createDialog.page_type,
+			scope: createDialog.scope,
+			target_role: createDialog.scope === "Role" ? createDialog.target_role : "",
+			summary: createDialog.summary,
+		})
+		if (res && res.ok === false) {
+			toast.error(res.reason || "Could not create the page.")
+		} else {
+			createDialog.show = false
+			toast.success("Page created")
+			resetLoad()
+			openPage(res.slug)
+		}
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		createDialog.saving = false
+	}
+}
+
+// ── SM extras (settings popover) ─────────────────────────────────────────────
+const syncing = ref(false)
+const linting = ref(false)
+
+async function changeLanguage(v) {
+	if (!v || v === caps.knowledge_language) return
+	const previous = caps.knowledge_language
+	try {
+		await setKnowledgeLanguage(v)
+		caps.knowledge_language = v
+		toast.success(`Knowledge language set to ${v}`)
+	} catch (e) {
+		caps.knowledge_language = previous
+		toast.error(errMsg(e))
+	}
+}
+
+function confirmSync() {
+	confirmDialog({
+		title: "Sync wiki to agent now?",
+		message:
+			"Pushes every active org-scope page into the agent's workspace mirror now, " +
+			"instead of waiting for the next change or the daily sync.",
+		onConfirm: async ({ hideDialog }) => {
+			syncing.value = true
+			try {
+				const r = await syncWikiMirrorNow()
+				hideDialog()
+				if (r && r.ok === false) toast.error(r.reason || "Could not queue the sync.")
+				else toast.success("Sync queued")
+			} catch (e) {
+				toast.error(errMsg(e))
+			} finally {
+				syncing.value = false
+			}
+		},
+	})
+}
+
+function confirmLint() {
+	confirmDialog({
+		title: "Run wiki health check?",
+		message:
+			"Scans active pages for contradictions, stale content, orphans and " +
+			"near-duplicate titles, and flags pages needing attention. May take a moment.",
+		onConfirm: async ({ hideDialog }) => {
+			linting.value = true
+			try {
+				const r = await runWikiLintNow()
+				hideDialog()
+				if (r && r.ok === false) toast.error(r.reason || "Could not run the health check.")
+				else toast.success("Health check finished")
+				loadCaps()
+				refreshKeep()
+			} catch (e) {
+				toast.error(errMsg(e))
+			} finally {
+				linting.value = false
+			}
+		},
+	})
+}
+
+// ── init ─────────────────────────────────────────────────────────────────────
+onMounted(loadCaps)
+</script>

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -98,6 +98,16 @@
 				/>
 			</template>
 
+			<!-- persistent orientation: the teaching copy otherwise lives only in
+			     the empty state, which real first-visits on a grown wiki never see -->
+			<template #banner>
+				<p class="mb-2 text-p-sm text-ink-gray-5">
+					The wiki is the knowledge Jarvis keeps about your business — customers,
+					suppliers, processes, conventions. It grows from chat and voice notes;
+					Jarvis cites it when answering.
+				</p>
+			</template>
+
 			<template #cell-title="{ row }">
 				<div class="flex items-center gap-2 overflow-hidden">
 					<div class="truncate text-base">{{ row.title || row.slug }}</div>
@@ -156,13 +166,18 @@
 						:modelValue="createDialog.title"
 						@update:modelValue="(v) => (createDialog.title = v)"
 					/>
-					<FormControl
-						type="select"
-						label="Type"
-						:options="TYPE_SELECT_OPTIONS"
-						:modelValue="createDialog.page_type"
-						@update:modelValue="(v) => (createDialog.page_type = v)"
-					/>
+					<div class="flex flex-col gap-1">
+						<FormControl
+							type="select"
+							label="Type"
+							:options="TYPE_SELECT_OPTIONS"
+							:modelValue="createDialog.page_type"
+							@update:modelValue="(v) => (createDialog.page_type = v)"
+						/>
+						<p v-if="TYPE_HELP[createDialog.page_type]" class="text-p-sm text-ink-gray-5">
+							{{ TYPE_HELP[createDialog.page_type] }}
+						</p>
+					</div>
 					<FormControl
 						type="select"
 						label="Scope"
@@ -180,6 +195,10 @@
 							:modelValue="createDialog.target_role"
 							@update:modelValue="(v) => (createDialog.target_role = (v && v.value) || '')"
 						/>
+						<p v-if="!caps.is_sm" class="text-p-sm text-ink-gray-5">
+							You can share knowledge with roles you hold yourself; an
+							administrator can target any role.
+						</p>
 					</div>
 					<FormControl
 						type="textarea"
@@ -300,6 +319,18 @@ const TYPE_LABELS = { Org: "Org notes" }
 function typeLabel(t) {
 	return TYPE_LABELS[t] || t
 }
+// one-line explanations for the create dialog's Type select
+const TYPE_HELP = {
+	Customer: "One specific customer's quirks — payment habits, contacts, gotchas.",
+	Supplier: "One specific supplier's quirks — lead times, terms, who to call.",
+	Item: "One item or item group — variants, storage, known issues.",
+	Process: "A procedure as your org actually runs it — steps, owners, exceptions.",
+	Doctype: "Org-wide conventions on a document type, e.g. Sales Invoice habits.",
+	Exception: "A known edge case or standing workaround.",
+	Integration: "An external system your org connects to and its rules.",
+	People: "Who does what — approvers, escalation paths, contacts.",
+	Org: "General org-level facts that fit nowhere else.",
+}
 const LANGUAGE_OPTIONS = [
 	{ label: "English (recommended)", value: "English" },
 	{ label: "Original language", value: "Original" },
@@ -324,12 +355,13 @@ const quickFilters = [
 	{ key: "search", label: "Search pages", type: "text" },
 	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
 	{ key: "page_type", label: "Type", type: "select", options: TYPE_OPTIONS },
-	{ key: "attention", label: "Attention", type: "select", options: ATTENTION_OPTIONS },
+	// "View", not "Attention": it also carries the Archived lifecycle view
+	{ key: "attention", label: "View", type: "select", options: ATTENTION_OPTIONS },
 ]
 const filterDefs = [
 	{ key: "scope", label: "Scope", type: "select", options: SCOPE_OPTIONS },
 	{ key: "page_type", label: "Type", type: "select", options: TYPE_OPTIONS },
-	{ key: "attention", label: "Attention", type: "select", options: ATTENTION_OPTIONS },
+	{ key: "attention", label: "View", type: "select", options: ATTENTION_OPTIONS },
 ]
 
 // ── list state (server envelope; endpoint paginates by page number) ──────────

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -375,8 +375,11 @@
 								<button v-if="nudge.mode === 'transcribing'" class="jv-iconbtn jv-micbtn" title="Transcribing…" disabled style="width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:7px;color:var(--text-3);">
 									<svg class="jv-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--blue)" stroke-width="2.4" stroke-linecap="round"><path d="M12 3a9 9 0 1 0 9 9" /></svg>
 								</button>
-								<button v-else class="jv-iconbtn jv-micbtn" :class="{ rec: nudge.mode === 'recording' }" :title="nudge.mode === 'recording' ? 'Stop and transcribe' : 'Record a voice note'" @click="nudge.mode === 'recording' ? stopNudgeMic() : startNudgeMic()" style="width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:7px;cursor:pointer;color:var(--text-3);">
+								<!-- labeled, unlike the composer's dictate mic 40px below — two
+								     identical icon-only mics were indistinguishable at a glance -->
+								<button v-else class="jv-iconbtn jv-micbtn" :class="{ rec: nudge.mode === 'recording' }" :title="nudge.mode === 'recording' ? 'Stop and transcribe' : 'Record a voice note (saved for Jarvis to learn from)'" @click="nudge.mode === 'recording' ? stopNudgeMic() : startNudgeMic()" style="height:28px;display:flex;align-items:center;justify-content:center;gap:5px;background:transparent;border:none;border-radius:7px;cursor:pointer;color:var(--text-3);padding:0 8px;font-size:12.5px;font-weight:600;">
 									<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" /><path d="M19 10v2a7 7 0 0 1-14 0v-2" /><path d="M12 19v3" /></svg>
+									<span v-if="nudge.mode !== 'recording'">Record answer</span>
 								</button>
 								<template v-if="nudge.mode === 'recording'">
 									<span class="jv-mic-live"><span class="jv-mic-dot"></span>{{ nudgeClock }}</span>
@@ -3366,6 +3369,9 @@ function dismissNudge() {
 	nudge.value = null
 	// Best-effort: the 7-day server-side snooze shouldn't block hiding the card.
 	if (n) voice.dismissWikiNudge(n.conversationId).catch(() => {})
+	// the dismissal mutes a week of nudges here — say so, once, or users
+	// won't know they opted out
+	notify("Okay — won't ask again in this chat for a week.")
 }
 
 // ---- file input ----
@@ -3857,6 +3863,11 @@ function onGlobalKey(e) {
 /* markdown content → the imported design's table look */
 .jv-md :deep(.jv-md-p) { margin: 0 0 10px; }
 .jv-md :deep(.jv-md-p:last-child) { margin-bottom: 0; }
+.jv-md :deep(.jv-md-h) { margin: 14px 0 6px; font-weight: 600; color: var(--text); }
+.jv-md :deep(h3.jv-md-h) { font-size: 15px; }
+.jv-md :deep(h4.jv-md-h) { font-size: 14px; }
+.jv-md :deep(h5.jv-md-h), .jv-md :deep(h6.jv-md-h) { font-size: 13px; }
+.jv-md :deep(.jv-md-h:first-child) { margin-top: 0; }
 .jv-md :deep(.jv-md-list) { margin: 0 0 10px; padding-left: 20px; }
 .jv-md :deep(.jv-md-list li) { margin: 2px 0; }
 .jv-md :deep(.jv-md-code) { background: var(--surface-2); padding: 1px 5px; border-radius: 4px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -461,6 +461,41 @@ def post_push_learned_skills(learned_skills: list[dict]) -> dict:
 	)
 
 
+def push_wiki_files(files: list[dict], delete: list | None = None,
+					known_paths: list | None = None) -> dict | None:
+	"""POST one batch of rendered org-wiki mirror files to admin → fleet →
+	container workspace ``wiki/`` (wiki v2 mirror; see jarvis.chat.wiki_mirror).
+
+	``files``: ``[{path, content_b64}]`` with paths RELATIVE under the wiki
+	dir (e.g. ``customers/customer--acme.md``, ``index.md``); the caller keeps
+	each batch under the fleet-agent's 256KB body cap. ``delete``: relative
+	paths to remove. ``known_paths``: full-sync reconcile — fleet prunes wiki
+	files not in the list.
+
+	NO restart (the workspace is a live RW bind mount), so admin gives this
+	relay its OWN rate bucket — it never burns the rotate-secret 20/h bucket
+	the skill pushes share.
+
+	Returns the parsed response dict (``{ok, written, deleted, pruned}``) or
+	None on ANY failure: the mirror is a derived, rebuildable copy and the
+	sync must degrade to "retry next sync" — never raise into the wiki save
+	paths or the sync worker (which also means: no negative cache; the next
+	sync should probe again immediately).
+	"""
+	try:
+		return _post(
+			path="/api/method/jarvis_admin.api.tenant.post_push_wiki_files",
+			body={"files": files, "delete": delete, "known_paths": known_paths},
+			timeout_s=60,
+		)
+	except Exception:
+		frappe.log_error(
+			title="admin_client: push_wiki_files failed",
+			message=frappe.get_traceback(),
+		)
+		return None
+
+
 def get_generated_media(since_ms: int = 0) -> list[dict]:
 	"""Pull recent codex ``imagegen`` output for this customer's running tenant
 	container (admin → fleet → container disk). Returns a list of

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -228,7 +228,8 @@ def list_custom_skills_page(
 		f"SELECT COUNT(*) FROM `tabJarvis Custom Skill` WHERE {where}", params
 	)[0][0]
 	rows = frappe.db.sql(
-		f"""SELECT name, skill_name, description, user_invocable, enabled, modified, owner
+		f"""SELECT name, skill_name, description, user_invocable, enabled, modified, owner,
+			ifnull(scope, 'Org') AS scope
 		FROM `tabJarvis Custom Skill`
 		WHERE {where}
 		ORDER BY {order}

--- a/jarvis/chat/knowledge_language.py
+++ b/jarvis/chat/knowledge_language.py
@@ -1,0 +1,55 @@
+"""Org-wide knowledge-language preference (design D6).
+
+Reads the ``Jarvis Settings.knowledge_language`` Select ("English" default /
+"Original") and renders the prompt block every knowledge-WRITING LLM funnel
+appends to its system prompt: voice-fact extraction
+(``jarvis.learning.voice_facts``), wiki ingest (``jarvis.chat.wiki``) and the
+insight-to-skill drafts (``jarvis.chat.learned_api``). English mode translates
+non-English source material; Original keeps the source's dominant language.
+
+Chat STT transcription is deliberately NOT covered: a conversation transcript
+stays verbatim in the spoken language (conversation != knowledge store).
+
+The field is a Select, not a Check, so a plain ``get_single_value`` with an
+English fallback is safe on v16 (no tabSingles row-existence probe needed -
+that dance is only for Check fields whose unset value coerces to 0).
+"""
+
+from __future__ import annotations
+
+import frappe
+
+SETTINGS = "Jarvis Settings"
+
+DEFAULT_LANGUAGE = "English"
+_LANGUAGES = ("English", "Original")
+
+_ENGLISH_DIRECTIVE = (
+	"Write all output (facts, wiki content, skill text) in English; translate "
+	"source material when needed; keep proper nouns (party/item/person names) "
+	"in original script followed by a Latin transliteration in parentheses."
+)
+_ORIGINAL_DIRECTIVE = "Write output in the dominant language of the source material."
+
+
+def get_knowledge_language() -> str:
+	"""The org-wide knowledge language: "English" (default) or "Original".
+
+	Falsy or unknown stored values coalesce to English - Frappe never backfills
+	Single defaults, so a pre-existing Settings row reads null until the
+	``voice_facts.after_migrate`` seeding runs."""
+	try:
+		value = (frappe.db.get_single_value(SETTINGS, "knowledge_language") or "").strip()
+	except Exception:
+		# Consumers embed this inside job/endpoint prompt builders; a broken
+		# Settings read must never take the extraction down with it.
+		return DEFAULT_LANGUAGE
+	return value if value in _LANGUAGES else DEFAULT_LANGUAGE
+
+
+def language_directive() -> str:
+	"""The language prompt block (always non-empty) appended to the
+	knowledge-writing system prompts."""
+	if get_knowledge_language() == "Original":
+		return _ORIGINAL_DIRECTIVE
+	return _ENGLISH_DIRECTIVE

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -98,6 +98,10 @@ _CARD_FIELDS = [
 	"exception_n", "not_applicable", "draft_edited", "overlap_warning",
 	"status", "surfaced", "reviewed_by", "approved_by", "creation",
 	"stale_reason", "last_validated_at", "flags_count", "materialized_skill",
+	# review_note distinguishes Acknowledged / "applied to skill" terminal
+	# states from a plain Reject - without it the board's disposition
+	# badges can never fire and every terminal row reads "Rejected".
+	"review_note",
 ]
 
 # Correction loop (plan 6.5): note cap, the distinct-user demotion quorum, and

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -36,6 +36,7 @@ from frappe.utils import add_days, now_datetime, today
 JLP = "Jarvis Learned Pattern"
 RUN = "Jarvis Pattern Run"
 SETTINGS = "Jarvis Settings"
+SKILL = "Jarvis Custom Skill"
 
 _DOMAINS = ("selling", "buying", "stock", "accounts", "projects", "org")
 _STRENGTHS = ("High", "Medium", "Low")
@@ -73,6 +74,12 @@ _SETTINGS_DEFAULTS = {
 # the board renders it as "Acknowledged" (not a real rejection) by matching this
 # note. Keep the string stable - the frontend keys off it.
 ACK_NOTE = "Acknowledged - insight only"
+
+# Terminal disposition for a B/C insight the SM APPLIED into a custom skill
+# (design D5 "Apply to skill..."). Sibling of ACK_NOTE: stored as Rejected +
+# this prefix followed by the target skill's slug, with ``materialized_skill``
+# pointing at the skill row. Keep the prefix stable - the frontend keys off it.
+APPLIED_NOTE_PREFIX = "Acknowledged - applied to skill: "
 
 # Rendered on the board when an SM edited the draft before approving: the
 # evidence line is frozen (plan section 6.5) - it still reflects the ORIGINALLY
@@ -711,6 +718,449 @@ def polish_learned_draft(name: str) -> dict:
 	)
 	frappe.db.commit()
 	return {"ok": True, "text": out["text"]}
+
+
+# --------------------------------------------------------------------------- #
+# insight -> skill (design D5): fold a B/C insight into an org custom skill
+# --------------------------------------------------------------------------- #
+# B/C insights never compile into the pushed learned skills (compiler is
+# A-only), so their only Phase-1 disposition was Acknowledge. D5 adds an SM
+# action that drafts the insight INTO an org-scope custom skill (update an
+# existing one or create a new one) via ONE strict-JSON openrouter_complete
+# call, then applies it after human confirmation.
+
+# Statuses an insight may be applied from (Snoozed rides along: applying is a
+# stronger decision than the snooze it interrupts).
+_INSIGHT_APPLY_SOURCES = ("Proposed", "Stale", "Snoozed")
+# Candidate update-targets offered to the model, and the per-candidate
+# instructions excerpt / evidence tail that ride the prompt.
+_INSIGHT_TARGET_CAP = 5
+_INSIGHT_CANDIDATE_INSTR_CHARS = 2000
+_INSIGHT_EVIDENCE_TAIL_CHARS = 1500
+
+_INSIGHT_SKILL_SYSTEM = (
+	"You review one learned business insight and decide whether it is worth "
+	"folding into the org's custom assistant skills. Output ONLY a JSON object "
+	"- no prose, no markdown fences - with exactly these keys: "
+	'"worth_applying" (boolean), "reason" (one short sentence explaining the '
+	'verdict), "action" ("update" to fold the insight into one of the offered '
+	'candidate skills, "create" to draft a new skill when the insight is '
+	'durable but fits no candidate, "none" when it is not worth applying), '
+	'"skill_name" (for "update": the chosen candidate\'s skill_name, verbatim; '
+	'otherwise ""), "updated_instructions" (for "update": the candidate\'s '
+	"FULL revised markdown instructions with the insight folded in - not a "
+	'diff; otherwise ""), "new_skill" (for "create": an object with '
+	'"skill_name" (a 3-40 character lowercase hyphen-separated slug), '
+	'"description" and "instructions"; otherwise null). Only pick "update" '
+	"targets from the offered candidates. Keep instructions concise and "
+	"actionable; never invent facts beyond the insight and the existing skill "
+	"text."
+)
+
+
+@frappe.whitelist()
+def draft_insight_skill_update(pattern_name: str) -> dict:
+	"""Draft "apply this insight to a skill" (D5). Gathers the B/C insight
+	(statement, draft bullet, evidence tail) + up to ``_INSIGHT_TARGET_CAP``
+	org-scope non-managed candidate skills (ranked by the lifecycle overlap
+	tokens, then recency) and makes ONE strict-JSON ``openrouter_complete``
+	call proposing update/create/none. Nothing is written here;
+	``apply_insight_skill_update`` is the confirm seam.
+
+	Guard/model failures return ``{ok: False, reason}`` (the dialog renders
+	them inline); only the SM/managed gate itself throws (sibling idiom). The
+	model's verdict is validated server-side - an "update" must name one of
+	the OFFERED candidates (managed/Personal rows are never offered) and stay
+	inside the doctype instruction cap."""
+	_guard()
+	doc = frappe.get_doc(JLP, pattern_name)
+	if (doc.effective_sensitivity or "") not in ("B", "C"):
+		return _draft_envelope(
+			ok=False,
+			reason=(
+				f"pattern {doc.name} is A-class; approve it to compile into the "
+				"learned skills instead of applying it to a custom skill"
+			),
+		)
+	if doc.status not in _INSIGHT_APPLY_SOURCES:
+		return _draft_envelope(
+			ok=False,
+			reason=(
+				f"pattern is {doc.status}; only "
+				f"{', '.join(_INSIGHT_APPLY_SOURCES)} insights can be applied"
+			),
+		)
+
+	candidates = _insight_skill_candidates(doc)
+	try:
+		from jarvis.chat import knowledge_language, voice
+
+		# Knowledge-language directive (D6): drafted skill text follows the
+		# org-wide English/Original preference like the other funnels.
+		system = _INSIGHT_SKILL_SYSTEM + "\n\n" + knowledge_language.language_directive()
+		raw = voice.openrouter_complete(
+			[
+				{"role": "system", "content": system},
+				{"role": "user", "content": _insight_draft_prompt(doc, candidates)},
+			],
+			max_tokens=4000,
+		)
+	except Exception as e:
+		frappe.log_error(
+			title="jarvis insight-to-skill: draft call failed",
+			message=frappe.get_traceback(),
+		)
+		return _draft_envelope(ok=False, reason=f"language model call failed: {e}")
+
+	parsed = _parse_json_object(raw)
+	if parsed is None:
+		frappe.log_error(
+			title="jarvis insight-to-skill: unparseable draft output",
+			message=(raw or "")[:2000] if isinstance(raw, str) else repr(raw)[:2000],
+		)
+		return _draft_envelope(
+			ok=False, reason="the model returned unparseable output; try again"
+		)
+	return _validated_draft(parsed, candidates)
+
+
+@frappe.whitelist()
+def apply_insight_skill_update(
+	pattern_name: str,
+	action: str,
+	skill_name: str | None = None,
+	updated_instructions: str | None = None,
+	new_skill=None,
+) -> dict:
+	"""Confirm seam for D5. Revalidates EVERYTHING server-side (the draft
+	payload sat with the client between the two calls): the SM/managed gate,
+	the B/C + source-status guards, and the target being an org-scope
+	non-managed row. Writes go through ``doc.save`` / the SPA create endpoint
+	so the doctype controller re-runs slug/cap/uniqueness validation. Then the
+	JLP is terminal-marked exactly like Acknowledge but with the applied note
+	+ the ``materialized_skill`` provenance pointer. The skill change rides
+	the normal Skills-tab apply bar afterwards - deliberately NOT auto-pushed."""
+	_guard()
+	doc = _load_for_transition(pattern_name, _INSIGHT_APPLY_SOURCES, "apply to a skill")
+	if (doc.effective_sensitivity or "") not in ("B", "C"):
+		frappe.throw(
+			_(
+				"Pattern {0} is A-class; approve it to apply, rather than folding "
+				"it into a custom skill."
+			).format(pattern_name)
+		)
+
+	action = (action or "").strip()
+	if action == "update":
+		row_name, slug = _apply_update_target(skill_name, updated_instructions)
+	elif action == "create":
+		row_name, slug = _apply_create_target(new_skill)
+	else:
+		frappe.throw(_("Nothing to apply: action must be 'update' or 'create'."))
+
+	# Terminal-mark exactly like Acknowledge (Rejected + stable note), plus
+	# provenance. Snoozed -> Rejected is not a legal transition; route through
+	# Proposed first (the un-snooze an SM would otherwise do by hand).
+	if doc.status == "Snoozed":
+		doc.status = "Proposed"
+		doc.snoozed_until = None
+		doc.save()
+	doc.status = "Rejected"
+	doc.review_note = APPLIED_NOTE_PREFIX + slug
+	doc.reviewed_by = frappe.session.user
+	doc.reviewed_at = now_datetime()
+	doc.materialized_skill = row_name
+	doc.save()
+	frappe.db.commit()
+	return {"ok": True, "skill_name": slug}
+
+
+def _draft_envelope(
+	ok: bool,
+	reason: str = "",
+	worth_applying: bool = False,
+	action: str = "none",
+	skill_name: str = "",
+	before_instructions: str = "",
+	updated_instructions: str = "",
+	new_skill: dict | None = None,
+) -> dict:
+	"""The frozen ``draft_insight_skill_update`` envelope - every key always
+	present so the dialog never branches on shape."""
+	return {
+		"ok": bool(ok),
+		"worth_applying": bool(worth_applying),
+		"reason": reason or "",
+		"action": action if action in ("update", "create", "none") else "none",
+		"skill_name": skill_name or "",
+		"before_instructions": before_instructions or "",
+		"updated_instructions": updated_instructions or "",
+		"new_skill": new_skill if isinstance(new_skill, dict) else None,
+	}
+
+
+def _insight_skill_candidates(doc) -> list[dict]:
+	"""Org-scope, enabled, non-managed custom-skill rows - the only legal
+	"update" targets (Personal and compiler-managed rows are never offered).
+	Ranked by shared lexical tokens with the insight (the lifecycle overlap
+	index's token rule), then recency; capped at ``_INSIGHT_TARGET_CAP``.
+
+	Candidates keep their FULL instructions (the prompt truncates its copy;
+	the confirm diff wants the real before-text). skill_name collisions across
+	owners keep only the best-ranked row so the model's ``skill_name`` answer
+	maps to exactly one row."""
+	rows = frappe.get_all(
+		SKILL,
+		filters={
+			"enabled": 1,
+			"managed_by_learning": 0,
+			"scope": ["in", ["Org", ""]],
+		},
+		fields=["name", "skill_name", "description", "instructions", "modified"],
+		order_by="modified desc",
+	)
+	try:
+		from jarvis.learning.lifecycle import _tokens as _overlap_tokens
+	except Exception:
+		_overlap_tokens = None
+	pat = (
+		_overlap_tokens(f"{doc.pattern_statement or ''} {doc.skill_draft or ''}")
+		if _overlap_tokens
+		else set()
+	)
+
+	scored = []
+	for r in rows:
+		score = 0
+		if pat:
+			toks = _overlap_tokens(
+				f"{(r.skill_name or '').replace('-', ' ')} {r.description or ''}"
+			)
+			score = len(pat & toks)
+		scored.append((score, r))
+	# Stable sort: rows arrive modified-desc, so ties keep recency order.
+	scored.sort(key=lambda t: -t[0])
+
+	out: list[dict] = []
+	seen: set[str] = set()
+	for _score, r in scored:
+		if r.skill_name in seen:
+			continue
+		seen.add(r.skill_name)
+		out.append(
+			{
+				"name": r.name,
+				"skill_name": r.skill_name,
+				"description": r.description or "",
+				"instructions": r.instructions or "",
+			}
+		)
+		if len(out) >= _INSIGHT_TARGET_CAP:
+			break
+	return out
+
+
+def _insight_draft_prompt(doc, candidates: list[dict]) -> str:
+	evidence = doc.evidence or ""
+	if not isinstance(evidence, str):
+		evidence = frappe.as_json(evidence)
+	tail = evidence[-_INSIGHT_EVIDENCE_TAIL_CHARS:]
+	cand_payload = [
+		{
+			"skill_name": c["skill_name"],
+			"description": c["description"],
+			"instructions": c["instructions"][:_INSIGHT_CANDIDATE_INSTR_CHARS],
+		}
+		for c in candidates
+	]
+	parts = [
+		"Insight (a learned business pattern a System Manager wants to keep):",
+		f"Statement: {doc.pattern_statement or ''}",
+		f"Draft instruction: {doc.skill_draft or ''}",
+	]
+	if tail:
+		parts.append(f"Evidence (tail): {tail}")
+	if cand_payload:
+		parts.append(
+			'Candidate skills (the ONLY valid "update" targets):\n'
+			+ json.dumps(cand_payload, default=str)
+		)
+	else:
+		parts.append('There are no candidate skills; choose "create" or "none".')
+	return "\n\n".join(parts)
+
+
+def _parse_json_object(raw) -> dict | None:
+	"""Tolerant strict-JSON object parse (the voice_facts._parse_json_array
+	pattern for a single object): strip a stray markdown fence, then fall back
+	to the outermost braces. None on anything unusable."""
+	if not raw or not isinstance(raw, str):
+		return None
+	text = raw.strip()
+	if text.startswith("```"):
+		text = text.strip("`").strip()
+		if "\n" in text:
+			first, rest = text.split("\n", 1)
+			if first.strip().lower() in ("json", ""):
+				text = rest
+	try:
+		parsed = json.loads(text)
+	except Exception:
+		lo, hi = text.find("{"), text.rfind("}")
+		if lo == -1 or hi <= lo:
+			return None
+		try:
+			parsed = json.loads(text[lo : hi + 1])
+		except Exception:
+			return None
+	return parsed if isinstance(parsed, dict) else None
+
+
+def _validated_draft(parsed: dict, candidates: list[dict]) -> dict:
+	"""Server-side validation of the model verdict - never trust the model to
+	pick a legal target or respect the doctype caps."""
+	from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
+		LEARNED_PREFIX,
+		MAX_DESC_LEN,
+		MAX_INSTR_LEN,
+		MAX_SLUG_LEN,
+		MIN_SLUG_LEN,
+		RESERVED_PREFIX,
+		SLUG_RE,
+	)
+
+	reason = " ".join(str(parsed.get("reason") or "").split())[:500]
+	action = parsed.get("action")
+	worth = bool(parsed.get("worth_applying"))
+	if not worth or action not in ("update", "create"):
+		return _draft_envelope(
+			ok=True,
+			reason=reason
+			or "The model did not find this insight worth applying to a skill.",
+		)
+
+	if action == "update":
+		slug = str(parsed.get("skill_name") or "").strip().lower()
+		cand = next((c for c in candidates if c["skill_name"] == slug), None)
+		if cand is None:
+			return _draft_envelope(
+				ok=False,
+				reason=(
+					f"the model picked '{slug or '?'}', which is not one of the "
+					"offered target skills; try again"
+				),
+			)
+		updated = str(parsed.get("updated_instructions") or "").strip()
+		if not updated:
+			return _draft_envelope(
+				ok=False, reason="the model returned no updated instructions; try again"
+			)
+		if len(updated) > MAX_INSTR_LEN:
+			return _draft_envelope(
+				ok=False,
+				reason=(
+					f"the drafted instructions exceed the {MAX_INSTR_LEN}-character "
+					"cap; try again"
+				),
+			)
+		return _draft_envelope(
+			ok=True,
+			worth_applying=True,
+			reason=reason,
+			action="update",
+			skill_name=cand["skill_name"],
+			before_instructions=cand["instructions"],
+			updated_instructions=updated,
+		)
+
+	ns = parsed.get("new_skill")
+	if not isinstance(ns, dict):
+		return _draft_envelope(
+			ok=False, reason="the model returned no new-skill draft; try again"
+		)
+	slug = str(ns.get("skill_name") or "").strip().lower()
+	desc = str(ns.get("description") or "").strip()
+	instr = str(ns.get("instructions") or "").strip()
+	problem = None
+	if not (slug and desc and instr):
+		problem = "the new-skill draft is incomplete"
+	elif not (MIN_SLUG_LEN <= len(slug) <= MAX_SLUG_LEN) or not SLUG_RE.fullmatch(slug):
+		problem = f"'{slug}' is not a valid skill slug"
+	elif slug.startswith((RESERVED_PREFIX, LEARNED_PREFIX)):
+		problem = f"'{slug}' uses a reserved skill prefix"
+	elif len(desc) > MAX_DESC_LEN or len(instr) > MAX_INSTR_LEN:
+		problem = "the new-skill draft exceeds the description/instructions caps"
+	if problem:
+		return _draft_envelope(ok=False, reason=f"{problem}; try again")
+	return _draft_envelope(
+		ok=True,
+		worth_applying=True,
+		reason=reason,
+		action="create",
+		skill_name=slug,
+		new_skill={"skill_name": slug, "description": desc, "instructions": instr},
+	)
+
+
+def _apply_update_target(skill_name, updated_instructions) -> tuple[str, str]:
+	"""Re-resolve + re-validate the update target from scratch (org-scope,
+	enabled, non-managed; Personal and learning-managed rows are refused
+	regardless of what the client sent), then save the new instructions
+	through the controller so the length caps re-run. The SM-gated save uses
+	ignore_permissions: custom-skill rows are if_owner and the target usually
+	belongs to another user."""
+	slug = (skill_name or "").strip().lower()
+	if not slug:
+		frappe.throw(_("A target skill name is required."))
+	updated = (updated_instructions or "").strip()
+	if not updated:
+		frappe.throw(_("Updated instructions are required."))
+	row = frappe.get_all(
+		SKILL,
+		filters={
+			"skill_name": slug,
+			"enabled": 1,
+			"managed_by_learning": 0,
+			"scope": ["in", ["Org", ""]],
+		},
+		fields=["name"],
+		order_by="modified desc",
+		limit=1,
+	)
+	if not row:
+		frappe.throw(
+			_(
+				"'{0}' is not an org custom skill this insight can be applied to "
+				"(personal, learning-managed, disabled or unknown skills are refused)."
+			).format(slug)
+		)
+	skill_doc = frappe.get_doc(SKILL, row[0].name)
+	skill_doc.instructions = updated
+	skill_doc.save(ignore_permissions=True)
+	return skill_doc.name, skill_doc.skill_name
+
+
+def _apply_create_target(new_skill) -> tuple[str, str]:
+	"""Create the skill through the SPA create endpoint (the controller runs
+	slug/cap/uniqueness validation; scope stays the doctype default Org and
+	``user_invocable`` the endpoint default 1). The row is owned by the acting
+	SM - the normal authored-skill ownership."""
+	ns = _parse_json(new_skill, None) if isinstance(new_skill, str) else new_skill
+	if not isinstance(ns, dict):
+		frappe.throw(
+			_(
+				"Provide the new skill as an object with skill_name, description "
+				"and instructions."
+			)
+		)
+	from jarvis.chat.custom_skills_api import create_custom_skill
+
+	out = create_custom_skill(
+		skill_name=str(ns.get("skill_name") or "").strip(),
+		description=str(ns.get("description") or "").strip(),
+		instructions=str(ns.get("instructions") or "").strip(),
+	)
+	return out["data"]["name"], out["data"]["skill_name"]
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -14,8 +14,18 @@ Four surfaces, one merge discipline:
 - voice-note ingest (``enqueue_ingest_note`` / ``_ingest_note``): merges one
   Conversation-context ``Jarvis Voice Note`` into pages via ONE
   ``jarvis.chat.voice.openrouter_complete`` call (strict-JSON page updates).
-- SPA endpoints (list/get/save/archive) + ``apply_extracted_page_updates``,
-  the single write path shared with ``jarvis.learning.voice_facts``.
+- SPA endpoints (list/get/create/save/archive + caps/language/mirror/lint)
+  + ``apply_extracted_page_updates``, the single write path shared with
+  ``jarvis.learning.voice_facts``.
+
+Scopes (wiki v2): every read surface filters by the caller's page visibility
+(Org pages for all desk users, Role pages for holders of ``target_role``,
+User pages for ``target_user`` only; System Manager sees all) via
+``jarvis.chat.wiki_permissions``; the SPA write endpoints enforce the human
+write matrix (``can_edit_page`` / ``can_archive_page``). The extraction
+pipeline keeps its deliberate LLM-channel exception: any desk user maintains
+ORG pages through the confirm-gated tool / ingest (``ignore_permissions``
+writes behind explicit channel checks + the controller sanitizer).
 
 Merge discipline (``apply_extracted_page_updates``): ``append_md`` appends,
 ``body_md`` replaces only when the update carries no contradiction; a flagged
@@ -34,6 +44,7 @@ import frappe
 from frappe import _
 from frappe.utils import cint, now_datetime
 
+from jarvis.chat import wiki_permissions
 from jarvis.chat.events import publish_to_user
 from jarvis.jarvis.doctype.jarvis_wiki_page.jarvis_wiki_page import (
 	MAX_BODY_LEN,
@@ -127,16 +138,11 @@ def _require_system_user() -> None:
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
 
 
-def _clamp_page(start, page_length) -> tuple[int, int]:
-	try:
-		start = max(0, int(start or 0))
-	except (TypeError, ValueError):
-		start = 0
-	try:
-		pl = int(page_length or 20)
-	except (TypeError, ValueError):
-		pl = 20
-	return start, max(1, min(pl, 100))
+def _clamp_paging(page, page_length) -> tuple[int, int, int]:
+	"""(page, page_length, start) — 1-based page, page_length clamped 1-100."""
+	page = max(1, cint(page) or 1)
+	pl = max(1, min(cint(page_length) or 20, 100))
+	return page, pl, (page - 1) * pl
 
 
 def is_stale(last_confirmed_at, fallback=None) -> bool:
@@ -273,9 +279,16 @@ def wiki_clause(conversation_id: str, context: dict | None = None) -> str:
 		pages = frappe.get_all(
 			WIKI,
 			filters={"slug": ["in", slugs], "status": "Active"},
-			fields=["slug", "summary"],
+			fields=["slug", "summary", "scope", "target_role", "target_user"],
 			limit_page_length=len(slugs),
 		)
+		# Scope visibility (belt and braces: entity-derived slugs are
+		# unsuffixed so only Org pages should ever match, but a clause must
+		# never inline a page the session user cannot read).
+		pages = [
+			p for p in pages
+			if wiki_permissions.can_read_page(p, frappe.session.user)
+		]
 		if not pages:
 			return ""
 		by_slug = {p.slug: p for p in pages}
@@ -546,11 +559,15 @@ def _extract_page_updates(note, entities, suggested, existing) -> list | None:
 		f"{json.dumps(existing, default=str)}"
 	)
 	try:
-		from jarvis.chat import voice
+		from jarvis.chat import knowledge_language, voice
 
+		# Org-wide knowledge-language preference (D6): extracted wiki content
+		# is written in English (translating the source) or in the source's
+		# own language, per Jarvis Settings.
+		system = _INGEST_SYSTEM + "\n\n" + knowledge_language.language_directive()
 		raw = voice.openrouter_complete(
 			[
-				{"role": "system", "content": _INGEST_SYSTEM},
+				{"role": "system", "content": system},
 				{"role": "user", "content": user_prompt},
 			],
 			max_tokens=4000,
@@ -706,64 +723,128 @@ def _merge_update_into_page(
 def list_wiki_pages_page(
 	search: str | None = None,
 	page_type: str | None = None,
-	start: int = 0,
+	scope_filter: str | None = None,
+	attention: int = 0,
+	page: int = 1,
 	page_length: int = 20,
 ) -> dict:
-	"""Active wiki pages, newest-modified first. Envelope:
-	``{rows, total, has_more, start, page_length}``; each row carries a
-	``stale`` flag (last confirmed more than 90 days ago)."""
+	"""Active wiki pages VISIBLE to the caller, newest-modified first.
+	Envelope: ``{rows, total, has_more, page, page_length}``; each row carries
+	``scope`` and a ``stale`` flag. ``scope_filter``: ``all`` (default) /
+	``org`` / ``role`` (Role pages) / ``mine`` (own User pages).
+	``attention=1`` keeps only pages needing review (contradiction flagged, or
+	last_confirmed_at missing / older than 90 days — computed in SQL). Raw SQL
+	because the visibility fragment + OR-search + a real COUNT(*) don't fit
+	get_all (``frappe.db.count`` takes no or_filters, and materializing every
+	matching name per request does not scale)."""
 	_require_system_user()
-	start, pl = _clamp_page(start, page_length)
+	user = frappe.session.user
+	page, pl, offset = _clamp_paging(page, page_length)
 
-	filters: dict = {"status": "Active"}
+	conditions = ["status = 'Active'"]
+	values: dict = {}
+	# Pre-escaped by wiki_permissions (frappe.db.escape) — no placeholders.
+	vis = (wiki_permissions.visible_scope_condition(user) or "").strip()
+	if vis:
+		conditions.append(f"({vis})")
 	if page_type:
 		if page_type not in PAGE_TYPES:
 			frappe.throw(_("Invalid page type filter."))
-		filters["page_type"] = page_type
-	kwargs: dict = {"filters": filters}
+		conditions.append("page_type = %(page_type)s")
+		values["page_type"] = page_type
+	scope_filter = (str(scope_filter).strip().lower() if scope_filter else "all")
+	if scope_filter not in ("all", "org", "role", "mine"):
+		frappe.throw(_("Invalid scope filter."))
+	if scope_filter == "org":
+		# Pre-backfill rows read as Org (scope is NULL until the patch runs).
+		conditions.append("ifnull(scope, '') in ('', 'Org')")
+	elif scope_filter == "role":
+		conditions.append("scope = 'Role'")
+	elif scope_filter == "mine":
+		conditions.append("(scope = 'User' and target_user = %(me)s)")
+		values["me"] = user
 	if search:
-		like = f"%{str(search).strip()[:140]}%"
-		kwargs["or_filters"] = [
-			["slug", "like", like],
-			["title", "like", like],
-			["summary", "like", like],
-		]
+		values["like"] = f"%{str(search).strip()[:140]}%"
+		conditions.append(
+			"(slug like %(like)s or title like %(like)s or summary like %(like)s)"
+		)
+	if cint(attention):
+		values["stale_cutoff"] = frappe.utils.add_to_date(
+			now_datetime(), days=-_STALE_DAYS
+		)
+		conditions.append(
+			"(contradiction_flag = 1 or last_confirmed_at is null"
+			" or last_confirmed_at < %(stale_cutoff)s)"
+		)
+	where = " and ".join(conditions)
 
-	total = len(frappe.get_all(WIKI, fields=["name"], limit_page_length=0, **kwargs))
-	rows = frappe.get_all(
-		WIKI,
-		fields=[
-			"name", "slug", "title", "page_type", "ref_doctype", "ref_name",
-			"summary", "status", "contradiction_flag", "last_confirmed_at",
-			"modified",
-		],
-		order_by="modified desc",
-		limit_start=start,
-		limit_page_length=pl,
-		**kwargs,
+	total = cint(frappe.db.sql(
+		f"select count(*) from `tabJarvis Wiki Page` where {where}", values
+	)[0][0])
+	values.update({"limit": pl, "offset": offset})
+	rows = frappe.db.sql(
+		f"""select name, slug, title, page_type, ifnull(scope, 'Org') as scope,
+			target_role, target_user, ref_doctype, ref_name, summary, status,
+			contradiction_flag, last_confirmed_at, modified
+		from `tabJarvis Wiki Page`
+		where {where}
+		order by modified desc
+		limit %(limit)s offset %(offset)s""",
+		values,
+		as_dict=True,
 	)
 	for r in rows:
+		r["contradiction_flag"] = cint(r.get("contradiction_flag"))
 		r["stale"] = is_stale(r.get("last_confirmed_at"), r.get("modified"))
 
 	return {
 		"rows": rows,
 		"total": total,
-		"has_more": start + len(rows) < total,
-		"start": start,
+		"has_more": offset + len(rows) < total,
+		"page": page,
 		"page_length": pl,
+	}
+
+
+@frappe.whitelist()
+def get_wiki_caps() -> dict:
+	"""The caller's wiki capabilities + the SM settings surfaced in the Wiki
+	tab header (knowledge language, last lint run)."""
+	_require_system_user()
+	user = frappe.session.user
+	from jarvis.chat import knowledge_language
+
+	lint_at = frappe.db.get_single_value(SETTINGS, "wiki_lint_last_run_at")
+	return {
+		"creatable_scopes": wiki_permissions.creatable_scopes(user),
+		"manageable_roles": wiki_permissions.manageable_roles(user),
+		"is_sm": (
+			user == "Administrator"
+			or "System Manager" in frappe.get_roles(user)
+		),
+		"knowledge_language": knowledge_language.get_knowledge_language(),
+		"wiki_lint_last_run_at": str(lint_at) if lint_at else None,
+		"wiki_lint_summary": frappe.db.get_single_value(
+			SETTINGS, "wiki_lint_summary"
+		) or None,
 	}
 
 
 @frappe.whitelist()
 def get_wiki_page(slug: str) -> dict:
 	"""One full wiki page by slug (any status — the editor can open an
-	archived page)."""
+	archived page). Invisible pages 404 as "not found" (existence is not
+	leaked); ``can_edit``/``can_archive`` are the server-computed write-matrix
+	flags the UI trusts (save/archive re-check)."""
 	_require_system_user()
+	user = frappe.session.user
 	slug = (slug or "").strip().lower()
 	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
 	if not name:
 		frappe.throw(_("Wiki page not found."))
 	doc = frappe.get_doc(WIKI, name)
+	if not wiki_permissions.can_read_page(doc, user):
+		frappe.throw(_("Wiki page not found."))
 	try:
 		sources = json.loads(doc.sources) if doc.sources else []
 	except Exception:
@@ -779,6 +860,11 @@ def get_wiki_page(slug: str) -> dict:
 		"body_md": doc.body_md,
 		"sensitivity": doc.sensitivity,
 		"status": doc.status,
+		"scope": doc.get("scope") or "Org",
+		"target_role": doc.get("target_role"),
+		"target_user": doc.get("target_user"),
+		"can_edit": bool(wiki_permissions.can_edit_page(doc, user)),
+		"can_archive": bool(wiki_permissions.can_archive_page(doc, user)),
 		"sources": sources if isinstance(sources, list) else [],
 		"last_confirmed_at": str(doc.last_confirmed_at) if doc.last_confirmed_at else None,
 		"contradiction_flag": cint(doc.contradiction_flag),
@@ -788,21 +874,100 @@ def get_wiki_page(slug: str) -> dict:
 
 
 @frappe.whitelist()
+def create_wiki_page(
+	title: str,
+	page_type: str,
+	scope: str = "Org",
+	target_role: str | None = None,
+	summary: str = "",
+	body_md: str = "",
+) -> dict:
+	"""Create one wiki page from the SPA "New page" dialog, write matrix
+	enforced (Org=SM; Role=KW Manager for a role they hold, or SM; User=the
+	caller with a KW role). The slug derives from the title
+	(``<page_type>--<scrubbed-title>``); the controller suffixes non-Org
+	slugs (``--u-…`` / ``--r-…``) so scopes never collide. Matrix denials
+	return ``{ok: False, reason}`` (the dialog shows the reason); malformed
+	input throws."""
+	_require_system_user()
+	user = frappe.session.user
+
+	title = " ".join(str(title or "").split())
+	if not title:
+		frappe.throw(_("Title is required."))
+	if page_type not in PAGE_TYPES:
+		frappe.throw(_("Invalid page type."))
+	scope = (str(scope).strip() if scope else "") or "Org"
+	if scope not in ("Org", "Role", "User"):
+		frappe.throw(_("Invalid scope."))
+
+	if scope not in wiki_permissions.creatable_scopes(user):
+		return {
+			"ok": False,
+			"reason": _("You cannot create {0}-scope wiki pages.").format(scope),
+		}
+	target_role = (str(target_role).strip() if target_role else "") or None
+	if scope == "Role":
+		if not target_role:
+			frappe.throw(_("A target role is required for Role-scope pages."))
+		if target_role not in wiki_permissions.manageable_roles(user):
+			return {
+				"ok": False,
+				"reason": _("You cannot manage wiki pages for role {0}.").format(
+					target_role
+				),
+			}
+	else:
+		target_role = None
+
+	slug = _normalize_slug(f"{page_type.lower()}--{title}")
+	if not slug:
+		return {"ok": False, "reason": _("Title does not produce a valid slug.")}
+
+	doc = frappe.get_doc({
+		"doctype": WIKI,
+		"slug": slug,
+		"title": title[:140],
+		"page_type": page_type,
+		"scope": scope,
+		"target_role": target_role,
+		"target_user": user if scope == "User" else None,
+		"summary": _clip_summary(summary),
+		"body_md": _clip_body(str(body_md or "")),
+		"status": "Active",
+		"sources": frappe.as_json([_source_entry("manual", None, user)]),
+		"last_confirmed_at": now_datetime(),
+	})
+	try:
+		doc.insert(ignore_permissions=True)
+	except frappe.DuplicateEntryError:
+		return {
+			"ok": False,
+			"reason": _("A page with this slug already exists: {0}").format(doc.slug),
+		}
+	return {"ok": True, "slug": doc.slug}
+
+
+@frappe.whitelist()
 def save_wiki_page(
 	slug: str,
 	body_md: str | None = None,
 	summary: str | None = None,
 	title: str | None = None,
 ) -> dict:
-	"""Human edit of an existing page (desk users). A saved body counts as a
-	review: it refreshes ``last_confirmed_at`` and clears the contradiction
-	flag (the human just resolved or endorsed the content)."""
+	"""Human edit of an existing page, write matrix enforced (Org=SM;
+	Role=KW Manager holding the role, or SM; User=the target user with a KW
+	role, or SM). A saved body counts as a review: it refreshes
+	``last_confirmed_at`` and clears the contradiction flag (the human just
+	resolved or endorsed the content)."""
 	_require_system_user()
 	slug = (slug or "").strip().lower()
 	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
 	if not name:
 		frappe.throw(_("Wiki page not found."))
 	doc = frappe.get_doc(WIKI, name)
+	if not wiki_permissions.can_edit_page(doc, frappe.session.user):
+		frappe.throw(_("Not permitted."), frappe.PermissionError)
 	if title is not None and str(title).strip():
 		doc.title = str(title).strip()[:140]
 	if summary is not None:
@@ -818,14 +983,52 @@ def save_wiki_page(
 
 @frappe.whitelist()
 def archive_wiki_page(slug: str) -> dict:
-	"""Retire a page (System Manager only). Archived pages drop out of the
-	list, the turn clause and read_wiki search; the slug stays reserved."""
-	frappe.only_for("System Manager")
+	"""Retire a page, write matrix enforced (``can_archive_page``: Org=SM;
+	Role=KW Manager holding the role, or SM; User per matrix). Archived pages
+	drop out of the list, the turn clause and read_wiki search; the slug
+	stays reserved."""
+	_require_system_user()
 	slug = (slug or "").strip().lower()
 	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
 	if not name:
 		frappe.throw(_("Wiki page not found."))
 	doc = frappe.get_doc(WIKI, name)
+	if not wiki_permissions.can_archive_page(doc, frappe.session.user):
+		frappe.throw(_("Not permitted."), frappe.PermissionError)
 	doc.status = "Archived"
 	doc.save(ignore_permissions=True)
 	return {"ok": True, "slug": doc.slug}
+
+
+@frappe.whitelist()
+def set_knowledge_language(value: str) -> dict:
+	"""SM-only: set the org-wide knowledge language (D6) consumed by the
+	wiki/voice-facts extraction prompts. English (default) translates source
+	material; Original keeps the source's dominant language."""
+	frappe.only_for("System Manager")
+	value = (value or "").strip()
+	if value not in ("English", "Original"):
+		frappe.throw(_("Knowledge language must be English or Original."))
+	frappe.db.set_single_value(SETTINGS, "knowledge_language", value)
+	return {"ok": True, "knowledge_language": value}
+
+
+@frappe.whitelist()
+def sync_wiki_mirror_now() -> dict:
+	"""SM-only: queue a FULL org-wiki mirror sync into the tenant container
+	workspace (same deduped job as the doc_events trigger; full=prunes strays)."""
+	frappe.only_for("System Manager")
+	from jarvis.chat import wiki_mirror
+
+	wiki_mirror.enqueue_sync(full=True)
+	return {"ok": True}
+
+
+@frappe.whitelist()
+def run_wiki_lint_now() -> dict:
+	"""SM-only: run the wiki health check (deterministic lint pass) now and
+	return its summary (also persisted on Jarvis Settings by run_lint)."""
+	frappe.only_for("System Manager")
+	from jarvis.learning import wiki_lint
+
+	return {"ok": True, "summary": wiki_lint.run_lint()}

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -725,6 +725,7 @@ def list_wiki_pages_page(
 	page_type: str | None = None,
 	scope_filter: str | None = None,
 	attention: int = 0,
+	archived: int = 0,
 	page: int = 1,
 	page_length: int = 20,
 ) -> dict:
@@ -741,7 +742,9 @@ def list_wiki_pages_page(
 	user = frappe.session.user
 	page, pl, offset = _clamp_paging(page, page_length)
 
-	conditions = ["status = 'Active'"]
+	# archived=1 lists Archived pages instead (still visibility-filtered) so
+	# an accidental archive is recoverable from the SPA, not only from Desk.
+	conditions = ["status = 'Archived'" if cint(archived) else "status = 'Active'"]
 	values: dict = {}
 	# Pre-escaped by wiki_permissions (frappe.db.escape) — no placeholders.
 	vis = (wiki_permissions.visible_scope_condition(user) or "").strip()
@@ -815,6 +818,7 @@ def get_wiki_caps() -> dict:
 	from jarvis.chat import knowledge_language
 
 	lint_at = frappe.db.get_single_value(SETTINGS, "wiki_lint_last_run_at")
+	synced_at = frappe.db.get_single_value(SETTINGS, "wiki_mirror_last_synced_at")
 	return {
 		"creatable_scopes": wiki_permissions.creatable_scopes(user),
 		"manageable_roles": wiki_permissions.manageable_roles(user),
@@ -826,6 +830,10 @@ def get_wiki_caps() -> dict:
 		"wiki_lint_last_run_at": str(lint_at) if lint_at else None,
 		"wiki_lint_summary": frappe.db.get_single_value(
 			SETTINGS, "wiki_lint_summary"
+		) or None,
+		"wiki_mirror_last_synced_at": str(synced_at) if synced_at else None,
+		"wiki_mirror_last_sync_status": frappe.db.get_single_value(
+			SETTINGS, "wiki_mirror_last_sync_status"
 		) or None,
 	}
 
@@ -996,6 +1004,23 @@ def archive_wiki_page(slug: str) -> dict:
 	if not wiki_permissions.can_archive_page(doc, frappe.session.user):
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
 	doc.status = "Archived"
+	doc.save(ignore_permissions=True)
+	return {"ok": True, "slug": doc.slug}
+
+
+@frappe.whitelist()
+def restore_wiki_page(slug: str) -> dict:
+	"""Undo an archive (same permission as archiving) — the SPA's escape hatch
+	for a one-click accidental archive."""
+	_require_system_user()
+	slug = (slug or "").strip().lower()
+	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
+	if not name:
+		frappe.throw(_("Wiki page not found."))
+	doc = frappe.get_doc(WIKI, name)
+	if not wiki_permissions.can_archive_page(doc, frappe.session.user):
+		frappe.throw(_("Not permitted."), frappe.PermissionError)
+	doc.status = "Active"
 	doc.save(ignore_permissions=True)
 	return {"ok": True, "slug": doc.slug}
 

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -817,6 +817,16 @@ def get_wiki_caps() -> dict:
 	user = frappe.session.user
 	from jarvis.chat import knowledge_language
 
+	def _dt_str(value):
+		# second precision: dayjs in the SPA chokes on the 6-digit microsecond
+		# tail of str(now_datetime()) and renders nonsense ("126 years ago")
+		if not value:
+			return None
+		try:
+			return frappe.utils.get_datetime(value).strftime("%Y-%m-%d %H:%M:%S")
+		except Exception:
+			return None
+
 	lint_at = frappe.db.get_single_value(SETTINGS, "wiki_lint_last_run_at")
 	synced_at = frappe.db.get_single_value(SETTINGS, "wiki_mirror_last_synced_at")
 	return {
@@ -827,11 +837,11 @@ def get_wiki_caps() -> dict:
 			or "System Manager" in frappe.get_roles(user)
 		),
 		"knowledge_language": knowledge_language.get_knowledge_language(),
-		"wiki_lint_last_run_at": str(lint_at) if lint_at else None,
+		"wiki_lint_last_run_at": _dt_str(lint_at),
 		"wiki_lint_summary": frappe.db.get_single_value(
 			SETTINGS, "wiki_lint_summary"
 		) or None,
-		"wiki_mirror_last_synced_at": str(synced_at) if synced_at else None,
+		"wiki_mirror_last_synced_at": _dt_str(synced_at),
 		"wiki_mirror_last_sync_status": frappe.db.get_single_value(
 			SETTINGS, "wiki_mirror_last_sync_status"
 		) or None,

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -238,12 +238,37 @@ def sync(full: bool = False) -> dict:
 	``full`` send ``known_paths`` so the fleet prunes strays (trashed pages,
 	type/dir moves). Returns a summary dict; NEVER raises into callers."""
 	try:
-		return _sync(full=bool(full))
+		result = _sync(full=bool(full))
 	except Exception:
 		frappe.log_error(
 			title="wiki mirror: sync crashed", message=frappe.get_traceback()
 		)
-		return {"ok": False, "reason": "sync crashed; see Error Log"}
+		result = {"ok": False, "reason": "sync crashed; see Error Log"}
+	_stamp_sync_status(result)
+	return result
+
+
+def _stamp_sync_status(result: dict) -> None:
+	"""Persist the outcome on Jarvis Settings so the Wiki tab can show a
+	"last synced" line — otherwise the sync is fire-and-forget and a failed
+	push surfaces nowhere in the SPA. Best-effort."""
+	try:
+		if result.get("skipped"):
+			return
+		if result.get("ok"):
+			status = f"OK — {result.get('pushed_files', 0)} file(s) pushed"
+		else:
+			status = f"Failed — {result.get('reason', 'see Error Log')}"
+		frappe.db.set_single_value(
+			SETTINGS,
+			{
+				"wiki_mirror_last_synced_at": frappe.utils.now_datetime(),
+				"wiki_mirror_last_sync_status": status[:140],
+			},
+			update_modified=False,
+		)
+	except Exception:
+		pass
 
 
 def _sync(full: bool) -> dict:

--- a/jarvis/chat/wiki_mirror.py
+++ b/jarvis/chat/wiki_mirror.py
@@ -1,0 +1,403 @@
+"""One-way markdown mirror of the Org-scope wiki into the tenant container
+workspace (wiki v2 D2).
+
+The site DB stays canonical (``Jarvis Wiki Page``); this module renders the
+Org-scope Active pages as Obsidian-style markdown and reconciles them into the
+container workspace ``wiki/`` directory through the no-restart push chain
+``jarvis.admin_client.push_wiki_files`` -> jarvis_admin relay -> fleet-agent
+``PUT /wiki-files`` (the workspace is a live RW bind mount, so writes appear
+to the running agent instantly). The mirror is a DERIVED, rebuildable copy for
+cheap native file reads/greps; ``jarvis__read_wiki`` stays authoritative.
+
+Scope discipline: only Org pages (scope NULL/'' counts as Org) are ever
+mirrored — the container workspace is org-shared, so Role/User pages must
+never land there. Diffing rides ``mirror_hash`` (sha256 of the rendered
+content, stamped per page via ``frappe.db.set_value`` — deliberately NOT
+``doc.save``, which would re-fire the very doc_events that trigger the sync).
+
+Renders return workspace-relative paths (``wiki/<typedir>/<slug>.md``); the
+wire payload strips the ``wiki/`` prefix — the fleet endpoint takes paths
+relative to its wiki dir (e.g. ``customers/customer--acme.md``, ``index.md``).
+
+Every failure path swallows + logs (``frappe.log_error``): the doc_events
+trigger runs inside user save paths and the sync job must degrade to "try
+again next sync" when the tenant is not provisioned or admin is unreachable.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import frappe
+from frappe.utils import cint
+
+WIKI = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+JOB_METHOD = "jarvis.chat.wiki_mirror.sync"
+# Two dedup ids so a queued incremental sync can't swallow a requested FULL
+# sync (manual "Sync now" / on_trash prune both need known_paths).
+JOB_ID = "wiki-mirror-sync"
+JOB_ID_FULL = "wiki-mirror-sync-full"
+QUEUE = "short"
+JOB_TIMEOUT_S = 120
+
+# fleet-agent hard-caps request bodies at 256KB; keep each push call's b64
+# file payload comfortably under it.
+MAX_CALL_PAYLOAD_BYTES = 200 * 1024
+_PER_FILE_OVERHEAD_BYTES = 64
+
+# page_type -> mirror subdirectory. Keys mirror the 9 options of
+# ``Jarvis Wiki Page.page_type`` (jarvis_wiki_page.json) / wiki.PAGE_TYPES.
+TYPE_DIRS = {
+	"Customer": "customers",
+	"Supplier": "suppliers",
+	"Item": "items",
+	"Process": "processes",
+	"Doctype": "doctypes",
+	"Exception": "exceptions",
+	"Integration": "integrations",
+	"People": "people",
+	"Org": "org",
+}
+_DEFAULT_TYPE_DIR = "org"
+
+INDEX_PATH = "wiki/index.md"
+LOG_PATH = "wiki/log.md"
+_INDEX_SUMMARY_CHARS = 100
+_LOG_MAX_EVENTS = 150
+
+_PAGE_FIELDS = [
+	"name", "slug", "title", "page_type", "scope", "status", "summary",
+	"body_md", "sources", "last_confirmed_at", "contradiction_flag",
+	"modified", "mirror_hash",
+]
+
+
+def _is_org_scope(scope) -> bool:
+	"""NULL/'' scope (pre-v2 rows) reads as Org everywhere."""
+	return (scope or "").strip() in ("", "Org")
+
+
+def _wire_path(path: str) -> str:
+	"""Workspace-relative render path -> wire path relative to the fleet
+	endpoint's wiki dir ("wiki/customers/x.md" -> "customers/x.md")."""
+	return path[len("wiki/"):] if path.startswith("wiki/") else path
+
+
+def page_path(page) -> str:
+	"""Workspace-relative mirror path for one page (dict row or Document)."""
+	type_dir = TYPE_DIRS.get((page.get("page_type") or "").strip(), _DEFAULT_TYPE_DIR)
+	slug = page.get("slug") or page.get("name")
+	return f"wiki/{type_dir}/{slug}.md"
+
+
+# --------------------------------------------------------------------------- #
+# renders (pure functions of page data; deterministic modulo the stale clock)
+# --------------------------------------------------------------------------- #
+def render_page(doc) -> tuple[str, str]:
+	"""Render one page as Obsidian-style markdown. Returns ``(path, content)``
+	with path ``wiki/<typedir>/<slug>.md``. Frontmatter carries the metadata
+	the agent needs to trust-or-verify (stale/contradiction flags); the body's
+	existing ``[[slug]]`` links pass through untouched; the provenance trail
+	renders as a ``## Sources`` tail."""
+	from jarvis.chat.wiki import is_stale
+
+	stale = is_stale(doc.get("last_confirmed_at"), doc.get("modified"))
+	lines = [
+		"---",
+		# json.dumps == a valid YAML double-quoted scalar; keeps a title with
+		# ':' / quotes from corrupting the frontmatter.
+		f"title: {json.dumps(str(doc.get('title') or ''))}",
+		f"type: {(doc.get('page_type') or '').strip() or 'Org'}",
+		f"updated: {str(doc.get('modified') or '')[:10]}",
+		f"stale: {'true' if stale else 'false'}",
+		f"contradiction: {'true' if cint(doc.get('contradiction_flag')) else 'false'}",
+		"---",
+		"",
+	]
+	summary = " ".join(str(doc.get("summary") or "").split())
+	if summary:
+		lines += [summary, ""]
+	body = str(doc.get("body_md") or "").strip("\n")
+	if body:
+		lines += [body, ""]
+	source_lines = _source_lines(doc.get("sources"))
+	if source_lines:
+		lines += ["## Sources", ""] + source_lines + [""]
+	content = "\n".join(lines).rstrip("\n") + "\n"
+	return page_path(doc), content
+
+
+def _source_lines(raw) -> list[str]:
+	"""``sources`` JSON ([{date, kind, ref, user}], already capped at 20 by
+	the controller-side append) -> markdown bullets. Corrupt JSON renders as
+	no tail rather than failing the sync."""
+	try:
+		entries = json.loads(raw) if raw else []
+	except Exception:
+		return []
+	if not isinstance(entries, list):
+		return []
+	out = []
+	for entry in entries:
+		if not isinstance(entry, dict):
+			continue
+		parts = [
+			str(entry.get(key)) for key in ("date", "kind", "ref", "user")
+			if entry.get(key)
+		]
+		if parts:
+			out.append("- " + " · ".join(parts))
+	return out
+
+
+def render_index() -> tuple[str, str]:
+	"""``wiki/index.md``: Active Org pages grouped by type, one line per page
+	``- [[slug]] — <summary ≤100ch>``, with a counts header. Surgically small
+	on purpose — the index is a routing file, not content."""
+	rows = frappe.get_all(
+		WIKI,
+		fields=["name", "page_type", "scope", "status", "summary"],
+		order_by="name asc",
+		limit_page_length=0,
+	)
+	pages = [
+		r for r in rows
+		if _is_org_scope(r.scope) and (r.status or "Active") == "Active"
+	]
+	by_type: dict[str, list] = {}
+	for r in pages:
+		by_type.setdefault((r.page_type or "").strip() or "Org", []).append(r)
+
+	lines = [
+		"# Org wiki index",
+		"",
+		f"{len(pages)} active page(s). Each [[slug]] is a file under wiki/; "
+		"use jarvis__read_wiki for the authoritative copy.",
+		"",
+	]
+	# TYPE_DIRS order = the doctype's option order; unknown types (defensive)
+	# trail alphabetically.
+	ordered = [t for t in TYPE_DIRS if t in by_type]
+	ordered += sorted(set(by_type) - set(TYPE_DIRS))
+	for ptype in ordered:
+		group = by_type[ptype]
+		lines.append(f"## {ptype} ({len(group)})")
+		lines.append("")
+		for r in group:
+			summary = " ".join(str(r.summary or "").split())[:_INDEX_SUMMARY_CHARS]
+			lines.append(f"- [[{r.name}]] — {summary}" if summary else f"- [[{r.name}]]")
+		lines.append("")
+	return INDEX_PATH, "\n".join(lines).rstrip("\n") + "\n"
+
+
+def render_log() -> tuple[str, str]:
+	"""``wiki/log.md``: the last ``_LOG_MAX_EVENTS`` mirror-relevant events
+	(page creation/modification/archival + the last lint run), newest first,
+	one grep-able line per event: ``## [YYYY-MM-DD] <action> | <slug>``."""
+	rows = frappe.get_all(
+		WIKI,
+		fields=["name", "scope", "status", "creation", "modified"],
+		limit_page_length=0,
+	)
+	events: list[tuple[str, str, str]] = []
+	for r in rows:
+		if not _is_org_scope(r.scope):
+			continue
+		events.append((str(r.creation), "created", r.name))
+		# A modified stamp beyond the same second as creation = a later write.
+		if str(r.modified)[:19] != str(r.creation)[:19]:
+			action = "archived" if (r.status or "") == "Archived" else "updated"
+			events.append((str(r.modified), action, r.name))
+	lint_at = frappe.db.get_single_value(SETTINGS, "wiki_lint_last_run_at")
+	if lint_at:
+		events.append((str(lint_at), "lint", "org-wiki"))
+	events.sort(key=lambda e: e[0], reverse=True)
+
+	lines = [
+		"# Org wiki log",
+		"",
+		"Newest first. Grep `| <slug>` for one page's history.",
+		"",
+	]
+	for ts, action, slug in events[:_LOG_MAX_EVENTS]:
+		lines.append(f"## [{ts[:10]}] {action} | {slug}")
+	return LOG_PATH, "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# sync
+# --------------------------------------------------------------------------- #
+def sync(full: bool = False) -> dict:
+	"""Reconcile the mirror: push changed/new Org Active pages (mirror_hash
+	sha256 diff; ``full`` bypasses the diff so a wiped container rebuilds),
+	delete archived pages' files, always re-send index.md + log.md, and on
+	``full`` send ``known_paths`` so the fleet prunes strays (trashed pages,
+	type/dir moves). Returns a summary dict; NEVER raises into callers."""
+	try:
+		return _sync(full=bool(full))
+	except Exception:
+		frappe.log_error(
+			title="wiki mirror: sync crashed", message=frappe.get_traceback()
+		)
+		return {"ok": False, "reason": "sync crashed; see Error Log"}
+
+
+def _sync(full: bool) -> dict:
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		# No managed container to mirror into; the DB copy stays canonical.
+		return {"ok": True, "skipped": "self-hosted"}
+
+	rows = frappe.get_all(WIKI, fields=_PAGE_FIELDS, limit_page_length=0)
+	org = [r for r in rows if _is_org_scope(r.scope)]
+	active = [r for r in org if (r.status or "Active") == "Active"]
+	inactive = [r for r in org if (r.status or "Active") != "Active"]
+
+	files: list[dict] = []
+	for r in active:
+		path, content = render_page(r)
+		digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+		if full or digest != (r.mirror_hash or ""):
+			files.append(_file_entry(path, content, page=r.name, digest=digest))
+
+	# index/log go LAST so navigation only lands after the content it points at.
+	ipath, icontent = render_index()
+	lpath, lcontent = render_log()
+	files.append(_file_entry(ipath, icontent))
+	files.append(_file_entry(lpath, lcontent))
+
+	# Archived pages whose file is (still) on the container: delete + clear the
+	# hash stamp after a confirmed push so the delete isn't re-sent forever.
+	deletes = [r for r in inactive if (r.mirror_hash or "")]
+	delete_paths = [_wire_path(page_path(r)) for r in deletes]
+	known_paths = None
+	if full:
+		known_paths = sorted(
+			{_wire_path(page_path(r)) for r in active}
+			| {_wire_path(INDEX_PATH), _wire_path(LOG_PATH)}
+		)
+
+	from jarvis import admin_client
+
+	pushed = 0
+	calls = 0
+	batches = _chunk_files(files)
+	for i, batch in enumerate(batches):
+		last = i == len(batches) - 1
+		resp = admin_client.push_wiki_files(
+			files=[{"path": f["path"], "content_b64": f["content_b64"]} for f in batch],
+			delete=delete_paths if (last and delete_paths) else None,
+			known_paths=known_paths if last else None,
+		)
+		if resp is None:
+			# Tenant not provisioned / admin unreachable: hashes for this and
+			# later batches stay unstamped, so the next sync retries them.
+			frappe.log_error(
+				title="wiki mirror: push failed; sync left partial",
+				message=f"full={full} calls_ok={calls} batches={len(batches)}",
+			)
+			return {
+				"ok": False,
+				"reason": "admin/tenant unreachable; will retry next sync",
+				"calls": calls,
+				"pushed_files": pushed,
+			}
+		calls += 1
+		pushed += len(batch)
+		for f in batch:
+			if f["page"]:
+				frappe.db.set_value(
+					WIKI, f["page"], "mirror_hash", f["hash"], update_modified=False
+				)
+		if last:
+			for r in deletes:
+				frappe.db.set_value(
+					WIKI, r.name, "mirror_hash", "", update_modified=False
+				)
+		frappe.db.commit()
+
+	return {
+		"ok": True,
+		"full": full,
+		"pages": len(active),
+		"pushed_files": pushed,
+		"deleted": len(delete_paths),
+		"calls": calls,
+	}
+
+
+def _file_entry(path: str, content: str, page: str | None = None,
+				digest: str | None = None) -> dict:
+	return {
+		"path": _wire_path(path),
+		"content_b64": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+		"page": page,
+		"hash": digest,
+	}
+
+
+def _chunk_files(files: list[dict]) -> list[list[dict]]:
+	"""Greedy order-preserving batching: each call's summed b64+path payload
+	stays under MAX_CALL_PAYLOAD_BYTES (a single page can't exceed it — the
+	controller caps bodies at 20k chars, ~27KB b64)."""
+	batches: list[list[dict]] = []
+	cur: list[dict] = []
+	cur_size = 0
+	for f in files:
+		size = len(f["content_b64"]) + len(f["path"]) + _PER_FILE_OVERHEAD_BYTES
+		if cur and cur_size + size > MAX_CALL_PAYLOAD_BYTES:
+			batches.append(cur)
+			cur, cur_size = [], 0
+		cur.append(f)
+		cur_size += size
+	if cur:
+		batches.append(cur)
+	return batches
+
+
+# --------------------------------------------------------------------------- #
+# triggers
+# --------------------------------------------------------------------------- #
+def enqueue_sync(full: bool = False) -> None:
+	"""Queue the deduped mirror sync (short queue, 120s deadline). Suppressed
+	under tests unless ``frappe.flags.jarvis_test_wiki_mirror_enqueue`` is set
+	— fixture inserts must not spray RQ jobs. Enqueue failures (Redis down)
+	are swallowed: this runs inside user save paths via doc_events."""
+	if frappe.flags.in_test and not frappe.flags.jarvis_test_wiki_mirror_enqueue:
+		return
+	try:
+		frappe.enqueue(
+			JOB_METHOD,
+			queue=QUEUE,
+			timeout=JOB_TIMEOUT_S,
+			job_id=JOB_ID_FULL if full else JOB_ID,
+			deduplicate=True,
+			full=bool(full),
+		)
+	except Exception:
+		frappe.log_error(
+			title="wiki mirror: enqueue failed", message=frappe.get_traceback()
+		)
+
+
+def on_wiki_page_change(doc, method: str | None = None) -> None:
+	"""doc_events hook (after_insert / on_update / on_trash on Jarvis Wiki
+	Page). Only Org-scope pages trigger a sync — Role/User pages are never
+	mirrored. A trash enqueues a FULL sync: the row is gone before the job
+	runs, so only known_paths pruning can remove its file (archival, by
+	contrast, is a status flip the incremental sync sees as a delete).
+	Never raises into the save/delete path."""
+	try:
+		if not _is_org_scope(doc.get("scope")):
+			return
+		enqueue_sync(full=(method == "on_trash"))
+	except Exception:
+		frappe.log_error(
+			title="wiki mirror: doc-event trigger failed",
+			message=frappe.get_traceback(),
+		)

--- a/jarvis/chat/wiki_permissions.py
+++ b/jarvis/chat/wiki_permissions.py
@@ -35,8 +35,18 @@ WIKI = "Jarvis Wiki Page"
 WIKI_USER_ROLE = "Knowledge Wiki User"
 WIKI_MANAGER_ROLE = "Knowledge Wiki Manager"
 
-# Never offered as a Role-scope audience (mirrors agents_api's selectable set).
-_NON_TARGETABLE_ROLES = ("Administrator", "Guest", "All")
+# Never offered as a Role-scope audience (mirrors agents_api's selectable
+# set). Framework/blanket roles are excluded too: "Desk User" (and kin) is
+# effectively everyone with a login, so targeting it would let a KW Manager
+# publish org-wide through a side door the write matrix reserves for SMs.
+_NON_TARGETABLE_ROLES = (
+	"Administrator",
+	"Guest",
+	"All",
+	"Desk User",
+	"System Manager",
+	"Website Manager",
+)
 
 # ptypes that reveal page content; everything read-shaped maps to visibility.
 _READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")

--- a/jarvis/chat/wiki_permissions.py
+++ b/jarvis/chat/wiki_permissions.py
@@ -1,0 +1,178 @@
+"""Scope visibility + human write matrix for ``Jarvis Wiki Page`` (wiki v2).
+
+Visibility (read) — enforced everywhere (Desk lists via the
+``permission_query_conditions`` hook, per-doc access via the
+``has_permission`` hook, SPA/tool queries via ``visible_scope_condition``):
+
+  * Org pages (scope NULL/empty counts as Org): every desk user.
+  * Role pages: users holding ``target_role`` (+ System Manager).
+  * User pages: ``target_user`` only (+ System Manager).
+
+Human write matrix (SPA create/save/archive; Desk edits are role-perm
+limited to System Manager anyway):
+
+  * Org: System Manager only.
+  * Role: Knowledge Wiki Manager holding that role, or SM (any role).
+  * User: the target user themselves when they hold Knowledge Wiki
+    User/Manager, or SM.
+
+The LLM channel (``update_wiki`` tool + ingest) deliberately bypasses this
+matrix for Org pages — any desk user feeds the org wiki through the
+confirm-gated, sanitized pipeline; those writers use ``ignore_permissions``
+with explicit channel checks (see jarvis/chat/wiki.py).
+
+NOTE on the has_permission hook: on this Frappe version controller hooks can
+only DENY — any falsy return (None included) denies, so this module returns
+an explicit True to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+WIKI = "Jarvis Wiki Page"
+
+WIKI_USER_ROLE = "Knowledge Wiki User"
+WIKI_MANAGER_ROLE = "Knowledge Wiki Manager"
+
+# Never offered as a Role-scope audience (mirrors agents_api's selectable set).
+_NON_TARGETABLE_ROLES = ("Administrator", "Guest", "All")
+
+# ptypes that reveal page content; everything read-shaped maps to visibility.
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	# Administrator's get_roles returns every Role, so the explicit check is
+	# just a shortcut; both spellings of "full access" land here.
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def _get(page, field: str):
+	# dict rows (frappe.get_all) and Document both expose .get.
+	return page.get(field)
+
+
+def can_read_page(page, user: str | None = None) -> bool:
+	"""Visibility matrix for one page (dict with scope/target_* fields, or a
+	Document)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	scope = (_get(page, "scope") or "").strip() or "Org"
+	if scope == "Org":
+		return True
+	if scope == "Role":
+		target_role = _get(page, "target_role")
+		return bool(target_role) and target_role in frappe.get_roles(user)
+	if scope == "User":
+		return (_get(page, "target_user") or "") == user
+	return False
+
+
+def can_edit_page(page, user: str | None = None) -> bool:
+	"""Human-channel write matrix (create/modify). The LLM channel's Org
+	writes bypass this by design — see the module docstring."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	scope = (_get(page, "scope") or "").strip() or "Org"
+	roles = set(frappe.get_roles(user))
+	if scope == "Role":
+		target_role = _get(page, "target_role")
+		return (
+			WIKI_MANAGER_ROLE in roles
+			and bool(target_role)
+			and target_role in roles
+		)
+	if scope == "User":
+		return (_get(page, "target_user") or "") == user and bool(
+			roles & {WIKI_USER_ROLE, WIKI_MANAGER_ROLE}
+		)
+	# Org pages: System Manager only.
+	return False
+
+
+def can_archive_page(page, user: str | None = None) -> bool:
+	"""Archive shares the edit matrix (archive is a status flip through save)."""
+	return can_edit_page(page, user)
+
+
+def creatable_scopes(user: str | None = None) -> list[str]:
+	"""Scopes this user may create pages in (subset of Org/Role/User).
+	Plain desk users get [] — their wiki writes flow through the LLM channel."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ["Org", "Role", "User"]
+	roles = set(frappe.get_roles(user))
+	out: list[str] = []
+	if WIKI_MANAGER_ROLE in roles:
+		out.append("Role")
+	if roles & {WIKI_USER_ROLE, WIKI_MANAGER_ROLE}:
+		out.append("User")
+	return out
+
+
+def manageable_roles(user: str | None = None) -> list[str]:
+	"""Roles the user may target for Role-scope pages: a Knowledge Wiki
+	Manager targets roles they hold; SM targets any enabled desk role."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return [
+			r
+			for r in frappe.get_all(
+				"Role",
+				filters={"disabled": 0, "desk_access": 1},
+				order_by="name asc",
+				pluck="name",
+			)
+			if r not in _NON_TARGETABLE_ROLES
+		]
+	if WIKI_MANAGER_ROLE not in frappe.get_roles(user):
+		return []
+	return sorted(set(frappe.get_roles(user)) - set(_NON_TARGETABLE_ROLES))
+
+
+def visible_scope_condition(user: str | None = None) -> str:
+	"""SQL boolean fragment over ``tabJarvis Wiki Page`` implementing the
+	visibility matrix; always a parenthesized valid expression so callers can
+	splice it with ``and``. Values go through frappe.db.escape — role names
+	and user emails are org-author-controlled strings."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return "(1=1)"
+	table = "`tabJarvis Wiki Page`"
+	clauses = [f"coalesce({table}.`scope`, '') in ('', 'Org')"]
+	roles = [r for r in frappe.get_roles(user) if r]
+	if roles:
+		role_list = ", ".join(frappe.db.escape(r) for r in roles)
+		clauses.append(
+			f"({table}.`scope` = 'Role' and {table}.`target_role` in ({role_list}))"
+		)
+	clauses.append(
+		f"({table}.`scope` = 'User' and {table}.`target_user` = {frappe.db.escape(user)})"
+	)
+	return "(" + " or ".join(clauses) + ")"
+
+
+def wiki_page_query_conditions(user: str | None = None) -> str:
+	"""hooks.permission_query_conditions entry — scopes every Desk/ORM list
+	query. Empty string (no restriction) for System Managers."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return visible_scope_condition(user)
+
+
+def has_wiki_page_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""hooks.has_permission entry — per-doc gate. Read-shaped ptypes follow
+	the visibility matrix, write follows the edit matrix, delete stays SM.
+	True defers to the role-perm check (hooks can only deny)."""
+	user = user or frappe.session.user
+	if ptype in _READ_PTYPES:
+		return can_read_page(doc, user)
+	if ptype == "write":
+		return can_edit_page(doc, user)
+	if ptype == "delete":
+		return _is_sm(user)
+	return True

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -171,6 +171,9 @@ after_migrate = [
 	# Voice & Wiki: seed the Settings Check defaults (row-existence probe;
 	# an unset Check reads 0 on v16, so defaults must be materialized).
 	"jarvis.learning.voice_facts.after_migrate",
+	# Wiki v2: seed the Knowledge Wiki User/Manager roles (idempotent;
+	# best-effort). Migrate follows a fresh install, so this covers both.
+	"jarvis.learning.roles.after_migrate",
 ]
 
 # Scheduled Tasks
@@ -231,6 +234,12 @@ scheduler_events = {
 		# candidates + wiki updates (self-gating; see jarvis/learning/voice_facts.py).
 		"jarvis.learning.voice_facts.process_daily",
 	],
+	"weekly": [
+		# Wiki v2 health check: deterministic lint over Active pages
+		# (contradictions, staleness, orphans, near-duplicate titles);
+		# summary lands on the Jarvis Settings RO fields. Swallows errors.
+		"jarvis.learning.wiki_lint.scheduled_lint",
+	],
 }
 
 # Python type annotations on whitelisted endpoints
@@ -252,5 +261,29 @@ _CLEAR_SCHEMA_CACHE = "jarvis.tools.get_schema.clear_schema_cache"
 doc_events = {
 	dt: {"on_update": _CLEAR_SCHEMA_CACHE, "on_trash": _CLEAR_SCHEMA_CACHE}
 	for dt in ("DocType", "Custom Field", "Property Setter", "Workflow")
+}
+
+# Org-scope wiki pages are mirrored as markdown into the tenant container
+# workspace; every page write/delete enqueues a debounced mirror sync (the
+# handler filters to Org scope itself and no-ops when the tenant is
+# unreachable — it never raises into the save path).
+_WIKI_MIRROR_SYNC = "jarvis.chat.wiki_mirror.on_wiki_page_change"
+doc_events["Jarvis Wiki Page"] = {
+	"after_insert": _WIKI_MIRROR_SYNC,
+	"on_update": _WIKI_MIRROR_SYNC,
+	"on_trash": _WIKI_MIRROR_SYNC,
+}
+
+# ---------------------------------------------------------------------------
+# Wiki page scoping (wiki v2)
+# ---------------------------------------------------------------------------
+# Org/Role/User visibility for Jarvis Wiki Page, enforced at the ORM: list
+# queries via permission_query_conditions, per-doc access via has_permission.
+# Matrix + SQL fragments live in jarvis/chat/wiki_permissions.py.
+permission_query_conditions = {
+	"Jarvis Wiki Page": "jarvis.chat.wiki_permissions.wiki_page_query_conditions",
+}
+has_permission = {
+	"Jarvis Wiki Page": "jarvis.chat.wiki_permissions.has_wiki_page_permission",
 }
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -1,632 +1,647 @@
 {
-  "doctype": "DocType",
-  "name": "Jarvis Settings",
-  "module": "Jarvis",
-  "issingle": 1,
-  "custom": 0,
-  "engine": "InnoDB",
-  "field_order": [
-    "config_tab",
-    "account_section",
-    "token_budget_monthly",
-    "enabled",
-    "llm_section",
-    "models",
-    "preset",
-    "routing_mode",
-    "proxy_active",
-    "proxy_recommended",
-    "llm_provider",
-    "llm_model",
-    "llm_column_break",
-    "llm_api_key",
-    "llm_base_url",
-    "llm_advanced_section",
-    "llm_temperature",
-    "llm_max_output_tokens",
-    "vision_attachments_enabled",
-    "llm_auth_section",
-    "llm_auth_mode",
-    "llm_oauth_account_email",
-    "llm_oauth_connected_at",
-    "behavioural_learning_section",
-    "pattern_learning_enabled",
-    "pattern_llm_polish",
-    "pattern_window_start",
-    "pattern_window_end",
-    "pattern_max_proposals_per_run",
-    "pattern_row_budget_per_night",
-    "pattern_last_run_at",
-    "pattern_last_run_status",
-    "pattern_next_run_at",
-    "pattern_scan_mode",
-    "voice_wiki_section",
-    "voice_features_enabled",
-    "wiki_enabled",
-    "wiki_nudge_cooldown_hours",
-    "voice_notes_last_processed_at",
-    "voice_notes_last_process_status",
-    "knowledge_language",
-    "wiki_lint_last_run_at",
-    "wiki_lint_summary",
-    "system_tab",
-    "deployment_section",
-    "deployment_mode",
-    "selfhost_last_validated_at",
-    "selfhost_last_validation",
-    "selfhost_tool_user",
-    "selfhost_stream",
-    "admin_connection_section",
-    "jarvis_admin_url",
-    "jarvis_admin_api_key",
-    "jarvis_admin_api_secret",
-    "jarvis_admin_customer_email",
-    "jarvis_admin_customer_password",
-    "operator_section",
-    "agent_url",
-    "agent_token",
-    "agent_token_issued_at",
-    "agent_token_max_age_days",
-    "chat_device_id",
-    "chat_device_public_key",
-    "chat_device_private_key",
-    "chat_device_token",
-    "last_sync_section",
-    "last_sync_at",
-    "last_sync_status",
-    "custom_skills_synced_at",
-    "custom_skills_sync_status",
-    "agent_skills_synced_at",
-    "agent_skills_sync_status",
-    "agent_catalog_dirty",
-    "agent_catalog_version",
-    "learned_skills_synced_at",
-    "learned_skills_sync_status",
-    "agent_tools_section",
-    "run_query_doctype_allowlist",
-    "auto_apply_changes",
-    "developer_section",
-    "sandbox_mode"
-  ],
-  "fields": [
-    {
-      "fieldname": "config_tab",
-      "fieldtype": "Tab Break",
-      "label": "Configuration"
-    },
-    {
-      "fieldname": "account_section",
-      "fieldtype": "Section Break",
-      "label": "Account"
-    },
-    {
-      "fieldname": "token_budget_monthly",
-      "fieldtype": "Int",
-      "label": "Monthly Token Budget",
-      "default": "0",
-      "description": "0 = unlimited. Otherwise hard cap before overage billing kicks in."
-    },
-    {
-      "fieldname": "enabled",
-      "fieldtype": "Check",
-      "label": "Enabled",
-      "default": "1"
-    },
-    {
-      "fieldname": "llm_section",
-      "fieldtype": "Section Break",
-      "label": "Language Model"
-    },
-    {
-      "fieldname": "models",
-      "fieldtype": "Table",
-      "label": "LLM Models",
-      "options": "Jarvis LLM Pool Model"
-    },
-    {
-      "fieldname": "preset",
-      "fieldtype": "Data",
-      "label": "Preset"
-    },
-    {
-      "fieldname": "routing_mode",
-      "fieldtype": "Select",
-      "label": "Routing Mode",
-      "options": "\ndynamic\nfailover",
-      "default": "dynamic",
-      "description": "How the LLM pool routes requests. 'dynamic' uses cost-tier routing; 'failover' tries models in order."
-    },
-    {
-      "fieldname": "proxy_active",
-      "fieldtype": "Check",
-      "label": "Proxy Active",
-      "read_only": 1
-    },
-    {
-      "fieldname": "proxy_recommended",
-      "fieldtype": "Check",
-      "label": "Proxy Recommended",
-      "read_only": 1
-    },
-    {
-      "fieldname": "llm_provider",
-      "fieldtype": "Data",
-      "label": "Provider",
-      "read_only": 1,
-      "description": "Mirrored from models[0].provider. May hold an internal provider ID (e.g. 'openai_compat') or a display name from legacy single-model config."
-    },
-    {
-      "fieldname": "llm_model",
-      "fieldtype": "Data",
-      "label": "Model",
-      "description": "Provider-specific model identifier (e.g. claude-sonnet-4-6, gpt-4o, gemini-2.0-flash, deepseek-chat, moonshot-v1-32k, llama-3.1-70b).",
-      "read_only": 1
-    },
-    {
-      "fieldname": "llm_column_break",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "llm_api_key",
-      "fieldtype": "Password",
-      "label": "API Key",
-      "description": "API key for the chosen provider. Leave blank for local providers (Ollama, vLLM).",
-      "read_only": 1
-    },
-    {
-      "fieldname": "llm_base_url",
-      "fieldtype": "Data",
-      "label": "Base URL",
-      "description": "Only for local or OpenAI-Compatible providers (e.g. http://localhost:11434/v1 for Ollama). Leave blank for hosted providers.",
-      "read_only": 1
-    },
-    {
-      "fieldname": "llm_advanced_section",
-      "fieldtype": "Section Break",
-      "label": "Sampling",
-      "collapsible": 1
-    },
-    {
-      "fieldname": "llm_temperature",
-      "fieldtype": "Float",
-      "label": "Temperature",
-      "default": "0.2",
-      "description": "0.0 = deterministic, 1.0 = creative. 0.2 is a good default for analytical Q&A."
-    },
-    {
-      "fieldname": "llm_max_output_tokens",
-      "fieldtype": "Int",
-      "label": "Max Output Tokens",
-      "default": "4096"
-    },
-    {
-      "fieldname": "llm_auth_section",
-      "fieldtype": "Section Break",
-      "label": "LLM Authentication"
-    },
-    {
-      "fieldname": "llm_auth_mode",
-      "fieldtype": "Select",
-      "label": "Auth Mode",
-      "options": "api_key\nsubscription\noauth",
-      "default": "api_key",
-      "reqd": 1,
-      "read_only": 1
-    },
-    {
-      "fieldname": "llm_oauth_account_email",
-      "fieldtype": "Data",
-      "label": "Connected Account",
-      "read_only": 1,
-      "depends_on": "eval:doc.llm_auth_mode == 'oauth'",
-      "description": "Email of the provider account whose subscription Jarvis is using. Populated on chat-subscription sign-in; cleared on Disconnect."
-    },
-    {
-      "fieldname": "llm_oauth_connected_at",
-      "fieldtype": "Datetime",
-      "label": "Connected At",
-      "read_only": 1,
-      "depends_on": "eval:doc.llm_auth_mode == 'oauth'"
-    },
-    {
-      "fieldname": "behavioural_learning_section",
-      "fieldtype": "Section Break",
-      "label": "Behavioural Learning",
-      "collapsible": 1,
-      "depends_on": "eval:doc.deployment_mode != 'Self-Hosted'",
-      "description": "Nightly, window-bound, READ-ONLY mining of this site's history into reviewable pattern proposals. Nothing activates without System Manager approval. Managed deployments only in v1 (hidden for self-host)."
-    },
-    {
-      "fieldname": "pattern_learning_enabled",
-      "fieldtype": "Check",
-      "label": "Enable Pattern Learning",
-      "default": "0"
-    },
-    {
-      "fieldname": "pattern_llm_polish",
-      "fieldtype": "Check",
-      "label": "Enable LLM Polish",
-      "default": "0",
-      "description": "Phase 2: let the reviewing System Manager rewrite a proposal's draft wording via one silent tenant-container LLM turn (never Administrator). Capped at 150 turns per site per month; over the cap or on any failure the deterministic template text is kept unchanged."
-    },
-    {
-      "fieldname": "pattern_window_start",
-      "fieldtype": "Time",
-      "label": "Analysis Window Start",
-      "default": "01:00:00"
-    },
-    {
-      "fieldname": "pattern_window_end",
-      "fieldtype": "Time",
-      "label": "Analysis Window End",
-      "default": "05:00:00",
-      "description": "Window must be at least 1 hour. End before start is legal: the window crosses midnight."
-    },
-    {
-      "fieldname": "pattern_max_proposals_per_run",
-      "fieldtype": "Int",
-      "label": "Max Proposals per Run",
-      "default": "10"
-    },
-    {
-      "fieldname": "pattern_row_budget_per_night",
-      "fieldtype": "Int",
-      "label": "Row Scan Budget per Night",
-      "default": "500000",
-      "description": "EXPLAIN-estimated rows a nightly run may scan before remaining detectors are deferred to later nights."
-    },
-    {
-      "fieldname": "pattern_last_run_at",
-      "fieldtype": "Datetime",
-      "label": "Last Learning Run At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "pattern_last_run_status",
-      "fieldtype": "Long Text",
-      "label": "Last Learning Run Status",
-      "read_only": 1
-    },
-    {
-      "fieldname": "pattern_next_run_at",
-      "fieldtype": "Datetime",
-      "label": "Next Learning Run At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "pattern_scan_mode",
-      "fieldtype": "Data",
-      "label": "Learning Scan Mode",
-      "read_only": 1
-    },
-    {
-      "fieldname": "voice_wiki_section",
-      "fieldtype": "Section Break",
-      "label": "Voice & Wiki",
-      "collapsible": 1
-    },
-    {
-      "fieldname": "voice_features_enabled",
-      "fieldtype": "Check",
-      "label": "Enable Voice Features",
-      "default": "1",
-      "description": "Mic capture + speech-to-text in chat and the Business tab. Readers treat an unset value as ON (Single defaults are not backfilled on migrate)."
-    },
-    {
-      "fieldname": "wiki_enabled",
-      "fieldtype": "Check",
-      "label": "Enable Business Wiki",
-      "default": "1",
-      "description": "Business wiki pages + post-turn wiki nudges. Readers treat an unset value as ON."
-    },
-    {
-      "fieldname": "wiki_nudge_cooldown_hours",
-      "fieldtype": "Int",
-      "label": "Wiki Nudge Cooldown (hours)",
-      "default": "24",
-      "description": "Minimum gap between wiki nudges in the same conversation."
-    },
-    {
-      "fieldname": "voice_notes_last_processed_at",
-      "fieldtype": "Datetime",
-      "label": "Voice Notes Last Processed At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "voice_notes_last_process_status",
-      "fieldtype": "Long Text",
-      "label": "Voice Notes Last Process Status",
-      "read_only": 1
-    },
-    {
-      "fieldname": "knowledge_language",
-      "fieldtype": "Select",
-      "label": "Knowledge Language",
-      "options": "English\nOriginal",
-      "default": "English",
-      "description": "Language for extracted knowledge (voice facts, wiki pages, drafted skill text). English (recommended) translates non-English input, keeping proper nouns in their original script with a Latin transliteration; Original keeps the dominant language of the source material. Chat transcription is always verbatim."
-    },
-    {
-      "fieldname": "wiki_lint_last_run_at",
-      "fieldtype": "Datetime",
-      "label": "Wiki Lint Last Run At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "wiki_lint_summary",
-      "fieldtype": "Small Text",
-      "label": "Wiki Lint Summary",
-      "read_only": 1,
-      "description": "Summary of the last wiki health check (contradictions, stale, orphans, near-duplicate titles)."
-    },
-    {
-      "fieldname": "system_tab",
-      "fieldtype": "Tab Break",
-      "label": "System"
-    },
-    {
-      "fieldname": "deployment_section",
-      "fieldtype": "Section Break",
-      "label": "Deployment Mode"
-    },
-    {
-      "fieldname": "deployment_mode",
-      "fieldtype": "Select",
-      "label": "Deployment Mode",
-      "options": "Managed\nSelf-Hosted",
-      "default": "Managed",
-      "description": "Managed = Aerele-hosted openclaw container (persona + skills, billed). Self-Hosted = connect to your own openclaw server (you bring openclaw + LLM; no Aerele persona/skills). Switchable; chat history is preserved."
-    },
-    {
-      "fieldname": "selfhost_last_validated_at",
-      "fieldtype": "Datetime",
-      "label": "Self-Host Last Validated At",
-      "read_only": 1,
-      "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'"
-    },
-    {
-      "fieldname": "selfhost_last_validation",
-      "fieldtype": "Long Text",
-      "label": "Self-Host Last Validation",
-      "read_only": 1,
-      "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
-      "description": "JSON result of the last connection validation (per-check pass/fail)."
-    },
-    {
-      "fieldname": "selfhost_tool_user",
-      "fieldtype": "Link",
-      "options": "User",
-      "label": "Self-Host Tool User",
-      "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
-      "description": "Frappe user whose permissions the jarvis__* (ERP) tools run under when chatting via a self-hosted openclaw. A self-hosted bench is single-tenant; defaults to whoever configured self-host."
-    },
-    {
-      "fieldname": "selfhost_stream",
-      "fieldtype": "Check",
-      "label": "Stream Self-Host Responses",
-      "default": "1",
-      "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
-      "description": "Stream the agent's reply token-by-token over HTTP (SSE) for a responsive chat. Turn off if your openclaw (or a proxy in front of it) buffers streaming responses, in which case the full reply appears at once."
-    },
-    {
-      "fieldname": "vision_attachments_enabled",
-      "fieldtype": "Check",
-      "label": "Send Image/PDF Attachments as Vision",
-      "default": "1",
-      "description": "When on, images and PDFs the customer attaches in chat are sent to the model as native vision (the model sees them directly; PDFs are rasterized to page-images). Requires a vision-capable model (Anthropic / OpenAI / Google Gemini). Managed pool only."
-    },
-    {
-      "fieldname": "admin_connection_section",
-      "fieldtype": "Section Break",
-      "label": "Jarvis Admin Connection",
-      "description": "Populated by the signup wizard; not customer-editable."
-    },
-    {
-      "fieldname": "jarvis_admin_url",
-      "fieldtype": "Data",
-      "label": "Jarvis Admin URL",
-      "read_only": 1,
-      "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
-    },
-    {
-      "fieldname": "jarvis_admin_api_key",
-      "fieldtype": "Password",
-      "label": "Jarvis Admin API Key",
-      "read_only": 1,
-      "description": "Native Frappe api_key for the customer's User on the admin site. Paired with the secret below as `Authorization: token <key>:<secret>`."
-    },
-    {
-      "fieldname": "jarvis_admin_api_secret",
-      "fieldtype": "Password",
-      "label": "Jarvis Admin API Secret",
-      "read_only": 1,
-      "description": "Native Frappe api_secret paired with the API Key. Set automatically at onboarding."
-    },
-    {
-      "fieldname": "jarvis_admin_customer_email",
-      "fieldtype": "Data",
-      "label": "Jarvis Admin Customer Email",
-      "read_only": 1,
-      "description": "The customer's login (email) on the admin site. Used as the OAuth password-grant username. Set automatically at onboarding."
-    },
-    {
-      "fieldname": "jarvis_admin_customer_password",
-      "fieldtype": "Password",
-      "label": "Jarvis Admin Customer Password",
-      "read_only": 1,
-      "description": "The customer's password on the admin site, exchanged for short-lived OAuth bearer tokens (client_id `jarvis-bench`). Set automatically once the email is verified. Empty for pre-OAuth customers, which fall back to api_key:api_secret."
-    },
-    {
-      "fieldname": "operator_section",
-      "fieldtype": "Section Break",
-      "label": "Agent Operator",
-      "description": "Operator config - populated by jarvis.openclaw_bootstrap.start (dev) or the Jarvis admin signup response (prod)."
-    },
-    {
-      "fieldname": "agent_url",
-      "fieldtype": "Data",
-      "label": "Agent URL",
-      "read_only": 1,
-      "description": "WebSocket URL for the customer's openclaw agent (e.g. ws://127.0.0.1:18789 in dev; wss://<subdomain>.<admin-host>:443 in prod)"
-    },
-    {
-      "fieldname": "agent_token",
-      "fieldtype": "Password",
-      "label": "Agent Token",
-      "read_only": 1,
-      "description": "Bearer token used to authenticate the secrets.reload RPC and the chat worker's WebSocket session"
-    },
-    {
-      "fieldname": "agent_token_issued_at",
-      "fieldtype": "Datetime",
-      "label": "Agent Token Issued At",
-      "read_only": 1,
-      "description": "Timestamp of the last rotate_agent_token. C2 (2026-06-16 review): combined with agent_token_max_age_days, lets the bench enforce periodic rotation hygiene like SSH host-key / TLS-cert rotation. Empty == unbounded (legacy)."
-    },
-    {
-      "fieldname": "agent_token_max_age_days",
-      "fieldtype": "Int",
-      "label": "Agent Token Max Age (days)",
-      "default": 90,
-      "description": "Reject the bearer token if issued_at + this many days < now. Default 90 days. Set to 0 to disable expiry (not recommended). Operator rotates via the rotate_agent_token endpoint."
-    },
-    {
-      "fieldname": "chat_device_id",
-      "fieldtype": "Data",
-      "label": "Chat Device ID",
-      "read_only": 1,
-      "description": "sha256(rawPublicKey).hex - openclaw deviceId this bench was paired as. Set lazily on first chat; cleared on re-pair."
-    },
-    {
-      "fieldname": "chat_device_public_key",
-      "fieldtype": "Long Text",
-      "label": "Chat Device Public Key",
-      "read_only": 1,
-      "description": "Base64url-encoded Ed25519 public key registered with openclaw at pair time."
-    },
-    {
-      "fieldname": "chat_device_private_key",
-      "fieldtype": "Password",
-      "label": "Chat Device Private Key",
-      "read_only": 1,
-      "description": "Base64url-encoded Ed25519 private key. Never leaves this bench. Used to sign the connect challenge at every chat WS handshake."
-    },
-    {
-      "fieldname": "chat_device_token",
-      "fieldtype": "Password",
-      "label": "Chat Device Token",
-      "read_only": 1,
-      "description": "Bearer token openclaw issued at pair time. Sent in auth.deviceToken at every chat WS connect."
-    },
-    {
-      "fieldname": "last_sync_section",
-      "fieldtype": "Section Break",
-      "label": "Last Sync",
-      "collapsible": 1
-    },
-    {
-      "fieldname": "last_sync_at",
-      "fieldtype": "Datetime",
-      "label": "Last Sync At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "last_sync_status",
-      "fieldtype": "Long Text",
-      "label": "Last Sync Status",
-      "read_only": 1
-    },
-    {
-      "fieldname": "custom_skills_synced_at",
-      "fieldtype": "Datetime",
-      "label": "Custom Skills Synced At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "custom_skills_sync_status",
-      "fieldtype": "Long Text",
-      "label": "Custom Skills Sync Status",
-      "read_only": 1
-    },
-    {
-      "fieldname": "agent_skills_synced_at",
-      "fieldtype": "Datetime",
-      "label": "Agent Skills Synced At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "agent_skills_sync_status",
-      "fieldtype": "Long Text",
-      "label": "Agent Skills Sync Status",
-      "read_only": 1
-    },
-    {
-      "default": "0",
-      "description": "Set when an install/uninstall/enable-disable changes the enabled agent set; cleared by a successful Apply push. Surfaced as `dirty` in get_agents_sync_status.",
-      "fieldname": "agent_catalog_dirty",
-      "fieldtype": "Check",
-      "hidden": 1,
-      "label": "Agent Catalog Dirty",
-      "read_only": 1
-    },
-    {
-      "default": "0",
-      "description": "Monotonic counter bumped by every enabled-set mutation. The Apply push snapshots it before building the payload and clears the dirty flag only if it is unchanged after a successful push, so a mutation landing mid-push keeps dirty set (TOCTOU guard).",
-      "fieldname": "agent_catalog_version",
-      "fieldtype": "Int",
-      "hidden": 1,
-      "label": "Agent Catalog Version",
-      "read_only": 1
-    },
-    {
-      "fieldname": "learned_skills_synced_at",
-      "fieldtype": "Datetime",
-      "label": "Learned Skills Synced At",
-      "read_only": 1
-    },
-    {
-      "fieldname": "learned_skills_sync_status",
-      "fieldtype": "Long Text",
-      "label": "Learned Skills Sync Status",
-      "read_only": 1
-    },
-    {
-      "fieldname": "agent_tools_section",
-      "fieldtype": "Section Break",
-      "label": "Agent Tool Restrictions"
-    },
-    {
-      "fieldname": "run_query_doctype_allowlist",
-      "fieldtype": "Small Text",
-      "label": "run_query DocType Allowlist",
-      "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
-    },
-    {
-      "fieldname": "auto_apply_changes",
-      "fieldtype": "Check",
-      "label": "Auto-apply changes (skip confirmation)",
-      "default": "0",
-      "description": "DEPRECATED (issue #186): auto-apply is now per-conversation and admin-gated (Jarvis Conversation.auto_apply). This site-wide Single field is no longer read or written; left in place to avoid a destructive schema change."
-    },
-    {
-      "fieldname": "developer_section",
-      "fieldtype": "Section Break",
-      "label": "Developer / Sandbox"
-    },
-    {
-      "fieldname": "sandbox_mode",
-      "fieldtype": "Check",
-      "label": "Enable Sandbox Mode",
-      "default": "0",
-      "description": "When enabled, skip payment + allow the developer-onboarding shortcut (jarvis.onboarding.dev_onboard) on this site. Customer's responsibility: only flip this on a dev/test bench. Replaces the legacy <code>frappe.conf.developer_mode</code> check; that flag still works as a backwards-compat fallback for one release."
-    }
-  ],
-  "permissions": [
-    {
-      "role": "System Manager",
-      "read": 1,
-      "write": 1,
-      "create": 1
-    }
-  ]
+ "doctype": "DocType",
+ "name": "Jarvis Settings",
+ "module": "Jarvis",
+ "issingle": 1,
+ "custom": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "config_tab",
+  "account_section",
+  "token_budget_monthly",
+  "enabled",
+  "llm_section",
+  "models",
+  "preset",
+  "routing_mode",
+  "proxy_active",
+  "proxy_recommended",
+  "llm_provider",
+  "llm_model",
+  "llm_column_break",
+  "llm_api_key",
+  "llm_base_url",
+  "llm_advanced_section",
+  "llm_temperature",
+  "llm_max_output_tokens",
+  "vision_attachments_enabled",
+  "llm_auth_section",
+  "llm_auth_mode",
+  "llm_oauth_account_email",
+  "llm_oauth_connected_at",
+  "behavioural_learning_section",
+  "pattern_learning_enabled",
+  "pattern_llm_polish",
+  "pattern_window_start",
+  "pattern_window_end",
+  "pattern_max_proposals_per_run",
+  "pattern_row_budget_per_night",
+  "pattern_last_run_at",
+  "pattern_last_run_status",
+  "pattern_next_run_at",
+  "pattern_scan_mode",
+  "voice_wiki_section",
+  "voice_features_enabled",
+  "wiki_enabled",
+  "wiki_nudge_cooldown_hours",
+  "voice_notes_last_processed_at",
+  "voice_notes_last_process_status",
+  "knowledge_language",
+  "wiki_lint_last_run_at",
+  "wiki_lint_summary",
+  "wiki_mirror_last_synced_at",
+  "wiki_mirror_last_sync_status",
+  "system_tab",
+  "deployment_section",
+  "deployment_mode",
+  "selfhost_last_validated_at",
+  "selfhost_last_validation",
+  "selfhost_tool_user",
+  "selfhost_stream",
+  "admin_connection_section",
+  "jarvis_admin_url",
+  "jarvis_admin_api_key",
+  "jarvis_admin_api_secret",
+  "jarvis_admin_customer_email",
+  "jarvis_admin_customer_password",
+  "operator_section",
+  "agent_url",
+  "agent_token",
+  "agent_token_issued_at",
+  "agent_token_max_age_days",
+  "chat_device_id",
+  "chat_device_public_key",
+  "chat_device_private_key",
+  "chat_device_token",
+  "last_sync_section",
+  "last_sync_at",
+  "last_sync_status",
+  "custom_skills_synced_at",
+  "custom_skills_sync_status",
+  "agent_skills_synced_at",
+  "agent_skills_sync_status",
+  "agent_catalog_dirty",
+  "agent_catalog_version",
+  "learned_skills_synced_at",
+  "learned_skills_sync_status",
+  "agent_tools_section",
+  "run_query_doctype_allowlist",
+  "auto_apply_changes",
+  "developer_section",
+  "sandbox_mode"
+ ],
+ "fields": [
+  {
+   "fieldname": "config_tab",
+   "fieldtype": "Tab Break",
+   "label": "Configuration"
+  },
+  {
+   "fieldname": "account_section",
+   "fieldtype": "Section Break",
+   "label": "Account"
+  },
+  {
+   "fieldname": "token_budget_monthly",
+   "fieldtype": "Int",
+   "label": "Monthly Token Budget",
+   "default": "0",
+   "description": "0 = unlimited. Otherwise hard cap before overage billing kicks in."
+  },
+  {
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled",
+   "default": "1"
+  },
+  {
+   "fieldname": "llm_section",
+   "fieldtype": "Section Break",
+   "label": "Language Model"
+  },
+  {
+   "fieldname": "models",
+   "fieldtype": "Table",
+   "label": "LLM Models",
+   "options": "Jarvis LLM Pool Model"
+  },
+  {
+   "fieldname": "preset",
+   "fieldtype": "Data",
+   "label": "Preset"
+  },
+  {
+   "fieldname": "routing_mode",
+   "fieldtype": "Select",
+   "label": "Routing Mode",
+   "options": "\ndynamic\nfailover",
+   "default": "dynamic",
+   "description": "How the LLM pool routes requests. 'dynamic' uses cost-tier routing; 'failover' tries models in order."
+  },
+  {
+   "fieldname": "proxy_active",
+   "fieldtype": "Check",
+   "label": "Proxy Active",
+   "read_only": 1
+  },
+  {
+   "fieldname": "proxy_recommended",
+   "fieldtype": "Check",
+   "label": "Proxy Recommended",
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_provider",
+   "fieldtype": "Data",
+   "label": "Provider",
+   "read_only": 1,
+   "description": "Mirrored from models[0].provider. May hold an internal provider ID (e.g. 'openai_compat') or a display name from legacy single-model config."
+  },
+  {
+   "fieldname": "llm_model",
+   "fieldtype": "Data",
+   "label": "Model",
+   "description": "Provider-specific model identifier (e.g. claude-sonnet-4-6, gpt-4o, gemini-2.0-flash, deepseek-chat, moonshot-v1-32k, llama-3.1-70b).",
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_column_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "llm_api_key",
+   "fieldtype": "Password",
+   "label": "API Key",
+   "description": "API key for the chosen provider. Leave blank for local providers (Ollama, vLLM).",
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_base_url",
+   "fieldtype": "Data",
+   "label": "Base URL",
+   "description": "Only for local or OpenAI-Compatible providers (e.g. http://localhost:11434/v1 for Ollama). Leave blank for hosted providers.",
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_advanced_section",
+   "fieldtype": "Section Break",
+   "label": "Sampling",
+   "collapsible": 1
+  },
+  {
+   "fieldname": "llm_temperature",
+   "fieldtype": "Float",
+   "label": "Temperature",
+   "default": "0.2",
+   "description": "0.0 = deterministic, 1.0 = creative. 0.2 is a good default for analytical Q&A."
+  },
+  {
+   "fieldname": "llm_max_output_tokens",
+   "fieldtype": "Int",
+   "label": "Max Output Tokens",
+   "default": "4096"
+  },
+  {
+   "fieldname": "llm_auth_section",
+   "fieldtype": "Section Break",
+   "label": "LLM Authentication"
+  },
+  {
+   "fieldname": "llm_auth_mode",
+   "fieldtype": "Select",
+   "label": "Auth Mode",
+   "options": "api_key\nsubscription\noauth",
+   "default": "api_key",
+   "reqd": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "llm_oauth_account_email",
+   "fieldtype": "Data",
+   "label": "Connected Account",
+   "read_only": 1,
+   "depends_on": "eval:doc.llm_auth_mode == 'oauth'",
+   "description": "Email of the provider account whose subscription Jarvis is using. Populated on chat-subscription sign-in; cleared on Disconnect."
+  },
+  {
+   "fieldname": "llm_oauth_connected_at",
+   "fieldtype": "Datetime",
+   "label": "Connected At",
+   "read_only": 1,
+   "depends_on": "eval:doc.llm_auth_mode == 'oauth'"
+  },
+  {
+   "fieldname": "behavioural_learning_section",
+   "fieldtype": "Section Break",
+   "label": "Behavioural Learning",
+   "collapsible": 1,
+   "depends_on": "eval:doc.deployment_mode != 'Self-Hosted'",
+   "description": "Nightly, window-bound, READ-ONLY mining of this site's history into reviewable pattern proposals. Nothing activates without System Manager approval. Managed deployments only in v1 (hidden for self-host)."
+  },
+  {
+   "fieldname": "pattern_learning_enabled",
+   "fieldtype": "Check",
+   "label": "Enable Pattern Learning",
+   "default": "0"
+  },
+  {
+   "fieldname": "pattern_llm_polish",
+   "fieldtype": "Check",
+   "label": "Enable LLM Polish",
+   "default": "0",
+   "description": "Phase 2: let the reviewing System Manager rewrite a proposal's draft wording via one silent tenant-container LLM turn (never Administrator). Capped at 150 turns per site per month; over the cap or on any failure the deterministic template text is kept unchanged."
+  },
+  {
+   "fieldname": "pattern_window_start",
+   "fieldtype": "Time",
+   "label": "Analysis Window Start",
+   "default": "01:00:00"
+  },
+  {
+   "fieldname": "pattern_window_end",
+   "fieldtype": "Time",
+   "label": "Analysis Window End",
+   "default": "05:00:00",
+   "description": "Window must be at least 1 hour. End before start is legal: the window crosses midnight."
+  },
+  {
+   "fieldname": "pattern_max_proposals_per_run",
+   "fieldtype": "Int",
+   "label": "Max Proposals per Run",
+   "default": "10"
+  },
+  {
+   "fieldname": "pattern_row_budget_per_night",
+   "fieldtype": "Int",
+   "label": "Row Scan Budget per Night",
+   "default": "500000",
+   "description": "EXPLAIN-estimated rows a nightly run may scan before remaining detectors are deferred to later nights."
+  },
+  {
+   "fieldname": "pattern_last_run_at",
+   "fieldtype": "Datetime",
+   "label": "Last Learning Run At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pattern_last_run_status",
+   "fieldtype": "Long Text",
+   "label": "Last Learning Run Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pattern_next_run_at",
+   "fieldtype": "Datetime",
+   "label": "Next Learning Run At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pattern_scan_mode",
+   "fieldtype": "Data",
+   "label": "Learning Scan Mode",
+   "read_only": 1
+  },
+  {
+   "fieldname": "voice_wiki_section",
+   "fieldtype": "Section Break",
+   "label": "Voice & Wiki",
+   "collapsible": 1
+  },
+  {
+   "fieldname": "voice_features_enabled",
+   "fieldtype": "Check",
+   "label": "Enable Voice Features",
+   "default": "1",
+   "description": "Mic capture + speech-to-text in chat and the Business tab. Readers treat an unset value as ON (Single defaults are not backfilled on migrate)."
+  },
+  {
+   "fieldname": "wiki_enabled",
+   "fieldtype": "Check",
+   "label": "Enable Business Wiki",
+   "default": "1",
+   "description": "Business wiki pages + post-turn wiki nudges. Readers treat an unset value as ON."
+  },
+  {
+   "fieldname": "wiki_nudge_cooldown_hours",
+   "fieldtype": "Int",
+   "label": "Wiki Nudge Cooldown (hours)",
+   "default": "24",
+   "description": "Minimum gap between wiki nudges in the same conversation."
+  },
+  {
+   "fieldname": "voice_notes_last_processed_at",
+   "fieldtype": "Datetime",
+   "label": "Voice Notes Last Processed At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "voice_notes_last_process_status",
+   "fieldtype": "Long Text",
+   "label": "Voice Notes Last Process Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "knowledge_language",
+   "fieldtype": "Select",
+   "label": "Knowledge Language",
+   "options": "English\nOriginal",
+   "default": "English",
+   "description": "Language for extracted knowledge (voice facts, wiki pages, drafted skill text). English (recommended) translates non-English input, keeping proper nouns in their original script with a Latin transliteration; Original keeps the dominant language of the source material. Chat transcription is always verbatim."
+  },
+  {
+   "fieldname": "wiki_lint_last_run_at",
+   "fieldtype": "Datetime",
+   "label": "Wiki Lint Last Run At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "wiki_lint_summary",
+   "fieldtype": "Small Text",
+   "label": "Wiki Lint Summary",
+   "read_only": 1,
+   "description": "Summary of the last wiki health check (contradictions, stale, orphans, near-duplicate titles)."
+  },
+  {
+   "fieldname": "wiki_mirror_last_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Wiki Mirror Last Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "wiki_mirror_last_sync_status",
+   "fieldtype": "Data",
+   "label": "Wiki Mirror Last Sync Status",
+   "read_only": 1,
+   "description": "Outcome of the last org-wiki mirror sync into the agent workspace."
+  },
+  {
+   "fieldname": "system_tab",
+   "fieldtype": "Tab Break",
+   "label": "System"
+  },
+  {
+   "fieldname": "deployment_section",
+   "fieldtype": "Section Break",
+   "label": "Deployment Mode"
+  },
+  {
+   "fieldname": "deployment_mode",
+   "fieldtype": "Select",
+   "label": "Deployment Mode",
+   "options": "Managed\nSelf-Hosted",
+   "default": "Managed",
+   "description": "Managed = Aerele-hosted openclaw container (persona + skills, billed). Self-Hosted = connect to your own openclaw server (you bring openclaw + LLM; no Aerele persona/skills). Switchable; chat history is preserved."
+  },
+  {
+   "fieldname": "selfhost_last_validated_at",
+   "fieldtype": "Datetime",
+   "label": "Self-Host Last Validated At",
+   "read_only": 1,
+   "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'"
+  },
+  {
+   "fieldname": "selfhost_last_validation",
+   "fieldtype": "Long Text",
+   "label": "Self-Host Last Validation",
+   "read_only": 1,
+   "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
+   "description": "JSON result of the last connection validation (per-check pass/fail)."
+  },
+  {
+   "fieldname": "selfhost_tool_user",
+   "fieldtype": "Link",
+   "options": "User",
+   "label": "Self-Host Tool User",
+   "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
+   "description": "Frappe user whose permissions the jarvis__* (ERP) tools run under when chatting via a self-hosted openclaw. A self-hosted bench is single-tenant; defaults to whoever configured self-host."
+  },
+  {
+   "fieldname": "selfhost_stream",
+   "fieldtype": "Check",
+   "label": "Stream Self-Host Responses",
+   "default": "1",
+   "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
+   "description": "Stream the agent's reply token-by-token over HTTP (SSE) for a responsive chat. Turn off if your openclaw (or a proxy in front of it) buffers streaming responses, in which case the full reply appears at once."
+  },
+  {
+   "fieldname": "vision_attachments_enabled",
+   "fieldtype": "Check",
+   "label": "Send Image/PDF Attachments as Vision",
+   "default": "1",
+   "description": "When on, images and PDFs the customer attaches in chat are sent to the model as native vision (the model sees them directly; PDFs are rasterized to page-images). Requires a vision-capable model (Anthropic / OpenAI / Google Gemini). Managed pool only."
+  },
+  {
+   "fieldname": "admin_connection_section",
+   "fieldtype": "Section Break",
+   "label": "Jarvis Admin Connection",
+   "description": "Populated by the signup wizard; not customer-editable."
+  },
+  {
+   "fieldname": "jarvis_admin_url",
+   "fieldtype": "Data",
+   "label": "Jarvis Admin URL",
+   "read_only": 1,
+   "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
+  },
+  {
+   "fieldname": "jarvis_admin_api_key",
+   "fieldtype": "Password",
+   "label": "Jarvis Admin API Key",
+   "read_only": 1,
+   "description": "Native Frappe api_key for the customer's User on the admin site. Paired with the secret below as `Authorization: token <key>:<secret>`."
+  },
+  {
+   "fieldname": "jarvis_admin_api_secret",
+   "fieldtype": "Password",
+   "label": "Jarvis Admin API Secret",
+   "read_only": 1,
+   "description": "Native Frappe api_secret paired with the API Key. Set automatically at onboarding."
+  },
+  {
+   "fieldname": "jarvis_admin_customer_email",
+   "fieldtype": "Data",
+   "label": "Jarvis Admin Customer Email",
+   "read_only": 1,
+   "description": "The customer's login (email) on the admin site. Used as the OAuth password-grant username. Set automatically at onboarding."
+  },
+  {
+   "fieldname": "jarvis_admin_customer_password",
+   "fieldtype": "Password",
+   "label": "Jarvis Admin Customer Password",
+   "read_only": 1,
+   "description": "The customer's password on the admin site, exchanged for short-lived OAuth bearer tokens (client_id `jarvis-bench`). Set automatically once the email is verified. Empty for pre-OAuth customers, which fall back to api_key:api_secret."
+  },
+  {
+   "fieldname": "operator_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Operator",
+   "description": "Operator config - populated by jarvis.openclaw_bootstrap.start (dev) or the Jarvis admin signup response (prod)."
+  },
+  {
+   "fieldname": "agent_url",
+   "fieldtype": "Data",
+   "label": "Agent URL",
+   "read_only": 1,
+   "description": "WebSocket URL for the customer's openclaw agent (e.g. ws://127.0.0.1:18789 in dev; wss://<subdomain>.<admin-host>:443 in prod)"
+  },
+  {
+   "fieldname": "agent_token",
+   "fieldtype": "Password",
+   "label": "Agent Token",
+   "read_only": 1,
+   "description": "Bearer token used to authenticate the secrets.reload RPC and the chat worker's WebSocket session"
+  },
+  {
+   "fieldname": "agent_token_issued_at",
+   "fieldtype": "Datetime",
+   "label": "Agent Token Issued At",
+   "read_only": 1,
+   "description": "Timestamp of the last rotate_agent_token. C2 (2026-06-16 review): combined with agent_token_max_age_days, lets the bench enforce periodic rotation hygiene like SSH host-key / TLS-cert rotation. Empty == unbounded (legacy)."
+  },
+  {
+   "fieldname": "agent_token_max_age_days",
+   "fieldtype": "Int",
+   "label": "Agent Token Max Age (days)",
+   "default": 90,
+   "description": "Reject the bearer token if issued_at + this many days < now. Default 90 days. Set to 0 to disable expiry (not recommended). Operator rotates via the rotate_agent_token endpoint."
+  },
+  {
+   "fieldname": "chat_device_id",
+   "fieldtype": "Data",
+   "label": "Chat Device ID",
+   "read_only": 1,
+   "description": "sha256(rawPublicKey).hex - openclaw deviceId this bench was paired as. Set lazily on first chat; cleared on re-pair."
+  },
+  {
+   "fieldname": "chat_device_public_key",
+   "fieldtype": "Long Text",
+   "label": "Chat Device Public Key",
+   "read_only": 1,
+   "description": "Base64url-encoded Ed25519 public key registered with openclaw at pair time."
+  },
+  {
+   "fieldname": "chat_device_private_key",
+   "fieldtype": "Password",
+   "label": "Chat Device Private Key",
+   "read_only": 1,
+   "description": "Base64url-encoded Ed25519 private key. Never leaves this bench. Used to sign the connect challenge at every chat WS handshake."
+  },
+  {
+   "fieldname": "chat_device_token",
+   "fieldtype": "Password",
+   "label": "Chat Device Token",
+   "read_only": 1,
+   "description": "Bearer token openclaw issued at pair time. Sent in auth.deviceToken at every chat WS connect."
+  },
+  {
+   "fieldname": "last_sync_section",
+   "fieldtype": "Section Break",
+   "label": "Last Sync",
+   "collapsible": 1
+  },
+  {
+   "fieldname": "last_sync_at",
+   "fieldtype": "Datetime",
+   "label": "Last Sync At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_sync_status",
+   "fieldtype": "Long Text",
+   "label": "Last Sync Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "custom_skills_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Custom Skills Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "custom_skills_sync_status",
+   "fieldtype": "Long Text",
+   "label": "Custom Skills Sync Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "agent_skills_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Agent Skills Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "agent_skills_sync_status",
+   "fieldtype": "Long Text",
+   "label": "Agent Skills Sync Status",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Set when an install/uninstall/enable-disable changes the enabled agent set; cleared by a successful Apply push. Surfaced as `dirty` in get_agents_sync_status.",
+   "fieldname": "agent_catalog_dirty",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Agent Catalog Dirty",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Monotonic counter bumped by every enabled-set mutation. The Apply push snapshots it before building the payload and clears the dirty flag only if it is unchanged after a successful push, so a mutation landing mid-push keeps dirty set (TOCTOU guard).",
+   "fieldname": "agent_catalog_version",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Agent Catalog Version",
+   "read_only": 1
+  },
+  {
+   "fieldname": "learned_skills_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Learned Skills Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "learned_skills_sync_status",
+   "fieldtype": "Long Text",
+   "label": "Learned Skills Sync Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "agent_tools_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Tool Restrictions"
+  },
+  {
+   "fieldname": "run_query_doctype_allowlist",
+   "fieldtype": "Small Text",
+   "label": "run_query DocType Allowlist",
+   "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
+  },
+  {
+   "fieldname": "auto_apply_changes",
+   "fieldtype": "Check",
+   "label": "Auto-apply changes (skip confirmation)",
+   "default": "0",
+   "description": "DEPRECATED (issue #186): auto-apply is now per-conversation and admin-gated (Jarvis Conversation.auto_apply). This site-wide Single field is no longer read or written; left in place to avoid a destructive schema change."
+  },
+  {
+   "fieldname": "developer_section",
+   "fieldtype": "Section Break",
+   "label": "Developer / Sandbox"
+  },
+  {
+   "fieldname": "sandbox_mode",
+   "fieldtype": "Check",
+   "label": "Enable Sandbox Mode",
+   "default": "0",
+   "description": "When enabled, skip payment + allow the developer-onboarding shortcut (jarvis.onboarding.dev_onboard) on this site. Customer's responsibility: only flip this on a dev/test bench. Replaces the legacy <code>frappe.conf.developer_mode</code> check; that flag still works as a backwards-compat fallback for one release."
+  }
+ ],
+ "permissions": [
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  }
+ ]
 }

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -46,6 +46,9 @@
     "wiki_nudge_cooldown_hours",
     "voice_notes_last_processed_at",
     "voice_notes_last_process_status",
+    "knowledge_language",
+    "wiki_lint_last_run_at",
+    "wiki_lint_summary",
     "system_tab",
     "deployment_section",
     "deployment_mode",
@@ -334,6 +337,27 @@
       "fieldtype": "Long Text",
       "label": "Voice Notes Last Process Status",
       "read_only": 1
+    },
+    {
+      "fieldname": "knowledge_language",
+      "fieldtype": "Select",
+      "label": "Knowledge Language",
+      "options": "English\nOriginal",
+      "default": "English",
+      "description": "Language for extracted knowledge (voice facts, wiki pages, drafted skill text). English (recommended) translates non-English input, keeping proper nouns in their original script with a Latin transliteration; Original keeps the dominant language of the source material. Chat transcription is always verbatim."
+    },
+    {
+      "fieldname": "wiki_lint_last_run_at",
+      "fieldtype": "Datetime",
+      "label": "Wiki Lint Last Run At",
+      "read_only": 1
+    },
+    {
+      "fieldname": "wiki_lint_summary",
+      "fieldtype": "Small Text",
+      "label": "Wiki Lint Summary",
+      "read_only": 1,
+      "description": "Summary of the last wiki health check (contradictions, stale, orphans, near-duplicate titles)."
     },
     {
       "fieldname": "system_tab",

--- a/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.json
+++ b/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.json
@@ -10,6 +10,9 @@
     "slug",
     "title",
     "page_type",
+    "scope",
+    "target_role",
+    "target_user",
     "ref_doctype",
     "ref_name",
     "summary",
@@ -18,7 +21,8 @@
     "status",
     "sources",
     "last_confirmed_at",
-    "contradiction_flag"
+    "contradiction_flag",
+    "mirror_hash"
   ],
   "fields": [
     {
@@ -45,6 +49,34 @@
       "in_list_view": 1,
       "in_standard_filter": 1,
       "search_index": 1
+    },
+    {
+      "fieldname": "scope",
+      "fieldtype": "Select",
+      "label": "Scope",
+      "options": "Org\nRole\nUser",
+      "default": "Org",
+      "reqd": 1,
+      "in_standard_filter": 1,
+      "description": "Who can see this page. Org = every desk user; Role = holders of the target role; User = the target user only. System Managers see everything."
+    },
+    {
+      "fieldname": "target_role",
+      "fieldtype": "Link",
+      "options": "Role",
+      "label": "Target Role",
+      "depends_on": "eval:doc.scope=='Role'",
+      "mandatory_depends_on": "eval:doc.scope=='Role'",
+      "description": "Role whose holders can read this page (Role scope only)."
+    },
+    {
+      "fieldname": "target_user",
+      "fieldtype": "Link",
+      "options": "User",
+      "label": "Target User",
+      "depends_on": "eval:doc.scope=='User'",
+      "mandatory_depends_on": "eval:doc.scope=='User'",
+      "description": "The only user who can read this page (User scope only). Defaults to the creator."
     },
     {
       "fieldname": "ref_doctype",
@@ -105,14 +137,21 @@
       "fieldtype": "Check",
       "label": "Contradiction Flagged",
       "description": "Set when an extracted update contradicted the existing body; the conflicting info is appended as a flagged section, never silently overwritten."
+    },
+    {
+      "fieldname": "mirror_hash",
+      "fieldtype": "Data",
+      "label": "Mirror Hash",
+      "hidden": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "sha256 of the last markdown render pushed to the container mirror (Org pages only); the mirror sync diffs against it."
     }
   ],
   "permissions": [
     {
       "role": "Desk User",
-      "read": 1,
-      "write": 1,
-      "create": 1
+      "read": 1
     },
     {
       "role": "System Manager",

--- a/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.py
+++ b/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.py
@@ -10,6 +10,13 @@ this controller, so the slug/length invariants hold no matter who wrote.
 
 Slug grammar: alnum runs separated by single hyphens, with ``--`` reserved as
 the type separator (``customer--acme-corp``, ``doctype--sales-invoice``).
+
+Scopes (wiki v2): ``Org`` (default; every desk user), ``Role`` (holders of
+``target_role``), ``User`` (``target_user`` only). Non-Org slugs get an
+audience suffix derived at create time (``--u-<localpart>`` / ``--r-<role>``)
+so the same base slug can exist per user/role without colliding on the
+docname. Visibility is enforced in ``jarvis.chat.wiki_permissions``; this
+controller owns scope consistency and the SM-only scope-change guard.
 """
 
 import re
@@ -27,6 +34,8 @@ SLUG_RE = re.compile(r"^[a-z0-9]+(?:-{1,2}[a-z0-9]+)*$")
 MAX_SLUG_LEN = 140
 MAX_SUMMARY_LEN = 500
 MAX_BODY_LEN = 20000
+
+SCOPES = ("Org", "Role", "User")
 
 # Cached "org has >=1 Active wiki page" flag consumed by the per-turn
 # wiki_clause hot path; invalidated by every controller write below.
@@ -54,8 +63,17 @@ def _invalidate_has_pages_flag():
 
 
 class JarvisWikiPage(Document):
+	def before_insert(self):
+		# Must run BEFORE set_new_name (autoname field:slug freezes the
+		# docname right after before_insert), so the audience suffix lands
+		# in the name too. validate() runs too late for that.
+		self._normalize_scope()
+		self._apply_scope_slug_suffix()
+
 	def validate(self):
 		self._validate_slug()
+		self._validate_scope()
+		self._guard_scope_change()
 		self._sanitize_untrusted_text()
 		self._validate_lengths()
 
@@ -85,6 +103,86 @@ class JarvisWikiPage(Document):
 			for pattern, repl in _BODY_NEUTRALIZE:
 				body = pattern.sub(repl, body)
 			self.body_md = body
+
+	def _normalize_scope(self):
+		"""Fill scope defaults + drop off-scope target fields. NULL scope
+		(pre-v2 rows) reads as Org everywhere, so it normalizes to Org here."""
+		self.scope = (self.scope or "").strip() or "Org"
+		if self.scope == "User":
+			# The creator is the default audience of their own page.
+			self.target_user = self.target_user or self.owner or frappe.session.user
+			self.target_role = None
+		elif self.scope == "Role":
+			self.target_user = None
+		else:
+			self.target_role = None
+			self.target_user = None
+
+	def _validate_scope(self):
+		self._normalize_scope()
+		if self.scope not in SCOPES:
+			frappe.throw(_("Scope must be one of {0}.").format(", ".join(SCOPES)))
+		if self.scope == "Role" and not self.target_role:
+			frappe.throw(_("Role-scope pages need a Target Role."))
+		if self.scope == "User" and not self.target_user:
+			frappe.throw(_("User-scope pages need a Target User."))
+
+	def _scope_slug_suffix(self) -> str:
+		"""The audience suffix a non-Org slug must carry (empty for Org)."""
+		from jarvis.chat.entities import scrub
+
+		if self.scope == "User" and self.target_user:
+			local = scrub(str(self.target_user).split("@")[0])
+			return f"--u-{local}" if local else ""
+		if self.scope == "Role" and self.target_role:
+			role = scrub(self.target_role)
+			return f"--r-{role}" if role else ""
+		return ""
+
+	def _apply_scope_slug_suffix(self):
+		"""Create-time only: suffix non-Org slugs (``--u-<localpart>`` /
+		``--r-<role>``) so per-user/per-role pages never collide with the org
+		page (or each other) on the shared slug namespace. Skipped when the
+		caller already suffixed; base is trimmed to keep the total <= 140 and
+		grammar-valid (scrub emits alnum-and-single-hyphen runs only)."""
+		self.slug = (self.slug or "").strip().lower()
+		suffix = self._scope_slug_suffix()
+		if not self.slug or not suffix or self.slug.endswith(suffix):
+			return
+		base = self.slug[: MAX_SLUG_LEN - len(suffix)].rstrip("-")
+		self.slug = f"{base}{suffix}"
+
+	def _guard_scope_change(self):
+		"""Only a System Manager may re-scope or re-target an existing page —
+		anything else would let a page's audience be widened (or a personal
+		page hijacked) by whoever can reach a save path. Runs regardless of
+		ignore_permissions, because the SPA/tool writers save that way."""
+		if self.is_new():
+			return
+		prev = frappe.db.get_value(
+			self.doctype,
+			self.name,
+			["scope", "target_role", "target_user"],
+			as_dict=True,
+		)
+		if not prev:
+			return
+		# Pre-v2 rows carry NULL scope; loading one normalizes it to Org,
+		# which must not read as a change.
+		prev_scope = (prev.scope or "").strip() or "Org"
+		if (
+			self.scope == prev_scope
+			and (self.target_role or None) == (prev.target_role or None)
+			and (self.target_user or None) == (prev.target_user or None)
+		):
+			return
+		user = frappe.session.user
+		if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+			return
+		frappe.throw(
+			_("Only a System Manager can change the scope or audience of an existing wiki page."),
+			frappe.PermissionError,
+		)
 
 	def _validate_slug(self):
 		self.slug = (self.slug or "").strip().lower()

--- a/jarvis/learning/roles.py
+++ b/jarvis/learning/roles.py
@@ -129,3 +129,34 @@ def _make_key(key: str) -> str:
 		return frappe.cache().make_key(key)
 	except Exception:
 		return key
+
+
+# --------------------------------------------------------------------------- #
+# Wiki v2 role seeding (hooks.after_migrate)
+# --------------------------------------------------------------------------- #
+# The two human wiki-editing roles (matrix in jarvis/chat/wiki_permissions.py).
+# Seeded on after_migrate because this app has no after_install channel and
+# migrate follows a fresh install anyway (same reasoning as the voice_facts
+# settings seeding). Pattern copied from jarvis_admin/install.py.
+_WIKI_ROLES = ("Knowledge Wiki User", "Knowledge Wiki Manager")
+
+
+def after_migrate() -> None:
+	"""Idempotently create the Knowledge Wiki roles (best-effort, never
+	blocks a migrate)."""
+	try:
+		created = False
+		for role_name in _WIKI_ROLES:
+			if frappe.db.exists("Role", role_name):
+				continue
+			frappe.get_doc({
+				"doctype": "Role", "role_name": role_name,
+				"desk_access": 1, "is_custom": 0,
+			}).insert(ignore_permissions=True)
+			created = True
+		if created:
+			frappe.db.commit()
+	except Exception:
+		frappe.log_error(
+			title="jarvis wiki roles seed failed", message=frappe.get_traceback()
+		)

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -81,6 +81,7 @@ _SETTINGS_DEFAULTS = {
 	"voice_features_enabled": 1,
 	"wiki_enabled": 1,
 	"wiki_nudge_cooldown_hours": 24,
+	"knowledge_language": "English",
 }
 
 
@@ -285,11 +286,17 @@ def _extract_batch(batch: dict) -> list | None:
 	"""ONE strict-JSON extraction call for a batch. None on call/parse failure
 	(NOT evidence of 'no facts' - the batch is retried next run)."""
 	try:
-		from jarvis.chat import voice
+		from jarvis.chat import knowledge_language, voice
 
+		# Org-wide knowledge-language preference (D6). This single boundary
+		# covers BOTH rule and context facts: context facts bypass the wiki
+		# ingest prompt (apply_extracted_page_updates writes the statements
+		# extracted here verbatim), so hooking only the wiki prompt would miss
+		# them.
+		system = _EXTRACTION_SYSTEM + "\n\n" + knowledge_language.language_directive()
 		raw = voice.openrouter_complete(
 			[
-				{"role": "system", "content": _EXTRACTION_SYSTEM},
+				{"role": "system", "content": system},
 				{"role": "user", "content": _batch_prompt(batch["notes"])},
 			]
 		)

--- a/jarvis/learning/wiki_lint.py
+++ b/jarvis/learning/wiki_lint.py
@@ -1,0 +1,332 @@
+"""Weekly wiki health check (wiki v2 D3).
+
+``run_lint`` runs deterministic, zero-LLM checks over the Active Org-scope
+wiki pages first:
+
+  * unresolved contradictions — ``contradiction_flag`` set, or the body still
+	carries a ``Contradiction flagged`` section (the ingest merge appends
+	those; a manual save clears the flag but may leave the section);
+  * stale pages — >90 days since ``last_confirmed_at`` (``modified``
+	fallback), via ``jarvis.chat.wiki.is_stale``;
+  * orphan pages — no inbound ``[[slug]]`` reference from any OTHER Active
+	Org page body;
+  * near-duplicate titles — normalized-title collisions (failure mode #1 of
+	LLM-maintained wikis: the same entity re-created under a slightly
+	different name).
+
+Then at most ONE strict-JSON ``openrouter_complete`` call confirms up to
+``_MAX_LLM_SUSPECTS`` contradiction/duplicate suspects (the job-safe pattern
+from ``jarvis.learning.voice_facts``); the pass is skipped silently when no
+OpenRouter key is resolvable (``voice._credentials``). Only LLM-CONFIRMED
+contradictions get ``contradiction_flag`` re-stamped (``frappe.db.set_value``,
+``update_modified=False`` — never ``doc.save``, which would re-fire the
+mirror-sync doc_events) — the deterministic pass alone never overrides a
+human's flag-clearing save.
+
+Results persist on Jarvis Settings (``wiki_lint_last_run_at`` +
+``wiki_lint_summary``, RO fields surfaced in the Wiki tab) and land in the
+container mirror's log.md on the next sync. ``scheduled_lint`` (hooks weekly)
+swallows everything.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import frappe
+from frappe.utils import cint, now_datetime
+
+WIKI = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+_CONTRADICTION_MARKER = "Contradiction flagged"
+# Matches the controller's slug grammar so a stray [[Some Prose]] never counts
+# as an inbound reference.
+_WIKILINK_RE = re.compile(r"\[\[([a-z0-9]+(?:-{1,2}[a-z0-9]+)*)\]\]")
+
+_MAX_LLM_SUSPECTS = 10
+_MAX_BODY_PROMPT_CHARS = 1500
+_MAX_SUMMARY_CHARS = 400
+_MAX_TOP_ISSUES = 10
+
+_CONFIRM_SYSTEM = (
+	"You review an internal business wiki for health issues. You are given "
+	"suspect pages. Output ONLY a JSON array - no prose, no markdown fences. "
+	'Each item must be an object with exactly these keys: "slug" (the page '
+	'slug exactly as given), "kind" ("contradiction" or "duplicate", matching '
+	'the suspicion you were given for that page) and "confirmed" (boolean). '
+	'Confirm "contradiction" only when the page body still contains genuinely '
+	"conflicting, unresolved statements about the same fact. Confirm "
+	'"duplicate" only when the listed pages clearly describe the same entity '
+	"or topic. When unsure, output false."
+)
+
+
+def _load_pages() -> list:
+	"""Active Org-scope pages (NULL/'' scope reads as Org). Role/User pages
+	are personal/team notes — the org health check leaves them alone."""
+	rows = frappe.get_all(
+		WIKI,
+		filters={"status": "Active"},
+		fields=[
+			"name", "title", "summary", "body_md", "contradiction_flag",
+			"last_confirmed_at", "modified", "scope",
+		],
+		order_by="name asc",
+		limit_page_length=0,
+	)
+	return [r for r in rows if (r.scope or "").strip() in ("", "Org")]
+
+
+# --------------------------------------------------------------------------- #
+# deterministic checks
+# --------------------------------------------------------------------------- #
+def _contradiction_suspects(pages: list) -> list:
+	return [
+		p for p in pages
+		if cint(p.contradiction_flag) or _CONTRADICTION_MARKER in (p.body_md or "")
+	]
+
+
+def _stale_pages(pages: list) -> list:
+	from jarvis.chat.wiki import is_stale
+
+	return [p for p in pages if is_stale(p.last_confirmed_at, p.modified)]
+
+
+def _find_orphans(pages: list) -> list:
+	"""Pages no OTHER Active Org page links to via [[slug]] (self-references
+	don't count; the generated index.md is not a page and never counts)."""
+	inbound: set[str] = set()
+	for p in pages:
+		for target in _WIKILINK_RE.findall(p.body_md or ""):
+			if target != p.name:
+				inbound.add(target)
+	return [p for p in pages if p.name not in inbound]
+
+
+def _normalize_title(title) -> str:
+	return " ".join(re.sub(r"[^a-z0-9]+", " ", str(title or "").lower()).split())
+
+
+def _duplicate_title_groups(pages: list) -> list[list]:
+	groups: dict[str, list] = {}
+	for p in pages:
+		key = _normalize_title(p.title)
+		if key:
+			groups.setdefault(key, []).append(p)
+	return [group for group in groups.values() if len(group) > 1]
+
+
+# --------------------------------------------------------------------------- #
+# LLM confirm pass (one call, strict JSON, silently skipped without a key)
+# --------------------------------------------------------------------------- #
+def _llm_confirm(contradictions: list, dupe_groups: list[list]) -> dict | None:
+	"""Confirm up to _MAX_LLM_SUSPECTS contradiction/duplicate suspects with
+	ONE strict-JSON call. Returns ``{"contradictions": [slug], "duplicates":
+	[slug]}`` (confirmed only, restricted to the suspect set — the model's
+	output is untrusted and must not flag arbitrary pages), or None when the
+	pass was skipped/failed (no key, call error, unparseable output)."""
+	suspects: list[tuple[str, dict]] = [("contradiction", p) for p in contradictions]
+	for group in dupe_groups:
+		suspects.extend(("duplicate", p) for p in group)
+	suspects = suspects[:_MAX_LLM_SUSPECTS]
+	if not suspects:
+		return None
+
+	try:
+		from jarvis.chat import voice
+
+		key, _model = voice._credentials()
+	except Exception:
+		return None
+	if not key:
+		return None
+
+	try:
+		raw = voice.openrouter_complete(
+			[
+				{"role": "system", "content": _CONFIRM_SYSTEM},
+				{"role": "user", "content": _confirm_prompt(suspects)},
+			]
+		)
+	except Exception:
+		frappe.log_error(
+			title="wiki lint: confirm call failed", message=frappe.get_traceback()
+		)
+		return None
+	items = _parse_json_array(raw)
+	if items is None:
+		frappe.log_error(
+			title="wiki lint: unparseable confirm output",
+			message=(raw or "")[:2000] if isinstance(raw, str) else repr(raw)[:2000],
+		)
+		return None
+
+	allowed = {(kind, p.name) for kind, p in suspects}
+	out: dict[str, list] = {"contradictions": [], "duplicates": []}
+	for item in items:
+		if not isinstance(item, dict) or not item.get("confirmed"):
+			continue
+		kind = item.get("kind")
+		slug = str(item.get("slug") or "")
+		if kind == "contradiction" and ("contradiction", slug) in allowed:
+			out["contradictions"].append(slug)
+		elif kind == "duplicate" and ("duplicate", slug) in allowed:
+			out["duplicates"].append(slug)
+	return out
+
+
+def _confirm_prompt(suspects: list[tuple[str, dict]]) -> str:
+	parts = []
+	for i, (kind, p) in enumerate(suspects, 1):
+		summary = " ".join(str(p.summary or "").split())
+		# Contradiction sections are appended at the bottom by the ingest
+		# merge, so the body TAIL is the informative slice.
+		body_tail = (p.body_md or "")[-_MAX_BODY_PROMPT_CHARS:]
+		parts.append(
+			f"Suspect {i} (suspected {kind}):\n"
+			f"slug: {p.name}\n"
+			f"title: {p.title}\n"
+			f"summary: {summary}\n"
+			f"body (tail):\n{body_tail}"
+		)
+	return (
+		"Review these suspect wiki pages and confirm or reject each suspicion.\n\n"
+		+ "\n\n".join(parts)
+	)
+
+
+def _parse_json_array(raw) -> list | None:
+	if not raw or not isinstance(raw, str):
+		return None
+	text = raw.strip()
+	if text.startswith("```"):
+		text = text.strip("`").strip()
+		if "\n" in text:
+			first, rest = text.split("\n", 1)
+			if first.strip().lower() in ("json", ""):
+				text = rest
+	try:
+		parsed = json.loads(text)
+	except Exception:
+		lo, hi = text.find("["), text.rfind("]")
+		if lo == -1 or hi <= lo:
+			return None
+		try:
+			parsed = json.loads(text[lo : hi + 1])
+		except Exception:
+			return None
+	return parsed if isinstance(parsed, list) else None
+
+
+# --------------------------------------------------------------------------- #
+# entry points
+# --------------------------------------------------------------------------- #
+def run_lint() -> dict:
+	"""Run the health check now. Returns the summary dict (counts + top
+	issues + per-check slug lists) and persists the run stamp + human summary
+	on Jarvis Settings. The LLM pass is best-effort; deterministic results
+	stand on their own."""
+	pages = _load_pages()
+	contradictions = _contradiction_suspects(pages)
+	stale = _stale_pages(pages)
+	orphans = _find_orphans(pages)
+	dupe_groups = _duplicate_title_groups(pages)
+
+	confirmed = _llm_confirm(contradictions, dupe_groups)
+	flagged = 0
+	if confirmed:
+		for slug in confirmed["contradictions"]:
+			if not cint(frappe.db.get_value(WIKI, slug, "contradiction_flag")):
+				frappe.db.set_value(
+					WIKI, slug, "contradiction_flag", 1, update_modified=False
+				)
+			flagged += 1
+
+	counts = {
+		"pages": len(pages),
+		"contradictions": len(contradictions),
+		"stale": len(stale),
+		"orphans": len(orphans),
+		"duplicate_title_groups": len(dupe_groups),
+	}
+	issues = _top_issues(contradictions, stale, orphans, dupe_groups)
+	summary = _summary_text(counts, confirmed, flagged)
+	_stamp_settings(summary)
+
+	return {
+		"ok": True,
+		"counts": counts,
+		"contradictions": [p.name for p in contradictions],
+		"stale": [p.name for p in stale],
+		"orphans": [p.name for p in orphans],
+		"duplicate_titles": [[p.name for p in g] for g in dupe_groups],
+		"issues": issues,
+		"llm_checked": confirmed is not None,
+		"confirmed_contradictions": (confirmed or {}).get("contradictions", []),
+		"confirmed_duplicates": (confirmed or {}).get("duplicates", []),
+		"summary": summary,
+	}
+
+
+def scheduled_lint() -> None:
+	"""hooks ``weekly`` entry. Skips when the operator turned the wiki off;
+	never raises out of the scheduler."""
+	try:
+		from jarvis.chat.wiki import wiki_enabled
+
+		if not wiki_enabled():
+			return
+		run_lint()
+	except Exception:
+		frappe.log_error(
+			title="wiki lint: scheduled run failed", message=frappe.get_traceback()
+		)
+
+
+def _top_issues(contradictions, stale, orphans, dupe_groups) -> list[str]:
+	issues: list[str] = []
+	issues += [f"contradiction: {p.name}" for p in contradictions]
+	issues += [f"stale: {p.name}" for p in stale]
+	issues += [
+		"duplicate titles: " + ", ".join(p.name for p in g) for g in dupe_groups
+	]
+	issues += [f"orphan: {p.name}" for p in orphans]
+	return issues[:_MAX_TOP_ISSUES]
+
+
+def _summary_text(counts: dict, confirmed: dict | None, flagged: int) -> str:
+	text = (
+		f"Checked {counts['pages']} page(s): "
+		f"{counts['contradictions']} contradiction(s), "
+		f"{counts['stale']} stale, {counts['orphans']} orphan(s), "
+		f"{counts['duplicate_title_groups']} duplicate-title group(s)."
+	)
+	if confirmed is None:
+		text += " LLM confirm pass skipped."
+	else:
+		text += (
+			f" LLM confirmed {len(confirmed['contradictions'])} contradiction(s)"
+			f" ({flagged} flagged) and {len(confirmed['duplicates'])} duplicate(s)."
+		)
+	return text[:_MAX_SUMMARY_CHARS]
+
+
+def _stamp_settings(summary: str) -> None:
+	"""Best-effort RO-field stamp (the voice_facts idiom: a background write
+	must never trip the Settings on_update sync)."""
+	try:
+		frappe.db.set_single_value(
+			SETTINGS, "wiki_lint_last_run_at", now_datetime(), update_modified=False
+		)
+		frappe.db.set_single_value(
+			SETTINGS, "wiki_lint_summary", (summary or "")[:_MAX_SUMMARY_CHARS],
+			update_modified=False,
+		)
+		frappe.db.commit()
+	except Exception:
+		frappe.log_error(
+			title="wiki lint: settings stamp failed", message=frappe.get_traceback()
+		)

--- a/jarvis/learning/wiki_lint.py
+++ b/jarvis/learning/wiki_lint.py
@@ -97,12 +97,21 @@ def _stale_pages(pages: list) -> list:
 
 def _find_orphans(pages: list) -> list:
 	"""Pages no OTHER Active Org page links to via [[slug]] (self-references
-	don't count; the generated index.md is not a page and never counts)."""
+	don't count; the generated index.md is not a page and never counts).
+
+	Young wikis have few cross-links, so "orphan" is only a signal once
+	linking is actually practiced: with fewer than 2 linking pages the check
+	would flag nearly the whole corpus (observed: 23 of 24) and read as
+	noise, so it reports nothing."""
+	linking_pages = 0
 	inbound: set[str] = set()
 	for p in pages:
-		for target in _WIKILINK_RE.findall(p.body_md or ""):
-			if target != p.name:
-				inbound.add(target)
+		targets = [t for t in _WIKILINK_RE.findall(p.body_md or "") if t != p.name]
+		if targets:
+			linking_pages += 1
+		inbound.update(targets)
+	if linking_pages < 2:
+		return []
 	return [p for p in pages if p.name not in inbound]
 
 
@@ -298,18 +307,30 @@ def _top_issues(contradictions, stale, orphans, dupe_groups) -> list[str]:
 
 
 def _summary_text(counts: dict, confirmed: dict | None, flagged: int) -> str:
+	"""Human copy, not a log line: named problems, real plurals, no pipeline
+	jargon. Reads well in the Wiki tab settings popover."""
+
+	def n(count, singular, plural=None):
+		return f"{count} {singular if count == 1 else (plural or singular + 's')}"
+
+	problems = []
+	if counts["contradictions"]:
+		problems.append(n(counts["contradictions"], "page with conflicting facts", "pages with conflicting facts"))
+	if counts["stale"]:
+		problems.append(n(counts["stale"], "page not confirmed in 90+ days", "pages not confirmed in 90+ days"))
+	if counts["orphans"]:
+		problems.append(n(counts["orphans"], "page no other page links to", "pages no other page links to"))
+	if counts["duplicate_title_groups"]:
+		problems.append(n(counts["duplicate_title_groups"], "possible duplicate title", "possible duplicate titles"))
 	text = (
-		f"Checked {counts['pages']} page(s): "
-		f"{counts['contradictions']} contradiction(s), "
-		f"{counts['stale']} stale, {counts['orphans']} orphan(s), "
-		f"{counts['duplicate_title_groups']} duplicate-title group(s)."
+		f"Checked {n(counts['pages'], 'page')}: "
+		+ ("; ".join(problems) if problems else "no problems found")
+		+ "."
 	)
-	if confirmed is None:
-		text += " LLM confirm pass skipped."
-	else:
+	if confirmed is not None:
 		text += (
-			f" LLM confirmed {len(confirmed['contradictions'])} contradiction(s)"
-			f" ({flagged} flagged) and {len(confirmed['duplicates'])} duplicate(s)."
+			f" AI double-check confirmed {len(confirmed['contradictions'])}"
+			f" conflict(s) ({flagged} flagged) and {len(confirmed['duplicates'])} duplicate(s)."
 		)
 	return text[:_MAX_SUMMARY_CHARS]
 

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -14,3 +14,4 @@ jarvis.patches.v1_seed_llm_models
 jarvis.patches.v1_6_rename_jarvis_approval
 jarvis.patches.v1_6_normalize_llm_preset_value
 jarvis.patches.v1_7_chat_message_page_index
+jarvis.patches.v1_8_backfill_wiki_scope

--- a/jarvis/patches/v1_8_backfill_wiki_scope.py
+++ b/jarvis/patches/v1_8_backfill_wiki_scope.py
@@ -1,0 +1,19 @@
+"""Backfill scope='Org' on pre-scope Jarvis Wiki Page rows (wiki v2).
+
+The new reqd Select defaults to 'Org', but defaults only apply on insert -
+rows created before the field existed read NULL. Readers coalesce NULL to
+Org, so this is belt-and-braces: it makes standard filters and the scope
+permission SQL exact instead of relying on the coalesce forever.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Jarvis Wiki Page", "scope"):
+		return
+	frappe.db.sql(
+		"""update `tabJarvis Wiki Page`
+		set scope = 'Org'
+		where scope is null or scope = ''"""
+	)

--- a/jarvis/tests/test_insight_skill_update.py
+++ b/jarvis/tests/test_insight_skill_update.py
@@ -1,0 +1,553 @@
+"""Tests for the D5 insight-to-skill endpoints
+(``jarvis.chat.learned_api.draft_insight_skill_update`` /
+``apply_insight_skill_update``).
+
+The LLM boundary (``jarvis.chat.voice.openrouter_complete``) is ALWAYS mocked.
+Covers: the draft happy paths (update / create / none, incl. a fenced-JSON
+response), the guard failures (A-class + wrong-status refusals return
+``{ok: False, reason}`` without a model call; non-SM throws PermissionError;
+an unoffered/managed/Personal target is rejected), candidate selection
+(Personal + managed rows never offered, overlap-ranked top-N cap, language
+directive rides the system prompt), and the apply seam (skill updated /
+created through the controller, JLP terminal-marked like Acknowledge with the
+stable applied-note prefix + ``materialized_skill`` provenance, Snoozed routed
+through Proposed, everything revalidated server-side).
+
+unittest.TestCase with explicit commits + prefix cleanup, mirroring
+``test_learned_api`` (the sibling suite for this module).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import unittest
+from unittest import mock
+
+import frappe
+
+from jarvis.chat import learned_api
+
+JLP = "Jarvis Learned Pattern"
+SKILL = "Jarvis Custom Skill"
+
+NON_SM = "isu-nonsm@example.com"
+KEY_PREFIX = "isu-test-"
+SLUG_PREFIX = "isu-test-"
+
+TARGET_SLUG = "isu-test-invoicing"
+TARGET_DESC = (
+	"Wholesale discount and shipping charges rules for Acme Traders invoices."
+)
+TARGET_INSTR = "# Invoicing\n\n- Check the price list before invoicing."
+
+STATEMENT = (
+	"Acme Traders invoices always apply the wholesale discount tier before "
+	"shipping charges."
+)
+
+LLM = "jarvis.chat.voice.openrouter_complete"
+
+
+# --------------------------------------------------------------------------- #
+# fixtures / helpers
+# --------------------------------------------------------------------------- #
+def _ensure_non_sm(email: str) -> str:
+	# Same shape as test_learned_api._ensure_non_sm: a System User WITHOUT
+	# System Manager is the realistic unauthorized actor for these endpoints.
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc({
+			"doctype": "User", "email": email,
+			"first_name": "isu-nonsm", "send_welcome_email": 0, "enabled": 1,
+			"user_type": "System User",
+			"roles": [{"role": "Sales User"}],
+		})
+		u.flags.ignore_permissions = True
+		u.insert()
+		frappe.db.commit()
+	elif frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+		frappe.db.commit()
+	if "System Manager" in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	return email
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _wipe() -> None:
+	for name in frappe.get_all(
+		JLP, filters={"pattern_key": ["like", f"{KEY_PREFIX}%"]}, pluck="name"
+	):
+		frappe.delete_doc(JLP, name, force=True, ignore_permissions=True)
+	for name in frappe.get_all(
+		SKILL, filters={"skill_name": ["like", f"{SLUG_PREFIX}%"]}, pluck="name"
+	):
+		frappe.delete_doc(SKILL, name, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _mk(key: str, **kw) -> str:
+	"""Insert a JLP row directly (engine flag bypasses the transition guard).
+	Defaults to a B-class Proposed insight - the D5 target population."""
+	fields = {
+		"doctype": JLP,
+		"detector_id": kw.pop("detector_id", "isu-test-det"),
+		"pattern_key": KEY_PREFIX + key,
+		"domain": kw.pop("domain", "selling"),
+		"pattern_statement": kw.pop("statement", STATEMENT),
+		"skill_draft": kw.pop(
+			"skill_draft",
+			f"- {STATEMENT} Evidence: stated in 3 voice note(s) by 2 user(s).",
+		),
+		"status": kw.pop("status", "Proposed"),
+		"surfaced": kw.pop("surfaced", 1),
+		"strength_band": kw.pop("strength_band", "Medium"),
+		"sensitivity": kw.pop("sensitivity", "B"),
+		"effective_sensitivity": kw.pop("effective_sensitivity", "B"),
+	}
+	evidence = kw.pop("evidence", None)
+	if evidence is not None:
+		fields["evidence"] = json.dumps(evidence)
+	fields.update(kw)
+
+	frappe.flags.jarvis_pattern_engine = True
+	try:
+		doc = frappe.get_doc(fields)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+	finally:
+		frappe.flags.jarvis_pattern_engine = False
+	frappe.db.commit()
+	return doc.name
+
+
+def _mk_skill(
+	slug=TARGET_SLUG,
+	description=TARGET_DESC,
+	instructions=TARGET_INSTR,
+	scope="Org",
+	managed=0,
+	enabled=1,
+) -> str:
+	frappe.flags.jarvis_pattern_engine = bool(managed)
+	try:
+		doc = frappe.get_doc({
+			"doctype": SKILL,
+			"skill_name": slug,
+			"description": description,
+			"instructions": instructions,
+			"scope": scope,
+			"enabled": enabled,
+			"managed_by_learning": 1 if managed else 0,
+		})
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+	finally:
+		frappe.flags.jarvis_pattern_engine = False
+	frappe.db.commit()
+	return doc.name
+
+
+def _update_response(slug=TARGET_SLUG, updated="- Updated instructions.") -> str:
+	return json.dumps({
+		"worth_applying": True,
+		"reason": "The insight extends the invoicing skill.",
+		"action": "update",
+		"skill_name": slug,
+		"updated_instructions": updated,
+		"new_skill": None,
+	})
+
+
+def _create_response(slug="isu-test-acme-terms") -> str:
+	return json.dumps({
+		"worth_applying": True,
+		"reason": "No candidate covers Acme billing quirks.",
+		"action": "create",
+		"skill_name": "",
+		"updated_instructions": "",
+		"new_skill": {
+			"skill_name": slug,
+			"description": "Acme Traders billing quirks.",
+			"instructions": "- Always apply the wholesale tier before shipping.",
+		},
+	})
+
+
+class TestInsightSkillUpdate(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls.non_sm = _ensure_non_sm(NON_SM)
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	# ------------------------------------------------------------------ #
+	# gating
+	# ------------------------------------------------------------------ #
+	def test_non_sm_is_refused(self):
+		name = _mk("g1")
+		with _as(self.non_sm):
+			with self.assertRaises(frappe.PermissionError):
+				learned_api.draft_insight_skill_update(name)
+			with self.assertRaises(frappe.PermissionError):
+				learned_api.apply_insight_skill_update(
+					name, "update", skill_name=TARGET_SLUG,
+					updated_instructions="- x",
+				)
+
+	def test_draft_refuses_a_class_without_model_call(self):
+		name = _mk("a1", effective_sensitivity="A", sensitivity="A")
+		with mock.patch(LLM) as m:
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("A-class", out["reason"])
+		m.assert_not_called()
+
+	def test_draft_refuses_wrong_status_without_model_call(self):
+		name = _mk("s1", status="Rejected", review_note="no")
+		with mock.patch(LLM) as m:
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("Rejected", out["reason"])
+		m.assert_not_called()
+
+	# ------------------------------------------------------------------ #
+	# draft: happy paths
+	# ------------------------------------------------------------------ #
+	def test_draft_update_happy_path(self):
+		_mk_skill()
+		name = _mk("u1")
+		with mock.patch(LLM, return_value=_update_response()) as m:
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertTrue(out["ok"])
+		self.assertTrue(out["worth_applying"])
+		self.assertEqual(out["action"], "update")
+		self.assertEqual(out["skill_name"], TARGET_SLUG)
+		# before_instructions is the FULL stored text (for the confirm diff).
+		self.assertEqual(out["before_instructions"], TARGET_INSTR)
+		self.assertEqual(out["updated_instructions"], "- Updated instructions.")
+		self.assertIsNone(out["new_skill"])
+		self.assertTrue(out["reason"])
+
+		# ONE call; the candidate rides the user prompt, the D5 schema rides
+		# the system prompt.
+		m.assert_called_once()
+		messages = m.call_args.args[0]
+		self.assertIn(learned_api._INSIGHT_SKILL_SYSTEM, messages[0]["content"])
+		self.assertIn(TARGET_SLUG, messages[1]["content"])
+		self.assertIn(STATEMENT, messages[1]["content"])
+
+	def test_draft_create_happy_path_with_fenced_json(self):
+		# No candidates at all + a markdown-fenced response (the tolerant
+		# strict-JSON parse the voice_facts pattern prescribes).
+		name = _mk("c1", evidence={"source": "voice", "notes": ["VN-1"]})
+		raw = "```json\n" + _create_response() + "\n```"
+		with mock.patch(LLM, return_value=raw):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertTrue(out["ok"])
+		self.assertTrue(out["worth_applying"])
+		self.assertEqual(out["action"], "create")
+		self.assertEqual(out["skill_name"], "isu-test-acme-terms")
+		self.assertEqual(out["new_skill"]["skill_name"], "isu-test-acme-terms")
+		self.assertEqual(out["new_skill"]["description"], "Acme Traders billing quirks.")
+		self.assertEqual(out["before_instructions"], "")
+
+	def test_draft_none_verdict(self):
+		name = _mk("n1")
+		raw = json.dumps({
+			"worth_applying": False,
+			"reason": "Too transient to keep.",
+			"action": "none",
+			"skill_name": "",
+			"updated_instructions": "",
+			"new_skill": None,
+		})
+		with mock.patch(LLM, return_value=raw):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["worth_applying"])
+		self.assertEqual(out["action"], "none")
+		self.assertEqual(out["reason"], "Too transient to keep.")
+
+	# ------------------------------------------------------------------ #
+	# draft: candidate selection
+	# ------------------------------------------------------------------ #
+	def test_candidates_exclude_personal_and_managed(self):
+		_mk_skill()
+		_mk_skill(slug="isu-test-personal", scope="Personal",
+			description=TARGET_DESC, instructions=TARGET_INSTR)
+		_mk_skill(slug="isu-test-managed", managed=1,
+			description=TARGET_DESC, instructions=TARGET_INSTR)
+		_mk_skill(slug="isu-test-disabled", enabled=0,
+			description=TARGET_DESC, instructions=TARGET_INSTR)
+		name = _mk("cand1")
+		with mock.patch(LLM, return_value=_update_response()) as m:
+			learned_api.draft_insight_skill_update(name)
+		prompt = m.call_args.args[0][1]["content"]
+		self.assertIn(TARGET_SLUG, prompt)
+		self.assertNotIn("isu-test-personal", prompt)
+		self.assertNotIn("isu-test-managed", prompt)
+		self.assertNotIn("isu-test-disabled", prompt)
+
+	def test_candidates_overlap_ranked_and_capped(self):
+		# Six zero-overlap fillers + one strongly overlapping target: the cap
+		# keeps 5, the overlap winner is in, the oldest filler falls out.
+		for i in range(1, 7):
+			_mk_skill(
+				slug=f"isu-test-filler-{i}",
+				description="Unrelated payroll onboarding checklist.",
+				instructions="- Unrelated.",
+			)
+		_mk_skill()  # the overlap winner
+		name = _mk("cand2")
+		with mock.patch(LLM, return_value=_update_response()) as m:
+			learned_api.draft_insight_skill_update(name)
+		prompt = m.call_args.args[0][1]["content"]
+		self.assertIn(TARGET_SLUG, prompt)
+		self.assertNotIn("isu-test-filler-1", prompt)
+
+	# ------------------------------------------------------------------ #
+	# draft: model-output validation + failure paths
+	# ------------------------------------------------------------------ #
+	def test_draft_rejects_unoffered_update_target(self):
+		_mk_skill()
+		_mk_skill(slug="isu-test-personal", scope="Personal")
+		name = _mk("bt1")
+		with mock.patch(LLM, return_value=_update_response(slug="isu-test-personal")):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("isu-test-personal", out["reason"])
+
+	def test_draft_rejects_invalid_new_skill_slug(self):
+		name = _mk("bs1")
+		raw = json.dumps({
+			"worth_applying": True, "reason": "r", "action": "create",
+			"skill_name": "", "updated_instructions": "",
+			"new_skill": {
+				"skill_name": "Bad Slug!", "description": "d", "instructions": "- i",
+			},
+		})
+		with mock.patch(LLM, return_value=raw):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+
+	def test_draft_rejects_reserved_new_skill_prefix(self):
+		name = _mk("bs2")
+		raw = json.dumps({
+			"worth_applying": True, "reason": "r", "action": "create",
+			"skill_name": "", "updated_instructions": "",
+			"new_skill": {
+				"skill_name": "learned-selling", "description": "d",
+				"instructions": "- i",
+			},
+		})
+		with mock.patch(LLM, return_value=raw):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("reserved", out["reason"])
+
+	def test_draft_rejects_oversized_update_instructions(self):
+		_mk_skill()
+		name = _mk("big1")
+		with mock.patch(LLM, return_value=_update_response(updated="x" * 20001)):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("cap", out["reason"])
+
+	def test_draft_call_failure_returns_reason(self):
+		name = _mk("f1")
+		with mock.patch(LLM, side_effect=frappe.ValidationError("STT not configured")):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("language model call failed", out["reason"])
+
+	def test_draft_unparseable_output_returns_reason(self):
+		name = _mk("f2")
+		with mock.patch(LLM, return_value="sorry, I cannot produce JSON"):
+			out = learned_api.draft_insight_skill_update(name)
+		self.assertFalse(out["ok"])
+		self.assertIn("unparseable", out["reason"])
+
+	# ------------------------------------------------------------------ #
+	# apply: update
+	# ------------------------------------------------------------------ #
+	def test_apply_update_updates_skill_and_marks_jlp(self):
+		skill = _mk_skill()
+		name = _mk("ap1")
+		out = learned_api.apply_insight_skill_update(
+			name, "update", skill_name=TARGET_SLUG,
+			updated_instructions="- New rule text.",
+		)
+		self.assertEqual(out, {"ok": True, "skill_name": TARGET_SLUG})
+		self.assertEqual(
+			frappe.db.get_value(SKILL, skill, "instructions"), "- New rule text."
+		)
+		row = frappe.db.get_value(
+			JLP, name,
+			["status", "review_note", "materialized_skill", "reviewed_by", "reviewed_at"],
+			as_dict=True,
+		)
+		self.assertEqual(row.status, "Rejected")
+		self.assertEqual(
+			row.review_note, learned_api.APPLIED_NOTE_PREFIX + TARGET_SLUG
+		)
+		self.assertEqual(
+			row.review_note, "Acknowledged - applied to skill: " + TARGET_SLUG
+		)
+		self.assertEqual(row.materialized_skill, skill)
+		self.assertEqual(row.reviewed_by, "Administrator")
+		self.assertTrue(row.reviewed_at)
+
+	def test_apply_update_refuses_illegal_targets(self):
+		managed = _mk_skill(slug="isu-test-managed", managed=1)
+		personal = _mk_skill(slug="isu-test-personal", scope="Personal")
+		name = _mk("ap2")
+		for slug in ("isu-test-managed", "isu-test-personal", "isu-test-missing", ""):
+			with self.assertRaises(frappe.ValidationError):
+				learned_api.apply_insight_skill_update(
+					name, "update", skill_name=slug, updated_instructions="- x"
+				)
+		# nothing was written anywhere
+		self.assertEqual(frappe.db.get_value(SKILL, managed, "instructions"), TARGET_INSTR)
+		self.assertEqual(frappe.db.get_value(SKILL, personal, "instructions"), TARGET_INSTR)
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Proposed")
+
+	def test_apply_update_requires_instructions(self):
+		_mk_skill()
+		name = _mk("ap3")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(
+				name, "update", skill_name=TARGET_SLUG, updated_instructions="   "
+			)
+
+	def test_apply_oversized_instructions_hit_controller_cap(self):
+		_mk_skill()
+		name = _mk("ap4")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(
+				name, "update", skill_name=TARGET_SLUG,
+				updated_instructions="x" * 20001,
+			)
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Proposed")
+
+	# ------------------------------------------------------------------ #
+	# apply: create
+	# ------------------------------------------------------------------ #
+	def test_apply_create_creates_org_skill_and_marks_jlp(self):
+		name = _mk("ac1")
+		out = learned_api.apply_insight_skill_update(
+			name, "create",
+			new_skill={
+				"skill_name": "isu-test-acme-terms",
+				"description": "Acme Traders billing quirks.",
+				"instructions": "- Always apply the wholesale tier.",
+			},
+		)
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["skill_name"], "isu-test-acme-terms")
+		row = frappe.get_all(
+			SKILL,
+			filters={"skill_name": "isu-test-acme-terms"},
+			fields=["name", "scope", "enabled", "user_invocable", "owner",
+				"managed_by_learning"],
+		)[0]
+		self.assertEqual(row.scope, "Org")
+		self.assertEqual(int(row.enabled), 1)
+		self.assertEqual(int(row.user_invocable), 1)
+		self.assertEqual(int(row.managed_by_learning), 0)
+		self.assertEqual(row.owner, "Administrator")
+		jlp = frappe.db.get_value(
+			JLP, name, ["status", "review_note", "materialized_skill"], as_dict=True
+		)
+		self.assertEqual(jlp.status, "Rejected")
+		self.assertEqual(
+			jlp.review_note,
+			learned_api.APPLIED_NOTE_PREFIX + "isu-test-acme-terms",
+		)
+		self.assertEqual(jlp.materialized_skill, row.name)
+
+	def test_apply_create_requires_payload(self):
+		name = _mk("ac2")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(name, "create", new_skill=None)
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(
+				name, "create", new_skill={"skill_name": "isu-test-x"}
+			)
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Proposed")
+
+	# ------------------------------------------------------------------ #
+	# apply: guards + Snoozed routing
+	# ------------------------------------------------------------------ #
+	def test_apply_refuses_a_class(self):
+		_mk_skill()
+		name = _mk("ag1", effective_sensitivity="A", sensitivity="A")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(
+				name, "update", skill_name=TARGET_SLUG, updated_instructions="- x"
+			)
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Proposed")
+
+	def test_apply_refuses_wrong_status(self):
+		_mk_skill()
+		name = _mk("ag2", status="Active")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(
+				name, "update", skill_name=TARGET_SLUG, updated_instructions="- x"
+			)
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Active")
+
+	def test_apply_refuses_bad_action(self):
+		_mk_skill()
+		name = _mk("ag3")
+		with self.assertRaises(frappe.ValidationError):
+			learned_api.apply_insight_skill_update(name, "delete")
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Proposed")
+
+	def test_apply_from_snoozed_routes_through_proposed(self):
+		# Snoozed -> Rejected is not a legal JLP transition; the apply routes
+		# Snoozed -> Proposed -> Rejected so the state machine holds.
+		_mk_skill()
+		name = _mk("sz1", status="Snoozed", snoozed_until="2030-01-01")
+		out = learned_api.apply_insight_skill_update(
+			name, "update", skill_name=TARGET_SLUG,
+			updated_instructions="- From snoozed.",
+		)
+		self.assertTrue(out["ok"])
+		row = frappe.db.get_value(
+			JLP, name, ["status", "snoozed_until", "review_note"], as_dict=True
+		)
+		self.assertEqual(row.status, "Rejected")
+		self.assertFalse(row.snoozed_until)
+		self.assertEqual(row.review_note, learned_api.APPLIED_NOTE_PREFIX + TARGET_SLUG)
+
+	def test_apply_from_stale(self):
+		_mk_skill()
+		name = _mk("st1", status="Stale", stale_reason="drifted")
+		out = learned_api.apply_insight_skill_update(
+			name, "update", skill_name=TARGET_SLUG,
+			updated_instructions="- From stale.",
+		)
+		self.assertTrue(out["ok"])
+		self.assertEqual(frappe.db.get_value(JLP, name, "status"), "Rejected")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_knowledge_language.py
+++ b/jarvis/tests/test_knowledge_language.py
@@ -1,0 +1,165 @@
+"""Tests for the org-wide knowledge-language preference (design D6):
+``jarvis.chat.knowledge_language`` (English-default read + the prompt
+directive block) and its wiring into the voice-facts extraction prompt
+(``jarvis.learning.voice_facts._extract_batch`` - the single boundary that
+covers BOTH rule and context facts) plus the ``_SETTINGS_DEFAULTS`` seeding.
+
+The Select field never needs the tabSingles row-probe (that is a Check-field
+trap); these tests still manipulate the raw Singles row to prove the falsy /
+bogus-value fallbacks. The LLM boundary is always mocked.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import frappe
+from frappe.utils import now_datetime
+
+from jarvis.chat import knowledge_language
+from jarvis.learning import voice_facts
+
+SETTINGS = "Jarvis Settings"
+FIELD = "knowledge_language"
+
+
+def _read_raw():
+	rows = frappe.db.sql(
+		"select value from `tabSingles` where doctype=%s and field=%s",
+		(SETTINGS, FIELD),
+	)
+	return rows[0][0] if rows else None
+
+
+def _set_value(value) -> None:
+	"""Set (or with None: unset) the raw Singles row, clearing the
+	get_single_value cache either way."""
+	if value is None:
+		frappe.db.delete("Singles", {"doctype": SETTINGS, "field": FIELD})
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+	else:
+		# No endpoint validation here on purpose - the raw write lets the
+		# bogus-value fallback be proven.
+		frappe.db.set_single_value(SETTINGS, FIELD, value, update_modified=False)
+	frappe.db.commit()
+
+
+def _batch() -> dict:
+	return {
+		"owner": "Administrator",
+		"notes": [
+			frappe._dict(
+				name="VN-kl-test-1",
+				transcript="hello there, a durable fact",
+				creation=now_datetime(),
+			)
+		],
+	}
+
+
+class TestKnowledgeLanguage(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls._original = _read_raw()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		_set_value(self._original)
+
+	# ------------------------------------------------------------------ #
+	# get_knowledge_language
+	# ------------------------------------------------------------------ #
+	def test_default_english_when_unset(self):
+		_set_value(None)
+		self.assertEqual(knowledge_language.get_knowledge_language(), "English")
+
+	def test_original_mode(self):
+		_set_value("Original")
+		self.assertEqual(knowledge_language.get_knowledge_language(), "Original")
+
+	def test_bogus_stored_value_falls_back_to_english(self):
+		# The whitelisted setter validates, but a raw Desk/db write can store
+		# anything; the reader must coalesce unknown values.
+		_set_value("Klingon")
+		self.assertEqual(knowledge_language.get_knowledge_language(), "English")
+
+	def test_survives_settings_read_failure(self):
+		with mock.patch.object(
+			frappe.db, "get_single_value", side_effect=Exception("boom")
+		):
+			self.assertEqual(knowledge_language.get_knowledge_language(), "English")
+			self.assertTrue(knowledge_language.language_directive())
+
+	# ------------------------------------------------------------------ #
+	# language_directive
+	# ------------------------------------------------------------------ #
+	def test_directive_english(self):
+		_set_value(None)
+		directive = knowledge_language.language_directive()
+		self.assertEqual(directive, knowledge_language._ENGLISH_DIRECTIVE)
+		self.assertIn("in English", directive)
+		self.assertIn("transliteration", directive)
+
+	def test_directive_original(self):
+		_set_value("Original")
+		directive = knowledge_language.language_directive()
+		self.assertEqual(directive, knowledge_language._ORIGINAL_DIRECTIVE)
+		self.assertIn("dominant language of the source material", directive)
+
+	def test_directive_always_non_empty(self):
+		for value in (None, "English", "Original", "Klingon", ""):
+			_set_value(value if value else None)
+			self.assertTrue(knowledge_language.language_directive())
+
+	# ------------------------------------------------------------------ #
+	# voice_facts prompt wiring (the single boundary for rule AND context
+	# facts - context facts bypass the wiki ingest prompt entirely)
+	# ------------------------------------------------------------------ #
+	def test_voice_facts_prompt_carries_english_directive_by_default(self):
+		_set_value(None)
+		with mock.patch(
+			"jarvis.chat.voice.openrouter_complete", return_value="[]"
+		) as m:
+			out = voice_facts._extract_batch(_batch())
+		self.assertEqual(out, [])
+		m.assert_called_once()
+		system = m.call_args.args[0][0]["content"]
+		# The extraction schema stays intact; the directive is appended.
+		self.assertIn(voice_facts._EXTRACTION_SYSTEM, system)
+		self.assertIn(knowledge_language._ENGLISH_DIRECTIVE, system)
+
+	def test_voice_facts_prompt_switches_to_original(self):
+		_set_value("Original")
+		with mock.patch(
+			"jarvis.chat.voice.openrouter_complete", return_value="[]"
+		) as m:
+			voice_facts._extract_batch(_batch())
+		system = m.call_args.args[0][0]["content"]
+		self.assertIn(knowledge_language._ORIGINAL_DIRECTIVE, system)
+		self.assertNotIn(knowledge_language._ENGLISH_DIRECTIVE, system)
+
+	# ------------------------------------------------------------------ #
+	# _SETTINGS_DEFAULTS seeding (after_migrate)
+	# ------------------------------------------------------------------ #
+	def test_settings_default_registered(self):
+		self.assertEqual(voice_facts._SETTINGS_DEFAULTS.get(FIELD), "English")
+
+	def test_after_migrate_seeds_missing_row_only(self):
+		_set_value(None)
+		voice_facts.after_migrate()
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		self.assertEqual(_read_raw(), "English")
+		self.assertEqual(knowledge_language.get_knowledge_language(), "English")
+		# An operator-set value is never clobbered by a re-migrate.
+		_set_value("Original")
+		voice_facts.after_migrate()
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		self.assertEqual(_read_raw(), "Original")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_wiki_lint.py
+++ b/jarvis/tests/test_wiki_lint.py
@@ -93,10 +93,15 @@ class WikiLintTestCase(FrappeTestCase):
 			"alpha", body=f"Links to [[{SLUG_PREFIX}--beta]] for details."
 		)
 		pages.beta = self._page("beta")
-		# contradiction via body marker (flag cleared by a human save)
+		# contradiction via body marker (flag cleared by a human save); also
+		# links beta so the corpus has >=2 linking pages — the orphan check
+		# reports nothing on younger wikis (deliberate noise gate)
 		pages.contra = self._page(
 			"contra",
-			body="Terms are 30 days.\n\n## Contradiction flagged (2026-01-01)\n\nTerms are 45 days.",
+			body=(
+				"Terms are 30 days (see [[" + SLUG_PREFIX + "--beta]])."
+				"\n\n## Contradiction flagged (2026-01-01)\n\nTerms are 45 days."
+			),
 		)
 		# contradiction via the stored flag
 		pages.flagged = self._page("flagged", contradiction_flag=1)
@@ -157,9 +162,21 @@ class TestDeterministicChecks(WikiLintTestCase):
 		selfie = self._page(
 			"selfie", body=f"I cite myself: [[{SLUG_PREFIX}--selfie]]."
 		)
+		# two real linking pages so the young-wiki orphan gate is open
+		self._page("linker-a", body=f"See [[{SLUG_PREFIX}--linker-b]].")
+		self._page("linker-b", body=f"Back to [[{SLUG_PREFIX}--linker-a]].")
 		with _mock_llm(key=""):
 			out = wiki_lint.run_lint()
 		self.assertIn(selfie.name, out["orphans"])
+
+	def test_orphans_not_reported_on_young_unlinked_wiki(self):
+		# a corpus where nobody links anybody: flagging everything as orphans
+		# is noise, so the check reports nothing
+		self._page("lone-a")
+		self._page("lone-b")
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertEqual(out["orphans"], [])
 
 	def test_settings_fields_are_stamped(self):
 		self._seed()

--- a/jarvis/tests/test_wiki_lint.py
+++ b/jarvis/tests/test_wiki_lint.py
@@ -1,0 +1,257 @@
+"""Tests for the wiki health check (``jarvis.learning.wiki_lint``):
+deterministic checks over seeded pages (contradictions, stale, orphans,
+near-duplicate titles), the no-key silent skip of the LLM confirm pass, the
+confirmed-contradiction flag stamping (restricted to the suspect set) and the
+Jarvis Settings RO stamps.
+
+``jarvis.chat.voice`` is mocked at its two seams (``_credentials`` /
+``openrouter_complete``) — no network. Fixtures are swept by slug prefix in
+tearDown (the lint stamps settings with a commit, so rollback isn't enough).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import cint
+
+from jarvis.learning import wiki_lint
+
+WIKI = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+SLUG_PREFIX = "linttest"
+
+_SETTINGS_FIELDS = ("wiki_lint_last_run_at", "wiki_lint_summary")
+
+
+@contextlib.contextmanager
+def _mock_llm(key="", reply=None):
+	"""Patch voice._credentials (key resolution) + openrouter_complete.
+	``key=""`` = no OpenRouter key anywhere -> the confirm pass must skip."""
+	kwargs = (
+		{"side_effect": reply}
+		if isinstance(reply, (Exception, list))
+		else {"return_value": reply}
+	)
+	with (
+		mock.patch(
+			"jarvis.chat.voice._credentials", return_value=(key, "test-model")
+		),
+		mock.patch("jarvis.chat.voice.openrouter_complete", **kwargs) as complete,
+	):
+		yield complete
+
+
+class WikiLintTestCase(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		singles = frappe.db.get_singles_dict(SETTINGS)
+		self._settings_before = {f: singles.get(f) for f in _SETTINGS_FIELDS}
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete(WIKI, {"slug": ["like", f"{SLUG_PREFIX}%"]})
+		for field, value in self._settings_before.items():
+			frappe.db.set_single_value(SETTINGS, field, value, update_modified=False)
+		frappe.db.commit()
+		super().tearDown()
+
+	def _page(self, slug, title=None, page_type="Customer", body="Body.",
+			  scope=None, status="Active", contradiction_flag=0,
+			  last_confirmed_at=None):
+		doc = frappe.get_doc(
+			{
+				"doctype": WIKI,
+				"slug": f"{SLUG_PREFIX}--{slug}",
+				"title": title or f"Lint {slug}",
+				"page_type": page_type,
+				"body_md": body,
+				"scope": scope,
+				"status": status,
+				"contradiction_flag": contradiction_flag,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		if last_confirmed_at:
+			frappe.db.set_value(
+				WIKI, doc.name, "last_confirmed_at", last_confirmed_at,
+				update_modified=False,
+			)
+		frappe.db.commit()
+		return doc
+
+	def _seed(self):
+		"""One page per failure mode + a healthy, referenced one."""
+		pages = frappe._dict()
+		# beta is referenced by alpha -> beta not orphan, alpha orphan
+		pages.alpha = self._page(
+			"alpha", body=f"Links to [[{SLUG_PREFIX}--beta]] for details."
+		)
+		pages.beta = self._page("beta")
+		# contradiction via body marker (flag cleared by a human save)
+		pages.contra = self._page(
+			"contra",
+			body="Terms are 30 days.\n\n## Contradiction flagged (2026-01-01)\n\nTerms are 45 days.",
+		)
+		# contradiction via the stored flag
+		pages.flagged = self._page("flagged", contradiction_flag=1)
+		# stale: confirmed long ago
+		pages.stale = self._page(
+			"stale", last_confirmed_at="2020-01-01 00:00:00"
+		)
+		# near-duplicate titles (normalized collision)
+		pages.dupa = self._page("dupa", title="Acme Corp")
+		pages.dupb = self._page("dupb", title="acme  CORP!!")
+		return pages
+
+
+class TestDeterministicChecks(WikiLintTestCase):
+	def test_seeded_pages_yield_expected_issues(self):
+		pages = self._seed()
+		with _mock_llm(key="") as complete:
+			out = wiki_lint.run_lint()
+		complete.assert_not_called()
+
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["llm_checked"])
+
+		self.assertIn(pages.contra.name, out["contradictions"])
+		self.assertIn(pages.flagged.name, out["contradictions"])
+		self.assertNotIn(pages.beta.name, out["contradictions"])
+
+		self.assertIn(pages.stale.name, out["stale"])
+		self.assertNotIn(pages.beta.name, out["stale"])
+
+		# beta has an inbound [[link]] from alpha; alpha has none
+		self.assertNotIn(pages.beta.name, out["orphans"])
+		self.assertIn(pages.alpha.name, out["orphans"])
+
+		dupe_groups = [set(g) for g in out["duplicate_titles"]]
+		self.assertIn({pages.dupa.name, pages.dupb.name}, dupe_groups)
+
+		self.assertGreaterEqual(out["counts"]["contradictions"], 2)
+		self.assertGreaterEqual(out["counts"]["stale"], 1)
+		self.assertGreaterEqual(out["counts"]["duplicate_title_groups"], 1)
+		self.assertTrue(out["issues"])
+		self.assertTrue(out["summary"])
+
+	def test_non_org_and_archived_pages_are_ignored(self):
+		user_page = self._page(
+			"private", scope="User",
+			body="## Contradiction flagged (2026-01-01)\n\nConflict.",
+			contradiction_flag=1,
+		)
+		archived = self._page("bygone", status="Archived", contradiction_flag=1)
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertNotIn(user_page.name, out["contradictions"])
+		self.assertNotIn(archived.name, out["contradictions"])
+		self.assertNotIn(user_page.name, out["orphans"])
+
+	def test_self_reference_does_not_rescue_an_orphan(self):
+		selfie = self._page(
+			"selfie", body=f"I cite myself: [[{SLUG_PREFIX}--selfie]]."
+		)
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		self.assertIn(selfie.name, out["orphans"])
+
+	def test_settings_fields_are_stamped(self):
+		self._seed()
+		with _mock_llm(key=""):
+			out = wiki_lint.run_lint()
+		singles = frappe.db.get_singles_dict(SETTINGS)
+		self.assertTrue(singles.get("wiki_lint_last_run_at"))
+		self.assertEqual(singles.get("wiki_lint_summary"), out["summary"])
+		self.assertLessEqual(len(out["summary"]), 400)
+
+
+class TestLlmConfirmPass(WikiLintTestCase):
+	def test_no_key_skips_llm_and_never_flags(self):
+		pages = self._seed()
+		with _mock_llm(key="") as complete:
+			out = wiki_lint.run_lint()
+		complete.assert_not_called()
+		self.assertFalse(out["llm_checked"])
+		self.assertEqual(out["confirmed_contradictions"], [])
+		# the deterministic pass alone never overrides a human's flag clear
+		self.assertEqual(
+			cint(frappe.db.get_value(WIKI, pages.contra.name, "contradiction_flag")), 0
+		)
+
+	def test_confirmed_contradiction_sets_flag(self):
+		pages = self._seed()
+		reply = frappe.as_json(
+			[
+				{"slug": pages.contra.name, "kind": "contradiction", "confirmed": True},
+				{"slug": pages.flagged.name, "kind": "contradiction", "confirmed": False},
+				{"slug": pages.dupa.name, "kind": "duplicate", "confirmed": True},
+				# out-of-suspect-set output must be discarded (untrusted model)
+				{"slug": pages.beta.name, "kind": "contradiction", "confirmed": True},
+			]
+		)
+		with _mock_llm(key="sk-test", reply=reply) as complete:
+			out = wiki_lint.run_lint()
+		complete.assert_called_once()
+		self.assertTrue(out["llm_checked"])
+		self.assertEqual(out["confirmed_contradictions"], [pages.contra.name])
+		self.assertIn(pages.dupa.name, out["confirmed_duplicates"])
+		self.assertEqual(
+			cint(frappe.db.get_value(WIKI, pages.contra.name, "contradiction_flag")), 1
+		)
+		self.assertEqual(
+			cint(frappe.db.get_value(WIKI, pages.beta.name, "contradiction_flag")), 0
+		)
+
+	def test_llm_failure_degrades_to_deterministic_results(self):
+		pages = self._seed()
+		with _mock_llm(key="sk-test", reply=frappe.ValidationError("openrouter down")):
+			out = wiki_lint.run_lint()
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["llm_checked"])
+		self.assertIn(pages.contra.name, out["contradictions"])
+
+	def test_unparseable_llm_output_degrades(self):
+		self._seed()
+		with _mock_llm(key="sk-test", reply="I cannot help with that."):
+			out = wiki_lint.run_lint()
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["llm_checked"])
+
+	def test_no_suspects_skips_llm_even_with_key(self):
+		self._page("solo")
+		with _mock_llm(key="sk-test") as complete:
+			out = wiki_lint.run_lint()
+		if out["counts"]["contradictions"] or out["counts"]["duplicate_title_groups"]:
+			self.skipTest("pre-existing suspect pages on this site")
+		complete.assert_not_called()
+		self.assertFalse(out["llm_checked"])
+
+
+class TestScheduledLint(WikiLintTestCase):
+	def test_scheduled_lint_swallows_errors(self):
+		with mock.patch.object(
+			wiki_lint, "run_lint", side_effect=Exception("boom")
+		):
+			wiki_lint.scheduled_lint()  # must not raise
+
+	def test_scheduled_lint_runs_when_wiki_enabled(self):
+		with (
+			mock.patch("jarvis.chat.wiki.wiki_enabled", return_value=True),
+			mock.patch.object(wiki_lint, "run_lint") as run,
+		):
+			wiki_lint.scheduled_lint()
+		run.assert_called_once()
+
+	def test_scheduled_lint_skips_when_wiki_disabled(self):
+		with (
+			mock.patch("jarvis.chat.wiki.wiki_enabled", return_value=False),
+			mock.patch.object(wiki_lint, "run_lint") as run,
+		):
+			wiki_lint.scheduled_lint()
+		run.assert_not_called()

--- a/jarvis/tests/test_wiki_mirror.py
+++ b/jarvis/tests/test_wiki_mirror.py
@@ -1,0 +1,410 @@
+"""Tests for the org-wiki container mirror (``jarvis.chat.wiki_mirror``):
+render determinism + path mapping, index/log shape, mirror_hash diffing,
+payload chunking under the fleet body cap, offline no-op, archive deletes and
+the doc_events/enqueue gates.
+
+The admin push seam (``jarvis.admin_client.push_wiki_files``) is mocked
+throughout — these tests never leave the bench. Page fixtures are inserted as
+Administrator (org scope) and swept by slug prefix in tearDown because the
+sync commits mid-run (FrappeTestCase rollback can't undo it).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import now_datetime
+
+from jarvis.chat import wiki_mirror
+
+WIKI = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+SLUG_PREFIX = "mirrortest"
+
+_PUSH_OK = {"ok": True, "written": 1, "deleted": 0, "pruned": 0}
+
+
+class WikiMirrorTestCase(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		self._lint_at_before = frappe.db.get_single_value(
+			SETTINGS, "wiki_lint_last_run_at"
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete(WIKI, {"slug": ["like", f"{SLUG_PREFIX}%"]})
+		frappe.db.set_single_value(
+			SETTINGS, "wiki_lint_last_run_at", self._lint_at_before,
+			update_modified=False,
+		)
+		frappe.db.commit()
+		super().tearDown()
+
+	def _page(self, slug, page_type="Customer", body="Body.", summary="",
+			  scope=None, status="Active"):
+		doc = frappe.get_doc(
+			{
+				"doctype": WIKI,
+				"slug": f"{SLUG_PREFIX}--{slug}",
+				"title": f"Mirror {slug}",
+				"page_type": page_type,
+				"body_md": body,
+				"summary": summary,
+				"scope": scope,
+				"status": status,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		frappe.db.commit()
+		return doc
+
+	@contextlib.contextmanager
+	def _mock_push(self, result=_PUSH_OK):
+		"""Patch the managed-tenant gate + the admin push seam. ``result``
+		is push_wiki_files' return for every call (None = offline)."""
+		with (
+			mock.patch("jarvis.selfhost.is_self_hosted", return_value=False),
+			mock.patch(
+				"jarvis.admin_client.push_wiki_files", return_value=result
+			) as push,
+		):
+			yield push
+
+	@staticmethod
+	def _pushed_paths(push_mock) -> list[str]:
+		paths = []
+		for call in push_mock.call_args_list:
+			paths += [f["path"] for f in call.kwargs["files"]]
+		return paths
+
+
+# --------------------------------------------------------------------------- #
+# renders
+# --------------------------------------------------------------------------- #
+class TestRenders(WikiMirrorTestCase):
+	def _row(self, **overrides):
+		row = frappe._dict(
+			name=f"{SLUG_PREFIX}--acme",
+			slug=f"{SLUG_PREFIX}--acme",
+			title="Acme Corp",
+			page_type="Customer",
+			scope="Org",
+			status="Active",
+			summary="Prefers morning deliveries.",
+			body_md="Acme buys monthly. See [[item--widget]].",
+			sources='[{"date": "2026-07-01", "kind": "voice", "ref": "VN-1", "user": "a@x.com"}]',
+			last_confirmed_at=now_datetime(),
+			contradiction_flag=0,
+			modified="2026-07-05 10:00:00",
+		)
+		row.update(overrides)
+		return row
+
+	def test_render_page_shape(self):
+		path, content = wiki_mirror.render_page(self._row())
+		self.assertEqual(path, f"wiki/customers/{SLUG_PREFIX}--acme.md")
+		self.assertTrue(content.startswith("---\n"))
+		self.assertIn('title: "Acme Corp"', content)
+		self.assertIn("type: Customer", content)
+		self.assertIn("updated: 2026-07-05", content)
+		self.assertIn("stale: false", content)
+		self.assertIn("contradiction: false", content)
+		self.assertIn("Prefers morning deliveries.", content)
+		# body (and its [[slug]] links) pass through untouched
+		self.assertIn("See [[item--widget]].", content)
+		self.assertIn("## Sources", content)
+		self.assertIn("- 2026-07-01 · voice · VN-1 · a@x.com", content)
+		self.assertTrue(content.endswith("\n"))
+
+	def test_render_page_stale_and_contradiction_flags(self):
+		row = self._row(last_confirmed_at="2020-01-01 00:00:00", contradiction_flag=1)
+		_path, content = wiki_mirror.render_page(row)
+		self.assertIn("stale: true", content)
+		self.assertIn("contradiction: true", content)
+
+	def test_render_page_is_deterministic(self):
+		row = self._row()
+		first = wiki_mirror.render_page(row)
+		second = wiki_mirror.render_page(row)
+		self.assertEqual(first, second)
+		self.assertEqual(
+			hashlib.sha256(first[1].encode("utf-8")).hexdigest(),
+			hashlib.sha256(second[1].encode("utf-8")).hexdigest(),
+		)
+
+	def test_render_page_type_dir_mapping(self):
+		expected = {
+			"Customer": "customers",
+			"Supplier": "suppliers",
+			"Item": "items",
+			"Process": "processes",
+			"Doctype": "doctypes",
+			"Exception": "exceptions",
+			"Integration": "integrations",
+			"People": "people",
+			"Org": "org",
+		}
+		self.assertEqual(wiki_mirror.TYPE_DIRS, expected)
+		for page_type, type_dir in expected.items():
+			path, _content = wiki_mirror.render_page(self._row(page_type=page_type))
+			self.assertEqual(path, f"wiki/{type_dir}/{SLUG_PREFIX}--acme.md")
+		# defensive: unknown type falls back rather than crashing the sync
+		path, _content = wiki_mirror.render_page(self._row(page_type="Weird"))
+		self.assertEqual(path, f"wiki/org/{SLUG_PREFIX}--acme.md")
+
+	def test_render_index_groups_and_clips(self):
+		cust = self._page("cust", page_type="Customer", summary="s " * 120)
+		proc = self._page("proc", page_type="Process", summary="Short.")
+		user_page = self._page("mine", scope="User")
+		archived = self._page("gone", status="Archived")
+
+		path, content = wiki_mirror.render_index()
+		self.assertEqual(path, "wiki/index.md")
+		self.assertIn("active page(s)", content)
+		self.assertIn("## Customer (", content)
+		self.assertIn("## Process (", content)
+		clipped = (" ".join(("s " * 120).split()))[:100]
+		self.assertIn(f"- [[{cust.name}]] — {clipped}", content)
+		self.assertIn(f"- [[{proc.name}]] — Short.", content)
+		# user-scope and archived pages never reach the org index
+		self.assertNotIn(user_page.name, content)
+		self.assertNotIn(archived.name, content)
+
+	def test_render_log_shape_and_order(self):
+		doc = self._page("logged")
+		frappe.db.set_value(
+			WIKI,
+			doc.name,
+			{"creation": "2026-07-01 09:00:00", "modified": "2026-07-03 09:00:00"},
+			update_modified=False,
+		)
+		frappe.db.set_single_value(
+			SETTINGS, "wiki_lint_last_run_at", "2026-07-04 12:00:00",
+			update_modified=False,
+		)
+
+		path, content = wiki_mirror.render_log()
+		self.assertEqual(path, "wiki/log.md")
+		created = f"## [2026-07-01] created | {doc.name}"
+		updated = f"## [2026-07-03] updated | {doc.name}"
+		lint = "## [2026-07-04] lint | org-wiki"
+		for line in (created, updated, lint):
+			self.assertIn(line, content)
+		# newest first
+		self.assertLess(content.index(lint), content.index(updated))
+		self.assertLess(content.index(updated), content.index(created))
+
+		# archival shows as its own action
+		frappe.db.set_value(WIKI, doc.name, "status", "Archived", update_modified=False)
+		_path, content = wiki_mirror.render_log()
+		self.assertIn(f"## [2026-07-03] archived | {doc.name}", content)
+
+	def test_render_log_excludes_non_org_pages(self):
+		user_page = self._page("private", scope="User")
+		_path, content = wiki_mirror.render_log()
+		self.assertNotIn(user_page.name, content)
+
+
+# --------------------------------------------------------------------------- #
+# sync
+# --------------------------------------------------------------------------- #
+class TestSync(WikiMirrorTestCase):
+	def test_sync_pushes_new_page_then_hash_diff_skips_it(self):
+		doc = self._page("acme", summary="Acme summary.")
+		wire_path = f"customers/{doc.name}.md"
+
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		paths = self._pushed_paths(push)
+		self.assertIn(wire_path, paths)
+		self.assertIn("index.md", paths)
+		self.assertIn("log.md", paths)
+		# hash stamped = sha256 of the current render
+		_p, content = wiki_mirror.render_page(frappe.get_doc(WIKI, doc.name))
+		self.assertEqual(
+			frappe.db.get_value(WIKI, doc.name, "mirror_hash"),
+			hashlib.sha256(content.encode("utf-8")).hexdigest(),
+		)
+
+		# unchanged page -> no file in the next payload; index/log always ride
+		with self._mock_push() as push2:
+			out2 = wiki_mirror.sync()
+		self.assertTrue(out2["ok"])
+		paths2 = self._pushed_paths(push2)
+		self.assertNotIn(wire_path, paths2)
+		self.assertIn("index.md", paths2)
+		self.assertIn("log.md", paths2)
+		last_kwargs = push2.call_args_list[-1].kwargs
+		self.assertIsNone(last_kwargs["known_paths"])
+		self.assertNotIn(wire_path, last_kwargs["delete"] or [])
+
+	def test_full_sync_resends_and_sends_known_paths(self):
+		doc = self._page("acme", summary="Acme summary.")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push():
+			wiki_mirror.sync()
+
+		with self._mock_push() as push:
+			out = wiki_mirror.sync(full=True)
+		self.assertTrue(out["ok"])
+		self.assertTrue(out["full"])
+		# full bypasses the hash diff (a wiped container rebuilds)
+		self.assertIn(wire_path, self._pushed_paths(push))
+		known = push.call_args_list[-1].kwargs["known_paths"]
+		self.assertIn(wire_path, known)
+		self.assertIn("index.md", known)
+		self.assertIn("log.md", known)
+
+	def test_sync_offline_is_a_logged_noop(self):
+		doc = self._page("acme")
+		with self._mock_push(result=None):
+			out = wiki_mirror.sync()  # must not raise
+		self.assertFalse(out["ok"])
+		self.assertTrue(out["reason"])
+		# nothing stamped -> the next sync retries the page
+		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+	def test_sync_self_hosted_skips_without_calling_admin(self):
+		self._page("acme")
+		with (
+			mock.patch("jarvis.selfhost.is_self_hosted", return_value=True),
+			mock.patch("jarvis.admin_client.push_wiki_files") as push,
+		):
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["skipped"], "self-hosted")
+		push.assert_not_called()
+
+	def test_archived_page_gets_deleted_and_hash_cleared(self):
+		doc = self._page("acme")
+		wire_path = f"customers/{doc.name}.md"
+		with self._mock_push():
+			wiki_mirror.sync()
+		self.assertTrue(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+		# status flip via db (the SPA archive path saves; the sync only cares
+		# about the stored status + the stamped hash)
+		frappe.db.set_value(WIKI, doc.name, "status", "Archived", update_modified=False)
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertNotIn(wire_path, self._pushed_paths(push))
+		self.assertIn(wire_path, push.call_args_list[-1].kwargs["delete"])
+		self.assertFalse(frappe.db.get_value(WIKI, doc.name, "mirror_hash"))
+
+		# delete confirmed -> not re-sent on the next sync
+		with self._mock_push() as push2:
+			wiki_mirror.sync()
+		last = push2.call_args_list[-1].kwargs
+		self.assertNotIn(wire_path, last["delete"] or [])
+
+	def test_sync_chunks_batches_under_payload_cap(self):
+		for i in range(12):
+			self._page(f"big-{i}", body="a" * 19000)
+
+		with self._mock_push() as push:
+			out = wiki_mirror.sync()
+		self.assertTrue(out["ok"])
+		self.assertGreaterEqual(push.call_count, 2)
+		self.assertEqual(out["calls"], push.call_count)
+		for call in push.call_args_list:
+			payload = sum(
+				len(f["content_b64"]) + len(f["path"]) + 64
+				for f in call.kwargs["files"]
+			)
+			self.assertLessEqual(payload, wiki_mirror.MAX_CALL_PAYLOAD_BYTES)
+		paths = self._pushed_paths(push)
+		for i in range(12):
+			self.assertIn(f"customers/{SLUG_PREFIX}--big-{i}.md", paths)
+		self.assertIn("index.md", paths)
+		self.assertIn("log.md", paths)
+
+	def test_sync_partial_failure_leaves_later_batches_unstamped(self):
+		for i in range(12):
+			self._page(f"big-{i}", body="a" * 19000)
+		with (
+			mock.patch("jarvis.selfhost.is_self_hosted", return_value=False),
+			mock.patch(
+				"jarvis.admin_client.push_wiki_files",
+				side_effect=[_PUSH_OK, None, None],
+			) as push,
+		):
+			out = wiki_mirror.sync()
+		self.assertFalse(out["ok"])
+		self.assertEqual(push.call_count, 2)
+		# first batch stamped, the rest left for retry
+		stamped = frappe.get_all(
+			WIKI,
+			filters={
+				"slug": ["like", f"{SLUG_PREFIX}%"],
+				"mirror_hash": ["!=", ""],
+			},
+			pluck="name",
+		)
+		self.assertTrue(stamped)
+		self.assertLess(len(stamped), 12)
+
+
+# --------------------------------------------------------------------------- #
+# triggers
+# --------------------------------------------------------------------------- #
+class TestTriggers(WikiMirrorTestCase):
+	def test_doc_event_triggers_only_for_org_scope(self):
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Org"), "on_update")
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope=None), "after_insert")
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope=""), "on_update")
+		self.assertEqual(enq.call_count, 3)
+		enq.assert_called_with(full=False)
+
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="User"), "on_update")
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Role"), "on_trash")
+		enq.assert_not_called()
+
+	def test_doc_event_trash_requests_full_sync(self):
+		with mock.patch.object(wiki_mirror, "enqueue_sync") as enq:
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Org"), "on_trash")
+		enq.assert_called_once_with(full=True)
+
+	def test_doc_event_swallows_enqueue_errors(self):
+		with mock.patch.object(
+			wiki_mirror, "enqueue_sync", side_effect=Exception("redis down")
+		):
+			# must not raise into the save path
+			wiki_mirror.on_wiki_page_change(frappe._dict(scope="Org"), "on_update")
+
+	def test_enqueue_sync_is_suppressed_in_tests_unless_overridden(self):
+		prev_in_test = frappe.flags.in_test
+		frappe.flags.in_test = True
+		try:
+			with mock.patch("frappe.enqueue") as enq:
+				wiki_mirror.enqueue_sync()
+			enq.assert_not_called()
+
+			frappe.flags.jarvis_test_wiki_mirror_enqueue = True
+			try:
+				with mock.patch("frappe.enqueue") as enq2:
+					wiki_mirror.enqueue_sync(full=True)
+				enq2.assert_called_once()
+				kwargs = enq2.call_args.kwargs
+				self.assertEqual(kwargs["queue"], "short")
+				self.assertEqual(kwargs["job_id"], wiki_mirror.JOB_ID_FULL)
+				self.assertTrue(kwargs["deduplicate"])
+				self.assertTrue(kwargs["full"])
+
+				with mock.patch("frappe.enqueue") as enq3:
+					wiki_mirror.enqueue_sync()
+				self.assertEqual(enq3.call_args.kwargs["job_id"], wiki_mirror.JOB_ID)
+			finally:
+				frappe.flags.jarvis_test_wiki_mirror_enqueue = False
+		finally:
+			frappe.flags.in_test = prev_in_test

--- a/jarvis/tests/test_wiki_permissions.py
+++ b/jarvis/tests/test_wiki_permissions.py
@@ -385,16 +385,22 @@ class TestWriteMatrix(WikiPermTestCase):
 		self.assertEqual(wiki_permissions.creatable_scopes(USER_PLAIN), [])
 
 	def test_manageable_roles(self):
+		# framework/blanket roles are never targetable: "Desk User" is
+		# effectively everyone with a login (an org-wide side door)
+		blocked_roles = (
+			"Administrator", "Guest", "All",
+			"Desk User", "System Manager", "Website Manager",
+		)
 		sm_roles = wiki_permissions.manageable_roles(USER_SM)
 		self.assertIn(TEST_ROLE, sm_roles)
 		self.assertIn(OTHER_ROLE, sm_roles)
-		for blocked in ("Administrator", "Guest", "All"):
+		for blocked in blocked_roles:
 			self.assertNotIn(blocked, sm_roles)
 
 		mgr_roles = wiki_permissions.manageable_roles(USER_KW_MGR)
 		self.assertIn(TEST_ROLE, mgr_roles)
 		self.assertNotIn(OTHER_ROLE, mgr_roles)
-		for blocked in ("Administrator", "Guest", "All"):
+		for blocked in blocked_roles:
 			self.assertNotIn(blocked, mgr_roles)
 
 		self.assertEqual(wiki_permissions.manageable_roles(USER_KW), [])

--- a/jarvis/tests/test_wiki_permissions.py
+++ b/jarvis/tests/test_wiki_permissions.py
@@ -1,0 +1,415 @@
+"""Scope model + visibility/write-matrix tests for Jarvis Wiki Page (wiki v2):
+the ``jarvis.chat.wiki_permissions`` matrix helpers and SQL fragments, the
+controller's scope normalization / slug audience-suffixing / SM-only
+scope-change guard, and the ``jarvis.learning.roles`` seeder.
+
+Matrix under test (design D1):
+  * System Manager: full read/write on every scope.
+  * Plain desk user: reads Org only; creates nothing (human channel).
+  * Knowledge Wiki User: + own User-scope pages (create/edit own).
+  * Knowledge Wiki Manager: + Role-scope pages for roles they hold.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import wiki_permissions
+from jarvis.learning import roles as learning_roles
+
+WIKI = "Jarvis Wiki Page"
+
+USER_PLAIN = "wiki-perm-plain@example.com"
+USER_KW = "wiki-perm-kwuser@example.com"
+USER_KW_MGR = "wiki-perm-kwmgr@example.com"
+USER_SM = "wiki-perm-sm@example.com"
+
+TEST_ROLE = "Wiki Perm Test Role"
+OTHER_ROLE = "Wiki Perm Other Role"
+
+SLUG_MARK = "wpermtest"
+
+
+def _ensure_user(email: str, roles: tuple = ()) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				# Explicit: a role-less insert becomes a Website User, which
+				# never reaches Desk data (and gets no Desk User role).
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	user = frappe.get_doc("User", email)
+	if user.user_type != "System User":
+		# Repair a stale fixture user left behind by an earlier run.
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
+		user = frappe.get_doc("User", email)
+	if roles:
+		user.add_roles(*roles)
+	elif "System Manager" in frappe.get_roles(email):
+		user.remove_roles("System Manager")
+	frappe.db.commit()
+	return email
+
+
+def _ensure_role(role_name: str) -> str:
+	if not frappe.db.exists("Role", role_name):
+		frappe.get_doc({
+			"doctype": "Role", "role_name": role_name,
+			"desk_access": 1, "is_custom": 1,
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+	return role_name
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _delete_test_pages():
+	frappe.db.delete(WIKI, {"slug": ["like", f"%{SLUG_MARK}%"]})
+
+
+def _make_page(slug, page_type, scope="Org", target_role=None, target_user=None, **kwargs):
+	doc = frappe.get_doc({
+		"doctype": WIKI,
+		"slug": slug,
+		"title": kwargs.pop("title", slug),
+		"page_type": page_type,
+		"scope": scope,
+		"target_role": target_role,
+		"target_user": target_user,
+		**kwargs,
+	})
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+class WikiPermTestCase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		# Roles must exist before add_roles below; this also exercises the
+		# after_migrate seeder on a site where it may already have run.
+		learning_roles.after_migrate()
+		_ensure_role(TEST_ROLE)
+		_ensure_role(OTHER_ROLE)
+		_ensure_user(USER_PLAIN)
+		_ensure_user(USER_KW, roles=(wiki_permissions.WIKI_USER_ROLE,))
+		_ensure_user(USER_KW_MGR, roles=(wiki_permissions.WIKI_MANAGER_ROLE, TEST_ROLE))
+		_ensure_user(USER_SM, roles=("System Manager",))
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+		self.org_page = _make_page(f"org--{SLUG_MARK}-org", "Org")
+		self.role_page = _make_page(
+			f"process--{SLUG_MARK}-role", "Process", scope="Role", target_role=TEST_ROLE
+		)
+		self.other_role_page = _make_page(
+			f"process--{SLUG_MARK}-other", "Process", scope="Role", target_role=OTHER_ROLE
+		)
+		self.my_page = _make_page(
+			f"people--{SLUG_MARK}-mine", "People", scope="User", target_user=USER_KW
+		)
+		self.their_page = _make_page(
+			f"people--{SLUG_MARK}-theirs", "People", scope="User", target_user=USER_KW_MGR
+		)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_delete_test_pages()
+		frappe.db.commit()
+		super().tearDown()
+
+
+# --------------------------------------------------------------------------- #
+# roles seeder + scope model (controller)
+# --------------------------------------------------------------------------- #
+class TestScopeModel(WikiPermTestCase):
+	def test_wiki_roles_seeded_idempotently(self):
+		learning_roles.after_migrate()
+		learning_roles.after_migrate()
+		for role in (wiki_permissions.WIKI_USER_ROLE, wiki_permissions.WIKI_MANAGER_ROLE):
+			self.assertTrue(frappe.db.exists("Role", role))
+			self.assertEqual(
+				frappe.db.get_value("Role", role, "desk_access"), 1, role
+			)
+
+	def test_org_scope_carries_no_targets(self):
+		self.assertEqual(self.org_page.scope, "Org")
+		self.assertFalse(self.org_page.target_role)
+		self.assertFalse(self.org_page.target_user)
+		self.assertEqual(self.org_page.name, f"org--{SLUG_MARK}-org")
+
+	def test_user_scope_slug_gets_audience_suffix(self):
+		# localpart of wiki-perm-kwuser@example.com, scrubbed
+		self.assertEqual(
+			self.my_page.name, f"people--{SLUG_MARK}-mine--u-wiki-perm-kwuser"
+		)
+		self.assertEqual(self.my_page.slug, self.my_page.name)
+
+	def test_role_scope_slug_gets_audience_suffix(self):
+		self.assertEqual(
+			self.role_page.name, f"process--{SLUG_MARK}-role--r-wiki-perm-test-role"
+		)
+
+	def test_suffix_not_doubled_when_caller_presuffixed(self):
+		doc = _make_page(
+			f"people--{SLUG_MARK}-presuf--u-wiki-perm-kwuser",
+			"People",
+			scope="User",
+			target_user=USER_KW,
+		)
+		self.assertEqual(doc.name, f"people--{SLUG_MARK}-presuf--u-wiki-perm-kwuser")
+
+	def test_suffix_trims_base_to_max_len(self):
+		from jarvis.jarvis.doctype.jarvis_wiki_page.jarvis_wiki_page import (
+			MAX_SLUG_LEN,
+			SLUG_RE,
+		)
+
+		long_slug = f"people--{SLUG_MARK}-" + "a" * (MAX_SLUG_LEN - 20)
+		doc = _make_page(long_slug, "People", scope="User", target_user=USER_KW)
+		self.assertLessEqual(len(doc.name), MAX_SLUG_LEN)
+		self.assertTrue(doc.name.endswith("--u-wiki-perm-kwuser"))
+		self.assertTrue(SLUG_RE.match(doc.name))
+
+	def test_target_user_defaults_to_creator(self):
+		with _as(USER_KW):
+			doc = frappe.get_doc({
+				"doctype": WIKI,
+				"slug": f"people--{SLUG_MARK}-default",
+				"title": "default target",
+				"page_type": "People",
+				"scope": "User",
+			})
+			doc.insert(ignore_permissions=True)
+		self.assertEqual(doc.target_user, USER_KW)
+		self.assertTrue(doc.name.endswith("--u-wiki-perm-kwuser"))
+
+	def test_role_scope_requires_target_role(self):
+		doc = frappe.get_doc({
+			"doctype": WIKI,
+			"slug": f"process--{SLUG_MARK}-notarget",
+			"title": "no target",
+			"page_type": "Process",
+			"scope": "Role",
+		})
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_scope_change_guard_blocks_non_sm(self):
+		with _as(USER_KW):
+			doc = frappe.get_doc(WIKI, self.my_page.name)
+			doc.scope = "Org"
+			# ignore_permissions mirrors the SPA/tool save paths; the guard
+			# must hold regardless.
+			with self.assertRaises(frappe.PermissionError):
+				doc.save(ignore_permissions=True)
+
+	def test_scope_change_guard_blocks_retarget(self):
+		with _as(USER_KW):
+			doc = frappe.get_doc(WIKI, self.my_page.name)
+			doc.target_user = USER_PLAIN
+			with self.assertRaises(frappe.PermissionError):
+				doc.save(ignore_permissions=True)
+
+	def test_non_sm_content_edit_passes_guard(self):
+		with _as(USER_KW):
+			doc = frappe.get_doc(WIKI, self.my_page.name)
+			doc.body_md = "- my private note"
+			doc.save(ignore_permissions=True)
+		self.assertIn(
+			"my private note", frappe.db.get_value(WIKI, self.my_page.name, "body_md")
+		)
+
+	def test_sm_can_rescope(self):
+		with _as(USER_SM):
+			doc = frappe.get_doc(WIKI, self.role_page.name)
+			doc.target_role = OTHER_ROLE
+			doc.save()
+		self.assertEqual(
+			frappe.db.get_value(WIKI, self.role_page.name, "target_role"), OTHER_ROLE
+		)
+
+
+# --------------------------------------------------------------------------- #
+# visibility (read) matrix
+# --------------------------------------------------------------------------- #
+class TestVisibility(WikiPermTestCase):
+	def _visible_names(self, user) -> set:
+		cond = wiki_permissions.visible_scope_condition(user)
+		rows = frappe.db.sql(
+			"select name from `tabJarvis Wiki Page` "
+			f"where slug like %s and {cond}",
+			(f"%{SLUG_MARK}%",),
+		)
+		return {r[0] for r in rows}
+
+	def test_sm_reads_everything(self):
+		for page in (
+			self.org_page, self.role_page, self.other_role_page,
+			self.my_page, self.their_page,
+		):
+			self.assertTrue(wiki_permissions.can_read_page(page, USER_SM), page.name)
+
+	def test_plain_user_reads_org_only(self):
+		self.assertTrue(wiki_permissions.can_read_page(self.org_page, USER_PLAIN))
+		for page in (self.role_page, self.other_role_page, self.my_page, self.their_page):
+			self.assertFalse(wiki_permissions.can_read_page(page, USER_PLAIN), page.name)
+
+	def test_role_page_visible_to_role_holder_only(self):
+		self.assertTrue(wiki_permissions.can_read_page(self.role_page, USER_KW_MGR))
+		self.assertFalse(wiki_permissions.can_read_page(self.other_role_page, USER_KW_MGR))
+		self.assertFalse(wiki_permissions.can_read_page(self.role_page, USER_KW))
+
+	def test_user_page_visible_to_target_only(self):
+		self.assertTrue(wiki_permissions.can_read_page(self.my_page, USER_KW))
+		self.assertFalse(wiki_permissions.can_read_page(self.my_page, USER_KW_MGR))
+		self.assertFalse(wiki_permissions.can_read_page(self.their_page, USER_KW))
+
+	def test_null_scope_reads_as_org(self):
+		# Pre-v2 rows: scope NULL. Bypass the ORM so normalization can't fill it.
+		frappe.db.set_value(WIKI, self.org_page.name, "scope", None, update_modified=False)
+		page = frappe.db.get_value(
+			WIKI, self.org_page.name,
+			["name", "scope", "target_role", "target_user"], as_dict=True,
+		)
+		self.assertTrue(wiki_permissions.can_read_page(page, USER_PLAIN))
+		self.assertIn(self.org_page.name, self._visible_names(USER_PLAIN))
+
+	def test_visible_scope_condition_sql(self):
+		all_names = {
+			self.org_page.name, self.role_page.name, self.other_role_page.name,
+			self.my_page.name, self.their_page.name,
+		}
+		self.assertEqual(self._visible_names(USER_PLAIN), {self.org_page.name})
+		self.assertEqual(
+			self._visible_names(USER_KW), {self.org_page.name, self.my_page.name}
+		)
+		self.assertEqual(
+			self._visible_names(USER_KW_MGR),
+			{self.org_page.name, self.role_page.name, self.their_page.name},
+		)
+		self.assertEqual(self._visible_names(USER_SM), all_names)
+
+	def test_query_conditions_unrestricted_for_sm(self):
+		self.assertEqual(wiki_permissions.wiki_page_query_conditions(USER_SM), "")
+		self.assertTrue(wiki_permissions.wiki_page_query_conditions(USER_PLAIN))
+
+	def test_get_list_respects_scope(self):
+		filters = {"slug": ["like", f"%{SLUG_MARK}%"]}
+		with _as(USER_PLAIN):
+			names = set(frappe.get_list(WIKI, filters=filters, pluck="name"))
+		self.assertEqual(names, {self.org_page.name})
+		with _as(USER_KW_MGR):
+			names = set(frappe.get_list(WIKI, filters=filters, pluck="name"))
+		self.assertEqual(
+			names, {self.org_page.name, self.role_page.name, self.their_page.name}
+		)
+
+	def test_has_permission_hook_enforces_visibility(self):
+		my_doc = frappe.get_doc(WIKI, self.my_page.name)
+		org_doc = frappe.get_doc(WIKI, self.org_page.name)
+		self.assertFalse(bool(frappe.has_permission(WIKI, doc=my_doc, user=USER_PLAIN)))
+		self.assertTrue(bool(frappe.has_permission(WIKI, doc=org_doc, user=USER_PLAIN)))
+
+
+# --------------------------------------------------------------------------- #
+# human write matrix
+# --------------------------------------------------------------------------- #
+class TestWriteMatrix(WikiPermTestCase):
+	def test_org_pages_are_sm_only(self):
+		self.assertTrue(wiki_permissions.can_edit_page(self.org_page, USER_SM))
+		for user in (USER_PLAIN, USER_KW, USER_KW_MGR):
+			self.assertFalse(wiki_permissions.can_edit_page(self.org_page, user), user)
+
+	def test_role_pages_need_manager_holding_the_role(self):
+		self.assertTrue(wiki_permissions.can_edit_page(self.role_page, USER_KW_MGR))
+		# manager without the target role
+		self.assertFalse(wiki_permissions.can_edit_page(self.other_role_page, USER_KW_MGR))
+		# role holder without the manager role
+		self.assertFalse(wiki_permissions.can_edit_page(self.role_page, USER_KW))
+		self.assertFalse(wiki_permissions.can_edit_page(self.role_page, USER_PLAIN))
+		self.assertTrue(wiki_permissions.can_edit_page(self.other_role_page, USER_SM))
+
+	def test_user_pages_need_target_user_with_kw_role(self):
+		self.assertTrue(wiki_permissions.can_edit_page(self.my_page, USER_KW))
+		self.assertTrue(wiki_permissions.can_edit_page(self.their_page, USER_KW_MGR))
+		# not the target, even with a manager role
+		self.assertFalse(wiki_permissions.can_edit_page(self.my_page, USER_KW_MGR))
+		self.assertTrue(wiki_permissions.can_edit_page(self.my_page, USER_SM))
+
+	def test_target_user_without_kw_role_cannot_edit(self):
+		page = _make_page(
+			f"people--{SLUG_MARK}-plain", "People", scope="User", target_user=USER_PLAIN
+		)
+		self.assertTrue(wiki_permissions.can_read_page(page, USER_PLAIN))
+		self.assertFalse(wiki_permissions.can_edit_page(page, USER_PLAIN))
+
+	def test_archive_mirrors_edit(self):
+		for page in (self.org_page, self.role_page, self.my_page):
+			for user in (USER_PLAIN, USER_KW, USER_KW_MGR, USER_SM):
+				self.assertEqual(
+					wiki_permissions.can_archive_page(page, user),
+					wiki_permissions.can_edit_page(page, user),
+					(page.name, user),
+				)
+
+	def test_creatable_scopes(self):
+		self.assertEqual(
+			wiki_permissions.creatable_scopes(USER_SM), ["Org", "Role", "User"]
+		)
+		self.assertEqual(wiki_permissions.creatable_scopes(USER_KW_MGR), ["Role", "User"])
+		self.assertEqual(wiki_permissions.creatable_scopes(USER_KW), ["User"])
+		self.assertEqual(wiki_permissions.creatable_scopes(USER_PLAIN), [])
+
+	def test_manageable_roles(self):
+		sm_roles = wiki_permissions.manageable_roles(USER_SM)
+		self.assertIn(TEST_ROLE, sm_roles)
+		self.assertIn(OTHER_ROLE, sm_roles)
+		for blocked in ("Administrator", "Guest", "All"):
+			self.assertNotIn(blocked, sm_roles)
+
+		mgr_roles = wiki_permissions.manageable_roles(USER_KW_MGR)
+		self.assertIn(TEST_ROLE, mgr_roles)
+		self.assertNotIn(OTHER_ROLE, mgr_roles)
+		for blocked in ("Administrator", "Guest", "All"):
+			self.assertNotIn(blocked, mgr_roles)
+
+		self.assertEqual(wiki_permissions.manageable_roles(USER_KW), [])
+		self.assertEqual(wiki_permissions.manageable_roles(USER_PLAIN), [])
+
+	def test_desk_write_stays_sm_only(self):
+		my_doc = frappe.get_doc(WIKI, self.my_page.name)
+		# The matrix allows the target user...
+		self.assertTrue(wiki_permissions.can_edit_page(my_doc, USER_KW))
+		# ...but Desk/ORM write perms stay SM-only by design: human edits flow
+		# through the SPA endpoints, which check the matrix then save with
+		# ignore_permissions.
+		self.assertFalse(
+			bool(frappe.has_permission(WIKI, ptype="write", doc=my_doc, user=USER_KW))
+		)
+		self.assertTrue(
+			bool(frappe.has_permission(WIKI, ptype="write", doc=my_doc, user=USER_SM))
+		)

--- a/jarvis/tests/test_wiki_scopes_api.py
+++ b/jarvis/tests/test_wiki_scopes_api.py
@@ -482,6 +482,26 @@ class TestWikiSaveArchiveMatrix(_WikiScopeFixture):
 		out = wiki.archive_wiki_page(slug=slugs["org"])
 		self.assertTrue(out["ok"])
 
+	def test_restore_after_archive(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user("Administrator")
+		wiki.archive_wiki_page(slug=slugs["org"])
+		# archived listing shows the page; active listing doesn't
+		archived = wiki.list_wiki_pages_page(archived=1, page_length=50)
+		self.assertIn(slugs["org"], [r["slug"] for r in archived["rows"]])
+		active = wiki.list_wiki_pages_page(page_length=50)
+		self.assertNotIn(slugs["org"], [r["slug"] for r in active["rows"]])
+		# restore obeys the same matrix as archive
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(frappe.PermissionError):
+			wiki.restore_wiki_page(slug=slugs["org"])
+		frappe.set_user("Administrator")
+		out = wiki.restore_wiki_page(slug=slugs["org"])
+		self.assertTrue(out["ok"])
+		self.assertEqual(
+			frappe.db.get_value(WIKI_DT, slugs["org"], "status"), "Active"
+		)
+
 
 class TestWikiToolVisibility(_WikiScopeFixture):
 	def test_read_by_slug_honors_visibility(self):

--- a/jarvis/tests/test_wiki_scopes_api.py
+++ b/jarvis/tests/test_wiki_scopes_api.py
@@ -1,0 +1,594 @@
+"""Wiki v2 scope tests: SPA endpoint visibility + write matrix
+(jarvis.chat.wiki list/get/create/save/archive/caps/language) and tool-side
+scope handling (jarvis.tools.read_wiki visibility, jarvis.tools.update_wiki
+scope param).
+
+No LLM anywhere in these paths (ingest is exercised in test_wiki.py); the
+mirror/lint `_now` endpoints are exercised in their own module tests. Pages
+use ``wkscope`` slugs/titles so cleanup can never touch real data; non-Org
+fixtures capture ``doc.slug`` because the controller suffixes Role/User slugs
+(``--r-…`` / ``--u-…``) on create.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, now_datetime
+
+from jarvis.chat import wiki
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.tools.read_wiki import read_wiki
+from jarvis.tools.update_wiki import update_wiki
+
+WIKI_DT = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+KW_USER_ROLE = "Knowledge Wiki User"
+KW_MANAGER_ROLE = "Knowledge Wiki Manager"
+TEST_ROLE = "Wkscope Test Role"
+OTHER_ROLE = "Wkscope Other Role"
+
+PLAIN_USER = "wkscope-plain@test.invalid"
+KW_USER = "wkscope-kwu@test.invalid"
+KW_MANAGER = "wkscope-kwm@test.invalid"
+
+
+def _delete_scope_pages():
+	frappe.db.delete(WIKI_DT, {"slug": ["like", "%wkscope%"]})
+	frappe.db.commit()
+
+
+def _ensure_role(name):
+	if not frappe.db.exists("Role", name):
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": name,
+			"desk_access": 1,
+			"is_custom": 0,
+		}).insert(ignore_permissions=True)
+
+
+def _ensure_user(email, first_name, roles):
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": first_name,
+			# Role-less users flip to Website User; every fixture carries at
+			# least one desk role so user_type sticks.
+			"user_type": "System User",
+			"send_welcome_email": 0,
+			"roles": [{"role": r} for r in roles],
+		}).insert(ignore_permissions=True)
+
+
+def _make_page(slug, title, page_type="Org", **kwargs):
+	fields = {
+		"doctype": WIKI_DT,
+		"slug": slug,
+		"title": title,
+		"page_type": page_type,
+		"status": "Active",
+		# Fresh by default so the attention filter only matches pages a test
+		# deliberately made stale / flagged / unconfirmed.
+		"last_confirmed_at": now_datetime(),
+	}
+	fields.update(kwargs)
+	doc = frappe.get_doc(fields)
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+class _WikiScopeFixture(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		# KW roles are normally seeded by after_migrate; ensure idempotently
+		# so this module doesn't depend on hook ordering.
+		for role in (KW_USER_ROLE, KW_MANAGER_ROLE, TEST_ROLE, OTHER_ROLE):
+			_ensure_role(role)
+		_ensure_user(PLAIN_USER, "Wkscope Plain", ["Desk User"])
+		_ensure_user(KW_USER, "Wkscope KWU", ["Desk User", KW_USER_ROLE])
+		_ensure_user(
+			KW_MANAGER, "Wkscope KWM", ["Desk User", KW_MANAGER_ROLE, TEST_ROLE]
+		)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_delete_scope_pages()
+		for email in (PLAIN_USER, KW_USER, KW_MANAGER):
+			if frappe.db.exists("User", email):
+				frappe.delete_doc("User", email, ignore_permissions=True, force=True)
+		# The KW roles are site fixtures (after_migrate reseeds them) — only
+		# the module-local test roles are removed.
+		for role in (TEST_ROLE, OTHER_ROLE):
+			if frappe.db.exists("Role", role):
+				frappe.delete_doc("Role", role, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_scope_pages()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_delete_scope_pages()
+
+	# -- shared fixtures ---------------------------------------------------- #
+	def _plant_matrix_pages(self):
+		"""One page per scope cell; returns {label: slug} (post-suffix)."""
+		org = _make_page("org--wkscope-handbook", "Wkscope Handbook")
+		role = _make_page(
+			"process--wkscope-role-note", "Wkscope Role Note",
+			page_type="Process", scope="Role", target_role=TEST_ROLE,
+		)
+		mine = _make_page(
+			"people--wkscope-plain-note", "Wkscope Plain Note",
+			page_type="People", scope="User", target_user=PLAIN_USER,
+		)
+		other = _make_page(
+			"people--wkscope-kwu-note", "Wkscope KWU Note",
+			page_type="People", scope="User", target_user=KW_USER,
+		)
+		return {
+			"org": org.slug,
+			"role": role.slug,
+			"plain_user": mine.slug,
+			"kwu_user": other.slug,
+		}
+
+
+class TestWikiCapsAndLanguage(_WikiScopeFixture):
+	def test_caps_matrix(self):
+		frappe.set_user(PLAIN_USER)
+		caps = wiki.get_wiki_caps()
+		self.assertFalse(caps["is_sm"])
+		self.assertEqual(set(caps["creatable_scopes"]), set())
+
+		frappe.set_user(KW_USER)
+		caps = wiki.get_wiki_caps()
+		self.assertFalse(caps["is_sm"])
+		self.assertEqual(set(caps["creatable_scopes"]), {"User"})
+
+		frappe.set_user(KW_MANAGER)
+		caps = wiki.get_wiki_caps()
+		self.assertFalse(caps["is_sm"])
+		self.assertEqual(set(caps["creatable_scopes"]), {"Role", "User"})
+		self.assertIn(TEST_ROLE, caps["manageable_roles"])
+		self.assertNotIn(OTHER_ROLE, caps["manageable_roles"])
+
+		frappe.set_user("Administrator")
+		caps = wiki.get_wiki_caps()
+		self.assertTrue(caps["is_sm"])
+		self.assertEqual(set(caps["creatable_scopes"]), {"Org", "Role", "User"})
+		self.assertIn(TEST_ROLE, caps["manageable_roles"])
+
+	def test_caps_guest_rejected(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			wiki.get_wiki_caps()
+
+	def test_knowledge_language_default_and_setter(self):
+		rows = frappe.db.sql(
+			"select value from `tabSingles` "
+			"where doctype='Jarvis Settings' and field='knowledge_language'"
+		)
+		original = rows[0][0] if rows else None
+		try:
+			frappe.db.delete(
+				"Singles", {"doctype": SETTINGS, "field": "knowledge_language"}
+			)
+			self.assertEqual(wiki.get_wiki_caps()["knowledge_language"], "English")
+
+			# SM-only setter.
+			frappe.set_user(PLAIN_USER)
+			with self.assertRaises(frappe.PermissionError):
+				wiki.set_knowledge_language("Original")
+
+			frappe.set_user("Administrator")
+			with self.assertRaises(frappe.ValidationError):
+				wiki.set_knowledge_language("Klingon")
+			out = wiki.set_knowledge_language("Original")
+			self.assertEqual(out, {"ok": True, "knowledge_language": "Original"})
+			self.assertEqual(wiki.get_wiki_caps()["knowledge_language"], "Original")
+		finally:
+			frappe.set_user("Administrator")
+			frappe.db.delete(
+				"Singles", {"doctype": SETTINGS, "field": "knowledge_language"}
+			)
+			if original is not None:
+				frappe.db.set_single_value(
+					SETTINGS, "knowledge_language", original, update_modified=False
+				)
+
+
+class TestWikiListScopes(_WikiScopeFixture):
+	def _visible_slugs(self, **kwargs):
+		out = wiki.list_wiki_pages_page(search="wkscope", page_length=100, **kwargs)
+		return {r["slug"] for r in out["rows"]}, out
+
+	def test_guest_rejected(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			wiki.list_wiki_pages_page()
+
+	def test_plain_user_sees_org_and_own_only(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		visible, out = self._visible_slugs()
+		self.assertEqual(visible, {slugs["org"], slugs["plain_user"]})
+		# The total honors the same visibility filter (real COUNT, not a
+		# row materialization).
+		self.assertEqual(out["total"], 2)
+		self.assertFalse(out["has_more"])
+
+	def test_role_holder_sees_role_page(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(KW_MANAGER)
+		visible, _ = self._visible_slugs()
+		self.assertEqual(visible, {slugs["org"], slugs["role"]})
+
+	def test_sm_sees_all(self):
+		slugs = self._plant_matrix_pages()
+		visible, out = self._visible_slugs()
+		self.assertEqual(visible, set(slugs.values()))
+		self.assertEqual(out["total"], 4)
+
+	def test_scope_filter(self):
+		slugs = self._plant_matrix_pages()
+		visible, _ = self._visible_slugs(scope_filter="org")
+		self.assertEqual(visible, {slugs["org"]})
+		visible, _ = self._visible_slugs(scope_filter="role")
+		self.assertEqual(visible, {slugs["role"]})
+		# "mine" is the CALLER's User pages: none for Administrator, exactly
+		# one for the plain user.
+		visible, _ = self._visible_slugs(scope_filter="mine")
+		self.assertEqual(visible, set())
+		frappe.set_user(PLAIN_USER)
+		visible, _ = self._visible_slugs(scope_filter="mine")
+		self.assertEqual(visible, {slugs["plain_user"]})
+		with self.assertRaises(frappe.ValidationError):
+			wiki.list_wiki_pages_page(scope_filter="bogus")
+
+	def test_attention_filter(self):
+		_make_page("org--wkscope-fresh", "Wkscope Fresh")
+		stale = _make_page(
+			"org--wkscope-stale", "Wkscope Stale",
+			last_confirmed_at=add_to_date(now_datetime(), days=-100),
+		)
+		contra = _make_page(
+			"org--wkscope-contra", "Wkscope Contra", contradiction_flag=1
+		)
+		never = _make_page(
+			"org--wkscope-never", "Wkscope Never", last_confirmed_at=None
+		)
+		visible, out = self._visible_slugs(attention=1)
+		self.assertEqual(visible, {stale.slug, contra.slug, never.slug})
+		row = next(r for r in out["rows"] if r["slug"] == stale.slug)
+		self.assertTrue(row["stale"])
+		self.assertEqual(row["scope"], "Org")
+
+	def test_page_type_and_search_filters(self):
+		self._plant_matrix_pages()
+		out = wiki.list_wiki_pages_page(
+			search="wkscope", page_type="Process", page_length=100
+		)
+		self.assertEqual(out["total"], 1)
+		self.assertEqual(len(out["rows"]), 1)
+		self.assertEqual(out["rows"][0]["page_type"], "Process")
+		self.assertTrue(
+			out["rows"][0]["slug"].startswith("process--wkscope-role-note")
+		)
+		out = wiki.list_wiki_pages_page(search="wkscope handbook", page_length=100)
+		self.assertEqual(out["total"], 1)
+		self.assertEqual(out["rows"][0]["slug"], "org--wkscope-handbook")
+		with self.assertRaises(frappe.ValidationError):
+			wiki.list_wiki_pages_page(page_type="Blog")
+
+	def test_pagination_and_total(self):
+		for i in range(5):
+			_make_page(f"org--wkscope-pg-{i}", f"Wkscope Pg {i}")
+		seen = set()
+		for page in (1, 2, 3):
+			out = wiki.list_wiki_pages_page(
+				search="wkscope-pg", page=page, page_length=2
+			)
+			self.assertEqual(out["total"], 5)
+			self.assertEqual(out["has_more"], page < 3)
+			seen |= {r["slug"] for r in out["rows"]}
+		self.assertEqual(len(seen), 5)
+
+
+class TestWikiGetPage(_WikiScopeFixture):
+	def test_org_page_flags_by_role(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		page = wiki.get_wiki_page(slugs["org"])
+		self.assertEqual(page["scope"], "Org")
+		self.assertFalse(page["can_edit"])
+		self.assertFalse(page["can_archive"])
+		frappe.set_user("Administrator")
+		page = wiki.get_wiki_page(slugs["org"])
+		self.assertTrue(page["can_edit"])
+		self.assertTrue(page["can_archive"])
+
+	def test_own_user_page_editable_with_kw_role(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(KW_USER)
+		page = wiki.get_wiki_page(slugs["kwu_user"])
+		self.assertEqual(page["scope"], "User")
+		self.assertEqual(page["target_user"], KW_USER)
+		self.assertTrue(page["can_edit"])
+
+	def test_foreign_user_page_hidden(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(frappe.ValidationError):
+			wiki.get_wiki_page(slugs["kwu_user"])
+
+	def test_role_page_visible_to_holder_only(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(KW_MANAGER)
+		page = wiki.get_wiki_page(slugs["role"])
+		self.assertEqual(page["scope"], "Role")
+		self.assertEqual(page["target_role"], TEST_ROLE)
+		self.assertTrue(page["can_edit"])
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(frappe.ValidationError):
+			wiki.get_wiki_page(slugs["role"])
+
+
+class TestWikiCreateMatrix(_WikiScopeFixture):
+	def test_sm_creates_org_page_with_derived_slug(self):
+		out = wiki.create_wiki_page(
+			title="Wkscope Returns Policy", page_type="Org",
+			summary="How wkscope returns work.", body_md="- 30 days",
+		)
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["slug"], "org--wkscope-returns-policy")
+		doc = frappe.get_doc(WIKI_DT, out["slug"])
+		self.assertEqual(doc.get("scope"), "Org")
+		self.assertEqual(doc.status, "Active")
+		self.assertIsNotNone(doc.last_confirmed_at)
+
+	def test_duplicate_slug_reports_reason(self):
+		wiki.create_wiki_page(title="Wkscope Dup", page_type="Org")
+		out = wiki.create_wiki_page(title="Wkscope Dup", page_type="Org")
+		self.assertFalse(out["ok"])
+		self.assertIn("already exists", out["reason"])
+
+	def test_plain_user_cannot_create(self):
+		frappe.set_user(PLAIN_USER)
+		for scope in ("Org", "User"):
+			out = wiki.create_wiki_page(
+				title="Wkscope Nope", page_type="Org", scope=scope
+			)
+			self.assertFalse(out["ok"])
+			self.assertTrue(out["reason"])
+
+	def test_kw_user_creates_user_scope_only(self):
+		frappe.set_user(KW_USER)
+		out = wiki.create_wiki_page(
+			title="Wkscope My Notes", page_type="People", scope="User"
+		)
+		self.assertTrue(out["ok"])
+		# Controller suffixes User-scope slugs so users can never collide.
+		self.assertIn("--u-", out["slug"])
+		self.assertTrue(out["slug"].startswith("people--wkscope-my-notes"))
+		doc = frappe.get_doc(WIKI_DT, out["slug"])
+		self.assertEqual(doc.get("scope"), "User")
+		self.assertEqual(doc.get("target_user"), KW_USER)
+
+		out = wiki.create_wiki_page(title="Wkscope Org Try", page_type="Org")
+		self.assertFalse(out["ok"])
+
+	def test_user_scope_slugs_do_not_collide_across_users(self):
+		frappe.set_user(KW_USER)
+		a = wiki.create_wiki_page(
+			title="Wkscope Same Title", page_type="People", scope="User"
+		)
+		frappe.set_user(KW_MANAGER)
+		b = wiki.create_wiki_page(
+			title="Wkscope Same Title", page_type="People", scope="User"
+		)
+		self.assertTrue(a["ok"] and b["ok"])
+		self.assertNotEqual(a["slug"], b["slug"])
+
+	def test_kw_manager_role_scope_matrix(self):
+		frappe.set_user(KW_MANAGER)
+		out = wiki.create_wiki_page(
+			title="Wkscope Team Runbook", page_type="Process",
+			scope="Role", target_role=TEST_ROLE,
+		)
+		self.assertTrue(out["ok"])
+		self.assertIn("--r-", out["slug"])
+		doc = frappe.get_doc(WIKI_DT, out["slug"])
+		self.assertEqual(doc.get("scope"), "Role")
+		self.assertEqual(doc.get("target_role"), TEST_ROLE)
+
+		# A role the manager does not hold is not manageable.
+		out = wiki.create_wiki_page(
+			title="Wkscope Foreign Runbook", page_type="Process",
+			scope="Role", target_role=OTHER_ROLE,
+		)
+		self.assertFalse(out["ok"])
+		# Role scope without a target role is malformed.
+		with self.assertRaises(frappe.ValidationError):
+			wiki.create_wiki_page(
+				title="Wkscope No Role", page_type="Process", scope="Role"
+			)
+
+	def test_malformed_input_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			wiki.create_wiki_page(title="", page_type="Org")
+		with self.assertRaises(frappe.ValidationError):
+			wiki.create_wiki_page(title="Wkscope X", page_type="Blog")
+		with self.assertRaises(frappe.ValidationError):
+			wiki.create_wiki_page(title="Wkscope X", page_type="Org", scope="Galaxy")
+
+
+class TestWikiSaveArchiveMatrix(_WikiScopeFixture):
+	def test_plain_user_cannot_save_org_page(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(frappe.PermissionError):
+			wiki.save_wiki_page(slug=slugs["org"], body_md="hijack")
+
+	def test_sm_saves_org_page(self):
+		slugs = self._plant_matrix_pages()
+		out = wiki.save_wiki_page(slug=slugs["org"], body_md="- reviewed")
+		self.assertTrue(out["ok"])
+		self.assertIn("reviewed", frappe.get_doc(WIKI_DT, slugs["org"]).body_md)
+
+	def test_kw_user_saves_own_page_not_others(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(KW_USER)
+		out = wiki.save_wiki_page(slug=slugs["kwu_user"], body_md="- mine")
+		self.assertTrue(out["ok"])
+		with self.assertRaises(frappe.PermissionError):
+			wiki.save_wiki_page(slug=slugs["plain_user"], body_md="- not mine")
+
+	def test_own_user_page_without_kw_role_read_only(self):
+		# The write matrix needs a KW role even on your own page; the plain
+		# user can read it but not save it.
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		self.assertEqual(
+			wiki.get_wiki_page(slugs["plain_user"])["can_edit"], False
+		)
+		with self.assertRaises(frappe.PermissionError):
+			wiki.save_wiki_page(slug=slugs["plain_user"], body_md="- edit")
+
+	def test_kw_manager_saves_and_archives_held_role_page(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(KW_MANAGER)
+		out = wiki.save_wiki_page(slug=slugs["role"], body_md="- team update")
+		self.assertTrue(out["ok"])
+		out = wiki.archive_wiki_page(slug=slugs["role"])
+		self.assertTrue(out["ok"])
+		self.assertEqual(
+			frappe.db.get_value(WIKI_DT, slugs["role"], "status"), "Archived"
+		)
+
+	def test_archive_org_page_sm_only(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(frappe.PermissionError):
+			wiki.archive_wiki_page(slug=slugs["org"])
+		frappe.set_user("Administrator")
+		out = wiki.archive_wiki_page(slug=slugs["org"])
+		self.assertTrue(out["ok"])
+
+
+class TestWikiToolVisibility(_WikiScopeFixture):
+	def test_read_by_slug_honors_visibility(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		page = read_wiki(slug=slugs["org"])
+		self.assertEqual(page["slug"], slugs["org"])
+		with self.assertRaises(PermissionDeniedError):
+			read_wiki(slug=slugs["kwu_user"])
+		# The owner still reads their own page.
+		frappe.set_user(KW_USER)
+		page = read_wiki(slug=slugs["kwu_user"])
+		self.assertEqual(page["slug"], slugs["kwu_user"])
+
+	def test_query_search_honors_visibility(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		found = {r["slug"] for r in read_wiki(query="wkscope", limit=10)}
+		self.assertEqual(found, {slugs["org"], slugs["plain_user"]})
+		frappe.set_user(KW_MANAGER)
+		found = {r["slug"] for r in read_wiki(query="wkscope", limit=10)}
+		self.assertEqual(found, {slugs["org"], slugs["role"]})
+		frappe.set_user("Administrator")
+		found = {r["slug"] for r in read_wiki(query="wkscope", limit=10)}
+		self.assertEqual(found, set(slugs.values()))
+
+
+class TestUpdateWikiScope(_WikiScopeFixture):
+	def test_plain_user_org_channel_preserved(self):
+		# v1 LLM-channel behavior: any desk user maintains ORG pages through
+		# the confirm-gated tool, even with doctype write moved off Desk User.
+		frappe.set_user(PLAIN_USER)
+		out = update_wiki(
+			slug="org--wkscope-tool-org", title="Wkscope Tool Org",
+			page_type="Org", replace_body_md="First.",
+		)
+		self.assertTrue(out["ok"] and out["created"])
+		self.assertEqual(out["scope"], "Org")
+		out = update_wiki(slug="org--wkscope-tool-org", append_md="Second.")
+		self.assertFalse(out["created"])
+		body = frappe.db.get_value(WIKI_DT, "org--wkscope-tool-org", "body_md")
+		self.assertIn("First.", body)
+		self.assertIn("Second.", body)
+
+	def test_user_scope_requires_kw_role(self):
+		frappe.set_user(PLAIN_USER)
+		out = update_wiki(
+			slug="wkscope-personal", title="Wkscope Personal",
+			page_type="People", scope="User", replace_body_md="x",
+		)
+		self.assertFalse(out["ok"])
+		self.assertIn("Knowledge Wiki", out["reason"])
+		self.assertFalse(
+			frappe.db.exists(WIKI_DT, {"slug": ["like", "wkscope-personal%"]})
+		)
+
+	def test_user_scope_happy_path_and_base_slug_reuse(self):
+		frappe.set_user(KW_USER)
+		out = update_wiki(
+			slug="wkscope-personal", title="Wkscope Personal",
+			page_type="People", scope="User", replace_body_md="First.",
+		)
+		self.assertTrue(out["ok"] and out["created"])
+		self.assertEqual(out["scope"], "User")
+		self.assertIn("--u-", out["slug"])
+		created_slug = out["slug"]
+		doc = frappe.get_doc(WIKI_DT, created_slug)
+		self.assertEqual(doc.get("target_user"), KW_USER)
+
+		# A follow-up call with the ORIGINAL base slug lands on the same
+		# personal page (suffix probe), not a duplicate.
+		out = update_wiki(slug="wkscope-personal", scope="User", append_md="Second.")
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["created"])
+		self.assertEqual(out["slug"], created_slug)
+		body = frappe.get_doc(WIKI_DT, created_slug).body_md
+		self.assertIn("First.", body)
+		self.assertIn("Second.", body)
+
+	def test_user_scope_on_org_slug_forks_a_personal_page(self):
+		org = _make_page(
+			"process--wkscope-shared", "Wkscope Shared",
+			page_type="Process", body_md="Org body.",
+		)
+		frappe.set_user(KW_USER)
+		out = update_wiki(
+			slug="process--wkscope-shared", title="Wkscope Shared Fork",
+			page_type="Process", scope="User", append_md="- personal view",
+		)
+		self.assertTrue(out["ok"] and out["created"])
+		self.assertNotEqual(out["slug"], org.slug)
+		self.assertEqual(out["scope"], "User")
+		# The org page is untouched.
+		self.assertEqual(
+			frappe.db.get_value(WIKI_DT, org.slug, "body_md"), "Org body."
+		)
+
+	def test_foreign_user_page_not_writable_via_tool(self):
+		slugs = self._plant_matrix_pages()
+		frappe.set_user(PLAIN_USER)
+		with self.assertRaises(PermissionDeniedError):
+			update_wiki(slug=slugs["kwu_user"], append_md="- vandalism")
+
+	def test_invalid_scope_rejected(self):
+		from jarvis.exceptions import InvalidArgumentError
+
+		with self.assertRaises(InvalidArgumentError):
+			update_wiki(
+				slug="org--wkscope-x", title="X", page_type="Org", scope="Team"
+			)

--- a/jarvis/tools/read_wiki.py
+++ b/jarvis/tools/read_wiki.py
@@ -3,8 +3,10 @@
 ``slug`` returns ONE full page (body included); ``query`` searches Active
 pages by slug/title/summary (LIKE) plus an exact ``ref_name`` match (so
 "read the wiki on ACME Corp" finds ``customer--acme-corp`` by the record
-name) and returns compact rows. Desk (System User) sessions only; reads go
-through the normal doctype permissions (Desk User has read).
+name) and returns compact rows. Desk (System User) sessions only. Both paths
+filter by the session user's scope visibility (Org pages for everyone, Role
+pages for holders of the target role, User pages for their target user only;
+System Manager sees all) via ``jarvis.chat.wiki_permissions``.
 """
 
 import json
@@ -12,6 +14,7 @@ import json
 import frappe
 from frappe.utils import cint
 
+from jarvis.chat import wiki_permissions
 from jarvis.chat.wiki import is_stale
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
@@ -48,6 +51,10 @@ def _get_by_slug(slug: str) -> dict:
 	if not frappe.has_permission(WIKI, ptype="read", doc=name):
 		raise PermissionDeniedError(f"no read permission on {WIKI} {name}")
 	doc = frappe.get_doc(WIKI, name)
+	# Scope visibility (explicit, on top of the has_permission hook): a Role/
+	# User page is only readable by its audience.
+	if not wiki_permissions.can_read_page(doc, frappe.session.user):
+		raise PermissionDeniedError(f"no read permission on {WIKI} {name}")
 	try:
 		sources = json.loads(doc.sources) if doc.sources else []
 	except Exception:
@@ -75,19 +82,25 @@ def _search(query: str, limit: int) -> list[dict]:
 		raise InvalidArgumentError("query must not be empty")
 	if not frappe.has_permission(WIKI, ptype="read"):
 		raise PermissionDeniedError(f"no read permission on {WIKI}")
-	like = f"%{query[:140]}%"
-	rows = frappe.get_all(
-		WIKI,
-		filters={"status": "Active"},
-		or_filters=[
-			["slug", "like", like],
-			["title", "like", like],
-			["summary", "like", like],
-			["ref_name", "=", query],
-		],
-		fields=["slug", "title", "page_type", "summary", "last_confirmed_at", "modified"],
-		order_by="modified desc",
-		limit_page_length=limit,
+	# Raw SQL: the scope-visibility fragment (pre-escaped by
+	# wiki_permissions) doesn't fit get_all's filters, and post-filtering
+	# would silently shrink the LIMIT.
+	where = "status = 'Active'"
+	vis = (
+		wiki_permissions.visible_scope_condition(frappe.session.user) or ""
+	).strip()
+	if vis:
+		where += f" and ({vis})"
+	rows = frappe.db.sql(
+		f"""select slug, title, page_type, summary, last_confirmed_at, modified
+		from `tabJarvis Wiki Page`
+		where {where}
+			and (slug like %(like)s or title like %(like)s
+				or summary like %(like)s or ref_name = %(query)s)
+		order by modified desc
+		limit %(limit)s""",
+		{"like": f"%{query[:140]}%", "query": query, "limit": limit},
+		as_dict=True,
 	)
 	return [
 		{

--- a/jarvis/tools/update_wiki.py
+++ b/jarvis/tools/update_wiki.py
@@ -1,20 +1,38 @@
-"""jarvis__update_wiki: create or update one org wiki page (Jarvis Wiki Page).
+"""jarvis__update_wiki: create or update one wiki page (Jarvis Wiki Page).
 
 Prefer ``append_md`` (adds a section, keeps everything already recorded) over
 ``replace_body_md`` (full rewrite); passing both is rejected so an intent is
 never half-applied. Creating a NEW page additionally requires ``title`` and
 ``page_type``; the slug grammar is enforced by the doctype controller. Desk
-(System User) sessions only; the write itself goes through normal doctype
-permissions (Desk User has write/create). Registered as a gated write in
-jarvis.api (_WRITE_TOOLS + _GATED_WRITES, never auto-applied).
+(System User) sessions only. Registered as a gated write in jarvis.api
+(_WRITE_TOOLS + _GATED_WRITES, never auto-applied).
+
+Scopes (wiki v2): optional ``scope`` — "Org" (default) or "User".
+- Org keeps the deliberate v1 LLM-channel behavior: ANY desk user maintains
+  org pages through this confirm-gated tool (the human write matrix only
+  governs the SPA/desk channel), so writes go ``ignore_permissions=True``
+  behind the explicit checks here + the controller sanitizer.
+- User scope requires the Knowledge Wiki User/Manager (or System Manager)
+  role and always targets the CALLER's personal namespace: ``target_user``
+  is forced to the session user and the controller suffixes the slug
+  (``<slug>--u-…``), so follow-up calls with the original base slug resolve
+  back to the same personal page.
+- Updating an existing Role/User page (by exact slug) follows the human
+  write matrix (``wiki_permissions.can_edit_page``).
 """
 
 import frappe
 
+from jarvis.chat import wiki_permissions
 from jarvis.chat.wiki import PAGE_TYPES, append_source
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 WIKI = "Jarvis Wiki Page"
+
+_SCOPES = ("Org", "User")
+_USER_SCOPE_ROLES = frozenset({
+	"Knowledge Wiki User", "Knowledge Wiki Manager", "System Manager",
+})
 
 
 def _require_system_user() -> None:
@@ -27,6 +45,27 @@ def _require_system_user() -> None:
 		raise PermissionDeniedError("wiki tools require a desk (System User) session")
 
 
+def _find_existing(slug: str, scope: str, user: str) -> str | None:
+	"""Resolve the page this call targets. ``scope="User"`` targets the
+	caller's personal namespace: an exact slug match only counts when it IS
+	the caller's own User page, and the controller-suffixed variant
+	(``<slug>--u-…``) is probed so follow-up calls with the original base
+	slug keep landing on the same page. Slug grammar has no LIKE
+	metacharacters, so the pattern is literal."""
+	row = frappe.db.get_value(
+		WIKI, {"slug": slug}, ["name", "scope", "target_user"], as_dict=True
+	)
+	if scope != "User":
+		return row.name if row else None
+	if row and (row.scope or "Org") == "User" and row.target_user == user:
+		return row.name
+	return frappe.db.get_value(
+		WIKI,
+		{"scope": "User", "target_user": user, "slug": ["like", f"{slug}--u-%"]},
+		"name",
+	)
+
+
 def update_wiki(
 	slug: str,
 	title: str | None = None,
@@ -36,11 +75,15 @@ def update_wiki(
 	summary: str | None = None,
 	append_md: str | None = None,
 	replace_body_md: str | None = None,
+	scope: str = "Org",
 ) -> dict:
 	"""Create or update the wiki page ``slug``. ``append_md`` appends a
 	section to the existing body (preferred); ``replace_body_md`` rewrites it.
-	Returns a compact summary of the saved page."""
+	``scope="User"`` writes the caller's personal page instead of the org
+	wiki (Knowledge Wiki role required). Returns a compact summary of the
+	saved page."""
 	_require_system_user()
+	user = frappe.session.user
 
 	slug = (slug or "").strip().lower()
 	if not slug:
@@ -53,11 +96,33 @@ def update_wiki(
 		raise InvalidArgumentError(
 			f"page_type must be one of: {', '.join(PAGE_TYPES)}"
 		)
+	scope = (str(scope).strip() if scope else "") or "Org"
+	scope = scope.capitalize()
+	if scope not in _SCOPES:
+		raise InvalidArgumentError('scope must be "Org" or "User"')
+	if (
+		scope == "User"
+		and user != "Administrator"
+		and not (_USER_SCOPE_ROLES & set(frappe.get_roles(user)))
+	):
+		return {
+			"ok": False,
+			"reason": (
+				"personal (User-scope) wiki pages require the Knowledge Wiki "
+				"User or Knowledge Wiki Manager role"
+			),
+		}
 
-	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
+	name = _find_existing(slug, scope, user)
 	if name:
 		doc = frappe.get_doc(WIKI, name)
-		if not frappe.has_permission(WIKI, ptype="write", doc=doc):
+		# Org pages: preserved v1 LLM-channel behavior — any desk user may
+		# maintain them through this confirm-gated tool (the explicit checks
+		# here + ignore_permissions replace the old doctype-perm probe, since
+		# write moved off Desk User). Role/User pages follow the human matrix.
+		if (doc.get("scope") or "Org") != "Org" and not wiki_permissions.can_edit_page(
+			doc, user
+		):
 			raise PermissionDeniedError(f"no write permission on {WIKI} {name}")
 		created = False
 		if title and str(title).strip():
@@ -75,9 +140,9 @@ def update_wiki(
 			doc.body_md = f"{existing}\n\n{str(append_md).strip()}".strip()
 		elif replace_body_md is not None:
 			doc.body_md = str(replace_body_md)
-		append_source(doc, "tool", None, frappe.session.user)
+		append_source(doc, "tool", None, user)
 		doc.last_confirmed_at = frappe.utils.now_datetime()
-		doc.save()
+		doc.save(ignore_permissions=True)
 	else:
 		if not (title and str(title).strip()) or not page_type:
 			raise InvalidArgumentError(
@@ -94,10 +159,12 @@ def update_wiki(
 			"summary": (" ".join(str(summary).split()) or None) if summary is not None else None,
 			"body_md": str(replace_body_md or append_md or "").strip(),
 			"status": "Active",
+			"scope": scope,
+			"target_user": user if scope == "User" else None,
 			"last_confirmed_at": frappe.utils.now_datetime(),
 		})
-		append_source(doc, "tool", None, frappe.session.user)
-		doc.insert()
+		append_source(doc, "tool", None, user)
+		doc.insert(ignore_permissions=True)
 
 	return {
 		"ok": True,
@@ -105,6 +172,7 @@ def update_wiki(
 		"slug": doc.slug,
 		"title": doc.title,
 		"page_type": doc.page_type,
+		"scope": doc.get("scope") or "Org",
 		"status": doc.status,
 		"body_chars": len(doc.body_md or ""),
 	}


### PR DESCRIPTION
## What

The wiki becomes the org's knowledge home (design doc: `jarvis-wiki-v2-plan.md` at repo root of the dev box):

- **Three knowledge scopes** on Jarvis Wiki Page — **Org / Role / User** with `target_role`/`target_user`, audience-suffixed slugs, and two new roles seeded on migrate: **Knowledge Wiki User** (create personal pages) and **Knowledge Wiki Manager** (create/edit pages for roles they hold). Visibility + write matrix enforced server-side (permission-query + has-permission hooks); the LLM channel (confirm-gated `update_wiki` + nudge/voice ingest) intentionally keeps letting any desk user contribute to **Org** pages — that loop is the wiki. `update_wiki` gains `scope="User"` for "remember this just for me".
- **Obsidian-style container mirror** — site DB stays canonical; Org-scope pages render to `workspace/wiki/<type>/<slug>.md` + `index.md` + `log.md` in the tenant container via a new no-restart fleet endpoint (bench → admin relay → fleet). sha256 hash-guarded, batched under the fleet body cap, archived pages deleted, full syncs prune strays; triggered on page change + daily + manual. The in-container agent reads org lore with native file tools (zero bench round-trips); Role/User pages are NEVER mirrored (workspace is org-shared).
- **Wiki tab** (4th tab on Skills, all desk users) — server-paginated list w/ real `COUNT(*)`, search, scope/type filters, needs-attention + archived views, role-gated create dialog, page viewer/editor with markdown preview, restore-from-archive, SM settings popover (knowledge language, sync-now, health check).
- **Wiki health check (lint)** — weekly + manual: unresolved contradictions, stale pages, orphans (gated on link practice), near-duplicate titles; optional single LLM confirm pass. Human-readable summary surfaced in the tab.
- **Insights → skills** — B/C (insight-only) learnings on the Learning tab gain **"Apply to skill…"**: one LLM call drafts an update into the best-matching org custom skill (or proposes a new one), reviewer confirms a before/after diff, JLP terminal-marked with provenance (`materialized_skill` + applied note).
- **Knowledge language** — org-wide Jarvis Settings select (default **English**): voice-fact extraction, wiki ingest and insight drafting all translate non-English input (proper nouns kept + transliterated). Chat STT stays verbatim by design.

## UX review

Three independent full reviews with live Playwright click-throughs as 4 role-differentiated users (Fable → Opus → Sonnet per process). 36 + 10 + 8 findings; blocker + all majors + high-value minors fixed in the two `fix(ux)` commits — including a kit-wide frappe-ui 0.1.278 bug (ListFooter never imports Button → "Load More" rendered as an empty element, capping every list at page 1) and its sibling (`w-max` inner wrapper defeating column truncation).

## Tests

`test_wiki_permissions` 29 · `test_wiki_scopes_api` 37 · `test_wiki_mirror` 18 · `test_wiki_lint` 13 · `test_insight_skill_update` 25 · `test_knowledge_language` 11, plus regressions (`test_wiki` 26, `test_learned_api` 59, `test_voice*` 50, skills suites) — all green on patterntest.

## Deploy order + env notes

1. **This PR first**, then jarvis-openclaw-plugin#46 (update_wiki `scope` param), jarvis-persona#120 (skill docs). Container mirror needs jarvis-admin#216 + jarvis-fleet-agent#123 and a **fleet-agent daemon restart** (new route; no container restarts involved).
2. Dev box: bench→admin OAuth needs repair (admin.localhost OAuth Client was wiped — restored via seeder; `loki@aerele.in`'s admin password no longer matches the bench-stored one and needs a manual reset) before the SPA "Sync to agent now" chain works end-to-end. The mirror itself is live-verified against the fleet endpoint directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)