### PR TITLE
Security review Part 2: skills scope ladder, promotion workflow, wiki/personalise leak fixes

### DIFF
--- a/frontend/src/pages/skills/SkillDetail.vue
+++ b/frontend/src/pages/skills/SkillDetail.vue
@@ -215,7 +215,7 @@
 // share this component (isNew prop). Explicit Save (D21) with dirty guard,
 // read-only mode for shared-with-me skills, DocMetaPanel + child-table
 // Shared-with block (#extra) + ShareDialog, sync pill on save/delete.
-import { ref, reactive, computed, watch, shallowRef, nextTick } from "vue"
+import { ref, reactive, computed, watch, shallowRef, nextTick, onMounted } from "vue"
 import { useRouter, onBeforeRouteLeave } from "vue-router"
 import {
 	Button,
@@ -235,6 +235,7 @@ import CommentsSection from "@/components/doc/CommentsSection.vue"
 import { useDocmeta } from "@/composables/useDocmeta"
 import SyncPill from "./SyncPill.vue"
 import ShareDialog from "./ShareDialog.vue"
+import { getSkillsAreaCaps } from "@/api/personalise"
 import { renderMarkdown } from "@/markdown"
 import { timeAgo } from "@/utils/datetime"
 import { useJarvisTheme } from "@/theme"
@@ -276,6 +277,20 @@ const docmeta = shallowRef(null) // useDocmeta instance (own skills only)
 const shares = ref([]) // [{name, full_name}]
 const shareOpen = ref(false)
 const syncPill = ref(null)
+
+// Only a reviewer/admin may push the shared container (apply is reviewer-gated -
+// security review PART 2 TASK 12). New skills default to private (User) scope
+// and are NEVER pushed, so for an ordinary user apply-on-save is both pointless
+// and a hard 403 (a scary red toast). Gate every apply on this signal.
+const isReviewer = ref(false)
+onMounted(async () => {
+	try {
+		const caps = await getSkillsAreaCaps()
+		isReviewer.value = !!(caps && caps.review)
+	} catch {
+		isReviewer.value = false
+	}
+})
 
 const canEdit = computed(() => props.isNew || !!(skill.value && skill.value.can_edit))
 const readonly = computed(() => !canEdit.value || saving.value)
@@ -395,7 +410,9 @@ async function save() {
 			const res = (await api.createCustomSkill(payload)) || {}
 			const newName = (res.data && res.data.name) || ""
 			snapshot.value = { ...form } // clean before navigating (leave guard)
-			syncPill.value && syncPill.value.apply() // saving updates the assistant
+			// Reviewers only: a new skill is private (User) scope and never pushed,
+			// so ordinary users need no apply (and would 403 on the gated endpoint).
+			if (isReviewer.value) syncPill.value && syncPill.value.apply()
 			toast.success("Saved")
 			if (newName) router.replace("/skills/" + newName)
 		} else {
@@ -407,7 +424,8 @@ async function save() {
 			await api.updateCustomSkill({ name: props.id, ...changed })
 			snapshot.value = { ...form }
 			skill.value = { ...skill.value, ...payload }
-			syncPill.value && syncPill.value.apply()
+			// Reviewers only (see create branch): the shared push is reviewer-gated.
+			if (isReviewer.value) syncPill.value && syncPill.value.apply()
 			toast.success("Saved")
 		}
 	} catch (e) {
@@ -424,8 +442,9 @@ function confirmDelete() {
 		onConfirm: async ({ hideDialog }) => {
 			try {
 				await api.deleteCustomSkill(props.id)
-				// reconcile the container; the list's pill picks up the pending state
-				await api.applyCustomSkills().catch(() => {})
+				// reconcile the container only for reviewers (apply is gated); a
+				// deleted private skill never affected the shared push anyway.
+				if (isReviewer.value) await api.applyCustomSkills().catch(() => {})
 				bypassGuard = true
 				hideDialog()
 				toast.success("Skill deleted")

--- a/jarvis/chat/custom_skills.py
+++ b/jarvis/chat/custom_skills.py
@@ -250,9 +250,10 @@ def personal_skill_clause(user: str | None = None) -> str:
 	count = cache.get_value(key)
 	if count is None:
 		# Exact scope match: NULL/empty scope rows are Org and never counted.
+		# "User" is the scope-ladder spelling of the old "Personal" (TASK 10).
 		count = frappe.db.count(
 			"Jarvis Custom Skill",
-			{"owner": user, "enabled": 1, "scope": "Personal"},
+			{"owner": user, "enabled": 1, "scope": "User"},
 		)
 		cache.set_value(key, int(count or 0), expires_in_sec=PERSONAL_CLAUSE_TTL_S)
 	try:
@@ -281,10 +282,21 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	only to scope tests). An empty list is a valid "remove all custom skills"
 	reconcile.
 
-	Personal-scope rows are EXCLUDED: they exist only for their owner (reached
-	via the find_skills/get_skill tools), never for the shared container
-	catalog, and must not eat into the 25-skill push budget. NULL/empty scope
-	(pre-migration rows) means Org and IS pushed.
+	User- AND Role-scope rows are EXCLUDED: User rows exist only for their owner
+	(reached via the find_skills/get_skill tools) and Role rows only for
+	role-holders; neither belongs in the shared container catalog nor may eat
+	into the 25-skill push budget. NULL/empty scope (pre-migration rows) means
+	Org and IS pushed.
+
+	Role-restricted bodies are kept off the shared blob (security review PART 2
+	TASK 11): an Org row narrowed by ``allowed_roles`` is a role-restricted skill
+	whose full instructions would otherwise be physically written to the shared,
+	role-BLIND container and be readable + auto-activatable by every user's agent
+	(a mass-exfil vector). So this push carries ONLY skills visible to EVERYONE —
+	Org scope with NO ``allowed_roles``. Role-restricted skills stay reachable via
+	the role-gated ``jarvis__find_skills`` / ``jarvis__get_skill`` tools; restoring
+	their /slug container activation needs a per-role workspace mount in the
+	fleet-agent (a follow-up outside the bench).
 
 	Managed learned rows (``managed_by_learning=1``) are EXCLUDED: since the
 	Phase-2 learned namespace they ride their own push
@@ -306,7 +318,7 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	  ``frappe.log_error`` a loud warning naming the dropped slugs, so the
 	  truncation is never silent again.
 	"""
-	# ("in", ("Org", "")) — not ("!=", "Personal") — because db_query wraps the
+	# ("in", ("Org", "")) — not ("!=", "User") — because db_query wraps the
 	# "in" operator in ifnull(scope, ''), so legacy NULL-scope rows match ''.
 	filters = {"enabled": 1, "managed_by_learning": 0, "scope": ("in", ("Org", ""))}
 	if owner:
@@ -314,9 +326,23 @@ def build_push_payload(owner: str | None = None, strict: bool = False) -> list[d
 	rows = frappe.get_all(
 		"Jarvis Custom Skill",
 		filters=filters,
-		fields=["skill_name", "description", "user_invocable", "instructions"],
+		fields=["name", "skill_name", "description", "user_invocable", "instructions"],
 		order_by="skill_name asc",
 	)
+	# TASK 11: drop role-restricted Org rows (any with allowed_roles) so a
+	# role-scoped body is never written to the shared, role-blind container.
+	restricted = {
+		r.parent
+		for r in frappe.get_all(
+			"Jarvis Custom Skill Allowed Role",
+			filters={
+				"parenttype": "Jarvis Custom Skill",
+				"parent": ["in", [r.name for r in rows] or [""]],
+			},
+			fields=["parent"],
+		)
+	}
+	rows = [r for r in rows if r.name not in restricted]
 	if len(rows) > MAX_SKILLS_PER_PUSH:
 		if strict:
 			frappe.throw(

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -312,24 +312,34 @@ def _create_custom_skill_impl(
 	instructions: str,
 	user_invocable: int = 1,
 	enabled: int = 1,
+	scope: str | None = None,
+	ignore_permissions: bool = False,
 ) -> dict:
 	"""Undecorated core of :func:`create_custom_skill`. Split out so a trusted
 	server caller already authorized by its own gate can create a skill without
 	re-tripping the ``@require_jarvis_user`` HTTP gate on the wrapper: the reviewer
 	insight-apply path (``learned_api._apply_create_target``) is gated on
 	``_REVIEWER_ROLES``, which admits a Jarvis Skill Reviewer / Jarvis Admin who
-	holds neither Jarvis User nor System Manager."""
-	doc = frappe.get_doc(
-		{
-			"doctype": SKILL,
-			"skill_name": skill_name,
-			"description": description,
-			"instructions": instructions,
-			"user_invocable": int(user_invocable or 0),
-			"enabled": int(enabled or 0),
-		}
-	)
-	doc.insert()
+	holds neither Jarvis User nor System Manager.
+
+	``scope`` is only accepted from trusted server callers (the reviewer
+	insight-apply passes ``scope="Org"``); a blank scope defaults to User
+	(private-first — security review PART 2 TASK 10). ``ignore_permissions``
+	skips the doctype create-perm check for reviewer callers who may lack the
+	Jarvis User role that the doctype now requires (the controller's own scope
+	guard still runs and admits them as reviewers)."""
+	fields = {
+		"doctype": SKILL,
+		"skill_name": skill_name,
+		"description": description,
+		"instructions": instructions,
+		"user_invocable": int(user_invocable or 0),
+		"enabled": int(enabled or 0),
+	}
+	if scope:
+		fields["scope"] = scope
+	doc = frappe.get_doc(fields)
+	doc.insert(ignore_permissions=bool(ignore_permissions))
 	frappe.db.commit()
 	return {"ok": True, "data": {"name": doc.name, "skill_name": doc.skill_name}}
 
@@ -404,8 +414,15 @@ def delete_custom_skills_bulk(names: str | list | None = None) -> dict:
 			)
 			skipped.append({"name": n, "reason": "error"})
 	frappe.db.commit()
+	# Only a reviewer's delete reconciles the shared catalog (TASK 12): a plain
+	# Jarvis User's rows are User/Role-scope and never in the shared push, so
+	# their delete changes nothing there and must not trigger a bench-wide
+	# restart. A reviewer deleting an Org skill DOES need the reconcile.
 	if deleted:
-		apply_custom_skills()
+		from jarvis.permissions import is_skill_reviewer
+
+		if is_skill_reviewer(me):
+			_apply_custom_skills_impl()
 	return {"deleted": deleted, "skipped": skipped}
 
 
@@ -467,6 +484,127 @@ def share_custom_skill(name: str, users: str | list | None = None) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# Scope promotion (User -> Role -> Org) — reviewer-gated widening workflow
+# (security review PART 2 TASK 10, mirrors the wiki promotion machinery).
+# --------------------------------------------------------------------------- #
+PROMO = "Jarvis Skill Promotion Request"
+_SCOPE_RANK = {"User": 0, "Personal": 0, "Role": 1, "Org": 2}
+
+
+def _notify_skill_reviewers() -> None:
+	"""Best-effort nudge to the skill-reviewer set that a promotion request
+	landed. Never breaks the request on failure."""
+	try:
+		from frappe.utils.user import get_users_with_role
+		from jarvis.chat.events import publish_to_user
+		from jarvis.permissions import JARVIS_REVIEWER_ROLES
+
+		users: set = set()
+		for role in JARVIS_REVIEWER_ROLES:
+			try:
+				users |= set(get_users_with_role(role))
+			except Exception:
+				pass
+		for u in sorted(users):
+			if u and u not in ("Administrator", "Guest"):
+				publish_to_user(u, {"kind": "review:pending", "queue": "skill_promotion"})
+	except Exception:
+		pass
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def request_skill_promotion(
+	name: str, to_scope: str, target_role: str = "", note: str = ""
+) -> dict:
+	"""Ask a reviewer to widen one of the caller's OWN skills up the scope ladder
+	(User->Role->Org). Files a Pending ``Jarvis Skill Promotion Request`` and
+	pings the reviewer set — the skill itself is untouched; promotion is a
+	request, never a self-service scope switch (the controller's scope guard
+	rejects a self-service widen anyway)."""
+	me = frappe.session.user
+	doc = frappe.get_doc(SKILL, name)
+	if doc.owner != me and me != "Administrator":
+		frappe.throw(_("You can only promote your own skills."), frappe.PermissionError)
+	if doc.get("managed_by_learning"):
+		frappe.throw(_("Learned skills are managed by the learning board, not promotion."))
+
+	from_scope = (doc.scope or "Org").strip() or "Org"
+	if from_scope == "Personal":
+		from_scope = "User"
+	to_scope = (to_scope or "").strip()
+	if to_scope not in ("Role", "Org"):
+		frappe.throw(_("Promotion target must be Role or Org."))
+	if _SCOPE_RANK.get(to_scope, 0) <= _SCOPE_RANK.get(from_scope, 0):
+		frappe.throw(_("Promotion can only widen a skill's scope."))
+	target_role = (str(target_role).strip() if target_role else "") or None
+	if to_scope == "Role" and not target_role:
+		frappe.throw(_("Promoting to Role scope needs a target role."))
+
+	req = frappe.get_doc({
+		"doctype": PROMO,
+		"skill": doc.name,
+		"skill_name": doc.skill_name,
+		"from_scope": from_scope,
+		"to_scope": to_scope,
+		"target_role": target_role if to_scope == "Role" else None,
+		"note": (note or "").strip()[:140] or None,
+		"status": "Pending",
+	})
+	req.insert(ignore_permissions=True)
+	frappe.db.commit()
+	_notify_skill_reviewers()
+	return {"ok": True, "request": req.name, "skill": doc.skill_name}
+
+
+@frappe.whitelist()
+def decide_skill_promotion(request_name: str, approve: int | str, note: str = "") -> dict:
+	"""Approve or reject a skill promotion request. Reviewer-gated
+	(``require_skill_reviewer``) + four-eyes (a reviewer cannot approve their own
+	request). On approve, widen the skill's scope in place under the reviewer's
+	authority (``ignore_permissions``; the controller ``_guard_scope_change``
+	admits a reviewer). TOCTOU-safe: the status is re-read under a row lock, and
+	the widening is re-validated against the LIVE skill scope, so two concurrent
+	approvals can't double-apply. The promoted Org skill joins the shared catalog
+	on the next explicit Apply (never auto-pushed here)."""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	reviewer = frappe.session.user
+	req = frappe.get_doc(PROMO, request_name)
+	if reviewer == (req.owner or "") and reviewer != "Administrator":
+		frappe.throw(
+			_("You cannot approve your own promotion request; another reviewer must decide it."),
+			frappe.PermissionError,
+		)
+	status = frappe.db.get_value(PROMO, request_name, "status", for_update=True)
+	if status != "Pending":
+		return {"ok": False, "reason": _("Already {0}.").format((status or "").lower())}
+
+	approved = str(approve).strip().lower() in ("1", "true", "yes", "on")
+	out: dict = {"ok": True, "status": "Approved" if approved else "Rejected"}
+	if approved:
+		skill = frappe.get_doc(SKILL, req.skill)
+		live = (skill.scope or "Org").strip() or "Org"
+		if live == "Personal":
+			live = "User"
+		if _SCOPE_RANK.get(req.to_scope, 0) <= _SCOPE_RANK.get(live, 0):
+			frappe.throw(_("The skill is already at or above the requested scope."))
+		skill.scope = req.to_scope
+		skill.target_role = req.target_role if req.to_scope == "Role" else None
+		skill.save(ignore_permissions=True)
+		out["skill"] = skill.skill_name
+
+	req.status = "Approved" if approved else "Rejected"
+	req.reviewer = reviewer
+	req.decided_at = frappe.utils.now_datetime()
+	req.decision_note = (note or "").strip()[:140] or None
+	req.save(ignore_permissions=True)
+	frappe.db.commit()
+	return out
+
+
+# --------------------------------------------------------------------------- #
 # Apply (explicit push to the container, via admin → fleet)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
@@ -492,9 +630,16 @@ def _custom_sync_status() -> dict:
 
 
 @frappe.whitelist()
-@require_jarvis_user
 def apply_custom_skills() -> dict:
 	"""Push all enabled skills to the assistant (one restart). Explicit action.
+
+	Reviewer/admin-gated (security review PART 2 TASK 12): a bench-wide push
+	reconciles + RESTARTS the shared container for EVERY user, so a plain Jarvis
+	User (which every backfilled user holds) must not be able to trigger it (DoS +
+	it is what forces any Org skill out to all pods). Gated with the skill-reviewer
+	set (Jarvis Skill Reviewer / Jarvis Admin / System Manager) — deliberately NOT
+	stacked under @require_jarvis_user, since a reviewer/admin may hold neither
+	Jarvis User nor System Manager.
 
 	Builds the payload synchronously so size/cap errors surface immediately,
 	marks a pending status, then enqueues the deduped worker (mirrors
@@ -502,6 +647,17 @@ def apply_custom_skills() -> dict:
 	endpoint - a human is present to act on the over-cap error, so raise
 	instead of truncating (the unattended worker below stays graceful).
 	"""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	return _apply_custom_skills_impl()
+
+
+def _apply_custom_skills_impl() -> dict:
+	"""Undecorated core of :func:`apply_custom_skills`. Split out so a caller
+	already authorized by its own gate can reconcile the shared catalog without
+	re-checking the reviewer gate (the bulk-delete path only invokes it for a
+	reviewer)."""
 	skills = build_push_payload(strict=True)
 	frappe.db.set_single_value(
 		_SETTINGS, "custom_skills_sync_status", "pending: applying skills"

--- a/jarvis/chat/custom_skills_api.py
+++ b/jarvis/chat/custom_skills_api.py
@@ -34,6 +34,22 @@ def _full_name(user: str) -> str:
 	return frappe.db.get_value("User", user, "full_name") or user
 
 
+def _require_skill_owner(doc, action: str = "modify") -> None:
+	"""Raise a CLEAR PermissionError unless the caller owns the skill (or is a
+	System Manager / Administrator — matching skill_permissions.has_skill_permission
+	write rule). The ORM hook denies a non-owner write anyway, but the framework's
+	generic message is opaque; the user-facing SPA write endpoints surface this
+	instead (security review PART 2 TASK E1)."""
+	me = frappe.session.user
+	if me == "Administrator" or (doc.get("owner") or "") == me:
+		return
+	if "System Manager" in frappe.get_roles(me):
+		return
+	frappe.throw(
+		_("You can only {0} your own skills.").format(action), frappe.PermissionError
+	)
+
+
 def _skill_names_shared_with(user: str) -> list[str]:
 	"""Skill row-names shared with ``user`` (child-table lookup, perm-free)."""
 	return [
@@ -356,6 +372,7 @@ def update_custom_skill(
 ) -> dict:
 	"""Update provided fields of a skill (owner-gated)."""
 	doc = frappe.get_doc(SKILL, name)
+	_require_skill_owner(doc, "edit")
 	if skill_name is not None:
 		doc.skill_name = skill_name
 	if description is not None:
@@ -376,7 +393,8 @@ def update_custom_skill(
 def delete_custom_skill(name: str) -> dict:
 	"""Delete a skill row (owner-gated). The delete only propagates to the
 	container on the next Apply (the fleet endpoint does a full reconcile)."""
-	frappe.delete_doc(SKILL, name)  # honors if_owner permission
+	_require_skill_owner(frappe.get_doc(SKILL, name), "delete")
+	frappe.delete_doc(SKILL, name)  # ORM hook also enforces owner-only delete
 	frappe.db.commit()
 	return {"ok": True}
 
@@ -491,9 +509,10 @@ PROMO = "Jarvis Skill Promotion Request"
 _SCOPE_RANK = {"User": 0, "Personal": 0, "Role": 1, "Org": 2}
 
 
-def _notify_skill_reviewers() -> None:
+def _notify_skill_reviewers(request_name: str | None = None) -> None:
 	"""Best-effort nudge to the skill-reviewer set that a promotion request
-	landed. Never breaks the request on failure."""
+	landed. Carries the request name so the reviewer client can deep-link to it.
+	Never breaks the request on failure."""
 	try:
 		from frappe.utils.user import get_users_with_role
 		from jarvis.chat.events import publish_to_user
@@ -505,9 +524,12 @@ def _notify_skill_reviewers() -> None:
 				users |= set(get_users_with_role(role))
 			except Exception:
 				pass
+		payload = {"kind": "review:pending", "queue": "skill_promotion"}
+		if request_name:
+			payload["request"] = request_name
 		for u in sorted(users):
 			if u and u not in ("Administrator", "Guest"):
-				publish_to_user(u, {"kind": "review:pending", "queue": "skill_promotion"})
+				publish_to_user(u, payload)
 	except Exception:
 		pass
 
@@ -553,7 +575,7 @@ def request_skill_promotion(
 	})
 	req.insert(ignore_permissions=True)
 	frappe.db.commit()
-	_notify_skill_reviewers()
+	_notify_skill_reviewers(req.name)
 	return {"ok": True, "request": req.name, "skill": doc.skill_name}
 
 
@@ -602,6 +624,92 @@ def decide_skill_promotion(request_name: str, approve: int | str, note: str = ""
 	req.save(ignore_permissions=True)
 	frappe.db.commit()
 	return out
+
+
+_PROMO_STATUSES = ("Pending", "Approved", "Rejected")
+
+
+@frappe.whitelist()
+def list_skill_promotion_requests(
+	status: str = "Pending",
+	search: str = "",
+	start: int = 0,
+	page_length: int = 20,
+) -> dict:
+	"""Reviewer discovery queue for skill promotion requests. The doctype perms
+	are ``All: read+if_owner`` (so a requester sees only their OWN requests) — a
+	reviewer holding only Jarvis Skill Reviewer would get [] from generic
+	get_list. So this reviewer-gated raw-SQL list sidesteps the doctype-perm limit
+	exactly as ``learned_api.list_promotion_requests_page`` does for the wiki
+	queue. Envelope parity: ``{rows, total, has_more, start, page_length}``.
+	Requester full name resolved via one batched lookup."""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
+	start, pl = _clamp_page(start, page_length)
+	if status and status != "All" and status not in _PROMO_STATUSES:
+		frappe.throw(_("Invalid status filter."))
+
+	params: dict = {"start": start, "page_length": pl}
+	conds: list[str] = []
+	if status and status != "All":
+		params["status"] = status
+		conds.append("status = %(status)s")
+	if search:
+		params["q"] = f"%{_lk(search)}%"
+		conds.append("(skill_name LIKE %(q)s OR note LIKE %(q)s)")
+	where = " AND ".join(conds) or "1=1"
+
+	total = frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tab{PROMO}` WHERE {where}", params
+	)[0][0]
+	rows = frappe.db.sql(
+		f"""SELECT name, skill, skill_name, from_scope, to_scope, target_role,
+			note, status, owner, creation, reviewer, decided_at, decision_note
+		FROM `tab{PROMO}`
+		WHERE {where}
+		ORDER BY creation DESC, name ASC
+		LIMIT %(page_length)s OFFSET %(start)s""",
+		params, as_dict=True,
+	)
+
+	owner_names = list({r["owner"] for r in rows if r.get("owner")})
+	fullnames = {
+		u.name: u.full_name
+		for u in (
+			frappe.get_all(
+				"User", filters={"name": ["in", owner_names]}, fields=["name", "full_name"]
+			)
+			if owner_names
+			else []
+		)
+	}
+	out_rows = [
+		{
+			"name": r["name"],
+			"skill": r.get("skill") or "",
+			"skill_name": r.get("skill_name") or "",
+			"from_scope": r.get("from_scope") or "",
+			"to_scope": r.get("to_scope") or "",
+			"target_role": r.get("target_role") or "",
+			"note": r.get("note") or "",
+			"status": r.get("status") or "",
+			"requested_by": r.get("owner") or "",
+			"requested_by_name": fullnames.get(r.get("owner")) or (r.get("owner") or ""),
+			"created": str(r.get("creation") or ""),
+			"reviewer": r.get("reviewer") or "",
+			"decided_at": str(r.get("decided_at") or ""),
+			"decision_note": r.get("decision_note") or "",
+		}
+		for r in rows
+	]
+	return {
+		"rows": out_rows,
+		"total": total,
+		"has_more": start + len(out_rows) < total,
+		"start": start,
+		"page_length": pl,
+	}
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -153,6 +153,14 @@ ACK_NOTE = "Acknowledged - insight only"
 # pointing at the skill row. Keep the prefix stable - the frontend keys off it.
 APPLIED_NOTE_PREFIX = "Acknowledged - applied to skill: "
 
+# Non-blocking warning shown to a reviewer promoting a personalise-origin pattern
+# org-wide (security review PART 2 TASK 16): the content came from a user's
+# PRIVATE note, so personal nuances must be scrubbed before it becomes org-wide.
+_SCRUB_WARNING = (
+	"This came from a user's private note - remove personal names and nuances "
+	"before making it org-wide."
+)
+
 # Rendered on the board when an SM edited the draft before approving: the
 # evidence line is frozen (plan section 6.5) - it still reflects the ORIGINALLY
 # detected pattern, not the human edit, which was not re-measured.
@@ -171,6 +179,9 @@ _CARD_FIELDS = [
 	# reviewed_at rides the card for the Decided log's "who/when" line.
 	"status", "surfaced", "reviewed_by", "reviewed_at", "approved_by", "creation",
 	"stale_reason", "last_validated_at", "flags_count", "materialized_skill",
+	# personalise_origin drives the scrub-personal-nuances warning on the promote
+	# action (security review PART 2 TASK 16).
+	"personalise_origin",
 	# review_note distinguishes Acknowledged / "applied to skill" terminal
 	# states from a plain Reject - without it the board's disposition
 	# badges can never fire and every terminal row reads "Rejected".
@@ -421,6 +432,13 @@ def list_learned_patterns_page(
 		r["exception_n"] = int(r.get("exception_n") or 0)
 		r["flags_count"] = int(r.get("flags_count") or 0)
 		r["has_overlap_warning"] = 1 if (r.get("overlap_warning") or "").strip() else 0
+		# TASK 16: a personalise-origin pattern is org-promoted by a reviewer, not
+		# the owner, so the promote action must warn them to scrub personal
+		# names/nuances first. Non-blocking; the board shows the flag + message.
+		r["personalise_origin"] = int(r.get("personalise_origin") or 0)
+		r["scrub_warning"] = (
+			_SCRUB_WARNING if r["personalise_origin"] else ""
+		)
 		r["creation"] = str(r.get("creation") or "")
 		r["reviewed_at"] = str(r.get("reviewed_at") or "")
 		r["last_validated_at"] = str(r.get("last_validated_at") or "")
@@ -690,7 +708,13 @@ def approve_learned_pattern(name: str, edited_skill_draft: str | None = None) ->
 	doc.reviewed_at = now
 	doc.save()
 	frappe.db.commit()
-	return {"ok": True, "status": doc.status, "draft_edited": int(doc.draft_edited or 0)}
+	out = {"ok": True, "status": doc.status, "draft_edited": int(doc.draft_edited or 0)}
+	# TASK 16: an A-class approve compiles the pattern into the org-wide
+	# learned-<domain> skill every user gets; if it drew from a private
+	# Personalise note, surface the scrub warning so the reviewer can act on it.
+	if doc.personalise_origin:
+		out["scrub_warning"] = _SCRUB_WARNING
+	return out
 
 
 @frappe.whitelist()
@@ -1077,7 +1101,12 @@ def apply_insight_skill_update(
 	doc.materialized_skill = row_name
 	doc.save()
 	frappe.db.commit()
-	return {"ok": True, "skill_name": slug}
+	out = {"ok": True, "skill_name": slug}
+	# TASK 16: folding a personalise-origin insight into a shared/org skill
+	# carries the same scrub obligation; surface the warning to the reviewer.
+	if doc.personalise_origin:
+		out["scrub_warning"] = _SCRUB_WARNING
+	return out
 
 
 def _draft_envelope(
@@ -1363,10 +1392,16 @@ def _apply_create_target(new_skill) -> tuple[str, str]:
 	# Call the undecorated impl: this reviewer path is already authorized by
 	# _guard() (_REVIEWER_ROLES), and a reviewer/admin may lack the Jarvis User
 	# role that the @require_jarvis_user HTTP wrapper on create_custom_skill needs.
+	# scope="Org" (the reviewer authors an org-effect skill, not a private one —
+	# the new default is User) + ignore_permissions so a reviewer without the
+	# Jarvis User doctype-create perm still lands the row; the controller's scope
+	# guard admits them as a reviewer either way (security review PART 2 TASK 10).
 	out = _create_custom_skill_impl(
 		skill_name=str(ns.get("skill_name") or "").strip(),
 		description=str(ns.get("description") or "").strip(),
 		instructions=str(ns.get("instructions") or "").strip(),
+		scope="Org",
+		ignore_permissions=True,
 	)
 	return out["data"]["name"], out["data"]["skill_name"]
 

--- a/jarvis/chat/personalise_permissions.py
+++ b/jarvis/chat/personalise_permissions.py
@@ -1,0 +1,55 @@
+"""``user``-keyed row scoping for ``Jarvis Personalise Question`` (security
+review PART 2, TASK 17).
+
+The app API scopes a user's question bank on the **``user``** field, while the
+generic Frappe REST surface scopes on **``owner``** (the doctype's ``if_owner``
+rule). Equality of the two relies solely on the ``before_insert`` owner-stamp
+(``jarvis_personalise_question.py``: ``self.owner = self.user``). Any future
+write path that sets ``user`` without going through that stamp (a raw
+``frappe.db`` insert, a bulk ``set_value``) would let ``owner`` and ``user``
+diverge, and the two access channels would then disagree about which rows a
+user sees.
+
+This hook keys the ORM scoping on the **``user``** field too, so generic REST
+list/get matches the API's ``user``-based scoping and survives any owner/user
+drift. Mirrors ``jarvis/chat/wiki_permissions.py`` / ``chat_permissions.py``.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+QUESTION = "Jarvis Personalise Question"
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def personalise_question_query_conditions(user: str | None = None) -> str:
+	"""Scope every list/report/REST query on Jarvis Personalise Question to the
+	caller's own rows, keyed on the ``user`` field (not ``owner``). System
+	Manager (and Administrator) are unrestricted (the existing SM perm row)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tabJarvis Personalise Question`.`user` = {frappe.db.escape(user)}"
+
+
+def has_personalise_question_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate keyed on the ``user`` field. System Manager: all. Everyone
+	else: only rows whose ``user`` is them. Create of a row targeting another
+	user is denied (the materializer inserts with ignore_permissions)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	target = doc.get("user")
+	if ptype == "create":
+		# A question must target the creator; backend materializers (running as
+		# Administrator / the engine) insert with ignore_permissions and skip
+		# this hook entirely.
+		return target is None or target == user
+	return target == user

--- a/jarvis/chat/skill_permissions.py
+++ b/jarvis/chat/skill_permissions.py
@@ -91,11 +91,19 @@ def has_skill_permission(doc, ptype: str = "read", user: str | None = None) -> b
 		return True
 	if ptype == "create":
 		return True
-	if ptype in _READ_PTYPES:
+	if ptype in _READ_PTYPES or ptype is None:
+		# ptype is None when Frappe builds the FULL perm dict (get_doc_permissions);
+		# resolve it as read-visibility so a visible skill isn't wrongly denied to a
+		# non-owner (the actual write/delete op re-checks with an explicit ptype).
 		from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
 			user_can_use_skill,
 		)
 
 		return user_can_use_skill(doc, user)
-	# write / delete / submit / cancel / amend: owner only.
+	# write / delete / submit / cancel / amend: owner only. This branch MUST return
+	# a bool (never frappe.throw) — get_doc_permissions calls this hook for every
+	# ptype while building a doc's perm dict, so a throw here would break plain
+	# reads. The clear user-facing "you can only edit your own skills" message is
+	# raised by the SPA write endpoints (custom_skills_api._require_skill_owner);
+	# generic REST writes fall back to Frappe's "does not have access" message.
 	return (doc.get("owner") or "") == user

--- a/jarvis/chat/skill_permissions.py
+++ b/jarvis/chat/skill_permissions.py
@@ -1,0 +1,101 @@
+"""Scope-ladder visibility for ``Jarvis Custom Skill`` at the ORM (security
+review PART 2, TASK 13).
+
+The visibility rule ({owner OR shared OR scope=Org (unless role-narrowed) OR
+scope=Role role-match}) used to live in FOUR hand-rolled read surfaces that
+disagreed (the plugin find/get honored ``allowed_roles``; the SPA list/get did
+not; generic REST was only accidentally safe because ``if_owner`` hid
+everything, so an owner couldn't even REST-list a skill shared to them). This
+module lifts the ONE rule (``jarvis_custom_skill.user_can_use_skill``) to the
+ORM so list/report/generic-REST queries (``permission_query_conditions``) and
+per-doc access (``has_permission``) inherit it automatically — exactly the
+``jarvis/chat/wiki_permissions.py`` pattern.
+
+Writes stay owner-only (create/save/delete of your own row); scope WIDENING is
+guarded in the controller (``_guard_scope_change`` / ``_guard_new_scope``) so it
+holds under ``ignore_permissions`` too. Reviewer/compiler writes (the promotion
+decide + insight-apply + compiler upsert) go through ``ignore_permissions`` and
+so never consult ``has_permission``.
+
+Every interpolated value in the SQL fragment goes through ``frappe.db.escape``;
+role names / user emails are org-author-controlled strings.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+SKILL = "Jarvis Custom Skill"
+SHARE = "Jarvis Custom Skill Share"
+ALLOWED_ROLE = "Jarvis Custom Skill Allowed Role"
+
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def skill_query_conditions(user: str | None = None) -> str:
+	"""hooks.permission_query_conditions — scopes every list/report/REST query to
+	the caller's visible skill set. Empty (no restriction) for System Managers.
+	Always a parenthesized valid boolean expression."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	table = f"`tab{SKILL}`"
+	esc_user = frappe.db.escape(user)
+	clauses = [
+		f"{table}.`owner` = {esc_user}",
+		# shared with me
+		(
+			f"exists (select 1 from `tab{SHARE}` sh "
+			f"where sh.parent = {table}.`name` and sh.parenttype = {frappe.db.escape(SKILL)} "
+			f"and sh.`user` = {esc_user})"
+		),
+		# Org (or legacy empty) with NO allowed_roles narrowing = everyone.
+		(
+			f"(coalesce({table}.`scope`, '') in ('', 'Org') and not exists "
+			f"(select 1 from `tab{ALLOWED_ROLE}` ar where ar.parent = {table}.`name` "
+			f"and ar.parenttype = {frappe.db.escape(SKILL)}))"
+		),
+	]
+	roles = [r for r in frappe.get_roles(user) if r]
+	if roles:
+		role_list = ", ".join(frappe.db.escape(r) for r in roles)
+		# Role-match via allowed_roles (managed learned rows + legacy Org narrowed
+		# by roles). Never applies to User-scope rows (private).
+		clauses.append(
+			f"(coalesce({table}.`scope`, '') != 'User' and exists "
+			f"(select 1 from `tab{ALLOWED_ROLE}` ar where ar.parent = {table}.`name` "
+			f"and ar.parenttype = {frappe.db.escape(SKILL)} and ar.`role` in ({role_list})))"
+		)
+		# Role-scope via target_role.
+		clauses.append(
+			f"({table}.`scope` = 'Role' and {table}.`target_role` in ({role_list}))"
+		)
+	return "(" + " or ".join(clauses) + ")"
+
+
+def has_skill_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""hooks.has_permission — per-doc gate. Reads follow the scope-ladder
+	visibility rule (``user_can_use_skill``); write/delete are owner-only (scope
+	widening is separately controller-guarded); create defers to the role perm
+	(owner is the creator; the controller caps a non-reviewer's new scope to
+	User). True defers to the normal role-perm check (hooks can only deny)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	if ptype == "create":
+		return True
+	if ptype in _READ_PTYPES:
+		from jarvis.jarvis.doctype.jarvis_custom_skill.jarvis_custom_skill import (
+			user_can_use_skill,
+		)
+
+		return user_can_use_skill(doc, user)
+	# write / delete / submit / cancel / amend: owner only.
+	return (doc.get("owner") or "") == user

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -897,6 +897,17 @@ def apply_promotion(
 	decision_note. Idempotent: a non-Pending request is a no-op."""
 	reviewer = reviewer or frappe.session.user
 	req = frappe.get_doc(PROMO, request_name)
+	# Security review PART 2 TASK 19: four-eyes / separation of duties. A user
+	# holding BOTH a Knowledge-Wiki role (so they could author + request) and a
+	# reviewer role must not approve their OWN promotion request. Bounded (the
+	# widened content is their own page) but promotion is an org-wide effect, so
+	# it needs a second pair of eyes. Checked before the TOCTOU claim so a
+	# self-approval never mutates the target page.
+	if reviewer == (req.owner or "") and reviewer != "Administrator":
+		frappe.throw(
+			_("You cannot approve your own promotion request; another reviewer must decide it."),
+			frappe.PermissionError,
+		)
 	# TOCTOU-safe claim: re-read the status under a row lock (for_update) before
 	# the merge, so two concurrent approvals (two reviewers, or a double-submit)
 	# can never both pass the Pending check and double-append body_snapshot into

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -337,3 +337,22 @@ has_permission.update({
 	"Jarvis Voice Note": "jarvis.chat.chat_permissions.has_voice_note_permission",
 })
 
+# ---------------------------------------------------------------------------
+# Skills / Personalise scoping (security review PART 2)
+# ---------------------------------------------------------------------------
+# TASK 13: Jarvis Custom Skill visibility (owner OR scope=Org OR scope=Role
+# role-match OR shared-with) at the ORM, so the four hand-rolled read surfaces
+# (generic REST, SPA list/get, plugin find/get) can never disagree. Matrix +
+# SQL fragment live in jarvis/chat/skill_permissions.py (reuses the controller's
+# user_can_use_skill rule).
+# TASK 17: Jarvis Personalise Question scoped on the `user` field (not `owner`)
+# so generic REST matches the API's user-based scoping and survives drift.
+permission_query_conditions.update({
+	"Jarvis Custom Skill": "jarvis.chat.skill_permissions.skill_query_conditions",
+	"Jarvis Personalise Question": "jarvis.chat.personalise_permissions.personalise_question_query_conditions",
+})
+has_permission.update({
+	"Jarvis Custom Skill": "jarvis.chat.skill_permissions.has_skill_permission",
+	"Jarvis Personalise Question": "jarvis.chat.personalise_permissions.has_personalise_question_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.json
@@ -11,6 +11,7 @@
     "enabled",
     "user_invocable",
     "scope",
+    "target_role",
     "description",
     "instructions",
     "shared_with",
@@ -45,9 +46,18 @@
       "fieldname": "scope",
       "fieldtype": "Select",
       "label": "Scope",
-      "options": "Org\nPersonal",
-      "default": "Org",
-      "description": "Org skills join the shared assistant catalog on Apply; Personal skills stay private to their owner and are only reachable via jarvis__find_skills / jarvis__get_skill. Empty (pre-migration rows) means Org."
+      "options": "User\nRole\nOrg",
+      "default": "User",
+      "description": "Scope ladder (security review PART 2 TASK 10, mirrors Jarvis Wiki Page). User = private to the owner (default; reached via jarvis__find_skills / jarvis__get_skill, never pushed to the shared catalog). Role = holders of Target Role. Org = everyone; joins the shared assistant catalog on Apply. Widening (User->Role->Org) is reviewer-approved only. Empty (pre-migration rows) means Org."
+    },
+    {
+      "fieldname": "target_role",
+      "fieldtype": "Link",
+      "label": "Target Role",
+      "options": "Role",
+      "depends_on": "eval:doc.scope=='Role'",
+      "mandatory_depends_on": "eval:doc.scope=='Role'",
+      "description": "Required for Role-scope skills: the single role whose holders may see/invoke this skill (the Wiki-parallel audience field)."
     },
     {
       "fieldname": "description",
@@ -89,12 +99,18 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "read": 1,
       "write": 1,
       "create": 1,
-      "delete": 1,
-      "if_owner": 1
+      "delete": 1
+    },
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
     }
   ],
   "sort_field": "skill_name",

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -35,6 +35,9 @@ RESERVED_PREFIX = "custom-"
 # sets ``frappe.flags.jarvis_pattern_engine``) or Administrator may author it.
 LEARNED_PREFIX = "learned-"
 
+# Scope ladder (security review PART 2 TASK 10), mirroring Jarvis Wiki Page.
+SCOPES = ("User", "Role", "Org")
+
 SKILL_DOCTYPE = "Jarvis Custom Skill"
 
 
@@ -65,15 +68,23 @@ def _managed_flag_privileged(user: str | None = None) -> bool:
 
 
 def user_can_use_skill(skill, user: str | None = None, user_roles: list[str] | None = None) -> bool:
-	"""Allowed-Roles visibility rule (pattern-learning plan section 6.6).
+	"""Scope-ladder visibility rule (security review PART 2 TASK 13; the single
+	rule every read path — generic REST via the ORM hook, the SPA list/get, the
+	plugin find/get tools — now agrees on).
 
-	A user may see/invoke a skill iff they are the owner, are in
-	``shared_with``, ``allowed_roles`` is empty (= everyone), or their roles
-	intersect ``allowed_roles``. System Manager (and Administrator) always
-	passes. ``skill`` may be a Document or any dict-like row; when the row
-	does not carry the child tables (e.g. a ``frappe.get_all`` row) they are
-	fetched by parent name. Instruction-level enforcement only - the skill
-	files stay readable in the shared container.
+	A user may see/invoke a skill iff they are the owner, are in ``shared_with``,
+	or the skill's scope admits them:
+
+	  * ``User``  — owner only (private).
+	  * ``Role``  — holders of ``target_role`` (or, for compiler-managed rows /
+	    legacy multi-role narrowing, an ``allowed_roles`` intersection).
+	  * ``Org``   — everyone, UNLESS ``allowed_roles`` is set (managed learned
+	    rows + legacy "Org narrowed by roles"), in which case role-match.
+
+	System Manager (and Administrator) always passes. ``skill`` may be a Document
+	or any dict-like row; child tables absent from a ``frappe.get_all`` row are
+	fetched by parent name. Instruction-level enforcement — see TASK 11 for why
+	role-restricted bodies must ALSO be kept off the shared container push.
 	"""
 	user = user or frappe.session.user
 	if user == "Administrator":
@@ -86,10 +97,27 @@ def user_can_use_skill(skill, user: str | None = None, user_roles: list[str] | N
 		return True
 	if user in _child_values(skill, "shared_with", "user", "Jarvis Custom Skill Share"):
 		return True
-	allowed = _child_values(skill, "allowed_roles", "role", "Jarvis Custom Skill Allowed Role")
+	# NULL/empty scope == Org (pre-migration rows); "Personal" is the pre-ladder
+	# spelling of User (safe until the migration backfills the DB).
+	scope = (skill.get("scope") or "Org").strip() or "Org"
+	if scope == "Personal":
+		scope = "User"
+	roles = set(user_roles)
+	if scope == "User":
+		# Private: owner/shared/SM already handled above.
+		return False
+	allowed = set(
+		_child_values(skill, "allowed_roles", "role", "Jarvis Custom Skill Allowed Role")
+	)
+	if scope == "Role":
+		target_role = (skill.get("target_role") or "").strip()
+		if target_role and target_role in roles:
+			return True
+		return bool(allowed & roles)
+	# Org (or legacy empty): everyone unless narrowed by allowed_roles.
 	if not allowed:
 		return True
-	return bool(set(allowed) & set(user_roles))
+	return bool(allowed & roles)
 
 
 def _child_values(skill, fieldname: str, value_field: str, child_doctype: str) -> list[str]:
@@ -120,6 +148,8 @@ class JarvisCustomSkill(Document):
 	def validate(self):
 		self._validate_slug()
 		self._validate_scope()
+		self._guard_new_scope()
+		self._guard_scope_change()
 		self._validate_lengths()
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
@@ -132,11 +162,86 @@ class JarvisCustomSkill(Document):
 		_clear_personal_clause_cache(self.owner)
 
 	def _validate_scope(self):
-		# NULL/empty scope == Org everywhere (pre-migration rows are never
-		# backfilled); normalize on save so new writes are explicit.
-		self.scope = (self.scope or "Org").strip()
-		if self.scope not in ("Org", "Personal"):
-			frappe.throw(_("Scope must be Org or Personal."))
+		# Scope ladder {User, Role, Org} (security review PART 2 TASK 10). NEW rows
+		# default to User (private-first); pre-migration rows carry legacy scopes,
+		# so a blank scope on an EXISTING row reads as Org (its historical meaning)
+		# while a blank scope on a fresh insert defaults to User. "Personal" is the
+		# pre-ladder spelling of User.
+		raw = (self.scope or "").strip()
+		if raw == "Personal":
+			raw = "User"
+		if not raw:
+			raw = "User" if self.is_new() else "Org"
+		self.scope = raw
+		if self.scope not in SCOPES:
+			frappe.throw(_("Scope must be one of {0}.").format(", ".join(SCOPES)))
+		if self.scope == "Role":
+			self.target_role = (self.target_role or "").strip() or None
+			if not self.target_role:
+				frappe.throw(_("Role-scope skills need a Target Role."))
+			# allowed_roles stays meaningful for compiler-managed rows only; an
+			# authored Role skill's audience is target_role.
+		elif self.scope == "User":
+			# A private skill has no role audience — clear both so a stray
+			# allowed_roles/target_role can never leak it to role-holders (TASK 13
+			# U1: no silent Personal+roles no-op).
+			self.target_role = None
+			if not frappe.flags.jarvis_pattern_engine:
+				self.set("allowed_roles", [])
+		else:  # Org
+			self.target_role = None
+
+	def _scope_change_authorized(self) -> bool:
+		"""Who may WIDEN a skill's scope (mint or promote it to Role/Org): the
+		learning compiler (engine flag), Administrator, or a skill reviewer
+		(Jarvis Skill Reviewer / Jarvis Admin / System Manager — TASK 15 set).
+		A normal owner may only ever create/keep a User-scope skill; widening is
+		reviewer-gated (the promotion workflow), never a self-service field flip."""
+		if frappe.flags.jarvis_pattern_engine:
+			return True
+		from jarvis.permissions import is_skill_reviewer
+
+		return is_skill_reviewer(frappe.session.user)
+
+	def _guard_new_scope(self):
+		"""Block a non-reviewer from CREATING a skill directly at Role/Org scope
+		(the [E1]/[O1] self-service org-escalation the review flagged) — closes the
+		generic-REST insert + the create_custom_skill tool's scope arg at the
+		controller, so it holds no matter which door the insert comes through.
+		New skills default to User; Role/Org creation needs the reviewer set."""
+		if not self.is_new():
+			return
+		if self.scope in ("Role", "Org") and not self._scope_change_authorized():
+			frappe.throw(
+				_("New skills are private (User scope); promoting to Role or Org "
+				  "needs a reviewer's approval."),
+				frappe.PermissionError,
+			)
+
+	def _guard_scope_change(self):
+		"""Only a reviewer (or the compiler) may re-scope or re-target an EXISTING
+		skill — anything else would let an owner widen their own skill bench-wide
+		via a save path (SPA, frappe.client.set_value, a raw controller write).
+		Runs regardless of ignore_permissions, exactly like the Wiki page guard
+		(jarvis_wiki_page._guard_scope_change), because the reviewer promotion
+		writes save with ignore_permissions=True."""
+		if self.is_new():
+			return
+		prev = frappe.db.get_value(
+			self.doctype, self.name, ["scope", "target_role"], as_dict=True
+		)
+		if not prev:
+			return
+		prev_scope = (prev.scope or "").strip() or "Org"
+		if self.scope == prev_scope and (self.target_role or None) == (prev.target_role or None):
+			return
+		if self._scope_change_authorized():
+			return
+		frappe.throw(
+			_("Only a reviewer can change the scope or audience of an existing "
+			  "skill. Request a promotion instead."),
+			frappe.PermissionError,
+		)
 
 	def _validate_slug(self):
 		self.skill_name = (self.skill_name or "").strip().lower()

--- a/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
+++ b/jarvis/jarvis/doctype/jarvis_custom_skill/jarvis_custom_skill.py
@@ -237,9 +237,17 @@ class JarvisCustomSkill(Document):
 			return
 		if self._scope_change_authorized():
 			return
+		# Owner-initiated NARROWING (strictly fewer viewers down the User<Role<Org
+		# ladder) is always safe — it reduces exposure — so the owner may
+		# self-demote without a reviewer (e.g. un-publish an Org skill back to
+		# private). WIDENING and lateral Role re-targeting stay reviewer-gated.
+		rank = {"User": 0, "Role": 1, "Org": 2}
+		is_owner = (self.owner or "") == frappe.session.user
+		if is_owner and rank.get(self.scope, 2) < rank.get(prev_scope, 2):
+			return
 		frappe.throw(
-			_("Only a reviewer can change the scope or audience of an existing "
-			  "skill. Request a promotion instead."),
+			_("Only a reviewer can widen the scope or change the audience of an "
+			  "existing skill. Request a promotion instead."),
 			frappe.PermissionError,
 		)
 

--- a/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
+++ b/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
@@ -46,7 +46,8 @@
     "counter_evidence",
     "flags_count",
     "flag_band_cap",
-    "overlap_warning"
+    "overlap_warning",
+    "personalise_origin"
   ],
   "fields": [
     {
@@ -305,6 +306,14 @@
       "fieldtype": "Small Text",
       "label": "Overlap Warning",
       "description": "Lexical overlap with a customer-authored skill (warn-only)."
+    },
+    {
+      "fieldname": "personalise_origin",
+      "fieldtype": "Check",
+      "label": "Personalise Origin",
+      "default": "0",
+      "read_only": 1,
+      "description": "Security review PART 2 TASK 16: a contribution to this pattern came from a user's PRIVATE Personalise answer note. A reviewer promoting it org-wide must scrub personal names/nuances first (a non-blocking warning is shown on the board), since the owner did not themselves request the promotion."
     }
   ],
   "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
+++ b/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.json
@@ -1,18 +1,18 @@
 {
   "doctype": "DocType",
-  "name": "Jarvis Wiki Promotion Request",
+  "name": "Jarvis Skill Promotion Request",
   "module": "Jarvis",
   "issingle": 0,
   "custom": 0,
   "engine": "InnoDB",
-  "autoname": "format:JWPR-{#####}",
+  "autoname": "format:JSPR-{#####}",
   "naming_rule": "Expression",
   "field_order": [
-    "page",
+    "skill",
+    "skill_name",
     "from_scope",
     "to_scope",
     "target_role",
-    "body_snapshot",
     "note",
     "status",
     "reviewer",
@@ -21,29 +21,37 @@
   ],
   "fields": [
     {
-      "fieldname": "page",
+      "fieldname": "skill",
       "fieldtype": "Link",
-      "label": "Page",
-      "options": "Jarvis Wiki Page",
+      "label": "Skill",
+      "options": "Jarvis Custom Skill",
       "reqd": 1,
       "in_list_view": 1,
       "in_standard_filter": 1,
       "search_index": 1,
-      "description": "The User-scope wiki page this request asks to promote."
+      "description": "The User/Role-scope custom skill this request asks to promote."
+    },
+    {
+      "fieldname": "skill_name",
+      "fieldtype": "Data",
+      "label": "Skill Name",
+      "read_only": 1,
+      "in_list_view": 1,
+      "description": "The skill's authored slug at request time (for the reviewer board)."
     },
     {
       "fieldname": "from_scope",
       "fieldtype": "Select",
       "label": "From Scope",
-      "options": "Org\nRole\nUser",
+      "options": "User\nRole\nOrg",
       "reqd": 1,
-      "description": "Snapshot of the page's scope at request time (User in practice for v1 - a requester can only act on their own User-scope page)."
+      "description": "Snapshot of the skill's scope at request time."
     },
     {
       "fieldname": "to_scope",
       "fieldtype": "Select",
       "label": "To Scope",
-      "options": "Org\nRole\nUser",
+      "options": "Role\nOrg",
       "reqd": 1,
       "in_list_view": 1,
       "in_standard_filter": 1,
@@ -56,12 +64,6 @@
       "options": "Role",
       "depends_on": "eval:doc.to_scope=='Role'",
       "mandatory_depends_on": "eval:doc.to_scope=='Role'"
-    },
-    {
-      "fieldname": "body_snapshot",
-      "fieldtype": "Long Text",
-      "label": "Body Snapshot",
-      "description": "The page's body_md at request time, frozen so the reviewer can diff it against the current target page even if the source page keeps changing in the meantime."
     },
     {
       "fieldname": "note",

--- a/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.py
+++ b/jarvis/jarvis/doctype/jarvis_skill_promotion_request/jarvis_skill_promotion_request.py
@@ -1,0 +1,61 @@
+"""Jarvis Skill Promotion Request DocType controller (security review PART 2,
+TASK 10).
+
+One row per "promote my private (User) or role skill up the scope ladder" ask,
+the Custom-Skill analogue of ``Jarvis Wiki Promotion Request``. Created by
+``jarvis.chat.custom_skills_api.request_skill_promotion`` when a skill owner
+asks to widen a skill they own; decided by a skill reviewer
+(``custom_skills_api.decide_skill_promotion``), who approves (widening the
+skill's scope) or rejects. The ``All`` role only ever gets read/create-free
+here (create dropped, so the ownership-checked endpoint is the sole creation
+path); a requester can never self-approve or edit a decision after the fact.
+
+Promotion only ever WIDENS visibility: ``to_scope`` is Role/Org (never back to
+User, never sideways). ``from_scope`` is a point-in-time snapshot of the source
+skill's scope, re-validated at decision time by the reviewer endpoint.
+"""
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+SKILL = "Jarvis Custom Skill"
+FROM_SCOPES = ("User", "Role", "Org")
+TO_SCOPES = ("Role", "Org")
+
+
+class JarvisSkillPromotionRequest(Document):
+	def before_insert(self):
+		# The requester must be able to READ the source skill before a request is
+		# filed against it — closes the same generic-REST disclosure class as the
+		# Wiki promotion request (TASK 14). Runs for EVERY insert path; the skill
+		# ORM hook resolves User-scope skills to their owner, so this subsumes an
+		# explicit owner check. Administrator bypasses has_permission natively.
+		if self.skill and not frappe.has_permission(SKILL, "read", self.skill):
+			frappe.throw(
+				_("You do not have access to this skill."), frappe.PermissionError
+			)
+		if self.skill and not self.skill_name:
+			self.skill_name = frappe.db.get_value(SKILL, self.skill, "skill_name") or ""
+
+	def validate(self):
+		self._validate_skill()
+		self._validate_scopes()
+
+	def _validate_skill(self):
+		if not self.skill:
+			frappe.throw(_("A promotion request must reference a skill."))
+
+	def _validate_scopes(self):
+		self.from_scope = (self.from_scope or "").strip()
+		if self.from_scope and self.from_scope not in FROM_SCOPES:
+			frappe.throw(
+				_("From Scope must be one of {0}.").format(", ".join(FROM_SCOPES))
+			)
+		self.to_scope = (self.to_scope or "").strip()
+		if self.to_scope not in TO_SCOPES:
+			frappe.throw(
+				_("To Scope must be one of {0}.").format(", ".join(TO_SCOPES))
+			)
+		if self.to_scope == "Role" and not self.target_role:
+			frappe.throw(_("Promoting to Role scope needs a Target Role."))

--- a/jarvis/jarvis/doctype/jarvis_wiki_promotion_request/jarvis_wiki_promotion_request.py
+++ b/jarvis/jarvis/doctype/jarvis_wiki_promotion_request/jarvis_wiki_promotion_request.py
@@ -29,6 +29,17 @@ TO_SCOPES = ("Role", "Org")
 
 class JarvisWikiPromotionRequest(Document):
 	def before_insert(self):
+		# Security review PART 2 TASK 14: this row's before_insert back-fills
+		# body_snapshot from the source page with a permission-bypassing
+		# db.get_value. Because the doctype used to grant `All: create`, a System
+		# User could frappe.client.insert a request naming ANOTHER user's private
+		# (User-scope) wiki page and read the victim's body_md back through the row
+		# they own (if_owner). Assert the caller can actually READ the page BEFORE
+		# snapshotting — closes the generic-REST disclosure at the controller so it
+		# holds no matter which door the insert comes through (the bare `All:
+		# create` grant is also dropped from the JSON, leaving the ownership-checked
+		# request_wiki_promotion endpoint as the only creation path).
+		self._guard_page_readable()
 		# Freeze the diff basis at request time (DESIGN.md 2.4): if the caller
 		# didn't already snapshot the body, pull it from the live page once,
 		# here, so a later edit to the source page can never retroactively
@@ -36,6 +47,20 @@ class JarvisWikiPromotionRequest(Document):
 		if not self.body_snapshot and self.page:
 			self.body_snapshot = (
 				frappe.db.get_value("Jarvis Wiki Page", self.page, "body_md") or ""
+			)
+
+	def _guard_page_readable(self):
+		"""The requester must be able to READ the source page before it is
+		snapshotted into a row they own. Runs for EVERY insert path (REST
+		included); Administrator bypasses frappe.has_permission natively. The
+		wiki's own has_permission hook resolves User-scope pages to their
+		target_user, so this subsumes an explicit owner check."""
+		if not self.page:
+			return
+		if not frappe.has_permission("Jarvis Wiki Page", "read", self.page):
+			frappe.throw(
+				_("You do not have access to this wiki page."),
+				frappe.PermissionError,
 			)
 
 	def validate(self):

--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -459,6 +459,11 @@ def _upsert_managed_skill(spec: dict) -> str:
 	doc.user_invocable = 0
 	doc.enabled = 1
 	doc.managed_by_learning = 1
+	# Managed learned rows are org-effect (role-gated at runtime by
+	# learned_skill_clause via allowed_roles); pin scope=Org so the new
+	# private-first User default (security review PART 2 TASK 10) never applies to
+	# them. The engine flag is set here, so the scope guard admits the write.
+	doc.scope = "Org"
 	doc.set("allowed_roles", [{"role": r} for r in spec["allowed_roles"]])
 	doc.save(ignore_permissions=True) if existing else doc.insert(ignore_permissions=True)
 	return doc.name

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -542,6 +542,13 @@ def _persist_rule_facts(rule_facts: list[dict]) -> dict:
 				stats["duplicates"] += 1
 			if outcome in ("created", "updated"):
 				_surface(cand["pattern_key"])
+				# Security review PART 2 TASK 16: a rule fact drawn (even partly)
+				# from a PRIVATE Personalise answer note carries personal nuances;
+				# stamp the pattern so a reviewer promoting it org-wide is warned to
+				# scrub them (the owner did not request the promotion). Sticky once
+				# set — a mixed-cohort pattern stays flagged (conservative).
+				if fact.get("personalise_users"):
+					_flag_personalise_origin(cand["pattern_key"])
 
 		frappe.db.set_value(
 			RUN,
@@ -566,6 +573,18 @@ def _persist_rule_facts(rule_facts: list[dict]) -> dict:
 		frappe.flags.jarvis_pattern_engine = prev_flag
 		frappe.set_user(original_user)
 	return stats
+
+
+def _flag_personalise_origin(pattern_key: str) -> None:
+	"""Stamp ``personalise_origin=1`` on the JLP for ``pattern_key`` (idempotent,
+	sticky). Security review PART 2 TASK 16 provenance."""
+	row = frappe.db.get_value(
+		JLP, {"pattern_key": pattern_key}, ["name", "personalise_origin"], as_dict=True
+	)
+	if row and not row.personalise_origin:
+		frappe.db.set_value(
+			JLP, row.name, {"personalise_origin": 1}, update_modified=False
+		)
 
 
 def _surface(pattern_key: str) -> None:

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -20,3 +20,4 @@ jarvis.patches.v1_10_backfill_llm_pool_synced_at
 jarvis.patches.v1_0.grant_jarvis_user_role
 jarvis.patches.v1_11_greeting_cadence
 jarvis.patches.v1_0.revoke_jarvis_user_from_website_users
+jarvis.patches.v1_12_skill_scope_ladder

--- a/jarvis/patches/v1_12_skill_scope_ladder.py
+++ b/jarvis/patches/v1_12_skill_scope_ladder.py
@@ -1,0 +1,24 @@
+"""Security review PART 2 TASK 10: migrate Jarvis Custom Skill onto the
+{User, Role, Org} scope ladder (default User).
+
+Legacy rows carried scope ∈ {Org, Personal} (default Org). The ladder renames
+"Personal" -> "User" (a private, owner-only skill) and treats a NULL/empty
+scope (pre-scope-field rows) as its historical meaning, Org. Org rows stay Org.
+Idempotent.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Jarvis Custom Skill", "scope"):
+		return
+	# Personal is the pre-ladder spelling of User.
+	frappe.db.sql(
+		"UPDATE `tabJarvis Custom Skill` SET `scope` = 'User' WHERE `scope` = 'Personal'"
+	)
+	# Pre-scope rows (NULL/empty) meant Org.
+	frappe.db.sql(
+		"UPDATE `tabJarvis Custom Skill` SET `scope` = 'Org' "
+		"WHERE `scope` IS NULL OR `scope` = ''"
+	)

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -26,6 +26,35 @@ import frappe
 JARVIS_USER_ROLE = "Jarvis User"
 JARVIS_ACCESS_ROLES = ("System Manager", JARVIS_USER_ROLE)
 
+# Reviewer set authorized for org-wide skill / pattern / wiki effects (security
+# review PART 2, TASK 15 — RATIFIED). Housed in this lightweight module (no heavy
+# imports) so the Jarvis Custom Skill controller / skill_permissions can import it
+# without pulling in the learned_api import graph. Keep in sync with
+# jarvis.chat.learned_api._REVIEWER_ROLES.
+JARVIS_REVIEWER_ROLES = ("Jarvis Skill Reviewer", "Jarvis Admin", "System Manager")
+
+
+def is_skill_reviewer(user: str | None = None) -> bool:
+	"""True iff ``user`` may authorize org-wide skill effects: promote a Custom
+	Skill up the User→Role→Org scope ladder, or apply skills bench-wide.
+	``Administrator`` always passes. Defaults to the current session user."""
+	user = user or frappe.session.user
+	if user == "Administrator":
+		return True
+	return bool(set(JARVIS_REVIEWER_ROLES) & set(frappe.get_roles(user)))
+
+
+def require_skill_reviewer(user: str | None = None) -> None:
+	"""Raise ``frappe.PermissionError`` unless ``user`` is a skill reviewer
+	(Jarvis Skill Reviewer / Jarvis Admin / System Manager; Administrator
+	implicit). Whitelisted endpoints call this to gate org-wide skill effects."""
+	if not is_skill_reviewer(user):
+		frappe.throw(
+			"This action needs a Jarvis Skill Reviewer, Jarvis Admin or System "
+			"Manager role.",
+			frappe.PermissionError,
+		)
+
 
 def ensure_jarvis_user_role() -> None:
 	"""Idempotently create the ``Jarvis User`` role (desk-access). Shared by the

--- a/jarvis/tests/learning/test_compiler.py
+++ b/jarvis/tests/learning/test_compiler.py
@@ -520,6 +520,9 @@ class TestApplyLearnedSkills(FrappeTestCase):
 			"instructions": "y",
 			"enabled": 1,
 			"user_invocable": 0,
+			# Org scope: only Org skills join the shared push (TASK 10 made User the
+			# default, which is never pushed).
+			"scope": "Org",
 			"managed_by_learning": 0,
 		})
 		d.owner = "Administrator"
@@ -593,6 +596,8 @@ class TestApplyLearnedSkills(FrappeTestCase):
 				"instructions": "y",
 				"enabled": 1,
 				"user_invocable": 0,
+				# Org scope: only Org skills join the shared push (TASK 10).
+				"scope": "Org",
 				"managed_by_learning": 0,
 			})
 			d.creation = d.modified = frappe.utils.now()

--- a/jarvis/tests/test_chat_endpoint_gating.py
+++ b/jarvis/tests/test_chat_endpoint_gating.py
@@ -42,6 +42,7 @@ _GATE_DECORATOR = "require_jarvis_user"
 _GUARD_CALL_SUBSTRS = (
 	"require_jarvis_access",
 	"require_jarvis_user",
+	"require_skill_reviewer",  # PART 2 TASK 12: skill-reviewer/admin gate (org-wide apply)
 	"_require_system_user",
 	"only_for",  # frappe.only_for(...) — an SM/role gate, stricter than Jarvis User
 	"_guard",  # learned_api._guard / _admin_guard (reviewer/admin role gate)

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -257,8 +257,12 @@ class TestConfirmTool(FrappeTestCase):
 		if not frappe.db.exists("User", other):
 			frappe.get_doc({
 				"doctype": "User", "email": other, "first_name": "Other",
-				"send_welcome_email": 0,
+				"send_welcome_email": 0, "user_type": "System User",
 			}).insert(ignore_permissions=True)
+		# confirm_tool is @require_jarvis_user-gated; a realistic non-owner caller
+		# holds the role, so the owner-mismatch (not the role gate) is what rejects.
+		if "Jarvis User" not in set(frappe.get_roles(other)):
+			frappe.get_doc("User", other).add_roles("Jarvis User")
 
 		original = frappe.session.user
 		frappe.set_user(other)
@@ -583,8 +587,12 @@ class TestListPendingConfirmations(FrappeTestCase):
 		if not frappe.db.exists("User", email):
 			frappe.get_doc({
 				"doctype": "User", "email": email, "first_name": "LP",
-				"send_welcome_email": 0,
+				"send_welcome_email": 0, "user_type": "System User",
 			}).insert(ignore_permissions=True)
+		# list_pending_confirmations is @require_jarvis_user-gated; the owner
+		# caller needs the role to reach the owner-scoped listing.
+		if "Jarvis User" not in set(frappe.get_roles(email)):
+			frappe.get_doc("User", email).add_roles("Jarvis User")
 		return email
 
 	def setUp(self):

--- a/jarvis/tests/test_custom_skill_visibility.py
+++ b/jarvis/tests/test_custom_skill_visibility.py
@@ -41,8 +41,12 @@ def _engine_flag():
 
 
 def _ensure_non_sm(email: str) -> str:
-	"""A logged-in user with no System Manager role (created inside the test
-	transaction, so it is rolled back with everything else)."""
+	"""A logged-in Jarvis User with NO System Manager role (created inside the
+	test transaction, so it is rolled back with everything else). The Jarvis User
+	role is what now grants Custom Skill create at the doctype layer (security
+	review PART 2 TASK 13 replaced the old `All` grant), so a realistic non-SM
+	author holds it — the point of these tests is that even a role-holding author
+	cannot forge the managed flag / learned slug."""
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
@@ -50,8 +54,11 @@ def _ensure_non_sm(email: str) -> str:
 		})
 		u.flags.ignore_permissions = True
 		u.insert(ignore_permissions=True)
+	udoc = frappe.get_doc("User", email)
 	if "System Manager" in set(frappe.get_roles(email)):
-		frappe.get_doc("User", email).remove_roles("System Manager")
+		udoc.remove_roles("System Manager")
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		udoc.add_roles("Jarvis User")
 	return email
 
 

--- a/jarvis/tests/test_custom_skills_push.py
+++ b/jarvis/tests/test_custom_skills_push.py
@@ -40,6 +40,9 @@ def _mk(suffix, *, owner=OWNER, enabled=1, managed=0, skill_name=None):
 		"instructions": "body",
 		"enabled": enabled,
 		"user_invocable": 0,
+		# Org scope: only Org skills join the shared container push (security
+		# review PART 2 TASK 10 made User the default, which is never pushed).
+		"scope": "Org",
 		"managed_by_learning": managed,
 	})
 	# db_insert stamps owner with the session user unless creation is already

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -175,6 +175,27 @@ class TestScopeCreationGuard(Part2Base):
 		self.assertEqual(out["scope"], "User")
 		self.assertEqual(frappe.db.get_value(SKILL, out["name"], "scope"), "User")
 
+	def test_owner_can_narrow_own_scope(self):
+		# TASK E2: narrowing (Org->User) reduces visibility, so the owner may
+		# self-demote without a reviewer; only widening stays reviewer-gated.
+		skill = _mk_skill(USER_A, f"{PFX}-narrow", scope="Org")
+		with _as(USER_A):
+			doc = frappe.get_doc(SKILL, skill.name)
+			doc.scope = "User"
+			doc.save()
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+
+	def test_non_owner_update_gets_clear_message(self):
+		# TASK E1: a non-owner write is denied with a CLEAR message (not an
+		# empty-string PermissionError).
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_B, f"{PFX}-e1", scope="Org")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError) as ctx:
+				custom_skills_api.update_custom_skill(name=skill.name, description="hax")
+		self.assertIn("your own skills", str(ctx.exception))
+
 
 class TestSkillOrmHook(Part2Base):
 	"""TASK 13: generic-REST (get_list) returns the SAME visibility set as the
@@ -282,6 +303,27 @@ class TestSkillPromotionWorkflow(Part2Base):
 		with _as(USER_B):
 			with self.assertRaises(frappe.PermissionError):
 				custom_skills_api.decide_skill_promotion(req["request"], 1)
+
+	def test_reviewer_discovers_pending_requests(self):
+		# TASK D: a reviewer-only user must be able to SEE pending requests (the
+		# doctype perms are owner-scoped, so a reviewer needs the gated list
+		# endpoint to discover a JSPR they didn't create).
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-discover", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		with _as(REVIEWER):
+			res = custom_skills_api.list_skill_promotion_requests(status="Pending")
+		names = [r["name"] for r in res["rows"]]
+		self.assertIn(req["request"], names)
+		row = next(r for r in res["rows"] if r["name"] == req["request"])
+		self.assertEqual(row["requested_by"], USER_A)
+		self.assertEqual(row["to_scope"], "Org")
+		# A plain (non-reviewer) user cannot list the queue.
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.list_skill_promotion_requests()
 
 
 class TestWikiPromotionRequestLeak(Part2Base):

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -1,0 +1,410 @@
+"""Security review PART 2 — exploit reproductions + fix proofs.
+
+Covers the Custom Skill scope ladder + guards + ORM hook (TASK 10, 13), the
+role-restricted-body push exclusion (TASK 11), the reviewer/admin apply gate
+(TASK 12), the wiki-promotion-request generic-REST leak (TASK 14), the
+personalise-origin scrub provenance (TASK 16), the personalise-question
+`user`-keyed ORM hook (TASK 17) and four-eyes on promotion (TASK 19).
+
+Every test runs inside the FrappeTestCase transaction (rolled back), and each
+exploit is exercised through the SAME door a real attacker would use — a
+perm-checked ``doc.insert()`` / ``doc.save()`` (the generic-REST path) or the
+whitelisted endpoint — NOT ``ignore_permissions`` (which would mask the gate).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.custom_skills import build_push_payload, prefixed_slug
+
+SKILL = "Jarvis Custom Skill"
+WIKI = "Jarvis Wiki Page"
+WIKI_PROMO = "Jarvis Wiki Promotion Request"
+SKILL_PROMO = "Jarvis Skill Promotion Request"
+QUESTION = "Jarvis Personalise Question"
+
+REVIEWER = "p2-reviewer@example.com"
+USER_A = "p2-usera@example.com"
+USER_B = "p2-userb@example.com"
+PFX = "p2sec"
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+@contextlib.contextmanager
+def _engine_flag():
+	prev = frappe.flags.jarvis_pattern_engine
+	frappe.flags.jarvis_pattern_engine = True
+	try:
+		yield
+	finally:
+		frappe.flags.jarvis_pattern_engine = prev
+
+
+def _ensure_user(email: str, roles: list[str]) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc({
+			"doctype": "User", "email": email, "first_name": PFX,
+			"send_welcome_email": 0, "enabled": 1, "user_type": "System User",
+		})
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+	# Reload AFTER the db.set_value so add/remove_roles don't trip the timestamp
+	# concurrency check; each roles mutation saves, so reload between them.
+	if "System Manager" in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).remove_roles("System Manager")
+	add = [r for r in roles if r not in set(frappe.get_roles(email))]
+	if add:
+		frappe.get_doc("User", email).add_roles(*add)
+	return email
+
+
+def _sweep():
+	"""Committing cleanup: several endpoints under test call frappe.db.commit()
+	(approve/promote), so their rows survive the per-test rollback and would
+	otherwise pollute later runs (and trip the unique pattern_key). Roll back
+	uncommitted work first, then hard-delete + commit the committed residue."""
+	frappe.db.rollback()
+	for dt, filt in (
+		(SKILL, {"skill_name": ["like", f"{PFX}-%"]}),
+		(WIKI, {"slug": ["like", f"{PFX}-%"]}),
+		("Jarvis Learned Pattern", {"pattern_key": ["like", f"{PFX}-%"]}),
+	):
+		for n in frappe.get_all(dt, filters=filt, pluck="name"):
+			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+	for dt in (SKILL_PROMO, WIKI_PROMO, QUESTION):
+		frappe.db.delete(dt, {"owner": ["in", [REVIEWER, USER_A, USER_B]]})
+	frappe.db.commit()
+
+
+def _mk_skill(owner, skill_name, *, scope="User", allowed_roles=None,
+			  target_role=None, shared_with=None, enabled=1):
+	"""Mint a skill owned by ``owner`` at any scope (engine flag bypasses the
+	creation guard — that guard is proven separately)."""
+	with _as(owner), _engine_flag():
+		doc = frappe.get_doc({
+			"doctype": SKILL, "skill_name": skill_name,
+			"description": f"{skill_name} desc", "instructions": "body",
+			"scope": scope, "enabled": enabled, "user_invocable": 1,
+			"target_role": target_role,
+			"shared_with": [{"user": u} for u in (shared_with or [])],
+			"allowed_roles": [{"role": r} for r in (allowed_roles or [])],
+		})
+		doc.insert(ignore_permissions=True)
+	return doc
+
+
+class Part2Base(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		_sweep()
+		_ensure_user(REVIEWER, ["Jarvis User", "Jarvis Skill Reviewer"])
+		_ensure_user(USER_A, ["Jarvis User", "Sales User"])
+		_ensure_user(USER_B, ["Jarvis User"])
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_sweep()
+		super().tearDown()
+
+
+class TestScopeCreationGuard(Part2Base):
+	"""TASK 10: new skills default User; a non-reviewer cannot mint or widen a
+	Role/Org skill by any door."""
+
+	def test_default_scope_is_user(self):
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-default",
+				"description": "d", "instructions": "i",
+			})
+			doc.insert()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "User")
+
+	def test_non_reviewer_cannot_create_org_skill(self):
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-orgcreate",
+				"description": "d", "instructions": "i", "scope": "Org",
+			})
+			with self.assertRaises(frappe.PermissionError):
+				doc.insert()
+
+	def test_non_reviewer_cannot_flip_scope_via_save(self):
+		# The frappe.client.set_value / REST-PUT path both go through doc.save().
+		doc = _mk_skill(USER_A, f"{PFX}-flip", scope="User")
+		with _as(USER_A):
+			reloaded = frappe.get_doc(SKILL, doc.name)
+			reloaded.scope = "Org"
+			with self.assertRaises(frappe.PermissionError):
+				reloaded.save()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "User")
+
+	def test_reviewer_can_create_org_skill(self):
+		with _as(REVIEWER):
+			doc = frappe.get_doc({
+				"doctype": SKILL, "skill_name": f"{PFX}-revorg",
+				"description": "d", "instructions": "i", "scope": "Org",
+			})
+			doc.insert()
+		self.assertEqual(frappe.db.get_value(SKILL, doc.name, "scope"), "Org")
+
+	def test_tool_caps_scope_at_user(self):
+		from jarvis.tools.create_custom_skill import create_custom_skill
+
+		with _as(USER_A):
+			out = create_custom_skill(
+				f"{PFX}-toolorg", "desc", "instr", scope="Org")
+		self.assertEqual(out["scope"], "User")
+		self.assertEqual(frappe.db.get_value(SKILL, out["name"], "scope"), "User")
+
+
+class TestSkillOrmHook(Part2Base):
+	"""TASK 13: generic-REST (get_list) returns the SAME visibility set as the
+	tools/SPA — owner OR scope=Org OR scope=Role role-match OR shared."""
+
+	def test_get_list_scopes_to_visible_set(self):
+		own = _mk_skill(USER_A, f"{PFX}-own", scope="User")
+		org = _mk_skill(USER_B, f"{PFX}-org", scope="Org")
+		role = _mk_skill(USER_B, f"{PFX}-role", scope="Role", target_role="Sales User")
+		other_private = _mk_skill(USER_B, f"{PFX}-bpriv", scope="User")
+		other_role_nomatch = _mk_skill(
+			USER_B, f"{PFX}-rolex", scope="Role", target_role="Stock User")
+		shared = _mk_skill(USER_B, f"{PFX}-shared", scope="User", shared_with=[USER_A])
+
+		with _as(USER_A):
+			names = set(frappe.get_list(
+				SKILL, filters={"skill_name": ["like", f"{PFX}-%"]},
+				pluck="name", limit_page_length=0))
+		self.assertIn(own.name, names)          # own
+		self.assertIn(org.name, names)          # org = everyone
+		self.assertIn(role.name, names)         # role-match (USER_A is Sales User)
+		self.assertIn(shared.name, names)       # shared with me
+		self.assertNotIn(other_private.name, names)      # another user's private
+		self.assertNotIn(other_role_nomatch.name, names) # role I don't hold
+
+	def test_has_permission_denies_foreign_private_read(self):
+		bpriv = _mk_skill(USER_B, f"{PFX}-bpriv2", scope="User")
+		with _as(USER_A):
+			self.assertFalse(frappe.has_permission(SKILL, "read", bpriv.name))
+			# write on a foreign row is denied too (owner-only).
+			org = _mk_skill(USER_B, f"{PFX}-borg", scope="Org")
+			self.assertFalse(frappe.has_permission(SKILL, "write", org.name))
+
+
+class TestRoleRestrictedPushExclusion(Part2Base):
+	"""TASK 11: a role-restricted Org body is never written to the shared,
+	role-blind container push."""
+
+	def test_role_restricted_org_skill_excluded_from_push(self):
+		plain = _mk_skill(REVIEWER, f"{PFX}-pushplain", scope="Org")
+		restricted = _mk_skill(
+			REVIEWER, f"{PFX}-pushrestricted", scope="Org",
+			allowed_roles=["Sales User"])
+		slugs = {p["slug"] for p in build_push_payload()}
+		self.assertIn(prefixed_slug(f"{PFX}-pushplain"), slugs)
+		self.assertNotIn(prefixed_slug(f"{PFX}-pushrestricted"), slugs)
+
+
+class TestApplyGate(Part2Base):
+	"""TASK 12: a plain Jarvis User cannot trigger a bench-wide apply."""
+
+	def test_plain_user_apply_denied(self):
+		from jarvis.chat import custom_skills_api
+
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.apply_custom_skills()
+
+	def test_reviewer_apply_passes_gate(self):
+		from jarvis.chat import custom_skills_api
+
+		with patch.object(
+			custom_skills_api, "_apply_custom_skills_impl", return_value={"ok": True}
+		) as impl:
+			with _as(REVIEWER):
+				out = custom_skills_api.apply_custom_skills()
+		self.assertTrue(out["ok"])
+		impl.assert_called_once()
+
+
+class TestSkillPromotionWorkflow(Part2Base):
+	"""TASK 10 promotion workflow + TASK 19 four-eyes."""
+
+	def test_request_then_reviewer_widens_scope(self):
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-promote", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		self.assertTrue(req["ok"])
+		# Still private until a reviewer decides.
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+		with _as(REVIEWER):
+			out = custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertTrue(out["ok"])
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "Org")
+
+	def test_requester_cannot_self_approve(self):
+		from jarvis.chat import custom_skills_api
+
+		# REVIEWER owns the skill AND requests promotion, then tries to decide.
+		skill = _mk_skill(REVIEWER, f"{PFX}-selfpromote", scope="User")
+		with _as(REVIEWER):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.decide_skill_promotion(req["request"], 1)
+		self.assertEqual(frappe.db.get_value(SKILL, skill.name, "scope"), "User")
+
+	def test_non_reviewer_cannot_decide(self):
+		from jarvis.chat import custom_skills_api
+
+		skill = _mk_skill(USER_A, f"{PFX}-nodecide", scope="User")
+		with _as(USER_A):
+			req = custom_skills_api.request_skill_promotion(skill.name, "Org")
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				custom_skills_api.decide_skill_promotion(req["request"], 1)
+
+
+class TestWikiPromotionRequestLeak(Part2Base):
+	"""TASK 14: a generic-REST insert of a promotion request pointing at another
+	user's private wiki page must not snapshot that page's body."""
+
+	def _mk_private_page(self, owner, slug, body):
+		with _as(owner):
+			doc = frappe.get_doc({
+				"doctype": WIKI, "slug": slug, "title": slug,
+				"page_type": "Process", "scope": "User", "target_user": owner,
+				"body_md": body, "status": "Active",
+			})
+			doc.insert(ignore_permissions=True)
+		return doc
+
+	def _promo(self, page):
+		return frappe.get_doc({
+			"doctype": WIKI_PROMO, "page": page,
+			"from_scope": "User", "to_scope": "Org", "status": "Pending",
+		})
+
+	def test_foreign_private_page_snapshot_blocked_via_rest(self):
+		# Generic-REST insert (no ignore_permissions): the dropped `All: create`
+		# grant denies it outright.
+		victim_page = self._mk_private_page(
+			USER_B, f"{PFX}-secret", "TOP SECRET personal note")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				self._promo(victim_page.name).insert()
+
+	def test_foreign_private_page_snapshot_blocked_even_under_ignore_perms(self):
+		# Defense in depth: even a create-perm-bypassing server path is blocked by
+		# the before_insert read guard, so the victim's body is never snapshotted.
+		victim_page = self._mk_private_page(
+			USER_B, f"{PFX}-secret2", "TOP SECRET personal note")
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				self._promo(victim_page.name).insert(ignore_permissions=True)
+
+	def test_owner_can_still_snapshot_own_page(self):
+		# The legit endpoint path inserts with ignore_permissions; the guard must
+		# not over-block the owner reading their own page.
+		mine = self._mk_private_page(USER_A, f"{PFX}-mine", "my own note body")
+		with _as(USER_A):
+			req = self._promo(mine.name)
+			req.insert(ignore_permissions=True)
+		self.assertEqual(req.body_snapshot, "my own note body")
+
+
+class TestPersonaliseQuestionHook(Part2Base):
+	"""TASK 17: generic-REST list of personalise questions is scoped on the
+	`user` field, surviving owner/user drift."""
+
+	def _mk_question(self, user, owner=None):
+		doc = frappe.get_doc({
+			"doctype": QUESTION, "user": user,
+			"question": f"{PFX} question for {user}", "origin": "From your organisation",
+			"status": "Unanswered",
+		})
+		doc.insert(ignore_permissions=True)
+		if owner and owner != doc.owner:
+			frappe.db.set_value(QUESTION, doc.name, "owner", owner, update_modified=False)
+		return doc
+
+	def test_list_scoped_on_user_not_owner(self):
+		mine = self._mk_question(USER_A)
+		theirs = self._mk_question(USER_B)
+		# Drift: a row whose `user` is B but `owner` was flipped to A must NOT
+		# leak to A (the hook keys on `user`).
+		drift = self._mk_question(USER_B, owner=USER_A)
+		with _as(USER_A):
+			names = set(frappe.get_list(
+				QUESTION, filters={"question": ["like", f"{PFX}%"]},
+				pluck="name", limit_page_length=0))
+		self.assertIn(mine.name, names)
+		self.assertNotIn(theirs.name, names)
+		self.assertNotIn(drift.name, names)
+
+
+class TestPersonaliseOriginProvenance(Part2Base):
+	"""TASK 16: a personalise-origin pattern carries a scrub warning to the
+	reviewer on the board + the promote action."""
+
+	def _mk_pattern(self, key, personalise_origin):
+		with _engine_flag():
+			doc = frappe.get_doc({
+				"doctype": "Jarvis Learned Pattern", "pattern_key": key,
+				"detector_id": "voice_facts", "domain": "selling",
+				"pattern_statement": f"{PFX} rule statement",
+				"skill_draft": "- do the thing", "status": "Proposed",
+				"strength_band": "High", "sensitivity": "A",
+				"effective_sensitivity": "A", "surfaced": 1,
+				"personalise_origin": 1 if personalise_origin else 0,
+			})
+			doc.insert(ignore_permissions=True)
+		return doc
+
+	def test_board_row_carries_scrub_warning(self):
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-po-key", personalise_origin=True)
+		with _as(REVIEWER):
+			res = learned_api.list_learned_patterns_page(
+				status="Proposed", search=f"{PFX}")
+		row = next(r for r in res["rows"] if r["name"] == p.name)
+		self.assertEqual(row["personalise_origin"], 1)
+		self.assertTrue(row["scrub_warning"])
+
+	def test_approve_returns_scrub_warning_for_personalise_origin(self):
+		# Run as Administrator: approving writes the SM-only JLP (the reviewer
+		# save-perm mechanics are orthogonal to this provenance check).
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-po-appr", personalise_origin=True)
+		with _as("Administrator"):
+			out = learned_api.approve_learned_pattern(p.name)
+		self.assertIn("scrub_warning", out)
+
+	def test_no_warning_for_non_personalise_pattern(self):
+		from jarvis.chat import learned_api
+
+		p = self._mk_pattern(f"{PFX}-nopo", personalise_origin=False)
+		with _as("Administrator"):
+			out = learned_api.approve_learned_pattern(p.name)
+		self.assertNotIn("scrub_warning", out)

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -46,6 +46,20 @@ def _as(user: str):
 		frappe.set_user(orig)
 
 
+@contextlib.contextmanager
+def _engine_flag():
+	"""Bypass the scope-creation guard (security review PART 2 TASK 10) for a
+	fixture that needs a pre-existing Role/Org skill owned by a NON-reviewer —
+	the creation guard itself is covered by TestCreateCustomSkill; these tests
+	exercise the VISIBILITY of already-scoped rows."""
+	prev = frappe.flags.jarvis_pattern_engine
+	frappe.flags.jarvis_pattern_engine = True
+	try:
+		yield
+	finally:
+		frappe.flags.jarvis_pattern_engine = prev
+
+
 def _ensure_system_user(email: str) -> str:
 	"""A non-SM System User (realistic tool caller)."""
 	if not frappe.db.exists("User", email):
@@ -87,8 +101,9 @@ def _make_skill(owner: str, skill_name: str, description: str, *,
 				scope: str = "Org", shared_with=None, allowed_roles=None,
 				enabled: int = 1):
 	"""Insert a row through the real doctype as ``owner`` (child tables can't
-	be passed through the tool)."""
-	with _as(owner):
+	be passed through the tool). The engine flag lets the fixture mint a
+	Role/Org row directly (the reviewer-gated creation path is tested elsewhere)."""
+	with _as(owner), _engine_flag():
 		doc = frappe.get_doc({
 			"doctype": SKILL,
 			"skill_name": skill_name,
@@ -100,7 +115,7 @@ def _make_skill(owner: str, skill_name: str, description: str, *,
 			"shared_with": [{"user": u} for u in (shared_with or [])],
 			"allowed_roles": [{"role": r} for r in (allowed_roles or [])],
 		})
-		doc.insert()
+		doc.insert(ignore_permissions=True)
 	return doc
 
 
@@ -142,7 +157,9 @@ class TestFindSkills(SkillToolsTestCase):
 			mine = find_skills("marker alpha")
 			self.assertEqual(
 				[s["skill_name"] for s in mine["skills"]], [f"{PFX}-priv-alpha"])
-			self.assertEqual(mine["skills"][0]["scope"], "Personal")
+			# The tool now creates private (User-scope) skills — the ladder's
+			# rename of "Personal" (security review PART 2 TASK 10).
+			self.assertEqual(mine["skills"][0]["scope"], "User")
 		with _as(PEER):
 			theirs = find_skills("marker alpha")
 			self.assertEqual(theirs["count"], 0)
@@ -213,7 +230,7 @@ class TestGetSkill(SkillToolsTestCase):
 				out = get_skill(query_name)
 				self.assertEqual(out["skill_name"], f"{PFX}-fetch-me")
 				self.assertEqual(out["instructions"], "fetch body")
-				self.assertEqual(out["scope"], "Personal")
+				self.assertEqual(out["scope"], "User")
 				self.assertEqual(out["enabled"], 1)
 
 	def test_unknown_skill_is_invalid_argument(self):
@@ -250,55 +267,41 @@ class TestGetSkill(SkillToolsTestCase):
 
 
 class TestCreateCustomSkill(SkillToolsTestCase):
-	def test_creates_personal_by_default_with_note(self):
+	def test_creates_private_by_default_with_note(self):
 		with _as(OWNER):
 			out = create_custom_skill(
 				f"{PFX}-mk-default", "sttool mk desc", "mk body")
-		self.assertEqual(out["scope"], "Personal")
+		self.assertEqual(out["scope"], "User")
 		self.assertEqual(out["skill_name"], f"{PFX}-mk-default")
 		self.assertIn("note", out)
 		row = frappe.db.get_value(
 			SKILL, out["name"], ["owner", "scope", "enabled"], as_dict=True)
 		self.assertEqual(row.owner, OWNER)
-		self.assertEqual(row.scope, "Personal")
+		self.assertEqual(row.scope, "User")
 		self.assertEqual(int(row.enabled), 1)
 
-	def test_org_scope_note_mentions_apply(self):
+	def test_org_scope_request_is_capped_to_user(self):
+		# Security review PART 2 TASK 10: the tool no longer mints a bench-wide
+		# (Org) skill in one agent call. A scope="Org" request is honored as a
+		# PRIVATE skill and the note explains promotion is reviewer-gated.
 		with _as(OWNER):
 			out = create_custom_skill(
 				f"{PFX}-mk-org", "sttool mk org desc", "mk org body", scope="Org")
-		self.assertEqual(out["scope"], "Org")
-		self.assertIn("Apply", out["note"])
+		self.assertEqual(out["scope"], "User")
+		self.assertIn("reviewer", out["note"].lower())
+		# The capped skill is private: a peer cannot see it via find_skills.
+		with _as(PEER):
+			found = find_skills("mk org desc")
+			self.assertNotIn(
+				f"{PFX}-mk-org", [s["skill_name"] for s in found["skills"]])
 
-	def test_org_scope_note_matches_actual_find_skills_visibility(self):
-		# F19: the note used to say Org skills "reach the assistant's skill
-		# catalog only after an admin clicks Apply" - factually false, since
-		# find_skills/get_skill already surface an Org row to every user right
-		# away (see TestFindSkills.test_org_row_visible_to_everyone below).
-		# There is no per-row 'applied'/'reviewed' flag anywhere in the
-		# doctype or the Apply flow (chat/custom_skills.py build_push_payload)
-		# to gate that discovery path on, so the note is corrected instead of
-		# inventing a gate. Lock the corrected wording + matching behavior
-		# together so they can't silently drift apart again.
+	def test_unknown_scope_is_capped_not_rejected(self):
+		# The scope arg is advisory (always capped to User), so an unrecognized
+		# value is not an error — it just yields a private skill.
 		with _as(OWNER):
 			out = create_custom_skill(
-				f"{PFX}-mk-org-note", "sttool mk org note desc", "mk org note body",
-				scope="Org",
-			)
-		note = out["note"]
-		self.assertIn("right away", note)
-		self.assertIn("jarvis__find_skills", note)
-		self.assertNotIn("only after an admin clicks Apply", note)
-
-		with _as(PEER):
-			found = find_skills("mk org note desc")
-			self.assertIn(f"{PFX}-mk-org-note", [s["skill_name"] for s in found["skills"]])
-
-	def test_invalid_scope_rejected(self):
-		with _as(OWNER):
-			with self.assertRaises(InvalidArgumentError):
-				create_custom_skill(
-					f"{PFX}-mk-badscope", "d", "i", scope="Team")
+				f"{PFX}-mk-badscope", "d", "i", scope="Team")
+		self.assertEqual(out["scope"], "User")
 
 	def test_slug_and_cap_violations_surface_as_jarvis_errors(self):
 		with _as(OWNER):
@@ -384,7 +387,7 @@ class TestRegistryAndClassification(SkillToolsTestCase):
 				"description": "sttool registry marker",
 				"instructions": "registry body",
 			})
-			self.assertEqual(created["scope"], "Personal")
+			self.assertEqual(created["scope"], "User")
 
 			found = dispatch("find_skills", {"query": "registry marker", "limit": 5})
 			self.assertEqual(

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -99,7 +99,7 @@ def _sweep_fixture_skills():
 
 def _make_skill(owner: str, skill_name: str, description: str, *,
 				scope: str = "Org", shared_with=None, allowed_roles=None,
-				enabled: int = 1):
+				target_role=None, enabled: int = 1):
 	"""Insert a row through the real doctype as ``owner`` (child tables can't
 	be passed through the tool). The engine flag lets the fixture mint a
 	Role/Org row directly (the reviewer-gated creation path is tested elsewhere)."""
@@ -110,6 +110,7 @@ def _make_skill(owner: str, skill_name: str, description: str, *,
 			"description": description,
 			"instructions": f"instructions for {skill_name}",
 			"scope": scope,
+			"target_role": target_role,
 			"enabled": enabled,
 			"user_invocable": 1,
 			"shared_with": [{"user": u} for u in (shared_with or [])],
@@ -256,6 +257,33 @@ class TestGetSkill(SkillToolsTestCase):
 		with _as(PEER):
 			with self.assertRaises(PermissionDeniedError):
 				get_skill(f"{PFX}-role-only")
+
+	def test_role_scope_visible_to_target_role_holder(self):
+		# TASK 13 fix C: a scope=Role skill whose target_role the caller holds is
+		# findable + fetchable through the tools (the tool SELECTs must carry
+		# target_role, else the whole User->Role promotion tier is dead). PEER
+		# holds "Sales User".
+		_make_skill(
+			OWNER, f"{PFX}-role-tier", "sttool role tier steps",
+			scope="Role", target_role="Sales User",
+		)
+		with _as(PEER):
+			names = [s["skill_name"] for s in find_skills("role tier")["skills"]]
+			self.assertIn(f"{PFX}-role-tier", names)
+			got = get_skill(f"{PFX}-role-tier")
+			self.assertEqual(got["scope"], "Role")
+			self.assertEqual(got["instructions"], f"instructions for {PFX}-role-tier")
+
+	def test_role_scope_denied_to_non_target_role_holder(self):
+		# A Role skill targeting a role the caller does NOT hold is invisible.
+		_make_skill(
+			OWNER, f"{PFX}-role-tier-x", "sttool role tier x steps",
+			scope="Role", target_role="Accounts Manager",
+		)
+		with _as(PEER):  # PEER holds Sales User, not Accounts Manager
+			self.assertEqual(find_skills("role tier x")["count"], 0)
+			with self.assertRaises(PermissionDeniedError):
+				get_skill(f"{PFX}-role-tier-x")
 
 	def test_own_row_preferred_over_same_named_foreign_row(self):
 		# skill_name is unique per owner, not globally.

--- a/jarvis/tests/test_v3_list_extensions.py
+++ b/jarvis/tests/test_v3_list_extensions.py
@@ -42,13 +42,22 @@ def _ensure_user(email: str) -> str:
 			"doctype": "User", "email": email,
 			"first_name": email.split("@")[0],
 			"send_welcome_email": 0, "enabled": 1,
+			"user_type": "System User",
 		})
 		u.flags.ignore_permissions = True
 		u.insert()
 		frappe.db.commit()
-	roles = set(frappe.get_roles(email))
-	if "System Manager" in roles:
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+		frappe.db.commit()
+	if "System Manager" in set(frappe.get_roles(email)):
 		frappe.get_doc("User", email).remove_roles("System Manager")
+		frappe.db.commit()
+	# The Jarvis User role is what the @require_jarvis_user endpoint decorators
+	# require (security review PART 1 TASK 8); a realistic non-SM Jarvis caller
+	# holds it.
+	if "Jarvis User" not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles("Jarvis User")
 		frappe.db.commit()
 	return email
 
@@ -124,6 +133,11 @@ class TestSkillsBulkDelete(unittest.TestCase):
 		frappe.set_user("Administrator")
 		_ensure_user(USER_A)
 		_ensure_user(USER_B)
+		# USER_A owns + deletes the fixture skills; the bulk-delete reconcile is
+		# now reviewer-gated (security review PART 2 TASK 12), so give USER_A the
+		# reviewer role to exercise the (deduped) apply path.
+		if "Jarvis Skill Reviewer" not in set(frappe.get_roles(USER_A)):
+			frappe.get_doc("User", USER_A).add_roles("Jarvis Skill Reviewer")
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -133,12 +147,13 @@ class TestSkillsBulkDelete(unittest.TestCase):
 		self.b_shared = _mk_skill(USER_B, "v3-skill-b-shared", shared_with=[USER_A])
 		self.b_priv = _mk_skill(USER_B, "v3-skill-b-priv")
 		# Stub the apply pipeline (it talks to the admin service) and count calls.
+		# delete_custom_skills_bulk calls the undecorated _apply_custom_skills_impl.
 		self.apply_calls = []
-		self._orig_apply = custom_skills_api.apply_custom_skills
-		custom_skills_api.apply_custom_skills = lambda: self.apply_calls.append(1)
+		self._orig_apply = custom_skills_api._apply_custom_skills_impl
+		custom_skills_api._apply_custom_skills_impl = lambda: self.apply_calls.append(1)
 
 	def tearDown(self):
-		custom_skills_api.apply_custom_skills = self._orig_apply
+		custom_skills_api._apply_custom_skills_impl = self._orig_apply
 		frappe.set_user("Administrator")
 		_wipe()
 

--- a/jarvis/tools/create_custom_skill.py
+++ b/jarvis/tools/create_custom_skill.py
@@ -1,13 +1,15 @@
 """Save a new skill (Jarvis Custom Skill row) from chat.
 
 The agent captures a procedure the user just walked it through and saves it
-as a skill owned by the session user. Defaults to scope=Personal (private,
-never pushed to the shared container catalog). scope=Org rows are visible to
-other users immediately via jarvis__find_skills/jarvis__get_skill (subject
-to allowed_roles/shared_with — see user_can_use_skill); they only join the
-/slug-invocable CONTAINER catalog after an admin clicks Apply on the Skills
-page. This tool NEVER triggers a push/apply itself — Apply restarts the
-container and stays a deliberate human action.
+as a skill owned by the session user. The skill is ALWAYS created private
+(scope=User): a bench-wide (Org) or role-shared (Role) skill can only be minted
+by a reviewer through the promotion workflow, never by the agent in one call
+(security review PART 2 TASK 10 — this tool used to accept scope="Org"
+directly, letting the agent mint a bench-wide skill with no reviewer gate). A
+private skill is reached via jarvis__find_skills / jarvis__get_skill and is
+never pushed to the shared container catalog. This tool NEVER triggers a
+push/apply itself — Apply restarts the container and stays a deliberate human
+action.
 
 Confirmation-gated in jarvis/api.py (_GATED_WRITES): the model path parks
 the call behind a human confirm card.
@@ -20,25 +22,27 @@ from jarvis.exceptions import InvalidArgumentError
 from jarvis.tools.find_skills import _require_system_user
 
 SKILL = "Jarvis Custom Skill"
-_SCOPES = ("Org", "Personal")
 
 
 def create_custom_skill(
     skill_name: str,
     description: str,
     instructions: str,
-    scope: str = "Personal",
+    scope: str = "User",
     user_invocable: int = 1,
 ) -> dict:
-    """Insert a skill row as the session user; the DocType controller enforces
-    the slug grammar, length caps, per-owner uniqueness/cap and the reserved
-    ``custom-``/``learned-`` prefixes. Returns ``{name, skill_name, scope,
-    note}``."""
+    """Insert a PRIVATE (User-scope) skill row as the session user; the DocType
+    controller enforces the slug grammar, length caps, per-owner uniqueness/cap,
+    the reserved ``custom-``/``learned-`` prefixes and the scope guard. The
+    ``scope`` argument is capped at User — a request for Role/Org is honored as a
+    private skill (promotion is reviewer-gated). Returns ``{name, skill_name,
+    scope, note}``."""
     _require_system_user()
 
-    scope = (scope or "Personal").strip().capitalize()
-    if scope not in _SCOPES:
-        raise InvalidArgumentError("scope must be 'Org' or 'Personal'")
+    # Cap at User regardless of what the model asked for: widening is
+    # reviewer-only (the controller would reject a non-reviewer's Role/Org
+    # create anyway; capping here keeps the agent path from 403-ing on itself).
+    requested = (scope or "User").strip().capitalize()
 
     ui = user_invocable
     if isinstance(ui, str):
@@ -50,7 +54,7 @@ def create_custom_skill(
             "skill_name": skill_name,
             "description": description,
             "instructions": instructions,
-            "scope": scope,
+            "scope": "User",
             "user_invocable": 1 if ui else 0,
             "enabled": 1,
         }
@@ -63,22 +67,19 @@ def create_custom_skill(
         # classify them identically.
         raise InvalidArgumentError(str(e) or type(e).__name__)
 
-    if scope == "Org":
-        note = (
-            "Saved. Org-scope skills are discoverable and usable by other users "
-            "right away via jarvis__find_skills / jarvis__get_skill (subject to "
-            "allowed_roles/shared_with); they only join the /slug-invocable "
-            "container catalog after an admin clicks Apply on the Skills page."
-        )
-    else:
-        note = (
-            "Saved as a personal skill: private to its owner and never pushed "
-            "to the shared catalog; recall it with jarvis__find_skills / "
-            "jarvis__get_skill."
+    note = (
+        "Saved as a private skill: only you can use it and it is never pushed "
+        "to the shared catalog; recall it with jarvis__find_skills / "
+        "jarvis__get_skill."
+    )
+    if requested in ("Org", "Role"):
+        note += (
+            " Making it visible to your role or the whole org needs a reviewer "
+            "to approve a promotion request."
         )
     return {
         "name": doc.name,
         "skill_name": doc.skill_name,
-        "scope": doc.scope or "Org",
+        "scope": doc.scope or "User",
         "note": note,
     }

--- a/jarvis/tools/find_skills.py
+++ b/jarvis/tools/find_skills.py
@@ -63,7 +63,11 @@ def find_skills(query: str, limit: int = 10) -> dict:
     limit = max(1, min(limit, _MAX_LIMIT))
 
     rows = frappe.db.sql(
-        """SELECT name, owner, skill_name, description, scope, managed_by_learning
+        # target_role is REQUIRED for user_can_use_skill to admit a Role-scope
+        # skill's role-holder (security review PART 2 TASK 13); omitting it made
+        # the whole User->Role promotion tier dead through this tool.
+        """SELECT name, owner, skill_name, description, scope, target_role,
+               managed_by_learning
         FROM `tabJarvis Custom Skill`
         WHERE enabled = 1 AND (skill_name LIKE %(q)s OR description LIKE %(q)s)
         ORDER BY skill_name ASC, name ASC

--- a/jarvis/tools/find_skills.py
+++ b/jarvis/tools/find_skills.py
@@ -39,8 +39,10 @@ def _visible(row, user: str, user_roles: list[str]) -> bool:
         user_can_use_skill,
     )
 
-    if (row.get("scope") or "Org") == "Personal" and (row.get("owner") or "") != user:
-        return False
+    # Single visibility rule shared with the ORM hook + SPA (security review
+    # PART 2 TASK 13): owner OR shared OR scope=Org (unless role-narrowed) OR
+    # scope=Role role-match. User-scope rows are owner-only inside the helper, so
+    # the old "Personal is owner-only" special case is subsumed.
     return user_can_use_skill(row, user, user_roles)
 
 

--- a/jarvis/tools/get_skill.py
+++ b/jarvis/tools/get_skill.py
@@ -35,7 +35,9 @@ def get_skill(skill_name: str) -> dict:
         filters={"skill_name": ["in", sorted(candidates)]},
         fields=[
             "name", "owner", "skill_name", "description", "instructions",
-            "scope", "enabled", "user_invocable",
+            # target_role is REQUIRED for user_can_use_skill to admit a Role-scope
+            # skill's role-holder (security review PART 2 TASK 13).
+            "scope", "target_role", "enabled", "user_invocable",
         ],
     )
     if not rows:


### PR DESCRIPTION
## Security review — Part 2 (Skills / Personalise / Wiki / Review / Analysis)

Builds the true `{User, Role, Org}` scope ladder for custom skills and closes the Part-2 leak/escalation surface, following strict Frappe standards (ORM `permission_query_conditions` + `has_permission` hooks + controller guards, so the generic REST surface is safe on its own — modeled on `wiki_permissions.py`).

> **Stacks on #284 (Part 1).** Base is `security/part1-chat-permissions`; merge that first. Constraints honored: **no leaks, no unauthorized access, no UX break, balance.**

### What landed (TASKs 10–19)
- **TASK 10/13 — scope ladder + ORM hook (the big build):** `Jarvis Custom Skill` gains `scope {User,Role,Org}` (default **User**) + `target_role`; perms `All`→`Jarvis User`+`System Manager`; new `chat/skill_permissions.py` (`skill_query_conditions`/`has_skill_permission`, every value `frappe.db.escape`d); `user_can_use_skill` is now the single visibility rule all read paths share; `_guard_new_scope`/`_guard_scope_change` block non-reviewer widening (even under `ignore_permissions`); new `Jarvis Skill Promotion Request` doctype + `request_skill_promotion`/`decide_skill_promotion` (reviewer-gated, TOCTOU `for_update`, four-eyes); tool `create_custom_skill` capped at User; migration `v1_12_skill_scope_ladder`.
- **TASK 11 — leak:** role-restricted Org bodies excluded from the shared container push (`build_push_payload`).
- **TASK 12:** `apply_custom_skills` reviewer-gated (bench-wide push/restart is not a per-user action).
- **TASK 14 — leak:** `Jarvis Wiki Promotion Request.before_insert` asserts read access to the source page before snapshotting; `All:create` dropped.
- **TASK 16:** `personalise_origin` provenance + `scrub_warning` on the reviewer surfaces.
- **TASK 17:** `Jarvis Personalise Question` ORM scoping keyed on the `user` field (survives owner/user drift).
- **TASK 19:** four-eyes (`reviewer != requester`) on both wiki and skill promotion.
- **TASK 15/18:** no-ops (reviewer set ratified; TASK 18 was absorbed by Part-1 TASK 21).

### Two-reviewer verification — no leaks
Independently reviewed by a Sonnet agent **and** by me, each reproducing exploits live (throwaway users, rolled back):
- Non-reviewer cannot create **or** re-scope a skill to Role/Org (blocked at the controller, even on their own rows, even under `ignore_permissions`); a reviewer can.
- Read-scoping is airtight through **every** surface — `get_list`/`/api/resource` (ORM hook), `has_permission`, and the `find_skills`/`get_skill` tools: a private User skill and a role-narrowed Org skill are hidden from non-members; the scope SQL was injection-tested with a hostile `attacker' OR '1'='1` username (correctly escaped).
- The wiki-promotion snapshot leak is dead, including under `ignore_permissions`; the owner path still works.
- Personalise owner/user drift does not leak.

### Remediation round (fixes found in verification, commit `67e18e2`)
The first review pass surfaced real **UX** regressions (fails-closed, not leaks) and stale tests, all fixed:
- **HIGH** — frontend called `applyCustomSkills()` on every save, but TASK 12 gated that to reviewers → every ordinary user got a permission-error toast. `SkillDetail.vue` now gates apply on a reviewer caps signal.
- **HIGH** — the new **Role** tier was dead through the agent's `find_skills`/`get_skill` tools (they didn't select `target_role`). Fixed + allow-case tests added.
- **MEDIUM** — added a reviewer-gated `list_skill_promotion_requests` so pending requests are discoverable.
- **LOW** — clear denial message on skill write-deny; `_guard_scope_change` now allows owner self-*narrowing* (widening still reviewer-gated).
- **Test fixtures** — 17 stale tests in `test_v3_list_extensions`/`test_confirm_gate`/`learning.test_compiler` (missing the Jarvis User role / assuming the old Org default) fixed.

### Testing
- Security-relevant modules all green on `patterntest.localhost`: `test_part2_security` (23), `test_skill_tools` (29), `test_custom_skill_visibility` (13), `test_custom_skills_push` (9), `test_v3_list_extensions` (19), `test_confirm_gate` (31), `learning.test_compiler` (24), `test_insight_skill_update` (25), plus the Part-1 suite.
- **Frontend `vite build` passes** (the `.vue` change compiles).
- Full-suite run triaged: the only remaining failures are **environmental** (`test_tier2b_hrms_frappe_reads` — `hrms` app not installed here; `test_realtime_handlers` — gevent/socketio), one pre-existing cross-module sort flake, and two **test-isolation** weaknesses (`test_macro_merge` per-owner cap, `test_turn_recovery` DB-wide count) that pass on a clean DB and are unrelated to this change.

### Design note (follows the ratified "default User" decision — no action needed)
New custom skills are now **private-first (User scope)** and are **not auto-pushed to the container**; they're reached via the `find_skills`/`get_skill` tools. Existing skills were migrated to Org, so they keep auto-loading. Deferred frontend follow-ups (not blockers): a scope picker / role-skill surfacing in the SPA and a promotion-request UI; the backend is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
