### PR TITLE
Security review Part 4: Jarvis Admin administration tier + settings/diagnostics hardening

### DIFF
--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -51,9 +51,11 @@ import { getDirectSubscriptionStatus } from "@/api"
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue"
 import DirectSubscriptionCard from "@/components/DirectSubscriptionCard.vue"
 
-// The rail already gates this section to System Managers; this flag additionally
-// gates the editor's edit affordances + which probes fire.
-const isSM = !!window.is_system_manager
+// The rail already gates this section to the tenant-admin tier; this flag
+// additionally gates the editor's edit affordances + which probes fire. PART 4
+// REVISED TASK 49(c): widened to System Manager OR Jarvis Admin (the LLM-config
+// endpoints are all require_jarvis_admin now).
+const isSM = !!(window.is_system_manager || window.is_jarvis_admin)
 
 // ---- AI models: brief save acknowledgement (editor persists itself) --------
 const savedNote = ref("")

--- a/frontend/src/components/settings/ConnectionPane.vue
+++ b/frontend/src/components/settings/ConnectionPane.vue
@@ -34,10 +34,11 @@
 import { ref, computed, onMounted } from "vue"
 import { getLlmConnectionStatus } from "@/api"
 
-// SM-only endpoint (server enforces `only_for("System Manager")`); the rail
-// already gates this pane, but guard the fetch so a non-SM never fires a
-// doomed request and sees a clear note instead.
-const isSystemManager = !!window.is_system_manager
+// Admin-tier endpoint (server enforces `require_jarvis_admin`); the rail already
+// gates this pane, but guard the fetch so a non-admin never fires a doomed
+// request and sees a clear note instead. PART 4 REVISED TASK 49(c): widened to
+// the Jarvis Admin tenant-admin tier.
+const isSystemManager = !!(window.is_system_manager || window.is_jarvis_admin)
 
 const conn = ref({})
 const loading = ref(true)

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -68,10 +68,12 @@ const convAutoApply = computed(() => !!(ctx.value && ctx.value.convAutoApply))
 const autoApplyNote = computed(() => (ctx.value && ctx.value.autoApplyNote) || "")
 
 // Real connection status (replaces the old hardcoded "Live"). getLlmConnectionStatus
-// is System-Manager-only on the server, and General is an all-user pane — so only
-// SM users get the live verdict; regular users (who can't query it and can't fix it
-// anyway) keep the benign "Connected" the surface implied before, never a 403 → "—".
-const isSM = !!window.is_system_manager
+// is admin-tier on the server (require_jarvis_admin), and General is an all-user
+// pane — so only tenant-admin (System Manager OR Jarvis Admin — PART 4 REVISED
+// TASK 49(c)) users get the live verdict; regular users (who can't query it and
+// can't fix it anyway) keep the benign "Connected" the surface implied before,
+// never a 403 → "—".
+const isSM = !!(window.is_system_manager || window.is_jarvis_admin)
 const connStatus = ref(null)
 const connected = computed(() =>
 	isSM ? !!(connStatus.value && connStatus.value.auth_present) : true,

--- a/frontend/src/components/shell/OnboardingGate.vue
+++ b/frontend/src/components/shell/OnboardingGate.vue
@@ -43,13 +43,14 @@ import JarvisMark from "@/components/JarvisMark.vue"
 const router = useRouter()
 
 // The /onboarding route's beforeEnter gate is a STRICT truthy check
-// (`window.is_system_manager ? … : Chat`). Match it exactly here — a lenient
-// `!== false` would show the "Complete setup" button on the vite dev server
-// (flag undefined), but the click would bounce straight back off the route
-// guard to Chat and re-trigger the poster: a dead-end. So the button appears
-// only when it can actually reach the wizard; a non-SM (or dev) user gets the
-// "ask your administrator" copy instead.
-const isSystemManager = !!window.is_system_manager
+// (`(is_system_manager || is_jarvis_admin) ? … : Chat`). Match it exactly here —
+// a lenient `!== false` would show the "Complete setup" button on the vite dev
+// server (flags undefined), but the click would bounce straight back off the
+// route guard to Chat and re-trigger the poster: a dead-end. So the button
+// appears only when it can actually reach the wizard; a non-admin (or dev) user
+// gets the "ask your administrator" copy instead. PART 4 REVISED TASK 49(c):
+// widened to the Jarvis Admin tenant-admin tier.
+const isSystemManager = !!(window.is_system_manager || window.is_jarvis_admin)
 
 function goOnboard() {
 	router.push({ name: "Onboarding" })

--- a/frontend/src/components/shell/SettingsDialog.vue
+++ b/frontend/src/components/shell/SettingsDialog.vue
@@ -37,9 +37,10 @@
 						<span>Shortcuts</span>
 					</button>
 
-					<!-- ACCOUNT & BILLING (System Managers only — the rail and the server
-					     both gate it, so no badge is needed) -->
-					<template v-if="isSM">
+					<!-- ACCOUNT & BILLING (the tenant-admin tier — System Manager OR
+					     Jarvis Admin; PART 4 REVISED TASK 49(c). The rail and the server
+					     both gate it (require_jarvis_admin), so no badge is needed) -->
+					<template v-if="isSM || isAdmin">
 						<div class="jv-settings-group">Account &amp; billing</div>
 						<button class="jv-settings-navitem" :class="{ on: section === 'plan' }" @click="go('plan')">
 							<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" /><path d="M1 10h22" /></svg>
@@ -180,7 +181,9 @@ const DESCRIPTIONS = {
 const section = computed(() => {
 	const s = store.settingsSection
 	if (!PANES[s]) return "general"
-	if (GATED_SM.includes(s) && !isSM) return "general"
+	// PART 4 REVISED TASK 49(c): ACCOUNT & BILLING panes are tenant-admin tier
+	// (SM OR Jarvis Admin), matching the widened require_jarvis_admin endpoints.
+	if (GATED_SM.includes(s) && !(isSM || isAdmin)) return "general"
 	if (GATED_ADMIN.includes(s) && !isAdmin) return "general"
 	return s
 })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -34,7 +34,8 @@ const routes = [
 		// Chrome-less: a first-run customer hasn't onboarded yet, so the full app
 		// sidebar/header (Chat/Skills/Macros/…) is noise — AppShell hides them.
 		meta: { chromeless: true },
-		beforeEnter: (to, from, next) => { next(window.is_system_manager ? undefined : { name: "Chat" }) },
+		// PART 4 REVISED TASK 49(c): a Jarvis Admin (not necessarily SM) may onboard.
+		beforeEnter: (to, from, next) => { next((window.is_system_manager || window.is_jarvis_admin) ? undefined : { name: "Chat" }) },
 	},
 	{ path: "/macros", name: "MacrosList", component: () => import("@/pages/macros/MacrosList.vue") },
 	{

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -64,7 +64,7 @@
 							</div>
 							<div class="jv-ob-foot">
 								<button class="jv-ob-back" @click="goBack"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6" /></svg>Back to tour</button>
-								<button class="jv-ob-link" @click="enterSelfhost">Self-hosted? Connect your own openclaw</button>
+								<button v-if="canSelfHost" class="jv-ob-link" @click="enterSelfhost">Self-hosted? Connect your own openclaw</button>
 								<button class="jv-ob-btn jv-ob-btn-primary" :disabled="!state.planName" @click="onPlanContinue">Continue</button>
 							</div>
 						</section>
@@ -325,6 +325,13 @@ import { errMessage as errMsg } from "@/lib/errors"
 
 const { effectiveDark: dark, paletteVars } = useTheme()
 
+// Self-host connect (save_self_hosted / test_connection) stays System-Manager-
+// ONLY (owner trust-boundary decision). Managed onboarding is widened to the
+// Jarvis Admin tier, but the self-host side-branch entry point + its auto-
+// reconcile must be hidden/short-circuited for a Jarvis-Admin-not-SM so they
+// never land on a step whose save 403s. NOT `|| window.is_jarvis_admin`.
+const canSelfHost = !!window.is_system_manager
+
 // The 4 named wizard steps shown on the rail. The intro tour and the
 // self-host track are chromeless (no rail entry).
 const RAIL = [
@@ -464,7 +471,10 @@ function backFromSelfhost() {
 async function reconcileMidFlightSignup() {
 	try {
 		const ready = await isReadyForChat()
-		if (ready && ready.reason === "selfhost_connection") {
+		if (ready && ready.reason === "selfhost_connection" && canSelfHost) {
+			// Self-host connect is SM-only; a Jarvis-Admin-not-SM must not be
+			// routed into the selfhost step (its save 403s). Fall through to the
+			// default step for them.
 			state.mode = "selfhost"
 			state.step = "selfhost"
 			return

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -16,6 +16,7 @@ import frappe
 
 from jarvis import admin_client
 from jarvis.onboarding import _surface
+from jarvis.permissions import require_jarvis_admin
 
 
 @frappe.whitelist()
@@ -124,7 +125,7 @@ def get_llm_usage() -> dict:
 	"""Real, curated Bifrost usage for the Monitor tab (System-Manager only,
 	spec 7). DIRECT tenants (proxy_active=0, no Bifrost) short-circuit to the
 	empty shape — no pointless admin round-trip."""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	if not getattr(settings, "proxy_active", 0):
 		return {"applicable": False, "period": None, "tokens_in": 0, "tokens_out": 0,
@@ -140,7 +141,7 @@ def get_llm_connection_status() -> dict:
 	"""Connection card for the Monitor tab: auth profile present + OAuth expiry.
 	Wrapper over admin_client.post_llm_auth_status, remapped to the customer
 	contract field names. Never returns token material. System-Manager only."""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	raw = _surface(admin_client.post_llm_auth_status) or {}
 	data = raw.get("data", raw) or {}
 	return {
@@ -161,7 +162,7 @@ def get_account() -> dict:
 	Neither stops a direct /api/method call, so any authenticated user could
 	read the account's plan, subscription status and validity.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _surface(admin_client.get_account_summary)
 
 
@@ -174,7 +175,7 @@ def preview_upgrade(target_plan: str) -> dict:
 	spends an admin round-trip per call. Whoever may not upgrade the plan has
 	no business pricing the upgrade either.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _surface(admin_client.preview_upgrade, target_plan)
 
 
@@ -186,5 +187,5 @@ def start_upgrade(target_plan: str) -> dict:
 	review): initiates a billing transaction tied to the site's admin
 	account; non-admin staff shouldn't be able to upgrade the plan.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _surface(admin_client.start_upgrade, target_plan)

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -14,7 +14,9 @@ Enable / schedule are pure DB writes (no container restart — O6); only Apply
 """
 
 import frappe
-from jarvis.permissions import require_jarvis_user
+from jarvis.permissions import (
+	has_jarvis_admin_access, require_jarvis_admin, require_jarvis_user,
+)
 from frappe import _
 
 from jarvis._session import impersonate
@@ -64,9 +66,12 @@ def _user_allowed_for_agent(listing, user: str | None = None) -> bool:
 		allowed = [row.role for row in (listing.get("allowed_roles") or [])]
 	if not allowed:
 		return True
-	roles = set(frappe.get_roles(user))
-	if "System Manager" in roles:
+	# PART 4 REVISED, TASK 49: admin parity — a Jarvis Admin / System Manager is
+	# ALWAYS allowed, in lockstep with the widened ``allowed`` display flag so an
+	# admin never sees an agent as installable but 403s on install.
+	if has_jarvis_admin_access(user):
 		return True
+	roles = set(frappe.get_roles(user))
 	return bool(roles.intersection(allowed))
 
 
@@ -104,7 +109,9 @@ def _enriched_catalog() -> list[dict]:
 	me = frappe.session.user
 	roles_map = _allowed_roles_map()
 	my_roles = set(frappe.get_roles(me))
-	is_sm = "System Manager" in my_roles
+	# PART 4 REVISED, TASK 49(d): admin display parity — a Jarvis Admin sees every
+	# agent card as ``allowed`` (and _user_allowed_for_agent lets them install).
+	is_sm = has_jarvis_admin_access(me)
 	listings = frappe.get_all(
 		LISTING,
 		fields=[
@@ -236,7 +243,9 @@ def get_agent(agent_slug: str) -> dict:
 	``all_roles`` rides along only for System Managers (Admin-tab roles editor)."""
 	listing = frappe.get_doc(LISTING, agent_slug)  # All-role read; 404s if unknown
 	me = frappe.session.user
-	is_sm = "System Manager" in frappe.get_roles(me)
+	# PART 4 REVISED, TASK 49(d): the Admin-tab signal (all_roles rider) rides for
+	# Jarvis Admins too — the SPA derives isSM from all_roles' presence.
+	is_sm = has_jarvis_admin_access(me)
 
 	out: dict = {
 		"name": listing.name,
@@ -323,17 +332,19 @@ def get_installations() -> list[dict]:
 
 
 # --------------------------------------------------------------------------- #
-# admin surface (System Manager ONLY — every check server-side)
+# admin surface (Jarvis Admin / System Manager — every check server-side)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
 def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
-	"""Restrict an agent listing to a set of Roles. System Manager only.
+	"""Restrict an agent listing to a set of Roles. Jarvis Admin / System Manager
+	(PART 4 REVISED, TASK 45; needs the Jarvis Admin write:1 row on Jarvis Agent
+	Listing — TASK 47 — for the perm-checked save).
 
 	``roles`` is a JSON array of Role names; ``[]`` clears the restriction
 	(unrestricted). Roles are validated against the Role doctype; the
 	non-grantable Administrator/Guest/All are rejected (All would silently mean
 	unrestricted — force the explicit empty list instead)."""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	parsed = roles
 	if isinstance(parsed, str):
 		try:
@@ -367,9 +378,10 @@ def set_agent_roles(agent_slug: str, roles: str | list | None = None) -> dict:
 
 @frappe.whitelist()
 def set_listing_status(agent_slug: str, status: str) -> dict:
-	"""Set a listing's marketplace status. System Manager only. Only the
-	admin-meaningful statuses are settable (Draft stays registry-controlled)."""
-	frappe.only_for("System Manager")
+	"""Set a listing's marketplace status. Jarvis Admin / System Manager (PART 4
+	REVISED, TASK 45). Only the admin-meaningful statuses are settable (Draft
+	stays registry-controlled)."""
+	require_jarvis_admin()
 	if status not in _ADMIN_STATUSES:
 		frappe.throw(_("Status must be one of: {0}.").format(", ".join(_ADMIN_STATUSES)))
 	doc = frappe.get_doc(LISTING, agent_slug)
@@ -383,9 +395,11 @@ def set_listing_status(agent_slug: str, status: str) -> dict:
 @frappe.whitelist()
 def get_agent_admin_overview() -> dict:
 	"""Bench-admin overview: the selectable Roles + every listing with its
-	allowed_roles and ALL owners' installs. System Manager only — the SPA probes
-	this endpoint and hides the Admin tab when it throws PermissionError."""
-	frappe.only_for("System Manager")
+	allowed_roles and ALL owners' installs. Jarvis Admin / System Manager (PART 4
+	REVISED, TASK 45; the cross-owner install read needs the Jarvis Admin read row
+	on Jarvis Agent Installation — TASK 47). The SPA probes this endpoint and hides
+	the Admin tab when it throws PermissionError."""
+	require_jarvis_admin()
 
 	roles = [
 		r
@@ -1034,7 +1048,9 @@ def get_agents_caps() -> dict:
 
 	return {
 		"review": bool(is_skill_reviewer()),
-		"admin": "System Manager" in frappe.get_roles(frappe.session.user),
+		# PART 4 REVISED, TASK 49(d): the admin roles editor / cross-owner overview
+		# is now Jarvis Admin | System Manager (get_agent_admin_overview widened).
+		"admin": has_jarvis_admin_access(),
 	}
 
 

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -14,6 +14,7 @@ from jarvis.chat.usage import current_month_key as _usage_month_key
 from jarvis.permissions import (
 	has_jarvis_access,
 	require_jarvis_access,
+	require_jarvis_admin,
 	require_jarvis_user,
 )
 
@@ -1094,8 +1095,9 @@ def set_auto_apply(conversation: str, value: str | int | bool) -> dict:
 	- Owner-only: the conversation must belong to the caller
 	  (``frappe.session.user == conv.owner``), else PermissionError. Jarvis
 	  Conversation is owner-guarded, so per-conversation == per-user.
-	- ENABLING requires the System Manager role (``frappe.only_for`` -> 403 for
-	  non-admins). DISABLING is always allowed for the owner.
+	- ENABLING requires the Jarvis Admin / System Manager tier
+	  (``require_jarvis_admin`` -> 403 for a plain Jarvis User; PART 4 REVISED,
+	  TASK 45). DISABLING is always allowed for the owner.
 
 	Writes ``auto_apply`` on the CONVERSATION row (not the deprecated site-wide
 	Jarvis Settings Single). Returns ``{ok, data: {auto_apply: on}}``.
@@ -1109,7 +1111,7 @@ def set_auto_apply(conversation: str, value: str | int | bool) -> dict:
 		raise frappe.PermissionError("not your conversation")
 	# Enabling is admin-only; disabling is always allowed for the owner.
 	if on:
-		frappe.only_for("System Manager")
+		require_jarvis_admin()
 	frappe.db.set_value(CONV, conversation, "auto_apply", on, update_modified=False)
 	frappe.db.commit()
 	return {"ok": True, "data": {"auto_apply": on}}

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -225,8 +225,13 @@ def rotate_chat_device() -> dict:
 
 	Punch-list item from the 2026-06-16 review: chat-device Ed25519
 	private key had no rotation surface.
+
+	Gated on ``require_jarvis_admin`` (PART 4 REVISED, TASK 45): the chat DEVICE
+	keypair is tenant infrastructure, distinct from the gateway ``agent_token``
+	(which STAYS SM-only via ``api.rotate_agent_token``).
 	"""
-	frappe.only_for("System Manager")
+	from jarvis.permissions import require_jarvis_admin
+	require_jarvis_admin()
 	creds = _generate_and_pair()
 	frappe.logger().info(
 		"chat_device.rotate: new device_id=%s", creds.device_id,

--- a/jarvis/chat/learned_api.py
+++ b/jarvis/chat/learned_api.py
@@ -50,6 +50,8 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, now_datetime, today
 
+from jarvis.permissions import JARVIS_REVIEWER_ROLES, require_jarvis_admin
+
 JLP = "Jarvis Learned Pattern"
 RUN = "Jarvis Pattern Run"
 SETTINGS = "Jarvis Settings"
@@ -217,12 +219,11 @@ def _is_self_hosted() -> bool:
 		return False
 
 
-# The two bench-side role sets seeded in jarvis/learning/roles.py
-# (_PERSONALISE_ROLES). Administrator is implicit in frappe.only_for. The
-# REVIEWER set gates the board/decide/apply/follow-up actions; the ADMIN set
-# gates the Analysis config surface. Keep in sync with roles.py + DESIGN.md §1.
-_REVIEWER_ROLES = ("Jarvis Skill Reviewer", "Jarvis Admin", "System Manager")
-_ADMIN_ROLES = ("Jarvis Admin", "System Manager")
+# The REVIEWER set gates the board/decide/apply/follow-up actions; the ADMIN
+# tier gates the Analysis config surface. Both now live in jarvis.permissions
+# (PART 4 REVISED, TASK 50 — one definition, no drift). The reviewer set stays
+# WIDER than admin (a Skill Reviewer is not a billing admin); keep them distinct.
+_REVIEWER_ROLES = JARVIS_REVIEWER_ROLES
 
 
 def _reviewer_roles() -> None:
@@ -245,10 +246,10 @@ def _guard() -> None:
 
 
 def _admin_roles() -> None:
-	"""Admin-set role check ONLY (no self-host block). The Analysis probe
+	"""Admin-tier role check ONLY (no self-host block). The Analysis probe
 	(``get_learning_status``) uses this so it stays reachable on a self-host
-	bench, exactly as it did when it was a bare ``frappe.only_for``."""
-	frappe.only_for(_ADMIN_ROLES)
+	bench. PART 4 REVISED, TASK 50 — delegates to jarvis.permissions."""
+	require_jarvis_admin()
 
 
 def _admin_guard() -> None:

--- a/jarvis/chat/personalise_api.py
+++ b/jarvis/chat/personalise_api.py
@@ -40,7 +40,10 @@ from __future__ import annotations
 import json
 
 import frappe
-from jarvis.permissions import require_jarvis_user
+from jarvis.permissions import (
+	has_jarvis_admin_access, is_skill_reviewer, require_jarvis_admin,
+	require_jarvis_user,
+)
 from frappe import _
 from frappe.utils import cint, now_datetime
 
@@ -50,17 +53,11 @@ NOTE = "Jarvis Voice Note"
 WIKI = "Jarvis Wiki Page"
 SETTINGS = "Jarvis Settings"
 
-# Admin set (DESIGN.md section 1): Personalisation Settings + question-rule
-# config. ``frappe.only_for`` special-cases Administrator BEFORE it ever
-# looks at roles (frappe/__init__.py:only_for short-circuits on
-# ``session.user == "Administrator"``), so passing this two-role tuple
-# already covers System Manager | Jarvis Admin | Administrator in one call -
-# the exact idiom ``learned_api._guard`` uses for "System Manager".
-_ADMIN_ROLES = ("System Manager", "Jarvis Admin")
-# Reviewer set, used only for the ``review`` boolean in get_skills_area_caps
-# (the reviewer-gated endpoints themselves live in learned_api.py, the
-# REVIEW agent's file this wave - not called from here).
-_REVIEWER_ROLES = ("Jarvis Skill Reviewer", "Jarvis Admin", "System Manager")
+# Admin + reviewer sets now live in jarvis.permissions (PART 4 REVISED, TASK 50 —
+# one definition, no drift). Admin = require_jarvis_admin/has_jarvis_admin_access
+# (Jarvis Admin | System Manager | Administrator); reviewer = is_skill_reviewer
+# (Jarvis Skill Reviewer | Jarvis Admin | System Manager). A Skill Reviewer must
+# NOT gain billing-admin reach, so the two tiers stay distinct.
 
 # Question status filter values a caller may ask for explicitly. "Deleted" is
 # a legal doctype value (soft-delete) but is NEVER a valid filter - every list
@@ -113,10 +110,10 @@ def _require_system_user() -> None:
 
 
 def _admin_guard() -> None:
-	"""Personalisation Settings / question-rule gate: System Manager |
-	Jarvis Admin | Administrator (see the ``_ADMIN_ROLES`` comment above for
-	why Administrator needs no separate check)."""
-	frappe.only_for(_ADMIN_ROLES)
+	"""Personalisation Settings / question-rule gate: Jarvis Admin / System
+	Manager (Administrator implicit). PART 4 REVISED, TASK 50 — delegates to the
+	one definition in jarvis.permissions."""
+	require_jarvis_admin()
 
 
 def _lk(s: str) -> str:
@@ -214,7 +211,6 @@ def get_skills_area_caps() -> dict:
 	for the integrator/F1-F4 frontend agents."""
 	_require_system_user()
 	me = frappe.session.user
-	roles = set(frappe.get_roles(me))
 
 	stt_enabled = False
 	try:
@@ -233,8 +229,8 @@ def get_skills_area_caps() -> dict:
 	return {
 		"personalise": True,
 		"wiki": True,
-		"analysis": bool(roles & set(_ADMIN_ROLES)),
-		"review": bool(roles & set(_REVIEWER_ROLES)),
+		"analysis": has_jarvis_admin_access(),
+		"review": is_skill_reviewer(),
 		"stt_enabled": stt_enabled,
 		"unanswered_count": unanswered_count,
 		"questions_total": questions_total,

--- a/jarvis/chat/user_settings_permissions.py
+++ b/jarvis/chat/user_settings_permissions.py
@@ -1,0 +1,61 @@
+"""``user``-keyed row scoping for ``Jarvis User Settings`` (security review
+PART 4 REVISED, TASK 52).
+
+``Jarvis User Settings`` (introduced by #278) is the per-user chat-prefs + usage
+doctype. Its permission rows were ``role:"All"`` + ``if_owner`` with NO ORM hook
+— the exact anti-pattern Parts 1–3 eliminated: ``role:"All"`` admits
+Website/portal users (PART 1 TASK 6), and the scoping rode purely on the
+``owner`` axis while the whitelisted API (``chat/user_settings_api.py``) scopes on
+the ``user`` field (owner/user-drift risk, PART 2 TASK 17).
+
+This hook keys the ORM scoping on the **``user``** field so generic REST
+list/get matches the API's ``user``-based scoping and survives any owner/user
+drift. The doctype ``All`` rows are now ``Jarvis User`` (the role is
+load-bearing), and the **admin tier** (System Manager / Jarvis Admin /
+Administrator) is unrestricted — the admin usage board
+(``user_settings_api.admin_list_user_usage``) reads every user's row via a
+permission-checked ``frappe.get_all``, so the query hook MUST return "" for an
+admin or that board would collapse to the admin's own row.
+
+Mirrors ``jarvis/chat/personalise_permissions.py`` (which is SM-only
+unrestricted); this one widens the unrestricted tier to the Jarvis-Admin
+management tier because per-user usage administration is a Jarvis-Admin surface.
+
+NOTE (hooks can only DENY): a falsy ``has_permission`` return denies, so every
+allow path returns an explicit ``True`` to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis.permissions import has_jarvis_admin_access
+
+USER_SETTINGS = "Jarvis User Settings"
+
+
+def user_settings_query_conditions(user: str | None = None) -> str:
+	"""Scope every list/report/REST query on Jarvis User Settings to the caller's
+	own row, keyed on the ``user`` field (not ``owner``). The admin tier
+	(System Manager / Jarvis Admin / Administrator) is unrestricted — the
+	admin usage board reads all rows via a permission-checked ``frappe.get_all``."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return ""
+	return f"`tabJarvis User Settings`.`user` = {frappe.db.escape(user)}"
+
+
+def has_user_settings_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""Per-doc gate keyed on the ``user`` field. Admin tier: all. Everyone else:
+	only the row whose ``user`` is them. Create of a row targeting another user is
+	denied (the usage worker inserts with ignore_permissions and skips this hook)."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return True
+	target = doc.get("user")
+	if ptype == "create":
+		# A settings row must target the creator; backend usage writers (running
+		# as Administrator / the worker) insert with ignore_permissions and skip
+		# this hook entirely.
+		return target is None or target == user
+	return target == user

--- a/jarvis/chat/voice_notes_api.py
+++ b/jarvis/chat/voice_notes_api.py
@@ -18,6 +18,8 @@ import frappe
 from frappe import _
 from frappe.query_builder import DocType, Order
 
+from jarvis.permissions import has_jarvis_admin_access, require_jarvis_admin
+
 NOTE = "Jarvis Voice Note"
 CONV = "Jarvis Conversation"
 _SETTINGS = "Jarvis Settings"
@@ -281,7 +283,9 @@ def get_business_status() -> dict:
 	(for System Managers) the org-wide New backlog + last sweep outcome."""
 	_require_system_user()
 	me = frappe.session.user
-	is_sm = "System Manager" in frappe.get_roles(me)
+	# PART 4 REVISED, TASK 49(d): a Jarvis Admin sees the org backlog + "process
+	# now" affordance (process_voice_notes_now is widened to admit them).
+	is_sm = has_jarvis_admin_access(me)
 
 	stt_enabled = False
 	try:
@@ -306,10 +310,10 @@ def get_business_status() -> dict:
 
 @frappe.whitelist()
 def process_voice_notes_now() -> dict:
-	"""SM-only: run the daily voice-facts sweep now (same deduped background
-	job). Returns ``{"ok": True}`` or ``{"ok": False, "reason": ...}`` when a
-	sweep is already queued or running."""
-	frappe.only_for("System Manager")
+	"""Jarvis Admin / System Manager (PART 4 REVISED, TASK 45): run the daily
+	voice-facts sweep now (same deduped background job). Returns ``{"ok": True}``
+	or ``{"ok": False, "reason": ...}`` when a sweep is already queued or running."""
+	require_jarvis_admin()
 	from jarvis.learning import voice_facts
 
 	return voice_facts.enqueue_process_now()

--- a/jarvis/chat/wiki.py
+++ b/jarvis/chat/wiki.py
@@ -54,6 +54,9 @@ from jarvis.jarvis.doctype.jarvis_wiki_page.jarvis_wiki_page import (
 	WIKI_HAS_PAGES_CACHE_KEY,
 )
 from jarvis.learning.sanitizer import scan_instruction_injection
+from jarvis.permissions import (
+	JARVIS_REVIEWER_ROLES, has_jarvis_admin_access, require_jarvis_admin,
+)
 
 WIKI = "Jarvis Wiki Page"
 CONV = "Jarvis Conversation"
@@ -62,10 +65,10 @@ NOTE = "Jarvis Voice Note"
 PROMO = "Jarvis Wiki Promotion Request"
 SETTINGS = "Jarvis Settings"
 
-# Reviewer set (DESIGN.md sections 1/6): who a new Review item pings. Kept in
-# lockstep with jarvis.chat.learned_api's reviewer guard; Administrator holds
-# every role but is a service identity, so it (and Guest) never gets a badge.
-_REVIEWER_ROLES = ("Jarvis Skill Reviewer", "Jarvis Admin", "System Manager")
+# Reviewer set (DESIGN.md sections 1/6): who a new Review item pings. Single
+# source of truth in jarvis.permissions (PART 4 REVISED, TASK 50); Administrator
+# holds every role but is a service identity, so it (and Guest) never gets a badge.
+_REVIEWER_ROLES = JARVIS_REVIEWER_ROLES
 
 PAGE_TYPES = (
 	"Customer", "Supplier", "Item", "Process", "Doctype",
@@ -1350,10 +1353,11 @@ def restore_wiki_page(slug: str) -> dict:
 
 @frappe.whitelist()
 def set_knowledge_language(value: str) -> dict:
-	"""SM-only: set the org-wide knowledge language (D6) consumed by the
-	wiki/voice-facts extraction prompts. English (default) translates source
-	material; Original keeps the source's dominant language."""
-	frappe.only_for("System Manager")
+	"""Jarvis Admin / System Manager (PART 4 REVISED, TASK 45): set the org-wide
+	knowledge language (D6) consumed by the wiki/voice-facts extraction prompts.
+	English (default) translates source material; Original keeps the source's
+	dominant language."""
+	require_jarvis_admin()
 	value = (value or "").strip()
 	if value not in ("English", "Original"):
 		frappe.throw(_("Knowledge language must be English or Original."))
@@ -1363,9 +1367,10 @@ def set_knowledge_language(value: str) -> dict:
 
 @frappe.whitelist()
 def sync_wiki_mirror_now() -> dict:
-	"""SM-only: queue a FULL org-wiki mirror sync into the tenant container
-	workspace (same deduped job as the doc_events trigger; full=prunes strays)."""
-	frappe.only_for("System Manager")
+	"""Jarvis Admin / System Manager (PART 4 REVISED, TASK 45): queue a FULL
+	org-wiki mirror sync into the tenant container workspace (same deduped job as
+	the doc_events trigger; full=prunes strays)."""
+	require_jarvis_admin()
 	from jarvis.chat import wiki_mirror
 
 	wiki_mirror.enqueue_sync(full=True)
@@ -1374,9 +1379,10 @@ def sync_wiki_mirror_now() -> dict:
 
 @frappe.whitelist()
 def run_wiki_lint_now() -> dict:
-	"""SM-only: run the wiki health check (deterministic lint pass) now and
-	return its summary (also persisted on Jarvis Settings by run_lint)."""
-	frappe.only_for("System Manager")
+	"""Jarvis Admin / System Manager (PART 4 REVISED, TASK 45): run the wiki
+	health check (deterministic lint pass) now and return its summary (also
+	persisted on Jarvis Settings by run_lint)."""
+	require_jarvis_admin()
 	from jarvis.learning import wiki_lint
 
 	return {"ok": True, "summary": wiki_lint.run_lint()}
@@ -1415,13 +1421,14 @@ def get_wiki_graph_history() -> list:
 	recorded by ``wiki_graph.record_history_snapshot`` (one row/day). Powers the
 	Evolution tab's real timeline (page + link growth, orphan decline).
 
-	System Manager only, unlike ``get_wiki_graph``: these are org-wide aggregates
-	over ALL pages (no scope filter), so a scoped user could learn totals about
-	pages they can't see. Non-SM callers get ``[]``; the Evolution tab falls back
-	to reconstructing growth from the caller's own visible pages' creation dates
-	— same fallback used when the daily job hasn't recorded a day yet."""
+	Jarvis Admin / System Manager, unlike ``get_wiki_graph``: these are org-wide
+	aggregates over ALL pages (no scope filter), so a scoped user could learn
+	totals about pages they can't see. Non-admin callers get ``[]``; the Evolution
+	tab falls back to reconstructing growth from the caller's own visible pages'
+	creation dates — same fallback used when the daily job hasn't recorded a day
+	yet (PART 4 REVISED, TASK 45)."""
 	_require_system_user()
-	if "System Manager" not in frappe.get_roles():
+	if not has_jarvis_admin_access():
 		return []
 	if not frappe.db.table_exists("Jarvis Wiki Graph History"):
 		return []

--- a/jarvis/chat/wiki_graph.py
+++ b/jarvis/chat/wiki_graph.py
@@ -333,6 +333,8 @@ def enqueue_sync() -> None:
 
 @frappe.whitelist()
 def sync_now() -> dict:
-	"""Operator 'Sync now' from the Wiki tab (System Manager only)."""
-	frappe.only_for("System Manager")
+	"""Operator 'Sync now' from the Wiki tab (Jarvis Admin / System Manager —
+	PART 4 REVISED, TASK 45)."""
+	from jarvis.permissions import require_jarvis_admin
+	require_jarvis_admin()
 	return sync()

--- a/jarvis/diagnostics.py
+++ b/jarvis/diagnostics.py
@@ -16,11 +16,22 @@ green / red toast based on `ok`.
 
 import frappe
 
+from jarvis.permissions import require_jarvis_admin
+
 
 @frappe.whitelist()
 def ping_admin() -> dict:
 	"""Hit the admin's get_connection endpoint with the customer's stored
-	jarvis_admin_api_key. Distinguishes auth failure from unreachable."""
+	jarvis_admin_api_key. Distinguishes auth failure from unreachable.
+
+	SECURITY (security review PART 4 REVISED, TASK 34-R): the admin
+	``get_connection`` payload carries the live container ``agent_token`` (an
+	``operator.admin``-scoped bearer) + the admin/agent URLs. This diagnostic
+	returns ONLY the connectivity verdict — NEVER the token or any operator URL,
+	for ANY role (even a System Manager reads the token via the permlevel-fenced
+	Settings form, not a ping). Gated on ``require_jarvis_admin`` (Jarvis Admin /
+	System Manager / Administrator)."""
+	require_jarvis_admin()
 	from jarvis import admin_client
 	settings = frappe.get_single("Jarvis Settings")
 	if not (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip():
@@ -29,12 +40,10 @@ def ping_admin() -> dict:
 			"error": "jarvis_admin_api_key is not set; complete onboarding first.",
 		}
 	try:
-		result = admin_client.get_connection()
-		return {
-			"ok": True,
-			"admin_url": admin_client._admin_url(settings),
-			"connection": result,
-		}
+		# Consume the connection to prove reachability + auth, but DISCARD it —
+		# do NOT return agent_token / agent_url / admin_url to the browser.
+		admin_client.get_connection()
+		return {"ok": True, "kind": "ok", "connected": True}
 	except admin_client.AdminAuthError as e:
 		return {"ok": False, "kind": "auth", "error": str(e)}
 	except admin_client.AdminUnreachableError as e:
@@ -43,7 +52,12 @@ def ping_admin() -> dict:
 
 @frappe.whitelist()
 def ping_openclaw() -> dict:
-	"""Open WS to agent_url with agent_token; connect handshake only."""
+	"""Open WS to agent_url with agent_token; connect handshake only.
+
+	SECURITY (PART 4 REVISED, TASK 34-R / 45): gated on ``require_jarvis_admin``
+	and the ``agent_url`` is dropped from the response (endpoint disclosure +
+	operator-scope probe surface). Returns only the connectivity verdict."""
+	require_jarvis_admin()
 	from jarvis import openclaw_ws
 	from jarvis.exceptions import OpenclawUnreachableError
 	settings = frappe.get_single("Jarvis Settings")
@@ -55,7 +69,7 @@ def ping_openclaw() -> dict:
 		return {"ok": False, "kind": "config", "error": "agent_token is not set."}
 	try:
 		openclaw_ws.ping(url, token)
-		return {"ok": True, "agent_url": url}
+		return {"ok": True, "kind": "ok", "connected": True}
 	except OpenclawUnreachableError as e:
 		return {"ok": False, "kind": "unreachable", "error": str(e)}
 	except Exception as e:
@@ -65,7 +79,11 @@ def ping_openclaw() -> dict:
 @frappe.whitelist()
 def force_resync(action: str = "reload") -> dict:
 	"""Bypass on_update change-detection. Run the same sync path on
-	current Settings values. action in {'reload', 'restart'}."""
+	current Settings values. action in {'reload', 'restart'}.
+
+	Gated on ``require_jarvis_admin`` (PART 4 REVISED, TASK 45): a restart
+	reconciles + recreates the tenant container (DoS-class)."""
+	require_jarvis_admin()
 	if action not in ("reload", "restart"):
 		raise frappe.ValidationError(f"invalid action {action!r}; expected reload or restart")
 	settings = frappe.get_single("Jarvis Settings")
@@ -87,7 +105,12 @@ def chat_recovery_stats() -> dict:
 	how often the never-error machinery is quietly compensating for a
 	gateway/turn that never completed live. currently_recovering is a live,
 	un-windowed snapshot (streaming=1 AND recovering=1 right now); the other
-	counts are windowed over 24h and 7d."""
+	counts are windowed over 24h and 7d.
+
+	Gated on ``require_jarvis_admin`` (PART 4 REVISED, TASK 45): the raw
+	``frappe.db.sql`` COUNT/SUM spans ALL users' chat messages (tenant-wide
+	operational metadata), bypassing the PART-1 chat query hook."""
+	require_jarvis_admin()
 	from jarvis.chat.turn_recovery import CEILING_ERROR_MESSAGE
 
 	currently_recovering = frappe.db.sql(
@@ -140,9 +163,12 @@ def reset_agent_pairing() -> dict:
 	mismatch') and the automatic repair did not fire because openclaw
 	returned a generic error code. Clears the chat-device creds, drops any
 	pooled connection, then opens a fresh device-paired connection (which
-	re-pairs via the ops bench + fleet-agent) to verify. System Manager only.
+	re-pairs via the ops bench + fleet-agent) to verify.
+
+	Gated on ``require_jarvis_admin`` (PART 4 REVISED, TASK 45) — tenant operator
+	diagnostic, widened from SM-only.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	from jarvis.chat import openclaw_session_pool
 	from jarvis.chat.device import clear_credentials
 	from jarvis.chat.openclaw_client import OpenclawSession

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -402,3 +402,23 @@ has_permission.update({
 	"Jarvis Agent Activity": "jarvis.chat.agent_permissions.has_activity_permission",
 })
 
+# ---------------------------------------------------------------------------
+# Per-user settings / usage scoping (security review PART 4 REVISED, TASK 52)
+# ---------------------------------------------------------------------------
+# Jarvis User Settings (#278) was role:"All" + if_owner with no ORM hook — the
+# anti-pattern Parts 1-3 eliminated. The doctype rows are now "Jarvis User"
+# (role load-bearing, no portal-user reach), and this hook keys row scoping on
+# the `user` field (matching the API's user-based scoping, surviving owner/user
+# drift). The admin tier (SM / Jarvis Admin / Administrator) is unrestricted so
+# generic REST (frappe.get_list / /api/resource) of Jarvis User Settings returns
+# every row for an admin. (The admin usage board's admin_list_user_usage uses
+# frappe.get_all, which hardcodes ignore_permissions=True and therefore sees all
+# rows regardless of this hook — the admin bypass here matters for the
+# permission-checked frappe.get_list / generic-REST surface, not for that fn.)
+permission_query_conditions.update({
+	"Jarvis User Settings": "jarvis.chat.user_settings_permissions.user_settings_query_conditions",
+})
+has_permission.update({
+	"Jarvis User Settings": "jarvis.chat.user_settings_permissions.has_user_settings_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -134,6 +134,10 @@
    "read": 1,
    "role": "Jarvis User",
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Jarvis Admin"
   }
  ],
  "sort_field": "modified",

--- a/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
@@ -148,6 +148,11 @@
    "role": "Jarvis User"
   },
   {
+   "read": 1,
+   "role": "Jarvis Admin",
+   "write": 1
+  },
+  {
    "permlevel": 1,
    "read": 1,
    "role": "System Manager",

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.py
@@ -9,6 +9,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from jarvis.permissions import has_jarvis_admin_access
+
 
 class JarvisConversation(Document):
 	def before_insert(self):
@@ -50,9 +52,11 @@ class JarvisConversation(Document):
 		if was_on:
 			return  # already on - no transition, nothing to gate
 
-		if "System Manager" not in frappe.get_roles(frappe.session.user):
+		# PART 4 REVISED, TASK 45: the admin tier (Jarvis Admin / System Manager),
+		# matching the widened set_auto_apply enable gate.
+		if not has_jarvis_admin_access(frappe.session.user):
 			frappe.throw(
-				_("Enabling auto-apply requires the System Manager role."),
+				_("Enabling auto-apply requires a Jarvis Admin or System Manager role."),
 				frappe.PermissionError,
 			)
 
@@ -69,8 +73,9 @@ class JarvisConversation(Document):
 		previous = self.get_doc_before_save()
 		if previous and bool(previous.file_box):
 			return
-		if "System Manager" not in frappe.get_roles(frappe.session.user):
+		# PART 4 REVISED, TASK 45: the admin tier (Jarvis Admin / System Manager).
+		if not has_jarvis_admin_access(frappe.session.user):
 			frappe.throw(
-				_("Enabling File Box mode requires the System Manager role."),
+				_("Enabling File Box mode requires a Jarvis Admin or System Manager role."),
 				frappe.PermissionError,
 			)

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -2,20 +2,18 @@ frappe.ui.form.on("Jarvis Settings", {
 	refresh(frm) {
 		if (frm.is_new()) return;
 
+		// Diagnostics now return only a redacted connectivity verdict
+		// ({ok, kind, connected}) — the admin_url / customer status / agent_url
+		// details were removed (PART 4 REVISED TASK 34-R redaction). Show a clean
+		// pass/fail verdict with no URL/status detail.
 		frm.add_custom_button(__("Test Admin Connection"), () => {
 			frappe.call({
 				method: "jarvis.diagnostics.ping_admin",
 			}).then((r) => {
 				const m = r.message || {};
 				if (m.ok) {
-					const conn = m.connection || {};
-					frappe.msgprint({
-						title: __("Admin Reachable"),
-						message: __("Admin URL: {0}<br>Customer status: {1}<br>Agent URL: {2}", [
-							m.admin_url || "?",
-							conn.status || "?",
-							conn.agent_url || "?",
-						]),
+					frappe.show_alert({
+						message: __("Admin reachable"),
 						indicator: "green",
 					});
 				} else {
@@ -35,7 +33,7 @@ frappe.ui.form.on("Jarvis Settings", {
 				const m = r.message || {};
 				if (m.ok) {
 					frappe.show_alert({
-						message: __("Agent Reachable at {0}", [m.agent_url || "?"]),
+						message: __("Agent reachable"),
 						indicator: "green",
 					});
 				} else {
@@ -125,9 +123,18 @@ frappe.ui.form.on("Jarvis Settings", {
 		}, __("Diagnostics"));
 
 		// ---- Self-Hosted openclaw -----------------------------------------
-		frm.add_custom_button(__("Configure Self-Hosted openclaw"), () => {
-			openSelfHostDialog(frm);
-		}, __("Deployment"));
+		// Self-host connect funnels into save_self_hosted / test_connection, which
+		// stay System-Manager-ONLY (owner trust-boundary decision #3). A
+		// Jarvis-Admin-not-SM now reaches this form (TASK 46 grants the admin tier
+		// a Jarvis Settings perm row) but must NOT see a connect button that
+		// dead-ends in a 403 — gate the entry point on System Manager so self-host
+		// config is SM-only end-to-end. ("Switch to Managed" below stays visible:
+		// switch_to_managed is require_jarvis_admin per TASK 45.)
+		if (frappe.user.has_role("System Manager")) {
+			frm.add_custom_button(__("Configure Self-Hosted openclaw"), () => {
+				openSelfHostDialog(frm);
+			}, __("Deployment"));
+		}
 
 		if ((frm.doc.deployment_mode || "Managed") === "Self-Hosted") {
 			frm.add_custom_button(__("Switch to Managed"), () => {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -451,6 +451,7 @@
   {
    "fieldname": "selfhost_tool_user",
    "fieldtype": "Link",
+   "permlevel": 1,
    "options": "User",
    "label": "Self-Host Tool User",
    "depends_on": "eval:doc.deployment_mode == 'Self-Hosted'",
@@ -480,12 +481,14 @@
   {
    "fieldname": "jarvis_admin_url",
    "fieldtype": "Data",
+   "permlevel": 1,
    "label": "Jarvis Admin URL",
    "read_only": 1,
    "description": "HTTPS URL of the Jarvis admin host. Used for signup, billing, subscription state."
   },
   {
    "fieldname": "jarvis_admin_api_key",
+   "permlevel": 1,
    "fieldtype": "Password",
    "label": "Jarvis Admin API Key",
    "read_only": 1,
@@ -493,6 +496,7 @@
   },
   {
    "fieldname": "jarvis_admin_api_secret",
+   "permlevel": 1,
    "fieldtype": "Password",
    "label": "Jarvis Admin API Secret",
    "read_only": 1,
@@ -500,6 +504,7 @@
   },
   {
    "fieldname": "jarvis_admin_customer_email",
+   "permlevel": 1,
    "fieldtype": "Data",
    "label": "Jarvis Admin Customer Email",
    "read_only": 1,
@@ -507,6 +512,7 @@
   },
   {
    "fieldname": "jarvis_admin_customer_password",
+   "permlevel": 1,
    "fieldtype": "Password",
    "label": "Jarvis Admin Customer Password",
    "read_only": 1,
@@ -521,6 +527,7 @@
   {
    "fieldname": "agent_url",
    "fieldtype": "Data",
+   "permlevel": 1,
    "label": "Agent URL",
    "read_only": 1,
    "description": "WebSocket URL for the customer's openclaw agent (e.g. ws://127.0.0.1:18789 in dev; wss://<subdomain>.<admin-host>:443 in prod)"
@@ -528,6 +535,7 @@
   {
    "fieldname": "agent_token",
    "fieldtype": "Password",
+   "permlevel": 1,
    "label": "Agent Token",
    "read_only": 1,
    "description": "Bearer token used to authenticate the secrets.reload RPC and the chat worker's WebSocket session"
@@ -562,6 +570,7 @@
   },
   {
    "fieldname": "chat_device_private_key",
+   "permlevel": 1,
    "fieldtype": "Password",
    "label": "Chat Device Private Key",
    "read_only": 1,
@@ -569,6 +578,7 @@
   },
   {
    "fieldname": "chat_device_token",
+   "permlevel": 1,
    "fieldtype": "Password",
    "label": "Chat Device Token",
    "read_only": 1,
@@ -677,6 +687,7 @@
   {
    "fieldname": "run_query_doctype_allowlist",
    "fieldtype": "Small Text",
+   "permlevel": 1,
    "label": "run_query DocType Allowlist",
    "description": "Defense-in-depth restriction for the run_query agent tool. Comma- or newline-separated list of DocType names. When non-empty, run_query refuses any query referencing a DocType not on this list - even if the calling user has read permission on it through Frappe's normal permission system. Leave empty (default) to allow any DocType the user can read. Use this to lock the agent to a known-good slice of your data (e.g. 'Sales Invoice, Customer, Item, Sales Invoice Item') so a future allowlist bypass in the SQL parser still can't reach the rest of the bench."
   },
@@ -695,6 +706,7 @@
   {
    "fieldname": "sandbox_mode",
    "fieldtype": "Check",
+   "permlevel": 1,
    "label": "Enable Sandbox Mode",
    "default": "0",
    "description": "When enabled, skip payment + allow the developer-onboarding shortcut (jarvis.onboarding.dev_onboard) on this site. Customer's responsibility: only flip this on a dev/test bench. Replaces the legacy <code>frappe.conf.developer_mode</code> check; that flag still works as a backwards-compat fallback for one release."
@@ -706,6 +718,19 @@
    "read": 1,
    "write": 1,
    "create": 1
+  },
+  {
+   "role": "System Manager",
+   "permlevel": 1,
+   "read": 1,
+   "write": 1,
+   "report": 1,
+   "export": 1
+  },
+  {
+   "role": "Jarvis Admin",
+   "read": 1,
+   "write": 1
   }
  ]
 }

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -130,14 +130,14 @@
   ],
   "permissions": [
     {
-      "role": "All",
+      "role": "Jarvis User",
       "permlevel": 0,
       "read": 1,
       "write": 1,
       "if_owner": 1
     },
     {
-      "role": "All",
+      "role": "Jarvis User",
       "permlevel": 1,
       "read": 1
     },

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.json
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.json
@@ -6,5 +6,5 @@
  "module": "Jarvis",
  "standard": "Yes",
  "system_page": 0,
- "roles": [{ "role": "System Manager" }]
+ "roles": [{ "role": "System Manager" }, { "role": "Jarvis Admin" }]
 }

--- a/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.json
+++ b/jarvis/jarvis/page/jarvis_onboarding/jarvis_onboarding.json
@@ -6,5 +6,5 @@
  "module": "Jarvis",
  "standard": "Yes",
  "system_page": 0,
- "roles": [{ "role": "System Manager" }]
+ "roles": [{ "role": "System Manager" }, { "role": "Jarvis Admin" }]
 }

--- a/jarvis/mobile/auth.py
+++ b/jarvis/mobile/auth.py
@@ -41,6 +41,18 @@ def get_mobile_token() -> dict:
 	if not user or user == "Guest":
 		raise frappe.AuthenticationError
 
+	# PART 4 REVISED, TASK 41: a Website/portal user has no legitimate use for the
+	# Jarvis mobile app's token endpoint (PART 1 TASK 6: portal users are a
+	# lower-trust population, and Frappe's own generate_keys is SM-gated). This
+	# stays session-user-only + idempotent, but refuses a non-Desk user
+	# self-minting a durable credential here.
+	from jarvis.permissions import is_system_user
+	if not is_system_user(user):
+		frappe.throw(
+			"The Jarvis mobile token is available to Jarvis app (Desk) users only.",
+			frappe.PermissionError,
+		)
+
 	doc = frappe.get_doc("User", user)
 	existing_secret = doc.get_password("api_secret", raise_exception=False) if doc.api_key else None
 

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -18,6 +18,7 @@ import requests
 
 from jarvis import admin_client, onboarding
 from jarvis.exceptions import JarvisError
+from jarvis.permissions import require_jarvis_admin
 from jarvis.oauth.providers import (
 	UnknownProviderError, build_authorize_url, extract_account_id, get_provider,
 	is_oauth_provider,
@@ -220,7 +221,7 @@ def begin_paste_signin(provider: str, model: str) -> dict:
 	another logged-in System Manager can't complete an in-flight sign-in
 	that someone else started.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _begin_signin(provider, model, pool=False)
 
 
@@ -236,7 +237,7 @@ def begin_pool_account_signin(provider: str, model: str) -> dict:
 	caller (see ``complete_pool_account_signin``) instead of writing creds
 	to Jarvis Settings / pushing to the container.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _begin_signin(provider, model, pool=True)
 
 
@@ -389,7 +390,7 @@ def complete_paste_signin(nonce: str, redirected_url: str) -> dict:
 	someone else started. Sprint-1 Important from the 2026-06-16 code
 	review.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	entry, err = _validate_signin_nonce(nonce)
 	if err:
 		return err
@@ -482,7 +483,7 @@ def complete_pool_account_signin(nonce: str, redirected_url: str) -> dict:
 	``account_ref`` is a freshly generated ``SUB_<hex>`` id that satisfies
 	``^[A-Za-z0-9_-]{1,64}$`` and ``oauth_blob`` is the JSON-encoded blob.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	entry, err = _validate_signin_nonce(nonce)
 	if err:
 		return err
@@ -635,7 +636,7 @@ def disconnect() -> dict:
 	code review): writes Jarvis Settings, ends an active subscription
 	connection.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	try:
 		admin_client.post_subscription_disconnect()
 	except (admin_client.AdminUnreachableError,
@@ -716,7 +717,7 @@ def get_direct_subscription_status() -> dict:
 	System-Manager only (matches the rest of the LLM-config surface). Never
 	returns token material - only display metadata.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	auth_mode = (settings.get("llm_auth_mode") or "").strip()
 	provider = settings.get("llm_provider") or ""

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -11,6 +11,7 @@ from jarvis.exceptions import (
 	AdminAuthError, AdminRateLimitedError, AdminUnreachableError,
 	AdminValidationError,
 )
+from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
 
 
 def _require_admin_url() -> None:
@@ -146,7 +147,7 @@ def sync_connection() -> dict:
 	scheduler runs as Administrator which bypasses only_for. Sprint-1 Important
 	from the 2026-06-16 code review.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
 	api_key = settings.get_password("jarvis_admin_api_key", raise_exception=False) or ""
 	api_secret = settings.get_password("jarvis_admin_api_secret", raise_exception=False) or ""
@@ -185,7 +186,7 @@ def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: s
 
 	System-Manager-gated. routing_mode is always 'failover' in v1. preset is an
 	admin-catalog key or None; validated against the fetched catalog."""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	if isinstance(models, str):
 		models = json.loads(models)
 	if not isinstance(models, list) or not models:
@@ -313,7 +314,7 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 	    magic link. Either shape persists api_key + api_secret on the
 	    bench so the poll endpoint can authenticate.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	_require_admin_url()
 	_require_https_site_url()
 	data = _surface(admin_client.signup, email, company, plan)
@@ -329,6 +330,13 @@ def start_signup(email: str, company: str, plan: str) -> dict:
 			"customer": data.get("customer", ""),
 			"customer_password": data.get("customer_password", ""),
 		})
+	# PART 4 REVISED, TASK 48: the onboarding user becomes a Jarvis Admin. Grant
+	# here (after the admin signup call + connection write succeed) as the EARLY
+	# durable stamp that survives the multi-session email-verify flow. Idempotent
+	# with the finish_payment grant. On a fresh bench nobody holds Jarvis Admin,
+	# so the require_jarvis_admin gate above still requires the first onboarder to
+	# be the SM site owner — a plain Jarvis User is rejected before reaching here.
+	grant_onboarding_admin()
 	return data
 
 
@@ -344,7 +352,7 @@ def get_account_defaults() -> dict:
 	because the SPA has no ``frappe.defaults``. System-Manager only (the onboarding
 	route is SM-gated).
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	user = frappe.session.user
 	email = (frappe.db.get_value("User", user, "email") or user) if user and user != "Guest" else ""
 
@@ -378,7 +386,7 @@ def check_signup_payment_state() -> dict:
 	Gated on System Manager for the same reason as start_signup: this is
 	part of the same paid-signup flow on the customer's bench.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	_require_admin_url()
 	data = _surface(admin_client.get_signup_payment_state)
 	# On the verified poll (email confirmed) admin delivers the customer's
@@ -396,11 +404,15 @@ def finish_payment(payload: dict | str) -> dict:
 	Gated on System Manager: writes container connection (agent_url,
 	agent_token) into Jarvis Settings.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	if isinstance(payload, str):
 		payload = json.loads(payload)
 	data = _surface(admin_client.confirm_payment, payload)
 	write_connection(data)
+	# PART 4 REVISED, TASK 48: the AUTHORITATIVE "onboarding AND paying" grant —
+	# make the paying user a Jarvis Admin once payment confirms and the connection
+	# is written. Idempotent with the start_signup grant.
+	grant_onboarding_admin()
 	return data
 
 
@@ -412,7 +424,7 @@ def renew() -> dict:
 	Gated on System Manager: initiates a billing transaction tied to the
 	site's admin account.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	return _surface(admin_client.renew)
 
 
@@ -446,7 +458,7 @@ def save_llm_creds(provider: str, model: str, api_key: str = "",
 	to an attacker-controlled URL and exfiltrate chat context through
 	future LLM calls.
 	"""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	if not provider or not model:
 		raise frappe.ValidationError("provider and model are required")
 	if auth_mode not in {"api_key", "oauth"}:
@@ -525,7 +537,7 @@ def get_llm_config() -> dict:
 	preset, routing_mode, derived proxy_active. Reads models[] (NOT the legacy
 	llm_* mirrors). Never returns api_key secrets — only a has_key boolean.
 	System-Manager-only (spec 7)."""
-	frappe.only_for("System Manager")
+	require_jarvis_admin()
 	from jarvis.jarvis.pool_serialize import _model_accounts
 	s = frappe.get_single("Jarvis Settings")
 	models = []
@@ -625,6 +637,9 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 
 	Gated on System Manager in addition to the sandbox_mode check.
 	"""
+	# STAYS SM-only (PART 4 REVISED, TASK 48): the dev-onboard shortcut GATE is
+	# deliberately NOT widened to the Jarvis Admin tier — it is a sandbox/dev
+	# escape hatch (SM + sandbox_mode). Only the grant below matches the paid path.
 	frappe.only_for("System Manager")
 	from jarvis.dev import is_sandbox_mode
 	if not is_sandbox_mode():
@@ -636,4 +651,7 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 	_require_admin_url()
 	data = _surface(admin_client.dev_signup, email, company, plan)
 	write_connection(data)
+	# PART 4 REVISED, TASK 48: sandbox parity with the paid path — grant the dev
+	# onboarder Jarvis Admin. The GATE above stays SM + sandbox.
+	grant_onboarding_admin()
 	return data

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -172,6 +172,33 @@ def require_jarvis_admin(user: str | None = None) -> None:
 		)
 
 
+def grant_onboarding_admin(user: str | None = None) -> None:
+	"""Grant ``Jarvis Admin`` to the onboarding/paying user (security review
+	PART 4 REVISED, TASK 44/48).
+
+	Grants ONLY ``Jarvis Admin`` — NOT ``Jarvis User`` — because
+	:data:`JARVIS_ACCESS_ROLES` already includes ``Jarvis Admin``, so a user
+	holding only ``Jarvis Admin`` still passes :func:`has_jarvis_access` and every
+	``@require_jarvis_user`` endpoint (they are not locked out of the chat surface
+	they administer).
+
+	The role name AND the target-user resolution are server-hardcoded (no
+	caller-supplied role), so the ``ignore_permissions`` insert carries NO
+	privilege-escalation vector. Idempotent — a no-op when the role is already
+	held; never grants to Administrator / Guest."""
+	ensure_jarvis_admin_role()
+	user = user or frappe.session.user
+	if not user or user in ("Administrator", "Guest"):
+		return
+	if not frappe.db.exists(
+		"Has Role", {"parenttype": "User", "parent": user, "role": JARVIS_ADMIN_ROLE}
+	):
+		frappe.get_doc({
+			"doctype": "Has Role", "parenttype": "User",
+			"parentfield": "roles", "parent": user, "role": JARVIS_ADMIN_ROLE,
+		}).insert(ignore_permissions=True)
+
+
 def require_jarvis_user(fn):
 	"""Decorator form of :func:`require_jarvis_access` for whitelisted chat
 	endpoints (PART 1 TASK 8).

--- a/jarvis/selfhost.py
+++ b/jarvis/selfhost.py
@@ -29,6 +29,7 @@ import requests
 from frappe.utils import now_datetime
 
 from jarvis._password_utils import clear_settings_password, set_settings_password
+from jarvis.permissions import require_jarvis_admin
 
 # Timeouts (seconds). Reachability is snappy; the deep chat ping tolerates a
 # slow reasoning model.
@@ -369,8 +370,10 @@ def switch_to_managed() -> dict:
     """Switch back to Managed mode. Re-syncs the managed connection from admin
     if the bench was onboarded; otherwise just flips the flag.
 
-    System Manager only."""
-    frappe.only_for("System Manager")
+    Jarvis Admin / System Manager (PART 4 REVISED, TASK 45 — the deployment-mode
+    toggle is tenant administration, not the operator connection secret; the
+    save_self_hosted / test_connection operator writes STAY SM-only)."""
+    require_jarvis_admin()
     s = frappe.get_single("Jarvis Settings")
     s.db_set("deployment_mode", "Managed")
     frappe.db.commit()
@@ -385,12 +388,24 @@ def switch_to_managed() -> dict:
 
 @frappe.whitelist()
 def get_status() -> dict:
-    """Deployment status for the account/settings UI. System Manager only."""
-    frappe.only_for("System Manager")
+    """Deployment status for the account/settings UI. Jarvis Admin / System
+    Manager (PART 4 REVISED, TASK 45).
+
+    SECURITY (Part-4 review finding A): ``agent_url`` is one of the six
+    permlevel-1 operator/connection fields fenced SM-only in Jarvis Settings
+    (TASK 46) and redacted from ``ping_openclaw`` (TASK 34-R). It must NOT be
+    disclosed to a Jarvis-Admin-not-SM through this widened endpoint, so it is
+    included ONLY for a System Manager / Administrator — mirroring the ping
+    redaction. (deployment_mode / validated_at / stream are not operator fields
+    and stay visible to the whole admin tier.)"""
+    require_jarvis_admin()
     s = frappe.get_single("Jarvis Settings")
+    is_sm = ("System Manager" in frappe.get_roles()) or (
+        frappe.session.user == "Administrator")
     return {
         "deployment_mode": s.deployment_mode or "Managed",
-        "agent_url": (s.agent_url or "") if (s.deployment_mode == "Self-Hosted") else "",
+        "agent_url": (s.agent_url or "")
+        if (is_sm and s.deployment_mode == "Self-Hosted") else "",
         "validated_at": str(s.selfhost_last_validated_at or ""),
         "stream": (s.selfhost_stream is None) or bool(s.selfhost_stream),
     }

--- a/jarvis/tests/test_diagnostics.py
+++ b/jarvis/tests/test_diagnostics.py
@@ -32,7 +32,15 @@ class TestPingAdmin(FrappeTestCase):
 				   return_value={"status": "active", "agent_url": "ws://localhost:19200"}):
 			out = diagnostics.ping_admin()
 		self.assertTrue(out["ok"])
-		self.assertEqual(out["connection"]["status"], "active")
+		self.assertEqual(out["kind"], "ok")
+		self.assertTrue(out["connected"])
+		# Security review PART 4 TASK 34-R: the admin get_connection payload carries
+		# the container agent_token + operator URLs; ping_admin consumes it to prove
+		# reachability but must NEVER return it (to ANY role). Assert the redaction.
+		self.assertNotIn("connection", out)
+		self.assertNotIn("admin_url", out)
+		self.assertNotIn("agent_url", out)
+		self.assertNotIn("agent_token", out)
 
 	def test_auth_failure_returns_kind_auth(self):
 		from jarvis.exceptions import AdminAuthError
@@ -96,6 +104,9 @@ class TestPingOpenclaw(FrappeTestCase):
 			out = diagnostics.ping_openclaw()
 		p.assert_called_once_with("ws://h:1", "t")
 		self.assertTrue(out["ok"])
+		# PART 4 TASK 34-R: the endpoint agent_url is an operator-disclosure surface
+		# and is dropped from the response.
+		self.assertNotIn("agent_url", out)
 
 	def test_unreachable(self):
 		from jarvis.exceptions import OpenclawUnreachableError

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -101,6 +101,13 @@ class Part4Base(FrappeTestCase):
 		# Deterministic baseline for the permlevel-fence read/write assertions.
 		frappe.db.set_value(
 			SETTINGS, SETTINGS, "agent_url", "ws://p4-baseline", update_modified=False)
+		# Behavioural learning is managed-only; the Settings validate() throws
+		# "available on managed plans only" when pattern_learning_enabled is on AND
+		# the site is self-hosted. The permlevel-fence tests save Jarvis Settings, so
+		# disable it here to keep that unrelated plan-gate from firing on a
+		# self-hosted test site (it is off in CI's baked dump, on locally).
+		frappe.db.set_value(
+			SETTINGS, SETTINGS, "pattern_learning_enabled", 0, update_modified=False)
 		frappe.db.commit()
 
 	@classmethod

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -1,0 +1,533 @@
+"""Security review PART 4 (REVISED — Jarvis Admin administration tier) —
+exploit reproductions + fix proofs.
+
+Covers the central admin gate (TASK 44), the Settings operator-field permlevel
+fence (TASK 46), the ping_admin/ping_openclaw token+URL redaction (TASK 34-R),
+the onboarding grant (TASK 48), the date_add SQLi (TASK 35), the widened
+agent-admin endpoints (TASK 45/47), the Jarvis User Settings ORM scoping (TASK
+52), the FOUR owner-decision capabilities kept System-Manager-only, and the
+cross-module endpoint-gating coverage guard (TASK 43/51).
+
+The tier gate is deliberately WIDEN-ONLY: converting only_for("System Manager")
+to require_jarvis_admin admits Jarvis Admin in ADDITION to SM/Administrator, so
+the tests assert both a plain Jarvis User is rejected AND a Jarvis-Admin-not-SM
+is admitted, while the four owner-SM-only capabilities still reject a non-SM
+Jarvis Admin.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from pypika.terms import Field
+
+from jarvis import diagnostics
+from jarvis.chat import agents_api, usage
+
+SETTINGS = "Jarvis Settings"
+USER_SETTINGS = "Jarvis User Settings"
+LISTING = "Jarvis Agent Listing"
+
+USER_A = "p4-usera@example.com"       # plain Jarvis User
+USER_B = "p4-userb@example.com"       # plain Jarvis User
+ADMIN = "p4-admin@example.com"        # Jarvis Admin, NOT System Manager
+SM = "p4-sm@example.com"              # System Manager (real, not Administrator)
+WEBSITE = "p4-website@example.com"    # Website (portal) user
+GRANTEE = "p4-grantee@example.com"    # Jarvis User with NO Jarvis Admin (grant target)
+AGENT_SLUG = "p4-test-agent"
+PFX = "p4"
+
+_MANAGEABLE = {"System Manager", "Jarvis User", "Jarvis Admin", "Jarvis Skill Reviewer"}
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _ensure_user(email: str, roles: list[str], user_type: str = "System User") -> str:
+	from jarvis.permissions import ensure_jarvis_admin_role, ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	ensure_jarvis_admin_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc({
+			"doctype": "User", "email": email, "first_name": PFX,
+			"send_welcome_email": 0, "enabled": 1, "user_type": user_type,
+		})
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	if frappe.db.get_value("User", email, "user_type") != user_type:
+		frappe.db.set_value("User", email, "user_type", user_type)
+	desired = set(roles)
+	current = set(frappe.get_roles(email))
+	to_add = desired - current
+	to_remove = (_MANAGEABLE & current) - desired
+	doc = frappe.get_doc("User", email)
+	if to_add:
+		doc.add_roles(*to_add)
+	if to_remove:
+		doc.remove_roles(*to_remove)
+	frappe.clear_cache(user=email)
+	return email
+
+
+class Part4Base(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(USER_A, ["Jarvis User"])
+		_ensure_user(USER_B, ["Jarvis User"])
+		_ensure_user(ADMIN, ["Jarvis Admin"])         # NOT System Manager
+		_ensure_user(SM, ["System Manager"])
+		_ensure_user(GRANTEE, ["Jarvis User"])        # no Jarvis Admin yet
+		_ensure_user(WEBSITE, [], user_type="Website User")
+		if not frappe.db.exists(LISTING, AGENT_SLUG):
+			frappe.get_doc({
+				"doctype": LISTING, "agent_slug": AGENT_SLUG, "title": "P4 Test Agent",
+				"description": "test", "status": "Published", "nature": "Auditor",
+			}).insert(ignore_permissions=True)
+		# Deterministic baseline for the permlevel-fence read/write assertions.
+		frappe.db.set_value(
+			SETTINGS, SETTINGS, "agent_url", "ws://p4-baseline", update_modified=False)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+		if frappe.db.exists(LISTING, AGENT_SLUG):
+			frappe.delete_doc(LISTING, AGENT_SLUG, force=True, ignore_permissions=True)
+		frappe.db.set_value(
+			SETTINGS, SETTINGS, "agent_url", "", update_modified=False)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# TASK 44 — the central require_jarvis_admin tier gate
+# --------------------------------------------------------------------------- #
+class TestAdminTierGate(Part4Base):
+	def test_gate_admits_admin_sm_administrator_blocks_plain_user(self):
+		from jarvis.permissions import has_jarvis_admin_access, require_jarvis_admin
+
+		with _as(USER_A):
+			self.assertFalse(has_jarvis_admin_access())
+			with self.assertRaises(frappe.PermissionError):
+				require_jarvis_admin()
+		with _as(ADMIN):
+			self.assertTrue(has_jarvis_admin_access())
+			require_jarvis_admin()  # no raise
+		with _as(SM):
+			self.assertTrue(has_jarvis_admin_access())
+			require_jarvis_admin()  # no raise
+		with _as("Administrator"):
+			require_jarvis_admin()  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# TASK 44/48 — grant_onboarding_admin
+# --------------------------------------------------------------------------- #
+class TestOnboardingGrant(Part4Base):
+	def test_grant_is_idempotent_and_only_jarvis_admin(self):
+		from jarvis.permissions import grant_onboarding_admin
+
+		def _rows():
+			return frappe.db.count(
+				"Has Role",
+				{"parenttype": "User", "parent": GRANTEE, "role": "Jarvis Admin"},
+			)
+
+		self.assertEqual(_rows(), 0)
+		grant_onboarding_admin(GRANTEE)
+		self.assertEqual(_rows(), 1)
+		frappe.clear_cache(user=GRANTEE)
+		self.assertIn("Jarvis Admin", frappe.get_roles(GRANTEE))
+		# Idempotent: a second call adds no duplicate row.
+		grant_onboarding_admin(GRANTEE)
+		self.assertEqual(_rows(), 1)
+
+	def test_grant_never_touches_administrator_or_guest(self):
+		from jarvis.permissions import grant_onboarding_admin
+
+		grant_onboarding_admin("Administrator")  # no-op, no raise
+		grant_onboarding_admin("Guest")          # no-op, no raise
+		self.assertFalse(frappe.db.exists(
+			"Has Role", {"parenttype": "User", "parent": "Guest", "role": "Jarvis Admin"}))
+
+
+# --------------------------------------------------------------------------- #
+# TASK 46 — Jarvis Settings operator fields fenced at permlevel 1
+# --------------------------------------------------------------------------- #
+class TestSettingsPermlevelFence(Part4Base):
+	OPERATOR_FIELDS = (
+		"jarvis_admin_url", "agent_url", "agent_token",
+		"selfhost_tool_user", "sandbox_mode", "run_query_doctype_allowlist",
+	)
+
+	def test_jarvis_admin_cannot_read_operator_fields_but_sm_can(self):
+		# Read fence via the exact method Frappe applies on the perm-checked form
+		# load: fields above the user's permlevel are stripped.
+		with _as(ADMIN):
+			doc = frappe.get_doc(SETTINGS)
+			doc.apply_fieldlevel_read_permissions()
+			for f in self.OPERATOR_FIELDS:
+				self.assertFalse(
+					doc.get(f), f"Jarvis Admin can read fenced operator field {f!r}")
+		with _as(SM):
+			doc_sm = frappe.get_doc(SETTINGS)
+			doc_sm.apply_fieldlevel_read_permissions()
+			self.assertEqual(
+				doc_sm.get("agent_url"), "ws://p4-baseline",
+				"System Manager lost read on the permlevel-1 operator section")
+
+	def test_jarvis_admin_write_to_operator_field_is_dropped_sm_write_applies(self):
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
+
+		# Patch on_update so a save doesn't fire the admin container sync.
+		with patch.object(JarvisSettings, "on_update", lambda self: None):
+			# Jarvis Admin (pl0 write, NO pl1) -> agent_url reset, stays baseline.
+			with _as(ADMIN):
+				try:
+					frappe.client.set_value(SETTINGS, SETTINGS, "agent_url", "ws://evil")
+				except frappe.PermissionError:
+					pass
+			self.assertEqual(
+				frappe.db.get_value(SETTINGS, SETTINGS, "agent_url"), "ws://p4-baseline",
+				"a Jarvis Admin repointed agent_url via REST — permlevel fence failed")
+			# System Manager (pl1 write) -> the write applies.
+			with _as(SM):
+				frappe.client.set_value(SETTINGS, SETTINGS, "agent_url", "ws://sm-set")
+			self.assertEqual(
+				frappe.db.get_value(SETTINGS, SETTINGS, "agent_url"), "ws://sm-set",
+				"System Manager could not write the permlevel-1 operator field")
+
+	def test_jarvis_admin_cannot_write_admin_credential_field_sm_can(self):
+		# Finding B: the six admin-credential / device fields (jarvis_admin_api_key
+		# et al.) are now permlevel-1 fenced. A {Jarvis Admin, write} pl0 row let a
+		# non-SM admin overwrite them via frappe.client.set_value (Frappe does NOT
+		# enforce field read_only on the REST save path — only permlevel does), e.g.
+		# hijacking the admin connection. The fence must drop the Admin write and
+		# keep it working for SM. Uses jarvis_admin_api_key (a Password field, read
+		# back via get_password); the production writer is set_settings_password
+		# (encrypts into __Auth, bypasses permlevel — proving no writer breaks).
+		from jarvis._password_utils import set_settings_password
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
+
+		def _key():
+			return frappe.get_doc(SETTINGS).get_password(
+				"jarvis_admin_api_key", raise_exception=False)
+
+		with patch.object(JarvisSettings, "on_update", lambda self: None):
+			# Server-side seed via the real writer (permlevel-bypass, unbroken).
+			set_settings_password(frappe.get_doc(SETTINGS), "jarvis_admin_api_key", "BASE-KEY")
+			self.assertEqual(_key(), "BASE-KEY")
+			# Jarvis Admin (pl0 write, NO pl1) -> the credential write is dropped.
+			with _as(ADMIN):
+				try:
+					frappe.client.set_value(
+						SETTINGS, SETTINGS, "jarvis_admin_api_key", "ADMIN-HIJACK")
+				except frappe.PermissionError:
+					pass
+			self.assertEqual(
+				_key(), "BASE-KEY",
+				"a Jarvis Admin overwrote jarvis_admin_api_key via REST — the "
+				"credential permlevel fence failed (admin-connection hijack)")
+			# System Manager (pl1 write) -> the write applies.
+			with _as(SM):
+				frappe.client.set_value(
+					SETTINGS, SETTINGS, "jarvis_admin_api_key", "SM-SET-KEY")
+			self.assertEqual(
+				_key(), "SM-SET-KEY",
+				"System Manager could not write the permlevel-1 credential field")
+
+
+# --------------------------------------------------------------------------- #
+# TASK 34-R — ping_admin / ping_openclaw never leak the token or operator URL
+# --------------------------------------------------------------------------- #
+class TestDiagnosticsRedaction(Part4Base):
+	def test_ping_admin_redacts_token_and_urls_on_success(self):
+		mock_settings = MagicMock()
+		mock_settings.get_password.return_value = "test-admin-key"
+		leaky = {
+			"agent_token": "SECRET-TOKEN", "agent_url": "ws://secret-agent",
+			"admin_url": "https://secret-admin",
+		}
+		with _as(ADMIN), \
+			patch("frappe.get_single", return_value=mock_settings), \
+			patch("jarvis.admin_client.get_connection", return_value=leaky):
+			res = diagnostics.ping_admin()
+		self.assertTrue(res.get("ok"))
+		blob = json.dumps(res)
+		self.assertNotIn("SECRET-TOKEN", blob)
+		self.assertNotIn("secret-agent", blob)
+		self.assertNotIn("secret-admin", blob)
+		self.assertNotIn("agent_token", res)
+		self.assertNotIn("connection", res)
+		self.assertNotIn("admin_url", res)
+
+	def test_ping_openclaw_drops_agent_url(self):
+		mock_settings = MagicMock()
+		mock_settings.agent_url = "ws://secret-openclaw"
+		mock_settings.get_password.return_value = "tok-secret"
+		with _as(ADMIN), \
+			patch("frappe.get_single", return_value=mock_settings), \
+			patch("jarvis.openclaw_ws.ping", return_value=None):
+			res = diagnostics.ping_openclaw()
+		self.assertTrue(res.get("ok"))
+		self.assertNotIn("agent_url", res)
+		self.assertNotIn("secret-openclaw", json.dumps(res))
+
+	def test_ping_endpoints_reject_plain_jarvis_user(self):
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				diagnostics.ping_admin()
+			with self.assertRaises(frappe.PermissionError):
+				diagnostics.ping_openclaw()
+
+	def test_ping_admin_admits_jarvis_admin(self):
+		# The gate lets a Jarvis-Admin-not-SM through (returns a config verdict
+		# here since no key is mocked — proving the gate passed, not a 403).
+		mock_settings = MagicMock()
+		mock_settings.get_password.return_value = ""  # no key -> config branch
+		with _as(ADMIN), patch("frappe.get_single", return_value=mock_settings):
+			res = diagnostics.ping_admin()
+		self.assertEqual(res.get("kind"), "config")
+
+
+# --------------------------------------------------------------------------- #
+# The FOUR owner-decision capabilities stay System-Manager-ONLY
+# --------------------------------------------------------------------------- #
+class TestOwnerSmOnlyCapabilities(Part4Base):
+	def test_rotate_agent_token_rejects_non_sm_admin(self):
+		from jarvis import api as jarvis_api
+
+		with _as(ADMIN):
+			with self.assertRaises(frappe.PermissionError):
+				jarvis_api.rotate_agent_token()
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				jarvis_api.rotate_agent_token()
+
+	def test_selfhost_write_capabilities_reject_non_sm_admin(self):
+		from jarvis import selfhost
+
+		with _as(ADMIN):
+			with self.assertRaises(frappe.PermissionError):
+				selfhost.save_self_hosted("http://x", "tok")
+			with self.assertRaises(frappe.PermissionError):
+				selfhost.test_connection("http://x")
+
+	def test_admin_can_use_widened_selfhost_status(self):
+		from jarvis import selfhost
+
+		# get_status was widened to the admin tier — a Jarvis Admin may call it.
+		with _as(ADMIN):
+			out = selfhost.get_status()
+		self.assertIn("deployment_mode", out)
+
+	def test_get_status_redacts_agent_url_from_non_sm_admin(self):
+		from jarvis import selfhost
+
+		# Finding A: agent_url is a permlevel-1 operator field (TASK 46) redacted
+		# from ping_openclaw (TASK 34-R). get_status was widened to the admin tier,
+		# so it must ALSO withhold agent_url from a Jarvis-Admin-not-SM while still
+		# showing it to a System Manager. Parallels test_ping_openclaw_drops_agent_url.
+		mock_settings = MagicMock()
+		mock_settings.deployment_mode = "Self-Hosted"
+		mock_settings.agent_url = "ws://secret-selfhost"
+		mock_settings.selfhost_last_validated_at = ""
+		mock_settings.selfhost_stream = 1
+		with _as(ADMIN), patch("frappe.get_single", return_value=mock_settings):
+			admin_out = selfhost.get_status()
+		self.assertFalse(
+			admin_out.get("agent_url"),
+			"get_status leaked the self-host agent_url to a Jarvis-Admin-not-SM")
+		self.assertNotIn("secret-selfhost", json.dumps(admin_out))
+		with _as(SM), patch("frappe.get_single", return_value=mock_settings):
+			sm_out = selfhost.get_status()
+		self.assertEqual(
+			sm_out.get("agent_url"), "ws://secret-selfhost",
+			"System Manager lost agent_url in get_status after the redaction")
+
+
+# --------------------------------------------------------------------------- #
+# TASK 35 — date_add SQLi (unconstrained literal n)
+# --------------------------------------------------------------------------- #
+class TestDateAddSqli(Part4Base):
+	def test_string_n_rejected_int_n_accepted(self):
+		from jarvis.exceptions import InvalidArgumentError
+		from jarvis.tools._expr import _build_date_add
+
+		x = Field("d")
+		payload = '1 YEAR)) UNION SELECT * FROM `__Auth` -- '
+		for dialect in ("mariadb", "sqlite"):
+			with self.assertRaises(InvalidArgumentError):
+				_build_date_add([x, payload, "year"], dialect)
+		# A valid integer (incl. negative) still builds on both paths.
+		_build_date_add([x, 3, "year"], "mariadb")
+		_build_date_add([x, -2, "month"], "sqlite")
+
+
+# --------------------------------------------------------------------------- #
+# TASK 45 / 47 — widened agent-admin endpoints work for a Jarvis-Admin-not-SM
+# --------------------------------------------------------------------------- #
+class TestAgentAdminWidened(Part4Base):
+	def test_set_agent_roles_and_status_work_for_jarvis_admin(self):
+		with _as(USER_A):  # plain Jarvis User is rejected
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.set_agent_roles(AGENT_SLUG, json.dumps([]))
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.set_listing_status(AGENT_SLUG, "Published")
+		with _as(ADMIN):  # Jarvis Admin (not SM) passes gate AND the doc-layer save
+			res = agents_api.set_agent_roles(AGENT_SLUG, json.dumps([]))
+			self.assertTrue(res.get("ok"))
+			res2 = agents_api.set_listing_status(AGENT_SLUG, "Deprecated")
+			self.assertEqual(res2.get("status"), "Deprecated")
+
+	def test_admin_overview_visible_to_jarvis_admin(self):
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.get_agent_admin_overview()
+		with _as(ADMIN):
+			out = agents_api.get_agent_admin_overview()
+		self.assertIn("listings", out)
+
+
+# --------------------------------------------------------------------------- #
+# TASK 52 — Jarvis User Settings ORM scoping (no All row; user-keyed hook)
+# --------------------------------------------------------------------------- #
+class TestUserSettingsScoping(Part4Base):
+	def test_website_user_cannot_read_the_doctype(self):
+		self.assertFalse(
+			frappe.has_permission(USER_SETTINGS, "read", user=WEBSITE),
+			"a Website/portal user can still reach Jarvis User Settings")
+		# A Jarvis User retains read (if_owner row).
+		self.assertTrue(frappe.has_permission(USER_SETTINGS, "read", user=USER_A))
+
+	def test_jarvis_user_sees_only_own_row_admin_sees_all(self):
+		row_a = usage.get_or_create_user_settings(USER_A)
+		row_b = usage.get_or_create_user_settings(USER_B)
+		with _as(USER_A):
+			mine = set(frappe.get_list(
+				USER_SETTINGS, pluck="name", limit_page_length=0))
+		self.assertIn(row_a.name, mine)
+		self.assertNotIn(row_b.name, mine, "leak: a Jarvis User sees another user's row")
+		# The admin tier is unrestricted (admin_list_user_usage relies on this).
+		with _as(ADMIN):
+			everyone = set(frappe.get_list(
+				USER_SETTINGS, pluck="name", limit_page_length=0))
+		self.assertIn(row_a.name, everyone)
+		self.assertIn(row_b.name, everyone)
+
+	def test_usage_write_path_still_works(self):
+		# The worker path (ignore_permissions + raw SQL) is unaffected by the
+		# All->Jarvis User row change: creating + recording usage still writes.
+		row = usage.get_or_create_user_settings(USER_A)
+		self.assertEqual(frappe.db.get_value(USER_SETTINGS, row.name, "user"), USER_A)
+
+
+# --------------------------------------------------------------------------- #
+# TASK 43 / 51 — cross-module endpoint-gating coverage guard
+# --------------------------------------------------------------------------- #
+_APP_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+# Whitelisted fns in these privileged modules must be gated. The Part-1
+# test_chat_endpoint_gating only sweeps jarvis/chat/, so every Part-4 gap lives
+# outside it — this guard closes that hole.
+_GUARD_SUBSTRS = (
+	"require_jarvis_admin", "require_jarvis_access", "require_jarvis_user",
+	"require_skill_reviewer", "only_for", "has_jarvis_access",
+	"has_jarvis_admin_access", "is_system_user", "_dev_guard",
+	"_require_system_user", "_require_admin",
+)
+
+# Intentionally-open endpoints (justified): boolean readiness probes, the public
+# plan/preset catalog + the onboarding sync poller (carry no secret; the SPA
+# needs them before roles settle), and the site-URL pairing QR (Guest-rejected,
+# no secret).
+_OPEN_ALLOWLIST = {
+	"account.is_onboarded": "boolean readiness probe, no secret",
+	"account.is_ready_for_chat": "boolean readiness probe, no secret",
+	"onboarding.list_plans": "public plan catalog (spec: leave ungated)",
+	"onboarding.get_preset_catalog": "public preset catalog (spec: leave ungated)",
+	"onboarding.get_llm_sync_status": "sanitized sync poller, needed pre-role-settle",
+	"mobile.auth.get_pairing_qr": "Guest-rejected; encodes only the site URL, no secret",
+}
+
+_COVERED_MODULES = {
+	"diagnostics.py": "diagnostics",
+	"onboarding.py": "onboarding",
+	"account.py": "account",
+	"selfhost.py": "selfhost",
+	"dev.py": "dev",
+}
+_COVERED_SUBPATHS = {
+	os.path.join("oauth", "api.py"): "oauth.api",
+	os.path.join("mobile", "auth.py"): "mobile.auth",
+}
+
+
+def _fn_is_gated(node: ast.FunctionDef) -> bool:
+	for d in node.decorator_list:
+		if any(g in ast.unparse(d) for g in _GUARD_SUBSTRS):
+			return True
+	for sub in ast.walk(node):
+		if isinstance(sub, ast.Call):
+			try:
+				name = ast.unparse(sub.func)
+			except Exception:
+				name = ""
+			if any(g in name for g in _GUARD_SUBSTRS):
+				return True
+	return False
+
+
+def _iter_privileged_endpoints():
+	targets = []
+	for fname, mod in _COVERED_MODULES.items():
+		targets.append((os.path.join(_APP_ROOT, fname), mod))
+	for sub, mod in _COVERED_SUBPATHS.items():
+		targets.append((os.path.join(_APP_ROOT, sub), mod))
+	for path, mod in targets:
+		with open(path, encoding="utf-8") as fh:
+			tree = ast.parse(fh.read(), filename=path)
+		for node in ast.walk(tree):
+			if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+				"whitelist" in ast.unparse(d) for d in node.decorator_list
+			):
+				yield mod, node.name, node
+
+
+class TestPrivilegedEndpointGating(Part4Base):
+	def test_every_privileged_endpoint_is_gated_or_allowlisted(self):
+		found_any = False
+		offenders = []
+		for mod, name, node in _iter_privileged_endpoints():
+			found_any = True
+			key = f"{mod}.{name}"
+			if key in _OPEN_ALLOWLIST:
+				continue
+			if _fn_is_gated(node):
+				continue
+			offenders.append(key)
+		self.assertTrue(found_any, "sweep found no privileged endpoints - the walk broke")
+		self.assertFalse(
+			offenders,
+			"ungated privileged @frappe.whitelist endpoints (add require_jarvis_admin / "
+			"only_for / a role guard, or allowlist with a justification): "
+			+ ", ".join(sorted(offenders)),
+		)

--- a/jarvis/tools/_expr.py
+++ b/jarvis/tools/_expr.py
@@ -208,6 +208,18 @@ def _build_date_add(args: list, dialect: str) -> Term:
 	``unit`` is a literal from the same set as date_part.
 	"""
 	x, n, unit = args
+	# SECURITY (security review PART 4, TASK 35): ``n`` is registered as an
+	# unconstrained ``literal`` (accepts any scalar), and the MariaDB path below
+	# interpolates it RAW into an ``fn.LiteralValue`` (unescaped SQL) — the sqlite
+	# path also f-strings it after ``n * multiplier``. Coerce + validate to an
+	# integer FIRST, before the dialect branch, so a string payload (e.g.
+	# "1 YEAR)) UNION SELECT ... FROM `__Auth` -- ") can never break out of the
+	# INTERVAL expression. This is the load-bearing fix; the only raw-literal
+	# interpolation site in this module (grep-audited: line 230 below).
+	try:
+		n = int(n)
+	except (TypeError, ValueError):
+		raise InvalidArgumentError("date_add(x, n, unit): n must be an integer")
 	unit = unit.lower()
 	if unit == "fiscal_year":
 		raise InvalidArgumentError(

--- a/jarvis/tools/run_method.py
+++ b/jarvis/tools/run_method.py
@@ -29,7 +29,27 @@ def run_method(method: str, args: dict | None = None) -> dict:
     Only ``@frappe.whitelist()`` methods are callable; anything else raises
     PermissionDeniedError. An optional site-config allowlist
     (``jarvis_run_method_allowlist``: a list of fnmatch patterns) further
-    narrows what may be called - recommended in production.
+    narrows what may be called - RECOMMENDED in production.
+
+    SECURITY / operator hardening (security review PART 4 REVISED, TASK 42 —
+    FLAGGED for owner decision): the default is deliberately ``None`` =
+    unrestricted. This is a defense-in-depth gap (a prompt-injected agent running
+    as a Jarvis User could invoke ANY whitelisted method the user can reach),
+    tempered by two existing controls: run_method is one of
+    ``api._GATED_WRITES`` (ALWAYS parks for human confirmation, never
+    auto-applies) and runs under the caller's identity (each target self-checks
+    its own ``@frappe.whitelist`` gate + permissions). A hardcoded in-code default
+    was deliberately NOT shipped: run_method is the generic escape hatch for BOTH
+    the ``make_*`` mappers AND arbitrary doctype-specific whitelisted actions, so
+    a narrow default (e.g. ``["*make_*"]``) would silently break legitimate agent
+    flows across every tenant. Managed tenants SHOULD set a conservative
+    ``jarvis_run_method_allowlist`` in site_config.json scoped to their known-good
+    method set, e.g.::
+
+        "jarvis_run_method_allowlist": [
+            "erpnext.*.make_*",
+            "erpnext.accounts.*"
+        ]
 
     Returns the method's return value verbatim (often a document dict).
     """


### PR DESCRIPTION
Part 4 of the Frappe-standards security review — sweeps every remaining entity (settings, billing, onboarding, auth, dispatchers, diagnostics, telemetry) and, per the owner directive, completes the **Jarvis Admin customer-administrator tier**. The `Jarvis Admin` role scaffolding landed in #278; this PR wires it through the administration surface (which #278 left `System Manager`-only) and closes the review's security findings.

## The tier (widen-only — SM / Administrator / scheduler are unaffected)
- **~30 tenant-administration endpoints** converted from `only_for("System Manager")`/ungated to `require_jarvis_admin()`: account/billing, onboarding, OAuth, self-host status/switch, diagnostics, device rotate, agents admin, voice, wiki, `set_auto_apply` enable, conversation auto-apply/file-box guards.
- **`grant_onboarding_admin()`** — the onboarding/paying user is granted `Jarvis Admin` (server-hardcoded role, idempotent, no arbitrary-role escalation). Grants only Jarvis Admin (main's `JARVIS_ACCESS_ROLES` already includes it, so chat access is covered).
- **Jarvis Settings + agent doctypes** get a `Jarvis Admin` perm row; **page roles + boot flag + SPA display gating** so a Jarvis-Admin-not-SM actually sees the admin UI.
- **Centralized** the scattered local `_ADMIN_ROLES` onto `require_jarvis_admin`; deduped `_REVIEWER_ROLES` onto `JARVIS_REVIEWER_ROLES` (reviewer tier stays **wider** than the admin tier — a Skill Reviewer does not gain billing-admin reach).

## Security fixes
- **[HIGH] SQL injection** in the `query` tool (`tools/_expr.py` `date_add`): unconstrained `n` interpolated raw into an unescaped `LiteralValue` → coerce `int(n)`.
- **[HIGH] `diagnostics.ping_admin`/`ping_openclaw`** returned the container `agent_token` + operator URLs to any authenticated user → **redacted for every role** (SM reads the token via the permlevel-fenced Settings form, not a ping).
- **[HIGH] Jarvis Settings permlevel fence** — 12 operator/credential fields (admin URL/api-key/secret, agent url/token, customer email/password, device private-key/token, selfhost tool user, sandbox mode, query-doctype allowlist) moved to **permlevel 1, SM-only read+write**; a Jarvis Admin cannot read/write them via REST. Customer LLM-config fields stay Jarvis-Admin-managed (permlevel 0). Server writers use `set_settings_password`/`db_set` (permlevel-bypass) so onboarding/device flows are unaffected.
- **[HIGH] `selfhost.get_status()`** redacts `agent_url` for non-SM callers.
- **[MED] `jarvis_user_settings`** (introduced by #278) used `role:"All"` + `if_owner` with no ORM hook — the anti-pattern Parts 1–3 eliminated → `Jarvis User` + a `user`-keyed `permission_query_conditions`/`has_permission` hook.
- **[LOW] `mobile.get_mobile_token`** gated on `is_system_user`.

## Owner decisions (on record)
1. **Four operator capabilities kept System-Manager-only** (owner, 2026-07-14): `rotate_agent_token`, `save_self_hosted`, `test_connection`, and the operator/connection Settings fields (permlevel fence). Not widened to Jarvis Admin.
2. **Existing-tenant `Jarvis Admin` backfill skipped** — current admins are System Managers, already in the tier; an optional `grant_jarvis_admin_to_system_managers` patch is deferred (it would enlarge the Jarvis-Admin holder set consumed by notifications/questions).
3. **`run_method` allowlist** kept `None`-default with documented operator hardening (a hardcoded default would break the generic escape-hatch tool) — flagged for owner.

## Verification
- **21** `test_part4_security` tests + updated `test_chat_endpoint_gating` + cross-module gating coverage — pass on `patterntest.localhost`.
- **Independent 4-lens adversarial review** (leak / UX-break / Frappe-correctness / regression): 7 confirmed findings, **all remediated** (incl. 2 HIGH: the `get_status` `agent_url` leak and the extended credential-field fence).
- **Reviewer live exploit-proofs: 14/14** (tier gate throws for a plain Jarvis User + admits Jarvis Admin; permlevel fence; `get_status` redaction; four SM-only rejects; SQLi rejection).
- Parts 1–3 + #276/#278 regression suites green; frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)