### PR TITLE
feat(get_creation_context): map derived records from their source document

### DIFF
--- a/jarvis/tests/test_get_creation_context.py
+++ b/jarvis/tests/test_get_creation_context.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -128,3 +130,77 @@ class TestGetCreationContext(FrappeTestCase):
                 get_creation_context("User")
         finally:
             frappe.set_user("Administrator")
+
+
+class TestCreationContextMappedSource(FrappeTestCase):
+    """A derived record (invoice from an order) gets the ERP's own mapper output
+    instead of lookalikes to infer from.
+
+    The agent ALREADY hands us the source - the production transcript shows
+    `{"customer": ..., "sales_order": "SAL-ORD-2026-00002", ...}` - it just was
+    not being read as one. Uses Note (clean Title Case, so the context key
+    "note" resolves) with a patched mapper: a real submitted Sales Order needs a
+    full ERPNext company this site does not have.
+    """
+
+    def setUp(self):
+        self.src = frappe.get_doc({
+            "doctype": "Note", "title": f"ctx-src-{frappe.generate_hash(length=8)}",
+        }).insert(ignore_permissions=True)
+        frappe.db.commit()
+
+    def tearDown(self):
+        frappe.db.delete("Note", {"name": self.src.name})
+        frappe.db.commit()
+
+    def _ctx(self, mapped, note=None):
+        return patch(
+            "jarvis.tools._source_mapper.resolve_mapper", return_value="fake.method"
+        ), patch(
+            "jarvis.tools._source_mapper.mapped_values", return_value=(mapped, note)
+        )
+
+    def test_mapped_source_returns_mapper_output_and_omits_similar(self):
+        """Authoritative beats similar: a mapped doc AND five lookalikes in one
+        payload would be the worst of both - cost without benefit."""
+        p1, p2 = self._ctx({"description": "from the mapper", "items": [{"x": 1}]})
+        with p1, p2:
+            out = get_creation_context("ToDo", {"note": self.src.name})
+        self.assertEqual(out["mapped"]["description"], "from the mapper")
+        self.assertEqual(out["mapped_from"]["source_doctype"], "Note")
+        self.assertEqual(out["mapped_from"]["source_name"], self.src.name)
+        self.assertEqual(out["similar"], [])
+        self.assertIsNone(out["example"])
+        self.assertIn("authoritative", out["match_note"])
+        # The instruction must flip: copy these values, don't re-derive them.
+        self.assertIn("mapper", out["note"])
+
+    def test_mapper_refusal_is_surfaced_and_similar_still_returned(self):
+        """"Sales Order is not submitted" says exactly what to fix - but the
+        agent must still get its normal context so the turn can continue."""
+        p1, p2 = self._ctx(None, note="could not map: Sales Order is not submitted")
+        with p1, p2:
+            out = get_creation_context("ToDo", {"note": self.src.name})
+        self.assertNotIn("mapped", out)
+        self.assertIn("not submitted", out["mapped_note"])
+
+    def test_no_mapper_leaves_the_normal_path_untouched(self):
+        with patch(
+            "jarvis.tools._source_mapper.resolve_mapper", return_value=None
+        ):
+            out = get_creation_context("ToDo", {"note": self.src.name})
+        self.assertNotIn("mapped", out)
+        self.assertNotIn("mapped_note", out)
+        self.assertIn("similar", out)
+
+    def test_context_key_that_is_not_a_doctype_is_ignored(self):
+        out = get_creation_context("ToDo", {"priority": "High"})
+        self.assertNotIn("mapped", out)
+
+    def test_nonexistent_source_doc_is_ignored(self):
+        with patch(
+            "jarvis.tools._source_mapper.resolve_mapper", return_value="fake.method"
+        ), patch("jarvis.tools._source_mapper.mapped_values") as mv:
+            out = get_creation_context("ToDo", {"note": "no-such-note-xyz"})
+        self.assertNotIn("mapped", out)
+        mv.assert_not_called()  # never run a mapper for a doc that isn't there

--- a/jarvis/tests/test_source_mapper.py
+++ b/jarvis/tests/test_source_mapper.py
@@ -1,0 +1,205 @@
+"""Tests for jarvis.tools._source_mapper - resolving and running the ERP's own
+make_* mapper for a (source -> target) pair.
+
+Split in two:
+
+- Resolution runs against REAL erpnext meta (Sales Order / Quotation): the three
+  filters only earn their keep against the real form-JS scrape, and the two
+  negative cases (a foreign mapper, a non-source doctype) are the whole point.
+- Execution is tested with a FAKE mapper. Building a submitted Sales Order needs
+  a full ERPNext company (chart of accounts, warehouses, price lists) that this
+  site does not have, and a fake lets us assert the thing that actually matters -
+  that a mapper which WRITES leaves nothing behind - using a lightweight doctype.
+"""
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools._source_mapper import (
+    _strip,
+    mapped_values,
+    resolve_mapper,
+)
+
+
+class TestResolveMapper(FrappeTestCase):
+    """Against real erpnext meta."""
+
+    def test_resolves_the_sales_invoice_mapper(self):
+        method = resolve_mapper("Sales Order", "Sales Invoice")
+        self.assertTrue(method, "expected a Sales Order -> Sales Invoice mapper")
+        self.assertTrue(method.endswith(".make_sales_invoice"), method)
+
+    def test_foreign_mapper_is_not_resolved(self):
+        """THE load-bearing filter. Sales Order's form JS references
+        quotation.mapper.make_sales_order, so a naive scrape offers target
+        "Sales Order" from source "Sales Order" - and that mapper expects a
+        QUOTATION. Feeding it a Sales Order would be silently wrong."""
+        self.assertIsNone(resolve_mapper("Sales Order", "Sales Order"))
+
+    def test_no_false_positive_for_a_non_source_doctype(self):
+        """Customer is a real DocType and a common context hint, but has no
+        mapper to a Sales Invoice - it must resolve to nothing rather than
+        something plausible."""
+        self.assertIsNone(resolve_mapper("Customer", "Sales Invoice"))
+
+    def test_resolves_quotation_to_sales_order(self):
+        method = resolve_mapper("Quotation", "Sales Order")
+        self.assertTrue(method and method.endswith(".make_sales_order"), method)
+
+    def test_unknown_doctypes_resolve_to_none_without_raising(self):
+        self.assertIsNone(resolve_mapper("Definitely Not A DocType", "ToDo"))
+        self.assertIsNone(resolve_mapper("", "ToDo"))
+        self.assertIsNone(resolve_mapper("Sales Order", ""))
+
+
+def _fake(returns, *, writes=False):
+    """A stand-in mapper. ``writes=True`` makes it insert a real row first -
+    which is what make_sales_invoice does via bundle.save()."""
+
+    def fn(source_name=None, target_doc=None):
+        if writes:
+            frappe.get_doc({
+                "doctype": "ToDo", "description": "sandbox-probe",
+            }).insert(ignore_permissions=True)
+        return returns
+
+    return fn
+
+
+# The fake the dotted path below resolves to. Tests point `resolve_mapper` at
+# `_fake_entry`'s real dotted path and let the production code's own
+# `frappe.get_attr` load it - patching `frappe.get_attr` instead would replace it
+# for FRAPPE TOO (same module object), and frappe calls it internally on every
+# get_doc, which recurses until the stack dies.
+_current_fake = None
+
+
+def _fake_entry(source_name=None, target_doc=None):
+    return _current_fake(source_name=source_name, target_doc=target_doc)
+
+
+class TestMappedValues(FrappeTestCase):
+    def setUp(self):
+        self.source = frappe.get_doc({
+            "doctype": "Note", "title": f"src-{frappe.generate_hash(length=8)}",
+        }).insert(ignore_permissions=True)
+        frappe.db.commit()
+
+    def tearDown(self):
+        frappe.db.delete("Note", {"name": self.source.name})
+        frappe.db.delete("ToDo", {"description": "sandbox-probe"})
+        frappe.db.commit()
+
+    def _run(self, mapper_fn):
+        global _current_fake
+        _current_fake = mapper_fn
+        with patch(
+            "jarvis.tools._source_mapper.resolve_mapper",
+            return_value="jarvis.tests.test_source_mapper._fake_entry",
+        ):
+            return mapped_values("Note", self.source.name, "ToDo")
+
+    def test_a_writing_mapper_persists_nothing(self):
+        """THE central invariant. Mappers are not side-effect free -
+        make_sales_invoice's postprocess reaches bundle.save() and inserts a
+        Serial and Batch Bundle, make_purchase_order calls doc.insert() outright.
+        Frappe commits any normally-returning request, so without the sandbox a
+        mere context lookup would leave rows behind."""
+        target = frappe.get_doc({"doctype": "ToDo", "description": "mapped"})
+        before = frappe.db.count("ToDo")
+        values, note = self._run(_fake(target, writes=True))
+        frappe.db.commit()  # fresh snapshot: prove it did not merely defer
+        self.assertIsNone(note)
+        self.assertEqual(values.get("description"), "mapped")
+        self.assertEqual(
+            frappe.db.count("ToDo"), before,
+            "the mapper's write escaped the sandbox and was persisted",
+        )
+
+    def test_none_returning_mapper_is_treated_as_no_mapper(self):
+        """make_maintenance_schedule guards its whole body with
+        `if not maint_schedule:` and implicitly returns None when one already
+        exists; make_purchase_order returns None without selected_items. Passing
+        the resolution filters does NOT make a mapper usable - so validate the
+        result, and never let a None reach `.doctype`."""
+        values, note = self._run(_fake(None))
+        self.assertIsNone(values)
+        self.assertIsNone(note)
+
+    def test_list_returning_mapper_is_treated_as_no_mapper(self):
+        """make_purchase_order returns a LIST when it works."""
+        values, note = self._run(_fake([frappe.get_doc({"doctype": "ToDo"})]))
+        self.assertIsNone(values)
+        self.assertIsNone(note, "a shape mismatch is 'no mapper', not an error")
+
+    def test_wrong_doctype_result_is_rejected(self):
+        other = frappe.get_doc({"doctype": "Note", "title": "wrong-type"})
+        values, note = self._run(_fake(other))
+        self.assertIsNone(values)
+        self.assertIsNone(note)
+
+    def test_mapper_error_is_surfaced_not_swallowed(self):
+        """The ERP's own refusal ("Sales Order is not submitted", "nothing left
+        to bill") usually says exactly what to fix - far more useful than
+        silence."""
+        def boom(source_name=None, target_doc=None):
+            raise frappe.ValidationError("Sales Order is not submitted")
+
+        values, note = self._run(boom)
+        self.assertIsNone(values)
+        self.assertIn("not submitted", note)
+
+    def test_no_mapper_is_a_clean_none(self):
+        with patch("jarvis.tools._source_mapper.resolve_mapper", return_value=None):
+            self.assertEqual(
+                mapped_values("Note", self.source.name, "ToDo"), (None, None)
+            )
+
+    def test_read_permission_on_the_source_is_enforced(self):
+        user = "mapper-noperm@example.com"
+        if not frappe.db.exists("User", user):
+            frappe.get_doc({
+                "doctype": "User", "email": user, "first_name": "NoPerm",
+                "send_welcome_email": 0,
+            }).insert(ignore_permissions=True)
+        frappe.set_user(user)
+        try:
+            with patch(
+                "jarvis.tools._source_mapper.resolve_mapper", return_value="fake.method"
+            ):
+                values, note = mapped_values("Note", self.source.name, "ToDo")
+            self.assertIsNone(values)
+            self.assertIn("no read permission", note)
+        finally:
+            frappe.set_user("Administrator")
+
+
+class TestStrip(FrappeTestCase):
+    def test_drops_framework_bookkeeping_including_child_rows(self):
+        """A draft must never carry a name/docstatus copied from the mapping."""
+        out = _strip({
+            "name": "SINV-0001", "docstatus": 1, "owner": "Administrator",
+            "creation": "2026-01-01", "doctype": "Sales Invoice",
+            "customer": "Acme",
+            "items": [{"name": "row1", "parent": "SINV-0001", "idx": 1,
+                       "item_code": "Widget", "so_detail": "abc"}],
+        })
+        self.assertEqual(
+            set(out.keys()), {"customer", "items"},
+            f"bookkeeping leaked: {sorted(out.keys())}",
+        )
+        row = out["items"][0]
+        self.assertEqual(set(row.keys()), {"item_code", "so_detail"})
+
+    def test_keeps_the_source_linkage(self):
+        """so_detail / sales_order are the whole point - they keep the order's
+        billed status correct."""
+        out = _strip({"items": [{"sales_order": "SO-1", "so_detail": "row-1"}]})
+        self.assertEqual(out["items"][0]["sales_order"], "SO-1")
+        self.assertEqual(out["items"][0]["so_detail"], "row-1")
+
+    def test_empty_values_and_empty_child_tables_are_dropped(self):
+        out = _strip({"customer": "Acme", "note": "", "ref": None, "items": []})
+        self.assertEqual(set(out.keys()), {"customer"})

--- a/jarvis/tools/_source_mapper.py
+++ b/jarvis/tools/_source_mapper.py
@@ -1,0 +1,189 @@
+"""Run the ERP's OWN ``make_*`` mapper for a (source doc -> target doctype) pair.
+
+When a record derives from another - a Sales Invoice from a Sales Order, a
+Purchase Receipt from a Purchase Order - ERPNext already knows how to build it:
+the form's "Create >" buttons call whitelisted mappers
+(``make_sales_invoice(source_name)``) that return a fully-populated, UNSAVED
+target doc. Those mappers carry things inference reliably misses - the
+``so_detail`` / ``sales_order`` row links that keep the order's billed status
+correct, billed-qty arithmetic, unit-price rows, advance allocation, payment
+schedules, SO-level tax templates.
+
+This module resolves the mapper and runs it, so the agent can draft from the
+ERP's own answer instead of reconstructing one. It never inserts: the caller gets
+values, and the normal create path (with its confirmation card) still applies.
+
+TWO FACTS THAT SHAPE EVERYTHING HERE:
+
+1. **Mappers are NOT side-effect free.** ``make_sales_invoice``'s postprocess
+   reaches ``bundle.save()`` (stock_reservation_entry.py) and inserts a Serial
+   and Batch Bundle when the order has serial/batch reservations;
+   ``make_purchase_order`` calls ``doc.insert()`` outright. Frappe commits any
+   normally-returning request, so a mapper run OUTSIDE a sandbox would persist
+   those. Every call here runs inside ``preview_sandbox`` and is rolled back.
+   This is the module's central invariant - do not "optimize" it away.
+2. **Passing the three resolution filters does not mean a mapper is usable.**
+   Several return None or a list rather than one doc (see ``mapped_values``). We
+   therefore validate the RESULT rather than curating a static allowlist that
+   would rot: anything that is not a single doc of the requested doctype is
+   treated as "no mapper", and the caller falls back to its normal path.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis.tools._doc_actions import get_doc_actions
+from jarvis.tools._preview_sandbox import preview_sandbox
+
+# Mapper naming convention on the "Create >" buttons: make_* / create_*.
+_MAPPER_PREFIXES = ("make_", "create_")
+
+# Resolution is cached because get_doc_actions assembles the DocType's form JS
+# and imports every candidate module - far too heavy to redo for each context
+# key on every call. Same TTL as the schema cache, and busted by the same
+# doc_events (get_schema.clear_cache_for), since a Client Script edit can change
+# which methods the form references.
+_MAPPER_TTL = 300
+
+
+def mapper_cache_key(source_doctype: str) -> str:
+	return f"jarvis_mappers:{source_doctype}"
+
+
+def _mapper_map(source_doctype: str) -> dict:
+	"""``{scrubbed_target: dotted_method}`` for ``source_doctype``'s OWN mappers.
+
+	Three filters, each load-bearing and each validated against live meta:
+
+	1. OWN mappers only - the dotted path must contain ``scrub(source_doctype)``
+	   as a segment. ``get_doc_actions`` scrapes every method the form JS
+	   references, including foreign ones: without this, Sales Order resolves
+	   target "Sales Order" via ``quotation.mapper.make_sales_order``, which
+	   expects a QUOTATION. Feeding it a Sales Order would be silently wrong.
+	   (Mirrors ``_doc_actions._sort_key``'s own/foreign split.)
+	2. Signature shape - the first parameter must be ``source_name``. Drops the
+	   non-mappers sharing the prefix: ``make_raw_material_request(items, ...)``,
+	   ``make_work_orders(items, ...)``, ``update_status(status, name)``.
+	3. Naming convention - ``make_``/``create_`` prefix. The remainder is
+	   compared SCRUBBED (not title-cased) so odd casing like ``BOM`` matches.
+
+	Keyed by scrubbed target because that is what the method name yields; the
+	lookup in ``resolve_mapper`` scrubs the caller's real doctype to match."""
+	cache = frappe.cache()
+	key = mapper_cache_key(source_doctype)
+	hit = cache.get_value(key)
+	if hit is not None:
+		return hit
+	out: dict = {}
+	own = frappe.scrub(source_doctype)
+	try:
+		actions = get_doc_actions(source_doctype)
+	except Exception:
+		actions = []
+	for action in actions:
+		method = action.get("method") or ""
+		if own not in method.split("."):
+			continue
+		args = action.get("args") or []
+		if not args or args[0] != "source_name":
+			continue
+		tail = method.rsplit(".", 1)[-1]
+		for prefix in _MAPPER_PREFIXES:
+			if tail.startswith(prefix):
+				# setdefault: first wins, and _doc_actions already sorts the
+				# DocType's own methods ahead of foreign ones.
+				out.setdefault(tail[len(prefix):], method)
+				break
+	cache.set_value(key, out, expires_in_sec=_MAPPER_TTL)
+	return out
+
+
+def resolve_mapper(source_doctype: str, target_doctype: str) -> str | None:
+	"""Dotted path of the mapper that builds ``target_doctype`` from
+	``source_doctype``, or None when there isn't one."""
+	if not source_doctype or not target_doctype:
+		return None
+	try:
+		return _mapper_map(source_doctype).get(frappe.scrub(target_doctype))
+	except Exception:
+		# Resolution is an optimisation, never a correctness gate: a failure
+		# means "no mapper", and the caller keeps its normal path.
+		return None
+
+
+def mapped_values(
+	source_doctype: str, source_name: str, target_doctype: str,
+) -> tuple[dict | None, str | None]:
+	"""``(values, note)`` for ``target_doctype`` mapped from ``source_name``.
+
+	``values`` is the mapped doc as a plain dict (child rows included), or None
+	when there is no mapper, the caller may not read the source, or the mapper
+	declined. ``note`` carries the ERP's own refusal when there is one - "Sales
+	Order is not submitted", "nothing left to bill" - which is far more useful to
+	the agent than silence, so it is surfaced rather than swallowed.
+
+	Runs inside ``preview_sandbox``: mappers write (see module docstring).
+	"""
+	method = resolve_mapper(source_doctype, target_doctype)
+	if not method:
+		return None, None
+	# The mapper runs as the chat user; check read on the SOURCE explicitly so a
+	# refusal is a clean note rather than whatever the mapper throws mid-build.
+	if not frappe.has_permission(source_doctype, ptype="read", doc=source_name):
+		return None, f"no read permission on {source_doctype} {source_name}"
+	try:
+		fn = frappe.get_attr(method)
+	except Exception:
+		return None, None
+	try:
+		with preview_sandbox():
+			doc = frappe.call(fn, source_name=source_name)
+			# Passing the filters does not make a mapper usable. Verified
+			# counter-examples: make_purchase_order returns None without
+			# `selected_items` and a LIST when it works; make_maintenance_schedule
+			# / make_maintenance_visit guard their whole body and implicitly
+			# return None when one already exists. Validate the RESULT - anything
+			# that is not one doc of the requested type is "no mapper", and the
+			# caller falls back rather than crashing on a None.
+			if getattr(doc, "doctype", None) != target_doctype:
+				return None, None
+			# Materialise INSIDE the sandbox; the rollback only touches the DB,
+			# but the doc must be read before we leave the block.
+			doc.apply_fieldlevel_read_permissions()
+			values = doc.as_dict(no_default_fields=True)
+	except frappe.PermissionError as e:
+		return None, str(e) or f"no permission to map {target_doctype}"
+	except Exception as e:
+		# The ERP's own refusal (draft source, nothing to bill, ...). Best-effort
+		# by contract: the caller must keep working without a mapping.
+		return None, f"could not map {target_doctype} from {source_name}: {e}"
+	return _strip(values), None
+
+
+# Framework bookkeeping the agent must never copy into a draft.
+_DROP_KEYS = {
+	"name", "owner", "creation", "modified", "modified_by", "docstatus", "idx",
+	"parent", "parentfield", "parenttype", "doctype",
+}
+
+
+def _strip(values: dict) -> dict:
+	"""Drop framework bookkeeping, recursively through child rows. ``as_dict``
+	keeps them even with ``no_default_fields``, and a draft must not carry a
+	``name``/``docstatus`` copied from a mapping."""
+	if not isinstance(values, dict):
+		return {}
+	out = {}
+	for k, v in values.items():
+		if k in _DROP_KEYS:
+			continue
+		if isinstance(v, list):
+			rows = [_strip(r) for r in v if isinstance(r, dict)]
+			if rows:
+				out[k] = rows
+			continue
+		if v in (None, ""):
+			continue
+		out[k] = v
+	return out

--- a/jarvis/tools/get_creation_context.py
+++ b/jarvis/tools/get_creation_context.py
@@ -91,13 +91,34 @@ def get_creation_context(
     fields = _field_map(meta)
     mandatory = [f["fieldname"] for f in fields if f["mandatory"]]
 
+    # Derived record? The agent already tells us the source - it passes
+    # {"sales_order": "SAL-ORD-2026-00002"} as a hint - so if the ERP has a
+    # mapper from that doc to this doctype, hand back ITS answer instead of
+    # lookalikes to infer from. Authoritative beats similar, so this REPLACES
+    # the similar/example blocks rather than adding to them (a mapped invoice
+    # and five lookalike invoices in one payload is the worst of both).
+    mapped, mapped_from, mapped_note = _mapped_from_context(doctype, context)
+
+    similar: list = []
+    example = None
+    facets: dict = {}
+    if mapped is not None:
+        match_note = (
+            f"Mapped by the ERP from {mapped_from['source_doctype']} "
+            f"{mapped_from['source_name']}. These values are authoritative - "
+            "similar records are omitted because you do not need to infer."
+        )
+        return _result(
+            doctype, fields, mandatory, similar, example, match_note, facets,
+            mapped=mapped, mapped_from=mapped_from, mapped_note=mapped_note,
+        )
+
     filters, matched = _resolve_context_filters(meta, context)
     value_fields = [
         f["fieldname"] for f in fields if f["fieldtype"] in _VALUE_FIELDTYPES
     ][:_MAX_VALUE_FIELDS]
     similar, match_note = _similar_records(doctype, filters, value_fields, limit)
 
-    example = None
     if similar:
         # One FULL example (incl. child rows) so the agent can learn the row
         # shape when mapping a document. get_list already proved row-level
@@ -109,11 +130,23 @@ def get_creation_context(
             doc.apply_fieldlevel_read_permissions()
             example = doc.as_dict(no_default_fields=True)
 
-    facets = {}
     if not matched and frappe.has_permission(doctype, ptype="read"):
         facets = _facets(doctype, meta)
 
-    return {
+    return _result(
+        doctype, fields, mandatory, similar, example, match_note, facets,
+        mapped_note=mapped_note,
+    )
+
+
+def _result(
+    doctype, fields, mandatory, similar, example, match_note, facets,
+    *, mapped=None, mapped_from=None, mapped_note=None,
+) -> dict:
+    """Assemble the response. ``mapped`` (when present) is the ERP's own mapper
+    output and carries a different instruction from the similar-records case:
+    copy it, don't re-derive it."""
+    out = {
         "doctype": doctype,
         "fields": fields,
         "mandatory": mandatory,
@@ -129,6 +162,71 @@ def get_creation_context(
             "about mandatory fields you cannot determine."
         ),
     }
+    if mapped is not None:
+        out["mapped"] = mapped
+        out["mapped_from"] = mapped_from
+        out["note"] = (
+            "`mapped` is this document built by the ERP's OWN mapper from "
+            f"{mapped_from['source_doctype']} {mapped_from['source_name']} - not "
+            "a guess, and not persisted. Draft from these values: they carry the "
+            "source row links (e.g. `so_detail`) that keep the source's billed / "
+            "delivered status correct, and taxes and rates as the ERP computes "
+            "them. Change only what the user asked to change; do not re-derive "
+            "the rest. Still set any `mandatory` field it left empty."
+        )
+    if mapped_note:
+        # The ERP declined to map (draft source, nothing left to bill, ...).
+        # Surfaced, not swallowed: it usually says exactly what to fix.
+        out["mapped_note"] = mapped_note
+    return out
+
+
+def _doctype_for_key(key: str) -> str | None:
+    """``"sales_order"`` -> ``"Sales Order"`` when that DocType exists, else None.
+
+    Deliberately keyed off the CONTEXT KEY, not the target's meta: the link that
+    matters usually is not a header field on the target at all (a Sales Invoice
+    carries `sales_order` per ITEM row, not on the header), so resolving through
+    ``_resolve_context_filters`` would never find it."""
+    if not key or not isinstance(key, str):
+        return None
+    guess = key.replace("_", " ").title()
+    return guess if frappe.db.exists("DocType", guess) else None
+
+
+def _mapped_from_context(target_doctype: str, context: dict) -> tuple:
+    """``(mapped_values, mapped_from, note)`` when a context hint names a source
+    document the ERP can map into ``target_doctype``.
+
+    The agent already passes the source - the production transcript shows
+    ``{"customer": ..., "sales_order": "SAL-ORD-2026-00002", "company": ...}`` -
+    it just was not being read as one. Non-source hints cost nothing: "Customer"
+    and "Company" are real DocTypes but have no mapper to a Sales Invoice, so
+    they resolve to None (cached) and fall through.
+    """
+    from jarvis.tools._source_mapper import mapped_values, resolve_mapper
+
+    first_note = None
+    for key, value in (context or {}).items():
+        if not value or not isinstance(value, str):
+            continue
+        source_doctype = _doctype_for_key(key)
+        if not source_doctype or source_doctype == target_doctype:
+            continue
+        if not resolve_mapper(source_doctype, target_doctype):
+            continue
+        if not frappe.db.exists(source_doctype, value):
+            continue
+        values, note = mapped_values(source_doctype, value, target_doctype)
+        if values:
+            return values, {
+                "source_doctype": source_doctype,
+                "source_name": value,
+            }, None
+        # Keep the first refusal ("Sales Order is not submitted") but keep
+        # looking: another hint may still map.
+        first_note = first_note or note
+    return None, None, first_note
 
 
 def _field_map(meta) -> list[dict]:

--- a/jarvis/tools/get_schema.py
+++ b/jarvis/tools/get_schema.py
@@ -151,10 +151,15 @@ def _as_bool(value) -> bool:
 
 
 def clear_cache_for(doctype: str) -> None:
-	"""Drop both cached schema variants (slim + verbose) for a DocType."""
+	"""Drop both cached schema variants (slim + verbose) for a DocType, plus its
+	resolved mapper map - that is scraped from the same form JS as ``actions``,
+	so a Client Script edit invalidates both."""
+	from jarvis.tools._source_mapper import mapper_cache_key
+
 	cache = frappe.cache()
 	cache.delete_value(f"jarvis_schema:{doctype}:0")
 	cache.delete_value(f"jarvis_schema:{doctype}:1")
+	cache.delete_value(mapper_cache_key(doctype))
 
 
 def clear_schema_cache(doc, method=None) -> None:


### PR DESCRIPTION
## The finding

Asked to "create an invoice from this order", the agent hand-assembles the invoice field by field rather than using ERPNext's `make_sales_invoice`. An exported production transcript (fleet-transcript export, jarvis-admin#235 — one conversation, **70 tool calls**) shows why:

- **`get_schema` was called zero times**, so PR #329's `actions` hint never reached the model.
- The agent isn't drifting — `AGENTS.md:149-152` **mandates** the `ocr-data-entry` invoice protocol, and `invoice-review.md` prescribes *"the normal `create_doc` card flow."* It executed a mandatory protocol correctly.
- **The resulting invoice was correct** — items carried `sales_order` and `so_detail`. So this is *not* a correctness bug. The case is reliability (inference vs. an authoritative mapper) and cost.

But the transcript also shows the agent **already hands us the source**:

```json
{"doctype": "Sales Invoice",
 "context": {"customer": "The Phoenix Mills Ltd",
             "sales_order": "SAL-ORD-2026-00002", ...}}
```

`get_creation_context` treated every context key as a similarity hint. It never noticed that `sales_order` names a source document with a mapper to the target — so it returned lookalike invoices to infer from, sitting right next to the authoritative answer it could have fetched.

## The fix

When a context hint names a document whose DocType has an own mapper to the target, run it and return the output as `mapped` (+ `mapped_from`), **replacing** the `similar`/`example` blocks — authoritative beats similar, and shipping both is cost without benefit. The `note` flips too: copy these values, don't re-derive them.

**No new tool, no gating, no card work, and no persona change.** The agent already calls this tool and already passes the source. It keeps the editable draft card ("make Widget A qty 12") and the invoice protocol's five checks, and just feeds them better input.

A dedicated `create_from_document` tool would additionally keep mapped values out of the model context — the one thing this doesn't buy — at the cost of new gating, card kinds in two frontends, an editability regression, and a persona rule fighting a mandatory skill. Deferred until someone measures whether that residual context cost is real. (Spec + full alternatives analysis in the workspace repo.)

## Mappers are not side-effect free — the central invariant

Verified, and it shapes the whole design:

- `make_sales_invoice`'s postprocess → `set_serial_batch_for_bundle_reservation` → **`bundle.save()`**, inserting a Serial and Batch Bundle when the order has serial/batch reservations.
- `make_purchase_order` calls **`doc.insert()`** outright.

Frappe commits any normally-returning request, so an unsandboxed run would persist those **from a mere context lookup**. Every mapper run goes through `preview_sandbox` and is rolled back. This has a dedicated test that inserts a real row from inside a fake mapper and asserts the count is unchanged after a commit.

## Passing the filters ≠ usable

The result is validated rather than curating an allowlist that would rot:

| Mapper | Hazard |
|---|---|
| `make_purchase_order` | returns `None` without `selected_items`; a **list** when it works; inserts internally |
| `make_maintenance_schedule` / `make_maintenance_visit` | body guarded by `if not …:` → **implicit `None`** when one already exists |

Anything that isn't one doc of the requested doctype is "no mapper", and the caller falls back to its normal path.

## Resolution

Reuses `_doc_actions`' form-JS scrape with three filters, each validated against live meta:

1. **Own mappers only** — load-bearing. Sales Order's form JS references `quotation.mapper.make_sales_order`, so a naive scrape offers target "Sales Order" from source "Sales Order" — and that mapper expects a **Quotation**. Feeding it a Sales Order would be silently wrong.
2. **First param is `source_name`** — drops `make_raw_material_request`, `make_work_orders`, `update_status`.
3. **`make_`/`create_` prefix**, compared *scrubbed* so odd casing (`BOM`) matches.

Verified live: `Sales Order → Sales Invoice` resolves `make_sales_invoice`; `Sales Order → Sales Order` and `Customer → Sales Invoice` both correctly resolve to nothing. Cached (the scrape assembles form JS and imports modules), busted by the same doc_events as the schema cache — a Client Script edit changes both.

## Testing

**64 pass** across the five affected suites: `test_source_mapper` (15, new), `test_get_creation_context` (19), `test_get_schema` (10), `test_doc_actions` (14), `test_get_schema_meta_cache` (6).

Highlights: the sandbox invariant; `None`/list/wrong-doctype results treated as "no mapper"; the ERP's own refusal ("not submitted") surfaced rather than swallowed; source read-permission enforced; bookkeeping stripped recursively through child rows while `so_detail`/`sales_order` survive.

Resolution is tested against **real** erpnext meta (both negative cases included). Execution uses a fake mapper — a submitted Sales Order needs a full ERPNext company (chart of accounts, warehouses, price lists) this test site doesn't have, and the fake lets us assert the thing that matters using a lightweight doctype.

## Known limit

Custom apps: filter 1 requires `scrub(source_doctype)` in the dotted path, so a mapper living in `myapp/api.py` is unreachable. Documented in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)