### PR TITLE
Onboarding: admit chat on admin CONVERGENCE, not HTTP success (R4-P0-6)

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -41,7 +41,14 @@ export async function isWorkspaceReady() {
 // the poster routes back to setup. Unlike llm_credentials this cannot fire
 // on an established workspace: once a pool applies ONCE the marker is
 // permanent.
-const NOT_ONBOARDED_REASONS = new Set(["signup", "selfhost_connection", "llm_pool_provisioning"])
+// "llm_provisioning" is the DIRECT (single-model) analogue (round-4 review
+// R4-P0-6): a direct config whose first apply admin never confirmed
+// (llm_direct_synced_at never stamped). Same permanence guarantee — once a
+// direct config confirms once, the marker is permanent — so it belongs here
+// too, never on the degraded-banner path.
+const NOT_ONBOARDED_REASONS = new Set([
+	"signup", "selfhost_connection", "llm_pool_provisioning", "llm_provisioning",
+])
 
 // True only when the workspace has NOT completed onboarding at all — the single
 // case the full-screen gate poster is for. A ready workspace, a fail-open

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -150,6 +150,18 @@ def is_ready_for_chat() -> dict:
 		model = (getattr(settings, "llm_model", "") or "").strip()
 		if not (llm_key and provider and model):
 			return {"ready": False, "reason": "llm_credentials"}
+		# Local key/provider/model presence is config INTENT (committed at save,
+		# before the async admin apply runs) — it does NOT prove the container ever
+		# received the creds. Gate on evidence of a CONFIRMED apply instead
+		# (round-4 review R4-P0-6 / P1-10): llm_direct_synced_at is stamped only on
+		# admin status="applied". A direct tenant that has EVER confirmed stays
+		# ready through a later re-save's transient "applying" (the container keeps
+		# serving its previous key); a FRESH tenant whose first apply is still
+		# pending/failed is NOT ready — opening chat there guarantees failing turns
+		# while onboarding still shows "applying". Legacy direct tenants are
+		# backfilled by patch v2_00_backfill_llm_direct_synced_at.
+		if not getattr(settings, "llm_direct_synced_at", None):
+			return {"ready": False, "reason": "llm_provisioning"}
 	elif auth_mode in ("subscription", "oauth"):
 		# Both modes use the same local signal: llm_oauth_connected_at is
 		# set (read-only) when the oauth grant completes and the admin

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -86,6 +86,7 @@
   "last_sync_at",
   "last_sync_status",
   "llm_pool_synced_at",
+  "llm_direct_synced_at",
   "last_subscription_status",
   "last_sync_warnings",
   "last_model_statuses",
@@ -638,6 +639,13 @@
    "fieldname": "llm_pool_synced_at",
    "fieldtype": "Datetime",
    "label": "LLM Pool Synced At",
+   "read_only": 1
+  },
+  {
+   "description": "Set when a DIRECT (single-model) LLM config was last CONFIRMED-applied to the container via admin (status=applied). Distinguishes a working direct tenant from one whose first apply is still pending/failed - is_ready_for_chat gates a first direct activation on it so chat never opens on an unconfirmed container (round-4 review R4-P0-6 / P1-10).",
+   "fieldname": "llm_direct_synced_at",
+   "fieldtype": "Datetime",
+   "label": "LLM Direct Synced At",
    "read_only": 1
   },
   {

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -112,9 +112,14 @@ def _admin_chat_readiness(*, timeout_s: int = _POOL_CONVERGE_PROBE_TIMEOUT_S):
 def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
     """Record a converged apply as a terminal success. last_sync_status keeps the
     literal "ok" prefix (the _pool_sync_is_redundant dedup gate + the onboarding
-    poller both key off it); the durable llm_pool_synced_at marker is stamped
-    ONLY for pool tenants - it is is_ready_for_chat's evidence-of-successful-apply
-    gate and must never be set from mere intent or an "applying" 200."""
+    poller both key off it); the durable evidence-of-successful-apply marker
+    (llm_pool_synced_at for a pool tenant, llm_direct_synced_at for a single-model
+    tenant — round-4 R4-P0-6) is is_ready_for_chat's first-activation gate and
+    must never be set from mere intent or an "applying" 200. A converged apply is
+    exactly the confirmation it wants: admin gates chat_readiness "Ready" on
+    applied_version >= desired_version. Without the direct marker here, a first
+    direct apply that converged via reconcile would flip "ok" yet strand the
+    tenant at llm_provisioning forever (an "ok" status stops every reconcile)."""
     import frappe as _frappe
     now = _frappe.utils.now()
     fields = {
@@ -123,6 +128,8 @@ def _stamp_converged_ok(settings, *, is_pool: bool) -> None:
     }
     if is_pool:
         fields["llm_pool_synced_at"] = now
+    else:
+        fields["llm_direct_synced_at"] = now
     settings.db_set(fields, update_modified=False)
     _commit_terminal_sync_status()
 
@@ -730,14 +737,19 @@ class JarvisSettings(Document):
                     auth_mode=self.llm_auth_mode or "api_key",
                 ) or {}
                 resolved_action = result.get("action", "restart")
-            # C5/F2: a "restart" (post_update_llm_creds) may come back accepted-
-            # but-still-converging. The admin committed the desired creds and a
-            # reconcile finishes the apply; treat "applying" as PENDING, converge
-            # via get_connection (is_pool=False - the single-model gate keys off
-            # the flat llm_* creds set at save, not llm_pool_synced_at), and only
-            # record pending when it hasn't landed yet. "reload" (hot secret
-            # rotation) has no applying semantics, so it skips this.
-            if action == "restart" and _is_applying_result(result):
+            # C5/F2 + round-4 R4-P0-6 — CONVERGENCE, not HTTP success: a sync may
+            # come back accepted-but-still-converging. Admin deliberately returns
+            # 200 with status="applying" on a busy apply lock / fleet read-timeout /
+            # applied-version CAS refusal — the container is NOT yet on the new
+            # creds. Treat anything but a demonstrable "applied" as PENDING:
+            # converge via get_connection (is_pool=False — stamps the direct
+            # llm_direct_synced_at marker on Ready), else record pending for the
+            # */5 reconcile / onboarding poller to finish. This gates BOTH actions:
+            # since round-4 the admin's rotate path also returns status="applying"
+            # when a newer generation raced the rotation, so "reload" is no longer
+            # applying-free. A missing status defaults to "applied" (an admin too
+            # old to thread it predates this contract).
+            if _is_applying_result(result) or (result.get("status") or "applied") != "applied":
                 if not _converge_via_admin(self, is_pool=False):
                     self.db_set(
                         "last_sync_status", _PENDING_APPLYING_STATUS,
@@ -749,6 +761,11 @@ class JarvisSettings(Document):
             self.db_set({
                 "last_sync_at": frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
+                # Durable "a direct config has been CONFIRMED-applied at least once"
+                # marker — stamped ONLY on status=applied (R4-P0-6 / P1-10). A first
+                # direct activation is gated on this so local key/provider/model
+                # presence alone can no longer open chat on an unconfirmed apply.
+                "llm_direct_synced_at": frappe.utils.now(),
             })
             # Commit EVERY terminal status (ok and each failed branch), not
             # just the finally-backstop: the rq SIGALRM can fire at any
@@ -1133,15 +1150,29 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
         terminal_written = False
         try:
             result = _post_pool_with_retry(spec, api_keys, oauth_blobs) or {}
-            # C5/F2: an accepted-but-still-converging apply ("applying") is NOT a
-            # confirmed apply. The admin committed the desired pool and a reconcile
-            # will finish it; the bench must NOT stamp llm_pool_synced_at off this
-            # 200 (that field is evidence of a SUCCESSFUL apply and gates chat
-            # readiness). Poll get_connection for chat_readiness == "Ready" (the
-            # cheap in-job fast path); if it lands, _stamp_converged_ok sets the
-            # markers, otherwise record the pending state and let the */5 reconcile
-            # finish it. Either way this is terminal for THIS job (no failed write).
-            if _is_applying_result(result):
+            # CONVERGENCE STATUS, not HTTP success (C5/F2 + round-4 R4-P0-6).
+            # Admin deliberately returns HTTP 200 with status="applying" when the
+            # apply lock was busy, the fleet read timed out, or the applied-version
+            # CAS refused — the container is NOT yet on the new pool — and status=
+            # "blocked" when a subscription pool has no persisted OAuth blobs.
+            # Stamping the durable "ever applied" marker (llm_pool_synced_at) on
+            # those made is_ready_for_chat open chat on a container still running
+            # the stub. "blocked" is terminal-failed: only the customer
+            # re-authenticating fixes it, so no reconcile poll can converge it.
+            # Anything else short of a demonstrable "applied" converges via
+            # get_connection (the cheap in-job fast path — on Ready
+            # _stamp_converged_ok sets the markers) or records the pending state
+            # for the */5 reconcile to finish. A missing status (an admin too old
+            # to thread it) defaults to "applied" — its own contract predates this.
+            status = (result.get("status") or "applied")
+            if status == "blocked":
+                settings.db_set("last_sync_status",
+                                "failed: subscription needs re-authentication (blocked)",
+                                update_modified=False)
+                _commit_terminal_sync_status()
+                terminal_written = True  # preserve this status past the finally backstop
+                return
+            if _is_applying_result(result) or status != "applied":
                 if not _converge_via_admin(settings, is_pool=True):
                     settings.db_set(
                         "last_sync_status", _PENDING_APPLYING_STATUS,
@@ -1155,11 +1186,10 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 "last_sync_at": _frappe.utils.now(),
                 "last_sync_status": f"ok ({resolved_action} via admin)",
                 # Durable "this pool has been APPLIED to the container at
-                # least once" marker. is_ready_for_chat gates pool tenants
-                # on it: proxy_active alone is config INTENT (committed
-                # synchronously at save, before this job runs) and must not
-                # be read as provisioning success - a fresh tenant whose
-                # first sync is still pending/failed has no working pool.
+                # least once" marker — stamped ONLY on a confirmed status=applied
+                # (R4-P0-6). is_ready_for_chat gates pool tenants on it: proxy_active
+                # alone is config INTENT (committed synchronously at save, before
+                # this job runs) and must not be read as provisioning success.
                 "llm_pool_synced_at": _frappe.utils.now(),
             }
             # A NO-OP apply (contract 1.10's ``unchanged: true``) changed nothing and,
@@ -1380,24 +1410,32 @@ def reconcile_pending_llm_sync() -> None:
         status = (settings.get("last_sync_status") or "")
         proxy_active = bool(settings.get("proxy_active"))
         pool_synced = bool(settings.get("llm_pool_synced_at"))
+        direct_synced = bool(settings.get("llm_direct_synced_at"))
 
         is_applying_pending = status.startswith(_PENDING_APPLYING_STATUS)
-        # A pool whose first apply never stamped the marker may have been
-        # converged by the admin reconcile cron since the bench last wrote its
-        # (pending/failed) status - re-probe so the customer isn't stranded at
-        # llm_pool_provisioning while the container is actually serving the pool.
-        is_unproven_pool = (
-            proxy_active and not pool_synced
-            and (status.startswith("pending:") or status.startswith("failed:"))
+        # A tenant whose FIRST apply never stamped its evidence marker may have
+        # been converged by the admin reconcile cron since the bench last wrote
+        # its (pending/failed) status - re-probe so the customer isn't stranded
+        # at llm_pool_provisioning / llm_provisioning while the container is
+        # actually serving the config. Direct analogue added in round-4
+        # (R4-P0-6): is_ready_for_chat now gates a first single-model activation
+        # on llm_direct_synced_at, so an unproven direct tenant is the same
+        # stranding class as an unproven pool.
+        is_stuck = status.startswith("pending:") or status.startswith("failed:")
+        is_unproven_pool = proxy_active and not pool_synced and is_stuck
+        is_unproven_direct = (
+            not proxy_active and not direct_synced and is_stuck
+            and (settings.get("llm_auth_mode") or "api_key") == "api_key"
+            and bool((settings.get("llm_provider") or "").strip())
         )
-        if not (is_applying_pending or is_unproven_pool):
+        if not (is_applying_pending or is_unproven_pool or is_unproven_direct):
             return
 
         state, _reason = _admin_chat_readiness()
         if state == "Ready":
-            # Stamp llm_pool_synced_at only for pool tenants (is_pool=proxy_active):
-            # for a single-model tenant the flat creds set at save time is already
-            # the readiness gate, so it just clears the pending status to "ok".
+            # Stamps the evidence marker for whichever mode is active:
+            # llm_pool_synced_at for pool tenants, llm_direct_synced_at for
+            # single-model tenants (is_ready_for_chat's first-activation gates).
             _stamp_converged_ok(settings, is_pool=proxy_active)
     except Exception:
         frappe.log_error(

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -606,6 +606,20 @@ def get_llm_sync_status() -> dict:
 	s = frappe.get_single("Jarvis Settings")
 	status = s.get("last_sync_status") or ""
 
+	# Round-4 review R4-P0-6: an apply that admin returned as status="applying"
+	# (busy lock / read-timeout / CAS refusal) left last_sync_status at the
+	# pending-applying marker and did NOT stamp the durable synced marker. The
+	# in-job convergence poll and the */5 reconcile_pending_llm_sync safety net
+	# converge it eventually, but this poller runs every few seconds during
+	# onboarding — so while (and ONLY while) we are pending-applying, consult
+	# admin's read-only serving receipt (get_connection -> chat_readiness) and,
+	# if it now reports Ready, flip the marker + status to "ok". Best-effort: any
+	# admin error leaves us pending (the next poll retries). This is the "admit
+	# chat from an admin serving receipt, not HTTP success" the review asks for,
+	# done lazily from the poller the UI already runs.
+	if status.startswith(_pending_applying_status()):
+		status = _reconcile_pending_applying(s) or status
+
 	def _json_list(raw):
 		"""Stored JSON text -> list, degrading a corrupt/empty value to [] rather than
 		ever 500ing this poller."""
@@ -627,6 +641,42 @@ def get_llm_sync_status() -> dict:
 		# contract 1.11. The AI-models list keys each api-key row's health off this.
 		"model_statuses": _json_list(s.get("last_model_statuses")),
 	}
+
+
+def _pending_applying_status() -> str:
+	"""The jarvis_settings pending-applying marker, imported lazily so this
+	module keeps zero import-time coupling to the (heavy) doctype module."""
+	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+		_PENDING_APPLYING_STATUS,
+	)
+	return _PENDING_APPLYING_STATUS
+
+
+def _reconcile_pending_applying(settings) -> str | None:
+	"""Lazy customer-side reconcile for a pending-applying sync (round-4 R4-P0-6).
+
+	Consult admin's read-only serving verdict for the active generation. When admin
+	reports the container Ready, the apply has CONVERGED — stamp the durable synced
+	marker (llm_pool_synced_at for a pool, llm_direct_synced_at for direct, via the
+	shared _stamp_converged_ok) and flip the status to "ok" so is_ready_for_chat
+	opens chat and the poller stops calling admin. Returns the new status string on
+	a flip, else None (stay pending).
+
+	Best-effort: any admin error / non-Ready verdict leaves the pending status
+	untouched; the next poll retries. Never raises out of the poller."""
+	from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+		_admin_chat_readiness,
+		_stamp_converged_ok,
+	)
+	state, _reason = _admin_chat_readiness()
+	if state != "Ready":
+		return None
+	_stamp_converged_ok(settings, is_pool=bool(settings.get("proxy_active")))
+	# _stamp_converged_ok's commit gate only fires in a worker/migrate context;
+	# this runs in a web request, where a GET would otherwise roll the terminal
+	# write back at request end.
+	frappe.db.commit()
+	return settings.get("last_sync_status")
 
 
 @frappe.whitelist()

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -26,3 +26,4 @@ jarvis.patches.v1_14_remove_desk_workspaces
 jarvis.patches.v1_15_unarchive_auto_expired_conversations
 jarvis.patches.v1_16_merge_user_preference_into_settings
 jarvis.patches.v1_17_drop_user_preference_doctype
+jarvis.patches.v2_00_backfill_llm_direct_synced_at

--- a/jarvis/patches/v2_00_backfill_llm_direct_synced_at.py
+++ b/jarvis/patches/v2_00_backfill_llm_direct_synced_at.py
@@ -1,0 +1,49 @@
+"""Backfill Jarvis Settings.llm_direct_synced_at for pre-marker direct tenants.
+
+The marker ("a DIRECT single-model config has been CONFIRMED-applied to the
+container at least once") was introduced with the round-4 R4-P0-6 / P1-10 fix:
+is_ready_for_chat's api_key branch used to admit chat from local
+key/provider/model presence alone — which is config INTENT committed at save,
+before the async admin apply runs — so a first apply still "applying" (busy
+lock / read-timeout / CAS refusal) opened chat on a container still on the stub.
+The direct-sync worker now stamps this marker only on a confirmed admin
+status="applied", and the gate reads it.
+
+Grandfather rule (mirrors v1_10_backfill_llm_pool_synced_at): a pre-marker
+DIRECT api-key tenant (proxy_active=0, auth_mode=api_key) with local creds
+(llm_api_key + llm_provider + llm_model) whose sync has EVER reached a terminal
+state (last_sync_at set) is stamped — before this deploy the gate was local
+presence alone, so an existing serving direct tenant whose LATEST re-save is
+transiently "pending"/"failed" at migrate time (while the container keeps
+serving its previous key) was chat-ready and must stay so.
+
+NOT stamped: a tenant with no completed sync (last_sync_at empty) — its creds
+have demonstrably never been applied; leaving it unstamped routes it to
+onboarding rather than a chat surface where every turn fails, and its marker
+sets on the first confirmed sync.
+
+Reads go through the document API, not frappe.db.get_single_value, for the same
+empty-Datetime coercion reason documented in v1_10.
+"""
+
+import frappe
+
+
+def execute():
+	settings = frappe.get_single("Jarvis Settings")
+	if getattr(settings, "proxy_active", 0):
+		return  # pool tenant — llm_pool_synced_at owns its gate
+	if settings.llm_direct_synced_at:
+		return
+	auth_mode = (getattr(settings, "llm_auth_mode", "") or "api_key").strip()
+	if auth_mode != "api_key":
+		return  # oauth/subscription gate on llm_oauth_connected_at, not this marker
+	key = (settings.get_password("llm_api_key", raise_exception=False) or "").strip()
+	provider = (getattr(settings, "llm_provider", "") or "").strip()
+	model = (getattr(settings, "llm_model", "") or "").strip()
+	if not (key and provider and model):
+		return  # not a configured direct tenant
+	if not settings.last_sync_at:
+		return  # no sync ever completed: nothing to grandfather
+	frappe.db.set_single_value(
+		"Jarvis Settings", "llm_direct_synced_at", settings.last_sync_at)

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1189,12 +1189,12 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
     # ------------------------------------------------------------------
 
     def test_api_key_onboarding_leaves_is_ready_for_chat_passing(self):
-        """is_ready_for_chat must return ready=True after a successful
-        api_key onboarding via save_llm_creds."""
+        """is_ready_for_chat must return ready=True after a successful (confirmed,
+        status=applied) api_key onboarding via save_llm_creds."""
         from unittest.mock import patch
 
         with patch("jarvis.admin_client.post_update_llm_creds",
-                   return_value={"action": "restart"}):
+                   return_value={"action": "restart", "status": "applied"}):
             from jarvis import onboarding
             onboarding.save_llm_creds(
                 provider="openai_compat",
@@ -1210,6 +1210,87 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
                         f"is_ready_for_chat must return ready=True after api_key onboarding; got: {result}")
         self.assertIsNone(result.get("reason"),
                           f"reason must be None when ready; got: {result.get('reason')!r}")
+
+    def test_api_key_first_apply_still_applying_is_not_ready(self):
+        """Round-4 review R4-P0-6 / P1-10: a FIRST direct apply that admin returns
+        as status="applying" (busy lock / timeout / CAS refusal) must NOT open
+        chat — local key/provider/model presence alone is config intent, not proof
+        the container received the creds. Gated on the durable llm_direct_synced_at
+        marker, which is stamped only on a confirmed status=applied."""
+        from unittest.mock import patch
+
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("llm_direct_synced_at", None, update_modified=False)
+        frappe.db.commit()
+        # get_connection must be pinned not-Ready: the applying path now runs the
+        # in-job convergence probe, and an unmocked call could reach a live admin.
+        with patch("jarvis.admin_client.post_update_llm_creds",
+                   return_value={"action": "restart", "status": "applying"}), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
+            from jarvis import onboarding
+            onboarding.save_llm_creds(
+                provider="openai_compat", model="gpt-4o",
+                api_key="sk-never-confirmed", base_url="https://api.openai.com",
+                auth_mode="api_key",
+            )
+        from jarvis.account import is_ready_for_chat
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertIsNone(settings.llm_direct_synced_at,
+                          "an 'applying' first apply is not confirmed")
+        result = is_ready_for_chat()
+        self.assertFalse(result.get("ready"),
+                         f"a never-confirmed direct tenant must not be chat-ready; got: {result}")
+        self.assertEqual(result.get("reason"), "llm_provisioning")
+
+    def test_api_key_first_apply_applying_then_ready_converges_and_stamps_marker(self):
+        """The direct analogue of the pool convergence test: an 'applying' first
+        direct apply whose in-job probe finds admin already Ready must stamp
+        llm_direct_synced_at (via _stamp_converged_ok) and open chat — without
+        this a converged-via-reconcile direct tenant would be stranded at
+        llm_provisioning forever (an 'ok' status stops every later reconcile)."""
+        from unittest.mock import patch
+
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("llm_direct_synced_at", None, update_modified=False)
+        frappe.db.commit()
+        with patch("jarvis.admin_client.post_update_llm_creds",
+                   return_value={"action": "restart", "status": "applying"}), \
+             patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            from jarvis import onboarding
+            onboarding.save_llm_creds(
+                provider="openai_compat", model="gpt-4o",
+                api_key="sk-converges", base_url="https://api.openai.com",
+                auth_mode="api_key",
+            )
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_direct_synced_at,
+                        "convergence to chat_readiness Ready must stamp llm_direct_synced_at")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"),
+                        f"a converged apply must read ok; got {settings.last_sync_status!r}")
+        from jarvis.account import is_ready_for_chat
+        self.assertTrue(is_ready_for_chat().get("ready"),
+                        "a converged first direct apply must open chat")
+
+    def test_established_direct_tenant_stays_ready_through_resave_pending(self):
+        """An already-confirmed direct tenant (marker set) keeps chatting on its
+        previous key while a re-save is transiently 'applying'."""
+        from jarvis.account import is_ready_for_chat
+        settings = frappe.get_single("Jarvis Settings")
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _PENDING_APPLYING_STATUS,
+        )
+        settings.db_set({
+            "llm_auth_mode": "api_key", "llm_provider": "openai_compat",
+            "llm_model": "gpt-4o", "proxy_active": 0,
+            "llm_direct_synced_at": frappe.utils.now(),
+            "last_sync_status": _PENDING_APPLYING_STATUS,
+        }, update_modified=False)
+        settings.db_set("llm_api_key", "sk-established")
+        frappe.db.commit()
+        self.assertTrue(is_ready_for_chat().get("ready"),
+                        "an established direct tenant must stay ready during a pending re-save")
 
     # ------------------------------------------------------------------
     # (e) OAuth mode leaves the models table untouched
@@ -2269,6 +2350,67 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         self.assertTrue((settings.last_sync_status or "").startswith("ok"),
                         f"expected ok status, got: {settings.last_sync_status!r}")
 
+    def test_pending_applying_flips_to_ok_when_admin_reports_ready(self):
+        """Round-4 review R4-P0-6: a pending-applying sync converges once admin's
+        read-only serving verdict (get_connection -> chat_readiness) reports Ready.
+        The poller flips the durable marker + status to ok, and stays pending while
+        admin is not Ready."""
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _PENDING_APPLYING_STATUS,
+        )
+        from jarvis.onboarding import get_llm_sync_status
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({
+            "proxy_active": 1, "llm_pool_synced_at": None,
+            "last_sync_status": _PENDING_APPLYING_STATUS,
+        }, update_modified=False)
+        frappe.db.commit()
+        # Admin not yet Ready -> stays pending, no marker.
+        with patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Configuring"}):
+            out = get_llm_sync_status()
+        self.assertTrue(out["last_sync_status"].startswith("pending"))
+        self.assertIsNone(frappe.get_single("Jarvis Settings").llm_pool_synced_at)
+        # Admin now Ready -> flip to ok + stamp the durable marker.
+        with patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            out = get_llm_sync_status()
+        self.assertTrue(out["last_sync_status"].startswith("ok"),
+                        f"expected ok after admin Ready, got: {out['last_sync_status']!r}")
+        self.assertTrue(frappe.get_single("Jarvis Settings").llm_pool_synced_at)
+
+    def test_pending_applying_stays_pending_when_admin_unreachable(self):
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            _PENDING_APPLYING_STATUS,
+        )
+        from jarvis.onboarding import get_llm_sync_status
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({
+            "proxy_active": 1, "llm_pool_synced_at": None,
+            "last_sync_status": _PENDING_APPLYING_STATUS,
+        }, update_modified=False)
+        frappe.db.commit()
+        with patch("jarvis.admin_client.get_connection",
+                   side_effect=RuntimeError("admin down")):
+            out = get_llm_sync_status()
+        self.assertTrue(out["last_sync_status"].startswith("pending"),
+                        "an admin error must leave the status pending, never crash the poller")
+
+    def test_pool_sync_blocked_is_failed_no_stamp(self):
+        """status="blocked" (subscription pool with no OAuth blobs) is terminal
+        failed — never a first-success."""
+        self._seed_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set("llm_pool_synced_at", None, update_modified=False)
+        frappe.db.commit()
+        with patch("jarvis.admin_client.post_update_llm_pool",
+                   return_value={"action": "pool", "status": "blocked"}):
+            _enqueued_sync_via_admin_pool()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertIsNone(settings.llm_pool_synced_at)
+        self.assertTrue((settings.last_sync_status or "").startswith("failed"),
+                        f"expected failed, got: {settings.last_sync_status!r}")
+
     # -- is_ready_for_chat gate ------------------------------------------
 
     def _set_pool_gate_state(self, *, synced_at, status):
@@ -2383,6 +2525,51 @@ class TestOnboardingAuditFixes(_RT3SettingsTestCase):
         settings = frappe.get_single("Jarvis Settings")
         self.assertFalse(settings.llm_pool_synced_at,
                          "direct tenants must not be stamped")
+
+    def test_direct_backfill_grandfathers_serving_direct_tenants(self):
+        """Round-4 review R4-P0-6: a pre-marker DIRECT api-key tenant with local
+        creds that has EVER synced is grandfathered (llm_direct_synced_at
+        backfilled from last_sync_at) so the new gate doesn't bounce it to
+        onboarding mid-upgrade; a never-synced one is not stamped."""
+        from jarvis.patches.v2_00_backfill_llm_direct_synced_at import execute
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({
+            "proxy_active": 0, "llm_auth_mode": "api_key",
+            "llm_provider": "openai_compat", "llm_model": "gpt-4o",
+            "llm_direct_synced_at": None, "last_sync_at": frappe.utils.now(),
+        }, update_modified=False)
+        settings.db_set("llm_api_key", "sk-grandfathered")
+        frappe.db.commit()
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_direct_synced_at,
+                        "a serving pre-marker direct tenant must be grandfathered")
+
+    def test_direct_backfill_skips_never_synced(self):
+        from jarvis.patches.v2_00_backfill_llm_direct_synced_at import execute
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({
+            "proxy_active": 0, "llm_auth_mode": "api_key",
+            "llm_provider": "openai_compat", "llm_model": "gpt-4o",
+            "llm_direct_synced_at": None, "last_sync_at": None,
+        }, update_modified=False)
+        settings.db_set("llm_api_key", "sk-never-synced")
+        frappe.db.commit()
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertFalse(settings.llm_direct_synced_at,
+                         "a never-synced direct tenant must not be grandfathered")
+
+    def test_direct_backfill_skips_pool_tenants(self):
+        from jarvis.patches.v2_00_backfill_llm_direct_synced_at import execute
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({"proxy_active": 1, "llm_direct_synced_at": None},
+                        update_modified=False)
+        frappe.db.commit()
+        execute()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertFalse(settings.llm_direct_synced_at,
+                         "pool tenants gate on llm_pool_synced_at, not this marker")
 
     def test_pool_sync_ok_status_survives_rollback(self):
         """The OK terminal write (status + marker) must be committed too: an
@@ -2809,6 +2996,31 @@ class TestConvergenceReconcile(_RT3SettingsTestCase):
         settings = frappe.get_single("Jarvis Settings")
         self.assertFalse(settings.llm_pool_synced_at)
         self.assertTrue((settings.last_sync_status or "").startswith("pending:"))
+
+    def test_reconcile_stamps_direct_marker_for_unproven_direct_tenant(self):
+        """Round-4 R4-P0-6 direct analogue of the unproven-pool re-probe: a
+        single-model tenant whose FIRST apply never stamped llm_direct_synced_at
+        (stuck at pending/failed) is re-probed, and admin Ready stamps the direct
+        marker so is_ready_for_chat stops reporting llm_provisioning."""
+        from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import (
+            reconcile_pending_llm_sync,
+        )
+        settings = frappe.get_single("Jarvis Settings")
+        settings.db_set({
+            "proxy_active": 0, "llm_auth_mode": "api_key",
+            "llm_provider": "openai_compat", "llm_model": "gpt-4o",
+            "llm_direct_synced_at": None,
+            "last_sync_status": "failed: admin briefly unreachable",
+        }, update_modified=False)
+        frappe.db.commit()
+        self._seed_admin_creds()  # after the commit; stays in the rolled-back txn
+        with patch("jarvis.admin_client.get_connection",
+                   return_value={"chat_readiness": "Ready"}):
+            reconcile_pending_llm_sync()
+        settings = frappe.get_single("Jarvis Settings")
+        self.assertTrue(settings.llm_direct_synced_at,
+                        "the */5 reconcile must stamp the DIRECT marker once admin reports Ready")
+        self.assertTrue((settings.last_sync_status or "").startswith("ok"))
 
     def test_reconcile_noop_on_healthy_tenant(self):
         """Inert on a healthy fleet: an 'ok' tenant is never probed or re-stamped."""


### PR DESCRIPTION
Adapts the customer app to the round-3/4 `jarvis_admin_v2` changes so the bench never opens chat on an unconfirmed first apply (Codex round-4 finding R4-P0-6 / P1-10).

**Note on base:** branched from the local `deploy/dev-all` deploy baseline (not on origin), so this PR's diff also carries that branch's commits ahead of `main`. The R4-P0-6 change is the top commit; retarget to your release branch as needed.

## The bug
The bench treated every non-exception admin response as success — `last_sync_status="ok"` and the durable `llm_pool_synced_at` marker were stamped even when admin returned HTTP 200 with `status="applying"` (busy apply lock / fleet read timeout / applied-version CAS refusal — the container is **not** yet on the new config) or `status="blocked"`. `is_ready_for_chat` then opened chat on a stub container. Direct api-key admission was worse: it admitted chat from local key/provider/model presence alone.

## The fix (top commit)
- **Status-aware stamping**: pool + direct sync stamp the "ever confirmed" marker and `"ok"` **only** on `status="applied"`; `"applying"` stays `pending`; `"blocked"` is terminal-failed.
- **Durable direct marker** `llm_direct_synced_at` + backfill `v2_00`; `is_ready_for_chat` gates a first direct activation on it.
- **Lazy admin-receipt reconcile**: `get_llm_sync_status` flips `pending: applying` → `ok` once admin's `get_connection → chat_readiness` reports Ready.
- **Frontend** routes the new `llm_provisioning` reason to the onboarding poster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)