### PR TITLE
feat(wiki): Obsidian-parity 3D knowledge graph — shared wiki-graph-core + tenant SPA tab

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "mermaid": "^11.15.0",
         "socket.io-client": "^4.7.5",
         "vue": "^3.4.21",
-        "vue-router": "^4.3.0"
+        "vue-router": "^4.3.0",
+        "wiki-graph-core": "file:../wiki-graph-core"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
@@ -25,10 +26,25 @@
         "vite": "^5.2.0"
       }
     },
+    "../wiki-graph-core": {
+      "version": "0.1.0",
+      "dependencies": {
+        "3d-force-graph": "^1.80.0",
+        "graphology": "^0.25.4",
+        "graphology-communities-louvain": "^2.0.2",
+        "graphology-metrics": "^2.4.0",
+        "vue": "^3.4.0"
+      }
+    },
+    "../wiki-graph-probe": {
+      "version": "0.0.0",
+      "extraneous": true
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -681,6 +697,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -694,6 +711,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -703,6 +721,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2348,6 +2367,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -2379,6 +2399,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-hidden": {
@@ -2560,6 +2581,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3311,12 +3333,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dompurify": {
@@ -3383,6 +3407,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3484,6 +3509,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3500,6 +3526,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3643,6 +3670,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3693,6 +3721,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3798,6 +3827,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -3864,6 +3894,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3915,6 +3946,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3927,6 +3959,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkifyjs": {
@@ -4020,6 +4053,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4070,6 +4104,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4083,6 +4118,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4148,6 +4184,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -4196,6 +4233,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4205,6 +4243,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4276,6 +4315,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -4306,6 +4346,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4315,6 +4356,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4379,6 +4421,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4396,6 +4439,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4421,6 +4465,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4463,6 +4508,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4488,6 +4534,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4514,6 +4561,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
@@ -4708,6 +4756,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4750,6 +4799,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4866,6 +4916,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4900,6 +4951,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4979,6 +5031,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5131,6 +5184,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -5153,6 +5207,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5174,6 +5229,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5186,6 +5242,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -5223,6 +5280,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5235,6 +5293,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5248,6 +5307,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -5257,6 +5317,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -5324,6 +5385,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -5684,6 +5746,10 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/wiki-graph-core": {
+      "resolved": "../wiki-graph-core",
+      "link": true
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "mermaid": "^11.15.0",
     "socket.io-client": "^4.7.5",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0"
+    "vue-router": "^4.3.0",
+    "wiki-graph-core": "file:../wiki-graph-core"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/frontend/src/api/wiki.js
+++ b/frontend/src/api/wiki.js
@@ -52,6 +52,18 @@ export const restoreWikiPage = (slug) => call(WK + "restore_wiki_page", { slug }
 // Chat nudge card: "don't ask again in this conversation" (7-day snooze).
 export const dismissWikiNudge = (conversation) => call(WK + "dismiss_nudge", { conversation })
 
+// ── Knowledge Graph ───────────────────────────────────────────────────────────
+// Caller-scoped {nodes, edges, counts} over ONLY the pages the viewer may see
+// (server-enforced isolation); page nodes carry title+summary for client TF-IDF.
+export const getWikiGraph = () => call(WK + "get_wiki_graph")
+// Curate a [[link]] slug→target, stored out-of-body (durable), idempotent,
+// concurrency-safe, permission-checked both ends. → {ok, manual_links, already?}
+export const addWikiLink = (slug, targetSlug) =>
+	call(WK + "add_wiki_link", { slug, target_slug: targetSlug })
+// Measured daily graph totals [{date, pages, links, orphans, ...}] for the
+// Evolution tab; [] until the daily snapshot job has recorded a day.
+export const getWikiGraphHistory = () => call(WK + "get_wiki_graph_history")
+
 // ── SM-only header extras ─────────────────────────────────────────────────────
 export const setKnowledgeLanguage = (value) => call(WK + "set_knowledge_language", { value })
 // Queues a FULL org-wiki mirror sync into the agent workspace. → {ok: true}

--- a/frontend/src/pages/skills/SkillsPage.vue
+++ b/frontend/src/pages/skills/SkillsPage.vue
@@ -24,6 +24,7 @@
 			@changed="refreshBadge"
 		/>
 		<WikiTab v-else-if="activeTab === 'wiki'" class="min-h-0 flex-1" />
+		<KnowledgeGraph v-else-if="activeTab === 'graph'" class="min-h-0 flex-1" />
 		<BusinessTab v-else class="min-h-0 flex-1" />
 	</div>
 </template>
@@ -46,6 +47,8 @@ import SkillsList from "./SkillsList.vue"
 import LearningTab from "./LearningTab.vue"
 import BusinessTab from "./BusinessTab.vue"
 import WikiTab from "./WikiTab.vue"
+import KnowledgeGraph from "@/pages/wiki/KnowledgeGraph.vue"
+import { renderer3dEnabled } from "wiki-graph-core"
 import { getLearningStatus, pendingLearnedCount } from "@/api/learning"
 import { getBusinessStatus } from "@/api/voice"
 
@@ -56,6 +59,9 @@ const isSM = ref(false)
 const businessAllowed = ref(false)
 const learningPending = ref(0)
 const activeTab = ref("skills")
+// Knowledge Graph tab is behind the per-surface renderer flag (R10, default off);
+// flip via localStorage.wg3d = "on" until the 3D renderer soaks in prod.
+const graph3dOn = renderer3dEnabled()
 
 const tabs = computed(() => {
 	const t = [{ label: "Skills", value: "skills" }]
@@ -66,6 +72,7 @@ const tabs = computed(() => {
 		// (no extra probe; portal/guest sessions never see the strip at all)
 		t.push({ label: "Business", value: "business" })
 		t.push({ label: "Wiki", value: "wiki" })
+		if (graph3dOn) t.push({ label: "Knowledge Graph", value: "graph" })
 	}
 	return t
 })
@@ -82,12 +89,14 @@ function applyHash() {
 	else if (h === "business" && (isSM.value || businessAllowed.value))
 		activeTab.value = "business"
 	else if (h === "wiki" && (isSM.value || businessAllowed.value)) activeTab.value = "wiki"
+	else if (h === "graph" && graph3dOn && (isSM.value || businessAllowed.value)) activeTab.value = "graph"
 	else activeTab.value = "skills"
 }
 function setTab(v) {
 	if (v === activeTab.value) return
 	if (v === "learning" && !isSM.value) return
 	if ((v === "business" || v === "wiki") && !(isSM.value || businessAllowed.value)) return
+	if (v === "graph" && !(graph3dOn && (isSM.value || businessAllowed.value))) return
 	activeTab.value = v
 	router.push({ hash: v === "skills" ? "" : `#${v}` })
 }

--- a/frontend/src/pages/wiki/KnowledgeGraph.vue
+++ b/frontend/src/pages/wiki/KnowledgeGraph.vue
@@ -1,0 +1,167 @@
+<template>
+	<div class="kg flex h-full flex-col overflow-hidden">
+		<div class="kg-head">
+			<h5>Knowledge Graph</h5>
+			<span v-if="state.loaded && pageCount" class="text-muted">{{ pageCount }} pages · {{ linkCount }} links</span>
+		</div>
+
+		<div v-if="!state.loaded" class="kg-skel"></div>
+		<div v-else-if="state.error" class="kg-err">
+			{{ state.error }} <button class="kg-btn" @click="load">Retry</button>
+		</div>
+		<div v-else-if="!rawPageCount" class="kg-empty text-muted">
+			<i>No wiki pages yet — create some under the Wiki tab, then come back to
+			connect and explore them here.</i>
+		</div>
+
+		<div v-else class="kg-layout min-h-0 flex-1">
+			<div class="kg-main">
+				<div class="kg-tools">
+					<FilterBar :mode="state.mode" :overlay="state.overlay" :shown="pageCount" :total="rawPageCount"
+						@update:mode="(v) => (state.mode = v)" @update:overlay="(v) => (state.overlay = v)" />
+					<input class="kg-search" type="text" placeholder="Search nodes…" v-model="state.search" />
+					<span v-if="state.focus" class="kg-focus">Focused · <a href="#" @click.prevent="state.focus = null">clear</a></span>
+				</div>
+				<ExclusionRules class="kg-excl" :page-types="pageTypes" :excluded="state.excluded"
+					@update:excluded="onExclude" />
+				<Graph3D :data="filtered" :metrics="state.analysis.metrics" :mode="state.mode"
+					:dark="dark" @node-click="onNode" />
+			</div>
+			<div class="kg-side">
+				<DetailPanel :node="state.selected" :metrics="state.analysis.metrics"
+					:communities="state.analysis.communities" @focus="(id) => (state.focus = id)" />
+				<AnalysisTabs :analysis="state.analysis" :nodes="baseData.nodes" :actions="state.actions"
+					:history="state.history" :can-act="true" @pick="pickId" @add-link="onAddLink" />
+			</div>
+		</div>
+
+		<div v-if="state.toast" class="kg-toast">{{ state.toast }}</div>
+	</div>
+</template>
+
+<script setup>
+// Tenant Knowledge Graph — the productive tool. Fetch caller-scoped graph → apply
+// exclusion → worker analysis (structure + TF-IDF similarity) → 3D graph + the
+// four analysis tabs. Productive loop: accept a suggested connection → add_wiki_link
+// (durable, out-of-body) → refetch → the edge appears.
+import { reactive, computed, watch, onMounted } from "vue"
+import {
+	Graph3D, FilterBar, DetailPanel, AnalysisTabs, ExclusionRules,
+	runAnalysis, computeActions, overlayFilter, egoGraph, searchGraph,
+} from "wiki-graph-core"
+import { getWikiGraph, addWikiLink, getWikiGraphHistory } from "@/api/wiki"
+
+const PAGE_TYPES = ["Customer", "Supplier", "Item", "Process", "Doctype", "Exception", "Integration", "People", "Org"]
+
+const state = reactive({
+	data: { nodes: [], edges: [] },
+	analysis: { metrics: {}, lists: {}, communities: {} },
+	actions: {},
+	history: [],
+	loaded: false, error: null, selected: null,
+	mode: "kind", overlay: "knowledge", search: "", focus: null, toast: "",
+	excluded: readExcluded(),
+})
+const dark = document.documentElement.getAttribute("data-theme") === "dark"
+
+function readExcluded() {
+	try { return JSON.parse(localStorage.getItem("wg-excl") || "[]") } catch (_) { return [] }
+}
+function onExclude(list) {
+	state.excluded = list
+	try { localStorage.setItem("wg-excl", JSON.stringify(list)) } catch (_) {}
+}
+
+function applyExclusion(data, excluded) {
+	if (!excluded || !excluded.length) return data
+	const ex = new Set(excluded)
+	const nodes = (data.nodes || []).filter((n) => n.kind !== "page" || !ex.has(n.page_type))
+	const ids = new Set(nodes.map((n) => n.id))
+	const edges = (data.edges || []).filter((e) => ids.has(e.source) && ids.has(e.target))
+	return { nodes, edges, gaps: data.gaps, co_read: data.co_read }
+}
+
+const baseData = computed(() => applyExclusion(state.data, state.excluded))
+const rawPageCount = computed(() => (state.data.nodes || []).filter((n) => n.kind === "page").length)
+const pageCount = computed(() => baseData.value.nodes.filter((n) => n.kind === "page").length)
+const linkCount = computed(() => baseData.value.edges.filter((e) => e.kind === "links-to").length)
+const pageTypes = computed(() => {
+	const present = new Set((state.data.nodes || []).filter((n) => n.kind === "page").map((n) => n.page_type))
+	return PAGE_TYPES.filter((t) => present.has(t))
+})
+const filtered = computed(() => {
+	const g = overlayFilter(baseData.value, state.overlay)
+	if (state.focus) return egoGraph(g, state.focus, 2)
+	if (state.search) return searchGraph(g, state.search, 1)
+	return g
+})
+
+let _seq = 0
+async function recompute() {
+	const token = ++_seq
+	const data = baseData.value
+	const analysis = await runAnalysis(data)
+	if (token !== _seq) return // a newer recompute superseded us
+	state.analysis = analysis
+	state.actions = computeActions(data, analysis)
+}
+
+async function load() {
+	state.loaded = false
+	state.error = null
+	try {
+		const d = await getWikiGraph()
+		state.data = d || { nodes: [], edges: [] }
+		// Measured evolution history (best-effort; empty until the daily job runs
+		// or the doctype is migrated in — the Evolution tab reconstructs meanwhile).
+		getWikiGraphHistory().then((h) => { state.history = Array.isArray(h) ? h : [] }).catch(() => {})
+		await recompute()
+	} catch (e) {
+		state.error = (e && e.message) || String(e)
+	} finally {
+		state.loaded = true
+	}
+}
+
+function onNode(node) { state.selected = node }
+function pickId(id) {
+	const n = (state.data.nodes || []).find((x) => x.id === id)
+	if (n) state.selected = n
+}
+async function onAddLink(s) {
+	const a = String(s.a || "").replace(/^page:/, "")
+	const b = String(s.b || "").replace(/^page:/, "")
+	if (!a || !b) return
+	state.toast = `Linking ${s.aLabel} ↔ ${s.bLabel}…`
+	try {
+		await addWikiLink(a, b)
+		state.toast = "Link added ✓"
+		await load()
+	} catch (e) {
+		state.toast = (e && e.message) ? `Couldn't add link: ${e.message}` : "Couldn't add link"
+	}
+	setTimeout(() => { state.toast = "" }, 2000)
+}
+
+watch(() => state.excluded, recompute)
+onMounted(load)
+</script>
+
+<style scoped>
+.kg { padding: 4px 2px; }
+.kg-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px; }
+.kg-layout { display: grid; grid-template-columns: 1fr 340px; gap: 16px; }
+.kg-side { display: flex; flex-direction: column; gap: 14px; overflow-y: auto; }
+.kg-tools { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 6px; }
+.kg-excl { margin-bottom: 8px; }
+.kg-search { font-size: 12px; padding: 4px 10px; border: 1px solid var(--border-color, #d1d8dd); border-radius: 6px; min-width: 180px; }
+.kg-focus { font-size: 12px; background: var(--bg-blue, #4c9aff); color: #fff; border-radius: 10px; padding: 1px 10px; }
+.kg-focus a { color: #fff; text-decoration: underline; }
+.kg-err { color: #d9534f; padding: 16px 0; }
+.kg-empty { padding: 24px 4px; font-size: 13px; }
+.kg-btn { font-size: 12px; padding: 3px 10px; border: 1px solid var(--border-color, #d1d8dd); border-radius: 6px; background: var(--card-bg, #fff); cursor: pointer; margin-left: 8px; }
+.kg-skel { height: 60vh; border-radius: 8px; background: var(--control-bg, #f3f4f6); animation: kg-pulse 1.4s ease-in-out infinite; }
+@keyframes kg-pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 0.9; } }
+.kg-toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: #222; color: #fff; padding: 8px 16px; border-radius: 8px; font-size: 13px; z-index: 50; }
+@media (max-width: 1100px) { .kg-layout { grid-template-columns: 1fr; } }
+</style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -19,6 +19,9 @@ export default defineConfig({
 		alias: {
 			"@": path.resolve(__dirname, "src"),
 		},
+		// wiki-graph-core is a self-contained file: package (own vue in its
+		// node_modules); dedupe keeps a single Vue instance shared with the app.
+		dedupe: ["vue"],
 	},
 	optimizeDeps: {
 		include: ["frappe-ui > feather-icons", "showdown", "engine.io-client"],

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -496,6 +496,29 @@ def push_wiki_files(files: list[dict], delete: list | None = None,
 		return None
 
 
+def push_wiki_graph(payload: dict) -> dict | None:
+	"""POST the computed User/Role/Org wiki-utilization graph to admin, which
+	re-validates and upserts it into ``Jarvis Wiki Graph Snapshot`` (see
+	jarvis.chat.wiki_graph). Own rate bucket admin-side; NOT a container op.
+
+	Returns the parsed response dict or None on ANY failure — the graph is a
+	derived, rebuildable analytics copy and the sync must degrade to "retry next
+	sync", never raise into the wiki save paths or the sync worker.
+	"""
+	try:
+		return _post(
+			path="/api/method/jarvis_admin.api.tenant.post_push_wiki_graph",
+			body={"graph": payload},
+			timeout_s=60,
+		)
+	except Exception:
+		frappe.log_error(
+			title="admin_client: push_wiki_graph failed",
+			message=frappe.get_traceback(),
+		)
+		return None
+
+
 def get_generated_media(since_ms: int = 0) -> list[dict]:
 	"""Pull recent codex ``imagegen`` output for this customer's running tenant
 	container (admin → fleet → container disk). Returns a list of

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -1067,3 +1067,132 @@ def run_wiki_lint_now() -> dict:
 	from jarvis.learning import wiki_lint
 
 	return {"ok": True, "summary": wiki_lint.run_lint()}
+
+
+@frappe.whitelist()
+def get_wiki_graph() -> dict:
+	"""Caller-scoped Obsidian-style graph for the tenant Knowledge Graph SPA:
+	``{nodes, edges, counts}`` over ONLY the Active pages the caller may see.
+
+	R3 isolation invariant: this is the SINGLE server-side enforcement point.
+	Pages outside the caller's scope-visibility never enter the node set, so the
+	client's TF-IDF/structural similarity (which runs over the received set only)
+	cannot surface an unseen page, and links to unseen pages drop by construction.
+	Page nodes carry ``title`` + ``summary`` for the client-side TF-IDF."""
+	_require_system_user()
+	from jarvis.chat import wiki_graph
+
+	where = "status = 'Active'"
+	vis = (wiki_permissions.visible_scope_condition(frappe.session.user) or "").strip()
+	if vis:
+		where += f" and ({vis})"
+	fields = ", ".join(f"`{f}`" for f in [*wiki_graph._PAGE_FIELDS, "summary"])
+	pages = frappe.db.sql(
+		f"select {fields} from `tabJarvis Wiki Page` where {where} "
+		"order by modified desc limit %(lim)s",
+		{"lim": wiki_graph.MAX_PAGES},
+		as_dict=True,
+	)
+	return wiki_graph._build_graph_from_pages(pages, include_content=True)
+
+
+@frappe.whitelist()
+def get_wiki_graph_history() -> list:
+	"""Measured Knowledge-Evolution series: the daily ORG-WIDE graph totals
+	recorded by ``wiki_graph.record_history_snapshot`` (one row/day). Powers the
+	Evolution tab's real timeline (page + link growth, orphan decline).
+
+	System Manager only, unlike ``get_wiki_graph``: these are org-wide aggregates
+	over ALL pages (no scope filter), so a scoped user could learn totals about
+	pages they can't see. Non-SM callers get ``[]``; the Evolution tab falls back
+	to reconstructing growth from the caller's own visible pages' creation dates
+	— same fallback used when the daily job hasn't recorded a day yet."""
+	_require_system_user()
+	if "System Manager" not in frappe.get_roles():
+		return []
+	if not frappe.db.table_exists("Jarvis Wiki Graph History"):
+		return []
+	rows = frappe.get_all(
+		"Jarvis Wiki Graph History",
+		fields=["snapshot_date", "pages", "links", "orphans", "stale", "contradictions"],
+		order_by="snapshot_date asc",
+		limit=1000,
+	)
+	return [
+		{
+			"date": str(r.snapshot_date),
+			"pages": r.pages or 0,
+			"links": r.links or 0,
+			"orphans": r.orphans or 0,
+			"stale": r.stale or 0,
+			"contradictions": r.contradictions or 0,
+		}
+		for r in rows
+	]
+
+
+def _parse_manual_links(raw) -> list:
+	"""manual_links JSON → a clean, deduped list of slug strings (NULL/junk → [])."""
+	try:
+		arr = json.loads(raw) if isinstance(raw, str) else (raw or [])
+	except Exception:
+		return []
+	if not isinstance(arr, list):
+		return []
+	out = []
+	for t in arr:
+		s = str(t or "").strip().lower()
+		if s and s not in out:
+			out.append(s)
+	return out
+
+
+@frappe.whitelist()
+def add_wiki_link(slug: str, target_slug: str) -> dict:
+	"""Curate a ``[[link]]`` from ``slug`` → ``target_slug``, stored OUT of
+	``body_md`` in ``manual_links``.
+
+	- R1 durable: the manual store survives LLM re-ingestion (which full-replaces
+	  body_md); this write never touches body_md.
+	- R2 idempotent: the store is an exact-slug list, so no ``[[foo]]`` vs
+	  ``[[foobar]]`` confusion and a repeat is a no-op.
+	- R2 concurrency-safe: the read locks the row (``for_update``), so it sees the
+	  latest committed value (not this transaction's REPEATABLE READ snapshot) and
+	  blocks concurrent adders until we commit — no retry loop needed.
+	- R3 permission-checked BOTH ends: caller must be able to EDIT ``slug`` and
+	  READ ``target_slug`` — a link can neither be added by an unauthorized user
+	  nor point at a page they can't see (and a non-visible target reads as
+	  not-found so its existence isn't disclosed)."""
+	_require_system_user()
+	slug = (slug or "").strip().lower()
+	target = (target_slug or "").strip().lower()
+	if not slug or not target:
+		frappe.throw(_("slug and target_slug are required."))
+	if slug == target:
+		frappe.throw(_("A page cannot link to itself."))
+
+	name = frappe.db.get_value(WIKI, {"slug": slug}, "name")
+	if not name:
+		frappe.throw(_("Wiki page not found."))
+	if not wiki_permissions.can_edit_page(frappe.get_doc(WIKI, name), frappe.session.user):
+		frappe.throw(_("Not permitted."), frappe.PermissionError)
+
+	target_name = frappe.db.get_value(WIKI, {"slug": target}, "name")
+	if not target_name or not wiki_permissions.can_read_page(
+		frappe.get_doc(WIKI, target_name), frappe.session.user
+	):
+		# Don't disclose a page the caller can't see.
+		frappe.throw(_("Target page not found."))
+
+	# Locking read: blocks until any concurrent add_wiki_link on this row commits,
+	# then returns the latest value (a plain read under REPEATABLE READ would
+	# keep replaying this transaction's original snapshot on every retry).
+	raw = frappe.db.get_value(WIKI, name, "manual_links", for_update=True)
+	links = _parse_manual_links(raw)
+	if target in links:
+		return {"ok": True, "slug": slug, "already": True, "manual_links": links}
+	links.append(target)
+	# set_value bumps modified/modified_by so a concurrent doc.save() built on the
+	# stale doc raises TimestampMismatch instead of silently clobbering (R1).
+	frappe.db.set_value(WIKI, name, "manual_links", json.dumps(links))
+	return {"ok": True, "slug": slug, "manual_links": links}

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -1,0 +1,338 @@
+"""Push a compact User/Role/Org wiki-utilization graph to admin (wiki v2 D3).
+
+The site DB is canonical (``Jarvis Wiki Page``); this renders a bounded node/edge
+STRUCTURE payload — the scope tiers (Org/Role/User), the authored-from-provenance
+edges, and user→role membership resolved via ``Has Role`` — and POSTs it to the
+control plane (``jarvis.admin_client.push_wiki_graph`` → jarvis_admin relay →
+``Jarvis Wiki Graph Snapshot``). Admin overlays READ/WRITE + latent-demand
+activity from openclaw telemetry it already reads; this push carries only the
+DB-only tiers (roles, scope, page metadata) that never otherwise leave the site
+— Role/User pages are never mirrored to the container. Derived + rebuildable;
+NEVER raises into the save/sync path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import frappe
+from frappe.utils import cint
+
+from jarvis.chat.wiki import PAGE_TYPES, is_stale
+
+# Obsidian-style wikilink in a page body: [[slug]], [[slug|alias]], [[slug#h]].
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+_MAX_LINKS_PER_PAGE = 50
+
+WIKI = "Jarvis Wiki Page"
+SETTINGS = "Jarvis Settings"
+
+JOB_METHOD = "jarvis.chat.wiki_graph.sync"
+JOB_ID = "wiki-graph-sync"
+QUEUE = "short"
+JOB_TIMEOUT_S = 120
+
+# Defensive caps — the admin ingest re-bounds these, but a bench must never emit
+# an unbounded payload. A normal org sits far under these.
+MAX_PAGES = 2000
+MAX_USERS = 500
+MAX_EDGES = 20000
+
+_PAGE_FIELDS = [
+	"name", "title", "page_type", "scope", "target_role", "target_user",
+	"sources", "status", "last_confirmed_at", "contradiction_flag", "modified",
+	"creation",
+	# manual_links: human-curated [[links]] kept OUT of body_md so LLM re-ingest
+	# (which full-replaces body_md) can't clobber them; unioned into links-to.
+	"manual_links",
+	# body_md is read to extract [[wikilink]] edges tenant-side; it is NEVER
+	# put on a node (only the derived page→page edges travel to admin).
+	"body_md",
+]
+
+# Scope value → the node an Org/Role/User page is "covered by".
+_ORG_ID = "org"
+
+
+def _norm_scope(scope) -> str:
+	"""NULL/'' → Org (pre-v2 rows), else the stored scope."""
+	return (scope or "").strip() or "Org"
+
+
+def _org_label() -> str:
+	"""Best-effort human name for the org node; admin can override from the
+	Jarvis Customer. Falls back to the site name."""
+	company = frappe.defaults.get_global_default("company")
+	return company or frappe.local.site or "Organization"
+
+
+def _extract_link_targets(body, known: set[str]) -> list[str]:
+	"""``[[slug]]`` wikilinks in a body → target slugs, keeping only links to
+	pages that exist (Obsidian's graph drops dangling links) and capping per
+	page. ``[[slug|alias]]`` / ``[[slug#heading]]`` normalize to ``slug``."""
+	out: list[str] = []
+	seen: set[str] = set()
+	for raw in _WIKILINK_RE.findall(body or ""):
+		target = raw.split("|", 1)[0].split("#", 1)[0].strip().lower()
+		if target and target in known and target not in seen:
+			seen.add(target)
+			out.append(target)
+			if len(out) >= _MAX_LINKS_PER_PAGE:
+				break
+	return out
+
+
+def _manual_link_targets(raw, known: set[str]) -> list[str]:
+	"""``manual_links`` (JSON list of target slugs) → the ones that exist. The
+	durable, out-of-body half of the link set (R1)."""
+	try:
+		arr = json.loads(raw) if isinstance(raw, str) else (raw or [])
+	except Exception:
+		return []
+	if not isinstance(arr, list):
+		return []
+	out: list[str] = []
+	for t in arr:
+		s = str(t or "").strip().lower()
+		if s and s in known and s not in out:
+			out.append(s)
+	return out
+
+
+def _sources_authors(raw) -> dict[str, int]:
+	"""``sources`` JSON ([{date, kind, ref, user}]) → {user: authored_count}.
+	Corrupt JSON contributes nothing rather than failing the compute."""
+	try:
+		entries = json.loads(raw) if raw else []
+	except Exception:
+		return {}
+	if not isinstance(entries, list):
+		return {}
+	counts: dict[str, int] = {}
+	for entry in entries:
+		if not isinstance(entry, dict):
+			continue
+		user = (entry.get("user") or "").strip()
+		if user:
+			counts[user] = counts.get(user, 0) + 1
+	return counts
+
+
+def compute_graph() -> dict:
+	"""Org-wide graph for the admin push (all scopes, no page content). Bounded
+	``{nodes, edges, counts}`` — see ``_build_graph_from_pages`` for the shape."""
+	pages = frappe.get_all(
+		WIKI,
+		filters={"status": "Active"},
+		fields=_PAGE_FIELDS,
+		order_by="modified desc",
+		limit=MAX_PAGES,
+	)
+	return _build_graph_from_pages(pages)
+
+
+def _build_graph_from_pages(pages, include_content: bool = False) -> dict:
+	"""Bounded ``{nodes, edges, counts}`` from an already-fetched page list.
+
+	Shared by ``compute_graph`` (org-wide → admin push) and ``get_wiki_graph``
+	(caller-scoped → tenant SPA). Nodes: one ``org``; ``role`` nodes per
+	``target_role``; ``user`` nodes for authors + User-page targets; a ``page``
+	node per page (slug, title, type, scope, stale/contradiction; +summary when
+	``include_content``). Edges: ``scope`` (page→tier), ``authored`` (user→page,
+	weighted), ``member-of`` (user→role via live ``frappe.get_roles``),
+	``links-to`` (body ``[[links]]`` ∪ durable ``manual_links``). Callers pass a
+	page set already filtered to what they may emit, so edges to pages outside
+	the set are dropped by construction (the isolation invariant, R3)."""
+	nodes: list[dict] = [{"id": _ORG_ID, "kind": "org", "label": _org_label()}]
+	edges: list[dict] = []
+	role_ids: set[str] = set()
+	user_ids: set[str] = set()
+	known_slugs = {p.name for p in pages}
+	link_edges = 0
+
+	def _role_node(role: str) -> str:
+		rid = f"role:{role}"
+		if rid not in role_ids:
+			role_ids.add(rid)
+			nodes.append({"id": rid, "kind": "role", "label": role})
+		return rid
+
+	def _user_node(user: str) -> str:
+		uid = f"user:{user}"
+		if uid not in user_ids and len(user_ids) < MAX_USERS:
+			user_ids.add(uid)
+			nodes.append({"id": uid, "kind": "user", "label": user})
+		return uid
+
+	for p in pages:
+		slug = p.name
+		pid = f"page:{slug}"
+		scope = _norm_scope(p.scope)
+		node = {
+			"id": pid,
+			"kind": "page",
+			"label": p.title or slug,
+			"slug": slug,
+			"page_type": p.page_type if p.page_type in PAGE_TYPES else "Org",
+			"scope": scope,
+			"stale": is_stale(p.last_confirmed_at, p.modified),
+			"contradiction": bool(cint(p.contradiction_flag)),
+		}
+		# creation date for the Evolution timeline (day precision) — needed by
+		# BOTH pushes (admin's daily Evolution tab has no other source); summary
+		# stays gated on include_content (content must not travel to admin).
+		node["created"] = str(p.get("creation") or "")[:10]
+		if include_content:
+			# tenant SPA needs content for client-side TF-IDF similarity.
+			node["summary"] = p.get("summary") or ""
+		nodes.append(node)
+
+		# scope-covers edge: page → the tier that can see it. A User-scope page
+		# whose target user didn't get a node (MAX_USERS cap) falls back to org
+		# so no page is left tierless and no edge dangles.
+		if scope == "Role" and p.target_role:
+			edges.append({"source": pid, "target": _role_node(p.target_role), "kind": "scope"})
+		elif scope == "User" and p.target_user:
+			uid = _user_node(p.target_user)
+			edges.append({
+				"source": pid,
+				"target": uid if uid in user_ids else _ORG_ID,
+				"kind": "scope",
+			})
+		else:
+			edges.append({"source": pid, "target": _ORG_ID, "kind": "scope"})
+
+		# authored edges from provenance.
+		for user, count in _sources_authors(p.sources).items():
+			uid = _user_node(user)
+			if uid in user_ids:
+				edges.append({"source": uid, "target": pid, "kind": "authored", "weight": count})
+
+		# page→page links — the Obsidian knowledge graph itself: body [[wikilinks]]
+		# ∪ durable out-of-body manual_links (R1), deduped.
+		targets = _extract_link_targets(p.body_md, known_slugs)
+		for t in _manual_link_targets(p.get("manual_links"), known_slugs):
+			if t not in targets:
+				targets.append(t)
+		for target in targets:
+			if target != slug:
+				edges.append({"source": pid, "target": f"page:{target}", "kind": "links-to"})
+				link_edges += 1
+
+	# member-of: connect each user to the role nodes they actually hold (roles
+	# that have wiki pages). Resolved now — role assignments are mutable.
+	role_labels = {rid.split(":", 1)[1] for rid in role_ids}
+	if role_labels:
+		for uid in list(user_ids):
+			user = uid.split(":", 1)[1]
+			try:
+				held = set(frappe.get_roles(user))
+			except Exception:
+				continue
+			for role in role_labels & held:
+				edges.append({"source": uid, "target": f"role:{role}", "kind": "member-of"})
+
+	if len(edges) > MAX_EDGES:
+		edges = edges[:MAX_EDGES]
+		frappe.log_error(
+			title="wiki graph: edge cap hit", message=f"pages={len(pages)}"
+		)
+
+	return {
+		"nodes": nodes,
+		"edges": edges,
+		"counts": {
+			"pages": len(pages),
+			"authors": len(user_ids),
+			"roles": len(role_ids),
+			"links": link_edges,
+		},
+	}
+
+
+HISTORY_DT = "Jarvis Wiki Graph History"
+
+
+def record_history_snapshot() -> dict:
+	"""Daily: append today's org-wide graph totals to ``Jarvis Wiki Graph History``
+	(one row per day, idempotent). This is the MEASURED Knowledge-Evolution series
+	— real link growth + orphan decline over time — which the Evolution tab prefers
+	over the reconstructed-from-creation-dates fallback. Derived + rebuildable;
+	never raises into the scheduler."""
+	try:
+		return _record_history_snapshot()
+	except Exception:
+		frappe.log_error(title="wiki graph: history snapshot crashed", message=frappe.get_traceback())
+		return {"ok": False, "reason": "history snapshot crashed; see Error Log"}
+
+
+def _record_history_snapshot() -> dict:
+	g = compute_graph()
+	pages = [n for n in g["nodes"] if n.get("kind") == "page"]
+	linked: set[str] = set()
+	for e in g["edges"]:
+		if e.get("kind") == "links-to":
+			linked.add(e["source"])
+			linked.add(e["target"])
+	stats = {
+		"pages": len(pages),
+		"links": g["counts"]["links"],
+		"orphans": sum(1 for n in pages if n["id"] not in linked),
+		"stale": sum(1 for n in pages if n.get("stale")),
+		"contradictions": sum(1 for n in pages if n.get("contradiction")),
+	}
+	today = frappe.utils.today()
+	# Idempotent per day: the row is named by its date, so a re-run overwrites
+	# today's totals rather than appending a duplicate.
+	if frappe.db.exists(HISTORY_DT, today):
+		doc = frappe.get_doc(HISTORY_DT, today)
+		doc.update(stats)
+		doc.save(ignore_permissions=True)
+	else:
+		doc = frappe.get_doc({"doctype": HISTORY_DT, "snapshot_date": today, **stats})
+		doc.insert(ignore_permissions=True)
+	frappe.db.commit()
+	return {"ok": True, "date": today, **stats}
+
+
+def sync() -> dict:
+	"""Compute + push the graph. Swallows + logs; never raises into callers."""
+	try:
+		return _sync()
+	except Exception:
+		frappe.log_error(title="wiki graph: sync crashed", message=frappe.get_traceback())
+		return {"ok": False, "reason": "sync crashed; see Error Log"}
+
+
+def _sync() -> dict:
+	from jarvis import admin_client, selfhost
+
+	if selfhost.is_self_hosted():
+		return {"ok": True, "skipped": "self-hosted"}
+	payload = compute_graph()
+	resp = admin_client.push_wiki_graph(payload)
+	if resp is None:
+		return {"ok": False, "reason": "admin/tenant unreachable; will retry next sync"}
+	return {"ok": True, **payload["counts"]}
+
+
+def enqueue_sync() -> None:
+	"""Queue the deduped graph sync (short queue). Suppressed under tests;
+	enqueue failures (Redis down) are swallowed."""
+	if frappe.flags.in_test and not frappe.flags.get("jarvis_test_wiki_graph_enqueue"):
+		return
+	try:
+		frappe.enqueue(
+			JOB_METHOD, queue=QUEUE, timeout=JOB_TIMEOUT_S,
+			job_id=JOB_ID, deduplicate=True,
+		)
+	except Exception:
+		frappe.log_error(title="wiki graph: enqueue failed", message=frappe.get_traceback())
+
+
+@frappe.whitelist()
+def sync_now() -> dict:
+	"""Operator 'Sync now' from the Wiki tab (System Manager only)."""
+	frappe.only_for("System Manager")
+	return sync()

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -237,6 +237,13 @@ scheduler_events = {
 		# Daily voice-note sweep: mine New voice notes into learned-pattern
 		# candidates + wiki updates (self-gating; see jarvis/learning/voice_facts.py).
 		"jarvis.learning.voice_facts.process_daily",
+		# Daily push of the User/Role/Org wiki-utilization graph to admin (the
+		# DB-only scope/role tiers; admin overlays telemetry activity). Not on
+		# every wiki save — too chatty for an analytics view.
+		"jarvis.chat.wiki_graph.sync",
+		# Daily append of org-wide graph totals to Jarvis Wiki Graph History (one
+		# row/day) — the measured Knowledge-Evolution series for the Evolution tab.
+		"jarvis.chat.wiki_graph.record_history_snapshot",
 	],
 	"weekly": [
 		# Wiki v2 health check: deterministic lint over Active pages

--- a/jarvis/jarvis/doctype/jarvis_wiki_graph_history/jarvis_wiki_graph_history.json
+++ b/jarvis/jarvis/doctype/jarvis_wiki_graph_history/jarvis_wiki_graph_history.json
@@ -1,0 +1,74 @@
+{
+  "doctype": "DocType",
+  "name": "Jarvis Wiki Graph History",
+  "module": "Jarvis",
+  "custom": 0,
+  "engine": "InnoDB",
+  "autoname": "field:snapshot_date",
+  "naming_rule": "By fieldname",
+  "field_order": [
+    "snapshot_date",
+    "pages",
+    "links",
+    "orphans",
+    "stale",
+    "contradictions"
+  ],
+  "fields": [
+    {
+      "fieldname": "snapshot_date",
+      "fieldtype": "Date",
+      "label": "Snapshot Date",
+      "reqd": 1,
+      "unique": 1,
+      "in_list_view": 1,
+      "description": "The day these graph totals were measured. One row per day (append-only); the unique index makes the daily upsert idempotent."
+    },
+    {
+      "default": "0",
+      "fieldname": "pages",
+      "fieldtype": "Int",
+      "label": "Pages",
+      "in_list_view": 1
+    },
+    {
+      "default": "0",
+      "fieldname": "links",
+      "fieldtype": "Int",
+      "label": "Links",
+      "in_list_view": 1,
+      "description": "[[links]] plus manual links between pages on this day."
+    },
+    {
+      "default": "0",
+      "fieldname": "orphans",
+      "fieldtype": "Int",
+      "label": "Orphans",
+      "in_list_view": 1,
+      "description": "Pages with no link to or from any other page."
+    },
+    {
+      "default": "0",
+      "fieldname": "stale",
+      "fieldtype": "Int",
+      "label": "Stale"
+    },
+    {
+      "default": "0",
+      "fieldname": "contradictions",
+      "fieldtype": "Int",
+      "label": "Contradictions"
+    }
+  ],
+  "permissions": [
+    {
+      "role": "System Manager",
+      "read": 1,
+      "report": 1,
+      "export": 1
+    }
+  ],
+  "sort_field": "snapshot_date",
+  "sort_order": "DESC",
+  "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_wiki_graph_history/jarvis_wiki_graph_history.py
+++ b/jarvis/jarvis/doctype/jarvis_wiki_graph_history/jarvis_wiki_graph_history.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aerele and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class JarvisWikiGraphHistory(Document):
+	pass

--- a/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.json
+++ b/jarvis/jarvis/doctype/jarvis_wiki_page/jarvis_wiki_page.json
@@ -22,6 +22,7 @@
     "sources",
     "last_confirmed_at",
     "contradiction_flag",
+    "manual_links",
     "mirror_hash"
   ],
   "fields": [
@@ -137,6 +138,12 @@
       "fieldtype": "Check",
       "label": "Contradiction Flagged",
       "description": "Set when an extracted update contradicted the existing body; the conflicting info is appended as a flagged section, never silently overwritten."
+    },
+    {
+      "fieldname": "manual_links",
+      "fieldtype": "JSON",
+      "label": "Manual Links",
+      "description": "Human-curated [[link]] target slugs kept OUT of body_md so LLM re-ingestion (which full-replaces the body) can't clobber them. Unioned into the graph's links-to edges."
     },
     {
       "fieldname": "mirror_hash",

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -15,3 +15,4 @@ jarvis.patches.v1_6_rename_jarvis_approval
 jarvis.patches.v1_6_normalize_llm_preset_value
 jarvis.patches.v1_7_chat_message_page_index
 jarvis.patches.v1_8_backfill_wiki_scope
+jarvis.patches.v1_9_backfill_wiki_manual_links

--- a/jarvis/patches/v1_9_backfill_wiki_manual_links.py
+++ b/jarvis/patches/v1_9_backfill_wiki_manual_links.py
@@ -1,0 +1,18 @@
+"""Backfill manual_links='[]' on pre-existing Jarvis Wiki Page rows.
+
+The new JSON field reads NULL on rows created before it existed. Readers coalesce
+NULL to [] (jarvis.chat.wiki_graph._manual_link_targets), so this is belt-and-
+braces — it makes the stored value explicit for the add_wiki_link append path.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Jarvis Wiki Page", "manual_links"):
+		return
+	frappe.db.sql(
+		"""update `tabJarvis Wiki Page`
+		set manual_links = '[]'
+		where manual_links is null or manual_links = ''"""
+	)

--- a/jarvis/tests/test_wiki_graph.py
+++ b/jarvis/tests/test_wiki_graph.py
@@ -1,0 +1,376 @@
+"""Tenant-side wiki-utilization graph compute + push (jarvis.chat.wiki_graph)."""
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import wiki as wiki_mod
+from jarvis.chat import wiki_graph
+
+WIKI = "Jarvis Wiki Page"
+_PREFIX = "graphtest"
+# Framework built-ins (never tenant data) used as a real Role/User link target.
+_ROLE = "System Manager"
+_USER = "Administrator"
+
+
+def _delete_pages():
+	for name in frappe.get_all(
+		WIKI, filters={"slug": ["like", f"{_PREFIX}%"]}, pluck="name"
+	):
+		frappe.delete_doc(WIKI, name, force=True, ignore_permissions=True)
+
+
+class TestWikiGraphCompute(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_delete_pages()
+
+	def tearDown(self):
+		_delete_pages()
+		frappe.set_user("Administrator")
+
+	def _page(self, slug, title, scope="Org", page_type="Org",
+			  target_role=None, target_user=None, sources=None,
+			  body_md="secret body that must not travel", manual_links=None,
+			  summary=None):
+		doc = frappe.get_doc({
+			"doctype": WIKI, "slug": slug, "title": title, "page_type": page_type,
+			"scope": scope, "target_role": target_role, "target_user": target_user,
+			"status": "Active", "body_md": body_md, "summary": summary,
+		}).insert(ignore_permissions=True)
+		vals = {}
+		if sources is not None:
+			vals["sources"] = json.dumps(sources)  # read_only on the form
+		if manual_links is not None:
+			vals["manual_links"] = json.dumps(manual_links)
+		if vals:
+			frappe.db.set_value(WIKI, doc.name, vals, update_modified=False)
+		return doc
+
+	def _graph(self):
+		return wiki_graph.compute_graph()
+
+	def _node(self, g, node_id):
+		return next((n for n in g["nodes"] if n["id"] == node_id), None)
+
+	def test_org_page_scope_edge_and_no_body(self):
+		doc = self._page(f"{_PREFIX}-org", "Org Page")
+		g = self._graph()
+		pid = f"page:{doc.name}"
+		node = self._node(g, pid)
+		self.assertIsNotNone(node)
+		self.assertEqual(node["kind"], "page")
+		self.assertEqual(node["scope"], "Org")
+		# body_md must never be in the payload.
+		self.assertNotIn("body_md", node)
+		self.assertIn(
+			{"source": pid, "target": "org", "kind": "scope"}, g["edges"]
+		)
+
+	def test_admin_push_gets_created_without_content(self):
+		"""Finding 11: the daily admin push (include_content=False) still needs
+		`created` for the Evolution tab; only `summary` is content-gated."""
+		doc = self._page(f"{_PREFIX}-created", "Created Page")
+		g = self._graph()
+		node = self._node(g, f"page:{doc.name}")
+		self.assertTrue(node["created"])  # non-empty, e.g. "2026-07-08"
+		self.assertNotIn("summary", node)
+
+	def test_user_scope_edge_falls_back_to_org_when_user_cap_hit(self):
+		"""Finding 14: when MAX_USERS is hit, _user_node returns a uid string
+		without creating the node — a User-scope page must fall back to the org
+		edge rather than dangling to a nonexistent node."""
+		doc = self._page(f"{_PREFIX}-usercap", "User Page", scope="User",
+						  target_user=_USER)
+		with patch.object(wiki_graph, "MAX_USERS", 0):
+			g = self._graph()
+		pid = f"page:{doc.name}"
+		self.assertIsNone(self._node(g, f"user:{_USER}"))  # cap hit, no node
+		self.assertIn({"source": pid, "target": "org", "kind": "scope"}, g["edges"])
+
+	def test_role_page_makes_role_node_and_scope_edge(self):
+		doc = self._page(f"{_PREFIX}-role", "Role Page", scope="Role",
+						 target_role=_ROLE)
+		g = self._graph()
+		pid = f"page:{doc.name}"
+		rid = f"role:{_ROLE}"
+		self.assertIsNotNone(self._node(g, rid))
+		self.assertIn({"source": pid, "target": rid, "kind": "scope"}, g["edges"])
+
+	def test_user_page_makes_user_node_and_scope_edge(self):
+		doc = self._page(f"{_PREFIX}-user", "User Page", scope="User",
+						 target_user=_USER)
+		g = self._graph()
+		pid = f"page:{doc.name}"
+		uid = f"user:{_USER}"
+		self.assertIsNotNone(self._node(g, uid))
+		self.assertIn({"source": pid, "target": uid, "kind": "scope"}, g["edges"])
+
+	def test_authored_edge_weighted_from_sources(self):
+		doc = self._page(
+			f"{_PREFIX}-auth", "Authored", sources=[
+				{"date": "2026-07-01", "kind": "tool", "ref": None, "user": _USER},
+				{"date": "2026-07-02", "kind": "manual", "ref": None, "user": _USER},
+			],
+		)
+		g = self._graph()
+		pid, uid = f"page:{doc.name}", f"user:{_USER}"
+		edge = next((e for e in g["edges"]
+					 if e["source"] == uid and e["target"] == pid
+					 and e["kind"] == "authored"), None)
+		self.assertIsNotNone(edge)
+		self.assertEqual(edge["weight"], 2)
+
+	def test_member_of_resolves_held_roles(self):
+		# A role page makes the role a node; an author who holds that role gets
+		# a member-of edge. Administrator holds System Manager.
+		self._page(f"{_PREFIX}-role2", "Role Page", scope="Role", target_role=_ROLE)
+		self._page(f"{_PREFIX}-auth2", "Authored",
+				   sources=[{"date": "2026-07-01", "kind": "tool", "user": _USER}])
+		g = self._graph()
+		self.assertIn(
+			{"source": f"user:{_USER}", "target": f"role:{_ROLE}", "kind": "member-of"},
+			g["edges"],
+		)
+
+	def test_counts_and_org_node_present(self):
+		self._page(f"{_PREFIX}-c1", "A")
+		self._page(f"{_PREFIX}-c2", "B",
+				   sources=[{"date": "2026-07-01", "kind": "tool", "user": _USER}])
+		g = self._graph()
+		self.assertIsNotNone(self._node(g, "org"))
+		self.assertGreaterEqual(g["counts"]["pages"], 2)
+		self.assertGreaterEqual(g["counts"]["authors"], 1)
+
+	def test_wikilink_edges_between_pages(self):
+		# One page links to another via [[slug]]; a dangling link is dropped.
+		a = self._page(f"{_PREFIX}-linka", "A")
+		b = frappe.get_doc({
+			"doctype": WIKI, "slug": f"{_PREFIX}-linkb", "title": "B",
+			"page_type": "Org", "scope": "Org", "status": "Active",
+			"body_md": f"see [[{a.name}]] and [[{_PREFIX}-nope]] (dangling)",
+		}).insert(ignore_permissions=True)
+		g = self._graph()
+		self.assertIn(
+			{"source": f"page:{b.name}", "target": f"page:{a.name}", "kind": "links-to"},
+			g["edges"],
+		)
+		# dangling target (no such page) is not emitted.
+		self.assertFalse(any(
+			e["kind"] == "links-to" and e["target"] == f"page:{_PREFIX}-nope"
+			for e in g["edges"]
+		))
+		# body_md still never leaks onto a node.
+		self.assertFalse(any("body_md" in n for n in g["nodes"]))
+		self.assertGreaterEqual(g["counts"]["links"], 1)
+
+	def test_manual_links_union_and_dedup(self):
+		a = self._page(f"{_PREFIX}-mla", "A", body_md="")
+		# manual link with NO body link → still an edge (out-of-body, durable R1)
+		b = self._page(f"{_PREFIX}-mlb", "B", body_md="no links", manual_links=[a.name])
+		# body link + manual link to the same target → one edge (deduped)
+		c = self._page(f"{_PREFIX}-mlc", "C", body_md=f"see [[{a.name}]]",
+					   manual_links=[a.name, "nope-missing-slug"])
+		g = self._graph()
+		self.assertIn(
+			{"source": f"page:{b.name}", "target": f"page:{a.name}", "kind": "links-to"},
+			g["edges"],
+		)
+		c_to_a = [e for e in g["edges"] if e["kind"] == "links-to"
+				  and e["source"] == f"page:{c.name}" and e["target"] == f"page:{a.name}"]
+		self.assertEqual(len(c_to_a), 1)  # body ∪ manual deduped
+		# dangling manual link (no such page) dropped
+		self.assertFalse(any(e.get("target") == "page:nope-missing-slug" for e in g["edges"]))
+
+	def test_get_wiki_graph_scoped_with_content(self):
+		from jarvis.chat import wiki as wiki_mod
+		a = self._page(f"{_PREFIX}-gwa", "Alpha", body_md="", summary="alpha summary")
+		b = self._page(f"{_PREFIX}-gwb", "Beta", body_md="", manual_links=[a.name])
+		g = wiki_mod.get_wiki_graph()
+		an = self._node(g, f"page:{a.name}")
+		self.assertIsNotNone(an)
+		self.assertEqual(an.get("summary"), "alpha summary")  # include_content
+		self.assertNotIn("body_md", an)  # content is summary+title only, never body
+		self.assertIn(
+			{"source": f"page:{b.name}", "target": f"page:{a.name}", "kind": "links-to"},
+			g["edges"],
+		)
+
+	def test_get_wiki_graph_history_non_sm_blocked(self):
+		"""R3: org-wide aggregates are SM-only, unlike get_wiki_graph."""
+		with patch("frappe.get_roles", return_value=["Blogger"]):
+			self.assertEqual(wiki_mod.get_wiki_graph_history(), [])
+
+	def test_get_wiki_graph_history_sm_allowed(self):
+		with patch("frappe.get_roles", return_value=["System Manager"]):
+			self.assertIsInstance(wiki_mod.get_wiki_graph_history(), list)
+
+	# --- add_wiki_link (R1/R2/R3) ---
+	def test_add_link_out_of_body_and_edge(self):
+		a = self._page(f"{_PREFIX}-ala", "A", body_md="")
+		p = self._page(f"{_PREFIX}-alp", "P", body_md="original body")
+		res = wiki_mod.add_wiki_link(p.name, a.name)
+		self.assertTrue(res["ok"])
+		# body_md untouched (R1 — out of body)
+		self.assertEqual(frappe.db.get_value(WIKI, p.name, "body_md"), "original body")
+		self.assertIn(a.name, wiki_mod._parse_manual_links(
+			frappe.db.get_value(WIKI, p.name, "manual_links")))
+		g = self._graph()
+		self.assertIn({"source": f"page:{p.name}", "target": f"page:{a.name}", "kind": "links-to"},
+					  g["edges"])
+
+	def test_add_link_idempotent_and_exact(self):
+		a = self._page(f"{_PREFIX}-foo", "Foo", body_md="")
+		self._page(f"{_PREFIX}-foobar", "Foobar", body_md="")
+		p = self._page(f"{_PREFIX}-idp", "P", body_md="")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		res2 = wiki_mod.add_wiki_link(p.name, a.name)
+		self.assertTrue(res2.get("already"))
+		links = wiki_mod._parse_manual_links(frappe.db.get_value(WIKI, p.name, "manual_links"))
+		self.assertEqual(links.count(a.name), 1)  # no duplicate
+		# exact-slug membership: linking to -foobar never implies -foo
+		self.assertNotIn(f"{_PREFIX}-foobar", links)
+
+	def test_add_link_self_rejected(self):
+		p = self._page(f"{_PREFIX}-self", "P", body_md="")
+		with self.assertRaises(frappe.ValidationError):
+			wiki_mod.add_wiki_link(p.name, p.name)
+
+	def test_add_link_source_not_editable_blocked(self):
+		a = self._page(f"{_PREFIX}-nea", "A", body_md="")
+		p = self._page(f"{_PREFIX}-nep", "P", body_md="")
+		with patch("jarvis.chat.wiki_permissions.can_edit_page", return_value=False):
+			with self.assertRaises(frappe.PermissionError):
+				wiki_mod.add_wiki_link(p.name, a.name)
+
+	def test_add_link_target_not_readable_blocked(self):
+		a = self._page(f"{_PREFIX}-nra", "A", body_md="")
+		p = self._page(f"{_PREFIX}-nrp", "P", body_md="")
+		# target invisible → reads as not-found (doesn't disclose existence, R3)
+		with patch("jarvis.chat.wiki_permissions.can_read_page", return_value=False):
+			with self.assertRaises(frappe.ValidationError):
+				wiki_mod.add_wiki_link(p.name, a.name)
+
+	def test_add_link_durable_across_reingest(self):
+		a = self._page(f"{_PREFIX}-dura", "A", body_md="")
+		p = self._page(f"{_PREFIX}-durp", "P", body_md="original")
+		wiki_mod.add_wiki_link(p.name, a.name)
+		# simulate LLM re-ingest that full-replaces body_md (no [[a]] in it)
+		wiki_mod.apply_extracted_page_updates(
+			[{"slug": p.name, "body_md": "re-ingested body, no links at all"}],
+			"voice", _USER,
+		)
+		links = wiki_mod._parse_manual_links(frappe.db.get_value(WIKI, p.name, "manual_links"))
+		self.assertIn(a.name, links)  # survived the body overwrite (R1)
+		g = self._graph()
+		self.assertIn({"source": f"page:{p.name}", "target": f"page:{a.name}", "kind": "links-to"},
+					  g["edges"])
+
+	def test_add_link_bumps_modified_defeats_stale_save(self):
+		"""R1 (finding 3): the manual_links write bumps `modified`, so a
+		concurrent full-doc save loaded BEFORE our link add (e.g. LLM
+		re-ingest's frappe.get_doc -> doc.save()) raises TimestampMismatch
+		instead of silently clobbering the just-added link."""
+		p = self._page(f"{_PREFIX}-tsp", "P", body_md="pre-link body")
+		a = self._page(f"{_PREFIX}-tsa", "A", body_md="")
+		stale = frappe.get_doc(WIKI, p.name)  # loaded BEFORE the link add
+		wiki_mod.add_wiki_link(p.name, a.name)
+		stale.body_md = "full re-ingested body, no [[links]] at all"
+		with self.assertRaises(frappe.TimestampMismatchError):
+			stale.save(ignore_permissions=True)
+		# the stale save never landed — the link survived.
+		links = wiki_mod._parse_manual_links(frappe.db.get_value(WIKI, p.name, "manual_links"))
+		self.assertIn(a.name, links)
+
+	def test_add_link_uses_locking_read(self):
+		"""for_update=True on the manual_links read is what makes the write
+		race-free (R2) — assert the mechanism directly."""
+		p = self._page(f"{_PREFIX}-lockp", "P", body_md="")
+		a = self._page(f"{_PREFIX}-locka", "A", body_md="")
+		orig = frappe.db.get_value
+		seen = {}
+
+		def spy(dt, name=None, field=None, *args, **kwargs):
+			if dt == WIKI and field == "manual_links":
+				seen["for_update"] = kwargs.get("for_update")
+			return orig(dt, name, field, *args, **kwargs)
+
+		with patch.object(frappe.db, "get_value", side_effect=spy):
+			wiki_mod.add_wiki_link(p.name, a.name)
+		self.assertTrue(seen.get("for_update"))
+
+	def test_add_link_concurrency_no_lost_update(self):
+		"""Real second DB connection reproduces the R2 bug (finding 4): under
+		REPEATABLE READ a plain read stays pinned to the snapshot taken before a
+		concurrent writer's commit, so a naive retry loop would see this
+		transaction's pre-concurrent NULL forever. add_wiki_link's locking
+		(for_update) read instead returns the latest committed row, so the
+		concurrent add is merged, not lost. Uses this compat FrappeTestCase's
+		primary_connection/secondary_connection helpers (genuinely separate
+		MySQL connections, same technique frappe core uses for lock tests) —
+		every primary-side statement is explicitly wrapped in
+		``primary_connection()`` (the helper leaves ``frappe.db`` pointed at the
+		secondary connection after its first use otherwise). Requires committing
+		our fixtures so the second connection can see them; cleaned up (deleted +
+		committed) in `finally` so nothing leaks."""
+		p = self._page(f"{_PREFIX}-cp", "P", body_md="")
+		t1 = self._page(f"{_PREFIX}-ct1", "T1", body_md="")
+		t2 = self._page(f"{_PREFIX}-ct2", "T2", body_md="")
+		frappe.db.commit()
+		try:
+			with self.primary_connection():
+				# Pin our (primary) transaction's REPEATABLE READ snapshot now,
+				# via a plain read, before the concurrent write below.
+				self.assertIsNone(frappe.db.get_value(WIKI, p.name, "manual_links"))
+
+			# Genuinely concurrent writer: separate connection adds t2, commits.
+			with self.secondary_connection():
+				frappe.db.set_value(WIKI, p.name, "manual_links", json.dumps([t2.name]))
+				frappe.db.commit()
+
+			with self.primary_connection():
+				# Proof the snapshot is really stale: a plain read on our
+				# transaction still doesn't see the concurrent commit.
+				self.assertIsNone(frappe.db.get_value(WIKI, p.name, "manual_links"))
+
+				# add_wiki_link's locking read must see the latest committed
+				# value and merge t1 into it instead of clobbering t2.
+				wiki_mod.add_wiki_link(p.name, t1.name)
+				links = wiki_mod._parse_manual_links(
+					frappe.db.get_value(WIKI, p.name, "manual_links"))
+				self.assertIn(t1.name, links)  # our add
+				self.assertIn(t2.name, links)  # the concurrent add — NOT lost (R2)
+		finally:
+			with self.primary_connection():
+				_delete_pages()
+				frappe.db.commit()
+
+	def test_archived_pages_excluded(self):
+		doc = self._page(f"{_PREFIX}-arch", "Archived")
+		frappe.db.set_value(WIKI, doc.name, "status", "Archived", update_modified=False)
+		g = self._graph()
+		self.assertIsNone(self._node(g, f"page:{doc.name}"))
+
+
+class TestWikiGraphSync(FrappeTestCase):
+	def test_self_hosted_skips(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True):
+			out = wiki_graph.sync()
+		self.assertTrue(out["ok"])
+		self.assertEqual(out.get("skipped"), "self-hosted")
+
+	def test_push_unreachable_reports_not_ok(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.admin_client.push_wiki_graph", return_value=None):
+			out = wiki_graph.sync()
+		self.assertFalse(out["ok"])
+
+	def test_push_ok_returns_counts(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=False), \
+			 patch("jarvis.admin_client.push_wiki_graph", return_value={"ok": True}):
+			out = wiki_graph.sync()
+		self.assertTrue(out["ok"])
+		self.assertIn("pages", out)

--- a/wiki-graph-core/index.js
+++ b/wiki-graph-core/index.js
@@ -1,0 +1,36 @@
+// wiki-graph-core — canonical shared knowledge-graph component set + pure analysis.
+// Consumed by the tenant (jarvis/frontend) and admin (jarvis_admin) Vite builds.
+// Presentational only: components take data via props and emit actions; each
+// surface wraps them with its own data-fetching + action wiring.
+
+// Pure analysis (graphology) — no Vue, no fetch.
+export { analyze } from "./src/graphAnalysis.js";
+export { overlayFilter, egoGraph, searchGraph, collapseClusters } from "./src/graphView.js";
+export { computeSimilarity, contentSuggestions } from "./src/similarity.js";
+export { fullAnalysis } from "./src/analysis.js";
+export { computeActions } from "./src/actions.js";
+// Worker-backed analysis (off the render thread, R4; sync fallback). Preferred
+// entry for surfaces: `await runAnalysis(data)`.
+export { runAnalysis } from "./src/runAnalysis.js";
+export { nodeStyle, edgeStyle, LEGEND } from "./src/graphStyle.js";
+
+// Renderer feature flag (R10) + WebGL detection (R5).
+export { renderer3dEnabled } from "./src/flag.js";
+export { webglAvailable } from "./src/Graph3D.vue";
+
+// Presentational components. Graph3D (3d-force-graph) is THE renderer; the
+// rollback path (R10) is handled at the mount site (flag-off = don't mount the
+// new graph; admin keeps its untouched old esbuild page until 3D soaks), so the
+// sigma GraphCanvas is not shipped here.
+export { default as Graph3D } from "./src/Graph3D.vue";
+export { default as HealthPanel } from "./src/HealthPanel.vue";
+export { default as ExpertPanel } from "./src/ExpertPanel.vue";
+export { default as RiskPanel } from "./src/RiskPanel.vue";
+export { default as SuggestPanel } from "./src/SuggestPanel.vue";
+export { default as DetailPanel } from "./src/DetailPanel.vue";
+export { default as FilterBar } from "./src/FilterBar.vue";
+export { default as DemandPanel } from "./src/DemandPanel.vue";
+export { default as AnalysisTabs } from "./src/AnalysisTabs.vue";
+export { default as EvolutionTab } from "./src/EvolutionTab.vue";
+export { default as ActionsTab } from "./src/ActionsTab.vue";
+export { default as ExclusionRules } from "./src/ExclusionRules.vue";

--- a/wiki-graph-core/package-lock.json
+++ b/wiki-graph-core/package-lock.json
@@ -1,0 +1,773 @@
+{
+  "name": "wiki-graph-core",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wiki-graph-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "3d-force-graph": "^1.80.0",
+        "graphology": "^0.25.4",
+        "graphology-communities-louvain": "^2.0.2",
+        "graphology-metrics": "^2.4.0",
+        "vue": "^3.4.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
+    },
+    "node_modules/@yomguithereal/helpers": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@yomguithereal/helpers/-/helpers-1.1.1.tgz",
+      "integrity": "sha512-UYvAq/XCA7xoh1juWDYsq3W0WywOB+pz8cgVnE1b45ZfdMhBvHDrgmSFG3jXeZSr2tMTYLGHFHON+ekG05Jebg==",
+      "license": "MIT"
+    },
+    "node_modules/3d-force-graph": {
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/3d-force-graph/-/3d-force-graph-1.80.0.tgz",
+      "integrity": "sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.179 <1",
+        "three-forcegraph": "1",
+        "three-render-objects": "^1.41"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/graphology": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
+      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "obliterator": "^2.0.2"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-communities-louvain": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/graphology-communities-louvain/-/graphology-communities-louvain-2.0.2.tgz",
+      "integrity": "sha512-zt+2hHVPYxjEquyecxWXoUoIuN/UvYzsvI7boDdMNz0rRvpESQ7+e+Ejv6wK7AThycbZXuQ6DkG8NPMCq6XwoA==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "^2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-indices": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.17.0.tgz",
+      "integrity": "sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-metrics": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/graphology-metrics/-/graphology-metrics-2.4.0.tgz",
+      "integrity": "sha512-7WOfOP+mFLCaTJx55Qg4eY+211vr1/b3D/R3biz3SXGhAaCVcWYkfabnmO4O4WBNWANEHtVnFrGgJ0kj6MM6xw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-shortest-path": "^2.0.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-shortest-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/graphology-shortest-path/-/graphology-shortest-path-2.1.0.tgz",
+      "integrity": "sha512-KbT9CTkP/u72vGEJzyRr24xFC7usI9Es3LMmCPHGwQ1KTsoZjxwA9lMKxfU0syvT/w+7fZUdB/Hu2wWYcJBm6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@yomguithereal/helpers": "^1.1.1",
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.3",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ngraph.events": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.4.0.tgz",
+      "integrity": "sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ngraph.forcelayout": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ngraph.forcelayout/-/ngraph.forcelayout-3.3.1.tgz",
+      "integrity": "sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.0.0",
+        "ngraph.merge": "^1.0.0",
+        "ngraph.random": "^1.0.0"
+      }
+    },
+    "node_modules/ngraph.graph": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-20.1.2.tgz",
+      "integrity": "sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.4.0"
+      }
+    },
+    "node_modules/ngraph.merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ngraph.merge/-/ngraph.merge-1.0.0.tgz",
+      "integrity": "sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==",
+      "license": "MIT"
+    },
+    "node_modules/ngraph.random": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-1.2.0.tgz",
+      "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
+    "node_modules/pandemonium": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/pandemonium/-/pandemonium-2.4.1.tgz",
+      "integrity": "sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==",
+      "license": "MIT",
+      "dependencies": {
+        "mnemonist": "^0.39.2"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.6",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.6.tgz",
+      "integrity": "sha512-/UzLXnc1jrAS2uHi89XsSECqXVHYzV1VUL1L3esxrmPRmDvKFWtmbabE2a4QQ5a3bLgBivubRCEOt4GGmncPBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/three-forcegraph": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/three-forcegraph/-/three-forcegraph-1.43.4.tgz",
+      "integrity": "sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "d3-array": "1 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "data-bind-mapper": "1",
+        "kapsule": "^1.16",
+        "ngraph.forcelayout": "3",
+        "ngraph.graph": "20",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.118.3"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.42.0.tgz",
+      "integrity": "sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.179"
+      }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/wiki-graph-core/package.json
+++ b/wiki-graph-core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "wiki-graph-core",
+  "version": "0.1.0",
+  "description": "Shared Vue3 knowledge-graph component set + pure analysis (graphology). Consumed by the tenant (jarvis) and admin (jarvis_admin) Vite builds — one canonical source, no drift. Self-contained (own runtime deps); consumers dedupe vue.",
+  "type": "module",
+  "main": "index.js",
+  "module": "index.js",
+  "sideEffects": ["*.vue"],
+  "dependencies": {
+    "3d-force-graph": "^1.80.0",
+    "graphology": "^0.25.4",
+    "graphology-communities-louvain": "^2.0.2",
+    "graphology-metrics": "^2.4.0",
+    "vue": "^3.4.0"
+  }
+}

--- a/wiki-graph-core/src/ActionsTab.vue
+++ b/wiki-graph-core/src/ActionsTab.vue
@@ -1,0 +1,80 @@
+<template>
+	<div class="wg-act">
+		<Sec title="Fix now (stale / contradicted)" :n="actions.stale.length" empty="Knowledge is fresh" warn>
+			<li v-for="(p, i) in actions.stale.slice(0, 8)" :key="'s' + i">
+				<a href="#" @click.prevent="$emit('pick', p.id)">{{ p.label || p.slug }}</a>
+				<span class="m">{{ p.reason }}</span>
+			</li>
+		</Sec>
+		<Sec title="Suggested links (connect these)" :n="actions.suggest.length" empty="No suggestions yet">
+			<li v-for="(s, i) in actions.suggest.slice(0, 8)" :key="'g' + i">
+				<span class="pair">{{ s.aLabel }} <span class="arr">↔</span> {{ s.bLabel }}</span>
+				<span class="m">
+					<button v-if="canAct" class="wg-add" @click="$emit('add-link', s)">+ link</button>
+					<template v-else>{{ s.score }}</template>
+				</span>
+			</li>
+		</Sec>
+		<Sec title="Orphans (unlinked — adopt them)" :n="actions.orphans.length" empty="Every page is linked">
+			<li v-for="(p, i) in actions.orphans.slice(0, 8)" :key="'o' + i">
+				<a href="#" @click.prevent="$emit('pick', p.id)">{{ p.label || p.slug }}</a>
+			</li>
+		</Sec>
+		<Sec title="Bus-factor risk (single author)" :n="actions.busFactor.length" empty="No single points of failure" warn>
+			<li v-for="(p, i) in actions.busFactor.slice(0, 8)" :key="'b' + i">
+				<a href="#" @click.prevent="$emit('pick', p.id)">{{ p.label || p.slug }}</a>
+				<span class="m">{{ p.author }}</span>
+			</li>
+		</Sec>
+		<Sec title="Near-duplicate titles (merge?)" :n="actions.duplicates.length" empty="No duplicates">
+			<li v-for="(d, i) in actions.duplicates.slice(0, 6)" :key="'d' + i">
+				<span>{{ d.title }}</span><span class="m">{{ d.slugs.length }} pages</span>
+			</li>
+		</Sec>
+	</div>
+</template>
+
+<script>
+import { h } from "vue";
+// runtime-only Vue can't compile template strings — render fn instead (#1)
+const Sec = {
+	name: "Sec",
+	props: { title: String, n: Number, empty: String, warn: Boolean },
+	render() {
+		return h("div", { class: "wg-sec" }, [
+			h("div", { class: ["wg-sec-h", { warn: this.warn }] }, [this.title + " ", h("span", { class: "wg-n" }, String(this.n))]),
+			this.n
+				? h("ul", null, this.$slots.default ? this.$slots.default() : undefined)
+				: h("div", { class: "wg-empty text-muted" }, h("i", null, this.empty)),
+		]);
+	},
+};
+export default {
+	name: "ActionsTab",
+	components: { Sec },
+	props: {
+		actions: { type: Object, default: () => ({ stale: [], orphans: [], busFactor: [], duplicates: [], suggest: [] }) },
+		canAct: { type: Boolean, default: false },
+	},
+	emits: ["pick", "add-link"],
+};
+</script>
+
+<style scoped>
+/* Sec's own markup is h()-rendered, not from this SFC's <template>, so it
+   never gets the scoped data-v attribute — :deep() targets it by ancestry.
+   .m/.arr/.wg-add live in the default slot content (this SFC's own template),
+   stay as-is. */
+:deep(.wg-sec) { margin-bottom: 12px; }
+:deep(.wg-sec:last-child) { margin-bottom: 0; }
+:deep(.wg-sec-h) { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-bottom: 4px; }
+:deep(.wg-sec-h.warn) { color: #d9534f; }
+:deep(.wg-sec-h .wg-n) { opacity: 0.6; }
+:deep(.wg-sec ul) { list-style: none; margin: 0; padding: 0; }
+:deep(.wg-sec li) { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; padding: 2px 0; }
+.wg-sec .m { color: var(--text-muted, #999); white-space: nowrap; font-size: 11px; }
+.wg-sec .arr { color: var(--text-muted, #aaa); margin: 0 3px; }
+.wg-add { font-size: 10px; padding: 1px 7px; border: 1px solid var(--bg-blue, #4c9aff); color: var(--bg-blue, #4c9aff); background: transparent; border-radius: 10px; cursor: pointer; }
+.wg-add:hover { background: var(--bg-blue, #4c9aff); color: #fff; }
+:deep(.wg-empty) { font-size: 12px; }
+</style>

--- a/wiki-graph-core/src/AnalysisTabs.vue
+++ b/wiki-graph-core/src/AnalysisTabs.vue
@@ -1,0 +1,81 @@
+<template>
+	<div class="wg-tabs">
+		<!-- Priority review cards -->
+		<div class="wg-prio">
+			<div class="wg-card"><span class="wg-card-n">{{ hubName }}</span><span class="wg-card-l">top hub</span></div>
+			<div class="wg-card"><span class="wg-card-n">{{ brokerName }}</span><span class="wg-card-l">key bridge</span></div>
+			<div class="wg-card" :class="{ warn: staleN }"><span class="wg-card-n">{{ staleN }}</span><span class="wg-card-l">to fix</span></div>
+			<div class="wg-card" :class="{ warn: orphanN }"><span class="wg-card-n">{{ orphanN }}</span><span class="wg-card-l">orphans</span></div>
+		</div>
+
+		<div class="wg-tabbar">
+			<button v-for="t in TABS" :key="t.v" :class="['wg-tab', tab === t.v ? 'active' : '']"
+				@click="tab = t.v">{{ t.label }}</button>
+		</div>
+
+		<div class="wg-tabbody">
+			<DemandPanel v-if="tab === 'structure'" :lists="analysis.lists" :metrics="analysis.metrics" @pick="onNodeId" />
+			<SuggestPanel v-else-if="tab === 'similar'" :lists="analysis.lists" :communities="analysis.communities"
+				:can-add-link="canAct" @pick="$emit('pick', $event)" @add-link="$emit('add-link', $event)" />
+			<EvolutionTab v-else-if="tab === 'evolution'" :nodes="nodes" :history="history" />
+			<ActionsTab v-else :actions="actions" :can-act="canAct"
+				@pick="$emit('pick', $event)" @add-link="$emit('add-link', $event)" />
+		</div>
+	</div>
+</template>
+
+<script>
+// The four-tab analysis shell (Obsidian parity): Structure / Similar / Evolution
+// / Actions, plus a priority-review card strip. Presentational — data in, events
+// out; each surface wires fetching + the (tenant-only) add-link action.
+import DemandPanel from "./DemandPanel.vue";
+import SuggestPanel from "./SuggestPanel.vue";
+import EvolutionTab from "./EvolutionTab.vue";
+import ActionsTab from "./ActionsTab.vue";
+
+export default {
+	name: "AnalysisTabs",
+	components: { DemandPanel, SuggestPanel, EvolutionTab, ActionsTab },
+	props: {
+		analysis: { type: Object, default: () => ({ metrics: {}, lists: {}, communities: {} }) },
+		nodes: { type: Array, default: () => [] },
+		actions: { type: Object, default: () => ({ stale: [], orphans: [], busFactor: [], duplicates: [], suggest: [] }) },
+		history: { type: Array, default: () => [] },
+		canAct: { type: Boolean, default: false },
+	},
+	emits: ["pick", "add-link"],
+	data() {
+		return {
+			tab: "structure",
+			TABS: [
+				{ v: "structure", label: "Structure" }, { v: "similar", label: "Similar" },
+				{ v: "evolution", label: "Evolution" }, { v: "actions", label: "Actions" },
+			],
+		};
+	},
+	computed: {
+		lists() { return this.analysis.lists || {}; },
+		hubName() { return (this.lists.hubs && this.lists.hubs[0] && (this.lists.hubs[0].label || this.lists.hubs[0].slug)) || "—"; },
+		brokerName() { return (this.lists.brokers && this.lists.brokers[0] && (this.lists.brokers[0].label || this.lists.brokers[0].slug)) || "—"; },
+		staleN() { return (this.actions.stale || []).length; },
+		orphanN() { return (this.actions.orphans || []).length; },
+	},
+	methods: {
+		onNodeId(node) { this.$emit("pick", node && node.id ? node.id : node); },
+	},
+};
+</script>
+
+<style scoped>
+.wg-tabs { display: flex; flex-direction: column; gap: 10px; }
+.wg-prio { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; }
+.wg-card { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 6px 8px; text-align: center; overflow: hidden; }
+.wg-card.warn { border-color: #f0c0c0; }
+.wg-card-n { display: block; font-weight: 600; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.wg-card.warn .wg-card-n { color: #d9534f; }
+.wg-card-l { font-size: 10px; color: var(--text-muted, #999); text-transform: uppercase; }
+.wg-tabbar { display: flex; gap: 4px; border-bottom: 1px solid var(--border-color, #e2e6ea); }
+.wg-tab { font-size: 12px; padding: 6px 10px; border: none; background: transparent; cursor: pointer; color: var(--text-muted, #888); border-bottom: 2px solid transparent; margin-bottom: -1px; }
+.wg-tab.active { color: var(--text-color, #222); border-bottom-color: var(--bg-blue, #4c9aff); font-weight: 500; }
+.wg-tabbody { border: 1px solid var(--border-color, #e2e6ea); border-top: none; border-radius: 0 0 8px 8px; padding: 12px; }
+</style>

--- a/wiki-graph-core/src/DemandPanel.vue
+++ b/wiki-graph-core/src/DemandPanel.vue
@@ -1,0 +1,73 @@
+<template>
+	<div class="wg-demand">
+		<Section title="Hubs (most connected)" :items="lists.hubs" empty="No links yet">
+			<template #row="{ it }">
+				<a href="#" @click.prevent="$emit('pick', it)">{{ it.label || it.slug }}</a>
+				<span class="wg-meta">{{ (metrics[it.id] || {}).degree || 0 }} links</span>
+			</template>
+		</Section>
+		<Section title="Most in demand" :items="lists.mostRead" empty="No reads recorded">
+			<template #row="{ it }">
+				<a href="#" @click.prevent="$emit('pick', it)">{{ it.label || it.slug }}</a>
+				<span class="wg-meta">{{ it.demand }} reads</span>
+			</template>
+		</Section>
+		<Section title="Knowledge debt (hot + stale)" :items="lists.debt" empty="None — knowledge is fresh" warn>
+			<template #row="{ it }">
+				<a href="#" @click.prevent="$emit('pick', it)">{{ it.label || it.slug }}</a>
+				<span class="wg-meta">{{ it.demand }} reads · {{ it.contradiction ? 'contradiction' : 'stale' }}</span>
+			</template>
+		</Section>
+		<Section title="Latent demand (searched, missing)" :items="lists.gaps" empty="No gaps detected" warn>
+			<template #row="{ it }">
+				<span>{{ it.query_norm }}</span>
+				<span class="wg-meta">asked {{ it.asked }}× · {{ it.hit ? 'thin' : 'missing' }}</span>
+			</template>
+		</Section>
+		<Section title="Orphans (no links)" :items="lists.orphans" empty="Every page is linked">
+			<template #row="{ it }">
+				<a href="#" @click.prevent="$emit('pick', it)">{{ it.label || it.slug }}</a>
+			</template>
+		</Section>
+	</div>
+</template>
+
+<script>
+import { h } from "vue";
+// runtime-only Vue can't compile template strings — render fn instead (#1)
+const Section = {
+	name: "Section",
+	props: { title: String, items: Array, empty: String, warn: Boolean },
+	render() {
+		const items = this.items || [];
+		return h("div", { class: "wg-sec" }, [
+			h("div", { class: ["wg-sec-h", { warn: this.warn }] }, [this.title + " ", h("span", { class: "wg-n" }, String(items.length))]),
+			items.length
+				? h("ul", null, items.slice(0, 8).map((it, i) => h("li", { key: i }, this.$slots.row ? this.$slots.row({ it }) : undefined)))
+				: h("div", { class: "wg-empty text-muted" }, h("i", null, this.empty)),
+		]);
+	},
+};
+export default {
+	name: "DemandPanel",
+	components: { Section },
+	props: {
+		lists: { type: Object, default: () => ({ hubs: [], mostRead: [], debt: [], gaps: [], orphans: [] }) },
+		metrics: { type: Object, default: () => ({}) },
+	},
+	emits: ["pick"],
+};
+</script>
+
+<style scoped>
+/* Section's own markup is rendered via h(), not this SFC's <template>, so it
+   never gets the scoped data-v attribute — :deep() targets it by ancestry instead */
+:deep(.wg-sec) { margin-bottom: 14px; }
+:deep(.wg-sec-h) { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-bottom: 4px; }
+:deep(.wg-sec-h.warn) { color: #d9534f; }
+:deep(.wg-sec-h .wg-n) { opacity: 0.6; }
+:deep(.wg-sec ul) { list-style: none; margin: 0; padding: 0; }
+:deep(.wg-sec li) { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; padding: 2px 0; }
+.wg-meta { color: var(--text-muted, #999); white-space: nowrap; font-size: 11px; }
+:deep(.wg-empty) { font-size: 12px; }
+</style>

--- a/wiki-graph-core/src/DetailPanel.vue
+++ b/wiki-graph-core/src/DetailPanel.vue
@@ -1,0 +1,72 @@
+<template>
+	<div class="wg-detail" v-if="node">
+		<div class="wg-detail-head">
+			<span class="wg-kind" :class="'k-' + node.kind">{{ node.kind }}</span>
+			<strong>{{ node.label || node.id }}</strong>
+		</div>
+		<table class="wg-kv">
+			<tr v-if="node.page_type"><td>Type</td><td>{{ node.page_type }}</td></tr>
+			<tr v-if="node.scope"><td>Scope</td><td>{{ node.scope }}</td></tr>
+			<tr v-if="m.degree != null"><td>Connections</td><td>{{ m.degree }}</td></tr>
+			<tr v-if="node.kind === 'page'"><td>Reads (demand)</td><td>{{ node.demand || 0 }}</td></tr>
+			<tr v-if="node.last_read"><td>Last read</td><td>{{ shortDate(node.last_read) }}</td></tr>
+			<tr v-if="node.kind === 'page'"><td>Cluster</td><td>{{ clusterLabel }}</td></tr>
+			<tr v-if="m.betweenness > 0"><td>Broker</td><td class="warn">bridges clusters</td></tr>
+			<tr v-if="node.stale"><td>Stale</td><td class="warn">yes</td></tr>
+			<tr v-if="node.contradiction"><td>Contradiction</td><td class="warn">flagged</td></tr>
+			<tr v-if="node.debt"><td>Knowledge debt</td><td class="warn">hot + stale</td></tr>
+			<tr v-if="m.orphan"><td>Orphan</td><td class="warn">no links</td></tr>
+		</table>
+		<div class="wg-actions" v-if="node.kind === 'page'">
+			<button class="wg-act" @click="$emit('focus', node.id)">Focus</button>
+			<button class="wg-act" v-if="siteUrl" @click="openPage">Open page ↗</button>
+			<button class="wg-act" @click="copySlug">Copy slug</button>
+		</div>
+	</div>
+	<div class="wg-detail empty text-muted" v-else><i>Click a node for details.</i></div>
+</template>
+
+<script>
+export default {
+	name: "DetailPanel",
+	props: {
+		node: { type: Object, default: null },
+		metrics: { type: Object, default: () => ({}) },
+		communities: { type: Object, default: () => ({}) },
+		siteUrl: { type: String, default: null },
+	},
+	emits: ["focus"],
+	computed: {
+		m() { return (this.node && this.metrics[this.node.id]) || {}; },
+		clusterLabel() {
+			const c = this.communities[this.m.community];
+			return c ? c.label : this.m.community;
+		},
+	},
+	methods: {
+		shortDate(v) { return String(v || "").slice(0, 10); },
+		openPage() {
+			const url = `${this.siteUrl.replace(/\/$/, "")}/app/jarvis-wiki-page/${encodeURIComponent(this.node.slug)}`;
+			window.open(url, "_blank", "noopener");
+		},
+		copySlug() {
+			try { navigator.clipboard.writeText(this.node.slug); frappe.show_alert("Slug copied"); } catch (_) {}
+		},
+	},
+};
+</script>
+
+<style scoped>
+.wg-detail { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 12px; }
+.wg-detail.empty { text-align: center; padding: 20px 12px; }
+.wg-detail-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.wg-kind { font-size: 10px; text-transform: uppercase; padding: 1px 6px; border-radius: 4px; color: #fff; }
+.k-org { background: #a970ff; } .k-role { background: #f2b134; }
+.k-user { background: #4c9aff; } .k-page { background: #8892b0; }
+.wg-kv { width: 100%; font-size: 12px; }
+.wg-kv td:first-child { color: var(--text-muted, #888); padding-right: 10px; white-space: nowrap; }
+.wg-kv .warn { color: #d9534f; }
+.wg-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.wg-act { font-size: 11px; padding: 2px 8px; border: 1px solid var(--border-color, #d1d8dd); border-radius: 6px; background: var(--card-bg, #fff); cursor: pointer; }
+.wg-act:hover { background: var(--control-bg, #f3f4f6); }
+</style>

--- a/wiki-graph-core/src/EvolutionTab.vue
+++ b/wiki-graph-core/src/EvolutionTab.vue
@@ -1,0 +1,120 @@
+<template>
+	<div class="wg-evo">
+		<div v-if="!rows.length" class="text-muted wg-empty"><i>Not enough dated pages to chart growth yet.</i></div>
+		<div v-else>
+			<div class="wg-evo-head">
+				<span><strong>{{ total }}</strong> pages<template v-if="measured && latestLinks != null"> · <strong>{{ latestLinks }}</strong> links</template></span>
+				<span class="wg-evo-mode" :class="measured ? 'meas' : 'est'">{{ measured ? "measured" : "estimated" }}</span>
+			</div>
+			<svg class="wg-evo-svg" viewBox="0 0 320 90" preserveAspectRatio="none">
+				<polyline v-if="measured" :points="linkPoly" fill="none" :stroke="linkStroke" stroke-width="1.5" stroke-dasharray="3 3" />
+				<polyline :points="pagePoly" fill="none" :stroke="stroke" stroke-width="2" />
+				<circle v-for="(p, i) in dots" :key="i" :cx="p.x" :cy="p.y" r="2.5" :fill="stroke" />
+			</svg>
+			<div class="wg-evo-axis text-muted">
+				<span>{{ rows[0].date }}</span><span>{{ rows[rows.length - 1].date }}</span>
+			</div>
+			<div v-if="measured" class="wg-evo-legend text-muted">
+				<span><span class="sw" :style="{ background: stroke }"></span>pages</span>
+				<span><span class="sw dash" :style="{ borderColor: linkStroke }"></span>links</span>
+			</div>
+			<div v-if="importNote" class="wg-evo-note">⚠ {{ importNote }}</div>
+		</div>
+	</div>
+</template>
+
+<script>
+// Knowledge Evolution. Prefers the MEASURED daily series (get_wiki_graph_history:
+// real page + link growth, orphan decline recorded once/day) when present; else
+// falls back to RECONSTRUCTING cumulative pages from node.created (day precision).
+// R9 data-quality (reconstruction only): drop invalid/future dates, annotate a
+// bulk-import spike so a one-day jump isn't read as organic growth.
+const W = 320, H = 90, PAD = 6;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export default {
+	name: "EvolutionTab",
+	props: {
+		nodes: { type: Array, default: () => [] },
+		// Measured daily totals [{date, pages, links, orphans, ...}]; empty → reconstruct.
+		history: { type: Array, default: () => [] },
+	},
+	computed: {
+		measured() { return Array.isArray(this.history) && this.history.length > 0; },
+		perDay() {
+			const today = new Date().toISOString().slice(0, 10);
+			const counts = {};
+			for (const n of this.nodes) {
+				if (n.kind !== "page") continue;
+				const d = n.created;
+				if (!DATE_RE.test(d) || d > today) continue; // drop invalid/future (R9)
+				counts[d] = (counts[d] || 0) + 1;
+			}
+			return counts;
+		},
+		reconRows() {
+			const dates = Object.keys(this.perDay).sort();
+			let cum = 0;
+			return dates.map((date) => { cum += this.perDay[date]; return { date, pages: cum, links: null }; });
+		},
+		rows() {
+			if (this.measured) {
+				return this.history
+					.filter((h) => DATE_RE.test(h.date))
+					.map((h) => ({ date: h.date, pages: +h.pages || 0, links: +h.links || 0 }));
+			}
+			return this.reconRows;
+		},
+		total() { return this.rows.length ? this.rows[this.rows.length - 1].pages : 0; },
+		latestLinks() { return this.rows.length ? this.rows[this.rows.length - 1].links : null; },
+		maxY() {
+			let m = 1;
+			for (const r of this.rows) m = Math.max(m, r.pages, r.links || 0);
+			return m;
+		},
+		pagePoly() { return this._poly((r) => r.pages); },
+		linkPoly() { return this.measured ? this._poly((r) => r.links || 0) : ""; },
+		dots() { return this._scaled((r) => r.pages); },
+		importNote() {
+			if (this.measured) return ""; // real series — no reconstruction caveat
+			const total = this.total;
+			let spikeDate = null, spikeN = 0;
+			for (const [date, n] of Object.entries(this.perDay)) {
+				if (n > spikeN) { spikeN = n; spikeDate = date; }
+			}
+			if (spikeDate && spikeN >= Math.max(3, 0.4 * total)) {
+				return `${spikeN} pages appeared on ${spikeDate} — likely a bulk import, not organic growth.`;
+			}
+			return "";
+		},
+		stroke() { return "#4c9aff"; },
+		linkStroke() { return "#9b8cff"; },
+	},
+	methods: {
+		_scaled(sel) {
+			const rows = this.rows, n = rows.length, maxY = this.maxY;
+			if (!n) return [];
+			return rows.map((r, i) => ({
+				x: PAD + (n === 1 ? (W - 2 * PAD) / 2 : (i / (n - 1)) * (W - 2 * PAD)),
+				y: H - PAD - (sel(r) / maxY) * (H - 2 * PAD),
+			}));
+		},
+		_poly(sel) { return this._scaled(sel).map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" "); },
+	},
+};
+</script>
+
+<style scoped>
+.wg-evo { padding: 4px 2px; }
+.wg-evo-head { display: flex; justify-content: space-between; align-items: center; font-size: 12px; margin-bottom: 6px; }
+.wg-evo-mode { font-size: 10px; text-transform: uppercase; letter-spacing: 0.03em; border-radius: 8px; padding: 1px 7px; }
+.wg-evo-mode.meas { background: #e6f0ff; color: #2f6fd0; }
+.wg-evo-mode.est { background: var(--control-bg, #f0f1f3); color: var(--text-muted, #888); }
+.wg-evo-svg { width: 100%; height: 90px; }
+.wg-evo-axis { display: flex; justify-content: space-between; font-size: 10px; margin-top: 2px; }
+.wg-evo-legend { display: flex; gap: 14px; font-size: 10px; margin-top: 6px; }
+.wg-evo-legend .sw { display: inline-block; width: 12px; height: 2px; vertical-align: middle; margin-right: 4px; }
+.wg-evo-legend .sw.dash { height: 0; border-top: 2px dashed; }
+.wg-evo-note { font-size: 11px; color: #d6a417; margin-top: 8px; }
+.wg-empty { font-size: 12px; padding: 16px 4px; }
+</style>

--- a/wiki-graph-core/src/ExclusionRules.vue
+++ b/wiki-graph-core/src/ExclusionRules.vue
@@ -1,0 +1,37 @@
+<template>
+	<div class="wg-excl" v-if="pageTypes.length > 1">
+		<span class="wg-excl-l">Show:</span>
+		<button v-for="t in pageTypes" :key="t" :class="['wg-chip', isOn(t) ? 'on' : 'off']"
+			@click="toggle(t)">{{ t }}</button>
+	</div>
+</template>
+
+<script>
+// Exclusion rules — click a page-type chip to hide it from the graph + analysis
+// (they auto-refresh). Persisted by the surface (localStorage tenant / query-arg
+// admin). Off chip = excluded.
+export default {
+	name: "ExclusionRules",
+	props: {
+		pageTypes: { type: Array, default: () => [] },
+		excluded: { type: Array, default: () => [] },
+	},
+	emits: ["update:excluded"],
+	methods: {
+		isOn(t) { return !this.excluded.includes(t); },
+		toggle(t) {
+			const set = new Set(this.excluded);
+			set.has(t) ? set.delete(t) : set.add(t);
+			this.$emit("update:excluded", [...set]);
+		},
+	},
+};
+</script>
+
+<style scoped>
+.wg-excl { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
+.wg-excl-l { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-right: 2px; }
+.wg-chip { font-size: 11px; padding: 2px 9px; border: 1px solid var(--border-color, #d1d8dd); border-radius: 12px; background: var(--card-bg, #fff); cursor: pointer; }
+.wg-chip.on { border-color: var(--bg-blue, #4c9aff); color: var(--bg-blue, #4c9aff); }
+.wg-chip.off { color: var(--text-muted, #aaa); text-decoration: line-through; opacity: 0.6; }
+</style>

--- a/wiki-graph-core/src/ExpertPanel.vue
+++ b/wiki-graph-core/src/ExpertPanel.vue
@@ -1,0 +1,45 @@
+<template>
+	<div class="wg-exp" v-if="experts">
+		<div class="wg-h">{{ selectedSlug ? "Experts on this page" : "Top experts" }}</div>
+		<div v-if="!rows.length" class="text-muted wg-empty"><i>No contributions yet.</i></div>
+		<ol v-else class="wg-exp-list">
+			<li v-for="(r, i) in rows" :key="i">
+				<span class="wg-rank">{{ i + 1 }}</span>
+				<span class="wg-user">{{ r.user }}</span>
+				<span class="wg-meta">{{ r.score }}</span>
+			</li>
+		</ol>
+		<div v-if="selectedSlug" class="wg-hint text-muted">go-to people for <code>{{ selectedSlug }}</code></div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "ExpertPanel",
+	props: {
+		experts: { type: Object, default: null },
+		selectedSlug: { type: String, default: null },
+	},
+	computed: {
+		rows() {
+			if (!this.experts) return [];
+			if (this.selectedSlug && this.experts.per_page) {
+				return this.experts.per_page[this.selectedSlug] || [];
+			}
+			return this.experts.top || [];
+		},
+	},
+};
+</script>
+
+<style scoped>
+.wg-exp { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 12px; }
+.wg-h { font-weight: 600; margin-bottom: 6px; }
+.wg-exp-list { list-style: none; margin: 0; padding: 0; }
+.wg-exp-list li { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 2px 0; }
+.wg-rank { width: 16px; color: var(--text-muted, #aaa); font-size: 11px; }
+.wg-user { flex: 1; }
+.wg-meta { color: var(--text-muted, #999); font-size: 11px; }
+.wg-hint { font-size: 11px; margin-top: 6px; }
+.wg-empty { font-size: 12px; }
+</style>

--- a/wiki-graph-core/src/FilterBar.vue
+++ b/wiki-graph-core/src/FilterBar.vue
@@ -1,0 +1,60 @@
+<template>
+	<div class="wg-filter">
+		<div class="wg-group">
+			<span class="wg-lbl">Color</span>
+			<button v-for="m in modes" :key="m.v"
+				:class="['wg-btn', mode === m.v ? 'active' : '']"
+				@click="$emit('update:mode', m.v)">{{ m.t }}</button>
+		</div>
+		<div class="wg-group">
+			<span class="wg-lbl">Layer</span>
+			<button v-for="o in overlays" :key="o.v"
+				:class="['wg-btn', overlay === o.v ? 'active' : '']"
+				@click="$emit('update:overlay', o.v)">{{ o.t }}</button>
+		</div>
+		<div class="wg-legend">
+			<span v-for="l in legend.nodes" :key="l.label" class="wg-swatch">
+				<i :style="{ background: l.color }"></i>{{ l.label }}
+			</span>
+		</div>
+		<span class="wg-count text-muted" v-if="total">showing {{ shown }} / {{ total }} pages</span>
+	</div>
+</template>
+
+<script>
+import { LEGEND } from "./graphStyle";
+export default {
+	name: "FilterBar",
+	props: {
+		mode: { type: String, default: "kind" },
+		overlay: { type: String, default: "knowledge" },
+		shown: { type: Number, default: 0 },
+		total: { type: Number, default: 0 },
+	},
+	emits: ["update:mode", "update:overlay"],
+	setup() {
+		return {
+			legend: LEGEND,
+			modes: [{ v: "kind", t: "By kind" }, { v: "community", t: "By cluster" }],
+			overlays: [
+				{ v: "knowledge", t: "Knowledge" },
+				{ v: "utilization", t: "+ Who" },
+				{ v: "demand", t: "+ Demand" },
+			],
+		};
+	},
+};
+</script>
+
+<style scoped>
+.wg-filter { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; margin-bottom: 10px; }
+.wg-group { display: flex; align-items: center; gap: 4px; }
+.wg-lbl { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-right: 4px; }
+.wg-btn { font-size: 12px; padding: 3px 10px; border: 1px solid var(--border-color, #d1d8dd); border-radius: 6px;
+	background: var(--card-bg, #fff); cursor: pointer; }
+.wg-btn.active { background: var(--bg-blue, #4c9aff); color: #fff; border-color: var(--bg-blue, #4c9aff); }
+.wg-legend { display: flex; flex-wrap: wrap; gap: 10px; }
+.wg-swatch { font-size: 11px; color: var(--text-muted, #777); display: inline-flex; align-items: center; gap: 4px; }
+.wg-swatch i { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.wg-count { font-size: 11px; margin-left: auto; }
+</style>

--- a/wiki-graph-core/src/Graph3D.vue
+++ b/wiki-graph-core/src/Graph3D.vue
@@ -1,0 +1,186 @@
+<template>
+	<div class="wg3d">
+		<div v-if="noWebgl" class="wg3d-fallback">
+			<div class="wg3d-fallback-inner">
+				<div class="wg3d-fallback-icon">◍</div>
+				<p><strong>3D graph unavailable</strong></p>
+				<p class="text-muted">WebGL is disabled or unsupported in this browser. The analysis
+					cards still work — use them to explore hubs, gaps, and suggested links.</p>
+			</div>
+		</div>
+		<template v-else>
+			<div class="wg3d-canvas" ref="el" role="img"
+				aria-label="3D knowledge graph. This canvas is decorative; use the analysis cards and lists beside it to explore the same data by keyboard."></div>
+			<span v-if="shownCount < totalCount" class="wg3d-cap" :title="`Rendering the ${shownCount} most-connected of ${totalCount} nodes for performance`">
+				showing {{ shownCount }} of {{ totalCount }}
+			</span>
+		</template>
+	</div>
+</template>
+
+<script>
+// The 3D renderer (3d-force-graph / three.js) — drop-in replacement for the
+// sigma GraphCanvas: same props/emits contract. Continuously-simulated force
+// layout (the "lively" feel), centrality/demand sizing + kind/community color
+// from graphStyle, hover-neighbor highlight. Lazy-imports three so it stays off
+// first paint. Detects WebGL and degrades to a cards-only message (R5). Caps the
+// rendered node count and pauses the render loop when hidden/off-screen (R4).
+import { onMounted, onBeforeUnmount, watch, ref } from "vue";
+import { nodeStyle, edgeStyle } from "./graphStyle.js";
+
+export function webglAvailable() {
+	try {
+		const c = document.createElement("canvas");
+		return !!(window.WebGLRenderingContext
+			&& (c.getContext("webgl") || c.getContext("experimental-webgl")));
+	} catch (_) {
+		return false;
+	}
+}
+
+export default {
+	name: "Graph3D",
+	props: {
+		data: { type: Object, required: true },
+		metrics: { type: Object, default: () => ({}) },
+		mode: { type: String, default: "kind" },
+		dark: { type: Boolean, default: false },
+		// Hard cap on rendered nodes (R4). Above this we keep the most-connected /
+		// biggest nodes so the graph stays legible and the sim stays responsive.
+		maxNodes: { type: Number, default: 1800 },
+	},
+	emits: ["node-click"],
+	setup(props, { emit }) {
+		const el = ref(null);
+		const noWebgl = ref(!webglAvailable());
+		const shownCount = ref(0), totalCount = ref(0);
+		let ForceGraph3D = null, graph = null, ro = null, io = null;
+		let hoverNode = null, adj = {};
+		const hlNodes = new Set(), hlLinks = new Set();
+
+		async function libs() {
+			if (!ForceGraph3D) ForceGraph3D = (await import("3d-force-graph")).default;
+		}
+
+		function build() {
+			const d = props.data || { nodes: [], edges: [] };
+			const ids = new Set(), all = [];
+			for (const n of d.nodes || []) {
+				if (!n || !n.id || ids.has(n.id)) continue;
+				ids.add(n.id);
+				const s = nodeStyle(n, props.metrics[n.id] || {}, { mode: props.mode, dark: props.dark });
+				all.push({ id: n.id, _node: n, __size: s.size || 6, __color: s.color, __label: s.label });
+			}
+			totalCount.value = all.length;
+			// Node-cap (R4): keep the biggest/most-connected nodes when over budget.
+			let nodes = all;
+			if (all.length > props.maxNodes) {
+				nodes = all.slice().sort((a, b) => b.__size - a.__size).slice(0, props.maxNodes);
+			}
+			shownCount.value = nodes.length;
+			const keep = new Set(nodes.map((n) => n.id));
+			const seen = new Set(), links = [];
+			adj = {};
+			for (const e of d.edges || []) {
+				if (!e || !keep.has(e.source) || !keep.has(e.target) || e.source === e.target) continue;
+				const key = e.source < e.target ? `${e.source}|${e.target}` : `${e.target}|${e.source}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				const st = edgeStyle(e, { dark: props.dark });
+				links.push({ source: e.source, target: e.target, __color: st.color, __width: st.size || 1 });
+				(adj[e.source] = adj[e.source] || new Set()).add(e.target);
+				(adj[e.target] = adj[e.target] || new Set()).add(e.source);
+			}
+			return { nodes, links };
+		}
+
+		const dimNode = () => (props.dark ? "#2a2e37" : "#e8eaed");
+		const dimLink = () => (props.dark ? "#20242b" : "#f0f1f3");
+		const nodeColor = (n) => (!hoverNode || hlNodes.has(n.id) ? n.__color : dimNode());
+		const linkColor = (l) => (!hoverNode || hlLinks.has(l) ? l.__color : dimLink());
+		const linkWidth = (l) => (hoverNode && hlLinks.has(l) ? (l.__width || 1) * 2 : (l.__width || 1));
+
+		function highlight(node) {
+			hoverNode = node || null;
+			hlNodes.clear();
+			hlLinks.clear();
+			if (node && graph) {
+				hlNodes.add(node.id);
+				for (const nb of (adj[node.id] || [])) hlNodes.add(nb);
+				for (const l of graph.graphData().links) {
+					const s = typeof l.source === "object" ? l.source.id : l.source;
+					const t = typeof l.target === "object" ? l.target.id : l.target;
+					if (s === node.id || t === node.id) hlLinks.add(l);
+				}
+			}
+			if (graph) graph.nodeColor(nodeColor).linkColor(linkColor).linkWidth(linkWidth);
+		}
+
+		// Pause-on-blur / off-screen (R4): stop the rAF render loop when the tab is
+		// hidden or the canvas is scrolled out of view; resume when visible again.
+		let onScreen = true;
+		function updatePause() {
+			if (!graph) return;
+			const active = onScreen && !document.hidden;
+			active ? graph.resumeAnimation() : graph.pauseAnimation();
+		}
+		const onVisibility = () => updatePause();
+
+		async function render() {
+			if (noWebgl.value) return;
+			await libs();
+			if (!el.value) return;
+			if (!graph) {
+				graph = ForceGraph3D()(el.value)
+					.backgroundColor("rgba(0,0,0,0)")
+					.nodeRelSize(1.4)
+					.nodeVal((n) => Math.max(1, n.__size))
+					.nodeColor(nodeColor)
+					.nodeLabel((n) => n.__label || n.id)
+					.nodeOpacity(0.95)
+					.linkColor(linkColor)
+					.linkWidth(linkWidth)
+					.linkOpacity(0.5)
+					.onNodeClick((n) => emit("node-click", n._node))
+					.onNodeHover((n) => highlight(n))
+					.cooldownTicks(140);
+				resize();
+				ro = new ResizeObserver(resize);
+				ro.observe(el.value);
+				io = new IntersectionObserver((ents) => {
+					onScreen = ents.some((e) => e.isIntersecting);
+					updatePause();
+				});
+				io.observe(el.value);
+				document.addEventListener("visibilitychange", onVisibility);
+			}
+			graph.graphData(build());
+			updatePause();
+		}
+
+		function resize() {
+			if (graph && el.value) graph.width(el.value.clientWidth).height(el.value.clientHeight);
+		}
+
+		onMounted(render);
+		watch(() => [props.data, props.mode, props.dark], () => { hoverNode = null; render(); });
+		onBeforeUnmount(() => {
+			if (ro) ro.disconnect();
+			if (io) io.disconnect();
+			document.removeEventListener("visibilitychange", onVisibility);
+			if (graph && graph._destructor) graph._destructor();
+		});
+		return { el, noWebgl, shownCount, totalCount };
+	},
+};
+</script>
+
+<style scoped>
+.wg3d { position: relative; width: 100%; height: 72vh; min-height: 420px; border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; overflow: hidden; background: var(--card-bg, transparent); }
+.wg3d-canvas { width: 100%; height: 100%; }
+.wg3d-cap { position: absolute; bottom: 8px; right: 10px; font-size: 11px; color: var(--text-muted, #888); background: var(--card-bg, rgba(255,255,255,0.7)); border: 1px solid var(--border-color, #e2e6ea); border-radius: 10px; padding: 1px 9px; pointer-events: none; }
+.wg3d-fallback { display: flex; align-items: center; justify-content: center; height: 100%; padding: 24px; }
+.wg3d-fallback-inner { text-align: center; max-width: 360px; }
+.wg3d-fallback-icon { font-size: 40px; opacity: 0.4; margin-bottom: 8px; }
+.wg3d-fallback p { margin: 4px 0; font-size: 13px; }
+</style>

--- a/wiki-graph-core/src/HealthPanel.vue
+++ b/wiki-graph-core/src/HealthPanel.vue
@@ -1,0 +1,56 @@
+<template>
+	<div class="wg-health" v-if="health">
+		<div class="wg-score-row">
+			<div class="wg-score" :style="{ color: tone }">{{ health.score }}</div>
+			<div class="wg-score-lbl">
+				<div class="wg-h">Knowledge Health</div>
+				<div class="text-muted">{{ health.pages }} pages · {{ grade }}</div>
+			</div>
+		</div>
+		<div class="wg-bars">
+			<div v-for="b in bars" :key="b.k" class="wg-bar">
+				<span class="wg-bar-l">{{ b.k }}</span>
+				<span class="wg-bar-track"><i :style="{ width: pct(b.v), background: tone }"></i></span>
+				<span class="wg-bar-v">{{ pct(b.v) }}</span>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "HealthPanel",
+	props: { health: { type: Object, default: null } },
+	computed: {
+		tone() {
+			const s = (this.health && this.health.score) || 0;
+			return s >= 75 ? "#2ea043" : s >= 50 ? "#d6a417" : "#d9534f";
+		},
+		grade() {
+			const s = (this.health && this.health.score) || 0;
+			return s >= 75 ? "healthy" : s >= 50 ? "needs care" : "at risk";
+		},
+		bars() {
+			const h = this.health || {};
+			return [
+				{ k: "freshness", v: h.freshness }, { k: "connectivity", v: h.connectivity },
+				{ k: "coverage", v: h.coverage }, { k: "bus-factor", v: h.bus_factor },
+			];
+		},
+	},
+	methods: { pct(v) { return Math.round((v || 0) * 100) + "%"; } },
+};
+</script>
+
+<style scoped>
+.wg-health { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 12px; }
+.wg-score-row { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+.wg-score { font-size: 34px; font-weight: 700; line-height: 1; }
+.wg-h { font-weight: 600; }
+.wg-bars { display: flex; flex-direction: column; gap: 5px; }
+.wg-bar { display: grid; grid-template-columns: 80px 1fr 34px; align-items: center; gap: 8px; font-size: 11px; }
+.wg-bar-l { color: var(--text-muted, #888); }
+.wg-bar-track { height: 6px; background: var(--control-bg, #eef0f2); border-radius: 3px; overflow: hidden; }
+.wg-bar-track i { display: block; height: 100%; border-radius: 3px; }
+.wg-bar-v { text-align: right; color: var(--text-muted, #888); }
+</style>

--- a/wiki-graph-core/src/RiskPanel.vue
+++ b/wiki-graph-core/src/RiskPanel.vue
@@ -1,0 +1,75 @@
+<template>
+	<div class="wg-risk">
+		<Sec title="Fix now (hot + stale)" :n="fixNow.length" empty="Nothing rotting" warn>
+			<li v-for="(p, i) in fixNow.slice(0, 8)" :key="'f' + i">
+				<a href="#" @click.prevent="$emit('pick', p.slug)">{{ p.label || p.slug }}</a>
+				<span class="m">{{ p.demand }} reads · {{ p.reason }}</span>
+			</li>
+		</Sec>
+		<Sec title="Bus-factor risk (single author)" :n="busFactor.length" empty="No single points of failure" warn>
+			<li v-for="(p, i) in busFactor.slice(0, 8)" :key="'b' + i">
+				<a href="#" @click.prevent="$emit('pick', p.slug)">{{ p.label || p.slug }}</a>
+				<span class="m">{{ p.author }} · {{ p.demand }} reads</span>
+			</li>
+		</Sec>
+		<Sec title="Safe to archive (stale + unread)" :n="archive.safe_to_archive.length" empty="Nothing to retire">
+			<li v-for="(p, i) in archive.safe_to_archive.slice(0, 8)" :key="'s' + i">
+				<a href="#" @click.prevent="$emit('pick', p.slug)">{{ p.label || p.slug }}</a>
+			</li>
+		</Sec>
+		<Sec title="Content gaps (searched, missing)" :n="gaps.missing.length" empty="No missing content" warn>
+			<li v-for="(g, i) in gaps.missing.slice(0, 8)" :key="'g' + i">
+				<span>{{ g.query_norm }}</span><span class="m">asked {{ g.asked }}×</span>
+			</li>
+		</Sec>
+		<Sec title="Terminology gaps (thin page exists)" :n="gaps.terminology.length" empty="No thin pages hit">
+			<li v-for="(g, i) in gaps.terminology.slice(0, 6)" :key="'t' + i">
+				<span>{{ g.query_norm }}</span><span class="m">asked {{ g.asked }}×</span>
+			</li>
+		</Sec>
+	</div>
+</template>
+
+<script>
+import { h } from "vue";
+// runtime-only Vue can't compile template strings — render fn instead (#1)
+const Sec = {
+	name: "Sec",
+	props: { title: String, n: Number, empty: String, warn: Boolean },
+	render() {
+		return h("div", { class: "wg-sec" }, [
+			h("div", { class: ["wg-sec-h", { warn: this.warn }] }, [this.title + " ", h("span", { class: "wg-n" }, String(this.n))]),
+			this.n
+				? h("ul", null, this.$slots.default ? this.$slots.default() : undefined)
+				: h("div", { class: "wg-empty text-muted" }, h("i", null, this.empty)),
+		]);
+	},
+};
+export default {
+	name: "RiskPanel",
+	components: { Sec },
+	props: {
+		archive: { type: Object, default: () => ({ fix_now: [], safe_to_archive: [] }) },
+		busFactor: { type: Array, default: () => [] },
+		gaps: { type: Object, default: () => ({ missing: [], terminology: [] }) },
+	},
+	emits: ["pick"],
+	computed: { fixNow() { return this.archive.fix_now || []; } },
+};
+</script>
+
+<style scoped>
+/* Sec's own markup is h()-rendered, not from this SFC's <template>, so it
+   never gets the scoped data-v attribute — :deep() targets it by ancestry.
+   .m lives in the default slot content (this SFC's own template), stays as-is. */
+.wg-risk { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 12px; }
+:deep(.wg-sec) { margin-bottom: 12px; }
+:deep(.wg-sec:last-child) { margin-bottom: 0; }
+:deep(.wg-sec-h) { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-bottom: 4px; }
+:deep(.wg-sec-h.warn) { color: #d9534f; }
+:deep(.wg-sec-h .wg-n) { opacity: 0.6; }
+:deep(.wg-sec ul) { list-style: none; margin: 0; padding: 0; }
+:deep(.wg-sec li) { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; padding: 2px 0; }
+.wg-sec .m { color: var(--text-muted, #999); white-space: nowrap; font-size: 11px; }
+:deep(.wg-empty) { font-size: 12px; }
+</style>

--- a/wiki-graph-core/src/SuggestPanel.vue
+++ b/wiki-graph-core/src/SuggestPanel.vue
@@ -1,0 +1,87 @@
+<template>
+	<div class="wg-sug">
+		<Sec title="Suggested links (should connect)" :n="lists.suggestedLinks.length" empty="No suggestions">
+			<li v-for="(s, i) in lists.suggestedLinks.slice(0, 8)" :key="'s' + i">
+				<span class="pair"><a href="#" @click.prevent="$emit('pick', s.a)">{{ s.aLabel }}</a>
+					<span class="arr">↔</span>
+					<a href="#" @click.prevent="$emit('pick', s.b)">{{ s.bLabel }}</a></span>
+				<span class="m">
+					<button v-if="canAddLink" class="wg-add" @click="$emit('add-link', s)">+ link</button>
+					<template v-else>{{ s.score }}</template>
+				</span>
+			</li>
+		</Sec>
+		<Sec title="Read together (implicit)" :n="lists.coRead.length" empty="No co-read pairs yet">
+			<li v-for="(c, i) in lists.coRead.slice(0, 8)" :key="'c' + i">
+				<span class="pair">{{ c.aLabel }} <span class="arr">↔</span> {{ c.bLabel }}</span>
+				<span class="m">{{ c.count }}×</span>
+			</li>
+		</Sec>
+		<Sec title="Broker pages (bridge clusters)" :n="lists.brokers.length" empty="No brokers" warn>
+			<li v-for="(p, i) in lists.brokers.slice(0, 6)" :key="'b' + i">
+				<a href="#" @click.prevent="$emit('pick', p.id)">{{ p.label || p.slug }}</a>
+				<span class="m">bridge</span>
+			</li>
+		</Sec>
+		<Sec title="Topic clusters" :n="clusterList.length" empty="No clusters">
+			<li v-for="(c, i) in clusterList.slice(0, 8)" :key="'t' + i">
+				<span>{{ c.label }}</span><span class="m">{{ c.size }} pages</span>
+			</li>
+		</Sec>
+	</div>
+</template>
+
+<script>
+import { h } from "vue";
+// runtime-only Vue can't compile template strings — render fn instead (#1)
+const Sec = {
+	name: "Sec",
+	props: { title: String, n: Number, empty: String, warn: Boolean },
+	render() {
+		return h("div", { class: "wg-sec" }, [
+			h("div", { class: ["wg-sec-h", { warn: this.warn }] }, [this.title + " ", h("span", { class: "wg-n" }, String(this.n))]),
+			this.n
+				? h("ul", null, this.$slots.default ? this.$slots.default() : undefined)
+				: h("div", { class: "wg-empty text-muted" }, h("i", null, this.empty)),
+		]);
+	},
+};
+export default {
+	name: "SuggestPanel",
+	components: { Sec },
+	props: {
+		lists: { type: Object, default: () => ({ suggestedLinks: [], coRead: [], brokers: [] }) },
+		communities: { type: Object, default: () => ({}) },
+		canAddLink: { type: Boolean, default: false },
+	},
+	emits: ["pick", "add-link"],
+	computed: {
+		clusterList() {
+			return Object.values(this.communities || {})
+				.filter((c) => c.size > 1)
+				.sort((a, b) => b.size - a.size);
+		},
+	},
+};
+</script>
+
+<style scoped>
+/* Sec's own markup (wg-sec/wg-sec-h/wg-n/ul/wg-empty) is h()-rendered, not
+   from this SFC's <template>, so it never gets the scoped data-v attribute —
+   :deep() targets it by ancestry. .pair/.arr/.m/.wg-add live in the default
+   slot content, which IS this SFC's own template, so those stay scoped as-is. */
+.wg-sug { border: 1px solid var(--border-color, #e2e6ea); border-radius: 8px; padding: 12px; }
+:deep(.wg-sec) { margin-bottom: 12px; }
+:deep(.wg-sec:last-child) { margin-bottom: 0; }
+:deep(.wg-sec-h) { font-size: 11px; text-transform: uppercase; color: var(--text-muted, #888); margin-bottom: 4px; }
+:deep(.wg-sec-h.warn) { color: #d9534f; }
+:deep(.wg-sec-h .wg-n) { opacity: 0.6; }
+:deep(.wg-sec ul) { list-style: none; margin: 0; padding: 0; }
+:deep(.wg-sec li) { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; padding: 2px 0; }
+.wg-sec .pair { overflow: hidden; text-overflow: ellipsis; }
+.wg-sec .arr { color: var(--text-muted, #aaa); margin: 0 3px; }
+.wg-sec .m { color: var(--text-muted, #999); white-space: nowrap; font-size: 11px; }
+.wg-add { font-size: 10px; padding: 1px 7px; border: 1px solid var(--bg-blue, #4c9aff); color: var(--bg-blue, #4c9aff); background: transparent; border-radius: 10px; cursor: pointer; }
+.wg-add:hover { background: var(--bg-blue, #4c9aff); color: #fff; }
+:deep(.wg-empty) { font-size: 12px; }
+</style>

--- a/wiki-graph-core/src/actions.js
+++ b/wiki-graph-core/src/actions.js
@@ -1,0 +1,41 @@
+// Prioritized action items from the graph (pure, both surfaces). Uses structure
+// + flags available everywhere; telemetry-only items (demand/gaps) are merged in
+// by the caller when present (admin). Guards degenerate/empty input (R8).
+export function computeActions(data, analysis) {
+	const nodes = (data && data.nodes) || [];
+	const edges = (data && data.edges) || [];
+	const pages = nodes.filter((n) => n.kind === "page");
+	const metrics = (analysis && analysis.metrics) || {};
+
+	const authors = {};
+	for (const e of edges) {
+		if (e.kind === "authored") (authors[e.target] = authors[e.target] || new Set()).add(e.source);
+	}
+
+	const stale = pages
+		.filter((p) => p.stale || p.contradiction)
+		.map((p) => ({ slug: p.slug, label: p.label, id: p.id,
+			reason: p.contradiction ? "contradiction" : "stale" }));
+
+	const orphans = pages
+		.filter((p) => (metrics[p.id] || {}).orphan)
+		.map((p) => ({ slug: p.slug, label: p.label, id: p.id }));
+
+	const busFactor = pages
+		.filter((p) => (authors[p.id] || new Set()).size === 1)
+		.map((p) => ({ slug: p.slug, label: p.label, id: p.id,
+			author: [...authors[p.id]][0].replace(/^user:/, "") }));
+
+	const norm = (t) => String(t || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+	const byNorm = {};
+	for (const p of pages) {
+		const k = norm(p.label);
+		if (k) (byNorm[k] = byNorm[k] || []).push(p);
+	}
+	const duplicates = Object.values(byNorm)
+		.filter((g) => g.length > 1)
+		.map((g) => ({ title: g[0].label, slugs: g.map((x) => x.slug) }));
+
+	const suggest = (analysis && analysis.lists && analysis.lists.suggestedLinks) || [];
+	return { stale, orphans, busFactor, duplicates, suggest };
+}

--- a/wiki-graph-core/src/analysis.js
+++ b/wiki-graph-core/src/analysis.js
@@ -1,0 +1,27 @@
+// Combined analysis: graphology structure (analyze) + TF-IDF content similarity.
+// Pure — the single source the Web Worker AND the sync fallback both call.
+// Merges suggested connections CONTENT-FIRST so a sparse/edgeless wiki still gets
+// useful "you should link" hints (R7), with structural (Adamic-Adar) filling in.
+import { analyze } from "./graphAnalysis.js";
+import { computeSimilarity, suggestionsFromSimilar } from "./similarity.js";
+
+function _mergeSuggestions(content, structural) {
+	const seen = new Set(), out = [];
+	for (const s of [...(content || []), ...(structural || [])]) {
+		if (!s || !s.a || !s.b) continue;
+		const key = s.a < s.b ? `${s.a}|${s.b}` : `${s.b}|${s.a}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(s);
+	}
+	return out.slice(0, 12);
+}
+
+export function fullAnalysis(data) {
+	const a = analyze(data);
+	const { similar } = computeSimilarity((data && data.nodes) || []);
+	a.lists.similar = similar; // slug -> top content-similar pages (DetailPanel)
+	const content = suggestionsFromSimilar(similar, data.nodes, data.edges);
+	a.lists.suggestedLinks = _mergeSuggestions(content, a.lists.suggestedLinks);
+	return a;
+}

--- a/wiki-graph-core/src/analysis.worker.js
+++ b/wiki-graph-core/src/analysis.worker.js
@@ -1,0 +1,12 @@
+// Web Worker: run the (heavy) graphology + TF-IDF analysis off the main thread
+// so the 3D graph stays responsive (R4). Echoes the request id back.
+import { fullAnalysis } from "./analysis.js";
+
+self.onmessage = (e) => {
+	const { id, data } = e.data || {};
+	try {
+		self.postMessage({ id, ok: true, result: fullAnalysis(data) });
+	} catch (err) {
+		self.postMessage({ id, ok: false, error: String((err && err.message) || err) });
+	}
+};

--- a/wiki-graph-core/src/flag.js
+++ b/wiki-graph-core/src/flag.js
@@ -1,0 +1,17 @@
+// Per-surface renderer feature flag (R10). Default ON — the 3D graph is now the
+// standard view (the old sigma/esbuild graph was retired). `localStorage.wg3d
+// = "off"` remains a per-surface kill-switch for instant rollback; a surface may
+// also force it via window.__wg3d.
+export function renderer3dEnabled() {
+	try {
+		if (typeof localStorage !== "undefined") {
+			const v = localStorage.getItem("wg3d");
+			if (v === "on") return true;
+			if (v === "off") return false;
+		}
+		if (typeof window !== "undefined" && window.__wg3d != null) return !!window.__wg3d;
+	} catch (_) {
+		/* privacy-mode storage access can throw */
+	}
+	return true;
+}

--- a/wiki-graph-core/src/graphAnalysis.js
+++ b/wiki-graph-core/src/graphAnalysis.js
@@ -1,0 +1,111 @@
+// Obsidian-style "Graph Analysis" over the wiki graph, client-side (graphology).
+// Pure: takes {nodes, edges, gaps, co_read}, returns per-node metrics + ranked
+// lists. Communities = Louvain (named by their top page); hubs/authorities =
+// HITS; brokers = betweenness (their loss fragments knowledge); suggested links =
+// Adamic-Adar over the [[links-to]] graph; orphans = pages with no link.
+import Graph from "graphology";
+import louvain from "graphology-communities-louvain";
+import hits from "graphology-metrics/centrality/hits";
+import betweenness from "graphology-metrics/centrality/betweenness";
+
+const _MAX_HUB_DEGREE = 60; // skip huge hubs in link prediction (pair blow-up)
+const _MAX_SUGGEST = 12;
+
+export function analyze(data) {
+	const nodes = (data && data.nodes) || [];
+	const edges = (data && data.edges) || [];
+	const pages = nodes.filter((n) => n.kind === "page");
+
+	// Full graph (all kinds) for communities + degree.
+	const full = new Graph({ type: "mixed" });
+	for (const n of nodes) if (n && n.id && !full.hasNode(n.id)) full.addNode(n.id);
+	for (const e of edges) {
+		if (!e || !full.hasNode(e.source) || !full.hasNode(e.target)) continue;
+		if (e.source === e.target || full.hasEdge(e.source, e.target)) continue;
+		try { full.addEdge(e.source, e.target, { weight: e.weight || 1 }); } catch (_) {}
+	}
+	let comm = {};
+	try { if (full.size > 0) comm = louvain(full); } catch (_) { comm = {}; }
+
+	// Page-only directed [[links-to]] graph for HITS + betweenness + orphans.
+	const pg = new Graph({ type: "directed", allowSelfLoops: false });
+	for (const p of pages) if (!pg.hasNode(p.id)) pg.addNode(p.id);
+	const adj = {}; // undirected adjacency for link prediction + orphan flag
+	for (const e of edges) {
+		if (!e || e.kind !== "links-to") continue;
+		if (pg.hasNode(e.source) && pg.hasNode(e.target) && e.source !== e.target
+			&& !pg.hasEdge(e.source, e.target)) {
+			try { pg.addEdge(e.source, e.target); } catch (_) {}
+		}
+		(adj[e.source] = adj[e.source] || new Set()).add(e.target);
+		(adj[e.target] = adj[e.target] || new Set()).add(e.source);
+	}
+	let hb = { hubs: {}, authorities: {} };
+	try { if (pg.size > 0) hb = hits(pg); } catch (_) {}
+	let bt = {};
+	try { if (pg.size > 0) bt = betweenness(pg); } catch (_) {}
+
+	const metrics = {};
+	for (const n of nodes) {
+		metrics[n.id] = {
+			degree: full.hasNode(n.id) ? full.degree(n.id) : 0,
+			community: comm[n.id] != null ? comm[n.id] : 0,
+			authority: hb.authorities[n.id] || 0,
+			hub: hb.hubs[n.id] || 0,
+			betweenness: bt[n.id] || 0,
+			orphan: n.kind === "page" && !(adj[n.id] && adj[n.id].size),
+		};
+	}
+
+	// Named communities: label each cluster by its highest-degree page.
+	const byComm = {};
+	for (const p of pages) (byComm[metrics[p.id].community] ||= []).push(p);
+	const communities = {};
+	for (const [cid, ps] of Object.entries(byComm)) {
+		const top = ps.slice().sort((a, b) => metrics[b.id].degree - metrics[a.id].degree)[0];
+		communities[cid] = { id: cid, label: top ? (top.label || top.slug) : cid, size: ps.length };
+	}
+
+	// Suggested links — Adamic-Adar over shared [[links-to]] neighbours.
+	const scores = {};
+	const deg = (id) => (adj[id] ? adj[id].size : 0);
+	for (const z of Object.keys(adj)) {
+		const ns = [...adj[z]];
+		if (ns.length < 2 || ns.length > _MAX_HUB_DEGREE) continue;
+		const w = 1 / Math.log(Math.max(2, deg(z)));
+		for (let i = 0; i < ns.length; i++) {
+			for (let j = i + 1; j < ns.length; j++) {
+				const a = ns[i], b = ns[j];
+				if (a === b || (adj[a] && adj[a].has(b))) continue; // already linked
+				const key = a < b ? a + "|" + b : b + "|" + a;
+				scores[key] = (scores[key] || 0) + w;
+			}
+		}
+	}
+	const label = {};
+	for (const p of pages) label[p.id] = p.label || p.slug;
+	const suggestedLinks = Object.entries(scores)
+		.map(([k, s]) => { const [a, b] = k.split("|"); return { a, b, aLabel: label[a], bLabel: label[b], score: Math.round(s * 100) / 100 }; })
+		.filter((x) => x.aLabel && x.bLabel)
+		.sort((x, y) => y.score - x.score)
+		.slice(0, _MAX_SUGGEST);
+
+	const byDegree = (a, b) => metrics[b.id].degree - metrics[a.id].degree;
+	const hubs = [...pages].sort((a, b) => metrics[b.id].authority - metrics[a.id].authority || byDegree(a, b)).slice(0, 12);
+	const brokers = [...pages].filter((p) => metrics[p.id].betweenness > 0)
+		.sort((a, b) => metrics[b.id].betweenness - metrics[a.id].betweenness).slice(0, 8);
+	const mostRead = pages.filter((n) => (n.demand || 0) > 0)
+		.sort((a, b) => (b.demand || 0) - (a.demand || 0)).slice(0, 12);
+	const debt = pages.filter((n) => n.debt)
+		.sort((a, b) => (b.demand || 0) - (a.demand || 0)).slice(0, 12);
+	const orphans = pages.filter((n) => metrics[n.id].orphan);
+	const gaps = ((data && data.gaps) || []).slice().sort((a, b) => (b.asked || 0) - (a.asked || 0));
+	const coRead = ((data && data.co_read) || []).slice()
+		.map((c) => ({ ...c, aLabel: label[`page:${c.a}`] || c.a, bLabel: label[`page:${c.b}`] || c.b }))
+		.sort((a, b) => (b.count || 0) - (a.count || 0)).slice(0, 12);
+
+	return {
+		metrics, communities,
+		lists: { hubs, brokers, mostRead, debt, orphans, gaps, suggestedLinks, coRead },
+	};
+}

--- a/wiki-graph-core/src/graphStyle.js
+++ b/wiki-graph-core/src/graphStyle.js
@@ -1,0 +1,68 @@
+// Pure node/edge styling for the wiki graph (no sigma/graphology import).
+// Color by node kind (Org/Role/User/page) or by Louvain community; size by
+// centrality × read-demand; knowledge-debt pages go red. Edge color by kind:
+// [[links-to]] solid (knowledge), the rest dashed-weight (utilization overlay).
+
+const KIND = { org: "#a970ff", role: "#f2b134", user: "#4c9aff", page: "#8892b0" };
+const COMMUNITY = [
+	"#7c9eff", "#f2b134", "#4bd0a0", "#ff7ab6", "#a970ff",
+	"#ff8a5c", "#5cc8ff", "#c3d82c", "#ff5c8a", "#9d7bff",
+];
+const DEBT = "#ff5c5c";
+
+export function nodeStyle(n, m, { mode, dark }) {
+	if (n.kind === "cluster") {
+		return {
+			label: `${n.label} (${n.weight || 1})`,
+			size: Math.min(12 + Math.sqrt(n.weight || 1) * 4, 40),
+			color: COMMUNITY[(Number(n.community) || 0) % COMMUNITY.length],
+		};
+	}
+	const deg = (m && m.degree) || 0;
+	const demand = n.demand || 0;
+	const auth = (m && m.authority) || 0;
+	let size = 4 + Math.sqrt(deg) * 2.4 + Math.sqrt(demand) * 1.8 + auth * 12;
+	if (m && m.betweenness > 0) size += 3; // broker pages stand out
+	if (n.kind === "org") size = Math.max(size, 10);
+	size = Math.min(size, 28);
+	let color;
+	if (mode === "community") color = COMMUNITY[((m && m.community) || 0) % COMMUNITY.length];
+	else color = KIND[n.kind] || "#888888";
+	if (n.debt) color = DEBT;
+	return { label: n.label || n.id, size, color };
+}
+
+const EDGE_COLORS_DARK = {
+	"links-to": "#5a6478", scope: "#3a3f4b", authored: "#3f6f57",
+	"member-of": "#5a4f7a", read: "#3a5a80", wrote: "#7a5a3a", "cluster-link": "#5a6478",
+};
+const EDGE_COLORS_LIGHT = {
+	"links-to": "#aeb6c2", scope: "#e2e6ea", authored: "#bfe3cf",
+	"member-of": "#d8cff0", read: "#cfe0f5", wrote: "#f0dcc0", "cluster-link": "#aeb6c2",
+};
+
+export function edgeStyle(e, { dark }) {
+	const map = dark ? EDGE_COLORS_DARK : EDGE_COLORS_LIGHT;
+	const strong = e.kind === "links-to" || e.kind === "cluster-link";
+	return {
+		size: e.kind === "cluster-link" ? Math.min(1 + (e.weight || 1) * 0.5, 5) : (strong ? 1.4 : 0.7),
+		color: map[e.kind] || (dark ? "#3a3f4b" : "#e2e6ea"),
+		type: "line",
+	};
+}
+
+export const LEGEND = {
+	nodes: [
+		{ label: "Org", color: KIND.org },
+		{ label: "Role", color: KIND.role },
+		{ label: "User", color: KIND.user },
+		{ label: "Page", color: KIND.page },
+		{ label: "Knowledge debt", color: DEBT },
+	],
+	edges: [
+		{ label: "links ([[wiki]])", kind: "links-to" },
+		{ label: "scope", kind: "scope" },
+		{ label: "authored", kind: "authored" },
+		{ label: "read / wrote", kind: "read" },
+	],
+};

--- a/wiki-graph-core/src/graphView.js
+++ b/wiki-graph-core/src/graphView.js
@@ -1,0 +1,112 @@
+// Pure display transforms that fight the hairball (Bloom / Linkurious / SemSpect).
+// overlayFilter = which tiers to show; egoGraph = one node's neighborhood (work
+// view); searchGraph = matches + their neighbors; collapseClusters = a topic map
+// of community meta-nodes you expand on click. All pure → node-testable.
+
+const NODE_KINDS = {
+	knowledge: new Set(["page", "org"]),
+	utilization: new Set(["page", "org", "role", "user"]),
+	demand: new Set(["page", "org", "role", "user"]),
+};
+const EDGE_KINDS = {
+	knowledge: new Set(["links-to", "scope"]),
+	utilization: new Set(["links-to", "scope", "authored", "member-of"]),
+	demand: new Set(["links-to", "scope", "authored", "member-of", "read", "wrote"]),
+};
+
+export function overlayFilter(data, overlay) {
+	const nodes = data.nodes || [], edges = data.edges || [];
+	if (overlay === "demand") return { nodes, edges, gaps: data.gaps };
+	const nk = NODE_KINDS[overlay] || NODE_KINDS.knowledge;
+	const ek = EDGE_KINDS[overlay] || EDGE_KINDS.knowledge;
+	const fn = nodes.filter((n) => nk.has(n.kind));
+	const ids = new Set(fn.map((n) => n.id));
+	const fe = edges.filter((e) => ek.has(e.kind) && ids.has(e.source) && ids.has(e.target));
+	return { nodes: fn, edges: fe, gaps: data.gaps };
+}
+
+function _adjacency(edges) {
+	const adj = {};
+	for (const e of edges) {
+		(adj[e.source] = adj[e.source] || []).push(e.target);
+		(adj[e.target] = adj[e.target] || []).push(e.source);
+	}
+	return adj;
+}
+
+function _ball(seeds, edges, hops) {
+	const adj = _adjacency(edges);
+	const keep = new Set(seeds);
+	let frontier = [...keep];
+	for (let h = 0; h < hops; h++) {
+		const next = [];
+		for (const id of frontier) for (const nb of (adj[id] || [])) {
+			if (!keep.has(nb)) { keep.add(nb); next.push(nb); }
+		}
+		frontier = next;
+	}
+	return keep;
+}
+
+export function egoGraph(data, focusId, hops = 2) {
+	const nodes = data.nodes || [], edges = data.edges || [];
+	if (!focusId || !nodes.some((n) => n.id === focusId)) return data;
+	const keep = _ball([focusId], edges, hops);
+	return {
+		nodes: nodes.filter((n) => keep.has(n.id)),
+		edges: edges.filter((e) => keep.has(e.source) && keep.has(e.target)),
+		gaps: data.gaps,
+	};
+}
+
+export function searchGraph(data, query, hops = 1) {
+	const q = (query || "").trim().toLowerCase();
+	if (!q) return data;
+	const nodes = data.nodes || [], edges = data.edges || [];
+	const seeds = nodes
+		.filter((n) => (n.label || n.id).toLowerCase().includes(q) || (n.slug || "").includes(q))
+		.map((n) => n.id);
+	if (!seeds.length) return { nodes: [], edges: [], gaps: data.gaps };
+	const keep = _ball(seeds, edges, hops);
+	return {
+		nodes: nodes.filter((n) => keep.has(n.id)),
+		edges: edges.filter((e) => keep.has(e.source) && keep.has(e.target)),
+		gaps: data.gaps,
+	};
+}
+
+export function collapseClusters(data, metrics, communities, expanded) {
+	const nodes = data.nodes || [], edges = data.edges || [];
+	expanded = expanded || new Set();
+	const commOf = (id) => (metrics[id] ? metrics[id].community : null);
+	const displayId = {}, out = [], size = {}, seen = new Set();
+	for (const n of nodes) {
+		if (n.kind !== "page") continue; // topic map = pages only
+		const c = String(commOf(n.id));
+		if (expanded.has(c)) {
+			displayId[n.id] = n.id;
+			out.push(n);
+		} else {
+			const cid = `cluster:${c}`;
+			displayId[n.id] = cid;
+			size[cid] = (size[cid] || 0) + 1;
+			if (!seen.has(cid)) {
+				seen.add(cid);
+				out.push({ id: cid, kind: "cluster", cluster: true, community: c,
+					label: (communities[c] || {}).label || `Cluster ${c}` });
+			}
+		}
+	}
+	for (const n of out) if (n.kind === "cluster") n.weight = size[n.id];
+	const byKey = {}, outEdges = [];
+	for (const e of edges) {
+		if (e.kind !== "links-to") continue;
+		const s = displayId[e.source], t = displayId[e.target];
+		if (!s || !t || s === t) continue;
+		const key = s < t ? s + "|" + t : t + "|" + s;
+		if (byKey[key]) { byKey[key].weight += 1; continue; }
+		const edge = { source: s, target: t, kind: "cluster-link", weight: 1 };
+		byKey[key] = edge; outEdges.push(edge);
+	}
+	return { nodes: out, edges: outEdges, gaps: data.gaps };
+}

--- a/wiki-graph-core/src/runAnalysis.js
+++ b/wiki-graph-core/src/runAnalysis.js
@@ -1,0 +1,45 @@
+// Analysis client — runs fullAnalysis in a Web Worker (R4: never blocks the
+// render thread), degrading to a synchronous call when workers are unavailable
+// or fail. Callers just `await runAnalysis(data)`.
+import { fullAnalysis } from "./analysis.js";
+
+let _worker = null, _seq = 0;
+const _pending = new Map();
+
+function _ensureWorker() {
+	if (_worker || typeof Worker === "undefined") return _worker;
+	try {
+		_worker = new Worker(new URL("./analysis.worker.js", import.meta.url), { type: "module" });
+		_worker.onmessage = (e) => {
+			const { id, ok, result, error } = e.data || {};
+			const p = _pending.get(id);
+			if (!p) return;
+			_pending.delete(id);
+			ok ? p.resolve(result) : p.reject(new Error(error));
+		};
+		_worker.onerror = () => {
+			_worker = null;
+			// worker chunk failed (stale deploy, CSP) — reject every queued call so
+			// callers' .catch fallback fires instead of hanging forever
+			for (const p of _pending.values()) p.reject(new Error("worker error"));
+			_pending.clear();
+		};
+	} catch (_) {
+		_worker = null;
+	}
+	return _worker;
+}
+
+export function runAnalysis(data) {
+	const w = _ensureWorker();
+	if (!w) return Promise.resolve(fullAnalysis(data)); // graceful sync fallback
+	// data is a Vue reactive proxy (computed over reactive state) — postMessage
+	// throws DataCloneError on Proxy, so send a plain-JSON clone instead
+	let plain;
+	try { plain = JSON.parse(JSON.stringify(data)); } catch (_) { plain = data; }
+	const id = ++_seq;
+	return new Promise((resolve, reject) => {
+		_pending.set(id, { resolve, reject });
+		w.postMessage({ id, data: plain });
+	}).catch(() => fullAnalysis(data)).finally(() => { _pending.delete(id); }); // any worker error → sync
+}

--- a/wiki-graph-core/src/similarity.js
+++ b/wiki-graph-core/src/similarity.js
@@ -1,0 +1,118 @@
+// TF-IDF content similarity + content-based suggested connections (pure).
+// No embeddings, no LLM: tokenize title+summary, build normalized TF-IDF vectors,
+// cosine via an INVERTED INDEX for top-k (R4 — not O(n²) all-pairs). Empty-content
+// docs are skipped (R8). Content suggestions BOOTSTRAP the graph when structural
+// methods are cold (R7 — an edgeless wiki still gets useful "you should link"
+// hints, which is how a sparse LLM-wiki starts to densify).
+
+const STOP = new Set(
+	("the a an of on in to for and or but with without from by as at is are was were be been "
+	+ "this that these those it its i we you they he she our your their my his her no not into "
+	+ "over under about above below up down out off then than so if else per via etc has have "
+	+ "had will shall may can could should would do does did what when where which who whom why").split(" ")
+);
+
+function tokenize(text) {
+	const out = [];
+	for (const t of String(text || "").toLowerCase().split(/[^a-z0-9]+/)) {
+		if (t.length > 2 && !STOP.has(t)) out.push(t);
+	}
+	return out;
+}
+
+function _vectorize(pages) {
+	const docs = [], df = new Map();
+	for (const p of pages) {
+		const toks = tokenize([p.label, p.summary].filter(Boolean).join(" "));
+		if (!toks.length) continue; // skip empty content (R8)
+		const tf = new Map();
+		for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+		for (const t of tf.keys()) df.set(t, (df.get(t) || 0) + 1);
+		docs.push({ id: p.id, slug: p.slug, label: p.label || p.slug, tf });
+	}
+	const N = docs.length;
+	const vecs = docs.map((d) => {
+		let norm = 0;
+		const raw = new Map();
+		for (const [t, c] of d.tf) {
+			const idf = Math.log((N + 1) / ((df.get(t) || 0) + 1)) + 1;
+			const w = (1 + Math.log(c)) * idf;
+			raw.set(t, w);
+			norm += w * w;
+		}
+		norm = Math.sqrt(norm) || 1;
+		const v = new Map();
+		for (const [t, w] of raw) v.set(t, w / norm);
+		return v;
+	});
+	const inv = new Map();
+	vecs.forEach((v, i) => {
+		for (const [t, w] of v) {
+			if (!inv.has(t)) inv.set(t, []);
+			inv.get(t).push([i, w]);
+		}
+	});
+	return { docs, vecs, inv, N };
+}
+
+// slug -> [{id, slug, label, score}] — the top-k most content-similar pages.
+export function computeSimilarity(nodes, opts = {}) {
+	const topK = opts.topK || 5;
+	const minSim = opts.minSim == null ? 0.12 : opts.minSim;
+	const pages = (nodes || []).filter((n) => n.kind === "page");
+	const { docs, vecs, inv, N } = _vectorize(pages);
+	const similar = {};
+	for (let i = 0; i < N; i++) {
+		const dot = new Map();
+		for (const [t, w] of vecs[i]) {
+			const postings = inv.get(t) || [];
+			if (postings.length > 200) continue; // ubiquitous term — skip (perf, R4)
+			for (const [j, wj] of postings) {
+				if (j !== i) dot.set(j, (dot.get(j) || 0) + w * wj);
+			}
+		}
+		const ranked = [...dot.entries()]
+			.filter(([, s]) => s >= minSim)
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, topK)
+			.map(([j, s]) => ({
+				id: docs[j].id, slug: docs[j].slug, label: docs[j].label,
+				score: Math.round(s * 100) / 100,
+			}));
+		if (ranked.length) similar[docs[i].slug] = ranked;
+	}
+	return { similar, docCount: N };
+}
+
+// Content-similar page PAIRS that are NOT already linked → "you should connect".
+export function suggestionsFromSimilar(similar, nodes, edges, opts = {}) {
+	const linked = new Set();
+	for (const e of edges || []) {
+		if (e.kind !== "links-to") continue;
+		linked.add(e.source < e.target ? `${e.source}|${e.target}` : `${e.target}|${e.source}`);
+	}
+	const label = {}, idBySlug = {};
+	for (const n of nodes || []) {
+		if (n.kind !== "page") continue;
+		label[n.id] = n.label || n.slug;
+		idBySlug[n.slug] = n.id;
+	}
+	const seen = new Set(), out = [];
+	for (const [slug, sims] of Object.entries(similar)) {
+		const a = idBySlug[slug];
+		for (const s of sims) {
+			const b = s.id;
+			if (!a || !b || a === b) continue;
+			const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+			if (linked.has(key) || seen.has(key)) continue;
+			seen.add(key);
+			out.push({ a, b, aLabel: label[a], bLabel: s.label, score: s.score, source: "content" });
+		}
+	}
+	return out.sort((x, y) => y.score - x.score).slice(0, opts.max || 12);
+}
+
+export function contentSuggestions(nodes, edges, opts = {}) {
+	const { similar } = computeSimilarity(nodes, opts);
+	return suggestionsFromSimilar(similar, nodes, edges, opts);
+}

--- a/wiki-graph-core/verify_pure.mjs
+++ b/wiki-graph-core/verify_pure.mjs
@@ -1,0 +1,233 @@
+// Pure-JS verification (#47) of wiki-graph-core analysis/similarity/actions.
+// Run with node20 from anywhere; the modules' bare `graphology` imports resolve
+// from wiki-graph-core/node_modules (self-contained package).
+import { computeSimilarity, contentSuggestions } from "./src/similarity.js";
+import { analyze } from "./src/graphAnalysis.js";
+import { fullAnalysis } from "./src/analysis.js";
+import { computeActions } from "./src/actions.js";
+
+let pass = 0, fail = 0;
+const ok = (c, m) => { if (c) { pass++; } else { fail++; console.error("  ✗ FAIL:", m); } };
+const section = (t) => console.log("\n== " + t + " ==");
+
+// ---- deterministic corpus (seeded LCG, no Math.random) ----
+let _s = 123456789;
+const rnd = () => ((_s = (_s * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+const VOCAB = ("invoice payment reconciliation ledger tax gst filing return credit debit "
+	+ "customer supplier item warehouse stock delivery order sales purchase quotation "
+	+ "employee payroll salary attendance leave shift expense claim asset depreciation "
+	+ "workflow approval notification email report dashboard chart filter export").split(" ");
+
+function makePages(n, wordsPer) {
+	const pages = [];
+	for (let i = 0; i < n; i++) {
+		const words = [];
+		// each page draws from a shifting window of the vocab so overlaps vary
+		const base = Math.floor(rnd() * (VOCAB.length - 8));
+		for (let w = 0; w < wordsPer; w++) {
+			const idx = (base + Math.floor(rnd() * 8)) % VOCAB.length;
+			words.push(VOCAB[idx]);
+		}
+		pages.push({
+			kind: "page", id: `page:p${i}`, slug: `p${i}`,
+			label: `Page ${i} ${VOCAB[i % VOCAB.length]}`,
+			summary: words.join(" "),
+		});
+	}
+	return pages;
+}
+
+// ---- independent brute-force TF-IDF cosine (mirrors similarity.js formulas) ----
+const STOP = new Set(("the a an of on in to for and or but with without from by as at is are was were be been "
+	+ "this that these those it its i we you they he she our your their my his her no not into "
+	+ "over under about above below up down out off then than so if else per via etc has have "
+	+ "had will shall may can could should would do does did what when where which who whom why").split(" "));
+const tok = (s) => String(s || "").toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 2 && !STOP.has(t));
+
+function bruteSimilar(pages, topK, minSim) {
+	const docs = [], df = new Map();
+	for (const p of pages) {
+		const toks = tok([p.label, p.summary].filter(Boolean).join(" "));
+		if (!toks.length) continue;
+		const tf = new Map();
+		for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+		for (const t of tf.keys()) df.set(t, (df.get(t) || 0) + 1);
+		docs.push({ slug: p.slug, tf });
+	}
+	const N = docs.length;
+	const vecs = docs.map((d) => {
+		let norm = 0; const raw = new Map();
+		for (const [t, c] of d.tf) {
+			const idf = Math.log((N + 1) / ((df.get(t) || 0) + 1)) + 1;
+			const w = (1 + Math.log(c)) * idf;
+			raw.set(t, w); norm += w * w;
+		}
+		norm = Math.sqrt(norm) || 1;
+		const v = new Map();
+		for (const [t, w] of raw) v.set(t, w / norm);
+		return v;
+	});
+	const out = {};
+	for (let i = 0; i < N; i++) {
+		const ranked = [];
+		for (let j = 0; j < N; j++) {
+			if (i === j) continue;
+			let dot = 0;
+			const [a, b] = vecs[i].size < vecs[j].size ? [vecs[i], vecs[j]] : [vecs[j], vecs[i]];
+			for (const [t, w] of a) { const wj = b.get(t); if (wj) dot += w * wj; }
+			if (dot >= minSim) ranked.push({ slug: docs[j].slug, score: Math.round(dot * 100) / 100 });
+		}
+		ranked.sort((x, y) => y.score - x.score || (x.slug < y.slug ? -1 : 1));
+		if (ranked.length) out[docs[i].slug] = ranked.slice(0, topK);
+	}
+	return out;
+}
+
+const canon = (list) => list.map((x) => `${x.slug}:${x.score}`)
+	.sort().join(",");
+
+// ================= R4: inverted-index top-k == brute force =================
+section("R4 — inverted-index top-k matches brute-force all-pairs cosine");
+{
+	const pages = makePages(60, 14);
+	const topK = 6, minSim = 0.12;
+	const { similar, docCount } = computeSimilarity(pages, { topK, minSim });
+	const brute = bruteSimilar(pages, topK, minSim);
+	ok(docCount === 60, `docCount 60 (got ${docCount})`);
+
+	// same set of source slugs with suggestions
+	const ks1 = Object.keys(similar).sort().join(",");
+	const ks2 = Object.keys(brute).sort().join(",");
+	ok(ks1 === ks2, `source-slug sets match (${Object.keys(similar).length} vs ${Object.keys(brute).length})`);
+
+	// for each source, the top-k neighbor+score set matches (canonicalized to
+	// drop tie-order cosmetics; the invariant is same neighbors & scores)
+	let mism = 0, cmp = 0;
+	for (const slug of Object.keys(brute)) {
+		cmp++;
+		// compare top-1 exactly (highest score must agree) and the k-set
+		const a = (similar[slug] || []);
+		const b = brute[slug];
+		if (canon(a) !== canon(b)) {
+			// tolerate a boundary tie: same scores multiset even if slugs at the
+			// cut differ — check score multiset first
+			const sa = a.map((x) => x.score).sort().join(",");
+			const sb = b.map((x) => x.score).sort().join(",");
+			if (sa !== sb) { mism++; if (mism <= 3) console.error(`    slug ${slug}: inv=${canon(a)} brute=${canon(b)}`); }
+		}
+		if (a.length && b.length) ok(a[0].score >= b[0].score - 1e-9, `${slug} top-1 score not below brute`);
+	}
+	ok(mism === 0, `all ${cmp} sources: top-k set matches brute force (${mism} mismatched)`);
+	console.log(`  compared ${cmp} sources; top1 example: ${Object.keys(similar)[0]} -> ${JSON.stringify((similar[Object.keys(similar)[0]]||[])[0])}`);
+}
+
+// ================= R7: edgeless graph still yields content suggestions =====
+section("R7 — edgeless wiki bootstraps content suggestions");
+{
+	const pages = makePages(30, 14);
+	const data = { nodes: pages, edges: [] }; // NO edges at all
+	const sugg = contentSuggestions(pages, [], { max: 12 });
+	ok(sugg.length > 0, `content suggestions on edgeless graph (${sugg.length})`);
+	ok(sugg.every((s) => s.a && s.b && s.a !== s.b), "every suggestion is a valid distinct pair");
+	ok(sugg.every((s) => s.source === "content"), "all sourced from content (no structure available)");
+	// fullAnalysis merges content-first: suggestedLinks non-empty on edgeless graph
+	const a = fullAnalysis(data);
+	ok((a.lists.suggestedLinks || []).length > 0, `fullAnalysis suggestedLinks non-empty edgeless (${a.lists.suggestedLinks.length})`);
+	console.log(`  example: ${sugg[0].aLabel} <-> ${sugg[0].bLabel} (score ${sugg[0].score})`);
+}
+
+// ================= R7b: existing edges are not re-suggested ================
+section("R7b — already-linked pairs are excluded from suggestions");
+{
+	const pages = makePages(20, 14);
+	const first = contentSuggestions(pages, [], { max: 20 });
+	ok(first.length > 0, "have a baseline suggestion to link");
+	const top = first[0];
+	const edges = [{ kind: "links-to", source: top.a, target: top.b }];
+	const after = contentSuggestions(pages, edges, { max: 20 });
+	const stillThere = after.some((s) => {
+		const k1 = `${s.a}|${s.b}`, k2 = `${s.b}|${s.a}`;
+		const t1 = `${top.a}|${top.b}`;
+		return k1 === t1 || k2 === t1;
+	});
+	ok(!stillThere, "the now-linked pair is no longer suggested");
+}
+
+// ================= R8: degenerate inputs never crash =======================
+section("R8 — degenerate graphs: guarded, no crash");
+const cases = {
+	"empty": { nodes: [], edges: [] },
+	"one node": { nodes: [{ kind: "page", id: "page:a", slug: "a", label: "A", summary: "hello world content" }], edges: [] },
+	"one node no content": { nodes: [{ kind: "page", id: "page:a", slug: "a", label: "", summary: "" }], edges: [] },
+	"two disconnected": { nodes: [
+		{ kind: "page", id: "page:a", slug: "a", label: "Alpha", summary: "invoice tax gst" },
+		{ kind: "page", id: "page:b", slug: "b", label: "Beta", summary: "payroll salary leave" }], edges: [] },
+	"all orphan (no links-to)": { nodes: makePages(8, 10), edges: [] },
+	"all empty content": { nodes: [
+		{ kind: "page", id: "page:a", slug: "a", label: "", summary: "" },
+		{ kind: "page", id: "page:b", slug: "b", label: "", summary: "" }], edges: [] },
+	"self-loop + dup edge": { nodes: makePages(4, 8), edges: [
+		{ kind: "links-to", source: "page:p0", target: "page:p0" },
+		{ kind: "links-to", source: "page:p0", target: "page:p1" },
+		{ kind: "links-to", source: "page:p0", target: "page:p1" }] },
+	"dangling edge target": { nodes: makePages(3, 8), edges: [
+		{ kind: "links-to", source: "page:p0", target: "page:MISSING" }] },
+};
+for (const [name, data] of Object.entries(cases)) {
+	try {
+		const a = fullAnalysis(data);
+		const acts = computeActions(data, a);
+		const sim = computeSimilarity(data.nodes);
+		ok(a && a.metrics && a.lists && a.communities, `${name}: fullAnalysis shape intact`);
+		ok(acts && Array.isArray(acts.stale) && Array.isArray(acts.orphans)
+			&& Array.isArray(acts.busFactor) && Array.isArray(acts.duplicates), `${name}: computeActions shape intact`);
+		ok(typeof sim.docCount === "number", `${name}: computeSimilarity ran`);
+	} catch (e) {
+		ok(false, `${name}: threw ${e && e.message}`);
+	}
+}
+
+// ================= computeActions semantics ================================
+section("computeActions — stale / orphan / busFactor / duplicates");
+{
+	const pages = [
+		{ kind: "page", id: "page:a", slug: "a", label: "Invoicing", summary: "invoice tax", stale: true },
+		{ kind: "page", id: "page:b", slug: "b", label: "Invoicing", summary: "invoice gst", contradiction: true },
+		{ kind: "page", id: "page:c", slug: "c", label: "Orphan One", summary: "lonely page" },
+		{ kind: "page", id: "page:d", slug: "d", label: "Linked", summary: "payroll salary" },
+		{ kind: "page", id: "page:e", slug: "e", label: "Linked Two", summary: "payroll leave" },
+	];
+	const edges = [
+		{ kind: "links-to", source: "page:d", target: "page:e" },
+		{ kind: "authored", source: "user:alice", target: "page:d" }, // single author -> bus factor
+	];
+	const data = { nodes: pages, edges };
+	const a = analyze(data);
+	const acts = computeActions(data, a);
+	ok(acts.stale.length === 2, `2 stale/contradicted (got ${acts.stale.length})`);
+	ok(acts.stale.some((s) => s.reason === "contradiction") && acts.stale.some((s) => s.reason === "stale"), "both stale reasons present");
+	ok(acts.orphans.some((o) => o.slug === "c"), "orphan 'c' flagged");
+	ok(!acts.orphans.some((o) => o.slug === "d" || o.slug === "e"), "linked d/e not orphaned");
+	ok(acts.busFactor.some((b) => b.slug === "d" && b.author === "alice"), "bus-factor: single author 'alice' on d");
+	ok(acts.duplicates.some((d) => d.slugs.includes("a") && d.slugs.includes("b")), "near-dup title 'Invoicing' merged (a,b)");
+}
+
+// ================= lists.debt — hot+stale pages, sorted by demand (#13) ====
+section("analyze — lists.debt (knowledge debt panel)");
+{
+	const pages = [
+		{ kind: "page", id: "page:a", slug: "a", label: "A", summary: "invoice tax", debt: true, demand: 5 },
+		{ kind: "page", id: "page:b", slug: "b", label: "B", summary: "invoice gst", debt: true, demand: 20 },
+		{ kind: "page", id: "page:c", slug: "c", label: "C", summary: "payroll salary" }, // not debt
+	];
+	const data = { nodes: pages, edges: [] };
+	const a = analyze(data);
+	ok(Array.isArray(a.lists.debt), "lists.debt is an array");
+	ok(a.lists.debt.length === 2, `only debt-flagged pages included (got ${a.lists.debt.length})`);
+	ok(!a.lists.debt.some((p) => p.slug === "c"), "non-debt page excluded");
+	ok(a.lists.debt[0] && a.lists.debt[0].slug === "b", "sorted by demand desc (b before a)");
+}
+
+// ================= summary =================================================
+console.log(`\n${fail === 0 ? "✅" : "❌"} pure-JS verification: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
- wiki-graph-core: self-contained file: package shared by tenant + admin Vite builds (Graph3D/3d-force-graph renderer, four analysis tabs, TF-IDF similarity, Web Worker analysis, exclusion rules, priority cards)
- tenant Knowledge Graph tab in the Skills SPA (flag wg3d, default on)
- durable out-of-body manual_links on Jarvis Wiki Page + backfill patch; add_wiki_link uses a locking read and bumps modified so concurrent re-ingest saves fail loudly instead of clobbering curated links
- get_wiki_graph (caller-scoped, single R3 enforcement point), get_wiki_graph_history (SM-only) + daily Jarvis Wiki Graph History snapshot
- admin push now carries page creation dates and never emits dangling scope edges past the user cap
- pure-JS verification harness (103 assertions) + 26 backend tests

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
