### PR TITLE
fix(tests): repair the red CI suite, and the voice-note search bug it was hiding

### DIFF
--- a/jarvis/chat/voice_notes_api.py
+++ b/jarvis/chat/voice_notes_api.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType, Order
 
 NOTE = "Jarvis Voice Note"
 CONV = "Jarvis Conversation"
@@ -187,13 +188,33 @@ def list_my_voice_notes_page(
 		filters["transcript"] = ["like", f"%{_lk(search)}%"]
 
 	total = frappe.db.count(NOTE, filters)
-	rows = frappe.get_all(
-		NOTE,
-		filters=filters,
-		fields=["name", "transcript", "context_type", "status", "creation", "conversation"],
-		order_by="creation desc, name asc",
-		limit_start=start,
-		limit_page_length=pl,
+
+	# Rows go through the SAME query builder as the count above, and not
+	# frappe.get_all, because the two disagree about an escaped LIKE pattern.
+	# get_all's DatabaseQuery runs the value through db.escape, which doubles the
+	# backslash: the `\%` that _lk emits to mean "a literal percent sign" reaches
+	# SQL as `\\%` — a literal BACKSLASH followed by anything — so it matches
+	# nothing. db.count (query builder) escapes it correctly and matches.
+	# The result was a search for a term containing % or _ reporting "1 result"
+	# while returning an empty list. There is no pattern that satisfies both
+	# paths (doubling it by hand only breaks the count too), so the rows query is
+	# expressed in the builder that gets it right.
+	t = DocType(NOTE)
+	q = (
+		frappe.qb.from_(t)
+		.select(t.name, t.transcript, t.context_type, t.status, t.creation, t.conversation)
+		.where(t.owner == frappe.session.user)
+	)
+	if status:
+		q = q.where(t.status == status)
+	if search:
+		q = q.where(t.transcript.like(f"%{_lk(search)}%"))
+	rows = (
+		q.orderby(t.creation, order=Order.desc)
+		.orderby(t.name, order=Order.asc)
+		.limit(pl)
+		.offset(start)
+		.run(as_dict=True)
 	)
 	for r in rows:
 		r["excerpt"] = (r.get("transcript") or "")[:_EXCERPT_LEN]

--- a/jarvis/tests/test_personalise_api.py
+++ b/jarvis/tests/test_personalise_api.py
@@ -928,7 +928,14 @@ class TestListRoleOptions(PersonaliseApiTestCase):
 		self.assertNotIn("All", roles)
 		# System Manager is an enabled desk role, so it IS offered.
 		self.assertIn("System Manager", roles)
-		self.assertEqual(roles, sorted(roles))
+		# Sorted the way the endpoint sorts: `ORDER BY name asc` under MariaDB's
+		# case-insensitive collation, which is NOT Python's case-sensitive order.
+		# With roles named both "Jarvis …" and "JPL …" present (the full suite
+		# creates both), the DB yields Jarvis→JPL while a bare sorted() demands
+		# JPL→Jarvis, because every uppercase letter sorts before any lowercase
+		# one. Compare case-insensitively so this asserts the endpoint's real
+		# contract rather than an ASCII accident.
+		self.assertEqual(roles, sorted(roles, key=str.lower))
 
 	def test_disabled_role_is_excluded(self):
 		role_name = "Persapi Disabled Role"

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -21,7 +21,7 @@ from jarvis.chat.custom_skills import (
 	prefixed_slug,
 )
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.permissions import JARVIS_USER_ROLE
+from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
 from jarvis.tools.create_custom_skill import create_custom_skill
 from jarvis.tools.find_skills import find_skills
 from jarvis.tools.get_skill import get_skill
@@ -70,6 +70,7 @@ def _ensure_system_user(email: str) -> str:
 	non-owner/peer scoping assertions — so without the role they are refused
 	before reaching the logic under test.
 	"""
+	ensure_jarvis_user_role()
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,

--- a/jarvis/tests/test_skill_tools.py
+++ b/jarvis/tests/test_skill_tools.py
@@ -21,6 +21,7 @@ from jarvis.chat.custom_skills import (
 	prefixed_slug,
 )
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.permissions import JARVIS_USER_ROLE
 from jarvis.tools.create_custom_skill import create_custom_skill
 from jarvis.tools.find_skills import find_skills
 from jarvis.tools.get_skill import get_skill
@@ -61,18 +62,28 @@ def _engine_flag():
 
 
 def _ensure_system_user(email: str) -> str:
-	"""A non-SM System User (realistic tool caller)."""
+	"""A non-SM System User (realistic tool caller).
+
+	Carries the Jarvis User role: since the chat permission hardening (#284) the
+	skill tools gate on System Manager or Jarvis User, and these fixtures are
+	deliberately NOT System Managers — that is the whole point of the
+	non-owner/peer scoping assertions — so without the role they are refused
+	before reaching the logic under test.
+	"""
 	if not frappe.db.exists("User", email):
 		u = frappe.get_doc({
 			"doctype": "User", "email": email,
 			"first_name": "sttool", "send_welcome_email": 0, "enabled": 1,
 			"user_type": "System User",
-			"roles": [{"role": "Sales User"}],
+			"roles": [{"role": "Sales User"}, {"role": JARVIS_USER_ROLE}],
 		})
 		u.flags.ignore_permissions = True
 		u.insert(ignore_permissions=True)
 	elif frappe.db.get_value("User", email, "user_type") != "System User":
 		frappe.db.set_value("User", email, "user_type", "System User")
+	if JARVIS_USER_ROLE not in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).add_roles(JARVIS_USER_ROLE)
+		frappe.clear_cache(user=email)
 	if "System Manager" in set(frappe.get_roles(email)):
 		frappe.get_doc("User", email).remove_roles("System Manager")
 	return email

--- a/jarvis/tests/test_voice_facts.py
+++ b/jarvis/tests/test_voice_facts.py
@@ -22,6 +22,7 @@ from frappe.utils import cint
 
 from jarvis.chat import voice_notes_api
 from jarvis.learning import voice_facts
+from jarvis.permissions import JARVIS_USER_ROLE
 
 NOTE = "Jarvis Voice Note"
 JLP = "Jarvis Learned Pattern"
@@ -60,10 +61,17 @@ def _ensure_user(email: str, roles: tuple = ()) -> str:
 		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
 		frappe.clear_cache(user=email)
 		user = frappe.get_doc("User", email)
+	# Jarvis access is a ROLE now (chat permission hardening, #284): the voice
+	# endpoints gate on System Manager or Jarvis User. Every fixture user here is
+	# meant to be able to REACH Jarvis — what varies is whether they're an admin —
+	# so all of them get Jarvis User, and the System-Manager-only distinction that
+	# these tests turn on is preserved by the roles argument below.
+	user.add_roles(JARVIS_USER_ROLE)
 	if roles:
 		user.add_roles(*roles)
 	elif "System Manager" in frappe.get_roles(email):
 		user.remove_roles("System Manager")
+	frappe.clear_cache(user=email)
 	frappe.db.commit()
 	return email
 
@@ -76,6 +84,22 @@ def _as(user: str):
 		yield
 	finally:
 		frappe.set_user(orig)
+
+
+@contextlib.contextmanager
+def _enforcing_permissions():
+	"""Make ``frappe.only_for`` actually enforce.
+
+	``only_for`` returns early when ``frappe.flags.in_test`` is set, so a
+	role-gate built on it is a no-op for the whole suite — asserting against it
+	without clearing the flag tests nothing. Scoped to the single call under
+	test; the flag is restored afterwards."""
+	prev = frappe.flags.in_test
+	frappe.flags.in_test = False
+	try:
+		yield
+	finally:
+		frappe.flags.in_test = prev
 
 
 @contextlib.contextmanager
@@ -539,7 +563,13 @@ class TestVoiceNotesApi(VoiceFactsTestCase):
 		self.assertGreaterEqual(st_sm["org_new_notes"], 1)
 
 	def test_process_now_is_sm_gated_and_dedupes(self):
-		with _as(USER_A), self.assertRaises(frappe.PermissionError):
+		# The gate is frappe.only_for("System Manager"), which SHORT-CIRCUITS when
+		# frappe.flags.in_test is set — so under a plain test run it enforces
+		# nothing. This assertion used to pass only because the fixture user was
+		# role-less and blew up earlier for an unrelated reason; now that USER_A is
+		# a proper (non-admin) Jarvis user, the flag has to come off for the test
+		# to exercise the gate at all.
+		with _as(USER_A), _enforcing_permissions(), self.assertRaises(frappe.PermissionError):
 			voice_notes_api.process_voice_notes_now()
 
 		with _as(USER_SM):

--- a/jarvis/tests/test_voice_facts.py
+++ b/jarvis/tests/test_voice_facts.py
@@ -22,7 +22,7 @@ from frappe.utils import cint
 
 from jarvis.chat import voice_notes_api
 from jarvis.learning import voice_facts
-from jarvis.permissions import JARVIS_USER_ROLE
+from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
 
 NOTE = "Jarvis Voice Note"
 JLP = "Jarvis Learned Pattern"
@@ -66,6 +66,7 @@ def _ensure_user(email: str, roles: tuple = ()) -> str:
 	# meant to be able to REACH Jarvis — what varies is whether they're an admin —
 	# so all of them get Jarvis User, and the System-Manager-only distinction that
 	# these tests turn on is preserved by the roles argument below.
+	ensure_jarvis_user_role()
 	user.add_roles(JARVIS_USER_ROLE)
 	if roles:
 		user.add_roles(*roles)

--- a/jarvis/tests/test_voice_notes_crud.py
+++ b/jarvis/tests/test_voice_notes_crud.py
@@ -16,7 +16,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import voice_notes_api
-from jarvis.permissions import JARVIS_USER_ROLE
+from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
 
 NOTE = "Jarvis Voice Note"
 
@@ -53,6 +53,7 @@ def _ensure_user(email: str) -> str:
 	# ordinary, non-admin Jarvis users — which is exactly the Jarvis User role — so
 	# grant it rather than escalating them to System Manager, whose broad
 	# permissions would hide the owner-scoping these tests exist to prove.
+	ensure_jarvis_user_role()
 	if JARVIS_USER_ROLE not in frappe.get_roles(email):
 		frappe.get_doc("User", email).add_roles(JARVIS_USER_ROLE)
 		frappe.clear_cache(user=email)

--- a/jarvis/tests/test_voice_notes_crud.py
+++ b/jarvis/tests/test_voice_notes_crud.py
@@ -16,6 +16,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import voice_notes_api
+from jarvis.permissions import JARVIS_USER_ROLE
 
 NOTE = "Jarvis Voice Note"
 
@@ -45,6 +46,15 @@ def _ensure_user(email: str) -> str:
 	# User on the very first run — not just a stale fixture from an earlier run.
 	if frappe.db.get_value("User", email, "user_type") != "System User":
 		frappe.db.set_value("User", email, "user_type", "System User", update_modified=False)
+		frappe.clear_cache(user=email)
+	# Jarvis access is a ROLE now (chat permission hardening, #284): the voice
+	# endpoints gate on System Manager or Jarvis User, so a role-less fixture is
+	# rejected before it reaches the logic under test. These users are meant to be
+	# ordinary, non-admin Jarvis users — which is exactly the Jarvis User role — so
+	# grant it rather than escalating them to System Manager, whose broad
+	# permissions would hide the owner-scoping these tests exist to prove.
+	if JARVIS_USER_ROLE not in frappe.get_roles(email):
+		frappe.get_doc("User", email).add_roles(JARVIS_USER_ROLE)
 		frappe.clear_cache(user=email)
 	frappe.db.commit()
 	return email


### PR DESCRIPTION
`main` has been failing CI (`failures=1, errors=25`). This fixes it — and one of the failures turned out to be hiding a **real bug**.

## 1. Role-less fixtures vs the new access gate (25 errors)

The chat permission hardening (#284) made Jarvis access a **role**: the voice, skill and personalise endpoints now require `System Manager` or `Jarvis User`. But the fixtures in `test_voice_notes_crud` / `test_voice_facts` / `test_skill_tools` deliberately build *role-less* System Users, so every call from them was refused before it ever reached the logic under test.

Fixed by granting those fixtures the **`Jarvis User`** role — deliberately *not* `System Manager`, which would have been the lazy fix. These users are non-admins on purpose; that is exactly what the owner-scoping and peer-visibility assertions depend on.

## 2. A gate that was never actually being tested

`test_process_now_is_sm_gated_and_dedupes` asserted a `PermissionError` from `frappe.only_for("System Manager")` — but **`only_for` returns early when `frappe.flags.in_test` is set**, so it enforces nothing under test. The assertion had been passing only because the role-less fixture blew up earlier for an unrelated reason. It now clears the flag for the duration of that one call, so the SM gate is exercised for real.

## 3. A real search bug the permission errors were masking

With the fixtures fixed, `test_search_escapes_like_wildcards` failed on `total=1` but `rows=[]`. That is a **live bug**, not a test artifact.

`list_my_voice_notes_page` built one filter dict and fed it to *both* `frappe.db.count` and `frappe.get_all` — and the two disagree about an escaped LIKE pattern. `get_all`'s `DatabaseQuery` runs the value through `db.escape`, which doubles the backslash, so the `\%` that `_lk` emits to mean *"a literal percent sign"* reaches SQL as `\\%` — a literal **backslash** followed by anything — and matches nothing. `db.count` (query builder) escapes it correctly.

**User-visible effect:** searching the notes pane for any term containing `%` or `_` reported *"1 result"* and rendered an empty list.

Verified directly against the DB with the pattern `%100\%%`:

| path | rows |
|---|---|
| `frappe.db.count` | 1 ✅ |
| `frappe.get_all` | 0 ❌ |
| query builder | 1 ✅ |

No pattern satisfies both paths (hand-doubling the backslash breaks the count too), so the rows query now goes through the **same query builder as the count** — they can no longer disagree.

Also fixes `test_returns_sorted_desk_roles_without_builtins`, which compared the endpoint's `ORDER BY name asc` (MariaDB, **case-insensitive** collation) against a case-**sensitive** Python `sorted()`. Once the suite creates roles named both `Jarvis …` and `JPL …`, the DB yields `Jarvis→JPL` while `sorted()` demands `JPL→Jarvis` (every uppercase letter sorts before any lowercase one). Now compared case-insensitively, against the endpoint's real contract.

## Verification

- `test_skill_tools`, `test_voice_notes_crud`, `test_voice_facts`: **failing → OK**
- the sort fix is verified against the actual 62-role list from CI's own log (old assertion `False`, new `True`)
- `test_personalise_api`'s other 5 local failures were confirmed **pre-existing** — they fail identically on a clean `main` and pass in CI, so they are environment-specific and left alone rather than "fixed" blind

🤖 Generated with [Claude Code](https://claude.com/claude-code)