### PR TITLE
feat: batch-create missing dependencies (resolve_links + create_docs)

### DIFF
--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -34,3 +34,18 @@ export function summarize(model, action = {}) {
   }
   return { kind: "create", headline, rows: proposedFields(action), tables }
 }
+
+// A create_docs batch parks one card. Its dry-run preview carries the created
+// records ({doctype, name}) and the model's reuse notes. Turn that into the flat
+// action lines the pending card renders as bullets. Pure; returns null when the
+// preview is not a batch (a single-doc dry-run, or a described-intent card).
+export function batchFromPreview(preview) {
+  const would = preview && preview.would
+  if (!would || typeof would !== "object" || !Array.isArray(would.created)) return null
+  return {
+    actions: would.created.map((d) => ({ doctype: d.doctype, name: d.name })),
+    notes: Array.isArray(would.notes)
+      ? would.notes.filter((n) => String(n ?? "").trim() !== "")
+      : [],
+  }
+}

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -1,7 +1,7 @@
 // frontend/src/lib/actionSummary.test.js
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { proposedFields, changedFields, lineItemSummary, summarize } from "./actionSummary.js"
+import { proposedFields, changedFields, lineItemSummary, summarize, batchFromPreview } from "./actionSummary.js"
 
 const createAction = {
   kind: "doc", verb: "create", doctype: "Sales Order", summary: "Sales Order - Acme, 2 items, total 1,100",
@@ -94,4 +94,24 @@ test("summarize(update): kind=update, mechanical diff, headline optional", () =>
   assert.equal(out.kind, "update")
   assert.equal(out.headline, "Closing SO-0001")
   assert.deepEqual(out.diff, [{ label: "Status", from: "Open", to: "Closed" }])
+})
+
+test("batchFromPreview: created records -> action lines, notes filtered", () => {
+  const out = batchFromPreview({
+    would: {
+      created: [{ doctype: "Item", name: "Widget" }, { doctype: "Customer", name: "Acme" }],
+      notes: ["Reuse existing Supplier 'Globex' for your 'Globe'", ""],
+    },
+  })
+  assert.deepEqual(out.actions, [
+    { doctype: "Item", name: "Widget" },
+    { doctype: "Customer", name: "Acme" },
+  ])
+  assert.deepEqual(out.notes, ["Reuse existing Supplier 'Globex' for your 'Globe'"])
+})
+
+test("batchFromPreview: non-batch or empty preview -> null", () => {
+  assert.equal(batchFromPreview({ would: "SomeDocName" }), null)
+  assert.equal(batchFromPreview({ described: true }), null)
+  assert.equal(batchFromPreview(null), null)
 })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -386,7 +386,15 @@
 						<div class="jv-pending-body">
 							<div v-if="pendingSummaryOf(pa)" class="jv-pending-summary">{{ pendingSummaryOf(pa) }}</div>
 							<div v-if="pendingNoteOf(pa)" class="jv-pending-note">{{ pendingNoteOf(pa) }}</div>
-							<pre v-if="pendingPreviewOf(pa)" class="jv-pending-preview">{{ pendingPreviewOf(pa) }}</pre>
+							<ul v-if="pendingBatchOf(pa)" class="jv-pending-batch">
+								<li v-for="(a, i) in pendingBatchOf(pa).actions" :key="'a' + i">
+									Create <b>{{ a.doctype }}</b> "{{ a.name }}"
+								</li>
+								<li v-for="(n, i) in pendingBatchOf(pa).notes" :key="'n' + i" class="jv-pending-batch-note">
+									{{ n }}
+								</li>
+							</ul>
+							<pre v-else-if="pendingPreviewOf(pa)" class="jv-pending-preview">{{ pendingPreviewOf(pa) }}</pre>
 						</div>
 						<div v-if="pa.error" class="jv-draft-error" style="margin:0 14px 10px">{{ pa.error }}</div>
 						<div class="jv-action-foot">
@@ -718,7 +726,7 @@ import DraftPreview from "@/components/doc/DraftPreview.vue"
 import { useShellStore } from "@/stores/shell"
 import { useJarvisTheme } from "@/theme"
 import { displayName } from "@/lib/user"
-import { summarize } from "@/lib/actionSummary"
+import { summarize, batchFromPreview } from "@/lib/actionSummary"
 
 const session = inject("$session")
 const socket = inject("$socket")
@@ -2074,6 +2082,12 @@ function pendingPreviewOf(pa) {
 	const w = pv.would
 	if (w == null) return ""
 	return typeof w === "string" ? w : prettyJson(w)
+}
+// A create_docs card renders as bullet lines (creates + reuse notes) rather than
+// a raw JSON dump. Returns null for every other tool, so the <pre> fallback runs.
+function pendingBatchOf(pa) {
+	if (!pa || pa.tool !== "create_docs") return null
+	return batchFromPreview(pa.preview)
 }
 // Drop one card from the queue by its token (confirm-success / discard / expiry).
 function removePending(token) {
@@ -4293,6 +4307,9 @@ onUnmounted(() => {
 .jv-pending-summary { font-size: 13.5px; line-height: 1.5; color: var(--text); }
 .jv-pending-note { font-size: 12px; line-height: 1.45; color: var(--text-3); }
 .jv-pending-preview { margin: 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; color: var(--text); white-space: pre-wrap; word-break: break-word; max-height: 260px; overflow-y: auto; }
+.jv-pending-batch { margin: 0 14px 8px; padding-left: 18px; font-size: 12.5px; color: var(--text-2); }
+.jv-pending-batch li { margin: 2px 0; }
+.jv-pending-batch-note { list-style: none; margin-left: -18px; color: var(--text-3); }
 .jv-action-primary:disabled, .jv-action-discard:disabled { opacity: .55; cursor: default; }
 /* rollout-window note shown for a legacy gated-write / email card whose own
    action button was removed (issue #186, #12/#13). */

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -413,7 +413,7 @@ def _parse_args(args: dict | str | None) -> dict:
 # Mutating tools: audited on every call, and the only tools that accept
 # ``preview`` (a dry-run with every DB write rolled back).
 _WRITE_TOOLS = frozenset({
-	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
+	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
 	"delete_doc", "run_method",
 	"send_email", "add_comment", "update_comment", "share_doc", "unshare_doc",
 	"assign_to", "unassign_from", "add_tag", "remove_tag",
@@ -429,7 +429,7 @@ _PREVIEWABLE = frozenset({
 # The lighter mutators in _WRITE_TOOLS (comments/tags/share/assign/attach/
 # dashboard-create) are intentionally NOT gated - they never fire the card.
 _GATED_WRITES = frozenset({
-	"create_doc", "update_doc", "submit_doc", "cancel_doc",
+	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc",
 	"amend_doc", "delete_doc", "run_method", "send_email",
 	"create_custom_skill", "update_wiki",
 })
@@ -454,7 +454,12 @@ _AUTO_APPLYABLE = frozenset({"create_doc", "update_doc"})
 # integrity) and dry-running them fires on_submit/on_cancel hooks - extending the
 # block to them is a separate, larger change. run_method is never sandbox-run at
 # park at all (its target's inline non-DB side effects would fire unconfirmed).
-_DRY_RUN_ON_PARK = frozenset({"create_doc", "update_doc"})
+#
+# create_docs joins the build-from-args creates: its whole batch is dry-run in
+# the sandbox at park, so a bad link / missing mandatory in ANY item bounces to
+# the model instead of a doomed card. Deliberately NOT in _AUTO_APPLYABLE - the
+# batch card is the human checkpoint against duplicate masters.
+_DRY_RUN_ON_PARK = frozenset({"create_doc", "create_docs", "update_doc"})
 
 
 def _as_bool(value) -> bool:

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -422,8 +422,8 @@ _WRITE_TOOLS = frozenset({
 	"create_custom_skill", "update_wiki",
 })
 _PREVIEWABLE = frozenset({
-	"create_doc", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
-	"delete_doc", "run_method",
+	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc",
+	"amend_doc", "delete_doc", "run_method",
 })
 # Writes that MUST get a human confirmation before executing (issue #186).
 # The lighter mutators in _WRITE_TOOLS (comments/tags/share/assign/attach/

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -581,3 +581,55 @@ class TestListPendingConfirmations(FrappeTestCase):
 				list_pending_confirmations()
 		finally:
 			frappe.set_user(original)
+
+
+class TestCreateDocsGate(FrappeTestCase):
+	def test_create_docs_parks_one_card_and_dry_runs_batch(self):
+		patcher, captured = _spy_mint()
+		with patcher:
+			r = api._run_tool(
+				"create_docs",
+				{
+					"docs": [
+						{"doctype": "ToDo", "values": {"description": "jarvis-gate-a"}},
+						{"doctype": "ToDo", "values": {"description": "jarvis-gate-b"}},
+					]
+				},
+			)
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertEqual(r["data"]["tool"], "create_docs")
+		# The dry-run preview lists both creates; nothing was committed.
+		would = r["data"]["preview"]["would"]
+		self.assertEqual(len(would["created"]), 2)
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-gate-a"}))
+		# Exactly one token for the whole batch.
+		self.assertIsNotNone(pending_confirm.peek(captured["token"]))
+		self.assertNotIn(captured["token"], frappe.as_json(r))
+
+	def test_create_docs_is_gated_but_not_auto_applyable(self):
+		# Locked decision: masters are never created without the batch card, so
+		# create_docs never fast-paths under auto_apply / file_box.
+		self.assertIn("create_docs", api._GATED_WRITES)
+		self.assertNotIn("create_docs", api._AUTO_APPLYABLE)
+
+	def test_create_docs_bad_batch_bounces_at_park(self):
+		# A deterministic failure (bad link on the 2nd doc) returns an error to
+		# the model instead of parking a doomed card.
+		r = api._run_tool(
+			"create_docs",
+			{
+				"docs": [
+					{"doctype": "ToDo", "values": {"description": "jarvis-gate-ok"}},
+					{
+						"doctype": "ToDo",
+						"values": {
+							"description": "jarvis-gate-bad",
+							"assigned_by": "no-such-user@invalid.example",
+						},
+					},
+				]
+			},
+		)
+		self.assertFalse(r["ok"])
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-gate-ok"}))

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -633,3 +633,45 @@ class TestCreateDocsGate(FrappeTestCase):
 		)
 		self.assertFalse(r["ok"])
 		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-gate-ok"}))
+
+	def test_create_docs_resync_preview_is_dry_run_not_described(self):
+		# Regression: the LIVE park path (_run_tool) builds the batch preview
+		# via _DRY_RUN_ON_PARK's direct _run_preview call, so it always worked.
+		# But the RESYNC path (list_pending_confirmations, hit on every
+		# conversation load / socket reconnect) rebuilds the preview via
+		# api._pending_preview, which routes on _PREVIEWABLE membership alone.
+		# If create_docs is missing from _PREVIEWABLE, _pending_preview
+		# short-circuits to a described-intent dict with no ``would`` - the
+		# batch card renders blank after a reload and a human would confirm
+		# master creation blind.
+		from jarvis.chat.actions_api import list_pending_confirmations
+
+		patcher, captured = _spy_mint()
+		with patcher:
+			r = api._run_tool(
+				"create_docs",
+				{
+					"docs": [
+						{"doctype": "ToDo", "values": {"description": "jarvis-resync-a"}},
+						{"doctype": "ToDo", "values": {"description": "jarvis-resync-b"}},
+					]
+				},
+			)
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		token = captured["token"]
+
+		# Simulate a reload/reconnect: the resync endpoint rebuilds the card's
+		# preview independently of the original park-time preview.
+		resynced = list_pending_confirmations()
+		items = [i for i in resynced["data"]["pending"] if i["token"] == token]
+		self.assertEqual(len(items), 1)
+		preview = items[0]["preview"]
+		self.assertTrue(
+			preview.get("preview"),
+			f"resync preview degraded to described-intent (blank batch card): {preview}",
+		)
+		self.assertNotIn("described", preview)
+		would = preview.get("would") or {}
+		self.assertEqual(len(would.get("created", [])), 2)
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-resync-a"}))

--- a/jarvis/tests/test_create_docs.py
+++ b/jarvis/tests/test_create_docs.py
@@ -1,0 +1,59 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.create_docs import create_docs
+
+
+class TestCreateDocs(FrappeTestCase):
+	def test_creates_all_and_returns_lean_shape(self):
+		out = create_docs(
+			[
+				{"doctype": "ToDo", "values": {"description": "jarvis-batch-a"}},
+				{"doctype": "ToDo", "values": {"description": "jarvis-batch-b"}},
+			],
+			notes=["Reuse existing User 'Administrator'"],
+		)
+		self.assertEqual(len(out["created"]), 2)
+		self.assertEqual(out["created"][0]["doctype"], "ToDo")
+		self.assertTrue(out["created"][0]["name"])
+		self.assertEqual(out["notes"], ["Reuse existing User 'Administrator'"])
+		self.assertTrue(frappe.db.exists("ToDo", {"description": "jarvis-batch-a"}))
+		self.assertTrue(frappe.db.exists("ToDo", {"description": "jarvis-batch-b"}))
+
+	def test_rolls_back_whole_batch_on_failure(self):
+		# Second doc has a bad Link (assigned_by -> a non-existent User), which
+		# fails at insert AFTER the first doc inserted. The savepoint must undo it.
+		with self.assertRaises(Exception):
+			create_docs(
+				[
+					{"doctype": "ToDo", "values": {"description": "jarvis-batch-ok"}},
+					{
+						"doctype": "ToDo",
+						"values": {
+							"description": "jarvis-batch-bad",
+							"assigned_by": "no-such-user@invalid.example",
+						},
+					},
+				]
+			)
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-batch-ok"}))
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-batch-bad"}))
+
+	def test_empty_list_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_docs([])
+
+	def test_item_missing_values_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_docs([{"doctype": "ToDo"}])
+
+	def test_protected_field_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			create_docs(
+				[{"doctype": "ToDo", "values": {"description": "x", "owner": "a@b.c"}}]
+			)
+
+	def test_notes_default_empty(self):
+		out = create_docs([{"doctype": "ToDo", "values": {"description": "jarvis-batch-n"}}])
+		self.assertEqual(out["notes"], [])

--- a/jarvis/tests/test_create_docs.py
+++ b/jarvis/tests/test_create_docs.py
@@ -57,3 +57,30 @@ class TestCreateDocs(FrappeTestCase):
 	def test_notes_default_empty(self):
 		out = create_docs([{"doctype": "ToDo", "values": {"description": "jarvis-batch-n"}}])
 		self.assertEqual(out["notes"], [])
+
+	def test_failed_batch_leaves_no_queued_side_effects(self):
+		# frappe.db.rollback(save_point=...) rolls back the rows but does NOT
+		# clear the commit/rollback callback queues. Without the fix, the first
+		# (successfully-inserted-then-rolled-back) doc's queued after_commit
+		# callbacks survive and would fire on the request's real commit.
+		before = len(frappe.db.after_commit._functions)
+		with self.assertRaises(Exception):
+			create_docs(
+				[
+					{"doctype": "ToDo", "values": {"description": "jarvis-batch-cbq-ok"}},
+					{
+						"doctype": "ToDo",
+						"values": {
+							"description": "jarvis-batch-cbq-bad",
+							"assigned_by": "no-such-user@invalid.example",
+						},
+					},
+				]
+			)
+		self.assertEqual(len(frappe.db.after_commit._functions), before)
+		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-batch-cbq-ok"}))
+
+	def test_batch_cap_rejected(self):
+		docs = [{"doctype": "ToDo", "values": {"description": f"jarvis-batch-cap-{i}"}} for i in range(21)]
+		with self.assertRaises(InvalidArgumentError):
+			create_docs(docs)

--- a/jarvis/tests/test_resolve_links.py
+++ b/jarvis/tests/test_resolve_links.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.resolve_links import resolve_links
+
+
+class TestResolveLinks(FrappeTestCase):
+	"""ToDo (header Link fields: role -> Role, allocated_to -> User) and User
+	(child table roles -> Has Role.role -> Role) are core doctypes, so no
+	ERPNext fixtures are needed."""
+
+	def _link(self, res, field, row=None):
+		for lk in res["links"]:
+			if lk["field"] == field and lk.get("row") == row:
+				return lk
+		return None
+
+	def test_exact_header_link(self):
+		res = resolve_links("ToDo", {"allocated_to": "Administrator"})
+		lk = self._link(res, "allocated_to")
+		self.assertEqual(lk["status"], "exact")
+		self.assertEqual(lk["target_doctype"], "User")
+
+	def test_missing_header_link(self):
+		res = resolve_links("ToDo", {"allocated_to": "ghost-not-a-user@invalid.example"})
+		lk = self._link(res, "allocated_to")
+		self.assertEqual(lk["status"], "missing")
+		self.assertEqual(lk["candidates"], [])
+
+	def test_candidates_header_link(self):
+		# "System" is not a Role, but "System Manager" like-matches it.
+		res = resolve_links("ToDo", {"role": "System"})
+		lk = self._link(res, "role")
+		self.assertEqual(lk["status"], "candidates")
+		self.assertIn("System Manager", [c["name"] for c in lk["candidates"]])
+
+	def test_child_row_links(self):
+		res = resolve_links(
+			"User",
+			{"roles": [{"role": "System Manager"}, {"role": "No Such Role XYZ"}]},
+		)
+		row0 = self._link(res, "role", row=0)
+		row1 = self._link(res, "role", row=1)
+		self.assertEqual(row0["table"], "roles")
+		self.assertEqual(row0["status"], "exact")
+		self.assertEqual(row1["status"], "missing")
+
+	def test_unchecked_when_no_read_permission(self):
+		with patch(
+			"jarvis.tools.resolve_links.frappe.has_permission", return_value=False
+		):
+			res = resolve_links("ToDo", {"allocated_to": "Administrator"})
+		self.assertEqual(self._link(res, "allocated_to")["status"], "unchecked")
+
+	def test_empty_values_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			resolve_links("ToDo", {})
+
+	def test_unknown_doctype_rejected(self):
+		with self.assertRaises(InvalidArgumentError):
+			resolve_links("No Such Doctype 999", {"x": "y"})

--- a/jarvis/tests/test_resolve_links.py
+++ b/jarvis/tests/test_resolve_links.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.exceptions import InvalidArgumentError
-from jarvis.tools.resolve_links import resolve_links
+from jarvis.tools.resolve_links import _resolve_one, resolve_links
 
 
 class TestResolveLinks(FrappeTestCase):
@@ -54,6 +54,45 @@ class TestResolveLinks(FrappeTestCase):
 		):
 			res = resolve_links("ToDo", {"allocated_to": "Administrator"})
 		self.assertEqual(self._link(res, "allocated_to")["status"], "unchecked")
+
+	def test_exact_check_is_permission_scoped(self):
+		"""A record that exists but is not readable by the caller (ToDo is
+		read-scoped to allocated_to/assigned_by via get_permission_query_conditions)
+		must not be reported "exact", even though the coarse doctype-level read
+		gate passes for the "All" role. Otherwise the exact check becomes an
+		existence oracle over records the user cannot read."""
+		other_todo = frappe.get_doc(
+			{
+				"doctype": "ToDo",
+				"description": "resolve_links permission-scope probe",
+				"allocated_to": "Administrator",
+			}
+		).insert(ignore_permissions=True)
+
+		uname = "resolve_links_perm_test@example.com"
+		if not frappe.db.exists("User", uname):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": uname,
+					"first_name": "PermTest",
+					"send_welcome_email": 0,
+					"roles": [{"role": "Desk User"}],
+				}
+			).insert(ignore_permissions=True)
+
+		orig_user = frappe.session.user
+		try:
+			frappe.set_user(uname)
+			# Sanity: the coarse doctype-level gate passes (role "All" grants
+			# read on ToDo) -- the leak can only be caught downstream, by the
+			# exact-check query itself being permission-scoped.
+			self.assertTrue(frappe.has_permission("ToDo", ptype="read"))
+			rec = _resolve_one("allocated_to", "ToDo", other_todo.name, 5)
+		finally:
+			frappe.set_user(orig_user)
+
+		self.assertNotEqual(rec["status"], "exact")
 
 	def test_empty_values_rejected(self):
 		with self.assertRaises(InvalidArgumentError):

--- a/jarvis/tools/create_docs.py
+++ b/jarvis/tools/create_docs.py
@@ -1,0 +1,59 @@
+"""Create several documents in one confirmed, atomic batch.
+
+Sibling of create_doc for the case where a create needs its dependencies made
+first (a new Customer + a new Item before the Sales Invoice that links them).
+The agent gathers the missing masters (resolve_links + get_creation_context) and
+submits them here as ONE list, so the user confirms the whole set with a single
+gated card instead of one per record. All inserts run in one transaction guarded
+by a savepoint: if any fails, the whole batch rolls back (the caller catches the
+error and would otherwise commit the partial inserts). Order matters — put a
+dependency before the doc that links it.
+"""
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools.create_doc import _set_title_from_title_field, _validate_create_args
+
+_MAX_BATCH = 20
+_SAVEPOINT = "jarvis_create_docs"
+
+
+def create_docs(docs: list, notes: list | None = None) -> dict:
+	"""Insert every ``{"doctype", "values"}`` in ``docs`` atomically.
+
+	Returns ``{"created": [{"doctype", "name"}, ...], "notes": [...]}`` — a lean
+	shape (no full doc dump, so no permlevel>0 field leaks). ``notes`` are
+	display-only lines echoed back for the confirmation card.
+	"""
+	if not isinstance(docs, list) or not docs:
+		raise InvalidArgumentError(
+			"docs must be a non-empty list of {doctype, values}"
+		)
+	if len(docs) > _MAX_BATCH:
+		raise InvalidArgumentError(f"too many docs in one batch (max {_MAX_BATCH})")
+	for i, item in enumerate(docs):
+		if not isinstance(item, dict):
+			raise InvalidArgumentError(f"docs[{i}] must be a dict with doctype + values")
+		values = item.get("values")
+		# Reuse create_doc's guards: non-empty values, no protected fields,
+		# per-doctype create permission. Raises InvalidArgumentError /
+		# PermissionDeniedError exactly as a single create would.
+		_validate_create_args(item.get("doctype"), values if isinstance(values, dict) else {})
+
+	created = []
+	frappe.db.savepoint(_SAVEPOINT)
+	try:
+		for item in docs:
+			doc = frappe.new_doc(item["doctype"])
+			for field, value in item["values"].items():
+				doc.set(field, value)
+			_set_title_from_title_field(doc)
+			doc.insert()  # links to earlier docs in this batch resolve (same txn)
+			created.append({"doctype": doc.doctype, "name": doc.name})
+	except Exception:
+		# The caller (_dispatch_and_wrap / dispatch_confirmed) catches and would
+		# commit at request end, so undo the partial batch here.
+		frappe.db.rollback(save_point=_SAVEPOINT)
+		raise
+	return {"created": created, "notes": list(notes) if isinstance(notes, list) else []}

--- a/jarvis/tools/create_docs.py
+++ b/jarvis/tools/create_docs.py
@@ -10,13 +10,14 @@ error and would otherwise commit the partial inserts). Order matters — put a
 dependency before the doc that links it.
 """
 
+from collections import deque
+
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools.create_doc import _set_title_from_title_field, _validate_create_args
 
 _MAX_BATCH = 20
-_SAVEPOINT = "jarvis_create_docs"
 
 
 def create_docs(docs: list, notes: list | None = None) -> dict:
@@ -42,7 +43,19 @@ def create_docs(docs: list, notes: list | None = None) -> dict:
 		_validate_create_args(item.get("doctype"), values if isinstance(values, dict) else {})
 
 	created = []
-	frappe.db.savepoint(_SAVEPOINT)
+	sp = "jcd_" + frappe.generate_hash(length=10)
+	# frappe.db.rollback(save_point=...) only issues ROLLBACK TO SAVEPOINT — it
+	# does not clear the before/after-commit or after-rollback callback queues.
+	# So on failure, callbacks queued by the docs that got inserted-then-rolled-
+	# back would otherwise survive and fire on the request's real commit. Snapshot
+	# here and restore only on failure; on success the queues are left alone so
+	# the (real, kept) docs' callbacks fire normally.
+	saved_queues = {
+		name: tuple(getattr(frappe.db, name)._functions)
+		for name in ("before_commit", "after_commit", "after_rollback")
+		if hasattr(frappe.db, name)
+	}
+	frappe.db.savepoint(sp)
 	try:
 		for item in docs:
 			doc = frappe.new_doc(item["doctype"])
@@ -54,6 +67,8 @@ def create_docs(docs: list, notes: list | None = None) -> dict:
 	except Exception:
 		# The caller (_dispatch_and_wrap / dispatch_confirmed) catches and would
 		# commit at request end, so undo the partial batch here.
-		frappe.db.rollback(save_point=_SAVEPOINT)
+		frappe.db.rollback(save_point=sp)
+		for name, functions in saved_queues.items():
+			getattr(frappe.db, name)._functions = deque(functions)
 		raise
 	return {"created": created, "notes": list(notes) if isinstance(notes, list) else []}

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -38,6 +38,8 @@ _TOOL_NAMES: tuple[str, ...] = (
     "query",
     "update_doc",
     "create_doc",
+    # Batch, atomic create for a doc's missing dependencies (one gated card).
+    "create_docs",
     "preview_doc",
     "submit_doc",
     "cancel_doc",

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -29,6 +29,9 @@ _TOOL_NAMES: tuple[str, ...] = (
     # decides field values from real examples instead of interrogating the
     # user. Read-only; picks no values. See jarvis-persona AGENTS.md.
     "get_creation_context",
+    # Link-resolution for the create flow: which referenced records exist,
+    # which have near-matches to reuse, which are missing (feed create_docs).
+    "resolve_links",
     "run_report",
     "get_report_filters",
     "run_method",

--- a/jarvis/tools/resolve_links.py
+++ b/jarvis/tools/resolve_links.py
@@ -91,7 +91,12 @@ def _resolve_one(field: str, target_dt: str, value: str, limit: int) -> dict:
 		rec["status"] = "unchecked"
 		return rec
 	try:
-		if frappe.db.exists(target_dt, value):
+		# frappe.db.exists is permission-unaware; it would confirm existence of
+		# records the user cannot actually read (if_owner / user-permission
+		# restricted doctypes). Use get_list, like _candidates, so an existing
+		# but unreadable record falls through to candidates/missing instead of
+		# leaking as "exact".
+		if frappe.get_list(target_dt, filters={"name": value}, limit=1):
 			rec["status"] = "exact"
 			return rec
 	except Exception:

--- a/jarvis/tools/resolve_links.py
+++ b/jarvis/tools/resolve_links.py
@@ -1,0 +1,145 @@
+"""Resolve the Link-field values of a doc you are about to create.
+
+Before a create, the agent calls this with the intended values (header fields
+AND child-table rows). For every Link field carrying a value it reports whether
+that value already exists (``exact``), has near-matches worth reusing
+(``candidates``), is genuinely absent (``missing``), or cannot be checked
+because the user lacks read on the target (``unchecked``). It only searches; the
+agent decides whether a candidate is really the same entity and creates the
+``missing`` ones (batched via create_docs). See jarvis-persona AGENTS.md.
+"""
+
+import frappe
+
+from jarvis.exceptions import InvalidArgumentError
+
+_MAX_LIMIT = 20
+
+
+def resolve_links(doctype: str, values: dict, limit: int = 5) -> dict:
+	"""Report the resolution status of every Link value in ``values``.
+
+	``values`` mirrors what will be passed to create_doc, including child-table
+	lists (``{"customer": "Acme", "items": [{"item_code": "Widget"}]}``). Decides
+	nothing — the agent reuses/creates from the statuses.
+	"""
+	if not doctype:
+		raise InvalidArgumentError("doctype is required")
+	if not frappe.db.exists("DocType", doctype):
+		raise InvalidArgumentError(f"unknown doctype: {doctype}")
+	if not isinstance(values, dict) or not values:
+		raise InvalidArgumentError("values must be a non-empty dict")
+	if limit <= 0 or limit > _MAX_LIMIT:
+		raise InvalidArgumentError(f"limit must be between 1 and {_MAX_LIMIT}")
+
+	meta = frappe.get_meta(doctype)
+	links: list = []
+
+	for df in meta.fields:
+		if df.fieldtype != "Link" or not df.options:
+			continue
+		for v in _iter_values(values.get(df.fieldname)):
+			links.append(_resolve_one(df.fieldname, df.options, v, limit))
+
+	for df in meta.fields:
+		if df.fieldtype != "Table" or not df.options:
+			continue
+		rows = values.get(df.fieldname)
+		if not isinstance(rows, list):
+			continue
+		child_meta = frappe.get_meta(df.options)
+		child_links = [
+			c for c in child_meta.fields if c.fieldtype == "Link" and c.options
+		]
+		for idx, row in enumerate(rows):
+			if not isinstance(row, dict):
+				continue
+			for c in child_links:
+				for v in _iter_values(row.get(c.fieldname)):
+					rec = _resolve_one(c.fieldname, c.options, v, limit)
+					rec["table"] = df.fieldname
+					rec["row"] = idx
+					links.append(rec)
+
+	return {"doctype": doctype, "links": links, "note": _summary_note(links)}
+
+
+def _iter_values(val):
+	"""Yield each non-empty scalar link value (a link field may hold one value,
+	or a list for table-multiselect)."""
+	if val in (None, ""):
+		return
+	if isinstance(val, (list, tuple, set)):
+		for v in val:
+			if isinstance(v, str) and v.strip():
+				yield v
+		return
+	if isinstance(val, str) and val.strip():
+		yield val
+
+
+def _resolve_one(field: str, target_dt: str, value: str, limit: int) -> dict:
+	rec = {
+		"field": field,
+		"target_doctype": target_dt,
+		"value": value,
+		"status": "missing",
+		"candidates": [],
+	}
+	# Don't turn this into an existence oracle over doctypes the user can't read.
+	if not frappe.has_permission(target_dt, ptype="read"):
+		rec["status"] = "unchecked"
+		return rec
+	try:
+		if frappe.db.exists(target_dt, value):
+			rec["status"] = "exact"
+			return rec
+	except Exception:
+		rec["status"] = "unchecked"
+		return rec
+	rec["candidates"] = _candidates(target_dt, value, limit)
+	if rec["candidates"]:
+		rec["status"] = "candidates"
+	return rec
+
+
+def _candidates(target_dt: str, value: str, limit: int) -> list:
+	"""Permission-safe near-match search on name + title_field. get_list (never
+	get_all) so row-level perms + permlevel are respected."""
+	meta = frappe.get_meta(target_dt)
+	title_field = meta.get("title_field")
+	has_title = bool(title_field) and title_field != "name"
+	fields = ["name"] + ([title_field] if has_title else [])
+	or_filters = [["name", "like", f"%{value}%"]]
+	if has_title:
+		or_filters.append([title_field, "like", f"%{value}%"])
+	try:
+		rows = frappe.get_list(
+			target_dt,
+			or_filters=or_filters,
+			fields=fields,
+			limit=limit,
+			order_by="modified desc",
+		)
+	except Exception:
+		return []
+	out = []
+	for r in rows:
+		entry = {"name": r.get("name")}
+		if has_title and r.get(title_field):
+			entry["title"] = r.get(title_field)
+		out.append(entry)
+	return out
+
+
+def _summary_note(links: list) -> str:
+	missing = [lk for lk in links if lk["status"] == "missing"]
+	cand = [lk for lk in links if lk["status"] == "candidates"]
+	parts = []
+	if missing:
+		parts.append(f"{len(missing)} missing (create these)")
+	if cand:
+		parts.append(f"{len(cand)} with near-matches (reuse or create)")
+	if not parts:
+		return "all links resolved to existing records"
+	return "; ".join(parts)


### PR DESCRIPTION
## Summary
Branch-2 of the infer-don't-interrogate create flow: when a create references a record that doesn't exist yet, Jarvis reuses a near-match or creates every genuinely-missing dependency as **one confirmed, atomic batch** — instead of interrogating the user field-by-field.

- **`resolve_links`** (read-only): per Link value in an intended doc (header **and** child rows), reports `exact` / `candidates` / `missing` / `unchecked`. Permission-scoped via `get_list` (no existence-oracle leak).
- **`create_docs`** (gated write): atomic batch insert behind **one** confirmation card; deliberately **not** `_AUTO_APPLYABLE` (the batch card is the human checkpoint against duplicate masters). On failure, rolls back rows **and** restores the commit/rollback callback queues so a rolled-back doc's side effects never fire.
- **Gate wiring**: parks one card, dry-runs the whole batch at park time; also in `_PREVIEWABLE` so the resync path renders the batch (not a blind confirm).
- **Frontend**: a bullet-list batch confirm card (creates + reuse notes) on the existing pending-action stack.

## Coordinated rollout (this PR is inert until both land)
- Plugin descriptors: Aerele-RnD/jarvis-openclaw-plugin#50 (when the model can call the tools; needs container redeploy).
- Persona branch-2 flow: Aerele-RnD/jarvis-persona#142 (teaches the flow; ships via persona update).

## Review
Built subagent-driven (TDD per task, review + adversarial verify per task, opus whole-branch final review). Findings fixed: resolve_links existence-oracle leak (permission-scoped exact check), create_docs callback-queue leak on rollback, and the `_PREVIEWABLE` resync-blank-card defect. Remaining items are deferred Minors.

## Test
`bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_resolve_links` (8), `test_create_docs` (8), `test_confirm_gate` (27, incl. resync-preview regression); `node --test frontend/src/lib/actionSummary.test.js` (10); `npm run build`. Regressions clean: `test_auto_apply` (20), `test_action_pending` (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)