### PR TITLE
fix(chat): stop leaking throwaway openclaw sessions; drain the backlog

### DIFF
--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -32,8 +32,42 @@ _WARM_COOLDOWN_S = 4 * 60
 _WARM_INPROGRESS_S = 90
 
 
+# The previous warm's session key, remembered so the NEXT warm can reclaim it
+# (see _reclaim_previous). TTL is far longer than the cooldown: losing this
+# pointer leaks one session, so err on the side of remembering. The orphan sweep
+# (session_lifecycle) is the backstop for whatever this misses.
+_WARM_LAST_TTL_S = 24 * 60 * 60
+
+
 def _warm_cooldown_key() -> str:
 	return f"jarvis:chat:prefix_warm:{frappe.local.site}"
+
+
+def _warm_last_key() -> str:
+	return f"jarvis:chat:prefix_warm:last:{frappe.local.site}"
+
+
+def _reclaim_previous(sess, prev, current: str) -> None:
+	"""Delete the throwaway session the PREVIOUS warm created.
+
+	A warm cannot delete its own: fire_agent is fire-and-forget, so the turn that
+	warms the prefix is still running when it returns, and waiting for it would
+	block a short-queue worker for no benefit. Instead each warm reclaims its
+	predecessor, which the cooldown guarantees has had at least _WARM_COOLDOWN_S
+	to finish. Steady state is one live prewarm session rather than one per warm -
+	at a 4-minute cooldown the old create-and-forget leaked up to ~350 sessions a
+	day against an orphan sweep capped at 25.
+
+	Best-effort: on failure (or a lost cache pointer) the session is left for the
+	orphan sweep, which reaps jarvis-prewarm-* on a short grace."""
+	if not prev or not isinstance(prev, str) or prev == current:
+		return
+	try:
+		sess.delete_session(prev)
+	except Exception:
+		frappe.logger("jarvis.chat.prewarm").debug(
+			"previous warm session delete failed", exc_info=True,
+		)
 
 
 def _gateway_ws_url(settings) -> str:
@@ -94,6 +128,14 @@ def warm_prefix() -> bool:
 				throwaway, "/think off warmup", uuid.uuid4().hex,
 				model=model or None, provider=provider,
 			)
+			# Remember the new throwaway BEFORE reclaiming the old one: a failure
+			# between the two then leaks only the PREVIOUS session (the orphan
+			# sweep still collects it) instead of losing the pointer to the one we
+			# just created, which would leak one every warm, forever.
+			last_key = _warm_last_key()
+			prev = cache.get_value(last_key)
+			cache.set_value(last_key, throwaway, expires_in_sec=_WARM_LAST_TTL_S)
+			_reclaim_previous(sess, prev, throwaway)
 		finally:
 			sess.close()
 		# Latency telemetry (plan Phase 0): connect+create+fire duration.

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -7,9 +7,13 @@ first turn. Without a sweep, state accumulates forever:
   session (and its growing working context) sits on the container.
 - Empty conversations: opening "New Chat" and closing the tab leaves a
   0-message row cluttering history.
-- Orphaned throwaway sessions: every auto-title generation and every prefix
-  prewarm creates a single-use session, and deleted conversations leave their
-  sessions behind. The dev tenant had 81 session state files after one month.
+- Orphaned throwaway sessions: deleted conversations leave their sessions behind,
+  and so do the three throwaway kinds (auto-title, pattern polish, prefix
+  prewarm) whenever their own cleanup is missed. All three DO now delete their
+  own - title and polish in a finally, prewarm by reclaiming its predecessor on
+  the next warm - so this sweep is their backstop, not their only collector. It
+  used to be the only one, and could not keep up: a 4-minute warm cooldown alone
+  minted up to ~350 sessions/day against a sweep capped at 25/day.
 
 The bench is the durable owner of chat history (Jarvis Chat Message rows); the
 openclaw session is a cache of working context, not the record. Deleting one is
@@ -18,7 +22,7 @@ deleteTranscript=true default), canvas/media artifacts were pulled to ERP Files
 at turn end, and the next message lazily creates a fresh session through the
 existing ``_ensure_session_key`` path - same UX, empty working context.
 
-The daily ``rotate_dormant_sessions`` cron:
+The hourly ``rotate_dormant_sessions`` cron:
 
 1. FREE IDLE SESSIONS: conversations idle past the configured retention window
    (Jarvis Settings.conversation_retention_days; 0 disables) that still hold a
@@ -36,15 +40,19 @@ The daily ``rotate_dormant_sessions`` cron:
    (empty chats are also hidden from the sidebar list; this reaps the row so it
    doesn't linger in the DB forever).
 3. ORPHANS: gateway sessions in the chat namespace that no conversation
-   references (title/prewarm throwaways, deleted conversations) and that have
-   been inactive past ``ORPHAN_GRACE_HOURS`` -> delete, plus any stale lookup
-   rows. Runs regardless of the retention setting - these are not user chats.
+   references (throwaways, deleted conversations) and that have been inactive
+   past their grace -> delete, plus any stale lookup rows. The grace is
+   per-session (``_grace_ms``): a short ``THROWAWAY_GRACE_HOURS`` for the known
+   throwaway labels, the conservative ``ORPHAN_GRACE_HOURS`` for everything
+   else. Runs regardless of the retention setting - these are not user chats -
+   and on its own ``ORPHAN_BATCH_MAX`` budget.
 
-Parts 1 + 2 are the retention sweep and honour ``conversation_retention_days``
-(0 => keep everything, do nothing). Part 3 is pure gateway hygiene and always
-runs. Everything is best-effort on a dedicated connection (never the pool - a
-sweep must not contend with live turns), batch-capped so a backlog drains over
-days instead of stampeding a gateway, and managed-mode only.
+Parts 1 + 2 are the retention sweep, honour ``conversation_retention_days``
+(0 => keep everything, do nothing), and share ``BATCH_MAX``. Part 3 is pure
+gateway hygiene, always runs, and has its own budget so parts 1 + 2 cannot
+starve it. Everything is best-effort on a dedicated connection (never the pool -
+a sweep must not contend with live turns), batch-capped so a backlog drains over
+a few runs instead of stampeding a gateway, and managed-mode only.
 """
 from __future__ import annotations
 
@@ -102,17 +110,37 @@ def _retention_days() -> int:
 # created session_key has not committed yet.
 ORPHAN_GRACE_HOURS = 24
 
-# Per-run cap across ALL parts, so a month of backlog drains over a few
-# days instead of hammering the gateway in one cron tick.
+# Per-run cap for the retention sweeps (parts 1 + 2), so a month of backlog
+# drains over a few runs instead of hammering the gateway in one cron tick.
 BATCH_MAX = 25
+
+# Orphans (part 3) get their OWN, larger per-run cap instead of parts 1+2's
+# leftovers. They are the only unbounded population in this sweep - every prefix
+# warm, auto-title and pattern polish mints one - and unlike parts 1+2 they touch
+# no user data, so a bigger batch is cheap. Sharing one 25-slot budget let a
+# backlog of idle conversations starve the sweep that actually needed the slots.
+ORPHAN_BATCH_MAX = 200
 
 # Only sessions in the chat namespace are ever considered for the orphan
 # sweep; the agent's main session is additionally refused server-side.
 _CHAT_NAMESPACE_MARKER = ":dashboard:"
 
+# Labels of every throwaway session kind the bench mints: prewarm.warm_prefix,
+# title._generate_via_gateway, and learning.polish._run_gateway_turn. All three
+# now delete their own sessions, so these only turn up here when that cleanup was
+# missed (a crash, a lost cache pointer, a gateway blip) - never as live state.
+#
+# A short grace is SAFE for these specifically because the labels are namespaced:
+# a real conversation session is always "jarvis-chat-<user>-<ms>" (api.py
+# _ensure_session_key), so a throwaway label can never be a conversation whose
+# freshly-minted session_key has not committed yet. That race is exactly what
+# ORPHAN_GRACE_HOURS protects, and it still gets the full 24h.
+_THROWAWAY_LABEL_PREFIXES = ("jarvis-prewarm-", "jarvis-title-", "jarvis-polish-")
+THROWAWAY_GRACE_HOURS = 1
+
 
 def rotate_dormant_sessions() -> dict:
-	"""Daily cron: free idle conversations' openclaw sessions, reap abandoned
+	"""Hourly cron: free idle conversations' openclaw sessions, reap abandoned
 	empty chats, and reap orphaned throwaway sessions. Returns a summary dict
 	(also logged) so a manual ``bench execute`` run shows what happened. (Name
 	kept for the scheduler entry in hooks.py.)"""
@@ -146,9 +174,11 @@ def rotate_dormant_sessions() -> dict:
 		if days > 0:
 			budget = _free_idle_sessions(sess, budget, summary, days)
 			if budget > 0:
-				budget = _reap_empty(sess, budget, summary)
-		if budget > 0:
-			_reap_orphans(sess, budget, summary)
+				_reap_empty(sess, budget, summary)
+		# Part 3 runs on its own budget (see ORPHAN_BATCH_MAX), so a backlog in
+		# parts 1+2 can no longer starve it, and it runs even when retention is
+		# disabled - orphaned throwaways are gateway hygiene, not user chats.
+		_reap_orphans(sess, ORPHAN_BATCH_MAX, summary)
 	finally:
 		try:
 			sess.close()
@@ -230,7 +260,8 @@ def _reap_empty(sess, budget: int, summary: dict) -> int:
 	non-starred conversation with ZERO messages, idle past ``EMPTY_GRACE_DAYS``.
 	Such a row has no messages / approvals / runs / voice notes hanging off it,
 	so ``delete_doc(force)`` is a clean removal. A stray session is freed first,
-	defensively. Returns leftover budget for the orphan sweep.
+	defensively. Returns the leftover retention budget (part 3 no longer runs on
+	it - it has its own ORPHAN_BATCH_MAX).
 
 	Two exclusions guard against destroying real data via ``delete_doc``'s
 	cascade to attached Files (frappe ``remove_all`` on delete):
@@ -300,10 +331,23 @@ def _reap_empty(sess, budget: int, summary: dict) -> int:
 	return budget
 
 
+def _grace_ms(entry: dict) -> int:
+	"""How long this session must have been idle before it can be reaped.
+
+	Known throwaway labels get THROWAWAY_GRACE_HOURS; everything else keeps the
+	conservative ORPHAN_GRACE_HOURS. See _THROWAWAY_LABEL_PREFIXES for why the
+	split is safe. An absent or non-string label falls through to the long
+	grace."""
+	label = entry.get("label") or ""
+	if isinstance(label, str) and label.startswith(_THROWAWAY_LABEL_PREFIXES):
+		return THROWAWAY_GRACE_HOURS * 3600 * 1000
+	return ORPHAN_GRACE_HOURS * 3600 * 1000
+
+
 def _reap_orphans(sess, budget: int, summary: dict) -> None:
 	"""Part 3: chat-namespace gateway sessions no conversation references
-	(title/prewarm throwaways, deleted conversations), inactive past the
-	grace window and with no active run."""
+	(title/prewarm/polish throwaways, deleted conversations), inactive past their
+	grace window (per-session, see _grace_ms) and with no active run."""
 	try:
 		entries = sess.list_sessions()
 	except Exception:
@@ -319,7 +363,6 @@ def _reap_orphans(sess, budget: int, summary: dict) -> None:
 			"WHERE session_key IS NOT NULL AND session_key != ''"
 		)
 	}
-	grace_ms = ORPHAN_GRACE_HOURS * 3600 * 1000
 	now_ms = int(time.time() * 1000)
 	for entry in entries:
 		if budget <= 0:
@@ -331,7 +374,7 @@ def _reap_orphans(sess, budget: int, summary: dict) -> None:
 			summary["skipped"] += 1
 			continue
 		updated = entry.get("updatedAt")
-		if not isinstance(updated, (int, float)) or (now_ms - updated) < grace_ms:
+		if not isinstance(updated, (int, float)) or (now_ms - updated) < _grace_ms(entry):
 			# No usable activity timestamp -> conservative skip; a fresh
 			# throwaway or a just-created conversation session survives.
 			summary["skipped"] += 1

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -138,11 +138,29 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 	try:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
-			for ev in sess.stream_agent_turn(
-				skey, prompt, f"title:{skey}", model=model, provider=provider,
-			):
-				if ev.get("kind") == "assistant" and ev.get("text"):
-					text = ev["text"]
+			try:
+				for ev in sess.stream_agent_turn(
+					skey, prompt, f"title:{skey}", model=model, provider=provider,
+				):
+					if ev.get("kind") == "assistant" and ev.get("text"):
+						text = ev["text"]
+			finally:
+				# Delete the throwaway on the SAME pooled connection, turn
+				# succeeded or not. Without this every auto-titled chat leaks a
+				# session that only the budget-capped orphan sweep could reclaim,
+				# and that sweep could never keep up. The turn is fully consumed
+				# by here (stream_agent_turn ran to exhaustion or raised), so
+				# nothing is in flight.
+				#
+				# Swallow a delete failure: `text` is already captured, and losing
+				# the title over failed cleanup would be the worse bug - the
+				# orphan sweep still collects jarvis-title-* as a backstop.
+				try:
+					sess.delete_session(skey)
+				except Exception:
+					frappe.logger("jarvis.chat.title").debug(
+						"throwaway title session delete failed", exc_info=True,
+					)
 	except Exception:
 		frappe.log_error(
 			title="auto-title: gateway generation failed",

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -236,6 +236,17 @@ scheduler_events = {
 		],
 	},
 	"hourly": [
+		# Session lifecycle: free dormant conversations' openclaw sessions, reap
+		# abandoned empty chats, and reap orphaned throwaway sessions
+		# (title/prewarm/polish, deleted conversations). Batch-capped; bench
+		# history untouched.
+		#
+		# Hourly, not daily: this sweep is the backstop for the throwaway session
+		# kinds, and one pass a day capped at 25 could never keep up with a bench
+		# minting them every few minutes. Parts 1 + 2 keep their own multi-day
+		# grace windows and are cheap no-ops when nothing is due, so the extra
+		# ticks cost one gateway connect.
+		"jarvis.chat.session_lifecycle.rotate_dormant_sessions",
 		# Sprint-3 (2026-06-16 review): bench has no way to know if the
 		# container's OAuth profile silently went away (refresh-token
 		# failure, operator clear, re-provision without re-push). Hourly
@@ -255,10 +266,6 @@ scheduler_events = {
 		"jarvis.chat.turn_recovery.recovery_rate_watch",
 	],
 	"daily": [
-		# Session lifecycle Phase 1: rotate dormant conversations' openclaw
-		# sessions and reap orphaned throwaway sessions (title/prewarm,
-		# deleted conversations). Batch-capped; bench history untouched.
-		"jarvis.chat.session_lifecycle.rotate_dormant_sessions",
 		"jarvis.onboarding.sync_connection",
 		# C2 (2026-06-16 review): nudge operators when the bench's
 		# agent_token is approaching or past its configured max age.

--- a/jarvis/learning/polish.py
+++ b/jarvis/learning/polish.py
@@ -257,11 +257,26 @@ def _run_gateway_turn(prompt: str) -> str:
 	try:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
-			for ev in sess.stream_agent_turn(
-				skey, prompt, f"polish:{skey}", model=model, provider=provider,
-			):
-				if ev.get("kind") == "assistant" and ev.get("text"):
-					text = ev["text"]
+			try:
+				for ev in sess.stream_agent_turn(
+					skey, prompt, f"polish:{skey}", model=model, provider=provider,
+				):
+					if ev.get("kind") == "assistant" and ev.get("text"):
+						text = ev["text"]
+			finally:
+				# Delete the throwaway on the SAME pooled connection, turn
+				# succeeded or not: otherwise every polish turn leaks a session
+				# that only the budget-capped orphan sweep could reclaim. The turn
+				# is fully consumed by here, so nothing is in flight.
+				#
+				# Swallow a delete failure - `text` is already captured, and the
+				# orphan sweep collects jarvis-polish-* as a backstop.
+				try:
+					sess.delete_session(skey)
+				except Exception:
+					frappe.logger("jarvis.learning.polish").debug(
+						"throwaway polish session delete failed", exc_info=True,
+					)
 	except Exception:
 		frappe.log_error(
 			title="pattern polish: gateway turn failed",

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -38,6 +38,9 @@ class TestWarmPrefix(FrappeTestCase):
     def tearDown(self):
         from jarvis.chat import prewarm
         frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        # Leaving this set would make the NEXT test's first warm reclaim a
+        # session this one invented.
+        frappe.cache().delete_value(prewarm._warm_last_key())
 
     def test_warm_prefix_throwaway_session_no_rows_best_effort(self):
         from jarvis.chat import prewarm
@@ -59,6 +62,56 @@ class TestWarmPrefix(FrappeTestCase):
         self.assertIn("/think off", msg)
         fake_sess.close.assert_called_once()
         self.assertEqual(frappe.db.count("Jarvis Chat Message"), before)
+
+    def test_warm_prefix_reclaims_previous_throwaway(self):
+        """Each warm deletes its PREDECESSOR's session. fire_agent is
+        fire-and-forget, so a warm cannot delete its own without blocking a
+        worker until the turn lands; the cooldown guarantees the predecessor has
+        long since finished. Steady state: one live prewarm session, not one per
+        warm (which at a 4-minute cooldown leaked up to ~350/day)."""
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        frappe.cache().delete_value(prewarm._warm_last_key())
+        fake_sess = MagicMock()
+        fake_sess.create_session.side_effect = ["sk_first", "sk_second"]
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()):
+            OC.connect.return_value = fake_sess
+            self.assertTrue(prewarm.warm_prefix())
+            # Nothing to reclaim on the very first warm of a bench.
+            fake_sess.delete_session.assert_not_called()
+            frappe.cache().delete_value(prewarm._warm_cooldown_key())  # lapse the cooldown
+            self.assertTrue(prewarm.warm_prefix())
+
+        # The second warm reclaimed the first's session — and only that one.
+        fake_sess.delete_session.assert_called_once_with("sk_first")
+        self.assertEqual(frappe.cache().get_value(prewarm._warm_last_key()), "sk_second")
+
+    def test_warm_prefix_survives_previous_delete_failure(self):
+        """A failed reclaim must never fail the warm — the orphan sweep is the
+        backstop — and must still leave the NEW key tracked, or the next warm
+        would reclaim nothing and the leak would quietly resume."""
+        from jarvis.chat import prewarm
+
+        frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        frappe.cache().delete_value(prewarm._warm_last_key())
+        fake_sess = MagicMock()
+        fake_sess.create_session.side_effect = ["sk_first", "sk_second"]
+        fake_sess.delete_session.side_effect = RuntimeError("gateway blip")
+
+        with patch("jarvis.chat.prewarm.OpenclawSession") as OC, \
+             patch("jarvis.chat.prewarm.selfhost.is_self_hosted", return_value=False), \
+             patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()):
+            OC.connect.return_value = fake_sess
+            self.assertTrue(prewarm.warm_prefix())
+            frappe.cache().delete_value(prewarm._warm_cooldown_key())
+            self.assertTrue(prewarm.warm_prefix())
+
+        self.assertEqual(fake_sess.fire_agent.call_count, 2)
+        self.assertEqual(frappe.cache().get_value(prewarm._warm_last_key()), "sk_second")
 
     def test_warm_prefix_debounced_second_call_is_noop(self):
         from jarvis.chat import prewarm
@@ -159,6 +212,9 @@ class TestKeepWarm(FrappeTestCase):
     def tearDown(self):
         from jarvis.chat import prewarm
         frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        # Leaving this set would make the NEXT test's first warm reclaim a
+        # session this one invented.
+        frappe.cache().delete_value(prewarm._warm_last_key())
 
     def test_keep_warm_warms_when_recent_activity(self):
         from jarvis.chat import prewarm
@@ -183,6 +239,9 @@ class TestEnqueueWarmIfDue(FrappeTestCase):
     def tearDown(self):
         from jarvis.chat import prewarm
         frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        # Leaving this set would make the NEXT test's first warm reclaim a
+        # session this one invented.
+        frappe.cache().delete_value(prewarm._warm_last_key())
 
     def test_enqueues_warm_when_not_on_cooldown(self):
         from jarvis.chat import prewarm
@@ -217,6 +276,9 @@ class TestListConversationsWarms(FrappeTestCase):
     def tearDown(self):
         from jarvis.chat import prewarm
         frappe.cache().delete_value(prewarm._warm_cooldown_key())
+        # Leaving this set would make the NEXT test's first warm reclaim a
+        # session this one invented.
+        frappe.cache().delete_value(prewarm._warm_last_key())
 
     def test_list_conversations_triggers_warm_on_load(self):
         from jarvis.chat import api

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -1,7 +1,7 @@
 """Tests for jarvis.chat.session_lifecycle (idle-session reclaim + empty-chat
 + orphan sweeps).
 
-The daily cron (1) frees the openclaw session of conversations idle past the
+The hourly cron (1) frees the openclaw session of conversations idle past the
 configurable retention window (Jarvis Settings.conversation_retention_days) -
 leaving the conversation Active and visible, only reclaiming its working memory;
 (2) hard-deletes Active, non-starred, zero-message chats idle past
@@ -29,6 +29,9 @@ RETENTION_FIELD = "conversation_retention_days"
 
 NOW_MS = int(time.time() * 1000)
 OLD_MS = NOW_MS - (session_lifecycle.ORPHAN_GRACE_HOURS + 2) * 3600 * 1000
+# Past the throwaway grace but comfortably INSIDE the long orphan grace, so a
+# test using it proves which of the two windows applied.
+THROWAWAY_OLD_MS = NOW_MS - (session_lifecycle.THROWAWAY_GRACE_HOURS + 1) * 3600 * 1000
 
 
 def _fake_sess(entries=None):
@@ -403,21 +406,97 @@ class TestSessionLifecycle(FrappeTestCase):
 		self.assertEqual(summary["orphans_reaped"], 0)
 		sess.delete_session.assert_not_called()
 
-	def test_batch_cap_bounds_total_work(self):
+	def test_throwaway_labels_reaped_on_the_short_grace(self):
+		"""A known throwaway label is reaped well inside ORPHAN_GRACE_HOURS. It
+		can never be a conversation whose session_key has not committed yet -
+		those are always labelled jarvis-chat-* - so the long grace bought
+		nothing here and only let the pile grow."""
+		sess = _fake_sess(entries=[
+			{"key": "test-lc-orph:dashboard:pw", "label": "jarvis-prewarm-abc123",
+			 "hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS},
+			{"key": "test-lc-orph:dashboard:ti", "label": "jarvis-title-def456",
+			 "hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS},
+			{"key": "test-lc-orph:dashboard:po", "label": "jarvis-polish-ghi789",
+			 "hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS},
+		])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 3)
+		for k in ("pw", "ti", "po"):
+			sess.delete_session.assert_any_call(f"test-lc-orph:dashboard:{k}")
+
+	def test_throwaway_inside_the_short_grace_skipped(self):
+		sess = _fake_sess(entries=[{
+			"key": "test-lc-orph:dashboard:fresh", "label": "jarvis-prewarm-abc123",
+			"hasActiveRun": False, "updatedAt": NOW_MS,
+		}])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 0)
+		sess.delete_session.assert_not_called()
+
+	def test_non_throwaway_label_keeps_the_long_grace(self):
+		"""The short grace is opt-in by label prefix. A real chat session (or an
+		unlabelled one) at the same age still gets the conservative 24h - THAT is
+		the row whose session_key may simply not have committed yet."""
+		sess = _fake_sess(entries=[
+			{"key": "test-lc-orph:dashboard:chat",
+			 "label": "jarvis-chat-a@b.c-1700000000000",
+			 "hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS},
+			{"key": "test-lc-orph:dashboard:nolabel",
+			 "hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS},
+		])
+		summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 0)
+		sess.delete_session.assert_not_called()
+
+	def test_batch_cap_bounds_retention_work(self):
 		for i in range(3):
 			self._conv(session_key=f"test-lc-batch-{i}", idle_days=40, has_message=True)
+		sess = _fake_sess()
+		with patch.object(session_lifecycle, "BATCH_MAX", 2):
+			summary = self._run(sess)
+		# Only 2 of the 3 idle sessions fit in the retention budget.
+		self.assertEqual(summary["sessions_freed"], 2)
+		self.assertEqual(summary["empty_reaped"], 0)
+
+	def test_orphan_budget_is_independent_of_retention_backlog(self):
+		"""Regression: orphans used to run on parts 1+2's LEFTOVER budget, so a
+		backlog of idle conversations starved the only sweep collecting throwaway
+		sessions - the one population here that grows without bound."""
+		for i in range(3):
+			self._conv(session_key=f"test-lc-starve-{i}", idle_days=40, has_message=True)
 		entries = [{
-			"key": f"test-lc-orph:dashboard:b{i}",
-			"hasActiveRun": False, "updatedAt": OLD_MS,
+			"key": f"test-lc-orph:dashboard:s{i}", "label": f"jarvis-prewarm-{i}",
+			"hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS,
 		} for i in range(3)]
 		sess = _fake_sess(entries=entries)
-		with patch.object(session_lifecycle, "BATCH_MAX", 4):
+		# A retention budget fully consumed by part 1 leaves nothing over...
+		with patch.object(session_lifecycle, "BATCH_MAX", 3):
 			summary = self._run(sess)
-		# 3 session frees + only 1 orphan fit in the budget of 4.
 		self.assertEqual(summary["sessions_freed"], 3)
-		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertEqual(summary["orphans_reaped"], 3)  # ...and orphans run anyway.
+
+	def test_orphan_batch_cap_bounds_orphan_work(self):
+		entries = [{
+			"key": f"test-lc-orph:dashboard:c{i}", "label": f"jarvis-prewarm-{i}",
+			"hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS,
+		} for i in range(5)]
+		sess = _fake_sess(entries=entries)
+		with patch.object(session_lifecycle, "ORPHAN_BATCH_MAX", 2):
+			summary = self._run(sess)
+		self.assertEqual(summary["orphans_reaped"], 2)
+		self.assertEqual(sess.delete_session.call_count, 2)
+
+	def test_orphans_reaped_even_when_retention_disabled(self):
+		frappe.db.set_single_value(SETTINGS, RETENTION_FIELD, 0)
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		frappe.db.commit()
+		sess = _fake_sess(entries=[{
+			"key": "test-lc-orph:dashboard:off", "label": "jarvis-prewarm-abc123",
+			"hasActiveRun": False, "updatedAt": THROWAWAY_OLD_MS,
+		}])
+		summary = self._run(sess)
+		self.assertEqual(summary["sessions_freed"], 0)
 		self.assertEqual(summary["orphans_reaped"], 1)
-		self.assertEqual(sess.delete_session.call_count, 4)
 
 	# ---- gating ------------------------------------------------------
 


### PR DESCRIPTION
## The problem

Fleet-transcript shows a large pile of `jarvis-prewarm-*` sessions on the live tenant. Every throwaway gateway session the bench mints is created and **never deleted** — and prewarm isn't the only source:

| Source | Label | Rate |
|---|---|---|
| `prewarm.warm_prefix` | `jarvis-prewarm-*` | up to ~350/day |
| `title._generate_via_gateway` | `jarvis-title-*` | one per auto-titled chat |
| `learning.polish._run_gateway_turn` | `jarvis-polish-*` | one per polish turn |

The only collector was `session_lifecycle`'s **daily** orphan sweep, capped at **25/run** and running on whatever budget parts 1+2 left over. So we created roughly 10x faster than we reaped, and the pile could only grow.

This is a latent regression: the 25/day cap was sized when `_WARM_COOLDOWN_S` was 25 minutes. The 2026-07 latency work cut it to 4 minutes — a 6x increase in inflow — without revisiting the sweep. The module docstring's "81 session state files after one month" dates from before that cut.

## The fix

**Stop the leaks at the source.**

- **title** and **polish** delete their own session in a `finally`. Both stream the turn to exhaustion inside a pooled checkout, so nothing is in flight and the delete is safe and immediate. A delete failure is swallowed — the text is already captured, and losing a title over failed cleanup would be the worse bug.
- **prewarm** can't delete its own: `fire_agent` is fire-and-forget, and waiting for the turn would block a `short`-queue worker for no benefit. Instead each warm **reclaims its predecessor** via a cache pointer, which the 4-minute cooldown guarantees has long since finished. Steady state goes from unbounded to ~1. The new key is stored *before* the reclaim, so a crash between the two leaks the old session (which the sweep still collects) rather than losing the pointer forever.

**Then drain what's already there.**

- Orphans get their own `ORPHAN_BATCH_MAX = 200` instead of parts 1+2's leftovers — a backlog of idle conversations could previously starve the one sweep collecting an unbounded population.
- Per-session grace (`_grace_ms`): known throwaway labels get **1h**, everything else keeps the conservative **24h**. This is safe because the labels are namespaced — a real conversation session is always `jarvis-chat-<user>-<ms>` (`api.py::_ensure_session_key`), so a throwaway label can never be the uncommitted-`session_key` race that the 24h exists to protect. Verified `label` is on the `sessions.list` row upstream (`openclaw/src/gateway/session-utils.types.ts:60`).
- The sweep moves **daily → hourly**. Parts 1+2 keep their multi-day graces and are cheap no-ops when nothing is due, so the extra ticks cost one gateway connect.

## Deliberately not changed

`EMPTY_GRACE_DAYS` stays 7 and retention stays 30. Empty chats are bounded at ~1/user by `create_or_focus_empty` and already hidden from the sidebar, so reaping them faster buys nothing and only risks deleting a chat under an idle open tab.

## Testing

`bench --site jarvis-test.localhost run-tests --app jarvis` — full suite run against an **identical `origin/main` baseline**: both show `failures=6, errors=4`, same 10 tests (diff of the red lists is empty). All 10 are pre-existing and unrelated.

8 new tests: prewarm reclaim + reclaim-failure resilience; the label grace split (short grace applies to all three throwaway kinds, long grace still applies to `jarvis-chat-*` and unlabelled); the budget-starvation regression; and orphan reaping with retention disabled.

Two environment issues surfaced while testing and are worth knowing: the bench's redis (11000/13000) was down, and `jarvis-test.localhost` hadn't been migrated since #325 — both were manufacturing phantom failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)