### PR TITLE
fix(chat): every pinned https fetch raised TypeError (server_hostname kwarg)

### DIFF
--- a/jarvis/chat/link_fetch.py
+++ b/jarvis/chat/link_fetch.py
@@ -250,6 +250,39 @@ def _host_header(hostname: str, port: int, scheme: str) -> str:
 	return hostname if port == default else f"{hostname}:{port}"
 
 
+def _build_pool(scheme: str, ip: str, port: int, hostname: str, timeout: int):
+	"""The pinned single-use urllib3 pool: the socket goes to ``ip``, while TLS
+	still verifies against the ORIGINAL ``hostname`` (SNI + cert check).
+
+	Split out of ``_open_pinned`` so the pool can be built - and its connection
+	actually constructed - in a test without a network round trip. It could not
+	be, when this was inline, and that is precisely how the bug below survived:
+	every test in test_link_fetch.py stubs ``_open_pinned`` wholesale, so the
+	real pool construction was never once executed in CI.
+
+	``server_hostname`` is a CONNECTION kwarg, not a pool one. urllib3 v2 pools
+	collect their surplus **kwargs into ``self.conn_kw`` and splat that onto the
+	connection, so it must be passed as a PLAIN kwarg here. Passing a literal
+	``conn_kw={"server_hostname": ...}`` (as this did until now) gets collected
+	one level too deep - ``conn_kw={"conn_kw": {...}}`` - and every https fetch
+	dies with ``TypeError: HTTPSConnection.__init__() got an unexpected keyword
+	argument 'conn_kw'``. That TypeError is neither HTTPError nor OSError, so
+	``fetch_and_extract``'s except clause does not catch it either."""
+	pool_timeout = urllib3.Timeout(connect=timeout, read=timeout)
+	if scheme != "https":
+		return urllib3.HTTPConnectionPool(host=ip, port=port, timeout=pool_timeout, retries=False)
+	return urllib3.HTTPSConnectionPool(
+		host=ip,
+		port=port,
+		assert_hostname=hostname,
+		cert_reqs="CERT_REQUIRED",
+		ca_certs=certifi.where(),
+		timeout=pool_timeout,
+		retries=False,
+		server_hostname=hostname,
+	)
+
+
 def _open_pinned(
 	parsed,
 	ip: str,
@@ -290,28 +323,7 @@ def _open_pinned(
 	headers = dict(extra_headers or {})
 	headers["User-Agent"] = _USER_AGENT
 	headers["Host"] = _host_header(hostname, port, scheme)
-	pool_timeout = urllib3.Timeout(connect=timeout, read=timeout)
-	if scheme == "https":
-		pool = urllib3.HTTPSConnectionPool(
-			host=ip,
-			port=port,
-			assert_hostname=hostname,
-			cert_reqs="CERT_REQUIRED",
-			ca_certs=certifi.where(),
-			timeout=pool_timeout,
-			retries=False,
-			# ``server_hostname`` is a CONNECTION kwarg (not a pool one) in
-			# urllib3 v2, so it rides in via ``conn_kw`` - this is what aims SNI
-			# at the real hostname while the socket goes to the pinned IP.
-			conn_kw={"server_hostname": hostname},
-		)
-	else:
-		pool = urllib3.HTTPConnectionPool(
-			host=ip,
-			port=port,
-			timeout=pool_timeout,
-			retries=False,
-		)
+	pool = _build_pool(scheme, ip, port, hostname, timeout)
 	resp = pool.urlopen(
 		method,
 		target,

--- a/jarvis/tests/test_link_fetch.py
+++ b/jarvis/tests/test_link_fetch.py
@@ -536,3 +536,37 @@ class TestRequestPinned(LinkFetchGuardTestCase):
 			with self.assertRaises(link_fetch.LinkFetchError):
 				link_fetch.request_pinned(
 					"https://public.example.com/chat/completions", method="POST", json_body={})
+
+
+class TestPinnedPoolConstruction(LinkFetchGuardTestCase):
+	"""The one seam every other test in this file stubs.
+
+	``_open_pinned`` is mocked wholesale everywhere else, which is exactly why a
+	real-world break in the pool construction (a literal ``conn_kw=`` kwarg that
+	urllib3 v2 collects one level too deep) passed CI while every https fetch
+	raised TypeError against the live library. These tests build the pool for
+	real and construct a connection off it - no network, no mock of the thing
+	under test.
+	"""
+
+	def test_https_pool_can_actually_construct_a_connection(self):
+		pool = link_fetch._build_pool("https", "93.184.216.34", 443, "example.com", 5)
+		# _new_conn() instantiates HTTPSConnection with **pool.conn_kw but does
+		# NOT open a socket - this is the call that used to raise
+		# "TypeError: HTTPSConnection.__init__() got an unexpected keyword
+		# argument 'conn_kw'".
+		conn = pool._new_conn()
+		self.assertEqual(conn.host, "93.184.216.34")
+		self.assertEqual(pool.conn_kw.get("server_hostname"), "example.com")
+		self.assertNotIn("conn_kw", pool.conn_kw)
+
+	def test_https_pool_pins_socket_to_ip_but_verifies_the_hostname(self):
+		pool = link_fetch._build_pool("https", "93.184.216.34", 443, "example.com", 5)
+		self.assertEqual(pool.host, "93.184.216.34")       # socket -> vetted IP
+		self.assertEqual(pool.assert_hostname, "example.com")  # cert -> real host
+		self.assertEqual(pool.conn_kw.get("server_hostname"), "example.com")  # SNI
+
+	def test_http_pool_can_also_construct_a_connection(self):
+		pool = link_fetch._build_pool("http", "93.184.216.34", 80, "example.com", 5)
+		conn = pool._new_conn()
+		self.assertEqual(conn.host, "93.184.216.34")

--- a/jarvis/tests/test_link_fetch.py
+++ b/jarvis/tests/test_link_fetch.py
@@ -203,7 +203,16 @@ class TestConnectionPinning(LinkFetchGuardTestCase):
 		self.assertEqual(kwargs["host"], PUBLIC_IP)
 		# TLS still verifies against, and SNI still targets, the ORIGINAL name.
 		self.assertEqual(kwargs["assert_hostname"], "public.example.com")
-		self.assertEqual(kwargs["conn_kw"], {"server_hostname": "public.example.com"})
+		# server_hostname goes as a PLAIN kwarg - urllib3 v2 collects a pool's
+		# surplus kwargs into conn_kw itself and splats them onto the connection.
+		# This used to assert `kwargs["conn_kw"] == {...}`, i.e. it asserted the
+		# double-wrapped form that made every real https fetch raise TypeError:
+		# because this test mocks the pool CLASS, the broken kwarg was never fed
+		# to the real urllib3, so the assertion locked the bug in as the expected
+		# contract. TestPinnedPoolConstruction below constructs a real pool and
+		# connection precisely so a mock can never hide that again.
+		self.assertEqual(kwargs["server_hostname"], "public.example.com")
+		self.assertNotIn("conn_kw", kwargs)
 		self.assertEqual(kwargs["cert_reqs"], "CERT_REQUIRED")
 
 		# The Host header carries the original hostname, not the pinned IP.


### PR DESCRIPTION
## What

`link_fetch._open_pinned` passed a literal `conn_kw={"server_hostname": hostname}` to `HTTPSConnectionPool`. urllib3 v2 pools collect their **surplus** `**kwargs` into `self.conn_kw` and splat that dict onto the connection, so a literal `conn_kw=` lands one level too deep (`conn_kw={"conn_kw": {...}}`) and connection construction dies with:

```
TypeError: HTTPSConnection.__init__() got an unexpected keyword argument 'conn_kw'
```

The docstring's *reasoning* was right (`server_hostname` is a connection kwarg, not a pool one). Only the mechanism was wrong: it has to be a plain kwarg, which urllib3 then collects for you.

## Blast radius (https only, both production callers)

| Caller | Feature | Since |
|---|---|---|
| `fetch_and_extract` | chat link preview | #271, where the line originated |
| `request_pinned` | pre-save API-key **Test** button | #357 |

`fetch_and_extract` catches only `(urllib3.exceptions.HTTPError, OSError)`. A `TypeError` is neither, so it was not even downgraded to a failed fetch. It propagated.

## Why CI was green

**Every test in `test_link_fetch.py` mocks `_open_pinned` wholesale**, so the real pool construction has never once executed under test. The existing guard tests remain valid (they cover the DNS / scheme / redirect guards *around* this seam), but nothing exercised the seam itself.

The pool build is therefore split into `_build_pool`, and `TestPinnedPoolConstruction` builds it for real and calls `_new_conn()` (constructs the connection object, no socket, no network, no mock of the code under test). **Those tests fail against the old kwarg and pass against the new one**, which is the only reason to trust them.

## Verification

Against the live library (urllib3 2.7.0, python 3.14):

```
conn_kw={'server_hostname':...}  (old):  TypeError: HTTPSConnection.__init__() ... 'conn_kw'
server_hostname=... (new):               OK status=301
```

Pinning properties are preserved and asserted: socket goes to the vetted IP (`pool.host`), cert verifies the real hostname (`assert_hostname`), SNI targets the real hostname (`conn_kw["server_hostname"]`).

Pre-existing `ruff` findings in these files (UP028, formatting) are present on pristine `develop` too and are left alone.

## How it was found

Live-probing a customer's real GLM key end-to-end after #355/#357 landed: the Test button could not make a single https request.