### PR TITLE
PWA: fix the worker that never installed, and render every message type the agent returns

### DIFF
--- a/pwa/src/api.js
+++ b/pwa/src/api.js
@@ -4,8 +4,9 @@
 // flow only exists in the native app because it lives on another origin.
 //
 // Deliberately its own module rather than an import of the SPA's api.js: this
-// surface needs ~10 of that file's 60-odd endpoints, and keeping it separate
+// surface needs ~20 of that file's 60-odd endpoints, and keeping it separate
 // means the phone bundle can't be grown by a change made for the desktop.
+// Voice is the exception — see transcribeAudio below.
 import { call } from "frappe-ui"
 
 const CHAT = "jarvis.chat.api."
@@ -16,14 +17,75 @@ export const archiveConversation = (conversation) =>
 	call(CHAT + "archive_conversation", { conversation })
 export const renameConversation = (conversation, title) =>
 	call(CHAT + "rename_conversation", { conversation, title })
+export const setStar = (conversation, starred) =>
+	call(CHAT + "set_star", { conversation, starred: starred ? 1 : 0 })
+export const setAutoApply = (conversation, value) =>
+	call(CHAT + "set_auto_apply", { conversation, value: value ? 1 : 0 })
+
+// Model name for the chat header + whether the mic is allowed to appear (STT is
+// off unless the admin configured a transcription key).
+export const getChatUiSettings = () => call(CHAT + "get_chat_ui_settings")
 
 // An empty `conversation` is allowed: the backend creates (or focuses) the
 // user's empty conversation and returns its id as `conversation_id`, which
 // saves the new-chat round-trip before the very first send.
-export const sendMessage = (conversation, message) =>
-	call(CHAT + "send_message", { conversation: conversation || "", message })
+export const sendMessage = (conversation, message, attachments = []) =>
+	call(CHAT + "send_message", {
+		conversation: conversation || "",
+		message,
+		...(attachments.length ? { attachments: JSON.stringify(attachments) } : {}),
+	})
 
 export const stopRun = (conversation, runId) =>
 	call(CHAT + "stop_run", { conversation, run_id: runId || "" })
 
+// A message's rich outputs (charts, generated images, files). `get_conversation`
+// returns the item list on `message.canvas`; this fetches one item's body.
+export const getCanvas = (message, name = "", dark = 0) =>
+	call(CHAT + "get_canvas", { message, name, dark })
+
+// Render-ready preview of a tabular/text artifact (xlsx/csv → sheets, txt → text).
+export const previewFile = (file_url) => call(CHAT + "preview_file", { file_url })
+
 export const listCustomSkills = () => call("jarvis.chat.custom_skills_api.list_custom_skills")
+
+// ── Write approvals (the write-safety gate) ─────────────────────────────────
+// A tool that would change ERP data is parked server-side and announced as an
+// `action:pending` event carrying a one-time token. confirm_tool is the ONLY
+// path that runs the parked call. There is no deny endpoint by design: dropping
+// the card leaves the token to expire, which is exactly what "no" means.
+export const listPendingConfirmations = (conversation) =>
+	call("jarvis.chat.actions_api.list_pending_confirmations", { conversation: conversation || "" })
+export const confirmTool = (token, conversation) =>
+	call("jarvis.chat.actions_api.confirm_tool", { token, conversation: conversation || "" })
+
+// ── Approval queue (Jarvis Approval: the agent asking a human a question) ───
+export const listApprovals = (status = "Pending", limit = 50) =>
+	call("jarvis.chat.approvals_api.list_approvals", { status, limit })
+export const pendingApprovalsCount = () => call("jarvis.chat.approvals_api.pending_count")
+export const decideApproval = (name, decision, approve) =>
+	call("jarvis.chat.approvals_api.decide", { name, decision, approve: approve ? 1 : 0 })
+
+// ── Attachments ────────────────────────────────────────────────────────────
+// Standard Frappe upload, private by default: a chat attachment is the user's
+// document, not a public asset. Same shape the SPA's uploadFile uses.
+export async function uploadFile(file) {
+	const fd = new FormData()
+	fd.append("file", file, file.name)
+	fd.append("is_private", "1")
+	const r = await fetch("/api/method/upload_file", {
+		method: "POST",
+		headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+		body: fd,
+		credentials: "include",
+	})
+	if (!r.ok) throw new Error(`Couldn't upload ${file.name} (${r.status})`)
+	const data = await r.json()
+	const f = data.message || data
+	return { file_url: f.file_url, file_name: f.file_name || file.name }
+}
+
+// Dictation goes through the SPA's module unchanged: same endpoint, same 25s
+// client cap, same error unwrapping. The mic is a place where two subtly
+// different clients would be two subtly different bugs.
+export { transcribeAudio } from "@shared/api/voice.js"

--- a/pwa/src/components/AppDrawer.vue
+++ b/pwa/src/components/AppDrawer.vue
@@ -4,11 +4,20 @@ import { store } from "../store"
 
 const router = useRouter()
 
-// Mirrors the native app's Drawer. Approvals are deliberately absent: they are
-// answered inside the chat where they arise (the same call the mobile app made
-// when it dropped its Approvals tab).
+// Two kinds of approval, and they are not the same thing:
+//  - a parked WRITE (action:pending) is answered in the chat that raised it —
+//    the context is the conversation, so that is where the card stays;
+//  - a Jarvis Approval is the agent stopping to ASK a human, and it can outlive
+//    the chat session. That queue needs a home you can reach from anywhere,
+//    which is here.
 const links = [
 	{ label: "Chats", to: "/", icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" },
+	{
+		label: "Approvals",
+		to: "/approvals",
+		icon: "M9 12l2 2 4-4M12 3l7 4v5c0 4.4-3 8.3-7 9-4-0.7-7-4.6-7-9V7z",
+		badge: true,
+	},
 	{ label: "Skills", to: "/skills", icon: "M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" },
 	{ label: "Account", to: "/account", icon: "M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" },
 ]
@@ -38,6 +47,9 @@ function go(to) {
 							<path :d="l.icon" />
 						</svg>
 						{{ l.label }}
+						<span v-if="l.badge && store.pendingApprovals" class="jv-drawer-count">
+							{{ store.pendingApprovals }}
+						</span>
 					</button>
 				</nav>
 
@@ -112,6 +124,17 @@ function go(to) {
 	height: 19px;
 	flex: none;
 	color: var(--ink5);
+}
+.jv-drawer-count {
+	margin-left: auto;
+	min-width: 20px;
+	padding: 2px 6px;
+	border-radius: 999px;
+	background: var(--amber-dot);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 600;
+	text-align: center;
 }
 .jv-drawer-foot {
 	margin: 8px;

--- a/pwa/src/components/CanvasFrame.vue
+++ b/pwa/src/components/CanvasFrame.vue
@@ -1,0 +1,97 @@
+<script setup>
+import { onMounted, ref, watch } from "vue"
+import * as api from "../api"
+
+// An agent-generated html/svg artifact (a chart, a diagram), rendered inline.
+//
+// It goes in a sandboxed iframe with `srcdoc`: the body is model-authored
+// markup, so it must not be able to touch this document, read the session, or
+// call the API. `sandbox` with no `allow-same-origin` gives it a null origin —
+// scripts may run (an ECharts artifact needs them) but they run in a box.
+const props = defineProps({
+	messageName: { type: String, required: true },
+	canvasName: { type: String, default: "" },
+	height: { type: Number, default: 260 },
+})
+
+const html = ref("")
+const loading = ref(true)
+const failed = ref(false)
+
+const isDark = () => (window.matchMedia("(prefers-color-scheme: dark)").matches ? 1 : 0)
+
+async function load() {
+	loading.value = true
+	failed.value = false
+	try {
+		const d = await api.getCanvas(props.messageName, props.canvasName, isDark())
+		if (d?.content) {
+			html.value = d.content
+		} else if (d?.data_url) {
+			html.value = `<!doctype html><body style="margin:0;background:transparent;display:flex;align-items:center;justify-content:center"><img src="${d.data_url}" style="max-width:100%;max-height:100%"></body>`
+		} else {
+			failed.value = true
+		}
+	} catch (e) {
+		console.error("Jarvis PWA: failed to load canvas", e)
+		failed.value = true
+	} finally {
+		loading.value = false
+	}
+}
+
+onMounted(load)
+watch(() => [props.messageName, props.canvasName], load)
+</script>
+
+<template>
+	<div class="jv-canvas" :style="{ height: `${props.height}px` }">
+		<div v-if="loading" class="jv-canvas-state"><span class="jv-spinner" /></div>
+		<div v-else-if="failed" class="jv-canvas-state">Couldn't load this chart.</div>
+		<iframe
+			v-else
+			:srcdoc="html"
+			sandbox="allow-scripts"
+			referrerpolicy="no-referrer"
+			title="Chart"
+			loading="lazy"
+		/>
+	</div>
+</template>
+
+<style scoped>
+.jv-canvas {
+	margin-top: 8px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+	overflow: hidden;
+}
+.jv-canvas iframe {
+	display: block;
+	width: 100%;
+	height: 100%;
+	border: 0;
+	background: transparent;
+}
+.jv-canvas-state {
+	display: grid;
+	place-items: center;
+	height: 100%;
+	font-size: 12px;
+	color: var(--ink5);
+}
+.jv-spinner {
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: 2px solid var(--card3);
+	border-top-color: var(--accent);
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/ChartCard.vue
+++ b/pwa/src/components/ChartCard.vue
@@ -1,0 +1,206 @@
+<script setup>
+import { computed } from "vue"
+
+// The agent's ```jarvis-chart``` spec, drawn as plain SVG.
+//
+// The desktop SPA renders these with ECharts. Pulling ECharts into the phone
+// bundle to draw a five-slice pie would roughly triple it, so — like the native
+// app — this hand-draws the shapes the agent actually emits (pie/donut/bar/
+// line/area) and degrades honestly for the rest.
+const props = defineProps({ spec: { type: Object, required: true } })
+
+const PALETTE = ["#8269F8", "#3B82F6", "#E8934E", "#22C55E", "#EC4899", "#14B8A6", "#F59E0B", "#8B5CF6"]
+
+const num = (v) => {
+	const n = Number(v)
+	return Number.isFinite(n) ? n : 0
+}
+
+const type = computed(() => String(props.spec.type || ""))
+const isPie = computed(() => type.value === "pie" || type.value === "donut")
+const isAxis = computed(() => ["bar", "line", "area"].includes(type.value))
+
+// ── pie / donut ─────────────────────────────────────────────────────────────
+const polar = (cx, cy, r, a) => [cx + r * Math.cos(a), cy + r * Math.sin(a)]
+
+function arcPath(cx, cy, rO, rI, a0, a1) {
+	const large = a1 - a0 > Math.PI ? 1 : 0
+	const [x1, y1] = polar(cx, cy, rO, a0)
+	const [x2, y2] = polar(cx, cy, rO, a1)
+	if (rI > 0) {
+		const [x3, y3] = polar(cx, cy, rI, a1)
+		const [x4, y4] = polar(cx, cy, rI, a0)
+		return `M${x1} ${y1} A${rO} ${rO} 0 ${large} 1 ${x2} ${y2} L${x3} ${y3} A${rI} ${rI} 0 ${large} 0 ${x4} ${y4} Z`
+	}
+	return `M${cx} ${cy} L${x1} ${y1} A${rO} ${rO} 0 ${large} 1 ${x2} ${y2} Z`
+}
+
+const slices = computed(() => {
+	const labels = (props.spec.x || []).map(String)
+	const values = (props.spec.series?.[0]?.data || []).map(num)
+	const data = values
+		.map((v, i) => ({ name: labels[i] ?? `#${i + 1}`, value: v, color: PALETTE[i % PALETTE.length] }))
+		.filter((d) => d.value > 0)
+	const total = data.reduce((a, d) => a + d.value, 0) || 1
+	const rI = type.value === "donut" ? 46 : 0
+	let angle = -Math.PI / 2
+	return data.map((d) => {
+		const a0 = angle
+		const a1 = angle + (d.value / total) * Math.PI * 2
+		angle = a1
+		return { ...d, pct: Math.round((d.value / total) * 100), d: arcPath(100, 100, 78, rI, a0, a1) }
+	})
+})
+
+// ── bar / line / area ───────────────────────────────────────────────────────
+const W = 300
+const H = 170
+const PAD = { l: 34, r: 10, t: 8, b: 30 }
+const plotW = W - PAD.l - PAD.r
+const plotH = H - PAD.t - PAD.b
+
+const cats = computed(() => (props.spec.x || []).map(String))
+const series = computed(() =>
+	(props.spec.series || []).map((s) => ({ name: s.name || "", data: (s.data || []).map(num) })),
+)
+const slots = computed(() => Math.max(cats.value.length, ...series.value.map((s) => s.data.length), 1))
+const maxV = computed(() => Math.max(1, ...series.value.flatMap((s) => s.data)))
+const step = computed(() => plotW / slots.value)
+const y = (v) => PAD.t + plotH - (v / maxV.value) * plotH
+
+const gridlines = computed(() =>
+	[0, 0.5, 1].map((t) => ({ y: PAD.t + plotH * (1 - t), label: Math.round(maxV.value * t) })),
+)
+
+const bars = computed(() => {
+	if (type.value !== "bar") return []
+	const out = []
+	const n = series.value.length
+	series.value.forEach((s, si) => {
+		const bw = (step.value * 0.7) / n
+		s.data.forEach((v, i) => {
+			out.push({
+				key: `${si}-${i}`,
+				x: PAD.l + i * step.value + step.value * 0.15 + si * bw,
+				y: y(v),
+				w: Math.max(1, bw - 1),
+				h: PAD.t + plotH - y(v),
+				fill: PALETTE[si % PALETTE.length],
+			})
+		})
+	})
+	return out
+})
+
+const lines = computed(() => {
+	if (type.value !== "line" && type.value !== "area") return []
+	return series.value.map((s, si) => {
+		const pts = s.data.map((v, i) => `${PAD.l + i * step.value + step.value / 2},${y(v)}`)
+		const color = PALETTE[si % PALETTE.length]
+		const area =
+			type.value === "area" && pts.length
+				? `M${PAD.l + step.value / 2},${PAD.t + plotH} L${pts.join(" L")} L${PAD.l + (s.data.length - 1) * step.value + step.value / 2},${PAD.t + plotH} Z`
+				: ""
+		return { key: si, d: pts.length ? `M${pts.join(" L")}` : "", area, color }
+	})
+})
+
+// Six labels max, or they overlap into mush at phone width.
+const catEvery = computed(() => Math.ceil(slots.value / 6))
+const catLabels = computed(() =>
+	cats.value
+		.map((c, i) => ({ i, x: PAD.l + i * step.value + step.value / 2, text: c.length > 8 ? `${c.slice(0, 7)}…` : c }))
+		.filter((c) => c.i % catEvery.value === 0),
+)
+</script>
+
+<template>
+	<div class="jv-chart">
+		<div v-if="props.spec.title" class="jv-chart-title">{{ props.spec.title }}</div>
+
+		<div v-if="isPie" class="jv-pie">
+			<svg width="180" height="180" viewBox="0 0 200 200">
+				<path v-for="(s, i) in slices" :key="i" :d="s.d" :fill="s.color" stroke="var(--card)" stroke-width="1.5" />
+			</svg>
+			<div class="jv-legend">
+				<span v-for="(s, i) in slices" :key="i" class="jv-legend-item">
+					<span class="jv-swatch" :style="{ background: s.color }" />{{ s.name }} · {{ s.pct }}%
+				</span>
+			</div>
+		</div>
+
+		<div v-else-if="isAxis">
+			<svg width="100%" :height="H" :viewBox="`0 0 ${W} ${H}`">
+				<g v-for="(g, i) in gridlines" :key="i">
+					<line :x1="PAD.l" :y1="g.y" :x2="W - PAD.r" :y2="g.y" stroke="var(--border)" stroke-width="1" />
+					<text :x="PAD.l - 5" :y="g.y + 3" font-size="9" fill="var(--ink4)" text-anchor="end">{{ g.label }}</text>
+				</g>
+
+				<rect v-for="b in bars" :key="b.key" :x="b.x" :y="b.y" :width="b.w" :height="b.h" rx="2" :fill="b.fill" />
+
+				<g v-for="l in lines" :key="l.key">
+					<path v-if="l.area" :d="l.area" :fill="l.color" fill-opacity="0.15" />
+					<path :d="l.d" :stroke="l.color" stroke-width="2" fill="none" />
+				</g>
+
+				<text v-for="c in catLabels" :key="c.i" :x="c.x" :y="H - 12" font-size="9" fill="var(--ink5)" text-anchor="middle">
+					{{ c.text }}
+				</text>
+			</svg>
+			<div v-if="series.length > 1" class="jv-legend">
+				<span v-for="(s, i) in series" :key="i" class="jv-legend-item">
+					<span class="jv-swatch" :style="{ background: PALETTE[i % PALETTE.length] }" />{{ s.name || `Series ${i + 1}` }}
+				</span>
+			</div>
+		</div>
+
+		<!-- A heatmap or a gauge is not worth hand-drawing for the phone; say so
+		     rather than silently dropping the agent's output. -->
+		<div v-else class="jv-chart-na">Chart ({{ type }}) — open the full workspace to view it.</div>
+	</div>
+</template>
+
+<style scoped>
+.jv-chart {
+	margin-top: 8px;
+	padding: 13px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+}
+.jv-chart-title {
+	margin-bottom: 10px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--ink9);
+}
+.jv-pie {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+.jv-legend {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 10px;
+	margin-top: 4px;
+	font-size: 11.5px;
+	color: var(--ink7);
+}
+.jv-legend-item {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+}
+.jv-swatch {
+	width: 9px;
+	height: 9px;
+	border-radius: 2px;
+	flex: none;
+}
+.jv-chart-na {
+	font-size: 12px;
+	color: var(--ink5);
+}
+</style>

--- a/pwa/src/components/Composer.vue
+++ b/pwa/src/components/Composer.vue
@@ -1,0 +1,264 @@
+<script setup>
+import { computed, ref } from "vue"
+
+// Attachments + dictation + send/stop. Split out of ChatView so the thread
+// screen stays about the thread.
+const props = defineProps({
+	modelValue: { type: String, default: "" },
+	sending: { type: Boolean, default: false },
+	attachments: { type: Array, default: () => [] },
+	micEnabled: { type: Boolean, default: false },
+	placeholder: { type: String, default: "Message Jarvis…" },
+})
+const emit = defineEmits(["update:modelValue", "send", "stop", "attach", "remove", "mic"])
+
+const inputEl = ref(null)
+const fileEl = ref(null)
+
+const uploading = computed(() => props.attachments.some((a) => a.uploading))
+// An attachment still uploading is not sendable: the worker would get a
+// file_url that doesn't exist yet.
+const canSend = computed(
+	() => !uploading.value && (props.modelValue.trim().length > 0 || props.attachments.some((a) => a.file_url)),
+)
+
+function onInput(e) {
+	emit("update:modelValue", e.target.value)
+	autoGrow()
+}
+
+function autoGrow() {
+	const el = inputEl.value
+	if (!el) return
+	el.style.height = "auto"
+	el.style.height = `${Math.min(el.scrollHeight, 120)}px`
+}
+
+// Enter sends on a physical keyboard; on a phone the on-screen Return key should
+// insert a newline, so only intercept when there is no soft keyboard.
+function onKeydown(e) {
+	if (e.key === "Enter" && !e.shiftKey && !/Mobi|Android/i.test(navigator.userAgent)) {
+		e.preventDefault()
+		if (canSend.value) emit("send")
+	}
+}
+
+function pick(e) {
+	const files = [...(e.target.files || [])]
+	if (files.length) emit("attach", files)
+	// Reset so picking the same file twice in a row still fires a change event.
+	e.target.value = ""
+}
+
+function reset() {
+	autoGrow()
+}
+defineExpose({ reset })
+</script>
+
+<template>
+	<div class="jv-composer jv-safe-bottom">
+		<div v-if="props.attachments.length" class="jv-atts">
+			<div v-for="a in props.attachments" :key="a.key" class="jv-att">
+				<img v-if="a.preview" class="jv-att-img" :src="a.preview" :alt="a.name" />
+				<div v-else class="jv-att-file">
+					<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+						<path d="M14 2v6h6" />
+					</svg>
+					<span class="jv-att-name">{{ a.name }}</span>
+				</div>
+				<div v-if="a.uploading" class="jv-att-busy"><span class="jv-spinner" /></div>
+				<button class="jv-att-x" aria-label="Remove attachment" @click="emit('remove', a.key)">
+					<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round">
+						<path d="M18 6 6 18M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+		</div>
+
+		<div class="jv-composer-row">
+			<input ref="fileEl" type="file" multiple hidden @change="pick" />
+			<button class="jv-icon-btn" aria-label="Attach a file" :disabled="props.sending" @click="fileEl.click()">
+				<svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+				</svg>
+			</button>
+
+			<div class="jv-pill">
+				<textarea
+					ref="inputEl"
+					rows="1"
+					:value="props.modelValue"
+					:placeholder="props.placeholder"
+					@input="onInput"
+					@keydown="onKeydown"
+				/>
+				<button v-if="props.micEnabled" class="jv-mic" aria-label="Dictate" @click="emit('mic')">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+						<path d="M19 10v2a7 7 0 0 1-14 0v-2M12 19v3" />
+					</svg>
+				</button>
+			</div>
+
+			<button v-if="props.sending" class="jv-send is-stop" aria-label="Stop" @click="emit('stop')">
+				<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2" /></svg>
+			</button>
+			<button v-else class="jv-send" aria-label="Send" :disabled="!canSend" @click="emit('send')">
+				<svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M12 19V5M5 12l7-7 7 7" />
+				</svg>
+			</button>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.jv-composer {
+	flex: none;
+	background: var(--menu-bar);
+	border-top: 1px solid var(--border);
+}
+.jv-composer-row {
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+	padding: 8px 12px 6px;
+}
+.jv-pill {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	align-items: flex-end;
+	border: 1px solid var(--border2);
+	border-radius: 19px;
+	background: var(--card);
+	padding-left: 14px;
+	padding-right: 4px;
+}
+.jv-pill:focus-within {
+	border-color: var(--accent);
+}
+.jv-pill textarea {
+	flex: 1;
+	min-width: 0;
+	resize: none;
+	border: 0;
+	outline: none;
+	background: transparent;
+	color: var(--ink9);
+	font: inherit;
+	font-size: 15px;
+	line-height: 1.35;
+	padding: 9px 0;
+	max-height: 120px;
+}
+.jv-mic {
+	display: grid;
+	place-items: center;
+	width: 30px;
+	height: 30px;
+	margin-bottom: 4px;
+	flex: none;
+	border: 0;
+	border-radius: 50%;
+	background: transparent;
+	color: var(--ink5);
+	cursor: pointer;
+}
+.jv-send {
+	flex: none;
+	width: 38px;
+	height: 38px;
+	display: grid;
+	place-items: center;
+	border: 0;
+	border-radius: 50%;
+	background: var(--inv-bg);
+	color: var(--inv-ink);
+	cursor: pointer;
+}
+.jv-send:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.jv-send.is-stop {
+	background: var(--inv-bg);
+}
+
+.jv-atts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	padding: 12px 14px 2px;
+}
+.jv-att {
+	position: relative;
+}
+.jv-att-img {
+	display: block;
+	width: 52px;
+	height: 52px;
+	object-fit: cover;
+	border: 1px solid var(--border);
+	border-radius: 9px;
+	background: var(--card2);
+}
+.jv-att-file {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	max-width: 180px;
+	height: 52px;
+	padding: 0 10px;
+	border: 1px solid var(--border);
+	border-radius: 9px;
+	background: var(--card2);
+	color: var(--ink6);
+}
+.jv-att-name {
+	font-size: 11.5px;
+	font-weight: 500;
+	color: var(--ink8);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-att-busy {
+	position: absolute;
+	inset: 0;
+	display: grid;
+	place-items: center;
+	border-radius: 9px;
+	background: rgba(0, 0, 0, 0.35);
+}
+.jv-att-x {
+	position: absolute;
+	top: -6px;
+	right: -6px;
+	display: grid;
+	place-items: center;
+	width: 20px;
+	height: 20px;
+	border: 2px solid var(--menu-bar);
+	border-radius: 999px;
+	background: var(--inv-bg);
+	color: var(--inv-ink);
+	cursor: pointer;
+	padding: 0;
+}
+.jv-spinner {
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	border: 2px solid rgba(255, 255, 255, 0.35);
+	border-top-color: #fff;
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/DecisionCard.vue
+++ b/pwa/src/components/DecisionCard.vue
@@ -1,0 +1,74 @@
+<script setup>
+// The agent has parked a write and is waiting for a human. This card is the
+// only thing standing between the model and your ERP data, so it is loud on
+// purpose: amber, full width, and it does not go away on its own.
+const props = defineProps({ summary: { type: String, required: true } })
+const emit = defineEmits(["open"])
+</script>
+
+<template>
+	<button class="jv-decision" @click="emit('open')">
+		<span class="jv-decision-icon">
+			<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+				<path d="M12 9v4M12 17h.01" />
+			</svg>
+		</span>
+		<span class="jv-decision-main">
+			<span class="jv-decision-title">{{ props.summary }}</span>
+			<span class="jv-decision-sub">Review and approve</span>
+		</span>
+		<svg class="jv-decision-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<path d="m9 18 6-6-6-6" />
+		</svg>
+	</button>
+</template>
+
+<style scoped>
+.jv-decision {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	width: 100%;
+	padding: 13px;
+	border: 1px solid var(--amber);
+	border-radius: 12px;
+	background: var(--amber-bg);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.jv-decision-icon {
+	display: grid;
+	place-items: center;
+	width: 34px;
+	height: 34px;
+	flex: none;
+	border-radius: 9px;
+	background: var(--amber);
+	color: #fff;
+}
+.jv-decision-main {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+.jv-decision-title {
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--ink9);
+	line-height: 1.35;
+}
+.jv-decision-sub {
+	margin-top: 1px;
+	font-size: 11.5px;
+	color: var(--amber);
+}
+.jv-decision-chev {
+	width: 18px;
+	height: 18px;
+	flex: none;
+	color: var(--amber);
+}
+</style>

--- a/pwa/src/components/DecisionSheet.vue
+++ b/pwa/src/components/DecisionSheet.vue
@@ -1,0 +1,282 @@
+<script setup>
+import { computed, ref, watch } from "vue"
+import { renderMarkdown } from "@shared/markdown.js"
+import Sheet from "./Sheet.vue"
+import * as api from "../api"
+
+// Approve / deny a parked write.
+//
+// Approve calls confirm_tool with the one-time token — the ONLY path that runs
+// the parked call. Deny has no endpoint by design: dropping the card leaves the
+// token to expire server-side, which is exactly what "no" means. The native app
+// puts a biometric prompt in front of approve; the browser has no equivalent it
+// can trust, and this surface is already behind the Frappe session, so the
+// confirmation itself is the gate.
+const props = defineProps({ action: { type: Object, default: null } })
+const emit = defineEmits(["close", "resolved"])
+
+const state = ref("review") // review | busy | approved | denied
+const error = ref("")
+
+// Fresh card → fresh sheet.
+watch(
+	() => props.action?.token,
+	() => {
+		state.value = "review"
+		error.value = ""
+	},
+)
+
+const summary = computed(
+	() => props.action?.summary || props.action?.tool || "Approve this change",
+)
+
+// The preview is either a ready-made string or {note, would} — `described` means
+// the note already says it all and the payload dump would just be noise.
+const previewHtml = computed(() => {
+	const pv = props.action?.preview
+	if (!pv) return ""
+	if (typeof pv === "string") return renderMarkdown(pv)
+	const parts = []
+	if (pv.note) parts.push(pv.note)
+	if (!pv.described && pv.would != null) {
+		const body = typeof pv.would === "string" ? pv.would : JSON.stringify(pv.would, null, 2)
+		parts.push("```\n" + body + "\n```")
+	}
+	return parts.length ? renderMarkdown(parts.join("\n\n")) : ""
+})
+
+function deny() {
+	if (state.value === "busy") return
+	state.value = "denied"
+	emit("resolved", props.action.token, "denied")
+}
+
+async function approve() {
+	if (state.value === "busy") return
+	error.value = ""
+	state.value = "busy"
+	try {
+		const r = await api.confirmTool(props.action.token, props.action.conversation)
+		if (r && r.ok === false) {
+			// The token is single-use and short-lived: a stale card must say so
+			// rather than look like a failure the user can retry.
+			if (r.error?.type === "InvalidConfirmation") {
+				error.value = "This confirmation is no longer valid — ask Jarvis to try again."
+				state.value = "review"
+				emit("resolved", props.action.token, "expired")
+				return
+			}
+			error.value = r.error?.message || r.reason || "Couldn't run this action."
+			state.value = "review"
+			return
+		}
+		state.value = "approved"
+		emit("resolved", props.action.token, "approved")
+	} catch (e) {
+		error.value = e?.message || "Couldn't run this action."
+		state.value = "review"
+	}
+}
+</script>
+
+<template>
+	<Sheet :open="!!props.action" @close="emit('close')">
+		<div v-if="props.action" class="jv-dsheet">
+			<div v-if="state === 'approved' || state === 'denied'" class="jv-dresult">
+				<div class="jv-dresult-icon" :class="state === 'approved' ? 'is-ok' : 'is-no'">
+					<svg v-if="state === 'approved'" viewBox="0 0 24 24" width="34" height="34" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M20 6 9 17l-5-5" />
+					</svg>
+					<svg v-else viewBox="0 0 24 24" width="32" height="32" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round">
+						<path d="M18 6 6 18M6 6l12 12" />
+					</svg>
+				</div>
+				<div class="jv-dresult-title">{{ state === "approved" ? "Approved" : "Denied" }}</div>
+				<div class="jv-dresult-sub">
+					{{
+						state === "approved"
+							? "Jarvis is running the action now. You'll see the result in the thread."
+							: "The change was rejected. Jarvis won't run this action."
+					}}
+				</div>
+				<button class="jv-btn is-primary" @click="emit('close')">Done</button>
+			</div>
+
+			<template v-else>
+				<div class="jv-dbody">
+					<div class="jv-dtags">
+						<span class="jv-dtag">NEEDS APPROVAL</span>
+						<span class="jv-dtool">{{ props.action.tool }}</span>
+					</div>
+					<div class="jv-dsummary">{{ summary }}</div>
+					<div v-if="previewHtml" class="jv-dpreview" v-html="previewHtml" />
+					<div v-if="error" class="jv-derror">{{ error }}</div>
+				</div>
+
+				<div class="jv-dactions">
+					<button class="jv-btn is-ghost" :disabled="state === 'busy'" @click="deny">Deny</button>
+					<button class="jv-btn is-primary jv-dapprove" :disabled="state === 'busy'" @click="approve">
+						<span v-if="state === 'busy'" class="jv-spinner" />
+						<span v-else>Approve</span>
+					</button>
+				</div>
+			</template>
+		</div>
+	</Sheet>
+</template>
+
+<style scoped>
+.jv-dsheet {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.jv-dbody {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 6px 20px 12px;
+}
+.jv-dtags {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+.jv-dtag {
+	padding: 2px 7px;
+	border-radius: 5px;
+	background: var(--amber);
+	color: #fff;
+	font-size: 10px;
+	font-weight: 600;
+}
+.jv-dtool {
+	font-size: 10.5px;
+	font-weight: 600;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	color: var(--ink5);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-dsummary {
+	font-size: 19px;
+	font-weight: 600;
+	line-height: 1.3;
+	letter-spacing: -0.2px;
+	color: var(--ink9);
+}
+.jv-dpreview {
+	margin-top: 12px;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--ink7);
+}
+.jv-dpreview :deep(pre) {
+	display: block;
+	max-width: 100%;
+	overflow-x: auto;
+	padding: 10px;
+	border-radius: 8px;
+	background: var(--card2);
+	font-size: 12px;
+}
+.jv-derror {
+	margin-top: 12px;
+	padding: 11px;
+	border-radius: 10px;
+	background: var(--red-bg);
+	color: var(--red);
+	font-size: 12.5px;
+	line-height: 1.4;
+}
+.jv-dactions {
+	display: flex;
+	gap: 10px;
+	flex: none;
+	padding: 12px 20px 16px;
+	border-top: 1px solid var(--border);
+}
+.jv-btn {
+	height: 48px;
+	padding: 0 18px;
+	border: 0;
+	border-radius: 12px;
+	font: inherit;
+	font-size: 15px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jv-btn.is-primary {
+	background: var(--accent-solid);
+	color: #fff;
+}
+.jv-btn.is-ghost {
+	width: 96px;
+	flex: none;
+	border: 1px solid var(--border2);
+	background: var(--card);
+	color: var(--ink8);
+}
+.jv-dapprove {
+	flex: 1;
+	display: grid;
+	place-items: center;
+}
+.jv-btn:disabled {
+	opacity: 0.6;
+}
+.jv-dresult {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 14px;
+	padding: 34px 26px 26px;
+	text-align: center;
+}
+.jv-dresult-icon {
+	display: grid;
+	place-items: center;
+	width: 70px;
+	height: 70px;
+	border-radius: 999px;
+}
+.jv-dresult-icon.is-ok {
+	background: var(--green-bg);
+	color: var(--green);
+}
+.jv-dresult-icon.is-no {
+	background: var(--red-bg);
+	color: var(--red);
+}
+.jv-dresult-title {
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--ink9);
+}
+.jv-dresult-sub {
+	font-size: 13.5px;
+	line-height: 1.5;
+	color: var(--ink5);
+}
+.jv-dresult .jv-btn {
+	align-self: stretch;
+	margin-top: 6px;
+}
+.jv-spinner {
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: 2px solid rgba(255, 255, 255, 0.35);
+	border-top-color: #fff;
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/FilePreviewSheet.vue
+++ b/pwa/src/components/FilePreviewSheet.vue
@@ -1,0 +1,256 @@
+<script setup>
+import { ref, watch } from "vue"
+import Sheet from "./Sheet.vue"
+import CanvasFrame from "./CanvasFrame.vue"
+import * as api from "../api"
+import { fileExt, previewKind } from "../lib/canvas"
+
+// Tap an artifact → see it, without leaving the chat. Spreadsheets and text
+// files come back already rendered by the bench (preview_file), so the phone
+// never downloads and parses an xlsx.
+const props = defineProps({
+	item: { type: Object, default: null },
+	messageName: { type: String, default: "" },
+})
+const emit = defineEmits(["close"])
+
+const preview = ref(null)
+const loading = ref(false)
+const error = ref("")
+const sheetIdx = ref(0)
+
+const kind = () => (props.item ? previewKind(props.item) : "file")
+
+watch(
+	() => props.item?.file_url,
+	async (url) => {
+		preview.value = null
+		error.value = ""
+		sheetIdx.value = 0
+		// Images, PDFs and canvases render straight from their URL; only the
+		// tabular/text kinds need the server to turn bytes into something a phone
+		// can show.
+		if (!url || ["image", "pdf", "html", "svg"].includes(kind())) return
+		loading.value = true
+		try {
+			preview.value = await api.previewFile(url)
+		} catch (e) {
+			error.value = e?.message || "Couldn't open this file."
+		} finally {
+			loading.value = false
+		}
+	},
+	{ immediate: true },
+)
+</script>
+
+<template>
+	<Sheet :open="!!props.item" @close="emit('close')">
+		<div v-if="props.item" class="jv-preview">
+			<div class="jv-preview-head">
+				<div class="jv-preview-title">{{ props.item.title || props.item.name || "Attachment" }}</div>
+				<a class="jv-preview-dl" :href="props.item.file_url" download target="_blank" rel="noopener">
+					<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" />
+					</svg>
+				</a>
+				<button class="jv-icon-btn" aria-label="Close" @click="emit('close')">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+						<path d="M18 6 6 18M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="jv-preview-body">
+				<img v-if="kind() === 'image'" class="jv-preview-img" :src="props.item.file_url" :alt="props.item.title || 'Image'" />
+
+				<iframe v-else-if="kind() === 'pdf'" class="jv-preview-pdf" :src="props.item.file_url" title="PDF" />
+
+				<CanvasFrame
+					v-else-if="kind() === 'html' || kind() === 'svg'"
+					:message-name="props.messageName"
+					:canvas-name="props.item.name"
+					:height="420"
+				/>
+
+				<div v-else-if="loading" class="jv-preview-state"><span class="jv-spinner" /></div>
+				<div v-else-if="error" class="jv-preview-state is-error">{{ error }}</div>
+
+				<template v-else-if="preview?.kind === 'table'">
+					<div v-if="(preview.sheets || []).length > 1" class="jv-tabs">
+						<button
+							v-for="(s, i) in preview.sheets"
+							:key="i"
+							class="jv-tab"
+							:class="{ 'is-on': sheetIdx === i }"
+							@click="sheetIdx = i"
+						>
+							{{ s.name || `Sheet ${i + 1}` }}
+						</button>
+					</div>
+					<!-- Wide sheets scroll inside this box; the sheet itself never
+					     scrolls sideways. -->
+					<div class="jv-tablewrap">
+						<table class="jv-table">
+							<tbody>
+								<tr v-for="(row, ri) in preview.sheets?.[sheetIdx]?.rows || []" :key="ri">
+									<td v-for="(cell, ci) in row" :key="ci">{{ cell }}</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</template>
+
+				<pre v-else-if="preview?.kind === 'text'" class="jv-preview-text">{{ preview.text }}</pre>
+
+				<div v-else class="jv-preview-state">
+					<div>{{ fileExt(props.item) }} file — no inline preview.</div>
+					<a class="jv-preview-open" :href="props.item.file_url" download target="_blank" rel="noopener">Download</a>
+				</div>
+			</div>
+		</div>
+	</Sheet>
+</template>
+
+<style scoped>
+.jv-preview {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.jv-preview-head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 8px 10px 16px;
+	border-bottom: 1px solid var(--border);
+	flex: none;
+}
+.jv-preview-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 14.5px;
+	font-weight: 600;
+	color: var(--ink9);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-preview-dl {
+	display: grid;
+	place-items: center;
+	width: 38px;
+	height: 38px;
+	flex: none;
+	border-radius: 10px;
+	color: var(--ink7);
+}
+.jv-preview-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 12px;
+}
+.jv-preview-img {
+	display: block;
+	max-width: 100%;
+	margin: 0 auto;
+	border-radius: 10px;
+}
+.jv-preview-pdf {
+	width: 100%;
+	height: 62dvh;
+	border: 0;
+	border-radius: 10px;
+	background: var(--card2);
+}
+.jv-preview-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 12px;
+	padding: 40px 16px;
+	font-size: 13px;
+	color: var(--ink5);
+	text-align: center;
+}
+.jv-preview-state.is-error {
+	color: var(--red);
+}
+.jv-preview-open {
+	padding: 10px 18px;
+	border-radius: 10px;
+	background: var(--accent-solid);
+	color: #fff;
+	font-size: 14px;
+	font-weight: 600;
+	text-decoration: none;
+}
+.jv-preview-text {
+	margin: 0;
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--ink8);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+.jv-tabs {
+	display: flex;
+	gap: 6px;
+	margin-bottom: 10px;
+	overflow-x: auto;
+}
+.jv-tab {
+	flex: none;
+	padding: 6px 12px;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	background: var(--card);
+	color: var(--ink6);
+	font: inherit;
+	font-size: 12.5px;
+	cursor: pointer;
+}
+.jv-tab.is-on {
+	background: var(--accent-bg);
+	border-color: transparent;
+	color: var(--accent);
+	font-weight: 600;
+}
+.jv-tablewrap {
+	overflow-x: auto;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+}
+.jv-table {
+	border-collapse: collapse;
+	font-size: 12px;
+}
+.jv-table td {
+	padding: 7px 10px;
+	border-bottom: 1px solid var(--border);
+	border-right: 1px solid var(--border);
+	color: var(--ink8);
+	white-space: nowrap;
+}
+.jv-table tr:first-child td {
+	background: var(--card2);
+	font-weight: 600;
+	color: var(--ink9);
+	position: sticky;
+	top: 0;
+}
+.jv-spinner {
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: 2px solid var(--card3);
+	border-top-color: var(--accent);
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/InstallBanner.vue
+++ b/pwa/src/components/InstallBanner.vue
@@ -1,36 +1,36 @@
 <script setup>
-import { onMounted, onUnmounted, ref } from "vue"
+import { computed, onMounted, ref } from "vue"
+import { installPrompt, isStandalone } from "../install"
 
 // "Add Jarvis to your home screen." Two different worlds:
-//  - Chrome/Android fires beforeinstallprompt, which we stash and replay on tap.
+//  - Chrome/Android fires beforeinstallprompt. That event is captured in
+//    src/install.js at module load, NOT here: it can fire in the same tick the
+//    app mounts, so a listener in onMounted loses the race and the banner never
+//    appears on a warm refresh. This component only reads the stashed event.
 //  - iOS Safari has no such event and never will; Add to Home Screen is a manual
 //    menu action, so there we can only tell the user where it is.
 const DISMISS_KEY = "jarvis.install.dismissed"
 
-const prompt = ref(null)
-const show = ref(false)
+const dismissed = ref(false)
 const isIos = ref(false)
 
-function standalone() {
-	return window.matchMedia("(display-mode: standalone)").matches || window.navigator.standalone === true
-}
-
-function onBeforeInstall(e) {
-	e.preventDefault()
-	prompt.value = e
-	show.value = true
-}
+// Show when we either hold a real prompt (Chrome) or know we're on iOS, unless
+// the user closed it or the app is already installed.
+const show = computed(
+	() => !dismissed.value && !isStandalone() && (!!installPrompt.value || isIos.value),
+)
 
 async function install() {
-	if (!prompt.value) return
-	prompt.value.prompt()
-	await prompt.value.userChoice
-	prompt.value = null
-	show.value = false
+	const e = installPrompt.value
+	if (!e) return
+	e.prompt()
+	await e.userChoice
+	// The event is single-use: once prompted it cannot be replayed.
+	installPrompt.value = null
 }
 
 function dismiss() {
-	show.value = false
+	dismissed.value = true
 	// Durable: a banner the user closed must not come back on every reload.
 	try {
 		localStorage.setItem(DISMISS_KEY, "1")
@@ -40,24 +40,16 @@ function dismiss() {
 }
 
 onMounted(() => {
-	let dismissed = false
 	try {
-		dismissed = localStorage.getItem(DISMISS_KEY) === "1"
+		dismissed.value = localStorage.getItem(DISMISS_KEY) === "1"
 	} catch {
 		/* ignore */
 	}
-	if (dismissed || standalone()) return
-
-	window.addEventListener("beforeinstallprompt", onBeforeInstall)
-
-	// iOS: no event to wait for, so decide from the UA and just show the hint.
 	const ua = window.navigator.userAgent
 	if (/iPhone|iPad|iPod/.test(ua) && /Safari/.test(ua) && !/CriOS|FxiOS/.test(ua)) {
 		isIos.value = true
-		show.value = true
 	}
 })
-onUnmounted(() => window.removeEventListener("beforeinstallprompt", onBeforeInstall))
 </script>
 
 <template>

--- a/pwa/src/components/InstallBanner.vue
+++ b/pwa/src/components/InstallBanner.vue
@@ -14,10 +14,20 @@ const DISMISS_KEY = "jarvis.install.dismissed"
 const dismissed = ref(false)
 const isIos = ref(false)
 
-// Show when we either hold a real prompt (Chrome) or know we're on iOS, unless
-// the user closed it or the app is already installed.
+// A browser will not install a page it does not trust. `isSecureContext` is
+// false on a plain-http LAN origin (http://192.168.x.x:8002 — how the bench is
+// reached from a phone in dev), and on such an origin Chrome never fires
+// beforeinstallprompt and navigator.serviceWorker is undefined. So the install
+// offer vanishes with no explanation, which reads as a bug in the app. Say what
+// is actually wrong instead. In production the app is only ever served over
+// HTTPS, so this branch is dead there.
+const insecure = ref(false)
+
+// Show when we either hold a real prompt (Chrome), know we're on iOS, or need
+// to explain why installing isn't possible here — unless the user closed it or
+// the app is already installed.
 const show = computed(
-	() => !dismissed.value && !isStandalone() && (!!installPrompt.value || isIos.value),
+	() => !dismissed.value && !isStandalone() && (!!installPrompt.value || isIos.value || insecure.value),
 )
 
 async function install() {
@@ -49,6 +59,7 @@ onMounted(() => {
 	if (/iPhone|iPad|iPod/.test(ua) && /Safari/.test(ua) && !/CriOS|FxiOS/.test(ua)) {
 		isIos.value = true
 	}
+	insecure.value = !window.isSecureContext
 })
 </script>
 
@@ -58,10 +69,11 @@ onMounted(() => {
 			<div class="jv-mark" style="width: 34px; height: 34px; font-size: 15px">J</div>
 			<div class="jv-install-text">
 				<strong>Install Jarvis</strong>
-				<span v-if="isIos">Tap Share, then “Add to Home Screen”.</span>
+				<span v-if="insecure">Open this site over https to install it — browsers won't install an insecure page.</span>
+				<span v-else-if="isIos">Tap Share, then “Add to Home Screen”.</span>
 				<span v-else>Keep it one tap away, like an app.</span>
 			</div>
-			<button v-if="!isIos" class="jv-install-cta" @click="install">Install</button>
+			<button v-if="!isIos && !insecure" class="jv-install-cta" @click="install">Install</button>
 			<button class="jv-icon-btn" aria-label="Dismiss" @click="dismiss">
 				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
 					<path d="M18 6 6 18M6 6l12 12" />

--- a/pwa/src/components/MessageMedia.vue
+++ b/pwa/src/components/MessageMedia.vue
@@ -1,0 +1,143 @@
+<script setup>
+import CanvasFrame from "./CanvasFrame.vue"
+import { fileExt, previewKind } from "../lib/canvas"
+
+// A message's `canvas` items: attached images, generated images, and agent
+// artifacts (charts, diagrams, PDFs, spreadsheets). The PWA used to ignore this
+// field entirely, so anything the agent produced other than prose simply never
+// appeared.
+//
+// Images render inline. html/svg artifacts render inline as a sandboxed frame.
+// Everything else becomes a chip that opens the preview sheet — a 4 MB xlsx has
+// no business auto-loading itself on mobile data.
+const props = defineProps({
+	items: { type: Array, default: () => [] },
+	messageName: { type: String, required: true },
+})
+const emit = defineEmits(["open"])
+</script>
+
+<template>
+	<template v-for="(item, i) in props.items" :key="item.name || item.file_url || i">
+		<button v-if="previewKind(item) === 'image'" class="jv-thumb" @click="emit('open', item)">
+			<!-- Same-origin: the session cookie authenticates the request, so a
+			     private file just works. (The native app has to attach headers.) -->
+			<img :src="item.file_url" :alt="item.title || 'Image'" loading="lazy" />
+			<span class="jv-thumb-tag">
+				<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
+				</svg>
+				{{ item.title || "Image" }}
+			</span>
+		</button>
+
+		<CanvasFrame
+			v-else-if="previewKind(item) === 'html' || previewKind(item) === 'svg'"
+			:message-name="props.messageName"
+			:canvas-name="item.name"
+		/>
+
+		<button v-else class="jv-artifact" @click="emit('open', item)">
+			<span class="jv-artifact-icon">
+				<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+					<path d="M14 2v6h6" />
+				</svg>
+			</span>
+			<span class="jv-artifact-main">
+				<span class="jv-artifact-title">{{ item.title || "Attachment" }}</span>
+				<span class="jv-artifact-sub">{{ fileExt(item) }} · open preview</span>
+			</span>
+			<svg class="jv-artifact-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m9 18 6-6-6-6" />
+			</svg>
+		</button>
+	</template>
+</template>
+
+<style scoped>
+.jv-thumb {
+	display: block;
+	position: relative;
+	margin-top: 8px;
+	max-width: 240px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card2);
+	overflow: hidden;
+	cursor: pointer;
+}
+.jv-thumb img {
+	display: block;
+	width: 240px;
+	height: 180px;
+	object-fit: cover;
+}
+.jv-thumb-tag {
+	position: absolute;
+	left: 8px;
+	bottom: 8px;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: 224px;
+	padding: 4px 8px;
+	border-radius: 999px;
+	background: rgba(0, 0, 0, 0.55);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-artifact {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	width: 100%;
+	margin-top: 8px;
+	padding: 11px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.jv-artifact-icon {
+	display: grid;
+	place-items: center;
+	width: 34px;
+	height: 34px;
+	flex: none;
+	border-radius: 9px;
+	background: var(--card2);
+	color: var(--ink6);
+}
+.jv-artifact-main {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+.jv-artifact-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--ink9);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-artifact-sub {
+	font-size: 11px;
+	color: var(--ink5);
+}
+.jv-artifact-chev {
+	width: 16px;
+	height: 16px;
+	flex: none;
+	color: var(--ink4);
+}
+</style>

--- a/pwa/src/components/RecordCards.vue
+++ b/pwa/src/components/RecordCards.vue
@@ -1,0 +1,79 @@
+<script setup>
+// The agent's ```jarvis-cards``` payload: a list of ERP records with a few
+// fields each. Rendered as cards instead of a markdown table — a table with six
+// columns is unreadable on a phone, and the raw JSON (what the PWA showed
+// before) is unreadable anywhere.
+const props = defineProps({ data: { type: Object, required: true } })
+</script>
+
+<template>
+	<div class="jv-cards">
+		<div v-if="props.data.title" class="jv-cards-title">{{ props.data.title }}</div>
+		<div v-for="(c, i) in props.data.cards" :key="i" class="jv-rcard">
+			<div v-if="c.title" class="jv-rcard-title">{{ c.title }}</div>
+			<div v-if="c.subtitle" class="jv-rcard-sub">{{ c.subtitle }}</div>
+			<div v-for="(f, fi) in c.fields" :key="fi" class="jv-rcard-field">
+				<span class="jv-rcard-label">{{ f.label }}</span>
+				<span class="jv-rcard-value">{{ f.value }}</span>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.jv-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 8px;
+}
+.jv-cards-title {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.4px;
+	text-transform: uppercase;
+	color: var(--ink5);
+}
+.jv-rcard {
+	padding: 12px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+}
+.jv-rcard-title {
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--ink9);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-rcard-sub {
+	margin-top: 1px;
+	font-size: 12px;
+	color: var(--ink5);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-rcard-field {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 6px;
+	font-size: 12px;
+}
+.jv-rcard-label {
+	color: var(--ink5);
+	flex: none;
+}
+.jv-rcard-value {
+	font-weight: 500;
+	color: var(--ink8);
+	text-align: right;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+</style>

--- a/pwa/src/components/Sheet.vue
+++ b/pwa/src/components/Sheet.vue
@@ -1,0 +1,86 @@
+<script setup>
+import { watch } from "vue"
+
+// Bottom sheet — the phone's dialog. A centred modal is a desktop idiom; on a
+// phone the thumb is at the bottom, so that is where a decision belongs.
+const props = defineProps({ open: { type: Boolean, default: false } })
+const emit = defineEmits(["close"])
+
+// While a sheet is up the thread behind it must not scroll under the user's
+// finger.
+watch(
+	() => props.open,
+	(open) => {
+		document.body.style.overflow = open ? "hidden" : ""
+	},
+)
+</script>
+
+<template>
+	<Transition name="jv-sheet">
+		<div v-if="props.open" class="jv-sheet-root">
+			<div class="jv-sheet-scrim" @click="emit('close')" />
+			<div class="jv-sheet jv-safe-bottom" role="dialog" aria-modal="true">
+				<div class="jv-sheet-grab" />
+				<slot />
+			</div>
+		</div>
+	</Transition>
+</template>
+
+<style scoped>
+.jv-sheet-root {
+	position: fixed;
+	inset: 0;
+	z-index: 60;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+}
+.jv-sheet-scrim {
+	position: absolute;
+	inset: 0;
+	background: var(--scrim);
+}
+.jv-sheet {
+	position: relative;
+	max-height: 88dvh;
+	display: flex;
+	flex-direction: column;
+	background: var(--card);
+	border-radius: 22px 22px 0 0;
+	border-top: 1px solid var(--border);
+	overflow: hidden;
+}
+.jv-sheet-grab {
+	width: 38px;
+	height: 4px;
+	margin: 8px auto 6px;
+	flex: none;
+	border-radius: 999px;
+	background: var(--card3);
+}
+
+.jv-sheet-enter-active,
+.jv-sheet-leave-active {
+	transition: opacity 0.18s ease;
+}
+.jv-sheet-enter-active .jv-sheet,
+.jv-sheet-leave-active .jv-sheet {
+	transition: transform 0.24s cubic-bezier(0.32, 0.72, 0, 1);
+}
+.jv-sheet-enter-from,
+.jv-sheet-leave-to {
+	opacity: 0;
+}
+.jv-sheet-enter-from .jv-sheet,
+.jv-sheet-leave-to .jv-sheet {
+	transform: translateY(100%);
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-sheet-enter-active .jv-sheet,
+	.jv-sheet-leave-active .jv-sheet {
+		transition: none;
+	}
+}
+</style>

--- a/pwa/src/components/SkillChips.vue
+++ b/pwa/src/components/SkillChips.vue
@@ -1,0 +1,37 @@
+<script setup>
+// "This answer used your Pricing skill." Small provenance chips, from the
+// agent's ```jarvis-skill``` block.
+const props = defineProps({ names: { type: Array, default: () => [] } })
+</script>
+
+<template>
+	<div v-if="props.names.length" class="jv-skills">
+		<span v-for="n in props.names" :key="n" class="jv-skill-chip">
+			<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M12 2 4 7v10l8 5 8-5V7z" />
+				<path d="M12 22V12M12 12 4 7M12 12l8-5" />
+			</svg>
+			{{ n }}
+		</span>
+	</div>
+</template>
+
+<style scoped>
+.jv-skills {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 8px;
+}
+.jv-skill-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 4px 9px;
+	border-radius: 999px;
+	background: var(--accent-bg);
+	color: var(--accent);
+	font-size: 11px;
+	font-weight: 500;
+}
+</style>

--- a/pwa/src/components/ThinkingIndicator.vue
+++ b/pwa/src/components/ThinkingIndicator.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { onMounted, onUnmounted, ref } from "vue"
+
+// A run can spend a long time in a tool before a single token streams back. A
+// bare spinner reads as "stuck", so say what it is plausibly doing — same
+// rotating copy as the native app.
+const WORDS = [
+	"Thinking…",
+	"Working on it…",
+	"Reading your records…",
+	"Reasoning it through…",
+	"Checking the details…",
+	"Putting it together…",
+	"Almost there…",
+]
+
+const props = defineProps({ label: { type: String, default: "" } })
+
+const i = ref(0)
+let timer = null
+
+onMounted(() => {
+	timer = setInterval(() => {
+		i.value = (i.value + 1) % WORDS.length
+	}, 2400)
+})
+onUnmounted(() => clearInterval(timer))
+</script>
+
+<template>
+	<div class="jv-thinking">
+		<span class="jv-dot" /><span class="jv-dot" /><span class="jv-dot" />
+		<span class="jv-thinking-text">{{ props.label || WORDS[i] }}</span>
+	</div>
+</template>
+
+<style scoped>
+.jv-thinking {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 2px;
+}
+.jv-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--accent);
+	animation: jv-pulse 1.2s infinite ease-in-out;
+}
+.jv-dot:nth-child(2) {
+	animation-delay: 0.17s;
+}
+.jv-dot:nth-child(3) {
+	animation-delay: 0.34s;
+}
+.jv-thinking-text {
+	margin-left: 5px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--ink5);
+}
+@keyframes jv-pulse {
+	0%,
+	60%,
+	100% {
+		opacity: 0.35;
+		transform: scale(0.85);
+	}
+	30% {
+		opacity: 1;
+		transform: scale(1.15);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-dot {
+		animation: none;
+		opacity: 0.6;
+	}
+}
+</style>

--- a/pwa/src/components/ToolsCard.vue
+++ b/pwa/src/components/ToolsCard.vue
@@ -1,0 +1,168 @@
+<script setup>
+import { ref } from "vue"
+
+// What the agent DID, as one collapsible card rather than a bubble per call.
+// Used twice: live (steps arriving on tool:start/tool:end) and settled (the
+// persisted `tool`-role rows, grouped). Collapsed by default once settled —
+// the answer is the point; the steps are the receipt.
+const props = defineProps({
+	title: { type: String, required: true },
+	steps: { type: Array, default: () => [] },
+	live: { type: Boolean, default: false },
+	defaultOpen: { type: Boolean, default: false },
+})
+
+const open = ref(props.defaultOpen)
+
+// Icons by intent, so a glance at the card reads as "it searched, then wrote".
+const ICONS = {
+	search: "M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM21 21l-4.35-4.35",
+	plus: "M12 5v14M5 12h14",
+	edit: "M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z",
+	trash: "M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6",
+	mail: "M4 4h16v16H4zM22 6l-10 7L2 6",
+	chart: "M18 20V10M12 20V4M6 20v-6",
+	file: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+	tool: "M14.7 6.3a4 4 0 0 1-5 5L4 17v3h3l5.7-5.7a4 4 0 0 1 5-5l2-2-3-3z",
+}
+
+function icon(name) {
+	const n = String(name || "").toLowerCase()
+	if (/search|list|find|query/.test(n)) return ICONS.search
+	if (/create|new/.test(n)) return ICONS.plus
+	if (/update|edit|set|amend/.test(n)) return ICONS.edit
+	if (/delete|cancel/.test(n)) return ICONS.trash
+	if (/mail|email|send/.test(n)) return ICONS.mail
+	if (/report|chart|aggregate|export/.test(n)) return ICONS.chart
+	if (/doc|get|read|schema|pdf/.test(n)) return ICONS.file
+	return ICONS.tool
+}
+</script>
+
+<template>
+	<div class="jv-tools">
+		<button class="jv-tools-head" @click="open = !open">
+			<span v-if="props.live" class="jv-spinner" />
+			<span class="jv-tools-title">{{ props.title }}</span>
+			<svg class="jv-chev" :class="{ 'is-open': open }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m6 9 6 6 6-6" />
+			</svg>
+		</button>
+
+		<div v-if="open" class="jv-tools-body">
+			<div v-for="s in props.steps" :key="s.id" class="jv-step">
+				<span class="jv-step-icon" :class="{ 'is-error': s.status === 'error' }">
+					<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path :d="icon(s.toolName || s.title)" />
+					</svg>
+				</span>
+				<span class="jv-step-title">{{ s.title }}</span>
+				<span v-if="s.status === 'running'" class="jv-spinner" />
+				<svg v-else-if="s.status === 'error'" class="jv-step-mark is-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round">
+					<path d="M18 6 6 18M6 6l12 12" />
+				</svg>
+				<svg v-else class="jv-step-mark is-done" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M20 6 9 17l-5-5" />
+				</svg>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.jv-tools {
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+	overflow: hidden;
+}
+.jv-tools-head {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	width: 100%;
+	padding: 10px 12px;
+	border: 0;
+	background: transparent;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.jv-tools-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--ink6);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-chev {
+	width: 15px;
+	height: 15px;
+	flex: none;
+	color: var(--ink4);
+	transition: transform 0.15s ease;
+}
+.jv-chev.is-open {
+	transform: rotate(180deg);
+}
+.jv-tools-body {
+	padding: 2px 12px 10px;
+}
+.jv-step {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	padding: 5px 0;
+}
+.jv-step-icon {
+	display: grid;
+	place-items: center;
+	width: 22px;
+	height: 22px;
+	flex: none;
+	border-radius: 6px;
+	background: var(--card2);
+	color: var(--ink6);
+}
+.jv-step-icon.is-error {
+	color: var(--red);
+}
+.jv-step-title {
+	flex: 1;
+	min-width: 0;
+	font-size: 12.5px;
+	line-height: 1.35;
+	color: var(--ink6);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-step-mark {
+	width: 14px;
+	height: 14px;
+	flex: none;
+}
+.jv-step-mark.is-done {
+	color: var(--green);
+}
+.jv-step-mark.is-error {
+	color: var(--red);
+}
+.jv-spinner {
+	width: 13px;
+	height: 13px;
+	flex: none;
+	border-radius: 50%;
+	border: 2px solid var(--card3);
+	border-top-color: var(--accent);
+	animation: jv-spin 0.7s linear infinite;
+}
+@keyframes jv-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/pwa/src/components/VoiceSheet.vue
+++ b/pwa/src/components/VoiceSheet.vue
@@ -1,0 +1,189 @@
+<script setup>
+import { ref, watch } from "vue"
+// The SAME recorder the desktop SPA's composer mic uses — one MediaRecorder
+// wrapper, one set of permission/format/duration-cap bugs, fixed once. The
+// transcript endpoint is shared too (api.transcribeAudio re-exports the SPA's
+// voice module), so the phone inherits the admin-configured STT credentials
+// exactly like the web does.
+import { useAudioRecorder } from "@shared/composables/useAudioRecorder.js"
+import Sheet from "./Sheet.vue"
+import { transcribeAudio } from "../api"
+import { formatDuration } from "../lib/time"
+
+const props = defineProps({ open: { type: Boolean, default: false } })
+const emit = defineEmits(["close", "transcript"])
+
+const busy = ref(false)
+const error = ref("")
+
+const rec = useAudioRecorder({
+	// The recorder hard-stops at 300s. If that fires while the user is still
+	// holding the sheet open, transcribe what we got rather than dropping it.
+	onAutoStop: (take) => finish(take, "Recording stopped at the 5-minute limit."),
+})
+
+watch(
+	() => props.open,
+	(open) => {
+		error.value = ""
+		busy.value = false
+		if (open) rec.start()
+		else rec.cancel()
+	},
+)
+
+async function finish(take, note = "") {
+	if (!take?.blob) {
+		emit("close")
+		return
+	}
+	busy.value = true
+	error.value = note
+	try {
+		const r = await transcribeAudio(take.blob, { durationS: take.durationS })
+		const text = (r?.text || "").trim()
+		if (!text) {
+			error.value = "Nothing was picked up. Try again, closer to the mic."
+			busy.value = false
+			return
+		}
+		emit("transcript", text)
+		emit("close")
+	} catch (e) {
+		error.value = e?.message || "Couldn't transcribe that."
+	} finally {
+		busy.value = false
+	}
+}
+
+async function stop() {
+	const take = await rec.stop()
+	await finish(take)
+}
+
+function cancel() {
+	rec.cancel()
+	emit("close")
+}
+</script>
+
+<template>
+	<Sheet :open="props.open" @close="cancel">
+		<div class="jv-voice">
+			<div class="jv-voice-mic" :class="{ 'is-live': rec.state === 'recording' }">
+				<svg viewBox="0 0 24 24" width="30" height="30" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+					<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+					<path d="M19 10v2a7 7 0 0 1-14 0v-2M12 19v3" />
+				</svg>
+			</div>
+
+			<div class="jv-voice-title">
+				{{ busy ? "Transcribing…" : rec.state === "recording" ? formatDuration(rec.durationS) : "Ready" }}
+			</div>
+			<div class="jv-voice-sub">
+				{{
+					busy
+						? "Turning your words into text."
+						: rec.state === "recording"
+							? "Speak, then tap Done. The text lands in the composer."
+							: "Tap Done when you've finished."
+				}}
+			</div>
+
+			<div v-if="error || rec.error" class="jv-voice-error">{{ error || rec.error }}</div>
+
+			<div class="jv-voice-actions">
+				<button class="jv-btn is-ghost" @click="cancel">Cancel</button>
+				<button class="jv-btn is-primary" :disabled="busy || rec.state !== 'recording'" @click="stop">
+					Done
+				</button>
+			</div>
+		</div>
+	</Sheet>
+</template>
+
+<style scoped>
+.jv-voice {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 22px 24px 24px;
+	text-align: center;
+}
+.jv-voice-mic {
+	display: grid;
+	place-items: center;
+	width: 76px;
+	height: 76px;
+	margin-bottom: 6px;
+	border-radius: 999px;
+	background: var(--accent-bg);
+	color: var(--accent);
+}
+.jv-voice-mic.is-live {
+	animation: jv-mic 1.6s ease-in-out infinite;
+}
+@keyframes jv-mic {
+	0%,
+	100% {
+		box-shadow: 0 0 0 0 rgba(130, 105, 248, 0.35);
+	}
+	50% {
+		box-shadow: 0 0 0 12px rgba(130, 105, 248, 0);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.jv-voice-mic.is-live {
+		animation: none;
+	}
+}
+.jv-voice-title {
+	font-size: 20px;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	color: var(--ink9);
+}
+.jv-voice-sub {
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--ink5);
+}
+.jv-voice-error {
+	margin-top: 4px;
+	padding: 10px 12px;
+	border-radius: 10px;
+	background: var(--red-bg);
+	color: var(--red);
+	font-size: 12.5px;
+	line-height: 1.4;
+}
+.jv-voice-actions {
+	display: flex;
+	gap: 10px;
+	align-self: stretch;
+	margin-top: 14px;
+}
+.jv-btn {
+	flex: 1;
+	height: 48px;
+	border: 0;
+	border-radius: 12px;
+	font: inherit;
+	font-size: 15px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jv-btn.is-primary {
+	background: var(--accent-solid);
+	color: #fff;
+}
+.jv-btn.is-ghost {
+	border: 1px solid var(--border2);
+	background: var(--card);
+	color: var(--ink8);
+}
+.jv-btn:disabled {
+	opacity: 0.55;
+}
+</style>

--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -24,8 +24,12 @@
 	--accent-solid: #7154f5;
 	--accent-bg: #eceafb;
 	--green: #218352;
+	--green-bg: #e4faeb;
 	--red: #cc2929;
 	--red-bg: #ffe7e7;
+	--amber: #b35309;
+	--amber-bg: #fff7d3;
+	--amber-dot: #db7706;
 	--inv-bg: #171717;
 	--inv-ink: #ffffff;
 	--scrim: rgba(20, 20, 22, 0.34);
@@ -51,8 +55,12 @@
 		--accent-solid: #8269f8;
 		--accent-bg: #1d1934;
 		--green: #58c08e;
+		--green-bg: #0b2e1c;
 		--red: #eb4d52;
 		--red-bg: #361515;
+		--amber: #e7a13b;
+		--amber-bg: #2e2206;
+		--amber-dot: #e37d00;
 		--inv-bg: #f8f8f8;
 		--inv-ink: #0f0f0f;
 		--scrim: rgba(0, 0, 0, 0.55);
@@ -95,6 +103,11 @@ body {
 /* The composer clears the home indicator. */
 .jv-safe-bottom {
 	padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Overlays (the drawer) escape .jv-app's padding, so they own the notch. */
+.jv-safe-top {
+	padding-top: env(safe-area-inset-top);
 }
 
 .jv-bar {

--- a/pwa/src/install.js
+++ b/pwa/src/install.js
@@ -1,0 +1,38 @@
+import { ref } from "vue"
+
+/**
+ * The install prompt, captured the moment Chrome offers it.
+ *
+ * This listener is deliberately registered at MODULE load — imported by main.js
+ * before the app mounts — and not inside a component's onMounted. Chrome fires
+ * `beforeinstallprompt` as soon as the page meets the install criteria, which on
+ * a warm refresh (bundle precached, worker already active) lands in the same
+ * millisecond the app mounts (measured: event at 141ms, mount at 141ms). A
+ * listener attached in onMounted therefore loses the race intermittently, the
+ * event is gone for that page load, and the install banner silently never
+ * appears — exactly the "no install option on refresh" symptom.
+ *
+ * The event fires at most once per page load, so it must be stashed rather than
+ * waited for: calling prompt() later is what actually opens the install dialog.
+ */
+export const installPrompt = ref(null)
+
+// True once the app is running as an installed app — there is nothing left to offer.
+export function isStandalone() {
+	return (
+		window.matchMedia("(display-mode: standalone)").matches ||
+		window.navigator.standalone === true
+	)
+}
+
+window.addEventListener("beforeinstallprompt", (e) => {
+	// Suppress Chrome's own mini-infobar; we surface the offer in-app instead.
+	e.preventDefault()
+	installPrompt.value = e
+})
+
+// Chrome fires this after a successful install; drop the stale event so the
+// banner doesn't linger on the next navigation.
+window.addEventListener("appinstalled", () => {
+	installPrompt.value = null
+})

--- a/pwa/src/lib/blocks.js
+++ b/pwa/src/lib/blocks.js
@@ -1,0 +1,147 @@
+// The agent embeds structured payloads in ```jarvis-*``` fences. They are part
+// of the reply's raw text, so a surface that renders the content verbatim shows
+// the user a wall of JSON. Every other surface strips them and renders the ones
+// it supports — the desktop SPA (ChatView) and the native app
+// (components/chat/messages.tsx) both do this, with these same regexes; the PWA
+// was the only one that didn't, which is why record lists and charts arrived as
+// raw code blocks.
+//
+// Keep the STRIP list a superset of what we render: an unrendered block must
+// still disappear from the prose rather than leak.
+
+const CARDS_RE = /```jarvis-cards[ \t]*\n([\s\S]*?)```/
+const SKILL_RE = /```jarvis-skill[ \t]*\n([\s\S]*?)```/
+const CHART_RE = /```jarvis-chart[ \t]*\n([\s\S]*?)```/g
+const XY_RE = /```mermaid[ \t]*\n([\s\S]*?)```/g
+
+const STRIP_RES = [
+	/```jarvis-action[ \t]*\n[\s\S]*?```/g,
+	/```confirm[ \t]*\n[\s\S]*?```/g,
+	/```jarvis-ask[ \t]*\n[\s\S]*?```/g,
+	/```jarvis-cards[ \t]*\n[\s\S]*?```/g,
+	/```jarvis-skill[ \t]*\n[\s\S]*?```/g,
+	/```jarvis-macro[ \t]*\n[\s\S]*?```/g,
+	/```jarvis-chart[ \t]*\n[\s\S]*?```/g,
+	/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g,
+]
+
+/** The agent's prose, with every control block removed. */
+export function stripAgentBlocks(text) {
+	let t = text || ""
+	for (const re of STRIP_RES) t = t.replace(re, "")
+	return t.replace(/\n{3,}/g, "\n\n").trim()
+}
+
+/** ```jarvis-cards``` → {title, cards:[{title, subtitle, doctype, name, fields}]}. */
+export function parseCards(content) {
+	if (!content || !content.includes("jarvis-cards")) return null
+	const mt = content.match(CARDS_RE)
+	if (!mt) return null
+	try {
+		const a = JSON.parse(mt[1].trim())
+		const list = Array.isArray(a) ? a : a?.cards
+		if (!Array.isArray(list)) return null
+		const cards = list
+			.slice(0, 60)
+			.map((c) => ({
+				title: String(c.title || c.name || "").trim(),
+				subtitle: String(c.subtitle || "").trim(),
+				doctype: String(c.doctype || "").trim(),
+				name: String(c.name || "").trim(),
+				fields: Array.isArray(c.fields)
+					? c.fields.slice(0, 12).map((f) => ({
+							label: String(f.label || ""),
+							value: String(f.value != null ? f.value : ""),
+						}))
+					: [],
+			}))
+			.filter((c) => c.title || c.fields.length)
+		if (!cards.length) return null
+		return { title: String(a?.title || ""), cards }
+	} catch {
+		// Mid-stream the JSON is still being typed out — render nothing until it parses.
+		return null
+	}
+}
+
+/** ```jarvis-skill``` → the skill names that shaped this reply. */
+export function parseSkillsUsed(content) {
+	if (!content || !content.includes("jarvis-skill")) return []
+	const mt = content.match(SKILL_RE)
+	if (!mt) return []
+	return [
+		...new Set(
+			mt[1]
+				.split(/[\n,]+/)
+				.map((s) => s.trim().replace(/^[-*]\s*/, ""))
+				.filter(Boolean)
+				.map((s) => s.replace(/^custom-/, "")),
+		),
+	].slice(0, 6)
+}
+
+const TYPES = new Set([
+	"bar", "line", "area", "pie", "donut", "scatter",
+	"bubble", "heatmap", "boxplot", "radar", "funnel", "gauge",
+])
+
+/** Minimal mermaid xychart-beta → chart spec (same subset the SPA understands). */
+function parseXychart(body) {
+	const text = String(body || "")
+	if (!/^\s*xychart-beta\b/.test(text)) return null
+	const split = (s) => {
+		const out = []
+		const re = /"([^"]*)"|'([^']*)'|([^,]+)/g
+		let m
+		while ((m = re.exec(s))) {
+			const v = (m[1] ?? m[2] ?? m[3] ?? "").trim().replace(/^["']|["']$/g, "")
+			if (v) out.push(v)
+		}
+		return out
+	}
+	const tM = text.match(/title[ \t]+"([^"]*)"/)
+	const xM = text.match(/x-axis[ \t]+\[([^\]]*)\]/)
+	const x = xM ? split(xM[1]) : []
+	const series = []
+	let anyBar = false
+	const re = /\b(bar|line)[ \t]+(?:"([^"]*)"[ \t]+)?\[([^\]]*)\]/g
+	let m
+	while ((m = re.exec(text))) {
+		const data = split(m[3]).map(Number).filter((n) => !Number.isNaN(n))
+		if (!data.length) continue
+		if (m[1] === "bar") anyBar = true
+		series.push({ name: m[2] || "Value", data })
+	}
+	if (!series.length) return null
+	const spec = { type: anyBar ? "bar" : "line", x, series }
+	if (tM) spec.title = tM[1].trim()
+	return spec
+}
+
+/** Every chart spec in a message: ```jarvis-chart``` blocks + mermaid xycharts. */
+export function parseCharts(content) {
+	if (!content || (!content.includes("jarvis-chart") && !content.includes("xychart-beta"))) return []
+	const specs = []
+	for (const mt of content.matchAll(CHART_RE)) {
+		try {
+			const s = JSON.parse(mt[1].trim())
+			if (s && typeof s === "object" && TYPES.has(s.type) && Array.isArray(s.series)) specs.push(s)
+		} catch {
+			/* incomplete mid-stream JSON */
+		}
+	}
+	for (const mt of content.matchAll(XY_RE)) {
+		const s = parseXychart(mt[1])
+		if (s) specs.push(s)
+	}
+	return specs
+}
+
+/** A tool row's terminal state. The backend writes free-text statuses, so match
+ * loosely rather than enumerating them. */
+export function toolStatus(raw) {
+	const s = String(raw || "").toLowerCase()
+	if (/err|fail/.test(s)) return "error"
+	if (/run|start|progress|pending/.test(s)) return "running"
+	return "done"
+}

--- a/pwa/src/lib/canvas.js
+++ b/pwa/src/lib/canvas.js
@@ -1,0 +1,30 @@
+// How to show one canvas item. The backend's `type` is authoritative when it is
+// set, but agent-written artifacts don't always carry one — fall back to the
+// extension rather than dropping the item on the floor.
+
+const IMG_RE = /\.(png|jpe?g|gif|webp|avif|bmp|heic)$/i
+const SHEET_RE = /\.(xlsx|xls|csv)$/i
+const TEXT_RE = /\.(txt|md|json|ya?ml|log|csv)$/i
+
+export function previewKind(item) {
+	const t = String(item?.type || "").toLowerCase()
+	if (t.includes("image")) return "image"
+	if (t.includes("pdf")) return "pdf"
+	if (t.includes("svg")) return "svg"
+	if (t.includes("html")) return "html"
+
+	const url = String(item?.file_url || item?.name || "")
+	if (IMG_RE.test(url)) return "image"
+	if (/\.pdf$/i.test(url)) return "pdf"
+	if (/\.svg$/i.test(url)) return "svg"
+	if (/\.html?$/i.test(url)) return "html"
+	if (SHEET_RE.test(url)) return "sheet"
+	if (TEXT_RE.test(url)) return "text"
+	return "file"
+}
+
+/** "INVOICE.PDF" → "PDF". Shown on the artifact chip. */
+export function fileExt(item) {
+	const m = String(item?.name || item?.file_url || "").match(/\.([a-z0-9]+)$/i)
+	return m ? m[1].toUpperCase() : "FILE"
+}

--- a/pwa/src/lib/time.js
+++ b/pwa/src/lib/time.js
@@ -1,12 +1,17 @@
 // Frappe hands back naive datetimes in the site timezone ("2026-07-13 14:02:11").
 // Safari refuses to parse that form, so normalise before constructing a Date --
 // otherwise every timestamp on iOS reads "Invalid Date".
-export function relativeTime(value) {
-	if (!value) return ""
-	const then = new Date(String(value).replace(" ", "T"))
-	if (Number.isNaN(then.getTime())) return ""
+export function parseTs(value) {
+	if (!value) return NaN
+	const t = new Date(String(value).replace(" ", "T")).getTime()
+	return Number.isNaN(t) ? NaN : t
+}
 
-	const secs = Math.max(0, (Date.now() - then.getTime()) / 1000)
+export function relativeTime(value) {
+	const then = parseTs(value)
+	if (Number.isNaN(then)) return ""
+
+	const secs = Math.max(0, (Date.now() - then) / 1000)
 	if (secs < 60) return "just now"
 	const mins = Math.floor(secs / 60)
 	if (mins < 60) return `${mins}m ago`
@@ -14,5 +19,22 @@ export function relativeTime(value) {
 	if (hours < 24) return `${hours}h ago`
 	const days = Math.floor(hours / 24)
 	if (days < 7) return `${days}d ago`
-	return then.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+	return new Date(then).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+/** Whole seconds → "8s" / "1m 12s". Used for "how long did that take". */
+export function formatDuration(seconds) {
+	const s = Math.max(0, Math.round(seconds))
+	return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`
+}
+
+/** How long a row took to settle: created → last written. Null when it is too
+ * short to be interesting (a sub-2s reply doesn't need a stopwatch on it). */
+export function spanBetween(from, to, minSeconds = 2) {
+	const t0 = parseTs(from)
+	const t1 = parseTs(to)
+	if (Number.isNaN(t0) || Number.isNaN(t1) || t1 <= t0) return ""
+	const s = Math.round((t1 - t0) / 1000)
+	if (s < minSeconds) return ""
+	return formatDuration(s)
 }

--- a/pwa/src/main.js
+++ b/pwa/src/main.js
@@ -4,6 +4,11 @@ import { setConfig, frappeRequest, resourcesPlugin } from "frappe-ui"
 import App from "./App.vue"
 import router from "./router"
 import { initSocket } from "./socket"
+// Side-effect import, and it must stay ABOVE the mount: it registers the
+// beforeinstallprompt listener at module load. Chrome can fire that event in the
+// same tick the app mounts, so capturing it from a component's onMounted loses
+// the race on a warm refresh and the install offer silently disappears.
+import "./install"
 import "./index.css"
 
 setConfig("resourceFetcher", frappeRequest)

--- a/pwa/src/router.js
+++ b/pwa/src/router.js
@@ -7,6 +7,7 @@ import ChatsView from "./views/ChatsView.vue"
 const routes = [
 	{ path: "/", name: "Chats", component: ChatsView },
 	{ path: "/c/:id", name: "Chat", component: () => import("./views/ChatView.vue"), props: true },
+	{ path: "/approvals", name: "Approvals", component: () => import("./views/ApprovalsView.vue") },
 	{ path: "/skills", name: "Skills", component: () => import("./views/SkillsView.vue") },
 	{ path: "/account", name: "Account", component: () => import("./views/AccountView.vue") },
 	{ path: "/:pathMatch(.*)*", redirect: "/" },

--- a/pwa/src/store.js
+++ b/pwa/src/store.js
@@ -2,12 +2,15 @@ import { reactive } from "vue"
 import * as api from "./api"
 
 // One small shared store: the conversation list is read by the chats screen and
-// written by the chat screen (a reply retitles the chat), and the drawer is
-// opened from whichever screen is on top.
+// written by the chat screen (a reply retitles the chat), the drawer is opened
+// from whichever screen is on top, and the pending-approval count has to be
+// visible from anywhere — an approval the agent is waiting on is not something
+// the user should have to go looking for.
 export const store = reactive({
 	drawerOpen: false,
 	conversations: [],
 	loaded: false,
+	pendingApprovals: 0,
 
 	async loadConversations() {
 		try {
@@ -19,6 +22,15 @@ export const store = reactive({
 			console.error("Jarvis PWA: failed to load conversations", e)
 		} finally {
 			this.loaded = true
+		}
+	},
+
+	async loadPendingCount() {
+		try {
+			const n = await api.pendingApprovalsCount()
+			this.pendingApprovals = Number(n) || 0
+		} catch {
+			/* a badge is not worth an error state */
 		}
 	},
 

--- a/pwa/src/sw.js
+++ b/pwa/src/sw.js
@@ -18,11 +18,29 @@ import { clientsClaim } from "workbox-core"
 import { NavigationRoute, registerRoute, setCatchHandler } from "workbox-routing"
 import { NetworkOnly } from "workbox-strategies"
 
-const OFFLINE_URL = "/assets/jarvis/pwa/offline.html"
+const BASE = "/assets/jarvis/pwa/"
+const OFFLINE_URL = `${BASE}offline.html`
+
+// Every precache URL must be ABSOLUTE. Workbox resolves relative entries against
+// the worker's own location, and this worker is served from the site root
+// (/jarvis-mobile.sw.js — see jarvis/pwa.py), not from the bundle directory, so
+// a relative "foo.js" would resolve to /foo.js and 404.
+//
+// vite.config.js pins the globbed entries with modifyURLPrefix, but that is not
+// enough on its own: vite-plugin-pwa APPENDS its own manifest.webmanifest entry
+// to the list AFTER those transforms run, so that one entry stays relative. A
+// single 404 rejects the install event, Chrome discards the registration, and
+// the app silently ends up with no service worker at all — which is exactly what
+// happened ("bad-precaching-response: /manifest.webmanifest, status 404").
+// Normalising here makes the worker correct regardless of plugin ordering.
+const precacheManifest = (self.__WB_MANIFEST || []).map((entry) => {
+	const e = typeof entry === "string" ? { url: entry, revision: null } : entry
+	return e.url.startsWith("/") ? e : { ...e, url: BASE + e.url.replace(/^\.?\//, "") }
+})
 
 // JS/CSS/icons + the offline card. index.html is excluded at build (see
 // vite.config.js): the real shell is Jinja-rendered per request.
-precacheAndRoute(self.__WB_MANIFEST)
+precacheAndRoute(precacheManifest)
 cleanupOutdatedCaches()
 
 // Navigations always go to the network — the shell carries a fresh CSRF token

--- a/pwa/src/views/ApprovalsView.vue
+++ b/pwa/src/views/ApprovalsView.vue
@@ -1,0 +1,292 @@
+<script setup>
+import { onMounted, ref } from "vue"
+import { useRouter } from "vue-router"
+import { renderMarkdown } from "@shared/markdown.js"
+import * as api from "../api"
+import { store } from "../store"
+import { relativeTime } from "../lib/time"
+
+// The approval queue: the agent stopped and asked a human a question. It lives
+// on the phone precisely because the person who can answer is usually not at a
+// desk — that is the whole reason the queue exists.
+const router = useRouter()
+
+const rows = ref([])
+const loaded = ref(false)
+const openRow = ref(null)
+const answer = ref("")
+const busy = ref("")
+const error = ref("")
+
+async function load() {
+	try {
+		const r = await api.listApprovals("Pending", 50)
+		rows.value = Array.isArray(r) ? r : []
+	} catch (e) {
+		error.value = e?.message || "Couldn't load approvals."
+	} finally {
+		loaded.value = true
+		store.loadPendingCount()
+	}
+}
+
+async function decide(row, decision, approve) {
+	const text = (decision || "").trim()
+	if (!text) return
+	busy.value = row.name
+	error.value = ""
+	try {
+		await api.decideApproval(row.name, text, approve)
+		// The decision resumes the agent in the chat it came from, so leave the
+		// board and go watch it happen.
+		rows.value = rows.value.filter((r) => r.name !== row.name)
+		openRow.value = null
+		answer.value = ""
+		store.loadPendingCount()
+		if (row.conversation) router.push(`/c/${row.conversation}`)
+	} catch (e) {
+		error.value = e?.message || "Couldn't record that decision."
+	} finally {
+		busy.value = ""
+	}
+}
+
+function toggle(row) {
+	openRow.value = openRow.value === row.name ? null : row.name
+	answer.value = ""
+	error.value = ""
+}
+
+onMounted(load)
+</script>
+
+<template>
+	<div class="jv-bar">
+		<button class="jv-icon-btn" aria-label="Back" @click="router.push('/')">
+			<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+				<path d="m15 18-6-6 6-6" />
+			</svg>
+		</button>
+		<div class="jv-title">Approvals</div>
+	</div>
+
+	<div class="jv-scroll">
+		<div v-if="!loaded" class="jv-empty">Loading…</div>
+
+		<div v-else-if="!rows.length" class="jv-empty">
+			<div style="font-size: 15px; font-weight: 600; color: var(--ink9)">Nothing to approve</div>
+			<div style="font-size: 14px; line-height: 1.5">
+				When Jarvis needs a decision before it acts, it lands here.
+			</div>
+		</div>
+
+		<ul v-else class="jv-alist">
+			<li v-for="r in rows" :key="r.name" class="jv-acard">
+				<button class="jv-ahead" @click="toggle(r)">
+					<div class="jv-amain">
+						<div class="jv-atitle">{{ r.title || r.question || "Jarvis needs a decision" }}</div>
+						<div class="jv-ameta">
+							<span v-if="r.document_type" class="jv-atag">{{ r.document_type }}</span>
+							{{ relativeTime(r.creation) }}
+						</div>
+					</div>
+					<svg class="jv-achev" :class="{ 'is-open': openRow === r.name }" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="m6 9 6 6 6-6" />
+					</svg>
+				</button>
+
+				<div v-if="openRow === r.name" class="jv-abody">
+					<div v-if="r.question" class="jv-aquestion">{{ r.question }}</div>
+					<div v-if="r.context_md" class="jv-md" v-html="renderMarkdown(r.context_md)" />
+
+					<!-- The agent may offer named options; otherwise the human types a
+					     free-text answer. Either way the reply goes back as a normal
+					     chat turn, so the agent sees it exactly like any message. -->
+					<div v-if="r.options?.length" class="jv-aoptions">
+						<button
+							v-for="o in r.options"
+							:key="o"
+							class="jv-aoption"
+							:disabled="busy === r.name"
+							@click="decide(r, o, true)"
+						>
+							{{ o }}
+						</button>
+					</div>
+
+					<template v-else>
+						<textarea v-model="answer" class="jv-atext" rows="2" placeholder="Your answer…" />
+						<div class="jv-aactions">
+							<button class="jv-btn is-ghost" :disabled="busy === r.name" @click="decide(r, answer || 'Rejected', false)">
+								Reject
+							</button>
+							<button class="jv-btn is-primary" :disabled="busy === r.name || !answer.trim()" @click="decide(r, answer, true)">
+								Approve
+							</button>
+						</div>
+					</template>
+
+					<div v-if="error && busy !== r.name" class="jv-aerror">{{ error }}</div>
+				</div>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<style scoped>
+.jv-alist {
+	list-style: none;
+	margin: 0;
+	padding: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.jv-acard {
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--card);
+	overflow: hidden;
+}
+.jv-ahead {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 13px 12px;
+	border: 0;
+	background: transparent;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.jv-amain {
+	flex: 1;
+	min-width: 0;
+}
+.jv-atitle {
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--ink9);
+	line-height: 1.35;
+}
+.jv-ameta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 4px;
+	font-size: 11.5px;
+	color: var(--ink5);
+}
+.jv-atag {
+	padding: 2px 6px;
+	border-radius: 5px;
+	background: var(--card2);
+	color: var(--ink6);
+	font-weight: 500;
+}
+.jv-achev {
+	flex: none;
+	color: var(--ink4);
+	transition: transform 0.15s ease;
+}
+.jv-achev.is-open {
+	transform: rotate(180deg);
+}
+.jv-abody {
+	padding: 0 12px 12px;
+	border-top: 1px solid var(--border);
+	padding-top: 12px;
+}
+.jv-aquestion {
+	font-size: 13.5px;
+	line-height: 1.5;
+	color: var(--ink8);
+}
+.jv-md {
+	margin-top: 8px;
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--ink6);
+}
+.jv-md :deep(pre) {
+	display: block;
+	max-width: 100%;
+	overflow-x: auto;
+	padding: 10px;
+	border-radius: 8px;
+	background: var(--card2);
+	font-size: 12px;
+}
+.jv-aoptions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 12px;
+}
+.jv-aoption {
+	padding: 10px 14px;
+	border: 1px solid var(--border2);
+	border-radius: 10px;
+	background: var(--card);
+	color: var(--ink8);
+	font: inherit;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+}
+.jv-aoption:active {
+	background: var(--accent-bg);
+	border-color: transparent;
+	color: var(--accent);
+}
+.jv-atext {
+	width: 100%;
+	margin-top: 12px;
+	padding: 10px 12px;
+	border: 1px solid var(--border2);
+	border-radius: 10px;
+	background: var(--card);
+	color: var(--ink9);
+	font: inherit;
+	font-size: 14px;
+	line-height: 1.4;
+	resize: none;
+	outline: none;
+}
+.jv-atext:focus {
+	border-color: var(--accent);
+}
+.jv-aactions {
+	display: flex;
+	gap: 8px;
+	margin-top: 10px;
+}
+.jv-btn {
+	flex: 1;
+	height: 44px;
+	border: 0;
+	border-radius: 10px;
+	font: inherit;
+	font-size: 14.5px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jv-btn.is-primary {
+	background: var(--accent-solid);
+	color: #fff;
+}
+.jv-btn.is-ghost {
+	border: 1px solid var(--border2);
+	background: var(--card);
+	color: var(--ink8);
+}
+.jv-btn:disabled {
+	opacity: 0.55;
+}
+.jv-aerror {
+	margin-top: 10px;
+	font-size: 12.5px;
+	color: var(--red);
+}
+</style>

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -1,11 +1,27 @@
 <script setup>
-import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from "vue"
+import { computed, defineAsyncComponent, inject, nextTick, onMounted, onUnmounted, ref, watch } from "vue"
 import { useRouter } from "vue-router"
 // The desktop SPA's renderer — dependency-free, and sharing it means an agent
 // reply reads identically on both surfaces.
 import { renderMarkdown } from "@shared/markdown.js"
 import * as api from "../api"
 import { store } from "../store"
+import { parseCards, parseCharts, parseSkillsUsed, stripAgentBlocks, toolStatus } from "../lib/blocks"
+import { spanBetween } from "../lib/time"
+import ChartCard from "../components/ChartCard.vue"
+import Composer from "../components/Composer.vue"
+import DecisionCard from "../components/DecisionCard.vue"
+import DecisionSheet from "../components/DecisionSheet.vue"
+import FilePreviewSheet from "../components/FilePreviewSheet.vue"
+import MessageMedia from "../components/MessageMedia.vue"
+import RecordCards from "../components/RecordCards.vue"
+import Sheet from "../components/Sheet.vue"
+import SkillChips from "../components/SkillChips.vue"
+import ThinkingIndicator from "../components/ThinkingIndicator.vue"
+import ToolsCard from "../components/ToolsCard.vue"
+// Lazy: the voice sheet pulls in the shared audio recorder, and a user who never
+// taps the mic should never pay for it.
+const VoiceSheet = defineAsyncComponent(() => import("../components/VoiceSheet.vue"))
 
 const props = defineProps({ id: { type: String, default: "" } })
 const router = useRouter()
@@ -15,20 +31,118 @@ const socket = inject("$socket")
 // first send, which is when the backend creates (or focuses) it and tells us
 // its real id.
 const convId = ref(props.id === "new" ? "" : props.id)
+const conversation = ref(null)
 const messages = ref([])
 const input = ref("")
-const busy = ref(false)
-const status = ref("")
-const runId = ref(null)
 const loading = ref(false)
-const scroller = ref(null)
-const inputEl = ref(null)
+const sendBusy = ref(false)
+const errorBanner = ref("")
+const attachments = ref([])
+const pending = ref([]) // parked writes awaiting approval
+const settings = ref(null)
 
-const title = computed(() => {
-	const row = store.conversations.find((c) => c.name === convId.value)
-	return row?.title || "New chat"
+// The turn in flight. Held separately from `messages` because it is not durable
+// yet: the row exists server-side but its content arrives as a stream.
+const live = ref(null) // { runId, messageId, text, tools[] }
+// Stop is a UI-level cancel too — the backend may still finish the turn, so
+// ignore what comes back rather than letting a "stopped" reply reappear.
+const ignoredRuns = ref(new Set())
+
+const decision = ref(null)
+const preview = ref(null)
+const voiceOpen = ref(false)
+const menuOpen = ref(false)
+const renaming = ref(false)
+const renameText = ref("")
+const menuError = ref("")
+const starred = ref(false)
+const autoApply = ref(false)
+
+const scroller = ref(null)
+const composer = ref(null)
+
+const sending = computed(() => !!live.value || sendBusy.value)
+const title = computed(
+	() => conversation.value?.title || store.conversations.find((c) => c.name === convId.value)?.title || "New chat",
+)
+const model = computed(() => conversation.value?.model_override || settings.value?.llm_model || "")
+const micEnabled = computed(() => !!settings.value?.stt_enabled)
+
+// Everything the agent's raw text carries, unpacked once per message. Done here
+// rather than in the template: the template would re-run it on every render, and
+// markdown + JSON parsing per message per frame is exactly how a chat thread
+// starts dropping frames as it grows.
+const view = (m) => {
+	const content = m.content || ""
+	const html = renderMarkdown(stripAgentBlocks(content))
+	const cards = parseCards(content)
+	const charts = parseCharts(content)
+	return {
+		html,
+		cards,
+		charts,
+		skills: parseSkillsUsed(content),
+		took: spanBetween(m.creation, m.modified),
+		// A turn can end with nothing to show: the runtime aborts a stalled model
+		// call and writes an empty assistant row. With no prose, no cards, no
+		// canvas and no error text, the thread would render a blank gap and the
+		// user would be left wondering whether anything happened at all.
+		empty: !html && !cards && !charts.length && !m.error && !(m.canvas || []).length,
+	}
+}
+
+// ── thread assembly ─────────────────────────────────────────────────────────
+// Tool rows BELONG to the assistant turn that ran them. The worker creates the
+// assistant placeholder first and appends each tool row after it, so in `seq`
+// order the tools trail the answer — render them literally and the thread reads
+// backwards ("16" … then "Ran 1 step"). Attach them to the assistant message
+// instead (the same rule the desktop SPA's activityByAssistant uses) and show
+// the card above the prose: it worked, then it answered.
+//
+// Each turn therefore renders as ONE card, not one bubble per call — a wall of
+// "get_list → completed" is not an answer.
+const items = computed(() => {
+	const out = []
+	let current = null // the assistant item tool rows attach to
+	for (const m of messages.value) {
+		// The streaming row renders from `live`, not from its (empty) stored copy.
+		if (live.value && (m.name === live.value.messageId || (m.role === "assistant" && m.streaming))) continue
+
+		if (m.role === "user") {
+			current = null
+			out.push({ type: "user", key: m.name, msg: m })
+		} else if (m.role === "tool") {
+			// A tool row with no assistant turn to hang off (a recovered or
+			// truncated thread) still has to appear — never silently drop it.
+			if (!current) {
+				current = { type: "assistant", key: m.name, msg: null, view: null, tools: [] }
+				out.push(current)
+			}
+			current.tools.push(m)
+		} else {
+			current = { type: "assistant", key: m.name, msg: m, view: view(m), tools: [] }
+			out.push(current)
+		}
+	}
+	return out
 })
 
+function toolsTitle(msgs) {
+	const dur = spanBetween(msgs[0]?.creation, msgs[msgs.length - 1]?.modified || msgs[msgs.length - 1]?.creation, 1)
+	const n = msgs.length
+	const steps = `${n} step${n === 1 ? "" : "s"}`
+	return dur ? `Worked for ${dur} · ${steps}` : `Ran ${steps}`
+}
+
+const toolSteps = (msgs) =>
+	msgs.map((m) => ({
+		id: m.name,
+		title: m.content || m.tool_name || "Tool call",
+		toolName: m.tool_name,
+		status: toolStatus(m.tool_status),
+	}))
+
+// ── scrolling ───────────────────────────────────────────────────────────────
 function atBottom() {
 	const el = scroller.value
 	if (!el) return true
@@ -42,16 +156,23 @@ async function scrollToBottom(force = false) {
 	if (stick && scroller.value) scroller.value.scrollTop = scroller.value.scrollHeight
 }
 
+// ── loading ─────────────────────────────────────────────────────────────────
 async function load(force = false) {
 	if (!convId.value) return
 	loading.value = true
 	try {
 		const d = await api.getConversation(convId.value)
+		conversation.value = d?.conversation || null
 		messages.value = d?.messages || []
-		// A reply still streaming when we (re)opened the chat: restore the spinner
-		// from the durable flag rather than assuming the turn is over.
+		autoApply.value = !!d?.conversation?.auto_apply
+		const row = store.conversations.find((c) => c.name === convId.value)
+		if (row) starred.value = !!row.starred
+		// A reply still streaming when we (re)opened the chat: restore the busy
+		// state from the durable flag rather than assuming the turn is over.
 		const last = messages.value[messages.value.length - 1]
-		busy.value = !!(last && last.role === "assistant" && last.streaming)
+		if (last?.role === "assistant" && last.streaming && !live.value) {
+			live.value = { runId: "", messageId: last.name, text: last.content || "", tools: [] }
+		}
 		await scrollToBottom(force)
 	} catch (e) {
 		console.error("Jarvis PWA: failed to load conversation", e)
@@ -60,20 +181,45 @@ async function load(force = false) {
 	}
 }
 
+// Parked writes survive a reload: re-ask rather than leaving an approval the
+// user can never reach.
+async function loadPending() {
+	if (!convId.value) return
+	try {
+		const r = await api.listPendingConfirmations(convId.value)
+		if (r?.ok && r.data) pending.value = r.data.pending.filter((p) => p.conversation === convId.value)
+	} catch {
+		/* the cards also arrive live; a failed resync is not worth a banner */
+	}
+}
+
+// ── sending ─────────────────────────────────────────────────────────────────
 async function send() {
 	const text = input.value.trim()
-	if (!text || busy.value) return
+	const ready = attachments.value.filter((a) => a.file_url)
+	if ((!text && !ready.length) || sending.value) return
 
+	errorBanner.value = ""
 	input.value = ""
-	autoGrow()
+	composer.value?.reset()
+	attachments.value = []
+	sendBusy.value = true
 	// Optimistic user bubble; the server echoes it back on the next load.
-	messages.value.push({ name: `local-${Date.now()}`, role: "user", content: text })
-	busy.value = true
-	status.value = "Thinking…"
+	messages.value.push({ name: `local-${Date.now()}`, role: "user", content: text, optimistic: true })
 	await scrollToBottom(true)
 
 	try {
-		const res = await api.sendMessage(convId.value, text)
+		const res = await api.sendMessage(
+			convId.value,
+			text,
+			ready.map((a) => ({ file_url: a.file_url, file_name: a.name })),
+		)
+		if (res?.ok === false) {
+			sendBusy.value = false
+			errorBanner.value = res.reason || "Couldn't send that message."
+			messages.value = messages.value.filter((m) => !m.optimistic)
+			return
+		}
 		// First send of a brand-new chat: adopt the id the backend just created,
 		// and put the row in the list without a refetch.
 		const id = res?.conversation_id
@@ -83,113 +229,227 @@ async function send() {
 			store.loadConversations()
 		}
 	} catch (e) {
-		busy.value = false
-		status.value = ""
-		messages.value.push({
-			name: `err-${Date.now()}`,
-			role: "assistant",
-			content: "That didn't reach Jarvis. Check your connection and try again.",
-			error: 1,
-		})
-		await scrollToBottom(true)
+		sendBusy.value = false
+		errorBanner.value = "That didn't reach Jarvis. Check your connection and try again."
+		messages.value = messages.value.filter((m) => !m.optimistic)
 	}
 }
 
 async function stop() {
-	if (!convId.value) return
-	busy.value = false
-	status.value = ""
+	const runId = live.value?.runId || ""
+	// Ignore anything still arriving for this run: the backend may well finish
+	// the turn anyway, and a reply the user stopped must not reappear.
+	if (runId) ignoredRuns.value.add(runId)
+	live.value = null
+	sendBusy.value = false
 	try {
-		await api.stopRun(convId.value, runId.value)
+		await api.stopRun(convId.value, runId)
 	} catch {
 		// Best-effort: the UI stop stands even if the turn finishes server-side.
 	}
+	load()
 }
 
-// The single realtime channel. `assistant:delta` carries the CUMULATIVE text,
-// not an increment — assign it, never append, or the reply doubles up.
+// ── attachments ─────────────────────────────────────────────────────────────
+async function attach(files) {
+	errorBanner.value = ""
+	const staged = files.map((f, i) => ({
+		key: `att-${Date.now()}-${i}`,
+		name: f.name,
+		file: f,
+		// Local thumbnail while it uploads — a picked photo should appear instantly.
+		preview: f.type.startsWith("image/") ? URL.createObjectURL(f) : "",
+		uploading: true,
+	}))
+	attachments.value.push(...staged)
+
+	await Promise.all(
+		staged.map(async (a) => {
+			try {
+				const up = await api.uploadFile(a.file)
+				const row = attachments.value.find((x) => x.key === a.key)
+				if (row) {
+					row.file_url = up.file_url
+					row.uploading = false
+				}
+			} catch (e) {
+				removeAttachment(a.key)
+				errorBanner.value = e?.message || `Couldn't upload ${a.name}.`
+			}
+		}),
+	)
+}
+
+function removeAttachment(key) {
+	const row = attachments.value.find((a) => a.key === key)
+	if (row?.preview) URL.revokeObjectURL(row.preview)
+	attachments.value = attachments.value.filter((a) => a.key !== key)
+}
+
+function onTranscript(text) {
+	input.value = input.value ? `${input.value} ${text}` : text
+}
+
+// ── conversation menu ───────────────────────────────────────────────────────
+async function toggleStar() {
+	const next = !starred.value
+	starred.value = next
+	try {
+		await api.setStar(convId.value, next)
+		store.loadConversations()
+	} catch {
+		starred.value = !next
+	}
+}
+
+async function toggleAutoApply() {
+	const next = !autoApply.value
+	menuError.value = ""
+	try {
+		await api.setAutoApply(convId.value, next)
+		autoApply.value = next
+	} catch (e) {
+		// Only a System Manager may turn this on — the server is the authority.
+		menuError.value = e?.message || "Only a System Manager can enable auto-apply."
+	}
+}
+
+async function saveRename() {
+	const t = renameText.value.trim()
+	if (!t) return
+	menuError.value = ""
+	try {
+		await api.renameConversation(convId.value, t)
+		if (conversation.value) conversation.value.title = t
+		store.applyRename(convId.value, t)
+		renaming.value = false
+		menuOpen.value = false
+	} catch (e) {
+		menuError.value = e?.message || "Couldn't rename this chat."
+	}
+}
+
+// ── realtime ────────────────────────────────────────────────────────────────
+// `assistant:delta` carries the CUMULATIVE text, not an increment — assign it,
+// never append, or the reply doubles up.
 function onEvent(p) {
-	if (p.conversation_id !== convId.value) return
+	const conv = p.conversation_id || p.conversation
+	if (conv !== convId.value) return
+	const ignored = p.run_id ? ignoredRuns.value.has(p.run_id) : false
 
 	switch (p.kind) {
 		case "run:start":
-			runId.value = p.run_id || null
-			busy.value = true
-			status.value = "Thinking…"
+			if (ignored) return
+			sendBusy.value = false
+			live.value = { runId: p.run_id || "", messageId: p.message_id || "", text: "", tools: [] }
 			break
-		case "tool:start":
-			status.value = p.tool_title || p.tool_name || "Working…"
-			break
-		case "tool:end":
-			status.value = "Thinking…"
-			break
-		case "run:status":
-			if (p.status) status.value = p.status
-			break
-		case "assistant:delta": {
-			const existing = messages.value.find((m) => m.name === p.message_id)
-			if (existing) existing.content = p.text
-			else messages.value.push({ name: p.message_id, role: "assistant", content: p.text })
-			status.value = ""
+
+		case "assistant:delta":
+			if (ignored) return
+			if (!live.value) live.value = { runId: p.run_id || "", messageId: "", text: "", tools: [] }
+			live.value.messageId = p.message_id || live.value.messageId
+			live.value.text = p.text || ""
 			scrollToBottom()
 			break
-		}
-		case "run:end":
-			busy.value = false
-			status.value = ""
-			runId.value = null
-			// The reply is durable now; reconcile against it (artifacts, final
-			// formatting) instead of trusting the streamed copy.
-			load()
-			break
-		case "run:error":
-			busy.value = false
-			status.value = ""
-			messages.value.push({
-				name: `err-${Date.now()}`,
-				role: "assistant",
-				content: p.error || "Something went wrong on that turn.",
-				error: 1,
+
+		case "tool:start": {
+			if (ignored || !live.value) return
+			const id = p.tool_call_id || `t-${live.value.tools.length}`
+			if (live.value.tools.some((t) => t.id === id)) return
+			live.value.tools.push({
+				id,
+				title: p.tool_title || p.tool_name || "Tool call",
+				toolName: p.tool_name,
+				status: "running",
 			})
 			scrollToBottom()
 			break
+		}
+
+		case "tool:end": {
+			if (ignored || !live.value) return
+			const step = live.value.tools.find((t) => t.id === p.tool_call_id)
+			if (step) step.status = toolStatus(p.status) === "error" ? "error" : "done"
+			break
+		}
+
+		case "run:end":
+			sendBusy.value = false
+			live.value = null
+			// The reply is durable now; reconcile against it (canvas items, final
+			// formatting) instead of trusting the streamed copy.
+			load()
+			break
+
+		case "run:error":
+			sendBusy.value = false
+			live.value = null
+			if (!ignored) errorBanner.value = p.error || "That turn failed."
+			load()
+			break
+
+		case "action:pending":
+			if (!p.token || pending.value.some((x) => x.token === p.token)) return
+			pending.value.push({
+				token: p.token,
+				tool: p.tool || "",
+				summary: p.summary || "",
+				preview: p.preview ?? null,
+				conversation: conv,
+				run_id: p.run_id,
+			})
+			scrollToBottom()
+			break
+
+		case "canvas":
+		case "conversation:renamed":
+			load()
+			break
 	}
 }
 
-function autoGrow() {
-	const el = inputEl.value
-	if (!el) return
-	el.style.height = "auto"
-	el.style.height = `${Math.min(el.scrollHeight, 140)}px`
+function onResolved(token) {
+	pending.value = pending.value.filter((p) => p.token !== token)
+	decision.value = null
 }
 
-// Enter sends on a physical keyboard; on a phone the on-screen Return key should
-// insert a newline, so only intercept when there is no soft keyboard shift key.
-function onKeydown(e) {
-	if (e.key === "Enter" && !e.shiftKey && !/Mobi|Android/i.test(navigator.userAgent)) {
-		e.preventDefault()
-		send()
-	}
+const onResync = () => {
+	load()
+	loadPending()
 }
 
-const onResync = () => load()
+watch(
+	() => props.id,
+	(id) => {
+		convId.value = id === "new" ? "" : id
+		messages.value = []
+		conversation.value = null
+		pending.value = []
+		live.value = null
+		sendBusy.value = false
+		errorBanner.value = ""
+		load(true)
+		loadPending()
+	},
+)
 
-watch(() => props.id, (id) => {
-	convId.value = id === "new" ? "" : id
-	messages.value = []
-	busy.value = false
-	load(true)
-})
-
-onMounted(() => {
+onMounted(async () => {
 	socket?.on("jarvis:event", onEvent)
 	window.addEventListener("jv:resync", onResync)
 	if (!store.loaded) store.loadConversations()
 	load(true)
+	loadPending()
+	try {
+		settings.value = await api.getChatUiSettings()
+	} catch {
+		// The header subtitle and the mic are both optional; a failure here must
+		// not stop the user from chatting.
+	}
 })
 onUnmounted(() => {
 	socket?.off("jarvis:event", onEvent)
 	window.removeEventListener("jv:resync", onResync)
+	attachments.value.forEach((a) => a.preview && URL.revokeObjectURL(a.preview))
 })
 </script>
 
@@ -200,190 +460,478 @@ onUnmounted(() => {
 				<path d="m15 18-6-6 6-6" />
 			</svg>
 		</button>
-		<div class="jv-title">{{ title }}</div>
-	</div>
-
-	<div ref="scroller" class="jv-scroll jv-thread">
-		<div v-if="!messages.length && !loading" class="jv-empty">
-			<div class="jv-mark" style="width: 52px; height: 52px; font-size: 21px">J</div>
-			<div style="font-size: 16px; font-weight: 600; color: var(--ink9)">What can I do for you?</div>
-			<div style="font-size: 14px; line-height: 1.5">
-				Try “show me this month's overdue invoices”.
-			</div>
+		<div class="jv-head">
+			<div class="jv-head-title">{{ title }}</div>
+			<div class="jv-head-sub">{{ model ? `Jarvis · ${model}` : "Jarvis" }}</div>
 		</div>
-
-		<div v-for="m in messages" :key="m.name" class="jv-msg" :class="m.role">
-			<div v-if="m.role === 'user'" class="jv-bubble-user">{{ m.content }}</div>
-			<div v-else class="jv-bubble-agent" :class="{ 'is-error': m.error }" v-html="renderMarkdown(m.content || '')" />
-		</div>
-
-		<div v-if="busy" class="jv-status">
-			<span class="jv-dot" /><span class="jv-dot" /><span class="jv-dot" />
-			<span v-if="status" class="jv-status-text">{{ status }}</span>
-		</div>
-	</div>
-
-	<div class="jv-composer jv-safe-bottom">
-		<textarea
-			ref="inputEl"
-			v-model="input"
-			rows="1"
-			placeholder="Message Jarvis…"
-			@input="autoGrow"
-			@keydown="onKeydown"
-		/>
-		<button v-if="busy" class="jv-send is-stop" aria-label="Stop" @click="stop">
-			<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2" /></svg>
-		</button>
-		<button v-else class="jv-send" aria-label="Send" :disabled="!input.trim()" @click="send">
-			<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-				<path d="M12 19V5M5 12l7-7 7 7" />
+		<button v-if="convId" class="jv-icon-btn" aria-label="Chat options" @click="menuOpen = true">
+			<svg viewBox="0 0 24 24" width="19" height="19" fill="currentColor">
+				<circle cx="12" cy="5" r="1.7" /><circle cx="12" cy="12" r="1.7" /><circle cx="12" cy="19" r="1.7" />
 			</svg>
 		</button>
 	</div>
+
+	<div ref="scroller" class="jv-scroll jv-thread">
+		<div v-if="!items.length && !live && !loading" class="jv-empty">
+			<div class="jv-mark" style="width: 52px; height: 52px; font-size: 21px">J</div>
+			<div style="font-size: 16px; font-weight: 600; color: var(--ink9)">What can I do for you?</div>
+			<div style="font-size: 14px; line-height: 1.5">Try “show me this month's overdue invoices”.</div>
+		</div>
+
+		<template v-for="it in items" :key="it.key">
+			<div v-if="it.type === 'user'" class="jv-msg-user">
+				<div v-if="it.msg.content" class="jv-bubble-user">{{ it.msg.content }}</div>
+				<MessageMedia
+					:items="it.msg.canvas"
+					:message-name="it.msg.name"
+					@open="preview = { item: $event, messageName: it.msg.name }"
+				/>
+			</div>
+
+			<!-- The assistant does not get a bubble: a reply can be a page of
+			     markdown, a table and a chart, and boxing all that in a chat
+			     bubble is what made this screen look like a toy next to the app. -->
+			<div v-else class="jv-msg-agent">
+				<ToolsCard v-if="it.tools.length" :title="toolsTitle(it.tools)" :steps="toolSteps(it.tools)" />
+				<template v-if="it.msg">
+					<div v-if="it.view.html" class="jv-md" v-html="it.view.html" />
+					<div v-else-if="it.view.empty" class="jv-msg-error">
+						Jarvis didn't return a reply for this turn. Try asking again.
+					</div>
+					<RecordCards v-if="it.view.cards" :data="it.view.cards" />
+					<ChartCard v-for="(c, ci) in it.view.charts" :key="ci" :spec="c" />
+					<SkillChips :names="it.view.skills" />
+					<div v-if="it.msg.error" class="jv-msg-error">{{ it.msg.error }}</div>
+					<MessageMedia
+						:items="it.msg.canvas"
+						:message-name="it.msg.name"
+						@open="preview = { item: $event, messageName: it.msg.name }"
+					/>
+					<div v-if="it.view.took" class="jv-took">
+						<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" />
+						</svg>
+						{{ it.view.took }}
+					</div>
+				</template>
+			</div>
+		</template>
+
+		<!-- the turn in flight -->
+		<template v-if="live">
+			<ToolsCard
+				v-if="live.tools.length"
+				live
+				default-open
+				:title="live.tools.find((t) => t.status === 'running')?.title || 'Working…'"
+				:steps="live.tools"
+			/>
+			<div v-if="live.text" class="jv-msg-agent">
+				<div class="jv-md" v-html="renderMarkdown(stripAgentBlocks(live.text))" />
+			</div>
+		</template>
+
+		<ThinkingIndicator v-if="sending && !(live && (live.text || live.tools.length))" />
+
+		<DecisionCard
+			v-for="p in pending"
+			:key="p.token"
+			:summary="p.summary || p.tool || 'Jarvis needs your approval'"
+			@open="decision = p"
+		/>
+	</div>
+
+	<div v-if="errorBanner" class="jv-banner">
+		<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+			<circle cx="12" cy="12" r="9" /><path d="M12 8v5M12 16h.01" />
+		</svg>
+		<span>{{ errorBanner }}</span>
+		<button class="jv-banner-x" aria-label="Dismiss" @click="errorBanner = ''">
+			<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+				<path d="M18 6 6 18M6 6l12 12" />
+			</svg>
+		</button>
+	</div>
+
+	<Composer
+		ref="composer"
+		v-model="input"
+		:sending="sending"
+		:attachments="attachments"
+		:mic-enabled="micEnabled"
+		@send="send"
+		@stop="stop"
+		@attach="attach"
+		@remove="removeAttachment"
+		@mic="voiceOpen = true"
+	/>
+
+	<!-- chat options -->
+	<Sheet :open="menuOpen" @close="((menuOpen = false), (renaming = false))">
+		<div class="jv-menu">
+			<template v-if="renaming">
+				<div class="jv-menu-title">Rename chat</div>
+				<input v-model="renameText" class="jv-input" placeholder="Chat title" @keydown.enter="saveRename" />
+				<div v-if="menuError" class="jv-menu-error">{{ menuError }}</div>
+				<div class="jv-menu-actions">
+					<button class="jv-btn is-ghost" @click="renaming = false">Cancel</button>
+					<button class="jv-btn is-primary" :disabled="!renameText.trim()" @click="saveRename">Save</button>
+				</div>
+			</template>
+
+			<template v-else>
+				<button class="jv-row-btn" @click="toggleStar">
+					<svg viewBox="0 0 24 24" width="19" height="19" :fill="starred ? 'var(--amber-dot)' : 'none'" :stroke="starred ? 'var(--amber-dot)' : 'currentColor'" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+						<path d="m12 2 3.1 6.3 6.9 1-5 4.9 1.2 6.8L12 17.8 5.8 21l1.2-6.8-5-4.9 6.9-1z" />
+					</svg>
+					{{ starred ? "Starred" : "Star this chat" }}
+				</button>
+
+				<button class="jv-row-btn" @click="((renameText = title), (renaming = true))">
+					<svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" />
+					</svg>
+					Rename chat
+				</button>
+
+				<!-- Auto-apply removes the approval gate for this chat: the agent
+				     commits ERP writes without asking. It is the single most
+				     dangerous switch in the product, so it looks like one. -->
+				<div class="jv-danger">
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+						<path d="M12 9v4M12 17h.01" />
+					</svg>
+					<div class="jv-danger-main">
+						<div class="jv-danger-title">Auto-apply changes</div>
+						<div class="jv-danger-sub">Jarvis commits ERP writes without asking. Turns off approval prompts.</div>
+						<div v-if="menuError" class="jv-menu-error">{{ menuError }}</div>
+					</div>
+					<button class="jv-toggle" :class="{ 'is-on': autoApply }" role="switch" :aria-checked="autoApply" @click="toggleAutoApply">
+						<span />
+					</button>
+				</div>
+			</template>
+		</div>
+	</Sheet>
+
+	<DecisionSheet :action="decision" @close="decision = null" @resolved="onResolved" />
+	<FilePreviewSheet :item="preview?.item" :message-name="preview?.messageName || ''" @close="preview = null" />
+	<VoiceSheet :open="voiceOpen" @close="voiceOpen = false" @transcript="onTranscript" />
 </template>
 
 <style scoped>
+.jv-head {
+	flex: 1;
+	min-width: 0;
+}
+.jv-head-title {
+	font-size: 14.5px;
+	font-weight: 600;
+	color: var(--ink9);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jv-head-sub {
+	font-size: 11.5px;
+	color: var(--ink5);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .jv-thread {
-	padding: 14px 12px 8px;
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 14px;
+	padding: 16px 14px 12px;
 }
-.jv-msg {
+.jv-msg-user {
 	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
 }
-.jv-msg.user {
-	justify-content: flex-end;
-}
+/* A tinted bubble, not a solid violet slab with white text: the reply next to
+   it is plain body copy, and a saturated block beside it fights for attention
+   it doesn't need. Same treatment as the native app. */
 .jv-bubble-user {
 	max-width: 82%;
-	padding: 10px 14px;
-	border-radius: 16px 16px 4px 16px;
-	background: var(--accent-solid);
-	color: #fff;
-	font-size: 15px;
-	line-height: 1.5;
+	padding: 10px 13px;
+	border-radius: 16px 16px 5px 16px;
+	background: var(--accent-bg);
+	color: var(--ink8);
+	font-size: 13.5px;
+	line-height: 1.45;
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
 }
-.jv-bubble-agent {
-	max-width: 92%;
-	padding: 11px 14px;
-	border-radius: 16px 16px 16px 4px;
-	background: var(--card);
-	border: 1px solid var(--border);
-	color: var(--ink9);
-	font-size: 15px;
-	line-height: 1.6;
-	overflow-wrap: anywhere;
+.jv-msg-agent {
+	min-width: 0;
 }
-.jv-bubble-agent.is-error {
-	background: var(--red-bg);
-	border-color: transparent;
+/* The activity card sits above the prose it produced; give it room. (Scoped
+   styles reach a child component's root element, which is what .jv-tools is.) */
+.jv-msg-agent .jv-tools {
+	margin-bottom: 10px;
+}
+.jv-msg-error {
+	margin-top: 4px;
+	font-size: 12px;
+	line-height: 1.4;
 	color: var(--red);
 }
-.jv-bubble-agent :deep(p) {
+.jv-took {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-top: 5px;
+	font-size: 11px;
+	color: var(--ink4);
+}
+
+.jv-md {
+	font-size: 14px;
+	line-height: 1.6;
+	color: var(--ink7);
+	overflow-wrap: anywhere;
+}
+.jv-md :deep(p) {
 	margin: 0 0 8px;
 }
-.jv-bubble-agent :deep(p:last-child) {
+.jv-md :deep(p:last-child) {
 	margin-bottom: 0;
 }
-.jv-bubble-agent :deep(pre),
-.jv-bubble-agent :deep(table) {
-	/* Wide content scrolls inside the bubble; the thread never scrolls sideways. */
+.jv-md :deep(h1),
+.jv-md :deep(h2),
+.jv-md :deep(h3) {
+	margin: 12px 0 6px;
+	color: var(--ink9);
+	font-weight: 600;
+	line-height: 1.3;
+}
+.jv-md :deep(h1) {
+	font-size: 19px;
+}
+.jv-md :deep(h2) {
+	font-size: 16.5px;
+}
+.jv-md :deep(h3) {
+	font-size: 15px;
+}
+.jv-md :deep(strong) {
+	color: var(--ink8);
+	font-weight: 600;
+}
+.jv-md :deep(a) {
+	color: var(--accent);
+}
+.jv-md :deep(ul),
+.jv-md :deep(ol) {
+	margin: 0 0 8px;
+	padding-left: 20px;
+}
+.jv-md :deep(li) {
+	margin: 2px 0;
+}
+/* Wide content scrolls inside its own box; the thread never scrolls sideways. */
+.jv-md :deep(pre),
+.jv-md :deep(table) {
 	display: block;
 	max-width: 100%;
 	overflow-x: auto;
 }
-.jv-bubble-agent :deep(code) {
-	font-size: 13px;
+.jv-md :deep(pre) {
+	padding: 10px;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--card2);
+	font-size: 12.5px;
+}
+.jv-md :deep(code) {
+	font-size: 12.5px;
 	background: var(--card2);
 	padding: 1px 5px;
 	border-radius: 5px;
 }
+.jv-md :deep(pre code) {
+	background: transparent;
+	padding: 0;
+}
+.jv-md :deep(table) {
+	border-collapse: collapse;
+	font-size: 12.5px;
+	white-space: nowrap;
+}
+.jv-md :deep(th),
+.jv-md :deep(td) {
+	padding: 6px 10px;
+	border: 1px solid var(--border);
+	text-align: left;
+}
+.jv-md :deep(th) {
+	background: var(--card2);
+	color: var(--ink9);
+}
+.jv-md :deep(blockquote) {
+	margin: 0 0 8px;
+	padding: 2px 10px;
+	border-left: 3px solid var(--border2);
+	background: var(--card2);
+	border-radius: 4px;
+}
 
-.jv-status {
+.jv-banner {
 	display: flex;
 	align-items: center;
-	gap: 5px;
-	padding: 4px 6px;
-}
-.jv-dot {
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-	background: var(--ink4);
-	animation: jv-pulse 1.2s infinite ease-in-out;
-}
-.jv-dot:nth-child(2) {
-	animation-delay: 0.15s;
-}
-.jv-dot:nth-child(3) {
-	animation-delay: 0.3s;
-}
-.jv-status-text {
-	margin-left: 6px;
-	font-size: 13px;
-	color: var(--ink5);
-}
-@keyframes jv-pulse {
-	0%,
-	60%,
-	100% {
-		opacity: 0.3;
-	}
-	30% {
-		opacity: 1;
-	}
-}
-
-.jv-composer {
-	flex: none;
-	display: flex;
-	align-items: flex-end;
 	gap: 8px;
-	padding: 10px 12px;
-	background: var(--menu-bar);
-	border-top: 1px solid var(--border);
+	flex: none;
+	padding: 8px 14px;
+	background: var(--red-bg);
+	color: var(--red);
+	font-size: 11.5px;
+	font-weight: 500;
 }
-.jv-composer textarea {
+.jv-banner span {
 	flex: 1;
 	min-width: 0;
-	resize: none;
-	padding: 11px 14px;
+	line-height: 1.35;
+}
+.jv-banner-x {
+	flex: none;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	padding: 2px;
+}
+
+/* chat options sheet */
+.jv-menu {
+	padding: 4px 14px 18px;
+}
+.jv-menu-title {
+	padding: 6px 2px 10px;
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--ink9);
+}
+.jv-row-btn {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+	padding: 13px 4px;
+	border: 0;
+	border-bottom: 1px solid var(--border);
+	background: transparent;
+	color: var(--ink8);
+	font: inherit;
+	font-size: 14.5px;
+	text-align: left;
+	cursor: pointer;
+}
+.jv-row-btn svg {
+	flex: none;
+	color: var(--ink5);
+}
+.jv-input {
+	width: 100%;
+	height: 46px;
+	padding: 0 14px;
 	border: 1px solid var(--border2);
-	border-radius: 20px;
+	border-radius: 12px;
 	background: var(--card);
 	color: var(--ink9);
 	font: inherit;
-	font-size: 15px;
-	line-height: 1.4;
-	max-height: 140px;
+	font-size: 14.5px;
 	outline: none;
 }
-.jv-composer textarea:focus {
+.jv-input:focus {
 	border-color: var(--accent);
 }
-.jv-send {
-	flex: none;
-	width: 40px;
-	height: 40px;
-	display: grid;
-	place-items: center;
+.jv-menu-error {
+	margin-top: 6px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--red);
+}
+.jv-menu-actions {
+	display: flex;
+	gap: 10px;
+	margin-top: 12px;
+}
+.jv-btn {
+	flex: 1;
+	height: 46px;
 	border: 0;
-	border-radius: 50%;
-	background: var(--accent-solid);
-	color: #fff;
+	border-radius: 12px;
+	font: inherit;
+	font-size: 15px;
+	font-weight: 600;
 	cursor: pointer;
 }
-.jv-send:disabled {
-	background: var(--card3);
-	color: var(--ink4);
-	cursor: default;
+.jv-btn.is-primary {
+	background: var(--accent-solid);
+	color: #fff;
 }
-.jv-send.is-stop {
-	background: var(--ink9);
-	color: var(--card);
+.jv-btn.is-ghost {
+	border: 1px solid var(--border2);
+	background: var(--card);
+	color: var(--ink8);
+}
+.jv-btn:disabled {
+	opacity: 0.55;
+}
+
+.jv-danger {
+	display: flex;
+	align-items: flex-start;
+	gap: 11px;
+	margin: 12px 0 0;
+	padding: 13px;
+	border: 1px solid var(--red);
+	border-radius: 12px;
+	background: var(--red-bg);
+	color: var(--red);
+}
+.jv-danger-main {
+	flex: 1;
+	min-width: 0;
+}
+.jv-danger-title {
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--ink9);
+}
+.jv-danger-sub {
+	margin-top: 2px;
+	font-size: 12px;
+	line-height: 1.4;
+	color: var(--red);
+}
+.jv-toggle {
+	flex: none;
+	width: 44px;
+	height: 26px;
+	padding: 3px;
+	border: 0;
+	border-radius: 999px;
+	background: var(--card3);
+	cursor: pointer;
+	transition: background 0.15s ease;
+}
+.jv-toggle span {
+	display: block;
+	width: 20px;
+	height: 20px;
+	border-radius: 999px;
+	background: #fff;
+	transition: transform 0.15s ease;
+}
+.jv-toggle.is-on {
+	background: var(--red);
+}
+.jv-toggle.is-on span {
+	transform: translateX(18px);
 }
 </style>

--- a/pwa/src/views/ChatsView.vue
+++ b/pwa/src/views/ChatsView.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { onMounted } from "vue"
+import { computed, onMounted, ref } from "vue"
 import { useRouter } from "vue-router"
 import { store } from "../store"
 import { relativeTime } from "../lib/time"
 
 const router = useRouter()
+const search = ref("")
 
 // New chat = navigate to the thread with no id. send_message creates (or
 // focuses) the empty conversation server-side on the first send, so we don't
@@ -13,8 +14,29 @@ function newChat() {
 	router.push("/c/new")
 }
 
+// Starred chats pin to the top — the same order list_conversations returns, kept
+// explicitly so a client-side filter can't quietly reshuffle it.
+const rows = computed(() => {
+	const q = search.value.trim().toLowerCase()
+	const list = q
+		? store.conversations.filter((c) => (c.title || "New chat").toLowerCase().includes(q))
+		: store.conversations
+	return [...list].sort((a, b) => (b.starred || 0) - (a.starred || 0))
+})
+
+// `last_active_at` — NOT `modified`. list_conversations doesn't return
+// `modified`, so reading it (as this screen used to) printed an empty timestamp
+// under every single chat.
+const subtitle = (c) => {
+	const when = relativeTime(c.last_active_at)
+	const n = Number(c.message_count || 0)
+	if (!n) return when || "Empty chat"
+	return [when, `${n} message${n === 1 ? "" : "s"}`].filter(Boolean).join(" · ")
+}
+
 onMounted(() => {
 	if (!store.loaded) store.loadConversations()
+	store.loadPendingCount()
 })
 </script>
 
@@ -24,6 +46,7 @@ onMounted(() => {
 			<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
 				<path d="M3 6h18M3 12h18M3 18h18" />
 			</svg>
+			<span v-if="store.pendingApprovals" class="jv-badge" />
 		</button>
 		<div class="jv-title">Chats</div>
 		<button class="jv-icon-btn" aria-label="New chat" @click="newChat">
@@ -31,6 +54,13 @@ onMounted(() => {
 				<path d="M12 5v14M5 12h14" />
 			</svg>
 		</button>
+	</div>
+
+	<div v-if="store.conversations.length > 4" class="jv-searchbar">
+		<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round">
+			<circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" />
+		</svg>
+		<input v-model="search" placeholder="Search chats" />
 	</div>
 
 	<div class="jv-scroll">
@@ -44,12 +74,19 @@ onMounted(() => {
 			</div>
 		</div>
 
+		<div v-else-if="!rows.length" class="jv-empty">No chat matches “{{ search }}”.</div>
+
 		<ul v-else class="jv-list">
-			<li v-for="c in store.conversations" :key="c.name">
+			<li v-for="c in rows" :key="c.name">
 				<button class="jv-row" @click="router.push(`/c/${c.name}`)">
 					<div class="jv-row-main">
-						<div class="jv-row-title">{{ c.title || "New chat" }}</div>
-						<div class="jv-row-time">{{ relativeTime(c.modified) }}</div>
+						<div class="jv-row-title">
+							<svg v-if="c.starred" class="jv-star" viewBox="0 0 24 24" width="13" height="13" fill="currentColor">
+								<path d="m12 2 3.1 6.3 6.9 1-5 4.9 1.2 6.8L12 17.8 5.8 21l1.2-6.8-5-4.9 6.9-1z" />
+							</svg>
+							{{ c.title || "New chat" }}
+						</div>
+						<div class="jv-row-time">{{ subtitle(c) }}</div>
 					</div>
 					<svg class="jv-row-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 						<path d="m9 18 6-6-6-6" />
@@ -59,8 +96,6 @@ onMounted(() => {
 		</ul>
 	</div>
 
-	<!-- The native app has no tab bar (chats is the only destination), so the
-	     FAB is the primary action here too. -->
 	<button class="jv-fab jv-safe-bottom" aria-label="New chat" @click="newChat">
 		<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 			<path d="M12 5v14M5 12h14" />
@@ -69,6 +104,46 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.jv-icon-btn {
+	position: relative;
+}
+/* A parked write is waiting somewhere behind the drawer — say so on the button
+   that opens it, or the user has no way to know. */
+.jv-badge {
+	position: absolute;
+	top: 7px;
+	right: 7px;
+	width: 8px;
+	height: 8px;
+	border-radius: 999px;
+	background: var(--amber-dot);
+	border: 2px solid var(--menu-bar);
+}
+
+.jv-searchbar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: none;
+	margin: 8px 12px 0;
+	padding: 0 12px;
+	height: 40px;
+	border: 1px solid var(--border2);
+	border-radius: 12px;
+	background: var(--card);
+	color: var(--ink4);
+}
+.jv-searchbar input {
+	flex: 1;
+	min-width: 0;
+	border: 0;
+	outline: none;
+	background: transparent;
+	color: var(--ink9);
+	font: inherit;
+	font-size: 14.5px;
+}
+
 .jv-list {
 	list-style: none;
 	margin: 0;
@@ -98,12 +173,19 @@ onMounted(() => {
 	min-width: 0;
 }
 .jv-row-title {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 	font-size: 15px;
 	font-weight: 500;
 	color: var(--ink9);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+.jv-star {
+	flex: none;
+	color: var(--amber-dot);
 }
 .jv-row-time {
 	margin-top: 3px;


### PR DESCRIPTION
The mobile PWA shipped in #287, but two of its fixes never made it in — and the chat thread only ever rendered prose. This lands both.

## The service worker never actually installed (#287 regression)

`vite-plugin-pwa` appends `manifest.webmanifest` to the precache list **after** `modifyURLPrefix` runs, so the entry stayed relative. The worker is served from the site root (`/jarvis-mobile.sw.js`), so it resolved to `/manifest.webmanifest` → 404 → `bad-precaching-response` → **install aborted, every time**. `main` has been shipping a PWA whose worker never installs. Fixed by normalising the manifest inside `sw.js`.

## The install offer vanished on refresh

`beforeinstallprompt` fires at most once per page load and cannot be replayed. On a warm refresh Chrome fired it in the *same millisecond* the app mounted (measured: event 141 ms, mount 141 ms), so the `onMounted` listener lost the race and the offer was gone for that load. Captured at module load now (`src/install.js`).

## Every message type the backend returns

The thread rendered anything that wasn't a user message as an agent bubble. So:

| Backend gives us | Before | Now |
|---|---|---|
| `role: tool` rows | one bubble each: `get_list → completed` | one collapsible activity card per turn — "Worked for 12s · 3 steps", per-step icons, pass/fail marks |
| ` ```jarvis-cards``` `, ` ```jarvis-chart``` `, ` ```jarvis-skill``` ` | raw JSON in the reply | record cards, SVG charts (pie/donut/bar/line/area), skill chips |
| `message.canvas` | **ignored entirely** | inline images, sandboxed html/svg frames, preview sheet (`preview_file`) for PDFs/sheets/text |
| `action:pending` | **no UI at all** | decision card + approve/deny sheet (`confirm_tool`) |
| empty assistant turn | blank gap | says so |

Tool rows trail their assistant placeholder in `seq` order, so rendering them literally put the receipt *below* the answer and the thread read backwards. They're grouped the way the SPA's `activityByAssistant` does and drawn above the prose.

Approvals matter beyond cosmetics: a parked ERP write previously **could not be approved from a phone at all**. Deny still has no endpoint by design — the one-time token is left to expire, same as the web.

## A real bug

The chat list read `c.modified`, but `list_conversations` returns `last_active_at` — so **every row showed a blank timestamp**. Now: "41m ago · 3 messages".

## Parity with the native app

Tinted user bubble (not a solid violet slab with white text), assistant replies as plain markdown with no bubble, model in the header, kebab menu (star / rename / auto-apply), composer with attachments + dictation, an Approvals screen with a drawer badge, reply and tool durations.

Dictation reuses the SPA's `useAudioRecorder` and `transcribe_audio` rather than growing a second recorder with its own permission/format/duration bugs.

## Install on an insecure origin

A browser will not install a page it does not trust. On a plain-http LAN origin (`http://192.168.x.x:8002` — how the bench is reached from a phone in dev) `isSecureContext` is false, Chrome never fires `beforeinstallprompt`, and `navigator.serviceWorker` is `undefined`. The banner used to vanish silently, which reads as a bug in the app; it now says to open the site over https. Dead branch in production.

## Verification

Driven in real Chrome at 390×844 over CDP: service worker **controls the page**, 17 precache entries, no console errors, no failed requests. Opened a tool-call chat (card renders above the answer, expands to `get_list → completed` ✓, "3m 16s"), the approvals screen, the drawer, and **sent a message from the composer**: optimistic bubble → thinking indicator → streamed reply.

One test send came back empty — that was the container aborting a stalled model call (`stalled_agent_run`, 0.5-CPU cap), not the PWA. The UI surfaced the recorded error correctly; the empty-turn fallback was added anyway.

## Not covered

This app has **no JS test runner** — CI runs only the Python suite, and even the SPA's existing `*.test.js` files are never executed by anything. So the new block/chart/time parsing has no automated coverage. Adding vitest + a CI job is the right fix; it's a tooling decision, not something to slip into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Sign-in inside the app (added)

The shell redirected every Guest to `/app`, so a logged-out visit landed on the Desk's `/login` — **outside the manifest scope** (`/jarvis-mobile`). A standalone PWA that navigates out of its scope is handed to the browser, so tapping the installed Jarvis icon with an expired session dropped the user into a Chrome tab showing a Desk login. HRMS renders its shell for guests and owns a `Login` route for exactly this reason; the PWA now does the same.

- Guests get the shell and the app's own `/jarvis-mobile/login`. A **signed-in** user without Jarvis access still goes to the Desk — they have one, and a login form would be nonsense.
- Sign-in ends in a **full navigation, not a router push**: the CSRF token is bound to the session and logging in mints a new one, so the token the guest page was rendered with dies with the guest session. Reloading re-renders the shell with the live token *and* stays in scope. Verified — a POST after sign-in returns `200`, not `CSRFTokenError`.
- Sign-out leaves for `/jarvis-mobile/login` rather than hitting `/api/method/logout` directly, which ejected the installed app the same way.
- No socket for a guest; 2FA accounts are told to sign in on the web rather than left on a form that cannot succeed.

Verified in a clean browser: logged out lands on `/jarvis-mobile/login` and never leaves the scope, the form signs in, and the app comes up on Chats. Backend tests: 11/11.
