### PR TITLE
fix(deploy): build installs frontend deps first (self-contained)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "jarvis",
 	"private": true,
-	"description": "Server-side node deps (gemini-cli for the OAuth confidential-client flow in jarvis/oauth/api.py) + Vue SPA build orchestration (the chat UI under frontend/, served at /jarvis). The scripts below are the contract Frappe Cloud's deploy pipeline picks up: `npm install` at this root triggers `postinstall` which installs the SPA's own deps, then `npm run build` delegates to the SPA's Vite build, dropping the bundle into jarvis/public/frontend/ + jarvis/www/jarvis.html. Without these scripts FC pulls the repo and never builds the SPA, so /jarvis 404s in production.",
+	"description": "Server-side node deps (gemini-cli for the OAuth confidential-client flow in jarvis/oauth/api.py) + Vue SPA build orchestration (the chat UI under frontend/, served at /jarvis). The scripts below are the contract Frappe Cloud's deploy pipeline picks up: `npm install` at this root triggers `postinstall` which installs the SPA's own deps, then `npm run build` (re)installs the SPA deps and runs its Vite build, dropping the bundle into jarvis/public/frontend/ + jarvis/www/jarvis.html. build installs first on purpose, so it is self-contained and picks up newly-added deps (e.g. wiki-graph-core) even when the deploy runs build without a fresh root install. Without these scripts FC pulls the repo and never builds the SPA, so /jarvis 404s in production.",
 	"scripts": {
 		"postinstall": "npm run install-frontend",
 		"install-frontend": "cd frontend && npm install",
 		"dev-frontend": "cd frontend && npm run dev",
-		"build": "npm run build-frontend",
+		"build": "npm run install-frontend && npm run build-frontend",
 		"build-frontend": "cd frontend && npm run build"
 	},
 	"dependencies": {


### PR DESCRIPTION
Follow-up to the root build wiring. The SPA `build` currently runs only `npm run build-frontend` (Vite), relying on `postinstall` having installed `frontend/` deps. But `postinstall` only fires on `npm install` at the root - so any deploy path that runs `npm run build` **without** a fresh root install (e.g. after a pull that added a new dep) builds against stale `frontend/node_modules` and Vite fails to resolve the new `wiki-graph-core`.

Fix: `build` now installs the frontend deps first, making it self-contained:

```
"build": "npm run install-frontend && npm run build-frontend"
```

So the build always picks up newly-added/changed deps, on Frappe Cloud or any bench, with no manual `npm install`. `postinstall` is kept for the plain `npm install` (dev) path.

Note on the local `file:` dep: npm v7+ symlinks `wiki-graph-core`, so re-running install relinks it and picks up changes; if a copy-mode environment ever caches it, add `--install-links=false`/`--force` to `install-frontend`.