### PR TITLE
fix(chat): stop confirming an action from logging the user out

### DIFF
--- a/jarvis/_session.py
+++ b/jarvis/_session.py
@@ -1,0 +1,65 @@
+"""Session-safe user impersonation for HTTP request paths.
+
+``frappe.set_user(x)`` is only safe in background/worker context. Inside a
+cookie-session HTTP request it GUTS the live session object:
+
+    local.session.user = username
+    local.session.sid  = username   # sid becomes the username string
+    local.session.data = _dict()     # csrf_token, session_expiry, inner user - all wiped
+
+``frappe.local.session`` IS ``frappe.local.session_obj.data`` (same object), so
+after such a switch the session object carries a bogus sid and an empty data
+dict. At the end of the request Frappe schedules ``session_obj.update()``
+(frappe/app.py sync_database -> after_response), which does
+``frappe.cache.hset("session", self.sid, self.data)`` keyed on ``self.sid`` -
+the ``__slots__`` attribute that STILL holds the browser's REAL sid. That
+overwrites the real session's Redis cache entry with the gutted dict. Because
+session resume reads cache before DB, the next request resolves the real sid to
+``user = None`` -> demoted to Guest -> the user is silently logged out.
+
+A plain ``frappe.set_user(orig)`` in a ``finally`` does NOT undo this: it
+restores only the user NAME, leaving ``sid`` and ``data`` wiped.
+
+``impersonate`` is the safe seam: it snapshots and restores ``sid`` and
+``data`` (which ``frappe.set_user`` REPLACES rather than mutates, so the saved
+reference stays intact), and is a true no-op when there is nothing to switch to
+or the target is already the current user.
+"""
+
+from contextlib import contextmanager
+
+import frappe
+
+
+@contextmanager
+def impersonate(user: str | None):
+	"""Run the enclosed block AS ``user``, then restore the caller's session.
+
+	No-op (yields without touching the session) when ``user`` is falsy or
+	already the current session user - so callers can drop their own
+	``if switch_to:`` guards and route unconditionally through here.
+
+	Otherwise snapshots ``frappe.session.user``/``sid``/``data``, switches with
+	``frappe.set_user`` (which rebuilds perms + caches for the target), and in a
+	``finally`` restores the user via ``frappe.set_user`` then puts the original
+	``sid`` and ``data`` back - keeping the browser's real cookie session intact
+	so end-of-request ``Session.update`` re-persists the RIGHT session.
+	"""
+	if not user or user == frappe.session.user:
+		yield
+		return
+
+	orig_user = frappe.session.user
+	orig_sid = frappe.session.sid
+	# frappe.set_user REPLACES local.session.data with a fresh dict rather than
+	# mutating it, so this reference to the original inner dict stays valid.
+	orig_data = frappe.session.data
+	# set_user is inside the try so a mid-switch failure still restores the
+	# caller's session in the finally (never leave it gutted / half-switched).
+	try:
+		frappe.set_user(user)
+		yield
+	finally:
+		frappe.set_user(orig_user)
+		frappe.local.session.sid = orig_sid
+		frappe.local.session.data = orig_data

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -4,6 +4,7 @@ import frappe
 
 from jarvis._http import validate_bearer as _validate_bearer  # noqa: F401 (kept for callers in mcp.py)
 from jarvis._plugin_auth import PluginAuthError, validate_plugin_request
+from jarvis._session import impersonate
 from jarvis.exceptions import InvalidArgumentError, JarvisError
 from jarvis.tools.registry import dispatch
 from jarvis import audit
@@ -175,9 +176,9 @@ def _dispatch_from_session(
 	"""Run the dispatch under ``user``, then attribute the tool call to the
 	chat session so the UI sees it.
 	"""
-	original = frappe.session.user
-	frappe.set_user(user)
-	try:
+	# impersonate is session-safe: a bare frappe.set_user in this HTTP path
+	# would gut the caller's cookie session sid + data and log them out.
+	with impersonate(user):
 		# Parse args up front so persist_and_publish gets the same
 		# dict shape the tool ran against (or the empty dict on a
 		# malformed-args rejection).
@@ -202,8 +203,6 @@ def _dispatch_from_session(
 			session_key=session_key, tool=tool, args=parsed_args, result=result,
 		)
 		return result
-	finally:
-		frappe.set_user(original)
 
 
 def _persist_and_publish_tool_call(
@@ -255,11 +254,11 @@ def persist_tool_receipt(conv_name: str, tool: str, args: dict, result: dict) ->
 	except Exception:
 		ref_doctype = ref_name = None
 
-	# Run as the conversation owner so DocType perms allow it
+	# Run as the conversation owner so DocType perms allow it. impersonate is
+	# session-safe (a bare frappe.set_user in this HTTP path would gut the
+	# caller's cookie session sid + data and log them out).
 	conv_owner = frappe.db.get_value("Jarvis Conversation", conv_name, "owner")
-	original = frappe.session.user
-	frappe.set_user(conv_owner)
-	try:
+	with impersonate(conv_owner):
 		from jarvis.chat.api import _next_seq
 		seq = _next_seq(conv_name)
 		doc = frappe.get_doc({
@@ -291,8 +290,6 @@ def persist_tool_receipt(conv_name: str, tool: str, args: dict, result: dict) ->
 		# canvas field + publish a canvas event so it renders inline - the
 		# same surface the agent's own canvas files use.
 		_maybe_attach_artifact(conv_name, conv_owner, result)
-	finally:
-		frappe.set_user(original)
 
 
 def _maybe_attach_artifact(conv_name: str, user: str, result: dict) -> None:

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -16,6 +16,7 @@ import frappe
 from frappe import _
 
 from jarvis import audit
+from jarvis._session import impersonate
 from jarvis.chat.api import _NON_EDIT_FIELDTYPES, _next_seq, enqueue_continuation
 from jarvis.exceptions import InvalidArgumentError
 
@@ -283,7 +284,9 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	Execution scope (#6): the confirmed write executes AS the stored
 	``exec_user`` (the scoped model-execution identity - the tool user in
 	self-host), so a confirm can never exceed the model path's permission scope.
-	The original session user is always restored in a finally.
+	The switch goes through ``impersonate`` (session-safe), so the confirming
+	browser session's sid + data are always restored - a bare ``frappe.set_user``
+	would gut the cookie session and log the user out.
 	"""
 	if frappe.session.user == "Guest":
 		raise frappe.PermissionError("authentication required")
@@ -310,14 +313,12 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	# the confirming session user afterwards no matter what. exec_user defaults
 	# to the owner for tokens minted before this field existed.
 	exec_user = record.get("exec_user") or record.get("owner") or frappe.session.user
-	original = frappe.session.user
-	frappe.set_user(exec_user)
-	try:
+	# impersonate is session-safe: a bare frappe.set_user here would gut the
+	# browser's cookie session (sid + data) and log the confirming user out.
+	with impersonate(exec_user):
 		# Same envelope + audit as an inline write - dispatch_confirmed bypasses
 		# the gate so the stored call actually executes instead of parking again.
 		result = api.dispatch_confirmed(record["tool"], record["args"])
-	finally:
-		frappe.set_user(original)
 
 	# Leave a transcript receipt (#7) so a confirmed delete/submit/email shows on
 	# reload, matching the inline model-write path's tool card. Best-effort: the

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -16,6 +16,7 @@ Enable / schedule are pure DB writes (no container restart — O6); only Apply
 import frappe
 from frappe import _
 
+from jarvis._session import impersonate
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.agent_catalog import build_agent_push_payload
 from jarvis.chat.filebox import _clamp_page, _lk
@@ -671,14 +672,13 @@ def run_agent_now(installation: str) -> dict:
 		frappe.throw(_("Cannot run this audit as the installation's owner (identity guard)."))
 
 	original_user = frappe.session.user
-	try:
+	# impersonate is session-safe (a bare frappe.set_user in this HTTP path
+	# would gut the caller's cookie session and log them out) and no-ops when
+	# the owner IS the caller (self-owned manual run).
+	with impersonate(doc.owner if doc.owner != original_user else None):
 		if doc.owner != original_user:
-			frappe.set_user(doc.owner)
 			doc = frappe.get_doc(INSTALLATION, installation)  # re-fetch under owner
 		result = _launch_audit(doc, trigger="manual")
-	finally:
-		if frappe.session.user != original_user:
-			frappe.set_user(original_user)
 	return {"ok": True, "data": result}
 
 

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -13,6 +13,8 @@ import json
 
 import frappe
 
+from jarvis._session import impersonate
+
 APPROVAL = "Jarvis Approval Request"
 
 
@@ -405,17 +407,15 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 			)
 		else:
 			try:
-				if switch_to:
-					frappe.set_user(switch_to)
-				res = send_message(conversation=doc.conversation, message=msg, attachments=attachments)
+				# impersonate is session-safe (a bare frappe.set_user in this
+				# HTTP path would gut the approver's cookie session and log them
+				# out) and no-ops when switch_to is None (self-owned resume).
+				with impersonate(switch_to):
+					res = send_message(
+						conversation=doc.conversation, message=msg, attachments=attachments)
 				resumed = bool(res.get("ok"))
 			except Exception:
-				# Restore BEFORE logging so the Error Log is attributed to the
-				# approver, not the impersonated conversation owner.
-				if frappe.session.user != original_user:
-					frappe.set_user(original_user)
+				# impersonate's finally already restored the approver, so the
+				# Error Log is attributed to them, not the conversation owner.
 				frappe.log_error(title="approval resume failed", message=frappe.get_traceback())
-			finally:
-				if frappe.session.user != original_user:
-					frappe.set_user(original_user)
 	return {"ok": True, "status": doc.status, "resumed": resumed}

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -325,6 +325,14 @@ class TestConfirmSelfHostOwnerBinding(FrappeTestCase):
 			acting["user"] = frappe.session.user
 			return {"name": "TODO-FAKE"}
 
+		# Snapshot the browser cookie session's sid + data BEFORE confirm. A bare
+		# frappe.set_user(exec_user) would gut both and end-of-request
+		# Session.update would poison this sid's Redis cache -> the operator gets
+		# logged out. impersonate must leave sid + data untouched.
+		before_sid = frappe.session.sid
+		before_data = frappe.session.data
+		frappe.session.data.csrf_token = "SENTINEL-SH-020"
+
 		with patch("jarvis.selfhost.is_self_hosted", return_value=True), \
 				patch("jarvis.api._selfhost_tool_user", return_value=tool_user), \
 				patch("jarvis.api.dispatch", side_effect=_spy_dispatch):
@@ -334,6 +342,12 @@ class TestConfirmSelfHostOwnerBinding(FrappeTestCase):
 		self.assertEqual(acting["user"], tool_user)
 		# The confirming session user is restored after dispatch.
 		self.assertEqual(frappe.session.user, operator)
+		# The browser cookie session survives: sid + data (incl. the sentinel)
+		# are the ORIGINAL objects, so end-of-request Session.update re-persists
+		# the operator's real session instead of logging them out.
+		self.assertEqual(frappe.session.sid, before_sid)
+		self.assertIs(frappe.session.data, before_data)
+		self.assertEqual(frappe.session.data.csrf_token, "SENTINEL-SH-020")
 		# Single use.
 		again = confirm_tool(token)
 		self.assertFalse(again["ok"])
@@ -368,9 +382,19 @@ class TestConfirmSelfHostOwnerBinding(FrappeTestCase):
 				conversation="", owner=session_user, tool="create_doc",
 				args={"doctype": "ToDo", "values": {"description": desc_ok}},
 				run_id="")
+			# Managed mode: owner == exec == session user, so confirm_tool's
+			# impersonate no-ops - but the cookie session must STILL survive
+			# intact (a bare unconditional frappe.set_user would gut it even for
+			# the same user and log the operator out).
+			before_sid = frappe.session.sid
+			before_data = frappe.session.data
+			frappe.session.data.csrf_token = "SENTINEL-MANAGED-022"
 			res = confirm_tool(ok_token)
 			self.assertTrue(res["ok"])
 			self.assertTrue(frappe.db.exists("ToDo", {"description": desc_ok}))
+			self.assertEqual(frappe.session.sid, before_sid)
+			self.assertIs(frappe.session.data, before_data)
+			self.assertEqual(frappe.session.data.csrf_token, "SENTINEL-MANAGED-022")
 
 			# Token minted under a DIFFERENT owner -> rejected, not executed.
 			bad_token = pending_confirm.mint(

--- a/jarvis/tests/test_session_impersonate.py
+++ b/jarvis/tests/test_session_impersonate.py
@@ -1,0 +1,100 @@
+"""Tests for ``jarvis._session.impersonate`` - the session-safe replacement for
+a bare ``frappe.set_user`` inside cookie-session HTTP request paths.
+
+The bug it guards against: ``frappe.set_user`` sets ``session.sid`` to the
+username string and REPLACES ``session.data`` with an empty dict. Inside a
+request, end-of-request ``Session.update`` then re-persists the gutted data
+under the browser's REAL sid (a ``__slots__`` attribute set_user doesn't
+touch), poisoning that sid's Redis cache entry -> the user is logged out on the
+next request. impersonate snapshots + restores ``sid`` and ``data`` so the real
+cookie session stays intact.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis._session import impersonate
+
+
+class TestImpersonate(FrappeTestCase):
+	# "Guest" always exists and switching to it exercises the exact set_user
+	# behaviour we guard (sid -> username string, data -> empty dict) without a
+	# test-only User insert (which pulls in unrelated notification-settings deps).
+	_OTHER = "Guest"
+
+	def test_switch_preserves_sid_and_data(self):
+		other = self._OTHER
+		orig_user = frappe.session.user
+		orig_sid = frappe.session.sid
+		orig_data = frappe.session.data
+		frappe.session.data.csrf_token = "SENTINEL-IMP-1"
+
+		with impersonate(other):
+			# Inside the block we ARE the other user...
+			self.assertEqual(frappe.session.user, other)
+			# ...and set_user has (correctly) swapped sid + data underneath us.
+			self.assertNotEqual(frappe.session.sid, orig_sid)
+
+		# After the block the original cookie session is fully restored:
+		# user name, sid, and the SAME data object (incl. the sentinel).
+		self.assertEqual(frappe.session.user, orig_user)
+		self.assertEqual(frappe.session.sid, orig_sid)
+		self.assertIs(frappe.session.data, orig_data)
+		self.assertEqual(frappe.session.data.csrf_token, "SENTINEL-IMP-1")
+
+	def test_same_user_is_a_true_noop(self):
+		# impersonate(current user) must NOT call frappe.set_user at all - even
+		# set_user(same_user) guts sid + data.
+		current = frappe.session.user
+		with patch("jarvis._session.frappe.set_user") as m:
+			with impersonate(current):
+				self.assertEqual(frappe.session.user, current)
+		m.assert_not_called()
+
+	def test_falsy_user_is_a_true_noop(self):
+		current = frappe.session.user
+		for val in (None, ""):
+			with patch("jarvis._session.frappe.set_user") as m:
+				with impersonate(val):
+					self.assertEqual(frappe.session.user, current)
+			m.assert_not_called()
+
+	def test_exception_in_block_still_restores(self):
+		other = self._OTHER
+		orig_user = frappe.session.user
+		orig_sid = frappe.session.sid
+		orig_data = frappe.session.data
+		frappe.session.data.csrf_token = "SENTINEL-IMP-2"
+
+		with self.assertRaises(ValueError):
+			with impersonate(other):
+				raise ValueError("boom")
+
+		self.assertEqual(frappe.session.user, orig_user)
+		self.assertEqual(frappe.session.sid, orig_sid)
+		self.assertIs(frappe.session.data, orig_data)
+		self.assertEqual(frappe.session.data.csrf_token, "SENTINEL-IMP-2")
+
+	def test_nested_impersonation_restores_each_layer(self):
+		other = self._OTHER
+		orig_user = frappe.session.user
+		orig_sid = frappe.session.sid
+		orig_data = frappe.session.data
+
+		with impersonate(other):
+			mid_sid = frappe.session.sid
+			mid_data = frappe.session.data
+			self.assertEqual(frappe.session.user, other)
+			# Nesting back to the original user from inside the other-user block
+			# is a real switch (other -> orig), then restores to `other`.
+			with impersonate(orig_user):
+				self.assertEqual(frappe.session.user, orig_user)
+			self.assertEqual(frappe.session.user, other)
+			self.assertEqual(frappe.session.sid, mid_sid)
+			self.assertIs(frappe.session.data, mid_data)
+
+		self.assertEqual(frappe.session.user, orig_user)
+		self.assertEqual(frappe.session.sid, orig_sid)
+		self.assertIs(frappe.session.data, orig_data)


### PR DESCRIPTION
## Problem

Clicking **Confirm** on a gated Jarvis action (create/update/submit/…) logs the operator out of Desk/SPA.

## Root cause

`confirm_tool` (and other request-path code) calls `frappe.set_user(exec_user)` **inside the browser's cookie-session HTTP request** to run the confirmed write as the scoped exec identity. `frappe.set_user` is only safe in a worker/background context — in a request it **guts the live session**:

- `frappe/__init__.py:526-532`: sets `session.sid = <username>` and **replaces** `session.data` with an empty dict (wiping `csrf_token`, inner `user`, …). `frappe.local.session` *is* `session_obj.data`; `session_obj.sid` is a separate attribute still holding the **real** sid.
- At end of request `Session.update()` (`sessions.py:411-452`) force-writes: the DB UPDATE keys on `self.data["sid"]` (now the username → **misses** the real row), but `frappe.cache.hset("session", self.sid, self.data)` keys on the untouched **real sid** → it **poisons the browser's cached session** with the gutted dict.
- Next SPA request reads cache-before-DB → `user → None` → demoted to **Guest** → logged out.

The `finally: frappe.set_user(original)` restore couldn't help — it restores only `.user`, not `sid`/`data`. Reproduces on **every** gated confirm, in both managed and self-host. (Classic signature: a Redis flush "fixes" it because the DB Sessions row is intact.)

## Fix

New `jarvis/_session.py` → **`impersonate(user)`** context manager: no-op when the target is falsy or already the current user; otherwise snapshots and restores `user` + **`sid`** + **`data`** (`frappe.set_user` *replaces* the data dict, so the saved reference stays valid). `set_user` runs inside the `try` so a mid-switch failure still restores.

Routed every request-path user switch through it:
- `jarvis/chat/actions_api.py` — `confirm_tool`
- `jarvis/api.py` — `persist_tool_receipt`, `_dispatch_from_session`
- `jarvis/chat/approvals_api.py` — `decide` (self-host resume), `jarvis/chat/agents_api.py` — `run_agent_now` (the `impersonate` no-op subsumes their old `if switch_to:` guards)

## Tests

- New `jarvis/tests/test_session_impersonate.py` (5): `sid` + `data` + a `csrf_token` sentinel preserved across a real switch (`assertIs` on the data object); `impersonate(same_user)` / `impersonate(None)` are true no-ops (patched `set_user`, asserted not called); exception-in-block and nested switches restore each layer.
- Extended `test_confirm_gate` to snapshot `session.sid` + a data sentinel before `confirm_tool` and assert both survive (managed + self-host variants).
- The old tests missed this because they call the Python function directly and only asserted `session.user` — never `sid`/`data`/the session cache (unit tests never run `HTTPRequest`/`sync_database`/`Session.update`).

## Verification (`jarvis-test.localhost`)

- `test_session_impersonate` → **5/5**; `test_actions_api` → **21/21** (exercises the confirm + receipt continuation flows — the core of the fix).
- Sanity: with the pre-fix code the managed assertion fails **exactly** on the bug (`session.data` gutted); with the fix it passes.
- `test_confirm_gate` shows 4 pre-existing errors on this test site (`DocType Notification Type not found` during User insert) — **verified identical on baseline** with the fix stashed, so unrelated to this change. A `bench --site … migrate` installs the missing DocType and unblocks the self-host confirm variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)