### PR TITLE
fix(onboarding): durable sync status, honest pool readiness, annotated API

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -650,6 +650,15 @@ function seedRows(config) {
 async function load() {
   err.value = ""
   try {
+    // A sync may already be in flight when the editor mounts (page reload
+    // mid-provisioning, wizard resume via reason llm_pool_provisioning).
+    // Seed the status AND start the poller for a pending one - polling only
+    // from save() left a resumed session staring at a permanent "Syncing…"
+    // banner that never picked up the background job's ok/failed flip.
+    try {
+      sync.value = (await api.getLlmSyncStatus()) || sync.value
+      if (sync.value && sync.value.pending) startPolling()
+    } catch (e) { /* status is advisory - never block the editor */ }
     cfg.value = (await api.getLlmConfig()) || cfg.value
     rows.value = seedRows(cfg.value)
     selectedPreset.value = cfg.value.preset || ""

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -650,15 +650,6 @@ function seedRows(config) {
 async function load() {
   err.value = ""
   try {
-    // A sync may already be in flight when the editor mounts (page reload
-    // mid-provisioning, wizard resume via reason llm_pool_provisioning).
-    // Seed the status AND start the poller for a pending one - polling only
-    // from save() left a resumed session staring at a permanent "Syncing…"
-    // banner that never picked up the background job's ok/failed flip.
-    try {
-      sync.value = (await api.getLlmSyncStatus()) || sync.value
-      if (sync.value && sync.value.pending) startPolling()
-    } catch (e) { /* status is advisory - never block the editor */ }
     cfg.value = (await api.getLlmConfig()) || cfg.value
     rows.value = seedRows(cfg.value)
     selectedPreset.value = cfg.value.preset || ""
@@ -691,7 +682,15 @@ async function load() {
     // Baseline for the unsaved-changes notice - the pool as just loaded is clean.
     savedSnapshot.value = poolSnapshot()
   } catch (e) { err.value = _err(e) }
-  try { sync.value = (await api.getLlmSyncStatus()) || sync.value } catch (e) { /* non-fatal */ }
+  // A sync may already be in flight when the editor mounts (page reload
+  // mid-provisioning, wizard resume via reason llm_pool_provisioning): start
+  // the poller for a pending one - polling only from save() left a resumed
+  // session staring at a permanent "Syncing…" banner that never picked up
+  // the background job's ok/failed flip.
+  try {
+    sync.value = (await api.getLlmSyncStatus()) || sync.value
+    if (sync.value && sync.value.pending) startPolling()
+  } catch (e) { /* non-fatal */ }
   try { catalog.value = (await api.getPresetCatalog()) || [] } catch (e) { /* backend bundled fallback */ }
 }
 

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -35,7 +35,13 @@ export async function isWorkspaceReady() {
 // working workspace out of its chat + data over a recoverable credential
 // problem is wrong — that case stays on the existing invite/banner path and
 // keeps /account reachable so an admin can reauthorize.
-const NOT_ONBOARDED_REASONS = new Set(["signup", "selfhost_connection"])
+// "llm_pool_provisioning" also belongs here: a pool is configured but its
+// FIRST apply never succeeded (llm_pool_synced_at never stamped) - the
+// workspace has never had a working AI connection, so chat can only fail;
+// the poster routes back to setup. Unlike llm_credentials this cannot fire
+// on an established workspace: once a pool applies ONCE the marker is
+// permanent.
+const NOT_ONBOARDED_REASONS = new Set(["signup", "selfhost_connection", "llm_pool_provisioning"])
 
 // True only when the workspace has NOT completed onboarding at all — the single
 // case the full-screen gate poster is for. A ready workspace, a fail-open

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -698,21 +698,25 @@ async function afterSaveRecheckReady({ followSync = false } = {}) {
 	state.finishNote = ""
 	state.finishing = true
 	if (followSync) {
-		let inFlight = false
+		// save_llm_pool writes "pending:" synchronously before its response,
+		// and onConnected only fires after a successful save - so whatever
+		// this probe reads is THIS save's sync: still pending (follow it to
+		// terminal) or already terminal (a fast failure, e.g. an immediate
+		// auth error - which must surface its actionable status, not fall
+		// through to a generic "still finishing" note that hides the
+		// diagnostic the status field already carries).
+		let terminal = null
 		try {
 			const s0 = await getLlmSyncStatus()
-			inFlight = !!(s0 && s0.pending)
+			terminal = s0 && s0.pending ? await waitForSyncTerminal() : s0
 		} catch (e) {
 			// status probe is advisory - fall through to the readiness poll
 		}
-		if (inFlight) {
-			const sync = await waitForSyncTerminal()
-			const status = ((sync && sync.last_sync_status) || "").trim()
-			if (status.startsWith("failed") || status.startsWith("skipped")) {
-				state.finishing = false
-				state.finishNote = `Setup hit a problem (${status}). Check the AI connection and save again - or continue to Jarvis and retry from Settings.`
-				return
-			}
+		const status = ((terminal && terminal.last_sync_status) || "").trim()
+		if (status.startsWith("failed") || status.startsWith("skipped")) {
+			state.finishing = false
+			state.finishNote = `Setup hit a problem (${status}). Check the AI connection and save again - or continue to Jarvis and retry from Settings.`
+			return
 		}
 	}
 	const ready = await waitUntilReady()

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -660,10 +660,13 @@ function forceContinue() {
 // (cold container provision + proxy sidecars), not seconds. Readiness only
 // flips once that job APPLIES the pool, so before probing is_ready_for_chat
 // we follow the job itself: poll get_llm_sync_status until it leaves
-// "pending:". Bounded above the backend's own 600s job budget - the backend
-// guarantees a terminal status (durable ok/failed) within it, so this loop
-// can't spin forever. Returns the terminal sync dict, or null on timeout.
-async function waitForSyncTerminal(maxMs = 11 * 60 * 1000, intervalMs = 3000) {
+// "pending:". The ceiling is a UX bound, not a correctness guarantee: it
+// clears the backend's 600s job envelope (ADMIN_SYNC_RQ_TIMEOUT_S) plus one
+// lock-loss retry hop; a pathological retry chain can honestly outlast it,
+// in which case the caller falls through to the "still finishing" note with
+// a manual continue - never a hard block. Returns the terminal sync dict,
+// or null on timeout.
+async function waitForSyncTerminal(maxMs = 15 * 60 * 1000, intervalMs = 3000) {
 	const deadline = Date.now() + maxMs
 	for (;;) {
 		try {
@@ -677,19 +680,40 @@ async function waitForSyncTerminal(maxMs = 11 * 60 * 1000, intervalMs = 3000) {
 	}
 }
 
-// Shared tail for both completion paths: wait for the provisioning sync to
-// reach a terminal state, then poll for readiness, then either auto-reload
-// (the common case) or leave a "still finishing" note with a manual continue
-// button so the user is never stuck staring at a spinner.
-async function afterSaveRecheckReady() {
+// Shared tail for both completion paths: optionally follow an in-flight
+// provisioning sync to a terminal state, then poll for readiness, then
+// either auto-reload (the common case) or leave a "still finishing" note
+// with a manual continue button so the user is never stuck on a spinner.
+//
+// followSync is ONLY for the managed pool path (save_llm_pool writes a
+// "pending:" status synchronously before returning, so a sync from THIS
+// save is observable as pending right now). The self-host save never
+// touches last_sync_status, and a no-op / container-owned managed save
+// enqueues nothing - in both cases the field may hold a STALE terminal
+// "failed:" (or a stale "pending:" from an abandoned earlier attempt),
+// which must not block an actually-ready tenant. Hence: only follow a
+// sync we can see in flight, and never gate the self-host path on this
+// field at all.
+async function afterSaveRecheckReady({ followSync = false } = {}) {
 	state.finishNote = ""
 	state.finishing = true
-	const sync = await waitForSyncTerminal()
-	const status = ((sync && sync.last_sync_status) || "").trim()
-	if (status.startsWith("failed") || status.startsWith("skipped")) {
-		state.finishing = false
-		state.finishNote = `Setup hit a problem (${status}). Check the AI connection and save again - or continue to Jarvis and retry from Settings.`
-		return
+	if (followSync) {
+		let inFlight = false
+		try {
+			const s0 = await getLlmSyncStatus()
+			inFlight = !!(s0 && s0.pending)
+		} catch (e) {
+			// status probe is advisory - fall through to the readiness poll
+		}
+		if (inFlight) {
+			const sync = await waitForSyncTerminal()
+			const status = ((sync && sync.last_sync_status) || "").trim()
+			if (status.startsWith("failed") || status.startsWith("skipped")) {
+				state.finishing = false
+				state.finishNote = `Setup hit a problem (${status}). Check the AI connection and save again - or continue to Jarvis and retry from Settings.`
+				return
+			}
+		}
 	}
 	const ready = await waitUntilReady()
 	if (ready) {
@@ -708,7 +732,7 @@ async function afterSaveRecheckReady() {
 // renderLlm) - the component itself owns Quick/Preset/Custom + save_llm_pool;
 // this is only the post-save readiness handoff. ---------------------------
 function onConnected(sync) {
-	afterSaveRecheckReady()
+	afterSaveRecheckReady({ followSync: true })
 }
 
 // The Connect-AI footer (Back + Save) lives here, not inside LlmPoolEditor

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -265,7 +265,7 @@ import LlmPoolEditor from "@/components/LlmPoolEditor.vue"
 import JvCombo from "@/components/JvCombo.vue"
 import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep, stepIndex } from "@/onboarding/steps"
 import {
-	checkSignupPaymentState, isReadyForChat,
+	checkSignupPaymentState, isReadyForChat, getLlmSyncStatus,
 	listPlans, startSignup, finishPayment, devOnboard,
 	saveSelfHosted, testSelfHostConnection, getAccountDefaults, syncConnection,
 } from "@/api"
@@ -656,12 +656,41 @@ function forceContinue() {
 	window.location.assign("/jarvis/")
 }
 
-// Shared tail for both completion paths: poll for readiness, then either
-// auto-reload (the common case) or leave a "still finishing" note with a
-// manual continue button so the user is never stuck staring at a spinner.
+// First-time provisioning runs in a background job whose budget is minutes
+// (cold container provision + proxy sidecars), not seconds. Readiness only
+// flips once that job APPLIES the pool, so before probing is_ready_for_chat
+// we follow the job itself: poll get_llm_sync_status until it leaves
+// "pending:". Bounded above the backend's own 600s job budget - the backend
+// guarantees a terminal status (durable ok/failed) within it, so this loop
+// can't spin forever. Returns the terminal sync dict, or null on timeout.
+async function waitForSyncTerminal(maxMs = 11 * 60 * 1000, intervalMs = 3000) {
+	const deadline = Date.now() + maxMs
+	for (;;) {
+		try {
+			const s = await getLlmSyncStatus()
+			if (s && !s.pending) return s
+		} catch (e) {
+			// transient network hiccups shouldn't strand the user
+		}
+		if (Date.now() >= deadline) return null
+		await sleep(intervalMs)
+	}
+}
+
+// Shared tail for both completion paths: wait for the provisioning sync to
+// reach a terminal state, then poll for readiness, then either auto-reload
+// (the common case) or leave a "still finishing" note with a manual continue
+// button so the user is never stuck staring at a spinner.
 async function afterSaveRecheckReady() {
 	state.finishNote = ""
 	state.finishing = true
+	const sync = await waitForSyncTerminal()
+	const status = ((sync && sync.last_sync_status) || "").trim()
+	if (status.startsWith("failed") || status.startsWith("skipped")) {
+		state.finishing = false
+		state.finishNote = `Setup hit a problem (${status}). Check the AI connection and save again - or continue to Jarvis and retry from Settings.`
+		return
+	}
 	const ready = await waitUntilReady()
 	if (ready) {
 		// Keep the "Setting up Jarvis" spinner up THROUGH the full-page reload.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -369,8 +369,11 @@ async function reconcileMidFlightSignup() {
 			state.step = "selfhost"
 			return
 		}
-		if (ready && ready.reason === "llm_credentials") {
-			// Signup + payment already done; only the AI connection is missing.
+		if (ready && (ready.reason === "llm_credentials" || ready.reason === "llm_pool_provisioning")) {
+			// Signup + payment already done; only the AI connection is missing
+			// (llm_credentials) or a configured pool never finished its first
+			// apply (llm_pool_provisioning) - both resume at the connect step,
+			// whose sync-status poller shows the pending/failed state.
 			state.mode = "managed"
 			state.step = "connect"
 			return

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -40,9 +40,10 @@ def is_ready_for_chat() -> dict:
 	render the chat surface or redirect the customer to /jarvis-onboarding.
 
 	Stricter than ``is_onboarded`` - signup (admin api_key) AND a usable LLM
-	credential for the active ``llm_auth_mode`` must be in place. Pool-pending
-	customers count as ready here (the chat surface has its own waiting state
-	while the tenant is being provisioned).
+	credential for the active ``llm_auth_mode`` must be in place. A pool
+	tenant mid-RE-save still counts as ready (the container keeps serving
+	its previous config), but a pool whose FIRST apply never succeeded does
+	not.
 
 	Returns ``{ready: bool, reason: str | None}`` where ``reason`` is one of:
 
@@ -52,6 +53,9 @@ def is_ready_for_chat() -> dict:
 	  auth mode are missing. api_key mode needs llm_api_key + llm_provider +
 	  llm_model; subscription / oauth modes need llm_oauth_connected_at
 	  (the timestamp set when the oauth grant completes).
+	- ``"llm_pool_provisioning"`` - a pool is configured (proxy_active) but
+	  no sync has ever applied it to the container (first sync pending or
+	  failed).
 	- ``None`` when ``ready`` is True.
 	"""
 	from jarvis import selfhost
@@ -71,9 +75,23 @@ def is_ready_for_chat() -> dict:
 	if not admin_api_key:
 		return {"ready": False, "reason": "signup"}
 
-	# Pool mode: proxy_active means the pool is provisioned → ready.
+	# Pool mode: proxy_active is config INTENT, derived and committed at
+	# save time BEFORE the async pool sync runs - it does not prove the
+	# container ever received the pool. Gate on evidence of a successful
+	# apply instead: llm_pool_synced_at (stamped by the pool-sync job on
+	# every "ok") or a current "ok" status (covers tenants provisioned
+	# before the marker field existed). A pool that has EVER applied stays
+	# ready through a later re-save's transient pending/failed - the
+	# container keeps serving its previous config. A fresh tenant whose
+	# FIRST sync is still pending or failed is NOT ready: sending them to
+	# chat guarantees failing turns while onboarding still shows
+	# "provisioning" (JARVIS-2026-07-08 split-brain).
 	if getattr(settings, "proxy_active", 0):
-		return {"ready": True, "reason": None}
+		synced = bool(getattr(settings, "llm_pool_synced_at", None))
+		status = (getattr(settings, "last_sync_status", "") or "").strip()
+		if synced or status.startswith("ok"):
+			return {"ready": True, "reason": None}
+		return {"ready": False, "reason": "llm_pool_provisioning"}
 
 	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
 

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -78,18 +78,21 @@ def is_ready_for_chat() -> dict:
 	# Pool mode: proxy_active is config INTENT, derived and committed at
 	# save time BEFORE the async pool sync runs - it does not prove the
 	# container ever received the pool. Gate on evidence of a successful
-	# apply instead: llm_pool_synced_at (stamped by the pool-sync job on
-	# every "ok") or a current "ok" status (covers tenants provisioned
-	# before the marker field existed). A pool that has EVER applied stays
-	# ready through a later re-save's transient pending/failed - the
-	# container keeps serving its previous config. A fresh tenant whose
-	# FIRST sync is still pending or failed is NOT ready: sending them to
-	# chat guarantees failing turns while onboarding still shows
-	# "provisioning" (JARVIS-2026-07-08 split-brain).
+	# apply instead: llm_pool_synced_at, stamped by the pool-sync job on
+	# every "ok" (tenants provisioned before the field existed are
+	# backfilled by patch v1_10). A pool that has EVER applied stays ready
+	# through a later re-save's transient pending/failed - the container
+	# keeps serving its previous config. A fresh tenant whose FIRST sync
+	# is still pending or failed is NOT ready: sending them to chat
+	# guarantees failing turns while onboarding still shows "provisioning"
+	# (JARVIS-2026-07-08 split-brain).
+	#
+	# Deliberately NOT a last_sync_status check: that field is shared with
+	# the single-model sync, so a stale legacy "ok (reload via admin)" from
+	# a queued creds job could falsely open the gate for a never-applied
+	# pool.
 	if getattr(settings, "proxy_active", 0):
-		synced = bool(getattr(settings, "llm_pool_synced_at", None))
-		status = (getattr(settings, "last_sync_status", "") or "").strip()
-		if synced or status.startswith("ok"):
+		if getattr(settings, "llm_pool_synced_at", None):
 			return {"ready": True, "reason": None}
 		return {"ready": False, "reason": "llm_pool_provisioning"}
 

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -318,7 +318,7 @@ def get_installations() -> list[dict]:
 # admin surface (System Manager ONLY — every check server-side)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def set_agent_roles(agent_slug: str, roles=None) -> dict:
+def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
 	"""Restrict an agent listing to a set of Roles. System Manager only.
 
 	``roles`` is a JSON array of Role names; ``[]`` clears the restriction
@@ -525,7 +525,7 @@ def set_schedule(
 	installation: str,
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
-	schedule_time=None,
+	schedule_time: str | None = None,
 ) -> dict:
 	"""Set an installed agent's audit schedule — pure DB write (O6: no restart).
 	Recomputes ``next_run_at`` when the schedule is enabled."""

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -143,7 +143,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_approvals_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -172,7 +172,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_custom_skills_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -415,7 +415,7 @@ def get_skill_shares(name: str) -> dict:
 
 
 @frappe.whitelist()
-def share_custom_skill(name: str, users=None) -> dict:
+def share_custom_skill(name: str, users: str | list | None = None) -> dict:
 	"""Replace a skill's share list with ``users`` (a JSON array or list of user
 	ids). Owner only. Recipients get read-only use; they can never re-share."""
 	doc = frappe.get_doc(SKILL, name)

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -279,7 +279,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_inbound_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -426,7 +426,7 @@ def delete_inbound(conversation: str) -> dict:
 
 
 @frappe.whitelist()
-def delete_inbound_bulk(conversations=None) -> dict:
+def delete_inbound_bulk(conversations: str | list | None = None) -> dict:
 	"""Bulk cascade delete (orchestrator Q4). Owner-gated per row, same cascade +
 	streaming refusal as ``delete_inbound``. Returns ``{deleted, skipped:[{
 	conversation, reason}]}`` — a bad/streaming/foreign row is skipped, not fatal."""

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -203,7 +203,7 @@ def list_learned_patterns_page(
 	status: str = "Proposed",
 	strength: str | None = None,
 	search: str | None = None,
-	surfaced=1,
+	surfaced: int | str = 1,
 	start: int = 0,
 	page_length: int = 20,
 	view: str | None = None,
@@ -623,7 +623,7 @@ def restore_rejected_pattern(name: str) -> dict:
 
 
 @frappe.whitelist()
-def snooze_learned_pattern(name: str, days=30) -> dict:
+def snooze_learned_pattern(name: str, days: int | str = 30) -> dict:
 	"""Proposed->Snoozed for 7/30/90 days (dismiss-for-now, section 6.4)."""
 	_guard()
 	try:
@@ -647,7 +647,7 @@ def snooze_learned_pattern(name: str, days=30) -> dict:
 
 
 @frappe.whitelist()
-def batch_approve(names) -> dict:
+def batch_approve(names: str | list) -> dict:
 	"""Approve many at once - A-class ONLY. If ANY named row has an effective
 	sensitivity of B or C, the WHOLE batch is refused (B needs individual
 	disclosure; C is insight-only) - plan sections 4.1 / 6.4."""
@@ -889,7 +889,7 @@ def apply_insight_skill_update(
 	action: str,
 	skill_name: str | None = None,
 	updated_instructions: str | None = None,
-	new_skill=None,
+	new_skill: str | dict | None = None,
 ) -> dict:
 	"""Confirm seam for D5. Revalidates EVERYTHING server-side (the draft
 	payload sat with the client between the two calls): the SM/managed gate,
@@ -1508,7 +1508,7 @@ def run_pattern_analysis_now() -> dict:
 # settings + status (the in-tab config surface, section 6.4)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def get_learning_settings(include_preflight=0) -> dict:
+def get_learning_settings(include_preflight: int | str = 0) -> dict:
 	"""Read the ``pattern_*`` config the tab exposes (SM only). ``include_preflight``
 	runs the (potentially expensive) enablement readiness probe lazily - only when
 	the caller asks (e.g. the enable modal)."""
@@ -1539,7 +1539,7 @@ def get_learning_settings(include_preflight=0) -> dict:
 
 
 @frappe.whitelist()
-def set_learning_settings(payload=None) -> dict:
+def set_learning_settings(payload: str | dict | None = None) -> dict:
 	"""Write the ``pattern_*`` config via the Settings doc so window validation
 	runs (>=1h, wrap-aware - plan section 5.1). Only the config fields are
 	writable; the engine status quartet is engine-owned. Unknown keys are

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -170,7 +170,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_macros_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -286,12 +286,12 @@ def _step_skills(step) -> list[str]:
 def create_macro(
 	macro_name: str,
 	description: str = "",
-	steps=None,
+	steps: str | list | None = None,
 	enabled: int = 1,
 	stop_on_error: int = 1,
 	schedule_enabled: int = 0,
 	schedule_frequency: str = "daily",
-	schedule_time=None,
+	schedule_time: str | None = None,
 ) -> dict:
 	"""Create a macro. Validation (name/steps/caps) runs in the doctype validate().
 	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``)."""
@@ -316,12 +316,12 @@ def update_macro(
 	name: str,
 	macro_name: str | None = None,
 	description: str | None = None,
-	steps=None,
+	steps: str | list | None = None,
 	enabled: int | None = None,
 	stop_on_error: int | None = None,
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
-	schedule_time=None,
+	schedule_time: str | None = None,
 	merged_prompt: str | None = None,
 ) -> dict:
 	"""Update provided fields of a macro (owner-gated). When ``steps`` is given it
@@ -449,7 +449,7 @@ _RUN_STATUSES = {"queued", "running", "completed", "failed", "stopped"}
 
 
 @frappe.whitelist()
-def list_macro_runs(status: str = "", macro: str = "", limit=30, start=0) -> dict:
+def list_macro_runs(status: str = "", macro: str = "", limit: int | str = 30, start: int | str = 0) -> dict:
 	"""The current user's macro runs, newest-first, for the history dashboard.
 
 	Joins the macro for its display name and computes each run's duration in

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -76,6 +76,7 @@
   "last_sync_section",
   "last_sync_at",
   "last_sync_status",
+  "llm_pool_synced_at",
   "custom_skills_synced_at",
   "custom_skills_sync_status",
   "agent_skills_synced_at",
@@ -549,6 +550,13 @@
    "fieldname": "last_sync_status",
    "fieldtype": "Long Text",
    "label": "Last Sync Status",
+   "read_only": 1
+  },
+  {
+   "description": "Set when a pool (proxy) config was last APPLIED to the container via admin. Distinguishes a provisioned pool from one whose first sync is still pending/failed - is_ready_for_chat gates on it.",
+   "fieldname": "llm_pool_synced_at",
+   "fieldtype": "Datetime",
+   "label": "LLM Pool Synced At",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -15,6 +15,26 @@ LLM_FIELDS_TRIGGERING_SYNC = (
 # value migrated tenants might still carry.
 _CONTAINER_OWNED_MODES = {"oauth", "subscription"}
 
+# Shared budget for the admin-sync background jobs (single-model + pool).
+# One constant, three consumers, one invariant chain:
+#
+#   RQ envelope > worst-case work it wraps, AND lock TTL >= RQ envelope.
+#
+# Worst-case pool work: <=60s redis-lock wait + up to 3 POST attempts x 120s
+# admin HTTP budget (post_update_llm_pool) + 2x5s retry sleeps ~= 430s.
+# Worst-case single-model work: <=60s lock wait + 90s admin HTTP budget +
+# the post-restart skills resyncs. 600s clears both with headroom, so the
+# rq SIGALRM (JobTimeoutException) only fires on something genuinely
+# wedged - not on a routine cold provision (JARVIS-2026-07-08, fault c).
+#
+# The lock TTL must be >= the RQ envelope: the TTL bounds how long a
+# CRASHED holder can block others, but a healthy holder may legitimately
+# run right up to its SIGALRM - a shorter TTL would expire mid-run and
+# let a second sync mutate the container in parallel with the first,
+# exactly the interleaving the lock exists to prevent.
+ADMIN_SYNC_RQ_TIMEOUT_S = 600
+ADMIN_SYNC_LOCK_TIMEOUT_S = ADMIN_SYNC_RQ_TIMEOUT_S
+
 
 class JarvisSettings(Document):
     def before_validate(self):
@@ -302,16 +322,12 @@ class JarvisSettings(Document):
         self.db_set("last_sync_status", "pending: provisioning container (pool)",
                     update_modified=False)
         run_inline = bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline)
-        # RQ envelope must exceed the work it wraps or the SIGALRM fires on
-        # every cold provision (JARVIS-2026-07-08, fault c): redis lock wait
-        # (<=60s) + up to 3 POST attempts where the admin call's own HTTP
-        # budget is 120s (post_update_llm_pool) + 5s inter-attempt sleeps.
-        # 300s clears one full slow attempt + a retry with headroom.
+        # Budget rationale lives on ADMIN_SYNC_RQ_TIMEOUT_S.
         frappe.enqueue(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
             "._enqueued_sync_via_admin_pool",
             queue="long",
-            timeout=300,
+            timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
             enqueue_after_commit=not run_inline,
             now=run_inline,
             job_id="jarvis_settings_sync:pool",
@@ -351,15 +367,12 @@ class JarvisSettings(Document):
         # fired. Different actions still both enqueue (one "reload" and
         # one "restart" are not the same op) but the in-worker Redis
         # lock makes them run serially, not interleaved.
-        # 300s for the same reason as the pool enqueue: lock wait (<=60s) +
-        # admin HTTP budget (90s default) + the post-restart custom/learned
-        # skills resync must all fit inside the RQ envelope, or the
-        # JobTimeoutException path is exercised on every slow provision.
+        # Budget rationale lives on ADMIN_SYNC_RQ_TIMEOUT_S.
         frappe.enqueue(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
             "._enqueued_sync_via_admin",
             queue="long",
-            timeout=300,
+            timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
             enqueue_after_commit=not run_inline,
             now=run_inline,
             job_id=f"jarvis_settings_sync:{action}",
@@ -411,6 +424,13 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
             })
+            # Commit EVERY terminal status (ok and each failed branch), not
+            # just the finally-backstop: the rq SIGALRM can fire at any
+            # later point in this job (log_error, lock release, skills
+            # resync), and execute_job's rollback would silently revert an
+            # uncommitted terminal write back to "pending:" - the stuck
+            # status this whole block exists to prevent.
+            frappe.db.commit()
             terminal_written = True
             # A "restart" means the container may be freshly (re)provisioned
             # (rebind / reboot recovery / image upgrade) with an EMPTY
@@ -425,6 +445,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: auth: {e}",
             })
+            frappe.db.commit()
             terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin auth failed",
@@ -435,6 +456,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: admin unreachable: {e}",
             })
+            frappe.db.commit()
             terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin unreachable",
@@ -447,6 +469,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: rate-limited; {retry_str}",
             })
+            frappe.db.commit()
             terminal_written = True
             frappe.logger().info(
                 f"admin_client: rate-limited; retry_after={retry}s"
@@ -617,7 +640,7 @@ def _post_pool_with_retry(spec, api_keys, oauth_blobs):
     raise last
 
 
-def _enqueued_sync_via_admin_pool() -> None:
+def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
     """Background-queue wrapper for the proxy (pool) sync path.
 
     Re-reads Jarvis Settings at run time and rebuilds the pool payload via
@@ -633,19 +656,57 @@ def _enqueued_sync_via_admin_pool() -> None:
     - Redis lock prevents parallel pool + creds calls racing on the container.
     - AdminRateLimitedError writes a terminal failure with retry hint.
     - try/finally backstop ensures the status never sticks at "pending:".
+
+    ``retry_left``: losing the lock race must not strand a FRESH tenant on a
+    terminal "failed: skipped" (their first pool apply would never happen and
+    is_ready_for_chat would gate them out of chat indefinitely). On the first
+    lock loss we re-enqueue ONE follow-up run under its own job_id with a
+    longer lock wait; only a second loss is terminal.
     """
     import frappe as _frappe
     from jarvis._redis_lock import redis_lock
     from jarvis import admin_client
     from jarvis.jarvis.pool_serialize import build_pool_payload
 
-    with redis_lock("jarvis_settings_admin_sync", timeout_s=120, blocking_timeout_s=60.0) as acquired:
+    with redis_lock(
+        "jarvis_settings_admin_sync",
+        # TTL must cover a healthy holder running to its rq SIGALRM - see
+        # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
+        # expire mid-run and admit a concurrent container mutation.
+        timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
+        # The retry run tolerates a long-held sibling lock: it may wait up
+        # to half the RQ envelope, leaving the other half for its own work.
+        blocking_timeout_s=(ADMIN_SYNC_RQ_TIMEOUT_S / 2.0) if retry_left <= 0 else 60.0,
+    ) as acquired:
         if not acquired:
+            settings = _frappe.get_single("Jarvis Settings")
+            if retry_left > 0:
+                _frappe.logger().warning(
+                    "jarvis_settings: pool admin sync lost the lock race; "
+                    "scheduling one retry",
+                )
+                settings.db_set(
+                    "last_sync_status",
+                    "pending: waiting for a concurrent sync to finish (will retry)",
+                    update_modified=False,
+                )
+                # Own job_id: the primary job (jarvis_settings_sync:pool) is
+                # THIS still-running job, so re-enqueueing under the same id
+                # would be dedup-dropped and the retry would never run.
+                _frappe.enqueue(
+                    "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+                    "._enqueued_sync_via_admin_pool",
+                    queue="long",
+                    timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
+                    job_id="jarvis_settings_sync:pool:retry",
+                    deduplicate=True,
+                    retry_left=0,
+                )
+                return
             _frappe.logger().warning(
                 "jarvis_settings: skipping pool admin sync; "
-                "another worker held the lock past blocking timeout",
+                "another worker held the lock past blocking timeout (retry exhausted)",
             )
-            settings = _frappe.get_single("Jarvis Settings")
             settings.db_set(
                 "last_sync_status",
                 "failed: skipped (concurrent sync did not finish in time)",
@@ -687,12 +748,16 @@ def _enqueued_sync_via_admin_pool() -> None:
                 # first sync is still pending/failed has no working pool.
                 "llm_pool_synced_at": _frappe.utils.now(),
             })
+            # Commit every terminal write - matching _sync_via_admin; see
+            # the comment there. Also makes llm_pool_synced_at durable.
+            _frappe.db.commit()
             terminal_written = True
         except admin_client.AdminAuthError as e:
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: auth: {e}",
             })
+            frappe.db.commit()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin auth failed (pool sync)",
@@ -703,6 +768,7 @@ def _enqueued_sync_via_admin_pool() -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: admin unreachable: {e}",
             })
+            frappe.db.commit()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin unreachable (pool sync)",
@@ -715,6 +781,7 @@ def _enqueued_sync_via_admin_pool() -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: rate-limited; {retry_str}",
             })
+            frappe.db.commit()
             terminal_written = True
             _frappe.logger().info(
                 f"admin_client: pool sync rate-limited; retry_after={retry}s"
@@ -724,6 +791,7 @@ def _enqueued_sync_via_admin_pool() -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: validation: {e}",
             })
+            _frappe.db.commit()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin validation failed (pool sync)",
@@ -770,7 +838,14 @@ def _enqueued_sync_via_admin(action: str) -> None:
     """
     from jarvis._redis_lock import redis_lock
 
-    with redis_lock("jarvis_settings_admin_sync", timeout_s=120, blocking_timeout_s=60.0) as acquired:
+    with redis_lock(
+        "jarvis_settings_admin_sync",
+        # TTL must cover a healthy holder running to its rq SIGALRM - see
+        # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
+        # expire mid-run and admit a concurrent container mutation.
+        timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
+        blocking_timeout_s=60.0,
+    ) as acquired:
         if not acquired:
             # Couldn't get the lock within 60s: an earlier sync is
             # apparently stuck. Log + bail; the failed status field

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -302,11 +302,16 @@ class JarvisSettings(Document):
         self.db_set("last_sync_status", "pending: provisioning container (pool)",
                     update_modified=False)
         run_inline = bool(frappe.flags.in_test or frappe.flags.run_admin_sync_inline)
+        # RQ envelope must exceed the work it wraps or the SIGALRM fires on
+        # every cold provision (JARVIS-2026-07-08, fault c): redis lock wait
+        # (<=60s) + up to 3 POST attempts where the admin call's own HTTP
+        # budget is 120s (post_update_llm_pool) + 5s inter-attempt sleeps.
+        # 300s clears one full slow attempt + a retry with headroom.
         frappe.enqueue(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
             "._enqueued_sync_via_admin_pool",
             queue="long",
-            timeout=120,
+            timeout=300,
             enqueue_after_commit=not run_inline,
             now=run_inline,
             job_id="jarvis_settings_sync:pool",
@@ -346,11 +351,15 @@ class JarvisSettings(Document):
         # fired. Different actions still both enqueue (one "reload" and
         # one "restart" are not the same op) but the in-worker Redis
         # lock makes them run serially, not interleaved.
+        # 300s for the same reason as the pool enqueue: lock wait (<=60s) +
+        # admin HTTP budget (90s default) + the post-restart custom/learned
+        # skills resync must all fit inside the RQ envelope, or the
+        # JobTimeoutException path is exercised on every slow provision.
         frappe.enqueue(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
             "._enqueued_sync_via_admin",
             queue="long",
-            timeout=120,
+            timeout=300,
             enqueue_after_commit=not run_inline,
             now=run_inline,
             job_id=f"jarvis_settings_sync:{action}",
@@ -445,15 +454,23 @@ class JarvisSettings(Document):
         finally:
             # Final backstop: if a non-Admin* exception path blew through
             # (network exception class admin_client doesn't translate,
-            # programmer error, etc.) the status would otherwise stay
-            # 'pending: ...' indefinitely. Flip it to a terminal failure
-            # so the UI poller stops spinning.
+            # rq JobTimeoutException, programmer error, etc.) the status
+            # would otherwise stay 'pending: ...' indefinitely. Flip it to
+            # a terminal failure so the UI poller stops spinning.
+            #
+            # The commit is load-bearing (JARVIS-2026-07-08, fault c): the
+            # exception keeps propagating after this finally, and Frappe's
+            # execute_job catches it with frappe.db.rollback() - an
+            # UNcommitted status write here is silently undone and the
+            # status sticks at "pending:" forever. Committing makes the
+            # terminal write durable before the rollback runs.
             if not terminal_written:
                 try:
                     self.db_set({
                         "last_sync_at": frappe.utils.now(),
                         "last_sync_status": "failed: unexpected error; see Error Log",
                     })
+                    frappe.db.commit()
                 except Exception:
                     # If even the status write fails, swallow - we're
                     # already in an error path and re-raising would mask
@@ -662,6 +679,13 @@ def _enqueued_sync_via_admin_pool() -> None:
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
+                # Durable "this pool has been APPLIED to the container at
+                # least once" marker. is_ready_for_chat gates pool tenants
+                # on it: proxy_active alone is config INTENT (committed
+                # synchronously at save, before this job runs) and must not
+                # be read as provisioning success - a fresh tenant whose
+                # first sync is still pending/failed has no working pool.
+                "llm_pool_synced_at": _frappe.utils.now(),
             })
             terminal_written = True
         except admin_client.AdminAuthError as e:
@@ -706,12 +730,20 @@ def _enqueued_sync_via_admin_pool() -> None:
                 message=_frappe.get_traceback(),
             )
         finally:
+            # Commit is load-bearing - see the matching backstop in
+            # _sync_via_admin. Without it, a propagating exception (rq
+            # JobTimeoutException in particular: the pool POST alone may
+            # consume the whole HTTP budget) reaches execute_job's
+            # frappe.db.rollback() and the terminal write is undone,
+            # pinning the UI poller on "pending:" forever
+            # (JARVIS-2026-07-08, fault c).
             if not terminal_written:
                 try:
                     settings.db_set({
                         "last_sync_at": _frappe.utils.now(),
                         "last_sync_status": "failed: unexpected error; see Error Log",
                     })
+                    _frappe.db.commit()
                 except Exception:
                     pass
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -41,9 +41,14 @@ ADMIN_SYNC_LOCK_TIMEOUT_S = ADMIN_SYNC_RQ_TIMEOUT_S
 # exceed the TTL or a fresh tenant's first sync can exhaust every attempt
 # against a corpse and strand on a terminal "failed: skipped". Chain:
 # primary 60s + 4 retries x 150s = 660s > 600s TTL. Each retry runs in its
-# own fresh RQ envelope, and per-attempt wait (150s) + worst-case work
-# (~430s) = 580s stays inside the 600s envelope - the wait must never eat
-# the work budget.
+# own fresh RQ envelope, and per-attempt lock wait + POST-ONLY work must
+# fit that envelope. POST-only worst case (lock wait excluded - the wait
+# is the other term of the sum): pool = 3x120s attempts + 2x5s sleeps
+# = 370s; single-model = 90s + skills resyncs. So 150s + 370s = 520s
+# <= 600s. These are the SAME figures the budget test in
+# test_unified_llm_config.TestOnboardingAuditFixes asserts - tune the
+# waits and the test together, and against the POOL figure (the larger
+# of the two paths).
 ADMIN_SYNC_PRIMARY_LOCK_WAIT_S = 60.0
 ADMIN_SYNC_RETRY_LOCK_WAIT_S = 150.0
 ADMIN_SYNC_LOCK_RETRIES = 4
@@ -60,9 +65,62 @@ def _commit_terminal_sync_status() -> None:
     execute_job: there is no rollback to defeat there, and committing would
     break FrappeTestCase transaction isolation (leaking every fixture write
     of the calling test). frappe.local.job is set exclusively by
-    execute_job, so it is the exact "real worker" signal to gate on."""
-    if getattr(frappe.local, "job", None):
+    execute_job, so it is the exact "real worker" signal to gate on.
+
+    Also commits under frappe.flags.in_migrate: when Redis is down during
+    a bench migrate, frappe.enqueue falls back to frappe.call - outside
+    execute_job, so frappe.local.job is unset - yet a later exception in
+    the same migrate transaction would roll the terminal write back.
+    Committing mid-migrate is normal (the patch runner itself commits
+    between patches)."""
+    if getattr(frappe.local, "job", None) or frappe.flags.in_migrate:
         frappe.db.commit()
+
+
+def _sync_lock_wait_s(retry_left: int) -> float:
+    """Lock wait for a sync attempt: short primary, longer retries."""
+    return (
+        ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
+        if retry_left >= ADMIN_SYNC_LOCK_RETRIES
+        else ADMIN_SYNC_RETRY_LOCK_WAIT_S
+    )
+
+
+def _schedule_sync_lock_retry(*, method: str, job_base: str, retry_left: int,
+                              **enqueue_kwargs) -> None:
+    """Shared lock-loss retry scheduling for BOTH sync workers.
+
+    One implementation so the retry-chain length, waits, status message,
+    and job-id scheme can never silently diverge between the pool and the
+    single-model paths (divergence re-arms the "stranded on failed:
+    skipped" failure for whichever path missed the tuning).
+
+    Writes the retry-pending status, then enqueues the next chain level:
+    - Per-LEVEL job id: this still-running job holds its own id, so
+      reusing it would be dedup-dropped and the chain would stop.
+    - Per-CHAIN random suffix: two independently-triggered chains can
+      reach the same level while the earlier one's job is still
+      queued/started; a level-only id would dedup-drop the newer chain's
+      retry, stranding its "pending: waiting..." status with no job
+      working on it. Uniqueness makes an occasional duplicate run instead
+      - harmless: workers re-read CURRENT settings and serialize on the
+      redis lock.
+    """
+    settings = frappe.get_single("Jarvis Settings")
+    settings.db_set(
+        "last_sync_status",
+        "pending: waiting for a concurrent sync to finish (will retry)",
+        update_modified=False,
+    )
+    frappe.enqueue(
+        method,
+        queue="long",
+        timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
+        job_id=f"{job_base}:retry:{retry_left - 1}:{frappe.generate_hash(length=6)}",
+        deduplicate=True,
+        retry_left=retry_left - 1,
+        **enqueue_kwargs,
+    )
 
 
 class JarvisSettings(Document):
@@ -705,11 +763,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
         # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
         # expire mid-run and admit a concurrent container mutation.
         timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
-        blocking_timeout_s=(
-            ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
-            if retry_left >= ADMIN_SYNC_LOCK_RETRIES
-            else ADMIN_SYNC_RETRY_LOCK_WAIT_S
-        ),
+        blocking_timeout_s=_sync_lock_wait_s(retry_left),
     ) as acquired:
         if not acquired:
             settings = _frappe.get_single("Jarvis Settings")
@@ -718,23 +772,11 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                     "jarvis_settings: pool admin sync lost the lock race; "
                     "scheduling retry (%d left)", retry_left - 1,
                 )
-                settings.db_set(
-                    "last_sync_status",
-                    "pending: waiting for a concurrent sync to finish (will retry)",
-                    update_modified=False,
-                )
-                # Own PER-LEVEL job_id: this still-running job holds its own
-                # id, and a later retry level holds ITS id while enqueueing
-                # the next - reusing any live id would be dedup-dropped and
-                # the chain would silently stop.
-                _frappe.enqueue(
-                    "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
-                    "._enqueued_sync_via_admin_pool",
-                    queue="long",
-                    timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
-                    job_id=f"jarvis_settings_sync:pool:retry:{retry_left - 1}",
-                    deduplicate=True,
-                    retry_left=retry_left - 1,
+                _schedule_sync_lock_retry(
+                    method="jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+                           "._enqueued_sync_via_admin_pool",
+                    job_base="jarvis_settings_sync:pool",
+                    retry_left=retry_left,
                 )
                 return
             _frappe.logger().warning(
@@ -878,11 +920,7 @@ def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETR
         # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
         # expire mid-run and admit a concurrent container mutation.
         timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
-        blocking_timeout_s=(
-            ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
-            if retry_left >= ADMIN_SYNC_LOCK_RETRIES
-            else ADMIN_SYNC_RETRY_LOCK_WAIT_S
-        ),
+        blocking_timeout_s=_sync_lock_wait_s(retry_left),
     ) as acquired:
         if not acquired:
             settings = frappe.get_single("Jarvis Settings")
@@ -897,20 +935,12 @@ def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETR
                     "jarvis_settings: admin sync (action=%s) lost the lock "
                     "race; scheduling retry (%d left)", action, retry_left - 1,
                 )
-                settings.db_set(
-                    "last_sync_status",
-                    "pending: waiting for a concurrent sync to finish (will retry)",
-                    update_modified=False,
-                )
-                frappe.enqueue(
-                    "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
-                    "._enqueued_sync_via_admin",
-                    queue="long",
-                    timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
-                    job_id=f"jarvis_settings_sync:{action}:retry:{retry_left - 1}",
-                    deduplicate=True,
+                _schedule_sync_lock_retry(
+                    method="jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+                           "._enqueued_sync_via_admin",
+                    job_base=f"jarvis_settings_sync:{action}",
+                    retry_left=retry_left,
                     action=action,
-                    retry_left=retry_left - 1,
                 )
                 return
             frappe.logger().warning(

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -35,6 +35,35 @@ _CONTAINER_OWNED_MODES = {"oauth", "subscription"}
 ADMIN_SYNC_RQ_TIMEOUT_S = 600
 ADMIN_SYNC_LOCK_TIMEOUT_S = ADMIN_SYNC_RQ_TIMEOUT_S
 
+# Lock-acquisition waits for the sync workers. A dead (SIGKILLed/OOMed)
+# holder blocks the lock for up to the full TTL (600s) - nothing releases
+# the key early in that case - so the retry chain's CUMULATIVE wait must
+# exceed the TTL or a fresh tenant's first sync can exhaust every attempt
+# against a corpse and strand on a terminal "failed: skipped". Chain:
+# primary 60s + 4 retries x 150s = 660s > 600s TTL. Each retry runs in its
+# own fresh RQ envelope, and per-attempt wait (150s) + worst-case work
+# (~430s) = 580s stays inside the 600s envelope - the wait must never eat
+# the work budget.
+ADMIN_SYNC_PRIMARY_LOCK_WAIT_S = 60.0
+ADMIN_SYNC_RETRY_LOCK_WAIT_S = 150.0
+ADMIN_SYNC_LOCK_RETRIES = 4
+
+
+def _commit_terminal_sync_status() -> None:
+    """Make a terminal last_sync_* write durable - ONLY in a real worker.
+
+    Frappe's execute_job wraps every background job in "rollback on any
+    exception", which silently reverted uncommitted terminal statuses back
+    to 'pending:' when the rq SIGALRM fired (JARVIS-2026-07-08, fault c) -
+    hence the explicit commit. But enqueue(now=True) (tests and the
+    run_admin_sync_inline path) invokes the worker via frappe.call, OUTSIDE
+    execute_job: there is no rollback to defeat there, and committing would
+    break FrappeTestCase transaction isolation (leaking every fixture write
+    of the calling test). frappe.local.job is set exclusively by
+    execute_job, so it is the exact "real worker" signal to gate on."""
+    if getattr(frappe.local, "job", None):
+        frappe.db.commit()
+
 
 class JarvisSettings(Document):
     def before_validate(self):
@@ -430,7 +459,7 @@ class JarvisSettings(Document):
             # resync), and execute_job's rollback would silently revert an
             # uncommitted terminal write back to "pending:" - the stuck
             # status this whole block exists to prevent.
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             # A "restart" means the container may be freshly (re)provisioned
             # (rebind / reboot recovery / image upgrade) with an EMPTY
@@ -445,7 +474,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: auth: {e}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin auth failed",
@@ -456,7 +485,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: admin unreachable: {e}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             frappe.log_error(
                 title="Jarvis: admin unreachable",
@@ -469,7 +498,7 @@ class JarvisSettings(Document):
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"failed: rate-limited; {retry_str}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             frappe.logger().info(
                 f"admin_client: rate-limited; retry_after={retry}s"
@@ -493,7 +522,7 @@ class JarvisSettings(Document):
                         "last_sync_at": frappe.utils.now(),
                         "last_sync_status": "failed: unexpected error; see Error Log",
                     })
-                    frappe.db.commit()
+                    _commit_terminal_sync_status()
                 except Exception:
                     # If even the status write fails, swallow - we're
                     # already in an error path and re-raising would mask
@@ -640,7 +669,7 @@ def _post_pool_with_retry(spec, api_keys, oauth_blobs):
     raise last
 
 
-def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
+def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> None:
     """Background-queue wrapper for the proxy (pool) sync path.
 
     Re-reads Jarvis Settings at run time and rebuilds the pool payload via
@@ -659,9 +688,11 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
 
     ``retry_left``: losing the lock race must not strand a FRESH tenant on a
     terminal "failed: skipped" (their first pool apply would never happen and
-    is_ready_for_chat would gate them out of chat indefinitely). On the first
-    lock loss we re-enqueue ONE follow-up run under its own job_id with a
-    longer lock wait; only a second loss is terminal.
+    is_ready_for_chat would gate them out of chat indefinitely). Each loss
+    re-enqueues a follow-up run under its own job_id with a longer lock wait,
+    down a chain sized so the CUMULATIVE wait outlives even a dead holder's
+    full lock TTL (see ADMIN_SYNC_LOCK_RETRIES); only the last loss is
+    terminal.
     """
     import frappe as _frappe
     from jarvis._redis_lock import redis_lock
@@ -674,38 +705,41 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
         # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
         # expire mid-run and admit a concurrent container mutation.
         timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
-        # The retry run tolerates a long-held sibling lock: it may wait up
-        # to half the RQ envelope, leaving the other half for its own work.
-        blocking_timeout_s=(ADMIN_SYNC_RQ_TIMEOUT_S / 2.0) if retry_left <= 0 else 60.0,
+        blocking_timeout_s=(
+            ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
+            if retry_left >= ADMIN_SYNC_LOCK_RETRIES
+            else ADMIN_SYNC_RETRY_LOCK_WAIT_S
+        ),
     ) as acquired:
         if not acquired:
             settings = _frappe.get_single("Jarvis Settings")
             if retry_left > 0:
                 _frappe.logger().warning(
                     "jarvis_settings: pool admin sync lost the lock race; "
-                    "scheduling one retry",
+                    "scheduling retry (%d left)", retry_left - 1,
                 )
                 settings.db_set(
                     "last_sync_status",
                     "pending: waiting for a concurrent sync to finish (will retry)",
                     update_modified=False,
                 )
-                # Own job_id: the primary job (jarvis_settings_sync:pool) is
-                # THIS still-running job, so re-enqueueing under the same id
-                # would be dedup-dropped and the retry would never run.
+                # Own PER-LEVEL job_id: this still-running job holds its own
+                # id, and a later retry level holds ITS id while enqueueing
+                # the next - reusing any live id would be dedup-dropped and
+                # the chain would silently stop.
                 _frappe.enqueue(
                     "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
                     "._enqueued_sync_via_admin_pool",
                     queue="long",
                     timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
-                    job_id="jarvis_settings_sync:pool:retry",
+                    job_id=f"jarvis_settings_sync:pool:retry:{retry_left - 1}",
                     deduplicate=True,
-                    retry_left=0,
+                    retry_left=retry_left - 1,
                 )
                 return
             _frappe.logger().warning(
                 "jarvis_settings: skipping pool admin sync; "
-                "another worker held the lock past blocking timeout (retry exhausted)",
+                "another worker held the lock past blocking timeout (retries exhausted)",
             )
             settings.db_set(
                 "last_sync_status",
@@ -750,14 +784,14 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
             })
             # Commit every terminal write - matching _sync_via_admin; see
             # the comment there. Also makes llm_pool_synced_at durable.
-            _frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
         except admin_client.AdminAuthError as e:
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: auth: {e}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin auth failed (pool sync)",
@@ -768,7 +802,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: admin unreachable: {e}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin unreachable (pool sync)",
@@ -781,7 +815,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: rate-limited; {retry_str}",
             })
-            frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             _frappe.logger().info(
                 f"admin_client: pool sync rate-limited; retry_after={retry}s"
@@ -791,7 +825,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: validation: {e}",
             })
-            _frappe.db.commit()
+            _commit_terminal_sync_status()
             terminal_written = True
             _frappe.log_error(
                 title="Jarvis: admin validation failed (pool sync)",
@@ -811,12 +845,12 @@ def _enqueued_sync_via_admin_pool(retry_left: int = 1) -> None:
                         "last_sync_at": _frappe.utils.now(),
                         "last_sync_status": "failed: unexpected error; see Error Log",
                     })
-                    _frappe.db.commit()
+                    _commit_terminal_sync_status()
                 except Exception:
                     pass
 
 
-def _enqueued_sync_via_admin(action: str) -> None:
+def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> None:
     """Background-queue wrapper: re-load Jarvis Settings + run _sync_via_admin.
 
     Loading a fresh Single is necessary because the queue worker runs in a
@@ -844,18 +878,46 @@ def _enqueued_sync_via_admin(action: str) -> None:
         # ADMIN_SYNC_LOCK_TIMEOUT_S. A 120s TTL under a 600s job would
         # expire mid-run and admit a concurrent container mutation.
         timeout_s=ADMIN_SYNC_LOCK_TIMEOUT_S,
-        blocking_timeout_s=60.0,
+        blocking_timeout_s=(
+            ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
+            if retry_left >= ADMIN_SYNC_LOCK_RETRIES
+            else ADMIN_SYNC_RETRY_LOCK_WAIT_S
+        ),
     ) as acquired:
         if not acquired:
-            # Couldn't get the lock within 60s: an earlier sync is
-            # apparently stuck. Log + bail; the failed status field
-            # carries the diagnostic. Don't fight the holder.
+            settings = frappe.get_single("Jarvis Settings")
+            if retry_left > 0:
+                # Same retry chain as the pool worker: a sibling sync may
+                # now legitimately hold the lock for minutes (600s
+                # envelope), so a single 60s wait + terminal "failed:
+                # skipped" would silently DROP this credential change -
+                # chat would keep running on the old key with only a
+                # status line to notice.
+                frappe.logger().warning(
+                    "jarvis_settings: admin sync (action=%s) lost the lock "
+                    "race; scheduling retry (%d left)", action, retry_left - 1,
+                )
+                settings.db_set(
+                    "last_sync_status",
+                    "pending: waiting for a concurrent sync to finish (will retry)",
+                    update_modified=False,
+                )
+                frappe.enqueue(
+                    "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings"
+                    "._enqueued_sync_via_admin",
+                    queue="long",
+                    timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
+                    job_id=f"jarvis_settings_sync:{action}:retry:{retry_left - 1}",
+                    deduplicate=True,
+                    action=action,
+                    retry_left=retry_left - 1,
+                )
+                return
             frappe.logger().warning(
                 "jarvis_settings: skipping admin sync (action=%s); "
-                "another worker held the lock past blocking timeout",
+                "another worker held the lock past blocking timeout (retries exhausted)",
                 action,
             )
-            settings = frappe.get_single("Jarvis Settings")
             settings.db_set(
                 "last_sync_status",
                 "failed: skipped (concurrent sync did not finish in time)",

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -162,11 +162,16 @@ def get_preset_catalog() -> list:
 
 
 @frappe.whitelist()
-def save_llm_pool(models, preset: str | None = None, routing_mode: str = "failover") -> dict:
+def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: str = "failover") -> dict:
 	"""Write the customer's multi-model LLM pool into Jarvis Settings.models[]
 	(+ preset, routing_mode) and let the existing on_update pipeline validate
 	(validate_models), derive proxy_active, mirror models[0] into legacy llm_*,
 	and sync DIRECT (/llm-creds) vs PROXY (/llm-pool) via admin.
+
+	``models`` MUST stay annotated: with Frappe's
+	``require_type_annotated_api_methods`` enforced (declared in hooks.py),
+	an un-annotated whitelisted param 500s the request before the body runs
+	(JARVIS-2026-07-08 incident, fault a).
 
 	System-Manager-gated. routing_mode is always 'failover' in v1. preset is an
 	admin-catalog key or None; validated against the fetched catalog."""

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -16,3 +16,4 @@ jarvis.patches.v1_6_normalize_llm_preset_value
 jarvis.patches.v1_7_chat_message_page_index
 jarvis.patches.v1_8_backfill_wiki_scope
 jarvis.patches.v1_9_backfill_wiki_manual_links
+jarvis.patches.v1_10_backfill_llm_pool_synced_at

--- a/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
+++ b/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
@@ -1,0 +1,37 @@
+"""Backfill Jarvis Settings.llm_pool_synced_at for pre-marker pool tenants.
+
+The marker ("this pool config has been APPLIED to the container at least
+once") was introduced with the honest is_ready_for_chat gate; the pool-sync
+worker stamps it on every successful apply. Tenants provisioned BEFORE the
+field existed have it empty, and the gate reads that as "never applied" -
+without this backfill they would be bounced to onboarding on their next
+pool re-save (the save flips last_sync_status to "pending:", so the
+one-shot "current status is ok" signal disappears exactly when they need
+it).
+
+Backfill rule: a pool tenant (proxy_active=1) whose last_sync_status
+currently starts with "ok" demonstrably has an applied pool - stamp the
+marker with last_sync_at (or now as a fallback). Tenants mid-sync or in a
+failed state at migrate time are left empty; their next successful sync
+stamps it.
+
+Reads go through the document API, NOT frappe.db.get_single_value: the
+latter coerces an EMPTY Datetime single to the truthy sentinel
+datetime(1, 1, 1), which would make the "already set" short-circuit fire
+on exactly the tenants this patch exists to backfill.
+"""
+
+import frappe
+
+
+def execute():
+	settings = frappe.get_single("Jarvis Settings")
+	if not settings.proxy_active:
+		return
+	if settings.llm_pool_synced_at:
+		return
+	status = (settings.last_sync_status or "").strip()
+	if not status.startswith("ok"):
+		return
+	synced_at = settings.last_sync_at or frappe.utils.now()
+	frappe.db.set_single_value("Jarvis Settings", "llm_pool_synced_at", synced_at)

--- a/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
+++ b/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
@@ -9,11 +9,17 @@ pool re-save (the save flips last_sync_status to "pending:", so the
 one-shot "current status is ok" signal disappears exactly when they need
 it).
 
-Backfill rule: a pool tenant (proxy_active=1) whose last_sync_status
-currently starts with "ok" demonstrably has an applied pool - stamp the
-marker with last_sync_at (or now as a fallback). Tenants mid-sync or in a
-failed state at migrate time are left empty; their next successful sync
-stamps it.
+Backfill rule: EVERY pre-marker pool tenant (proxy_active=1) is stamped.
+The patch's job is grandfathering, not retroactive enforcement: before
+this deploy the gate was proxy_active alone, so every existing pool
+tenant - including one whose LATEST re-save happens to be transiently
+"pending:"/"failed:" at migrate time while the container keeps serving
+the previously applied pool - was chat-ready. Conditioning the stamp on
+a current "ok" status would demote exactly those working tenants to
+"never provisioned" mid-upgrade (onboarding banner, wizard shove). A
+truly never-applied pre-marker pool tenant is theoretical (the old gate
+let them into chat anyway); the honest gate applies to tenants created
+AFTER this deploy, whose marker lifecycle starts clean.
 
 Reads go through the document API, NOT frappe.db.get_single_value: the
 latter coerces an EMPTY Datetime single to the truthy sentinel
@@ -29,9 +35,6 @@ def execute():
 	if not settings.proxy_active:
 		return
 	if settings.llm_pool_synced_at:
-		return
-	status = (settings.last_sync_status or "").strip()
-	if not status.startswith("ok"):
 		return
 	synced_at = settings.last_sync_at or frappe.utils.now()
 	frappe.db.set_single_value("Jarvis Settings", "llm_pool_synced_at", synced_at)

--- a/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
+++ b/jarvis/patches/v1_10_backfill_llm_pool_synced_at.py
@@ -9,17 +9,24 @@ pool re-save (the save flips last_sync_status to "pending:", so the
 one-shot "current status is ok" signal disappears exactly when they need
 it).
 
-Backfill rule: EVERY pre-marker pool tenant (proxy_active=1) is stamped.
-The patch's job is grandfathering, not retroactive enforcement: before
-this deploy the gate was proxy_active alone, so every existing pool
-tenant - including one whose LATEST re-save happens to be transiently
-"pending:"/"failed:" at migrate time while the container keeps serving
-the previously applied pool - was chat-ready. Conditioning the stamp on
-a current "ok" status would demote exactly those working tenants to
-"never provisioned" mid-upgrade (onboarding banner, wizard shove). A
-truly never-applied pre-marker pool tenant is theoretical (the old gate
-let them into chat anyway); the honest gate applies to tenants created
-AFTER this deploy, whose marker lifecycle starts clean.
+Backfill rule: every pre-marker pool tenant (proxy_active=1) whose sync
+has EVER reached a terminal state (last_sync_at set) is stamped. The
+patch's job is grandfathering, not retroactive enforcement: before this
+deploy the gate was proxy_active alone, so an existing pool tenant whose
+LATEST re-save happens to be transiently "pending:"/"failed:" at migrate
+time - while the container keeps serving the previously applied pool -
+was chat-ready and must stay so. Conditioning the stamp on a current
+"ok" status would demote exactly those working tenants to "never
+provisioned" mid-upgrade (onboarding banner, wizard shove).
+
+The one tenant NOT stamped: last_sync_at empty, i.e. no sync ever
+completed - their pool has demonstrably never been applied, chat has
+never worked, and stamping would permanently mark the broken pool as
+ready and permanently disarm the llm_pool_provisioning gate for them.
+Leaving them unstamped routes them to the onboarding poster, which is an
+improvement over their pre-deploy state (a chat surface where every
+turn failed), not a regression. Their marker sets on the first
+successful sync.
 
 Reads go through the document API, NOT frappe.db.get_single_value: the
 latter coerces an EMPTY Datetime single to the truthy sentinel
@@ -36,5 +43,7 @@ def execute():
 		return
 	if settings.llm_pool_synced_at:
 		return
-	synced_at = settings.last_sync_at or frappe.utils.now()
-	frappe.db.set_single_value("Jarvis Settings", "llm_pool_synced_at", synced_at)
+	if not settings.last_sync_at:
+		# No sync ever completed: nothing to grandfather (see module doc).
+		return
+	frappe.db.set_single_value("Jarvis Settings", "llm_pool_synced_at", settings.last_sync_at)

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -681,7 +681,10 @@ class TestEnqueuedSyncRedisLock(_SettingsSingletonTestCase):
         self.assertIn("pending: waiting for a concurrent sync",
                       settings.last_sync_status or "")
         self.assertEqual(len(captured), 1)
-        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:reload:retry:3")
+        self.assertTrue(
+            (captured[0].get("job_id") or "").startswith("jarvis_settings_sync:reload:retry:3:"),
+            f"unexpected retry job_id: {captured[0].get('job_id')!r}",
+        )
         self.assertEqual(captured[0].get("retry_left"), 3)
 
     def test_lock_contention_retries_exhausted_is_terminal(self):

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -653,10 +653,13 @@ class TestEnqueuedSyncRedisLock(_SettingsSingletonTestCase):
         # the happy path and yielded into the sync.
         self.assertEqual(len(sync_called), 1)
 
-    def test_lock_contention_writes_skipped_status_and_no_admin_call(self):
+    def test_lock_contention_schedules_retry_and_no_admin_call(self):
         """If a prior worker is still holding the lock past blocking timeout,
-        the late arrival logs + writes a 'failed: skipped' status. It must
-        NOT call admin (the in-flight one is in charge)."""
+        the late arrival must NOT call admin (the in-flight one is in
+        charge) and must NOT terminal-fail: a sibling sync may now hold the
+        lock legitimately for minutes (600s envelope), and terminally
+        dropping this sync would silently lose a credential change. First
+        loss -> pending + one retry enqueued under a per-level job_id."""
         from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
             _enqueued_sync_via_admin,
         )
@@ -668,10 +671,37 @@ class TestEnqueuedSyncRedisLock(_SettingsSingletonTestCase):
         def _held(*_a, **_kw):
             yield False
 
+        captured = []
         with patch("jarvis._redis_lock.redis_lock", side_effect=_held), \
+             patch("frappe.enqueue", side_effect=lambda *a, **kw: captured.append(kw)), \
              patch("jarvis.admin_client.post_rotate_llm_secret") as admin_mock:
             _enqueued_sync_via_admin("reload")
         admin_mock.assert_not_called()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertIn("pending: waiting for a concurrent sync",
+                      settings.last_sync_status or "")
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:reload:retry:3")
+        self.assertEqual(captured[0].get("retry_left"), 3)
+
+    def test_lock_contention_retries_exhausted_is_terminal(self):
+        """Only the LAST retry's loss writes the terminal 'failed: skipped'."""
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _enqueued_sync_via_admin,
+        )
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _held(*_a, **_kw):
+            yield False
+
+        captured = []
+        with patch("jarvis._redis_lock.redis_lock", side_effect=_held), \
+             patch("frappe.enqueue", side_effect=lambda *a, **kw: captured.append(kw)), \
+             patch("jarvis.admin_client.post_rotate_llm_secret") as admin_mock:
+            _enqueued_sync_via_admin("reload", retry_left=0)
+        admin_mock.assert_not_called()
+        self.assertFalse(captured, "no further retries after exhaustion")
         settings = frappe.get_single("Jarvis Settings")
         self.assertIn("failed", settings.last_sync_status or "")
         self.assertIn("skipped", settings.last_sync_status or "")

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2279,6 +2279,22 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertTrue(settings.llm_pool_synced_at,
                         "pre-marker pool tenants must be grandfathered unconditionally")
 
+    def test_backfill_patch_skips_never_synced_pools(self):
+        """A pre-marker pool tenant whose sync NEVER completed (last_sync_at
+        empty) has a demonstrably never-applied pool - stamping would
+        permanently disarm the llm_pool_provisioning gate for a tenant whose
+        chat has never worked."""
+        from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
+        self._set_pool_gate_state(
+            synced_at=None, status="failed: admin unreachable: since creation")
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_at", None, update_modified=False)
+        frappe.db.commit()
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertFalse(settings.llm_pool_synced_at,
+                         "never-synced pools must not be grandfathered")
+
     def test_backfill_patch_skips_non_pool_tenants(self):
         from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
         settings = frappe.get_single("Jarvis Settings")
@@ -2332,7 +2348,12 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertTrue(status.startswith("pending: waiting for a concurrent sync"),
                         f"first lock loss must stay pending-with-retry; got {status!r}")
         self.assertEqual(len(captured), 1, "exactly one retry must be enqueued")
-        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:pool:retry:0")
+        # Per-level prefix + per-chain random suffix (two overlapping chains
+        # at the same level must not dedup-collide and drop one).
+        self.assertTrue(
+            (captured[0].get("job_id") or "").startswith("jarvis_settings_sync:pool:retry:0:"),
+            f"unexpected retry job_id: {captured[0].get('job_id')!r}",
+        )
         self.assertEqual(captured[0].get("retry_left"), 0)
 
         captured.clear()

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1657,7 +1657,7 @@ class TestFT2ValidateMirrorTiming(_RT3SettingsTestCase):
         settings = frappe.get_single("Jarvis Settings")
         settings.db_set("proxy_active", 1, update_modified=False)
         settings.db_set("llm_oauth_connected_at", None, update_modified=False)
-        settings.db_set("last_sync_status", "ok (pool_update via admin)",
+        settings.db_set("llm_pool_synced_at", frappe.utils.now(),
                         update_modified=False)
         frappe.db.commit()
 
@@ -2212,20 +2212,118 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
             status="failed: rate-limited; retry_after=90s")
         self.assertTrue(is_ready_for_chat().get("ready"))
 
-    def test_pre_marker_tenant_with_ok_status_is_ready(self):
-        """Tenants provisioned before llm_pool_synced_at existed have an empty
-        marker but an 'ok' status - they must stay ready with no migration."""
+    def test_legacy_ok_status_alone_does_not_open_the_gate(self):
+        """last_sync_status is SHARED with the single-model sync: a stale
+        'ok (reload via admin)' from a queued legacy creds job must not make
+        a never-applied pool look ready. Only the marker counts."""
         from jarvis.account import is_ready_for_chat
         self._set_pool_gate_state(
+            synced_at=None, status="ok (reload via admin)")
+        result = is_ready_for_chat()
+        self.assertFalse(result.get("ready"))
+        self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+
+    def test_backfill_patch_grandfathers_pre_marker_tenants(self):
+        """Tenants provisioned before llm_pool_synced_at existed are
+        grandfathered by patch v1_10 (marker backfilled from last_sync_at
+        when the pool demonstrably applied), NOT by a status heuristic in
+        the gate."""
+        from jarvis.account import is_ready_for_chat
+        from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
+
+        self._set_pool_gate_state(
             synced_at=None, status="ok (pool_update via admin)")
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_at", frappe.utils.now(), update_modified=False)
+        frappe.db.commit()
+
+        execute()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "patch must backfill the marker for an applied pool")
         self.assertTrue(is_ready_for_chat().get("ready"))
+
+    def test_backfill_patch_skips_unapplied_pools(self):
+        from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
+        self._set_pool_gate_state(
+            synced_at=None, status="pending: provisioning container (pool)")
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertFalse(settings.llm_pool_synced_at,
+                         "a mid-sync/never-applied pool must not be backfilled")
+
+    def test_pool_sync_ok_status_survives_rollback(self):
+        """The OK terminal write (status + marker) must be committed too: an
+        rq SIGALRM can fire AFTER the ok db_set but before job end, and the
+        job-runner rollback would otherwise revert a SUCCESSFUL apply back
+        to 'pending:' forever."""
+        self._seed_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_status", "pending: provisioning container (pool)",
+                        update_modified=False)
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        frappe.db.commit()
+
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            _enqueued_sync_via_admin_pool()
+        frappe.db.rollback()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"),
+                        f"ok status must survive rollback; got {settings.last_sync_status!r}")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "llm_pool_synced_at must survive rollback")
+
+    def test_lock_loss_schedules_one_retry_then_terminal(self):
+        """Losing the sync lock must not strand a fresh tenant on a terminal
+        'failed: skipped' - first loss re-enqueues one retry under its own
+        job_id; only the retry's loss is terminal."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _never_acquired(*_a, **_kw):
+            yield False
+
+        captured = []
+        with patch("jarvis._redis_lock.redis_lock", _never_acquired), \
+             patch("frappe.enqueue", side_effect=lambda *a, **kw: captured.append(kw)):
+            _enqueued_sync_via_admin_pool(retry_left=1)
+        status = frappe.db.get_single_value("Jarvis Settings", "last_sync_status") or ""
+        self.assertTrue(status.startswith("pending: waiting for a concurrent sync"),
+                        f"first lock loss must stay pending-with-retry; got {status!r}")
+        self.assertEqual(len(captured), 1, "exactly one retry must be enqueued")
+        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:pool:retry")
+        self.assertEqual(captured[0].get("retry_left"), 0)
+
+        captured.clear()
+        with patch("jarvis._redis_lock.redis_lock", _never_acquired), \
+             patch("frappe.enqueue", side_effect=lambda *a, **kw: captured.append(kw)):
+            _enqueued_sync_via_admin_pool(retry_left=0)
+        status = frappe.db.get_single_value("Jarvis Settings", "last_sync_status") or ""
+        self.assertTrue(status.startswith("failed: skipped"),
+                        f"retry exhaustion must be terminal; got {status!r}")
+        self.assertFalse(captured, "no further retries after exhaustion")
 
     # -- RQ envelope budgets ----------------------------------------------
 
-    def test_sync_enqueues_use_300s_rq_timeout(self):
-        """The RQ job budget must exceed the admin HTTP budget it wraps
-        (120s pool POST + <=60s lock wait + retries) or the SIGALRM fires on
-        every cold provision - the trigger of the stuck-pending incident."""
+    def test_sync_enqueues_share_the_budget_constant(self):
+        """BOTH sync enqueues (pool + single-model) must use
+        ADMIN_SYNC_RQ_TIMEOUT_S - and the constant itself must clear the
+        worst-case work it wraps (~430s: 60s lock wait + 3x120s pool POST
+        attempts + sleeps). Tuning either enqueue away from the shared
+        budget re-arms the JARVIS-2026-07-08 stuck-pending trigger."""
+        from unittest.mock import patch as _patch
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            ADMIN_SYNC_LOCK_TIMEOUT_S, ADMIN_SYNC_RQ_TIMEOUT_S,
+        )
+
+        self.assertGreaterEqual(ADMIN_SYNC_RQ_TIMEOUT_S, 440,
+                                "RQ envelope must exceed worst-case sync work (~430s)")
+        self.assertGreaterEqual(ADMIN_SYNC_LOCK_TIMEOUT_S, ADMIN_SYNC_RQ_TIMEOUT_S,
+                                "lock TTL must cover a holder running to its SIGALRM")
+
         settings = frappe.get_single("Jarvis Settings")
         captured = []
 
@@ -2235,4 +2333,9 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         with patch("frappe.enqueue", side_effect=_capture_enqueue):
             settings.db_set("last_sync_status", "", update_modified=False)
             settings._enqueue_pool_sync()
-        self.assertEqual(captured[-1].get("timeout"), 300)
+            with _patch.object(type(settings), "_classify_llm_change",
+                               return_value="restart"):
+                settings._on_update_single_model_legacy()
+        self.assertEqual(len(captured), 2)
+        for kw in captured:
+            self.assertEqual(kw.get("timeout"), ADMIN_SYNC_RQ_TIMEOUT_S)

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2129,6 +2129,25 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
                    return_value={"action": "pool_update"}):
             settings.save()
 
+    @staticmethod
+    def _as_background_job():
+        """Simulate execute_job's worker context: _commit_terminal_sync_status
+        commits ONLY when frappe.local.job is set (the real-worker signal), so
+        durability tests must fake it - and everything else in the suite runs
+        WITHOUT it, preserving FrappeTestCase transaction isolation."""
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _ctx():
+            prior = getattr(frappe.local, "job", None)
+            frappe.local.job = frappe._dict(method="test")
+            try:
+                yield
+            finally:
+                frappe.local.job = prior
+
+        return _ctx()
+
     def test_unexpected_pool_sync_error_status_survives_rollback(self):
         """RuntimeError (stand-in for rq JobTimeoutException - both take the
         non-Admin* path) -> finally writes 'failed: unexpected error' AND
@@ -2142,7 +2161,7 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         with patch(
             "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._post_pool_with_retry",
             side_effect=RuntimeError("job timeout simulation"),
-        ):
+        ), self._as_background_job():
             with self.assertRaises(RuntimeError):
                 _enqueued_sync_via_admin_pool()
 
@@ -2244,14 +2263,32 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
                         "patch must backfill the marker for an applied pool")
         self.assertTrue(is_ready_for_chat().get("ready"))
 
-    def test_backfill_patch_skips_unapplied_pools(self):
+    def test_backfill_patch_stamps_even_non_ok_pool_tenants(self):
+        """Grandfathering is unconditional for pre-marker pool tenants: an
+        established tenant whose LATEST re-save is transiently pending/failed
+        at migrate time (container still serving the applied pool) was
+        chat-ready before the deploy and must stay so after it."""
         from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
         self._set_pool_gate_state(
-            synced_at=None, status="pending: provisioning container (pool)")
+            synced_at=None, status="failed: admin unreachable: transient")
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_at", frappe.utils.now(), update_modified=False)
+        frappe.db.commit()
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "pre-marker pool tenants must be grandfathered unconditionally")
+
+    def test_backfill_patch_skips_non_pool_tenants(self):
+        from jarvis.patches.v1_10_backfill_llm_pool_synced_at import execute
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("proxy_active", 0, update_modified=False)
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        frappe.db.commit()
         execute()
         settings = frappe.get_single("Jarvis Settings")
         self.assertFalse(settings.llm_pool_synced_at,
-                         "a mid-sync/never-applied pool must not be backfilled")
+                         "direct tenants must not be stamped")
 
     def test_pool_sync_ok_status_survives_rollback(self):
         """The OK terminal write (status + marker) must be committed too: an
@@ -2266,7 +2303,8 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         frappe.db.commit()
 
         with patch("jarvis.admin_client.post_update_llm_pool",
-                   return_value={"action": "pool_update"}):
+                   return_value={"action": "pool_update"}), \
+             self._as_background_job():
             _enqueued_sync_via_admin_pool()
         frappe.db.rollback()
 
@@ -2294,7 +2332,7 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertTrue(status.startswith("pending: waiting for a concurrent sync"),
                         f"first lock loss must stay pending-with-retry; got {status!r}")
         self.assertEqual(len(captured), 1, "exactly one retry must be enqueued")
-        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:pool:retry")
+        self.assertEqual(captured[0].get("job_id"), "jarvis_settings_sync:pool:retry:0")
         self.assertEqual(captured[0].get("retry_left"), 0)
 
         captured.clear()
@@ -2319,10 +2357,27 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
             ADMIN_SYNC_LOCK_TIMEOUT_S, ADMIN_SYNC_RQ_TIMEOUT_S,
         )
 
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            ADMIN_SYNC_LOCK_RETRIES,
+            ADMIN_SYNC_PRIMARY_LOCK_WAIT_S,
+            ADMIN_SYNC_RETRY_LOCK_WAIT_S,
+        )
+
         self.assertGreaterEqual(ADMIN_SYNC_RQ_TIMEOUT_S, 440,
                                 "RQ envelope must exceed worst-case sync work (~430s)")
         self.assertGreaterEqual(ADMIN_SYNC_LOCK_TIMEOUT_S, ADMIN_SYNC_RQ_TIMEOUT_S,
                                 "lock TTL must cover a holder running to its SIGALRM")
+        # A dead (SIGKILLed) holder blocks for the full TTL; the retry chain's
+        # cumulative wait must outlive it or a fresh tenant's first sync can
+        # exhaust every attempt against a corpse.
+        cumulative_wait = (ADMIN_SYNC_PRIMARY_LOCK_WAIT_S
+                           + ADMIN_SYNC_LOCK_RETRIES * ADMIN_SYNC_RETRY_LOCK_WAIT_S)
+        self.assertGreater(cumulative_wait, ADMIN_SYNC_LOCK_TIMEOUT_S,
+                           "retry-chain cumulative lock wait must outlive a dead holder's TTL")
+        # And the per-attempt wait must not eat the work budget: wait + POST
+        # work (~370s: 3x120 + sleeps, lock wait excluded) must fit the envelope.
+        self.assertLessEqual(ADMIN_SYNC_RETRY_LOCK_WAIT_S + 380, ADMIN_SYNC_RQ_TIMEOUT_S,
+                             "retry lock wait + worst-case POST work must fit the RQ envelope")
 
         settings = frappe.get_single("Jarvis Settings")
         captured = []

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1647,16 +1647,24 @@ class TestFT2ValidateMirrorTiming(_RT3SettingsTestCase):
                 self.fail(f"Fresh tenant save raised ValidationError unexpectedly: {exc}")
 
     def test_proxy_active_pool_is_ready_for_chat(self):
-        """proxy_active=1 (without llm_oauth_connected_at) → is_ready_for_chat returns ready."""
+        """proxy_active=1 + an APPLIED pool (status ok) → ready.
+
+        proxy_active alone no longer suffices: it is config intent, committed
+        at save time BEFORE the async sync runs. Evidence of a successful
+        apply (llm_pool_synced_at, or an 'ok' status for tenants provisioned
+        before that marker existed) is what opens the gate.
+        """
         settings = frappe.get_single("Jarvis Settings")
         settings.db_set("proxy_active", 1, update_modified=False)
         settings.db_set("llm_oauth_connected_at", None, update_modified=False)
+        settings.db_set("last_sync_status", "ok (pool_update via admin)",
+                        update_modified=False)
         frappe.db.commit()
 
         from jarvis.account import is_ready_for_chat
         result = is_ready_for_chat()
         self.assertTrue(result.get("ready"),
-                        f"proxy_active=1 must make is_ready_for_chat return ready=True; got: {result}")
+                        f"an applied pool must make is_ready_for_chat return ready=True; got: {result}")
 
 
 # ---------------------------------------------------------------------------
@@ -2077,3 +2085,154 @@ class TestFT4bValidateModelsNeverRaises(_RT3SettingsTestCase):
             ),
             f"Expected a clean 'decryption error' / 'cannot read' error string; got: {errors}",
         )
+
+
+# ---------------------------------------------------------------------------
+# JARVIS-2026-07-08 onboarding-audit fixes: durable sync status + honest
+# pool readiness. (Faults (a)/(c) of the incident + the split-brain gate.)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch  # noqa: E402
+
+
+class TestOnboardingAuditFixes(_RT3SettingsTestCase):
+    """Pins the incident-class behaviors:
+
+    1. A NON-Admin* exception in the pool sync worker (rq JobTimeoutException,
+       programmer error, ...) leaves a terminal 'failed:' status that SURVIVES
+       the frappe.db.rollback() Frappe's execute_job performs on any job
+       exception - previously the finally-backstop write was uncommitted and
+       rolled back with it, pinning the UI poller on 'pending:' forever.
+    2. A successful pool sync stamps llm_pool_synced_at.
+    3. is_ready_for_chat treats proxy_active as intent, not provisioning
+       success: a never-applied pool is NOT ready (reason
+       llm_pool_provisioning); an ever-applied pool stays ready through a
+       later re-save's transient pending/failed.
+    4. The sync jobs' RQ envelopes (300s) exceed the admin HTTP budgets they
+       wrap (120s pool / 90s single-model + lock waits + retries).
+    """
+
+    def _seed_pool(self):
+        """Two api_key models -> proxy_active=1, sync job enqueued (mocked ok)."""
+        settings = frappe.get_single("Jarvis Settings")
+        _add_model_row(settings,
+                       provider="openai_compat", model="gpt-4o",
+                       tier="strong", order=0,
+                       api_key="sk-audit-key-1",
+                       base_url="https://api.openai.com")
+        _add_model_row(settings,
+                       provider="openai_compat", model="gpt-3.5-turbo",
+                       tier="cheap", order=1,
+                       api_key="sk-audit-key-2",
+                       base_url="https://api.openai.com")
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            settings.save()
+
+    def test_unexpected_pool_sync_error_status_survives_rollback(self):
+        """RuntimeError (stand-in for rq JobTimeoutException - both take the
+        non-Admin* path) -> finally writes 'failed: unexpected error' AND
+        commits it, so execute_job's rollback can't undo it."""
+        self._seed_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_status", "pending: provisioning container (pool)",
+                        update_modified=False)
+        frappe.db.commit()
+
+        with patch(
+            "jarvis.jarvis.doctype.jarvis_settings.jarvis_settings._post_pool_with_retry",
+            side_effect=RuntimeError("job timeout simulation"),
+        ):
+            with self.assertRaises(RuntimeError):
+                _enqueued_sync_via_admin_pool()
+
+        # Simulate Frappe's execute_job exception handler.
+        frappe.db.rollback()
+
+        status = frappe.db.get_single_value("Jarvis Settings", "last_sync_status") or ""
+        self.assertTrue(
+            status.startswith("failed: unexpected error"),
+            "the terminal failure status must survive the job-runner rollback "
+            f"(was the finally-backstop committed?); got: {status!r}",
+        )
+
+    def test_pool_sync_ok_stamps_llm_pool_synced_at(self):
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        frappe.db.commit()
+
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            _enqueued_sync_via_admin_pool()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "a successful pool apply must stamp llm_pool_synced_at")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"),
+                        f"expected ok status, got: {settings.last_sync_status!r}")
+
+    # -- is_ready_for_chat gate ------------------------------------------
+
+    def _set_pool_gate_state(self, *, synced_at, status):
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("proxy_active", 1, update_modified=False)
+        settings.db_set("llm_pool_synced_at", synced_at, update_modified=False)
+        settings.db_set("last_sync_status", status, update_modified=False)
+        frappe.db.commit()
+
+    def test_never_applied_pool_pending_is_not_ready(self):
+        from jarvis.account import is_ready_for_chat
+        self._set_pool_gate_state(
+            synced_at=None, status="pending: provisioning container (pool)")
+        result = is_ready_for_chat()
+        self.assertFalse(result.get("ready"),
+                         f"a never-applied pool must not be chat-ready; got: {result}")
+        self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+
+    def test_never_applied_pool_failed_is_not_ready(self):
+        from jarvis.account import is_ready_for_chat
+        self._set_pool_gate_state(
+            synced_at=None, status="failed: unexpected error; see Error Log")
+        result = is_ready_for_chat()
+        self.assertFalse(result.get("ready"))
+        self.assertEqual(result.get("reason"), "llm_pool_provisioning")
+
+    def test_ever_applied_pool_stays_ready_through_resave_pending(self):
+        """A tenant whose pool applied once keeps chatting on the container's
+        previous config while a re-save is mid-sync - must NOT be bounced to
+        onboarding over a transient pending/failed."""
+        from jarvis.account import is_ready_for_chat
+        self._set_pool_gate_state(
+            synced_at=frappe.utils.now(),
+            status="pending: provisioning container (pool)")
+        self.assertTrue(is_ready_for_chat().get("ready"))
+        self._set_pool_gate_state(
+            synced_at=frappe.utils.now(),
+            status="failed: rate-limited; retry_after=90s")
+        self.assertTrue(is_ready_for_chat().get("ready"))
+
+    def test_pre_marker_tenant_with_ok_status_is_ready(self):
+        """Tenants provisioned before llm_pool_synced_at existed have an empty
+        marker but an 'ok' status - they must stay ready with no migration."""
+        from jarvis.account import is_ready_for_chat
+        self._set_pool_gate_state(
+            synced_at=None, status="ok (pool_update via admin)")
+        self.assertTrue(is_ready_for_chat().get("ready"))
+
+    # -- RQ envelope budgets ----------------------------------------------
+
+    def test_sync_enqueues_use_300s_rq_timeout(self):
+        """The RQ job budget must exceed the admin HTTP budget it wraps
+        (120s pool POST + <=60s lock wait + retries) or the SIGALRM fires on
+        every cold provision - the trigger of the stuck-pending incident."""
+        settings = frappe.get_single("Jarvis Settings")
+        captured = []
+
+        def _capture_enqueue(*args, **kwargs):
+            captured.append(kwargs)
+
+        with patch("frappe.enqueue", side_effect=_capture_enqueue):
+            settings.db_set("last_sync_status", "", update_modified=False)
+            settings._enqueue_pool_sync()
+        self.assertEqual(captured[-1].get("timeout"), 300)

--- a/jarvis/tests/test_whitelist_annotations.py
+++ b/jarvis/tests/test_whitelist_annotations.py
@@ -1,0 +1,74 @@
+"""Guard: every @frappe.whitelist method must have fully type-annotated
+parameters.
+
+jarvis/hooks.py declares ``require_type_annotated_api_methods = True``. On a
+Frappe that enforces it, an UN-annotated parameter on a whitelisted method
+500s the request before the function body runs. The local dev bench's Frappe
+does not enforce the flag, so the bug is invisible here and detonates only on
+freshly-deployed strict benches - exactly how ``save_llm_pool(models, ...)``
+took down onboarding in the JARVIS-2026-07-08 incident (fault a).
+
+This sweep makes the contract testable on ANY Frappe: walk the app's API
+modules, find every whitelisted function, and assert each parameter carries
+an annotation.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+from frappe.tests.utils import FrappeTestCase
+
+# The customer-facing API surface: modules whose whitelisted methods are hit
+# by the SPA / onboarding wizard / plugin. Extend when adding a new module
+# with @frappe.whitelist methods.
+_API_MODULES = (
+	"jarvis.onboarding",
+	"jarvis.oauth.api",
+	"jarvis.account",
+	"jarvis.chat.api",
+	"jarvis.api",
+	"jarvis.diagnostics",
+	"jarvis.selfhost",
+	"jarvis.chat.device",
+)
+
+
+def _whitelisted_functions(module):
+	# frappe.whitelist() registers the function in the global
+	# ``frappe.whitelisted`` set (no attribute is stamped on the function),
+	# so detection is set membership.
+	import frappe
+
+	for name, fn in vars(module).items():
+		if callable(fn) and fn in frappe.whitelisted:
+			# Only functions defined in THIS module (skip re-exports).
+			if getattr(fn, "__module__", None) == module.__name__:
+				yield name, fn
+
+
+class TestWhitelistAnnotations(FrappeTestCase):
+	def test_every_whitelisted_param_is_annotated(self):
+		offenders = []
+		found_any = False
+		for modname in _API_MODULES:
+			module = importlib.import_module(modname)
+			for name, fn in _whitelisted_functions(module):
+				found_any = True
+				sig = inspect.signature(fn)
+				for pname, param in sig.parameters.items():
+					if pname in ("self", "cls"):
+						continue
+					if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+						continue
+					if param.annotation is inspect.Parameter.empty:
+						offenders.append(f"{modname}.{name}({pname})")
+		self.assertTrue(found_any, "sweep found no whitelisted functions - "
+						"module list or detection broke")
+		self.assertFalse(
+			offenders,
+			"un-annotated @frappe.whitelist parameters (500 under Frappe's "
+			"require_type_annotated_api_methods, which hooks.py enables): "
+			+ ", ".join(offenders),
+		)

--- a/jarvis/tests/test_whitelist_annotations.py
+++ b/jarvis/tests/test_whitelist_annotations.py
@@ -8,31 +8,39 @@ does not enforce the flag, so the bug is invisible here and detonates only on
 freshly-deployed strict benches - exactly how ``save_llm_pool(models, ...)``
 took down onboarding in the JARVIS-2026-07-08 incident (fault a).
 
-This sweep makes the contract testable on ANY Frappe: walk the app's API
-modules, find every whitelisted function, and assert each parameter carries
-an annotation.
+This sweep makes the contract testable on ANY Frappe: walk EVERY module in
+the jarvis package (derived via pkgutil, not a hand-kept list - a hand-kept
+list missed live offenders in agents_api/custom_skills_api), find every
+whitelisted function, and assert each parameter carries an annotation.
 """
 
 from __future__ import annotations
 
 import importlib
 import inspect
+import pkgutil
 
 from frappe.tests.utils import FrappeTestCase
 
-# The customer-facing API surface: modules whose whitelisted methods are hit
-# by the SPA / onboarding wizard / plugin. Extend when adding a new module
-# with @frappe.whitelist methods.
-_API_MODULES = (
-	"jarvis.onboarding",
-	"jarvis.oauth.api",
-	"jarvis.account",
-	"jarvis.chat.api",
-	"jarvis.api",
-	"jarvis.diagnostics",
-	"jarvis.selfhost",
-	"jarvis.chat.device",
-)
+# Subtrees that never serve whitelisted endpoints and may have import-time
+# side effects (migrations) or are test-only.
+_SKIP_PREFIXES = ("jarvis.patches", "jarvis.tests")
+
+
+def _iter_api_modules():
+	"""Yield every importable module in the jarvis package (minus skips).
+
+	Coverage is DERIVED, not hand-listed: a new module with whitelisted
+	methods is swept automatically. An unimportable module fails the test
+	loudly - in a site context every app module must import cleanly anyway.
+	"""
+	import jarvis
+
+	yield jarvis
+	for info in pkgutil.walk_packages(jarvis.__path__, prefix="jarvis."):
+		if info.name.startswith(_SKIP_PREFIXES):
+			continue
+		yield importlib.import_module(info.name)
 
 
 def _whitelisted_functions(module):
@@ -51,10 +59,14 @@ def _whitelisted_functions(module):
 class TestWhitelistAnnotations(FrappeTestCase):
 	def test_every_whitelisted_param_is_annotated(self):
 		offenders = []
+		seen = set()
 		found_any = False
-		for modname in _API_MODULES:
-			module = importlib.import_module(modname)
+		for module in _iter_api_modules():
 			for name, fn in _whitelisted_functions(module):
+				key = f"{fn.__module__}.{name}"
+				if key in seen:
+					continue
+				seen.add(key)
 				found_any = True
 				sig = inspect.signature(fn)
 				for pname, param in sig.parameters.items():
@@ -63,12 +75,12 @@ class TestWhitelistAnnotations(FrappeTestCase):
 					if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
 						continue
 					if param.annotation is inspect.Parameter.empty:
-						offenders.append(f"{modname}.{name}({pname})")
+						offenders.append(f"{key}({pname})")
 		self.assertTrue(found_any, "sweep found no whitelisted functions - "
-						"module list or detection broke")
+						"module walk or detection broke")
 		self.assertFalse(
 			offenders,
 			"un-annotated @frappe.whitelist parameters (500 under Frappe's "
 			"require_type_annotated_api_methods, which hooks.py enables): "
-			+ ", ".join(offenders),
+			+ ", ".join(sorted(offenders)),
 		)


### PR DESCRIPTION
Fixes the four confirmed defects from the fresh-onboarding audit following the **JARVIS-2026-07-08 incident** (tenant 502s + config never reaching the control plane). Each maps to an incident fault or a bug the incident exposed.

## 1. `save_llm_pool(models, …)` — un-annotated whitelisted param (incident fault a) — CRITICAL

On a Frappe that enforces `require_type_annotated_api_methods` (which `hooks.py:262` declares), the request layer 500s before the function body runs, making the entire pool-onboarding step unreachable. The local dev Frappe ignores the flag, which is why this only detonated on the freshly-deployed bench.

- Annotated `models: str | list`.
- **New guard test** (`test_whitelist_annotations.py`): sweeps every `@frappe.whitelist` function in the API modules (`onboarding`, `oauth.api`, `account`, `chat.api`, `api`, `diagnostics`, `selfhost`, `chat.device`) and fails on any un-annotated parameter — enforcing the contract on any Frappe. Verified to FAIL on unfixed main flagging exactly `jarvis.onboarding.save_llm_pool(models)`, and to pass on this branch.

## 2. Sync status stuck at `pending:` forever (incident fault c) — CRITICAL

Both sync workers' `try/finally` backstops wrote the terminal `failed:` status but **never committed**. A propagating non-`Admin*` exception (rq `JobTimeoutException` in particular) then reached Frappe `execute_job`'s `frappe.db.rollback()`, which silently undid the write — the UI poller spun on "pending" indefinitely. Both backstops now **commit the terminal status** before the exception continues; a new test proves the status survives a simulated job-runner rollback.

## 3. RQ envelope smaller than the work it wraps — the trigger of #2

The pool sync ran under `timeout=120` while wrapping an admin POST whose own HTTP budget is **120s**, plus up to 60s of redis-lock wait and retry sleeps — the SIGALRM fired reliably on every cold provision. Both sync enqueues now use `timeout=300` (pinned by a test).

## 4. `is_ready_for_chat` false-positive for never-provisioned pools — HIGH

`proxy_active` is config **intent**, committed at save time before the async sync runs — but the gate read it as provisioning success. A fresh tenant with a stuck/failed first sync was sent to chat (every turn fails; the container never received the pool) while onboarding simultaneously said "provisioning" — the incident's split-brain.

- New read-only field **`llm_pool_synced_at`**, stamped by the pool-sync worker on every successful apply.
- Gate: pool tenants are ready iff the marker is set **or** `last_sync_status` is currently `ok` (grandfathers tenants provisioned before the marker existed — no data migration needed).
- A pool that has EVER applied stays ready through a later re-save's transient pending/failed — preserving the deliberate "a re-save must not bounce a working tenant to onboarding" behavior.
- New reason `llm_pool_provisioning`; the wizard's mid-flight reconcile resumes such tenants at the connect step (whose sync-status poller shows the real state).

## Tests

- `test_unified_llm_config`: 39 + 34 passed (7 new: rollback-survival proof, marker stamping, all four gate states, RQ-timeout pin; 1 existing test updated to the new gate semantics).
- `test_whitelist_annotations`: passes here; fails on main with exactly the incident's offender.
- `test_settings_on_update`: 36 passed.
- `test_onboarding_sync`: 1 pre-existing failure that reproduces identically on unmodified main (local-site state pollution; not introduced by this change).

## Deploy note

`bench migrate` syncs the new `llm_pool_synced_at` field from the doctype JSON — no patch required. Related fleet-agent-side incident fixes (compose restart cliproxy, fake-async handlers) are a separate repo and still need their own PR from the incident author.