### PR TITLE
fix(api): annotate whitelisted method args missing type annotations

### DIFF
--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -318,7 +318,7 @@ def get_installations() -> list[dict]:
 # admin surface (System Manager ONLY — every check server-side)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def set_agent_roles(agent_slug: str, roles=None) -> dict:
+def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
 	"""Restrict an agent listing to a set of Roles. System Manager only.
 
 	``roles`` is a JSON array of Role names; ``[]`` clears the restriction

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -172,7 +172,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_custom_skills_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -415,7 +415,7 @@ def get_skill_shares(name: str) -> dict:
 
 
 @frappe.whitelist()
-def share_custom_skill(name: str, users=None) -> dict:
+def share_custom_skill(name: str, users: str | list | None = None) -> dict:
 	"""Replace a skill's share list with ``users`` (a JSON array or list of user
 	ids). Owner only. Recipients get read-only use; they can never re-share."""
 	doc = frappe.get_doc(SKILL, name)

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -426,7 +426,7 @@ def delete_inbound(conversation: str) -> dict:
 
 
 @frappe.whitelist()
-def delete_inbound_bulk(conversations=None) -> dict:
+def delete_inbound_bulk(conversations: str | list | None = None) -> dict:
 	"""Bulk cascade delete (orchestrator Q4). Owner-gated per row, same cascade +
 	streaming refusal as ``delete_inbound``. Returns ``{deleted, skipped:[{
 	conversation, reason}]}`` — a bad/streaming/foreign row is skipped, not fatal."""

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -623,7 +623,7 @@ def restore_rejected_pattern(name: str) -> dict:
 
 
 @frappe.whitelist()
-def snooze_learned_pattern(name: str, days=30) -> dict:
+def snooze_learned_pattern(name: str, days: int = 30) -> dict:
 	"""Proposed->Snoozed for 7/30/90 days (dismiss-for-now, section 6.4)."""
 	_guard()
 	try:
@@ -1508,7 +1508,7 @@ def run_pattern_analysis_now() -> dict:
 # settings + status (the in-tab config surface, section 6.4)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def get_learning_settings(include_preflight=0) -> dict:
+def get_learning_settings(include_preflight: int = 0) -> dict:
 	"""Read the ``pattern_*`` config the tab exposes (SM only). ``include_preflight``
 	runs the (potentially expensive) enablement readiness probe lazily - only when
 	the caller asks (e.g. the enable modal)."""
@@ -1539,7 +1539,7 @@ def get_learning_settings(include_preflight=0) -> dict:
 
 
 @frappe.whitelist()
-def set_learning_settings(payload=None) -> dict:
+def set_learning_settings(payload: str | dict | None = None) -> dict:
 	"""Write the ``pattern_*`` config via the Settings doc so window validation
 	runs (>=1h, wrap-aware - plan section 5.1). Only the config fields are
 	writable; the engine status quartet is engine-owned. Unknown keys are

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -170,7 +170,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 @frappe.whitelist()
 def list_macros_page(
 	search: str = "",
-	filters=None,
+	filters: str | dict | None = None,
 	sort_field: str = "",
 	sort_dir: str = "",
 	start: int = 0,
@@ -286,12 +286,12 @@ def _step_skills(step) -> list[str]:
 def create_macro(
 	macro_name: str,
 	description: str = "",
-	steps=None,
+	steps: str | list | None = None,
 	enabled: int = 1,
 	stop_on_error: int = 1,
 	schedule_enabled: int = 0,
 	schedule_frequency: str = "daily",
-	schedule_time=None,
+	schedule_time: str | None = None,
 ) -> dict:
 	"""Create a macro. Validation (name/steps/caps) runs in the doctype validate().
 	Per-step tagged skills arrive INSIDE each step dict (``steps[].skills``)."""
@@ -316,12 +316,12 @@ def update_macro(
 	name: str,
 	macro_name: str | None = None,
 	description: str | None = None,
-	steps=None,
+	steps: str | list | None = None,
 	enabled: int | None = None,
 	stop_on_error: int | None = None,
 	schedule_enabled: int | None = None,
 	schedule_frequency: str | None = None,
-	schedule_time=None,
+	schedule_time: str | None = None,
 	merged_prompt: str | None = None,
 ) -> dict:
 	"""Update provided fields of a macro (owner-gated). When ``steps`` is given it
@@ -449,7 +449,7 @@ _RUN_STATUSES = {"queued", "running", "completed", "failed", "stopped"}
 
 
 @frappe.whitelist()
-def list_macro_runs(status: str = "", macro: str = "", limit=30, start=0) -> dict:
+def list_macro_runs(status: str = "", macro: str = "", limit: int = 30, start: int = 0) -> dict:
 	"""The current user's macro runs, newest-first, for the history dashboard.
 
 	Joins the macro for its display name and computes each run's duration in


### PR DESCRIPTION
## Problem
With `require_type_annotated_api_methods = True`, Frappe rejects any whitelisted method whose args lack type annotations — so several chat endpoints raised `FrappeTypeError` the moment the SPA/agent called them (surfaced by `test_v3_list_extensions` for the macros/skills list pages).

## Fix
Annotate every remaining un-annotated whitelisted arg across the chat API, matching the types each body already parses:
- `macros_api`: `list_macros_page.filters`, `create/update_macro.steps` + `schedule_time`, `list_macro_runs.limit/start`
- `custom_skills_api`: `list_custom_skills_page.filters`, `share_custom_skill.users`
- `agents_api`: `set_agent_roles.roles`
- `learned_api`: `snooze_learned_pattern.days`, `get/set_learning_settings` (`include_preflight`, `payload`)
- `filebox`: `delete_inbound_bulk.conversations`

Types follow the existing conventions in these files (`str | dict`, `str | list`, `int`); the bodies already parse string/JSON inputs.

## Tests
`test_v3_list_extensions`: **19/19** (was 5 errors). A repo-wide scan confirms **0** remaining un-annotated whitelisted params across `jarvis/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
