### PR TITLE
fix(onboarding): free/trial plans complete the wizard instead of dead-ending after email verification

### DIFF
--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -29,3 +29,26 @@ export function prevStep(steps, cur) {
 export function isOnboardComplete(readyResp) {
 	return !!(readyResp && readyResp.ready)
 }
+
+// Branch decision for the "I've verified my email" poll. Admin's
+// get_signup_payment_state (jarvis_admin_v2/billing/signup.py) returns one of
+// THREE shapes: still-pending, paid-plan order handles, or the free/trial
+// completion {pending_verification: false, subscription_status: "..."} with
+// no order (verification WAS the whole signup). Pure so the free-plan branch
+// - the one that used to dead-end on "Signup state has changed" - stays
+// unit-tested.
+//   {kind: "wait"}                  - link not clicked yet (or empty resp)
+//   {kind: "checkout"}              - paid plan: open Razorpay Checkout
+//   {kind: "complete"}              - free/trial plan: already Active, skip
+//                                     payment and go straight to provisioning
+//   {kind: "halted", status: "..."} - Cancelled/Expired/etc: dead sub, tell
+//                                     the customer instead of the generic
+//                                     "state changed" shrug
+//   {kind: "stale"}                 - unrecognized shape: ask for a refresh
+export function verifyPollAction(d) {
+	if (!d || d.pending_verification) return { kind: "wait" }
+	if (d.razorpay_order_id) return { kind: "checkout" }
+	if (d.subscription_status === "Active") return { kind: "complete" }
+	if (d.subscription_status) return { kind: "halted", status: String(d.subscription_status) }
+	return { kind: "stale" }
+}

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -47,7 +47,9 @@ export function isOnboardComplete(readyResp) {
 //   {kind: "stale"}                 - unrecognized shape: ask for a refresh
 export function verifyPollAction(d) {
 	if (!d || d.pending_verification) return { kind: "wait" }
-	if (d.razorpay_order_id) return { kind: "checkout" }
+	// checkout covers both Checkout modes: one-shot order (razorpay_order_id)
+	// and autopay-trial mandate auth (razorpay_subscription_id).
+	if (d.razorpay_order_id || d.razorpay_subscription_id) return { kind: "checkout" }
 	if (d.subscription_status === "Active") return { kind: "complete" }
 	if (d.subscription_status) return { kind: "halted", status: String(d.subscription_status) }
 	return { kind: "stale" }

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -48,6 +48,15 @@ test("verifyPollAction: paid plan goes to checkout", () => {
 	assert.deepEqual(verifyPollAction(d), { kind: "checkout" })
 })
 
+test("verifyPollAction: autopay-trial (subscription) plan goes to checkout", () => {
+	// Admin's poll shape for a paid plan with trial_days: a Razorpay
+	// SUBSCRIPTION id (mandate-auth Checkout), no order id.
+	const d = { pending_verification: false, razorpay_subscription_id: "sub_x",
+		razorpay_key_id: "rzp_test", amount_inr: 999, trial_days: 14,
+		customer_password: "pw" }
+	assert.deepEqual(verifyPollAction(d), { kind: "checkout" })
+})
+
 test("verifyPollAction: free plan already Active completes without payment", () => {
 	const d = { pending_verification: false, subscription_status: "Active",
 		customer_password: "pw" }

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep, stepIndex, isOnboardComplete } from "./steps.js"
+import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep, stepIndex, isOnboardComplete, verifyPollAction } from "./steps.js"
 
 test("managed step order", () => {
 	assert.deepEqual(STEPS_MANAGED, ["intro", "plan", "details", "pay", "connect"])
@@ -29,4 +29,39 @@ test("isOnboardComplete reads readiness", () => {
 	assert.equal(isOnboardComplete({ ready: false, reason: "llm_credentials" }), false)
 	assert.equal(isOnboardComplete(null), false)
 	assert.equal(isOnboardComplete(undefined), false)
+})
+
+// verifyPollAction consumes admin's get_signup_payment_state shapes verbatim
+// (jarvis_admin_v2/billing/signup.py::get_signup_payment_state docstring).
+// The "complete" case is the free-plan fix: {pending_verification: false,
+// subscription_status: "Active"} with NO razorpay_order_id used to fall
+// through every branch and dead-end the wizard.
+test("verifyPollAction: link not clicked yet keeps waiting", () => {
+	assert.deepEqual(verifyPollAction({ pending_verification: true }), { kind: "wait" })
+	assert.deepEqual(verifyPollAction(null), { kind: "wait" })
+	assert.deepEqual(verifyPollAction(undefined), { kind: "wait" })
+})
+
+test("verifyPollAction: paid plan goes to checkout", () => {
+	const d = { pending_verification: false, razorpay_order_id: "order_x",
+		razorpay_key_id: "rzp_test", amount_inr: 2000, customer_password: "pw" }
+	assert.deepEqual(verifyPollAction(d), { kind: "checkout" })
+})
+
+test("verifyPollAction: free plan already Active completes without payment", () => {
+	const d = { pending_verification: false, subscription_status: "Active",
+		customer_password: "pw" }
+	assert.deepEqual(verifyPollAction(d), { kind: "complete" })
+})
+
+test("verifyPollAction: terminal statuses surface as halted", () => {
+	for (const status of ["Cancelled", "Expired", "Past Due"]) {
+		assert.deepEqual(verifyPollAction({ pending_verification: false, subscription_status: status }),
+			{ kind: "halted", status })
+	}
+})
+
+test("verifyPollAction: unknown shape asks for a refresh", () => {
+	assert.deepEqual(verifyPollAction({ pending_verification: false }), { kind: "stale" })
+	assert.deepEqual(verifyPollAction({}), { kind: "stale" })
 })

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -131,7 +131,7 @@
 								<div class="jv-ob-body">
 									<div class="jv-ob-head">
 										<h1>Setting up your workspace</h1>
-										<p v-if="state.provisioning">{{ isFreePlan ? "You're signed up." : "Payment received." }} We're provisioning your Jarvis workspace. This usually takes under a minute…</p>
+										<p v-if="state.provisioning">{{ isFreePlan ? "You're signed up." : (isTrialPlan ? "Auto-pay authorized — nothing charged until your trial ends." : "Payment received.") }} We're provisioning your Jarvis workspace. This usually takes under a minute…</p>
 									</div>
 									<div v-if="state.provisioning" class="jv-ob-spinner" aria-hidden="true"></div>
 									<Banner v-if="state.provisionErr" type="error" :message="state.provisionErr" role="alert" />
@@ -160,7 +160,7 @@
 							<template v-else-if="state.successData">
 								<div class="jv-ob-body">
 									<div class="jv-ob-head">
-										<h1>{{ isFreePlan ? "You're signed up" : "Payment complete" }}</h1>
+										<h1>{{ isFreePlan ? "You're signed up" : (isTrialPlan ? "Free trial started" : "Payment complete") }}</h1>
 										<p>You're all set. Continue to connect your AI.</p>
 									</div>
 								</div>
@@ -172,7 +172,7 @@
 								<div class="jv-ob-body">
 									<div class="jv-ob-head">
 										<h1>Review &amp; pay</h1>
-										<p>{{ isFreePlan ? "Confirm the details below." : "Confirm the details below. You'll complete payment securely via Razorpay." }}</p>
+										<p>{{ isFreePlan ? "Confirm the details below." : (isTrialPlan ? "Confirm the details below. You'll authorize auto-pay securely via Razorpay — nothing is charged until your trial ends." : "Confirm the details below. You'll complete payment securely via Razorpay.") }}</p>
 									</div>
 									<div class="jv-ob-rev">
 										<div class="jv-ob-rev-row"><span>Plan</span><b>{{ planRowLabel }}</b></div>
@@ -408,10 +408,19 @@ const frameSub = computed(() => FRAME_SUBS[state.step] || "Set up your workspace
 // lock note, "Free" in the total row.
 const isFreePlan = computed(() => (Number(selectedPlan.value.price_inr) || 0) <= 0)
 
-// Pay CTA copy: dev signup in sandbox; "Pay ₹X →" for a paid plan; plain
-// sign-up for a free one.
+// Auto-pay trial: a PAID plan with a trial window (admin: Jarvis Plan
+// trial_days on is_free=0). Checkout collects the autopay mandate now; the
+// first charge fires when the trial ends. Distinct from a FREE plan with
+// trial_days (finite free trial - no payment instrument at all).
+const trialDays = computed(() => Number(selectedPlan.value.trial_days) || 0)
+const isTrialPlan = computed(() => !isFreePlan.value && trialDays.value > 0)
+
+// Pay CTA copy: dev signup in sandbox; "Start free trial" for an autopay
+// trial (nothing due today); "Pay ₹X" for a plain paid plan; plain sign-up
+// for a free one.
 const payCta = computed(() => {
 	if (state.devActive) return "Dev signup & connect"
+	if (isTrialPlan.value) return "Start free trial"
 	return isFreePlan.value ? "Sign up" : `Pay ${inr(selectedPlan.value.price_inr)}`
 })
 
@@ -422,7 +431,10 @@ const planRowLabel = computed(() => {
 	if (!p.plan_name) return ""
 	return p.billing_cycle ? `${p.plan_name} · ${p.billing_cycle}` : p.plan_name
 })
-const dueTodayLabel = computed(() => planAmount(selectedPlan.value.price_inr))
+const dueTodayLabel = computed(() => {
+	if (isTrialPlan.value) return `₹0 · then ${inr(selectedPlan.value.price_inr)}${planSuffix(selectedPlan.value.price_inr, selectedPlan.value.billing_cycle) || ""} after ${trialDays.value} days`
+	return planAmount(selectedPlan.value.price_inr)
+})
 
 function goNext() {
 	state.step = nextStep(steps.value, state.step)
@@ -534,8 +546,14 @@ function planFeatures(p) {
 // off the shared suffix helper so the cycle rule can't drift.
 function planCycleLabel(p) {
 	const suffix = planSuffix(p && p.price_inr, p && p.billing_cycle)
-	if (!suffix) return "For trying Jarvis"
-	return suffix === "/yr" ? "Billed annually" : "Billed monthly"
+	const trial = Number(p && p.trial_days) || 0
+	if (!suffix) {
+		// Free plan: finite free trial (lapses after N days) vs free forever.
+		return trial > 0 ? `${trial}-day free trial` : "For trying Jarvis"
+	}
+	const billed = suffix === "/yr" ? "Billed annually" : "Billed monthly"
+	// Paid plan with a trial window: auto-pay starts when the trial ends.
+	return trial > 0 ? `${trial}-day free trial, then ${billed.toLowerCase()}` : billed
 }
 function onPlanContinue() {
 	if (!state.planName) return
@@ -757,16 +775,24 @@ async function openCheckout(d) {
 		return
 	}
 	state.payBusy = false
-	const rz = new window.Razorpay({
+	// Two Checkout modes sharing one options object: a one-shot order
+	// (order_id) or an autopay-trial mandate authorization (subscription_id -
+	// Razorpay collects the recurring-payment consent; the first charge fires
+	// at the trial's end, server-side). The success payload mirrors the mode:
+	// order checkouts return razorpay_order_id, subscription checkouts return
+	// razorpay_subscription_id; finishPayment forwards whichever is present.
+	const rzOpts = {
 		key: d.razorpay_key_id,
-		order_id: d.razorpay_order_id,
 		name: "Jarvis",
-		description: "Jarvis subscription",
+		description: d.razorpay_subscription_id
+			? "Jarvis subscription (auto-pay after trial)"
+			: "Jarvis subscription",
 		handler: (res) => {
 			state.payBusy = true
 			finishPayment({
 				razorpay_payment_id: res.razorpay_payment_id,
 				razorpay_order_id: res.razorpay_order_id,
+				razorpay_subscription_id: res.razorpay_subscription_id,
 				razorpay_signature: res.razorpay_signature,
 			}).then((rr) => {
 				state.successData = rr
@@ -783,10 +809,15 @@ async function openCheckout(d) {
 		modal: {
 			ondismiss: () => {
 				state.payBusy = false
-				state.payErr = "Payment cancelled. Click Pay to try again."
+				state.payErr = isTrialPlan.value
+					? "Authorization cancelled. Click Start free trial to try again."
+					: "Payment cancelled. Click Pay to try again."
 			},
 		},
-	})
+	}
+	if (d.razorpay_subscription_id) rzOpts.subscription_id = d.razorpay_subscription_id
+	else rzOpts.order_id = d.razorpay_order_id
+	const rz = new window.Razorpay(rzOpts)
 	rz.open()
 }
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -131,7 +131,7 @@
 								<div class="jv-ob-body">
 									<div class="jv-ob-head">
 										<h1>Setting up your workspace</h1>
-										<p v-if="state.provisioning">Payment received. We're provisioning your Jarvis workspace. This usually takes under a minute…</p>
+										<p v-if="state.provisioning">{{ isFreePlan ? "You're signed up." : "Payment received." }} We're provisioning your Jarvis workspace. This usually takes under a minute…</p>
 									</div>
 									<div v-if="state.provisioning" class="jv-ob-spinner" aria-hidden="true"></div>
 									<Banner v-if="state.provisionErr" type="error" :message="state.provisionErr" role="alert" />
@@ -146,7 +146,7 @@
 										<h1>Check your email</h1>
 										<p>We sent a confirmation link to <b>{{ state.email || "your email" }}</b>.
 											Click the link to verify your address, then come back here and click the button below
-											to continue to payment.</p>
+											{{ isFreePlan ? "to finish setting up your workspace." : "to continue to payment." }}</p>
 									</div>
 									<p class="jv-ob-hint">The link expires in 24 hours. Check your spam folder if it doesn't arrive.</p>
 									<Banner v-if="state.payErr" type="error" :message="state.payErr" />
@@ -160,7 +160,7 @@
 							<template v-else-if="state.successData">
 								<div class="jv-ob-body">
 									<div class="jv-ob-head">
-										<h1>Payment complete</h1>
+										<h1>{{ isFreePlan ? "You're signed up" : "Payment complete" }}</h1>
 										<p>You're all set. Continue to connect your AI.</p>
 									</div>
 								</div>
@@ -314,7 +314,7 @@ import JarvisMark from "@/components/JarvisMark.vue"
 import Banner from "@/components/Banner.vue"
 import TourIntro from "@/onboarding/TourIntro.vue"
 import SetupNeuralNet from "@/onboarding/SetupNeuralNet.vue"
-import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep } from "@/onboarding/steps"
+import { STEPS_MANAGED, STEPS_SELFHOST, nextStep, prevStep, verifyPollAction } from "@/onboarding/steps"
 import { inr, planAmount, planSuffix } from "@/account/format"
 import {
 	checkSignupPaymentState, isReadyForChat, getLlmSyncStatus,
@@ -707,25 +707,38 @@ async function runStartPay() {
 	}
 }
 
-// Mirrors desk's "I've verified my email" click handler (renderVerifyEmail,
-// jarvis_onboarding.js ~1612): re-poll check_signup_payment_state and branch
-// on the same two fields desk checks, in the same order.
+// "I've verified my email" click handler: re-poll check_signup_payment_state
+// and branch via verifyPollAction (steps.js - pure + unit-tested). Paid plans
+// continue to Razorpay Checkout; free/trial plans are already Active after
+// the email click (verification IS the whole signup), so they skip payment
+// and go straight to the provisioning gate - the poll response also carried
+// customer_password, which the bench endpoint already persisted.
 async function onVerifyCheck() {
 	state.payErr = ""
 	state.payBusy = true
 	try {
 		const d = await checkSignupPaymentState()
-		if (d && d.pending_verification) {
-			state.payBusy = false
-			state.payErr = "We haven't received your verification yet. Click the link in your email, then try again."
-			return
-		}
-		if (d && d.razorpay_order_id) {
+		const action = verifyPollAction(d)
+		if (action.kind === "checkout") {
 			await openCheckout(d)
 			return
 		}
+		if (action.kind === "complete") {
+			// No connection handles in this response - proceedAfterPay polls
+			// sync_connection until the container is assigned + running.
+			state.successData = d || {}
+			state.payBusy = false
+			await proceedAfterPay()
+			return
+		}
 		state.payBusy = false
-		state.payErr = "Signup state has changed. Refresh this page to continue."
+		if (action.kind === "wait") {
+			state.payErr = "We haven't received your verification yet. Click the link in your email, then try again."
+		} else if (action.kind === "halted") {
+			state.payErr = `This signup is ${action.status.toLowerCase()} and can't continue. Start a new signup or contact support.`
+		} else {
+			state.payErr = "Signup state has changed. Refresh this page to continue."
+		}
 	} catch (e) {
 		state.payBusy = false
 		state.payErr = errMsg(e)


### PR DESCRIPTION
## Why

Free-plan signups dead-end on the "Check your email" screen. After the customer clicks the magic link, admin's poll returns the free completion shape \`{pending_verification: false, subscription_status: "Active"}\` with **no** \`razorpay_order_id\` — \`onVerifyCheck\` only understood "still pending" and "has order", so it fell through to *"Signup state has changed. Refresh this page to continue."* with no way forward. The container connection is only written by the Checkout success path, which a free plan never reaches.

## What

- New pure helper \`verifyPollAction(d)\` in \`onboarding/steps.js\` (unit-tested, node --test) mapping the poll response to wait / checkout / **complete** / halted / stale.
- \`onVerifyCheck\`: the free **complete** branch reuses the existing \`proceedAfterPay\` provisioning gate, which polls \`sync_connection\` every 2s until the container is assigned — zero new backend endpoints. (\`check_signup_payment_state\` already persists the \`customer_password\` the fixed admin poll now delivers.)
- Terminal statuses (Cancelled/Expired) get a real message instead of the generic shrug.
- Free-aware copy: verify screen no longer promises "continue to payment"; provisioning/success screens stop claiming "Payment received/complete" on a free plan.

## Verification

- \`steps.test.js\`: 5 new tests covering all five shapes (9/9 module, 85/85 across frontend suites); vite build clean.
- Live e2e on staging with the companion admin PR (Aerele-RnD/jarvis-admin-v2 \`fix/free-signup-completion\`): full free signup → real verification email → magic link → poll delivers password → \`sync_connection\` persists \`wss://…\` connection; wizard advances exactly as the new branch drives it.

Companion/prereq: the admin PR must deploy first (it supplies the poll's \`customer_password\` + commit fix); this SPA change is safe either way (the free branch simply keeps polling until admin serves the fixed shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)