### PR TITLE
feat(confirm-card): render the change summary + expiry UX on the PWA card (approval review Phase 3c)

### DIFF
--- a/pwa/src/components/DecisionSheet.vue
+++ b/pwa/src/components/DecisionSheet.vue
@@ -1,7 +1,9 @@
 <script setup>
 import { computed, ref, watch } from "vue"
 import { renderMarkdown } from "@shared/markdown.js"
+import { pendingCardOf, pendingExpiry } from "@shared/lib/actionSummary.js"
 import Sheet from "./Sheet.vue"
+import PendingCard from "./PendingCard.vue"
 import * as api from "../api"
 
 // Approve / deny a parked write.
@@ -30,6 +32,18 @@ watch(
 const summary = computed(
 	() => props.action?.summary || props.action?.tool || "Approve this change",
 )
+
+// F9: the server-built "what will change" card (null -> fall back to previewHtml).
+const card = computed(() => pendingCardOf({ preview: props.action?.preview }))
+// Raw dry-run JSON for the card's Details expander; empty for described-intent
+// previews or when there is no dry-run doc.
+const rawDetails = computed(() => {
+	const pv = props.action?.preview
+	if (!pv || typeof pv === "string" || pv.described || pv.would == null) return ""
+	return typeof pv.would === "string" ? pv.would : JSON.stringify(pv.would, null, 2)
+})
+// F15: the server's wall-clock expiry (epoch seconds) for this parked token.
+const expired = computed(() => pendingExpiry(props.action?.expires_at, Date.now()).expired)
 
 // The preview is either a ready-made string or {note, would} — `described` means
 // the note already says it all and the payload dump would just be noise.
@@ -62,7 +76,11 @@ async function approve() {
 			// The token is single-use and short-lived: a stale card must say so
 			// rather than look like a failure the user can retry.
 			if (r.error?.type === "InvalidConfirmation") {
-				error.value = "This confirmation is no longer valid — ask Jarvis to try again."
+				// InvalidConfirmation is deliberately opaque; use the card's own
+				// wall-clock expiry to say the right thing (F15).
+				error.value = pendingExpiry(props.action?.expires_at, Date.now()).expired
+					? "This confirmation expired — tell Jarvis the action again to retry it."
+					: "Couldn't confirm — it may have been handled elsewhere. Refresh, or ask Jarvis to try again."
 				state.value = "review"
 				emit("resolved", props.action.token, "expired")
 				return
@@ -110,13 +128,15 @@ async function approve() {
 						<span class="jv-dtool">{{ props.action.tool }}</span>
 					</div>
 					<div class="jv-dsummary">{{ summary }}</div>
-					<div v-if="previewHtml" class="jv-dpreview" v-html="previewHtml" />
+					<PendingCard v-if="card" :card="card" :details="rawDetails" class="jv-dcard" />
+					<div v-else-if="previewHtml" class="jv-dpreview" v-html="previewHtml" />
+					<div v-if="expired" class="jv-dexpired">This confirmation expired — tell Jarvis the action again to retry it.</div>
 					<div v-if="error" class="jv-derror">{{ error }}</div>
 				</div>
 
 				<div class="jv-dactions">
 					<button class="jv-btn is-ghost" :disabled="state === 'busy'" @click="deny">Deny</button>
-					<button class="jv-btn is-primary jv-dapprove" :disabled="state === 'busy'" @click="approve">
+					<button class="jv-btn is-primary jv-dapprove" :disabled="state === 'busy' || expired" @click="approve">
 						<span v-if="state === 'busy'" class="jv-spinner" />
 						<span v-else>Approve</span>
 					</button>
@@ -184,6 +204,8 @@ async function approve() {
 	background: var(--card2);
 	font-size: 12px;
 }
+.jv-dcard { margin-top: 12px; }
+.jv-dexpired { margin-top: 12px; padding: 11px; border-radius: 10px; background: var(--card2); color: var(--ink5); font-size: 12.5px; line-height: 1.45; }
 .jv-derror {
 	margin-top: 12px;
 	padding: 11px;

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -1,0 +1,97 @@
+<script setup>
+// Renders the server-built "what will change" summary (F9) for a parked write's
+// approval sheet - replacing the raw-JSON dump. The structured card comes from
+// jarvis/chat/confirm_card.py (kind = create | update | verb | email | method |
+// batch_create), already perm-filtered + size-capped + secret-masked server-side.
+// Logic (verbSentence) is the SAME helper the desktop uses (@shared). All values
+// render as escaped text; the raw dry-run JSON stays behind a Details expander.
+import { computed } from "vue"
+
+import { verbSentence } from "@shared/lib/actionSummary.js"
+
+const props = defineProps({
+	card: { type: Object, required: true },
+	details: { type: String, default: "" },
+})
+
+const sentence = computed(() =>
+	props.card.kind === "verb" ? verbSentence(props.card) : "")
+</script>
+
+<template>
+	<div class="jv-pc">
+		<template v-if="card.kind === 'create'">
+			<div class="jv-pc-head">Create {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<div v-for="(r, i) in card.rows" :key="i" class="jv-pc-kv"><span>{{ r.label }}</span><b>{{ r.value }}</b></div>
+			<div v-if="!card.rows.length" class="jv-pc-empty">No fields set.</div>
+		</template>
+
+		<template v-else-if="card.kind === 'update'">
+			<div class="jv-pc-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<div v-for="(d, i) in card.diff" :key="i" class="jv-pc-diff">
+				<span class="jv-pc-lbl">{{ d.label }}</span>
+				<span class="jv-pc-from">{{ d.from || "(empty)" }}</span>
+				<span class="jv-pc-arrow">→</span>
+				<span class="jv-pc-to">{{ d.to || "(empty)" }}</span>
+			</div>
+			<div v-if="!card.diff.length" class="jv-pc-empty">No field changes.</div>
+		</template>
+
+		<template v-else-if="card.kind === 'verb'">
+			<div class="jv-pc-verb">{{ sentence }}</div>
+			<ul v-if="card.count > 1 && card.targets.length" class="jv-pc-list">
+				<li v-for="(t, i) in card.targets" :key="i">{{ t }}</li>
+				<li v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</li>
+			</ul>
+		</template>
+
+		<template v-else-if="card.kind === 'email'">
+			<div class="jv-pc-kv"><span>To</span><b>{{ card.to }}</b></div>
+			<div class="jv-pc-kv"><span>Subject</span><b>{{ card.subject }}</b></div>
+			<pre v-if="card.body" class="jv-pc-body">{{ card.body }}</pre>
+		</template>
+
+		<template v-else-if="card.kind === 'method'">
+			<div class="jv-pc-kv"><span>Method</span><b>{{ card.method }}</b></div>
+			<div v-for="(v, k) in card.args" :key="k" class="jv-pc-kv"><span>{{ k }}</span><b>{{ v }}</b></div>
+		</template>
+
+		<template v-else-if="card.kind === 'batch_create'">
+			<div class="jv-pc-head">Create {{ card.count }} record<template v-if="card.count !== 1">s</template></div>
+			<ul class="jv-pc-list">
+				<li v-for="(r, i) in card.rows" :key="i">{{ r.doctype }} <b>{{ r.name }}</b></li>
+				<li v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</li>
+			</ul>
+			<div v-for="(n, i) in card.notes" :key="'n' + i" class="jv-pc-note">{{ n }}</div>
+		</template>
+
+		<details v-if="details" class="jv-pc-details">
+			<summary>Details</summary>
+			<pre>{{ details }}</pre>
+		</details>
+	</div>
+</template>
+
+<style scoped>
+.jv-pc { font-size: 13px; color: var(--ink7); line-height: 1.5; }
+.jv-pc-head { font-weight: 600; color: var(--ink9); margin-bottom: 6px; overflow-wrap: anywhere; }
+.jv-pc-verb { font-weight: 500; color: var(--ink9); overflow-wrap: anywhere; }
+.jv-pc-kv { display: flex; justify-content: space-between; gap: 12px; padding: 4px 0; border-bottom: 1px solid var(--border); }
+.jv-pc-kv:last-child { border-bottom: 0; }
+.jv-pc-kv span { color: var(--ink5); }
+.jv-pc-kv b { font-weight: 500; color: var(--ink8); text-align: right; overflow-wrap: anywhere; }
+.jv-pc-diff { display: grid; grid-template-columns: 1fr auto auto auto; gap: 8px; align-items: baseline; padding: 3px 0; }
+.jv-pc-lbl { color: var(--ink5); }
+.jv-pc-from { color: var(--ink5); text-decoration: line-through; overflow-wrap: anywhere; }
+.jv-pc-arrow { color: var(--ink5); }
+.jv-pc-to { color: var(--green, var(--ink9)); font-weight: 500; overflow-wrap: anywhere; }
+.jv-pc-empty { color: var(--ink5); font-style: italic; }
+.jv-pc-list { margin: 5px 0 0; padding-left: 18px; }
+.jv-pc-list li { padding: 1px 0; overflow-wrap: anywhere; }
+.jv-pc-more { list-style: none; color: var(--ink5); }
+.jv-pc-note { margin-top: 6px; color: var(--ink5); font-size: 12.5px; }
+.jv-pc-body { margin: 8px 0 0; padding: 10px; border-radius: 8px; background: var(--card2); color: var(--ink7); font-size: 12.5px; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 220px; overflow-y: auto; }
+.jv-pc-details { margin-top: 10px; }
+.jv-pc-details summary { cursor: pointer; color: var(--ink5); font-size: 12px; }
+.jv-pc-details pre { margin: 6px 0 0; padding: 10px; border-radius: 8px; background: var(--card2); font-size: 12px; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 240px; overflow-y: auto; }
+</style>

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -417,6 +417,7 @@ function onEvent(p) {
 				preview: p.preview ?? null,
 				conversation: conv,
 				run_id: p.run_id,
+				expires_at: p.expires_at ?? null,
 			})
 			scrollToBottom()
 			break


### PR DESCRIPTION
## What this does

Completes the confirmation-card rendering on the **PWA** (mobile). Its approval sheet (`DecisionSheet.vue`) dumped the parked write's dry-run preview as **raw JSON** — the same thing the desktop did before #308. Now it renders the server-built `preview.card` (Phase 3a #307): a field list for creates, a **from→to diff** for updates, a plain line for submit/cancel/delete/amend, to/subject/body for emails, method+args for run_method, bullets for batch creates — with the raw JSON behind a **Details** expander.

- **New `pwa/src/components/PendingCard.vue`**, PWA-styled, values rendered as **escaped text**.
- **No logic duplication** — `verbSentence` / `pendingCardOf` / `pendingExpiry` are imported from `@shared/lib/actionSummary.js` (the desktop's already-tested helpers; `@shared` → `frontend/src`).
- **F15:** `expires_at` carried through the live event (resync already gets it); an expired card shows an inline "expired — tell Jarvis again" note + disables Approve, and the failure message tells a real TTL lapse apart from "handled elsewhere".
- **F10** (Approve spinner) already existed.
- Falls back to today's `previewHtml` for older tokens / uncovered shapes.

## Verification

- `cd app && npm run build-pwa` — **green**.
- Shared `node --test frontend/src/lib/actionSummary.test.js` — **14/14** (same helpers).
- Mirrors the Fable-reviewed desktop rendering (#308) against the identical backend card contract.

## ⚠️ Needs a UI smoke

No automated coverage of the sheet (no live tenant). Smoke on a phone/PWA: open a parked update (the diff), a delete/submit (the verb line), a send_email (to/subject/body), the Details expander, and an aged-out card (the expired state + disabled Approve).

Part of the approval-mechanism remediation (Phase 3c). With this + #308, both clients render the card. Follows merged #307 (backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
