### PR TITLE
fix(chat): loose numbered lists no longer restart at "1"

### DIFF
--- a/frontend/src/markdown.js
+++ b/frontend/src/markdown.js
@@ -129,9 +129,24 @@ export function renderMarkdown(src) {
 			const items = []
 			while (i < lines.length) {
 				const m = lines[i].match(/^(\s*)([-*]|\d+\.)\s+(.*)/)
-				if (!m) break
-				items.push({ indent: m[1].length, tag: /\d/.test(m[2]) ? "ol" : "ul", text: m[3] })
-				i++
+				if (m) {
+					items.push({ indent: m[1].length, tag: /\d/.test(m[2]) ? "ol" : "ul", text: m[3] })
+					i++
+					continue
+				}
+				// A blank line inside a list (a "loose" list, common in agent
+				// output) does NOT end it: keep the same list only if another
+				// list item follows. A real paragraph after the blank ends it,
+				// so "1. a\n\n2. b" is ONE <ol> (1, 2), not two that both show 1.
+				if (!lines[i].trim()) {
+					let j = i + 1
+					while (j < lines.length && !lines[j].trim()) j++
+					if (j < lines.length && /^(\s*)([-*]|\d+\.)\s+/.test(lines[j])) {
+						i = j
+						continue
+					}
+				}
+				break
 			}
 			out.push(renderListBlock(items))
 			continue


### PR DESCRIPTION
## Bug

Numbered lists in agent replies rendered every item as **"1."** instead of 1, 2, 3 — surfaced while testing (a Salary Slip walkthrough where every step showed "1").

## Cause

`renderMarkdown` (`frontend/src/markdown.js`) ended a list at the first non-list line — **including a blank line**. So a *loose* list (items separated by blank lines, which agent output emits constantly) became a **separate `<ol>` per item**, each restarting at 1.

Deterministic repro (before):
```
renderMarkdown("1. First\n\n2. Second\n\n3. Third")
→ <ol><li>First</li></ol>
  <ol><li>Second</li></ol>   ← each its own <ol> = all show "1."
  <ol><li>Third</li></ol>
```

## Fix

Tolerate blank lines inside a list: on a blank line, peek ahead — keep the same list only if another list item follows; a real paragraph after the blank still ends the list.

After:
```
"1. First\n\n2. Second\n\n3. Third"  → one <ol> with 3 <li>  (1, 2, 3)
"1. a\n2. b"                          → unchanged (1, 2)
"1. a\n2. b\n\nPara."                → <ol>…</ol> + <p>  (list still ends)
```

**Shared renderer** — `@shared/markdown.js` is imported by both the desktop SPA (`ChatView.vue`) and the mobile PWA (`pwa/.../ChatView.vue`, `DecisionSheet.vue`), so this one change fixes both.

## Test

No frontend test framework, so verified via node repro across 5 cases (loose → one `<ol>`; tight, nested, list-then-paragraph, double-blank all correct). Both frontends build clean; eslint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)