### PR TITLE
Security review Part 1: chat permission hardening + reviewer-path fix

### DIFF
--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -215,7 +215,7 @@
 // share this component (isNew prop). Explicit Save (D21) with dirty guard,
 // read-only mode for shared-with-me skills, DocMetaPanel + child-table
 // Shared-with block (#extra) + ShareDialog, sync pill on save/delete.
-import { ref, reactive, computed, watch, shallowRef, nextTick } from "vue"
+import { ref, reactive, computed, watch, shallowRef, nextTick, onMounted } from "vue"
 import { useRouter, onBeforeRouteLeave } from "vue-router"
 import {
 	Button,
@@ -235,6 +235,7 @@ import CommentsSection from "@/components/doc/CommentsSection.vue"
 import { useDocmeta } from "@/composables/useDocmeta"
 import SyncPill from "./SyncPill.vue"
 import ShareDialog from "./ShareDialog.vue"
+import { getSkillsAreaCaps } from "@/api/personalise"
 import { renderMarkdown } from "@/markdown"
 import { timeAgo } from "@/utils/datetime"
 import { useJarvisTheme } from "@/theme"
@@ -276,6 +277,20 @@ const docmeta = shallowRef(null) // useDocmeta instance (own skills only)
 const shares = ref([]) // [{name, full_name}]
 const shareOpen = ref(false)
 const syncPill = ref(null)
+
+// Only a reviewer/admin may push the shared container (apply is reviewer-gated -
+// security review PART 2 TASK 12). New skills default to private (User) scope
+// and are NEVER pushed, so for an ordinary user apply-on-save is both pointless
+// and a hard 403 (a scary red toast). Gate every apply on this signal.
+const isReviewer = ref(false)
+onMounted(async () => {
+	try {
+		const caps = await getSkillsAreaCaps()
+		isReviewer.value = !!(caps && caps.review)
+	} catch {
+		isReviewer.value = false
+	}
+})
 
 const canEdit = computed(() => props.isNew || !!(skill.value && skill.value.can_edit))
 const readonly = computed(() => !canEdit.value || saving.value)
@@ -395,7 +410,9 @@ async function save() {
 			const res = (await api.createCustomSkill(payload)) || {}
 			const newName = (res.data && res.data.name) || ""
 			snapshot.value = { ...form } // clean before navigating (leave guard)
-			syncPill.value && syncPill.value.apply() // saving updates the assistant
+			// Reviewers only: a new skill is private (User) scope and never pushed,
+			// so ordinary users need no apply (and would 403 on the gated endpoint).
+			if (isReviewer.value) syncPill.value && syncPill.value.apply()
 			toast.success("Saved")
 			if (newName) router.replace("/skills/" + newName)
 		} else {
@@ -407,7 +424,8 @@ async function save() {
 			await api.updateCustomSkill({ name: props.id, ...changed })
 			snapshot.value = { ...form }
 			skill.value = { ...skill.value, ...payload }
-			syncPill.value && syncPill.value.apply()
+			// Reviewers only (see create branch): the shared push is reviewer-gated.
+			if (isReviewer.value) syncPill.value && syncPill.value.apply()
 			toast.success("Saved")
 		}
 	} catch (e) {
@@ -424,8 +442,9 @@ function confirmDelete() {
 		onConfirm: async ({ hideDialog }) => {
 			try {
 				await api.deleteCustomSkill(props.id)
-				// reconcile the container; the list's pill picks up the pending state
-				await api.applyCustomSkills().catch(() => {})
+				// reconcile the container only for reviewers (apply is gated); a
+				// deleted private skill never affected the shared push anyway.
+				if (isReviewer.value) await api.applyCustomSkills().catch(() => {})
 				bypassGuard = true
 				hideDialog()
 				toast.success("Skill deleted")

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -13,6 +13,7 @@ the receipt, so the agent stages the plan's next step without the user typing
 """
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 
 from jarvis import audit
@@ -53,6 +54,7 @@ def _child_columns(child_doctype: str) -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_doctype_form_meta(doctype: str) -> dict:
 	"""Form metadata for the draft panel: main fields INCLUDING Table fields,
 	plus per-table child columns - one call, so the panel never fans out.
@@ -89,6 +91,7 @@ def get_doctype_form_meta(doctype: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def load_doc(doctype: str, name: str) -> dict:
 	"""Current values of one document (main fields + child rows restricted to
 	the form-meta columns) so the panel can pre-fill an update draft. Gated on
@@ -167,6 +170,7 @@ def _append_receipt(conversation: str, verb: str, doctype: str, name: str,
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def apply_action(action: dict | str | None = None) -> dict:
 	"""Apply a human-authored draft-panel edit: create or update ONLY, with the
 	values the human deliberately entered before applying. Runs as the session
@@ -283,6 +287,7 @@ _INVALID_CONFIRM = {
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	"""Execute a parked mutating tool call after the human clicked Confirm.
 
@@ -393,6 +398,7 @@ def _confirm_receipt_text(record: dict, result) -> str:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_pending_confirmations(conversation: str | None = None) -> dict:
 	"""Re-surface the caller's OWN currently-parked confirmation cards after a
 	reload/reconnect (issue #186, enables R3's fix for #3).

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -170,12 +170,18 @@ def _launch_audit(inst, trigger: str) -> dict:
 	)
 
 	# O3: dispatch as an unattended background turn (interactive=False) so it
-	# never jumps ahead of a human's queued question.
-	result = api.send_message(
-		conversation=conv.name,
-		message=_audit_prompt(listing, inst, trigger),
-		background=1,
-	)
+	# never jumps ahead of a human's queued question. delegated_send() marks
+	# this as a trusted server re-entry so send_message's Jarvis-access gate
+	# (and the now role-gated Message create perm) accept it even when the
+	# impersonated owner does not hold the Jarvis User role.
+	from jarvis.permissions import delegated_send
+
+	with delegated_send():
+		result = api.send_message(
+			conversation=conv.name,
+			message=_audit_prompt(listing, inst, trigger),
+			background=1,
+		)
 	if not result.get("ok"):
 		raise RuntimeError(f"send_message refused: {result.get('reason')}")
 	return {"run": run.name, "conversation": conv.name}

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -14,6 +14,7 @@ Enable / schedule are pure DB writes (no container restart — O6); only Apply
 """
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 
 from jarvis._session import impersonate
@@ -86,6 +87,7 @@ def _allowed_roles_map() -> dict[str, list[str]]:
 # catalog + install state (read)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def list_agents() -> list[dict]:
 	"""The full catalog plus THIS owner's install/enable/schedule state per
 	agent. Read-only — the catalog is visible to every logged-in user. Each row
@@ -158,6 +160,7 @@ def _enriched_catalog() -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_agents_page(
 	tab: str = "available",
 	category: str | None = None,
@@ -225,6 +228,7 @@ def list_agents_page(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_agent(agent_slug: str) -> dict:
 	"""One listing + the CURRENT user's installation for the agent detail page
 	(DESIGN-V3 §8.3 / D39). Any authenticated user may read (listing perms =
@@ -290,6 +294,7 @@ def get_agent(agent_slug: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_installations() -> list[dict]:
 	"""This owner's installations, with the linked listing title/nature/status."""
 	me = frappe.session.user
@@ -452,6 +457,7 @@ def _mark_catalog_dirty() -> None:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def install_agent(agent_slug: str) -> dict:
 	"""Install a Published agent for the current user. The doctype validate()
 	enforces the per-owner cap + (owner, agent) uniqueness. Role-gated: a user
@@ -699,6 +705,7 @@ def _count(doctype: str, filters: dict, or_filters: list | None = None) -> int:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_runs(agent: str | None = None, limit: int = 50) -> list[dict]:
 	"""This owner's run history (optionally filtered to one agent)."""
 	me = frappe.session.user
@@ -719,6 +726,7 @@ def list_runs(agent: str | None = None, limit: int = 50) -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_runs_page(
 	agent: str | None = None,
 	status: str | None = None,
@@ -771,6 +779,7 @@ def list_runs_page(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_findings(
 	run: str | None = None,
 	state: str | None = None,
@@ -883,6 +892,7 @@ def set_finding_state(finding: str, state: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_agent_activity_page(
 	agent: str | None = None,
 	action: str | None = None,
@@ -985,6 +995,7 @@ def take_finding_to_chat(finding: str) -> dict:
 # Apply (explicit push to the container, via admin -> fleet) + status poller
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def get_agents_sync_status() -> dict:
 	"""Lightweight poller mirroring get_custom_skills_sync_status."""
 	s = frappe.get_single(_SETTINGS)
@@ -1000,6 +1011,7 @@ def get_agents_sync_status() -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def apply_agents() -> dict:
 	"""Push all ENABLED installed agent bundles to the container (one restart).
 	Explicit action. Builds the payload synchronously (surfaces size/cap errors

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -10,7 +10,11 @@ from urllib.parse import quote
 
 import frappe
 
-from jarvis.permissions import require_jarvis_access
+from jarvis.permissions import (
+	has_jarvis_access,
+	require_jarvis_access,
+	require_jarvis_user,
+)
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
@@ -376,6 +380,7 @@ def _search_records(search: str, limit: int) -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def search_workspace(search: str = "", limit: int = 6) -> dict:
 	"""Full desk search over the caller's Frappe desk for the ⌘K palette,
 	delegated entirely to Frappe's own search (no bespoke matcher):
@@ -755,13 +760,21 @@ def send_message(
 	frappe.DoesNotExistError if the conversation does not exist, or
 	frappe.PermissionError if the caller is not the owner.
 	"""
-	# NO require_jarvis_access() here: send_message is invoked under
-	# frappe.set_user(owner) by delegated/system flows (agent_scheduler,
-	# approvals resume), where the impersonated owner may not hold the role — a
-	# gate here would silently break those resumes. It is already owner-only
-	# (SEC-002, validate_can_send below), and reaching it requires a conversation
-	# created through the gated create_* endpoints; human access is enforced at
-	# the SPA route + desk page.
+	# Access gate (PART 1 TASK 1). send_message is ALSO invoked under
+	# impersonate(owner) by delegated/system flows (agent_scheduler, approvals
+	# resume, agent-run, File-Box drop), where the impersonated owner may not
+	# hold the Jarvis User role — those flows mark themselves with
+	# ``delegated_send()`` (a frappe.flags signal a browser POST cannot forge).
+	# A human caller must actually hold Jarvis access; do NOT infer access from
+	# conversation ownership (a conversation can be REST-inserted). The ORM now
+	# also requires the role to insert a conversation/message, so this is the
+	# explicit, clean-error front of a defense-in-depth pair.
+	_delegated = bool(frappe.flags.get("jarvis_delegated_send"))
+	if not (_delegated or has_jarvis_access()):
+		frappe.throw(
+			_("You need the Jarvis User role to use Jarvis."),
+			frappe.PermissionError,
+		)
 	t0 = time.monotonic()
 	user = frappe.session.user
 
@@ -851,6 +864,13 @@ def send_message(
 		"streaming": 0,
 		"canvas": canvas_json,
 	})
+	# Delegated re-entry (scheduler/approval-resume/agent-run/File-Box): the
+	# impersonated owner may lack the now role-gated Message create perm, but
+	# ownership of THIS conversation is already asserted (_get_owned_conversation
+	# above), so the trusted server path inserts the seed message directly. The
+	# controller validate() cross-link check also honours ignore_permissions.
+	if _delegated:
+		msg_doc.flags.ignore_permissions = True
 	msg_doc.insert()
 
 	# Title is NOT taken from the raw first message anymore. The worker
@@ -866,6 +886,8 @@ def send_message(
 	# worker creates it on its pooled connection and inserts the Jarvis Chat
 	# Session row BEFORE streaming starts (2026-07 latency plan, Phase 1.1).
 	first_turn = 1 if not conv_doc.session_key else 0
+	if _delegated:
+		conv_doc.flags.ignore_permissions = True
 	conv_doc.save()
 	frappe.db.commit()
 

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 
 from jarvis._session import impersonate
 
@@ -43,6 +44,7 @@ def _may_act_on(conversation: str | None) -> bool:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_approvals(status: str = "Pending", limit: int = 50) -> list[dict]:
 	"""Approvals visible to the current user (owner of the linked
 	conversation, or any System Manager)."""
@@ -146,6 +148,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_approvals_page(
 	search: str = "",
 	filters: str | dict | None = None,
@@ -378,6 +381,7 @@ def get_approval(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def pending_count() -> int:
 	# Scoped like list_approvals_page: non-SM users count rows whose
 	# conversation they own OR that carry an approval-level DocShare read grant
@@ -497,7 +501,13 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 				# impersonate is session-safe (a bare frappe.set_user in this
 				# HTTP path would gut the approver's cookie session and log them
 				# out) and no-ops when switch_to is None (self-owned resume).
-				with impersonate(switch_to):
+				# delegated_send() marks this as a trusted server re-entry so the
+				# resume clears send_message's Jarvis-access gate and the now
+				# role-gated Message create perm even when the conversation owner
+				# does not hold the Jarvis User role.
+				from jarvis.permissions import delegated_send
+
+				with impersonate(switch_to), delegated_send():
 					res = send_message(
 						conversation=doc.conversation, message=msg, attachments=attachments)
 				resumed = bool(res.get("ok"))

--- a/jarvis/chat/chat_permissions.py
+++ b/jarvis/chat/chat_permissions.py
@@ -1,0 +1,197 @@
+"""Row-level ownership scoping for the Jarvis chat doctypes (Jarvis
+Conversation, Jarvis Chat Message, Jarvis Approval Request, Jarvis Voice
+Note).
+
+This is the data-layer twin of ``jarvis/chat/wiki_permissions.py``: list /
+report / generic-REST queries are scoped via the ``permission_query_conditions``
+hook, and per-doc read/write/create/delete via the ``has_permission`` hook -
+both registered in ``hooks.py``. Together with putting the ``Jarvis User`` role
+(not ``role: "All"``) on the doctype permission rows, this closes the
+REST-insert bypass and the cross-user injection at the ORM, so *every* endpoint
+(current and future) and stock ``/api/resource`` / ``frappe.client.*`` inherit
+owner scoping automatically instead of relying on a hand-rolled owner check in
+each whitelisted function.
+
+Ownership axes (deliberately NOT uniform - each doctype's real owner differs):
+
+  * Jarvis Conversation   -> the row's own ``owner`` (the chat user). Matches
+    the ``if_owner`` perm rule that also stays on the doctype.
+  * Jarvis Chat Message   -> the owner of the LINKED conversation, never the
+    message row's own owner. Assistant / tool / system rows are inserted by the
+    worker or tool dispatcher (as the impersonated owner or Administrator), so
+    the row owner is not a reliable authority; ``api.get_conversation``
+    deliberately treats the conversation owner as the single source of truth.
+  * Jarvis Approval Request -> owner of the linked conversation OR a DocShare
+    read grant on the approval itself (mirrors ``approvals_api``'s EXISTS
+    probes: a tagged user may READ/view on the board, only the owner or a
+    System Manager may ACT). System Manager sees all (oversight; existing SM
+    perm row).
+  * Jarvis Voice Note     -> the row's own ``owner``; System Manager gets
+    org-wide READ (the Business-tab processing view; existing SM perm row).
+
+Server context: assistant / tool / system rows and the API-layer inserts are
+written with ``insert(ignore_permissions=True)`` (often under
+``impersonate(owner)``), so the ``has_permission`` hook is never consulted for
+them. The controller ``validate`` cross-link checks (message->conversation,
+voice->conversation) additionally skip when ``self.flags.ignore_permissions``
+is set. ``Administrator`` bypasses Frappe perms entirely (the hook is not even
+called for it), but every function guards for it defensively.
+
+NOTE (hooks can only DENY): on this Frappe version a falsy ``has_permission``
+return (``None`` included) denies, so every allow path returns an explicit
+``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+CONVERSATION = "Jarvis Conversation"
+MESSAGE = "Jarvis Chat Message"
+APPROVAL = "Jarvis Approval Request"
+VOICE_NOTE = "Jarvis Voice Note"
+
+# ptypes that reveal a row's content; everything read-shaped maps to visibility.
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	# Administrator's get_roles returns every Role; the explicit check is a
+	# shortcut so both spellings of "full access" land here.
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def _conversation_owner(conversation) -> str | None:
+	if not conversation:
+		return None
+	return frappe.db.get_value(CONVERSATION, conversation, "owner")
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Conversation - the row's own owner is the axis (matches ``if_owner``).
+# --------------------------------------------------------------------------- #
+def conversation_query_conditions(user: str | None = None) -> str:
+	"""Scope every list/report/REST query on Jarvis Conversation to the caller's
+	own rows. Administrator is unrestricted; System Manager sees only its own
+	conversations (unchanged from the pre-fix ``All`` + ``if_owner`` rule - we do
+	NOT expand SM to org-wide private chats)."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+	return f"`tabJarvis Conversation`.`owner` = {frappe.db.escape(user)}"
+
+
+def has_conversation_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return True
+	if ptype == "create":
+		# ``owner`` is assigned by Frappe during insert; the role + ``if_owner``
+		# rule governs create (creator == owner trivially). Enforcing owner here
+		# would race the owner assignment. Reads/writes/deletes of EXISTING rows
+		# are gated below.
+		return True
+	return doc.get("owner") == user
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Chat Message - the LINKED conversation's owner is the axis.
+# --------------------------------------------------------------------------- #
+def message_query_conditions(user: str | None = None) -> str:
+	"""Scope Jarvis Chat Message queries to rows whose linked conversation the
+	caller owns (a subquery on ``tabJarvis Conversation`` - the message row's own
+	owner is deliberately NOT the authority). Administrator is unrestricted."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return ""
+	esc = frappe.db.escape(user)
+	return (
+		"exists (select 1 from `tabJarvis Conversation` c "
+		"where c.name = `tabJarvis Chat Message`.`conversation` "
+		f"and c.owner = {esc})"
+	)
+
+
+def has_message_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate for Jarvis Chat Message: read/write/create/delete all require
+	owning the LINKED conversation. This is the primary control that blocks the
+	cross-user injection (inserting a message with ``conversation`` = another
+	user's id) at the ORM, so it covers generic REST too."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return True
+	return _conversation_owner(doc.get("conversation")) == user
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Approval Request - linked-conversation owner OR DocShare read grant.
+# --------------------------------------------------------------------------- #
+def approval_query_conditions(user: str | None = None) -> str:
+	"""Scope Jarvis Approval Request queries exactly like ``approvals_api``'s
+	list: the caller owns the linked conversation, OR holds a DocShare read grant
+	on the approval (tagging). System Manager (and Administrator) see all."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	esc = frappe.db.escape(user)
+	return (
+		"(exists (select 1 from `tabJarvis Conversation` c "
+		"where c.name = `tabJarvis Approval Request`.`conversation` "
+		f"and c.owner = {esc}) "
+		"or exists (select 1 from `tabDocShare` ds "
+		"where ds.share_doctype = 'Jarvis Approval Request' "
+		"and ds.share_name = `tabJarvis Approval Request`.`name` "
+		f"and ds.user = {esc} and ds.`read` = 1))"
+	)
+
+
+def has_approval_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate for Jarvis Approval Request. System Manager: all. Owner of the
+	linked conversation: full. A DocShare-read holder: READ only (view on the
+	board, ``can_act=0`` - mirrors ``get_approval`` vs ``decide``). Create of a
+	row that names another user's conversation is denied (cross-inject guard),
+	but a conversation-less agent approval is allowed."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	owner = _conversation_owner(doc.get("conversation"))
+	if ptype == "create":
+		# Block injecting an approval into another user's conversation; a row
+		# with no conversation (agent-internal) is allowed, gated by the role.
+		return owner is None or owner == user
+	if owner == user:
+		return True
+	# Non-owner may only READ a row explicitly shared to them.
+	if ptype in _READ_PTYPES:
+		return bool(
+			frappe.db.exists(
+				"DocShare",
+				{
+					"share_doctype": APPROVAL,
+					"share_name": doc.get("name"),
+					"user": user,
+					"read": 1,
+				},
+			)
+		)
+	return False
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Voice Note - the row's own owner is the axis; SM gets org-wide read.
+# --------------------------------------------------------------------------- #
+def voice_note_query_conditions(user: str | None = None) -> str:
+	"""Scope Jarvis Voice Note queries to the caller's own notes. System Manager
+	(and Administrator) get org-wide READ - the Business-tab processing view;
+	the existing SM perm row is read-only, so this never widens SM write."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tabJarvis Voice Note`.`owner` = {frappe.db.escape(user)}"
+
+
+def has_voice_note_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	return doc.get("owner") == user

--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -250,9 +250,10 @@ def personal_skill_clause(user: str | None = None) -> str:
 	count = cache.get_value(key)
 	if count is None:
 		# Exact scope match: NULL/empty scope rows are Org and never counted.
+		# "User" is the scope-ladder spelling of the old "Personal" (TASK 10).
 		count = frappe.db.count(
 			"Jarvis Custom Skill",
-			{"owner": user, "enabled": 1, "scope": "Personal"},
+			{"owner": user, "enabled": 1, "scope": "User"},
 		)
 		cache.set_value(key, int(count or 0), expires_in_sec=PERSONAL_CLAUSE_TTL_S)
 	try:
@@ -281,10 +282,21 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	only to scope tests). An empty list is a valid "remove all custom skills"
 	reconcile.
 
-	Personal-scope rows are EXCLUDED: they exist only for their owner (reached
-	via the find_skills/get_skill tools), never for the shared container
-	catalog, and must not eat into the 25-skill push budget. NULL/empty scope
-	(pre-migration rows) means Org and IS pushed.
+	User- AND Role-scope rows are EXCLUDED: User rows exist only for their owner
+	(reached via the find_skills/get_skill tools) and Role rows only for
+	role-holders; neither belongs in the shared container catalog nor may eat
+	into the 25-skill push budget. NULL/empty scope (pre-migration rows) means
+	Org and IS pushed.
+
+	Role-restricted bodies are kept off the shared blob (security review PART 2
+	TASK 11): an Org row narrowed by ``allowed_roles`` is a role-restricted skill
+	whose full instructions would otherwise be physically written to the shared,
+	role-BLIND container and be readable + auto-activatable by every user's agent
+	(a mass-exfil vector). So this push carries ONLY skills visible to EVERYONE —
+	Org scope with NO ``allowed_roles``. Role-restricted skills stay reachable via
+	the role-gated ``jarvis__find_skills`` / ``jarvis__get_skill`` tools; restoring
+	their /slug container activation needs a per-role workspace mount in the
+	fleet-agent (a follow-up outside the bench).
 
 	Managed learned rows (``managed_by_learning=1``) are EXCLUDED: since the
 	Phase-2 learned namespace they ride their own push
@@ -306,7 +318,7 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	  ``frappe.log_error`` a loud warning naming the dropped slugs, so the
 	  truncation is never silent again.
 	"""
-	# ("in", ("Org", "")) — not ("!=", "Personal") — because db_query wraps the
+	# ("in", ("Org", "")) — not ("!=", "User") — because db_query wraps the
 	# "in" operator in ifnull(scope, ''), so legacy NULL-scope rows match ''.
 	filters = {"enabled": 1, "managed_by_learning": 0, "scope": ("in", ("Org", ""))}
 	if owner:
@@ -314,9 +326,23 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	rows = frappe.get_all(
 		"Jarvis Custom Skill",
 		filters=filters,
-		fields=["skill_name", "description", "user_invocable", "instructions"],
+		fields=["name", "skill_name", "description", "user_invocable", "instructions"],
 		order_by="skill_name asc",
 	)
+	# TASK 11: drop role-restricted Org rows (any with allowed_roles) so a
+	# role-scoped body is never written to the shared, role-blind container.
+	restricted = {
+		r.parent
+		for r in frappe.get_all(
+			"Jarvis Custom Skill Allowed Role",
+			filters={
+				"parenttype": "Jarvis Custom Skill",
+				"parent": ["in", [r.name for r in rows] or [""]],
+			},
+			fields=["parent"],
+		)
+	}
+	rows = [r for r in rows if r.name not in restricted]
 	if len(rows) > MAX_SKILLS_PER_PUSH:
 		if strict:
 			frappe.throw(

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -13,6 +13,7 @@ and flip the status to a terminal ``ok ...`` / ``failed: ...`` the SPA polls.
 """
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 
 from jarvis.chat.custom_skills import build_push_payload
@@ -44,6 +45,7 @@ def _skill_names_shared_with(user: str) -> list[str]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_custom_skills() -> list[dict]:
 	"""The current user's own skills PLUS skills shared with them (read-only).
 
@@ -170,6 +172,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_custom_skills_page(
 	search: str = "",
 	filters: str | dict | None = None,
@@ -264,6 +267,7 @@ def list_custom_skills_page(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_custom_skill(name: str) -> dict:
 	"""Return one skill incl. the full markdown instructions. Readable by the
 	owner (editable) or a user it's shared with (read-only). ``can_edit`` tells
@@ -288,6 +292,7 @@ def get_custom_skill(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def create_custom_skill(
 	skill_name: str,
 	description: str,
@@ -296,6 +301,24 @@ def create_custom_skill(
 	enabled: int = 1,
 ) -> dict:
 	"""Create a skill. Validation (slug/caps) runs in the doctype's validate()."""
+	return _create_custom_skill_impl(
+		skill_name, description, instructions, user_invocable, enabled
+	)
+
+
+def _create_custom_skill_impl(
+	skill_name: str,
+	description: str,
+	instructions: str,
+	user_invocable: int = 1,
+	enabled: int = 1,
+) -> dict:
+	"""Undecorated core of :func:`create_custom_skill`. Split out so a trusted
+	server caller already authorized by its own gate can create a skill without
+	re-tripping the ``@require_jarvis_user`` HTTP gate on the wrapper: the reviewer
+	insight-apply path (``learned_api._apply_create_target``) is gated on
+	``_REVIEWER_ROLES``, which admits a Jarvis Skill Reviewer / Jarvis Admin who
+	holds neither Jarvis User nor System Manager."""
 	doc = frappe.get_doc(
 		{
 			"doctype": SKILL,
@@ -312,6 +335,7 @@ def create_custom_skill(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def update_custom_skill(
 	name: str,
 	skill_name: str | None = None,
@@ -338,6 +362,7 @@ def update_custom_skill(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_custom_skill(name: str) -> dict:
 	"""Delete a skill row (owner-gated). The delete only propagates to the
 	container on the next Apply (the fleet endpoint does a full reconcile)."""
@@ -347,6 +372,7 @@ def delete_custom_skill(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_custom_skills_bulk(names: str | list | None = None) -> dict:
 	"""Bulk delete skills the caller OWNS (DESIGN-V3 §8.3 / D20). ``names`` is a
 	JSON array of skill row-names. Per-row try/except so one bad row never
@@ -388,6 +414,7 @@ def delete_custom_skills_bulk(names: str | list | None = None) -> dict:
 # use — they cannot edit, disable, delete, or re-share it)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def list_shareable_users() -> list[dict]:
 	"""Users the current user can share a skill with (staff on this bench,
 	excluding self + Guest). Feeds the share multiselect."""
@@ -402,6 +429,7 @@ def list_shareable_users() -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_skill_shares(name: str) -> dict:
 	"""Return who a skill is currently shared with (owner only)."""
 	doc = frappe.get_doc(SKILL, name)
@@ -442,8 +470,18 @@ def share_custom_skill(name: str, users: str | list | None = None) -> dict:
 # Apply (explicit push to the container, via admin → fleet)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def get_custom_skills_sync_status() -> dict:
 	"""Lightweight poller mirroring onboarding.get_llm_sync_status."""
+	return _custom_sync_status()
+
+
+def _custom_sync_status() -> dict:
+	"""Undecorated core of :func:`get_custom_skills_sync_status`. Split out so the
+	reviewer Apply board (``learned_api._cutover_custom_sync_status``, reached from
+	``get_learned_apply_status`` under ``_REVIEWER_ROLES``) can read the custom sync
+	pair without tripping the ``@require_jarvis_user`` HTTP gate — a read of two
+	``Jarvis Settings`` fields the reviewer is already authorized to see."""
 	s = frappe.get_single(_SETTINGS)
 	status = s.get("custom_skills_sync_status") or ""
 	return {
@@ -454,6 +492,7 @@ def get_custom_skills_sync_status() -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def apply_custom_skills() -> dict:
 	"""Push all enabled skills to the assistant (one restart). Explicit action.
 

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -34,6 +34,22 @@ def _full_name(user: str) -> str:
 	return frappe.db.get_value("User", user, "full_name") or user
 
 
+def _require_skill_owner(doc, action: str = "modify") -> None:
+	"""Raise a CLEAR PermissionError unless the caller owns the skill (or is a
+	System Manager / Administrator — matching skill_permissions.has_skill_permission
+	write rule). The ORM hook denies a non-owner write anyway, but the framework's
+	generic message is opaque; the user-facing SPA write endpoints surface this
+	instead (security review PART 2 TASK E1)."""
+	me = frappe.session.user
+	if me == "Administrator" or (doc.get("owner") or "") == me:
+		return
+	if "System Manager" in frappe.get_roles(me):
+		return
+	frappe.throw(
+		_("You can only {0} your own skills.").format(action), frappe.PermissionError
+	)
+
+
 def _skill_names_shared_with(user: str) -> list[str]:
 	"""Skill row-names shared with ``user`` (child-table lookup, perm-free)."""
 	return [
@@ -312,24 +328,34 @@ def _create_custom_skill_impl(
 	instructions: str,
 	user_invocable: int = 1,
 	enabled: int = 1,
+	scope: str | None = None,
+	ignore_permissions: bool = False,
 ) -> dict:
 	"""Undecorated core of :func:`create_custom_skill`. Split out so a trusted
 	server caller already authorized by its own gate can create a skill without
 	re-tripping the ``@require_jarvis_user`` HTTP gate on the wrapper: the reviewer
 	insight-apply path (``learned_api._apply_create_target``) is gated on
 	``_REVIEWER_ROLES``, which admits a Jarvis Skill Reviewer / Jarvis Admin who
-	holds neither Jarvis User nor System Manager."""
-	doc = frappe.get_doc(
-		{
-			"doctype": SKILL,
-			"skill_name": skill_name,
-			"description": description,
-			"instructions": instructions,
-			"user_invocable": int(user_invocable or 0),
-			"enabled": int(enabled or 0),
-		}
-	)
-	doc.insert()
+	holds neither Jarvis User nor System Manager.
+
+	``scope`` is only accepted from trusted server callers (the reviewer
+	insight-apply passes ``scope="Org"``); a blank scope defaults to User
+	(private-first — security review PART 2 TASK 10). ``ignore_permissions``
+	skips the doctype create-perm check for reviewer callers who may lack the
+	Jarvis User role that the doctype now requires (the controller's own scope
+	guard still runs and admits them as reviewers)."""
+	fields = {
+		"doctype": SKILL,
+		"skill_name": skill_name,
+		"description": description,
+		"instructions": instructions,
+		"user_invocable": int(user_invocable or 0),
+		"enabled": int(enabled or 0),
+	}
+	if scope:
+		fields["scope"] = scope
+	doc = frappe.get_doc(fields)
+	doc.insert(ignore_permissions=bool(ignore_permissions))
 	frappe.db.commit()
 	return {"ok": True, "data": {"name": doc.name, "skill_name": doc.skill_name}}
 
@@ -346,6 +372,7 @@ def update_custom_skill(
 ) -> dict:
 	"""Update provided fields of a skill (owner-gated)."""
 	doc = frappe.get_doc(SKILL, name)
+	_require_skill_owner(doc, "edit")
 	if skill_name is not None:
 		doc.skill_name = skill_name
 	if description is not None:
@@ -366,7 +393,8 @@ def update_custom_skill(
 def delete_custom_skill(name: str) -> dict:
 	"""Delete a skill row (owner-gated). The delete only propagates to the
 	container on the next Apply (the fleet endpoint does a full reconcile)."""
-	frappe.delete_doc(SKILL, name)  # honors if_owner permission
+	_require_skill_owner(frappe.get_doc(SKILL, name), "delete")
+	frappe.delete_doc(SKILL, name)  # ORM hook also enforces owner-only delete
 	frappe.db.commit()
 	return {"ok": True}
 
@@ -404,8 +432,15 @@ def delete_custom_skills_bulk(names: str | list | None = None) -> dict:
 			)
 			skipped.append({"name": n, "reason": "error"})
 	frappe.db.commit()
+	# Only a reviewer's delete reconciles the shared catalog (TASK 12): a plain
+	# Jarvis User's rows are User/Role-scope and never in the shared push, so
+	# their delete changes nothing there and must not trigger a bench-wide
+	# restart. A reviewer deleting an Org skill DOES need the reconcile.
 	if deleted:
-		apply_custom_skills()
+		from jarvis.permissions import is_skill_reviewer
+
+		if is_skill_reviewer(me):
+			_apply_custom_skills_impl()
 	return {"deleted": deleted, "skipped": skipped}
 
 
@@ -467,6 +502,217 @@ def share_custom_skill(name: str, users: str | list | None = None) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# Scope promotion (User -> Role -> Org) — reviewer-gated widening workflow
+# (security review PART 2 TASK 10, mirrors the wiki promotion machinery).
+# --------------------------------------------------------------------------- #
+PROMO = "Jarvis Skill Promotion Request"
+_SCOPE_RANK = {"User": 0, "Personal": 0, "Role": 1, "Org": 2}
+
+
+def _notify_skill_reviewers(request_name: str | None = None) -> None:
+	"""Best-effort nudge to the skill-reviewer set that a promotion request
+	landed. Carries the request name so the reviewer client can deep-link to it.
+	Never breaks the request on failure."""
+	try:
+		from frappe.utils.user import get_users_with_role
+		from jarvis.chat.events import publish_to_user
+		from jarvis.permissions import JARVIS_REVIEWER_ROLES
+
+		users: set = set()
+		for role in JARVIS_REVIEWER_ROLES:
+			try:
+				users |= set(get_users_with_role(role))
+			except Exception:
+				pass
+		payload = {"kind": "review:pending", "queue": "skill_promotion"}
+		if request_name:
+			payload["request"] = request_name
+		for u in sorted(users):
+			if u and u not in ("Administrator", "Guest"):
+				publish_to_user(u, payload)
+	except Exception:
+		pass
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def request_skill_promotion(
+	name: str, to_scope: str, target_role: str = "", note: str = ""
+) -> dict:
+	"""Ask a reviewer to widen one of the caller's OWN skills up the scope ladder
+	(User->Role->Org). Files a Pending ``Jarvis Skill Promotion Request`` and
+	pings the reviewer set — the skill itself is untouched; promotion is a
+	request, never a self-service scope switch (the controller's scope guard
+	rejects a self-service widen anyway)."""
+	me = frappe.session.user
+	doc = frappe.get_doc(SKILL, name)
+	if doc.owner != me and me != "Administrator":
+		frappe.throw(_("You can only promote your own skills."), frappe.PermissionError)
+	if doc.get("managed_by_learning"):
+		frappe.throw(_("Learned skills are managed by the learning board, not promotion."))
+
+	from_scope = (doc.scope or "Org").strip() or "Org"
+	if from_scope == "Personal":
+		from_scope = "User"
+	to_scope = (to_scope or "").strip()
+	if to_scope not in ("Role", "Org"):
+		frappe.throw(_("Promotion target must be Role or Org."))
+	if _SCOPE_RANK.get(to_scope, 0) <= _SCOPE_RANK.get(from_scope, 0):
+		frappe.throw(_("Promotion can only widen a skill's scope."))
+	target_role = (str(target_role).strip() if target_role else "") or None
+	if to_scope == "Role" and not target_role:
+		frappe.throw(_("Promoting to Role scope needs a target role."))
+
+	req = frappe.get_doc({
+		"doctype": PROMO,
+		"skill": doc.name,
+		"skill_name": doc.skill_name,
+		"from_scope": from_scope,
+		"to_scope": to_scope,
+		"target_role": target_role if to_scope == "Role" else None,
+		"note": (note or "").strip()[:140] or None,
+		"status": "Pending",
+	})
+	req.insert(ignore_permissions=True)
+	frappe.db.commit()
+	_notify_skill_reviewers(req.name)
+	return {"ok": True, "request": req.name, "skill": doc.skill_name}
+
+
+@frappe.whitelist()
+def decide_skill_promotion(request_name: str, approve: int | str, note: str = "") -> dict:
+	"""Approve or reject a skill promotion request. Reviewer-gated
+	(``require_skill_reviewer``) + four-eyes (a reviewer cannot approve their own
+	request). On approve, widen the skill's scope in place under the reviewer's
+	authority (``ignore_permissions``; the controller ``_guard_scope_change``
+	admits a reviewer). TOCTOU-safe: the status is re-read under a row lock, and
+	the widening is re-validated against the LIVE skill scope, so two concurrent
+	approvals can't double-apply. The promoted Org skill joins the shared catalog
+	on the next explicit Apply (never auto-pushed here)."""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	reviewer = frappe.session.user
+	req = frappe.get_doc(PROMO, request_name)
+	if reviewer == (req.owner or "") and reviewer != "Administrator":
+		frappe.throw(
+			_("You cannot approve your own promotion request; another reviewer must decide it."),
+			frappe.PermissionError,
+		)
+	status = frappe.db.get_value(PROMO, request_name, "status", for_update=True)
+	if status != "Pending":
+		return {"ok": False, "reason": _("Already {0}.").format((status or "").lower())}
+
+	approved = str(approve).strip().lower() in ("1", "true", "yes", "on")
+	out: dict = {"ok": True, "status": "Approved" if approved else "Rejected"}
+	if approved:
+		skill = frappe.get_doc(SKILL, req.skill)
+		live = (skill.scope or "Org").strip() or "Org"
+		if live == "Personal":
+			live = "User"
+		if _SCOPE_RANK.get(req.to_scope, 0) <= _SCOPE_RANK.get(live, 0):
+			frappe.throw(_("The skill is already at or above the requested scope."))
+		skill.scope = req.to_scope
+		skill.target_role = req.target_role if req.to_scope == "Role" else None
+		skill.save(ignore_permissions=True)
+		out["skill"] = skill.skill_name
+
+	req.status = "Approved" if approved else "Rejected"
+	req.reviewer = reviewer
+	req.decided_at = frappe.utils.now_datetime()
+	req.decision_note = (note or "").strip()[:140] or None
+	req.save(ignore_permissions=True)
+	frappe.db.commit()
+	return out
+
+
+_PROMO_STATUSES = ("Pending", "Approved", "Rejected")
+
+
+@frappe.whitelist()
+def list_skill_promotion_requests(
+	status: str = "Pending",
+	search: str = "",
+	start: int = 0,
+	page_length: int = 20,
+) -> dict:
+	"""Reviewer discovery queue for skill promotion requests. The doctype perms
+	are ``All: read+if_owner`` (so a requester sees only their OWN requests) — a
+	reviewer holding only Jarvis Skill Reviewer would get [] from generic
+	get_list. So this reviewer-gated raw-SQL list sidesteps the doctype-perm limit
+	exactly as ``learned_api.list_promotion_requests_page`` does for the wiki
+	queue. Envelope parity: ``{rows, total, has_more, start, page_length}``.
+	Requester full name resolved via one batched lookup."""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	start, pl = _clamp_page(start, page_length)
+	if status and status != "All" and status not in _PROMO_STATUSES:
+		frappe.throw(_("Invalid status filter."))
+
+	params: dict = {"start": start, "page_length": pl}
+	conds: list[str] = []
+	if status and status != "All":
+		params["status"] = status
+		conds.append("status = %(status)s")
+	if search:
+		params["q"] = f"%{_lk(search)}%"
+		conds.append("(skill_name LIKE %(q)s OR note LIKE %(q)s)")
+	where = " AND ".join(conds) or "1=1"
+
+	total = frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tab{PROMO}` WHERE {where}", params
+	)[0][0]
+	rows = frappe.db.sql(
+		f"""SELECT name, skill, skill_name, from_scope, to_scope, target_role,
+			note, status, owner, creation, reviewer, decided_at, decision_note
+		FROM `tab{PROMO}`
+		WHERE {where}
+		ORDER BY creation DESC, name ASC
+		LIMIT %(page_length)s OFFSET %(start)s""",
+		params, as_dict=True,
+	)
+
+	owner_names = list({r["owner"] for r in rows if r.get("owner")})
+	fullnames = {
+		u.name: u.full_name
+		for u in (
+			frappe.get_all(
+				"User", filters={"name": ["in", owner_names]}, fields=["name", "full_name"]
+			)
+			if owner_names
+			else []
+		)
+	}
+	out_rows = [
+		{
+			"name": r["name"],
+			"skill": r.get("skill") or "",
+			"skill_name": r.get("skill_name") or "",
+			"from_scope": r.get("from_scope") or "",
+			"to_scope": r.get("to_scope") or "",
+			"target_role": r.get("target_role") or "",
+			"note": r.get("note") or "",
+			"status": r.get("status") or "",
+			"requested_by": r.get("owner") or "",
+			"requested_by_name": fullnames.get(r.get("owner")) or (r.get("owner") or ""),
+			"created": str(r.get("creation") or ""),
+			"reviewer": r.get("reviewer") or "",
+			"decided_at": str(r.get("decided_at") or ""),
+			"decision_note": r.get("decision_note") or "",
+		}
+		for r in rows
+	]
+	return {
+		"rows": out_rows,
+		"total": total,
+		"has_more": start + len(out_rows) < total,
+		"start": start,
+		"page_length": pl,
+	}
+
+
+# --------------------------------------------------------------------------- #
 # Apply (explicit push to the container, via admin → fleet)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
@@ -492,9 +738,16 @@ def _custom_sync_status() -> dict:
 
 
 @frappe.whitelist()
-@require_jarvis_user
 def apply_custom_skills() -> dict:
 	"""Push all enabled skills to the assistant (one restart). Explicit action.
+
+	Reviewer/admin-gated (security review PART 2 TASK 12): a bench-wide push
+	reconciles + RESTARTS the shared container for EVERY user, so a plain Jarvis
+	User (which every backfilled user holds) must not be able to trigger it (DoS +
+	it is what forces any Org skill out to all pods). Gated with the skill-reviewer
+	set (Jarvis Skill Reviewer / Jarvis Admin / System Manager) — deliberately NOT
+	stacked under @require_jarvis_user, since a reviewer/admin may hold neither
+	Jarvis User nor System Manager.
 
 	Builds the payload synchronously so size/cap errors surface immediately,
 	marks a pending status, then enqueues the deduped worker (mirrors
@@ -502,6 +755,17 @@ def apply_custom_skills() -> dict:
 	endpoint - a human is present to act on the over-cap error, so raise
 	instead of truncating (the unattended worker below stays graceful).
 	"""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	return _apply_custom_skills_impl()
+
+
+def _apply_custom_skills_impl() -> dict:
+	"""Undecorated core of :func:`apply_custom_skills`. Split out so a caller
+	already authorized by its own gate can reconcile the shared catalog without
+	re-checking the reviewer gate (the bulk-delete path only invokes it for a
+	reviewer)."""
 	skills = build_push_payload(strict=True)
 	frappe.db.set_single_value(
 		_SETTINGS, "custom_skills_sync_status", "pending: applying skills"

--- a/jarvis/chat/dev_seed.py
+++ b/jarvis/chat/dev_seed.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import random
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe.utils import add_days, now_datetime
 
 SECOND_USER = "seed-userb@example.com"
@@ -296,6 +297,7 @@ def _wipe_varied(user: str) -> None:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def seed_varied_approvals(user: str) -> dict:
 	"""Seed ~6 currently-PENDING approvals with genuinely varied 3+ option
 	payloads (see ``_VARIED_PENDING``) so the varied-chip decide UI is
@@ -351,6 +353,7 @@ def _seed_for(owner: str, share_to: str | None, scale: str) -> None:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def seed_feature_pages(user: str) -> dict:
 	"""Seed the four feature pages for ``user`` at scale, plus a small scoping
 	dataset for a second user. DEV ONLY. Not called by tests (tests build their

--- a/jarvis/chat/docmeta_api.py
+++ b/jarvis/chat/docmeta_api.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import json
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 from frappe.desk.form import assign_to as _assign_to
 from frappe.share import add_docshare
@@ -229,6 +230,7 @@ def _validate_target_user(user: str) -> str:
 # read bundle
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def get_docmeta(doctype: str, name: str) -> dict:
 	"""The doc-page metadata bundle (§8.1 as amended by §14 F1) in one round trip."""
 	doc = _get_gated(doctype, name)
@@ -257,6 +259,7 @@ def get_docmeta(doctype: str, name: str) -> dict:
 # comments (direct inserts/updates AFTER the gate — §14 DA-03)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def add_comment(doctype: str, name: str, content: str) -> dict:
 	"""Add a comment (read-gated, matching desk's 'read is enough to comment').
 
@@ -292,6 +295,7 @@ def _comment_gated(comment: str):
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def update_comment(comment: str, content: str) -> dict:
 	"""Edit a comment's HTML (author or System Manager only)."""
 	doc = _comment_gated(comment)
@@ -305,6 +309,7 @@ def update_comment(comment: str, content: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_comment(comment: str) -> None:
 	"""Delete a comment (author or System Manager only)."""
 	_comment_gated(comment)
@@ -316,6 +321,7 @@ def delete_comment(comment: str) -> None:
 # assignment (ToDo + DocShare read-grant — D23, §14 DA-09)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def toggle_assignment(doctype: str, name: str, user: str, action: str = "add") -> list[dict]:
 	"""Assign/unassign ``user`` on the doc (write-gated: owner / approval-
 	conversation-owner / SM). Returns the fresh assignees list.
@@ -373,6 +379,7 @@ def toggle_assignment(doctype: str, name: str, user: str, action: str = "add") -
 # sharing (DocShare read — §14 F1)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def toggle_share(doctype: str, name: str, user: str, action: str = "add") -> list[dict]:
 	"""Share/unshare the doc with ``user`` (write-gated). Returns the fresh
 	shares list. Explicit shares carry the ``notify_by_email=1`` marker (see the
@@ -453,6 +460,7 @@ def toggle_share(doctype: str, name: str, user: str, action: str = "add") -> lis
 # like (direct _liked_by update — §14 DA-03)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def toggle_like(doctype: str, name: str, like: int = 1) -> list[str]:
 	"""Like (``like=1``) / unlike (``like=0``) the doc for the current user.
 	Read-gated. Mirrors desk semantics (``_liked_by`` JSON + a "Like" Comment
@@ -506,6 +514,7 @@ def _set_liked_by(doctype: str, name: str, liked_by: list[str]) -> None:
 # attachments (upload rides stock /api/method/upload_file; delete is gated here)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def delete_attachment(doctype: str, name: str, file: str) -> None:
 	"""Delete an attachment of the doc (write-gated). The File must actually be
 	attached to this doc — a foreign file name is refused."""

--- a/jarvis/chat/filebox.py
+++ b/jarvis/chat/filebox.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 
 INBOUND_PROMPT = (
 	"This file arrived through the File Box - process it as an inbound "
@@ -31,6 +32,7 @@ INBOUND_PROMPT = (
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def drop_file(file_url: str, file_name: str | None = None) -> dict:
 	"""Create a conversation for an uploaded file and kick off processing."""
 	file_url = (file_url or "").strip()
@@ -86,6 +88,7 @@ def drop_file(file_url: str, file_name: str | None = None) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_inbound(limit: int = 30) -> list[dict]:
 	"""DEPRECATED (superseded by ``list_inbound_page``): kept for one release for
 	back-compat. Recent File-Box conversations for the pane's inbound list, with a
@@ -277,6 +280,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_inbound_page(
 	search: str = "",
 	filters: str | dict | None = None,
@@ -418,6 +422,7 @@ def _delete_one(conversation: str) -> None:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_inbound(conversation: str) -> dict:
 	"""Owner-gated cascade delete of a File-Box conversation (FB-1)."""
 	_delete_one(conversation)
@@ -426,6 +431,7 @@ def delete_inbound(conversation: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_inbound_bulk(conversations: str | list | None = None) -> dict:
 	"""Bulk cascade delete (orchestrator Q4). Owner-gated per row, same cascade +
 	streaming refusal as ``delete_inbound``. Returns ``{deleted, skipped:[{
@@ -449,6 +455,7 @@ def delete_inbound_bulk(conversations: str | list | None = None) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def clear_processed_inbound() -> dict:
 	"""Bulk-delete the caller's OWN File-Box rows whose derived status is
 	done|error (never processing/needs_approval), computed with the same status

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -832,12 +832,13 @@ def _apply_pending() -> bool:
 	"""True while a learned-skills push is between enqueue and its terminal
 	status (Phase-2 namespace: the un-approve gate keys off the LEARNED push -
 	learned skills no longer ride the custom-skills push)."""
-	try:
-		from jarvis.chat.learned_skills_api import get_learned_skills_sync_status
+	# Undecorated read (a Jarvis Settings poll the reviewer is authorized to see):
+	# do NOT swallow errors here — the old bare except masked the @require_jarvis_user
+	# PermissionError and silently returned "not pending", weakening the mid-push
+	# un-approve guard for reviewer-only users (security review TASK 21).
+	from jarvis.chat.learned_skills_api import _learned_sync_status
 
-		return bool(get_learned_skills_sync_status().get("pending"))
-	except Exception:
-		return False
+	return bool(_learned_sync_status().get("pending"))
 
 
 def _apply_in_progress() -> bool:
@@ -1357,9 +1358,12 @@ def _apply_create_target(new_skill) -> tuple[str, str]:
 				"and instructions."
 			)
 		)
-	from jarvis.chat.custom_skills_api import create_custom_skill
+	from jarvis.chat.custom_skills_api import _create_custom_skill_impl
 
-	out = create_custom_skill(
+	# Call the undecorated impl: this reviewer path is already authorized by
+	# _guard() (_REVIEWER_ROLES), and a reviewer/admin may lack the Jarvis User
+	# role that the @require_jarvis_user HTTP wrapper on create_custom_skill needs.
+	out = _create_custom_skill_impl(
 		skill_name=str(ns.get("skill_name") or "").strip(),
 		description=str(ns.get("description") or "").strip(),
 		instructions=str(ns.get("instructions") or "").strip(),
@@ -1591,9 +1595,9 @@ def get_learned_apply_status() -> dict:
 	reports to the SEPARATE custom sync pair - included here so a failed
 	cutover reconcile is visible on the board instead of fire-and-forget."""
 	_guard()
-	from jarvis.chat.learned_skills_api import get_learned_skills_sync_status
+	from jarvis.chat.learned_skills_api import _learned_sync_status
 
-	out = get_learned_skills_sync_status()
+	out = _learned_sync_status()
 	out["custom_sync"] = _cutover_custom_sync_status(out)
 	return out
 
@@ -1620,9 +1624,9 @@ def _cutover_custom_sync_status(learned: dict):
 			age = (now_datetime() - last).total_seconds()
 			if age > _CUTOVER_SURFACE_HOURS * 3600:
 				return None
-		from jarvis.chat.custom_skills_api import get_custom_skills_sync_status
+		from jarvis.chat.custom_skills_api import _custom_sync_status
 
-		return get_custom_skills_sync_status()
+		return _custom_sync_status()
 	except Exception:
 		return None
 

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -153,6 +153,14 @@ ACK_NOTE = "Acknowledged - insight only"
 # pointing at the skill row. Keep the prefix stable - the frontend keys off it.
 APPLIED_NOTE_PREFIX = "Acknowledged - applied to skill: "
 
+# Non-blocking warning shown to a reviewer promoting a personalise-origin pattern
+# org-wide (security review PART 2 TASK 16): the content came from a user's
+# PRIVATE note, so personal nuances must be scrubbed before it becomes org-wide.
+_SCRUB_WARNING = (
+	"This came from a user's private note - remove personal names and nuances "
+	"before making it org-wide."
+)
+
 # Rendered on the board when an SM edited the draft before approving: the
 # evidence line is frozen (plan section 6.5) - it still reflects the ORIGINALLY
 # detected pattern, not the human edit, which was not re-measured.
@@ -171,6 +179,9 @@ _CARD_FIELDS = [
 	# reviewed_at rides the card for the Decided log's "who/when" line.
 	"status", "surfaced", "reviewed_by", "reviewed_at", "approved_by", "creation",
 	"stale_reason", "last_validated_at", "flags_count", "materialized_skill",
+	# personalise_origin drives the scrub-personal-nuances warning on the promote
+	# action (security review PART 2 TASK 16).
+	"personalise_origin",
 	# review_note distinguishes Acknowledged / "applied to skill" terminal
 	# states from a plain Reject - without it the board's disposition
 	# badges can never fire and every terminal row reads "Rejected".
@@ -421,6 +432,13 @@ def list_learned_patterns_page(
 		r["exception_n"] = int(r.get("exception_n") or 0)
 		r["flags_count"] = int(r.get("flags_count") or 0)
 		r["has_overlap_warning"] = 1 if (r.get("overlap_warning") or "").strip() else 0
+		# TASK 16: a personalise-origin pattern is org-promoted by a reviewer, not
+		# the owner, so the promote action must warn them to scrub personal
+		# names/nuances first. Non-blocking; the board shows the flag + message.
+		r["personalise_origin"] = int(r.get("personalise_origin") or 0)
+		r["scrub_warning"] = (
+			_SCRUB_WARNING if r["personalise_origin"] else ""
+		)
 		r["creation"] = str(r.get("creation") or "")
 		r["reviewed_at"] = str(r.get("reviewed_at") or "")
 		r["last_validated_at"] = str(r.get("last_validated_at") or "")
@@ -690,7 +708,13 @@ def approve_learned_pattern(name: str, edited_skill_draft: str | None = None) ->
 	doc.reviewed_at = now
 	doc.save()
 	frappe.db.commit()
-	return {"ok": True, "status": doc.status, "draft_edited": int(doc.draft_edited or 0)}
+	out = {"ok": True, "status": doc.status, "draft_edited": int(doc.draft_edited or 0)}
+	# TASK 16: an A-class approve compiles the pattern into the org-wide
+	# learned-<domain> skill every user gets; if it drew from a private
+	# Personalise note, surface the scrub warning so the reviewer can act on it.
+	if doc.personalise_origin:
+		out["scrub_warning"] = _SCRUB_WARNING
+	return out
 
 
 @frappe.whitelist()
@@ -1077,7 +1101,12 @@ def apply_insight_skill_update(
 	doc.materialized_skill = row_name
 	doc.save()
 	frappe.db.commit()
-	return {"ok": True, "skill_name": slug}
+	out = {"ok": True, "skill_name": slug}
+	# TASK 16: folding a personalise-origin insight into a shared/org skill
+	# carries the same scrub obligation; surface the warning to the reviewer.
+	if doc.personalise_origin:
+		out["scrub_warning"] = _SCRUB_WARNING
+	return out
 
 
 def _draft_envelope(
@@ -1363,10 +1392,16 @@ def _apply_create_target(new_skill) -> tuple[str, str]:
 	# Call the undecorated impl: this reviewer path is already authorized by
 	# _guard() (_REVIEWER_ROLES), and a reviewer/admin may lack the Jarvis User
 	# role that the @require_jarvis_user HTTP wrapper on create_custom_skill needs.
+	# scope="Org" (the reviewer authors an org-effect skill, not a private one —
+	# the new default is User) + ignore_permissions so a reviewer without the
+	# Jarvis User doctype-create perm still lands the row; the controller's scope
+	# guard admits them as a reviewer either way (security review PART 2 TASK 10).
 	out = _create_custom_skill_impl(
 		skill_name=str(ns.get("skill_name") or "").strip(),
 		description=str(ns.get("description") or "").strip(),
 		instructions=str(ns.get("instructions") or "").strip(),
+		scope="Org",
+		ignore_permissions=True,
 	)
 	return out["data"]["name"], out["data"]["skill_name"]
 

--- a/jarvis/chat/learned_skills_api.py
+++ b/jarvis/chat/learned_skills_api.py
@@ -41,6 +41,7 @@ Entry points:
 from __future__ import annotations
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 
 _SETTINGS = "Jarvis Settings"
 _PUSH_JOB_ID = "jarvis_learned_skills_push"
@@ -50,8 +51,19 @@ _PENDING_STATUS = "pending: applying learned skills"
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_learned_skills_sync_status() -> dict:
 	"""Lightweight poller mirroring ``get_custom_skills_sync_status``."""
+	return _learned_sync_status()
+
+
+def _learned_sync_status() -> dict:
+	"""Undecorated core of :func:`get_learned_skills_sync_status`. Split out so the
+	reviewer-facing Apply board — ``learned_api.get_learned_apply_status`` and
+	``learned_api._apply_pending``, both gated on ``_REVIEWER_ROLES`` which admits a
+	reviewer / admin who lacks Jarvis User / System Manager — can read the sync
+	status without tripping the ``@require_jarvis_user`` HTTP gate. It is a read of
+	two ``Jarvis Settings`` fields the reviewer is already authorized to see."""
 	s = frappe.get_single(_SETTINGS)
 	status = s.get("learned_skills_sync_status") or ""
 	return {

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -9,6 +9,7 @@ commit). Execution itself lives in ``jarvis.chat.macros``.
 import re
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 
 MACRO = "Jarvis Macro"
@@ -80,6 +81,7 @@ def _clean_step_skills(skills) -> list[str]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_macros() -> list[dict]:
 	"""The current user's macros (no step bodies), newest first, with a count."""
 	macros = frappe.get_all(
@@ -168,6 +170,7 @@ def _order_by(sort_field, sort_dir, sortable: dict, default_field, default_dir, 
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_macros_page(
 	search: str = "",
 	filters: str | dict | None = None,
@@ -283,6 +286,7 @@ def _step_skills(step) -> list[str]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def create_macro(
 	macro_name: str,
 	description: str = "",
@@ -374,6 +378,7 @@ def delete_macro(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_macros_bulk(names: str | list | None = None) -> dict:
 	"""Bulk delete macros the caller OWNS (DESIGN-V3 §8.3 / D20). ``names`` is a
 	JSON array of macro row-names. Reuses the ``delete_macro`` path per row so
@@ -411,6 +416,7 @@ def delete_macros_bulk(names: str | list | None = None) -> dict:
 # Run / stop
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+@require_jarvis_user
 def run_macro(name: str) -> dict:
 	"""Start a macro now (manual trigger). Returns the run + conversation."""
 	from jarvis.chat import macros
@@ -419,6 +425,7 @@ def run_macro(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def stop_macro_run(run: str) -> dict:
 	"""Stop an in-progress run (owner-gated)."""
 	from jarvis.chat import macros
@@ -449,6 +456,7 @@ _RUN_STATUSES = {"queued", "running", "completed", "failed", "stopped"}
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def list_macro_runs(status: str = "", macro: str = "", limit: int | str = 30, start: int | str = 0) -> dict:
 	"""The current user's macro runs, newest-first, for the history dashboard.
 
@@ -493,6 +501,7 @@ def list_macro_runs(status: str = "", macro: str = "", limit: int | str = 30, st
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def macro_run_stats() -> dict:
 	"""Summary tiles for the dashboard: counts per status, success rate, and the
 	last run time — all owner-scoped. Success rate = completed / (completed +
@@ -594,6 +603,7 @@ def summarize_macro(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_macro_merge(conversation: str) -> dict:
 	"""Poll target for the merge turn: pending → ready(merge)/error."""
 	_own_conversation(conversation)
@@ -663,6 +673,7 @@ def clear_macro_merge(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def discard_macro_merge(conversation: str) -> dict:
 	"""Delete the throwaway merge conversation + its messages (Keep sequence /
 	unmergeable / error paths). Best-effort: if a link blocks the delete the

--- a/jarvis/chat/personalise_api.py
+++ b/jarvis/chat/personalise_api.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 from frappe import _
 from frappe.utils import cint, now_datetime
 
@@ -94,10 +95,13 @@ _ATTACHMENT_BINARY_EXT = {
 # voice_notes_api._require_system_user / learned_api._guard / _lk)
 # --------------------------------------------------------------------------- #
 def _require_system_user() -> None:
-	"""Desk-user gate: Guest rejected, Administrator always allowed, else the
-	caller must be a System User. Verbatim clone of
+	"""Chat-surface gate: Guest rejected, Administrator always allowed, else the
+	caller must be a System User AND hold Jarvis access (the Jarvis User role or
+	System Manager - TASK 6/8). Mirrors
 	``voice_notes_api._require_system_user`` - Personalise is Desk-SPA only,
 	same as the Business tab it replaces."""
+	from jarvis.permissions import require_jarvis_access
+
 	user = frappe.session.user
 	if not user or user == "Guest":
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
@@ -105,6 +109,7 @@ def _require_system_user() -> None:
 		return
 	if frappe.db.get_value("User", user, "user_type") != "System User":
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
+	require_jarvis_access(user)
 
 
 def _admin_guard() -> None:
@@ -724,6 +729,7 @@ def get_note(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_note(name: str) -> dict:
 	"""Owner-only delete. Alias of ``voice_notes_api.delete_voice_note``
 	(DESIGN.md 6b: "delete_note exists as delete_voice_note; alias ok") kept

--- a/jarvis/chat/personalise_permissions.py
+++ b/jarvis/chat/personalise_permissions.py
@@ -1,0 +1,55 @@
+"""``user``-keyed row scoping for ``Jarvis Personalise Question`` (security
+review PART 2, TASK 17).
+
+The app API scopes a user's question bank on the **``user``** field, while the
+generic Frappe REST surface scopes on **``owner``** (the doctype's ``if_owner``
+rule). Equality of the two relies solely on the ``before_insert`` owner-stamp
+(``jarvis_personalise_question.py``: ``self.owner = self.user``). Any future
+write path that sets ``user`` without going through that stamp (a raw
+``frappe.db`` insert, a bulk ``set_value``) would let ``owner`` and ``user``
+diverge, and the two access channels would then disagree about which rows a
+user sees.
+
+This hook keys the ORM scoping on the **``user``** field too, so generic REST
+list/get matches the API's ``user``-based scoping and survives any owner/user
+drift. Mirrors ``jarvis/chat/wiki_permissions.py`` / ``chat_permissions.py``.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+QUESTION = "Jarvis Personalise Question"
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def personalise_question_query_conditions(user: str | None = None) -> str:
+	"""Scope every list/report/REST query on Jarvis Personalise Question to the
+	caller's own rows, keyed on the ``user`` field (not ``owner``). System
+	Manager (and Administrator) are unrestricted (the existing SM perm row)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tabJarvis Personalise Question`.`user` = {frappe.db.escape(user)}"
+
+
+def has_personalise_question_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate keyed on the ``user`` field. System Manager: all. Everyone
+	else: only rows whose ``user`` is them. Create of a row targeting another
+	user is denied (the materializer inserts with ignore_permissions)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	target = doc.get("user")
+	if ptype == "create":
+		# A question must target the creator; backend materializers (running as
+		# Administrator / the engine) insert with ignore_permissions and skip
+		# this hook entirely.
+		return target is None or target == user
+	return target == user

--- a/jarvis/chat/proactive.py
+++ b/jarvis/chat/proactive.py
@@ -13,6 +13,7 @@ customer" action) just call :func:`start_conversation`. A trivial demo trigger
 import frappe
 
 from jarvis.chat.events import publish_to_user
+from jarvis.permissions import require_jarvis_access
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
@@ -69,7 +70,14 @@ def start_conversation(message: str, *, title: str | None = None, user: str | No
 
 @frappe.whitelist()
 def demo_proactive(message: str | None = None, title: str | None = None) -> dict:
-	"""Test trigger: Jarvis proactively messages the current user."""
+	"""Test trigger: Jarvis proactively messages the current user.
+
+	Gated (PART 1 TASK 1): this whitelisted endpoint hands the caller an OWNED
+	conversation (via start_conversation's ignore_permissions insert) and could
+	otherwise seed a chat for a user without Jarvis access. ``start_conversation``
+	itself stays ungated — it is the internal seam the scheduler/doc-event/admin
+	triggers call directly."""
+	require_jarvis_access()
 	return start_conversation(
 		message
 		or "Hi! Your monthly close is due in 3 days. Want me to prepare a draft "

--- a/jarvis/chat/skill_permissions.py
+++ b/jarvis/chat/skill_permissions.py
@@ -1,0 +1,109 @@
+"""Scope-ladder visibility for ``Jarvis Custom Skill`` at the ORM (security
+review PART 2, TASK 13).
+
+The visibility rule ({owner OR shared OR scope=Org (unless role-narrowed) OR
+scope=Role role-match}) used to live in FOUR hand-rolled read surfaces that
+disagreed (the plugin find/get honored ``allowed_roles``; the SPA list/get did
+not; generic REST was only accidentally safe because ``if_owner`` hid
+everything, so an owner couldn't even REST-list a skill shared to them). This
+module lifts the ONE rule (``jarvis_custom_skill.user_can_use_skill``) to the
+ORM so list/report/generic-REST queries (``permission_query_conditions``) and
+per-doc access (``has_permission``) inherit it automatically — exactly the
+``jarvis/chat/wiki_permissions.py`` pattern.
+
+Writes stay owner-only (create/save/delete of your own row); scope WIDENING is
+guarded in the controller (``_guard_scope_change`` / ``_guard_new_scope``) so it
+holds under ``ignore_permissions`` too. Reviewer/compiler writes (the promotion
+decide + insight-apply + compiler upsert) go through ``ignore_permissions`` and
+so never consult ``has_permission``.
+
+Every interpolated value in the SQL fragment goes through ``frappe.db.escape``;
+role names / user emails are org-author-controlled strings.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+SKILL = "Jarvis Custom Skill"
+SHARE = "Jarvis Custom Skill Share"
+ALLOWED_ROLE = "Jarvis Custom Skill Allowed Role"
+
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def skill_query_conditions(user: str | None = None) -> str:
+	"""hooks.permission_query_conditions — scopes every list/report/REST query to
+	the caller's visible skill set. Empty (no restriction) for System Managers.
+	Always a parenthesized valid boolean expression."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	table = f"`tab{SKILL}`"
+	esc_user = frappe.db.escape(user)
+	clauses = [
+		f"{table}.`owner` = {esc_user}",
+		# shared with me
+		(
+			f"exists (select 1 from `tab{SHARE}` sh "
+			f"where sh.parent = {table}.`name` and sh.parenttype = {frappe.db.escape(SKILL)} "
+			f"and sh.`user` = {esc_user})"
+		),
+		# Org (or legacy empty) with NO allowed_roles narrowing = everyone.
+		(
+			f"(coalesce({table}.`scope`, '') in ('', 'Org') and not exists "
+			f"(select 1 from `tab{ALLOWED_ROLE}` ar where ar.parent = {table}.`name` "
+			f"and ar.parenttype = {frappe.db.escape(SKILL)}))"
+		),
+	]
+	roles = [r for r in frappe.get_roles(user) if r]
+	if roles:
+		role_list = ", ".join(frappe.db.escape(r) for r in roles)
+		# Role-match via allowed_roles (managed learned rows + legacy Org narrowed
+		# by roles). Never applies to User-scope rows (private).
+		clauses.append(
+			f"(coalesce({table}.`scope`, '') != 'User' and exists "
+			f"(select 1 from `tab{ALLOWED_ROLE}` ar where ar.parent = {table}.`name` "
+			f"and ar.parenttype = {frappe.db.escape(SKILL)} and ar.`role` in ({role_list})))"
+		)
+		# Role-scope via target_role.
+		clauses.append(
+			f"({table}.`scope` = 'Role' and {table}.`target_role` in ({role_list}))"
+		)
+	return "(" + " or ".join(clauses) + ")"
+
+
+def has_skill_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""hooks.has_permission — per-doc gate. Reads follow the scope-ladder
+	visibility rule (``user_can_use_skill``); write/delete are owner-only (scope
+	widening is separately controller-guarded); create defers to the role perm
+	(owner is the creator; the controller caps a non-reviewer's new scope to
+	User). True defers to the normal role-perm check (hooks can only deny)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	if ptype == "create":
+		return True
+	if ptype in _READ_PTYPES or ptype is None:
+		# ptype is None when Frappe builds the FULL perm dict (get_doc_permissions);
+		# resolve it as read-visibility so a visible skill isn't wrongly denied to a
+		# non-owner (the actual write/delete op re-checks with an explicit ptype).
+		from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
+			user_can_use_skill,
+		)
+
+		return user_can_use_skill(doc, user)
+	# write / delete / submit / cancel / amend: owner only. This branch MUST return
+	# a bool (never frappe.throw) — get_doc_permissions calls this hook for every
+	# ptype while building a doc's perm dict, so a throw here would break plain
+	# reads. The clear user-facing "you can only edit your own skills" message is
+	# raised by the SPA write endpoints (custom_skills_api._require_skill_owner);
+	# generic REST writes fall back to Frappe's "does not have access" message.
+	return (doc.get("owner") or "") == user

--- a/jarvis/chat/voice.py
+++ b/jarvis/chat/voice.py
@@ -17,6 +17,7 @@ import base64
 import time
 
 import frappe
+from jarvis.permissions import require_jarvis_user
 import requests
 from frappe import _
 from frappe.utils import cint
@@ -199,6 +200,7 @@ def _audio_format(content_type: str | None) -> str:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def transcribe_audio() -> dict:
 	"""Transcribe one recorded clip (multipart field ``audio`` + form
 	``duration_s``). Desk (System User) only; bytes are size/duration capped

--- a/jarvis/chat/voice_notes_api.py
+++ b/jarvis/chat/voice_notes_api.py
@@ -30,6 +30,11 @@ _SEARCH_MAX = 140
 
 
 def _require_system_user() -> None:
+	# System User AND Jarvis access (TASK 6/8): these voice/personalise
+	# endpoints are part of the chat surface, so they require the Jarvis User
+	# role (or System Manager), not merely a Desk login.
+	from jarvis.permissions import require_jarvis_access
+
 	user = frappe.session.user
 	if not user or user == "Guest":
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
@@ -37,6 +42,7 @@ def _require_system_user() -> None:
 		return
 	if frappe.db.get_value("User", user, "user_type") != "System User":
 		frappe.throw(_("Not permitted."), frappe.PermissionError)
+	require_jarvis_access(user)
 
 
 def _single(field: str):

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -897,6 +897,17 @@ def apply_promotion(
 	decision_note. Idempotent: a non-Pending request is a no-op."""
 	reviewer = reviewer or frappe.session.user
 	req = frappe.get_doc(PROMO, request_name)
+	# Security review PART 2 TASK 19: four-eyes / separation of duties. A user
+	# holding BOTH a Knowledge-Wiki role (so they could author + request) and a
+	# reviewer role must not approve their OWN promotion request. Bounded (the
+	# widened content is their own page) but promotion is an org-wide effect, so
+	# it needs a second pair of eyes. Checked before the TOCTOU claim so a
+	# self-approval never mutates the target page.
+	if reviewer == (req.owner or "") and reviewer != "Administrator":
+		frappe.throw(
+			_("You cannot approve your own promotion request; another reviewer must decide it."),
+			frappe.PermissionError,
+		)
 	# TOCTOU-safe claim: re-read the status under a row lock (for_update) before
 	# the merge, so two concurrent approvals (two reviewers, or a double-submit)
 	# can never both pass the Pending check and double-append body_snapshot into

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -337,3 +337,22 @@ has_permission.update({
 	"Jarvis Voice Note": "jarvis.chat.chat_permissions.has_voice_note_permission",
 })
 
+# ---------------------------------------------------------------------------
+# Skills / Personalise scoping (security review PART 2)
+# ---------------------------------------------------------------------------
+# TASK 13: Jarvis Custom Skill visibility (owner OR scope=Org OR scope=Role
+# role-match OR shared-with) at the ORM, so the four hand-rolled read surfaces
+# (generic REST, SPA list/get, plugin find/get) can never disagree. Matrix +
+# SQL fragment live in jarvis/chat/skill_permissions.py (reuses the controller's
+# user_can_use_skill rule).
+# TASK 17: Jarvis Personalise Question scoped on the `user` field (not `owner`)
+# so generic REST matches the API's user-based scoping and survives drift.
+permission_query_conditions.update({
+	"Jarvis Custom Skill": "jarvis.chat.skill_permissions.skill_query_conditions",
+	"Jarvis Personalise Question": "jarvis.chat.personalise_permissions.personalise_question_query_conditions",
+})
+has_permission.update({
+	"Jarvis Custom Skill": "jarvis.chat.skill_permissions.has_skill_permission",
+	"Jarvis Personalise Question": "jarvis.chat.personalise_permissions.has_personalise_question_permission",
+})
+

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -313,3 +313,27 @@ has_permission = {
 	"Jarvis Wiki Page": "jarvis.chat.wiki_permissions.has_wiki_page_permission",
 }
 
+# ---------------------------------------------------------------------------
+# Chat doctype ownership scoping (security review PART 1, TASK 7)
+# ---------------------------------------------------------------------------
+# Row-level owner scoping for the chat doctypes at the ORM, so generic REST
+# (/api/resource, frappe.client.*, reportview) and every future endpoint
+# inherit it automatically instead of relying on a hand-rolled owner check in
+# each whitelisted function. Conversation/Voice scope by the row owner;
+# Message/Approval scope by the LINKED conversation's owner (+ DocShare for
+# Approval). Matrix + SQL fragments live in jarvis/chat/chat_permissions.py.
+# The doctype permission rows carry role "Jarvis User" (not "All"), so the role
+# is genuinely load-bearing: revoking it denies all four via REST.
+permission_query_conditions.update({
+	"Jarvis Conversation": "jarvis.chat.chat_permissions.conversation_query_conditions",
+	"Jarvis Chat Message": "jarvis.chat.chat_permissions.message_query_conditions",
+	"Jarvis Approval Request": "jarvis.chat.chat_permissions.approval_query_conditions",
+	"Jarvis Voice Note": "jarvis.chat.chat_permissions.voice_note_query_conditions",
+})
+has_permission.update({
+	"Jarvis Conversation": "jarvis.chat.chat_permissions.has_conversation_permission",
+	"Jarvis Chat Message": "jarvis.chat.chat_permissions.has_message_permission",
+	"Jarvis Approval Request": "jarvis.chat.chat_permissions.has_approval_permission",
+	"Jarvis Voice Note": "jarvis.chat.chat_permissions.has_voice_note_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
@@ -141,8 +141,7 @@
    "create": 1,
    "read": 1,
    "write": 1,
-   "if_owner": 1,
-   "role": "All"
+   "role": "Jarvis User"
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
@@ -36,6 +36,17 @@ class JarvisApprovalRequest(Document):
 		):
 			return
 		decider = self.decided_by or frappe.session.user
+		# TASK 4: the trace comment is an ignore_permissions write attributed to
+		# the decider on a user-controllable ref_doctype/ref_name. Do not plant
+		# an attributed comment on a document the decider cannot access — that
+		# would be a permission-bypass write driven by attacker-chosen fields.
+		# Skip the trace (the decision itself is still recorded) when the decider
+		# lacks read+write on the target.
+		if not (
+			frappe.has_permission(self.ref_doctype, "read", self.ref_name, user=decider)
+			and frappe.has_permission(self.ref_doctype, "write", self.ref_name, user=decider)
+		):
+			return
 		comment = frappe.get_doc({
 			"doctype": "Comment",
 			"comment_type": "Comment",

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -88,7 +88,8 @@
       "label": "Openclaw Seq Watermark",
       "read_only": 1,
       "hidden": 1,
-      "description": "Highest openclaw transcript seq observed before this turn's chat.send; snapshot recovery only finalizes from strictly newer assistant messages."
+      "permlevel": 1,
+      "description": "Highest openclaw transcript seq observed before this turn's chat.send; snapshot recovery only finalizes from strictly newer assistant messages. permlevel 1 (server-only; TASK 9): written by the worker via frappe.db.set_value / read via raw SQL, so no user can read/set the watermark through generic REST."
     },
     {
       "fieldname": "was_recovered",
@@ -157,12 +158,24 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "read": 1,
       "write": 1,
       "create": 1,
-      "delete": 1,
-      "if_owner": 1
+      "delete": 1
+    },
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
+    },
+    {
+      "role": "System Manager",
+      "permlevel": 1,
+      "read": 1,
+      "write": 1
     }
   ],
   "sort_field": "seq",

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.py
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.py
@@ -9,8 +9,41 @@ chat session.
 """
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class JarvisChatMessage(Document):
-	pass
+	def validate(self):
+		self._validate_conversation_owner()
+
+	def _validate_conversation_owner(self):
+		"""Cross-link ownership guard (security review TASK 2).
+
+		A chat message must belong to a conversation the acting user owns.
+		``if_owner`` on the message row's OWN owner does not prevent injecting a
+		row into another user's conversation (the row owner is trivially the
+		creator on insert; ``api.get_conversation`` treats the CONVERSATION owner
+		as the authority, so an injected row would surface in the victim's
+		transcript). The ``has_permission`` hook
+		(``jarvis.chat.chat_permissions.has_message_permission``) is the primary
+		ORM control; this validate is defense-in-depth on every write path.
+
+		Server context: the worker, tool dispatch (``impersonate(owner)``),
+		scheduler and approval-resume writers insert assistant/tool/system rows
+		with ``ignore_permissions=True`` (as the impersonated owner or
+		Administrator) — those are trusted and skipped. Administrator bypasses
+		perms entirely.
+		"""
+		if self.flags.ignore_permissions or frappe.session.user == "Administrator":
+			return
+		if not self.conversation:
+			return
+		owner = frappe.db.get_value(
+			"Jarvis Conversation", self.conversation, "owner"
+		)
+		if owner and owner != frappe.session.user:
+			frappe.throw(
+				_("You can only post messages to your own conversations."),
+				frappe.PermissionError,
+			)

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -30,8 +30,9 @@
    "fieldtype": "Data",
    "label": "Openclaw Session Key",
    "unique": 1,
+   "permlevel": 1,
    "in_standard_filter": 1,
-   "description": "Populated on first agent turn; reused for subsequent turns in this conversation."
+   "description": "Populated on first agent turn; reused for subsequent turns in this conversation. permlevel 1 (server-only; TASK 9): the session_key->user map is impersonation-sensitive, so even the owner cannot read/write it via generic REST. The worker sets it via frappe.db.set_value (bypasses permlevel)."
   },
   {
    "fieldname": "model_override",
@@ -88,12 +89,26 @@
  ],
  "permissions": [
   {
-   "role": "All",
+   "role": "Jarvis User",
    "read": 1,
    "write": 1,
    "create": 1,
    "delete": 1,
    "if_owner": 1
+  },
+  {
+   "role": "System Manager",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1
+  },
+  {
+   "role": "System Manager",
+   "permlevel": 1,
+   "read": 1,
+   "write": 1
   }
  ],
  "sort_field": "last_active_at",

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
@@ -11,6 +11,7 @@
     "enabled",
     "user_invocable",
     "scope",
+    "target_role",
     "description",
     "instructions",
     "shared_with",
@@ -45,9 +46,18 @@
       "fieldname": "scope",
       "fieldtype": "Select",
       "label": "Scope",
-      "options": "Org\nPersonal",
-      "default": "Org",
-      "description": "Org skills join the shared assistant catalog on Apply; Personal skills stay private to their owner and are only reachable via jarvis__find_skills / jarvis__get_skill. Empty (pre-migration rows) means Org."
+      "options": "User\nRole\nOrg",
+      "default": "User",
+      "description": "Scope ladder (security review PART 2 TASK 10, mirrors Jarvis Wiki Page). User = private to the owner (default; reached via jarvis__find_skills / jarvis__get_skill, never pushed to the shared catalog). Role = holders of Target Role. Org = everyone; joins the shared assistant catalog on Apply. Widening (User->Role->Org) is reviewer-approved only. Empty (pre-migration rows) means Org."
+    },
+    {
+      "fieldname": "target_role",
+      "fieldtype": "Link",
+      "label": "Target Role",
+      "options": "Role",
+      "depends_on": "eval:doc.scope=='Role'",
+      "mandatory_depends_on": "eval:doc.scope=='Role'",
+      "description": "Required for Role-scope skills: the single role whose holders may see/invoke this skill (the Wiki-parallel audience field)."
     },
     {
       "fieldname": "description",
@@ -89,12 +99,18 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "read": 1,
       "write": 1,
       "create": 1,
-      "delete": 1,
-      "if_owner": 1
+      "delete": 1
+    },
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
     }
   ],
   "sort_field": "skill_name",

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -35,6 +35,9 @@ RESERVED_PREFIX = "custom-"
 # sets ``frappe.flags.jarvis_pattern_engine``) or Administrator may author it.
 LEARNED_PREFIX = "learned-"
 
+# Scope ladder (security review PART 2 TASK 10), mirroring Jarvis Wiki Page.
+SCOPES = ("User", "Role", "Org")
+
 SKILL_DOCTYPE = "Jarvis Custom Skill"
 
 
@@ -65,15 +68,23 @@ def _managed_flag_privileged(user: str | None = None) -> bool:
 
 
 def user_can_use_skill(skill, user: str | None = None, user_roles: list[str] | None = None) -> bool:
-	"""Allowed-Roles visibility rule (pattern-learning plan section 6.6).
+	"""Scope-ladder visibility rule (security review PART 2 TASK 13; the single
+	rule every read path — generic REST via the ORM hook, the SPA list/get, the
+	plugin find/get tools — now agrees on).
 
-	A user may see/invoke a skill iff they are the owner, are in
-	``shared_with``, ``allowed_roles`` is empty (= everyone), or their roles
-	intersect ``allowed_roles``. System Manager (and Administrator) always
-	passes. ``skill`` may be a Document or any dict-like row; when the row
-	does not carry the child tables (e.g. a ``frappe.get_all`` row) they are
-	fetched by parent name. Instruction-level enforcement only - the skill
-	files stay readable in the shared container.
+	A user may see/invoke a skill iff they are the owner, are in ``shared_with``,
+	or the skill's scope admits them:
+
+	  * ``User``  — owner only (private).
+	  * ``Role``  — holders of ``target_role`` (or, for compiler-managed rows /
+	    legacy multi-role narrowing, an ``allowed_roles`` intersection).
+	  * ``Org``   — everyone, UNLESS ``allowed_roles`` is set (managed learned
+	    rows + legacy "Org narrowed by roles"), in which case role-match.
+
+	System Manager (and Administrator) always passes. ``skill`` may be a Document
+	or any dict-like row; child tables absent from a ``frappe.get_all`` row are
+	fetched by parent name. Instruction-level enforcement — see TASK 11 for why
+	role-restricted bodies must ALSO be kept off the shared container push.
 	"""
 	user = user or frappe.session.user
 	if user == "Administrator":
@@ -86,10 +97,27 @@ def user_can_use_skill(skill, user: str | None = None, user_roles: list[str] | N
 		return True
 	if user in _child_values(skill, "shared_with", "user", "Jarvis Custom Skill Share"):
 		return True
-	allowed = _child_values(skill, "allowed_roles", "role", "Jarvis Custom Skill Allowed Role")
+	# NULL/empty scope == Org (pre-migration rows); "Personal" is the pre-ladder
+	# spelling of User (safe until the migration backfills the DB).
+	scope = (skill.get("scope") or "Org").strip() or "Org"
+	if scope == "Personal":
+		scope = "User"
+	roles = set(user_roles)
+	if scope == "User":
+		# Private: owner/shared/SM already handled above.
+		return False
+	allowed = set(
+		_child_values(skill, "allowed_roles", "role", "Jarvis Custom Skill Allowed Role")
+	)
+	if scope == "Role":
+		target_role = (skill.get("target_role") or "").strip()
+		if target_role and target_role in roles:
+			return True
+		return bool(allowed & roles)
+	# Org (or legacy empty): everyone unless narrowed by allowed_roles.
 	if not allowed:
 		return True
-	return bool(set(allowed) & set(user_roles))
+	return bool(allowed & roles)
 
 
 def _child_values(skill, fieldname: str, value_field: str, child_doctype: str) -> list[str]:
@@ -120,6 +148,8 @@ class JarvisCustomSkill(Document):
 	def validate(self):
 		self._validate_slug()
 		self._validate_scope()
+		self._guard_new_scope()
+		self._guard_scope_change()
 		self._validate_lengths()
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
@@ -132,11 +162,94 @@ class JarvisCustomSkill(Document):
 		_clear_personal_clause_cache(self.owner)
 
 	def _validate_scope(self):
-		# NULL/empty scope == Org everywhere (pre-migration rows are never
-		# backfilled); normalize on save so new writes are explicit.
-		self.scope = (self.scope or "Org").strip()
-		if self.scope not in ("Org", "Personal"):
-			frappe.throw(_("Scope must be Org or Personal."))
+		# Scope ladder {User, Role, Org} (security review PART 2 TASK 10). NEW rows
+		# default to User (private-first); pre-migration rows carry legacy scopes,
+		# so a blank scope on an EXISTING row reads as Org (its historical meaning)
+		# while a blank scope on a fresh insert defaults to User. "Personal" is the
+		# pre-ladder spelling of User.
+		raw = (self.scope or "").strip()
+		if raw == "Personal":
+			raw = "User"
+		if not raw:
+			raw = "User" if self.is_new() else "Org"
+		self.scope = raw
+		if self.scope not in SCOPES:
+			frappe.throw(_("Scope must be one of {0}.").format(", ".join(SCOPES)))
+		if self.scope == "Role":
+			self.target_role = (self.target_role or "").strip() or None
+			if not self.target_role:
+				frappe.throw(_("Role-scope skills need a Target Role."))
+			# allowed_roles stays meaningful for compiler-managed rows only; an
+			# authored Role skill's audience is target_role.
+		elif self.scope == "User":
+			# A private skill has no role audience — clear both so a stray
+			# allowed_roles/target_role can never leak it to role-holders (TASK 13
+			# U1: no silent Personal+roles no-op).
+			self.target_role = None
+			if not frappe.flags.jarvis_pattern_engine:
+				self.set("allowed_roles", [])
+		else:  # Org
+			self.target_role = None
+
+	def _scope_change_authorized(self) -> bool:
+		"""Who may WIDEN a skill's scope (mint or promote it to Role/Org): the
+		learning compiler (engine flag), Administrator, or a skill reviewer
+		(Jarvis Skill Reviewer / Jarvis Admin / System Manager — TASK 15 set).
+		A normal owner may only ever create/keep a User-scope skill; widening is
+		reviewer-gated (the promotion workflow), never a self-service field flip."""
+		if frappe.flags.jarvis_pattern_engine:
+			return True
+		from jarvis.permissions import is_skill_reviewer
+
+		return is_skill_reviewer(frappe.session.user)
+
+	def _guard_new_scope(self):
+		"""Block a non-reviewer from CREATING a skill directly at Role/Org scope
+		(the [E1]/[O1] self-service org-escalation the review flagged) — closes the
+		generic-REST insert + the create_custom_skill tool's scope arg at the
+		controller, so it holds no matter which door the insert comes through.
+		New skills default to User; Role/Org creation needs the reviewer set."""
+		if not self.is_new():
+			return
+		if self.scope in ("Role", "Org") and not self._scope_change_authorized():
+			frappe.throw(
+				_("New skills are private (User scope); promoting to Role or Org "
+				  "needs a reviewer's approval."),
+				frappe.PermissionError,
+			)
+
+	def _guard_scope_change(self):
+		"""Only a reviewer (or the compiler) may re-scope or re-target an EXISTING
+		skill — anything else would let an owner widen their own skill bench-wide
+		via a save path (SPA, frappe.client.set_value, a raw controller write).
+		Runs regardless of ignore_permissions, exactly like the Wiki page guard
+		(jarvis_wiki_page._guard_scope_change), because the reviewer promotion
+		writes save with ignore_permissions=True."""
+		if self.is_new():
+			return
+		prev = frappe.db.get_value(
+			self.doctype, self.name, ["scope", "target_role"], as_dict=True
+		)
+		if not prev:
+			return
+		prev_scope = (prev.scope or "").strip() or "Org"
+		if self.scope == prev_scope and (self.target_role or None) == (prev.target_role or None):
+			return
+		if self._scope_change_authorized():
+			return
+		# Owner-initiated NARROWING (strictly fewer viewers down the User<Role<Org
+		# ladder) is always safe — it reduces exposure — so the owner may
+		# self-demote without a reviewer (e.g. un-publish an Org skill back to
+		# private). WIDENING and lateral Role re-targeting stay reviewer-gated.
+		rank = {"User": 0, "Role": 1, "Org": 2}
+		is_owner = (self.owner or "") == frappe.session.user
+		if is_owner and rank.get(self.scope, 2) < rank.get(prev_scope, 2):
+			return
+		frappe.throw(
+			_("Only a reviewer can widen the scope or change the audience of an "
+			  "existing skill. Request a promotion instead."),
+			frappe.PermissionError,
+		)
 
 	def _validate_slug(self):
 		self.skill_name = (self.skill_name or "").strip().lower()

--- a/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
+++ b/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
@@ -46,7 +46,8 @@
     "counter_evidence",
     "flags_count",
     "flag_band_cap",
-    "overlap_warning"
+    "overlap_warning",
+    "personalise_origin"
   ],
   "fields": [
     {
@@ -305,6 +306,14 @@
       "fieldtype": "Small Text",
       "label": "Overlap Warning",
       "description": "Lexical overlap with a customer-authored skill (warn-only)."
+    },
+    {
+      "fieldname": "personalise_origin",
+      "fieldtype": "Check",
+      "label": "Personalise Origin",
+      "default": "0",
+      "read_only": 1,
+      "description": "Security review PART 2 TASK 16: a contribution to this pattern came from a user's PRIVATE Personalise answer note. A reviewer promoting it org-wide must scrub personal names/nuances first (a non-blocking warning is shown on the board), since the owner did not themselves request the promotion."
     }
   ],
   "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
+++ b/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
@@ -1,18 +1,18 @@
 {
   "doctype": "DocType",
-  "name": "Jarvis Wiki Promotion Request",
+  "name": "Jarvis Skill Promotion Request",
   "module": "Jarvis",
   "issingle": 0,
   "custom": 0,
   "engine": "InnoDB",
-  "autoname": "format:JWPR-{#####}",
+  "autoname": "format:JSPR-{#####}",
   "naming_rule": "Expression",
   "field_order": [
-    "page",
+    "skill",
+    "skill_name",
     "from_scope",
     "to_scope",
     "target_role",
-    "body_snapshot",
     "note",
     "status",
     "reviewer",
@@ -21,29 +21,37 @@
   ],
   "fields": [
     {
-      "fieldname": "page",
+      "fieldname": "skill",
       "fieldtype": "Link",
-      "label": "Page",
-      "options": "Jarvis Wiki Page",
+      "label": "Skill",
+      "options": "Jarvis Custom Skill",
       "reqd": 1,
       "in_list_view": 1,
       "in_standard_filter": 1,
       "search_index": 1,
-      "description": "The User-scope wiki page this request asks to promote."
+      "description": "The User/Role-scope custom skill this request asks to promote."
+    },
+    {
+      "fieldname": "skill_name",
+      "fieldtype": "Data",
+      "label": "Skill Name",
+      "read_only": 1,
+      "in_list_view": 1,
+      "description": "The skill's authored slug at request time (for the reviewer board)."
     },
     {
       "fieldname": "from_scope",
       "fieldtype": "Select",
       "label": "From Scope",
-      "options": "Org\nRole\nUser",
+      "options": "User\nRole\nOrg",
       "reqd": 1,
-      "description": "Snapshot of the page's scope at request time (User in practice for v1 - a requester can only act on their own User-scope page)."
+      "description": "Snapshot of the skill's scope at request time."
     },
     {
       "fieldname": "to_scope",
       "fieldtype": "Select",
       "label": "To Scope",
-      "options": "Org\nRole\nUser",
+      "options": "Role\nOrg",
       "reqd": 1,
       "in_list_view": 1,
       "in_standard_filter": 1,
@@ -56,12 +64,6 @@
       "options": "Role",
       "depends_on": "eval:doc.to_scope=='Role'",
       "mandatory_depends_on": "eval:doc.to_scope=='Role'"
-    },
-    {
-      "fieldname": "body_snapshot",
-      "fieldtype": "Long Text",
-      "label": "Body Snapshot",
-      "description": "The page's body_md at request time, frozen so the reviewer can diff it against the current target page even if the source page keeps changing in the meantime."
     },
     {
       "fieldname": "note",

--- a/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.py
+++ b/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.py
@@ -1,0 +1,61 @@
+"""Jarvis Skill Promotion Request DocType controller (security review PART 2,
+TASK 10).
+
+One row per "promote my private (User) or role skill up the scope ladder" ask,
+the Custom-Skill analogue of ``Jarvis Wiki Promotion Request``. Created by
+``jarvis.chat.custom_skills_api.request_skill_promotion`` when a skill owner
+asks to widen a skill they own; decided by a skill reviewer
+(``custom_skills_api.decide_skill_promotion``), who approves (widening the
+skill's scope) or rejects. The ``All`` role only ever gets read/create-free
+here (create dropped, so the ownership-checked endpoint is the sole creation
+path); a requester can never self-approve or edit a decision after the fact.
+
+Promotion only ever WIDENS visibility: ``to_scope`` is Role/Org (never back to
+User, never sideways). ``from_scope`` is a point-in-time snapshot of the source
+skill's scope, re-validated at decision time by the reviewer endpoint.
+"""
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+SKILL = "Jarvis Custom Skill"
+FROM_SCOPES = ("User", "Role", "Org")
+TO_SCOPES = ("Role", "Org")
+
+
+class JarvisSkillPromotionRequest(Document):
+	def before_insert(self):
+		# The requester must be able to READ the source skill before a request is
+		# filed against it — closes the same generic-REST disclosure class as the
+		# Wiki promotion request (TASK 14). Runs for EVERY insert path; the skill
+		# ORM hook resolves User-scope skills to their owner, so this subsumes an
+		# explicit owner check. Administrator bypasses has_permission natively.
+		if self.skill and not frappe.has_permission(SKILL, "read", self.skill):
+			frappe.throw(
+				_("You do not have access to this skill."), frappe.PermissionError
+			)
+		if self.skill and not self.skill_name:
+			self.skill_name = frappe.db.get_value(SKILL, self.skill, "skill_name") or ""
+
+	def validate(self):
+		self._validate_skill()
+		self._validate_scopes()
+
+	def _validate_skill(self):
+		if not self.skill:
+			frappe.throw(_("A promotion request must reference a skill."))
+
+	def _validate_scopes(self):
+		self.from_scope = (self.from_scope or "").strip()
+		if self.from_scope and self.from_scope not in FROM_SCOPES:
+			frappe.throw(
+				_("From Scope must be one of {0}.").format(", ".join(FROM_SCOPES))
+			)
+		self.to_scope = (self.to_scope or "").strip()
+		if self.to_scope not in TO_SCOPES:
+			frappe.throw(
+				_("To Scope must be one of {0}.").format(", ".join(TO_SCOPES))
+			)
+		if self.to_scope == "Role" and not self.target_role:
+			frappe.throw(_("Promoting to Role scope needs a Target Role."))

--- a/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.json
+++ b/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.json
@@ -126,7 +126,7 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "read": 1,
       "write": 1,
       "create": 1,

--- a/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.py
+++ b/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.py
@@ -67,3 +67,20 @@ class JarvisVoiceNote(Document):
 			frappe.throw(
 				_("A Conversation-context voice note must link a conversation.")
 			)
+		# Cross-link ownership guard (security review TASK 5): a note may only
+		# reference a conversation the caller OWNS. if_owner blocks cross-user
+		# READS, but without this a user could still link attacker content into
+		# another user's conversation namespace (and its wiki-ingest pipeline).
+		# Server writers (ignore_permissions — the API endpoints already verify
+		# ownership before insert) and Administrator are exempt.
+		if self.conversation and not (
+			self.flags.ignore_permissions or frappe.session.user == "Administrator"
+		):
+			owner = frappe.db.get_value(
+				"Jarvis Conversation", self.conversation, "owner"
+			)
+			if owner and owner != frappe.session.user:
+				frappe.throw(
+					_("You can only attach notes to your own conversations."),
+					frappe.PermissionError,
+				)

--- a/jarvis/jarvis/doctype/jarvis_wiki_promotion_request/jarvis_wiki_promotion_request.py
+++ b/jarvis/jarvis/doctype/jarvis_wiki_promotion_request/jarvis_wiki_promotion_request.py
@@ -29,6 +29,17 @@ TO_SCOPES = ("Role", "Org")
 
 class JarvisWikiPromotionRequest(Document):
 	def before_insert(self):
+		# Security review PART 2 TASK 14: this row's before_insert back-fills
+		# body_snapshot from the source page with a permission-bypassing
+		# db.get_value. Because the doctype used to grant `All: create`, a System
+		# User could frappe.client.insert a request naming ANOTHER user's private
+		# (User-scope) wiki page and read the victim's body_md back through the row
+		# they own (if_owner). Assert the caller can actually READ the page BEFORE
+		# snapshotting — closes the generic-REST disclosure at the controller so it
+		# holds no matter which door the insert comes through (the bare `All:
+		# create` grant is also dropped from the JSON, leaving the ownership-checked
+		# request_wiki_promotion endpoint as the only creation path).
+		self._guard_page_readable()
 		# Freeze the diff basis at request time (DESIGN.md 2.4): if the caller
 		# didn't already snapshot the body, pull it from the live page once,
 		# here, so a later edit to the source page can never retroactively
@@ -36,6 +47,20 @@ class JarvisWikiPromotionRequest(Document):
 		if not self.body_snapshot and self.page:
 			self.body_snapshot = (
 				frappe.db.get_value("Jarvis Wiki Page", self.page, "body_md") or ""
+			)
+
+	def _guard_page_readable(self):
+		"""The requester must be able to READ the source page before it is
+		snapshotted into a row they own. Runs for EVERY insert path (REST
+		included); Administrator bypasses frappe.has_permission natively. The
+		wiki's own has_permission hook resolves User-scope pages to their
+		target_user, so this subsumes an explicit owner check."""
+		if not self.page:
+			return
+		if not frappe.has_permission("Jarvis Wiki Page", "read", self.page):
+			frappe.throw(
+				_("You do not have access to this wiki page."),
+				frappe.PermissionError,
 			)
 
 	def validate(self):

--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -459,6 +459,11 @@ def _upsert_managed_skill(spec: dict) -> str:
 	doc.user_invocable = 0
 	doc.enabled = 1
 	doc.managed_by_learning = 1
+	# Managed learned rows are org-effect (role-gated at runtime by
+	# learned_skill_clause via allowed_roles); pin scope=Org so the new
+	# private-first User default (security review PART 2 TASK 10) never applies to
+	# them. The engine flag is set here, so the scope guard admits the write.
+	doc.scope = "Org"
 	doc.set("allowed_roles", [{"role": r} for r in spec["allowed_roles"]])
 	doc.save(ignore_permissions=True) if existing else doc.insert(ignore_permissions=True)
 	return doc.name

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -542,6 +542,13 @@ def _persist_rule_facts(rule_facts: list[dict]) -> dict:
 				stats["duplicates"] += 1
 			if outcome in ("created", "updated"):
 				_surface(cand["pattern_key"])
+				# Security review PART 2 TASK 16: a rule fact drawn (even partly)
+				# from a PRIVATE Personalise answer note carries personal nuances;
+				# stamp the pattern so a reviewer promoting it org-wide is warned to
+				# scrub them (the owner did not request the promotion). Sticky once
+				# set — a mixed-cohort pattern stays flagged (conservative).
+				if fact.get("personalise_users"):
+					_flag_personalise_origin(cand["pattern_key"])
 
 		frappe.db.set_value(
 			RUN,
@@ -566,6 +573,18 @@ def _persist_rule_facts(rule_facts: list[dict]) -> dict:
 		frappe.flags.jarvis_pattern_engine = prev_flag
 		frappe.set_user(original_user)
 	return stats
+
+
+def _flag_personalise_origin(pattern_key: str) -> None:
+	"""Stamp ``personalise_origin=1`` on the JLP for ``pattern_key`` (idempotent,
+	sticky). Security review PART 2 TASK 16 provenance."""
+	row = frappe.db.get_value(
+		JLP, {"pattern_key": pattern_key}, ["name", "personalise_origin"], as_dict=True
+	)
+	if row and not row.personalise_origin:
+		frappe.db.set_value(
+			JLP, row.name, {"personalise_origin": 1}, update_modified=False
+		)
 
 
 def _surface(pattern_key: str) -> None:

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -19,3 +19,4 @@ jarvis.patches.v1_9_backfill_wiki_manual_links
 jarvis.patches.v1_10_backfill_llm_pool_synced_at
 jarvis.patches.v1_0.grant_jarvis_user_role
 jarvis.patches.v1_11_greeting_cadence
+jarvis.patches.v1_0.revoke_jarvis_user_from_website_users

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -20,3 +20,4 @@ jarvis.patches.v1_10_backfill_llm_pool_synced_at
 jarvis.patches.v1_0.grant_jarvis_user_role
 jarvis.patches.v1_11_greeting_cadence
 jarvis.patches.v1_0.revoke_jarvis_user_from_website_users
+jarvis.patches.v1_12_skill_scope_ladder

--- a/jarvis/patches/v1_0/revoke_jarvis_user_from_website_users.py
+++ b/jarvis/patches/v1_0/revoke_jarvis_user_from_website_users.py
@@ -1,0 +1,53 @@
+"""Revoke the 'Jarvis User' role from Website (portal) users.
+
+Follow-up to ``grant_jarvis_user_role`` (security review PART 1 TASK 6). The
+original backfill granted 'Jarvis User' to EVERY enabled user — System Users
+AND Website Users — to preserve the previously-open access. But portal/website
+users are a distinct, lower-trust population that must not reach Jarvis chat:
+the shared access gate (``jarvis.permissions.has_jarvis_access``) now also
+requires ``user_type == "System User"``, and the role should follow the same
+policy so the two never drift.
+
+We do NOT rewrite the already-applied grant patch (it ran on existing benches);
+this new, separately-registered patch removes the role from any Website User
+that received it. Idempotent: re-runs are no-ops once the rows are gone.
+
+Website Users legitimately hold NO desk-access role, so a bare ``Has Role`` row
+delete is safe — Frappe never renders a portal user through Desk regardless.
+"""
+
+import frappe
+
+from jarvis.permissions import JARVIS_USER_ROLE
+
+
+def execute():
+	if not frappe.db.exists("Role", JARVIS_USER_ROLE):
+		return
+
+	# Every user that holds the role AND is a Website User.
+	holders = frappe.get_all(
+		"Has Role",
+		filters={"parenttype": "User", "role": JARVIS_USER_ROLE},
+		pluck="parent",
+	)
+	if not holders:
+		return
+
+	website_users = set(
+		frappe.get_all(
+			"User",
+			filters={"name": ["in", list(set(holders))], "user_type": "Website User"},
+			pluck="name",
+		)
+	)
+	for user in website_users:
+		# Delete the child Has Role row directly rather than loading + saving the
+		# full User doc — mirrors the grant patch's insert-the-row approach.
+		frappe.db.delete(
+			"Has Role",
+			{"parenttype": "User", "parent": user, "role": JARVIS_USER_ROLE},
+		)
+		frappe.clear_cache(user=user)
+
+	frappe.db.commit()

--- a/jarvis/patches/v1_12_skill_scope_ladder.py
+++ b/jarvis/patches/v1_12_skill_scope_ladder.py
@@ -1,0 +1,24 @@
+"""Security review PART 2 TASK 10: migrate Jarvis Custom Skill onto the
+{User, Role, Org} scope ladder (default User).
+
+Legacy rows carried scope ∈ {Org, Personal} (default Org). The ladder renames
+"Personal" -> "User" (a private, owner-only skill) and treats a NULL/empty
+scope (pre-scope-field rows) as its historical meaning, Org. Org rows stay Org.
+Idempotent.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Jarvis Custom Skill", "scope"):
+		return
+	# Personal is the pre-ladder spelling of User.
+	frappe.db.sql(
+		"UPDATE `tabJarvis Custom Skill` SET `scope` = 'User' WHERE `scope` = 'Personal'"
+	)
+	# Pre-scope rows (NULL/empty) meant Org.
+	frappe.db.sql(
+		"UPDATE `tabJarvis Custom Skill` SET `scope` = 'Org' "
+		"WHERE `scope` IS NULL OR `scope` = ''"
+	)

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -26,6 +26,35 @@ import frappe
 JARVIS_USER_ROLE = "Jarvis User"
 JARVIS_ACCESS_ROLES = ("System Manager", JARVIS_USER_ROLE)
 
+# Reviewer set authorized for org-wide skill / pattern / wiki effects (security
+# review PART 2, TASK 15 — RATIFIED). Housed in this lightweight module (no heavy
+# imports) so the Jarvis Custom Skill controller / skill_permissions can import it
+# without pulling in the learned_api import graph. Keep in sync with
+# jarvis.chat.learned_api._REVIEWER_ROLES.
+JARVIS_REVIEWER_ROLES = ("Jarvis Skill Reviewer", "Jarvis Admin", "System Manager")
+
+
+def is_skill_reviewer(user: str | None = None) -> bool:
+	"""True iff ``user`` may authorize org-wide skill effects: promote a Custom
+	Skill up the User→Role→Org scope ladder, or apply skills bench-wide.
+	``Administrator`` always passes. Defaults to the current session user."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return True
+	return bool(set(JARVIS_REVIEWER_ROLES) & set(frappe.get_roles(user)))
+
+
+def require_skill_reviewer(user: str | None = None) -> None:
+	"""Raise ``frappe.PermissionError`` unless ``user`` is a skill reviewer
+	(Jarvis Skill Reviewer / Jarvis Admin / System Manager; Administrator
+	implicit). Whitelisted endpoints call this to gate org-wide skill effects."""
+	if not is_skill_reviewer(user):
+		frappe.throw(
+			"This action needs a Jarvis Skill Reviewer, Jarvis Admin or System "
+			"Manager role.",
+			frappe.PermissionError,
+		)
+
 
 def ensure_jarvis_user_role() -> None:
 	"""Idempotently create the ``Jarvis User`` role (desk-access). Shared by the

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -14,6 +14,9 @@ identity that legitimately may not hold the role.
 
 from __future__ import annotations
 
+import functools
+from contextlib import contextmanager
+
 import frappe
 
 # The role name + the access rule, everywhere: "Jarvis User" OR "System Manager"
@@ -40,12 +43,27 @@ def ensure_jarvis_user_role() -> None:
 def has_jarvis_access(user: str | None = None) -> bool:
 	"""True iff ``user`` may reach Jarvis.
 
-	``Administrator`` is always allowed; otherwise the user must hold at least
+	``Administrator`` is always allowed; otherwise the user must be a **System
+	User** (never a Website/portal user - PART 1 TASK 6: portal users are a
+	distinct, lower-trust population and must not reach chat) AND hold at least
 	one of :data:`JARVIS_ACCESS_ROLES`. Defaults to the current session user."""
 	user = user or frappe.session.user
 	if user == "Administrator":
 		return True
+	if not is_system_user(user):
+		return False
 	return bool(set(JARVIS_ACCESS_ROLES) & set(frappe.get_roles(user)))
+
+
+def is_system_user(user: str | None = None) -> bool:
+	"""True iff ``user`` is a Desk (System User), not a Website/portal user.
+	``Administrator`` counts. Defaults to the current session user."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return True
+	if not user or user == "Guest":
+		return False
+	return frappe.db.get_value("User", user, "user_type") == "System User"
 
 
 def require_jarvis_access(user: str | None = None) -> None:
@@ -60,3 +78,49 @@ def require_jarvis_access(user: str | None = None) -> None:
 			"You need the Jarvis User role to use Jarvis. Ask an administrator for access.",
 			frappe.PermissionError,
 		)
+
+
+def require_jarvis_user(fn):
+	"""Decorator form of :func:`require_jarvis_access` for whitelisted chat
+	endpoints (PART 1 TASK 8).
+
+	Replaces the per-function ``require_jarvis_access()`` call convention with a
+	single declarative marker so the ``test_chat_endpoint_gating`` coverage test
+	can enumerate every ``@frappe.whitelist`` function under ``jarvis/chat/`` and
+	assert each is either decorated or explicitly allowlisted - the "new endpoint
+	forgot the gate" regression class can no longer slip through.
+
+	Stack it BELOW ``@frappe.whitelist()`` (whitelist outermost) so Frappe
+	registers the wrapper, and the gate runs before the body. ``functools.wraps``
+	preserves the signature + annotations so Frappe's
+	``require_type_annotated_api_methods`` still sees the real parameters.
+	"""
+
+	@functools.wraps(fn)
+	def wrapper(*args, **kwargs):
+		require_jarvis_access()
+		return fn(*args, **kwargs)
+
+	# Marker the coverage test reads (survives functools.wraps).
+	wrapper.__jarvis_gated__ = True
+	return wrapper
+
+
+@contextmanager
+def delegated_send():
+	"""Mark the enclosed call stack as a TRUSTED server / delegated re-entry into
+	``jarvis.chat.api.send_message`` (the scheduler, approval-resume, agent-run
+	and File-Box drop paths), which run under ``impersonate(owner)`` where the
+	impersonated owner legitimately may not hold the ``Jarvis User`` role.
+
+	Uses ``frappe.flags`` (never an HTTP-settable parameter) so a browser POST
+	cannot forge it. ``send_message`` reads this flag to (a) accept the call
+	past its access gate and (b) insert the seed user message / touch the
+	conversation with ``ignore_permissions`` so the now role-gated Message/
+	Conversation create perms do not break the resume."""
+	prev = frappe.flags.get("jarvis_delegated_send")
+	frappe.flags.jarvis_delegated_send = True
+	try:
+		yield
+	finally:
+		frappe.flags.jarvis_delegated_send = prev

--- a/jarvis/tests/learning/test_compiler.py
+++ b/jarvis/tests/learning/test_compiler.py
@@ -520,6 +520,9 @@ class TestApplyLearnedSkills(FrappeTestCase):
 			"instructions": "y",
 			"enabled": 1,
 			"user_invocable": 0,
+			# Org scope: only Org skills join the shared push (TASK 10 made User the
+			# default, which is never pushed).
+			"scope": "Org",
 			"managed_by_learning": 0,
 		})
 		d.owner = "Administrator"
@@ -593,6 +596,8 @@ class TestApplyLearnedSkills(FrappeTestCase):
 				"instructions": "y",
 				"enabled": 1,
 				"user_invocable": 0,
+				# Org scope: only Org skills join the shared push (TASK 10).
+				"scope": "Org",
 				"managed_by_learning": 0,
 			})
 			d.creation = d.modified = frappe.utils.now()

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -42,6 +42,9 @@ def _give_role(email: str, role_name: str) -> None:
 
 
 def _ensure_user(email: str) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User",
@@ -49,9 +52,19 @@ def _ensure_user(email: str) -> str:
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0,
 			"enabled": 1,
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
+		frappe.db.commit()
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
+	# The agents endpoints are chat-surface: they now require the Jarvis User
+	# role (security review TASK 8). Grant it so the fixtures reach the
+	# agent-specific allowed_roles / owner gates they actually test.
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 

--- a/jarvis/tests/test_chat_asks.py
+++ b/jarvis/tests/test_chat_asks.py
@@ -61,18 +61,30 @@ def _ask(q="Which supplier is this from?", type="single", options=("Acme", "Glob
 # module fixtures / helpers
 # --------------------------------------------------------------------------- #
 def _ensure_user(email: str) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0, "enabled": 1,
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
 		frappe.db.commit()
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
 	roles = set(frappe.get_roles(email))
 	if "System Manager" in roles:
 		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	# Approvals endpoints are chat-surface: now require the Jarvis User role
+	# (security review TASK 8).
+	if "Jarvis User" not in roles:
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 

--- a/jarvis/tests/test_chat_endpoint_gating.py
+++ b/jarvis/tests/test_chat_endpoint_gating.py
@@ -1,0 +1,119 @@
+"""Coverage guard: every ``@frappe.whitelist`` endpoint under ``jarvis/chat/``
+must be access-gated (security review PART 1 TASK 8).
+
+The requirement ("Jarvis + chat accessible ONLY if the Jarvis User role is
+given") only holds if NO whitelisted chat endpoint is reachable without an
+access check. Historically the role gate lived only in ``chat/api.py`` and was
+applied ad-hoc, so ~60 SPA endpoints across the other ``chat/*_api.py`` modules
+were reachable with just a session cookie + CSRF token. This test enumerates
+every whitelisted function under ``jarvis/chat/`` (AST-derived, never a
+hand-kept list) and asserts each one is gated, so the "new endpoint forgot the
+gate" regression class fails CI permanently.
+
+An endpoint counts as gated when it:
+  * carries the ``@require_jarvis_user`` decorator (the preferred forward form,
+    ``jarvis.permissions``), OR
+  * calls a recognized access guard in its body — the Jarvis-User gate
+    (``require_jarvis_access``), a stricter role gate
+    (``frappe.only_for`` / the module reviewer/admin ``_guard`` helpers), a
+    System-User gate (``_require_system_user``), or a per-doc ownership gate
+    (``check_permission`` / ``_may_act_on`` / ``_get_owned_conversation``) that
+    the security review blesses as "already correct", OR
+  * is listed in :data:`_OWNER_GATED_ALLOWLIST` with a one-line justification.
+
+Any whitelisted chat endpoint that is none of these fails the test.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+from frappe.tests.utils import FrappeTestCase
+
+_CHAT_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "chat")
+
+# The gate decorator (marker the wrapper stamps + the source-level name).
+_GATE_DECORATOR = "require_jarvis_user"
+
+# Substrings identifying an access-guard CALL inside an endpoint body. Kept in
+# sync with the guards the security review recognizes; a new module-local guard
+# helper just needs a recognizable name (``_guard`` / ``_require_*`` / ``*only_for*``).
+_GUARD_CALL_SUBSTRS = (
+	"require_jarvis_access",
+	"require_jarvis_user",
+	"_require_system_user",
+	"only_for",  # frappe.only_for(...) — an SM/role gate, stricter than Jarvis User
+	"_guard",  # learned_api._guard / _admin_guard (reviewer/admin role gate)
+	"_reviewer_roles",
+	"_admin_roles",
+	"check_permission",  # per-doc owner/role gate (Frappe native)
+	"_may_act_on",  # approvals ownership gate
+	"_get_owned_conversation",  # chat/api ownership gate
+	"has_jarvis_access",
+)
+
+# Endpoints intentionally gate-free (with a one-line justification). Empty by
+# design: every current chat endpoint is gated by decorator or an in-body guard.
+# Add an entry ONLY with a reviewer-approved reason (e.g. a deliberately public
+# health probe); the test then permits it and documents why.
+_OWNER_GATED_ALLOWLIST: dict[str, str] = {}
+
+
+def _is_whitelisted(node: ast.FunctionDef) -> bool:
+	return any("whitelist" in ast.unparse(d) for d in node.decorator_list)
+
+
+def _has_gate_decorator(node: ast.FunctionDef) -> bool:
+	return any(_GATE_DECORATOR in ast.unparse(d) for d in node.decorator_list)
+
+
+def _calls_a_guard(node: ast.FunctionDef) -> bool:
+	for sub in ast.walk(node):
+		if isinstance(sub, ast.Call):
+			try:
+				name = ast.unparse(sub.func)
+			except Exception:
+				name = ""
+			if any(g in name for g in _GUARD_CALL_SUBSTRS):
+				return True
+	return False
+
+
+def _iter_chat_endpoints():
+	"""Yield ``(module, funcname, node)`` for every whitelisted function under
+	jarvis/chat/ — AST-derived so a new endpoint is swept automatically."""
+	for fname in sorted(os.listdir(_CHAT_DIR)):
+		if not fname.endswith(".py"):
+			continue
+		path = os.path.join(_CHAT_DIR, fname)
+		with open(path, encoding="utf-8") as fh:
+			tree = ast.parse(fh.read(), filename=path)
+		for node in ast.walk(tree):
+			if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_whitelisted(node):
+				yield fname[:-3], node.name, node
+
+
+class TestChatEndpointGating(FrappeTestCase):
+	def test_every_chat_endpoint_is_access_gated(self):
+		found_any = False
+		offenders = []
+		for module, name, node in _iter_chat_endpoints():
+			found_any = True
+			key = f"{module}.{name}"
+			if key in _OWNER_GATED_ALLOWLIST:
+				continue
+			if _has_gate_decorator(node) or _calls_a_guard(node):
+				continue
+			offenders.append(key)
+
+		self.assertTrue(
+			found_any,
+			"sweep found no whitelisted chat endpoints - the AST walk broke",
+		)
+		self.assertFalse(
+			offenders,
+			"ungated @frappe.whitelist chat endpoints (reachable with just a "
+			"session cookie + CSRF - add @require_jarvis_user, call an access "
+			"guard, or allowlist with a justification): " + ", ".join(sorted(offenders)),
+		)

--- a/jarvis/tests/test_chat_endpoint_gating.py
+++ b/jarvis/tests/test_chat_endpoint_gating.py
@@ -42,6 +42,7 @@ _GATE_DECORATOR = "require_jarvis_user"
 _GUARD_CALL_SUBSTRS = (
 	"require_jarvis_access",
 	"require_jarvis_user",
+	"require_skill_reviewer",  # PART 2 TASK 12: skill-reviewer/admin gate (org-wide apply)
 	"_require_system_user",
 	"only_for",  # frappe.only_for(...) — an SM/role gate, stricter than Jarvis User
 	"_guard",  # learned_api._guard / _admin_guard (reviewer/admin role gate)

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -257,8 +257,12 @@ class TestConfirmTool(FrappeTestCase):
 		if not frappe.db.exists("User", other):
 			frappe.get_doc({
 				"doctype": "User", "email": other, "first_name": "Other",
-				"send_welcome_email": 0,
+				"send_welcome_email": 0, "user_type": "System User",
 			}).insert(ignore_permissions=True)
+		# confirm_tool is @require_jarvis_user-gated; a realistic non-owner caller
+		# holds the role, so the owner-mismatch (not the role gate) is what rejects.
+		if "Jarvis User" not in set(frappe.get_roles(other)):
+			frappe.get_doc("User", other).add_roles("Jarvis User")
 
 		original = frappe.session.user
 		frappe.set_user(other)
@@ -583,8 +587,12 @@ class TestListPendingConfirmations(FrappeTestCase):
 		if not frappe.db.exists("User", email):
 			frappe.get_doc({
 				"doctype": "User", "email": email, "first_name": "LP",
-				"send_welcome_email": 0,
+				"send_welcome_email": 0, "user_type": "System User",
 			}).insert(ignore_permissions=True)
+		# list_pending_confirmations is @require_jarvis_user-gated; the owner
+		# caller needs the role to reach the owner-scoped listing.
+		if "Jarvis User" not in set(frappe.get_roles(email)):
+			frappe.get_doc("User", email).add_roles("Jarvis User")
 		return email
 
 	def setUp(self):

--- a/jarvis/tests/test_custom_skill_visibility.py
+++ b/jarvis/tests/test_custom_skill_visibility.py
@@ -41,8 +41,12 @@ def _engine_flag():
 
 
 def _ensure_non_sm(email: str) -> str:
-	"""A logged-in user with no System Manager role (created inside the test
-	transaction, so it is rolled back with everything else)."""
+	"""A logged-in Jarvis User with NO System Manager role (created inside the
+	test transaction, so it is rolled back with everything else). The Jarvis User
+	role is what now grants Custom Skill create at the doctype layer (security
+	review PART 2 TASK 13 replaced the old `All` grant), so a realistic non-SM
+	author holds it — the point of these tests is that even a role-holding author
+	cannot forge the managed flag / learned slug."""
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
@@ -50,8 +54,11 @@ def _ensure_non_sm(email: str) -> str:
 		})
 		u.flags.ignore_permissions = True
 		u.insert(ignore_permissions=True)
+	udoc = frappe.get_doc("User", email)
 	if "System Manager" in set(frappe.get_roles(email)):
-		frappe.get_doc("User", email).remove_roles("System Manager")
+		udoc.remove_roles("System Manager")
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		udoc.add_roles("Jarvis User")
 	return email
 
 

--- a/jarvis/tests/test_custom_skills_push.py
+++ b/jarvis/tests/test_custom_skills_push.py
@@ -40,6 +40,9 @@ def _mk(suffix, *, owner=OWNER, enabled=1, managed=0, skill_name=None):
 		"instructions": "body",
 		"enabled": enabled,
 		"user_invocable": 0,
+		# Org scope: only Org skills join the shared container push (security
+		# review PART 2 TASK 10 made User the default, which is never pushed).
+		"scope": "Org",
 		"managed_by_learning": managed,
 	})
 	# db_insert stamps owner with the session user unless creation is already

--- a/jarvis/tests/test_docmeta_api.py
+++ b/jarvis/tests/test_docmeta_api.py
@@ -40,18 +40,33 @@ CONV = "Jarvis Conversation"
 
 
 def _ensure_user(email: str) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0, "enabled": 1,
+			# System User so the chat-surface access gate (which now requires a
+			# Desk user + the Jarvis User role) admits the fixture.
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
 		frappe.db.commit()
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
 	roles = set(frappe.get_roles(email))
 	if "System Manager" in roles:
 		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	# The docmeta/approvals endpoints are chat-surface: they now require the
+	# Jarvis User role (security review TASK 8). Grant it so these non-SM
+	# fixtures still exercise the ownership/DocShare logic.
+	if "Jarvis User" not in roles:
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 

--- a/jarvis/tests/test_feature_pages_api.py
+++ b/jarvis/tests/test_feature_pages_api.py
@@ -48,19 +48,31 @@ APPROVAL = "Jarvis Approval Request"
 # module fixtures / helpers
 # --------------------------------------------------------------------------- #
 def _ensure_user(email: str) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0, "enabled": 1,
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
 		frappe.db.commit()
-	# Guarantee these test users are NOT System Managers (non-SM scoping path).
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
+	# Guarantee these test users are NOT System Managers (non-SM scoping path)
+	# but DO hold the Jarvis User role (the approvals endpoints are chat-surface
+	# and now require it — security review TASK 8).
 	roles = set(frappe.get_roles(email))
 	if "System Manager" in roles:
 		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	if "Jarvis User" not in roles:
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 

--- a/jarvis/tests/test_jarvis_chat_message.py
+++ b/jarvis/tests/test_jarvis_chat_message.py
@@ -78,12 +78,55 @@ class TestJarvisChatMessageDocType(FrappeTestCase):
 		finally:
 			_cleanup_conversation(conv)
 
-	def test_owner_only_read_perm(self):
+	def test_read_scoped_to_jarvis_user_role(self):
+		"""Security review TASK 7: Jarvis Chat Message read is granted only to
+		"Jarvis User" (+ System Manager), NOT to ``role: "All"``, and is NOT
+		row-``owner`` ``if_owner`` scoped. The ownership axis is the LINKED
+		conversation's owner, enforced at the ORM by
+		``jarvis.chat.chat_permissions`` (permission_query_conditions +
+		has_permission) — the message row's own owner is not the authority, so
+		``if_owner`` must NOT be set on these rows (it would wrongly hide the
+		worker-owned assistant/tool rows of the caller's own conversation)."""
 		meta = frappe.get_meta(DOCTYPE)
+		read_roles = {p.role for p in meta.permissions if p.read and (p.permlevel or 0) == 0}
+		self.assertNotIn("All", read_roles, "chat message read must not be granted to role 'All'")
+		self.assertEqual(
+			read_roles,
+			{"Jarvis User", "System Manager"},
+			f"unexpected read roles on Jarvis Chat Message: {read_roles}",
+		)
 		for perm in meta.permissions:
-			if perm.read:
-				self.assertEqual(
+			if perm.read and (perm.permlevel or 0) == 0:
+				self.assertFalse(
 					perm.if_owner,
-					1,
-					f"role {perm.role} has read without if_owner",
+					f"role {perm.role} uses if_owner, but the axis is the linked "
+					f"conversation's owner (chat_permissions hooks), not the row owner",
 				)
+
+	def test_cross_conversation_injection_blocked(self):
+		"""TASK 2: a message pointing at a conversation the caller does not own
+		is rejected (has_permission hook + controller validate)."""
+		conv = _make_conversation("victim-conv")
+		attacker = "cm-inject-attacker@example.test"
+		try:
+			if not frappe.db.exists("User", attacker):
+				frappe.get_doc({
+					"doctype": "User", "email": attacker, "first_name": "atk",
+					"send_welcome_email": 0, "enabled": 1, "user_type": "System User",
+				}).insert(ignore_permissions=True)
+			frappe.get_doc("User", attacker).add_roles("Jarvis User")
+			# conv is owned by Administrator (inserted ignore_permissions); attacker
+			# is a different user, so the injection must be denied.
+			frappe.db.commit()
+			frappe.set_user(attacker)
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc({
+					"doctype": DOCTYPE, "conversation": conv, "seq": 42,
+					"role": "user", "content": "injected",
+				}).insert()
+		finally:
+			frappe.set_user("Administrator")
+			_cleanup_conversation(conv)
+			if frappe.db.exists("User", attacker):
+				frappe.delete_doc("User", attacker, ignore_permissions=True, force=True)
+			frappe.db.commit()

--- a/jarvis/tests/test_jarvis_conversation.py
+++ b/jarvis/tests/test_jarvis_conversation.py
@@ -34,15 +34,21 @@ class TestJarvisConversationDocType(FrappeTestCase):
 		self.assertIn("Archived", options)
 
 	def test_owner_can_read_own_only(self):
-		"""Permissions are owner-only (no role grants global read)."""
+		"""Permissions are owner-only and role-gated (security review TASK 7):
+		read at permlevel 0 is granted only to "Jarvis User"/"System Manager"
+		(NOT ``role: "All"``) and is ``if_owner`` scoped. The permlevel-1 row
+		(session_key protection, TASK 9) is SM-only and correctly carries no
+		``if_owner`` (permlevel rows are not owner-scoped)."""
 		meta = frappe.get_meta(DOCTYPE)
+		base_read_roles = {p.role for p in meta.permissions if p.read and (p.permlevel or 0) == 0}
+		self.assertNotIn("All", base_read_roles, "conversation read must not be granted to 'All'")
+		self.assertEqual(base_read_roles, {"Jarvis User", "System Manager"})
 		for perm in meta.permissions:
-			# Any read permission must be scoped: if_owner=1
-			if perm.read:
+			if perm.read and (perm.permlevel or 0) == 0:
 				self.assertEqual(
 					perm.if_owner,
 					1,
-					f"role {perm.role} has read without if_owner",
+					f"role {perm.role} has permlevel-0 read without if_owner",
 				)
 
 	def test_before_insert_sets_last_active_at(self):

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1,0 +1,452 @@
+"""Security review PART 2 — exploit reproductions + fix proofs.
+
+Covers the Custom Skill scope ladder + guards + ORM hook (TASK 10, 13), the
+role-restricted-body push exclusion (TASK 11), the reviewer/admin apply gate
+(TASK 12), the wiki-promotion-request generic-REST leak (TASK 14), the
+personalise-origin scrub provenance (TASK 16), the personalise-question
+`user`-keyed ORM hook (TASK 17) and four-eyes on promotion (TASK 19).
+
+Every test runs inside the FrappeTestCase transaction (rolled back), and each
+exploit is exercised through the SAME door a real attacker would use — a
+perm-checked ``doc.insert()`` / ``doc.save()`` (the generic-REST path) or the
+whitelisted endpoint — NOT ``ignore_permissions`` (which would mask the gate).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.custom_skills import build_push_payload, prefixed_slug
+
+SKILL = "Jarvis Custom Skill"
+WIKI = "Jarvis Wiki Page"
+WIKI_PROMO = "Jarvis Wiki Promotion Request"
+SKILL_PROMO = "Jarvis Skill Promotion Request"
+QUESTION = "Jarvis Personalise Question"
+
+REVIEWER = "p2-reviewer@example.com"
+USER_A = "p2-usera@example.com"
+USER_B = "p2-userb@example.com"
+PFX = "p2sec"
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+@contextlib.contextmanager
+def _engine_flag():
+	prev = frappe.flags.jarvis_pattern_engine
+	frappe.flags.jarvis_pattern_engine = True
+	try:
+		yield
+	finally:
+		frappe.flags.jarvis_pattern_engine = prev
+
+
+def _ensure_user(email: str, roles: list[str]) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc({
+			"doctype": "User", "email": email, "first_name": PFX,
+			"send_welcome_email": 0, "enabled": 1, "user_type": "System User",
+		})
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+	# Reload AFTER the db.set_value so add/remove_roles don't trip the timestamp
+	# concurrency check; each roles mutation saves, so reload between them.
+	if "System Manager" in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).remove_roles("System Manager")
+	add = [r for r in roles if r not in set(frappe.get_roles(email))]
+	if add:
+		frappe.get_doc("User", email).add_roles(*add)
+	return email
+
+
+def _sweep():
+	"""Committing cleanup: several endpoints under test call frappe.db.commit()
+	(approve/promote), so their rows survive the per-test rollback and would
+	otherwise pollute later runs (and trip the unique pattern_key). Roll back
+	uncommitted work first, then hard-delete + commit the committed residue."""
+	frappe.db.rollback()
+	for dt, filt in (
+		(SKILL, {"skill_name": ["like", f"{PFX}-%"]}),
+		(WIKI, {"slug": ["like", f"{PFX}-%"]}),
+		("Jarvis Learned Pattern", {"pattern_key": ["like", f"{PFX}-%"]}),
+	):
+		for n in frappe.get_all(dt, filters=filt, pluck="name"):
+			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+	for dt in (SKILL_PROMO, WIKI_PROMO, QUESTION):
+		frappe.db.delete(dt, {"owner": ["in", [REVIEWER, USER_A, USER_B]]})
+	frappe.db.commit()
+
+
+def _mk_skill(owner, skill_name, *, scope="User", allowed_roles=None,
+			  target_role=None, shared_with=None, enabled=1):
+	"""Mint a skill owned by ``owner`` at any scope (engine flag bypasses the
+	creation guard — that guard is proven separately)."""
+	with _as(owner), _engine_flag():
+		doc = frappe.get_doc({
+			"doctype": SKILL, "skill_name": skill_name,
+			"description": f"{skill_name} desc", "instructions": "body",
+			"scope": scope, "enabled": enabled, "user_invocable": 1,
+			"target_role": target_role,
+			"shared_with": [{"user": u} for u in (shared_with or [])],
+			"allowed_roles": [{"role": r} for r in (allowed_roles or [])],
+		})
+		doc.insert(ignore_permissions=True)
+	return doc
+
+
+class Part2Base(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		_sweep()
+		_ensure_user(REVIEWER, ["Jarvis User", "Jarvis Skill Reviewer"])
+		_ensure_user(USER_A, ["Jarvis User", "Sales User"])
+		_ensure_user(USER_B, ["Jarvis User"])
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_sweep()
+		super().tearDown()
+
+
+class TestScopeCreationGuard(Part2Base):
+	"""TASK 10: new skills default User; a non-reviewer cannot mint or widen a
+	Role/Org skill by any door."""
+
+	def test_default_scope_is_user(self):
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-default",
+				"description": "d", "instructions": "i",
+			})
+			doc.insert()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "User")
+
+	def test_non_reviewer_cannot_create_org_skill(self):
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-orgcreate",
+				"description": "d", "instructions": "i", "scope": "Org",
+			})
+			with self.assertRaises(frappe.PermissionError):
+				doc.insert()
+
+	def test_non_reviewer_cannot_flip_scope_via_save(self):
+		# The frappe.client.set_value / REST-PUT path both go through doc.save().
+		doc = _mk_skill(USER_A, f"{PFX}-flip", scope="User")
+		with _as(USER_A):
+			reloaded = frappe.get_doc(SKILL, doc.name)
+			reloaded.scope = "Org"
+			with self.assertRaises(frappe.PermissionError):
+				reloaded.save()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "User")
+
+	def test_reviewer_can_create_org_skill(self):
+		with _as(REVIEWER):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-revorg",
+				"description": "d", "instructions": "i", "scope": "Org",
+			})
+			doc.insert()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "Org")
+
+	def test_tool_caps_scope_at_user(self):
+		from jarvis.tools.create_custom_skill import create_custom_skill
+
+		with _as(USER_A):
+			out = create_custom_skill(
+				f"{PFX}-toolorg", "desc", "instr", scope="Org")
+		self.assertEqual(out["scope"], "User")
+		self.assertEqual(frappe.db.get_value(SKILL, out["name"], "scope"), "User")
+
+	def test_owner_can_narrow_own_scope(self):
+		# TASK E2: narrowing (Org->User) reduces visibility, so the owner may
+		# self-demote without a reviewer; only widening stays reviewer-gated.
+		skill = _mk_skill(USER_A, f"{PFX}-narrow", scope="Org")
+		with _as(USER_A):
+			doc = frappe.get_doc(SKILL, skill.name)
+			doc.scope = "User"
+			doc.save()
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+
+	def test_non_owner_update_gets_clear_message(self):
+		# TASK E1: a non-owner write is denied with a CLEAR message (not an
+		# empty-string PermissionError).
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_B, f"{PFX}-e1", scope="Org")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError) as ctx:
+				custom_skills_api.update_custom_skill(name=skill.name, description="hax")
+		self.assertIn("your own skills", str(ctx.exception))
+
+
+class TestSkillOrmHook(Part2Base):
+	"""TASK 13: generic-REST (get_list) returns the SAME visibility set as the
+	tools/SPA — owner OR scope=Org OR scope=Role role-match OR shared."""
+
+	def test_get_list_scopes_to_visible_set(self):
+		own = _mk_skill(USER_A, f"{PFX}-own", scope="User")
+		org = _mk_skill(USER_B, f"{PFX}-org", scope="Org")
+		role = _mk_skill(USER_B, f"{PFX}-role", scope="Role", target_role="Sales User")
+		other_private = _mk_skill(USER_B, f"{PFX}-bpriv", scope="User")
+		other_role_nomatch = _mk_skill(
+			USER_B, f"{PFX}-rolex", scope="Role", target_role="Stock User")
+		shared = _mk_skill(USER_B, f"{PFX}-shared", scope="User", shared_with=[USER_A])
+
+		with _as(USER_A):
+			names = set(frappe.get_list(
+				SKILL, filters={"skill_name": ["like", f"{PFX}-%"]},
+				pluck="name", limit_page_length=0))
+		self.assertIn(own.name, names)          # own
+		self.assertIn(org.name, names)          # org = everyone
+		self.assertIn(role.name, names)         # role-match (USER_A is Sales User)
+		self.assertIn(shared.name, names)       # shared with me
+		self.assertNotIn(other_private.name, names)      # another user's private
+		self.assertNotIn(other_role_nomatch.name, names) # role I don't hold
+
+	def test_has_permission_denies_foreign_private_read(self):
+		bpriv = _mk_skill(USER_B, f"{PFX}-bpriv2", scope="User")
+		with _as(USER_A):
+			self.assertFalse(frappe.has_permission(SKILL, "read", bpriv.name))
+			# write on a foreign row is denied too (owner-only).
+			org = _mk_skill(USER_B, f"{PFX}-borg", scope="Org")
+			self.assertFalse(frappe.has_permission(SKILL, "write", org.name))
+
+
+class TestRoleRestrictedPushExclusion(Part2Base):
+	"""TASK 11: a role-restricted Org body is never written to the shared,
+	role-blind container push."""
+
+	def test_role_restricted_org_skill_excluded_from_push(self):
+		plain = _mk_skill(REVIEWER, f"{PFX}-pushplain", scope="Org")
+		restricted = _mk_skill(
+			REVIEWER, f"{PFX}-pushrestricted", scope="Org",
+			allowed_roles=["Sales User"])
+		slugs = {p["slug"] for p in build_push_payload()}
+		self.assertIn(prefixed_slug(f"{PFX}-pushplain"), slugs)
+		self.assertNotIn(prefixed_slug(f"{PFX}-pushrestricted"), slugs)
+
+
+class TestApplyGate(Part2Base):
+	"""TASK 12: a plain Jarvis User cannot trigger a bench-wide apply."""
+
+	def test_plain_user_apply_denied(self):
+		from jarvis.chat import custom_skills_api
+
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.apply_custom_skills()
+
+	def test_reviewer_apply_passes_gate(self):
+		from jarvis.chat import custom_skills_api
+
+		with patch.object(
+			custom_skills_api, "_apply_custom_skills_impl", return_value={"ok": True}
+		) as impl:
+			with _as(REVIEWER):
+				out = custom_skills_api.apply_custom_skills()
+		self.assertTrue(out["ok"])
+		impl.assert_called_once()
+
+
+class TestSkillPromotionWorkflow(Part2Base):
+	"""TASK 10 promotion workflow + TASK 19 four-eyes."""
+
+	def test_request_then_reviewer_widens_scope(self):
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-promote", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		self.assertTrue(req["ok"])
+		# Still private until a reviewer decides.
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertTrue(out["ok"])
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "Org")
+
+	def test_requester_cannot_self_approve(self):
+		from jarvis.chat import custom_skills_api
+
+		# REVIEWER owns the skill AND requests promotion, then tries to decide.
+		skill = _mk_skill(REVIEWER, f"{PFX}-selfpromote", scope="User")
+		with _as(REVIEWER):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+
+	def test_non_reviewer_cannot_decide(self):
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-nodecide", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.decide_skill_promotion(req["request"], 1)
+
+	def test_reviewer_discovers_pending_requests(self):
+		# TASK D: a reviewer-only user must be able to SEE pending requests (the
+		# doctype perms are owner-scoped, so a reviewer needs the gated list
+		# endpoint to discover a JSPR they didn't create).
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-discover", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		with _as(REVIEWER):
+			res = custom_skills_api.list_skill_promotion_requests(status="Pending")
+		names = [r["name"] for r in res["rows"]]
+		self.assertIn(req["request"], names)
+		row = next(r for r in res["rows"] if r["name"] == req["request"])
+		self.assertEqual(row["requested_by"], USER_A)
+		self.assertEqual(row["to_scope"], "Org")
+		# A plain (non-reviewer) user cannot list the queue.
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.list_skill_promotion_requests()
+
+
+class TestWikiPromotionRequestLeak(Part2Base):
+	"""TASK 14: a generic-REST insert of a promotion request pointing at another
+	user's private wiki page must not snapshot that page's body."""
+
+	def _mk_private_page(self, owner, slug, body):
+		with _as(owner):
+			doc = frappe.get_doc({
+				"doctype": WIKI, "slug": slug, "title": slug,
+				"page_type": "Process", "scope": "User", "target_user": owner,
+				"body_md": body, "status": "Active",
+			})
+			doc.insert(ignore_permissions=True)
+		return doc
+
+	def _promo(self, page):
+		return frappe.get_doc({
+			"doctype": WIKI_PROMO, "page": page,
+			"from_scope": "User", "to_scope": "Org", "status": "Pending",
+		})
+
+	def test_foreign_private_page_snapshot_blocked_via_rest(self):
+		# Generic-REST insert (no ignore_permissions): the dropped `All: create`
+		# grant denies it outright.
+		victim_page = self._mk_private_page(
+			USER_B, f"{PFX}-secret", "TOP SECRET personal note")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				self._promo(victim_page.name).insert()
+
+	def test_foreign_private_page_snapshot_blocked_even_under_ignore_perms(self):
+		# Defense in depth: even a create-perm-bypassing server path is blocked by
+		# the before_insert read guard, so the victim's body is never snapshotted.
+		victim_page = self._mk_private_page(
+			USER_B, f"{PFX}-secret2", "TOP SECRET personal note")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				self._promo(victim_page.name).insert(ignore_permissions=True)
+
+	def test_owner_can_still_snapshot_own_page(self):
+		# The legit endpoint path inserts with ignore_permissions; the guard must
+		# not over-block the owner reading their own page.
+		mine = self._mk_private_page(USER_A, f"{PFX}-mine", "my own note body")
+		with _as(USER_A):
+			req = self._promo(mine.name)
+			req.insert(ignore_permissions=True)
+		self.assertEqual(req.body_snapshot, "my own note body")
+
+
+class TestPersonaliseQuestionHook(Part2Base):
+	"""TASK 17: generic-REST list of personalise questions is scoped on the
+	`user` field, surviving owner/user drift."""
+
+	def _mk_question(self, user, owner=None):
+		doc = frappe.get_doc({
+			"doctype": QUESTION, "user": user,
+			"question": f"{PFX} question for {user}", "origin": "From your organisation",
+			"status": "Unanswered",
+		})
+		doc.insert(ignore_permissions=True)
+		if owner and owner != doc.owner:
+			frappe.db.set_value(QUESTION, doc.name, "owner", owner, update_modified=False)
+		return doc
+
+	def test_list_scoped_on_user_not_owner(self):
+		mine = self._mk_question(USER_A)
+		theirs = self._mk_question(USER_B)
+		# Drift: a row whose `user` is B but `owner` was flipped to A must NOT
+		# leak to A (the hook keys on `user`).
+		drift = self._mk_question(USER_B, owner=USER_A)
+		with _as(USER_A):
+			names = set(frappe.get_list(
+				QUESTION, filters={"question": ["like", f"{PFX}%"]},
+				pluck="name", limit_page_length=0))
+		self.assertIn(mine.name, names)
+		self.assertNotIn(theirs.name, names)
+		self.assertNotIn(drift.name, names)
+
+
+class TestPersonaliseOriginProvenance(Part2Base):
+	"""TASK 16: a personalise-origin pattern carries a scrub warning to the
+	reviewer on the board + the promote action."""
+
+	def _mk_pattern(self, key, personalise_origin):
+		with _engine_flag():
+			doc = frappe.get_doc({
+				"doctype": "Jarvis Learned Pattern", "pattern_key": key,
+				"detector_id": "voice_facts", "domain": "selling",
+				"pattern_statement": f"{PFX} rule statement",
+				"skill_draft": "- do the thing", "status": "Proposed",
+				"strength_band": "High", "sensitivity": "A",
+				"effective_sensitivity": "A", "surfaced": 1,
+				"personalise_origin": 1 if personalise_origin else 0,
+			})
+			doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_board_row_carries_scrub_warning(self):
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-po-key", personalise_origin=True)
+		with _as(REVIEWER):
+			res = learned_api.list_learned_patterns_page(
+				status="Proposed", search=f"{PFX}")
+		row = next(r for r in res["rows"] if r["name"] == p.name)
+		self.assertEqual(row["personalise_origin"], 1)
+		self.assertTrue(row["scrub_warning"])
+
+	def test_approve_returns_scrub_warning_for_personalise_origin(self):
+		# Run as Administrator: approving writes the SM-only JLP (the reviewer
+		# save-perm mechanics are orthogonal to this provenance check).
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-po-appr", personalise_origin=True)
+		with _as("Administrator"):
+			out = learned_api.approve_learned_pattern(p.name)
+		self.assertIn("scrub_warning", out)
+
+	def test_no_warning_for_non_personalise_pattern(self):
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-nopo", personalise_origin=False)
+		with _as("Administrator"):
+			out = learned_api.approve_learned_pattern(p.name)
+		self.assertNotIn("scrub_warning", out)

--- a/jarvis/tests/test_personalise_api.py
+++ b/jarvis/tests/test_personalise_api.py
@@ -66,6 +66,14 @@ def _ensure_user(email: str) -> str:
 	if frappe.db.get_value("User", email, "user_type") != "System User":
 		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
 		frappe.clear_cache(user=email)
+	# Personalise is a chat-surface feature: its shared guard now requires the
+	# Jarvis User role (security review TASK 6/8). Grant it so the fixtures pass
+	# the gate (SM/Admin fixtures already satisfy it via their own roles).
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 	frappe.db.commit()
 	return email
 

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -46,6 +46,20 @@ def _as(user: str):
 		frappe.set_user(orig)
 
 
+@contextlib.contextmanager
+def _engine_flag():
+	"""Bypass the scope-creation guard (security review PART 2 TASK 10) for a
+	fixture that needs a pre-existing Role/Org skill owned by a NON-reviewer —
+	the creation guard itself is covered by TestCreateCustomSkill; these tests
+	exercise the VISIBILITY of already-scoped rows."""
+	prev = frappe.flags.jarvis_pattern_engine
+	frappe.flags.jarvis_pattern_engine = True
+	try:
+		yield
+	finally:
+		frappe.flags.jarvis_pattern_engine = prev
+
+
 def _ensure_system_user(email: str) -> str:
 	"""A non-SM System User (realistic tool caller)."""
 	if not frappe.db.exists("User", email):
@@ -85,22 +99,24 @@ def _sweep_fixture_skills():
 
 def _make_skill(owner: str, skill_name: str, description: str, *,
 				scope: str = "Org", shared_with=None, allowed_roles=None,
-				enabled: int = 1):
+				target_role=None, enabled: int = 1):
 	"""Insert a row through the real doctype as ``owner`` (child tables can't
-	be passed through the tool)."""
-	with _as(owner):
+	be passed through the tool). The engine flag lets the fixture mint a
+	Role/Org row directly (the reviewer-gated creation path is tested elsewhere)."""
+	with _as(owner), _engine_flag():
 		doc = frappe.get_doc({
 			"doctype": SKILL,
 			"skill_name": skill_name,
 			"description": description,
 			"instructions": f"instructions for {skill_name}",
 			"scope": scope,
+			"target_role": target_role,
 			"enabled": enabled,
 			"user_invocable": 1,
 			"shared_with": [{"user": u} for u in (shared_with or [])],
 			"allowed_roles": [{"role": r} for r in (allowed_roles or [])],
 		})
-		doc.insert()
+		doc.insert(ignore_permissions=True)
 	return doc
 
 
@@ -142,7 +158,9 @@ class TestFindSkills(SkillToolsTestCase):
 			mine = find_skills("marker alpha")
 			self.assertEqual(
 				[s["skill_name"] for s in mine["skills"]], [f"{PFX}-priv-alpha"])
-			self.assertEqual(mine["skills"][0]["scope"], "Personal")
+			# The tool now creates private (User-scope) skills — the ladder's
+			# rename of "Personal" (security review PART 2 TASK 10).
+			self.assertEqual(mine["skills"][0]["scope"], "User")
 		with _as(PEER):
 			theirs = find_skills("marker alpha")
 			self.assertEqual(theirs["count"], 0)
@@ -213,7 +231,7 @@ class TestGetSkill(SkillToolsTestCase):
 				out = get_skill(query_name)
 				self.assertEqual(out["skill_name"], f"{PFX}-fetch-me")
 				self.assertEqual(out["instructions"], "fetch body")
-				self.assertEqual(out["scope"], "Personal")
+				self.assertEqual(out["scope"], "User")
 				self.assertEqual(out["enabled"], 1)
 
 	def test_unknown_skill_is_invalid_argument(self):
@@ -240,6 +258,33 @@ class TestGetSkill(SkillToolsTestCase):
 			with self.assertRaises(PermissionDeniedError):
 				get_skill(f"{PFX}-role-only")
 
+	def test_role_scope_visible_to_target_role_holder(self):
+		# TASK 13 fix C: a scope=Role skill whose target_role the caller holds is
+		# findable + fetchable through the tools (the tool SELECTs must carry
+		# target_role, else the whole User->Role promotion tier is dead). PEER
+		# holds "Sales User".
+		_make_skill(
+			OWNER, f"{PFX}-role-tier", "sttool role tier steps",
+			scope="Role", target_role="Sales User",
+		)
+		with _as(PEER):
+			names = [s["skill_name"] for s in find_skills("role tier")["skills"]]
+			self.assertIn(f"{PFX}-role-tier", names)
+			got = get_skill(f"{PFX}-role-tier")
+			self.assertEqual(got["scope"], "Role")
+			self.assertEqual(got["instructions"], f"instructions for {PFX}-role-tier")
+
+	def test_role_scope_denied_to_non_target_role_holder(self):
+		# A Role skill targeting a role the caller does NOT hold is invisible.
+		_make_skill(
+			OWNER, f"{PFX}-role-tier-x", "sttool role tier x steps",
+			scope="Role", target_role="Accounts Manager",
+		)
+		with _as(PEER):  # PEER holds Sales User, not Accounts Manager
+			self.assertEqual(find_skills("role tier x")["count"], 0)
+			with self.assertRaises(PermissionDeniedError):
+				get_skill(f"{PFX}-role-tier-x")
+
 	def test_own_row_preferred_over_same_named_foreign_row(self):
 		# skill_name is unique per owner, not globally.
 		_make_skill(OWNER, f"{PFX}-dup-name", "sttool dup owner copy")
@@ -250,55 +295,41 @@ class TestGetSkill(SkillToolsTestCase):
 
 
 class TestCreateCustomSkill(SkillToolsTestCase):
-	def test_creates_personal_by_default_with_note(self):
+	def test_creates_private_by_default_with_note(self):
 		with _as(OWNER):
 			out = create_custom_skill(
 				f"{PFX}-mk-default", "sttool mk desc", "mk body")
-		self.assertEqual(out["scope"], "Personal")
+		self.assertEqual(out["scope"], "User")
 		self.assertEqual(out["skill_name"], f"{PFX}-mk-default")
 		self.assertIn("note", out)
 		row = frappe.db.get_value(
 			SKILL, out["name"], ["owner", "scope", "enabled"], as_dict=True)
 		self.assertEqual(row.owner, OWNER)
-		self.assertEqual(row.scope, "Personal")
+		self.assertEqual(row.scope, "User")
 		self.assertEqual(int(row.enabled), 1)
 
-	def test_org_scope_note_mentions_apply(self):
+	def test_org_scope_request_is_capped_to_user(self):
+		# Security review PART 2 TASK 10: the tool no longer mints a bench-wide
+		# (Org) skill in one agent call. A scope="Org" request is honored as a
+		# PRIVATE skill and the note explains promotion is reviewer-gated.
 		with _as(OWNER):
 			out = create_custom_skill(
 				f"{PFX}-mk-org", "sttool mk org desc", "mk org body", scope="Org")
-		self.assertEqual(out["scope"], "Org")
-		self.assertIn("Apply", out["note"])
+		self.assertEqual(out["scope"], "User")
+		self.assertIn("reviewer", out["note"].lower())
+		# The capped skill is private: a peer cannot see it via find_skills.
+		with _as(PEER):
+			found = find_skills("mk org desc")
+			self.assertNotIn(
+				f"{PFX}-mk-org", [s["skill_name"] for s in found["skills"]])
 
-	def test_org_scope_note_matches_actual_find_skills_visibility(self):
-		# F19: the note used to say Org skills "reach the assistant's skill
-		# catalog only after an admin clicks Apply" - factually false, since
-		# find_skills/get_skill already surface an Org row to every user right
-		# away (see TestFindSkills.test_org_row_visible_to_everyone below).
-		# There is no per-row 'applied'/'reviewed' flag anywhere in the
-		# doctype or the Apply flow (chat/custom_skills.py build_push_payload)
-		# to gate that discovery path on, so the note is corrected instead of
-		# inventing a gate. Lock the corrected wording + matching behavior
-		# together so they can't silently drift apart again.
+	def test_unknown_scope_is_capped_not_rejected(self):
+		# The scope arg is advisory (always capped to User), so an unrecognized
+		# value is not an error — it just yields a private skill.
 		with _as(OWNER):
 			out = create_custom_skill(
-				f"{PFX}-mk-org-note", "sttool mk org note desc", "mk org note body",
-				scope="Org",
-			)
-		note = out["note"]
-		self.assertIn("right away", note)
-		self.assertIn("jarvis__find_skills", note)
-		self.assertNotIn("only after an admin clicks Apply", note)
-
-		with _as(PEER):
-			found = find_skills("mk org note desc")
-			self.assertIn(f"{PFX}-mk-org-note", [s["skill_name"] for s in found["skills"]])
-
-	def test_invalid_scope_rejected(self):
-		with _as(OWNER):
-			with self.assertRaises(InvalidArgumentError):
-				create_custom_skill(
-					f"{PFX}-mk-badscope", "d", "i", scope="Team")
+				f"{PFX}-mk-badscope", "d", "i", scope="Team")
+		self.assertEqual(out["scope"], "User")
 
 	def test_slug_and_cap_violations_surface_as_jarvis_errors(self):
 		with _as(OWNER):
@@ -384,7 +415,7 @@ class TestRegistryAndClassification(SkillToolsTestCase):
 				"description": "sttool registry marker",
 				"instructions": "registry body",
 			})
-			self.assertEqual(created["scope"], "Personal")
+			self.assertEqual(created["scope"], "User")
 
 			found = dispatch("find_skills", {"query": "registry marker", "limit": 5})
 			self.assertEqual(

--- a/jarvis/tests/test_v3_list_extensions.py
+++ b/jarvis/tests/test_v3_list_extensions.py
@@ -42,13 +42,22 @@ def _ensure_user(email: str) -> str:
 			"doctype": "User", "email": email,
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0, "enabled": 1,
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
 		frappe.db.commit()
-	roles = set(frappe.get_roles(email))
-	if "System Manager" in roles:
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+		frappe.db.commit()
+	if "System Manager" in set(frappe.get_roles(email)):
 		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	# The Jarvis User role is what the @require_jarvis_user endpoint decorators
+	# require (security review PART 1 TASK 8); a realistic non-SM Jarvis caller
+	# holds it.
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 
@@ -124,6 +133,11 @@ class TestSkillsBulkDelete(unittest.TestCase):
 		frappe.set_user("Administrator")
 		_ensure_user(USER_A)
 		_ensure_user(USER_B)
+		# USER_A owns + deletes the fixture skills; the bulk-delete reconcile is
+		# now reviewer-gated (security review PART 2 TASK 12), so give USER_A the
+		# reviewer role to exercise the (deduped) apply path.
+		if "Jarvis Skill Reviewer" not in set(frappe.get_roles(USER_A)):
+			frappe.get_doc("User", USER_A).add_roles("Jarvis Skill Reviewer")
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -133,12 +147,13 @@ class TestSkillsBulkDelete(unittest.TestCase):
 		self.b_shared = _mk_skill(USER_B, "v3-skill-b-shared", shared_with=[USER_A])
 		self.b_priv = _mk_skill(USER_B, "v3-skill-b-priv")
 		# Stub the apply pipeline (it talks to the admin service) and count calls.
+		# delete_custom_skills_bulk calls the undecorated _apply_custom_skills_impl.
 		self.apply_calls = []
-		self._orig_apply = custom_skills_api.apply_custom_skills
-		custom_skills_api.apply_custom_skills = lambda: self.apply_calls.append(1)
+		self._orig_apply = custom_skills_api._apply_custom_skills_impl
+		custom_skills_api._apply_custom_skills_impl = lambda: self.apply_calls.append(1)
 
 	def tearDown(self):
-		custom_skills_api.apply_custom_skills = self._orig_apply
+		custom_skills_api._apply_custom_skills_impl = self._orig_apply
 		frappe.set_user("Administrator")
 		_wipe()
 

--- a/jarvis/tools/create_custom_skill.py
+++ b/jarvis/tools/create_custom_skill.py
@@ -1,13 +1,15 @@
 """Save a new skill (Jarvis Custom Skill row) from chat.
 
 The agent captures a procedure the user just walked it through and saves it
-as a skill owned by the session user. Defaults to scope=Personal (private,
-never pushed to the shared container catalog). scope=Org rows are visible to
-other users immediately via jarvis__find_skills/jarvis__get_skill (subject
-to allowed_roles/shared_with — see user_can_use_skill); they only join the
-/slug-invocable CONTAINER catalog after an admin clicks Apply on the Skills
-page. This tool NEVER triggers a push/apply itself — Apply restarts the
-container and stays a deliberate human action.
+as a skill owned by the session user. The skill is ALWAYS created private
+(scope=User): a bench-wide (Org) or role-shared (Role) skill can only be minted
+by a reviewer through the promotion workflow, never by the agent in one call
+(security review PART 2 TASK 10 — this tool used to accept scope="Org"
+directly, letting the agent mint a bench-wide skill with no reviewer gate). A
+private skill is reached via jarvis__find_skills / jarvis__get_skill and is
+never pushed to the shared container catalog. This tool NEVER triggers a
+push/apply itself — Apply restarts the container and stays a deliberate human
+action.
 
 Confirmation-gated in jarvis/api.py (_GATED_WRITES): the model path parks
 the call behind a human confirm card.
@@ -20,25 +22,27 @@ from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools.find_skills import _require_system_user
 
 SKILL = "Jarvis Custom Skill"
-_SCOPES = ("Org", "Personal")
 
 
 def create_custom_skill(
     skill_name: str,
     description: str,
     instructions: str,
-    scope: str = "Personal",
+    scope: str = "User",
     user_invocable: int = 1,
 ) -> dict:
-    """Insert a skill row as the session user; the DocType controller enforces
-    the slug grammar, length caps, per-owner uniqueness/cap and the reserved
-    ``custom-``/``learned-`` prefixes. Returns ``{name, skill_name, scope,
-    note}``."""
+    """Insert a PRIVATE (User-scope) skill row as the session user; the DocType
+    controller enforces the slug grammar, length caps, per-owner uniqueness/cap,
+    the reserved ``custom-``/``learned-`` prefixes and the scope guard. The
+    ``scope`` argument is capped at User — a request for Role/Org is honored as a
+    private skill (promotion is reviewer-gated). Returns ``{name, skill_name,
+    scope, note}``."""
     _require_system_user()
 
-    scope = (scope or "Personal").strip().capitalize()
-    if scope not in _SCOPES:
-        raise InvalidArgumentError("scope must be 'Org' or 'Personal'")
+    # Cap at User regardless of what the model asked for: widening is
+    # reviewer-only (the controller would reject a non-reviewer's Role/Org
+    # create anyway; capping here keeps the agent path from 403-ing on itself).
+    requested = (scope or "User").strip().capitalize()
 
     ui = user_invocable
     if isinstance(ui, str):
@@ -50,7 +54,7 @@ def create_custom_skill(
             "skill_name": skill_name,
             "description": description,
             "instructions": instructions,
-            "scope": scope,
+            "scope": "User",
             "user_invocable": 1 if ui else 0,
             "enabled": 1,
         }
@@ -63,22 +67,19 @@ def create_custom_skill(
         # classify them identically.
         raise InvalidArgumentError(str(e) or type(e).__name__)
 
-    if scope == "Org":
-        note = (
-            "Saved. Org-scope skills are discoverable and usable by other users "
-            "right away via jarvis__find_skills / jarvis__get_skill (subject to "
-            "allowed_roles/shared_with); they only join the /slug-invocable "
-            "container catalog after an admin clicks Apply on the Skills page."
-        )
-    else:
-        note = (
-            "Saved as a personal skill: private to its owner and never pushed "
-            "to the shared catalog; recall it with jarvis__find_skills / "
-            "jarvis__get_skill."
+    note = (
+        "Saved as a private skill: only you can use it and it is never pushed "
+        "to the shared catalog; recall it with jarvis__find_skills / "
+        "jarvis__get_skill."
+    )
+    if requested in ("Org", "Role"):
+        note += (
+            " Making it visible to your role or the whole org needs a reviewer "
+            "to approve a promotion request."
         )
     return {
         "name": doc.name,
         "skill_name": doc.skill_name,
-        "scope": doc.scope or "Org",
+        "scope": doc.scope or "User",
         "note": note,
     }

--- a/jarvis/tools/find_skills.py
+++ b/jarvis/tools/find_skills.py
@@ -39,8 +39,10 @@ def _visible(row, user: str, user_roles: list[str]) -> bool:
         user_can_use_skill,
     )
 
-    if (row.get("scope") or "Org") == "Personal" and (row.get("owner") or "") != user:
-        return False
+    # Single visibility rule shared with the ORM hook + SPA (security review
+    # PART 2 TASK 13): owner OR shared OR scope=Org (unless role-narrowed) OR
+    # scope=Role role-match. User-scope rows are owner-only inside the helper, so
+    # the old "Personal is owner-only" special case is subsumed.
     return user_can_use_skill(row, user, user_roles)
 
 
@@ -61,7 +63,11 @@ def find_skills(query: str, limit: int = 10) -> dict:
     limit = max(1, min(limit, _MAX_LIMIT))
 
     rows = frappe.db.sql(
-        """SELECT name, owner, skill_name, description, scope, managed_by_learning
+        # target_role is REQUIRED for user_can_use_skill to admit a Role-scope
+        # skill's role-holder (security review PART 2 TASK 13); omitting it made
+        # the whole User->Role promotion tier dead through this tool.
+        """SELECT name, owner, skill_name, description, scope, target_role,
+               managed_by_learning
         FROM `tabJarvis Custom Skill`
         WHERE enabled = 1 AND (skill_name LIKE %(q)s OR description LIKE %(q)s)
         ORDER BY skill_name ASC, name ASC

--- a/jarvis/tools/get_skill.py
+++ b/jarvis/tools/get_skill.py
@@ -35,7 +35,9 @@ def get_skill(skill_name: str) -> dict:
         filters={"skill_name": ["in", sorted(candidates)]},
         fields=[
             "name", "owner", "skill_name", "description", "instructions",
-            "scope", "enabled", "user_invocable",
+            # target_role is REQUIRED for user_can_use_skill to admit a Role-scope
+            # skill's role-holder (security review PART 2 TASK 13).
+            "scope", "target_role", "enabled", "user_invocable",
         ],
     )
     if not rows:


### PR DESCRIPTION
## Security review — Part 1 (Chat) permission hardening

Closes the chat surface's permission gaps found in the Frappe-standards security review. The core change moves enforcement from per-endpoint checks to the **ORM layer** (doctype permission rows + `permission_query_conditions`/`has_permission` hooks), so generic REST (`/api/resource`, `frappe.client.*`, reportview) and every future endpoint inherit owner scoping instead of relying on a hand-rolled check in each whitelisted function. Modeled on the existing `wiki_permissions.py` reference.

**Constraints honored:** no leaks, no unauthorized access, no UX break, balance.

### Part 1 (TASKs 1–9)
- **Ownership hooks + role on the doctype (TASK 2, 7)** — `jarvis/chat/chat_permissions.py` for Jarvis Conversation / Chat Message / Approval Request / Voice Note; doctype perm rows changed `All` → `Jarvis User`. Conversation/Voice scope by row owner; Message/Approval by the **linked conversation's** owner (+ DocShare for Approval).
- **Access gate on chat entry (TASK 1)** — `send_message` + `demo_proactive` require Jarvis access; delegated server re-entry (scheduler, approval-resume) is marked with a `frappe.flags` signal a browser POST cannot forge and seeds its writes with `ignore_permissions`.
- **Role gate on endpoints (TASK 3, 8)** — `@require_jarvis_user` on 60 chat endpoints + a coverage test; `require_jarvis_access` folded into the voice_notes/personalise `_require_system_user` helpers.
- **Approval trace-comment (TASK 4)** — checks the decider's read+write on the target before the attributed `ignore_permissions` write.
- **Voice Note (TASK 5)** — validates conversation ownership; URL fetch stays on the hardened IP-pinned fetcher.
- **Website users (TASK 6)** — `has_jarvis_access` now requires `user_type == "System User"`; a new patch revokes the role from Website/portal users the backfill had granted.
- **permlevel (TASK 9)** — `session_key` + `openclaw_seq_watermark` protected at permlevel 1.

### Part 1 Round 2 (TASK 20/21) — reviewer-only UX break found during verification
The TASK-8 decorator sweep over-restricted one legitimate population: a System User holding **only** `Jarvis Skill Reviewer`/`Jarvis Admin` (no `Jarvis User`/`System Manager`). The reviewer insight-apply and Apply-board paths call `create_custom_skill` / `get_learned_skills_sync_status` **internally**, so the decorator threw for them (and `_apply_pending` silently swallowed it, weakening the mid-push un-approve guard). Fixed with the **impl-split pattern** already used by `macro_scheduler.py`: undecorated `*_impl` cores that the already-authorized reviewer paths call, while the HTTP wrappers stay strict.

## Verification
- **Exploits independently reproduced and confirmed blocked** (throwaway users, rolled back): roleless conversation create, cross-user message injection (roleless *and* role-holding attacker), REST list scoping (0 rows), approval/voice cross-injection, Website-user access, `session_key` permlevel. Worker `ignore_permissions` path still inserts.
- **UX-break audit** (multi-agent, all caller categories): plugin, admin control-plane, fleet-agent, guest, and the `_require_system_user` folds are clean; the two reviewer-only breaks above were found, fixed, and re-verified (HTTP wrappers still `PermissionError` for non-Jarvis-User; reviewer path works).
- **Regression/test audit**: no regressions, no weakened assertions; do-not-regress list holds.
- **Tests**: focused suite green on `patterntest.localhost` — `test_insight_skill_update` (25), `test_learned_api` (69), `test_learned_skills_api` (4), `test_custom_skills_push` (9), `test_custom_skill_visibility` (13), `test_chat_endpoint_gating` (1).

## Known follow-ups (not blockers; tracked for a later round)
- `wiki.py`'s own `_require_system_user` was not folded — ~16 wiki endpoints require only System User, not the Jarvis User role; the coverage test currently counts them as gated by name.
- Add a `test_chat_permissions.py` that pins cross-user **read** scoping (today, unregistering the hooks would pass CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
