### PR TITLE
feat(tools): surface DocType button server-methods in get_schema (discovery)

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -291,11 +291,14 @@ require_type_annotated_api_methods = True
 # get_schema caches each DocType's schema in Redis with a short TTL. Bust that
 # cache the moment a schema-defining doc changes, so the agent never builds a
 # write off a stale field list inside the TTL window (a Custom Field added via
-# Customize Form must show up immediately, not 5 minutes later).
+# Customize Form must show up immediately, not 5 minutes later). Client Script is
+# included because get_schema's `actions` hint is scraped from the DocType's form
+# JS, which includes enabled Form Client Scripts - a newly-added button must
+# surface without waiting out the TTL.
 _CLEAR_SCHEMA_CACHE = "jarvis.tools.get_schema.clear_schema_cache"
 doc_events = {
 	dt: {"on_update": _CLEAR_SCHEMA_CACHE, "on_trash": _CLEAR_SCHEMA_CACHE}
-	for dt in ("DocType", "Custom Field", "Property Setter", "Workflow")
+	for dt in ("DocType", "Custom Field", "Property Setter", "Workflow", "Client Script")
 }
 
 # Org-scope wiki pages are mirrored as markdown into the tenant container

--- a/jarvis/tests/test_doc_actions.py
+++ b/jarvis/tests/test_doc_actions.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools import _doc_actions
+from jarvis.tools._doc_actions import get_doc_actions
+from jarvis.tools.get_schema import get_schema
+
+
+class TestDocActions(FrappeTestCase):
+	"""Extraction of whitelisted, button-surfaced server methods per DocType.
+
+	Runs against a real bench with erpnext installed (Sales Order etc.).
+	Discovery is fail-safe: the helper must never raise and must only ever
+	return methods that genuinely resolve + pass is_whitelisted.
+	"""
+
+	def test_sales_order_surfaces_make_mappers(self):
+		"""The high-value create-from mapper family (added by base controllers
+		but implemented in the subclass sales_order.js) is captured."""
+		actions = get_doc_actions("Sales Order")
+		self.assertTrue(actions, "expected Sales Order to expose button actions")
+		tails = {a["method"].rsplit(".", 1)[-1] for a in actions}
+		self.assertTrue(
+			{"make_delivery_note", "make_sales_order"} & tails,
+			f"expected make_* mappers, got {sorted(tails)}",
+		)
+		self.assertEqual(set(actions[0].keys()), {"method", "label", "args"})
+
+	def test_returned_methods_are_dotted_and_whitelisted(self):
+		"""Every surfaced method is a full dotted path (run_method-callable) and
+		actually whitelisted - the validation step is doing real work."""
+		actions = get_doc_actions("Sales Order")
+		for a in actions:
+			self.assertIn(".", a["method"], f"{a['method']} is not a dotted path")
+			fn = frappe.get_attr(a["method"])
+			frappe.is_whitelisted(fn)  # raises if not whitelisted -> test fails
+
+	def test_capped_at_max(self):
+		"""A pathological form can't blow the context budget - result is capped."""
+		many = " ".join(f'x.xcall("a.b.c{i}")' for i in range(_doc_actions._MAX_ACTIONS + 15))
+		with (
+			patch.object(_doc_actions, "_assembled_form_js", return_value=many),
+			patch.object(
+				_doc_actions,
+				"_validated_action",
+				side_effect=lambda dotted, installed_apps=None: {
+					"method": dotted,
+					"label": dotted,
+					"args": [],
+				},
+			),
+		):
+			actions = get_doc_actions("Whatever")
+		self.assertEqual(len(actions), _doc_actions._MAX_ACTIONS)
+
+	def test_candidate_resolution_is_bounded(self):
+		"""A form with far more distinct methods than the cap must not resolve
+		(import) all of them - work is bounded, not just output."""
+		n = _doc_actions._MAX_CANDIDATES + 50
+		js = " ".join(f'x.xcall("a.b.c{i}")' for i in range(n))
+		calls = []
+		with (
+			patch.object(_doc_actions, "_assembled_form_js", return_value=js),
+			patch.object(
+				_doc_actions,
+				"_validated_action",
+				side_effect=lambda dotted, installed_apps=None: calls.append(dotted) or None,
+			),
+		):
+			get_doc_actions("Whatever")
+		self.assertLessEqual(len(calls), _doc_actions._MAX_CANDIDATES)
+
+	def test_own_doctype_methods_rank_first(self):
+		"""When the cap bites, the DocType's own actions outrank foreign
+		reverse-mappers even if the foreign path sorts earlier alphabetically."""
+		js = (
+			'x.xcall("erpnext.buying.doctype.purchase_order.mapper.a_make");'
+			'x.xcall("erpnext.selling.doctype.sales_order.mapper.z_make");'
+		)
+		with (
+			patch.object(_doc_actions, "_assembled_form_js", return_value=js),
+			patch.object(
+				_doc_actions,
+				"_validated_action",
+				side_effect=lambda dotted, installed_apps=None: {"method": dotted, "label": "", "args": []},
+			),
+		):
+			actions = get_doc_actions("Sales Order")
+		self.assertEqual(actions[0]["method"].split(".")[3], "sales_order")
+
+	def test_no_message_log_pollution(self):
+		"""Rejecting an uninstalled-app ref or a resolvable-but-unwhitelisted
+		method must not leak stray messages into frappe.local.message_log (the
+		throwing APIs append before raising; we must avoid them)."""
+		js = 'frappe.call({ method: "notanapp.foo.bar" });frappe.call({ method: "frappe.utils.get_url" });'
+		before = len(frappe.local.message_log or [])
+		with patch.object(_doc_actions, "_assembled_form_js", return_value=js):
+			actions = get_doc_actions("Whatever")
+		self.assertEqual(actions, [])
+		self.assertEqual(len(frappe.local.message_log or []), before)
+
+	def test_empty_when_no_form_js(self):
+		with patch.object(_doc_actions, "_assembled_form_js", return_value=""):
+			self.assertEqual(get_doc_actions("Sales Order"), [])
+
+	def test_real_method_extracted_from_synthetic_js(self):
+		"""A dotted, whitelisted method referenced in the form JS is returned."""
+		js = 'frappe.call({ method: "frappe.client.get_list", args: {} });'
+		with patch.object(_doc_actions, "_assembled_form_js", return_value=js):
+			methods = {a["method"] for a in get_doc_actions("Whatever")}
+		self.assertIn("frappe.client.get_list", methods)
+
+	def test_bogus_dotted_method_filtered(self):
+		"""A dotted string that isn't a real whitelisted method is dropped."""
+		js = 'frappe.call({ method: "not.a.real.whitelisted.method" });'
+		with patch.object(_doc_actions, "_assembled_form_js", return_value=js):
+			self.assertEqual(get_doc_actions("Whatever"), [])
+
+	def test_relative_docmethod_skipped(self):
+		"""A bare (non-dotted) name is a doc-method run_method can't call - skip."""
+		js = 'frappe.call({ doc: frm.doc, method: "create_stock_reservation_entries" });'
+		with patch.object(_doc_actions, "_assembled_form_js", return_value=js):
+			self.assertEqual(get_doc_actions("Whatever"), [])
+
+	def test_nonexistent_doctype_returns_empty(self):
+		"""FormMeta raises for an unknown DocType; the helper swallows it -> []."""
+		self.assertEqual(get_doc_actions("No Such DocType 9Z"), [])
+
+	def test_never_raises_on_internal_failure(self):
+		"""The 'never raises' contract holds even when a frappe call deep inside
+		the body blows up (here get_installed_apps), not just FormMeta."""
+		with (
+			patch.object(_doc_actions, "_assembled_form_js", return_value='x.xcall("a.b.c");'),
+			patch("frappe.get_installed_apps", side_effect=RuntimeError("boom")),
+		):
+			self.assertEqual(get_doc_actions("Whatever"), [])
+
+	# --- get_schema integration ---
+
+	def test_get_schema_includes_actions(self):
+		result = get_schema("Sales Order", refresh=True)
+		self.assertIn("actions", result)
+		self.assertTrue(result["actions"], "expected a non-empty actions list")
+		self.assertIn(".", result["actions"][0]["method"])
+
+	def test_get_schema_survives_actions_error(self):
+		"""Extraction blowing up must never break get_schema itself."""
+		with patch(
+			"jarvis.tools.get_schema.get_doc_actions",
+			side_effect=RuntimeError("boom"),
+		):
+			result = get_schema("Customer", refresh=True)
+		self.assertEqual(result["actions"], [])

--- a/jarvis/tools/_doc_actions.py
+++ b/jarvis/tools/_doc_actions.py
@@ -1,0 +1,161 @@
+"""Discover the whitelisted server methods a DocType's form exposes as custom
+buttons, so the agent knows what ``run_method`` can call for that doctype
+instead of guessing dotted paths.
+
+Best-effort + fail-safe: this is a DISCOVERY hint, not an allowlist. We read the
+DocType's assembled form JS (the canonical ``<dt>.js`` + regional override +
+cross-app ``doctype_js`` hooks + enabled ``Client Script`` (Form) rows - all
+unioned for us by Frappe's ``FormMeta``) and scrape the dotted ``method:`` string
+literals that ``frappe.call`` / ``frappe.xcall`` / ``open_mapped_doc`` /
+``map_current_doc`` pass, then keep only the ones that resolve to a real
+``@frappe.whitelist()`` function (the same gate ``run_method`` enforces). A
+missed method just means one fewer hint - the agent falls back to its own
+knowledge and the ``unknown method`` error loop - so incompleteness is fine and
+this module never raises.
+
+Only PATH-A methods (module-level, full dotted path) are surfaced: those are
+exactly what ``run_method`` can call. Relative doc-methods (bare names dispatched
+via ``run_doc_method``) are intentionally skipped - surfacing a method the agent
+cannot actually call would only waste a turn.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import frappe
+
+# `method: "a.b.c"` as passed to frappe.call / open_mapped_doc / map_current_doc,
+# and `xcall("a.b.c")`. We keep only DOTTED names below (a real module path);
+# bare relative names are doc-methods run_method can't reach.
+_METHOD_KEY_RE = re.compile(r"""method\s*:\s*["']([\w.]+)["']""")
+_XCALL_RE = re.compile(r"""\.xcall\(\s*["']([\w.]+)["']""")
+
+# Cap the list so a pathological form can't bloat the model context (get_schema
+# already trims for exactly this reason).
+_MAX_ACTIONS = 25
+
+# Bound how many DISTINCT candidates we resolve (each `frappe.get_attr` imports a
+# module; failed imports aren't cached). A pathological/large Client Script can't
+# turn one cache-miss get_schema into thousands of import attempts. Real forms
+# have a few dozen; this only bites abuse.
+_MAX_CANDIDATES = 200
+
+
+def get_doc_actions(doctype: str) -> list[dict]:
+	"""Up to ``_MAX_ACTIONS`` whitelisted server methods this DocType's form
+	exposes as buttons, each ``{"method", "label", "args"}``. Never raises -
+	returns ``[]`` on any failure or when nothing usable is found."""
+	try:
+		js = _assembled_form_js(doctype)
+		if not js:
+			return []
+		installed_apps = frozenset(frappe.get_installed_apps())
+		seen: set[str] = set()
+		actions: list[dict] = []
+		for dotted in _iter_candidates(js):
+			if dotted in seen:
+				continue
+			seen.add(dotted)
+			if len(seen) > _MAX_CANDIDATES:
+				break
+			try:
+				entry = _validated_action(dotted, installed_apps)
+			except Exception:
+				# One odd candidate must never sink the whole batch.
+				continue
+			if entry is not None:
+				actions.append(entry)
+
+		actions.sort(key=_sort_key(doctype))
+		return actions[:_MAX_ACTIONS]
+	except Exception:
+		# Fail-safe: any unexpected error (FormMeta, get_installed_apps, ...)
+		# degrades to no hint rather than breaking the caller.
+		return []
+
+
+def _sort_key(doctype: str):
+	"""Stable ordering that keeps the DocType's OWN actions ahead of foreign ones
+	when the cap bites: e.g. on Sales Order, ``...sales_order.mapper.make_*`` sorts
+	before ``...purchase_order...make_inter_company_sales_order``. Alphabetical
+	within each group so rebuilds are byte-identical (cache-friendly)."""
+	own_segment = frappe.scrub(doctype)
+
+	def key(action: dict):
+		is_own = own_segment in action["method"].split(".")
+		return (0 if is_own else 1, action["method"])
+
+	return key
+
+
+def _assembled_form_js(doctype: str) -> str:
+	"""The DocType's full client form script, unioned across the canonical
+	``<dt>.js``, regional override, cross-app ``doctype_js`` hooks and enabled
+	``Client Script`` (Form) rows - exactly what Frappe ships to the form.
+	``FormMeta`` skips asset loading for child tables, so those yield empty JS."""
+	from frappe.desk.form.meta import get_meta as get_form_meta
+
+	meta = get_form_meta(doctype)
+	return (meta.get("__js") or "") + "\n" + (meta.get("__custom_js") or "")
+
+
+def _iter_candidates(js: str):
+	"""Yield the DOTTED method names referenced in the form JS. Dotted == a
+	module-level function (path-a, ``run_method``-callable); bare names are
+	relative doc-methods (path-b) and are skipped."""
+	for regex in (_METHOD_KEY_RE, _XCALL_RE):
+		for match in regex.finditer(js):
+			name = match.group(1)
+			if "." in name:
+				yield name
+
+
+def _validated_action(dotted: str, installed_apps) -> dict | None:
+	"""Resolve ``dotted`` and confirm it's a real whitelisted method, dropping
+	scrape false-positives and not-installed-app references. Returns None if it
+	isn't callable via ``run_method``.
+
+	Deliberately avoids the throwing APIs ``run_method`` uses at call time
+	(``frappe.get_attr`` on an uninstalled app and ``frappe.is_whitelisted`` on a
+	non-whitelisted fn both ``frappe.throw``, which appends to ``message_log``
+	*before* raising - the caught exception doesn't unwind that, so it would leak
+	stray ``_server_messages`` on every cache-miss get_schema). The installed-app
+	pre-check mirrors ``get_attr``'s own gate, and membership in
+	``frappe.whitelisted`` is exactly what ``is_whitelisted`` tests - minus the
+	throw."""
+	if dotted.split(".", 1)[0] not in installed_apps:
+		return None
+	try:
+		fn = frappe.get_attr(dotted)
+	except (AttributeError, ImportError):
+		return None
+	if fn not in frappe.whitelisted:
+		return None
+	return {
+		"method": dotted,
+		"label": _humanize(dotted),
+		"args": _arg_names(fn),
+	}
+
+
+def _arg_names(fn) -> list[str]:
+	"""Positional/keyword parameter names, so the agent knows what to pass. Skips
+	``*args``/``**kwargs``; empty on un-introspectable builtins."""
+	try:
+		params = inspect.signature(fn).parameters
+	except (TypeError, ValueError):
+		return []
+	return [
+		name
+		for name, p in params.items()
+		if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+	]
+
+
+def _humanize(dotted: str) -> str:
+	"""``erpnext...make_sales_invoice`` -> ``Make Sales Invoice``. A readable
+	nicety; the dotted ``method`` is the load-bearing value."""
+	tail = dotted.rsplit(".", 1)[-1]
+	return tail.replace("_", " ").strip().title()

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -1,6 +1,7 @@
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools._doc_actions import get_doc_actions
 
 TABLE_FIELDTYPES = {"Table", "Table MultiSelect"}
 _SCHEMA_TTL = 300  # seconds; schema is user-independent + changes rarely
@@ -58,8 +59,19 @@ def _build_schema(doctype: str, verbose: bool) -> dict:
 		"naming_rule": getattr(meta, "naming_rule", None),
 		"title_field": meta.title_field,
 		"workflow": _workflow_for(doctype),
+		"actions": _safe_actions(doctype),
 		"fields": fields,
 	}
+
+
+def _safe_actions(doctype: str) -> list:
+	"""Discovery hint: whitelisted server methods this DocType's form exposes as
+	buttons (callable via run_method). Extraction is best-effort and must never
+	break get_schema, so degrade to [] on any error."""
+	try:
+		return get_doc_actions(doctype)
+	except Exception:
+		return []
 
 
 def _as_bool(value) -> bool:
@@ -92,6 +104,9 @@ def clear_schema_cache(doc, method=None) -> None:
 		dt = getattr(doc, "doc_type", None)
 	elif dtype == "Workflow":
 		dt = getattr(doc, "document_type", None)
+	elif dtype == "Client Script":
+		# actions hints are scraped from form JS, which includes Form Client Scripts
+		dt = getattr(doc, "dt", None)
 	if dt:
 		clear_cache_for(dt)
 
@@ -102,9 +117,15 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 
 	Top level: ``doctype``, ``is_submittable`` (docstatus lifecycle applies),
 	``autoname`` / ``naming_rule`` (how name is assigned), ``title_field``,
-	``workflow`` ({name, state_field, states} or None), and ``fields``.
+	``workflow`` ({name, state_field, states} or None), ``actions``, and ``fields``.
 	Every field record carries ``fieldname``, ``fieldtype``, ``label``,
 	``options`` (Link target / Select enum / child DocType), and ``reqd``.
+
+		``actions`` is a discovery hint: the whitelisted server methods this
+		DocType's form exposes as custom buttons (e.g. ``make_sales_invoice`` on a
+		Sales Order), each ``{"method", "label", "args"}``, callable via
+		``run_method``. Best-effort and possibly incomplete - absence does not
+		mean a method is uncallable.
 
 	By default Table / Table MultiSelect fields surface as ordinary records
 	(child DocType named via ``options``) WITHOUT recursive ``child_fields`` -


### PR DESCRIPTION
## What

`get_schema` now returns an `actions` block per DocType: the whitelisted server methods that DocType's form exposes as **custom buttons** (e.g. `make_sales_invoice` / `make_delivery_note` on a Sales Order), each `{method, label, args}`, so the agent can call them via `run_method` instead of guessing dotted paths.

## Why

`run_method` can call any `@frappe.whitelist()` method by dotted path, but the agent had **no way to discover which methods exist** for a doctype — it leaned on training knowledge + a trial-and-error loop on `unknown method` errors (only 44 of 579 persona skill pages document endpoints). This surfaces the doctype's blessed actions directly and cheaply.

## How

- **New `jarvis/tools/_doc_actions.py`** — reads the DocType's *assembled* form JS via Frappe's `FormMeta` (canonical `<dt>.js` + regional + cross-app `doctype_js` hooks + enabled Form `Client Script`s — all unioned by Frappe), scrapes the dotted `method:` literals passed to `frappe.call` / `xcall` / `open_mapped_doc` / `map_current_doc`, and keeps only those that resolve and are in `frappe.whitelisted`. Relative doc-methods (the `run_doc_method` path) are skipped — `run_method` can't call them.
- **`get_schema`** gains `actions: [...]`, riding its existing 5-min Redis cache (now also busted on `Client Script` change).

## Design decisions

- **Discovery only, no enforcement.** `run_method`'s allowlist is untouched.
- **On-demand, not skill files.** The hint is produced per-doctype when `get_schema` is called and **capped at 25**, so it adds zero always-loaded context — keeps the agent fast (the explicit goal).
- **Fail-safe.** Best-effort extraction; a missed method just means one fewer hint. `get_doc_actions` never raises, and the `get_schema` call site is defensively wrapped, so extraction can never break the schema read.
- **Hardening (from review):** installed-app pre-filter + `frappe.whitelisted` membership instead of the throwing `is_whitelisted`/`get_attr` (no stray `_server_messages`); bounded candidate resolution (`_MAX_CANDIDATES`) so a large Client Script can't turn one cache miss into thousands of imports; own-DocType methods sort ahead of foreign reverse-mappers so the useful ones survive the cap.

## Testing

- 14 unit tests in `jarvis/tests/test_doc_actions.py`, all green on `jarvis-test.localhost`; existing `get_schema` tests still pass; pre-commit clean.
- Verified live: Sales Order → 22 actions (full `make_*` mapper family), ~3.7 KB. `jarvis-test.localhost` has frappe + erpnext installed; the extractor is app-agnostic and covers every installed app's doctypes (frappe / erpnext / hrms / india_compliance) on a full bench.
- Reviewed adversarially by Fable across two passes; all findings resolved.

## Deferred (not in scope)

- Path-b doc-methods (`create_stock_reservation_entries` etc.) — need a separate `run_doc_method`-style tool before they're callable.
- Base-controller-only form helpers (pricing/tax/item-detail auto-fill) — those are field-change plumbing, not custom-button actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)