### PR TITLE
feat(billing): customer-facing subscription cancellation (cancel at period end)

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -40,8 +40,20 @@ export function shortDate(dt) {
 	const s = (dt || "").trim().split(" ")[0];
 	const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
 	if (!m) return "";
-	const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-					"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+	const MONTHS = [
+		"Jan",
+		"Feb",
+		"Mar",
+		"Apr",
+		"May",
+		"Jun",
+		"Jul",
+		"Aug",
+		"Sep",
+		"Oct",
+		"Nov",
+		"Dec",
+	];
 	return `${Number(m[3])} ${MONTHS[Number(m[2]) - 1]}`;
 }
 // Pill text while a cancellation is scheduled: a glanceable end date, not the

--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -5,9 +5,42 @@ const STATUS_LABELS = {
 	Cancelled: "Cancelled",
 	Expired: "Expired",
 };
-export function statusLabel(status) {
+export function statusLabel(status, cancelAtPeriodEnd) {
+	// A plan scheduled to end still reports status "Active" server-side (the
+	// customer keeps full access until the period ends), so "Active" would be
+	// technically true and practically misleading. Say what is happening.
+	if (cancelAtPeriodEnd) return "Cancelling";
 	if (!status) return "Unknown";
 	return STATUS_LABELS[status] || status;
+}
+// Pill colour for a subscription status. Lives here (not inline in the pane)
+// so the cancelling branch is unit-tested like its siblings.
+export function pillTone(status, cancelAtPeriodEnd) {
+	if (cancelAtPeriodEnd) return "jv-pill-warn";
+	if (status === "Active") return "jv-pill-ok";
+	if (
+		status === "Cancelled" ||
+		status === "Past Due" ||
+		status === "Pending Payment" ||
+		status === "Pending Verification"
+	)
+		return "jv-pill-warn";
+	if (status === "Expired") return "jv-pill-bad";
+	return "jv-pill-muted";
+}
+// The cancel button's label adapts to what the customer actually has: an
+// autopay mandate is an auto-renewal to switch off; a one-shot plan is a
+// subscription to end. Promising to "cancel auto-renewal" on a plan that
+// never auto-renews would be a lie.
+export function cancelActionLabel(hasMandate) {
+	return hasMandate ? "Cancel auto-renewal" : "Cancel subscription";
+}
+// Banner copy while a cancellation is scheduled.
+export function cancellationNotice(accessEndsOn) {
+	const end = (accessEndsOn || "").trim();
+	const date = end ? end.split(" ")[0] : "";
+	if (!date) return "Your plan is scheduled to end. You keep full access until then.";
+	return `Your plan ends on ${date}. You keep full access until then.`;
 }
 // Shared INR formatter - the single place amounts get localized.
 export function inr(n) {

--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -35,6 +35,22 @@ export function pillTone(status, cancelAtPeriodEnd) {
 export function cancelActionLabel(hasMandate) {
 	return hasMandate ? "Cancel auto-renewal" : "Cancel subscription";
 }
+// Short "D MMM" date for pills/inline chips. "2026-08-21 12:00" -> "21 Aug".
+export function shortDate(dt) {
+	const s = (dt || "").trim().split(" ")[0];
+	const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!m) return "";
+	const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+					"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+	return `${Number(m[3])} ${MONTHS[Number(m[2]) - 1]}`;
+}
+// Pill text while a cancellation is scheduled: a glanceable end date, not the
+// ambiguous "Cancelling" (which reads as an in-progress operation). The plan is
+// still Active until then; the date is what the customer actually needs.
+export function cancelPillLabel(accessEndsOn) {
+	const d = shortDate(accessEndsOn);
+	return d ? `Ends ${d}` : "Ending";
+}
 // Banner copy while a cancellation is scheduled.
 export function cancellationNotice(accessEndsOn) {
 	const end = (accessEndsOn || "").trim();

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -82,7 +82,7 @@ test("cancelActionLabel: only promises auto-renewal when one exists", () => {
 test("cancellationNotice: names the end date, degrades without one", () => {
 	assert.equal(
 		cancellationNotice("2026-08-20 16:11:36.216083"),
-		"Your plan ends on 2026-08-20. You keep full access until then.",
+		"Your plan ends on 2026-08-20. You keep full access until then."
 	);
 	assert.match(cancellationNotice(""), /keep full access until then/);
 	assert.match(cancellationNotice(null), /keep full access until then/);

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -80,7 +80,7 @@ test("cancelActionLabel: only promises auto-renewal when one exists", () => {
 test("cancellationNotice: names the end date, degrades without one", () => {
 	assert.equal(
 		cancellationNotice("2026-08-20 16:11:36.216083"),
-		"Your plan ends on 2026-08-20. You keep full access until then.",
+		"Your plan ends on 2026-08-20. You keep full access until then."
 	);
 	assert.match(cancellationNotice(""), /keep full access until then/);
 	assert.match(cancellationNotice(null), /keep full access until then/);

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -10,6 +10,8 @@ import {
 	planSuffix,
 	cancelActionLabel,
 	cancellationNotice,
+	shortDate,
+	cancelPillLabel,
 } from "./format.js";
 
 test("statusLabel: maps known states, passes through unknown", () => {
@@ -84,4 +86,18 @@ test("cancellationNotice: names the end date, degrades without one", () => {
 	);
 	assert.match(cancellationNotice(""), /keep full access until then/);
 	assert.match(cancellationNotice(null), /keep full access until then/);
+});
+
+test("shortDate: D MMM, degrades on junk", () => {
+	assert.equal(shortDate("2026-08-21 12:56:09"), "21 Aug");
+	assert.equal(shortDate("2026-01-05"), "5 Jan");
+	assert.equal(shortDate(""), "");
+	assert.equal(shortDate(null), "");
+	assert.equal(shortDate("not-a-date"), "");
+});
+
+test("cancelPillLabel: glanceable end date, not the ambiguous 'Cancelling'", () => {
+	assert.equal(cancelPillLabel("2026-08-21 12:56:09"), "Ends 21 Aug");
+	assert.equal(cancelPillLabel(""), "Ending");
+	assert.equal(cancelPillLabel(null), "Ending");
 });

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -2,11 +2,14 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
 	statusLabel,
+	pillTone,
 	planPriceLabel,
 	renewalLabel,
 	inr,
 	planAmount,
 	planSuffix,
+	cancelActionLabel,
+	cancellationNotice,
 } from "./format.js";
 
 test("statusLabel: maps known states, passes through unknown", () => {
@@ -50,4 +53,35 @@ test("renewalLabel: renders days remaining; handles empty/zero", () => {
 test("renewalLabel: expired/past-due (<= 0 days) shows Expired, not negative days", () => {
 	assert.equal(renewalLabel("2026-06-01 00:00:00", -12), "Expired 2026-06-01");
 	assert.equal(renewalLabel("2026-06-01 00:00:00", 0), "Expired 2026-06-01");
+});
+
+test("statusLabel: a scheduled cancellation reads Cancelling, not Active", () => {
+	// The server keeps status Active through the paid period, so without this
+	// branch a cancelling plan would render a reassuring green "Active".
+	assert.equal(statusLabel("Active", 1), "Cancelling");
+	assert.equal(statusLabel("Active", 0), "Active");
+	assert.equal(statusLabel("Active"), "Active");
+});
+
+test("pillTone: cancelling warns; otherwise tracks status", () => {
+	assert.equal(pillTone("Active", 1), "jv-pill-warn");
+	assert.equal(pillTone("Active", 0), "jv-pill-ok");
+	assert.equal(pillTone("Expired", 0), "jv-pill-bad");
+	assert.equal(pillTone("Past Due", 0), "jv-pill-warn");
+	assert.equal(pillTone("", 0), "jv-pill-muted");
+});
+
+test("cancelActionLabel: only promises auto-renewal when one exists", () => {
+	assert.equal(cancelActionLabel(true), "Cancel auto-renewal");
+	assert.equal(cancelActionLabel(false), "Cancel subscription");
+	assert.equal(cancelActionLabel(undefined), "Cancel subscription");
+});
+
+test("cancellationNotice: names the end date, degrades without one", () => {
+	assert.equal(
+		cancellationNotice("2026-08-20 16:11:36.216083"),
+		"Your plan ends on 2026-08-20. You keep full access until then.",
+	);
+	assert.match(cancellationNotice(""), /keep full access until then/);
+	assert.match(cancellationNotice(null), /keep full access until then/);
 });

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -250,8 +250,7 @@ export const getAccount = () => call("jarvis.account.get_account");
 // BILLING plan lifecycle. Not to be confused with disconnectSubscription
 // above, which drops the LLM PROVIDER subscription (ChatGPT/Claude OAuth).
 // These end / restore the paid Jarvis plan itself.
-export const cancelPlanAtPeriodEnd = () =>
-	call("jarvis.account.cancel_plan_at_period_end");
+export const cancelPlanAtPeriodEnd = () => call("jarvis.account.cancel_plan_at_period_end");
 export const resumePlan = () => call("jarvis.account.resume_plan");
 
 // File input: upload to Frappe's File doctype, return {file_url, file_name}.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -247,6 +247,12 @@ export const disconnectSubscription = () => call("jarvis.oauth.api.disconnect");
 export const getLlmUsage = () => call("jarvis.account.get_llm_usage");
 export const getLlmConnectionStatus = () => call("jarvis.account.get_llm_connection_status");
 export const getAccount = () => call("jarvis.account.get_account");
+// BILLING plan lifecycle. Not to be confused with disconnectSubscription
+// above, which drops the LLM PROVIDER subscription (ChatGPT/Claude OAuth).
+// These end / restore the paid Jarvis plan itself.
+export const cancelPlanAtPeriodEnd = () =>
+	call("jarvis.account.cancel_plan_at_period_end");
+export const resumePlan = () => call("jarvis.account.resume_plan");
 
 // File input: upload to Frappe's File doctype, return {file_url, file_name}.
 export async function uploadFile(file) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -258,6 +258,7 @@ export const getAccount = () => call("jarvis.account.get_account");
 // These end / restore the paid Jarvis plan itself.
 export const cancelPlanAtPeriodEnd = () => call("jarvis.account.cancel_plan_at_period_end");
 export const resumePlan = () => call("jarvis.account.resume_plan");
+export const reauthorizeAutopay = () => call("jarvis.account.reauthorize_autopay");
 
 // File input: upload to Frappe's File doctype, return {file_url, file_name}.
 export async function uploadFile(file) {

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -210,6 +210,9 @@
 .jv-acct-btn-sm:hover { background: var(--surface-3); }
 /* scheduled-cancellation banner: warn-toned, above the plan actions */
 .jv-acct-notice { margin-top: 12px; padding: 9px 11px; border-radius: 8px; background: var(--surface-2); font-size: 12.5px; color: var(--text-2); }
+/* notice with an inline action (the cancellation notice carries Resume) */
+.jv-acct-notice--row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.jv-acct-notice--row > span { min-width: 0; }
 /* plan lifecycle actions (cancel / resume) sit below the feature list */
 .jv-acct-actions { display: flex; gap: 8px; margin-top: 16px; }
 .jv-acct-actions .jv-acct-btn-sm { width: auto; padding: 0 12px; }
@@ -217,6 +220,13 @@
 .jv-acct-link { display: inline-flex; align-items: center; gap: 5px; margin-top: 18px; font-size: 13px; color: var(--link); text-decoration: none; }
 .jv-acct-link:hover { text-decoration: underline; }
 .jv-acct-link svg { flex: none; }
+/* manage footer: billing link left, quiet cancel action right (same baseline) */
+.jv-acct-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 18px; }
+.jv-acct-footer .jv-acct-link { margin-top: 0; }
+/* cancel: a quiet text link, red only on hover — confirm dialog owns the red */
+.jv-acct-cancel { flex: none; padding: 0; border: 0; background: none; font: inherit; font-size: 13px; color: var(--text-3); cursor: pointer; transition: color .15s ease; }
+.jv-acct-cancel:hover:not(:disabled) { color: var(--red); text-decoration: underline; }
+.jv-acct-cancel:disabled { opacity: .5; cursor: default; }
 .jv-acct-savednote { font-size: 12px; color: var(--text-3); font-weight: 420; }
 .jv-acct-usage-line { font-size: 13px; color: var(--text-2); }
 

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -208,6 +208,11 @@
 /* the upgrade CTA is an <a> (same Desk href) rendered as a quiet subtle button */
 .jv-acct-btn-sm { display: flex; align-items: center; justify-content: center; width: 100%; height: 28px; font-size: 12.5px; font-weight: 500; color: var(--text); text-decoration: none; border-radius: 8px; background: var(--surface-2); transition: background-color .15s ease; }
 .jv-acct-btn-sm:hover { background: var(--surface-3); }
+/* scheduled-cancellation banner: warn-toned, above the plan actions */
+.jv-acct-notice { margin-top: 12px; padding: 9px 11px; border-radius: 8px; background: var(--surface-2); font-size: 12.5px; color: var(--text-2); }
+/* plan lifecycle actions (cancel / resume) sit below the feature list */
+.jv-acct-actions { display: flex; gap: 8px; margin-top: 16px; }
+.jv-acct-actions .jv-acct-btn-sm { width: auto; padding: 0 12px; }
 /* manage-billing: a plain text link (design.md §4.2) */
 .jv-acct-link { display: inline-flex; align-items: center; gap: 5px; margin-top: 18px; font-size: 13px; color: var(--link); text-decoration: none; }
 .jv-acct-link:hover { text-decoration: underline; }

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -163,9 +163,7 @@ const upgradePlans = computed(() => account.value.upgrade_plans || []);
 // A plan scheduled to end. Server keeps status "Active" through the paid
 // period, so this flag - not the status - drives the cancelling UI.
 const cancelling = computed(() => !!account.value.cancel_at_period_end);
-const tone = computed(() =>
-	pillTone(account.value.subscription_status, cancelling.value),
-);
+const tone = computed(() => pillTone(account.value.subscription_status, cancelling.value));
 const busy = ref(false);
 const reauthNotice = ref("");
 

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -94,7 +94,18 @@
 				<div v-if="ended" class="jv-acct-actions">
 					<a :href="billingUrl" class="jv-btn jv-btn--primary">Renew subscription</a>
 				</div>
-				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
+				<!-- Autopay off but re-armable. This MUST carry an action: a
+					 released mandate is terminal at Razorpay, so neither resume
+					 nor a one-shot renew brings auto-renewal back, and the notice
+					 alone left the customer told to "set up payment again" with
+					 nothing to click. -->
+				<div v-if="account.can_reauthorize" class="jv-acct-notice jv-acct-notice--row">
+					<span>{{ reauthBanner }}</span>
+					<a :href="billingUrl" class="jv-btn jv-btn--sm jv-btn--ghost"
+						>Set up auto-renewal</a
+					>
+				</div>
+				<div v-else-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
 
 				<!-- Manage footer: the external billing link, with cancel tucked
 					 beside it as a quiet text link. It stays low-key because the confirm
@@ -221,6 +232,16 @@ async function doCancel() {
 		busy.value = false;
 	}
 }
+
+// Derived from the server payload, not from the resume response alone, so the
+// banner survives a page reload (the pane is reopened far more often than a
+// resume is performed).
+const reauthBanner = computed(() => {
+	const endsOn = (account.value.access_ends_on || "").split(" ")[0];
+	return endsOn
+		? `Auto-renewal is off. Set it up before ${endsOn} to stay subscribed.`
+		: "Auto-renewal is off. Set it up before your period ends.";
+});
 
 async function doResume() {
 	// Constructive action - no danger confirm.

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -179,9 +179,7 @@ const cancelling = computed(() => !!account.value.cancel_at_period_end);
 // fresh payment restores service. Distinct from `cancelling` (still entitled).
 const ENDED_STATUSES = new Set(["Expired", "Cancelled"]);
 const ended = computed(() => ENDED_STATUSES.has(account.value.subscription_status));
-const tone = computed(() =>
-	pillTone(account.value.subscription_status, cancelling.value),
-);
+const tone = computed(() => pillTone(account.value.subscription_status, cancelling.value));
 const busy = ref(false);
 const reauthNotice = ref("");
 

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -22,13 +22,21 @@
 								planPriceLabel(account.plan.price_inr, account.plan.billing_cycle)
 							}}
 						</div>
-						<span class="jv-acct-pill" :class="pillTone">{{
-							statusLabel(account.subscription_status)
+						<span class="jv-acct-pill" :class="tone">{{
+							statusLabel(account.subscription_status, cancelling)
 						}}</span>
 					</div>
 					<div class="jv-acct-renewal">
 						{{ renewalLabel(account.current_period_end, account.days_remaining)
-						}}<template v-if="account.autorenew"> · Auto-renew on</template>
+						}}<template v-if="account.autorenew && !cancelling">
+							· Auto-renew on</template
+						>
+					</div>
+					<!-- A scheduled cancellation must be visible on sight: it is the
+						 only affordance that surfaces Resume, and an invisible one
+						 generates support tickets. -->
+					<div v-if="cancelling" class="jv-acct-notice">
+						{{ cancellationNotice(account.access_ends_on) }}
 					</div>
 					<ul v-if="planFeatures.length" class="jv-acct-features">
 						<li v-for="(f, i) in planFeatures" :key="i">
@@ -52,7 +60,10 @@
 				<!-- Upgrade / Renew — deep-links to the existing Desk billing flow
 					 (Razorpay checkout). No new payment logic in this phase; the
 					 wizard-driven upgrade UI is a Phase-2 item. -->
-				<div v-if="upgradePlans.length" class="jv-acct-upgrades">
+				<!-- Hidden while cancelling: the server refuses upgrades with
+					 ResumeBeforeUpgrade, and offering a CTA that 400s is worse
+					 than offering none. -->
+				<div v-if="upgradePlans.length && !cancelling" class="jv-acct-upgrades">
 					<div class="jv-acct-upgrades-label">Upgrade options</div>
 					<div class="jv-acct-upgrade-grid">
 						<div v-for="p in upgradePlans" :key="p.name" class="jv-acct-upgrade-card">
@@ -68,6 +79,28 @@
 						</div>
 					</div>
 				</div>
+				<div v-if="account.plan && account.plan.plan_name" class="jv-acct-actions">
+					<button
+						v-if="cancelling"
+						type="button"
+						class="jv-acct-btn-sm"
+						:disabled="busy"
+						@click="doResume"
+					>
+						Resume subscription
+					</button>
+					<button
+						v-else
+						type="button"
+						class="jv-btn jv-btn--danger"
+						:disabled="busy"
+						@click="doCancel"
+					>
+						{{ cancelActionLabel(account.has_mandate) }}
+					</button>
+				</div>
+				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
+
 				<a :href="billingUrl" class="jv-acct-link">
 					Manage plan &amp; billing
 					<svg
@@ -92,9 +125,19 @@
 
 <script setup>
 import { ref, computed, onMounted } from "vue";
-import { getAccount } from "@/api";
-import { statusLabel, planPriceLabel, renewalLabel } from "@/account/format.js";
+import { getAccount, cancelPlanAtPeriodEnd, resumePlan } from "@/api";
+import {
+	statusLabel,
+	pillTone,
+	planPriceLabel,
+	renewalLabel,
+	cancelActionLabel,
+	cancellationNotice,
+} from "@/account/format.js";
+import { useConfirm } from "@/composables/useConfirm";
 import { errMessage as errMsg } from "@/lib/errors";
+
+const { confirm } = useConfirm();
 
 // The desk page (still Razorpay-backed) is the existing billing entry point.
 const billingUrl = "/app/jarvis-account?billing=1";
@@ -117,19 +160,14 @@ const planFeatures = computed(() => {
 	return [];
 });
 const upgradePlans = computed(() => account.value.upgrade_plans || []);
-const pillTone = computed(() => {
-	const sub = account.value.subscription_status;
-	if (sub === "Active") return "jv-pill-ok";
-	if (
-		sub === "Cancelled" ||
-		sub === "Past Due" ||
-		sub === "Pending Payment" ||
-		sub === "Pending Verification"
-	)
-		return "jv-pill-warn";
-	if (sub === "Expired") return "jv-pill-bad";
-	return "jv-pill-muted";
-});
+// A plan scheduled to end. Server keeps status "Active" through the paid
+// period, so this flag - not the status - drives the cancelling UI.
+const cancelling = computed(() => !!account.value.cancel_at_period_end);
+const tone = computed(() =>
+	pillTone(account.value.subscription_status, cancelling.value),
+);
+const busy = ref(false);
+const reauthNotice = ref("");
 
 async function loadAccount() {
 	accountLoading.value = true;
@@ -140,6 +178,55 @@ async function loadAccount() {
 		accountErr.value = errMsg(e);
 	} finally {
 		accountLoading.value = false;
+	}
+}
+
+async function doCancel() {
+	const label = cancelActionLabel(account.value.has_mandate);
+	const endsOn = (account.value.access_ends_on || "").split(" ")[0];
+	const ok = await confirm({
+		title: `${label}?`,
+		message: endsOn
+			? `You'll keep full access until ${endsOn}. You can resume any time before then.`
+			: "You'll keep full access until the end of your current period, and can resume any time before then.",
+		confirmLabel: label,
+		danger: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	accountErr.value = "";
+	reauthNotice.value = "";
+	try {
+		await cancelPlanAtPeriodEnd();
+		// Re-read rather than optimistically patching: the server payload is
+		// the truth, and it is a single round-trip.
+		await loadAccount();
+	} catch (e) {
+		accountErr.value = errMsg(e);
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function doResume() {
+	// Constructive action - no danger confirm.
+	busy.value = true;
+	accountErr.value = "";
+	try {
+		const out = (await resumePlan()) || {};
+		if (out.requires_reauthorization) {
+			// Cancelling released the autopay mandate and there is no way to
+			// re-arm it silently; say so rather than let them assume it renews.
+			const endsOn = (account.value.access_ends_on || "").split(" ")[0];
+			reauthNotice.value = endsOn
+				? `Auto-renewal is off. Set up payment again before ${endsOn} to stay subscribed.`
+				: "Auto-renewal is off. Set up payment again before your period ends.";
+		}
+		await loadAccount();
+	} catch (e) {
+		accountErr.value = errMsg(e);
+	} finally {
+		busy.value = false;
 	}
 }
 

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -23,7 +23,9 @@
 							}}
 						</div>
 						<span class="jv-acct-pill" :class="tone">{{
-							statusLabel(account.subscription_status, cancelling)
+							cancelling
+								? cancelPillLabel(account.access_ends_on)
+								: statusLabel(account.subscription_status)
 						}}</span>
 					</div>
 					<div class="jv-acct-renewal">
@@ -32,11 +34,19 @@
 							· Auto-renew on</template
 						>
 					</div>
-					<!-- A scheduled cancellation must be visible on sight: it is the
-						 only affordance that surfaces Resume, and an invisible one
-						 generates support tickets. -->
-					<div v-if="cancelling" class="jv-acct-notice">
-						{{ cancellationNotice(account.access_ends_on) }}
+					<!-- Scheduled cancellation: state it plainly and put Resume right
+						 here, so the one affordance that undoes it is where the customer
+						 is already looking. -->
+					<div v-if="cancelling" class="jv-acct-notice jv-acct-notice--row">
+						<span>{{ cancellationNotice(account.access_ends_on) }}</span>
+						<button
+							type="button"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+							:disabled="busy"
+							@click="doResume"
+						>
+							Resume
+						</button>
 					</div>
 					<ul v-if="planFeatures.length" class="jv-acct-features">
 						<li v-for="(f, i) in planFeatures" :key="i">
@@ -79,45 +89,46 @@
 						</div>
 					</div>
 				</div>
-				<div v-if="account.plan && account.plan.plan_name" class="jv-acct-actions">
+				<!-- Lapsed: renewing is the point (where the chat suspension banner
+					 sends them), so keep it prominent. -->
+				<div v-if="ended" class="jv-acct-actions">
+					<a :href="billingUrl" class="jv-btn jv-btn--primary">Renew subscription</a>
+				</div>
+				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
+
+				<!-- Manage footer: the external billing link, with cancel tucked
+					 beside it as a quiet text link. It stays low-key because the confirm
+					 dialog (danger) owns the deliberate red step; a solid red button here
+					 just makes the pane hostile. Hidden while cancelling (Resume is above)
+					 or ended (nothing to cancel). -->
+				<div class="jv-acct-footer">
+					<a :href="billingUrl" class="jv-acct-link">
+						Manage plan &amp; billing
+						<svg
+							width="13"
+							height="13"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+							<path d="M15 3h6v6" />
+							<path d="M10 14 21 3" />
+						</svg>
+					</a>
 					<button
-						v-if="cancelling"
+						v-if="!cancelling && !ended"
 						type="button"
-						class="jv-acct-btn-sm"
-						:disabled="busy"
-						@click="doResume"
-					>
-						Resume subscription
-					</button>
-					<button
-						v-else
-						type="button"
-						class="jv-btn jv-btn--danger"
+						class="jv-acct-cancel"
 						:disabled="busy"
 						@click="doCancel"
 					>
 						{{ cancelActionLabel(account.has_mandate) }}
 					</button>
 				</div>
-				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
-
-				<a :href="billingUrl" class="jv-acct-link">
-					Manage plan &amp; billing
-					<svg
-						width="13"
-						height="13"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-						<path d="M15 3h6v6" />
-						<path d="M10 14 21 3" />
-					</svg>
-				</a>
 			</template>
 		</section>
 	</div>
@@ -132,6 +143,7 @@ import {
 	planPriceLabel,
 	renewalLabel,
 	cancelActionLabel,
+	cancelPillLabel,
 	cancellationNotice,
 } from "@/account/format.js";
 import { useConfirm } from "@/composables/useConfirm";
@@ -163,6 +175,10 @@ const upgradePlans = computed(() => account.value.upgrade_plans || []);
 // A plan scheduled to end. Server keeps status "Active" through the paid
 // period, so this flag - not the status - drives the cancelling UI.
 const cancelling = computed(() => !!account.value.cancel_at_period_end);
+// Terminal: paid period over, no access left to cancel and no Resume - only a
+// fresh payment restores service. Distinct from `cancelling` (still entitled).
+const ENDED_STATUSES = new Set(["Expired", "Cancelled"]);
+const ended = computed(() => ENDED_STATUSES.has(account.value.subscription_status));
 const tone = computed(() =>
 	pillTone(account.value.subscription_status, cancelling.value),
 );

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -30,6 +30,19 @@ export function isOnboardComplete(readyResp) {
 	return !!(readyResp && readyResp.ready);
 }
 
+// Used when an older admin sends the Suspended state without a reason string.
+export const SUSPENDED_FALLBACK =
+	"Your subscription is no longer active. Renew to restore access to Jarvis.";
+
+// The renew-banner sentence, or null when not suspended. Kept out of
+// NOT_ONBOARDED_REASONS on purpose: the workspace is set up, not un-onboarded,
+// so it renders normally with a banner rather than the setup poster.
+export function suspensionNotice(readyResp) {
+	if (!readyResp || readyResp.ready) return null;
+	if (readyResp.reason !== "subscription_suspended") return null;
+	return readyResp.detail || SUSPENDED_FALLBACK;
+}
+
 // Branch decision for the "I've verified my email" poll. Admin's
 // get_signup_payment_state (jarvis_admin_v2/billing/signup.py) returns one of
 // THREE shapes: still-pending, paid-plan order handles, or the free/trial

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -8,6 +8,8 @@ import {
 	stepIndex,
 	isOnboardComplete,
 	verifyPollAction,
+	suspensionNotice,
+	SUSPENDED_FALLBACK,
 } from "./steps.js";
 
 test("managed step order", () => {
@@ -96,4 +98,35 @@ test("verifyPollAction: terminal statuses surface as halted", () => {
 test("verifyPollAction: unknown shape asks for a refresh", () => {
 	assert.deepEqual(verifyPollAction({ pending_verification: false }), { kind: "stale" });
 	assert.deepEqual(verifyPollAction({}), { kind: "stale" });
+});
+
+test("suspensionNotice: only fires for a suspended workspace", () => {
+	// Entitled / ready / absent → no banner.
+	assert.equal(suspensionNotice({ ready: true }), null);
+	assert.equal(suspensionNotice(null), null);
+	assert.equal(suspensionNotice(undefined), null);
+	// A different not-ready reason must NOT raise the billing banner — that
+	// would tell a customer mid-provisioning to go pay again.
+	assert.equal(suspensionNotice({ ready: false, reason: "container_provisioning" }), null);
+	assert.equal(suspensionNotice({ ready: false, reason: "llm_credentials" }), null);
+});
+
+test("suspensionNotice: prefers admin's sentence, falls back when absent", () => {
+	assert.equal(
+		suspensionNotice({
+			ready: false,
+			reason: "subscription_suspended",
+			detail: "Your subscription has expired. Renew to restore access to Jarvis.",
+		}),
+		"Your subscription has expired. Renew to restore access to Jarvis."
+	);
+	// Older admin sends the state with no reason string.
+	assert.equal(
+		suspensionNotice({ ready: false, reason: "subscription_suspended" }),
+		SUSPENDED_FALLBACK
+	);
+	assert.equal(
+		suspensionNotice({ ready: false, reason: "subscription_suspended", detail: "" }),
+		SUSPENDED_FALLBACK
+	);
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2075,6 +2075,19 @@
 					background: var(--surface);
 				"
 			>
+				<!-- Lapsed sub: container stopped, so every send would fail. -->
+				<Banner
+					v-if="suspendedNotice"
+					type="warning"
+					title="Chat is paused"
+					:message="suspendedNotice"
+					style="margin-bottom: 10px"
+				>
+					<template #action>
+						<button class="jv-btn jv-btn--sm" @click="goRenew">Renew</button>
+					</template>
+				</Banner>
+
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
 					<button
@@ -3452,8 +3465,11 @@ import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue";
 import JarvisMark from "@/components/JarvisMark.vue";
 import DraftPreview from "@/components/doc/DraftPreview.vue";
 import ActionError from "@/components/ActionError.vue";
+import Banner from "@/components/Banner.vue";
 import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
+import { checkReady } from "@/onboarding/readiness.js";
+import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
 import { displayName } from "@/lib/user";
@@ -3505,6 +3521,9 @@ const histDraft = ref("");
 const sending = ref(false);
 const waiting = ref(false);
 const ui = ref({});
+// Renew-banner copy when the subscription has lapsed; null while entitled.
+// The composer is disabled alongside it (no send can succeed while stopped).
+const suspendedNotice = ref(null);
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.
@@ -3955,6 +3974,10 @@ const liveStatus = computed(() => {
 });
 // Recovery banner copy: compaction (context overflow, retrying) vs a connection
 // hiccup. Both mean "still working, in the background" — not an error.
+// Renew CTA → Settings ▸ Plan & billing, the only surface that takes payment.
+function goRenew() {
+	store.openSettings("plan");
+}
 const recoveringLabel = computed(() =>
 	recovering.value && recovering.value.reason === "compacting"
 		? "That was a big one — reorganizing the conversation and retrying…"
@@ -4292,7 +4315,11 @@ const headerSub = computed(() => {
 	return n ? `${Math.ceil(n / 2)} message${n > 2 ? "s" : ""}` : "ERPNext Assistant";
 });
 const canSend = computed(
-	() => (input.value.trim().length > 0 || pendingFiles.value.length > 0) && !sending.value
+	() =>
+		(input.value.trim().length > 0 || pendingFiles.value.length > 0) &&
+		!sending.value &&
+		// Suspended: the server rejects every send, so keep the button dead.
+		!suspendedNotice.value
 );
 const busy = computed(() => sending.value || waiting.value);
 // A parked write's Confirm dispatches a follow-up agent turn (continuation).
@@ -6436,10 +6463,16 @@ async function retry(messageId) {
 	try {
 		const r = await api.retryMessage(messageId);
 		if (r && r.ok === false) {
-			// e.g. the single-flight guard ("a reply is already in progress").
 			sending.value = false;
 			waiting.value = false;
-			notify(r.reason || "Couldn't retry that.", { type: "error" });
+			// Lapsed sub: raise the persistent banner (as a blocked send does),
+			// not a toast that vanishes before they can renew.
+			if (r.reason === "subscription_suspended") {
+				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+			} else {
+				// e.g. the single-flight guard ("a reply is already in progress").
+				notify(r.reason || "Couldn't retry that.", { type: "error" });
+			}
 		}
 	} catch (e) {
 		sending.value = false;
@@ -6548,6 +6581,12 @@ async function send(textArg) {
 			if (fromMain && !input.value) input.value = text;
 			sending.value = false;
 			waiting.value = false;
+			// Lapsed sub: raise the persistent banner (with its Renew link)
+			// rather than a toast that vanishes before they can act on it.
+			if (r.reason === "subscription_suspended") {
+				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+				return;
+			}
 			notify(
 				r.reason === "usage_limit"
 					? "Monthly usage limit reached. Ask your Jarvis admin to raise your limit."
@@ -7303,6 +7342,13 @@ onMounted(async () => {
 	api.listTools()
 		.then((t) => {
 			if (Array.isArray(t) && t.length) jarvisTools.value = t;
+		})
+		.catch(() => {});
+	// Billing banner off the boot readiness promise (memoized, already awaited by
+	// AppShell). Not awaited here: it must never delay painting the chat.
+	checkReady()
+		.then((r) => {
+			suspendedNotice.value = suspensionNotice(r);
 		})
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -18,10 +18,11 @@ from jarvis import admin_client
 from jarvis.onboarding import _surface
 from jarvis.permissions import require_jarvis_admin
 
-# R2-H4 client-side chat-readiness gate. The positive verdict is cached briefly
-# so a boot / SPA-load storm doesn't pay an admin round-trip on every hit.
+# R2-H4 chat-readiness gate, shared by boot, is_ready_for_chat and the send
+# entitlement check. Only "Ready" is cached, so suspension/renewal is still seen
+# promptly; 2 min keeps active-chat admin calls to ~1 per burst.
 _CHAT_GATE_CACHE_KEY = "jarvis:chat_readiness_gate"
-_CHAT_GATE_CACHE_TTL_S = 30
+_CHAT_GATE_CACHE_TTL_S = 120
 
 
 def _admin_chat_gate() -> dict:
@@ -31,9 +32,12 @@ def _admin_chat_gate() -> dict:
 	Called only AFTER the local signup + LLM-credential checks have passed, at
 	the managed ready-exits of ``is_ready_for_chat`` — it is the final gate.
 
-	Returns ``{"ready": True, "reason": None}`` UNLESS the admin is reachable AND
-	reports a ``chat_readiness`` that is PRESENT and != ``"Ready"``, in which case
-	``{"ready": False, "reason": "container_provisioning"}``.
+	Returns ``{"ready": True, "reason": None}`` UNLESS admin is reachable AND
+	reports a ``chat_readiness`` != ``"Ready"``, in which case
+	``{"ready": False, "reason": <code>, "detail": <admin's sentence>}``. The
+	code is ``"subscription_suspended"`` for ``Suspended`` (renew) and
+	``"container_provisioning"`` otherwise (wait) - kept distinct so a suspended
+	customer isn't told to wait for a container that won't come back.
 
 	- v1-tolerance: an ABSENT ``chat_readiness`` key (v1 admin, or a v2 that
 	  doesn't surface it) means the control plane has no opinion → allow.
@@ -51,7 +55,15 @@ def _admin_chat_gate() -> dict:
 		# Fail open on ANY admin error; deliberately no negative cache.
 		return {"ready": True, "reason": None}
 	if "chat_readiness" in conn and conn["chat_readiness"] != "Ready":
-		return {"ready": False, "reason": "container_provisioning"}
+		suspended = conn["chat_readiness"] == "Suspended"
+		return {
+			"ready": False,
+			"reason": "subscription_suspended" if suspended else "container_provisioning",
+			# Admin owns the wording (jarvis_admin_v2.billing.entitlement) so the
+			# two sides can't drift into different explanations. A v1/older admin
+			# sends no reason; the SPA falls back to its own copy.
+			"detail": conn.get("chat_readiness_reason") or "",
+		}
 	# Reachable + (Ready, or v1-absent) → allow and cache the positive verdict.
 	cache.set_value(_CHAT_GATE_CACHE_KEY, 1, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
 	return {"ready": True, "reason": None}
@@ -292,7 +304,7 @@ def resume_plan() -> dict:
 
 
 def _bust_chat_gate() -> None:
-	"""Drop the 30s chat-readiness cache after a billing state change.
+	"""Drop the chat-readiness cache after a billing state change.
 
 	Belt-and-braces: cancelling does not itself change readiness (entitlement
 	runs to period end), but the pane re-reads immediately afterwards and a

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -320,6 +320,17 @@ def resume_plan() -> dict:
 	return out
 
 
+@frappe.whitelist()
+def reauthorize_autopay() -> dict:
+	"""Start re-arming auto-renewal; the page then opens a mandate Checkout.
+
+	No chat-gate bust: this only creates a Razorpay object, it changes no
+	entitlement. confirm_payment is what flips autorenew back on.
+	"""
+	require_jarvis_admin()
+	return _surface(admin_client.reauthorize_autopay)
+
+
 def _bust_chat_gate() -> None:
 	"""Drop the chat-readiness cache after a billing state change.
 

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -262,3 +262,42 @@ def start_upgrade(target_plan: str) -> dict:
 	"""
 	require_jarvis_admin()
 	return _surface(admin_client.start_upgrade, target_plan)
+
+
+@frappe.whitelist()
+def cancel_plan_at_period_end() -> dict:
+	"""Schedule a period-end cancellation of the site's BILLING plan.
+
+	Named plan, not subscription: in this app "subscription" means the LLM
+	provider subscription (disconnect_subscription / DirectSubscriptionCard),
+	and confusing the two would be expensive.
+
+	Gated on System Manager for the same reason as start_upgrade: it changes
+	the billing state of the site's admin account. The gate runs BEFORE the
+	admin round-trip so an unauthorized caller never spends a network call.
+	"""
+	require_jarvis_admin()
+	out = _surface(admin_client.cancel_plan_at_period_end)
+	_bust_chat_gate()
+	return out
+
+
+@frappe.whitelist()
+def resume_plan() -> dict:
+	"""Undo a scheduled cancellation (System Manager, as above)."""
+	require_jarvis_admin()
+	out = _surface(admin_client.resume_plan)
+	_bust_chat_gate()
+	return out
+
+
+def _bust_chat_gate() -> None:
+	"""Drop the 30s chat-readiness cache after a billing state change.
+
+	Belt-and-braces: cancelling does not itself change readiness (entitlement
+	runs to period end), but the pane re-reads immediately afterwards and a
+	stale positive verdict would be confusing. Costs one Redis DEL."""
+	try:
+		frappe.cache().delete_value(_CHAT_GATE_CACHE_KEY)
+	except Exception:
+		pass

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -729,6 +729,24 @@ def start_upgrade(target_plan: str) -> dict:
 	)
 
 
+def cancel_plan_at_period_end() -> dict:
+	"""Schedule a period-end cancellation of the BILLING plan.
+
+	Not the LLM provider subscription - that is post_subscription_disconnect.
+	Service runs until current_period_end; resume_plan undoes it until then.
+	Returns {cancel_at_period_end, cancelled_at, access_ends_on,
+	days_remaining, has_mandate}."""
+	return _post(path=_m("api.account.cancel_plan_at_period_end"), body={})
+
+
+def resume_plan() -> dict:
+	"""Undo a scheduled cancellation while the paid period still has time.
+	Returns the same shape plus ``requires_reauthorization`` - true when the
+	sub had an autopay mandate, which cancelling released and which cannot be
+	re-armed without a fresh payment authorization."""
+	return _post(path=_m("api.account.resume_plan"), body={})
+
+
 def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
 	"""POST a form-encoded grant to admin's OAuth token endpoint. Returns the
 	token dict ({access_token, refresh_token, expires_in, ...}) on success, or

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -755,6 +755,15 @@ def resume_plan() -> dict:
 	return _post(path=_m("api.account.resume_plan"), body={})
 
 
+def reauthorize_autopay() -> dict:
+	"""Mint a replacement Razorpay mandate for a sub whose autopay is off.
+
+	Returns the subscription id for a mandate-auth Checkout. Nothing is charged
+	now - the first cycle fires at the current period end.
+	"""
+	return _post(path=_m("api.account.reauthorize_autopay"), body={})
+
+
 def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
 	"""POST a form-encoded grant to admin's OAuth token endpoint. Returns the
 	token dict ({access_token, refresh_token, expires_in, ...}) on success, or

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1519,6 +1519,12 @@ def retry_message(message: str) -> dict:
 	the parent conversation.
 	"""
 	require_jarvis_access()
+	# Same entitlement gate as send_message: a retry re-runs a full turn, so a
+	# suspended sub must reject here, not grind the WS-open loop on a stopped
+	# container (the Retry button sits on the very error that loop produces).
+	ok, reason = validate_can_send(frappe.session.user)
+	if not ok:
+		return {"ok": False, "reason": reason}
 	doc = frappe.get_doc(MSG, message)
 	# Ownership is enforced on the PARENT conversation: message rows can be
 	# inserted by the RQ worker under a different session user, so the

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -8,7 +8,8 @@ this module's contract.
 
 Returns (True, None) on success or (False, reason: str) on rejection. The
 reason is a machine code the SPA maps to a human toast; the enforcement
-rejection uses reason ``"usage_limit"``.
+rejection uses reason ``"usage_limit"`` and the billing one
+``"subscription_suspended"``.
 """
 
 from __future__ import annotations
@@ -23,7 +24,25 @@ def validate_can_send(user: str) -> tuple[bool, str | None]:
 		return False, "Guest users cannot use Jarvis chat"
 	if _over_monthly_limit(user):
 		return False, "usage_limit"
+	if _subscription_suspended():
+		return False, "subscription_suspended"
 	return True, None
+
+
+def _subscription_suspended() -> bool:
+	"""True iff admin reports the subscription no longer entitles chat. Reuses
+	_admin_chat_gate's cache; fails OPEN (a control-plane hiccup must never block
+	a paying customer, and self-host has no admin)."""
+	try:
+		from jarvis.account import _admin_chat_gate
+
+		return _admin_chat_gate().get("reason") == "subscription_suspended"
+	except Exception:
+		frappe.log_error(
+			title="jarvis policy: entitlement check failed (allowing send)",
+			message=frappe.get_traceback(),
+		)
+		return False
 
 
 def _over_monthly_limit(user: str) -> bool:

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -2060,6 +2060,15 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 						  }">${esc(ctaSecondary.label)}</button>`
 						: ""
 				}
+				${
+					// Autopay is off and re-armable. Without this the customer is
+					// told to "set up payment again" with nothing to click:
+					// releasing a mandate is terminal at Razorpay, so cancel->resume
+					// (and one-shot renew) can never restore auto-renewal by itself.
+					account.can_reauthorize
+						? `<button class="ja-btn ja-btn-ghost" id="ja-cta-reauth" data-action="reauth">Set up auto-renewal</button>`
+						: ""
+				}
 			</div>
 			<div class="ja-err" id="ja-billing-err"></div>
 		</div>`;
@@ -2117,11 +2126,33 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	}
 
 	function bindBilling() {
-		$body.find("#ja-cta-primary, #ja-cta-secondary").on("click", function () {
+		$body.find("#ja-cta-primary, #ja-cta-secondary, #ja-cta-reauth").on("click", function () {
 			const action = $(this).data("action");
 			if (action === "upgrade") return openUpgradeModal();
 			if (action === "renew") return startRenew();
+			if (action === "reauth") return startReauthorize();
 		});
+	}
+
+	// ---- re-authorize autopay ---------------------------------------------
+	function startReauthorize() {
+		setBusy("#ja-cta-reauth", true);
+		frappe
+			.call({ method: "jarvis.account.reauthorize_autopay" })
+			.then((r) => {
+				setBusy("#ja-cta-reauth", false);
+				const data = (r.message && r.message.data) || r.message || {};
+				// Mandate-only Checkout: nothing is charged now (the period is
+				// already paid for), so this always takes the subscription_id
+				// branch and never an amount.
+				openCheckout(data, /*upgrade=*/ false);
+			})
+			.catch((e) => {
+				setBusy("#ja-cta-reauth", false);
+				$body
+					.find("#ja-billing-err")
+					.text(e.message || "Couldn't start auto-renewal setup.");
+			});
 	}
 
 	// ---- renew flow -------------------------------------------------------
@@ -2223,19 +2254,28 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	function openCheckout(handles, isUpgrade) {
 		const opts = {
 			key: handles.razorpay_key_id,
-			amount: Math.round((handles.amount_inr || 0) * 100),
-			currency: "INR",
-			order_id: handles.razorpay_order_id,
 			name: "Jarvis",
 			description: isUpgrade ? "Plan upgrade" : "Subscription payment",
 			handler: function (res) {
 				confirmAndRefresh({
 					razorpay_payment_id: res.razorpay_payment_id,
-					razorpay_order_id: res.razorpay_order_id,
+					razorpay_order_id: res.razorpay_order_id || null,
+					razorpay_subscription_id: res.razorpay_subscription_id || null,
 					razorpay_signature: res.razorpay_signature,
 				});
 			},
 		};
+		if (handles.razorpay_subscription_id) {
+			// Recurring (Monthly) upgrade: subscription-mode Checkout collects the
+			// mandate; the prorated amount rides on the Subscription as an upfront
+			// add-on, so amount/order_id must NOT be set here (an order_id of
+			// undefined made Checkout charge a stray standalone payment).
+			opts.subscription_id = handles.razorpay_subscription_id;
+		} else {
+			opts.order_id = handles.razorpay_order_id;
+			opts.amount = Math.round((handles.amount_inr || 0) * 100);
+			opts.currency = "INR";
+		}
 		new Razorpay(opts).open();
 	}
 

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -142,7 +142,7 @@ class TestAccountGatesFailClosed(FrappeTestCase):
 
 class TestAdminChatGate(FrappeTestCase):
 	"""jarvis.account._admin_chat_gate — the final managed ready-gate for
-	is_ready_for_chat. Fail-open, v1-tolerant, positive verdict cached ~30s.
+	is_ready_for_chat. Fail-open, v1-tolerant, positive verdict cached ~2 min.
 	admin_client.get_connection is mocked."""
 
 	def setUp(self):
@@ -157,10 +157,36 @@ class TestAdminChatGate(FrappeTestCase):
 		) as gc:
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "container_provisioning"},
+				{"ready": False, "reason": "container_provisioning", "detail": ""},
 			)
 		# Uses the short 8s budget so a slow admin can't stall the SPA/boot path.
 		gc.assert_called_once_with(timeout_s=8)
+
+	def test_suspended_is_distinct_from_provisioning(self):
+		"""A revoked subscription must NOT read as "still starting up": that
+		tells the customer to wait for a container that is never coming back
+		instead of renewing."""
+		with patch.object(
+			admin_client, "get_connection",
+			return_value={"chat_readiness": "Suspended",
+						  "chat_readiness_reason": "Your subscription has expired."},
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "subscription_suspended",
+				 "detail": "Your subscription has expired."},
+			)
+
+	def test_suspended_without_reason_still_classifies(self):
+		"""Older admin sends the state with no sentence — the code must still be
+		the billing one; the SPA supplies its own fallback copy."""
+		with patch.object(
+			admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "subscription_suspended", "detail": ""},
+			)
 
 	def test_allows_when_admin_ready(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
@@ -188,7 +214,7 @@ class TestAdminChatGate(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:
 			account._admin_chat_gate()
 			account._admin_chat_gate()
-		# Second call served from the ~30s positive cache → one admin round-trip.
+		# Second call served from the positive cache → one admin round-trip.
 		gc.assert_called_once()
 
 	def test_not_ready_verdict_is_not_cached(self):

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -167,22 +167,26 @@ class TestAdminChatGate(FrappeTestCase):
 		tells the customer to wait for a container that is never coming back
 		instead of renewing."""
 		with patch.object(
-			admin_client, "get_connection",
-			return_value={"chat_readiness": "Suspended",
-						  "chat_readiness_reason": "Your subscription has expired."},
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Suspended",
+				"chat_readiness_reason": "Your subscription has expired.",
+			},
 		):
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "subscription_suspended",
-				 "detail": "Your subscription has expired."},
+				{
+					"ready": False,
+					"reason": "subscription_suspended",
+					"detail": "Your subscription has expired.",
+				},
 			)
 
 	def test_suspended_without_reason_still_classifies(self):
 		"""Older admin sends the state with no sentence — the code must still be
 		the billing one; the SPA supplies its own fallback copy."""
-		with patch.object(
-			admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}
-		):
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}):
 			self.assertEqual(
 				account._admin_chat_gate(),
 				{"ready": False, "reason": "subscription_suspended", "detail": ""},

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -433,6 +433,12 @@ class TestRetryMessage(_ChatTestCase):
 	def setUp(self):
 		super().setUp()
 		self.conv = create_conversation()
+		# retry_message now shares send_message's entitlement gate. Pin it to
+		# "entitled" so these tests don't depend on the live control plane's
+		# current subscription state; the suspended case is tested explicitly.
+		gate = patch("jarvis.account._admin_chat_gate", return_value={"ready": True, "reason": None})
+		gate.start()
+		self.addCleanup(gate.stop)
 
 	def test_routes_through_shared_dispatcher(self):
 		"""Retry must use the SAME dispatcher as send_message (after-commit
@@ -530,6 +536,19 @@ class TestRetryMessage(_ChatTestCase):
 			retry_message(asst_id)
 		after = frappe.utils.get_datetime(frappe.get_value(CONV, self.conv, "last_active_at"))
 		self.assertGreaterEqual(after, before)
+
+	def test_rejects_when_subscription_suspended(self):
+		"""The Retry button sits on the exact error a stopped container produces.
+		A suspended retry must be refused HERE, not dispatched to the worker to
+		grind the 25s WS-open loop and error identically all over again."""
+		_u, asst_id = self._make_turn(self.conv, with_error=True)
+		suspended = {"ready": False, "reason": "subscription_suspended", "detail": "expired"}
+		with patch("jarvis.account._admin_chat_gate", return_value=suspended):
+			with patch("jarvis.chat.api._dispatch_turn") as dispatch:
+				result = retry_message(asst_id)
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["reason"], "subscription_suspended")
+		dispatch.assert_not_called()
 
 
 class TestSetConversationModel(_ChatTestCase):

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -1,18 +1,31 @@
 """Tests for jarvis.chat.policy - the subscription/credits validation seam."""
 
+from unittest.mock import patch
+
 from frappe.tests.utils import FrappeTestCase
 
+import jarvis.account as account
 from jarvis.chat.policy import validate_can_send
+
+# Entitled verdict. Patched in by default so these tests never depend on the
+# live control plane's current subscription state.
+_ENTITLED = {"ready": True, "reason": None}
+_SUSPENDED = {"ready": False, "reason": "subscription_suspended",
+			  "detail": "Your subscription has expired."}
 
 
 class TestValidateCanSend(FrappeTestCase):
+	def setUp(self):
+		self._gate = patch.object(account, "_admin_chat_gate", return_value=_ENTITLED)
+		self._gate.start()
+		self.addCleanup(self._gate.stop)
+
 	def test_administrator_can_send(self):
 		ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
 
-	def test_any_user_can_send_today(self):
-		"""Phase 3 fills in subscription/credit logic. Today any non-empty user is fine."""
+	def test_any_entitled_user_can_send(self):
 		ok, reason = validate_can_send("nobody@example.invalid")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
@@ -26,3 +39,41 @@ class TestValidateCanSend(FrappeTestCase):
 		ok, reason = validate_can_send("Guest")
 		self.assertFalse(ok)
 		self.assertIsNotNone(reason)
+
+
+class TestSubscriptionGate(FrappeTestCase):
+	"""The entitlement check. Rejecting HERE is the whole point: without it the
+	message is persisted and enqueued, and the worker spends the full WS-open
+	deadline retrying a socket into a stopped container - surfacing to the
+	customer as "the assistant may be starting up"."""
+
+	def test_suspended_subscription_rejects_the_send(self):
+		with patch.object(account, "_admin_chat_gate", return_value=_SUSPENDED):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "subscription_suspended")
+
+	def test_provisioning_does_not_reject(self):
+		"""A container still coming up is NOT a billing block - the send must go
+		through so the existing retry can ride out a dormant container."""
+		with patch.object(
+			account, "_admin_chat_gate",
+			return_value={"ready": False, "reason": "container_provisioning", "detail": ""},
+		):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+	def test_fails_open_when_the_gate_raises(self):
+		"""A control-plane hiccup must never block a paying customer."""
+		with patch.object(account, "_admin_chat_gate", side_effect=RuntimeError("admin down")):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+	def test_guest_rejected_before_the_admin_round_trip(self):
+		"""Cheap local checks come first - a Guest must not cost an admin call."""
+		with patch.object(account, "_admin_chat_gate") as gate:
+			ok, _ = validate_can_send("Guest")
+		self.assertFalse(ok)
+		gate.assert_not_called()

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -10,8 +10,7 @@ from jarvis.chat.policy import validate_can_send
 # Entitled verdict. Patched in by default so these tests never depend on the
 # live control plane's current subscription state.
 _ENTITLED = {"ready": True, "reason": None}
-_SUSPENDED = {"ready": False, "reason": "subscription_suspended",
-			  "detail": "Your subscription has expired."}
+_SUSPENDED = {"ready": False, "reason": "subscription_suspended", "detail": "Your subscription has expired."}
 
 
 class TestValidateCanSend(FrappeTestCase):
@@ -57,7 +56,8 @@ class TestSubscriptionGate(FrappeTestCase):
 		"""A container still coming up is NOT a billing block - the send must go
 		through so the existing retry can ride out a dormant container."""
 		with patch.object(
-			account, "_admin_chat_gate",
+			account,
+			"_admin_chat_gate",
 			return_value={"ready": False, "reason": "container_provisioning", "detail": ""},
 		):
 			ok, reason = validate_can_send("someone@example.invalid")


### PR DESCRIPTION
## Customer-facing subscription cancellation (bench side)

Customers could **purchase** a plan but never **cancel** one — the only cancel paths were operator-side or refund-driven, both terminal (suspend the customer, disable their login, stop their container immediately). This adds the industry-standard period-end flow to **Settings → Plan & billing**.

**Pairs with jarvis-admin-v2 `feat/subscription-cancellation`, which MUST deploy first** (see Deploy order).

### What the customer gets
- **Cancel** → keeps full access until `current_period_end`, then the plan expires. Banner: *"Your plan ends on 2026-08-20. You keep full access until then."*
- **Resume** → one click, no payment, any time before the period ends.
- Status pill reads **Cancelling** (warn) rather than a reassuring green *Active* — the server deliberately keeps `status=Active` through the paid period, so the flag drives the UI, not the status.
- Cancel button label adapts: **"Cancel auto-renewal"** only when a Razorpay mandate actually exists, **"Cancel subscription"** otherwise. We never promise to switch off something that was never on.
- Upgrade grid hides while cancelling, agreeing with the server's `ResumeBeforeUpgrade` refusal — a CTA that 400s is worse than no CTA.

### Implementation notes
- `admin_client`: `cancel_plan_at_period_end` / `resume_plan` via `_post(_m("api.account.…"))`.
- `account.py`: shims with the same `require_jarvis_admin()` gate as `start_upgrade`, running **before** the admin round-trip so an unauthorized caller never spends a network call; busts the 30s chat-readiness cache afterwards.
- Named **plan**, not *subscription*: in this app "subscription" already means the **LLM provider** subscription (`disconnectSubscription`, `DirectSubscriptionCard`) — conflating them would be expensive.
- `format.js`: new pure helpers (`pillTone` moved out of the component so its cancelling branch is testable), `cancelActionLabel`, `cancellationNotice`.
- Uses the canonical `jv-btn jv-btn--danger` + `useConfirm({danger: true})` per that composable's documented rule. Resume is constructive → no confirm. `requires_reauthorization` is surfaced honestly when a released mandate can't be re-armed.
- **No typed-confirmation gate** — none exists in this app, it would mean modifying the shared `useConfirm`/`ConfirmDialog`, and the action is reversible until period end.

### Verification
`node --test src/account/format.test.js` → **11/11 pass** (4 new). `bench build --app jarvis` clean. Full round trip exercised on the local stack (bench shim → admin → DB → back): cancel returns the end date + 31 days remaining, summary flips `cancel_at_period_end` and suppresses upgrades, resume clears it.

Note: `test_account.py::test_false_when_admin_key_blank` fails on this machine — **verified pre-existing** (fails identically on pristine `develop`); it's environment state, not this change.

### Deploy order
**Admin first.** Admin-new/bench-old is inert. Bench-new/admin-old is the bad direction: the button 404s, and worse, absent `has_mandate`/`cancel_at_period_end` make the UI *lie* (wrong label, no banner). Bench needs a full redeploy (SPA bundle), not just a migrate.
