### PR TITLE
ci: guard that beta only accepts PRs from develop

### DIFF
--- a/.github/workflows/beta-source-guard.yml
+++ b/.github/workflows/beta-source-guard.yml
@@ -1,0 +1,39 @@
+name: Beta source guard
+
+# beta accepts promotions from develop and nothing else. There is no native
+# ruleset rule for "restrict the source branch of a PR", so this job exists to be
+# a REQUIRED STATUS CHECK on beta: the ruleset requires it, and it fails any PR
+# whose head is not develop.
+#
+# Only ever require this on the BETA ruleset. It is filtered to
+# `pull_request: branches: [beta]`, so on a PR into develop it never runs - and a
+# required check that never reports leaves a PR stuck pending forever. (Same trap
+# as requiring `build` from ci-base-image.yml, which is paths-filtered and only
+# runs when the Dockerfile changes.)
+
+on:
+  pull_request:
+    branches: [beta]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: beta-source-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source-branch:
+    name: source-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only develop may promote to beta
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::beta only accepts PRs from develop. This PR is from '$HEAD_REF'."
+            echo "Merge the work into develop first, then open develop -> beta."
+            exit 1
+          fi
+          echo "source branch is develop - ok"


### PR DESCRIPTION
Part of locking down `develop` and `beta`. This is the piece that has to be code — the rest is repository rulesets (config, see below).

## Why a workflow

Rulesets have **no native "restrict the PR source branch" rule**. So "beta only accepts PRs from develop" has to be a **required status check**: this job fails any PR into `beta` whose head is not `develop`.

## Require this on the BETA ruleset ONLY

It is filtered to `pull_request: branches: [beta]`, so on a PR into `develop` it **never runs** — and a required check that never reports leaves a PR **stuck pending forever**.

That trap is live in this repo already: `ci-base-image.yml` is paths-filtered to the Dockerfile, so **`build` does not run on most PRs** (#352 reported only `tests`; #359 reported both only because it touched that workflow). **Requiring `build` would block every normal PR.**

## The ruleset config this pairs with

`jarvis` is public, so rulesets are available on the free plan. The other three repos are private and GitHub answers: *"Upgrade to GitHub Pro or make this repository public to enable this feature."* — so they stay convention-only for now.

**Ruleset `protect-develop`** → target `refs/heads/develop`, enforcement active:
- Restrict deletions
- Block force pushes (non-fast-forward)
- Require a pull request before merging
- Require status checks: **`tests`** — and only `tests`

**Ruleset `protect-beta`** → target `refs/heads/beta`, enforcement active:
- Restrict deletions
- Block force pushes
- Require a pull request before merging
- Require status checks: **`tests`** + **`source-branch`** (this workflow)

Bypass list empty, so nobody pushes directly — including admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)