### PR TITLE
feat(tools): workflow-aware tools (get_workflow_transitions + apply_workflow_action) + submit/cancel guards

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -415,7 +415,7 @@ def _parse_args(args: dict | str | None) -> dict:
 # ``preview`` (a dry-run with every DB write rolled back).
 _WRITE_TOOLS = frozenset({
 	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc", "amend_doc",
-	"delete_doc", "run_method",
+	"delete_doc", "run_method", "apply_workflow_action",
 	"send_email", "add_comment", "update_comment", "share_doc", "unshare_doc",
 	"assign_to", "unassign_from", "add_tag", "remove_tag",
 	"follow_document", "unfollow_document", "attach_to_doc",
@@ -444,13 +444,13 @@ _PREVIEWABLE = frozenset({
 # sandboxed dry-run.
 _GATED_WRITES = frozenset({
 	"create_doc", "create_docs", "update_doc", "submit_doc", "cancel_doc",
-	"amend_doc", "delete_doc", "run_method", "send_email",
+	"amend_doc", "delete_doc", "run_method", "apply_workflow_action", "send_email",
 	"create_custom_skill", "update_wiki",
 	"share_doc", "assign_to",
 })
 # Irreversible/consequential subset - gated even when a user has auto-apply
 # on (Task 4 uses this; define it here so the sets live together).
-_DESTRUCTIVE = frozenset({"delete_doc", "cancel_doc", "amend_doc", "send_email"})
+_DESTRUCTIVE = frozenset({"delete_doc", "cancel_doc", "amend_doc", "send_email", "apply_workflow_action"})
 # Writes that auto-apply may fast-path without a confirmation click. Strictly
 # the reversible create/update pair, per spec. submit_doc, run_method and every
 # _DESTRUCTIVE tool ALWAYS park even with auto-apply on: run_method's
@@ -544,7 +544,7 @@ def _describe_call(tool: str, args: dict) -> str:
 	a = args if isinstance(args, dict) else {}
 	parts = [tool]
 	for key in ("doctype", "name", "docname", "target_doctype", "target_name",
-				"method", "recipients", "to", "subject"):
+				"method", "action", "recipients", "to", "subject"):
 		val = a.get(key)
 		if val:
 			parts.append(f"{key}={val}")

--- a/jarvis/tests/test_workflow_tools.py
+++ b/jarvis/tests/test_workflow_tools.py
@@ -1,0 +1,265 @@
+"""Tests for the Workflow tools + the workflow-awareness guards.
+
+Covers get_workflow_transitions (read) and apply_workflow_action (gated write),
+plus the refuse-and-redirect guards added to submit_doc / cancel_doc, and the
+api.py gating classification + confirm-card summary for the write tool.
+
+Mock-based by design (mirrors test_submit_doc): a REAL active Workflow on a
+submittable DocType needs heavy fixtures, and the engine these tools wrap
+(frappe.model.workflow) is Frappe's own, already tested upstream. We verify what
+these tools OWN: response shape, the docstatus/empty-state branches, the
+has_approval_access filter, the no-workflow guard, the background-queue branch,
+error propagation, the cancel-guard short-circuit order, the gating sets, and
+the confirm card carrying the action. Nothing here does a real insert, so the
+local-site global-search / user-creation gotchas never fire.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.model.workflow import WorkflowStateError
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools.apply_workflow_action import apply_workflow_action
+from jarvis.tools.cancel_doc import cancel_doc
+from jarvis.tools.get_workflow_transitions import get_workflow_transitions
+from jarvis.tools.submit_doc import submit_doc
+
+GWT = "jarvis.tools.get_workflow_transitions"
+AWA = "jarvis.tools.apply_workflow_action"
+
+
+def _meta(submittable=True):
+	m = MagicMock()
+	m.is_submittable = submittable
+	return m
+
+
+class TestGetWorkflowTransitions(FrappeTestCase):
+	def test_rejects_empty_doctype(self):
+		with self.assertRaises(InvalidArgumentError):
+			get_workflow_transitions("", "X-1")
+
+	def test_unknown_doc_raises(self):
+		with patch("frappe.db.exists", return_value=False):
+			with self.assertRaises(InvalidArgumentError):
+				get_workflow_transitions("ToDo", "nope")
+
+	def test_no_read_permission_raises(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=False),
+		):
+			with self.assertRaises(PermissionDeniedError):
+				get_workflow_transitions("ToDo", "TODO-001")
+
+	def test_no_workflow_returns_flag(self):
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch(f"{GWT}.get_workflow_name", return_value=""),
+		):
+			result = get_workflow_transitions("ToDo", "TODO-001")
+		self.assertEqual(result, {"doctype": "ToDo", "name": "TODO-001", "has_workflow": False})
+
+	def test_lists_actions_filtered_by_approval_access(self):
+		doc = frappe._dict({"owner": "a@b.c", "docstatus": 0, "workflow_state": "Applied"})
+		transitions = [
+			frappe._dict({"action": "Approve", "next_state": "Approved"}),
+			frappe._dict({"action": "Reject", "next_state": "Rejected"}),
+		]
+
+		def _only_approve(user, d, t):
+			return t.get("action") == "Approve"
+
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch(f"{GWT}.get_workflow_name", return_value="WF"),
+			patch(f"{GWT}.get_workflow_state_field", return_value="workflow_state"),
+			patch(f"{GWT}.get_transitions", return_value=transitions),
+			patch(f"{GWT}.has_approval_access", side_effect=_only_approve),
+			patch("frappe.get_doc", return_value=doc),
+		):
+			result = get_workflow_transitions("Leave Application", "LA-001")
+
+		self.assertTrue(result["has_workflow"])
+		self.assertEqual(result["workflow"], "WF")
+		self.assertEqual(result["current_state"], "Applied")
+		self.assertEqual(
+			result["available_actions"],
+			[{"action": "Approve", "next_state": "Approved"}],
+		)
+
+	def test_cancelled_doc_returns_no_actions(self):
+		doc = frappe._dict({"owner": "a@b.c", "docstatus": 2, "workflow_state": "Approved"})
+		gt = MagicMock()
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch(f"{GWT}.get_workflow_name", return_value="WF"),
+			patch(f"{GWT}.get_workflow_state_field", return_value="workflow_state"),
+			patch(f"{GWT}.get_transitions", gt),
+			patch("frappe.get_doc", return_value=doc),
+		):
+			result = get_workflow_transitions("Leave Application", "LA-001")
+		self.assertEqual(result["available_actions"], [])
+		self.assertEqual(result["current_state"], "Approved")
+		gt.assert_not_called()  # never consult the engine for a cancelled doc
+
+	def test_empty_state_returns_note_not_error(self):
+		doc = frappe._dict({"owner": "a@b.c", "docstatus": 0, "workflow_state": None})
+		with (
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch(f"{GWT}.get_workflow_name", return_value="WF"),
+			patch(f"{GWT}.get_workflow_state_field", return_value="workflow_state"),
+			patch(f"{GWT}.get_transitions", side_effect=WorkflowStateError("no state")),
+			patch("frappe.get_doc", return_value=doc),
+		):
+			result = get_workflow_transitions("Leave Application", "LA-001")
+		self.assertIsNone(result["current_state"])
+		self.assertEqual(result["available_actions"], [])
+		self.assertIn("note", result)
+
+
+class TestApplyWorkflowAction(FrappeTestCase):
+	def test_rejects_empty_action(self):
+		with self.assertRaises(InvalidArgumentError):
+			apply_workflow_action("Leave Application", "LA-001", "")
+
+	def test_rejects_non_workflow_doctype(self):
+		with patch(f"{AWA}.get_workflow_name", return_value=""):
+			with self.assertRaises(InvalidArgumentError) as ctx:
+				apply_workflow_action("ToDo", "TODO-001", "Approve")
+		self.assertIn("not governed by an active Workflow", str(ctx.exception))
+
+	def test_applies_trimmed_action_and_returns_doc(self):
+		doc = MagicMock()
+		doc.as_dict.return_value = {"name": "LA-001", "workflow_state": "Approved", "docstatus": 1}
+		with (
+			patch(f"{AWA}.get_workflow_name", return_value="WF"),
+			patch("frappe.get_doc", return_value=doc),
+			patch(f"{AWA}.apply_workflow", return_value=doc) as aw,
+		):
+			result = apply_workflow_action("Leave Application", "LA-001", "  Approve  ")
+		aw.assert_called_once_with(doc, "Approve")
+		doc.apply_fieldlevel_read_permissions.assert_called_once()
+		self.assertEqual(result["workflow_state"], "Approved")
+
+	def test_queued_transition_returns_marker(self):
+		doc = MagicMock()
+		with (
+			patch(f"{AWA}.get_workflow_name", return_value="WF"),
+			patch("frappe.get_doc", return_value=doc),
+			patch(f"{AWA}.apply_workflow", return_value=None),
+		):
+			result = apply_workflow_action("Leave Application", "LA-001", "Approve")
+		self.assertEqual(
+			result,
+			{"doctype": "Leave Application", "name": "LA-001", "action": "Approve", "queued": True},
+		)
+		doc.apply_fieldlevel_read_permissions.assert_not_called()
+
+	def test_propagates_validation_error(self):
+		doc = MagicMock()
+		with (
+			patch(f"{AWA}.get_workflow_name", return_value="WF"),
+			patch("frappe.get_doc", return_value=doc),
+			patch(f"{AWA}.apply_workflow", side_effect=frappe.ValidationError("Self approval is not allowed")),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				apply_workflow_action("Leave Application", "LA-001", "Approve")
+		self.assertIn("Self approval", str(ctx.exception))
+
+
+class TestSubmitCancelWorkflowGuard(FrappeTestCase):
+	def test_submit_doc_refuses_workflow_doctype(self):
+		with (
+			patch("frappe.get_meta", return_value=_meta(True)),
+			patch("jarvis.tools.submit_doc.get_workflow_name", return_value="WF"),
+		):
+			with self.assertRaises(InvalidArgumentError) as ctx:
+				submit_doc("Leave Application", "LA-001")
+		self.assertIn("governed by a Workflow", str(ctx.exception))
+
+	def test_cancel_doc_refuses_when_cancel_is_modeled(self):
+		with (
+			patch("frappe.get_meta", return_value=_meta(True)),
+			patch("jarvis.tools.cancel_doc.get_workflow_name", return_value="WF"),
+			patch("jarvis.tools.cancel_doc.can_cancel_document", return_value=False),
+		):
+			with self.assertRaises(InvalidArgumentError) as ctx:
+				cancel_doc("Leave Application", "LA-001")
+		self.assertIn("apply_workflow_action", str(ctx.exception))
+
+	def test_cancel_doc_allows_when_no_cancel_path(self):
+		doc = MagicMock()
+		doc.docstatus = 1
+		doc.as_dict.return_value = {"name": "LA-001", "docstatus": 2}
+		with (
+			patch("frappe.get_meta", return_value=_meta(True)),
+			patch("jarvis.tools.cancel_doc.get_workflow_name", return_value="WF"),
+			patch("jarvis.tools.cancel_doc.can_cancel_document", return_value=True),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.get_doc", return_value=doc),
+		):
+			result = cancel_doc("Leave Application", "LA-001")
+		doc.cancel.assert_called_once()
+		self.assertEqual(result["docstatus"], 2)
+
+	def test_cancel_doc_non_workflow_short_circuits_can_cancel(self):
+		"""can_cancel_document crashes on a null workflow, so the guard must
+		short-circuit on get_workflow_name first - assert it's never called."""
+		doc = MagicMock()
+		doc.docstatus = 1
+		doc.as_dict.return_value = {"name": "SINV-1", "docstatus": 2}
+		ccd = MagicMock()
+		with (
+			patch("frappe.get_meta", return_value=_meta(True)),
+			patch("jarvis.tools.cancel_doc.get_workflow_name", return_value=""),
+			patch("jarvis.tools.cancel_doc.can_cancel_document", ccd),
+			patch("frappe.has_permission", return_value=True),
+			patch("frappe.get_doc", return_value=doc),
+		):
+			cancel_doc("Sales Invoice", "SINV-1")
+		ccd.assert_not_called()
+
+
+class TestWorkflowActionGating(FrappeTestCase):
+	def test_classified_as_gated_destructive_write(self):
+		self.assertIn("apply_workflow_action", api._WRITE_TOOLS)
+		self.assertIn("apply_workflow_action", api._GATED_WRITES)
+		self.assertIn("apply_workflow_action", api._DESTRUCTIVE)
+
+	def test_not_dry_run_previewable(self):
+		# on_submit/on_cancel hooks fire, so it must never be sandbox-dry-run.
+		self.assertNotIn("apply_workflow_action", api._PREVIEWABLE)
+		self.assertNotIn("apply_workflow_action", api._DRY_RUN_ON_PARK)
+		self.assertNotIn("apply_workflow_action", api._AUTO_APPLYABLE)
+
+	def test_parks_as_described_intent(self):
+		pv = api._pending_preview(
+			"apply_workflow_action",
+			{"doctype": "Leave Application", "name": "LA-001", "action": "Approve"},
+		)
+		self.assertTrue(pv.get("described"))
+		self.assertFalse(pv.get("preview"))
+
+	def test_confirm_summary_names_the_action(self):
+		summary = api._describe_call(
+			"apply_workflow_action",
+			{"doctype": "Leave Application", "name": "LA-001", "action": "Approve"},
+		)
+		self.assertIn("action=Approve", summary)
+		self.assertIn("Leave Application", summary)
+
+
+class TestWorkflowToolsRegistered(FrappeTestCase):
+	def test_registered(self):
+		from jarvis.tools.registry import _TOOL_NAMES
+
+		self.assertIn("get_workflow_transitions", _TOOL_NAMES)
+		self.assertIn("apply_workflow_action", _TOOL_NAMES)

--- a/jarvis/tools/apply_workflow_action.py
+++ b/jarvis/tools/apply_workflow_action.py
@@ -1,0 +1,61 @@
+"""Apply a Workflow action to a document (Approve / Reject / ...).
+
+The WRITE half of workflow support (read half: ``get_workflow_transitions``).
+Frappe-workflow-governed DocTypes advance by applying a named *action*, which
+the engine validates (is it a legal transition from the current state for this
+user's roles?), checks self-approval on, then commits by internally
+save()/submit()/cancel()-ing the doc per the target state's docstatus - firing
+the usual on_submit / on_cancel side effects.
+
+Consequential: a transition can post to the GL, move stock, or cancel a doc,
+exactly like submit_doc / cancel_doc. It is confirmation-gated in api.py.
+
+We wrap Frappe's own ``frappe.model.workflow.apply_workflow`` - it does all the
+validation and permission enforcement; we only guard the "no workflow here"
+case up front and shape the result.
+"""
+
+import frappe
+from frappe.model.workflow import apply_workflow, get_workflow_name
+
+from jarvis.exceptions import InvalidArgumentError
+from jarvis.tools import require_doctype_and_name
+
+
+def apply_workflow_action(doctype: str, name: str, action: str) -> dict:
+    """Apply ``action`` to the doc's workflow and return the updated doc.
+
+    Raises:
+      - InvalidArgumentError on empty args, a DocType with no active workflow
+        (use submit_doc / update_doc instead), or an action the workflow does
+        not offer from the current state
+      - frappe.DoesNotExistError when the record doesn't exist
+      - frappe.ValidationError for a self-approval violation, a failed
+        transition condition, or the DocType's own validate()/on_submit rules
+
+    When the DocType submits in the background (``queue_in_background``), the
+    transition is enqueued rather than committed inline; the result is then
+    ``{"queued": True}`` (no doc dict, because nothing is committed yet).
+    """
+    require_doctype_and_name(doctype, name)
+    if not action or not str(action).strip():
+        raise InvalidArgumentError("action is required")
+    action = str(action).strip()
+
+    if not get_workflow_name(doctype):
+        raise InvalidArgumentError(
+            f"{doctype} is not governed by an active Workflow; use submit_doc / "
+            f"update_doc / cancel_doc instead of a workflow action."
+        )
+
+    doc = frappe.get_doc(doctype, name)  # raises DoesNotExistError if missing
+    result = apply_workflow(doc, action)  # validates transition + role + self-approval
+
+    # Background-queued submittable DocTypes: apply_workflow enqueues the
+    # submit/cancel and early-returns None - nothing is committed synchronously,
+    # so don't report a state/docstatus as if it were.
+    if result is None:
+        return {"doctype": doctype, "name": name, "action": action, "queued": True}
+
+    result.apply_fieldlevel_read_permissions()
+    return result.as_dict()

--- a/jarvis/tools/cancel_doc.py
+++ b/jarvis/tools/cancel_doc.py
@@ -27,6 +27,7 @@ Safety bounds:
 """
 
 import frappe
+from frappe.model.workflow import can_cancel_document, get_workflow_name
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools import require_doctype_and_name
@@ -38,7 +39,9 @@ def cancel_doc(doctype: str, name: str) -> dict:
     Returns the cancelled document as a dict (with ``docstatus: 2``).
     Raises:
       - InvalidArgumentError on empty args, non-submittable DocType,
-        or wrong starting docstatus (Draft or already Cancelled)
+        a workflow-governed DocType that models cancellation (advance via
+        apply_workflow_action), or wrong starting docstatus (Draft or
+        already Cancelled)
       - PermissionDeniedError when the calling user lacks cancel
       - frappe.DoesNotExistError when the record doesn't exist
       - frappe.ValidationError from the DocType's on_cancel hook
@@ -50,6 +53,19 @@ def cancel_doc(doctype: str, name: str) -> dict:
         raise InvalidArgumentError(
             f"{doctype} is not submittable - cancellation only applies to "
             f"docstatus-tracked DocTypes"
+        )
+
+    # When a workflow models a cancel path (a transition into a docstatus=2
+    # state), cancelling must go through that action, not a direct cancel.
+    # get_workflow_name MUST short-circuit first: can_cancel_document assumes an
+    # active workflow exists and errors otherwise. Workflows with no cancel path
+    # still allow a plain cancel (Desk shows the Cancel button there too).
+    if get_workflow_name(doctype) and not can_cancel_document(doctype):
+        raise InvalidArgumentError(
+            f"{doctype} is governed by a Workflow that models cancellation as a "
+            f"state transition; use apply_workflow_action instead of cancelling "
+            f"directly. Use get_workflow_transitions to see the actions "
+            f"available to you."
         )
 
     if not frappe.has_permission(doctype, ptype="cancel", doc=name):

--- a/jarvis/tools/get_workflow_transitions.py
+++ b/jarvis/tools/get_workflow_transitions.py
@@ -1,0 +1,96 @@
+"""List the Workflow transitions available to the current user for a doc.
+
+Frappe DocTypes can be governed by a **Workflow** (a state machine: e.g.
+Leave Application *Applied -> Approved / Rejected*). You advance such a doc by
+applying an *action* (Approve / Reject), not by calling submit(). Which actions
+are available depends on the current state, the acting user's roles, each
+transition's condition, and the self-approval rule.
+
+This is the READ half of workflow support: it tells the agent (and the user)
+the doc's current state and exactly which actions THIS user may take next, so
+the agent never guesses. The WRITE half is ``apply_workflow_action``.
+
+Pure read - enforces read permission and reuses Frappe's own user-aware
+``get_transitions`` (roles + condition) plus ``has_approval_access`` (the
+self-approval rule the engine omits from ``get_transitions``).
+"""
+
+import frappe
+from frappe.model.workflow import (
+    WorkflowStateError,
+    get_transitions,
+    get_workflow_name,
+    get_workflow_state_field,
+    has_approval_access,
+)
+
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools import require_doctype_and_name
+
+
+def get_workflow_transitions(doctype: str, name: str) -> dict:
+    """Return the current workflow state + the actions available to the caller.
+
+    Shape when the DocType has no active workflow:
+        {"doctype", "name", "has_workflow": False}
+
+    Shape when it does:
+        {"doctype", "name", "has_workflow": True, "workflow", "state_field",
+         "current_state", "available_actions": [{"action", "next_state"}, ...]}
+
+    ``available_actions`` is filtered to what THIS user may do now (role +
+    condition + self-approval); an empty list means no forward move exists from
+    here for this user (terminal / cancelled / no-role / unset state).
+    """
+    require_doctype_and_name(doctype, name)
+
+    if not frappe.db.exists(doctype, name):
+        raise InvalidArgumentError(f"unknown {doctype}: {name}")
+
+    if not frappe.has_permission(doctype, ptype="read", doc=name):
+        raise PermissionDeniedError(f"no read permission on {doctype} {name}")
+
+    wf = get_workflow_name(doctype)
+    if not wf:
+        return {"doctype": doctype, "name": name, "has_workflow": False}
+
+    doc = frappe.get_doc(doctype, name)
+    state_field = get_workflow_state_field(wf)
+    current_state = doc.get(state_field)
+
+    base = {
+        "doctype": doctype,
+        "name": name,
+        "has_workflow": True,
+        "workflow": wf,
+        "state_field": state_field,
+    }
+
+    # A cancelled doc has no forward transitions: apply_workflow's docstatus
+    # ladder rejects docstatus 2, so surfacing any action here would list a
+    # move the write tool would always refuse.
+    if doc.docstatus == 2:
+        return {**base, "current_state": current_state or None, "available_actions": []}
+
+    try:
+        # raise_exception=True keeps the empty-state case a bare raise; the
+        # default frappe.throw()s, which first msgprints into message_log and
+        # would ride out of our ok response as a stray _server_messages.
+        transitions = get_transitions(doc, raise_exception=True)
+    except WorkflowStateError:
+        # No workflow state on the doc yet (e.g. created before the workflow was
+        # activated). Report it plainly instead of a confusing error envelope.
+        return {
+            **base,
+            "current_state": None,
+            "available_actions": [],
+            "note": "This document has no workflow state set yet.",
+        }
+
+    user = frappe.session.user
+    available = [
+        {"action": t.get("action"), "next_state": t.get("next_state")}
+        for t in transitions
+        if has_approval_access(user, doc, t)
+    ]
+    return {**base, "current_state": current_state, "available_actions": available}

--- a/jarvis/tools/registry.py
+++ b/jarvis/tools/registry.py
@@ -45,6 +45,11 @@ _TOOL_NAMES: tuple[str, ...] = (
     "cancel_doc",
     "delete_doc",
     "amend_doc",
+    # Workflow (state-machine) support: read the actions the current user may
+    # take on a doc, then apply one. apply_workflow_action is gated in api.py;
+    # submit_doc/cancel_doc refuse workflow-governed doctypes and point here.
+    "get_workflow_transitions",
+    "apply_workflow_action",
     # Tier 1 artifact producers: hand the agent a file/URL the customer
     # can act on, instead of a wall of JSON.
     "download_pdf",

--- a/jarvis/tools/submit_doc.py
+++ b/jarvis/tools/submit_doc.py
@@ -29,6 +29,7 @@ Safety bounds:
 """
 
 import frappe
+from frappe.model.workflow import get_workflow_name
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools import require_doctype_and_name
@@ -40,6 +41,7 @@ def submit_doc(doctype: str, name: str) -> dict:
     Returns the submitted document as a dict, including the new
     ``docstatus: 1``. Raises:
       - InvalidArgumentError on empty args, non-submittable DocType,
+        a workflow-governed DocType (advance via apply_workflow_action),
         or wrong starting docstatus
       - PermissionDeniedError when the calling user lacks submit on the record
       - frappe.DoesNotExistError when the record doesn't exist
@@ -52,6 +54,17 @@ def submit_doc(doctype: str, name: str) -> dict:
         raise InvalidArgumentError(
             f"{doctype} is not submittable - submit only applies to "
             f"docstatus-tracked DocTypes"
+        )
+
+    # A workflow-governed doctype must advance through its state machine, not a
+    # direct submit (which would jump the doc straight to a submitted state,
+    # skipping approval steps). Desk hides the Submit button here too.
+    if get_workflow_name(doctype):
+        raise InvalidArgumentError(
+            f"{doctype} is governed by a Workflow; advance it with "
+            f"apply_workflow_action (e.g. Approve/Reject) instead of "
+            f"submitting directly. Use get_workflow_transitions to see the "
+            f"actions available to you."
         )
 
     if not frappe.has_permission(doctype, ptype="submit", doc=name):


### PR DESCRIPTION
## What

Makes Jarvis workflow-aware: the agent can now **read and execute Frappe Workflow transitions** instead of being blind to them, and can no longer bypass a workflow with a direct submit/cancel.

- **`get_workflow_transitions(doctype, name)`** (read) — current workflow state + the actions *this user* may take next (`{action, next_state}`), filtered by roles + condition + self-approval. Wraps Frappe's own `get_transitions` + `has_approval_access`. Returns clean shapes for no-workflow, cancelled (`docstatus=2`), and unset-state docs.
- **`apply_workflow_action(doctype, name, action)`** (gated write) — wraps `frappe.model.workflow.apply_workflow`. Confirmation-gated + destructive; parks as **described-intent** (no dry-run, since `on_submit`/`on_cancel` hooks fire). Handles background-queued transitions (`{queued: true}`).
- **`submit_doc` / `cancel_doc` guards** — refuse workflow-governed doctypes and redirect to `apply_workflow_action`, so the agent can't skip approval steps. `cancel_doc` only refuses when the workflow models a cancel path (Desk parity), short-circuiting `get_workflow_name` before `can_cancel_document`.
- `_describe_call` now includes `action`, so the confirm card distinguishes **Approve** from **Reject** instead of showing an identical, ambiguous card.

## Why

Frappe DocTypes governed by a Workflow advance by applying an *action* (Approve/Reject), not by `submit()`. Previously `get_schema` could tell the model a doctype *had* a workflow, but there was no way to enumerate the valid next actions for a specific doc+user or to execute one — and `submit_doc`/`cancel_doc` bypassed the workflow entirely.

## Ships with

Companion PRs: plugin descriptors (`jarvis-openclaw-plugin`) and persona `TOOLS.md` rows. **Merge this app PR first** — an older bench + newer plugin degrades cleanly to a `ToolNotFoundError` envelope; the reverse would advertise a tool the bench can't run.

## Tests

`test_workflow_tools` — 21 tests, all green: response shape, the self-approval filter, `docstatus==2`, empty-state (`WorkflowStateError`), the no-workflow guard, the queued branch, the gating classification (`_WRITE_TOOLS`/`_GATED_WRITES`/`_DESTRUCTIVE`, not `_PREVIEWABLE`/`_DRY_RUN_ON_PARK`/`_AUTO_APPLYABLE`), described-intent parking, and the confirm-card summary carrying the action. Existing `submit_doc`/`cancel_doc` suites still green.

Two-round Fable design review of the plan, plus a Fable code review verified against the real Frappe engine and a rolled-back live e2e (READ shape, Approve advances state, terminal → `[]`, invalid action → `WorkflowTransitionError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
