### PR TITLE
feat(confirm-card): render-ready change summary + expiry on the gate (approval review Phase 3a, backend)

### DIFF
--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1039,9 +1039,21 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 				return _preview_error(e)
 		else:
 			preview = _pending_preview(tool, args)
+		# Render-ready confirmation summary (F9) + wall-clock expiry (F15), attached
+		# ONCE here at park: F2 stores the preview in the token record and resync
+		# returns it verbatim, so the card + expiry ride the event, the record, and
+		# every resync identically (never rebuilt -> cannot diverge). build_card
+		# returns None for uncovered shapes; the SPA falls back to the raw preview.
+		import time
+
+		from jarvis.chat import confirm_card
+		if isinstance(preview, dict):
+			preview["card"] = confirm_card.build_card(tool, args, preview)
+		expires_at = int(time.time()) + pending_confirm._TTL_S
 		token = pending_confirm.mint(conversation=conv, owner=owner_user,
 									 tool=tool, args=args, run_id=run_id,
-									 exec_user=exec_user, preview=preview)
+									 exec_user=exec_user, preview=preview,
+									 expires_at=expires_at)
 		# Deliver the token to the human's UI out-of-band, over the realtime
 		# channel, NEVER via the function return below - the model must never
 		# see it. Published to the OWNER (the subscribed browser), not the acting
@@ -1058,14 +1070,20 @@ def _run_tool(tool: str, raw_args: dict | str | None,
 				"conversation": conv,
 				"run_id": run_id,
 				"summary": _describe_call(tool, args),
+				"expires_at": expires_at,
 			})
 		except Exception:
 			frappe.log_error(
 				title="action:pending publish failed",
 				message=frappe.get_traceback(),
 			)
+		# The model-facing return carries the raw preview but NOT the human ``card``
+		# (it is duplicate UX for the model's context; the model gets tool + args +
+		# would already).
+		model_preview = ({k: v for k, v in preview.items() if k != "card"}
+						 if isinstance(preview, dict) else preview)
 		return {"ok": True, "data": {
-			"status": "pending_confirmation", "preview": preview, "tool": tool,
+			"status": "pending_confirmation", "preview": model_preview, "tool": tool,
 		}}
 
 	return _dispatch_and_wrap(tool, args, is_write)

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -543,6 +543,7 @@ def list_pending_confirmations(conversation: str | None = None) -> dict:
 				"summary": _describe_call(tool, args),
 				"conversation": r.get("conversation"),
 				"run_id": r.get("run_id"),
+				"expires_at": r.get("expires_at"),
 			})
 		except Exception:
 			frappe.log_error(

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -1,0 +1,216 @@
+"""Build the render-ready "what will change" summary for a confirmation card (F9).
+
+The write-safety gate (``jarvis.api._run_tool``) parks a gated write and shows the
+user a card. Today that card renders a raw-JSON dump of the dry-run ``would`` doc
+and a one-line ``_describe_call`` target string - it names the record but not what
+the write does to it. ``build_card`` turns the tool + args + park-time preview into
+a structured, human-readable summary the SPA renders like the model-authored draft
+card (a field list for a create, a from->to diff for an update, a verb line for
+submit/cancel/delete/amend, to/subject/body for an email, method + args for
+run_method).
+
+It is attached ONCE at park as ``preview["card"]`` (see the gate). Phase-1 F2 stores
+the park-time preview in the token record and the resync endpoint returns it
+verbatim, so the card rides the ``action:pending`` event, the record, and every
+resync identically - it is never rebuilt at resync (which would let it diverge from
+the stored preview and re-load the doc on each reconnect).
+
+Safety: values come from the ALREADY perm-filtered ``would`` (create/update tools
+call ``apply_fieldlevel_read_permissions`` before returning), and the update
+``from`` values are read from a freshly-fetched, perm-filtered current doc - so a
+restricted field's value never lands in the card. Long values are truncated, rows
+capped, and obviously-secret ``run_method`` arg keys masked. The card carries no
+material the owner would not already see in the post-confirm receipt.
+
+Returns ``None`` for tool shapes without a bespoke card (share_doc, assign_to,
+create_custom_skill, update_wiki, bulk update/email, and any token minted before
+this existed) - the SPA falls back to the summary + raw-preview rendering.
+"""
+
+from __future__ import annotations
+
+import re
+
+import frappe
+
+_MAX_VAL = 200  # truncate a single displayed value to this many chars
+_MAX_ROWS = 20  # cap fields / diff rows / batch bullets / targets shown
+_BULK_KEYS = ("names", "updates", "docs", "messages")
+_SECRET_KEY_RE = re.compile(r"password|secret|token|api[_-]?key", re.IGNORECASE)
+
+# tool -> present-tense verb for the "will <verb> this <doctype> <name>" card.
+_VERB = {
+	"submit_doc": "submit",
+	"cancel_doc": "cancel",
+	"delete_doc": "delete",
+	"amend_doc": "amend",
+	"apply_workflow_action": "apply",
+}
+
+
+def build_card(tool: str, args, preview) -> dict | None:
+	"""Structured, render-ready confirmation summary, or None to fall back to the
+	SPA's summary + raw-preview rendering. Best-effort: never raises (a card is
+	UX, not correctness), so a failure just yields None."""
+	if not isinstance(args, dict):
+		return None
+	would = preview.get("would") if isinstance(preview, dict) else None
+	try:
+		bulk_key, bulk_items = _bulk(args)
+		if tool == "create_doc":
+			return _batch_create_card(would) if bulk_key == "docs" else _create_card(args, would)
+		if tool == "update_doc" and not bulk_key:
+			return _update_card(args, would)
+		if tool in _VERB:
+			return _verb_card(tool, args, bulk_items)
+		if tool == "send_email":
+			return _email_card(args)
+		if tool == "run_method":
+			return _method_card(args)
+	except Exception:
+		frappe.log_error(title="build_card failed", message=frappe.get_traceback())
+	return None
+
+
+def _bulk(args: dict):
+	"""(batch-key, items) for a bulk call, else (None, None). Keys are mutually
+	exclusive per the tool contracts."""
+	for k in _BULK_KEYS:
+		v = args.get(k)
+		if isinstance(v, list) and v:
+			return k, v
+	return None, None
+
+
+def _meta(doctype):
+	try:
+		return frappe.get_meta(doctype) if doctype else None
+	except Exception:
+		return None
+
+
+def _label(meta, fieldname: str) -> str:
+	if meta:
+		df = meta.get_field(fieldname)
+		if df and df.label:
+			return df.label
+	return fieldname
+
+
+def _fmt(value) -> str:
+	"""A scalar as a short display string; a child-table list -> "N rows"."""
+	if isinstance(value, list):
+		return f"{len(value)} row{'' if len(value) == 1 else 's'}"
+	if isinstance(value, dict):
+		return "..."
+	s = "" if value is None else str(value)
+	return s if len(s) <= _MAX_VAL else s[: _MAX_VAL - 1] + "…"
+
+
+def _create_card(args: dict, would) -> dict:
+	doctype = args.get("doctype")
+	values = args.get("values") if isinstance(args.get("values"), dict) else {}
+	meta = _meta(doctype)
+	rows = []
+	for key in list(values)[: _MAX_ROWS * 2]:
+		# Perm guard: only show a field that survived the resolved doc's
+		# field-level read-permission filter.
+		if isinstance(would, dict) and key not in would:
+			continue
+		val = would.get(key) if isinstance(would, dict) else values.get(key)
+		if val is None or (not isinstance(val, list) and str(val).strip() == ""):
+			continue
+		rows.append({"label": _label(meta, key), "value": _fmt(val)})
+		if len(rows) >= _MAX_ROWS:
+			break
+	name = would.get("name") if isinstance(would, dict) else None
+	return {"kind": "create", "doctype": doctype, "name": name, "rows": rows}
+
+
+def _update_card(args: dict, would) -> dict:
+	doctype = args.get("doctype")
+	name = args.get("name")
+	changes = args.get("changes") if isinstance(args.get("changes"), dict) else {}
+	meta = _meta(doctype)
+	# OLD values from the current doc (the park dry-run rolled back, so the DB is
+	# back to the pre-update state), perm-filtered so a restricted field's old
+	# value never leaks. NEW values from ``would`` (already perm-filtered +
+	# normalized by the tool).
+	old = {}
+	try:
+		doc = frappe.get_doc(doctype, name)
+		doc.apply_fieldlevel_read_permissions()
+		old = doc.as_dict()
+	except Exception:
+		old = {}
+	diff = []
+	for key in list(changes)[: _MAX_ROWS * 2]:
+		if isinstance(would, dict) and key not in would:
+			continue  # not perm-visible in the resolved doc
+		to_val = would.get(key) if isinstance(would, dict) else changes.get(key)
+		from_val = old.get(key)
+		if from_val == to_val:
+			continue  # normalized to a no-op
+		diff.append({
+			"label": _label(meta, key), "from": _fmt(from_val), "to": _fmt(to_val)})
+		if len(diff) >= _MAX_ROWS:
+			break
+	return {"kind": "update", "doctype": doctype, "name": name, "diff": diff}
+
+
+def _batch_create_card(would) -> dict | None:
+	if not isinstance(would, dict) or not isinstance(would.get("created"), list):
+		return None
+	created = would["created"]
+	rows = [
+		{"doctype": d.get("doctype"), "name": d.get("name")}
+		for d in created[:_MAX_ROWS] if isinstance(d, dict)
+	]
+	notes = [str(n) for n in (would.get("notes") or []) if str(n or "").strip()]
+	return {
+		"kind": "batch_create", "count": len(created), "rows": rows,
+		"extra": max(0, len(created) - len(rows)), "notes": notes[:_MAX_ROWS],
+	}
+
+
+def _target_name(item):
+	if isinstance(item, dict):
+		return item.get("name") or item.get("recipients") or item.get("doctype")
+	return item
+
+
+def _verb_card(tool: str, args: dict, bulk_items) -> dict:
+	verb = _VERB[tool]
+	doctype = args.get("doctype")
+	action = args.get("action") or ""  # apply_workflow_action only
+	if bulk_items:
+		targets = [t for t in (_target_name(x) for x in bulk_items[:_MAX_ROWS]) if t]
+		return {
+			"kind": "verb", "verb": verb, "action": action, "doctype": doctype,
+			"count": len(bulk_items), "targets": targets,
+			"extra": max(0, len(bulk_items) - len(targets)),
+		}
+	return {
+		"kind": "verb", "verb": verb, "action": action, "doctype": doctype,
+		"count": 1, "targets": [args["name"]] if args.get("name") else [], "extra": 0,
+	}
+
+
+def _email_card(args: dict) -> dict | None:
+	if isinstance(args.get("messages"), list):
+		return None  # bulk mail-merge: the summary's count is clearer than one body
+	to = args.get("recipients") or args.get("to") or ""
+	if isinstance(to, list):
+		to = ", ".join(str(x) for x in to)
+	return {
+		"kind": "email", "to": _fmt(to), "subject": _fmt(args.get("subject") or ""),
+		"body": _fmt(args.get("content") or args.get("message") or ""),
+	}
+
+
+def _method_card(args: dict) -> dict:
+	inner = args.get("args") if isinstance(args.get("args"), dict) else {}
+	shown = {}
+	for k, v in list(inner.items())[:_MAX_ROWS]:
+		shown[str(k)] = "[hidden]" if _SECRET_KEY_RE.search(str(k)) else _fmt(v)
+	return {"kind": "method", "method": _fmt(args.get("method") or ""), "args": shown}

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import pickle
 import secrets
+import time
 
 import frappe
 import redis.exceptions
@@ -51,7 +52,8 @@ def args_hash(tool: str, args: dict) -> str:
 
 
 def mint(*, conversation: str, owner: str, tool: str, args: dict, run_id: str,
-		 exec_user: str | None = None, preview: dict | None = None) -> str:
+		 exec_user: str | None = None, preview: dict | None = None,
+		 expires_at: int | None = None) -> str:
 	"""Store a pending call and return a fresh single-use token
 	(secrets.token_urlsafe(24)). The stored record carries conversation,
 	owner, tool, args (the full dict - this is the authoritative payload
@@ -82,6 +84,11 @@ def mint(*, conversation: str, owner: str, tool: str, args: dict, run_id: str,
 		"args_hash": args_hash(tool, args),
 		"run_id": run_id,
 		"preview": preview,
+		# Wall-clock expiry (epoch seconds) so the SPA can show a real countdown
+		# and distinguish a genuine TTL lapse from other confirm failures (F15).
+		# Defaults to now + TTL when the caller does not pass one, so every record
+		# carries it (the resync payload reads it straight off the record).
+		"expires_at": expires_at if expires_at is not None else int(time.time()) + _TTL_S,
 	}
 	frappe.cache().set_value(_key(token), record, expires_in_sec=_TTL_S)
 	# Index the token under its owner so list_for_owner can re-surface it. Best

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -1,0 +1,154 @@
+"""Tests for jarvis.chat.confirm_card.build_card - the render-ready "what will
+change" summary attached to a confirmation card at park (F9).
+
+The builder shapes tool + args + the park-time preview into a structured card the
+SPA renders; it never raises (a card is UX, not correctness) and returns None for
+shapes it does not cover, so the SPA falls back to the raw preview.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.confirm_card import build_card
+
+
+class TestCreateCard(FrappeTestCase):
+	def test_create_lists_set_fields_from_would(self):
+		would = {"name": "TODO-NEW-1", "description": "buy milk", "priority": "High"}
+		card = build_card(
+			"create_doc",
+			{"doctype": "ToDo", "values": {"description": "buy milk", "priority": "High"}},
+			{"preview": True, "would": would})
+		self.assertEqual(card["kind"], "create")
+		self.assertEqual(card["doctype"], "ToDo")
+		self.assertEqual(card["name"], "TODO-NEW-1")
+		labels = {r["value"] for r in card["rows"]}
+		self.assertIn("buy milk", labels)
+		self.assertIn("High", labels)
+
+	def test_create_hides_fields_absent_from_permfiltered_would(self):
+		# A field the model set but that is NOT in the perm-filtered ``would`` is
+		# dropped (never leak a restricted field's value).
+		card = build_card(
+			"create_doc",
+			{"doctype": "ToDo", "values": {"description": "x", "secret_field": "SEE"}},
+			{"would": {"name": "T-1", "description": "x"}})
+		vals = {r["value"] for r in card["rows"]}
+		self.assertIn("x", vals)
+		self.assertNotIn("SEE", vals)
+
+
+class TestUpdateCard(FrappeTestCase):
+	def test_update_shows_from_to_diff(self):
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "old desc", "priority": "Medium",
+		}).insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc(
+			"ToDo", todo.name, force=True, ignore_permissions=True))
+		would = {"description": "new desc", "priority": "Low"}
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name,
+			 "changes": {"description": "new desc", "priority": "Low"}},
+			{"would": would})
+		self.assertEqual(card["kind"], "update")
+		self.assertEqual(card["name"], todo.name)
+		by_from = {d["from"]: d["to"] for d in card["diff"]}
+		# OLD from the current doc, NEW from ``would``.
+		self.assertEqual(by_from.get("old desc"), "new desc")
+		self.assertEqual(by_from.get("Medium"), "Low")
+
+	def test_update_skips_unchanged_and_permhidden(self):
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "same", "priority": "Medium",
+		}).insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc(
+			"ToDo", todo.name, force=True, ignore_permissions=True))
+		would = {"description": "same"}  # no-op change; priority not in would
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name,
+			 "changes": {"description": "same", "priority": "High"}},
+			{"would": would})
+		# description is a no-op (from == to) and priority is not perm-visible.
+		self.assertEqual(card["diff"], [])
+
+
+class TestVerbCard(FrappeTestCase):
+	def test_single_verb(self):
+		card = build_card("submit_doc", {"doctype": "Sales Order", "name": "SO-1"}, {"would": {}})
+		self.assertEqual(card["kind"], "verb")
+		self.assertEqual(card["verb"], "submit")
+		self.assertEqual(card["doctype"], "Sales Order")
+		self.assertEqual(card["targets"], ["SO-1"])
+		self.assertEqual(card["count"], 1)
+
+	def test_bulk_verb_lists_targets(self):
+		names = [f"SO-{i}" for i in range(3)]
+		card = build_card("cancel_doc", {"doctype": "Sales Order", "names": names}, {})
+		self.assertEqual(card["verb"], "cancel")
+		self.assertEqual(card["count"], 3)
+		self.assertEqual(card["targets"], names)
+
+	def test_workflow_action_carries_action(self):
+		card = build_card(
+			"apply_workflow_action",
+			{"doctype": "Sales Order", "name": "SO-1", "action": "Approve"}, {})
+		self.assertEqual(card["verb"], "apply")
+		self.assertEqual(card["action"], "Approve")
+
+
+class TestEmailAndMethodCards(FrappeTestCase):
+	def test_email_shows_to_subject_body(self):
+		card = build_card(
+			"send_email",
+			{"recipients": "a@x.test", "subject": "Hi", "content": "the body"}, {})
+		self.assertEqual(card["kind"], "email")
+		self.assertEqual(card["to"], "a@x.test")
+		self.assertEqual(card["subject"], "Hi")
+		self.assertEqual(card["body"], "the body")
+
+	def test_bulk_email_falls_back(self):
+		card = build_card("send_email", {"messages": [{"recipients": "a@x.test"}]}, {})
+		self.assertIsNone(card)
+
+	def test_method_masks_secret_arg_keys(self):
+		card = build_card(
+			"run_method",
+			{"method": "some.method", "args": {"doc": "X", "api_key": "SECRET", "password": "p"}},
+			{})
+		self.assertEqual(card["kind"], "method")
+		self.assertEqual(card["method"], "some.method")
+		self.assertEqual(card["args"]["doc"], "X")
+		self.assertEqual(card["args"]["api_key"], "[hidden]")
+		self.assertEqual(card["args"]["password"], "[hidden]")
+
+
+class TestBatchAndFallback(FrappeTestCase):
+	def test_batch_create_from_would_created(self):
+		would = {"created": [
+			{"doctype": "ToDo", "name": "T-1"}, {"doctype": "ToDo", "name": "T-2"}],
+			"notes": ["reused Supplier X"]}
+		card = build_card(
+			"create_doc", {"docs": [{"doctype": "ToDo", "values": {}}]}, {"would": would})
+		self.assertEqual(card["kind"], "batch_create")
+		self.assertEqual(card["count"], 2)
+		self.assertEqual([r["name"] for r in card["rows"]], ["T-1", "T-2"])
+		self.assertEqual(card["notes"], ["reused Supplier X"])
+
+	def test_uncovered_tool_returns_none(self):
+		self.assertIsNone(build_card("share_doc", {"doctype": "ToDo", "name": "T-1"}, {}))
+		self.assertIsNone(build_card("assign_to", {"doctype": "ToDo", "name": "T-1"}, {}))
+
+	def test_never_raises_on_bad_input(self):
+		self.assertIsNone(build_card("update_doc", None, None))
+		self.assertIsNone(build_card("create_doc", "not-a-dict", {}))
+
+	def test_long_value_truncated(self):
+		would = {"name": "T-1", "description": "z" * 500}
+		card = build_card(
+			"create_doc", {"doctype": "ToDo", "values": {"description": "z" * 500}},
+			{"would": would})
+		shown = card["rows"][0]["value"]
+		self.assertLessEqual(len(shown), 200)
+		self.assertTrue(shown.endswith("…"))

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -940,3 +940,34 @@ class TestConvLessTokenIsolation(FrappeTestCase):
 		# The real owner can still confirm it (not burned by the wrong-owner try).
 		with patch("jarvis.chat.api._dispatch_turn"):
 			self.assertTrue(confirm_tool(token, conversation="mine")["ok"])
+
+
+class TestConfirmCardWiring(FrappeTestCase):
+	"""F9/F15 wiring: the gate attaches a render-ready ``card`` + ``expires_at`` to
+	the stored/published preview, the model-facing return omits the ``card`` (UX,
+	not model context), and the resync payload carries ``expires_at``."""
+
+	def test_gate_attaches_card_and_expiry_and_strips_card_from_model_return(self):
+		patcher, captured = _spy_mint()
+		with patcher:
+			r = api._run_tool("create_doc", {
+				"doctype": "ToDo", "values": {"description": "card-wire-1"}})
+		self.assertEqual(r["data"]["status"], "pending_confirmation")
+		# Model-facing preview: present, but WITHOUT the human card.
+		self.assertNotIn("card", r["data"]["preview"])
+		# The stored/published preview DOES carry the card, and expires_at is set.
+		kw = captured["kwargs"]
+		self.assertEqual(kw["preview"]["card"]["kind"], "create")
+		self.assertIsInstance(kw["expires_at"], int)
+		self.assertGreater(kw["expires_at"], 0)
+
+	def test_resync_payload_carries_expires_at(self):
+		from jarvis.chat import pending_confirm
+		from jarvis.chat.actions_api import list_pending_confirmations
+		owner = frappe.session.user
+		pending_confirm.mint(
+			conversation="cardwire-conv", owner=owner, exec_user=owner,
+			tool="delete_doc", args={"doctype": "ToDo", "name": "X"}, run_id="")
+		items = list_pending_confirmations(conversation="cardwire-conv")["data"]["pending"]
+		self.assertTrue(items)
+		self.assertIsInstance(items[0]["expires_at"], int)


### PR DESCRIPTION
## Problem

The confirmation card the user approves for **every** gated write renders a **raw-JSON dump** of the dry-run doc plus a one-line target string — it names the record but not **what the write does to it** (#1 raw JSON, #2 no change summary). And the card carries no expiry, so the SPA can't show a real countdown or tell a genuine 15-min TTL lapse from other confirm failures (#3 "expires too soon").

## This PR: the backend half (harmless to old clients)

It attaches the *data* a readable card needs; the **frontend that renders it is a follow-up PR**. Old clients ignore the new fields, so this ships safely on its own.

- **New `jarvis/chat/confirm_card.py` → `build_card(tool, args, preview)`** shapes a structured, render-ready summary per tool:
  - create → set fields; update → **from→to diff**; submit/cancel/delete/amend/apply_workflow_action → a verb line ("will submit this Sales Order SO-0001"), single + bulk; send_email → to/subject/body; run_method → method + args (secret-ish keys masked); batch create → the created list.
  - Returns `None` for uncovered shapes (share_doc, assign_to, create_custom_skill, update_wiki, bulk update/email) → the SPA falls back to today's rendering.
- **Perm-safe by construction.** Values come from the **already field-level-perm-filtered** `would` (the create/update tools call `apply_fieldlevel_read_permissions` before returning), and the update **old** values from a freshly-fetched, perm-filtered current doc — so a restricted field's value never lands in the card. The guard holds whether the perm filter *removes* a restricted key (`key not in would` skips it) or *blanks* it (from=None, to=None → equal → skipped). Long values truncated, rows/targets capped, and `build_card` never raises (a card is UX, not correctness).
- **Attached ONCE at park** as `preview["card"]`, plus a wall-clock `expires_at`. Phase-1 F2 stores the preview in the token record and resync returns it verbatim, so card + expiry ride the `action:pending` event, the record, and every resync **identically** — never rebuilt, so it can't diverge (and no per-token doc load on reconnect). The **model-facing return strips** the human `card` (duplicate UX for the model's context).
- `pending_confirm.mint` stores `expires_at`; `list_pending_confirmations` returns it.

## Verification

- `bench --site jarvis-test.localhost run-tests --app jarvis` — green: **`test_confirm_card` (14 new)** covers every card kind incl. the perm-hidden-field guard, secret masking, truncation, and the `None` fallbacks; **`test_confirm_gate` (41)** wiring tests assert the gate attaches `card` + `expires_at`, strips `card` from the model return, and resync carries `expires_at`. No regressions across `test_pending_confirm`/`test_actions_api`/`test_auto_apply`/`test_bulk_tools`/`test_action_pending`/`test_receipt_chips`.
- Fable design-reviewed the approach (all corrections applied — attach-once-at-park not at resync, perm-safe value sourcing, size caps); the update perm-leak guard was self-verified airtight.

Part of the approval-mechanism remediation (Phase 3a; follows merged #305 Phase 1 and #306 Phase 2A). **Follow-up (Phase 3b):** the frontend that renders this card in place of the raw JSON, the expiry UX (#3), and the Confirm spinner — needs a UI smoke on a real tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
