### PR TITLE
Scope confirmed/model writes in a savepoint (no half-commit on failure)

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -701,8 +701,22 @@ def _dispatch_and_wrap(tool: str, args: dict, is_write: bool) -> dict:
 	"""Dispatch + translate exceptions into the ``{ok, data}`` / ``{ok, error}``
 	envelope + audit write tools. This is the shared core of ``_run_tool``'s
 	execute path, reused verbatim by ``confirm_tool`` so a confirmed write runs
-	through the exact same translation + audit as an inline one."""
+	through the exact same translation + audit as an inline one.
+
+	A write is scoped in a SAVEPOINT so a KNOWN failure is rolled back before we
+	RETURN the ``{ok:false}`` envelope. Frappe commits any endpoint that returns
+	normally (frappe/app.py), so without this a tool that half-applied before
+	raising - e.g. a submit whose ``on_submit`` hook throws AFTER ``docstatus=1``
+	was written - would be persisted at end-of-request. Rolling back to the
+	savepoint (not a full rollback) undoes ONLY this tool, leaving the caller's
+	surrounding writes intact (``confirm_tool``'s failure receipt/continuation,
+	the model path's tool-call row). Unexpected exceptions re-raise unchanged:
+	Frappe's handler does a full request rollback (nothing persists, no envelope,
+	no traceback to the client)."""
 	mark = _msglog_mark()
+	sp = f"jarvis_{frappe.generate_hash(length=10)}" if is_write else None
+	if sp:
+		frappe.db.savepoint(sp)
 	try:
 		data = dispatch(tool, args)
 	except Exception as e:
@@ -712,11 +726,24 @@ def _dispatch_and_wrap(tool: str, args: dict, is_write: bool) -> dict:
 				audit.record(tool=tool, args=args, ok=False,
 							 error_code=type(e).__name__, error_message=str(e))
 			raise
+		if sp:
+			# Undo this tool's partial writes. Guard against a tool that committed
+			# mid-op (the savepoint would be gone) so we never turn a clean tool
+			# failure into a 500.
+			try:
+				frappe.db.rollback(save_point=sp)
+			except Exception:
+				pass
 		if is_write:
 			err_obj = envelope["error"]
 			audit.record(tool=tool, args=args, ok=False,
 						 error_code=err_obj["code"], error_message=err_obj["message"])
 		return envelope
+	if sp:
+		try:
+			frappe.db.release_savepoint(sp)
+		except Exception:
+			pass
 	if is_write:
 		audit.record(tool=tool, args=args, ok=True, result=data)
 	return {"ok": True, "data": data}

--- a/jarvis/tests/test_action_error_detail.py
+++ b/jarvis/tests/test_action_error_detail.py
@@ -169,6 +169,45 @@ class TestDispatchAndWrapEnrichment(FrappeTestCase):
 			with self.assertRaises(ValueError):
 				api._dispatch_and_wrap("update_doc", {"doctype": "X"}, is_write=True)
 
+	def test_savepoint_rolls_back_partial_write_on_known_failure(self):
+		# A tool that half-applied (wrote a row) before raising a KNOWN error must
+		# be undone before the {ok:false} envelope is returned - else Frappe's
+		# end-of-request commit would persist the partial write (e.g. a submit
+		# whose on_submit hook throws after docstatus=1 was written).
+		marker = "jarvis-sp-rollback-marker"
+		frappe.local.conf["disable_global_search"] = 1
+		self.addCleanup(lambda: frappe.local.conf.pop("disable_global_search", None))
+
+		def half_apply(tool, args):
+			frappe.get_doc({"doctype": "ToDo", "description": marker}).insert(ignore_permissions=True)
+			raise frappe.ValidationError("blew up after writing")
+
+		with patch("jarvis.api.dispatch", side_effect=half_apply):
+			env = api._dispatch_and_wrap("update_doc", {"doctype": "ToDo"}, is_write=True)
+		self.assertFalse(env["ok"])
+		self.assertEqual(env["error"]["code"], "InvalidArgumentError")
+		self.assertFalse(frappe.db.exists("ToDo", {"description": marker}))
+
+	def test_savepoint_keeps_write_on_success(self):
+		# The savepoint must NOT undo a successful write (it is released, not
+		# rolled back) - the row persists in the transaction as before.
+		marker = "jarvis-sp-success-marker"
+		frappe.local.conf["disable_global_search"] = 1
+		self.addCleanup(lambda: frappe.local.conf.pop("disable_global_search", None))
+		self.addCleanup(
+			lambda: frappe.db.exists("ToDo", {"description": marker})
+			and frappe.db.delete("ToDo", {"description": marker})
+		)
+
+		def apply_ok(tool, args):
+			doc = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert(ignore_permissions=True)
+			return {"name": doc.name}
+
+		with patch("jarvis.api.dispatch", side_effect=apply_ok):
+			env = api._dispatch_and_wrap("update_doc", {"doctype": "ToDo"}, is_write=True)
+		self.assertTrue(env["ok"])
+		self.assertTrue(frappe.db.exists("ToDo", {"description": marker}))
+
 
 class TestApplyActionContract(FrappeTestCase):
 	def setUp(self):


### PR DESCRIPTION
Follow-up to #279 (finding #1 from Fable's review).

## Why
`_dispatch_and_wrap` returned the `{ok:false}` envelope **without a rollback**, and Frappe commits any endpoint that returns normally (`frappe/app.py`). So a tool that **half-applied before raising** — the canonical case being a confirmed `submit_doc` whose `on_submit` hook throws *after* `docstatus=1` was written — would be **persisted at end-of-request**. Verified against the vendored Frappe: `insert`/`save`/`submit` carry no internal savepoint, and `_submit` writes `docstatus=1` (via `save()`) *before* `on_submit` runs (`document.py`), with the only synchronous-path rollback living in the background-worker `execute_action`.

## What
Wrap each **write's** `dispatch()` in a `SAVEPOINT` and, on a **known** failure, `rollback(save_point=…)` before returning the envelope — undoing **only that tool**, so the caller's surrounding writes survive:
- `confirm_tool`'s failure **receipt + continuation** (written after `dispatch_confirmed`),
- the model path's already-**committed** tool-call row.

Details:
- **Reads are unscoped** (`is_write` gate) — nothing to undo, no extra SQL.
- **Unexpected exceptions still re-raise** → Frappe's handler does a full request rollback (nothing persists, no envelope, no traceback to the client) — unchanged.
- Both `rollback`/`release_savepoint` calls are **guarded** so a tool that committed mid-op (savepoint already gone) degrades to today's no-rollback behaviour instead of turning a clean tool failure into a 500.
- A **savepoint** (not a full rollback) is deliberate: a full rollback in `_dispatch_and_wrap` could wipe the model path's tool-call row / confirm receipt.
- `apply_action` is **unchanged** — it already does its own full rollback and, as the top-level endpoint with no surrounding writes, that's correct there.

## Testing
- `jarvis.tests.test_action_error_detail` — **18** (2 new): a half-applied write is rolled back on a known failure; a successful write is kept (savepoint released, not rolled back).
- Regression: the two insert-heavy modules (`test_actions_api`, `test_confirm_gate`) show the **same** pre-existing local-env failure counts with/without this change — zero new regressions; `test_api` green.

App-only; ships on a bench build. The `jarvis__*` contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)