### PR TITLE
fix(oauth): don't let an ambiguous admin reply crash the hourly poll

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -582,13 +582,17 @@ def post_llm_auth_status() -> dict:
 	profile."
 
 	Returns:
-	    Same shape as the admin endpoint:
-	    {"ok": True,
-	     "data": {"auth_profile_present": bool,
-	              "profile_ids": [...],
-	              "default_model": str,
-	              "openai_profile_expires_ms": int | None}}
+	    ``_post`` already unwraps the admin's ``data`` envelope, so this is
+	    the inner dict itself (not ``{"ok": ..., "data": ...}``):
+	    {"auth_profile_present": bool,
+	     "profile_ids": [...],
+	     "default_model": str,
+	     "openai_profile_expires_ms": int | None}
 	    Never includes token material.
+
+	    ``auth_profile_present`` is provider-aware: admin recomputes it from
+	    the tenant's llm_provider rather than trusting the fleet-agent's
+	    OpenAI-only flag.
 
 	Raises AdminAuthError / AdminUnreachableError / AdminValidationError
 	in the same shape as the other admin_client methods.

--- a/jarvis/oauth/cron.py
+++ b/jarvis/oauth/cron.py
@@ -68,6 +68,17 @@ def poll_oauth_refresh_status() -> None:
 			message=frappe.get_traceback(),
 		)
 		return
+	except admin_client.AdminValidationError as e:
+		# Admin answered, but can't tell us anything authoritative: the 409
+		# NoRunningTenant case (container mid-restart after a creds/skills
+		# push, or a lapsed subscription). Ambiguous by the same argument as
+		# AdminUnreachableError above - a stopped container hasn't "lost" its
+		# profile - so log and skip rather than flipping to oauth_expired.
+		# Left uncaught this raised out of the scheduled job every hour.
+		frappe.logger().info(
+			"oauth_refresh_poll: admin could not report status; skipping (%s)", e,
+		)
+		return
 	except admin_client.AdminRateLimitedError as e:
 		retry = e.retry_after_seconds or 0
 		frappe.logger().info(

--- a/jarvis/tests/test_oauth_refresh_poll.py
+++ b/jarvis/tests/test_oauth_refresh_poll.py
@@ -127,3 +127,18 @@ class TestOauthRefreshPoll(_PollTestCase):
 		# Unchanged.
 		self.assertEqual(s.last_sync_status, "ok (restart via admin)")
 		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")
+
+	def test_admin_validation_error_skips_without_flip_and_does_not_raise(self):
+		"""409 NoRunningTenant (container mid-restart, lapsed subscription)
+		arrives as AdminValidationError. It is ambiguous for the same reason
+		AdminUnreachableError is - a stopped container hasn't lost its profile
+		- so it must not flip. It also must not escape: uncaught, it raised out
+		of the hourly scheduled job."""
+		from jarvis.exceptions import AdminValidationError
+		with patch("jarvis.admin_client.post_llm_auth_status",
+		           side_effect=AdminValidationError("NoRunningTenant")):
+			poll_oauth_refresh_status()  # must not raise
+		s = frappe.get_single("Jarvis Settings")
+		# Unchanged.
+		self.assertEqual(s.last_sync_status, "ok (restart via admin)")
+		self.assertEqual(s.llm_oauth_account_email, "connected@example.com")


### PR DESCRIPTION
## Why now

This is a latent bug that **jarvis-admin#222 activates**. Land that PR without this one and the hourly `poll_oauth_refresh_status` job starts throwing.

`jarvis/oauth/cron.py` catches `AdminUnreachableError`, `AdminAuthError` and `AdminRateLimitedError`. It does not catch `AdminValidationError` — and all four are *independent* siblings of `JarvisError` (`jarvis/exceptions.py:97-126`), so nothing else absorbs it.

Today `jarvis_admin.api.tenant.llm_auth_status` doesn't exist, so the call 404s into `AdminUnreachableError`, which **is** caught. The hole is invisible. Once admin implements the endpoint, a `409 NoRunningTenant` (container mid-restart after a creds/skills push, or a lapsed subscription) becomes `AdminValidationError` and raises straight out of the scheduled job, once an hour, into Error Log.

The 409 → `AdminValidationError` mapping is pinned by an existing test: `jarvis/tests/test_admin_client.py:258-270` (`test_409_with_envelope_raises_validation_error`).

## What

Catch it, and **skip without flipping state**. A 409 is ambiguous for exactly the reason this module's own docstring already gives for `AdminUnreachableError`:

> Failure modes are noisy on purpose: an AdminUnreachableError is logged but does NOT flip the status (we can't tell the difference between "container forgot the profile" and "we can't reach the container"). **Only an authoritative `auth_profile_present == False` flips state.**

A stopped container has not lost its profile. Flipping would write `last_sync_status="oauth_expired"` and clear `llm_oauth_account_email` — a spurious force-disconnect.

Also corrects `post_llm_auth_status`'s docstring, which promised the wrapped `{"ok", "data"}` envelope. `_post` already unwraps it (`admin_client.py:1023` → `envelope.get("data", envelope)`), which is why both callers defensively do `raw.get("data", raw)`. Harmless, but misleading.

## Verification

Run locally against `site.jarvis`:

- `jarvis.tests.test_oauth_refresh_poll` — **8/8 pass**, including the new `test_admin_validation_error_skips_without_flip_and_does_not_raise`.
- Red/green confirmed: with the new `except` clause deleted, that test — and only that test — fails, with `jarvis.exceptions.AdminValidationError: NoRunningTenant` propagating out of `poll_oauth_refresh_status()`. It asserts both that state is unchanged and that the call does not raise.
- `jarvis.tests.test_admin_client` — **51/51 pass** (covers the docstring'd function's error mapping).

The new test mirrors the three existing sibling tests: `test_admin_unreachable_does_not_false_flip`, `test_admin_auth_error_writes_distinct_status`, `test_admin_rate_limited_skips_without_flip`.

## Merge order

Merge this **before** jarvis-admin#222, or together. This PR is safe on its own (it only adds a catch); #222 alone is not.