### PR TITLE
fix(learning): let non-SM reviewers action learned patterns

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
+++ b/jarvis/jarvis/doctype/jarvis_learned_pattern/jarvis_learned_pattern.json
@@ -325,6 +325,16 @@
       "export": 1,
       "print": 1,
       "email": 1
+    },
+    {
+      "role": "Jarvis Skill Reviewer",
+      "read": 1,
+      "write": 1
+    },
+    {
+      "role": "Jarvis Admin",
+      "read": 1,
+      "write": 1
     }
   ],
   "sort_field": "creation",


### PR DESCRIPTION
## Problem

The learned-pattern **Review board** decision actions — Approve, Reject, Acknowledge, and "Apply to skill" — silently did nothing for a reviewer who holds only `Jarvis Skill Reviewer` or `Jarvis Admin` (no `System Manager`). They could open the board and see candidates (the list uses reviewer-gated raw SQL), but every decision returned `PermissionError`.

**Root cause:** the decision endpoints (`approve` / `reject` / `acknowledge` / `unapprove` / `restore` / `snooze_learned_pattern` and `apply_insight_skill_update`) authorize the caller via `_guard()` (the reviewer set: Jarvis Skill Reviewer / Jarvis Admin / System Manager), but then `doc.save()` on `Jarvis Learned Pattern`, whose doctype granted write to `System Manager` **only**. So a reviewer cleared the gate and then failed at the save — the reviewer roles were non-functional for their core purpose.

## Fix

Grant `read` + `write` on the `Jarvis Learned Pattern` doctype to `Jarvis Skill Reviewer` and `Jarvis Admin` (System Manager already had it). This authorizes the reviewer set at the ORM layer — the load-bearing permission surface — with the endpoint `_guard()` remaining as defense-in-depth. No `ignore_permissions` in code; +10 lines in the doctype JSON only.

## Verification

Reproduced live via per-user API-token auth as a reviewer-only user (holds only `Jarvis Skill Reviewer`). Every action returned `PermissionError` before, `200 {ok:true}` after:

| Action | Pattern class | Result |
|---|---|---|
| Acknowledge | B | ok |
| Approve | A | Approved |
| Apply to skill (create) | B | skill materialized |

`validate_transition()` still runs on every save, so illegal status transitions remain blocked.

## Note / follow-up

Granting doctype write means the reviewer roles can now also write patterns via generic REST (`/api/resource/Jarvis Learned Pattern`), not only the guarded endpoints. Transition legality is still enforced by the controller, but the A/B/C **class** guards (A-only approve, B/C-only apply, no un-approve mid-apply) live in the endpoints, not `validate()`. If we want the endpoints to remain the only sanctioned write path, those guards should move into the controller's `validate()`.