### PR TITLE
fix(chat): auto-recover from stale device-pairing (INVALID_REQUEST) rejection

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -122,20 +122,33 @@ _CLIENT_MODE = "backend"
 _ROLE = "operator"
 _PLATFORM = "linux"  # informational; only affects the v3 signature payload
 
-# openclaw rejection codes that indicate the customer's stored pairing
-# is stale for the CURRENT container (typically because admin re-provisioned
-# the tenant and the new container has no record of this deviceId). On
-# any of these we wipe + re-pair once. OTHER rejection codes
-# (signature-invalid, scope-mismatch, etc.) are programming bugs / config
-# errors and must NOT trigger a retry - that'd hide the bug behind silent
-# re-pair attempts that destroy valid credentials.
+# A stale-pairing rejection means the customer's stored device token no longer
+# matches the CURRENT container (typically admin re-provisioned the tenant and
+# the new container has no record of this deviceId). On these we wipe + re-pair
+# once. Scope/rate failures and signature/client-bug rejections are NOT fixable
+# by re-pairing and must NOT trigger it - that'd churn valid credentials.
 #
-# Sprint-3 (2026-06-16 review): we used to substring-match on
-# ``str(err).lower()`` which would false-positive any future error
-# embedding one of these tokens in its message text (think log lines,
-# diagnostic dumps, partial-match codes like ``device-not-paired-yet``).
-# The classifier now reads the structured ``.code`` attribute populated
-# at the raise site from openclaw's response envelope.
+# THE RELIABLE SIGNAL IS ``error.details.code``, NOT the top-level code. The
+# gateway reports this rejection with a coarse top-level ``error.code =
+# "INVALID_REQUEST"`` and the precise reason under
+# ``error.details.code = "AUTH_DEVICE_TOKEN_MISMATCH"``. Because the bench
+# always presents an explicit device token, the gateway collapses every
+# recoverable device-token failure (not-paired / token-missing / token-revoked /
+# token-mismatch / role-missing) into that single detail code, so matching it is
+# both correct AND complete. Scope/rate map to AUTH_SCOPE_MISMATCH /
+# AUTH_RATE_LIMITED (excluded), and the device-SIGNATURE path is a different
+# shape (client bug, excluded).
+_STALE_PAIRING_DETAIL_CODE = "AUTH_DEVICE_TOKEN_MISMATCH"
+# Secondary signal: the underscore wire ``authReason`` (used if a future gateway
+# ever ships the detail code absent). NOT the hyphenated fine-grained reasons -
+# those are collapsed server-side and never reach the wire on this path.
+_STALE_PAIRING_AUTH_REASON = "device_token_mismatch"
+# Legacy top-level ``.code`` set. DEAD against the current gateway: its
+# top-level error.code enum is {NOT_LINKED, NOT_PAIRED, AGENT_TIMEOUT,
+# INVALID_REQUEST, APPROVAL_NOT_FOUND, UNAVAILABLE} - none of these hyphenated
+# values can appear there, so this never matched a real rejection. Kept only as
+# a harmless defensive fallback if a future gateway promotes a fine-grained code
+# to the top level.
 _STALE_PAIRING_CODES = frozenset({
 	"device-not-paired",
 	"token-mismatch",
@@ -145,16 +158,57 @@ _STALE_PAIRING_CODES = frozenset({
 
 
 def _is_stale_pairing(err: Exception) -> bool:
-	"""Return True iff ``err`` is an OpenclawUnreachableError whose
-	openclaw error.code is in the stale-pairing set.
+	"""Return True iff ``err`` is a recoverable stale device-pairing rejection
+	that a wipe + re-pair can fix.
 
-	Strictly typed: an error WITHOUT a ``.code`` attribute (network-level
-	failure, programmer bug) never triggers the repair path. The previous
-	substring check would have caught these falsely if their message
-	happened to contain one of the marker strings.
+	Primary signal: openclaw's structured ``error.details.code ==
+	"AUTH_DEVICE_TOKEN_MISMATCH"``. Secondary: the underscore wire
+	``authReason == "device_token_mismatch"``. We deliberately do NOT recover on
+	scope/rate failures (AUTH_SCOPE_MISMATCH / AUTH_RATE_LIMITED) or the separate
+	device-signature path - re-pairing can't fix those and would churn creds. An
+	error without these structured markers (network failure, programmer bug)
+	never triggers repair.
 	"""
-	code = getattr(err, "code", None)
-	return code in _STALE_PAIRING_CODES
+	if getattr(err, "detail_code", None) == _STALE_PAIRING_DETAIL_CODE:
+		return True
+	if getattr(err, "auth_reason", None) == _STALE_PAIRING_AUTH_REASON:
+		return True
+	# Legacy defensive fallback (see _STALE_PAIRING_CODES above).
+	return getattr(err, "code", None) in _STALE_PAIRING_CODES
+
+
+# Cross-turn re-pair cooldown. Per-connect the repair loop is bounded
+# (allow_repair flips to False on the retry), but across turns nothing stops a
+# tenant whose pairing keeps diverging (e.g. agent_url points at a different
+# container than admin re-pairs) from re-pairing on EVERY turn - silent
+# credential churn plus gateway auth-rate-limiter pressure. After a re-pair we
+# mark a short cooldown (keyed by gateway_url, stable across keypair rotation);
+# if we hit stale-pairing again within it, we skip the re-pair and surface the
+# error loudly so ops can spot the divergence.
+_REPAIR_COOLDOWN_SECONDS = 300
+
+
+def _repair_cooldown_key(gateway_url: str) -> str:
+	return f"jarvis_chat_repair_cooldown:{gateway_url}"
+
+
+def _repair_on_cooldown(gateway_url: str) -> bool:
+	import frappe
+	try:
+		return bool(frappe.cache().get_value(_repair_cooldown_key(gateway_url)))
+	except Exception:
+		return False  # cache hiccup must never block a legitimate repair
+
+
+def _mark_repair_attempted(gateway_url: str) -> None:
+	import frappe
+	try:
+		frappe.cache().set_value(
+			_repair_cooldown_key(gateway_url), "1",
+			expires_in_sec=_REPAIR_COOLDOWN_SECONDS,
+		)
+	except Exception:
+		pass
 
 
 def _chat_final_text(payload: dict) -> str | None:
@@ -248,7 +302,23 @@ class OpenclawSession:
 			try: ws.close()
 			except Exception: pass
 			if allow_repair and _is_stale_pairing(e):
+				if _repair_on_cooldown(gateway_url):
+					# A re-pair already ran for this gateway within the cooldown
+					# and we're STILL rejected - re-pairing isn't fixing it.
+					# Surface loudly instead of churning credentials every turn.
+					_logger.warning(
+						"OpenclawSession.connect: re-pair ran recently but the "
+						"gateway still rejects device pairing (%s) - not re-pairing "
+						"again to avoid credential churn. Likely a divergence "
+						"(agent_url points at a different/older container, or the "
+						"container's device store keeps resetting). Run "
+						"jarvis.chat.device.rotate_chat_device on the site or check "
+						"the tenant's container assignment. gateway=%s",
+						e, gateway_url,
+					)
+					raise
 				cls._repair_and_reconnect(gateway_url, stale_device_id=creds.device_id)
+				_mark_repair_attempted(gateway_url)
 				return cls._attempt_connect(gateway_url, allow_repair=False)
 			raise
 		except Exception:
@@ -707,9 +777,16 @@ class OpenclawSession:
 			if _is_response_frame(frame, connect_id):
 				if not frame.get("ok"):
 					err = frame.get("error") or {}
+					# The precise auth reason rides in error.details, NOT the
+					# coarse top-level code (which is INVALID_REQUEST for a device
+					# -token mismatch). Capture both so _is_stale_pairing can
+					# branch on the structured detail.
+					details = err.get("details") or {}
 					raise OpenclawUnreachableError(
 						f"connect rejected: {err.get('code', '?')}: {err.get('message', '')}",
 						code=err.get("code"),
+						detail_code=details.get("code"),
+						auth_reason=details.get("authReason"),
 					)
 				return
 		raise OpenclawUnreachableError("no connect response before timeout")

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -68,17 +68,29 @@ class OpenclawUnreachableError(JarvisError):
     """Raised when the openclaw gateway can't be reached (WS handshake
     failed, container down).
 
-    Sprint-3 (2026-06-16 review): may carry a structured ``code`` taken
-    from openclaw's rejection payload (``device-not-paired``,
-    ``token-mismatch``, ``signature-invalid``, etc.). Downstream
-    classifiers (e.g. _is_stale_pairing) should branch on this
-    attribute, not on a substring match of the message. ``code`` is
-    None when the error didn't originate from an openclaw response
-    (e.g. network-level WS open failure)."""
+    May carry the openclaw connect-rejection envelope so downstream
+    classifiers (e.g. ``_is_stale_pairing``) can branch on structured
+    fields instead of substring-matching the message:
 
-    def __init__(self, message: str, *, code: str | None = None):
+    - ``code`` - the COARSE top-level ``error.code`` (e.g.
+      ``INVALID_REQUEST``, ``UNAVAILABLE``). Note the gateway reports a
+      device-token mismatch under ``INVALID_REQUEST``; the precise reason
+      is in the detail fields below, NOT here.
+    - ``detail_code`` - ``error.details.code`` (e.g.
+      ``AUTH_DEVICE_TOKEN_MISMATCH``, ``AUTH_SCOPE_MISMATCH``). This is the
+      reliable recover-signal for stale pairing.
+    - ``auth_reason`` - ``error.details.authReason`` (underscore wire form,
+      e.g. ``device_token_mismatch``).
+
+    All three are None when the error didn't originate from an openclaw
+    response (e.g. a network-level WS open failure)."""
+
+    def __init__(self, message: str, *, code: str | None = None,
+                 detail_code: str | None = None, auth_reason: str | None = None):
         super().__init__(message)
         self.code = code
+        self.detail_code = detail_code
+        self.auth_reason = auth_reason
 
 
 class OpenclawReloadFailedError(JarvisError):

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.device import ChatDeviceCredentials
-from jarvis.chat.openclaw_client import OpenclawSession
+from jarvis.chat.openclaw_client import OpenclawSession, _is_stale_pairing
 from jarvis.exceptions import OpenclawUnreachableError
 
 
@@ -377,17 +377,25 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 	that, clear local creds, re-pair via ensure_paired, and retry the WS
 	once. A second stale signal is a real failure (no infinite loop)."""
 
+	def setUp(self):
+		# The cross-turn re-pair cooldown is keyed by gateway_url in shared
+		# Redis; clear it so a prior test's repair doesn't suppress this one's.
+		import frappe
+		from jarvis.chat.openclaw_client import _repair_cooldown_key
+		frappe.cache().delete_value(_repair_cooldown_key("ws://t"))
+
 	def _build_two_ws(self, first_reject_marker: str, second_ok: bool):
-		"""Return two scripted WS instances: first one rejects connect with
-		`first_reject_marker` in the error message; second one accepts."""
+		"""Return two scripted WS instances: first rejects connect with
+		`first_reject_marker` as the LEGACY top-level error.code; second accepts.
+
+		Note: the real gateway reports a device-token mismatch as
+		error.code="INVALID_REQUEST" with the reason under error.details.code
+		("AUTH_DEVICE_TOKEN_MISMATCH") - exercised by the *_real_wire_* tests
+		below. These legacy-shaped fixtures only exercise the defensive
+		top-level-.code fallback in _is_stale_pairing."""
 		first_sent: list = []
 		second_sent: list = []
 
-		# Sprint-3 (2026-06-16 review): openclaw's rejection payload puts
-		# the marker in error.code, not error.message. The classifier on
-		# the client side now reads the structured code rather than
-		# substring-matching the message text, so the scripted fixture
-		# must place the marker accordingly.
 		def _first_nack():
 			req_id = first.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
@@ -459,10 +467,9 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		device-signature-invalid means our client code is broken; clearing
 		creds won't help and the operator needs to see the original error.
 
-		Sprint-3 (2026-06-16): the classifier now reads the structured
-		``code`` attribute, not the message. Putting the marker in
-		``error.code`` is the production wire shape; this test pins that
-		signature-invalid is NOT in the stale-pairing code set."""
+		The classifier reads structured fields, never the message. This marker
+		is neither the stale-pairing detail code nor in the legacy fallback set,
+		so it is NOT stale-pairing."""
 		creds = _make_creds()
 
 		def _nack():
@@ -513,6 +520,139 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			"path - we read the structured error.code",
 		)
 
+	# --- Real gateway wire shape: error.code=INVALID_REQUEST + error.details ---
+
+	def _connect_rejecting_with(self, error: dict, *, second_ok: bool | None):
+		"""Connect against a first WS that rejects with the given `error`
+		object. If second_ok is None only one WS is scripted (no retry
+		expected); else a second WS accepts (True) or rejects (False).
+		Returns (clear_called, ensure_calls, raised)."""
+		def _first_nack():
+			return _frame({"type": "res", "id": first.sent[-1]["id"],
+						   "ok": False, "error": error})
+
+		first = _ScriptedWS([_challenge(), _first_nack])
+		ws_list = [first]
+		if second_ok is not None:
+			def _second():
+				rid = second.sent[-1]["id"]
+				return _frame({"type": "res", "id": rid, "ok": second_ok,
+							   "error": error, "payload": {}})
+			second = _ScriptedWS([_challenge(), _second])
+			ws_list.append(second)
+
+		ws_iter = iter(ws_list)
+		clear_called: list = []
+		ensure_calls: list = []
+		creds = _make_creds()
+
+		def _ensure():
+			ensure_calls.append(True)
+			return creds
+
+		raised = None
+		try:
+			with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+					   side_effect=lambda *a, **kw: next(ws_iter)), \
+				 patch("jarvis.chat.openclaw_client.ensure_paired", side_effect=_ensure), \
+				 patch("jarvis.chat.openclaw_client.clear_credentials",
+					   side_effect=lambda: clear_called.append(True)):
+				sess = OpenclawSession.connect("ws://t")
+				sess.close()
+		except OpenclawUnreachableError as e:
+			raised = e
+		return clear_called, ensure_calls, raised
+
+	def test_real_wire_device_token_mismatch_triggers_repair(self):
+		"""The production shape: top-level INVALID_REQUEST with the reason in
+		error.details.code=AUTH_DEVICE_TOKEN_MISMATCH must wipe + re-pair once."""
+		err = {"code": "INVALID_REQUEST",
+			   "message": "unauthorized: device token mismatch (rotate/reissue device token)",
+			   "details": {"code": "AUTH_DEVICE_TOKEN_MISMATCH",
+						   "authReason": "device_token_mismatch"}}
+		clears, ensure_calls, raised = self._connect_rejecting_with(err, second_ok=True)
+		self.assertEqual(len(clears), 1)
+		self.assertEqual(len(ensure_calls), 2)
+		self.assertIsNone(raised)
+
+	def test_real_wire_scope_mismatch_does_not_repair(self):
+		"""A scope/config problem is not fixable by re-pairing - surface it."""
+		err = {"code": "INVALID_REQUEST", "message": "unauthorized: scope",
+			   "details": {"code": "AUTH_SCOPE_MISMATCH", "authReason": "scope_mismatch"}}
+		clears, _, raised = self._connect_rejecting_with(err, second_ok=None)
+		self.assertFalse(clears, "scope mismatch must NOT trigger a re-pair")
+		self.assertIsNotNone(raised)
+
+	def test_real_wire_rate_limited_does_not_repair(self):
+		err = {"code": "INVALID_REQUEST", "message": "rate limited",
+			   "details": {"code": "AUTH_RATE_LIMITED", "authReason": "rate_limited"}}
+		clears, _, raised = self._connect_rejecting_with(err, second_ok=None)
+		self.assertFalse(clears, "rate limiting must NOT trigger a re-pair (would worsen it)")
+		self.assertIsNotNone(raised)
+
+	def test_bare_invalid_request_without_details_does_not_repair(self):
+		"""INVALID_REQUEST with no pairing detail is a generic bad request,
+		not stale pairing - must not churn credentials."""
+		err = {"code": "INVALID_REQUEST", "message": "bad request"}
+		clears, _, raised = self._connect_rejecting_with(err, second_ok=None)
+		self.assertFalse(clears)
+		self.assertIsNotNone(raised)
+
+	def test_auth_reason_underscore_is_stale_when_detail_code_absent(self):
+		"""Secondary signal: the underscore authReason still classifies as
+		stale if the gateway ever omits details.code."""
+		err = {"code": "INVALID_REQUEST", "message": "device token mismatch",
+			   "details": {"authReason": "device_token_mismatch"}}
+		clears, _, raised = self._connect_rejecting_with(err, second_ok=True)
+		self.assertEqual(len(clears), 1)
+		self.assertIsNone(raised)
+
+	def test_repair_skipped_when_on_cooldown(self):
+		"""If a re-pair already ran for this gateway within the cooldown and we
+		are STILL rejected, skip the re-pair and surface the error (no churn)."""
+		from jarvis.chat.openclaw_client import _mark_repair_attempted
+		_mark_repair_attempted("ws://t")  # simulate a very recent repair
+		err = {"code": "INVALID_REQUEST", "message": "device token mismatch",
+			   "details": {"code": "AUTH_DEVICE_TOKEN_MISMATCH"}}
+		# Only one WS scripted: with the cooldown active, no repair + retry happens.
+		clears, ensure_calls, raised = self._connect_rejecting_with(err, second_ok=None)
+		self.assertFalse(clears, "cooldown must suppress the re-pair")
+		self.assertEqual(len(ensure_calls), 1, "no second attempt while on cooldown")
+		self.assertIsNotNone(raised)
+
+
+class TestStalePairingClassifier(FrappeTestCase):
+	"""Unit tests for _is_stale_pairing against the structured error fields."""
+
+	def _err(self, **kw):
+		return OpenclawUnreachableError("connect rejected", **kw)
+
+	def test_detail_code_device_token_mismatch_is_stale(self):
+		self.assertTrue(_is_stale_pairing(
+			self._err(code="INVALID_REQUEST", detail_code="AUTH_DEVICE_TOKEN_MISMATCH")))
+
+	def test_scope_and_rate_detail_codes_not_stale(self):
+		self.assertFalse(_is_stale_pairing(
+			self._err(code="INVALID_REQUEST", detail_code="AUTH_SCOPE_MISMATCH")))
+		self.assertFalse(_is_stale_pairing(
+			self._err(code="INVALID_REQUEST", detail_code="AUTH_RATE_LIMITED")))
+
+	def test_bare_invalid_request_not_stale(self):
+		self.assertFalse(_is_stale_pairing(self._err(code="INVALID_REQUEST")))
+
+	def test_underscore_auth_reason_is_stale(self):
+		self.assertTrue(_is_stale_pairing(
+			self._err(code="INVALID_REQUEST", auth_reason="device_token_mismatch")))
+
+	def test_legacy_top_level_code_still_stale(self):
+		# Defensive fallback path stays green even though the live gateway
+		# never emits these as a top-level code.
+		self.assertTrue(_is_stale_pairing(self._err(code="device-not-paired")))
+
+	def test_plain_error_never_stale(self):
+		self.assertFalse(_is_stale_pairing(OpenclawUnreachableError("network down")))
+		self.assertFalse(_is_stale_pairing(RuntimeError("nope")))
+
 
 class TestRepairConvoyCollapse(FrappeTestCase):
 	"""Sprint-2 (2026-06-16): N concurrent workers all observe a stale
@@ -524,15 +664,22 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 	collapses the convoy: one worker pairs, the rest detect the new
 	device_id on disk and skip the wipe."""
 
+	def setUp(self):
+		import frappe
+		from jarvis.chat.openclaw_client import _repair_cooldown_key
+		frappe.cache().delete_value(_repair_cooldown_key("ws://t"))
+
 	def _build_stale_then_ok(self) -> tuple[_ScriptedWS, _ScriptedWS]:
-		"""Two scripted WS: first rejects with device-not-paired, second
+		"""Two scripted WS: first rejects with a stale-pairing signal, second
 		accepts. Caller wires per-test patches on top."""
 		first = _ScriptedWS([_challenge(), None])
 		second = _ScriptedWS([_challenge(), None])
 		first._frames[1] = lambda: _frame({
 			"type": "res", "id": first.sent[-1]["id"], "ok": False,
-			# Sprint-3: marker in code, not message - matches openclaw's wire shape.
-			"error": {"code": "device-not-paired", "message": "stale"},
+			# Real gateway wire shape: coarse INVALID_REQUEST + the reason under
+			# error.details.code (AUTH_DEVICE_TOKEN_MISMATCH).
+			"error": {"code": "INVALID_REQUEST", "message": "device token mismatch",
+					  "details": {"code": "AUTH_DEVICE_TOKEN_MISMATCH"}},
 		})
 		second._frames[1] = lambda: _frame({
 			"type": "res", "id": second.sent[-1]["id"], "ok": True, "payload": {},


### PR DESCRIPTION
## Problem

Chat shows this on every turn and never recovers:

```
connect rejected: INVALID_REQUEST: unauthorized: device token mismatch (rotate/reissue device token)
```

Chat turns connect to the tenant's openclaw gateway with a **device bearer token** (`Jarvis Settings.chat_device_token`). When that token no longer matches the container's `openclaw_state/devices/paired.json` — container `destroy`+reprovision, bench site restore/clone, etc. — the gateway rejects the connect.

**Root cause (two layers):**
1. The bench's token genuinely went stale vs. the container's paired record.
2. The bench *has* an auto self-heal (wipe creds + re-pair once), but `_is_stale_pairing` matched the reason against the **top-level** `error.code`. The gateway sends this rejection with the coarse top-level code `INVALID_REQUEST` and the real reason under **`error.details.code = "AUTH_DEVICE_TOKEN_MISMATCH"`** — which `_handshake` discarded. Since the top-level `error.code` enum is a fixed set (`{NOT_LINKED, NOT_PAIRED, AGENT_TIMEOUT, INVALID_REQUEST, APPROVAL_NOT_FOUND, UNAVAILABLE}`), the old hyphenated `_STALE_PAIRING_CODES` could never match — the self-heal was effectively **dead code**. So the raw rejection was relayed to the UI every turn.

## Fix

- `_handshake` captures `error.details`; `OpenclawUnreachableError` now carries `detail_code` / `auth_reason` (docstring corrected).
- `_is_stale_pairing` classifies on **`error.details.code == "AUTH_DEVICE_TOKEN_MISMATCH"`** — the complete recover-signal (the gateway collapses every recoverable device-token failure into it because the bench always presents an explicit device token), with the underscore `authReason` as a secondary check. `AUTH_SCOPE_MISMATCH` / `AUTH_RATE_LIMITED` and the separate device-**signature** path are excluded (re-pair can't fix those). The legacy top-level `.code` set stays only as a relabeled defensive fallback.
- **Cross-turn re-pair cooldown** (Redis, keyed by gateway_url, 5 min): if a re-pair already ran and we're *still* rejected, skip re-pairing and log a loud WARN instead of churning credentials + driving the gateway auth rate-limiter on every turn — so a genuinely diverging tenant (e.g. `agent_url` points at a different container than admin re-pairs) surfaces to ops instead of flapping silently.

Effect: on a stale token the bench re-pairs transparently — the user sees a brief reconnect, not a permanent error.

## Design note

The fix design was corrected after a review that verified the wire contract: `authReason` is server-collapsed to underscore values (`device_token_mismatch`), not the hyphenated forms; and gating on `canRetryWithDeviceToken` would have *nullified* the fix (it's `false` exactly when a device token is presented — our case), so it's deliberately not used.

## Verification (against `jarvis-test.localhost`)

- `test_chat_openclaw_client` — **36 pass** (12 new: real-wire trigger, scope/rate/bare-request non-recovery, underscore `authReason`, cooldown skip, and a `_is_stale_pairing` classifier unit suite). Corrected the misleading "production wire shape" fixture comments.
- Adjacent modules green: `test_chat_device`, `test_openclaw_session_pool`, `test_chat_worker`, `test_session_lifecycle`, `test_prewarm`, `test_openclaw_http_client` (97 tests).

## Immediate operational unblock (currently-stuck tenant)

```
bench --site <tenant-site> execute jarvis.chat.device.rotate_chat_device
```

## Follow-ups (not in this PR)

Latent divergence hazards, not the live cause: fleet-agent `pair_device` mints a new token on every call, and `jarvis_admin` skips its `Jarvis Tenant` mirror write on same-`device_id` re-pairs (on a false "idempotent" assumption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)