### PR TITLE
fix(confirm-gate): usable conversation-less confirm tokens + stop resync re-firing dry-run side effects (approval review Phase 1)

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -989,7 +989,7 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 			preview = _pending_preview(tool, args)
 		token = pending_confirm.mint(conversation=conv, owner=owner_user,
 									 tool=tool, args=args, run_id=run_id,
-									 exec_user=exec_user)
+									 exec_user=exec_user, preview=preview)
 		# Deliver the token to the human's UI out-of-band, over the realtime
 		# channel, NEVER via the function return below - the model must never
 		# see it. Published to the OWNER (the subscribed browser), not the acting

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -142,6 +142,19 @@ def _require_own_conversation(conversation: str) -> None:
 		frappe.throw(_("Not your conversation."), frappe.PermissionError)
 
 
+def _owns_conversation(conversation: str) -> bool:
+	"""Soft ownership check: True iff the current session user owns
+	``conversation``. Used to gate the conversation-less-token receipt +
+	continuation attach (F1): the fallback ``passed_conv`` is client-supplied, so
+	a caller could otherwise point a confirm/dismiss of their OWN conversation-
+	less token at another user's conversation and inject a receipt chip +
+	continuation turn there. Unlike ``_require_own_conversation`` this returns
+	False instead of raising - the write has already executed, so a non-owned
+	target must be skipped gracefully, not turned into a post-write 500."""
+	return bool(conversation) and frappe.db.get_value(
+		CONV, conversation, "owner") == frappe.session.user
+
+
 def _receipt_text(verb: str, doctype: str, name: str, submitted: int = 0) -> str:
 	if verb == "create" and submitted:
 		return f"Created and submitted {doctype} {name}."
@@ -355,9 +368,15 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 
 	# Leave a transcript receipt (#7) so a confirmed delete/submit/email shows on
 	# reload, matching the inline model-write path's tool card. Best-effort: the
-	# write already committed, so a receipt hiccup must not report failure. Needs
-	# a resolved conversation to attach to (self-host with no conv binding skips).
+	# write already committed, so a receipt hiccup must not report failure.
+	# Attach to the conversation the click came from (``passed_conv``) when the
+	# token itself was minted conversation-less (F1: a managed session_key lookup
+	# miss / self-host ambiguous concurrency), but only when the caller OWNS that
+	# conversation (passed_conv is client-supplied - never inject into another
+	# user's chat). A true headless caller with no owned conversation just skips.
 	conv = record.get("conversation")
+	if not conv and _owns_conversation(passed_conv):
+		conv = passed_conv
 	if conv:
 		ok = isinstance(result, dict) and bool(result.get("ok"))
 		# Leave a durable receipt CHIP (#7 / receipt-chips): action_outcome makes
@@ -459,7 +478,12 @@ def dismiss_tool(token: str, conversation: str | None = None) -> dict:
 
 	tool = record.get("tool") or ""
 	args = record.get("args") or {}
+	# Attach the discarded chip + veto note to the conversation the click came
+	# from when the token was minted conversation-less (F1), but only when the
+	# caller OWNS that conversation (passed_conv is client-supplied).
 	conv = record.get("conversation")
+	if not conv and _owns_conversation(passed_conv):
+		conv = passed_conv
 	if conv:
 		# Durable "discarded" chip: what the user declined, in their transcript.
 		try:
@@ -493,21 +517,35 @@ def list_pending_confirmations(conversation: str | None = None) -> dict:
 	if frappe.session.user == "Guest":
 		raise frappe.PermissionError("authentication required")
 
-	from jarvis.api import _describe_call, _pending_preview
+	from jarvis.api import _describe_call
 	from jarvis.chat import pending_confirm
 
 	conv = (conversation or "").strip() or None
 	records = pending_confirm.list_for_owner(frappe.session.user, conversation=conv)
 	items = []
 	for r in records:
-		tool = r.get("tool")
-		args = r.get("args") or {}
-		items.append({
-			"token": r.get("token"),
-			"tool": tool,
-			"preview": _pending_preview(tool, args),
-			"summary": _describe_call(tool, args),
-			"conversation": r.get("conversation"),
-			"run_id": r.get("run_id"),
-		})
+		# Per-record guard (F3): a single malformed record must NOT 500 the whole
+		# endpoint - that would blind resync of EVERY card until TTL. Skip + log
+		# the bad one; surface the rest.
+		try:
+			tool = r.get("tool")
+			args = r.get("args") or {}
+			items.append({
+				"token": r.get("token"),
+				"tool": tool,
+				# Return the PARK-TIME preview verbatim (F2). Recomputing it here
+				# via _pending_preview re-runs the sandboxed dry-run, whose inline
+				# on_submit/on_cancel side effects are NOT sandboxed and would
+				# re-fire on every reload/reconnect/tab-wake/post-confirm. Tokens
+				# minted before preview was stored carry None (summary still
+				# describes the action); no dry-run is ever run on this path.
+				"preview": r.get("preview"),
+				"summary": _describe_call(tool, args),
+				"conversation": r.get("conversation"),
+				"run_id": r.get("run_id"),
+			})
+		except Exception:
+			frappe.log_error(
+				title="list_pending_confirmations record skipped",
+				message=frappe.get_traceback())
 	return {"ok": True, "data": {"pending": items}}

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -21,9 +21,8 @@ import json
 import pickle
 import secrets
 
-import redis.exceptions
-
 import frappe
+import redis.exceptions
 
 _TTL_S = 900  # 15 min; a confirmation token the user must click within
 _PREFIX = "jarvis:pending_confirm:"
@@ -52,12 +51,18 @@ def args_hash(tool: str, args: dict) -> str:
 
 
 def mint(*, conversation: str, owner: str, tool: str, args: dict, run_id: str,
-		 exec_user: str | None = None) -> str:
+		 exec_user: str | None = None, preview: dict | None = None) -> str:
 	"""Store a pending call and return a fresh single-use token
 	(secrets.token_urlsafe(24)). The stored record carries conversation,
 	owner, tool, args (the full dict - this is the authoritative payload
-	that will execute), args_hash, run_id, exec_user. TTL _TTL_S. Returns
-	the token.
+	that will execute), args_hash, run_id, exec_user, preview. TTL _TTL_S.
+	Returns the token.
+
+	``preview`` is the park-time confirmation preview (dry-run "would" doc or
+	described-intent dict). It is stored so the resync endpoint can return it
+	verbatim instead of RE-running the dry-run - re-running fires unsandboxed
+	on_submit/on_cancel side effects on every reload/reconnect (F2). Tokens
+	minted before this field existed simply carry no ``preview``.
 
 	``owner`` is the CONVERSATION OWNER - the human who sees the card, clicks
 	Confirm, and whose browser is subscribed. Delivery + binding + confirm all
@@ -76,6 +81,7 @@ def mint(*, conversation: str, owner: str, tool: str, args: dict, run_id: str,
 		"args": args,
 		"args_hash": args_hash(tool, args),
 		"run_id": run_id,
+		"preview": preview,
 	}
 	frappe.cache().set_value(_key(token), record, expires_in_sec=_TTL_S)
 	# Index the token under its owner so list_for_owner can re-surface it. Best
@@ -102,10 +108,13 @@ def peek(token: str) -> dict | None:
 
 def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	"""Validate AND atomically single-use-consume. Returns the stored record
-	ONLY when: token exists, record.owner == owner, record.conversation ==
-	conversation. On success the token is deleted BEFORE returning (single
-	use - a second consume returns None). On any mismatch returns None and
-	does NOT delete (so a wrong-owner probe cannot burn a legitimate token).
+	ONLY when: token exists, record.owner == owner, and (when the record has a
+	non-empty stored conversation) record.conversation == conversation. A record
+	whose stored conversation is "" carries no conversation binding and passes
+	that check for any caller conversation (owner + single-use still hold). On
+	success the token is deleted BEFORE returning (single use - a second consume
+	returns None). On any mismatch returns None and does NOT delete (so a
+	wrong-owner probe cannot burn a legitimate token).
 
 	Atomicity: ownership is checked first with a plain (non-destructive)
 	read, so a mismatched call never touches the stored key. Only once
@@ -122,7 +131,19 @@ def consume(token: str, *, owner: str, conversation: str) -> dict | None:
 	record = frappe.cache().get_value(_key(token), use_local_cache=False)
 	if not record:
 		return None
-	if record.get("owner") != owner or record.get("conversation") != conversation:
+	# Owner is the real security boundary and is always enforced.
+	if record.get("owner") != owner:
+		return None
+	# Conversation is a SECONDARY replay guard, not the boundary. A token minted
+	# without a resolvable conversation ("" - a managed session_key->conversation
+	# lookup miss, or self-host ambiguous concurrency) carries no conversation
+	# binding, so an owner-matched consume must still succeed even when the caller
+	# passes its current conversation id. Without this skip such a card is
+	# delivered to the owner but EVERY Confirm click fails here and shows a
+	# misleading "expired" toast (the card is un-confirmable for its full TTL).
+	# When a conversation WAS bound, it is still enforced.
+	stored_conv = record.get("conversation")
+	if stored_conv and stored_conv != conversation:
 		return None
 
 	full_key = frappe.cache().make_key(_key(token))
@@ -161,7 +182,8 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	  - prunes dead members (token record expired/consumed) from the index,
 	  - filters to records whose stored owner matches ``owner`` (defense in
 	    depth - never returns another user's token),
-	  - filters to ``conversation`` when one is given.
+	  - filters to ``conversation`` when one is given, EXCEPT conversation-less
+	    records ("") which carry no binding and surface under any filter (F1).
 
 	Never returns another user's tokens. Used by the resync endpoint so the SPA
 	can re-surface confirmation cards after a reload/reconnect.
@@ -186,7 +208,13 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 			continue
 		if record.get("owner") != owner:
 			continue
-		if conversation is not None and record.get("conversation") != conversation:
+		# A conversation-less record ("" - see consume/F1) carries no binding, so
+		# surface it under ANY conversation filter: otherwise the card is
+		# confirmable while its live event is on screen but VANISHES on reload
+		# (resync drops it) for the full TTL - the SPA re-binds it to the current
+		# conversation. Bound records are still filtered to the asked conversation.
+		rec_conv = record.get("conversation")
+		if conversation is not None and rec_conv and rec_conv != conversation:
 			continue
 		out.append({**record, "token": token})
 	if dead:

--- a/jarvis/tests/test_actions_api.py
+++ b/jarvis/tests/test_actions_api.py
@@ -354,3 +354,152 @@ class TestContinuation(FrappeTestCase):
 		self.assertEqual(hidden[0].content.count("`"), 2)
 		# Sanity: the endpoint itself never raises on a failed inner write.
 		self.assertIn("ok", res)
+
+
+class TestConfirmEmptyConversationToken(FrappeTestCase):
+	"""F1: a gated write parked with an unresolvable conversation ("" - managed
+	session_key->conversation lookup miss / self-host ambiguous concurrency) is
+	delivered to and rendered by the owner, so it must still be confirmable /
+	discardable, and its receipt + continuation must attach to the conversation
+	the click came from (the SPA's current id, passed in)."""
+
+	def _conv(self) -> str:
+		conv = _make_conversation()
+		self.addCleanup(lambda: frappe.delete_doc(
+			"Jarvis Conversation", conv, force=True, ignore_permissions=True))
+		return conv
+
+	def _roles(self, conv):
+		return [m.role for m in frappe.get_all(
+			"Jarvis Chat Message", filters={"conversation": conv},
+			fields=["role"], order_by="seq asc")]
+
+	def test_confirm_empty_conv_token_executes_and_attaches_receipt(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import confirm_tool
+		conv = self._conv()
+		desc = "jarvis-test-empty-conv-confirm-001"
+		token = pending_confirm.mint(
+			conversation="", owner="Administrator", tool="create_doc",
+			args={"doctype": "ToDo", "values": {"description": desc}}, run_id="")
+		with patch("jarvis.chat.api._dispatch_turn") as disp:
+			res = confirm_tool(token, conversation=conv)
+		# Before F1 this returned InvalidConfirmation ("expired on click"); now
+		# it executes.
+		self.assertTrue(res["ok"])
+		created = frappe.db.get_value("ToDo", {"description": desc}, "name")
+		self.assertTrue(created)
+		self.addCleanup(lambda: frappe.delete_doc(
+			"ToDo", created, force=True, ignore_permissions=True))
+		# Receipt chip (role=tool) + continuation attached to the passed conv.
+		self.assertIn("tool", self._roles(conv))
+		self.assertEqual(disp.call_count, 1)
+
+	def test_discard_empty_conv_token_leaves_chip(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import dismiss_tool
+		conv = self._conv()
+		token = pending_confirm.mint(
+			conversation="", owner="Administrator", tool="delete_doc",
+			args={"doctype": "ToDo", "name": "no-such-todo"}, run_id="")
+		res = dismiss_tool(token, conversation=conv)
+		# Before F1 this consumed nothing and returned already_handled with no
+		# chip; now it discards and leaves a durable chip on the passed conv.
+		self.assertEqual(res["data"]["status"], "discarded")
+		self.assertIn("tool", self._roles(conv))
+
+	def test_confirm_empty_conv_token_does_not_attach_to_unowned_conversation(self):
+		"""F1 hardening: passed_conv is client-supplied. A conversation-less
+		token must NOT inject a receipt chip / continuation turn into a
+		conversation the confirming user does not own. The write still executes
+		(the token is owner-matched); only the attach is skipped."""
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import confirm_tool
+		other = _make_conversation()
+		frappe.db.set_value("Jarvis Conversation", other, "owner", "someone@else.invalid")
+		self.addCleanup(lambda: frappe.delete_doc(
+			"Jarvis Conversation", other, force=True, ignore_permissions=True))
+		desc = "jarvis-test-empty-conv-unowned-001"
+		token = pending_confirm.mint(
+			conversation="", owner="Administrator", tool="create_doc",
+			args={"doctype": "ToDo", "values": {"description": desc}}, run_id="")
+		with patch("jarvis.chat.api._dispatch_turn") as disp:
+			res = confirm_tool(token, conversation=other)
+		self.assertTrue(res["ok"])  # the write still executes
+		created = frappe.db.get_value("ToDo", {"description": desc}, "name")
+		self.assertTrue(created)
+		self.addCleanup(lambda: frappe.delete_doc(
+			"ToDo", created, force=True, ignore_permissions=True))
+		# Nothing injected into the unowned conversation, no continuation fired.
+		self.assertEqual(self._roles(other), [])
+		disp.assert_not_called()
+
+	def test_discard_empty_conv_token_does_not_attach_to_unowned_conversation(self):
+		"""F1 hardening (dismiss twin): a conversation-less token discarded with
+		another user's conversation id must consume the token but inject no
+		chip/note there."""
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import dismiss_tool
+		other = _make_conversation()
+		frappe.db.set_value("Jarvis Conversation", other, "owner", "someone@else.invalid")
+		self.addCleanup(lambda: frappe.delete_doc(
+			"Jarvis Conversation", other, force=True, ignore_permissions=True))
+		token = pending_confirm.mint(
+			conversation="", owner="Administrator", tool="delete_doc",
+			args={"doctype": "ToDo", "name": "no-such-todo"}, run_id="")
+		res = dismiss_tool(token, conversation=other)
+		self.assertEqual(res["data"]["status"], "discarded")  # token consumed
+		self.assertEqual(self._roles(other), [])  # nothing injected
+
+
+class TestListPendingConfirmations(FrappeTestCase):
+	"""F2/F3: resync returns the park-time preview verbatim (no side-effecting
+	dry-run recompute) and one bad record cannot 500 the whole endpoint."""
+
+	def _conv(self) -> str:
+		conv = _make_conversation()
+		self.addCleanup(lambda: frappe.delete_doc(
+			"Jarvis Conversation", conv, force=True, ignore_permissions=True))
+		return conv
+
+	def test_returns_stored_preview_without_rerunning_dry_run(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import list_pending_confirmations
+		conv = self._conv()
+		stored = {"preview": True, "would": {"doctype": "ToDo", "sentinel": "park-time"}}
+		pending_confirm.mint(
+			conversation=conv, owner="Administrator", tool="submit_doc",
+			args={"doctype": "ToDo", "name": "x"}, run_id="", preview=stored)
+		# The dry-run (whose on_submit/on_cancel side effects are unsandboxed)
+		# must NOT be re-run on resync.
+		with patch("jarvis.api._run_preview") as rp:
+			r = list_pending_confirmations(conversation=conv)
+		rp.assert_not_called()
+		items = r["data"]["pending"]
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0]["preview"], stored)
+
+	def test_one_bad_record_does_not_blind_the_endpoint(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import list_pending_confirmations
+		conv = self._conv()
+		pending_confirm.mint(
+			conversation=conv, owner="Administrator", tool="submit_doc",
+			args={"doctype": "ToDo", "name": "a"}, run_id="", preview={"described": True})
+		pending_confirm.mint(
+			conversation=conv, owner="Administrator", tool="submit_doc",
+			args={"doctype": "ToDo", "name": "b"}, run_id="", preview={"described": True})
+
+		calls = {"n": 0}
+
+		def _boom(tool, args):
+			calls["n"] += 1
+			if calls["n"] == 1:
+				raise RuntimeError("boom building this record's summary")
+			return "ok-summary"
+
+		with patch("jarvis.api._describe_call", side_effect=_boom):
+			r = list_pending_confirmations(conversation=conv)
+		# One record raised; the endpoint still returns ok with the other card.
+		self.assertTrue(r["ok"])
+		self.assertEqual(len(r["data"]["pending"]), 1)

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -81,6 +81,29 @@ class TestExecUser(FrappeTestCase):
 		self.assertEqual(pending_confirm.peek(token)["exec_user"], OWNER)
 
 
+class TestPreview(FrappeTestCase):
+	def test_preview_stored_and_returned(self):
+		"""F2: the park-time preview is stored so resync can return it verbatim
+		(instead of re-running the side-effecting dry-run)."""
+		preview = {"preview": True, "would": {"doctype": "Task", "subject": "hi"}}
+		token = pending_confirm.mint(
+			conversation=CONV, owner=OWNER, tool=TOOL, args=ARGS, run_id=RUN_ID,
+			preview=preview,
+		)
+		self.assertEqual(pending_confirm.peek(token)["preview"], preview)
+		# consume returns it too.
+		self.assertEqual(
+			pending_confirm.consume(token, owner=OWNER, conversation=CONV)["preview"],
+			preview,
+		)
+
+	def test_preview_defaults_to_none(self):
+		token = pending_confirm.mint(
+			conversation=CONV, owner=OWNER, tool=TOOL, args=ARGS, run_id=RUN_ID,
+		)
+		self.assertIsNone(pending_confirm.peek(token).get("preview"))
+
+
 class TestListForOwner(FrappeTestCase):
 	_A = "owner-a@example.invalid"
 	_B = "owner-b@example.invalid"
@@ -114,6 +137,19 @@ class TestListForOwner(FrappeTestCase):
 		self._mint(self._A, "conv-a2", "fc-2")
 		got = pending_confirm.list_for_owner(self._A, conversation="conv-a1")
 		self.assertEqual([r["token"] for r in got], [t1])
+
+	def test_conversationless_record_surfaces_under_any_filter(self):
+		"""F1: a token minted without a resolvable conversation ("") carries no
+		binding, so resync (which always passes the SPA's current conversation)
+		must still return it - else the card is confirmable live but lost on
+		reload for its TTL. A bound record is still filtered out."""
+		t_unbound = self._mint(self._A, "", "cl-unbound")
+		self._mint(self._A, "conv-other", "cl-bound")
+		got = {r["token"] for r in pending_confirm.list_for_owner(
+			self._A, conversation="conv-current")}
+		self.assertIn(t_unbound, got)  # surfaces despite the filter
+		# The bound record for a different conversation is still excluded.
+		self.assertEqual(len(got), 1)
 
 	def test_excludes_expired_and_consumed(self):
 		t_live = self._mint(self._A, "conv-a1", "ex-live")
@@ -193,6 +229,32 @@ class TestConsume(FrappeTestCase):
 		)
 		record = pending_confirm.consume(token, owner=OWNER, conversation=CONV)
 		self.assertIsNotNone(record)
+
+	def test_empty_stored_conversation_is_confirmable_by_owner(self):
+		"""F1: a token minted with an unresolvable conversation ("") carries no
+		conversation binding, so an owner-matched consume must still succeed even
+		when the caller passes its current (non-empty) conversation id. Regression
+		for the managed session_key-miss / self-host ambiguous-concurrency case
+		where the card was delivered but every Confirm click failed the
+		conversation check and showed a misleading 'expired' toast."""
+		token = pending_confirm.mint(
+			conversation="", owner=OWNER, tool=TOOL, args=ARGS, run_id=RUN_ID)
+		record = pending_confirm.consume(token, owner=OWNER, conversation="conv-current")
+		self.assertIsNotNone(record)
+		self.assertEqual(record["tool"], TOOL)
+
+	def test_empty_stored_conversation_still_enforces_owner(self):
+		"""F1: owner is still the real boundary for a conversation-less token."""
+		token = pending_confirm.mint(
+			conversation="", owner=OWNER, tool=TOOL, args=ARGS, run_id=RUN_ID)
+		self.assertIsNone(
+			pending_confirm.consume(
+				token, owner="intruder@example.invalid", conversation="conv-current")
+		)
+		# Not burned - the real owner can still consume it.
+		self.assertIsNotNone(
+			pending_confirm.consume(token, owner=OWNER, conversation="conv-current")
+		)
 
 	def test_unknown_token_returns_none(self):
 		self.assertIsNone(


### PR DESCRIPTION
## Problem

Deep review of the in-chat **approval / write-safety confirmation** mechanism surfaced three backend bugs. Phase 1 fixes the highest-severity, including the **live "expired on click"** issue reported on the managed product.

## Root cause

**F1 — the live "expired on click" bug.** When the gate cannot resolve a conversation, the confirmation token is minted with `conversation=""`. In managed mode this happens whenever `get_value("Jarvis Conversation", {session_key}, "name")` misses — the `session_key` is not immutable (`_ensure_session_key` mints a new openclaw session per session; session lifecycle *clears* `conv.session_key` for dormant chats), so a container tool-call under a `session_key` the bench no longer has stored resolves to `conv=""`. The card is still **delivered to and rendered by** the owner (owner-room delivery + SPA rebind to the current chat), but every `Confirm` click failed `consume()`'s conversation check — the SPA sends its current conversation id while the stored conversation is `""` — producing a misleading "That confirmation expired" toast for the token's full 15-min TTL. `dismiss` likewise no-op'd (no chip, no agent veto note).

**F2 — repeated unsandboxed side effects on resync.** `list_pending_confirmations` recomputed `_pending_preview(tool, args)` per record on **every** reload / reconnect / tab-wake / post-confirm. For `submit_doc`/`cancel_doc`/`delete_doc`/`amend_doc` that re-ran the sandboxed dry-run, whose **inline `on_submit`/`on_cancel` side effects (e-invoice HTTP, webhooks, emails) are not sandboxed** — so they re-fired repeatedly, and as the browser owner rather than the stored `exec_user`.

**F3 — one poisoned record 500'd the whole resync**, blinding re-surfacing of *every* card until TTL (no per-record guard).

## Fix

- **`consume()`** treats a stored `conversation == ""` as "no binding" and skips that check — **owner + atomic single-use remain the real boundary** (the relaxation grants the owner nothing they couldn't already do via the pre-existing empty-conversation back-compat path).
- **`confirm_tool` / `dismiss_tool`** attach the receipt + continuation to the conversation the click came from (`passed_conv`), but **only when the caller owns it** (new soft `_owns_conversation` check) — a client-supplied conversation id can never inject a receipt chip / continuation turn into another user's chat. The write itself still executes regardless (the token is owner-matched).
- **`list_for_owner`** surfaces conversation-less records under any conversation filter, so a conv-less card survives a reload/reconnect instead of vanishing.
- **`mint`** stores the park-time `preview`; **`list_pending_confirmations`** returns it verbatim and **never recomputes a dry-run**, and wraps each record in a per-record guard.

## Verification

- `bench --site jarvis-test.localhost run-tests --app jarvis` for the touched + adjacent modules — all green: `test_pending_confirm` (25), `test_actions_api` (27), `test_confirm_gate` (31), `test_auto_apply` (20), `test_receipt_chips` (13), `test_action_pending` (4).
- New regression tests: consume passthrough + owner still enforced; preview stored/returned; conversation-less resync passthrough; empty-conv confirm/dismiss execute and attach to the owned conversation; **unowned-conversation attach is skipped (no injection)**; resync returns the stored preview without re-running the dry-run; one bad record does not 500 the endpoint.
- Adversarially reviewed (Fable): verdict **ship** — security boundary intact, no missed call-sites, no regression in the strict conversation-match path.

Part of a phased remediation of the approval mechanism (Phase 1 of 3). Follow-ups (Phase 2 concurrency/lifecycle, Phase 3 confirm-card rendering + expiry UX) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
