### PR TITLE
fix(build): install wiki-graph-core deps before the SPA build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "Server-side node deps (gemini-cli for the OAuth confidential-client flow in jarvis/oauth/api.py) + Vue SPA build orchestration (the chat UI under frontend/, served at /jarvis). The scripts below are the contract Frappe Cloud's deploy pipeline picks up: `npm install` at this root triggers `postinstall` which installs the SPA's own deps, then `npm run build` (re)installs the SPA deps and runs its Vite build, dropping the bundle into jarvis/public/frontend/ + jarvis/www/jarvis.html. build installs first on purpose, so it is self-contained and picks up newly-added deps (e.g. wiki-graph-core) even when the deploy runs build without a fresh root install. Without these scripts FC pulls the repo and never builds the SPA, so /jarvis 404s in production.",
 	"scripts": {
 		"postinstall": "npm run install-frontend",
-		"install-frontend": "cd frontend && npm install",
+		"install-graph-core": "cd wiki-graph-core && npm install",
+		"install-frontend": "npm run install-graph-core && cd frontend && npm install",
 		"dev-frontend": "cd frontend && npm run dev",
 		"build": "npm run install-frontend && npm run build-frontend",
 		"build-frontend": "cd frontend && npm run build"

--- a/wiki-graph-core/package-lock.json
+++ b/wiki-graph-core/package-lock.json
@@ -503,6 +503,13 @@
         "graphology-types": ">=0.20.0"
       }
     },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/graphology-utils": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",


### PR DESCRIPTION
## Problem

`bench build` (and Frappe Cloud deploys) fail with:

```
[vite]: Rollup failed to resolve import "graphology" from
app/wiki-graph-core/src/graphAnalysis.js
```

The `/jarvis` SPA bundles `wiki-graph-core` as a `file:../wiki-graph-core` **source** package. It's designed self-contained — own `node_modules` (graphology, 3d-force-graph, vue) with `vite.config.js` `dedupe:["vue"]`. But nothing installed those deps:

- Vite resolves the symlink to the package's **real path**, so its bare imports resolve from `wiki-graph-core/node_modules`, not `frontend/node_modules` (declaring the deps in `frontend/package.json` does **not** work).
- `npm install` in `frontend/` links the `file:` package but does **not** install its transitive deps.
- The app build script never ran `npm install` inside `wiki-graph-core`.

The wiring was simply omitted when the wiki-graph feature landed (`e486a79`).

## Fix

Add an `install-graph-core` step chained into `install-frontend` in `package.json`, so `wiki-graph-core`'s own deps are installed before the Vite build on every `bench build` / FC deploy — mirroring `jarvis_admin`'s "build installs first on purpose" contract. Also commits the completed `wiki-graph-core` lockfile (adds the `graphology-types` peer dep) for reproducible installs.

```diff
+ "install-graph-core": "cd wiki-graph-core && npm install",
- "install-frontend": "cd frontend && npm install",
+ "install-frontend": "npm run install-graph-core && cd frontend && npm install",
```

## Verification

```
rm -rf app/wiki-graph-core/node_modules
bench build --app jarvis   # ✔ jarvis built in ~14s, green from a clean checkout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)