### PR TITLE
fix(build): declare frappe-dependencies for Frappe Cloud compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ name = "jarvis"
 # supports. erpnext/hrms are deliberately absent - jarvis runs on frappe-only
 # benches (app-gated skills/tools handle the rest).
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0,<17.0.0"
+frappe = ">=15.0.0,<17.0.0"
 
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,12 @@ build-backend = "flit_core.buildapi"
 [tool.flit.module]
 name = "jarvis"
 
+# Frappe Cloud / bench compatibility gate: which framework majors this app
+# supports. erpnext/hrms are deliberately absent - jarvis runs on frappe-only
+# benches (app-gated skills/tools handle the rest).
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"


### PR DESCRIPTION
Frappe Cloud's app-compatibility check fails with **"Could not find compatible Frappe version in pyproject.toml"** when adding jarvis to a bench: the file had no `[tool.bench.frappe-dependencies]` section at all.

Adds the section (same shape hrms/india_compliance use), declaring the supported framework range — jarvis supports both v15 and v16 benches:

```toml
[tool.bench.frappe-dependencies]
frappe = ">=15.0.0,<17.0.0"
```

erpnext/hrms are deliberately NOT declared — jarvis supports frappe-only benches by design (app-gated skills/tools handle optional apps).