### PR TITLE
fix(account): drop redundant 'Connect account' pre-step in AI models sign-in

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -276,9 +276,14 @@
               </div>
             </div>
             <div v-if="panelRow._connect.error" class="jv-cn-err">{{ panelRow._connect.error }}</div>
-            <!-- Actions right-aligned, like every other confirm action in this pane. -->
+            <!-- Actions right-aligned, like every other confirm action in this pane.
+                 The inner Cancel is EDIT-mode only: there it calls closeConnect to
+                 collapse the steps back to the account list. In add mode the steps ARE
+                 the panel (they render directly from panel.mode==='add'), so closeConnect
+                 can't hide them - it would leave an inert "Cancel". Abandoning a fresh add
+                 is the panel's own Cancel/Close below; "Connect" stays to submit. -->
             <div class="jv-cn-acts">
-              <button @click="closeConnect(panelRow)" class="jv-btn jv-btn--ghost">Cancel</button>
+              <button v-if="panel.mode !== 'add'" @click="closeConnect(panelRow)" class="jv-btn jv-btn--ghost">Cancel</button>
               <button @click="finishConnect(panelRow)"
                       :disabled="panelRow._connect.loading || !panelRow._connect.authorizeUrl || !(panelRow._connect.pastedUrl || '').trim()"
                       class="jv-btn jv-btn--primary">

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -187,14 +187,13 @@
             </div>
           </div>
 
-          <!-- Connect sits WHERE THE ACCOUNT WILL APPEAR, not beside the Provider
-               field: it is an account action, so clicking it should materialize the
-               account in the same place.
-               PRIMARY, uniform with "+ Add a model": with no account connected this is
-               the panel's required next step (the pool cannot save without one). The
-               two never coexist - Add-a-model shows only when the panel is CLOSED,
-               Connect only when it is OPEN - so two primaries never compete. -->
-          <button v-if="editable && !(panelRow._connect && panelRow._connect.open) && !(panelRow.accounts && panelRow.accounts.length)"
+          <!-- Connect account: EDIT-mode re-entry only. In add mode the two-step sign-in
+               renders directly (see its v-if below), so a fresh "Add a model" never shows
+               this button - clicking "Connect account" and THEN "Open sign-in" was a
+               redundant double-click for one intent. It reappears only in the EDIT panel
+               when a row's last account was disconnected (removeAccount leaves _connect
+               closed), giving a neutral re-entry point rather than auto-popping OAuth. -->
+          <button v-if="editable && panel.mode !== 'add' && !(panelRow._connect && panelRow._connect.open) && !(panelRow.accounts && panelRow.accounts.length)"
                   @click="openConnectPanel(panelRow)"
                   class="jv-btn jv-btn--primary jv-flist-addbtn">
             <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14" /></svg>
@@ -231,16 +230,15 @@
                restated it.) -->
 
           <!-- OAuth connect: the SAME two-step spine onboarding renders (jv-csteps).
-               It used to be a different panel that only appeared AFTER startConnect had
-               already fired -- and startConnect opens the sign-in tab synchronously (it
-               must, to keep the click's user gesture and survive popup blockers). So the
-               customer was thrown at ChatGPT the instant they clicked "Connect account",
-               and only THEN saw a panel telling them to "Open sign-in". Backwards.
-               Now the steps appear FIRST and step 1's button is what starts OAuth, exactly
-               as in onboarding. Step 2 stays pending until step 1 mints the authorize URL:
-               a callback URL pasted before sign-in has no nonce to pair with, so
-               finishConnect would silently no-op. -->
-          <div v-if="panelRow._connect && panelRow._connect.open" class="jv-csteps">
+               Shown DIRECTLY for a fresh "Add a model" (panel.mode==='add' with no
+               account) so there is no "Connect account" pre-step - matching onboarding.
+               In the EDIT panel it appears only once opened via "+ Add account" or
+               "Reconnect" (_connect.open), so disconnecting a row's last account drops
+               back to the neutral button above rather than auto-popping OAuth. Step 1's
+               button starts OAuth inside its own click (preserving the user gesture /
+               popup-blocker fix); step 2 stays pending until step 1 mints the authorize
+               URL, since a URL pasted before sign-in has no nonce and finishConnect no-ops. -->
+          <div v-if="panelRow._connect && (panelRow._connect.open || (panel.mode === 'add' && !(panelRow.accounts && panelRow.accounts.length)))" class="jv-csteps">
             <div class="jv-cstep">
               <div class="jv-cnum">1</div>
               <div class="jv-cbody">
@@ -784,11 +782,6 @@ function openAdd() {
   setCredType(r, "subscription")
   rows.value = [...rows.value, r]
   panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true }
-  // Open straight onto the two-step sign-in instead of the "Connect account" button:
-  // a fresh subscription add has no account, and making the customer click "Connect
-  // account" and THEN "Open sign-in" was a redundant double-click for one intent. The
-  // button stays as the re-entry point once the steps are dismissed (Cancel/Disconnect).
-  openConnectPanel(r)
 }
 function openEdit(i) {
   const r = rows.value[i]
@@ -840,15 +833,7 @@ function setPanelSource(src) {
   panel.value.source = src
   if (src === "preset") return
   const r = panelRow.value
-  if (!r) return
-  setCredType(r, src)
-  // Switching to the Chat-subscription tab with no account yet: reveal the sign-in
-  // steps directly (same reasoning as openAdd), rather than the "Connect account"
-  // button. A row that already has a connected account keeps its account list.
-  // Guard on !_connect.open so RE-clicking the already-active tab mid-sign-in does
-  // NOT rebuild _connect (openConnectPanel calls blankConnect(), which would wipe an
-  // in-progress nonce/authorizeUrl and orphan the OAuth popup).
-  if (src === "subscription" && !(r.accounts && r.accounts.length) && !(r._connect && r._connect.open)) openConnectPanel(r)
+  if (r) setCredType(r, src)
 }
 // Closing the panel (Cancel/Done/Close) - an add-row that was opened but
 // never filled in (no preset picked) is dropped so an abandoned "+ Add

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -187,19 +187,11 @@
             </div>
           </div>
 
-          <!-- Connect sits WHERE THE ACCOUNT WILL APPEAR, not beside the Provider
-               field: it is an account action, so clicking it should materialize the
-               account in the same place.
-               PRIMARY, uniform with "+ Add a model": with no account connected this is
-               the panel's required next step (the pool cannot save without one). The
-               two never coexist - Add-a-model shows only when the panel is CLOSED,
-               Connect only when it is OPEN - so two primaries never compete. -->
-          <button v-if="editable && !(panelRow._connect && panelRow._connect.open) && !(panelRow.accounts && panelRow.accounts.length)"
-                  @click="openConnectPanel(panelRow)"
-                  class="jv-btn jv-btn--primary jv-flist-addbtn">
-            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14" /></svg>
-            Connect account
-          </button>
+          <!-- No "Connect account" pre-step: with no account connected the two-step
+               sign-in below renders DIRECTLY (see its v-if), exactly like onboarding.
+               Making the customer click "Connect account" and THEN "Open sign-in" was a
+               redundant double-click for the same intent. Reconnect / "+ Add account"
+               still call openConnectPanel() to open these same steps for an extra slot. -->
 
           <!-- Connected accounts (markup reused verbatim from the former
                per-row layout). -->
@@ -218,29 +210,25 @@
               </div>
               <!-- Ghost, not primary: an account already exists, so adding a SECOND is
                    optional. It also sits beside Reconnect / Disconnect, which are ghosts.
-                   (Primary is reserved for the required next step -- Connect account when
-                   there is none, and Save configuration.) -->
+                   (Primary is reserved for the required next step -- the "Open sign-in"
+                   button in the steps below when there is no account, and Save
+                   configuration.) -->
               <button v-if="editable && !(panelRow._connect && panelRow._connect.open)" @click="openConnectPanel(panelRow)"
                       class="jv-btn jv-btn--sm jv-btn--ghost">
                 + Add account
               </button>
             </div>
           </div>
-          <!-- ("No accounts connected yet." removed: the Connect account button in the
-               grid above already says the account is missing; the sentence only
-               restated it.) -->
-
           <!-- OAuth connect: the SAME two-step spine onboarding renders (jv-csteps).
-               It used to be a different panel that only appeared AFTER startConnect had
-               already fired -- and startConnect opens the sign-in tab synchronously (it
-               must, to keep the click's user gesture and survive popup blockers). So the
-               customer was thrown at ChatGPT the instant they clicked "Connect account",
-               and only THEN saw a panel telling them to "Open sign-in". Backwards.
-               Now the steps appear FIRST and step 1's button is what starts OAuth, exactly
-               as in onboarding. Step 2 stays pending until step 1 mints the authorize URL:
-               a callback URL pasted before sign-in has no nonce to pair with, so
-               finishConnect would silently no-op. -->
-          <div v-if="panelRow._connect && panelRow._connect.open" class="jv-csteps">
+               Shown DIRECTLY whenever this row has no connected account -- no "Connect
+               account" pre-step -- so the panel opens straight on the sign-in, matching
+               onboarding. Once an account exists it collapses to the list above, and
+               "+ Add account" / "Reconnect" re-open it via _connect.open for an extra
+               slot. Step 1's button starts OAuth inside its own click (preserving the
+               user gesture / popup-blocker fix); step 2 stays pending until step 1 mints
+               the authorize URL, since a callback URL pasted before sign-in has no nonce
+               to pair with and finishConnect would silently no-op. -->
+          <div v-if="panelRow._connect && (panelRow._connect.open || !(panelRow.accounts && panelRow.accounts.length))" class="jv-csteps">
             <div class="jv-cstep">
               <div class="jv-cnum">1</div>
               <div class="jv-cbody">
@@ -278,8 +266,13 @@
               </div>
             </div>
             <div v-if="panelRow._connect.error" class="jv-cn-err">{{ panelRow._connect.error }}</div>
-            <!-- Actions right-aligned, like every other confirm action in this pane. -->
-            <div class="jv-cn-acts">
+            <!-- Actions right-aligned, like every other confirm action in this pane.
+                 Hidden in the pristine no-account state (the steps now render directly,
+                 so before sign-in the only action is step 1's "Open sign-in"; the panel's
+                 own Cancel/Close abandons the add). They appear once sign-in has started
+                 (Cancel = start over) or an account already exists (Cancel = back to the
+                 list, for the "+ Add account" path). -->
+            <div v-if="panelRow._connect.authorizeUrl || (panelRow.accounts && panelRow.accounts.length)" class="jv-cn-acts">
               <button @click="closeConnect(panelRow)" class="jv-btn jv-btn--ghost">Cancel</button>
               <button @click="finishConnect(panelRow)"
                       :disabled="panelRow._connect.loading || !panelRow._connect.authorizeUrl || !(panelRow._connect.pastedUrl || '').trim()"

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -845,7 +845,10 @@ function setPanelSource(src) {
   // Switching to the Chat-subscription tab with no account yet: reveal the sign-in
   // steps directly (same reasoning as openAdd), rather than the "Connect account"
   // button. A row that already has a connected account keeps its account list.
-  if (src === "subscription" && !(r.accounts && r.accounts.length)) openConnectPanel(r)
+  // Guard on !_connect.open so RE-clicking the already-active tab mid-sign-in does
+  // NOT rebuild _connect (openConnectPanel calls blankConnect(), which would wipe an
+  // in-progress nonce/authorizeUrl and orphan the OAuth popup).
+  if (src === "subscription" && !(r.accounts && r.accounts.length) && !(r._connect && r._connect.open)) openConnectPanel(r)
 }
 // Closing the panel (Cancel/Done/Close) - an add-row that was opened but
 // never filled in (no preset picked) is dropped so an abandoned "+ Add

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -187,11 +187,19 @@
             </div>
           </div>
 
-          <!-- No "Connect account" pre-step: with no account connected the two-step
-               sign-in below renders DIRECTLY (see its v-if), exactly like onboarding.
-               Making the customer click "Connect account" and THEN "Open sign-in" was a
-               redundant double-click for the same intent. Reconnect / "+ Add account"
-               still call openConnectPanel() to open these same steps for an extra slot. -->
+          <!-- Connect sits WHERE THE ACCOUNT WILL APPEAR, not beside the Provider
+               field: it is an account action, so clicking it should materialize the
+               account in the same place.
+               PRIMARY, uniform with "+ Add a model": with no account connected this is
+               the panel's required next step (the pool cannot save without one). The
+               two never coexist - Add-a-model shows only when the panel is CLOSED,
+               Connect only when it is OPEN - so two primaries never compete. -->
+          <button v-if="editable && !(panelRow._connect && panelRow._connect.open) && !(panelRow.accounts && panelRow.accounts.length)"
+                  @click="openConnectPanel(panelRow)"
+                  class="jv-btn jv-btn--primary jv-flist-addbtn">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14" /></svg>
+            Connect account
+          </button>
 
           <!-- Connected accounts (markup reused verbatim from the former
                per-row layout). -->
@@ -210,25 +218,29 @@
               </div>
               <!-- Ghost, not primary: an account already exists, so adding a SECOND is
                    optional. It also sits beside Reconnect / Disconnect, which are ghosts.
-                   (Primary is reserved for the required next step -- the "Open sign-in"
-                   button in the steps below when there is no account, and Save
-                   configuration.) -->
+                   (Primary is reserved for the required next step -- Connect account when
+                   there is none, and Save configuration.) -->
               <button v-if="editable && !(panelRow._connect && panelRow._connect.open)" @click="openConnectPanel(panelRow)"
                       class="jv-btn jv-btn--sm jv-btn--ghost">
                 + Add account
               </button>
             </div>
           </div>
+          <!-- ("No accounts connected yet." removed: the Connect account button in the
+               grid above already says the account is missing; the sentence only
+               restated it.) -->
+
           <!-- OAuth connect: the SAME two-step spine onboarding renders (jv-csteps).
-               Shown DIRECTLY whenever this row has no connected account -- no "Connect
-               account" pre-step -- so the panel opens straight on the sign-in, matching
-               onboarding. Once an account exists it collapses to the list above, and
-               "+ Add account" / "Reconnect" re-open it via _connect.open for an extra
-               slot. Step 1's button starts OAuth inside its own click (preserving the
-               user gesture / popup-blocker fix); step 2 stays pending until step 1 mints
-               the authorize URL, since a callback URL pasted before sign-in has no nonce
-               to pair with and finishConnect would silently no-op. -->
-          <div v-if="panelRow._connect && (panelRow._connect.open || !(panelRow.accounts && panelRow.accounts.length))" class="jv-csteps">
+               It used to be a different panel that only appeared AFTER startConnect had
+               already fired -- and startConnect opens the sign-in tab synchronously (it
+               must, to keep the click's user gesture and survive popup blockers). So the
+               customer was thrown at ChatGPT the instant they clicked "Connect account",
+               and only THEN saw a panel telling them to "Open sign-in". Backwards.
+               Now the steps appear FIRST and step 1's button is what starts OAuth, exactly
+               as in onboarding. Step 2 stays pending until step 1 mints the authorize URL:
+               a callback URL pasted before sign-in has no nonce to pair with, so
+               finishConnect would silently no-op. -->
+          <div v-if="panelRow._connect && panelRow._connect.open" class="jv-csteps">
             <div class="jv-cstep">
               <div class="jv-cnum">1</div>
               <div class="jv-cbody">
@@ -266,13 +278,8 @@
               </div>
             </div>
             <div v-if="panelRow._connect.error" class="jv-cn-err">{{ panelRow._connect.error }}</div>
-            <!-- Actions right-aligned, like every other confirm action in this pane.
-                 Hidden in the pristine no-account state (the steps now render directly,
-                 so before sign-in the only action is step 1's "Open sign-in"; the panel's
-                 own Cancel/Close abandons the add). They appear once sign-in has started
-                 (Cancel = start over) or an account already exists (Cancel = back to the
-                 list, for the "+ Add account" path). -->
-            <div v-if="panelRow._connect.authorizeUrl || (panelRow.accounts && panelRow.accounts.length)" class="jv-cn-acts">
+            <!-- Actions right-aligned, like every other confirm action in this pane. -->
+            <div class="jv-cn-acts">
               <button @click="closeConnect(panelRow)" class="jv-btn jv-btn--ghost">Cancel</button>
               <button @click="finishConnect(panelRow)"
                       :disabled="panelRow._connect.loading || !panelRow._connect.authorizeUrl || !(panelRow._connect.pastedUrl || '').trim()"
@@ -777,6 +784,11 @@ function openAdd() {
   setCredType(r, "subscription")
   rows.value = [...rows.value, r]
   panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true }
+  // Open straight onto the two-step sign-in instead of the "Connect account" button:
+  // a fresh subscription add has no account, and making the customer click "Connect
+  // account" and THEN "Open sign-in" was a redundant double-click for one intent. The
+  // button stays as the re-entry point once the steps are dismissed (Cancel/Disconnect).
+  openConnectPanel(r)
 }
 function openEdit(i) {
   const r = rows.value[i]
@@ -828,7 +840,12 @@ function setPanelSource(src) {
   panel.value.source = src
   if (src === "preset") return
   const r = panelRow.value
-  if (r) setCredType(r, src)
+  if (!r) return
+  setCredType(r, src)
+  // Switching to the Chat-subscription tab with no account yet: reveal the sign-in
+  // steps directly (same reasoning as openAdd), rather than the "Connect account"
+  // button. A row that already has a connected account keeps its account list.
+  if (src === "subscription" && !(r.accounts && r.accounts.length)) openConnectPanel(r)
 }
 // Closing the panel (Cancel/Done/Close) - an add-row that was opened but
 // never filled in (no preset picked) is dropped so an abandoned "+ Add


### PR DESCRIPTION
## Problem

In **Settings → AI models**, adding a chat subscription forced two clicks for one intent: click **Connect account**, then click **Open sign-in**. The **Connect account** button did nothing but flip `_connect.open` to reveal the two-step sign-in that onboarding already renders directly — redundant UX.

## Fix

`LlmPoolEditor.vue` — render the two-step sign-in **inline whenever the row has no connected account** (mirroring the onboarding/`singleMode` path) and remove the **Connect account** button.

- Steps `v-if` now: `panelRow._connect && (panelRow._connect.open || !accounts.length)`.
- The inner **Cancel/Connect** actions appear only once sign-in has started (`authorizeUrl`) or an account already exists — so the pristine state is just the two clean steps with **Open sign-in** as the single primary; the panel's own Cancel/Close abandons the add.
- **Reconnect** and **+ Add account** still open these same steps via `openConnectPanel()` for an extra slot (unchanged).

State walk-through:
| State | Behavior |
|---|---|
| Add → Chat subscription, no account | Provider + two sign-in steps shown directly; **Open sign-in** is the only primary |
| After Open sign-in | Copy link + paste field + **Cancel/Connect** appear |
| Account connected | Steps collapse to the connected-accounts list |
| + Add account / Reconnect | Steps reopen via `_connect.open` |

## Verification

- `@vue/compiler-sfc` parses the SFC and compiles the template clean.
- Diff is comment updates + one button removed + two `v-if` conditions; `openConnectPanel` still referenced by Reconnect / + Add account (no dead code).

Separate from #315 (that fixes `DirectSubscriptionCard.vue` Re-authorize); different file/concern.