### PR TITLE
fix(pool): offer "Copy link" up front and right-align "Add a model"

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -747,7 +747,10 @@
 											<button
 												type="button"
 												class="jv-cbtn jv-cbtn-ghost"
-												:disabled="!editable || panelRow._connect.loading"
+												:disabled="
+													panelRow._connect.loading ||
+													(!editable && !panelRow._connect.authorizeUrl)
+												"
 												@click="copySigninLink(panelRow)"
 											>
 												{{
@@ -1372,8 +1375,12 @@
 													type="button"
 													class="jv-cbtn jv-cbtn-ghost"
 													:disabled="
-														!editable ||
-														(m._connect && m._connect.loading)
+														(m._connect && m._connect.loading) ||
+														(!editable &&
+															!(
+																m._connect &&
+																m._connect.authorizeUrl
+															))
 													"
 													@click="copySigninLink(m)"
 												>
@@ -2645,19 +2652,25 @@ async function finishConnect(m) {
 function closeConnect(m) {
 	m._connect = blankConnect();
 }
-function copyAuthorizeUrl(m) {
-	const url = m._connect && m._connect.authorizeUrl;
+function copyConnectUrl(m, url) {
 	if (!url) return;
+	// Capture the connect object we are flashing. Reconnect (and closeConnect)
+	// REPLACE m._connect wholesale, so a timer that re-reads m._connect can clear
+	// the "Copied ✓" of a LATER, unrelated copy that started inside our 1400ms.
+	const c = m._connect;
 	copyTextWithFallback(url)
 		.then(() => {
-			m._connect.copied = true;
+			c.copied = true;
 			setTimeout(() => {
-				if (m._connect) m._connect.copied = false;
+				if (m._connect === c) c.copied = false;
 			}, 1400);
 		})
 		.catch(() => {
-			m._connect.error = "Could not copy. Select the URL above and copy manually.";
+			c.error = "Could not copy. Select the URL above and copy manually.";
 		});
+}
+function copyAuthorizeUrl(m) {
+	copyConnectUrl(m, m._connect && m._connect.authorizeUrl);
 }
 // "Copy link" is offered from the START of the sign-in step, not only after
 // "Open sign-in" has already fetched a URL. Signing in on a PHONE (or any second
@@ -2671,10 +2684,23 @@ async function copySigninLink(m) {
 	}
 	const reconnectIdx = (m._connect && m._connect.reconnectIdx) ?? null;
 	await startConnect(m, reconnectIdx, { openTab: false });
-	// Device-code upstreams (Kimi) resolve no authorize URL -- the panel switches to
-	// the verification-code step instead, so there is nothing to copy. startConnect
-	// has already surfaced any error into _connect.error.
-	if (m._connect && m._connect.authorizeUrl) copyAuthorizeUrl(m);
+	if (!m._connect) return;
+	if (m._connect.authorizeUrl) {
+		copyAuthorizeUrl(m);
+		return;
+	}
+	// Device-code upstreams (Kimi) resolve a VERIFICATION PAGE instead of an
+	// authorize URL, and the panel flips to the code step underneath this click.
+	// That page is exactly the link worth carrying to a second device, so copy it
+	// rather than leaving the click silently doing nothing.
+	if (m._connect.deviceFlow) {
+		if (m._connect.verificationUri) copyConnectUrl(m, m._connect.verificationUri);
+		return;
+	}
+	// No URL and startConnect surfaced no error: say so rather than dead-clicking.
+	if (!m._connect.error) {
+		m._connect.error = "Couldn't get a sign-in link. Try Open sign-in instead.";
+	}
 }
 
 // ---- load / save ---------------------------------------------------------

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -206,7 +206,7 @@
 			<button
 				v-if="editable && !panel.open"
 				@click="openAdd"
-				class="jv-btn jv-btn--primary jv-flist-addbtn"
+				class="jv-btn jv-btn--primary jv-flist-addbtn jv-flist-addbtn--end"
 			>
 				<svg
 					viewBox="0 0 24 24"
@@ -716,26 +716,14 @@
 											Sign in with {{ upstreamLabelOf(panelRow.upstream) }}
 										</div>
 										<div class="jv-crow">
-											<template v-if="panelRow._connect.authorizeUrl">
-												<a
-													:href="panelRow._connect.authorizeUrl"
-													target="_blank"
-													rel="noopener noreferrer"
-													class="jv-cbtn jv-cbtn-primary"
-													>Open sign-in ↗</a
-												>
-												<button
-													type="button"
-													class="jv-cbtn jv-cbtn-ghost"
-													@click="copyAuthorizeUrl(panelRow)"
-												>
-													{{
-														panelRow._connect.copied
-															? "Copied ✓"
-															: "Copy link"
-													}}
-												</button>
-											</template>
+											<a
+												v-if="panelRow._connect.authorizeUrl"
+												:href="panelRow._connect.authorizeUrl"
+												target="_blank"
+												rel="noopener noreferrer"
+												class="jv-cbtn jv-cbtn-primary"
+												>Open sign-in ↗</a
+											>
 											<button
 												v-else
 												type="button"
@@ -752,6 +740,20 @@
 													panelRow._connect.loading
 														? "Starting sign-in…"
 														: "Open sign-in ↗"
+												}}
+											</button>
+											<!-- Always offered, never gated behind "Open sign-in": signing in on
+                           another device needs the URL WITHOUT opening a tab here. -->
+											<button
+												type="button"
+												class="jv-cbtn jv-cbtn-ghost"
+												:disabled="!editable || panelRow._connect.loading"
+												@click="copySigninLink(panelRow)"
+											>
+												{{
+													panelRow._connect.copied
+														? "Copied ✓"
+														: "Copy link"
 												}}
 											</button>
 										</div>
@@ -1340,28 +1342,14 @@
 												Sign in with {{ upstreamLabelOf(m.upstream) }}
 											</div>
 											<div class="jv-crow">
-												<template
+												<a
 													v-if="m._connect && m._connect.authorizeUrl"
+													:href="m._connect.authorizeUrl"
+													target="_blank"
+													rel="noopener noreferrer"
+													class="jv-cbtn jv-cbtn-primary"
+													>Open sign-in ↗</a
 												>
-													<a
-														:href="m._connect.authorizeUrl"
-														target="_blank"
-														rel="noopener noreferrer"
-														class="jv-cbtn jv-cbtn-primary"
-														>Open sign-in ↗</a
-													>
-													<button
-														type="button"
-														class="jv-cbtn jv-cbtn-ghost"
-														@click="copyAuthorizeUrl(m)"
-													>
-														{{
-															m._connect.copied
-																? "Copied ✓"
-																: "Copy link"
-														}}
-													</button>
-												</template>
 												<button
 													v-else
 													type="button"
@@ -1376,6 +1364,23 @@
 														m._connect && m._connect.loading
 															? "Starting sign-in…"
 															: "Open sign-in ↗"
+													}}
+												</button>
+												<!-- Always offered, never gated behind "Open sign-in": signing in on
+												     another device needs the URL WITHOUT opening a tab here. -->
+												<button
+													type="button"
+													class="jv-cbtn jv-cbtn-ghost"
+													:disabled="
+														!editable ||
+														(m._connect && m._connect.loading)
+													"
+													@click="copySigninLink(m)"
+												>
+													{{
+														m._connect && m._connect.copied
+															? "Copied ✓"
+															: "Copy link"
 													}}
 												</button>
 											</div>
@@ -2454,7 +2459,7 @@ function openConnectPanel(m, reconnectIdx = null) {
 	m._connect = { ...blankConnect(), open: true, reconnectIdx, pastedUrl: carried };
 }
 
-async function startConnect(m, reconnectIdx = null) {
+async function startConnect(m, reconnectIdx = null, opts = {}) {
 	if (!m._connect) m._connect = blankConnect();
 	// Simplified editor hides the model field - make sure a subscription row always
 	// carries a model id so the connect flow never dead-ends on an unfillable field.
@@ -2484,12 +2489,16 @@ async function startConnect(m, reconnectIdx = null) {
 	// second click (the first only fetched the URL). We navigate this blank tab
 	// once the authorize URL resolves; if it was blocked (win === null) the visible
 	// "Open sign-in ↗" link is still there for the user to click manually.
+	// opts.openTab === false is the "Copy link" path: it only needs the URL, so
+	// suppress the tab rather than spawning one the user did not ask for.
 	let win = null;
-	try {
-		win = window.open("about:blank", "_blank");
-		if (win) win.opener = null;
-	} catch (e) {
-		win = null;
+	if (opts.openTab !== false) {
+		try {
+			win = window.open("about:blank", "_blank");
+			if (win) win.opener = null;
+		} catch (e) {
+			win = null;
+		}
 	}
 	try {
 		const provider = UPSTREAM_OAUTH_PROVIDER[m.upstream] || "OpenAI";
@@ -2649,6 +2658,23 @@ function copyAuthorizeUrl(m) {
 		.catch(() => {
 			m._connect.error = "Could not copy. Select the URL above and copy manually.";
 		});
+}
+// "Copy link" is offered from the START of the sign-in step, not only after
+// "Open sign-in" has already fetched a URL. Signing in on a PHONE (or any second
+// device) is the whole point of copying, and forcing a tab open on this machine
+// first was a pointless detour. When no authorize URL exists yet we fetch one on
+// demand with the tab suppressed, then copy it.
+async function copySigninLink(m) {
+	if (m._connect && m._connect.authorizeUrl) {
+		copyAuthorizeUrl(m);
+		return;
+	}
+	const reconnectIdx = (m._connect && m._connect.reconnectIdx) ?? null;
+	await startConnect(m, reconnectIdx, { openTab: false });
+	// Device-code upstreams (Kimi) resolve no authorize URL -- the panel switches to
+	// the verification-code step instead, so there is nothing to copy. startConnect
+	// has already surfaced any error into _connect.error.
+	if (m._connect && m._connect.authorizeUrl) copyAuthorizeUrl(m);
 }
 
 // ---- load / save ---------------------------------------------------------
@@ -3351,6 +3377,17 @@ defineExpose({ save });
 .jv-flist-addbtn {
 	margin-top: 10px;
 	gap: 6px;
+}
+/* "Add a model" trails the failover LIST, so it sits at the list's right edge --
+   the same edge Save configuration occupies, which is where the eye already is
+   after reading the rows. Scoped to a modifier because .jv-flist-addbtn is shared
+   with the panel's "Connect account", which stays left-aligned under its field.
+   display/width are needed because the parent <section> is a plain block: an
+   inline-flex .jv-btn ignores margin-left:auto until it is block-level. */
+.jv-flist-addbtn--end {
+	display: flex;
+	width: fit-content;
+	margin-left: auto;
 }
 .jv-flist-addbtn svg {
 	color: var(--text-3);


### PR DESCRIPTION
Two small UI corrections in the failover pool editor, both reported from live e2e.

## 1. "Copy link" was gated behind "Open sign-in"

`Copy link` lived inside the `v-if="authorizeUrl"` branch, so it only appeared *after* `Open sign-in` had been clicked and had resolved a URL.

That is backwards. Copying the link exists so you can sign in on a **phone or a second device**; forcing a tab open on *this* machine first is a pointless detour.

Both buttons now render from the start of the sign-in step. When no authorize URL exists yet, `copySigninLink()` fetches one on demand and copies it.

To keep that fetch tab-free, `startConnect` gained an `opts.openTab` flag:
- The click path is **unchanged**. The synchronous `window.open` still fires inside the click, preserving the user gesture and dodging the popup blocker (the documented reason it is written that way).
- Only the copy path passes `openTab: false`.

Device-code upstreams (Kimi) resolve no authorize URL and switch the panel to the verification-code step instead, so the copy is skipped there rather than erroring. Errors still surface through `_connect.error` as before.

Applied to **both** connect surfaces (the panel row and the inline row).

## 2. "Add a model" moves to the right

Right-aligned via a new `--end` modifier, so it sits on the same edge as *Save configuration*.

Scoped to a modifier deliberately: `.jv-flist-addbtn` is **shared** with the panel's *Connect account* button, which stays left-aligned under its field. `display`/`width` are needed because the parent `<section>` is a plain block, and an `inline-flex` `.jv-btn` ignores `margin-left: auto` until it is block-level.

## Verification

- `vite build` passes (52s, 427+ modules)
- `prettier@2.7.1` clean (matches the hooks enforced in #367)
- Rebased onto current `develop` (`7a324a5`) so it carries the recent reformat

Not yet exercised in a browser: local e2e is paused while parallel usage-limits work lands.

https://claude.ai/code/session_01DGcyrXsQFmpB3Kg98dwZkr