### PR TITLE
fix(account): gate get_account + preview_upgrade on System Manager

### DIFF
--- a/frontend/src/components/shell/SettingsDialog.vue
+++ b/frontend/src/components/shell/SettingsDialog.vue
@@ -103,8 +103,13 @@ const BillingMeteringPane = defineAsyncComponent(() => import("@/components/sett
 const { effectiveDark: dark, paletteVars } = useJarvisTheme()
 const store = useShellStore()
 
-// Only the ACCOUNT & BILLING group is gated (server already enforces the
-// underlying endpoints). Non-SM users see WORKSPACE only.
+// Only the ACCOUNT & BILLING group is shown to System Managers; non-SM users
+// see WORKSPACE only. This rail is presentation, NOT a security boundary - each
+// endpoint must gate itself, because /api/method is reachable directly.
+// Server-enforced today: get_account, preview_upgrade, start_upgrade,
+// get_llm_usage, get_llm_connection_status, get_llm_config.
+// Still ungated: onboarding.get_llm_sync_status (OnboardingView needs it before
+// roles settle) and oauth.api.get_direct_subscription_status.
 const isSM = !!window.is_system_manager
 
 const GATED = ["plan", "aimodels", "connection", "billing"]

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -153,13 +153,28 @@ def get_llm_connection_status() -> dict:
 
 @frappe.whitelist()
 def get_account() -> dict:
-	"""Plan + validity + upgrade-eligible plans for the account page."""
+	"""Plan + validity + upgrade-eligible plans for the account page.
+
+	System-Manager only, like its siblings above. Until now the only gate was
+	the UI: SettingsDialog hides the ACCOUNT & BILLING rail group from non-SM
+	users, and the /jarvis-account desk page carries roles=["System Manager"].
+	Neither stops a direct /api/method call, so any authenticated user could
+	read the account's plan, subscription status and validity.
+	"""
+	frappe.only_for("System Manager")
 	return _surface(admin_client.get_account_summary)
 
 
 @frappe.whitelist()
 def preview_upgrade(target_plan: str) -> dict:
-	"""Prorated amount for the upgrade modal's per-plan cards."""
+	"""Prorated amount for the upgrade modal's per-plan cards.
+
+	Same gate as ``start_upgrade`` below: this is the read half of the same
+	billing transaction, reachable only from the SM-only desk page, and it
+	spends an admin round-trip per call. Whoever may not upgrade the plan has
+	no business pricing the upgrade either.
+	"""
+	frappe.only_for("System Manager")
 	return _surface(admin_client.preview_upgrade, target_plan)
 
 

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -16,12 +16,6 @@ _SNAPSHOTTED_FIELDS = (
 	"agent_url", "agent_token",
 )
 
-# A System User who is NOT a System Manager: the realistic caller these gates
-# exist to stop. A Website User is a weaker test - plenty of code paths reject
-# those for unrelated reasons.
-NON_SM_USER = "account-gate-staff@test.invalid"
-WEBSITE_USER = "account-gate-portal@test.invalid"
-
 
 def _snapshot_settings() -> dict:
 	s = frappe.get_single("Jarvis Settings")
@@ -104,92 +98,22 @@ class TestAccountWrappers(FrappeTestCase):
 		self.assertIn("downgrade not supported", str(cm.exception))
 
 
-class TestAccountEndpointsAreSystemManagerOnly(FrappeTestCase):
-	"""get_account and preview_upgrade were whitelisted but ungated.
+class TestAccountGatesFailClosed(FrappeTestCase):
+	"""get_account and preview_upgrade are System-Manager-only.
 
-	The only thing keeping non-admins out was presentation: SettingsDialog
-	hides the ACCOUNT & BILLING rail group, and the /jarvis-account desk page
-	declares roles=["System Manager"]. Neither constrains a direct
-	/api/method/jarvis.account.get_account call, so any authenticated user
-	could read the account's plan, subscription status and validity - and
-	price upgrades, one admin round-trip per request.
-
-	start_upgrade was gated in the 2026-06-16 review; these two are its read
-	siblings and were missed.
+	The rejection itself is covered by the canonical parametrized sweep in
+	test_role_gates.py (both endpoints are entries in GATED_ENDPOINTS, which
+	asserts Guest is refused and Administrator is not). This class adds the one
+	property that sweep cannot express: the gate must run BEFORE _surface()
+	reaches admin_client, so an unauthorised caller can neither leak the
+	payload into admin's logs nor burn an admin request per attempt.
 	"""
-
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		if not frappe.db.exists("User", NON_SM_USER):
-			frappe.get_doc({
-				"doctype": "User", "email": NON_SM_USER,
-				"first_name": "Account Gate Staff",
-				"user_type": "System User", "send_welcome_email": 0,
-			}).insert(ignore_permissions=True)
-		if not frappe.db.exists("User", WEBSITE_USER):
-			frappe.get_doc({
-				"doctype": "User", "email": WEBSITE_USER,
-				"first_name": "Account Gate Portal",
-				"user_type": "Website User", "send_welcome_email": 0,
-			}).insert(ignore_permissions=True)
-		# Site role defaults / hooks can hand out System Manager. Strip it, or
-		# this whole class would silently assert nothing.
-		u = frappe.get_doc("User", NON_SM_USER)
-		u.remove_roles("System Manager")
-		u.save(ignore_permissions=True)
-		frappe.db.commit()
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.set_user("Administrator")
-		for user in (NON_SM_USER, WEBSITE_USER):
-			frappe.delete_doc("User", user, ignore_permissions=True, force=True)
-		frappe.db.commit()
-		super().tearDownClass()
-
-	def setUp(self):
-		frappe.set_user("Administrator")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
 
-	def test_the_fixture_user_really_lacks_system_manager(self):
-		"""Guard the guard: if the site hands this user System Manager, every
-		rejection test below would pass for the wrong reason."""
-		roles = frappe.get_roles(NON_SM_USER)
-		self.assertNotIn("System Manager", roles)
-
-	def test_get_account_rejects_non_system_manager(self):
-		frappe.set_user(NON_SM_USER)
-		with self.assertRaises(frappe.PermissionError):
-			account.get_account()
-
-	def test_preview_upgrade_rejects_non_system_manager(self):
-		frappe.set_user(NON_SM_USER)
-		with self.assertRaises(frappe.PermissionError):
-			account.preview_upgrade("plan-pro")
-
-	def test_get_account_rejects_website_user(self):
-		frappe.set_user(WEBSITE_USER)
-		with self.assertRaises(frappe.PermissionError):
-			account.get_account()
-
-	def test_get_account_rejects_guest(self):
-		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
-			account.get_account()
-
-	def test_preview_upgrade_rejects_guest(self):
-		frappe.set_user("Guest")
-		with self.assertRaises(frappe.PermissionError):
-			account.preview_upgrade("plan-pro")
-
 	def test_rejection_happens_before_any_admin_round_trip(self):
-		"""Fail closed: the gate must run before _surface() calls admin. A
-		gate placed after the round-trip would still leak the payload into
-		admin's logs and burn a request per unauthorised caller."""
-		frappe.set_user(NON_SM_USER)
+		frappe.set_user("Guest")
 		with patch.object(admin_client, "get_account_summary") as get_summary, \
 				patch.object(admin_client, "preview_upgrade") as prev:
 			with self.assertRaises(frappe.PermissionError):
@@ -198,14 +122,3 @@ class TestAccountEndpointsAreSystemManagerOnly(FrappeTestCase):
 				account.preview_upgrade("plan-pro")
 		get_summary.assert_not_called()
 		prev.assert_not_called()
-
-	def test_system_manager_still_allowed(self):
-		"""The gate must not break the legitimate caller."""
-		frappe.set_user("Administrator")
-		self.assertIn("System Manager", frappe.get_roles("Administrator"))
-		fake = {"subscription_status": "Active", "plan": {"name": "p1"},
-				"days_remaining": 12, "upgrade_plans": []}
-		with patch.object(admin_client, "get_account_summary", return_value=fake):
-			self.assertEqual(account.get_account(), fake)
-		with patch.object(admin_client, "preview_upgrade", return_value={"prorated_inr": 1}):
-			self.assertEqual(account.preview_upgrade("plan-pro"), {"prorated_inr": 1})

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -16,6 +16,12 @@ _SNAPSHOTTED_FIELDS = (
 	"agent_url", "agent_token",
 )
 
+# A System User who is NOT a System Manager: the realistic caller these gates
+# exist to stop. A Website User is a weaker test - plenty of code paths reject
+# those for unrelated reasons.
+NON_SM_USER = "account-gate-staff@test.invalid"
+WEBSITE_USER = "account-gate-portal@test.invalid"
+
 
 def _snapshot_settings() -> dict:
 	s = frappe.get_single("Jarvis Settings")
@@ -96,3 +102,110 @@ class TestAccountWrappers(FrappeTestCase):
 			with self.assertRaises(frappe.ValidationError) as cm:
 				account.preview_upgrade("plan-cheap")
 		self.assertIn("downgrade not supported", str(cm.exception))
+
+
+class TestAccountEndpointsAreSystemManagerOnly(FrappeTestCase):
+	"""get_account and preview_upgrade were whitelisted but ungated.
+
+	The only thing keeping non-admins out was presentation: SettingsDialog
+	hides the ACCOUNT & BILLING rail group, and the /jarvis-account desk page
+	declares roles=["System Manager"]. Neither constrains a direct
+	/api/method/jarvis.account.get_account call, so any authenticated user
+	could read the account's plan, subscription status and validity - and
+	price upgrades, one admin round-trip per request.
+
+	start_upgrade was gated in the 2026-06-16 review; these two are its read
+	siblings and were missed.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("User", NON_SM_USER):
+			frappe.get_doc({
+				"doctype": "User", "email": NON_SM_USER,
+				"first_name": "Account Gate Staff",
+				"user_type": "System User", "send_welcome_email": 0,
+			}).insert(ignore_permissions=True)
+		if not frappe.db.exists("User", WEBSITE_USER):
+			frappe.get_doc({
+				"doctype": "User", "email": WEBSITE_USER,
+				"first_name": "Account Gate Portal",
+				"user_type": "Website User", "send_welcome_email": 0,
+			}).insert(ignore_permissions=True)
+		# Site role defaults / hooks can hand out System Manager. Strip it, or
+		# this whole class would silently assert nothing.
+		u = frappe.get_doc("User", NON_SM_USER)
+		u.remove_roles("System Manager")
+		u.save(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for user in (NON_SM_USER, WEBSITE_USER):
+			frappe.delete_doc("User", user, ignore_permissions=True, force=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_the_fixture_user_really_lacks_system_manager(self):
+		"""Guard the guard: if the site hands this user System Manager, every
+		rejection test below would pass for the wrong reason."""
+		roles = frappe.get_roles(NON_SM_USER)
+		self.assertNotIn("System Manager", roles)
+
+	def test_get_account_rejects_non_system_manager(self):
+		frappe.set_user(NON_SM_USER)
+		with self.assertRaises(frappe.PermissionError):
+			account.get_account()
+
+	def test_preview_upgrade_rejects_non_system_manager(self):
+		frappe.set_user(NON_SM_USER)
+		with self.assertRaises(frappe.PermissionError):
+			account.preview_upgrade("plan-pro")
+
+	def test_get_account_rejects_website_user(self):
+		frappe.set_user(WEBSITE_USER)
+		with self.assertRaises(frappe.PermissionError):
+			account.get_account()
+
+	def test_get_account_rejects_guest(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			account.get_account()
+
+	def test_preview_upgrade_rejects_guest(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			account.preview_upgrade("plan-pro")
+
+	def test_rejection_happens_before_any_admin_round_trip(self):
+		"""Fail closed: the gate must run before _surface() calls admin. A
+		gate placed after the round-trip would still leak the payload into
+		admin's logs and burn a request per unauthorised caller."""
+		frappe.set_user(NON_SM_USER)
+		with patch.object(admin_client, "get_account_summary") as get_summary, \
+				patch.object(admin_client, "preview_upgrade") as prev:
+			with self.assertRaises(frappe.PermissionError):
+				account.get_account()
+			with self.assertRaises(frappe.PermissionError):
+				account.preview_upgrade("plan-pro")
+		get_summary.assert_not_called()
+		prev.assert_not_called()
+
+	def test_system_manager_still_allowed(self):
+		"""The gate must not break the legitimate caller."""
+		frappe.set_user("Administrator")
+		self.assertIn("System Manager", frappe.get_roles("Administrator"))
+		fake = {"subscription_status": "Active", "plan": {"name": "p1"},
+				"days_remaining": 12, "upgrade_plans": []}
+		with patch.object(admin_client, "get_account_summary", return_value=fake):
+			self.assertEqual(account.get_account(), fake)
+		with patch.object(admin_client, "preview_upgrade", return_value={"prorated_inr": 1}):
+			self.assertEqual(account.preview_upgrade("plan-pro"), {"prorated_inr": 1})

--- a/jarvis/tests/test_role_gates.py
+++ b/jarvis/tests/test_role_gates.py
@@ -36,6 +36,11 @@ GATED_ENDPOINTS = [
 	("jarvis.onboarding", "get_llm_config", {}),
 	("jarvis.onboarding", "get_account_defaults", {}),
 	("jarvis.account", "start_upgrade", {"target_plan": "team_monthly"}),
+	# The read half of the same billing surface. Both were whitelisted but
+	# ungated: the settings rail and the desk page's roles=["System Manager"]
+	# are presentation, and neither constrains a direct /api/method call.
+	("jarvis.account", "get_account", {}),
+	("jarvis.account", "preview_upgrade", {"target_plan": "team_monthly"}),
 	("jarvis.account", "get_llm_usage", {}),
 	("jarvis.account", "get_llm_connection_status", {}),
 	("jarvis.oauth.api", "begin_paste_signin", {"provider": "OpenAI", "model": "gpt-5.5"}),


### PR DESCRIPTION
## What

`jarvis.account.get_account` and `jarvis.account.preview_upgrade` were `@frappe.whitelist()` with **no server-side authorisation**. Adds `frappe.only_for("System Manager")` to both, and registers them in the canonical `GATED_ENDPOINTS` list.

## Why it was reachable

The only thing keeping non-admins out was presentation:

- `SettingsDialog.vue` hides the ACCOUNT & BILLING rail group from non-SM users
- the `/jarvis-account` desk page declares `roles: ["System Manager"]`

Neither constrains a direct `POST /api/method/jarvis.account.get_account`. Any authenticated user — including the `Jarvis User` role added in #244 — could read the account's **plan, subscription status and validity**, and price upgrades at one admin round-trip per request.

`start_upgrade` was gated in the 2026-06-16 review *because it initiates a billing transaction*. These two are its read siblings and were missed. Their neighbours `get_llm_usage` and `get_llm_connection_status` in the same module were already gated.

## The comment that let it through

`SettingsDialog.vue:106` asserted:

> Only the ACCOUNT & BILLING group is gated (server already enforces the underlying endpoints).

That was false for `get_account`. Replaced with the real inventory, naming the two endpoints that stay ungated deliberately:

| Endpoint | Gated? | Note |
|---|---|---|
| `account.get_account` | ✅ **this PR** | |
| `account.preview_upgrade` | ✅ **this PR** | |
| `account.start_upgrade` | ✅ already | |
| `account.get_llm_usage` | ✅ already | |
| `account.get_llm_connection_status` | ✅ already | |
| `onboarding.get_llm_config` | ✅ already | |
| `onboarding.get_llm_sync_status` | ❌ **left open** | `OnboardingView` polls it before roles settle — gating breaks onboarding |
| `oauth.api.get_direct_subscription_status` | ❌ **left open** | belongs with the AI-models section; `AiModelsPane` already skips it for non-SM |

Follow-ups, not oversights. Gating `get_llm_sync_status` needs the onboarding role model resolved first.

## Safety

No legitimate caller breaks:
- `PlanBillingPane.vue` sits inside the rail group already hidden from non-SM
- the `/jarvis-account` desk page is already `roles: ["System Manager"]`
- `preview_upgrade` isn't even exported to the SPA (`api.js`) — desk page only

## Tests

Both endpoints added to **`test_role_gates.GATED_ENDPOINTS`**, the canonical parametrized sweep that already carries their siblings. Registering them there matters as much as the gate itself: a maintainer auditing that list to see which `jarvis.account` endpoints are System-Manager-gated would otherwise conclude these two are not, and a future endpoint silently dropping its `only_for` wouldn't be caught by the guest/admin sweep the way its siblings are.

`test_account` adds only the one property that sweep cannot express — `test_rejection_happens_before_any_admin_round_trip`: the gate must run **before** `_surface()` reaches `admin_client`, so an unauthorised caller can neither leak the payload into admin's logs nor burn an admin request per attempt.

**Verified red.** Removing the two `only_for` lines fails both suites. In `test_role_gates` it surfaces as an `ERROR` rather than a failure — because Guest gets past the gate and reaches `admin_client`, which raises `AdminAuthError`. That error *is* the vulnerability.

Green: `test_account` 8/8, `test_role_gates` 6/6, `test_onboarding_sync` 26/26.

Local `site.jarvis` is role-polluted, so **CI is the authority** on these permission assertions.

---

<sub>An earlier revision of this PR hand-rolled ~100 lines of gate-test scaffolding with its own `User` fixtures, duplicating `test_role_gates.py`. Code review caught it. Those fixtures also created a portal-tier `User` row — which `test_role_gates.py`'s own docstring warns "trips Frappe's global search assertion under FrappeTestCase" — and were the likely cause of a one-off `test_onboarding_sync` error I saw and couldn't reproduce. Both are gone.</sub>