### PR TITLE
fix(ai-models): show per-model health for api-key failover rows

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -521,6 +521,7 @@ import * as api from "@/api"
 import {
   deriveMode, reorder, presetToModels, missingVendorKeys, validatePool,
   PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig, defaultSubscriptionModel,
+  apiKeyModelHealth,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
 import { useConfirm } from "@/composables/useConfirm"
@@ -559,7 +560,7 @@ const selectedPreset = ref("")
 const keysByVendor = ref({})
 const err = ref("")
 const saving = ref(false)
-const sync = ref({ last_sync_status: "", pending: false, subscription_status: "", warnings: [] })
+const sync = ref({ last_sync_status: "", pending: false, subscription_status: "", warnings: [], model_statuses: [] })
 const savedSnapshot = ref("__init__")  // savable pool as of last load/save; drives the unsaved-changes notice
 let pollTimer = null
 
@@ -1002,24 +1003,28 @@ function accountLabel(a) {
 function firstWarningMessage() {
   return (sync.value.warnings && sync.value.warnings[0] && sync.value.warnings[0].message) || ""
 }
-// Option A "honest model health": the connected-account dot + label for a model
-// row. Subscriptions reflect the fleet's last subscription-probe result;
-// api-key rows stay a quiet green (a saved key is validated at save time, not
-// probed live). Onboarding (singleMode) never shows this - always neutral.
+// Honest model health: the connected-account dot + label for a model row.
+// Subscriptions reflect the fleet's last (pool-wide) subscription-probe result;
+// api-key rows reflect their own per-model verdict from the last apply
+// (contract 1.11 model_statuses). Onboarding (singleMode) never shows this - always neutral.
 function accountHealth(m) {
   if (singleMode.value) return { level: "neutral" }
-  if (!m || m.credentialType !== "subscription") return { level: "ok" }
+  if (!m) return { level: "ok" }
   // Config changed but not yet (re)applied - the last probe result no longer
   // describes what's about to be saved, so don't assert a stale health.
   if (dirty.value || sync.value.pending) return { level: "neutral" }
+  // api-key rows carry a PER-MODEL verdict (contract 1.11 model_statuses), probed in
+  // isolation, so each shows its own health instead of the presence-only "key set" that
+  // once made a dead model look identical to a healthy one.
+  if (m.credentialType !== "subscription") {
+    return apiKeyModelHealth(m, sync.value.model_statuses)
+  }
   // sync.subscription_status is POOL-WIDE, not per-row: the fleet probes the pool's
   // subscription credential and returns ONE verdict. Painting it on every subscription
   // row is only honest when there is exactly one -- with two, a single "unverified"
   // would flag the healthy row too, and a "verified" would vouch for a row that was
   // never probed. Attribute it only when it can only mean this row; otherwise stay
   // neutral rather than assert something we did not measure.
-  // (The fleet gained per-model verdicts in contract 1.11 -- once model_statuses is
-  // plumbed through admin -> customer, key off that and drop this guard.)
   const subRows = rows.value.filter((r) => r.credentialType === "subscription")
   if (subRows.length > 1) return { level: "neutral" }
   const status = sync.value.subscription_status

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -135,3 +135,46 @@ export function seedRowsFromConfig(cfg) {
       credentialType: "api_key", rotation: "sticky", accounts: [], order: i }
   })
 }
+
+// The fleet's last per-model probe verdict for ONE api-key row, matched out of the
+// model_statuses list (contract 1.11: [{ provider, model, status }], api-key models only).
+// Matches on model id, disambiguating a model-id collision (validate() allows the same
+// model id under two providers) by provider. Rows carry the provider LABEL while
+// model_statuses carry the id, so normalize the row's provider back to an id to compare.
+// Returns "" when the row has no verdict (a pre-1.11 fleet, or a model not yet probed).
+function modelVerdict(row, modelStatuses) {
+  if (!row || !Array.isArray(modelStatuses)) return ""
+  const byModel = modelStatuses.filter((e) => e && e.model === row.model)
+  if (byModel.length === 0) return ""
+  if (byModel.length === 1) return byModel[0].status || ""
+  const rid = providerId(row.provider)
+  const exact = byModel.find((e) => e.provider === rid)
+  return (exact && exact.status) || ""
+}
+
+// Map an api-key pool row to its health for the failover list. Unlike a subscription
+// (probed pool-wide), an api-key model is probed in isolation, so its row shows its OWN
+// verdict instead of the presence-only "key set" that used to make a dead model look
+// identical to a healthy one.
+//   failed    -> warn      : rejected (bad key/model id) OR an unreachable base_url
+//   unchecked -> unchecked : could not confirm; re-checked on the next apply
+//   verified / "" / unknown -> ok (quiet green; "" = pre-1.11 fleet or a not-yet-probed row)
+export function apiKeyModelHealth(row, modelStatuses) {
+  const status = modelVerdict(row, modelStatuses)
+  if (status === "failed") {
+    return {
+      level: "warn",
+      label: "Not working",
+      title: "This model failed a test request — check its API key, model id, and base URL. "
+        + "It's skipped during failover until it passes.",
+    }
+  }
+  if (status === "unchecked") {
+    return {
+      level: "unchecked",
+      label: "Not verified yet",
+      title: "We couldn't confirm this model — it will be re-checked on the next apply.",
+    }
+  }
+  return { level: "ok" }
+}

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -138,18 +138,17 @@ export function seedRowsFromConfig(cfg) {
 
 // The fleet's last per-model probe verdict for ONE api-key row, matched out of the
 // model_statuses list (contract 1.11: [{ provider, model, status }], api-key models only).
-// Matches on model id, disambiguating a model-id collision (validate() allows the same
-// model id under two providers) by provider. Rows carry the provider LABEL while
-// model_statuses carry the id, so normalize the row's provider back to an id to compare.
-// Returns "" when the row has no verdict (a pre-1.11 fleet, or a model not yet probed).
+// The match keys on (provider, model) TOGETHER: a model id is NOT unique -- validate() only
+// forbids duplicate provider/model PAIRS, so the same id can appear under two providers, and
+// keying on the id alone would attach one provider's verdict to the other's row. Rows carry
+// the provider LABEL while model_statuses carry the id, so normalize the row's provider back
+// to an id to compare. Returns "" when the row has no matching verdict (a pre-1.11 fleet, a
+// model not yet probed, or an entry that belongs to a different provider).
 function modelVerdict(row, modelStatuses) {
   if (!row || !Array.isArray(modelStatuses)) return ""
-  const byModel = modelStatuses.filter((e) => e && e.model === row.model)
-  if (byModel.length === 0) return ""
-  if (byModel.length === 1) return byModel[0].status || ""
   const rid = providerId(row.provider)
-  const exact = byModel.find((e) => e.provider === rid)
-  return (exact && exact.status) || ""
+  const entry = modelStatuses.find((e) => e && e.model === row.model && e.provider === rid)
+  return (entry && entry.status) || ""
 }
 
 // Map an api-key pool row to its health for the failover list. Unlike a subscription

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict"
 import { deriveMode, uniqueVendors, missingVendorKeys, presetToModels, buildCustomModels, reorder, validatePool } from "./pool.js"
 import { PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig } from "./pool.js"
 import { defaultSubscriptionModel } from "./pool.js"
+import { apiKeyModelHealth } from "./pool.js"
 
 test("defaultSubscriptionModel: per-upstream default, openai fallback", () => {
   assert.equal(defaultSubscriptionModel("openai"), "gpt-5.5")
@@ -166,4 +167,53 @@ test("seedRowsFromConfig: real get_llm_config shape - subscription model (flat r
   assert.equal(row.accounts.length, 1)
   assert.equal(row.accounts[0].connected, true)
   assert.equal(row.accounts[0].account_ref, "SUB_x")
+})
+
+// ---- apiKeyModelHealth: per-row health from the fleet's model_statuses (contract 1.11) ----
+// Before this, api-key rows were hardcoded to a green dot + presence-only "key set", so a
+// model with a dead base_url / bad key showed identically to a healthy one. These pin that a
+// per-model verdict now drives the row.
+
+const _apiRow = (over = {}) => ({ credentialType: "api_key", provider: providerLabel("openai_compat"),
+  model: "claude-sonnet-4-6", hasKey: true, ...over })
+
+test("apiKeyModelHealth: a failed model surfaces a warn state with actionable title", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "failed" }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.equal(h.level, "warn")
+  assert.ok(h.label, "a failed row must carry a label, not just a bare dot")
+  assert.match(h.title, /base URL|API key|model id/i)
+})
+
+test("apiKeyModelHealth: verified is a MEANINGFUL green (ok, no label)", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "verified" }]
+  assert.deepEqual(apiKeyModelHealth(_apiRow(), ms), { level: "ok" })
+})
+
+test("apiKeyModelHealth: unchecked reads as a neutral 'not verified yet'", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "unchecked" }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.equal(h.level, "unchecked")
+  assert.ok(h.label)
+})
+
+test("apiKeyModelHealth: no verdict for the row -> quiet green (pre-1.11 fleet / not probed)", () => {
+  assert.deepEqual(apiKeyModelHealth(_apiRow(), []), { level: "ok" })
+  assert.deepEqual(apiKeyModelHealth(_apiRow(), undefined), { level: "ok" })
+  assert.deepEqual(
+    apiKeyModelHealth(_apiRow(), [{ provider: "x", model: "other", status: "failed" }]),
+    { level: "ok" },
+  )
+})
+
+test("apiKeyModelHealth: a model-id collision is disambiguated by provider", () => {
+  // validate() allows the same model id under two providers (only provider/model PAIRS
+  // must be unique), so the verdict must attach to the RIGHT row. Rows store the provider
+  // LABEL, model_statuses store the id -> the match must normalize.
+  const ms = [
+    { provider: "openai", model: "gpt-4o", status: "verified" },
+    { provider: "openai_compat", model: "gpt-4o", status: "failed" },
+  ]
+  assert.equal(apiKeyModelHealth(_apiRow({ provider: providerLabel("openai_compat"), model: "gpt-4o" }), ms).level, "warn")
+  assert.equal(apiKeyModelHealth(_apiRow({ provider: providerLabel("openai"), model: "gpt-4o" }), ms).level, "ok")
 })

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -217,3 +217,15 @@ test("apiKeyModelHealth: a model-id collision is disambiguated by provider", () 
   assert.equal(apiKeyModelHealth(_apiRow({ provider: providerLabel("openai_compat"), model: "gpt-4o" }), ms).level, "warn")
   assert.equal(apiKeyModelHealth(_apiRow({ provider: providerLabel("openai"), model: "gpt-4o" }), ms).level, "ok")
 })
+
+test("apiKeyModelHealth: a SINGLE entry under a DIFFERENT provider is not misattributed", () => {
+  // Only one model_statuses entry carries this model id, but it belongs to another
+  // provider than the row. The row was never probed under its own provider, so it must
+  // stay quiet green -- NOT inherit the other provider's 'failed'. (Model id is not a key:
+  // validate() only forbids duplicate provider/model PAIRS.)
+  const ms = [{ provider: "openai_compat", model: "gpt-4o", status: "failed" }]
+  assert.deepEqual(
+    apiKeyModelHealth(_apiRow({ provider: providerLabel("openai"), model: "gpt-4o" }), ms),
+    { level: "ok" },
+  )
+})

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -84,6 +84,7 @@
   "llm_pool_synced_at",
   "last_subscription_status",
   "last_sync_warnings",
+  "last_model_statuses",
   "custom_skills_synced_at",
   "custom_skills_sync_status",
   "agent_skills_synced_at",
@@ -623,6 +624,14 @@
    "fieldtype": "Long Text",
    "hidden": 1,
    "label": "Last Sync Warnings",
+   "read_only": 1
+  },
+  {
+   "description": "JSON array of {provider, model, status} per-model verdicts from the last pool apply (status: verified | failed | unchecked; api-key models only). '[]' when none or on a pre-1.11 fleet. Backend-only - the SPA reads this via get_llm_sync_status to render each api-key row's health, not the form.",
+   "fieldname": "last_model_statuses",
+   "fieldtype": "Long Text",
+   "hidden": 1,
+   "label": "Last Model Statuses",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -839,7 +839,11 @@ def _cleared_subscription_status_fields() -> dict:
     last real apply is still the truth (the pre-enqueue redundant-sync skip,
     or the run-time "no longer proxy-valid" skip - neither one touched the
     container, so whatever it's currently running is unchanged)."""
-    return {"last_subscription_status": "", "last_sync_warnings": "[]"}
+    return {
+        "last_subscription_status": "",
+        "last_sync_warnings": "[]",
+        "last_model_statuses": "[]",
+    }
 
 
 def _post_pool_with_retry(spec, api_keys, oauth_blobs):
@@ -1008,6 +1012,12 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
             if not result.get("unchanged"):
                 _synced["last_subscription_status"] = str(result.get("subscription_status") or "")
                 _synced["last_sync_warnings"] = _frappe.as_json(result.get("warnings") or [])
+                # Per-model verdicts (contract 1.11: [{provider, model, status}], api-key
+                # models only) ride the SAME PUT response. The AI-models list keys each
+                # api-key row's health off this; without persisting it a dead model shows
+                # the same green "key set" as a healthy one. Same no-op reasoning as the two
+                # fields above: a "unchanged" apply ran no probe, so leave the prior verdicts.
+                _synced["last_model_statuses"] = _frappe.as_json(result.get("model_statuses") or [])
             settings.db_set(_synced)
             # last_sync_status MUST keep starting with the literal "ok" -
             # _pool_sync_is_redundant() gates its dedup skip on

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -596,25 +596,36 @@ def get_llm_sync_status() -> dict:
 	    ``""`` if the pool sync worker never wrote one - e.g. no pool sync
 	    has run yet, or the fleet is on a pre-warnings contract), and
 	    ``warnings`` - a list of ``{"code": str, "message": str}`` dicts
-	    from the last pool apply (empty list when none). A corrupt/empty
-	    stored ``last_sync_warnings`` value degrades to ``[]`` rather than
-	    ever 500ing this poller.
+	    from the last pool apply (empty list when none), and
+	    ``model_statuses`` - a list of ``{"provider", "model", "status"}``
+	    per-model verdicts (``status`` one of ``verified``/``failed``/
+	    ``unchecked``; api-key models only) the AI-models list keys each
+	    api-key row's health off. A corrupt/empty stored value for either
+	    list degrades to ``[]`` rather than ever 500ing this poller.
 	"""
 	s = frappe.get_single("Jarvis Settings")
 	status = s.get("last_sync_status") or ""
-	raw_warnings = s.get("last_sync_warnings") or "[]"
-	try:
-		warnings = json.loads(raw_warnings)
-		if not isinstance(warnings, list):
-			warnings = []
-	except (ValueError, TypeError):
-		warnings = []
+
+	def _json_list(raw):
+		"""Stored JSON text -> list, degrading a corrupt/empty value to [] rather than
+		ever 500ing this poller."""
+		try:
+			val = json.loads(raw or "[]")
+			return val if isinstance(val, list) else []
+		except (ValueError, TypeError):
+			return []
+
 	return {
 		"last_sync_at": str(s.get("last_sync_at") or ""),
 		"last_sync_status": status,
 		"pending": status.startswith("pending:"),
 		"subscription_status": s.get("last_subscription_status") or "",
-		"warnings": warnings,
+		"warnings": _json_list(s.get("last_sync_warnings")),
+		# Per-model verdicts from the last pool apply: [{provider, model, status}] where
+		# status is verified | failed | unchecked (api-key models only; subscriptions use
+		# subscription_status above). [] when no pool sync has run or the fleet predates
+		# contract 1.11. The AI-models list keys each api-key row's health off this.
+		"model_statuses": _json_list(s.get("last_model_statuses")),
 	}
 
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -472,6 +472,7 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 		self.assertIn("pending", out)
 		self.assertIn("subscription_status", out)
 		self.assertIn("warnings", out)
+		self.assertIn("model_statuses", out)
 
 	# -- Apply-warning propagation (subscription_status + warnings) -------
 
@@ -524,3 +525,38 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 		frappe.db.commit()
 		out = onboarding.get_llm_sync_status()
 		self.assertEqual(out["warnings"], [])
+
+	# -- Per-model verdicts (model_statuses, contract 1.11) --------------
+
+	def test_returns_parsed_model_statuses(self):
+		"""The pool sync worker stores the fleet's per-model verdicts as a JSON
+		array string; get_llm_sync_status must hand back a parsed list of dicts
+		so the AI-models list can key each api-key row's health off it."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set(
+			"last_model_statuses",
+			'[{"provider": "openai_compat", "model": "claude-sonnet-4-6", "status": "failed"}]',
+			update_modified=False,
+		)
+		frappe.db.commit()
+		out = onboarding.get_llm_sync_status()
+		self.assertEqual(
+			out["model_statuses"],
+			[{"provider": "openai_compat", "model": "claude-sonnet-4-6", "status": "failed"}],
+		)
+
+	def test_empty_model_statuses_defaults_to_empty_list(self):
+		"""No pool sync yet, or a pre-1.11 fleet - the field is empty and must
+		degrade to [] rather than raise."""
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_model_statuses", "", update_modified=False)
+		frappe.db.commit()
+		self.assertEqual(onboarding.get_llm_sync_status()["model_statuses"], [])
+
+	def test_corrupt_or_non_list_model_statuses_degrades_to_empty_list(self):
+		"""A malformed or non-list last_model_statuses must never 500 this poller."""
+		s = frappe.get_single("Jarvis Settings")
+		for bad in ("{not valid json", '{"model": "m", "status": "failed"}'):
+			s.db_set("last_model_statuses", bad, update_modified=False)
+			frappe.db.commit()
+			self.assertEqual(onboarding.get_llm_sync_status()["model_statuses"], [])

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -171,6 +171,14 @@ class TestOnUpdateAdminDispatch(_SettingsSnapshotTestCase):
 		self.settings.db_set("llm_base_url", "https://api.anthropic.com")
 		self.settings.db_set("llm_api_key", "sk-original")
 		frappe.db.commit()
+		# Fresh-read the Single after the db_sets. A prior test can leave a stale
+		# Jarvis Settings doc in the singles/document cache; without this, the
+		# test body's frappe.get_doc + on_update's change-classification compare
+		# against that stale provider, misclassify a provider change as an
+		# api-key-only reload, and hit the unmocked admin path ("admin
+		# unreachable") — the order-dependent flake this class documents. Clearing
+		# the cached doc guarantees reads reflect the values just written.
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 	def _save_with_new_api_key(self, new_key="sk-new"):
 		# Re-fetch + change llm_api_key, then save (triggers on_update).

--- a/jarvis/tests/test_settings.py
+++ b/jarvis/tests/test_settings.py
@@ -170,6 +170,22 @@ class TestOnUpdateAdminDispatch(_SettingsSnapshotTestCase):
 		self.settings.db_set("llm_model", "claude-sonnet-4-6")
 		self.settings.db_set("llm_base_url", "https://api.anthropic.com")
 		self.settings.db_set("llm_api_key", "sk-original")
+		# Force DIRECT (single-model) dispatch. on_update routes into the POOL path
+		# whenever the models child table has ANY row (compute_proxy_active), and an
+		# earlier test class (e.g. test_unified_llm_config) can leave a COMMITTED
+		# Jarvis LLM Pool Model row that Frappe's per-class rollback cannot undo. With
+		# a leftover row, this test's provider-change save routes to the unmocked
+		# post_update_llm_pool → "admin unreachable" instead of the restart path it
+		# mocks — the real, order-dependent cause of this flake (the clear_document_cache
+		# below is inert for it: the classifier's before-save read is an uncached
+		# get_doc). Same fix already shipped for the same bug in
+		# test_settings_on_update._reset_settings (commit 6fc9b74).
+		frappe.db.delete(
+			"Jarvis LLM Pool Model",
+			{"parenttype": "Jarvis Settings", "parent": "Jarvis Settings"},
+		)
+		self.settings.db_set("preset", "")
+		self.settings.db_set("proxy_active", 0, update_modified=False)
 		frappe.db.commit()
 		# Finish the isolation hardening #300 started: the restart-vs-reload
 		# classifier (_classify_llm_change) compares the new provider/model/


### PR DESCRIPTION
## Problem

When a customer configures a **failover pool** with an api-key model, a broken member (bad key → 401, wrong/dead `base_url` → unreachable) was **invisible** in the AI-models UI: the row showed the same green **"key set"** as a healthy one, and the save reported **"Applied"**. They'd discover the fallback was dead only when the primary failed — the worst possible moment.

Root cause (traced on `site.jarvis`, 2026-07-15): the fleet computes a per-model verdict (`model_statuses`, contract 1.11) and returns it on the pool-apply response, but it was **dropped at the bench boundary** — `jarvis_settings` persisted only `subscription_status` + `warnings`, and `LlmPoolEditor.accountHealth` **hardcoded every api-key row green** (the acknowledged *"drop this guard once model_statuses is plumbed"* TODO).

## Fix — plumb `model_statuses` to per-row health

- **Persist** `last_model_statuses` alongside `last_sync_warnings` (`jarvis_settings.py`), with the same no-op / clear-on-failure reasoning. New hidden `Long Text` field on Jarvis Settings.
- **Return** it from `onboarding.get_llm_sync_status` (corrupt / non-list → `[]`, never 500s the poller).
- **Render** it: `LlmPoolEditor.accountHealth` now keys api-key rows off their own verdict via a new **pure** `apiKeyModelHealth(row, model_statuses)`:
  - `failed` → **warn** "Not working" + actionable title (check key / model id / base URL; skipped during failover)
  - `unchecked` → "Not verified yet"
  - `verified` / absent → quiet green (now *meaningful*; absent = pre-1.11 fleet or not-yet-probed)
  - Matches by model id, disambiguating the legal provider/model-id collision by provider (rows store the provider *label*, `model_statuses` the *id*, so the match normalizes via `providerId`).

No admin change: `jarvis_admin.fleet.llm_pool.update_llm_pool` returns the raw fleet result unmodified, so `model_statuses` already flows admin→customer.

## Pairs with fleet-agent PR #137

PR #137 makes an unreachable `base_url` return `failed` (instead of silent `unchecked`). Together: a dead fallback leg now goes **red on its own row** here, and also raises the pool-wide "N model(s) need attention" banner. Merge order doesn't matter (this degrades gracefully on a pre-#137 fleet — `unchecked` renders "Not verified yet").

## Tests

- `frontend/src/llm/pool.test.js` (5, `node --test`): the health mapping incl. the model-id collision and the pre-1.11 / no-verdict → green fallbacks. **30/30 pass.**
- `jarvis/tests/test_onboarding_sync.py` (3): the poller returns parsed `model_statuses` and degrades corrupt/empty/non-list to `[]`. (Runs on CI — the app is installed from the main checkout, not this worktree.)
- Frontend **vite build clean** (13.9s).

No migration patch: a new Single-doctype field is synced by `bench migrate`'s meta reload; values live in `tabSingles`.
