### PR TITLE
security: remediate 25 confirmed tool-layer audit findings

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -420,18 +420,32 @@ _WRITE_TOOLS = frozenset({
 	"follow_document", "unfollow_document", "attach_to_doc",
 	"create_dashboard_chart", "create_dashboard",
 	"create_custom_skill", "update_wiki",
+	# Audited but NOT gated (see _GATED_WRITES comment below): run_scrutiny's
+	# optional persistence path inserts Jarvis Agent Run/Finding rows, and
+	# download_pdf/export_excel both insert a File doc (download_pdf also
+	# attaches it) - real DB writes that need an audit trail, not a
+	# confirmation card (audit-findings.md F24/F25).
+	"run_scrutiny", "download_pdf", "export_excel",
 })
 _PREVIEWABLE = frozenset({
 	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc",
 	"amend_doc", "delete_doc", "run_method",
 })
 # Writes that MUST get a human confirmation before executing (issue #186).
-# The lighter mutators in _WRITE_TOOLS (comments/tags/share/assign/attach/
-# dashboard-create) are intentionally NOT gated - they never fire the card.
+# The lighter mutators in _WRITE_TOOLS (comments/tags/attach/dashboard-create)
+# are intentionally NOT gated - they never fire the card. share_doc/assign_to
+# WERE in that "lighter" bucket but their own descriptors promise "ALWAYS
+# confirm" (share_doc: re-share/everyone=true grants; assign_to: emails a
+# third party) - audit-findings.md F17/F20/F23 - so they now gate too. Neither
+# is in _PREVIEWABLE/_DRY_RUN_ON_PARK: no side-effect-free sandbox preview is
+# meaningful for a share grant or a ToDo+notification email, so both fall
+# through to the described-intent park path (like send_email) rather than a
+# sandboxed dry-run.
 _GATED_WRITES = frozenset({
 	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc",
 	"amend_doc", "delete_doc", "run_method", "send_email",
 	"create_custom_skill", "update_wiki",
+	"share_doc", "assign_to",
 })
 # Irreversible/consequential subset - gated even when a user has auto-apply
 # on (Task 4 uses this; define it here so the sets live together).

--- a/jarvis/audit.py
+++ b/jarvis/audit.py
@@ -12,11 +12,13 @@ import json
 
 import frappe
 
-# Secret-shaped keys scrubbed from the logged args summary.
-_SECRET_KEYS = {
-    "password", "new_password", "pwd", "api_key", "api_secret", "secret",
-    "token", "access_token", "refresh_token", "key",
-}
+# Secret-shaped SUBSTRINGS scrubbed from the logged args summary (matched
+# against the lowercased key, not equality) - so compound field names like
+# llm_api_key, agent_token, smtp_password, jarvis_admin_api_secret,
+# chat_device_private_key all redact, not just a literal "password"/"token".
+_SECRET_KEYS = (
+    "password", "pwd", "secret", "token", "key",
+)
 _MAX_ARGS_CHARS = 2000
 
 
@@ -28,7 +30,7 @@ def record(*, tool: str, args: dict | None, ok: bool,
     Best-effort: never raises (audit must not break or fail the tool)."""
     try:
         doctype, name, method = _ref(args, result)
-        scrubbed = _scrub(args)
+        scrubbed = _scrub(args, _password_fields(doctype))
         rendered = json.dumps(scrubbed, default=str)
         if len(rendered) > _MAX_ARGS_CHARS:
             scrubbed = {"_truncated": rendered[:_MAX_ARGS_CHARS]}
@@ -67,14 +69,35 @@ def _ref(args, result):
     return doctype, name, method
 
 
-def _scrub(value):
+def _password_fields(doctype) -> frozenset:
+    """Password-fieldtype field names for ``doctype``, lowercased. Best-effort
+    (an unknown/bad doctype yields an empty set, never raises) - a defense-in-
+    depth layer alongside the substring match, so a Password field whose name
+    doesn't contain any of the generic ``_SECRET_KEYS`` substrings still
+    redacts, and it can never drift from the real schema."""
+    if not doctype:
+        return frozenset()
+    try:
+        return frozenset(f.lower() for f in frappe.get_meta(doctype).get_password_fields())
+    except Exception:
+        return frozenset()
+
+
+def _is_secret_key(key: str, extra_keys: frozenset) -> bool:
+    k = (key or "").lower()
+    if k in extra_keys:
+        return True
+    return any(s in k for s in _SECRET_KEYS)
+
+
+def _scrub(value, extra_keys: frozenset = frozenset()):
     """Recursively redact secret-shaped keys in dicts, including dicts nested in
     lists (e.g. child-table rows like values={"users":[{"password":...}]}).
     Non-collection values pass through. Size-capping is applied once by the
     caller after the whole structure is scrubbed."""
     if isinstance(value, dict):
-        return {k: ("[REDACTED]" if k.lower() in _SECRET_KEYS else _scrub(v))
+        return {k: ("[REDACTED]" if _is_secret_key(k, extra_keys) else _scrub(v, extra_keys))
                 for k, v in value.items()}
     if isinstance(value, list):
-        return [_scrub(item) for item in value]
+        return [_scrub(item, extra_keys) for item in value]
     return value

--- a/jarvis/audit.py
+++ b/jarvis/audit.py
@@ -70,17 +70,34 @@ def _ref(args, result):
 
 
 def _password_fields(doctype) -> frozenset:
-    """Password-fieldtype field names for ``doctype``, lowercased. Best-effort
-    (an unknown/bad doctype yields an empty set, never raises) - a defense-in-
-    depth layer alongside the substring match, so a Password field whose name
-    doesn't contain any of the generic ``_SECRET_KEYS`` substrings still
-    redacts, and it can never drift from the real schema."""
+    """Password-fieldtype field names for ``doctype``, lowercased, UNIONed with
+    the Password-fieldtype field names of every child table doctype (one level
+    deep) - a defense-in-depth layer alongside the substring match, so a
+    Password field whose name doesn't contain any of the generic
+    ``_SECRET_KEYS`` substrings still redacts (e.g. ``subscription_accounts``
+    on the ``Jarvis LLM Pool Model`` child table, reached via the ``models``
+    Table field on ``Jarvis Settings``), and it can never drift from the real
+    schema. Best-effort: an unknown/bad doctype yields an empty set, never
+    raises, but the lookup itself must not silently swallow a real bug - only
+    the per-doctype meta fetch is guarded, not the whole function."""
     if not doctype:
         return frozenset()
     try:
-        return frozenset(f.lower() for f in frappe.get_meta(doctype).get_password_fields())
+        meta = frappe.get_meta(doctype)
     except Exception:
         return frozenset()
+    names = {df.fieldname.lower() for df in meta.fields if df.fieldtype == "Password"}
+    for df in meta.fields:
+        if df.fieldtype != "Table" or not df.options:
+            continue
+        try:
+            child_meta = frappe.get_meta(df.options)
+        except Exception:
+            continue
+        names.update(
+            cf.fieldname.lower() for cf in child_meta.fields if cf.fieldtype == "Password"
+        )
+    return frozenset(names)
 
 
 def _is_secret_key(key: str, extra_keys: frozenset) -> bool:

--- a/jarvis/tests/test_agent_scrutiny.py
+++ b/jarvis/tests/test_agent_scrutiny.py
@@ -5,8 +5,12 @@ here. run_scrutiny is integration-validated against a live GL (see the
 build validation); its pure helpers (threshold binding, pack loading)
 are covered here.
 """
+import contextlib
 import os
 import unittest
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from jarvis.tools.compute_materiality import compute_materiality
 from jarvis.tools.run_scrutiny import (
@@ -292,3 +296,153 @@ class TestRunScrutinyLive(unittest.TestCase):
             touched | evaluated_clean,
             {"FPA-EXPENSE-VARIANCE-YOY", "FPA-PL-YOY-SWING"},
         )
+
+
+# ---------------------------------------------------------------------------
+# F5 (see .superpowers/sdd/audit-findings.md): run_scrutiny ran every
+# evaluator via raw frappe.db.sql with NO frappe.has_permission check
+# anywhere in the file, so any role could pull full GL/Account/Supplier data
+# for any company. These tests exercise the real permission decision (not a
+# mocked one) against real users/roles/company records, unlike the classes
+# above which pin the pure/live-GL behavior.
+# ---------------------------------------------------------------------------
+
+SCRUTINY_COMPANY_A = "_JPL Scrutiny Company A"
+SCRUTINY_COMPANY_B = "_JPL Scrutiny Company B"
+ROLE_NO_GRANTS = "JPL Scrutiny No Grants Role"
+USER_NO_GRANTS = "jpl-scrutiny-no-grants@example.com"
+# Accounts User grants role-level GL Entry + Company read, but this user is
+# additionally scoped by a Company User Permission to SCRUTINY_COMPANY_A -
+# the "restricted via a Company User Permission" case the audit findings
+# call out (a company-restricted user asking for a DIFFERENT company).
+USER_COMPANY_SCOPED = "jpl-scrutiny-company-scoped@example.com"
+
+
+def _ensure_role(name: str) -> None:
+    if not frappe.db.exists("Role", name):
+        frappe.get_doc({
+            "doctype": "Role", "role_name": name, "desk_access": 1, "is_custom": 1,
+        }).insert(ignore_permissions=True)
+
+
+def _ensure_user(email: str, roles: tuple) -> None:
+    if not frappe.db.exists("User", email):
+        frappe.get_doc({
+            "doctype": "User",
+            "email": email,
+            "first_name": email.split("@")[0],
+            "send_welcome_email": 0,
+            "enabled": 1,
+            "user_type": "System User",
+        }).insert(ignore_permissions=True)
+    user = frappe.get_doc("User", email)
+    if "System Manager" in frappe.get_roles(email):
+        user.remove_roles("System Manager")
+    missing = [r for r in roles if r not in frappe.get_roles(email)]
+    if missing:
+        user.add_roles(*missing)
+
+
+def _ensure_company(name: str, abbr: str) -> None:
+    if frappe.db.exists("Company", name):
+        return
+    # Skip default chart-of-accounts / warehouse / tax-template creation -
+    # this fixture only needs a Company row for permission checks, not a
+    # functioning ledger, and CI sites may be missing the fixtures those
+    # hooks depend on (e.g. Warehouse Type "Transit").
+    frappe.local.flags.ignore_chart_of_accounts = True
+    try:
+        frappe.get_doc({
+            "doctype": "Company",
+            "company_name": name,
+            "abbr": abbr,
+            "default_currency": "INR",
+            "country": "India",
+        }).insert(ignore_permissions=True)
+    finally:
+        frappe.local.flags.ignore_chart_of_accounts = False
+
+
+def _ensure_user_permission(user: str, allow: str, for_value: str) -> None:
+    if frappe.db.exists("User Permission", {"user": user, "allow": allow, "for_value": for_value}):
+        return
+    frappe.get_doc({
+        "doctype": "User Permission", "user": user, "allow": allow, "for_value": for_value,
+    }).insert(ignore_permissions=True)
+
+
+@contextlib.contextmanager
+def _as(user: str):
+    orig = frappe.session.user
+    frappe.set_user(user)
+    try:
+        yield
+    finally:
+        frappe.set_user(orig)
+
+
+def _trivial_pack():
+    # tb_balance_check just sums debit/credit over the (empty) GL for the
+    # company - no seeded ledger data needed to exercise the permission
+    # gate, which fires before any SQL runs.
+    return {"pack_id": "inline-perm-test", "rules": [
+        {"rule_id": "T-TB", "kind": "tb_balance_check", "params": {}, "severity": "note",
+         "domain": "audit", "status": "active", "statement": "trial balance check"},
+    ]}
+
+
+class TestRunScrutinyPermissionGate(FrappeTestCase):
+    """F5: run_scrutiny must gate on GL Entry read + Company read before
+    running any raw SQL."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        # Roles/users are cheap, harmless to leave committed (reused
+        # idempotently across runs, mirrors test_permlevel_leak.py).
+        _ensure_role(ROLE_NO_GRANTS)
+        _ensure_user(USER_NO_GRANTS, roles=(ROLE_NO_GRANTS,))
+        _ensure_user(USER_COMPANY_SCOPED, roles=("Accounts User",))
+        frappe.db.commit()
+        # Company/User Permission are NOT committed - a leftover Company
+        # row changes production inference elsewhere (this very file's
+        # TestRunScrutinyLive picks "the single Company on the site" as a
+        # default), so these must vanish via FrappeTestCase's automatic
+        # per-class rollback rather than persist across test modules.
+        # They're still visible within this class's own transaction (same
+        # DB connection), which is all these tests need.
+        _ensure_company(SCRUTINY_COMPANY_A, "JPLSA")
+        _ensure_company(SCRUTINY_COMPANY_B, "JPLSB")
+        _ensure_user_permission(USER_COMPANY_SCOPED, "Company", SCRUTINY_COMPANY_A)
+
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+    def test_restricted_user_denied_before_any_query(self):
+        with _as(USER_NO_GRANTS), self.assertRaises(frappe.PermissionError):
+            run_scrutiny(
+                rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_A,
+                from_date="2026-01-01", to_date="2026-12-31",
+            )
+
+    def test_company_scoped_user_denied_for_other_company(self):
+        with _as(USER_COMPANY_SCOPED), self.assertRaises(frappe.PermissionError):
+            run_scrutiny(
+                rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_B,
+                from_date="2026-01-01", to_date="2026-12-31",
+            )
+
+    def test_company_scoped_user_still_succeeds_for_own_company(self):
+        with _as(USER_COMPANY_SCOPED):
+            res = run_scrutiny(
+                rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_A,
+                from_date="2026-01-01", to_date="2026-12-31",
+            )
+        self.assertEqual(res["scope"]["company"], SCRUTINY_COMPANY_A)
+        self.assertEqual(res["skipped_unsupported"], [])

--- a/jarvis/tests/test_agent_scrutiny.py
+++ b/jarvis/tests/test_agent_scrutiny.py
@@ -20,7 +20,7 @@ from jarvis.tools.run_scrutiny import (
     _resolve_threshold,
     run_scrutiny,
 )
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 _MARKETPLACE_PACK = "/home/vignesh/jarvis/jarvis-agent-marketplace/rules/scrutiny-pack.json"
 _BENCH_PACK = os.path.join(
@@ -316,6 +316,14 @@ USER_NO_GRANTS = "jpl-scrutiny-no-grants@example.com"
 # the "restricted via a Company User Permission" case the audit findings
 # call out (a company-restricted user asking for a DIFFERENT company).
 USER_COMPANY_SCOPED = "jpl-scrutiny-company-scoped@example.com"
+# ERPNext's stock "Auditor" role: granted GL Entry read (via role
+# permission), but only Company "select" (not "read") - no Company User
+# Permission at all. This is exactly the over-block Fix 1 addresses: an
+# audit-agent user in this role must be able to run_scrutiny.
+USER_AUDITOR = "jpl-scrutiny-auditor@example.com"
+# A role with read on plenty of ERP doctypes but NOT GL Entry - must still
+# be denied by the GL Entry read gate, unaffected by the company-scope fix.
+USER_NON_GL = "jpl-scrutiny-sales@example.com"
 
 
 def _ensure_role(name: str) -> None:
@@ -404,6 +412,8 @@ class TestRunScrutinyPermissionGate(FrappeTestCase):
         _ensure_role(ROLE_NO_GRANTS)
         _ensure_user(USER_NO_GRANTS, roles=(ROLE_NO_GRANTS,))
         _ensure_user(USER_COMPANY_SCOPED, roles=("Accounts User",))
+        _ensure_user(USER_AUDITOR, roles=("Auditor",))
+        _ensure_user(USER_NON_GL, roles=("Sales User",))
         frappe.db.commit()
         # Company/User Permission are NOT committed - a leftover Company
         # row changes production inference elsewhere (this very file's
@@ -432,7 +442,10 @@ class TestRunScrutinyPermissionGate(FrappeTestCase):
             )
 
     def test_company_scoped_user_denied_for_other_company(self):
-        with _as(USER_COMPANY_SCOPED), self.assertRaises(frappe.PermissionError):
+        # Company scoping is enforced via the Company User Permission, not
+        # a Company-doctype read check (Fix 1) - the denial is now a
+        # jarvis PermissionDeniedError, not frappe.PermissionError.
+        with _as(USER_COMPANY_SCOPED), self.assertRaises(PermissionDeniedError):
             run_scrutiny(
                 rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_B,
                 from_date="2026-01-01", to_date="2026-12-31",
@@ -446,3 +459,25 @@ class TestRunScrutinyPermissionGate(FrappeTestCase):
             )
         self.assertEqual(res["scope"]["company"], SCRUTINY_COMPANY_A)
         self.assertEqual(res["skipped_unsupported"], [])
+
+    def test_auditor_role_can_run_without_company_user_permission(self):
+        # Auditor has GL Entry read but only Company "select" (not "read")
+        # and no Company User Permission scoping it - under the old
+        # Company-doctype-read gate this was denied entirely (the bug Fix 1
+        # addresses); under the fix it must succeed, unrestricted.
+        with _as(USER_AUDITOR):
+            res = run_scrutiny(
+                rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_A,
+                from_date="2026-01-01", to_date="2026-12-31",
+            )
+        self.assertEqual(res["scope"]["company"], SCRUTINY_COMPANY_A)
+        self.assertEqual(res["skipped_unsupported"], [])
+
+    def test_non_gl_role_still_denied(self):
+        # A role with no GL Entry read at all (e.g. Sales User) must still
+        # be denied - the company-scope rework must not loosen this gate.
+        with _as(USER_NON_GL), self.assertRaises(frappe.PermissionError):
+            run_scrutiny(
+                rule_pack=_trivial_pack(), company=SCRUTINY_COMPANY_A,
+                from_date="2026-01-01", to_date="2026-12-31",
+            )

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -84,6 +84,85 @@ class TestGateParks(FrappeTestCase):
 		self.assertIsNotNone(captured.get("token"))
 
 
+class TestShareAssignGatedWrites(FrappeTestCase):
+	"""F17/F20 (share_doc) + F23 (assign_to): their own docstrings/descriptors
+	say "ALWAYS confirm" (share_doc: re-share/everyone=true is a permission
+	escalation; assign_to: a person gets a notification email) but neither
+	tool was in _GATED_WRITES, so a model-path call fired immediately with no
+	human confirmation - the exact prompt-injection escalation risk their own
+	authors documented as requiring a gate. Both now park like send_email:
+	described-intent preview, never sandbox-executed."""
+
+	def test_share_doc_and_assign_to_are_gated_not_auto_applyable(self):
+		self.assertIn("share_doc", api._GATED_WRITES)
+		self.assertIn("assign_to", api._GATED_WRITES)
+		self.assertNotIn("share_doc", api._AUTO_APPLYABLE)
+		self.assertNotIn("assign_to", api._AUTO_APPLYABLE)
+
+	def test_share_doc_parks_described_and_does_not_execute(self):
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "jarvis-test-share-gate-target",
+		}).insert(ignore_permissions=True)
+		patcher, captured = _spy_mint()
+		with patch("jarvis.api.dispatch") as disp, patcher:
+			r = api._run_tool("share_doc", {
+				"doctype": "ToDo", "name": todo.name,
+				"user": "jarvis-share-gate-target@example.com", "share": True,
+			})
+			# The gate parks BEFORE any dispatch: share_doc never fired.
+			self.assertFalse(disp.called)
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertEqual(r["data"]["tool"], "share_doc")
+		preview = r["data"]["preview"]
+		# Not previewable (no side-effect-free sandbox dry-run for a share
+		# grant) - described intent, like send_email.
+		self.assertFalse(preview["preview"])
+		self.assertTrue(preview["described"])
+		self.assertIn("summary", preview)
+		self.assertIsNotNone(captured.get("token"))
+		self.assertFalse(frappe.db.exists("DocShare", {
+			"share_doctype": "ToDo", "share_name": todo.name,
+			"user": "jarvis-share-gate-target@example.com",
+		}))
+
+	def test_assign_to_parks_described_and_does_not_execute(self):
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "jarvis-test-assign-gate-target",
+		}).insert(ignore_permissions=True)
+		patcher, captured = _spy_mint()
+		with patch("jarvis.api.dispatch") as disp, patcher:
+			r = api._run_tool("assign_to", {
+				"doctype": "ToDo", "name": todo.name, "user": "Administrator",
+			})
+			# The gate parks BEFORE any dispatch: assign_to never fired, so no
+			# ToDo/notification is created for the confirmation-less call.
+			self.assertFalse(disp.called)
+		self.assertTrue(r["ok"])
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertEqual(r["data"]["tool"], "assign_to")
+		preview = r["data"]["preview"]
+		self.assertFalse(preview["preview"])
+		self.assertTrue(preview["described"])
+		self.assertIn("summary", preview)
+		self.assertIsNotNone(captured.get("token"))
+
+
+class TestDryRunOnParkInvariant(FrappeTestCase):
+	"""api.py's comment above _DRY_RUN_ON_PARK documents an invariant: every
+	tool dry-run at park time must also be _PREVIEWABLE, or the LIVE park
+	path (a real sandboxed dry-run) and the RESYNC path (_pending_preview,
+	which routes purely on _PREVIEWABLE membership) diverge - a reload/
+	reconnect would silently degrade a real dry-run card to a blind
+	described-intent one (see test_create_docs_resync_preview_is_dry_run_
+	not_described below for the concrete failure mode this guards against).
+	This asserts the invariant holds as a standing regression guard, since
+	nothing else in the module enforces it structurally."""
+
+	def test_dry_run_on_park_is_subset_of_previewable(self):
+		self.assertTrue(api._DRY_RUN_ON_PARK.issubset(api._PREVIEWABLE))
+
+
 class TestGatePreValidatesBeforePark(FrappeTestCase):
 	"""A dry-runnable gated write is validated in the sandbox BEFORE the
 	confirmation card is minted. A deterministic failure (e.g. a missing

--- a/jarvis/tests/test_create_doc.py
+++ b/jarvis/tests/test_create_doc.py
@@ -69,6 +69,8 @@ class TestCreateDocValidation(FrappeTestCase):
 					self._values[f] = v
 				def insert(self):
 					pass
+				def apply_fieldlevel_read_permissions(self):
+					pass
 				def as_dict(self):
 					return {"doctype": dt, "name": "generated", **self._values}
 			return _Stub()

--- a/jarvis/tests/test_permlevel_leak.py
+++ b/jarvis/tests/test_permlevel_leak.py
@@ -1,0 +1,313 @@
+"""Regression tests for the permlevel-leak finding group (F1, F3, F7, F8, F9,
+F10, F22 - see .superpowers/sdd/audit-findings.md).
+
+All six mutating/read tools (get_doc, create_doc, update_doc, submit_doc,
+cancel_doc, amend_doc) returned ``doc.as_dict()`` without first calling
+``doc.apply_fieldlevel_read_permissions()``, so a permlevel-restricted field
+on the doc travelled straight back to a caller who lacks that permlevel role
+- even though ``frappe.has_permission(..., ptype=...)`` only gates the
+document as a whole, not individual fields. preview_doc has the same bug
+class structurally: ``_summarize()`` echoes header field values with no
+permlevel filter.
+
+Fixture: one custom submittable DocType (``JV Permlevel Test``) with a
+permlevel-0 field and a permlevel-1 field (default value = SECRET_VALUE, so
+every fresh/copied doc carries it automatically). Two System Users:
+
+- ``USER_RESTRICTED`` holds a role with full permlevel-0 CRUD + submit/
+  cancel/amend, but no permlevel-1 grant at all.
+- ``USER_PRIVILEGED`` holds a role with the same permlevel-0 grants *plus*
+  permlevel-1 read/write.
+
+Each test proves the restricted user's tool call does NOT surface the
+restricted field's real value (``apply_fieldlevel_read_permissions()``
+nulls it out, though the schema-defined key still appears in ``as_dict()``),
+while the privileged user's identical call does - so the fix strips the
+leak without breaking legitimate access.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import frappe
+from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools.amend_doc import amend_doc
+from jarvis.tools.cancel_doc import cancel_doc
+from jarvis.tools.create_doc import create_doc
+from jarvis.tools.get_doc import get_doc
+from jarvis.tools.preview_doc import preview_doc
+from jarvis.tools.submit_doc import submit_doc
+from jarvis.tools.update_doc import update_doc
+
+DT_NAME = "JV Permlevel Test"
+FIELD_PUBLIC = "public_field"
+FIELD_RESTRICTED = "restricted_field"
+ROLE_BASE = "JPL Permlevel Base Role"
+ROLE_PRIV = "JPL Permlevel Priv Role"
+USER_RESTRICTED = "jpl-permlevel-restricted@example.com"
+USER_PRIVILEGED = "jpl-permlevel-privileged@example.com"
+SECRET_VALUE = "top-secret-value"
+
+
+def _ensure_role(name: str) -> None:
+	if not frappe.db.exists("Role", name):
+		frappe.get_doc({
+			"doctype": "Role", "role_name": name, "desk_access": 1, "is_custom": 1,
+		}).insert(ignore_permissions=True)
+
+
+def _ensure_user(email: str, roles: tuple) -> None:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": email.split("@")[0],
+			"send_welcome_email": 0,
+			"enabled": 1,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	user = frappe.get_doc("User", email)
+	if user.user_type != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
+		user = frappe.get_doc("User", email)
+	if "System Manager" in frappe.get_roles(email):
+		user.remove_roles("System Manager")
+	missing = [r for r in roles if r not in frappe.get_roles(email)]
+	if missing:
+		user.add_roles(*missing)
+
+
+def _ensure_doctype() -> None:
+	# Recreate on every run rather than skip-if-exists: this fixture's shape
+	# is authoritative for this test module, and a stale schema from an
+	# earlier iteration would silently invalidate the assertions below.
+	if frappe.db.exists("DocType", DT_NAME):
+		frappe.delete_doc("DocType", DT_NAME, force=True, ignore_permissions=True)
+	new_doctype(
+		name=DT_NAME,
+		custom=1,
+		is_submittable=1,
+		fields=[
+			{"label": "Public Field", "fieldname": FIELD_PUBLIC, "fieldtype": "Data", "permlevel": 0},
+			{
+				"label": "Restricted Field",
+				"fieldname": FIELD_RESTRICTED,
+				"fieldtype": "Data",
+				"permlevel": 1,
+				"default": SECRET_VALUE,
+			},
+		],
+		permissions=[
+			{
+				"role": ROLE_BASE, "permlevel": 0, "read": 1, "write": 1, "create": 1,
+				"submit": 1, "cancel": 1, "amend": 1,
+			},
+			{
+				"role": ROLE_PRIV, "permlevel": 0, "read": 1, "write": 1, "create": 1,
+				"submit": 1, "cancel": 1, "amend": 1,
+			},
+			{"role": ROLE_PRIV, "permlevel": 1, "read": 1, "write": 1},
+		],
+	).insert()
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _make_doc(*, docstatus: int = 0) -> str:
+	"""Insert a JV Permlevel Test doc as Administrator (bypasses permlevel
+	entirely, so the restricted field lands with its real SECRET_VALUE
+	default) and drive it to the requested docstatus."""
+	doc = frappe.get_doc({"doctype": DT_NAME, FIELD_PUBLIC: "visible"})
+	doc.insert(ignore_permissions=True)
+	if docstatus >= 1:
+		doc.submit()
+	if docstatus >= 2:
+		doc.cancel()
+	frappe.db.commit()
+	return doc.name
+
+
+class PermlevelLeakTestCase(FrappeTestCase):
+	"""Shared fixture for the whole finding group."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		_ensure_role(ROLE_BASE)
+		_ensure_role(ROLE_PRIV)
+		_ensure_doctype()
+		_ensure_user(USER_RESTRICTED, roles=(ROLE_BASE,))
+		_ensure_user(USER_PRIVILEGED, roles=(ROLE_PRIV,))
+		frappe.db.commit()
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.delete(DT_NAME)
+		frappe.db.commit()
+		super().tearDown()
+
+
+class TestGetDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F1: get_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		name = _make_doc()
+		with _as(USER_RESTRICTED):
+			result = get_doc(doctype=DT_NAME, name=name)
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result[FIELD_PUBLIC], "visible")
+
+	def test_privileged_user_sees_restricted_field(self):
+		name = _make_doc()
+		with _as(USER_PRIVILEGED):
+			result = get_doc(doctype=DT_NAME, name=name)
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestCreateDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F7: create_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		with _as(USER_RESTRICTED):
+			result = create_doc(doctype=DT_NAME, values={FIELD_PUBLIC: "created"})
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result[FIELD_PUBLIC], "created")
+
+	def test_privileged_user_sees_restricted_field(self):
+		with _as(USER_PRIVILEGED):
+			result = create_doc(doctype=DT_NAME, values={FIELD_PUBLIC: "created"})
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestUpdateDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F8: update_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		name = _make_doc()
+		with _as(USER_RESTRICTED):
+			result = update_doc(doctype=DT_NAME, name=name, changes={FIELD_PUBLIC: "updated"})
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result[FIELD_PUBLIC], "updated")
+
+	def test_privileged_user_sees_restricted_field(self):
+		name = _make_doc()
+		with _as(USER_PRIVILEGED):
+			result = update_doc(doctype=DT_NAME, name=name, changes={FIELD_PUBLIC: "updated"})
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestSubmitDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F9: submit_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		name = _make_doc(docstatus=0)
+		with _as(USER_RESTRICTED):
+			result = submit_doc(doctype=DT_NAME, name=name)
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result["docstatus"], 1)
+
+	def test_privileged_user_sees_restricted_field(self):
+		name = _make_doc(docstatus=0)
+		with _as(USER_PRIVILEGED):
+			result = submit_doc(doctype=DT_NAME, name=name)
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestCancelDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F3: cancel_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		name = _make_doc(docstatus=1)
+		with _as(USER_RESTRICTED):
+			result = cancel_doc(doctype=DT_NAME, name=name)
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result["docstatus"], 2)
+
+	def test_privileged_user_sees_restricted_field(self):
+		name = _make_doc(docstatus=1)
+		with _as(USER_PRIVILEGED):
+			result = cancel_doc(doctype=DT_NAME, name=name)
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestAmendDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F22: amend_doc."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		name = _make_doc(docstatus=2)
+		with _as(USER_RESTRICTED):
+			result = amend_doc(doctype=DT_NAME, name=name)
+		# apply_fieldlevel_read_permissions() deletes the in-memory attribute,
+		# but as_dict() still emits the key (schema-defined column) with a
+		# None fallback rather than omitting it - assert the value is gone,
+		# not the key.
+		self.assertIsNone(result.get(FIELD_RESTRICTED))
+		self.assertEqual(result["docstatus"], 0)
+
+	def test_privileged_user_sees_restricted_field(self):
+		name = _make_doc(docstatus=2)
+		with _as(USER_PRIVILEGED):
+			result = amend_doc(doctype=DT_NAME, name=name)
+		self.assertEqual(result[FIELD_RESTRICTED], SECRET_VALUE)
+
+
+class TestPreviewDocPermlevelLeak(PermlevelLeakTestCase):
+	"""F10: preview_doc - structural (no as_dict; _summarize() echoes
+	header field values). The restricted caller supplies a guessed value
+	for the restricted field; Frappe's write-side permlevel reset silently
+	overwrites it back to the REAL default inside the preview sandbox's
+	doc.insert(), so an unfiltered echo hands back the real secret instead
+	of the caller's own guess - or a validation error."""
+
+	def test_restricted_user_does_not_see_restricted_field(self):
+		with _as(USER_RESTRICTED):
+			result = preview_doc(
+				DT_NAME, {FIELD_PUBLIC: "visible", FIELD_RESTRICTED: "guessed-value"}
+			)
+		self.assertTrue(result["valid"])
+		self.assertNotIn(FIELD_RESTRICTED, result["resolved"])
+
+	def test_privileged_user_sees_restricted_field(self):
+		with _as(USER_PRIVILEGED):
+			result = preview_doc(
+				DT_NAME, {FIELD_PUBLIC: "visible", FIELD_RESTRICTED: "guessed-value"}
+			)
+		self.assertTrue(result["valid"])
+		self.assertEqual(result["resolved"][FIELD_RESTRICTED], "guessed-value")

--- a/jarvis/tests/test_permlevel_leak.py
+++ b/jarvis/tests/test_permlevel_leak.py
@@ -45,11 +45,13 @@ from jarvis.tools.update_doc import update_doc
 DT_NAME = "JV Permlevel Test"
 FIELD_PUBLIC = "public_field"
 FIELD_RESTRICTED = "restricted_field"
+FIELD_TOTAL = "grand_total"
 ROLE_BASE = "JPL Permlevel Base Role"
 ROLE_PRIV = "JPL Permlevel Priv Role"
 USER_RESTRICTED = "jpl-permlevel-restricted@example.com"
 USER_PRIVILEGED = "jpl-permlevel-privileged@example.com"
 SECRET_VALUE = "top-secret-value"
+SECRET_TOTAL = 918273.0
 
 
 def _ensure_role(name: str) -> None:
@@ -99,6 +101,13 @@ def _ensure_doctype() -> None:
 				"fieldtype": "Data",
 				"permlevel": 1,
 				"default": SECRET_VALUE,
+			},
+			{
+				"label": "Grand Total",
+				"fieldname": FIELD_TOTAL,
+				"fieldtype": "Currency",
+				"permlevel": 1,
+				"default": str(SECRET_TOTAL),
 			},
 		],
 		permissions=[
@@ -311,3 +320,25 @@ class TestPreviewDocPermlevelLeak(PermlevelLeakTestCase):
 			)
 		self.assertTrue(result["valid"])
 		self.assertEqual(result["resolved"][FIELD_RESTRICTED], "guessed-value")
+
+
+class TestPreviewDocTotalsPermlevelLeak(PermlevelLeakTestCase):
+	"""F10 completion: `_summarize()`'s `totals` dict comprehension (the
+	`_TOTAL_FIELDS` net_total/total_taxes_and_charges/grand_total/
+	rounded_total) did an unguarded `doc.get(f)` with no permlevel filter,
+	unlike `resolved`/`server_filled`. A tenant who customizes one of those
+	fields to permlevel>0 (fixture: `grand_total`, default SECRET_TOTAL) had
+	its real server-computed value leak to a restricted caller via `totals`
+	even though the same field is correctly withheld from `resolved`."""
+
+	def test_restricted_user_does_not_see_restricted_total(self):
+		with _as(USER_RESTRICTED):
+			result = preview_doc(DT_NAME, {FIELD_PUBLIC: "visible"})
+		self.assertTrue(result["valid"])
+		self.assertNotIn(FIELD_TOTAL, result["totals"])
+
+	def test_privileged_user_sees_restricted_total(self):
+		with _as(USER_PRIVILEGED):
+			result = preview_doc(DT_NAME, {FIELD_PUBLIC: "visible"})
+		self.assertTrue(result["valid"])
+		self.assertEqual(float(result["totals"][FIELD_TOTAL]), SECRET_TOTAL)

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -1900,3 +1900,300 @@ class TestQuerySqlInjectionHardening(FrappeTestCase):
 			           "value": "%Administrator%"}],
 		})
 		self.assertIn("_assign", sql)
+
+
+class TestQueryPermlevelFieldACL(FrappeTestCase):
+	"""F2: the column resolver must enforce field-level (permlevel) read
+	permission, mirroring frappe.get_list's apply_fieldlevel_read_permissions
+	(frappe/model/db_query.py -> frappe.model.get_permitted_fields).
+
+	Pre-fix, ``_validate_column`` only proved a column EXISTED
+	(``get_valid_columns()``), never that the caller could READ it. A user
+	with plain doctype read but no elevated-permlevel role could
+	select / filter / order / group-by / having / join-on / EXISTS any
+	permlevel>0 field. These tests prove:
+
+	- A restricted user (permlevel-0 role only) is DENIED on a permlevel>0
+	  field in every field position that funnels through the resolver.
+	- A permlevel-0 field still works for that restricted user (no
+	  over-blocking).
+	- A privileged user (permlevel-1 role) can read the restricted field.
+	- Child-table fields are gated via the base/FROM doctype's permissions
+	  (parenttype), exactly as apply_fieldlevel_read_permissions does.
+
+	Fixture mirrors test_permlevel_leak.py: one header doctype + one child
+	table doctype, each with a permlevel-0 and a permlevel-1 field; a base
+	role (permlevel-0 grants only) and a priv role (adds permlevel-1 read).
+
+	Note on child-table tests: ``frappe.has_permission(<child>, "read")``
+	with no parent context returns False for non-admins (Frappe's
+	has_child_permission), so the query tool's DocType-level gate (step 3)
+	would block a non-admin child-table join for an unrelated reason. Those
+	tests patch ``frappe.has_permission`` to isolate the *field-level* ACL,
+	while still running as the real restricted / privileged user so the
+	role-driven permlevel resolution is exercised for real.
+	"""
+
+	PARENT_DT = "JV Query Permlevel Parent"
+	CHILD_DT = "JV Query Permlevel Child"
+	F_PUBLIC = "public_field"
+	F_RESTRICTED = "restricted_field"
+	CF_PUBLIC = "child_public"
+	CF_RESTRICTED = "child_restricted"
+	ROLE_BASE = "JQP Base Role"
+	ROLE_PRIV = "JQP Priv Role"
+	USER_RESTRICTED = "jqp-restricted@example.com"
+	USER_PRIVILEGED = "jqp-privileged@example.com"
+
+	@staticmethod
+	def _ensure_role(name: str) -> None:
+		if not frappe.db.exists("Role", name):
+			frappe.get_doc({
+				"doctype": "Role", "role_name": name, "desk_access": 1, "is_custom": 1,
+			}).insert(ignore_permissions=True)
+
+	@staticmethod
+	def _ensure_user(email: str, roles: tuple) -> None:
+		if not frappe.db.exists("User", email):
+			frappe.get_doc({
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}).insert(ignore_permissions=True)
+		user = frappe.get_doc("User", email)
+		if "System Manager" in frappe.get_roles(email):
+			user.remove_roles("System Manager")
+		missing = [r for r in roles if r not in frappe.get_roles(email)]
+		if missing:
+			user.add_roles(*missing)
+
+	@classmethod
+	def _ensure_doctypes(cls) -> None:
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		for dt in (cls.PARENT_DT, cls.CHILD_DT):
+			if frappe.db.exists("DocType", dt):
+				frappe.delete_doc("DocType", dt, force=True, ignore_permissions=True)
+		# Child table (istable) — its own permissions are irrelevant to the
+		# field ACL (the parent's permissions govern child fields), but it
+		# must exist before the parent references it.
+		new_doctype(
+			name=cls.CHILD_DT,
+			custom=1,
+			istable=1,
+			fields=[
+				{"label": "Child Public", "fieldname": cls.CF_PUBLIC,
+				 "fieldtype": "Data", "permlevel": 0},
+				{"label": "Child Restricted", "fieldname": cls.CF_RESTRICTED,
+				 "fieldtype": "Data", "permlevel": 1},
+			],
+			permissions=[],
+		).insert()
+		new_doctype(
+			name=cls.PARENT_DT,
+			custom=1,
+			fields=[
+				{"label": "Public Field", "fieldname": cls.F_PUBLIC,
+				 "fieldtype": "Data", "permlevel": 0},
+				{"label": "Restricted Field", "fieldname": cls.F_RESTRICTED,
+				 "fieldtype": "Data", "permlevel": 1},
+				{"label": "Items", "fieldname": "items", "fieldtype": "Table",
+				 "options": cls.CHILD_DT},
+			],
+			permissions=[
+				{"role": cls.ROLE_BASE, "permlevel": 0, "read": 1, "write": 1, "create": 1},
+				{"role": cls.ROLE_PRIV, "permlevel": 0, "read": 1, "write": 1, "create": 1},
+				{"role": cls.ROLE_PRIV, "permlevel": 1, "read": 1, "write": 1},
+			],
+		).insert()
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls._ensure_role(cls.ROLE_BASE)
+		cls._ensure_role(cls.ROLE_PRIV)
+		cls._ensure_doctypes()
+		cls._ensure_user(cls.USER_RESTRICTED, (cls.ROLE_BASE,))
+		cls._ensure_user(cls.USER_PRIVILEGED, (cls.ROLE_PRIV,))
+		frappe.db.commit()
+		# Warm the meta cache for the fixture doctypes. The run-tests harness
+		# on this site can hit a pre-existing infinite get_meta recursion when
+		# cold-loading a doctype's meta (client_cache not persisting mid-load,
+		# unrelated to this fix — it also flakes existing Sales Invoice / User
+		# tests). Warming here keeps the child-table tests off that path.
+		frappe.get_meta(cls.PARENT_DT)
+		frappe.get_meta(cls.CHILD_DT)
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		# Ensure the shared per-site allowlist doesn't pre-empt the
+		# field-level check with an allowlist rejection.
+		settings = frappe.get_single("Jarvis Settings")
+		settings.run_query_doctype_allowlist = ""
+		settings.save(ignore_permissions=True)
+		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		super().tearDown()
+
+	# ---- header-doctype field positions (run fully real) -----------
+
+	def test_restricted_cannot_select_permlevel_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError) as cm:
+			query({
+				"from": self.PARENT_DT, "alias": "p",
+				"select": ["p.public_field", "p.restricted_field"],
+			})
+		self.assertIn("restricted_field", str(cm.exception))
+
+	def test_restricted_cannot_filter_permlevel_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({
+				"from": self.PARENT_DT, "alias": "p",
+				"select": ["p.public_field"],
+				"where": [{"field": "p.restricted_field", "op": "=", "value": "x"}],
+			})
+
+	def test_restricted_cannot_order_by_permlevel_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({
+				"from": self.PARENT_DT, "alias": "p",
+				"select": ["p.public_field"],
+				"order_by": [{"field": "p.restricted_field", "dir": "asc"}],
+			})
+
+	def test_restricted_cannot_group_by_permlevel_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({
+				"from": self.PARENT_DT, "alias": "p",
+				"select": ["p.public_field"],
+				"group_by": ["p.restricted_field"],
+			})
+
+	def test_restricted_cannot_having_permlevel_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with self.assertRaises(PermissionDeniedError):
+			query({
+				"from": self.PARENT_DT, "alias": "p",
+				"select": ["p.public_field"],
+				"group_by": ["p.public_field"],
+				"having": [{"field": "p.restricted_field", "op": "=", "value": "x"}],
+			})
+
+	def test_restricted_can_select_public_field(self):
+		"""Over-block guard: a permlevel-0 field still works for the
+		restricted user (runs fully real end-to-end)."""
+		frappe.set_user(self.USER_RESTRICTED)
+		result = query({
+			"from": self.PARENT_DT, "alias": "p",
+			"select": ["p.name", "p.public_field"],
+		})
+		self.assertIn("rows", result)
+
+	def test_privileged_can_select_permlevel_field(self):
+		frappe.set_user(self.USER_PRIVILEGED)
+		result = query({
+			"from": self.PARENT_DT, "alias": "p",
+			"select": ["p.name", "p.public_field", "p.restricted_field"],
+		})
+		self.assertIn("rows", result)
+
+	# ---- child-table field positions (parenttype resolution) -------
+
+	def test_restricted_cannot_select_child_permlevel_field(self):
+		"""Child-table permlevel field is gated via the base/FROM doctype's
+		permissions (parenttype), mirroring
+		apply_fieldlevel_read_permissions' parenttype=self.doctype."""
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				query({
+					"from": self.PARENT_DT, "alias": "p",
+					"joins": [{
+						"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+						"on": {"c.parent": "p.name"},
+					}],
+					"select": ["p.name", "c.child_restricted"],
+				})
+		self.assertIn("child_restricted", str(cm.exception))
+
+	def test_restricted_can_select_child_public_field(self):
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine, \
+		     patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			result = query({
+				"from": self.PARENT_DT, "alias": "p",
+				"joins": [{
+					"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+					"on": {"c.parent": "p.name"},
+				}],
+				"select": ["p.name", "c.child_public"],
+			})
+		self.assertIn("rows", result)
+
+	def test_privileged_can_select_child_permlevel_field(self):
+		frappe.set_user(self.USER_PRIVILEGED)
+		with patch("frappe.has_permission", return_value=True), \
+		     patch("frappe.database.query.Engine") as fake_engine, \
+		     patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			result = query({
+				"from": self.PARENT_DT, "alias": "p",
+				"joins": [{
+					"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+					"on": {"c.parent": "p.name"},
+				}],
+				"select": ["p.name", "c.child_restricted"],
+			})
+		self.assertIn("rows", result)
+
+	# ---- join ON + EXISTS positions --------------------------------
+
+	def test_restricted_cannot_join_on_permlevel_field(self):
+		"""A permlevel>0 field used in a JOIN ... ON clause is gated too."""
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError) as cm:
+				query({
+					"from": self.PARENT_DT, "alias": "p",
+					"joins": [{
+						"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+						"on": {"c.child_restricted": "p.restricted_field"},
+					}],
+					"select": ["p.name"],
+				})
+		# The lhs (c.child_restricted) resolves first, so the error names it.
+		self.assertIn("child_restricted", str(cm.exception))
+
+	def test_restricted_cannot_reference_permlevel_field_in_exists(self):
+		"""A permlevel>0 field inside an EXISTS sub-spec WHERE is gated."""
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch("frappe.has_permission", return_value=True):
+			with self.assertRaises(PermissionDeniedError):
+				query({
+					"from": self.PARENT_DT, "alias": "p",
+					"select": ["p.name"],
+					"where": [{
+						"op": "exists",
+						"value": {
+							"from": self.PARENT_DT, "alias": "p2",
+							"where": [{
+								"field": "p2.restricted_field", "op": "=",
+								"value": "x",
+							}],
+						},
+					}],
+				})

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -109,6 +109,12 @@ class TestQueryPermissions(FrappeTestCase):
 			checked.append(doctype)
 			return True
 
+		# Warm the meta cache before patching the query Engine: _validate_doctype
+		# calls frappe.get_meta, which would otherwise load these DocTypes via the
+		# patched Engine (returning MagicMocks) and recurse. Deterministic
+		# regardless of whether a prior test left these metas cached.
+		frappe.get_meta("Sales Invoice")
+		frappe.get_meta("Sales Invoice Item")
 		with patch("frappe.has_permission", side_effect=fake_has_perm), \
 		     patch("frappe.database.query.Engine") as fake_engine, \
 		     patch("pypika.queries.QueryBuilder.run", return_value=[]):

--- a/jarvis/tests/test_read_file_perm.py
+++ b/jarvis/tests/test_read_file_perm.py
@@ -1,0 +1,163 @@
+"""Regression tests for F12 (read_file / get_file_pages info-disclosure) -
+see .superpowers/sdd/audit-findings.md.
+
+``_resolve_file``'s filename-based lookup used ``frappe.get_all`` (a
+permission bypass) with a substring LIKE fallback ordered by
+``creation desc``, so a low-privilege caller searching by a generic
+filename could have the globally most-recent name-matching File selected
+for them even when it is a private file they have no access to - and the
+subsequent permission-denied message then echoed that file's real
+``file_name`` back to the caller, confirming the existence of a private
+document they had no other way to see.
+
+Needs DB (File doctype); FrappeTestCase rolls back per-test inserts, so
+the File fixtures created inside each test method need no manual cleanup
+(mirrors the pattern in test_untrusted_fence.py / test_vision_attachments.py).
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.get_file_pages import get_file_pages
+from jarvis.tools.read_file import read_file
+
+USER_CALLER = "jpl-readfile-caller@example.com"
+USER_OTHER = "jpl-readfile-other@example.com"
+
+
+def _ensure_user(email: str) -> None:
+    if not frappe.db.exists("User", email):
+        frappe.get_doc({
+            "doctype": "User",
+            "email": email,
+            "first_name": email.split("@")[0],
+            "send_welcome_email": 0,
+            "enabled": 1,
+            "user_type": "System User",
+        }).insert(ignore_permissions=True)
+
+
+@contextlib.contextmanager
+def _as(user: str):
+    orig = frappe.session.user
+    frappe.set_user(user)
+    try:
+        yield
+    finally:
+        frappe.set_user(orig)
+
+
+def _make_file(name: str, content: bytes, owner: str):
+    """Insert a private, unattached File owned by ``owner`` - File's own
+    permission model (frappe.core.doctype.file.file.has_permission) grants
+    read on an unattached private file only to its owner (or
+    Administrator), so this is the simplest fixture that reproduces a
+    "private file the caller cannot read" without needing a whole
+    permission-scoped target doctype."""
+    from frappe.utils.file_manager import save_file
+
+    with _as(owner):
+        return save_file(name, content, None, None, is_private=1)
+
+
+class ReadFilePermTestCase(FrappeTestCase):
+    """Shared fixture for the F12 permission-path tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        _ensure_user(USER_CALLER)
+        _ensure_user(USER_OTHER)
+        frappe.db.commit()
+
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+
+class TestResolveFileByFilenamePermissionAware(ReadFilePermTestCase):
+    """F12: filename-based fuzzy resolution must not pick a file the
+    caller can't read, and must not leak that file's name on denial.
+
+    Note: FrappeTestCase (IntegrationTestCase) only rolls back at CLASS
+    teardown, not between individual test methods - so each test method
+    below uses its own unique substring token to avoid one test's fixture
+    files being visible to (and satisfying) another test's fuzzy search.
+    """
+
+    def test_fuzzy_match_skips_unreadable_newer_file_and_finds_own_older_one(self):
+        # caller's own (older) file, matches the "invoicealpha" substring
+        mine = _make_file("my-invoicealpha-draft.txt", b"my own draft", USER_CALLER)
+        # someone else's newer, unrelated, PRIVATE file that also matches -
+        # under the old bug ("most recent" wins, zero permission filter)
+        # this one would have been picked instead.
+        _make_file("confidential-invoicealpha-CEO-bonus.txt", b"secret bonus data", USER_OTHER)
+
+        with _as(USER_CALLER):
+            out = read_file(filename="invoicealpha")
+        self.assertEqual(out["filename"], mine.file_name)
+
+    def test_fuzzy_match_with_no_readable_candidate_is_generic_and_does_not_leak_name(self):
+        _make_file("confidential-invoicebeta-CEO-bonus.txt", b"secret bonus data", USER_OTHER)
+
+        with _as(USER_CALLER), self.assertRaises(InvalidArgumentError) as ctx:
+            read_file(filename="invoicebeta")
+        message = str(ctx.exception)
+        self.assertNotIn("confidential-invoicebeta-CEO-bonus", message)
+        self.assertIn("no matching file found", message)
+
+    def test_exact_file_url_denial_is_generic_and_does_not_leak_name(self):
+        theirs = _make_file("their-private-report.txt", b"secret", USER_OTHER)
+
+        with _as(USER_CALLER), self.assertRaises(PermissionDeniedError) as ctx:
+            read_file(file_url=theirs.file_url)
+        message = str(ctx.exception)
+        self.assertNotIn("their-private-report", message)
+        self.assertIn("no matching file found", message)
+
+    def test_owner_still_reads_own_file_by_filename(self):
+        _make_file("owner-report.txt", b"hello owner", USER_CALLER)
+        with _as(USER_CALLER):
+            out = read_file(filename="owner-report.txt")
+        self.assertEqual(out["text"], "hello owner")
+
+    def test_owner_still_reads_own_file_by_url(self):
+        mine = _make_file("owner-report-2.txt", b"hello again", USER_CALLER)
+        with _as(USER_CALLER):
+            out = read_file(file_url=mine.file_url)
+        self.assertEqual(out["text"], "hello again")
+
+
+class TestGetFilePagesPermissionErrorGeneric(ReadFilePermTestCase):
+    """Same permission-denial generic-message fix, applied to
+    get_file_pages (shares read_file._resolve_file). The permission check
+    runs before any PDF/image parsing, so a plain .txt fixture is enough -
+    no need for real PDF bytes to exercise the denial path."""
+
+    def test_exact_file_url_denial_is_generic_and_does_not_leak_name(self):
+        theirs = _make_file("their-private-scan.txt", b"not a real scan", USER_OTHER)
+
+        with _as(USER_CALLER), self.assertRaises(PermissionDeniedError) as ctx:
+            get_file_pages(file_url=theirs.file_url)
+        message = str(ctx.exception)
+        self.assertNotIn("their-private-scan", message)
+        self.assertIn("no matching file found", message)
+
+    def test_fuzzy_match_with_no_readable_candidate_is_generic_and_does_not_leak_name(self):
+        _make_file("confidential-scangamma-CEO.txt", b"not a real scan", USER_OTHER)
+
+        with _as(USER_CALLER), self.assertRaises(InvalidArgumentError) as ctx:
+            get_file_pages(filename="scangamma")
+        message = str(ctx.exception)
+        self.assertNotIn("confidential-scangamma-CEO", message)
+        self.assertIn("no matching file found", message)

--- a/jarvis/tests/test_read_file_perm.py
+++ b/jarvis/tests/test_read_file_perm.py
@@ -126,9 +126,12 @@ class TestResolveFileByFilenamePermissionAware(ReadFilePermTestCase):
         self.assertIn("no matching file found", message)
 
     def test_owner_still_reads_own_file_by_filename(self):
-        _make_file("owner-report.txt", b"hello owner", USER_CALLER)
+        # Frappe hash-suffixes file_name on collision (a File named
+        # "owner-report.txt" may already exist earlier in the full suite),
+        # so search by the ACTUAL stored name, not the requested one.
+        f = _make_file("owner-report.txt", b"hello owner", USER_CALLER)
         with _as(USER_CALLER):
-            out = read_file(filename="owner-report.txt")
+            out = read_file(filename=f.file_name)
         self.assertEqual(out["text"], "hello owner")
 
     def test_owner_still_reads_own_file_by_url(self):

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -270,6 +270,30 @@ class TestCreateCustomSkill(SkillToolsTestCase):
 		self.assertEqual(out["scope"], "Org")
 		self.assertIn("Apply", out["note"])
 
+	def test_org_scope_note_matches_actual_find_skills_visibility(self):
+		# F19: the note used to say Org skills "reach the assistant's skill
+		# catalog only after an admin clicks Apply" - factually false, since
+		# find_skills/get_skill already surface an Org row to every user right
+		# away (see TestFindSkills.test_org_row_visible_to_everyone below).
+		# There is no per-row 'applied'/'reviewed' flag anywhere in the
+		# doctype or the Apply flow (chat/custom_skills.py build_push_payload)
+		# to gate that discovery path on, so the note is corrected instead of
+		# inventing a gate. Lock the corrected wording + matching behavior
+		# together so they can't silently drift apart again.
+		with _as(OWNER):
+			out = create_custom_skill(
+				f"{PFX}-mk-org-note", "sttool mk org note desc", "mk org note body",
+				scope="Org",
+			)
+		note = out["note"]
+		self.assertIn("right away", note)
+		self.assertIn("jarvis__find_skills", note)
+		self.assertNotIn("only after an admin clicks Apply", note)
+
+		with _as(PEER):
+			found = find_skills("mk org note desc")
+			self.assertIn(f"{PFX}-mk-org-note", [s["skill_name"] for s in found["skills"]])
+
 	def test_invalid_scope_rejected(self):
 		with _as(OWNER):
 			with self.assertRaises(InvalidArgumentError):

--- a/jarvis/tests/test_tier1_artifact_tools.py
+++ b/jarvis/tests/test_tier1_artifact_tools.py
@@ -134,20 +134,87 @@ class TestAttachToDocEnvelope(FrappeTestCase):
     def test_calls_add_attachments_and_returns_envelope(self):
         user_name = frappe.db.get_value("User", filters={}, fieldname="name")
         file_url = "/private/files/some-attached.pdf"
+        source_file_name = "source-File-1"
+
+        # Signature-faithful fake: distinguishes the "resolve docname from
+        # url" lookup from the "find the newly-attached File" lookup by
+        # filters, instead of a single return_value that would mask
+        # whichever value the tool actually passes to add_attachments.
+        # Anything else (e.g. the tool's own frappe.db.exists("User", ...),
+        # which delegates through get_value) falls through to the real
+        # lookup - args/kwargs are forwarded verbatim so defaults like
+        # fieldname="name" aren't clobbered.
+        _real_get_value = frappe.db.get_value
+
+        def _fake_get_value(doctype, *args, **kwargs):
+            filters = args[0] if args else kwargs.get("filters")
+            if doctype == "File" and isinstance(filters, dict) and "attached_to_doctype" in filters:
+                return "attached-File-99"
+            if doctype == "File" and filters == {"file_url": file_url}:
+                return source_file_name
+            return _real_get_value(doctype, *args, **kwargs)
 
         with patch(
             "frappe.utils.file_manager.add_attachments",
         ) as add_a, patch(
-            "frappe.db.get_value", return_value="attached-File-99",
+            "frappe.db.get_value", side_effect=_fake_get_value,
         ):
             out = attach_to_doc(file_url, "User", user_name)
 
-        add_a.assert_called_once_with("User", user_name, [file_url])
+        # add_attachments needs the File DOCNAME resolved from file_url,
+        # never the raw url - passing the url raises DoesNotExistError
+        # (add_attachments looks the entry up by File.name).
+        add_a.assert_called_once_with("User", user_name, [source_file_name])
         self.assertEqual(set(out.keys()), {
             "file_url", "target_doctype", "target_name", "attached_file_name",
         })
         self.assertEqual(out["file_url"], file_url)
         self.assertEqual(out["attached_file_name"], "attached-File-99")
+
+    def test_raises_invalid_argument_when_file_url_unresolvable(self):
+        user_name = frappe.db.get_value("User", filters={}, fieldname="name")
+        missing_url = "/private/files/does-not-exist.pdf"
+        _real_get_value = frappe.db.get_value
+
+        def _fake_get_value(doctype, *args, **kwargs):
+            filters = args[0] if args else kwargs.get("filters")
+            if doctype == "File" and filters == {"file_url": missing_url}:
+                return None
+            return _real_get_value(doctype, *args, **kwargs)
+
+        with patch("frappe.db.get_value", side_effect=_fake_get_value):
+            with self.assertRaises(InvalidArgumentError):
+                attach_to_doc(missing_url, "User", user_name)
+
+
+class TestAttachToDocRealFlow(FrappeTestCase):
+    """End-to-end regression for F11: a real File's file_url must resolve
+    to its docname and actually attach, with no mocking of
+    add_attachments/save_url. Pre-fix this raises frappe.DoesNotExistError
+    because add_attachments is handed the url instead of the docname."""
+
+    def test_real_file_url_resolves_and_attaches(self):
+        target_name = frappe.db.get_value("User", filters={}, fieldname="name")
+
+        source = frappe.get_doc({
+            "doctype": "File",
+            "file_name": "attach-to-doc-real-test.txt",
+            "content": b"hello from attach_to_doc real-flow test",
+            "is_private": 1,
+        })
+        source.insert(ignore_permissions=True)
+        self.addCleanup(lambda: frappe.delete_doc("File", source.name, force=True, ignore_permissions=True))
+
+        out = attach_to_doc(source.file_url, "User", target_name)
+
+        self.assertIsNotNone(out["attached_file_name"])
+        attached = frappe.get_doc("File", out["attached_file_name"])
+        self.addCleanup(
+            lambda: frappe.delete_doc("File", attached.name, force=True, ignore_permissions=True),
+        )
+        self.assertEqual(attached.attached_to_doctype, "User")
+        self.assertEqual(attached.attached_to_name, target_name)
+        self.assertEqual(attached.file_url, source.file_url)
 
 
 # ---------------------------------------------------------------------

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -307,6 +307,7 @@ PERM_ITEM_GROUP = "_JPL Perm Test Item Group"
 PERM_UOM = "_JPL Perm Nos"
 PERM_ITEM = "_JPL Perm Test Item"
 PERM_CUSTOMER = "_JPL Perm Test Customer"
+PERM_WAREHOUSE = "_JPL Perm Test Warehouse"
 ROLE_NO_GRANTS = "JPL Perm No Grants Role"
 USER_NO_GRANTS = "jpl-perm-no-grants@example.com"
 USER_ITEM_READER = "jpl-perm-item-reader@example.com"
@@ -377,6 +378,17 @@ def _ensure_item(name: str) -> None:
     }).insert(ignore_permissions=True)
 
 
+def _ensure_warehouse(name: str, company: str) -> str:
+    existing = frappe.db.exists("Warehouse", {"warehouse_name": name, "company": company})
+    if existing:
+        return existing
+    doc = frappe.get_doc({
+        "doctype": "Warehouse", "warehouse_name": name, "company": company,
+    })
+    doc.insert(ignore_permissions=True)
+    return doc.name
+
+
 def _ensure_customer(name: str) -> str:
     existing = frappe.db.exists("Customer", {"customer_name": name})
     if existing:
@@ -431,6 +443,7 @@ class CrossCompanyPermTestCase(FrappeTestCase):
         _ensure_company(PERM_COMPANY_B, "JPLB")
         _ensure_item(PERM_ITEM)
         cls.customer = _ensure_customer(PERM_CUSTOMER)
+        cls.warehouse = _ensure_warehouse(PERM_WAREHOUSE, PERM_COMPANY_A)
         _ensure_user_permission(USER_COMPANY_SCOPED, "Company", PERM_COMPANY_A)
 
     def setUp(self):
@@ -443,8 +456,8 @@ class CrossCompanyPermTestCase(FrappeTestCase):
 
 
 class TestScanBarcodePermissionGate(CrossCompanyPermTestCase):
-    """F16: scan_barcode must gate on Item read permission - the
-    underlying erpnext helper performs none itself."""
+    """F16: scan_barcode must gate on Item / Warehouse read permission -
+    the underlying erpnext helper performs none itself."""
 
     def test_restricted_user_denied(self):
         with _as(USER_NO_GRANTS), patch(
@@ -460,6 +473,25 @@ class TestScanBarcodePermissionGate(CrossCompanyPermTestCase):
         ):
             out = scan_barcode("012")
         self.assertEqual(out["item_code"], PERM_ITEM)
+
+    def test_restricted_user_denied_for_warehouse_match(self):
+        # The erpnext helper's Warehouse branch (scanning a warehouse name
+        # itself, e.g. a bin-location barcode) returns {"warehouse": ...}
+        # with no permission check of its own - this must be gated too.
+        with _as(USER_NO_GRANTS), patch(
+            "erpnext.stock.utils.scan_barcode",
+            return_value={"warehouse": self.warehouse},
+        ), self.assertRaises(frappe.PermissionError):
+            scan_barcode("WH-012")
+
+    def test_warehouse_reader_still_succeeds_for_warehouse_match(self):
+        # Stock User has role-level Warehouse read.
+        with _as(USER_ITEM_READER), patch(
+            "erpnext.stock.utils.scan_barcode",
+            return_value={"warehouse": self.warehouse},
+        ):
+            out = scan_barcode("WH-012")
+        self.assertEqual(out["warehouse"], self.warehouse)
 
 
 class TestGetCustomerOutstandingCompanyPermission(CrossCompanyPermTestCase):

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -19,12 +19,14 @@ The ERPNext computations themselves are tested upstream.
 """
 from __future__ import annotations
 
+import contextlib
 from datetime import date as _date
 from unittest.mock import patch
 
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools.get_balance_on import get_balance_on
 from jarvis.tools.get_customer_outstanding import get_customer_outstanding
 from jarvis.tools.get_exchange_rate import get_exchange_rate
@@ -288,3 +290,252 @@ class TestGetItemisedTaxBreakup(FrappeTestCase):
         self.assertEqual(out["doctype"], "Sales Invoice")
         self.assertEqual(out["name"], "SINV-001")
         self.assertEqual(out["itemised_tax"], {"_T-Item": {"VAT - X": 18.0}})
+
+
+# ---------------------------------------------------------------------
+# Real permission-path regression tests (F13/F14/F15/F16 - see
+# .superpowers/sdd/audit-findings.md). Unlike the envelope tests above
+# (which patch frappe.has_permission/frappe.db.exists to pin the boundary
+# contract without heavy master-data), these exercise real
+# frappe.has_permission decisions against real users/roles/records so the
+# permission checks the fix added are proven end to end, not just wired.
+# ---------------------------------------------------------------------
+
+PERM_COMPANY_A = "_JPL Perm Company A"
+PERM_COMPANY_B = "_JPL Perm Company B"
+PERM_ITEM_GROUP = "_JPL Perm Test Item Group"
+PERM_UOM = "_JPL Perm Nos"
+PERM_ITEM = "_JPL Perm Test Item"
+PERM_CUSTOMER = "_JPL Perm Test Customer"
+ROLE_NO_GRANTS = "JPL Perm No Grants Role"
+USER_NO_GRANTS = "jpl-perm-no-grants@example.com"
+USER_ITEM_READER = "jpl-perm-item-reader@example.com"
+# Sales User grants role-level Customer + Company read, but this user is
+# additionally scoped by a Company User Permission to PERM_COMPANY_A only -
+# exactly the "restricted via a Company User Permission" case the audit
+# findings call out.
+USER_COMPANY_SCOPED = "jpl-perm-company-scoped@example.com"
+
+
+def _ensure_role(name: str) -> None:
+    if not frappe.db.exists("Role", name):
+        frappe.get_doc({
+            "doctype": "Role", "role_name": name, "desk_access": 1, "is_custom": 1,
+        }).insert(ignore_permissions=True)
+
+
+def _ensure_user(email: str, roles: tuple) -> None:
+    if not frappe.db.exists("User", email):
+        frappe.get_doc({
+            "doctype": "User",
+            "email": email,
+            "first_name": email.split("@")[0],
+            "send_welcome_email": 0,
+            "enabled": 1,
+            "user_type": "System User",
+        }).insert(ignore_permissions=True)
+    user = frappe.get_doc("User", email)
+    if "System Manager" in frappe.get_roles(email):
+        user.remove_roles("System Manager")
+    missing = [r for r in roles if r not in frappe.get_roles(email)]
+    if missing:
+        user.add_roles(*missing)
+
+
+def _ensure_company(name: str, abbr: str) -> None:
+    if frappe.db.exists("Company", name):
+        return
+    # Skip default chart-of-accounts / warehouse / tax-template creation -
+    # this fixture only needs a Company row for permission checks, not a
+    # functioning ledger, and CI sites may be missing the fixtures those
+    # hooks depend on (e.g. Warehouse Type "Transit").
+    frappe.local.flags.ignore_chart_of_accounts = True
+    try:
+        frappe.get_doc({
+            "doctype": "Company",
+            "company_name": name,
+            "abbr": abbr,
+            "default_currency": "INR",
+            "country": "India",
+        }).insert(ignore_permissions=True)
+    finally:
+        frappe.local.flags.ignore_chart_of_accounts = False
+
+
+def _ensure_item(name: str) -> None:
+    if frappe.db.exists("Item", name):
+        return
+    if not frappe.db.exists("Item Group", PERM_ITEM_GROUP):
+        frappe.get_doc({
+            "doctype": "Item Group", "item_group_name": PERM_ITEM_GROUP, "is_group": 0,
+        }).insert(ignore_permissions=True)
+    if not frappe.db.exists("UOM", PERM_UOM):
+        frappe.get_doc({"doctype": "UOM", "uom_name": PERM_UOM}).insert(ignore_permissions=True)
+    frappe.get_doc({
+        "doctype": "Item", "item_code": name, "item_name": name,
+        "item_group": PERM_ITEM_GROUP, "stock_uom": PERM_UOM,
+    }).insert(ignore_permissions=True)
+
+
+def _ensure_customer(name: str) -> str:
+    existing = frappe.db.exists("Customer", {"customer_name": name})
+    if existing:
+        return existing
+    doc = frappe.get_doc({
+        "doctype": "Customer", "customer_name": name, "customer_type": "Company",
+    })
+    doc.insert(ignore_permissions=True)
+    return doc.name
+
+
+def _ensure_user_permission(user: str, allow: str, for_value: str) -> None:
+    if frappe.db.exists("User Permission", {"user": user, "allow": allow, "for_value": for_value}):
+        return
+    frappe.get_doc({
+        "doctype": "User Permission", "user": user, "allow": allow, "for_value": for_value,
+    }).insert(ignore_permissions=True)
+
+
+@contextlib.contextmanager
+def _as(user: str):
+    orig = frappe.session.user
+    frappe.set_user(user)
+    try:
+        yield
+    finally:
+        frappe.set_user(orig)
+
+
+class CrossCompanyPermTestCase(FrappeTestCase):
+    """Shared fixture for the F13/F14/F15/F16 permission-path tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        # Roles/users are cheap, harmless to leave committed (reused
+        # idempotently across runs, mirrors test_permlevel_leak.py).
+        _ensure_role(ROLE_NO_GRANTS)
+        _ensure_user(USER_NO_GRANTS, roles=(ROLE_NO_GRANTS,))
+        _ensure_user(USER_ITEM_READER, roles=("Stock User",))
+        _ensure_user(USER_COMPANY_SCOPED, roles=("Sales User",))
+        frappe.db.commit()
+        # Company/Item/Customer/User Permission are NOT committed - unlike
+        # roles/users, a leftover Company row changes production inference
+        # elsewhere (e.g. run_scrutiny._resolve_scope's "single Company on
+        # the site" fallback), so these must vanish via FrappeTestCase's
+        # automatic per-class rollback rather than persist across test
+        # modules. They're still visible within this class's own
+        # transaction (same DB connection), which is all these tests need.
+        _ensure_company(PERM_COMPANY_A, "JPLA")
+        _ensure_company(PERM_COMPANY_B, "JPLB")
+        _ensure_item(PERM_ITEM)
+        cls.customer = _ensure_customer(PERM_CUSTOMER)
+        _ensure_user_permission(USER_COMPANY_SCOPED, "Company", PERM_COMPANY_A)
+
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+
+class TestScanBarcodePermissionGate(CrossCompanyPermTestCase):
+    """F16: scan_barcode must gate on Item read permission - the
+    underlying erpnext helper performs none itself."""
+
+    def test_restricted_user_denied(self):
+        with _as(USER_NO_GRANTS), patch(
+            "erpnext.stock.utils.scan_barcode",
+            return_value={"item_code": PERM_ITEM, "barcode": "012"},
+        ), self.assertRaises(frappe.PermissionError):
+            scan_barcode("012")
+
+    def test_item_reader_still_succeeds(self):
+        with _as(USER_ITEM_READER), patch(
+            "erpnext.stock.utils.scan_barcode",
+            return_value={"item_code": PERM_ITEM, "barcode": "012"},
+        ):
+            out = scan_barcode("012")
+        self.assertEqual(out["item_code"], PERM_ITEM)
+
+
+class TestGetCustomerOutstandingCompanyPermission(CrossCompanyPermTestCase):
+    """F13: company must be permission-checked, not just the customer."""
+
+    def test_company_scoped_user_denied_for_other_company(self):
+        with _as(USER_COMPANY_SCOPED), patch(
+            "erpnext.selling.doctype.customer.customer.get_customer_outstanding",
+            return_value=2500.0,
+        ), self.assertRaises(PermissionDeniedError):
+            get_customer_outstanding(self.customer, PERM_COMPANY_B)
+
+    def test_company_scoped_user_allowed_for_own_company(self):
+        with _as(USER_COMPANY_SCOPED), patch(
+            "erpnext.selling.doctype.customer.customer.get_customer_outstanding",
+            return_value=2500.0,
+        ):
+            out = get_customer_outstanding(self.customer, PERM_COMPANY_A)
+        self.assertEqual(out["outstanding"], 2500.0)
+
+
+class TestGetPartyDashboardInfoCompanyStrip(CrossCompanyPermTestCase):
+    """F14: dashboard entries for companies the caller can't read must be
+    stripped, not just gated on the party itself."""
+
+    def test_company_scoped_user_only_sees_own_company_entry(self):
+        with _as(USER_COMPANY_SCOPED), patch(
+            "erpnext.accounts.party.get_dashboard_info",
+            return_value=[
+                {"company": PERM_COMPANY_A, "total_unpaid": 100},
+                {"company": PERM_COMPANY_B, "total_unpaid": 999},
+            ],
+        ):
+            out = get_party_dashboard_info("Customer", self.customer)
+        companies = [d["company"] for d in out["dashboard"]]
+        self.assertEqual(companies, [PERM_COMPANY_A])
+
+    def test_unrestricted_user_sees_every_company_entry(self):
+        # No Company User Permission at all -> role-level Company read
+        # (granted broadly to most ERP roles) is unrestricted, so both
+        # entries must survive the strip.
+        with _as("Administrator"), patch(
+            "erpnext.accounts.party.get_dashboard_info",
+            return_value=[
+                {"company": PERM_COMPANY_A, "total_unpaid": 100},
+                {"company": PERM_COMPANY_B, "total_unpaid": 999},
+            ],
+        ):
+            out = get_party_dashboard_info("Customer", self.customer)
+        companies = {d["company"] for d in out["dashboard"]}
+        self.assertEqual(companies, {PERM_COMPANY_A, PERM_COMPANY_B})
+
+
+class TestGetBalanceOnCompanyPermission(CrossCompanyPermTestCase):
+    """F15: an explicit company must be permission-checked, and party-only
+    mode (which otherwise sums across every company) must not silently
+    blend in companies a restricted caller can't read."""
+
+    def test_company_scoped_user_denied_for_other_company(self):
+        with _as(USER_COMPANY_SCOPED), self.assertRaises(PermissionDeniedError):
+            get_balance_on(account=None, party_type="Customer", party=self.customer, company=PERM_COMPANY_B)
+
+    def test_company_scoped_user_allowed_for_own_company(self):
+        with _as(USER_COMPANY_SCOPED), patch(
+            "erpnext.accounts.utils.get_balance_on", return_value=500.0,
+        ):
+            out = get_balance_on(party_type="Customer", party=self.customer, company=PERM_COMPANY_A)
+        self.assertEqual(out["balance"], 500.0)
+
+    def test_company_scoped_user_must_pass_company_in_party_only_mode(self):
+        with _as(USER_COMPANY_SCOPED), self.assertRaises(InvalidArgumentError):
+            get_balance_on(party_type="Customer", party=self.customer)
+
+    def test_unrestricted_user_party_only_mode_still_works(self):
+        with _as("Administrator"), patch(
+            "erpnext.accounts.utils.get_balance_on", return_value=750.0,
+        ):
+            out = get_balance_on(party_type="Customer", party=self.customer)
+        self.assertEqual(out["balance"], 750.0)

--- a/jarvis/tests/test_tier2b_hrms_frappe_reads.py
+++ b/jarvis/tests/test_tier2b_hrms_frappe_reads.py
@@ -145,12 +145,33 @@ class TestGetEmployeeShift(FrappeTestCase):
         with self.assertRaises(InvalidArgumentError):
             get_employee_shift("")
 
-    def test_returns_envelope_when_shift_assigned(self):
-        fake_shift = MagicMock()
-        fake_shift.as_dict.return_value = {"name": "Day Shift", "start_time": "09:00"}
+    def test_calls_real_signature_with_for_timestamp(self):
+        # autospec=True validates the call against the REAL hrms function's
+        # signature (employee, for_timestamp, consider_default_shift,
+        # next_shift_direction) - it has no `for_date` parameter, so this
+        # raises TypeError pre-fix, catching the exact bug a loose
+        # MagicMock(return_value=...) mock would silently swallow.
         with _all_exist(), _allow_perm(), patch(
             "hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift",
-            return_value=fake_shift,
+            autospec=True,
+            return_value={"name": "Day Shift", "start_time": "09:00"},
+        ) as ges:
+            out = get_employee_shift("HR-EMP-001", "2026-06-18")
+        ges.assert_called_once_with(
+            employee="HR-EMP-001", for_timestamp="2026-06-18", consider_default_shift=True,
+        )
+        self.assertEqual(out["shift"], {"name": "Day Shift", "start_time": "09:00"})
+        self.assertEqual(out["employee"], "HR-EMP-001")
+        self.assertEqual(out["for_date"], "2026-06-18")
+
+    def test_returns_envelope_when_shift_assigned(self):
+        # The real helper returns a plain dict (frappe._dict), never a
+        # Document - it has no .as_dict() method. Mock with a real dict so
+        # a stray `.as_dict()` call on the result raises, not silently
+        # resolves via frappe._dict's dict.get-based __getattr__.
+        with _all_exist(), _allow_perm(), patch(
+            "hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift",
+            return_value={"name": "Day Shift", "start_time": "09:00"},
         ):
             out = get_employee_shift("HR-EMP-001", "2026-06-18")
         self.assertEqual(out["shift"], {"name": "Day Shift", "start_time": "09:00"})
@@ -158,9 +179,13 @@ class TestGetEmployeeShift(FrappeTestCase):
         self.assertEqual(out["for_date"], "2026-06-18")
 
     def test_returns_none_when_no_shift(self):
+        # The real helper returns `{}` (never None) when nothing is found
+        # (`return shift_details or {}`) - assert the tool collapses that
+        # falsy empty dict to None rather than calling a nonexistent
+        # .as_dict() on it.
         with _all_exist(), _allow_perm(), patch(
             "hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift",
-            return_value=None,
+            return_value={},
         ):
             out = get_employee_shift("HR-EMP-001", "2026-06-18")
         self.assertIsNone(out["shift"])

--- a/jarvis/tests/test_tool_preview_audit.py
+++ b/jarvis/tests/test_tool_preview_audit.py
@@ -77,6 +77,51 @@ class TestWriteAudit(FrappeTestCase):
         self.assertFalse(r["ok"])
         self.assertFalse(rec.called)
 
+    def test_run_scrutiny_write_is_audited(self):
+        # F24: run_scrutiny's optional persistence path (installation arg)
+        # inserts real Jarvis Agent Run/Finding rows but was absent from
+        # _WRITE_TOOLS, so the write left no audit trail. dispatch is
+        # mocked so this asserts the wiring, not run_scrutiny's own logic.
+        with patch("jarvis.api.dispatch", return_value={"ok": True}) as disp, \
+                patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("run_scrutiny", {"company": "_Test Company"})
+        self.assertTrue(disp.called)
+        self.assertTrue(r["ok"])
+        self.assertTrue(rec.called)
+        self.assertEqual(rec.call_args.kwargs["tool"], "run_scrutiny")
+        self.assertTrue(rec.call_args.kwargs["ok"])
+
+    def test_download_pdf_write_is_audited(self):
+        # F25: download_pdf inserts a new File doc (and attaches it to the
+        # source record) but was absent from _WRITE_TOOLS.
+        with patch("jarvis.api.dispatch", return_value={"file_url": "/private/files/x.pdf"}), \
+                patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("download_pdf", {"doctype": "ToDo", "name": "x"})
+        self.assertTrue(r["ok"])
+        self.assertTrue(rec.called)
+        self.assertEqual(rec.call_args.kwargs["tool"], "download_pdf")
+        self.assertTrue(rec.call_args.kwargs["ok"])
+
+    def test_export_excel_write_is_audited(self):
+        # F25: export_excel inserts a new File doc but was absent from
+        # _WRITE_TOOLS.
+        with patch("jarvis.api.dispatch", return_value={"file_url": "/private/files/x.xlsx"}), \
+                patch("jarvis.api.audit.record") as rec:
+            r = api._run_tool("export_excel", {"doctype": "ToDo"})
+        self.assertTrue(r["ok"])
+        self.assertTrue(rec.called)
+        self.assertEqual(rec.call_args.kwargs["tool"], "export_excel")
+        self.assertTrue(rec.call_args.kwargs["ok"])
+
+    def test_run_scrutiny_download_pdf_export_excel_are_write_but_not_gated(self):
+        # These need auditing (real DB writes), not a confirmation card - not
+        # user-facing mutations the model should have to get a human click
+        # for. NOT in _GATED_WRITES/_AUTO_APPLYABLE.
+        for tool in ("run_scrutiny", "download_pdf", "export_excel"):
+            self.assertIn(tool, api._WRITE_TOOLS)
+            self.assertNotIn(tool, api._GATED_WRITES)
+            self.assertNotIn(tool, api._AUTO_APPLYABLE)
+
     def test_preview_sandboxes_a_tool_that_commits(self):
         # The core fix: even when the dispatched tool calls frappe.db.commit()
         # internally, preview must not persist anything.

--- a/jarvis/tests/test_tool_preview_audit.py
+++ b/jarvis/tests/test_tool_preview_audit.py
@@ -206,3 +206,54 @@ class TestAuditRedaction(FrappeTestCase):
         self.assertNotIn("tok-should-not-leak", logged)
         self.assertIn("[REDACTED]", logged)
         self.assertIn("gpt-5", logged)  # ordinary field passes through
+
+    def test_password_fields_includes_child_table_password_fields(self):
+        # F6 completion: _password_fields previously called the nonexistent
+        # frappe.get_meta(doctype).get_password_fields(), which raised
+        # AttributeError, was swallowed by a bare except, and returned an
+        # empty set on every call - the whole meta-lookup redaction layer was
+        # dead. Real Password fields whose names don't contain a
+        # _SECRET_KEYS substring (subscription_accounts on the child doctype
+        # Jarvis LLM Pool Model, wired via the models Table field on Jarvis
+        # Settings) must be discovered.
+        fields = audit._password_fields("Jarvis Settings")
+        self.assertTrue(fields)  # proves the meta layer isn't dead
+        self.assertIn("subscription_accounts", fields)
+
+    def test_record_redacts_child_table_password_field_not_caught_by_substring(self):
+        # End-to-end through record(): subscription_accounts is a Password
+        # field on the Jarvis LLM Pool Model child doctype (reached via the
+        # models Table field on Jarvis Settings) and contains none of
+        # password/pwd/secret/token/key, so this only passes if the meta
+        # layer (not the substring layer) is doing real work.
+        captured = {}
+
+        class _FakeLogger:
+            def info(self, msg):
+                captured["msg"] = msg
+
+            def error(self, msg):
+                captured["err"] = msg
+
+        with patch("frappe.logger", return_value=_FakeLogger()):
+            audit.record(
+                tool="update_doc",
+                args={
+                    "doctype": "Jarvis Settings",
+                    "name": "Jarvis Settings",
+                    "changes": {
+                        "models": [
+                            {
+                                "provider": "openai",
+                                "subscription_accounts": "SECRET-OAUTH-BLOB",
+                            }
+                        ],
+                    },
+                },
+                ok=True,
+            )
+        self.assertIn("msg", captured)
+        logged = captured["msg"]
+        self.assertNotIn("SECRET-OAUTH-BLOB", logged)
+        self.assertIn("[REDACTED]", logged)
+        self.assertIn("openai", logged)  # ordinary field passes through

--- a/jarvis/tests/test_tool_preview_audit.py
+++ b/jarvis/tests/test_tool_preview_audit.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import api
+from jarvis import api, audit
 
 
 # These exercise the model-facing preview BRANCH in _run_tool. Every real
@@ -139,3 +139,70 @@ class TestWriteAudit(FrappeTestCase):
         self.assertTrue(r["ok"])
         self.assertTrue(r["data"]["preview"])
         self.assertFalse(frappe.db.exists("ToDo", {"description": sentinel}))
+
+
+class TestAuditRedaction(FrappeTestCase):
+    """F6: _scrub only redacted keys EXACTLY equal to a fixed literal set, so
+    compound secret field names (llm_api_key, agent_token, smtp_password...)
+    were logged in plaintext. Fixed via substring match + per-doctype
+    Password-fieldtype lookup (frappe.get_meta(doctype).get_password_fields())."""
+
+    def test_compound_secret_keys_are_redacted(self):
+        # Substring match: none of these equal a literal in the old fixed set,
+        # but each contains "key"/"token"/"password".
+        scrubbed = audit._scrub({
+            "llm_api_key": "sk-super-secret",
+            "agent_token": "tok-abc123",
+            "smtp_password": "hunter2",
+            "ordinary_field": "keep me",
+            "description": "not a secret",
+        })
+        self.assertEqual(scrubbed["llm_api_key"], "[REDACTED]")
+        self.assertEqual(scrubbed["agent_token"], "[REDACTED]")
+        self.assertEqual(scrubbed["smtp_password"], "[REDACTED]")
+        self.assertEqual(scrubbed["ordinary_field"], "keep me")
+        self.assertEqual(scrubbed["description"], "not a secret")
+
+    def test_nested_and_list_secrets_are_redacted(self):
+        scrubbed = audit._scrub({
+            "changes": {"jarvis_admin_api_secret": "x", "title": "y"},
+            "users": [{"webhook_secret": "z", "name": "ok"}],
+        })
+        self.assertEqual(scrubbed["changes"]["jarvis_admin_api_secret"], "[REDACTED]")
+        self.assertEqual(scrubbed["changes"]["title"], "y")
+        self.assertEqual(scrubbed["users"][0]["webhook_secret"], "[REDACTED]")
+        self.assertEqual(scrubbed["users"][0]["name"], "ok")
+
+    def test_record_redacts_update_doc_changes_for_real_doctype(self):
+        # End-to-end through record(): args shaped like a real update_doc call
+        # against Jarvis Settings, whose Password-fieldtype fields include
+        # llm_api_key/agent_token/smtp_password-style compound names.
+        captured = {}
+
+        class _FakeLogger:
+            def info(self, msg):
+                captured["msg"] = msg
+
+            def error(self, msg):
+                captured["err"] = msg
+
+        with patch("frappe.logger", return_value=_FakeLogger()):
+            audit.record(
+                tool="update_doc",
+                args={
+                    "doctype": "Jarvis Settings",
+                    "name": "Jarvis Settings",
+                    "changes": {
+                        "llm_api_key": "sk-live-should-not-leak",
+                        "agent_token": "tok-should-not-leak",
+                        "default_model": "gpt-5",
+                    },
+                },
+                ok=True,
+            )
+        self.assertIn("msg", captured)
+        logged = captured["msg"]
+        self.assertNotIn("sk-live-should-not-leak", logged)
+        self.assertNotIn("tok-should-not-leak", logged)
+        self.assertIn("[REDACTED]", logged)
+        self.assertIn("gpt-5", logged)  # ordinary field passes through

--- a/jarvis/tests/test_unshare_doc_share_boundary.py
+++ b/jarvis/tests/test_unshare_doc_share_boundary.py
@@ -1,0 +1,113 @@
+"""Regression tests for F18 - unshare_doc's broken permission boundary.
+
+``frappe.share.remove()`` without ``ignore_permissions`` deletes the
+DocShare row via ``frappe.delete_doc``, which checks DELETE permission on
+the DocShare doctype ITSELF - a System-Manager-only role table with no
+``if_owner`` - instead of "share" permission on the TARGET document. That
+denied essentially every ordinary (non-System-Manager) user, even one who
+legitimately shared the document themselves and should be able to revoke
+their own grant.
+
+The fix (jarvis/tools/unshare_doc.py) explicitly checks
+``frappe.has_permission(doctype, "share", doc=name, throw=True)`` on the
+target doc - mirroring the boundary ``frappe.share.add`` enforces via
+``check_share_permission`` - then calls ``frappe.share.remove`` with
+``flags={"ignore_permissions": True}`` to bypass the DocShare ACL, the same
+pattern ``frappe.share.set_docshare_permission`` uses.
+
+Fixture: ``Note`` is a core doctype whose "Desk User" DocPerm grants
+``share=1`` only ``if_owner=1`` (frappe/core/doctype/note/note.json) - so a
+plain Desk User who creates+owns a Note has "share" permission on THAT
+Note, while a second, unrelated Desk User does not.
+"""
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools.unshare_doc import unshare_doc
+
+OWNER = "jv-unshare-owner@example.com"
+RECIPIENT = "jv-unshare-recipient@example.com"
+OUTSIDER = "jv-unshare-outsider@example.com"
+
+
+def _ensure_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": email.split("@")[0],
+			"send_welcome_email": 0,
+			"enabled": 1,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	user = frappe.get_doc("User", email)
+	# Fresh test-bench users may inherit System Manager - strip it so these
+	# are genuinely "normal" (non-System-Manager) users, matching the
+	# finding's empirical repro.
+	if "System Manager" in frappe.get_roles(email):
+		user.remove_roles("System Manager")
+	if "Desk User" not in frappe.get_roles(email):
+		user.add_roles("Desk User")
+	return email
+
+
+class TestUnshareDocPermissionBoundary(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(OWNER)
+		_ensure_user(RECIPIENT)
+		_ensure_user(OUTSIDER)
+
+	def setUp(self):
+		self._orig_user = frappe.session.user
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+
+	def _make_shared_note(self) -> str:
+		"""As OWNER (a plain Desk User): create a Note - if_owner gives OWNER
+		"share" on it - and share it with RECIPIENT. Returns the note name."""
+		frappe.set_user(OWNER)
+		note = frappe.get_doc({
+			"doctype": "Note", "title": "jv-unshare-test-note", "content": "hello",
+		}).insert()
+		frappe.share.add(doctype="Note", name=note.name, user=RECIPIENT, read=1)
+		self.assertTrue(frappe.db.exists(
+			"DocShare",
+			{"share_doctype": "Note", "share_name": note.name, "user": RECIPIENT},
+		))
+		return note.name
+
+	def test_owner_who_shared_can_unshare_without_permission_error(self):
+		"""RED before the fix: unshare_doc raised frappe.PermissionError for
+		OWNER (a normal Desk User, not System Manager) even though OWNER
+		legitimately has "share" permission on their own Note - because the
+		old code checked delete-permission on the System-Manager-only
+		DocShare doctype instead."""
+		note_name = self._make_shared_note()
+		# Still acting as OWNER.
+		out = unshare_doc("Note", note_name, RECIPIENT)
+		self.assertEqual(
+			out, {"doctype": "Note", "name": note_name, "user": RECIPIENT})
+		self.assertFalse(frappe.db.exists(
+			"DocShare",
+			{"share_doctype": "Note", "share_name": note_name, "user": RECIPIENT},
+		))
+
+	def test_user_without_share_permission_on_target_is_denied(self):
+		"""A Desk User with no relationship to the Note (not owner, not
+		granted share=True) is denied - the fix must not open unshare_doc up
+		to every authenticated user, only those with "share" on the doc."""
+		note_name = self._make_shared_note()
+		frappe.set_user(OUTSIDER)
+		with self.assertRaises(frappe.PermissionError):
+			unshare_doc("Note", note_name, RECIPIENT)
+		# Nothing was removed by the denied attempt.
+		frappe.set_user(OWNER)
+		self.assertTrue(frappe.db.exists(
+			"DocShare",
+			{"share_doctype": "Note", "share_name": note_name, "user": RECIPIENT},
+		))

--- a/jarvis/tools/amend_doc.py
+++ b/jarvis/tools/amend_doc.py
@@ -80,4 +80,5 @@ def amend_doc(doctype: str, name: str) -> dict:
     new_doc.amended_from = source.name
     new_doc.docstatus = 0
     new_doc.insert()  # runs validate(); autoname appends suffix
+    new_doc.apply_fieldlevel_read_permissions()
     return new_doc.as_dict()

--- a/jarvis/tools/attach_to_doc.py
+++ b/jarvis/tools/attach_to_doc.py
@@ -7,8 +7,10 @@ invoice PDF to the related Customer doc"). Without this tool the agent
 would have to re-render the PDF, doubling the storage cost and creating
 a content-hash mismatch in the File doctype's dedup table.
 
-The underlying ``frappe.utils.file_manager.add_attachments`` accepts a
-file_url OR a File doc name; we forward whichever the agent supplies.
+The underlying ``frappe.utils.file_manager.add_attachments`` needs the
+source File's **doc name**, not its url, so this tool resolves the
+docname from the agent-supplied ``file_url`` first (same pattern as
+``read_file.py``'s ``_resolve_file``).
 
 Permission contract: **write** permission on the target record (a user
 who can't write to the doc can't add an attachment to it, mirroring the
@@ -50,9 +52,17 @@ def attach_to_doc(
             f"no write permission on {target_doctype} {target_name}",
         )
 
+    # add_attachments (and File's own permission check inside it) resolves
+    # its `attachments` entries by File.name, never by file_url - look the
+    # docname up first (same pattern as read_file.py::_resolve_file) or
+    # every call raises DoesNotExistError.
+    source_file_name = frappe.db.get_value("File", {"file_url": file_url}, "name")
+    if not source_file_name:
+        raise InvalidArgumentError(f"no file found for url {file_url!r}")
+
     from frappe.utils.file_manager import add_attachments
 
-    add_attachments(target_doctype, target_name, [file_url])
+    add_attachments(target_doctype, target_name, [source_file_name])
 
     # add_attachments doesn't return a handle; look up the file the
     # caller just attached so the agent can confirm which File doc id

--- a/jarvis/tools/cancel_doc.py
+++ b/jarvis/tools/cancel_doc.py
@@ -69,4 +69,5 @@ def cancel_doc(doctype: str, name: str) -> dict:
         )
 
     doc.cancel()  # runs on_cancel hooks; sets docstatus=2
+    doc.apply_fieldlevel_read_permissions()
     return doc.as_dict()

--- a/jarvis/tools/create_custom_skill.py
+++ b/jarvis/tools/create_custom_skill.py
@@ -2,10 +2,12 @@
 
 The agent captures a procedure the user just walked it through and saves it
 as a skill owned by the session user. Defaults to scope=Personal (private,
-never pushed to the shared container catalog); scope=Org rows join the
-shared catalog only after an admin clicks Apply. This tool NEVER triggers a
-push/apply itself — Apply restarts the container and stays a deliberate
-human action.
+never pushed to the shared container catalog). scope=Org rows are visible to
+other users immediately via jarvis__find_skills/jarvis__get_skill (subject
+to allowed_roles/shared_with — see user_can_use_skill); they only join the
+/slug-invocable CONTAINER catalog after an admin clicks Apply on the Skills
+page. This tool NEVER triggers a push/apply itself — Apply restarts the
+container and stays a deliberate human action.
 
 Confirmation-gated in jarvis/api.py (_GATED_WRITES): the model path parks
 the call behind a human confirm card.
@@ -63,9 +65,10 @@ def create_custom_skill(
 
     if scope == "Org":
         note = (
-            "Saved. Org-scope skills reach the assistant's skill catalog only "
-            "after an admin clicks Apply on the Skills page; until then recall "
-            "it with jarvis__find_skills / jarvis__get_skill."
+            "Saved. Org-scope skills are discoverable and usable by other users "
+            "right away via jarvis__find_skills / jarvis__get_skill (subject to "
+            "allowed_roles/shared_with); they only join the /slug-invocable "
+            "container catalog after an admin clicks Apply on the Skills page."
         )
     else:
         note = (

--- a/jarvis/tools/create_doc.py
+++ b/jarvis/tools/create_doc.py
@@ -77,6 +77,7 @@ def create_doc(doctype: str, values: dict) -> dict:
         doc.set(field, value)
     _set_title_from_title_field(doc)
     doc.insert()  # runs DocType validate() + on_insert hooks; sets autoname
+    doc.apply_fieldlevel_read_permissions()
     return doc.as_dict()
 
 

--- a/jarvis/tools/get_balance_on.py
+++ b/jarvis/tools/get_balance_on.py
@@ -9,13 +9,19 @@ rows by hand will miss.
 
 Permission gating: the underlying helper checks Account read perm
 internally unless ``ignore_account_permission`` is set, which we do
-NOT expose to the agent (callers can't override perm checks).
+NOT expose to the agent (callers can't override perm checks). It applies
+NO company-level filter of its own, so this wrapper additionally checks
+Company read perm (honors Company User Permissions) whenever ``company``
+is supplied, and - in party-only mode, where the balance is otherwise
+summed across every company in the bench - requires an explicit,
+permission-checked ``company`` from a caller who is restricted to
+specific companies.
 """
 from __future__ import annotations
 
 import frappe
 
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 
 def get_balance_on(
@@ -43,6 +49,24 @@ def get_balance_on(
         raise InvalidArgumentError(f"unknown Company: {company}")
     if party and party_type and not frappe.db.exists(party_type, party):
         raise InvalidArgumentError(f"unknown {party_type}: {party}")
+
+    if company:
+        if not frappe.has_permission("Company", "read", doc=company):
+            raise PermissionDeniedError(f"no read permission on Company {company}")
+    elif party_type and party and not account:
+        # Party-only mode sums the balance across every company in the
+        # bench (the underlying helper applies no company filter here at
+        # all). A caller restricted to specific companies via a Company
+        # User Permission would otherwise get that cross-company exposure
+        # blended in - require an explicit, permission-checked company
+        # instead of silently aggregating across companies they can't see.
+        from frappe.permissions import get_user_permissions
+
+        if get_user_permissions(frappe.session.user).get("Company"):
+            raise InvalidArgumentError(
+                "company is required: your access is restricted to specific companies, so a "
+                "party balance cannot be summed across every company in the bench"
+            )
 
     from erpnext.accounts.utils import get_balance_on as _gbo
 

--- a/jarvis/tools/get_customer_outstanding.py
+++ b/jarvis/tools/get_customer_outstanding.py
@@ -5,8 +5,11 @@ The underlying helper sums GL entries against the customer's
 receivable accounts and optionally adds open Sales Orders' invoiceable
 balance - the same calculation as the Customer Credit Limit check.
 
-Customer read perm is enforced before delegating so a user who can't
-read the customer can't probe their outstanding balance.
+Customer read perm AND Company read perm (honors Company User
+Permissions) are enforced before delegating, so a user who can't read
+the customer - or who is restricted to a different company - can't
+probe an outstanding balance outside what they can see. The underlying
+helper itself applies no company-level permission filter.
 """
 from __future__ import annotations
 
@@ -38,6 +41,8 @@ def get_customer_outstanding(
         raise InvalidArgumentError(f"unknown Company: {company}")
     if not frappe.has_permission("Customer", "read", doc=customer):
         raise PermissionDeniedError(f"no read permission on Customer {customer}")
+    if not frappe.has_permission("Company", "read", doc=company):
+        raise PermissionDeniedError(f"no read permission on Company {company}")
 
     from erpnext.selling.doctype.customer.customer import (
         get_customer_outstanding as _gco,

--- a/jarvis/tools/get_doc.py
+++ b/jarvis/tools/get_doc.py
@@ -18,4 +18,5 @@ def get_doc(doctype: str, name: str) -> dict:
         raise PermissionDeniedError(f"no read permission on {doctype} {name}")
 
     doc = frappe.get_doc(doctype, name)
+    doc.apply_fieldlevel_read_permissions()
     return doc.as_dict(no_default_fields=False)

--- a/jarvis/tools/get_employee_shift.py
+++ b/jarvis/tools/get_employee_shift.py
@@ -3,7 +3,7 @@
 Wraps ``hrms.hr.doctype.shift_assignment.shift_assignment.get_employee_shift``.
 Walks Shift Assignment records (date-bounded) + the employee's default
 shift in priority order; falls back to "no shift assigned" without
-raising. Returns the resolved Shift Type doc.
+raising. Returns the resolved shift details as a plain dict.
 
 The agent uses this for attendance / OT / roster questions where
 the answer depends on shift start + end times that vary day-to-day.
@@ -40,12 +40,14 @@ def get_employee_shift(
     date_to_use = for_date or frappe.utils.today()
     shift = _ges(
         employee=employee,
-        for_date=date_to_use,
+        for_timestamp=date_to_use,
         consider_default_shift=bool(consider_default_shift),
     )
-    # Helper returns a Document or None; expose as dict for JSON envelope.
+    # Helper always returns a plain dict (`shift_details or {}`) - never a
+    # Document, never None. Collapse the falsy "nothing found" {} to None
+    # for a cleaner envelope instead of calling a nonexistent .as_dict().
     return {
-        "shift": shift.as_dict() if shift else None,
+        "shift": dict(shift) if shift else None,
         "employee": employee,
         "for_date": date_to_use,
     }

--- a/jarvis/tools/get_file_pages.py
+++ b/jarvis/tools/get_file_pages.py
@@ -39,7 +39,10 @@ def get_file_pages(
 
     fdoc = _resolve_file(file_url, filename)
     if not frappe.has_permission("File", "read", doc=fdoc.name):
-        raise PermissionDeniedError(f"no read permission on file {fdoc.file_name!r}")
+        # Generic on purpose - see read_file._resolve_file / F12 in
+        # audit-findings.md: do not echo the resolved file's real name back
+        # to a caller who isn't permitted to read it.
+        raise PermissionDeniedError("no matching file found")
 
     first_page = max(1, int(first_page or 1))
     max_pages = max(1, min(int(max_pages or _DEFAULT_PAGES), _MAX_PAGES_PER_CALL))

--- a/jarvis/tools/get_party_dashboard_info.py
+++ b/jarvis/tools/get_party_dashboard_info.py
@@ -28,8 +28,9 @@ def get_party_dashboard_info(
     loyalty_program: str | None = None,
 ) -> dict:
     """Return ``{dashboard, party_type, party}`` where ``dashboard`` is
-    the raw per-company list ERPNext renders on the form (each entry
-    has billing_this_year, total_unpaid, currency, etc.).
+    the per-company list ERPNext renders on the form (each entry has
+    billing_this_year, total_unpaid, currency, etc.), stripped down to
+    only the companies the caller can read.
     """
     if party_type not in _VALID_PARTY_TYPES:
         raise InvalidArgumentError(
@@ -47,6 +48,14 @@ def get_party_dashboard_info(
     dashboard = _gdi(
         party_type=party_type, party=party, loyalty_program=loyalty_program,
     )
+    # The underlying helper builds this breakdown with frappe.get_all
+    # (ignore_permissions=True) and raw frappe.qb GL Entry queries - no
+    # company-level permission filter of its own - so a caller restricted
+    # to one company via a Company User Permission would otherwise see
+    # every other company that party has ever transacted with. Strip
+    # entries for companies the caller can't read.
+    if isinstance(dashboard, list):
+        dashboard = [d for d in dashboard if frappe.has_permission("Company", "read", doc=d.get("company"))]
     return {
         "dashboard": dashboard,
         "party_type": party_type,

--- a/jarvis/tools/preview_doc.py
+++ b/jarvis/tools/preview_doc.py
@@ -66,11 +66,16 @@ def _summarize(doc, caller_values: dict) -> dict:
     # server_filled = differs from a bare new_doc, so zero-defaults don't
     # masquerade as auto-fill.
     baseline = frappe.new_doc(doc.doctype)
+    has_permlevel_read = doc.get_permlevel_access("read")
     resolved: dict = {}
     server_filled: list[str] = []
     empty_fields: list[str] = []
     for df in doc.meta.fields:
         if df.fieldtype not in _HEADER_TYPES:
+            continue
+        if df.permlevel and df.permlevel not in has_permlevel_read:
+            # Caller can't read this field at its permlevel - never echo its
+            # value (caller-supplied or server/hook-computed) back to them.
             continue
         name = df.fieldname
         val = doc.get(name)

--- a/jarvis/tools/preview_doc.py
+++ b/jarvis/tools/preview_doc.py
@@ -90,10 +90,16 @@ def _summarize(doc, caller_values: dict) -> dict:
         elif _norm(val) != _norm(baseline.get(name)):
             resolved[name] = val
             server_filled.append(name)
+    # Same permlevel guard as the header loop above: a tenant can customize
+    # any of these totals to permlevel>0, and its server-computed value must
+    # not leak to a caller who can't read that permlevel.
+    allowed_permlevels = (0, *has_permlevel_read)
     totals = {
         f: doc.get(f)
         for f in _TOTAL_FIELDS
-        if doc.meta.has_field(f) and doc.get(f) is not None
+        if doc.meta.has_field(f)
+        and doc.get(f) is not None
+        and doc.meta.get_field(f).permlevel in allowed_permlevels
     }
     return {
         "valid": True,

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -71,6 +71,7 @@ import re
 from typing import Any
 
 import frappe
+from frappe.model import get_permitted_fields
 from frappe.model import optional_fields as _OPTIONAL_FIELDS
 from pypika import Order
 from pypika import functions as fn
@@ -149,7 +150,14 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	2. Extract referenced DocTypes (FROM + joins).
 	3. DocType-level read permission check per referenced DocType.
 	4. Per-site DocType allowlist check (reused from run_query).
-	5. Build the qb query from the spec.
+	5. Build the qb query from the spec. Every concrete column reference
+	   (select / where / having / group_by / order_by / join-on / EXISTS)
+	   funnels through ``_resolve_field`` → ``_validate_column``, which
+	   enforces the **field-level (permlevel) read ACL** — the same layer
+	   ``get_list`` applies via ``apply_fieldlevel_read_permissions``. A
+	   permlevel>0 field the caller's roles don't cover is rejected here,
+	   so this tool now has field-level parity with ``get_list`` (not just
+	   the record-level parity of step 6).
 	6. Apply ``Engine.get_permission_conditions()`` for each referenced
 	   DocType — weaves User Permissions + permission_query_conditions
 	   hooks + DocShare + if_owner + role-based access predicates into
@@ -160,8 +168,10 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 
 	Raises:
 		InvalidArgumentError: spec is malformed.
-		PermissionDeniedError: caller lacks DocType-level read OR a
-			referenced DocType is not on the per-site allowlist.
+		PermissionDeniedError: caller lacks DocType-level read, a
+			referenced DocType is not on the per-site allowlist, OR a
+			referenced column is a permlevel-restricted field the caller's
+			roles don't cover (field-level ACL).
 		ResultTooLargeError: result exceeds ``ROW_GUARD`` and
 			``confirm_large`` is False.
 	"""
@@ -522,18 +532,53 @@ def _validate_doctype(dt: Any) -> None:
 		raise InvalidArgumentError(f"unknown DocType: {dt!r}")
 
 
-def _validate_column(dt: str, field: str) -> None:
-	"""Validate ``field`` is a real column of DocType ``dt``. Runs the
-	identifier-syntax check first (rejects malicious characters), then
-	confirms the column exists via ``get_valid_columns()`` — which
-	includes the standard fields (name / owner / creation / modified /
-	modified_by / idx / docstatus) and, for child tables,
-	parent / parentfield / parenttype.
+def _from_doctype(alias_map: dict) -> str:
+	"""Return the FROM/base doctype of a query scope.
 
-	``get_valid_columns()`` omits the optional meta columns (_assign /
-	_comments / _liked_by / _user_tags / _seen), which are nonetheless
-	real, queryable columns on standard doctypes — permit them too so a
-	legitimate query (e.g. filtering on ``_assign``) is not over-blocked.
+	``_build_from_and_aliases`` seeds ``alias_map`` with the FROM entry
+	before any join is appended, so the first-inserted value is always the
+	base doctype. Used to mirror ``db_query``'s field-level ACL parenttype
+	handling: the base table is the "main" table, and every other
+	referenced doctype is a joined table whose field permissions are
+	governed by the base doctype (``parenttype``)."""
+	return next(iter(alias_map.values()))[0]
+
+
+def _validate_column(dt: str, field: str, base_doctype: str | None = None) -> None:
+	"""Validate ``field`` is a real, READABLE column of DocType ``dt``.
+
+	Two gates, in order:
+
+	1. **Existence.** The identifier-syntax check first (rejects malicious
+	   characters), then column existence via ``get_valid_columns()`` —
+	   which includes the standard fields (name / owner / creation /
+	   modified / modified_by / idx / docstatus) and, for child tables,
+	   parent / parentfield / parenttype. ``get_valid_columns()`` omits the
+	   optional meta columns (_assign / _comments / _liked_by / _user_tags /
+	   _seen), which are nonetheless real, queryable columns on standard
+	   doctypes — permit them too so a legitimate query (e.g. filtering on
+	   ``_assign``) is not over-blocked.
+
+	2. **Field-level (permlevel) read ACL.** ``get_valid_columns()`` proves
+	   the column EXISTS but says nothing about whether the caller may READ
+	   it. Frappe's ``get_list`` strips permlevel>0 fields the caller's
+	   roles don't cover via ``apply_fieldlevel_read_permissions``
+	   (``frappe/model/db_query.py``); this tool re-implements field
+	   resolution from scratch, so it must mirror that gate or a caller with
+	   plain doctype read (but no elevated-permlevel role) could
+	   select / filter / order / group-by / having / join-on / EXISTS any
+	   permlevel>0 field. We defer to ``frappe.model.get_permitted_fields``
+	   — the exact helper ``apply_fieldlevel_read_permissions`` uses — which
+	   already handles CORE_DOCTYPES (no field ACL), the always-allowed
+	   standard / OPTIONAL fields, and child-table ``parenttype`` resolution.
+
+	``base_doctype`` is the query scope's FROM doctype. Mirroring
+	``apply_fieldlevel_read_permissions``, the base table is the "main"
+	table (``parenttype=None``, i.e. ``self.parent_doctype``) and every
+	OTHER referenced doctype is a joined table whose field ACL is governed
+	by the base doctype's permissions (``parenttype=base_doctype``, i.e.
+	``self.doctype``). When ``base_doctype`` is None (defensive default) or
+	equals ``dt``, ``dt`` is treated as its own base.
 	"""
 	_validate_identifier(field, "field")
 	try:
@@ -543,6 +588,27 @@ def _validate_column(dt: str, field: str) -> None:
 	if field not in valid_columns and field not in _OPTIONAL_FIELDS:
 		raise InvalidArgumentError(
 			f"unknown column {field!r} on DocType {dt!r}"
+		)
+	# Field-level (permlevel) read ACL — mirror get_list's
+	# apply_fieldlevel_read_permissions. ``ignore_virtual=True`` matches
+	# db_query (a virtual field carries no real column, so it never reaches
+	# here anyway — its name fails the existence check above).
+	parenttype = None if (base_doctype is None or dt == base_doctype) else base_doctype
+	permitted = set(
+		get_permitted_fields(
+			doctype=dt,
+			parenttype=parenttype,
+			permission_type="read",
+			ignore_virtual=True,
+		)
+	)
+	# OPTIONAL_FIELDS are always readable (mirrors
+	# apply_fieldlevel_read_permissions' explicit ``column in
+	# OPTIONAL_FIELDS`` allowance) even when absent from the permitted set.
+	if field not in permitted and field not in _OPTIONAL_FIELDS:
+		raise PermissionDeniedError(
+			f"no read permission on field {field!r} of DocType {dt!r} "
+			f"(restricted by permission level)"
 		)
 
 
@@ -601,8 +667,10 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 			# Single-doctype query — the alias is unambiguous; resolve
 			# against the only table.
 			((dt, table),) = list(alias_map.values())
-			# SEC-003: validate the column identifier + existence.
-			_validate_column(dt, field_ref)
+			# SEC-003: validate the column identifier + existence, and the
+			# field-level (permlevel) read ACL. Single-table query, so ``dt``
+			# is its own base doctype (parenttype resolves to None).
+			_validate_column(dt, field_ref, _from_doctype(alias_map))
 			return table[field_ref]
 		raise InvalidArgumentError(
 			f"field reference {field_ref!r} is ambiguous in a multi-table "
@@ -624,8 +692,11 @@ def _resolve_field(field_ref: str, alias_map: dict, allow_alias: bool = False):
 		)
 	dt, table = alias_map[alias]
 	# SEC-003: validate the column identifier + existence against the
-	# resolved DocType before it reaches pypika's ``table[field]`` sink.
-	_validate_column(dt, field)
+	# resolved DocType before it reaches pypika's ``table[field]`` sink,
+	# plus the field-level (permlevel) read ACL. ``dt`` may be a joined /
+	# child table, so its field permissions are governed by the FROM/base
+	# doctype (parenttype) — mirrors apply_fieldlevel_read_permissions.
+	_validate_column(dt, field, _from_doctype(alias_map))
 	return table[field]
 
 

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -71,6 +71,8 @@ import re
 from typing import Any
 
 import frappe
+from frappe.model import child_table_fields as _CHILD_FIELDS
+from frappe.model import default_fields as _DEFAULT_FIELDS
 from frappe.model import get_permitted_fields
 from frappe.model import optional_fields as _OPTIONAL_FIELDS
 from pypika import Order
@@ -593,6 +595,13 @@ def _validate_column(dt: str, field: str, base_doctype: str | None = None) -> No
 	# apply_fieldlevel_read_permissions. ``ignore_virtual=True`` matches
 	# db_query (a virtual field carries no real column, so it never reaches
 	# here anyway — its name fails the existence check above).
+	# Standard framework columns (name/owner/creation/.../parent) carry no
+	# permlevel restriction and are always readable - skip the permitted-
+	# fields lookup for them: it is needless DB work in production for these
+	# columns, and it lets a broadly-Engine-mocked query test resolve
+	# standard-field references without recursing through the patched Engine.
+	if field in _OPTIONAL_FIELDS or field in _DEFAULT_FIELDS or field in _CHILD_FIELDS:
+		return
 	parenttype = None if (base_doctype is None or dt == base_doctype) else base_doctype
 	permitted = set(
 		get_permitted_fields(

--- a/jarvis/tools/read_file.py
+++ b/jarvis/tools/read_file.py
@@ -97,19 +97,20 @@ def _resolve_file(file_url: str | None, filename: str | None):
             raise InvalidArgumentError(f"no file found for url {file_url!r}")
         return frappe.get_doc("File", name)
     if filename:
-        # frappe.get_list (not get_all) applies File's permission-query
-        # condition so candidates are already permission-scoped, but that
-        # condition is only an approximation (doctype-level: "attached to a
-        # doctype you can generally read"), not the row-level has_permission
-        # check File actually enforces - so we still verify each candidate
-        # explicitly and pick the first (most recent) one that passes. This
-        # closes the F12 hole where frappe.get_all (no permission filtering
-        # at all) + a substring LIKE fallback could hand back a private File
-        # attached to a record the caller has no access to.
-        candidates = frappe.get_list(
+        # Gather name-matching candidates unfiltered, then gate EACH with the
+        # row-level has_permission check File actually enforces, returning the
+        # first (most recent) one the caller may read. This closes the F12 hole
+        # (the old code picked the most-recent match with NO permission check,
+        # so a private File the caller couldn't access could be handed back)
+        # while still letting a user read their OWN file: we deliberately do NOT
+        # pre-filter with get_list, because File's permission-query condition is
+        # a coarse, environment-sensitive approximation (attached-doc based) that
+        # can exclude a caller's own unattached private file - the per-candidate
+        # has_permission below is the authoritative gate.
+        candidates = frappe.get_all(
             "File", filters={"file_name": filename}, fields=["name"],
             order_by="creation desc", limit=20,
-        ) or frappe.get_list(
+        ) or frappe.get_all(
             "File", filters={"file_name": ["like", f"%{filename}%"]}, fields=["name"],
             order_by="creation desc", limit=20,
         )

--- a/jarvis/tools/read_file.py
+++ b/jarvis/tools/read_file.py
@@ -57,7 +57,11 @@ def read_file(
     """
     fdoc = _resolve_file(file_url, filename)
     if not frappe.has_permission("File", "read", doc=fdoc.name):
-        raise PermissionDeniedError(f"no read permission on file {fdoc.file_name!r}")
+        # Generic on purpose - do not echo the resolved file's real name back
+        # to a caller who isn't permitted to read it (see F12 in
+        # audit-findings.md: that would confirm the existence/name of a
+        # private file the caller has no other way to see).
+        raise PermissionDeniedError("no matching file found")
 
     ext = (fdoc.file_name or "").rsplit(".", 1)[-1].lower() if "." in (fdoc.file_name or "") else ""
     # encodings=[] -> raw bytes; skip Frappe's text-encoding guess loop, which
@@ -93,16 +97,29 @@ def _resolve_file(file_url: str | None, filename: str | None):
             raise InvalidArgumentError(f"no file found for url {file_url!r}")
         return frappe.get_doc("File", name)
     if filename:
-        rows = frappe.get_all(
+        # frappe.get_list (not get_all) applies File's permission-query
+        # condition so candidates are already permission-scoped, but that
+        # condition is only an approximation (doctype-level: "attached to a
+        # doctype you can generally read"), not the row-level has_permission
+        # check File actually enforces - so we still verify each candidate
+        # explicitly and pick the first (most recent) one that passes. This
+        # closes the F12 hole where frappe.get_all (no permission filtering
+        # at all) + a substring LIKE fallback could hand back a private File
+        # attached to a record the caller has no access to.
+        candidates = frappe.get_list(
             "File", filters={"file_name": filename}, fields=["name"],
-            order_by="creation desc", limit=1,
-        ) or frappe.get_all(
+            order_by="creation desc", limit=20,
+        ) or frappe.get_list(
             "File", filters={"file_name": ["like", f"%{filename}%"]}, fields=["name"],
-            order_by="creation desc", limit=1,
+            order_by="creation desc", limit=20,
         )
-        if not rows:
-            raise InvalidArgumentError(f"no file found named {filename!r}")
-        return frappe.get_doc("File", rows[0].name)
+        for row in candidates:
+            if frappe.has_permission("File", "read", doc=row.name):
+                return frappe.get_doc("File", row.name)
+        # Generic on purpose - covers both "nothing matched" and "something
+        # matched but you can't read it"; the latter must not confirm the
+        # existence/name of a private file the caller can't otherwise see.
+        raise InvalidArgumentError("no matching file found")
     raise InvalidArgumentError("pass file_url or filename to identify the attachment")
 
 

--- a/jarvis/tools/run_method.py
+++ b/jarvis/tools/run_method.py
@@ -8,8 +8,10 @@ whitelisted actions. Runs under the calling user's identity
 ``@frappe.whitelist()`` gate and permission checks apply.
 
 Consequential by default: it can mutate. The persona confirms before
-calling it, ``api._run_tool`` audits it, and it supports ``preview``
-(dry-run with DB writes rolled back).
+calling it and ``api._run_tool`` audits it. ``preview`` is NOT honored for
+this tool: it is one of ``api._GATED_WRITES``, so ``preview=True`` is always
+rejected with an InvalidArgumentError rather than dry-run - the call always
+parks for human confirmation instead.
 """
 import fnmatch
 import inspect

--- a/jarvis/tools/run_scrutiny.py
+++ b/jarvis/tools/run_scrutiny.py
@@ -10,9 +10,16 @@ be REPRODUCIBLE (same data -> same hits, re-runnable by a peer reviewer)
 and a real ledger is far larger than one chat turn can read, so the
 filtering happens set-based in the DB.
 
-Read-only over ERP data. Runs under the calling user's Frappe identity,
-so it can only see accounts the user is permitted to (company-level
-perms + the standard GL Entry query). Statutory rules
+Read-only over ERP data. Every rule evaluator runs raw ``frappe.db.sql``
+against GL Entry / Account / Supplier - NOT the standard GL Entry query -
+so Frappe's ORM-level permission filtering never applies to those rows.
+Before any evaluator runs, this tool explicitly checks the calling user
+has ``GL Entry`` read permission and ``Company`` read permission on the
+resolved company (``frappe.has_permission(..., throw=True)``, which
+honors Company User Permissions); a caller who fails either check is
+denied before a single query executes. Those two checks are the entire
+permission gate - they are doctype/company-level, not per-account or
+per-transaction filtered the way ``frappe.get_list`` would be. Statutory rules
 (``status == "needs_legal_review"``) are SKIPPED unless
 ``include_unreviewed`` is set, and every statutory finding carries its
 section + effective_date + disclaimer.
@@ -610,6 +617,13 @@ def run_scrutiny(
     persist (this runs under the caller's identity)."""
     pack = _load_pack(rule_pack)
     scope = _resolve_scope(company, fiscal_year, from_date, to_date)
+
+    # Every evaluator below runs raw SQL over GL Entry/Account/Supplier -
+    # Frappe's ORM permission layer never sees these queries, so the gate
+    # has to be explicit: GL Entry read (doctype-level) and Company read
+    # on the resolved company (honors Company User Permissions).
+    frappe.has_permission("GL Entry", "read", throw=True)
+    frappe.has_permission("Company", "read", doc=scope["company"], throw=True)
 
     materiality = None
     if engagement_config:

--- a/jarvis/tools/run_scrutiny.py
+++ b/jarvis/tools/run_scrutiny.py
@@ -14,10 +14,19 @@ Read-only over ERP data. Every rule evaluator runs raw ``frappe.db.sql``
 against GL Entry / Account / Supplier - NOT the standard GL Entry query -
 so Frappe's ORM-level permission filtering never applies to those rows.
 Before any evaluator runs, this tool explicitly checks the calling user
-has ``GL Entry`` read permission and ``Company`` read permission on the
-resolved company (``frappe.has_permission(..., throw=True)``, which
-honors Company User Permissions); a caller who fails either check is
-denied before a single query executes. Those two checks are the entire
+has ``GL Entry`` read permission (``frappe.has_permission(..., throw=True)``)
+- this is what keeps non-financial roles (Sales User, Employee, ...) out
+- and, separately, that the resolved company is not excluded by a
+``Company`` **User Permission** scope. The company check deliberately
+does NOT require ``Company``-doctype read: ERPNext's own "Auditor" role
+is granted ``GL Entry`` read but only ``select`` (not ``read``) on
+``Company``, so gating on Company-doctype read would lock out a
+legitimate audit-agent user entirely. A caller with no Company User
+Permission is not company-restricted at all (the GL Entry check already
+gates who may run this tool); a caller WITH one may only scrutinize a
+company inside that scope - a user restricted to Company A cannot pass
+``company="Company B"``. A caller who fails either check is denied
+before a single query executes. These two checks are the entire
 permission gate - they are doctype/company-level, not per-account or
 per-transaction filtered the way ``frappe.get_list`` would be. Statutory rules
 (``status == "needs_legal_review"``) are SKIPPED unless
@@ -36,8 +45,9 @@ import os
 from decimal import Decimal
 
 import frappe
+from frappe.core.doctype.user_permission.user_permission import get_user_permissions
 
-from jarvis.exceptions import InvalidArgumentError
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 
 _PACK_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "agents", "rule_packs")
 INSTALLATION_DT = "Jarvis Agent Installation"
@@ -620,10 +630,22 @@ def run_scrutiny(
 
     # Every evaluator below runs raw SQL over GL Entry/Account/Supplier -
     # Frappe's ORM permission layer never sees these queries, so the gate
-    # has to be explicit: GL Entry read (doctype-level) and Company read
-    # on the resolved company (honors Company User Permissions).
+    # has to be explicit. GL Entry read (doctype-level) keeps non-financial
+    # roles out entirely. Cross-company scoping is enforced via Company
+    # User Permissions, NOT Company-doctype read: ERPNext's "Auditor" role
+    # has GL Entry read but only "select" (not "read") on Company, so
+    # gating on Company read would deny a legitimate audit user outright.
+    # No Company User Permission -> not company-restricted -> allowed
+    # (already gated by the GL Entry check above). A Company User
+    # Permission for a DIFFERENT company than the one requested -> denied.
     frappe.has_permission("GL Entry", "read", throw=True)
-    frappe.has_permission("Company", "read", doc=scope["company"], throw=True)
+    company_scope = get_user_permissions(frappe.session.user).get("Company")
+    if company_scope:
+        allowed_companies = {up.get("doc") for up in company_scope}
+        if scope["company"] not in allowed_companies:
+            raise PermissionDeniedError(
+                f"no access to company {scope['company']!r} (restricted by Company User Permission)"
+            )
 
     materiality = None
     if engagement_config:

--- a/jarvis/tools/scan_barcode.py
+++ b/jarvis/tools/scan_barcode.py
@@ -8,9 +8,10 @@ warehouse the scan happened in.
 Read-only - no DB writes, just a lookup. The underlying erpnext helper
 performs NO permission checks of its own (verified by reading
 ``erpnext.stock.utils.scan_barcode``: it looks Item Barcode / Serial No /
-Batch up via raw ``frappe.db.get_value``, never ``frappe.has_permission``)
-- this wrapper explicitly checks Item / Serial No / Batch read permission
-on whatever the scan resolved before returning it.
+Batch / Warehouse up via raw ``frappe.db.get_value`` /
+``frappe.get_cached_value``, never ``frappe.has_permission``) - this
+wrapper explicitly checks Item / Serial No / Batch / Warehouse read
+permission on whatever the scan resolved before returning it.
 """
 from __future__ import annotations
 
@@ -47,4 +48,7 @@ def scan_barcode(search_value: str) -> dict:
     batch_no = result.get("batch_no")
     if batch_no:
         frappe.has_permission("Batch", "read", doc=batch_no, throw=True)
+    warehouse = result.get("warehouse")
+    if warehouse:
+        frappe.has_permission("Warehouse", "read", doc=warehouse, throw=True)
     return result

--- a/jarvis/tools/scan_barcode.py
+++ b/jarvis/tools/scan_barcode.py
@@ -5,11 +5,16 @@ workflows where the agent receives a raw scanned value and needs to
 know what item it is, what serial / batch is implied, and what
 warehouse the scan happened in.
 
-Read-only - no DB writes, just a lookup. Permission gating is the
-underlying helper's responsibility (it consults Item / Serial No /
-Batch read perms).
+Read-only - no DB writes, just a lookup. The underlying erpnext helper
+performs NO permission checks of its own (verified by reading
+``erpnext.stock.utils.scan_barcode``: it looks Item Barcode / Serial No /
+Batch up via raw ``frappe.db.get_value``, never ``frappe.has_permission``)
+- this wrapper explicitly checks Item / Serial No / Batch read permission
+on whatever the scan resolved before returning it.
 """
 from __future__ import annotations
+
+import frappe
 
 from jarvis.exceptions import InvalidArgumentError
 
@@ -29,7 +34,17 @@ def scan_barcode(search_value: str) -> dict:
     # or a dict depending on the ERPNext release; normalise to a JSON-
     # friendly dict either way.
     if hasattr(result, "__dict__"):
-        return {k: v for k, v in vars(result).items() if not k.startswith("_")}
-    if isinstance(result, dict):
-        return result
-    return {"raw": result}
+        result = {k: v for k, v in vars(result).items() if not k.startswith("_")}
+    elif not isinstance(result, dict):
+        result = {"raw": result}
+
+    item_code = result.get("item_code")
+    if item_code:
+        frappe.has_permission("Item", "read", doc=item_code, throw=True)
+    serial_no = result.get("serial_no")
+    if serial_no:
+        frappe.has_permission("Serial No", "read", doc=serial_no, throw=True)
+    batch_no = result.get("batch_no")
+    if batch_no:
+        frappe.has_permission("Batch", "read", doc=batch_no, throw=True)
+    return result

--- a/jarvis/tools/submit_doc.py
+++ b/jarvis/tools/submit_doc.py
@@ -71,4 +71,5 @@ def submit_doc(doctype: str, name: str) -> dict:
         )
 
     doc.submit()  # runs validate() + on_submit hooks; sets docstatus=1
+    doc.apply_fieldlevel_read_permissions()
     return doc.as_dict()

--- a/jarvis/tools/unshare_doc.py
+++ b/jarvis/tools/unshare_doc.py
@@ -19,7 +19,19 @@ def unshare_doc(doctype: str, name: str, user: str) -> dict:
     if not user:
         raise InvalidArgumentError("user is required")
 
+    # frappe.share.remove() (without ignore_permissions) deletes the DocShare
+    # row via frappe.delete_doc, which checks DELETE permission on the
+    # DocShare doctype itself - a System-Manager-only role table with no
+    # if_owner - so it denies every ordinary user, even one with legitimate
+    # share rights on the target document. The correct boundary is "share"
+    # permission on the TARGET doc (mirroring share_doc's implicit check via
+    # frappe.share.add -> check_share_permission), then bypass the DocShare
+    # ACL explicitly - the same pattern frappe.share.set_docshare_permission
+    # uses (share.flags.ignore_permissions = True before deleting).
+    frappe.has_permission(doctype, "share", doc=name, throw=True)
+
     from frappe.share import remove as _share_remove
 
-    _share_remove(doctype=doctype, name=name, user=user)
+    _share_remove(doctype=doctype, name=name, user=user,
+                   flags={"ignore_permissions": True})
     return {"doctype": doctype, "name": name, "user": user}

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -74,4 +74,5 @@ def update_doc(doctype: str, name: str, changes: dict) -> dict:
     for field, value in changes.items():
         doc.set(field, value)
     doc.save()  # runs DocType validate() and on_update hooks
+    doc.apply_fieldlevel_read_permissions()
     return doc.as_dict()


### PR DESCRIPTION
## Summary
Fixes all **25 confirmed findings** from an adversarially-verified security audit of the `jarvis__*` tool layer (6 Critical / 14 Important / 5 Minor). Grouped by root cause:

- **Permlevel field leaks (F1,F3,F7,F8,F9,F10,F22 + F2)** — `get_doc`/`cancel_doc`/`create_doc`/`update_doc`/`submit_doc`/`amend_doc`/`preview_doc` returned `as_dict()` without `apply_fieldlevel_read_permissions()`, leaking permlevel>0 fields (salary/cost/margin) to users who can read the doc but not those fields; the `query` DSL's column resolver never checked permlevel. All now strip restricted fields (query mirrors `get_list`'s `get_permitted_fields`).
- **Broken tools (F4, F11)** — `get_employee_shift` passed a wrong kwarg (`for_date`→`for_timestamp`, `TypeError` every call, hidden by a too-loose mock); `attach_to_doc` passed a File URL where a docname was required (failed every call).
- **Permission bypasses / cross-company leaks (F5,F12,F13,F14,F15,F16)** — `run_scrutiny` ran raw GL SQL with no permission check (now GL-read + Company **User-Permission** scoping, so the Auditor role still works); `read_file` filename search could pick + name a private file; `scan_barcode` trusted a helper that checks nothing; three ERPNext reads never checked the `company` arg.
- **Write-gate coverage (F17,F18,F20,F23,F24,F25)** — `share_doc`/`assign_to` now park a confirmation card (were silent despite "ALWAYS confirm"); `run_scrutiny`/`download_pdf`/`export_excel` now audited; `unshare_doc`'s permission boundary fixed (was System-Manager-only).
- **Secret redaction (F6)** — audit log redacted only exact key names, leaking compound Password fields (`llm_api_key`, `subscription_accounts`, …) in plaintext; now substring + per-doctype (incl. child-table) Password-field redaction.
- **Doc drift (F19, F21)** — corrected a false "admin Apply gates this" skill note (Org skills are immediately discoverable by design); F21 plugin-side text in Aerele-RnD/jarvis-openclaw-plugin#51.

## Process
Built subagent-driven: TDD per fix (each with a test that was RED against the vulnerable code), per-task review + adversarial verify, and an opus whole-branch merge-gate review — verdict **ready to merge**, all findings closed, no regressions/over-blocks.

## Test
Full app suite green on this branch after `bench migrate`: **855 tests OK** (2 pre-existing skips). Rebased onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

