### PR TITLE
fix(account): Re-authorize crashes with 'trim is not a function' in AI models

### DIFF
--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -40,7 +40,7 @@
       <div v-if="status.connected_at" class="jv-dsub-kv"><span>Connected</span><b>{{ connectedAtLabel }}</b></div>
       <div class="jv-dsub-actions" style="margin-top:14px;">
         <button v-if="editable" class="jv-dsub-btn jv-dsub-btn-ghost" :disabled="busy" @click="doDisconnect">Disconnect</button>
-        <button v-if="editable" class="jv-dsub-btn jv-dsub-btn-primary" @click="startSignin">Re-authorize</button>
+        <button v-if="editable" class="jv-dsub-btn jv-dsub-btn-primary" @click="startSignin()">Re-authorize</button>
       </div>
       <div v-if="err" class="jv-dsub-err">{{ err }}</div>
     </div>


### PR DESCRIPTION
## Problem

Clicking **Re-authorize** on the direct chat-subscription card (Settings → AI models / Account) fails every time with:

```
(providerOverride || props.status.provider || pickProvider.value || '').trim is not a function
```

(minified: `(n || c.status.provider || m.value || '').trim is not a function`)

## Root cause

`DirectSubscriptionCard.vue` bound the bare method to the Re-authorize button:

```html
<button ... @click="startSignin">Re-authorize</button>
```

In Vue 3, binding a bare method to `@click` passes the **native `PointerEvent`** as the first argument. So `startSignin(providerOverride, modelOverride)` receives the event as `providerOverride`. The event object is truthy, so it short-circuits the `||` chain at:

```js
const p = (providerOverride || props.status.provider || pickProvider.value || "").trim()
```

and `.trim()` is called on a `PointerEvent` → `TypeError`. It's caught by the surrounding try/catch, so the flow just flashes an error and aborts — direct re-authorize is fully broken.

The fresh-connect sibling was always correct: `@click="startSignin(pickProvider, pickModel)"`.

## Fix

Call `startSignin()` explicitly with no args, matching the documented intent ("Re-authorize (no args) reuses the connected provider/model"):

```html
<button ... @click="startSignin()">Re-authorize</button>
```

## Verification

- SPA vite build transforms the full module graph including the edited component with no errors (the only build failure in my out-of-bench worktree is an unrelated `socket.js` bench-relative config path).
- One-line, behavior matches the existing working fresh-connect call site.