### PR TITLE
fix(pwa): stop the tap-highlight and focus box flashing on touch

### DIFF
--- a/pwa/src/index.css
+++ b/pwa/src/index.css
@@ -144,6 +144,50 @@ body {
 	-webkit-tap-highlight-color: transparent;
 }
 
+/* Touch feel. The grey/blue box that flashes when you tap or type on a phone is
+   the UA's tap-highlight plus its native focus ring. The rule above only covered
+   <body>, and each control cleared its own ring in a scoped block, so anything
+   that missed one — buttons, chips, sheet rows — still flashed. Reset both
+   app-wide instead of per component.
+
+   :focus-visible is what keeps this accessible: pointers get no ring, keyboards
+   still get a clear one. A blanket `outline: none` would strip focus for keyboard
+   users entirely.
+
+   touch-action: manipulation drops the UA's 300ms wait for a double-tap-to-zoom
+   that this app never wants, so taps register immediately. */
+* {
+	-webkit-tap-highlight-color: transparent;
+}
+
+button,
+input,
+textarea,
+select,
+a,
+[role="button"],
+[tabindex] {
+	touch-action: manipulation;
+}
+
+/* iOS paints its own inset shadow and rounding on form controls otherwise. */
+input,
+textarea,
+select {
+	-webkit-appearance: none;
+	appearance: none;
+	font-family: inherit;
+}
+
+:focus {
+	outline: none;
+}
+
+:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
 /* A phone app scrolls its panes, never the document. The shell owns the top
    safe area (rather than each screen's bar) so anything stacked up there — the
    install strip, then the bar — clears the notch without double padding. */


### PR DESCRIPTION
## The problem

Tapping or typing anywhere in the PWA on a phone flashed a grey/blue box.

Two separate UA behaviours cause it: the **tap-highlight** and the **native focus ring**. `-webkit-tap-highlight-color: transparent` was set on `<body>` only, and each control cleared its own ring inside its own scoped block — so anything that missed one (buttons, chips, sheet rows) still flashed.

## The fix

Reset both **app-wide** rather than per component:

- `* { -webkit-tap-highlight-color: transparent }` — no tap flash anywhere.
- `appearance: none` on `input`/`textarea`/`select` — drops iOS's inset shadow and rounding.
- `:focus { outline: none }` **plus** `:focus-visible { outline: 2px solid var(--accent) }`.
- `touch-action: manipulation` on interactive elements.

## Accessibility

Deliberately **not** a blanket `outline: none` — that strips focus for keyboard users. `:focus-visible` keeps the ring for keyboards while pointers get none, which is the behaviour we actually want.

## Bonus

`touch-action: manipulation` also drops the UA's 300 ms wait for a double-tap-to-zoom this app never wants, so taps register immediately — the whole app feels snappier.

## Notes

- Uses `var(--accent)`, which still exists on `main` (`#8269f8` / `#9e8bfa`) after the `--blue → --cta` rename in #300.
- CSS-only, one file, +44 lines. No JS, no markup, no behaviour change.

## Testing

- `npm run build` passes; verified `touch-action:manipulation`, `:focus-visible` and `tap-highlight-color:transparent` are present in the built bundle.
- Branched off latest `main` (`ac2d0fb`) and re-applied onto the current `index.css` rather than a stale base, since #300 had rewritten the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
