### PR TITLE
Write-UX Phase 2: read-only Preview panel

### DIFF
--- a/frontend/src/components/doc/DraftPreview.vue
+++ b/frontend/src/components/doc/DraftPreview.vue
@@ -1,0 +1,110 @@
+<script setup>
+import { computed } from "vue"
+
+const props = defineProps({
+  model: { type: Object, required: true },
+  headline: { type: String, default: "" },
+})
+const emit = defineEmits(["close", "edit", "confirm"])
+
+const isUpdate = computed(() => props.model.verb === "update")
+const badge = computed(() => (isUpdate.value ? "Pending change" : "Draft - not saved"))
+const docTitle = computed(() => {
+  const m = props.model
+  return `${isUpdate.value ? "Update" : "New"} ${m.doctype}${m.docName ? " · " + m.docName : ""}`
+})
+// Read-only fields to show: create -> the proposed (non-empty) fields; update ->
+// populated or changed fields (so the change shows in context).
+const fields = computed(() =>
+  (props.model.fields || []).filter((f) => {
+    const set = String(f.value ?? "").trim() !== ""
+    return isUpdate.value ? set || f.changed : set
+  }),
+)
+const tables = computed(() => (props.model.tables || []).filter((t) => (t.rows || []).length))
+</script>
+
+<template>
+  <transition name="dp-slide" appear>
+    <div class="dp-overlay" @click.self="emit('close')">
+      <aside class="dp-panel" tabindex="-1">
+        <div class="dp-head">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M9 4v16"/></svg>
+          <span class="dp-title">{{ docTitle }}</span>
+          <span class="dp-badge" :class="{ 'dp-badge-upd': isUpdate }">{{ badge }}</span>
+          <button class="dp-close" @click="emit('close')" title="Close" aria-label="Close">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+        </div>
+        <div class="dp-body">
+          <div v-if="headline" class="dp-headline">{{ headline }}</div>
+          <dl v-if="fields.length" class="dp-fields">
+            <template v-for="f in fields" :key="f.fieldname">
+              <dt>{{ f.label }}</dt>
+              <dd :class="{ 'dp-changed': f.changed }">
+                <template v-if="f.changed"><span class="dp-old">{{ f.orig || '(empty)' }}</span> <span class="dp-arrow">-&gt;</span> <span class="dp-new">{{ f.value || '(empty)' }}</span></template>
+                <template v-else>{{ f.value }}</template>
+              </dd>
+            </template>
+          </dl>
+          <div v-for="t in tables" :key="t.fieldname" class="dp-table">
+            <div class="dp-table-title">{{ t.label }} ({{ t.rows.length }})</div>
+            <div class="dp-gridwrap">
+              <table class="dp-grid">
+                <thead><tr><th v-for="c in t.columns" :key="c.fieldname">{{ c.label }}</th></tr></thead>
+                <tbody>
+                  <tr v-for="(r, ri) in t.rows" :key="ri">
+                    <td v-for="c in t.columns" :key="c.fieldname">{{ r[c.fieldname] ?? '' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div v-if="!fields.length && !tables.length" class="dp-empty">No values proposed yet.</div>
+        </div>
+        <div class="dp-foot">
+          <button class="dp-btn dp-btn-primary" @click="emit('confirm')">{{ isUpdate ? 'Confirm update' : 'Confirm create' }}</button>
+          <button class="dp-btn" @click="emit('edit')">Edit</button>
+          <button class="dp-btn" @click="emit('close')">Close</button>
+        </div>
+      </aside>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.dp-overlay { position: absolute; inset: 0; z-index: 61; background: rgba(15, 15, 22, 0.32); display: flex; justify-content: flex-end; }
+.dp-panel { width: min(720px, 82%); height: 100%; background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; box-shadow: -14px 0 44px rgba(20, 20, 30, 0.14); }
+.dp-head { display: flex; align-items: center; gap: 9px; padding: 11px 12px 11px 14px; border-bottom: 1px solid var(--border); flex: none; }
+.dp-head svg { flex: none; }
+.dp-title { font-size: 14px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
+.dp-badge { font-size: 10px; font-weight: 650; letter-spacing: .08em; text-transform: uppercase; color: var(--amber); background: var(--amber-bg); border: 1px solid var(--amber-bd); border-radius: 99px; padding: 3px 9px; flex: none; }
+.dp-badge-upd { color: var(--blue); background: var(--blue-bg); border-color: var(--blue-bd); }
+.dp-close { background: none; border: none; color: var(--text-3); cursor: pointer; padding: 4px; border-radius: 6px; display: flex; }
+.dp-close:hover { background: var(--surface-2); color: var(--text); }
+.dp-body { flex: 1; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 14px; }
+.dp-headline { font-size: 13.5px; font-weight: 600; color: var(--text); }
+.dp-fields { display: grid; grid-template-columns: max-content 1fr; gap: 6px 16px; margin: 0; }
+.dp-fields dt { font-size: 10.5px; font-weight: 650; letter-spacing: .06em; text-transform: uppercase; color: var(--text-3); align-self: center; }
+.dp-fields dd { margin: 0; font-size: 13.5px; color: var(--text); }
+.dp-changed .dp-old { color: var(--text-3); text-decoration: line-through; }
+.dp-changed .dp-arrow { color: var(--text-3); }
+.dp-changed .dp-new { color: var(--green); font-weight: 600; }
+.dp-table { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.dp-table-title { padding: 7px 10px; background: var(--surface-2); font-size: 12px; font-weight: 650; color: var(--text-2); }
+.dp-gridwrap { overflow-x: auto; }
+.dp-grid { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.dp-grid th { text-align: left; padding: 6px 10px; color: var(--text-3); font-weight: 600; border-bottom: 1px solid var(--border); white-space: nowrap; }
+.dp-grid td { padding: 5px 10px; color: var(--text); border-bottom: 1px solid var(--border); white-space: nowrap; }
+.dp-grid tbody tr:last-child td { border-bottom: none; }
+.dp-empty { font-size: 12.5px; color: var(--text-3); }
+.dp-foot { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-top: 1px solid var(--border); background: var(--surface-1); flex: none; }
+.dp-btn { padding: 8px 14px; border-radius: 8px; font-size: 13px; font-weight: 600; border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
+.dp-btn:hover { background: var(--surface-2); }
+.dp-btn-primary { background: var(--blue); border-color: var(--blue); color: #fff; }
+.dp-btn-primary:hover { filter: brightness(1.05); }
+.dp-slide-enter-active, .dp-slide-leave-active { transition: opacity .18s ease; }
+.dp-slide-enter-active .dp-panel, .dp-slide-leave-active .dp-panel { transition: transform .22s cubic-bezier(.4, 0, .2, 1); }
+.dp-slide-enter-from, .dp-slide-leave-to { opacity: 0; }
+.dp-slide-enter-from .dp-panel, .dp-slide-leave-to .dp-panel { transform: translateX(100%); }
+</style>

--- a/frontend/src/components/doc/DraftPreview.vue
+++ b/frontend/src/components/doc/DraftPreview.vue
@@ -4,6 +4,7 @@ import { computed } from "vue"
 const props = defineProps({
   model: { type: Object, required: true },
   headline: { type: String, default: "" },
+  disabled: { type: Boolean, default: false },
 })
 const emit = defineEmits(["close", "edit", "confirm"])
 
@@ -63,7 +64,7 @@ const tables = computed(() => (props.model.tables || []).filter((t) => (t.rows |
           <div v-if="!fields.length && !tables.length" class="dp-empty">No values proposed yet.</div>
         </div>
         <div class="dp-foot">
-          <button class="dp-btn dp-btn-primary" @click="emit('confirm')">{{ isUpdate ? 'Confirm update' : 'Confirm create' }}</button>
+          <button class="dp-btn dp-btn-primary" :disabled="disabled" @click="emit('confirm')">{{ isUpdate ? 'Confirm update' : 'Confirm create' }}</button>
           <button class="dp-btn" @click="emit('edit')">Edit</button>
           <button class="dp-btn" @click="emit('close')">Close</button>
         </div>
@@ -76,6 +77,7 @@ const tables = computed(() => (props.model.tables || []).filter((t) => (t.rows |
 .dp-overlay { position: absolute; inset: 0; z-index: 61; background: rgba(15, 15, 22, 0.32); display: flex; justify-content: flex-end; }
 .jv-dark .dp-overlay { background: rgba(0, 0, 0, 0.5); }
 .dp-panel { width: min(720px, 82%); height: 100%; background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; box-shadow: -14px 0 44px rgba(20, 20, 30, 0.14); }
+.dp-panel:focus { outline: none; }
 .dp-head { display: flex; align-items: center; gap: 9px; padding: 11px 12px 11px 14px; border-bottom: 1px solid var(--border); flex: none; }
 .dp-head svg { flex: none; }
 .dp-title { font-size: 14px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
@@ -104,6 +106,7 @@ const tables = computed(() => (props.model.tables || []).filter((t) => (t.rows |
 .dp-btn:hover { background: var(--surface-2); }
 .dp-btn-primary { background: var(--blue); border-color: var(--blue); color: #fff; }
 .dp-btn-primary:hover { filter: brightness(1.05); }
+.dp-btn-primary:disabled { opacity: .55; cursor: not-allowed; }
 .dp-slide-enter-active, .dp-slide-leave-active { transition: opacity .18s ease; }
 .dp-slide-enter-active .dp-panel, .dp-slide-leave-active .dp-panel { transition: transform .22s cubic-bezier(.4, 0, .2, 1); }
 .dp-slide-enter-from, .dp-slide-leave-to { opacity: 0; }

--- a/frontend/src/components/doc/DraftPreview.vue
+++ b/frontend/src/components/doc/DraftPreview.vue
@@ -74,6 +74,7 @@ const tables = computed(() => (props.model.tables || []).filter((t) => (t.rows |
 
 <style scoped>
 .dp-overlay { position: absolute; inset: 0; z-index: 61; background: rgba(15, 15, 22, 0.32); display: flex; justify-content: flex-end; }
+.jv-dark .dp-overlay { background: rgba(0, 0, 0, 0.5); }
 .dp-panel { width: min(720px, 82%); height: 100%; background: var(--surface); border-left: 1px solid var(--border); display: flex; flex-direction: column; box-shadow: -14px 0 44px rgba(20, 20, 30, 0.14); }
 .dp-head { display: flex; align-items: center; gap: 9px; padding: 11px 12px 11px 14px; border-bottom: 1px solid var(--border); flex: none; }
 .dp-head svg { flex: none; }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -887,10 +887,10 @@
 			</div>
 		</transition>
 		<DraftPreview
-			v-if="preview"
-			:model="preview.model"
-			:headline="preview.headline"
-			@close="preview = null"
+			v-if="previewOpen && summaryState.model"
+			:model="summaryState.model"
+			:headline="(summaryState.view && summaryState.view.headline) || ''"
+			@close="previewOpen = false"
 			@edit="onPreviewEdit"
 			@confirm="onPreviewConfirm"
 		/>
@@ -2141,20 +2141,17 @@ async function confirmSummary() {
 }
 
 // Read-only preview: opens DraftPreview over the current summary's model.
-const preview = ref(null) // { model, headline } while the read-only preview is open
+const previewOpen = ref(false)
 function previewSummary() {
 	if (!summaryState.value.model) return
-	preview.value = {
-		model: summaryState.value.model,
-		headline: (summaryState.value.view && summaryState.value.view.headline) || "",
-	}
+	previewOpen.value = true
 }
 async function onPreviewConfirm() {
-	preview.value = null
+	previewOpen.value = false
 	await confirmSummary()
 }
 function onPreviewEdit() {
-	preview.value = null
+	previewOpen.value = false
 	const a = activeAction.value
 	if (a) openDraftPanel({ verb: a.verb || "create", ...a })
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -223,6 +223,7 @@
 											<button class="jv-action-primary" :disabled="!summaryState.model || (summaryState.model && summaryState.model.applying) || convStreaming" :title="convStreaming ? 'Waiting for the current reply to finish' : ''" @click="confirmSummary">
 												{{ summaryState.model && summaryState.model.applying ? 'Saving...' : (activeAction.verb === 'update' ? 'Confirm update' : 'Confirm create') }}
 											</button>
+											<button class="jv-action-2nd" :disabled="!summaryState.model" @click="previewSummary">Preview</button>
 											<button class="jv-action-2nd" @click="openDraftPanel({ verb: activeAction.verb || 'create', ...activeAction })">Edit</button>
 										</div>
 										<div class="jv-summary-hint">Want a change? just tell me, e.g. "make Widget A qty 12".</div>
@@ -885,6 +886,14 @@
 				</aside>
 			</div>
 		</transition>
+		<DraftPreview
+			v-if="preview"
+			:model="preview.model"
+			:headline="preview.headline"
+			@close="preview = null"
+			@edit="onPreviewEdit"
+			@confirm="onPreviewConfirm"
+		/>
 	</div>
 </template>
 
@@ -900,6 +909,7 @@ import { takeChatPrefill } from "@/composables/chatPrefill"
 import { formatDate, exactDate } from "@/utils/datetime"
 import { renderMarkdown } from "@/markdown"
 import JvChart from "@/charts/JvChart.vue"
+import DraftPreview from "@/components/doc/DraftPreview.vue"
 import { useShellStore } from "@/stores/shell"
 import { useJarvisTheme } from "@/theme"
 import { displayName } from "@/lib/user"
@@ -2128,6 +2138,25 @@ async function confirmSummary() {
 	const model = summaryState.value.model
 	if (!model || model.applying || convStreaming.value) return
 	await applyDraft(0, model)
+}
+
+// Read-only preview: opens DraftPreview over the current summary's model.
+const preview = ref(null) // { model, headline } while the read-only preview is open
+function previewSummary() {
+	if (!summaryState.value.model) return
+	preview.value = {
+		model: summaryState.value.model,
+		headline: (summaryState.value.view && summaryState.value.view.headline) || "",
+	}
+}
+async function onPreviewConfirm() {
+	preview.value = null
+	await confirmSummary()
+}
+function onPreviewEdit() {
+	preview.value = null
+	const a = activeAction.value
+	if (a) openDraftPanel({ verb: a.verb || "create", ...a })
 }
 
 // Summary-first default (Task 1.3): a fresh create/update action builds the

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -799,7 +799,7 @@
 					<div class="jv-artifact-head">
 						<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M9 4v16"/></svg>
 						<span class="jv-artifact-head-title">{{ draftPanel.verb === 'update' ? 'Update' : 'New' }} {{ draftPanel.doctype }}<template v-if="draftPanel.docName"> · {{ draftPanel.docName }}</template></span>
-						<span class="jv-draft-badge">Draft — not saved</span>
+						<span class="jv-draft-badge">Draft - not saved</span>
 						<button class="jv-art-close" @click="closeDraftPanel" title="Close (draft stays in chat)" aria-label="Close">
 							<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
 						</button>
@@ -890,6 +890,7 @@
 			v-if="previewOpen && summaryState.model"
 			:model="summaryState.model"
 			:headline="(summaryState.view && summaryState.view.headline) || ''"
+			:disabled="convStreaming || !!(summaryState.model && summaryState.model.applying)"
 			@close="previewOpen = false"
 			@edit="onPreviewEdit"
 			@confirm="onPreviewConfirm"


### PR DESCRIPTION
## Phase 2 of the write-interaction UX: read-only Preview panel

Second of five phases (spec `docs/superpowers/specs/2026-07-07-jarvis-write-interaction-ux-design.md` section 3; plan Phase 2). Builds on Phase 1 (PR #237, merged).

**What it adds:** a **Preview** button on the summary card that opens a read-only side-over showing the full pending record - the "see the whole thing before I commit" affordance, without entering edit mode. It's the spec's DocPage-renderer decision: same field metadata, SPA-styled, and it can show the *pending* state a desk form cannot.

### What changed

- **New self-contained component** `frontend/src/components/doc/DraftPreview.vue`: a read-only right side-over matching the editable draft panel's visual weight. Renders the model-driven summary in full - the fields the model proposed, the optional headline, and child tables as read-only grids; for updates, changed fields show old -> new. Badges: "Draft - not saved" (create) / "Pending change" (update). Footer: Confirm / Edit / Close.
- **Wiring** in `ChatView.vue`: a Preview button (Confirm / Preview / Edit), and the panel rendered **live-bound** to the current model.

### Design and theme fidelity

- Matches the existing `.jv-artifact-panel` chrome (width, shadow, border, header) so it reads as the same family as the editable panel.
- **Tokens-only** styling (`--surface`, `--text`, `--blue`, `--amber`, `--green`, ...); includes the `.jv-dark` backdrop override so dark mode matches the existing overlay.
- **Read-only and safe:** no inputs, no `v-model`, no `v-html` - all values render through escaped `{{ }}`, so the model-authored headline has no XSS surface.
- **Model-driven, consistent with Phase 1:** no re-introduced field heuristic or code-computed total.

### Correctness

- The preview binds **live** to `summaryState.model` (not a snapshot), so if the draft re-emits while the preview is open, the panel updates and Confirm applies exactly what is shown - no stale-apply mismatch.
- The preview's Confirm is disabled while a reply is streaming or the write is applying, matching the card's Confirm.

### Verification done

- `@vue/compiler-sfc` parse + compileScript + compileTemplate on both files: zero errors.
- Combined spec+quality review, a whole-branch final review (opus), and re-reviews after fixes: 0 Critical, 0 Important. Two issues found and fixed mid-review (a stale-snapshot WYSIWYG bug; a missing dark-mode backdrop override) plus three final-review Minors folded in.

### Live smoke PENDING (please run before merge)

No headless render test exists. In a **fresh chat on `jarvis-test.localhost`**, **light and dark**:

1. Create with line items -> summary card -> **Preview** -> read-only panel shows the proposed fields + full items table (no inputs); Confirm from the preview creates the record.
2. Update -> Preview shows the record with the changed field as old -> new.
3. Edit from the preview opens the editable panel; Close returns to the chat.

### Notes

- No backend change. The optional `docmeta` widening (comments/attachments on existing records) is deferred - the core preview needs no backend.
- Deferred Minors: a benign remount/flicker if the draft re-emits while the preview is open; Escape-to-close (the sibling editable panel also lacks it).
- Separate pre-existing debt surfaced: `ChatView.vue` carries ~95 em-dashes in unrelated comments/UI strings (project rule is no em-dashes). Not touched here to keep this PR scoped; worth a dedicated cleanup PR.
- Next: Phase 3 (few-vs-many input) after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
