### PR TITLE
Security review Part 3: File Box/attachments, macros, approvals, comment-tagging, agents

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -104,6 +104,10 @@ jobs:
             --admin-password admin
           bench --site test_site install-app erpnext hrms jarvis
           bench --site test_site set-config allow_tests true
+          # Full suite creates far more than Frappe's default 60-users/60-min limit
+          # (throttle_user_creation); raise it so no mid-suite fixture insert hits
+          # "Throttled". -p stores an INT (a string limit breaks the count>limit compare).
+          bench --site test_site set-config -p throttle_user_limit 100000
 
       - name: Run tests + coverage
         working-directory: frappe-bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,12 @@ jobs:
             --source-sql /opt/ci/test_site.sql
           bench --site test_site install-app jarvis
           bench --site test_site set-config allow_tests true
+          # The full suite creates far more than Frappe's default 60-users/60-min
+          # limit (throttle_user_creation), so a mid-suite fixture insert otherwise
+          # hits "Throttled" (flaky, depends on which module crosses the threshold).
+          # -p stores an INT: throttle_user_creation compares count > limit, and a
+          # string limit raises "TypeError: '>' not supported between int and str".
+          bench --site test_site set-config -p throttle_user_limit 100000
 
       - name: Assert the restored site is what we think it is
         working-directory: /opt/frappe-bench

--- a/frontend/src/api/agents.js
+++ b/frontend/src/api/agents.js
@@ -17,6 +17,13 @@ export const getAgent = (agent_slug) =>
 // fetchFn that maps its ({search, filters, sort_field, ...}) call onto these.
 const AG = "jarvis.chat.agents_api."
 
+// PART 3 remediation — lightweight capability probe. `review` (skill-reviewer
+// set: Jarvis Skill Reviewer | Jarvis Admin | System Manager) is what
+// apply_agents() actually requires, so it drives the Apply-catalog button —
+// decoupled from the SM-only get_agent_admin_overview cross-owner admin data.
+// -> { review: 0|1, admin: 0|1 }
+export const getAgentsCaps = () => call(AG + "get_agents_caps")
+
 // tab: featured|available|installed · sort: installs|updated|name
 export const listAgentsPage = (p = {}) =>
 	call(AG + "list_agents_page", {

--- a/frontend/src/pages/agents/AgentsList.vue
+++ b/frontend/src/pages/agents/AgentsList.vue
@@ -5,9 +5,11 @@
 				<Breadcrumbs :items="[{ label: 'Agents', route: { name: 'AgentsList' } }]" />
 			</template>
 			<template #right-header>
-				<!-- SM-only apply pipeline: prominent while the catalog is dirty,
-				     SyncPill-style pending/failed states while an apply runs -->
-				<div v-if="isSM" class="flex items-center gap-2">
+				<!-- Reviewer/SM apply pipeline: prominent while the catalog is dirty,
+				     SyncPill-style pending/failed states while an apply runs.
+				     Gated on the skill-reviewer capability (what apply_agents needs),
+				     NOT the SM-only cross-owner admin overview. -->
+				<div v-if="canApply" class="flex items-center gap-2">
 					<!-- duration lives IN the badge text - tooltips are invisible to
 					     keyboard/SR users -->
 					<Badge v-if="sync.pending" theme="orange" variant="subtle">
@@ -37,7 +39,7 @@
 		<!-- persistent apply-failure banner: the reason must survive the toast and
 		     be reachable without hovering a badge (keyboard/SR access) -->
 		<div
-			v-if="isSM && syncFailed && !sync.pending"
+			v-if="canApply && syncFailed && !sync.pending"
 			class="mx-5 mt-3 flex shrink-0 items-start gap-2 rounded-lg border border-outline-red-1 bg-surface-red-1 px-3 py-2 text-sm text-ink-red-4"
 		>
 			<FeatherIcon name="x-circle" class="mt-0.5 size-4 shrink-0" />
@@ -220,10 +222,12 @@
 //     (Most installed / Recently updated / Name). No ratings - deliberately
 //     deferred.
 //   Activity - the owner's lifecycle feed (AgentActivityTab, self-contained).
-// SM header action: prominent "Apply catalog changes" driven by
+// Reviewer/SM header action: prominent "Apply catalog changes" driven by
 // get_agents_sync_status().dirty (install/uninstall/enable since the last
 // successful Apply), with SyncPill-style pending/failed polling, plus a
-// route-leave + beforeunload guard while dirty.
+// route-leave + beforeunload guard while dirty. Gated on the skill-reviewer
+// capability (get_agents_caps().review) since apply_agents needs the reviewer
+// set, not System Manager.
 import { reactive, ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router"
 import {
@@ -407,17 +411,23 @@ function installsLabel(n) {
 	return `${c} install${c === 1 ? "" : "s"}`
 }
 
-// ── SM probe (round-2 parity): getAgentAdminOverview succeeds only for System
-// Managers - PermissionError hides the apply action, no noise. ────────────────
-const isSM = ref(false)
-async function probeAdmin() {
+// ── Reviewer capability probe (PART 3 remediation): apply_agents needs the
+// skill-reviewer set (Jarvis Skill Reviewer | Jarvis Admin | System Manager),
+// NOT System Manager. get_agents_caps().review drives the Apply button so a
+// reviewer-only System User (no SM) can see and use it; a plain Jarvis User
+// gets review=false and no button. Decoupled from the SM-only cross-owner
+// getAgentAdminOverview data. ─────────────────────────────────────────────────
+const canApply = ref(false)
+async function probeCaps() {
 	try {
-		await api.getAgentAdminOverview()
-		isSM.value = true
-		await loadSyncStatus()
-		if (sync.pending) startSyncPoll()
+		const caps = (await agentsApi.getAgentsCaps()) || {}
+		canApply.value = !!caps.review
+		if (canApply.value) {
+			await loadSyncStatus()
+			if (sync.pending) startSyncPoll()
+		}
 	} catch (e) {
-		isSM.value = false
+		canApply.value = false
 	}
 }
 
@@ -473,12 +483,12 @@ async function applyCatalog() {
 	}
 }
 
-// ── leave-guard: SM + dirty (unapplied catalog changes) ──────────────────────
+// ── leave-guard: can-apply + dirty (unapplied catalog changes) ───────────────
 const leaveDialog = reactive({ show: false, next: null })
 
 onBeforeRouteLeave((to, from, next) => {
 	// drilling into /agents/:slug stays inside the agents area - don't nag
-	if (!isSM.value || !sync.dirty || String(to.path || "").startsWith("/agents")) return next()
+	if (!canApply.value || !sync.dirty || String(to.path || "").startsWith("/agents")) return next()
 	leaveDialog.next = next
 	leaveDialog.show = true
 })
@@ -498,14 +508,14 @@ async function applyAndLeave() {
 
 // hard reloads / tab close while dirty → native browser prompt
 function onBeforeUnload(e) {
-	if (isSM.value && sync.dirty) {
+	if (canApply.value && sync.dirty) {
 		e.preventDefault()
 		e.returnValue = "" // Chrome requires returnValue to show the prompt
 	}
 }
 
 onMounted(() => {
-	probeAdmin()
+	probeCaps()
 	loadCategories()
 	window.addEventListener("beforeunload", onBeforeUnload)
 })

--- a/jarvis/chat/agent_permissions.py
+++ b/jarvis/chat/agent_permissions.py
@@ -1,0 +1,106 @@
+"""Row-level ownership scoping for the Jarvis agent doctypes (security review
+PART 3, TASK 29).
+
+The data-layer twin of ``jarvis/chat/chat_permissions.py`` for the four
+owner/installer-scoped agent doctypes:
+
+  * Jarvis Agent Installation -> the row's own ``owner`` (the installer).
+  * Jarvis Agent Run          -> the row's own ``owner``.
+  * Jarvis Agent Finding      -> the row's own ``owner``.
+  * Jarvis Agent Activity     -> the row's own ``owner``.
+
+Runs / findings / activity are inserted server-side (``ignore_permissions``) by
+the audit engine and then handed to the installation owner via a raw
+``db.set_value(..., "owner", owner)`` reassignment (``agent_runs.py`` /
+``agent_scheduler.py``), so the row's own ``owner`` is always the installer — a
+reliable single axis. Findings/runs can carry sensitive audit output, so this
+keeps them owner-or-SM scoped even over generic REST.
+
+The catalog doctype ``Jarvis Agent Listing`` is deliberately NOT scoped here: it
+is a shared vendor catalog readable by every Jarvis User (its perm row stays
+read-for-all). Its proprietary ``skill_bundle`` field is protected by a
+permlevel-1 grant (TASK 33) instead of an owner hook.
+
+System Manager (and Administrator) get org-wide READ (oversight; the existing SM
+perm rows are the base grant). ``Administrator`` bypasses Frappe perms entirely.
+
+Every interpolated value goes through ``frappe.db.escape``.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+ACTIVITY = "Jarvis Agent Activity"
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def _owner_query(table: str, user: str | None) -> str:
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tab{table}`.`owner` = {frappe.db.escape(user)}"
+
+
+def _owner_has_permission(doc, ptype: str, user: str | None) -> bool:
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	if ptype == "create":
+		# ``owner`` is assigned by Frappe / reassigned to the installer by the
+		# engine; the role + ``if_owner`` rule governs create.
+		return True
+	return doc.get("owner") == user
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Agent Installation
+# --------------------------------------------------------------------------- #
+def installation_query_conditions(user: str | None = None) -> str:
+	return _owner_query(INSTALLATION, user)
+
+
+def has_installation_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	return _owner_has_permission(doc, ptype, user)
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Agent Run
+# --------------------------------------------------------------------------- #
+def run_query_conditions(user: str | None = None) -> str:
+	return _owner_query(RUN, user)
+
+
+def has_run_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	return _owner_has_permission(doc, ptype, user)
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Agent Finding
+# --------------------------------------------------------------------------- #
+def finding_query_conditions(user: str | None = None) -> str:
+	return _owner_query(FINDING, user)
+
+
+def has_finding_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	return _owner_has_permission(doc, ptype, user)
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Agent Activity
+# --------------------------------------------------------------------------- #
+def activity_query_conditions(user: str | None = None) -> str:
+	return _owner_query(ACTIVITY, user)
+
+
+def has_activity_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	return _owner_has_permission(doc, ptype, user)

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -1020,6 +1020,25 @@ def get_agents_sync_status() -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
+def get_agents_caps() -> dict:
+	"""Lightweight capability probe for the Agents SPA (PART 3 remediation).
+
+	``review`` is the skill-reviewer set (Jarvis Skill Reviewer / Jarvis Admin /
+	System Manager) — exactly what ``apply_agents`` requires — so it drives the
+	Apply-catalog button's visibility, decoupled from the SM-only cross-owner
+	``get_agent_admin_overview``. ``admin`` stays the System-Manager gate for the
+	admin-only roles editor / cross-owner data. Any Jarvis User may call this and
+	simply gets ``{review: False, admin: False}`` (no button)."""
+	from jarvis.permissions import is_skill_reviewer
+
+	return {
+		"review": bool(is_skill_reviewer()),
+		"admin": "System Manager" in frappe.get_roles(frappe.session.user),
+	}
+
+
+@frappe.whitelist()
 def apply_agents() -> dict:
 	"""Push all ENABLED installed agent bundles to the container (one restart).
 	Explicit action. Builds the payload synchronously (surfaces size/cap errors

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -251,7 +251,10 @@ def get_agent(agent_slug: str) -> dict:
 		"tools_required": listing.tools_required,
 		"min_apps": listing.min_apps,
 		"rule_pack": listing.rule_pack,
-		"skill_bundle": listing.skill_bundle,
+		# skill_bundle deliberately omitted (PART 3 TASK 33): it is proprietary
+		# vendor IP (the full agent SKILL.md rule-pack) and is now permlevel-1
+		# (SM-only). A normal Jarvis User's detail page never needs it; SM / the
+		# engine read it via generic REST / get_doc.
 		"default_schedule": listing.default_schedule,
 		"validated_for_fy": listing.validated_for_fy,
 		"allowed_roles": [row.role for row in (listing.allowed_roles or [])],
@@ -818,8 +821,14 @@ def list_findings(
 
 	filters = {"owner": me}
 	if run:
-		run_row = frappe.db.get_value(RUN, run, ["agent", "creation", "status"], as_dict=True)
-		if not run_row or run_row.status not in ("completed", "partial"):
+		# TASK 32 (AGENTS-4): fetch owner alongside and gate it — this raw
+		# get_value bypasses perms, so without the owner check a foreign run id is
+		# an existence/metadata oracle. A run the caller does not own returns empty
+		# (identical to an unknown run), never leaking that it exists.
+		run_row = frappe.db.get_value(RUN, run, ["agent", "creation", "status", "owner"], as_dict=True)
+		if not run_row or run_row.owner != me:
+			return _empty()
+		if run_row.status not in ("completed", "partial"):
 			# unknown / failed / still-running runs recorded no findings snapshot
 			# (findings_count is 0 there too — the drill-down must match).
 			return _empty()
@@ -1011,12 +1020,23 @@ def get_agents_sync_status() -> dict:
 
 
 @frappe.whitelist()
-@require_jarvis_user
 def apply_agents() -> dict:
 	"""Push all ENABLED installed agent bundles to the container (one restart).
 	Explicit action. Builds the payload synchronously (surfaces size/cap errors
 	immediately), marks pending, then enqueues the deduped redis-locked worker —
-	mirrors ``custom_skills_api.apply_custom_skills``."""
+	mirrors ``custom_skills_api.apply_custom_skills``.
+
+	Reviewer/admin-gated (security review PART 3 TASK 30): a bench-wide push
+	reconciles + RESTARTS the shared container for EVERY user and builds a payload
+	of EVERY owner's enabled agent bundles, so a plain Jarvis User (which every
+	backfilled user holds) must not be able to trigger it (DoS). Gated with the
+	skill-reviewer set (Jarvis Skill Reviewer / Jarvis Admin / System Manager),
+	mirroring ``apply_custom_skills`` — deliberately NOT stacked under
+	@require_jarvis_user, since a reviewer/admin may hold neither Jarvis User nor
+	System Manager."""
+	from jarvis.permissions import require_skill_reviewer
+
+	require_skill_reviewer()
 	_rate_limit_apply()
 	payload = build_agent_push_payload()
 	frappe.db.set_single_value(_SETTINGS, "agent_skills_sync_status", "pending: applying agents")

--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -339,6 +339,7 @@ def _awaiting_reply(me: str) -> list[dict]:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_approval(name: str) -> dict:
 	"""One approval with every field the detail page renders (DESIGN-V3 §8.3).
 
@@ -404,6 +405,7 @@ def pending_count() -> int:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def decide(name: str, decision: str, approve: int = 1) -> dict:
 	"""Record the decision and resume the linked conversation.
 
@@ -519,6 +521,7 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def dismiss_approval(name: str) -> dict:
 	"""Clear a Pending request off the board WITHOUT acting on it — no
 	verdict, no chat resume. For requests the user simply doesn't want to
@@ -548,6 +551,7 @@ def dismiss_approval(name: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def restore_approval(name: str) -> dict:
 	"""Put a Dismissed request back on the board (Pending). The undo for an
 	accidental dismiss."""

--- a/jarvis/chat/docmeta_api.py
+++ b/jarvis/chat/docmeta_api.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import json
 
 import frappe
-from jarvis.permissions import require_jarvis_user
+from jarvis.permissions import has_jarvis_access, require_jarvis_user
 from frappe import _
 from frappe.desk.form import assign_to as _assign_to
 from frappe.share import add_docshare
@@ -217,12 +217,19 @@ def _open_todo_exists(doctype: str, name: str, user: str) -> bool:
 
 
 def _validate_target_user(user: str) -> str:
-	"""Assign/share target must be a real, enabled, non-Guest user."""
+	"""Assign/share target must be a real, enabled, non-Guest user WHO CAN REACH
+	JARVIS. TASK 27 (TAG-01): a share/assign grants a DocShare-read that Part-1's
+	approval scoping honors as visibility, so the target must be confined to the
+	Jarvis population — otherwise a Website/portal (or any non-Jarvis) user could
+	be handed visibility into a Jarvis Approval Request / Macro / Agent
+	Installation they must never reach."""
 	user = (user or "").strip()
 	if not user or user == "Guest":
 		frappe.throw(_("Invalid user."))
 	if not frappe.db.get_value("User", user, "enabled"):
 		frappe.throw(_("Invalid user."))
+	if not has_jarvis_access(user):
+		frappe.throw(_("You can only share or assign to Jarvis users."))
 	return user
 
 
@@ -258,6 +265,28 @@ def get_docmeta(doctype: str, name: str) -> dict:
 # --------------------------------------------------------------------------- #
 # comments (direct inserts/updates AFTER the gate — §14 DA-03)
 # --------------------------------------------------------------------------- #
+def _strip_mention_spans(content: str) -> str:
+	"""TASK 28 (TAG-02): neutralize @mention markup before insert.
+	``Comment.after_insert`` -> ``notify_mentions`` emails/notifies every
+	``class="mention"`` target of the comment (and thus the doc's title). On these
+	Jarvis boards a DocShare-tagged NON-owner could otherwise forge a mention and
+	leak a sensitive approval title ("SECRET payroll approve $840k") to an
+	arbitrary third party. Access to these docs is granted via ``toggle_share``,
+	never via @mention, so mention-NOTIFY is not a needed feature here — unwrap
+	each mention element to its plain text so the comment still reads naturally
+	(e.g. "@Carol") but triggers no notification."""
+	if not content or "mention" not in content:
+		return content
+	from bs4 import BeautifulSoup
+
+	soup = BeautifulSoup(content, "html.parser")
+	changed = False
+	for el in soup.find_all(class_="mention"):
+		el.unwrap()
+		changed = True
+	return str(soup) if changed else content
+
+
 @frappe.whitelist()
 @require_jarvis_user
 def add_comment(doctype: str, name: str, content: str) -> dict:
@@ -270,6 +299,7 @@ def add_comment(doctype: str, name: str, content: str) -> dict:
 	content = (content or "").strip()
 	if not content:
 		frappe.throw(_("Comment is empty."))
+	content = _strip_mention_spans(content)
 	comment = frappe.get_doc({
 		"doctype": "Comment",
 		"comment_type": "Comment",

--- a/jarvis/chat/file_permissions.py
+++ b/jarvis/chat/file_permissions.py
@@ -1,0 +1,56 @@
+"""List-surface scoping for the GLOBAL ``File`` doctype (security review PART 3,
+TASK 22).
+
+``File`` is a Frappe core doctype used app-wide (avatars, print formats, every
+doctype's attachments). Core already registers a permissive
+``permission_query_conditions["File"]`` that, for a desk (System User) role,
+admits any file whose ``attached_to_doctype`` is a doctype the caller can read.
+The ``Jarvis User`` role grants read on ``Jarvis Conversation`` (the doctype),
+so that clause admits EVERY user's inbound-doc File rows — leaking filenames,
+``content_hash`` (an existence oracle), owner and the private ``file_url`` (the
+bytes stay protected by core's per-doc ``File.has_permission`` deferral, but the
+metadata leaks).
+
+Frappe **ANDs** every registered ``permission_query_conditions`` hook for a
+doctype, so this Jarvis fragment MUST be permissive for non-Jarvis files: it
+only restricts rows attached to ``Jarvis Conversation`` and lets everything else
+through. A conversation-attached File is visible when the caller owns the File
+itself OR owns the linked conversation; all other files (``attached_to_doctype``
+!= Jarvis Conversation, including NULL / other doctypes / public files) pass this
+fragment unconditionally and are then subject only to core's own condition.
+
+We register ONLY ``permission_query_conditions["File"]`` — deliberately NO
+``has_permission["File"]`` hook: core's ``File.has_permission`` defers an
+attached file's read to ``ref_doc.has_permission("read")`` (i.e. Part-1's
+conversation gate), which already denies cross-user BYTE download; a second
+Jarvis hook could only break that correct per-doc deferral.
+
+Every interpolated value goes through ``frappe.db.escape``.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+CONVERSATION = "Jarvis Conversation"
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def file_query_conditions(user: str | None = None) -> str:
+	"""Restrict ONLY Jarvis-Conversation-attached File rows to ones the caller
+	owns (the File, or the linked conversation); every other File passes. Empty
+	(no restriction) for System Manager / Administrator. Returned as a single
+	parenthesized boolean expression that Frappe ANDs with core's File condition."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	esc = frappe.db.escape(user)
+	return (
+		"(ifnull(`tabFile`.`attached_to_doctype`, '') != 'Jarvis Conversation' "
+		f"or `tabFile`.`owner` = {esc} "
+		"or exists (select 1 from `tabJarvis Conversation` c "
+		f"where c.name = `tabFile`.`attached_to_name` and c.owner = {esc}))"
+	)

--- a/jarvis/chat/macro_permissions.py
+++ b/jarvis/chat/macro_permissions.py
@@ -1,0 +1,102 @@
+"""Row-level ownership scoping for the Jarvis macro doctypes (Jarvis Macro,
+Jarvis Macro Run) — security review PART 3, TASK 23/24.
+
+The data-layer twin of ``jarvis/chat/chat_permissions.py``: list / report /
+generic-REST queries are scoped via ``permission_query_conditions`` and per-doc
+read/write/create/delete via ``has_permission`` — both registered in
+``hooks.py``. Together with putting the ``Jarvis User`` role (not ``role:
+"All"``) on the doctype permission rows, this makes the role genuinely
+load-bearing (a Website/portal user, categorically denied Jarvis, can no longer
+``POST /api/resource/Jarvis Macro`` and have the scheduler run it) and closes
+the Macro-Run create-inject at the ORM.
+
+Ownership axes:
+
+  * Jarvis Macro     -> the row's own ``owner`` (the creator). Matches the
+    ``if_owner`` perm rule that also stays on the doctype.
+  * Jarvis Macro Run -> the row's own ``owner`` too. A run is inserted server
+    side (``macros.run_macro`` with ``ignore_permissions``) and its owner is
+    reassigned to the MACRO's owner by construction (``macros.py``: the
+    ``_reassign_owner`` handoff), so scoping by the run's own owner is exactly
+    the macro-owner axis. On CREATE (the only path a generic-REST insert can
+    reach — legit runs bypass this hook via ``ignore_permissions``) the hook
+    additionally rejects a run whose linked ``macro`` (or ``conversation``, if
+    set) is not owned by the caller (MAC-2 cross-inject guard).
+
+System Manager gets org-wide READ (oversight; the SM perm rows added to both
+doctypes are read-only, mirroring ``Jarvis Voice Note``). ``Administrator``
+bypasses Frappe perms entirely; every function guards for it via ``_is_sm``.
+
+Every interpolated value in a SQL fragment goes through ``frappe.db.escape``.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+MACRO = "Jarvis Macro"
+MACRO_RUN = "Jarvis Macro Run"
+CONVERSATION = "Jarvis Conversation"
+
+
+def _is_sm(user: str) -> bool:
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Macro - the row's own owner is the axis (matches ``if_owner``).
+# --------------------------------------------------------------------------- #
+def macro_query_conditions(user: str | None = None) -> str:
+	"""Scope every list/report/REST query on Jarvis Macro to the caller's own
+	rows. System Manager (and Administrator) get org-wide READ (oversight)."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tab{MACRO}`.`owner` = {frappe.db.escape(user)}"
+
+
+def has_macro_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	if ptype == "create":
+		# ``owner`` is assigned by Frappe during insert (creator == owner); the
+		# role + ``if_owner`` rule governs create. Enforcing owner here would race
+		# the owner assignment.
+		return True
+	return doc.get("owner") == user
+
+
+# --------------------------------------------------------------------------- #
+# Jarvis Macro Run - the row's own owner (= the macro owner by construction).
+# --------------------------------------------------------------------------- #
+def macro_run_query_conditions(user: str | None = None) -> str:
+	"""Scope Jarvis Macro Run queries to the caller's own rows. System Manager
+	(and Administrator) get org-wide READ."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return ""
+	return f"`tab{MACRO_RUN}`.`owner` = {frappe.db.escape(user)}"
+
+
+def has_macro_run_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate for Jarvis Macro Run. Read/write/delete: own-owner axis. On
+	CREATE (MAC-2): reject a run whose linked ``macro`` (or ``conversation``, if
+	set) is not owned by the caller, so a generic-REST insert cannot attach a run
+	to another user's macro. Legit runs are inserted server-side with
+	``ignore_permissions`` and never consult this hook."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return True
+	if ptype == "create":
+		macro = doc.get("macro")
+		if macro and frappe.db.get_value(MACRO, macro, "owner") != user:
+			return False
+		conv = doc.get("conversation")
+		if conv and frappe.db.get_value(CONVERSATION, conv, "owner") != user:
+			return False
+		return True
+	return doc.get("owner") == user

--- a/jarvis/chat/macro_scheduler.py
+++ b/jarvis/chat/macro_scheduler.py
@@ -29,8 +29,27 @@ def run_due_macros() -> None:
 	if not due:
 		return
 
+	from jarvis.permissions import has_jarvis_access
+
 	original_user = frappe.session.user
 	for m in due:
+		# MAC-1 (security review PART 3, TASK 23): never run a macro whose owner
+		# has lost Jarvis access (demoted System User, or a Website/portal owner) —
+		# the scheduled turn would otherwise execute jarvis__* tools as an identity
+		# categorically barred from Jarvis. Advance the schedule so it does not busy
+		# re-fire, but skip the run.
+		if not has_jarvis_access(m.owner):
+			frappe.db.set_value(
+				MACRO,
+				m.name,
+				{
+					"last_run_at": now,
+					"next_run_at": compute_next_run(m.schedule_frequency, m.schedule_time, from_dt=now),
+				},
+				update_modified=False,
+			)
+			frappe.db.commit()
+			continue
 		try:
 			frappe.set_user(m.owner)
 			from jarvis.chat import macros

--- a/jarvis/chat/macros_api.py
+++ b/jarvis/chat/macros_api.py
@@ -247,6 +247,7 @@ def list_macros_page(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_macro(name: str) -> dict:
 	"""One macro incl. its ordered steps (owner-gated)."""
 	doc = frappe.get_doc(MACRO, name)
@@ -316,6 +317,7 @@ def create_macro(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def update_macro(
 	name: str,
 	macro_name: str | None = None,
@@ -364,6 +366,7 @@ def update_macro(
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def delete_macro(name: str) -> dict:
 	"""Delete a macro row (owner-gated). Its Macro Run history rows link the
 	macro and would block the delete (LinkExistsError), so they go first — they
@@ -434,6 +437,7 @@ def stop_macro_run(run: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def get_macro_run(run: str) -> dict:
 	"""Current state of a run (for polling as a socketio fallback)."""
 	doc = frappe.get_doc(RUN, run)
@@ -564,6 +568,7 @@ def _own_conversation(conversation: str) -> None:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def summarize_macro(name: str) -> dict:
 	"""Kick off the merge: throwaway archived conversation + one agent turn
 	that invokes /macro-merge over the macro's steps. Returns the conversation
@@ -636,6 +641,7 @@ def get_macro_merge(conversation: str) -> dict:
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def apply_macro_merge(name: str, merged_prompt: str, conversation: str = "") -> dict:
 	"""Store ``merged_prompt`` (possibly user-edited) on the macro. The step
 	sequence STAYS as the editable source of truth — but when a merged prompt
@@ -660,6 +666,7 @@ def apply_macro_merge(name: str, merged_prompt: str, conversation: str = "") -> 
 
 
 @frappe.whitelist()
+@require_jarvis_user
 def clear_macro_merge(name: str) -> dict:
 	"""Remove the stored merged prompt so the step sequence runs again."""
 	doc = frappe.get_doc(MACRO, name)

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -369,3 +369,36 @@ has_permission.update({
 	"Jarvis Personalise Question": "jarvis.chat.personalise_permissions.has_personalise_question_permission",
 })
 
+# ---------------------------------------------------------------------------
+# File Box / Macros / Agents scoping (security review PART 3)
+# ---------------------------------------------------------------------------
+# TASK 22: File is a GLOBAL doctype. Core already registers a permissive
+# permission_query_conditions["File"]; Frappe ANDs the hooks, so the Jarvis
+# fragment ONLY restricts rows attached to Jarvis Conversation (owner / linked-
+# conversation-owner) and lets every non-Jarvis file (avatars, print formats,
+# other doctypes' attachments) through. NO has_permission["File"] hook — core's
+# per-doc byte deferral already protects the bytes; a second hook could break it.
+# TASK 23/24: Jarvis Macro / Macro Run scoped by the row owner at the ORM (Run's
+# owner is the macro owner by construction); the create arm of the Macro Run hook
+# also blocks attaching a run to another user's macro/conversation.
+# TASK 29: the four owner/installer-scoped agent doctypes (Installation, Run,
+# Finding, Activity). The Listing catalog stays All-readable (no owner hook); its
+# skill_bundle IP is permlevel-guarded (TASK 33) instead.
+permission_query_conditions.update({
+	"File": "jarvis.chat.file_permissions.file_query_conditions",
+	"Jarvis Macro": "jarvis.chat.macro_permissions.macro_query_conditions",
+	"Jarvis Macro Run": "jarvis.chat.macro_permissions.macro_run_query_conditions",
+	"Jarvis Agent Installation": "jarvis.chat.agent_permissions.installation_query_conditions",
+	"Jarvis Agent Run": "jarvis.chat.agent_permissions.run_query_conditions",
+	"Jarvis Agent Finding": "jarvis.chat.agent_permissions.finding_query_conditions",
+	"Jarvis Agent Activity": "jarvis.chat.agent_permissions.activity_query_conditions",
+})
+has_permission.update({
+	"Jarvis Macro": "jarvis.chat.macro_permissions.has_macro_permission",
+	"Jarvis Macro Run": "jarvis.chat.macro_permissions.has_macro_run_permission",
+	"Jarvis Agent Installation": "jarvis.chat.agent_permissions.has_installation_permission",
+	"Jarvis Agent Run": "jarvis.chat.agent_permissions.has_run_permission",
+	"Jarvis Agent Finding": "jarvis.chat.agent_permissions.has_finding_permission",
+	"Jarvis Agent Activity": "jarvis.chat.agent_permissions.has_activity_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_activity/jarvis_agent_activity.json
@@ -75,7 +75,7 @@
   {
    "if_owner": 1,
    "read": 1,
-   "role": "All"
+   "role": "Jarvis User"
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.json
@@ -148,7 +148,7 @@
   {
    "if_owner": 1,
    "read": 1,
-   "role": "All",
+   "role": "Jarvis User",
    "write": 1
   }
  ],

--- a/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.py
@@ -12,6 +12,47 @@ installation owner).
 
 from frappe.model.document import Document
 
+# Engine-owned audit fields — everything except the user-actionable ``state``.
+# Frozen on any customer save so the audited party cannot rewrite/erase a finding.
+_FROZEN_FIELDS = (
+	"run",
+	"agent",
+	"rule_id",
+	"severity",
+	"title",
+	"detail_md",
+	"section",
+	"effective_date",
+	"disclaimer",
+	"ref_doctype",
+	"ref_name",
+	"amount",
+	"fingerprint",
+	"first_seen_run",
+	"last_seen_run",
+)
+
 
 class JarvisAgentFinding(Document):
-	pass
+	def validate(self):
+		self._freeze_audit_fields()
+
+	def _freeze_audit_fields(self):
+		"""TASK 31 (AGENTS-3): a finding is the reproducibility guarantee of an
+		audit run. The customer gets ``if_owner`` WRITE so they can move a finding's
+		``state`` (acknowledge / resolve), but the audited party must NOT be able to
+		silently rewrite or erase the audit content (severity / detail_md / amount /
+		…) via a generic-REST PUT and defeat the audit trail. On any non-new,
+		non-server save, restore every engine-owned field to its stored value so
+		only ``state`` can change. The engine writes with ``ignore_permissions``
+		(insert) or raw ``db.set_value`` (recurrence / auto-resolve bumps), both of
+		which bypass this."""
+		if self.is_new() or self.flags.ignore_permissions:
+			return
+		before = self.get_doc_before_save()
+		if not before:
+			return
+		for field in _FROZEN_FIELDS:
+			stored = before.get(field)
+			if self.get(field) != stored:
+				self.set(field, stored)

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -132,7 +132,7 @@
    "delete": 1,
    "if_owner": 1,
    "read": 1,
-   "role": "All",
+   "role": "Jarvis User",
    "write": 1
   }
  ],

--- a/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
@@ -99,7 +99,8 @@
    "fieldname": "skill_bundle",
    "fieldtype": "Long Text",
    "label": "Skill Bundle (JSON)",
-   "description": "JSON list of {path, body} SKILL.md payloads pushed to the container on Apply."
+   "permlevel": 1,
+   "description": "JSON list of {path, body} SKILL.md payloads pushed to the container on Apply. permlevel 1 (SM-only; PART 3 TASK 33): the proprietary agent rule-pack is vendor IP, so a normal Jarvis User cannot read it via generic REST / get_agent. The catalog seed writes it via ignore_permissions and the engine reads it via get_doc (both bypass permlevel)."
   },
   {
    "fieldname": "default_schedule",
@@ -144,7 +145,13 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Jarvis User"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
   }
  ],
  "sort_field": "modified",

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
@@ -116,7 +116,7 @@
   {
    "if_owner": 1,
    "read": 1,
-   "role": "All"
+   "role": "Jarvis User"
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
@@ -32,6 +32,7 @@
   {
    "default": "Pending",
    "fieldname": "status",
+   "permlevel": 1,
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
@@ -94,23 +95,27 @@
   },
   {
    "fieldname": "decision",
+   "permlevel": 1,
    "fieldtype": "Small Text",
    "label": "Decision"
   },
   {
    "fieldname": "decided_by",
+   "permlevel": 1,
    "fieldtype": "Link",
    "label": "Decided By",
    "options": "User"
   },
   {
    "fieldname": "decided_at",
+   "permlevel": 1,
    "fieldtype": "Datetime",
    "label": "Decided At"
   },
   {
    "default": "0",
    "fieldname": "trace_comment_added",
+   "permlevel": 1,
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Trace Comment Added"
@@ -142,6 +147,12 @@
    "read": 1,
    "write": 1,
    "role": "Jarvis User"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
@@ -153,6 +153,11 @@
    "read": 1,
    "role": "System Manager",
    "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Jarvis User"
   }
  ],
  "sort_field": "creation",

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.py
@@ -16,8 +16,41 @@ class JarvisApprovalRequest(Document):
 	"""
 
 	def validate(self):
+		self._guard_decided_fields()
 		if self.status != "Pending" and not self.decision:
 			frappe.throw("A decided approval must carry the decision text.")
+
+	def _guard_decided_fields(self):
+		"""TASK 25(b): the decided-outcome fields (status / decision / decided_by /
+		decided_at / trace_comment_added) are permlevel-1 (SM-only), so a normal
+		Jarvis User's REST create/write cannot set them — but assert the invariant
+		here too so no doc.save path can forge a decided or misattributed approval:
+
+		  * a NEW row by a normal caller must be Pending & undecided;
+		  * a CHANGE to ``decided_by`` must set it to the acting user.
+
+		Server transitions bypass this entirely: the real decide/dismiss/restore
+		flows use raw ``db.sql`` / ``db.set_value`` (never reach validate), and the
+		chat-ask materializer + agent tool insert with ``ignore_permissions``.
+		Administrator is trusted. An update that leaves ``decided_by`` untouched
+		(e.g. the agent filling ref_doctype/ref_name after the decision) is allowed."""
+		if self.flags.ignore_permissions:
+			return
+		user = frappe.session.user
+		if user == "Administrator":
+			return
+		if self.is_new():
+			if (self.status or "Pending") != "Pending" or self.decision or self.decided_by:
+				frappe.throw(
+					"A new approval request must be Pending and undecided.",
+					frappe.PermissionError,
+				)
+			return
+		if self.has_value_changed("decided_by") and self.decided_by and self.decided_by != user:
+			frappe.throw(
+				"decided_by must be the deciding user.",
+				frappe.PermissionError,
+			)
 
 	def on_update(self):
 		self._leave_trace_comment()

--- a/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
+++ b/jarvis/jarvis/doctype/jarvis_macro/jarvis_macro.json
@@ -120,12 +120,16 @@
  ],
  "permissions": [
   {
-   "role": "All",
+   "role": "Jarvis User",
    "read": 1,
    "write": 1,
    "create": 1,
    "delete": 1,
    "if_owner": 1
+  },
+  {
+   "role": "System Manager",
+   "read": 1
   }
  ],
  "sort_field": "modified",

--- a/jarvis/jarvis/doctype/jarvis_macro_run/jarvis_macro_run.json
+++ b/jarvis/jarvis/doctype/jarvis_macro_run/jarvis_macro_run.json
@@ -79,12 +79,16 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "read": 1,
       "write": 1,
       "create": 1,
       "delete": 1,
       "if_owner": 1
+    },
+    {
+      "role": "System Manager",
+      "read": 1
     }
   ],
   "sort_field": "modified",

--- a/jarvis/tests/test_part3_security.py
+++ b/jarvis/tests/test_part3_security.py
@@ -307,6 +307,39 @@ class TestApprovalForgery(Part3Base):
 			with self.assertRaises(frappe.PermissionError):
 				doc._guard_decided_fields()
 
+	def test_owner_can_read_but_not_write_decided_fields(self):
+		# FIX 2: permlevel-1 on the decided fields closed WRITE (forgery) but also
+		# stripped READ via the perm-checked frappe.client.get path for a non-SM
+		# owner. A permlevel-1 READ-only Jarvis User row restores read WITHOUT
+		# reopening write or row-level scoping.
+		conv = _mk_conv(USER_A)
+		appr = _mk_approval(USER_A, conversation=conv, status="Pending")
+		# Server stamp (raw set_value, exactly like decide()'s SQL — bypasses
+		# permlevel), then the owner reads it back through the perm-checked door.
+		frappe.db.set_value(APPROVAL, appr.name, {
+			"status": "Approved", "decision": "ok", "decided_by": USER_A,
+		}, update_modified=False)
+		frappe.db.commit()
+
+		# (c) owner CAN now read status/decision/decided_by via client.get.
+		with _as(USER_A):
+			got = frappe.client.get(APPROVAL, appr.name)
+		self.assertEqual(got.get("status"), "Approved")
+		self.assertEqual(got.get("decision"), "ok")
+		self.assertEqual(got.get("decided_by"), USER_A)
+
+		# (b) owner still CANNOT write the decided fields (permlevel-1 write is
+		# SM-only): the set_value is stripped, status stays Approved.
+		with _as(USER_A):
+			frappe.client.set_value(APPROVAL, appr.name, "status", "Rejected")
+		self.assertEqual(frappe.db.get_value(APPROVAL, appr.name, "status"), "Approved")
+
+		# (a) a non-owner still cannot read the row at all (row-level scoping via
+		# has_approval_permission is unaffected by the permlevel READ grant).
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.client.get(APPROVAL, appr.name)
+
 	def test_real_decide_stamps_fields(self):
 		conv = _mk_conv(USER_A)
 		appr = _mk_approval(USER_A, conversation=conv)

--- a/jarvis/tests/test_part3_security.py
+++ b/jarvis/tests/test_part3_security.py
@@ -1,0 +1,427 @@
+"""Security review PART 3 — exploit reproductions + fix proofs.
+
+Covers the File-list IDOR (TASK 22), the macro role/ORM tightening + MAC-2
+create-inject + scheduler skip (TASK 23/24), the approval decided-field forgery
+(TASK 25), comment-tag grant-to-non-Jarvis + mention-notify leak (TASK 27/28),
+the agent role/ORM tightening (TASK 29), the reviewer-gated agent apply (TASK
+30), the finding audit-field freeze (TASK 31), the run-existence oracle (TASK
+32) and the skill_bundle IP permlevel (TASK 33).
+
+Every exploit is exercised through the SAME door a real attacker would use — a
+perm-checked ``doc.insert()`` / ``doc.save()`` (the generic-REST path) or the
+whitelisted endpoint — NOT ``ignore_permissions`` (which would mask the gate).
+Fixtures the engine/server would create are minted with ``ignore_permissions``
+and owner-reassigned, mirroring the real writers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, get_datetime, now_datetime
+
+from jarvis.chat import agents_api, approvals_api, docmeta_api, macro_scheduler
+
+CONVERSATION = "Jarvis Conversation"
+MACRO = "Jarvis Macro"
+MACRO_RUN = "Jarvis Macro Run"
+APPROVAL = "Jarvis Approval Request"
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+
+USER_A = "p3-usera@example.com"
+USER_B = "p3-userb@example.com"
+REVIEWER = "p3-reviewer@example.com"
+OUTSIDER = "p3-outsider@example.com"  # System User, NO Jarvis role
+AGENT_SLUG = "p3-test-agent"
+PFX = "p3"
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _ensure_user(email: str, roles: list[str]) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc({
+			"doctype": "User", "email": email, "first_name": PFX,
+			"send_welcome_email": 0, "enabled": 1, "user_type": "System User",
+		})
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	if frappe.db.get_value("User", email, "user_type") != "System User":
+		frappe.db.set_value("User", email, "user_type", "System User")
+	# Force the exact role set (drop System Manager so the role gates are real).
+	if "System Manager" in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).remove_roles("System Manager")
+	have = set(frappe.get_roles(email))
+	add = [r for r in roles if r not in have]
+	if add:
+		frappe.get_doc("User", email).add_roles(*add)
+	# Drop any stray Jarvis roles OUTSIDER must not hold.
+	strip = [r for r in ("Jarvis User", "Jarvis Skill Reviewer", "Jarvis Admin")
+			 if r not in roles and r in set(frappe.get_roles(email))]
+	if strip:
+		frappe.get_doc("User", email).remove_roles(*strip)
+	return email
+
+
+def _reassign(dt: str, name: str, owner: str) -> None:
+	frappe.db.set_value(dt, name, "owner", owner, update_modified=False)
+
+
+def _mk_conv(owner: str, title: str = "p3 conv") -> str:
+	doc = frappe.get_doc({"doctype": CONVERSATION, "title": title})
+	doc.insert(ignore_permissions=True)
+	_reassign(CONVERSATION, doc.name, owner)
+	return doc.name
+
+
+def _mk_file(owner: str, tag: str, attached=None, is_private: int = 1):
+	doc = frappe.get_doc({
+		"doctype": "File",
+		"file_name": f"{tag}.txt",
+		"content": f"content-{tag}",
+		"is_private": is_private,
+		"attached_to_doctype": attached[0] if attached else None,
+		"attached_to_name": attached[1] if attached else None,
+	})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	_reassign("File", doc.name, owner)
+	return doc
+
+
+def _mk_macro(owner: str, name: str, **extra):
+	doc = frappe.get_doc({
+		"doctype": MACRO, "macro_name": name, "enabled": 1,
+		"steps": [{"prompt": "do the thing"}], **extra,
+	})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	_reassign(MACRO, doc.name, owner)
+	return doc
+
+
+def _mk_approval(owner: str, *, conversation=None, status="Pending", **extra):
+	doc = frappe.get_doc({
+		"doctype": APPROVAL, "title": f"{PFX} approval", "question": "Approve?",
+		"status": status, "conversation": conversation, **extra,
+	})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	_reassign(APPROVAL, doc.name, owner)
+	return doc
+
+
+def _mk_run(owner: str, *, status="completed", agent=AGENT_SLUG):
+	doc = frappe.get_doc({"doctype": RUN, "agent": agent, "status": status})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	_reassign(RUN, doc.name, owner)
+	return doc
+
+
+def _mk_finding(owner: str, *, agent=AGENT_SLUG, run=None, severity="blocker",
+				title=f"{PFX}-finding", detail_md="orig detail", amount=1000,
+				first_seen=None, last_seen=None):
+	doc = frappe.get_doc({
+		"doctype": FINDING, "agent": agent, "run": run, "severity": severity,
+		"title": title, "detail_md": detail_md, "amount": amount, "state": "open",
+		"first_seen_run": first_seen, "last_seen_run": last_seen,
+	})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	_reassign(FINDING, doc.name, owner)
+	return doc
+
+
+class Part3Base(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(USER_A, ["Jarvis User"])
+		_ensure_user(USER_B, ["Jarvis User"])
+		_ensure_user(REVIEWER, ["Jarvis Skill Reviewer"])
+		_ensure_user(OUTSIDER, [])  # System User, no Jarvis role
+		if not frappe.db.exists(LISTING, AGENT_SLUG):
+			frappe.get_doc({
+				"doctype": LISTING, "agent_slug": AGENT_SLUG, "title": "P3 Test Agent",
+				"description": "test", "status": "Published", "nature": "Auditor",
+				"skill_bundle": '[{"path":"SKILL.md","body":"PROPRIETARY VENDOR IP"}]',
+			}).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		# The listing is committed in setUpClass (users/listing must survive the
+		# per-test rollback); delete it so it never pollutes the shared
+		# patterntest DB (e.g. the agents-marketplace listing count).
+		frappe.db.rollback()
+		if frappe.db.exists(LISTING, AGENT_SLUG):
+			frappe.delete_doc(LISTING, AGENT_SLUG, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.db.rollback()
+		# Committed residue (decide() commits): hard-delete p3 rows.
+		for dt, filt in (
+			(APPROVAL, {"title": ["like", f"{PFX}%"]}),
+			(MACRO, {"macro_name": ["like", f"{PFX}%"]}),
+		):
+			for n in frappe.get_all(dt, filters=filt, pluck="name"):
+				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+		frappe.db.set_single_value("Jarvis Settings", "agent_skills_sync_status", "")
+		frappe.db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# TASK 22 — File list IDOR
+# --------------------------------------------------------------------------- #
+class TestFileListScoping(Part3Base):
+	def test_file_list_excludes_other_users_conversation_files(self):
+		conv_a = _mk_conv(USER_A)
+		fa = _mk_file(USER_A, f"{PFX}-a-secret", attached=(CONVERSATION, conv_a))
+		conv_b = _mk_conv(USER_B)
+		fb = _mk_file(USER_B, f"{PFX}-b-own", attached=(CONVERSATION, conv_b))
+		# Non-Jarvis public file owned by A (must stay listable — permissive AND).
+		pub = _mk_file(USER_A, f"{PFX}-pub", attached=None, is_private=0)
+		# B's own non-Jarvis file (own attachments still listable).
+		own_np = _mk_file(USER_B, f"{PFX}-b-note", attached=None, is_private=1)
+
+		with _as(USER_B):
+			names = set(frappe.get_list(
+				"File", filters={"file_name": ["like", f"{PFX}-%"]},
+				pluck="name", limit_page_length=0,
+			))
+
+		self.assertNotIn(fa.name, names, "leak: B sees A's conversation-attached File")
+		self.assertIn(fb.name, names, "regression: B lost their own conversation File")
+		self.assertIn(pub.name, names, "over-restrict: a non-Jarvis public File vanished")
+		self.assertIn(own_np.name, names, "over-restrict: B's own non-Jarvis File vanished")
+
+	def test_sm_sees_all_conversation_files(self):
+		conv_a = _mk_conv(USER_A)
+		fa = _mk_file(USER_A, f"{PFX}-sm-a", attached=(CONVERSATION, conv_a))
+		with _as("Administrator"):
+			names = set(frappe.get_list(
+				"File", filters={"file_name": ["like", f"{PFX}-sm-%"]}, pluck="name"))
+		self.assertIn(fa.name, names)
+
+
+# --------------------------------------------------------------------------- #
+# TASK 23 / 24 — Macros
+# --------------------------------------------------------------------------- #
+class TestMacroScoping(Part3Base):
+	def test_non_jarvis_user_cannot_create_macro(self):
+		with _as(OUTSIDER):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc({
+					"doctype": MACRO, "macro_name": f"{PFX}-x",
+					"steps": [{"prompt": "hi"}],
+				}).insert()
+
+	def test_jarvis_user_creates_own_macro(self):
+		with _as(USER_A):
+			m = frappe.get_doc({
+				"doctype": MACRO, "macro_name": f"{PFX}-ok",
+				"steps": [{"prompt": "hi"}],
+			}).insert()
+		self.assertEqual(m.owner, USER_A)
+
+	def test_macro_list_scoped_to_owner(self):
+		ma = _mk_macro(USER_A, f"{PFX}-listA")
+		mb = _mk_macro(USER_B, f"{PFX}-listB")
+		with _as(USER_B):
+			names = set(frappe.get_list(
+				MACRO, filters={"macro_name": ["like", f"{PFX}-list%"]}, pluck="name"))
+		self.assertIn(mb.name, names)
+		self.assertNotIn(ma.name, names)
+
+	def test_macro_run_cross_inject_rejected(self):
+		# MAC-2: B inserts a Macro Run linked to A's macro.
+		ma = _mk_macro(USER_A, f"{PFX}-mac2")
+		with _as(USER_B):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc({
+					"doctype": MACRO_RUN, "macro": ma.name, "status": "queued",
+				}).insert()
+
+	def test_scheduler_skips_barred_owner(self):
+		# MAC-1: a due macro owned by a user who lost Jarvis access is skipped.
+		m = _mk_macro(OUTSIDER, f"{PFX}-sched", schedule_enabled=1)
+		frappe.db.set_value(MACRO, m.name, {
+			"schedule_enabled": 1,
+			"next_run_at": add_to_date(now_datetime(), hours=-1),
+		}, update_modified=False)
+		with patch("jarvis.chat.macros.run_macro") as mock_run:
+			macro_scheduler.run_due_macros()
+		called = [c.args[0] for c in mock_run.call_args_list]
+		self.assertNotIn(m.name, called, "scheduler ran a barred owner's macro")
+		# processed-as-skipped: schedule advanced past now.
+		nxt = get_datetime(frappe.db.get_value(MACRO, m.name, "next_run_at"))
+		self.assertGreater(nxt, now_datetime())
+
+
+# --------------------------------------------------------------------------- #
+# TASK 25 — Approval decided-field forgery
+# --------------------------------------------------------------------------- #
+class TestApprovalForgery(Part3Base):
+	def test_rest_insert_cannot_forge_decided_approval(self):
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": APPROVAL, "title": f"{PFX} forge", "question": "q?",
+				"status": "Approved", "decision": "sneaky", "decided_by": USER_B,
+			})
+			doc.insert()  # perm-checked (generic REST); permlevel strips forged fields
+			name = doc.name
+		row = frappe.db.get_value(
+			APPROVAL, name, ["status", "decision", "decided_by"], as_dict=True)
+		self.assertEqual(row.status, "Pending")
+		self.assertFalse(row.decision)
+		self.assertFalse(row.decided_by)
+
+	def test_validate_invariant_rejects_new_decided_row(self):
+		# Direct proof of the controller invariant (independent of permlevel).
+		with _as(USER_A):
+			doc = frappe.get_doc({
+				"doctype": APPROVAL, "title": f"{PFX} inv", "question": "q?",
+				"status": "Approved", "decision": "x",
+			})
+			doc.set("__islocal", 1)  # insert() sets this; validate runs with it set
+			with self.assertRaises(frappe.PermissionError):
+				doc._guard_decided_fields()
+
+	def test_real_decide_stamps_fields(self):
+		conv = _mk_conv(USER_A)
+		appr = _mk_approval(USER_A, conversation=conv)
+		with _as(USER_A), patch("jarvis.chat.api.send_message", return_value={"ok": True}):
+			approvals_api.decide(appr.name, "Approve as drafted", 1)
+		row = frappe.db.get_value(
+			APPROVAL, appr.name, ["status", "decision", "decided_by"], as_dict=True)
+		self.assertEqual(row.status, "Approved")
+		self.assertEqual(row.decided_by, USER_A)
+		self.assertEqual(row.decision, "Approve as drafted")
+
+
+# --------------------------------------------------------------------------- #
+# TASK 27 / 28 — Comment tagging
+# --------------------------------------------------------------------------- #
+class TestCommentTagging(Part3Base):
+	def test_share_to_non_jarvis_user_rejected(self):
+		m = _mk_macro(USER_A, f"{PFX}-share")
+		with _as(USER_A):
+			with self.assertRaises(frappe.ValidationError):
+				docmeta_api.toggle_share("Jarvis Macro", m.name, OUTSIDER, "add")
+			docmeta_api.toggle_share("Jarvis Macro", m.name, USER_B, "add")
+		self.assertTrue(frappe.db.exists("DocShare", {
+			"share_doctype": "Jarvis Macro", "share_name": m.name, "user": USER_B}))
+
+	def test_add_comment_strips_mentions(self):
+		m = _mk_macro(USER_A, f"{PFX}-comment")
+		with _as(USER_A):
+			row = docmeta_api.add_comment(
+				"Jarvis Macro", m.name,
+				'<div>hi <span class="mention" data-id="carol@example.com">@Carol</span></div>',
+			)
+		content = frappe.db.get_value("Comment", row["name"], "content")
+		self.assertNotIn('class="mention"', content)
+		self.assertNotIn("carol@example.com", content)
+		self.assertIn("@Carol", content)  # readable text preserved
+		with _as(USER_A):
+			row2 = docmeta_api.add_comment("Jarvis Macro", m.name, "plain body")
+		self.assertEqual(
+			frappe.db.get_value("Comment", row2["name"], "content"), "plain body")
+
+
+# --------------------------------------------------------------------------- #
+# TASK 29 / 30 / 31 / 32 / 33 — Agents
+# --------------------------------------------------------------------------- #
+class TestAgentScoping(Part3Base):
+	def test_non_jarvis_user_cannot_install_agent(self):
+		with _as(OUTSIDER):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc({
+					"doctype": INSTALLATION, "agent": AGENT_SLUG, "enabled": 1,
+				}).insert()
+
+	def test_finding_list_scoped_to_owner(self):
+		fa = _mk_finding(USER_A, title=f"{PFX}-fA")
+		fb = _mk_finding(USER_B, title=f"{PFX}-fB")
+		with _as(USER_B):
+			names = set(frappe.get_list(
+				FINDING, filters={"title": ["like", f"{PFX}-f%"]}, pluck="name"))
+		self.assertIn(fb.name, names)
+		self.assertNotIn(fa.name, names)
+
+	def test_apply_agents_requires_reviewer(self):
+		with _as(USER_A):  # plain Jarvis User
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.apply_agents()
+		with _as(REVIEWER), \
+			patch("jarvis.chat.agents_api.build_agent_push_payload", return_value=[]), \
+			patch("jarvis.chat.agents_api.frappe.enqueue", MagicMock()), \
+			patch("frappe.db.set_single_value", MagicMock()):
+			res = agents_api.apply_agents()
+		self.assertTrue(res["ok"])
+
+	def test_finding_owner_cannot_rewrite_audit_fields(self):
+		f = _mk_finding(USER_A, severity="blocker", detail_md="orig detail", amount=1000)
+		with _as(USER_A):
+			doc = frappe.get_doc(FINDING, f.name)
+			doc.severity = "note"
+			doc.detail_md = ""
+			doc.amount = 0
+			doc.state = "resolved"
+			doc.save()  # if_owner write
+		row = frappe.db.get_value(
+			FINDING, f.name, ["severity", "detail_md", "amount", "state"], as_dict=True)
+		self.assertEqual(row.severity, "blocker", "audit severity was rewritten")
+		self.assertEqual(row.detail_md, "orig detail", "audit detail was erased")
+		self.assertEqual(row.amount, 1000, "audit amount was rewritten")
+		self.assertEqual(row.state, "resolved", "legit state flip was blocked")
+		# The engine (ignore_permissions) can still write audit fields.
+		doc2 = frappe.get_doc(FINDING, f.name)
+		doc2.severity = "warning"
+		doc2.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value(FINDING, f.name, "severity"), "warning")
+
+	def test_list_findings_foreign_run_is_not_an_oracle(self):
+		run_a = _mk_run(USER_A, status="completed")
+		_mk_finding(USER_A, run=run_a.name, first_seen=run_a.name, last_seen=run_a.name)
+		with _as(USER_B):
+			res = agents_api.list_findings(run=run_a.name)
+		self.assertEqual(res["total"], 0)
+		self.assertEqual(res["rows"], [])
+		# The owner still sees their own run's findings (gate is owner-correct).
+		with _as(USER_A):
+			mine = agents_api.list_findings(run=run_a.name)
+		self.assertGreaterEqual(mine["total"], 1)
+
+	def test_skill_bundle_hidden_from_normal_user(self):
+		with _as(USER_A):
+			out = agents_api.get_agent(AGENT_SLUG)
+			self.assertNotIn("skill_bundle", out)
+			rows = frappe.get_list(
+				LISTING, filters={"agent_slug": AGENT_SLUG}, fields=["name", "skill_bundle"])
+		self.assertTrue(rows)
+		self.assertNotIn("skill_bundle", rows[0], "skill_bundle leaked to a normal user")
+		with _as("Administrator"):
+			rows2 = frappe.get_list(
+				LISTING, filters={"agent_slug": AGENT_SLUG}, fields=["name", "skill_bundle"])
+		self.assertIn("skill_bundle", rows2[0])


### PR DESCRIPTION
## Security review — Part 3 (File Box / attachments, Macros, Approval Board, Comment tagging, Agents)

Closes the ORM/REST-layer gaps under the File Box, macro, approval, and agent surfaces, following the Parts 1/2 doctrine (doctype role `Jarvis User` not `All` + correct `if_owner` axis + `permission_query_conditions`/`has_permission` hooks + permlevel, so the generic REST surface is safe on its own; endpoint decorators are defense-in-depth).

> **Stacks on #285 (Part 2), which stacks on #284 (Part 1).** Base is `security/part2-skills-wiki`. Constraints honored: **no leaks, no unauthorized access, no UX break, balance.**

### Review method
A 6-area fan-out review + adversarial verification (many exploits reproduced live, rolled back) produced 16 confirmed findings, written up as TASK 22–33. Notably, several *hypothesized* holes were **refuted** and recorded as do-not-regress: File **bytes** are already protected (Part-1's conversation hook via `File.has_permission` deferral), macro cross-user IDOR is already blocked by `if_owner`, and the File Box endpoints are already owner-scoped. Part 3 is mostly the ORM/REST layer beneath those endpoints.

### What landed (TASK 22–33)
- **TASK 22 [HIGH] — File metadata leak.** The `File` *list* surface had no Jarvis scoping, so any user could read every other user's inbound-doc filenames, `content_hash`, owner, and private `file_url` via `/api/resource/File`. New `jarvis/chat/file_permissions.py` registers a **query-condition-only** hook (no `has_permission["File"]` — core's per-doc byte deferral already works). `File` is global, so the fragment is deliberately permissive (only conversation-attached rows are owner-scoped; avatars/print-formats/other attachments pass unchanged).
- **TASK 23/24/29 — role `All`→`Jarvis User`** on the Macro and Agent doctypes + new owner-axis ORM hooks (`macro_permissions.py`, `agent_permissions.py`), closing barred/portal-user REST creation; the macro scheduler now skips owners lacking Jarvis access.
- **TASK 25 [HIGH] — approval-outcome forgery.** `status/decision/decided_by/decided_at/trace_comment_added` are now permlevel-1 (SM-write only) + a controller invariant, so a user cannot REST-insert or `set_value` a pre-"Approved"/foreign-`decided_by` approval.
- **TASK 27/28 — comment tagging.** Share/assign targets are confined to the Jarvis population; `add_comment` strips attacker mention-HTML (closing a title-leak-via-notify).
- **TASK 30 [HIGH] — `apply_agents`** (bench-wide push + restart) now requires the reviewer set, mirroring Part-2's `apply_custom_skills`.
- **TASK 31 — Agent Finding audit fields frozen** (the audited party can flip `state` but not rewrite severity/detail/amount).
- **TASK 32/33 — `list_findings` run-oracle closed; `skill_bundle` (vendor IP) permlevel-guarded.**

### Two-reviewer verification — no leaks
Independently verified by a Sonnet agent (**verdict: safe to merge**) and by me, each reproducing exploits + non-regressions live:
- **TASK 22 (the risky global-`File` change):** cross-user conversation-file excluded from the list; own files, public files, and non-Jarvis-doctype attachments all still listable; byte download still denied; scope SQL injection-tested (`' OR '1'='1`) and `frappe.db.escape`d; no `has_permission["File"]` added.
- Approval forgery neutralized (insert → Pending, `set_value` blocked); `apply_agents` reviewer-gated; share-to-non-Jarvis rejected; audit-field freeze holds; `skill_bundle` hidden from normal users.

### Remediation round (UX findings from review, commit `fb27ad7`)
Two narrow "no break in UX" findings (not leaks) were fixed and re-verified:
- **[MEDIUM]** the Agents SPA "Apply" button was gated on `isSM` while `apply_agents` allows the full reviewer set — a Jarvis Skill Reviewer could apply but never saw the button. Added `get_agents_caps()` (reviewer probe, mirroring the Skills area) and gated the button on it.
- **[LOW-MEDIUM]** TASK 25's permlevel also blanked the *owner's own* decided-approval fields via generic REST / Desk view (the Jarvis SPA was unaffected). Added a read-only permlevel-1 row for `Jarvis User` — write stays SM-only, forgery path not reopened (verified: owner reads status/decision, still can't write; non-owner still can't see the row).

### Testing
- `test_part3_security` (19) + `test_agents_marketplace`, `test_docmeta_api`, `test_feature_pages_api`, `test_chat_endpoint_gating`, `test_macro_merge`, `test_part2_security` — all green on `patterntest.localhost`.
- **Frontend `vite build` passes.**
- Full-suite run: no Part-3 regressions; remaining failures are environmental (`hrms` app not installed here; gevent/socketio) and one pre-existing cross-module sort flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
