### PR TITLE
fix: scope 3 cross-company reads by Company User Permission (unblock Auditor)

### DIFF
--- a/jarvis/tests/test_company_scope.py
+++ b/jarvis/tests/test_company_scope.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``jarvis.tools._company_scope`` - the Company User
+Permission scoping helper shared by ``get_customer_outstanding``,
+``get_balance_on``, ``get_party_dashboard_info``, and ``run_scrutiny``.
+
+Exercises real ``get_user_permissions`` decisions (not a mocked one)
+against a real ``User Permission`` row, so the fix (scope by Company User
+Permission, not Company-doctype read) is proven end to end.
+"""
+from __future__ import annotations
+
+import contextlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.tools._company_scope import assert_company_permitted, is_company_permitted
+
+COMPANY_A = "_JPL Scope Company A"
+COMPANY_B = "_JPL Scope Company B"
+USER_SCOPED = "jpl-scope-company-a@example.com"
+
+
+def _ensure_company(name: str, abbr: str) -> None:
+    if frappe.db.exists("Company", name):
+        return
+    # Skip default chart-of-accounts / warehouse / tax-template creation -
+    # this fixture only needs a Company row for permission checks, not a
+    # functioning ledger, and CI sites may be missing the fixtures those
+    # hooks depend on (e.g. Warehouse Type "Transit").
+    frappe.local.flags.ignore_chart_of_accounts = True
+    try:
+        frappe.get_doc({
+            "doctype": "Company",
+            "company_name": name,
+            "abbr": abbr,
+            "default_currency": "INR",
+            "country": "India",
+        }).insert(ignore_permissions=True)
+    finally:
+        frappe.local.flags.ignore_chart_of_accounts = False
+
+
+def _ensure_user(email: str) -> None:
+    if not frappe.db.exists("User", email):
+        frappe.get_doc({
+            "doctype": "User",
+            "email": email,
+            "first_name": email.split("@")[0],
+            "send_welcome_email": 0,
+            "enabled": 1,
+            "user_type": "System User",
+        }).insert(ignore_permissions=True)
+    user = frappe.get_doc("User", email)
+    if "System Manager" in frappe.get_roles(email):
+        user.remove_roles("System Manager")
+
+
+def _ensure_user_permission(user: str, allow: str, for_value: str) -> None:
+    if frappe.db.exists("User Permission", {"user": user, "allow": allow, "for_value": for_value}):
+        return
+    frappe.get_doc({
+        "doctype": "User Permission", "user": user, "allow": allow, "for_value": for_value,
+    }).insert(ignore_permissions=True)
+
+
+@contextlib.contextmanager
+def _as(user: str):
+    orig = frappe.session.user
+    frappe.set_user(user)
+    try:
+        yield
+    finally:
+        frappe.set_user(orig)
+
+
+class TestCompanyScope(FrappeTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        frappe.set_user("Administrator")
+        # User is cheap, harmless to leave committed (reused idempotently
+        # across runs, mirrors test_tier2a_erpnext_reads.py).
+        _ensure_user(USER_SCOPED)
+        frappe.db.commit()
+        # Company/User Permission are NOT committed - vanish via
+        # FrappeTestCase's automatic per-class rollback rather than
+        # persist across test modules (mirrors CrossCompanyPermTestCase in
+        # test_tier2a_erpnext_reads.py).
+        _ensure_company(COMPANY_A, "JPLSCA")
+        _ensure_company(COMPANY_B, "JPLSCB")
+        _ensure_user_permission(USER_SCOPED, "Company", COMPANY_A)
+
+    def setUp(self):
+        super().setUp()
+        frappe.set_user("Administrator")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+    def test_unrestricted_user_is_permitted_for_any_company(self):
+        # No Company User Permission at all -> not company-restricted.
+        with _as("Administrator"):
+            self.assertTrue(is_company_permitted(COMPANY_A))
+            self.assertTrue(is_company_permitted(COMPANY_B))
+            assert_company_permitted(COMPANY_A)  # must not raise
+            assert_company_permitted(COMPANY_B)  # must not raise
+
+    def test_scoped_user_permitted_for_own_company(self):
+        with _as(USER_SCOPED):
+            self.assertTrue(is_company_permitted(COMPANY_A))
+            assert_company_permitted(COMPANY_A)  # must not raise
+
+    def test_scoped_user_denied_for_other_company(self):
+        with _as(USER_SCOPED):
+            self.assertFalse(is_company_permitted(COMPANY_B))
+            with self.assertRaises(PermissionDeniedError):
+                assert_company_permitted(COMPANY_B)
+
+    def test_is_company_permitted_explicit_user_arg(self):
+        # is_company_permitted takes an explicit `user` kwarg independent
+        # of the current session (assert_company_permitted always checks
+        # the session user).
+        with _as("Administrator"):
+            self.assertFalse(is_company_permitted(COMPANY_B, user=USER_SCOPED))
+            self.assertTrue(is_company_permitted(COMPANY_A, user=USER_SCOPED))

--- a/jarvis/tests/test_tier2a_erpnext_reads.py
+++ b/jarvis/tests/test_tier2a_erpnext_reads.py
@@ -316,6 +316,14 @@ USER_ITEM_READER = "jpl-perm-item-reader@example.com"
 # exactly the "restricted via a Company User Permission" case the audit
 # findings call out.
 USER_COMPANY_SCOPED = "jpl-perm-company-scoped@example.com"
+# ERPNext's stock "Auditor" role (GL Entry read, Company "select" only -
+# not "read") combined with "Sales Manager" (Customer read, no Company
+# permission of any kind) for party read - together, real stock roles
+# that add up to GL/party read with NO Company read anywhere and no
+# Company User Permission at all. This is exactly the over-block Fix A
+# addresses: gating on Company-doctype read (rather than Company User
+# Permission scope) would deny this combination outright.
+USER_AUDITOR_LIKE = "jpl-perm-auditor-like@example.com"
 
 
 def _ensure_role(name: str) -> None:
@@ -431,6 +439,7 @@ class CrossCompanyPermTestCase(FrappeTestCase):
         _ensure_user(USER_NO_GRANTS, roles=(ROLE_NO_GRANTS,))
         _ensure_user(USER_ITEM_READER, roles=("Stock User",))
         _ensure_user(USER_COMPANY_SCOPED, roles=("Sales User",))
+        _ensure_user(USER_AUDITOR_LIKE, roles=("Auditor", "Sales Manager"))
         frappe.db.commit()
         # Company/Item/Customer/User Permission are NOT committed - unlike
         # roles/users, a leftover Company row changes production inference
@@ -571,3 +580,36 @@ class TestGetBalanceOnCompanyPermission(CrossCompanyPermTestCase):
         ):
             out = get_balance_on(party_type="Customer", party=self.customer)
         self.assertEqual(out["balance"], 750.0)
+
+
+class TestAuditorLikeCompanyScope(CrossCompanyPermTestCase):
+    """Fix A: company scoping must be by Company User Permission, not
+    Company-doctype read - so a real, non-Administrator user with GL/party
+    read but NO Company read anywhere (like ERPNext's stock "Auditor"
+    role) and no Company User Permission is allowed, not denied. Using
+    Administrator wouldn't catch a regression here (Administrator bypasses
+    frappe.has_permission entirely), so USER_AUDITOR_LIKE genuinely lacks
+    Company read via any of its roles - see the constant's docstring."""
+
+    def test_get_customer_outstanding_allowed_without_company_read(self):
+        with _as(USER_AUDITOR_LIKE), patch(
+            "erpnext.selling.doctype.customer.customer.get_customer_outstanding",
+            return_value=42.0,
+        ):
+            out = get_customer_outstanding(self.customer, PERM_COMPANY_A)
+        self.assertEqual(out["outstanding"], 42.0)
+
+    def test_get_party_dashboard_info_keeps_entry_without_company_read(self):
+        with _as(USER_AUDITOR_LIKE), patch(
+            "erpnext.accounts.party.get_dashboard_info",
+            return_value=[{"company": PERM_COMPANY_A, "total_unpaid": 10}],
+        ):
+            out = get_party_dashboard_info("Customer", self.customer)
+        self.assertEqual([d["company"] for d in out["dashboard"]], [PERM_COMPANY_A])
+
+    def test_get_balance_on_allowed_without_company_read(self):
+        with _as(USER_AUDITOR_LIKE), patch(
+            "erpnext.accounts.utils.get_balance_on", return_value=333.0,
+        ):
+            out = get_balance_on(party_type="Customer", party=self.customer, company=PERM_COMPANY_A)
+        self.assertEqual(out["balance"], 333.0)

--- a/jarvis/tools/_company_scope.py
+++ b/jarvis/tools/_company_scope.py
@@ -1,0 +1,32 @@
+"""Company-scope gating by User Permission (not Company-doctype read).
+
+ERPNext scopes multi-company access via User Permissions on Company, not the
+Company doctype's own read role - so a user with no Company User Permission is
+NOT company-restricted, and a user WITH one may only touch companies in that
+set. Gating on Company-doctype read would wrongly deny the "Auditor" role
+(GL read, Company `select` only). Mirrors run_scrutiny's gate.
+"""
+from __future__ import annotations
+
+import frappe
+from frappe.core.doctype.user_permission.user_permission import get_user_permissions
+
+from jarvis.exceptions import PermissionDeniedError
+
+
+def _permitted_companies(user: str | None = None):
+    """Set of companies the user is restricted to, or None if unrestricted."""
+    scope = get_user_permissions(user or frappe.session.user).get("Company")
+    return {up.get("doc") for up in scope} if scope else None
+
+
+def is_company_permitted(company: str, user: str | None = None) -> bool:
+    allowed = _permitted_companies(user)
+    return allowed is None or company in allowed
+
+
+def assert_company_permitted(company: str) -> None:
+    if not is_company_permitted(company):
+        raise PermissionDeniedError(
+            f"no access to company {company!r} (restricted by Company User Permission)"
+        )

--- a/jarvis/tools/get_balance_on.py
+++ b/jarvis/tools/get_balance_on.py
@@ -10,18 +10,19 @@ rows by hand will miss.
 Permission gating: the underlying helper checks Account read perm
 internally unless ``ignore_account_permission`` is set, which we do
 NOT expose to the agent (callers can't override perm checks). It applies
-NO company-level filter of its own, so this wrapper additionally checks
-Company read perm (honors Company User Permissions) whenever ``company``
-is supplied, and - in party-only mode, where the balance is otherwise
-summed across every company in the bench - requires an explicit,
-permission-checked ``company`` from a caller who is restricted to
-specific companies.
+NO company-level filter of its own, so this wrapper additionally gates
+``company`` by Company User Permission scope (not Company-doctype read
+- see ``jarvis.tools._company_scope``) whenever ``company`` is supplied,
+and - in party-only mode, where the balance is otherwise summed across
+every company in the bench - requires an explicit, permission-checked
+``company`` from a caller who is restricted to specific companies.
 """
 from __future__ import annotations
 
 import frappe
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._company_scope import assert_company_permitted
 
 
 def get_balance_on(
@@ -51,8 +52,7 @@ def get_balance_on(
         raise InvalidArgumentError(f"unknown {party_type}: {party}")
 
     if company:
-        if not frappe.has_permission("Company", "read", doc=company):
-            raise PermissionDeniedError(f"no read permission on Company {company}")
+        assert_company_permitted(company)
     elif party_type and party and not account:
         # Party-only mode sums the balance across every company in the
         # bench (the underlying helper applies no company filter here at

--- a/jarvis/tools/get_customer_outstanding.py
+++ b/jarvis/tools/get_customer_outstanding.py
@@ -5,11 +5,12 @@ The underlying helper sums GL entries against the customer's
 receivable accounts and optionally adds open Sales Orders' invoiceable
 balance - the same calculation as the Customer Credit Limit check.
 
-Customer read perm AND Company read perm (honors Company User
-Permissions) are enforced before delegating, so a user who can't read
-the customer - or who is restricted to a different company - can't
-probe an outstanding balance outside what they can see. The underlying
-helper itself applies no company-level permission filter.
+Customer read perm is enforced before delegating, and the company is
+gated by Company User Permission scope (not Company-doctype read - see
+``jarvis.tools._company_scope``), so a user who can't read the customer
+- or who is restricted to a different company - can't probe an
+outstanding balance outside what they can see. The underlying helper
+itself applies no company-level permission filter.
 """
 from __future__ import annotations
 
@@ -19,6 +20,7 @@ from jarvis.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
 )
+from jarvis.tools._company_scope import assert_company_permitted
 
 
 def get_customer_outstanding(
@@ -41,8 +43,7 @@ def get_customer_outstanding(
         raise InvalidArgumentError(f"unknown Company: {company}")
     if not frappe.has_permission("Customer", "read", doc=customer):
         raise PermissionDeniedError(f"no read permission on Customer {customer}")
-    if not frappe.has_permission("Company", "read", doc=company):
-        raise PermissionDeniedError(f"no read permission on Company {company}")
+    assert_company_permitted(company)
 
     from erpnext.selling.doctype.customer.customer import (
         get_customer_outstanding as _gco,

--- a/jarvis/tools/get_party_dashboard_info.py
+++ b/jarvis/tools/get_party_dashboard_info.py
@@ -18,6 +18,7 @@ from jarvis.exceptions import (
     InvalidArgumentError,
     PermissionDeniedError,
 )
+from jarvis.tools._company_scope import is_company_permitted
 
 _VALID_PARTY_TYPES = ("Customer", "Supplier")
 
@@ -53,9 +54,10 @@ def get_party_dashboard_info(
     # company-level permission filter of its own - so a caller restricted
     # to one company via a Company User Permission would otherwise see
     # every other company that party has ever transacted with. Strip
-    # entries for companies the caller can't read.
+    # entries for companies outside the caller's Company User Permission
+    # scope (see jarvis.tools._company_scope - not Company-doctype read).
     if isinstance(dashboard, list):
-        dashboard = [d for d in dashboard if frappe.has_permission("Company", "read", doc=d.get("company"))]
+        dashboard = [d for d in dashboard if is_company_permitted(d.get("company"))]
     return {
         "dashboard": dashboard,
         "party_type": party_type,

--- a/jarvis/tools/run_scrutiny.py
+++ b/jarvis/tools/run_scrutiny.py
@@ -45,9 +45,9 @@ import os
 from decimal import Decimal
 
 import frappe
-from frappe.core.doctype.user_permission.user_permission import get_user_permissions
 
-from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools._company_scope import assert_company_permitted
 
 _PACK_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "agents", "rule_packs")
 INSTALLATION_DT = "Jarvis Agent Installation"
@@ -632,20 +632,15 @@ def run_scrutiny(
     # Frappe's ORM permission layer never sees these queries, so the gate
     # has to be explicit. GL Entry read (doctype-level) keeps non-financial
     # roles out entirely. Cross-company scoping is enforced via Company
-    # User Permissions, NOT Company-doctype read: ERPNext's "Auditor" role
-    # has GL Entry read but only "select" (not "read") on Company, so
-    # gating on Company read would deny a legitimate audit user outright.
-    # No Company User Permission -> not company-restricted -> allowed
-    # (already gated by the GL Entry check above). A Company User
-    # Permission for a DIFFERENT company than the one requested -> denied.
+    # User Permissions, NOT Company-doctype read (jarvis.tools._company_scope):
+    # ERPNext's "Auditor" role has GL Entry read but only "select" (not
+    # "read") on Company, so gating on Company read would deny a
+    # legitimate audit user outright. No Company User Permission -> not
+    # company-restricted -> allowed (already gated by the GL Entry check
+    # above). A Company User Permission for a DIFFERENT company than the
+    # one requested -> denied.
     frappe.has_permission("GL Entry", "read", throw=True)
-    company_scope = get_user_permissions(frappe.session.user).get("Company")
-    if company_scope:
-        allowed_companies = {up.get("doc") for up in company_scope}
-        if scope["company"] not in allowed_companies:
-            raise PermissionDeniedError(
-                f"no access to company {scope['company']!r} (restricted by Company User Permission)"
-            )
+    assert_company_permitted(scope["company"])
 
     materiality = None
     if engagement_config:


### PR DESCRIPTION
## Summary
Follow-up to the tool-audit remediation (#272). FixTask 4 gated `get_customer_outstanding` / `get_party_dashboard_info` / `get_balance_on` on `has_permission("Company", "read")`, which over-blocks the ERPNext **Auditor** role (GL/party read, but only `select` — not `read` — on Company). `run_scrutiny` already scoped by **Company User Permission** (the correct multi-company primitive). This aligns the three tools with that model via a shared helper.

- New `jarvis/tools/_company_scope.py` — `is_company_permitted` / `assert_company_permitted`: no Company User Permission → unrestricted; one present → restricted to that set. Does NOT require Company-doctype read.
- The three tools swap the Company-read gate for the company-scope check (party read checks unchanged); `run_scrutiny` refactored onto the same helper (behavior-identical).
- Net: an Auditor can now use these tools for a company they're permitted; a Company-A-restricted user still can't reach Company B (raise) or see it (dashboard strip).

## Review
Approved — helper verified against frappe's `get_user_permissions`, security model confirmed against the actual Company/Customer/GL Entry role JSONs, no fail-open, tests exercise the real permission engine both directions.

## Test
`test_company_scope` (4), `test_tier2a_erpnext_reads` (41, incl. auditor-like + restricted-cross-company), `test_agent_scrutiny` (20) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)