### PR TITLE
feat(ai-models): pre-save API-key Test button + real failure reasons on the health chip

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -174,6 +174,11 @@ export const saveLlmPool = (models, preset = null, routingMode = "failover") =>
 		preset: preset || "",
 		routing_mode: routingMode,
 	})
+// Pre-save "Test" probe for ONE api-key model row (never persists, never
+// touches the fleet/container - see jarvis/llm_key_probe.py). args:
+// {provider, model, api_key, base_url}. Returns
+// {ok, checks:[{check,ok,detail}], provider, local_endpoint, caveat}.
+export const testLlmApiKey = (args) => call("jarvis.llm_key_probe.test_llm_api_key", args)
 
 // --- Onboarding wizard (managed signup + self-hosted connect) ---
 // Arg names mirror the real backend signatures (jarvis/onboarding.py,

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -872,18 +872,28 @@ function sourceChip(row) {
 // per-row, since only one panel is ever open at a time - testResult is cleared
 // whenever the panel's row identity changes OR its own provider/model/apiKey/
 // baseUrl fields are edited (a stale green check must not survive an edit).
-const panel = ref({ open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null })
+// testGen additionally guards testApiKeyRow's in-flight request against a stale
+// response landing after an edit (see that function's doc comment).
+const panel = ref({ open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null, testGen: 0 })
 const panelRow = computed(() => rows.value.find((r) => r._uid === panel.value.uid) || null)
 // A removed panel row leaves panelRow null; close rather than render a headless panel.
 watch(panelRow, (r) => { if (panel.value.open && !r) panel.value = closedPanel() })
 // Invalidate a stale Test verdict the instant any field it depends on changes -
 // otherwise editing the key after a failed test would leave the old red result
-// on screen, implying it still applies to what's now typed in.
+// on screen, implying it still applies to what's now typed in. Array-of-getters
+// form (not a joined string key: two different field combos could join to the
+// same string, e.g. provider="a",model="b c" vs provider="a b",model="c") -
+// same idiom AgentsList.vue already uses for a multi-source watch. Bumping
+// testGen here (not just nulling testResult) also ABANDONS an in-flight Test:
+// its response, when it lands, will see the generation mismatch and skip
+// writing testResult/testing (testApiKeyRow's `stale()` guard) - so `testing`
+// must be reset to false HERE too, or the button would stay stuck on
+// "Testing…" until that now-irrelevant response arrives (if it ever does).
 watch(
-  () => panelRow.value && [panelRow.value.provider, panelRow.value.model, panelRow.value.apiKey, panelRow.value.baseUrl].join(" "),
-  () => { panel.value.testResult = null },
+  [() => panelRow.value?.provider, () => panelRow.value?.model, () => panelRow.value?.apiKey, () => panelRow.value?.baseUrl],
+  () => { panel.value.testResult = null; panel.value.testGen++; panel.value.testing = false },
 )
-function closedPanel() { return { open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null } }
+function closedPanel() { return { open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null, testGen: 0 } }
 function isRowEmpty(r) {
   if (!r) return true
   if (r.credentialType === "subscription") return !((r.accounts || []).length)
@@ -902,12 +912,12 @@ function openAdd() {
   // last row's type; that would be unpredictable.)
   setCredType(r, "subscription")
   rows.value = [...rows.value, r]
-  panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true, testing: false, testResult: null }
+  panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true, testing: false, testResult: null, testGen: 0 }
 }
 function openEdit(i) {
   const r = rows.value[i]
   if (!r) return
-  panel.value = { open: true, mode: "edit", uid: r._uid, source: r.credentialType === "subscription" ? "subscription" : "api_key", addBackups: true, testing: false, testResult: null }
+  panel.value = { open: true, mode: "edit", uid: r._uid, source: r.credentialType === "subscription" ? "subscription" : "api_key", addBackups: true, testing: false, testResult: null, testGen: 0 }
 }
 
 // ---- pre-save "Test" (API-key rows only) ---------------------------------
@@ -927,6 +937,7 @@ function isLocalProviderRow(row) {
 // encrypted secret), so it has nothing to send yet.
 function testBlockedReason(row) {
   if (!row) return "Nothing to test"
+  if (!(row.provider || "").trim()) return "Choose a provider to test"
   if (!(row.model || "").trim()) return "Enter a model id to test"
   if (!(row.apiKey || "").trim()) return row.hasKey ? "Re-enter the key to test it" : "Enter an API key to test"
   return ""
@@ -939,34 +950,62 @@ function testButtonHint(row) {
   }
   return "Sends a minimal live request to this provider using what's typed above. Nothing is saved."
 }
+// Effective base_url to send: the row's own value, falling back to the provider's
+// known default. A row a customer saved on a STANDARD provider (OpenAI/Anthropic/...)
+// legitimately stores no base_url at all (build_pool_payload only emits one when
+// present; validatePool doesn't require one outside NEEDS_BASE_URL) - onProviderChange
+// only fills it in when the provider is freshly PICKED, not when Edit re-opens an
+// already-saved row. Without this fallback, Test on any such existing row always
+// failed with "Enter a base URL before testing." even though Save would succeed.
+function effectiveTestBaseUrl(row) {
+  const own = (row && row.baseUrl || "").trim()
+  if (own) return own
+  return (PROVIDER_DEFAULTS[row && row.provider] || {}).baseUrl || ""
+}
 // Live, side-effect-free probe (jarvis.llm_key_probe.test_llm_api_key) of whatever is
 // currently typed into the panel - never persists, never touches the fleet/container, and
 // is NOT a substitute for (must never call) the mutating /llm-pool apply. Motivated by a
 // real GLM/Z.ai case: a valid key on a zero-balance account saved cleanly and only failed
 // AFTER save with a bare "Not working" chip - this surfaces the provider's OWN error
 // (e.g. "Insufficient balance or no resource package. Please recharge.") before Save.
+//
+// Race guard: `panel` is a ref whose `.value` is WHOLESALE REPLACED (not mutated) by
+// openAdd/openEdit/closePanel, and this function awaits a network round-trip in between
+// reading and writing it - so a slow response for row A landing after the customer closed
+// A's panel and opened B's must never overwrite B's testing/testResult (the same class of
+// bug the OAuth-connect flow elsewhere in this file guards against with its nonce check).
+// `myPanel` pins the EXACT panel object this call started on (object identity, not just a
+// uid - a closed-then-reopened panel on the same row is a different object); `testGen` is
+// bumped both here and by the field-edit watch() below, so an in-flight response is also
+// discarded if the customer edits the row while waiting (otherwise the watch's clear could
+// be immediately undone by a stale response landing after it).
 async function testApiKeyRow(row) {
   if (!row || panel.value.testing || testBlockedReason(row)) return
-  panel.value.testing = true
-  panel.value.testResult = null
+  const myPanel = panel.value
+  const myGen = ++myPanel.testGen
+  const stale = () => panel.value !== myPanel || myPanel.testGen !== myGen
+  myPanel.testing = true
+  myPanel.testResult = null
   try {
     const res = await api.testLlmApiKey({
       provider: row.provider || "",
       model: row.model || "",
       api_key: row.apiKey || "",
-      base_url: row.baseUrl || "",
+      base_url: effectiveTestBaseUrl(row),
     })
+    if (stale()) return
     const checks = Array.isArray(res && res.checks) ? res.checks : []
     const last = checks[checks.length - 1]
-    panel.value.testResult = {
+    myPanel.testResult = {
       ok: !!(res && res.ok),
       message: (last && last.detail) || (res && res.ok ? "The provider accepted the request." : "The test failed."),
       caveat: (res && res.caveat) || "",
     }
   } catch (e) {
-    panel.value.testResult = { ok: false, message: _err(e), caveat: "" }
+    if (stale()) return
+    myPanel.testResult = { ok: false, message: _err(e), caveat: "" }
   } finally {
-    panel.value.testing = false
+    if (!stale()) myPanel.testing = false
   }
 }
 

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -156,6 +156,32 @@
               <input v-model="panelRow.baseUrl" :disabled="!editable" placeholder="Base URL (OpenAI-compatible)" class="jv-cfg-inp" />
             </div>
           </div>
+
+          <!-- Pre-save "Test": a live, side-effect-free 1-token request straight from this
+               bench to the provider using whatever is typed above - never saved, never
+               touches the fleet/container (jarvis.llm_key_probe.test_llm_api_key). Motivated
+               by a real GLM/Z.ai case: a valid key on a zero-balance account saved cleanly and
+               only failed AFTER save with a bare "Not working" - this lets the customer catch
+               that (and see the provider's OWN error) before they ever click Save. -->
+          <div style="display:flex;align-items:center;gap:10px;margin-top:11px;flex-wrap:wrap;">
+            <button type="button" class="jv-btn jv-btn--sm jv-btn--ghost"
+                    :disabled="!editable || panel.testing || !!testBlockedReason(panelRow)"
+                    :title="testBlockedReason(panelRow) || testButtonHint(panelRow)"
+                    @click="testApiKeyRow(panelRow)">
+              {{ panel.testing ? 'Testing…' : 'Test' }}
+            </button>
+            <span v-if="testBlockedReason(panelRow)" class="jv-pool-opt" style="font-size:11.5px;">{{ testBlockedReason(panelRow) }}</span>
+            <span v-else-if="isLocalProviderRow(panelRow)" class="jv-pool-opt" style="font-size:11.5px;">Local endpoint - only verifiable from inside your Jarvis container</span>
+          </div>
+          <div v-if="panel.testResult" class="jv-status" :class="panel.testResult.ok ? 'jv-status-ok' : 'jv-status-bad'" style="margin-top:10px;">
+            <span class="jv-status-ic">
+              <svg v-if="panel.testResult.ok" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+              <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+            </span>
+            <span class="jv-status-tx"><b>{{ panel.testResult.ok ? 'Key works.' : 'Test failed.' }}</b> {{ panel.testResult.message }}</span>
+          </div>
+          <div v-if="panel.testResult && panel.testResult.caveat" style="font-size:11px;color:var(--text-3);margin-top:5px;">{{ panel.testResult.caveat }}</div>
+
           <!-- Resilient-by-default (API KEYS ONLY): expands this provider into
                its full single-vendor failover chain on close, sharing the
                same key. Add-mode only. -->
@@ -842,11 +868,22 @@ function sourceChip(row) {
 // remove mutate `rows` while the panel is open, and an index would silently repoint
 // it at a neighbour mid-OAuth. _uid is a client-only handle -- buildSaveModels maps
 // explicit fields, so it never reaches the payload.
-const panel = ref({ open: false, mode: "add", uid: null, source: "subscription", addBackups: true })
+// testing/testResult drive the API-key "Test" button (below): per-PANEL, not
+// per-row, since only one panel is ever open at a time - testResult is cleared
+// whenever the panel's row identity changes OR its own provider/model/apiKey/
+// baseUrl fields are edited (a stale green check must not survive an edit).
+const panel = ref({ open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null })
 const panelRow = computed(() => rows.value.find((r) => r._uid === panel.value.uid) || null)
 // A removed panel row leaves panelRow null; close rather than render a headless panel.
 watch(panelRow, (r) => { if (panel.value.open && !r) panel.value = closedPanel() })
-function closedPanel() { return { open: false, mode: "add", uid: null, source: "subscription", addBackups: true } }
+// Invalidate a stale Test verdict the instant any field it depends on changes -
+// otherwise editing the key after a failed test would leave the old red result
+// on screen, implying it still applies to what's now typed in.
+watch(
+  () => panelRow.value && [panelRow.value.provider, panelRow.value.model, panelRow.value.apiKey, panelRow.value.baseUrl].join(" "),
+  () => { panel.value.testResult = null },
+)
+function closedPanel() { return { open: false, mode: "add", uid: null, source: "subscription", addBackups: true, testing: false, testResult: null } }
 function isRowEmpty(r) {
   if (!r) return true
   if (r.credentialType === "subscription") return !((r.accounts || []).length)
@@ -865,13 +902,74 @@ function openAdd() {
   // last row's type; that would be unpredictable.)
   setCredType(r, "subscription")
   rows.value = [...rows.value, r]
-  panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true }
+  panel.value = { open: true, mode: "add", uid: r._uid, source: "subscription", addBackups: true, testing: false, testResult: null }
 }
 function openEdit(i) {
   const r = rows.value[i]
   if (!r) return
-  panel.value = { open: true, mode: "edit", uid: r._uid, source: r.credentialType === "subscription" ? "subscription" : "api_key", addBackups: true }
+  panel.value = { open: true, mode: "edit", uid: r._uid, source: r.credentialType === "subscription" ? "subscription" : "api_key", addBackups: true, testing: false, testResult: null }
 }
+
+// ---- pre-save "Test" (API-key rows only) ---------------------------------
+// Provider ids whose usual endpoint only makes sense reached from INSIDE the
+// tenant's bifrost container (localhost / a customer LAN), never from this
+// browser's bench - MUST match jarvis.llm_key_probe.LOCAL_PROVIDER_IDS. The
+// button still runs (a customer CAN point "vllm"/"ollama" at a real public
+// URL), this only softens the promise with an upfront disclaimer instead of
+// silently implying a guarantee the bench can't make.
+const LOCAL_PROVIDER_IDS = new Set(["ollama", "vllm"])
+function isLocalProviderRow(row) {
+  return !!(row && LOCAL_PROVIDER_IDS.has(providerId(row.provider)))
+}
+// Why the Test button is disabled right now, or "" when it's enabled. hasKey +
+// a blank apiKey means an already-saved key that hasn't been re-typed - the
+// probe only ever sees what's in the panel (it never reads the stored,
+// encrypted secret), so it has nothing to send yet.
+function testBlockedReason(row) {
+  if (!row) return "Nothing to test"
+  if (!(row.model || "").trim()) return "Enter a model id to test"
+  if (!(row.apiKey || "").trim()) return row.hasKey ? "Re-enter the key to test it" : "Enter an API key to test"
+  return ""
+}
+function testButtonHint(row) {
+  if (isLocalProviderRow(row)) {
+    return "Sends a minimal live request from the bench. Local/private endpoints (ollama, "
+      + "vllm) can only be fully verified from inside your Jarvis container - a pass here "
+      + "doesn't guarantee the container can reach it too."
+  }
+  return "Sends a minimal live request to this provider using what's typed above. Nothing is saved."
+}
+// Live, side-effect-free probe (jarvis.llm_key_probe.test_llm_api_key) of whatever is
+// currently typed into the panel - never persists, never touches the fleet/container, and
+// is NOT a substitute for (must never call) the mutating /llm-pool apply. Motivated by a
+// real GLM/Z.ai case: a valid key on a zero-balance account saved cleanly and only failed
+// AFTER save with a bare "Not working" chip - this surfaces the provider's OWN error
+// (e.g. "Insufficient balance or no resource package. Please recharge.") before Save.
+async function testApiKeyRow(row) {
+  if (!row || panel.value.testing || testBlockedReason(row)) return
+  panel.value.testing = true
+  panel.value.testResult = null
+  try {
+    const res = await api.testLlmApiKey({
+      provider: row.provider || "",
+      model: row.model || "",
+      api_key: row.apiKey || "",
+      base_url: row.baseUrl || "",
+    })
+    const checks = Array.isArray(res && res.checks) ? res.checks : []
+    const last = checks[checks.length - 1]
+    panel.value.testResult = {
+      ok: !!(res && res.ok),
+      message: (last && last.detail) || (res && res.ok ? "The provider accepted the request." : "The test failed."),
+      caveat: (res && res.caveat) || "",
+    }
+  } catch (e) {
+    panel.value.testResult = { ok: false, message: _err(e), caveat: "" }
+  } finally {
+    panel.value.testing = false
+  }
+}
+
 // Resilient-by-default (API KEYS ONLY - no subscription presets exist and
 // multi-model-per-account is unconfirmed for cliproxy, so subscriptions never
 // auto-add backups). Finds the catalog's single-vendor preset for this
@@ -1547,7 +1645,11 @@ defineExpose({ save })
 .jv-pool-dot--ok, .jv-pool-dot--neutral { background: var(--green); }
 .jv-pool-dot--warn { background: var(--amber); }
 .jv-pool-dot--unchecked { background: var(--text-3); }
-.jv-pool-acct-health { flex: none; font-size: 12px; font-weight: 600; white-space: nowrap; }
+/* flex: none + a cap, not 0 1 auto: the label can now carry a provider's own error detail
+   (apiKeyModelHealth's `detail`, e.g. a GLM/Z.ai balance message) instead of always being one
+   of two fixed short strings - pool.js already truncates the text itself, this is just a
+   layout safety net so a row can never overflow. */
+.jv-pool-acct-health { flex: none; max-width: 220px; overflow: hidden; text-overflow: ellipsis; font-size: 12px; font-weight: 600; white-space: nowrap; }
 .jv-pool-acct-health--warn { color: var(--amber); }
 .jv-pool-acct-health--unchecked { color: var(--text-3); }
 .jv-pool-acctacts { margin-left: auto; display: flex; gap: 6px; flex: none; }

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -147,18 +147,28 @@ export function seedRowsFromConfig(cfg) {
 }
 
 // The fleet's last per-model probe verdict for ONE api-key row, matched out of the
-// model_statuses list (contract 1.11: [{ provider, model, status }], api-key models only).
-// The match keys on (provider, model) TOGETHER: a model id is NOT unique -- validate() only
-// forbids duplicate provider/model PAIRS, so the same id can appear under two providers, and
-// keying on the id alone would attach one provider's verdict to the other's row. Rows carry
-// the provider LABEL while model_statuses carry the id, so normalize the row's provider back
-// to an id to compare. Returns "" when the row has no matching verdict (a pre-1.11 fleet, a
-// model not yet probed, or an entry that belongs to a different provider).
-function modelVerdict(row, modelStatuses) {
-  if (!row || !Array.isArray(modelStatuses)) return ""
+// model_statuses list (contract 1.11: [{ provider, model, status[, detail] }], api-key
+// models only). The match keys on (provider, model) TOGETHER: a model id is NOT unique --
+// validate() only forbids duplicate provider/model PAIRS, so the same id can appear under
+// two providers, and keying on the id alone would attach one provider's verdict to the
+// other's row. Rows carry the provider LABEL while model_statuses carry the id, so
+// normalize the row's provider back to an id to compare. Returns null when the row has no
+// matching verdict (a pre-1.11 fleet, a model not yet probed, or an entry that belongs to a
+// different provider).
+function modelVerdictEntry(row, modelStatuses) {
+  if (!row || !Array.isArray(modelStatuses)) return null
   const rid = providerId(row.provider)
-  const entry = modelStatuses.find((e) => e && e.model === row.model && e.provider === rid)
-  return (entry && entry.status) || ""
+  return modelStatuses.find((e) => e && e.model === row.model && e.provider === rid) || null
+}
+
+// Sensible truncation for a provider error string of unknown length dropped into a fixed-
+// width row/tooltip. The inline chip LABEL sits in a `white-space:nowrap` flex row next to
+// several other elements, so it stays short; the tooltip TITLE has more room (still capped -
+// the backend already caps at 400 chars, but a defensive cap here means this helper is safe
+// even if that ever changes).
+function truncate(s, max) {
+  const t = (s || "").trim()
+  return t.length > max ? t.slice(0, max - 1).trimEnd() + "…" : t
 }
 
 // Map an api-key pool row to its health for the failover list. Unlike a subscription
@@ -168,21 +178,32 @@ function modelVerdict(row, modelStatuses) {
 //   failed    -> warn      : rejected (bad key/model id) OR an unreachable base_url
 //   unchecked -> unchecked : could not confirm; re-checked on the next apply
 //   verified / "" / unknown -> ok (quiet green; "" = pre-1.11 fleet or a not-yet-probed row)
+//
+// `detail` (a parallel fleet-agent PR, feat/probe-error-detail) carries the PROVIDER'S OWN
+// error message on a failed row (e.g. "Insufficient balance or no resource package. Please
+// recharge." from a real GLM/Z.ai zero-balance case) instead of the generic "Not working" -
+// the whole point being a customer can tell a bad key from an unpaid account. Consumed
+// DEFENSIVELY: an older fleet-agent that doesn't send it yet falls back to today's text, so
+// this must work unchanged against a fleet that predates the field.
 export function apiKeyModelHealth(row, modelStatuses) {
-  const status = modelVerdict(row, modelStatuses)
+  const entry = modelVerdictEntry(row, modelStatuses)
+  const status = (entry && entry.status) || ""
+  const detail = (entry && typeof entry.detail === "string" && entry.detail.trim()) || ""
   if (status === "failed") {
     return {
       level: "warn",
-      label: "Not working",
-      title: "This model failed a test request — check its API key, model id, and base URL. "
-        + "It's skipped during failover until it passes.",
+      label: detail ? `Not working: ${truncate(detail, 46)}` : "Not working",
+      title: detail
+        ? `This model failed a test request: ${truncate(detail, 220)}`
+        : "This model failed a test request - check its API key, model id, and base URL. "
+          + "It's skipped during failover until it passes.",
     }
   }
   if (status === "unchecked") {
     return {
       level: "unchecked",
       label: "Not verified yet",
-      title: "We couldn't confirm this model — it will be re-checked on the next apply.",
+      title: "We couldn't confirm this model - it will be re-checked on the next apply.",
     }
   }
   return { level: "ok" }

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -229,3 +229,55 @@ test("apiKeyModelHealth: a SINGLE entry under a DIFFERENT provider is not misatt
     { level: "ok" },
   )
 })
+
+// ---- apiKeyModelHealth: consuming the OPTIONAL `detail` field (a parallel fleet-agent PR,
+// feat/probe-error-detail) DEFENSIVELY - must render the real reason when present, and fall
+// back to today's generic text unchanged when it's absent (an older fleet-agent). This is
+// the GLM/Z.ai insufficient-balance case: "Not working" alone couldn't distinguish a bad key
+// from an unpaid account; the provider's own message can. ----
+
+test("apiKeyModelHealth: detail present -> surfaced in both label and title", () => {
+  const ms = [{ provider: "openai_compat", model: "glm-4.6", status: "failed",
+    detail: "Insufficient balance or no resource package. Please recharge." }]
+  const h = apiKeyModelHealth(_apiRow({ model: "glm-4.6" }), ms)
+  assert.equal(h.level, "warn")
+  assert.match(h.label, /Insufficient balance/)
+  assert.match(h.title, /Insufficient balance/)
+  assert.match(h.title, /Please recharge/)
+})
+
+test("apiKeyModelHealth: detail ABSENT falls back to today's generic text (older fleet-agent)", () => {
+  // No `detail` key at all on the entry - the exact shape a pre-feat/probe-error-detail
+  // fleet-agent sends. Must behave identically to before this feature existed.
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "failed" }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.equal(h.level, "warn")
+  assert.equal(h.label, "Not working")
+  assert.match(h.title, /base URL|API key|model id/i)
+})
+
+test("apiKeyModelHealth: blank/whitespace-only detail also falls back to the generic text", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "failed", detail: "   " }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.equal(h.label, "Not working")
+})
+
+test("apiKeyModelHealth: a non-string detail (defensive) is ignored, not rendered", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "failed", detail: 12345 }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.equal(h.label, "Not working")
+})
+
+test("apiKeyModelHealth: detail on a non-failed status is never rendered (verified stays quiet green)", () => {
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "verified",
+    detail: "should never surface" }]
+  assert.deepEqual(apiKeyModelHealth(_apiRow(), ms), { level: "ok" })
+})
+
+test("apiKeyModelHealth: a long detail is truncated in the label but stays fuller in the title", () => {
+  const long = "x".repeat(500)
+  const ms = [{ provider: "openai_compat", model: "claude-sonnet-4-6", status: "failed", detail: long }]
+  const h = apiKeyModelHealth(_apiRow(), ms)
+  assert.ok(h.label.length < 80, `label should be short, got ${h.label.length} chars`)
+  assert.ok(h.title.length < 260, `title should still be capped, got ${h.title.length} chars`)
+})

--- a/jarvis/chat/link_fetch.py
+++ b/jarvis/chat/link_fetch.py
@@ -69,6 +69,7 @@ string. Pure exception-vs-string-return split, no silent partial results.
 from __future__ import annotations
 
 import ipaddress
+import json
 import re
 import socket
 from urllib.parse import urljoin, urlparse
@@ -249,15 +250,27 @@ def _host_header(hostname: str, port: int, scheme: str) -> str:
 	return hostname if port == default else f"{hostname}:{port}"
 
 
-def _open_pinned(parsed, ip: str, timeout: int):
-	"""Open a GET pinned to the already-vetted ``ip`` - the DNS-rebind defense
-	the module docstring describes. The socket connects straight to ``ip`` via
-	a fresh single-use ``urllib3`` pool whose host IS the IP, so no second
-	resolution of ``parsed.hostname`` can ever divert the connection. TLS still
-	verifies against the ORIGINAL hostname (SNI ``server_hostname`` + cert
-	``assert_hostname``) and the ``Host:`` header carries it too, so virtual
-	hosts and certificate checks keep working. Returns ``(response, pool)``;
-	the caller owns closing both."""
+def _open_pinned(
+	parsed,
+	ip: str,
+	timeout: int,
+	*,
+	method: str = "GET",
+	body: bytes | None = None,
+	extra_headers: dict | None = None,
+):
+	"""Open a request pinned to the already-vetted ``ip`` - the DNS-rebind
+	defense the module docstring describes. The socket connects straight to
+	``ip`` via a fresh single-use ``urllib3`` pool whose host IS the IP, so no
+	second resolution of ``parsed.hostname`` can ever divert the connection.
+	TLS still verifies against the ORIGINAL hostname (SNI ``server_hostname``
+	+ cert ``assert_hostname``) and the ``Host:`` header carries it too, so
+	virtual hosts and certificate checks keep working. Returns
+	``(response, pool)``; the caller owns closing both.
+
+	``method``/``body``/``extra_headers`` default to a bare GET (every
+	original caller here, ``fetch_and_extract``) - ``request_pinned`` below
+	is the only caller that overrides them, for a JSON POST probe."""
 	hostname = parsed.hostname
 	scheme = parsed.scheme
 	port = parsed.port or (443 if scheme == "https" else 80)
@@ -265,6 +278,7 @@ def _open_pinned(parsed, ip: str, timeout: int):
 	if parsed.query:
 		target += "?" + parsed.query
 	headers = {"User-Agent": _USER_AGENT, "Host": _host_header(hostname, port, scheme)}
+	headers.update(extra_headers or {})
 	pool_timeout = urllib3.Timeout(connect=timeout, read=timeout)
 	if scheme == "https":
 		pool = urllib3.HTTPSConnectionPool(
@@ -288,8 +302,9 @@ def _open_pinned(parsed, ip: str, timeout: int):
 			retries=False,
 		)
 	resp = pool.urlopen(
-		"GET",
+		method,
 		target,
+		body=body,
 		headers=headers,
 		redirect=False,
 		preload_content=False,
@@ -353,3 +368,67 @@ def fetch_and_extract(
 
 		text = _neutralize(_extract_text(body, content_type))
 		return text[:MAX_EXTRACTED_LEN]
+
+
+# --------------------------------------------------------------------------- #
+# generic pinned request (non-GET, non-text/html callers)
+# --------------------------------------------------------------------------- #
+def request_pinned(
+	url: str,
+	*,
+	method: str = "GET",
+	headers: dict | None = None,
+	json_body: dict | None = None,
+	timeout: int = TIMEOUT_S_DEFAULT,
+	max_bytes: int = MAX_BYTES_DEFAULT,
+) -> tuple[int, dict, bytes]:
+	"""SSRF-guarded HTTP request for a caller that needs something other than
+	``fetch_and_extract``'s GET + ``text/*``-only shape - e.g.
+	``jarvis.llm_key_probe``'s provider API-key test, which POSTs a JSON body
+	to a CUSTOMER-SUPPLIED ``base_url`` (an OpenAI-Compatible / GLM-Z.ai /
+	self-hosted vLLM endpoint) and needs the provider's raw error body back,
+	not extracted page text.
+
+	Reuses this module's guard exactly (see the module docstring): scheme
+	allowlist + every resolved address checked via ``_validate_url``, then the
+	connection is PINNED to that one vetted address so a DNS record that
+	changes between the check and the connect can't divert the socket - the
+	same TOCTOU defense ``fetch_and_extract`` relies on. Unlike
+	``fetch_and_extract`` this does NOT follow redirects (a 3xx from a JSON
+	API is returned to the caller as-is - chasing HTML-style redirect chains
+	is not this entry point's job) and does NOT restrict the response
+	content-type (JSON APIs reply ``application/json``, not ``text/*``).
+
+	Returns ``(status_code, headers, body_bytes)`` - the body is READ AND
+	CAPPED at ``max_bytes`` (via ``_read_capped``, same as the fetch path) but
+	otherwise handed back raw; the caller owns parsing/scrubbing it.
+
+	Raises :class:`LinkFetchError` for a blocked scheme/host (SSRF) or any
+	network failure. The raised message never includes ``headers`` or
+	``json_body`` - callers routinely pass a secret (e.g. an
+	``Authorization`` header), and that secret must never end up in an
+	exception string a caller might log.
+	"""
+	current = (url or "").strip()
+	if not current:
+		raise LinkFetchError("No URL given.")
+
+	parsed, ip = _validate_url(current)
+
+	body: bytes | None = None
+	hdrs = dict(headers or {})
+	if json_body is not None:
+		body = json.dumps(json_body).encode("utf-8")
+		hdrs.setdefault("Content-Type", "application/json")
+
+	try:
+		resp, pool = _open_pinned(parsed, ip, timeout, method=method, body=body, extra_headers=hdrs)
+	except (urllib3.exceptions.HTTPError, OSError) as exc:
+		raise LinkFetchError(f"Request failed: {exc}") from exc
+
+	try:
+		data = _read_capped(resp, max_bytes)
+		return resp.status, dict(resp.headers), data
+	finally:
+		resp.close()
+		pool.close()

--- a/jarvis/chat/link_fetch.py
+++ b/jarvis/chat/link_fetch.py
@@ -277,8 +277,19 @@ def _open_pinned(
 	target = parsed.path or "/"
 	if parsed.query:
 		target += "?" + parsed.query
-	headers = {"User-Agent": _USER_AGENT, "Host": _host_header(hostname, port, scheme)}
-	headers.update(extra_headers or {})
+	# extra_headers first, THEN the computed Host/User-Agent - never the other way
+	# round. Host in particular is part of the DNS-rebind defense's bookkeeping
+	# (it must always name the ORIGINAL hostname the address was vetted for, not
+	# whatever a caller's headers dict happens to carry); request_pinned's caller
+	# passes its own headers through here as extra_headers, and nothing stops a
+	# future caller from including a "Host" key, so this order stays defensive
+	# even though today's only extra_headers callers never set one. (The actual
+	# TCP/TLS destination is pinned independently via host=ip / assert_hostname
+	# below, so this was never an SSRF bypass - just correctness hardening for a
+	# general-purpose entry point.)
+	headers = dict(extra_headers or {})
+	headers["User-Agent"] = _USER_AGENT
+	headers["Host"] = _host_header(hostname, port, scheme)
 	pool_timeout = urllib3.Timeout(connect=timeout, read=timeout)
 	if scheme == "https":
 		pool = urllib3.HTTPSConnectionPool(

--- a/jarvis/llm_key_probe.py
+++ b/jarvis/llm_key_probe.py
@@ -241,7 +241,17 @@ def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -
 		)
 		return _done(True)
 
-	message = _scrub(_extract_provider_message(body), api_key)
+	# `body` came back from whatever the customer-supplied base_url points to - a
+	# hostile or merely malformed response must never turn "the test failed" into
+	# an unhandled 500 (breaking probe_api_key's documented "NEVER raises"
+	# contract). _extract_provider_message already guards the failure modes it
+	# knows about (bad JSON, undecodable bytes); this catches anything else
+	# (e.g. a pathological structure blowing the interpreter's recursion limit)
+	# so a bad response body degrades to a generic message instead of a crash.
+	try:
+		message = _scrub(_extract_provider_message(body), api_key)
+	except Exception:
+		message = ""
 	checks.append(
 		_check(
 			"probe_request",

--- a/jarvis/llm_key_probe.py
+++ b/jarvis/llm_key_probe.py
@@ -1,0 +1,278 @@
+"""Pre-save "Test" probe for one API-key LLM pool model row (Settings -> AI
+models -> Edit -> API key -> Test), BEFORE the customer clicks Save.
+
+Motivated by a live case: a syntactically valid GLM/Z.ai key whose z.ai
+account had zero balance saved cleanly and only failed AFTER save, with a
+bare "Not working" chip and no reason - the customer could not tell a bad key
+from an unpaid account. z.ai's own error is precise::
+
+    {"error":{"code":"1113","message":"Insufficient balance or no resource
+    package. Please recharge."}}
+
+This probe surfaces exactly that message instead of swallowing it.
+
+Mirrors ``jarvis.selfhost.validate_connection`` / ``test_connection``'s
+shape: synchronous, no persistence, gated, does live HTTP, and NEVER raises
+for a failed check - it always returns a structured
+``{"ok": bool, "checks": [{"check", "ok", "detail"}, ...]}``.
+
+NOT the same thing as ``PUT /v1/containers/{name}/llm-pool``
+(``jarvis.admin_client.post_update_llm_pool``): that is a MUTATING apply on
+the fleet-agent that rotates secrets, rewrites the tenant's openclaw.json and
+can restart the container (10-30s chat outage). This probe never writes
+Jarvis Settings, never calls admin_client, and never touches the fleet or a
+container - it is a single side-effect-free HTTP round-trip straight from
+THIS bench to the provider's own API, using whatever
+provider/base_url/model/api_key the customer has typed into the panel so far
+(nothing here is persisted, and nothing here may call the mutating pool
+apply).
+
+CAVEAT - read before trusting a green check: live tenant chat is actually
+served from INSIDE the tenant's bifrost container, not from this bench. For
+a public provider (OpenAI/Groq/Z.ai/...) the two networks agree, so a pass
+here is a real signal. For a provider whose endpoint is only reachable from
+inside the container (ollama/vllm on localhost, or a customer's own private
+network), this probe cannot confirm reachability from here - see
+``LOCAL_PROVIDER_IDS`` and the ``local_endpoint`` flag the caller should
+render as a disclaimer, never a guarantee. ``test_llm_api_key`` always
+attaches a ``caveat`` string for this reason, whether or not the provider is
+tagged local.
+
+SECURITY: ``base_url`` is customer-supplied, so this is an SSRF vector
+exactly like ``jarvis.chat.link_fetch``'s Personalise link fetch (a prior
+security audit flagged SSRF as an open risk in this app) - this module reuses
+that guard via ``link_fetch.request_pinned`` rather than re-implementing it.
+The api_key is NEVER echoed back: not in a returned check detail, not in a
+raised exception, not in ``frappe.log_error``. Provider error bodies are
+scrubbed for a literal key match and capped in length before they reach the
+response.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+from jarvis.chat import link_fetch
+from jarvis.jarvis.pool_serialize import normalize_provider
+from jarvis.permissions import require_jarvis_admin
+
+_TIMEOUT_S = 15
+_MAX_BODY_BYTES = 65536
+_MAX_DETAIL_LEN = 400
+
+# Canonical provider ids (jarvis.jarvis.pool_serialize.normalize_provider's
+# vocabulary) whose usual endpoint only makes sense reached from INSIDE the
+# tenant's bifrost container (localhost / a customer LAN), never from this
+# bench - see the module docstring's CAVEAT. The Test button still runs (a
+# customer CAN point "vllm"/"ollama" at a real public URL), but the result
+# carries local_endpoint=True so the caller renders a disclaimer, and a guard
+# rejection gets a locality-aware message instead of a bare "blocked".
+LOCAL_PROVIDER_IDS = {"ollama", "vllm"}
+
+# Wire-protocol grouping for building the probe request. Everything not
+# explicitly Anthropic/Gemini speaks the OpenAI chat/completions shape - this
+# is also true of Z.ai/GLM, which normalize_provider maps to "openai_compat"
+# (jarvis.jarvis.pool_serialize._PROVIDER_ALIASES), and is exactly today's
+# motivating case.
+_ANTHROPIC_IDS = {"anthropic"}
+_GEMINI_IDS = {"gemini"}
+
+
+def _check(name: str, ok: bool, detail: str) -> dict:
+	return {"check": name, "ok": bool(ok), "detail": detail}
+
+
+def _provider_kind(provider_id: str) -> str:
+	if provider_id in _ANTHROPIC_IDS:
+		return "anthropic"
+	if provider_id in _GEMINI_IDS:
+		return "gemini"
+	return "openai"
+
+
+def _scrub(text: str, api_key: str) -> str:
+	"""Cap length and strip a literal api_key match, so a provider that
+	echoes the credential back in an error body (some do, on a malformed
+	auth header) never leaks it into the UI or a log."""
+	t = (text or "").strip()
+	if api_key:
+		t = t.replace(api_key, "***")
+	if len(t) > _MAX_DETAIL_LEN:
+		t = t[:_MAX_DETAIL_LEN] + "...(truncated)"
+	return t
+
+
+def _extract_provider_message(body: bytes) -> str:
+	"""Best-effort pull of a human-readable message out of a provider's JSON
+	error body. OpenAI-, Anthropic- and Gemini-shaped errors all nest under
+	"error" (an object carrying "message", occasionally a bare string) -
+	this is exactly the z.ai shape that motivated this module::
+
+	    {"error":{"code":"1113","message":"Insufficient balance or no
+	    resource package. Please recharge."}}
+
+	Falls back to the raw decoded body when the shape doesn't match, and to
+	a fixed string when the body isn't decodable text at all. Never raises.
+	"""
+	try:
+		text = body.decode("utf-8", errors="replace")
+	except Exception:
+		return "(response body could not be decoded)"
+	try:
+		data = json.loads(text)
+	except (ValueError, TypeError):
+		return text
+	if isinstance(data, dict):
+		err = data.get("error")
+		if isinstance(err, dict):
+			msg = err.get("message") or err.get("code") or ""
+			if msg:
+				return str(msg)
+		elif isinstance(err, str) and err:
+			return err
+		if data.get("message"):
+			return str(data["message"])
+	return text
+
+
+def _build_request(kind: str, base_url: str, model: str, api_key: str) -> dict:
+	"""Build ``{"url", "headers", "json_body"}`` for a minimal 1-token
+	completion against ``kind``'s wire protocol. The key always rides in a
+	HEADER (never a URL query param, including Gemini's ``x-goog-api-key``),
+	so it can never end up logged as part of a URL."""
+	base = (base_url or "").rstrip("/")
+	if kind == "anthropic":
+		return {
+			"url": f"{base}/v1/messages",
+			"headers": {"x-api-key": api_key, "anthropic-version": "2023-06-01"},
+			"json_body": {
+				"model": model,
+				"max_tokens": 1,
+				"messages": [{"role": "user", "content": "hi"}],
+			},
+		}
+	if kind == "gemini":
+		return {
+			"url": f"{base}/v1beta/models/{model}:generateContent",
+			"headers": {"x-goog-api-key": api_key},
+			"json_body": {
+				"contents": [{"parts": [{"text": "hi"}]}],
+				"generationConfig": {"maxOutputTokens": 1},
+			},
+		}
+	# OpenAI-compatible (openai, mistral, groq, together, deepseek, moonshot,
+	# xai, openrouter, openai_compat, ollama, vllm, and Z.ai/GLM via
+	# openai_compat) - all speak POST {base}/chat/completions, Bearer auth.
+	return {
+		"url": f"{base}/chat/completions",
+		"headers": {"Authorization": f"Bearer {api_key}"},
+		"json_body": {
+			"model": model,
+			"messages": [{"role": "user", "content": "hi"}],
+			"max_tokens": 1,
+			"stream": False,
+		},
+	}
+
+
+def probe_api_key(provider: str, model: str, api_key: str, base_url: str = "") -> dict:
+	"""Live, side-effect-free check of one provider/base_url/model/api_key
+	combination. NEVER raises - every failure mode (missing input, an
+	SSRF-blocked endpoint, a network error, a provider rejection) comes back
+	as a failed check with a human-readable, key-scrubbed detail.
+
+	Returns ``{"ok": bool, "checks": [...], "provider": <canonical id>,
+	"local_endpoint": bool}``. See the module docstring for the CAVEAT
+	(probed from the bench, not the tenant's container) and the SECURITY
+	notes (SSRF guard via link_fetch, key scrubbing)."""
+	checks: list[dict] = []
+	provider_id = normalize_provider(provider)
+	is_local = provider_id in LOCAL_PROVIDER_IDS
+
+	model = (model or "").strip()
+	api_key = (api_key or "").strip()
+	base = (base_url or "").strip()
+
+	def _done(ok: bool) -> dict:
+		return {"ok": ok, "checks": checks, "provider": provider_id, "local_endpoint": is_local}
+
+	if not model:
+		checks.append(_check("input", False, "Enter a model id before testing."))
+		return _done(False)
+	if not api_key:
+		checks.append(_check("input", False, "Enter an API key before testing."))
+		return _done(False)
+	if not base:
+		checks.append(_check("input", False, "Enter a base URL before testing."))
+		return _done(False)
+
+	kind = _provider_kind(provider_id)
+	req = _build_request(kind, base, model, api_key)
+
+	try:
+		status, _headers, body = link_fetch.request_pinned(
+			req["url"],
+			method="POST",
+			headers=req["headers"],
+			json_body=req["json_body"],
+			timeout=_TIMEOUT_S,
+			max_bytes=_MAX_BODY_BYTES,
+		)
+	except link_fetch.LinkFetchError as exc:
+		detail = _scrub(str(exc), api_key)
+		if is_local:
+			detail = (
+				f"Can't reach this endpoint from the bench ({detail}). Local/private "
+				"endpoints are only reachable from inside your Jarvis container, so "
+				"this can't be verified from here."
+			)
+		checks.append(_check("probe_request", False, detail))
+		return _done(False)
+
+	if 200 <= status < 300:
+		checks.append(
+			_check(
+				"probe_request",
+				True,
+				f"{provider_id or 'The provider'} accepted a 1-token test request (HTTP {status}).",
+			)
+		)
+		return _done(True)
+
+	message = _scrub(_extract_provider_message(body), api_key)
+	checks.append(
+		_check(
+			"probe_request",
+			False,
+			f"HTTP {status}: {message}" if message else f"HTTP {status} with no error detail.",
+		)
+	)
+	return _done(False)
+
+
+@frappe.whitelist()
+def test_llm_api_key(provider: str, model: str, api_key: str = "", base_url: str = "") -> dict:
+	"""UI 'Test' button on an API-key LLM pool model row, run BEFORE save.
+
+	Jarvis Admin / System Manager - the same gate ``jarvis.onboarding.
+	save_llm_pool`` already enforces for this exact panel (the Edit panel's
+	``editable`` prop is ``isSM || is_jarvis_admin``), so anyone who can edit
+	a row can also test it.
+
+	Operates ONLY on the values passed in (whatever is currently typed into
+	the panel) - it never reads or writes the stored, encrypted key on an
+	existing row, and never persists anything or touches the fleet/container.
+	See the module docstring for why this must never call the mutating
+	``/llm-pool`` apply."""
+	require_jarvis_admin()
+	result = probe_api_key(provider, model, api_key, base_url)
+	result["caveat"] = (
+		"Tested from the bench, not from your Jarvis container. Local/private "
+		"endpoints (ollama, vllm) can only be confirmed from inside the container."
+		if result.get("local_endpoint")
+		else "Tested from the bench's network. Live chat runs from inside your Jarvis "
+		"container - for a public provider these agree."
+	)
+	return result

--- a/jarvis/tests/test_link_fetch.py
+++ b/jarvis/tests/test_link_fetch.py
@@ -457,3 +457,82 @@ class TestExtractionAndNeutralization(LinkFetchGuardTestCase):
 			):
 			text = link_fetch.fetch_and_extract("http://public.example.com/plain.txt")
 		self.assertEqual(text, "line one\nline two")
+
+
+# --------------------------------------------------------------------------- #
+# request_pinned - the generic (non-GET, non-text/html) pinned request added
+# for jarvis.llm_key_probe's provider API-key test. Reuses the SAME guard +
+# _open_pinned pinning seam as fetch_and_extract above (only the response
+# shaping differs: raw status/headers/body instead of extracted text), so
+# these tests focus on what's NEW - method/body/headers reaching the pinned
+# open, JSON content-type not being enforced, and redirects/network errors
+# surfacing as LinkFetchError rather than being chased or leaking a raw
+# exception with headers/body in it.
+# --------------------------------------------------------------------------- #
+class TestRequestPinned(LinkFetchGuardTestCase):
+	def test_blocked_host_raises_before_any_open(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PRIVATE_IP)), \
+			mock.patch("jarvis.chat.link_fetch._open_pinned") as m_open:
+			with self.assertRaises(link_fetch.LinkFetchError):
+				link_fetch.request_pinned("http://internal.example.com/v1/chat/completions",
+				                            method="POST", json_body={"a": 1})
+			m_open.assert_not_called()
+
+	def test_post_json_body_and_headers_reach_the_pinned_open(self):
+		resp = _FakeResponse(status=200, headers={}, chunks=_chunk_list(b'{"ok":true}'))
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PUBLIC_IP)), \
+			mock.patch(
+				"jarvis.chat.link_fetch._open_pinned", return_value=_open_result(resp)
+			) as m_open:
+			status, _headers, body = link_fetch.request_pinned(
+				"https://public.example.com/chat/completions",
+				method="POST",
+				headers={"Authorization": "Bearer sk-test"},
+				json_body={"model": "x", "messages": []},
+			)
+		self.assertEqual(status, 200)
+		self.assertEqual(body, b'{"ok":true}')
+		kwargs = m_open.call_args.kwargs
+		self.assertEqual(kwargs["method"], "POST")
+		self.assertEqual(kwargs["extra_headers"]["Authorization"], "Bearer sk-test")
+		self.assertIn(b'"model"', kwargs["body"])
+
+	def test_non_json_content_type_response_is_not_rejected(self):
+		# fetch_and_extract refuses a non-text/* content-type; request_pinned must NOT -
+		# a provider API replies application/json, not text/*.
+		resp = _FakeResponse(status=400, headers={"Content-Type": "application/json"},
+		                      chunks=_chunk_list(b'{"error":{"message":"bad key"}}'))
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PUBLIC_IP)), \
+			mock.patch(
+				"jarvis.chat.link_fetch._open_pinned", return_value=_open_result(resp)
+			):
+			status, _headers, body = link_fetch.request_pinned(
+				"https://public.example.com/chat/completions", method="POST", json_body={})
+		self.assertEqual(status, 400)
+		self.assertIn(b"bad key", body)
+
+	def test_network_error_becomes_link_fetch_error_without_leaking_headers(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PUBLIC_IP)), \
+			mock.patch(
+				"jarvis.chat.link_fetch._open_pinned",
+				side_effect=OSError("connection refused"),
+			):
+			with self.assertRaises(link_fetch.LinkFetchError) as cm:
+				link_fetch.request_pinned(
+					"https://public.example.com/chat/completions",
+					method="POST",
+					headers={"Authorization": "Bearer sk-should-not-leak"},
+					json_body={},
+				)
+		self.assertNotIn("sk-should-not-leak", str(cm.exception))
+
+	def test_oversize_response_is_rejected_not_silently_truncated(self):
+		big = b'{"pad":"' + (b"x" * (link_fetch.MAX_BYTES_DEFAULT + 10)) + b'"}'
+		resp = _FakeResponse(status=200, headers={}, chunks=_chunk_list(big))
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PUBLIC_IP)), \
+			mock.patch(
+				"jarvis.chat.link_fetch._open_pinned", return_value=_open_result(resp)
+			):
+			with self.assertRaises(link_fetch.LinkFetchError):
+				link_fetch.request_pinned(
+					"https://public.example.com/chat/completions", method="POST", json_body={})

--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -1,0 +1,264 @@
+"""Tests for jarvis.llm_key_probe - the pre-save "Test" probe for one API-key
+LLM pool model row (Settings -> AI models -> Edit -> API key -> Test).
+
+Covers: the GLM/Z.ai insufficient-balance case that motivated this module,
+the SSRF guard rejecting a private/loopback base_url (exercised end-to-end
+through the real jarvis.chat.link_fetch guard, mocking only
+socket.getaddrinfo - never the guard itself), api_key scrubbing out of a
+provider error body, the local-provider (ollama/vllm) disclaimer, and the
+System-Manager/Jarvis-Admin gate on the whitelisted endpoint.
+
+Run: bench --site <site> run-tests --module jarvis.tests.test_llm_key_probe
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import llm_key_probe
+from jarvis.chat import link_fetch
+
+
+def _addrinfo(ip: str):
+	"""One socket.getaddrinfo-shaped tuple carrying `ip` at index [4][0]
+	(same shape jarvis.tests.test_link_fetch uses)."""
+	return [(2, 1, 6, "", (ip, 443))]
+
+
+PUBLIC_IP = "93.184.216.34"  # example.com - genuinely public/routable.
+PRIVATE_IP = "10.0.0.5"
+
+
+class TestExtractProviderMessage(FrappeTestCase):
+	"""_extract_provider_message: pulling a human-readable error out of a
+	provider's JSON body - the whole point of this feature."""
+
+	def test_glm_insufficient_balance_shape(self):
+		# The exact z.ai body that motivated this module.
+		body = b'{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}'
+		msg = llm_key_probe._extract_provider_message(body)
+		self.assertEqual(msg, "Insufficient balance or no resource package. Please recharge.")
+
+	def test_openai_shaped_error(self):
+		body = b'{"error":{"message":"Incorrect API key provided.","type":"invalid_request_error"}}'
+		self.assertEqual(llm_key_probe._extract_provider_message(body), "Incorrect API key provided.")
+
+	def test_bare_string_error_field(self):
+		body = b'{"error":"bad request"}'
+		self.assertEqual(llm_key_probe._extract_provider_message(body), "bad request")
+
+	def test_error_object_with_only_a_code_falls_back_to_code(self):
+		body = b'{"error":{"code":"429"}}'
+		self.assertEqual(llm_key_probe._extract_provider_message(body), "429")
+
+	def test_non_json_body_returns_raw_text(self):
+		body = b"<html>upstream timeout</html>"
+		self.assertIn("upstream timeout", llm_key_probe._extract_provider_message(body))
+
+	def test_undecodable_body_never_raises(self):
+		msg = llm_key_probe._extract_provider_message(b"\xff\xfe\x00\x01")
+		self.assertIsInstance(msg, str)
+
+
+class TestScrub(FrappeTestCase):
+	def test_strips_literal_api_key(self):
+		out = llm_key_probe._scrub("your key sk-secret-123 is invalid", "sk-secret-123")
+		self.assertNotIn("sk-secret-123", out)
+		self.assertIn("***", out)
+
+	def test_caps_length(self):
+		out = llm_key_probe._scrub("x" * 5000, "")
+		self.assertLessEqual(len(out), llm_key_probe._MAX_DETAIL_LEN + len("...(truncated)"))
+
+	def test_blank_key_is_a_noop_replace(self):
+		# An empty api_key must never turn every message into "***" via a
+		# blanket str.replace("", ...).
+		self.assertEqual(llm_key_probe._scrub("hello world", ""), "hello world")
+
+
+class TestProviderKindAndRequestShape(FrappeTestCase):
+	def test_anthropic_uses_x_api_key_header_and_messages_endpoint(self):
+		req = llm_key_probe._build_request("anthropic", "https://api.anthropic.com", "claude-x", "sk-a")
+		self.assertEqual(req["url"], "https://api.anthropic.com/v1/messages")
+		self.assertEqual(req["headers"]["x-api-key"], "sk-a")
+		self.assertNotIn("Authorization", req["headers"])
+
+	def test_gemini_key_rides_in_a_header_not_the_url(self):
+		req = llm_key_probe._build_request(
+			"gemini", "https://generativelanguage.googleapis.com", "gemini-2.5-pro", "sk-g"
+		)
+		self.assertNotIn("sk-g", req["url"])
+		self.assertEqual(req["headers"]["x-goog-api-key"], "sk-g")
+
+	def test_openai_kind_is_bearer_chat_completions(self):
+		req = llm_key_probe._build_request("openai", "https://api.z.ai/api/paas/v4", "glm-4.6", "sk-z")
+		self.assertEqual(req["url"], "https://api.z.ai/api/paas/v4/chat/completions")
+		self.assertEqual(req["headers"]["Authorization"], "Bearer sk-z")
+
+	def test_glm_zai_label_normalizes_into_the_openai_kind(self):
+		# GLM / Z.ai has no native Bifrost provider - pool_serialize.normalize_provider
+		# maps its label to "openai_compat", which must still speak the OpenAI wire
+		# protocol (that's what z.ai's own API actually is).
+		self.assertEqual(
+			llm_key_probe._provider_kind(llm_key_probe.normalize_provider("GLM / Z.ai")), "openai"
+		)
+
+	def test_ollama_and_vllm_are_flagged_local(self):
+		self.assertIn(llm_key_probe.normalize_provider("Ollama (local)"), llm_key_probe.LOCAL_PROVIDER_IDS)
+		self.assertIn(llm_key_probe.normalize_provider("vLLM (local)"), llm_key_probe.LOCAL_PROVIDER_IDS)
+
+	def test_public_provider_not_flagged_local(self):
+		self.assertNotIn(llm_key_probe.normalize_provider("OpenAI"), llm_key_probe.LOCAL_PROVIDER_IDS)
+
+
+class TestProbeApiKey(FrappeTestCase):
+	"""probe_api_key with link_fetch.request_pinned mocked - no real network."""
+
+	def test_missing_model_fails_fast_with_no_network_call(self):
+		with mock.patch.object(link_fetch, "request_pinned") as rp:
+			result = llm_key_probe.probe_api_key("OpenAI", "", "sk-x", "https://api.openai.com/v1")
+		rp.assert_not_called()
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["checks"][0]["check"], "input")
+
+	def test_missing_api_key_fails_fast(self):
+		with mock.patch.object(link_fetch, "request_pinned") as rp:
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "", "https://api.openai.com/v1")
+		rp.assert_not_called()
+		self.assertFalse(result["ok"])
+
+	def test_missing_base_url_fails_fast(self):
+		with mock.patch.object(link_fetch, "request_pinned") as rp:
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "sk-x", "")
+		rp.assert_not_called()
+		self.assertFalse(result["ok"])
+
+	def test_200_response_is_ok(self):
+		with mock.patch.object(
+			link_fetch,
+			"request_pinned",
+			return_value=(200, {}, b'{"choices":[{"message":{"content":"hi"}}]}'),
+		):
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "sk-x", "https://api.openai.com/v1")
+		self.assertTrue(result["ok"])
+		self.assertEqual(result["provider"], "openai")
+		self.assertFalse(result["local_endpoint"])
+
+	def test_glm_insufficient_balance_surfaces_the_real_reason(self):
+		"""THE motivating case: a valid key against a zero-balance z.ai account
+		must surface z.ai's own message, not a bare "failed"."""
+		body = b'{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}'
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(400, {}, body)):
+			result = llm_key_probe.probe_api_key(
+				"GLM / Z.ai", "glm-4.6", "sk-real-but-unpaid", "https://api.z.ai/api/paas/v4"
+			)
+		self.assertFalse(result["ok"])
+		detail = result["checks"][-1]["detail"]
+		self.assertIn("Insufficient balance", detail)
+		self.assertIn("recharge", detail)
+		self.assertNotIn("sk-real-but-unpaid", detail)
+
+	def test_provider_error_body_never_leaks_the_api_key(self):
+		# A provider that (badly) echoes the credential back in its error body.
+		body = b'{"error":{"message":"key sk-super-secret-999 is not authorized"}}'
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(401, {}, body)):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI", "gpt-4o", "sk-super-secret-999", "https://api.openai.com/v1"
+			)
+		detail = result["checks"][-1]["detail"]
+		self.assertNotIn("sk-super-secret-999", detail)
+		self.assertIn("***", detail)
+
+	def test_ssrf_blocked_endpoint_gets_a_locality_aware_message_for_local_providers(self):
+		with mock.patch.object(
+			link_fetch,
+			"request_pinned",
+			side_effect=link_fetch.LinkFetchError("Host resolves to a disallowed address"),
+		):
+			result = llm_key_probe.probe_api_key(
+				"Ollama (local)", "llama3", "unused", "http://127.0.0.1:11434/v1"
+			)
+		self.assertFalse(result["ok"])
+		self.assertTrue(result["local_endpoint"])
+		detail = result["checks"][-1]["detail"]
+		self.assertIn("container", detail)
+
+	def test_ssrf_blocked_endpoint_for_a_non_local_provider_still_fails_cleanly(self):
+		with mock.patch.object(
+			link_fetch,
+			"request_pinned",
+			side_effect=link_fetch.LinkFetchError("Host resolves to a disallowed address"),
+		):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "x", "sk-x", "http://169.254.169.254/v1"
+			)
+		self.assertFalse(result["ok"])
+		self.assertFalse(result["local_endpoint"])
+		# Non-local providers don't get the ollama/vllm-specific container wording.
+		self.assertNotIn("container", result["checks"][-1]["detail"])
+
+
+class TestProbeApiKeySsrfEndToEnd(FrappeTestCase):
+	"""Exercises the REAL jarvis.chat.link_fetch guard (only socket.getaddrinfo
+	is mocked - never request_pinned/the guard itself) so this asserts the
+	actual SSRF rejection wiring, not just that probe_api_key handles a
+	pre-canned LinkFetchError."""
+
+	def test_private_ip_base_url_is_rejected_before_any_socket_open(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo(PRIVATE_IP)):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "some-model", "sk-x", "http://internal.example.com/v1"
+			)
+		self.assertFalse(result["ok"])
+		detail = result["checks"][-1]["detail"]
+		self.assertTrue(detail)
+
+	def test_metadata_ip_base_url_is_rejected(self):
+		with mock.patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "some-model", "sk-x", "http://metadata.example.com/v1"
+			)
+		self.assertFalse(result["ok"])
+
+	def test_unresolvable_host_is_rejected_not_raised(self):
+		with mock.patch("socket.getaddrinfo", side_effect=OSError("nxdomain")):
+			result = llm_key_probe.probe_api_key(
+				"OpenAI-Compatible", "some-model", "sk-x", "http://does-not-resolve.invalid/v1"
+			)
+		self.assertFalse(result["ok"])
+
+	def test_non_http_scheme_is_rejected(self):
+		result = llm_key_probe.probe_api_key("OpenAI-Compatible", "some-model", "sk-x", "file:///etc/passwd")
+		self.assertFalse(result["ok"])
+
+
+class TestTestLlmApiKeyGating(FrappeTestCase):
+	"""The whitelisted endpoint: gated the same as save_llm_pool (Jarvis
+	Admin / System Manager), and always attaches a caveat."""
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_guest_is_rejected(self):
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			llm_key_probe.test_llm_api_key("OpenAI", "gpt-4o", "sk-x", "https://api.openai.com/v1")
+
+	def test_administrator_gets_a_result_with_a_caveat(self):
+		frappe.set_user("Administrator")
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(200, {}, b"{}")):
+			result = llm_key_probe.test_llm_api_key("OpenAI", "gpt-4o", "sk-x", "https://api.openai.com/v1")
+		self.assertTrue(result["ok"])
+		self.assertIn("caveat", result)
+		self.assertTrue(result["caveat"])
+
+	def test_local_provider_caveat_mentions_the_container(self):
+		frappe.set_user("Administrator")
+		with mock.patch.object(link_fetch, "request_pinned", return_value=(200, {}, b"{}")):
+			result = llm_key_probe.test_llm_api_key(
+				"Ollama (local)", "llama3", "unused", "http://host.docker.internal:11434/v1"
+			)
+		self.assertIn("container", result["caveat"])

--- a/jarvis/tests/test_llm_key_probe.py
+++ b/jarvis/tests/test_llm_key_probe.py
@@ -136,6 +136,21 @@ class TestProbeApiKey(FrappeTestCase):
 		rp.assert_not_called()
 		self.assertFalse(result["ok"])
 
+	def test_a_message_extraction_crash_never_escapes_probe_api_key(self):
+		"""_extract_provider_message is best-effort against a body from whatever
+		the customer-supplied base_url points to - probe_api_key's documented
+		"NEVER raises" contract must hold even if that helper itself blows up
+		on a pathological response (code-review finding: only ValueError/
+		TypeError were caught inside the helper; anything else used to
+		propagate all the way out as an unhandled 500)."""
+		with (
+			mock.patch.object(link_fetch, "request_pinned", return_value=(400, {}, b"whatever")),
+			mock.patch.object(llm_key_probe, "_extract_provider_message", side_effect=RecursionError("boom")),
+		):
+			result = llm_key_probe.probe_api_key("OpenAI", "gpt-4o", "sk-x", "https://api.openai.com/v1")
+		self.assertFalse(result["ok"])
+		self.assertIn("HTTP 400", result["checks"][-1]["detail"])
+
 	def test_200_response_is_ok(self):
 		with mock.patch.object(
 			link_fetch,


### PR DESCRIPTION
## Motivation

Today, in Settings -> AI models, adding an LLM API-key row has no way to test
the key before saving. The customer saves, and only afterwards sees a bare
"Not working" chip with no reason.

Real case that motivated this PR: a **valid** GLM (Z.ai) key against an
account on a "GLM Coding Plan" (not pay-as-you-go credits). The same key
works fine against a different base URL. z.ai's own API returns a precise
error for the wrong endpoint:

```json
{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}
```

...but the UI only ever showed "Not working", so the customer had no way to
tell a bad key from a valid key hitting the wrong plan/endpoint. That's why
this PR always surfaces the provider's own message, never a bare boolean -
a separate PR (jarvis#355) handles offering the right GLM endpoint; this one
just makes sure the provider's real text reaches the user regardless of
which endpoint they end up on.

## What this adds

**(A) A pre-save "Test" action** on an API-key model row in the Edit panel
(`frontend/src/components/LlmPoolEditor.vue`), backed by a new endpoint
`jarvis.llm_key_probe.test_llm_api_key`:

- Synchronous, no persistence, live HTTP, structured
  `{ok, checks:[{check, ok, detail}], provider, local_endpoint, caveat}` -
  mirrors the shape and gating precedent of `jarvis/selfhost.py`'s
  `test_connection`/`validate_connection`.
- Sends a minimal 1-token completion using whatever
  provider/base_url/model/api_key is currently typed into the panel (nothing
  saved), against the provider's own wire protocol (OpenAI-compatible /
  Anthropic / Gemini), and surfaces the **provider's own error message** on
  failure - not a generic "failed". This is deliberate: a valid key on the
  wrong plan/endpoint and an actually-bad key both come back "failed", but
  only the provider's own text tells them apart.
- **Not** the mutating `PUT /v1/containers/{name}/llm-pool` apply - that
  rotates secrets, rewrites the tenant's `openclaw.json`, and can restart the
  container (10-30s chat outage). This probe never touches the fleet,
  admin_client, or any container, and never persists anything.
- **Caveat handled honestly**: the bench probes from the bench's own network,
  while live tenant chat runs from inside the tenant's bifrost container. For
  public providers (GLM/OpenAI/Groq/...) these agree. For `ollama`/`vllm`
  (local providers), the button still works but is flagged
  `local_endpoint: true`, the frontend shows a disclaimer before clicking,
  and a guard rejection gets a locality-aware message instead of implying a
  guarantee the bench can't make.

**Security (non-negotiable per the request):**
- `base_url` is customer-supplied, so this is an SSRF vector. Rather than
  writing a new guard, this **extends** the existing SSRF guard in
  `jarvis/chat/link_fetch.py` (already used for Personalise link fetches,
  flagged as an open risk in a prior security audit): a new
  `request_pinned()` generalizes the existing `_open_pinned` pinning seam to
  support POST + JSON body + arbitrary headers, reusing the same
  `_validate_url` scheme/host/DNS-rebinding checks and connection pinning -
  no separate/duplicate guard logic.
- The `api_key` is **never** echoed back: not in a check detail, not in a
  raised exception, not in a log. Provider error bodies are scrubbed for a
  literal key match and capped in length before they ever reach the
  response.

**(B) The post-save health chip now surfaces the real reason.** Fleet PR
`fleet-agent#141` (merged, CI-green) adds an optional `detail` string to each
`model_statuses` entry carrying the provider's real error text, and bumps
`contract_version` to 1.12 - so the data this consumes now exists.
`frontend/src/llm/pool.js`'s `apiKeyModelHealth` renders it
(`"Not working: Insufficient balance..."`) in both the chip label (truncated)
and its tooltip, when present - and falls back to today's generic "Not
working" text, **unchanged**, when the field is absent, since the user's own
running fleet-agent predates contract 1.12.

## Verified

- Backend (`bench --site <site> run-tests --module ...`, via
  `PYTHONPATH=<worktree>`): `jarvis.tests.test_llm_key_probe` (30 tests, incl.
  the GLM insufficient-balance case end to end, api_key scrubbing, SSRF
  rejection both via a mocked guard and end-to-end through the *real* guard
  with only `socket.getaddrinfo` mocked, and the whitelisted-endpoint gate),
  `jarvis.tests.test_link_fetch` (34 tests, 5 new covering the extended
  `request_pinned`/`_open_pinned`), `jarvis.tests.test_llm_pool_endpoints`
  and `jarvis.tests.test_selfhost` (unaffected, still green).
- Frontend: `node --test src/llm/pool.test.js` (37 tests, 6 new covering the
  detail-present / detail-absent-fallback / non-string-detail /
  non-failed-status / truncation cases), and a full `vite build` (clean,
  confirms the Vue SFC compiles with every new template binding actually
  defined in the script).
- `ruff check` / `ruff format --diff` (pinned 0.14.10) clean on every touched
  Python file; no em/en dashes in any new user-facing string (grep-verified
  across every changed file).
- Did **not** call the mutating `/llm-pool` endpoint, touch live tenant data,
  or touch the main checkout / live-served site.

## Base branch note

Opened against `beta` by `gh`'s default and retargeted to `develop` per the
current merge convention - `main` no longer exists on this repo; `develop` is
2 commits ahead of `beta` (both unrelated PWA fixes), and this branch's base
commit is an ancestor of `develop`, so the retarget was clean with no rebase.