### PR TITLE
fix(tools): support child-table reads in get_list (timesheet perm error)

### DIFF
--- a/jarvis/tests/test_get_list.py
+++ b/jarvis/tests/test_get_list.py
@@ -57,6 +57,21 @@ class TestGetList(FrappeTestCase):
                     "territory": "_Test Territory",
                 }).insert(ignore_permissions=True)
 
+        # Child-table (istable) fixture: a Contact with an email row. Contact
+        # (parent) owns "Contact Email" (child) via its ``email_ids`` Table
+        # field - a core Frappe pair, so the child-table tests need no ERPNext
+        # Timesheet setup while exercising the same istable mechanism.
+        contact_fn = "Jarvis TS Contact"
+        existing = frappe.db.get_value("Contact", {"first_name": contact_fn})
+        if existing:
+            cls.contact_name = existing
+        else:
+            cls.contact_name = frappe.get_doc({
+                "doctype": "Contact",
+                "first_name": contact_fn,
+                "email_ids": [{"email_id": "jarvis-ts@example.com", "is_primary": 1}],
+            }).insert(ignore_permissions=True).name
+
     def test_returns_rows(self):
         rows = get_list(
             doctype="Customer",
@@ -133,3 +148,60 @@ class TestGetList(FrappeTestCase):
                 get_list(doctype="Customer", fields=["name"])
         finally:
             frappe.set_user("Administrator")
+
+    def test_child_table_without_parent_doctype_errors(self):
+        """A direct get_list on a child (istable) DocType with no parent_doctype
+        must raise a clear InvalidArgumentError that names the parent - not the
+        opaque 'no read permission' the old code produced."""
+        with self.assertRaises(InvalidArgumentError) as cm:
+            get_list(doctype="Contact Email", fields=["email_id"])
+        msg = str(cm.exception)
+        self.assertIn("child table", msg)
+        self.assertIn("parent_doctype", msg)
+        self.assertIn("Contact", msg)  # the discovered owning DocType
+
+    def test_child_table_with_parent_doctype_reads_rows(self):
+        """With parent_doctype supplied the child rows are readable (here as
+        Administrator - proves the arg is forwarded and the query runs)."""
+        rows = get_list(
+            doctype="Contact Email",
+            fields=["parent", "email_id"],
+            filters={"parent": self.contact_name},
+            parent_doctype="Contact",
+        )
+        self.assertIn("jarvis-ts@example.com", {r["email_id"] for r in rows})
+
+    def test_child_table_permission_derived_from_parent(self):
+        """A user who cannot read the parent DocType is denied the child rows
+        even with parent_doctype set - access derives from the parent, so this
+        is not a permission bypass. Uses the reported Timesheet Detail / Timesheet
+        pair: Timesheet is role-restricted, and the perm check fires before any
+        rows are fetched so no Timesheet needs to exist."""
+        user_email = "childless@example.com"
+        if not frappe.db.exists("User", user_email):
+            frappe.get_doc({
+                "doctype": "User",
+                "email": user_email,
+                "first_name": "Childless",
+                "send_welcome_email": 0,
+            }).insert(ignore_permissions=True)
+        frappe.set_user(user_email)
+        try:
+            with self.assertRaises(PermissionDeniedError):
+                get_list(
+                    doctype="Timesheet Detail",
+                    fields=["activity_type"],
+                    parent_doctype="Timesheet",
+                )
+        finally:
+            frappe.set_user("Administrator")
+
+    def test_parent_doctype_harmless_for_non_child(self):
+        """Passing parent_doctype on a normal (non-child) DocType is ignored."""
+        rows = get_list(
+            doctype="Customer",
+            fields=["name"],
+            filters={"customer_name": ["like", "Jarvis List%"]},
+            parent_doctype="Anything",
+        )
+        self.assertEqual({r["name"] for r in rows}, {"Jarvis List A", "Jarvis List B"})

--- a/jarvis/tools/get_list.py
+++ b/jarvis/tools/get_list.py
@@ -16,6 +16,31 @@ MAX_LIMIT = 1000
 # 2026-06-22 outage that motivated this.
 ROW_GUARD = 200
 
+_CHILD_TABLE_FIELDTYPES = ("Table", "Table MultiSelect")
+
+
+def _child_table_parents(doctype: str) -> list[str]:
+    """DocTypes that own ``doctype`` as a child table (via a Table field).
+
+    Frappe derives a child DocType's read permission from its parent, so when a
+    caller queries a child table without a parent we surface the candidate
+    parents to point them at ``parent_doctype``. Reads schema metadata via
+    ``frappe.get_all`` (permissions bypassed) - ``DocField`` is itself a child
+    table, so ``get_list`` here would hit the very wall we are explaining.
+    Checks both standard fields (``DocField``) and ``Custom Field`` (``dt``).
+    """
+    parents = frappe.get_all(
+        "DocField",
+        filters={"fieldtype": ["in", _CHILD_TABLE_FIELDTYPES], "options": doctype},
+        pluck="parent",
+    )
+    parents += frappe.get_all(
+        "Custom Field",
+        filters={"fieldtype": ["in", _CHILD_TABLE_FIELDTYPES], "options": doctype},
+        pluck="dt",
+    )
+    return list(dict.fromkeys(parents))
+
 
 def get_list(
     doctype: str,
@@ -24,11 +49,22 @@ def get_list(
     order_by: str | None = None,
     limit: int = 20,
     confirm_large: bool = False,
+    parent_doctype: str | None = None,
 ) -> list[dict]:
     """List documents with filters.
 
     Frappe's get_list applies per-user record permissions automatically.
     We additionally enforce DocType-level read permission and cap the limit.
+
+    Child (Table) DocTypes have no permissions of their own - Frappe derives
+    their access from a parent DocType. To read child rows (e.g. a Timesheet's
+    ``time_logs``) pass ``parent_doctype`` (the owning DocType) and usually
+    filter by ``parent``; permission is then derived from the parent. Calling
+    get_list on a child DocType without ``parent_doctype`` raises
+    ``InvalidArgumentError``. Note child tables lack parent-only fields (e.g.
+    employee/date live on ``Timesheet``, not ``Timesheet Detail``) - to filter
+    or aggregate by those, query the parent with a join via the ``query`` tool
+    or use ``run_report``.
 
     Row guard: results above ``ROW_GUARD`` (200) rows raise
     ``ResultTooLargeError`` unless ``confirm_large=True``. The agent
@@ -41,7 +77,21 @@ def get_list(
     if limit <= 0 or limit > MAX_LIMIT:
         raise InvalidArgumentError(f"limit must be between 1 and {MAX_LIMIT}")
 
-    if not frappe.has_permission(doctype, ptype="read"):
+    if frappe.get_meta(doctype).istable:
+        if not parent_doctype:
+            parents = _child_table_parents(doctype)
+            hint = f" (e.g. parent_doctype='{parents[0]}')" if parents else ""
+            raise InvalidArgumentError(
+                f"'{doctype}' is a child table; pass parent_doctype{hint} and filter by "
+                f"parent, or query its parent with a join via the `query` tool / use "
+                f"run_report. Child tables lack parent-only fields like employee/date."
+            )
+    else:
+        # parent_doctype only makes sense for child tables; drop a stray value so
+        # it never turns a normal query into a "DocType <x> not found" error.
+        parent_doctype = None
+
+    if not frappe.has_permission(doctype, ptype="read", parent_doctype=parent_doctype):
         raise PermissionDeniedError(f"no read permission on {doctype}")
 
     rows = frappe.get_list(
@@ -50,6 +100,7 @@ def get_list(
         filters=filters or {},
         order_by=order_by,
         limit=limit,
+        parent_doctype=parent_doctype,
     )
     if len(rows) > ROW_GUARD and not confirm_large:
         raise ResultTooLargeError(


### PR DESCRIPTION
## Problem
Asking Jarvis for a timesheet report over a long period / many employees made the agent bulk-fetch the child table via `get_list("Timesheet Detail", ...)`, which failed with an opaque **permission error**.

## Root cause
`Timesheet Detail` is a child (`istable`) DocType. Child DocTypes have no permissions of their own — Frappe derives their access from a **parent** (`has_child_permission`). `get_list` passed no parent context, so `has_permission` returned `False` for any non-Administrator → `PermissionDeniedError`. The tool exposed no way to supply a parent.

## Fix
- Add a `parent_doctype` param, forwarded to `frappe.has_permission` + `frappe.get_list` → permission is derived from the parent (**not a bypass**: a user who can't read the parent still can't read its child rows).
- Querying a child DocType **without** `parent_doctype` now raises a clear `InvalidArgumentError` naming the owning DocType and pointing to the parent-anchored `query` tool / `run_report` (child tables can't filter by parent-only fields like employee/date anyway).
- A stray `parent_doctype` on a non-child DocType is ignored.

## Tests
`test_get_list`: **12/12**, incl. new cases — child-without-parent errors, child-with-parent reads, permission-derived-from-parent denial (real `Timesheet Detail` / `Timesheet` pair), non-child harmless.

## Companion
The openclaw plugin's `get_list` descriptor is updated in a **separate PR** (jarvis-openclaw-plugin) to stop steering the model to query child DocTypes directly + add the `parent_doctype` param; it takes effect after a plugin release + container redeploy. This app-side change works immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
