### PR TITLE
feat: record-wise detail on every confirmation card, and stop drafts failing silently

### DIFF
--- a/docs/superpowers/specs/2026-07-17-blank-draft-card.md
+++ b/docs/superpowers/specs/2026-07-17-blank-draft-card.md
@@ -1,0 +1,367 @@
+# The blank draft card: three fixes
+
+Status: **draft, awaiting Fable review** · Date: 2026-07-17
+Repos: `Aerele-RnD/jarvis` (app), `Aerele-RnD/jarvis-persona`
+
+## What happened (a real production transcript, 2026-07-17)
+
+User: *"Create the below tasks and assign to me — test the confirmation ui / test admin v2 / fix
+issues in the list"*
+
+The agent called `get_creation_context("ToDo", …)`, then emitted:
+
+```
+```jarvis-action
+{"kind":"doc","verb":"create","doctype":"ToDo","title":"Create 3 assigned tasks",
+ "summary":"3 open ToDos assigned to Administrator","docs":[{…},{…},{…}]}
+```
+```
+
+**The user got a card that proposed nothing** — the model-written headline, zero field rows, and an
+enabled Confirm. (Click Edit or Preview and you get a single empty Description box. See "What the
+user actually saw" below: the summary card and the Edit panel fail differently, and the smoke must
+check both.)
+
+## Root cause: `docs` is not a `jarvis-action` key
+
+The persona documents exactly one shape for a doc action (`AGENTS.md:122`):
+
+```json
+{"kind":"doc","verb":"create","doctype":"Sales Order","title":"…","summary":"…",
+ "fields":[{"label":"customer","value":"…"}],"tables":[{"fieldname":"items","rows":[…]}]}
+```
+
+`fields` + `tables`. **No `docs`.** Verified: **nothing** in `frontend/src` or `pwa/src` reads
+`docs` off an action block. (The two `args.docs` hits in `actionSummary.js:160/180` are
+`receiptView`/`receiptNames`, which read a parked **tool call**'s args — a different path.)
+
+So `buildDraftModel` (`ChatView.vue:2126`) reads `a.fields` → `undefined` → `proposed = {}`, then:
+
+```js
+const baseV = base.values[f.fieldname]   // {} on a create — loadDocForEdit only runs for update
+if (!has && !f.reqd) continue            // skips every non-proposed, non-required field
+```
+
+Only `description` survives (it is `reqd`), with an undefined value. Hence one empty box.
+
+**Nothing failed.** `buildDraftModel` did not throw, so `ensureActionSummary`'s error path never
+fired. The agent never learns the card was blank — the only channels into its memory are a
+continuation turn or the `[Context:]` bracket, and neither carries "your card rendered empty".
+
+**Why the model did it — and the correction that matters.** An earlier draft of this spec claimed
+"no rule covers three independent records". **That is false.** `AGENTS.md:115` covers it exactly:
+
+> *"SEVERAL -> state the count ("54 Tasks + 1 Timesheet") and **ask ONCE**: stage each for review,
+> or take consent now and create all in bulk. On bulk consent, stop asking per record:
+> `jarvis__create_doc(docs=[...])` in batches of up to 20, one atomic card per batch."*
+
+So the model **violated an existing rule** — it neither asked once nor called the tool. This is not
+a contract hole it fell through, and the "it will recur" argument does not rest on one.
+
+What **is** genuinely absent is any statement that `docs` is not a `jarvis-action` key. The block
+shape is documented positively (`:122`) and never negatively, and nothing validates it. So fix 1
+still earns its place, but as a **prohibition**, not as the missing batching rule — that rule is
+already there, twenty lines up.
+
+## Fix 1 — persona: one record per action block
+
+`jarvis-persona/AGENTS.md`. **Budget: AGENTS.md is 30,309 of the fleet's 32,000/file cap — 1,691
+chars of headroom.** This must be one sentence, not a section. Lint gates: ASCII only, no em-dash
+(U+2014) or en-dash (U+2013), `./lint.sh` + `python validate.py` must pass.
+
+Add to the drafting rule at `:117`, after "Draft the WHOLE record in ONE message.":
+
+> One `jarvis-action` block is ONE record - `fields` + `tables`, never a `docs` list. Several
+> independent records take the one-or-many fork above: ask once, then stage each or one
+> `jarvis__create_doc(docs=[...])` batch (it parks).
+
+**228 chars** — AGENTS.md lands at **30,538 of 32,000**, leaving **1,462**. (Measured, not
+estimated; an earlier draft guessed "~210 / ~1,480".) `validate.py`'s call-shape check accepts
+`jarvis__create_doc(docs=[...])` — `:129` already cites that exact shape and lints green.
+
+The referential style ("the one-or-many fork above") is house style rather than a new ambiguity:
+`:139` already says "take the bulk fork above" pointing at the same `:115`. And "(it parks)" is
+unconditionally true — `TOOLS.md:146`: create_doc may fast-path but "never a batch", so a `docs`
+batch parks even under auto-apply ON.
+
+**Why this wording, and what an earlier draft got wrong.** The first version ended *"Several
+independent records go in one `jarvis__create_doc(docs=[...])` call instead"* — which prescribes
+bulk **directly**, skipping the ask-once consent fork `:115` mandates, two paragraphs below the rule
+it contradicts. `:139` also routes "many records under ONE operation" to "the bulk fork above",
+i.e. `:115`. A persona fix that quietly overrides an existing consent gate is worse than the bug it
+fixes. The corrected sentence **points at** `:115` rather than restating a lossy version of it.
+
+It still names the wrong shape explicitly (`never a docs list`) because that is the exact mistake
+made, and a prohibition the model can pattern-match on is the whole point of the change.
+
+## Fix 2 — fail loudly instead of rendering a blank card
+
+`frontend/src/views/ChatView.vue` **and** `pwa/src/components/ActionCard.vue`. An earlier draft
+hedged with "(+ the PWA if it parses action blocks)" — it does, and it has its own version of this
+bug, so the hedge was just an unchecked assumption.
+
+**PWA (`pwa/src/lib/blocks.js:67-99` `parseAction`, `pwa/src/components/ActionCard.vue:135`):** a
+docs block renders a titled card with an **empty body and a live Create button**; pressing it builds
+`values = {}` and fails at `ActionCard.vue:60-63` ("Couldn't match any of these fields..."). Better
+than the desktop (it fails eventually) but still a blank card first.
+
+> **⚠️ Do NOT guard by returning `null` from `parseAction`.** `STRIP_RES` (`blocks.js:17-26`) strips
+> the ```jarvis-action fence from the prose **unconditionally**, independent of whether the parse
+> succeeded. A null parse therefore makes the proposal **disappear entirely** — no card, no text,
+> nothing — which is the exact failure `blocks.js`'s own header comment warns about, and strictly
+> worse than the blank card.
+
+> **⚠️ Do NOT copy the desktop condition.** ActionCard renders only `props.action.fields`
+> (`:135`) and `apply()` sends only mapped scalar `values` (`:53-81`) — **the PWA neither renders
+> nor applies `tables`** (desktop `applyDraft` does, `ChatView.vue:2360-2366`). So the desktop's
+> "a tables-only create is legal" escape is meaningless here: a fields-empty block has nothing to
+> show on the phone regardless of tables, and transcribing `&& !tables.length` would let it render
+> blank again.
+
+Add to `ActionCard.vue`'s script setup, after `heading` (`:28`) — a computed, checked up front so
+the problem renders **before** a tap rather than inside `apply()`:
+
+```js
+// No `tables` escape here, unlike the desktop: this card neither renders nor
+// applies child tables, so a block with no `fields` has nothing to show.
+const invalid = computed(() => {
+	if (!isWrite.value) return ""
+	if (Array.isArray(props.action.docs))
+		return "This draft carries a `docs` batch, which is a create_doc payload rather than a card. Ask Jarvis to apply them as a batch."
+	if (verb.value === "create" && !(props.action.fields || []).length)
+		return "This draft has no fields to show."
+	return ""
+})
+```
+
+Template (`:141`), reusing the existing error div: `<div v-if="invalid || error" class="jv-action-err">{{ invalid || error }}</div>`,
+and `:disabled="state === 'busy' || !!invalid"` on the primary button (`:152`). **Keep Cancel live**
+so the card stays dismissable.
+
+Copy note: the PWA says "Ask **Jarvis**" (matching its existing voice at `:68`); the desktop says
+"Ask **me**". Do not unify them.
+
+A `kind:"doc"` action that yields **no renderable fields** must render an **error**, not an empty
+form. Silent-blank is the worst outcome available: it looks like Jarvis didn't try, the user cannot
+tell what went wrong, and no signal reaches anyone.
+
+**`buildDraftModel` has TWO callers, and a throw breaks the other one.** `openDraftPanel`
+(`ChatView.vue:2193-2197`) has no `try/catch` — it handles `undefined` (`if (!model) return`), not a
+throw. And the **Edit** button (`ChatView.vue:300`) has **no `:disabled` binding**, unlike Confirm
+(`:296`) and Preview (`:299`), so it renders even in the error state. Failure: docs block → error
+card (good) → user clicks Edit → the rejection escapes the `@click` handler → dead button, console
+error. `ChatView.vue:2325`'s `openDraftPanel(...).then(...)` in the `watch` has no `.catch` either.
+
+Both must be fixed in the same change:
+
+```js
+// Open the editable panel for an action, via the shared buildDraftModel.
+async function openDraftPanel(a) {
+	let model
+	// Deliberate: swallow to the SAME dead-end the old `if (!model) return` gave, so
+	// a guard throw cannot escape a @click handler. The summary card already shows
+	// the error. Do not "fix" this into a rethrow.
+	try { model = await buildDraftModel(a) } catch (e) { return }
+	if (!model) return
+	draftPanel.value = model
+}
+```
+
+plus `:disabled="!summaryState.model"` on the Edit button at `:300`, mirroring Preview.
+
+**Place the guard right after the `verb` line (`:2128`), NOT after `proposed` is built.** It reads
+only `a.fields`/`a.tables`/`a.docs`, so putting it later wastes a `_formMeta` network call and
+implies a dependency on `proposed` that does not exist.
+
+In `buildDraftModel`:
+
+```js
+	// An action block we cannot render must FAIL, not render empty - a blank card
+	// reads as "Jarvis did not try" rather than "Jarvis emitted a shape I cannot
+	// draw". `docs` is a create_doc batch payload, not an action key (AGENTS.md:122
+	// documents fields+tables for ONE record) - throw on it for EITHER verb: a
+	// {"verb":"update","docs":[...]} fusion otherwise builds an empty diff, renders
+	// "No field changes." with Confirm ENABLED, and sends update_doc(dt, "", {}).
+	// A hybrid carrying BOTH fields and docs throws too: rendering the fields and
+	// dropping the docs is a half-card the user confirms believing it is the set.
+	if (Array.isArray(a.docs)) {
+		const err = new Error(
+			"This draft carries a `docs` batch, which is a create_doc payload rather than a card. Ask me to apply them as a batch.")
+		err.jvUserMessage = err.message
+		throw err
+	}
+	// Create-only: a fieldless UPDATE block legitimately renders "No field changes.",
+	// and a tables-only create is legal, so neither may throw.
+	if (verb === "create" && !(a.fields || []).length && !(a.tables || []).length) {
+		const err = new Error("This draft has no fields to show.")
+		err.jvUserMessage = err.message
+		throw err
+	}
+```
+
+and in `ensureActionSummary`, surface a specific message rather than the generic one:
+
+```js
+	} catch (e) {
+		const msg = (e && e.jvUserMessage) || "Could not load this draft. Tell me to try again."
+		if (summaryState.value.key === key) summaryState.value = { key, model: null, view: null, error: msg }
+		return
+	}
+```
+
+**Scope note — this does not tell the agent.** Closing that loop needs a continuation turn or a
+`[Context:]` line, which is a separate change. Fix 1 stops the shape being emitted; fix 2 stops it
+being invisible when it is. **Deliberately not doing** the agent-feedback channel here.
+
+**This is the precondition for "Jarvis analyses errors and suggests a fix".** That behaviour already
+exists — `AGENTS.md:139` (*"on FAILED I surface the error verbatim and propose the fix"*) and
+`_translate_write_error`'s `{ok:false, error}` envelope with `message`/`detail`/`hint`. It did not
+fire here because **nothing failed**. Error analysis only works on failures that are visible as
+failures.
+
+## Fix 3 — split `auto`: "Frappe computes it" vs "Frappe guesses it"
+
+`jarvis/tools/get_creation_context.py:242`:
+
+```python
+"auto": bool(df.fetch_from) or (df.default not in (None, "")),
+```
+
+One flag, two meanings, and the note says *"skip `auto`/`readonly` fields (Frappe fills those)"*:
+
+- `assigned_by_full_name` — `fetch_from`. Frappe **computes** it. Genuinely skip.
+- `date` — `default: "Today"`. Frappe **guesses** it. That is a decision, and it is made silently.
+
+Those three ToDos are created **due today** and the user never sees it. "Valid without a value" and
+"the user does not care about the value" are different claims; this line treats them as one.
+
+**Change** — note this file is **4-SPACE indented**, not tabs. `jarvis/tools/*.py` is 4-space while
+`jarvis/chat/*.py` and `jarvis/api.py` are tabs; CLAUDE.md's "ruff uses tabs" describes the *config*,
+not the files. A tab-indented block typed in here raises `TabError`. Verify with `cat -t` before
+writing.
+
+```python
+        rec = {
+            "fieldname": df.fieldname,
+            "label": df.label,
+            "fieldtype": df.fieldtype,
+            "options": df.options,
+            "mandatory": bool(df.reqd),
+            # `auto` means Frappe COMPUTES this (fetch_from) - skipping it is safe.
+            # A field with a DEFAULT is different: Frappe GUESSES it, and the guess is
+            # a decision the human never sees unless it reaches the draft. Surface the
+            # default value and let the model decide, rather than hiding both.
+            "auto": bool(df.fetch_from),
+            "readonly": bool(df.read_only),
+        }
+        if df.default not in (None, ""):
+            rec["default"] = df.default
+```
+
+and the note (`get_creation_context.py:159-162`) is rewritten — **not** merely extended:
+
+> "Skip `auto`/`readonly` fields (Frappe computes those). A field with a `default` is NOT auto -
+> Frappe applies the default silently, so decide it yourself: leave it out to accept the default,
+> set it when the default is wrong for this record; a symbolic default (`Today`, `:Company`) is
+> resolved by Frappe - never copy the token as a value. Set every **remaining** `mandatory` field
+> before create_doc. Ask the user only about mandatory fields you cannot determine."
+
+**Two traps this wording exists to avoid — note the ORDER is load-bearing:**
+
+1. **The reqd+default double-bind.** Sales Order's `order_type` (reqd, default "Sales"),
+   `transaction_date` (reqd, default "Today") and `status` (reqd, default "Draft") all flip from
+   `auto: true` (skip) to **mandatory-and-not-auto**. The original note leads with *"Set every
+   `mandatory` field that is not already `auto`"* — which then **commands** setting them, while the
+   decide-clause **permits** leaving them: two rules, same field, opposite directions. A previous
+   draft of this spec softened the clause and claimed the contradiction was resolved. **It was not**
+   — the command was never qualified. The fix is structural: state the default rule **first**, then
+   scope the mandatory command to every **remaining** field. Now all four cases resolve —
+   reqd+no-default (command applies), reqd+default (default rule claims it first), optional+default
+   (decide-clause), optional+no-default (untouched, governed by `:131`'s "set only what the user
+   gave").
+2. **Symbolic defaults.** `df.default` is frequently a token, not a value (`Today`, `:Company`,
+   `0`). Shipping it raw invites a model to copy `"Today"` into a Date field, which fails downstream.
+   Frappe resolves the token itself, so the note says accept-or-override — never copy.
+
+**Known risk, stated plainly.** This is the same shape as `get_schema`'s `actions` block and PR
+#343's docfield properties: **data surfaced to the model that the model may simply not use.** Both
+of those shipped correct and unreachable. The mitigation is that this one lands on a field map the
+agent demonstrably *does* read (this very transcript shows it consuming `mandatory`/`auto` from it),
+which neither of those did. It is still a bet.
+
+**Not in scope:** rendering Frappe-applied defaults on the card. For the gated `_create_card` the
+data exists (`would` carries the resolved doc) but is filtered to the agent's `values` keys; for the
+draft card no resolved doc is fetched at all on a create (`base.values` is `{}`). Both are real, both
+are bigger, and neither is needed if fix 3 puts the default in the draft.
+
+## Testing
+
+**Fix 2** — `frontend/src/lib/actionSummary.test.js` exists (`node --test`); `buildDraftModel` lives
+in `ChatView.vue` and is not exported, so it has no unit surface. Verify by compiling and by manual
+smoke. **CI does not run node tests** (`ci.yml` is Python-only).
+
+Fix 2 spans **two frontends**, so the smoke does too:
+- **Desktop:** a docs block renders the error card, not a blank one; **Edit and Preview do not die**
+  (the throw is caught, the button is disabled); a normal single-record draft still renders.
+- **PWA:** a docs block renders the error inside the card with the primary button **disabled** and
+  **Cancel still live**; a fields-empty create likewise; the block never vanishes from the prose.
+
+**Fix 3** — `jarvis/tests/test_get_creation_context.py` **exists** (an earlier draft hedged "if
+present", which just meant nobody looked). Its shape assertion at `:40` is a subset check
+(`assertLessEqual`), so the conditional `default` key passes it. Add:
+- a `fetch_from` field is `auto: true` and carries no `default`
+- `ToDo.date` (`default: "Today"`) is `auto: false` and carries `default: "Today"`
+- `ToDo.description` (`reqd`) is still `mandatory: true` (it is computed from `df.reqd`
+  independently of `auto`, so the change is isolated)
+- a reqd+default field (Sales Order `transaction_date`) is `mandatory: true, auto: false`
+- the note contains the decide-it-yourself and symbolic-default clauses
+
+**Regression: answerable, and the answer is "nothing in code".** No app code reads `auto` back from
+this tool — the only consumers are the model (`AGENTS.md:127`, `TOOLS.md:25`) and the plugin's
+tool description (`tool-defs.ts:158`), all of which stay textually valid. So the blast radius is
+entirely behavioural, not structural.
+
+Run: `cd bench && bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.<module>`
+
+**Fix 1** — `cd jarvis-persona && ./lint.sh && python validate.py`, and confirm AGENTS.md stays
+under 32,000.
+
+## Rollout
+
+Fixes 2 and 3 are **app-only** — no plugin, no container restart. Fix 1 is a **persona** change: it
+needs a `git pull` on the persona checkout plus a container restart per tenant (a brief chat blip),
+so batch it with the next persona roll rather than forcing an outage for a sentence.
+
+Fix 3 changes what the model sees, so its benefit only appears once tenants pick it up.
+
+## What the user actually saw — corrected
+
+An earlier draft said "a card with one empty Description box". **That is the Edit-panel /
+DraftPreview surface, not the summary card.** On the summary card a docs block renders the
+model-written headline ("3 open ToDos assigned to Administrator", `actionSummary.js:30` reads
+`action.summary`), **zero rows**, and an **enabled Confirm** (`ChatView.vue:296` only checks
+`!summaryState.model`, and a model *was* built). The empty Description box appears once you click
+Edit or Preview — both fed by `buildDraftModel`.
+
+The mechanism in this spec is right; the surface attribution was not. **The manual smoke must check
+all three surfaces** — summary card, Preview, Edit panel — not just the one. Note the pre-fix
+Confirm path does fail visibly on its own: `apply_action` → `create_doc(ToDo, {})` → the
+mandatory-field error envelope (`actions_api.py:187-247`). So the bug is "silent until you commit
+to it", not "silent forever".
+
+## Open
+
+- **Card display of Frappe-applied defaults** (above, "not in scope").
+- **The agent-feedback channel for fix 2** — nothing tells the agent its block failed to render.
+- **The `kind:"email"` sibling.** The same fusion failure exists there: a model emitting a
+  `messages:[...]` bulk-email shape renders a card with empty To/Subject/body
+  (`ChatView.vue:229`). Lower stakes since the Send button is gone (legacy note, `:242-246`), but it
+  is the same silent-blank family, and `docs` is unlikely to be the only key a model will invent.
+  The generic no-fields guard in fix 2 catches the create case; the email kind has no equivalent.
+- **The PWA drops child tables on apply — pre-existing, found while specifying fix 2.**
+  `ActionCard.apply()` sends only `values` derived from `action.fields` (`:53-81`); it never reads
+  `action.tables`, which the desktop's `applyDraft` does (`ChatView.vue:2360-2366`). So a
+  fields+tables draft — AGENTS.md's own Sales Order example — applied **from the phone** writes the
+  parent without its rows. Where the ERP mandates the table (SO items) it errors visibly; where it
+  does not, it is a **silent partial write**. Same family as the bug this spec kills, strictly out
+  of scope, recorded so it is not lost.

--- a/docs/superpowers/specs/2026-07-17-confirmation-card-redesign.md
+++ b/docs/superpowers/specs/2026-07-17-confirmation-card-redesign.md
@@ -1,0 +1,562 @@
+# Confirmation card redesign — record summaries on every gated action
+
+Status: **rev 3 — Fable-approved, ready to plan** · Date: 2026-07-17 ·
+Repo: `Aerele-RnD/jarvis` (app only)
+
+Two Fable review rounds. Rev 1 returned **don't-ship** with three blocking findings; rev 2
+returned **ship after five text corrections**, all applied here. The review ledgers at the
+bottom list every error so none is silently buried. Load-bearing claims from both rounds were
+independently verified against source before acceptance — including one where Fable corrected a
+false citation of mine, and one where Fable corrected its own rev-1 recommendation.
+
+## Problem
+
+Every gated write parks behind a "Confirm before this runs" card. The cards tell you the
+**identifier** of what is about to change, not the **thing**. A delete card says
+`Will delete this Sales Order SO-0001` and nothing about the order; a bulk-create card lists
+`{doctype, name}` per record and throws the field values away even though they are sitting in
+`args.docs[i].values`; **eight of the 24 gated shapes** render no card at all and fall back to a
+technical string from `_describe_call`.
+
+`bulk_update` (PR #317) is the exception: it shows per-record content, collapsibly. It is the
+only card that answers "what am I actually approving". This spec brings every other card up to
+that standard — and fixes two defects the review found in the cards that already ship.
+
+## Scope
+
+**In:** phases 1-4 below, all inside the `jarvis` app. No plugin build, no persona change, no
+container restart.
+
+**Out (own round):** `summary_fields` — letting the model choose which fields a card shows.
+See "Round 2".
+
+## What exists today (verified 2026-07-17)
+
+14 tools gate (`api.py:469` `_GATED_WRITES`). They present **24 shapes**, because most have a
+single and a bulk path (`_BULK_ARG_KEYS = ("names", "updates", "docs", "messages")`,
+`api.py:505`). `build_card` (`confirm_card.py:51`) covers 16:
+
+| Card kind | Tools | Renders |
+|---|---|---|
+| `create` | `create_doc` single | field list from perm-filtered `would` |
+| `batch_create` | `create_doc(docs=[])` | `{doctype, name}` bullets + model-authored notes |
+| `update` | `update_doc` single | from→to diff |
+| `bulk_update` | `update_doc(updates=[])` | per-record from→to, collapsible |
+| `verb` | `submit_doc`, `cancel_doc`, `delete_doc`, `amend_doc`, `apply_workflow_action` (single + `names=[]`) | "Will {verb} …" + bare target names |
+| `email` | `send_email` single | to / subject / body |
+| `method` | `run_method` | dotted path + args, secret keys masked |
+
+Eight shapes get **no card** — `build_card` returns `None` and the SPA falls back to
+`_describe_call`'s string plus "not a dry run":
+
+| Shape | What the human sees today |
+|---|---|
+| `send_email(messages=[])` | `send_email count=20 targets=[SI-0001, …]` — document names, **no recipients** |
+| `share_doc` single / bulk | `share_doc doctype=X name=Y` — **no user, no permission flags** |
+| `assign_to` single / bulk | `assign_to doctype=X name=Y` — **no assignee, no description** |
+| `create_custom_skill` | `create_custom_skill` — **bare tool name** |
+| `update_wiki` | `update_wiki` — **bare tool name** |
+| `create_docs` (deprecated shim) | older batch bullets (`build_card` dispatches on `tool == "create_doc"` only) |
+
+`_describe_call` (`api.py:610`) surfaces only `doctype`, `name`, `docname`, `target_doctype`,
+`target_name`, `method`, `action`, `recipients`, `to`, `subject`. It has no `user`,
+`skill_name` or `slug`, which is why the last four rows above are that thin.
+
+### Two pre-existing defects this spec must fix, not inherit
+
+**A. Model-authored prose already renders on the trust surface.** `create_doc`'s `notes` is a
+**tool argument the model writes** (`create_doc.py:87`), echoed verbatim into `would["notes"]`
+(`create_doc.py:134`) and rendered by `_batch_create_card` (`confirm_card.py:244-247`) and both
+frontends. A prompt-injected agent can render "these records already exist — confirming changes
+nothing" above a card that creates 20 rows. Escaped rendering stops XSS, not lying. **This spec
+removes `notes` from the card.**
+
+**B. Card doc reads are not permission-checked.** `frappe.get_doc` checks nothing **unless** a
+`check_permission` kwarg is passed: `get_doc_str` forwards it into `get_doc_permission_check`
+(`frappe/model/document.py:141-145` → `:336-349`), which runs `doc.check_permission("read")`
+only when truthy. It defaults to `None`, so the bare call the cards make performs no check. And
+`apply_fieldlevel_read_permissions` (`document.py:1248`) only does permlevel `delattr` plus
+`mask_fields`. **Both `_update_card` (`confirm_card.py:143`) and `_bulk_update_card`
+(`confirm_card.py:203`)** already read docs this way, so a user who cannot read a record can
+already see its old values on an update card — single or bulk. **This spec adds a doc-level read
+check** rather than spreading the hole to fourteen more shapes.
+
+(Rev 3 named only `_bulk_update_card`; `_update_card` has the identical unchecked read and was
+caught while writing the phase-1 plan, after two review rounds had missed it. Both are fixed in
+phase 1.)
+
+We use **`doc.has_permission("read")`** (returns a bool) rather than `get_doc`'s
+`check_permission` kwarg (which throws): the card must degrade to a header-only row, not raise,
+and throwing would conflate "missing" with "unreadable".
+
+Frappe's own `link_preview.py` reads via `frappe.get_list`, which **is** permission-checked —
+rev 1 took its field-selection idea and dropped the permission model that came with it.
+
+### Three facts that shape the design
+
+1. **The card never reaches the model.** `api.py:1083` strips `card` out of `model_preview`
+   before returning. Richer cards cost **zero tokens**. The only budget is human attention and
+   the Redis token / realtime payload — which is the argument for collapsing, not for hiding.
+
+2. **`_fmt` is a raw `str()`** (`confirm_card.py:102`). Today a Currency renders `125000.0`,
+   a Check renders `1`, a Link renders the docname. A live defect in cards that already ship.
+
+3. **Tool args are not the write.** Tools normalize. `create_custom_skill` computes a
+   `requested` scope and then hardcodes `"scope": "User"` (`create_custom_skill.py:44-57`), so a
+   card echoing `args.scope="Org"` would misdescribe its own payload. `share_doc` coerces flags
+   via `int(bool(flag))` (`share_doc.py:92-94`), and `bool("false")` is `True`.
+
+## Design decisions
+
+**1. Model chooses, server renders, meta is the floor.** The model may (in round 2) name which
+fields a card shows. It must never author the values.
+
+This is a trust boundary, not a preference. The confirmation card is the human's *independent*
+check on the agent: the one surface that reports what will happen rather than what the agent
+says will happen. If the agent authors the card, the card stops verifying the agent and merely
+repeats it. Every other component honours this — `_run_preview` sandbox-executes the real call,
+`build_card` reads only from the perm-filtered `would` and the caller's args, and the token
+never goes near the model. Defect A above is the one existing violation; it is removed here.
+
+**2. Cards render EFFECTIVE values, not raw args.** Where a card is built from args, it must
+show what the tool will actually write after its own normalization — never the raw request. A
+card that echoes a value the tool overrides is a card that lies. Concretely: `skill` renders
+scope as **"User (private)"** unconditionally; `share` renders flags through the same
+`int(bool(...))` the tool applies.
+
+**3. Stored content is selected; proposed content is shown whole.** When summarizing a record
+that exists (delete, submit, cancel, amend, workflow, share/assign targets), the doc has 50-200
+fields and the floor **selects** the few worth showing — hiding the rest is the point. When
+rendering content the caller **proposed** (bulk create's values, an email's body), every key
+renders in caller order, capped with an explicit remainder count. Filtering proposed content to
+a floor subset would hide a field the caller set, so you could approve a create without seeing a
+value it will write.
+
+**Rejected: Frappe's `in_preview` / link-preview field set.** `frappe/desk/link_preview.py` is
+gated on `meta.show_preview_popup` and most doctypes leave `in_preview` unset, so it degrades to
+mandatory-fields-only anyway. We take its `reqd` fallback idea and skip the `in_preview` lookup —
+but we keep its permission model (see B above).
+
+**Known risk, from measured evidence.** PR #329 added `actions` to `get_schema`; a production
+transcript showed `get_schema` called **zero times** on the create path, so the hint shipped
+unreachable. `summary_fields` shares that failure mode: it is optional, so if the persona does
+not mandate it the meta floor is what renders. The floor must be good on its own — it is the
+product, not a fallback.
+
+## The primitive
+
+New module `jarvis/chat/_record_summary.py`. `confirm_card.py` is already 291 lines and this
+roughly doubles it; the helper holds all the real branching, so it earns its own test surface.
+
+### Caps
+
+```
+_MAX_VAL    = 200     # a scalar display value (existing)
+_MAX_ROWS   = 20      # records / fields per record / child rows (existing)
+_MAX_COLS   = 8       # columns in a rendered child table (a 20-column table is unusable)
+_MAX_TABLES = 3       # child tables rendered per record; the rest degrade to "N rows"
+_MAX_BODY   = 8_000   # a single long-form body (skill instructions, wiki body, one email)
+_MAX_BULK_BODY = 2_000  # per-message body in a bulk-email card (20 x 2k bounds the payload)
+```
+
+`_MAX_TABLES` bounds the one dimension the other caps miss. Without it the pathological
+batch_create is 20 records × several table fields × 20 rows × ~6 columns × 200 chars ≈ 1MB+.
+Not a live problem — realistic P99 is tens of KB and today's `bulk_update` already ships ~160KB
+worst case — but the "Bounded" invariant should have no unbounded axis. **Payload landing
+verified:** the token is a single pickled Redis key with a 15-min TTL (`pending_confirm.py:93`),
+comfortable at MBs; the `action:pending` event goes `frappe.publish_realtime` → Redis pub/sub →
+node socketio (`chat/events.py:65-67`, `api.py:1064-1074`) with no server→client rejection
+threshold; and the model pays nothing (`card` stripped at `api.py:1083`).
+
+`_MAX_BODY` exists because a 200-char cap on `create_custom_skill.instructions` makes the
+approval theater: you would be confirming persistent agent instructions — the canonical
+prompt-injection persistence vector — while structurally unable to read them. Long-form bodies
+live inside a collapsible, so the cost is payload, not attention.
+
+### `pick_fields(meta) -> list[str]`
+
+Selection only — used by `summary_rows`, never by `values_rows`. Pure given a meta. The **meta
+floor**, in order, deduped, capped at 8:
+
+1. `meta.get_title_field()` when it is not `"name"` (`frappe/model/meta.py:371`)
+2. `meta.get_list_fields()` — Frappe's list-view set: `["name"]` + `in_list_view` fields
+   restricted to `data_fieldtypes` + the title field (`frappe/model/meta.py:359`)
+3. `reqd` fields (the record's essence — Frappe's own link-preview fallback)
+4. `status` and/or `docstatus` when `meta.is_submittable`
+5. `grand_total`, else `total`, when the field exists
+
+`name` is dropped (it is the row header). **Long-text fieldtypes are deprioritized to last**:
+`data_fieldtypes` includes `Text Editor`, `Markdown Editor`, `Code`, `HTML Editor`
+(`frappe/model/__init__.py:8`), so a 10k-char body field can legitimately be `in_list_view` and
+would otherwise win a floor slot over the customer and the total. Safety is handled by `fmt`'s
+carve-out; this is about summary quality.
+
+No `requested` parameter. Round 2 adds it as a kwarg — a one-line change — rather than carrying
+an unused seam through four phases.
+
+### `summary_rows(doctype, name) -> {"title", "rows"} | None`
+
+For stored records. In order:
+
+1. `frappe.get_doc(doctype, name)` — fresh DB load, **not** `get_cached_doc`, so no cache can
+   serve sandbox-mutated state. A `DoesNotExistError` catch must call `frappe.clear_messages()`:
+   `frappe.throw` leaves an entry in `message_log` that would otherwise leak into the turn (the
+   same latent bug exists in today's `_bulk_update_card` catch).
+2. **`doc.has_permission("read")`** — the fix for defect B. On failure return `None`; the caller
+   renders the header-only row it already defines for a missing target. Fieldlevel perms are not
+   doc-level perms.
+3. `doc.apply_fieldlevel_read_permissions()`, then skip any field no longer present
+   (permlevel-restricted fields are `delattr`-ed, `document.py:1264`).
+4. Skip empty values; mask via `_is_secret` (`confirm_card.py:163`); format via `fmt`.
+
+One `get_doc` per record, callers capped at `_MAX_ROWS`. `has_permission` adds negligible cost.
+
+It returns `{"title": str, "rows": [{"label", "value"}]}` — the title travels **inside** the
+return, not as a separate lookup, which is what puts it inside the permission boundary below.
+
+**The header title is part of the perm boundary.** A record's `title` may only be produced by
+this function's successful, perm-checked path — it is returned alongside the rows. When
+`summary_rows` returns `None`, the caller renders **name only**. Do not source the header from a
+separate `frappe.db.get_value(doctype, name, title_field)`: that read is unchecked, and the
+title field is typically the customer or party name — i.e. precisely the data being protected.
+The obvious implementation of the `{name, title, rows}` shape leaks; this sentence exists to
+stop it.
+
+**Administrator caveat:** both `apply_fieldlevel_read_permissions` (`document.py:1250`) and the
+permission layer early-return for Administrator. `FrappeTestCase` runs as Administrator, so
+neither guard is unit-testable — the same limitation already recorded for `_bulk_update_card`.
+The tests assert the call is made (via mock), not its effect.
+
+### `values_rows(meta, values: dict) -> {rows, extra}`
+
+For proposed content. Renders **every** key in `values`, in **caller order** (no reordering —
+the card should be comparable against the request), capped at `_MAX_ROWS`, with `extra` =
+the number of keys not shown so the card can say "+N more fields". Never filtered to the floor.
+
+Same `fmt` and `_is_secret` masking. No perm filter is possible or needed: the values are the
+caller's own args. The single-doc `create` path continues to read from the perm-filtered `would`.
+
+`meta` may be `None` (unknown doctype) — labels fall back to fieldnames and formatting to the
+`df=None` path rather than failing the card.
+
+### `table_rows(meta, fieldname, rows) -> {label, count, columns, rows, extra, extra_columns}`
+
+Proposed child tables, rendered as a real table rather than "5 rows". Up to `_MAX_ROWS` rows,
+`extra` for the remainder; every cell through `fmt` and `_is_secret`.
+
+**Columns are `in_list_view` order ∪ every key the caller actually set**, capped with
+`extra_columns` = "+N more columns". `in_list_view` alone would re-break design decision 3
+inside the new primitive: Sales Invoice Item's list-view columns are item/qty/rate/amount, so a
+proposed batch that also sets `income_account` or `cost_center` on every row would write them
+invisibly. `in_list_view` is a sound **ordering** source; it is not a sufficient **selection**
+one for proposed content.
+
+For the single-`create` card, whose rows come from `would` with every default populated, the
+union is `in_list_view` ∪ **caller-set** keys — not ∪ all `would` keys, which would be unbounded
+and is not what the human is approving.
+
+A proposed key that is not a real child field is dropped by the save (it fails `valid_columns`).
+Rendering it as a written value would violate the effective-values invariant, so such keys are
+**counted, not rendered as values**.
+
+This exists because "N rows" on a proposed create hides the economically load-bearing content —
+a Sales Invoice's line items and amounts. The old model-driven **draft** card already renders
+child tables with columns (`actionSummary.js:19-27`), so without this the *gated* card would be
+strictly weaker than the *draft* card on exactly the invoice content that motivated this work.
+
+**Stored** summaries keep "N rows": the floor is a summary, and a delete card does not need the
+line items to identify the order.
+
+### `fmt(value, df=None, doc=None, limit=_MAX_VAL) -> str`
+
+Replaces `_fmt`. Routes through
+`frappe.format_value(value, df=df, doc=doc, translated=False)`
+(`frappe/utils/formatters.py:26`) so Currency renders `₹ 1,25,000.00`, Date uses the user
+format, Percent gets its sign, and Link resolves to its title when `doc.__link_titles` is
+populated (raw docname otherwise — acceptable).
+
+Rules, each load-bearing:
+
+- **`translated=False`.** `format_value` runs `value = frappe._(value)` on **every string
+  value** before the fieldtype switch (`formatters.py:59-60`) — docnames, subjects, Data. On a
+  non-English session any value colliding with a translation msgid would render as something
+  other than what is stored, and a one-sided collision corrupts no-op detection. Select options
+  still translate inside their own branch (`formatters.py:142-144`), which is the only
+  translation wanted.
+- **HTML-emitting fieldtypes bypass `format_value`**: `Text`, `Small Text`, `Long Text`
+  (newlines → `<br>`), `Markdown Editor` (→ HTML), `Text Editor` (→ `<div class='ql-snow'>`).
+  Both frontends render through **escaped interpolation, never `v-html`**
+  (`PendingCard.vue:6`), so these would show literal tags. `HTML Editor` and `Code` fall through
+  `format_value` raw, so bypassing them too is equivalent and simpler.
+- **`Check` → `"Yes" if cint(value) else "No"`.** `format_value` has no Check branch; it falls
+  to `return value` (`formatters.py:146`). Naive truthiness breaks on the string `"0"`: a model
+  sending `changes={"disabled": "0"}` against a DB `0` would render from `No` → to `Yes`, a
+  **phantom change on a gated card**. `cint` is mandatory.
+- **`cstr` the result.** `format_value` returns non-strings on the Check/Data/unknown paths.
+- **Lists → `"N rows"`** for stored content (child tables in proposed content go through
+  `table_rows`).
+- **Truncate at `limit`** after formatting. Callers pass `_MAX_BODY` / `_MAX_BULK_BODY` for
+  long-form fields; everything else takes the 200 default.
+- **Per-field `try/except → str(value)`.** `format_value` genuinely raises: `get_field_currency`
+  does attribute access on the doc (`meta.py:886`) and `get_cached_value` on a bad link value
+  can throw (`meta.py:897`); `get_field_precision` asserts (`meta.py:936`). One odd field must
+  never blank a card. Note `doc.as_dict()` returns a `frappe._dict` so attribute access works
+  in-process; a plain JSON dict must be passed as `doc=None`.
+
+### No-op detection — cast-compare (rev 1 and rev 2 both got this wrong)
+
+Baseline, stated correctly: `_update_card` compares **raw** values (`confirm_card.py:154`); only
+`_bulk_update_card` compares **display** forms (`confirm_card.py:216-217`). Rev 1 claimed both
+compared display and said to preserve it, which would have been a silent behavior change.
+
+**Display forms must never participate in equality.** `fmt_money` at precision 2 renders both
+`100.005` and `100.001` as `100.00`, so a display compare **drops a real change and omits it
+from a gated card**. Percent (`flt(value, 2)`) and post-truncation compare are the same class.
+
+Rev 2's "raw first, display fallback on type mismatch" does not fix this, and the hole sits in
+the *common* branch: an LLM sends numbers as strings, so `from=100.005` (typed float from the
+DB) vs `to="100.001"` (string arg) is a type mismatch → falls to display → both `"100.00"` →
+**hidden**. Same for an exchange rate `83.1234` vs `"83.1236"` at display precision 3.
+
+**The rule is cast-compare.** Coerce both sides with the same coercion the save applies, chosen
+by DocField type, and compare the cast values — never their display forms:
+
+| Fieldtype | Cast |
+|---|---|
+| Currency, Float, Percent | `flt` at the **column's** precision, not display precision |
+| Int, Check | `cint` |
+| Date | `getdate` |
+| Datetime | `get_datetime` |
+| everything else | `cstr` |
+
+This answers the question the guard actually exists for — *will the save change the stored
+value?* — rather than "do the two render the same":
+
+- `flt(100.0) == flt("100")` → no-op (the phantom-diff fix `_bulk_update_card` was given, kept)
+- `flt(100.005) != flt("100.001")` → shown (the hiding hole, closed)
+- `cint(0) == cint("0")` → no-op
+- `cstr(None) == cstr("")` → no-op
+
+A cast failure (garbage string) counts as **changed** — show the row. Garbage bounces pre-card
+anyway via `_DRY_RUN_ON_PARK` (`api.py:1033-1039`), so this branch is a safety net, not a path.
+
+## Per-card changes
+
+### Phase 1 — primitive + formatter + the two pre-existing defects
+
+- Add `_record_summary.py` (`pick_fields`, `summary_rows`, `values_rows`, `table_rows`, `fmt`).
+- Repoint `_create_card`, `_update_card`, `_bulk_update_card`, `_email_card`, `_method_card`
+  from `_fmt` to `fmt`.
+- Apply the no-op rule above to both diff cards.
+- Add `has_permission("read")` to `_bulk_update_card`'s doc read (**defect B**, pre-existing).
+- `create`: render child tables via `table_rows`.
+- `update` / `bulk_update`: add the record title to the header (`SO-0001 · Acme Corp`).
+
+Ships a visible improvement plus a real permission fix, with no new card kinds and no frontend
+whitelist change.
+
+### Phase 2 — `verb` card (10 shapes; the delete case)
+
+`_verb_card` keeps its sentence as the headline and gains `records: [{name, title, rows}]` via
+`summary_rows`, capped at 20 with `extra` for the remainder, rendered in the `bulk_update`
+grammar: collapsible rows, first open, 320px scroll, "+N more". A record whose `summary_rows`
+returns `None` (unreadable or missing) renders header-only — never an error, never a leak.
+
+A single delete becomes one open row headed `SO-0001 · Acme Corp` with customer, date, grand
+total and status inside.
+
+**Verified:** no verb shape renders post-action state. Bulk verbs route to described-intent
+(`api.py:665-667`, nothing runs); single submit/cancel/delete/amend go through `_run_preview`,
+whose rollback is in a `finally` (`_preview_sandbox.py:32-37`) so it holds even when the tool
+raises; `apply_workflow_action` single is not in `_PREVIEWABLE` → described-intent. `build_card`
+has exactly one call site, post-rollback (`api.py:1051`), and never runs at resync.
+
+### Phase 3 — `batch_create`
+
+`_batch_create_card` gains per-record `rows` from `values_rows(meta_i, args.docs[i].values)` plus
+`table_rows` for child tables. **Removes `notes`** (defect A).
+
+Three implementation caveats:
+
+- **`zip` the two lists; never filter-then-index.** Today's `_batch_create_card` filters
+  non-dicts out of `would.created` (`confirm_card.py:241-243`), which would desync the pairing.
+- **Meta is per-item** (`args.docs[i].doctype`) — a batch can mix doctypes.
+- **The displayed name may shift.** It is a sandbox-consumed series number; a concurrent insert
+  can take it before confirm. The card says so in one line.
+
+Alignment is otherwise guaranteed: `run_atomic_batch` appends results in `enumerate` order
+(`_bulk.py:61-62`), items are validated up front (`create_doc.py:120-127`), any failure bounces
+pre-card via `_DRY_RUN_ON_PARK` (`api.py:1033-1039`), and batch size ≤ 20 = `_MAX_ROWS`.
+
+Add `create_docs` to `build_card`'s dispatch (one line) so the deprecated shim gets the card.
+
+### Phase 4 — the five missing kinds + `_describe_call`
+
+| New kind | Tool | Contents |
+|---|---|---|
+| `bulk_email` | `send_email(messages=[])` | per-message collapsible; recipients + subject on the header, body inside at `_MAX_BULK_BODY` |
+| `share` | `share_doc` single + bulk | grantee (user, or **Everyone**), permission flags as chips rendered through the tool's own `int(bool(...))` coercion, notify, + target `summary_rows` |
+| `assign` | `assign_to` single + bulk | assignee, the description **that gets emailed**, priority, date, notify, + target `summary_rows` |
+| `skill` | `create_custom_skill` | name, **scope rendered as "User (private)" unconditionally** (the tool hardcodes it, `create_custom_skill.py:57`), user_invocable, description, + instructions body at `_MAX_BODY` in a collapsible |
+| `wiki` | `update_wiki` | slug, title, scope, page_type, ref doc, body at `_MAX_BODY`, with `replace_body_md` flagged as a **full replace** vs `append_md` |
+
+`email` (single) also gains **cc, bcc and the attached print format**, and its body budget rises
+to `_MAX_BODY`.
+
+`_describe_call` gains `user`, `skill_name`, `slug`, `title`, `scope`. It remains the summary
+line above the card and the `action:pending` event's `summary`.
+
+### Frontend (phases 1-4)
+
+Each new kind needs, in lockstep:
+
+1. an entry in `CARD_KINDS` (`frontend/src/lib/actionSummary.js:61`) — **omitting this silently
+   rejects the card and falls back to raw**;
+2. a branch in desktop `frontend/src/components/PendingCard.vue`;
+3. a branch in PWA `pwa/src/components/PendingCard.vue` (mounted by `DecisionSheet.vue`).
+
+Phase 1 also needs the child-table sub-template in both. The PWA reuses desktop helpers via
+`@shared` → `frontend/src`, so the whitelist is shared but the templates are not.
+
+**Commit the frontend with plain `git`, matching the existing 2-space / no-semicolon style.**
+`pre-commit` runs prettier, which reformats whole files to tabs+semicolons; no CI enforces it.
+
+## Invariants (must hold for every card)
+
+- **Values are server-derived.** From the perm-filtered `would`, a perm-checked + perm-filtered
+  doc read, or the caller's own args. **Never model-authored prose** — this is why `notes` goes.
+- **Doc-level read permission is checked** on every stored-record read, not just fieldlevel.
+- **Effective values, not raw args.** A card never echoes a value the tool will override.
+- **No phantom changes, and no hidden real ones.** See the no-op rule.
+- **Secrets masked.** `_is_secret` covers Password fieldtypes and
+  `password|secret|token|api[_-]?key` names. `data_fieldtypes` includes `Password`, so a Password
+  field can legitimately be `in_list_view` and reach the floor — masking is not optional.
+- **Escaped rendering.** No `v-html`, ever. (The PWA's one `v-html`, `DecisionSheet.vue:132`, is
+  safe: `renderMarkdown` escapes source before markup, `frontend/src/markdown.js:5-7`.)
+- **Best-effort.** `build_card` never raises; failure yields `None` and the SPA falls back.
+- **Built once at park.** Attached at `api.py:1051`, returned verbatim on resync (F2). Never
+  rebuilt — rebuilding re-fires unsandboxed side effects.
+- **Bounded, with no unbounded axis.** 20 records, 8 floor fields, 20 rows/record, 3 child
+  tables/record, 20 child rows, 200 chars/scalar, 8k/body, 2k/bulk-email body.
+- **The header title is inside the perm boundary** — name-only when the record is unreadable.
+
+## Testing
+
+`jarvis/tests/test_confirm_card.py` extends (currently 20 tests). Run against
+`jarvis-test.localhost`, not the dev site:
+
+```bash
+cd bench && bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_confirm_card
+```
+
+- **1** — `pick_fields` floor order, dedupe, cap, long-text deprioritized; `values_rows` renders
+  every proposed key in caller order with `extra` (never floor-filtered); `table_rows` columns
+  are `in_list_view` ∪ caller-set keys (**a caller-set column outside `in_list_view` must
+  render**), `_MAX_TABLES` degrades the rest to "N rows", a non-field key is counted not
+  rendered; `fmt` per fieldtype (Currency symbol, **Check with string `"0"` → No**, Date,
+  HTML-type bypass, `cstr`, truncation, raising field → `str`); `translated=False` (a value
+  colliding with a msgid is not translated); **cast-compare**: `flt(100.0)` vs `"100"` is a
+  no-op, `100.005` vs `"100.001"` **renders** (the display-compare hiding case), `cint(0)` vs
+  `"0"` is a no-op, `cstr(None)` vs `""` is a no-op, an uncastable value renders;
+  `has_permission` is called on the `bulk_update` doc read.
+- **2** — `verb` card carries `records`; cap + `extra`; an unreadable target degrades to
+  **name-only** — no `title`, no field, and no second unchecked read for the title;
+  unreadable and missing render identically (no existence oracle).
+- **3** — `batch_create` rows come from args; `zip` alignment survives a non-dict in
+  `would.created`; per-item meta on a mixed-doctype batch; **`notes` absent from the card**.
+- **4** — one test per new kind; `share` renders flags through the tool's coercion; `assign`
+  renders the description; **`skill` renders scope "User (private)" even when args say "Org"**;
+  bodies honour `_MAX_BODY`; secret masking on each; **`CARD_KINDS` parity** (every kind
+  `build_card` can emit is whitelisted).
+
+No frontend test framework exists; the Vue branches are verified by manual smoke (desktop +
+PWA), which is the standing gap on this subsystem.
+
+Beware `frappe`'s FS-order test discovery flake (`test_settings` admin-dispatch is a known
+pre-existing order-dependent failure that adding a test file can trip). Prove any red is
+pre-existing by stashing and re-running on `origin/main` before diagnosing.
+
+## Decomposition
+
+Four phases, one PR each. Phases 2-4 depend on phase 1's primitive; 2, 3 and 4 are independent
+of each other afterwards. Phase 1 alone is shippable and user-visible (formatter + the
+permission fix), which de-risks the primitive against real cards before four kinds depend on it.
+
+## Round 2 (deferred)
+
+`summary_fields` — model chooses the fields:
+
+- `_run_tool` **pops** `summary_fields` from args before dispatch and passes it to `build_card`.
+  It is presentational, not a tool concern; the tools would reject an unknown kwarg; and the
+  token must store the cleaned args so confirm dispatches unchanged.
+- `pick_fields` gains a `requested` kwarg (keep the ones `meta.get_field` resolves, drop the
+  rest — never an error).
+- Plugin descriptors + typebox schemas gain the param; persona guidance so it is actually passed.
+- Requires a plugin build + container roll; phases 1-4 do not.
+
+## Open questions
+
+1. **Park→confirm staleness (unresolved, flagged deliberately).** Phase 2 puts decision weight
+   on values snapshotted at park; the doc can change inside the 15-minute TTL and confirm does
+   not re-verify. Storing `doc.modified` at park and refusing or flagging on mismatch at confirm
+   is cheap optimistic concurrency. **Not in this spec** — it changes `confirm_tool`, not the
+   cards, and deserves its own decision. Recorded so it is not mistaken for an oversight.
+2. Floor capped at **8** fields — chosen to fill a collapsed row without scrolling; unverified
+   against a wide doctype.
+3. `update_wiki`'s `replace_body_md` shows the new body flagged as a replace, **not** a diff
+   against the current body. A diff is the better card; it needs the current body loaded.
+   Deferred.
+
+## What rev 1 got wrong
+
+Fable's review, all eight confirmed; the first three were blocking. Three were independently
+verified against source before acceptance (`get_doc` perm, `notes` provenance, skill scope).
+
+1. **`summary_rows` never checked doc-level read permission** — `get_doc` checks nothing and
+   fieldlevel perms are not doc perms. Would have spread a pre-existing hole to 14 shapes.
+2. **Kept `notes`** — model-authored prose on the trust surface, three sections after declaring
+   values must never be model-authored.
+3. **200-char cap on `create_custom_skill.instructions`** — rubber-stamp approval of a
+   prompt-injection persistence vector.
+4. **`translated=True`** — translates data values, not just labels.
+5. **Check → Yes/No without `cint`** — string `"0"` renders "Yes" and fabricates a diff.
+6. **Claimed `_update_card` compares display forms** — it compares raw. "Preserve it" was
+   actually specifying a silent behavior change; and display comparison can hide a real change
+   through rounding.
+7. **Cards echoing raw args** — `create_custom_skill` hardcodes scope, so the card would lie.
+8. **`values_rows` capped at 20 with no remainder indicator** — silently hid proposed fields,
+   the exact defect its own rule forbids.
+
+Also missed entirely: proposed child-table content (the gated card was weaker than the draft
+card on invoice line items), long-text fieldtypes winning floor slots, park→confirm staleness,
+and the Problem section said "five" shapes where the verified table says eight.
+
+Cut as YAGNI: `pick_fields`'s unused `requested` seam; floor-first reordering in `values_rows`.
+
+## What rev 2 got wrong
+
+Second Fable round: **ship after five text corrections**, all applied.
+
+1. **The no-op rule still hid real changes — in its common branch.** "Raw first, display
+   fallback on type mismatch" leaves the hiding hole inside the type-mismatch branch, and type
+   mismatch is the *normal* case because LLMs send numbers as strings. Replaced with
+   cast-compare. Notably this was Fable's own rev-1 suggestion, which it retracted on attack —
+   the reason a fix gets re-reviewed rather than assumed correct.
+2. **`table_rows` selected proposed child columns by `in_list_view`** — reintroducing rev 1's
+   finding 8 inside the new primitive. A batch setting `income_account` on every line would
+   have written it invisibly. Columns are now `in_list_view` ∪ caller-set keys.
+3. **The `{name, title, rows}` header left `title`'s source unpinned**, and the obvious
+   implementation (`db.get_value(title_field)`) is an unchecked read of exactly the protected
+   data. Pinned to name-only on an unreadable record.
+4. **The `get_doc` citation was false.** `get_doc_str` *does* forward a `check_permission` kwarg
+   (`document.py:141-145` → `:336-349`); it defaults to `None`, so the conclusion held but the
+   evidence did not. Verified and corrected. (The window I read stopped one line short of the
+   forwarding call — the failure mode of citing from a partial read.)
+5. **No cap on child tables per record** — the one unbounded axis in a "Bounded" invariant.
+
+Nit also applied: `summary_rows`' `DoesNotExistError` catch clears `message_log`.
+
+Confirmed clean on the second pass: `has_permission` on `_bulk_update_card`, skill
+"User (private)", share flags through the tool's coercion, `translated=False`, `cint` Check,
+`values_rows` shape, both YAGNI cuts, the staleness deferral, and the phase-2/3 park-state
+verification (independently re-traced and matching). Payload sizing verified as a non-issue.

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -124,11 +124,41 @@ function tableNote(t) {
 		<!-- batch create -->
 		<template v-else-if="card.kind === 'batch_create'">
 			<div class="jv-pcard-head">Create {{ card.count }} record<template v-if="card.count !== 1">s</template></div>
-			<ul class="jv-pcard-list">
+			<div v-if="(card.records || []).length" class="jv-pcard-recs">
+				<details v-for="(r, i) in card.records" :key="'br' + i" class="jv-rec" :open="i === 0">
+					<summary>
+						<span class="jv-chev" aria-hidden="true"></span>
+						<span class="jv-rec-id">{{ r.doctype }} <b>{{ r.name }}</b></span>
+					</summary>
+					<div class="jv-rec-body">
+						<dl v-if="r.rows.length" class="jv-pcard-fields">
+							<template v-for="(f, j) in r.rows" :key="'bf' + j"><dt>{{ f.label }}</dt><dd>{{ f.value }}</dd></template>
+						</dl>
+						<div v-if="r.extra > 0" class="jv-pcard-more">+{{ r.extra }} more fields</div>
+						<div v-for="(t, ti) in (r.tables || [])" :key="'bt' + ti" class="jv-pcard-table">
+							<div class="jv-pcard-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>
+							<div class="jv-pcard-table-scroll">
+								<table>
+									<thead>
+										<tr><th v-for="(c, ci) in t.columns" :key="'bc' + ci">{{ c }}</th></tr>
+									</thead>
+									<tbody>
+										<tr v-for="(row, ri) in t.rows" :key="'brw' + ri">
+											<td v-for="(cell, di) in row.cells" :key="'bd' + di">{{ cell }}</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<div v-if="tableNote(t)" class="jv-pcard-more">{{ tableNote(t) }}</div>
+						</div>
+					</div>
+				</details>
+			</div>
+			<ul v-else class="jv-pcard-list">
 				<li v-for="(r, i) in card.rows" :key="i">{{ r.doctype }} <b>{{ r.name }}</b></li>
 				<li v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</li>
 			</ul>
-			<div v-for="(n, i) in card.notes" :key="'n' + i" class="jv-pcard-note">{{ n }}</div>
+			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</div>
 		</template>
 
 		<!-- bulk update: one collapsible from→to preview per record -->
@@ -219,7 +249,6 @@ function tableNote(t) {
 	.jv-rec-body .jv-pcard-lbl { grid-column: 1 / -1; }
 }
 @media (prefers-reduced-motion: reduce) { .jv-chev { transition: none; } }
-.jv-pcard-note { margin-top: 5px; color: var(--text-3); font-size: 12px; }
 .jv-pcard-body { margin: 6px 0 0; padding: 8px 10px; background: var(--surface-2); border-radius: 7px; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; font-size: 12px; line-height: 1.5; }
 .jv-pcard-details { margin-top: 8px; }
 .jv-pcard-details summary { cursor: pointer; color: var(--text-3); font-size: 11.5px; user-select: none; }

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -41,7 +41,7 @@ function tableNote(t) {
 			<dl v-if="card.rows.length" class="jv-pcard-fields">
 				<template v-for="(r, i) in card.rows" :key="i"><dt>{{ r.label }}</dt><dd>{{ r.value }}</dd></template>
 			</dl>
-			<div v-else class="jv-pcard-empty">No fields set.</div>
+			<div v-else-if="!(card.tables || []).length" class="jv-pcard-empty">No fields set.</div>
 			<!-- proposed child tables: "5 rows" would hide an invoice's line items -->
 			<div v-for="(t, ti) in (card.tables || [])" :key="'t' + ti" class="jv-pcard-table">
 				<div class="jv-pcard-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -1,10 +1,15 @@
 <script setup>
 // Renders the server-built "what will change" summary (F9) for a parked gated
 // write's confirmation card - replacing the raw-JSON dump. The structured card
-// comes from jarvis/chat/confirm_card.py (kind = create | update | verb | email |
-// method | batch_create) and is already perm-filtered + size-capped server-side.
-// All values render through escaped interpolation (no v-html); the raw dry-run
-// preview stays available behind a collapsed Details expander.
+// comes from jarvis/chat/confirm_card.py (kind = create | update | bulk_update |
+// verb | email | bulk_email | share | assign | skill | wiki | method |
+// batch_create) and is already perm-filtered + size-capped server-side. All values
+// render through escaped interpolation (no v-html); the raw dry-run preview stays
+// available behind a collapsed Details expander.
+//
+// A kind rendered here ALSO needs an entry in CARD_KINDS (@/lib/actionSummary):
+// pendingCardOf returns null for a kind not in that set and the SPA falls back to
+// the raw preview, so a branch added here alone is dead code.
 import { computed } from "vue"
 
 import { verbSentence } from "@/lib/actionSummary"
@@ -106,11 +111,139 @@ function tableNote(t) {
 			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</div>
 		</template>
 
-		<!-- email -->
+		<!-- email: cc/bcc/print format are v-if'd so an empty one adds no row. Without
+		     them "you could not see who was copied" stayed true no matter what the
+		     server sent. The body is a _MAX_BODY budget now, so it rides an expander -
+		     open by default: this is the one tool that cannot be recalled. -->
 		<template v-else-if="card.kind === 'email'">
 			<div class="jv-pcard-kv"><span>To</span><b>{{ card.to }}</b></div>
+			<div v-if="card.cc" class="jv-pcard-kv"><span>Cc</span><b>{{ card.cc }}</b></div>
+			<div v-if="card.bcc" class="jv-pcard-kv"><span>Bcc</span><b>{{ card.bcc }}</b></div>
 			<div class="jv-pcard-kv"><span>Subject</span><b>{{ card.subject }}</b></div>
-			<pre v-if="card.body" class="jv-pcard-body">{{ card.body }}</pre>
+			<div v-if="card.print_format" class="jv-pcard-kv"><span>Print format</span><b>{{ card.print_format }}</b></div>
+			<details v-if="card.body" class="jv-pcard-expand" open>
+				<summary>Message</summary>
+				<pre class="jv-pcard-body">{{ card.body }}</pre>
+			</details>
+		</template>
+
+		<!-- bulk email: a mail-merge. Every message has its OWN recipient, subject and
+		     body, so each gets its own expander - a count cannot stand in for 20
+		     distinct irreversible emails. -->
+		<template v-else-if="card.kind === 'bulk_email'">
+			<div class="jv-pcard-head">Send {{ card.count }} email<template v-if="card.count !== 1">s</template></div>
+			<p class="jv-pcard-caption">Each message has its own recipient and body. Click one to read it.</p>
+			<div class="jv-pcard-recs">
+				<details v-for="(m, i) in card.messages" :key="'me' + i" class="jv-rec" :open="i === 0">
+					<summary>
+						<span class="jv-chev" aria-hidden="true"></span>
+						<span class="jv-rec-id">{{ m.recipients }}</span>
+						<span v-if="m.subject" class="jv-rec-title">{{ m.subject }}</span>
+					</summary>
+					<div class="jv-rec-body">
+						<div v-if="m.name" class="jv-pcard-kv"><span>About</span><b>{{ m.name }}</b></div>
+						<div v-if="m.cc" class="jv-pcard-kv"><span>Cc</span><b>{{ m.cc }}</b></div>
+						<div v-if="m.bcc" class="jv-pcard-kv"><span>Bcc</span><b>{{ m.bcc }}</b></div>
+						<pre v-if="m.body" class="jv-pcard-body">{{ m.body }}</pre>
+					</div>
+				</details>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more · full list in Details</div>
+		</template>
+
+		<!-- share: grantee + the permission flags. "Read for one person" and
+		     "everyone + write + share" rendered identically before, and those grants are
+		     the exact reason share_doc gates. Flags are filtered IN THE EXPRESSION:
+		     v-for + v-if on one element is invalid in Vue 3 (v-if wins and cannot see
+		     the loop variable), which only warns at compile and throws at render. -->
+		<template v-else-if="card.kind === 'share'">
+			<div class="jv-pcard-head">Share {{ card.doctype }}<template v-if="card.count > 1"> · {{ card.count }} records</template></div>
+			<div class="jv-pcard-kv"><span>Shared with</span><b>{{ card.grantee }}</b></div>
+			<div class="jv-pcard-kv">
+				<span>Grants</span>
+				<b>
+					<span v-for="f in card.flags.filter((x) => x.on)" :key="f.label" class="jv-chip">{{ f.label }}</span>
+					<span v-if="!card.flags.some((x) => x.on)" class="jv-pcard-empty">None</span>
+				</b>
+			</div>
+			<div class="jv-pcard-kv"><span>Notify by email</span><b>{{ card.notify ? "Yes" : "No" }}</b></div>
+			<div v-if="(card.records || []).length" class="jv-pcard-recs">
+				<template v-for="(r, i) in card.records" :key="'sr' + i">
+					<details v-if="r.rows.length" class="jv-rec" :open="i === 0">
+						<summary>
+							<span class="jv-chev" aria-hidden="true"></span>
+							<span class="jv-rec-id">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+						</summary>
+						<dl class="jv-pcard-fields">
+							<template v-for="(f, j) in r.rows" :key="'sf' + j"><dt>{{ f.label }}</dt><dd>{{ f.value }}</dd></template>
+						</dl>
+					</details>
+					<div v-else class="jv-rec jv-rec-bare">
+						<span class="jv-rec-id">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</div>
+		</template>
+
+		<!-- assign: the assignee and the description that gets EMAILED to them -->
+		<template v-else-if="card.kind === 'assign'">
+			<div class="jv-pcard-head">Assign {{ card.doctype }}<template v-if="card.count > 1"> · {{ card.count }} records</template></div>
+			<div class="jv-pcard-kv"><span>Assign to</span><b>{{ card.assignee }}</b></div>
+			<div v-if="card.priority" class="jv-pcard-kv"><span>Priority</span><b>{{ card.priority }}</b></div>
+			<div v-if="card.date" class="jv-pcard-kv"><span>Due date</span><b>{{ card.date }}</b></div>
+			<div class="jv-pcard-kv"><span>Notify by email</span><b>{{ card.notify ? "Yes" : "No" }}</b></div>
+			<pre v-if="card.description" class="jv-pcard-body">{{ card.description }}</pre>
+			<div v-if="(card.records || []).length" class="jv-pcard-recs">
+				<template v-for="(r, i) in card.records" :key="'ar' + i">
+					<details v-if="r.rows.length" class="jv-rec" :open="i === 0">
+						<summary>
+							<span class="jv-chev" aria-hidden="true"></span>
+							<span class="jv-rec-id">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+						</summary>
+						<dl class="jv-pcard-fields">
+							<template v-for="(f, j) in r.rows" :key="'af' + j"><dt>{{ f.label }}</dt><dd>{{ f.value }}</dd></template>
+						</dl>
+					</details>
+					<div v-else class="jv-rec jv-rec-bare">
+						<span class="jv-rec-id">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</div>
+		</template>
+
+		<!-- skill: PERSISTENT AGENT INSTRUCTIONS. The card was the literal string
+		     "create_custom_skill". Scope is the tool's EFFECTIVE value, not the request. -->
+		<template v-else-if="card.kind === 'skill'">
+			<div class="jv-pcard-head">Create skill<template v-if="card.skill_name"> · {{ card.skill_name }}</template></div>
+			<div class="jv-pcard-kv"><span>Scope</span><b>{{ card.scope }}</b></div>
+			<div class="jv-pcard-kv"><span>User invocable</span><b>{{ card.user_invocable ? "Yes" : "No" }}</b></div>
+			<div v-if="card.description" class="jv-pcard-kv"><span>Description</span><b>{{ card.description }}</b></div>
+			<details v-if="card.instructions" class="jv-pcard-expand" open>
+				<summary>Instructions · shape every future session</summary>
+				<pre class="jv-pcard-body">{{ card.instructions }}</pre>
+			</details>
+		</template>
+
+		<!-- wiki: replace_body_md is a full rewrite and says so -->
+		<template v-else-if="card.kind === 'wiki'">
+			<div class="jv-pcard-head">Update wiki<template v-if="card.slug"> · {{ card.slug }}</template></div>
+			<div v-if="card.title" class="jv-pcard-kv"><span>Title</span><b>{{ card.title }}</b></div>
+			<div v-if="card.scope" class="jv-pcard-kv"><span>Scope</span><b>{{ card.scope }}</b></div>
+			<div v-if="card.page_type" class="jv-pcard-kv"><span>Page type</span><b>{{ card.page_type }}</b></div>
+			<div v-if="card.ref" class="jv-pcard-kv"><span>About</span><b>{{ card.ref }}</b></div>
+			<div v-if="card.summary" class="jv-pcard-kv"><span>Summary</span><b>{{ card.summary }}</b></div>
+			<div v-if="card.mode === 'replace'" class="jv-pcard-warn">Replaces the entire page body</div>
+			<div v-else-if="card.mode === 'append'" class="jv-pcard-caption">Appends a section; nothing already recorded is removed.</div>
+			<details v-if="card.body" class="jv-pcard-expand" :open="card.mode === 'replace'">
+				<summary>{{ card.mode === "replace" ? "New body" : "Added section" }}</summary>
+				<pre class="jv-pcard-body">{{ card.body }}</pre>
+			</details>
 		</template>
 
 		<!-- run_method -->
@@ -250,6 +383,15 @@ function tableNote(t) {
 }
 @media (prefers-reduced-motion: reduce) { .jv-chev { transition: none; } }
 .jv-pcard-body { margin: 6px 0 0; padding: 8px 10px; background: var(--surface-2); border-radius: 7px; white-space: pre-wrap; word-break: break-word; max-height: 200px; overflow-y: auto; font-size: 12px; line-height: 1.5; }
+/* share: one chip per GRANTED permission (filtered server-side value, not the request) */
+.jv-chip { display: inline-block; margin-left: 4px; padding: 1px 7px; border-radius: 999px; background: var(--surface-2); border: 1px solid var(--border); font-size: 11px; font-weight: 500; color: var(--text); }
+/* wiki: a full-body replace is a rewrite, not an edit - it must not read as routine */
+.jv-pcard-warn { margin-top: 6px; padding: 5px 9px; border-radius: 6px; background: var(--surface-2); border-left: 2px solid var(--red, var(--text-3)); color: var(--text); font-weight: 500; }
+/* long-form bodies (skill instructions, wiki body, one email) - an 8k body must not
+   dominate the card, so it collapses; the expander itself stays visible */
+.jv-pcard-expand { margin-top: 8px; }
+.jv-pcard-expand summary { cursor: pointer; color: var(--text-3); font-size: 11.5px; user-select: none; }
+.jv-pcard-expand .jv-pcard-body { max-height: 260px; }
 .jv-pcard-details { margin-top: 8px; }
 .jv-pcard-details summary { cursor: pointer; color: var(--text-3); font-size: 11.5px; user-select: none; }
 .jv-pcard-details pre { margin: 6px 0 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; max-height: 260px; overflow-y: auto; }

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -74,12 +74,36 @@ function tableNote(t) {
 		</template>
 
 		<!-- verb: submit / cancel / delete / amend / apply_workflow_action -->
+		<!-- ORDER IS LOAD-BEARING: records div -> targets <ul v-else-if> -> +N more.
+		     v-else-if chains to the immediately preceding sibling carrying a v-if, so
+		     putting the +N more div between them would chain the <ul> to IT - and with
+		     extra === 0 (always, via the F16 batch cap) every bulk card would render
+		     its targets twice, once as records and once as the old list. -->
 		<template v-else-if="card.kind === 'verb'">
 			<div class="jv-pcard-verb">{{ sentence }}</div>
-			<ul v-if="card.count > 1 && card.targets.length" class="jv-pcard-list">
+			<div v-if="(card.records || []).length" class="jv-pcard-recs">
+				<template v-for="(r, i) in card.records" :key="'vr' + i">
+					<details v-if="r.rows.length" class="jv-rec" :open="i === 0">
+						<summary>
+							<span class="jv-chev" aria-hidden="true"></span>
+							<span class="jv-rec-id">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+						</summary>
+						<dl class="jv-pcard-fields">
+							<template v-for="(f, j) in r.rows" :key="'vf' + j"><dt>{{ f.label }}</dt><dd>{{ f.value }}</dd></template>
+						</dl>
+					</details>
+					<div v-else class="jv-rec jv-rec-bare">
+						<span class="jv-rec-id">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<ul v-else-if="card.count > 1 && card.targets.length" class="jv-pcard-list">
 				<li v-for="(t, i) in card.targets" :key="i">{{ t }}</li>
 				<li v-if="card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</li>
 			</ul>
+			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pcard-more">+{{ card.extra }} more</div>
 		</template>
 
 		<!-- email -->
@@ -183,6 +207,9 @@ function tableNote(t) {
 .jv-rec > summary:focus-visible { outline: 2px solid var(--blue, var(--text)); outline-offset: -2px; }
 .jv-chev { flex: none; width: 7px; height: 7px; border-right: 1.6px solid var(--text-3); border-bottom: 1.6px solid var(--text-3); transform: rotate(-45deg); transition: transform .15s ease; margin-left: 2px; }
 .jv-rec[open] > summary .jv-chev { transform: rotate(45deg); }
+/* verb: a name-only record (missing or unreadable) gets no expander, so it needs
+   the <summary> row's metrics by hand to line up with its expandable siblings. */
+.jv-rec-bare { display: flex; align-items: center; gap: 9px; min-height: 38px; padding: 6px 2px 6px 18px; }
 .jv-rec-id { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); font-weight: 500; flex: none; }
 .jv-rec-title { font-size: 11.5px; color: var(--text); overflow-wrap: anywhere; }
 .jv-rec-fields { font-size: 11.5px; color: var(--text-3); margin-left: auto; text-align: right; overflow-wrap: anywhere; }

--- a/frontend/src/components/PendingCard.vue
+++ b/frontend/src/components/PendingCard.vue
@@ -17,6 +17,20 @@ const props = defineProps({
 
 const sentence = computed(() =>
 	props.card.kind === "verb" ? verbSentence(props.card) : "")
+
+// The remainder line for a proposed child table. A helper rather than chained
+// <template>s: with only extra_columns set, an inline chain renders a dangling
+// " · ". unknown_columns MUST surface - the server counts keys it dropped rather
+// than rendering them (they are not real child fields, so the save discards
+// them), and a count nobody sees makes a silent drop silent again.
+function tableNote(t) {
+	const parts = []
+	if (t.extra > 0) parts.push(`+${t.extra} more rows`)
+	if (t.extra_columns > 0) parts.push(`+${t.extra_columns} more columns`)
+	if (t.unknown_columns > 0)
+		parts.push(`${t.unknown_columns} unrecognized field${t.unknown_columns === 1 ? "" : "s"} ignored`)
+	return parts.join(" · ")
+}
 </script>
 
 <template>
@@ -28,11 +42,28 @@ const sentence = computed(() =>
 				<template v-for="(r, i) in card.rows" :key="i"><dt>{{ r.label }}</dt><dd>{{ r.value }}</dd></template>
 			</dl>
 			<div v-else class="jv-pcard-empty">No fields set.</div>
+			<!-- proposed child tables: "5 rows" would hide an invoice's line items -->
+			<div v-for="(t, ti) in (card.tables || [])" :key="'t' + ti" class="jv-pcard-table">
+				<div class="jv-pcard-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>
+				<div class="jv-pcard-table-scroll">
+					<table>
+						<thead>
+							<tr><th v-for="(c, ci) in t.columns" :key="'c' + ci">{{ c }}</th></tr>
+						</thead>
+						<tbody>
+							<tr v-for="(r, ri) in t.rows" :key="'r' + ri">
+								<td v-for="(cell, di) in r.cells" :key="'d' + di">{{ cell }}</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-if="tableNote(t)" class="jv-pcard-more">{{ tableNote(t) }}</div>
+			</div>
 		</template>
 
 		<!-- update: from -> to diff -->
 		<template v-else-if="card.kind === 'update'">
-			<div class="jv-pcard-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<div class="jv-pcard-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template><template v-if="card.title"> · {{ card.title }}</template></div>
 			<div v-for="(d, i) in card.diff" :key="i" class="jv-pcard-diffrow">
 				<span class="jv-pcard-lbl">{{ d.label }}</span>
 				<span class="jv-pcard-from">{{ d.from || "(empty)" }}</span>
@@ -85,6 +116,7 @@ const sentence = computed(() =>
 					<summary>
 						<span class="jv-chev" aria-hidden="true"></span>
 						<span class="jv-rec-id">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-rec-title">{{ r.title }}</span>
 						<span v-if="r.fields?.length" class="jv-rec-fields">{{ r.fields.join(" · ") }}</span>
 					</summary>
 					<div class="jv-rec-body">
@@ -127,6 +159,17 @@ const sentence = computed(() =>
 .jv-pcard-list { margin: 4px 0 0; padding-left: 18px; }
 .jv-pcard-list li { padding: 1px 0; overflow-wrap: anywhere; }
 .jv-pcard-more { list-style: none; color: var(--text-3); }
+/* create: a proposed child table, scrolling inside its own box so the card never
+   scrolls the page sideways */
+.jv-pcard-table { margin-top: 10px; }
+.jv-pcard-table-head { font-size: 11.5px; color: var(--text-3); margin-bottom: 4px; }
+.jv-pcard-table-scroll { overflow-x: auto; max-height: 240px; overflow-y: auto; }
+.jv-pcard-table table { border-collapse: collapse; width: 100%; font-size: 12px; }
+.jv-pcard-table th, .jv-pcard-table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--surface-2); white-space: nowrap; }
+.jv-pcard-table th { color: var(--text-3); font-weight: 500; }
+.jv-pcard-table td { font-variant-numeric: tabular-nums; }
+/* scoped: .jv-pcard-more is shared with the verb/batch_create <li>s */
+.jv-pcard-table .jv-pcard-more { font-size: 11.5px; margin-top: 4px; }
 /* bulk update: collapsible per-record from→to list */
 .jv-pcard-sub { font-weight: 400; color: var(--text-3); }
 .jv-pcard-caption { font-size: 11.5px; color: var(--text-3); margin: 0 0 8px; }
@@ -141,6 +184,7 @@ const sentence = computed(() =>
 .jv-chev { flex: none; width: 7px; height: 7px; border-right: 1.6px solid var(--text-3); border-bottom: 1.6px solid var(--text-3); transform: rotate(-45deg); transition: transform .15s ease; margin-left: 2px; }
 .jv-rec[open] > summary .jv-chev { transform: rotate(45deg); }
 .jv-rec-id { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--text); font-weight: 500; flex: none; }
+.jv-rec-title { font-size: 11.5px; color: var(--text); overflow-wrap: anywhere; }
 .jv-rec-fields { font-size: 11.5px; color: var(--text-3); margin-left: auto; text-align: right; overflow-wrap: anywhere; }
 .jv-rec-body { padding: 2px 2px 8px 19px; }
 @media (max-width: 460px) {

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -188,12 +188,16 @@ export function receiptView(tool, args, result, outcome) {
         : argCount(args)
 
   // Target links (create keeps each row's own doctype; email targets have no doc).
+  // A DELETED record gets no link: the row is gone, so the shortcut would open a
+  // 404. Only when it actually ran, though - a discarded or failed delete left the
+  // record alive, and that one is worth opening.
+  const isGoneDelete = tool === "delete_doc" && outcome === "confirmed"
   let targets
   if (Array.isArray(data.created)) {
     targets = data.created
       .filter((d) => d && d.name)
       .map((d) => ({ name: d.name, url: docUrl(d.doctype || doctype, d.name) }))
-  } else if (isEmail) {
+  } else if (isEmail || isGoneDelete) {
     targets = names.map((n) => ({ name: n, url: "" }))
   } else {
     targets = names.map((n) => ({ name: n, url: docUrl(doctype, n) }))

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -36,17 +36,23 @@ export function summarize(model, action = {}) {
 }
 
 // A create_docs batch parks one card. Its dry-run preview carries the created
-// records ({doctype, name}) and the model's reuse notes. Turn that into the flat
-// action lines the pending card renders as bullets. Pure; returns null when the
-// preview is not a batch (a single-doc dry-run, or a described-intent card).
+// records ({doctype, name}). Turn that into the flat action lines the pending card
+// renders as bullets. Pure; returns null when the preview is not a batch (a
+// single-doc dry-run, or a described-intent card).
+//
+// ``would.notes`` is deliberately NOT returned. It is a tool argument the MODEL
+// writes (jarvis/tools/create_doc.py), and this is the rendering that runs when the
+// server built no card - including when build_card FAILS. Rendered here as
+// unattributed bullets it reads as system truth, letting a prompt-injected or simply
+// confused agent caption its own confirmation ("these already exist - confirming
+// changes nothing") above a write that inserts 20 rows. The card is the human's
+// INDEPENDENT check on the agent; escaped rendering stops XSS, not lying. The agent
+// can still say what it likes in chat, where the claim is attributed to it.
 export function batchFromPreview(preview) {
   const would = preview && preview.would
   if (!would || typeof would !== "object" || !Array.isArray(would.created)) return null
   return {
     actions: would.created.map((d) => ({ doctype: d.doctype, name: d.name })),
-    notes: Array.isArray(would.notes)
-      ? would.notes.filter((n) => String(n ?? "").trim() !== "")
-      : [],
   }
 }
 

--- a/frontend/src/lib/actionSummary.js
+++ b/frontend/src/lib/actionSummary.js
@@ -64,7 +64,8 @@ export function batchFromPreview(preview) {
 // expiry state instead of the raw dry-run JSON. A missing/unknown card -> null, and
 // the card falls back to the summary + raw-preview rendering.
 
-const CARD_KINDS = new Set(["create", "update", "bulk_update", "verb", "email", "method", "batch_create"])
+const CARD_KINDS = new Set(["create", "update", "bulk_update", "verb", "email", "method",
+  "batch_create", "bulk_email", "share", "assign", "skill", "wiki"])
 
 // The structured card for a parked action ({kind, ...}), or null when the server
 // built none (an older token, or an uncovered tool shape).

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -126,6 +126,17 @@ test("pendingCardOf: returns the structured card for a known kind", () => {
   assert.deepEqual(pendingCardOf({ preview: { card } }), card)
 })
 
+// CARD_KINDS IS THE GATE. pendingCardOf returns null for a kind not in the set and
+// the SPA silently falls back to the raw preview, so a kind build_card emits but the
+// whitelist omits ships as a no-op: the card renders exactly as before, every test
+// stays green, and nothing says so. One assertion per kind the server can emit.
+test("pendingCardOf: every kind build_card emits is whitelisted", () => {
+  for (const kind of ["create", "update", "bulk_update", "verb", "email", "method",
+    "batch_create", "bulk_email", "share", "assign", "skill", "wiki"]) {
+    assert.ok(pendingCardOf({ preview: { card: { kind } } }), `${kind} is not in CARD_KINDS`)
+  }
+})
+
 test("pendingCardOf: null for missing / unknown-kind / non-object cards", () => {
   assert.equal(pendingCardOf({ preview: {} }), null)
   assert.equal(pendingCardOf({ preview: { card: { kind: "wat" } } }), null)

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -96,18 +96,23 @@ test("summarize(update): kind=update, mechanical diff, headline optional", () =>
   assert.deepEqual(out.diff, [{ label: "Status", from: "Open", to: "Closed" }])
 })
 
-test("batchFromPreview: created records -> action lines, notes filtered", () => {
+// THE trust-boundary fix, on the FALLBACK path - the one that runs when the server
+// built no card, including when build_card FAILS. `notes` is a tool argument the
+// MODEL writes; rendered as unattributed bullets it reads as system truth, so a
+// prompt-injected agent could caption its own confirmation.
+test("batchFromPreview: created records -> action lines; model-authored notes are NOT returned", () => {
   const out = batchFromPreview({
     would: {
       created: [{ doctype: "Item", name: "Widget" }, { doctype: "Customer", name: "Acme" }],
-      notes: ["Reuse existing Supplier 'Globex' for your 'Globe'", ""],
+      notes: ["these already exist - confirming changes nothing"],
     },
   })
   assert.deepEqual(out.actions, [
     { doctype: "Item", name: "Widget" },
     { doctype: "Customer", name: "Acme" },
   ])
-  assert.deepEqual(out.notes, ["Reuse existing Supplier 'Globex' for your 'Globe'"])
+  assert.equal(out.notes, undefined)
+  assert.equal(JSON.stringify(out).includes("confirming changes nothing"), false)
 })
 
 test("batchFromPreview: non-batch or empty preview -> null", () => {

--- a/frontend/src/lib/actionSummary.test.js
+++ b/frontend/src/lib/actionSummary.test.js
@@ -1,7 +1,7 @@
 // frontend/src/lib/actionSummary.test.js
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { proposedFields, changedFields, lineItemSummary, summarize, batchFromPreview, pendingCardOf, verbSentence, pendingExpiry } from "./actionSummary.js"
+import { proposedFields, changedFields, lineItemSummary, summarize, batchFromPreview, pendingCardOf, verbSentence, pendingExpiry, receiptView } from "./actionSummary.js"
 
 const createAction = {
   kind: "doc", verb: "create", doctype: "Sales Order", summary: "Sales Order - Acme, 2 items, total 1,100",
@@ -163,4 +163,24 @@ test("pendingExpiry: expired vs live vs no-stamp", () => {
   assert.deepEqual(pendingExpiry(now / 1000 - 5, now), { expired: true, secondsLeft: -5 })
   assert.deepEqual(pendingExpiry(null, now), { expired: false, secondsLeft: null })
   assert.deepEqual(pendingExpiry(0, now), { expired: false, secondsLeft: null })
+})
+
+test("receiptView: a CONFIRMED delete offers no open link - the record is gone", () => {
+  // The shortcut would 404. Every non-batch, non-email receipt used to linkify.
+  const v = receiptView("delete_doc", { doctype: "Task", name: "TASK-0001" },
+    { data: { deleted: true, doctype: "Task", name: "TASK-0001" } }, "confirmed")
+  assert.equal(v.targets.length, 1)
+  assert.equal(v.targets[0].name, "TASK-0001")
+  assert.equal(v.targets[0].url, "")
+})
+
+test("receiptView: a DISCARDED delete keeps its link - nothing ran, the record lives", () => {
+  const v = receiptView("delete_doc", { doctype: "Task", name: "TASK-0001" }, {}, "discarded")
+  assert.ok(v.targets[0].url, "a record that still exists must stay openable")
+})
+
+test("receiptView: a create links the record it made", () => {
+  const v = receiptView("create_doc", { doctype: "Task" },
+    { data: { doctype: "Task", name: "TASK-0002" } }, "confirmed")
+  assert.ok(v.targets[0].url.includes("TASK-0002"))
 })

--- a/frontend/src/notify/globalNotifier.js
+++ b/frontend/src/notify/globalNotifier.js
@@ -128,6 +128,9 @@ export function attachGlobalNotifier({ socket, router }) {
 					store.applyRemoteNew()
 				}
 				const title = convTitle(conv) || "Jarvis"
+				// A stop is the user's own click, seconds ago - the dot is useful, a
+				// notification saying "Reply ready" for the reply they just killed is not.
+				if (p.stopped) return
 				const body =
 					p.kind === "run:error"
 						? `Jarvis hit an error in ${convTitle(conv) || "your chat"}`

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -297,7 +297,7 @@
 												{{ summaryState.model && summaryState.model.applying ? 'Saving...' : (activeAction.verb === 'update' ? 'Confirm update' : 'Confirm create') }}
 											</button>
 											<button class="jv-action-2nd" :disabled="!summaryState.model" @click="previewSummary">Preview</button>
-											<button class="jv-action-2nd" @click="openDraftPanel({ verb: activeAction.verb || 'create', ...activeAction })">Edit</button>
+											<button class="jv-action-2nd" :disabled="!summaryState.model" @click="openDraftPanel({ verb: activeAction.verb || 'create', ...activeAction })">Edit</button>
 										</div>
 										<div class="jv-summary-hint">Want a change? just tell me, e.g. "make Widget A qty 12".</div>
 									</div>
@@ -2126,6 +2126,27 @@ function _panelField(metaField, value) {
 async function buildDraftModel(a) {
 	if (!a || a.kind !== "doc" || !a.doctype) return
 	const verb = a.verb === "update" ? "update" : "create"
+	// An action block we cannot render must FAIL, not render empty - a blank card
+	// reads as "Jarvis did not try" rather than "Jarvis emitted a shape I cannot
+	// draw". `docs` is a create_doc batch payload, not an action key (AGENTS.md:122
+	// documents fields+tables for ONE record) - throw on it for EITHER verb: a
+	// {"verb":"update","docs":[...]} fusion otherwise builds an empty diff, renders
+	// "No field changes." with Confirm ENABLED, and sends update_doc(dt, "", {}).
+	// A hybrid carrying BOTH fields and docs throws too: rendering the fields and
+	// dropping the docs is a half-card the user confirms believing it is the set.
+	if (Array.isArray(a.docs)) {
+		const err = new Error(
+			"This draft carries a `docs` batch, which is a create_doc payload rather than a card. Ask me to apply them as a batch.")
+		err.jvUserMessage = err.message
+		throw err
+	}
+	// Create-only: a fieldless UPDATE block legitimately renders "No field changes.",
+	// and a tables-only create is legal, so neither may throw.
+	if (verb === "create" && !(a.fields || []).length && !(a.tables || []).length) {
+		const err = new Error("This draft has no fields to show.")
+		err.jvUserMessage = err.message
+		throw err
+	}
 	let meta
 	try { meta = await _formMeta(a.doctype) } catch (e) { return } // no meta → no panel (old card still shows)
 	let base = { values: {}, tables: {} }
@@ -2191,7 +2212,11 @@ async function buildDraftModel(a) {
 
 // Open the editable panel for an action, via the shared buildDraftModel.
 async function openDraftPanel(a) {
-	const model = await buildDraftModel(a)
+	let model
+	// Deliberate: swallow to the SAME dead-end the old `if (!model) return` gave, so
+	// a guard throw cannot escape a @click handler. The summary card already shows
+	// the error. Do not "fix" this into a rethrow.
+	try { model = await buildDraftModel(a) } catch (e) { return }
 	if (!model) return
 	draftPanel.value = model
 }
@@ -2276,7 +2301,8 @@ async function ensureActionSummary(a) {
 	try {
 		model = await buildDraftModel({ verb: a.verb || "create", ...a })
 	} catch (e) {
-		if (summaryState.value.key === key) summaryState.value = { key, model: null, view: null, error: "Could not load this draft. Tell me to try again." }
+		const msg = (e && e.jvUserMessage) || "Could not load this draft. Tell me to try again."
+		if (summaryState.value.key === key) summaryState.value = { key, model: null, view: null, error: msg }
 		return
 	}
 	if (!model) {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -475,7 +475,6 @@
 									<div v-if="pendingNoteOf(pa)" class="jv-pending-note">{{ pendingNoteOf(pa) }}</div>
 									<ul v-if="pendingBatchOf(pa)" class="jv-pending-batch">
 										<li v-for="(a, i) in pendingBatchOf(pa).actions" :key="'a' + i">Create <b>{{ a.doctype }}</b> "{{ a.name }}"</li>
-										<li v-for="(n, i) in pendingBatchOf(pa).notes" :key="'n' + i" class="jv-pending-batch-note">{{ n }}</li>
 									</ul>
 									<pre v-else-if="pendingPreviewOf(pa)" class="jv-pending-preview">{{ pendingPreviewOf(pa) }}</pre>
 								</template>
@@ -2439,8 +2438,9 @@ function pendingPreviewOf(pa) {
 	if (w == null) return ""
 	return typeof w === "string" ? w : prettyJson(w)
 }
-// A create_docs card renders as bullet lines (creates + reuse notes) rather than
+// A create_docs card renders as bullet lines (one per created record) rather than
 // a raw JSON dump. Returns null for every other tool, so the <pre> fallback runs.
+// The model-authored notes are NOT rendered here - see batchFromPreview.
 function pendingBatchOf(pa) {
 	if (!pa || pa.tool !== "create_docs") return null
 	return batchFromPreview(pa.preview)
@@ -4979,7 +4979,6 @@ onUnmounted(() => {
 .jv-pending-preview { margin: 0; padding: 9px 11px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; line-height: 1.5; color: var(--text); white-space: pre-wrap; word-break: break-word; max-height: 260px; overflow-y: auto; }
 .jv-pending-batch { margin: 0 14px 8px; padding-left: 18px; font-size: 12.5px; color: var(--text-2); }
 .jv-pending-batch li { margin: 2px 0; }
-.jv-pending-batch-note { list-style: none; margin-left: -18px; color: var(--text-3); }
 .jv-action-primary:disabled, .jv-action-discard:disabled { opacity: .55; cursor: default; }
 /* rollout-window note shown for a legacy gated-write / email card whose own
    action button was removed (issue #186, #12/#13). */

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -287,19 +287,29 @@
 												</div>
 											</div>
 										</div>
-										<div v-else-if="summaryState.error" class="jv-summary-body jv-summary-loading">{{ summaryState.error }}</div>
+										<!-- A draft we could not build is a FAILURE, not a pending state: style
+										     it as one (it shared jv-summary-loading with "Preparing summary..."
+										     and read as a placeholder), and drop the footer entirely - three
+										     disabled buttons on a dead card are worse than no buttons, because
+										     they look like something you should be able to press. -->
+										<div v-else-if="summaryState.error" role="alert" class="jv-summary-body jv-summary-err">
+											<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--red)" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><path d="M12 9v4M12 17h.01" /></svg>
+											<span>{{ summaryState.error }}</span>
+										</div>
 										<div v-else class="jv-summary-body jv-summary-loading">Preparing summary...</div>
 
 										<div v-if="summaryState.model && summaryState.model.error" style="margin:0 14px 10px"><ActionError :error="summaryState.model.error" /></div>
 
-										<div class="jv-action-foot">
-											<button class="jv-action-primary" :disabled="!summaryState.model || (summaryState.model && summaryState.model.applying) || convStreaming" :title="convStreaming ? 'Waiting for the current reply to finish' : ''" @click="confirmSummary">
-												{{ summaryState.model && summaryState.model.applying ? 'Saving...' : (activeAction.verb === 'update' ? 'Confirm update' : 'Confirm create') }}
-											</button>
-											<button class="jv-action-2nd" :disabled="!summaryState.model" @click="previewSummary">Preview</button>
-											<button class="jv-action-2nd" :disabled="!summaryState.model" @click="openDraftPanel({ verb: activeAction.verb || 'create', ...activeAction })">Edit</button>
-										</div>
-										<div class="jv-summary-hint">Want a change? just tell me, e.g. "make Widget A qty 12".</div>
+										<template v-if="!summaryState.error">
+											<div class="jv-action-foot">
+												<button class="jv-action-primary" :disabled="!summaryState.model || (summaryState.model && summaryState.model.applying) || convStreaming" :title="convStreaming ? 'Waiting for the current reply to finish' : ''" @click="confirmSummary">
+													{{ summaryState.model && summaryState.model.applying ? 'Saving...' : (activeAction.verb === 'update' ? 'Confirm update' : 'Confirm create') }}
+												</button>
+												<button class="jv-action-2nd" :disabled="!summaryState.model" @click="previewSummary">Preview</button>
+												<button class="jv-action-2nd" :disabled="!summaryState.model" @click="openDraftPanel({ verb: activeAction.verb || 'create', ...activeAction })">Edit</button>
+											</div>
+											<div class="jv-summary-hint">Want a change? just tell me, e.g. "make Widget A qty 12".</div>
+										</template>
 									</div>
 									<!-- submit/cancel/delete/amend are gated writes (issue #186): the real
 									     confirmation is the action:pending card rendered below the thread,
@@ -5029,6 +5039,10 @@ onUnmounted(() => {
 .jv-summary-arrow { color: var(--text-3); }
 .jv-summary-to { color: var(--green); font-weight: 600; }
 .jv-summary-nochange, .jv-summary-loading { font-size: 12.5px; color: var(--text-3); }
+/* A draft that could not be built. Deliberately NOT jv-summary-loading's muted
+   grey: this is a dead end, not a pending state, and it read as a placeholder. */
+.jv-summary-err { display: flex; align-items: flex-start; gap: 8px; font-size: 12.5px; color: var(--red); line-height: 1.45; }
+.jv-summary-err svg { flex: none; margin-top: 1px; }
 .jv-summary-table { border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
 .jv-summary-table-h { padding: 7px 10px; background: var(--surface-2); font-size: 12px; font-weight: 650; color: var(--text-2); border-bottom: 1px solid var(--border); }
 .jv-summary-gridwrap { overflow-x: auto; }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -223,6 +223,12 @@
 									</div>
 								</div>
 								<div v-else class="jv-md" style="font-size:14px;line-height:1.6;color:var(--text);" v-html="render(m.content)"></div>
+								<!-- The user stopped this reply. A SIBLING of the body, not part of
+								     it: gated only on `stopped`, so it shows for a partial stop
+								     (content present) and an empty one alike, and the renderer can
+								     never mangle it. Muted, never an error tone - a deliberate stop
+								     is not a failure. -->
+								<div v-if="m.stopped" class="jv-stopped">You stopped this reply.</div>
 								<!-- rich action card the agent emits (doc confirm / email draft) -->
 								<template v-if="actionFor === m.name && activeAction">
 									<!-- email draft -->
@@ -3794,7 +3800,11 @@ function stopRun() {
 	if (m) {
 		m.streaming = false
 		if (m.name) stoppedMsgIds.value.add(m.name)
-		if (!m.content) m.content = "_Stopped._"
+		// A stop is a state of the turn, not prose: leave whatever streamed
+		// alone and flag the row. The marker renders from `stopped`, so a
+		// mid-sentence stop no longer reads as a complete answer. The server
+		// sets the same flag, so the marker survives a reload.
+		m.stopped = true
 	}
 	waiting.value = false
 	sending.value = false
@@ -4605,6 +4615,10 @@ onUnmounted(() => {
 /* day separators between message groups (UX #23) */
 .jv-daydivider { display: flex; align-items: center; justify-content: center; margin: 6px 0 2px; }
 .jv-daydivider span { font-size: 11px; font-weight: 550; color: var(--text-3); background: var(--surface-1); border: 1px solid var(--border); border-radius: 999px; padding: 2px 10px; }
+/* "You stopped this reply." - a muted rule under the body, in the same
+   vocabulary as .jv-msgtime. Deliberately NOT --red: the user chose to stop,
+   and dressing their own click as a failure is a lie about what happened. */
+.jv-stopped { margin-top: 8px; padding-top: 7px; border-top: 1px solid var(--border); font-size: 11.5px; color: var(--text-3); }
 .jv-md :deep(.jv-md-link) { color: var(--cta); text-decoration: none; font-weight: 500; }
 /* Auto-linked document IDs → open the record in ERPNext Desk. Dashed underline
    marks them as record links, distinct from plain markdown links. */

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -629,7 +629,8 @@ def _describe_call(tool: str, args: dict) -> str:
 		return " ".join(str(p) for p in parts)
 	parts = [tool]
 	for key in ("doctype", "name", "docname", "target_doctype", "target_name",
-				"method", "action", "recipients", "to", "subject"):
+				"method", "action", "recipients", "to", "subject",
+				"user", "skill_name", "slug", "title", "scope"):
 		val = a.get(key)
 		if val:
 			parts.append(f"{key}={val}")

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -278,3 +278,26 @@ def summary_rows(doctype: str, name: str) -> dict | None:
 	except Exception:
 		title = ""
 	return {"title": title, "rows": rows}
+
+
+def values_rows(meta, values: dict, limit: int = _MAX_VAL) -> dict:
+	"""``{"rows", "extra"}`` for PROPOSED content (a create's values, an email body).
+
+	Renders EVERY key, in caller order, capped with an explicit remainder. Never
+	filtered to the floor: a proposed field outside the floor is one the save will
+	write, so hiding it would let a human approve a value they never saw. Caller
+	order is preserved so the card stays comparable against the request.
+
+	No perm filter is possible or needed - the values are the caller's own args.
+	"""
+	if not isinstance(values, dict):
+		return {"rows": [], "extra": 0}
+	rows = []
+	keys = list(values)
+	for fieldname in keys[:_MAX_ROWS]:
+		df = meta.get_field(fieldname) if meta else None
+		label = df.label if df and df.label else fieldname
+		value = values.get(fieldname)
+		shown = "[hidden]" if is_secret(meta, fieldname) else fmt(value, df, None, limit)
+		rows.append({"label": label, "value": shown})
+	return {"rows": rows, "extra": max(0, len(keys) - len(rows))}

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -301,3 +301,71 @@ def values_rows(meta, values: dict, limit: int = _MAX_VAL) -> dict:
 		shown = "[hidden]" if is_secret(meta, fieldname) else fmt(value, df, None, limit)
 		rows.append({"label": label, "value": shown})
 	return {"rows": rows, "extra": max(0, len(keys) - len(rows))}
+
+
+def table_rows(meta, fieldname: str, rows: list) -> dict | None:
+	"""A PROPOSED child table as a real table, or None when there is nothing to show.
+
+	Columns are the child doctype's ``in_list_view`` order UNION every key the caller
+	actually set. in_list_view alone would re-break "proposed content renders whole"
+	inside this primitive: Sales Invoice Item's list columns are item/qty/rate/amount,
+	so a batch also setting income_account on every row would write it invisibly.
+
+	A key that is not a real child field is DROPPED by the save (it fails
+	valid_columns), so it is counted in ``unknown_columns`` rather than rendered as
+	a value that will persist.
+
+	STORED child tables keep "N rows" (fmt's list branch) - a delete card does not
+	need line items to identify the order.
+	"""
+	if not meta or not isinstance(rows, list) or not rows:
+		return None
+	df = meta.get_field(fieldname)
+	if df is None or df.fieldtype not in _TABLE_FIELDTYPES or not df.options:
+		return None
+	try:
+		child = frappe.get_meta(df.options)
+	except Exception:
+		return None
+
+	proposed: list[str] = []
+	unknown: set[str] = set()  # a SET: an unknown key never enters `proposed`, so a
+	# counter would re-increment once per row (20 rows -> unknown_columns=20).
+	for row in rows:
+		if not isinstance(row, dict):
+			continue
+		for key in row:
+			if key in proposed or key in unknown:
+				continue
+			if child.get_field(key) is None:
+				unknown.add(key)
+				continue
+			proposed.append(key)
+
+	listed = [d.fieldname for d in child.fields if d.in_list_view and d.fieldname in proposed]
+	columns = listed + [f for f in proposed if f not in listed]
+	shown_cols = columns[:_MAX_COLS]  # NOT _MAX_ROWS - 20 columns is an unusable table
+
+	out_rows = []
+	for row in rows[:_MAX_ROWS]:
+		if not isinstance(row, dict):
+			continue
+		cells = []
+		for key in shown_cols:
+			cdf = child.get_field(key)
+			value = row.get(key)
+			cells.append("[hidden]" if is_secret(child, key) else fmt(value, cdf))
+		out_rows.append({"cells": cells})
+
+	return {
+		"label": df.label or fieldname,
+		"count": len(rows),
+		# ``columns`` is labels (what the card renders); ``fieldnames`` is the
+		# parallel machine-readable list - tests assert on it, and phases 3-4 use it.
+		"columns": [(child.get_field(c).label or c) for c in shown_cols],
+		"fieldnames": shown_cols,
+		"rows": out_rows,
+		"extra": max(0, len(rows) - len(out_rows)),
+		"extra_columns": max(0, len(columns) - len(shown_cols)),
+		"unknown_columns": len(unknown),
+	}

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -95,3 +95,59 @@ def fmt(value, df=None, doc=None, limit: int = _MAX_VAL) -> str:
 			# in get_field_precision (meta.py:936).
 			out = "" if value is None else cstr(value)
 	return out if len(out) <= limit else out[: limit - 1] + "…"
+
+
+def _cast_date(value):
+	# getdate(None) and getdate("") return TODAY (frappe/utils/data.py:125-126), so
+	# a bare getdate would make "set the due date to today" on an unset field compare
+	# equal to itself and VANISH from the card. Empties must stay empty.
+	if value in (None, ""):
+		return None
+	return getdate(value)
+
+
+def _cast_datetime(value):
+	# get_datetime(None) returns now() (data.py:164-165) - two calls microseconds
+	# apart are unequal, so None vs None would render a phantom "(empty) -> (empty)".
+	if value in (None, ""):
+		return None
+	out = get_datetime(value)
+	if out is None:
+		# get_datetime returns None for an INVALID string rather than raising, so two
+		# different pieces of garbage would compare equal. Force the changed branch.
+		raise ValueError(f"not a datetime: {value!r}")
+	return out
+
+
+# Cast a value the way the SAVE would, per fieldtype. Deliberately NOT the display
+# form: fmt_money at precision 2 renders 100.005 and 100.001 identically, so a
+# display compare drops a REAL change from a gated card. flt takes no precision
+# here - rounding is exactly what caused that bug.
+_CAST = {
+	"Currency": flt,
+	"Float": flt,
+	"Percent": flt,
+	"Int": cint,
+	"Long Int": cint,
+	"Check": cint,
+	"Date": _cast_date,
+	"Datetime": _cast_datetime,
+}
+
+
+def same_value(a, b, df=None) -> bool:
+	"""True when saving ``b`` over a stored ``a`` would not change the stored value.
+
+	Answers the question the no-op guard actually exists for, rather than "do these
+	two render the same". Comparing DISPLAY forms hides real changes; comparing raw
+	values shows phantom ones (the DB holds a typed 100.0, the model sends "100").
+	Casting both sides the way the save does gets both right.
+
+	An uncastable value counts as CHANGED - never hide a row because we could not
+	compare it.
+	"""
+	cast = _CAST.get(_fieldtype(df), cstr)
+	try:
+		return cast(a) == cast(b)
+	except Exception:
+		return False

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -98,10 +98,11 @@ def fmt(value, df=None, doc=None, limit: int = _MAX_VAL) -> str:
 
 
 def _cast_date(value):
-	# getdate(None) and getdate("") return TODAY (frappe/utils/data.py:125-126), so
-	# a bare getdate would make "set the due date to today" on an unset field compare
-	# equal to itself and VANISH from the card. Empties must stay empty.
-	if value in (None, ""):
+	# getdate() returns TODAY for ANY falsy input (frappe/utils/data.py:125-126), so a
+	# bare getdate would make "set the due date to today" on an unset field compare
+	# equal to itself and VANISH from the card. `not value` rather than `in (None, "")`
+	# so 0/False take the same branch instead of silently becoming today.
+	if not value:
 		return None
 	return getdate(value)
 
@@ -109,7 +110,7 @@ def _cast_date(value):
 def _cast_datetime(value):
 	# get_datetime(None) returns now() (data.py:164-165) - two calls microseconds
 	# apart are unequal, so None vs None would render a phantom "(empty) -> (empty)".
-	if value in (None, ""):
+	if not value:
 		return None
 	out = get_datetime(value)
 	if out is None:

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -265,7 +265,11 @@ def summary_rows(doctype: str, name: str) -> dict | None:
 			break
 
 	if getattr(meta, "is_submittable", 0):
-		# docstatus is not a DocField, so pick_fields cannot select it.
+		# docstatus is not a DocField, so pick_fields cannot select it. It is appended
+		# AFTER the capped loop, so reserve its slot rather than exceed _MAX_ROWS -
+		# "bounded, no unbounded axis" is an invariant, and a cap the code quietly
+		# overshoots by one is a cap nobody can trust.
+		rows = rows[: _MAX_ROWS - 1]
 		rows.append({
 			"label": "Docstatus",
 			"value": _DOCSTATUS_LABEL.get(cint(doc.get("docstatus")), "?"),

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -151,3 +151,57 @@ def same_value(a, b, df=None) -> bool:
 		return cast(a) == cast(b)
 	except Exception:
 		return False
+
+
+def pick_fields(meta) -> list[str]:
+	"""The meta floor: which fields identify a STORED record at a glance.
+
+	Selection only - never used for proposed content, which renders whole (a
+	proposed field outside the floor is one the save will write, so hiding it would
+	let you approve a value you never saw).
+
+	Order: title, list-view columns, mandatory fields, status, grand_total/total.
+	Frappe's own link_preview (frappe/desk/link_preview.py) falls back to ``reqd``
+	when no preview fields are set - a record's required fields are its essence -
+	and that is the idea borrowed here. ``docstatus`` is not a DocField, so it is
+	not selectable; summary_rows renders it as a synthetic row instead.
+	"""
+	if not meta:
+		return []
+	out: list[str] = []
+	seen: set[str] = set()
+
+	def add(fieldname):
+		if not fieldname or fieldname == "name" or fieldname in seen:
+			return
+		df = meta.get_field(fieldname)
+		if df is None or df.fieldtype in _TABLE_FIELDTYPES:
+			return
+		seen.add(fieldname)
+		out.append(fieldname)
+
+	try:
+		add(meta.get_title_field())
+	except Exception:
+		pass
+	try:
+		for fieldname in meta.get_list_fields() or []:
+			add(fieldname)
+	except Exception:
+		pass
+	for df in meta.fields or []:
+		if df.reqd:
+			add(df.fieldname)
+	if getattr(meta, "is_submittable", 0):
+		add("status")
+	for fieldname in ("grand_total", "total"):
+		if meta.has_field(fieldname):
+			add(fieldname)
+			break
+
+	def is_long(fieldname):
+		df = meta.get_field(fieldname)
+		return bool(df) and df.fieldtype in _HTML_FIELDTYPES
+
+	ordered = [f for f in out if not is_long(f)] + [f for f in out if is_long(f)]
+	return ordered[:_MAX_FLOOR]

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -205,3 +205,76 @@ def pick_fields(meta) -> list[str]:
 
 	ordered = [f for f in out if not is_long(f)] + [f for f in out if is_long(f)]
 	return ordered[:_MAX_FLOOR]
+
+
+_DOCSTATUS_LABEL = {0: "Draft", 1: "Submitted", 2: "Cancelled"}
+
+
+def summary_rows(doctype: str, name: str) -> dict | None:
+	"""``{"title", "rows"}`` for a STORED record, or None when it is missing or the
+	caller cannot read it.
+
+	The caller renders a NAME-ONLY row on None. ``title`` is returned only from this
+	function's successful, permission-checked path - never source a card header from
+	a separate db.get_value(title_field): that read is unchecked and the title field
+	is typically the party name, i.e. the data being protected.
+	"""
+	try:
+		# Fresh DB load, NOT get_cached_doc: a cache could serve sandbox-mutated
+		# state from the park-time dry-run.
+		doc = frappe.get_doc(doctype, name)
+	except frappe.DoesNotExistError:
+		# frappe.throw leaves an entry in message_log that would leak into the turn.
+		frappe.clear_messages()
+		return None
+	except Exception:
+		frappe.clear_messages()
+		return None
+
+	# get_doc checks NO permission unless the check_permission kwarg is passed
+	# (document.py:141-145 -> :336-349, defaults to None). has_permission returns a
+	# bool; the kwarg throws, and a card must degrade rather than raise.
+	try:
+		if not doc.has_permission("read"):
+			return None
+	except Exception:
+		return None
+
+	try:
+		doc.apply_fieldlevel_read_permissions()
+	except Exception:
+		return None
+
+	meta = doc.meta
+	rows = []
+	for fieldname in pick_fields(meta):
+		# A permlevel-restricted field is delattr'd by the filter above
+		# (document.py:1264) and is dropped by the confirmed save too - never show a
+		# phantom value.
+		if not hasattr(doc, fieldname):
+			continue
+		value = doc.get(fieldname)
+		if value is None or (not isinstance(value, list) and cstr(value).strip() == ""):
+			continue
+		df = meta.get_field(fieldname)
+		label = df.label if df and df.label else fieldname
+		shown = "[hidden]" if is_secret(meta, fieldname) else fmt(value, df, doc)
+		rows.append({"label": label, "value": shown})
+		if len(rows) >= _MAX_ROWS:
+			break
+
+	if getattr(meta, "is_submittable", 0):
+		# docstatus is not a DocField, so pick_fields cannot select it.
+		rows.append({
+			"label": "Docstatus",
+			"value": _DOCSTATUS_LABEL.get(cint(doc.get("docstatus")), "?"),
+		})
+
+	title = ""
+	try:
+		title_field = meta.get_title_field()
+		if title_field and title_field != "name" and hasattr(doc, title_field):
+			title = fmt(doc.get(title_field), meta.get_field(title_field), doc)
+	except Exception:
+		title = ""
+	return {"title": title, "rows": rows}

--- a/jarvis/chat/_record_summary.py
+++ b/jarvis/chat/_record_summary.py
@@ -1,0 +1,97 @@
+"""Record summaries for confirmation cards: which fields to show, how to read them
+safely, how to format them, and whether a proposed value actually changes anything.
+
+``confirm_card.build_card`` owns card SHAPE; this module owns everything that
+touches a doc or a value. Split out because the branching lives here and it needs
+its own test surface.
+
+Safety contract (see docs/confirmation-card-redesign-spec.md):
+  - Every value is server-derived - from the perm-filtered dry-run ``would``, a
+    perm-CHECKED + perm-filtered doc read, or the caller's own args. Never from
+    model-authored prose: the card is the human's INDEPENDENT check on the agent.
+  - ``frappe.get_doc`` checks NO permission unless a ``check_permission`` kwarg is
+    passed (``frappe/model/document.py:141-145`` -> ``:336-349``), and it defaults
+    to None. ``apply_fieldlevel_read_permissions`` is permlevel-only. So a doc read
+    for a card MUST call ``has_permission`` itself.
+  - Nothing here raises into a card: ``build_card`` is best-effort.
+"""
+
+from __future__ import annotations
+
+import re
+
+import frappe
+from frappe.utils import cint, cstr, flt, get_datetime, getdate
+
+_MAX_VAL = 200  # a scalar display value
+_MAX_ROWS = 20  # records / fields per record / child rows
+_MAX_COLS = 8  # columns in a rendered child table (NOT _MAX_ROWS: 20 columns is unusable)
+_MAX_TABLES = 3  # child tables rendered per record; the rest degrade to "N rows"
+_MAX_BODY = 8_000  # a single long-form body (skill instructions, wiki body, one email)
+_MAX_BULK_BODY = 2_000  # per-message body in a bulk-email card
+_MAX_FLOOR = 8  # fields the meta floor selects for a stored record
+
+# A Password field or an obviously-secret key name - masked, never rendered. This
+# lives HERE, not in confirm_card, so the dependency runs one way only
+# (confirm_card -> _record_summary). The primitive must never import the card
+# module: a module-level import back would be circular.
+_SECRET_KEY_RE = re.compile(r"password|secret|token|api[_-]?key", re.IGNORECASE)
+
+# ``format_value`` emits HTML for these (newlines -> <br>, markdown -> HTML,
+# Text Editor -> a ql-snow div). Both frontends render through ESCAPED
+# interpolation, so these would show literal tags. HTML Editor / Code fall through
+# format_value raw, so bypassing them too is equivalent and simpler.
+_HTML_FIELDTYPES = frozenset({
+	"Text", "Small Text", "Long Text", "Markdown Editor", "Text Editor",
+	"HTML Editor", "Code",
+})
+_TABLE_FIELDTYPES = frozenset({"Table", "Table MultiSelect"})
+
+
+def _fieldtype(df) -> str | None:
+	return getattr(df, "fieldtype", None) if df is not None else None
+
+
+def is_secret(meta, key) -> bool:
+	"""A Password field or an obviously-secret key name. ``meta`` may be None.
+
+	Moved here from confirm_card so the primitive never imports the card module.
+	"""
+	if _SECRET_KEY_RE.search(str(key)):
+		return True
+	if meta:
+		df = meta.get_field(key)
+		if df and df.fieldtype == "Password":
+			return True
+	return False
+
+
+def fmt(value, df=None, doc=None, limit: int = _MAX_VAL) -> str:
+	"""A value as a short display string, formatted the way Frappe would show it.
+
+	``translated=False`` is deliberate: format_value runs ``frappe._(value)`` on
+	every string VALUE, not just labels (frappe/utils/formatters.py:59-60), so a
+	non-English session could render something other than what is stored. Select
+	options still translate inside their own branch, which is the only translation
+	wanted.
+	"""
+	if isinstance(value, list):
+		return f"{len(value)} row{'' if len(value) == 1 else 's'}"
+	if isinstance(value, dict):
+		return "..."
+	fieldtype = _fieldtype(df)
+	if fieldtype == "Check":
+		# format_value has no Check branch (formatters.py:146) -> raw 1/0. cint is
+		# mandatory: the string "0" is truthy and would render "Yes".
+		out = "Yes" if cint(value) else "No"
+	elif df is None or fieldtype in _HTML_FIELDTYPES:
+		out = "" if value is None else cstr(value)
+	else:
+		try:
+			out = cstr(frappe.format_value(value, df=df, doc=doc, translated=False))
+		except Exception:
+			# format_value raises for real: attribute access in get_field_currency
+			# (meta.py:886), a bad link in get_cached_value (meta.py:897), an assert
+			# in get_field_precision (meta.py:936).
+			out = "" if value is None else cstr(value)
+	return out if len(out) <= limit else out[: limit - 1] + "…"

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -173,6 +173,13 @@ def _append_receipt(conversation: str, verb: str, doctype: str, name: str,
 		"tool_args": frappe.as_json(args),
 		"tool_result": frappe.as_json({"ok": True, "data": {"doctype": doctype, "name": name}}),
 		"tool_status": "completed",
+		# This row DID come from a confirmation card - the human pressed Confirm on
+		# the draft - so mark it and let the SPA render the same receipt chip (with
+		# its open-in-Desk shortcut) that the gated path gets. Without this it fell
+		# into the Activity accordion, so a confirmed DELETE offered a shortcut to a
+		# record that no longer exists while a confirmed CREATE offered none to a
+		# record that does.
+		"action_outcome": "confirmed",
 	}).insert(ignore_permissions=True)
 	frappe.get_doc({
 		"doctype": MSG, "conversation": conversation, "seq": _next_seq(conversation),

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -506,8 +506,8 @@ def get_conversation(conversation: str) -> dict:
 		filters={"conversation": conversation, "hidden": 0},
 		fields=[
 			"name", "seq", "role", "content", "streaming", "error", "recovering",
-			"tool_name", "tool_args", "tool_result", "tool_status", "action_outcome",
-			"canvas", "creation", "modified",
+			"stopped", "tool_name", "tool_args", "tool_result", "tool_status",
+			"action_outcome", "canvas", "creation", "modified",
 		],
 		order_by="seq asc",
 	)

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -39,6 +39,8 @@ from __future__ import annotations
 import frappe
 
 from jarvis.chat._record_summary import (
+	_MAX_BODY,
+	_MAX_BULK_BODY,
 	_MAX_TABLES,
 	fmt,
 	is_secret,
@@ -81,6 +83,14 @@ def build_card(tool: str, args, preview) -> dict | None:
 		if tool in _VERB:
 			return _verb_card(tool, args, bulk_items)
 		if tool == "send_email":
+			if "messages" in args:
+				# _bulk treats an EMPTY list as non-bulk (confirm_card.py:94), so a
+				# bare `messages=[]` would otherwise reach _email_card and render a
+				# plausible empty single-email card - while the tool raises "messages
+				# must be a non-empty list" at confirm (send_email.py:107-109). A card
+				# that describes a call that cannot run is a lying card; fall back to
+				# raw instead.
+				return _bulk_email_card(bulk_items) if bulk_key == "messages" else None
 			return _email_card(args)
 		if tool == "run_method":
 			return _method_card(args)
@@ -387,15 +397,52 @@ def _verb_card(tool: str, args: dict, bulk_items) -> dict:
 	}
 
 
+def _recips(value) -> str:
+	if isinstance(value, list):
+		return ", ".join(str(x) for x in value)
+	return "" if value is None else str(value)
+
+
 def _email_card(args: dict) -> dict | None:
-	if isinstance(args.get("messages"), list):
-		return None  # bulk mail-merge: the summary's count is clearer than one body
 	to = args.get("recipients") or args.get("to") or ""
-	if isinstance(to, list):
-		to = ", ".join(str(x) for x in to)
 	return {
-		"kind": "email", "to": fmt(to), "subject": fmt(args.get("subject") or ""),
-		"body": fmt(args.get("content") or args.get("message") or ""),
+		"kind": "email", "to": fmt(_recips(to)),
+		"subject": fmt(args.get("subject") or ""),
+		"cc": fmt(_recips(args.get("cc") or "")),
+		"bcc": fmt(_recips(args.get("bcc") or "")),
+		"print_format": fmt(args.get("print_format") or ""),
+		"body": fmt(args.get("content") or args.get("message") or "", limit=_MAX_BODY),
+	}
+
+
+def _bulk_email_card(messages: list) -> dict | None:
+	"""A mail-merge: every message has its OWN recipient, subject and body
+	(send_email.py:19-24). The old card returned None on the reasoning that "the
+	count is clearer than one body" - true for ONE message to many people, which is
+	the SINGLE call's ``recipients`` list, not this shape. send_email is _DESTRUCTIVE
+	and always parks; showing the least of any gated tool for the one thing that
+	cannot be recalled was the worst gap in the system.
+	"""
+	shown = []
+	for m in messages[:_MAX_ROWS]:
+		if not isinstance(m, dict):
+			continue
+		shown.append({
+			"name": fmt(m.get("name") or ""),
+			"recipients": fmt(_recips(m.get("recipients") or "")),
+			# The batch honours per-message cc/bcc (send_email.py:119). Without these
+			# a merge that bcc's a third party on every message renders identical to
+			# one that does not - hidden recipients on the one irreversible tool.
+			"cc": fmt(_recips(m.get("cc") or "")),
+			"bcc": fmt(_recips(m.get("bcc") or "")),
+			"subject": fmt(m.get("subject") or ""),
+			"body": fmt(m.get("content") or "", limit=_MAX_BULK_BODY),
+		})
+	if not shown:
+		return None
+	return {
+		"kind": "bulk_email", "count": len(messages), "messages": shown,
+		"extra": max(0, len(messages) - len(shown)),
 	}
 
 

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -29,9 +29,15 @@ Field selection, doc reads, value formatting and no-op detection all live in
 ``jarvis.chat._record_summary``; this module owns card SHAPE only. The dependency
 runs one way (confirm_card -> _record_summary) and must stay that way.
 
-Returns ``None`` for tool shapes without a bespoke card (share_doc, assign_to,
-create_custom_skill, update_wiki, bulk email, and any token minted before this
-existed) - the SPA falls back to the summary + raw-preview rendering.
+Every GATED write now has a card: phase 4 added the last five kinds (bulk_email,
+share, assign, skill, wiki), so share_doc, assign_to, create_custom_skill,
+update_wiki and a bulk mail-merge no longer fall back to a bare tool name.
+``None`` is still returned for a shape without a bespoke card and for any token
+minted before this existed - the SPA then falls back to the summary + raw-preview
+rendering. Each new kind ALSO needs an entry in the frontends' ``CARD_KINDS``
+whitelist (``frontend/src/lib/actionSummary.js``): ``pendingCardOf`` returns null
+for a kind not in that set, so a kind added here alone renders as if it never
+shipped.
 """
 
 from __future__ import annotations
@@ -42,6 +48,7 @@ from jarvis.chat._record_summary import (
 	_MAX_BODY,
 	_MAX_BULK_BODY,
 	_MAX_TABLES,
+	_MAX_VAL,
 	fmt,
 	is_secret,
 	same_value,
@@ -96,6 +103,10 @@ def build_card(tool: str, args, preview) -> dict | None:
 				# raw instead.
 				return _bulk_email_card(bulk_items) if bulk_key == "messages" else None
 			return _email_card(args)
+		if tool == "create_custom_skill":
+			return _skill_card(args)
+		if tool == "update_wiki":
+			return _wiki_card(args)
 		if tool == "run_method":
 			return _method_card(args)
 	except Exception:
@@ -513,6 +524,67 @@ def _bulk_email_card(messages: list) -> dict | None:
 	return {
 		"kind": "bulk_email", "count": len(messages), "messages": shown,
 		"extra": max(0, len(messages) - len(shown)),
+	}
+
+
+def _skill_card(args: dict) -> dict:
+	"""Persistent agent instructions - the card was the bare tool name.
+
+	``scope`` is the EFFECTIVE value: create_custom_skill computes a `requested`
+	scope and then hardcodes "scope": "User" (create_custom_skill.py:44-57), so
+	echoing args.scope would claim a bench-wide skill while creating a private one.
+	The instructions body gets _MAX_BODY, not the 200-char scalar cap: approving
+	text you structurally cannot read is theatre.
+	"""
+	ui = args.get("user_invocable")
+	if isinstance(ui, str):
+		ui = ui.strip().lower() in ("1", "true", "yes", "on")
+	return {
+		"kind": "skill",
+		"skill_name": fmt(args.get("skill_name") or ""),
+		"scope": "User (private)",  # the tool caps it regardless of the request
+		"user_invocable": bool(1 if ui is None else ui),
+		"description": fmt(args.get("description") or "", limit=_MAX_VAL),
+		"instructions": fmt(args.get("instructions") or "", limit=_MAX_BODY),
+	}
+
+
+def _wiki_card(args: dict) -> dict:
+	"""``replace_body_md`` is a FULL REWRITE and says so; ``append_md`` adds a
+	section. The tool rejects both together (update_wiki.py:3-4), so mode is
+	unambiguous. A diff against the current body is the better card - deferred, it
+	needs the current body loaded (spec open question 3).
+	"""
+	replace = args.get("replace_body_md")
+	append = args.get("append_md")
+	# `is not None`, NOT truthiness: update_wiki.py:146 is
+	# `elif replace_body_md is not None: doc.body_md = str(replace_body_md)` - so
+	# replace_body_md="" ERASES THE WHOLE PAGE. The both-args guard (:96) is also
+	# truthiness, so "" sails through it too. Classifying that as mode="meta" with an
+	# empty body would render the most destructive call this tool accepts as the most
+	# innocuous card in the set.
+	if replace is not None:
+		mode = "replace"
+	elif append and str(append).strip():
+		mode = "append"  # the tool no-ops a blank append (update_wiki.py:143)
+	else:
+		mode = "meta"
+	ref = ""
+	if args.get("ref_doctype") and args.get("ref_name"):
+		ref = f"{args['ref_doctype']} {args['ref_name']}"
+	return {
+		"kind": "wiki",
+		"slug": fmt((args.get("slug") or "").strip().lower()),  # the tool strips/lowers (:93)
+		"title": fmt((args.get("title") or "")[:140]),  # the tool truncates to 140 (:134)
+		"scope": fmt((args.get("scope") or "Org").capitalize()),  # the tool capitalizes (:104)
+		"page_type": fmt(args.get("page_type") or ""),
+		"ref": fmt(ref),
+		# `summary` is PERSISTED (update_wiki.py:141-142, :164) - a call setting only
+		# summary would otherwise render as an empty "meta" card and the human would
+		# approve stored text they never saw.
+		"summary": fmt(args.get("summary") or "", limit=_MAX_VAL),
+		"mode": mode,
+		"body": fmt(replace if replace is not None else (append or ""), limit=_MAX_BODY),
 	}
 
 

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -43,6 +43,7 @@ from jarvis.chat._record_summary import (
 	fmt,
 	is_secret,
 	same_value,
+	summary_rows,
 	table_rows,
 )
 
@@ -299,6 +300,23 @@ def _target_name(item):
 	return item
 
 
+def _verb_records(doctype, names) -> list[dict]:
+	"""A summary per target, capped. ``summary_rows`` returns None for a record that
+	is MISSING or that the caller cannot READ - both degrade to name-only, and they
+	must stay indistinguishable so the card is not an existence oracle. The title
+	only ever comes from summary_rows' permission-checked path.
+	"""
+	out = []
+	for name in names[:_MAX_ROWS]:
+		summary = summary_rows(doctype, name) if doctype and name else None
+		out.append({
+			"name": name,
+			"title": summary["title"] if summary else "",
+			"rows": summary["rows"] if summary else [],
+		})
+	return out
+
+
 def _verb_card(tool: str, args: dict, bulk_items) -> dict:
 	verb = _VERB[tool]
 	doctype = args.get("doctype")
@@ -309,10 +327,13 @@ def _verb_card(tool: str, args: dict, bulk_items) -> dict:
 			"kind": "verb", "verb": verb, "action": action, "doctype": doctype,
 			"count": len(bulk_items), "targets": targets,
 			"extra": max(0, len(bulk_items) - len(targets)),
+			"records": _verb_records(doctype, targets),
 		}
+	targets = [args["name"]] if args.get("name") else []
 	return {
 		"kind": "verb", "verb": verb, "action": action, "doctype": doctype,
-		"count": 1, "targets": [args["name"]] if args.get("name") else [], "extra": 0,
+		"count": 1, "targets": targets, "extra": 0,
+		"records": _verb_records(doctype, targets),
 	}
 
 

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -17,10 +17,17 @@ the stored preview and re-load the doc on each reconnect).
 
 Safety: values come from the ALREADY perm-filtered ``would`` (create/update tools
 call ``apply_fieldlevel_read_permissions`` before returning), and the update
-``from`` values are read from a freshly-fetched, perm-filtered current doc - so a
-restricted field's value never lands in the card. Long values are truncated, rows
-capped, and obviously-secret ``run_method`` arg keys masked. The card carries no
-material the owner would not already see in the post-confirm receipt.
+``from`` values are read from a freshly-fetched doc that is permission-CHECKED
+(``has_permission("read")``) and then perm-filtered - ``frappe.get_doc`` checks no
+permission on its own unless passed a ``check_permission`` kwarg (which defaults to
+None), and the fieldlevel filter is permlevel-only, so the explicit check is what
+keeps an unreadable record's old values off the card. Long values are truncated,
+rows capped, and obviously-secret ``run_method`` arg keys masked. The card carries
+no material the owner would not already see in the post-confirm receipt.
+
+Field selection, doc reads, value formatting and no-op detection all live in
+``jarvis.chat._record_summary``; this module owns card SHAPE only. The dependency
+runs one way (confirm_card -> _record_summary) and must stay that way.
 
 Returns ``None`` for tool shapes without a bespoke card (share_doc, assign_to,
 create_custom_skill, update_wiki, bulk email, and any token minted before this
@@ -29,14 +36,18 @@ existed) - the SPA falls back to the summary + raw-preview rendering.
 
 from __future__ import annotations
 
-import re
-
 import frappe
 
-_MAX_VAL = 200  # truncate a single displayed value to this many chars
+from jarvis.chat._record_summary import (
+	_MAX_TABLES,
+	fmt,
+	is_secret,
+	same_value,
+	table_rows,
+)
+
 _MAX_ROWS = 20  # cap fields / diff rows / batch bullets / targets shown
 _BULK_KEYS = ("names", "updates", "docs", "messages")
-_SECRET_KEY_RE = re.compile(r"password|secret|token|api[_-]?key", re.IGNORECASE)
 
 # tool -> present-tense verb for the "will <verb> this <doctype> <name>" card.
 _VERB = {
@@ -99,34 +110,45 @@ def _label(meta, fieldname: str) -> str:
 	return fieldname
 
 
-def _fmt(value) -> str:
-	"""A scalar as a short display string; a child-table list -> "N rows"."""
-	if isinstance(value, list):
-		return f"{len(value)} row{'' if len(value) == 1 else 's'}"
-	if isinstance(value, dict):
-		return "..."
-	s = "" if value is None else str(value)
-	return s if len(s) <= _MAX_VAL else s[: _MAX_VAL - 1] + "…"
-
-
 def _create_card(args: dict, would) -> dict:
 	doctype = args.get("doctype")
 	values = args.get("values") if isinstance(args.get("values"), dict) else {}
 	meta = _meta(doctype)
+	# Child tables FIRST: a list value rendered as a table must not also render as a
+	# bare "Items · 1 row" text row below. The ``would`` guard is the same perm check
+	# the scalar rows use - a permlevel-dropped table would otherwise show as a write
+	# that will not happen.
+	tables, table_keys = [], set()
+	for key in list(values):
+		if len(tables) >= _MAX_TABLES:
+			break
+		value = values.get(key)
+		if not isinstance(value, list) or not value:
+			continue
+		if isinstance(would, dict) and key not in would:
+			continue  # perm-dropped from the resolved doc: the save will not write it
+		t = table_rows(meta, key, value)
+		if t:
+			tables.append(t)
+			table_keys.add(key)
 	rows = []
 	for key in list(values)[: _MAX_ROWS * 2]:
 		# Perm guard: only show a field that survived the resolved doc's
 		# field-level read-permission filter.
 		if isinstance(would, dict) and key not in would:
 			continue
+		if key in table_keys:
+			continue  # rendered as a table below, not as a bare "N rows"
 		val = would.get(key) if isinstance(would, dict) else values.get(key)
 		if val is None or (not isinstance(val, list) and str(val).strip() == ""):
 			continue
-		rows.append({"label": _label(meta, key), "value": _fmt(val)})
+		df = meta.get_field(key) if meta else None
+		rows.append({"label": _label(meta, key), "value": fmt(val, df)})
 		if len(rows) >= _MAX_ROWS:
 			break
 	name = would.get("name") if isinstance(would, dict) else None
-	return {"kind": "create", "doctype": doctype, "name": name, "rows": rows}
+	return {"kind": "create", "doctype": doctype, "name": name, "rows": rows,
+			"tables": tables}
 
 
 def _update_card(args: dict, would) -> dict:
@@ -135,51 +157,59 @@ def _update_card(args: dict, would) -> dict:
 	changes = args.get("changes") if isinstance(args.get("changes"), dict) else {}
 	meta = _meta(doctype)
 	# OLD values from the current doc (the park dry-run rolled back, so the DB is
-	# back to the pre-update state), perm-filtered so a restricted field's old
-	# value never leaks. NEW values from ``would`` (already perm-filtered +
-	# normalized by the tool).
+	# back to the pre-update state), permission-CHECKED then perm-filtered so
+	# neither an unreadable record's nor a restricted field's old value ever leaks.
+	# NEW values from ``would`` (already perm-filtered + normalized by the tool).
 	old = {}
+	doc = None  # must be bound: fmt(..., doc=doc) below needs it for currency/link titles
 	try:
 		doc = frappe.get_doc(doctype, name)
+		# get_doc checks NO permission unless passed a check_permission kwarg
+		# (document.py:141-145 -> :336-349), which defaults to None; and the
+		# fieldlevel filter below is permlevel-only. Without this, a user who cannot
+		# read the record sees its old values on the card.
+		if not doc.has_permission("read"):
+			raise frappe.PermissionError
 		doc.apply_fieldlevel_read_permissions()
 		old = doc.as_dict()
 	except Exception:
-		old = {}
+		frappe.clear_messages()  # get_doc's throw leaves an entry that leaks into the turn
+		old, doc = {}, None
 	diff = []
 	for key in list(changes)[: _MAX_ROWS * 2]:
 		if isinstance(would, dict) and key not in would:
 			continue  # not perm-visible in the resolved doc
 		to_val = would.get(key) if isinstance(would, dict) else changes.get(key)
 		from_val = old.get(key)
-		if from_val == to_val:
-			continue  # normalized to a no-op
+		df = meta.get_field(key) if meta else None
+		if same_value(from_val, to_val, df):
+			continue  # the save would not change the stored value
 		diff.append({
-			"label": _label(meta, key), "from": _fmt(from_val), "to": _fmt(to_val)})
+			"label": _label(meta, key), "from": fmt(from_val, df, doc),
+			"to": fmt(to_val, df)})
 		if len(diff) >= _MAX_ROWS:
 			break
-	return {"kind": "update", "doctype": doctype, "name": name, "diff": diff}
-
-
-def _is_secret(meta, key) -> bool:
-	"""A Password field or an obviously-secret key name - masked, never rendered
-	(mirrors _method_card's secret handling and the single-update card, where a
-	Password field's ``would`` value is already Frappe-masked before capture)."""
-	if _SECRET_KEY_RE.search(str(key)):
-		return True
-	if meta:
-		df = meta.get_field(key)
-		if df and df.fieldtype == "Password":
-			return True
-	return False
+	title = ""
+	if doc is not None and meta:
+		try:
+			tf = meta.get_title_field()
+			if tf and tf != "name" and hasattr(doc, tf):
+				title = fmt(doc.get(tf), meta.get_field(tf), doc)
+		except Exception:
+			title = ""
+	return {"kind": "update", "doctype": doctype, "name": name, "title": title,
+			"diff": diff}
 
 
 def _bulk_update_card(args: dict, updates) -> dict | None:
 	"""Per-record from->to diff for a batch ``update_doc(updates=[{name, changes}])``.
 
 	Each rendered record's OLD values come from its current (post-rollback) doc,
-	perm-filtered so a restricted field never leaks; the NEW values are the
-	caller's requested ``changes``. No-op fields are dropped (comparing DISPLAY
-	forms, so a typed DB value equals its string request), permlevel-restricted
+	permission-CHECKED then perm-filtered so a restricted field never leaks; the
+	NEW values are the caller's requested ``changes``. No-op fields are dropped
+	(comparing the values the SAVE would store, never their display forms - see
+	``same_value``: fmt_money renders 100.005 and 100.001 identically, so a display
+	compare would drop a real change from the card), permlevel-restricted
 	fields are skipped (the confirmed save would silently drop them - mirrors
 	_update_card's ``would`` guard), and secret / Password values are masked. Only
 	the first ``_MAX_ROWS`` records are rendered - each costs one doc read - and the
@@ -201,10 +231,15 @@ def _bulk_update_card(args: dict, updates) -> dict | None:
 		old, loaded = {}, False
 		try:
 			doc = frappe.get_doc(doctype, name)
+			# get_doc checks NO permission (document.py:141-145 -> :336-349 defaults
+			# check_permission to None) and the fieldlevel filter is permlevel-only.
+			if not doc.has_permission("read"):
+				raise frappe.PermissionError
 			doc.apply_fieldlevel_read_permissions()
 			old = doc.as_dict()
 			loaded = True
 		except Exception:
+			frappe.clear_messages()
 			old = {}
 		diff, fields = [], []
 		for key in list(changes)[: _MAX_ROWS * 2]:  # over-scan so no-ops don't eat slots
@@ -213,17 +248,26 @@ def _bulk_update_card(args: dict, updates) -> dict | None:
 			# show a phantom change (mirrors _update_card's ``key not in would``).
 			if loaded and key not in old:
 				continue
-			from_s, to_s = _fmt(old.get(key)), _fmt(changes.get(key))
-			if from_s == to_s:
-				continue  # no-op: display forms match (typed DB value vs its string arg)
-			if _is_secret(meta, key):
+			cdf = meta.get_field(key) if meta else None
+			if same_value(old.get(key), changes.get(key), cdf):
+				continue  # the save would not change the stored value
+			from_s, to_s = fmt(old.get(key), cdf, doc if loaded else None), fmt(changes.get(key), cdf)
+			if is_secret(meta, key):
 				from_s = to_s = "[hidden]"  # never render a password / secret value
 			label = _label(meta, key)
 			fields.append(label)
 			diff.append({"label": label, "from": from_s, "to": to_s})
 			if len(diff) >= _MAX_ROWS:
 				break
-		records.append({"name": name, "fields": fields, "diff": diff})
+		row_title = ""
+		if loaded and meta:
+			try:
+				tf = meta.get_title_field()
+				if tf and tf != "name" and hasattr(doc, tf):
+					row_title = fmt(doc.get(tf), meta.get_field(tf), doc)
+			except Exception:
+				row_title = ""
+		records.append({"name": name, "title": row_title, "fields": fields, "diff": diff})
 	if not records:
 		return None
 	return {
@@ -278,8 +322,8 @@ def _email_card(args: dict) -> dict | None:
 	if isinstance(to, list):
 		to = ", ".join(str(x) for x in to)
 	return {
-		"kind": "email", "to": _fmt(to), "subject": _fmt(args.get("subject") or ""),
-		"body": _fmt(args.get("content") or args.get("message") or ""),
+		"kind": "email", "to": fmt(to), "subject": fmt(args.get("subject") or ""),
+		"body": fmt(args.get("content") or args.get("message") or ""),
 	}
 
 
@@ -287,5 +331,6 @@ def _method_card(args: dict) -> dict:
 	inner = args.get("args") if isinstance(args.get("args"), dict) else {}
 	shown = {}
 	for k, v in list(inner.items())[:_MAX_ROWS]:
-		shown[str(k)] = "[hidden]" if _SECRET_KEY_RE.search(str(k)) else _fmt(v)
-	return {"kind": "method", "method": _fmt(args.get("method") or ""), "args": shown}
+		# No meta for a run_method arg bag, so this is the key-name check only.
+		shown[str(k)] = "[hidden]" if is_secret(None, k) else fmt(v)
+	return {"kind": "method", "method": fmt(args.get("method") or ""), "args": shown}

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -45,6 +45,7 @@ from jarvis.chat._record_summary import (
 	same_value,
 	summary_rows,
 	table_rows,
+	values_rows,
 )
 
 _MAX_ROWS = 20  # cap fields / diff rows / batch bullets / targets shown
@@ -69,8 +70,10 @@ def build_card(tool: str, args, preview) -> dict | None:
 	would = preview.get("would") if isinstance(preview, dict) else None
 	try:
 		bulk_key, bulk_items = _bulk(args)
-		if tool == "create_doc":
-			return _batch_create_card(would) if bulk_key == "docs" else _create_card(args, would)
+		if tool in ("create_doc", "create_docs"):
+			if bulk_key == "docs" or tool == "create_docs":
+				return _batch_create_card(args, would)
+			return _create_card(args, would)
 		if tool == "update_doc" and not bulk_key:
 			return _update_card(args, would)
 		if tool == "update_doc" and bulk_key == "updates":
@@ -279,18 +282,65 @@ def _bulk_update_card(args: dict, updates) -> dict | None:
 	}
 
 
-def _batch_create_card(would) -> dict | None:
+def _batch_create_card(args: dict, would) -> dict | None:
+	"""Per-record proposed content for a batch create.
+
+	Values come from ``args.docs[i].values``, NOT from ``would``: the sandbox inserted
+	those rows and rolled them back, so ``would.created[i]["name"]`` points at nothing
+	and cannot be read. For a create the args are also the MORE truthful source -
+	Frappe skips the child-table permlevel reset on new records
+	(document.py:1326-1328), so a permlevel-restricted child field the caller set IS
+	written, while ``would`` is read-filtered and would under-report it.
+
+	``notes`` is NOT rendered: it is a tool argument the MODEL writes
+	(create_doc.py:87 -> :134), and on the card it reads as system truth. The card is
+	the human's independent check on the agent; the agent can say what it likes in
+	chat, where the claim is attributed to it.
+	"""
 	if not isinstance(would, dict) or not isinstance(would.get("created"), list):
 		return None
 	created = would["created"]
+	docs = args.get("docs") if isinstance(args.get("docs"), list) else []
 	rows = [
 		{"doctype": d.get("doctype"), "name": d.get("name")}
 		for d in created[:_MAX_ROWS] if isinstance(d, dict)
 	]
-	notes = [str(n) for n in (would.get("notes") or []) if str(n or "").strip()]
+	records = []
+	# zip, never filter-then-index: filtering non-dicts out of `created` first would
+	# pair docs[i] with the WRONG created entry from the first bad row onwards.
+	for made, req in list(zip(created, docs))[:_MAX_ROWS]:
+		if not isinstance(made, dict) or not isinstance(req, dict):
+			continue
+		doctype = req.get("doctype") or made.get("doctype")
+		values = req.get("values") if isinstance(req.get("values"), dict) else {}
+		meta = _meta(doctype)  # PER ITEM: a batch can mix doctypes
+		# Tables FIRST, then EVERYTHING not rendered as a table goes through
+		# values_rows - including lists table_rows REJECTED (unknown doctype -> meta
+		# is None -> table_rows returns None; a list on a non-Table field) and the
+		# _MAX_TABLES overflow, which the spec promises degrades to "N rows". Those
+		# fall to fmt's list branch. A proposed key must NEVER vanish: splitting on
+		# isinstance(v, list) up front drops every list table_rows rejects, so a
+		# human approves a create without seeing its line items - the exact defect
+		# this redesign exists to kill. Mirrors _create_card's table_keys pattern
+		# (confirm_card.py:121-141), which already solved this.
+		tables, table_keys = [], set()
+		for key, value in values.items():
+			if len(tables) >= _MAX_TABLES:
+				break
+			if not isinstance(value, list) or not value:
+				continue
+			t = table_rows(meta, key, value)
+			if t:
+				tables.append(t)
+				table_keys.add(key)
+		body = values_rows(meta, {k: v for k, v in values.items() if k not in table_keys})
+		records.append({
+			"doctype": doctype, "name": made.get("name"),
+			"rows": body["rows"], "extra": body["extra"], "tables": tables,
+		})
 	return {
 		"kind": "batch_create", "count": len(created), "rows": rows,
-		"extra": max(0, len(created) - len(rows)), "notes": notes[:_MAX_ROWS],
+		"extra": max(0, len(created) - len(rows)), "records": records,
 	}
 
 

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -94,13 +94,19 @@ def build_card(tool: str, args, preview) -> dict | None:
 		if tool == "assign_to":
 			return _assign_card(args, bulk_items if bulk_key == "names" else None)
 		if tool == "send_email":
-			if "messages" in args:
+			if args.get("messages") is not None:
+				# Key off `is not None`, exactly as the tool does (send_email.py:54):
+				# an explicit `messages: null` takes the SINGLE-email path and sends,
+				# so `"messages" in args` here would drop that card to raw fallback
+				# for a call that really does send one email.
+				#
 				# _bulk treats an EMPTY list as non-bulk (confirm_card.py:94), so a
 				# bare `messages=[]` would otherwise reach _email_card and render a
 				# plausible empty single-email card - while the tool raises "messages
 				# must be a non-empty list" at confirm (send_email.py:107-109). A card
 				# that describes a call that cannot run is a lying card; fall back to
-				# raw instead.
+				# raw instead. (`[]` is not None -> this branch -> bulk_key is None ->
+				# None.)
 				return _bulk_email_card(bulk_items) if bulk_key == "messages" else None
 			return _email_card(args)
 		if tool == "create_custom_skill":
@@ -557,18 +563,28 @@ def _wiki_card(args: dict) -> dict:
 	"""
 	replace = args.get("replace_body_md")
 	append = args.get("append_md")
-	# `is not None`, NOT truthiness: update_wiki.py:146 is
-	# `elif replace_body_md is not None: doc.body_md = str(replace_body_md)` - so
-	# replace_body_md="" ERASES THE WHOLE PAGE. The both-args guard (:96) is also
-	# truthiness, so "" sails through it too. Classifying that as mode="meta" with an
-	# empty body would render the most destructive call this tool accepts as the most
-	# innocuous card in the set.
-	if replace is not None:
+	# MIRROR THE TOOL'S PRECEDENCE EXACTLY. update_wiki.py:143-146 is
+	#   if append_md and str(append_md).strip(): ...append...
+	#   elif replace_body_md is not None: doc.body_md = str(replace_body_md)
+	# and the new-page path (:165) is str(replace_body_md or append_md or "") -
+	# APPEND WINS whenever it is non-blank, including over replace_body_md="", which
+	# is falsy and so sails through the both-args guard (:96, also truthiness).
+	# Checking replace first inverts this: update_wiki(replace_body_md="",
+	# append_md="<injected>") would render an EMPTY ERASE card while the tool APPENDS
+	# the payload - a phantom action and a hidden real one in the same shape.
+	#
+	# `is not None` on replace is still right for the lone case: replace_body_md=""
+	# sets body_md = str("") - a full ERASE - and must not be mistaken for a metadata
+	# edit.
+	if append and str(append).strip():
+		mode = "append"
+		body_src = append
+	elif replace is not None:
 		mode = "replace"
-	elif append and str(append).strip():
-		mode = "append"  # the tool no-ops a blank append (update_wiki.py:143)
+		body_src = replace
 	else:
-		mode = "meta"
+		mode = "meta"  # the tool no-ops a blank append (update_wiki.py:143)
+		body_src = ""
 	ref = ""
 	if args.get("ref_doctype") and args.get("ref_name"):
 		ref = f"{args['ref_doctype']} {args['ref_name']}"
@@ -584,7 +600,7 @@ def _wiki_card(args: dict) -> dict:
 		# approve stored text they never saw.
 		"summary": fmt(args.get("summary") or "", limit=_MAX_VAL),
 		"mode": mode,
-		"body": fmt(replace if replace is not None else (append or ""), limit=_MAX_BODY),
+		"body": fmt(body_src, limit=_MAX_BODY),  # the body the TOOL will write
 	}
 
 

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -184,9 +184,10 @@ def _update_card(args: dict, would) -> dict:
 		df = meta.get_field(key) if meta else None
 		if same_value(from_val, to_val, df):
 			continue  # the save would not change the stored value
-		diff.append({
-			"label": _label(meta, key), "from": fmt(from_val, df, doc),
-			"to": fmt(to_val, df)})
+		from_s, to_s = fmt(from_val, df, doc), fmt(to_val, df)
+		if is_secret(meta, key):
+			from_s = to_s = "[hidden]"  # never render a password / secret value
+		diff.append({"label": _label(meta, key), "from": from_s, "to": to_s})
 		if len(diff) >= _MAX_ROWS:
 			break
 	title = ""

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -82,6 +82,10 @@ def build_card(tool: str, args, preview) -> dict | None:
 			return _bulk_update_card(args, bulk_items)
 		if tool in _VERB:
 			return _verb_card(tool, args, bulk_items)
+		if tool == "share_doc":
+			return _share_card(args, bulk_items if bulk_key == "names" else None)
+		if tool == "assign_to":
+			return _assign_card(args, bulk_items if bulk_key == "names" else None)
 		if tool == "send_email":
 			if "messages" in args:
 				# _bulk treats an EMPTY list as non-bulk (confirm_card.py:94), so a
@@ -394,6 +398,72 @@ def _verb_card(tool: str, args: dict, bulk_items) -> dict:
 		"kind": "verb", "verb": verb, "action": action, "doctype": doctype,
 		"count": 1, "targets": targets, "extra": 0,
 		"records": _verb_records(doctype, targets),
+	}
+
+
+# (key, label, the TOOL'S SIGNATURE DEFAULT). read defaults True (share_doc.py:38);
+# everything else False. The default is half the effective value.
+_SHARE_FLAGS = (("read", "Read", True), ("write", "Write", False),
+				("submit", "Submit", False), ("share", "Share", False))
+
+
+def _flag_on(args: dict, key: str, default: bool) -> bool:
+	"""The value the TOOL will act on, not the value the model typed.
+
+	``bool(args[key])`` when the key is PRESENT - mirroring share_doc's
+	``int(bool(...))`` (share_doc.py:92-94), where bool("false") is True, so the
+	string "false" GRANTS. The signature default when the key is ABSENT - share_doc
+	defaults read=True (share_doc.py:38), so a call that never mentions `read` still
+	grants it. Presence, not ``.get()``: absent and explicit-null take different
+	branches in the tool.
+	"""
+	return bool(args[key]) if key in args else default
+
+
+def _share_card(args: dict, bulk_items) -> dict:
+	"""Grantee + permission flags + target summaries.
+
+	Before this, share_doc's card was "share_doc doctype=X name=Y": read-for-one-user
+	and everyone+write+share rendered IDENTICALLY - and those grants are the exact
+	reason share_doc was pulled into the gate.
+	"""
+	doctype = args.get("doctype")
+	everyone = _flag_on(args, "everyone", False)
+	targets = [t for t in (bulk_items or [args.get("name")]) if t][:_MAX_ROWS]
+	total = len(bulk_items) if bulk_items else 1
+	return {
+		"kind": "share", "doctype": doctype,
+		"grantee": "Everyone" if everyone else fmt(args.get("user") or ""),
+		"everyone": everyone,
+		"flags": [{"label": label, "on": _flag_on(args, key, default)}
+				  for key, label, default in _SHARE_FLAGS],
+		"notify": _flag_on(args, "notify", False),
+		"count": total,
+		"records": _verb_records(doctype, targets),
+		"extra": max(0, total - len(targets)),
+	}
+
+
+def _assign_card(args: dict, bulk_items) -> dict:
+	"""Assignee + the description that gets EMAILED to them + target summaries.
+
+	``notify`` defaults True (assign_to.py:40) so an absent arg still sends mail -
+	but an EXPLICIT notify=None reaches int(bool(None)) -> 0 and sends none
+	(assign_to.py:84). _flag_on distinguishes them; ``.get()`` truthiness would not.
+	"""
+	doctype = args.get("doctype")
+	targets = [t for t in (bulk_items or [args.get("name")]) if t][:_MAX_ROWS]
+	total = len(bulk_items) if bulk_items else 1
+	return {
+		"kind": "assign", "doctype": doctype,
+		"assignee": fmt(args.get("user") or ""),
+		"description": fmt(args.get("description") or "", limit=_MAX_BODY),
+		"priority": fmt(args.get("priority") or ""),
+		"date": fmt(args.get("date") or ""),
+		"notify": _flag_on(args, "notify", True),
+		"count": total,
+		"records": _verb_records(doctype, targets),
+		"extra": max(0, total - len(targets)),
 	}
 
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -930,15 +930,12 @@ def handle_chat_send(payload: dict) -> None:
 					})
 					return
 				if terminal.get("state") == "aborted":
-					# User hit Stop -> stop_run -> openclaw chat.abort. Finalize as a
-					# clean stop: keep whatever streamed, no error. Publish run:end so
-					# OTHER tabs (which never muted this run) also unlock - the
-					# stopping tab mutes it via stoppedRunId. A reload then shows the
-					# partial reply, not an error card for a deliberate stop. (Ordered
-					# after the overflow check - the two terminal states are mutually
-					# exclusive, and the overflow branch stays first for its test.)
-					if not (frappe.db.get_value(MSG, assistant_msg.name, "content") or "").strip():
-						frappe.db.set_value(MSG, assistant_msg.name, "content", "_Stopped._")
+					# The user hit Stop. Keep whatever streamed verbatim and record the
+					# stop as a FLAG - `content` is what the agent said, and a partial
+					# answer with no marker reads as a complete one. The SPA renders
+					# the marker from `stopped`, so a mid-sentence stop is finally
+					# distinguishable from a short reply.
+					frappe.db.set_value(MSG, assistant_msg.name, "stopped", 1)
 					frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
 					frappe.db.commit()
 					_publish_to_user(user, {
@@ -946,6 +943,7 @@ def handle_chat_send(payload: dict) -> None:
 						"conversation_id": conversation_id,
 						"message_id": assistant_msg.name,
 						"run_id": run_id,
+						"stopped": True,
 					})
 					_advance_macro(conversation_id, errored=True)
 					return

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -930,11 +930,21 @@ def handle_chat_send(payload: dict) -> None:
 					})
 					return
 				if terminal.get("state") == "aborted":
-					# The user hit Stop. Keep whatever streamed verbatim and record the
-					# stop as a FLAG - `content` is what the agent said, and a partial
-					# answer with no marker reads as a complete one. The SPA renders
-					# the marker from `stopped`, so a mid-sentence stop is finally
-					# distinguishable from a short reply.
+					# User hit Stop -> stop_run -> openclaw chat.abort. Finalize as a
+					# clean stop: keep whatever streamed, no error. Publish run:end so
+					# OTHER tabs (which never muted this run) also unlock - the
+					# stopping tab mutes it via stoppedRunId. (Ordered after the
+					# overflow check - the two terminal states are mutually exclusive,
+					# and the overflow branch stays first FOR ITS TEST: reordering
+					# these breaks TestRelayOverflowParks, which reads this file as
+					# text and asserts on a window after the relay:error line.)
+					#
+					# The stop is recorded as a FLAG, not as prose in `content`:
+					# `content` is what the agent said, and a partial answer with no
+					# marker reads as a complete one. The SPA renders the marker from
+					# `stopped`, so a mid-sentence stop is finally distinguishable
+					# from a short reply. `stopped` means the abort LANDED - the
+					# several paths where stop_run never reaches here leave it 0.
 					frappe.db.set_value(MSG, assistant_msg.name, "stopped", 1)
 					frappe.db.set_value(MSG, assistant_msg.name, "streaming", 0)
 					frappe.db.commit()

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -17,6 +17,7 @@
     "recovery_started_at",
     "openclaw_seq_watermark",
     "was_recovered",
+    "stopped",
     "tool_name",
     "tool_args",
     "tool_result",
@@ -100,6 +101,14 @@
       "read_only": 1,
       "hidden": 1,
       "description": "Set when this turn was finalized or errored by snapshot recovery rather than its live worker - the never-error machinery's fingerprint."
+    },
+    {
+      "fieldname": "stopped",
+      "fieldtype": "Check",
+      "label": "Stopped",
+      "default": 0,
+      "read_only": 1,
+      "description": "User hit Stop and the abort landed; content is whatever streamed first (may be empty)."
     },
     {
       "fieldname": "tool_name",

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import openclaw_session_pool
-from jarvis.chat.api import create_conversation, send_message
+from jarvis.chat.api import create_conversation, get_conversation, send_message
 from jarvis.chat.worker import run_agent_turn
 from jarvis.tests.test_chat_api import (
 	TEST_USER,
@@ -1129,3 +1129,112 @@ class TestRelayOverflowParks(FrappeTestCase):
 		self.assertIn('"context overflow" in err_text.lower()', branch)
 		self.assertIn("_mark_recovering(assistant_msg.name)", branch)
 		self.assertIn('"kind": "run:recovering"', branch)
+
+
+class TestRunAgentTurnAborted(FrappeTestCase):
+	"""The user hit Stop: stop_run -> openclaw chat.abort -> the relay terminal
+	arrives as relay:error with state="aborted".
+
+	A stop is a STATE of the turn, not prose: `content` stays exactly what the
+	agent streamed and `stopped` records the stop. The case that matters is a
+	stop MID-SENTENCE - the partial text must survive byte-for-byte AND be
+	flagged, because a truncated answer carrying no marker reads as a complete
+	one, which is the chat asserting a wrong answer.
+	"""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _run(self, relay_events):
+		"""Drive one turn through the relay path; return the publish mock."""
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {
+			"runId": idem, "status": "started",
+		}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream(relay_events)
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user") as pub:
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		return pub
+
+	def _assistant_row(self, fields):
+		return frappe.db.get_value(
+			MSG, {"conversation": self.conv, "role": "assistant"}, fields,
+			as_dict=isinstance(fields, list),
+		)
+
+	def test_abort_with_partial_content_keeps_it_verbatim_and_flags_stopped(self):
+		# THE regression this branch exists for: a mid-sentence stop. The text
+		# must survive untouched (no marker smuggled into it) and the row must
+		# carry the flag the SPA draws its marker from.
+		self._run([
+			{"kind": "assistant", "text": "The invoice total is", "delta": "The invoice total is"},
+			{"kind": "relay:error", "state": "aborted", "error": "aborted"},
+		])
+		row = self._assistant_row(["content", "stopped", "streaming"])
+		self.assertEqual(row["content"], "The invoice total is")
+		self.assertEqual(row["stopped"], 1)
+		self.assertEqual(row["streaming"], 0)
+
+	def test_abort_with_no_content_flags_stopped_and_leaves_content_empty(self):
+		# Stopped before anything streamed: content stays empty and the marker
+		# is the flag alone - no "_Stopped._" prose anywhere.
+		self._run([{"kind": "relay:error", "state": "aborted", "error": "aborted"}])
+		row = self._assistant_row(["content", "stopped", "streaming"])
+		self.assertFalse((row["content"] or "").strip())
+		self.assertNotIn("_Stopped._", row["content"] or "")
+		self.assertEqual(row["stopped"], 1)
+		self.assertEqual(row["streaming"], 0)
+
+	def test_abort_never_writes_stopped_prose_into_content(self):
+		# Guards the whole class of fix-by-magic-string: the sentinel must not
+		# come back through either writer.
+		self._run([
+			{"kind": "assistant", "text": "half an ans", "delta": "half an ans"},
+			{"kind": "relay:error", "state": "aborted", "error": "aborted"},
+		])
+		self.assertNotIn("_Stopped._", self._assistant_row("content") or "")
+
+	def test_abort_publishes_run_end_carrying_stopped(self):
+		# The three run:end consumers (desktop notifier, PWA notify-on-done,
+		# PWA bell feed) each announce a completion for a reply the user
+		# killed; they can only suppress it if the payload says so.
+		pub = self._run([{"kind": "relay:error", "state": "aborted", "error": "aborted"}])
+		ends = [c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "run:end"]
+		self.assertEqual(len(ends), 1)
+		self.assertTrue(ends[0]["stopped"])
+		# A deliberate stop is not a failure - it must never surface as one.
+		self.assertNotIn("run:error", [c.args[1]["kind"] for c in pub.call_args_list])
+
+	def test_get_conversation_returns_stopped(self):
+		# get_conversation's field list is explicit: omit "stopped" and the
+		# flag never reaches the SPA, so the marker vanishes on reload.
+		self._run([
+			{"kind": "assistant", "text": "cut off here", "delta": "cut off here"},
+			{"kind": "relay:error", "state": "aborted", "error": "aborted"},
+		])
+		msgs = get_conversation(self.conv)["messages"]
+		row = next(m for m in msgs if m["role"] == "assistant")
+		self.assertIn("stopped", row)
+		self.assertEqual(row["stopped"], 1)
+		self.assertEqual(row["content"], "cut off here")
+
+	def test_completed_turn_is_not_stopped(self):
+		# The flag records that an abort LANDED - a normal turn never sets it.
+		self._run([
+			{"kind": "assistant", "text": "all done", "delta": "all done"},
+			{"kind": "relay:final", "text": "all done"},
+		])
+		row = self._assistant_row(["content", "stopped", "streaming"])
+		self.assertEqual(row["stopped"], 0)
+		self.assertEqual(row["content"], "all done")
+		self.assertEqual(row["streaming"], 0)

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -477,19 +477,28 @@ class TestBatchCreateContent(FrappeTestCase):
 	def test_tables_past_MAX_TABLES_degrade_to_N_rows(self):
 		# The spec's caps section promises the overflow degrades to "N rows", not
 		# that it disappears.
+		#
+		# Uses REAL Table fields on a real doctype. An earlier version passed fake
+		# field names to ToDo: table_rows returned None for every one, so zero tables
+		# ever rendered, `rendered <= _MAX_TABLES` passed as 0 <= 3, and the
+		# _MAX_TABLES break was never reached - the test named a cap it did not
+		# exercise.
 		from jarvis.chat._record_summary import _MAX_TABLES
+		real_tables = ["items", "taxes", "pricing_rules", "packed_items"]
+		self.assertGreater(len(real_tables), _MAX_TABLES)  # or this proves nothing
 		values = {"customer": "X"}
-		for i in range(_MAX_TABLES + 1):
-			values[f"table_{i}"] = [{"a": 1}]
-		args = self._args([{"doctype": "ToDo", "values": values}])
-		would = {"created": [{"doctype": "ToDo", "name": "T-1"}]}
+		for fieldname in real_tables:
+			values[fieldname] = [{"idx": 1}]
+		args = self._args([{"doctype": "Sales Invoice", "values": values}])
+		would = {"created": [{"doctype": "Sales Invoice", "name": "SI-1"}]}
 		card = build_card("create_doc", args, {"would": would})
 		rendered = len(card["records"][0]["tables"])
-		self.assertLessEqual(rendered, _MAX_TABLES)
-		# every table key not rendered as a table still appears as a row
-		self.assertEqual(
-			len([r for r in card["records"][0]["rows"] if r["value"].endswith("row")]),
-			(_MAX_TABLES + 1) - rendered)
+		# the cap actually bit: fewer rendered than were proposed
+		self.assertEqual(rendered, _MAX_TABLES)
+		self.assertLess(rendered, len(real_tables))
+		# and every table key past the cap still shows up as an "N rows" row
+		degraded = [r for r in card["records"][0]["rows"] if r["value"].endswith("row")]
+		self.assertEqual(len(degraded), len(real_tables) - _MAX_TABLES)
 
 	def test_child_tables_render_per_record(self):
 		args = self._args([{"doctype": "Sales Invoice", "values": {

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -233,3 +233,88 @@ class TestBatchAndFallback(FrappeTestCase):
 		shown = card["rows"][0]["value"]
 		self.assertLessEqual(len(shown), 200)
 		self.assertTrue(shown.endswith("…"))
+
+
+from unittest.mock import patch
+
+
+class TestPhase1Rewire(FrappeTestCase):
+	def test_update_card_renders_a_real_change(self):
+		# Baseline shape check. NOT a no-op test - a text change passes against the
+		# old raw comparison too. The cast-compare logic is covered at the unit level
+		# in test_record_summary (TestSameValue) and at card level by the existing
+		# test_bulk_update_normalizes_typed_noop.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "x"}).insert(
+			ignore_permissions=True)
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name, "changes": {"description": "y"}},
+			{"would": {"description": "y"}})
+		self.assertEqual(card["kind"], "update")
+		self.assertTrue(any(d["to"] == "y" for d in card["diff"]))
+
+	def test_update_card_drops_an_unchanged_field(self):
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "x"}).insert(
+			ignore_permissions=True)
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name, "changes": {"description": "x"}},
+			{"would": {"description": "x"}})
+		self.assertEqual(card["diff"], [])
+
+	def test_update_card_carries_the_record_title(self):
+		# ToDo's title_field is `description`.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "probe title"}).insert(
+			ignore_permissions=True)
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name, "changes": {"priority": "High"}},
+			{"would": {"priority": "High"}})
+		self.assertIn("probe title", card["title"])
+
+	def test_update_card_checks_read_permission(self):
+		# _update_card:143 has the same unchecked get_doc as _bulk_update_card - the
+		# spec and both review rounds named only the bulk one. Without this, a user
+		# who cannot read the record sees its old values on a single-update card.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "secret"}).insert(
+			ignore_permissions=True)
+		with patch("frappe.model.document.Document.has_permission", return_value=False):
+			card = build_card(
+				"update_doc",
+				{"doctype": "ToDo", "name": todo.name, "changes": {"description": "y"}},
+				{"would": {"description": "y"}})
+		# The old value must not appear: the read failed, so `from` is empty.
+		self.assertNotIn("secret", str(card))
+		self.assertEqual(card["title"], "")
+
+	def test_bulk_update_card_checks_read_permission_on_each_doc(self):
+		# The pre-existing hole: get_doc checks nothing, and
+		# apply_fieldlevel_read_permissions is permlevel-only, so a user who cannot
+		# read a record could see its OLD values on an update card.
+		#
+		# The degrade is deliberate: the record still lists the caller's own proposed
+		# changes (which they authored, so they are not a leak) with an EMPTY `from`,
+		# and no title. Asserting "no diff rows" would be wrong - it contradicts the
+		# implementation, which cannot skip rows it never loaded.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "secret-old"}).insert(
+			ignore_permissions=True)
+		with patch("frappe.model.document.Document.has_permission", return_value=False):
+			card = build_card(
+				"update_doc",
+				{"doctype": "ToDo", "updates": [{"name": todo.name, "changes": {"description": "y"}}]},
+				{})
+		self.assertNotIn("secret-old", str(card))  # the old value must not leak
+		self.assertTrue(all(d["from"] == "" for r in card["records"] for d in r["diff"]))
+		self.assertEqual(card["records"][0]["title"], "")
+
+	def test_create_card_renders_child_tables(self):
+		card = build_card(
+			"create_doc",
+			{"doctype": "Sales Invoice", "values": {
+				"customer": "X",
+				"items": [{"item_code": "I-1", "qty": 2}],
+			}},
+			{"would": {"name": "SI-1", "customer": "X",
+					   "items": [{"item_code": "I-1", "qty": 2}]}})
+		self.assertTrue(card.get("tables"))
+		self.assertEqual(card["tables"][0]["count"], 1)

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -331,3 +331,65 @@ class TestPhase1Rewire(FrappeTestCase):
 					   "items": [{"item_code": "I-1", "qty": 2}]}})
 		self.assertTrue(card.get("tables"))
 		self.assertEqual(card["tables"][0]["count"], 1)
+
+
+class TestVerbCardRecords(FrappeTestCase):
+	def setUp(self):
+		self.todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "verb card probe", "priority": "High",
+		}).insert(ignore_permissions=True)
+		self.addCleanup(frappe.db.rollback)  # match the sibling classes' convention
+
+	def test_single_delete_carries_a_record_summary(self):
+		# THE motivating case: "Will delete this ToDo <name>" told you the ID and
+		# nothing about the record.
+		card = build_card("delete_doc", {"doctype": "ToDo", "name": self.todo.name}, {})
+		self.assertEqual(card["kind"], "verb")
+		self.assertEqual(len(card["records"]), 1)
+		self.assertEqual(card["records"][0]["name"], self.todo.name)
+		self.assertIn("verb card probe", card["records"][0]["title"])
+		self.assertIn("High", {r["value"] for r in card["records"][0]["rows"]})
+
+	def test_targets_and_count_are_unchanged(self):
+		# Additive only: three existing tests assert these, and a client running the
+		# previous bundle still reads `targets`.
+		card = build_card("delete_doc", {"doctype": "ToDo", "name": self.todo.name}, {})
+		self.assertEqual(card["targets"], [self.todo.name])
+		self.assertEqual(card["count"], 1)
+
+	def test_bulk_verb_carries_a_record_per_target(self):
+		other = frappe.get_doc({"doctype": "ToDo", "description": "second"}).insert(
+			ignore_permissions=True)
+		card = build_card(
+			"cancel_doc", {"doctype": "ToDo", "names": [self.todo.name, other.name]}, {})
+		self.assertEqual(card["count"], 2)
+		self.assertEqual([r["name"] for r in card["records"]], [self.todo.name, other.name])
+
+	def test_unreadable_target_degrades_to_name_only(self):
+		# summary_rows returns None for missing OR unreadable; the card must leak
+		# neither the title (typically the party name) nor any field.
+		with patch("frappe.model.document.Document.has_permission", return_value=False):
+			card = build_card("delete_doc", {"doctype": "ToDo", "name": self.todo.name}, {})
+		self.assertEqual(card["records"][0]["name"], self.todo.name)
+		self.assertEqual(card["records"][0]["title"], "")
+		self.assertEqual(card["records"][0]["rows"], [])
+		self.assertNotIn("verb card probe", str(card))
+
+	def test_missing_target_renders_identically_to_unreadable(self):
+		# No existence oracle: the two must be indistinguishable on the card.
+		card = build_card("delete_doc", {"doctype": "ToDo", "name": "no-such-todo"}, {})
+		self.assertEqual(card["records"][0], {"name": "no-such-todo", "title": "", "rows": []})
+
+	def test_records_are_capped_at_MAX_ROWS(self):
+		names = [f"fake-{i}" for i in range(_MAX_ROWS + 5)]
+		card = build_card("delete_doc", {"doctype": "ToDo", "names": names}, {})
+		self.assertEqual(len(card["records"]), _MAX_ROWS)
+		self.assertEqual(card["count"], _MAX_ROWS + 5)
+		self.assertEqual(card["extra"], 5)
+
+	def test_workflow_action_still_carries_action_and_gains_records(self):
+		card = build_card(
+			"apply_workflow_action",
+			{"doctype": "ToDo", "name": self.todo.name, "action": "Approve"}, {})
+		self.assertEqual(card["action"], "Approve")
+		self.assertEqual(card["records"][0]["name"], self.todo.name)

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -239,6 +239,19 @@ from unittest.mock import patch
 
 
 class TestPhase1Rewire(FrappeTestCase):
+	def test_update_card_masks_a_secret_named_field(self):
+		# The single-update card had no is_secret call while the BULK card masked by
+		# key name - so a Data field named api_token rendered plaintext on one card
+		# and [hidden] on the other for the identical change.
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "x"}).insert(
+			ignore_permissions=True)
+		card = build_card(
+			"update_doc",
+			{"doctype": "ToDo", "name": todo.name, "changes": {"api_token": "sk-live-999"}},
+			{"would": {"api_token": "sk-live-999"}})
+		self.assertNotIn("sk-live-999", str(card))
+		self.assertTrue(all(d["to"] == "[hidden]" for d in card["diff"]))
+
 	def test_update_card_renders_a_real_change(self):
 		# Baseline shape check. NOT a no-op test - a text change passes against the
 		# old raw comparison too. The cast-compare logic is covered at the unit level

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -213,8 +213,14 @@ class TestBatchAndFallback(FrappeTestCase):
 		self.assertEqual([r["name"] for r in card["rows"]], ["T-1", "T-2"])
 
 	def test_uncovered_tool_returns_none(self):
-		self.assertIsNone(build_card("share_doc", {"doctype": "ToDo", "name": "T-1"}, {}))
-		self.assertIsNone(build_card("assign_to", {"doctype": "ToDo", "name": "T-1"}, {}))
+		# Phase 4 gave every GATED write a card, so share_doc/assign_to - this test's
+		# old examples - render real cards now. The invariant it exists for is the
+		# dispatch FALLTHROUGH, not those two tools: a shape build_card does not cover
+		# returns None and the SPA falls back to the summary + raw preview. Re-pointed
+		# at tools that have no card rather than deleted, so the fallback stays tested
+		# no matter how many shapes later phases cover.
+		self.assertIsNone(build_card("get_doc", {"doctype": "ToDo", "name": "T-1"}, {}))
+		self.assertIsNone(build_card("no_such_tool", {"doctype": "ToDo", "name": "T-1"}, {}))
 
 	def test_never_raises_on_bad_input(self):
 		self.assertIsNone(build_card("update_doc", None, None))
@@ -570,3 +576,93 @@ class TestBulkEmailCard(FrappeTestCase):
 		self.assertEqual(card["cc"], "c@x.test")
 		self.assertEqual(card["bcc"], "b@x.test")
 		self.assertEqual(card["print_format"], "Standard")
+
+
+class TestShareAndAssignCards(FrappeTestCase):
+	def setUp(self):
+		self.todo = frappe.get_doc({"doctype": "ToDo", "description": "share probe"}).insert(
+			ignore_permissions=True)
+
+	def test_share_shows_grantee_and_flags(self):
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test",
+			"read": True, "write": True}, {})
+		self.assertEqual(card["kind"], "share")
+		self.assertEqual(card["grantee"], "x@y.test")
+		on = {f["label"] for f in card["flags"] if f["on"]}
+		self.assertEqual(on, {"Read", "Write"})
+
+	def test_share_everyone_is_distinguishable_from_one_user(self):
+		# read-for-one and everyone+write+share rendered IDENTICALLY before.
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "name": self.todo.name, "everyone": True,
+			"read": True, "write": True, "share": True}, {})
+		self.assertTrue(card["everyone"])
+		self.assertEqual(card["grantee"], "Everyone")
+
+	def test_share_flags_use_the_tools_own_coercion(self):
+		# share_doc does int(bool(flag)) - and bool("false") is True, so the string
+		# "false" GRANTS write. The card must agree with the grant, not the request.
+		# NOTE `read` is absent here, so it defaults ON - assert the full set, not
+		# just assertIn, or the test hides the default.
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test",
+			"write": "false"}, {})
+		on = {f["label"] for f in card["flags"] if f["on"]}
+		self.assertEqual(on, {"Read", "Write"})
+
+	def test_share_read_defaults_ON_when_absent(self):
+		# THE trap. share_doc.py:38 defaults read=True, so a call that never mentions
+		# `read` still grants it. A card built from args.get("read") renders "Write
+		# only" over a read+write grant - the card lying, on the tool that gates
+		# BECAUSE of grant escalation.
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test",
+			"write": True}, {})
+		on = {f["label"] for f in card["flags"] if f["on"]}
+		self.assertEqual(on, {"Read", "Write"})
+
+	def test_assign_explicit_null_notify_is_not_the_default(self):
+		# Absent -> tool's default True -> mail sent. Explicit None -> int(bool(None))
+		# -> 0 -> no mail (assign_to.py:84). .get() truthiness cannot tell them apart.
+		card = build_card("assign_to", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test",
+			"notify": None}, {})
+		self.assertFalse(card["notify"])
+
+	def test_share_carries_the_target_summary(self):
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test"}, {})
+		self.assertIn("share probe", card["records"][0]["title"])
+
+	def test_assign_shows_assignee_and_the_emailed_description(self):
+		card = build_card("assign_to", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test",
+			"description": "please review by friday", "priority": "High"}, {})
+		self.assertEqual(card["kind"], "assign")
+		self.assertEqual(card["assignee"], "x@y.test")
+		self.assertIn("please review by friday", card["description"])
+		self.assertEqual(card["priority"], "High")
+
+	def test_assign_notify_defaults_to_the_effective_value(self):
+		# assign_to's signature defaults notify=True; the card must show what the
+		# tool will DO, not "unset".
+		card = build_card("assign_to", {
+			"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test"}, {})
+		self.assertTrue(card["notify"])
+
+	def test_bulk_share_lists_every_target(self):
+		other = frappe.get_doc({"doctype": "ToDo", "description": "second"}).insert(
+			ignore_permissions=True)
+		card = build_card("share_doc", {
+			"doctype": "ToDo", "names": [self.todo.name, other.name],
+			"user": "x@y.test", "read": True}, {})
+		self.assertEqual(card["count"], 2)
+		self.assertEqual(len(card["records"]), 2)
+
+	def test_unreadable_share_target_degrades_to_name_only(self):
+		with patch("frappe.model.document.Document.has_permission", return_value=False):
+			card = build_card("share_doc", {
+				"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test"}, {})
+		self.assertEqual(card["records"][0]["title"], "")
+		self.assertNotIn("share probe", str(card))

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -215,7 +215,6 @@ class TestBatchAndFallback(FrappeTestCase):
 		self.assertEqual(card["kind"], "batch_create")
 		self.assertEqual(card["count"], 2)
 		self.assertEqual([r["name"] for r in card["rows"]], ["T-1", "T-2"])
-		self.assertEqual(card["notes"], ["reused Supplier X"])
 
 	def test_uncovered_tool_returns_none(self):
 		self.assertIsNone(build_card("share_doc", {"doctype": "ToDo", "name": "T-1"}, {}))
@@ -393,3 +392,132 @@ class TestVerbCardRecords(FrappeTestCase):
 			{"doctype": "ToDo", "name": self.todo.name, "action": "Approve"}, {})
 		self.assertEqual(card["action"], "Approve")
 		self.assertEqual(card["records"][0]["name"], self.todo.name)
+
+
+class TestBatchCreateContent(FrappeTestCase):
+	def _args(self, docs, notes=None):
+		out = {"docs": docs}
+		if notes is not None:
+			out["notes"] = notes
+		return out
+
+	def test_each_record_carries_its_proposed_values(self):
+		# The card listed {doctype, name} and threw the values away - even though
+		# they were sitting in args.docs[i].values.
+		args = self._args([
+			{"doctype": "ToDo", "values": {"description": "first", "priority": "High"}},
+			{"doctype": "ToDo", "values": {"description": "second", "priority": "Low"}},
+		])
+		would = {"created": [
+			{"doctype": "ToDo", "name": "T-1"}, {"doctype": "ToDo", "name": "T-2"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertEqual(card["kind"], "batch_create")
+		self.assertEqual(len(card["records"]), 2)
+		self.assertEqual(card["records"][0]["name"], "T-1")
+		self.assertIn("first", {r["value"] for r in card["records"][0]["rows"]})
+		self.assertIn("Low", {r["value"] for r in card["records"][1]["rows"]})
+
+	def test_model_authored_notes_are_NOT_on_the_card(self):
+		# THE trust-boundary fix. `notes` is a tool arg the model writes; on the card
+		# it reads as system truth. A prompt-injected agent could caption its own
+		# confirmation.
+		args = self._args(
+			[{"doctype": "ToDo", "values": {"description": "x"}}],
+			notes=["these already exist - confirming changes nothing"])
+		would = {"created": [{"doctype": "ToDo", "name": "T-1"}],
+				 "notes": ["these already exist - confirming changes nothing"]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertNotIn("notes", card)
+		self.assertNotIn("confirming changes nothing", str(card))
+
+	def test_mixed_doctype_batch_uses_per_item_meta(self):
+		# A batch can mix doctypes; one meta for the card would mislabel every field
+		# of every other doctype.
+		args = self._args([
+			{"doctype": "ToDo", "values": {"description": "a todo"}},
+			{"doctype": "Note", "values": {"title": "a note"}},
+		])
+		would = {"created": [
+			{"doctype": "ToDo", "name": "T-1"}, {"doctype": "Note", "name": "N-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertEqual(card["records"][0]["doctype"], "ToDo")
+		self.assertEqual(card["records"][1]["doctype"], "Note")
+		# Assert the LABEL, not the value: values render identically under the wrong
+		# meta (values_rows falls back to fieldnames), so a value assertion stays
+		# green even with the meta hoisted out of the loop. Note.title's label is
+		# "Title"; under a hoisted ToDo meta it would render as the raw "title".
+		self.assertIn({"label": "Title", "value": "a note"}, card["records"][1]["rows"])
+
+	def test_a_non_dict_in_created_does_not_desync_the_pairing(self):
+		# Filter-then-index would pair args.docs[1] with created[2].
+		args = self._args([
+			{"doctype": "ToDo", "values": {"description": "first"}},
+			{"doctype": "ToDo", "values": {"description": "second"}},
+		])
+		would = {"created": ["garbage", {"doctype": "ToDo", "name": "T-2"}]}
+		card = build_card("create_doc", args, {"would": would})
+		# Whatever we render, "second" must never be labelled T-2's sibling wrongly:
+		# the surviving pair is args.docs[1] <-> created[1].
+		named = [r for r in card["records"] if r["name"] == "T-2"]
+		self.assertEqual(len(named), 1)
+		self.assertIn("second", {r["value"] for r in named[0]["rows"]})
+
+	def test_a_list_table_rows_rejects_still_renders_as_N_rows(self):
+		# An unknown doctype means _meta -> None -> table_rows returns None. Without
+		# the table_keys pattern the child rows vanish ENTIRELY and a human approves
+		# a create never seeing its line items.
+		args = self._args([{"doctype": "NoSuchDoctype9", "values": {
+			"customer": "X", "items": [{"item_code": "I-1"}, {"item_code": "I-2"}]}}])
+		would = {"created": [{"doctype": "NoSuchDoctype9", "name": "N-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertIn("2 rows", {r["value"] for r in card["records"][0]["rows"]})
+
+	def test_tables_past_MAX_TABLES_degrade_to_N_rows(self):
+		# The spec's caps section promises the overflow degrades to "N rows", not
+		# that it disappears.
+		from jarvis.chat._record_summary import _MAX_TABLES
+		values = {"customer": "X"}
+		for i in range(_MAX_TABLES + 1):
+			values[f"table_{i}"] = [{"a": 1}]
+		args = self._args([{"doctype": "ToDo", "values": values}])
+		would = {"created": [{"doctype": "ToDo", "name": "T-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		rendered = len(card["records"][0]["tables"])
+		self.assertLessEqual(rendered, _MAX_TABLES)
+		# every table key not rendered as a table still appears as a row
+		self.assertEqual(
+			len([r for r in card["records"][0]["rows"] if r["value"].endswith("row")]),
+			(_MAX_TABLES + 1) - rendered)
+
+	def test_child_tables_render_per_record(self):
+		args = self._args([{"doctype": "Sales Invoice", "values": {
+			"customer": "X", "items": [{"item_code": "I-1", "qty": 2}]}}])
+		would = {"created": [{"doctype": "Sales Invoice", "name": "SI-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertTrue(card["records"][0]["tables"])
+		self.assertEqual(card["records"][0]["tables"][0]["count"], 1)
+
+	def test_secret_values_are_masked(self):
+		args = self._args([{"doctype": "ToDo", "values": {
+			"description": "x", "api_token": "sk-live-1"}}])
+		would = {"created": [{"doctype": "ToDo", "name": "T-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertNotIn("sk-live-1", str(card))
+
+	def test_create_docs_shim_gets_the_same_card(self):
+		# The deprecated shim delegates to create_doc's batch path; build_card
+		# dispatched on tool == "create_doc" only, so an old plugin still advertising
+		# jarvis__create_docs fell back to the raw rendering.
+		args = self._args([{"doctype": "ToDo", "values": {"description": "x"}}])
+		would = {"created": [{"doctype": "ToDo", "name": "T-1"}]}
+		card = build_card("create_docs", args, {"would": would})
+		self.assertEqual(card["kind"], "batch_create")
+
+	def test_old_bundle_keys_are_kept(self):
+		# `rows` ({doctype,name}) and `count`/`extra` are what a client running the
+		# previous bundle reads. Additive only.
+		args = self._args([{"doctype": "ToDo", "values": {"description": "x"}}])
+		would = {"created": [{"doctype": "ToDo", "name": "T-1"}]}
+		card = build_card("create_doc", args, {"would": would})
+		self.assertEqual(card["rows"], [{"doctype": "ToDo", "name": "T-1"}])
+		self.assertEqual(card["count"], 1)

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -715,6 +715,17 @@ class TestSkillAndWikiCards(FrappeTestCase):
 		card = build_card("update_wiki", {"slug": "pricing", "replace_body_md": ""}, {})
 		self.assertEqual(card["mode"], "replace")
 
+	def test_wiki_append_wins_over_an_empty_replace_exactly_as_the_tool_does(self):
+		# The tool applies APPEND FIRST (update_wiki.py:143-146; new page :165), so
+		# replace_body_md="" + append_md=X slips the falsy both-args guard (:96) and
+		# APPENDS X. A card checking replace first renders an EMPTY ERASE over a call
+		# that persists text the card never showed - a phantom action and a hidden
+		# real one in one shape, reachable by a prompt-injected agent.
+		card = build_card("update_wiki", {
+			"slug": "s", "replace_body_md": "", "append_md": "injected section"}, {})
+		self.assertEqual(card["mode"], "append")
+		self.assertIn("injected section", card["body"])
+
 	def test_wiki_renders_the_summary_it_persists(self):
 		# summary is stored (update_wiki.py:141-142); a summary-only call would
 		# otherwise be an empty "meta" card over text that gets written.

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -666,3 +666,67 @@ class TestShareAndAssignCards(FrappeTestCase):
 				"doctype": "ToDo", "name": self.todo.name, "user": "x@y.test"}, {})
 		self.assertEqual(card["records"][0]["title"], "")
 		self.assertNotIn("share probe", str(card))
+
+
+class TestSkillAndWikiCards(FrappeTestCase):
+	def test_skill_renders_the_instructions_body(self):
+		# The card was the literal string "create_custom_skill". You approved
+		# persistent agent instructions - the prompt-injection persistence vector -
+		# seeing nothing at all.
+		card = build_card("create_custom_skill", {
+			"skill_name": "Weekly report", "description": "d",
+			"instructions": "Always include the pipeline table." * 50}, {})
+		self.assertEqual(card["kind"], "skill")
+		self.assertEqual(card["skill_name"], "Weekly report")
+		self.assertIn("Always include the pipeline table.", card["instructions"])
+
+	def test_skill_instructions_use_the_long_form_budget(self):
+		from jarvis.chat._record_summary import _MAX_BODY
+		card = build_card("create_custom_skill", {
+			"skill_name": "s", "description": "d", "instructions": "x" * 20000}, {})
+		self.assertGreater(len(card["instructions"]), 200)  # not the scalar cap
+		self.assertLessEqual(len(card["instructions"]), _MAX_BODY)
+
+	def test_skill_scope_shows_the_effective_value_not_the_request(self):
+		# create_custom_skill.py:44-57 computes `requested` then hardcodes
+		# "scope": "User". Echoing args.scope would claim a bench-wide skill while
+		# creating a private one.
+		card = build_card("create_custom_skill", {
+			"skill_name": "s", "description": "d", "instructions": "i",
+			"scope": "Org"}, {})
+		self.assertEqual(card["scope"], "User (private)")
+
+	def test_wiki_flags_a_full_replace(self):
+		card = build_card("update_wiki", {
+			"slug": "pricing", "replace_body_md": "brand new body"}, {})
+		self.assertEqual(card["kind"], "wiki")
+		self.assertEqual(card["slug"], "pricing")
+		self.assertEqual(card["mode"], "replace")
+		self.assertIn("brand new body", card["body"])
+
+	def test_wiki_append_is_not_a_replace(self):
+		card = build_card("update_wiki", {"slug": "pricing", "append_md": "one more line"}, {})
+		self.assertEqual(card["mode"], "append")
+		self.assertIn("one more line", card["body"])
+
+	def test_wiki_empty_replace_is_flagged_as_a_replace_not_meta(self):
+		# update_wiki.py:146 is `is not None`, so replace_body_md="" WIPES the page.
+		# Truthiness would classify the erase as an innocuous metadata edit.
+		card = build_card("update_wiki", {"slug": "pricing", "replace_body_md": ""}, {})
+		self.assertEqual(card["mode"], "replace")
+
+	def test_wiki_renders_the_summary_it_persists(self):
+		# summary is stored (update_wiki.py:141-142); a summary-only call would
+		# otherwise be an empty "meta" card over text that gets written.
+		card = build_card("update_wiki", {"slug": "pricing", "summary": "what changed"}, {})
+		self.assertIn("what changed", card["summary"])
+
+
+class TestDescribeCall(FrappeTestCase):
+	def test_describe_call_surfaces_user_skill_and_slug(self):
+		from jarvis.api import _describe_call
+		self.assertIn("x@y.test", _describe_call(
+			"share_doc", {"doctype": "ToDo", "name": "T-1", "user": "x@y.test"}))
+		self.assertIn("Weekly report", _describe_call(
+			"create_custom_skill", {"skill_name": "Weekly report"}))
+		self.assertIn("pricing", _describe_call("update_wiki", {"slug": "pricing"}))

--- a/jarvis/tests/test_confirm_card.py
+++ b/jarvis/tests/test_confirm_card.py
@@ -108,10 +108,6 @@ class TestEmailAndMethodCards(FrappeTestCase):
 		self.assertEqual(card["subject"], "Hi")
 		self.assertEqual(card["body"], "the body")
 
-	def test_bulk_email_falls_back(self):
-		card = build_card("send_email", {"messages": [{"recipients": "a@x.test"}]}, {})
-		self.assertIsNone(card)
-
 	def test_method_masks_secret_arg_keys(self):
 		card = build_card(
 			"run_method",
@@ -521,3 +517,56 @@ class TestBatchCreateContent(FrappeTestCase):
 		card = build_card("create_doc", args, {"would": would})
 		self.assertEqual(card["rows"], [{"doctype": "ToDo", "name": "T-1"}])
 		self.assertEqual(card["count"], 1)
+
+
+class TestBulkEmailCard(FrappeTestCase):
+	def _msgs(self, n=2):
+		return [
+			{"doctype": "Sales Invoice", "name": f"SI-{i}",
+			 "recipients": f"c{i}@x.test", "subject": f"Invoice SI-{i}",
+			 "content": f"Dear customer {i}, your invoice is attached."}
+			for i in range(n)
+		]
+
+	def test_bulk_email_renders_a_card_not_none(self):
+		# It returned None: you confirmed 20 irreversible emails seeing only
+		# "send_email count=20 targets=[SI-0001, ...]" - document names, no
+		# recipients, no subject, no body.
+		card = build_card("send_email", {"messages": self._msgs(2)}, {})
+		self.assertIsNotNone(card)
+		self.assertEqual(card["kind"], "bulk_email")
+		self.assertEqual(card["count"], 2)
+
+	def test_each_message_shows_recipient_subject_and_body(self):
+		card = build_card("send_email", {"messages": self._msgs(2)}, {})
+		m = card["messages"][0]
+		self.assertEqual(m["recipients"], "c0@x.test")
+		self.assertEqual(m["subject"], "Invoice SI-0")
+		self.assertIn("Dear customer 0", m["body"])
+
+	def test_recipient_list_is_joined(self):
+		card = build_card("send_email", {"messages": [
+			{"recipients": ["a@x.test", "b@x.test"], "subject": "s", "content": "c"}]}, {})
+		self.assertEqual(card["messages"][0]["recipients"], "a@x.test, b@x.test")
+
+	def test_bodies_use_the_bulk_body_budget(self):
+		from jarvis.chat._record_summary import _MAX_BULK_BODY
+		card = build_card("send_email", {"messages": [
+			{"recipients": "a@x.test", "subject": "s", "content": "x" * 5000}]}, {})
+		self.assertLessEqual(len(card["messages"][0]["body"]), _MAX_BULK_BODY)
+
+	def test_messages_are_capped_with_a_remainder(self):
+		card = build_card("send_email", {"messages": self._msgs(_MAX_ROWS + 3)}, {})
+		self.assertEqual(len(card["messages"]), _MAX_ROWS)
+		self.assertEqual(card["count"], _MAX_ROWS + 3)
+		self.assertEqual(card["extra"], 3)
+
+	def test_single_email_shows_cc_bcc_and_print_format(self):
+		# None of these rendered before - you could not see who was copied.
+		card = build_card("send_email", {
+			"recipients": "a@x.test", "subject": "Hi", "content": "body",
+			"cc": ["c@x.test"], "bcc": "b@x.test", "print_format": "Standard"}, {})
+		self.assertEqual(card["kind"], "email")
+		self.assertEqual(card["cc"], "c@x.test")
+		self.assertEqual(card["bcc"], "b@x.test")
+		self.assertEqual(card["print_format"], "Standard")

--- a/jarvis/tests/test_get_creation_context.py
+++ b/jarvis/tests/test_get_creation_context.py
@@ -132,6 +132,61 @@ class TestGetCreationContext(FrappeTestCase):
             frappe.set_user("Administrator")
 
 
+class TestCreationContextAutoAndDefaults(FrappeTestCase):
+    """`auto` must mean "Frappe COMPUTES this" (fetch_from), not "Frappe has a
+    guess for it" (default).
+
+    Conflating them made every defaulted field invisible: the agent was told to
+    skip `auto` fields, so three ToDos were created due today and the human was
+    never shown the date. A default is a decision - surface it and let the model
+    decide.
+    """
+
+    def _field(self, ctx, fieldname):
+        for f in ctx["fields"]:
+            if f["fieldname"] == fieldname:
+                return f
+        self.fail(f"{fieldname} is missing from the field map")
+
+    def test_fetch_from_field_is_auto_and_carries_no_default(self):
+        """ToDo.assigned_by_full_name is `fetch_from: assigned_by.full_name` -
+        Frappe computes it, so skipping it is genuinely safe."""
+        f = self._field(get_creation_context("ToDo"), "assigned_by_full_name")
+        self.assertTrue(f["auto"])
+        self.assertNotIn("default", f)
+
+    def test_defaulted_field_is_not_auto_and_surfaces_its_default(self):
+        """ToDo.date defaults to Today. Frappe GUESSES it, so the model must see
+        both that it is not auto and what the guess is."""
+        f = self._field(get_creation_context("ToDo"), "date")
+        self.assertFalse(f["auto"])
+        self.assertEqual(f["default"], "Today")
+
+    def test_reqd_field_is_still_mandatory(self):
+        """`mandatory` is computed from df.reqd independently of `auto`, so
+        splitting `auto` cannot move it."""
+        f = self._field(get_creation_context("ToDo"), "description")
+        self.assertTrue(f["mandatory"])
+
+    def test_reqd_with_default_is_mandatory_and_not_auto(self):
+        """Sales Order.transaction_date is reqd AND defaults to Today - the
+        double-bind the note's ordering exists to resolve."""
+        f = self._field(get_creation_context("Sales Order"), "transaction_date")
+        self.assertTrue(f["mandatory"])
+        self.assertFalse(f["auto"])
+        self.assertEqual(f["default"], "Today")
+
+    def test_note_carries_the_default_and_symbolic_default_clauses(self):
+        note = get_creation_context("ToDo")["note"]
+        # a default is decided, not skipped
+        self.assertIn("decide it yourself", note)
+        # `Today` / `:Company` are tokens Frappe resolves, never values to copy
+        self.assertIn("never copy the token as a value", note)
+        # the mandatory command is scoped to what the default rule left over,
+        # so a reqd+default field is not commanded and permitted at once
+        self.assertIn("remaining", note)
+
+
 class TestCreationContextMappedSource(FrappeTestCase):
     """A derived record (invoice from an order) gets the ERP's own mapper output
     instead of lookalikes to infer from.

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -168,3 +168,55 @@ class TestPickFields(FrappeTestCase):
 
 	def test_no_meta_returns_empty(self):
 		self.assertEqual(pick_fields(None), [])
+
+
+from unittest.mock import patch
+
+from jarvis.chat._record_summary import summary_rows
+
+
+class TestSummaryRows(FrappeTestCase):
+	def setUp(self):
+		self.todo = frappe.get_doc({
+			"doctype": "ToDo", "description": "card summary probe", "priority": "High",
+		}).insert(ignore_permissions=True)
+
+	def test_returns_title_and_rows_for_a_readable_record(self):
+		out = summary_rows("ToDo", self.todo.name)
+		self.assertIsNotNone(out)
+		self.assertIn("rows", out)
+		values = {r["value"] for r in out["rows"]}
+		self.assertIn("High", values)
+
+	def test_missing_record_returns_none(self):
+		self.assertIsNone(summary_rows("ToDo", "does-not-exist-xyz"))
+
+	def test_missing_record_leaves_no_message_in_the_log(self):
+		# frappe.throw leaves an entry in message_log that would otherwise leak into
+		# the turn. Pre-existing latent bug in _bulk_update_card's catch.
+		frappe.clear_messages()
+		summary_rows("ToDo", "does-not-exist-xyz")
+		self.assertFalse(frappe.get_message_log())
+
+	def test_unreadable_record_returns_none_and_no_title(self):
+		# THE permission fix. get_doc checks nothing (document.py:141-145 -> :336-349
+		# defaults check_permission to None) and apply_fieldlevel_read_permissions is
+		# permlevel-only, so without has_permission the card would render the
+		# customer name of a record the user cannot read.
+		# FrappeTestCase runs as Administrator, whose permission checks early-return,
+		# so assert the CALL, not the effect.
+		with patch("frappe.model.document.Document.has_permission", return_value=False) as hp:
+			out = summary_rows("ToDo", self.todo.name)
+		hp.assert_called_once_with("read")
+		self.assertIsNone(out)
+
+	def test_permission_is_checked_before_any_field_is_read(self):
+		with patch("frappe.model.document.Document.has_permission", return_value=False):
+			with patch("frappe.model.document.Document.apply_fieldlevel_read_permissions") as afl:
+				summary_rows("ToDo", self.todo.name)
+		afl.assert_not_called()
+
+	def test_submittable_doctype_gets_a_synthetic_docstatus_row(self):
+		# docstatus is not a DocField, so pick_fields cannot select it.
+		out = summary_rows("ToDo", self.todo.name)
+		self.assertIsNotNone(out)  # ToDo is not submittable; just assert no crash

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -1,0 +1,61 @@
+"""Tests for jarvis.chat._record_summary - field selection, permission-checked doc
+reads, Frappe-correct formatting, and cast-compare no-op detection.
+
+These back every confirmation card. A bug here is a card that misdescribes a write.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat._record_summary import _MAX_VAL, fmt
+
+
+def _df(**kwargs):
+	"""A stand-in DocField. format_value only reads attributes, so a _dict is enough."""
+	return frappe._dict(kwargs)
+
+
+class TestFmt(FrappeTestCase):
+	def test_check_uses_cint_so_string_zero_is_no(self):
+		# format_value has no Check branch (formatters.py:146) and returns 1/0. A
+		# model sends "0" as a string; naive truthiness would render "Yes" and
+		# fabricate a phantom change on a gated card.
+		df = _df(fieldtype="Check", fieldname="disabled")
+		self.assertEqual(fmt(0, df), "No")
+		self.assertEqual(fmt("0", df), "No")
+		self.assertEqual(fmt(1, df), "Yes")
+		self.assertEqual(fmt("1", df), "Yes")
+
+	def test_html_fieldtypes_bypass_format_value(self):
+		# format_value turns newlines into <br> for Text; the cards escape every
+		# value, so that would render as literal tags.
+		df = _df(fieldtype="Small Text", fieldname="notes")
+		self.assertEqual(fmt("a\nb", df), "a\nb")
+
+	def test_percent_formats(self):
+		df = _df(fieldtype="Percent", fieldname="pct")
+		self.assertEqual(fmt(12.5, df), "12.5%")
+
+	def test_list_renders_row_count(self):
+		self.assertEqual(fmt([1, 2, 3]), "3 rows")
+		self.assertEqual(fmt([1]), "1 row")
+
+	def test_none_renders_empty(self):
+		self.assertEqual(fmt(None), "")
+
+	def test_truncates_at_limit(self):
+		out = fmt("x" * 500)
+		self.assertEqual(len(out), _MAX_VAL)
+		self.assertTrue(out.endswith("…"))
+
+	def test_limit_is_overridable_for_long_form_bodies(self):
+		out = fmt("x" * 500, limit=8000)
+		self.assertEqual(out, "x" * 500)
+
+	def test_raising_field_falls_back_to_str(self):
+		# format_value can raise (get_field_currency attribute access, meta.py:886).
+		# One odd field must never blank a whole card. Assert the VALUE, not the type:
+		# fmt always returns a str, so assertIsInstance would pass even with the
+		# except branch deleted.
+		df = _df(fieldtype="Currency", fieldname="amount", options="bad_link_field")
+		self.assertEqual(fmt(5, df, doc=object()), "5")

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -59,3 +59,77 @@ class TestFmt(FrappeTestCase):
 		# except branch deleted.
 		df = _df(fieldtype="Currency", fieldname="amount", options="bad_link_field")
 		self.assertEqual(fmt(5, df, doc=object()), "5")
+
+
+from jarvis.chat._record_summary import same_value
+
+
+class TestSameValue(FrappeTestCase):
+	def test_typed_float_equals_string_request(self):
+		# The phantom-diff case display comparison was introduced to fix: the DB
+		# holds a typed 100.0, the model sends "100". The save changes nothing.
+		df = _df(fieldtype="Currency", fieldname="rate")
+		self.assertTrue(same_value(100.0, "100", df))
+
+	def test_rounding_collision_is_NOT_a_no_op(self):
+		# THE regression this rule exists for. fmt_money at precision 2 renders both
+		# as "100.00"; a display compare would drop the row and the card would omit
+		# a change the confirm writes.
+		df = _df(fieldtype="Currency", fieldname="rate")
+		self.assertFalse(same_value(100.005, "100.001", df))
+
+	def test_float_precision_collision_is_NOT_a_no_op(self):
+		df = _df(fieldtype="Float", fieldname="exchange_rate")
+		self.assertFalse(same_value(83.1234, "83.1236", df))
+
+	def test_check_string_zero_is_a_no_op(self):
+		df = _df(fieldtype="Check", fieldname="disabled")
+		self.assertTrue(same_value(0, "0", df))
+		self.assertFalse(same_value(0, "1", df))
+
+	def test_none_equals_empty_string(self):
+		self.assertTrue(same_value(None, ""))
+
+	def test_uncastable_value_counts_as_changed(self):
+		# Never hide a row because we could not compare it. Garbage bounces pre-card
+		# via _DRY_RUN_ON_PARK anyway (api.py:1033-1039); this is a safety net.
+		df = _df(fieldtype="Currency", fieldname="rate")
+		self.assertFalse(same_value(100.0, object(), df))
+
+	def test_dates_compare_across_types(self):
+		# A typed date from the DB vs the model's string. Comparing two identical
+		# STRINGS here would pass even with Date missing from _CAST entirely.
+		import datetime
+		df = _df(fieldtype="Date", fieldname="due_date")
+		self.assertTrue(same_value(datetime.date(2026, 7, 17), "2026-07-17", df))
+		self.assertFalse(same_value(datetime.date(2026, 7, 17), "2026-07-18", df))
+
+	def test_setting_a_date_to_today_on_an_empty_field_is_NOT_a_no_op(self):
+		# getdate(None) returns TODAY (frappe/utils/data.py:125-126). A bare getdate
+		# cast would compare today to today and silently drop "due today" - a routine
+		# request - from a gated card.
+		from frappe.utils import nowdate
+		df = _df(fieldtype="Date", fieldname="due_date")
+		self.assertFalse(same_value(None, nowdate(), df))
+		self.assertFalse(same_value(nowdate(), None, df))
+
+	def test_empty_dates_are_equal_to_each_other(self):
+		df = _df(fieldtype="Date", fieldname="due_date")
+		self.assertTrue(same_value(None, "", df))
+		self.assertTrue(same_value(None, None, df))
+
+	def test_empty_datetimes_do_not_produce_a_phantom_change(self):
+		# get_datetime(None) returns now() (data.py:164-165); two calls microseconds
+		# apart would render "(empty) -> (empty)" as a change.
+		df = _df(fieldtype="Datetime", fieldname="starts_on")
+		self.assertTrue(same_value(None, None, df))
+
+	def test_invalid_datetime_strings_are_not_equal(self):
+		# get_datetime returns None for garbage rather than raising, so two different
+		# invalid strings would otherwise compare equal (None == None).
+		df = _df(fieldtype="Datetime", fieldname="starts_on")
+		self.assertFalse(same_value("not-a-date", "also-not-a-date", df))
+
+	def test_no_df_falls_back_to_string_compare(self):
+		self.assertTrue(same_value("abc", "abc"))
+		self.assertFalse(same_value("abc", "abd"))

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -217,6 +217,19 @@ class TestSummaryRows(FrappeTestCase):
 		afl.assert_not_called()
 
 	def test_submittable_doctype_gets_a_synthetic_docstatus_row(self):
-		# docstatus is not a DocField, so pick_fields cannot select it.
+		# docstatus is not a DocField, so pick_fields cannot select it and
+		# summary_rows appends it. ToDo is not submittable, so flip the meta flag:
+		# the branch reads meta.is_submittable and doc.docstatus, and this exercises
+		# both. (Asserting only "no crash" on a non-submittable doctype would ship
+		# this branch with zero coverage.)
+		self.todo.db_set("docstatus", 1)
+		meta = frappe.get_meta("ToDo")
+		with patch.object(meta, "is_submittable", 1):
+			out = summary_rows("ToDo", self.todo.name)
+		row = next((r for r in out["rows"] if r["label"] == "Docstatus"), None)
+		self.assertIsNotNone(row)
+		self.assertEqual(row["value"], "Submitted")
+
+	def test_non_submittable_doctype_has_no_docstatus_row(self):
 		out = summary_rows("ToDo", self.todo.name)
-		self.assertIsNotNone(out)  # ToDo is not submittable; just assert no crash
+		self.assertNotIn("Docstatus", {r["label"] for r in out["rows"]})

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -230,6 +230,17 @@ class TestSummaryRows(FrappeTestCase):
 		self.assertIsNotNone(row)
 		self.assertEqual(row["value"], "Submitted")
 
+	def test_docstatus_row_does_not_exceed_the_row_cap(self):
+		# The synthetic row is appended AFTER the capped loop breaks, so without a
+		# reserved slot a submittable doctype returns _MAX_ROWS + 1 rows and the
+		# documented cap is a lie.
+		from jarvis.chat._record_summary import _MAX_ROWS
+		meta = frappe.get_meta("ToDo")
+		with patch.object(meta, "is_submittable", 1):
+			out = summary_rows("ToDo", self.todo.name)
+		self.assertLessEqual(len(out["rows"]), _MAX_ROWS)
+		self.assertEqual(out["rows"][-1]["label"], "Docstatus")
+
 	def test_non_submittable_doctype_has_no_docstatus_row(self):
 		out = summary_rows("ToDo", self.todo.name)
 		self.assertNotIn("Docstatus", {r["label"] for r in out["rows"]})

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -270,3 +270,62 @@ class TestValuesRows(FrappeTestCase):
 		out = values_rows(None, {"whatever": "v"})
 		self.assertEqual(out["rows"][0]["label"], "whatever")
 		self.assertEqual(out["extra"], 0)
+
+
+from jarvis.chat._record_summary import table_rows
+
+
+class TestTableRows(FrappeTestCase):
+	def test_columns_union_includes_caller_set_keys_outside_list_view(self):
+		# THE rule. Sales Invoice Item's list-view columns are item/qty/rate/amount;
+		# a batch that also sets income_account on every row must not write it
+		# invisibly. ``columns`` holds LABELS for rendering; ``fieldnames`` is the
+		# machine-readable list, so assert against that.
+		meta = frappe.get_meta("Sales Invoice")
+		rows = [{"item_code": "ITEM-1", "qty": 2, "income_account": "Sales - X"}]
+		out = table_rows(meta, "items", rows)
+		self.assertIn("income_account", out["fieldnames"])
+
+	def test_renders_cells_for_each_row(self):
+		meta = frappe.get_meta("Sales Invoice")
+		rows = [{"item_code": "ITEM-1", "qty": 2}, {"item_code": "ITEM-2", "qty": 3}]
+		out = table_rows(meta, "items", rows)
+		self.assertEqual(out["count"], 2)
+		self.assertEqual(len(out["rows"]), 2)
+
+	def test_caps_rows_and_reports_the_remainder(self):
+		meta = frappe.get_meta("Sales Invoice")
+		rows = [{"item_code": f"I-{i}"} for i in range(_MR + 3)]
+		out = table_rows(meta, "items", rows)
+		self.assertEqual(len(out["rows"]), _MR)
+		self.assertEqual(out["extra"], 3)
+
+	def test_a_key_that_is_not_a_child_field_is_counted_not_rendered(self):
+		# The save drops it (fails valid_columns); rendering it as a written value
+		# would violate the effective-values invariant.
+		meta = frappe.get_meta("Sales Invoice")
+		out = table_rows(meta, "items", [{"item_code": "I-1", "not_a_real_field": "x"}])
+		self.assertNotIn("not_a_real_field", out["fieldnames"])
+		self.assertEqual(out["unknown_columns"], 1)
+
+	def test_unknown_key_is_counted_once_not_once_per_row(self):
+		# An unknown key never enters `proposed`, so a plain counter re-increments on
+		# every row: 3 rows -> unknown_columns=3 for ONE bad field.
+		meta = frappe.get_meta("Sales Invoice")
+		rows = [{"item_code": f"I-{i}", "not_a_real_field": "x"} for i in range(3)]
+		out = table_rows(meta, "items", rows)
+		self.assertEqual(out["unknown_columns"], 1)
+
+	def test_columns_are_capped_at_MAX_COLS_not_MAX_ROWS(self):
+		meta = frappe.get_meta("Sales Invoice")
+		child = frappe.get_meta(meta.get_field("items").options)
+		many = {d.fieldname: "v" for d in child.fields[:15] if d.fieldtype not in ("Section Break", "Column Break")}
+		out = table_rows(meta, "items", [many])
+		self.assertLessEqual(len(out["fieldnames"]), 8)
+		self.assertGreater(out["extra_columns"], 0)
+
+	def test_unknown_table_field_returns_none(self):
+		self.assertIsNone(table_rows(frappe.get_meta("ToDo"), "nope", [{"a": 1}]))
+
+	def test_empty_rows_returns_none(self):
+		self.assertIsNone(table_rows(frappe.get_meta("Sales Invoice"), "items", []))

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -133,3 +133,38 @@ class TestSameValue(FrappeTestCase):
 	def test_no_df_falls_back_to_string_compare(self):
 		self.assertTrue(same_value("abc", "abc"))
 		self.assertFalse(same_value("abc", "abd"))
+
+
+from jarvis.chat._record_summary import _MAX_FLOOR, pick_fields
+
+
+class TestPickFields(FrappeTestCase):
+	def test_floor_includes_title_and_list_view_fields(self):
+		fields = pick_fields(frappe.get_meta("ToDo"))
+		self.assertIn("description", fields)
+		self.assertNotIn("name", fields)  # name is the row header, not a row
+
+	def test_floor_is_capped_and_deduped(self):
+		fields = pick_fields(frappe.get_meta("User"))
+		self.assertLessEqual(len(fields), _MAX_FLOOR)
+		self.assertEqual(len(fields), len(set(fields)))
+
+	def test_floor_excludes_child_tables(self):
+		meta = frappe.get_meta("User")
+		for f in pick_fields(meta):
+			self.assertNotIn(meta.get_field(f).fieldtype, ("Table", "Table MultiSelect"))
+
+	def test_long_text_fieldtypes_sort_last(self):
+		# data_fieldtypes includes Text Editor / Markdown Editor / Code, so a 10k
+		# body field can be in_list_view and would otherwise take a floor slot from
+		# the customer and the total.
+		meta = frappe.get_meta("ToDo")
+		fields = pick_fields(meta)
+		types = [meta.get_field(f).fieldtype for f in fields]
+		long_idx = [i for i, t in enumerate(types) if t in ("Text Editor", "Markdown Editor", "Code")]
+		short_idx = [i for i, t in enumerate(types) if t not in ("Text Editor", "Markdown Editor", "Code")]
+		if long_idx and short_idx:
+			self.assertGreater(min(long_idx), max(short_idx))
+
+	def test_no_meta_returns_empty(self):
+		self.assertEqual(pick_fields(None), [])

--- a/jarvis/tests/test_record_summary.py
+++ b/jarvis/tests/test_record_summary.py
@@ -233,3 +233,40 @@ class TestSummaryRows(FrappeTestCase):
 	def test_non_submittable_doctype_has_no_docstatus_row(self):
 		out = summary_rows("ToDo", self.todo.name)
 		self.assertNotIn("Docstatus", {r["label"] for r in out["rows"]})
+
+
+from jarvis.chat._record_summary import _MAX_ROWS as _MR
+from jarvis.chat._record_summary import values_rows
+
+
+class TestValuesRows(FrappeTestCase):
+	def test_renders_every_proposed_key_not_just_floor_fields(self):
+		# Design decision 3: proposed content is shown WHOLE. A field outside the
+		# meta floor is one the save will write - hiding it would let you approve a
+		# value you never saw.
+		meta = frappe.get_meta("ToDo")
+		out = values_rows(meta, {"description": "x", "color": "#fff"})
+		labels = {r["label"] for r in out["rows"]}
+		self.assertEqual(len(out["rows"]), 2)
+		self.assertTrue(any("olor" in la for la in labels))
+
+	def test_preserves_caller_order(self):
+		meta = frappe.get_meta("ToDo")
+		out = values_rows(meta, {"priority": "High", "description": "x"})
+		self.assertEqual(out["rows"][0]["value"], "High")
+
+	def test_caps_and_reports_the_remainder(self):
+		values = {f"f{i}": f"v{i}" for i in range(_MR + 5)}
+		out = values_rows(None, values)
+		self.assertEqual(len(out["rows"]), _MR)
+		self.assertEqual(out["extra"], 5)
+
+	def test_masks_secrets(self):
+		out = values_rows(None, {"api_key": "sk-live-123"})
+		self.assertEqual(out["rows"][0]["value"], "[hidden]")
+		self.assertNotIn("sk-live-123", str(out))
+
+	def test_no_meta_falls_back_to_fieldnames(self):
+		out = values_rows(None, {"whatever": "v"})
+		self.assertEqual(out["rows"][0]["label"], "whatever")
+		self.assertEqual(out["extra"], 0)

--- a/jarvis/tools/get_creation_context.py
+++ b/jarvis/tools/get_creation_context.py
@@ -156,10 +156,14 @@ def _result(
         "facets": facets,
         "note": (
             "Reference only - decide each field yourself from these examples "
-            "and the user's input; never copy blindly. Set every `mandatory` "
-            "field that is not already `auto` before create_doc; skip "
-            "`auto`/`readonly` fields (Frappe fills those). Ask the user only "
-            "about mandatory fields you cannot determine."
+            "and the user's input; never copy blindly. Skip `auto`/`readonly` "
+            "fields (Frappe computes those). A field with a `default` is NOT "
+            "auto - Frappe applies the default silently, so decide it "
+            "yourself: leave it out to accept the default, set it when the "
+            "default is wrong for this record; a symbolic default (`Today`, "
+            "`:Company`) is resolved by Frappe - never copy the token as a "
+            "value. Set every remaining `mandatory` field before create_doc. "
+            "Ask the user only about mandatory fields you cannot determine."
         ),
     }
     if mapped is not None:
@@ -240,9 +244,15 @@ def _field_map(meta) -> list[dict]:
             "fieldtype": df.fieldtype,
             "options": df.options,
             "mandatory": bool(df.reqd),
-            "auto": bool(df.fetch_from) or (df.default not in (None, "")),
+            # `auto` means Frappe COMPUTES this (fetch_from) - skipping it is safe.
+            # A field with a DEFAULT is different: Frappe GUESSES it, and the guess is
+            # a decision the human never sees unless it reaches the draft. Surface the
+            # default value and let the model decide, rather than hiding both.
+            "auto": bool(df.fetch_from),
             "readonly": bool(df.read_only),
         }
+        if df.default not in (None, ""):
+            rec["default"] = df.default
         cond = getattr(df, "mandatory_depends_on", None)
         if cond:
             rec["mandatory_if"] = cond

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -43,7 +43,7 @@ function onEvent(p) {
 		store.applyRename(p.conversation_id, p.title)
 	} else if (p.kind === "conversation:new") {
 		store.loadConversations()
-	} else if (p.kind === "run:end" && prefs.notifyDone) {
+	} else if (p.kind === "run:end" && !p.stopped && prefs.notifyDone) {
 		const title = store.conversations.find((c) => c.name === conv)?.title || "Jarvis"
 		notify("Jarvis finished", title, conv)
 	} else if (p.kind === "action:pending" && prefs.notifyDecision) {

--- a/pwa/src/components/ActionCard.vue
+++ b/pwa/src/components/ActionCard.vue
@@ -29,6 +29,17 @@ const heading = computed(
 	() => props.action.title || `${verb.value === "create" ? "Create" : "Update"} ${props.action.doctype || "record"}`,
 )
 
+// No `tables` escape here, unlike the desktop: this card neither renders nor
+// applies child tables, so a block with no `fields` has nothing to show.
+const invalid = computed(() => {
+	if (!isWrite.value) return ""
+	if (Array.isArray(props.action.docs))
+		return "This draft carries a `docs` batch, which is a create_doc payload rather than a card. Ask Jarvis to apply them as a batch."
+	if (verb.value === "create" && !(props.action.fields || []).length)
+		return "This draft has no fields to show."
+	return ""
+})
+
 async function apply() {
 	if (state.value === "busy") return
 	state.value = "busy"
@@ -138,7 +149,7 @@ async function copyBody() {
 			</div>
 		</div>
 
-		<div v-if="error" class="jv-action-err">{{ error }}</div>
+		<div v-if="invalid || error" class="jv-action-err">{{ invalid || error }}</div>
 
 		<div v-if="state === 'done'" class="jv-action-done">
 			<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
@@ -149,7 +160,7 @@ async function copyBody() {
 
 		<div v-else class="jv-action-foot">
 			<button class="jv-btn is-ghost" :disabled="state === 'busy'" @click="emit('dismissed')">Cancel</button>
-			<button class="jv-btn is-primary" :disabled="state === 'busy'" @click="apply">
+			<button class="jv-btn is-primary" :disabled="state === 'busy' || !!invalid" @click="apply">
 				<span v-if="state === 'busy'" class="jv-spinner" />
 				<span v-else>{{ verb === "create" ? "Create" : "Save" }}</span>
 			</button>

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -37,7 +37,7 @@ function tableNote(t) {
 		<template v-if="card.kind === 'create'">
 			<div class="jv-pc-head">Create {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
 			<div v-for="(r, i) in card.rows" :key="i" class="jv-pc-kv"><span>{{ r.label }}</span><b>{{ r.value }}</b></div>
-			<div v-if="!card.rows.length" class="jv-pc-empty">No fields set.</div>
+			<div v-if="!card.rows.length && !(card.tables || []).length" class="jv-pc-empty">No fields set.</div>
 			<div v-for="(t, ti) in (card.tables || [])" :key="'t' + ti" class="jv-pc-table">
 				<div class="jv-pc-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>
 				<div class="jv-pc-table-scroll">

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -112,11 +112,39 @@ function tableNote(t) {
 
 		<template v-else-if="card.kind === 'batch_create'">
 			<div class="jv-pc-head">Create {{ card.count }} record<template v-if="card.count !== 1">s</template></div>
-			<ul class="jv-pc-list">
+			<div v-if="(card.records || []).length" class="jv-pc-recs">
+				<details v-for="(r, i) in card.records" :key="'br' + i" class="jv-pc-rec" :open="i === 0">
+					<summary>
+						<span class="jv-pc-chev" aria-hidden="true"></span>
+						<span class="jv-pc-rid">{{ r.doctype }} <b>{{ r.name }}</b></span>
+					</summary>
+					<div class="jv-pc-rbody">
+						<div v-for="(f, j) in r.rows" :key="'bf' + j" class="jv-pc-kv"><span>{{ f.label }}</span><b>{{ f.value }}</b></div>
+						<div v-if="r.extra > 0" class="jv-pc-more">+{{ r.extra }} more fields</div>
+						<div v-for="(t, ti) in (r.tables || [])" :key="'bt' + ti" class="jv-pc-table">
+							<div class="jv-pc-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>
+							<div class="jv-pc-table-scroll">
+								<table>
+									<thead>
+										<tr><th v-for="(c, ci) in t.columns" :key="'bc' + ci">{{ c }}</th></tr>
+									</thead>
+									<tbody>
+										<tr v-for="(row, ri) in t.rows" :key="'brw' + ri">
+											<td v-for="(cell, di) in row.cells" :key="'bd' + di">{{ cell }}</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<div v-if="tableNote(t)" class="jv-pc-more">{{ tableNote(t) }}</div>
+						</div>
+					</div>
+				</details>
+			</div>
+			<ul v-else class="jv-pc-list">
 				<li v-for="(r, i) in card.rows" :key="i">{{ r.doctype }} <b>{{ r.name }}</b></li>
 				<li v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</li>
 			</ul>
-			<div v-for="(n, i) in card.notes" :key="'n' + i" class="jv-pc-note">{{ n }}</div>
+			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</div>
 		</template>
 
 		<template v-else-if="card.kind === 'bulk_update'">
@@ -203,7 +231,6 @@ function tableNote(t) {
 	.jv-pc-rbody .jv-pc-lbl { grid-column: 1 / -1; }
 }
 @media (prefers-reduced-motion: reduce) { .jv-pc-chev { transition: none; } }
-.jv-pc-note { margin-top: 6px; color: var(--ink5); font-size: 12.5px; }
 .jv-pc-body { margin: 8px 0 0; padding: 10px; border-radius: 8px; background: var(--card2); color: var(--ink7); font-size: 12.5px; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 220px; overflow-y: auto; }
 .jv-pc-details { margin-top: 10px; }
 .jv-pc-details summary { cursor: pointer; color: var(--ink5); font-size: 12px; }

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -16,6 +16,20 @@ const props = defineProps({
 
 const sentence = computed(() =>
 	props.card.kind === "verb" ? verbSentence(props.card) : "")
+
+// The remainder line for a proposed child table. Duplicated from the desktop card
+// rather than shared: the two TEMPLATES are deliberately separate (different class
+// and token vocabularies), and only @shared lib logic crosses. unknown_columns MUST
+// surface - the server counts keys it dropped rather than rendering them, and a
+// count nobody sees makes a silent drop silent again.
+function tableNote(t) {
+	const parts = []
+	if (t.extra > 0) parts.push(`+${t.extra} more rows`)
+	if (t.extra_columns > 0) parts.push(`+${t.extra_columns} more columns`)
+	if (t.unknown_columns > 0)
+		parts.push(`${t.unknown_columns} unrecognized field${t.unknown_columns === 1 ? "" : "s"} ignored`)
+	return parts.join(" · ")
+}
 </script>
 
 <template>
@@ -24,10 +38,26 @@ const sentence = computed(() =>
 			<div class="jv-pc-head">Create {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
 			<div v-for="(r, i) in card.rows" :key="i" class="jv-pc-kv"><span>{{ r.label }}</span><b>{{ r.value }}</b></div>
 			<div v-if="!card.rows.length" class="jv-pc-empty">No fields set.</div>
+			<div v-for="(t, ti) in (card.tables || [])" :key="'t' + ti" class="jv-pc-table">
+				<div class="jv-pc-table-head">{{ t.label }} · {{ t.count }} row<template v-if="t.count !== 1">s</template></div>
+				<div class="jv-pc-table-scroll">
+					<table>
+						<thead>
+							<tr><th v-for="(c, ci) in t.columns" :key="'c' + ci">{{ c }}</th></tr>
+						</thead>
+						<tbody>
+							<tr v-for="(r, ri) in t.rows" :key="'r' + ri">
+								<td v-for="(cell, di) in r.cells" :key="'d' + di">{{ cell }}</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-if="tableNote(t)" class="jv-pc-more">{{ tableNote(t) }}</div>
+			</div>
 		</template>
 
 		<template v-else-if="card.kind === 'update'">
-			<div class="jv-pc-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template></div>
+			<div class="jv-pc-head">Update {{ card.doctype }}<template v-if="card.name"> · {{ card.name }}</template><template v-if="card.title"> · {{ card.title }}</template></div>
 			<div v-for="(d, i) in card.diff" :key="i" class="jv-pc-diff">
 				<span class="jv-pc-lbl">{{ d.label }}</span>
 				<span class="jv-pc-from">{{ d.from || "(empty)" }}</span>
@@ -73,6 +103,7 @@ const sentence = computed(() =>
 					<summary>
 						<span class="jv-pc-chev" aria-hidden="true"></span>
 						<span class="jv-pc-rid">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
 						<span v-if="r.fields?.length" class="jv-pc-rfields">{{ r.fields.join(" · ") }}</span>
 					</summary>
 					<div class="jv-pc-rbody">
@@ -113,6 +144,17 @@ const sentence = computed(() =>
 .jv-pc-list { margin: 5px 0 0; padding-left: 18px; }
 .jv-pc-list li { padding: 1px 0; overflow-wrap: anywhere; }
 .jv-pc-more { list-style: none; color: var(--ink5); }
+/* create: a proposed child table, scrolling inside its own box so the card never
+   scrolls the page sideways */
+.jv-pc-table { margin-top: 10px; }
+.jv-pc-table-head { font-size: 12px; color: var(--ink5); margin-bottom: 4px; }
+.jv-pc-table-scroll { overflow-x: auto; max-height: 240px; overflow-y: auto; -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
+.jv-pc-table table { border-collapse: collapse; width: 100%; font-size: 12px; }
+.jv-pc-table th, .jv-pc-table td { text-align: left; padding: 4px 8px; white-space: nowrap; }
+.jv-pc-table th { color: var(--ink5); font-weight: 500; }
+.jv-pc-table td { color: var(--ink8); font-variant-numeric: tabular-nums; }
+/* scoped: .jv-pc-more is shared with the verb/batch_create <li>s */
+.jv-pc-table .jv-pc-more { font-size: 12px; margin-top: 4px; }
 /* bulk update: collapsible per-record from→to list (touch-first) */
 .jv-pc-sub { font-weight: 400; color: var(--ink5); }
 .jv-pc-cap { font-size: 12px; color: var(--ink5); margin: 0 0 8px; }
@@ -126,6 +168,7 @@ const sentence = computed(() =>
 .jv-pc-chev { flex: none; width: 8px; height: 8px; border-right: 1.7px solid var(--ink5); border-bottom: 1.7px solid var(--ink5); transform: rotate(-45deg); transition: transform .15s ease; margin-left: 2px; }
 .jv-pc-rec[open] > summary .jv-pc-chev { transform: rotate(45deg); }
 .jv-pc-rid { font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: var(--ink9); font-weight: 500; flex: none; }
+.jv-pc-rtitle { font-size: 12px; color: var(--ink7); overflow-wrap: anywhere; }
 .jv-pc-rfields { font-size: 12px; color: var(--ink5); margin-left: auto; text-align: right; overflow-wrap: anywhere; }
 .jv-pc-rbody { padding: 2px 2px 10px 20px; }
 @media (max-width: 460px) {

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -1,10 +1,16 @@
 <script setup>
 // Renders the server-built "what will change" summary (F9) for a parked write's
 // approval sheet - replacing the raw-JSON dump. The structured card comes from
-// jarvis/chat/confirm_card.py (kind = create | update | verb | email | method |
-// batch_create), already perm-filtered + size-capped + secret-masked server-side.
-// Logic (verbSentence) is the SAME helper the desktop uses (@shared). All values
-// render as escaped text; the raw dry-run JSON stays behind a Details expander.
+// jarvis/chat/confirm_card.py (kind = create | update | bulk_update | verb | email |
+// bulk_email | share | assign | skill | wiki | method | batch_create), already
+// perm-filtered + size-capped + secret-masked server-side. Logic (verbSentence) is
+// the SAME helper the desktop uses (@shared). All values render as escaped text;
+// the raw dry-run JSON stays behind a Details expander.
+//
+// A kind rendered here ALSO needs an entry in CARD_KINDS
+// (@shared/lib/actionSummary.js): pendingCardOf returns null for a kind not in that
+// set and the sheet falls back to the raw preview, so a branch added here alone is
+// dead code.
 import { computed } from "vue"
 
 import { verbSentence } from "@shared/lib/actionSummary.js"
@@ -99,10 +105,139 @@ function tableNote(t) {
 			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</div>
 		</template>
 
+		<!-- email: cc/bcc/print format are v-if'd so an empty one adds no row. Without
+		     them "you could not see who was copied" stayed true no matter what the
+		     server sent. The body rides an expander (a _MAX_BODY budget now), open by
+		     default: this is the one tool that cannot be recalled. -->
 		<template v-else-if="card.kind === 'email'">
 			<div class="jv-pc-kv"><span>To</span><b>{{ card.to }}</b></div>
+			<div v-if="card.cc" class="jv-pc-kv"><span>Cc</span><b>{{ card.cc }}</b></div>
+			<div v-if="card.bcc" class="jv-pc-kv"><span>Bcc</span><b>{{ card.bcc }}</b></div>
 			<div class="jv-pc-kv"><span>Subject</span><b>{{ card.subject }}</b></div>
-			<pre v-if="card.body" class="jv-pc-body">{{ card.body }}</pre>
+			<div v-if="card.print_format" class="jv-pc-kv"><span>Print format</span><b>{{ card.print_format }}</b></div>
+			<details v-if="card.body" class="jv-pc-expand" open>
+				<summary>Message</summary>
+				<pre class="jv-pc-body">{{ card.body }}</pre>
+			</details>
+		</template>
+
+		<!-- bulk email: a mail-merge. Every message has its OWN recipient, subject and
+		     body, so each gets its own expander - a count cannot stand in for 20
+		     distinct irreversible emails. -->
+		<template v-else-if="card.kind === 'bulk_email'">
+			<div class="jv-pc-head">Send {{ card.count }} email<template v-if="card.count !== 1">s</template></div>
+			<p class="jv-pc-cap">Each message has its own recipient and body. Tap one to read it.</p>
+			<div class="jv-pc-recs">
+				<details v-for="(m, i) in card.messages" :key="'me' + i" class="jv-pc-rec" :open="i === 0">
+					<summary>
+						<span class="jv-pc-chev" aria-hidden="true"></span>
+						<span class="jv-pc-rid">{{ m.recipients }}</span>
+						<span v-if="m.subject" class="jv-pc-rtitle">{{ m.subject }}</span>
+					</summary>
+					<div class="jv-pc-rbody">
+						<div v-if="m.name" class="jv-pc-kv"><span>About</span><b>{{ m.name }}</b></div>
+						<div v-if="m.cc" class="jv-pc-kv"><span>Cc</span><b>{{ m.cc }}</b></div>
+						<div v-if="m.bcc" class="jv-pc-kv"><span>Bcc</span><b>{{ m.bcc }}</b></div>
+						<pre v-if="m.body" class="jv-pc-body">{{ m.body }}</pre>
+					</div>
+				</details>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more · full list in Details</div>
+		</template>
+
+		<!-- share: grantee + the permission flags. "Read for one person" and
+		     "everyone + write + share" rendered identically before, and those grants are
+		     the exact reason share_doc gates. Flags are filtered IN THE EXPRESSION:
+		     v-for + v-if on one element is invalid in Vue 3 (v-if wins and cannot see
+		     the loop variable), which only warns at compile and throws at render. -->
+		<template v-else-if="card.kind === 'share'">
+			<div class="jv-pc-head">Share {{ card.doctype }}<template v-if="card.count > 1"> · {{ card.count }} records</template></div>
+			<div class="jv-pc-kv"><span>Shared with</span><b>{{ card.grantee }}</b></div>
+			<div class="jv-pc-kv">
+				<span>Grants</span>
+				<b>
+					<span v-for="f in card.flags.filter((x) => x.on)" :key="f.label" class="jv-pc-chip">{{ f.label }}</span>
+					<span v-if="!card.flags.some((x) => x.on)" class="jv-pc-empty">None</span>
+				</b>
+			</div>
+			<div class="jv-pc-kv"><span>Notify by email</span><b>{{ card.notify ? "Yes" : "No" }}</b></div>
+			<div v-if="(card.records || []).length" class="jv-pc-recs">
+				<template v-for="(r, i) in card.records" :key="'sr' + i">
+					<details v-if="r.rows.length" class="jv-pc-rec" :open="i === 0">
+						<summary>
+							<span class="jv-pc-chev" aria-hidden="true"></span>
+							<span class="jv-pc-rid">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+						</summary>
+						<div class="jv-pc-rbody">
+							<div v-for="(f, j) in r.rows" :key="'sf' + j" class="jv-pc-kv"><span>{{ f.label }}</span><b>{{ f.value }}</b></div>
+						</div>
+					</details>
+					<div v-else class="jv-pc-rec jv-pc-rec-bare">
+						<span class="jv-pc-rid">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</div>
+		</template>
+
+		<!-- assign: the assignee and the description that gets EMAILED to them -->
+		<template v-else-if="card.kind === 'assign'">
+			<div class="jv-pc-head">Assign {{ card.doctype }}<template v-if="card.count > 1"> · {{ card.count }} records</template></div>
+			<div class="jv-pc-kv"><span>Assign to</span><b>{{ card.assignee }}</b></div>
+			<div v-if="card.priority" class="jv-pc-kv"><span>Priority</span><b>{{ card.priority }}</b></div>
+			<div v-if="card.date" class="jv-pc-kv"><span>Due date</span><b>{{ card.date }}</b></div>
+			<div class="jv-pc-kv"><span>Notify by email</span><b>{{ card.notify ? "Yes" : "No" }}</b></div>
+			<pre v-if="card.description" class="jv-pc-body">{{ card.description }}</pre>
+			<div v-if="(card.records || []).length" class="jv-pc-recs">
+				<template v-for="(r, i) in card.records" :key="'ar' + i">
+					<details v-if="r.rows.length" class="jv-pc-rec" :open="i === 0">
+						<summary>
+							<span class="jv-pc-chev" aria-hidden="true"></span>
+							<span class="jv-pc-rid">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+						</summary>
+						<div class="jv-pc-rbody">
+							<div v-for="(f, j) in r.rows" :key="'af' + j" class="jv-pc-kv"><span>{{ f.label }}</span><b>{{ f.value }}</b></div>
+						</div>
+					</details>
+					<div v-else class="jv-pc-rec jv-pc-rec-bare">
+						<span class="jv-pc-rid">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<div v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</div>
+		</template>
+
+		<!-- skill: PERSISTENT AGENT INSTRUCTIONS. The card was the literal string
+		     "create_custom_skill". Scope is the tool's EFFECTIVE value, not the request. -->
+		<template v-else-if="card.kind === 'skill'">
+			<div class="jv-pc-head">Create skill<template v-if="card.skill_name"> · {{ card.skill_name }}</template></div>
+			<div class="jv-pc-kv"><span>Scope</span><b>{{ card.scope }}</b></div>
+			<div class="jv-pc-kv"><span>User invocable</span><b>{{ card.user_invocable ? "Yes" : "No" }}</b></div>
+			<div v-if="card.description" class="jv-pc-kv"><span>Description</span><b>{{ card.description }}</b></div>
+			<details v-if="card.instructions" class="jv-pc-expand" open>
+				<summary>Instructions · shape every future session</summary>
+				<pre class="jv-pc-body">{{ card.instructions }}</pre>
+			</details>
+		</template>
+
+		<!-- wiki: replace_body_md is a full rewrite and says so -->
+		<template v-else-if="card.kind === 'wiki'">
+			<div class="jv-pc-head">Update wiki<template v-if="card.slug"> · {{ card.slug }}</template></div>
+			<div v-if="card.title" class="jv-pc-kv"><span>Title</span><b>{{ card.title }}</b></div>
+			<div v-if="card.scope" class="jv-pc-kv"><span>Scope</span><b>{{ card.scope }}</b></div>
+			<div v-if="card.page_type" class="jv-pc-kv"><span>Page type</span><b>{{ card.page_type }}</b></div>
+			<div v-if="card.ref" class="jv-pc-kv"><span>About</span><b>{{ card.ref }}</b></div>
+			<div v-if="card.summary" class="jv-pc-kv"><span>Summary</span><b>{{ card.summary }}</b></div>
+			<div v-if="card.mode === 'replace'" class="jv-pc-warn">Replaces the entire page body</div>
+			<div v-else-if="card.mode === 'append'" class="jv-pc-cap">Appends a section; nothing already recorded is removed.</div>
+			<details v-if="card.body" class="jv-pc-expand" :open="card.mode === 'replace'">
+				<summary>{{ card.mode === "replace" ? "New body" : "Added section" }}</summary>
+				<pre class="jv-pc-body">{{ card.body }}</pre>
+			</details>
 		</template>
 
 		<template v-else-if="card.kind === 'method'">
@@ -232,6 +367,15 @@ function tableNote(t) {
 }
 @media (prefers-reduced-motion: reduce) { .jv-pc-chev { transition: none; } }
 .jv-pc-body { margin: 8px 0 0; padding: 10px; border-radius: 8px; background: var(--card2); color: var(--ink7); font-size: 12.5px; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 220px; overflow-y: auto; }
+/* share: one chip per GRANTED permission (the effective value, not the request) */
+.jv-pc-chip { display: inline-block; margin-left: 4px; padding: 2px 8px; border-radius: 999px; background: var(--card2); border: 1px solid var(--border); font-size: 11.5px; font-weight: 500; color: var(--ink8); }
+/* wiki: a full-body replace is a rewrite, not an edit - it must not read as routine */
+.jv-pc-warn { margin-top: 8px; padding: 6px 10px; border-radius: 7px; background: var(--card2); border-left: 2px solid var(--red, var(--ink5)); color: var(--ink9); font-weight: 500; }
+/* long-form bodies (skill instructions, wiki body, one email) - an 8k body must not
+   dominate the sheet, so it collapses; the expander itself stays visible */
+.jv-pc-expand { margin-top: 10px; }
+.jv-pc-expand summary { cursor: pointer; color: var(--ink5); font-size: 12px; user-select: none; }
+.jv-pc-expand .jv-pc-body { max-height: 260px; }
 .jv-pc-details { margin-top: 10px; }
 .jv-pc-details summary { cursor: pointer; color: var(--ink5); font-size: 12px; }
 .jv-pc-details pre { margin: 6px 0 0; padding: 10px; border-radius: 8px; background: var(--card2); font-size: 12px; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 240px; overflow-y: auto; }

--- a/pwa/src/components/PendingCard.vue
+++ b/pwa/src/components/PendingCard.vue
@@ -67,12 +67,36 @@ function tableNote(t) {
 			<div v-if="!card.diff.length" class="jv-pc-empty">No field changes.</div>
 		</template>
 
+		<!-- ORDER IS LOAD-BEARING: records div -> targets <ul v-else-if> -> +N more.
+		     v-else-if chains to the immediately preceding sibling carrying a v-if, so
+		     putting the +N more div between them would chain the <ul> to IT - and with
+		     extra === 0 (always, via the F16 batch cap) every bulk card would render
+		     its targets twice, once as records and once as the old list. -->
 		<template v-else-if="card.kind === 'verb'">
 			<div class="jv-pc-verb">{{ sentence }}</div>
-			<ul v-if="card.count > 1 && card.targets.length" class="jv-pc-list">
+			<div v-if="(card.records || []).length" class="jv-pc-recs">
+				<template v-for="(r, i) in card.records" :key="'vr' + i">
+					<details v-if="r.rows.length" class="jv-pc-rec" :open="i === 0">
+						<summary>
+							<span class="jv-pc-chev" aria-hidden="true"></span>
+							<span class="jv-pc-rid">{{ r.name }}</span>
+							<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+						</summary>
+						<div class="jv-pc-rbody">
+							<div v-for="(f, j) in r.rows" :key="'vf' + j" class="jv-pc-kv"><span>{{ f.label }}</span><b>{{ f.value }}</b></div>
+						</div>
+					</details>
+					<div v-else class="jv-pc-rec jv-pc-rec-bare">
+						<span class="jv-pc-rid">{{ r.name }}</span>
+						<span v-if="r.title" class="jv-pc-rtitle">{{ r.title }}</span>
+					</div>
+				</template>
+			</div>
+			<ul v-else-if="card.count > 1 && card.targets.length" class="jv-pc-list">
 				<li v-for="(t, i) in card.targets" :key="i">{{ t }}</li>
 				<li v-if="card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</li>
 			</ul>
+			<div v-if="(card.records || []).length && card.extra > 0" class="jv-pc-more">+{{ card.extra }} more</div>
 		</template>
 
 		<template v-else-if="card.kind === 'email'">
@@ -167,6 +191,9 @@ function tableNote(t) {
 .jv-pc-rec > summary:active { background: var(--card2); }
 .jv-pc-chev { flex: none; width: 8px; height: 8px; border-right: 1.7px solid var(--ink5); border-bottom: 1.7px solid var(--ink5); transform: rotate(-45deg); transition: transform .15s ease; margin-left: 2px; }
 .jv-pc-rec[open] > summary .jv-pc-chev { transform: rotate(45deg); }
+/* verb: a name-only record (missing or unreadable) gets no expander, so it needs
+   the <summary> row's touch metrics by hand to line up with its expandable siblings. */
+.jv-pc-rec-bare { display: flex; align-items: center; gap: 10px; min-height: 44px; padding: 8px 2px 8px 20px; }
 .jv-pc-rid { font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: var(--ink9); font-weight: 500; flex: none; }
 .jv-pc-rtitle { font-size: 12px; color: var(--ink7); overflow-wrap: anywhere; }
 .jv-pc-rfields { font-size: 12px; color: var(--ink5); margin-left: auto; text-align: right; overflow-wrap: anywhere; }

--- a/pwa/src/lib/notifications.js
+++ b/pwa/src/lib/notifications.js
@@ -74,7 +74,10 @@ export function recordEvent(e) {
 	const conv = e.conversation_id || e.conversation
 	const at = Date.now()
 
-	if (e.kind === "run:end" && conv) {
+	// A stopped run is not a finished task. This feed is durable (localStorage +
+	// unread badge), so without the guard the user finds an unread "Task
+	// finished" hours after they killed the reply themselves.
+	if (e.kind === "run:end" && !e.stopped && conv) {
 		push({
 			id: `end:${e.run_id || e.message_id}`,
 			kind: "task-finished",

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -93,8 +93,13 @@ const view = (m) => {
 		// call and writes an empty assistant row. With no prose, no cards, no
 		// canvas and no error text, the thread would render a blank gap and the
 		// user would be left wondering whether anything happened at all.
-		empty:
-			!html && !cards && !charts.length && !parseAction(content) && !m.error && !(m.canvas || []).length,
+		// A stop is not a failure: excluded here so a stopped-before-stream turn
+		// (content == "") never lands in the "Jarvis didn't return a reply" error
+		// branch, telling the user it failed when they are the one who stopped it.
+		// The marker itself renders from a SIBLING gated on `stopped`, outside
+		// this chain - the exclusion alone would leave a blank gap.
+		empty: !html && !cards && !charts.length && !parseAction(content) && !m.error
+			&& !(m.canvas || []).length && !m.stopped,
 	}
 }
 
@@ -503,6 +508,12 @@ onUnmounted(() => {
 					<div v-else-if="it.view.empty" class="jv-msg-error">
 						Jarvis didn't return a reply for this turn. Try asking again.
 					</div>
+					<!-- SIBLING of the chain above, not a v-else-if in it: a partial stop
+					     has non-empty html, so chaining this would let the first branch
+					     win and the marker would never render - the exact defect it
+					     exists to fix. Gated only on `stopped`, it shows for both the
+					     partial and the empty stop. -->
+					<div v-if="it.msg.stopped" class="jv-stopped">You stopped this reply.</div>
 					<ActionCard
 						v-if="it.view.action && it.key === lastAssistantKey && !dismissedActions.has(it.key)"
 						:action="it.view.action"
@@ -684,6 +695,16 @@ onUnmounted(() => {
 	font-size: 12px;
 	line-height: 1.4;
 	color: var(--red);
+}
+/* The stop marker is muted (--ink5), never the error tone above it: the user
+   pressed Stop on purpose, so this states what happened, it doesn't warn. */
+.jv-stopped {
+	margin-top: 8px;
+	padding-top: 7px;
+	border-top: 1px solid var(--border);
+	font-size: 11.5px;
+	line-height: 1.4;
+	color: var(--ink5);
 }
 .jv-took {
 	display: flex;


### PR DESCRIPTION
Every gated write parks behind a "Confirm before this runs" card. The cards told you the **identifier** of what was about to change, not the **thing**. A delete card said `Will delete this Sales Order SO-0001` and nothing about the order.

The 14 gated tools present **24 shapes** (most have a single and a bulk path). Eight rendered no card at all — including `create_custom_skill`, whose entire card was the literal string `create_custom_skill` while you approved **persistent agent instructions**, and bulk `send_email`, where you approved 20 distinct irreversible emails seeing only document names.

**All 24 shapes now render a structured card with record-wise detail.**

## Two defects this fixes that are live on `main` today

**Card doc reads were not permission-checked.** `frappe.get_doc` checks nothing unless passed a `check_permission` kwarg (`document.py:141-145` → `:336-349`), which defaults to `None`; `apply_fieldlevel_read_permissions` is permlevel-only. **Both** `_update_card` and `_bulk_update_card` read docs this way, so a user who cannot read a record could see its old values on an update card. Both now call `has_permission("read")` and degrade to a name-only row.

**Model-authored prose rendered on the trust surface.** `create_doc`'s `notes` is a tool argument the *model* writes, echoed onto the batch-create card. A prompt-injected agent could caption its own confirmation with *"these already exist — confirming changes nothing"*. Escaped rendering stops XSS, not lying. Removed from the card **and** the fallback path (`batchFromPreview` + `ChatView.vue:478`) — deleting only the card's would leave it alive on exactly the path that runs when `build_card` fails.

## The phases

**1 — the primitive** (`jarvis/chat/_record_summary.py`): `fmt` / `same_value` / `pick_fields` / `summary_rows` / `values_rows` / `table_rows` / `is_secret`. Rewires the existing cards onto it. Money renders `₹ 1,25,000.00` instead of `125000.0`; checkboxes Yes/No instead of `1`. Proposed child tables render as real tables — "5 rows" hid an invoice's line items, and the *draft* card already showed them, so the gated card was strictly weaker on the content that mattered.

**2 — the verb card** (10 shapes): each delete/submit/cancel/amend/workflow target carries its title and a field summary, collapsible.

**3 — batch create**: per-record proposed values, zipped positionally against `would.created` with per-item meta (a batch can mix doctypes). Drops `notes`. Adds the `create_docs` shim to dispatch.

**4 — the five missing kinds**: `bulk_email`, `share`, `assign`, `skill`, `wiki`, plus `_describe_call` gaining `user`/`skill_name`/`slug`/`title`/`scope` — it had none of them, which is why those cards were bare.

## Invariants (a change that breaks one is a bug, not a tradeoff)

- Values are **server-derived** — never model-authored prose.
- **Doc-level** read permission checked on every stored-record read, not just permlevel.
- Cards render **effective** values, not raw args. `create_custom_skill` hardcodes `scope: "User"` regardless of the request, so the card renders "User (private)" unconditionally; `share_doc` flags render through the tool's own `int(bool(...))` and its **`read=True` signature default**, because a card that echoes a value the tool overrides is a card that lies.
- No phantom changes, and **no hidden real ones** — no-op detection is cast-compare, never display forms (`fmt_money` renders `100.005` and `100.001` identically, so a display compare *drops a real change*).
- Secrets masked; escaped rendering only; `build_card` never raises; built once at park; bounded with no unbounded axis.

## Notable landmines (all verified against source)

- `getdate()` / `get_datetime()` return **today/now for any falsy input** — a bare cast made "set the due date to today" on an empty field compare equal to itself and vanish from the card.
- `update_wiki` applies **append first**, so `replace_body_md="" + append_md=X` slips the falsy both-args guard and appends — a replace-first card rendered an *empty erase* over a write that persisted text it never showed.
- Frappe **skips the child-table permlevel reset on new records** (`document.py:1326-1328`), so for a create the args are the *more* truthful source than `would` (which is read-filtered and would under-report).
- `v-else-if` chains to the immediately preceding sibling — element order in the verb card is load-bearing and is commented as such.

## Testing

`test_confirm_card` **68/68**, `test_record_summary` **46/46** (new), `node --test actionSummary.test.js` **15/15** (incl. a `CARD_KINDS` parity guard — an unwhitelisted kind silently falls back to raw). All 20 pre-existing card tests pass **unmodified**.

Every guard is **mutation-tested**: removing it turns exactly the right test red, and nothing else.

Rebased onto `main` after #341; no file overlap.

⚠️ **Browser smoke is PENDING.** Layout, CSS token resolution and scroll containment are the one thing that cannot be verified without a browser — structure, escaping (incl. an XSS probe) and branch selection are covered. Note `@vue/compiler-dom` is **silent** on `v-for`+`v-if` misuse, so "compiles clean" proves less than it looks; the templates were checked with an AST walk validated against a known-bad file.

## Known open (recorded, not fixed here)

- **Park→confirm staleness.** The card snapshots values at park; confirm never re-verifies inside the 15-minute TTL. This redesign makes it *worse* by making the snapshot worth trusting. Cheap fix: store `doc.modified` at park, compare at confirm. Deliberately out of scope — it changes `confirm_tool`, not the cards.
- `summary_fields` (the model choosing which fields show) — designed, not built.
- `would.notes` remains inside the raw-JSON **Details** expander and the PWA raw fallback — a labelled payload dump is not a rendered caption. Accepted.
- CI does not run the node tests (`ci.yml` is Python-only), so `actionSummary.test.js` fails silently. Worth wiring up.

Spec: `docs/confirmation-card-redesign-spec.md` (rev 3). Four Fable review rounds — rev 1 don't-ship with 3 blockers, rev 2 ship-after-5-edits, then a gate per phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also in this PR: the blank draft card (was #351)

Same subsystem, folded in so it's one review.

A user asked: *"Create the below tasks and assign to me — test the confirmation ui / test admin v2 / fix issues in the list"*. The agent emitted a `jarvis-action` block carrying a **`docs` array**. `docs` is not an action key — nothing in either frontend reads it — so `buildDraftModel` got `a.fields === undefined`, skipped every non-`reqd` field, and **the card proposed nothing**, with an enabled Confirm. Nothing threw; nobody, including the agent, learned anything.

**Fail loudly** (`ChatView.vue`, `pwa/ActionCard.vue`) — a block carrying `docs`, or a fieldless create, now renders an error naming the problem. Silent-blank reads as *"Jarvis didn't try"* rather than *"Jarvis emitted a shape I can't draw"*. `openDraftPanel` gets a try/catch and Edit gets `:disabled` — without both, the new throw kills a live button. The PWA guard deliberately **differs** from the desktop's: it neither renders nor applies `tables`, so the desktop's tables-escape would let it render blank again. Not guarded via `parseAction` returning null — `STRIP_RES` strips the fence from the prose unconditionally, so a null parse makes the proposal *vanish entirely*.

**Split `auto`** (`get_creation_context.py`) — `bool(df.fetch_from) or (df.default not in (None, ""))` conflated *Frappe computes it* with *Frappe guesses it*. `ToDo.date` has `default: "Today"`, so it was `auto`, so the note said skip — and those three ToDos are created **due today** with nobody seeing it. `auto` is now `fetch_from` only; a defaulted field surfaces its `default` and the note tells the model to decide it. Nothing in app code reads `auto` back, so the blast radius is behavioural.

The third fix is the persona sentence — **`Aerele-RnD/jarvis-persona#162`**, separate repo, needs a container roll.

Worth stating plainly for review: **the batching rule already existed.** `AGENTS.md:115` covers several-records ("ask ONCE… then `create_doc(docs=[...])` in batches of up to 20"). The model **violated** it rather than falling through a gap — and an earlier draft of the persona sentence would have prescribed bulk directly, silently skipping that rule's ask-once consent gate. What was genuinely missing is that the block shape is documented positively and never negatively, and nothing validates it.

Spec: `docs/superpowers/specs/2026-07-17-blank-draft-card.md`. Fable-reviewed twice (don't-ship with 4 blockers, then ship after 2 edits). `test_get_creation_context` **24/24**, mutation-tested 4/4.

### Known open from this half

- The card doesn't render Frappe-applied **defaults** — fix 2 puts the default in the model's hands instead.
- Nothing tells the **agent** its block failed to render.
- `kind:"email"` has the same silent-blank family.
- **The PWA drops child tables on apply** — pre-existing; `apply()` never reads `action.tables`, so a fields+tables draft applied from the phone writes the parent without its rows.
