### PR TITLE
Encrypt Settings Password-field writes, migrate plaintext/stale secrets, dedup pool syncs

### DIFF
--- a/jarvis/_password_utils.py
+++ b/jarvis/_password_utils.py
@@ -1,0 +1,61 @@
+"""Shared helper for writing Jarvis Settings Password fields OUTSIDE the
+normal Document.save() pipeline.
+
+Frappe only encrypts a Password field into the __Auth table when a value
+passes through Document._save_passwords() - i.e. a real doc.save(). Writing
+via doc.db_set(...) or frappe.db.set_value(...) bypasses that entirely and
+stores the raw value in plaintext in the Single's row in tabSingles. Several
+call sites in this app use db_set deliberately (to avoid re-triggering
+on_update's admin-sync push during onboarding/rotation flows) but were
+writing secrets straight into that plaintext column.
+
+This mirrors the idiom already established in
+jarvis_settings.py::_on_update_unified_llm for mirroring models[0].api_key
+into the legacy llm_api_key field: encrypt the real value into __Auth via
+set_encrypted_password, then write only an all-asterisk mask to the doc's
+own field (db_set) so tabSingles never holds the secret. Every reader in
+this app already goes through get_password(), so this is a drop-in swap.
+"""
+
+from frappe.utils.password import set_encrypted_password
+
+SETTINGS = "Jarvis Settings"
+
+# Same masking shape jarvis_settings.py already uses for llm_api_key - a
+# fixed-length mask (not len(value)-length like Document._save_passwords)
+# so the mask itself never leaks the secret's length.
+_MASK = "*" * 10
+
+
+def set_settings_password(doc, fieldname: str, value: str, *, update_modified: bool = True) -> None:
+	"""Encrypt ``value`` into __Auth for Jarvis Settings.<fieldname>, then
+	write only the mask to ``doc`` via db_set (never the plaintext).
+
+	No-op when ``value`` is falsy - callers already guard on truthiness
+	before calling (matching the db_set(...) call sites this replaces, which
+	only wrote when the incoming value was present).
+
+	``doc`` must be the Jarvis Settings singleton Document (or a doc whose
+	db_set targets it) so the __Auth row (keyed to doctype+name) and the
+	db_set column write land on the same record.
+	"""
+	if not value:
+		return
+	set_encrypted_password(SETTINGS, SETTINGS, value, fieldname)
+	doc.db_set(fieldname, _MASK, update_modified=update_modified)
+
+
+def clear_settings_password(doc, fieldname: str) -> None:
+	"""Wipe a Jarvis Settings Password field: blank the tabSingles column AND
+	drop the __Auth row.
+
+	db_set(field, "") alone only blanks the masked placeholder in tabSingles;
+	__Auth retains the prior secret, so get_password() keeps returning it
+	after a "clear" (see jarvis/dev.py's _PASSWORD_FIELDS comment for the
+	same footgun). Both writes are needed for the field to actually read
+	as cleared afterwards.
+	"""
+	from frappe.utils.password import remove_encrypted_password
+
+	doc.db_set(fieldname, "")
+	remove_encrypted_password(SETTINGS, SETTINGS, fieldname)

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1121,9 +1121,14 @@ def rotate_agent_token() -> dict:
 	# Admin succeeded -> the container is now running against new_token.
 	# Persist it locally so the bench's future plugin-auth validations
 	# match what the container holds.
+	from jarvis._password_utils import set_settings_password
+
 	settings = frappe.get_single("Jarvis Settings")
 	now = frappe.utils.now()
-	settings.db_set("agent_token", new_token)
+	# agent_token is a Password field - db_set would write the rotated
+	# secret straight into tabSingles as plaintext; encrypt it into __Auth
+	# first (see _password_utils module docstring).
+	set_settings_password(settings, "agent_token", new_token)
 	# C2 time-bound: stamp issued_at so plugin_auth's expiry check has
 	# a reference point. Tolerate the column not existing yet on a
 	# pre-migration deploy state.

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -62,10 +62,18 @@ def _load_private_key(b64u: str) -> Ed25519PrivateKey:
 
 def _save_credentials(*, settings_doc, private_key_b64u: str, public_key_b64u: str,
 					  device_id: str, device_token: str) -> None:
+	# chat_device_private_key / chat_device_token are Password fields; db_set
+	# writes exactly what it's given straight into tabSingles with no
+	# encryption (only Document.save()'s _save_passwords path encrypts a
+	# Password field). set_settings_password encrypts into __Auth first and
+	# db_sets only a mask, so the private key + bearer token never sit in
+	# plaintext in the Single's row.
+	from jarvis._password_utils import set_settings_password
+
 	settings_doc.db_set("chat_device_id", device_id)
 	settings_doc.db_set("chat_device_public_key", public_key_b64u)
-	settings_doc.db_set("chat_device_private_key", private_key_b64u)
-	settings_doc.db_set("chat_device_token", device_token)
+	set_settings_password(settings_doc, "chat_device_private_key", private_key_b64u)
+	set_settings_password(settings_doc, "chat_device_token", device_token)
 	frappe.db.commit()
 
 
@@ -229,11 +237,21 @@ def rotate_chat_device() -> dict:
 def clear_credentials() -> None:
 	"""Wipe persisted chat-device creds. Called when openclaw rejects an
 	existing pairing (token revoked, device not paired, etc.) so the next
-	chat attempt regenerates."""
+	chat attempt regenerates.
+
+	chat_device_private_key / chat_device_token are Password fields:
+	db_set(field, "") only blanks the masked placeholder in tabSingles - the
+	__Auth row still holds the prior secret, so get_password() would keep
+	returning the just-revoked key/token after a "clear" (same footgun
+	documented on jarvis/dev.py's _PASSWORD_FIELDS). clear_settings_password
+	drops the __Auth row too so the fields actually read as cleared."""
+	from jarvis._password_utils import clear_settings_password
+
 	settings = frappe.get_single("Jarvis Settings")
-	for field in ("chat_device_id", "chat_device_public_key",
-				  "chat_device_private_key", "chat_device_token"):
-		settings.db_set(field, "")
+	settings.db_set("chat_device_id", "")
+	settings.db_set("chat_device_public_key", "")
+	clear_settings_password(settings, "chat_device_private_key")
+	clear_settings_password(settings, "chat_device_token")
 	frappe.db.commit()
 
 
@@ -257,6 +275,7 @@ def update_device_token(new_token: str, *, device_id: str) -> bool:
 	token). Lock unavailable -> skip the persist (return False): the
 	stale-pairing self-heal recovers the next connect, which beats
 	risking the interleave. Returns True when persisted."""
+	from jarvis._password_utils import set_settings_password
 	from jarvis._redis_lock import redis_lock
 
 	with redis_lock(
@@ -267,7 +286,10 @@ def update_device_token(new_token: str, *, device_id: str) -> bool:
 		settings = frappe.get_single("Jarvis Settings")
 		if (settings.chat_device_id or "").strip() != device_id:
 			return False
-		settings.db_set("chat_device_token", new_token)
+		# chat_device_token is a Password field - db_set would write the
+		# rotated bearer straight into tabSingles as plaintext; encrypt it
+		# into __Auth first (see _password_utils module docstring).
+		set_settings_password(settings, "chat_device_token", new_token)
 		frappe.db.commit()
 		return True
 

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -278,6 +278,13 @@ def update_device_token(new_token: str, *, device_id: str) -> bool:
 	from jarvis._password_utils import set_settings_password
 	from jarvis._redis_lock import redis_lock
 
+	# A falsy token is never persisted: set_settings_password no-ops on a
+	# falsy value, so proceeding would return True without writing anything
+	# - violating the "Returns True when persisted" contract above. Reject
+	# up front, before taking the repair lock.
+	if not new_token:
+		return False
+
 	with redis_lock(
 		"chat_device_pair_repair", timeout_s=30, blocking_timeout_s=5.0,
 	) as acquired:

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -80,6 +80,8 @@
   "last_sync_at",
   "last_sync_status",
   "llm_pool_synced_at",
+  "last_subscription_status",
+  "last_sync_warnings",
   "custom_skills_synced_at",
   "custom_skills_sync_status",
   "agent_skills_synced_at",
@@ -581,6 +583,22 @@
    "fieldname": "llm_pool_synced_at",
    "fieldtype": "Datetime",
    "label": "LLM Pool Synced At",
+   "read_only": 1
+  },
+  {
+   "description": "fleet-agent's subscription_status from the last pool apply: verified | unverified | unchecked | not_applicable. Empty when the fleet didn't report one (older contract) or the last sync failed. Backend-only - the SPA reads this via get_llm_sync_status, not the form.",
+   "fieldname": "last_subscription_status",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Last Subscription Status",
+   "read_only": 1
+  },
+  {
+   "description": "JSON array of {code, message} warnings from the last pool apply (e.g. a subscription that loaded but failed a probe). '[]' when none. Backend-only - the SPA reads this via get_llm_sync_status, not the form.",
+   "fieldname": "last_sync_warnings",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Last Sync Warnings",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -813,6 +813,17 @@ _POOL_SYNC_RETRIES = 3
 _POOL_SYNC_RETRY_DELAY_S = 5
 
 
+def _cleared_subscription_status_fields() -> dict:
+    """Merge into a FAILED pool-worker db_set() dict so a stale
+    subscription_status/warnings pair from a PRIOR successful apply can't
+    linger next to a `failed:` status the next poll reads. Never merged into
+    the "ok (...)" success write, nor into a skip path where the container's
+    last real apply is still the truth (the pre-enqueue redundant-sync skip,
+    or the run-time "no longer proxy-valid" skip - neither one touched the
+    container, so whatever it's currently running is unchanged)."""
+    return {"last_subscription_status": "", "last_sync_warnings": "[]"}
+
+
 def _post_pool_with_retry(spec, api_keys, oauth_blobs):
     """post_update_llm_pool, retrying only the transient AdminUnreachableError.
     Re-raises the last unreachable error after exhausting retries; other Admin*
@@ -855,6 +866,18 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
     - AdminRateLimitedError writes a terminal failure with retry hint.
     - try/finally backstop ensures the status never sticks at "pending:".
 
+    Apply-warning propagation (2026-07-10): the admin response to a
+    successful apply also carries ``subscription_status`` and ``warnings``
+    (e.g. a subscription credential that loaded but failed an upstream
+    probe). Both are persisted alongside the "ok (...)" write into
+    ``last_subscription_status`` / ``last_sync_warnings`` and are CLEARED on
+    every failed/skipped-on-retries-exhausted terminal write so a stale
+    warning from a prior successful apply never lingers next to a
+    "failed:" status. The run-time "no longer proxy-valid" skip below
+    leaves them untouched, like the pre-enqueue redundant-sync skip: the
+    container itself was never touched, so its last real apply is still
+    the truth.
+
     ``retry_left``: losing the lock race must not strand a FRESH tenant on a
     terminal "failed: skipped" (their first pool apply would never happen and
     is_ready_for_chat would gate them out of chat indefinitely). Each loss
@@ -894,9 +917,14 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 "jarvis_settings: skipping pool admin sync; "
                 "another worker held the lock past blocking timeout (retries exhausted)",
             )
+            # Terminal "failed:" write - clear any stale warnings/subscription_status
+            # from a prior successful apply alongside it (see
+            # _cleared_subscription_status_fields).
             settings.db_set(
-                "last_sync_status",
-                "failed: skipped (concurrent sync did not finish in time)",
+                {
+                    "last_sync_status": "failed: skipped (concurrent sync did not finish in time)",
+                    **_cleared_subscription_status_fields(),
+                },
                 update_modified=False,
             )
             return
@@ -934,7 +962,19 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 # be read as provisioning success - a fresh tenant whose
                 # first sync is still pending/failed has no working pool.
                 "llm_pool_synced_at": _frappe.utils.now(),
+                # subscription_status/warnings ride the SAME PUT response as
+                # action/result (contract docs: fleet-agent llm-pool). A
+                # fleet still on the pre-warnings contract (1.9) reports
+                # neither key, so this always lands "" / "[]" - never raise
+                # on their absence, and never assume result is a dict beyond
+                # what `or {}` above already guarantees.
+                "last_subscription_status": str(result.get("subscription_status") or ""),
+                "last_sync_warnings": _frappe.as_json(result.get("warnings") or []),
             })
+            # last_sync_status MUST keep starting with the literal "ok" -
+            # _pool_sync_is_redundant() gates its dedup skip on
+            # startswith("ok"); a warned-but-applied pool is still an "ok"
+            # apply and must stay skippable on an unchanged re-save.
             # Commit every terminal write - matching _sync_via_admin; see
             # the comment there. Also makes llm_pool_synced_at durable.
             _commit_terminal_sync_status()
@@ -943,6 +983,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: auth: {e}",
+                **_cleared_subscription_status_fields(),
             })
             _commit_terminal_sync_status()
             terminal_written = True
@@ -954,6 +995,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: admin unreachable: {e}",
+                **_cleared_subscription_status_fields(),
             })
             _commit_terminal_sync_status()
             terminal_written = True
@@ -967,6 +1009,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: rate-limited; {retry_str}",
+                **_cleared_subscription_status_fields(),
             })
             _commit_terminal_sync_status()
             terminal_written = True
@@ -977,6 +1020,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
             settings.db_set({
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"failed: validation: {e}",
+                **_cleared_subscription_status_fields(),
             })
             _commit_terminal_sync_status()
             terminal_written = True
@@ -997,6 +1041,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                     settings.db_set({
                         "last_sync_at": _frappe.utils.now(),
                         "last_sync_status": "failed: unexpected error; see Error Log",
+                        **_cleared_subscription_status_fields(),
                     })
                     _commit_terminal_sync_status()
                 except Exception:

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -175,6 +175,17 @@ class JarvisSettings(Document):
         # Plain Select field - direct change comparison via has_value_changed.
         self.flags.llm_auth_mode_changed = bool(self.has_value_changed("llm_auth_mode"))
 
+        # Pool change-detection snapshot (see _pool_state_snapshot). Captured
+        # HERE - before _validate()'s _save_passwords masks freshly-typed child
+        # row secrets to '*'*len(value) - because a new api_key of the SAME
+        # LENGTH as the old one would otherwise mask to an identical string by
+        # on_update time, and a real key rotation would compare as "unchanged"
+        # (the pool sync would be skipped and the container would keep serving
+        # the revoked key). At validate() time a freshly-typed key is still
+        # plaintext, which never equals the stored mask, so any newly-supplied
+        # secret reliably reads as a change.
+        self.flags.pool_state_snapshot = self._pool_state_snapshot(self)
+
         self._validate_auth_mode_requirements()
         self._validate_pattern_window()
 
@@ -372,7 +383,24 @@ class JarvisSettings(Document):
             # Jarvis Settings at run time so no snapshot is needed here.
             # validate_models() already ran above (Step 1) so we know the
             # current config is clean before enqueuing.
-            self._enqueue_pool_sync()
+            #
+            # Diff gate (pool analog of _classify_llm_change): every save of
+            # this Single lands here when proxy_active - including saves that
+            # touch nothing pool-related (sandbox toggles, pattern-learning
+            # windows, chat-device writes through save()) - and each one
+            # re-POSTed the FULL pool spec + secrets to admin. Skip the
+            # enqueue only when all three hold: a before-doc exists, the
+            # pool-relevant snapshot is identical, and the last sync ended
+            # "ok" (a failed sync must stay retryable by re-saving). When
+            # skipping, last_sync_status is left untouched (no "pending:"
+            # write - nothing was enqueued to complete it).
+            if self._pool_sync_is_redundant():
+                frappe.logger().debug(
+                    "jarvis_settings: skipping pool sync enqueue; "
+                    "pool state unchanged and last sync ok"
+                )
+            else:
+                self._enqueue_pool_sync()
         else:
             # Single-model path (1 model, no preset): reset any stale proxy
             # flags so UI/workers don't think the tenant is still in pool mode.
@@ -389,6 +417,89 @@ class JarvisSettings(Document):
             # The legacy fields are now mirrored, so _classify_llm_change
             # will correctly see any structural change.
             self._on_update_single_model_legacy()
+
+    @staticmethod
+    def _pool_state_snapshot(doc) -> tuple:
+        """Comparable snapshot of the pool-RELEVANT state of a settings doc.
+
+        Covers exactly the inputs that feed the admin pool push:
+        ``preset`` + ``routing_mode`` (read by compute_proxy_active /
+        build_pool_payload) and, per models[] child row, every field
+        build_pool_payload serializes: provider, model, base_url, tier,
+        order, credential_type, enabled, rotation, plus the two row
+        secrets - api_key and subscription_accounts (the JSON string
+        holding account_ref/upstream/label/oauth_blob per account).
+        Timestamps/metadata (modified, name, idx) are deliberately
+        excluded so a no-op re-save compares equal.
+
+        Secrets are compared BY VALUE AS STORED on the row - an untouched
+        DB-loaded row carries the '*'-mask, so mask == mask reads as
+        unchanged, while a freshly-typed plaintext secret differs from any
+        mask and reads as changed (see the validate() comment for why the
+        current doc's snapshot must be captured pre-masking). They are
+        sha256-digested into the snapshot rather than embedded raw so a
+        stray log/repr of doc.flags can never leak a live credential.
+        """
+        import hashlib
+
+        def _get(row, field):
+            if hasattr(row, "get"):
+                return row.get(field)
+            return getattr(row, field, None)
+
+        def _digest(value) -> str:
+            value = value or ""
+            if not value:
+                return ""
+            return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+        rows = []
+        for m in (doc.get("models") or []):
+            rows.append((
+                (_get(m, "provider") or ""),
+                (_get(m, "model") or ""),
+                (_get(m, "base_url") or ""),
+                (_get(m, "tier") or "strong"),
+                int(_get(m, "order") or 0),
+                (_get(m, "credential_type") or "api_key"),
+                1 if _get(m, "enabled") else 0,
+                (_get(m, "rotation") or ""),
+                _digest(_get(m, "api_key")),
+                _digest(_get(m, "subscription_accounts")),
+            ))
+        return (
+            (doc.get("preset") or ""),
+            (doc.get("routing_mode") or ""),
+            tuple(rows),
+        )
+
+    def _pool_sync_is_redundant(self) -> bool:
+        """True iff this save changes nothing the pool push would transmit
+        AND the container is already in a known-good state.
+
+        Skip conditions (ALL must hold; anything unknown falls through to
+        "not redundant" so the sync always errs toward firing):
+        - no caller-forced sync (flags.force_admin_sync - the same
+          save_llm_creds(force=True) override the legacy diff gate honors),
+        - a doc_before_save exists (first-ever save always syncs),
+        - validate() captured a snapshot for the current doc (a save path
+          that skipped validate - flags.ignore_validate - always syncs),
+        - the snapshots compare equal,
+        - last_sync_status starts with "ok": a prior failed/pending/skipped
+          sync means the container may not hold the current pool, so an
+          unchanged re-save is the operator's retry lever and must enqueue.
+        """
+        if self.flags.get("force_admin_sync"):
+            return False
+        before = self.get_doc_before_save()
+        if before is None:
+            return False
+        current = self.flags.get("pool_state_snapshot")
+        if current is None:
+            return False
+        if current != self._pool_state_snapshot(before):
+            return False
+        return (self.get("last_sync_status") or "").startswith("ok")
 
     def _enqueue_pool_sync(self) -> None:
         """Enqueue the pool-sync admin call for the proxy path.

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -952,7 +952,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
         try:
             result = _post_pool_with_retry(spec, api_keys, oauth_blobs) or {}
             resolved_action = result.get("action", "pool_update")
-            settings.db_set({
+            _synced = {
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
                 # Durable "this pool has been APPLIED to the container at
@@ -962,15 +962,32 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 # be read as provisioning success - a fresh tenant whose
                 # first sync is still pending/failed has no working pool.
                 "llm_pool_synced_at": _frappe.utils.now(),
-                # subscription_status/warnings ride the SAME PUT response as
-                # action/result (contract docs: fleet-agent llm-pool). A
-                # fleet still on the pre-warnings contract (1.9) reports
-                # neither key, so this always lands "" / "[]" - never raise
-                # on their absence, and never assume result is a dict beyond
-                # what `or {}` above already guarantees.
-                "last_subscription_status": str(result.get("subscription_status") or ""),
-                "last_sync_warnings": _frappe.as_json(result.get("warnings") or []),
-            })
+            }
+            # A NO-OP apply (contract 1.10's ``unchanged: true``) changed nothing and,
+            # BY DESIGN, ran no probe: a 1-token completion is a side effect and that
+            # path is side-effect-free, so the fleet reports subscription_status
+            # "unchecked" and warnings [].
+            #
+            # Persisting those would DISCARD the verdict from the last real apply.
+            # A healthy "verified" silently decays to "unchecked" (which reads as a
+            # regression the customer did not cause) and -- far worse -- a genuine
+            # ``model_unreachable`` / ``subscription_unverified`` warning gets CLEARED,
+            # so a dead model looks healthy again after any redundant re-save.
+            #
+            # Nothing about the running pool changed, so the previous verdict still
+            # describes it exactly. Leave both fields alone. (Same reasoning as the
+            # two skip paths above, which also leave them untouched: the container was
+            # never touched, so its last real apply is still the truth.)
+            #
+            # subscription_status/warnings ride the SAME PUT response as action/result
+            # (contract docs: fleet-agent llm-pool). A fleet still on the pre-warnings
+            # contract (1.9) reports neither key, so this lands "" / "[]" - never raise
+            # on their absence, and never assume result is a dict beyond what the
+            # `or {}` above already guarantees.
+            if not result.get("unchanged"):
+                _synced["last_subscription_status"] = str(result.get("subscription_status") or "")
+                _synced["last_sync_warnings"] = _frappe.as_json(result.get("warnings") or [])
+            settings.db_set(_synced)
             # last_sync_status MUST keep starting with the literal "ok" -
             # _pool_sync_is_redundant() gates its dedup skip on
             # startswith("ok"); a warned-but-applied pool is still an "ok"

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -578,15 +578,31 @@ def get_llm_sync_status() -> dict:
 	Returns:
 	    A dict with ``last_sync_at`` (ISO string or ""), ``last_sync_status``
 	    (e.g. ``pending: provisioning container``, ``ok (restart via admin)``,
-	    ``failed: admin unreachable: ...``), and a convenience boolean
-	    ``pending`` for client-side branching.
+	    ``failed: admin unreachable: ...``), a convenience boolean
+	    ``pending`` for client-side branching, ``subscription_status`` (one
+	    of ``verified``/``unverified``/``unchecked``/``not_applicable``, or
+	    ``""`` if the pool sync worker never wrote one - e.g. no pool sync
+	    has run yet, or the fleet is on a pre-warnings contract), and
+	    ``warnings`` - a list of ``{"code": str, "message": str}`` dicts
+	    from the last pool apply (empty list when none). A corrupt/empty
+	    stored ``last_sync_warnings`` value degrades to ``[]`` rather than
+	    ever 500ing this poller.
 	"""
 	s = frappe.get_single("Jarvis Settings")
 	status = s.get("last_sync_status") or ""
+	raw_warnings = s.get("last_sync_warnings") or "[]"
+	try:
+		warnings = json.loads(raw_warnings)
+		if not isinstance(warnings, list):
+			warnings = []
+	except (ValueError, TypeError):
+		warnings = []
 	return {
 		"last_sync_at": str(s.get("last_sync_at") or ""),
 		"last_sync_status": status,
 		"pending": status.startswith("pending:"),
+		"subscription_status": s.get("last_subscription_status") or "",
+		"warnings": warnings,
 	}
 
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -102,14 +102,25 @@ def _surface(fn, *args, **kwargs):
 
 def write_connection(data: dict) -> None:
 	"""Persist native admin credentials + container connection into Jarvis
-	Settings via db_set (no on_update creds-push retrigger during onboarding)."""
+	Settings via db_set (no on_update creds-push retrigger during onboarding).
+
+	The four Password fields (jarvis_admin_api_key/_secret,
+	jarvis_admin_customer_password, agent_token) go through
+	set_settings_password instead of a bare db_set: db_set writes exactly what
+	it's given straight into tabSingles with no encryption (only
+	Document.save()'s _save_passwords path encrypts a Password field), so a
+	bare db_set of a real secret sat there in plaintext. set_settings_password
+	encrypts into __Auth first, then db_sets only the mask - preserving the
+	"no on_update retrigger" property this function exists for."""
 	if not isinstance(data, dict):
 		return
+	from jarvis._password_utils import set_settings_password
+
 	s = frappe.get_single("Jarvis Settings")
 	if data.get("api_key"):
-		s.db_set("jarvis_admin_api_key", data["api_key"])
+		set_settings_password(s, "jarvis_admin_api_key", data["api_key"])
 	if data.get("api_secret"):
-		s.db_set("jarvis_admin_api_secret", data["api_secret"])
+		set_settings_password(s, "jarvis_admin_api_secret", data["api_secret"])
 	# OAuth password-grant credentials. ``customer`` is the admin-side login
 	# (email, the grant username); ``customer_password`` is the durable secret
 	# the bench exchanges for short-lived bearer tokens. The email arrives in
@@ -118,11 +129,11 @@ def write_connection(data: dict) -> None:
 	if data.get("customer"):
 		s.db_set("jarvis_admin_customer_email", data["customer"])
 	if data.get("customer_password"):
-		s.db_set("jarvis_admin_customer_password", data["customer_password"])
+		set_settings_password(s, "jarvis_admin_customer_password", data["customer_password"])
 	if data.get("agent_url"):
 		s.db_set("agent_url", data["agent_url"])
 	if data.get("agent_token"):
-		s.db_set("agent_token", data["agent_token"])
+		set_settings_password(s, "agent_token", data["agent_token"])
 
 
 @frappe.whitelist()

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -21,3 +21,4 @@ jarvis.patches.v1_0.grant_jarvis_user_role
 jarvis.patches.v1_11_greeting_cadence
 jarvis.patches.v1_0.revoke_jarvis_user_from_website_users
 jarvis.patches.v1_12_skill_scope_ladder
+jarvis.patches.v1_13_encrypt_plaintext_settings_passwords

--- a/jarvis/patches/v1_13_encrypt_plaintext_settings_passwords.py
+++ b/jarvis/patches/v1_13_encrypt_plaintext_settings_passwords.py
@@ -42,6 +42,8 @@ masked-with-__Auth, both of which the branches above leave unchanged.
 import frappe
 from frappe.utils.password import remove_encrypted_password, set_encrypted_password
 
+from jarvis._password_utils import _MASK
+
 SETTINGS = "Jarvis Settings"
 
 # Every Password-fieldtype field on Jarvis Settings (jarvis_settings.json).
@@ -72,5 +74,5 @@ def execute():
 		if _is_dummy_password(raw):
 			continue
 		set_encrypted_password(SETTINGS, SETTINGS, raw, field)
-		frappe.db.set_single_value(SETTINGS, field, "*" * 10, update_modified=False)
+		frappe.db.set_single_value(SETTINGS, field, _MASK, update_modified=False)
 	frappe.db.commit()

--- a/jarvis/patches/v1_13_encrypt_plaintext_settings_passwords.py
+++ b/jarvis/patches/v1_13_encrypt_plaintext_settings_passwords.py
@@ -1,0 +1,76 @@
+"""Encrypt plaintext-written Password fields on Jarvis Settings.
+
+Several call sites (jarvis/onboarding.py::write_connection,
+jarvis/chat/device.py::_save_credentials/update_device_token,
+jarvis/api.py::rotate_agent_token, jarvis/selfhost.py::save_self_hosted)
+wrote Password field values via doc.db_set(...), which stores exactly what
+it's given straight into the Single's row in tabSingles - no encryption.
+Only Document.save()'s _save_passwords path (or a direct
+set_encrypted_password call) puts a Password field's real value into the
+__Auth table. So any of the seven Password fields on Jarvis Settings that
+was ever written through one of those call sites has sat in tabSingles in
+PLAINTEXT, readable by a bare SELECT despite every reader going through
+get_password() and expecting encryption-at-rest.
+
+This is a one-time cleanup for state written BEFORE the app-code fix landed
+(same commit as this patch). For each Password field, read the RAW
+tabSingles value - frappe.db.get_single_value does a plain SELECT against
+Singles with no decryption, so it returns exactly what's stored, plaintext
+or mask alike (frappe.db.get_value("Jarvis Settings", "Jarvis Settings",
+field) resolves to the same Singles read for a Single doctype; either works,
+get_single_value is used here as the more direct/documented API). Then
+three branches:
+
+- EMPTY column -> purge any __Auth row. The pre-fix clear paths
+  (chat/device.clear_credentials, selfhost's blank-token db_set("")) blanked
+  the column WITHOUT remove_encrypted_password, and fields also saved via a
+  full .save() at some point in history have __Auth rows - so a REVOKED
+  secret can survive behind the empty column, and BaseDocument.get_password
+  falls through to __Auth whenever the column is falsy, resurrecting it.
+  Harmless no-op for never-set fields.
+- MASKED (all-asterisk) column -> leave untouched. It is already in the
+  correct post-fix representation; re-encrypting the mask over the stored
+  secret would destroy the credential.
+- PLAINTEXT column -> move the value into __Auth via set_encrypted_password
+  and overwrite the column with a mask - exactly what
+  Document._save_passwords does on a normal save().
+
+Idempotent: after one run every field is empty-and-no-__Auth or
+masked-with-__Auth, both of which the branches above leave unchanged.
+"""
+
+import frappe
+from frappe.utils.password import remove_encrypted_password, set_encrypted_password
+
+SETTINGS = "Jarvis Settings"
+
+# Every Password-fieldtype field on Jarvis Settings (jarvis_settings.json).
+_PASSWORD_FIELDS = (
+	"llm_api_key",
+	"jarvis_admin_api_key",
+	"jarvis_admin_api_secret",
+	"jarvis_admin_customer_password",
+	"agent_token",
+	"chat_device_private_key",
+	"chat_device_token",
+)
+
+# Matches BaseDocument.is_dummy_password: non-empty and every char is '*'.
+def _is_dummy_password(value: str) -> bool:
+	return bool(value) and set(value) == {"*"}
+
+
+def execute():
+	for field in _PASSWORD_FIELDS:
+		raw = frappe.db.get_single_value(SETTINGS, field, cache=False)
+		if not raw:
+			# Cleared/never-set column: drop any stale __Auth row hiding
+			# behind it so get_password can't resurrect a revoked secret
+			# (see module docstring, branch 1).
+			remove_encrypted_password(SETTINGS, SETTINGS, field)
+			continue
+		if _is_dummy_password(raw):
+			continue
+		set_encrypted_password(SETTINGS, SETTINGS, raw, field)
+		frappe.db.set_single_value(SETTINGS, field, "*" * 10, update_modified=False)
+	frappe.db.commit()

--- a/jarvis/selfhost.py
+++ b/jarvis/selfhost.py
@@ -28,6 +28,8 @@ import frappe
 import requests
 from frappe.utils import now_datetime
 
+from jarvis._password_utils import set_settings_password
+
 # Timeouts (seconds). Reachability is snappy; the deep chat ping tolerates a
 # slow reasoning model.
 _REACHABLE_TIMEOUT = 8
@@ -326,7 +328,20 @@ def save_self_hosted(base_url: str, token: str, deep: int | str = 0,
     s = frappe.get_single("Jarvis Settings")
     s.db_set("deployment_mode", "Self-Hosted")
     s.db_set("agent_url", base)
-    s.db_set("agent_token", (token or "").strip())
+    # agent_token is a Password field - db_set would write the customer's
+    # openclaw bearer token straight into tabSingles as plaintext; encrypt it
+    # into __Auth first (see _password_utils module docstring). This site was
+    # missed by the original plaintext-write audit (jarvis/onboarding.py,
+    # jarvis/chat/device.py, jarvis/api.py) - self-hosted benches wrote a
+    # customer-supplied token in the clear. A BLANK token (no-auth openclaw
+    # that validated clean) clears the field + its __Auth row, matching the
+    # old db_set("") semantics - a stale bearer must not linger.
+    cleaned_token = (token or "").strip()
+    if cleaned_token:
+        set_settings_password(s, "agent_token", cleaned_token)
+    else:
+        from jarvis._password_utils import clear_settings_password
+        clear_settings_password(s, "agent_token")
     s.db_set("selfhost_stream", 1 if str(stream) in ("1", "true", "True") else 0)
     s.db_set("selfhost_last_validated_at", now_datetime())
     s.db_set("selfhost_last_validation", json.dumps(result))

--- a/jarvis/selfhost.py
+++ b/jarvis/selfhost.py
@@ -28,7 +28,7 @@ import frappe
 import requests
 from frappe.utils import now_datetime
 
-from jarvis._password_utils import set_settings_password
+from jarvis._password_utils import clear_settings_password, set_settings_password
 
 # Timeouts (seconds). Reachability is snappy; the deep chat ping tolerates a
 # slow reasoning model.
@@ -340,7 +340,6 @@ def save_self_hosted(base_url: str, token: str, deep: int | str = 0,
     if cleaned_token:
         set_settings_password(s, "agent_token", cleaned_token)
     else:
-        from jarvis._password_utils import clear_settings_password
         clear_settings_password(s, "agent_token")
     s.db_set("selfhost_stream", 1 if str(stream) in ("1", "true", "True") else 0)
     s.db_set("selfhost_last_validated_at", now_datetime())

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -497,6 +497,11 @@ class TestRotateAgentTokenEndpoint(FrappeTestCase):
 
 	@classmethod
 	def tearDownClass(cls):
+		# A successful rotation stores the token in __Auth (masked column);
+		# drop that row so a stale rotated token can't shadow the restored
+		# value via get_password's __Auth fallback in later suites.
+		from frappe.utils.password import remove_encrypted_password
+		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "agent_token")
 		settings = frappe.get_single("Jarvis Settings")
 		settings.db_set("agent_token", cls._original_token)
 		frappe.db.commit()
@@ -505,7 +510,9 @@ class TestRotateAgentTokenEndpoint(FrappeTestCase):
 	def setUp(self):
 		# rotate_agent_token requires System Manager; tests run as Admin.
 		frappe.set_user("Administrator")
-		# Reset to a known starting token.
+		# Reset to a known starting token (column write shadows any __Auth
+		# row a prior test's rotation left - get_password short-circuits on
+		# a non-masked column value).
 		settings = frappe.get_single("Jarvis Settings")
 		settings.db_set("agent_token", "before-rotation-token")
 		frappe.db.commit()

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -62,10 +62,18 @@ class _SettingsSnapshotMixin:
 
 
 def _clear_settings():
-	"""Wipe chat_device_* between tests so each one starts unpaired."""
+	"""Wipe chat_device_* between tests so each one starts unpaired.
+
+	The Password fields need their __Auth rows dropped too: the production
+	write path stores the secret in __Auth (masked column), so a column-only
+	db_set("") would let get_password resurrect a previous test's secret."""
+	from frappe.utils.password import remove_encrypted_password
+
 	s = frappe.get_single("Jarvis Settings")
 	for f in (*_SNAPSHOT_PLAIN_FIELDS, *_SNAPSHOT_PASSWORD_FIELDS):
 		s.db_set(f, "")
+	for f in _SNAPSHOT_PASSWORD_FIELDS:
+		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", f)
 	frappe.db.commit()
 
 

--- a/jarvis/tests/test_chat_device.py
+++ b/jarvis/tests/test_chat_device.py
@@ -340,6 +340,28 @@ class TestUpdateDeviceToken(_SettingsSnapshotMixin, FrappeTestCase):
 			"tok-fresh",
 		)
 
+	def test_falsy_token_returns_false_without_persist(self):
+		"""A falsy reissued token must return False and never touch
+		Settings: set_settings_password no-ops on falsy values, so
+		proceeding would have claimed True while persisting nothing -
+		violating the 'Returns True when persisted' contract."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("chat_device_id", "dev-1")
+		s.db_set("chat_device_token", "tok-old")
+		frappe.db.commit()
+
+		with patch("jarvis._password_utils.set_settings_password") as mock_set:
+			self.assertFalse(
+				chat_device.update_device_token("", device_id="dev-1"),
+			)
+		mock_set.assert_not_called()
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			s.get_password("chat_device_token", raise_exception=False),
+			"tok-old",
+			"stored token must be untouched by a falsy reissue",
+		)
+
 
 class TestSigning(FrappeTestCase):
 	def test_build_payload_v3_format(self):

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -470,3 +470,57 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 		self.assertIn("last_sync_at", out)
 		self.assertIn("last_sync_status", out)
 		self.assertIn("pending", out)
+		self.assertIn("subscription_status", out)
+		self.assertIn("warnings", out)
+
+	# -- Apply-warning propagation (subscription_status + warnings) -------
+
+	def test_returns_parsed_warnings_and_subscription_status(self):
+		"""The pool sync worker stores warnings as a JSON array string;
+		get_llm_sync_status must hand back a parsed list of dicts, plus
+		the raw subscription_status string, to the SPA poller."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_subscription_status", "unverified", update_modified=False)
+		s.db_set(
+			"last_sync_warnings",
+			'[{"code": "subscription_unverified", "message": "probe failed"}]',
+			update_modified=False,
+		)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(out["subscription_status"], "unverified")
+		self.assertEqual(
+			out["warnings"],
+			[{"code": "subscription_unverified", "message": "probe failed"}],
+		)
+
+	def test_empty_warnings_and_subscription_status_default_cleanly(self):
+		"""No pool sync has run yet (or the fleet is on a pre-warnings
+		contract) - both fields are empty and must degrade to "" / []
+		rather than raise."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_subscription_status", "", update_modified=False)
+		s.db_set("last_sync_warnings", "", update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(out["subscription_status"], "")
+		self.assertEqual(out["warnings"], [])
+
+	def test_corrupt_warnings_json_degrades_to_empty_list(self):
+		"""A malformed last_sync_warnings value must never 500 this poller -
+		it must degrade to an empty list."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_warnings", "{not valid json", update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(out["warnings"], [])
+
+	def test_non_list_warnings_json_degrades_to_empty_list(self):
+		"""Valid JSON that isn't a list (e.g. a stray object) must also
+		degrade to [] - the SPA always expects a list of {code, message}."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_warnings", '{"code": "x", "message": "y"}',
+		         update_modified=False)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(out["warnings"], [])

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -10,11 +10,21 @@ from jarvis import onboarding
 
 def _set_token(value, secret="secret"):
 	"""Set both native credentials for tests that exercise the authenticated
-	admin path. value="" clears them (simulates 'not onboarded')."""
+	admin path. value="" clears them (simulates 'not onboarded').
+
+	Clearing must also drop the __Auth rows: the production write path
+	(write_connection -> set_settings_password) stores the secret in __Auth
+	with a masked column, so a column-only db_set("") would let get_password
+	fall back to a previous test's __Auth value."""
+	from frappe.utils.password import remove_encrypted_password
+
 	s = frappe.get_single("Jarvis Settings")
 	s.db_set("jarvis_admin_api_key", value)
 	s.db_set("jarvis_admin_api_secret", secret if value else "")
 	s.db_set("agent_url", "")
+	if not value:
+		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_key")
+		remove_encrypted_password("Jarvis Settings", "Jarvis Settings", "jarvis_admin_api_secret")
 	frappe.db.commit()
 
 
@@ -40,7 +50,17 @@ def _snapshot_settings() -> dict:
 
 
 def _restore_settings(snap: dict) -> None:
+	"""Restore the snapshot. Password fields also get their __Auth row
+	dropped: the production write path stores secrets there (masked column),
+	and restoring only the column would leave a test's secret readable via
+	get_password's __Auth fallback in the NEXT test. The snapshot value
+	itself is written to the column (get_password short-circuits on a
+	non-masked column value), matching this helper's original semantics."""
+	from frappe.utils.password import remove_encrypted_password
+
 	for f, v in snap.items():
+		if f.endswith(("_key", "_secret", "_token", "_password")):
+			remove_encrypted_password("Jarvis Settings", "Jarvis Settings", f)
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", f, v)
 	frappe.db.commit()
 

--- a/jarvis/tests/test_password_write_encryption.py
+++ b/jarvis/tests/test_password_write_encryption.py
@@ -1,0 +1,367 @@
+"""Password fields on Jarvis Settings must never land in tabSingles as plaintext.
+
+Frappe only encrypts a Password field (into __Auth) when the value passes
+through Document._save_passwords() - i.e. a real doc.save(). Several flows
+here deliberately write via db_set to avoid re-triggering on_update's admin
+sync (onboarding.write_connection, chat/device.py, api.rotate_agent_token,
+selfhost.save_self_hosted); before the fix each of those wrote the raw
+secret straight into the Single's row in tabSingles.
+
+These tests pin the fixed behavior of jarvis._password_utils and every
+call site:
+- the RAW tabSingles column (read via direct SQL, no ORM decryption) holds
+  only an all-asterisk mask, never the secret;
+- get_password() still returns the real secret (readers are unchanged);
+- clear paths (chat clear_credentials) also drop the __Auth row so a
+  revoked secret cannot be resurrected by get_password;
+- the v1_11 migration patch moves an already-plaintext column value into
+  __Auth, masks the column, and is idempotent (a second run must NOT
+  encrypt the mask over the real secret).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+SETTINGS = "Jarvis Settings"
+
+_ALL_PASSWORD_FIELDS = (
+	"llm_api_key",
+	"jarvis_admin_api_key",
+	"jarvis_admin_api_secret",
+	"jarvis_admin_customer_password",
+	"agent_token",
+	"chat_device_private_key",
+	"chat_device_token",
+)
+
+# Plain (non-Password) fields the exercised flows also write.
+_PLAIN_FIELDS = (
+	"jarvis_admin_customer_email",
+	"agent_url",
+	"agent_token_issued_at",
+	"chat_device_id",
+	"chat_device_public_key",
+	"deployment_mode",
+	"selfhost_stream",
+	"selfhost_last_validated_at",
+	"selfhost_last_validation",
+	"selfhost_tool_user",
+)
+
+
+def _raw_singles_value(field: str) -> str | None:
+	"""The value exactly as stored in tabSingles - no decryption, no cache."""
+	rows = frappe.db.sql(
+		"select `value` from `tabSingles` where doctype=%s and field=%s",
+		(SETTINGS, field),
+	)
+	return rows[0][0] if rows else None
+
+
+def _auth_row(field: str):
+	"""The raw __Auth row for a Jarvis Settings password field (or None)."""
+	rows = frappe.db.sql(
+		"select `password`, `encrypted` from `__Auth` "
+		"where doctype=%s and name=%s and fieldname=%s",
+		(SETTINGS, SETTINGS, field),
+	)
+	return rows[0] if rows else None
+
+
+def _is_masked(value: str | None) -> bool:
+	return bool(value) and set(value) == {"*"}
+
+
+class _SecretsSnapshotTestCase(FrappeTestCase):
+	"""Snapshot/restore the raw tabSingles column AND the raw __Auth row for
+	every Password field (plus the plain fields these flows touch), so the
+	suite leaves the singleton exactly as found - byte-for-byte, whichever
+	representation (plaintext-legacy or encrypted) the site had."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		cls._raw_snapshot = {f: _raw_singles_value(f) for f in _ALL_PASSWORD_FIELDS}
+		cls._auth_snapshot = {f: _auth_row(f) for f in _ALL_PASSWORD_FIELDS}
+		s = frappe.get_single(SETTINGS)
+		cls._plain_snapshot = {f: s.get(f) for f in _PLAIN_FIELDS}
+
+	@classmethod
+	def tearDownClass(cls):
+		try:
+			for field, raw in cls._raw_snapshot.items():
+				frappe.db.set_single_value(SETTINGS, field, raw or "",
+				                           update_modified=False)
+			for field, row in cls._auth_snapshot.items():
+				frappe.db.sql(
+					"delete from `__Auth` where doctype=%s and name=%s and fieldname=%s",
+					(SETTINGS, SETTINGS, field),
+				)
+				if row:
+					frappe.db.sql(
+						"insert into `__Auth` (doctype, name, fieldname, `password`, encrypted) "
+						"values (%s, %s, %s, %s, %s)",
+						(SETTINGS, SETTINGS, field, row[0], row[1]),
+					)
+			for field, value in cls._plain_snapshot.items():
+				frappe.db.set_single_value(SETTINGS, field, value if value is not None else "",
+				                           update_modified=False)
+			frappe.db.commit()
+		finally:
+			super().tearDownClass()
+
+	def setUp(self):
+		super().setUp()
+		# Each test starts with every password field fully absent (no column
+		# value, no __Auth row) so cross-test residue can't mask a regression.
+		from frappe.utils.password import remove_encrypted_password
+		for field in _ALL_PASSWORD_FIELDS:
+			frappe.db.set_single_value(SETTINGS, field, "", update_modified=False)
+			remove_encrypted_password(SETTINGS, SETTINGS, field)
+		frappe.db.commit()
+
+	def assert_encrypted_at_rest(self, field: str, secret: str):
+		"""The core Fix-1 invariant: raw column masked, get_password intact."""
+		raw = _raw_singles_value(field)
+		self.assertNotEqual(raw, secret,
+		                    f"{field}: raw tabSingles column must NOT hold the plaintext secret")
+		self.assertTrue(_is_masked(raw),
+		                f"{field}: raw tabSingles column must be an all-asterisk mask, got {raw!r}")
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.get_password(field, raise_exception=False), secret,
+		                 f"{field}: get_password must still return the secret")
+		auth = _auth_row(field)
+		self.assertTrue(auth and auth[1] == 1,
+		                f"{field}: __Auth must hold an encrypted=1 row")
+		self.assertNotEqual(auth[0], secret,
+		                    f"{field}: __Auth.password must be the ENCRYPTED form, not plaintext")
+
+
+class TestOnboardingWriteConnection(_SecretsSnapshotTestCase):
+	def test_write_connection_encrypts_all_password_fields(self):
+		from jarvis import onboarding
+
+		onboarding.write_connection({
+			"api_key": "native-key-abc123",
+			"api_secret": "native-secret-def456",
+			"customer": "cust@example.com",
+			"customer_password": "grant-pass-xyz789",
+			"agent_url": "http://127.0.0.1:19000",
+			"agent_token": "agent-tok-0011223344",
+		})
+
+		self.assert_encrypted_at_rest("jarvis_admin_api_key", "native-key-abc123")
+		self.assert_encrypted_at_rest("jarvis_admin_api_secret", "native-secret-def456")
+		self.assert_encrypted_at_rest("jarvis_admin_customer_password", "grant-pass-xyz789")
+		self.assert_encrypted_at_rest("agent_token", "agent-tok-0011223344")
+		# Plain fields still written verbatim.
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.jarvis_admin_customer_email, "cust@example.com")
+		self.assertEqual(s.agent_url, "http://127.0.0.1:19000")
+
+	def test_write_connection_skips_absent_fields(self):
+		"""Partial payloads (email-only signup response) must not touch the
+		other credentials."""
+		from jarvis import onboarding
+
+		onboarding.write_connection({"customer": "only-email@example.com"})
+		for field in ("jarvis_admin_api_key", "jarvis_admin_api_secret",
+		              "jarvis_admin_customer_password", "agent_token"):
+			self.assertFalse(_raw_singles_value(field),
+			                 f"{field}: must stay empty on a partial payload")
+			self.assertIsNone(_auth_row(field))
+
+
+class TestChatDeviceCredentialWrites(_SecretsSnapshotTestCase):
+	def test_save_credentials_encrypts_private_key_and_token(self):
+		from jarvis.chat import device as chat_device
+
+		s = frappe.get_single(SETTINGS)
+		chat_device._save_credentials(
+			settings_doc=s,
+			private_key_b64u="priv-key-material-b64u",
+			public_key_b64u="pub-key-b64u",
+			device_id="device-id-hex",
+			device_token="device-bearer-tok-1",
+		)
+
+		self.assert_encrypted_at_rest("chat_device_private_key", "priv-key-material-b64u")
+		self.assert_encrypted_at_rest("chat_device_token", "device-bearer-tok-1")
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.chat_device_id, "device-id-hex")
+		self.assertEqual(s.chat_device_public_key, "pub-key-b64u")
+
+	def test_clear_credentials_removes_auth_rows(self):
+		"""db_set('') alone leaves __Auth intact and get_password keeps
+		returning the revoked secret - the clear must drop the __Auth rows."""
+		from jarvis.chat import device as chat_device
+
+		s = frappe.get_single(SETTINGS)
+		chat_device._save_credentials(
+			settings_doc=s,
+			private_key_b64u="priv-to-revoke",
+			public_key_b64u="pub",
+			device_id="dev-revoked",
+			device_token="tok-to-revoke",
+		)
+		# Pre-condition: secrets are retrievable.
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.get_password("chat_device_token", raise_exception=False),
+		                 "tok-to-revoke")
+
+		chat_device.clear_credentials()
+
+		s = frappe.get_single(SETTINGS)
+		self.assertFalse(s.get_password("chat_device_private_key", raise_exception=False),
+		                 "revoked private key must NOT be readable after clear_credentials")
+		self.assertFalse(s.get_password("chat_device_token", raise_exception=False),
+		                 "revoked device token must NOT be readable after clear_credentials")
+		self.assertIsNone(_auth_row("chat_device_private_key"),
+		                  "__Auth row for chat_device_private_key must be removed")
+		self.assertIsNone(_auth_row("chat_device_token"),
+		                  "__Auth row for chat_device_token must be removed")
+		self.assertFalse(s.chat_device_id)
+		self.assertFalse(s.chat_device_public_key)
+
+	def test_update_device_token_encrypts_rotated_token(self):
+		from jarvis.chat import device as chat_device
+
+		s = frappe.get_single(SETTINGS)
+		chat_device._save_credentials(
+			settings_doc=s,
+			private_key_b64u="priv-x",
+			public_key_b64u="pub-x",
+			device_id="dev-current",
+			device_token="tok-original",
+		)
+
+		self.assertTrue(
+			chat_device.update_device_token("tok-rotated-by-gateway", device_id="dev-current"))
+		self.assert_encrypted_at_rest("chat_device_token", "tok-rotated-by-gateway")
+
+
+class TestRotateAgentToken(_SecretsSnapshotTestCase):
+	def test_rotate_agent_token_encrypts_new_token(self):
+		from jarvis import api as jarvis_api
+
+		with patch("jarvis.admin_client.post_rotate_agent_token", return_value={}):
+			out = jarvis_api.rotate_agent_token()
+
+		self.assertTrue(out["ok"], f"rotation must succeed, got: {out}")
+		s = frappe.get_single(SETTINGS)
+		new_token = s.get_password("agent_token", raise_exception=False) or ""
+		self.assertEqual(len(new_token), 64, "rotated token must be 64 hex chars")
+		self.assertFalse(_is_masked(new_token))
+		self.assert_encrypted_at_rest("agent_token", new_token)
+
+
+class TestSaveSelfHostedToken(_SecretsSnapshotTestCase):
+	def test_save_self_hosted_encrypts_agent_token(self):
+		"""The audit-missed site: a self-hosted bench persisted the
+		customer-supplied openclaw bearer token via bare db_set."""
+		from jarvis import selfhost
+
+		ok_result = {"ok": True, "checks": [], "openclaw_version": None, "models": ["m1"]}
+		with patch("jarvis.selfhost.validate_connection", return_value=ok_result):
+			out = selfhost.save_self_hosted(
+				base_url="http://127.0.0.1:18789", token="selfhost-bearer-tok-42")
+
+		self.assertTrue(out["ok"], f"save must succeed, got: {out}")
+		self.assert_encrypted_at_rest("agent_token", "selfhost-bearer-tok-42")
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.deployment_mode, "Self-Hosted")
+
+
+class TestV111EncryptPlaintextPatch(_SecretsSnapshotTestCase):
+	"""The v1_11 migration: plaintext column values move to __Auth + mask."""
+
+	def _execute_patch(self):
+		from jarvis.patches import v1_13_encrypt_plaintext_settings_passwords as patch_mod
+		patch_mod.execute()
+
+	def test_plaintext_values_are_encrypted_and_masked(self):
+		# Simulate the pre-fix state: raw plaintext written straight into
+		# tabSingles (what the old db_set call sites produced), no __Auth row.
+		seeded = {
+			"agent_token": "plain-agent-token-1",
+			"jarvis_admin_api_secret": "plain-admin-secret-2",
+			"chat_device_private_key": "plain-priv-key-3",
+		}
+		for field, value in seeded.items():
+			frappe.db.set_single_value(SETTINGS, field, value, update_modified=False)
+		frappe.db.commit()
+
+		self._execute_patch()
+
+		for field, value in seeded.items():
+			self.assert_encrypted_at_rest(field, value)
+
+	def test_patch_skips_empty_and_masked_fields(self):
+		# One field already in the CORRECT post-fix state...
+		from frappe.utils.password import set_encrypted_password
+		set_encrypted_password(SETTINGS, SETTINGS, "already-good-secret", "agent_token")
+		frappe.db.set_single_value(SETTINGS, "agent_token", "*" * 10, update_modified=False)
+		# ...everything else empty.
+		frappe.db.commit()
+
+		self._execute_patch()
+
+		# The masked field must be untouched: encrypting the MASK over the
+		# stored secret would destroy the credential.
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.get_password("agent_token", raise_exception=False),
+		                 "already-good-secret",
+		                 "patch must NOT re-encrypt the mask over the real secret")
+		# Empty fields stay empty - no __Auth rows conjured from nothing.
+		for field in _ALL_PASSWORD_FIELDS:
+			if field == "agent_token":
+				continue
+			self.assertIsNone(_auth_row(field),
+			                  f"{field}: patch must not create __Auth rows for empty fields")
+
+	def test_patch_is_idempotent(self):
+		frappe.db.set_single_value(SETTINGS, "jarvis_admin_api_key",
+		                           "plain-key-run-twice", update_modified=False)
+		frappe.db.commit()
+
+		self._execute_patch()
+		self._execute_patch()
+
+		self.assert_encrypted_at_rest("jarvis_admin_api_key", "plain-key-run-twice")
+
+	def test_patch_purges_stale_auth_row_behind_empty_column(self):
+		"""The pre-fix clear paths (clear_credentials, selfhost blank-token)
+		db_set("") the column WITHOUT remove_encrypted_password, so the
+		REVOKED secret survived in __Auth - and get_password falls through to
+		__Auth whenever the column is falsy, resurrecting it. The patch must
+		purge __Auth rows behind empty columns."""
+		from frappe.utils.password import set_encrypted_password
+
+		# Simulate the pre-fix cleared state: secret in __Auth, empty column
+		# (setUp already blanked every column).
+		set_encrypted_password(SETTINGS, SETTINGS, "revoked-secret", "chat_device_token")
+		frappe.db.commit()
+
+		# Precondition: the revoked secret is still served via the fallback.
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(
+			s.get_password("chat_device_token", raise_exception=False),
+			"revoked-secret",
+			"precondition: stale __Auth secret must be readable pre-patch",
+		)
+
+		self._execute_patch()
+
+		s = frappe.get_single(SETTINGS)
+		self.assertFalse(
+			s.get_password("chat_device_token", raise_exception=False),
+			"patch must purge the stale __Auth row behind an empty column",
+		)
+		self.assertIsNone(_auth_row("chat_device_token"),
+		                  "__Auth row must be gone after the patch")
+		self.assertFalse(_raw_singles_value("chat_device_token"),
+		                 "column must stay empty - nothing to backfill")

--- a/jarvis/tests/test_selfhost.py
+++ b/jarvis/tests/test_selfhost.py
@@ -175,7 +175,12 @@ class TestSaveSelfHostedToolUser(unittest.TestCase):
     def _save(self, *, session_user, existing_tool_user="", tool_user="", enabled=True):
         fake = _FakeSettings(selfhost_tool_user=existing_tool_user)
         validation = {"ok": True, "checks": [], "openclaw_version": None, "models": ["openclaw"]}
+        # set_settings_password is patched to a plain setattr: the real one
+        # writes __Auth via frappe.utils.password (a DB write this fully-mocked
+        # suite must never make).
         with mock.patch("jarvis.selfhost.validate_connection", return_value=validation), \
+                mock.patch("jarvis.selfhost.set_settings_password",
+                           side_effect=lambda doc, field, value, **kw: setattr(doc, field, value)), \
                 mock.patch("jarvis.selfhost.frappe") as fr:
             fr.get_single.return_value = fake
             fr.session.user = session_user

--- a/jarvis/tests/test_selfhost.py
+++ b/jarvis/tests/test_selfhost.py
@@ -226,6 +226,25 @@ class TestSaveSelfHostedToolUser(unittest.TestCase):
         self.assertEqual(fake.selfhost_tool_user, "carol@example.com")
         self.assertNotIn("warning", out)
 
+    def test_blank_token_clears_stored_secret_via_module_seam(self):
+        """A blank token (no-auth openclaw that validated clean) must route
+        through the MODULE-LEVEL clear_settings_password seam - never
+        set_settings_password - so this fully-mocked suite can intercept it
+        and a real __Auth delete is never performed against the DB."""
+        fake = _FakeSettings(selfhost_tool_user="carol@example.com")
+        validation = {"ok": True, "checks": [], "openclaw_version": None, "models": ["openclaw"]}
+        with mock.patch("jarvis.selfhost.validate_connection", return_value=validation), \
+                mock.patch("jarvis.selfhost.set_settings_password") as set_mock, \
+                mock.patch("jarvis.selfhost.clear_settings_password") as clear_mock, \
+                mock.patch("jarvis.selfhost.frappe") as fr:
+            fr.get_single.return_value = fake
+            fr.session.user = "alice@example.com"
+            fr.db.get_value.return_value = 1
+            out = selfhost.save_self_hosted("http://host:19060", "")
+        self.assertTrue(out["ok"])
+        clear_mock.assert_called_once_with(fake, "agent_token")
+        set_mock.assert_not_called()
+
 
 class TestSelfhostToolUserResolver(unittest.TestCase):
     """Use-time guard: _selfhost_tool_user refuses Administrator/Guest/disabled,

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2415,3 +2415,129 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertEqual(len(captured), 2)
         for kw in captured:
             self.assertEqual(kw.get("timeout"), ADMIN_SYNC_RQ_TIMEOUT_S)
+
+
+# ---------------------------------------------------------------------------
+# Pool-sync change detection: the pool analog of _classify_llm_change.
+#
+# Before this gate, EVERY save of Jarvis Settings while proxy_active - sandbox
+# toggles, pattern-learning windows, any unrelated field - re-POSTed the full
+# pool spec + secrets to admin. on_update now skips _enqueue_pool_sync only
+# when (a) a doc_before_save exists, (b) the pool-relevant snapshot
+# (_pool_state_snapshot) is identical, and (c) last_sync_status starts with
+# "ok" - so a failed sync stays retryable by re-saving.
+# ---------------------------------------------------------------------------
+
+class TestPoolSyncChangeDetection(_RT3SettingsTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._clear_models()
+        _reset_settings()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("preset", "", update_modified=False)
+        settings.db_set("proxy_active", 0, update_modified=False)
+        settings.db_set("proxy_recommended", 0, update_modified=False)
+        frappe.db.commit()
+
+    def _save_two_model_pool(self):
+        """Establish a synced 2-model pool: proxy_active=1, status 'ok ...'."""
+        from unittest.mock import patch
+
+        settings = frappe.get_single("Jarvis Settings")
+        _add_model_row(settings,
+                       provider="openai_compat", model="gpt-4o",
+                       tier="strong", order=0,
+                       api_key="sk-diff-key-1",
+                       base_url="https://api.openai.com")
+        _add_model_row(settings,
+                       provider="openai_compat", model="gpt-3.5-turbo",
+                       tier="cheap", order=1,
+                       api_key="sk-diff-key-2",
+                       base_url="https://api.openai.com")
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            settings.save()
+        settings = frappe.get_single("Jarvis Settings")
+        # Pre-condition shared by every test here: the pool applied cleanly.
+        assert (settings.last_sync_status or "").startswith("ok"), \
+            f"fixture: expected ok status, got {settings.last_sync_status!r}"
+        return settings
+
+    # ------------------------------------------------------------------ #
+    # (a) no-change save -> NO enqueue, status left alone
+    # ------------------------------------------------------------------ #
+
+    def test_unchanged_save_skips_pool_sync_enqueue(self):
+        """A save that changes nothing pool-relevant while the last sync is
+        'ok ...' must NOT enqueue a pool sync, and must leave
+        last_sync_status untouched (no 'pending:' write)."""
+        from unittest.mock import patch
+
+        self._save_two_model_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        status_before = settings.last_sync_status
+
+        with patch.object(type(settings), "_enqueue_pool_sync") as mock_enqueue:
+            settings.save()
+
+        mock_enqueue.assert_not_called()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_sync_status, status_before,
+                         "skipping must leave last_sync_status alone")
+
+    # ------------------------------------------------------------------ #
+    # (b) pool-relevant change -> enqueue fires
+    # ------------------------------------------------------------------ #
+
+    def test_model_row_change_enqueues_pool_sync(self):
+        from unittest.mock import patch
+
+        self._save_two_model_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.models[1].model = "gpt-4o-mini"
+
+        with patch.object(type(settings), "_enqueue_pool_sync") as mock_enqueue:
+            settings.save()
+
+        mock_enqueue.assert_called_once()
+
+    def test_same_length_api_key_rotation_enqueues_pool_sync(self):
+        """Regression guard for the snapshot's capture point: a freshly-typed
+        api_key of the SAME LENGTH as the old one masks to an identical
+        '*'*len string by on_update time, so a snapshot taken there would
+        read the rotation as 'unchanged' and silently drop the push. The
+        snapshot is captured in validate() (pre-masking), where the new
+        plaintext never equals the stored mask."""
+        from unittest.mock import patch
+
+        self._save_two_model_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        # Same length as the stored "sk-diff-key-1".
+        settings.models[0].api_key = "sk-diff-key-9"
+
+        with patch.object(type(settings), "_enqueue_pool_sync") as mock_enqueue:
+            settings.save()
+
+        mock_enqueue.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # (c) unchanged save while last sync FAILED -> still enqueues (retry)
+    # ------------------------------------------------------------------ #
+
+    def test_unchanged_save_with_failed_status_still_enqueues(self):
+        """A failed sync must always be retryable by re-saving, even with an
+        identical pool config."""
+        from unittest.mock import patch
+
+        self._save_two_model_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("last_sync_status", "failed: admin unreachable: boom",
+                        update_modified=False)
+        frappe.db.commit()
+
+        settings = frappe.get_single("Jarvis Settings")
+        with patch.object(type(settings), "_enqueue_pool_sync") as mock_enqueue:
+            settings.save()
+
+        mock_enqueue.assert_called_once()

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2450,6 +2450,60 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
             f"dedup gate; got {settings.last_sync_status!r}",
         )
 
+    def test_noop_reapply_does_not_clobber_the_last_real_verdict(self):
+        """A NO-OP apply (contract 1.10 `unchanged: true`) must LEAVE the previous
+        verdict alone.
+
+        The no-op path is side-effect-free by contract, so the fleet deliberately
+        runs no probe there (a 1-token completion is a side effect) and reports
+        subscription_status "unchecked" with warnings []. Persisting those would
+        DISCARD the last real apply's verdict:
+
+          * a healthy "verified" silently decays to "unchecked" -- reads as a
+            regression the customer never caused (this is exactly what was seen
+            live: a redundant re-save turned a working ChatGPT subscription into
+            "unchecked"), and
+          * far worse, a genuine `model_unreachable` / `subscription_unverified`
+            warning is CLEARED, so a dead model looks healthy again after any
+            redundant re-save.
+
+        Nothing about the running pool changed, so the previous verdict still
+        describes it exactly.
+        """
+        self._seed_pool()
+        warnings = [{"code": "model_unreachable",
+                     "message": "claude-sonnet-4-6: the upstream rejected a "
+                                "1-token probe"}]
+        # 1) a REAL apply lands a definitive verdict + a real warning
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool-applied",
+                                 "subscription_status": "verified",
+                                 "warnings": warnings}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, "verified")
+        self.assertEqual(json.loads(settings.last_sync_warnings), warnings)
+
+        # 2) a redundant re-save -> fleet short-circuits: unchanged, no probe
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool-applied",
+                                 "unchanged": True,
+                                 "subscription_status": "unchecked",
+                                 "warnings": []}):
+            _enqueued_sync_via_admin_pool()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(
+            settings.last_subscription_status, "verified",
+            "a no-op must not downgrade a verified subscription to 'unchecked'",
+        )
+        self.assertEqual(
+            json.loads(settings.last_sync_warnings), warnings,
+            "a no-op must not CLEAR a real warning -- that hides a dead model",
+        )
+        # the sync itself still succeeded, and the dedup gate's "ok" prefix holds
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"))
+
     def test_pool_sync_contract_1_9_response_defaults_to_empty(self):
         """A fleet on the pre-warnings contract (1.9) reports neither key -
         must default to "" / "[]" without raising (result is never assumed

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -9,6 +9,8 @@ Verifies:
 - Subscription Account upstream options do NOT contain 'anthropic'
 """
 
+import json
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -2415,6 +2417,106 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertEqual(len(captured), 2)
         for kw in captured:
             self.assertEqual(kw.get("timeout"), ADMIN_SYNC_RQ_TIMEOUT_S)
+
+    # -- Apply-warning propagation (subscription_status + warnings) -------
+    #
+    # The fleet-agent's PUT /v1/containers/{name}/llm-pool response carries
+    # subscription_status + warnings alongside action/result. Persisted into
+    # last_subscription_status / last_sync_warnings so the SPA (via
+    # onboarding.get_llm_sync_status) can surface a subscription that loaded
+    # but failed an upstream probe, instead of showing a blanket "ok".
+
+    def test_pool_sync_persists_subscription_status_and_warnings(self):
+        """A successful apply that reports subscription_status/warnings must
+        persist both, and last_sync_status must still start with the
+        literal "ok" - _pool_sync_is_redundant()'s dedup gate depends on
+        that exact prefix, so warnings must never be encoded into it."""
+        self._seed_pool()
+        warnings = [{"code": "subscription_unverified",
+                    "message": "cliproxy loaded the credential but the "
+                               "upstream rejected a 1-token probe"}]
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update",
+                                 "subscription_status": "unverified",
+                                 "warnings": warnings}):
+            _enqueued_sync_via_admin_pool()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, "unverified")
+        self.assertEqual(json.loads(settings.last_sync_warnings), warnings)
+        self.assertTrue(
+            (settings.last_sync_status or "").startswith("ok"),
+            f"warned-but-applied sync must still read 'ok ...' for the "
+            f"dedup gate; got {settings.last_sync_status!r}",
+        )
+
+    def test_pool_sync_contract_1_9_response_defaults_to_empty(self):
+        """A fleet on the pre-warnings contract (1.9) reports neither key -
+        must default to "" / "[]" without raising (result is never assumed
+        to carry these keys)."""
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            _enqueued_sync_via_admin_pool()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, "")
+        self.assertEqual(settings.last_sync_warnings, "[]")
+
+    def test_failed_pool_sync_clears_stale_subscription_status_and_warnings(self):
+        """A FAILED sync must clear both fields even when a PRIOR successful
+        apply had set them - a stale 'verified' status must not linger next
+        to a 'failed:' status the poller reads as broken."""
+        from jarvis.exceptions import AdminUnreachableError
+
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update",
+                                 "subscription_status": "verified",
+                                 "warnings": []}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, "verified")
+
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   side_effect=AdminUnreachableError("boom")):
+            _enqueued_sync_via_admin_pool()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue((settings.last_sync_status or "").startswith("failed:"))
+        self.assertEqual(settings.last_subscription_status, "",
+                         "a failed sync must clear the stale subscription_status")
+        self.assertEqual(settings.last_sync_warnings, "[]",
+                         "a failed sync must clear stale warnings")
+
+    def test_redundant_skip_leaves_subscription_status_and_warnings_untouched(self):
+        """The pre-enqueue redundant-sync skip (_pool_sync_is_redundant) must
+        leave subscription_status/warnings untouched, exactly like it leaves
+        last_sync_status untouched - the container's last real apply is
+        still the truth, nothing was pushed to it this time."""
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update",
+                                 "subscription_status": "verified",
+                                 "warnings": [{"code": "x", "message": "y"}]}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, "verified")
+        status_before = settings.last_subscription_status
+        warnings_before = settings.last_sync_warnings
+
+        # An unrelated re-save (no pool-relevant change, last sync "ok")
+        # must skip the enqueue entirely (_pool_sync_is_redundant) and
+        # leave both fields exactly as the last real apply left them.
+        # Mirrors TestPoolSyncChangeDetection's mock seam (patch
+        # _enqueue_pool_sync itself, not the admin call it would make).
+        with patch.object(type(settings), "_enqueue_pool_sync") as mock_enqueue:
+            settings.save()
+        mock_enqueue.assert_not_called()
+
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertEqual(settings.last_subscription_status, status_before)
+        self.assertEqual(settings.last_sync_warnings, warnings_before)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the jarvis-app HIGH findings from the 2026-07-02 proxy security audit (Password fields written in plaintext via `db_set`) and adds the customer-plane half of the zero-interruption goal: change detection so pool-unrelated saves stop re-POSTing the full pool + secrets.

## What

- **`jarvis/_password_utils.py` (new):** `set_settings_password` — `set_encrypted_password` into `__Auth` + `db_set` of a fixed 10-char mask (fixed-length so the mask never leaks secret length; fires no hooks, preserving the deliberate no-`on_update`-retrigger property of the db_set call sites). `clear_settings_password` — blanks the column AND drops the `__Auth` row, so `get_password` can't keep serving a revoked secret.
- **Fixed every plaintext write site:** `onboarding.py::write_connection` (4 fields), `chat/device.py::_save_credentials` / `update_device_token` / `clear_credentials`, `api.py::rotate_agent_token`, and `selfhost.py::save_self_hosted` — a site the original audit missed (customer-supplied openclaw bearer written in the clear; blank token now explicitly clears, matching the old `db_set("")` semantics).
- **`patches/v1_11_encrypt_plaintext_settings_passwords`:** one-time backfill over all 7 Password fields on the `Jarvis Settings` Single, three-branch: plaintext → encrypt + mask; masked → untouched; **empty → purge any stale `__Auth` row** (pre-fix clears blanked the column without `remove_encrypted_password`, and `get_password` falls through to `__Auth` on a falsy column — resurrecting revoked device tokens). Idempotent; verified under a real `bench migrate` (Patch Log row present).
- **Pool-sync dedup (`jarvis_settings.py`):** `_pool_state_snapshot` (preset + routing_mode + every field `build_pool_payload` serializes per models[] row, secrets sha256-digested so `doc.flags` can never leak one) + `_pool_sync_is_redundant` gate. The enqueue is skipped only when a before-doc exists AND snapshots are equal AND `last_sync_status` starts with `"ok"` (failed syncs stay retryable by re-saving); `flags.force_admin_sync` bypasses the gate. The snapshot is captured in `validate()` — by `on_update` time `_save_passwords` has masked freshly-typed child secrets to `'*'*len(value)`, so a same-length key rotation would compare "unchanged" and be silently dropped; validate-time capture makes rotations reliably read as changes (pinned by test).

## Tests

All local suites green on a fresh DB: `test_password_write_encryption` 11/11 (incl. the stale-`__Auth` purge and mask-idempotency pins), `test_unified_llm_config` 83/83 (incl. 4 new gate tests + same-length-rotation), `test_settings_on_update` 37/37, `test_chat_device` 14/14, `test_onboarding_sync` 26/26, `test_selfhost` 40/40, `test_dev` 8/8, `test_api` 28/28. Local site lacks hrms after a reinstall — CI is the authority.