### PR TITLE
feat(chat): reclaim idle sessions instead of archiving; reap & hide empty chats

### DIFF
--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -259,14 +259,6 @@ function applyRemoteRename(name, title) {
 	if (conv && title) conv.title = title
 }
 
-// The retention sweep (session_lifecycle) archived an idle conversation
-// server-side. Mirror the local removal so an open sidebar drops the row instead
-// of leaving a ghost that 404s on click; if it's the open chat, ChatView's store
-// watcher reacts to the removal.
-function applyRemoteExpired(name) {
-	conversations.value = conversations.value.filter((c) => c.name !== name)
-}
-
 let _remoteNewTimer = null
 function applyRemoteNew() {
 	if (_remoteNewTimer) return
@@ -328,7 +320,6 @@ const store = reactive({
 	toggleNotify,
 	syncSettingsFromServer,
 	applyRemoteRename,
-	applyRemoteExpired,
 	applyRemoteNew,
 	markUnread,
 	clearUnread,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3304,9 +3304,11 @@ async function newChat() {
 	resetRunState()
 	currentId.value = conv?.name || conv
 	messages.value = []
-	// Leaving a /c/:id URL on an old conversation would make its sidebar row
-	// unclickable (same-route push is a no-op) — reset to the chat home.
-	if (route.params.id) router.replace({ name: "Chat" })
+	// Reflect the new chat's own id in the URL (/c/:id) so it's refresh-persistent
+	// and shareable, instead of dropping to the id-less home. currentId already
+	// equals this id, so the route watcher no-ops (no redundant load), and it
+	// replaces any /c/:old-id so the previous conversation isn't stranded.
+	if (currentId.value) router.replace("/c/" + currentId.value)
 	await store.loadConversations()
 	// A genuinely-new chat may have just moved the server-side counter onto a
 	// multiple of three - re-probe, but never await it (must never block chat).
@@ -3424,7 +3426,6 @@ async function send(textArg) {
 	// itself and returns conversation_id — two fewer round-trips before the
 	// first message even leaves the browser. The sidebar refresh happens
 	// after the send resolves, off the critical path.
-	const isNewConv = !currentId.value
 	sending.value = true
 	waiting.value = true
 	stoppedRunId.value = null
@@ -3444,7 +3445,11 @@ async function send(textArg) {
 	await nextTick()
 	scrollBottom()
 	try {
-		const r = await api.sendMessage(currentId.value || "", text, undefined, attachments)
+		// The conversation we're sending FROM. The user may switch to another chat
+		// while this POST is in flight, so all post-send reconciliation gates on
+		// "still on the chat we sent from" — never yank them back to this one.
+		const sentFrom = currentId.value || ""
+		const r = await api.sendMessage(sentFrom, text, undefined, attachments)
 		if (r && r.ok === false) {
 			// The server rejected the send (e.g. the single-flight guard:
 			// "a reply is already in progress", or the monthly usage cap).
@@ -3463,10 +3468,21 @@ async function send(textArg) {
 			)
 			return
 		}
-		if (isNewConv && r?.conversation_id) {
-			// Adopt the server-created conversation so realtime events route to
-			// this thread, then refresh the sidebar without blocking anything.
-			currentId.value = r.conversation_id
+		if (r?.conversation_id && (currentId.value || "") === sentFrom) {
+			// Still on the chat we sent from — safe to reconcile it. Adopt the
+			// server's id when it differs (a brand-new chat that just got its id, or
+			// a stale/reaped conversation send_message fell back to a fresh one for),
+			// and keep the URL on it so a refresh doesn't restore a dead /c/:id
+			// (route.params.id outranks localStorage on boot).
+			if (r.conversation_id !== currentId.value) {
+				currentId.value = r.conversation_id
+				if (route.params.id !== r.conversation_id) router.replace("/c/" + r.conversation_id)
+			}
+			// Empties are hidden from the sidebar; surface the row now it has a message.
+			if (!store.conversations.some((c) => c.name === currentId.value)) store.loadConversations()
+		} else if (r?.conversation_id) {
+			// The user switched conversations mid-send: don't yank them back — just
+			// refresh the sidebar so the chat we sent into (now non-empty) surfaces.
 			store.loadConversations()
 		}
 	} catch (e) {
@@ -3506,13 +3522,6 @@ function onEvent(p) {
 	if (p.kind === "conversation:new" && p.conversation_id) {
 		store.applyRemoteNew()
 		proactiveToast.value = { id: p.conversation_id, title: p.title || "Message from Jarvis", preview: p.preview || "" }
-		return
-	}
-	// The retention sweep archived an idle conversation (session_lifecycle). Drop
-	// it from the sidebar; handled before the current-conversation guard so an open
-	// tab updates even if the user has since switched chats.
-	if (p.kind === "conversation:expired" && p.conversation_id) {
-		store.applyRemoteExpired(p.conversation_id)
 		return
 	}
 	// Macro-run events use `conversation` (not conversation_id) and are handled
@@ -4089,7 +4098,10 @@ function onResync() {
 	if (now - _lastResync < 2000) return // connect + visibility often co-fire
 	_lastResync = now
 	store.loadConversations()
-	loadConversation(currentId.value)
+	// Swallow a load failure for a conversation deleted mid-session: the
+	// store.conversations watcher above handles resetting a vanished persisted
+	// chat; here we just avoid an unhandled rejection on the dead id.
+	loadConversation(currentId.value).catch(() => {})
 }
 function onVisibility() {
 	if (document.visibilityState === "visible") onResync()
@@ -4125,6 +4137,12 @@ watch(
 	() => store.conversations,
 	(list) => {
 		if (booting.value || !currentId.value) return
+		// A fresh/unsent chat is intentionally hidden from the list — "hidden" is
+		// not "deleted", so don't reset it out from under the user. This covers an
+		// empty draft (no messages) AND the first send in flight (only optimistic
+		// `tmp-` rows exist, no persisted row in the list yet). Only fall back when
+		// a conversation that HAS persisted content vanished (archived/reaped).
+		if (sending.value || messages.value.every((m) => String(m.name).startsWith("tmp-"))) return
 		if (!list.some((c) => c.name === currentId.value)) {
 			currentId.value = null
 			messages.value = []
@@ -4193,7 +4211,19 @@ onMounted(async () => {
 			const first = route.params.id || (_storedValid ? _stored : null) || store.conversations[0]?.name
 			if (first) {
 				currentId.value = first
-				await loadConversation(first)
+				try {
+					await loadConversation(first)
+				} catch (e) {
+					// The URL/stored conversation is gone (a reaped empty, a cleared or
+					// externally-deleted chat) — don't let the unhandled rejection abort
+					// the rest of boot. Drop cleanly to the welcome state and forget the
+					// dead id. newChat() now mints /c/:id URLs whose empty targets are
+					// hard-deleted after EMPTY_GRACE_DAYS, so a stale bookmark is routine.
+					currentId.value = null
+					messages.value = []
+					try { localStorage.removeItem("jarvis-last-conv") } catch (_e) {}
+					if (route.params.id) router.replace({ name: "Chat" })
+				}
 			}
 		}
 	} finally {

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -90,10 +90,15 @@ def list_tools() -> list[str]:
 
 @frappe.whitelist()
 def list_conversations() -> list[dict]:
-	"""Return active conversations owned by the current user, newest first.
+	"""Return active, non-empty conversations owned by the current user, newest
+	first.
 
-	Each row includes ``message_count`` so the UI can identify empty
-	conversations (used by ``create_or_focus_empty``).
+	Empty conversations (a "New Chat" opened and abandoned with no message) are
+	hidden so a stray draft never lingers in the sidebar; it surfaces the moment
+	it gets its first message (the send path reloads this list). ``message_count``
+	is still returned for the UI, and is always >= 1 given the EXISTS filter.
+	``create_or_focus_empty`` queries the DB directly, so it still finds and
+	reuses the hidden empty row.
 	"""
 	require_jarvis_access()
 	# Chat page loaded: warm the openclaw prefix cache in the background
@@ -109,6 +114,10 @@ def list_conversations() -> list[dict]:
 		        WHERE m.conversation = c.name) AS message_count
 		FROM `tabJarvis Conversation` c
 		WHERE c.owner = %s AND c.status = 'Active'
+		  AND EXISTS (
+		    SELECT 1 FROM `tabJarvis Chat Message` m2
+		    WHERE m2.conversation = c.name
+		  )
 		ORDER BY c.starred DESC, c.last_active_at DESC
 		""",
 		(user,),
@@ -135,7 +144,12 @@ def search_conversations(search: str = "", start: int = 0, page_length: int = 20
 		pl = 20
 	pl = max(1, min(pl, 50))
 
-	conds = ["c.owner = %(me)s", "c.status = 'Active'"]
+	conds = [
+		"c.owner = %(me)s",
+		"c.status = 'Active'",
+		# Hide empty (message-less) drafts, mirroring list_conversations.
+		"EXISTS (SELECT 1 FROM `tabJarvis Chat Message` m WHERE m.conversation = c.name)",
+	]
 	params: dict = {"me": me, "start": start, "page_length": pl}
 	if search:
 		escaped = (search or "").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -429,14 +443,26 @@ def create_or_focus_empty() -> str:
 	"""
 	require_jarvis_access()
 	user = frappe.session.user
+	# Reuse only a genuine blank chat. A File-Box drop that failed to send
+	# (filebox.drop_file) leaves a 0-message file_box conversation with the
+	# uploaded File attached - reusing THAT as a "New Chat" would silently inherit
+	# the file_box confirm-card bypass (jarvis.api.call_tool auto-applies reversible
+	# writes on file_box convs) and adopt a stray File. Exclude both, mirroring
+	# session_lifecycle._reap_empty (which now spares such rows from reaping too).
 	empty = frappe.db.sql(
 		"""
 		SELECT c.name
 		FROM `tabJarvis Conversation` c
 		WHERE c.owner = %s AND c.status = 'Active'
+		  AND c.file_box = 0
 		  AND NOT EXISTS (
 		    SELECT 1 FROM `tabJarvis Chat Message` m
 		    WHERE m.conversation = c.name
+		  )
+		  AND NOT EXISTS (
+		    SELECT 1 FROM `tabFile` f
+		    WHERE f.attached_to_doctype = 'Jarvis Conversation'
+		      AND f.attached_to_name = c.name
 		  )
 		ORDER BY c.last_active_at DESC
 		LIMIT 1
@@ -444,6 +470,10 @@ def create_or_focus_empty() -> str:
 		(user,),
 	)
 	if empty:
+		# Focusing an existing empty as the target of a New Chat is activity: bump
+		# its idle clock so the empty-reaper (session_lifecycle._reap_empty) can't
+		# delete it out from under a tab the user just opened onto it.
+		frappe.db.set_value(CONV, empty[0][0], "last_active_at", frappe.utils.now())
 		return empty[0][0]
 	# Count only genuinely-new interactive chats toward the business-greeting
 	# cadence (every third new chat surfaces the card). Hooked here rather than
@@ -759,9 +789,11 @@ def send_message(
 	string as "leave the existing value alone".
 
 	Returns {ok: True, run_id, message_id, conversation_id} on success or
-	{ok: False, reason: str} on validation failure. Raises
-	frappe.DoesNotExistError if the conversation does not exist, or
-	frappe.PermissionError if the caller is not the owner.
+	{ok: False, reason: str} on validation failure. A human (non-delegated) send
+	whose ``conversation`` no longer exists falls back to a fresh empty
+	conversation (its id is returned as ``conversation_id``); a delegated/system
+	send instead raises frappe.DoesNotExistError. frappe.PermissionError if the
+	conversation belongs to another user.
 	"""
 	# Access gate (PART 1 TASK 1). send_message is ALSO invoked under
 	# impersonate(owner) by delegated/system flows (agent_scheduler, approvals
@@ -807,7 +839,22 @@ def send_message(
 	if (not message or not message.strip()) and not atts:
 		return {"ok": False, "reason": _("message is empty")}
 
-	conv_doc = _get_owned_conversation(conversation)
+	# A human (non-delegated) send whose conversation was reaped out from under a
+	# stale tab - an empty chat deleted by session_lifecycle's empty-reap, or a
+	# chat cleared elsewhere - would otherwise dead-end on DoesNotExistError with
+	# a Retry that loops on the gone id. Fall back to a fresh empty conversation
+	# so the message still lands; the new id is returned so the client re-targets.
+	# Delegated/system flows (agent_scheduler, approvals resume, File-Box drop)
+	# pass a real conversation and must surface a genuine not-found as an error -
+	# silently retargeting them would strand the message on a chat they don't
+	# track. PermissionError (someone else's conversation) always propagates.
+	try:
+		conv_doc = _get_owned_conversation(conversation)
+	except frappe.DoesNotExistError:
+		if _delegated:
+			raise
+		conversation = create_or_focus_empty()
+		conv_doc = _get_owned_conversation(conversation)
 
 	# Single-flight guard: reject a second concurrent turn on the same
 	# conversation (extra tab / double-send / a retry racing a live turn) -

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -1,48 +1,50 @@
-"""Session lifecycle Phase 1: dormant-session rotation + orphan sweep.
+"""Session lifecycle: idle-session reclaim + empty-chat + orphan sweeps.
 
-Every Jarvis Conversation maps to one openclaw session, created lazily on
-the first turn and - before this module - never rotated or deleted. Two
-kinds of gateway state accumulate forever:
+Every Jarvis Conversation maps to one openclaw session, created lazily on the
+first turn. Without a sweep, state accumulates forever:
 
-- Dormant conversation sessions: the user stopped chatting weeks ago but
-  the session (and its growing working context) sits on the container.
-- Orphaned throwaway sessions: every auto-title generation and every
-  prefix prewarm creates a single-use session, and deleted conversations
-  leave their sessions behind. The dev tenant had 81 session state files
-  after one month.
+- Dormant conversation sessions: the user stopped chatting weeks ago but the
+  session (and its growing working context) sits on the container.
+- Empty conversations: opening "New Chat" and closing the tab leaves a
+  0-message row cluttering history.
+- Orphaned throwaway sessions: every auto-title generation and every prefix
+  prewarm creates a single-use session, and deleted conversations leave their
+  sessions behind. The dev tenant had 81 session state files after one month.
 
-The bench is the durable owner of chat history (Jarvis Chat Message
-rows); the openclaw session is a cache of working context, not the
-record. Deleting one is safe: the gateway archives the transcript first
-(sessions.delete deleteTranscript=true default), canvas/media artifacts
-were pulled to ERP Files at turn end, and the next message in a rotated
-conversation lazily creates a fresh session through the existing
-``_ensure_session_key`` path - same UX, empty working context.
+The bench is the durable owner of chat history (Jarvis Chat Message rows); the
+openclaw session is a cache of working context, not the record. Deleting one is
+safe: the gateway archives the transcript first (sessions.delete
+deleteTranscript=true default), canvas/media artifacts were pulled to ERP Files
+at turn end, and the next message lazily creates a fresh session through the
+existing ``_ensure_session_key`` path - same UX, empty working context.
 
 The daily ``rotate_dormant_sessions`` cron:
 
-1. EXPIRE: conversations idle past the configured retention window
-   (Jarvis Settings.conversation_retention_days; 0 disables) and not
-   starred, with no in-flight rows -> free the openclaw session (delete
-   gateway session, clear ``conv.session_key``, drop ``Jarvis Chat
-   Session`` lookup rows) and, for still-``Active`` chats, archive them:
-   set ``status = Archived`` + ``auto_expired`` + ``expired_at`` and push
-   a ``conversation:expired`` realtime event so an open tab drops the row.
-   A reversible soft-delete - a separate follow-on purge permanently
-   deletes archived chats later. (Reason we don't hard-delete here: a
-   Jarvis Conversation is referenced by five doctypes + File blobs, so a
-   safe delete needs a full dependency cascade we keep out of the cron.)
-   Already user-archived chats that still hold a session are session-freed
-   only (no status change, no event) so their working context is reclaimed
-   too. Starred chats are fully exempt - kept, session and all.
-2. ORPHANS: gateway sessions in the chat namespace that no conversation
-   references (title/prewarm throwaways, deleted conversations) and that
-   have been inactive past ``ORPHAN_GRACE_HOURS`` -> delete, plus any
-   stale lookup rows.
+1. FREE IDLE SESSIONS: conversations idle past the configured retention window
+   (Jarvis Settings.conversation_retention_days; 0 disables) that still hold a
+   live openclaw session, with no in-flight rows -> free the session (delete the
+   gateway session, clear ``conv.session_key``, drop ``Jarvis Chat Session``
+   lookup rows). The conversation is LEFT ACTIVE AND VISIBLE - only the
+   container-side working memory is reclaimed. Returning to the chat lazily
+   mints a fresh session (full history, empty working context). Starred chats
+   are freed too: starring pins a chat in the list, it does not hold a session
+   hostage for a month of idleness.
+2. REAP EMPTY CHATS: Active, non-starred conversations with ZERO messages, idle
+   past ``EMPTY_GRACE_DAYS`` with nothing in-flight -> hard-delete the row. A
+   0-message chat has no messages / approvals / runs / files to cascade, so the
+   delete is trivial. This clears the "opened New Chat, closed the tab" ghost
+   (empty chats are also hidden from the sidebar list; this reaps the row so it
+   doesn't linger in the DB forever).
+3. ORPHANS: gateway sessions in the chat namespace that no conversation
+   references (title/prewarm throwaways, deleted conversations) and that have
+   been inactive past ``ORPHAN_GRACE_HOURS`` -> delete, plus any stale lookup
+   rows. Runs regardless of the retention setting - these are not user chats.
 
-Everything is best-effort on a dedicated connection (never the pool - a
-sweep must not contend with live turns), batch-capped so a backlog
-drains over days instead of stampeding a gateway, and managed-mode only.
+Parts 1 + 2 are the retention sweep and honour ``conversation_retention_days``
+(0 => keep everything, do nothing). Part 3 is pure gateway hygiene and always
+runs. Everything is best-effort on a dedicated connection (never the pool - a
+sweep must not contend with live turns), batch-capped so a backlog drains over
+days instead of stampeding a gateway, and managed-mode only.
 """
 from __future__ import annotations
 
@@ -57,15 +59,22 @@ CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 CHAT_SESSION = "Jarvis Chat Session"
 
-# Retention: a conversation idle this long is archived (hidden) and its
-# openclaw session freed. Configurable per-tenant via
-# Jarvis Settings.conversation_retention_days; these are the fallbacks a
-# reader applies. DEFAULT is used when the Single field is unset (Single
-# defaults are NOT backfilled on migrate, so None must read as 30, not 0 -
-# 0 means "keep forever"). MIN is a defensive floor mirroring the settings
-# validator, so a value that slipped in below it can't mass-archive.
+# Retention: a conversation idle this long has its openclaw session freed (its
+# working memory reclaimed). The conversation itself stays Active and visible.
+# Configurable per-tenant via Jarvis Settings.conversation_retention_days; these
+# are the fallbacks a reader applies. DEFAULT is used when the Single field is
+# unset (Single defaults are NOT backfilled on migrate, so None must read as 30,
+# not 0 - 0 means "keep forever / never free"). MIN is a defensive floor
+# mirroring the settings validator, so a value that slipped in below it can't
+# mass-free on the very next cron.
 DEFAULT_RETENTION_DAYS = 30
 MIN_RETENTION_DAYS = 7
+
+# An Active conversation with ZERO messages that has been idle this long is
+# hard-deleted (the abandoned "New Chat" ghost). Comfortably longer than any
+# realistic gap between opening a new chat and typing into it, so a chat the
+# user is about to use is never reaped out from under an open tab.
+EMPTY_GRACE_DAYS = 7
 
 
 def _retention_days() -> int:
@@ -93,7 +102,7 @@ def _retention_days() -> int:
 # created session_key has not committed yet.
 ORPHAN_GRACE_HOURS = 24
 
-# Per-run cap across BOTH parts, so a month of backlog drains over a few
+# Per-run cap across ALL parts, so a month of backlog drains over a few
 # days instead of hammering the gateway in one cron tick.
 BATCH_MAX = 25
 
@@ -103,10 +112,10 @@ _CHAT_NAMESPACE_MARKER = ":dashboard:"
 
 
 def rotate_dormant_sessions() -> dict:
-	"""Daily cron: archive conversations past the idle-retention window (freeing
-	their openclaw session) and reap orphaned throwaway sessions. Returns a
-	summary dict (also logged) so a manual ``bench execute`` run shows what
-	happened. (Name kept for the scheduler entry in hooks.py.)"""
+	"""Daily cron: free idle conversations' openclaw sessions, reap abandoned
+	empty chats, and reap orphaned throwaway sessions. Returns a summary dict
+	(also logged) so a manual ``bench execute`` run shows what happened. (Name
+	kept for the scheduler entry in hooks.py.)"""
 	from jarvis import selfhost
 
 	if selfhost.is_self_hosted():
@@ -120,7 +129,7 @@ def rotate_dormant_sessions() -> dict:
 
 	from jarvis.chat.openclaw_client import OpenclawSession
 
-	summary = {"archived": 0, "sessions_freed": 0, "orphans_reaped": 0, "skipped": 0, "errors": 0}
+	summary = {"sessions_freed": 0, "empty_reaped": 0, "orphans_reaped": 0, "skipped": 0, "errors": 0}
 	budget = BATCH_MAX
 	try:
 		sess = OpenclawSession.connect(gateway_url)
@@ -131,7 +140,13 @@ def rotate_dormant_sessions() -> dict:
 		)
 		return {"skipped": "connect failed"}
 	try:
-		budget = _expire_dormant(sess, budget, summary)
+		# Parts 1 + 2 are the retention sweep (0 = disabled, keep everything).
+		# Part 3 (orphans) is gateway hygiene and runs regardless.
+		days = _retention_days()
+		if days > 0:
+			budget = _free_idle_sessions(sess, budget, summary, days)
+			if budget > 0:
+				budget = _reap_empty(sess, budget, summary)
 		if budget > 0:
 			_reap_orphans(sess, budget, summary)
 	finally:
@@ -143,25 +158,20 @@ def rotate_dormant_sessions() -> dict:
 	return summary
 
 
-def _expire_dormant(sess, budget: int, summary: dict) -> int:
-	"""Part 1: conversations idle past the retention window. Frees the openclaw
-	session and archives still-``Active`` chats (marking ``auto_expired`` +
-	``expired_at`` and pushing a ``conversation:expired`` event); already
-	user-archived chats that still hold a session are session-freed only.
-	Starred chats are exempt entirely. Returns leftover budget for the orphan
-	sweep. Retention disabled (0) is a no-op that keeps the whole budget."""
-	days = _retention_days()
-	if days <= 0:
-		return budget  # retention disabled - keep chats forever
+def _free_idle_sessions(sess, budget: int, summary: dict, days: int) -> int:
+	"""Part 1: conversations idle past the retention window that still hold an
+	openclaw session -> free the session (delete gateway session, null
+	``session_key``, drop the lookup rows). The conversation is left Active and
+	visible; only the container-side working memory is reclaimed. Starred and
+	status are irrelevant here - any idle chat with a live session qualifies.
+	Returns leftover budget for the remaining sweeps."""
 	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-days)
 	rows = frappe.db.sql(
 		"""
-		SELECT c.name, c.owner, c.session_key, c.status
+		SELECT c.name, c.session_key
 		FROM `tabJarvis Conversation` c
-		WHERE c.starred = 0
+		WHERE c.session_key IS NOT NULL AND c.session_key != ''
 		  AND c.last_active_at IS NOT NULL AND c.last_active_at < %(cutoff)s
-		  AND (c.status = 'Active'
-		       OR (c.session_key IS NOT NULL AND c.session_key != ''))
 		  AND NOT EXISTS (
 			SELECT 1 FROM `tabJarvis Chat Message` m
 			WHERE m.conversation = c.name
@@ -173,7 +183,6 @@ def _expire_dormant(sess, budget: int, summary: dict) -> int:
 		{"cutoff": cutoff, "limit": budget},
 		as_dict=True,
 	)
-	now = frappe.utils.now_datetime()
 	for row in rows:
 		if budget <= 0:
 			break  # defensive; the SQL LIMIT already bounds rows to budget
@@ -183,40 +192,25 @@ def _expire_dormant(sess, budget: int, summary: dict) -> int:
 		# the local commit must not strand the sweep - the idempotent not-found
 		# handling in _delete_gateway_session lets the next run finish cleanup.
 		try:
-			has_session = bool(row.session_key)
 			# Free the openclaw session FIRST; only detach the bench side once
 			# the gateway side is gone, else a crash would strand a live session
 			# under a nulled key. A gateway-delete failure leaves the row intact
-			# for next run (do NOT archive it - archiving would hide it from the
-			# only sweep that re-selects it, stranding the session forever).
-			if has_session and not _delete_gateway_session(sess, row.session_key, summary):
-				# NOTE (follow-up): a row whose gateway delete PERMANENTLY fails is
-				# the oldest, so ORDER BY last_active_at ASC re-selects it at the
-				# front every run, consuming a batch slot; >= BATCH_MAX such corpses
-				# would starve healthy archiving. Inherited from the rotate sweep - a
-				# last_expire_error_at cooldown column is the planned guard.
+			# for the next run.
+			# KNOWN LIMITATION: a row whose gateway delete PERMANENTLY fails is the
+			# oldest, so ORDER BY last_active_at ASC re-selects it at the front every
+			# run, consuming a batch slot; >= BATCH_MAX such corpses would starve the
+			# empty-reap and orphan sweeps that run on the leftover budget. Planned
+			# guard: a last_free_error_at cooldown column. (Inherited from the prior
+			# rotate sweep.)
+			if not _delete_gateway_session(sess, row.session_key, summary):
 				continue
-			# Only Active chats transition to Archived; an already user-archived
-			# chat is session-freed only (its status/marker stay the user's).
-			archived = row.status == "Active"
-			updates = {}
-			if has_session:
-				# NULL, not "": session_key is UNIQUE and two "" rows collide.
-				updates["session_key"] = None
-			if archived:
-				updates.update({"status": "Archived", "auto_expired": 1, "expired_at": now})
-			# Conversation update before the lookup-row delete so a per-row
-			# failure at the primary (conversation) write skips cleanly with no
-			# partial detach (mirrors the original rotate ordering).
-			if updates:
-				frappe.db.set_value(CONV, row.name, updates)
-			if has_session:
-				frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
-				summary["sessions_freed"] += 1
+			# NULL, not "": session_key is UNIQUE and two "" rows collide. The
+			# conversation write lands before the lookup-row delete so a per-row
+			# failure at the primary write skips cleanly with no partial detach.
+			frappe.db.set_value(CONV, row.name, {"session_key": None})
+			frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
 			frappe.db.commit()
-			if archived:
-				summary["archived"] += 1
-				_notify_expired(row.name, row.owner)
+			summary["sessions_freed"] += 1
 		except Exception:
 			# Discard any partial write from this row (e.g. the conversation
 			# update landed but the lookup-row delete then failed) so it can't
@@ -224,26 +218,90 @@ def _expire_dormant(sess, budget: int, summary: dict) -> int:
 			# the next run finish cleanly. Rollback before log_error.
 			frappe.db.rollback()
 			frappe.log_error(
-				title="session_lifecycle: expire row failed",
+				title="session_lifecycle: free-session row failed",
 				message=f"conversation={row.name}\n{frappe.get_traceback()}",
 			)
 			summary["errors"] += 1
 	return budget
 
 
-def _notify_expired(conversation: str, owner: str) -> None:
-	"""Best-effort realtime nudge so an open tab drops the archived row instead
-	of showing a ghost that 404s on click. Never fatal to the sweep."""
-	try:
-		from jarvis.chat.events import publish_to_user
+def _reap_empty(sess, budget: int, summary: dict) -> int:
+	"""Part 2: hard-delete the abandoned "New Chat" ghost - an Active,
+	non-starred conversation with ZERO messages, idle past ``EMPTY_GRACE_DAYS``.
+	Such a row has no messages / approvals / runs / voice notes hanging off it,
+	so ``delete_doc(force)`` is a clean removal. A stray session is freed first,
+	defensively. Returns leftover budget for the orphan sweep.
 
-		publish_to_user(owner, {"kind": "conversation:expired", "conversation_id": conversation})
-	except Exception:
-		pass
+	Two exclusions guard against destroying real data via ``delete_doc``'s
+	cascade to attached Files (frappe ``remove_all`` on delete):
+	- ``file_box = 0``: a File-Box drop (``filebox.drop_file``) creates the
+	  conversation, attaches the uploaded File, and only THEN sends; a drop that
+	  fails (usage cap, paused sub) leaves a 0-message file_box conversation the
+	  user is meant to retry - reaping it would delete their uploaded file.
+	- no attached File of any kind, as belt-and-suspenders for the same cascade.
+	"""
+	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-EMPTY_GRACE_DAYS)
+	rows = frappe.db.sql(
+		"""
+		SELECT c.name, c.session_key
+		FROM `tabJarvis Conversation` c
+		WHERE c.status = 'Active'
+		  AND c.starred = 0
+		  AND c.file_box = 0
+		  AND c.last_active_at IS NOT NULL AND c.last_active_at < %(cutoff)s
+		  AND NOT EXISTS (
+			SELECT 1 FROM `tabJarvis Chat Message` m WHERE m.conversation = c.name
+		  )
+		  AND NOT EXISTS (
+			SELECT 1 FROM `tabFile` f
+			WHERE f.attached_to_doctype = 'Jarvis Conversation'
+			  AND f.attached_to_name = c.name
+		  )
+		ORDER BY c.last_active_at ASC
+		LIMIT %(limit)s
+		""",
+		{"cutoff": cutoff, "limit": budget},
+		as_dict=True,
+	)
+	for row in rows:
+		if budget <= 0:
+			break
+		budget -= 1
+		try:
+			# Re-check emptiness before the destructive delete: a user returning to
+			# a just-past-grace empty could have inserted their first message
+			# (committed by send_message) between the SELECT and here; deleting then
+			# would orphan that fresh message and kill the live turn. commit() first
+			# so this read opens a FRESH snapshot - under MariaDB's default
+			# REPEATABLE READ a read inside the batch-SELECT's transaction would
+			# still see the row as message-less. Nothing is pending to commit here
+			# (the prior row committed or rolled back at the end of its iteration).
+			frappe.db.commit()
+			if frappe.db.exists(MSG, {"conversation": row.name}):
+				continue
+			# A 0-message chat almost never holds a session (session_key is set
+			# on the first turn), but free one defensively so a hard delete never
+			# strands gateway state. A gateway-delete failure leaves the row for
+			# the next run rather than orphaning the session.
+			if row.session_key:
+				if not _delete_gateway_session(sess, row.session_key, summary):
+					continue
+				frappe.db.delete(CHAT_SESSION, {"session_key": row.session_key})
+			frappe.delete_doc(CONV, row.name, force=True, ignore_permissions=True)
+			frappe.db.commit()
+			summary["empty_reaped"] += 1
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(
+				title="session_lifecycle: empty reap failed",
+				message=f"conversation={row.name}\n{frappe.get_traceback()}",
+			)
+			summary["errors"] += 1
+	return budget
 
 
 def _reap_orphans(sess, budget: int, summary: dict) -> None:
-	"""Part 2: chat-namespace gateway sessions no conversation references
+	"""Part 3: chat-namespace gateway sessions no conversation references
 	(title/prewarm throwaways, deleted conversations), inactive past the
 	grace window and with no active run."""
 	try:

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -411,9 +411,9 @@
   {
    "fieldname": "conversation_retention_days",
    "fieldtype": "Int",
-   "label": "Auto-archive idle chats after (days)",
+   "label": "Reclaim idle chat memory after (days)",
    "default": "30",
-   "description": "A chat you have not opened for this many days is automatically archived (hidden from your list) and its agent working-memory freed. Starred chats are never touched. Minimum 7; set to 0 to keep chats forever. Default 30. Archived chats are retained (not destroyed) and recoverable by support; a separate purge permanently deletes them later. Readers treat an unset value as 30 (Single defaults are not backfilled on migrate)."
+   "description": "A chat you have not opened for this many days keeps its full history but has its agent working-memory (its openclaw session) reclaimed to free container resources. The chat stays in your list and resumes automatically on your next message, starting without the old working context. Chats with history are never deleted. Minimum 7; set to 0 to keep sessions forever (also disables cleanup of abandoned empty chats). Default 30. Readers treat an unset value as 30 (Single defaults are not backfilled on migrate)."
   },
   {
    "fieldname": "system_tab",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -191,18 +191,18 @@ class JarvisSettings(Document):
         self._validate_conversation_retention()
 
     def _validate_conversation_retention(self):
-        """Retention floor. The daily sweep archives idle chats past this many
-        days, so a fumbled tiny value would mass-archive on the very next cron
-        (the batch cap only spreads that over days). 0 disables (keep forever);
-        otherwise require >= 7. Unset is left untouched - readers default it to
-        30 (Single defaults are not backfilled on migrate)."""
+        """Retention floor. The daily sweep frees idle chats' openclaw sessions
+        past this many days, so a fumbled tiny value would mass-free on the very
+        next cron (the batch cap only spreads that over days). 0 disables (keep
+        sessions forever); otherwise require >= 7. Unset is left untouched -
+        readers default it to 30 (Single defaults are not backfilled on migrate)."""
         raw = getattr(self, "conversation_retention_days", None)
         if raw in (None, ""):
             return
         days = frappe.utils.cint(raw)
         if days != 0 and days < 7:
             frappe.throw(
-                "Auto-archive idle chats after must be 0 (never) or at least 7 days.",
+                "Reclaim idle chat memory after must be 0 (never) or at least 7 days.",
                 frappe.ValidationError,
             )
 

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -23,3 +23,4 @@ jarvis.patches.v1_0.revoke_jarvis_user_from_website_users
 jarvis.patches.v1_12_skill_scope_ladder
 jarvis.patches.v1_13_encrypt_plaintext_settings_passwords
 jarvis.patches.v1_14_remove_desk_workspaces
+jarvis.patches.v1_15_unarchive_auto_expired_conversations

--- a/jarvis/patches/v1_15_unarchive_auto_expired_conversations.py
+++ b/jarvis/patches/v1_15_unarchive_auto_expired_conversations.py
@@ -1,0 +1,34 @@
+"""Un-archive conversations the OLD idle sweep auto-archived.
+
+Before this change, session_lifecycle's daily sweep ARCHIVED a conversation
+idle past the retention window (status=Archived, auto_expired=1) and hid it from
+the sidebar, on the promise of a "separate follow-on purge" that was never
+built. The sweep now only frees the openclaw session and leaves the chat Active
+and visible (nothing is hidden or deleted for idleness). Conversations the old
+sweep already auto-archived would otherwise stay hidden forever with no way to
+resume them, contradicting the new "your chats stay in your list" contract.
+
+Restore them: flip the auto_expired=1 rows back to Active. Their session_key was
+already freed by the old sweep, so the next message lazily mints a fresh session
+(same as any idle chat now). Chats the USER archived by hand (auto_expired=0,
+status=Archived) are left untouched - that was their choice.
+
+Idempotent: after one run no auto_expired=1 row remains Archived.
+"""
+
+import frappe
+
+
+def execute():
+	# The auto_expired flag cleanly distinguishes system-archived (this sweep)
+	# from user-archived rows, so we only restore the ones the system hid. Also
+	# clear the now-dead auto_expired/expired_at markers on the restored rows: if
+	# the user later hand-archives one, it must not read as system-archived to any
+	# future purge keyed on that flag.
+	frappe.db.sql(
+		"""
+		UPDATE `tabJarvis Conversation`
+		SET status = 'Active', auto_expired = 0, expired_at = NULL
+		WHERE status = 'Archived' AND auto_expired = 1
+		"""
+	)

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -99,9 +99,19 @@ class TestListConversations(_ChatTestCase):
 		result = list_conversations()
 		self.assertEqual(result, [])
 
+	def _add_message(self, conversation, seq=1):
+		frappe.get_doc({
+			"doctype": MSG, "conversation": conversation, "seq": seq,
+			"role": "user", "content": "hi",
+		}).insert(ignore_permissions=True)
+		frappe.db.commit()
+
 	def test_returns_active_conversations_for_current_user_only(self):
 		a = create_conversation()
 		b = create_conversation()
+		# Only conversations with at least one message appear in the list.
+		self._add_message(a)
+		self._add_message(b)
 		result = list_conversations()
 		names = {c["name"] for c in result}
 		self.assertIn(a, names)
@@ -109,27 +119,31 @@ class TestListConversations(_ChatTestCase):
 
 	def test_excludes_archived_by_default(self):
 		a = create_conversation()
+		self._add_message(a)  # non-empty, so exclusion is due to archiving
 		archive_conversation(a)
 		result = list_conversations()
 		names = {c["name"] for c in result}
 		self.assertNotIn(a, names)
 
+	def test_hides_empty_conversations(self):
+		# A "New Chat" opened and abandoned (no message) never clutters the list;
+		# it surfaces once it has a message.
+		empty = create_conversation()
+		filled = create_conversation()
+		self._add_message(filled)
+		names = {c["name"] for c in list_conversations()}
+		self.assertNotIn(empty, names)
+		self.assertIn(filled, names)
+
 	def test_includes_message_count(self):
 		a = create_conversation()
 		b = create_conversation()
-		# Add one message to `a` only
-		frappe.get_doc({
-			"doctype": MSG,
-			"conversation": a,
-			"seq": 1,
-			"role": "user",
-			"content": "hi",
-		}).insert(ignore_permissions=True)
-		frappe.db.commit()
+		# Add one message to `a` only; `b` stays empty (and thus hidden).
+		self._add_message(a)
 
 		result = {c["name"]: c for c in list_conversations()}
 		self.assertEqual(result[a]["message_count"], 1)
-		self.assertEqual(result[b]["message_count"], 0)
+		self.assertNotIn(b, result)
 
 
 class TestCreateOrFocusEmpty(_ChatTestCase):
@@ -142,8 +156,9 @@ class TestCreateOrFocusEmpty(_ChatTestCase):
 		existing = create_conversation()
 		returned = create_or_focus_empty()
 		self.assertEqual(returned, existing)
-		# Only one conversation total
-		self.assertEqual(len(list_conversations()), 1)
+		# Reuse, not a duplicate: still exactly one conversation row for the user
+		# (it is empty, so it does not show in list_conversations).
+		self.assertEqual(frappe.db.count(CONV, {"owner": TEST_USER}), 1)
 
 	def test_creates_new_when_only_non_empty_exist(self):
 		filled = create_conversation()
@@ -158,10 +173,13 @@ class TestCreateOrFocusEmpty(_ChatTestCase):
 
 		returned = create_or_focus_empty()
 		self.assertNotEqual(returned, filled)
-		# A second conversation now exists, and it's empty
+		# A second (empty) conversation row now exists in the DB...
+		self.assertTrue(frappe.db.exists(CONV, returned))
+		self.assertEqual(frappe.db.count(CONV, {"owner": TEST_USER}), 2)
+		# ...but the list shows only the non-empty one (the new empty is hidden).
 		all_names = {c["name"] for c in list_conversations()}
 		self.assertIn(filled, all_names)
-		self.assertIn(returned, all_names)
+		self.assertNotIn(returned, all_names)
 
 	def test_prefers_most_recent_empty(self):
 		older = create_conversation()
@@ -170,6 +188,41 @@ class TestCreateOrFocusEmpty(_ChatTestCase):
 		newer = create_conversation()
 		returned = create_or_focus_empty()
 		self.assertEqual(returned, newer)
+
+	def test_reuse_bumps_last_active_at(self):
+		# Focusing an old empty resets its idle clock so the empty-reaper
+		# (session_lifecycle) can't delete it out from under a freshly-opened tab.
+		old = create_conversation()
+		frappe.db.set_value(CONV, old, "last_active_at", "2020-01-01 00:00:00")
+		returned = create_or_focus_empty()
+		self.assertEqual(returned, old)
+		bumped = frappe.utils.get_datetime(frappe.db.get_value(CONV, old, "last_active_at"))
+		self.assertGreater(bumped, frappe.utils.get_datetime("2020-06-01 00:00:00"))
+
+	def test_skips_filebox_drop_when_reusing_empty(self):
+		# A failed File-Box drop is a 0-message file_box conversation. Reusing it as
+		# a "New Chat" would silently inherit the file_box confirm-card bypass, so
+		# it must be skipped in favour of a genuinely blank chat.
+		fb = create_conversation()
+		frappe.db.set_value(CONV, fb, "file_box", 1)
+		frappe.db.commit()
+		returned = create_or_focus_empty()
+		self.assertNotEqual(returned, fb)
+		self.assertEqual(frappe.db.get_value(CONV, returned, "file_box"), 0)
+
+	def test_skips_empty_with_attached_file_when_reusing(self):
+		# Belt-and-suspenders: any empty carrying an attached File is skipped so a
+		# reuse never adopts a stray upload (delete-cascade / bypass concerns).
+		withfile = create_conversation()
+		f = frappe.get_doc({
+			"doctype": "File", "file_name": "coe-attach.txt",
+			"attached_to_doctype": CONV, "attached_to_name": withfile,
+			"content": "x", "is_private": 1,
+		}).insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc("File", f.name, force=True, ignore_permissions=True))
+		frappe.db.commit()
+		returned = create_or_focus_empty()
+		self.assertNotEqual(returned, withfile)
 
 
 class TestGetConversation(_ChatTestCase):
@@ -230,9 +283,28 @@ class TestSendMessage(_ChatTestCase):
 		self.assertFalse(result["ok"])
 		self.assertIn("empty", result["reason"].lower())
 
-	def test_rejects_unknown_conversation(self):
-		with self.assertRaises(frappe.DoesNotExistError):
-			send_message("JCONV-99999", "hi")
+	def test_human_send_to_missing_conversation_falls_back(self):
+		# A stale/reaped conversation id from a human send lands in a fresh chat
+		# instead of dead-ending on DoesNotExistError.
+		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"), \
+		     patch("frappe.enqueue"):
+			result = send_message("JCONV-99999", "hi")
+		self.assertTrue(result["ok"])
+		self.assertNotEqual(result["conversation_id"], "JCONV-99999")
+		self.assertTrue(frappe.db.exists(CONV, result["conversation_id"]))
+		# The message landed in the fallback conversation.
+		self.assertTrue(frappe.db.exists(
+			MSG, {"conversation": result["conversation_id"], "role": "user"}))
+
+	def test_delegated_send_to_missing_conversation_raises(self):
+		# Delegated/system flows pass a real conversation; a genuine not-found is
+		# a real error, never silently retargeted.
+		frappe.flags.jarvis_delegated_send = True
+		try:
+			with self.assertRaises(frappe.DoesNotExistError):
+				send_message("JCONV-99999", "hi")
+		finally:
+			frappe.flags.jarvis_delegated_send = False
 
 	def test_persists_user_message_and_enqueues_worker(self):
 		with patch("jarvis.chat.api._ensure_session_key", return_value="agent:fake"):

--- a/jarvis/tests/test_conversation_search.py
+++ b/jarvis/tests/test_conversation_search.py
@@ -75,6 +75,12 @@ def _mk_conv(owner: str, title: str, status: str = "Active", starred: int = 0,
 			"doctype": CONV, "title": title, "status": status, "starred": starred,
 		})
 		doc.insert(ignore_permissions=True)
+	# search_conversations hides message-less drafts, so give each fixture a
+	# message to keep it searchable (a real chat always has at least one).
+	frappe.get_doc({
+		"doctype": "Jarvis Chat Message", "conversation": doc.name, "seq": 1,
+		"role": "user", "content": "hi",
+	}).insert(ignore_permissions=True)
 	frappe.db.set_value(
 		CONV, doc.name, "last_active_at",
 		now_datetime() - timedelta(days=active_days_ago), update_modified=False,

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -1,12 +1,15 @@
-"""Tests for jarvis.chat.session_lifecycle (retention expiry + orphan sweep).
+"""Tests for jarvis.chat.session_lifecycle (idle-session reclaim + empty-chat
++ orphan sweeps).
 
-The daily cron archives conversations idle past the configurable retention
-window (Jarvis Settings.conversation_retention_days), freeing their openclaw
-session; starred and in-flight chats are exempt, and an already user-archived
-chat is session-freed only. The gateway is reached only through
-OpenclawSession.connect (a dedicated connection, never the pool), so tests
-patch ``connect`` with a fake session exposing list_sessions/delete_session/
-close. Conversations and messages are real rows on the test site.
+The daily cron (1) frees the openclaw session of conversations idle past the
+configurable retention window (Jarvis Settings.conversation_retention_days) -
+leaving the conversation Active and visible, only reclaiming its working memory;
+(2) hard-deletes Active, non-starred, zero-message chats idle past
+EMPTY_GRACE_DAYS (the abandoned "New Chat" ghost); and (3) reaps orphaned
+throwaway gateway sessions. The gateway is reached only through
+OpenclawSession.connect (a dedicated connection, never the pool), so tests patch
+``connect`` with a fake session exposing list_sessions/delete_session/close.
+Conversations and messages are real rows on the test site.
 """
 from __future__ import annotations
 
@@ -38,9 +41,9 @@ class TestSessionLifecycle(FrappeTestCase):
 	def setUp(self):
 		self._made = []
 		# The sweep is site-global. Neutralize every pre-existing candidate so
-		# only THIS test's fixtures are eligible: null all session_keys AND bump
-		# all conversations to "just active" (the archive path now also selects
-		# session-less idle Active chats, so parking keys alone is not enough).
+		# only THIS test's fixtures are eligible: null all session_keys (so no
+		# pre-existing row is session-freed) AND bump all last_active_at to now
+		# (so no pre-existing row is session-freed OR empty-reaped for idleness).
 		frappe.db.sql("UPDATE `tabJarvis Conversation` SET session_key = NULL")
 		frappe.db.sql(
 			"UPDATE `tabJarvis Conversation` SET last_active_at = %s",
@@ -55,11 +58,6 @@ class TestSessionLifecycle(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, None)
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		frappe.db.commit()
-		# Realtime is a best-effort nudge; mock it so tests are hermetic and can
-		# assert the conversation:expired push.
-		patcher = patch("jarvis.chat.events.publish_to_user")
-		self.pub = patcher.start()
-		self.addCleanup(patcher.stop)
 
 	def tearDown(self):
 		for name in self._made:
@@ -72,10 +70,17 @@ class TestSessionLifecycle(FrappeTestCase):
 		frappe.db.commit()
 
 	def _conv(self, *, session_key=None, idle_days, streaming=False,
-	          starred=0, status="Active"):
+	          starred=0, status="Active", has_message=False, file_box=0):
+		"""Insert a real conversation fixture.
+
+		``has_message`` gives it a normal completed message (so it is NOT an
+		empty-reap candidate - mirrors any real chat with history); ``streaming``
+		gives it an in-flight message; ``file_box`` marks it a File-Box drop; the
+		default is a truly empty 0-message chat.
+		"""
 		doc = frappe.get_doc({
 			"doctype": CONV, "title": f"lc-{session_key or idle_days}",
-			"starred": starred, "status": status,
+			"starred": starred, "status": status, "file_box": file_box,
 		}).insert(ignore_permissions=True)
 		self._made.append(doc.name)
 		fields = {"last_active_at": frappe.utils.add_to_date(
@@ -87,6 +92,11 @@ class TestSessionLifecycle(FrappeTestCase):
 			frappe.get_doc({
 				"doctype": MSG, "conversation": doc.name, "seq": 1,
 				"role": "assistant", "content": "", "streaming": 1,
+			}).insert(ignore_permissions=True)
+		elif has_message:
+			frappe.get_doc({
+				"doctype": MSG, "conversation": doc.name, "seq": 1,
+				"role": "user", "content": "hi",
 			}).insert(ignore_permissions=True)
 		if session_key:
 			frappe.get_doc({
@@ -120,130 +130,116 @@ class TestSessionLifecycle(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 3)
 		self.assertEqual(session_lifecycle._retention_days(), 7)
 
-	# ---- retention expiry (archive) ---------------------------------
+	# ---- free idle sessions -----------------------------------------
 
-	def test_dormant_active_with_session_is_archived_and_freed(self):
-		name = self._conv(session_key="test-lc-dormant", idle_days=40)
+	def test_idle_session_freed_not_archived(self):
+		name = self._conv(session_key="test-lc-dormant", idle_days=40, has_message=True)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 1)
 		self.assertEqual(summary["sessions_freed"], 1)
 		sess.delete_session.assert_any_call("test-lc-dormant")
-		self.assertEqual(self._get(name, "status"), "Archived")
-		self.assertEqual(self._get(name, "auto_expired"), 1)
-		self.assertTrue(self._get(name, "expired_at"))
+		# The conversation stays Active and visible - only the session is freed.
+		self.assertEqual(self._get(name, "status"), "Active")
 		self.assertFalse(self._get(name, "session_key"))
 		self.assertFalse(frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-dormant"}))
-		# The owner gets a conversation:expired nudge so an open tab drops the row.
-		self.pub.assert_called_once()
-		self.assertEqual(self.pub.call_args[0][1]["kind"], "conversation:expired")
-		self.assertEqual(self.pub.call_args[0][1]["conversation_id"], name)
+		self.assertTrue(frappe.db.exists(CONV, name))  # not deleted, not archived
 
-	def test_dormant_active_without_session_is_archived(self):
-		name = self._conv(idle_days=40)  # never had an agent turn
-		summary = self._run(_fake_sess())
-		self.assertEqual(summary["archived"], 1)
-		self.assertEqual(summary["sessions_freed"], 0)
-		self.assertEqual(self._get(name, "status"), "Archived")
-		self.assertEqual(self._get(name, "auto_expired"), 1)
-		self.pub.assert_called_once()
-
-	def test_starred_is_exempt(self):
-		name = self._conv(session_key="test-lc-star", idle_days=40, starred=1)
-		sess = _fake_sess()
-		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 0)
-		sess.delete_session.assert_not_called()
-		self.assertEqual(self._get(name, "status"), "Active")
-		self.assertEqual(self._get(name, "session_key"), "test-lc-star")  # kept, session and all
-		self.pub.assert_not_called()
-
-	def test_user_archived_with_session_is_freed_only(self):
-		name = self._conv(session_key="test-lc-uarch", idle_days=40, status="Archived")
+	def test_starred_idle_session_freed_too(self):
+		# Starred chats are NO LONGER exempt: starring pins the chat, it does not
+		# keep an idle session alive for a month.
+		name = self._conv(session_key="test-lc-star", idle_days=40, starred=1, has_message=True)
 		sess = _fake_sess()
 		summary = self._run(sess)
 		self.assertEqual(summary["sessions_freed"], 1)
-		self.assertEqual(summary["archived"], 0)          # already archived - not re-counted
-		sess.delete_session.assert_any_call("test-lc-uarch")
-		self.assertEqual(self._get(name, "status"), "Archived")
-		self.assertFalse(self._get(name, "session_key"))  # session reclaimed
-		self.assertEqual(self._get(name, "auto_expired"), 0)  # NOT a retention expiry
-		self.pub.assert_not_called()
+		sess.delete_session.assert_any_call("test-lc-star")
+		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertFalse(self._get(name, "session_key"))
 
-	def test_two_expiries_in_one_run_no_unique_collision(self):
-		"""Regression: session_key is UNIQUE; clearing to '' (instead of NULL)
-		collided on the SECOND expiry of a run (1062)."""
-		a = self._conv(session_key="test-lc-two-a", idle_days=40)
-		b = self._conv(session_key="test-lc-two-b", idle_days=41)
-		summary = self._run(_fake_sess())
-		self.assertEqual(summary["archived"], 2)
-		self.assertFalse(self._get(a, "session_key"))
-		self.assertFalse(self._get(b, "session_key"))
-
-	def test_fresh_conversation_untouched(self):
-		name = self._conv(session_key="test-lc-fresh", idle_days=2)
+	def test_idle_chat_without_session_untouched(self):
+		# No session to free + it has history -> the sweep leaves it entirely alone
+		# (visible, unchanged). This is the case that USED to be archived.
+		name = self._conv(idle_days=40, has_message=True)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 0)
+		self.assertEqual(summary["sessions_freed"], 0)
+		self.assertEqual(summary["empty_reaped"], 0)
 		sess.delete_session.assert_not_called()
 		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_fresh_session_untouched(self):
+		name = self._conv(session_key="test-lc-fresh", idle_days=2, has_message=True)
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["sessions_freed"], 0)
+		sess.delete_session.assert_not_called()
 		self.assertEqual(self._get(name, "session_key"), "test-lc-fresh")
 
-	def test_dormant_with_inflight_row_skipped(self):
+	def test_inflight_session_skipped(self):
 		name = self._conv(session_key="test-lc-busy", idle_days=40, streaming=True)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 0)
+		self.assertEqual(summary["sessions_freed"], 0)
 		sess.delete_session.assert_not_called()
-		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(self._get(name, "session_key"), "test-lc-busy")
 
 	def test_retention_disabled_is_noop(self):
 		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 0)
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		frappe.db.commit()
-		name = self._conv(session_key="test-lc-dis", idle_days=99)
+		# A chat that would be BOTH session-freed and empty-reaped under retention:
+		# disabled means neither runs.
+		with_sess = self._conv(session_key="test-lc-dis", idle_days=99, has_message=True)
+		empty = self._conv(idle_days=99)
 		sess = _fake_sess()
 		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 0)
+		self.assertEqual(summary["sessions_freed"], 0)
+		self.assertEqual(summary["empty_reaped"], 0)
 		sess.delete_session.assert_not_called()
-		self.assertEqual(self._get(name, "status"), "Active")
-		self.assertEqual(self._get(name, "session_key"), "test-lc-dis")
+		self.assertEqual(self._get(with_sess, "session_key"), "test-lc-dis")
+		self.assertTrue(frappe.db.exists(CONV, empty))
+
+	def test_two_frees_in_one_run_no_unique_collision(self):
+		"""Regression: session_key is UNIQUE; clearing to '' (instead of NULL)
+		collided on the SECOND free of a run (1062)."""
+		a = self._conv(session_key="test-lc-two-a", idle_days=40, has_message=True)
+		b = self._conv(session_key="test-lc-two-b", idle_days=41, has_message=True)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["sessions_freed"], 2)
+		self.assertFalse(self._get(a, "session_key"))
+		self.assertFalse(self._get(b, "session_key"))
 
 	def test_gateway_delete_failure_keeps_row_intact(self):
-		"""A failed sessions.delete must leave the conversation Active with its
-		session_key + lookup row so the next run retries - archiving it would
-		hide it from the only sweep that re-selects it."""
-		name = self._conv(session_key="test-lc-fail", idle_days=40)
+		"""A failed sessions.delete must leave the conversation with its
+		session_key + lookup row so the next run retries."""
+		name = self._conv(session_key="test-lc-fail", idle_days=40, has_message=True)
 		sess = _fake_sess()
 		sess.delete_session.side_effect = RuntimeError("gateway said no")
 		with patch("frappe.log_error"):
 			summary = self._run(sess)
-		self.assertEqual(summary["archived"], 0)
+		self.assertEqual(summary["sessions_freed"], 0)
 		self.assertEqual(summary["errors"], 1)
-		self.assertEqual(self._get(name, "status"), "Active")
 		self.assertEqual(self._get(name, "session_key"), "test-lc-fail")
 		self.assertTrue(frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-fail"}))
-		self.pub.assert_not_called()
 
 	def test_not_found_delete_treated_as_success(self):
 		"""Idempotent cleanup: a session already gone (a prior run crashed
-		between the gateway delete and the local commit) counts as deleted, so
-		the chat still archives instead of retry-failing forever."""
-		name = self._conv(session_key="test-lc-gone", idle_days=40)
+		between the gateway delete and the local commit) counts as freed, so the
+		bench pointers finally clear instead of retry-failing forever."""
+		name = self._conv(session_key="test-lc-gone", idle_days=40, has_message=True)
 		sess = _fake_sess()
 		sess.delete_session.side_effect = RuntimeError(
 			"gateway error: session not found: test-lc-gone")
 		summary = self._run(sess)
-		self.assertEqual(summary["archived"], 1)
+		self.assertEqual(summary["sessions_freed"], 1)
 		self.assertEqual(summary["errors"], 0)
-		self.assertEqual(self._get(name, "status"), "Archived")
 		self.assertFalse(self._get(name, "session_key"))
 
 	def test_one_bad_row_does_not_abort_the_batch(self):
 		"""Per-row isolation (turn_recovery's loop pattern): a bench-side write
 		failure on row 1 logs and continues to row 2."""
-		a = self._conv(session_key="test-lc-bad", idle_days=41)
-		b = self._conv(session_key="test-lc-good", idle_days=40)
+		a = self._conv(session_key="test-lc-bad", idle_days=41, has_message=True)
+		b = self._conv(session_key="test-lc-good", idle_days=40, has_message=True)
 		sess = _fake_sess()
 		real_set_value = frappe.db.set_value
 
@@ -255,17 +251,16 @@ class TestSessionLifecycle(FrappeTestCase):
 		with patch("frappe.db.set_value", side_effect=flaky_set_value), \
 		     patch("frappe.log_error") as log_err:
 			summary = self._run(sess)
-		self.assertEqual(summary["archived"], 1)
+		self.assertEqual(summary["sessions_freed"], 1)
 		self.assertEqual(summary["errors"], 1)
 		log_err.assert_called()
-		self.assertEqual(self._get(b, "status"), "Archived")
 		self.assertFalse(self._get(b, "session_key"))
 
-	def test_secondary_delete_failure_rolls_back_partial_archive(self):
+	def test_secondary_delete_failure_rolls_back_partial_free(self):
 		"""If the CHAT_SESSION lookup delete fails AFTER the conversation update
-		(same uncommitted row), the except rolls back so no half-archived state
-		(status=Archived + nulled key) rides to the next row's commit."""
-		name = self._conv(session_key="test-lc-partial", idle_days=40)
+		(same uncommitted row), the except rolls back so no half-freed state
+		(nulled key with a live gateway session) rides to the next row's commit."""
+		name = self._conv(session_key="test-lc-partial", idle_days=40, has_message=True)
 		sess = _fake_sess()
 		real_delete = frappe.db.delete
 
@@ -278,11 +273,96 @@ class TestSessionLifecycle(FrappeTestCase):
 		     patch("frappe.log_error"):
 			summary = self._run(sess)
 		self.assertEqual(summary["errors"], 1)
-		self.assertEqual(summary["archived"], 0)
-		# Rolled back: conversation stays Active with its key, not half-archived.
-		self.assertEqual(self._get(name, "status"), "Active")
+		self.assertEqual(summary["sessions_freed"], 0)
+		# Rolled back: the conversation keeps its key, not half-freed.
 		self.assertEqual(self._get(name, "session_key"), "test-lc-partial")
-		self.pub.assert_not_called()
+
+	# ---- reap empty chats -------------------------------------------
+
+	def test_empty_idle_chat_reaped(self):
+		name = self._conv(idle_days=10)  # 0 messages, idle > EMPTY_GRACE_DAYS
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 1)
+		self.assertFalse(frappe.db.exists(CONV, name))
+
+	def test_empty_recent_chat_kept(self):
+		name = self._conv(idle_days=2)  # inside the grace window
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_empty_starred_chat_kept(self):
+		name = self._conv(idle_days=10, starred=1)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_nonempty_idle_chat_not_reaped(self):
+		name = self._conv(idle_days=10, has_message=True)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_empty_chat_with_stray_session_freed_then_reaped(self):
+		"""Defensive: a 0-message chat carrying a session (idle within the 30-day
+		session window but past the 7-day empty window) has its stray session
+		freed, then the row is reaped."""
+		name = self._conv(session_key="test-lc-stray", idle_days=10)  # < 30, > 7
+		sess = _fake_sess()
+		summary = self._run(sess)
+		self.assertEqual(summary["sessions_freed"], 0)   # 10 days < 30-day session window
+		self.assertEqual(summary["empty_reaped"], 1)
+		sess.delete_session.assert_any_call("test-lc-stray")
+		self.assertFalse(frappe.db.exists(CONV, name))
+		self.assertFalse(frappe.db.exists(CHAT_SESSION, {"session_key": "test-lc-stray"}))
+
+	def test_streaming_chat_not_reaped_as_empty(self):
+		# There is no separate in-flight guard: a streaming row is still a MESSAGE,
+		# so the any-message EXISTS filter makes the chat non-empty and safe.
+		name = self._conv(idle_days=10, streaming=True)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_empty_filebox_drop_not_reaped(self):
+		# A File-Box drop that failed to send leaves a 0-message file_box chat with
+		# the user's uploaded File attached - reaping it would delete their file.
+		name = self._conv(idle_days=10, file_box=1)
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_empty_chat_with_attached_file_not_reaped(self):
+		# Belt-and-suspenders for delete_doc's cascade to attached Files: any chat
+		# with an attached File is spared regardless of the file_box flag.
+		name = self._conv(idle_days=10)
+		f = frappe.get_doc({
+			"doctype": "File", "file_name": "lc-attach.txt",
+			"attached_to_doctype": CONV, "attached_to_name": name,
+			"content": "x", "is_private": 1,
+		}).insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc("File", f.name, force=True, ignore_permissions=True))
+		frappe.db.commit()
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+
+	def test_empty_reap_rechecks_messages_before_delete(self):
+		"""TOCTOU guard: a first message landing between the SELECT and the delete
+		spares the row (the fresh message + live turn are not destroyed)."""
+		name = self._conv(idle_days=10)
+		real_exists = frappe.db.exists
+
+		def exists_with_race(dt, filt=None, *a, **k):
+			# Simulate a message committed for this conv after it was selected.
+			if dt == MSG and isinstance(filt, dict) and filt.get("conversation") == name:
+				return "MSG-raced"
+			return real_exists(dt, filt, *a, **k)
+
+		with patch("frappe.db.exists", side_effect=exists_with_race):
+			summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
 
 	# ---- orphan sweep -----------------------------------------------
 
@@ -296,7 +376,7 @@ class TestSessionLifecycle(FrappeTestCase):
 		sess.delete_session.assert_any_call("test-lc-orph:dashboard:o1")
 
 	def test_referenced_session_never_reaped(self):
-		self._conv(session_key="test-lc-ref:dashboard:live-1", idle_days=2)
+		self._conv(session_key="test-lc-ref:dashboard:live-1", idle_days=2, has_message=True)
 		sess = _fake_sess(entries=[{
 			"key": "test-lc-ref:dashboard:live-1",
 			"hasActiveRun": False, "updatedAt": OLD_MS,
@@ -325,7 +405,7 @@ class TestSessionLifecycle(FrappeTestCase):
 
 	def test_batch_cap_bounds_total_work(self):
 		for i in range(3):
-			self._conv(session_key=f"test-lc-batch-{i}", idle_days=40)
+			self._conv(session_key=f"test-lc-batch-{i}", idle_days=40, has_message=True)
 		entries = [{
 			"key": f"test-lc-orph:dashboard:b{i}",
 			"hasActiveRun": False, "updatedAt": OLD_MS,
@@ -333,8 +413,9 @@ class TestSessionLifecycle(FrappeTestCase):
 		sess = _fake_sess(entries=entries)
 		with patch.object(session_lifecycle, "BATCH_MAX", 4):
 			summary = self._run(sess)
-		# 3 expiries + only 1 orphan fit in the budget of 4.
-		self.assertEqual(summary["archived"], 3)
+		# 3 session frees + only 1 orphan fit in the budget of 4.
+		self.assertEqual(summary["sessions_freed"], 3)
+		self.assertEqual(summary["empty_reaped"], 0)
 		self.assertEqual(summary["orphans_reaped"], 1)
 		self.assertEqual(sess.delete_session.call_count, 4)
 
@@ -350,7 +431,7 @@ class TestSessionLifecycle(FrappeTestCase):
 		connect.assert_not_called()
 
 	def test_connect_failure_is_a_clean_skip(self):
-		self._conv(session_key="test-lc-x", idle_days=40)
+		self._conv(session_key="test-lc-x", idle_days=40, has_message=True)
 		with patch(
 			"jarvis.chat.openclaw_client.OpenclawSession.connect",
 			side_effect=RuntimeError("refused"),
@@ -362,7 +443,7 @@ class TestSessionLifecycle(FrappeTestCase):
 
 class TestRetentionSettingValidation(FrappeTestCase):
 	"""The floor lives in the Jarvis Settings controller so a fumbled tiny value
-	can't be saved and mass-archive on the next cron. 0 (never) and unset are
+	can't be saved and mass-free on the next cron. 0 (never) and unset are
 	always allowed; anything 1-6 is rejected."""
 
 	def _validate(self, val):
@@ -375,7 +456,7 @@ class TestRetentionSettingValidation(FrappeTestCase):
 			self._validate(3)
 
 	def test_zero_is_allowed(self):
-		self._validate(0)  # never-delete sentinel
+		self._validate(0)  # never-free sentinel
 
 	def test_seven_is_allowed(self):
 		self._validate(7)

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -171,6 +171,16 @@ class TestOnUpdateAdminDispatch(_SettingsSnapshotTestCase):
 		self.settings.db_set("llm_base_url", "https://api.anthropic.com")
 		self.settings.db_set("llm_api_key", "sk-original")
 		frappe.db.commit()
+		# Finish the isolation hardening #300 started: the restart-vs-reload
+		# classifier (_classify_llm_change) compares the new provider/model/
+		# base_url against get_doc_before_save(), which loads through the
+		# single-doc cache. A prior test can leave that cache holding the exact
+		# OpenAI/gpt-4o values test_admin_path_restart switches TO, so the change
+		# reads as "no structural change" → misclassified "reload" → the unmocked
+		# post_rotate_llm_secret → "admin unreachable" (order-dependent flake).
+		# Clear the cache so the before-save baseline is the Anthropic state just
+		# committed above.
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 	def _save_with_new_api_key(self, new_key="sk-new"):
 		# Re-fetch + change llm_api_key, then save (triggers on_update).


### PR DESCRIPTION
## Problem
The daily session-lifecycle sweep **archived** idle conversations (hiding them from the sidebar) on the promise of a follow-on purge that was never built, so idle chats silently vanished. Separately, an abandoned "New Chat" (opened, never sent) lingered as a ghost row in history.

## What this does
- **Idle sweep → session-reclaim only.** At the retention window (`conversation_retention_days`, 30d default; `0` disables) the sweep now frees **only** the openclaw session (gateway session + `session_key` + lookup rows) for every idle chat **incl. starred**. The chat stays Active and visible and resumes with a fresh session on the next message. Setting relabeled ("Reclaim idle chat memory after").
- **Empty chats** are hidden from the sidebar list + search, and hard-deleted after **7** idle days. Failed **File-Box drops** (0-message, `file_box=1`, File attached) are spared from **both** the reap and `create_or_focus_empty` reuse — they carry the confirm-card bypass and an uploaded file.
- **`send_message`** falls back to a fresh chat when a **human** send targets a reaped/cleared conversation; **delegated** sends still raise.
- **SPA routing:** New Chat puts its id in the URL (`/c/:id`, refresh-persistent); the send adopts a re-targeted conversation **without yanking a mid-send chat switch**; the conversations watcher no longer resets a hidden empty draft; a dead `/c/:id` drops cleanly to welcome.
- **Migration `v1_15`** un-archives chats the old sweep auto-archived (`auto_expired=1`) so they reappear, matching the new "chats stay in your list" contract (clears the dead `auto_expired`/`expired_at` markers too).

## Review
Three adversarial **Fable** passes — surfaced & fixed: File-Box data-loss on reap/reuse, a mid-send-switch regression, an ineffective TOCTOU re-check (REPEATABLE READ), and the migration flag-clearing.

## Verification
- `test_session_lifecycle` (33), `test_chat_api` (57+5), `test_conversation_search` (9) — all green on `jarvis-test.localhost`.
- SPA builds clean; migration executes clean.
- ⚠️ Frontend routing/send flows have **no test harness** — wants a browser smoke-test: New Chat → `/c/:id`; refresh persists; first message surfaces the row; **send in A, switch to B mid-send → stays on B**; dead URL → welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)