### PR TITLE
feat(oauth): xAI + Kimi chat-subscription capture (Phase 2)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -202,6 +202,11 @@ export const beginPoolAccountSignin = (provider, model) =>
 // complete is capture-only → { account_ref, label, oauth_blob, account_email }
 export const completePoolAccountSignin = (nonce, redirectedUrl) =>
 	call("jarvis.oauth.api.complete_pool_account_signin", { nonce, redirected_url: redirectedUrl })
+// Device-code (Kimi) capture: begin returns { device_flow:true, user_code,
+// verification_uri, interval }; poll on `interval` → { status:"pending" } until
+// the user approves, then the same capture-only { account_ref, label, oauth_blob }.
+export const pollPoolAccountSignin = (nonce) =>
+	call("jarvis.oauth.api.poll_pool_account_signin", { nonce })
 
 // --- DIRECT single chat-subscription (legacy flat-field path) ---------------
 // Existing customers who onboarded a single chat subscription keep their creds

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -250,11 +250,32 @@
                popup-blocker fix); step 2 stays pending until step 1 mints the authorize
                URL, since a URL pasted before sign-in has no nonce and finishConnect no-ops. -->
           <div v-if="panelRow._connect && (panelRow._connect.open || (panel.mode === 'add' && !(panelRow.accounts && panelRow.accounts.length)))" class="jv-csteps">
+            <!-- DEVICE-CODE (Kimi): show the code + verification link, poll for approval. -->
+            <template v-if="panelRow._connect.deviceFlow">
+              <div class="jv-cstep">
+                <div class="jv-cnum">1</div>
+                <div class="jv-cbody">
+                  <div class="jv-ctit">Sign in with {{ upstreamLabelOf(panelRow.upstream) }}</div>
+                  <div class="jv-cdesc">Open the verification page, enter the code, and approve access. This panel updates automatically.</div>
+                  <div class="jv-crow" style="margin-top:8px">
+                    <a v-if="panelRow._connect.verificationUri" :href="panelRow._connect.verificationUri" target="_blank" rel="noopener noreferrer" class="jv-cbtn jv-cbtn-primary">Open verification page ↗</a>
+                  </div>
+                  <div v-if="panelRow._connect.userCode" class="jv-cdesc" style="margin-top:10px">Code: <code style="font-size:17px;letter-spacing:2px;font-weight:700">{{ panelRow._connect.userCode }}</code></div>
+                  <div v-if="panelRow._connect.polling" class="jv-cdesc" style="margin-top:8px">Waiting for approval…</div>
+                </div>
+              </div>
+              <div v-if="panelRow._connect.error" class="jv-cn-err">{{ panelRow._connect.error }}</div>
+              <div class="jv-cn-acts">
+                <button @click="closeConnect(panelRow)" class="jv-btn jv-btn--ghost">Cancel</button>
+              </div>
+            </template>
+            <!-- PASTE-BACK (OpenAI/Google/xAI): open sign-in, paste the callback URL. -->
+            <template v-else>
             <div class="jv-cstep">
               <div class="jv-cnum">1</div>
               <div class="jv-cbody">
                 <div class="jv-chead">
-                  <div class="jv-ctit">Sign in with {{ panelRow.upstream === 'google' ? 'Google' : 'OpenAI' }}</div>
+                  <div class="jv-ctit">Sign in with {{ upstreamLabelOf(panelRow.upstream) }}</div>
                   <div class="jv-crow">
                     <template v-if="panelRow._connect.authorizeUrl">
                       <a :href="panelRow._connect.authorizeUrl" target="_blank" rel="noopener noreferrer" class="jv-cbtn jv-cbtn-primary">Open sign-in ↗</a>
@@ -267,7 +288,7 @@
                     </button>
                   </div>
                 </div>
-                <div class="jv-cdesc">Opens {{ panelRow.upstream === 'google' ? 'Google' : 'OpenAI' }} in a new tab. Approve access, then come back here.</div>
+                <div class="jv-cdesc">Opens {{ upstreamLabelOf(panelRow.upstream) }} in a new tab. Approve access, then come back here.</div>
               </div>
             </div>
             <div class="jv-cstep" :class="{ 'jv-pending': !panelRow._connect.authorizeUrl }">
@@ -301,6 +322,7 @@
                 {{ panelRow._connect.loading ? 'Connecting…' : 'Connect' }}
               </button>
             </div>
+            </template>
           </div>
 
         </div>
@@ -457,11 +479,31 @@
           <template v-if="singleMode && !(m.accounts && m.accounts.length)">
             <div class="jv-cdivider"></div>
             <div class="jv-csteps">
+              <!-- DEVICE-CODE (Kimi): show the code + verification link, poll for approval. -->
+              <template v-if="m._connect && m._connect.deviceFlow">
+                <div class="jv-cstep">
+                  <div class="jv-cnum">1</div>
+                  <div class="jv-cbody">
+                    <div class="jv-ctit">Sign in with {{ upstreamLabelOf(m.upstream) }}</div>
+                    <div class="jv-cdesc">Open the verification page, enter the code, and approve access. This panel updates automatically.</div>
+                    <div class="jv-crow" style="margin-top:8px">
+                      <a v-if="m._connect.verificationUri" :href="m._connect.verificationUri" target="_blank" rel="noopener noreferrer" class="jv-cbtn jv-cbtn-primary">Open verification page ↗</a>
+                    </div>
+                    <div v-if="m._connect.userCode" class="jv-cdesc" style="margin-top:10px">Code: <code style="font-size:17px;letter-spacing:2px;font-weight:700">{{ m._connect.userCode }}</code></div>
+                    <div v-if="m._connect.polling" class="jv-cdesc" style="margin-top:8px">Waiting for approval…</div>
+                    <div class="jv-cacts" style="margin-top:10px">
+                      <button type="button" class="jv-cbtn jv-cbtn-ghost" @click="closeConnect(m)">Cancel</button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <!-- PASTE-BACK (OpenAI/Google/xAI): open sign-in, paste the callback URL. -->
+              <template v-else>
               <div class="jv-cstep">
                 <div class="jv-cnum">1</div>
                 <div class="jv-cbody">
                   <div class="jv-chead">
-                    <div class="jv-ctit">Sign in with {{ m.upstream === 'google' ? 'Google' : 'OpenAI' }}</div>
+                    <div class="jv-ctit">Sign in with {{ upstreamLabelOf(m.upstream) }}</div>
                     <div class="jv-crow">
                       <template v-if="m._connect && m._connect.authorizeUrl">
                         <a :href="m._connect.authorizeUrl" target="_blank" rel="noopener noreferrer" class="jv-cbtn jv-cbtn-primary">Open sign-in ↗</a>
@@ -473,7 +515,7 @@
                       </button>
                     </div>
                   </div>
-                  <div class="jv-cdesc">Opens {{ m.upstream === 'google' ? 'Google' : 'OpenAI' }} in a new tab. Approve access, then come back here.</div>
+                  <div class="jv-cdesc">Opens {{ upstreamLabelOf(m.upstream) }} in a new tab. Approve access, then come back here.</div>
                 </div>
               </div>
               <div class="jv-cstep" :class="{ 'jv-pending': !(m._connect && m._connect.authorizeUrl) }">
@@ -501,6 +543,7 @@
                   </div>
                 </div>
               </div>
+              </template>
             </div>
             <div v-if="m._connect && m._connect.error" class="jv-cn-err">{{ m._connect.error }}</div>
           </template>
@@ -609,7 +652,15 @@ const credTypes = [
 const upstreamOpts = [
   { value: "openai", label: "OpenAI" },
   { value: "google", label: "Google Gemini" },
+  { value: "xai", label: "xAI Grok" },
+  { value: "kimi", label: "Kimi (Moonshot)" },
 ]
+// upstream value -> the OAuth provider label the backend _PROVIDER_OAUTH_MAP is
+// keyed by (begin_pool_account_signin needs the label, not the upstream value).
+// MUST match jarvis/oauth/providers.py _PROVIDER_OAUTH_MAP keys.
+const UPSTREAM_OAUTH_PROVIDER = {
+  openai: "OpenAI", google: "Google Gemini", xai: "xAI Grok", kimi: "Kimi (Moonshot)",
+}
 // JvCombo speaks display LABELS; a row stores `upstream` as the VALUE the pool spec
 // requires ("openai" / "google"). Bridge the two rather than letting "OpenAI" reach
 // the spec (the fleet validates upstream against openai|anthropic|google and 422s).
@@ -742,7 +793,7 @@ const dirty = computed(() =>
 )
 
 // ---- helpers -------------------------------------------------------------
-function blankConnect() { return { open: false, loading: false, error: "", copied: false, nonce: "", authorizeUrl: "", pastedUrl: "", reconnectIdx: null } }
+function blankConnect() { return { open: false, loading: false, error: "", copied: false, nonce: "", authorizeUrl: "", pastedUrl: "", reconnectIdx: null, deviceFlow: false, userCode: "", verificationUri: "", polling: false } }
 function presetCardStyle(entry) {
   const on = selectedPreset.value === entry.key
   return {
@@ -1114,7 +1165,7 @@ async function startConnect(m, reconnectIdx = null) {
   let win = null
   try { win = window.open("about:blank", "_blank"); if (win) win.opener = null } catch (e) { win = null }
   try {
-    const provider = m.upstream === "google" ? "Google Gemini" : "OpenAI"
+    const provider = UPSTREAM_OAUTH_PROVIDER[m.upstream] || "OpenAI"
     const res = await api.beginPoolAccountSignin(provider, m.model.trim())
     // Backend returns an envelope: {ok:true, data:{nonce, authorize_url, …}} or
     // {ok:false, error:{code, message}}. Unwrap data; surface errors instead of
@@ -1127,10 +1178,72 @@ async function startConnect(m, reconnectIdx = null) {
     }
     const d = res.data || {}
     m._connect.nonce = d.nonce
-    m._connect.authorizeUrl = d.authorize_url
     m._connect.loading = false
-    if (win && d.authorize_url) win.location.href = d.authorize_url
+    if (d.device_flow) {
+      // Device-code (Kimi): no authorize URL, no paste. Show the user_code +
+      // verification link, open the verification page, and poll for approval.
+      m._connect.deviceFlow = true
+      m._connect.userCode = d.user_code || ""
+      m._connect.verificationUri = d.verification_uri || d.verification_uri_complete || ""
+      const openUrl = d.verification_uri_complete || d.verification_uri
+      if (win && openUrl) win.location.href = openUrl
+      else if (win) win.close()
+      _pollDeviceConnect(m, Math.max(2, Number(d.interval) || 5))
+    } else {
+      m._connect.authorizeUrl = d.authorize_url
+      if (win && d.authorize_url) win.location.href = d.authorize_url
+      else if (win) win.close()
+    }
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e); if (win) win.close() }
+}
+// Poll a device-code (Kimi) sign-in until the user approves, then place the
+// account (same contract as finishConnect's success path). Bails if the panel
+// is closed/reset or a new sign-in rebinds the nonce.
+async function _pollDeviceConnect(m, intervalSecs) {
+  const nonce = m._connect && m._connect.nonce
+  if (!nonce) return
+  m._connect.polling = true
+  const tick = async () => {
+    if (!m._connect || !m._connect.deviceFlow || m._connect.nonce !== nonce) return
+    let res
+    try { res = await api.pollPoolAccountSignin(nonce) }
+    catch (e) { if (m._connect && m._connect.nonce === nonce) { m._connect.error = _err(e); m._connect.polling = false } return }
+    if (!m._connect || m._connect.nonce !== nonce) return
+    if (!res || res.ok === false) {
+      m._connect.error = (res && res.error && res.error.message) || "Sign-in failed. Start again."
+      m._connect.polling = false
+      return
+    }
+    const d = res.data || {}
+    if (d.status === "pending") { setTimeout(tick, intervalSecs * 1000); return }
+    m._connect.polling = false
+    await _placeConnectedAccount(m, d)
+  }
+  setTimeout(tick, intervalSecs * 1000)
+}
+// Shared account placement for both the paste-back (finishConnect) and
+// device-code (_pollDeviceConnect) success paths.
+async function _placeConnectedAccount(m, d) {
+  if (!Array.isArray(m.accounts)) m.accounts = []
+  const acct = {
+    upstream: m.upstream || "openai",
+    account_ref: d.account_ref,
+    label: d.label || d.account_email || d.account_ref,
+    account_email: d.account_email || "",
+    oauth_blob: d.oauth_blob || "",
+    connected: true,
+  }
+  const ri = m._connect.reconnectIdx
+  const byEmail = acct.account_email
+    ? m.accounts.findIndex((a) => a.account_email && a.account_email.toLowerCase() === acct.account_email.toLowerCase())
+    : -1
+  if (ri != null && ri >= 0 && ri < m.accounts.length) {
+    m.accounts.splice(ri, 1, acct)
+    if (byEmail >= 0 && byEmail !== ri) m.accounts.splice(byEmail, 1)
+  } else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
+  else m.accounts.push(acct)
+  m._connect = blankConnect()
+  if (!props.footerless) await save()
 }
 async function finishConnect(m) {
   if (!m._connect || !m._connect.nonce) return
@@ -1144,38 +1257,13 @@ async function finishConnect(m) {
       m._connect.error = (res && res.error && res.error.message) || "Couldn't connect the account. Check the pasted URL and try again."
       return
     }
-    const d = res.data || {}
-    if (!Array.isArray(m.accounts)) m.accounts = []
-    const acct = {
-      upstream: m.upstream || "openai",
-      account_ref: d.account_ref,
-      label: d.label || d.account_email || d.account_ref,
-      account_email: d.account_email || "",
-      oauth_blob: d.oauth_blob || "",
-      connected: true,
-    }
     // Place the (re)connected account. The backend mints a fresh account_ref on
     // every sign-in, so it can't be a dedupe key: a per-account Reconnect refreshes
     // that exact slot (reconnectIdx); otherwise fold onto an existing account with
-    // the same email; otherwise append a new one.
-    const ri = m._connect.reconnectIdx
-    const byEmail = acct.account_email
-      ? m.accounts.findIndex((a) => a.account_email && a.account_email.toLowerCase() === acct.account_email.toLowerCase())
-      : -1
-    if (ri != null && ri >= 0 && ri < m.accounts.length) {
-      m.accounts.splice(ri, 1, acct)
-      // Reconnecting one slot but signing in as an account already held by a
-      // DIFFERENT slot would leave two identical accounts - drop the duplicate.
-      if (byEmail >= 0 && byEmail !== ri) m.accounts.splice(byEmail, 1)
-    } else if (byEmail >= 0) m.accounts.splice(byEmail, 1, acct)
-    else m.accounts.push(acct)
-    m._connect = blankConnect()
-    // The just-minted OAuth blob lives only in memory until the pool is saved, so
-    // navigating off the page would orphan this account. In the account editor,
-    // persist immediately; if the pool isn't valid yet, save() surfaces the reason
-    // and the "Unsaved changes" notice stays up so nothing is silently lost. Skip
-    // in the footerless onboarding editor - there the host's CTA drives save.
-    if (!props.footerless) await save()
+    // the same email; otherwise append a new one. The just-minted OAuth blob lives
+    // only in memory until the pool is saved, so _placeConnectedAccount persists
+    // immediately (unless footerless onboarding, where the host CTA drives save).
+    await _placeConnectedAccount(m, res.data || {})
   } catch (e) { m._connect.loading = false; m._connect.error = _err(e) }
 }
 function closeConnect(m) { m._connect = blankConnect() }

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -665,7 +665,9 @@ const UPSTREAM_OAUTH_PROVIDER = {
 // requires ("openai" / "google"). Bridge the two rather than letting "OpenAI" reach
 // the spec (the fleet validates upstream against openai|anthropic|google and 422s).
 const upstreamLabels = upstreamOpts.map((o) => o.label)
-const upstreamLabelOf = (v) => (upstreamOpts.find((o) => o.value === v) || {}).label || ""
+// Fall back to the raw value (never blank) so an unrecognized/legacy upstream
+// renders "Sign in with <value>" rather than "Sign in with " (review finding).
+const upstreamLabelOf = (v) => (upstreamOpts.find((o) => o.value === v) || {}).label || v || "your provider"
 const upstreamValueOf = (l) => (upstreamOpts.find((o) => o.label === l) || {}).value || l
 // Provider dropdown fed by the shared PROVIDER_LABELS (id⇄label). Rows store the
 // display LABEL as `provider` (matches seedRowsFromConfig + the desk page).
@@ -1234,6 +1236,10 @@ async function _placeConnectedAccount(m, d) {
     connected: true,
   }
   const ri = m._connect.reconnectIdx
+  // Device-code accounts (Kimi) carry NO email, so byEmail can't fold two
+  // captures of the same account — to REFRESH an existing device account use its
+  // per-slot Reconnect (sets reconnectIdx, replacing that slot); a generic
+  // Connect always appends (intended for pooling a genuinely different account).
   const byEmail = acct.account_email
     ? m.accounts.findIndex((a) => a.account_email && a.account_email.toLowerCase() === acct.account_email.toLowerCase())
     : -1

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -39,7 +39,13 @@ export function reorder(list, from, to) {
 // Suggested chat-subscription model ids per upstream (index 0 = the default the
 // onboarding editor uses when it hides the model field). Single source of truth,
 // shared with LlmPoolEditor's datalist so the default + suggestions can't drift.
-export const SUB_MODEL_SUGGESTIONS = { openai: ["gpt-5.5", "gpt-5.4"], google: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"] }
+export const SUB_MODEL_SUGGESTIONS = {
+  openai: ["gpt-5.5", "gpt-5.4"],
+  google: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"],
+  // Model ids must exist in cli-proxy-api's v7.2.35 catalogue (grok-4.5 is NOT).
+  xai: ["grok-4.3", "grok-build-0.1"],
+  kimi: ["kimi-k2.7-code", "kimi-k2.6"],
+}
 // Default chat-subscription model for an upstream (SUB_MODEL_SUGGESTIONS[0], with
 // an openai fallback for unmapped upstreams). Onboarding hides the model field
 // (provider is enough), so the row still needs a model id for validatePool + save.

--- a/jarvis/_subscription_models.py
+++ b/jarvis/_subscription_models.py
@@ -35,9 +35,16 @@ SUBSCRIPTION_MODELS: dict[str, list[str]] = {
 		"gemini-2.5-flash",
 		"gemini-3.1-flash",
 	],
+	# Model ids MUST exist in cli-proxy-api's embedded catalogue for the pinned
+	# image (v7.2.35). NB: "grok-4.5" is NOT in that catalogue (use grok-4.3 /
+	# grok-build-0.1); "kimi-k2.7-code" IS present.
+	"xAI Grok": ["grok-4.3", "grok-build-0.1"],
+	"Kimi (Moonshot)": ["kimi-k2.7-code", "kimi-k2.6"],
 }
 
 DEFAULT_MODEL: dict[str, str] = {
 	"OpenAI": "gpt-5.5",
 	"Google Gemini": "gemini-2.5-pro",
+	"xAI Grok": "grok-4.3",
+	"Kimi (Moonshot)": "kimi-k2.7-code",
 }

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -88,6 +88,16 @@ OAUTH_CLIENT_IDS = {
 		# Operators set the env var if our embedded default goes stale.
 		"681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
 	),
+	# xAI Grok — public/PKCE client id used by cli-proxy-api's --xai-login.
+	"xAI Grok": _env_or_default(
+		"JARVIS_XAI_OAUTH_CLIENT_ID",
+		"b1a00492-073a-47ea-816f-4c329264a828",
+	),
+	# Kimi (Moonshot) — public device-flow client id used by --kimi-login.
+	"Kimi (Moonshot)": _env_or_default(
+		"JARVIS_KIMI_OAUTH_CLIENT_ID",
+		"17e5f671-d194-4dfb-9706-5516cb48c098",
+	),
 }
 
 
@@ -120,6 +130,9 @@ def get_oauth_client_id(provider: str) -> str:
 OAUTH_CLIENT_SECRETS = {
 	"OpenAI": _env_or_default("JARVIS_OPENAI_CODEX_OAUTH_CLIENT_SECRET", ""),
 	"Google Gemini": _env_or_default("JARVIS_GEMINI_CLI_OAUTH_CLIENT_SECRET", ""),
+	# xAI (PKCE) + Kimi (device-flow) are public clients — no secret.
+	"xAI Grok": _env_or_default("JARVIS_XAI_OAUTH_CLIENT_SECRET", ""),
+	"Kimi (Moonshot)": _env_or_default("JARVIS_KIMI_OAUTH_CLIENT_SECRET", ""),
 }
 
 

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -239,13 +239,15 @@ def validate_models(settings) -> list:
                     errors.append(
                         f"{label} account[{j}] ({acc_ref}): upstream='anthropic' is not permitted (ToS)"
                     )
-                # Only openai/google subscription upstreams are supported. The old
-                # child-doctype Select(reqd) structurally enforced this; the JSON
-                # migration dropped the guard, so a typo'd upstream would route to a
+                # Only these subscription upstreams are supported (the pinned
+                # cli-proxy-api image ships codex/antigravity/xai/kimi channels;
+                # anthropic is ToS-banned above). The old child-doctype
+                # Select(reqd) structurally enforced this; the JSON migration
+                # dropped the guard, so a typo'd upstream would route to a
                 # nonexistent provider. Re-enforce here. #200 review #6.
-                elif upstream and upstream not in ("openai", "google"):
+                elif upstream and upstream not in ("openai", "google", "xai", "kimi"):
                     errors.append(
-                        f"{label} account[{j}] ({acc_ref}): unsupported upstream '{upstream}' (must be openai or google)"
+                        f"{label} account[{j}] ({acc_ref}): unsupported upstream '{upstream}' (must be openai, google, xai, or kimi)"
                     )
 
                 upstreams.add(upstream)

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -21,7 +21,7 @@ from jarvis.exceptions import JarvisError
 from jarvis.permissions import require_jarvis_admin
 from jarvis.oauth.providers import (
 	UnknownProviderError, build_authorize_url, extract_account_id, get_provider,
-	is_oauth_provider,
+	is_oauth_provider, provider_redirect_uri,
 )
 
 
@@ -179,16 +179,23 @@ def _begin_signin(provider: str, model: str, *, pool: bool) -> dict:
 	nonce = secrets.token_hex(24)
 	verifier, challenge = _generate_pkce()
 	state = secrets.token_urlsafe(16)
+	# xAI's authorize endpoint requires a fresh nonce alongside state; other
+	# providers ignore it (build_authorize_url only emits it when requires_nonce).
+	oidc_nonce = secrets.token_urlsafe(16)
+	# Per-provider redirect_uri (xAI pins cli-proxy-api's exact loopback
+	# callback). Cached so _exchange_code re-sends the SAME value.
+	redirect_uri = provider_redirect_uri(provider, _REDIRECT_URI)
 
 	authorize_url = build_authorize_url(
 		provider=provider,
-		redirect_uri=_REDIRECT_URI,
+		redirect_uri=redirect_uri,
 		code_challenge=challenge,
 		state=state,
 		# Pool accounts feed cli-proxy-api, which needs the codex-scope
 		# token audience; the direct flow keeps the connectors scope for
 		# openclaw's own codex path. See providers.py pool_scope.
 		pool=pool,
+		oidc_nonce=oidc_nonce,
 	)
 
 	entry = {
@@ -198,6 +205,7 @@ def _begin_signin(provider: str, model: str, *, pool: bool) -> dict:
 		"expires_at_ts": int(time.time()) + _NONCE_TTL_SECS,
 		"verifier": verifier,
 		"state": state,
+		"redirect_uri": redirect_uri,
 		"originator_user": frappe.session.user,
 	}
 	if pool:
@@ -225,19 +233,96 @@ def begin_paste_signin(provider: str, model: str) -> dict:
 	return _begin_signin(provider, model, pool=False)
 
 
+def _begin_device_signin(provider: str, model: str) -> dict:
+	"""Device-code (RFC 8628) capture start for a device-flow provider (Kimi).
+
+	Requests a device_code + user_code from the provider's
+	device_authorization endpoint, caches the device_code bound to the user
+	(tagged pool+device), and returns the user_code + verification_uri for the
+	frontend to display. There is NO authorize URL / redirect / paste — the user
+	approves out-of-band and the frontend polls ``poll_pool_account_signin``.
+	"""
+	p = get_provider(provider)
+	_gc_expired_nonces()
+	device_id = secrets.token_hex(16)
+	headers = dict(p.get("device_headers") or {})
+	headers["X-Msh-Device-Id"] = device_id
+	try:
+		resp = requests.post(
+			p["device_authorization"],
+			data={"client_id": p["client_id"]},
+			headers=headers,
+			timeout=_HTTP_TIMEOUT,
+		)
+	except requests.RequestException as e:
+		frappe.log_error(title="oauth device authorization: network error",
+		                 message=f"provider={provider!r} error={e!r}")
+		return _err("network_error", "Couldn't reach the sign-in provider. Try again in a minute.")
+	if not resp.ok:
+		frappe.log_error(title="oauth device authorization: provider rejected",
+		                 message=f"provider={provider!r} status={resp.status_code} detail={resp.text!r}")
+		return _err("device_start_failed", "Couldn't start sign-in with the provider. Try again.")
+	try:
+		body = resp.json()
+	except ValueError:
+		return _err("device_start_failed", "The provider returned an unexpected response.")
+
+	device_code = body.get("device_code")
+	user_code = body.get("user_code")
+	verification_uri = body.get("verification_uri") or body.get("verification_url")
+	if not device_code or not user_code:
+		return _err("device_start_failed", "The provider returned an incomplete device response.")
+	interval = int(body.get("interval") or p.get("poll_interval_s") or 5)
+	# Device flow's own expiry (typically <=15 min) but never past our nonce TTL.
+	expires_in = min(int(body.get("expires_in") or _NONCE_TTL_SECS), _NONCE_TTL_SECS)
+
+	nonce = secrets.token_hex(24)
+	entry = {
+		"provider": provider,
+		"model": _coerce_subscription_model(provider, model),
+		"status": "pending",
+		"expires_at_ts": int(time.time()) + expires_in,
+		"device_code": device_code,
+		"device_id": device_id,
+		"interval": interval,
+		"pool": True,
+		"device": True,
+		"originator_user": frappe.session.user,
+	}
+	frappe.cache.hset(_CACHE_KEY, nonce, entry)
+	return _ok({
+		"nonce": nonce,
+		"device_flow": True,
+		"user_code": user_code,
+		"verification_uri": verification_uri,
+		"verification_uri_complete": body.get("verification_uri_complete") or verification_uri,
+		"interval": interval,
+		"expires_in": expires_in,
+	})
+
+
 @frappe.whitelist()
 def begin_pool_account_signin(provider: str, model: str) -> dict:
-	"""POOL variant of ``begin_paste_signin``: mint a nonce + PKCE pair for
-	capturing ONE more account into a pool "subscription" model.
+	"""POOL variant of ``begin_paste_signin``: start capturing ONE more account
+	into a pool "subscription" model.
 
-	Same nonce/PKCE/state machinery and same System-Manager + per-user
-	binding as the DIRECT flow; the only difference is the cached entry is
-	tagged ``pool`` so ``complete_pool_account_signin`` can distinguish it.
-	Unlike the DIRECT flow this captures a blob and hands it back to the
-	caller (see ``complete_pool_account_signin``) instead of writing creds
-	to Jarvis Settings / pushing to the container.
+	Routes on the provider's grant type: paste-back providers (OpenAI, Google,
+	xAI) mint a nonce + PKCE pair via the shared ``_begin_signin`` machinery;
+	device-code providers (Kimi) go through ``_begin_device_signin`` (no
+	authorize URL — the frontend shows a code + link and polls
+	``poll_pool_account_signin``). Either way the cached entry is tagged ``pool``
+	and this endpoint captures a blob for the caller to stash, rather than
+	writing creds to Jarvis Settings / pushing to the container.
+
+	Gated on System Manager + per-user nonce binding.
 	"""
 	require_jarvis_admin()
+	try:
+		p = get_provider(provider)
+	except UnknownProviderError as e:
+		return _err("unknown_provider", str(e))
+	if p.get("grant_type") == "device_code":
+		return _begin_device_signin(provider, model)
 	return _begin_signin(provider, model, pool=True)
 
 
@@ -341,6 +426,7 @@ def _exchange_and_build_blob(entry: dict, redirected_url: str):
 			provider=provider,
 			code=parsed["code"],
 			code_verifier=entry["verifier"],
+			redirect_uri=entry.get("redirect_uri") or _REDIRECT_URI,
 		)
 	except TokenExchangeError as e:
 		# Nonce NOT cleared; customer can paste again if they fix the URL.
@@ -514,7 +600,103 @@ def complete_pool_account_signin(nonce: str, redirected_url: str) -> dict:
 	})
 
 
-def _exchange_code(*, provider: str, code: str, code_verifier: str) -> dict:
+@frappe.whitelist()
+def poll_pool_account_signin(nonce: str) -> dict:
+	"""Poll a device-code (Kimi) pool sign-in started by
+	``begin_pool_account_signin``.
+
+	Returns ``{status:"pending"}`` while the user hasn't approved yet, or the
+	same capture-only ``{account_ref, label, oauth_blob, account_email}`` shape
+	as ``complete_pool_account_signin`` on success. The frontend calls this on
+	the device flow's ``interval`` until it stops returning "pending".
+
+	Gated on System Manager + per-user nonce binding; the nonce must have been
+	minted by ``begin_pool_account_signin`` for a device-flow provider.
+	"""
+	require_jarvis_admin()
+	entry, err = _validate_signin_nonce(nonce)
+	if err:
+		return err
+	if not (entry.get("pool") and entry.get("device")):
+		# Same opaque message as unknown_nonce so live nonces aren't leaked.
+		return _err("unknown_nonce", "nonce not recognized")
+
+	p = get_provider(entry["provider"])
+	headers = dict(p.get("device_headers") or {})
+	headers["X-Msh-Device-Id"] = entry.get("device_id", "")
+	try:
+		resp = requests.post(
+			p["token"],
+			data={
+				"grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+				"device_code": entry["device_code"],
+				"client_id": p["client_id"],
+			},
+			headers=headers,
+			timeout=_HTTP_TIMEOUT,
+		)
+	except requests.RequestException as e:
+		frappe.log_error(title="oauth device poll: network error",
+		                 message=f"provider={entry['provider']!r} error={e!r}")
+		return _err("network_error", "Couldn't reach the sign-in provider. Try again in a minute.")
+
+	body: dict = {}
+	try:
+		parsed = resp.json()
+		if isinstance(parsed, dict):
+			body = parsed
+	except ValueError:
+		pass
+
+	if not resp.ok:
+		err_code = body.get("error") if isinstance(body.get("error"), str) else ""
+		# Not-yet-approved: keep the nonce alive and keep polling.
+		if err_code in ("authorization_pending", "slow_down"):
+			return _ok({"status": "pending"})
+		# Terminal failure (expired_token / access_denied / ...): burn the nonce.
+		frappe.cache.hdel(_CACHE_KEY, nonce)
+		frappe.log_error(title="oauth device poll: provider rejected",
+		                 message=(f"provider={entry['provider']!r} status={resp.status_code} "
+		                          f"err={err_code!r} detail={resp.text!r}"))
+		msg = ("Sign-in expired; start again." if err_code == "expired_token"
+		       else "Sign-in was declined or failed. Start again.")
+		return _err("device_" + (err_code or "failed"), msg)
+
+	access_token = body.get("access_token")
+	if not access_token:
+		# 200 with no token yet — treat as still pending.
+		return _ok({"status": "pending"})
+
+	# Success. Build the device-flow openclaw blob; the fleet-agent's
+	# oauth_blob_to_cliproxy_kimi transform consumes access/refresh/expires/
+	# token_type/scope/device_id (Kimi is device-code: NO id_token, NO email).
+	now_ms = int(time.time() * 1000)
+	expires_ms = now_ms + int(body.get("expires_in", 3600)) * 1000
+	blob = {
+		"type": "oauth",
+		"provider": p["openclaw_provider"],
+		"access": access_token,
+		"refresh": body.get("refresh_token") or "",
+		"expires": expires_ms,
+		"token_type": body.get("token_type") or "Bearer",
+		"scope": body.get("scope") or "",
+		"device_id": entry.get("device_id", ""),
+	}
+	account_ref = "SUB_" + secrets.token_hex(8)
+	frappe.cache.hdel(_CACHE_KEY, nonce)
+	# Kimi returns no account email, so synthesize a stable non-secret label.
+	label = f"Kimi {account_ref[-4:]}"
+	return _ok({
+		"status": "ok",
+		"account_ref": account_ref,
+		"label": label,
+		"oauth_blob": json.dumps(blob),
+		"account_email": "",
+	})
+
+
+def _exchange_code(*, provider: str, code: str, code_verifier: str,
+                   redirect_uri: str = "") -> dict:
 	"""POST to provider's token endpoint, return parsed JSON.
 
 	On error, raises TokenExchangeError with an opaque code + user-safe
@@ -530,7 +712,7 @@ def _exchange_code(*, provider: str, code: str, code_verifier: str) -> dict:
 			"code": code,
 			"code_verifier": code_verifier,
 			"client_id": p["client_id"],
-			"redirect_uri": _REDIRECT_URI,
+			"redirect_uri": redirect_uri or _REDIRECT_URI,
 		}
 		# Confidential clients (gemini-cli) require client_secret alongside
 		# PKCE. Pure-PKCE clients (codex) leave it blank and we don't send it.

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -167,9 +167,17 @@ def _begin_signin(provider: str, model: str, *, pool: bool) -> dict:
 	System-Manager gate.
 	"""
 	try:
-		get_provider(provider)
+		p = get_provider(provider)
 	except UnknownProviderError as e:
 		return _err("unknown_provider", str(e))
+	if p.get("grant_type") == "device_code":
+		# Device-code providers (Kimi) have no authorize URL — build_authorize_url
+		# would KeyError on p["authorize"]. They are captured via
+		# begin_pool_account_signin -> _begin_device_signin, never the paste-back
+		# path. Fail clean rather than 500 if this is reached (e.g. a DIRECT
+		# re-authorize for a stored device-code provider).
+		return _err("device_flow_required",
+		            "This provider uses a device-code sign-in and can't be connected this way.")
 
 	# GC abandoned sign-ins BEFORE writing the new nonce. Otherwise a
 	# user who loops begin without ever completing (e.g. wizard reload
@@ -573,10 +581,12 @@ def complete_pool_account_signin(nonce: str, redirected_url: str) -> dict:
 	entry, err = _validate_signin_nonce(nonce)
 	if err:
 		return err
-	# Only nonces minted by begin_pool_account_signin may be completed here;
-	# a DIRECT paste-signin nonce must go through complete_paste_signin. Same
-	# opaque message as unknown_nonce so live nonces aren't leaked.
-	if not entry.get("pool"):
+	# Only PASTE-BACK pool nonces may be completed here; a DIRECT paste-signin
+	# nonce goes through complete_paste_signin, and a DEVICE-code pool nonce
+	# (pool+device, no state/verifier) goes through poll_pool_account_signin —
+	# routing one here would KeyError on entry["state"] in _exchange_and_build_blob.
+	# Same opaque message as unknown_nonce so live nonces aren't leaked.
+	if not entry.get("pool") or entry.get("device"):
 		return _err("unknown_nonce", "nonce not recognized")
 
 	result, err = _exchange_and_build_blob(entry, redirected_url)

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -74,6 +74,35 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 			"prompt":      "consent",
 		},
 	},
+	# xAI Grok — SAME authorization_code + PKCE paste-back flow as codex. The
+	# only deltas: a distinct loopback redirect_uri (xAI's server validates it
+	# as an exact string, so mirror cli-proxy-api's default) and a fresh per-
+	# request `nonce` param on the authorize URL (requires_nonce). Public/PKCE
+	# client, so client_secret stays empty. Pooled accounts feed cli-proxy-api's
+	# `xai` channel; there is no distinct pool_scope (one scope constant).
+	"xAI Grok": {
+		"authorize":   "https://auth.x.ai/oauth2/authorize",
+		"token":       "https://auth.x.ai/oauth2/token",
+		"userinfo":    "https://auth.x.ai/oauth2/userinfo",
+		"scope":       "openid profile email offline_access grok-cli:access api:access",
+		"openclaw_provider": "xai",
+		"redirect_uri": "http://127.0.0.1:56121/callback",
+		"requires_nonce": True,
+		"extra_authorize_params": {"plan": "generic", "referrer": "cli-proxy-api"},
+	},
+	# Kimi (Moonshot) — DEVICE-CODE flow (RFC 8628), NOT paste-back: there is no
+	# authorize URL / redirect / code to paste. begin_pool_account_signin routes
+	# grant_type=="device_code" providers to _begin_device_signin; the frontend
+	# shows user_code + verification_uri and polls poll_pool_account_signin.
+	# Public device client (no secret, no PKCE). Custom X-Msh-* headers required.
+	"Kimi (Moonshot)": {
+		"grant_type":    "device_code",
+		"device_authorization": "https://auth.kimi.com/api/oauth/device_authorization",
+		"token":         "https://auth.kimi.com/api/oauth/token",
+		"openclaw_provider": "kimi",
+		"device_headers": {"X-Msh-Platform": "cli-proxy-api", "X-Msh-Version": "1.0.0"},
+		"poll_interval_s": 5,
+	},
 }
 
 
@@ -141,12 +170,17 @@ def extract_account_id(provider: str, access_token: str) -> str:
 
 def build_authorize_url(*, provider: str, redirect_uri: str,
                          code_challenge: str, state: str,
-                         pool: bool = False) -> str:
+                         pool: bool = False, oidc_nonce: str = "") -> str:
 	"""Construct the /oauth/authorize URL with all required parameters.
 
 	``pool=True`` selects the provider's ``pool_scope`` when it defines one
 	(subscription-pool accounts consumed by cli-proxy-api need a different
 	token audience than the direct openclaw flow - see the OpenAI entry).
+
+	``oidc_nonce`` is added to the authorize params only for providers that set
+	``requires_nonce`` (xAI's authorize endpoint 400s without a fresh nonce, the
+	same way ``state`` is minted per request). Ignored for providers that don't.
+	``redirect_uri`` is the effective per-provider redirect the caller resolved.
 	"""
 	p = get_provider(provider)
 	params = {
@@ -158,5 +192,15 @@ def build_authorize_url(*, provider: str, redirect_uri: str,
 		"code_challenge_method": "S256",
 		"state": state,
 	}
+	if p.get("requires_nonce") and oidc_nonce:
+		params["nonce"] = oidc_nonce
 	params.update(p["extra_authorize_params"])
 	return f"{p['authorize']}?{urlencode(params)}"
+
+
+def provider_redirect_uri(provider: str, default: str) -> str:
+	"""The effective OAuth redirect_uri for ``provider``: its own value when it
+	pins one (xAI mirrors cli-proxy-api's exact loopback callback), else the
+	shared default. build_authorize_url and the token exchange MUST use the same
+	value, so this is resolved once in _begin_signin and cached on the nonce."""
+	return _PROVIDER_OAUTH_MAP.get(provider, {}).get("redirect_uri") or default

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -107,16 +107,18 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 
 
 def is_oauth_provider(label: str) -> bool:
-	"""True when ``label`` is an OAuth/chat-subscription-capable provider.
+	"""True when ``label`` is a PASTE-BACK (authorization_code) OAuth provider —
+	exactly the providers ``begin_paste_signin`` can mint an authorize URL for.
 
-	The canonical set is the keys of ``_PROVIDER_OAUTH_MAP`` — exactly the
-	providers ``begin_paste_signin`` can mint an authorize URL for. Callers use
-	this to avoid offering a "Re-authorize" affordance for a stored
-	``llm_provider`` (e.g. a non-OAuth default like ``Anthropic`` left behind by
-	``reset_onboarding``) that ``get_provider`` would reject with
-	``UnknownProviderError``.
+	Device-code providers (Kimi) are deliberately EXCLUDED: they are in
+	``_PROVIDER_OAUTH_MAP`` but have no authorize URL, so ``build_authorize_url``
+	would KeyError on ``p["authorize"]``. Callers use this to gate the DIRECT
+	"Re-authorize" affordance for a stored ``llm_provider`` (e.g. skip it for a
+	non-OAuth default like ``Anthropic`` left behind by ``reset_onboarding``, and
+	for a device-code provider that can only be captured via the pool flow).
 	"""
-	return label in _PROVIDER_OAUTH_MAP
+	entry = _PROVIDER_OAUTH_MAP.get(label)
+	return entry is not None and entry.get("grant_type") != "device_code"
 
 
 def get_provider(label: str) -> dict:

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -943,3 +943,18 @@ class TestKimiDeviceFlow(_OAuthApiBase):
 			res = oauth_api.poll_pool_account_signin(nonce)
 		self.assertFalse(res["ok"])
 		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))  # terminal -> burned
+
+	def test_begin_paste_signin_rejects_device_provider(self):
+		# Review finding [2]: the DIRECT paste-back path must not KeyError on a
+		# device-code provider (no authorize URL) — it returns a clean error.
+		res = oauth_api.begin_paste_signin("Kimi (Moonshot)", "kimi-k2.7-code")
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "device_flow_required")
+
+	def test_complete_pool_rejects_device_nonce(self):
+		# Review finding [3]: a device nonce (no state/verifier) routed to
+		# complete_pool_account_signin must return unknown_nonce, not KeyError-500.
+		nonce = self._begin()["data"]["nonce"]
+		res = oauth_api.complete_pool_account_signin(nonce, "http://x/cb?code=A&state=B")
+		self.assertFalse(res["ok"])
+		self.assertEqual(res["error"]["code"], "unknown_nonce")

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -958,3 +958,37 @@ class TestKimiDeviceFlow(_OAuthApiBase):
 		res = oauth_api.complete_pool_account_signin(nonce, "http://x/cb?code=A&state=B")
 		self.assertFalse(res["ok"])
 		self.assertEqual(res["error"]["code"], "unknown_nonce")
+
+
+class TestXaiPoolCapture(_OAuthApiBase):
+	"""Phase 2: xAI pool capture reuses the paste-back flow, producing an openclaw
+	blob the fleet oauth_blob_to_cliproxy_xai transform consumes (provider='xai',
+	id_token retained)."""
+
+	def _seed_xai(self):
+		nonce = "nx_" + ("b" * 45)
+		frappe.cache.hset(_CACHE_KEY, nonce, {
+			"provider": "xAI Grok", "model": "grok-4.3", "status": "pending",
+			"expires_at_ts": int(time.time()) + 600,
+			"verifier": "vv", "state": "test-state",
+			"redirect_uri": "http://127.0.0.1:56121/callback",
+			"pool": True, "originator_user": frappe.session.user,
+		})
+		return nonce
+
+	def test_pool_capture_builds_xai_blob_with_id_token(self):
+		nonce = self._seed_xai()
+		with patch("jarvis.oauth.api._exchange_code", return_value={
+			"access_token": "XAT", "refresh_token": "XRT",
+			"id_token": _jwt({"email": "x@y.com"}), "expires_in": 3600, "email": "x@y.com",
+		}):
+			res = oauth_api.complete_pool_account_signin(
+				nonce, "http://127.0.0.1:56121/callback?code=CODE&state=test-state")
+		self.assertTrue(res["ok"])
+		d = res["data"]
+		self.assertTrue(d["account_ref"].startswith("SUB_"))
+		blob = json.loads(d["oauth_blob"])
+		self.assertEqual(blob["provider"], "xai")   # openclaw_provider
+		self.assertEqual(blob["access"], "XAT")
+		self.assertTrue(blob["id_token"])            # xai transform REQUIRES it
+		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))  # single-use

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -869,3 +869,77 @@ class TestGetDirectSubscriptionStatus(_OAuthApiBase):
 		settings.db_set("llm_auth_mode", "api_key", update_modified=False)
 		out = oauth_api.get_direct_subscription_status()
 		self.assertFalse(out["is_direct_subscription"])
+
+
+class _MockResp:
+	"""Minimal requests.Response stand-in for the device-flow HTTP mocks."""
+	def __init__(self, status, body, text=""):
+		self.status_code = status
+		self.ok = 200 <= status < 300
+		self._body = body
+		self.text = text or (json.dumps(body) if body is not None else "")
+	def json(self):
+		if self._body is None:
+			raise ValueError("no json")
+		return self._body
+
+
+class TestKimiDeviceFlow(_OAuthApiBase):
+	"""Phase 2: Kimi (Moonshot) device-code pool capture (begin + poll)."""
+
+	_DEV = {"device_code": "DC", "user_code": "ABCD-EFGH",
+	        "verification_uri": "https://www.kimi.com/device", "interval": 5, "expires_in": 900}
+
+	def _begin(self):
+		with patch("jarvis.oauth.api.requests.post", return_value=_MockResp(200, dict(self._DEV))):
+			return oauth_api.begin_pool_account_signin("Kimi (Moonshot)", "kimi-k2.7-code")
+
+	def test_begin_returns_device_flow_and_caches_device_code(self):
+		res = self._begin()
+		self.assertTrue(res["ok"])
+		d = res["data"]
+		self.assertTrue(d["device_flow"])
+		self.assertEqual(d["user_code"], "ABCD-EFGH")
+		self.assertTrue(d["nonce"])
+		# device_code is cached server-side, NOT returned to the browser
+		self.assertNotIn("device_code", d)
+		entry = frappe.cache.hget(_CACHE_KEY, d["nonce"])
+		self.assertEqual(entry["device_code"], "DC")
+		self.assertTrue(entry.get("pool") and entry.get("device"))
+
+	def test_poll_pending_keeps_nonce_alive(self):
+		nonce = self._begin()["data"]["nonce"]
+		with patch("jarvis.oauth.api.requests.post",
+		           return_value=_MockResp(400, {"error": "authorization_pending"})):
+			res = oauth_api.poll_pool_account_signin(nonce)
+		self.assertTrue(res["ok"])
+		self.assertEqual(res["data"]["status"], "pending")
+		self.assertIsNotNone(frappe.cache.hget(_CACHE_KEY, nonce))  # keep polling
+
+	def test_poll_success_returns_kimi_device_blob(self):
+		nonce = self._begin()["data"]["nonce"]
+		token = {"access_token": "KAT", "refresh_token": "KRT", "token_type": "Bearer",
+		         "scope": "kimi:coding", "expires_in": 3600}
+		with patch("jarvis.oauth.api.requests.post", return_value=_MockResp(200, token)):
+			res = oauth_api.poll_pool_account_signin(nonce)
+		self.assertTrue(res["ok"])
+		d = res["data"]
+		self.assertEqual(d["status"], "ok")
+		self.assertTrue(d["account_ref"].startswith("SUB_"))
+		blob = json.loads(d["oauth_blob"])
+		# openclaw blob shape the fleet oauth_blob_to_cliproxy_kimi transform consumes
+		self.assertEqual(blob["provider"], "kimi")
+		self.assertEqual(blob["access"], "KAT")
+		self.assertEqual(blob["refresh"], "KRT")
+		self.assertEqual(blob["scope"], "kimi:coding")
+		self.assertTrue(blob["device_id"])           # minted at begin
+		self.assertNotIn("id_token", blob)           # device flow has none
+		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))  # nonce consumed
+
+	def test_poll_expired_burns_nonce(self):
+		nonce = self._begin()["data"]["nonce"]
+		with patch("jarvis.oauth.api.requests.post",
+		           return_value=_MockResp(400, {"error": "expired_token"})):
+			res = oauth_api.poll_pool_account_signin(nonce)
+		self.assertFalse(res["ok"])
+		self.assertIsNone(frappe.cache.hget(_CACHE_KEY, nonce))  # terminal -> burned

--- a/jarvis/tests/test_oauth_providers.py
+++ b/jarvis/tests/test_oauth_providers.py
@@ -144,3 +144,47 @@ class TestBuildAuthorizeUrl(unittest.TestCase):
 		q = parse_qs(urlparse(url).query)
 		self.assertEqual(q["access_type"], ["offline"])
 		self.assertEqual(q["prompt"], ["consent"])
+
+
+class TestPhase2Providers(unittest.TestCase):
+	"""Phase 2: xAI (paste-back) + Kimi (device-code) provider metadata."""
+
+	def test_xai_authorize_url_has_nonce_and_pinned_redirect(self):
+		url = providers.build_authorize_url(
+			provider="xAI Grok", redirect_uri="http://ignored", code_challenge="CH",
+			state="ST", pool=True, oidc_nonce="NON")
+		q = parse_qs(urlparse(url).query)
+		self.assertEqual(urlparse(url).netloc, "auth.x.ai")
+		self.assertEqual(q["nonce"], ["NON"])
+		self.assertEqual(q["code_challenge_method"], ["S256"])
+		self.assertEqual(q["client_id"], ["b1a00492-073a-47ea-816f-4c329264a828"])
+		self.assertIn("grok-cli:access", q["scope"][0])
+
+	def test_openai_authorize_url_has_no_nonce(self):
+		# Only requires_nonce providers get a nonce; OpenAI must be unaffected.
+		url = providers.build_authorize_url(
+			provider="OpenAI", redirect_uri="R", code_challenge="C", state="S",
+			pool=True, oidc_nonce="N")
+		self.assertNotIn("nonce", parse_qs(urlparse(url).query))
+
+	def test_provider_redirect_uri_xai_pinned_openai_default(self):
+		self.assertEqual(providers.provider_redirect_uri("xAI Grok", "DEF"),
+		                 "http://127.0.0.1:56121/callback")
+		self.assertEqual(providers.provider_redirect_uri("OpenAI", "DEF"), "DEF")
+
+	def test_is_oauth_provider_excludes_device_code(self):
+		# Paste-back providers -> True; device-code (Kimi) -> False (no authorize URL).
+		self.assertTrue(providers.is_oauth_provider("OpenAI"))
+		self.assertTrue(providers.is_oauth_provider("xAI Grok"))
+		self.assertFalse(providers.is_oauth_provider("Kimi (Moonshot)"))
+		self.assertFalse(providers.is_oauth_provider("Anthropic"))
+
+	def test_kimi_is_device_code(self):
+		p = providers.get_provider("Kimi (Moonshot)")
+		self.assertEqual(p["grant_type"], "device_code")
+		self.assertEqual(p["openclaw_provider"], "kimi")
+		self.assertEqual(p["client_id"], "17e5f671-d194-4dfb-9706-5516cb48c098")
+		self.assertIn("device_authorization", p)
+
+	def test_xai_client_secret_empty_public_client(self):
+		self.assertEqual(providers.get_provider("xAI Grok")["client_secret"], "")


### PR DESCRIPTION
## Phase 2 — jarvis customer app (chat-subscription capture)

Adds **xAI Grok** and **Kimi (Moonshot)** as poolable chat subscriptions (BYO-only, routed
through the CLIProxyAPI sidecar). This is the customer-facing capture half of Phase 2.

**Merge order:** `llm-proxy` #8 (tag v0.3.0) → fleet #135 → admin #233 → this. Stacks after
Phase-1 jarvis **#319** (no file overlap — different functions/regions).

### xAI Grok — mirrors the existing paste-back flow (per your steer)
- New `_PROVIDER_OAUTH_MAP` entry (auth.x.ai, `requires_nonce`, pinned loopback
  `redirect_uri`) + `hooks.py` client id (public/PKCE — empty secret).
- `build_authorize_url` gains `oidc_nonce` (emitted **only** for `requires_nonce` providers;
  OpenAI/Google unaffected — pure-tested). `_begin_signin` resolves + caches a per-provider
  `redirect_uri` so `_exchange_code` re-sends the same value.
- No new UI — reuses the existing paste-back capture.

### Kimi (Moonshot) — new device-code flow (accepted trade-off)
- `grant_type: device_code` entry + `_begin_device_signin` (device_code + user_code) + new
  `poll_pool_account_signin` (polls until approval; returns the same capture-only
  `{account_ref, label, oauth_blob}`). Device blob has **no** `id_token`.
- `LlmPoolEditor.vue`: a device sub-view (user_code + verification link + poll) in both
  connect blocks; `upstreamOpts` + `SUB_MODEL_SUGGESTIONS` gain xai/kimi; **fixes** the
  hardcoded OpenAI/Google connect label.

### Also
`_subscription_models` catalogues (cliproxy-valid ids: `grok-4.3` not 4.5; `kimi-k2.7-code`)
+ `validate_models` upstream whitelist widened to `openai/google/xai/kimi`.

### Verification
- `build_authorize_url` / provider-map / redirect / nonce — **pure checks green**.
- `vite build` — **clean**.
- Device-flow **bench tests added** (begin / poll-pending / poll-success / expired) — run in CI.
- ⚠️ **Live device-flow UX (Kimi) needs post-deploy browser verification** — it can't run
  against a worktree.