### PR TITLE
fix(ai-models): provider logos on the subscription service picker

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -217,7 +217,7 @@
             <div class="jv-pool-lab">Connected accounts ({{ panelRow.accounts.length }})</div>
             <div class="jv-pool-acctlist">
               <div v-for="(a, ai) in panelRow.accounts" :key="a.account_ref || ai" class="jv-pool-acctchip">
-                <ProviderLogo :upstream="panelRow.upstream" :size="18" />
+                <span class="jv-pool-avatar">{{ (accountLabel(a) || '?').charAt(0).toUpperCase() }}</span>
                 <span class="jv-pool-accttx">{{ accountLabel(a) }}</span>
                 <span class="jv-pool-dot" :class="'jv-pool-dot--' + accountHealth(panelRow).level" aria-hidden="true"></span>
                 <span v-if="accountHealth(panelRow).label" class="jv-pool-acct-health" :class="'jv-pool-acct-health--' + accountHealth(panelRow).level" :title="accountHealth(panelRow).title">{{ accountHealth(panelRow).label }}</span>
@@ -456,7 +456,7 @@
             <div class="jv-pool-lab">Connected accounts ({{ m.accounts.length }})</div>
             <div class="jv-pool-acctlist">
               <div v-for="(a, ai) in m.accounts" :key="a.account_ref || ai" class="jv-pool-acctchip">
-                <ProviderLogo :upstream="m.upstream" :size="18" />
+                <span class="jv-pool-avatar">{{ (accountLabel(a) || '?').charAt(0).toUpperCase() }}</span>
                 <span class="jv-pool-accttx">{{ accountLabel(a) }}</span>
                 <span class="jv-pool-dot" :class="'jv-pool-dot--' + accountHealth(m).level" aria-hidden="true"></span>
                 <span v-if="accountHealth(m).label" class="jv-pool-acct-health" :class="'jv-pool-acct-health--' + accountHealth(m).level" :title="accountHealth(m).title">{{ accountHealth(m).label }}</span>

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -217,7 +217,7 @@
             <div class="jv-pool-lab">Connected accounts ({{ panelRow.accounts.length }})</div>
             <div class="jv-pool-acctlist">
               <div v-for="(a, ai) in panelRow.accounts" :key="a.account_ref || ai" class="jv-pool-acctchip">
-                <span class="jv-pool-avatar">{{ (accountLabel(a) || '?').charAt(0).toUpperCase() }}</span>
+                <ProviderLogo :upstream="panelRow.upstream" :size="18" />
                 <span class="jv-pool-accttx">{{ accountLabel(a) }}</span>
                 <span class="jv-pool-dot" :class="'jv-pool-dot--' + accountHealth(panelRow).level" aria-hidden="true"></span>
                 <span v-if="accountHealth(panelRow).label" class="jv-pool-acct-health" :class="'jv-pool-acct-health--' + accountHealth(panelRow).level" :title="accountHealth(panelRow).title">{{ accountHealth(panelRow).label }}</span>
@@ -445,7 +445,10 @@
                  are provider-specific), so reselecting the CURRENT provider must
                  be a no-op rather than wiping a finished OAuth connect. -->
             <JvCombo :model-value="m.upstream" @update:model-value="(v) => { if (v === m.upstream) return; m.upstream = v; onUpstreamChange(m) }"
-                     :options="upstreamOpts" :editable="editable" placeholder="Provider" />
+                     :options="upstreamOpts" :editable="editable" placeholder="Provider">
+              <template #option="{ option }"><span style="display:inline-flex;align-items:center;gap:8px"><ProviderLogo :upstream="option.value" :size="16" />{{ option.label }}</span></template>
+              <template #selected="{ label, placeholder }"><span style="display:inline-flex;align-items:center;gap:8px"><ProviderLogo v-if="m.upstream" :upstream="m.upstream" :size="16" />{{ label || placeholder }}</span></template>
+            </JvCombo>
           </div>
 
           <!-- Connected accounts -->
@@ -453,7 +456,7 @@
             <div class="jv-pool-lab">Connected accounts ({{ m.accounts.length }})</div>
             <div class="jv-pool-acctlist">
               <div v-for="(a, ai) in m.accounts" :key="a.account_ref || ai" class="jv-pool-acctchip">
-                <span class="jv-pool-avatar">{{ (accountLabel(a) || '?').charAt(0).toUpperCase() }}</span>
+                <ProviderLogo :upstream="m.upstream" :size="18" />
                 <span class="jv-pool-accttx">{{ accountLabel(a) }}</span>
                 <span class="jv-pool-dot" :class="'jv-pool-dot--' + accountHealth(m).level" aria-hidden="true"></span>
                 <span v-if="accountHealth(m).label" class="jv-pool-acct-health" :class="'jv-pool-acct-health--' + accountHealth(m).level" :title="accountHealth(m).title">{{ accountHealth(m).label }}</span>


### PR DESCRIPTION
## What

Renders `ProviderLogo` in the **subscription/OAuth service picker** (`m.upstream` combo) of `LlmPoolEditor`, matching what the API-key provider combo already does — so OpenAI / Google / xAI / Kimi show their brand mark instead of plain text. Added `#option`/`#selected` slots mirroring the API-key combo.

Also surfaces in onboarding, which embeds the same editor in `quick` mode.

## Scope note (addressed a review finding)

An earlier revision also swapped the **connected-account chips'** initial-letter avatar for a provider logo. Code review flagged that as a regression: in a failover pool with multiple accounts on the **same** provider, every chip would render an identical logo, losing the per-account differentiator. **Reverted** — the chips keep their initial-letter avatar; only the picker (whose options are *distinct* providers) gets logos.

## Why a separate PR

The gap needed both #319 (introduced `ProviderLogo`) and #323 (introduced the subscription picker) in one tree, so it couldn't live in either alone. Flagged during #319 review.

## Verification
- `vite build` ✓ on current `main`.
- Net diff = the 2 picker-slot lines only; `ProviderLogo` maps each upstream to a real mark (`openai→openai, google→gemini, xai→xai, kimi→moonshot`).

## Deferred (minor, from review)
- The `#option`/`#selected` slot markup is now repeated in 3 combos (provider ×2 + this one). A shared render helper would DRY it up — left as a follow-up to keep this diff minimal.