### PR TITLE
chore(frontend): replace em-dashes and en-dashes with hyphens

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -1,4 +1,4 @@
-// Pure display helpers for the account/billing section. No Vue, no I/O — unit-tested.
+// Pure display helpers for the account/billing section. No Vue, no I/O - unit-tested.
 const STATUS_LABELS = {
   Active: "Active",
   "Pending Verification": "Pending verification",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -68,7 +68,7 @@ export const stopMacroRun = (run) => call(MC + "stop_macro_run", { run })
 export const listMacroRuns = (params) => call(MC + "list_macro_runs", params || {})
 export const macroRunStats = () => call(MC + "macro_run_stats")
 // Background summarize: fired after every 2+ step save; the WORKER applies the
-// summary when the turn ends (macro:merged event) — no client round-trip needed.
+// summary when the turn ends (macro:merged event) - no client round-trip needed.
 // Run is gated on merge_status while pending.
 export const summarizeMacro = (name) => call(MC + "summarize_macro", { name })
 export const setConversationModel = (conversation, model) =>
@@ -94,7 +94,7 @@ export const listPendingConfirmations = (conversation) =>
 
 export async function sendMessage(conversation, message, modelOverride, attachments, context) {
 	// Empty conversation is allowed: the backend creates (or focuses) an empty
-	// conversation itself and returns its id as `conversation_id` — saves the
+	// conversation itself and returns its id as `conversation_id` - saves the
 	// SPA a createOrFocusEmpty round-trip before the first send (latency plan).
 	const args = { conversation: conversation || "", message }
 	if (modelOverride) args.model_override = modelOverride
@@ -125,7 +125,7 @@ export const saveLlmPool = (models, preset = null, routingMode = "failover") =>
 
 // --- Onboarding wizard (managed signup + self-hosted connect) ---
 // Arg names mirror the real backend signatures (jarvis/onboarding.py,
-// jarvis/account.py, jarvis/selfhost.py) — verified against the desk wizard's
+// jarvis/account.py, jarvis/selfhost.py) - verified against the desk wizard's
 // frappe.call usage in jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.js.
 export const listPlans = () => call("jarvis.onboarding.list_plans")
 export const getAccountDefaults = () => call("jarvis.onboarding.get_account_defaults")
@@ -165,7 +165,7 @@ export const getDirectSubscriptionStatus = () =>
 // DIRECT paste-back re-authorize: begin → { ok, data:{nonce, authorize_url,
 // expires_in} }; complete pushes the fresh blob to the container's
 // auth-profiles.json + rewrites the flat fields (force restart). These write
-// Jarvis Settings — unlike the pool "capture-only" variants above.
+// Jarvis Settings - unlike the pool "capture-only" variants above.
 export const beginPasteSignin = (provider, model) =>
 	call("jarvis.oauth.api.begin_paste_signin", { provider, model })
 export const completePasteSignin = (nonce, redirectedUrl) =>
@@ -234,7 +234,7 @@ export const listAgentRuns = (agent, limit) =>
 export const listAgentFindings = (p) => call(AG + "list_findings", p || {})
 export const setFindingState = (finding, state) =>
 	call(AG + "set_finding_state", { finding, state })
-// Role gating + listing admin (System Manager only — the server enforces it;
+// Role gating + listing admin (System Manager only - the server enforces it;
 // the SPA merely probes getAgentAdminOverview and hides the Admin tab on 403).
 export const setAgentRoles = (agent_slug, roles) =>
 	call(AG + "set_agent_roles", { agent_slug, roles: JSON.stringify(roles || []) })

--- a/frontend/src/api/agents.js
+++ b/frontend/src/api/agents.js
@@ -1,12 +1,12 @@
-// Agents-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen — new
+// Agents-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen - new
 // endpoints get thin wrappers in per-feature modules under src/api/.
 import { call } from "frappe-ui"
 
-// §8.3 — one agent's listing + THIS owner's installation (or null) for the
+// §8.3 - one agent's listing + THIS owner's installation (or null) for the
 // detail page. -> { ...listing fields, allowed_roles, allowed: 0|1,
 //   installation: {name, enabled, installed_version, config, schedule_*,
 //   next_run_at, last_run_at, sync_status} | null, install_count: int,
-//   all_roles: [str] (present only for System Manager — the Admin-tab signal) }
+//   all_roles: [str] (present only for System Manager - the Admin-tab signal) }
 export const getAgent = (agent_slug) =>
 	call("jarvis.chat.agents_api.get_agent", { agent_slug })
 

--- a/frontend/src/api/approvals.js
+++ b/frontend/src/api/approvals.js
@@ -1,4 +1,4 @@
-// Approval detail client (DESIGN-V3 §8.3, D39) — get_approval returns the full
+// Approval detail client (DESIGN-V3 §8.3, D39) - get_approval returns the full
 // row (name, title, status, document_type, conversation, question, context_md,
 // options, ref_doctype, ref_name, decision, decided_by, decided_by_name,
 // decided_at, creation, owner, can_act) gated like decide(): SM or the owner

--- a/frontend/src/api/docmeta.js
+++ b/frontend/src/api/docmeta.js
@@ -1,4 +1,4 @@
-// Docmeta client (DESIGN-V3 §8.1 + §14 F1) — thin call() wrappers around the
+// Docmeta client (DESIGN-V3 §8.1 + §14 F1) - thin call() wrappers around the
 // jarvis.chat.docmeta_api endpoints (B7). Signatures are FROZEN by the design;
 // the SPA is built against them. All endpoints are gated server-side
 // (owner / conversation-owner / SM; assignees get DocShare read).
@@ -10,7 +10,7 @@ const DM = "jarvis.chat.docmeta_api."
 // attachments, created, modified} (D22 + §14 F1 `shares`).
 export const getDocmeta = (doctype, name) => call(DM + "get_docmeta", { doctype, name })
 
-// Comments — add returns the new row (get_docmeta shape); update returns the
+// Comments - add returns the new row (get_docmeta shape); update returns the
 // updated row; delete returns nothing.
 export const addComment = (doctype, name, content) =>
 	call(DM + "add_comment", { doctype, name, content })
@@ -18,17 +18,17 @@ export const updateComment = (comment, content) =>
 	call(DM + "update_comment", { comment, content })
 export const deleteComment = (comment) => call(DM + "delete_comment", { comment })
 
-// Assignees — returns the fresh assignees list. action: "add" | "remove".
-// Not offered on Jarvis Custom Skill (§14 DA-09 — server allowlist matches).
+// Assignees - returns the fresh assignees list. action: "add" | "remove".
+// Not offered on Jarvis Custom Skill (§14 DA-09 - server allowlist matches).
 export const toggleAssignment = (doctype, name, user, action = "add") =>
 	call(DM + "toggle_assignment", { doctype, name, user, action })
 
-// Shares (§14 F1) — DocShare read grant for Macro/Approval/Agent Installation
+// Shares (§14 F1) - DocShare read grant for Macro/Approval/Agent Installation
 // (skills keep their child-table share model). action: "add" | "remove".
 export const toggleShare = (doctype, name, user, action = "add") =>
 	call(DM + "toggle_share", { doctype, name, user, action })
 
-// Like — hides the desk `add="Yes"` string quirk (D25); returns liked_by list.
+// Like - hides the desk `add="Yes"` string quirk (D25); returns liked_by list.
 export const toggleLike = (doctype, name, like = 1) =>
 	call(DM + "toggle_like", { doctype, name, like: like ? 1 : 0 })
 

--- a/frontend/src/api/learning.js
+++ b/frontend/src/api/learning.js
@@ -1,4 +1,4 @@
-// Learning-board API (plan §6.4) — thin wrappers around
+// Learning-board API (plan §6.4) - thin wrappers around
 // `jarvis.chat.learned_api.*`, the SM-gated + managed-only endpoints behind the
 // Skills-page "Learning" tab. Mirrors src/api/skills.js: one `call` per
 // endpoint; list/settings/batch args are JSON-encoded where the server
@@ -13,7 +13,7 @@ const LR = "jarvis.chat.learned_api."
 // Flat kwargs (NOT the frozen `filters` JSON envelope the four feature lists
 // use): the endpoint takes domain/status/strength/search/surfaced directly.
 // `surfaced`: 1 (default review board) | 0 | "all" (decided tabs).
-// `view`: "" (default board) | "decided" — the Review tab's Decided log; the
+// `view`: "" (default board) | "decided" - the Review tab's Decided log; the
 // server then OVERRIDES status with every human-touched terminal/parked state,
 // ignores `surfaced` and orders by reviewed_at (nulls last; `sort` "newest"
 // (default) | "oldest" flips it). `disposition` filters the decided view only
@@ -37,7 +37,7 @@ export const listLearnedPatternsPage = (p = {}) =>
 // roles, compiled-bullet preview, exceptions (SM may see named parties), runs.
 export const getLearnedPattern = (name) => call(LR + "get_learned_pattern", { name })
 
-// ── lifecycle transitions (§6.5) — human SM actions, TOCTOU-safe server-side ──
+// ── lifecycle transitions (§6.5) - human SM actions, TOCTOU-safe server-side ──
 // Proposed→Approved (or Stale→Approved). Passing an edited draft freezes the
 // evidence line (draft_edited=1); omit it to approve as-drafted.
 export const approveLearnedPattern = (name, editedSkillDraft) =>
@@ -52,7 +52,7 @@ export const rejectLearnedPattern = (name, reason) =>
 	call(LR + "reject_learned_pattern", { name, reason })
 // B/C insight-only disposition (Phase 1): records that the SM read the insight
 // and dismisses it (stored server-side as a terminal Rejected + a stable note).
-// A-class rows are refused server-side — they must be Approved to reach the
+// A-class rows are refused server-side - they must be Approved to reach the
 // container. Wired to the "Acknowledge (insight only)" card action.
 export const acknowledgeLearnedPattern = (name) =>
 	call(LR + "acknowledge_learned_pattern", { name })
@@ -90,7 +90,7 @@ export const applyInsightSkillUpdate = (patternName, payload = {}) => {
 
 // ── apply / sync (learned skills ride the custom-skill push, §6.2) ───────────
 export const applyLearnedSkills = () => call(LR + "apply_learned_skills")
-// Proxies get_custom_skills_sync_status — same pill the Skills page polls.
+// Proxies get_custom_skills_sync_status - same pill the Skills page polls.
 export const getLearnedApplyStatus = () => call(LR + "get_learned_apply_status")
 // Board badge: surfaced patterns still awaiting a decision.
 export const pendingLearnedCount = () => call(LR + "pending_learned_count")
@@ -103,6 +103,6 @@ export const getLearningSettings = (includePreflight = 0) =>
 	call(LR + "get_learning_settings", { include_preflight: includePreflight ? 1 : 0 })
 export const setLearningSettings = (payload) =>
 	call(LR + "set_learning_settings", { payload: JSON.stringify(payload || {}) })
-// SM-only but NOT self-host-gated — the probe the tab uses to render the
+// SM-only but NOT self-host-gated - the probe the tab uses to render the
 // managed-only empty state (reports {self_hosted, enabled, last/next run, ...}).
 export const getLearningStatus = () => call(LR + "get_learning_status")

--- a/frontend/src/api/macros.js
+++ b/frontend/src/api/macros.js
@@ -1,8 +1,8 @@
-// Macros-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen — new
+// Macros-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen - new
 // endpoints get thin wrappers in per-feature modules under src/api/.
 import { call } from "frappe-ui"
 
-// §8.3 — bulk delete of own macros (each row's run history goes first, server
+// §8.3 - bulk delete of own macros (each row's run history goes first, server
 // side). Not-owned rows are skipped with per-row reasons.
 // -> { deleted: int, skipped: [{name, reason}] }
 export const deleteMacrosBulk = (names) =>

--- a/frontend/src/api/shell.js
+++ b/frontend/src/api/shell.js
@@ -1,8 +1,8 @@
-// Shell-owned API wrappers (DESIGN-V3 §8.4). `src/api.js` is frozen — new
+// Shell-owned API wrappers (DESIGN-V3 §8.4). `src/api.js` is frozen - new
 // endpoints get thin wrappers in per-feature modules under src/api/.
 import { call } from "frappe-ui"
 
-// D40 — title-only, paginated, owner-scoped conversation search (⌘K palette).
+// D40 - title-only, paginated, owner-scoped conversation search (⌘K palette).
 // -> { rows: [{name, title, starred, last_active_at}], total, has_more, start, page_length }
 export const searchConversations = (params = {}) =>
 	call("jarvis.chat.api.search_conversations", {

--- a/frontend/src/api/skills.js
+++ b/frontend/src/api/skills.js
@@ -1,8 +1,8 @@
-// Skills-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen — new
+// Skills-page API additions (DESIGN-V3 §8.4). `src/api.js` is frozen - new
 // endpoints get thin wrappers in per-feature modules under src/api/.
 import { call } from "frappe-ui"
 
-// §8.3 — bulk delete of own skills. The server skips shared/not-owned rows
+// §8.3 - bulk delete of own skills. The server skips shared/not-owned rows
 // with per-row reasons and enqueues ONE skills-apply at the end.
 // -> { deleted: int, skipped: [{name, reason}] }
 export const deleteCustomSkillsBulk = (names) =>

--- a/frontend/src/api/voice.js
+++ b/frontend/src/api/voice.js
@@ -1,4 +1,4 @@
-// Voice API — thin wrappers around `jarvis.chat.voice` and
+// Voice API - thin wrappers around `jarvis.chat.voice` and
 // `jarvis.chat.voice_notes_api` (wiki endpoints live in src/api/wiki.js).
 // Mirrors src/api/learning.js: one `call` per endpoint. The exception is
 // `transcribeAudio`, which must POST a multipart body (the recorded blob), so
@@ -70,7 +70,7 @@ export async function transcribeAudio(blob, { durationS = 0 } = {}) {
 
 // ── voice notes (Business tab + chat nudge share these) ──────────────────────
 // p: {transcript, context_type, conversation, entities (JSON string),
-//     duration_s, source} — server defaults context_type "Business" /
+//     duration_s, source} - server defaults context_type "Business" /
 // source "Business Tab" when omitted. → {name}
 export const saveVoiceNote = (p = {}) => call(VN + "save_voice_note", p)
 export const listMyVoiceNotesPage = (p = {}) =>
@@ -80,7 +80,7 @@ export const listMyVoiceNotesPage = (p = {}) =>
 		...(p.status ? { status: p.status } : {}),
 		...(p.search ? { search: p.search } : {}),
 	})
-// owner-only, status "New" only — edited transcript re-feeds the daily sweep
+// owner-only, status "New" only - edited transcript re-feeds the daily sweep
 export const updateVoiceNote = (name, transcript) =>
 	call(VN + "update_voice_note", { name, transcript })
 export const deleteVoiceNote = (name) => call(VN + "delete_voice_note", { name })

--- a/frontend/src/api/wiki.js
+++ b/frontend/src/api/wiki.js
@@ -1,7 +1,7 @@
-// Wiki API — thin wrappers around `jarvis.chat.wiki.*`, the scope-aware wiki
+// Wiki API - thin wrappers around `jarvis.chat.wiki.*`, the scope-aware wiki
 // endpoints behind the Skills-page "Wiki" tab. Mirrors src/api/learning.js:
 // one `call` per endpoint. The list endpoint paginates by page number (page,
-// page_length) — useListPage callers map their start offset onto `page` in
+// page_length) - useListPage callers map their start offset onto `page` in
 // the fetchFn. Wiki wrappers used to live in src/api/voice.js; voice.js
 // re-exports `dismissWikiNudge` so ChatView's namespace import keeps working.
 import { call } from "frappe-ui"
@@ -23,7 +23,7 @@ export const listWikiPagesPage = (p = {}) =>
 	})
 
 // {creatable_scopes, manageable_roles, is_sm, knowledge_language,
-//  wiki_lint_last_run_at, wiki_lint_summary} — the caller's capabilities +
+//  wiki_lint_last_run_at, wiki_lint_summary} - the caller's capabilities +
 // the SM header extras. Any desk user may call it.
 export const getWikiCaps = () => call(WK + "get_wiki_caps")
 
@@ -43,13 +43,13 @@ export const createWikiPage = (p = {}) =>
 		body_md: p.body_md || "",
 	})
 
-// patch: any of {body_md, summary, title} — only the provided fields change.
+// patch: any of {body_md, summary, title} - only the provided fields change.
 export const saveWikiPage = (slug, patch = {}) => call(WK + "save_wiki_page", { slug, ...patch })
 export const archiveWikiPage = (slug) => call(WK + "archive_wiki_page", { slug })
 // Undoes an accidental archive (same permission as archiving).
 export const restoreWikiPage = (slug) => call(WK + "restore_wiki_page", { slug })
 // PERMANENT delete (same authority as archiving; archive is the reversible
-// path — callers warn accordingly). The mirror prunes the file on next sync.
+// path - callers warn accordingly). The mirror prunes the file on next sync.
 export const deleteWikiPage = (slug) => call(WK + "delete_wiki_page", { slug })
 
 // Chat nudge card: "don't ask again in this conversation" (7-day snooze).

--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -10,7 +10,7 @@
   <div class="jv-dsub" style="font-family:inherit;color:var(--text);">
     <!-- ===== Paste-back flow (Screen 2) ===== -->
     <div v-if="flowOpen">
-      <p class="jv-dsub-step"><b>Step 1</b> — Sign in with your {{ status.provider || pickProvider }} account in a new tab.</p>
+      <p class="jv-dsub-step"><b>Step 1</b> - Sign in with your {{ status.provider || pickProvider }} account in a new tab.</p>
       <div class="jv-dsub-actions" style="margin-bottom:10px;">
         <a v-if="authorizeUrl" :href="authorizeUrl" target="_blank" rel="noopener noreferrer" class="jv-dsub-btn jv-dsub-btn-primary">Open sign-in URL ↗</a>
         <span v-else class="jv-dsub-muted">Starting sign-in…</span>
@@ -19,7 +19,7 @@
         <code class="jv-dsub-url" :title="authorizeUrl">{{ authorizeUrl }}</code>
         <button type="button" class="jv-dsub-btn jv-dsub-btn-ghost" @click="copyUrl">{{ copied ? 'Copied ✓' : 'Copy' }}</button>
       </div>
-      <p class="jv-dsub-step" style="margin-top:14px;"><b>Step 2</b> — After you click Authorize, your browser shows a “This site can’t be reached” page. <b>That’s expected.</b> Copy the URL from the address bar (starts with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
+      <p class="jv-dsub-step" style="margin-top:14px;"><b>Step 2</b> - After you click Authorize, your browser shows a “This site can’t be reached” page. <b>That’s expected.</b> Copy the URL from the address bar (starts with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
       <textarea v-model="pastedUrl" rows="3" class="jv-dsub-input" placeholder="Paste the URL from the error page here"></textarea>
       <div class="jv-dsub-actions" style="margin-top:10px;">
         <button class="jv-dsub-btn jv-dsub-btn-ghost" @click="cancelFlow">Cancel</button>
@@ -32,11 +32,11 @@
     <!-- ===== Connected (Screen 3) ===== -->
     <div v-else-if="status.connected">
       <p class="jv-dsub-muted" style="margin:0 0 12px;">
-        Your chat subscription is served directly to the provider. Refresh state lives inside your Jarvis container — if chat starts failing, re-authorize to mint fresh tokens.
+        Your chat subscription is served directly to the provider. Refresh state lives inside your Jarvis container - if chat starts failing, re-authorize to mint fresh tokens.
       </p>
-      <div class="jv-dsub-kv"><span>Account</span><b>{{ status.account_email || '—' }}</b></div>
-      <div class="jv-dsub-kv"><span>Provider</span><b>{{ status.provider || '—' }}</b></div>
-      <div class="jv-dsub-kv"><span>Model</span><b>{{ status.model || '—' }}</b></div>
+      <div class="jv-dsub-kv"><span>Account</span><b>{{ status.account_email || '-' }}</b></div>
+      <div class="jv-dsub-kv"><span>Provider</span><b>{{ status.provider || '-' }}</b></div>
+      <div class="jv-dsub-kv"><span>Model</span><b>{{ status.model || '-' }}</b></div>
       <div v-if="status.connected_at" class="jv-dsub-kv"><span>Connected</span><b>{{ connectedAtLabel }}</b></div>
       <div class="jv-dsub-actions" style="margin-top:14px;">
         <button v-if="editable" class="jv-dsub-btn jv-dsub-btn-ghost" :disabled="busy" @click="doDisconnect">Disconnect</button>
@@ -48,10 +48,10 @@
     <!-- ===== Not connected → connect a chat subscription (DIRECT) ===== -->
     <div v-else>
       <p v-if="status.is_single_subscription_pool" class="jv-dsub-muted" style="margin:0 0 12px;">
-        Your {{ status.provider || 'chat subscription' }} is currently running through the <b>proxy</b>. Sign in below to switch it to <b>direct</b> — served straight to the provider (codex), lighter, with no proxy sidecar.
+        Your {{ status.provider || 'chat subscription' }} is currently running through the <b>proxy</b>. Sign in below to switch it to <b>direct</b> - served straight to the provider (codex), lighter, with no proxy sidecar.
       </p>
       <p v-else class="jv-dsub-muted" style="margin:0 0 12px;">
-        Sign in with your existing ChatGPT Plus/Pro or Gemini Advanced account — no API key needed. It's served directly to the provider (codex), not through the proxy.
+        Sign in with your existing ChatGPT Plus/Pro or Gemini Advanced account - no API key needed. It's served directly to the provider (codex), not through the proxy.
       </p>
       <div class="jv-dsub-pick">
         <label class="jv-dsub-field">
@@ -134,10 +134,10 @@ const minsLeft = computed(() =>
   expiresAt.value ? Math.max(0, Math.floor((expiresAt.value - nowTick.value) / 60000)) : null,
 )
 // exactDate parses the server's naive datetime in the SITE timezone (via
-// frappe-ui dayjsLocal) and renders it in the viewer's zone — do NOT hand the
+// frappe-ui dayjsLocal) and renders it in the viewer's zone - do NOT hand the
 // raw string to new Date(), which reads it as browser-local (wrong offset) and
 // can yield Invalid Date on strict engines for the 6-digit microsecond suffix.
-const connectedAtLabel = computed(() => exactDate(props.status.connected_at) || "—")
+const connectedAtLabel = computed(() => exactDate(props.status.connected_at) || "-")
 
 function resetFlow() {
   flowOpen.value = false
@@ -154,7 +154,7 @@ function cancelFlow() { resetFlow(); err.value = "" }
 // connected provider/model; a fresh connect passes the picked provider/model.
 // The backend coerces the model to a valid subscription model for the provider,
 // and complete_paste_signin clears any existing models[] pool + sets the direct
-// flat fields — so this doubles as the "switch a pooled subscription to direct".
+// flat fields - so this doubles as the "switch a pooled subscription to direct".
 async function startSignin(providerOverride, modelOverride) {
   err.value = ""
   busy.value = true
@@ -165,7 +165,7 @@ async function startSignin(providerOverride, modelOverride) {
     const m = (modelOverride || props.status.model || pickModel.value || "").trim()
     const res = await api.beginPasteSignin(p, m)
     if (!res || res.ok === false) {
-      err.value = (res && res.error && res.error.message) || "Couldn't start sign-in — try again."
+      err.value = (res && res.error && res.error.message) || "Couldn't start sign-in - try again."
       flowOpen.value = false
       return
     }
@@ -190,7 +190,7 @@ async function submitPasted() {
     if (!res || res.ok === false) {
       const code = (res && res.error && res.error.code) || ""
       err.value = `${code ? code + ": " : ""}${(res && res.error && res.error.message) || "Sign-in failed."}`
-      // A dead nonce can't be retried — drop back to the connected screen.
+      // A dead nonce can't be retried - drop back to the connected screen.
       if (code === "expired" || code === "unknown_nonce") resetFlow()
       return
     }
@@ -218,13 +218,13 @@ function copyUrl() {
   const url = authorizeUrl.value
   if (!url) return
   const done = () => { copied.value = true; setTimeout(() => { copied.value = false }, 1400) }
-  const fail = () => { err.value = "Could not copy — select the URL and copy manually." }
+  const fail = () => { err.value = "Could not copy - select the URL and copy manually." }
   if (navigator.clipboard && window.isSecureContext) {
     navigator.clipboard.writeText(url).then(done).catch(fail)
     return
   }
   // LAN HTTP fallback: navigator.clipboard is undefined in insecure contexts.
-  // execCommand can return false WITHOUT throwing (e.g. selection disallowed) —
+  // execCommand can return false WITHOUT throwing (e.g. selection disallowed) -
   // honour the boolean so a failed copy doesn't falsely flash "Copied ✓".
   const ta = document.createElement("textarea")
   ta.value = url; ta.style.position = "fixed"; ta.style.left = "-9999px"

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -109,7 +109,7 @@
 </template>
 
 <script setup>
-// FilePreview — reusable file preview dialog (extracted from ChatView's
+// FilePreview - reusable file preview dialog (extracted from ChatView's
 // artifact panel, rebuilt in the current token system). Routing:
 // pdf → same-origin iframe, image → <img>, html/svg → sandboxed srcdoc
 // iframe (raw file fetched over the session cookie), everything else →
@@ -125,7 +125,7 @@ const props = defineProps({
 	fileName: { type: String, default: "" },
 	// extension ("pdf", "xlsx", …) or mime type ("application/pdf", …)
 	fileType: { type: String, default: "" },
-	// spec asks for "lg", but frappe-ui's lg is max-w-lg (32rem) — too narrow
+	// spec asks for "lg", but frappe-ui's lg is max-w-lg (32rem) - too narrow
 	// for PDFs and sheets, so the default is 4xl; pass size="lg" to shrink it.
 	size: { type: String, default: "4xl" },
 })

--- a/frontend/src/components/JvCombo.vue
+++ b/frontend/src/components/JvCombo.vue
@@ -1,4 +1,4 @@
-<!-- Themed select / combobox — a CSS-styleable replacement for native <select>
+<!-- Themed select / combobox - a CSS-styleable replacement for native <select>
      and <input list=datalist>, whose popups can't be styled to match the app.
      `options` accepts strings or {value,label}. `allowCustom` makes it a
      free-text combobox (type your own value, filtered suggestions); otherwise
@@ -79,7 +79,7 @@ function move(d) {
 }
 function onEnter() {
   if (open.value && hi.value >= 0 && filtered.value[hi.value]) { choose(filtered.value[hi.value]); return }
-  // No suggestion picked — keep whatever the user typed and let the host act on Enter.
+  // No suggestion picked - keep whatever the user typed and let the host act on Enter.
   open.value = false
   emit("enter")
 }

--- a/frontend/src/components/LayoutHeader.vue
+++ b/frontend/src/components/LayoutHeader.vue
@@ -6,7 +6,7 @@
 					<slot name="left-header" />
 				</div>
 				<div class="flex items-center gap-2">
-					<!-- "Go to Desk" — uniform across every page, and always the
+					<!-- "Go to Desk" - uniform across every page, and always the
 					     LEFTMOST item of the right cluster so each page's primary
 					     action keeps the rightmost corner (the design standard). -->
 					<Button

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -8,13 +8,13 @@
   <div class="jv-llm-editor" style="font-family:inherit;color:var(--text);">
     <div v-if="err" style="color:var(--red);font-size:13px;margin-bottom:12px;">{{ err }}</div>
 
-    <!-- Setup mode tabs + derived Direct/Proxy badge — hidden when the host
+    <!-- Setup mode tabs + derived Direct/Proxy badge - hidden when the host
          allows only one mode (onboarding's quick-only editor). -->
     <div v-if="!singleMode" style="display:flex;align-items:center;gap:12px;margin-bottom:14px;flex-wrap:wrap;">
       <div role="tablist" style="display:inline-flex;border:1px solid var(--border);border-radius:9px;overflow:hidden;">
         <button v-for="t in modeTabs" :key="t.value" role="tab" :aria-selected="llmMode===t.value"
                 @click="setMode(t.value)" :disabled="!editable || (t.value==='quick' && quickLocked)"
-                :title="t.value==='quick' && quickLocked ? 'Your pool has multiple models — edit them in Custom. Remove models to switch to Quick.' : ''"
+                :title="t.value==='quick' && quickLocked ? 'Your pool has multiple models - edit them in Custom. Remove models to switch to Quick.' : ''"
                 :style="{fontSize:'14px',padding:'10px 18px',border:'none',
                          cursor: (!editable || (t.value==='quick' && quickLocked)) ? 'not-allowed' : 'pointer',
                          opacity: (t.value==='quick' && quickLocked) ? '0.4' : '1',
@@ -130,7 +130,7 @@
         </div>
 
         <!-- API-key credential. Onboarding (singleMode) lays the four fields out as
-             a 2×2 grid so this view's height sits close to the subscription view —
+             a 2×2 grid so this view's height sits close to the subscription view -
              no jarring resize when toggling. The Account editor keeps the dense row. -->
         <div v-if="m.credentialType!=='subscription'" :class="{ 'jv-single-body': singleMode }">
           <div v-if="singleMode" class="jv-ak-grid">
@@ -196,7 +196,7 @@
           </div>
           <div v-else-if="!singleMode" style="font-size:13px;color:var(--text-3);margin-bottom:8px;">No accounts connected yet.</div>
 
-          <!-- Inline paste-back OAuth flow — two clear steps: open the sign-in
+          <!-- Inline paste-back OAuth flow - two clear steps: open the sign-in
                (OAuth) URL, then paste the callback URL you're redirected to. -->
           <div v-if="m._connect && m._connect.open" class="jv-cn">
             <div v-if="m._connect.authorizeUrl">
@@ -246,7 +246,7 @@
       </button>
     </section>
 
-    <!-- Save bar + sync status — hidden when a host renders its own footer. -->
+    <!-- Save bar + sync status - hidden when a host renders its own footer. -->
     <div v-if="!footerless" style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
       <button v-if="editable" @click="save" :disabled="saving || saveBlocked"
               :style="{padding:'12px 24px',background: saveBlocked ? 'var(--surface-3)' : 'var(--blue)',
@@ -257,7 +257,7 @@
       <span v-if="saveBlocked && missingVendors.length" style="font-size:13px;color:var(--amber);">
         Provide keys for: {{ missingVendors.map(providerLabel).join(', ') }}
       </span>
-      <span v-else-if="dirty" style="font-size:13px;color:var(--amber);font-weight:600;">● Unsaved changes — Save configuration to apply</span>
+      <span v-else-if="dirty" style="font-size:13px;color:var(--amber);font-weight:600;">● Unsaved changes - Save configuration to apply</span>
       <span style="font-size:13px;color:var(--text-3);">{{ syncLabel }}</span>
     </div>
   </div>
@@ -277,7 +277,7 @@ const props = defineProps({
   editable: { type: Boolean, default: true },
   // Which setup tabs to expose. Default = the full 3-mode editor (Account page).
   // Onboarding passes ["quick"] to offer a single direct model and hide the
-  // proxy-pool Preset/Custom tabs + the Direct/Proxy badge — faster signup, no
+  // proxy-pool Preset/Custom tabs + the Direct/Proxy badge - faster signup, no
   // failover/pooling decisions up front (users configure that later in Account).
   modes: { type: Array, default: () => ["quick", "preset", "custom"] },
   // Hide the built-in Save bar so a host (onboarding) can render its own footer
@@ -306,13 +306,13 @@ const ALL_MODE_TABS = [
 ]
 // Only the tabs the host allows, in canonical order.
 const modeTabs = computed(() => ALL_MODE_TABS.filter((t) => props.modes.includes(t.value)))
-// With a single allowed mode the tab bar + Direct/Proxy badge are just noise —
+// With a single allowed mode the tab bar + Direct/Proxy badge are just noise -
 // hide them and render that mode's body directly (onboarding's quick-only editor).
 const singleMode = computed(() => modeTabs.value.length <= 1)
-// Whether any proxy-pool tab (Preset/Custom) is reachable — gates the Quick hint
+// Whether any proxy-pool tab (Preset/Custom) is reachable - gates the Quick hint
 // copy so it never points at tabs that aren't there.
 const canPool = computed(() => props.modes.includes("preset") || props.modes.includes("custom"))
-// Whether the single-mode (onboarding) row is savable — an account is connected,
+// Whether the single-mode (onboarding) row is savable - an account is connected,
 // or an API key + provider/model are filled. Emitted so the host footer can
 // invite the final "Onboard Jarvis" click once the user is ready.
 const ready = computed(() => {
@@ -385,7 +385,7 @@ const isMulti = computed(() => llmMode.value === "custom")
 const editorRows = computed(() => isMulti.value ? rows.value : rows.value.slice(0, 1))
 // Quick renders only rows[0] and saving in Quick collapses the pool to that one
 // model. When a real multi-model pool exists, lock the Quick tab so a stray click
-// can't silently drop the other models — the user reduces the pool via Custom.
+// can't silently drop the other models - the user reduces the pool via Custom.
 const quickLocked = computed(() => rows.value.length >= 2)
 const singleVendorPresets = computed(() => catalog.value.filter((c) => c.kind === "single_vendor"))
 const crossVendorPresets = computed(() => catalog.value.filter((c) => c.kind === "cross_vendor"))
@@ -404,10 +404,10 @@ const missingVendors = computed(() => {
 })
 const saveBlocked = computed(() => llmMode.value === "preset" && !!selectedPreset.value && missingVendors.value.length > 0)
 
-// Direct/Proxy badge — mirrors jarvis_account.js renderModeBadge().
+// Direct/Proxy badge - mirrors jarvis_account.js renderModeBadge().
 // Quick is always Direct (single model); Preset is Proxy once chosen; Custom
 // derives from the count of valid rows via the shared deriveMode helper.
-// Valid (fillable) rows — shared by the badge mode + label. A subscription row
+// Valid (fillable) rows - shared by the badge mode + label. A subscription row
 // needs a model id; an api_key row needs provider + model.
 const validModels = computed(() => rows.value.filter((r) => r && (
   r.credentialType === "subscription" ? (r.model || "").trim() : ((r.provider || "").trim() && (r.model || "").trim())
@@ -427,8 +427,8 @@ const badgeMode = computed(() => {
 // the cliproxy sidecar) but has nothing to fail over to, so it reads plain
 // "Proxy" rather than the misleading "Proxy (failover)".
 const badgeLabel = computed(() => {
-  // Only badge a real multi-model FAILOVER pool. A single model — a direct
-  // api-key OR a lone chat subscription — shows NO badge: it was just noise, and
+  // Only badge a real multi-model FAILOVER pool. A single model - a direct
+  // api-key OR a lone chat subscription - shows NO badge: it was just noise, and
   // "Proxy" on a single subscription read as confusing/broken.
   if (llmMode.value === "preset") return selectedPreset.value ? "Proxy (failover)" : ""
   if (llmMode.value === "custom") return validModels.value.length >= 2 ? "Proxy (failover)" : ""
@@ -498,7 +498,7 @@ function setCredType(m, type) {
     if (!m.upstream) m.upstream = "openai"
     if (!Array.isArray(m.accounts)) m.accounts = []
     if (!m._connect) m._connect = blankConnect()
-    // Onboarding hides the model field — default it from the chosen provider so
+    // Onboarding hides the model field - default it from the chosen provider so
     // validatePool + save still have a model id.
     if (singleMode.value) m.model = defaultSubscriptionModel(m.upstream)
   } else if (singleMode.value) {
@@ -515,7 +515,7 @@ function onProviderChange(m) {
 }
 // Provider switch on a subscription row in the simplified onboarding editor:
 // re-default the (hidden) model AND drop any already-connected account, which is
-// provider-specific — otherwise we'd save a model bound to the wrong provider's
+// provider-specific - otherwise we'd save a model bound to the wrong provider's
 // OAuth credential. A no-op elsewhere (full editor manages model/accounts itself).
 function onUpstreamChange(m) {
   if (singleMode.value && m.credentialType === "subscription") {
@@ -550,7 +550,7 @@ function accountLabel(a) {
 }
 async function startConnect(m, reconnectIdx = null) {
   if (!m._connect) m._connect = blankConnect()
-  // Simplified editor hides the model field — make sure a subscription row always
+  // Simplified editor hides the model field - make sure a subscription row always
   // carries a model id so the connect flow never dead-ends on an unfillable field.
   if (singleMode.value && m.credentialType === "subscription" && !(m.model || "").trim()) {
     m.model = defaultSubscriptionModel(m.upstream)
@@ -583,7 +583,7 @@ async function finishConnect(m) {
   m._connect.loading = true; m._connect.error = ""
   try {
     const res = await api.completePoolAccountSignin(m._connect.nonce, m._connect.pastedUrl.trim())
-    // Same {ok, data} envelope as begin — unwrap + surface errors.
+    // Same {ok, data} envelope as begin - unwrap + surface errors.
     if (!res || res.ok === false) {
       m._connect.loading = false
       m._connect.error = (res && res.error && res.error.message) || "Couldn't connect the account. Check the pasted URL and try again."
@@ -610,7 +610,7 @@ async function finishConnect(m) {
     if (ri != null && ri >= 0 && ri < m.accounts.length) {
       m.accounts.splice(ri, 1, acct)
       // Reconnecting one slot but signing in as an account already held by a
-      // DIFFERENT slot would leave two identical accounts — drop the duplicate.
+      // DIFFERENT slot would leave two identical accounts - drop the duplicate.
       if (byEmail >= 0 && byEmail !== ri) m.accounts.splice(byEmail, 1)
     } else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
     else m.accounts.push(acct)
@@ -619,7 +619,7 @@ async function finishConnect(m) {
     // navigating off the page would orphan this account. In the account editor,
     // persist immediately; if the pool isn't valid yet, save() surfaces the reason
     // and the "Unsaved changes" notice stays up so nothing is silently lost. Skip
-    // in the footerless onboarding editor — there the host's CTA drives save.
+    // in the footerless onboarding editor - there the host's CTA drives save.
     if (!props.footerless) await save()
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e) }
 }
@@ -636,7 +636,7 @@ function copyAuthorizeUrl(m) {
 // ---- load / save ---------------------------------------------------------
 // Seed the canonical rows from get_llm_config, then augment each with the
 // transient UI-only fields the editor needs (upstream + _connect). Seeded
-// accounts carry no oauth_blob (never returned by the server) — reconnect to
+// accounts carry no oauth_blob (never returned by the server) - reconnect to
 // change; they render as "connected" via their label.
 function seedRows(config) {
   return seedRowsFromConfig(config).map((r) => ({
@@ -679,14 +679,14 @@ async function load() {
       selectedPreset.value = ""
       if (!rows.value.length) rows.value = [newRow()]
     }
-    // Baseline for the unsaved-changes notice — the pool as just loaded is clean.
+    // Baseline for the unsaved-changes notice - the pool as just loaded is clean.
     savedSnapshot.value = poolSnapshot()
   } catch (e) { err.value = _err(e) }
   try { sync.value = (await api.getLlmSyncStatus()) || sync.value } catch (e) { /* non-fatal */ }
   try { catalog.value = (await api.getPresetCatalog()) || [] } catch (e) { /* backend bundled fallback */ }
 }
 
-// Stable string of the savable pool + preset — the cheap key the dirty-notice
+// Stable string of the savable pool + preset - the cheap key the dirty-notice
 // and snapshot reset compare against.
 function poolSnapshot() {
   try { return JSON.stringify({ m: buildSaveModels(rows.value), p: selectedPreset.value }) }
@@ -788,7 +788,7 @@ defineExpose({ save })
 </script>
 
 <style scoped>
-/* Onboarding credential-type cards — self-describing "API key vs Chat
+/* Onboarding credential-type cards - self-describing "API key vs Chat
    subscription" choice. Selected state mirrors the wizard's plan cards
    (var(--blue) ring), so it's consistent with the rest of onboarding. */
 .jv-ct { margin-bottom: 16px; }
@@ -813,8 +813,8 @@ defineExpose({ save })
 .jv-ct-tx { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .jv-ct-t { font-size: 14px; font-weight: 650; }
 .jv-ct-d { font-size: 12px; color: var(--text-3); line-height: 1.4; }
-/* Clean status pill — connected (ok) / failed (bad). Reused by the subscription
-   connected row and (later) the API-key verify result. No red ✕ — a subtle text
+/* Clean status pill - connected (ok) / failed (bad). Reused by the subscription
+   connected row and (later) the API-key verify result. No red ✕ - a subtle text
    action handles disconnect. */
 .jv-status { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border-radius: 9px; font-size: 13.5px; margin-bottom: 8px; }
 .jv-status-ok { border: 1px solid var(--green-bd); background: var(--green-bg); }
@@ -827,7 +827,7 @@ defineExpose({ save })
 .jv-status-acts { margin-left: auto; display: flex; gap: 12px; flex: none; }
 .jv-status-act { background: transparent; border: 0; color: var(--text-3); font-size: 12.5px; cursor: pointer; padding: 0; }
 .jv-status-act:hover { color: var(--text); text-decoration: underline; text-underline-offset: 2px; }
-/* Paste-back OAuth connect panel — two numbered steps (open sign-in URL / paste
+/* Paste-back OAuth connect panel - two numbered steps (open sign-in URL / paste
    the callback URL), styled to match the rest of the onboarding editor. */
 .jv-cn { margin-top: 8px; padding: 15px; background: var(--surface-1); border: 1px solid var(--border); border-radius: 11px; }
 .jv-cn-step { display: flex; gap: 10px; margin-bottom: 13px; }
@@ -850,7 +850,7 @@ defineExpose({ save })
 /* Lock both credential modes to the same body height in onboarding so toggling
    API key ↔ Chat subscription never resizes the card (first-impression polish). */
 .jv-single-body { min-height: 96px; }
-/* API-key fields as a 2×2 grid in onboarding — keeps this view's height close to
+/* API-key fields as a 2×2 grid in onboarding - keeps this view's height close to
    the subscription view so toggling doesn't resize the card. */
 .jv-ak-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
 .jv-ak-grid select, .jv-ak-grid input {

--- a/frontend/src/components/VoiceRecorder.vue
+++ b/frontend/src/components/VoiceRecorder.vue
@@ -2,7 +2,7 @@
 	<div class="flex flex-wrap items-center gap-2">
 		<template v-if="!rec.supported">
 			<span class="text-sm text-ink-gray-5">
-				Voice recording isn't supported in this browser — type your note instead.
+				Voice recording isn't supported in this browser - type your note instead.
 			</span>
 		</template>
 
@@ -23,17 +23,17 @@
 		<template v-else>
 			<Button variant="subtle" label="Record a note" iconLeft="mic" @click="begin" />
 			<span class="text-sm text-ink-gray-5">
-				Up to 5 minutes — you can edit the text before saving.
+				Up to 5 minutes - you can edit the text before saving.
 			</span>
 		</template>
 	</div>
 </template>
 
 <script setup>
-// VoiceRecorder — the Business-tab record→transcribe control. Wraps the shared
+// VoiceRecorder - the Business-tab record→transcribe control. Wraps the shared
 // useAudioRecorder composable (300 s hard cap lives there; onAutoStop still
 // transcribes) and voice.transcribeAudio, then hands the verbatim text to the
-// parent via @transcript — the parent owns the editable textarea + Save.
+// parent via @transcript - the parent owns the editable textarea + Save.
 import { ref, computed, onBeforeUnmount } from "vue"
 import { Button, toast } from "frappe-ui"
 import { useAudioRecorder } from "@/composables/useAudioRecorder"
@@ -47,7 +47,7 @@ function errMsg(e) {
 
 const rec = useAudioRecorder({
 	onAutoStop: (r) => {
-		toast.info("Recording stopped at the 5-minute limit — transcribing.")
+		toast.info("Recording stopped at the 5-minute limit - transcribing.")
 		transcribe(r)
 	},
 })
@@ -88,7 +88,7 @@ async function transcribe(r) {
 		const res = await transcribeAudio(r.blob, { durationS: r.durationS })
 		const text = ((res && res.text) || "").trim()
 		if (text) emit("transcript", text)
-		else toast.error("Nothing was transcribed — try again closer to the microphone.")
+		else toast.error("Nothing was transcribed - try again closer to the microphone.")
 	} catch (e) {
 		toast.error(errMsg(e))
 	} finally {

--- a/frontend/src/components/business/NotesPane.vue
+++ b/frontend/src/components/business/NotesPane.vue
@@ -7,12 +7,12 @@
 				<div class="mt-0.5 text-sm text-ink-gray-6">
 					<!-- the Review tab is SM-only; pointing everyone at it is a dead end -->
 					<template v-if="canProcess">
-						Notes you've saved. Usually processed within a day — proposals show
+						Notes you've saved. Usually processed within a day - proposals show
 						up on the Review tab; wiki context may update sooner.
 					</template>
 					<template v-else>
 						Notes you've saved. Jarvis usually works them into its org knowledge
-						within a day — wiki pages may update sooner.
+						within a day - wiki pages may update sooner.
 					</template>
 				</div>
 			</div>
@@ -116,7 +116,7 @@
 					</div>
 				</div>
 				<div class="flex shrink-0 items-center">
-					<!-- only New notes are editable — the edited transcript re-feeds
+					<!-- only New notes are editable - the edited transcript re-feeds
 					     the daily sweep; Processed/Archived text is already consumed -->
 					<Button
 						v-if="row.status === 'New'"
@@ -175,7 +175,7 @@
 </template>
 
 <script setup>
-// NotesPane — the right pane of the Business tab: the caller's own voice
+// NotesPane - the right pane of the Business tab: the caller's own voice
 // notes with server-side search (300ms debounce), a status filter, real
 // Load More pagination, edit-while-New and delete. For System Managers the
 // old Processing card collapses into this pane's header: "Process notes now"
@@ -235,7 +235,7 @@ const editDialog = reactive({ show: false, name: "", text: "", saving: false })
 const filtered = computed(() => !!(search.value.trim() || statusFilter.value))
 
 // ── loader ───────────────────────────────────────────────────────────────────
-// monotonic request id — drops stale responses (the useListPage idiom): the
+// monotonic request id - drops stale responses (the useListPage idiom): the
 // debounced search fetch, the immediate status-filter fetch and the parent's
 // reload() can be in flight at once; only the newest may render.
 let reqId = 0
@@ -251,7 +251,7 @@ async function fetchNotes(mode = "reset") {
 			status: statusFilter.value || undefined,
 			search: search.value.trim() || undefined,
 		})
-		if (id !== reqId) return // stale — a newer request superseded this one
+		if (id !== reqId) return // stale - a newer request superseded this one
 		const rows = res.rows || []
 		notes.rows = append ? [...notes.rows, ...rows] : rows
 		notes.total = res.total || 0
@@ -279,7 +279,7 @@ watch(search, () => {
 watch(statusFilter, () => fetchNotes("reset"))
 onBeforeUnmount(() => clearTimeout(searchTimer))
 
-// ── edit (New notes only — server enforces owner + status) ───────────────────
+// ── edit (New notes only - server enforces owner + status) ───────────────────
 function openEdit(row) {
 	editDialog.name = row.name
 	editDialog.text = row.transcript || row.excerpt || ""
@@ -311,7 +311,7 @@ function confirmDeleteNote(row) {
 		message:
 			row.status === "Processed"
 				? "This removes the note from your list. Knowledge Jarvis already extracted from it is kept."
-				: "This note hasn't been processed yet — Jarvis won't learn from it if you delete it now.",
+				: "This note hasn't been processed yet - Jarvis won't learn from it if you delete it now.",
 		onConfirm: async ({ hideDialog }) => {
 			await doDeleteNote(row)
 			hideDialog()

--- a/frontend/src/components/doc/CommentComposer.vue
+++ b/frontend/src/components/doc/CommentComposer.vue
@@ -26,7 +26,7 @@
 // Mention plumbing lives at module level, shared by every composer instance
 // on the page. We deliberately do NOT use TextEditor's :mentions prop:
 // frappe-ui 0.1.278's suggestion renderer is incompatible with
-// @tiptap/suggestion 3.x — onStart now fires with empty items BEFORE the
+// @tiptap/suggestion 3.x - onStart now fires with empty items BEFORE the
 // async items() fetch, the empty SuggestionList (v-if="items.length")
 // renders a comment node so VueRenderer.element is null, tippy creation is
 // skipped, and onUpdate only repositions an existing popup. Net effect: the
@@ -142,11 +142,11 @@ const CommentMention = Mention.configure({
 </script>
 
 <script setup>
-// CommentComposer — async-loaded comment editor (DESIGN-V3 §6.1, D33): the
+// CommentComposer - async-loaded comment editor (DESIGN-V3 §6.1, D33): the
 // frappe-ui TextEditor (tiptap + prosemirror) stays isolated in THIS chunk so
 // list/detail pages don't pay for it until the user actually comments; editor
 // styles are imported here only. Ctrl/⌘+Enter submits. Mention rendering
-// only — no mention notifications this wave (stated non-goal).
+// only - no mention notifications this wave (stated non-goal).
 import "frappe-ui/editor-style.css"
 import { ref, computed, onMounted } from "vue"
 import { TextEditor, Button } from "frappe-ui"

--- a/frontend/src/components/doc/CommentsSection.vue
+++ b/frontend/src/components/doc/CommentsSection.vue
@@ -40,7 +40,7 @@
 				</div>
 			</div>
 		</div>
-		<div v-else class="text-sm text-ink-gray-5">No comments yet — be the first to add one.</div>
+		<div v-else class="text-sm text-ink-gray-5">No comments yet - be the first to add one.</div>
 
 		<template v-if="canComment">
 			<button
@@ -66,12 +66,12 @@
 </template>
 
 <script setup>
-// CommentsSection — the doc-page comment stream (DESIGN-V3 §6.1): asc by
+// CommentsSection - the doc-page comment stream (DESIGN-V3 §6.1): asc by
 // creation, own-comment edit (inline composer) / delete (confirm), comment
-// HTML sanitized with DOMPurify (§14 O2 — TextEditor output rendered via
+// HTML sanitized with DOMPurify (§14 O2 - TextEditor output rendered via
 // v-html). The composer is a defineAsyncComponent behind a click-to-reveal
-// placeholder, so the tiptap chunk (~280KB gzip) never loads — let alone
-// leaks into list/detail chunks (D33) — unless the user actually comments
+// placeholder, so the tiptap chunk (~280KB gzip) never loads - let alone
+// leaks into list/detail chunks (D33) - unless the user actually comments
 // or edits.
 import { ref, computed, defineAsyncComponent } from "vue"
 import { Avatar, Badge, Button, Dropdown, Tooltip, confirmDialog } from "frappe-ui"
@@ -143,7 +143,7 @@ async function saveEdit(c, html) {
 
 <style>
 /* Mention chips inside rendered comments. Mirrors frappe-ui's mention
-   style.css, which only ships with the lazy composer chunk — comments with
+   style.css, which only ships with the lazy composer chunk - comments with
    mentions must render styled even before the composer is ever opened. */
 .prose .mention {
 	font-weight: 600;

--- a/frontend/src/components/doc/DocMetaPanel.vue
+++ b/frontend/src/components/doc/DocMetaPanel.vue
@@ -19,7 +19,7 @@
 		</div>
 
 		<div class="divide-y">
-			<!-- 2. assignees — not offered on skills (§14 DA-09) -->
+			<!-- 2. assignees - not offered on skills (§14 DA-09) -->
 			<div v-if="showAssignees" class="px-5 py-4">
 				<div class="flex items-center justify-between">
 					<div class="text-sm text-ink-gray-5">Assignees</div>
@@ -119,7 +119,7 @@
 				<div v-if="uploadHint" class="mt-2 text-xs text-ink-gray-5">{{ uploadHint }}</div>
 			</div>
 
-			<!-- 4. shared with (§14 F1) — DocShare block for Macro/Approval/Agent
+			<!-- 4. shared with (§14 F1) - DocShare block for Macro/Approval/Agent
 			     Installation; skills replace it with their child-table block via #extra -->
 			<div v-if="showShares" class="px-5 py-4">
 				<div class="flex items-center justify-between">
@@ -186,7 +186,7 @@
 </template>
 
 <script setup>
-// DocMetaPanel — the right-panel doctype blocks (DESIGN-V3 §6.1 + §14 F1/DA-09):
+// DocMetaPanel - the right-panel doctype blocks (DESIGN-V3 §6.1 + §14 F1/DA-09):
 // docname/like row · assignees (hidden on skills) · attachments · shared-with
 // (Macro/Approval/Agent Installation) · #extra · byline. All mutations go
 // through the shared useDocmeta object passed in by the page.
@@ -276,7 +276,7 @@ function confirmDeleteAttachment(f) {
 }
 
 // O3: stock upload_file can reject (mimetype allowlist for website users,
-// if_owner write on approvals) — surface the server message as a toast and
+// if_owner write on approvals) - surface the server message as a toast and
 // show the allowed-types caveat as an inline hint.
 const uploadHint = ref("")
 function onUploadError(e) {

--- a/frontend/src/components/doc/DocPage.vue
+++ b/frontend/src/components/doc/DocPage.vue
@@ -54,10 +54,10 @@
 </template>
 
 <script setup>
-// DocPage — the detail-page frame every doc page uses (DESIGN-V3 §6.1):
+// DocPage - the detail-page frame every doc page uses (DESIGN-V3 §6.1):
 // LayoutHeader (breadcrumbs | #actions) → title row (+ status / "Not Saved"
 // badges) → #main sections → border-t → #footer comments, with the #aside
-// panel in a CRM-style Resizer (352px default, 256–480).
+// panel in a CRM-style Resizer (352px default, 256-480).
 import { computed } from "vue"
 import { useRouter } from "vue-router"
 import { Breadcrumbs, Badge, Button } from "frappe-ui"

--- a/frontend/src/components/doc/DocSection.vue
+++ b/frontend/src/components/doc/DocSection.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-// DocSection — CRM CollapsibleSection port (DESIGN-V3 §6.1): chevron header
+// DocSection - CRM CollapsibleSection port (DESIGN-V3 §6.1): chevron header
 // (rotate-90 when open), max-height transition, sections separated by border-t
 // (first:border-t-0). #header-suffix is additive (status badges next to the
 // label, e.g. macro "Summarized prompt").

--- a/frontend/src/components/learning/InsightApplyDialog.vue
+++ b/frontend/src/components/learning/InsightApplyDialog.vue
@@ -17,7 +17,7 @@
 			>
 				<LoadingIndicator class="size-5 text-ink-gray-5" />
 				<span class="max-w-sm text-sm text-ink-gray-6">
-					Drafting — Jarvis is matching this insight against your custom skills and writing
+					Drafting - Jarvis is matching this insight against your custom skills and writing
 					the update. This takes a few seconds.
 				</span>
 			</div>
@@ -88,7 +88,7 @@
 				v-if="phase === 'update' || phase === 'create'"
 				class="mt-3 text-sm text-ink-gray-5"
 			>
-				Confirming saves the skill only — it reaches your assistant with the next
+				Confirming saves the skill only - it reaches your assistant with the next
 				skills push.
 			</p>
 		</template>
@@ -129,7 +129,7 @@
 </template>
 
 <script setup>
-// InsightApplyDialog — the wiki-v2 D5 "Apply to skill…" flow for B/C
+// InsightApplyDialog - the wiki-v2 D5 "Apply to skill…" flow for B/C
 // (insight-only) learned patterns. Opening drafts server-side (ONE LLM call
 // matching the insight against org custom skills) and returns a verdict:
 // update an existing skill (before/after comparison with a cheap line-diff

--- a/frontend/src/components/list/ColumnsButton.vue
+++ b/frontend/src/components/list/ColumnsButton.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-// ColumnsButton — column show/hide with per-page persistence (DESIGN-V3 §14 F2):
+// ColumnsButton - column show/hide with per-page persistence (DESIGN-V3 §14 F2):
 // checkbox list over all columns + "Reset to default"; hidden keys persist in
 // useStorage('jarvis-cols-'+storageKey). No width editing / no reorder this wave.
 // Emits update:hidden (immediately on mount and on every change) so ListPage

--- a/frontend/src/components/list/FilterButton.vue
+++ b/frontend/src/components/list/FilterButton.vue
@@ -81,7 +81,7 @@
 </template>
 
 <script setup>
-// FilterButton — fixed per-page filter popover (DESIGN-V3 §5.3, D14):
+// FilterButton - fixed per-page filter popover (DESIGN-V3 §5.3, D14):
 // equals-selects + one date-range only; emits a plain {key: value} object
 // (daterange contributes from_date/to_date keys). Count-chip split trigger,
 // CRM popover anatomy ("Where/And <field> is <control>").

--- a/frontend/src/components/list/ListPage.vue
+++ b/frontend/src/components/list/ListPage.vue
@@ -58,7 +58,7 @@
 
 		<!-- list body -->
 		<!-- !w-full: upstream's inner wrapper is `w-max min-w-full`, which sizes
-		     the grid to max-content — long cells push trailing columns past the
+		     the grid to max-content - long cells push trailing columns past the
 		     viewport behind a subtle inner scrollbar. Pinning to the container
 		     lets the minmax(0, Nfr) tracks compress and truncation work. -->
 		<ListView
@@ -98,7 +98,7 @@
 			</template>
 		</ListView>
 
-		<!-- error state (fetch failed, no rows to show) — precedes the empty state
+		<!-- error state (fetch failed, no rows to show) - precedes the empty state
 		     so a broken fetch isn't misreported as "no records" -->
 		<div v-else-if="error" class="relative flex-1">
 			<div
@@ -163,7 +163,7 @@
 </template>
 
 <script setup>
-// ListPage — the standard list frame (DESIGN-V3 §5.2 + §14 F2/DA-08):
+// ListPage - the standard list frame (DESIGN-V3 §5.2 + §14 F2/DA-08):
 // LayoutHeader breadcrumbs → toolbar (quick filters · Refresh/Filter/Sort/Columns)
 // → banner slot → frappe-ui ListView composition → ListFooter load-more.
 import { ref, computed, onBeforeUnmount } from "vue"
@@ -205,7 +205,7 @@ const props = defineProps({
 	getRowRoute: { type: Function, default: null },
 	onRowClick: { type: Function, default: null },
 	emptyState: { type: Object, default: () => ({}) }, // {title, description, icon?}
-	storageKey: { type: String, default: "" }, // §14 F2 — column show/hide persistence
+	storageKey: { type: String, default: "" }, // §14 F2 - column show/hide persistence
 })
 
 const emit = defineEmits([
@@ -217,7 +217,7 @@ const emit = defineEmits([
 	"update:selections",
 ])
 
-// §14 F2 — ColumnsButton owns useStorage('jarvis-cols-'+storageKey) and pushes
+// §14 F2 - ColumnsButton owns useStorage('jarvis-cols-'+storageKey) and pushes
 // the hidden-key list up; ListPage filters the visible columns from it.
 const hiddenKeys = ref([])
 // Numeric widths compile to bare `Nfr` grid tracks whose implicit minimum is

--- a/frontend/src/components/list/SortButton.vue
+++ b/frontend/src/components/list/SortButton.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup>
-// SortButton — single field + direction (DESIGN-V3 §5.4, D15): plain "Sort"
+// SortButton - single field + direction (DESIGN-V3 §5.4, D15): plain "Sort"
 // button at the page default; split button (asc/desc toggle + field label +
 // ghost x reset) once a non-default sort is active. Emits update:sort {field, dir}.
 import { computed } from "vue"

--- a/frontend/src/components/list/TabBar.vue
+++ b/frontend/src/components/list/TabBar.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-// TabBar — underline tabs strip (DESIGN-V3 §5.5); used by MacrosList (B5) and
+// TabBar - underline tabs strip (DESIGN-V3 §5.5); used by MacrosList (B5) and
 // AgentDetail (B6). Active tab = ink-gray-9 text + 2px underline bar.
 import { Badge } from "frappe-ui"
 

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -1,13 +1,13 @@
 <template>
 	<FrappeUIProvider>
 		<div class="flex h-screen w-screen">
-			<!-- Chrome-less routes (onboarding) drop the sidebar entirely — a
+			<!-- Chrome-less routes (onboarding) drop the sidebar entirely - a
 			     not-yet-onboarded customer has no app to navigate. -->
 			<div v-if="!route.meta.chromeless" class="h-full border-r bg-surface-gray-1">
 				<Sidebar />
 			</div>
 			<div class="flex flex-1 flex-col h-full overflow-auto bg-surface-white">
-				<!-- LayoutHeader teleport target — non-chat routes only (D41).
+				<!-- LayoutHeader teleport target - non-chat routes only (D41).
 				     The "Go to Desk" button is rendered INSIDE LayoutHeader's right
 				     cluster (leftmost, before each page's own actions) so it is
 				     uniform across pages and never displaces the page's primary
@@ -42,7 +42,7 @@ const router = useRouter()
 const store = useShellStore()
 
 // Boot gate: hold the routed page (NOT the shell chrome) until systemTimezone
-// is configured — timeAgo strings render once, so a late setConfig would leave
+// is configured - timeAgo strings render once, so a late setConfig would leave
 // stale future-tense timestamps on the first paint. Production boot injects
 // window.time_zone via jinjaBootData (www/jarvis.py), so this is synchronous;
 // the awaited getChatUiSettings read in onMounted is only the dev-server /
@@ -53,7 +53,7 @@ if (typeof window !== "undefined" && window.time_zone) {
 	booted.value = true
 }
 
-// Global shortcuts (§3.1). ⌘K moved here from the stock CommandPalette —
+// Global shortcuts (§3.1). ⌘K moved here from the stock CommandPalette -
 // JarvisCommandPalette is now built on plain Dialog and owns no keys itself
 // (the stock component never mounted its Dialog subtree; DA-06 died with it).
 useShortcuts([
@@ -98,19 +98,19 @@ onMounted(async () => {
 	// Fallback only (vite dev server serves index.html without the jinja boot
 	// injection, and older cached shells may miss the key): fetch the timezone
 	// the old way before revealing the routed page. In production this branch
-	// never runs — booted flipped synchronously in setup above.
+	// never runs - booted flipped synchronously in setup above.
 	if (!booted.value) {
 		try {
 			const res = await api.getChatUiSettings()
 			if (res?.time_zone) setConfig("systemTimezone", res.time_zone)
 		} catch {
-			// fall through — dayjsLocal degrades to browser-local parsing
+			// fall through - dayjsLocal degrades to browser-local parsing
 		}
 		booted.value = true
 	}
 
 	// NOTE: no onboarding force-redirect here. Policy (see router/index.js
-	// beforeEach) is "invite, don't force" — a not-ready user stays in the app
+	// beforeEach) is "invite, don't force" - a not-ready user stays in the app
 	// and is invited to onboard via the chat welcome card + desk banner. The
 	// old D11 gate redirected not-ready users to /app/jarvis-onboarding (desk),
 	// which redirects back to /jarvis/onboarding (SPA) → AppShell re-mounts →

--- a/frontend/src/components/shell/ConversationRow.vue
+++ b/frontend/src/components/shell/ConversationRow.vue
@@ -78,7 +78,7 @@ function cancelRename() {
 }
 function commitRename() {
 	if (!renaming.value) return
-	renaming.value = false // clear first — Enter also fires blur
+	renaming.value = false // clear first - Enter also fires blur
 	const t = renameText.value.trim()
 	if (!t || t === (props.conv.title || "")) return
 	store.renameConversation(props.conv.name, t)
@@ -95,7 +95,7 @@ const menuOptions = computed(() => [
 	{ label: "Delete", icon: "trash-2", theme: "red", onClick: confirmDelete },
 ])
 
-// ConfirmDialog renders `message` with v-html — escape the user-authored title.
+// ConfirmDialog renders `message` with v-html - escape the user-authored title.
 function esc(s) {
 	return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]))
 }

--- a/frontend/src/components/shell/JarvisCommandPalette.vue
+++ b/frontend/src/components/shell/JarvisCommandPalette.vue
@@ -44,7 +44,7 @@
 <script setup>
 // ⌘K palette (DESIGN-V3 §3.5), rebuilt on plain frappe-ui Dialog. The stock
 // CommandPalette in 0.1.278 nests a bare <template> element at its root, which
-// Vue renders as an inert native <template> — its whole Dialog subtree never
+// Vue renders as an inert native <template> - its whole Dialog subtree never
 // mounts (no [role=dialog], no errors), so ⌘K and the sidebar Search rows did
 // nothing. Same anatomy as the stock component: search input + grouped list,
 // ↑/↓/Enter keyboard navigation, Esc closes (Dialog's own handling). Opens via
@@ -75,7 +75,7 @@ const searching = ref(false)
 const activeIndex = ref(0)
 
 // Focus the input once the Dialog's portal content is in the DOM (reka-ui's
-// autofocus usually lands on it anyway — this covers re-opens reliably).
+// autofocus usually lands on it anyway - this covers re-opens reliably).
 watch(open, (v) => {
 	if (v) nextTick(() => inputEl.value?.focus())
 })
@@ -197,7 +197,7 @@ function select(item) {
 	else router.push("/c/" + item.name)
 }
 
-// after-leave (Dialog's overlay finished its exit) — wipe for the next open.
+// after-leave (Dialog's overlay finished its exit) - wipe for the next open.
 function reset() {
 	clearTimeout(_debounce)
 	_seq++ // invalidate any in-flight search

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -59,7 +59,7 @@ const { effectiveDark, toggleTheme } = useJarvisTheme()
 function cookie(name) {
 	// URLSearchParams already percent-decodes; decoding AGAIN throws URIError
 	// when the display name contains a literal '%' (stored as %25 → '%'),
-	// blanking the whole shell — same bug main fixed in lib/user.js (0d19e7c).
+	// blanking the whole shell - same bug main fixed in lib/user.js (0d19e7c).
 	return new URLSearchParams(document.cookie.split("; ").join("&")).get(name)
 }
 const fullName = cookie("full_name") || session.user || "User"
@@ -70,7 +70,7 @@ const menuOptions = computed(() => [
 		hideLabel: true,
 		items: [
 			{ label: "Settings", icon: "settings", onClick: () => store.openSettings(router) },
-			// Account/Monitor ship on main (llm-proxy UI) — the routes exist only
+			// Account/Monitor ship on main (llm-proxy UI) - the routes exist only
 			// once this branch merges with it, so gate on the router. Monitor is
 			// SM-only there; www/jarvis.py (main side) boots is_system_manager.
 			...(router.hasRoute("Account")

--- a/frontend/src/components/wiki/WikiPageDialog.vue
+++ b/frontend/src/components/wiki/WikiPageDialog.vue
@@ -46,7 +46,7 @@
 					v-if="page.contradiction_flag"
 					class="mt-3 rounded-lg border border-outline-red-2 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 				>
-					People have reported conflicting facts — look for the "Contradiction
+					People have reported conflicting facts - look for the "Contradiction
 					flagged" section in the body below.{{
 						page.can_edit
 							? " Edit the page to keep the correct version; saving marks the conflict resolved."
@@ -58,7 +58,7 @@
 					v-if="page.stale"
 					class="mt-3 rounded-lg border border-outline-amber-2 bg-surface-amber-1 px-3 py-2 text-sm text-ink-amber-3"
 				>
-					Not confirmed in 90+ days{{ page.can_edit ? " — saving an edit marks it reviewed." : "." }}
+					Not confirmed in 90+ days{{ page.can_edit ? " - saving an edit marks it reviewed." : "." }}
 				</div>
 
 				<template v-if="editing">
@@ -109,14 +109,14 @@
 					<p v-if="page.summary" class="mt-3 text-sm text-ink-gray-6">
 						{{ page.summary }}
 					</p>
-					<!-- renderMarkdown from @/markdown (escapes HTML first — safe) -->
+					<!-- renderMarkdown from @/markdown (escapes HTML first - safe) -->
 					<div
 						v-if="page.body_md"
 						class="prose prose-sm mt-3 max-w-none"
 						v-html="bodyHtml"
 					/>
 					<p v-else class="mt-3 text-sm text-ink-gray-5">No content yet.</p>
-					<!-- provenance: where Jarvis learned this — earns trust and edits -->
+					<!-- provenance: where Jarvis learned this - earns trust and edits -->
 					<p v-if="provenance" class="mt-3 border-t pt-2 text-p-sm text-ink-gray-5">
 						{{ provenance }}
 					</p>
@@ -169,7 +169,7 @@
 </template>
 
 <script setup>
-// WikiPageDialog — THE full-featured wiki editor popup (size xl): rendered-
+// WikiPageDialog - THE full-featured wiki editor popup (size xl): rendered-
 // markdown read view with scope/attention metadata + provenance, and an Edit
 // mode (title + summary + body) shown only when the server-computed `can_edit`
 // flag allows it. Editing shows the textarea and a live rendered preview side
@@ -243,7 +243,7 @@ const scopeTarget = computed(() => {
 	if (page.value.scope === "User") return page.value.target_user || ""
 	return ""
 })
-// "From a voice note by X, Jul 7" — the page's latest source entry. Pages a
+// "From a voice note by X, Jul 7" - the page's latest source entry. Pages a
 // pipeline wrote (not a person) earn trust by saying where they came from.
 const provenance = computed(() => {
 	const sources = (page.value && page.value.sources) || []
@@ -296,7 +296,7 @@ async function save() {
 			summary: editSummary.value,
 			body_md: editBody.value,
 		})
-		// a saved body counts as a review server-side — mirror that locally
+		// a saved body counts as a review server-side - mirror that locally
 		if (page.value) {
 			if (editTitle.value.trim()) page.value.title = editTitle.value.trim()
 			page.value.summary = editSummary.value
@@ -353,7 +353,7 @@ function confirmArchive() {
 function confirmDelete() {
 	confirmDialog({
 		title: "Delete this page?",
-		message: "Permanently deletes this page — archiving keeps it recoverable.",
+		message: "Permanently deletes this page - archiving keeps it recoverable.",
 		onConfirm: async ({ hideDialog }) => {
 			deleting.value = true
 			try {

--- a/frontend/src/composables/macroPrefill.js
+++ b/frontend/src/composables/macroPrefill.js
@@ -1,7 +1,7 @@
 import { ref } from "vue"
 
 // Cross-view hand-off for "Save as macro". The chat (ChatView) no longer hosts
-// the macro editor — it lives on /macros. So the chat's "Save as macro" actions
+// the macro editor - it lives on /macros. So the chat's "Save as macro" actions
 // stash a draft macro here and router.push("/macros"); MacrosView consumes it
 // ONCE on mount and opens its editor pre-filled. Shape:
 //   { macro_name?: string, description?: string, steps: [{ label?, prompt, skills? }] }

--- a/frontend/src/composables/useAudioRecorder.js
+++ b/frontend/src/composables/useAudioRecorder.js
@@ -1,4 +1,4 @@
-// useAudioRecorder — shared MediaRecorder wrapper for the composer mic, the
+// useAudioRecorder - shared MediaRecorder wrapper for the composer mic, the
 // wiki-nudge card and the Business-tab recorder. One instance per surface.
 //
 // Returned as reactive() (house style, like useDocmeta) so consumers read
@@ -7,14 +7,14 @@
 //   state:     'idle' | 'recording' | 'stopped' | 'error'
 //   error:     friendly message when state === 'error' (mic denied, no mic, …)
 //   durationS: elapsed whole seconds while recording
-//   start():   Promise<void> — requests the mic; on denial → state 'error'
+//   start():   Promise<void> - requests the mic; on denial → state 'error'
 //   stop():    Promise<{blob, mimeType, durationS} | null>
 //   cancel():  discard the take (no blob), release the mic
 //   supported: false on browsers without getUserMedia/MediaRecorder
 //
 // Recordings hard-stop at 300 s (the server rejects longer clips). When the
-// cap fires without a user stop() in flight, the result is stashed — a later
-// stop() resolves with it — and opts.onAutoStop(result) is invoked so the UI
+// cap fires without a user stop() in flight, the result is stashed - a later
+// stop() resolves with it - and opts.onAutoStop(result) is invoked so the UI
 // can transcribe immediately and tell the user why recording ended.
 import { reactive, ref } from "vue"
 
@@ -134,7 +134,7 @@ export function useAudioRecorder(opts = {}) {
 				settle = null
 				r(result)
 			} else if (autoStopped && typeof opts.onAutoStop === "function") {
-				// hit the 300 s cap with no stop() waiting — the callback owns
+				// hit the 300 s cap with no stop() waiting - the callback owns
 				// the take (stashing it too would risk a double transcribe).
 				opts.onAutoStop(result)
 			} else {

--- a/frontend/src/composables/useDocmeta.js
+++ b/frontend/src/composables/useDocmeta.js
@@ -1,7 +1,7 @@
-// useDocmeta — one docmeta bundle per doc page (DESIGN-V3 §6.1). The parent
+// useDocmeta - one docmeta bundle per doc page (DESIGN-V3 §6.1). The parent
 // page creates it and passes the SAME object to DocMetaPanel + CommentsSection.
 // Mutations call src/api/docmeta.js then patch `meta` locally (comments
-// append/replace; assignees/likes/shares replace from the response) — no full
+// append/replace; assignees/likes/shares replace from the response) - no full
 // reload per action. Mutation errors → toast; the initial-load error is kept
 // in `error` for the page's not-found state.
 //
@@ -144,7 +144,7 @@ export function useDocmeta(doctype, name) {
 		}
 	}
 
-	// FileUploader's success payload is the created File doc — patch locally;
+	// FileUploader's success payload is the created File doc - patch locally;
 	// callers without the payload get a plain reload.
 	function afterUpload(fileDoc) {
 		if (meta.value && fileDoc && fileDoc.name) {

--- a/frontend/src/composables/useListPage.js
+++ b/frontend/src/composables/useListPage.js
@@ -1,4 +1,4 @@
-// useListPage — server-envelope list state for the v3 list kit (DESIGN-V3 §5.1).
+// useListPage - server-envelope list state for the v3 list kit (DESIGN-V3 §5.1).
 // One instance per list page; feeds ListPage.vue. Wire format matches api.js
 // `_page()` ({search, filters, sort_field, sort_dir, start, page_length})
 // against the frozen envelope {rows, total, has_more, start, page_length[, facets]}.
@@ -29,7 +29,7 @@ export function useListPage({ fetchFn, defaultSort = { field: "", dir: "" }, sto
 	const sort = ref({ field: defaultSort.field || "", dir: defaultSort.dir || "" })
 	const pageLength = useStorage(`jarvis-pl-${storageKey}`, 20)
 
-	// monotonic request id — drops stale responses (same guard as ChatView.loadConversation)
+	// monotonic request id - drops stale responses (same guard as ChatView.loadConversation)
 	let reqId = 0
 
 	// mode: "reset" (page 1, replaces rows) | "more" (start=rows.length, appends)
@@ -53,7 +53,7 @@ export function useListPage({ fetchFn, defaultSort = { field: "", dir: "" }, sto
 					start: append ? rows.value.length : 0,
 					page_length: pl,
 				})) || {}
-			if (id !== reqId) return // stale — a newer request superseded this one
+			if (id !== reqId) return // stale - a newer request superseded this one
 			const nr = res.rows || []
 			rows.value = append ? [...rows.value, ...nr] : nr
 			total.value = res.total != null ? res.total : rows.value.length

--- a/frontend/src/composables/useShortcuts.js
+++ b/frontend/src/composables/useShortcuts.js
@@ -1,13 +1,13 @@
-// Global keyboard shortcuts (DESIGN-V3 §3.1) — lifts Helpdesk's normalization:
+// Global keyboard shortcuts (DESIGN-V3 §3.1) - lifts Helpdesk's normalization:
 //   - `meta: true` means ⌘ on Mac and Ctrl everywhere else
 //   - shortcuts are suppressed while the user is typing (input / textarea /
-//     contenteditable / inside [role=dialog] or [role=menu]) — EXCEPT chords
+//     contenteditable / inside [role=dialog] or [role=menu]) - EXCEPT chords
 //     that carry a ctrl/meta/alt modifier: pressing Ctrl+Shift+O with the
 //     caret in the composer is a command, not typing (parity: New Chat must
 //     work from the chat composer, which holds focus almost always).
 // ⌘K IS bound here (via AppShell): JarvisCommandPalette is built on plain
-// Dialog and owns no keys itself (the stock CommandPalette — which bound ⌘K
-// internally, old DA-06 — never mounted its Dialog subtree in 0.1.278).
+// Dialog and owns no keys itself (the stock CommandPalette - which bound ⌘K
+// internally, old DA-06 - never mounted its Dialog subtree in 0.1.278).
 import { onMounted, onBeforeUnmount } from "vue"
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent)

--- a/frontend/src/composables/useTheme.js
+++ b/frontend/src/composables/useTheme.js
@@ -2,14 +2,14 @@ import { ref, computed, onMounted, onBeforeUnmount } from "vue"
 import { LIGHT_VARS, DARK_VARS, isDark } from "@/theme"
 
 /**
- * Shared theme composable — single source of truth for the "jarvis-theme"
+ * Shared theme composable - single source of truth for the "jarvis-theme"
  * localStorage preference across ChatView, AiView, AccountView/AppSidebar,
  * and any future views.
  *
  * The underlying refs are module-level singletons (not re-created per call)
  * so that when a view and a child component (e.g. AccountView + AppSidebar)
  * both call useTheme() on the same page, toggling in one instantly re-themes
- * the other — the browser's "storage" event only fires for *other* tabs, so
+ * the other - the browser's "storage" event only fires for *other* tabs, so
  * per-instance refs would otherwise fall out of sync within a single page.
  *
  * Exposes: pref, prefersDark, effectiveDark, paletteVars, setTheme, toggleTheme.
@@ -22,7 +22,7 @@ const paletteVars = computed(() => (effectiveDark.value ? DARK_VARS : LIGHT_VARS
 function setTheme(t) {
 	pref.value = t
 	try { localStorage.setItem("jarvis-theme", t) } catch (e) {
-		/* private mode / storage disabled — keep the in-memory choice */
+		/* private mode / storage disabled - keep the in-memory choice */
 	}
 }
 // Quick toggle: flip between light and dark (drops out of 'system').

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,7 +14,7 @@
 	list-style: revert;
 }
 /* 2. @tailwindcss/forms restyles native selects (appearance:none + preset
-      chevron at right .44rem); jv selects keep their own look — give the text
+      chevron at right .44rem); jv selects keep their own look - give the text
       room under the injected chevron */
 .jv-root select {
 	padding-right: 1.75rem;
@@ -29,7 +29,7 @@
 [data-theme="dark"] .jv-root img {
 	filter: none;
 }
-/* 5. the one bare <p> (artifact no-preview note) loses UA margin — ChatView
+/* 5. the one bare <p> (artifact no-preview note) loses UA margin - ChatView
       carries class="jv-preview-note"; compensation: */
 .jv-preview-note {
 	margin: revert;

--- a/frontend/src/lib/user.js
+++ b/frontend/src/lib/user.js
@@ -4,7 +4,7 @@
 
 export function readCookie(name) {
   // URLSearchParams already percent-decodes the value (handles %25, %20, %2B).
-  // Do NOT decodeURIComponent the result again — a display name containing a
+  // Do NOT decodeURIComponent the result again - a display name containing a
   // literal '%' is stored as '%25', URLSearchParams turns it back into a bare
   // '%', and a second decodeURIComponent('%…') throws URIError, blanking every
   // page that embeds the sidebar.

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -3,7 +3,7 @@
 export function deriveMode(models, preset) {
   const list = Array.isArray(models) ? models : []
   // A chat-subscription model needs the cliproxy sidecar, which only the proxy
-  // path provisions — so even a single subscription is "proxy". (#200 review #1)
+  // path provisions - so even a single subscription is "proxy". (#200 review #1)
   const hasSubscription = list.some(
     (m) => m && (m.subscription || m.credentialType === "subscription" || m.credential_type === "subscription"),
   )
@@ -64,7 +64,7 @@ export function validatePool(models, preset) {
     }
     // API-key model.
     if (!(m.provider || "").trim() || !(m.model || "").trim()) return { ok: false, error: "Every model needs a provider and a model id." }
-    // Custom-endpoint providers ARE their base_url — an OpenAI-Compatible shim
+    // Custom-endpoint providers ARE their base_url - an OpenAI-Compatible shim
     // (e.g. a Claude-CLI gateway) or a local vLLM with no base_url would push a
     // provider that routes nowhere, and both validators used to let it through.
     const pid = _ID_BY_LABEL[m.provider] || (m.provider || "").trim().toLowerCase()
@@ -101,7 +101,7 @@ export const PROVIDER_LABELS = [
 const _LABEL_BY_ID = Object.fromEntries(PROVIDER_LABELS.map(p => [p.id, p.label]))
 const _ID_BY_LABEL = Object.fromEntries(PROVIDER_LABELS.map(p => [p.label, p.id]))
 // Custom-endpoint providers whose whole identity IS the base_url (no default
-// endpoint) — validatePool requires one for these (mirrors validate_models).
+// endpoint) - validatePool requires one for these (mirrors validate_models).
 const NEEDS_BASE_URL = new Set(["openai_compat", "vllm"])
 export function providerLabel(id) { return _LABEL_BY_ID[id] || id || "" }
 export function providerId(label) { return _ID_BY_LABEL[label] || label || "" }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,7 +10,7 @@ import { session, requireLogin } from "./data/session"
 import "./index.css"
 import "./main.css"
 
-// Bounce to Frappe login if there's no session (cookie) — same auth as Desk.
+// Bounce to Frappe login if there's no session (cookie) - same auth as Desk.
 requireLogin()
 
 setConfig("resourceFetcher", frappeRequest)
@@ -19,7 +19,7 @@ const app = createApp(App)
 app.use(resourcesPlugin)
 app.use(router)
 
-// `?nosocket` skips the realtime connection — handy for headless screenshots,
+// `?nosocket` skips the realtime connection - handy for headless screenshots,
 // where an open websocket otherwise keeps the page from ever going idle.
 const socket = window.location.search.includes("nosocket") ? null : initSocket()
 app.provide("$socket", socket)

--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -1,4 +1,4 @@
-// Compact GFM renderer — enough for agent replies: paragraphs, bold/italic,
+// Compact GFM renderer - enough for agent replies: paragraphs, bold/italic,
 // inline code, links, bullet/number lists, and pipe tables (rendered into the
 // imported design's table look via the .jv-md classes in ChatView's styles).
 function esc(s) {
@@ -51,7 +51,7 @@ export function renderMarkdown(src) {
 	}
 	while (i < lines.length) {
 		const line = lines[i]
-		// fenced code block: ``` or ```lang — mermaid renders as a diagram,
+		// fenced code block: ``` or ```lang - mermaid renders as a diagram,
 		// everything else as a styled code block.
 		const fence = line.match(/^\s*```\s*([\w-]*)\s*$/)
 		if (fence) {
@@ -80,7 +80,7 @@ export function renderMarkdown(src) {
 			out.push(renderTable(tbl))
 			continue
 		}
-		// ATX headings (#–####): wiki page bodies lead with them, and a
+		// ATX headings (#-####): wiki page bodies lead with them, and a
 		// knowledge base that shows raw hashes reads as broken.
 		const heading = line.match(/^\s*(#{1,4})\s+(.*)/)
 		if (heading) {

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -1,5 +1,5 @@
 // Pure step-progression helpers for the onboarding wizard. No Vue, no API
-// calls — kept pure so they're cheap to unit-test with node --test (see
+// calls - kept pure so they're cheap to unit-test with node --test (see
 // steps.test.js) and reusable from both the wizard component and the
 // router's first-run guard.
 
@@ -20,7 +20,7 @@ export function prevStep(steps, cur) {
 }
 
 // jarvis.account.is_ready_for_chat (jarvis/account.py) returns
-// {ready: bool, reason: str|None} — reason is one of "signup" /
+// {ready: bool, reason: str|None} - reason is one of "signup" /
 // "llm_credentials" / "selfhost_connection" when not ready, null when ready.
 // Onboarding is "complete" (chat-ready) exactly when `ready` is true.
 export function isOnboardComplete(readyResp) {

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -20,7 +20,7 @@ test("stepIndex", () => {
 })
 
 // jarvis.account.is_ready_for_chat returns {ready: bool, reason: str|None}
-// (see jarvis/account.py::is_ready_for_chat) — isOnboardComplete reads the
+// (see jarvis/account.py::is_ready_for_chat) - isOnboardComplete reads the
 // real `ready` field, so this doubles as a real-shape regression test.
 test("isOnboardComplete reads readiness", () => {
 	assert.equal(isOnboardComplete({ ready: true, reason: null }), true)

--- a/frontend/src/pages/agents/AgentActivityTab.vue
+++ b/frontend/src/pages/agents/AgentActivityTab.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup>
-// Agent activity feed — the Agents page's 4th tab. Self-contained: owns its
+// Agent activity feed - the Agents page's 4th tab. Self-contained: owns its
 // useListPage bound to list_agent_activity_page (owner-scoped, newest first),
 // its own debounced search and its own ListFooter, so AgentsList only mounts
 // it when #activity is active (lazy first fetch via useListPage's onMounted).
@@ -107,7 +107,7 @@ function actionColor(a) {
 }
 
 // useListPage adapter: {search, start, page_length} → listAgentActivityPage
-// (its filters/sort_field don't apply — the feed is fixed newest-first)
+// (its filters/sort_field don't apply - the feed is fixed newest-first)
 const { rows, total, loading, error, search, pageLength, loadMore } = useListPage({
 	fetchFn: (p) =>
 		listAgentActivityPage({ search: p.search, start: p.start, page_length: p.page_length }),

--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -50,7 +50,7 @@
 			</div>
 			<Button label="Back to Agents" @click="router.push({ name: 'AgentsList' })" />
 		</div>
-		<!-- loading (AgentsList/AgentActivityTab pattern — never a blank page) -->
+		<!-- loading (AgentsList/AgentActivityTab pattern - never a blank page) -->
 		<div v-else-if="!agent" class="flex flex-1 flex-col items-center justify-center gap-2">
 			<LoadingIndicator class="size-5 text-ink-gray-5" />
 			<span class="text-sm text-ink-gray-5">Loading agent…</span>
@@ -116,7 +116,7 @@
 					</div>
 				</div>
 				<div v-if="!agent.allowed" class="mt-3 text-sm text-ink-gray-5">
-					Available to: {{ (agent.allowed_roles || []).join(", ") || "—" }} — ask your
+					Available to: {{ (agent.allowed_roles || []).join(", ") || "-" }} - ask your
 					administrator.
 				</div>
 			</div>
@@ -161,7 +161,7 @@
 					<div>
 						<div class="text-sm font-medium text-ink-gray-5">Version</div>
 						<div class="mt-1 flex flex-wrap items-center gap-2 text-base text-ink-gray-8">
-							<span>{{ agent.version && agent.version !== "0.0.0" ? "v" + agent.version : "—" }}</span>
+							<span>{{ agent.version && agent.version !== "0.0.0" ? "v" + agent.version : "-" }}</span>
 							<Badge v-if="updateAvailable" variant="subtle" theme="orange" label="Update available" />
 						</div>
 						<div v-if="updateAvailable" class="mt-1 text-sm text-ink-gray-5">
@@ -170,7 +170,7 @@
 					</div>
 					<div>
 						<div class="text-sm font-medium text-ink-gray-5">Validated FY</div>
-						<div class="mt-1 text-base text-ink-gray-8">{{ agent.validated_for_fy || "—" }}</div>
+						<div class="mt-1 text-base text-ink-gray-8">{{ agent.validated_for_fy || "-" }}</div>
 					</div>
 					<div>
 						<div class="text-sm font-medium text-ink-gray-5">Allowed roles</div>
@@ -250,7 +250,7 @@
 
 			<!-- ── Admin (SM only; server enforces every call). Listing status is
 			     publisher/catalog state curated in registry.json (it reverts on the
-			     next deploy) — deliberately NOT editable here. ── -->
+			     next deploy) - deliberately NOT editable here. ── -->
 			<div v-else-if="tab === 'admin' && isSM" class="max-w-2xl shrink-0 space-y-10 px-5 py-6">
 				<section>
 					<div class="text-base font-medium text-ink-gray-9">Allowed roles</div>
@@ -273,7 +273,7 @@
 							/>
 						</div>
 						<span v-if="!roleDraft.length" class="text-sm text-ink-gray-4">
-							Everyone — no restriction
+							Everyone - no restriction
 						</span>
 					</div>
 					<div class="mt-3 w-72">
@@ -329,10 +329,10 @@
 								:label="row.enabled ? 'Enabled' : 'Disabled'"
 							/>
 							<div v-else-if="column.key === 'last_run_at'" class="truncate text-base">
-								{{ row.last_run_at ? timeAgo(row.last_run_at) : "—" }}
+								{{ row.last_run_at ? timeAgo(row.last_run_at) : "-" }}
 							</div>
 							<div v-else-if="column.key === 'sync_status'" class="truncate text-base">
-								{{ row.sync_status || "—" }}
+								{{ row.sync_status || "-" }}
 							</div>
 							<ListRowItem v-else :column="column" :row="row" :item="item" :align="align" />
 						</template>
@@ -344,7 +344,7 @@
 </template>
 
 <script setup>
-// Agent detail — /agents/:slug (DESIGN-V3 §7.2, D29/D30 + §14 F3/O1 + §15.4).
+// Agent detail - /agents/:slug (DESIGN-V3 §7.2, D29/D30 + §14 F3/O1 + §15.4).
 // Marketplace template: de-texted hero (logo · name · one meta line ·
 // one-line tagline · category chips; install count + Enabled switch right) →
 // hash-synced tabs. Overview (markdown description + static facts panel) ·
@@ -442,7 +442,7 @@ watch(
 )
 
 const installation = computed(() => (agent.value && agent.value.installation) || null)
-// §8.3: all_roles is present only in the SM payload — the Admin-tab signal
+// §8.3: all_roles is present only in the SM payload - the Admin-tab signal
 const isSM = computed(() => Array.isArray(agent.value && agent.value.all_roles))
 const updateAvailable = computed(
 	() =>
@@ -497,7 +497,7 @@ const canInstall = computed(
 const installTooltip = computed(() => {
 	if (!agent.value || canInstall.value) return ""
 	if (!agent.value.allowed)
-		return "Restricted to: " + ((agent.value.allowed_roles || []).join(", ") || "—")
+		return "Restricted to: " + ((agent.value.allowed_roles || []).join(", ") || "-")
 	return agent.value.status === "Coming Soon" ? "Coming soon" : "Not available to install"
 })
 
@@ -532,7 +532,7 @@ const runDisabled = computed(
 const runTooltip = computed(() => {
 	if (!agent.value || !installation.value) return ""
 	if (agent.value.nature !== "Auditor")
-		return "Operators draft through the Approval Board — no on-demand runs"
+		return "Operators draft through the Approval Board - no on-demand runs"
 	if (!installation.value.enabled) return "Enable the agent first"
 	if (!agent.value.allowed) return "Your roles do not permit this agent"
 	return "Run this audit now"
@@ -595,7 +595,7 @@ async function setEnabled(v) {
 const logoText = computed(() =>
 	String((agent.value && agent.value.title) || props.slug || "?").slice(0, 2).toUpperCase()
 )
-// §15.4 — ONE meta line: "by {publisher} · v{version}" (badges follow inline)
+// §15.4 - ONE meta line: "by {publisher} · v{version}" (badges follow inline)
 const heroMetaText = computed(() => {
 	const parts = ["by " + ((agent.value && agent.value.publisher) || "Jarvis")]
 	if (agent.value && agent.value.version && agent.value.version !== "0.0.0") {
@@ -603,14 +603,14 @@ const heroMetaText = computed(() => {
 	}
 	return parts.join(" · ")
 })
-// §15.4 — one-line tagline: first non-empty description line, heading markers
+// §15.4 - one-line tagline: first non-empty description line, heading markers
 // stripped; the full markdown renders only in the Overview tab
 const tagline = computed(() => {
 	const d = (agent.value && agent.value.description) || ""
 	const line = d.split("\n").find((l) => l.trim()) || ""
 	return line.replace(/^#{1,6}\s+/, "").trim()
 })
-// O1 — renderMarkdown (jv-md-* classes are global via the main chunk)
+// O1 - renderMarkdown (jv-md-* classes are global via the main chunk)
 const descriptionHtml = computed(() =>
 	agent.value && agent.value.description ? renderMarkdown(agent.value.description) : ""
 )
@@ -638,7 +638,7 @@ const defaultScheduleText = computed(() => {
 		s = {}
 	}
 	const freq = String(s.schedule_frequency || "").toLowerCase()
-	if (!freq) return "None — runs on demand."
+	if (!freq) return "None - runs on demand."
 	return s.schedule_enabled ? `On by default · ${freq}` : `Off by default · suggested ${freq}`
 })
 function categoryTitle(slug) {
@@ -788,7 +788,7 @@ async function saveRoles() {
 		toast.success(
 			agent.value.allowed_roles.length
 				? "Roles saved"
-				: "Restriction cleared — available to everyone"
+				: "Restriction cleared - available to everyone"
 		)
 		load() // refresh allowed/lock state
 	} catch (e) {

--- a/frontend/src/pages/agents/AgentRunsBoard.vue
+++ b/frontend/src/pages/agents/AgentRunsBoard.vue
@@ -56,7 +56,7 @@
 							</div>
 							<!-- partial scans carry an extra indicator so truncated coverage
 							     never blends in with clean completed runs -->
-							<Tooltip v-if="row.status === 'partial'" text="Partial scan — coverage gaps">
+							<Tooltip v-if="row.status === 'partial'" text="Partial scan - coverage gaps">
 								<FeatherIcon name="alert-triangle" class="mt-1 size-3.5 shrink-0 text-ink-amber-3" />
 							</Tooltip>
 							<Badge
@@ -116,7 +116,7 @@
 </template>
 
 <script setup>
-// AgentRunsBoard — the Runs tab of /agents/:slug as a two-pane master-detail
+// AgentRunsBoard - the Runs tab of /agents/:slug as a two-pane master-detail
 // (Approval-Board §15.2 pattern; replaces the single-pane AgentRunsTab).
 // LEFT: this owner's run history for ONE agent via useListPage →
 // list_runs_page (search / status facet, Load More + "N of M"). RIGHT:
@@ -172,11 +172,11 @@ const emptyState = computed(() => {
 	}
 	return {
 		title: "No runs yet",
-		description: "Use Run Now or a schedule — every run lands here with its findings.",
+		description: "Use Run Now or a schedule - every run lands here with its findings.",
 	}
 })
 
-// ── selection (local — runs live under the agent's hash tab, no :id route) ──
+// ── selection (local - runs live under the agent's hash tab, no :id route) ──
 const selectedRun = ref(null)
 const selectedId = computed(() => (selectedRun.value && selectedRun.value.name) || "")
 
@@ -187,7 +187,7 @@ function selectRun(row) {
 // auto-select the first row; on refresh, re-pin the selection to the fresh row
 // object so a running run's status/counters flip live in the right pane. When
 // the status/search facet excludes the selected run, fall over to the first
-// row (or clear to the placeholder) — never leave a stale run that isn't in
+// row (or clear to the placeholder) - never leave a stale run that isn't in
 // the rail.
 watch(rows, (r) => {
 	if (selectedRun.value) {

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -8,13 +8,13 @@
 				<!-- SM-only apply pipeline: prominent while the catalog is dirty,
 				     SyncPill-style pending/failed states while an apply runs -->
 				<div v-if="isSM" class="flex items-center gap-2">
-					<!-- duration lives IN the badge text — tooltips are invisible to
+					<!-- duration lives IN the badge text - tooltips are invisible to
 					     keyboard/SR users -->
 					<Badge v-if="sync.pending" theme="orange" variant="subtle">
 						<template #prefix>
 							<LoadingIndicator class="size-3" />
 						</template>
-						Applying agents — ~30s, one restart
+						Applying agents - ~30s, one restart
 					</Badge>
 					<template v-else>
 						<Badge v-if="syncFailed" theme="red" variant="subtle" label="Apply failed" />
@@ -43,7 +43,7 @@
 			<FeatherIcon name="x-circle" class="mt-0.5 size-4 shrink-0" />
 			<span>
 				Applying agents to your assistant failed<template v-if="syncFailureReason">
-					— {{ syncFailureReason }}</template
+					- {{ syncFailureReason }}</template
 				>. Use Retry apply to try again.
 			</span>
 		</div>
@@ -171,7 +171,7 @@
 						</div>
 
 						<div v-if="!a.allowed" class="mt-2 text-sm text-ink-gray-5">
-							Available to: {{ (a.allowed_roles || []).join(", ") || "—" }} — ask your
+							Available to: {{ (a.allowed_roles || []).join(", ") || "-" }} - ask your
 							administrator.
 						</div>
 					</div>
@@ -197,7 +197,7 @@
 			<template #body-content>
 				<p class="text-p-base text-ink-gray-6">
 					You have unapplied catalog changes. Apply them now, or leave anyway? Your changes
-					stay saved either way — they only reach the assistant after an Apply.
+					stay saved either way - they only reach the assistant after an Apply.
 				</p>
 			</template>
 			<template #actions>
@@ -212,14 +212,14 @@
 </template>
 
 <script setup>
-// Agents marketplace listing — /agents (DESIGN-V3 §15.3, marketplace revision).
+// Agents marketplace listing - /agents (DESIGN-V3 §15.3, marketplace revision).
 // Four hash-synced tabs (no hash = Featured; #available/#installed/#activity):
-//   Featured / Available / Installed — SERVER-paginated card grids via
+//   Featured / Available / Installed - SERVER-paginated card grids via
 //     agents_api.list_agents_page (tab semantics live server-side; envelope
 //     {rows,total,has_more,...}) with a Category select + a single sort choice
-//     (Most installed / Recently updated / Name). No ratings — deliberately
+//     (Most installed / Recently updated / Name). No ratings - deliberately
 //     deferred.
-//   Activity — the owner's lifecycle feed (AgentActivityTab, self-contained).
+//   Activity - the owner's lifecycle feed (AgentActivityTab, self-contained).
 // SM header action: prominent "Apply catalog changes" driven by
 // get_agents_sync_status().dirty (install/uninstall/enable since the last
 // successful Apply), with SyncPill-style pending/failed polling, plus a
@@ -301,12 +301,12 @@ const sortChoice = ref("installs") // installs | updated | name
 const SORT_OPTIONS = [
 	{ label: "Most installed", value: "installs" },
 	{ label: "Recently updated", value: "updated" },
-	{ label: "Name (A–Z)", value: "name" },
+	{ label: "Name (A-Z)", value: "name" },
 ]
 
 const { rows, total, loading, error, search, pageLength, resetLoad, loadMore } = useListPage({
 	fetchFn: (p) => {
-		// Activity owns its own list — never hit the catalog endpoint for it
+		// Activity owns its own list - never hit the catalog endpoint for it
 		// (covers the mount-time fetch when deep-linked to #activity)
 		if (!AGENT_TABS.includes(tab.value)) return { rows: [], total: 0, has_more: false }
 		return agentsApi.listAgentsPage({
@@ -329,7 +329,7 @@ watch([tab, category, sortChoice], ([t]) => {
 })
 
 // ── category select options (distinct catalog categories, DOMAINS titles) ────
-// One cheap list_agents() call feeds the distinct set — server pages can't
+// One cheap list_agents() call feeds the distinct set - server pages can't
 // (a page only sees its slice); DOMAINS is the fallback until/if it loads.
 const catalogCategories = ref(null)
 async function loadCategories() {
@@ -345,7 +345,7 @@ async function loadCategories() {
 		}
 		if (out.length) catalogCategories.value = out
 	} catch (e) {
-		// keep the DOMAINS fallback — the select must not break the page
+		// keep the DOMAINS fallback - the select must not break the page
 	}
 }
 const categoryOptions = computed(() => {
@@ -356,7 +356,7 @@ const categoryOptions = computed(() => {
 	]
 })
 
-// ── empty states (per-TAB copy — "catalog is empty" only when it truly is) ───
+// ── empty states (per-TAB copy - "catalog is empty" only when it truly is) ───
 const filtersActive = computed(() => !!(search.value || category.value))
 const emptyState = computed(() => {
 	if (filtersActive.value) {
@@ -408,7 +408,7 @@ function installsLabel(n) {
 }
 
 // ── SM probe (round-2 parity): getAgentAdminOverview succeeds only for System
-// Managers — PermissionError hides the apply action, no noise. ────────────────
+// Managers - PermissionError hides the apply action, no noise. ────────────────
 const isSM = ref(false)
 async function probeAdmin() {
 	try {
@@ -422,7 +422,7 @@ async function probeAdmin() {
 }
 
 // ── apply pipeline status (SyncPill pattern: 3s poll while pending) ──────────
-// dirty = the enabled set changed since the last successful Apply — drives the
+// dirty = the enabled set changed since the last successful Apply - drives the
 // prominent solid button, the "Changes pending" badge and the leave-guard.
 const sync = reactive({ pending: false, dirty: false, status: "" })
 const syncFailed = computed(() => (sync.status || "").startsWith("failed"))
@@ -461,7 +461,7 @@ async function applyCatalog() {
 	applying.value = true
 	try {
 		await api.applyAgents()
-		toast.success("Applying catalog changes — ~30s, one restart")
+		toast.success("Applying catalog changes - ~30s, one restart")
 		sync.pending = true
 		startSyncPoll()
 		return true
@@ -477,7 +477,7 @@ async function applyCatalog() {
 const leaveDialog = reactive({ show: false, next: null })
 
 onBeforeRouteLeave((to, from, next) => {
-	// drilling into /agents/:slug stays inside the agents area — don't nag
+	// drilling into /agents/:slug stays inside the agents area - don't nag
 	if (!isSM.value || !sync.dirty || String(to.path || "").startsWith("/agents")) return next()
 	leaveDialog.next = next
 	leaveDialog.show = true

--- a/frontend/src/pages/agents/ConfigForm.vue
+++ b/frontend/src/pages/agents/ConfigForm.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<div v-if="!fields.length && !hasAdvanced" class="text-sm text-ink-gray-5">
-			No configuration set yet — add keys under Advanced (JSON).
+			No configuration set yet - add keys under Advanced (JSON).
 		</div>
 
 		<div v-if="fields.length" class="space-y-4">
@@ -52,7 +52,7 @@
 </template>
 
 <script setup>
-// ConfigForm — §14 F3: a real form generated from the installation's current
+// ConfigForm - §14 F3: a real form generated from the installation's current
 // config object. boolean → Switch, number → FormControl type=number, string →
 // type=text; array/object values + unknown/new keys live in a collapsed
 // "Advanced (JSON)" DocSection (mono textarea, JSON.parse-validated). Save

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -41,7 +41,7 @@
 		>
 			<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
 			<span>
-				Partial scan — {{ coverageNote }}. Treat gaps as unreviewed, not clean.
+				Partial scan - {{ coverageNote }}. Treat gaps as unreviewed, not clean.
 			</span>
 		</div>
 
@@ -87,7 +87,7 @@
 			</div>
 			<div class="mt-2 divide-y overflow-hidden rounded-lg border">
 				<div v-for="f in group.rows" :key="f.name">
-					<!-- collapsed row (div, not button — it hosts the state select);
+					<!-- collapsed row (div, not button - it hosts the state select);
 					     role/tabindex + enter/space keep it keyboard-operable -->
 					<div
 						role="button"
@@ -110,7 +110,7 @@
 							:label="severityBadgeLabel(f.severity)"
 						/>
 						<span class="w-20 shrink-0 truncate font-mono text-sm text-ink-gray-5">
-							{{ f.rule_id || "—" }}
+							{{ f.rule_id || "-" }}
 						</span>
 						<span class="min-w-0 flex-1 truncate text-base text-ink-gray-8">
 							{{ f.title }}
@@ -139,10 +139,10 @@
 						</div>
 					</div>
 
-					<!-- expanded: the recorded detail — detail_md, the referenced
+					<!-- expanded: the recorded detail - detail_md, the referenced
 					     document, the statutory caveat, and the finding actions -->
 					<div v-if="isExpanded(f.name)" class="border-t bg-surface-gray-1 px-4 py-3">
-						<!-- O1: renderMarkdown from @/markdown (escapes HTML first — safe) -->
+						<!-- O1: renderMarkdown from @/markdown (escapes HTML first - safe) -->
 						<div
 							v-if="f.detail_md"
 							class="prose prose-sm max-w-none"
@@ -196,7 +196,7 @@
 			</div>
 		</div>
 
-		<!-- coverage honesty: the page cap must never be silent — always say how
+		<!-- coverage honesty: the page cap must never be silent - always say how
 		     much of the run is on screen, and offer the rest -->
 		<div v-if="rows.length" class="mt-4 flex items-center justify-between gap-2">
 			<Button
@@ -213,14 +213,14 @@
 </template>
 
 <script setup>
-// FindingsPanel — the right pane of AgentRunsBoard (DESIGN-V3 §7.2): the
+// FindingsPanel - the right pane of AgentRunsBoard (DESIGN-V3 §7.2): the
 // selected run's findings, grouped by severity (blocker → warning → note),
 // each row expandable to the recorded detail_md (markdown), the referenced
 // document, and the statutory caveat (section/effective_date/disclaimer).
 // A partial run always carries a coverage-honesty banner. Actions per finding:
 // Discuss in chat (take_finding_to_chat → /c/:id), Open document, and the
 // open/acknowledged/resolved state select → setFindingState (optimistic).
-// No remediation text is ever fabricated — only what the run persisted.
+// No remediation text is ever fabricated - only what the run persisted.
 import { ref, computed, watch } from "vue"
 import { useRouter } from "vue-router"
 import {
@@ -286,7 +286,7 @@ const expanded = ref(new Set())
 const runLabel = computed(() =>
 	props.run && props.run.started_at ? timeAgo(props.run.started_at) : props.run.name
 )
-// a failed run shows ONLY the red failed banner — never the amber partial one
+// a failed run shows ONLY the red failed banner - never the amber partial one
 const coverageWarning = computed(
 	() =>
 		props.run.status === "partial" ||
@@ -298,7 +298,7 @@ const coverageNote = computed(() => {
 	return note.replace(/[.\s]+$/, "") || "some records were not reviewed"
 })
 const emptyText = computed(() => {
-	if (props.run.status === "running") return "Run in progress — findings appear when it completes."
+	if (props.run.status === "running") return "Run in progress - findings appear when it completes."
 	if (props.run.status === "failed") return "This run recorded no findings."
 	return `No ${stateFilter.value ? stateFilter.value + " " : ""}findings for this run.`
 })
@@ -331,7 +331,7 @@ function severityBadgeLabel(sev) {
 	return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
-// monotonic request id — rapid rail clicks must not land stale findings
+// monotonic request id - rapid rail clicks must not land stale findings
 let reqId = 0
 async function load({ append = false } = {}) {
 	if (!props.run || !props.run.name) return
@@ -380,7 +380,7 @@ function loadMore() {
 
 // reload on run switch AND on status flip (a re-pinned running run that just
 // completed now has a findings snapshot to show). Watch the name/status
-// STRINGS, not the run object — the rail re-pins a fresh row object on every
+// STRINGS, not the run object - the rail re-pins a fresh row object on every
 // refresh and object identity alone must not re-fetch findings.
 watch(
 	[() => props.run && props.run.name, () => props.run && props.run.status],
@@ -423,7 +423,7 @@ async function moveFinding(f, state) {
 		await api.setFindingState(f.name, state)
 		toast.success(`Finding ${state}`)
 		// reconcile with the active state-filter chip: a finding moved OUT of
-		// the filtered state leaves the visible list (and its counts) at once —
+		// the filtered state leaves the visible list (and its counts) at once -
 		// acknowledging while viewing "Open" must not leave a stale row
 		if (stateFilter.value && state !== stateFilter.value) {
 			rows.value = rows.value.filter((r) => r.name !== f.name)
@@ -473,7 +473,7 @@ function refUrl(row) {
 	const dt = String(row.ref_doctype || "").toLowerCase().replace(/ /g, "-")
 	return `/app/${dt}/${encodeURIComponent(row.ref_name)}`
 }
-// "Statutory basis: {section} (effective {date}). {disclaimer}" — only the
+// "Statutory basis: {section} (effective {date}). {disclaimer}" - only the
 // pieces the run recorded
 function caveatText(f) {
 	const bits = []

--- a/frontend/src/pages/approvals/ApprovalsBoard.vue
+++ b/frontend/src/pages/approvals/ApprovalsBoard.vue
@@ -6,7 +6,7 @@
 			</template>
 		</LayoutHeader>
 
-		<!-- toolbar (§15.2): search · status · type facets · Refresh — no
+		<!-- toolbar (§15.2): search · status · type facets · Refresh - no
 		     Filter/Sort/Columns; the split view IS the workflow -->
 		<div class="flex items-center justify-between gap-2 border-b px-5 py-3">
 			<div class="flex flex-1 items-center gap-2 overflow-x-auto py-0.5">
@@ -179,7 +179,7 @@
 					<div class="mt-4">
 						<!-- 3. context -->
 						<DocSection v-if="selected.context_md" label="Context">
-							<!-- O1: renderMarkdown from @/markdown (escapes HTML first — safe) -->
+							<!-- O1: renderMarkdown from @/markdown (escapes HTML first - safe) -->
 							<div class="prose prose-sm max-w-none" v-html="contextHtml" />
 						</DocSection>
 
@@ -187,7 +187,7 @@
 						<DocSection label="Decision" :collapsible="false">
 							<template v-if="selected.status === 'Pending'">
 								<div v-if="selected.can_act">
-									<!-- the LLM's options are varied per chat — selectable chips;
+									<!-- the LLM's options are varied per chat - selectable chips;
 									     hidden when they merely restate Approve/Reject -->
 									<div v-if="showOptionChips" class="flex flex-wrap gap-2">
 										<Button
@@ -201,7 +201,7 @@
 									<FormControl
 										type="textarea"
 										:class="showOptionChips ? 'mt-3' : ''"
-										placeholder="Add a note — optional"
+										placeholder="Add a note - optional"
 										:modelValue="note"
 										@update:modelValue="(v) => (note = v)"
 									/>
@@ -223,7 +223,7 @@
 											@click="submitDecide(0)"
 										/>
 										<div class="flex-1" />
-										<!-- tag for review — the DocShare path DocMetaPanel's
+										<!-- tag for review - the DocShare path DocMetaPanel's
 										     "Shared with" block uses (same docmeta object, so the
 										     Record details block stays in sync) -->
 										<Popover placement="bottom-end">
@@ -267,11 +267,11 @@
 										</Popover>
 									</div>
 									<div class="mt-2 text-sm text-ink-gray-5">
-										Tag a colleague to view and comment — only you (or an admin) can approve.
+										Tag a colleague to view and comment - only you (or an admin) can approve.
 									</div>
 								</div>
 								<div v-else class="text-sm text-ink-gray-5">
-									Waiting for a decision — comment below and @mention someone who can approve.
+									Waiting for a decision - comment below and @mention someone who can approve.
 								</div>
 							</template>
 							<template v-else>
@@ -280,7 +280,7 @@
 							</template>
 						</DocSection>
 
-						<!-- 5. comments — the "tag someone to approve" surface -->
+						<!-- 5. comments - the "tag someone to approve" surface -->
 						<div class="border-t py-4">
 							<CommentsSection :docmeta="docmeta" :can-comment="true" />
 						</div>
@@ -299,10 +299,10 @@
 </template>
 
 <script setup>
-// Approval Board — two-pane master-detail (DESIGN-V3 §15.2, supersedes
+// Approval Board - two-pane master-detail (DESIGN-V3 §15.2, supersedes
 // §5.8/§6.4). LEFT: envelope-fed inbox rail (search/status/type facets,
 // Load More + "N of M", auto-select first row). RIGHT: the action pane for
-// the selected approval — question + meta, Context markdown, varied option
+// the selected approval - question + meta, Context markdown, varied option
 // chips + note + Approve/Reject, CommentsSection (mentions), collapsed
 // DocMetaPanel. Row click → router.replace('/approvals/'+id); both approval
 // routes render this board.
@@ -351,7 +351,7 @@ const STATUS_OPTIONS = [
 const STATUS_VALUES = ["Pending", "Decided", "All"]
 const DEFAULT_SORT = { field: "creation", dir: "desc" }
 
-// deep-link seeds (?status=, ?type= — parity with the old list page)
+// deep-link seeds (?status=, ?type= - parity with the old list page)
 const initialStatus = STATUS_VALUES.includes(route.query.status) ? route.query.status : "Pending"
 const initialType = typeof route.query.type === "string" ? route.query.type : ""
 
@@ -414,7 +414,7 @@ function setQuick(key, value) {
 	syncQuery()
 }
 // keep ?status=/?type= in the URL so deep links preserve the view (D32);
-// Pending is the default — keep the URL clean for it.
+// Pending is the default - keep the URL clean for it.
 function syncQuery() {
 	const q = { ...route.query }
 	const status = filters.status || "Pending"
@@ -430,18 +430,18 @@ function docType(row) {
 }
 
 // ── selection (right pane always reads the full record via get_approval,
-//    incl. can_act — the rail row is never enough) ─────────────────────────────
+//    incl. can_act - the rail row is never enough) ─────────────────────────────
 const selectedId = ref("")
 const selected = ref(null)
 const paneError = ref("")
-let paneReq = 0 // monotonic — stale responses dropped
+let paneReq = 0 // monotonic - stale responses dropped
 
 const docmeta = useDocmeta("Jarvis Approval Request", selectedId)
 
 // deep-link seed: a routed :id beyond the loaded page still gets a rail row,
 // built from the get_approval payload and pinned on top. The computed drops
-// the seed the moment the real row shows up (page 1 or Load More) — dedupe
-// for free — and never mutates `rows`, so Load More's start offset stays true.
+// the seed the moment the real row shows up (page 1 or Load More) - dedupe
+// for free - and never mutates `rows`, so Load More's start offset stays true.
 const seedTargetId = typeof route.params.id === "string" ? route.params.id : ""
 let seedWanted = !!seedTargetId
 const seedRow = ref(null)
@@ -450,7 +450,7 @@ const railRows = computed(() => {
 	if (!seed || rows.value.some((r) => r.name === seed.name)) return rows.value
 	return [seed, ...rows.value]
 })
-// the seed sits outside the server's filtered total — count it explicitly
+// the seed sits outside the server's filtered total - count it explicitly
 const railTotal = computed(() => total.value + (railRows.value.length - rows.value.length))
 
 function select(id) {
@@ -494,7 +494,7 @@ async function loadRecord(id, { keep = false } = {}) {
 
 function onRowClick(row) {
 	select(row.name)
-	// replace, not push — selection must not spam browser history
+	// replace, not push - selection must not spam browser history
 	router.replace({ name: "ApprovalDetail", params: { id: row.name }, query: route.query })
 }
 
@@ -517,7 +517,7 @@ const refUrl = computed(() => {
 const contextHtml = computed(() =>
 	selected.value && selected.value.context_md ? renderMarkdown(selected.value.context_md) : ""
 )
-// options may arrive parsed (list) or as the raw JSON string — be defensive
+// options may arrive parsed (list) or as the raw JSON string - be defensive
 const options = computed(() => {
 	const raw = selected.value && selected.value.options
 	if (Array.isArray(raw)) return raw.map(String)
@@ -558,7 +558,7 @@ const decidedLine = computed(() => {
 // Sharing IS tagging: same DocShare path as DocMetaPanel's "Shared with" block
 // (docmeta.toggleShare), surfaced next to the Decision buttons so it's
 // discoverable. The backend makes shared approvals visible on the tagged
-// user's board; can_act stays owner/SM-only — tagged users view and comment.
+// user's board; can_act stays owner/SM-only - tagged users view and comment.
 const shares = computed(() => (docmeta.meta && docmeta.meta.shares) || [])
 const shareUsers = ref([])
 let shareUsersLoaded = false
@@ -602,7 +602,7 @@ async function submitDecide(approve) {
 	if (deciding.value !== null || !selected.value) return
 	deciding.value = approve
 	const noteText = note.value.trim()
-	// decide() requires non-empty decision text — Approve sends the selected
+	// decide() requires non-empty decision text - Approve sends the selected
 	// option chip, else the note, else the verdict word; Reject sends the note
 	// or the verdict word (the picked option was what got refused)
 	const text = approve ? selectedOption.value || noteText || "Approved" : noteText || "Rejected"
@@ -628,10 +628,10 @@ async function submitDecide(approve) {
 		}
 		selectedOption.value = ""
 		note.value = ""
-		toast.success((approve ? "Approved" : "Rejected") + (res.resumed ? " — conversation resumed" : ""))
+		toast.success((approve ? "Approved" : "Rejected") + (res.resumed ? " - conversation resumed" : ""))
 		store.refreshApprovalsCount()
 		if ((filters.status || "Pending") === "Pending") {
-			// the decided row no longer matches the Pending quick-filter —
+			// the decided row no longer matches the Pending quick-filter -
 			// drop it and move the selection along so triage keeps flowing
 			advanceAfterDecide(id)
 		} else {
@@ -673,7 +673,7 @@ function advanceAfterDecide(id) {
 	}
 }
 
-// ── selection wiring (after every ref it touches exists — the immediate
+// ── selection wiring (after every ref it touches exists - the immediate
 //    watcher fires during setup) ───────────────────────────────────────────────
 // route :id → selection (deep links, back/forward); absent id keeps the
 // current selection (breadcrumb click doesn't blank the pane)

--- a/frontend/src/pages/files/FilesList.vue
+++ b/frontend/src/pages/files/FilesList.vue
@@ -60,10 +60,10 @@
 						<FeatherIcon name="upload-cloud" class="size-6 text-ink-gray-5" />
 						<div class="text-base font-medium text-ink-gray-8">
 							{{ dragging ? "Drop files to add to File Box" : "Drop files here, or click to browse"
-							}}<span v-if="uploadingCount"> — {{ uploadingCount }} uploading…</span>
+							}}<span v-if="uploadingCount"> - {{ uploadingCount }} uploading…</span>
 						</div>
 						<div class="max-w-2xl text-p-sm text-ink-gray-6">
-							Drop your files — single or in bulk — and leave them. Jarvis identifies each file's
+							Drop your files - single or in bulk - and leave them. Jarvis identifies each file's
 							nature and processes it in the background. If it needs your input, it asks in the
 							<!-- .stop keeps the link from also triggering the card's pickFiles
 							     (click) and from having Enter swallowed by the card's
@@ -75,7 +75,7 @@
 								@keydown.enter.stop
 								>Approval Board</router-link
 							>
-							— watch for the <span class="font-semibold">red dot</span> there and answer its
+							- watch for the <span class="font-semibold">red dot</span> there and answer its
 							questions.
 						</div>
 					</div>
@@ -158,7 +158,7 @@
 </template>
 
 <script setup>
-// File Box list — DESIGN-V3 §5.7 + §15.1: search quick filter (envelope
+// File Box list - DESIGN-V3 §5.7 + §15.1: search quick filter (envelope
 // `search`), persistent drop card (click → picker, page-wide drag highlights
 // it, drop anywhere uploads) with per-file error chips, status quick filter
 // with ?status= deep link, date-range filter, processing poll (5s) +
@@ -240,7 +240,7 @@ const {
 	refreshKeep,
 } = useListPage({
 	fetchFn: (p) => {
-		// the backend whitelists filter keys and throws on "search" — strip it
+		// the backend whitelists filter keys and throws on "search" - strip it
 		// out of filters and send it as the envelope's search param instead
 		const { search: q, ...rest } = p.filters || {}
 		return api.fileboxListPage({ ...p, search: q || p.search || "", filters: rest })
@@ -292,7 +292,7 @@ function onPick(ev) {
 
 // drop-card state: in-flight count ("{n} uploading…") + per-file error chips
 const uploadingCount = ref(0)
-const dropErrors = ref([]) // [{key, name, error}] — last 8, dismissible
+const dropErrors = ref([]) // [{key, name, error}] - last 8, dismissible
 let dropErrKey = 0
 function pushDropError(name, error) {
 	dropErrors.value = [...dropErrors.value, { key: ++dropErrKey, name, error }].slice(-8)
@@ -332,7 +332,7 @@ async function uploadBatch(fileList) {
 			error: () => "Upload failed",
 		})
 	} catch (e) {
-		// every file failed — the per-file chips below carry the reasons
+		// every file failed - the per-file chips below carry the reasons
 	}
 	for (const f of failures) pushDropError(f.name, f.error)
 	if (okCount) resetLoad()

--- a/frontend/src/pages/macros/MacroDetail.vue
+++ b/frontend/src/pages/macros/MacroDetail.vue
@@ -15,7 +15,7 @@
 				:loading="running"
 				:disabled="mergePending || running"
 				:tooltip="
-					mergePending ? 'Summarizing… — Run unlocks when the summary is ready' : 'Run this macro now'
+					mergePending ? 'Summarizing… - Run unlocks when the summary is ready' : 'Run this macro now'
 				"
 				@click="run"
 			/>
@@ -48,13 +48,13 @@
 					<Switch
 						v-model="form.enabled"
 						label="Enabled"
-						description="Off = saved as a draft — it won't run and stays out of the chat run menu."
+						description="Off = saved as a draft - it won't run and stays out of the chat run menu."
 						:disabled="saving"
 					/>
 					<Switch
 						v-model="form.stop_on_error"
 						label="Stop on error"
-						description="Stop the chain if a step fails — otherwise it keeps going after an error."
+						description="Stop the chain if a step fails - otherwise it keeps going after an error."
 						:disabled="saving"
 					/>
 				</div>
@@ -107,7 +107,7 @@
 					type="textarea"
 					:rows="9"
 					class="font-mono"
-					placeholder="No summary yet — saving 2+ steps generates one in the background."
+					placeholder="No summary yet - saving 2+ steps generates one in the background."
 					description="When present, runs use this prompt instead of the steps."
 					:modelValue="form.merged_prompt"
 					:disabled="saving || mergePending"
@@ -201,7 +201,7 @@ const form = reactive({
 // Saved-state copy for the dirty compare (set by seed). MUST be a ref: on
 // /macros/:id the dirty computed first evaluates while the load is in flight,
 // and with a plain variable the `!snapshot` short-circuit would track zero
-// reactive deps — the computed caches false and never re-runs, so Save never
+// reactive deps - the computed caches false and never re-runs, so Save never
 // enables on existing macros.
 const snapshot = ref(null)
 
@@ -395,13 +395,13 @@ async function save() {
 			await api.updateMacro(upd)
 		}
 		// Re-summarize only when the sequence actually changed (or has no summary
-		// yet) — a rename shouldn't burn an LLM turn.
+		// yet) - a rename shouldn't burn an LLM turn.
 		const needsSummary = steps.length >= 2 && (stepsTouched || props.isNew || !sentMerged)
 		if (savedName && needsSummary) {
 			try {
 				await api.summarizeMacro(savedName)
 				toast.create({
-					message: "Summarizing in the background — Run unlocks when the summary is ready.",
+					message: "Summarizing in the background - Run unlocks when the summary is ready.",
 					type: "info",
 				})
 			} catch (e) {
@@ -430,7 +430,7 @@ async function run() {
 		const res = await api.runMacro(props.id)
 		const data = (res && res.data) || res || {}
 		toast.success("Macro started")
-		// hand off to the chat — the live macro banner is ChatView's machinery
+		// hand off to the chat - the live macro banner is ChatView's machinery
 		if (data.conversation) router.push("/c/" + data.conversation)
 	} catch (e) {
 		toast.error(errMsg(e))
@@ -444,7 +444,7 @@ async function resummarize() {
 		await api.summarizeMacro(props.id)
 		mergeStatus.value = "pending"
 		toast.create({
-			message: "Summarizing in the background — Run unlocks when the summary is ready.",
+			message: "Summarizing in the background - Run unlocks when the summary is ready.",
 			type: "info",
 		})
 	} catch (e) {
@@ -475,10 +475,10 @@ function onEvent(p) {
 	if (!p || p.kind !== "macro:merged" || props.isNew || p.macro !== props.id) return
 	refreshMergeFields()
 	if (p.status === "ready") {
-		toast.success("Summary ready — this macro now runs as one prompt.")
+		toast.success("Summary ready - this macro now runs as one prompt.")
 	} else {
 		toast.create({
-			message: "Couldn't summarize — the steps run as a sequence.",
+			message: "Couldn't summarize - the steps run as a sequence.",
 			type: "info",
 		})
 	}

--- a/frontend/src/pages/macros/MacrosList.vue
+++ b/frontend/src/pages/macros/MacrosList.vue
@@ -57,26 +57,26 @@
 					label="Summarizing…"
 				/>
 				<Badge v-else-if="row.has_summary" variant="subtle" theme="gray" label="Summarized" />
-				<span v-else class="text-base text-ink-gray-4">—</span>
+				<span v-else class="text-base text-ink-gray-4">-</span>
 			</template>
 
 			<template #cell-schedule="{ row }">
 				<div v-if="row.schedule_enabled" class="truncate text-base">{{ scheduleLabel(row) }}</div>
-				<span v-else class="text-base text-ink-gray-4">—</span>
+				<span v-else class="text-base text-ink-gray-4">-</span>
 			</template>
 
 			<template #cell-last_run_at="{ row }">
 				<Tooltip v-if="row.last_run_at" :text="exactDate(row.last_run_at)">
 					<div class="truncate text-base">{{ timeAgo(row.last_run_at) }}</div>
 				</Tooltip>
-				<span v-else class="text-base text-ink-gray-4">—</span>
+				<span v-else class="text-base text-ink-gray-4">-</span>
 			</template>
 
 			<template #cell-next_run_at="{ row }">
 				<Tooltip v-if="row.next_run_at" :text="exactDate(row.next_run_at)">
 					<div class="truncate text-base">{{ timeAgo(row.next_run_at) }}</div>
 				</Tooltip>
-				<span v-else class="text-base text-ink-gray-4">—</span>
+				<span v-else class="text-base text-ink-gray-4">-</span>
 			</template>
 
 			<template #cell-_run="{ row }">
@@ -88,7 +88,7 @@
 						:disabled="row.merge_status === 'pending' || !!runningRow"
 						:tooltip="
 							row.merge_status === 'pending'
-								? 'Summarizing… — Run unlocks when the summary is ready'
+								? 'Summarizing… - Run unlocks when the summary is ready'
 								: 'Run'
 						"
 						@click="runRow(row)"
@@ -109,7 +109,7 @@
 </template>
 
 <script setup>
-// Macros list — DESIGN-V3 §5.9: TabBar (Macros | Runs) synced to /macros vs
+// Macros list - DESIGN-V3 §5.9: TabBar (Macros | Runs) synced to /macros vs
 // /macros/runs, envelope list with enabled/schedule quick filters, summary +
 // schedule badge cells, inline ghost Run cell (gated while summarizing), bulk
 // delete (incl. run history) and macro:merged live refresh.
@@ -233,7 +233,7 @@ async function runRow(row) {
 		const res = await api.runMacro(row.name)
 		const data = (res && res.data) || res || {}
 		toast.success(`Running “${row.macro_name || row.name}”`)
-		// hand off to the chat — the live macro banner is ChatView's machinery
+		// hand off to the chat - the live macro banner is ChatView's machinery
 		if (data.conversation) router.push("/c/" + data.conversation)
 	} catch (e) {
 		toast.error(errMsg(e))
@@ -242,7 +242,7 @@ async function runRow(row) {
 	}
 }
 
-// ── bulk delete (run history goes too — server side, per row) ────────────────
+// ── bulk delete (run history goes too - server side, per row) ────────────────
 function bulkDelete(selections, unselectAll) {
 	const names = Array.from(selections || [])
 	if (!names.length) return
@@ -278,7 +278,7 @@ function onEvent(p) {
 	if (!p || p.kind !== "macro:merged") return
 	refreshKeep()
 	if (p.status === "ready") {
-		toast.success(`Summary ready — “${p.macro_name || "macro"}” now runs as one prompt.`)
+		toast.success(`Summary ready - “${p.macro_name || "macro"}” now runs as one prompt.`)
 	} else {
 		toast.create({
 			message: `“${p.macro_name || "Macro"}” keeps its step sequence (couldn't summarize).`,

--- a/frontend/src/pages/macros/RunsTab.vue
+++ b/frontend/src/pages/macros/RunsTab.vue
@@ -74,7 +74,7 @@
 				</template>
 				<template v-else-if="column.key === 'duration'">
 					<div class="truncate text-base">
-						{{ row.duration_s != null ? fmtDuration(row.duration_s) : "—" }}
+						{{ row.duration_s != null ? fmtDuration(row.duration_s) : "-" }}
 					</div>
 				</template>
 				<template v-else-if="column.key === 'steps'">
@@ -134,7 +134,7 @@
 </template>
 
 <script setup>
-// RunsTab — the /macros/runs dashboard (DESIGN-V3 §5.9): stat cards from
+// RunsTab - the /macros/runs dashboard (DESIGN-V3 §5.9): stat cards from
 // macro_run_stats, status/macro filters, runs table rendered with the stock
 // ListView pieces (no selection), Stop / open-chat row actions, load-more
 // footer, and live socket updates (macro:progress / macro:done → silent
@@ -221,14 +221,14 @@ const totalCount = computed(() => {
 const statCards = computed(() => {
 	const s = stats.value || {}
 	return [
-		{ label: "Total runs", value: s.total != null ? s.total : "—" },
-		{ label: "Success rate", value: s.success_rate != null ? `${s.success_rate}%` : "—" },
-		{ label: "Running now", value: s.running != null ? s.running : "—" },
-		{ label: "Last run", value: s.last_run_at ? timeAgo(s.last_run_at) : "—" },
+		{ label: "Total runs", value: s.total != null ? s.total : "-" },
+		{ label: "Success rate", value: s.success_rate != null ? `${s.success_rate}%` : "-" },
+		{ label: "Running now", value: s.running != null ? s.running : "-" },
+		{ label: "Last run", value: s.last_run_at ? timeAgo(s.last_run_at) : "-" },
 	]
 })
 
-// ── data (monotonic request id — stale responses dropped, like useListPage) ──
+// ── data (monotonic request id - stale responses dropped, like useListPage) ──
 let reqId = 0
 
 // mode: "reset" (page 1, replaces) | "more" (appends) | "keep" (silent window refetch)

--- a/frontend/src/pages/macros/StepsBuilder.vue
+++ b/frontend/src/pages/macros/StepsBuilder.vue
@@ -100,7 +100,7 @@
 </template>
 
 <script setup>
-// StepsBuilder — the macro steps editor (DESIGN-V3 §6.3): step cards with a
+// StepsBuilder - the macro steps editor (DESIGN-V3 §6.3): step cards with a
 // drag handle (HTML5 drag-reorder, ported from round-2 MacrosView), ↑/↓
 // buttons as the accessible fallback, per-step skills chips + Autocomplete,
 // dashed "Add step" footer. v-model on the steps array; field edits mutate
@@ -118,7 +118,7 @@ const props = defineProps({
 const emit = defineEmits(["update:modelValue"])
 
 // ── per-step skills: own + shared-with-me, enabled only (a disabled skill
-//    can't be invoked — round-2 parity) ────────────────────────────────────────
+//    can't be invoked - round-2 parity) ────────────────────────────────────────
 const skillRows = ref([])
 onMounted(async () => {
 	try {
@@ -166,7 +166,7 @@ function removeStep(si) {
 	if ((st.prompt || "").trim()) {
 		confirmDialog({
 			title: "Remove step?",
-			message: `Step ${si + 1} has a prompt — remove it anyway?`,
+			message: `Step ${si + 1} has a prompt - remove it anyway?`,
 			onConfirm: ({ hideDialog }) => {
 				doRemove()
 				hideDialog()
@@ -198,7 +198,7 @@ function onDragStart(si, e) {
 		try {
 			e.dataTransfer.setData("text/plain", String(si))
 		} catch (err) {
-			// some browsers throw on setData for non-standard types — ignore
+			// some browsers throw on setData for non-standard types - ignore
 		}
 	}
 }

--- a/frontend/src/pages/skills/AnalysisTab.vue
+++ b/frontend/src/pages/skills/AnalysisTab.vue
@@ -230,7 +230,7 @@
 </template>
 
 <script setup>
-// AnalysisTab — the pattern-learning settings + run telemetry, the "Analysis"
+// AnalysisTab - the pattern-learning settings + run telemetry, the "Analysis"
 // tab inside the Skills page (Skills IA v2). Split out of the old LearningTab:
 // this file owns the Settings card (enable / window / max proposals / Save),
 // the Run-now control (top-right, confirm popup, dynamic first-run label) and

--- a/frontend/src/pages/skills/BusinessTab.vue
+++ b/frontend/src/pages/skills/BusinessTab.vue
@@ -30,7 +30,7 @@
 							Tell Jarvis about your business
 						</div>
 						<div class="mt-0.5 text-sm text-ink-gray-6">
-							Record or type notes about how your business runs — Jarvis processes them daily
+							Record or type notes about how your business runs - Jarvis processes them daily
 							into learned defaults and wiki knowledge it uses in chat.
 						</div>
 
@@ -48,7 +48,7 @@
 						<div class="mt-4">
 							<VoiceRecorder v-if="status.stt_enabled" @transcript="onTranscript" />
 							<span v-else-if="status.loaded" class="text-sm text-ink-gray-5">
-								Voice transcription isn't enabled on this site — type your note below.
+								Voice transcription isn't enabled on this site - type your note below.
 							</span>
 						</div>
 
@@ -110,9 +110,9 @@
 </template>
 
 <script setup>
-// BusinessTab — the "Business" tab inside the Skills page, now two panes:
+// BusinessTab - the "Business" tab inside the Skills page, now two panes:
 // left is the capture card (record/type voice notes about how the business
-// runs — processed daily by the voice-facts worker), right is NotesPane
+// runs - processed daily by the voice-facts worker), right is NotesPane
 // (search / status filter / paginate / edit-while-New / delete your own
 // notes; the SM "Process notes now" control and sweep telemetry moved into
 // that pane's header). The org wiki lives on the Wiki tab (WikiTab.vue); a
@@ -174,7 +174,7 @@ async function loadStatus() {
 		status.loaded = true
 	} catch (e) {
 		// parent mounts this only after the same probe succeeded; a failure here
-		// is transient — the page stays usable (textarea + notes still load)
+		// is transient - the page stays usable (textarea + notes still load)
 		status.loaded = true
 	}
 }
@@ -201,7 +201,7 @@ async function saveNote() {
 	try {
 		await saveVoiceNote({ transcript, context_type: "Business", source: "Business Tab" })
 		draft.value = ""
-		toast.success("Saved — processed daily")
+		toast.success("Saved - processed daily")
 		notesPane.value?.reload()
 		loadStatus()
 	} catch (e) {
@@ -213,7 +213,7 @@ async function saveNote() {
 
 function confirmDiscardDraft() {
 	// a tiny draft clears instantly; anything substantial (possibly minutes of
-	// dictation) gets a confirm — Discard sits right next to Save
+	// dictation) gets a confirm - Discard sits right next to Save
 	if (draft.value.trim().length <= 15) {
 		draft.value = ""
 		return
@@ -230,7 +230,7 @@ function confirmDiscardDraft() {
 
 // ── org wiki pointer ─────────────────────────────────────────────────────────
 function goToWiki() {
-	// hash swap on the same /skills route — SkillsPage's hash watcher flips the tab
+	// hash swap on the same /skills route - SkillsPage's hash watcher flips the tab
 	router.push({ hash: "#wiki" })
 }
 

--- a/frontend/src/pages/skills/ReviewTab.vue
+++ b/frontend/src/pages/skills/ReviewTab.vue
@@ -73,7 +73,7 @@
 						/>
 					</div>
 
-					<!-- pane header: honest math up front — the tab badge counts surfaced
+					<!-- pane header: honest math up front - the tab badge counts surfaced
 					     proposals only, but queued rows are fully actionable here too, so
 					     both numbers are said out loud (site-wide, filter-independent) -->
 					<div class="flex flex-wrap items-center justify-between gap-2">
@@ -180,19 +180,19 @@
 							<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0" />
 							<span>
 								Rows marked <b>B</b> contain exact text every chat user on this
-								site can read once approved — expand a row for its role details.
+								site can read once approved - expand a row for its role details.
 							</span>
 						</div>
 						<template v-for="group in rowGroups" :key="group.key">
 							<!-- queued divider: not-yet-surfaced Proposed rows ride the same
 							     fetch (surfaced=all, partitioned client-side) and keep full
-							     actions — no separate "Review them now" detour anymore -->
+							     actions - no separate "Review them now" detour anymore -->
 							<div
 								v-if="group.key === 'queued'"
 								class="mt-1 flex items-center gap-2 text-sm text-ink-gray-5"
 							>
 								<span class="h-px flex-1 border-t"></span>
-								<span>Queued — surfaces after the next analysis run</span>
+								<span>Queued - surfaces after the next analysis run</span>
 								<span class="h-px flex-1 border-t"></span>
 							</div>
 
@@ -334,7 +334,7 @@
 											v-if="expanded[row.name].detector_id === 'voice-context'"
 											class="text-sm text-ink-gray-6"
 										>
-											From spoken or written business notes — table statistics don't
+											From spoken or written business notes - table statistics don't
 											apply to this kind of insight.
 										</div>
 										<!-- raw stats -->
@@ -587,7 +587,7 @@
 						v-if="boardStatus === 'Proposed' && queuedCount > 0 && !queuedVisible"
 						class="text-sm text-ink-gray-5"
 					>
-						{{ queuedCount }} queued proposal{{ queuedCount === 1 ? "" : "s" }} site-wide —
+						{{ queuedCount }} queued proposal{{ queuedCount === 1 ? "" : "s" }} site-wide -
 						they surface after the next analysis run.<template v-if="board.hasMore">
 							Load more to see them here.</template
 						>
@@ -719,7 +719,7 @@
 										v-if="dExpanded[row.name].detector_id === 'voice-context'"
 										class="text-sm text-ink-gray-6"
 									>
-										From spoken or written business notes — table statistics don't
+										From spoken or written business notes - table statistics don't
 										apply to this kind of insight.
 									</div>
 									<div v-else class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
@@ -857,7 +857,7 @@
 		>
 			<template #body-content>
 				<p class="text-sm text-ink-gray-6">
-					Rejected patterns are hidden but reversible — you can restore them from the Rejected
+					Rejected patterns are hidden but reversible - you can restore them from the Rejected
 					filter later.
 				</p>
 				<FormControl
@@ -890,7 +890,7 @@
 		>
 			<template #body-content>
 				<p class="text-sm text-ink-gray-6">
-					Your edit is used verbatim in the compiled skill. The evidence line stays frozen — it
+					Your edit is used verbatim in the compiled skill. The evidence line stays frozen - it
 					still reflects the originally detected pattern, which was not re-measured.
 				</p>
 				<FormControl
@@ -959,7 +959,7 @@
 			</template>
 		</Dialog>
 
-		<!-- Apply-insight-to-skill modal (D5): self-contained — drafts an LLM
+		<!-- Apply-insight-to-skill modal (D5): self-contained - drafts an LLM
 		     skill update for a B/C insight and applies it on confirm (the server
 		     marks the pattern acknowledged with an applied-to-skill note); the
 		     board only opens it and refreshes on completion. -->
@@ -972,9 +972,9 @@
 </template>
 
 <script setup>
-// ReviewTab — the pattern decision queue, the "Review" tab inside the Skills
+// ReviewTab - the pattern decision queue, the "Review" tab inside the Skills
 // page (Skills IA v2). Two panes at xl+ (stacked below): LEFT "To review" owns
-// the Apply bar (learned skills ride the shared custom-skill push — the
+// the Apply bar (learned skills ride the shared custom-skill push - the
 // SyncPill pattern), a debounced search + status select, domain facet chips,
 // the review board of plain-English cards with strength/sensitivity chips,
 // caveat badges, an expandable drill-down (raw stats + roles + compiled bullet
@@ -985,7 +985,7 @@
 // surfaced rows only. RIGHT "Decided" is a compact log (view="decided"):
 // one-line rows (excerpt + disposition badge + who/when) with its own search /
 // disposition / newest-oldest sort and click-to-expand drill-down. Each
-// actionable row gets "Discuss in chat" — a prefilled prompt stashed via
+// actionable row gets "Discuss in chat" - a prefilled prompt stashed via
 // chatPrefill with autoSend, so ChatView opens a FRESH conversation and sends
 // it as the first message. Both fetchers use the useListPage monotonic-reqId
 // guard so reset/load-more/search races never interleave. Settings + run
@@ -1043,7 +1043,7 @@ const STATUS_OPTIONS = [
 	{ label: "Rejected", value: "Rejected" },
 	{ label: "All", value: "All" },
 ]
-// Decided-log disposition filter — server-validated slugs (decided view only).
+// Decided-log disposition filter - server-validated slugs (decided view only).
 const DISPOSITION_OPTIONS = [
 	{ label: "All", value: "" },
 	{ label: "Approved", value: "approved" },
@@ -1111,7 +1111,7 @@ const decided = reactive({
 })
 
 const expanded = reactive({}) // board drill-down: name -> detail | "loading"
-// Decided drill-down cache — separate from `expanded` so a pattern visible in
+// Decided drill-down cache - separate from `expanded` so a pattern visible in
 // both panes at once never couples its open/close state across surfaces.
 const dExpanded = reactive({}) // name -> detail | "loading"
 const selected = ref(new Set())
@@ -1219,7 +1219,7 @@ function deskUrl(doctype, name) {
 	const dt = String(doctype).toLowerCase().replace(/ /g, "-")
 	return `/app/${dt}/${encodeURIComponent(name)}`
 }
-// exceptions items may be strings or {doctype,name,label,...} — render defensively
+// exceptions items may be strings or {doctype,name,label,...} - render defensively
 function exLabel(ex) {
 	if (ex == null) return ""
 	if (typeof ex === "string") return ex
@@ -1254,7 +1254,7 @@ const hasActionableB = computed(() =>
 
 // The pane-header "N to review": surfaced Proposed = review_activity.total
 // (surfaced ∈ Proposed/Approved/Rejected/Snoozed) minus .decided (the latter
-// three) — the same number the tab badge shows, kept honest next to the
+// three) - the same number the tab badge shows, kept honest next to the
 // site-wide queued count.
 const toReviewCount = computed(() =>
 	Math.max((reviewActivity.value.total || 0) - (reviewActivity.value.decided || 0), 0)
@@ -1270,10 +1270,10 @@ const emptyTitle = computed(() => {
 })
 const emptyDescription = computed(() => {
 	if (boardSearch.value.trim())
-		return "Nothing matches your search — try different words or clear it."
+		return "Nothing matches your search - try different words or clear it."
 	if (boardStatus.value === "Proposed") {
 		if (queuedCount.value > 0)
-			return `Nothing under this filter — ${queuedCount.value} queued site-wide. Queued proposals appear in this list; try clearing the domain filter.`
+			return `Nothing under this filter - ${queuedCount.value} queued site-wide. Queued proposals appear in this list; try clearing the domain filter.`
 		return status.enabled
 			? "Proposals appear the morning after an analysis run."
 			: "Enable behavioural learning on the Analysis tab, then run an analysis to see proposals."
@@ -1303,8 +1303,8 @@ function mergeRows(prev, next, append) {
 	return [...prev, ...next.filter((r) => !seen.has(r.name))]
 }
 
-// monotonic request ids (the useListPage idiom): a reset racing a load-more —
-// or two debounced searches — must not interleave; stale responses are dropped.
+// monotonic request ids (the useListPage idiom): a reset racing a load-more -
+// or two debounced searches - must not interleave; stale responses are dropped.
 let boardReq = 0
 async function fetchBoard(mode = "reset") {
 	const id = ++boardReq
@@ -1322,7 +1322,7 @@ async function fetchBoard(mode = "reset") {
 			start: append ? board.rows.length : 0,
 			page_length: 20,
 		})
-		if (id !== boardReq) return // stale — a newer request superseded this one
+		if (id !== boardReq) return // stale - a newer request superseded this one
 		board.rows = mergeRows(board.rows, res.rows || [], append)
 		board.total = res.total || 0
 		board.hasMore = !!res.has_more
@@ -1356,7 +1356,7 @@ async function fetchDecided(mode = "reset") {
 			start: append ? decided.rows.length : 0,
 			page_length: 20,
 		})
-		if (id !== decidedReq) return // stale — a newer request superseded this one
+		if (id !== decidedReq) return // stale - a newer request superseded this one
 		decided.rows = mergeRows(decided.rows, res.rows || [], append)
 		decided.total = res.total || 0
 		decided.hasMore = !!res.has_more
@@ -1395,7 +1395,7 @@ function toggleDecidedSort() {
 	fetchDecided("reset")
 }
 
-// debounced searches (300ms — the NotesPane / useListPage idiom)
+// debounced searches (300ms - the NotesPane / useListPage idiom)
 let boardSearchTimer = null
 watch(boardSearch, () => {
 	clearTimeout(boardSearchTimer)
@@ -1442,7 +1442,7 @@ async function toggleDecidedExpand(name) {
 // Builds a prefilled prompt (pattern statement + evidence excerpt + suggested
 // instruction + the weigh-it ask) and stashes it via the chatPrefill composable
 // with autoSend: ChatView opens a FRESH conversation and sends it as the first
-// message — the drafted prompt never lands in an old thread's composer. Uses
+// message - the drafted prompt never lands in an old thread's composer. Uses
 // the drill-down detail when it is already loaded; falls back to card fields
 // (no extra fetch).
 function buildDiscussPrompt(row, detail) {

--- a/frontend/src/pages/skills/ShareDialog.vue
+++ b/frontend/src/pages/skills/ShareDialog.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-// ShareDialog — skill sharing manager (DESIGN-V3 §6.2; round-2 semantics
+// ShareDialog - skill sharing manager (DESIGN-V3 §6.2; round-2 semantics
 // ported): search over listShareableUsers, checked rows + selected chips,
 // Save replaces the whole share list via shareCustomSkill (replace semantics).
 import { ref, computed, watch } from "vue"

--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -40,7 +40,7 @@
 						:disabled="!isNew || saving"
 						:description="
 							isNew
-								? `Lowercase letters, digits and hyphens — trigger it in chat with /${form.skill_name || 'name'}.`
+								? `Lowercase letters, digits and hyphens - trigger it in chat with /${form.skill_name || 'name'}.`
 								: 'Skill names can\'t be changed after creation.'
 						"
 						@update:modelValue="(v) => (form.skill_name = v)"
@@ -119,7 +119,7 @@
 				</template>
 			</DocMetaPanel>
 
-			<!-- shared-with-me: read-only info card (no docmeta — the docmeta read
+			<!-- shared-with-me: read-only info card (no docmeta - the docmeta read
 			     gate covers owner/SM/DocShare only; child-table shares would 403) -->
 			<div v-else-if="skill && !canEdit" class="m-5 space-y-3 rounded-md border p-4">
 				<div class="flex items-center gap-2">
@@ -127,7 +127,7 @@
 					<div class="text-base font-medium text-ink-gray-8">{{ sharedBy || "Another user" }}</div>
 				</div>
 				<div class="text-sm text-ink-gray-5">
-					Shared with you · read-only. Use /{{ form.skill_name }} in chat — you can’t edit or
+					Shared with you · read-only. Use /{{ form.skill_name }} in chat - you can’t edit or
 					re-share it.
 				</div>
 				<div v-if="skill.modified" class="text-sm text-ink-gray-5">
@@ -265,7 +265,7 @@ async function init() {
 		seed(full)
 		if (full.can_edit) {
 			docmeta.value = useDocmeta(DOCTYPE, props.id)
-			// created outside setup (async load / post-create replace) — fetch
+			// created outside setup (async load / post-create replace) - fetch
 			// explicitly rather than relying on the composable's auto-load
 			if (docmeta.value && typeof docmeta.value.reload === "function") docmeta.value.reload()
 			loadShares()

--- a/frontend/src/pages/skills/SkillsList.vue
+++ b/frontend/src/pages/skills/SkillsList.vue
@@ -46,7 +46,7 @@
 				<div class="truncate text-base font-medium text-ink-gray-9">{{ row.skill_name }}</div>
 				<Tooltip
 					v-if="row.scope === 'Personal'"
-					text="Personal skill — only you; never pushed to the shared assistant"
+					text="Personal skill - only you; never pushed to the shared assistant"
 				>
 					<Badge variant="subtle" theme="green" label="Personal" />
 				</Tooltip>
@@ -68,7 +68,7 @@
 					theme="gray"
 					:label="`${row.shared_count} user${row.shared_count === 1 ? '' : 's'}`"
 				/>
-				<span v-else class="text-base text-ink-gray-4">—</span>
+				<span v-else class="text-base text-ink-gray-4">-</span>
 			</div>
 		</template>
 
@@ -97,7 +97,7 @@
 </template>
 
 <script setup>
-// Skills list — DESIGN-V3 §5.6: scope/enabled quick filters, sync-pill banner
+// Skills list - DESIGN-V3 §5.6: scope/enabled quick filters, sync-pill banner
 // (apply pipeline status, 3s poll while pending), bulk delete with skip
 // reasons (owner-only rows), rows → /skills/:id, New Skill → /skills/new.
 import { ref } from "vue"
@@ -180,7 +180,7 @@ const {
 	loadMore,
 } = useListPage({
 	fetchFn: (p) => {
-		// the backend whitelists filter keys and throws on "search" — strip it
+		// the backend whitelists filter keys and throws on "search" - strip it
 		// out of filters and send it as the envelope's search param instead
 		const { search: q, ...rest } = p.filters || {}
 		return api.listCustomSkillsPage({ ...p, search: q || p.search || "", filters: rest })
@@ -220,7 +220,7 @@ function bulkDelete(selections, unselectAll) {
 				unselectAll()
 				hideDialog()
 				resetLoad()
-				// the server enqueued one skills-apply at the end (§8.3) — show it
+				// the server enqueued one skills-apply at the end (§8.3) - show it
 				syncPill.value && syncPill.value.checkNow()
 			} catch (e) {
 				toast.error(errMsg(e))

--- a/frontend/src/pages/skills/SkillsPage.vue
+++ b/frontend/src/pages/skills/SkillsPage.vue
@@ -6,7 +6,7 @@
 		     both probes see exactly today's Skills list with no tab chrome (zero
 		     regression). The active tab stays "skills" until a probe lands, so
 		     SkillsList mounts once and is NOT remounted when the strip later
-		     appears — only clicking another tab swaps the body (v-if so exactly
+		     appears - only clicking another tab swaps the body (v-if so exactly
 		     one LayoutHeader teleports to #app-header at a time, the Macros-page
 		     precedent). -->
 		<TabBar
@@ -34,18 +34,18 @@
 </template>
 
 <script setup>
-// SkillsPage — the routed component for /skills (plan §6.4, owner-mandated):
+// SkillsPage - the routed component for /skills (plan §6.4, owner-mandated):
 // wraps the existing Skills list in a hash-synced tab shell (mirrors the
 // Agents page). Tab "Skills" renders SkillsList.vue unchanged; tab "Business"
 // (#business) renders the voice-notes capture + notes surface; tab "Wiki"
 // (#wiki) renders the scope-aware org wiki; tab "Analysis" (#analysis) renders
 // the pattern-learning settings + run telemetry; tab "Review" (#review)
 // renders the pattern decision queue + decided log. Analysis and Review are
-// offered to System Managers only — get_learning_status is the SM probe (it
-// throws for everyone else). Business and Wiki are offered to any desk user —
+// offered to System Managers only - get_learning_status is the SM probe (it
+// throws for everyone else). Business and Wiki are offered to any desk user -
 // get_business_status is the probe (403s for portal users), so the strip
 // stays hidden for them and the page behaves exactly as before.
-// "#learning" (the old combined tab) redirects to "#review" — muscle memory
+// "#learning" (the old combined tab) redirects to "#review" - muscle memory
 // and old deep links keep landing somewhere sensible.
 import { ref, computed, onMounted, watch } from "vue"
 import { useRoute, useRouter } from "vue-router"
@@ -69,7 +69,7 @@ const activeTab = ref("skills")
 const tabs = computed(() => {
 	const t = [{ label: "Skills", value: "skills" }]
 	if (isSM.value || businessAllowed.value) {
-		// any desk user passes the Business probe — Wiki rides the same gate
+		// any desk user passes the Business probe - Wiki rides the same gate
 		// (no extra probe; portal/guest sessions never see the strip at all)
 		t.push({ label: "Business", value: "business" })
 		t.push({ label: "Wiki", value: "wiki" })
@@ -83,13 +83,13 @@ const tabs = computed(() => {
 
 // hash-synced tabs (Agents precedent; no hash = Skills). "#analysis"/"#review"
 // only resolve once we know the viewer is an SM, and "#business"/"#wiki" once
-// a probe has confirmed access — an unauthorized deep link falls back to the
+// a probe has confirmed access - an unauthorized deep link falls back to the
 // Skills tab. "#learning" is the pre-split name for the combined board; it
 // redirects (replace, so back doesn't loop) to "#review".
 // "#skills" is intentionally never used (the router keeps that legacy chat
 // deep-link mapping /jarvis/#skills → /skills untouched).
 function applyHash() {
-	// tolerate suffixed forms like "#wiki?page=x" — land on the right tab
+	// tolerate suffixed forms like "#wiki?page=x" - land on the right tab
 	// instead of silently falling through to Skills
 	const h = (route.hash || "").replace(/^#/, "").split("?")[0]
 	if ((h === "review" || h === "analysis") && isSM.value) activeTab.value = h
@@ -128,7 +128,7 @@ async function refreshBadge() {
 
 onMounted(async () => {
 	// both probes in parallel, but flip the refs together only after BOTH have
-	// settled — otherwise the strip could show [Skills, Business] and the later
+	// settled - otherwise the strip could show [Skills, Business] and the later
 	// probe would visibly append tabs. The strip goes straight from hidden to
 	// its final stable order, and applyHash resolves any deep-linked
 	// #analysis/#review/#learning/#business at that same instant.

--- a/frontend/src/pages/skills/SyncPill.vue
+++ b/frontend/src/pages/skills/SyncPill.vue
@@ -25,14 +25,14 @@
 </template>
 
 <script setup>
-// SyncPill — shared skills-apply status pill (DESIGN-V3 §5.6 + §6.2): shown by
+// SyncPill - shared skills-apply status pill (DESIGN-V3 §5.6 + §6.2): shown by
 // the Skills list banner and the skill detail header. Polls
 // getCustomSkillsSyncStatus every 3s while an apply is pending; a failed apply
 // turns the pill red with a Retry ghost button (applyCustomSkills).
 // Exposed API:
-//   apply()    — trigger an apply then poll (save/delete flows; those
+//   apply()    - trigger an apply then poll (save/delete flows; those
 //                endpoints don't enqueue an apply on their own)
-//   checkNow() — read the status and poll if pending (bulk delete — the
+//   checkNow() - read the status and poll if pending (bulk delete - the
 //                server already enqueued the apply, §8.3)
 import { ref, computed, onMounted, onBeforeUnmount } from "vue"
 import { Badge, Button, Tooltip, LoadingIndicator, toast } from "frappe-ui"

--- a/frontend/src/pages/skills/WikiTab.vue
+++ b/frontend/src/pages/skills/WikiTab.vue
@@ -63,7 +63,7 @@
 										Last synced {{ timeAgo(caps.wiki_mirror_last_synced_at) }}<span
 											v-if="caps.wiki_mirror_last_sync_status"
 										>
-											— {{ caps.wiki_mirror_last_sync_status }}</span
+											- {{ caps.wiki_mirror_last_sync_status }}</span
 										>
 									</template>
 									<template v-else>Not synced yet.</template>
@@ -81,7 +81,7 @@
 									Last health check {{ timeAgo(caps.wiki_lint_last_run_at) }}<span
 										v-if="caps.wiki_lint_summary"
 									>
-										— {{ caps.wiki_lint_summary }}</span
+										- {{ caps.wiki_lint_summary }}</span
 									>
 								</template>
 								<template v-else>Health check hasn't run yet.</template>
@@ -102,7 +102,7 @@
 			     the empty state, which real first-visits on a grown wiki never see -->
 			<template #banner>
 				<p class="mb-2 text-p-sm text-ink-gray-5">
-					The wiki is the knowledge Jarvis keeps about your business — customers,
+					The wiki is the knowledge Jarvis keeps about your business - customers,
 					suppliers, processes, conventions. It grows from chat and voice notes;
 					Jarvis cites it when answering.
 				</p>
@@ -279,7 +279,7 @@
 </template>
 
 <script setup>
-// WikiTab — the "Wiki" tab inside the Skills page (design D4): the org-wide
+// WikiTab - the "Wiki" tab inside the Skills page (design D4): the org-wide
 // knowledge base Jarvis maintains, now scope-aware (Org / Role / User pages,
 // server-side visibility). Standard ListPage + useListPage kit (FilesList
 // precedent): server pagination, debounced search, scope / type / attention
@@ -362,14 +362,14 @@ function typeLabel(t) {
 }
 // one-line explanations for the create dialog's Type select
 const TYPE_HELP = {
-	Customer: "One specific customer's quirks — payment habits, contacts, gotchas.",
-	Supplier: "One specific supplier's quirks — lead times, terms, who to call.",
-	Item: "One item or item group — variants, storage, known issues.",
-	Process: "A procedure as your org actually runs it — steps, owners, exceptions.",
+	Customer: "One specific customer's quirks - payment habits, contacts, gotchas.",
+	Supplier: "One specific supplier's quirks - lead times, terms, who to call.",
+	Item: "One item or item group - variants, storage, known issues.",
+	Process: "A procedure as your org actually runs it - steps, owners, exceptions.",
 	Doctype: "Org-wide conventions on a document type, e.g. Sales Invoice habits.",
 	Exception: "A known edge case or standing workaround.",
 	Integration: "An external system your org connects to and its rules.",
-	People: "Who does what — approvers, escalation paths, contacts.",
+	People: "Who does what - approvers, escalation paths, contacts.",
 	Org: "General org-level facts that fit nowhere else.",
 }
 const LANGUAGE_OPTIONS = [
@@ -377,9 +377,9 @@ const LANGUAGE_OPTIONS = [
 	{ label: "Original language", value: "Original" },
 ]
 const SCOPE_LABELS = {
-	Org: "Org — visible to everyone",
-	Role: "Role — people holding a role",
-	User: "Personal — just me",
+	Org: "Org - visible to everyone",
+	Role: "Role - people holding a role",
+	User: "Personal - just me",
 }
 
 const columns = [
@@ -447,7 +447,7 @@ const emptyState = computed(() => {
 			icon: "book-open",
 			title: "No personal pages yet",
 			description:
-				'Personal pages are knowledge only you and Jarvis share — shortcuts, ' +
+				'Personal pages are knowledge only you and Jarvis share - shortcuts, ' +
 				'preferences, your own working notes. Use "New page" and pick the ' +
 				'Personal scope to create your first one.',
 		}
@@ -461,7 +461,7 @@ const emptyState = computed(() => {
 		icon: "book-open",
 		title: "No wiki pages yet",
 		description:
-			"The wiki is the knowledge base Jarvis keeps about your business — customers, " +
+			"The wiki is the knowledge base Jarvis keeps about your business - customers, " +
 			"suppliers, items and processes. It grows on its own as people answer chat " +
 			"nudges and record voice notes on the Business tab; pages appear here as " +
 			"Jarvis learns.",
@@ -469,8 +469,8 @@ const emptyState = computed(() => {
 })
 
 function scopeTooltip(row) {
-	if (row.scope === "Role") return `Visible to people with role: ${row.target_role || "—"}`
-	if (row.scope === "User") return `Personal page — visible only to ${row.target_user || "its owner"}`
+	if (row.scope === "Role") return `Visible to people with role: ${row.target_role || "-"}`
+	if (row.scope === "User") return `Personal page - visible only to ${row.target_user || "its owner"}`
 	return "Visible to everyone"
 }
 
@@ -513,7 +513,7 @@ function openPage(slug) {
 }
 
 // ── row actions (archive / restore / delete) ─────────────────────────────────
-// slug of the row with an in-flight lifecycle call — one at a time is plenty
+// slug of the row with an in-flight lifecycle call - one at a time is plenty
 const rowBusy = ref("")
 function rowSlug(row) {
 	return row.slug || row.name
@@ -554,7 +554,7 @@ function confirmDelete(row) {
 	confirmDialog({
 		title: "Delete this page permanently?",
 		message:
-			"Permanently deletes this page — archiving keeps it recoverable. This cannot be undone.",
+			"Permanently deletes this page - archiving keeps it recoverable. This cannot be undone.",
 		onConfirm: async ({ hideDialog }) => {
 			hideDialog()
 			await runRowAction(row, deleteWikiPage, "Page deleted")
@@ -581,7 +581,7 @@ const roleSelectOptions = computed(() =>
 	(caps.manageable_roles || []).map((r) => ({ label: r, value: r }))
 )
 // Preview of the server-derived slug (`<type>--<scrubbed-title>` plus the
-// controller's audience suffix for non-Org scopes) — mirror it fully so the
+// controller's audience suffix for non-Org scopes) - mirror it fully so the
 // preview never lies about the final page id.
 const scrub = (s) =>
 	String(s || "")

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -25,7 +25,7 @@ const routes = [
 		component: () => import("@/pages/skills/SkillDetail.vue"),
 		props: true,
 	},
-	// Account: plan/billing + AI models editor + connection/usage summaries —
+	// Account: plan/billing + AI models editor + connection/usage summaries -
 	// System-Manager only; guard redirects others to Chat.
 	{
 		path: "/account",
@@ -33,7 +33,7 @@ const routes = [
 		component: () => import("@/views/AccountView.vue"),
 		beforeEnter: (to, from, next) => { next(window.is_system_manager ? undefined : { name: "Chat" }) },
 	},
-	// First-run wizard (managed signup or self-hosted connect) — System-Manager
+	// First-run wizard (managed signup or self-hosted connect) - System-Manager
 	// only; guard redirects others to Chat. Reached via the chat welcome card
 	// or the desk banner, not a forced redirect (see beforeEach below).
 	{
@@ -41,11 +41,11 @@ const routes = [
 		name: "Onboarding",
 		component: () => import("@/views/OnboardingView.vue"),
 		// Chrome-less: a first-run customer hasn't onboarded yet, so the full app
-		// sidebar/header (Chat/Skills/Macros/…) is noise — AppShell hides them.
+		// sidebar/header (Chat/Skills/Macros/…) is noise - AppShell hides them.
 		meta: { chromeless: true },
 		beforeEnter: (to, from, next) => { next(window.is_system_manager ? undefined : { name: "Chat" }) },
 	},
-	// Usage dashboard (moved out of the old /ai shell) — System-Manager only;
+	// Usage dashboard (moved out of the old /ai shell) - System-Manager only;
 	// guard redirects others to Chat.
 	{
 		path: "/monitor",
@@ -75,7 +75,7 @@ const routes = [
 	{ path: "/files", name: "FilesList", component: () => import("@/pages/files/FilesList.vue") },
 	// §15.2: both approval routes render the two-pane board (the :id row is
 	// selected in place); names kept so nav highlighting + router.push targets
-	// keep working. The board reads route.params itself — no props.
+	// keep working. The board reads route.params itself - no props.
 	{
 		path: "/approvals",
 		name: "ApprovalsList",
@@ -87,7 +87,7 @@ const routes = [
 		component: () => import("@/pages/approvals/ApprovalsBoard.vue"),
 	},
 	{ path: "/agents", name: "AgentsList", component: () => import("@/pages/agents/AgentsList.vue") },
-	// Legacy round-2 tab routes — static, registered BEFORE :slug (§9). Point at
+	// Legacy round-2 tab routes - static, registered BEFORE :slug (§9). Point at
 	// the current hash-tabs (mine→Installed, activity→Activity); admin is now a
 	// per-agent detail tab, so it falls back to the catalog.
 	{ path: "/agents/mine", redirect: "/agents#installed" },
@@ -109,7 +109,7 @@ const router = createRouter({
 
 // First-run guard: bounce a fully-onboarded user away from a stale
 // /onboarding link back to Chat. The readiness check hits the backend once
-// per page load — `readyPromise` caches the in-flight/resolved call so
+// per page load - `readyPromise` caches the in-flight/resolved call so
 // repeated client-side navigations (Chat -> Account -> Chat, etc.) don't
 // re-fire it. Fail-open: if the backend call throws, treat the app as ready
 // so a flaky check never strands the user unable to reach Chat.
@@ -119,7 +119,7 @@ router.beforeEach(async (to) => {
 		readyPromise = isReadyForChat().catch(() => ({ ready: true }))
 	}
 	const ready = isOnboardComplete(await readyPromise)
-	// We no longer force not-ready users into the wizard — onboarding is now
+	// We no longer force not-ready users into the wizard - onboarding is now
 	// invited via the chat welcome card (below) + the desk banner. Only bounce a
 	// fully-onboarded user away from a stale /onboarding link.
 	if (ready && to.name === "Onboarding") {

--- a/frontend/src/socket.js
+++ b/frontend/src/socket.js
@@ -11,7 +11,7 @@ export function initSocket() {
 	// Follow the page's own scheme instead of assuming https on portless
 	// pages: an http-only deployment (e.g. a bench exposed on port 80
 	// before TLS is set up) otherwise dials wss://host:443, which isn't
-	// listening — the socket never connects and chat only renders after a
+	// listening - the socket never connects and chat only renders after a
 	// reload. With an explicit port (local dev) the socketio process is
 	// plain http, as before.
 	const protocol = port ? "http" : window.location.protocol.replace(":", "")

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -1,4 +1,4 @@
-// Shared shell state (DESIGN-V3 §4) — a module-scope singleton, house style
+// Shared shell state (DESIGN-V3 §4) - a module-scope singleton, house style
 // (no pinia). The shell (Sidebar/UserMenu/palette) and ChatView both consume
 // it; write ownership is split by contract:
 //   - only ChatView writes currentConvId / streamingConvId
@@ -26,7 +26,7 @@ const pendingNewChat = ref(false) // consumed + cleared by ChatView
 const paletteOpen = ref(false)
 
 // Sidebar collapse: persisted preference (same localStorage key/values as
-// today — existing prefs survive, D5) + a non-persisted narrow-screen
+// today - existing prefs survive, D5) + a non-persisted narrow-screen
 // override (auto-collapse at ≤820px; manual toggles there are temporary, D8).
 const sidebarPref = useStorage("jarvis-sidebar", "open") // 'open' | 'collapsed'
 const _narrow = ref(false)
@@ -107,7 +107,7 @@ async function toggleStar(name) {
 	const conv = conversations.value.find((c) => c.name === name)
 	if (!conv) return
 	const next = conv.starred ? 0 : 1
-	conv.starred = next // optimistic — regroups instantly
+	conv.starred = next // optimistic - regroups instantly
 	try {
 		await api.setStar(name, next)
 	} catch (e) {
@@ -128,21 +128,21 @@ async function archiveConversation(name) {
 	}
 }
 
-// D10 — New Chat from any route: one mechanism for on-chat and cross-route.
+// D10 - New Chat from any route: one mechanism for on-chat and cross-route.
 function requestNewChat(router) {
 	pendingNewChat.value = true
 	const name = router.currentRoute.value.name
 	if (name !== "Chat" && name !== "Conversation") router.push({ name: "Chat" })
 }
 
-// D9 — settings dialog lives inside ChatView; reach it from any route.
+// D9 - settings dialog lives inside ChatView; reach it from any route.
 function openSettings(router) {
 	settingsOpen.value = true
 	const name = router.currentRoute.value.name
 	if (name !== "Chat" && name !== "Conversation") router.push({ name: "Chat" })
 }
 
-// ---- socket contract (§14 DA-04) — called by ChatView's handlers only ------
+// ---- socket contract (§14 DA-04) - called by ChatView's handlers only ------
 function applyRemoteRename(name, title) {
 	const conv = conversations.value.find((c) => c.name === name)
 	if (conv && title) conv.title = title

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -61,7 +61,7 @@ function _start() {
 	const mq = window.matchMedia("(prefers-color-scheme: dark)")
 	prefersDark.value = mq.matches
 	mq.addEventListener("change", (e) => { prefersDark.value = e.matches })
-	// Singleton watcher (never stopped — lives for the page's lifetime).
+	// Singleton watcher (never stopped - lives for the page's lifetime).
 	watch(effectiveDark, applyTheme)
 	applyTheme()
 }

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -4,7 +4,7 @@
 // timezone differs from the site's. frappe-ui's dayjsLocal() parses in
 // setConfig("systemTimezone") (fed from get_chat_ui_settings.time_zone in
 // AppShell) and converts to the browser zone; without the config it falls
-// back to plain dayjs() — today's behavior.
+// back to plain dayjs() - today's behavior.
 import { dayjsLocal } from "frappe-ui"
 
 export function timeAgo(d) {

--- a/frontend/src/views/AccountView.vue
+++ b/frontend/src/views/AccountView.vue
@@ -4,7 +4,7 @@
 
 		<!-- Shell-integrated header: teleports into the app shell's #app-header
 		     strip (same "Open ERPNext Desk" button as every other page). There is
-		     no per-view sidebar — the app shell's Sidebar owns navigation, so the
+		     no per-view sidebar - the app shell's Sidebar owns navigation, so the
 		     Account page sits in the same chrome as Agents / Skills / Macros. -->
 		<LayoutHeader>
 			<template #left-header>
@@ -39,7 +39,7 @@
 							</ul>
 						</template>
 
-						<!-- Upgrade / Renew — deep-links to the existing Desk billing flow
+						<!-- Upgrade / Renew - deep-links to the existing Desk billing flow
 							 (Razorpay checkout). No new payment logic in this phase; the
 							 wizard-driven upgrade UI is a Phase-2 item. -->
 						<div v-if="upgradePlans.length" class="jv-acct-upgrades">
@@ -103,7 +103,7 @@
 					</template>
 				</section>
 
-				<!-- ===== Usage (compact — full dashboard lives on the Monitor tab) ===== -->
+				<!-- ===== Usage (compact - full dashboard lives on the Monitor tab) ===== -->
 				<section class="jv-acct-card">
 					<h2>Usage<span v-if="usage.applicable && usage.period" class="jv-acct-sub"> · {{ usage.period }}</span></h2>
 					<div v-if="usageLoading" class="jv-acct-muted">Loading…</div>
@@ -127,7 +127,7 @@ import DirectSubscriptionCard from "@/components/DirectSubscriptionCard.vue"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import { errMessage as errMsg } from "@/lib/errors"
 
-// Theme — shared composable: honours "jarvis-theme" pref, cross-tab sync, OS live.
+// Theme - shared composable: honours "jarvis-theme" pref, cross-tab sync, OS live.
 // (The theme toggle lives in the app shell's UserMenu; this view only needs the
 // palette vars for its .jv-acct-* card styles.)
 const { effectiveDark: dark, paletteVars } = useTheme()
@@ -178,7 +178,7 @@ async function loadAccount() {
 const savedNote = ref("")
 let savedTimer = null
 function onSaved(sync) {
-	savedNote.value = sync && sync.pending ? "Saved — syncing…" : "Saved"
+	savedNote.value = sync && sync.pending ? "Saved - syncing…" : "Saved"
 	clearTimeout(savedTimer)
 	savedTimer = setTimeout(() => { savedNote.value = "" }, 4000)
 }
@@ -195,7 +195,7 @@ const directSub = ref({ is_direct_subscription: false })
 const directSubLoading = ref(true)
 const directSubErr = ref("")
 // "subscription" (direct codex) | "pool" (api-key / multi-model). Defaulted ONCE
-// from the stored config — a direct subscription OR a single-subscription pool
+// from the stored config - a direct subscription OR a single-subscription pool
 // opens on the Chat-subscription tab (so a pooled single sub can switch to
 // direct); everything else opens on the pool editor. After that the user's tab
 // choice sticks across reloads.
@@ -216,7 +216,7 @@ async function loadDirectSub() {
 		}
 	} catch (e) {
 		// Don't silently drop a real direct-subscription tenant onto the empty
-		// pool editor (which has no re-authorize button) — surface a retryable
+		// pool editor (which has no re-authorize button) - surface a retryable
 		// error so they aren't left at a dead end.
 		directSub.value = { is_direct_subscription: false }
 		directSubErr.value = errMsg(e) || "Couldn't load your AI connection."
@@ -238,7 +238,7 @@ const connLoading = ref(true)
 const connErr = ref("")
 const expiresLabel = computed(() => {
 	const ms = conn.value.oauth_expires_at
-	return ms ? new Date(Number(ms)).toLocaleString() : "—"
+	return ms ? new Date(Number(ms)).toLocaleString() : "-"
 })
 async function loadConnection() {
 	if (!isSystemManager) { connLoading.value = false; return }
@@ -266,7 +266,7 @@ async function loadUsage() {
 onMounted(() => {
 	loadAccount()
 	// The Connection card is proxy-only, so fetch its status only once we know
-	// the tenant is a proxy tenant — avoids a wasted (currently failing) admin
+	// the tenant is a proxy tenant - avoids a wasted (currently failing) admin
 	// round-trip on every direct/api_key account load.
 	loadDirectSub().then(() => { if (directSub.value.proxy_active) loadConnection() })
 	loadUsage()
@@ -275,7 +275,7 @@ onMounted(() => {
 
 <style scoped>
 .jv-acct-main {
-	/* Scroll region inside the app shell's flex-col content column — flex:1 +
+	/* Scroll region inside the app shell's flex-col content column - flex:1 +
 	   min-height:0 (NOT height:100vh, which double-scrolls inside the shell). */
 	flex: 1;
 	min-width: 0;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4,14 +4,14 @@
 		<!-- ============ MAIN ============ -->
 		<main style="flex:1;display:flex;flex-direction:column;height:100%;min-width:0;background:var(--surface);">
 			<header style="height:52px;flex:none;border-bottom:1px solid var(--border);display:flex;align-items:center;padding:0 18px;gap:12px;">
-				<!-- (no expand button here — the collapsed rail's top button already expands;
+				<!-- (no expand button here - the collapsed rail's top button already expands;
 				     two visible "Expand sidebar" controls was confusing) -->
 				<div style="display:flex;flex-direction:column;line-height:1.15;min-width:0;">
 					<span style="font-size:14px;font-weight:600;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">{{ currentTitle }}</span>
 					<span style="font-size:11.5px;color:var(--text-3);">{{ headerSub }}</span>
 				</div>
 				<div style="margin-left:auto;display:flex;align-items:center;gap:8px;">
-					<!-- "Go to Desk" — at the rightmost end of the cluster (chat only, via CSS order)
+					<!-- "Go to Desk" - at the rightmost end of the cluster (chat only, via CSS order)
 					     (uniform with LayoutHeader across every page) -->
 					<button class="jv-iconbtn" @click="openErpDesk" title="Open ERPNext Desk" aria-label="Open ERPNext Desk" style="order:99;width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:transparent;border:1px solid var(--border);border-radius:7px;cursor:pointer;">
 						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><path d="M15 3h6v6M10 14 21 3" /></svg>
@@ -82,7 +82,7 @@
 					<div v-if="macroRun && macroRun.conversation === currentId" class="jv-macrobar" :class="{ ok: macroRun.status === 'completed', err: macroRun.status === 'failed', stopped: macroRun.status === 'stopped' }">
 						<template v-if="macroRun.status === 'running'">
 							<span class="jv-macrobar-dot spin"></span>
-							<span class="jv-macrobar-txt">Running macro — step {{ macroRun.step }}/{{ macroRun.total }}<template v-if="macroRun.label">: {{ macroRun.label }}</template></span>
+							<span class="jv-macrobar-txt">Running macro - step {{ macroRun.step }}/{{ macroRun.total }}<template v-if="macroRun.label">: {{ macroRun.label }}</template></span>
 							<button class="jv-macrobar-stop" @click="stopMacro">Stop</button>
 						</template>
 						<template v-else-if="macroRun.status === 'completed'"><span class="jv-macrobar-chip">✓ Macro completed</span></template>
@@ -119,7 +119,7 @@
 							</div>
 							<div style="flex:1;min-width:0;">
 								<!-- Activity: the tool calls (with input + output) that produced
-								     this answer — openclaw-style, collapsible. -->
+								     this answer - openclaw-style, collapsible. -->
 								<div v-if="showActivityDetail && (activityByAssistant[m.name] || []).length" class="jv-activity">
 									<button class="jv-activity-head" @click="toggleActivity(m.name)" :aria-expanded="!!isActivityOpen(m.name)">
 										<svg class="jv-activity-chev" :class="{ open: isActivityOpen(m.name) }" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6" /></svg>
@@ -286,10 +286,10 @@
 											<div v-for="(f, fi) in c.fields" :key="fi" class="jv-card-field"><span class="jv-card-k">{{ f.label }}</span><span class="jv-card-v">{{ f.value }}</span></div>
 										</div>
 									</div>
-									<!-- long lists paginate — an endless horizontal scroll loses your place -->
+									<!-- long lists paginate - an endless horizontal scroll loses your place -->
 									<div v-if="cardsOf(m).cards.length > CARD_PAGE_SIZE" class="jv-cards-pager">
 										<button class="jv-cards-pgbtn" :disabled="cardPageOf(m) === 0" @click="stepCardPage(m, -1)" aria-label="Previous cards">‹</button>
-										<span class="jv-cards-pginfo">{{ cardPageOf(m) * CARD_PAGE_SIZE + 1 }}–{{ Math.min((cardPageOf(m) + 1) * CARD_PAGE_SIZE, cardsOf(m).cards.length) }} of {{ cardsOf(m).cards.length }}</span>
+										<span class="jv-cards-pginfo">{{ cardPageOf(m) * CARD_PAGE_SIZE + 1 }}-{{ Math.min((cardPageOf(m) + 1) * CARD_PAGE_SIZE, cardsOf(m).cards.length) }} of {{ cardsOf(m).cards.length }}</span>
 										<button class="jv-cards-pgbtn" :disabled="(cardPageOf(m) + 1) * CARD_PAGE_SIZE >= cardsOf(m).cards.length" @click="stepCardPage(m, 1)" aria-label="Next cards">›</button>
 									</div>
 								</div>
@@ -419,7 +419,7 @@
 								<button v-if="nudge.mode === 'transcribing'" class="jv-iconbtn jv-micbtn" title="Transcribing…" disabled style="width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:7px;color:var(--text-3);">
 									<svg class="jv-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--blue)" stroke-width="2.4" stroke-linecap="round"><path d="M12 3a9 9 0 1 0 9 9" /></svg>
 								</button>
-								<!-- labeled, unlike the composer's dictate mic 40px below — two
+								<!-- labeled, unlike the composer's dictate mic 40px below - two
 								     identical icon-only mics were indistinguishable at a glance -->
 								<button v-else class="jv-iconbtn jv-micbtn" :class="{ rec: nudge.mode === 'recording' }" :title="nudge.mode === 'recording' ? 'Stop and transcribe' : 'Record a voice note (saved for Jarvis to learn from)'" @click="nudge.mode === 'recording' ? stopNudgeMic() : startNudgeMic()" style="height:28px;display:flex;align-items:center;justify-content:center;gap:5px;background:transparent;border:none;border-radius:7px;cursor:pointer;color:var(--text-3);padding:0 8px;font-size:12.5px;font-weight:600;">
 									<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" /><path d="M19 10v2a7 7 0 0 1-14 0v-2" /><path d="M12 19v3" /></svg>
@@ -586,8 +586,8 @@
 						<template v-if="settingsTab === 'overview'">
 							<div class="jv-set-sec">Connection</div>
 							<div class="jv-set-row"><span>Model</span><b>{{ modelLabel }}</b></div>
-							<div class="jv-set-row"><span>Provider</span><b>{{ ui.llm_provider || "—" }}</b></div>
-							<div class="jv-set-row"><span>Auth mode</span><b>{{ ui.llm_auth_mode || "—" }}</b></div>
+							<div class="jv-set-row"><span>Provider</span><b>{{ ui.llm_provider || "-" }}</b></div>
+							<div class="jv-set-row"><span>Auth mode</span><b>{{ ui.llm_auth_mode || "-" }}</b></div>
 							<div class="jv-set-row"><span>Status</span><b style="color:var(--green);">Live</b></div>
 								<div class="jv-set-sec" style="margin-top:18px;">Behavior</div>
 								<div class="jv-set-row">
@@ -609,11 +609,11 @@
 									<span class="jv-switch-knob"></span>
 								</button>
 							</div>
-							<!-- (the Workspace counts block lived here — removed as noise; the Usage tab has it all) -->
+							<!-- (the Workspace counts block lived here - removed as noise; the Usage tab has it all) -->
 							<div class="jv-set-sec" style="margin-top:18px;display:flex;align-items:center;gap:7px;">Token usage <span class="jv-est">est.</span></div>
-							<div class="jv-set-row"><span>This chat</span><b>{{ usage ? fmtTokens(usage.chat_tokens) : "—" }}</b></div>
-							<div class="jv-set-row"><span>{{ usage ? usage.month_label : "This month" }}</span><b>{{ usage ? fmtTokens(usage.month_tokens) : "—" }}</b></div>
-							<div class="jv-set-row"><span>All time</span><b>{{ usage ? fmtTokens(usage.total_tokens) : "—" }}</b></div>
+							<div class="jv-set-row"><span>This chat</span><b>{{ usage ? fmtTokens(usage.chat_tokens) : "-" }}</b></div>
+							<div class="jv-set-row"><span>{{ usage ? usage.month_label : "This month" }}</span><b>{{ usage ? fmtTokens(usage.month_tokens) : "-" }}</b></div>
+							<div class="jv-set-row"><span>All time</span><b>{{ usage ? fmtTokens(usage.total_tokens) : "-" }}</b></div>
 							<template v-if="usage && usage.budget_monthly">
 								<div class="jv-usage-bar"><div class="jv-usage-fill" :style="{ width: usagePct + '%' }"></div></div>
 								<div class="jv-set-hint">{{ fmtTokens(usage.month_tokens) }} / {{ fmtTokens(usage.budget_monthly) }} this month · {{ usagePct }}%</div>
@@ -633,9 +633,9 @@
 								<div class="jv-stat"><div class="jv-stat-label">Tool calls</div><div class="jv-stat-val">{{ sessionToolCalls }}</div><div class="jv-stat-sub">this session</div></div>
 								<div class="jv-stat"><div class="jv-stat-label">Avg tokens / msg</div><div class="jv-stat-val">{{ avgTokensPerMsg }}</div><div class="jv-stat-sub">this chat</div></div>
 								<div class="jv-stat"><div class="jv-stat-label">Conversations</div><div class="jv-stat-val">{{ convCount }}</div><div class="jv-stat-sub">{{ starredCount }} starred</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">This chat</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.chat_tokens) : "—" }}</div><div class="jv-stat-sub">tokens</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">{{ usage ? usage.month_label : "This month" }}</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.month_tokens) : "—" }}</div><div class="jv-stat-sub">tokens</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">All time</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.total_tokens) : "—" }}</div><div class="jv-stat-sub">tokens</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">This chat</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.chat_tokens) : "-" }}</div><div class="jv-stat-sub">tokens</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">{{ usage ? usage.month_label : "This month" }}</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.month_tokens) : "-" }}</div><div class="jv-stat-sub">tokens</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">All time</div><div class="jv-stat-val">{{ usage ? fmtTokens(usage.total_tokens) : "-" }}</div><div class="jv-stat-sub">tokens</div></div>
 								<div class="jv-stat"><div class="jv-stat-label">Tools</div><div class="jv-stat-val">{{ toolCount }}</div><div class="jv-stat-sub">available</div></div>
 							</div>
 							<template v-if="usage && usage.budget_monthly">
@@ -661,10 +661,10 @@
 						<!-- MACRO RUNS -->
 						<template v-else-if="settingsTab === 'macroruns'">
 							<div class="jv-statgrid">
-								<div class="jv-stat"><div class="jv-stat-label">Total runs</div><div class="jv-stat-val">{{ macroRunStats ? macroRunStats.total : "—" }}</div><div class="jv-stat-sub">all time</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">Success rate</div><div class="jv-stat-val" style="color:var(--green);">{{ macroRunStats && macroRunStats.success_rate != null ? macroRunStats.success_rate + "%" : "—" }}</div><div class="jv-stat-sub">completed ÷ finished</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">Running now</div><div class="jv-stat-val" style="color:var(--blue);">{{ macroRunStats ? macroRunStats.running : "—" }}</div><div class="jv-stat-sub">active</div></div>
-								<div class="jv-stat"><div class="jv-stat-label">Last run</div><div class="jv-stat-val">{{ macroRunStats && macroRunStats.last_run_at ? fmtAgo(macroRunStats.last_run_at) : "—" }}</div><div class="jv-stat-sub">&nbsp;</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">Total runs</div><div class="jv-stat-val">{{ macroRunStats ? macroRunStats.total : "-" }}</div><div class="jv-stat-sub">all time</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">Success rate</div><div class="jv-stat-val" style="color:var(--green);">{{ macroRunStats && macroRunStats.success_rate != null ? macroRunStats.success_rate + "%" : "-" }}</div><div class="jv-stat-sub">completed ÷ finished</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">Running now</div><div class="jv-stat-val" style="color:var(--blue);">{{ macroRunStats ? macroRunStats.running : "-" }}</div><div class="jv-stat-sub">active</div></div>
+								<div class="jv-stat"><div class="jv-stat-label">Last run</div><div class="jv-stat-val">{{ macroRunStats && macroRunStats.last_run_at ? fmtAgo(macroRunStats.last_run_at) : "-" }}</div><div class="jv-stat-sub">&nbsp;</div></div>
 							</div>
 							<div class="jv-runfilters">
 								<div class="jv-seg jv-runchips">
@@ -748,7 +748,7 @@
 			</div>
 		</transition>
 
-		<!-- Artifact preview panel — slides in from the right (PDF in a viewer, Excel as a table) -->
+		<!-- Artifact preview panel - slides in from the right (PDF in a viewer, Excel as a table) -->
 		<transition name="jv-slide">
 			<div v-if="artifact" class="jv-artifact-overlay" @click.self="closeArtifact">
 				<aside class="jv-artifact-panel" ref="artifactPanelEl" tabindex="-1">
@@ -792,7 +792,7 @@
 				</aside>
 			</div>
 		</transition>
-		<!-- Record draft panel — the agent's proposed create/update, fully editable, applied directly -->
+		<!-- Record draft panel - the agent's proposed create/update, fully editable, applied directly -->
 		<transition name="jv-slide">
 			<div v-if="draftPanel" class="jv-artifact-overlay" @click.self="closeDraftPanel">
 				<aside class="jv-artifact-panel jv-draft-panel" tabindex="-1">
@@ -819,7 +819,7 @@
 										<div v-if="draftLink.open && draftLink.key === 'f:' + f.fieldname && draftLink.items.length"
 										     class="jv-action-linkmenu" :class="{ up: draftLink.up }">
 											<button v-for="it in draftLink.items" :key="it.value" @mousedown.prevent="pickDraftLink((v) => { f.value = v }, it)">
-												<b>{{ it.value }}</b><span v-if="it.label"> — {{ it.label }}</span>
+												<b>{{ it.value }}</b><span v-if="it.label"> - {{ it.label }}</span>
 											</button>
 										</div>
 									</template>
@@ -855,7 +855,7 @@
 													<div v-if="draftLink.open && draftLink.key === 't:' + ti + ':' + ri + ':' + c.fieldname && draftLink.items.length"
 													     class="jv-action-linkmenu" :class="{ up: draftLink.up }">
 														<button v-for="it in draftLink.items" :key="it.value" @mousedown.prevent="pickDraftLink((v) => { r[c.fieldname] = v }, it)">
-															<b>{{ it.value }}</b><span v-if="it.label"> — {{ it.label }}</span>
+															<b>{{ it.value }}</b><span v-if="it.label"> - {{ it.label }}</span>
 														</button>
 													</div>
 												</template>
@@ -873,7 +873,7 @@
 							</div>
 							<button class="jv-draft-addrow" @click="addDraftRow(ti)">＋ Add row</button>
 						</div>
-						<div v-if="draftTotals" class="jv-draft-totals">{{ draftTotals }} <span class="jv-draft-est">(estimate — ERPNext computes final totals)</span></div>
+						<div v-if="draftTotals" class="jv-draft-totals">{{ draftTotals }} <span class="jv-draft-est">(estimate - ERPNext computes final totals)</span></div>
 						<div v-if="draftPanel.error" class="jv-draft-error">{{ draftPanel.error }}</div>
 					</div>
 					<div class="jv-draft-foot">
@@ -927,7 +927,7 @@ const router = useRouter()
 const store = useShellStore()
 
 const currentId = ref(null)
-// Remember the open chat per-device so a refresh — or a duplicated tab — restores
+// Remember the open chat per-device so a refresh - or a duplicated tab - restores
 // it instead of jumping to whatever sorts first in the sidebar (e.g. a starred
 // chat). Also lets a duplicated tab land on the SAME in-progress conversation.
 // Also mirrors the selection into the shell store (sidebar active row).
@@ -962,7 +962,7 @@ const threadInnerEl = ref(null)
 const rootEl = ref(null)
 // Jump-to-latest arrow: shown when the thread is scrolled up away from the newest
 // message. `pinnedToBottom` tracks whether we should auto-stick to the bottom as
-// content grows (streaming replies, late-loading images/charts) — true until the
+// content grows (streaming replies, late-loading images/charts) - true until the
 // user deliberately scrolls up.
 const showScrollDown = ref(false)
 const pinnedToBottom = ref(true)
@@ -970,7 +970,7 @@ const pinnedToBottom = ref(true)
 // ---- Reusable notifier + confirm dialog ------------------------------------
 // notify("Deleted", { type: "success" }) drops a lightweight toast that stacks
 // bottom-right and auto-dismisses. confirmDialog({...}) shows a centered confirm
-// modal and resolves true/false — a drop-in replacement for the native
+// modal and resolves true/false - a drop-in replacement for the native
 // window.confirm() used across destructive actions (delete chat/skill/macro).
 // Both are intentionally generic so any new call site can reuse them.
 const notes = ref([])
@@ -1007,7 +1007,7 @@ function _settleConfirm(val) {
 }
 const modelMenuOpen = ref(false)
 // (sidebar collapse machinery, per-conversation ⋯ menu and inline rename
-// moved to the app shell — stores/shell.js + components/shell/*, §3.7)
+// moved to the app shell - stores/shell.js + components/shell/*, §3.7)
 const modelOverride = ref("")
 
 // ---- settings panel (openclaw-style console) ----
@@ -1150,7 +1150,7 @@ function fmtDuration(sec) {
 	const h = Math.floor(m / 60)
 	return `${h}h ${m % 60}m`
 }
-// Elapsed for a run that hasn't finished (running/queued) — shows "· 18s".
+// Elapsed for a run that hasn't finished (running/queued) - shows "· 18s".
 function macroRunElapsed(run) {
 	if (run.duration_s != null || !run.started_at) return fmtDuration(run.duration_s)
 	const t = new Date(String(run.started_at).replace(" ", "T")).getTime()
@@ -1225,7 +1225,7 @@ const failedCount = computed(() => activeTools.value.filter((t) => t.status === 
 // Real progress instead of a blanket "Thinking…": phase transitions come from
 // the run's realtime events (run:start → tool:start/end → assistant:delta).
 // Faithful by construction: tool phrases derive from the tool NAME plus
-// openclaw's own arg summary (tool_title, e.g. "get_list Sales Invoice") —
+// openclaw's own arg summary (tool_title, e.g. "get_list Sales Invoice") -
 // nothing is invented client-side.
 const statusPhase = ref(null) // 'model' | 'analyzing' | null
 const TOOL_PHRASES = {
@@ -1290,7 +1290,7 @@ const liveStatus = computed(() => {
 	if (waiting.value || sending.value || statusPhase.value === "model") return "Talking to the model…"
 	return thinkingWord.value
 })
-const runMeta = ref({}) // { [message_id]: { ms, tools, names } } — survives reloads
+const runMeta = ref({}) // { [message_id]: { ms, tools, names } } - survives reloads
 const canvasContent = ref({}) // { `${msgName}::${canvasName}`: srcdoc html (html/svg) | data-url (pdf/image/file) }
 const pendingFiles = ref([]) // [{ file_url, file_name }] attachments to send
 const uploading = ref(false)
@@ -1324,7 +1324,7 @@ const visibleMessages = computed(() =>
 )
 // Group role=tool messages under the assistant turn they belong to, so each
 // answer can show an expandable "Activity" list of the tool calls (with input
-// + output) that produced it — openclaw-style. Tool rows follow their
+// + output) that produced it - openclaw-style. Tool rows follow their
 // assistant placeholder in seq order, so we attach to the most recent
 // assistant message and reset on each user message.
 const activityByAssistant = computed(() => {
@@ -1374,7 +1374,7 @@ function _notifyReplyReady() {
 			tag: "jarvis-reply", // collapse bursts into one notification
 		})
 		n.onclick = () => { window.focus(); n.close() }
-	} catch (e) { /* notification blocked at OS level — nothing to do */ }
+	} catch (e) { /* notification blocked at OS level - nothing to do */ }
 }
 
 // Danger zone: wipe every conversation + message (macros/skills untouched).
@@ -1428,7 +1428,7 @@ function activityNames(assistantName) {
 	return (activityByAssistant.value[assistantName] || [])
 		.map((t) => toolLabel(t.tool_name)).join(", ")
 }
-// args/result are stored as JSON strings — pretty-print, and trim very large
+// args/result are stored as JSON strings - pretty-print, and trim very large
 // payloads so a 10k-row result doesn't blow up the chat.
 function prettyJson(s) {
 	if (s == null || s === "") return ""
@@ -1438,7 +1438,7 @@ function prettyJson(s) {
 	try { out = JSON.stringify(v, null, 2) } catch (e) { out = String(s) }
 	return out.length > 4000 ? out.slice(0, 4000) + "\n… (truncated)" : out
 }
-// True only until the initial conversation load finishes — keeps the welcome
+// True only until the initial conversation load finishes - keeps the welcome
 // screen from flashing on refresh before the open chat appears.
 const booting = ref(true)
 const showWelcome = computed(
@@ -1456,7 +1456,7 @@ const userMsgCount = computed(() => visibleMessages.value.filter((m) => m.role =
 const assistantMsgCount = computed(() => visibleMessages.value.filter((m) => m.role === "assistant").length)
 const avgTokensPerMsg = computed(() => {
 	const n = msgCount.value
-	if (!usage.value || !n) return "—"
+	if (!usage.value || !n) return "-"
 	return fmtTokens(Math.round((usage.value.chat_tokens || 0) / n))
 })
 const starredCount = computed(() => store.conversations.filter((c) => c.starred).length)
@@ -1624,7 +1624,7 @@ function cardsOf(m) {
 	return res
 }
 // Card-strip pagination: past a page of cards the horizontal scroll loses your
-// place, so long lists page instead (‹ 1–6 of 50 ›). Page index per message.
+// place, so long lists page instead (‹ 1-6 of 50 ›). Page index per message.
 const CARD_PAGE_SIZE = 6
 const cardPage = ref({}) // message name -> 0-based page
 function cardPageOf(m) {
@@ -1644,7 +1644,7 @@ function stepCardPage(m, dir) {
 	cardPage.value = { ...cardPage.value, [m.name]: next }
 }
 const _macroCardCache = new Map()
-// "Save as macro" — the macro editor now lives on /macros, so these stash a
+// "Save as macro" - the macro editor now lives on /macros, so these stash a
 // draft (via macroPrefill) and navigate there; MacrosView opens it pre-filled.
 const canSaveAsMacro = computed(
 	() => !!currentId.value && messages.value.some((m) => m.role === "user" && m.content && !m.content.startsWith("▶ Running macro")),
@@ -1805,7 +1805,7 @@ const docNameRegex = computed(() => {
 	try {
 		return new RegExp(`(?<![\\w-])(${names.map(_escapeRegex).join("|")})(?![\\w-])`, "g")
 	} catch (e) {
-		return null // e.g. a browser without lookbehind — degrade to no links
+		return null // e.g. a browser without lookbehind - degrade to no links
 	}
 })
 const _deskSlug = (dt) => dt.toLowerCase().replace(/ /g, "-")
@@ -1829,7 +1829,7 @@ function linkifyDocs(html) {
 		})
 	})
 }
-// The last assistant message (finished, turn idle) decides which card is live —
+// The last assistant message (finished, turn idle) decides which card is live -
 // once the user clicks, a new message lands and the card retires automatically.
 const _lastAssistant = computed(() => {
 	if (busy.value) return null
@@ -1851,9 +1851,9 @@ function actionSend(text) {
 }
 function answerConfirm(ok, label) {
 	// Echo the card's own wording so the transcript reads like what the user
-	// clicked ("Yes — Confirm and save") instead of a canned "go ahead".
+	// clicked ("Yes - Confirm and save") instead of a canned "go ahead".
 	const l = (label || "").trim()
-	send(ok ? (l ? `Yes — ${l}` : "Yes, go ahead.") : "No, cancel that.")
+	send(ok ? (l ? `Yes - ${l}` : "Yes, go ahead.") : "No, cancel that.")
 }
 
 // --- Field-control helpers shared by the confirm card and the record draft
@@ -1937,7 +1937,7 @@ async function _formMeta(doctype) {
 }
 
 // Native date/time inputs REQUIRE canonical values (yyyy-mm-dd / yyyy-mm-ddThh:mm);
-// anything else — "2026-07-10 00:00:00", "10-07-2026" — renders the input EMPTY,
+// anything else - "2026-07-10 00:00:00", "10-07-2026" - renders the input EMPTY,
 // which read as "the date isn't picking". Normalize whatever the agent/doc gave us.
 function _normDateVal(fieldtype, v) {
 	const s = String(v == null ? "" : v).trim()
@@ -2222,7 +2222,7 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 		store.loadConversations()
 	} catch (e) {
 		p.applying = false
-		p.error = (e && e.messages && e.messages[0]) || (e && e.message) || "Could not save — check the values."
+		p.error = (e && e.messages && e.messages[0]) || (e && e.message) || "Could not save - check the values."
 	}
 }
 
@@ -2412,7 +2412,7 @@ function pickSingle(i, opt) {
 	askSel.value = { ...askSel.value, [i]: opt }
 }
 // Option BUTTONS (single/yesno) toggle: clicking the picked option again
-// unselects it, and picking one clears the "Other…" text (they're exclusive —
+// unselects it, and picking one clears the "Other…" text (they're exclusive -
 // both being sent as the answer was a reported bug).
 function toggleSingle(i, opt) {
 	const cur = askSel.value[i]
@@ -2457,7 +2457,7 @@ function submitAsk() {
 		const v = askSel.value[i]
 		const other = (askOther.value[i] || "").trim()
 		if (Array.isArray(v)) ans.push(...v)
-		// Single-answer questions: a typed "Other…" IS the answer — never send
+		// Single-answer questions: a typed "Other…" IS the answer - never send
 		// both it and a leftover pick (the UI keeps them exclusive; this is the
 		// belt-and-braces for stale state).
 		else if (v != null && v !== "" && !other) ans.push(v)
@@ -2472,7 +2472,7 @@ function copyText(t) {
 	const s = t || ""
 	// navigator.clipboard only exists in a secure context (https / localhost).
 	// Over plain http (e.g. jarvis-test.localhost) it's undefined, so the old
-	// `navigator.clipboard?.writeText` silently did nothing — that's why Copy
+	// `navigator.clipboard?.writeText` silently did nothing - that's why Copy
 	// "didn't work". Fall back to the legacy execCommand path in that case.
 	try {
 		if (navigator.clipboard && window.isSecureContext) {
@@ -2542,7 +2542,7 @@ function editCommand(m) {
 	})
 }
 // Cached render payload for an artifact: HTML srcdoc (html/svg) or a base64
-// data-url (pdf/image/file). Keyed by `${msgName}::${canvasName}::${theme}` —
+// data-url (pdf/image/file). Keyed by `${msgName}::${canvasName}::${theme}` -
 // the theme is in the key because the backend themes the srcdoc shell (dark
 // preview bg), so a toggle refetches instead of showing the stale scheme.
 function cvOf(m, cv) {
@@ -2620,7 +2620,7 @@ async function openArtifact(m, cv) {
 async function ensureCanvas(m) {
 	if (!m || !Array.isArray(m.canvas) || !m.canvas.length) return
 	for (const cv of m.canvas) {
-		// pdf / image / file render from file_url directly — only html/svg need
+		// pdf / image / file render from file_url directly - only html/svg need
 		// the fetched srcdoc content.
 		if (cv.file_url && cv.type !== "html" && cv.type !== "svg") continue
 		const dark = effectiveDark.value ? 1 : 0
@@ -2662,7 +2662,7 @@ function jumpToBottom() {
 	scrollBottom(true)
 }
 // Keep the thread pinned to the newest message while its content is still
-// settling — streaming text, plus images/charts/mermaid that finish loading
+// settling - streaming text, plus images/charts/mermaid that finish loading
 // *after* the initial scrollBottom() and would otherwise leave a freshly
 // refreshed chat parked mid-thread (the "10 messages, opens at the top" bug).
 // A ResizeObserver on the inner content re-pins on every growth, but only while
@@ -2717,7 +2717,7 @@ function onKey(e) {
 			return
 		}
 	}
-	// Up/Down: recall sent prompts — only when the caret is at the very start
+	// Up/Down: recall sent prompts - only when the caret is at the very start
 	// (Up) or end (Down) so it doesn't fight normal multi-line editing.
 	const el = e.target
 	if (e.key === "ArrowUp" && (input.value === "" || el.selectionStart === 0) && promptHistory.value.length) {
@@ -2772,7 +2772,7 @@ async function loadConversation(id) {
 	// Stale-response guard: if the user navigated to a different conversation
 	// while this request was in flight, drop the result. Without this, a slow
 	// get_conversation response clobbers the conversation you actually switched
-	// to with the wrong (or empty) messages — and only a page refresh, which
+	// to with the wrong (or empty) messages - and only a page refresh, which
 	// does a single clean load, would put it right. (Root cause of "open a
 	// chat, switch away and back, it shows empty until I refresh".)
 	if (currentId.value !== id) return
@@ -2820,7 +2820,7 @@ async function loadConversation(id) {
 	// Reconcile the sidebar streaming dot with the fetched state: if the store
 	// still marks THIS conversation as streaming but its messages say otherwise
 	// (run ended while we were on another route, or a stale streaming=1 flag),
-	// clear it — otherwise the dot pulses forever. A dot on a DIFFERENT
+	// clear it - otherwise the dot pulses forever. A dot on a DIFFERENT
 	// conversation is left alone: its live socket deltas keep it honest.
 	if (!_resumed && store.streamingConvId === id) store.streamingConvId = null
 	// A freshly opened/refreshed chat should land on the newest message and stay
@@ -2836,7 +2836,7 @@ async function loadConversation(id) {
 // Lazy-loads mermaid so it never bloats the initial bundle; only runs on
 // finalized messages (mid-stream mermaid source is incomplete and would error).
 let _mermaid = null
-// Vibrant, high-contrast categorical palette for pie/bar slices — distinct
+// Vibrant, high-contrast categorical palette for pie/bar slices - distinct
 // hues that stay legible with white section labels in both light and dark.
 // (The app's own palette is near-monochrome, which is why the old "neutral"
 // mermaid theme rendered charts as washed-out grays.)
@@ -2873,7 +2873,7 @@ async function _renderMermaid() {
 	} catch (e) {
 		return
 	}
-	// Re-initialize each run so the palette tracks the active light/dark theme —
+	// Re-initialize each run so the palette tracks the active light/dark theme -
 	// mermaid snapshots its theme at init, so a one-time init would freeze it.
 	const dark = effectiveDark.value
 	const pie = Object.fromEntries(MERMAID_PALETTE.map((c, i) => [`pie${i + 1}`, c]))
@@ -2995,12 +2995,12 @@ async function selectConversation(id) {
 	if (id === currentId.value) return
 	swapDraft(id)
 	resetRunState()
-	// Don't let the macro banner leak across conversations — clear it unless we're
+	// Don't let the macro banner leak across conversations - clear it unless we're
 	// navigating into the run's own conversation.
 	if (macroRun.value && macroRun.value.conversation !== id) macroRun.value = null
 	currentId.value = id
 	// Selection can also start INSIDE the component (proactive toast, run
-	// history) — keep the URL coherent with the sidebar's /c/:id navigation.
+	// history) - keep the URL coherent with the sidebar's /c/:id navigation.
 	// No-op when the route watcher initiated this call (params already match).
 	if (route.params.id !== id) router.replace("/c/" + id)
 	await loadConversation(id)
@@ -3012,12 +3012,12 @@ async function selectConversation(id) {
 // the extracted reason so a non-string Frappe error payload can't throw inside the
 // caller's catch and re-swallow the very failure we're trying to report.
 function notifyActionError(prefix, e) {
-	notify(`${prefix} — ${String(_skillErr(e)).replace(/\.$/, "")}. Try again.`, { type: "error" })
+	notify(`${prefix} - ${String(_skillErr(e)).replace(/\.$/, "")}. Try again.`, { type: "error" })
 }
 async function newChat() {
 	// Create FIRST, mutate the UI only on success. If the backend 500s, we must
 	// not leave the user on a half-reset screen (blank draft + wiped run state
-	// but still the old conversation) with no feedback — surface why and bail,
+	// but still the old conversation) with no feedback - surface why and bail,
 	// keeping them exactly where they were.
 	let conv
 	try {
@@ -3031,7 +3031,7 @@ async function newChat() {
 	currentId.value = conv?.name || conv
 	messages.value = []
 	// Leaving a /c/:id URL on an old conversation would make its sidebar row
-	// unclickable (same-route push is a no-op) — reset to the chat home.
+	// unclickable (same-route push is a no-op) - reset to the chat home.
 	if (route.params.id) router.replace({ name: "Chat" })
 	await store.loadConversations()
 	await nextTick()
@@ -3099,7 +3099,7 @@ async function send(textArg) {
 	}
 	// No awaited pre-flight for a brand-new chat (latency plan, Phase 1.3):
 	// the backend's send_message creates/focuses the empty conversation
-	// itself and returns conversation_id — two fewer round-trips before the
+	// itself and returns conversation_id - two fewer round-trips before the
 	// first message even leaves the browser. The sidebar refresh happens
 	// after the send resolves, off the critical path.
 	const isNewConv = !currentId.value
@@ -3127,7 +3127,7 @@ async function send(textArg) {
 		}
 	} catch (e) {
 		// send_message failed (e.g. a 500 on a migration gap). Stop the spinner and
-		// surface why — the fix this PR is really about is that the failure used to
+		// surface why - the fix this PR is really about is that the failure used to
 		// be silent. We deliberately do NOT roll the optimistic bubble back or refill
 		// the composer: the send is fire-and-forget, so a mid-send conversation
 		// switch would strand one thread's draft in another, and a post-ack timeout
@@ -3243,7 +3243,7 @@ function onEvent(p) {
 			waiting.value = false
 			statusPhase.value = null
 			// Upsert: the message may not be loaded yet when the first delta
-			// arrives — add it so streaming text shows immediately (the bug fix).
+			// arrives - add it so streaming text shows immediately (the bug fix).
 			let m = messages.value.find((x) => x.name === p.message_id)
 			if (!m) {
 				m = { name: p.message_id, role: "assistant", content: "", streaming: true }
@@ -3271,7 +3271,7 @@ function onEvent(p) {
 			break
 		}
 		case "canvas": {
-			// Agent produced a chart/canvas this turn — attach + render inline.
+			// Agent produced a chart/canvas this turn - attach + render inline.
 			const cm = messages.value.find((x) => x.name === p.message_id)
 			if (cm) {
 				cm.canvas = p.items
@@ -3302,7 +3302,7 @@ function onEvent(p) {
 			_notifyReplyReady() // browser notification when the tab is hidden (opt-in)
 			store.loadConversations()
 			loadConversation(currentId.value)
-			// Re-render charts after the reload settles — late re-renders can swap a
+			// Re-render charts after the reload settles - late re-renders can swap a
 			// freshly-rendered mermaid node back to raw source; these idle passes
 			// (mutex-guarded, no-op when nothing's pending) catch that race.
 			setTimeout(processMermaid, 300)
@@ -3311,7 +3311,7 @@ function onEvent(p) {
 		}
 		case "wiki:nudge": {
 			// Post-turn "remember this?" prompt. Don't clobber a card the user is
-			// already recording into / editing — only replace an idle (or absent)
+			// already recording into / editing - only replace an idle (or absent)
 			// one, or a card stranded on ANOTHER conversation than the one on
 			// screen (invisible, so its stuck recorder would otherwise block every
 			// future nudge; cancel it before taking the slot).
@@ -3363,15 +3363,15 @@ function stopRun() {
 // ---- voice dictation (composer mic) ----
 // Hidden unless get_chat_ui_settings reports stt_enabled AND the browser has
 // MediaRecorder. micState is the UI phase; the recorder itself lives in the
-// composable (300 s hard cap enforced there — onAutoStop still transcribes).
+// composable (300 s hard cap enforced there - onAutoStop still transcribes).
 const micRec = useAudioRecorder({
 	onAutoStop: (r) => {
-		notify("Recording stopped at the 5-minute limit — transcribing.", { type: "info" })
+		notify("Recording stopped at the 5-minute limit - transcribing.", { type: "info" })
 		_transcribeToInput(r)
 	},
 })
 const micState = ref("idle") // 'idle' | 'recording' | 'transcribing'
-let _micConvId = null // conversation the take was started in — transcript belongs to it
+let _micConvId = null // conversation the take was started in - transcript belongs to it
 function _fmtClock(s) {
 	return Math.floor(s / 60) + ":" + String(Math.max(0, s) % 60).padStart(2, "0")
 }
@@ -3403,7 +3403,7 @@ async function _transcribeToInput(r) {
 		const res = await voice.transcribeAudio(r.blob, { durationS: r.durationS })
 		const text = ((res && res.text) || "").trim()
 		if (!text) {
-			notify("Nothing was transcribed — try again closer to the microphone.", { type: "info" })
+			notify("Nothing was transcribed - try again closer to the microphone.", { type: "info" })
 		} else if (currentId.value === forId) {
 			// fillInput pattern, but APPENDING: dictation adds to any typed draft.
 			input.value = input.value.trim() ? input.value.replace(/\s+$/, "") + " " + text : text
@@ -3413,7 +3413,7 @@ async function _transcribeToInput(r) {
 			})
 		} else if (forId) {
 			// The user switched chats mid-transcription: the words belong to the
-			// chat they were spoken in — merge into its stashed draft (swapDraft
+			// chat they were spoken in - merge into its stashed draft (swapDraft
 			// restores it when they return), never into the composer on screen.
 			const prev = drafts.value[forId] || ""
 			drafts.value[forId] = prev.trim() ? prev.replace(/\s+$/, "") + " " + text : text
@@ -3440,7 +3440,7 @@ const nudgeLabels = computed(() =>
 )
 const nudgeRec = useAudioRecorder({
 	onAutoStop: (r) => {
-		notify("Recording stopped at the 5-minute limit — transcribing.", { type: "info" })
+		notify("Recording stopped at the 5-minute limit - transcribing.", { type: "info" })
 		_nudgeTranscribe(r)
 	},
 })
@@ -3472,7 +3472,7 @@ async function _nudgeTranscribe(r) {
 		const res = await voice.transcribeAudio(r.blob, { durationS: r.durationS })
 		const text = ((res && res.text) || "").trim()
 		if (!text) {
-			notify("Nothing was transcribed — try again closer to the microphone.", { type: "info" })
+			notify("Nothing was transcribed - try again closer to the microphone.", { type: "info" })
 			if (nudge.value) nudge.value.mode = "idle"
 			return
 		}
@@ -3509,7 +3509,7 @@ async function saveNudgeNote() {
 			entities: JSON.stringify(n.entities || []),
 			source: "Chat Nudge",
 		})
-		notify("Noted — Jarvis will remember this", { type: "success" })
+		notify("Noted - Jarvis will remember this", { type: "success" })
 		nudge.value = null
 	} catch (e) {
 		n.saving = false
@@ -3522,9 +3522,9 @@ function dismissNudge() {
 	nudge.value = null
 	// Best-effort: the 7-day server-side snooze shouldn't block hiding the card.
 	if (n) voice.dismissWikiNudge(n.conversationId).catch(() => {})
-	// the dismissal mutes a week of nudges here — say so, once, or users
+	// the dismissal mutes a week of nudges here - say so, once, or users
 	// won't know they opted out
-	notify("Okay — won't ask again in this chat for a week.")
+	notify("Okay - won't ask again in this chat for a week.")
 }
 
 // ---- file input ----
@@ -3714,7 +3714,7 @@ function onVisibility() {
 
 // ---- shell contract (§3.7): New Chat requests, external navigation and
 // external deletes now arrive from outside the component. ----
-// D10 — the shell sets pendingNewChat; consume + clear it here. During boot
+// D10 - the shell sets pendingNewChat; consume + clear it here. During boot
 // the flag is only marked (onMounted starts on the empty state instead of
 // restoring the last conversation).
 let _consumedNewChat = false
@@ -3728,7 +3728,7 @@ watch(
 	},
 	{ immediate: true },
 )
-// Sidebar rows navigate via /c/:id — selection now happens outside the
+// Sidebar rows navigate via /c/:id - selection now happens outside the
 // component, so follow the route param.
 watch(
 	() => route.params.id,
@@ -3770,8 +3770,8 @@ onMounted(async () => {
 	// Load custom skills so the "/" composer menu can offer them.
 	loadCustomSkills()
 	// "Discuss in chat" hand-off (Review tab → chatPrefill stash). Take the
-	// stash on EVERY mount — a stale prompt must never survive to pop into the
-	// composer on a later, unrelated visit — but only act on it when landing
+	// stash on EVERY mount - a stale prompt must never survive to pop into the
+	// composer on a later, unrelated visit - but only act on it when landing
 	// on the chat home (no /c/:id param).
 	const prefill = takeChatPrefill()
 	const applyPrefill = !route.params.id && !!(prefill && prefill.text)
@@ -3785,7 +3785,7 @@ onMounted(async () => {
 			_consumedNewChat = false // newChat() below satisfies a pending request too
 			await newChat()
 		} else if (_consumedNewChat) {
-			// New Chat was requested from another route while we booted —
+			// New Chat was requested from another route while we booted -
 			// start on a fresh empty conversation instead of restoring.
 			_consumedNewChat = false
 			await newChat()
@@ -3807,14 +3807,14 @@ onMounted(async () => {
 		booting.value = false // reveal welcome/thread only after the first load
 	}
 	// The thread (and its chart skeletons) only enter the DOM now that booting is
-	// false — loadConversation's earlier processMermaid pass ran against an empty
+	// false - loadConversation's earlier processMermaid pass ran against an empty
 	// thread, so render the charts here once they're actually mounted.
 	await nextTick()
 	processMermaid()
 	// Apply the "Discuss in chat" prefill now that booting is false and the
 	// composer is mounted: drop the drafted prompt into the fresh conversation
 	// started above and, per the hand-off contract, send it as the user's
-	// first message (send() with no arg reads input.value — the main-composer
+	// first message (send() with no arg reads input.value - the main-composer
 	// path).
 	if (applyPrefill) {
 		input.value = prefill.text
@@ -3831,12 +3831,12 @@ onBeforeUnmount(() => {
 	document.removeEventListener("pointerdown", onDocClick)
 	window.removeEventListener("keydown", onGlobalKey)
 	clearInterval(_thinkTimer)
-	// Release the mic — navigating to another route mid-take must not leave the
+	// Release the mic - navigating to another route mid-take must not leave the
 	// track hot (and its duration interval ticking) behind the dead view.
 	micRec?.cancel()
 	if (nudge.value && (nudge.value.mode === "recording" || nudge.value.mode === "transcribing")) nudgeRec?.cancel()
 	// ChatView is the sole writer of streamingConvId (§4 contract) and its
-	// socket handlers detach above — nothing can clear the flag once we're
+	// socket handlers detach above - nothing can clear the flag once we're
 	// gone, so navigating off mid-stream would leave the sidebar dot pulsing
 	// forever. Remount reconciles from fetched state in loadConversation.
 	store.streamingConvId = null
@@ -3861,12 +3861,12 @@ function onGlobalKey(e) {
 
 <style scoped>
 /* Native form controls (select dropdowns, date/time pickers, scrollbars)
-   follow the app theme instead of the OS default — without this, a dark app
+   follow the app theme instead of the OS default - without this, a dark app
    pops white select menus and calendar popups. */
 .jv-root { color-scheme: light; }
 .jv-root.jv-dark { color-scheme: dark; }
-/* Refined Indigo brand mark (dark mode): the spark boxes — empty-state hero,
-   assistant avatars, proactive toast — trade the flat accent fill for an
+/* Refined Indigo brand mark (dark mode): the spark boxes - empty-state hero,
+   assistant avatars, proactive toast - trade the flat accent fill for an
    indigo→violet gradient with a soft indigo glow. !important beats the
    elements' inline background:var(--blue). */
 .jv-dark .jv-logo,
@@ -3893,7 +3893,7 @@ function onGlobalKey(e) {
 .jv-menuitem-danger:hover { background: var(--red-bg); }
 .jv-suggest:hover { border-color: var(--border-2); background: var(--surface-1); }
 /* buttons invert to black/white on hover (theme-adaptive: black on light,
-   white on dark) — var(--text)/var(--surface) flip, with an svg-stroke
+   white on dark) - var(--text)/var(--surface) flip, with an svg-stroke
    override so the icon stays visible on the inverted background. */
 .jv-iconbtn:hover { background: var(--text) !important; color: var(--surface) !important; }
 .jv-iconbtn:hover svg { stroke: var(--surface) !important; }
@@ -3906,7 +3906,7 @@ function onGlobalKey(e) {
 .jv-menuitem:hover, .jv-menuitem.on { background: var(--surface-1); }
 /* black focus highlight on the composer */
 .jv-composer:focus-within { border-color: var(--text); box-shadow: 0 0 0 3px rgba(23, 23, 23, 0.07); }
-/* jump-to-latest arrow — floats just above the composer, centered */
+/* jump-to-latest arrow - floats just above the composer, centered */
 .jv-scrolldown {
 	position: absolute;
 	left: 50%;
@@ -3953,14 +3953,14 @@ function onGlobalKey(e) {
 .jv-tool-dot.err { background: var(--red); }
 .jv-tool-dot.run { background: var(--amber); animation: jv-pulse 1s ease-in-out infinite; }
 @keyframes jv-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
-/* dictation mic (composer + nudge card) — red while a take is live */
+/* dictation mic (composer + nudge card) - red while a take is live */
 .jv-micbtn.rec { color: var(--red) !important; }
 .jv-micbtn:disabled { cursor: default; }
 .jv-mic-live { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; font-weight: 600; color: var(--red); font-variant-numeric: tabular-nums; }
 .jv-mic-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--red); animation: jv-pulse 1s ease-in-out infinite; flex: none; }
 .jv-mic-cancel { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; border: none; background: transparent; border-radius: 6px; cursor: pointer; color: var(--text-3); }
 .jv-mic-cancel:hover { background: var(--surface-2); color: var(--text); }
-/* wiki nudge card — own block above the composer, never inside it */
+/* wiki nudge card - own block above the composer, never inside it */
 .jv-nudge { display: flex; flex-direction: column; gap: 8px; margin: 0 0 8px; padding: 10px 12px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 8px; font-size: 13px; color: var(--text); }
 .jv-nudge-head { display: flex; align-items: flex-start; gap: 8px; }
 .jv-nudge-q { flex: 1; min-width: 0; line-height: 1.45; }
@@ -3979,7 +3979,7 @@ function onGlobalKey(e) {
 .jv-tool-detail { padding: 4px 11px 11px; border-top: 1px solid var(--border); }
 .jv-tool-io-k { font-size: 10.5px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--text-3); margin: 9px 0 4px; }
 .jv-tool-io { margin: 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; color: var(--text); white-space: pre-wrap; word-break: break-word; overflow-x: auto; max-height: 320px; overflow-y: auto; }
-/* per-message Copy/Edit bar — revealed on hover */
+/* per-message Copy/Edit bar - revealed on hover */
 .jv-msgbar { display: flex; align-items: center; gap: 3px; margin-top: 5px; opacity: 0; transition: opacity .12s ease; }
 .jv-umsg:hover .jv-msgbar, .jv-amsg:hover .jv-msgbar { opacity: 1; }
 .jv-msgtime { font-size: 11.5px; color: var(--text-3); padding: 0 3px; cursor: default; user-select: none; }
@@ -4022,7 +4022,7 @@ function onGlobalKey(e) {
 .jv-btn-danger:disabled { opacity: .6; }
 .jv-md :deep(.jv-mermaid) { position: relative; margin: 8px 0 12px; text-align: center; overflow-x: auto; }
 .jv-md :deep(.jv-mermaid svg) { max-width: 100%; height: auto; }
-/* skeleton shimmer while a chart hasn't rendered to SVG yet (no data-rendered) —
+/* skeleton shimmer while a chart hasn't rendered to SVG yet (no data-rendered) -
    hides the raw mermaid source so the user never sees the markup flash. */
 .jv-md :deep(.jv-mermaid:not([data-rendered])) { min-height: 196px; color: transparent !important; user-select: none; overflow: hidden; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-1); }
 .jv-md :deep(.jv-mermaid:not([data-rendered])) * { color: transparent !important; }
@@ -4385,7 +4385,7 @@ function onGlobalKey(e) {
 .jv-macro-merged-badge--pending { color: var(--amber); background: var(--amber-bg); border-color: var(--amber-bd); }
 
 /* rich action cards (doc confirm / email draft) */
-/* .jv-action must stay overflow:visible — the edit form's Link dropdown
+/* .jv-action must stay overflow:visible - the edit form's Link dropdown
    (.jv-action-linkmenu, position:absolute) would be CLIPPED to the card
    otherwise, leaving a sliver you have to scroll inside. The rounded corners
    are preserved by rounding the footer's own bottom edge instead. */
@@ -4527,7 +4527,7 @@ function onGlobalKey(e) {
 .jv-artifact-frame { flex: 1; width: 100%; border: 0; background: #fff; }
 /* Dark preview: the frame behind html/svg srcdoc follows the app surface (the
    srcdoc itself is themed by get_canvas's dark param); PDFs keep the white
-   frame — pages are white paper either way. */
+   frame - pages are white paper either way. */
 .jv-dark .jv-artifact-frame:not([title="PDF preview"]) { background: var(--surface-1); }
 .jv-artifact-img { max-width: 100%; height: auto; margin: auto; padding: 16px; }
 .jv-artifact-text { margin: 0; padding: 16px; font-size: 12.5px; line-height: 1.55; white-space: pre-wrap; word-break: break-word; color: var(--text); font-family: ui-monospace, "SF Mono", Menlo, monospace; }

--- a/frontend/src/views/MonitorTab.vue
+++ b/frontend/src/views/MonitorTab.vue
@@ -5,7 +5,7 @@
       <section class="jv-mon-card">
         <h3>Status</h3>
         <div class="jv-mon-kv"><span>Mode</span><b>{{ config.proxy_active ? "Proxy" : "Direct" }}</b></div>
-        <div class="jv-mon-kv"><span>Sync</span><b>{{ sync.last_sync_status || "—" }}</b></div>
+        <div class="jv-mon-kv"><span>Sync</span><b>{{ sync.last_sync_status || "-" }}</b></div>
         <div v-if="sync.last_sync_at" class="jv-mon-kv"><span>Last sync</span><b>{{ sync.last_sync_at }}</b></div>
       </section>
 
@@ -77,7 +77,7 @@ const gaugeOption = computed(() => {
 })
 const expiresLabel = computed(() => {
   const ms = conn.value.oauth_expires_at
-  return ms ? new Date(Number(ms)).toLocaleString() : "—"
+  return ms ? new Date(Number(ms)).toLocaleString() : "-"
 })
 
 async function load(fetchFn, target) {

--- a/frontend/src/views/MonitorView.vue
+++ b/frontend/src/views/MonitorView.vue
@@ -2,7 +2,7 @@
 	<div class="jv-app flex h-full flex-col overflow-hidden" :class="{ 'jv-dark': dark }" :style="paletteVars"
 		 style="background:var(--surface);color:var(--text);">
 
-		<!-- Shell-integrated header — no per-view sidebar; the app shell's Sidebar
+		<!-- Shell-integrated header - no per-view sidebar; the app shell's Sidebar
 		     owns navigation, same chrome as Agents / Skills / Macros / Account. -->
 		<LayoutHeader>
 			<template #left-header>
@@ -22,6 +22,6 @@ import { Breadcrumbs } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import MonitorTab from "@/views/MonitorTab.vue"
 
-// Theme — shared composable: honours "jarvis-theme" pref, cross-tab sync, OS live.
+// Theme - shared composable: honours "jarvis-theme" pref, cross-tab sync, OS live.
 const { effectiveDark: dark, paletteVars } = useTheme()
 </script>

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -10,7 +10,7 @@
 			<div class="jv-ob-orb jv-ob-orb-br"></div>
 		</div>
 
-		<!-- Branded header — a centered wizard reads better than a full-height
+		<!-- Branded header - a centered wizard reads better than a full-height
 			 empty sidebar; the logo mark keeps it unmistakably Jarvis. -->
 		<header class="jv-ob-header">
 			<div class="jv-ob-logo"><svg width="18" height="18" viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg></div>
@@ -21,7 +21,7 @@
 		<main class="jv-ob-main">
 			<div class="jv-ob-center">
 			<div class="jv-ob-wrap">
-				<!-- ===== step indicator — managed mode only, mirrors desk renderSteps
+				<!-- ===== step indicator - managed mode only, mirrors desk renderSteps
 					 (jarvis_onboarding.js ~213: STEP_NAMES = Account/Plan/Pay/Connect AI).
 					 Hidden on the mode-choice screen and for self-host (single step). ===== -->
 				<div v-if="state.mode === 'managed' && state.step !== 'mode'" class="jv-ob-steps">
@@ -34,7 +34,7 @@
 					</template>
 				</div>
 
-				<!-- ===== step area — placeholder panels; Tasks 3-5 replace these ===== -->
+				<!-- ===== step area - placeholder panels; Tasks 3-5 replace these ===== -->
 				<div class="jv-ob-body">
 					<div v-if="state.step === 'mode'">
 						<h1 class="jv-ob-h1">How do you want to run Jarvis?</h1>
@@ -66,7 +66,7 @@
 						</div>
 					</div>
 
-					<!-- ===== Account — ported from desk renderAccount (jarvis_onboarding.js
+					<!-- ===== Account - ported from desk renderAccount (jarvis_onboarding.js
 						 ~378). No Company Link-control (desk falls back to a plain input
 						 anyway when make_control throws); validation matches desk verbatim. ===== -->
 					<div v-else-if="state.step === 'account'">
@@ -89,7 +89,7 @@
 						</div>
 					</div>
 
-					<!-- ===== Plan — ported from desk renderPlan (jarvis_onboarding.js ~481). ===== -->
+					<!-- ===== Plan - ported from desk renderPlan (jarvis_onboarding.js ~481). ===== -->
 					<div v-else-if="state.step === 'plan'">
 						<h1 class="jv-ob-h1">Choose your plan</h1>
 						<p class="jv-ob-sub">No auto-renewal, extend anytime.</p>
@@ -116,7 +116,7 @@
 						</template>
 					</div>
 
-					<!-- ===== Pay — ported from desk renderPay + renderVerifyEmail + startPay/
+					<!-- ===== Pay - ported from desk renderPay + renderVerifyEmail + startPay/
 						 openCheckout/devOnboard (jarvis_onboarding.js ~515, ~1575-1682). The
 						 Razorpay options/handler fields below are lifted verbatim; see
 						 task-4-report.md for the field-by-field comparison. ===== -->
@@ -168,7 +168,7 @@
 						</template>
 					</div>
 
-					<!-- ===== Connect AI (managed) — embeds the shared LlmPoolEditor component
+					<!-- ===== Connect AI (managed) - embeds the shared LlmPoolEditor component
 						 (same one AccountView uses), restricted to :modes="['quick']" so
 						 onboarding shows only a single direct model. The Preset/Custom
 						 proxy-pool tabs + Direct/Proxy badge are intentionally hidden here to
@@ -182,7 +182,7 @@
 							 state). Show a clean full-step "setting up" screen through that
 							 transition so the reload reads as intentional, not a flicker.
 							 v-show (not v-if) so the editor stays MOUNTED while its own save()
-							 is still awaiting — a v-if here would tear it down mid-save and, on
+							 is still awaiting - a v-if here would tear it down mid-save and, on
 							 a not-ready poll, remount + refetch with a visible flash. -->
 						<div v-show="state.finishing">
 							<h1 class="jv-ob-h1">Setting up Jarvis</h1>
@@ -206,10 +206,10 @@
 						</div>
 					</div>
 
-					<!-- ===== Self-host — ported from desk renderSelfHost + renderShResults
+					<!-- ===== Self-host - ported from desk renderSelfHost + renderShResults
 						 (jarvis_onboarding.js ~296-376). Field names/args match
 						 test_connection / save_self_hosted verbatim (base_url, token, deep,
-						 stream) — see api.js's testSelfHostConnection/saveSelfHosted. ===== -->
+						 stream) - see api.js's testSelfHostConnection/saveSelfHosted. ===== -->
 					<div v-else-if="state.step === 'selfhost'">
 						<h1 class="jv-ob-h1">Connect your openclaw</h1>
 						<p class="jv-ob-sub">Point Jarvis at <b>your own</b> openclaw server. Jarvis connects over HTTP
@@ -275,13 +275,13 @@ import { errMessage as errMsg } from "@/lib/errors"
 const { effectiveDark: dark, paletteVars } = useTheme()
 
 
-// Mirrors jarvis_onboarding.js's STEP_NAMES (~line 212) — the 4 named steps
+// Mirrors jarvis_onboarding.js's STEP_NAMES (~line 212) - the 4 named steps
 // shown in managed mode. "mode" and "selfhost" have no header entry.
 const STEP_NAMES = ["Account", "Plan", "Pay", "Connect"]
 
 // ---- step machine -----------------------------------------------------------
 // `state.step` is one of STEPS_MANAGED/STEPS_SELFHOST depending on `state.mode`.
-// Kept intentionally small here — Tasks 3-5 add fields as their panels need
+// Kept intentionally small here - Tasks 3-5 add fields as their panels need
 // them (email/company/plan choice/etc.), same shape as the desk `state` object.
 const state = reactive({
 	mode: null, step: "mode",
@@ -290,7 +290,7 @@ const state = reactive({
 	// plan (renderPlan)
 	plans: [], planName: null, plansLoading: false, plansErr: "",
 	// pay (renderPay / renderVerifyEmail / startPay / openCheckout / devOnboard)
-	payPhase: "review", // "review" | "verify" — mirrors desk's step-3 vs "check your email" sub-screen
+	payPhase: "review", // "review" | "verify" - mirrors desk's step-3 vs "check your email" sub-screen
 	payErr: "", payBusy: false,
 	devActive: null, // UX-only mirror of desk's boot-time `dev`; null until probed on entering "pay"
 	successData: null,
@@ -313,7 +313,7 @@ const selectedPlan = computed(() => state.plans.find((p) => p.name === state.pla
 
 // 1-based position within the 4 named managed steps (Account=1 … Connect AI=4),
 // matching desk's `state.step` numbering used by renderSteps/STEP_NAMES. Index
-// 0 ("mode") intentionally renders as 0 — the header is hidden for that step.
+// 0 ("mode") intentionally renders as 0 - the header is hidden for that step.
 const managedStepNum = computed(() => stepIndex(steps.value, state.step))
 
 function goNext() {
@@ -324,7 +324,7 @@ function goBack() {
 }
 // Entry point from the mode-choice screen: record the choice, then advance
 // to that track's first real step ("account" for managed, "selfhost" for
-// self-host) — mirrors desk's `state.mode = "managed"; go(1)` on mode pick.
+// self-host) - mirrors desk's `state.mode = "managed"; go(1)` on mode pick.
 function setMode(m) {
 	state.mode = m
 	goNext()
@@ -334,7 +334,7 @@ function setMode(m) {
 // Desk's boot (jarvis_onboarding.js bootRender, ~1699) only checks
 // is_onboarded/is_ready_for_chat to decide wizard-vs-completion-card; the
 // router's first-run guard (Task 1) already does that before this view ever
-// mounts. What desk does NOT do at boot is poll check_signup_payment_state —
+// mounts. What desk does NOT do at boot is poll check_signup_payment_state -
 // that's only called interactively from the "verify your email" screen
 // (jarvis_onboarding.js ~1615). So there's no literal desk boot-time
 // reconcile to mirror for "signup started but not finished, then the tab
@@ -345,21 +345,21 @@ function setMode(m) {
 // case) poll check_signup_payment_state to see whether there's a live
 // order/verification to resume. Fails open on any error (no admin URL
 // configured yet, not a System Manager, admin API unreachable are all
-// expected on a genuine first run) — falls back to the default "mode" step.
+// expected on a genuine first run) - falls back to the default "mode" step.
 //
 // RESOLVED (was a CONCERN in task-2-report.md, "revisit once Task 4 builds
 // the real pay panel"): check_signup_payment_state is, on desk, ONLY ever
 // called from the "check your email" screen (renderVerifyEmail's "I've
-// verified" button, jarvis_onboarding.js ~1612) — never from a fresh
+// verified" button, jarvis_onboarding.js ~1612) - never from a fresh
 // pay-review screen. So EITHER truthy result here (a live razorpay_order_id,
 // or still-pending_verification) maps to that same desk sub-screen, not to
-// the plan-review screen (which would re-call start_signup — untested for
+// the plan-review screen (which would re-call start_signup - untested for
 // idempotency and not a real desk code path) and not to "account" (a plain
 // mis-mapping in the original scaffold). onVerifyCheck() below re-polls
 // check_signup_payment_state itself and branches on the same two fields, so
 // landing here in "verify" phase re-derives the correct next action either
 // way. Known gap: email/company/plan text are blank on a resumed session
-// (never persisted) until the customer re-verifies — cosmetic only, doesn't
+// (never persisted) until the customer re-verifies - cosmetic only, doesn't
 // block the resume.
 async function reconcileMidFlightSignup() {
 	try {
@@ -375,7 +375,7 @@ async function reconcileMidFlightSignup() {
 			state.step = "connect"
 			return
 		}
-		// reason === "signup" (or call failed) — no completed signup yet, but
+		// reason === "signup" (or call failed) - no completed signup yet, but
 		// one may still be mid-flight (started, awaiting verification/payment).
 		const pay = await checkSignupPaymentState()
 		if (pay && (pay.razorpay_order_id || pay.pending_verification)) {
@@ -383,9 +383,9 @@ async function reconcileMidFlightSignup() {
 			state.step = "pay"
 			state.payPhase = "verify"
 		}
-		// else: nothing in flight — leave the default "mode" step.
+		// else: nothing in flight - leave the default "mode" step.
 	} catch (e) {
-		// Fail-open — never block the wizard from rendering.
+		// Fail-open - never block the wizard from rendering.
 	}
 }
 
@@ -458,7 +458,7 @@ function ensureRazorpayLoaded() {
 }
 
 // Probe `jarvis.dev.is_dev_mode_active` once on entering the Pay step, purely
-// for the heading/button copy — the SPA's boot payload (jarvis/www/jarvis.py)
+// for the heading/button copy - the SPA's boot payload (jarvis/www/jarvis.py)
 // doesn't carry an equivalent of desk's boot-time `frappe.boot.jarvis_sandbox_mode`,
 // so this RPC stands in for that cosmetic read. Preload the checkout script
 // unconditionally (harmless if unused) rather than gating it on this same
@@ -475,7 +475,7 @@ async function enterPayStep() {
 
 // Click handler for the single Pay/Dev-signup button. Server-authoritative
 // branch: re-query is_dev_mode_active at CLICK time, not the cached
-// state.devActive — mirrors desk's explicit anti-staleness comment
+// state.devActive - mirrors desk's explicit anti-staleness comment
 // (jarvis_onboarding.js ~532-554): a stale "false" must never let this
 // silently skip payment when sandbox mode was actually flipped on, and a
 // stale cached "true" must never skip a real charge either.
@@ -487,7 +487,7 @@ async function onPayClick() {
 		const r = await call("jarvis.dev.is_dev_mode_active")
 		isDev = !!(r && r.data && r.data.active)
 	} catch (e) {
-		// Server unreachable — fall back to the best-effort cosmetic value,
+		// Server unreachable - fall back to the best-effort cosmetic value,
 		// same as desk's catch branch.
 	}
 	if (isDev) await runDevOnboard()
@@ -508,7 +508,7 @@ async function runDevOnboard() {
 function _sleep(ms) { return new Promise((r) => setTimeout(r, ms)) }
 
 // Provisioning gate: after pay, the openclaw container is still spinning up.
-// Don't enter Connect-AI until it's running — otherwise save_llm_pool there has
+// Don't enter Connect-AI until it's running - otherwise save_llm_pool there has
 // no container to configure. If pay already returned a running tenant, advance
 // immediately; otherwise poll sync_connection until the container is ready.
 async function proceedAfterPay() {
@@ -524,7 +524,7 @@ async function proceedAfterPay() {
 				goNext()
 				return
 			}
-		} catch (e) { /* transient admin/agent hiccup — keep polling */ }
+		} catch (e) { /* transient admin/agent hiccup - keep polling */ }
 		await _sleep(2000)
 	}
 	state.provisioning = false
@@ -571,7 +571,7 @@ async function onVerifyCheck() {
 	}
 }
 
-// Razorpay Checkout — options object + success handler ported verbatim from
+// Razorpay Checkout - options object + success handler ported verbatim from
 // desk openCheckout (jarvis_onboarding.js ~1646-1676). See task-4-report.md
 // for the field-by-field comparison against the desk source.
 async function openCheckout(d) {
@@ -603,7 +603,7 @@ async function openCheckout(d) {
 				state.payErr = errMsg(e)
 			})
 		},
-		// Razorpay dismiss (customer closed Checkout without paying) — same
+		// Razorpay dismiss (customer closed Checkout without paying) - same
 		// message as desk's modal.ondismiss, shown inline instead of via
 		// frappe.show_alert (no toast primitive on this surface yet).
 		modal: {
@@ -619,7 +619,7 @@ async function openCheckout(d) {
 // ---- post-save readiness recheck (Connect-AI + self-host) ------------------
 // CRITICAL: the router's first-run guard (router/index.js) caches its
 // is_ready_for_chat probe in a module-level `readyPromise` for the lifetime
-// of the page — it never invalidates mid-session. So a plain
+// of the page - it never invalidates mid-session. So a plain
 // `router.push({ name: "Chat" })` right after completing onboarding would
 // read that STALE "not ready" cache and bounce straight back to
 // /onboarding. Both completion paths (onConnected below and
@@ -629,17 +629,17 @@ async function openCheckout(d) {
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Poll is_ready_for_chat a few times (short backoff) rather than trusting a
-// single check — the save itself (pool save or self-host connect) can
+// single check - the save itself (pool save or self-host connect) can
 // return before whatever it kicked off (e.g. proxy provisioning) is fully
 // reflected. Fails closed (returns false) on a persistent error; callers
-// treat "not ready yet" as advisory, not fatal — see finishNote below.
+// treat "not ready yet" as advisory, not fatal - see finishNote below.
 async function waitUntilReady(attempts = 5, delayMs = 800) {
 	for (let i = 0; i < attempts; i++) {
 		try {
 			const r = await isReadyForChat()
 			if (r && r.ready) return true
 		} catch (e) {
-			// keep retrying — transient network hiccups shouldn't strand the user
+			// keep retrying - transient network hiccups shouldn't strand the user
 		}
 		if (i < attempts - 1) await sleep(delayMs)
 	}
@@ -663,7 +663,7 @@ async function afterSaveRecheckReady() {
 	if (ready) {
 		// Keep the "Setting up Jarvis" spinner up THROUGH the full-page reload.
 		// Flipping finishing off first re-shows the "Give Jarvis a brain" editor
-		// for a frame before the browser navigates — the flicker/rerender users
+		// for a frame before the browser navigates - the flicker/rerender users
 		// saw on the final click. Leave it on; location.assign tears the page down.
 		window.location.assign("/jarvis/")
 		return
@@ -673,7 +673,7 @@ async function afterSaveRecheckReady() {
 }
 
 // ---- Connect AI (renders <LlmPoolEditor>, jarvis_onboarding.js ~559-1080
-// renderLlm) — the component itself owns Quick/Preset/Custom + save_llm_pool;
+// renderLlm) - the component itself owns Quick/Preset/Custom + save_llm_pool;
 // this is only the post-save readiness handoff. ---------------------------
 function onConnected(sync) {
 	afterSaveRecheckReady()
@@ -685,7 +685,7 @@ function onConnected(sync) {
 const poolRef = ref(null)
 const savingConnect = ref(false)
 // True once the embedded editor reports a savable config (account connected, or
-// API key filled) — drives the "Onboard Jarvis" attention pulse.
+// API key filled) - drives the "Onboard Jarvis" attention pulse.
 const connectReady = ref(false)
 async function saveConnect() {
 	if (!poolRef.value) return
@@ -736,7 +736,7 @@ async function onSelfHostSave() {
 		const m = r || {}
 		state.shSaveBusy = false
 		if (m.ok) {
-			// Advisory only (e.g. no Self-Host Tool User set yet) — the connection
+			// Advisory only (e.g. no Self-Host Tool User set yet) - the connection
 			// itself is already saved, so this doesn't block the readiness recheck.
 			if (m.warning) state.shWarning = m.warning
 			await afterSaveRecheckReady()
@@ -750,7 +750,7 @@ async function onSelfHostSave() {
 	}
 }
 
-// Enter-step triggers: load the plan list on reaching "plan" (defensive —
+// Enter-step triggers: load the plan list on reaching "plan" (defensive -
 // normally already loaded by onAccountSubmit, but also covers a reconcile
 // that lands directly on "plan"), and probe dev-mode + preload Razorpay on
 // reaching "pay".
@@ -791,7 +791,7 @@ onMounted(() => {
 	flex-direction: column;
 	position: relative;
 }
-/* Framing orbs — fixed behind everything, decorative only. Deep navy/indigo in
+/* Framing orbs - fixed behind everything, decorative only. Deep navy/indigo in
    light (consistent with the black/white primary), brighter blue on dark. */
 .jv-ob-bg { position: fixed; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
 .jv-ob-orb { position: absolute; width: min(760px, 66vw); aspect-ratio: 1; border-radius: 50%; filter: blur(14px); }
@@ -905,7 +905,7 @@ onMounted(() => {
 }
 .jv-ob-btn:hover { background: var(--surface-2); }
 .jv-ob-btn-primary { border-color: var(--blue-bd); background: var(--blue-bg); color: var(--blue); }
-/* Attention pulse on the final CTA once the config is ready — a soft expanding
+/* Attention pulse on the final CTA once the config is ready - a soft expanding
    ring that invites the click. Pauses on hover; off for reduced-motion. */
 @keyframes jvObCtaPulse {
 	0% { box-shadow: 0 0 0 0 rgba(37, 99, 235, .38); }
@@ -919,7 +919,7 @@ onMounted(() => {
 @keyframes jvObSpin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .jv-ob-spinner { animation: none; } }
 
-/* ---- mode-choice cards — ported from desk .jo-mode* (jarvis_onboarding.js
+/* ---- mode-choice cards - ported from desk .jo-mode* (jarvis_onboarding.js
    ~1889-1898), theme tokens standing in for the desk's --jarvis-primary /
    --card-bg / --border-color. ---- */
 .jv-ob-modes { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 6px; }
@@ -955,7 +955,7 @@ onMounted(() => {
 .jv-ob-warn-icon { color: var(--red); margin-right: 4px; flex: none; }
 .jv-ob-mode-btn { width: 100%; margin-top: auto; }
 
-/* ---- Account — ported from desk .jo-label/.jo-input (jarvis_onboarding.js
+/* ---- Account - ported from desk .jo-label/.jo-input (jarvis_onboarding.js
    ~378 renderAccount). ---- */
 .jv-ob-label { display: block; font-size: 12.5px; font-weight: 600; color: var(--text-2); margin: 14px 0 6px; }
 .jv-ob-label:first-of-type { margin-top: 0; }
@@ -973,7 +973,7 @@ onMounted(() => {
 .jv-ob-input:focus { outline: none; border-color: var(--blue-bd); }
 .jv-ob-err { font-size: 12.5px; color: var(--red); min-height: 1em; margin: 10px 0; }
 
-/* ---- Plan — ported from desk .jo-plans/.jo-plan (jarvis_onboarding.js ~481
+/* ---- Plan - ported from desk .jo-plans/.jo-plan (jarvis_onboarding.js ~481
    renderPlan). ---- */
 .jv-ob-plans { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin: 4px 0 20px; }
 .jv-ob-plan {
@@ -1001,7 +1001,7 @@ onMounted(() => {
 .jv-ob-plan-feats li { display: flex; gap: 7px; font-size: 12px; color: var(--text-2); line-height: 1.5; margin-bottom: 5px; }
 .jv-ob-muted { color: var(--text-3); }
 
-/* ---- Pay — ported from desk .jo-summary/.jo-row/.jo-devnote
+/* ---- Pay - ported from desk .jo-summary/.jo-row/.jo-devnote
    (jarvis_onboarding.js ~515 renderPay). ---- */
 .jv-ob-summary { border: 1px solid var(--border); border-radius: 10px; padding: 4px 14px; margin: 4px 0 14px; }
 .jv-ob-row { display: flex; justify-content: space-between; align-items: baseline; padding: 9px 0; font-size: 13px; color: var(--text-3); border-bottom: 1px solid var(--border); }
@@ -1011,7 +1011,7 @@ onMounted(() => {
 .jv-ob-row-total b { font-size: 15px; }
 .jv-ob-devnote { font-size: 12.5px; color: var(--amber); background: var(--amber-bg); border: 1px solid var(--amber-bd); border-radius: 8px; padding: 8px 12px; margin-bottom: 14px; }
 
-/* ---- Self-host — ported from desk .jo-check/.jo-sh-* (jarvis_onboarding.js
+/* ---- Self-host - ported from desk .jo-check/.jo-sh-* (jarvis_onboarding.js
    ~296-376 renderSelfHost/renderShResults). ---- */
 .jv-ob-check { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--text); margin-top: 8px; cursor: pointer; }
 .jv-ob-sh-results { margin: 14px 0 4px; font-size: 12.5px; line-height: 1.7; }


### PR DESCRIPTION
## Replace em-dashes and en-dashes with hyphens (frontend)

Clears the project's no-em-dash rule debt across the SPA. Surfaced during the write-UX work (Phase 2 review flagged ~95 em-dashes in `ChatView.vue`); the sweep found the debt is frontend-wide.

### Scope
- **520 em-dashes (U+2014) + 5 en-dashes (U+2013)** replaced with ASCII hyphens across **78 files** in `frontend/src`.
- Pure 1:1 mechanical change: 519 insertions / 519 deletions, every one a dash -> hyphen.
- **Python is already clean** (0 em-dashes in `app/jarvis`) - this is frontend-only.

### Safety - no functional dashes changed
Before replacing, I verified none of the dashes are load-bearing:
- 361 of the occurrences are pure comment lines; the rest are display / template strings.
- The functional-context checks (`.split`/`.includes`/`.indexOf`/`.startsWith`/`.endsWith`, SVG `d="..."` paths) returned nothing.
- The one regex-adjacent line (`ChatView.vue` notify with `.replace(/\.$/, "")`) had the em-dash in the *displayed* message, not the regex - the regex is untouched.
- The en-dashes were all comments or display ranges ("Name (A-Z)", pagination "1-6 of 50").

### Verification
- `vite build` (full SPA compile of all 78 touched files): **succeeds** (`✓ built in 7.75s`).
- All 8 `node --test` suites pass (`theme`, `pool`, `chartTheme`, `usageCharts`, `actionSummary`, `user`, `format`, `steps`).
- `grep` confirms **0 em-dashes and 0 en-dashes** remain in `frontend/src`.

Every change is `—`/`–` -> `-`; a handful of no-space em-dashes became tight hyphens (e.g. "a—b" -> "a-b"), which is fine and reads naturally in the sampled strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
