### PR TITLE
feat(confirm-gate): graceful confirm-failure + stop_run token sweep (approval review Phase 2B)

### DIFF
--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -361,10 +361,25 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 	exec_user = record.get("exec_user") or record.get("owner") or frappe.session.user
 	# impersonate is session-safe: a bare frappe.set_user here would gut the
 	# browser's cookie session (sid + data) and log the confirming user out.
-	with impersonate(exec_user):
-		# Same envelope + audit as an inline write - dispatch_confirmed bypasses
-		# the gate so the stored call actually executes instead of parking again.
-		result = api.dispatch_confirmed(record["tool"], record["args"])
+	try:
+		with impersonate(exec_user):
+			# Same envelope + audit as an inline write - dispatch_confirmed bypasses
+			# the gate so the stored call actually executes instead of parking again.
+			result = api.dispatch_confirmed(record["tool"], record["args"])
+	except Exception:
+		# F5: an UNEXPECTED (untranslated) exception from the confirmed write would
+		# otherwise 500 with the token ALREADY consumed (GETDEL above) - no receipt,
+		# no continuation, the agent stuck at "awaiting confirmation" and the user
+		# unable to retry. _dispatch_and_wrap re-raises such exceptions with its
+		# savepoint still open, so roll back the partial write, log it, and fall
+		# through to a graceful failure envelope: the "failed" receipt + continuation
+		# below still fire, so the user sees it and the agent learns.
+		frappe.db.rollback()
+		frappe.log_error(title="confirm_tool dispatch crashed",
+						 message=frappe.get_traceback())
+		result = api._error(
+			"InternalError",
+			"the confirmed action failed unexpectedly and was not saved")
 
 	# Leave a transcript receipt (#7) so a confirmed delete/submit/email shows on
 	# reload, matching the inline model-write path's tool card. Best-effort: the

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1391,6 +1391,14 @@ def stop_run(conversation: str, run_id: str | None = None) -> dict:
 	abort RPC) - the UI stop stands alone there."""
 	require_jarvis_access()
 	conv = _get_owned_conversation(conversation)
+	# F6: a stopped run's parked cards must not linger or resurface on resync.
+	# Sweep this owner's live confirmation tokens for the conversation (best-effort).
+	try:
+		from jarvis.chat import pending_confirm
+
+		pending_confirm.clear_for_conversation(frappe.session.user, conversation, run_id)
+	except Exception:
+		frappe.log_error(title="stop_run token sweep", message=frappe.get_traceback())
 	from jarvis.chat import selfhost
 
 	if selfhost.is_self_hosted():

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -230,3 +230,28 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 		except Exception:
 			pass
 	return out
+
+
+def clear_for_conversation(owner: str, conversation: str, run_id: str | None = None) -> int:
+	"""Delete all of ``owner``'s live tokens STRICTLY bound to ``conversation``
+	and return the count cleared. Conversation-less tokens ("") are left alone -
+	they carry no conversation binding and may belong to another view. Used when a
+	run is stopped so its parked confirmation cards cannot linger or resurface on
+	resync (F6). Best-effort: a token consumed concurrently just isn't counted.
+
+	``run_id``: when given AND the token itself carries a run_id (self-host), only
+	that run's cards are swept - so stopping one run does not consume a sibling
+	run's still-valid card. In managed mode the token's run_id is always "" (it is
+	never tracked there), so the filter no-ops and the whole conversation is swept,
+	which is the intended behaviour for the single-run-per-conversation case."""
+	if not owner or not conversation:
+		return 0
+	n = 0
+	for rec in list_for_owner(owner, conversation=conversation):
+		if rec.get("conversation") != conversation:
+			continue  # list_for_owner surfaces conv-less tokens under any filter
+		if run_id and rec.get("run_id") and rec.get("run_id") != run_id:
+			continue  # a sibling run's card (self-host only; managed run_id is "")
+		if consume(rec["token"], owner=owner, conversation=conversation) is not None:
+			n += 1
+	return n

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -971,3 +971,31 @@ class TestConfirmCardWiring(FrappeTestCase):
 		items = list_pending_confirmations(conversation="cardwire-conv")["data"]["pending"]
 		self.assertTrue(items)
 		self.assertIsInstance(items[0]["expires_at"], int)
+
+
+class TestConfirmGracefulFailure(FrappeTestCase):
+	"""F5: an UNEXPECTED exception during a confirmed write must fail gracefully -
+	the endpoint returns {ok:false} instead of a 500 with the token burned and the
+	agent stuck at 'awaiting confirmation', and it still fires the failed
+	continuation so the agent learns the outcome."""
+
+	def tearDown(self):
+		for name in frappe.get_all(CONV, filters={"title": "confirm-gate test"}, pluck="name"):
+			frappe.delete_doc(CONV, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_unexpected_dispatch_exception_returns_graceful_error(self):
+		owner = frappe.session.user
+		conv = _make_conv(owner)
+		token = pending_confirm.mint(
+			conversation=conv, owner=owner, exec_user=owner, tool="delete_doc",
+			args={"doctype": "ToDo", "name": "no-such"}, run_id="")
+		# An UNTRANSLATED exception from the write (dispatch raises RuntimeError).
+		with patch("jarvis.api.dispatch", side_effect=RuntimeError("boom")), \
+				patch("jarvis.chat.api._dispatch_turn") as disp:
+			res = confirm_tool(token, conversation=conv)
+		# Graceful envelope, NOT a raised 500.
+		self.assertFalse(res["ok"])
+		self.assertIn("error", res)
+		# The agent still gets a (failed) continuation, so it isn't left hanging.
+		self.assertEqual(disp.call_count, 1)

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -167,6 +167,40 @@ class TestListForOwner(FrappeTestCase):
 	def test_empty_for_unknown_owner(self):
 		self.assertEqual(pending_confirm.list_for_owner("nobody@example.invalid"), [])
 
+	def test_clear_for_conversation_removes_only_that_conversation(self):
+		"""F6: clearing a conversation's tokens (on stop_run) deletes its own live
+		tokens and leaves other conversations - and conversation-less tokens - alone."""
+		t_x1 = self._mint(self._A, "conv-x", "cfc-1")
+		t_x2 = self._mint(self._A, "conv-x", "cfc-2")
+		t_y = self._mint(self._A, "conv-y", "cfc-3")
+		t_cl = pending_confirm.mint(
+			conversation="", owner=self._A, tool="delete_doc",
+			args={"doctype": "ToDo", "name": "z"}, run_id="")
+		n = pending_confirm.clear_for_conversation(self._A, "conv-x")
+		self.assertEqual(n, 2)
+		self.assertIsNone(pending_confirm.peek(t_x1))
+		self.assertIsNone(pending_confirm.peek(t_x2))
+		self.assertIsNotNone(pending_confirm.peek(t_y))   # other conversation kept
+		self.assertIsNotNone(pending_confirm.peek(t_cl))  # conv-less kept
+
+	def test_clear_for_conversation_run_id_scoping(self):
+		"""F6: with a run_id, a self-host token (which carries a run_id) is swept
+		only when it matches; a managed token (run_id "") is always swept."""
+		t_r1 = pending_confirm.mint(
+			conversation="conv-z", owner=self._A, tool="delete_doc",
+			args={"doctype": "ToDo", "name": "a"}, run_id="r1")
+		t_r2 = pending_confirm.mint(
+			conversation="conv-z", owner=self._A, tool="delete_doc",
+			args={"doctype": "ToDo", "name": "b"}, run_id="r2")
+		t_managed = pending_confirm.mint(
+			conversation="conv-z", owner=self._A, tool="delete_doc",
+			args={"doctype": "ToDo", "name": "c"}, run_id="")
+		n = pending_confirm.clear_for_conversation(self._A, "conv-z", run_id="r1")
+		self.assertEqual(n, 2)  # the r1 card + the run_id-less (managed) card
+		self.assertIsNone(pending_confirm.peek(t_r1))
+		self.assertIsNone(pending_confirm.peek(t_managed))
+		self.assertIsNotNone(pending_confirm.peek(t_r2))  # sibling run kept
+
 
 class TestPeek(FrappeTestCase):
 	def test_unknown_token_is_none(self):


### PR DESCRIPTION
## What this does

The final lifecycle-hardening phase for the confirmation gate — two fixes, both backend + tested.

**F5 — graceful confirm-failure.** A confirmed write runs through `dispatch_confirmed` → `_dispatch_and_wrap`, which re-raises an **unexpected (untranslated)** exception with its savepoint still open. That **500'd `confirm_tool` after the token was already consumed** — no receipt, no continuation, the agent stuck at "awaiting confirmation," the user unable to retry. Now `confirm_tool` catches it, **rolls back the partial write**, logs it, and falls through to a graceful `{ok:false}` envelope so the existing **failed-receipt + failed-continuation still fire** — the user sees a "failed" chip and the agent learns and stops instead of hanging. (The token stays single-use-burned; the failure receipt is the compensating record.)

**F6 — `stop_run` sweeps a conversation's tokens.** New `pending_confirm.clear_for_conversation(owner, conversation, run_id)` deletes the owner's live tokens strictly bound to the conversation (conv-less tokens left alone), called from `stop_run` so a **stopped run's parked card can't linger or resurface on resync**. It's `run_id`-scoped when the token carries one (self-host) so stopping one run can't consume a sibling run's still-valid card; in managed mode (token `run_id` is always `""`) it sweeps the conversation, matching the one-card-per-conversation model.

## Deferred (noted in the plan)

- **F7** invalidate-on-new-message — debatable UX (silently dropping a card the user might still confirm), and **F16 already serializes to one card per conversation**, reducing its value.
- **F8** mint-time `args_hash` dedup — largely covered by F16, and adds a per-park scan on the hot path.

## Verification

- `bench --site jarvis-test.localhost run-tests --app jarvis` — green: `test_pending_confirm` (27, incl. `clear_for_conversation` strict-conversation + conv-less-kept + run_id scoping), `test_confirm_gate` (42, incl. the unexpected-exception graceful path), no regressions across `test_actions_api`/`test_confirm_card`/`test_auto_apply`/`test_bulk_tools`.
- Fable-reviewed — **ship**: no transaction-corruption / session-corruption / lost-write path; F5 strictly improves the prior 500-and-burn behavior; F6 owner-scoped and best-effort.

Completes the approval-mechanism remediation (Phase 2B; follows merged Phases 1, 2A, 3a, 3b, 3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
