### PR TITLE
fix(query): derive child-table read permission from parent (unblock child-table joins)

### DIFF
--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -2196,12 +2196,11 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 
 	def test_child_with_no_readable_parent_is_denied(self):
 		"""When no owning parent the caller can read is derivable, the child
-		read is a genuine denial (the gate does not silently allow it)."""
+		read is a genuine denial (the gate does not silently allow it). The
+		PermissionDeniedError is raised in step 3, before any query translation,
+		so no Engine/run patch is needed."""
 		frappe.set_user(self.USER_RESTRICTED)
-		with patch(
-			"jarvis.tools.get_list._child_table_parents", return_value=[],
-		), patch("frappe.database.query.Engine"), \
-		     patch("pypika.queries.QueryBuilder.run", return_value=[]):
+		with patch("jarvis.tools.get_list._child_table_parents", return_value=[]):
 			with self.assertRaises(PermissionDeniedError):
 				query({
 					"from": self.PARENT_DT, "alias": "p",

--- a/jarvis/tests/test_query.py
+++ b/jarvis/tests/test_query.py
@@ -2166,6 +2166,52 @@ class TestQueryPermlevelFieldACL(FrappeTestCase):
 			})
 		self.assertIn("rows", result)
 
+	# ---- DocType-level gate: child perm derived from a parent ------
+	# These exercise step 3's child-table branch with the REAL has_permission
+	# (not the patched gate above), proving a non-admin who can read the parent
+	# is not falsely denied on the child. _child_table_parents is patched so the
+	# derivation does not issue a DB query through the mocked Engine.
+
+	def test_restricted_can_query_child_via_readable_parent(self):
+		"""A restricted user who can read the parent passes the DocType gate
+		for the child: has_permission(child) is False without a parent, so the
+		gate derives permission from a readable owning parent (mirrors
+		get_list) instead of failing closed."""
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch(
+			"jarvis.tools.get_list._child_table_parents",
+			return_value=[self.PARENT_DT],
+		), patch("frappe.database.query.Engine") as fake_engine, \
+		     patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			fake_engine.return_value.get_permission_conditions.return_value = None
+			result = query({
+				"from": self.PARENT_DT, "alias": "p",
+				"joins": [{
+					"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+					"on": {"c.parent": "p.name"},
+				}],
+				"select": ["p.name", "c.child_public"],
+			})
+		self.assertIn("rows", result)
+
+	def test_child_with_no_readable_parent_is_denied(self):
+		"""When no owning parent the caller can read is derivable, the child
+		read is a genuine denial (the gate does not silently allow it)."""
+		frappe.set_user(self.USER_RESTRICTED)
+		with patch(
+			"jarvis.tools.get_list._child_table_parents", return_value=[],
+		), patch("frappe.database.query.Engine"), \
+		     patch("pypika.queries.QueryBuilder.run", return_value=[]):
+			with self.assertRaises(PermissionDeniedError):
+				query({
+					"from": self.PARENT_DT, "alias": "p",
+					"joins": [{
+						"type": "left", "doctype": self.CHILD_DT, "alias": "c",
+						"on": {"c.parent": "p.name"},
+					}],
+					"select": ["p.name", "c.child_public"],
+				})
+
 	# ---- join ON + EXISTS positions --------------------------------
 
 	def test_restricted_cannot_join_on_permlevel_field(self):

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -187,36 +187,33 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	# Step 2: collect all referenced DocTypes for the permission gates.
 	doctypes = _collect_doctypes(spec)
 
-	# Step 3: DocType-level read permission gate (mirrors run_query). Child
-	# (istable) DocTypes carry no permissions of their own - Frappe derives them
-	# from a parent - so a plain has_permission(child) returns False for every
-	# non-admin, which broke every join/read that references a child table.
-	# Mirror get_list: allow a child table if the caller can read at least one of
-	# its owning parents (parent_doctype-derived permission) - so a join to a
-	# readable parent works; a child whose parents are all unreadable is a
-	# genuine denial. Row-level permission_query_conditions still apply below.
-	from jarvis.tools.get_list import _child_table_parents
-
+	# Step 3: DocType-level read permission gate (mirrors run_query). The plain
+	# has_permission check comes first and is the only thing on the happy path -
+	# no meta or schema lookup - so a readable DocType (or the mocked gate in
+	# tests) never triggers the child-table derivation below, and an unknown
+	# DocType still falls through to the downstream translation error rather than
+	# a DoesNotExistError here.
 	for dt in doctypes:
+		if frappe.has_permission(dt, ptype="read"):
+			continue
+		# Denied by the plain check. For a CHILD (istable) DocType that is a false
+		# negative: child DocTypes carry no permissions of their own, so
+		# has_child_permission returns False for every non-admin without a parent -
+		# which broke every join/read referencing a child table. Mirror get_list:
+		# allow the child if the caller can read one of its owning parents
+		# (parent_doctype-derived permission). Only reached on an actual denial, so
+		# the get_meta / get_all derivation stays off the hot path.
 		if frappe.get_meta(dt).istable:
+			from jarvis.tools.get_list import _child_table_parents
+
 			parents = _child_table_parents(dt)
-			if parents:
-				if not any(
-					frappe.has_permission(dt, ptype="read", parent_doctype=p) for p in parents
-				):
-					raise PermissionDeniedError(
-						f"no read permission on referenced child table: {dt} "
-						f"(no readable parent among {parents})"
-					)
+			if any(
+				frappe.has_permission(dt, ptype="read", parent_doctype=p) for p in parents
+			):
 				continue
-			# No owning parent is derivable (e.g. a core meta table like DocField,
-			# whose parent Table field is not itself introspectable via DocField).
-			# Fall through to the plain child-permission check rather than failing
-			# closed on a child we cannot trace to a parent.
-		if not frappe.has_permission(dt, ptype="read"):
-			raise PermissionDeniedError(
-				f"no read permission on referenced DocType: {dt}"
-			)
+		raise PermissionDeniedError(
+			f"no read permission on referenced DocType: {dt}"
+		)
 
 	# Step 4: per-site DocType allowlist (defense-in-depth).
 	allowlist = _load_doctype_allowlist()

--- a/jarvis/tools/query.py
+++ b/jarvis/tools/query.py
@@ -187,8 +187,32 @@ def query(spec: dict, confirm_large: bool = False) -> dict:
 	# Step 2: collect all referenced DocTypes for the permission gates.
 	doctypes = _collect_doctypes(spec)
 
-	# Step 3: DocType-level read permission gate (mirrors run_query).
+	# Step 3: DocType-level read permission gate (mirrors run_query). Child
+	# (istable) DocTypes carry no permissions of their own - Frappe derives them
+	# from a parent - so a plain has_permission(child) returns False for every
+	# non-admin, which broke every join/read that references a child table.
+	# Mirror get_list: allow a child table if the caller can read at least one of
+	# its owning parents (parent_doctype-derived permission) - so a join to a
+	# readable parent works; a child whose parents are all unreadable is a
+	# genuine denial. Row-level permission_query_conditions still apply below.
+	from jarvis.tools.get_list import _child_table_parents
+
 	for dt in doctypes:
+		if frappe.get_meta(dt).istable:
+			parents = _child_table_parents(dt)
+			if parents:
+				if not any(
+					frappe.has_permission(dt, ptype="read", parent_doctype=p) for p in parents
+				):
+					raise PermissionDeniedError(
+						f"no read permission on referenced child table: {dt} "
+						f"(no readable parent among {parents})"
+					)
+				continue
+			# No owning parent is derivable (e.g. a core meta table like DocField,
+			# whose parent Table field is not itself introspectable via DocField).
+			# Fall through to the plain child-permission check rather than failing
+			# closed on a child we cannot trace to a parent.
 		if not frappe.has_permission(dt, ptype="read"):
 			raise PermissionDeniedError(
 				f"no read permission on referenced DocType: {dt}"


### PR DESCRIPTION
## The bug
The `query` tool's step-3 permission gate does `frappe.has_permission(dt, "read")` for every referenced DocType with **no parent context**. For a **child (istable) DocType** that routes through Frappe's `has_child_permission`, which returns `False` for every non-admin without a parent — so **any query referencing a child table** (as `FROM` or in a `JOIN`) raises `PermissionDeniedError` for real tenant users, even when they can read the parent.

This is the same class of bug the **`get_list`** tool was hardened against (it takes `parent_doctype` and derives the child's permission from the parent).

## The fix
Mirror `get_list`: for a child DocType, allow the read if the caller can read **at least one owning parent** (`has_permission(child, parent_doctype=p)`, via the shared `_child_table_parents` helper). A child whose parents are all unreadable is a genuine denial. Non-child DocTypes are unchanged. Row-level `permission_query_conditions` and the field-level ACL still apply downstream — this makes step 3 match Frappe's real child-permission model, it doesn't weaken it.

## Impact
Unblocks every legitimate child-table join/aggregate over the query tool — and the **persona skill library's cross-parent query examples** (the `parent_doctype` audit sweep routed ~25 multi-parent/aggregate reads here, and they currently dead-end for tenant users). Surfaced by a Fable review that empirically reproduced the denial on `jarvis-test.localhost` as an Accounts User.

## Verification
- `py_compile` passes.
- **Before merge, run** `bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_query` (couldn't run against the isolated worktree). The permlevel-ACL tests patch `has_permission`; confirm they still pass, and **add a positive test**: a non-admin who can read the parent can now query the child, while one who can't is still denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)