### PR TITLE
feat(mobile): QR pairing endpoints + Connect phone in chat header

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -37,6 +37,10 @@ export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" })
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat")
 
+// --- Mobile app onboarding: QR the phone scans to learn the site connection
+// details (no secret — just where to reach this site). ---
+export const getPairingQr = () => call("jarvis.mobile.auth.get_pairing_qr")
+
 // --- Custom skills (customer-authored, pushed to the container) ---
 const SK = "jarvis.chat.custom_skills_api."
 export const listCustomSkills = () => call(SK + "list_custom_skills")

--- a/frontend/src/components/ConnectPhoneDialog.vue
+++ b/frontend/src/components/ConnectPhoneDialog.vue
@@ -1,0 +1,95 @@
+<template>
+	<Dialog
+		:modelValue="modelValue"
+		:options="{ title: 'Connect your phone', size: 'sm' }"
+		@update:modelValue="(v) => emit('update:modelValue', v)"
+	>
+		<template #body-content>
+			<p class="text-p-sm text-ink-gray-6">
+				Open the <b>Jarvis</b> app on your phone and scan this code to connect to this
+				workspace — then sign in with your email and password.
+			</p>
+
+			<div class="mt-4 flex flex-col items-center">
+				<div v-if="loading" class="flex h-52 w-52 items-center justify-center text-sm text-ink-gray-5">
+					Generating code…
+				</div>
+				<div
+					v-else-if="error"
+					class="flex h-52 w-52 flex-col items-center justify-center gap-2 text-center text-sm text-ink-gray-5"
+				>
+					<FeatherIcon name="alert-triangle" class="size-5 text-ink-amber-3" />
+					<span>{{ error }}</span>
+					<Button label="Retry" variant="subtle" @click="load" />
+				</div>
+				<template v-else>
+					<div class="rounded-xl border border-outline-gray-2 bg-white p-3">
+						<img :src="qrSrc" alt="Pairing QR code" class="size-52" />
+					</div>
+					<div class="mt-3 text-center">
+						<div class="text-base font-medium text-ink-gray-8">{{ payload.name }}</div>
+						<div class="text-sm text-ink-gray-5">{{ payload.site }}</div>
+					</div>
+				</template>
+			</div>
+
+			<p class="mt-4 text-p-sm text-ink-gray-5">
+				Don’t have the app yet? Install <b>Jarvis</b> from your app store, then tap
+				<b>Scan to connect</b> on the welcome screen.
+			</p>
+		</template>
+
+		<template #actions>
+			<Button label="Done" variant="solid" class="w-full" @click="emit('update:modelValue', false)" />
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// ConnectPhoneDialog — shows a QR encoding this site's connection details
+// (site URL, real site name, dev socket port) for the mobile app to scan during
+// onboarding. Contains NO credential; the phone signs in with email+password
+// after scanning. Backend: jarvis.mobile.auth.get_pairing_qr.
+import { ref, computed, watch } from "vue"
+import { Dialog, Button, FeatherIcon } from "frappe-ui"
+import * as api from "@/api"
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+})
+const emit = defineEmits(["update:modelValue"])
+
+const loading = ref(false)
+const error = ref("")
+const svg = ref("")
+const payload = ref({ name: "", site: "" })
+
+const qrSrc = computed(() => (svg.value ? `data:image/svg+xml;base64,${svg.value}` : ""))
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Could not generate the code."
+}
+
+async function load() {
+	loading.value = true
+	error.value = ""
+	try {
+		const res = await api.getPairingQr()
+		svg.value = res?.svg || ""
+		payload.value = res?.payload || { name: "", site: "" }
+		if (!svg.value) error.value = "Could not generate the code."
+	} catch (e) {
+		error.value = errMsg(e)
+	} finally {
+		loading.value = false
+	}
+}
+
+// Fetch a fresh QR each time the dialog opens.
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (open) load()
+	}
+)
+</script>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -43,6 +43,10 @@
 							</button>
 						</div>
 					</div>
+					<!-- Connect phone: shows a QR the mobile app scans to onboard -->
+					<button class="jv-iconbtn" @click="showConnect = true" title="Connect phone" aria-label="Connect phone" style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:transparent;border:1px solid var(--border);border-radius:7px;cursor:pointer;">
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="2" width="10" height="20" rx="2" /><path d="M11 18h2" /></svg>
+					</button>
 					<button class="jv-iconbtn" @click="toggleTheme" :title="effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'" style="width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:transparent;border:1px solid var(--border);border-radius:7px;cursor:pointer;">
 						<svg v-if="effectiveDark" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4" /><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" /></svg>
 						<svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" /></svg>
@@ -895,6 +899,8 @@
 			@edit="onPreviewEdit"
 			@confirm="onPreviewConfirm"
 		/>
+
+		<ConnectPhoneDialog v-model="showConnect" />
 	</div>
 </template>
 
@@ -910,6 +916,7 @@ import { takeChatPrefill } from "@/composables/chatPrefill"
 import { formatDate, exactDate } from "@/utils/datetime"
 import { renderMarkdown } from "@/markdown"
 import JvChart from "@/charts/JvChart.vue"
+import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue"
 import DraftPreview from "@/components/doc/DraftPreview.vue"
 import { useShellStore } from "@/stores/shell"
 import { useJarvisTheme } from "@/theme"
@@ -1006,6 +1013,7 @@ function _settleConfirm(val) {
 	if (r) r(val)
 }
 const modelMenuOpen = ref(false)
+const showConnect = ref(false)
 // (sidebar collapse machinery, per-conversation ⋯ menu and inline rename
 // moved to the app shell — stores/shell.js + components/shell/*, §3.7)
 const modelOverride = ref("")

--- a/jarvis/mobile/auth.py
+++ b/jarvis/mobile/auth.py
@@ -1,0 +1,98 @@
+"""Mobile-app authentication + pairing helpers.
+
+Onboarding (issue #224): the phone scans a QR shown in the Jarvis web app to
+learn the *site connection details* (no typing a workspace URL), then signs in
+with email + password once. That login establishes a short-lived cookie session
+purely to call `get_mobile_token`, which returns a durable API key/secret; from
+then on the app authenticates every request (and the realtime socket) with
+`Authorization: token key:secret` — stateless, no idle-timeout. The password is
+never stored; on logout the phone re-signs-in (the site is remembered).
+
+`get_mobile_token` is idempotent: if the user already has an api_key/api_secret
+it returns the EXISTING pair (decrypted) and does NOT rotate it, so a user's
+existing API integrations keep working. Keys are only generated when missing.
+This differs from frappe.core.doctype.user.user.generate_keys, which is
+System-Manager gated AND rotates the secret on every call.
+"""
+
+import json
+from base64 import b64encode
+from io import BytesIO
+
+import frappe
+
+# Bumped if the QR payload shape changes so old app builds can reject it cleanly.
+PAIRING_PAYLOAD_VERSION = 1
+
+
+@frappe.whitelist(methods=["POST"])
+def get_mobile_token() -> dict:
+	"""Return the logged-in user's durable api_key/api_secret (creating them only
+	if absent — never rotating an existing secret).
+
+	Returns the plaintext secret so the phone can store it. Only ever acts on the
+	session user, never an arbitrary `user` argument. Also returns `site` (the
+	real Frappe site name) so the client targets the realtime namespace correctly
+	when the workspace is reached via a bare IP.
+	"""
+	user = frappe.session.user
+	if not user or user == "Guest":
+		raise frappe.AuthenticationError
+
+	doc = frappe.get_doc("User", user)
+	existing_secret = doc.get_password("api_secret", raise_exception=False) if doc.api_key else None
+
+	if doc.api_key and existing_secret:
+		# Reuse — rotating would break the user's existing API integrations.
+		secret = existing_secret
+	else:
+		secret = frappe.generate_hash(length=15)
+		if not doc.api_key:
+			doc.api_key = frappe.generate_hash(length=15)
+		doc.api_secret = secret
+		doc.save(ignore_permissions=True)
+
+	return {"api_key": doc.api_key, "api_secret": secret, "site": frappe.local.site}
+
+
+def _pairing_payload() -> dict:
+	"""Non-secret site connection details the phone needs to reach this site."""
+	# In dev/self-host the realtime server listens on its own port; in production
+	# it rides the site origin, so no port is advertised.
+	port = None
+	if frappe.conf.get("developer_mode"):
+		port = frappe.conf.get("socketio_port")
+
+	return {
+		"v": PAIRING_PAYLOAD_VERSION,
+		"site": frappe.utils.get_url(),
+		"name": frappe.local.site,
+		"port": port,
+		# The web user's login id, so the phone can prefill the email field
+		# (they still type their password). Not a secret.
+		"email": frappe.session.user,
+	}
+
+
+@frappe.whitelist()
+def get_pairing_qr() -> dict:
+	"""Return an SVG QR (base64) encoding the site connection details, plus the
+	raw payload. Shown in the Jarvis web app for the phone to scan during
+	onboarding. Contains NO secret — only where to reach the site."""
+	if not frappe.session.user or frappe.session.user == "Guest":
+		raise frappe.AuthenticationError
+
+	from pyqrcode import create as qrcreate
+
+	payload = _pairing_payload()
+	data = json.dumps(payload, separators=(",", ":"))
+
+	qr = qrcreate(data, error="M")
+	stream = BytesIO()
+	try:
+		qr.svg(stream, scale=5, quiet_zone=2, background="#ffffff", module_color="#111111")
+		svg_b64 = b64encode(stream.getvalue()).decode()
+	finally:
+		stream.close()
+
+	return {"svg": svg_b64, "payload": payload}

--- a/jarvis/mobile/auth.py
+++ b/jarvis/mobile/auth.py
@@ -16,8 +16,10 @@ System-Manager gated AND rotates the secret on every call.
 """
 
 import json
+import socket
 from base64 import b64encode
 from io import BytesIO
+from urllib.parse import urlparse
 
 import frappe
 
@@ -55,17 +57,42 @@ def get_mobile_token() -> dict:
 	return {"api_key": doc.api_key, "api_secret": secret, "site": frappe.local.site}
 
 
+def _lan_ip() -> str | None:
+	"""Best-effort primary LAN IP of this host (opens a UDP socket, sends nothing)."""
+	try:
+		s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		try:
+			s.connect(("8.8.8.8", 80))
+			return s.getsockname()[0]
+		finally:
+			s.close()
+	except Exception:
+		return None
+
+
 def _pairing_payload() -> dict:
 	"""Non-secret site connection details the phone needs to reach this site."""
+	dev = bool(frappe.conf.get("developer_mode"))
 	# In dev/self-host the realtime server listens on its own port; in production
 	# it rides the site origin, so no port is advertised.
-	port = None
-	if frappe.conf.get("developer_mode"):
-		port = frappe.conf.get("socketio_port")
+	port = frappe.conf.get("socketio_port") if dev else None
+
+	site = frappe.utils.get_url()
+	# Dev foolproofing: if the web was opened at localhost/.localhost/127.0.0.1,
+	# the phone can't reach that host — swap in the laptop's LAN IP so the scanned
+	# URL is reachable. Dev-only; production hostnames are never touched.
+	if dev:
+		parsed = urlparse(site)
+		host = parsed.hostname or ""
+		if host in ("127.0.0.1", "localhost") or host.endswith(".localhost"):
+			lan = _lan_ip()
+			if lan:
+				suffix = f":{parsed.port}" if parsed.port else ""
+				site = f"{parsed.scheme}://{lan}{suffix}"
 
 	return {
 		"v": PAIRING_PAYLOAD_VERSION,
-		"site": frappe.utils.get_url(),
+		"site": site,
 		"name": frappe.local.site,
 		"port": port,
 		# The web user's login id, so the phone can prefill the email field


### PR DESCRIPTION
## What

Backend + web support for onboarding the Jarvis **mobile app** by scanning a QR (issue #224). The mobile client itself lives in a separate private repo (`Aerele-RnD/jarvis_mobile`); this PR is only the open-source server + web pieces.

### Backend — `jarvis/mobile/auth.py`
- `get_mobile_token` — mints (or returns) the logged-in users api_key/api_secret for durable token auth. **Idempotent**: reuses an existing secret instead of rotating it, so existing API integrations keep working. Self-scoped to `frappe.session.user`.
- `get_pairing_qr` — renders a pyqrcode SVG of the non-secret site connection details (URL, real site name, dev socket port, email) for the phone to scan. No new dependency (pyqrcode ships with Frappes 2FA).

### Web — chat header
- A **Connect phone** button (top-right of the chat header) opens `ConnectPhoneDialog`, which shows the pairing QR. Reachable by any user.

## Notes
- No secret is ever in the QR; the phone signs in with the users password, which mints the durable token.
- Built assets are gitignored, so this is source-only (deploy runs `bench build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)