### PR TITLE
fix(lint): clear the behavioural ruff debt (B905, F841, RUF007)

### DIFF
--- a/jarvis/chat/approvals_api.py
+++ b/jarvis/chat/approvals_api.py
@@ -441,7 +441,7 @@ def decide(name: str, decision: str, approve: int = 1) -> dict:
 	new_status = "Approved" if int(approve) else "Rejected"
 	# Conditional flip closes the double-decide race: only ONE concurrent
 	# caller wins the Pending -> decided transition.
-	changed = frappe.db.sql(
+	frappe.db.sql(
 		"""update `tabJarvis Approval Request`
 		set status=%s, decision=%s, decided_by=%s, decided_at=%s
 		where name=%s and status='Pending'""",

--- a/jarvis/chat/confirm_card.py
+++ b/jarvis/chat/confirm_card.py
@@ -341,7 +341,11 @@ def _batch_create_card(args: dict, would) -> dict | None:
 	records = []
 	# zip, never filter-then-index: filtering non-dicts out of `created` first would
 	# pair docs[i] with the WRONG created entry from the first bad row onwards.
-	for made, req in list(zip(created, docs))[:_MAX_ROWS]:
+	# strict=False is the DELIBERATE choice: unequal lengths only happen for a
+	# direct caller or a stale preview, and the card must degrade to a partial
+	# render rather than raise (build_card is best-effort; a raise costs the
+	# whole card). Through the gate the lists are always equal and aligned.
+	for made, req in list(zip(created, docs, strict=False))[:_MAX_ROWS]:
 		if not isinstance(made, dict) or not isinstance(req, dict):
 			continue
 		doctype = req.get("doctype") or made.get("doctype")

--- a/jarvis/chat/device.py
+++ b/jarvis/chat/device.py
@@ -146,7 +146,7 @@ def _generate_and_pair_under_lock() -> ChatDeviceCredentials:
 		"chat_device_initial_pair",
 		timeout_s=60,
 		blocking_timeout_s=30.0,
-	) as acquired:
+	) as _acquired:  # deliberately unchecked - see below
 		# Re-check inside the lock window. The winner of a contended cold-
 		# start has already populated Jarvis Settings; followers read those
 		# creds and return without a second pair_chat_device round-trip.

--- a/jarvis/learning/stats.py
+++ b/jarvis/learning/stats.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime
 import math
+from itertools import pairwise
 
 # Strength bands on the Wilson LOWER bound, not raw k/n (plan section 4.1).
 BAND_HIGH = 0.90
@@ -273,7 +274,7 @@ def collapse_bursts(timestamps, max_gap_s: int = 1) -> int:
 	if not ts:
 		return 0
 	units = 1
-	for prev, cur in zip(ts, ts[1:]):
+	for prev, cur in pairwise(ts):
 		if (cur - prev).total_seconds() > max_gap_s:
 			units += 1
 	return units

--- a/jarvis/tests/learning/factory.py
+++ b/jarvis/tests/learning/factory.py
@@ -432,7 +432,7 @@ def _accounts_alpha() -> None:
 		["Cash"] * 30 + ["Bank Draft"] * 2,  # Pay
 	)
 	idx = 0
-	for ptype, modes in zip(("Receive", "Pay"), plan):
+	for ptype, modes in zip(("Receive", "Pay"), plan, strict=True):
 		for mode in modes:
 			name = f"{PREFIX}PE-A-{idx:04d}"
 			_insert(

--- a/jarvis/tests/learning/test_stats.py
+++ b/jarvis/tests/learning/test_stats.py
@@ -8,6 +8,7 @@ arithmetic (fractions.Fraction over math.comb) and hardcoded the same way.
 """
 
 import datetime
+from itertools import pairwise
 
 from frappe.tests.utils import FrappeTestCase
 
@@ -394,7 +395,7 @@ class TestFisherExact(FrappeTestCase):
 
 	def test_monotone_decreasing_in_k(self):
 		ps = [fisher_exact_greater(k, 20, 60, 200) for k in range(0, 21)]
-		for weaker, stronger in zip(ps, ps[1:]):
+		for weaker, stronger in pairwise(ps):
 			self.assertGreaterEqual(weaker, stronger)
 
 	def test_zero_margin_K_is_one(self):

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -366,7 +366,7 @@ class TestAgentsMarketplace(unittest.TestCase):
 	# (d) catalog sync idempotency
 	# ------------------------------------------------------------------ #
 	def test_sync_agent_listings_idempotent(self):
-		r1 = agent_catalog.sync_agent_listings()
+		agent_catalog.sync_agent_listings()
 		count1 = frappe.db.count(LISTING)
 		r2 = agent_catalog.sync_agent_listings()
 		count2 = frappe.db.count(LISTING)

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -455,8 +455,6 @@ class TestSelfHealOnStalePairing(FrappeTestCase):
 		"""Return two scripted WS instances: first one rejects connect with
 		`first_reject_marker` in the error message (or the full `first_error`
 		dict when given); second one accepts."""
-		first_sent: list = []
-		second_sent: list = []
 
 		# Sprint-3 (2026-06-16 review): openclaw's rejection payload puts
 		# the marker in error.code, not error.message. The classifier on

--- a/jarvis/tests/test_part2_security.py
+++ b/jarvis/tests/test_part2_security.py
@@ -262,8 +262,8 @@ class TestRoleRestrictedPushExclusion(Part2Base):
 	role-blind container push."""
 
 	def test_role_restricted_org_skill_excluded_from_push(self):
-		plain = _mk_skill(REVIEWER, f"{PFX}-pushplain", scope="Org")
-		restricted = _mk_skill(REVIEWER, f"{PFX}-pushrestricted", scope="Org", allowed_roles=["Sales User"])
+		_mk_skill(REVIEWER, f"{PFX}-pushplain", scope="Org")
+		_mk_skill(REVIEWER, f"{PFX}-pushrestricted", scope="Org", allowed_roles=["Sales User"])
 		slugs = {p["slug"] for p in build_push_payload()}
 		self.assertIn(prefixed_slug(f"{PFX}-pushplain"), slugs)
 		self.assertNotIn(prefixed_slug(f"{PFX}-pushrestricted"), slugs)

--- a/jarvis/tests/test_triggers_engine.py
+++ b/jarvis/tests/test_triggers_engine.py
@@ -382,7 +382,7 @@ class TestDispatch(_TriggerTestCase):
 
 	def test_blocked_message_is_prefixed_with_trigger_name(self):
 		# Review P2: the blocked user should be told which automation stopped them.
-		trig = self._make_script_trigger(body='frappe.throw("no discounts")', event="validate")
+		self._make_script_trigger(body='frappe.throw("no discounts")', event="validate")
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "blocked"})
 		with patch(EXEC_FLAG, return_value=True), patch("frappe.enqueue"):
 			try:

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -1611,6 +1611,10 @@ class TestRT5OnboardingWritesModelsRow(_RT3SettingsTestCase):
 		# Pre-condition: no models rows.
 		settings = frappe.get_single("Jarvis Settings")
 		initial_count = len(settings.get("models") or [])
+		# The comment above states this pre-condition; assert it rather than
+		# assume it - if rows already existed the assertions below could pass
+		# for the wrong reason.
+		self.assertEqual(initial_count, 0)
 
 		with patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}):
 			from jarvis import onboarding
@@ -1891,9 +1895,7 @@ class TestFT1MigrationPatch(_RT3SettingsTestCase):
 		)
 
 		with (
-			mock_patch(
-				"jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}
-			) as mock_creds,
+			mock_patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
 			mock_patch("jarvis.admin_client.post_update_llm_pool") as mock_pool,
 		):
 			import importlib
@@ -1969,8 +1971,6 @@ class TestFT1MigrationPatch(_RT3SettingsTestCase):
 		)
 
 		enqueued_calls = []
-
-		original_enqueue = frappe.enqueue
 
 		def capture_enqueue(*args, **kwargs):
 			# Capture any enqueue calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,9 @@ ignore = [
     # F841 can be hiding a real bug). Ignored HERE so the rule stays enforced
     # for every other rule and all new code, rather than left un-run.
     # Burn these down file-by-file; delete each line as it hits zero.
+    # Cleared 2026-07-20: B905 (4), F841 (11), RUF007 (2) - the behavioural ones.
     "B007",   # loop control variable not used in the body            (4)
-    "B905",   # zip() without explicit strict=  - BEHAVIOURAL         (4)
-    "F841",   # local variable assigned but never used - may be a bug (11)
     "RUF005", # prefer iterable unpacking over concatenation          (3)
-    "RUF007", # prefer itertools.pairwise over zip                    (2)
     "RUF012", # mutable class default needs ClassVar - may be a bug   (8)
     "RUF013", # implicit Optional in a type annotation                (1)
     "RUF015", # unnecessary allocation to grab the first element      (5)


### PR DESCRIPTION
The pre-commit rollout deferred 50 ruff violations rule-by-rule in `pyproject.toml`. They split into **24 that can hide a bug** and 26 that are style. This clears the first group and **re-enables those rules**; the cosmetic ones stay deferred.

## B905 — four sites, four *different* correct answers

A blanket `strict=True` would have broken two of them:

| Site | Fix | Why |
|---|---|---|
| `confirm_card.py` | `strict=False` | Truncation is **deliberate** — unequal lengths are direct-caller/stale-preview territory, and the card must degrade to a partial render rather than raise (`build_card` is best-effort). |
| `stats.py`, `test_stats.py` | `itertools.pairwise` | `zip(xs, xs[1:])` **always** differs by one, so `strict=True` would raise every time. Also clears `RUF007`. |
| `factory.py` | `strict=True` | A length mismatch means the fixture silently builds the wrong shape — worth failing on. |

## F841 — both production sites investigated, **neither was a bug**

- **`approvals_api.py`** — the unused rowcount *looked* like an unchecked double-decide race, since the comment claims "only ONE concurrent caller wins". The race is genuinely closed, just by the follow-up `SELECT` on `decided_by` rather than the rowcount. Genuinely dead; dropped.
- **`device.py`** — not checking the lock flag is deliberate and documented immediately below it ("at-worst-one-duplicate-pair ... strictly better than chat-permanently-broken"). Contrast `:306`, which *does* check — the author knew the pattern and chose differently here. Renamed `_acquired` to say so.

Nine test bindings were dead setup calls.

## One thing I got wrong

I added an assertion to `test_agents_marketplace` arguing `r2["created"] == 0` was vacuous without it. **The test proved me wrong** — the DB is not clean between tests, so `r1` creates 0 — and the existing `assertEqual(count2, 7)` already covers exactly that concern. Reverted.

## Verification

`test_confirm_card` 68 · `test_record_summary` 46 · `test_part2_security` 23 · `test_agents_marketplace` 18 — all green. 13/13 hooks pass with the three rules re-enabled.

Two pre-existing failures are **not** from this change, verified by stashing and re-running on clean `develop`: `test_triggers_engine` (40 errors — `No module named frappe.core.doctype.jarvis_trigger`, the test site needs a `bench migrate` for the newly-merged trigger DocType) and `test_unified_llm_config` (1 error — `JarvisSettings has no attribute llm_direct_synced_at`, same schema drift).

**Worth knowing:** `ast.parse` does **not** enforce `__future__` placement. It gave me a false pass on a `stats.py` that was failing the entire suite at import. `compile()` catches it — use that for syntax checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)