### PR TITLE
fix(oauth): accept xAI's bare authorization code, not just a callback URL

### DIFF
--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -19,8 +19,9 @@
         <code class="jv-dsub-url" :title="authorizeUrl">{{ authorizeUrl }}</code>
         <button type="button" class="jv-dsub-btn jv-dsub-btn-ghost" @click="copyUrl">{{ copied ? 'Copied' : 'Copy' }}</button>
       </div>
-      <p class="jv-dsub-step" style="margin-top:14px;"><b>2.</b> After you click Authorize, your browser shows a “This site can’t be reached” page. <b>That’s expected.</b> Copy the URL from the address bar (starts with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
-      <textarea v-model="pastedUrl" rows="3" class="jv-dsub-input" placeholder="Paste the URL from the error page here"></textarea>
+      <p v-if="codeOnly" class="jv-dsub-step" style="margin-top:14px;"><b>2.</b> After you click Authorize, {{ status.provider || pickProvider }} shows you an <b>authorization code</b>. Copy that code and paste it here:</p>
+      <p v-else class="jv-dsub-step" style="margin-top:14px;"><b>2.</b> After you click Authorize, your browser shows a “This site can’t be reached” page. <b>That’s expected.</b> Copy the URL from the address bar (starts with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
+      <textarea v-model="pastedUrl" rows="3" class="jv-dsub-input" :placeholder="codeOnly ? 'Paste the code shown after you approve' : 'Paste the URL from the error page here'"></textarea>
       <div class="jv-dsub-actions" style="margin-top:10px;">
         <button class="jv-dsub-btn jv-dsub-btn-ghost" @click="cancelFlow">Cancel</button>
         <button class="jv-dsub-btn jv-dsub-btn-primary" :disabled="busy" @click="submitPasted">{{ busy ? 'Connecting…' : 'Submit' }}</button>
@@ -79,6 +80,7 @@
 import { ref, computed, onBeforeUnmount } from "vue"
 import * as api from "@/api"
 import { errMessage as _err } from "@/lib/errors"
+import { isCodeOnlyPaste } from "@/llm/pool"
 import { exactDate } from "@/utils/datetime"
 import { useConfirm } from "@/composables/useConfirm"
 
@@ -106,6 +108,11 @@ function _defaultProvider() {
   return byModel ? byModel.provider : "OpenAI"
 }
 const pickProvider = ref(_defaultProvider())
+// The Re-authorize path reuses `status.provider` regardless of SUB_PROVIDERS
+// (which only gates NEW connections), so a tenant already stored as "xAI Grok"
+// can reach this flow. xAI shows a bare code, not a callback URL, so the step-2
+// copy has to follow. Shared with LlmPoolEditor via @/llm/pool.
+const codeOnly = computed(() => isCodeOnlyPaste(status.value.provider || pickProvider.value))
 const pickModels = computed(() =>
   (SUB_PROVIDERS.find((p) => p.provider === pickProvider.value) || SUB_PROVIDERS[0]).models,
 )
@@ -186,7 +193,12 @@ async function startSignin(providerOverride, modelOverride) {
 async function submitPasted() {
   err.value = ""
   const pasted = (pastedUrl.value || "").trim()
-  if (!pasted) { err.value = "Paste the URL from your browser's address bar first."; return }
+  if (!pasted) {
+    err.value = codeOnly.value
+      ? "Paste the code you were shown first."
+      : "Paste the URL from your browser's address bar first."
+    return
+  }
   busy.value = true
   try {
     const res = await api.completePasteSignin(nonce.value, pasted)

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -579,7 +579,7 @@ import * as api from "@/api"
 import {
   deriveMode, reorder, presetToModels, missingVendorKeys, validatePool,
   PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig, defaultSubscriptionModel,
-  apiKeyModelHealth,
+  apiKeyModelHealth, isCodeOnlyPaste,
 } from "@/llm/pool"
 import { errMessage as _err } from "@/lib/errors"
 import { useConfirm } from "@/composables/useConfirm"
@@ -672,12 +672,8 @@ const upstreamLabelOf = (v) => (upstreamOpts.find((o) => o.value === v) || {}).l
 const upstreamValueOf = (l) => (upstreamOpts.find((o) => o.label === l) || {}).value || l
 // Upstreams whose approval screen hands back a BARE authorization code instead
 // of redirecting to a callback URL the customer can copy from the address bar.
-// MUST match the providers carrying `code_only_paste` in jarvis/oauth/providers.py
-// (the backend is what actually accepts a bare code; this only steers the copy).
-// Telling an xAI customer to "copy the full URL from the address bar" sends them
-// looking for an address bar that never holds a code.
-const CODE_ONLY_PASTE = { xai: true }
-const isCodeOnlyPaste = (u) => !!CODE_ONLY_PASTE[u]
+// isCodeOnlyPaste (xAI) is imported from @/llm/pool so the pool editor and the
+// direct subscription card share one answer rather than each keeping a copy.
 const pasteTitle = (u) => (isCodeOnlyPaste(u) ? "Paste the code" : "Paste the callback URL")
 const pastePlaceholder = (u, ready) => {
   if (!ready) return isCodeOnlyPaste(u) ? "Complete step 1 first, then paste the code here"

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -294,16 +294,15 @@
             <div class="jv-cstep" :class="{ 'jv-pending': !panelRow._connect.authorizeUrl }">
               <div class="jv-cnum">2</div>
               <div class="jv-cbody">
-                <div class="jv-ctit">Paste the callback URL</div>
+                <div class="jv-ctit">{{ pasteTitle(panelRow.upstream) }}</div>
                 <div class="jv-callout">
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
-                  <p>After you approve, the browser shows a <b>&ldquo;This site can&rsquo;t be reached&rdquo;</b> page. That&rsquo;s expected: copy the <b>full URL from the address bar</b> (<kbd>⌘/Ctrl</kbd>+<kbd>L</kbd>, then <kbd>⌘/Ctrl</kbd>+<kbd>C</kbd>) and paste it below.</p>
+                  <p v-if="isCodeOnlyPaste(panelRow.upstream)">After you approve, {{ upstreamLabelOf(panelRow.upstream) }} shows you an <b>authorization code</b>. Copy that code and paste it below.</p>
+                  <p v-else>After you approve, the browser shows a <b>&ldquo;This site can&rsquo;t be reached&rdquo;</b> page. That&rsquo;s expected: copy the <b>full URL from the address bar</b> (<kbd>⌘/Ctrl</kbd>+<kbd>L</kbd>, then <kbd>⌘/Ctrl</kbd>+<kbd>C</kbd>) and paste it below.</p>
                 </div>
                 <input v-model="panelRow._connect.pastedUrl" class="jv-paste"
                        :disabled="!editable || !panelRow._connect.authorizeUrl"
-                       :placeholder="panelRow._connect.authorizeUrl
-                         ? 'http://localhost:1455/auth/callback?code=…'
-                         : 'Complete step 1 first, then paste the URL here'"
+                       :placeholder="pastePlaceholder(panelRow.upstream, panelRow._connect.authorizeUrl)"
                        @keydown.enter="finishConnect(panelRow)" />
               </div>
             </div>
@@ -524,19 +523,18 @@
               <div class="jv-cstep" :class="{ 'jv-pending': !(m._connect && m._connect.authorizeUrl) }">
                 <div class="jv-cnum">2</div>
                 <div class="jv-cbody">
-                  <div class="jv-ctit">Paste the callback URL</div>
+                  <div class="jv-ctit">{{ pasteTitle(m.upstream) }}</div>
                   <div class="jv-callout">
                     <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
-                    <p>After you approve, the browser shows a <b>&ldquo;This site can&rsquo;t be reached&rdquo;</b> page. That&rsquo;s expected: copy the <b>full URL from the address bar</b> (<kbd>⌘/Ctrl</kbd>+<kbd>L</kbd>, then <kbd>⌘/Ctrl</kbd>+<kbd>C</kbd>) and paste it below.</p>
+                    <p v-if="isCodeOnlyPaste(m.upstream)">After you approve, {{ upstreamLabelOf(m.upstream) }} shows you an <b>authorization code</b>. Copy that code and paste it below.</p>
+                    <p v-else>After you approve, the browser shows a <b>&ldquo;This site can&rsquo;t be reached&rdquo;</b> page. That&rsquo;s expected: copy the <b>full URL from the address bar</b> (<kbd>⌘/Ctrl</kbd>+<kbd>L</kbd>, then <kbd>⌘/Ctrl</kbd>+<kbd>C</kbd>) and paste it below.</p>
                   </div>
                   <!-- Disabled until step 1 minted an authorize URL: a URL pasted
                        before sign-in has no nonce to pair with (finishConnect
                        would no-op), a silent dead-end. -->
                   <input v-model="m._connect.pastedUrl" class="jv-paste"
                          :disabled="!editable || !(m._connect && m._connect.authorizeUrl)"
-                         :placeholder="m._connect && m._connect.authorizeUrl
-                           ? 'http://localhost:1455/auth/callback?code=…'
-                           : 'Complete step 1 first, then paste the URL here'"
+                         :placeholder="pastePlaceholder(m.upstream, m._connect && m._connect.authorizeUrl)"
                          @keydown.enter="finishConnect(m)" />
                   <div v-if="m._connect && m._connect.authorizeUrl" class="jv-cacts">
                     <button type="button" class="jv-cbtn jv-cbtn-ghost" @click="closeConnect(m)">Cancel</button>
@@ -672,6 +670,21 @@ const upstreamLabels = upstreamOpts.map((o) => o.label)
 // renders "Sign in with <value>" rather than "Sign in with " (review finding).
 const upstreamLabelOf = (v) => (upstreamOpts.find((o) => o.value === v) || {}).label || v || "your provider"
 const upstreamValueOf = (l) => (upstreamOpts.find((o) => o.label === l) || {}).value || l
+// Upstreams whose approval screen hands back a BARE authorization code instead
+// of redirecting to a callback URL the customer can copy from the address bar.
+// MUST match the providers carrying `code_only_paste` in jarvis/oauth/providers.py
+// (the backend is what actually accepts a bare code; this only steers the copy).
+// Telling an xAI customer to "copy the full URL from the address bar" sends them
+// looking for an address bar that never holds a code.
+const CODE_ONLY_PASTE = { xai: true }
+const isCodeOnlyPaste = (u) => !!CODE_ONLY_PASTE[u]
+const pasteTitle = (u) => (isCodeOnlyPaste(u) ? "Paste the code" : "Paste the callback URL")
+const pastePlaceholder = (u, ready) => {
+  if (!ready) return isCodeOnlyPaste(u) ? "Complete step 1 first, then paste the code here"
+                                        : "Complete step 1 first, then paste the URL here"
+  return isCodeOnlyPaste(u) ? "Paste the code shown after you approve"
+                            : "http://localhost:1455/auth/callback?code=…"
+}
 // Provider dropdown fed by the shared PROVIDER_LABELS (id⇄label). Rows store the
 // display LABEL as `provider` (matches seedRowsFromConfig + the desk page).
 const providerOptions = PROVIDER_LABELS.map((p) => p.label)
@@ -1256,14 +1269,22 @@ async function _placeConnectedAccount(m, d) {
 }
 async function finishConnect(m) {
   if (!m._connect || !m._connect.nonce) return
-  if (!(m._connect.pastedUrl || "").trim()) { m._connect.error = "Paste the URL you were redirected to."; return }
+  if (!(m._connect.pastedUrl || "").trim()) {
+    m._connect.error = isCodeOnlyPaste(m.upstream)
+      ? "Paste the code you were shown."
+      : "Paste the URL you were redirected to."
+    return
+  }
   m._connect.loading = true; m._connect.error = ""
   try {
     const res = await api.completePoolAccountSignin(m._connect.nonce, m._connect.pastedUrl.trim())
     // Same {ok, data} envelope as begin - unwrap + surface errors.
     if (!res || res.ok === false) {
       m._connect.loading = false
-      m._connect.error = (res && res.error && res.error.message) || "Couldn't connect the account. Check the pasted URL and try again."
+      m._connect.error = (res && res.error && res.error.message)
+        || (isCodeOnlyPaste(m.upstream)
+            ? "Couldn't connect the account. Check the pasted code and try again."
+            : "Couldn't connect the account. Check the pasted URL and try again.")
       return
     }
     // Place the (re)connected account. The backend mints a fresh account_ref on

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -108,6 +108,21 @@ export const PROVIDER_LABELS = [
 ]
 const _LABEL_BY_ID = Object.fromEntries(PROVIDER_LABELS.map(p => [p.id, p.label]))
 const _ID_BY_LABEL = Object.fromEntries(PROVIDER_LABELS.map(p => [p.label, p.id]))
+
+// Providers whose approval screen hands back a BARE authorization code instead
+// of redirecting to a callback URL the customer can copy from the address bar.
+// Keyed by BOTH the pool `upstream` value ("xai") and the OAuth provider label
+// ("xAI Grok"), so the pool editor and the direct paste-back card can share one
+// answer instead of each keeping a copy.
+//
+// MUST match the providers carrying `code_only_paste` in
+// jarvis/oauth/providers.py - that flag is what actually makes the backend take
+// a bare code; this only steers the paste copy. Telling an xAI customer to
+// "copy the full URL from the address bar" sends them hunting for an address
+// bar that never holds a code.
+const _CODE_ONLY_PASTE = new Set(["xai", "xAI Grok"])
+export const isCodeOnlyPaste = (upstreamOrLabel) => _CODE_ONLY_PASTE.has(upstreamOrLabel)
+
 // Custom-endpoint providers whose whole identity IS the base_url (no default
 // endpoint) - validatePool requires one for these (mirrors validate_models).
 // "zai" (GLM / Z.ai) has no native Bifrost provider, so it needs its Z.ai

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -137,6 +137,16 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	// renders the loading placeholder. Punch-list "_SUBSCRIPTION_MODELS
 	// duplicated 4-5 times" from the 2026-06-16 cross-repo review.
 	let subscriptionModels = {};
+
+	// Providers whose approval screen hands back a BARE authorization code
+	// rather than redirecting to a callback URL. xAI Grok reaches this page:
+	// provOptions is built from subscriptionModels above, which carries every
+	// key of jarvis/_subscription_models.py including "xAI Grok". Telling that
+	// customer to copy the address bar sends them hunting for a URL that never
+	// appears. MUST match `code_only_paste` in jarvis/oauth/providers.py (that
+	// flag is what makes the backend accept a bare code; this only steers copy).
+	const CODE_ONLY_PASTE_PROVIDERS = ["xAI Grok"];
+	const isCodeOnlyPaste = (p) => CODE_ONLY_PASTE_PROVIDERS.indexOf(p) !== -1;
 	let defaultModels = {};
 	// Preset failover ladders (jarvis.onboarding.get_preset_catalog). Fetched in
 	// loadInitial alongside the pool config so the Preset tab is populated before
@@ -549,9 +559,11 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					<code class="ja-url-text" id="ja-sub-url-text" title="${esc(ui.subAuthorizeUrl)}">${esc(ui.subAuthorizeUrl)}</code>
 					<button type="button" class="ja-btn ja-btn-ghost ja-btn-small" id="ja-sub-copy-url" title="Copy URL">Copy</button>
 				</div>
-				<p class="ja-sub"><strong>Step 2</strong> - After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>
+				${isCodeOnlyPaste(ui.subProvider)
+					? `<p class="ja-sub"><strong>Step 2</strong> - After clicking Authorize, ${esc(ui.subProvider)} shows you an <strong>authorization code</strong>. Copy that code and paste it here:</p>`
+					: `<p class="ja-sub"><strong>Step 2</strong> - After clicking Authorize, your browser will show a page saying <em>"This site can't be reached."</em> <strong>That's expected.</strong> Copy the URL from your browser's address bar (it'll start with <code>http://localhost:1455/auth/callback?code=…</code>) and paste it here:</p>`}
 				<div class="ja-field">
-					<textarea class="ja-input" id="ja-sub-pasted-url" rows="3" placeholder="Paste the URL from the error page here"></textarea>
+					<textarea class="ja-input" id="ja-sub-pasted-url" rows="3" placeholder="${isCodeOnlyPaste(ui.subProvider) ? 'Paste the code shown after you approve' : 'Paste the URL from the error page here'}"></textarea>
 				</div>
 				<div class="ja-actions">
 					<button class="ja-btn ja-btn-ghost" id="ja-sub-cancel">Cancel</button>
@@ -816,7 +828,9 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		$err.text("");
 		const pasted = ($body.find("#ja-sub-pasted-url").val() || "").trim();
 		if (!pasted) {
-			$err.text("Paste the URL from your browser's address bar first.");
+			$err.text(isCodeOnlyPaste(ui.subProvider)
+				? "Paste the code you were shown first."
+				: "Paste the URL from your browser's address bar first.");
 			return;
 		}
 		setBusy("#ja-sub-submit", true);

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -10,6 +10,7 @@ Plus disconnect() to reverse the connection.
 import base64
 import hashlib
 import json
+import re
 import secrets
 import time
 
@@ -20,8 +21,8 @@ from jarvis import admin_client, onboarding
 from jarvis.exceptions import JarvisError
 from jarvis.permissions import require_jarvis_admin
 from jarvis.oauth.providers import (
-	UnknownProviderError, build_authorize_url, extract_account_id, get_provider,
-	is_oauth_provider, provider_redirect_uri,
+	UnknownProviderError, accepts_bare_code, build_authorize_url, extract_account_id,
+	get_provider, is_oauth_provider, provider_redirect_uri,
 )
 
 
@@ -337,19 +338,41 @@ def begin_pool_account_signin(provider: str, model: str) -> dict:
 from urllib.parse import urlparse, parse_qs
 
 
-def _parse_redirected_url(raw: str) -> dict:
-	"""Defensively parse the URL the customer pasted.
+# A bare authorization code: no query syntax ("=" / "&"), no URL syntax
+# ("://", leading "/" or "?"), no whitespace, and printable ASCII only. Anything
+# holding "=" is treated as a query string instead, so a customer who pastes
+# only "state=..." still lands on missing_code rather than having the fragment
+# mistaken for a code. The length floor rejects stray keystrokes; the ceiling
+# keeps a pasted essay out of the token request.
+_BARE_CODE_RE = re.compile(r"\A[\x21-\x7e]{8,512}\Z")
+
+
+def _looks_like_bare_code(raw: str) -> bool:
+	if "://" in raw or raw.startswith(("/", "?")) or "=" in raw or "&" in raw:
+		return False
+	return bool(_BARE_CODE_RE.match(raw))
+
+
+def _parse_redirected_url(raw: str, *, allow_bare_code: bool = False) -> dict:
+	"""Defensively parse whatever the customer pasted back.
 
 	Accepts:
 	  - http://localhost:1455/auth/callback?code=A&state=B
 	  - ?code=A&state=B
 	  - code=A&state=B
+	  - A                     (bare code; only when allow_bare_code)
 
-	Returns: {"code": str|None, "state": str|None}
+	``allow_bare_code`` is set from the provider's ``code_only_paste`` flag —
+	xAI shows a bare code instead of redirecting to a callback URL. A bare code
+	has no ``state``, so ``bare`` is returned True to tell the caller the state
+	compare has nothing to compare against (PKCE binds the code instead; see
+	providers.py's ``code_only_paste`` comment).
+
+	Returns: {"code": str|None, "state": str|None, "bare": bool}
 	"""
 	raw = (raw or "").strip()
 	if not raw:
-		return {"code": None, "state": None}
+		return {"code": None, "state": None, "bare": False}
 
 	if "://" in raw or raw.startswith("/"):
 		query = urlparse(raw).query
@@ -359,10 +382,15 @@ def _parse_redirected_url(raw: str) -> dict:
 		query = raw
 
 	q = parse_qs(query)
-	return {
-		"code": (q.get("code") or [None])[0],
-		"state": (q.get("state") or [None])[0],
-	}
+	code = (q.get("code") or [None])[0]
+	if code:
+		return {"code": code, "state": (q.get("state") or [None])[0], "bare": False}
+
+	# No `code=` anywhere. For a code-only provider the paste may be the code
+	# itself; for everyone else this stays a missing_code.
+	if allow_bare_code and _looks_like_bare_code(raw):
+		return {"code": raw, "state": None, "bare": True}
+	return {"code": None, "state": None, "bare": False}
 
 
 def _validate_signin_nonce(nonce: str):
@@ -407,21 +435,34 @@ def _exchange_and_build_blob(entry: dict, redirected_url: str):
 	save creds, or touch Jarvis Settings — those side effects belong to the
 	DIRECT caller only.
 	"""
-	parsed = _parse_redirected_url(redirected_url)
+	provider = entry["provider"]
+	bare_ok = accepts_bare_code(provider)
+	parsed = _parse_redirected_url(redirected_url, allow_bare_code=bare_ok)
 	if not parsed["code"]:
-		return None, _err("missing_code", "no `code` parameter found in the pasted URL")
+		return None, _err("missing_code",
+		            "couldn't find an authorization code in what you pasted; paste the code "
+		            "itself or the full callback URL"
+		            if bare_ok else
+		            "no `code` parameter found in the pasted URL")
 	# Constant-time compare on the state parameter. The state value is the
 	# OAuth CSRF nonce - if an attacker can observe how long the
 	# comparison takes, plain ``!=`` short-circuits on the first
 	# differing byte and leaks a prefix-recovery oracle. secrets.compare_digest
 	# runs in constant time over the longer of the two inputs.
 	# Punch-list "state comparison non-constant-time" from the 2026-06-16 review.
-	if not secrets.compare_digest(parsed["state"] or "", entry["state"] or ""):
+	#
+	# Skipped only for a BARE code from a code_only_paste provider (xAI), which
+	# has no state to echo back. The exchange below still sends this nonce's
+	# `code_verifier`, so PKCE keeps the code bound to this very authorize
+	# request. A pasted URL is still state-checked even for those providers:
+	# if a `code=` param came through, a `state=` one should have too.
+	if not parsed["bare"] and not secrets.compare_digest(
+		parsed["state"] or "", entry["state"] or ""
+	):
 		return None, _err("state_mismatch",
 		            "the `state` parameter doesn't match; "
 		            "regenerate the sign-in URL and try again")
 
-	provider = entry["provider"]
 	# Re-coerce belt-and-suspenders: nonces live up to 10 min, so
 	# _SUBSCRIPTION_MODELS could in principle be tightened mid-flight
 	# (e.g. a codex model deprecated). begin_paste_signin already coerced

--- a/jarvis/oauth/api.py
+++ b/jarvis/oauth/api.py
@@ -338,17 +338,26 @@ def begin_pool_account_signin(provider: str, model: str) -> dict:
 from urllib.parse import urlparse, parse_qs
 
 
-# A bare authorization code: no query syntax ("=" / "&"), no URL syntax
-# ("://", leading "/" or "?"), no whitespace, and printable ASCII only. Anything
-# holding "=" is treated as a query string instead, so a customer who pastes
-# only "state=..." still lands on missing_code rather than having the fragment
-# mistaken for a code. The length floor rejects stray keystrokes; the ceiling
-# keeps a pasted essay out of the token request.
+# A bare authorization code: no URL syntax ("://", leading "/" or "?"), no
+# pair separator ("&"), no whitespace, printable ASCII only. The length floor
+# rejects stray keystrokes; the ceiling keeps a pasted essay out of the token
+# request.
+#
+# "=" is deliberately NOT disqualifying. A base64/JWT-shaped code can carry "="
+# as padding, and excluding it would re-break the very case this exists to
+# handle. Query pastes are ruled out by _OAUTH_QUERY_KEYS below instead, which
+# keys off what the string actually *parses to* rather than one character.
 _BARE_CODE_RE = re.compile(r"\A[\x21-\x7e]{8,512}\Z")
+
+# Params that mark a paste as an OAuth query/callback rather than a bare code.
+# If one of these parsed out but `code` did not, the customer pasted a real
+# (but code-less) callback, so this is a missing_code, not a code to redeem.
+_OAUTH_QUERY_KEYS = ("state", "error", "error_description", "error_uri",
+                     "session_state", "iss", "scope")
 
 
 def _looks_like_bare_code(raw: str) -> bool:
-	if "://" in raw or raw.startswith(("/", "?")) or "=" in raw or "&" in raw:
+	if "://" in raw or raw.startswith(("/", "?")) or "&" in raw:
 		return False
 	return bool(_BARE_CODE_RE.match(raw))
 
@@ -386,8 +395,15 @@ def _parse_redirected_url(raw: str, *, allow_bare_code: bool = False) -> dict:
 	if code:
 		return {"code": code, "state": (q.get("state") or [None])[0], "bare": False}
 
-	# No `code=` anywhere. For a code-only provider the paste may be the code
-	# itself; for everyone else this stays a missing_code.
+	# No `code=`. If the paste still parsed to recognisable OAuth params, it was
+	# a genuine callback that simply lacks a code (e.g. "state=..." on its own,
+	# or an ?error= bounce) - that is a missing_code, never a code to redeem.
+	if any(k in q for k in _OAUTH_QUERY_KEYS):
+		return {"code": None, "state": None, "bare": False}
+
+	# Otherwise, for a code-only provider the paste may be the code itself. A
+	# base64-padded code parses to junk like {"AbC123": ["="]}, which matches no
+	# OAuth key, so it correctly falls through to here.
 	if allow_bare_code and _looks_like_bare_code(raw):
 		return {"code": raw, "state": None, "bare": True}
 	return {"code": None, "state": None, "bare": False}

--- a/jarvis/oauth/providers.py
+++ b/jarvis/oauth/providers.py
@@ -88,6 +88,18 @@ _PROVIDER_OAUTH_MAP: dict[str, dict] = {
 		"openclaw_provider": "xai",
 		"redirect_uri": "http://127.0.0.1:56121/callback",
 		"requires_nonce": True,
+		# xAI's approval screen hands the customer a BARE authorization code to
+		# copy rather than bouncing them to a callback URL they can lift from the
+		# address bar. cli-proxy-api hits the same wall: its xai prompt reads
+		# "Paste the xAI callback Token", where the claude channel's reads "Paste
+		# the Claude callback URL". A bare code carries no `state`, so
+		# _exchange_and_build_blob skips the state compare for this provider.
+		# That is safe HERE AND ONLY HERE: the token exchange always sends this
+		# nonce's PKCE `code_verifier` (S256), so a code minted for anyone else's
+		# authorize request cannot be redeemed against it - PKCE already supplies
+		# the request binding that state would. Do NOT set this on a provider
+		# that returns a real callback URL.
+		"code_only_paste": True,
 		"extra_authorize_params": {"plan": "generic", "referrer": "cli-proxy-api"},
 	},
 	# Kimi (Moonshot) — DEVICE-CODE flow (RFC 8628), NOT paste-back: there is no
@@ -119,6 +131,17 @@ def is_oauth_provider(label: str) -> bool:
 	"""
 	entry = _PROVIDER_OAUTH_MAP.get(label)
 	return entry is not None and entry.get("grant_type") != "device_code"
+
+
+def accepts_bare_code(label: str) -> bool:
+	"""True when ``label``'s approval screen hands back a BARE authorization code
+	instead of a callback URL, so the paste box must take the code on its own.
+
+	Only xAI sets ``code_only_paste``. See the comment on that key for why
+	skipping the ``state`` compare is sound for a bare code (PKCE binds it) and
+	why no URL-returning provider may opt in.
+	"""
+	return bool(_PROVIDER_OAUTH_MAP.get(label, {}).get("code_only_paste"))
 
 
 def get_provider(label: str) -> dict:

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -273,6 +273,59 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 			)
 		self.assertTrue(out["ok"], msg=str(out))
 
+	# ---- bare-code paste (xAI) -------------------------------------------
+	# xAI's approval screen shows a bare authorization code, not a callback URL,
+	# so parse_qs finds no `code=` and every xAI sign-in used to dead-end on
+	# missing_code. See providers.py "code_only_paste".
+
+	def test_xai_accepts_bare_code(self):
+		nonce = self._seed(provider="xAI Grok")
+		with patch("jarvis.oauth.api._exchange_code", return_value={
+			"access_token": "AT", "refresh_token": "RT", "expires_in": 3600,
+			"id_token": "", "email": "x@y.com",
+		}) as ex, patch("jarvis.oauth.api.admin_client.post_push_oauth_blob"), \
+		     patch("jarvis.oauth.api.onboarding.save_llm_creds",
+		           return_value={"last_sync_status": "ok"}):
+			out = oauth_api.complete_paste_signin(
+				nonce=nonce,
+				redirected_url="xai-code-ABC123def456",
+			)
+		self.assertTrue(out["ok"], msg=str(out))
+		# The whole paste IS the code, and PKCE still binds it to this nonce -
+		# that binding is what lets the state compare be skipped.
+		self.assertEqual(ex.call_args.kwargs["code"], "xai-code-ABC123def456")
+		self.assertEqual(ex.call_args.kwargs["code_verifier"], "test-verifier")
+
+	def test_bare_code_rejected_for_url_provider(self):
+		# OpenAI returns a real callback URL, so a bare code there is a paste
+		# mistake, not a supported shape. Only code_only_paste providers opt in.
+		nonce = self._seed()
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="some-bare-code-ABC123",
+		)
+		self.assertEqual(out["error"]["code"], "missing_code")
+
+	def test_xai_pasted_url_is_still_state_checked(self):
+		# Relaxing state is scoped to a BARE code. If a `code=` param arrives, a
+		# `state=` one should have too, so the compare still runs for xAI.
+		nonce = self._seed(provider="xAI Grok")
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="http://127.0.0.1:56121/callback?code=A&state=wrong",
+		)
+		self.assertEqual(out["error"]["code"], "state_mismatch")
+
+	def test_xai_bare_state_fragment_is_not_a_code(self):
+		# "state=..." holds an "=", so it parses as a query with no `code` and
+		# must not be mistaken for a bare code.
+		nonce = self._seed(provider="xAI Grok")
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="state=test-state",
+		)
+		self.assertEqual(out["error"]["code"], "missing_code")
+
 
 class TestCompletePasteSigninFlow(_OAuthApiBase):
 	def _seed(self, provider="OpenAI", model="gpt-5.5"):

--- a/jarvis/tests/test_oauth_api.py
+++ b/jarvis/tests/test_oauth_api.py
@@ -317,12 +317,41 @@ class TestCompletePasteSigninParsing(_OAuthApiBase):
 		self.assertEqual(out["error"]["code"], "state_mismatch")
 
 	def test_xai_bare_state_fragment_is_not_a_code(self):
-		# "state=..." holds an "=", so it parses as a query with no `code` and
-		# must not be mistaken for a bare code.
+		# "state=..." parses to a recognised OAuth param with no `code`, so it is
+		# a code-less callback (missing_code), never a code to redeem.
 		nonce = self._seed(provider="xAI Grok")
 		out = oauth_api.complete_paste_signin(
 			nonce=nonce,
 			redirected_url="state=test-state",
+		)
+		self.assertEqual(out["error"]["code"], "missing_code")
+
+	def test_xai_accepts_base64_padded_code(self):
+		# A code carrying "=" as base64/JWT padding is still a bare code. Keying
+		# "is this a query?" off the "=" character alone would reject exactly the
+		# shape this path exists to accept, so the check keys off whether the
+		# paste parses to real OAuth params instead.
+		nonce = self._seed(provider="xAI Grok")
+		with patch("jarvis.oauth.api._exchange_code", return_value={
+			"access_token": "AT", "refresh_token": "RT", "expires_in": 3600,
+			"id_token": "", "email": "x@y.com",
+		}) as ex, patch("jarvis.oauth.api.admin_client.post_push_oauth_blob"), \
+		     patch("jarvis.oauth.api.onboarding.save_llm_creds",
+		           return_value={"last_sync_status": "ok"}):
+			out = oauth_api.complete_paste_signin(
+				nonce=nonce,
+				redirected_url="QUJDMTIzZGVmNDU2Zw==",
+			)
+		self.assertTrue(out["ok"], msg=str(out))
+		self.assertEqual(ex.call_args.kwargs["code"], "QUJDMTIzZGVmNDU2Zw==")
+
+	def test_xai_error_bounce_is_not_redeemed_as_a_code(self):
+		# An ?error= callback must not be mistaken for a bare code and shipped to
+		# the token endpoint.
+		nonce = self._seed(provider="xAI Grok")
+		out = oauth_api.complete_paste_signin(
+			nonce=nonce,
+			redirected_url="http://127.0.0.1:56121/callback?error=access_denied",
 		)
 		self.assertEqual(out["error"]["code"], "missing_code")
 


### PR DESCRIPTION
## Symptom

Live report: the xAI chat-subscription auth flow completes, xAI shows **only a code**, but Jarvis insists on a callback URL and rejects the paste with `missing_code`.

## Root cause

xAI's approval screen hands back a **bare authorization code**. It does not redirect to a callback URL, so there is no address bar holding `?code=&state=`. The `redirect_uri` (`127.0.0.1:56121/callback`) exists only because xAI validates it as an exact string; nothing listens there.

`_parse_redirected_url` only ever pulled `code` out of a query string, so `parse_qs("<the code>")` found no `code` key and every xAI sign-in dead-ended. The step-2 copy compounded it by telling the customer to copy "the full URL from the address bar", which for xAI never contains one.

Corroboration from the reference implementation: cli-proxy-api v7.2.35's xai fallback prompt reads `Paste the xAI callback Token`, where its claude channel reads `Paste the Claude callback URL`.

## Fix

New per-provider `code_only_paste` flag (xAI only). When set, a bare code is accepted as the code itself, and the UI copy switches to "Paste the code".

## On skipping `state`

A bare code carries no `state`, so the compare is skipped **for a bare code from a `code_only_paste` provider only**. This is sound here and nowhere else:

- The token exchange always sends this nonce's PKCE `code_verifier` (S256, verified against cli-proxy-api v7.2.35's own `xai` implementation), so a code minted for anyone else's authorize request **cannot be redeemed against this nonce**. PKCE already supplies the request binding that `state` would.
- The nonce stays bound to `originator_user`.
- A pasted **URL** is still state-checked, even for xAI: if a `code=` param arrived, a `state=` one should have too.
- Anything containing `=` parses as a query, so a stray `state=...` can never be mistaken for a code.
- OpenAI/Google are unchanged; a bare code there is still `missing_code`.

## Tests

- `test_xai_accepts_bare_code` (asserts the PKCE verifier still rides along)
- `test_bare_code_rejected_for_url_provider`
- `test_xai_pasted_url_is_still_state_checked`
- `test_xai_bare_state_fragment_is_not_a_code`

Parser logic additionally exercised standalone across 14 cases (URL / `?query` / bare query / bare code / gated-off / whitespace / length bounds / trimming), all passing. SPA `npm run build` green.

## Not fixed here

This unblocks **capture only**. A captured xAI/Kimi account still cannot sync until the companion admin-v2 PR lands (`Aerele-RnD/jarvis-admin-v2` `fix/xai-provider-port`): admin v2 pins a stale llm-proxy whose `PoolSpec` rejects `xai`/`kimi`.
