### PR TITLE
feat(confirm-gate): sequential one-card-at-a-time batch confirmation (F16, approval review Phase 2A)

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -516,6 +516,19 @@ def _is_bulk_call(args) -> bool:
 	return any(isinstance(args.get(k), list) and args.get(k) for k in _BULK_ARG_KEYS)
 
 
+def _bulk_len(args) -> int:
+	"""Number of targets in a bulk call - the length of the first non-empty batch
+	list (the batch keys are mutually exclusive per the tool contracts). 0 for a
+	non-bulk call. Used to bounce an over-size batch at park (F16)."""
+	if not isinstance(args, dict):
+		return 0
+	for k in _BULK_ARG_KEYS:
+		v = args.get(k)
+		if isinstance(v, list) and v:
+			return len(v)
+	return 0
+
+
 def _bulk_targets(args: dict) -> list:
 	"""Display names for a batch call: ``names[]`` directly, else the per-item
 	name / recipients / doctype from ``updates`` / ``messages`` / ``docs``."""
@@ -910,6 +923,7 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 	# _pending_preview (no sandbox); single calls to these tools are unchanged.
 	if tool in _GATED_WRITES or (is_write and _is_bulk_call(args)):
 		from jarvis.chat import events, pending_confirm
+		from jarvis.tools._bulk import _MAX_BATCH
 
 		# preview=True on a gated write is a category error (issue #186, #14):
 		# the model never needs preview here - it calls the tool directly and the
@@ -922,6 +936,22 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 				"InvalidArgumentError",
 				f"preview is not needed for {tool}: call it directly and the "
 				"bench will show a confirmation card")
+
+		# Batch cap at PARK (F16): a bulk call over the shared max bounces to the
+		# model now with a split-and-sequence instruction, instead of parking a
+		# card that only dies at execution. create/update/create_docs already
+		# bounce via their park-time dry-run (run_atomic_batch), but the
+		# consequential bulk writes (submit/cancel/delete/amend/workflow) take a
+		# described-intent preview with NO dry-run, so without this an over-size
+		# batch would fail only AFTER the user confirmed. One rule for all bulk.
+		if _is_bulk_call(args):
+			batch_n = _bulk_len(args)
+			if batch_n > _MAX_BATCH:
+				return _error(
+					"InvalidArgumentError",
+					f"too many records in one batch ({batch_n}); the max is "
+					f"{_MAX_BATCH}. Split into batches of {_MAX_BATCH} and confirm "
+					"each one before starting the next.")
 
 		conv, run_id = _gate_context(conversation)
 		# Two identities (issue #186, #1/#5/#6):
@@ -968,6 +998,28 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 				as_dict=True) or {}
 			if flags.get("auto_apply") or flags.get("file_box"):
 				return dispatch_confirmed(tool, args)
+		# Sequential confirmation (F16): at most ONE live confirmation card per
+		# conversation. If one is already awaiting the user here, REFUSE to park a
+		# second and tell the model to stop - the continuation turn fired after the
+		# pending card is confirmed + executed is where it issues the next batch.
+		# This makes "batch 2's card appears only after batch 1 completes" a bench
+		# guarantee (not just persona discipline) and is the server-side
+		# single-flight for the confirm path. Auto-apply above is deliberately NOT
+		# gated by this (it parks no card).
+		#   STRICT conversation match: list_for_owner returns conversation-LESS
+		#   tokens under any filter (F1), so re-filter to record.conversation == conv
+		#   - an unrelated conv-less token (a rare session-resolution miss) must not
+		#   block a legitimate new card here.
+		if conv and any(
+				t.get("conversation") == conv
+				for t in pending_confirm.list_for_owner(owner_user, conversation=conv)):
+			return _error(
+				"ConfirmationPendingError",
+				"a confirmation card for a previous action is still awaiting the "
+				"user in this conversation. Only one runs at a time - do NOT retry "
+				"this call; stop and end your turn now. Once the user confirms the "
+				"pending card you'll get a follow-up turn to continue with the next "
+				"step.")
 		# Validate BEFORE parking. For a create/update (build-from-args) write,
 		# run the real call in the rollback sandbox now: a deterministic failure
 		# (missing mandatory field, bad link, no create permission) means the

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -762,3 +762,181 @@ class TestCreateDocsGate(FrappeTestCase):
 		would = preview.get("would") or {}
 		self.assertEqual(len(would.get("created", [])), 2)
 		self.assertFalse(frappe.db.exists("ToDo", {"description": "jarvis-resync-a"}))
+
+
+class TestBulkBatchCapAtPark(FrappeTestCase):
+	"""F16: a bulk gated write over the shared max (20) bounces at PARK with a
+	split-and-sequence instruction - before any card is minted - so an over-size
+	batch never reaches a doomed confirmation card. create/update/create_docs
+	already bounced via their park-time dry-run; this also closes the
+	consequential bulk writes (submit/cancel/delete/amend/workflow) which take a
+	described preview with NO dry-run and would otherwise only fail at execution."""
+
+	def test_oversize_bulk_bounces_before_any_card(self):
+		names = [f"TD-{i:04d}" for i in range(21)]  # 21 > _MAX_BATCH (20)
+		patcher, captured = _spy_mint()
+		with patch("jarvis.chat.events.publish_to_user") as pub, patcher:
+			r = api._run_tool("submit_doc", {"doctype": "ToDo", "names": names})
+			self.assertFalse(pub.called)  # no card published
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+		self.assertIn("too many records", r["error"]["message"])
+		self.assertIsNone(captured.get("token"))  # nothing minted
+
+	def test_at_limit_bulk_still_parks(self):
+		names = [f"TD-{i:04d}" for i in range(20)]  # exactly the max
+		patcher, captured = _spy_mint()
+		with patcher:
+			r = api._run_tool("submit_doc", {"doctype": "ToDo", "names": names})
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertIsNotNone(captured.get("token"))
+
+
+class TestSequentialConfirmationGuard(FrappeTestCase):
+	"""F16: at most ONE live confirmation card per conversation. A second gated
+	park while one is pending in the SAME conversation is refused (the model is
+	told to stop), so batches confirm strictly one at a time; a different
+	conversation is unaffected; a stray conversation-less token does not block;
+	once the pending token clears, the next batch parks."""
+
+	def setUp(self):
+		# Redis is NOT rolled back / flushed by FrappeTestCase and a parked token
+		# lives 15 min, so a token minted by a PRIOR run of this suite would trip
+		# the very guard under test (a leftover card in the same conversation).
+		# Clear this owner's pending-confirm index so each run starts clean, the
+		# same way TestListPendingConfirmations isolates its own owner.
+		frappe.cache().delete_value(
+			pending_confirm._OWNER_PREFIX + frappe.session.user)
+
+	def tearDown(self):
+		for name in frappe.get_all(
+				CONV, filters={"title": "confirm-gate test"}, pluck="name"):
+			frappe.delete_doc(CONV, name, force=True, ignore_permissions=True)
+		frappe.db.delete("ToDo", {"description": ["like", "seq-e2e-%"]})
+		frappe.db.commit()
+
+	def test_second_park_in_same_conversation_is_refused(self):
+		conv = "seq-guard-conv-100"
+		patcher1, cap1 = _spy_mint()
+		with patcher1:
+			r1 = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-1"}},
+				conversation=conv)
+		self.assertEqual(r1["data"]["status"], "pending_confirmation")
+		self.assertIsNotNone(cap1.get("token"))
+
+		patcher2, cap2 = _spy_mint()
+		with patch("jarvis.chat.events.publish_to_user") as pub, patcher2:
+			r2 = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-2"}},
+				conversation=conv)
+			self.assertFalse(pub.called)  # no second card published
+		self.assertFalse(r2["ok"])
+		self.assertEqual(r2["error"]["code"], "ConfirmationPendingError")
+		self.assertIsNone(cap2.get("token"))  # no second token minted
+
+	def test_pending_card_does_not_block_a_different_conversation(self):
+		with _spy_mint()[0]:
+			a = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-A"}},
+				conversation="seq-guard-conv-A")
+		self.assertEqual(a["data"]["status"], "pending_confirmation")
+		patcher_b, cap_b = _spy_mint()
+		with patcher_b:
+			b = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-B"}},
+				conversation="seq-guard-conv-B")
+		self.assertEqual(b["data"]["status"], "pending_confirmation")
+		self.assertIsNotNone(cap_b.get("token"))
+
+	def test_stray_conversation_less_token_does_not_block(self):
+		# A conversation-less token for the same owner (a rare session-resolution
+		# miss) must NOT block a legitimate new card - the guard matches the
+		# conversation STRICTLY (list_for_owner surfaces conv-less under any filter).
+		pending_confirm.mint(
+			conversation="", owner=frappe.session.user, exec_user=frappe.session.user,
+			tool="delete_doc", args={"doctype": "ToDo", "name": "x"}, run_id="")
+		patcher, cap = _spy_mint()
+		with patcher:
+			r = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-cl"}},
+				conversation="seq-guard-conv-CL")
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		self.assertIsNotNone(cap.get("token"))
+
+	def test_next_batch_parks_after_pending_confirmed(self):
+		# End-to-end: confirm batch 1 (runs the write + consumes its token), then a
+		# second gated park in the same conversation succeeds - the continuation
+		# turn's next batch. Real conversation so confirm_tool's receipt attaches.
+		owner = frappe.session.user
+		conv = _make_conv(owner)
+		patcher1, cap1 = _spy_mint()
+		with patcher1:
+			r1 = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-e2e-1"}},
+				conversation=conv)
+		self.assertEqual(r1["data"]["status"], "pending_confirmation")
+		with patch("jarvis.chat.api._dispatch_turn"):
+			res = confirm_tool(cap1["token"], conversation=conv)
+		self.assertTrue(res["ok"])
+		# Batch 2 now parks - no pending card left in this conversation.
+		patcher2, cap2 = _spy_mint()
+		with patcher2:
+			r2 = api._run_tool(
+				"create_doc", {"doctype": "ToDo", "values": {"description": "seq-e2e-2"}},
+				conversation=conv)
+		self.assertEqual(r2["data"]["status"], "pending_confirmation")
+		self.assertIsNotNone(cap2.get("token"))
+
+
+class TestConvLessTokenIsolation(FrappeTestCase):
+	"""F1 follow-up (Codex/Fable adversarial review of #305): a conversation-less
+	token is confirmable in whatever chat the owner is viewing, but WHAT executes
+	is determined SOLELY by the token - never by the confirming conversation.
+	Confirming in an unrelated conversation runs exactly the stored write,
+	owner-scoped + single-use. This bounds the conv-less wart to receipt/
+	continuation PLACEMENT, never to which (or whose) data is written."""
+
+	def test_conv_less_token_runs_only_its_own_write_from_another_chat(self):
+		owner = frappe.session.user
+		desc = "jarvis-test-convless-isolation-060"
+		token = pending_confirm.mint(
+			conversation="", owner=owner, exec_user=owner, tool="create_doc",
+			args={"doctype": "ToDo", "values": {"description": desc}}, run_id="")
+		# Confirm from an unrelated conversation the owner is viewing.
+		with patch("jarvis.chat.api._dispatch_turn"):
+			res = confirm_tool(token, conversation="an-unrelated-conv")
+		self.assertTrue(res["ok"])
+		# Exactly the token's write ran - nothing else.
+		self.assertTrue(frappe.db.exists("ToDo", {"description": desc}))
+		# Single use: cannot be re-confirmed from any conversation.
+		self.assertFalse(confirm_tool(token, conversation="an-unrelated-conv")["ok"])
+
+	def test_conv_less_token_stays_owner_scoped(self):
+		# The owner boundary still holds for a conv-less token: a different user
+		# cannot confirm it, and the attempt does not burn it.
+		owner = frappe.session.user
+		desc = "jarvis-test-convless-isolation-061"
+		token = pending_confirm.mint(
+			conversation="", owner=owner, exec_user=owner, tool="create_doc",
+			args={"doctype": "ToDo", "values": {"description": desc}}, run_id="")
+		other = "jarvis-convless-other@example.com"
+		if not frappe.db.exists("User", other):
+			frappe.get_doc({
+				"doctype": "User", "email": other, "first_name": "Other",
+				"send_welcome_email": 0, "user_type": "System User",
+			}).insert(ignore_permissions=True)
+		if "Jarvis User" not in set(frappe.get_roles(other)):
+			frappe.get_doc("User", other).add_roles("Jarvis User")
+		original = frappe.session.user
+		frappe.set_user(other)
+		try:
+			res = confirm_tool(token, conversation="whatever")
+		finally:
+			frappe.set_user(original)
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["type"], "InvalidConfirmation")
+		self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+		# The real owner can still confirm it (not burned by the wrong-owner try).
+		with patch("jarvis.chat.api._dispatch_turn"):
+			self.assertTrue(confirm_tool(token, conversation="mine")["ok"])


### PR DESCRIPTION
## Problem

When a bulk ERP action has **too many records to confirm**, Jarvis should batch them by 20 and ask for confirmation **one batch at a time** — batch 2's confirmation card should appear only *after* batch 1's action is performed and completed. The 20-cap is already enforced (`run_atomic_batch` rejects >20, so the model splits into ≤20 batches) and the persona already prescribes sequential batching, **but nothing in the bench enforced it** — a model that parked several batch cards in one turn produced stacked cards (the F4/F13 concurrency surface), so the "one at a time" guarantee was model discipline, not a guarantee.

## Fix (make it a bench guarantee)

- **One live confirmation card per conversation.** Before parking a gated write, if the conversation already holds a live pending token, refuse it with a `ConfirmationPendingError` telling the model to stop. The **continuation turn** fired after the pending card is confirmed **and executed** is where the model issues the next batch — so batch 2's card can only appear after batch 1 completes. This is the server-side single-flight for the confirm path (delivers **F4**). The check strictly matches the conversation, so a stray conversation-less token (F1) can't spuriously block, and it sits **after** the auto-apply bypass (auto-apply parks no card, so serializing it would deadlock unattended File-Box runs).
- **Park-time >20 bounce for consequential bulk** (submit/cancel/delete/amend/apply_workflow_action). create/update/create_docs already bounce via their park-time dry-run, but the consequential bulk writes take a *described-intent* preview with no dry-run — so an over-size batch used to fail only **after** the user confirmed. Now it bounces at park with a split-and-sequence instruction, before any card.

Also locks in the **F1 conversation-less-token invariant** flagged by the Codex/Fable adversarial review of #305: a conv-less token confirmed from another chat runs *exactly its stored write*, owner-scoped + single-use (the wart is receipt/continuation **placement**, never which/whose data is written).

## Behavior notes (by design)

- The guard serializes **all** gated writes per conversation (matches "only one runs at a time"), not just ≤20 batches.
- A pending card the user neither confirms nor discards blocks new gated writes **in that conversation** until they act or the 15-min TTL lapses — discard, confirm, and TTL all clear it. Reads and non-gated writes are unaffected.
- The check→mint is best-effort under *true* concurrency (parallel tool calls / racing turns / self-host ambiguous `conv=""`): it degrades to the pre-change two-cards behavior, never to an executed write or a wrongly-locked conversation.

## Verification

- `bench --site jarvis-test.localhost run-tests --app jarvis` — **all green**: `test_confirm_gate` (39, incl. 8 new), plus no regressions in `test_bulk_tools` (23), `test_auto_apply` (20), `test_actions_api` (27), `test_action_pending` (4), `test_pending_confirm` (25), `test_receipt_chips` (13). Ran the gate module twice back-to-back to prove no Redis re-run flake.
- New tests: oversize bulk bounces before any card / at-limit still parks; second park in the same conversation refused (no 2nd token); different conversation unaffected; stray conv-less token does not block; next batch parks after the pending is confirmed; conv-less token isolation.
- Adversarially reviewed (Fable): **ship** — every degraded path falls back to pre-change behavior, never to an executed write or a locked conversation.

Companion `jarvis-persona` PR reinforces the recipe (the bench now enforces one card at a time). Part of the approval-mechanism remediation (Phase 2A; follows merged Phase 1 #305).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
