### PR TITLE
Write-UX Phase 3 (app): all-field-type ask as a compact mini-form

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -245,7 +245,7 @@
 									<button class="jv-confirm-yes" @click="answerConfirm(true, confirmLabel(m))">Confirm</button>
 								</div>
 								<!-- interactive clarifying questions (Claude-style cards; one Submit) -->
-								<div v-else-if="askFor === m.name && activeAsk" class="jv-ask">
+								<div v-else-if="askFor === m.name && activeAsk" class="jv-ask" :class="{ 'jv-ask--form': askIsForm }">
 									<div v-for="(q, qi) in activeAsk.questions" :key="qi" class="jv-ask-q">
 										<div class="jv-ask-qt"><span class="jv-ask-num">{{ qi + 1 }}</span>{{ q.q }}</div>
 										<!-- yes/no, with optional custom labels (e.g. Approve / Reject) -->
@@ -2381,6 +2381,12 @@ const askSel = ref({}) // qIdx -> string (single/yesno/date/datetime/text/link) 
 const askOther = ref({}) // qIdx -> free-text (option types only)
 const askLink = ref({}) // qIdx -> { q, items, open } for link-type record search
 const _FIELD_TYPES = ["date", "datetime", "link", "text"]
+// An ask whose questions are ALL field-type reads better as a compact mini-form
+// (no numbered badges, no dividers) than as a numbered question list.
+const askIsForm = computed(() => {
+	const spec = activeAsk.value
+	return !!spec && spec.questions.length > 0 && spec.questions.every((q) => _FIELD_TYPES.includes(q.type))
+})
 // Reset the draft whenever a new question set appears (new message asks).
 watch(askFor, () => {
 	askSel.value = {}
@@ -4282,6 +4288,10 @@ function onGlobalKey(e) {
 .jv-ask-q:last-of-type { border-bottom: 0; padding-bottom: 4px; margin-bottom: 4px; }
 .jv-ask-qt { display: flex; align-items: flex-start; gap: 8px; font-size: 13.5px; font-weight: 600; color: var(--text); margin-bottom: 9px; line-height: 1.4; }
 .jv-ask-num { flex: none; width: 19px; height: 19px; border-radius: 99px; background: var(--blue-bg); color: var(--blue); font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; margin-top: 1px; }
+.jv-ask--form .jv-ask-num { display: none; }
+.jv-ask--form .jv-ask-q { border-bottom: 0; padding-bottom: 11px; margin-bottom: 11px; }
+.jv-ask--form .jv-ask-q:last-of-type { padding-bottom: 0; margin-bottom: 0; }
+.jv-ask--form .jv-ask-qt { font-size: 10.5px; font-weight: 650; letter-spacing: .06em; text-transform: uppercase; color: var(--text-3); margin-bottom: 6px; }
 .jv-ask-opts { display: flex; flex-wrap: wrap; gap: 7px; }
 .jv-ask-opt { display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 9px; font-family: inherit; font-size: 12.5px; font-weight: 500; color: var(--text-2); cursor: pointer; transition: border-color .12s, background .12s, color .12s; }
 .jv-ask-opt:hover { border-color: var(--border-2); color: var(--text); }


### PR DESCRIPTION
## Phase 3 (app side): all-field-type jarvis-ask renders as a compact mini-form

Third of five phases of the write-interaction UX (input collection). This is the small frontend half; the substance is in the paired persona PR (jarvis-persona).

**What it does:** when a `jarvis-ask` clarifying round is entirely field-type questions (`text` / `date` / `datetime` / `link`), the chat renders it as a tidy inline **mini-form** - number badges and per-question dividers dropped, each question shown as a small uppercase field label. Option-bearing asks (yes/no, single, multi) keep the numbered question list unchanged.

This is what makes the persona's "a few missing details -> one inline mini-form" rule actually look like a form rather than a quiz.

### Change
- `frontend/src/views/ChatView.vue`: an `askIsForm` computed (reuses the existing `_FIELD_TYPES`), a `jv-ask--form` modifier class, and four scoped, tokens-only CSS rules. +11 lines.

### Verification
- `@vue/compiler-sfc` parse + compileScript + compileTemplate: zero errors.
- Tokens-only (light/dark safe); no em-dashes.

### Live smoke PENDING (please run before merge)
Fresh chat on `jarvis-test.localhost`, light and dark:
1. A create that makes Jarvis ask for a few field-type details -> the ask renders as a compact mini-form (no numbers, label-style text).
2. An ask with yes/no or single/multi options still shows the numbered question list.

Pairs with jarvis-persona PR (few-vs-many ask rules + summary headline). Merge order does not matter; the persona change needs a container restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
