### PR TITLE
feat(confirm-card): render the change summary + expiry UX on the desktop card (approval review Phase 3b)

### DIFF
--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -1,0 +1,110 @@
+<script setup>
+// Renders the server-built "what will change" summary (F9) for a parked gated
+// write's confirmation card - replacing the raw-JSON dump. The structured card
+// comes from jarvis/chat/confirm_card.py (kind = create | update | verb | email |
+// method | batch_create) and is already perm-filtered + size-capped server-side.
+// All values render through escaped interpolation (no v-html); the raw dry-run
+// preview stays available behind a collapsed Details expander.
+import { computed } from "vue"
+
+import { verbSentence } from "@/lib/actionSummary"
+
+const props = defineProps({
+	card: { type: Object, required: true },
+	// Raw preview text (pretty JSON) for the Details expander; "" hides it.
+	details: { type: String, default: "" },
+})
+
+const sentence = computed(() =>
+	props.card.kind === "verb" ? verbSentence(props.card) : "")
+</script>
+
+<template>
+	<div class="jv-pcard">
+		<!-- create: the fields the write will set -->
+		<template v-if="card.kind === 'create'">
+			<div class="jv-pcard-head">Create {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<dl v-if="card.rows.length" class="jv-pcard-fields">
+				<template v-for="(r, i) in card.rows" :key="i"><dt>{{ r.label }}</dt><dd>{{ r.value }}</dd></template>
+			</dl>
+			<div v-else class="jv-pcard-empty">No fields set.</div>
+		</template>
+
+		<!-- update: from -> to diff -->
+		<template v-else-if="card.kind === 'update'">
+			<div class="jv-pcard-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<div v-for="(d, i) in card.diff" :key="i" class="jv-pcard-diffrow">
+				<span class="jv-pcard-lbl">{{ d.label }}</span>
+				<span class="jv-pcard-from">{{ d.from || "(empty)" }}</span>
+				<span class="jv-pcard-arrow">→</span>
+				<span class="jv-pcard-to">{{ d.to || "(empty)" }}</span>
+			</div>
+			<div v-if="!card.diff.length" class="jv-pcard-empty">No field changes.</div>
+		</template>
+
+		<!-- verb: submit / cancel / delete / amend / apply_workflow_action -->
+		<template v-else-if="card.kind === 'verb'">
+			<div class="jv-pcard-verb">{{ sentence }}</div>
+			<ul v-if="card.count > 1 && card.targets.length" class="jv-pcard-list">
+				<li v-for="(t, i) in card.targets" :key="i">{{ t }}</li>
+				<li v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</li>
+			</ul>
+		</template>
+
+		<!-- email -->
+		<template v-else-if="card.kind === 'email'">
+			<div class="jv-pcard-kv"><span>To</span><b>{{ card.to }}</b></div>
+			<div class="jv-pcard-kv"><span>Subject</span><b>{{ card.subject }}</b></div>
+			<pre v-if="card.body" class="jv-pcard-body">{{ card.body }}</pre>
+		</template>
+
+		<!-- run_method -->
+		<template v-else-if="card.kind === 'method'">
+			<div class="jv-pcard-kv"><span>Method</span><b>{{ card.method }}</b></div>
+			<dl v-if="Object.keys(card.args).length" class="jv-pcard-fields">
+				<template v-for="(v, k) in card.args" :key="k"><dt>{{ k }}</dt><dd>{{ v }}</dd></template>
+			</dl>
+		</template>
+
+		<!-- batch create -->
+		<template v-else-if="card.kind === 'batch_create'">
+			<div class="jv-pcard-head">Create {{ card.count }} record<template v-if="card.count !== 1">s</template></div>
+			<ul class="jv-pcard-list">
+				<li v-for="(r, i) in card.rows" :key="i">{{ r.doctype }} <b>{{ r.name }}</b></li>
+				<li v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</li>
+			</ul>
+			<div v-for="(n, i) in card.notes" :key="'n' + i" class="jv-pcard-note">{{ n }}</div>
+		</template>
+
+		<details v-if="details" class="jv-pcard-details">
+			<summary>Details</summary>
+			<pre>{{ details }}</pre>
+		</details>
+	</div>
+</template>
+
+<style scoped>
+.jv-pcard { font-size: 12.5px; color: var(--text); }
+.jv-pcard-head { font-weight: 600; margin-bottom: 6px; overflow-wrap: anywhere; }
+.jv-pcard-verb { font-weight: 500; overflow-wrap: anywhere; }
+.jv-pcard-fields { display: grid; grid-template-columns: auto 1fr; gap: 3px 12px; margin: 0; }
+.jv-pcard-fields dt { color: var(--text-3); }
+.jv-pcard-fields dd { margin: 0; text-align: right; overflow-wrap: anywhere; }
+.jv-pcard-diffrow { display: grid; grid-template-columns: 1fr auto auto auto; gap: 8px; align-items: baseline; padding: 2px 0; }
+.jv-pcard-lbl { color: var(--text-3); }
+.jv-pcard-from { color: var(--text-3); text-decoration: line-through; overflow-wrap: anywhere; }
+.jv-pcard-arrow { color: var(--text-3); }
+.jv-pcard-to { color: var(--green, var(--text)); font-weight: 500; overflow-wrap: anywhere; }
+.jv-pcard-empty { color: var(--text-3); font-style: italic; }
+.jv-pcard-kv { display: flex; justify-content: space-between; gap: 12px; padding: 2px 0; }
+.jv-pcard-kv span { color: var(--text-3); }
+.jv-pcard-kv b { font-weight: 500; text-align: right; overflow-wrap: anywhere; }
+.jv-pcard-list { margin: 4px 0 0; padding-left: 18px; }
+.jv-pcard-list li { padding: 1px 0; overflow-wrap: anywhere; }
+.jv-pcard-more { list-style: none; color: var(--text-3); }
+.jv-pcard-note { margin-top: 5px; color: var(--text-3); font-size: 12px; }
+.jv-pcard-body { margin: 6px 0 0; padding: 8px 10px; background: var(--surface-2); border-radius: 7px; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; font-size: 12px; line-height: 1.5; }
+.jv-pcard-details { margin-top: 8px; }
+.jv-pcard-details summary { cursor: pointer; color: var(--text-3); font-size: 11.5px; user-select: none; }
+.jv-pcard-details pre { margin: 6px 0 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 260px; overflow-y: auto; }
+</style>

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -50,6 +50,46 @@ export function batchFromPreview(preview) {
   }
 }
 
+// ── Pending-confirmation card (F9/F15) ──────────────────────────────────────
+// The write-safety gate attaches a render-ready ``card`` object to a parked
+// write's preview (server side: jarvis/chat/confirm_card.py) plus a wall-clock
+// ``expires_at``. These pure helpers pull the card out for the token confirmation
+// card and compute the expiry, so the SPA renders "what will change" + a real
+// expiry state instead of the raw dry-run JSON. A missing/unknown card -> null, and
+// the card falls back to the summary + raw-preview rendering.
+
+const CARD_KINDS = new Set(["create", "update", "verb", "email", "method", "batch_create"])
+
+// The structured card for a parked action ({kind, ...}), or null when the server
+// built none (an older token, or an uncovered tool shape).
+export function pendingCardOf(pa) {
+  const card = pa && pa.preview && pa.preview.card
+  if (!card || typeof card !== "object" || !CARD_KINDS.has(card.kind)) return null
+  return card
+}
+
+// One-line sentence for a verb card (submit/cancel/delete/amend/apply): "Will
+// submit this Sales Order SO-0001" / "Will cancel 6 Sales Orders".
+export function verbSentence(card) {
+  const verb = card.verb || "run"
+  const dt = card.doctype || "record"
+  const act = card.action ? ` "${card.action}" to` : ""
+  if ((card.count || 1) > 1) {
+    return `Will ${verb}${act} ${card.count} ${pluralize(dt, card.count)}`
+  }
+  const name = (card.targets && card.targets[0]) || ""
+  return `Will ${verb}${act} this ${dt}${name ? " " + name : ""}`
+}
+
+// Wall-clock expiry for a parked confirmation. ``expiresAt`` is epoch SECONDS (as
+// the server stamps it); ``nowMs`` is Date.now(). Returns {expired, secondsLeft}
+// (secondsLeft null when there is no expiry stamp — an older token).
+export function pendingExpiry(expiresAt, nowMs) {
+  if (typeof expiresAt !== "number" || !expiresAt) return { expired: false, secondsLeft: null }
+  const secondsLeft = Math.round(expiresAt - nowMs / 1000)
+  return { expired: secondsLeft <= 0, secondsLeft }
+}
+
 // ── Post-action receipt chips ───────────────────────────────────────────────
 // A gated write, once the user clicks Confirm or Discard, is replaced by a
 // DURABLE receipt chip instead of the card vanishing. These pure helpers turn

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -1,7 +1,7 @@
 // frontend/src/lib/actionSummary.test.js
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { proposedFields, changedFields, lineItemSummary, summarize, batchFromPreview } from "./actionSummary.js"
+import { proposedFields, changedFields, lineItemSummary, summarize, batchFromPreview, pendingCardOf, verbSentence, pendingExpiry } from "./actionSummary.js"
 
 const createAction = {
   kind: "doc", verb: "create", doctype: "Sales Order", summary: "Sales Order - Acme, 2 items, total 1,100",
@@ -114,4 +114,37 @@ test("batchFromPreview: non-batch or empty preview -> null", () => {
   assert.equal(batchFromPreview({ would: "SomeDocName" }), null)
   assert.equal(batchFromPreview({ described: true }), null)
   assert.equal(batchFromPreview(null), null)
+})
+
+test("pendingCardOf: returns the structured card for a known kind", () => {
+  const card = { kind: "update", doctype: "ToDo", diff: [{ label: "Priority", from: "Medium", to: "Low" }] }
+  assert.deepEqual(pendingCardOf({ preview: { card } }), card)
+})
+
+test("pendingCardOf: null for missing / unknown-kind / non-object cards", () => {
+  assert.equal(pendingCardOf({ preview: {} }), null)
+  assert.equal(pendingCardOf({ preview: { card: { kind: "wat" } } }), null)
+  assert.equal(pendingCardOf({ preview: { card: "nope" } }), null)
+  assert.equal(pendingCardOf({}), null)
+  assert.equal(pendingCardOf(null), null)
+})
+
+test("verbSentence: single names the record, bulk counts + pluralizes", () => {
+  assert.equal(
+    verbSentence({ kind: "verb", verb: "submit", doctype: "Sales Order", count: 1, targets: ["SO-1"] }),
+    "Will submit this Sales Order SO-1")
+  assert.equal(
+    verbSentence({ kind: "verb", verb: "cancel", doctype: "Sales Order", count: 6, targets: ["SO-1"] }),
+    "Will cancel 6 Sales Orders")
+  assert.equal(
+    verbSentence({ kind: "verb", verb: "apply", action: "Approve", doctype: "Leave Application", count: 1, targets: ["LA-1"] }),
+    'Will apply "Approve" to this Leave Application LA-1')
+})
+
+test("pendingExpiry: expired vs live vs no-stamp", () => {
+  const now = 1_000_000_000_000 // Date.now() ms
+  assert.deepEqual(pendingExpiry(now / 1000 + 120, now), { expired: false, secondsLeft: 120 })
+  assert.deepEqual(pendingExpiry(now / 1000 - 5, now), { expired: true, secondsLeft: -5 })
+  assert.deepEqual(pendingExpiry(null, now), { expired: false, secondsLeft: null })
+  assert.deepEqual(pendingExpiry(0, now), { expired: false, secondsLeft: null })
 })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -469,20 +469,23 @@
 						</div>
 						<div class="jv-pending-body">
 							<div v-if="pendingSummaryOf(pa)" class="jv-pending-summary">{{ pendingSummaryOf(pa) }}</div>
-							<div v-if="pendingNoteOf(pa)" class="jv-pending-note">{{ pendingNoteOf(pa) }}</div>
-							<ul v-if="pendingBatchOf(pa)" class="jv-pending-batch">
-								<li v-for="(a, i) in pendingBatchOf(pa).actions" :key="'a' + i">
-									Create <b>{{ a.doctype }}</b> "{{ a.name }}"
-								</li>
-								<li v-for="(n, i) in pendingBatchOf(pa).notes" :key="'n' + i" class="jv-pending-batch-note">
-									{{ n }}
-								</li>
-							</ul>
-							<pre v-else-if="pendingPreviewOf(pa)" class="jv-pending-preview">{{ pendingPreviewOf(pa) }}</pre>
+							<div v-if="pendingExpiredOf(pa)" class="jv-pending-expired">This confirmation expired. Tell me the action again to retry it.</div>
+							<template v-else>
+								<!-- F9: the server-built "what will change" card (raw preview behind Details) -->
+								<PendingCard v-if="pendingCardOf(pa)" :card="pendingCardOf(pa)" :details="pendingDetailsOf(pa)" />
+								<template v-else>
+									<div v-if="pendingNoteOf(pa)" class="jv-pending-note">{{ pendingNoteOf(pa) }}</div>
+									<ul v-if="pendingBatchOf(pa)" class="jv-pending-batch">
+										<li v-for="(a, i) in pendingBatchOf(pa).actions" :key="'a' + i">Create <b>{{ a.doctype }}</b> "{{ a.name }}"</li>
+										<li v-for="(n, i) in pendingBatchOf(pa).notes" :key="'n' + i" class="jv-pending-batch-note">{{ n }}</li>
+									</ul>
+									<pre v-else-if="pendingPreviewOf(pa)" class="jv-pending-preview">{{ pendingPreviewOf(pa) }}</pre>
+								</template>
+							</template>
 						</div>
 						<div v-if="pa.error" style="margin:0 14px 10px"><ActionError :error="pa.error" /></div>
 						<div class="jv-action-foot">
-							<button class="jv-action-primary" :disabled="pa.busy || convStreaming" :title="convStreaming ? 'Waiting for the current reply to finish' : ''" @click="confirmPending(pa)">✓ Confirm</button>
+							<button class="jv-action-primary" :disabled="pa.busy || convStreaming || pendingExpiredOf(pa)" :title="convStreaming ? 'Waiting for the current reply to finish' : ''" @click="confirmPending(pa)"><span v-if="pa.busy">Confirming…</span><span v-else>✓ Confirm</span></button>
 							<button class="jv-action-discard" :disabled="pa.busy" @click="discardPending(pa)">Discard</button>
 						</div>
 					</div>
@@ -838,11 +841,12 @@ import JvChart from "@/charts/JvChart.vue"
 import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue"
 import DraftPreview from "@/components/doc/DraftPreview.vue"
 import ActionError from "@/components/ActionError.vue"
+import PendingCard from "@/components/PendingCard.vue"
 import ReceiptChip from "@/components/ReceiptChip.vue"
 import { useShellStore } from "@/stores/shell"
 import { useJarvisTheme } from "@/theme"
 import { displayName } from "@/lib/user"
-import { summarize, batchFromPreview } from "@/lib/actionSummary"
+import { summarize, batchFromPreview, pendingCardOf, verbSentence, pendingExpiry } from "@/lib/actionSummary"
 
 const session = inject("$session")
 const socket = inject("$socket")
@@ -2460,6 +2464,27 @@ function pendingBatchOf(pa) {
 	if (!pa || pa.tool !== "create_docs") return null
 	return batchFromPreview(pa.preview)
 }
+// The raw dry-run preview JSON, shown behind the card's Details expander (the
+// same string the pre-F9 card dumped directly).
+function pendingDetailsOf(pa) {
+	return pendingPreviewOf(pa)
+}
+// Wall-clock expiry (F15): a coarse tick flips a card to its "expired" state once
+// the 15-min token TTL lapses, so a stale card stops looking actionable. Real
+// enforcement stays server-side (confirming an expired token fails).
+const pendingNowMs = ref(Date.now())
+let _expiryTick = null
+onMounted(() => {
+	_expiryTick = setInterval(() => {
+		pendingNowMs.value = Date.now()
+	}, 15000)
+})
+onUnmounted(() => {
+	if (_expiryTick) clearInterval(_expiryTick)
+})
+function pendingExpiredOf(pa) {
+	return pendingExpiry(pa && pa.expires_at, pendingNowMs.value).expired
+}
 // Drop one card from the queue by its token (confirm-success / discard / expiry).
 function removePending(token) {
 	if (!token) return
@@ -2477,6 +2502,7 @@ function enqueuePending(card) {
 		summary: card.summary || "",
 		preview: card.preview || null,
 		run_id: card.run_id || null,
+		expires_at: card.expires_at || null,
 		busy: false,
 		error: null,
 	})
@@ -2502,7 +2528,16 @@ async function confirmPending(pa) {
 			// way the card is spent - surface a brief note and dismiss.
 			if (r.error && r.error.type === "InvalidConfirmation") {
 				removePending(token)
-				notify("That confirmation expired - ask Jarvis to try again.", { type: "error" })
+				// InvalidConfirmation is deliberately opaque (expired / used in another
+				// tab / a redis blip). Use the card's own wall-clock expiry for the right
+				// message instead of always blaming expiry (F15).
+				const expired = pendingExpiry(pa.expires_at, Date.now()).expired
+				notify(
+					expired
+						? "This confirmation expired — tell me the action again to retry it."
+						: "Couldn't confirm — it may have been handled in another tab. Refresh, or ask me to try again.",
+					{ type: "error" },
+				)
 				return
 			}
 			// The token was consumed and the tool failed; confirm_tool already
@@ -2571,6 +2606,7 @@ async function resyncPendingConfirmations(id) {
 			summary: it.summary || "",
 			preview: it.preview || null,
 			run_id: it.run_id || null,
+			expires_at: it.expires_at || null,
 		})
 	}
 }
@@ -3558,6 +3594,7 @@ function onEvent(p) {
 				summary: p.summary || "",
 				preview: p.preview || null,
 				run_id: p.run_id || null,
+				expires_at: p.expires_at || null,
 			})
 		}
 		return
@@ -4909,6 +4946,7 @@ onUnmounted(() => {
 .jv-pending-body { padding: 11px 14px; display: flex; flex-direction: column; gap: 8px; }
 .jv-pending-summary { font-size: 13.5px; line-height: 1.5; color: var(--text); }
 .jv-pending-note { font-size: 12px; line-height: 1.45; color: var(--text-3); }
+.jv-pending-expired { padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; color: var(--text-3); font-size: 12.5px; line-height: 1.45; }
 .jv-pending-preview { margin: 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; color: var(--text); white-space: pre-wrap; word-break: break-word; max-height: 260px; overflow-y: auto; }
 .jv-pending-batch { margin: 0 14px 8px; padding-left: 18px; font-size: 12.5px; color: var(--text-2); }
 .jv-pending-batch li { margin: 2px 0; }


### PR DESCRIPTION
## What this does

Makes the confirmation card **visible** — it renders the server-built `preview.card` from Phase 3a (#307) instead of the raw-JSON dump, so the user finally sees **what the write does to the record** (#1 raw JSON → rendered, #2 the change summary), plus the expiry UX (#3) and a Confirm spinner. **Desktop `/jarvis` SPA only**; the PWA is a follow-up.

- **New `components/PendingCard.vue`** renders each card kind:
  - **create** → a field list; **update** → a **from→to diff**; **submit/cancel/delete/amend/apply** → a plain-English line ("Will submit this Sales Order SO-1" / "Will cancel 6 Sales Orders"); **email** → to/subject/body; **run_method** → method + args; **batch create** → a bullet list.
  - The raw dry-run JSON is kept behind a collapsed **Details** expander. All values render as **escaped text** (no `v-html`); the server already perm-filtered, truncated, and masked secret-ish keys.
- **F15 expiry UX:** the server `expires_at` is carried through the live event, resync, and enqueue; a coarse 15s tick flips a stale card to an inline **"this confirmation expired — tell me the action again"** state (Confirm disabled, Discard still clears it), and the confirm-failure toast now tells a genuine TTL lapse apart from "handled in another tab / retry" instead of always blaming expiry.
- **F10:** the Confirm button shows **"Confirming…"** during the round-trip.
- **Graceful fallback:** a card the server didn't build (older token / uncovered shape) renders today's summary + raw-preview, byte-identical.

Logic lives in **pure, unit-tested helpers** (`lib/actionSummary.js`: `pendingCardOf`, `verbSentence`, `pendingExpiry`) so the untestable template stays thin.

## Verification

- `cd app && npm run build` — **green**.
- `node --test frontend/src/lib/actionSummary.test.js` — **14/14** (card extraction, verb phrasing, expiry-seconds-vs-ms contract, fallbacks).
- Fable-reviewed the rendering against the backend card contract — **ship**: every field the template touches is unconditionally set by the builder (no throw paths), no `v-html`, `expires_at` units consistent end-to-end, old tokens degrade gracefully, and an expired card stays discardable even after its server token self-expires.

## ⚠️ Needs a UI smoke

There is **no automated coverage of the rendered template** (no live tenant to drive). Before relying on it, please smoke on a real tenant: a parked **update** (see the from→to diff), a **delete/submit** (the verb line), a **send_email** (to/subject/body), the **Details** expander, the **Confirming…** spinner, and let a card sit ~15 min to see the **expired** state.

Part of the approval-mechanism remediation (Phase 3b; the frontend for merged #307). **Follow-up:** the PWA's confirmation card (`pwa/`) gets the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
