### PR TITLE
fix(chat): skip auto-title for a deleted conversation instead of logging

### DIFF
--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -229,6 +229,8 @@ def autotitle_job(conversation_id: str, user: str) -> None:
 		gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 		if not gateway_url:
 			return
+		if not frappe.db.exists(CONV, conversation_id):
+			return  # deleted between enqueue and run — benign race, not an error
 		conv = frappe.get_doc(CONV, conversation_id)
 		model, provider = _resolve_model_and_provider(conv)
 		maybe_autotitle(


### PR DESCRIPTION
## Problem

`autotitle_job` runs on the short queue after a chat turn finishes. If the conversation is deleted between when the job is enqueued and when it runs, `frappe.get_doc(CONV, conversation_id)` raises `DoesNotExistError`. The job's best-effort `except Exception` catches it and logs it via `frappe.log_error("auto-title job failed", …)` — so a benign, expected race surfaces as a scary Error Log entry:

```
frappe.exceptions.DoesNotExistError: Jarvis Conversation 1ndtt6lqpa not found
  File "apps/jarvis/jarvis/chat/title.py", line 187, in autotitle_job
    conv = frappe.get_doc(CONV, conversation_id)
```

It never affected the finished turn (the job is best-effort by design), but it pollutes the Error Log with noise every time a just-created conversation is cleaned up before its title job runs.

## Fix

Return early when the conversation no longer exists — matching the function's existing no-op guards (`if not gateway_url: return`). A deleted conversation is now a silent no-op; genuinely unexpected failures are still logged.

```diff
 if not gateway_url:
     return
+if not frappe.db.exists(CONV, conversation_id):
+    return  # deleted between enqueue and run — benign race, not an error
 conv = frappe.get_doc(CONV, conversation_id)
```

## Verification

Ran `autotitle_job("<nonexistent-id>", "Administrator")` against a live site: it returns `None` with **zero** new Error Log entries. Before the fix, the same call logged the `DoesNotExistError` traceback shown above.
