### PR TITLE
feat(get_schema): surface every configured docfield property

### DIFF
--- a/jarvis/tests/test_get_schema.py
+++ b/jarvis/tests/test_get_schema.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools.get_schema import get_schema
+from jarvis.tools.get_schema import _field_record, get_schema
 
 
 class TestGetSchema(FrappeTestCase):
@@ -13,18 +13,15 @@ class TestGetSchema(FrappeTestCase):
         fieldnames = {f["fieldname"] for f in result["fields"]}
         self.assertIn("customer_name", fieldnames)
 
-    def test_default_returns_five_keys_per_field(self):
-        """The default per-field shape carries fieldname / fieldtype /
-        label / options / reqd. options and reqd are load-bearing:
-        Link/Select/Table targets and write-path requireds. The
-        previous 3-key slim default was too aggressive and got walked
-        back."""
+    def test_identity_keys_always_present_on_every_field(self):
+        """fieldname + fieldtype are unconditional; a record without them is
+        anonymous. Everything else - label, options, reqd included - appears only
+        when configured, because falsy IS the Frappe default and absence says so
+        for free. This used to assert an exact 5-key set."""
         result = get_schema(doctype="Customer")
-        f = result["fields"][0]
-        self.assertEqual(
-            set(f.keys()),
-            {"fieldname", "fieldtype", "label", "options", "reqd"},
-        )
+        for f in result["fields"]:
+            self.assertIn("fieldname", f)
+            self.assertIn("fieldtype", f)
 
     def test_default_includes_options_on_link_field(self):
         """A Link field's options carries its target DocType. Without
@@ -45,18 +42,25 @@ class TestGetSchema(FrappeTestCase):
         self.assertEqual(items_field["options"], "Sales Invoice Item")
         self.assertNotIn("child_fields", items_field)
 
-    def test_default_includes_reqd(self):
-        """reqd is a single bool per field - cheap, but essential for
-        the agent to know which fields must be set on create_doc."""
+    def test_default_includes_reqd_on_mandatory_fields_only(self):
+        """reqd is essential for the agent to know what create_doc must set - but
+        it rides the omit-when-falsy rule like everything else, so it marks the
+        mandatory fields and is simply absent on the rest."""
         result = get_schema(doctype="Customer")
-        # customer_name is mandatory on Customer (the doc's autoname);
-        # at least one field on every standard DocType has reqd=True.
-        reqds = [f["reqd"] for f in result["fields"]]
-        self.assertIn(True, reqds, "expected at least one reqd=True field")
+        # At least one field on every standard DocType is mandatory.
+        self.assertTrue(
+            any(f.get("reqd") for f in result["fields"]),
+            "expected at least one reqd field",
+        )
+        # ...and a field that is not mandatory says so by omission, not reqd=False.
+        optional = [f for f in result["fields"] if not f.get("reqd")]
+        self.assertTrue(optional, "expected some optional fields")
+        self.assertNotIn("reqd", optional[0])
 
     def test_verbose_expands_child_table_schemas(self):
-        """verbose=True is the opt-in for inlined child schemas. Same
-        per-field shape (5 keys) inside the expansion."""
+        """verbose=True is the opt-in for inlined child schemas. Child records
+        use the same shape as parents: the core keys always, plus whatever the
+        child DocType configures."""
         result = get_schema(doctype="Sales Invoice", verbose=True)
         items_field = next(f for f in result["fields"] if f["fieldname"] == "items")
         self.assertEqual(items_field["fieldtype"], "Table")
@@ -65,12 +69,9 @@ class TestGetSchema(FrappeTestCase):
         child_fieldnames = {cf["fieldname"] for cf in items_field["child_fields"]}
         self.assertIn("item_code", child_fieldnames)
         self.assertIn("qty", child_fieldnames)
-        # Child records use the same 5-key shape.
-        first_child = items_field["child_fields"][0]
-        self.assertEqual(
-            set(first_child.keys()),
-            {"fieldname", "fieldtype", "label", "options", "reqd"},
-        )
+        for cf in items_field["child_fields"]:
+            self.assertIn("fieldname", cf)
+            self.assertIn("fieldtype", cf)
 
     def test_verbose_non_table_fields_have_no_child_fields_key(self):
         result = get_schema(doctype="Customer", verbose=True)
@@ -102,3 +103,115 @@ class TestGetSchema(FrappeTestCase):
                 get_schema(doctype="Customer")
         finally:
             frappe.set_user("Administrator")
+
+
+class _StubField:
+    """Stands in for a meta DocField: _field_record only needs the five core
+    attributes plus as_dict(). A stub (not a real doctype) keeps these assertions
+    from drifting when ERPNext reshuffles its own field properties."""
+
+    def __init__(self, **props):
+        self._props = props
+        for k, v in props.items():
+            setattr(self, k, v)
+
+    def as_dict(self):
+        return dict(self._props)
+
+
+class TestFieldRecordConfiguredProps(FrappeTestCase):
+    """Per-field records carry the configured docfield properties, and only
+    those: absent == not configured (the Frappe default, always falsy)."""
+
+    def _rec(self, **props):
+        base = {"fieldname": "f1", "fieldtype": "Data", "label": "F1",
+                "options": "", "reqd": 0}
+        base.update(props)
+        return _field_record(_StubField(**base))
+
+    def test_configured_props_surface(self):
+        rec = self._rec(
+            read_only=1,
+            fetch_from="customer.customer_name",
+            allow_on_submit=1,
+            mandatory_depends_on="eval:doc.docstatus==1",
+            default="Draft",
+            link_filters='[["Item","has_variants","=",0]]',
+        )
+        self.assertEqual(rec["read_only"], 1)
+        self.assertEqual(rec["fetch_from"], "customer.customer_name")
+        self.assertEqual(rec["allow_on_submit"], 1)
+        self.assertEqual(rec["mandatory_depends_on"], "eval:doc.docstatus==1")
+        self.assertEqual(rec["default"], "Draft")
+        self.assertEqual(rec["link_filters"], '[["Item","has_variants","=",0]]')
+
+    def test_unconfigured_props_are_omitted_not_falsy(self):
+        """The whole point of the omit rule: an ordinary field costs almost
+        nothing, which is what pays for the properties added above."""
+        rec = self._rec(read_only=0, fetch_from="", allow_on_submit=None, default="")
+        self.assertEqual(set(rec.keys()), {"fieldname", "fieldtype", "label"})
+
+    def test_falsy_label_options_reqd_are_omitted_too(self):
+        """These three used to be emitted unconditionally. Emitting `options: ""`
+        on every primitive field said "no options" in 15 bytes where absence says
+        it in zero - across ~1000 fields that padding cost more than every
+        property this change adds."""
+        rec = self._rec(options="", reqd=0, label="")
+        self.assertEqual(set(rec.keys()), {"fieldname", "fieldtype"})
+
+    def test_configured_label_options_reqd_survive(self):
+        rec = self._rec(label="Customer", options="Customer", reqd=1, fieldtype="Link")
+        self.assertEqual(rec["label"], "Customer")
+        self.assertEqual(rec["options"], "Customer")
+        self.assertEqual(rec["reqd"], 1)
+
+    def test_presentation_only_props_never_surface(self):
+        """These can't affect a write; measured at ~17% of an all-props payload."""
+        rec = self._rec(print_hide=1, width="200px", collapsible=1, bold=1,
+                        in_global_search=1, translatable=1, report_hide=1,
+                        columns=2, search_index=1, show_dashboard=1)
+        for k in ("print_hide", "width", "collapsible", "bold", "in_global_search",
+                  "translatable", "report_hide", "columns", "search_index",
+                  "show_dashboard"):
+            self.assertNotIn(k, rec)
+
+    def test_docfield_row_metadata_never_surfaces(self):
+        """as_dict() carries the DocField ROW's own fields; they describe the
+        docfield record, not the field it defines - and creation/modified are
+        datetimes that would not survive the JSON hop."""
+        import datetime
+
+        rec = self._rec(name="abc123", parent="Sales Order", idx=7, docstatus=0,
+                        owner="Administrator", creation=datetime.datetime.now(),
+                        parentfield="fields", parenttype="DocType")
+        for k in ("name", "parent", "idx", "owner", "creation", "parentfield",
+                  "parenttype", "docstatus"):
+            self.assertNotIn(k, rec)
+
+    def test_non_primitive_values_are_dropped(self):
+        """Defensive: everything emitted must survive the JSON hop to the plugin
+        and the pickled cache entry."""
+        rec = self._rec(some_future_column={"a": 1}, another=[1, 2])
+        self.assertNotIn("some_future_column", rec)
+        self.assertNotIn("another", rec)
+
+
+class TestConfiguredPropsOnRealDoctype(FrappeTestCase):
+    def test_real_schema_omits_presentation_props_and_row_metadata(self):
+        result = get_schema(doctype="Customer", refresh=True)
+        banned = {"print_hide", "width", "collapsible", "bold", "in_global_search",
+                  "search_index", "translatable", "report_hide", "print_width",
+                  "name", "parent", "idx", "owner", "creation", "modified",
+                  "parentfield", "parenttype", "docstatus"}
+        for f in result["fields"]:
+            leaked = banned & set(f.keys())
+            self.assertFalse(leaked, f"{f['fieldname']} leaked {leaked}")
+
+    def test_real_schema_surfaces_a_read_only_field(self):
+        """Sanity that the mechanism fires against real meta, not just stubs.
+        Customer always has at least one read-only field."""
+        result = get_schema(doctype="Customer", refresh=True)
+        self.assertTrue(
+            any(f.get("read_only") for f in result["fields"]),
+            "expected at least one read_only field on Customer",
+        )

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -6,26 +6,93 @@ from jarvis.tools._doc_actions import get_doc_actions
 TABLE_FIELDTYPES = {"Table", "Table MultiSelect"}
 _SCHEMA_TTL = 300  # seconds; schema is user-independent + changes rarely
 
+# Identity: emitted unconditionally because a record without them is anonymous.
+# Every other property is emitted ONLY when the DocType configures it to a truthy
+# value - including label / options / reqd, which used to be emitted always. A
+# falsy docfield property IS the Frappe default (Check -> 0, Data/Text -> "" or
+# None), so `"options": ""` on a thousand primitive fields was pure padding: it
+# said "no options" in 15 bytes where absence says it in zero. Measured across 6
+# real doctypes, dropping that padding pays for every property added below - the
+# whole change lands at ~1.07x the old payload instead of ~1.28x.
+_IDENTITY_PROPS = ("fieldname", "fieldtype")
+
+# DocField's OWN row metadata - describes the docfield record, not the field it
+# defines. Never useful to the agent, and some values (creation/modified) are
+# datetimes that would not survive the JSON hop anyway.
+_ROW_META_PROPS = frozenset({
+	"name", "owner", "creation", "modified", "modified_by", "parent",
+	"parentfield", "parenttype", "idx", "docstatus", "doctype",
+	"oldfieldname", "oldfieldtype", "__islocal", "__unsaved",
+})
+
+# Presentation-only: these change how Desk PAINTS a field and can never affect
+# what a write may contain, so for the agent they are pure context cost.
+#
+# Measured across Sales Order / Sales Invoice / Item / Payment Entry / Delivery
+# Note: emitting EVERY configured property costs ~1.29x the old slim record;
+# excluding this set brings that to ~1.07x while keeping every property that can
+# change what the agent may write. That matters - the slim default exists because
+# of the 2026-06-22 gpt-5.5 context overflow, so growth here has to earn itself.
+_UI_ONLY_PROPS = frozenset({
+	"allow_bulk_edit", "allow_in_quick_entry", "bold", "collapsible",
+	"collapsible_depends_on", "columns", "documentation_url", "hide_border",
+	"hide_days", "hide_seconds", "hide_toolbar", "in_global_search",
+	"in_preview", "make_attachment_public", "print_hide",
+	"print_hide_if_no_value", "print_width", "remember_last_selected_value",
+	"report_hide", "search_index", "show_dashboard",
+	"show_description_on_click", "sort_options", "translatable", "width",
+})
+
+_SKIP_PROPS = _ROW_META_PROPS | _UI_ONLY_PROPS | frozenset(_IDENTITY_PROPS)
+
 
 def _field_record(f) -> dict:
-	"""Per-field response shape. Five keys, all load-bearing:
+	"""Per-field response shape: ``fieldname`` + ``fieldtype`` always, then every
+	docfield property the DocType configures to a truthy value.
 
-	- ``fieldname`` / ``fieldtype`` / ``label``: identity + type + human label.
-	- ``options``: target DocType for Link / Table / Table MultiSelect /
-	  Dynamic Link fields; enum values (newline-separated) for Select fields.
-	  Empty string for primitive fields. Without it Link/Select/Table fields
-	  are opaque - the agent can't follow them, filter on enum values, or
-	  ``get_schema`` the child DocType.
-	- ``reqd``: whether the field is mandatory on insert. Essential for write
-	  paths (create_doc / update_doc); cheap on reads.
+	ABSENT MEANS "NOT CONFIGURED" - i.e. the Frappe default, which is always
+	falsy. A reader must never read a missing key as unknown. That one rule is
+	what lets this carry far more per field than the old fixed five keys while
+	costing ~7% more, not ~28%.
+
+	Commonly present, and the reason this exists - the properties that change what
+	a write may legally contain:
+
+	- ``label``: human label (absent on layout breaks, which have none).
+	- ``options``: target DocType for Link / Table / Table MultiSelect / Dynamic
+	  Link; enum values (newline-separated) for Select. Absent on primitives.
+	  Without it Link/Select/Table fields are opaque - the agent can't follow
+	  them, filter on enum values, or ``get_schema`` the child DocType.
+	- ``reqd``: mandatory on insert.
+	- ``read_only`` / ``allow_on_submit`` / ``set_only_once``: writable at all,
+	  after submit, or on insert only.
+	- ``fetch_from``: value is pulled from a linked doc - set the LINK, not this.
+	- ``mandatory_depends_on`` / ``read_only_depends_on`` / ``depends_on``: the
+	  conditional forms, which ``reqd`` alone does not capture.
+	- ``default``, ``unique``, ``no_copy``, ``precision``, ``permlevel``,
+	  ``is_virtual``, ``link_filters``.
+
+	Deliberately dropped: DocField row metadata (``_ROW_META_PROPS``) and
+	presentation-only properties (``_UI_ONLY_PROPS``) that cannot affect a write.
+	Everything else rides along by default, so a property Frappe adds later
+	surfaces without a code change - the inverse of an allowlist, which would
+	silently omit it.
 	"""
-	return {
-		"fieldname": f.fieldname,
-		"fieldtype": f.fieldtype,
-		"label": f.label,
-		"options": f.options,
-		"reqd": bool(f.reqd),
-	}
+	record = {"fieldname": f.fieldname, "fieldtype": f.fieldtype}
+	for key, value in f.as_dict().items():
+		if key in _SKIP_PROPS:
+			continue
+		# Falsy == "not configured" for every docfield property: Check defaults to
+		# 0, Data/Text to "" or None. Dropping them is the whole budget.
+		if not value:
+			continue
+		# Defensive: docfield columns are all Data/Text/Int/Check, so this only
+		# bites if Frappe adds an exotic column - which must not break the JSON
+		# hop to the plugin or the pickled cache entry.
+		if not isinstance(value, (str, int, float, bool)):
+			continue
+		record[key] = value
+	return record
 
 
 def _workflow_for(doctype: str):
@@ -118,8 +185,34 @@ def get_schema(doctype: str, verbose: bool = False, refresh: bool = False) -> di
 	Top level: ``doctype``, ``is_submittable`` (docstatus lifecycle applies),
 	``autoname`` / ``naming_rule`` (how name is assigned), ``title_field``,
 	``workflow`` ({name, state_field, states} or None), ``actions``, and ``fields``.
-	Every field record carries ``fieldname``, ``fieldtype``, ``label``,
-	``options`` (Link target / Select enum / child DocType), and ``reqd``.
+	Every field record carries ``fieldname`` and ``fieldtype``, then EVERY other
+	docfield property the DocType configures - and only those. **A key that is
+	absent is not configured: read it as the Frappe default, which is always
+	falsy (0 / "" ). Never read absence as unknown.** So a plain Data field is
+	just ``{"fieldname", "fieldtype", "label"}``, while a mandatory Link carries
+	``options`` + ``reqd`` too.
+
+	- ``label``: human label (absent on layout breaks).
+	- ``options``: Link/Table/Dynamic Link target DocType, or Select enum values
+	  (newline-separated). Absent on primitive fields.
+	- ``reqd``: mandatory on insert.
+	- ``read_only`` / ``allow_on_submit`` / ``set_only_once``: whether the field
+	  can be written at all, after submit, or only on insert.
+	- ``fetch_from`` (``"link_field.source_field"``): the value is pulled from a
+	  linked doc - set the LINK, not this.
+	- ``mandatory_depends_on`` / ``read_only_depends_on`` / ``depends_on``: the
+	  condition under which the field becomes required / locked / shown, so
+	  ``reqd`` alone does not tell the whole story.
+	- ``default``, ``unique``, ``no_copy``, ``precision``, ``permlevel``.
+	- ``link_filters`` (JSON, e.g. ``[["Item","has_variants","=",0]]``): which
+	  target rows this Link will accept. Drop the leading DocType and the rest is
+	  a ``get_list`` filter, so it doubles as the query for finding a valid value
+	  (``get_list("Item", filters={"has_variants": 0})``). Only a minority of Link
+	  fields declare it; absence does not mean the Link is unfiltered.
+
+	Presentation-only properties (print/report/column widths, collapsible,
+	in_global_search, ...) are deliberately omitted - they cannot affect a write
+	and the field list is already the biggest thing this tool returns.
 
 		``actions`` is a discovery hint: the whitelisted server methods this
 		DocType's form exposes as custom buttons (e.g. ``make_sales_invoice`` on a


### PR DESCRIPTION
## Why

A field record carried a fixed five keys — `fieldname` / `fieldtype` / `label` / `options` / `reqd`. That left the agent blind to most of what determines whether a write is even legal. It couldn't see that `grand_total` is `read_only`, that a field is `fetch_from` a link (so you set the *link*, not the field), that a field is only writable before submit, or that `reqd` is conditional via `mandatory_depends_on`. So it guessed.

## What

Each record now carries `fieldname` + `fieldtype`, then **every docfield property the DocType actually configures**:

```json
{"fieldname": "grand_total", "fieldtype": "Currency", "label": "Grand Total",
 "reqd": 1, "options": "currency", "in_list_view": 1, "read_only": 1}
```

A **denylist, not an allowlist** — so a property Frappe adds later surfaces without a code change. Two things are excluded:

- **DocField row metadata** (`name`/`parent`/`idx`/`owner`/`creation`/…) — describes the docfield *record*, not the field it defines; the datetimes wouldn't survive the JSON hop anyway.
- **Presentation-only** (`print_hide`, `width`, `collapsible`, `in_global_search`, …) — changes how Desk *paints* a field, can never affect a write. Measured at **14%** of an all-properties payload.

## The rule that pays for it

**Absent now means "not configured."** Falsy *is* the Frappe default (Check → `0`, Data/Text → `""`), so `label` / `options` / `reqd` are omitted when falsy like everything else. `"options": ""` on a thousand primitive fields said "no options" in 15 bytes where absence says it in zero.

Measured over Sales Order / Sales Invoice / Item / Payment Entry / Delivery Note / Customer:

| Variant | Payload | vs today |
|---|---|---|
| Today (fixed 5 keys) | 107.7 KB | ×1.00 |
| Every configured prop, no denylist | 160.7 KB | ×1.49 |
| Keeping falsy `options`/`reqd` | 138.3 KB | ×1.28 |
| **This PR** | **115.4 KB** | **×1.07** |

Strictly more information than today for +7%. Keeping the falsy keys would have cost ×1.28 for *identical* information. This matters — the slim default exists because of the 2026-06-22 gpt-5.5 context overflow, so growth here has to earn itself.

## Is the shape change safe?

Checked before relying on it: **nothing reads the field-record shape in code.** The plugin declares *input* typebox schemas only and passes results through as raw JSON (no output schema anywhere in `src/`), and no Python consumer indexes into the records — `get_schema` is referenced only by the registry, the cache-busting hook, and a self-host smoke prompt. The sole reader is the model, and the docstring now states plainly that a missing key is the falsy default, never unknown.

## `link_filters`

Rides along free. Format is `[["Item","has_variants","=",0]]` — drop the leading DocType and the rest is a `get_list` filter, so it doubles as the query for finding a valid value. Worth knowing: only **31 of 2,839** Link fields declare it (1.1%) — the rest filter via client-side `frm.set_query`, so absence does *not* mean a Link is unfiltered. The docstring says so.

## Testing

`test_get_schema` **19 pass**, `test_get_schema_meta_cache` **6 pass**.

New coverage: configured props surface; unconfigured props omitted rather than falsy; falsy `label`/`options`/`reqd` omitted too; presentation props and row metadata never leak; non-primitives dropped. Plus real-doctype checks that nothing banned leaks and that `read_only` actually fires against live meta. Field-level assertions use a stub docfield so they don't drift when ERPNext reshuffles its own properties.

Three existing tests asserted the exact-5-key shape and were updated deliberately — that contract is what this PR changes.

The full local suite is red on both this branch (`failures=7, errors=9`) and unmodified `origin/main` (`failures=7, errors=13`) — the known local state-pollution flakes (macro caps, turn_recovery, stale_scan) that pass on CI's clean site. My branch has *fewer*. Leaving CI as the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)