### PR TITLE
feat(ui): reusable confirmation dialog + confirm on model removal

### DIFF
--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -80,6 +80,9 @@ import { ref, computed, onBeforeUnmount } from "vue"
 import * as api from "@/api"
 import { errMessage as _err } from "@/lib/errors"
 import { exactDate } from "@/utils/datetime"
+import { useConfirm } from "@/composables/useConfirm"
+
+const { confirm } = useConfirm()
 
 const props = defineProps({
   // Shape from getDirectSubscriptionStatus(): { connected, provider, model,
@@ -200,7 +203,12 @@ async function submitPasted() {
 }
 
 async function doDisconnect() {
-  if (!window.confirm("Disconnect the chat subscription? Jarvis chat will stop working until you reconnect.")) return
+  if (!(await confirm({
+    title: "Disconnect chat subscription?",
+    message: "Jarvis chat will stop working until you reconnect.",
+    confirmLabel: "Disconnect",
+    danger: true,
+  }))) return
   err.value = ""
   busy.value = true
   try {

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -957,7 +957,8 @@ function onUpstreamChange(m) {
 function move(i, d) { rows.value = reorder(rows.value, i, i + d) }
 async function remove(i) {
   const r = rows.value[i]
-  const label = r ? rowModelLabel(r) : ""
+  if (!r) return
+  const label = rowModelLabel(r)
   if (!(await confirm({
     title: "Remove this model?",
     message: label
@@ -966,7 +967,9 @@ async function remove(i) {
     confirmLabel: "Remove",
     danger: true,
   }))) return
-  rows.value = rows.value.filter((_, j) => j !== i)
+  // Filter by the row's stable handle, not the captured index: confirm() awaits, so
+  // an index could go stale if rows.value is re-seeded meanwhile.
+  rows.value = rows.value.filter((x) => x._uid !== r._uid)
 }
 function removeAccount(m, idx) { m.accounts = (m.accounts || []).filter((_, j) => j !== idx) }
 function addModel() { rows.value = [...rows.value, { ...newRow(), order: rows.value.length }] }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -520,8 +520,11 @@ import {
   PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig, defaultSubscriptionModel,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
+import { useConfirm } from "@/composables/useConfirm"
 import JvCombo from "@/components/JvCombo.vue"
 import DirectSubscriptionCard from "@/components/DirectSubscriptionCard.vue"
+
+const { confirm } = useConfirm()
 
 const props = defineProps({
   editable: { type: Boolean, default: true },
@@ -868,7 +871,12 @@ function onDirectCardChanged() {
   emit("direct-changed")
 }
 async function removeDirect() {
-  if (!window.confirm("Disconnect the chat subscription? Jarvis chat will stop working until you reconnect.")) return
+  if (!(await confirm({
+    title: "Disconnect chat subscription?",
+    message: "Jarvis chat will stop working until you reconnect.",
+    confirmLabel: "Disconnect",
+    danger: true,
+  }))) return
   try {
     const res = await api.disconnectSubscription()
     if (!res || res.ok === false) { err.value = (res && res.error && res.error.message) || "Disconnect failed."; return }
@@ -947,7 +955,19 @@ function onUpstreamChange(m) {
   m._connect = blankConnect()
 }
 function move(i, d) { rows.value = reorder(rows.value, i, i + d) }
-function remove(i) { rows.value = rows.value.filter((_, j) => j !== i) }
+async function remove(i) {
+  const r = rows.value[i]
+  const label = r ? rowModelLabel(r) : ""
+  if (!(await confirm({
+    title: "Remove this model?",
+    message: label
+      ? `"${label}" will be removed from the failover list. Save configuration to apply.`
+      : "This model will be removed from the failover list. Save configuration to apply.",
+    confirmLabel: "Remove",
+    danger: true,
+  }))) return
+  rows.value = rows.value.filter((_, j) => j !== i)
+}
 function removeAccount(m, idx) { m.accounts = (m.accounts || []).filter((_, j) => j !== idx) }
 function addModel() { rows.value = [...rows.value, { ...newRow(), order: rows.value.length }] }
 

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -979,7 +979,10 @@ function selectPreset(entry) {
   rows.value = seedFromPreset(entry)
 }
 function seedFromPreset(entry) {
+  // Every row needs a unique _uid: remove() deletes by _uid, so preset rows that
+  // shared an undefined _uid would all vanish on removing any one of them.
   return presetToModels(entry, keysByVendor.value).map((m) => ({
+    _uid: nextUid(),
     provider: providerLabel(m.provider), model: m.model, apiKey: m.api_key || "", baseUrl: "",
     hasKey: false, credentialType: "api_key", rotation: "sticky", upstream: "openai",
     accounts: [], _connect: blankConnect(), order: m.order,

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -35,6 +35,7 @@
 			<SettingsDialog />
 			<JarvisCommandPalette />
 			<NotifyToaster />
+			<ConfirmDialog />
 		</div>
 	</FrappeUIProvider>
 </template>
@@ -57,6 +58,7 @@ import { needsOnboarding } from "@/onboarding/readiness.js"
 import Sidebar from "./Sidebar.vue"
 import JarvisCommandPalette from "./JarvisCommandPalette.vue"
 import SettingsDialog from "./SettingsDialog.vue"
+import ConfirmDialog from "./ConfirmDialog.vue"
 import OnboardingGate from "./OnboardingGate.vue"
 
 const route = useRoute()

--- a/frontend/src/components/shell/ConfirmDialog.vue
+++ b/frontend/src/components/shell/ConfirmDialog.vue
@@ -59,4 +59,11 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKey, true))
 .jv-confirm-fade-enter-active, .jv-confirm-fade-leave-active { transition: opacity .16s ease; }
 .jv-confirm-fade-enter-from, .jv-confirm-fade-leave-to { opacity: 0; }
 @keyframes jv-confirm-popin { from { transform: scale(0.98); opacity: 0.5; } to { transform: scale(1); opacity: 1; } }
+
+/* Respect OS "reduce motion" — the inline dialog this replaced was covered by
+   ChatView's reduced-motion block; keep that accessibility guarantee here. */
+@media (prefers-reduced-motion: reduce) {
+  .jv-cdialog { animation: none; }
+  .jv-confirm-fade-enter-active, .jv-confirm-fade-leave-active { transition: none; }
+}
 </style>

--- a/frontend/src/components/shell/ConfirmDialog.vue
+++ b/frontend/src/components/shell/ConfirmDialog.vue
@@ -1,0 +1,62 @@
+<template>
+  <!-- App-wide confirmation modal. Mounted ONCE in AppShell; driven entirely by
+       the shared useConfirm() state. Renders above every other surface (settings
+       dialog included, z-index 60) so a Remove/Delete inside a modal is still
+       confirmable. See composables/useConfirm.js for the promise-based API. -->
+  <transition name="jv-confirm-fade">
+    <div v-if="state" class="jv-confirm-overlay" @click.self="settleConfirm(false)">
+      <div class="jv-cdialog" role="alertdialog" aria-modal="true" aria-labelledby="jv-confirm-title">
+        <div id="jv-confirm-title" class="jv-cdialog-title">{{ state.title }}</div>
+        <div v-if="state.message" class="jv-cdialog-msg">{{ state.message }}</div>
+        <div class="jv-cdialog-foot">
+          <button class="jv-btn jv-btn--ghost" @click="settleConfirm(false)">{{ state.cancelLabel }}</button>
+          <button class="jv-btn" :class="state.danger ? 'jv-btn--danger' : 'jv-btn--primary'"
+                  @click="settleConfirm(true)">{{ state.confirmLabel }}</button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { onMounted, onBeforeUnmount } from "vue"
+import { confirmState as state, settleConfirm } from "@/composables/useConfirm"
+
+// Escape cancels. Capture phase + stopPropagation so a global Escape handler on
+// an underlying view (e.g. ChatView closing settings) does NOT also fire when the
+// user is only dismissing this dialog.
+function onKey(e) {
+  if (e.key === "Escape" && state.value) {
+    e.preventDefault()
+    e.stopPropagation()
+    settleConfirm(false)
+  }
+}
+onMounted(() => window.addEventListener("keydown", onKey, true))
+onBeforeUnmount(() => window.removeEventListener("keydown", onKey, true))
+</script>
+
+<style scoped>
+/* Copied from ChatView's former inline confirm dialog so the visual is identical;
+   own overlay + transition names keep it decoupled from ChatView's jv-skills-overlay
+   (still used by the skills modal). Fixed + high z-index to clear the settings modal. */
+.jv-confirm-overlay {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(15, 15, 22, 0.34);
+  display: flex; align-items: center; justify-content: center; padding: 24px;
+}
+:global(.jv-dark) .jv-confirm-overlay { background: rgba(0, 0, 0, 0.55); }
+
+.jv-cdialog {
+  width: 400px; max-width: 100%; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 14px; padding: 20px;
+  box-shadow: 0 24px 70px rgba(20, 20, 30, .28); animation: jv-confirm-popin .16s ease;
+}
+.jv-cdialog-title { font-size: 16px; font-weight: 650; color: var(--text); }
+.jv-cdialog-msg { margin-top: 8px; font-size: 13.5px; line-height: 1.5; color: var(--text-2); }
+.jv-cdialog-foot { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
+
+.jv-confirm-fade-enter-active, .jv-confirm-fade-leave-active { transition: opacity .16s ease; }
+.jv-confirm-fade-enter-from, .jv-confirm-fade-leave-to { opacity: 0; }
+@keyframes jv-confirm-popin { from { transform: scale(0.98); opacity: 0.5; } to { transform: scale(1); opacity: 1; } }
+</style>

--- a/frontend/src/components/shell/ConfirmDialog.vue
+++ b/frontend/src/components/shell/ConfirmDialog.vue
@@ -1,10 +1,11 @@
 <template>
   <!-- App-wide confirmation modal. Mounted ONCE in AppShell; driven entirely by
-       the shared useConfirm() state. Renders above every other surface (settings
-       dialog included, z-index 60) so a Remove/Delete inside a modal is still
-       confirmable. See composables/useConfirm.js for the promise-based API. -->
+       the shared useConfirm() state. Its own z-index is 200 so it clears the
+       settings overlay (z-index 60) — a Remove/Delete inside that modal is still
+       confirmable. Applies paletteVars + jv-dark on its root (jv- vars aren't
+       global). See composables/useConfirm.js for the promise-based API. -->
   <transition name="jv-confirm-fade">
-    <div v-if="state" class="jv-confirm-overlay" @click.self="settleConfirm(false)">
+    <div v-if="state" class="jv-confirm-overlay jv-root" :class="{ 'jv-dark': dark }" :style="paletteVars" @click.self="settleConfirm(false)">
       <div class="jv-cdialog" role="alertdialog" aria-modal="true" aria-labelledby="jv-confirm-title">
         <div id="jv-confirm-title" class="jv-cdialog-title">{{ state.title }}</div>
         <div v-if="state.message" class="jv-cdialog-msg">{{ state.message }}</div>
@@ -21,6 +22,13 @@
 <script setup>
 import { onMounted, onBeforeUnmount } from "vue"
 import { confirmState as state, settleConfirm } from "@/composables/useConfirm"
+import { useJarvisTheme } from "@/theme"
+
+// The jv- palette (--surface, --text, --red, …) is NOT global :root — every jv-
+// surface applies it to its own root via paletteVars + a jv-dark class (see
+// SettingsDialog). This dialog is a shell sibling, so it must do the same or its
+// var(--…) styling and dark backdrop resolve to nothing.
+const { effectiveDark: dark, paletteVars } = useJarvisTheme()
 
 // Escape cancels. Capture phase + stopPropagation so a global Escape handler on
 // an underlying view (e.g. ChatView closing settings) does NOT also fire when the
@@ -45,7 +53,9 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKey, true))
   background: rgba(15, 15, 22, 0.34);
   display: flex; align-items: center; justify-content: center; padding: 24px;
 }
-:global(.jv-dark) .jv-confirm-overlay { background: rgba(0, 0, 0, 0.55); }
+/* jv-dark is applied to the overlay itself (not an ancestor), matching the way
+   paletteVars is scoped to this root. */
+.jv-confirm-overlay.jv-dark { background: rgba(0, 0, 0, 0.55); }
 
 .jv-cdialog {
   width: 400px; max-width: 100%; background: var(--surface);

--- a/frontend/src/composables/useConfirm.js
+++ b/frontend/src/composables/useConfirm.js
@@ -20,9 +20,11 @@ export const confirmState = ref(null) // { title, message, confirmLabel, cancelL
 let _resolve = null
 
 export function confirm(opts = {}) {
-  // Only one dialog can be open at a time. If a second confirm() arrives while one
-  // is live, resolve the previous as cancelled so its awaiter never hangs.
-  if (_resolve) { const prev = _resolve; _resolve = null; prev(false) }
+  // One dialog at a time. If one is already open, DON'T clobber what the user is
+  // looking at — the extra request resolves false (treated as not confirmed) and
+  // the visible dialog keeps its own awaiter. (Two concurrent confirms only happen
+  // from programmatic paths; a modal blocks the user from triggering a second.)
+  if (_resolve) return Promise.resolve(false)
   return new Promise((resolve) => {
     _resolve = resolve
     confirmState.value = {

--- a/frontend/src/composables/useConfirm.js
+++ b/frontend/src/composables/useConfirm.js
@@ -1,0 +1,51 @@
+import { ref } from "vue"
+
+// App-wide confirmation dialog — a promise-based, drop-in replacement for the
+// native window.confirm(). A SINGLE <ConfirmDialog> mounted in the app shell
+// (components/shell/ConfirmDialog.vue) renders from this shared state, so any
+// component can:
+//
+//   import { useConfirm } from "@/composables/useConfirm"
+//   const { confirm } = useConfirm()
+//   if (await confirm({ title: "Remove model?", message: "…", danger: true,
+//                       confirmLabel: "Remove" })) { …destructive action… }
+//
+// confirm() resolves true when the user confirms and false on Cancel / backdrop
+// click / Escape. This was extracted from ChatView's former inline confirmDialog
+// so there is one implementation, not several.
+
+// The live request, or null when no dialog is open. The mounted ConfirmDialog is
+// the only reader; call sites never touch it directly.
+export const confirmState = ref(null) // { title, message, confirmLabel, cancelLabel, danger }
+let _resolve = null
+
+export function confirm(opts = {}) {
+  // Only one dialog can be open at a time. If a second confirm() arrives while one
+  // is live, resolve the previous as cancelled so its awaiter never hangs.
+  if (_resolve) { const prev = _resolve; _resolve = null; prev(false) }
+  return new Promise((resolve) => {
+    _resolve = resolve
+    confirmState.value = {
+      title: opts.title || "Are you sure?",
+      message: opts.message || "",
+      confirmLabel: opts.confirmLabel || "Confirm",
+      cancelLabel: opts.cancelLabel || "Cancel",
+      // General-purpose: neutral (primary) by default. Destructive call sites opt
+      // in with danger:true to get the red confirm button.
+      danger: opts.danger === true,
+    }
+  })
+}
+
+// Called by <ConfirmDialog> when the user resolves the dialog (button, backdrop,
+// or Escape). Safe to call when nothing is open.
+export function settleConfirm(val) {
+  confirmState.value = null
+  const r = _resolve
+  _resolve = null
+  if (r) r(val)
+}
+
+export function useConfirm() {
+  return { confirm }
+}

--- a/frontend/src/composables/useConfirm.js
+++ b/frontend/src/composables/useConfirm.js
@@ -13,6 +13,13 @@ import { ref } from "vue"
 // confirm() resolves true when the user confirms and false on Cancel / backdrop
 // click / Escape. This was extracted from ChatView's former inline confirmDialog
 // so there is one implementation, not several.
+//
+// WHICH CONFIRM TO USE:
+//   • This useConfirm() — on the custom jv- surfaces (chat, settings, AI models,
+//     onboarding). It renders with the jv- design tokens so it looks native there.
+//   • frappe-ui's confirmDialog({ onConfirm }) — on the frappe-ui-styled list/
+//     detail pages (macros, skills, files, wiki, agents), which are built from
+//     frappe-ui components and match its dialog. Don't cross the streams.
 
 // The live request, or null when no dialog is open. The mounted ConfirmDialog is
 // the only reader; call sites never touch it directly.

--- a/frontend/src/composables/useConfirm.js
+++ b/frontend/src/composables/useConfirm.js
@@ -39,8 +39,10 @@ export function confirm(opts = {}) {
       message: opts.message || "",
       confirmLabel: opts.confirmLabel || "Confirm",
       cancelLabel: opts.cancelLabel || "Cancel",
-      // General-purpose: neutral (primary) by default. Destructive call sites opt
-      // in with danger:true to get the red confirm button.
+      // General-purpose: neutral (primary) by default. Destructive call sites MUST
+      // pass danger:true to get the red confirm button — don't assume deletes
+      // default to danger (they do not here). Deliberately opt-in, unlike the old
+      // ChatView confirmDialog which defaulted danger true.
       danger: opts.danger === true,
     }
   })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4534,7 +4534,8 @@ onUnmounted(() => {
    so once ChatView stopped rendering the dialog they matched nothing: edits to them
    silently did nothing while the live styles came from @/assets/settings.css.
    Removed rather than left as a decoy. Style the dialog in assets/settings.css.
-   (jv-popin STAYS — .jv-skills-modal / .jv-cdialog still animate with it.) */
+   (jv-popin STAYS — .jv-skills-modal still animates with it. The confirm dialog
+   moved to components/shell/ConfirmDialog.vue with its own jv-confirm-popin.) */
 @keyframes jv-popin { from { transform: scale(0.97); opacity: 0; } to { transform: scale(1); opacity: 1; } }
 .jv-settings-nav { width: 196px; flex: none; background: var(--surface-1); border-right: 1px solid var(--border); padding: 14px 10px; display: flex; flex-direction: column; gap: 2px; }
 .jv-settings-nav-title { font-size: 15px; font-weight: 700; color: var(--text); padding: 4px 10px 12px; }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -630,19 +630,8 @@
 			</transition-group>
 		</div>
 
-		<!-- ============ CONFIRM DIALOG (reusable; replaces window.confirm) ============ -->
-		<transition name="jv-fade">
-			<div v-if="confirmBox" class="jv-skills-overlay" @click.self="_settleConfirm(false)">
-				<div class="jv-cdialog" role="alertdialog" aria-modal="true">
-					<div class="jv-cdialog-title">{{ confirmBox.title }}</div>
-					<div v-if="confirmBox.message" class="jv-cdialog-msg">{{ confirmBox.message }}</div>
-					<div class="jv-cdialog-foot">
-						<button class="jv-btn jv-btn--ghost" @click="_settleConfirm(false)">{{ confirmBox.cancelLabel }}</button>
-						<button class="jv-btn" :class="confirmBox.danger ? 'jv-btn--danger' : 'jv-btn--primary'" @click="_settleConfirm(true)">{{ confirmBox.confirmLabel }}</button>
-					</div>
-				</div>
-			</div>
-		</transition>
+		<!-- CONFIRM DIALOG moved to the app shell (components/shell/ConfirmDialog.vue),
+		     driven by composables/useConfirm.js — call confirm() from anywhere. -->
 
 		<!-- SETTINGS dialog hoisted to the shell (components/shell/SettingsDialog.vue) -->
 
@@ -834,6 +823,7 @@ import * as voice from "@/api/voice"
 import { useAudioRecorder } from "@/composables/useAudioRecorder"
 import { setMacroPrefill } from "@/composables/macroPrefill"
 import { takeChatPrefill } from "@/composables/chatPrefill"
+import { useConfirm } from "@/composables/useConfirm"
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime"
 import { renderMarkdown } from "@/markdown"
@@ -902,12 +892,11 @@ const rootEl = ref(null)
 const showScrollDown = ref(false)
 const pinnedToBottom = ref(true)
 
-// ---- Reusable notifier + confirm dialog ------------------------------------
+// ---- Reusable notifier -----------------------------------------------------
 // notify("Deleted", { type: "success" }) drops a lightweight toast that stacks
-// bottom-right and auto-dismisses. confirmDialog({...}) shows a centered confirm
-// modal and resolves true/false — a drop-in replacement for the native
-// window.confirm() used across destructive actions (delete chat/skill/macro).
-// Both are intentionally generic so any new call site can reuse them.
+// bottom-right and auto-dismisses. (The confirm dialog it used to sit beside now
+// lives app-wide in composables/useConfirm.js + the shell's ConfirmDialog — call
+// confirm() from anywhere.)
 const notes = ref([])
 let _noteSeq = 0
 function notify(message, opts = {}) {
@@ -927,26 +916,10 @@ function announceSR(msg) {
 	srMessage.value = ""
 	nextTick(() => { srMessage.value = msg })
 }
-const confirmBox = ref(null) // { title, message, confirmLabel, cancelLabel, danger }
-let _confirmResolve = null
-function confirmDialog(opts = {}) {
-	return new Promise((resolve) => {
-		_confirmResolve = resolve
-		confirmBox.value = {
-			title: opts.title || "Are you sure?",
-			message: opts.message || "",
-			confirmLabel: opts.confirmLabel || "Confirm",
-			cancelLabel: opts.cancelLabel || "Cancel",
-			danger: opts.danger !== false, // deletes default to the red confirm button
-		}
-	})
-}
-function _settleConfirm(val) {
-	confirmBox.value = null
-	const r = _confirmResolve
-	_confirmResolve = null
-	if (r) r(val)
-}
+// Confirm dialog now lives app-wide (composables/useConfirm.js + the single
+// <ConfirmDialog> in AppShell) — this view just calls confirm(). Escape/backdrop
+// dismissal and rendering are owned by that component.
+const { confirm } = useConfirm()
 const modelMenuOpen = ref(false)
 const showConnect = ref(false)
 // (sidebar collapse machinery, per-conversation ⋯ menu and inline rename
@@ -1449,10 +1422,11 @@ const notifyEnabled = computed(() => store.notifyEnabled)
 // Danger zone: wipe every conversation + message (macros/skills untouched).
 const clearingHistory = ref(false)
 async function clearAllHistory() {
-	if (!(await confirmDialog({
+	if (!(await confirm({
 		title: "Delete ALL chat history?",
 		message: "Every conversation and message will be permanently deleted. Macros, skills and settings stay. This can't be undone.",
 		confirmLabel: "Delete everything",
+		danger: true,
 	}))) return
 	clearingHistory.value = true
 	try {
@@ -4267,12 +4241,13 @@ function onGlobalKey(e) {
 	// listener here, so bail out entirely while it's open — otherwise this chain
 	// would ALSO close an artifact panel behind it on a single Escape.
 	if (store.settingsOpen) return
+	// A confirm dialog, when open, swallows Escape itself (ConfirmDialog listens in
+	// capture phase and stops propagation), so this chain never sees Escape while
+	// one is up — no branch for it here.
 	if (e.key === "Escape" && micState.value === "recording") {
 		cancelMic()
 	} else if (e.key === "Escape" && nudge.value && nudge.value.mode === "recording") {
 		cancelNudgeMic()
-	} else if (e.key === "Escape" && confirmBox.value) {
-		_settleConfirm(false)
 	} else if (e.key === "Escape" && artifact.value) {
 		closeArtifact()
 	}
@@ -4463,7 +4438,7 @@ onUnmounted(() => {
 	.jv-tool-dot.run, .jv-mic-dot { animation: none; }
 	.jv-sendbtn.ready { animation: none; }
 	.jv-md :deep(.jv-mermaid:not([data-rendered]))::after { animation: none; }
-	.jv-settings, .jv-skills-modal, .jv-cdialog { animation: none; }
+	.jv-settings, .jv-skills-modal { animation: none; }
 }
 /* mobile layout (UX #12): the chat had fixed 40px desktop paddings + a 2-col
    welcome grid; inline styles win over class rules, so these override with
@@ -4845,11 +4820,7 @@ onUnmounted(() => {
 .jv-note-enter-active, .jv-note-leave-active { transition: opacity .18s ease, transform .18s ease; }
 .jv-note-enter-from, .jv-note-leave-to { opacity: 0; transform: translateY(-8px); }
 
-/* reusable confirm dialog (replaces window.confirm) */
-.jv-cdialog { width: 400px; max-width: 100%; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 20px; box-shadow: 0 24px 70px rgba(20, 20, 30, .28); animation: jv-popin .16s ease; }
-.jv-cdialog-title { font-size: 16px; font-weight: 650; color: var(--text); }
-.jv-cdialog-msg { margin-top: 8px; font-size: 13.5px; line-height: 1.5; color: var(--text-2); }
-.jv-cdialog-foot { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
+/* confirm dialog styles moved to components/shell/ConfirmDialog.vue */
 
 /* proactive message toast */
 .jv-toast { position: absolute; right: 20px; bottom: 22px; z-index: 70; display: flex; align-items: center; gap: 11px; width: 360px; max-width: calc(100% - 40px); padding: 13px 14px; background: var(--surface); border: 1px solid var(--border-2); border-radius: 13px; box-shadow: 0 12px 32px rgba(20, 20, 30, .22); cursor: pointer; }


### PR DESCRIPTION
## What

A reusable, app-wide confirmation dialog for destructive actions — and wires it to **Remove model** (which previously deleted with no confirmation).

- **`composables/useConfirm.js`** — promise-based `confirm(opts): Promise<boolean>` (a drop-in for `window.confirm`). Opts: `title`, `message`, `confirmLabel`, `cancelLabel`, `danger`.
- **`components/shell/ConfirmDialog.vue`** — renders the shared state, mounted **once** in `AppShell` (above the settings modal, `z-index: 200`). Owns Escape (capture-phase, so it doesn't also close an underlying modal) and backdrop dismissal.

Usage anywhere:
```js
const { confirm } = useConfirm()
if (await confirm({ title: "Remove this model?", message: "…", danger: true, confirmLabel: "Remove" })) { …delete… }
```

## Wired to

- **LlmPoolEditor** — `Remove` model (was a silent delete) and Disconnect direct subscription (was `window.confirm`).
- **DirectSubscriptionCard** — Disconnect (was `window.confirm`).

## Dedup

`ChatView.vue`'s inline `confirmDialog` (its own `jv-cdialog` markup, state, Escape branch, styles) is **removed**; its one call site (`clearAllHistory`) now uses the shared `confirm()`. Single implementation, matching the jv- design system.

## Scope note

`frappe-ui`'s own `confirmDialog` stays in the frappe-ui-styled list/detail pages (macros / skills / files / wiki / agents) — a different design context, intentionally left as-is. This PR is the **jv-design-system** confirm for the custom-styled surfaces.

## Verification

- Full `vite build` passes.
- No remaining `window.confirm` / inline `confirmDialog` / `confirmBox` in the touched files.