### PR TITLE
fix(knowledge-graph): hide analytics and detail tabs

### DIFF
--- a/frontend/src/pages/wiki/KnowledgeGraph.vue
+++ b/frontend/src/pages/wiki/KnowledgeGraph.vue
@@ -1,5 +1,13 @@
 <template>
 	<div class="kg flex h-full flex-col overflow-hidden">
+		<LayoutHeader>
+			<template #left-header>
+				<Breadcrumbs :items="breadcrumbs" />
+			</template>
+			<template #right-header>
+				<Button icon="refresh-cw" :tooltip="'Refresh'" :loading="!state.loaded" @click="load" />
+			</template>
+		</LayoutHeader>
 		<div class="kg-head">
 			<h5>Knowledge Graph</h5>
 			<span v-if="state.loaded && pageCount" class="text-muted">{{ pageCount }} pages · {{ linkCount }} links</span>
@@ -29,9 +37,9 @@
 			</div>
 			<div class="kg-side">
 				<DetailPanel :node="state.selected" :metrics="state.analysis.metrics"
-					:communities="state.analysis.communities" @focus="(id) => (state.focus = id)" />
+					:communities="state.analysis.communities" :show-actions="false" @focus="(id) => (state.focus = id)" />
 				<AnalysisTabs :analysis="state.analysis" :nodes="baseData.nodes" :actions="state.actions"
-					:history="state.history" :can-act="true" @pick="pickId" @add-link="onAddLink" />
+					:history="state.history" :can-act="false" :show-priority="false" :show-actions-tab="false" @pick="pickId" />
 			</div>
 		</div>
 
@@ -45,11 +53,18 @@
 // four analysis tabs. Productive loop: accept a suggested connection → add_wiki_link
 // (durable, out-of-body) → refetch → the edge appears.
 import { reactive, computed, watch, onMounted } from "vue"
+import { Breadcrumbs, Button } from "frappe-ui"
+import LayoutHeader from "@/components/LayoutHeader.vue"
 import {
 	Graph3D, FilterBar, DetailPanel, AnalysisTabs, ExclusionRules,
 	runAnalysis, computeActions, overlayFilter, egoGraph, searchGraph,
 } from "wiki-graph-core"
-import { getWikiGraph, addWikiLink, getWikiGraphHistory } from "@/api/wiki"
+import { getWikiGraph, getWikiGraphHistory } from "@/api/wiki"
+
+// Same breadcrumb + persistent "Open ERPNext Desk" top bar the other Skills
+// tabs get; LayoutHeader supplies the ⧉ button, so the graph tab no longer
+// needs its own inline one.
+const breadcrumbs = [{ label: "Skills", route: { name: "SkillsList" } }, { label: "Knowledge Graph" }]
 
 const PAGE_TYPES = ["Customer", "Supplier", "Item", "Process", "Doctype", "Exception", "Integration", "People", "Org"]
 
@@ -128,21 +143,6 @@ function pickId(id) {
 	const n = (state.data.nodes || []).find((x) => x.id === id)
 	if (n) state.selected = n
 }
-async function onAddLink(s) {
-	const a = String(s.a || "").replace(/^page:/, "")
-	const b = String(s.b || "").replace(/^page:/, "")
-	if (!a || !b) return
-	state.toast = `Linking ${s.aLabel} ↔ ${s.bLabel}…`
-	try {
-		await addWikiLink(a, b)
-		state.toast = "Link added ✓"
-		await load()
-	} catch (e) {
-		state.toast = (e && e.message) ? `Couldn't add link: ${e.message}` : "Couldn't add link"
-	}
-	setTimeout(() => { state.toast = "" }, 2000)
-}
-
 watch(() => state.excluded, recompute)
 onMounted(load)
 </script>
@@ -150,7 +150,11 @@ onMounted(load)
 <style scoped>
 .kg { padding: 4px 2px; }
 .kg-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px; }
-.kg-layout { display: grid; grid-template-columns: 1fr 340px; gap: 16px; }
+.kg-layout { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; }
+/* min-width:0 lets the graph column shrink to its track — without it the
+   3d-force-graph canvas (an explicit-pixel-width element) forces the column
+   wider than the viewport and shoves the side panel off-screen. */
+.kg-main { min-width: 0; }
 .kg-side { display: flex; flex-direction: column; gap: 14px; overflow-y: auto; }
 .kg-tools { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 6px; }
 .kg-excl { margin-bottom: 8px; }
@@ -163,5 +167,8 @@ onMounted(load)
 .kg-skel { height: 60vh; border-radius: 8px; background: var(--control-bg, #f3f4f6); animation: kg-pulse 1.4s ease-in-out infinite; }
 @keyframes kg-pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 0.9; } }
 .kg-toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background: #222; color: #fff; padding: 8px 16px; border-radius: 8px; font-size: 13px; z-index: 50; }
-@media (max-width: 1100px) { .kg-layout { grid-template-columns: 1fr; } }
+/* Only stack (panel below the graph) on genuinely narrow screens. The old
+   1100px breakpoint hid the analysis panel off-screen on ordinary
+   retina-scaled laptop widths — it read as "the panel is missing". */
+@media (max-width: 760px) { .kg-layout { grid-template-columns: 1fr; } }
 </style>

--- a/wiki-graph-core/src/AnalysisTabs.vue
+++ b/wiki-graph-core/src/AnalysisTabs.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="wg-tabs">
 		<!-- Priority review cards -->
-		<div class="wg-prio">
+		<div class="wg-prio" v-if="showPriority">
 			<div class="wg-card"><span class="wg-card-n">{{ hubName }}</span><span class="wg-card-l">top hub</span></div>
 			<div class="wg-card"><span class="wg-card-n">{{ brokerName }}</span><span class="wg-card-l">key bridge</span></div>
 			<div class="wg-card" :class="{ warn: staleN }"><span class="wg-card-n">{{ staleN }}</span><span class="wg-card-l">to fix</span></div>
@@ -18,7 +18,7 @@
 			<SuggestPanel v-else-if="tab === 'similar'" :lists="analysis.lists" :communities="analysis.communities"
 				:can-add-link="canAct" @pick="$emit('pick', $event)" @add-link="$emit('add-link', $event)" />
 			<EvolutionTab v-else-if="tab === 'evolution'" :nodes="nodes" :history="history" />
-			<ActionsTab v-else :actions="actions" :can-act="canAct"
+			<ActionsTab v-else-if="tab === 'actions'" :actions="actions" :can-act="canAct"
 				@pick="$emit('pick', $event)" @add-link="$emit('add-link', $event)" />
 		</div>
 	</div>
@@ -42,18 +42,25 @@ export default {
 		actions: { type: Object, default: () => ({ stale: [], orphans: [], busFactor: [], duplicates: [], suggest: [] }) },
 		history: { type: Array, default: () => [] },
 		canAct: { type: Boolean, default: false },
+		// Priority-card strip (top hub / bridge / to-fix / orphans). On for the
+		// operator graph; the tenant graph turns it off for a cleaner surface.
+		showPriority: { type: Boolean, default: true },
+		// Actions tab (operator curation surface). Off for the tenant graph.
+		showActionsTab: { type: Boolean, default: true },
 	},
 	emits: ["pick", "add-link"],
 	data() {
-		return {
-			tab: "structure",
-			TABS: [
-				{ v: "structure", label: "Structure" }, { v: "similar", label: "Similar" },
-				{ v: "evolution", label: "Evolution" }, { v: "actions", label: "Actions" },
-			],
-		};
+		return { tab: "structure" };
 	},
 	computed: {
+		TABS() {
+			const t = [
+				{ v: "structure", label: "Structure" }, { v: "similar", label: "Similar" },
+				{ v: "evolution", label: "Evolution" },
+			];
+			if (this.showActionsTab) t.push({ v: "actions", label: "Actions" });
+			return t;
+		},
 		lists() { return this.analysis.lists || {}; },
 		hubName() { return (this.lists.hubs && this.lists.hubs[0] && (this.lists.hubs[0].label || this.lists.hubs[0].slug)) || "—"; },
 		brokerName() { return (this.lists.brokers && this.lists.brokers[0] && (this.lists.brokers[0].label || this.lists.brokers[0].slug)) || "—"; },

--- a/wiki-graph-core/src/DetailPanel.vue
+++ b/wiki-graph-core/src/DetailPanel.vue
@@ -17,7 +17,7 @@
 			<tr v-if="node.debt"><td>Knowledge debt</td><td class="warn">hot + stale</td></tr>
 			<tr v-if="m.orphan"><td>Orphan</td><td class="warn">no links</td></tr>
 		</table>
-		<div class="wg-actions" v-if="node.kind === 'page'">
+		<div class="wg-actions" v-if="showActions && node.kind === 'page'">
 			<button class="wg-act" @click="$emit('focus', node.id)">Focus</button>
 			<button class="wg-act" v-if="siteUrl" @click="openPage">Open page ↗</button>
 			<button class="wg-act" @click="copySlug">Copy slug</button>
@@ -34,6 +34,9 @@ export default {
 		metrics: { type: Object, default: () => ({}) },
 		communities: { type: Object, default: () => ({}) },
 		siteUrl: { type: String, default: null },
+		// Focus / Copy slug / Open page actions. On for the operator graph; the
+		// tenant graph turns them off for a read-only detail view.
+		showActions: { type: Boolean, default: true },
 	},
 	emits: ["focus"],
 	computed: {


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [ ] Branch is **up to date with `main`** (so it is tested against the latest code)
- [ ] New/changed behavior has tests (the coverage gate still passes)
- [ ] I self-reviewed the diff
