### PR TITLE
UX Phase 3 (safe subset): markdown depth + day separators

### DIFF
--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -1,6 +1,7 @@
 // Compact GFM renderer - enough for agent replies: paragraphs, bold/italic,
-// inline code, links, bullet/number lists, and pipe tables (rendered into the
-// imported design's table look via the .jv-md classes in ChatView's styles).
+// strikethrough, inline code, links, nested bullet/number lists, blockquotes,
+// and pipe tables (rendered into the imported design's table look via the
+// .jv-md classes in ChatView's styles).
 function esc(s) {
 	return String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]))
 }
@@ -8,6 +9,7 @@ function esc(s) {
 function inline(s) {
 	let t = esc(s)
 	t = t.replace(/`([^`]+)`/g, '<code class="jv-md-code">$1</code>')
+	t = t.replace(/~~([^~]+)~~/g, "<del>$1</del>")
 	t = t.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
 	t = t.replace(/(^|[^*])\*([^*]+)\*/g, "$1<em>$2</em>")
 	t = t.replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener" class="jv-md-link">$1</a>')
@@ -30,23 +32,45 @@ function renderTable(rows) {
 	return h + "</tbody></table></div>"
 }
 
+// Build (possibly nested) list HTML from a run of list-item lines, nesting by
+// leading-space indent. A deeper indent nests inside the current item; a mixed
+// bullet/number type at the same indent starts a fresh sibling list.
+function renderListBlock(items) {
+	let html = ""
+	const stack = [] // [{ indent, tag }], innermost last
+	for (const it of items) {
+		while (stack.length && it.indent < stack[stack.length - 1].indent) {
+			html += `</li></${stack.pop().tag}>`
+		}
+		const top = stack[stack.length - 1]
+		if (top && it.indent === top.indent) {
+			if (top.tag !== it.tag) {
+				html += `</li></${stack.pop().tag}>`
+				html += `<${it.tag} class="jv-md-list"><li>`
+				stack.push({ indent: it.indent, tag: it.tag })
+			} else {
+				html += "</li><li>"
+			}
+		} else {
+			html += `<${it.tag} class="jv-md-list"><li>`
+			stack.push({ indent: it.indent, tag: it.tag })
+		}
+		html += inline(it.text)
+	}
+	while (stack.length) html += `</li></${stack.pop().tag}>`
+	return html
+}
+
 export function renderMarkdown(src) {
 	if (!src) return ""
 	const lines = String(src).replace(/\r\n/g, "\n").split("\n")
 	const out = []
 	let i = 0
 	let para = []
-	let list = null
 	const flushPara = () => {
 		if (para.length) {
 			out.push(`<p class="jv-md-p">${inline(para.join(" "))}</p>`)
 			para = []
-		}
-	}
-	const flushList = () => {
-		if (list) {
-			out.push(`<${list.tag} class="jv-md-list">${list.items.map((x) => `<li>${inline(x)}</li>`).join("")}</${list.tag}>`)
-			list = null
 		}
 	}
 	while (i < lines.length) {
@@ -56,7 +80,6 @@ export function renderMarkdown(src) {
 		const fence = line.match(/^\s*```\s*([\w-]*)\s*$/)
 		if (fence) {
 			flushPara()
-			flushList()
 			const lang = (fence[1] || "").toLowerCase()
 			const body = []
 			i++
@@ -73,7 +96,6 @@ export function renderMarkdown(src) {
 		// table: a header row followed by a |---| separator
 		if (/\|/.test(line) && i + 1 < lines.length && /^\s*\|?[\s:-]+\|[\s:|-]*$/.test(lines[i + 1])) {
 			flushPara()
-			flushList()
 			const tbl = [line, lines[i + 1]]
 			i += 2
 			while (i < lines.length && /\|/.test(lines[i]) && lines[i].trim()) tbl.push(lines[i++])
@@ -85,36 +107,43 @@ export function renderMarkdown(src) {
 		const heading = line.match(/^\s*(#{1,4})\s+(.*)/)
 		if (heading) {
 			flushPara()
-			flushList()
 			const level = Math.min(heading[1].length + 2, 6)
 			out.push(`<h${level} class="jv-md-h">${inline(heading[2])}</h${level}>`)
 			i++
 			continue
 		}
-		const ul = line.match(/^\s*[-*]\s+(.*)/)
-		const ol = line.match(/^\s*\d+\.\s+(.*)/)
-		if (ul || ol) {
+		// blockquote: one or more consecutive `>` lines.
+		if (/^\s*>\s?/.test(line)) {
 			flushPara()
-			const tag = ul ? "ul" : "ol"
-			if (!list || list.tag !== tag) {
-				flushList()
-				list = { tag, items: [] }
+			const q = []
+			while (i < lines.length && /^\s*>\s?/.test(lines[i])) {
+				q.push(lines[i].replace(/^\s*>\s?/, ""))
+				i++
 			}
-			list.items.push((ul || ol)[1])
-			i++
+			out.push(`<blockquote class="jv-md-quote">${inline(q.join(" "))}</blockquote>`)
+			continue
+		}
+		// bullet / numbered lists, indent-nested.
+		if (/^(\s*)([-*]|\d+\.)\s+/.test(line)) {
+			flushPara()
+			const items = []
+			while (i < lines.length) {
+				const m = lines[i].match(/^(\s*)([-*]|\d+\.)\s+(.*)/)
+				if (!m) break
+				items.push({ indent: m[1].length, tag: /\d/.test(m[2]) ? "ol" : "ul", text: m[3] })
+				i++
+			}
+			out.push(renderListBlock(items))
 			continue
 		}
 		if (!line.trim()) {
 			flushPara()
-			flushList()
 			i++
 			continue
 		}
-		flushList()
 		para.push(line.trim())
 		i++
 	}
 	flushPara()
-	flushList()
 	return out.join("\n")
 }

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -18,3 +18,18 @@ export function exactDate(d) {
 export function formatDate(d, fmt) {
 	return d ? dayjsLocal(String(d)).format(fmt || "MMM D, YYYY") : ""
 }
+
+// Day-bucket label for chat day separators, timezone-safe like the rest of this
+// module. Accepts a naive site-tz string (creation/modified) or a browser Date /
+// ms number (optimistic rows). "Today" / "Yesterday" / weekday within a week /
+// "D MMMM" beyond.
+export function dayLabel(d) {
+	if (d == null || d === "") return ""
+	const dj = dayjsLocal(d)
+	if (!dj || typeof dj.isValid !== "function" || !dj.isValid()) return ""
+	const diff = dayjsLocal().startOf("day").diff(dj.startOf("day"), "day")
+	if (diff === 0) return "Today"
+	if (diff === 1) return "Yesterday"
+	if (diff > 1 && diff < 7) return dj.format("dddd")
+	return dj.format("D MMMM")
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -93,7 +93,8 @@
 						<template v-else-if="macroRun.status === 'failed'"><span class="jv-macrobar-chip">✗ Macro failed</span></template>
 						<template v-else-if="macroRun.status === 'stopped'"><span class="jv-macrobar-chip">⏹ Macro stopped</span></template>
 					</div>
-					<template v-for="m in visibleMessages" :key="m.name">
+					<template v-for="(m, mi) in visibleMessages" :key="m.name">
+						<div v-if="dayDividers[mi]" class="jv-daydivider"><span>{{ dayDividers[mi] }}</span></div>
 						<!-- user -->
 						<div v-if="m.role === 'user'" class="jv-umsg" style="display:flex;flex-direction:column;align-items:flex-end;">
 							<div v-if="m.content" class="jv-ububble" style="max-width:78%;min-width:0;background:var(--surface-2);border:1px solid var(--border);border-radius:14px 14px 4px 14px;padding:10px 14px;font-size:14px;line-height:1.5;color:var(--text);white-space:pre-wrap;overflow-wrap:anywhere;">{{ m.content }}</div>
@@ -746,7 +747,7 @@ import { useAudioRecorder } from "@/composables/useAudioRecorder"
 import { setMacroPrefill } from "@/composables/macroPrefill"
 import { takeChatPrefill } from "@/composables/chatPrefill"
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
-import { formatDate, exactDate } from "@/utils/datetime"
+import { formatDate, exactDate, dayLabel } from "@/utils/datetime"
 import { renderMarkdown } from "@/markdown"
 import JvChart from "@/charts/JvChart.vue"
 import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue"
@@ -2429,6 +2430,29 @@ function msgTimeFull(m) {
 		})
 	return ""
 }
+// Day bucket for a message (timezone-safe via dayLabel), for the "Today /
+// Yesterday / 3 July" separators between message groups (UX #23). Empty for a
+// dateless streaming placeholder.
+function msgDay(m) {
+	return dayLabel(msgStamp(m) || (m.creation_browser ? new Date(m.creation_browser) : null))
+}
+// Precompute a divider label per visible message in ONE pass: a label shows only
+// on the first message of a new day. A dateless row (streaming placeholder) is
+// skipped without resetting the running day, so it can't split a day group.
+const dayDividers = computed(() => {
+	const out = []
+	let prev = null
+	for (const m of visibleMessages.value) {
+		const d = msgDay(m)
+		if (d && d !== prev) {
+			out.push(d)
+			prev = d
+		} else {
+			out.push("")
+		}
+	}
+	return out
+})
 // Per-message Copy with a brief "copied" tick, and Edit (load a previous
 // command back into the composer to tweak and resend).
 const copiedId = ref("")
@@ -4116,6 +4140,12 @@ onUnmounted(() => {
 .jv-md :deep(.jv-md-list) { margin: 0 0 10px; padding-left: 20px; }
 .jv-md :deep(.jv-md-list li) { margin: 2px 0; }
 .jv-md :deep(.jv-md-code) { background: var(--surface-2); padding: 1px 5px; border-radius: 4px; font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+.jv-md :deep(.jv-md-list .jv-md-list) { margin: 2px 0; }
+.jv-md :deep(.jv-md-quote) { margin: 0 0 10px; padding: 2px 0 2px 12px; border-left: 3px solid var(--border-2); color: var(--text-2); }
+.jv-md :deep(del) { opacity: .65; }
+/* day separators between message groups (UX #23) */
+.jv-daydivider { display: flex; align-items: center; justify-content: center; margin: 6px 0 2px; }
+.jv-daydivider span { font-size: 11px; font-weight: 550; color: var(--text-3); background: var(--surface-1); border: 1px solid var(--border); border-radius: 999px; padding: 2px 10px; }
 .jv-md :deep(.jv-md-link) { color: var(--blue); text-decoration: none; font-weight: 500; }
 /* Auto-linked document IDs → open the record in ERPNext Desk. Dashed underline
    marks them as record links, distinct from plain markdown links. */


### PR DESCRIPTION
Phase 3 — the self-contained, build-verifiable slice. Stacked on #269 (Phase 2); base is `ux/chat-phase-2`.

## Changes
- **#20 Markdown renderer** — nested lists (indent-nested `<ul>/<ol>`), blockquotes (`>`), and strikethrough (`~~`). The agent's structured ERP output no longer flattens to one level or leaks raw `>` / `~~`. Security posture preserved (all text still `esc()`-escaped before the inline regexes).
- **#23 Day separators** — "Today / Yesterday / 3 July" dividers between message groups, computed in one pass and **timezone-safe** (via a new `dayLabel` in `utils/datetime.js`, matching how every other timestamp in the chat is rendered).

## Review
Reviewed by a Fable agent, which verified the list-nesting stack produces balanced, CommonMark-correct HTML across flat / nested / de-dent / mixed / jagged-indent cases and no injection path. Fixed its 3 day-divider findings: timezone parsing (was browser-local, contradicting the hover timestamps), a dateless-streaming-row spurious-divider race, and the per-render perf (hoisted to one `computed`).

## Deferred (with rationale)
The two headline structural items are **not** in this PR because they can't be safely verified without the app running and carry a large regression surface:
- **#18 Server-owned turn lifecycle** + **ChatView componentization** — big refactors of a 4,414-line file. Phase 1 already delivered most of #18's user-facing value tactically (persisted recovering state + reconstruction, error taxonomy, real Stop).
- **#19 run:end settle-flicker reconcile**, **#21 button/radius consolidation** — polish touching many call sites; better done live.

These are worth a follow-up once the stack is running locally.

Verified: Vite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)