### PR TITLE
fix(chat): stop_run crashed on ImportError before it could abort

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1446,7 +1446,7 @@ def stop_run(conversation: str, run_id: str | None = None) -> dict:
 		pending_confirm.clear_for_conversation(frappe.session.user, conversation, run_id)
 	except Exception:
 		frappe.log_error(title="stop_run token sweep", message=frappe.get_traceback())
-	from jarvis.chat import selfhost
+	from jarvis import selfhost
 
 	if selfhost.is_self_hosted():
 		return {"ok": False, "reason": _("stop isn't available on this connection yet")}


### PR DESCRIPTION
## Problem
Clicking **Stop** on a chat turn did nothing server-side — the reply kept coming. Investigating turned up a hard runtime bug in the Stop endpoint itself.

## Root cause
`jarvis.chat.api.stop_run` imported `from jarvis.chat import selfhost`, but there is **no `jarvis/chat/selfhost.py`** and `jarvis/chat/__init__.py` is empty, so that line raises `ImportError` at runtime (every other caller correctly uses `from jarvis import selfhost`). It shipped in `0c53f47` (2026-07-10 — the commit that added "real Stop"), so `stop_run` has blown up **before ever reaching `chat_abort` on every Stop click since**. The frontend's `api.stopRun(...).catch(() => {})` swallowed the resulting 500, so Stop silently did nothing.

## Fix
One line — correct the import so `stop_run` reaches `chat_abort` and actually cancels an actively-running turn:

```diff
-	from jarvis.chat import selfhost
+	from jarvis import selfhost
```

## Verification
- Confirmed at runtime that `from jarvis.chat import selfhost` raises `ImportError` and `from jarvis import selfhost` resolves (`selfhost.is_self_hosted` callable).
- `python -m py_compile jarvis/chat/api.py` passes.
- Existing `jarvis` test suite unaffected (import-only change).

## Scope note
This restores openclaw's abort for **actively-running turns** (warm container / any 2nd+ turn). It does **not** address two known edges that need more than the import fix: the **first-turn cold-start window** (Stop during the ~10–25s before the openclaw session exists — `stop_run` still returns early with nothing to abort) and the **last-instant completion race** (openclaw no-ops an abort once the answer is committed). Those are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)