### PR TITLE
fix(shell): drop redundant Account/Monitor items from the user menu

### DIFF
--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -68,17 +68,6 @@ const menuOptions = computed(() => [
 		hideLabel: true,
 		items: [
 			{ label: "Settings", icon: "settings", onClick: () => store.openSettings() },
-			// Account/Monitor now open the unified settings dialog to the right
-			// section instead of navigating to the (deleted) /account + /monitor
-			// routes. The ACCOUNT & BILLING group is SM-only, so keep these items
-			// gated to System Managers; the dialog itself falls back to "general"
-			// if a non-SM ever reaches a gated section.
-			...(!!window.is_system_manager
-				? [
-						{ label: "Account", icon: "user", onClick: () => store.openSettings("plan") },
-						{ label: "Monitor", icon: "activity", onClick: () => store.openSettings("billing") },
-					]
-				: []),
 			{
 				label: "Switch to Desk",
 				icon: "grid",


### PR DESCRIPTION
## What

Removes the `Account` and `Monitor` entries from the sidebar user menu.

## Why

Since the unified settings dialog (#241) landed, both items just called `store.openSettings("plan")` / `store.openSettings("billing")` — the same dialog that `Settings` already opens. The dialog's own left rail (**Account & billing** group) is the single place those panes are reached from, so the menu was duplicating navigation and hoisting the System-Manager-only grouping up into the top-level menu.

Menu is now: **Settings · Switch to Desk · Toggle theme · Log out** — which is exactly what the component's own header comment already claimed it was.

## Notes

- `store.openSettings()` with no arg falls back to the `general` section, so the remaining `Settings` item is unaffected.
- `window.is_system_manager` is no longer read in this component; gating still lives in `SettingsDialog.vue` (rail group + `GATED` fallback) and on the server endpoints.
- No other call sites reference the removed items (`grep openSettings(` → only `shell.js` definition + this one caller).

## Verification

- `vite build` green.
- Grep sweep for stray `Account` / `Monitor` menu labels across `components/`, `router/`, `views/` → none.

First step of a broader settings-dialog UX + backend pass.