### PR TITLE
fix(chat): validate create/update before showing the confirmation card

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -429,6 +429,19 @@ _DESTRUCTIVE = frozenset({"delete_doc", "cancel_doc", "amend_doc", "send_email"}
 # default-unrestricted allowlist under auto-apply + a prompt injection would be
 # an unconfirmed arbitrary whitelisted method call, so it never fast-paths.
 _AUTO_APPLYABLE = frozenset({"create_doc", "update_doc"})
+# Gated writes we dry-run in the sandbox AT PARK TIME and BLOCK on if the dry-run
+# fails, so a deterministic failure (missing mandatory field, bad link, no create
+# permission) is returned to the model BEFORE a confirmation card is shown instead
+# of surfacing after the human confirms a doomed card. Preview and confirm build
+# the same doc as the same exec_user, so a preview failure faithfully predicts the
+# confirm failure. Scoped to the build-from-args create/update pair - the reported
+# mandatory-field case. submit_doc/cancel_doc/delete_doc/amend_doc are _PREVIEWABLE
+# too and are STILL dry-run at park via _pending_preview, but keep the legacy
+# park-with-note: their failures are state-based (already exists, docstatus, link
+# integrity) and dry-running them fires on_submit/on_cancel hooks - extending the
+# block to them is a separate, larger change. run_method is never sandbox-run at
+# park at all (its target's inline non-DB side effects would fire unconfirmed).
+_DRY_RUN_ON_PARK = frozenset({"create_doc", "update_doc"})
 
 
 def _as_bool(value) -> bool:
@@ -456,6 +469,19 @@ def _run_preview(tool: str, args: dict) -> dict:
 				 "hooks (inline HTTP calls in on_submit / on_cancel) are "
 				 "not sandboxed by preview."),
 	}
+
+
+def _preview_error(e: Exception) -> dict:
+	"""Translate a sandboxed dry-run exception into the model-facing error
+	envelope. NEVER audited: a dry-run commits nothing, so there is no write to
+	record. Shared by the model-facing ``preview=True`` path and the park gate's
+	pre-park validation so both classify the same exceptions identically."""
+	if isinstance(e, JarvisError):
+		return _error(type(e).__name__, str(e))
+	if isinstance(e, frappe.PermissionError):
+		return _error("PermissionDeniedError", str(e) or "permission denied")
+	# frappe.ValidationError (incl. MandatoryError) / frappe.DuplicateEntryError
+	return _error("InvalidArgumentError", str(e) or type(e).__name__)
 
 
 def _gate_context(conversation: str | None) -> tuple[str, str]:
@@ -617,12 +643,9 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 		# is committed, so there is no write to record.
 		try:
 			return {"ok": True, "data": _run_preview(tool, args)}
-		except JarvisError as e:
-			return _error(type(e).__name__, str(e))
-		except frappe.PermissionError as e:
-			return _error("PermissionDeniedError", str(e) or "permission denied")
-		except (frappe.ValidationError, frappe.DuplicateEntryError) as e:
-			return _error("InvalidArgumentError", str(e) or type(e).__name__)
+		except (JarvisError, frappe.PermissionError, frappe.ValidationError,
+				frappe.DuplicateEntryError) as e:
+			return _preview_error(e)
 
 	# Write-safety confirmation gate (issue #186): a gated write is NEVER
 	# executed on the model path. Park it - build a preview, mint a single-use
@@ -688,7 +711,25 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 				as_dict=True) or {}
 			if flags.get("auto_apply") or flags.get("file_box"):
 				return dispatch_confirmed(tool, args)
-		preview = _pending_preview(tool, args)
+		# Validate BEFORE parking. For a create/update (build-from-args) write,
+		# run the real call in the rollback sandbox now: a deterministic failure
+		# (missing mandatory field, bad link, no create permission) means the
+		# confirmed write would fail identically - preview and confirm build the
+		# same doc as the same exec_user - so return the error to the model NOW
+		# instead of showing a confirmation card that dies on click. clear_messages
+		# so the validation msgprint does not leak into the turn (mirrors
+		# preview_doc). Every other gated write (submit/cancel/delete/amend get a
+		# sandboxed preview; send_email/run_method/create_custom_skill/update_wiki
+		# a described-intent one) parks via _pending_preview exactly as before.
+		if tool in _DRY_RUN_ON_PARK:
+			try:
+				preview = _run_preview(tool, args)
+			except (JarvisError, frappe.PermissionError,
+					frappe.ValidationError, frappe.DuplicateEntryError) as e:
+				frappe.clear_messages()
+				return _preview_error(e)
+		else:
+			preview = _pending_preview(tool, args)
 		token = pending_confirm.mint(conversation=conv, owner=owner_user,
 									 tool=tool, args=args, run_id=run_id,
 									 exec_user=exec_user)

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -84,6 +84,48 @@ class TestGateParks(FrappeTestCase):
 		self.assertIsNotNone(captured.get("token"))
 
 
+class TestGatePreValidatesBeforePark(FrappeTestCase):
+	"""A dry-runnable gated write is validated in the sandbox BEFORE the
+	confirmation card is minted. A deterministic failure (e.g. a missing
+	mandatory field) is returned to the model immediately instead of parking a
+	card that would die on click - the confirmed write is the SAME call as the
+	same user, so a preview failure is a faithful predictor."""
+
+	def test_gated_create_missing_mandatory_returns_error_not_park(self):
+		# ToDo.description is mandatory. Pass a non-empty values dict that omits
+		# it (an empty dict is refused earlier by _validate_create_args).
+		patcher, captured = _spy_mint()
+		with patch("jarvis.chat.events.publish_to_user") as pub, patcher:
+			r = api._run_tool("create_doc", {
+				"doctype": "ToDo", "values": {"priority": "Medium"},
+			})
+			# No confirmation card was published either.
+			self.assertFalse(pub.called)
+		# Model-facing validation error, NOT the park shape.
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+		self.assertIn("description", r["error"]["message"].lower())
+		# Did NOT park: no token minted (and the error envelope + no publish
+		# above prove nothing was parked or executed).
+		self.assertIsNone(captured.get("token"))
+
+	def test_valid_gated_create_still_parks(self):
+		# Regression guard: a preview that VALIDATES cleanly still parks a card
+		# with the sandboxed dry-run shape and mints a token.
+		desc = "jarvis-test-gate-prevalidate-valid-011"
+		patcher, captured = _spy_mint()
+		with patcher:
+			r = api._run_tool("create_doc", {
+				"doctype": "ToDo", "values": {"description": desc},
+			})
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertTrue(r["data"]["preview"]["preview"])
+		self.assertIn("would", r["data"]["preview"])
+		self.assertIsNotNone(captured.get("token"))
+		self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+
+
 class TestNonGatedWriteRunsImmediately(FrappeTestCase):
 	def test_add_comment_executes_immediately(self):
 		# add_comment is a write but NOT gated - it must run inline, no park.


### PR DESCRIPTION
## Problem

When a user asks Jarvis to create a document (e.g. an Item), Jarvis shows a confirmation card. After the user clicks **Confirm**, the create fails with a mandatory-field error (`Value missing for …`). Mandatory validation should happen **before** the card is shown, so the user is never asked to confirm a write that is already doomed.

## Root cause

`create_doc` is a gated write, so the gate parks it behind a confirmation card. To build that card it dry-runs the real create in a rollback sandbox (`_run_preview`), which runs full Frappe validation and raises `MandatoryError`. But `_pending_preview` (`api.py:518-523`) **caught that `ValidationError`, buried it in a `"preview unavailable"` note, and parked the card anyway**. On confirm, `dispatch_confirmed` re-ran the write fresh and the same error finally surfaced.

Preview and confirm build the **same doc as the same `exec_user`**, so a preview failure faithfully predicts the confirm failure — there is no reason to show the card.

## Fix

For `create_doc`/`update_doc`, dry-run the write **before** parking. On a deterministic failure (missing mandatory field, bad link, no create permission) return the error to the model **instead of** minting a token or publishing a card — so it can collect the missing input and retry. Only a clean preview parks.

- `_DRY_RUN_ON_PARK = {create_doc, update_doc}` — scoped to the build-from-args pair (the reported case). `submit`/`cancel`/`delete`/`amend` keep the **legacy park-with-note**: their failures are state-based and dry-running them fires `on_submit`/`on_cancel` hooks — a separate, larger change (and existing `test_auto_apply` cases rely on those doomed previews still parking).
- Shared no-audit `_preview_error()` helper — a dry-run commits nothing, so there is no write to record (per the principle at `api.py:616-617`); also dedups the existing `preview=True` path.
- `_pending_preview` left **untouched** — it is also called by the resync endpoint (`actions_api.py:392`), where park-with-note is correct.

## Tests

Extends `test_confirm_gate.py`:
- `test_gated_create_missing_mandatory_returns_error_not_park` — `InvalidArgumentError` returned, **no token minted, no `action:pending` published**, nothing executed.
- `test_valid_gated_create_still_parks` — regression guard: a clean preview still parks a sandboxed card and mints a token.

Ran locally against `jarvis.localhost` — **95 tests green** across `test_confirm_gate`, `test_auto_apply`, `test_tool_preview_audit`, `test_action_pending`, `test_pending_confirm`, `test_actions_api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)