### PR TITLE
Onboarding convergence: applying-tolerant sync + reconcile safety net (bench half)

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -206,7 +206,7 @@
 								<div v-show="state.finishing">
 									<div class="jv-ob-head">
 										<h1>Setting up Jarvis</h1>
-										<p>Bringing your workspace online, taking you to chat…</p>
+										<p>{{ state.finishSubtitle || "Bringing your workspace online, taking you to chat…" }}</p>
 									</div>
 									<div class="jv-ob-setup-net">
 										<SetupNeuralNet :dark="dark" />
@@ -384,8 +384,10 @@ const state = reactive({
 	// has no container to configure).
 	provisioning: false, provisionErr: "",
 	// post-save readiness recheck (Connect + self-host both funnel through
-	// afterSaveRecheckReady/forceContinue below)
-	finishing: false, finishNote: "",
+	// afterSaveRecheckReady/forceContinue below). finishSubtitle swaps the
+	// spinner's default line for a calm "this can take a few minutes" message
+	// once the sync is confirmed still-converging server-side (F2 pending).
+	finishing: false, finishNote: "", finishSubtitle: "",
 	// self-host (renderSelfHost / renderShResults, jarvis_onboarding.js ~296-376)
 	shUrl: "", shToken: "", shStream: true, shDeep: false,
 	shTestBusy: false, shTestResult: null, shSaveBusy: false,
@@ -827,7 +829,16 @@ async function waitForSyncTerminal(maxMs = 15 * 60 * 1000, intervalMs = 3000) {
 	for (;;) {
 		try {
 			const s = await getLlmSyncStatus()
+			// "pending:" (incl. "pending: admin applying config") is NOT terminal
+			// - the admin persisted the config and a reconcile is finishing the
+			// apply. Keep following it; surface a calm reassurance rather than the
+			// red failure note. Only ok/failed (not pending) ends the loop.
 			if (s && !s.pending) return s
+			if (s && s.pending) {
+				state.finishSubtitle =
+					"Finishing setup — this can take a few minutes. We’ll keep at it; " +
+					"you can safely wait or come back."
+			}
 		} catch (e) {
 			// transient network hiccups shouldn't strand the user
 		}
@@ -852,6 +863,7 @@ async function waitForSyncTerminal(maxMs = 15 * 60 * 1000, intervalMs = 3000) {
 // field at all.
 async function afterSaveRecheckReady({ followSync = false } = {}) {
 	state.finishNote = ""
+	state.finishSubtitle = ""
 	state.finishing = true
 	if (followSync) {
 		// save_llm_pool writes "pending:" synchronously before its response,

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -27,9 +27,13 @@ from jarvis.exceptions import (
 )
 
 
-# Admin's provision_healthz_timeout_s defaults to 60s for restart operations;
-# 90s leaves 30s buffer for network round-trip + handler overhead.
-DEFAULT_TIMEOUT_S = 90
+# Outer bench->admin HTTP budget. It MUST sit strictly ABOVE the admin's own
+# admin->agent leg (now 100s) so the bench never hangs up on an apply the admin
+# is still driving and writes a spurious "failed" over creds that land seconds
+# later (the onboarding livelock, audit F1/F2). 150s = the 100s admin->agent
+# budget + headroom for the HTTPS round-trip and admin's handler/response
+# serialization. Increase both together if the admin->agent leg grows.
+DEFAULT_TIMEOUT_S = 150
 
 # OAuth password-grant config. The bench exchanges the customer's password
 # (Jarvis Settings.jarvis_admin_customer_password) for short-lived bearer
@@ -301,9 +305,15 @@ def confirm_payment(payload: dict) -> dict:
 def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	"""Fetch the assigned container connection (fallback / scheduled sync).
 
-	``timeout_s`` is keyword-only and defaults to DEFAULT_TIMEOUT_S=90 so existing
+	``timeout_s`` is keyword-only and defaults to DEFAULT_TIMEOUT_S so existing
 	callers are unaffected. The chat-readiness gate (jarvis.account) passes a
 	short 8s budget so a slow admin can't stall the SPA/boot path.
+
+	The response carries ``chat_readiness`` ("Provisioning" | "Configuring" |
+	"Ready") + ``chat_readiness_reason`` - the convergence signal the bench polls
+	after an "applying"/timeout apply outcome to learn the admin reconcile
+	finished the apply (F2). Pass a short ``timeout_s`` for those hot status
+	probes so a slow admin can't stretch a convergence loop past its job budget.
 	"""
 	return _post(path=_m("api.tenant.get_connection"), body={}, timeout_s=timeout_s)
 
@@ -588,10 +598,14 @@ def post_update_llm_pool(*, spec: dict, api_keys: dict, oauth_blobs: dict) -> di
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError
 	"""
+	# Rides the shared DEFAULT_TIMEOUT_S (150s) like post_update_llm_creds so
+	# both interactive apply legs sit above the admin's 100s admin->agent budget
+	# (ladder fix F1). The pool apply is the same class of restart-render op; a
+	# read-timeout here is now absorbed as an "applying"/pending outcome and
+	# reconciled via get_connection, not written as a terminal failure.
 	return _post(
 		path=_m("api.tenant.update_llm_pool"),
 		body={"spec": spec, "api_keys": api_keys, "oauth_blobs": oauth_blobs},
-		timeout_s=120,
 	)
 
 
@@ -646,10 +660,10 @@ def pair_chat_device(public_key: str, device_id: str,
 	the budget the bench asks admin to allow for its admin -> fleet-agent
 	leg. Defaults to 30s (matches admin's prior hardcoded value). Admin
 	clamps to [5, 90] on its side so an over-large value can't push the
-	overall HTTPS round-trip past the bench's outer DEFAULT_TIMEOUT_S=90.
+	overall HTTPS round-trip past the bench's outer DEFAULT_TIMEOUT_S.
 
 	The outer HTTPS round-trip timeout (bench -> admin) stays at
-	DEFAULT_TIMEOUT_S=90s; that's the absolute upper bound on this call.
+	DEFAULT_TIMEOUT_S; that's the absolute upper bound on this call.
 	"""
 	return _post(
 		path=_m("api.tenant.pair_chat_device"),

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -200,6 +200,13 @@ scheduler_events = {
 	"cron": {
 		"*/5 * * * *": [
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
+			# Onboarding convergence safety net (review P0-2): when an LLM
+			# apply parked at "pending: admin applying config" (admin accepted
+			# it and its reconcile is converging server-side), probe
+			# get_connection once per tick and stamp llm_pool_synced_at the
+			# moment chat_readiness reads Ready. Without this, a pending apply
+			# that outlives the in-job 120s poll is a permanent dead-end.
+			"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.reconcile_pending_llm_sync",
 			# 2026-07 latency plan, Phase 1.4: was */30, which left the
 			# provider prompt cache (5-10 min retention) cold for most of
 			# each half-hour. Every 5 min + a 4-min cooldown in prewarm.py

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -20,12 +20,15 @@ _CONTAINER_OWNED_MODES = {"oauth", "subscription"}
 #
 #   RQ envelope > worst-case work it wraps, AND lock TTL >= RQ envelope.
 #
-# Worst-case pool work: <=60s redis-lock wait + up to 3 POST attempts x 120s
-# admin HTTP budget (post_update_llm_pool) + 2x5s retry sleeps ~= 430s.
-# Worst-case single-model work: <=60s lock wait + 90s admin HTTP budget +
-# the post-restart skills resyncs. 600s clears both with headroom, so the
-# rq SIGALRM (JobTimeoutException) only fires on something genuinely
-# wedged - not on a routine cold provision (JARVIS-2026-07-08, fault c).
+# Worst-case pool work: <=60s redis-lock wait + up to 2 POST attempts x 150s
+# admin HTTP budget (post_update_llm_pool, now on DEFAULT_TIMEOUT_S) + 1x5s
+# retry sleep + a bounded in-job convergence poll (_POOL_CONVERGE_DEADLINE_S,
+# ~120s) that absorbs an "applying"/timeout apply outcome. That is
+# ~60 + 305 + 120 = 485s. Worst-case single-model work: <=60s lock wait + 150s
+# admin HTTP budget + the post-restart skills resyncs. 600s clears both with
+# headroom, so the rq SIGALRM (JobTimeoutException) only fires on something
+# genuinely wedged - not on a routine cold provision (JARVIS-2026-07-08,
+# fault c).
 #
 # The lock TTL must be >= the RQ envelope: the TTL bounds how long a
 # CRASHED holder can block others, but a healthy holder may legitimately
@@ -43,15 +46,106 @@ ADMIN_SYNC_LOCK_TIMEOUT_S = ADMIN_SYNC_RQ_TIMEOUT_S
 # primary 60s + 4 retries x 150s = 660s > 600s TTL. Each retry runs in its
 # own fresh RQ envelope, and per-attempt lock wait + POST-ONLY work must
 # fit that envelope. POST-only worst case (lock wait excluded - the wait
-# is the other term of the sum): pool = 3x120s attempts + 2x5s sleeps
-# = 370s; single-model = 90s + skills resyncs. So 150s + 370s = 520s
-# <= 600s. These are the SAME figures the budget test in
-# test_unified_llm_config.TestOnboardingAuditFixes asserts - tune the
+# is the other term of the sum): pool = 2x150s attempts + 1x5s sleep +
+# ~120s convergence poll = 425s; single-model = 150s + skills resyncs. So
+# 150s + 425s = 575s <= 600s. These are the SAME figures the budget test
+# in test_unified_llm_config.TestOnboardingAuditFixes asserts - tune the
 # waits and the test together, and against the POOL figure (the larger
 # of the two paths).
 ADMIN_SYNC_PRIMARY_LOCK_WAIT_S = 60.0
 ADMIN_SYNC_RETRY_LOCK_WAIT_S = 150.0
 ADMIN_SYNC_LOCK_RETRIES = 4
+
+
+# ---------------------------------------------------------------------------
+# Convergence (audit F2): "applying" is NOT failure.
+# ---------------------------------------------------------------------------
+# The admin now persists the customer's desired LLM config, COMMITS it, and only
+# THEN drives the agent apply. On a read-timeout it returns an accepted
+# ("applying") outcome instead of a 502 and a */5 admin reconcile cron finishes
+# the apply server-side. Historically the bench stamped a terminal "failed:" the
+# moment the inline POST didn't come back "ok", so a late-succeeding apply left
+# the bench pinned at llm_pool_provisioning FOREVER while the container was
+# actually fine - THE onboarding livelock.
+#
+# Now: an "applying"/timeout outcome is recorded as PENDING (not failed) and the
+# bench CONVERGES from its own end - it polls admin get_connection, whose
+# chat_readiness flips to "Ready" once the apply lands (admin gates Ready on
+# applied_version >= desired_version, so it never reports Ready from mere
+# intent). Convergence stamps the durable success markers; until it converges the
+# status stays "pending: ..." and the UI shows a calm "finishing setup" state.
+_PENDING_APPLYING_STATUS = "pending: admin applying config"
+
+# In-job fast-path convergence poll. Bounded well under the RQ envelope (see the
+# budget note above); anything not converged inside it is finished by the
+# scheduled safety net (reconcile_pending_llm_sync, every 5 min). Probes use a
+# short HTTP timeout so one slow admin read can't stretch the loop past budget.
+_POOL_CONVERGE_DEADLINE_S = 120.0
+_POOL_CONVERGE_INTERVAL_S = 20.0
+_POOL_CONVERGE_PROBE_TIMEOUT_S = 15
+
+
+def _is_applying_result(result) -> bool:
+    """True iff an admin apply response is an ACCEPTED-but-still-converging
+    outcome (C5) rather than a confirmed apply. The creds/pool fleet layer
+    reports this as ``status == "applying"`` (or ``result == "applying"``); a
+    genuine apply is ``status == "applied"`` / ``result == "ok"`` / absent (older
+    contract). Absent keys => treat as a confirmed apply so a fleet still on the
+    pre-C5 contract keeps its old "ok" semantics."""
+    if not isinstance(result, dict):
+        return False
+    return result.get("status") == "applying" or result.get("result") == "applying"
+
+
+def _admin_chat_readiness(*, timeout_s: int = _POOL_CONVERGE_PROBE_TIMEOUT_S):
+    """Probe admin get_connection for (chat_readiness, reason). Returns
+    (state, reason); (None, "<err>") on any failure. Never raises - a convergence
+    probe must not blow up the sync job or the scheduled reconcile."""
+    from jarvis import admin_client
+    try:
+        data = admin_client.get_connection(timeout_s=timeout_s) or {}
+    except Exception as e:  # noqa: BLE001 - convergence probe is best-effort
+        return None, str(e)
+    return (data.get("chat_readiness") or ""), (data.get("chat_readiness_reason") or "")
+
+
+def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
+    """Record a converged apply as a terminal success. last_sync_status keeps the
+    literal "ok" prefix (the _pool_sync_is_redundant dedup gate + the onboarding
+    poller both key off it); the durable llm_pool_synced_at marker is stamped
+    ONLY for pool tenants - it is is_ready_for_chat's evidence-of-successful-apply
+    gate and must never be set from mere intent or an "applying" 200."""
+    import frappe as _frappe
+    now = _frappe.utils.now()
+    fields = {
+        "last_sync_at": now,
+        "last_sync_status": "ok (converged via admin reconcile)",
+    }
+    if is_pool:
+        fields["llm_pool_synced_at"] = now
+    settings.db_set(fields, update_modified=False)
+    _commit_terminal_sync_status()
+
+
+def _converge_via_admin(settings, *, is_pool: bool,
+                        deadline_s: float = _POOL_CONVERGE_DEADLINE_S,
+                        interval_s: float = _POOL_CONVERGE_INTERVAL_S) -> bool:
+    """Poll admin get_connection until chat_readiness == "Ready" (bounded by
+    deadline_s). On Ready: stamp the terminal success markers and return True. On
+    deadline: return False so the caller records the pending state for the
+    scheduled safety net to finish. Under frappe.flags.in_test the loop probes
+    exactly once (no sleep) so tests observe a single deterministic outcome."""
+    import time as _time
+    import frappe as _frappe
+    deadline = _time.monotonic() + deadline_s
+    while True:
+        state, _reason = _admin_chat_readiness()
+        if state == "Ready":
+            _stamp_converged_ok(settings, is_pool=is_pool)
+            return True
+        if _frappe.flags.in_test or _time.monotonic() + interval_s >= deadline:
+            return False
+        _time.sleep(interval_s)
 
 
 def _commit_terminal_sync_status() -> None:
@@ -636,6 +730,22 @@ class JarvisSettings(Document):
                     auth_mode=self.llm_auth_mode or "api_key",
                 ) or {}
                 resolved_action = result.get("action", "restart")
+            # C5/F2: a "restart" (post_update_llm_creds) may come back accepted-
+            # but-still-converging. The admin committed the desired creds and a
+            # reconcile finishes the apply; treat "applying" as PENDING, converge
+            # via get_connection (is_pool=False - the single-model gate keys off
+            # the flat llm_* creds set at save, not llm_pool_synced_at), and only
+            # record pending when it hasn't landed yet. "reload" (hot secret
+            # rotation) has no applying semantics, so it skips this.
+            if action == "restart" and _is_applying_result(result):
+                if not _converge_via_admin(self, is_pool=False):
+                    self.db_set(
+                        "last_sync_status", _PENDING_APPLYING_STATUS,
+                        update_modified=False,
+                    )
+                    _commit_terminal_sync_status()
+                terminal_written = True
+                return
             self.db_set({
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
@@ -668,16 +778,35 @@ class JarvisSettings(Document):
                 message=frappe.get_traceback(),
             )
         except admin_client.AdminUnreachableError as e:
-            self.db_set({
-                "last_sync_at": frappe.utils.now(),
-                "last_sync_status": f"failed: admin unreachable: {e}",
-            })
-            _commit_terminal_sync_status()
-            terminal_written = True
-            frappe.log_error(
-                title="Jarvis: admin unreachable",
-                message=frappe.get_traceback(),
-            )
+            # F2: for a "restart" (creds re-render), an unreachable/timeout is an
+            # apply the admin persisted desired-first and will reconcile - not a
+            # lost change. Converge via get_connection and record PENDING (not
+            # failed) when it hasn't landed yet, mirroring the pool path. "reload"
+            # (hot secret rotation) is a fast, non-desired-first op with no
+            # reconcile, so an unreachable there stays terminal-failed as before.
+            if action == "restart":
+                if not _converge_via_admin(self, is_pool=False):
+                    self.db_set(
+                        "last_sync_status", _PENDING_APPLYING_STATUS,
+                        update_modified=False,
+                    )
+                    _commit_terminal_sync_status()
+                    frappe.logger().warning(
+                        "jarvis_settings: creds sync admin-unreachable; recorded "
+                        "pending for reconcile (%s)", e,
+                    )
+                terminal_written = True
+            else:
+                self.db_set({
+                    "last_sync_at": frappe.utils.now(),
+                    "last_sync_status": f"failed: admin unreachable: {e}",
+                })
+                _commit_terminal_sync_status()
+                terminal_written = True
+                frappe.log_error(
+                    title="Jarvis: admin unreachable",
+                    message=frappe.get_traceback(),
+                )
         except admin_client.AdminRateLimitedError as e:
             retry = e.retry_after_seconds or 0
             retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
@@ -818,16 +947,44 @@ class JarvisSettings(Document):
         if self.flags.get("llm_api_key_changed"):
             return "reload"
 
+        # F5: a re-save of IDENTICAL creds after a sync that DEMONSTRABLY did not
+        # succeed is the customer's natural retry lever - it MUST re-run the full
+        # render+restart apply, not no-op. Before this, an unchanged re-save
+        # classified as None (nothing changed) even when the previous apply
+        # failed/timed out, so the broken container was never re-applied and
+        # onboarding could never recover by saving again. Mirror
+        # _pool_sync_is_redundant's ok-gate, but only when there is a REAL prior
+        # verdict to act on: a non-empty last_sync_status that is not "ok"
+        # (failed:/pending:/skipped:). An EMPTY status is "never attempted" (the
+        # first-ever save is handled by the old is None branch above; an unrelated
+        # field save on a baseline pre-config must stay a genuine no-op), so it is
+        # deliberately NOT forced. Only fires when there is real config to apply.
+        last_status = (self.get("last_sync_status") or "")
+        if last_status and not last_status.startswith("ok"):
+            configured = any(
+                getattr(self, f, None)
+                for f in ("llm_provider", "llm_model", "llm_base_url")
+            ) or bool(getattr(self, "llm_api_key", None))
+            if configured:
+                return "restart"
+
         return None
 
 
 # Auto-retry transient pool-provisioning failures. The fleet-agent can 500
 # ("admin unreachable: … agent_error: Internal Server Error") on a first cold
 # provision that succeeds moments later (e.g. a sidecar not yet healthy within
-# the health-poll window). A bounded retry self-heals the hiccup so it never
+# the health-poll window). A bounded retry self-heals the FAST hiccup so it never
 # strands the customer at the Connect-AI step. Only AdminUnreachableError (the
 # 502/agent_error/connection class) is retried; auth/validation are terminal.
-_POOL_SYNC_RETRIES = 3
+#
+# 2 (was 3): a genuine read-TIMEOUT surfaces as the same AdminUnreachableError,
+# so retrying it 3x150s would storm the budget - and it no longer needs to, since
+# an unreachable outcome now drains through the convergence poll (which absorbs a
+# still-applying apply) rather than a blind re-POST. Two attempts keep the cheap
+# fast-500 self-heal; the convergence loop + the */5 reconcile own everything
+# slower. Keep this in lockstep with the budget arithmetic on ADMIN_SYNC_*.
+_POOL_SYNC_RETRIES = 2
 _POOL_SYNC_RETRY_DELAY_S = 5
 
 
@@ -972,6 +1129,23 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
         terminal_written = False
         try:
             result = _post_pool_with_retry(spec, api_keys, oauth_blobs) or {}
+            # C5/F2: an accepted-but-still-converging apply ("applying") is NOT a
+            # confirmed apply. The admin committed the desired pool and a reconcile
+            # will finish it; the bench must NOT stamp llm_pool_synced_at off this
+            # 200 (that field is evidence of a SUCCESSFUL apply and gates chat
+            # readiness). Poll get_connection for chat_readiness == "Ready" (the
+            # cheap in-job fast path); if it lands, _stamp_converged_ok sets the
+            # markers, otherwise record the pending state and let the */5 reconcile
+            # finish it. Either way this is terminal for THIS job (no failed write).
+            if _is_applying_result(result):
+                if not _converge_via_admin(settings, is_pool=True):
+                    settings.db_set(
+                        "last_sync_status", _PENDING_APPLYING_STATUS,
+                        update_modified=False,
+                    )
+                    _commit_terminal_sync_status()
+                terminal_written = True
+                return
             resolved_action = result.get("action", "pool_update")
             _synced = {
                 "last_sync_at": _frappe.utils.now(),
@@ -1030,17 +1204,25 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 message=_frappe.get_traceback(),
             )
         except admin_client.AdminUnreachableError as e:
-            settings.db_set({
-                "last_sync_at": _frappe.utils.now(),
-                "last_sync_status": f"failed: admin unreachable: {e}",
-                **_cleared_subscription_status_fields(),
-            })
-            _commit_terminal_sync_status()
+            # F2: an unreachable/timeout is NOT a lost apply. The admin persists
+            # desired-first (committed) and reconciles a late-landing apply, so
+            # writing a terminal "failed:" here is exactly the livelock that
+            # blocked onboarding - the container often applied the pool moments
+            # after the bench hung up. Converge instead: poll get_connection for
+            # chat_readiness == "Ready" (stamps the success markers on a hit);
+            # otherwise record PENDING (not failed) and let the */5 reconcile
+            # finish it. Only genuine auth/validation/rate-limit stay terminal.
+            if not _converge_via_admin(settings, is_pool=True):
+                settings.db_set(
+                    "last_sync_status", _PENDING_APPLYING_STATUS,
+                    update_modified=False,
+                )
+                _commit_terminal_sync_status()
+                _frappe.logger().warning(
+                    "jarvis_settings: pool sync admin-unreachable; recorded "
+                    "pending for reconcile (%s)", e,
+                )
             terminal_written = True
-            _frappe.log_error(
-                title="Jarvis: admin unreachable (pool sync)",
-                message=_frappe.get_traceback(),
-            )
         except admin_client.AdminRateLimitedError as e:
             retry = e.retry_after_seconds or 0
             retry_str = f"retry_after={retry}s" if retry > 0 else "retry shortly"
@@ -1150,3 +1332,65 @@ def _enqueued_sync_via_admin(action: str, retry_left: int = ADMIN_SYNC_LOCK_RETR
             return
         settings = frappe.get_single("Jarvis Settings")
         settings._sync_via_admin(action)
+
+
+def reconcile_pending_llm_sync() -> None:
+    """Scheduled safety net (*/5, hooks.py): finish a sync the in-band job left
+    PENDING because the admin apply was still converging (F2).
+
+    Mirrors the admin-side */5 reconcile from the bench end so the two systems
+    converge from either direction. It is deliberately minimal and defensive:
+
+    - No-op unless the tenant is in a state the admin reconcile might have
+      resolved since the bench last looked: either the explicit
+      ``pending: admin applying config`` marker, OR a pool whose FIRST apply is
+      still unproven (proxy_active + no llm_pool_synced_at) sitting at a
+      pending/failed status (the onboarding livelock class).
+    - Probes admin get_connection EXACTLY ONCE (chat_readiness); stamps the
+      terminal success markers only on "Ready" (admin gates Ready on
+      applied_version >= desired_version, so it never reports Ready from intent).
+    - Never flips a status to a new "failed:" and never touches a healthy /
+      already-"ok" tenant. Swallows every error - a scheduled task must not
+      raise. Self-host and un-onboarded sites short-circuit.
+    """
+    try:
+        from jarvis import selfhost
+        if selfhost.is_self_hosted():
+            return
+
+        settings = frappe.get_single("Jarvis Settings")
+        # Un-onboarded: no admin credentials -> get_connection would just raise.
+        admin_api_key = (settings.get_password(
+            "jarvis_admin_api_key", raise_exception=False) or "").strip()
+        customer_pw = (settings.get_password(
+            "jarvis_admin_customer_password", raise_exception=False) or "").strip()
+        if not admin_api_key and not customer_pw:
+            return
+
+        status = (settings.get("last_sync_status") or "")
+        proxy_active = bool(settings.get("proxy_active"))
+        pool_synced = bool(settings.get("llm_pool_synced_at"))
+
+        is_applying_pending = status.startswith(_PENDING_APPLYING_STATUS)
+        # A pool whose first apply never stamped the marker may have been
+        # converged by the admin reconcile cron since the bench last wrote its
+        # (pending/failed) status - re-probe so the customer isn't stranded at
+        # llm_pool_provisioning while the container is actually serving the pool.
+        is_unproven_pool = (
+            proxy_active and not pool_synced
+            and (status.startswith("pending:") or status.startswith("failed:"))
+        )
+        if not (is_applying_pending or is_unproven_pool):
+            return
+
+        state, _reason = _admin_chat_readiness()
+        if state == "Ready":
+            # Stamp llm_pool_synced_at only for pool tenants (is_pool=proxy_active):
+            # for a single-model tenant the flat creds set at save time is already
+            # the readiness gate, so it just clears the pending status to "ok".
+            _stamp_converged_ok(settings, is_pool=proxy_active)
+    except Exception:
+        frappe.log_error(
+            title="Jarvis: reconcile_pending_llm_sync failed",
+            message=frappe.get_traceback(),
+        )

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -102,16 +102,23 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
         self.assertTrue(s.last_sync_status.startswith("ok"), f"expected ok, got {s.last_sync_status!r}")
 
     def test_pool_sync_gives_up_after_bounded_retries(self):
-        """Persistent unreachable → terminal 'failed', but only after the bounded
-        retry budget (no infinite loop)."""
+        """Persistent unreachable → the bounded retry budget runs (no infinite
+        loop), then F2 convergence takes over: an unreachable/timeout is NOT a
+        lost apply (admin persists desired-first and reconciles it), so the
+        outcome is PENDING, not a terminal 'failed'. A get_connection probe that
+        is not yet Ready leaves the pending marker for the */5 safety net."""
         from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import _POOL_SYNC_RETRIES
         with patch("jarvis.admin_client.post_update_llm_pool",
                    side_effect=admin_client.AdminUnreachableError("down")) as m, \
-             patch("jarvis.admin_client.post_update_llm_creds"):
+             patch("jarvis.admin_client.post_update_llm_creds"), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
             onboarding.save_llm_pool(frappe.as_json(self._two_models()), preset=None, routing_mode="failover")
         self.assertEqual(m.call_count, _POOL_SYNC_RETRIES)
         s = frappe.get_single("Jarvis Settings")
-        self.assertIn("admin unreachable", s.last_sync_status)
+        self.assertTrue(
+            (s.last_sync_status or "").startswith("pending: admin applying"),
+            f"unreachable must converge to pending, not failed; got {s.last_sync_status!r}")
 
     def test_preset_validated_against_catalog(self):
         models = [{"provider": "openai", "model": "gpt-5.5", "api_key": "sk-x", "base_url": "", "tier": "strong", "order": 0}]

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2437,9 +2437,11 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertGreater(cumulative_wait, ADMIN_SYNC_LOCK_TIMEOUT_S,
                            "retry-chain cumulative lock wait must outlive a dead holder's TTL")
         # And the per-attempt wait must not eat the work budget: wait + POST
-        # work (~370s: 3x120 + sleeps, lock wait excluded) must fit the envelope.
-        self.assertLessEqual(ADMIN_SYNC_RETRY_LOCK_WAIT_S + 380, ADMIN_SYNC_RQ_TIMEOUT_S,
-                             "retry lock wait + worst-case POST work must fit the RQ envelope")
+        # work (~425s: 2x150 pool attempts + 5s sleep + ~120s in-job convergence
+        # poll, lock wait excluded) must fit the envelope. Tuning _POOL_SYNC_RETRIES,
+        # the pool HTTP timeout, or _POOL_CONVERGE_DEADLINE_S moves this figure.
+        self.assertLessEqual(ADMIN_SYNC_RETRY_LOCK_WAIT_S + 425, ADMIN_SYNC_RQ_TIMEOUT_S,
+                             "retry lock wait + worst-case POST+convergence work must fit the RQ envelope")
 
         settings = frappe.get_single("Jarvis Settings")
         captured = []
@@ -2557,10 +2559,17 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertEqual(settings.last_sync_warnings, "[]")
 
     def test_failed_pool_sync_clears_stale_subscription_status_and_warnings(self):
-        """A FAILED sync must clear both fields even when a PRIOR successful
-        apply had set them - a stale 'verified' status must not linger next
-        to a 'failed:' status the poller reads as broken."""
-        from jarvis.exceptions import AdminUnreachableError
+        """A genuinely-terminal FAILED sync (auth/validation) must clear both
+        fields even when a PRIOR successful apply had set them - a stale
+        'verified' status must not linger next to a 'failed:' status the poller
+        reads as broken.
+
+        NB (F2): an AdminUnreachableError/timeout is NO LONGER a terminal failure
+        - it converges to 'pending' and is reconciled, so this test now uses a
+        genuine terminal error (AdminAuthError) to exercise the failed-clearing
+        path. The unreachable->pending path is covered by
+        test_pool_sync_unreachable_records_pending_not_failed."""
+        from jarvis.exceptions import AdminAuthError
 
         self._seed_pool()
         with patch("jarvis.admin_client.post_update_llm_pool",
@@ -2572,7 +2581,7 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertEqual(settings.last_subscription_status, "verified")
 
         with patch("jarvis.admin_client.post_update_llm_pool",
-                   side_effect=AdminUnreachableError("boom")):
+                   side_effect=AdminAuthError("bad token")):
             _enqueued_sync_via_admin_pool()
 
         settings = frappe.get_single("Jarvis Settings")
@@ -2610,6 +2619,220 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         settings = frappe.get_single("Jarvis Settings")
         self.assertEqual(settings.last_subscription_status, status_before)
         self.assertEqual(settings.last_sync_warnings, warnings_before)
+
+
+class TestConvergenceReconcile(_RT3SettingsTestCase):
+    """Audit F2 (livelock) + C5 (applying-is-not-failure) + F5 (retry
+    classification) + F1 (timeout ladder).
+
+    An admin apply that is accepted-but-still-converging ("applying") or times
+    out is recorded as PENDING (never terminal "failed"), and the bench converges
+    to the durable success markers by polling admin get_connection's
+    chat_readiness. Critically: llm_pool_synced_at (is_ready_for_chat's
+    evidence-of-successful-apply gate) is stamped ONLY on a confirmed apply or a
+    convergence "Ready" - never off an "applying" 200.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._clear_models()
+        _reset_settings()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("preset", "", update_modified=False)
+        settings.db_set("proxy_active", 0, update_modified=False)
+        settings.db_set("proxy_recommended", 0, update_modified=False)
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        settings.db_set("last_sync_status", "", update_modified=False)
+        frappe.db.commit()
+
+    def _seed_pool(self):
+        settings = frappe.get_single("Jarvis Settings")
+        _add_model_row(settings, provider="openai_compat", model="gpt-4o",
+                       tier="strong", order=0, api_key="sk-conv-1",
+                       base_url="https://api.openai.com")
+        _add_model_row(settings, provider="openai_compat", model="gpt-3.5-turbo",
+                       tier="cheap", order=1, api_key="sk-conv-2",
+                       base_url="https://api.openai.com")
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update"}):
+            settings.save()
+        # A clean baseline for the applying/timeout assertions below.
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        frappe.db.commit()
+
+    def _seed_admin_creds(self):
+        """Write an admin api_key into __Auth so reconcile_pending_llm_sync does
+        not short-circuit on "un-onboarded". Deliberately does NOT commit: the
+        __Auth row must stay inside the test transaction so FrappeTestCase's
+        rollback cleans it up (a committed password write escapes rollback and
+        pollutes the shared singleton for every later test - e.g. is_onboarded).
+        Call it AFTER the plain-field commit so no later commit flushes it."""
+        from frappe.utils.password import set_encrypted_password
+        set_encrypted_password("Jarvis Settings", "Jarvis Settings",
+                               "test-admin-key", "jarvis_admin_api_key")
+
+    # -- C5/P1-7: "applying" is pending, and must NOT stamp the marker --------
+
+    def test_applying_result_records_pending_not_failed_and_no_marker(self):
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update", "status": "applying"}), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(
+            (settings.last_sync_status or "").startswith("pending: admin applying"),
+            f"an 'applying' apply must be pending, not failed; got {settings.last_sync_status!r}")
+        self.assertFalse(
+            settings.llm_pool_synced_at,
+            "llm_pool_synced_at must NOT be stamped off an 'applying' 200 - it is "
+            "evidence of a SUCCESSFUL apply and gates chat readiness")
+
+    def test_applying_then_ready_converges_and_stamps_marker(self):
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool_update", "status": "applying"}), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"),
+                        f"a converged apply must read ok; got {settings.last_sync_status!r}")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "convergence to chat_readiness Ready must stamp llm_pool_synced_at")
+
+    # -- F2: timeout/unreachable is pending+converge, never a lost apply -----
+
+    def test_unreachable_then_ready_converges_and_stamps_marker(self):
+        from jarvis.exceptions import AdminUnreachableError
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   side_effect=AdminUnreachableError("read timeout")), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"))
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "an unreachable apply that the container actually landed must "
+                        "converge to ok+marker, not livelock at failed")
+
+    def test_unreachable_not_ready_records_pending_not_failed(self):
+        from jarvis.exceptions import AdminUnreachableError
+        self._seed_pool()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   side_effect=AdminUnreachableError("read timeout")), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(
+            (settings.last_sync_status or "").startswith("pending: admin applying"),
+            f"unreachable must record pending for the reconcile, not failed; "
+            f"got {settings.last_sync_status!r}")
+        self.assertFalse(settings.llm_pool_synced_at)
+
+    # -- Scheduled safety net (reconcile_pending_llm_sync) -------------------
+
+    def test_reconcile_stamps_marker_when_admin_reports_ready(self):
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            reconcile_pending_llm_sync,
+        )
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("proxy_active", 1, update_modified=False)
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        settings.db_set("last_sync_status", "pending: admin applying config",
+                        update_modified=False)
+        frappe.db.commit()
+        self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+        with patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            reconcile_pending_llm_sync()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_pool_synced_at,
+                        "the */5 reconcile must stamp the marker once admin reports Ready")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"))
+
+    def test_reconcile_noop_when_not_ready(self):
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            reconcile_pending_llm_sync,
+        )
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("proxy_active", 1, update_modified=False)
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        settings.db_set("last_sync_status", "pending: admin applying config",
+                        update_modified=False)
+        frappe.db.commit()
+        self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+        with patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
+            reconcile_pending_llm_sync()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertFalse(settings.llm_pool_synced_at)
+        self.assertTrue((settings.last_sync_status or "").startswith("pending:"))
+
+    def test_reconcile_noop_on_healthy_tenant(self):
+        """Inert on a healthy fleet: an 'ok' tenant is never probed or re-stamped."""
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            reconcile_pending_llm_sync,
+        )
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("proxy_active", 1, update_modified=False)
+        settings.db_set("llm_pool_synced_at", frappe.utils.now(), update_modified=False)
+        settings.db_set("last_sync_status", "ok (pool_update via admin)",
+                        update_modified=False)
+        frappe.db.commit()
+        self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+        with patch("jarvis.admin_client.get_connection") as m:
+            reconcile_pending_llm_sync()
+        m.assert_not_called()
+
+    # -- F5: a re-save after a NON-ok sync forces a full restart apply -------
+
+    def test_classify_forces_restart_when_last_sync_not_ok(self):
+        s = frappe.get_single("Jarvis Settings")
+        s.llm_provider = "OpenAI"
+        s.llm_model = "gpt-4o"
+        s.llm_base_url = ""
+        s.flags.force_admin_sync = False
+        s.flags.llm_auth_mode_changed = False
+        s.flags.llm_api_key_changed = False
+        before = frappe._dict(llm_provider="OpenAI", llm_model="gpt-4o", llm_base_url="")
+
+        s.last_sync_status = "failed: admin unreachable: x"
+        with patch.object(type(s), "get_doc_before_save", return_value=before):
+            self.assertEqual(
+                s._classify_llm_change(), "restart",
+                "a re-save of identical creds after a FAILED sync must re-run the "
+                "full apply (F5), not no-op")
+
+        # Mirror image: an unchanged save after an OK sync stays a no-op.
+        s.last_sync_status = "ok (restart via admin)"
+        with patch.object(type(s), "get_doc_before_save", return_value=before):
+            self.assertIsNone(
+                s._classify_llm_change(),
+                "an unchanged re-save after an OK sync must remain a no-op")
+
+    # -- F1: the timeout ladder + both apply legs ride DEFAULT_TIMEOUT_S -----
+
+    def test_default_timeout_is_150_and_apply_legs_use_it(self):
+        from jarvis import admin_client
+        self.assertEqual(admin_client.DEFAULT_TIMEOUT_S, 150,
+                         "bench->admin budget must sit above the 100s admin->agent leg")
+        captured = []
+
+        def _cap(path, body, *, timeout_s=admin_client.DEFAULT_TIMEOUT_S):
+            captured.append(timeout_s)
+            return {}
+
+        with patch("jarvis.admin_client._post", side_effect=_cap):
+            admin_client.post_update_llm_pool(spec={}, api_keys={}, oauth_blobs={})
+            admin_client.post_update_llm_creds(
+                provider="p", model="m", base_url="", api_key="k")
+        self.assertEqual(captured, [150, 150],
+                         "both interactive apply legs must ride DEFAULT_TIMEOUT_S=150")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The customer-bench half of the onboarding-stability work (stacks on #311). The admin half is jarvis-admin-v2 PR #1; together they close the onboarding livelock (audit finding F2) that meant managed onboarding **never completed end-to-end**.

**Problem:** the admin now persists desired LLM config first and, on an apply timeout, returns an accepted/"applying" result while a server-side */5 reconcile finishes the apply. The bench previously treated any non-ok as terminal `failed:` and stamped `llm_pool_synced_at` off any 200 — so a late-succeeding apply left the customer stuck at "provisioning" forever, and each re-save re-timed-out.

**This PR:**
- `admin_client`: `DEFAULT_TIMEOUT_S` 90→150 (the admin→agent leg is now 100s; 150 gives real headroom); `post_update_llm_pool` rides the default; `get_connection` gains a short-budget keyword timeout for convergence probes.
- `jarvis_settings`: an `applying`/timeout outcome is **pending, not failed** — an in-job fast-path poll of `get_connection` (20s × ≤120s), then `pending: admin applying config`. `llm_pool_synced_at` is stamped ONLY on real convergence evidence (`chat_readiness == "Ready"`), never off a 200-with-applying. A failed last-sync forces a full reapply on re-save (fixes the classification bug where a retry did nothing).
- **New `reconcile_pending_llm_sync` on the `*/5` cron** — the bench half of the two-sided reconcile: probes `get_connection` while a pending marker is set and stamps on Ready. Without it a pending apply that outlives the in-job poll was a permanent dead-end.
- `OnboardingView`: the pending state shows a calm "Finishing setup" note and keeps polling; only a genuine terminal failure shows the error UI.

**Verification:** server-side onboarding proven live (a real stuck tenant went Configuring→Ready in 15s, plugin loaded, reconcile a no-op after). Bench module tests green. Recovered from a stash the chat-mining session had parked it in; resolved the `get_connection`/timeout conflict onto the repointed base.

> Deploy order: admin (jarvis-admin-v2 PR #1) + agent 0.2.11 must be live before this bench half, so the "applying" contract exists on the other end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)