### PR TITLE
fix(chat): revive the stale-pairing self-heal + adopt gateway-reissued device tokens

### DIFF
--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -237,6 +237,28 @@ def clear_credentials() -> None:
 	frappe.db.commit()
 
 
+def update_device_token(new_token: str, *, device_id: str) -> bool:
+	"""Persist a gateway-REISSUED device token for the current pairing.
+
+	openclaw's hello-ok can carry a rotated ``auth.deviceToken`` (the
+	gateway replaces the stored token whenever the existing entry no
+	longer lines up with the connect's scopes/issuer). The rotation is
+	already durable on the gateway side by the time the client sees
+	hello-ok, so a bench that keeps signing with the pair-time token
+	fails every FOLLOWING connect with "device token mismatch".
+
+	Guarded on ``device_id``: if another worker re-paired while this
+	connect was in flight, Jarvis Settings now holds a DIFFERENT
+	device's credentials, and the rotated token of the old device must
+	not overwrite them. Returns True when persisted."""
+	settings = frappe.get_single("Jarvis Settings")
+	if (settings.chat_device_id or "").strip() != device_id:
+		return False
+	settings.db_set("chat_device_token", new_token)
+	frappe.db.commit()
+	return True
+
+
 def _normalize_metadata(value: str) -> str:
 	"""Mirrors openclaw's normalizeDeviceMetadataForAuth: trim + ASCII lowercase
 	(only [A-Z] → [a-z]; Unicode left alone, matching the deterministic

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -250,13 +250,26 @@ def update_device_token(new_token: str, *, device_id: str) -> bool:
 	Guarded on ``device_id``: if another worker re-paired while this
 	connect was in flight, Jarvis Settings now holds a DIFFERENT
 	device's credentials, and the rotated token of the old device must
-	not overwrite them. Returns True when persisted."""
-	settings = frappe.get_single("Jarvis Settings")
-	if (settings.chat_device_id or "").strip() != device_id:
-		return False
-	settings.db_set("chat_device_token", new_token)
-	frappe.db.commit()
-	return True
+	not overwrite them. The check-then-write runs under the same
+	``chat_device_pair_repair`` lock the repair path wipes under, so a
+	re-pair can't land BETWEEN our device_id read and our token write
+	(which would mix the new device's identity with the old device's
+	token). Lock unavailable -> skip the persist (return False): the
+	stale-pairing self-heal recovers the next connect, which beats
+	risking the interleave. Returns True when persisted."""
+	from jarvis._redis_lock import redis_lock
+
+	with redis_lock(
+		"chat_device_pair_repair", timeout_s=30, blocking_timeout_s=5.0,
+	) as acquired:
+		if not acquired:
+			return False
+		settings = frappe.get_single("Jarvis Settings")
+		if (settings.chat_device_id or "").strip() != device_id:
+			return False
+		settings.db_set("chat_device_token", new_token)
+		frappe.db.commit()
+		return True
 
 
 def _normalize_metadata(value: str) -> str:

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -219,6 +219,21 @@ def _persisted_device_id() -> str:
 		return ""
 
 
+def _persisted_device_token() -> str:
+	"""Read of Jarvis Settings.chat_device_token (Password field).
+
+	Used by the repair path to detect "a peer already adopted a gateway-
+	reissued token for this same device" - the device_id alone can't,
+	because a token rotation keeps the device_id. Returns "" when
+	unreadable (the caller treats empty as "nothing newer, proceed")."""
+	import frappe
+	try:
+		s = frappe.get_single("Jarvis Settings")
+		return (s.get_password("chat_device_token", raise_exception=False) or "").strip()
+	except Exception:
+		return ""
+
+
 class OpenclawSession:
 	"""Direct WebSocket session to one tenant's openclaw gateway.
 
@@ -275,7 +290,10 @@ class OpenclawSession:
 			try: ws.close()
 			except Exception: pass
 			if allow_repair and _is_stale_pairing(e):
-				cls._repair_and_reconnect(gateway_url, stale_device_id=creds.device_id)
+				cls._repair_and_reconnect(
+					gateway_url, stale_device_id=creds.device_id,
+					stale_device_token=creds.device_token,
+				)
 				return cls._attempt_connect(gateway_url, allow_repair=False)
 			raise
 		except Exception:
@@ -360,7 +378,10 @@ class OpenclawSession:
 		return dataclasses.replace(creds, device_token=reissued_token)
 
 	@classmethod
-	def _repair_and_reconnect(cls, gateway_url: str, *, stale_device_id: str) -> None:
+	def _repair_and_reconnect(
+		cls, gateway_url: str, *, stale_device_id: str,
+		stale_device_token: str = "",
+	) -> None:
 		"""Serialize the clear+re-pair window after a stale-pairing rejection.
 
 		Sprint-2 (2026-06-16 review): with N concurrent chat workers
@@ -394,6 +415,17 @@ class OpenclawSession:
 			if current and current != stale_device_id:
 				# Another worker already re-paired while we waited. Don't
 				# wipe their work; let the caller re-read.
+				return
+			# A gateway token ROTATION keeps the device_id, so the id check
+			# alone can't see that a peer just adopted the reissued token
+			# (hello-ok auth.deviceToken) while our rejected connect was in
+			# flight with the pre-rotation token. If the persisted token
+			# moved on from the one we presented, the pairing is already
+			# healed - retrying with the fresh creds beats destroying them
+			# and paying a full re-pair round-trip.
+			persisted_token = _persisted_device_token()
+			if stale_device_token and persisted_token \
+					and persisted_token != stale_device_token:
 				return
 			clear_credentials()
 			# Don't prime ensure_paired() here: the caller's next
@@ -667,9 +699,11 @@ class OpenclawSession:
 			if ftype == "res" and frame.get("id") == agent_id:
 				if not frame.get("ok"):
 					err = frame.get("error") or {}
+					details = err.get("details")
 					raise OpenclawUnreachableError(
 						f"agent rejected: {err.get('code', '?')}: {err.get('message', '')}",
 						code=err.get("code"),
+						details=details if isinstance(details, dict) else None,
 					)
 				active_run_id = (frame.get("payload") or {}).get("runId")
 				got_ack = True
@@ -782,8 +816,12 @@ class OpenclawSession:
 						code=err.get("code"),
 						details=details if isinstance(details, dict) else None,
 					)
-				auth = (frame.get("payload") or {}).get("auth") or {}
-				reissued = auth.get("deviceToken")
+				# Shape-defensive: a successful connect must NEVER fail on
+				# an unexpected hello-ok payload (pre-change behavior was to
+				# ignore the payload entirely).
+				payload = frame.get("payload")
+				auth = payload.get("auth") if isinstance(payload, dict) else None
+				reissued = auth.get("deviceToken") if isinstance(auth, dict) else None
 				if isinstance(reissued, str) and reissued \
 						and reissued != creds.device_token:
 					return reissued
@@ -811,9 +849,11 @@ class OpenclawSession:
 			if _is_response_frame(frame, req_id):
 				if not frame.get("ok"):
 					err = frame.get("error") or {}
+					details = err.get("details")
 					raise OpenclawUnreachableError(
 						f"{method} rejected: {err.get('code', '?')}: {err.get('message', '')}",
 						code=err.get("code"),
+						details=details if isinstance(details, dict) else None,
 					)
 				return frame
 		raise OpenclawUnreachableError(f"{method} timed out")

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -41,7 +41,7 @@ _logger = logging.getLogger(__name__)
 
 from jarvis.chat.device import (
 	ChatDeviceCredentials, build_payload_v3, clear_credentials,
-	ensure_paired, sign_payload,
+	ensure_paired, sign_payload, update_device_token,
 )
 from jarvis.chat.events import parse_event
 
@@ -143,18 +143,45 @@ _STALE_PAIRING_CODES = frozenset({
 	"device-id-mismatch",
 })
 
+# openclaw's ACTUAL wire shape for device-token auth failures (verified
+# 2026-07-09 against the ghcr.io/openclaw/openclaw image from 2026-06-16
+# AND current :latest, plus a live reproduction against a running
+# gateway): connect is rejected with the GENERIC ``error.code``
+# "INVALID_REQUEST" and the machine-readable reason lives in
+# ``error.details.authReason``. The gateway maps EVERY explicit-
+# deviceToken auth failure - device not paired (container replaced /
+# state reset), token mismatch (gateway rotated the stored token),
+# token revoked - to the single coarse reason "device_token_mismatch"
+# ("unauthorized: device token mismatch (rotate/reissue device token)").
+# The hyphenated reasons in _STALE_PAIRING_CODES are openclaw's INTERNAL
+# verifyDeviceToken results; they never reach the wire as error.code, so
+# the code-only classifier alone never fired and the self-heal below was
+# dead code - a replaced tenant container permanently broke chat
+# (2026-07-08 post-deploy regression). _STALE_PAIRING_CODES is kept as a
+# belt-and-braces layer in case a future openclaw promotes the internal
+# reasons to wire codes.
+_STALE_PAIRING_AUTH_REASONS = frozenset({
+	"device_token_mismatch",
+})
+
 
 def _is_stale_pairing(err: Exception) -> bool:
-	"""Return True iff ``err`` is an OpenclawUnreachableError whose
-	openclaw error.code is in the stale-pairing set.
+	"""Return True iff ``err`` is an OpenclawUnreachableError that openclaw
+	classified as a stale device pairing - either via error.code (internal
+	reason set) or via error.details.authReason (the real wire shape for
+	connect auth failures, see _STALE_PAIRING_AUTH_REASONS above).
 
-	Strictly typed: an error WITHOUT a ``.code`` attribute (network-level
-	failure, programmer bug) never triggers the repair path. The previous
-	substring check would have caught these falsely if their message
-	happened to contain one of the marker strings.
+	Strictly typed: an error WITHOUT a ``.code``/``.details`` attribute
+	(network-level failure, programmer bug) never triggers the repair
+	path, and neither does a marker string embedded in the message text.
 	"""
 	code = getattr(err, "code", None)
-	return code in _STALE_PAIRING_CODES
+	if code in _STALE_PAIRING_CODES:
+		return True
+	details = getattr(err, "details", None)
+	if not isinstance(details, dict):
+		return False
+	return details.get("authReason") in _STALE_PAIRING_AUTH_REASONS
 
 
 def _chat_final_text(payload: dict) -> str | None:
@@ -243,7 +270,7 @@ class OpenclawSession:
 		t_ws_done = time.monotonic()
 
 		try:
-			cls._handshake(ws, creds)
+			reissued_token = cls._handshake(ws, creds)
 		except OpenclawUnreachableError as e:
 			try: ws.close()
 			except Exception: pass
@@ -255,6 +282,8 @@ class OpenclawSession:
 			try: ws.close()
 			except Exception: pass
 			raise
+		if reissued_token:
+			creds = cls._adopt_reissued_token(creds, reissued_token)
 		t_handshake_done = time.monotonic()
 		_logger.info(
 			"OpenclawSession.connect: pair_ms=%d ws_open_ms=%d handshake_ms=%d total_ms=%d gateway=%s",
@@ -297,6 +326,38 @@ class OpenclawSession:
 						f"starting up; please try again in a moment ({e})"
 					) from e
 				time.sleep(CONNECT_OPEN_RETRY_BACKOFF_SECONDS)
+
+	@classmethod
+	def _adopt_reissued_token(
+		cls, creds: ChatDeviceCredentials, reissued_token: str,
+	) -> ChatDeviceCredentials:
+		"""Adopt a device token the gateway rotated at connect (hello-ok
+		``auth.deviceToken``). The rotation is already persisted gateway-
+		side, so we persist our half too; failing that, we still use the
+		fresh token in-memory for this session and let the stale-pairing
+		self-heal recover the NEXT connect (a persistence hiccup must not
+		fail the user's current turn)."""
+		import dataclasses
+		try:
+			persisted = update_device_token(
+				reissued_token, device_id=creds.device_id,
+			)
+			if not persisted:
+				# Another worker re-paired while we were connecting;
+				# Settings holds a newer device's creds. Ours still work
+				# for THIS session - don't clobber theirs.
+				_logger.warning(
+					"gateway reissued device token for %s but Settings "
+					"moved to a different pairing; kept in-memory only",
+					creds.device_id,
+				)
+		except Exception:
+			_logger.warning(
+				"failed to persist reissued device token for %s; kept "
+				"in-memory only (self-heal will re-pair on next connect)",
+				creds.device_id, exc_info=True,
+			)
+		return dataclasses.replace(creds, device_token=reissued_token)
 
 	@classmethod
 	def _repair_and_reconnect(cls, gateway_url: str, *, stale_device_id: str) -> None:
@@ -652,8 +713,16 @@ class OpenclawSession:
 	# -- internals --------------------------------------------------------
 
 	@classmethod
-	def _handshake(cls, ws: websocket.WebSocket, creds: ChatDeviceCredentials) -> None:
-		"""Receive connect.challenge → sign v3 payload → send connect → expect hello-ok."""
+	def _handshake(cls, ws: websocket.WebSocket, creds: ChatDeviceCredentials) -> str | None:
+		"""Receive connect.challenge → sign v3 payload → send connect → expect hello-ok.
+
+		Returns the REISSUED device token from hello-ok's ``auth.deviceToken``
+		when the gateway rotated it (None otherwise). openclaw's gateway
+		replaces the stored device token at connect whenever the existing
+		entry no longer lines up with the requested scopes/issuer; the new
+		token is already durable on the gateway side when hello-ok arrives,
+		so the caller MUST adopt it or every following connect fails with
+		"device token mismatch"."""
 		deadline = time.monotonic() + CONNECT_TIMEOUT_SECONDS
 
 		# 1. Wait for the challenge event.
@@ -707,11 +776,18 @@ class OpenclawSession:
 			if _is_response_frame(frame, connect_id):
 				if not frame.get("ok"):
 					err = frame.get("error") or {}
+					details = err.get("details")
 					raise OpenclawUnreachableError(
 						f"connect rejected: {err.get('code', '?')}: {err.get('message', '')}",
 						code=err.get("code"),
+						details=details if isinstance(details, dict) else None,
 					)
-				return
+				auth = (frame.get("payload") or {}).get("auth") or {}
+				reissued = auth.get("deviceToken")
+				if isinstance(reissued, str) and reissued \
+						and reissued != creds.device_token:
+					return reissued
+				return None
 		raise OpenclawUnreachableError("no connect response before timeout")
 
 	def _send(self, method: str, params: dict) -> str:

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -74,11 +74,20 @@ class OpenclawUnreachableError(JarvisError):
     classifiers (e.g. _is_stale_pairing) should branch on this
     attribute, not on a substring match of the message. ``code`` is
     None when the error didn't originate from an openclaw response
-    (e.g. network-level WS open failure)."""
+    (e.g. network-level WS open failure).
 
-    def __init__(self, message: str, *, code: str | None = None):
+    2026-07-09: also carries ``details`` - openclaw's ``error.details``
+    object. Connect AUTH failures arrive with the GENERIC error.code
+    "INVALID_REQUEST" and the machine-readable reason only in
+    ``details.authReason`` (e.g. "device_token_mismatch"), so ``code``
+    alone cannot distinguish an auth rejection from any other
+    malformed-request rejection."""
+
+    def __init__(self, message: str, *, code: str | None = None,
+                 details: dict | None = None):
         super().__init__(message)
         self.code = code
+        self.details = details
 
 
 class OpenclawReloadFailedError(JarvisError):

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -291,6 +291,32 @@ class TestUpdateDeviceToken(_SettingsSnapshotMixin, FrappeTestCase):
 			"tok-rotated",
 		)
 
+	def test_lock_unavailable_skips_persist(self):
+		"""Redis lock unavailable -> return False without touching Settings;
+		the check-then-write must never run unserialized against a
+		concurrent re-pair (it could mix the new device's identity with
+		the old device's rotated token)."""
+		from contextlib import contextmanager
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", "dev-1")
+		s.db_set("chat_device_token", "tok-old")
+		frappe.db.commit()
+
+		@contextmanager
+		def _unavailable_lock(*a, **kw):
+			yield False
+
+		with patch("jarvis._redis_lock.redis_lock", _unavailable_lock):
+			self.assertFalse(
+				chat_device.update_device_token("tok-rotated", device_id="dev-1"),
+			)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("chat_device_token", raise_exception=False),
+			"tok-old",
+		)
+
 	def test_refuses_when_pairing_moved_on(self):
 		s = frappe.get_single("Jarvis Settings")
 		s.db_set("chat_device_id", "dev-2-fresh")

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -268,6 +268,45 @@ class TestRotateChatDevice(_SettingsSnapshotMixin, FrappeTestCase):
 		self.assertEqual(s2.get_password("chat_device_token"), "tok-old")
 
 
+class TestUpdateDeviceToken(_SettingsSnapshotMixin, FrappeTestCase):
+	"""update_device_token persists a gateway-REISSUED device token, but
+	only for the pairing Settings still holds - a concurrent re-pair by
+	another worker must never be clobbered by the old device's rotation."""
+
+	def setUp(self):
+		_clear_settings()
+
+	def test_persists_for_current_pairing(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", "dev-1")
+		s.db_set("chat_device_token", "tok-old")
+		frappe.db.commit()
+
+		self.assertTrue(
+			chat_device.update_device_token("tok-rotated", device_id="dev-1"),
+		)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("chat_device_token", raise_exception=False),
+			"tok-rotated",
+		)
+
+	def test_refuses_when_pairing_moved_on(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", "dev-2-fresh")
+		s.db_set("chat_device_token", "tok-fresh")
+		frappe.db.commit()
+
+		self.assertFalse(
+			chat_device.update_device_token("tok-rotated", device_id="dev-1-old"),
+		)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("chat_device_token", raise_exception=False),
+			"tok-fresh",
+		)
+
+
 class TestSigning(FrappeTestCase):
 	def test_build_payload_v3_format(self):
 		out = chat_device.build_payload_v3(

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -425,17 +425,20 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			ensure_paired_calls.append(True)
 			return creds
 
-		# _repair_and_reconnect's convoy guard reads the REAL site's
-		# Jarvis Settings.chat_device_id; on a dev site with a live
-		# pairing it differs from the test creds' device_id and the
-		# guard skips the wipe ("another worker already re-paired").
-		# Pin it to "no winner yet" so these tests are hermetic instead
-		# of depending on whatever the local site happens to hold.
+		# _repair_and_reconnect's convoy guards read the REAL site's
+		# Jarvis Settings (chat_device_id + chat_device_token); on a dev
+		# site with a live pairing they differ from the test creds and
+		# the guards skip the wipe ("another worker already re-paired" /
+		# "a peer already adopted a rotated token"). Pin both to "no
+		# winner yet" so these tests are hermetic instead of depending
+		# on whatever the local site happens to hold.
 		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
 				   side_effect=lambda *a, **kw: next(ws_iter)), \
 			 patch("jarvis.chat.openclaw_client.ensure_paired",
 				   side_effect=_fake_ensure_paired), \
 			 patch("jarvis.chat.openclaw_client._persisted_device_id",
+				   return_value=""), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_token",
 				   return_value=""), \
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=_fake_clear):
@@ -489,6 +492,34 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		sess, clears, ensure_calls = self._connect_with_two_ws(first_ws, second_ws)
 		self.assertEqual(len(clears), 1)
 		self.assertEqual(len(ensure_calls), 2)
+		sess.close()
+
+	def test_peer_adopted_rotation_skips_the_wipe_but_still_retries(self):
+		"""A gateway token ROTATION keeps the device_id, so when worker B
+		is rejected (it signed with the pre-rotation token) while worker A
+		already adopted the reissued token, the repair path must NOT wipe
+		the healed pairing - but must still retry with fresh creds."""
+		first_ws, second_ws = self._build_two_ws(
+			"", second_ok=True, first_error=self._WIRE_AUTH_REJECTION,
+		)
+		ws_iter = iter([first_ws, second_ws])
+		creds = _make_creds()
+		clear_called: list = []
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   side_effect=lambda *a, **kw: next(ws_iter)), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired",
+				   return_value=creds), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_id",
+				   return_value=creds.device_id), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_token",
+				   return_value="tok-rotated-by-peer"), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)):
+			sess = OpenclawSession.connect("ws://t")
+		self.assertFalse(
+			clear_called,
+			"a pairing healed by a peer's token adoption must not be wiped",
+		)
 		sess.close()
 
 	def test_invalid_request_without_auth_details_does_not_trigger_repair(self):
@@ -661,6 +692,31 @@ class TestReissuedTokenAdoption(FrappeTestCase):
 		self.assertEqual(sess._creds.device_token, "tok-rotated")
 		sess.close()
 
+	def test_malformed_hello_ok_payload_never_fails_the_connect(self):
+		"""A successful connect must tolerate ANY hello-ok payload shape
+		(pre-adoption behavior ignored the payload entirely): payload as a
+		list, auth as a scalar, deviceToken as a non-string."""
+		creds = _make_creds()
+		for payload in (["unexpected"], {"auth": True}, {"auth": "tok"},
+						{"auth": {"deviceToken": 42}}, None, "str"):
+			def _ok(payload=payload):
+				req_id = ws.sent[-1]["id"]
+				return _frame({"type": "res", "id": req_id, "ok": True,
+							   "payload": payload})
+
+			ws = _ScriptedWS([_challenge(), _ok])
+			update_mock = MagicMock(return_value=True)
+			with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+					   return_value=ws), \
+				 patch("jarvis.chat.openclaw_client.ensure_paired",
+					   return_value=creds), \
+				 patch("jarvis.chat.openclaw_client.update_device_token",
+					   update_mock):
+				sess = OpenclawSession.connect("ws://t")
+			update_mock.assert_not_called()
+			self.assertEqual(sess._creds.device_token, creds.device_token)
+			sess.close()
+
 
 class TestRepairConvoyCollapse(FrappeTestCase):
 	"""Sprint-2 (2026-06-16): N concurrent workers all observe a stale
@@ -725,7 +781,9 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=lambda: clear_called.append(True)), \
 			 patch("jarvis.chat.openclaw_client._persisted_device_id",
-				   return_value=stale_creds.device_id):
+				   return_value=stale_creds.device_id), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_token",
+				   return_value=stale_creds.device_token):
 			sess = OpenclawSession.connect("ws://t")
 		self.assertEqual(len(clear_called), 1,
 			"lock-holder must wipe + re-pair when persisted id matches stale")

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -377,9 +377,11 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 	that, clear local creds, re-pair via ensure_paired, and retry the WS
 	once. A second stale signal is a real failure (no infinite loop)."""
 
-	def _build_two_ws(self, first_reject_marker: str, second_ok: bool):
+	def _build_two_ws(self, first_reject_marker: str, second_ok: bool,
+					  first_error: dict | None = None):
 		"""Return two scripted WS instances: first one rejects connect with
-		`first_reject_marker` in the error message; second one accepts."""
+		`first_reject_marker` in the error message (or the full `first_error`
+		dict when given); second one accepts."""
 		first_sent: list = []
 		second_sent: list = []
 
@@ -388,10 +390,12 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		# the client side now reads the structured code rather than
 		# substring-matching the message text, so the scripted fixture
 		# must place the marker accordingly.
+		error = first_error or {"code": first_reject_marker, "message": "stale"}
+
 		def _first_nack():
 			req_id = first.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
-						   "error": {"code": first_reject_marker, "message": "stale"}})
+						   "error": error})
 
 		def _second_ok():
 			req_id = second.sent[-1]["id"]
@@ -400,7 +404,7 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		def _second_nack():
 			req_id = second.sent[-1]["id"]
 			return _frame({"type": "res", "id": req_id, "ok": False,
-						   "error": {"code": first_reject_marker, "message": "stale"}})
+						   "error": error})
 
 		first = _ScriptedWS([_challenge(), _first_nack])
 		second_response = _second_ok if second_ok else _second_nack
@@ -421,10 +425,18 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			ensure_paired_calls.append(True)
 			return creds
 
+		# _repair_and_reconnect's convoy guard reads the REAL site's
+		# Jarvis Settings.chat_device_id; on a dev site with a live
+		# pairing it differs from the test creds' device_id and the
+		# guard skips the wipe ("another worker already re-paired").
+		# Pin it to "no winner yet" so these tests are hermetic instead
+		# of depending on whatever the local site happens to hold.
 		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
 				   side_effect=lambda *a, **kw: next(ws_iter)), \
 			 patch("jarvis.chat.openclaw_client.ensure_paired",
 				   side_effect=_fake_ensure_paired), \
+			 patch("jarvis.chat.openclaw_client._persisted_device_id",
+				   return_value=""), \
 			 patch("jarvis.chat.openclaw_client.clear_credentials",
 				   side_effect=_fake_clear):
 			result = OpenclawSession.connect("ws://t")
@@ -446,6 +458,68 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		sess, clears, _ = self._connect_with_two_ws(first_ws, second_ws)
 		self.assertEqual(len(clears), 1)
 		sess.close()
+
+	# openclaw's REAL wire shape for a device-token auth rejection, captured
+	# verbatim from a live gateway (2026-07-09, reproduction against
+	# ghcr.io/openclaw/openclaw): the generic INVALID_REQUEST code with the
+	# machine-readable reason only in error.details.authReason. This is what
+	# a bench actually receives after its tenant container is replaced (the
+	# gateway maps device-not-paired / token-mismatch / token-revoked all to
+	# this one frame for explicit-deviceToken connects).
+	_WIRE_AUTH_REJECTION = {
+		"code": "INVALID_REQUEST",
+		"message": "unauthorized: device token mismatch (rotate/reissue device token)",
+		"details": {
+			"code": "AUTH_DEVICE_TOKEN_MISMATCH",
+			"authReason": "device_token_mismatch",
+			"canRetryWithDeviceToken": False,
+			"recommendedNextStep": "update_auth_credentials",
+		},
+	}
+
+	def test_wire_shape_invalid_request_auth_reason_triggers_repair(self):
+		"""The 2026-07-08 post-deploy regression: openclaw rejects with
+		code=INVALID_REQUEST + details.authReason=device_token_mismatch.
+		The code-only classifier missed it and chat stayed permanently
+		broken after a tenant container was replaced. The classifier must
+		fire on details.authReason."""
+		first_ws, second_ws = self._build_two_ws(
+			"", second_ok=True, first_error=self._WIRE_AUTH_REJECTION,
+		)
+		sess, clears, ensure_calls = self._connect_with_two_ws(first_ws, second_ws)
+		self.assertEqual(len(clears), 1)
+		self.assertEqual(len(ensure_calls), 2)
+		sess.close()
+
+	def test_invalid_request_without_auth_details_does_not_trigger_repair(self):
+		"""INVALID_REQUEST covers every malformed-request rejection (bad
+		params, protocol mismatch, ...). Without details.authReason in the
+		stale set it must NOT wipe valid credentials - even when the
+		message text happens to mention a token mismatch."""
+		creds = _make_creds()
+
+		def _nack():
+			req_id = first_ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": False,
+						   "error": {
+							   "code": "INVALID_REQUEST",
+							   "message": "unauthorized: device token "
+										  "mismatch (rotate/reissue device token)",
+						   }})
+
+		first_ws = _ScriptedWS([_challenge(), _nack])
+		clear_called: list = []
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   return_value=first_ws), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds), \
+			 patch("jarvis.chat.openclaw_client.clear_credentials",
+				   side_effect=lambda: clear_called.append(True)):
+			with self.assertRaises(OpenclawUnreachableError):
+				OpenclawSession.connect("ws://t")
+		self.assertFalse(
+			clear_called,
+			"INVALID_REQUEST without details.authReason must not wipe creds",
+		)
 
 	def test_second_failure_does_not_loop(self):
 		"""After one repair attempt, a second stale-pairing signal must
@@ -512,6 +586,80 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 			"a substring match in the message must NOT trigger the repair "
 			"path - we read the structured error.code",
 		)
+
+
+class TestReissuedTokenAdoption(FrappeTestCase):
+	"""openclaw's hello-ok can carry a REISSUED auth.deviceToken: the
+	gateway rotates the stored device token at connect whenever the
+	existing entry no longer lines up with the requested scopes/issuer,
+	and the rotation is already durable gateway-side when hello-ok
+	arrives. A client that drops it signs every FOLLOWING connect with
+	the dead token -> "device token mismatch". The client must persist
+	and adopt it."""
+
+	def _connect(self, hello_auth: dict, creds=None, update_mock=None):
+		creds = creds or _make_creds()
+		update_mock = update_mock if update_mock is not None else MagicMock(return_value=True)
+
+		def _ok():
+			req_id = ws.sent[-1]["id"]
+			return _frame({"type": "res", "id": req_id, "ok": True,
+						   "payload": {"auth": hello_auth}})
+
+		ws = _ScriptedWS([_challenge(), _ok])
+		with patch("jarvis.chat.openclaw_client.websocket.create_connection",
+				   return_value=ws), \
+			 patch("jarvis.chat.openclaw_client.ensure_paired", return_value=creds), \
+			 patch("jarvis.chat.openclaw_client.update_device_token", update_mock):
+			sess = OpenclawSession.connect("ws://t")
+		return sess, creds, update_mock
+
+	def test_reissued_token_is_persisted_and_adopted(self):
+		sess, creds, update_mock = self._connect(
+			{"scopes": ["operator.write"], "deviceToken": "tok-rotated"},
+		)
+		update_mock.assert_called_once_with(
+			"tok-rotated", device_id=creds.device_id,
+		)
+		self.assertEqual(sess._creds.device_token, "tok-rotated")
+		sess.close()
+
+	def test_no_device_token_in_hello_ok_is_a_noop(self):
+		sess, creds, update_mock = self._connect(
+			{"scopes": ["operator.write", "operator.admin"]},
+		)
+		update_mock.assert_not_called()
+		self.assertEqual(sess._creds.device_token, creds.device_token)
+		sess.close()
+
+	def test_unchanged_token_is_a_noop(self):
+		creds = _make_creds()
+		sess, _, update_mock = self._connect(
+			{"deviceToken": creds.device_token}, creds=creds,
+		)
+		update_mock.assert_not_called()
+		sess.close()
+
+	def test_persist_refusal_still_adopts_in_memory(self):
+		"""update_device_token returns False when another worker re-paired
+		mid-connect (Settings holds a different device). The reissued token
+		is still the right credential for THIS session's device."""
+		sess, _, update_mock = self._connect(
+			{"deviceToken": "tok-rotated"},
+			update_mock=MagicMock(return_value=False),
+		)
+		self.assertEqual(sess._creds.device_token, "tok-rotated")
+		sess.close()
+
+	def test_persist_failure_does_not_fail_the_turn(self):
+		"""A persistence hiccup must not kill the user's current turn; the
+		stale-pairing self-heal recovers the NEXT connect."""
+		sess, _, update_mock = self._connect(
+			{"deviceToken": "tok-rotated"},
+			update_mock=MagicMock(side_effect=RuntimeError("db down")),
+		)
+		self.assertEqual(sess._creds.device_token, "tok-rotated")
+		sess.close()
 
 
 class TestRepairConvoyCollapse(FrappeTestCase):


### PR DESCRIPTION
## The regression

After the 2026-07-08 deployment, existing benches failed every chat connect with:

```
connect rejected: INVALID_REQUEST: unauthorized: device token mismatch (rotate/reissue device token)
```

and never recovered — a hard chat outage requiring manual `rotate_chat_device`.

## Root cause (verified by live reproduction)

openclaw sends connect **auth** failures with the generic `error.code = "INVALID_REQUEST"`; the machine-readable reason lives only in `error.details.authReason`. It also maps **every** explicit-deviceToken failure — device not paired (container replaced / state reset), token mismatch (gateway rotated the stored token), token revoked — to the single coarse reason `device_token_mismatch`.

The Sprint-3 classifier reads `error.code` and matches openclaw's *internal* hyphenated reasons (`device-not-paired`, `token-mismatch`, …) which never appear on the wire, so `_is_stale_pairing` never fired: **the designed two-shot self-heal (clear + re-pair) was dead code**, and the exact scenario it was built for (admin replaces the tenant container) became a permanent outage.

Verified against the openclaw image from 2026-06-16 **and** current `:latest` (bundle diff — behavior identical in both), plus a live reproduction against a running gateway; the wire frame in the test fixture is captured verbatim:

```json
{"code": "INVALID_REQUEST",
 "message": "unauthorized: device token mismatch (rotate/reissue device token)",
 "details": {"code": "AUTH_DEVICE_TOKEN_MISMATCH", "authReason": "device_token_mismatch",
             "canRetryWithDeviceToken": false, "recommendedNextStep": "update_auth_credentials"}}
```

## Fixes

1. **Classifier** — `OpenclawUnreachableError` now carries openclaw's `error.details`; `_is_stale_pairing` additionally classifies on `details.authReason == "device_token_mismatch"`. The internal-code set is kept as belt-and-braces; message-substring matching stays banned (pinned by a new negative test).
2. **Reissued-token adoption** — openclaw's hello-ok can carry a rotated `auth.deviceToken` (the gateway replaces the stored token at connect when the entry no longer lines up with the requested scopes/issuer; the rotation is already durable gateway-side). We previously discarded the hello-ok payload, so any server-side rotation bricked every following connect. `_handshake` now returns the reissued token and the client persists it (`device.update_device_token`, guarded on `device_id` so a concurrent re-pair is never clobbered) and adopts it in-memory. Persistence failure never fails the user's turn — the revived self-heal recovers the next connect.
3. **Hermetic self-heal tests** — they depended on the site having no `chat_device_id` (the repair convoy-guard reads real Settings) and failed on any dev site with a live pairing; `_persisted_device_id` is now pinned in the shared helper.

## Tests

- `test_chat_openclaw_client`: 31 passed (7 new: real wire-shape triggers repair; INVALID_REQUEST *without* auth details must NOT wipe creds; reissued-token persisted/adopted, no-op cases, persist-refusal and persist-failure resilience).
- `test_chat_device`: 13 passed (2 new for `update_device_token` including the concurrent-re-pair guard).

## Not in this PR

- Ops remediation for currently-affected sites: run `jarvis.chat.device.rotate_chat_device` (System Manager) — after this PR the self-heal makes that automatic.
- Pinning the openclaw image by digest (currently `ghcr.io/openclaw/openclaw:latest`, so deployments silently roll the gateway version) — admin/fleet-side change, recommended follow-up.