### PR TITLE
fix(personalise): include Jarvis Admins in Org-scope question targeting

### DIFF
--- a/jarvis/learning/questions.py
+++ b/jarvis/learning/questions.py
@@ -357,9 +357,10 @@ def on_rule_update(doc, method: str | None = None) -> None:
 
 
 def _rule_in_scope_users(rule) -> list[str]:
-	"""In-scope users for a rule, mirroring the Jarvis Wiki Page scope model:
-	Org = every enabled desk user (Jarvis User or System Manager), Role = holders
-	of target_role, User = target_user only."""
+	"""In-scope users for a rule: Org = every enabled desk person who can use
+	Jarvis (Jarvis User, Jarvis Admin, or System Manager), Role = holders of
+	target_role, User = target_user only. Administrator/Guest are always excluded
+	(service identities, filtered by ``_users_with_role``)."""
 	scope = rule.scope or "Org"
 	if scope == "User":
 		u = rule.target_user
@@ -370,8 +371,15 @@ def _rule_in_scope_users(rule) -> list[str]:
 		if not rule.target_role:
 			return []
 		return _users_with_role(rule.target_role)
-	# Org: enabled desk users with Jarvis User or System Manager.
-	users = set(_users_with_role("Jarvis User")) | set(_users_with_role("System Manager"))
+	# Org: every enabled person with Jarvis access. Jarvis Admin is included so an
+	# admin who authors an org-wide question is also asked it (they are part of the
+	# org too) — otherwise a Jarvis-Admin-only account never receives its own org
+	# questions. Administrator/Guest stay excluded via _users_with_role.
+	users = (
+		set(_users_with_role("Jarvis User"))
+		| set(_users_with_role("Jarvis Admin"))
+		| set(_users_with_role("System Manager"))
+	)
 	return sorted(users)
 
 

--- a/jarvis/tests/test_personalise_pipeline.py
+++ b/jarvis/tests/test_personalise_pipeline.py
@@ -340,6 +340,19 @@ class TestRuleQuestionMaterialization(_PipelineFixture):
 			self.assertEqual(rows[0]["origin"], "From your organisation")
 			self.assertEqual(rows[0]["question"], rule.question)
 
+	def test_org_scope_includes_jarvis_admin(self):
+		# An admin who authors an org-wide question is part of the org and must be
+		# asked it too — a Jarvis-Admin-only account was previously left out.
+		rule = self._rule()
+		with mock.patch.object(
+			questions,
+			"_users_with_role",
+			side_effect=lambda role: {"Jarvis Admin": [ADMIN_USER]}.get(role, []),
+		):
+			out = questions.materialize_rule_questions(rule.name)
+		self.assertEqual(out["created"], 1)
+		self.assertEqual(len(self._user_questions(ADMIN_USER, source_config=rule.name)), 1)
+
 	def test_role_scope_only_targets_role_holders(self):
 		rule = self._rule(scope="Role", target_role=TEST_ROLE)
 		with mock.patch.object(


### PR DESCRIPTION
## Problem
Org-scope Personalise question rules ("ask everyone") materialize a question for every holder of **Jarvis User** or **System Manager**, excluding `Administrator`/`Guest`. So a **Jarvis-Admin-only account** — the exact persona that authors org questions — never received its own org questions. (Reported: "there are 2 questions in the personalise for everyone in the org, but they're not shown to me.")

It was never a "creator" exclusion (no such logic exists) — it's a role-set gap.

## Fix
Add `Jarvis Admin` to the Org target set in `questions._rule_in_scope_users`, so an admin who authors an org-wide question is also asked it (they're part of the org too). Role/User scopes and the `Administrator`/`Guest` exclusion are unchanged.

Existing org rules reach admins automatically on the next daily `materialize_rule_questions` sweep (or the rule's next save) via the existing `(source_config, user)` dedupe — only the newly-in-scope admins get a row; no duplicates.

> Note: if you were seeing this while logged in as `Administrator` itself, that account is a service identity and is *always* excluded by design — use a normal Jarvis account.

## Tests
- New `test_org_scope_includes_jarvis_admin`.
- Existing `test_org_scope_fans_out_to_jarvis_user_and_sm` unchanged (green) — 38 in `test_personalise_pipeline`.
- **Live-verified on dev:** a Jarvis-Admin-only user went **0 → 1** org question after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)