### PR TITLE
feat: cross-day chat memory + configurable archive retention

### DIFF
--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -229,6 +229,14 @@ function applyRemoteRename(name, title) {
 	if (conv && title) conv.title = title
 }
 
+// The retention sweep (session_lifecycle) archived an idle conversation
+// server-side. Mirror the local removal so an open sidebar drops the row instead
+// of leaving a ghost that 404s on click; if it's the open chat, ChatView's store
+// watcher reacts to the removal.
+function applyRemoteExpired(name) {
+	conversations.value = conversations.value.filter((c) => c.name !== name)
+}
+
 let _remoteNewTimer = null
 function applyRemoteNew() {
 	if (_remoteNewTimer) return
@@ -289,6 +297,7 @@ const store = reactive({
 	setActivityDetail,
 	toggleNotify,
 	applyRemoteRename,
+	applyRemoteExpired,
 	applyRemoteNew,
 	markUnread,
 	clearUnread,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3493,6 +3493,13 @@ function onEvent(p) {
 		proactiveToast.value = { id: p.conversation_id, title: p.title || "Message from Jarvis", preview: p.preview || "" }
 		return
 	}
+	// The retention sweep archived an idle conversation (session_lifecycle). Drop
+	// it from the sidebar; handled before the current-conversation guard so an open
+	// tab updates even if the user has since switched chats.
+	if (p.kind === "conversation:expired" && p.conversation_id) {
+		store.applyRemoteExpired(p.conversation_id)
+		return
+	}
 	// Macro-run events use `conversation` (not conversation_id) and are handled
 	// before the current-conversation guard so the banner tracks the run.
 	if (p.kind === "macro:progress") {

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -21,9 +21,20 @@ conversation lazily creates a fresh session through the existing
 
 The daily ``rotate_dormant_sessions`` cron:
 
-1. DORMANT: conversations idle past ``DORMANT_DAYS`` with a session_key
-   and no in-flight rows -> delete the gateway session, clear
-   ``conv.session_key``, drop the ``Jarvis Chat Session`` lookup rows.
+1. EXPIRE: conversations idle past the configured retention window
+   (Jarvis Settings.conversation_retention_days; 0 disables) and not
+   starred, with no in-flight rows -> free the openclaw session (delete
+   gateway session, clear ``conv.session_key``, drop ``Jarvis Chat
+   Session`` lookup rows) and, for still-``Active`` chats, archive them:
+   set ``status = Archived`` + ``auto_expired`` + ``expired_at`` and push
+   a ``conversation:expired`` realtime event so an open tab drops the row.
+   A reversible soft-delete - a separate follow-on purge permanently
+   deletes archived chats later. (Reason we don't hard-delete here: a
+   Jarvis Conversation is referenced by five doctypes + File blobs, so a
+   safe delete needs a full dependency cascade we keep out of the cron.)
+   Already user-archived chats that still hold a session are session-freed
+   only (no status change, no event) so their working context is reclaimed
+   too. Starred chats are fully exempt - kept, session and all.
 2. ORPHANS: gateway sessions in the chat namespace that no conversation
    references (title/prewarm throwaways, deleted conversations) and that
    have been inactive past ``ORPHAN_GRACE_HOURS`` -> delete, plus any
@@ -46,9 +57,36 @@ CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 CHAT_SESSION = "Jarvis Chat Session"
 
-# A conversation idle this long gets its session rotated. Matches the
-# fleet's archive_retention_days default so there is one retention story.
-DORMANT_DAYS = 30
+# Retention: a conversation idle this long is archived (hidden) and its
+# openclaw session freed. Configurable per-tenant via
+# Jarvis Settings.conversation_retention_days; these are the fallbacks a
+# reader applies. DEFAULT is used when the Single field is unset (Single
+# defaults are NOT backfilled on migrate, so None must read as 30, not 0 -
+# 0 means "keep forever"). MIN is a defensive floor mirroring the settings
+# validator, so a value that slipped in below it can't mass-archive.
+DEFAULT_RETENTION_DAYS = 30
+MIN_RETENTION_DAYS = 7
+
+
+def _retention_days() -> int:
+	"""Effective idle-retention window in days. 0 => disabled (keep forever).
+
+	Read the RAW tabSingles value, not ``get_single_value``: the latter casts an
+	unset Int Single field to 0, which is indistinguishable from an explicit 0
+	(=disabled). The raw value is None when the field was never set (Single
+	defaults are not backfilled on migrate) -> the 30-day default (on by
+	default). An explicit '0' stays 0 (never)."""
+	rows = frappe.db.sql(
+		"SELECT value FROM `tabSingles` "
+		"WHERE doctype = 'Jarvis Settings' AND field = 'conversation_retention_days'"
+	)
+	raw = rows[0][0] if rows else None
+	if raw is None or raw == "":
+		return DEFAULT_RETENTION_DAYS
+	days = frappe.utils.cint(raw)
+	if days <= 0:
+		return 0
+	return max(days, MIN_RETENTION_DAYS)
 
 # An unreferenced gateway session younger than this is skipped: it may be
 # an in-flight title/prewarm throwaway, or a conversation whose freshly
@@ -65,9 +103,10 @@ _CHAT_NAMESPACE_MARKER = ":dashboard:"
 
 
 def rotate_dormant_sessions() -> dict:
-	"""Daily cron: rotate dormant conversation sessions and reap orphaned
-	throwaway sessions. Returns a summary dict (also logged) so a manual
-	``bench execute`` run shows what happened."""
+	"""Daily cron: archive conversations past the idle-retention window (freeing
+	their openclaw session) and reap orphaned throwaway sessions. Returns a
+	summary dict (also logged) so a manual ``bench execute`` run shows what
+	happened. (Name kept for the scheduler entry in hooks.py.)"""
 	from jarvis import selfhost
 
 	if selfhost.is_self_hosted():
@@ -81,7 +120,7 @@ def rotate_dormant_sessions() -> dict:
 
 	from jarvis.chat.openclaw_client import OpenclawSession
 
-	summary = {"dormant_rotated": 0, "orphans_reaped": 0, "skipped": 0, "errors": 0}
+	summary = {"archived": 0, "sessions_freed": 0, "orphans_reaped": 0, "skipped": 0, "errors": 0}
 	budget = BATCH_MAX
 	try:
 		sess = OpenclawSession.connect(gateway_url)
@@ -92,7 +131,7 @@ def rotate_dormant_sessions() -> dict:
 		)
 		return {"skipped": "connect failed"}
 	try:
-		budget = _rotate_dormant(sess, budget, summary)
+		budget = _expire_dormant(sess, budget, summary)
 		if budget > 0:
 			_reap_orphans(sess, budget, summary)
 	finally:
@@ -104,16 +143,25 @@ def rotate_dormant_sessions() -> dict:
 	return summary
 
 
-def _rotate_dormant(sess, budget: int, summary: dict) -> int:
-	"""Part 1: conversations idle past DORMANT_DAYS. Returns leftover
-	budget for the orphan sweep."""
-	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-DORMANT_DAYS)
+def _expire_dormant(sess, budget: int, summary: dict) -> int:
+	"""Part 1: conversations idle past the retention window. Frees the openclaw
+	session and archives still-``Active`` chats (marking ``auto_expired`` +
+	``expired_at`` and pushing a ``conversation:expired`` event); already
+	user-archived chats that still hold a session are session-freed only.
+	Starred chats are exempt entirely. Returns leftover budget for the orphan
+	sweep. Retention disabled (0) is a no-op that keeps the whole budget."""
+	days = _retention_days()
+	if days <= 0:
+		return budget  # retention disabled - keep chats forever
+	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-days)
 	rows = frappe.db.sql(
 		"""
-		SELECT c.name, c.session_key
+		SELECT c.name, c.owner, c.session_key, c.status
 		FROM `tabJarvis Conversation` c
-		WHERE c.session_key IS NOT NULL AND c.session_key != ''
+		WHERE c.starred = 0
 		  AND c.last_active_at IS NOT NULL AND c.last_active_at < %(cutoff)s
+		  AND (c.status = 'Active'
+		       OR (c.session_key IS NOT NULL AND c.session_key != ''))
 		  AND NOT EXISTS (
 			SELECT 1 FROM `tabJarvis Chat Message` m
 			WHERE m.conversation = c.name
@@ -125,31 +173,73 @@ def _rotate_dormant(sess, budget: int, summary: dict) -> int:
 		{"cutoff": cutoff, "limit": budget},
 		as_dict=True,
 	)
+	now = frappe.utils.now_datetime()
 	for row in rows:
 		if budget <= 0:
 			break  # defensive; the SQL LIMIT already bounds rows to budget
 		budget -= 1
-		# Per-row isolation (turn_recovery's loop pattern): one bad row
-		# must never abort the rest of the batch, and a failure between
-		# the gateway delete and the local commit must not strand the
-		# sweep - the idempotent not-found handling in
-		# _delete_gateway_session lets the next run finish the cleanup.
+		# Per-row isolation (turn_recovery's loop pattern): one bad row must
+		# never abort the batch, and a failure between the gateway delete and
+		# the local commit must not strand the sweep - the idempotent not-found
+		# handling in _delete_gateway_session lets the next run finish cleanup.
 		try:
-			if _delete_gateway_session(sess, row.session_key, summary):
-				# Only detach the bench side once the gateway side is
-				# gone. NULL, not "": session_key is UNIQUE and two ""
-				# rows would collide.
-				frappe.db.set_value(CONV, row.name, "session_key", None)
+			has_session = bool(row.session_key)
+			# Free the openclaw session FIRST; only detach the bench side once
+			# the gateway side is gone, else a crash would strand a live session
+			# under a nulled key. A gateway-delete failure leaves the row intact
+			# for next run (do NOT archive it - archiving would hide it from the
+			# only sweep that re-selects it, stranding the session forever).
+			if has_session and not _delete_gateway_session(sess, row.session_key, summary):
+				# NOTE (follow-up): a row whose gateway delete PERMANENTLY fails is
+				# the oldest, so ORDER BY last_active_at ASC re-selects it at the
+				# front every run, consuming a batch slot; >= BATCH_MAX such corpses
+				# would starve healthy archiving. Inherited from the rotate sweep - a
+				# last_expire_error_at cooldown column is the planned guard.
+				continue
+			# Only Active chats transition to Archived; an already user-archived
+			# chat is session-freed only (its status/marker stay the user's).
+			archived = row.status == "Active"
+			updates = {}
+			if has_session:
+				# NULL, not "": session_key is UNIQUE and two "" rows collide.
+				updates["session_key"] = None
+			if archived:
+				updates.update({"status": "Archived", "auto_expired": 1, "expired_at": now})
+			# Conversation update before the lookup-row delete so a per-row
+			# failure at the primary (conversation) write skips cleanly with no
+			# partial detach (mirrors the original rotate ordering).
+			if updates:
+				frappe.db.set_value(CONV, row.name, updates)
+			if has_session:
 				frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
-				frappe.db.commit()
-				summary["dormant_rotated"] += 1
+				summary["sessions_freed"] += 1
+			frappe.db.commit()
+			if archived:
+				summary["archived"] += 1
+				_notify_expired(row.name, row.owner)
 		except Exception:
+			# Discard any partial write from this row (e.g. the conversation
+			# update landed but the lookup-row delete then failed) so it can't
+			# ride to the NEXT row's commit; the idempotent gateway delete lets
+			# the next run finish cleanly. Rollback before log_error.
+			frappe.db.rollback()
 			frappe.log_error(
-				title="session_lifecycle: dormant row cleanup failed",
+				title="session_lifecycle: expire row failed",
 				message=f"conversation={row.name}\n{frappe.get_traceback()}",
 			)
 			summary["errors"] += 1
 	return budget
+
+
+def _notify_expired(conversation: str, owner: str) -> None:
+	"""Best-effort realtime nudge so an open tab drops the archived row instead
+	of showing a ghost that 404s on click. Never fatal to the sweep."""
+	try:
+		from jarvis.chat.events import publish_to_user
+
+		publish_to_user(owner, {"kind": "conversation:expired", "conversation_id": conversation})
+	except Exception:
+		pass
 
 
 def _reap_orphans(sess, budget: int, summary: dict) -> None:

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -15,7 +15,9 @@
   "status",
   "last_active_at",
   "starred",
-  "pending_agent_notes"
+  "pending_agent_notes",
+  "auto_expired",
+  "expired_at"
  ],
  "fields": [
   {
@@ -95,6 +97,25 @@
    "no_copy": 1,
    "read_only": 1,
    "description": "Server-set queue (JSON list of strings) of deferred bench-authored notes to fold into the NEXT outgoing turn's [Context: ...] bracket - e.g. 'the user declined the pending submit on SINV-0001; it was NOT performed'. Drained and cleared by turn_handler after a successful chat.send, so a discarded action corrects the agent's in-container session memory the next time it acts, without firing an extra turn."
+  },
+  {
+   "fieldname": "auto_expired",
+   "fieldtype": "Check",
+   "label": "Auto Expired",
+   "hidden": 1,
+   "no_copy": 1,
+   "read_only": 1,
+   "default": "0",
+   "description": "Set by the retention sweep (jarvis.chat.session_lifecycle) when this conversation was archived for exceeding the idle retention limit (Jarvis Settings.conversation_retention_days) - distinguishes a retention-expired chat from a user-archived one, and marks it for the follow-on permanent purge. Never set for a user-initiated archive."
+  },
+  {
+   "fieldname": "expired_at",
+   "fieldtype": "Datetime",
+   "label": "Expired At",
+   "hidden": 1,
+   "no_copy": 1,
+   "read_only": 1,
+   "description": "When the retention sweep archived this conversation. Drives the follow-on hard-purge horizon (permanently delete archived chats expired longer than a second, longer window)."
   }
  ],
  "permissions": [

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -54,6 +54,8 @@
   "personalise_section",
   "personalise_daily_question_cap",
   "personalise_enabled",
+  "chat_history_section",
+  "conversation_retention_days",
   "system_tab",
   "deployment_section",
   "deployment_mode",
@@ -398,6 +400,18 @@
    "label": "Enable Personalisation",
    "default": "1",
    "description": "Master toggle for the Personalise tab: question materialization, free-capture notes, and question-rule sweeps. Readers treat an unset value as ON (Single defaults are not backfilled on migrate; seeded by jarvis.learning.roles.after_migrate)."
+  },
+  {
+   "fieldname": "chat_history_section",
+   "fieldtype": "Section Break",
+   "label": "Chat History"
+  },
+  {
+   "fieldname": "conversation_retention_days",
+   "fieldtype": "Int",
+   "label": "Auto-archive idle chats after (days)",
+   "default": "30",
+   "description": "A chat you have not opened for this many days is automatically archived (hidden from your list) and its agent working-memory freed. Starred chats are never touched. Minimum 7; set to 0 to keep chats forever. Default 30. Archived chats are retained (not destroyed) and recoverable by support; a separate purge permanently deletes them later. Readers treat an unset value as 30 (Single defaults are not backfilled on migrate)."
   },
   {
    "fieldname": "system_tab",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -177,6 +177,23 @@ class JarvisSettings(Document):
 
         self._validate_auth_mode_requirements()
         self._validate_pattern_window()
+        self._validate_conversation_retention()
+
+    def _validate_conversation_retention(self):
+        """Retention floor. The daily sweep archives idle chats past this many
+        days, so a fumbled tiny value would mass-archive on the very next cron
+        (the batch cap only spreads that over days). 0 disables (keep forever);
+        otherwise require >= 7. Unset is left untouched - readers default it to
+        30 (Single defaults are not backfilled on migrate)."""
+        raw = getattr(self, "conversation_retention_days", None)
+        if raw in (None, ""):
+            return
+        days = frappe.utils.cint(raw)
+        if days != 0 and days < 7:
+            frappe.throw(
+                "Auto-archive idle chats after must be 0 (never) or at least 7 days.",
+                frappe.ValidationError,
+            )
 
     def _validate_pattern_window(self):
         """Behavioural-learning window must be at least 1 hour when enabled.
@@ -355,8 +372,9 @@ class JarvisSettings(Document):
             # (it bypasses Frappe's __Auth encryption). Use set_encrypted_password
             # so the secret is stored in the __Auth table, never in plaintext.
             if cred_type == "api_key":
-                from jarvis.jarvis.pool_serialize import _get_password
                 from frappe.utils.password import set_encrypted_password
+
+                from jarvis.jarvis.pool_serialize import _get_password
                 api_key_val = _get_password(m0, "api_key")
                 if api_key_val:
                     set_encrypted_password(
@@ -707,7 +725,9 @@ def _post_pool_with_retry(spec, api_keys, oauth_blobs):
     Re-raises the last unreachable error after exhausting retries; other Admin*
     errors propagate immediately (not retried)."""
     import time as _time
+
     import frappe as _frappe
+
     from jarvis import admin_client
 
     last = None
@@ -753,8 +773,9 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
     terminal.
     """
     import frappe as _frappe
-    from jarvis._redis_lock import redis_lock
+
     from jarvis import admin_client
+    from jarvis._redis_lock import redis_lock
     from jarvis.jarvis.pool_serialize import build_pool_payload
 
     with redis_lock(
@@ -796,7 +817,7 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
 
         # Re-validate: the config may have changed between enqueue and run.
         # If no longer proxy-valid, skip the push.
-        from jarvis.jarvis.pool_serialize import validate_models, compute_proxy_active
+        from jarvis.jarvis.pool_serialize import compute_proxy_active, validate_models
         revalidation_errors = validate_models(settings)
         if revalidation_errors or not compute_proxy_active(settings):
             reason = "; ".join(revalidation_errors) if revalidation_errors else "not proxy_active"

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -1,10 +1,12 @@
-"""Tests for jarvis.chat.session_lifecycle (Phase 1: dormant rotation +
-orphan sweep).
+"""Tests for jarvis.chat.session_lifecycle (retention expiry + orphan sweep).
 
-The sweep talks to the gateway only through OpenclawSession.connect (a
-dedicated connection, never the pool), so tests patch ``connect`` with a
-fake session exposing list_sessions/delete_session/close. Conversations
-and messages are real rows on the test site.
+The daily cron archives conversations idle past the configurable retention
+window (Jarvis Settings.conversation_retention_days), freeing their openclaw
+session; starred and in-flight chats are exempt, and an already user-archived
+chat is session-freed only. The gateway is reached only through
+OpenclawSession.connect (a dedicated connection, never the pool), so tests
+patch ``connect`` with a fake session exposing list_sessions/delete_session/
+close. Conversations and messages are real rows on the test site.
 """
 from __future__ import annotations
 
@@ -19,6 +21,8 @@ from jarvis.chat import session_lifecycle
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 CHAT_SESSION = "Jarvis Chat Session"
+SETTINGS = "Jarvis Settings"
+RETENTION_FIELD = "conversation_retention_days"
 
 NOW_MS = int(time.time() * 1000)
 OLD_MS = NOW_MS - (session_lifecycle.ORPHAN_GRACE_HOURS + 2) * 3600 * 1000
@@ -33,52 +37,62 @@ def _fake_sess(entries=None):
 class TestSessionLifecycle(FrappeTestCase):
 	def setUp(self):
 		self._made = []
-		# The sweep is site-global: park every pre-existing candidate so
-		# only THIS test's fixtures are eligible (mirrors the recovery
-		# rate-watch tests' residue-neutralizing setUp).
+		# The sweep is site-global. Neutralize every pre-existing candidate so
+		# only THIS test's fixtures are eligible: null all session_keys AND bump
+		# all conversations to "just active" (the archive path now also selects
+		# session-less idle Active chats, so parking keys alone is not enough).
+		frappe.db.sql("UPDATE `tabJarvis Conversation` SET session_key = NULL")
 		frappe.db.sql(
-			"UPDATE `tabJarvis Conversation` SET session_key = NULL "
-			"WHERE session_key IS NOT NULL"
+			"UPDATE `tabJarvis Conversation` SET last_active_at = %s",
+			(frappe.utils.now_datetime(),),
 		)
 		# Residue from aborted earlier runs would 1062 on re-insert.
 		frappe.db.delete(CHAT_SESSION, {"session_key": ["like", "test-lc-%"]})
 		# The sweep bails without an agent_url; pin one for the run.
-		self._orig_agent_url = frappe.db.get_single_value(
-			"Jarvis Settings", "agent_url")
-		frappe.db.set_single_value(
-			"Jarvis Settings", "agent_url", "http://gw.test:18789")
-		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		self._orig_agent_url = frappe.db.get_single_value(SETTINGS, "agent_url")
+		frappe.db.set_single_value(SETTINGS, "agent_url", "http://gw.test:18789")
+		# Default retention (unset -> 30); tests override where needed.
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, None)
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		frappe.db.commit()
+		# Realtime is a best-effort nudge; mock it so tests are hermetic and can
+		# assert the conversation:expired push.
+		patcher = patch("jarvis.chat.events.publish_to_user")
+		self.pub = patcher.start()
+		self.addCleanup(patcher.stop)
 
 	def tearDown(self):
 		for name in self._made:
 			frappe.db.delete(MSG, {"conversation": name})
 			frappe.db.delete(CONV, {"name": name})
 		frappe.db.delete(CHAT_SESSION, {"session_key": ["like", "test-lc-%"]})
-		frappe.db.set_single_value(
-			"Jarvis Settings", "agent_url", self._orig_agent_url or "")
-		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		frappe.db.set_single_value(SETTINGS, "agent_url", self._orig_agent_url or "")
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, None)
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		frappe.db.commit()
 
-	def _conv(self, *, session_key: str, idle_days: int, streaming: bool = False):
+	def _conv(self, *, session_key=None, idle_days, streaming=False,
+	          starred=0, status="Active"):
 		doc = frappe.get_doc({
-			"doctype": CONV, "title": f"lc-{session_key}",
+			"doctype": CONV, "title": f"lc-{session_key or idle_days}",
+			"starred": starred, "status": status,
 		}).insert(ignore_permissions=True)
 		self._made.append(doc.name)
-		frappe.db.set_value(CONV, doc.name, {
-			"session_key": session_key,
-			"last_active_at": frappe.utils.add_to_date(
-				frappe.utils.now_datetime(), days=-idle_days),
-		})
+		fields = {"last_active_at": frappe.utils.add_to_date(
+			frappe.utils.now_datetime(), days=-idle_days)}
+		if session_key:
+			fields["session_key"] = session_key
+		frappe.db.set_value(CONV, doc.name, fields)
 		if streaming:
 			frappe.get_doc({
 				"doctype": MSG, "conversation": doc.name, "seq": 1,
 				"role": "assistant", "content": "", "streaming": 1,
 			}).insert(ignore_permissions=True)
-		frappe.get_doc({
-			"doctype": CHAT_SESSION, "session_key": session_key,
-			"user": "Administrator", "chat_device_id": "d1",
-		}).insert(ignore_permissions=True)
+		if session_key:
+			frappe.get_doc({
+				"doctype": CHAT_SESSION, "session_key": session_key,
+				"user": "Administrator", "chat_device_id": "d1",
+			}).insert(ignore_permissions=True)
 		frappe.db.commit()
 		return doc.name
 
@@ -89,84 +103,145 @@ class TestSessionLifecycle(FrappeTestCase):
 		), patch("jarvis.selfhost.is_self_hosted", return_value=False):
 			return session_lifecycle.rotate_dormant_sessions()
 
-	# ---- dormant rotation -------------------------------------------
+	def _get(self, name, field):
+		return frappe.db.get_value(CONV, name, field)
 
-	def test_dormant_conversation_rotated(self):
+	# ---- retention window reader ------------------------------------
+
+	def test_retention_days_unset_defaults_to_30(self):
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, None)
+		self.assertEqual(session_lifecycle._retention_days(), 30)
+
+	def test_retention_days_zero_disables(self):
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 0)
+		self.assertEqual(session_lifecycle._retention_days(), 0)
+
+	def test_retention_days_below_floor_clamped(self):
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 3)
+		self.assertEqual(session_lifecycle._retention_days(), 7)
+
+	# ---- retention expiry (archive) ---------------------------------
+
+	def test_dormant_active_with_session_is_archived_and_freed(self):
 		name = self._conv(session_key="test-lc-dormant", idle_days=40)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 1)
+		self.assertEqual(summary["archived"], 1)
+		self.assertEqual(summary["sessions_freed"], 1)
 		sess.delete_session.assert_any_call("test-lc-dormant")
-		self.assertFalse(frappe.db.get_value(CONV, name, "session_key"))
-		self.assertFalse(
-			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-dormant"})
-		)
+		self.assertEqual(self._get(name, "status"), "Archived")
+		self.assertEqual(self._get(name, "auto_expired"), 1)
+		self.assertTrue(self._get(name, "expired_at"))
+		self.assertFalse(self._get(name, "session_key"))
+		self.assertFalse(frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-dormant"}))
+		# The owner gets a conversation:expired nudge so an open tab drops the row.
+		self.pub.assert_called_once()
+		self.assertEqual(self.pub.call_args[0][1]["kind"], "conversation:expired")
+		self.assertEqual(self.pub.call_args[0][1]["conversation_id"], name)
 
-	def test_two_rotations_in_one_run_no_unique_collision(self):
-		"""Regression: session_key is UNIQUE; clearing to '' (instead of
-		NULL) collided on the SECOND rotation of a run (1062)."""
+	def test_dormant_active_without_session_is_archived(self):
+		name = self._conv(idle_days=40)  # never had an agent turn
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["archived"], 1)
+		self.assertEqual(summary["sessions_freed"], 0)
+		self.assertEqual(self._get(name, "status"), "Archived")
+		self.assertEqual(self._get(name, "auto_expired"), 1)
+		self.pub.assert_called_once()
+
+	def test_starred_is_exempt(self):
+		name = self._conv(session_key="test-lc-star", idle_days=40, starred=1)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["archived"], 0)
+		sess.delete_session.assert_not_called()
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-star")  # kept, session and all
+		self.pub.assert_not_called()
+
+	def test_user_archived_with_session_is_freed_only(self):
+		name = self._conv(session_key="test-lc-uarch", idle_days=40, status="Archived")
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["sessions_freed"], 1)
+		self.assertEqual(summary["archived"], 0)          # already archived - not re-counted
+		sess.delete_session.assert_any_call("test-lc-uarch")
+		self.assertEqual(self._get(name, "status"), "Archived")
+		self.assertFalse(self._get(name, "session_key"))  # session reclaimed
+		self.assertEqual(self._get(name, "auto_expired"), 0)  # NOT a retention expiry
+		self.pub.assert_not_called()
+
+	def test_two_expiries_in_one_run_no_unique_collision(self):
+		"""Regression: session_key is UNIQUE; clearing to '' (instead of NULL)
+		collided on the SECOND expiry of a run (1062)."""
 		a = self._conv(session_key="test-lc-two-a", idle_days=40)
 		b = self._conv(session_key="test-lc-two-b", idle_days=41)
 		summary = self._run(_fake_sess())
-		self.assertEqual(summary["dormant_rotated"], 2)
-		self.assertFalse(frappe.db.get_value(CONV, a, "session_key"))
-		self.assertFalse(frappe.db.get_value(CONV, b, "session_key"))
+		self.assertEqual(summary["archived"], 2)
+		self.assertFalse(self._get(a, "session_key"))
+		self.assertFalse(self._get(b, "session_key"))
 
 	def test_fresh_conversation_untouched(self):
 		name = self._conv(session_key="test-lc-fresh", idle_days=2)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 0)
+		self.assertEqual(summary["archived"], 0)
 		sess.delete_session.assert_not_called()
-		self.assertEqual(
-			frappe.db.get_value(CONV, name, "session_key"), "test-lc-fresh"
-		)
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-fresh")
 
 	def test_dormant_with_inflight_row_skipped(self):
-		name = self._conv(
-			session_key="test-lc-busy", idle_days=40, streaming=True)
+		name = self._conv(session_key="test-lc-busy", idle_days=40, streaming=True)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 0)
+		self.assertEqual(summary["archived"], 0)
 		sess.delete_session.assert_not_called()
-		self.assertEqual(
-			frappe.db.get_value(CONV, name, "session_key"), "test-lc-busy"
-		)
+		self.assertEqual(self._get(name, "status"), "Active")
 
-	def test_gateway_delete_failure_keeps_bench_pointers(self):
-		"""A failed sessions.delete must leave session_key and the lookup
-		row intact so the next run retries."""
+	def test_retention_disabled_is_noop(self):
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 0)
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		frappe.db.commit()
+		name = self._conv(session_key="test-lc-dis", idle_days=99)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["archived"], 0)
+		sess.delete_session.assert_not_called()
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-dis")
+
+	def test_gateway_delete_failure_keeps_row_intact(self):
+		"""A failed sessions.delete must leave the conversation Active with its
+		session_key + lookup row so the next run retries - archiving it would
+		hide it from the only sweep that re-selects it."""
 		name = self._conv(session_key="test-lc-fail", idle_days=40)
 		sess = _fake_sess()
 		sess.delete_session.side_effect = RuntimeError("gateway said no")
 		with patch("frappe.log_error"):
 			summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 0)
+		self.assertEqual(summary["archived"], 0)
 		self.assertEqual(summary["errors"], 1)
-		self.assertEqual(
-			frappe.db.get_value(CONV, name, "session_key"), "test-lc-fail"
-		)
-		self.assertTrue(
-			frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-fail"})
-		)
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-fail")
+		self.assertTrue(frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-fail"}))
+		self.pub.assert_not_called()
 
 	def test_not_found_delete_treated_as_success(self):
-		"""Idempotent cleanup: a session already gone (e.g. a prior run
-		crashed between the gateway delete and the local commit) counts
-		as deleted, so the bench pointers finally clear instead of
-		retry-failing forever."""
+		"""Idempotent cleanup: a session already gone (a prior run crashed
+		between the gateway delete and the local commit) counts as deleted, so
+		the chat still archives instead of retry-failing forever."""
 		name = self._conv(session_key="test-lc-gone", idle_days=40)
 		sess = _fake_sess()
 		sess.delete_session.side_effect = RuntimeError(
 			"gateway error: session not found: test-lc-gone")
 		summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 1)
+		self.assertEqual(summary["archived"], 1)
 		self.assertEqual(summary["errors"], 0)
-		self.assertFalse(frappe.db.get_value(CONV, name, "session_key"))
+		self.assertEqual(self._get(name, "status"), "Archived")
+		self.assertFalse(self._get(name, "session_key"))
 
 	def test_one_bad_row_does_not_abort_the_batch(self):
-		"""Per-row isolation (turn_recovery's loop pattern): a bench-side
-		cleanup failure on row 1 logs and continues to row 2."""
+		"""Per-row isolation (turn_recovery's loop pattern): a bench-side write
+		failure on row 1 logs and continues to row 2."""
 		a = self._conv(session_key="test-lc-bad", idle_days=41)
 		b = self._conv(session_key="test-lc-good", idle_days=40)
 		sess = _fake_sess()
@@ -180,10 +255,34 @@ class TestSessionLifecycle(FrappeTestCase):
 		with patch("frappe.db.set_value", side_effect=flaky_set_value), \
 		     patch("frappe.log_error") as log_err:
 			summary = self._run(sess)
-		self.assertEqual(summary["dormant_rotated"], 1)
+		self.assertEqual(summary["archived"], 1)
 		self.assertEqual(summary["errors"], 1)
 		log_err.assert_called()
-		self.assertFalse(frappe.db.get_value(CONV, b, "session_key"))
+		self.assertEqual(self._get(b, "status"), "Archived")
+		self.assertFalse(self._get(b, "session_key"))
+
+	def test_secondary_delete_failure_rolls_back_partial_archive(self):
+		"""If the CHAT_SESSION lookup delete fails AFTER the conversation update
+		(same uncommitted row), the except rolls back so no half-archived state
+		(status=Archived + nulled key) rides to the next row's commit."""
+		name = self._conv(session_key="test-lc-partial", idle_days=40)
+		sess = _fake_sess()
+		real_delete = frappe.db.delete
+
+		def flaky_delete(doctype, *a, **k):
+			if doctype == CHAT_SESSION:
+				raise RuntimeError("lookup delete boom")
+			return real_delete(doctype, *a, **k)
+
+		with patch("frappe.db.delete", side_effect=flaky_delete), \
+		     patch("frappe.log_error"):
+			summary = self._run(sess)
+		self.assertEqual(summary["errors"], 1)
+		self.assertEqual(summary["archived"], 0)
+		# Rolled back: conversation stays Active with its key, not half-archived.
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-partial")
+		self.pub.assert_not_called()
 
 	# ---- orphan sweep -----------------------------------------------
 
@@ -234,8 +333,8 @@ class TestSessionLifecycle(FrappeTestCase):
 		sess = _fake_sess(entries=entries)
 		with patch.object(session_lifecycle, "BATCH_MAX", 4):
 			summary = self._run(sess)
-		# 3 dormant + only 1 orphan fit in the budget of 4.
-		self.assertEqual(summary["dormant_rotated"], 3)
+		# 3 expiries + only 1 orphan fit in the budget of 4.
+		self.assertEqual(summary["archived"], 3)
 		self.assertEqual(summary["orphans_reaped"], 1)
 		self.assertEqual(sess.delete_session.call_count, 4)
 
@@ -259,3 +358,27 @@ class TestSessionLifecycle(FrappeTestCase):
 		     patch("frappe.log_error"):
 			summary = session_lifecycle.rotate_dormant_sessions()
 		self.assertEqual(summary, {"skipped": "connect failed"})
+
+
+class TestRetentionSettingValidation(FrappeTestCase):
+	"""The floor lives in the Jarvis Settings controller so a fumbled tiny value
+	can't be saved and mass-archive on the next cron. 0 (never) and unset are
+	always allowed; anything 1-6 is rejected."""
+
+	def _validate(self, val):
+		s = frappe.get_single(SETTINGS)
+		s.conversation_retention_days = val
+		s._validate_conversation_retention()
+
+	def test_floor_rejects_below_7(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._validate(3)
+
+	def test_zero_is_allowed(self):
+		self._validate(0)  # never-delete sentinel
+
+	def test_seven_is_allowed(self):
+		self._validate(7)
+
+	def test_unset_is_allowed(self):
+		self._validate(None)


### PR DESCRIPTION
## What Problem This Solves

Conversations forgot everything from prior days: a chat opened yesterday, reopened today, only remembered today. Root cause is openclaw's default daily session reset wiping each session's transcript at the 04:00 boundary — the `openclaw.json` fix ships in **jarvis-fleet-agent#129**. This PR is the bench-side half: make Jarvis the single conversation-lifecycle owner and add configurable retention.

## Why This Change Was Made

- **`Jarvis Settings.conversation_retention_days`** (Int, default 30, floor ≥7, `0` = never) in a new "Chat History" section, validated in the settings controller (`_validate_conversation_retention` rejects 1–6).
- **Evolve the daily `session_lifecycle` sweep** from "rotate session" → "archive + free session": non-starred, idle-past-window, no-in-flight conversations are **archived** (`status=Archived` + `auto_expired` + `expired_at`, hidden from every `status='Active'` list) and their openclaw session freed; a `conversation:expired` realtime event drops the row from an open sidebar. Already user-archived chats that still hold a session are session-freed only. Starred chats are fully exempt.
- **Soft-delete, not hard-delete:** a `Jarvis Conversation` is referenced by five doctypes (Chat Message, Approval Request, Agent Run, Macro Run, Voice Note) plus File blobs; the permanent purge (full cascade) is a deferred follow-on. Archived chats are support-recoverable.
- **Retention read dodges a landmine:** `frappe.db.get_single_value` casts an unset Int Single field to `0`, indistinguishable from an explicit `0` (= disabled). The reader reads the **raw `tabSingles` value** so unset → 30 (default), `'0'` → disabled.

Frontend: `conversation:expired` handled in `ChatView.vue` (before the current-conv guard) → `shell.applyRemoteExpired` filters the row.

## User Impact

Chats keep full memory across days. Idle chats past the retention window (default 30d) are auto-archived (reversible, support-recoverable). **On-by-default-at-30 is a visible upgrade behavior:** today's sweep already frees sessions at 30d but keeps chats visible; now they also get hidden — a multi-day trickle for any backlog (batch-capped). Set `0` to disable.

## Evidence

`jarvis/tests/test_session_lifecycle.py` — **25** tests: archive (Active+session / Active-no-session / user-archived-freed-only), starred-exempt, in-flight-skip, unique-collision, gateway-fail-intact, per-row-isolation + rollback, retention reader (None/0/floor), batch cap, orphan sweep, gating, floor validation. Regression suites green: `test_settings` (13), `test_settings_on_update` (37), `test_jarvis_conversation` (6), `test_conversation_search` (9), `test_chat_api` (57). SPA builds clean.

Reviewed with Fable (advisor): added the per-row `frappe.db.rollback()`; Part-C rehydration + hard-purge + starvation-guard are recorded follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)