### PR TITLE
fix(llm): store GLM / Z.ai as its own provider id, collapse to openai_compat only on the wire

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -688,6 +688,7 @@ const STATIC_MODEL_SUGGESTIONS = {
   "Moonshot (Kimi)": ["kimi-k2.6"],
   "xAI Grok": ["grok-4.5", "grok-4.3", "grok-build-0.1"],
   "GLM / Z.ai": ["glm-4.6", "glm-4.7"],
+  "GLM / Z.ai (Coding Plan)": ["glm-4.6", "glm-4.7"],
   "OpenRouter": ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
   "Ollama (local)": ["qwen2.5:3b", "qwen2.5:0.5b", "llama3"],
   "OpenAI-Compatible": ["claude-sonnet-4-6", "gpt-4o", "qwen2.5:3b", "llama3"],
@@ -703,6 +704,11 @@ const PROVIDER_DEFAULTS = {
   "Moonshot (Kimi)": { model: "kimi-k2.6", baseUrl: "https://api.moonshot.ai/v1" },
   "xAI Grok": { model: "grok-4.5", baseUrl: "https://api.x.ai/v1" },
   "GLM / Z.ai": { model: "glm-4.6", baseUrl: "https://api.z.ai/api/paas/v4" },
+  // GLM Coding Plan is a separate z.ai subscription from pay-as-you-go "GLM / Z.ai"
+  // above - a coding-plan key 402s with "insufficient balance" on the pay-as-you-go
+  // base URL even though it's perfectly valid on this one (see apiKeyModelHealth's
+  // targeted hint in pool.js for the exact trap this option exists to avoid).
+  "GLM / Z.ai (Coding Plan)": { model: "glm-4.6", baseUrl: "https://api.z.ai/api/coding/paas/v4" },
   "OpenRouter": { model: "anthropic/claude-sonnet-4-6", baseUrl: "https://openrouter.ai/api/v1" },
   "Ollama (local)": { model: "llama3", baseUrl: "http://host.docker.internal:11434/v1" },
   "vLLM (local)": { model: "", baseUrl: "" },

--- a/frontend/src/components/ProviderLogo.vue
+++ b/frontend/src/components/ProviderLogo.vue
@@ -37,7 +37,7 @@ const MARKS = {
 // subscription upstream -> logo key (kimi = Moonshot)
 const UPSTREAM_TO_KEY = { openai: "openai", google: "gemini", xai: "xai", kimi: "moonshot" }
 // neutral monograms for providers with no clean official mark
-const MONO = { zai: "GLM", together: "TAI", vllm: "vLM", openai_compat: "{ }" }
+const MONO = { zai: "GLM", zai_coding: "GLM", together: "TAI", vllm: "vLM", openai_compat: "{ }" }
 
 const key = computed(() =>
   props.upstream ? (UPSTREAM_TO_KEY[props.upstream] || props.upstream) : providerId(props.provider),

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -101,6 +101,16 @@ export const PROVIDER_LABELS = [
   { id: "moonshot", label: "Moonshot (Kimi)" },
   { id: "xai", label: "xAI Grok" },
   { id: "zai", label: "GLM / Z.ai" },
+  // z.ai sells two distinct products on two distinct endpoints: pay-as-you-go
+  // API credits (plain "zai", above) and a separate "GLM Coding Plan"
+  // subscription that reports "insufficient balance" (code 1113) on the
+  // pay-as-you-go endpoint even with a perfectly valid key - the two do not
+  // share a balance. A dedicated provider id (rather than a toggle inside the
+  // "zai" option) means the existing PROVIDER_DEFAULTS/NEEDS_BASE_URL/dropdown
+  // machinery just works with no new UI - the same shape every other provider
+  // already uses. See apiKeyModelHealth() below for the targeted hint when a
+  // "zai" row hits this exact trap.
+  { id: "zai_coding", label: "GLM / Z.ai (Coding Plan)" },
   { id: "openrouter", label: "OpenRouter" },
   { id: "ollama", label: "Ollama (local)" },
   { id: "vllm", label: "vLLM (local)" },
@@ -110,9 +120,10 @@ const _LABEL_BY_ID = Object.fromEntries(PROVIDER_LABELS.map(p => [p.id, p.label]
 const _ID_BY_LABEL = Object.fromEntries(PROVIDER_LABELS.map(p => [p.label, p.id]))
 // Custom-endpoint providers whose whole identity IS the base_url (no default
 // endpoint) - validatePool requires one for these (mirrors validate_models).
-// "zai" (GLM / Z.ai) has no native Bifrost provider, so it needs its Z.ai
-// base_url (standard api.z.ai/api/paas/v4 or the coding-plan .../coding/paas/v4).
-const NEEDS_BASE_URL = new Set(["openai_compat", "vllm", "zai"])
+// "zai" (GLM / Z.ai, pay-as-you-go) and "zai_coding" (GLM Coding Plan) both
+// have no native Bifrost provider, so each needs its own Z.ai base_url
+// (standard api.z.ai/api/paas/v4 vs coding-plan api.z.ai/api/coding/paas/v4).
+const NEEDS_BASE_URL = new Set(["openai_compat", "vllm", "zai", "zai_coding"])
 export function providerLabel(id) { return _LABEL_BY_ID[id] || id || "" }
 export function providerId(label) { return _ID_BY_LABEL[label] || label || "" }
 
@@ -147,18 +158,36 @@ export function seedRowsFromConfig(cfg) {
 }
 
 // The fleet's last per-model probe verdict for ONE api-key row, matched out of the
-// model_statuses list (contract 1.11: [{ provider, model, status }], api-key models only).
-// The match keys on (provider, model) TOGETHER: a model id is NOT unique -- validate() only
-// forbids duplicate provider/model PAIRS, so the same id can appear under two providers, and
-// keying on the id alone would attach one provider's verdict to the other's row. Rows carry
-// the provider LABEL while model_statuses carry the id, so normalize the row's provider back
-// to an id to compare. Returns "" when the row has no matching verdict (a pre-1.11 fleet, a
-// model not yet probed, or an entry that belongs to a different provider).
-function modelVerdict(row, modelStatuses) {
-  if (!row || !Array.isArray(modelStatuses)) return ""
+// model_statuses list (contract 1.11: [{ provider, model, status }], api-key models only;
+// contract 1.12 adds an optional `detail` string carrying the provider's raw error text -
+// absent on an older fleet). The match keys on (provider, model) TOGETHER: a model id is NOT
+// unique -- validate() only forbids duplicate provider/model PAIRS, so the same id can appear
+// under two providers, and keying on the id alone would attach one provider's verdict to the
+// other's row. Rows carry the provider LABEL while model_statuses carry the id, so normalize
+// the row's provider back to an id to compare. Returns null when the row has no matching
+// verdict (a pre-1.11 fleet, a model not yet probed, or an entry that belongs to a different
+// provider) - callers must not assume a match.
+function modelVerdictEntry(row, modelStatuses) {
+  if (!row || !Array.isArray(modelStatuses)) return null
   const rid = providerId(row.provider)
-  const entry = modelStatuses.find((e) => e && e.model === row.model && e.provider === rid)
-  return (entry && entry.status) || ""
+  return modelStatuses.find((e) => e && e.model === row.model && e.provider === rid) || null
+}
+
+// z.ai's exact "wrong endpoint" trap: a GLM Coding Plan key authenticates fine against
+// the pay-as-you-go endpoint (api.z.ai/api/paas/v4) but that endpoint reports the key's
+// coding-plan balance as zero, so the probe fails with z.ai's real error text - code 1113,
+// "Insufficient balance or no resource package. Please recharge." - even though the key
+// itself is perfectly valid on the coding-plan endpoint. Only meaningful on a "zai" (the
+// pay-as-you-go option) row: a "zai_coding" row already points at the right endpoint, so
+// the same error there is a real balance problem, not a wrong-endpoint one. Matching is
+// defensive by construction - it only ever fires when `detail` is present (contract 1.12);
+// an older fleet that never sends `detail` simply never matches and falls through to the
+// generic "Not working" message below.
+const _ZAI_INSUFFICIENT_BALANCE_RE = /\b1113\b|insufficient balance/i
+function isZaiWrongEndpoint(row, entry) {
+  if (!entry || !entry.detail) return false
+  if (providerId(row && row.provider) !== "zai") return false
+  return _ZAI_INSUFFICIENT_BALANCE_RE.test(entry.detail)
 }
 
 // Map an api-key pool row to its health for the failover list. Unlike a subscription
@@ -166,15 +195,27 @@ function modelVerdict(row, modelStatuses) {
 // verdict instead of the presence-only "key set" that used to make a dead model look
 // identical to a healthy one.
 //   failed    -> warn      : rejected (bad key/model id) OR an unreachable base_url
+//     - a "zai" row whose failure detail is z.ai's insufficient-balance/1113 error gets a
+//       specific hint instead of the generic message (see isZaiWrongEndpoint above)
 //   unchecked -> unchecked : could not confirm; re-checked on the next apply
 //   verified / "" / unknown -> ok (quiet green; "" = pre-1.11 fleet or a not-yet-probed row)
 export function apiKeyModelHealth(row, modelStatuses) {
-  const status = modelVerdict(row, modelStatuses)
+  const entry = modelVerdictEntry(row, modelStatuses)
+  const status = (entry && entry.status) || ""
   if (status === "failed") {
+    if (isZaiWrongEndpoint(row, entry)) {
+      return {
+        level: "warn",
+        label: "Wrong Z.ai endpoint",
+        title: "Z.ai reported insufficient balance on the pay-as-you-go endpoint. If this is a "
+          + "GLM Coding Plan key, switch this model's provider to \"GLM / Z.ai (Coding Plan)\" "
+          + "(base URL https://api.z.ai/api/coding/paas/v4) instead.",
+      }
+    }
     return {
       level: "warn",
       label: "Not working",
-      title: "This model failed a test request — check its API key, model id, and base URL. "
+      title: "This model failed a test request - check its API key, model id, and base URL. "
         + "It's skipped during failover until it passes.",
     }
   }
@@ -182,7 +223,7 @@ export function apiKeyModelHealth(row, modelStatuses) {
     return {
       level: "unchecked",
       label: "Not verified yet",
-      title: "We couldn't confirm this model — it will be re-checked on the next apply.",
+      title: "We couldn't confirm this model - it will be re-checked on the next apply.",
     }
   }
   return { level: "ok" }

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -252,3 +252,82 @@ test("apiKeyModelHealth: a SINGLE entry under a DIFFERENT provider is not misatt
     { level: "ok" },
   )
 })
+
+// ---- GLM Coding Plan ("zai_coding"): a distinct provider from pay-as-you-go "zai" ----
+// Live discovery: a Coding Plan key authenticates fine but reports "insufficient balance"
+// (z.ai error code 1113) on the pay-as-you-go endpoint (api.z.ai/api/paas/v4) even though
+// it's perfectly valid on the coding-plan endpoint (api.z.ai/api/coding/paas/v4). This
+// section covers the new provider option and the targeted diagnostic hint for that trap.
+
+test("providerLabel/providerId: zai_coding id ⇄ 'GLM / Z.ai (Coding Plan)' label, distinct from zai", () => {
+  assert.equal(providerLabel("zai_coding"), "GLM / Z.ai (Coding Plan)")
+  assert.equal(providerId("GLM / Z.ai (Coding Plan)"), "zai_coding")
+  assert.notEqual(providerLabel("zai_coding"), providerLabel("zai"))
+})
+
+test("PROVIDER_LABELS: zai_coding is a first-class entry", () => {
+  const ids = PROVIDER_LABELS.map(p => p.id)
+  assert.ok(ids.includes("zai_coding"))
+})
+
+test("validatePool: GLM / Z.ai (Coding Plan) requires a base_url, same as GLM / Z.ai", () => {
+  assert.equal(validatePool([{ provider: "GLM / Z.ai (Coding Plan)", model: "glm-4.6", api_key: "k" }], null).ok, false)
+  assert.equal(validatePool([{ provider: "GLM / Z.ai (Coding Plan)", model: "glm-4.6", api_key: "k",
+    base_url: "https://api.z.ai/api/coding/paas/v4" }], null).ok, true)
+})
+
+test("seedRowsFromConfig: a row stored as 'zai_coding' renders its own distinct label", () => {
+  const cfg = { models: [{ provider: "zai_coding", model: "glm-4.6", credential_type: "api_key",
+    has_key: true, base_url: "https://api.z.ai/api/coding/paas/v4", order: 0 }] }
+  const [row] = seedRowsFromConfig(cfg)
+  assert.equal(row.provider, "GLM / Z.ai (Coding Plan)")
+  assert.equal(row.baseUrl, "https://api.z.ai/api/coding/paas/v4")
+})
+
+const _zaiRow = (over = {}) => ({ credentialType: "api_key", provider: providerLabel("zai"),
+  model: "glm-4.6", hasKey: true, ...over })
+
+test("apiKeyModelHealth: a 'zai' row failing with z.ai's insufficient-balance (1113) detail gets the coding-plan hint", () => {
+  const ms = [{ provider: "zai", model: "glm-4.6", status: "failed",
+    detail: '{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}' }]
+  const h = apiKeyModelHealth(_zaiRow(), ms)
+  assert.equal(h.level, "warn")
+  assert.match(h.label, /endpoint/i)
+  assert.match(h.title, /coding plan/i)
+  assert.match(h.title, /api\.z\.ai\/api\/coding\/paas\/v4/)
+})
+
+test("apiKeyModelHealth: the hint also matches on the plain 'insufficient balance' phrase (no code substring)", () => {
+  const ms = [{ provider: "zai", model: "glm-4.6", status: "failed", detail: "Insufficient balance. Please recharge." }]
+  assert.match(apiKeyModelHealth(_zaiRow(), ms).title, /coding plan/i)
+})
+
+test("apiKeyModelHealth: a 'zai' failure with a DIFFERENT detail falls through to the generic message", () => {
+  const ms = [{ provider: "zai", model: "glm-4.6", status: "failed", detail: "invalid api key" }]
+  const h = apiKeyModelHealth(_zaiRow(), ms)
+  assert.equal(h.level, "warn")
+  assert.equal(h.label, "Not working")
+})
+
+test("apiKeyModelHealth: a 'zai' failure with NO detail (pre-1.12 fleet) falls through defensively, never throws", () => {
+  const ms = [{ provider: "zai", model: "glm-4.6", status: "failed" }]
+  const h = apiKeyModelHealth(_zaiRow(), ms)
+  assert.equal(h.level, "warn")
+  assert.equal(h.label, "Not working")
+})
+
+test("apiKeyModelHealth: the same 1113 detail on a 'zai_coding' row does NOT trigger the hint (already the right endpoint)", () => {
+  const ms = [{ provider: "zai_coding", model: "glm-4.6", status: "failed",
+    detail: "Insufficient balance or no resource package. Please recharge." }]
+  const h = apiKeyModelHealth(_zaiRow({ provider: providerLabel("zai_coding") }), ms)
+  assert.equal(h.level, "warn")
+  assert.equal(h.label, "Not working")
+})
+
+test("apiKeyModelHealth: the same 1113 detail on an UNRELATED provider does NOT trigger the hint", () => {
+  const ms = [{ provider: "openai_compat", model: "gpt-4o", status: "failed",
+    detail: "Insufficient balance or no resource package. Please recharge." }]
+  const h = apiKeyModelHealth(_apiRow({ provider: providerLabel("openai_compat"), model: "gpt-4o" }), ms)
+  assert.equal(h.level, "warn")
+  assert.equal(h.label, "Not working")
+})

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -114,6 +114,14 @@ test("providerLabel/providerId: gemini id ⇄ Google Gemini label (matches catal
   assert.equal(providerLabel("gemini"), "Google Gemini")
   assert.equal(providerId("Google Gemini"), "gemini")
 })
+test("providerLabel/providerId: zai id ⇄ GLM / Z.ai label (first-class provider, distinct from openai_compat)", () => {
+  // Regression lock: "zai" must render as its own label, never fall back to
+  // "OpenAI-Compatible" - that fallback only happens for an id absent from
+  // PROVIDER_LABELS, and zai has been a first-class entry since #319.
+  assert.equal(providerLabel("zai"), "GLM / Z.ai")
+  assert.equal(providerId("GLM / Z.ai"), "zai")
+  assert.notEqual(providerLabel("zai"), providerLabel("openai_compat"))
+})
 test("PROVIDER_LABELS: includes the vendors + compat, each {id,label}", () => {
   const ids = PROVIDER_LABELS.map(p => p.id)
   assert.ok(ids.includes("openai"))
@@ -130,6 +138,21 @@ test("seedRowsFromConfig: api-key model → api_key row with label provider + ha
   assert.equal(row.baseUrl, "http://h:9000/openai")
   assert.equal(row.apiKey, "")      // keys never returned to client
   assert.equal(row.hasKey, true)    // but we know one is set → placeholder
+})
+test("seedRowsFromConfig: GLM/Z.ai model stored as first-class 'zai' renders its own label, not OpenAI-Compatible", () => {
+  // End-to-end regression lock for the storage-collapsing bug: a row that
+  // survives jarvis.onboarding.save_llm_pool -> get_llm_config as provider
+  // "zai" (the post-fix stored shape) must seed an editor row labeled
+  // "GLM / Z.ai" - not "OpenAI-Compatible", which is what a collapsed
+  // "openai_compat" row would render as.
+  const cfg = { models: [{ provider: "zai", model: "glm-4.6", credential_type: "api_key",
+    has_key: true, base_url: "https://api.z.ai/api/paas/v4", order: 0 }] }
+  const [row] = seedRowsFromConfig(cfg)
+  assert.equal(row.credentialType, "api_key")
+  assert.equal(row.provider, "GLM / Z.ai")
+  assert.equal(row.model, "glm-4.6")
+  assert.equal(row.baseUrl, "https://api.z.ai/api/paas/v4")
+  assert.equal(row.hasKey, true)
 })
 test("seedRowsFromConfig: subscription model → subscription row with connected accounts", () => {
   const cfg = { models: [{ model: "gpt-5.5", order: 1, subscription: { rotation: "sticky",

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -1227,10 +1227,14 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
                 _synced["last_subscription_status"] = str(result.get("subscription_status") or "")
                 _synced["last_sync_warnings"] = _frappe.as_json(result.get("warnings") or [])
                 # Per-model verdicts (contract 1.11: [{provider, model, status}], api-key
-                # models only) ride the SAME PUT response. The AI-models list keys each
-                # api-key row's health off this; without persisting it a dead model shows
-                # the same green "key set" as a healthy one. Same no-op reasoning as the two
-                # fields above: a "unchanged" apply ran no probe, so leave the prior verdicts.
+                # models only; contract 1.12 adds an optional "detail" string with the
+                # provider's raw error text, absent on an older fleet) ride the SAME PUT
+                # response. The AI-models list keys each api-key row's health off this;
+                # without persisting it a dead model shows the same green "key set" as a
+                # healthy one. Stored/forwarded verbatim (no field whitelisting), so a new
+                # optional key like "detail" needs no change here to reach the client. Same
+                # no-op reasoning as the two fields above: a "unchanged" apply ran no probe,
+                # so leave the prior verdicts.
                 _synced["last_model_statuses"] = _frappe.as_json(result.get("model_statuses") or [])
             settings.db_set(_synced)
             # last_sync_status MUST keep starting with the literal "ok" -

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -23,6 +23,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		"Moonshot (Kimi)":    { model: "kimi-k2.6",                         baseUrl: "https://api.moonshot.ai/v1" },
 		"xAI Grok":           { model: "grok-4.5",                          baseUrl: "https://api.x.ai/v1" },
 		"GLM / Z.ai":         { model: "glm-4.6",                           baseUrl: "https://api.z.ai/api/paas/v4" },
+		"GLM / Z.ai (Coding Plan)": { model: "glm-4.6",                     baseUrl: "https://api.z.ai/api/coding/paas/v4" },
 		"OpenRouter":         { model: "anthropic/claude-sonnet-4-6",       baseUrl: "https://openrouter.ai/api/v1" },
 		"Ollama (local)":     { model: "llama3",                            baseUrl: "http://host.docker.internal:11434/v1" },
 		"vLLM (local)":       { model: "",                                  baseUrl: "" },
@@ -36,7 +37,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const PROVIDER_LABEL_BY_ID = {
 		anthropic: "Anthropic", openai: "OpenAI", google: "Google Gemini", mistral: "Mistral",
 		groq: "Groq", together: "Together AI", deepseek: "DeepSeek", moonshot: "Moonshot (Kimi)",
-		xai: "xAI Grok", zai: "GLM / Z.ai",
+		xai: "xAI Grok", zai: "GLM / Z.ai", zai_coding: "GLM / Z.ai (Coding Plan)",
 		openrouter: "OpenRouter", ollama: "Ollama (local)", vllm: "vLLM (local)", openai_compat: "OpenAI-Compatible",
 	};
 	function providerLabel(v) {
@@ -64,6 +65,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		"Moonshot (Kimi)":   ["kimi-k2.6"],
 		"xAI Grok":          ["grok-4.5", "grok-4.3", "grok-build-0.1"],
 		"GLM / Z.ai":        ["glm-4.6", "glm-4.7"],
+		"GLM / Z.ai (Coding Plan)": ["glm-4.6", "glm-4.7"],
 		"OpenRouter":        ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
 		"Ollama (local)":    ["qwen2.5:3b", "qwen2.5:0.5b", "llama3"],
 		"OpenAI-Compatible": ["claude-sonnet-4-6", "gpt-4o", "qwen2.5:3b", "llama3"],

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -61,10 +61,17 @@ _PROVIDER_ALIASES = {
     "openai-compatible": "openai_compat",
     # xAI Grok is a native Bifrost provider.
     "xai grok": "xai",
-    # GLM / Z.ai has no native Bifrost provider, so it rides the existing
-    # openai-compatible custom-endpoint path (Bifrost custom provider +
-    # base_url). validate_models already requires a base_url for openai_compat.
-    "glm / z.ai": "openai_compat",
+    # GLM / Z.ai is a first-class stored provider id ("zai"), same as every
+    # other alias here: a dropdown label normalizes to ITS OWN canonical id,
+    # not a different provider's. It has no native Bifrost provider, so it
+    # rides the openai-compatible custom-endpoint path (base_url required,
+    # see validate_models) - but that collapse happens ONLY at wire time, in
+    # build_pool_payload's _WIRE_PROVIDER_OVERRIDES below. Collapsing here
+    # (at storage time) used to permanently overwrite the stored provider
+    # with "openai_compat", so a saved GLM row round-tripped back into the
+    # UI as "OpenAI-Compatible" - base_url was the only surviving evidence
+    # it was ever GLM. Fixed 2026-07-17.
+    "glm / z.ai": "zai",
     # legacy id alias: the old frontend used "google" for Gemini
     "google": "gemini",
 }
@@ -75,11 +82,38 @@ def normalize_provider(value: str) -> str:
 
     Case-insensitive on the lookup; unknown values pass through lowercased
     (Bifrost provider ids are lowercase). Blank stays blank.
+
+    This is the STORAGE-time normalization: it must be a true round-trip for
+    every provider (label in -> its own id out -> same id back in unchanged),
+    so a saved pool always reflects what the customer actually picked. Any
+    collapsing of one provider's identity onto another's wire transport (e.g.
+    "zai" riding the openai-compatible Bifrost transport) belongs in
+    build_pool_payload's _wire_provider(), not here.
     """
     v = (value or "").strip()
     if not v:
         return ""
     return _PROVIDER_ALIASES.get(v.lower(), v.lower())
+
+
+# ---------------------------------------------------------------------------
+# Wire-time-only provider collapsing (build_pool_payload). Distinct from
+# normalize_provider(): a provider id can be first-class in STORAGE (so the
+# UI shows its real name) while still riding a different provider's transport
+# on the Bifrost wire payload (because Bifrost has no native support for it).
+# "zai" (GLM / Z.ai) is the only entry today - it rides the openai-compatible
+# custom-endpoint transport (base_url carries the real Z.ai endpoint).
+# ---------------------------------------------------------------------------
+_WIRE_PROVIDER_OVERRIDES = {
+    "zai": "openai_compat",
+}
+
+
+def _wire_provider(canonical_id: str) -> str:
+    """Map a STORED canonical provider id to the id emitted on the Bifrost wire
+    payload. Passthrough for every provider except the wire-only overrides above.
+    """
+    return _WIRE_PROVIDER_OVERRIDES.get(canonical_id, canonical_id)
 
 
 def _model_accounts(m) -> list:
@@ -203,13 +237,17 @@ def validate_models(settings) -> list:
             if not key_val:
                 errors.append(f"{label}: api_key is blank on an enabled model (would produce a dangling key_ref)")
 
-            # Custom-endpoint providers (OpenAI-Compatible shim / local vLLM) are
-            # defined by their base_url; without it build_pool_payload emits a
-            # provider with no endpoint and every turn on that model fails. The
-            # provider is already normalized to its canonical id at this point.
+            # Custom-endpoint providers (OpenAI-Compatible shim / local vLLM /
+            # GLM / Z.ai) are defined by their base_url; without it
+            # build_pool_payload emits a provider with no endpoint and every
+            # turn on that model fails. The provider is already normalized to
+            # its canonical id at this point. "zai" needs this exactly like
+            # "openai_compat" because it rides the same wire transport
+            # (see pool_serialize._wire_provider) - the requirement follows
+            # the transport, not the stored identity.
             prov = (m.provider if hasattr(m, "provider") else m.get("provider", "")) or ""
             base_url = (m.base_url if hasattr(m, "base_url") else m.get("base_url", "")) or ""
-            if prov in ("openai_compat", "vllm") and not base_url.strip():
+            if prov in ("openai_compat", "vllm", "zai") and not base_url.strip():
                 errors.append(
                     f"{label}: provider '{prov}' requires a base_url (its custom endpoint)"
                 )
@@ -389,7 +427,12 @@ def build_pool_payload(settings):
                 entry["base_url"] = base_url
             provider = normalize_provider(provider)
             if provider:
-                entry["provider"] = provider
+                # Wire-only collapse (e.g. "zai" -> "openai_compat"): the
+                # stored/displayed identity stays "zai"; only the Bifrost
+                # payload's provider id changes, so this MUST run last, right
+                # before the entry is written - never earlier, and never at
+                # storage time (see normalize_provider's docstring).
+                entry["provider"] = _wire_provider(provider)
 
         models.append(entry)
 

--- a/jarvis/jarvis/pool_serialize.py
+++ b/jarvis/jarvis/pool_serialize.py
@@ -72,6 +72,16 @@ _PROVIDER_ALIASES = {
     # UI as "OpenAI-Compatible" - base_url was the only surviving evidence
     # it was ever GLM. Fixed 2026-07-17.
     "glm / z.ai": "zai",
+    # GLM Coding Plan is a SEPARATE z.ai product from pay-as-you-go "zai" above
+    # - different balance, different endpoint (api.z.ai/api/coding/paas/v4).
+    # A coding-plan key authenticates fine against the pay-as-you-go endpoint
+    # but reports "insufficient balance" (z.ai error code 1113) there, which
+    # reads as a dead key/account when it is really just the wrong endpoint.
+    # Distinct stored id so the two never collide and each keeps its own
+    # base_url; both collapse to the same openai-compatible wire transport
+    # (see _WIRE_PROVIDER_OVERRIDES below) since Bifrost has no native
+    # provider for either.
+    "glm / z.ai (coding plan)": "zai_coding",
     # legacy id alias: the old frontend used "google" for Gemini
     "google": "gemini",
 }
@@ -101,11 +111,13 @@ def normalize_provider(value: str) -> str:
 # normalize_provider(): a provider id can be first-class in STORAGE (so the
 # UI shows its real name) while still riding a different provider's transport
 # on the Bifrost wire payload (because Bifrost has no native support for it).
-# "zai" (GLM / Z.ai) is the only entry today - it rides the openai-compatible
-# custom-endpoint transport (base_url carries the real Z.ai endpoint).
+# "zai" and "zai_coding" (both GLM / Z.ai variants) are the entries today -
+# both ride the openai-compatible custom-endpoint transport (base_url carries
+# the real Z.ai endpoint - the standard or coding-plan one respectively).
 # ---------------------------------------------------------------------------
 _WIRE_PROVIDER_OVERRIDES = {
     "zai": "openai_compat",
+    "zai_coding": "openai_compat",
 }
 
 
@@ -238,16 +250,16 @@ def validate_models(settings) -> list:
                 errors.append(f"{label}: api_key is blank on an enabled model (would produce a dangling key_ref)")
 
             # Custom-endpoint providers (OpenAI-Compatible shim / local vLLM /
-            # GLM / Z.ai) are defined by their base_url; without it
-            # build_pool_payload emits a provider with no endpoint and every
-            # turn on that model fails. The provider is already normalized to
-            # its canonical id at this point. "zai" needs this exactly like
-            # "openai_compat" because it rides the same wire transport
-            # (see pool_serialize._wire_provider) - the requirement follows
-            # the transport, not the stored identity.
+            # GLM / Z.ai / GLM Coding Plan) are defined by their base_url;
+            # without it build_pool_payload emits a provider with no endpoint
+            # and every turn on that model fails. The provider is already
+            # normalized to its canonical id at this point. "zai" and
+            # "zai_coding" both need this exactly like "openai_compat" because
+            # both ride the same wire transport (see pool_serialize._wire_provider)
+            # - the requirement follows the transport, not the stored identity.
             prov = (m.provider if hasattr(m, "provider") else m.get("provider", "")) or ""
             base_url = (m.base_url if hasattr(m, "base_url") else m.get("base_url", "")) or ""
-            if prov in ("openai_compat", "vllm", "zai") and not base_url.strip():
+            if prov in ("openai_compat", "vllm", "zai", "zai_coding") and not base_url.strip():
                 errors.append(
                     f"{label}: provider '{prov}' requires a base_url (its custom endpoint)"
                 )

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -600,8 +600,14 @@ def get_llm_sync_status() -> dict:
 	    ``model_statuses`` - a list of ``{"provider", "model", "status"}``
 	    per-model verdicts (``status`` one of ``verified``/``failed``/
 	    ``unchecked``; api-key models only) the AI-models list keys each
-	    api-key row's health off. A corrupt/empty stored value for either
-	    list degrades to ``[]`` rather than ever 500ing this poller.
+	    api-key row's health off. Contract 1.12 adds an optional ``"detail"``
+	    string per entry carrying the provider's raw error text (e.g. a z.ai
+	    "insufficient balance" 1113 error) - absent on a fleet that predates
+	    1.12, and passed through here verbatim with no whitelisting (this
+	    function stores/returns whatever admin sent, so a new optional key
+	    needs no server-side change to reach the client). A corrupt/empty
+	    stored value for either list degrades to ``[]`` rather than ever
+	    500ing this poller.
 	"""
 	s = frappe.get_single("Jarvis Settings")
 	status = s.get("last_sync_status") or ""

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -27,3 +27,4 @@ jarvis.patches.v1_15_unarchive_auto_expired_conversations
 jarvis.patches.v1_16_merge_user_preference_into_settings
 jarvis.patches.v1_17_drop_user_preference_doctype
 jarvis.patches.v2_00_backfill_llm_direct_synced_at
+jarvis.patches.v2_01_backfill_glm_zai_provider_id

--- a/jarvis/patches/v2_01_backfill_glm_zai_provider_id.py
+++ b/jarvis/patches/v2_01_backfill_glm_zai_provider_id.py
@@ -1,5 +1,6 @@
 """Backfill Jarvis LLM Pool Model rows collapsed into "openai_compat" that were
-actually GLM / Z.ai, restoring their first-class "zai" provider id.
+actually GLM / Z.ai (either the pay-as-you-go or the Coding Plan product),
+restoring their first-class "zai" / "zai_coding" provider id.
 
 Root cause (fixed in the same deploy as this patch): jarvis.onboarding.save_llm_pool
 normalized the incoming provider label BEFORE persisting it into
@@ -14,14 +15,25 @@ row was ever GLM without re-checking the base_url.
 
 The fix moves that collapse to WIRE-serialization time only (inside
 pool_serialize.build_pool_payload, via _wire_provider()), so new saves store
-the first-class "zai" id and the label renders correctly, while the Bifrost
-wire payload is unchanged (still emits "openai_compat" + base_url for a zai
-row - Bifrost has no native zai provider).
+the first-class "zai"/"zai_coding" id and the label renders correctly, while
+the Bifrost wire payload is unchanged (still emits "openai_compat" + base_url
+for either - Bifrost has no native provider for either z.ai product).
+
+z.ai sells two distinct products on two distinct endpoints, and both were
+folded into the same "openai_compat" bucket by the old bug:
+- pay-as-you-go API credits: https://api.z.ai/api/paas/v4        -> "zai"
+- GLM Coding Plan subscription: https://api.z.ai/api/coding/paas/v4 -> "zai_coding"
+(A Coding Plan key authenticates fine but reports "insufficient balance" on
+the pay-as-you-go endpoint - a different, unrelated bug this patch does not
+fix; it only restores whichever provider id the row's base_url actually names.)
 
 This patch backfills rows written under the old (storage-collapsing) code:
-provider == "openai_compat" AND base_url points at a Z.ai host
-(api.z.ai - covers both the standard .../api/paas/v4 and coding-plan
-.../coding/paas/v4 endpoints) -> provider = "zai".
+provider == "openai_compat" AND base_url points at a Z.ai host (api.z.ai) ->
+provider = "zai_coding" if the URL path is the coding-plan one, else "zai".
+Path match is a simple "/coding/" substring check - both known coding-plan
+URL shapes ("https://api.z.ai/api/coding/paas/v4" and any future path under
+that same coding-plan family) contain it, and the pay-as-you-go path
+("/api/paas/v4") never does.
 
 Conservative by design: a genuine openai_compat row (a Claude-CLI gateway
 shim, a local relay, anything NOT hosted at api.z.ai) is left untouched -
@@ -37,9 +49,23 @@ admin/fleet-agent network call during bench migrate.
 
 import frappe
 
-# Both known Z.ai API hosts: the standard endpoint and the coding-plan
-# endpoint (different path, same host) - either identifies a GLM / Z.ai row.
+# The Z.ai API host - shared by both products, only the path differs.
 _ZAI_HOST = "api.z.ai"
+# Substring present in every known GLM Coding Plan endpoint path, absent from
+# the pay-as-you-go path ("/api/paas/v4").
+_ZAI_CODING_PATH_HINT = "/coding/"
+
+
+def _zai_provider_for_base_url(base_url: str) -> str | None:
+	"""Return the canonical provider id a collapsed openai_compat row's
+	base_url actually names ("zai" or "zai_coding"), or None if it isn't a
+	Z.ai endpoint at all (a genuine openai_compat row - left untouched)."""
+	url = (base_url or "").strip().lower()
+	if _ZAI_HOST not in url:
+		return None
+	if _ZAI_CODING_PATH_HINT in url:
+		return "zai_coding"
+	return "zai"
 
 
 def execute():
@@ -49,10 +75,10 @@ def execute():
 		fields=["name", "base_url"],
 	)
 	for row in rows:
-		base_url = (row.base_url or "").strip().lower()
-		if _ZAI_HOST in base_url:
+		target = _zai_provider_for_base_url(row.base_url)
+		if target:
 			frappe.db.set_value(
-				"Jarvis LLM Pool Model", row.name, "provider", "zai",
+				"Jarvis LLM Pool Model", row.name, "provider", target,
 				update_modified=False,
 			)
 	frappe.db.commit()

--- a/jarvis/patches/v2_01_backfill_glm_zai_provider_id.py
+++ b/jarvis/patches/v2_01_backfill_glm_zai_provider_id.py
@@ -1,0 +1,58 @@
+"""Backfill Jarvis LLM Pool Model rows collapsed into "openai_compat" that were
+actually GLM / Z.ai, restoring their first-class "zai" provider id.
+
+Root cause (fixed in the same deploy as this patch): jarvis.onboarding.save_llm_pool
+normalized the incoming provider label BEFORE persisting it into
+Jarvis Settings.models[].provider, and pool_serialize._PROVIDER_ALIASES mapped
+"glm / z.ai" straight to "openai_compat" - a different provider's canonical id,
+unlike every other alias in that table (which maps a label to ITS OWN id). So a
+row saved as "GLM / Z.ai" was permanently stored as provider="openai_compat";
+the row's `model` (glm-4.6) and `base_url` (https://api.z.ai/...) survived, but
+the Provider dropdown and the AI-models row chip both rendered
+"OpenAI-Compatible" on every reload, with no way for the customer to tell the
+row was ever GLM without re-checking the base_url.
+
+The fix moves that collapse to WIRE-serialization time only (inside
+pool_serialize.build_pool_payload, via _wire_provider()), so new saves store
+the first-class "zai" id and the label renders correctly, while the Bifrost
+wire payload is unchanged (still emits "openai_compat" + base_url for a zai
+row - Bifrost has no native zai provider).
+
+This patch backfills rows written under the old (storage-collapsing) code:
+provider == "openai_compat" AND base_url points at a Z.ai host
+(api.z.ai - covers both the standard .../api/paas/v4 and coding-plan
+.../coding/paas/v4 endpoints) -> provider = "zai".
+
+Conservative by design: a genuine openai_compat row (a Claude-CLI gateway
+shim, a local relay, anything NOT hosted at api.z.ai) is left untouched -
+matching on base_url host, not merely "has a base_url", avoids
+misclassifying unrelated custom-endpoint rows as GLM.
+
+Direct field update via frappe.db.set_value on the child row, bypassing
+Jarvis Settings.save()/on_update entirely (mirrors v1_seed_llm_models's
+insert-not-save pattern): this is a label-only correction of already-applied
+config, so it must not re-validate, re-render openclaw.json, or make any
+admin/fleet-agent network call during bench migrate.
+"""
+
+import frappe
+
+# Both known Z.ai API hosts: the standard endpoint and the coding-plan
+# endpoint (different path, same host) - either identifies a GLM / Z.ai row.
+_ZAI_HOST = "api.z.ai"
+
+
+def execute():
+	rows = frappe.get_all(
+		"Jarvis LLM Pool Model",
+		filters={"parenttype": "Jarvis Settings", "provider": "openai_compat"},
+		fields=["name", "base_url"],
+	)
+	for row in rows:
+		base_url = (row.base_url or "").strip().lower()
+		if _ZAI_HOST in base_url:
+			frappe.db.set_value(
+				"Jarvis LLM Pool Model", row.name, "provider", "zai",
+				update_modified=False,
+			)
+	frappe.db.commit()

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -166,6 +166,25 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
         self.assertEqual(cfg["models"][0]["provider"], "zai")
         self.assertEqual(cfg["models"][0]["base_url"], "https://api.z.ai/api/paas/v4")
 
+    def test_glm_coding_plan_round_trips_as_its_own_distinct_provider(self):
+        """Same round-trip guarantee as the standard GLM row, for the Coding
+        Plan variant added after live discovery that a Coding Plan key
+        reports "insufficient balance" on the pay-as-you-go endpoint. Must
+        store/read back as "zai_coding" - never collapsed onto "zai" (the
+        two are separate z.ai products with separate balances)."""
+        models = [{"provider": "GLM / Z.ai (Coding Plan)", "model": "glm-4.6", "api_key": "zck",
+                   "base_url": "https://api.z.ai/api/coding/paas/v4", "tier": "strong", "order": 0}]
+        with patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}), \
+             patch("jarvis.admin_client.post_update_llm_pool") as pool:
+            onboarding.save_llm_pool(frappe.as_json(models))
+        pool.assert_not_called()
+        s = frappe.get_single("Jarvis Settings")
+        self.assertEqual(s.models[0].provider, "zai_coding")
+        self.assertEqual(s.models[0].base_url, "https://api.z.ai/api/coding/paas/v4")
+        cfg = onboarding.get_llm_config()
+        self.assertEqual(cfg["models"][0]["provider"], "zai_coding")
+        self.assertEqual(cfg["models"][0]["base_url"], "https://api.z.ai/api/coding/paas/v4")
+
 
 class TestGetLlmConfig(_RT3SettingsTestCase):
     def setUp(self):
@@ -194,7 +213,8 @@ class TestBackfillGlmZaiProviderIdPatch(_RT3SettingsTestCase):
     """v2_01_backfill_glm_zai_provider_id: existing rows that were collapsed
     into provider="openai_compat" by the old storage-time normalize_provider
     bug (see pool_serialize._PROVIDER_ALIASES) must be flipped back to the
-    first-class "zai" id when their base_url is a Z.ai host. A genuine
+    first-class "zai" (pay-as-you-go) or "zai_coding" (Coding Plan) id
+    depending on which Z.ai endpoint their base_url actually names. A genuine
     openai_compat row (any other custom endpoint) must be left untouched."""
 
     def setUp(self):
@@ -239,14 +259,18 @@ class TestBackfillGlmZaiProviderIdPatch(_RT3SettingsTestCase):
         self._run_patch()
         self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
 
-    def test_collapsed_glm_coding_plan_endpoint_is_also_flipped(self):
-        """The coding-plan Z.ai endpoint (same host, different path) must match too."""
+    def test_collapsed_glm_coding_plan_endpoint_is_flipped_to_zai_coding(self):
+        """The coding-plan Z.ai endpoint (same host, different path) is a DIFFERENT
+        product from pay-as-you-go and must backfill to its own "zai_coding" id,
+        not "zai" - the two have separate balances and a coding-plan key rejected
+        on the pay-as-you-go endpoint is exactly the trap this distinction exists
+        to avoid re-creating during backfill."""
         name = self._insert_model_row(
             provider="openai_compat", base_url="https://api.z.ai/api/coding/paas/v4",
             model="glm-4.6",
         )
         self._run_patch()
-        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai_coding")
 
     def test_genuine_openai_compat_row_is_left_untouched(self):
         """A real OpenAI-Compatible shim (not Z.ai) must NOT be reclassified."""
@@ -264,6 +288,14 @@ class TestBackfillGlmZaiProviderIdPatch(_RT3SettingsTestCase):
         )
         self._run_patch()
         self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
+
+    def test_already_zai_coding_row_is_a_no_op(self):
+        """Same idempotency guarantee for the coding-plan id."""
+        name = self._insert_model_row(
+            provider="zai_coding", base_url="https://api.z.ai/api/coding/paas/v4", model="glm-4.6",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai_coding")
 
     def test_non_openai_compat_provider_is_untouched(self):
         """Only rows currently stored as openai_compat are candidates; an

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -140,6 +140,32 @@ class TestSaveLlmPool(_RT3SettingsTestCase):
                 onboarding.save_llm_pool(frappe.as_json(models))
         pool.assert_not_called()  # on_update validate_models throws before enqueue
 
+    def test_glm_zai_round_trips_as_first_class_provider(self):
+        """Regression test for the bug where a GLM / Z.ai row permanently stored
+        (and re-rendered) as "OpenAI-Compatible": saving "GLM / Z.ai" must
+        round-trip through save_llm_pool -> Jarvis Settings -> get_llm_config
+        as its own "zai" id, not collapse into a different provider's id.
+        model + base_url already survived the old bug; provider is the fix.
+        The wire payload's separate collapse (zai -> openai_compat, so Bifrost
+        - which has no native zai provider - still gets a working config) is
+        covered by test_unified_llm_config.py's TestProviderNormalization and
+        is unaffected by this test."""
+        models = [{"provider": "GLM / Z.ai", "model": "glm-4.6", "api_key": "zk",
+                   "base_url": "https://api.z.ai/api/paas/v4", "tier": "strong", "order": 0}]
+        with patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}), \
+             patch("jarvis.admin_client.post_update_llm_pool") as pool:
+            onboarding.save_llm_pool(frappe.as_json(models))
+        pool.assert_not_called()  # single model, no preset -> DIRECT path
+        s = frappe.get_single("Jarvis Settings")
+        self.assertEqual(
+            s.models[0].provider, "zai",
+            "GLM / Z.ai must be stored as its own id, not collapsed to openai_compat",
+        )
+        self.assertEqual(s.models[0].base_url, "https://api.z.ai/api/paas/v4")
+        cfg = onboarding.get_llm_config()
+        self.assertEqual(cfg["models"][0]["provider"], "zai")
+        self.assertEqual(cfg["models"][0]["base_url"], "https://api.z.ai/api/paas/v4")
+
 
 class TestGetLlmConfig(_RT3SettingsTestCase):
     def setUp(self):
@@ -162,3 +188,88 @@ class TestGetLlmConfig(_RT3SettingsTestCase):
         self.assertNotIn("sk-a", frappe.as_json(cfg))
         self.assertEqual(cfg["routing_mode"], "failover")
         self.assertTrue(cfg["proxy_active"])
+
+
+class TestBackfillGlmZaiProviderIdPatch(_RT3SettingsTestCase):
+    """v2_01_backfill_glm_zai_provider_id: existing rows that were collapsed
+    into provider="openai_compat" by the old storage-time normalize_provider
+    bug (see pool_serialize._PROVIDER_ALIASES) must be flipped back to the
+    first-class "zai" id when their base_url is a Z.ai host. A genuine
+    openai_compat row (any other custom endpoint) must be left untouched."""
+
+    def setUp(self):
+        super().setUp()
+        self._clear_models()
+
+    def _insert_model_row(self, *, provider, base_url, model="m", order=0):
+        """Insert a model row directly (bypassing Jarvis Settings.save()), the
+        same way the patch will encounter it: already-persisted config, not a
+        fresh in-memory row. Mirrors v1_seed_llm_models's insert-not-save
+        pattern so this test never triggers on_update / validate_models /
+        any admin network call."""
+        row = frappe.get_doc({
+            "doctype": "Jarvis LLM Pool Model",
+            "parent": "Jarvis Settings",
+            "parenttype": "Jarvis Settings",
+            "parentfield": "models",
+            "provider": provider,
+            "model": model,
+            "base_url": base_url,
+            "credential_type": "api_key",
+            "tier": "strong",
+            "order": order,
+            "enabled": 1,
+            "api_key": "sk-test",
+        })
+        row.insert(ignore_permissions=True)
+        frappe.db.commit()
+        return row.name
+
+    def _run_patch(self):
+        from jarvis.patches import v2_01_backfill_glm_zai_provider_id
+        import importlib
+        importlib.reload(v2_01_backfill_glm_zai_provider_id)
+        v2_01_backfill_glm_zai_provider_id.execute()
+
+    def test_collapsed_glm_row_is_flipped_to_zai(self):
+        name = self._insert_model_row(
+            provider="openai_compat", base_url="https://api.z.ai/api/paas/v4",
+            model="glm-4.6",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
+
+    def test_collapsed_glm_coding_plan_endpoint_is_also_flipped(self):
+        """The coding-plan Z.ai endpoint (same host, different path) must match too."""
+        name = self._insert_model_row(
+            provider="openai_compat", base_url="https://api.z.ai/api/coding/paas/v4",
+            model="glm-4.6",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
+
+    def test_genuine_openai_compat_row_is_left_untouched(self):
+        """A real OpenAI-Compatible shim (not Z.ai) must NOT be reclassified."""
+        name = self._insert_model_row(
+            provider="openai_compat", base_url="https://my-claude-cli-gateway.example.com/v1",
+            model="claude-sonnet-4-6",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "openai_compat")
+
+    def test_already_zai_row_is_a_no_op(self):
+        """A row already migrated (e.g. a second patch run) is idempotent."""
+        name = self._insert_model_row(
+            provider="zai", base_url="https://api.z.ai/api/paas/v4", model="glm-4.6",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "zai")
+
+    def test_non_openai_compat_provider_is_untouched(self):
+        """Only rows currently stored as openai_compat are candidates; an
+        unrelated provider's row must never be inspected/rewritten."""
+        name = self._insert_model_row(
+            provider="openai", base_url="https://api.openai.com/v1", model="gpt-4o",
+        )
+        self._run_patch()
+        self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "openai")

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -290,6 +290,72 @@ class TestProviderNormalization(FrappeTestCase):
             f"expected a base_url error for a zai row with no base_url, got: {errors}",
         )
 
+    # ------------------------------------------------------------------ #
+    # GLM Coding Plan ("zai_coding"): a SEPARATE z.ai product from
+    # pay-as-you-go "zai" above, added after live discovery that a Coding
+    # Plan key authenticates fine but reports "insufficient balance" (z.ai
+    # error 1113) on the pay-as-you-go endpoint - a different balance, a
+    # different endpoint, so a distinct stored id (never collapsed onto
+    # "zai"). Both ride the same openai-compatible wire transport.
+    # ------------------------------------------------------------------ #
+
+    def test_glm_coding_plan_normalizes_to_zai_coding(self):
+        from jarvis.jarvis.pool_serialize import normalize_provider
+        self.assertEqual(normalize_provider("GLM / Z.ai (Coding Plan)"), "zai_coding")
+        # Passthrough, same as every other canonical id.
+        self.assertEqual(normalize_provider("zai_coding"), "zai_coding")
+        # The two GLM ids are DISTINCT - never collapse into each other at
+        # the storage layer (only their wire transport happens to coincide).
+        self.assertNotEqual(
+            normalize_provider("GLM / Z.ai (Coding Plan)"), normalize_provider("GLM / Z.ai"),
+        )
+
+    def test_glm_coding_plan_serializes_to_openai_compat_with_its_own_base_url(self):
+        # Same wire-collapse guarantee as the standard GLM row, but the
+        # coding-plan row must keep ITS OWN base_url (the coding endpoint),
+        # not the pay-as-you-go one - the whole point of the two ids existing
+        # separately is that they point at different URLs.
+        from jarvis.jarvis.pool_serialize import build_pool_payload
+        glm_coding = _api_key_model(provider="GLM / Z.ai (Coding Plan)", model="glm-4.6",
+                                    base_url="https://api.z.ai/api/coding/paas/v4", api_key="zk", order=0)
+        settings = _make_settings_with_models([glm_coding])
+        spec, _api_keys, _ = build_pool_payload(settings)
+        self.assertEqual(spec["models"][0]["provider"], "openai_compat")
+        self.assertEqual(spec["models"][0]["base_url"], "https://api.z.ai/api/coding/paas/v4")
+
+    def test_standard_zai_wire_payload_unaffected_by_the_coding_plan_sibling(self):
+        # Regression lock: adding "zai_coding" must NOT change one byte of the
+        # standard "zai" row's wire output. Same assertions as
+        # test_xai_and_glm_serialize_into_pool_payload, re-run in a pool that
+        # ALSO contains a coding-plan row, to catch any cross-talk between the
+        # two _WIRE_PROVIDER_OVERRIDES entries.
+        from jarvis.jarvis.pool_serialize import build_pool_payload
+        glm = _api_key_model(provider="GLM / Z.ai", model="glm-4.6",
+                             base_url="https://api.z.ai/api/paas/v4", api_key="zk", order=0)
+        glm_coding = _api_key_model(provider="GLM / Z.ai (Coding Plan)", model="glm-4.6-coding",
+                                    base_url="https://api.z.ai/api/coding/paas/v4", api_key="zck", order=1)
+        settings = _make_settings_with_models([glm, glm_coding])
+        spec, api_keys, _ = build_pool_payload(settings)
+        prov = {m["model"]: m.get("provider") for m in spec["models"]}
+        base = {m["model"]: m.get("base_url") for m in spec["models"]}
+        self.assertEqual(prov["glm-4.6"], "openai_compat")
+        self.assertEqual(base["glm-4.6"], "https://api.z.ai/api/paas/v4")
+        self.assertEqual(prov["glm-4.6-coding"], "openai_compat")
+        self.assertEqual(base["glm-4.6-coding"], "https://api.z.ai/api/coding/paas/v4")
+        # Each row keeps its own api_key under its own key_ref - no collision.
+        self.assertEqual(len(api_keys), 2)
+
+    def test_validate_models_requires_base_url_for_zai_coding(self):
+        from jarvis.jarvis.pool_serialize import validate_models
+        glm_coding_no_url = _api_key_model(provider="zai_coding", model="glm-4.6",
+                                           base_url="", api_key="zk", order=0)
+        settings = _make_settings_with_models([glm_coding_no_url])
+        errors = validate_models(settings)
+        self.assertTrue(
+            any("requires a base_url" in e for e in errors),
+            f"expected a base_url error for a zai_coding row with no base_url, got: {errors}",
+        )
+
 
 class TestPoolSerializeFromSettings(FrappeTestCase):
     """Task 2: Direct-call tests for build_pool_payload / validate_models / compute_proxy_active."""

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -217,11 +217,20 @@ class TestProviderNormalization(FrappeTestCase):
         # xAI Grok is a native Bifrost provider; its label normalizes to "xai".
         self.assertEqual(normalize_provider("xAI Grok"), "xai")
 
-    def test_glm_zai_normalizes_to_openai_compat(self):
+    def test_glm_zai_normalizes_to_zai(self):
         from jarvis.jarvis.pool_serialize import normalize_provider
-        # GLM / Z.ai has no native Bifrost provider, so it rides the existing
-        # openai-compatible custom-endpoint path (base_url required).
-        self.assertEqual(normalize_provider("GLM / Z.ai"), "openai_compat")
+        # GLM / Z.ai is a first-class STORED provider id, same as every other
+        # alias: a dropdown label round-trips to its OWN canonical id, not a
+        # different provider's. (It has no native Bifrost provider, so it
+        # rides the openai-compatible custom-endpoint transport - but that
+        # collapse happens only at wire-serialization time, in
+        # build_pool_payload; see test_xai_and_glm_serialize_into_pool_payload
+        # below.) Regression test for the bug where storage-time collapsing
+        # onto "openai_compat" made a saved GLM row permanently render as
+        # "OpenAI-Compatible" everywhere the pool was displayed.
+        self.assertEqual(normalize_provider("GLM / Z.ai"), "zai")
+        # Passthrough: a row already stored as "zai" re-normalizes to itself.
+        self.assertEqual(normalize_provider("zai"), "zai")
 
     def test_existing_labels_unchanged(self):
         from jarvis.jarvis.pool_serialize import normalize_provider
@@ -231,7 +240,13 @@ class TestProviderNormalization(FrappeTestCase):
 
     def test_xai_and_glm_serialize_into_pool_payload(self):
         # The actual feature: build_pool_payload emits xAI as the native "xai"
-        # provider and GLM/Z.ai as an openai_compat custom provider (base_url kept).
+        # provider and GLM/Z.ai as an openai_compat custom provider (base_url
+        # kept). This is the wire-payload guarantee: it must stay exactly
+        # "openai_compat" even though normalize_provider now returns "zai" for
+        # GLM/Z.ai - the collapse moved into build_pool_payload's
+        # _wire_provider(), not away entirely. A GLM row's stored provider
+        # ("GLM / Z.ai" label, or the persisted "zai" id) must both serialize
+        # identically here so the Bifrost payload never changes shape.
         from jarvis.jarvis.pool_serialize import build_pool_payload
         xai = _api_key_model(provider="xAI Grok", model="grok-4.5",
                              base_url="https://api.x.ai/v1", api_key="xk", order=0)
@@ -244,6 +259,36 @@ class TestProviderNormalization(FrappeTestCase):
         self.assertEqual(prov["grok-4.5"], "xai")            # native passthrough
         self.assertEqual(prov["glm-4.6"], "openai_compat")   # GLM rides openai_compat
         self.assertEqual(base["glm-4.6"], "https://api.z.ai/api/paas/v4")
+
+    def test_glm_zai_already_stored_as_id_serializes_same_as_label(self):
+        # A row already persisted with the new first-class "zai" id (the
+        # normal post-fix state) must serialize onto the wire IDENTICALLY to
+        # one that still carries the raw "GLM / Z.ai" label - build_pool_payload
+        # re-normalizes before collapsing, so storage shape never leaks into
+        # the Bifrost payload.
+        from jarvis.jarvis.pool_serialize import build_pool_payload
+        glm = _api_key_model(provider="zai", model="glm-4.6",
+                             base_url="https://api.z.ai/api/paas/v4", api_key="zk", order=0)
+        settings = _make_settings_with_models([glm])
+        spec, _api_keys, _ = build_pool_payload(settings)
+        self.assertEqual(spec["models"][0]["provider"], "openai_compat")
+        self.assertEqual(spec["models"][0]["base_url"], "https://api.z.ai/api/paas/v4")
+
+    def test_validate_models_requires_base_url_for_zai(self):
+        # Defense in depth: the same base_url requirement that already gated
+        # openai_compat/vllm must cover zai now that it is a distinct stored
+        # id, or a GLM row could be saved with no endpoint and every turn on
+        # it would fail. (The frontend already blocks this client-side; this
+        # is the server-side backstop the frontend validator mirrors.)
+        from jarvis.jarvis.pool_serialize import validate_models
+        glm_no_url = _api_key_model(provider="zai", model="glm-4.6",
+                                    base_url="", api_key="zk", order=0)
+        settings = _make_settings_with_models([glm_no_url])
+        errors = validate_models(settings)
+        self.assertTrue(
+            any("requires a base_url" in e for e in errors),
+            f"expected a base_url error for a zai row with no base_url, got: {errors}",
+        )
 
 
 class TestPoolSerializeFromSettings(FrappeTestCase):


### PR DESCRIPTION
## Summary

**Part 1 - the original bug**: in Settings -> AI models, selecting provider "GLM / Z.ai", entering an api key, and saving left both the row chip and the Edit panel's Provider dropdown showing "OpenAI-Compatible" instead of GLM. Root cause: `jarvis.onboarding.save_llm_pool` normalized the incoming provider label BEFORE persisting into `Jarvis Settings.models[].provider`, and `pool_serialize._PROVIDER_ALIASES` mapped `"glm / z.ai"` straight to `"openai_compat"` - a different provider's canonical id, unlike every other alias (which maps a label to ITS OWN id). Fixed by moving that collapse to wire-serialization time only (`build_pool_payload`'s new `_wire_provider()`), so storage/display now correctly keep `"zai"` while the Bifrost payload is unchanged.

**Part 2 - live discovery during verification, added to this same PR**: z.ai sells two distinct products on two distinct endpoints - pay-as-you-go API credits (`api.z.ai/api/paas/v4`) and a separate "GLM Coding Plan" subscription (`api.z.ai/api/coding/paas/v4`). A Coding Plan key authenticates fine but the pay-as-you-go endpoint reports it as "insufficient balance" (z.ai error code 1113), since the two products don't share a balance - this reads as a dead key when it's really just the wrong endpoint, and made an otherwise-valid key look completely non-functional. Added a distinct provider id + a targeted diagnostic hint for this exact trap.

Note on base branch: this branch was created off `main`, which no longer exists on the remote (`upstream`'s default is now `beta`, and the user has since directed PRs to target `develop`, an ancestor of which is `beta`). Retargeted to `develop`.

## Part 1: storage vs. wire-time provider identity

- `jarvis/jarvis/pool_serialize.py`: `_PROVIDER_ALIASES["glm / z.ai"]` now maps to `"zai"` (true round-trip, like every other provider). New `_WIRE_PROVIDER_OVERRIDES`/`_wire_provider()`, applied only inside `build_pool_payload`, collapses `"zai" -> "openai_compat"` on the wire only. `validate_models` requires `base_url` for `zai` (mirrors `openai_compat`/`vllm`).
- `jarvis/patches/v2_01_backfill_glm_zai_provider_id.py`: backfills existing `provider=="openai_compat"` rows on an `api.z.ai` host to the correct first-class id.
- `jarvis/jarvis/page/jarvis_account/jarvis_account.js` (Desk duplicate provider table): verified already consistent (added in #319), no change needed for Part 1.
- Tests: `test_glm_zai_normalizes_to_openai_compat` (encoded the bug) renamed/updated to `test_glm_zai_normalizes_to_zai`; `test_xai_and_glm_serialize_into_pool_payload` left asserting `"openai_compat"` on the wire, UNCHANGED as the regression lock; round-trip + backfill-patch test coverage added.

## Part 2: GLM Coding Plan (`zai_coding`)

- New first-class provider id `"zai_coding"` (label `"GLM / Z.ai (Coding Plan)"`), synced everywhere `"zai"` already appears: `PROVIDER_LABELS`, `NEEDS_BASE_URL` (`frontend/src/llm/pool.js`), `PROVIDER_DEFAULTS`/`STATIC_MODEL_SUGGESTIONS` (`LlmPoolEditor.vue` and the desk `jarvis_account.js` duplicate), `ProviderLogo.vue`'s monogram map, `pool_serialize`'s alias table + wire-collapse table + `validate_models`' base_url gate. A distinct provider id (rather than a toggle inside the existing "zai" option) needed **no new UI** - just data-table entries, the same shape every other provider already uses. Both variants collapse to the same `openai_compat` wire transport.
- Diagnostic hint: `apiKeyModelHealth` (`pool.js`) now recognizes the 1113/insufficient-balance failure pattern on a `"zai"` row specifically (never `"zai_coding"`, never another provider) and names the coding-plan base URL instead of the generic "Not working" message. Consumes the fleet's optional `model_statuses[].detail` field (contract 1.12, landing separately in fleet-agent PR #141) defensively - falls through to the generic message when `detail` is absent (older fleet) or doesn't match. **No backend plumbing needed**: `model_statuses` already passes through `Jarvis Settings -> get_llm_sync_status` verbatim with zero field whitelisting, verified by reading the full call chain (`jarvis_settings.py` -> `_frappe.as_json` -> `onboarding.py`'s `_json_list` -> frontend); comment-only doc updates added there for accuracy.
- `jarvis/patches/v2_01_backfill_glm_zai_provider_id.py` rewritten to distinguish the two endpoints by URL path (`"/coding/"` substring, gated behind the existing `api.z.ai` host + `openai_compat` provider checks) rather than backfilling every collapsed Z.ai row to `"zai"` - a coding-plan row now correctly backfills to `"zai_coding"`.
- Tests: `zai_coding` round-trip (Python, `test_llm_pool_endpoints.py`), wire-payload tests including a dedicated regression lock proving a standard `"zai"` row's wire output is byte-identical whether or not a `"zai_coding"` sibling exists in the same pool, backfill-patch tests for both endpoints + idempotency, and 10 new JS tests in `pool.test.js` covering the label round-trip and all 5 hint-logic branches (fires on match, falls through on non-matching detail, falls through on missing detail, does not fire on `zai_coding`, does not fire on an unrelated provider).

## Verification

CI is the authority for this repo (local `site.jarvis` is role/data-polluted; per the worktree's constraints I could not run `bench run-tests` against any live site without risking mutating live tenant data). Verified instead with:

- `ruff check` + `python3 -m py_compile` on all touched/added Python: clean (zero new lint issues vs. the pre-existing baseline, confirmed by diffing ruff output before/after via `git stash`).
- Standalone, DB-free execution of `normalize_provider` / `build_pool_payload` / `validate_models` (stubbing only `frappe.local.site`, no site/DB involved) for both `zai` and `zai_coding`, confirming:
  - Both normalize to their own id and pass through unchanged on re-normalization.
  - **The Bifrost wire payload is byte-for-byte unchanged for the standard GLM row**, including when a `zai_coding` sibling exists in the same pool: `{"model": "glm-4.6", ..., "base_url": "https://api.z.ai/api/paas/v4", "provider": "openai_compat"}`, identical to a solo-row payload.
  - A `zai_coding` row emits `provider: "openai_compat"` with its own `base_url` (the coding-plan endpoint) and its own `key_ref` (no collision with the sibling row's key).
  - `validate_models` flags a `base_url`-less row for both ids.
- Standalone, DB-free execution of the rewritten backfill patch's `execute()` against in-memory fake `frappe.get_all`/`frappe.db.set_value`, confirming both endpoints backfill to the correct distinct id, genuine `openai_compat` / unrelated-provider rows stay untouched, and re-running is a true no-op for both ids.
- `node --test frontend/src/llm/pool.test.js`: **43/43 passing** (31 pre-existing + 12 new across both parts).
- Two independent Sonnet code-review passes per part (4 total), all clean - no high-confidence issues found in either round. One low-severity edge case was surfaced and assessed (not fixed): a narrow transition-window mismatch in the `prior_api_keys` re-save lookup for a not-yet-backfilled row, which fails safe (blocks the save with a validation error, does not lose data) and closes itself once `bench migrate` runs.

The full Frappe-dependent test suite (round-trip and backfill-patch tests) will run in CI against a fresh DB.

## Test plan

- [x] CI green
- [ ] Manual: save a GLM / Z.ai row, reload, confirm it renders "GLM / Z.ai" (not "OpenAI-Compatible")
- [ ] Manual: add a "GLM / Z.ai (Coding Plan)" row with a coding-plan key, confirm it saves/renders correctly and the base URL defaults to `https://api.z.ai/api/coding/paas/v4`
- [ ] Manual (once fleet-agent #141 ships `detail`): point a Coding Plan key at the standard "GLM / Z.ai" option, confirm the AI-models list shows the "Wrong Z.ai endpoint" hint naming the coding-plan URL instead of a generic "Not working"
- [ ] Confirm `bench migrate` on a tenant with a pre-existing collapsed GLM row (either endpoint) backfills it to the correct id with no visible disruption