### PR TITLE
ci: prebuilt base image (frappe+erpnext+hrms + seeded site DB) — 7m21s → ~3m15s

### DIFF
--- a/.github/docker/Dockerfile.ci-base
+++ b/.github/docker/Dockerfile.ci-base
@@ -6,7 +6,9 @@
 # with those three already installed. PR CI consumes this so it only has to install jarvis
 # itself (~2.5s) instead of rebuilding a 5-minute environment on every run.
 #
-# DRAFT — not yet executed. See PROPOSAL.md §4 for the gotchas this encodes.
+# Every non-obvious line below encodes a failure this image hit while being brought up: a missing
+# crontab binary, a missing redis, a passworded mysqladmin shutdown, /opt ownership, and 3.1 GB of
+# yarn/uv cache. Read the comments before "simplifying" any of them.
 
 ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-bookworm AS base
@@ -29,7 +31,7 @@ RUN set -eux; \
         redis-tools gettext cron; \
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
     apt-get install -y --no-install-recommends nodejs; \
-    npm install -g yarn; \
+    npm install -g yarn@1.22.22; \
     rm -rf /var/lib/apt/lists/*
 
 # Pinned to match what the current workflow resolves to (frappe-bench 5.31.0).
@@ -95,11 +97,19 @@ RUN apt-get update \
 # Shutdown is `mariadb-admin ... shutdown`, not `service mariadb stop`: the init script shells out
 # to a passwordless mysqladmin, which fails once a root password is set, and `set -e` would kill
 # the build on that last line — after the dump had already been written.
+#
+# The bare `mariadb-admin ping` after the retry loop is deliberate: on total failure the loop's
+# last command is `sleep 1`, which exits 0, so `set -e` would not catch it and the build would die
+# later at an unrelated line. The bare ping makes "mariadb never came up" fail where it happened.
+#
+# The `root@localhost` grant does serve TCP: MariaDB reverse-resolves 127.0.0.1 to localhost, so
+# `mariadb -h 127.0.0.1 -u root` matches it (verified: CURRENT_USER() returns root@localhost).
 RUN set -eux; \
     mkdir -p /opt/ci && chown ci:ci /opt/ci; \
     service mariadb start; \
     service redis-server start; \
     for i in $(seq 30); do mariadb-admin ping --silent && break || sleep 1; done; \
+    mariadb-admin ping --silent; \
     redis-cli ping; \
     mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'root'; FLUSH PRIVILEGES;"; \
     su ci -c 'cd /opt/frappe-bench && \

--- a/.github/docker/Dockerfile.ci-base
+++ b/.github/docker/Dockerfile.ci-base
@@ -1,0 +1,144 @@
+# syntax=docker/dockerfile:1
+#
+# ghcr.io/aerele-rnd/jarvis-ci-base:v16
+#
+# A pre-built Frappe bench (frappe + erpnext + hrms, version-16) plus a SQL dump of a site
+# with those three already installed. PR CI consumes this so it only has to install jarvis
+# itself (~2.5s) instead of rebuilding a 5-minute environment on every run.
+#
+# DRAFT — not yet executed. See PROPOSAL.md §4 for the gotchas this encodes.
+
+ARG PYTHON_VERSION=3.14
+FROM python:${PYTHON_VERSION}-bookworm AS base
+
+ARG FRAPPE_BRANCH=version-16
+ARG NODE_MAJOR=24
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+# `cron` provides /usr/bin/crontab. bench init shells out to it via python-crontab and dies with
+# FileNotFoundError without it. The GitHub runner image ships cron, which is why the current
+# from-scratch workflow never hit this.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git curl ca-certificates gnupg build-essential \
+        mariadb-client libmariadb-dev pkg-config \
+        redis-tools gettext cron; \
+    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -; \
+    apt-get install -y --no-install-recommends nodejs; \
+    npm install -g yarn; \
+    rm -rf /var/lib/apt/lists/*
+
+# Pinned to match what the current workflow resolves to (frappe-bench 5.31.0).
+RUN pip install --no-cache-dir "frappe-bench>=5.29,<6"
+
+# bench hard-exits as root (bench/cli.py -> change_uid). uid 1001 is the GitHub Actions
+# runner user that owns the job workspace, so `container.options: --user 1001` lines up.
+RUN useradd --create-home --uid 1001 --shell /bin/bash ci \
+ && mkdir -p /opt && chown ci:ci /opt
+USER ci
+WORKDIR /opt
+
+# bench init clones frappe, creates the venv, yarn-installs and runs a full esbuild pass.
+# All of that is paid once, here, instead of on every PR.
+#
+# The cache purge must happen inside this RUN: yarn + uv leave ~2 GB under ~/.cache, and deleting
+# it in a later layer would not reclaim the space — the bytes stay in this layer forever.
+RUN bench init \
+        --skip-redis-config-generation \
+        --frappe-branch "${FRAPPE_BRANCH}" \
+        --python "$(which python)" \
+        frappe-bench \
+ && yarn cache clean \
+ && rm -rf /home/ci/.cache
+
+WORKDIR /opt/frappe-bench
+
+# --skip-assets skips build_assets() but NOT `yarn install` (bench/app.py). We pay the yarn
+# cost once here and then delete the node_modules it produced — backend tests never read them.
+# frappe's own node_modules stay: `bench build` symlinks them into sites/assets.
+RUN set -eux; \
+    bench get-app --branch "${FRAPPE_BRANCH}" --skip-assets erpnext; \
+    bench get-app --branch "${FRAPPE_BRANCH}" --skip-assets hrms; \
+    rm -rf apps/erpnext/node_modules apps/erpnext/banking/node_modules \
+           apps/hrms/node_modules apps/hrms/frontend/node_modules apps/hrms/roster/node_modules; \
+    yarn cache clean; \
+    rm -rf /home/ci/.cache
+
+# coverage: frappe's --coverage flag imports it. gevent: jarvis/realtime/handlers.py.
+RUN ./env/bin/pip install --no-cache-dir coverage gevent
+
+# ---------------------------------------------------------------------------------------
+# seed stage: stand up a throwaway mariadb, install frappe+erpnext+hrms into a scratch site,
+# dump the result. mariadb-server never reaches the final image.
+# ---------------------------------------------------------------------------------------
+FROM base AS seed
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends mariadb-server redis-server \
+ && rm -rf /var/lib/apt/lists/*
+
+# `service mariadb start` + TCP root login after ALTER USER are both verified to work in a
+# bookworm container. bookworm ships mariadb 10.11.14 — same major as the `mariadb:10.11`
+# service image CI uses, so the dump restores cleanly.
+#
+# redis is required too: `bench new-site` writes to the cache, and `bench init
+# --skip-redis-config-generation` leaves the default ports (11000/13000) with nothing behind
+# them, so new-site dies with ConnectionError. Point bench at a plain local redis instead.
+# These config writes live only in this throwaway stage — the final image inherits `base`'s
+# common_site_config.json, and the consumer workflow sets its own hosts anyway.
+#
+# Shutdown is `mariadb-admin ... shutdown`, not `service mariadb stop`: the init script shells out
+# to a passwordless mysqladmin, which fails once a root password is set, and `set -e` would kill
+# the build on that last line — after the dump had already been written.
+RUN set -eux; \
+    mkdir -p /opt/ci && chown ci:ci /opt/ci; \
+    service mariadb start; \
+    service redis-server start; \
+    for i in $(seq 30); do mariadb-admin ping --silent && break || sleep 1; done; \
+    redis-cli ping; \
+    mariadb -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'root'; FLUSH PRIVILEGES;"; \
+    su ci -c 'cd /opt/frappe-bench && \
+        bench set-config -g db_host 127.0.0.1 && \
+        bench set-config -g redis_cache "redis://127.0.0.1:6379/0" && \
+        bench set-config -g redis_queue "redis://127.0.0.1:6379/1" && \
+        bench set-config -g redis_socketio "redis://127.0.0.1:6379/2" && \
+        bench new-site ci_seed \
+            --db-host 127.0.0.1 \
+            --mariadb-user-host-login-scope="%" \
+            --mariadb-root-password root \
+            --db-root-username root \
+            --admin-password admin \
+            --install-app erpnext \
+            --install-app hrms'; \
+    DB=$(python -c "import json;print(json.load(open('/opt/frappe-bench/sites/ci_seed/site_config.json'))['db_name'])"); \
+    mariadb-dump -h 127.0.0.1 -u root -proot \
+        --single-transaction --routines --triggers --no-tablespaces \
+        "$DB" > /opt/ci/test_site.sql; \
+    test -s /opt/ci/test_site.sql; \
+    su ci -c 'cd /opt/frappe-bench && rm -rf sites/ci_seed'; \
+    mariadb-admin -u root -proot shutdown; \
+    service redis-server stop
+
+# ---------------------------------------------------------------------------------------
+# final: bench + the dump, no mariadb-server, no erpnext/hrms node_modules
+# ---------------------------------------------------------------------------------------
+FROM base AS final
+
+COPY --from=seed --chown=ci:ci /opt/ci/test_site.sql /opt/ci/test_site.sql
+
+USER ci
+WORKDIR /opt/frappe-bench
+
+# Recorded so a CI run can assert the image is not stale relative to upstream.
+ARG FRAPPE_SHA=unknown
+ARG ERPNEXT_SHA=unknown
+ARG HRMS_SHA=unknown
+LABEL org.opencontainers.image.source="https://github.com/Aerele-RnD/jarvis" \
+      ai.jarvis.frappe-sha="${FRAPPE_SHA}" \
+      ai.jarvis.erpnext-sha="${ERPNEXT_SHA}" \
+      ai.jarvis.hrms-sha="${HRMS_SHA}"

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -8,8 +8,11 @@ name: CI base image
 #
 # This workflow does not change ci.yml. It only publishes the image.
 #
-# On pull_request the image is BUILT but NOT PUSHED, so a PR touching the Dockerfile proves the
-# build still works without mutating the published tag.
+# Order is build -> smoke-test -> push, never build+push -> smoke-test: `:v16` is a mutable tag
+# that every PR run will pull, so it must never receive an image that has not passed the gate.
+#
+# On pull_request the image is BUILT and TESTED but NOT PUSHED, so a PR touching the Dockerfile
+# proves the build still works without mutating the published tag.
 
 on:
   schedule:
@@ -26,17 +29,24 @@ on:
       - ".github/workflows/ci-base-image.yml"
 
 concurrency:
-  # Keyed on ref so a PR build never cancels the nightly publish.
+  # Keyed on ref so a PR build never cancels the nightly publish. Only PR builds are cancellable:
+  # a cancelled run reads as neutral rather than failed, so cancelling a publish would silently
+  # leave `:v16` stale with nothing marked red — the same reasoning ci.yml uses to protect main.
   group: ci-base-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
+  # packages: write is needed only by the final `docker push` step, and only on non-PR runs.
+  # GitHub forces GITHUB_TOKEN read-only for fork-originated `pull_request` runs regardless of
+  # this block, so a fork PR cannot publish even though it re-runs this workflow's own file.
   contents: read
   packages: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Longer than ci.yml's 45: this builds everything ci.yml builds, plus a throwaway mariadb,
+    # a full erpnext+hrms site install, and the dump. Locally the whole build is ~25 min.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -60,15 +70,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      # Build once, into the local docker daemon. Nothing is pushed here — publishing an image
+      # before validating it would put a broken `:v16` in front of every PR, and the smoke test
+      # below could only report the damage after the fact.
+      #
+      # `load: true` is what lets the smoke test run the *exact* artifact that gets pushed,
+      # instead of a second `docker build` producing a different image with different labels.
+      - name: Build image
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: .github/docker/Dockerfile.ci-base
-          push: ${{ github.event_name != 'pull_request' }}
-          # :v16 is the tag ci.yml will pin. The run-numbered tag gives you a rollback target.
+          push: false
+          load: true
+          # :v16 is the tag ci.yml will pin. run_id (not run_number) is the rollback target:
+          # run_number restarts if the workflow is renamed, so old numbered tags could be
+          # silently overwritten by a new incarnation. run_id is unique for the repo, forever.
           tags: |
             ghcr.io/aerele-rnd/jarvis-ci-base:v16
-            ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_number }}
+            ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_id }}
           build-args: |
             FRAPPE_SHA=${{ steps.shas.outputs.frappe }}
             ERPNEXT_SHA=${{ steps.shas.outputs.erpnext }}
@@ -76,13 +96,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Fails the build if the seeded dump is missing or suspiciously small, rather than
-      # publishing an image whose ci.yml consumer would fail later at `bench new-site`.
+      # Gate. A build can exit 0 and still produce a useless image — e.g. an upstream change that
+      # installs fewer doctypes, or a dump truncated by a full disk. The Dockerfile's own `test -s`
+      # only proves the dump is non-empty.
       - name: Smoke-test the built image
         run: |
-          docker build --target final -t ci-base-probe \
-            -f .github/docker/Dockerfile.ci-base .
-          docker run --rm ci-base-probe bash -lc '
+          docker run --rm ghcr.io/aerele-rnd/jarvis-ci-base:v16 bash -lc '
             set -e
             test -s /opt/ci/test_site.sql
             bytes=$(stat -c%s /opt/ci/test_site.sql)
@@ -98,3 +117,10 @@ jobs:
             /opt/frappe-bench/env/bin/python -c "import coverage, gevent; print(\"test deps OK\")"
             test "$(id -u)" = "1001"
           '
+
+      # Only now, and never from a pull_request.
+      - name: Push
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push ghcr.io/aerele-rnd/jarvis-ci-base:v16
+          docker push ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_id }}

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -1,0 +1,100 @@
+name: CI base image
+
+# Builds ghcr.io/aerele-rnd/jarvis-ci-base:v16 — a pre-built Frappe bench (frappe + erpnext +
+# hrms, version-16) plus a SQL dump of a site with all three already installed.
+#
+# Today, every PR run rebuilds that environment from scratch: ~5m26s of a ~7m21s run, identical
+# every time. Once ci.yml consumes this image, a PR only installs jarvis itself (~2.5s).
+#
+# This workflow does not change ci.yml. It only publishes the image.
+#
+# On pull_request the image is BUILT but NOT PUSHED, so a PR touching the Dockerfile proves the
+# build still works without mutating the published tag.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"        # 02:00 UTC nightly — picks up version-16 drift within a day
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/docker/Dockerfile.ci-base"
+      - ".github/workflows/ci-base-image.yml"
+  pull_request:
+    paths:
+      - ".github/docker/Dockerfile.ci-base"
+      - ".github/workflows/ci-base-image.yml"
+
+concurrency:
+  # Keyed on ref so a PR build never cancels the nightly publish.
+  group: ci-base-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      # Recorded as image labels so a consumer can tell how stale the image is.
+      - name: Resolve upstream SHAs
+        id: shas
+        run: |
+          for repo in frappe erpnext hrms; do
+            sha=$(git ls-remote "https://github.com/frappe/${repo}.git" version-16 | cut -f1)
+            echo "${repo}=${sha}" >> "$GITHUB_OUTPUT"
+          done
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Skipped on PRs: nothing is pushed, so no registry credentials are needed.
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile.ci-base
+          push: ${{ github.event_name != 'pull_request' }}
+          # :v16 is the tag ci.yml will pin. The run-numbered tag gives you a rollback target.
+          tags: |
+            ghcr.io/aerele-rnd/jarvis-ci-base:v16
+            ghcr.io/aerele-rnd/jarvis-ci-base:v16-${{ github.run_number }}
+          build-args: |
+            FRAPPE_SHA=${{ steps.shas.outputs.frappe }}
+            ERPNEXT_SHA=${{ steps.shas.outputs.erpnext }}
+            HRMS_SHA=${{ steps.shas.outputs.hrms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Fails the build if the seeded dump is missing or suspiciously small, rather than
+      # publishing an image whose ci.yml consumer would fail later at `bench new-site`.
+      - name: Smoke-test the built image
+        run: |
+          docker build --target final -t ci-base-probe \
+            -f .github/docker/Dockerfile.ci-base .
+          docker run --rm ci-base-probe bash -lc '
+            set -e
+            test -s /opt/ci/test_site.sql
+            bytes=$(stat -c%s /opt/ci/test_site.sql)
+            tables=$(grep -c "CREATE TABLE" /opt/ci/test_site.sql)
+            echo "dump: ${bytes} bytes, ${tables} tables"
+            # Measured locally: 10,097,125 bytes / 884 tables. Floors sit well below that so a
+            # normal upstream change does not trip them, but an empty or truncated dump does.
+            test "${bytes}" -gt 5000000
+            test "${tables}" -gt 700
+            grep -q "tabDocType" /opt/ci/test_site.sql
+            test -x /opt/frappe-bench/env/bin/python
+            /opt/frappe-bench/env/bin/python -c "import frappe, erpnext, hrms; print(\"imports OK\")"
+            /opt/frappe-bench/env/bin/python -c "import coverage, gevent; print(\"test deps OK\")"
+            test "$(id -u)" = "1001"
+          '


### PR DESCRIPTION
## What

Adds a CI base image (`ghcr.io/aerele-rnd/jarvis-ci-base:v16`) and a workflow that publishes it.

**This PR does not touch `ci.yml`.** Nothing about existing PR runs changes. It only publishes
the image, so that a follow-up PR can switch CI over to it.

## Why

Profiling five recent runs: **73% of every CI run rebuilds an environment that is byte-identical
across runs.** Only 27% actually tests jarvis.

Budget for [run 29021973358](https://github.com/Aerele-RnD/jarvis/actions/runs/29021973358)
(7m21s = 441s):

| Step | Time | Identical every run? |
|---|---:|---|
| Initialize containers | 19s | yes |
| Clone jarvis | 2s | **no** |
| System deps | 41s | yes |
| Init bench | 42s | yes |
| Get apps (erpnext 24s, hrms 51s, jarvis 25s) | 101s | mostly |
| Create site (frappe 26s, erpnext 62s, hrms 25s, **jarvis 2.5s**) | 121s | all but 2.5s |
| Run tests + coverage | 113s | **no** |

Two findings drive this:

**1. `--skip-assets` does not skip `yarn install`.** Every `bench get-app` in `ci.yml` passes
`--skip-assets`, with a comment saying backend tests never use the JS bundles. But in
`bench/app.py`, `skip_assets` gates only `build_assets()`:

```python
if not using_cached and os.path.exists(os.path.join(app_path, "package.json")):
    bench.run("yarn install --check-files", cwd=app_path)   # always runs

if not skip_assets:
    build_assets(...)                                        # only this is gated
```

Measured: erpnext 20.5s, hrms 48.1s, jarvis 23.8s, plus 15.8s in `bench init` and a 12s esbuild
pass. **~120s per run — 27% — is npm work producing `node_modules` the Python suite never reads.**

**2. Installing apps into the site costs 116s, of which jarvis is 2.5s.** frappe 26s, erpnext 62s,
hrms 25s. The app under test is 2% of that step; the rest is a fixed, reproducible DB state.

## How

The image bakes both:

- A pre-built bench with frappe + erpnext + hrms (`version-16`), `pip install -e`'d, assets built
  once, erpnext/hrms `node_modules` deleted afterwards. `coverage` and `gevent` preinstalled.
- `/opt/ci/test_site.sql` — a dump of a site with all three already installed, produced in a
  throwaway `seed` stage so `mariadb-server` never reaches the final image.

The follow-up `ci.yml` then does `bench new-site --source-sql /opt/ci/test_site.sql` +
`install-app jarvis` (2.5s) and goes straight to tests.

Projected: **~7m21s → ~3m15s.**

## Gotchas encoded here (each verified, not assumed)

- **bench hard-exits as root** (`bench/cli.py` → `change_uid`). Reproduced: `bench init` as root
  prints `WARN: You should not run this command as root` and exits 1. GitHub Actions `container:`
  jobs are root by default, so the image builds and runs as uid **1001** — matching the runner
  user that owns the workspace. Verified `bench init` as uid 1001 works even with `HOME` unset.
- **You cannot bake a datadir into a child of `mariadb:10.11`** — the parent declares
  `VOLUME /var/lib/mysql`, so build-time writes there are discarded. Hence a SQL dump.
- bookworm ships mariadb **10.11.14**, the same major as the `mariadb:10.11` service image, so the
  dump restores cleanly.
- `bench new-site --source-sql` exists (`frappe/commands/site.py:59`) and initialises DB + user +
  `site_config.json` from a SQL file.

## Testing

Built end-to-end locally (arm64, Colima). Final image **3.53 GB**; smoke checks inside it:

```
dump: 10097125 bytes, 884 tables
tabDocType: ok
imports OK          # frappe, erpnext, hrms from the baked venv
test deps OK        # coverage, gevent
uid 1001: ok
```

**On `pull_request` this workflow builds the image but does not push it**, so this PR proves the
Dockerfile still builds on amd64 GitHub runners without mutating the published tag. The
`Smoke-test the built image` step re-runs the assertions above in CI.

### Five bugs the local build caught

Worth recording, because none are visible from reading the code and each would have failed the
first nightly build:

1. **`bench init` needs `/usr/bin/crontab`** (via python-crontab) and dies with `FileNotFoundError`
   without it. The GitHub runner image ships `cron`; a clean `python:3.14-bookworm` does not.
2. **`bench new-site` needs a live Redis.** `bench init --skip-redis-config-generation` leaves the
   default ports (11000/13000) with nothing behind them → `ConnectionError: Error 111`. The seed
   stage now runs `redis-server` and points bench at `127.0.0.1:6379`.
3. **`service mariadb stop` fails once a root password is set** — the init script uses a
   passwordless `mysqladmin shutdown` — and `set -e` killed the build on the last line, *after* the
   dump had been written. Now shuts down with credentials.
4. **`/opt` is root-owned but `bench init` runs as `ci`.** Needed an explicit `chown`.
5. **The image was 7.48 GB**; `/home/ci/.cache` held 3.1 GB of yarn + uv caches. The purge has to
   happen inside the same `RUN` that creates them, or the bytes stay in the layer. → 3.53 GB.

## Cost

`jarvis` is public and the org is on the Free plan, so this is free: Actions minutes are unlimited
for public repos, and GitHub Packages usage is free for public packages. Image pulls via
`GITHUB_TOKEN` inside Actions never count against data transfer regardless.

The savings are wall-clock, not dollars — today's waste costs PR feedback latency, not money.

## Merge checklist (for the maintainer)

1. Merge this PR. The nightly `schedule:` starts publishing `:v16`.
2. Trigger it once immediately: **Actions → CI base image → Run workflow**.
3. **Flip the package to public** — Package settings → Danger Zone → Change visibility → Public.
   *This is one-way.* Safe: the image contains only OSS (frappe/erpnext/hrms) plus a throwaway
   test fixture DB whose admin password is `admin`. No secrets.
   (The org may first need Settings → Packages → Package Creation → Public enabled.)
4. Then review the follow-up PR that swaps `ci.yml` over and moves the from-scratch build to a
   nightly schedule — keeping upstream `version-16` breakage detection, just off the PR path.

Do **not** merge a `ci.yml` switch before step 3, or PR runs will fail to pull the image.
