### PR TITLE
fix(learning): stop Apply Learned Skills from logging the caller out

### DIFF
--- a/jarvis/learning/compiler.py
+++ b/jarvis/learning/compiler.py
@@ -244,16 +244,18 @@ def _apply_learned_skills_locked() -> dict:
 	# this apply's own managed rows.
 	cutover = _is_learned_cutover()
 
-	original_user = frappe.session.user
 	prev_engine = frappe.flags.jarvis_pattern_engine
 	applied_domains: list[str] = []
 	deleted_domains: list[str] = []
 	skill_by_domain: dict[str, str] = {}
 	activated = 0
 	try:
-		# Own the managed rows as Administrator (normal users cannot reach them)
-		# and lift the JLP transition guard for the Approved -> Active flips.
-		frappe.set_user(MANAGED_OWNER)
+		# Lift the JLP transition guard for the Approved -> Active flips. Every
+		# managed-row write below runs under ignore_permissions and pins its own
+		# owner - deliberately NOT via frappe.set_user(). set_user() on a live web
+		# request rewrites session.sid and wipes session.data; persisting the
+		# request's session at request-end then logs the CALLER out the moment
+		# Apply returns (every follow-up call becomes Guest -> 403 wall).
 		frappe.flags.jarvis_pattern_engine = True
 
 		existing_managed = {
@@ -277,7 +279,6 @@ def _apply_learned_skills_locked() -> dict:
 		frappe.db.commit()
 	finally:
 		frappe.flags.jarvis_pattern_engine = prev_engine
-		frappe.set_user(original_user)
 
 	# Push through the DEDICATED learned chain (deduped jarvis_learned_skills_push
 	# job; Phase-2 namespace). The worker rebuilds the payload from the managed
@@ -442,8 +443,9 @@ def build_learned_push_payload() -> list[dict]:
 
 
 def _upsert_managed_skill(spec: dict) -> str:
-	"""Create or update one managed ``learned-<domain>`` row. Owner = the current
-	session user (Administrator during apply). Returns the row name."""
+	"""Create or update one managed ``learned-<domain>`` row. New rows are pinned to
+	owner=MANAGED_OWNER (Administrator) so normal users cannot reach them. Returns
+	the row name."""
 	sname = spec["skill_name"]
 	existing = frappe.db.get_value(
 		SKILL, {"managed_by_learning": 1, "skill_name": sname}, "name"
@@ -465,7 +467,13 @@ def _upsert_managed_skill(spec: dict) -> str:
 	# them. The engine flag is set here, so the scope guard admits the write.
 	doc.scope = "Org"
 	doc.set("allowed_roles", [{"role": r} for r in spec["allowed_roles"]])
-	doc.save(ignore_permissions=True) if existing else doc.insert(ignore_permissions=True)
+	if existing:
+		doc.save(ignore_permissions=True)
+	else:
+		doc.insert(ignore_permissions=True)
+		# insert() forces owner=session.user (document.py set_user_and_timestamp);
+		# pin managed rows to MANAGED_OWNER here instead of via a session switch.
+		frappe.db.set_value(SKILL, doc.name, "owner", MANAGED_OWNER, update_modified=False)
 	return doc.name
 
 


### PR DESCRIPTION
## Problem

Clicking **Apply Learned Skills** logs the user out. The apply endpoint returns 200 and the compile/push succeed, but the moment it returns, every follow-up call (the board's status polls — `get_learned_apply_status`, `list_learned_patterns_page`, `pending_learned_count`, `get_custom_skills_sync_status`) returns **403 Guest**. The review board fills with 403s and shows a "User None not found" toast.

## Root cause

`jarvis/learning/compiler.py::_apply_learned_skills_locked` elevates via `frappe.set_user(MANAGED_OWNER)` inside the live web request — to own the managed `learned-<domain>` skills as Administrator and lift the JLP transition guard — restoring the caller in a `finally`.

But `frappe.set_user()` is **not** a safe run-as on a web request. `frappe/__init__.py` shows it rewrites `session.sid` and wipes `session.data`:

```python
def set_user(username: str):
    local.session.user = username
    local.session.sid = username      # ← overwrites the session id
    ...
    local.session.data = _dict()      # ← wipes the session data
```

When the request's session is persisted at request-end, the caller's session is corrupted, so every subsequent request from that browser is Guest.

## Fix

The elevation was unnecessary:
- The managed-row writes (`_upsert_managed_skill`, `_finalize_patterns`) already use `ignore_permissions=True`.
- The `Approved → Active` transition guard is lifted by `frappe.flags.jarvis_pattern_engine`, not the user switch.

So this removes both `set_user()` calls and pins new managed skills to `owner=MANAGED_OWNER` explicitly (`insert()` forces `owner=session.user` via `set_user_and_timestamp`, so it's set via `db.set_value` after insert). No session is touched. `+16 / -8` in one file.

## Verification

- Reproduced live in the browser: Apply → `apply_learned_skills` 200 → then a burst of `403 Guest` (`get_custom_skills_sync_status`, `list_learned_patterns_page`, `pending_learned_count`, repeated `get_learned_apply_status`) + the "User None not found" toast. Traced to the `set_user`.
- After the fix, a real-session Apply followed by a call **after** it returns `200` — **5/5 across repeats** (before the fix it was `403`). The apply/compile/push still succeed and the `learned-*` skills materialize.