### PR TITLE
feat(export_excel): multi-tab workbooks via a sheets param

### DIFF
--- a/jarvis/tests/test_export_excel.py
+++ b/jarvis/tests/test_export_excel.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.exceptions import NoDataError
+from jarvis.exceptions import InvalidArgumentError, NoDataError
 from jarvis.tools.export_excel import export_excel
 
 
@@ -59,3 +59,72 @@ class TestExportExcelNoData(FrappeTestCase):
             )
             out = export_excel([["Name", "Qty"], ["Widget", 5]])
         self.assertEqual(out["file_url"], "/private/files/ll.xlsx")
+
+
+def _saved_bytes(mock):
+    """The content bytes export_excel handed save_file (2nd positional arg)."""
+    return mock.call_args.args[1]
+
+
+def _load(content):
+    from io import BytesIO
+
+    from openpyxl import load_workbook
+
+    return load_workbook(BytesIO(content))
+
+
+class TestExportExcelMultiSheet(FrappeTestCase):
+    def _mock_save(self):
+        m = patch("frappe.utils.file_manager.save_file").start()
+        self.addCleanup(patch.stopall)
+        m.return_value = frappe._dict(
+            file_url="/private/files/wb.xlsx", file_name="wb.xlsx", file_size=99, name="F-WB"
+        )
+        return m
+
+    def test_builds_named_tabs_in_order(self):
+        m = self._mock_save()
+        out = export_excel(
+            title="MIS",
+            sheets=[
+                {"title": "Financials", "rows": [{"metric": "Revenue", "value": 100}]},
+                {"title": "Customers", "rows": [["Name", "Due"], ["Acme", 50]]},
+            ],
+        )
+        self.assertEqual(out["file_url"], "/private/files/wb.xlsx")
+        wb = _load(_saved_bytes(m))
+        self.assertEqual(wb.sheetnames, ["Financials", "Customers"])
+        self.assertEqual(wb["Financials"]["A1"].value, "metric")   # header from dict keys
+        self.assertEqual(wb["Financials"]["A2"].value, "Revenue")
+        self.assertEqual(wb["Customers"]["B2"].value, 50)           # list-of-lists body
+
+    def test_empty_tabs_are_skipped_but_the_rest_ship(self):
+        m = self._mock_save()
+        export_excel(
+            title="w",
+            sheets=[
+                {"title": "HR", "rows": []},                 # empty → skipped
+                {"title": "Ops", "rows": [{"a": 1}]},        # kept
+                {"title": "Blank", "rows": [{"a": None}]},   # all-blank → skipped
+            ],
+        )
+        self.assertEqual(_load(_saved_bytes(m)).sheetnames, ["Ops"])
+
+    def test_all_empty_raises_no_data(self):
+        with self.assertRaises(NoDataError):
+            export_excel(sheets=[{"title": "A", "rows": []}, {"title": "B", "rows": [{}]}])
+
+    def test_empty_sheets_list_is_invalid(self):
+        with self.assertRaises(InvalidArgumentError):
+            export_excel(sheets=[])
+
+    def test_duplicate_titles_get_unique_sheet_names(self):
+        m = self._mock_save()
+        export_excel(
+            sheets=[
+                {"title": "Summary", "rows": [{"a": 1}]},
+                {"title": "Summary", "rows": [{"a": 2}]},
+            ],
+        )
+        self.assertEqual(_load(_saved_bytes(m)).sheetnames, ["Summary", "Summary-2"])

--- a/jarvis/tools/export_excel.py
+++ b/jarvis/tools/export_excel.py
@@ -6,6 +6,13 @@ here; we build the workbook with ``frappe.utils.xlsxutils.make_xlsx`` — the
 same engine Frappe's own report export uses — and save the bytes as a private
 File. The chat surface then renders a download card from the returned
 ``file_url``.
+
+Two shapes:
+  * single sheet — pass ``rows`` (+ optional ``title`` / ``columns``);
+  * multi-tab workbook — pass ``sheets`` = a list of
+    ``{"title", "rows", "columns"?}``; ``title`` then names the file. This is
+    the only way to hand the user a real multi-tab workbook as a download —
+    building one by hand via ``exec`` leaves the file stranded in the container.
 """
 import frappe
 
@@ -15,20 +22,66 @@ _XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 def export_excel(
-	rows: list,
+	rows: list | None = None,
 	title: str | None = None,
 	columns: list | None = None,
+	sheets: list | None = None,
 ) -> dict:
-	"""Build an .xlsx from ``rows`` and return
-	``{file_url, filename, mime_type, size_bytes, name}``.
+	"""Build an .xlsx and return ``{file_url, filename, title, mime_type,
+	size_bytes, name}``.
 
-	``rows`` is either a list of dicts (columns = first row's keys, or the
-	given ``columns``) or a list of lists (first row is the header unless
-	``columns`` is given). ``title`` names the sheet + file.
+	Single sheet: ``rows`` is a list of dicts (columns = first row's keys, or
+	the given ``columns``) or a list of lists (first row is the header unless
+	``columns`` is given); ``title`` names the sheet + file.
+
+	Multi-tab: pass ``sheets`` = ``[{"title": str, "rows": [...], "columns":
+	[...]?}, ...]`` — one tab per entry (empty tabs are skipped). ``title``
+	names the workbook file. When ``sheets`` is given, ``rows`` is ignored.
 	"""
-	# Nothing to export → tell the caller plainly instead of handing back an
-	# empty (or header-only) workbook the user then has to open to discover is
-	# blank. The agent relays this message to the user.
+	if sheets is not None:
+		if not isinstance(sheets, list) or not sheets:
+			raise InvalidArgumentError("sheets must be a non-empty list of {title, rows}.")
+		sheet_data: list[tuple[str, list]] = []
+		used: set[str] = set()
+		for i, spec in enumerate(sheets):
+			if not isinstance(spec, dict):
+				raise InvalidArgumentError(
+					"each sheet must be an object with 'rows' (+ optional 'title', 'columns').")
+			try:
+				data = _normalize(spec.get("rows"), spec.get("columns"))
+			except NoDataError:
+				continue  # skip an empty tab, keep the rest of the workbook
+			sheet_data.append((_unique_sheet_name(spec.get("title") or f"Sheet{i + 1}", used), data))
+		# Every tab was empty → nothing to hand back (same rule as single-sheet).
+		if not sheet_data:
+			raise NoDataError("No data to prepare for Excel.")
+	else:
+		sheet_data = [((title or "Sheet1")[:31], _normalize(rows, columns))]
+
+	content = _workbook_bytes(sheet_data)
+
+	from frappe.utils.file_manager import save_file
+
+	safe = (title or "export").replace(" ", "-").replace("/", "-")[:60] or "export"
+	fdoc = save_file(f"{safe}.xlsx", content, None, None, is_private=1)
+	return {
+		"file_url": fdoc.file_url,
+		"filename": fdoc.file_name,
+		"title": title or "Export",  # clean title for the chat artifact card
+		"mime_type": _XLSX_MIME,
+		"size_bytes": int(fdoc.file_size or len(content)),
+		"name": fdoc.name,
+	}
+
+
+def _normalize(rows, columns) -> list:
+	"""``rows`` (list of dicts or list of lists) → ``[header] + body`` 2D list.
+
+	Raises ``NoDataError`` for an empty / contentless set (no columns, no data
+	rows, or every cell blank) and ``InvalidArgumentError`` for a malformed one
+	— the same guards the single-sheet path has always applied, now shared by
+	every tab so one blank tab can't ship a user a workbook that opens empty.
+	"""
 	if not isinstance(rows, list) or not rows:
 		raise NoDataError("No data to prepare for Excel.")
 
@@ -46,32 +99,42 @@ def export_excel(
 	else:
 		raise InvalidArgumentError("rows must be a list of dicts or a list of lists")
 
-	# Reject a contentless workbook — no columns, no data rows, or every cell
-	# blank — instead of handing back a blank .xlsx the user opens to find empty.
-	# (The earlier guard only caught zero rows, so `[{}]` / all-None rows and
-	# header-only lists still generated a file.)
 	if not header or not any(_nonempty(c) for r in body for c in r):
 		raise NoDataError("No data to prepare for Excel.")
-	data = [header] + body
+	return [header] + body
 
-	from frappe.utils.xlsxutils import make_xlsx
 
-	sheet = (title or "Sheet1")[:31]  # Excel caps sheet names at 31 chars
-	xlsx = make_xlsx(data, sheet)  # io.BytesIO
-	content = xlsx.getvalue()
+def _workbook_bytes(sheet_data: list[tuple[str, list]]) -> bytes:
+	"""One workbook, a sheet per (name, data). Mirrors ``make_xlsx``'s own
+	workbook options so dates format identically, then reuses ``make_xlsx``
+	(which appends a bold-header worksheet) for each tab."""
+	from io import BytesIO
 
-	from frappe.utils.file_manager import save_file
+	import xlsxwriter
+	from frappe.utils.xlsxutils import XLSXStyleBuilder, make_xlsx
 
-	safe = (title or "export").replace(" ", "-").replace("/", "-")[:60] or "export"
-	fdoc = save_file(f"{safe}.xlsx", content, None, None, is_private=1)
-	return {
-		"file_url": fdoc.file_url,
-		"filename": fdoc.file_name,
-		"title": title or "Export",  # clean title for the chat artifact card
-		"mime_type": _XLSX_MIME,
-		"size_bytes": int(fdoc.file_size or len(content)),
-		"name": fdoc.name,
-	}
+	out = BytesIO()
+	wb = xlsxwriter.Workbook(out, {
+		"constant_memory": True,
+		"default_date_format": XLSXStyleBuilder.get_datetime_format(),
+	})
+	for name, data in sheet_data:
+		make_xlsx(data, name, wb=wb)  # adds a worksheet to `wb`, returns None
+	wb.close()
+	return out.getvalue()
+
+
+def _unique_sheet_name(raw, used: set[str]) -> str:
+	"""Excel sheet names are ≤31 chars and must be unique; de-dupe collisions
+	(after truncation) so a workbook with two 'Summary' tabs doesn't blow up."""
+	base = (str(raw) or "Sheet")[:31]
+	name, n = base, 2
+	while name.lower() in used:
+		suffix = f"-{n}"
+		name = base[:31 - len(suffix)] + suffix
+		n += 1
+	used.add(name.lower())
+	return name
 
 
 def _cell(v):


### PR DESCRIPTION
## Problem

`export_excel` only builds a **single-sheet** workbook (`title` names the one sheet). A multi-tab workbook therefore has **no** download-producing tool, so the agent falls back to `exec`/openpyxl — and an exec-built file never reaches the user (it stays in the container). That's why a multi-tab MIS workbook shows *"Created the workbook"* with **no download card** (confirmed on a live chat: no attached File, no canvas reference).

## Fix

Add a `sheets=[{title, rows, columns?}, ...]` parameter that builds one tab per entry, reusing Frappe's own `make_xlsx` engine (one workbook, a sheet per tab). Empty tabs are skipped, duplicate sheet names are de-duped, and the row normalization is shared so every tab keeps the existing 'no blank workbook' guards. **Single-sheet form is unchanged.**

## Verified

- +5 regression tests, **12 total pass**.
- Live on jarvis.local: a 3-tab export produced a real private downloadable File — tabs `Financials`, `Customers`, `Financials-2` (dup de-duped), empty `HR` skipped, dict-rows + list-of-lists both correct.

Companion changes advertise it to the agent: the plugin tool schema (`sheets` param) and the persona download guidance.