### PR TITLE
Platform prerequisites PP-1..6: result classes, truthful states, shadow activation, provenance, activation budget

### DIFF
--- a/frontend/src/pages/agents/AgentRunsBoard.vue
+++ b/frontend/src/pages/agents/AgentRunsBoard.vue
@@ -73,6 +73,19 @@
 									class="mt-1 size-3.5 shrink-0 text-ink-amber-3"
 								/>
 							</Tooltip>
+							<!-- PP-4 preview/shadow: a shadow run is reviewer-only and NOT a
+							     compliant attestation, so it must never read the same as a
+							     live run. The lifecycle status badge (running/completed/…) is
+							     an orthogonal axis; this violet pill carries the activation
+							     axis independently. Badge has no violet theme in
+							     frappe-ui 0.1.278, so this reuses the app's violet-pill
+							     recipe (see triggers/TriggersListPane.vue). -->
+							<span
+								v-if="row.preparation_mode === 'shadow'"
+								class="mt-0.5 inline-flex h-5 shrink-0 select-none items-center whitespace-nowrap rounded-full bg-surface-violet-1 px-1.5 text-xs text-ink-violet-1"
+							>
+								Preview
+							</span>
 							<Badge
 								class="mt-0.5 shrink-0"
 								variant="subtle"
@@ -121,6 +134,21 @@
 
 			<!-- RIGHT pane: the selected run's findings -->
 			<div class="flex-1 overflow-y-auto">
+				<!-- PP-4 shadow banner: the honest "Preview (shadow) - not a compliant
+				     attestation" statement must live in the reviewer's primary screen,
+				     not only in the detached fallback-dashboard HTML. Shown whenever the
+				     selected run was prepared in shadow, above the findings pane. -->
+				<div
+					v-if="selectedRun && selectedRun.preparation_mode === 'shadow'"
+					class="flex items-start gap-2 border-b bg-surface-violet-1 px-6 py-2.5 text-sm text-ink-violet-1"
+				>
+					<FeatherIcon name="eye" class="mt-0.5 size-4 shrink-0" />
+					<span>
+						Preview (shadow) - this run is visible to the named reviewer only and is
+						not a compliant attestation. Promote the capability to live before relying
+						on its results.
+					</span>
+				</div>
 				<div
 					v-if="!selectedRun"
 					class="flex h-full flex-col items-center justify-center gap-3 px-8 text-center"
@@ -158,6 +186,11 @@ const props = defineProps({
 	agentName: { type: String, required: true }, // listing docname (list_runs_page filter)
 });
 
+// lifecycle status (did the run finish) is ONE axis; PP-4 preparation_mode
+// ('shadow'|'live', snapshot of the installation's activation_state at launch)
+// is an orthogonal axis rendered separately as the "Preview" pill/banner above.
+// A shadow run must never read the same as a live one. preparation_mode is
+// supplied per row by list_runs_page (agents_api.py) — see cross-file note.
 const STATUS_THEME = { running: "blue", completed: "green", partial: "orange", failed: "red" };
 const STATUS_OPTIONS = [
 	{ label: "All statuses", value: "" },

--- a/frontend/src/pages/agents/FindingsPanel.vue
+++ b/frontend/src/pages/agents/FindingsPanel.vue
@@ -11,6 +11,13 @@
 				:label="run.status"
 			/>
 			<Button
+				v-if="run.dashboard"
+				variant="subtle"
+				label="Open dashboard"
+				iconLeft="bar-chart-2"
+				@click="router.push('/dashboards/' + run.dashboard)"
+			/>
+			<Button
 				v-if="run.conversation"
 				variant="subtle"
 				label="Open Chat"
@@ -242,8 +249,11 @@ import { takeFindingToChat } from "@/api/agents";
 
 const props = defineProps({
 	// full row from list_runs_page: {name, status, trigger, started_at,
-	// finished_at, conversation, findings_count, blocker_count, error,
-	// coverage_note, ...}
+	// finished_at, conversation, dashboard, findings_count, blocker_count,
+	// error, coverage_note, ...}. `dashboard` is the saved Jarvis Dashboard
+	// name (Run.dashboard); the run header links to /dashboards/:id when set.
+	// NB: list_runs_page must include `dashboard` in its fields for the link to
+	// appear (cross-file — see report notes).
 	run: { type: Object, required: true },
 });
 

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -949,7 +949,12 @@ def record_delegate_run(
 	if inst.schedule_enabled:
 		inst_values["next_run_at"] = compute_next_run(inst.schedule_frequency, inst.schedule_time)
 	frappe.db.set_value(INSTALLATION, inst.name, inst_values, update_modified=False)
-	frappe.db.commit()
+	# Under FrappeTestCase the enclosing transaction is rolled back at teardown; a
+	# mid-test commit would defeat that and leak Run/Finding/Provenance/Dashboard
+	# rows onto the shared site. All in-test asserts read the same connection, so the
+	# uncommitted writes are visible without it.
+	if not frappe.flags.in_test:
+		frappe.db.commit()
 
 	run_doc.reload()
 	return run_doc

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -19,6 +19,7 @@ import hashlib
 import frappe
 from frappe.utils import getdate
 
+from jarvis.chat import coverage_reasons as cr
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.macro_scheduler import compute_next_run
 
@@ -86,14 +87,62 @@ def _esc(value) -> str:
 	return escape_html(str(value if value is not None else ""))
 
 
-def _fallback_dashboard_html(title: str, findings: list, counts: dict, coverage_note: str) -> str:
+# PP-2: the in-body (screenshot-safe) coverage-verdict heading. Label + colour
+# per state; rendered as a first-class block inside the document body, NEVER as a
+# detachable banner, so a crop/PDF keeps it.
+_STATE_HEADING = {
+	"evaluated_clean": ("Evaluated — clean coverage", "#065f46", "#d1fae5"),
+	"partial": ("Partial coverage — not a clean result", "#92400e", "#fef3c7"),
+	"not_evaluable": ("Not evaluable — required checks could not run", "#991b1b", "#fee2e2"),
+	"failed": ("Run failed — no result produced", "#991b1b", "#fee2e2"),
+}
+
+# PP-2: the empty-findings sentence is state-conditional. "No exceptions were
+# found" is UNREACHABLE unless result_state == evaluated_clean.
+_EMPTY_SENTENCE = {
+	"evaluated_clean": "No exceptions were found for this run.",
+	"partial": (
+		"Partial coverage — this run did not evaluate every required check; "
+		"absence of findings is not a clean result."
+	),
+	"not_evaluable": "This run could not evaluate the required checks (see reasons below).",
+	"failed": "This run failed to produce a result.",
+}
+
+
+def _fallback_dashboard_html(
+	title: str,
+	findings: list,
+	counts: dict,
+	coverage_note: str,
+	*,
+	result_state: str = "partial",
+	coverage_notes: list | None = None,
+	shadow: bool = False,
+	integrity_digest: str | None = None,
+) -> str:
 	"""A minimal, self-contained, A2-safe findings summary — the server-generated
 	FLOOR used only when the delegate produced findings but authored no dashboard
 	(so a completed/partial run always yields ONE saved dashboard). It renders the
 	already-persisted, already-lossy finding fields (authored ``note`` + ref +
-	amount + severity) — NEVER the opaque token, and never any rule id/threshold.
-	Inline styles only (CSP sandbox). The Jarvis theme injects the surrounding CSS
-	variables; sane fallbacks keep it legible standalone."""
+	amount + severity + PP-1 ``result_class``) — NEVER the opaque token, and never
+	any rule id/threshold. Inline styles only (CSP sandbox). The Jarvis theme
+	injects the surrounding CSS variables; sane fallbacks keep it legible standalone.
+
+	PP-1: every row shows its ``result_class`` label beside the amount, and its
+	authored note is routed through the strong-verb helper so "saved/recovered/
+	prevented" can never render for a non-``confirmed_outcome`` row. PP-2: the
+	coverage-verdict ``result_state`` is rendered as an in-body heading and the
+	empty-findings sentence is state-conditional. PP-3: the coverage gaps section
+	surfaces each not_evaluable check's typed remediation text.
+
+	PP-4: when ``shadow`` is set the artifact is a reviewer-only PREVIEW — no
+	outward clean/compliant attestation renders even when ``result_state ==
+	evaluated_clean`` (the clean heading and the "No exceptions were found" sentence
+	are both suppressed in favour of an explicit preview banner). PP-6: when an
+	``integrity_digest`` is supplied it is stamped into the document BODY (same
+	in-body, screenshot-safe placement as the state block) so the coverage/integrity
+	digest travels with the numbers on a saved/exported meter artifact."""
 	total = sum(counts.get(s, 0) for s in ("blocker", "warning", "note"))
 	cards = "".join(
 		f'<div style="flex:1;min-width:120px;padding:14px 16px;border:1px solid var(--jarvis-border,#e5e7eb);'
@@ -112,19 +161,85 @@ def _fallback_dashboard_html(title: str, findings: list, counts: dict, coverage_
 			amt = f"{float(amt):,.2f}"
 		except (TypeError, ValueError):
 			amt = _esc(amt)
+		# PP-1 strong-verb gate: an evaluator row is never confirmed_outcome, so the
+		# helper strips saved/recovered/prevented/… from the authored note.
+		safe_note = cr.render_value_text(
+			f.get("note"), f.get("result_class"), outcome_provenance=f.get("outcome_provenance")
+		)
 		rows += (
 			f'<tr style="border-top:1px solid var(--jarvis-border,#e5e7eb)">'
 			f'<td style="padding:8px 10px;white-space:nowrap;text-transform:capitalize">{_esc(sev)}</td>'
-			f'<td style="padding:8px 10px">{_esc(f.get("note"))}</td>'
+			f'<td style="padding:8px 10px;white-space:nowrap;color:var(--jarvis-muted,#6b7280)">'
+			f"{_esc(f.get('result_class'))}</td>"
+			f'<td style="padding:8px 10px">{_esc(safe_note)}</td>'
 			f'<td style="padding:8px 10px;white-space:nowrap;color:var(--jarvis-muted,#6b7280)">'
 			f"{_esc(f.get('ref_doctype'))} · {_esc(f.get('ref_name'))}</td>"
 			f'<td style="padding:8px 10px;text-align:right;white-space:nowrap">{amt}</td></tr>'
 		)
 	if not rows:
+		# PP-4: in shadow the clean "No exceptions were found" sentence is UNREACHABLE
+		# even when result_state == evaluated_clean — a preview run issues no outward
+		# clean/compliant claim. Otherwise the sentence is PP-2 state-conditional.
+		if shadow:
+			sentence = (
+				"Preview (shadow) run — findings are visible to the reviewer only; "
+				"no clean or compliant attestation is issued while this capability is in preview."
+			)
+		else:
+			sentence = _EMPTY_SENTENCE.get(result_state, _EMPTY_SENTENCE["partial"])
 		rows = (
-			'<tr><td colspan="4" style="padding:14px 10px;color:var(--jarvis-muted,#6b7280)">'
-			"No exceptions were found for this run.</td></tr>"
+			'<tr><td colspan="5" style="padding:14px 10px;color:var(--jarvis-muted,#6b7280)">'
+			f"{_esc(sentence)}</td></tr>"
 		)
+
+	# PP-2 in-body coverage-verdict heading (screenshot-safe — inside the body).
+	# PP-4: in shadow the outward clean/compliant heading is REPLACED by a preview
+	# banner, so a computed evaluated_clean never surfaces as an outward attestation.
+	if shadow:
+		label, fg, bg = ("Preview (shadow) — not a compliant attestation", "#3730a3", "#e0e7ff")
+		state_attr = "shadow"
+	else:
+		label, fg, bg = _STATE_HEADING.get(result_state, _STATE_HEADING["partial"])
+		state_attr = result_state
+	state_block = (
+		f'<div data-result-state="{_esc(state_attr)}" '
+		f'style="display:inline-block;margin:0 0 16px;padding:6px 12px;border-radius:8px;'
+		f'font-size:13px;font-weight:600;color:{fg};background:{bg}">{_esc(label)}</div>'
+	)
+
+	# PP-6 in-body coverage/integrity digest — stamped onto the numbers, screenshot-
+	# safe (inside the body, never a separable page), so a saved/exported meter
+	# artifact always carries its evaluator integrity digest and coverage caveat.
+	digest_block = ""
+	if integrity_digest:
+		caveat = _esc(coverage_note) if coverage_note else "full coverage for the reported windows"
+		digest_block = (
+			f'<div data-digest-block style="margin:20px 0 0;padding:12px 14px;'
+			f"border:1px dashed var(--jarvis-border,#e5e7eb);border-radius:8px;"
+			f'color:var(--jarvis-muted,#6b7280);font-size:12px">'
+			f'<div style="text-transform:uppercase;letter-spacing:.04em;font-weight:600;margin:0 0 6px">'
+			f"Coverage &amp; integrity digest</div>"
+			f"<div>Evaluator integrity digest: <code>{_esc(integrity_digest)}</code></div>"
+			f"<div>Coverage caveats: {caveat}</div>"
+			f"<div>Reporting windows are computed server-side and fixed on this artifact.</div>"
+			f"</div>"
+		)
+
+	# PP-3 coverage-gaps section: typed remediation text per not_evaluable check.
+	gaps = ""
+	if coverage_notes:
+		items = "".join(
+			f'<li style="margin:0 0 6px"><strong>{_esc(n.get("reason_code"))}</strong> — '
+			f"{_esc(n.get('remediation'))}"
+			f"{(' (' + _esc(n.get('detail')) + ')') if n.get('detail') else ''}</li>"
+			for n in coverage_notes
+		)
+		gaps = (
+			f'<div style="margin:20px 0 0"><h2 style="font-size:15px;margin:0 0 8px">Coverage gaps</h2>'
+			f'<ul style="margin:0;padding-left:18px;color:var(--jarvis-text,#111827);font-size:13px">'
+			f"{items}</ul></div>"
+		)
+
 	banner = ""
 	if coverage_note:
 		banner = (
@@ -137,7 +252,8 @@ def _fallback_dashboard_html(title: str, findings: list, counts: dict, coverage_
 		f"<title>{_esc(title)}</title></head>"
 		f'<body style="margin:0;font-family:var(--jarvis-font,system-ui,-apple-system,Segoe UI,Roboto,sans-serif);'
 		f'color:var(--jarvis-text,#111827);background:var(--jarvis-bg,#f9fafb);padding:24px">'
-		f'<h1 style="font-size:20px;margin:0 0 4px">{_esc(title)}</h1>'
+		f'<h1 style="font-size:20px;margin:0 0 8px">{_esc(title)}</h1>'
+		f"{state_block}"
 		f'<p style="margin:0 0 18px;color:var(--jarvis-muted,#6b7280);font-size:13px">'
 		f"{total} finding(s) this run.</p>"
 		f"{banner}"
@@ -145,15 +261,30 @@ def _fallback_dashboard_html(title: str, findings: list, counts: dict, coverage_
 		f'<div style="overflow-x:auto"><table style="width:100%;border-collapse:collapse;font-size:14px">'
 		f'<thead><tr style="text-align:left;color:var(--jarvis-muted,#6b7280);font-size:12px;'
 		f'text-transform:uppercase;letter-spacing:.04em">'
-		f'<th style="padding:8px 10px">Severity</th><th style="padding:8px 10px">Finding</th>'
+		f'<th style="padding:8px 10px">Severity</th><th style="padding:8px 10px">Class</th>'
+		f'<th style="padding:8px 10px">Finding</th>'
 		f'<th style="padding:8px 10px">Reference</th>'
 		f'<th style="padding:8px 10px;text-align:right">Amount</th></tr></thead>'
-		f"<tbody>{rows}</tbody></table></div></body></html>"
+		f"<tbody>{rows}</tbody></table></div>"
+		f"{gaps}{digest_block}</body></html>"
 	)
 
 
+def _visibility_owner(inst) -> str:
+	"""PP-4 — WHO may see this installation's outputs. While ``shadow`` the named
+	reviewer alone sees the findings/dashboards/activity (not the general owner
+	surface, not any customer-facing attestation); once ``live`` the installer owner
+	sees them. The agent permission-query hooks (``agent_permissions``) and the
+	dashboard scope condition both gate reads on the row ``owner``/``target_user``,
+	so re-homing the persisted rows to THIS identity is what enforces shadow
+	visibility on every read path — the SPA, the Desk, and generic REST alike."""
+	if (inst.get("activation_state") or "shadow") == "shadow":
+		return inst.get("reviewer") or inst.owner
+	return inst.owner
+
+
 def persist_agent_dashboard(
-	run_doc, inst, html: str, *, title=None, description=None, set_on_run: bool = True
+	run_doc, inst, html: str, *, title=None, description=None, set_on_run: bool = True, owner_override=None
 ) -> str:
 	"""Create ONE ``Jarvis Dashboard`` from a self-contained HTML document and
 	(by default) link it on the Run.
@@ -164,8 +295,13 @@ def persist_agent_dashboard(
 	the (possibly service-account) run_as_user. User-scoped, Static (no live
 	sources → no query specs that could leak rule shape; the summary is
 	self-contained). The controller enforces the html/title caps + CSP contract.
-	Returns the new dashboard name."""
-	owner = inst.owner
+	Returns the new dashboard name.
+
+	PP-4: ``owner_override`` re-homes the saved dashboard to the reviewer while the
+	installation is in shadow (so ``_validate_scope`` pins ``target_user`` to the
+	reviewer and the owner surface never shows a shadow dashboard); it defaults to
+	the installer owner for a live installation."""
+	owner = owner_override or inst.owner
 	listing_title = frappe.db.get_value(LISTING, run_doc.agent, "title") or run_doc.agent
 	dash_title = (title or "").strip()[:140] or _default_dashboard_title(run_doc, listing_title)
 
@@ -254,17 +390,111 @@ def _reassign_owner(doctype: str, name: str, owner: str) -> None:
 # auto-resolve is coverage-scoped and gated (drift / scoped / under-read), so it
 # never silently closes real blockers a chunk-scoped/partial run never observed.
 # --------------------------------------------------------------------------- #
+def _parse_legacy_coverage(st: str) -> tuple[str, str | None, str]:
+	"""Map a legacy free-string per-token coverage value to
+	``(state, reason_code_or_None, detail)``. Handles ``evaluated``,
+	``not_evaluable`` / ``not_evaluable(<reason>)``, ``truncated`` and any other
+	free string (treated as a not_evaluable whose raw text is preserved as
+	``detail`` so PP-3 fail-safe coercion keeps it)."""
+	if st == "evaluated":
+		return "evaluated", None, ""
+	if st.startswith("truncated"):
+		return "truncated", "run_truncated_watermark", ""
+	if st.startswith("not_evaluable"):
+		inner = ""
+		if "(" in st and st.endswith(")"):
+			inner = st[st.index("(") + 1 : -1].strip()
+		return "not_evaluable", (inner or None), ""
+	# an unrecognised free string — keep it, let coerce_reason_code preserve it.
+	return "not_evaluable", st, ""
+
+
+# PP-3: each placeholdered reason-code template names ONE substitution key; the
+# typed coverage manifest's ``detail`` is the concrete subject that fills it (the
+# app name, the setting, the doctype, ...). Threading it here — with a neutral noun
+# when the evaluator supplied no detail — is what stops the LITERAL ``{app}`` /
+# ``{setting}`` brace-string leaking to the customer in the coverage-gap remediation
+# text (``remediation_for`` called with no fmt renders the raw, unsubstituted brace).
+_REASON_PLACEHOLDER = {
+	"app_absent_or_ineligible": ("app", "the required app"),
+	"configuration_missing": ("setting", "the required setting"),
+	"record_coverage_insufficient": ("records", "records"),
+	"source_stale": ("source", "source"),
+	"external_evidence_absent": ("evidence", "the required evidence"),
+	"unsupported_customisation": ("doctype", "this doctype"),
+}
+
+
+def _remediation_text(reason_code: str, detail: str = "") -> str:
+	"""Customer-facing PP-3 remediation for a reason code, with its ``{...}``
+	placeholder filled from the typed manifest ``detail`` (a neutral noun when the
+	evaluator supplied none) so a literal ``{app}`` / ``{setting}`` brace NEVER
+	reaches the customer. Reason codes without a placeholder pass straight through."""
+	slot = _REASON_PLACEHOLDER.get(reason_code)
+	if not slot:
+		return cr.remediation_for(reason_code)
+	key, default = slot
+	subject = (detail or "").strip() or default
+	return cr.remediation_for(reason_code, **{key: subject})
+
+
+def _listing_rule_tokens(agent: str) -> set:
+	"""The agent's DECLARED opaque rule-token manifest (``Jarvis Agent Listing.
+	rule_tokens``) — the AUTHORITATIVE required-check set for the PP-2 coverage
+	verdict. Sourcing the required tokens from the listing here (NOT from the
+	writeback-supplied coverage keys) is what stops a delegate under-reporting its
+	coverage to earn a false ``evaluated_clean``: a declared token the run never
+	returns ``evaluated`` is un-evaluated required coverage. Empty for operators /
+	legacy agents (no rule tokens -> no coverage bar to fail)."""
+	import json as _json
+
+	raw = frappe.db.get_value(LISTING, agent, "rule_tokens")
+	if not raw:
+		return set()
+	try:
+		parsed = _json.loads(raw)
+	except Exception:
+		return set()
+	return {str(t) for t in parsed if t} if isinstance(parsed, list) else set()
+
+
 def _coverage_summary(coverage: dict) -> tuple[set, list]:
-	"""(fully-evaluated token set, [not_evaluable/truncated notes]) from the
-	per-rule coverage manifest ``{token: "evaluated"|"not_evaluable(reason)"|
-	"truncated"}`` the evaluator emits (A16)."""
+	"""Resolve the per-check coverage manifest into
+	``(fully-evaluated token set, [typed not_evaluable/truncated notes])`` (PP-3).
+
+	Each manifest value is either the typed form
+	``{state, reason_code, detail}`` or the legacy string form
+	``{token: "evaluated"|"not_evaluable(reason)"|"truncated"}``. A non-``evaluated``
+	token yields a typed note dict carrying the closed PP-3 ``reason_code`` (an
+	unknown code is coerced to ``unsupported_customisation`` with the raw string in
+	``detail`` — never dropped) plus its customer remediation, retryability and
+	support routing, so the dashboard / support UI / telemetry all read one shape."""
 	evaluated, notes = set(), []
-	for token, state in (coverage or {}).items():
-		st = str(state or "")
-		if st == "evaluated":
+	for token, raw in (coverage or {}).items():
+		if isinstance(raw, dict):
+			state = str(raw.get("state") or "")
+			reason_raw = raw.get("reason_code")
+			detail = str(raw.get("detail") or "")
+		else:
+			state, reason_raw, detail = _parse_legacy_coverage(str(raw or ""))
+		if state == "evaluated":
 			evaluated.add(token)
-		elif st:
-			notes.append(f"{token}: {st}")
+			continue
+		if not state and reason_raw is None and not detail:
+			continue  # empty / unset token — no coverage signal
+		code, coerced_detail = cr.coerce_reason_code(reason_raw)
+		detail = detail or coerced_detail
+		notes.append(
+			{
+				"token": token,
+				"state": state or "not_evaluable",
+				"reason_code": code,
+				"detail": detail,
+				"remediation": _remediation_text(code, detail),
+				"retryable": cr.is_retryable(code),
+				"routing": cr.routing_for(code),
+			}
+		)
 	return evaluated, notes
 
 
@@ -389,6 +619,13 @@ def record_delegate_run(
 	inst = installation if hasattr(installation, "owner") else frappe.get_doc(INSTALLATION, installation)
 	run_doc = run if hasattr(run, "name") else frappe.get_doc(RUN, run)
 	owner = inst.owner
+	# PP-4: WHO the persisted run/findings/dashboard are re-homed to for read
+	# visibility — the reviewer while shadow, the installer once live. The row
+	# ``owner`` is the single axis the agent permission hooks scope on, so this
+	# reassignment IS the shadow-visibility enforcement (owner cannot read shadow
+	# output; the named reviewer can).
+	shadow = (inst.get("activation_state") or "shadow") == "shadow"
+	visibility_owner = _visibility_owner(inst)
 	agent = inst.agent
 	coverage = coverage or {}
 	scope = scope or {}
@@ -420,6 +657,12 @@ def record_delegate_run(
 			frappe.db.set_value(FINDING, existing, "last_seen_run", run_doc.name, update_modified=False)
 			continue
 
+		# PP-1: the epistemic class + its class-conditional metadata, already
+		# validated by the tool (result_class in-enum, never confirmed_outcome, and
+		# the required candidate/legal fields present). Persisted verbatim; the
+		# controller set-once guard makes result_class immutable thereafter, and
+		# confirmation_status stays ``unconfirmed`` until the PP-5 ledger moves it.
+		result_class = f.get("result_class")
 		fd = frappe.get_doc(
 			{
 				"doctype": FINDING,
@@ -429,18 +672,30 @@ def record_delegate_run(
 				# identifier never reaches the bench; fingerprint dedup keeps working.
 				"rule_id": token or "",
 				"severity": sev,
+				"result_class": result_class,
 				# A2: authored, outcome-level text only (the evaluator's fixed-template
 				# note). No as-coded threshold / carve-out text.
 				"title": note[:140],
 				"detail_md": note,
-				"section": "",
+				"section": f.get("section") or "",
+				"effective_date": _safe_date(f.get("effective_date")),
+				# derived_candidate metadata (empty for other classes).
+				"confidence": f.get("confidence"),
+				"match_basis": f.get("match_basis") or "",
+				"false_positive_path": f.get("false_positive_path") or "",
+				# legal_scenario metadata (empty for other classes).
+				"rule_version": f.get("rule_version") or "",
+				"assumptions": f.get("assumptions") or "",
+				"known_exceptions": f.get("known_exceptions") or "",
+				"source": f.get("source") or "",
+				"reviewer": f.get("reviewer") or None,
 				"ref_doctype": f.get("ref_doctype") or "",
 				"ref_name": f.get("ref_name") or "",
 				# A16: stamp the company scope so a Company-B run never auto-resolves a
 				# Company-A finding; empty legacy rows are exempt until re-seen.
 				"company": company or None,
 				"amount": f.get("amount") or 0,
-				"disclaimer": "",
+				"disclaimer": f.get("disclaimer") or "",
 				"fingerprint": fp,
 				"state": "open",
 				"first_seen_run": run_doc.name,
@@ -449,7 +704,9 @@ def record_delegate_run(
 		)
 		fd.flags.ignore_permissions = True
 		fd.insert()
-		_reassign_owner(FINDING, fd.name, owner)
+		# PP-4: re-home to the reviewer while shadow (visibility_owner), the installer
+		# once live — the row owner is what the finding read path gates on.
+		_reassign_owner(FINDING, fd.name, visibility_owner)
 
 	# --- A17 watermark recheck (FIX 2: HOISTED before the A16 gate) ------------
 	# Computed BEFORE the auto-resolve loop so it can gate it: a run that observed an
@@ -479,6 +736,16 @@ def record_delegate_run(
 	# belong to THIS run's company scope are eligible; empty-company legacy rows are
 	# exempt.
 	evaluated_tokens, coverage_notes = _coverage_summary(coverage)
+
+	# PP-2 (false-clean gate): the required-check set is the agent's DECLARED
+	# rule-token manifest (authoritative), NEVER the writeback-supplied coverage
+	# keys — a delegate under-reporting its coverage must not be able to define its
+	# own bar. A declared token the run never returned ``evaluated`` (absent from,
+	# or not_evaluable in, the coverage payload) is un-evaluated required coverage:
+	# it forces the run partial so an empty/narrow manifest can never read as clean.
+	required_tokens = _listing_rule_tokens(agent)
+	required_unevaluated = required_tokens - evaluated_tokens
+
 	if not truncated and not wm_drift and not scoped and not row_shortfall and evaluated_tokens:
 		candidates = frappe.get_all(
 			FINDING,
@@ -498,7 +765,20 @@ def record_delegate_run(
 			# legacy row, is left untouched (exempt) — never cross-company resolved.
 			if not company or not c.company or c.company != company:
 				continue
-			frappe.db.set_value(FINDING, c.name, "state", "resolved", update_modified=False)
+			# PP-5 review provenance: an A16 coverage-scoped auto-resolve is machine,
+			# not human — stamp resolution_kind + resolved_at so a coverage close is
+			# forever separable from a person acknowledging the finding (which stamps
+			# resolution_kind = human + resolved_by).
+			frappe.db.set_value(
+				FINDING,
+				c.name,
+				{
+					"state": "resolved",
+					"resolution_kind": "auto_coverage",
+					"resolved_at": frappe.utils.now(),
+				},
+				update_modified=False,
+			)
 
 	# --- status + coverage note ------------------------------------------------
 	dropped_notes = [
@@ -507,6 +787,23 @@ def record_delegate_run(
 	]
 	partial = bool(truncated) or wm_drift or scoped or row_shortfall or bool(dropped) or bool(coverage_notes)
 	status = "partial" if partial else "completed"
+
+	# PP-2: resolve EXACTLY one coverage-verdict run_state from the DECLARED required
+	# checks. This is a SEPARATE axis from the execution-lifecycle ``status`` (which
+	# stays ``completed`` for a run that finished executing) — a run can complete yet
+	# leave required coverage incomplete. ``required_tokens`` is the agent's declared
+	# manifest (resolved above, NOT the writeback coverage keys, so a delegate cannot
+	# under-report to define its own bar): all-required-unevaluated -> not_evaluable;
+	# some required token unevaluated -> partial; else evaluated_clean. A declared
+	# required token the run never evaluated drives the coverage verdict off
+	# ``evaluated_clean`` WITHOUT touching ``status``. "No exceptions" is unreachable
+	# unless evaluated_clean.
+	result_state = cr.resolve_run_state(
+		required_tokens=required_tokens,
+		evaluated_tokens=evaluated_tokens,
+		partial=partial or bool(required_unevaluated),
+		failed=False,
+	)
 
 	note_parts = []
 	if truncated:
@@ -518,7 +815,18 @@ def record_delegate_run(
 	if row_shortfall:
 		note_parts.append("ledger under-read vs watermark — re-run advised")
 	if coverage_notes:
-		note_parts.append("not evaluable: " + "; ".join(coverage_notes))
+		# PP-3: surface the CUSTOMER remediation sentence (placeholder-filled) that the
+		# amber "Partial scan — {coverageNote}" banner reads day to day, NOT the raw
+		# internal reason-code enum slug.
+		note_parts.append(
+			"not evaluable: " + "; ".join(f"{n['token']}: {n['remediation']}" for n in coverage_notes)
+		)
+	# PP-2: a DECLARED required token entirely omitted from the coverage manifest
+	# (no evaluator note of its own) still made the run partial — name the shortfall
+	# so the banner is not silently blank when that is the only reason for partial.
+	absent_required = required_unevaluated - {n["token"] for n in coverage_notes}
+	if absent_required:
+		note_parts.append(f"{len(absent_required)} required check(s) not evaluated this run")
 	if dropped_notes:
 		note_parts.append("dropped: " + "; ".join(dropped_notes))
 	coverage_note = " | ".join(note_parts)
@@ -531,6 +839,8 @@ def record_delegate_run(
 	coverage_blob = _json.dumps(
 		{
 			"coverage": coverage,
+			"required_tokens": sorted(required_tokens),
+			"result_state": result_state,
 			"not_evaluable": coverage_notes,
 			"not_evaluable_scoped": sorted(evaluated_tokens) if scoped else [],
 			"dropped": dropped,
@@ -547,6 +857,7 @@ def record_delegate_run(
 
 	run_values = {
 		"status": status,
+		"result_state": result_state,
 		"findings_count": len(seen_fps),
 		"blocker_count": counts.get("blocker", 0),
 		"finished_at": frappe.utils.now(),
@@ -560,6 +871,12 @@ def record_delegate_run(
 	if canvas_ref:
 		run_values["canvas_ref"] = str(canvas_ref)[:255]
 	frappe.db.set_value(RUN, run_doc.name, run_values, update_modified=False)
+
+	# PP-4: re-home the run itself to the visibility owner (reviewer while shadow,
+	# installer once live) so the run history read path (owner-scoped) shows a shadow
+	# run only to its reviewer. Raw set_value bypasses the launch-fields controller.
+	if visibility_owner and frappe.db.get_value(RUN, run_doc.name, "owner") != visibility_owner:
+		frappe.db.set_value(RUN, run_doc.name, "owner", visibility_owner, update_modified=False)
 
 	# --- Phase 4: exactly ONE saved Jarvis Dashboard per run ------------------
 	# Precedence: (1) a dashboard the delegate already authored via
@@ -576,15 +893,31 @@ def record_delegate_run(
 	if not dashboard_name:
 		try:
 			title = _default_dashboard_title(run_doc, agent_title)
-			html = _fallback_dashboard_html(title, list(by_fp.values()), counts, coverage_note)
-			dashboard_name = persist_agent_dashboard(run_doc, inst, html, title=title)
+			html = _fallback_dashboard_html(
+				title,
+				list(by_fp.values()),
+				counts,
+				coverage_note,
+				result_state=result_state,
+				coverage_notes=coverage_notes,
+				# PP-4: a shadow run's fallback artifact issues no outward clean/compliant
+				# attestation. PP-6: stamp the evaluator integrity digest in-body.
+				shadow=shadow,
+				integrity_digest=integrity_digest,
+			)
+			dashboard_name = persist_agent_dashboard(
+				run_doc, inst, html, title=title, owner_override=visibility_owner
+			)
 		except Exception:
 			frappe.log_error(
 				title="jarvis agent: fallback dashboard build failed",
 				message=frappe.get_traceback(),
 			)
 
-	# Activity trail (best-effort, owner-scoped, Link-free) + owner notification.
+	# Activity trail (best-effort, Link-free) + completion notification. PP-4: the
+	# completion row + bell carry finding COUNTS, so in shadow they go to the reviewer
+	# (visibility_owner), never the general owner surface — the owner sees the
+	# preview's results only after promotion re-homes them.
 	log_activity(
 		agent=agent,
 		agent_title=agent_title,
@@ -594,11 +927,17 @@ def record_delegate_run(
 		detail=f"{len(seen_fps)} findings, {counts.get('blocker', 0)} blockers"
 		+ (f"; {coverage_note}" if coverage_note else "")
 		+ (f"; dashboard {dashboard_name}" if dashboard_name else ""),
-		owner=owner,
+		owner=visibility_owner,
 	)
 	if dashboard_name:
 		_notify_owner_dashboard(
-			owner, run_doc.name, dashboard_name, agent_title, status, len(seen_fps), counts.get("blocker", 0)
+			visibility_owner,
+			run_doc.name,
+			dashboard_name,
+			agent_title,
+			status,
+			len(seen_fps),
+			counts.get("blocker", 0),
 		)
 
 	# A8 (zero-trace): the per-run session bearer must not outlive the run.

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -222,6 +222,23 @@ def _launch_audit(inst, trigger: str) -> dict:
 	conv.flags.ignore_permissions = True
 	conv.insert()
 
+	# PP-5: the run's IMMUTABLE launch-time provenance, stamped once at insert (the
+	# controller's _IMMUTABLE_LAUNCH_FIELDS guard refuses any later ORM change):
+	#   * bundle_version — a SNAPSHOT of the version this run actually executes, taken
+	#     from the installation's installed_version (falling back to the listing) so it
+	#     is fixed even though the listing/installation versions are mutable.
+	#   * preparation_mode — a snapshot of the installation's activation_state
+	#     (shadow|live) at launch, so a run made in shadow is forever attributable as
+	#     such even after the install is later promoted.
+	#   * initiating_human — the human who triggered a MANUAL run; None for a
+	#     scheduled cron run (no human initiated it). On the manual path the caller has
+	#     switched the session to the run-as user, so frappe.session.user is the
+	#     triggering human ONLY on a self-mapped install (run_as == triggerer); see the
+	#     cross-file note for the run_as != triggerer case.
+	bundle_version = inst.installed_version or listing.version or None
+	preparation_mode = inst.activation_state or "shadow"
+	initiating_human = frappe.session.user if trigger == "manual" else None
+
 	run = frappe.get_doc(
 		{
 			"doctype": RUN,
@@ -231,6 +248,9 @@ def _launch_audit(inst, trigger: str) -> dict:
 			"status": "running",
 			"conversation": conv.name,
 			"started_at": frappe.utils.now(),
+			"bundle_version": bundle_version,
+			"preparation_mode": preparation_mode,
+			"initiating_human": initiating_human,
 		}
 	)
 	run.flags.ignore_permissions = True

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -17,6 +17,7 @@ import frappe
 from frappe import _
 
 from jarvis._session import impersonate
+from jarvis.chat import coverage_reasons as cr
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.agent_catalog import build_agent_push_payload
 from jarvis.chat.filebox import _clamp_page, _lk
@@ -32,8 +33,16 @@ INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
 FINDING = "Jarvis Agent Finding"
 ACTIVITY = "Jarvis Agent Activity"
+DASHBOARD = "Jarvis Dashboard"
+PROVENANCE = "Jarvis Agent Provenance Event"
 ALLOWED_ROLE = "Jarvis Agent Allowed Role"
 _SETTINGS = "Jarvis Settings"
+
+# PP-6 — the stage-maximum global activation ceiling. The initial ceiling is 1
+# (every customer starts with a single live module); a Jarvis Admin may raise it
+# to 2 (this maximum) with a recorded reviewer-capacity justification. No path to
+# 3+ exists at this stage.
+_ACTIVATION_CEILING_MAX = 2
 _PUSH_JOB_ID = "jarvis_agent_skills_push"
 _LOCK_NAME = "jarvis_agent_skills_push"
 
@@ -343,6 +352,13 @@ def get_installations() -> list[dict]:
 			"name",
 			"agent",
 			"enabled",
+			# PP-4: the activation state + named reviewer + promotion stamp so the SPA
+			# can surface a customer's SHADOW installations as a distinct set and wire the
+			# promote/demote actions (the reviewer's "one clear action") to them.
+			"activation_state",
+			"reviewer",
+			"promoted_by",
+			"promoted_at",
 			"installed_version",
 			"installed_at",
 			"config",
@@ -564,6 +580,12 @@ def install_agent(agent_slug: str) -> dict:
 			# which the controller's escalation guard always permits. An admin may
 			# retarget it later via set_run_as_user.
 			"run_as_user": me,
+			# PP-4: every capability activates per customer in preview/SHADOW first,
+			# with the installer as the initial named reviewer (retargetable by an
+			# admin). The controller also defaults reviewer + forbids a non-shadow
+			# birth, but set it explicitly here so the install intent is on the record.
+			"activation_state": "shadow",
+			"reviewer": me,
 			"installed_version": listing.version,
 			"installed_at": frappe.utils.now(),
 			"schedule_enabled": int(sched.get("schedule_enabled") or 0),
@@ -725,13 +747,30 @@ def uninstall_agent(installation: str) -> dict:
 		installation=doc.name,
 		action="uninstalled",
 	)
-	run_names = frappe.get_all(RUN, filters={"installation": doc.name}, pluck="name")
+	# PP-4: a shadow installation's runs/findings are re-homed to the REVIEWER (not
+	# the installer owner), so the owner-scoped permission-query hook would hide them
+	# from this owner-initiated cascade and leave orphans that block the delete.
+	# ignore_permissions here finds every row regardless of its current visibility
+	# owner; the delete itself is already ignore_permissions + owner-gated above.
+	run_names = frappe.get_all(RUN, filters={"installation": doc.name}, pluck="name", ignore_permissions=True)
+	# Findings for this install are owned by the installer (live) OR the reviewer
+	# (shadow) — cover both, plus (belt-and-braces) any finding whose run pointers
+	# land in this install's runs.
 	finding_names = set(
-		frappe.get_all(FINDING, filters={"owner": doc.owner, "agent": doc.agent}, pluck="name")
+		frappe.get_all(
+			FINDING,
+			filters={"agent": doc.agent, "owner": ["in", [doc.owner, doc.reviewer]]},
+			pluck="name",
+			ignore_permissions=True,
+		)
 	)
 	if run_names:
 		for field in ("run", "first_seen_run", "last_seen_run"):
-			finding_names.update(frappe.get_all(FINDING, filters={field: ["in", run_names]}, pluck="name"))
+			finding_names.update(
+				frappe.get_all(
+					FINDING, filters={field: ["in", run_names]}, pluck="name", ignore_permissions=True
+				)
+			)
 	for name in finding_names:
 		frappe.delete_doc(FINDING, name, ignore_permissions=True, force=True)
 	for name in run_names:
@@ -807,6 +846,297 @@ def run_agent_now(installation: str) -> dict:
 			doc = frappe.get_doc(INSTALLATION, installation)  # re-fetch under run_as
 		result = _launch_audit(doc, trigger="manual")
 	return {"ok": True, "data": result}
+
+
+# --------------------------------------------------------------------------- #
+# PP-4 shadow activation + PP-6 global activation budget
+# --------------------------------------------------------------------------- #
+def _has_ceiling_grant(customer: str) -> bool:
+	"""PP-6 — True iff a Jarvis Admin has recorded an ``activation_ceiling_raised``
+	provenance grant BOUND TO THIS CUSTOMER. The grant is stored on the append-only
+	ledger, keyed to the customer via ``result_link_doctype='User' / result_link_name
+	=<owner>`` — never a global singleton — so a raise justified by ONE customer's
+	reviewer can never silently unlock a second live module for every other customer
+	on the site (the exact detachment the global-singleton read caused)."""
+	if not customer:
+		return False
+	return bool(
+		frappe.db.exists(
+			PROVENANCE,
+			{
+				"event_type": "activation_ceiling_raised",
+				"result_link_doctype": "User",
+				"result_link_name": customer,
+			},
+		)
+	)
+
+
+def _activation_ceiling(customer: str) -> int:
+	"""PP-6 — the LIVE-module ceiling FOR THIS CUSTOMER. Base 1 (every customer starts
+	with a single live module); raised to the stage maximum only for a customer who
+	has a recorded per-customer grant (``_has_ceiling_grant``). Per-customer, never a
+	site-wide singleton — the budget is a per-customer ceiling (Round-4 condition 2),
+	so its raise must bind to the customer it was justified for."""
+	return _ACTIVATION_CEILING_MAX if _has_ceiling_grant(customer) else 1
+
+
+def _verify_reviewer_two_pack_capacity(customer: str) -> str:
+	"""PP-6 reviewer-capacity gate (system-verified, not free text): a second live
+	module needs a named reviewer who can own it, so require this customer to have a
+	single named ``reviewer`` who is the reviewer-of-record across installations
+	spanning at least TWO DISTINCT packs. Returns that reviewer; throws if none
+	qualifies. Pack identity is the listing ``rule_pack`` (falling back to the agent
+	slug when a listing declares no pack), so two distinct agents count as two packs."""
+	rows = frappe.get_all(INSTALLATION, filters={"owner": customer}, fields=["reviewer", "agent"])
+	packs_by_reviewer: dict[str, set] = {}
+	for r in rows:
+		if not r.reviewer:
+			continue
+		pack = frappe.db.get_value(LISTING, r.agent, "rule_pack") or r.agent
+		packs_by_reviewer.setdefault(r.reviewer, set()).add(pack)
+	for reviewer, packs in packs_by_reviewer.items():
+		if len(packs) >= 2:
+			return reviewer
+	frappe.throw(
+		_(
+			"No named reviewer for this customer covers two packs. A second live module "
+			"needs a reviewer who is the reviewer-of-record on installations spanning at "
+			"least two distinct packs before the activation ceiling may be raised."
+		)
+	)
+
+
+def _append_provenance_event(**fields) -> str:
+	"""PP-5 — append ONE immutable provenance event. The controller enforces
+	append-only + stamps ``occurred_at``; this is the only ledger writer Phase C
+	needs (``agent_promoted_to_live`` on promotion, ``activation_ceiling_raised`` on
+	a budget raise). ignore_permissions — trusted server infrastructure, exactly
+	like the finding/run inserts (the ledger perm grants create to System Manager
+	only, but a reviewer/admin action legitimately records one)."""
+	doc = frappe.get_doc({"doctype": PROVENANCE, **fields})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _rehome_installation_outputs(inst, to_owner: str) -> None:
+	"""PP-4 — move the VISIBILITY ownership of this installation's already-persisted
+	runs / findings / dashboards / activity to ``to_owner``: the reviewer while
+	shadow, the installer once promoted to live. The agent permission-query hooks
+	and the dashboard scope condition gate reads on ``owner``/``target_user``, so
+	re-homing is how promotion OPENS the owner surface (and demotion re-closes it).
+	Raw ``db.set_value`` bypasses the finding/run immutability controllers. Rows are
+	located precisely by installation membership (never a broad owner+agent match
+	that could sweep a different install of the same agent)."""
+	run_names = frappe.get_all(
+		RUN, filters={"installation": inst.name}, pluck="name", ignore_permissions=True
+	)
+	dash_names, finding_names = set(), set()
+	if run_names:
+		for r in frappe.get_all(
+			RUN, filters={"name": ["in", run_names]}, fields=["dashboard"], ignore_permissions=True
+		):
+			if r.dashboard:
+				dash_names.add(r.dashboard)
+		for field in ("run", "first_seen_run", "last_seen_run"):
+			finding_names.update(
+				frappe.get_all(
+					FINDING, filters={field: ["in", run_names]}, pluck="name", ignore_permissions=True
+				)
+			)
+	for rn in run_names:
+		frappe.db.set_value(RUN, rn, "owner", to_owner, update_modified=False)
+	for fn in finding_names:
+		frappe.db.set_value(FINDING, fn, "owner", to_owner, update_modified=False)
+	for dn in dash_names:
+		frappe.db.set_value(
+			DASHBOARD, dn, {"owner": to_owner, "target_user": to_owner}, update_modified=False
+		)
+	for an in frappe.get_all(
+		ACTIVITY, filters={"installation": inst.name}, pluck="name", ignore_permissions=True
+	):
+		frappe.db.set_value(ACTIVITY, an, "owner", to_owner, update_modified=False)
+
+
+@frappe.whitelist()
+def promote_installation(installation: str, justification: str | None = None) -> dict:
+	"""PP-4 — promote a shadow installation to LIVE by the named reviewer's explicit
+	sign-off. This is the SINGLE choke point PP-4 (calibration) and PP-6 (budget)
+	both enforce:
+
+	  * Authority: the named ``reviewer`` (their sign-off), or an authorised approver
+	    (Jarvis Admin / System Manager). NOT the owner surface — ``check_permission``
+	    gates on ``if_owner`` and the reviewer may not be the owner, so authority is
+	    checked explicitly here.
+	  * PP-6 budget: refuse when this customer already has ``activation_module_ceiling``
+	    live modules (global across all packs, per customer; default 1).
+	  * Records who/when (``promoted_by``/``promoted_at``, track_changes audited) and
+	    writes an append-only ``agent_promoted_to_live`` provenance event.
+	  * Re-homes the installation's runs/findings/dashboards to the owner so the
+	    owner surface + attestation become available only AFTER sign-off."""
+	from jarvis._redis_lock import redis_lock
+
+	doc = frappe.get_doc(INSTALLATION, installation)
+	me = frappe.session.user
+	if me != doc.reviewer and not has_jarvis_admin_access(me):
+		frappe.throw(
+			_("Only the named reviewer or a Jarvis Admin may promote this installation to live."),
+			frappe.PermissionError,
+		)
+	if doc.activation_state == "live":
+		frappe.throw(_("This installation is already live."))
+
+	# PP-6 activation-budget enforcement must be RACE-FREE: the read-check-flip below
+	# (count live -> compare to ceiling -> save live) is a TOCTOU window. Two concurrent
+	# promotions for the same customer would both read live_count=0 against ceiling 1 and
+	# both flip to live, exceeding the per-customer ceiling. Serialize every activation
+	# change for a customer on a redis lock keyed on the OWNER, and — inside the lock —
+	# force a fresh transaction snapshot (``commit`` ends the REPEATABLE-READ snapshot the
+	# earlier ``get_doc`` opened, so the count reflects any promotion another request has
+	# committed) before re-reading state and re-checking the ceiling.
+	owner = doc.owner
+	with redis_lock(f"jarvis_agent_activation:{owner}", timeout_s=30, blocking_timeout_s=10.0) as acquired:
+		if not acquired:
+			frappe.throw(
+				_("Another activation change for this customer is in progress — please retry in a moment.")
+			)
+		frappe.db.commit()  # fresh snapshot under the lock (defeats stale REPEATABLE-READ count)
+		doc = frappe.get_doc(INSTALLATION, installation)  # re-read the row under the lock
+		if doc.activation_state == "live":
+			frappe.throw(_("This installation is already live."))
+
+		ceiling = _activation_ceiling(owner)
+		live_count = frappe.db.count(INSTALLATION, {"owner": owner, "activation_state": "live"})
+		if live_count >= ceiling:
+			frappe.throw(
+				_(
+					"Activation budget reached: this customer already has {0} live module(s) and the "
+					"activation ceiling is {1}. The initial budget is a single live module; a Jarvis Admin "
+					"can raise the ceiling to {2} once the reviewer covers a second pack."
+				).format(live_count, ceiling, _ACTIVATION_CEILING_MAX)
+			)
+
+		doc.activation_state = "live"
+		doc.promoted_by = me
+		doc.promoted_at = frappe.utils.now()
+		doc.flags.promoting = True  # authorises the shadow->live transition guard
+		doc.save(ignore_permissions=True)
+
+		_rehome_installation_outputs(doc, owner)
+		event = _append_provenance_event(
+			event_type="agent_promoted_to_live",
+			agent=doc.agent,
+			installation=doc.name,
+			preparation_mode="live",
+			reviewing_human=me,
+			detail=((justification or "").strip()[:500] or None),
+		)
+		log_activity(
+			agent=doc.agent,
+			agent_title=frappe.db.get_value(LISTING, doc.agent, "title"),
+			installation=doc.name,
+			action="promoted_to_live",
+			detail=f"signed off by {me}",
+			owner=owner,
+		)
+		frappe.db.commit()
+	return {
+		"ok": True,
+		"data": {
+			"name": doc.name,
+			"activation_state": "live",
+			"promoted_by": me,
+			"promoted_at": str(doc.promoted_at),
+			"provenance_event": event,
+		},
+	}
+
+
+@frappe.whitelist()
+def demote_installation(installation: str, reason: str | None = None) -> dict:
+	"""PP-4 — the demotion / kill path: send a live installation back to SHADOW
+	(re-closing the owner surface, freeing a global activation-budget slot). Same
+	authority as promotion (named reviewer or a Jarvis Admin). Clears the promotion
+	stamp and re-homes outputs back to the reviewer-only surface; audited via
+	track_changes + the activity feed."""
+	doc = frappe.get_doc(INSTALLATION, installation)
+	me = frappe.session.user
+	if me != doc.reviewer and not has_jarvis_admin_access(me):
+		frappe.throw(
+			_("Only the named reviewer or a Jarvis Admin may demote this installation."),
+			frappe.PermissionError,
+		)
+	if doc.activation_state != "live":
+		frappe.throw(_("This installation is not live."))
+	doc.activation_state = "shadow"
+	doc.promoted_by = None
+	doc.promoted_at = None
+	doc.flags.demoting = True  # authorises the live->shadow transition guard
+	doc.save(ignore_permissions=True)
+	_rehome_installation_outputs(doc, doc.reviewer or doc.owner)
+	log_activity(
+		agent=doc.agent,
+		agent_title=frappe.db.get_value(LISTING, doc.agent, "title"),
+		installation=doc.name,
+		action="demoted_to_shadow",
+		detail=((reason or "").strip()[:140] or f"by {me}"),
+		owner=doc.owner,
+	)
+	frappe.db.commit()
+	return {"ok": True, "data": {"name": doc.name, "activation_state": "shadow"}}
+
+
+@frappe.whitelist()
+def raise_activation_ceiling(customer: str, justification: str, new_ceiling: int = 2) -> dict:
+	"""PP-6 — raise the activation ceiling from 1 to 2 (the stage maximum) FOR ONE
+	NAMED CUSTOMER. Restricted to a Jarvis Admin. The raise is per-customer, never a
+	site-wide singleton: it must name the ``customer`` (owner) being raised, is granted
+	only when that customer's named reviewer is system-verified to cover two packs'
+	competency (``_verify_reviewer_two_pack_capacity`` — the reviewer-capacity signal,
+	not a free-text claim), and is recorded as an append-only ``activation_ceiling_raised``
+	provenance event bound to the customer (who / when / customer / reviewer /
+	justification / new ceiling). Any value above 2 is rejected — no path to 3+ here."""
+	require_jarvis_admin()
+	just = (justification or "").strip()
+	if not just:
+		frappe.throw(_("A reviewer-capacity justification is required to raise the activation ceiling."))
+	nc = frappe.utils.cint(new_ceiling)
+	if nc != _ACTIVATION_CEILING_MAX:
+		frappe.throw(
+			_("The activation ceiling may be raised only to {0} (the stage maximum).").format(
+				_ACTIVATION_CEILING_MAX
+			)
+		)
+	customer = (customer or "").strip()
+	if not customer or not frappe.db.exists("User", customer):
+		frappe.throw(_("Name the customer (installation owner) whose activation ceiling is being raised."))
+	# System-verified reviewer-capacity gate (not just a free-text justification): a
+	# second live module needs a named reviewer who can own it.
+	reviewer = _verify_reviewer_two_pack_capacity(customer)
+	me = frappe.session.user
+	# The grant lives ONLY on the append-only ledger, bound to this customer via
+	# result_link_doctype/name — no global singleton is written, so the raise cannot
+	# leak a second live module to any other customer. Idempotent: one grant per
+	# customer already lifts _activation_ceiling(customer) to the maximum.
+	event = _append_provenance_event(
+		event_type="activation_ceiling_raised",
+		initiating_human=me,
+		reviewing_human=reviewer,
+		result_link_doctype="User",
+		result_link_name=customer,
+		detail=f"activation_module_ceiling -> {nc} for {customer}; reviewer {reviewer}; {just}"[:500],
+	)
+	frappe.db.commit()
+	return {
+		"ok": True,
+		"data": {
+			"customer": customer,
+			"reviewer": reviewer,
+			"activation_module_ceiling": nc,
+			"provenance_event": event,
+		},
+	}
 
 
 # --------------------------------------------------------------------------- #
@@ -999,6 +1329,21 @@ def list_findings(
 			"agent",
 			"rule_id",
 			"severity",
+			# PP-1: the immutable result class + its class-conditional metadata ride on
+			# EVERY read row so the SPA can label the class beside the amount and mark a
+			# derived_candidate / legal_scenario as unconfirmed — a candidate must never
+			# render indistinguishable from an observed_fact on the primary triage surface.
+			"result_class",
+			"confidence",
+			"match_basis",
+			"false_positive_path",
+			"confirmation_status",
+			"rule_version",
+			"assumptions",
+			"known_exceptions",
+			"source",
+			"reviewer",
+			"outcome_provenance",
 			"title",
 			"detail_md",
 			"section",
@@ -1019,6 +1364,18 @@ def list_findings(
 	# Derived recurrence label: dedupe only ever bumps ``last_seen_run`` while a
 	# finding stays open, so a span wider than one run means it recurred.
 	for r in rows:
+		# PP-1 strong-verb gate on the READ path (angle-6): the stored authored
+		# ``title``/``detail_md`` is served through the SAME shared helper the fallback
+		# dashboard uses, so a "saved/recovered/prevented" token on any row that is NOT a
+		# confirmed_outcome with a resolving provenance link is neutralised server-side —
+		# no read surface (this list, FindingsPanel's v-html) can emit an unearned strong
+		# verb, and the guard holds by construction, not author discipline.
+		_rc = r.get("result_class")
+		_op = r.get("outcome_provenance")
+		if r.get("title"):
+			r["title"] = cr.render_value_text(r["title"], _rc, outcome_provenance=_op)
+		if r.get("detail_md"):
+			r["detail_md"] = cr.render_value_text(r["detail_md"], _rc, outcome_provenance=_op)
 		if r.state == "resolved":
 			r["recurrence"] = "resolved"
 		elif r.first_seen_run and r.first_seen_run != r.last_seen_run:

--- a/jarvis/chat/coverage_reasons.py
+++ b/jarvis/chat/coverage_reasons.py
@@ -1,0 +1,320 @@
+"""Shared platform enums for the agent result grammar (PP-1 / PP-2 / PP-3).
+
+This module is the SINGLE source of truth for the three closed enums the
+platform prerequisites introduce, so the enum can never drift between the
+doctype schema (the ``Select`` ``options`` strings), the writeback validators,
+the dashboard render layer, the support UI, and telemetry — all of which read
+from here:
+
+  * PP-1 — ``RESULT_CLASSES``: the four-class value grammar every value-bearing
+    result carries (``00-MASTER-PLAN.md`` §6). ``confirmed_outcome`` is reserved
+    for the PP-5 provenance ledger and may never be emitted by an evaluator.
+  * PP-2 — ``RUN_STATES``: the coverage-verdict axis (distinct from the
+    execution-lifecycle ``status``) that decides whether a clean conclusion is
+    warranted.
+  * PP-3 — ``REASON_CODES``: the closed, typed ``not_evaluable`` reason-code
+    registry, each code carrying customer remediation text, a retryability flag,
+    and support-routing metadata.
+
+Every ``Select`` in the corresponding doctype JSON derives its ``options`` from
+the tuples below (kept byte-for-byte in sync via ``select_options``); the
+runtime enforcement (set-once validation, writeback drops, strong-verb gating,
+the render layer) is layered on top of these definitions in later phases.
+"""
+
+import re
+
+# --------------------------------------------------------------------------- #
+# PP-1 — result classes (the four-class value grammar)
+# --------------------------------------------------------------------------- #
+RESULT_CLASSES = (
+	"observed_fact",
+	"derived_candidate",
+	"legal_scenario",
+	"confirmed_outcome",
+)
+
+#: The class an evaluator may NOT emit. It is written ONLY by the PP-5
+#: provenance ledger, from an accepted recovery / avoided-payment / completed
+#: remediation with a resolving ``outcome_provenance`` link. The finding
+#: writeback drops any evaluator row carrying it.
+RESERVED_RESULT_CLASS = "confirmed_outcome"
+
+#: The only ungated class — a direct read from declared records; no extra
+#: metadata required. Used as the conservative backfill for legacy fact rows.
+DEFAULT_RESULT_CLASS = "observed_fact"
+
+#: Per-class REQUIRED metadata fieldnames. A writeback row whose class is
+#: ``derived_candidate`` / ``legal_scenario`` and that is missing ANY of these
+#: is dropped (forces the run partial, names the rejected ref). ``observed_fact``
+#: needs nothing; ``confirmed_outcome`` is never evaluator-emitted (it needs an
+#: ``outcome_provenance`` link, supplied only by the ledger).
+RESULT_CLASS_REQUIRED_FIELDS = {
+	"observed_fact": (),
+	"derived_candidate": ("confidence", "match_basis", "false_positive_path"),
+	"legal_scenario": ("rule_version", "source", "reviewer"),
+	"confirmed_outcome": ("outcome_provenance",),
+}
+
+#: Confirmation lifecycle for ``derived_candidate`` findings. Only the PP-5
+#: ledger may move a finding off ``unconfirmed``.
+CONFIRMATION_STATUSES = (
+	"unconfirmed",
+	"confirmed",
+	"rejected",
+)
+
+#: The strong verbs that may render ONLY for a ``confirmed_outcome`` row with a
+#: resolving ``outcome_provenance``. For every other class the shared render
+#: helper (later phase) refuses the token rather than trusting author discipline.
+STRONG_VERBS = (
+	"saved",
+	"recovered",
+	"prevented",
+	"actually paid",
+	"replaces",
+)
+
+
+# --------------------------------------------------------------------------- #
+# PP-2 — coverage-verdict run states
+# --------------------------------------------------------------------------- #
+RUN_STATES = (
+	"evaluated_clean",  # every required rule evaluated AND no findings
+	"partial",  # some required rules evaluated, result incomplete
+	"not_evaluable",  # no conclusion possible for the required checks
+	"failed",  # the run produced no result (exec failure)
+)
+
+#: The ONLY run state under which "no exceptions were found" may render.
+CLEAN_RUN_STATE = "evaluated_clean"
+
+
+# --------------------------------------------------------------------------- #
+# PP-3 — typed not_evaluable reason codes
+# --------------------------------------------------------------------------- #
+#: The closed reason-code registry. Each entry carries:
+#:   meaning     — internal description
+#:   retryable   — whether re-running (after the stated remediation) can succeed
+#:   remediation — customer-facing text; may contain ``{}`` placeholders
+#:                 (e.g. ``{app}``, ``{setting}``) filled at render time
+#:   routing     — where a persistent occurrence is routed
+REASON_CODES = {
+	"app_absent_or_ineligible": {
+		"meaning": "a min_apps dependency is not installed / edition ineligible",
+		"retryable": False,
+		"remediation": "This capability needs {app}; it is not installed on your site.",
+		"routing": "install/onboarding",
+	},
+	"permission_slice": {
+		"meaning": "the run-as identity is record-sliced (A12 scoped_visibility)",
+		"retryable": True,
+		"remediation": "The scheduled user only sees part of the ledger; findings are limited to that slice.",
+		"routing": "admin/permissions",
+	},
+	"configuration_missing": {
+		"meaning": "a required setting/master is unconfigured",
+		"retryable": True,
+		"remediation": "Configure {setting} to evaluate this check.",
+		"routing": "config/support",
+	},
+	"record_coverage_insufficient": {
+		"meaning": "too few in-scope records to conclude",
+		"retryable": True,
+		"remediation": "Not enough {records} in scope this period to evaluate.",
+		"routing": "none/informational",
+	},
+	"source_stale": {
+		"meaning": "an input source is behind its freshness watermark",
+		"retryable": True,
+		"remediation": "The {source} data is stale; refresh and re-run.",
+		"routing": "data/support",
+	},
+	"rule_expired": {
+		"meaning": "a statutory rule set is past review/expiry (unknown applicability)",
+		"retryable": False,
+		"remediation": "This statutory rule is pending review; the check is paused.",
+		"routing": "legal-rule owner",
+	},
+	"external_evidence_absent": {
+		"meaning": "required external evidence (import artifact) not supplied",
+		"retryable": True,
+		"remediation": "Upload the {evidence} to evaluate this check.",
+		"routing": "reviewer/File-Box",
+	},
+	"run_truncated_watermark": {
+		"meaning": "fetch hit the turn budget / GL drifted mid-scan (A17)",
+		"retryable": True,
+		"remediation": "The run was truncated; re-run to complete coverage.",
+		"routing": "none/auto-retry",
+	},
+	"unsupported_customisation": {
+		"meaning": "a customer customisation the evaluator cannot safely read",
+		"retryable": False,
+		"remediation": "A customisation on {doctype} is not supported by this check.",
+		"routing": "product/support",
+	},
+}
+
+#: The fail-safe code an unknown/unmapped reason string is coerced to (never
+#: dropped silently — the raw string is preserved in the token ``detail``).
+FALLBACK_REASON_CODE = "unsupported_customisation"
+
+#: Per-token coverage states in the typed coverage manifest (PP-3).
+COVERAGE_STATES = (
+	"evaluated",
+	"not_evaluable",
+	"truncated",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — the enforcement layers (writeback, render, telemetry) call these
+# --------------------------------------------------------------------------- #
+def select_options(seq) -> str:
+	"""Render an enum tuple as a Frappe ``Select`` ``options`` string (the exact
+	value stored in the doctype JSON), so schema and code share one definition."""
+	return "\n".join(seq)
+
+
+def is_result_class(value) -> bool:
+	return value in RESULT_CLASSES
+
+
+def is_run_state(value) -> bool:
+	return value in RUN_STATES
+
+
+def is_reason_code(value) -> bool:
+	return value in REASON_CODES
+
+
+def required_metadata_for(result_class) -> tuple:
+	"""The metadata fieldnames a writeback row of this class must carry."""
+	return RESULT_CLASS_REQUIRED_FIELDS.get(result_class, ())
+
+
+def missing_metadata(result_class, row) -> list:
+	"""The subset of required metadata for ``result_class`` that ``row`` (a dict)
+	is missing or has empty. Empty list == the class contract is satisfied."""
+	out = []
+	for field in required_metadata_for(result_class):
+		val = row.get(field)
+		if val is None or (isinstance(val, str) and not val.strip()):
+			out.append(field)
+	return out
+
+
+def coerce_reason_code(raw) -> tuple:
+	"""Map a raw coverage reason to ``(reason_code, detail)`` (PP-3 fail-safe):
+	a known code passes through with empty detail; anything else becomes
+	``unsupported_customisation`` with the raw string preserved in ``detail`` —
+	never dropped."""
+	if raw in REASON_CODES:
+		return raw, ""
+	return FALLBACK_REASON_CODE, ("" if raw is None else str(raw))
+
+
+def remediation_for(reason_code, **fmt) -> str:
+	"""Customer-facing remediation text for a reason code, with any ``{...}``
+	placeholders filled from ``fmt``. Unknown placeholders are left literal so a
+	missing substitution never raises in the render path."""
+	entry = REASON_CODES.get(reason_code) or REASON_CODES[FALLBACK_REASON_CODE]
+	text = entry["remediation"]
+	if not fmt:
+		return text
+	try:
+		return text.format(**fmt)
+	except (KeyError, IndexError):
+		return text
+
+
+def is_retryable(reason_code) -> bool:
+	entry = REASON_CODES.get(reason_code) or REASON_CODES[FALLBACK_REASON_CODE]
+	return bool(entry["retryable"])
+
+
+def routing_for(reason_code) -> str:
+	entry = REASON_CODES.get(reason_code) or REASON_CODES[FALLBACK_REASON_CODE]
+	return entry["routing"]
+
+
+# --------------------------------------------------------------------------- #
+# PP-2 — coverage-verdict resolution (the ONE run_state a writeback resolves)
+# --------------------------------------------------------------------------- #
+def resolve_run_state(*, required_tokens, evaluated_tokens, partial: bool, failed: bool = False) -> str:
+	"""Resolve EXACTLY one PP-2 coverage verdict from the per-check coverage
+	payload (never derived from an empty-findings heuristic):
+
+	  * ``failed``          — the run produced no result (exec failure);
+	  * ``not_evaluable``   — required checks were named but NONE were evaluated
+	    (every required token is not_evaluable/truncated);
+	  * ``partial``         — some required checks evaluated, result incomplete
+	    (a partial gate fired, or some — not all — required tokens not_evaluable);
+	  * ``evaluated_clean`` — every required check evaluated and no partial gate
+	    fired (the ONLY state under which "no exceptions" may render; the render
+	    layer additionally requires an empty findings list).
+
+	``required_tokens`` is the set of checks this run was asked to cover (the keys
+	of the coverage manifest); ``evaluated_tokens`` is the subset that came back
+	``evaluated``. An empty manifest (an evaluator that reports no required tokens)
+	has no required coverage to fail, so — absent any partial gate — it resolves
+	``evaluated_clean`` exactly as the pre-PP-2 behaviour did."""
+	if failed:
+		return "failed"
+	req = set(required_tokens or ())
+	ev = set(evaluated_tokens or ())
+	if req and not (req & ev):
+		return "not_evaluable"
+	if partial:
+		return "partial"
+	return CLEAN_RUN_STATE
+
+
+# --------------------------------------------------------------------------- #
+# PP-1 — strong-verb gating (a shared helper refuses the token, not authors)
+# --------------------------------------------------------------------------- #
+#: ``\b`` word boundaries so a substring ("un-saved") never trips; the phrase
+#: verbs ("actually paid") match with their internal space intact.
+_STRONG_VERB_RE = re.compile(r"\b(" + "|".join(re.escape(v) for v in STRONG_VERBS) + r")\b", re.IGNORECASE)
+
+#: The neutral marker a stripped strong verb is replaced with in non-strict
+#: render paths, so the row still renders but makes no outcome claim.
+STRONG_VERB_REPLACEMENT = "[unverified]"
+
+
+def contains_strong_verb(text) -> bool:
+	"""True iff ``text`` carries any outcome-claim strong verb (case-insensitive)."""
+	return bool(text) and bool(_STRONG_VERB_RE.search(str(text)))
+
+
+def strong_verb_allowed(result_class, outcome_provenance) -> bool:
+	"""A strong verb ("saved/recovered/prevented/actually paid/replaces") may
+	render ONLY for a ``confirmed_outcome`` row whose ``outcome_provenance`` link
+	resolves — every other class is a scenario/candidate/fact, never a measured
+	outcome."""
+	return result_class == RESERVED_RESULT_CLASS and bool(outcome_provenance)
+
+
+def render_value_text(text, result_class, *, outcome_provenance=None, strict: bool = False) -> str:
+	"""Return ``text`` made safe to render (PP-1 strong-verb gate).
+
+	If the text carries no strong verb it passes through unchanged. If it does,
+	the verb is permitted only for a ``confirmed_outcome`` row with a resolving
+	``outcome_provenance``; for every other class the helper — not author
+	discipline — neutralises it: ``strict=True`` raises ``ValueError`` (the export
+	/ collateral template path, which must fail a build rather than emit the
+	claim); otherwise the verb tokens are replaced with :data:`STRONG_VERB_REPLACEMENT`
+	so the row still renders without the unearned claim."""
+	if text is None:
+		return ""
+	text = str(text)
+	if not contains_strong_verb(text):
+		return text
+	if strong_verb_allowed(result_class, outcome_provenance):
+		return text
+	if strict:
+		raise ValueError(
+			f"strong verb not permitted for result_class={result_class!r} without outcome provenance"
+		)
+	return _STRONG_VERB_RE.sub(STRONG_VERB_REPLACEMENT, text)

--- a/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.json
@@ -10,19 +10,35 @@
   "agent",
   "rule_id",
   "severity",
+  "result_class",
   "title",
   "detail_md",
   "section",
   "effective_date",
   "disclaimer",
+  "rule_version",
+  "assumptions",
+  "known_exceptions",
+  "source",
+  "reviewer",
+  "confidence",
+  "match_basis",
+  "false_positive_path",
+  "confirmation_status",
   "ref_doctype",
   "ref_name",
   "company",
   "amount",
+  "outcome_provenance",
   "fingerprint",
   "state",
   "first_seen_run",
-  "last_seen_run"
+  "last_seen_run",
+  "resolved_by",
+  "resolved_at",
+  "resolution_kind",
+  "result_link_doctype",
+  "result_link_name"
  ],
  "fields": [
   {
@@ -131,6 +147,130 @@
    "fieldtype": "Link",
    "label": "Last Seen Run",
    "options": "Jarvis Agent Run"
+  },
+  {
+   "fieldname": "result_class",
+   "fieldtype": "Select",
+   "label": "Result Class",
+   "options": "observed_fact\nderived_candidate\nlegal_scenario\nconfirmed_outcome",
+   "reqd": 1,
+   "no_copy": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "PP-1 four-class value grammar. Set once at writeback, never editable afterwards (controller set-once guard). observed_fact = direct record read; derived_candidate = a candidate until confirmed; legal_scenario = a rule scenario, never realised exposure; confirmed_outcome is RESERVED — an evaluator may not emit it (written only by the PP-5 provenance ledger)."
+  },
+  {
+   "fieldname": "confidence",
+   "fieldtype": "Percent",
+   "label": "Confidence",
+   "depends_on": "eval:doc.result_class=='derived_candidate'",
+   "description": "derived_candidate only — the match/estimate confidence."
+  },
+  {
+   "fieldname": "match_basis",
+   "fieldtype": "Small Text",
+   "label": "Match Basis",
+   "depends_on": "eval:doc.result_class=='derived_candidate'",
+   "description": "derived_candidate only — how the candidate was matched (e.g. '2B-match', 'fuzzy vendor')."
+  },
+  {
+   "fieldname": "false_positive_path",
+   "fieldtype": "Small Text",
+   "label": "False Positive Path",
+   "depends_on": "eval:doc.result_class=='derived_candidate'",
+   "description": "derived_candidate only — how a false positive would present, so a reviewer can rule it out."
+  },
+  {
+   "default": "unconfirmed",
+   "fieldname": "confirmation_status",
+   "fieldtype": "Select",
+   "label": "Confirmation Status",
+   "options": "unconfirmed\nconfirmed\nrejected",
+   "read_only": 1,
+   "depends_on": "eval:doc.result_class=='derived_candidate'",
+   "description": "derived_candidate lifecycle. Unconfirmed at writeback; only the PP-5 provenance ledger may move it off unconfirmed."
+  },
+  {
+   "fieldname": "rule_version",
+   "fieldtype": "Data",
+   "label": "Rule Version",
+   "depends_on": "eval:doc.result_class=='legal_scenario'",
+   "description": "legal_scenario only — the version of the statutory rule set applied."
+  },
+  {
+   "fieldname": "assumptions",
+   "fieldtype": "Small Text",
+   "label": "Assumptions",
+   "depends_on": "eval:doc.result_class=='legal_scenario'",
+   "description": "legal_scenario only — the assumptions the scenario rests on."
+  },
+  {
+   "fieldname": "known_exceptions",
+   "fieldtype": "Small Text",
+   "label": "Known Exceptions",
+   "depends_on": "eval:doc.result_class=='legal_scenario'",
+   "description": "legal_scenario only — documented carve-outs / exceptions to the rule."
+  },
+  {
+   "fieldname": "source",
+   "fieldtype": "Data",
+   "label": "Source",
+   "depends_on": "eval:doc.result_class=='legal_scenario'",
+   "description": "legal_scenario only — the authoritative reference for the rule."
+  },
+  {
+   "fieldname": "reviewer",
+   "fieldtype": "Link",
+   "label": "Reviewer",
+   "options": "User",
+   "depends_on": "eval:doc.result_class=='legal_scenario'",
+   "description": "legal_scenario only — the named reviewer of record."
+  },
+  {
+   "fieldname": "outcome_provenance",
+   "fieldtype": "Link",
+   "label": "Outcome Provenance",
+   "options": "Jarvis Agent Provenance Event",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-5 — required iff result_class == confirmed_outcome, empty for every other class. Set ONLY by the provenance ledger when a transaction_posted / finding_resolved(human) event closes the loop; also moves confirmation_status to confirmed."
+  },
+  {
+   "fieldname": "resolved_by",
+   "fieldtype": "Link",
+   "label": "Resolved By",
+   "options": "User",
+   "read_only": 1,
+   "description": "PP-5 finding review provenance — the user who resolved this finding (human resolves only)."
+  },
+  {
+   "fieldname": "resolved_at",
+   "fieldtype": "Datetime",
+   "label": "Resolved At",
+   "read_only": 1,
+   "description": "PP-5 finding review provenance — when the finding was resolved (human OR automatic)."
+  },
+  {
+   "fieldname": "resolution_kind",
+   "fieldtype": "Select",
+   "label": "Resolution Kind",
+   "options": "human\nauto_coverage\nauto_watermark",
+   "read_only": 1,
+   "description": "PP-5 — separates human resolution from automatic. A16 coverage auto-resolve stamps auto_coverage; a watermark-gated auto-resolve stamps auto_watermark; a person stamps human."
+  },
+  {
+   "fieldname": "result_link_doctype",
+   "fieldtype": "Data",
+   "label": "Result Link DocType",
+   "read_only": 1,
+   "description": "PP-5 — the resulting transaction/draft CREATED from acting on this finding (distinct from the flagged ref_doctype/ref_name)."
+  },
+  {
+   "fieldname": "result_link_name",
+   "fieldtype": "Data",
+   "label": "Result Link Name",
+   "read_only": 1,
+   "description": "PP-5 — the name of the resulting transaction/draft created from acting on this finding."
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_finding/jarvis_agent_finding.py
@@ -9,10 +9,15 @@ cannot forge or reassign one (rows are inserted server-side and owned by the
 installation owner).
 """
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 # Engine-owned audit fields — everything except the user-actionable ``state``.
 # Frozen on any customer save so the audited party cannot rewrite/erase a finding.
+# PP-5 review-provenance fields are included: once the engine/ledger stamps them
+# (via ``db.set_value``, which bypasses this controller) a customer ORM save can
+# never rewrite who/when/what-kind resolved the finding, nor forge a result link.
 _FROZEN_FIELDS = (
 	"run",
 	"agent",
@@ -29,12 +34,40 @@ _FROZEN_FIELDS = (
 	"fingerprint",
 	"first_seen_run",
 	"last_seen_run",
+	# PP-5 provenance / review fields (immutable-once-written at the ORM level).
+	"confirmation_status",
+	"outcome_provenance",
+	"resolved_by",
+	"resolved_at",
+	"resolution_kind",
+	"result_link_doctype",
+	"result_link_name",
 )
 
 
 class JarvisAgentFinding(Document):
 	def validate(self):
+		self._guard_result_class_set_once()
 		self._freeze_audit_fields()
+
+	def _guard_result_class_set_once(self):
+		"""PP-1: ``result_class`` is the immutable epistemic class of the finding —
+		set once at writeback and never editable afterwards. Unlike the audit fields
+		(silently restored), a changed class is a contract violation, so this RAISES.
+		The insert (``is_new``) is exempt (the one legitimate write); the engine /
+		ledger never re-classes a finding via the ORM, so the guard fires regardless
+		of ``ignore_permissions`` — the class is a hard, one-way commit."""
+		if self.is_new():
+			return
+		before = self.get_doc_before_save()
+		if not before:
+			return
+		stored = before.get("result_class")
+		if stored and self.result_class != stored:
+			frappe.throw(
+				_("result_class is set once at writeback (PP-1) and cannot be changed afterwards."),
+				frappe.PermissionError,
+			)
 
 	def _freeze_audit_fields(self):
 		"""TASK 31 (AGENTS-3): a finding is the reproducibility guarantee of an

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -10,6 +10,12 @@
   "enabled",
   "run_as_user",
   "scoped_visibility",
+  "activation_state",
+  "reviewer",
+  "promoted_by",
+  "promoted_at",
+  "installable",
+  "not_installable_reason",
   "installed_version",
   "installed_at",
   "config",
@@ -123,6 +129,59 @@
    "fieldtype": "Datetime",
    "label": "Last Run At",
    "read_only": 1
+  },
+  {
+   "default": "shadow",
+   "fieldname": "activation_state",
+   "fieldtype": "Select",
+   "label": "Activation State",
+   "options": "shadow\nlive",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "PP-4 — every capability activates per customer in preview/shadow first. In shadow, findings/dashboards are reviewer-visible only and NO clean/compliant attestation renders. Flips to live ONLY via the reviewer promotion path (PP-6 global activation budget gates the flip)."
+  },
+  {
+   "fieldname": "reviewer",
+   "fieldtype": "Link",
+   "label": "Reviewer",
+   "options": "User",
+   "reqd": 1,
+   "in_standard_filter": 1,
+   "description": "PP-4 — the named reviewer who sees shadow output and signs off on promotion to live. Backfilled to run_as_user on legacy rows."
+  },
+  {
+   "fieldname": "promoted_by",
+   "fieldtype": "Link",
+   "label": "Promoted By",
+   "options": "User",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-4 — set on promotion to live; must equal reviewer or an authorised approver."
+  },
+  {
+   "fieldname": "promoted_at",
+   "fieldtype": "Datetime",
+   "label": "Promoted At",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-4 — when the installation was promoted from shadow to live."
+  },
+  {
+   "default": "1",
+   "fieldname": "installable",
+   "fieldtype": "Check",
+   "label": "Installable",
+   "read_only": 1,
+   "description": "PP-3 — 0 when a min_apps dependency is unmet / edition ineligible (a NOT-INSTALLABLE install-time state, never a run result). A non-installable capability produces no run and no finding."
+  },
+  {
+   "fieldname": "not_installable_reason",
+   "fieldtype": "Select",
+   "label": "Not Installable Reason",
+   "options": "\napp_absent_or_ineligible\npermission_slice\nconfiguration_missing\nrecord_coverage_insufficient\nsource_stale\nrule_expired\nexternal_evidence_absent\nrun_truncated_watermark\nunsupported_customisation",
+   "read_only": 1,
+   "depends_on": "eval:doc.installable==0",
+   "description": "PP-3 — the typed reason (closed enum, mainly app_absent_or_ineligible) when installable == 0. Distinct from any run coverage reason."
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -41,13 +41,59 @@ _GL_SCOPED_DIMENSIONS = (
 
 class JarvisAgentInstallation(Document):
 	def validate(self):
+		self._default_reviewer()
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
 		self._validate_run_as_user()
 		self._validate_schedule_budget()
+		self._guard_activation_transition()
 
 	def on_update(self):
 		self._audit_cross_user_run_as()
+
+	def _default_reviewer(self):
+		"""PP-4: ``reviewer`` is reqd — the named human who sees this installation's
+		SHADOW output (findings/dashboards) and whose explicit sign-off is the only
+		path to ``live``. Default it to the run-as user (which itself defaults to the
+		installer) so every write surface (SPA / Desk / data import / direct save /
+		test) gets a sensible reviewer without the caller having to supply one; a
+		Jarvis Admin may retarget it. Never leave it empty — a shadow install with no
+		reviewer would have no one who can see its output or promote it. Runs before
+		Frappe's mandatory check, so it satisfies ``reqd`` on every surface."""
+		if not (self.reviewer or "").strip():
+			self.reviewer = self.run_as_user or self.owner or frappe.session.user
+
+	def _guard_activation_transition(self):
+		"""PP-4 / PP-6: ``activation_state`` is THE flag. A fresh install is always
+		born in ``shadow`` (it may not skip the reviewer-calibration stage), and the
+		flip ``shadow -> live`` happens ONLY through the reviewer promotion path
+		(``agents_api.promote_installation``, which stamps ``promoted_by``/
+		``promoted_at``, checks the PP-6 global activation budget and writes a PP-5
+		provenance event) and ``live -> shadow`` ONLY through the demotion/kill path —
+		each sets its dedicated flag. A plain ORM save (a customer editing the row, a
+		generic-REST PUT) may NOT flip it: that would bypass the sign-off, the who/when
+		audit and the budget ceiling."""
+		if self.is_new():
+			if (self.activation_state or "shadow") != "shadow":
+				frappe.throw(
+					_("A new installation activates in shadow; promote it via reviewer sign-off (PP-4).")
+				)
+			return
+		before = self.get_doc_before_save()
+		if not before:
+			return
+		old = before.get("activation_state") or "shadow"
+		new = self.activation_state or "shadow"
+		if old == new:
+			return
+		if old == "shadow" and new == "live" and self.flags.get("promoting"):
+			return
+		if old == "live" and new == "shadow" and self.flags.get("demoting"):
+			return
+		frappe.throw(
+			_("activation_state flips only via the reviewer promotion / demotion path (PP-4)."),
+			frappe.PermissionError,
+		)
 
 	def _validate_schedule_budget(self):
 		"""A14: warn (do not hard-block) when an enabled schedule's expected monthly

--- a/jarvis/jarvis/doctype/jarvis_agent_provenance_event/jarvis_agent_provenance_event.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_provenance_event/jarvis_agent_provenance_event.json
@@ -1,0 +1,149 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-21 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "event_type",
+  "occurred_at",
+  "agent",
+  "bundle_version",
+  "run",
+  "installation",
+  "preparation_mode",
+  "initiating_human",
+  "reviewing_human",
+  "outcome",
+  "finding",
+  "approval",
+  "result_link_doctype",
+  "result_link_name",
+  "detail"
+ ],
+ "fields": [
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Select",
+   "label": "Event Type",
+   "options": "run_launched\nfinding_raised\napproval_requested\napproval_decided\ndraft_created\ntransaction_posted\nfinding_resolved\nagent_promoted_to_live\nincident_raised\nactivation_ceiling_raised",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "PP-5 append-only provenance event kind. confirmed_outcome findings (PP-1) are closed only by a transaction_posted / finding_resolved(human) event; agent_promoted_to_live records a PP-4 promotion; activation_ceiling_raised records a PP-6 budget raise."
+  },
+  {
+   "fieldname": "occurred_at",
+   "fieldtype": "Datetime",
+   "label": "Occurred At",
+   "read_only": 1,
+   "in_list_view": 1,
+   "description": "When the event occurred. Stamped at insert, never editable (append-only)."
+  },
+  {
+   "fieldname": "agent",
+   "fieldtype": "Link",
+   "label": "Agent",
+   "options": "Jarvis Agent Listing",
+   "in_standard_filter": 1
+  },
+  {
+   "fieldname": "bundle_version",
+   "fieldtype": "Data",
+   "label": "Bundle Version",
+   "description": "Copied immutably from the run's bundle_version."
+  },
+  {
+   "fieldname": "run",
+   "fieldtype": "Link",
+   "label": "Run",
+   "options": "Jarvis Agent Run"
+  },
+  {
+   "fieldname": "installation",
+   "fieldtype": "Link",
+   "label": "Installation",
+   "options": "Jarvis Agent Installation"
+  },
+  {
+   "fieldname": "preparation_mode",
+   "fieldtype": "Select",
+   "label": "Preparation Mode",
+   "options": "shadow\nlive"
+  },
+  {
+   "fieldname": "initiating_human",
+   "fieldtype": "Link",
+   "label": "Initiating Human",
+   "options": "User"
+  },
+  {
+   "fieldname": "reviewing_human",
+   "fieldtype": "Link",
+   "label": "Reviewing Human",
+   "options": "User"
+  },
+  {
+   "fieldname": "outcome",
+   "fieldtype": "Select",
+   "label": "Outcome",
+   "options": "\napproved\nrejected\nreworked",
+   "description": "For decision events (approval_decided): approved | rejected | reworked."
+  },
+  {
+   "fieldname": "finding",
+   "fieldtype": "Link",
+   "label": "Finding",
+   "options": "Jarvis Agent Finding"
+  },
+  {
+   "fieldname": "approval",
+   "fieldtype": "Link",
+   "label": "Approval",
+   "options": "Jarvis Approval Request"
+  },
+  {
+   "fieldname": "result_link_doctype",
+   "fieldtype": "Data",
+   "label": "Result Link DocType",
+   "description": "The resulting draft/transaction this event records."
+  },
+  {
+   "fieldname": "result_link_name",
+   "fieldtype": "Data",
+   "label": "Result Link Name"
+  },
+  {
+   "fieldname": "detail",
+   "fieldtype": "Small Text",
+   "label": "Detail",
+   "description": "Free-text context: e.g. the PP-6 reviewer-capacity justification + new ceiling for an activation_ceiling_raised event."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-21 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Agent Provenance Event",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "read": 1,
+   "report": 1,
+   "export": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Jarvis Admin"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_agent_provenance_event/jarvis_agent_provenance_event.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_provenance_event/jarvis_agent_provenance_event.py
@@ -1,0 +1,42 @@
+"""PP-5 — append-only provenance ledger event.
+
+Connects findings -> approvals -> drafts/transactions -> incidents with
+immutable launch-time facts and first-class outcome events. Once a row is
+persisted it may never be modified or deleted (System Manager included); the
+only permitted operations are ``create`` + ``read``. This is the structural
+guarantee that the measurement ledger — confirmed outcomes (PP-1), shadow
+promotions (PP-4), approval decisions, the activation-budget raises (PP-6) —
+cannot be rewritten after the fact.
+
+The ledger-writer helpers (which actually append events and, for a
+transaction_posted / finding_resolved(human) event, close a finding's
+``outcome_provenance`` loop and move its ``confirmation_status`` to
+``confirmed``) are layered on in a later phase; this controller only enforces
+the append-only invariant and stamps ``occurred_at``.
+"""
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class JarvisAgentProvenanceEvent(Document):
+	def before_insert(self):
+		if not self.occurred_at:
+			self.occurred_at = frappe.utils.now()
+
+	def on_update(self):
+		# Frappe runs on_update on both insert and every subsequent save. The
+		# insert is permitted (flags.in_insert is set only during insert); any
+		# later modification is refused — append-only, no exceptions.
+		if not self.flags.in_insert:
+			frappe.throw(
+				_("Jarvis Agent Provenance Event is append-only; a persisted event cannot be modified."),
+				frappe.PermissionError,
+			)
+
+	def on_trash(self):
+		frappe.throw(
+			_("Jarvis Agent Provenance Event is append-only; a persisted event cannot be deleted."),
+			frappe.PermissionError,
+		)

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
@@ -9,7 +9,11 @@
   "agent",
   "installation",
   "trigger",
+  "bundle_version",
+  "preparation_mode",
+  "initiating_human",
   "status",
+  "result_state",
   "started_at",
   "finished_at",
   "conversation",
@@ -163,6 +167,41 @@
    "label": "Canvas Ref",
    "read_only": 1,
    "description": "The delegate's saved canvas/dashboard reference reported at writeback. Phase 4's save_dashboard resolves this into the Run.dashboard link."
+  },
+  {
+   "fieldname": "result_state",
+   "fieldtype": "Select",
+   "label": "Result State",
+   "options": "evaluated_clean\npartial\nnot_evaluable\nfailed",
+   "read_only": 1,
+   "in_standard_filter": 1,
+   "description": "PP-2 coverage-verdict axis, distinct from the execution-lifecycle status. Computed at writeback: failed if the run errored; not_evaluable if all required tokens are not_evaluable; partial if any partial gate fired; else evaluated_clean. 'No exceptions were found' may render ONLY when this is evaluated_clean."
+  },
+  {
+   "fieldname": "bundle_version",
+   "fieldtype": "Data",
+   "label": "Bundle Version",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-5 — the agent/bundle version stamped IMMUTABLY at launch (unlike the mutable listing/installation version). Controller set-once: changing it after insert raises."
+  },
+  {
+   "fieldname": "preparation_mode",
+   "fieldtype": "Select",
+   "label": "Preparation Mode",
+   "options": "shadow\nlive",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-5 — snapshot of the installation's activation_state at launch (shadow|live), immutable."
+  },
+  {
+   "fieldname": "initiating_human",
+   "fieldtype": "Link",
+   "label": "Initiating Human",
+   "options": "User",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-5 — the human who triggered a manual run (distinct from the run-as user and from the reassigned owner)."
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.py
@@ -9,8 +9,37 @@ only — the customer sees their own run history but cannot forge rows.
 as ``completed``).
 """
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
+
+# PP-5: launch-time facts stamped once when the run starts. Unlike the listing /
+# installation versions (mutable), these are the run's immutable provenance — the
+# bundle it actually executed, whether it ran in shadow, and the human who
+# triggered it. The engine stamps them at launch and updates run lifecycle via
+# raw ``db.set_value`` (which bypasses this controller); any ORM save that tries
+# to change a stamped launch fact is refused.
+_IMMUTABLE_LAUNCH_FIELDS = (
+	"bundle_version",
+	"preparation_mode",
+	"initiating_human",
+)
 
 
 class JarvisAgentRun(Document):
-	pass
+	def validate(self):
+		self._guard_immutable_launch_fields()
+
+	def _guard_immutable_launch_fields(self):
+		if self.is_new():
+			return
+		before = self.get_doc_before_save()
+		if not before:
+			return
+		for field in _IMMUTABLE_LAUNCH_FIELDS:
+			stored = before.get(field)
+			if stored and self.get(field) != stored:
+				frappe.throw(
+					_("{0} is stamped immutably at launch (PP-5) and cannot be changed.").format(field),
+					frappe.PermissionError,
+				)

--- a/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
+++ b/jarvis/jarvis/doctype/jarvis_approval_request/jarvis_approval_request.json
@@ -9,6 +9,10 @@
   "title",
   "status",
   "source",
+  "agent",
+  "run",
+  "preparation_mode",
+  "result_class",
   "document_type",
   "conversation",
   "question",
@@ -119,6 +123,40 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Trace Comment Added"
+  },
+  {
+   "fieldname": "agent",
+   "fieldtype": "Link",
+   "label": "Agent",
+   "options": "Jarvis Agent Listing",
+   "read_only": 1,
+   "in_standard_filter": 1,
+   "description": "PP-5 — set for an agent-originated request; a human File-Box/Chat request leaves it blank. Distinguishes the two provenance paths."
+  },
+  {
+   "fieldname": "run",
+   "fieldtype": "Link",
+   "label": "Run",
+   "options": "Jarvis Agent Run",
+   "read_only": 1,
+   "description": "PP-5 — the Jarvis Agent Run that raised this request (agent-originated requests only)."
+  },
+  {
+   "fieldname": "preparation_mode",
+   "fieldtype": "Select",
+   "label": "Preparation Mode",
+   "options": "shadow\nlive",
+   "read_only": 1,
+   "description": "PP-5 — the activation mode (shadow|live) the originating run executed under; blank for human requests."
+  },
+  {
+   "fieldname": "result_class",
+   "fieldtype": "Select",
+   "label": "Result Class",
+   "options": "observed_fact\nderived_candidate\nlegal_scenario\nconfirmed_outcome",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "PP-1 — the value grammar class for an agent-originated, value-bearing request. Blank for a human File-Box/Chat request. Set once, never editable afterwards."
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -5,6 +5,7 @@
  "issingle": 1,
  "custom": 0,
  "engine": "InnoDB",
+ "track_changes": 1,
  "field_order": [
   "config_tab",
   "account_section",
@@ -98,6 +99,7 @@
   "agent_catalog_dirty",
   "agent_catalog_version",
   "agent_run_budget_monthly",
+  "activation_module_ceiling",
   "learned_skills_synced_at",
   "learned_skills_sync_status",
   "agent_tools_section",
@@ -731,6 +733,13 @@
    "fieldname": "agent_run_budget_monthly",
    "fieldtype": "Int",
    "label": "Agent Run Budget (monthly, per installation)"
+  },
+  {
+   "default": "1",
+   "description": "PP-6 — site-wide ceiling on the number of LIVE agent modules (Jarvis Agent Installation.activation_state == live), global across all packs. Default 1: every customer starts with a single live module. The PP-4 promotion path refuses to flip an installation to live once the count of live installations reaches this ceiling. Raised to 2 (the stage maximum — no higher value is accepted) only by a Jarvis Admin, and only with a recorded reviewer-capacity justification (audited via track_changes + a provenance event).",
+   "fieldname": "activation_module_ceiling",
+   "fieldtype": "Int",
+   "label": "Activation Module Ceiling (live agents, site-wide)"
   },
   {
    "fieldname": "learned_skills_synced_at",

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -30,3 +30,6 @@ jarvis.patches.v2_00_backfill_llm_direct_synced_at
 jarvis.patches.v2_01_backfill_glm_zai_provider_id
 jarvis.patches.v2_02_backfill_agent_run_as_user
 jarvis.patches.v2_02_unique_model_usage_row
+jarvis.patches.v2_03_backfill_finding_result_class
+jarvis.patches.v2_03_backfill_installation_activation
+jarvis.patches.v2_03_backfill_approval_provenance

--- a/jarvis/patches/v2_03_backfill_approval_provenance.py
+++ b/jarvis/patches/v2_03_backfill_approval_provenance.py
@@ -1,0 +1,109 @@
+"""PP-1 / PP-5: backfill ``result_class`` + ``agent``/``run``/``preparation_mode``
+on agent-originated ``Jarvis Approval Request`` rows.
+
+The PP-1/PP-5 contract (``01-PLATFORM-PREREQS.md``) adds these fields so an
+agent-originated approval is DISTINGUISHABLE from a human one: an agent-originated
+request carries ``agent``/``run``/``preparation_mode`` + a PP-1 ``result_class``; a
+HUMAN File-Box/Chat request leaves them blank and MUST stay untouched. The sibling
+patches (``v2_03_backfill_finding_result_class`` / ``..._installation_activation``)
+grandfathered findings + installations but NOT approvals — this closes that gap.
+
+Legacy agent-originated rows predate these fields. The only signal that a legacy
+approval was raised INSIDE an agent run is that its ``conversation`` matches a
+``Jarvis Agent Run.conversation`` — an agent run owns a dedicated conversation,
+whereas a human ask links the user's own chat conversation. Rows with no such
+linkage are human-originated and are left blank (untouched).
+
+For each agent-originated row still missing its provenance:
+
+  * ``agent``            <- the run's ``agent``;
+  * ``run``              <- the run's name;
+  * ``preparation_mode`` <- the run's ``preparation_mode`` (falling back to the
+    installation's ``activation_state``, else ``shadow``);
+  * ``result_class``     <- CONSERVATIVE (never silently a fact): ``observed_fact``
+    UNLESS the row's title/question/context carries a match/estimate/exposure
+    marker or a strong verb, in which case ``derived_candidate``. No legacy row is
+    backfilled to ``confirmed_outcome`` (reserved for the PP-5 ledger) — mirrors
+    the finding backfill's conservative classification, which it reuses verbatim.
+
+Raw ``db.set_value`` (never ``doc.save()``): ``agent``/``run``/``preparation_mode``/
+``result_class`` are ``read_only`` and this is trusted migration infrastructure.
+Idempotent: a row is processed only while its ``agent`` link is still empty (the
+origination marker), so a re-run is a no-op and any row a newer code path already
+stamped is skipped.
+"""
+
+import frappe
+
+from jarvis.patches.v2_03_backfill_finding_result_class import _looks_like_candidate
+
+APPROVAL = "Jarvis Approval Request"
+RUN = "Jarvis Agent Run"
+INSTALLATION = "Jarvis Agent Installation"
+
+
+def execute():
+	# Only run once the schema carries the new columns (schema-sync precedes this
+	# post_model_sync patch, but guard so an out-of-order run is a safe no-op).
+	if not (
+		frappe.db.has_column(APPROVAL, "agent")
+		and frappe.db.has_column(APPROVAL, "run")
+		and frappe.db.has_column(APPROVAL, "preparation_mode")
+		and frappe.db.has_column(APPROVAL, "result_class")
+	):
+		return
+
+	# Agent-originated legacy rows = an approval whose conversation is an agent
+	# run's conversation, still missing its origination stamp (agent empty). A human
+	# File-Box/Chat approval never matches a run conversation, so it is excluded.
+	rows = frappe.db.sql(
+		"""
+		SELECT a.name AS approval, a.title, a.question, a.context_md,
+		       r.name AS run, r.agent, r.installation, r.preparation_mode
+		FROM `tabJarvis Approval Request` a
+		JOIN `tabJarvis Agent Run` r ON r.conversation = a.conversation
+		WHERE a.conversation IS NOT NULL AND a.conversation != ''
+		  AND (a.agent IS NULL OR a.agent = '')
+		ORDER BY r.creation ASC
+		""",
+		as_dict=True,
+	)
+
+	seen: set[str] = set()
+	facts = candidates = 0
+	for row in rows:
+		if row.approval in seen:
+			continue  # a conversation maps to one run; first (earliest) wins
+		seen.add(row.approval)
+
+		prep = (row.preparation_mode or "").strip()
+		if not prep and row.installation:
+			prep = (frappe.db.get_value(INSTALLATION, row.installation, "activation_state") or "").strip()
+		prep = prep or "shadow"
+
+		blob = f"{row.title or ''}\n{row.question or ''}\n{row.context_md or ''}"
+		if _looks_like_candidate(blob):
+			result_class = "derived_candidate"
+			candidates += 1
+		else:
+			result_class = "observed_fact"
+			facts += 1
+
+		frappe.db.set_value(
+			APPROVAL,
+			row.approval,
+			{
+				"agent": row.agent,
+				"run": row.run,
+				"preparation_mode": prep,
+				"result_class": result_class,
+			},
+			update_modified=False,
+		)
+
+	frappe.db.commit()
+	if seen:
+		frappe.logger("jarvis").info(
+			f"PP-1/PP-5 approval provenance backfill: {facts} observed_fact, "
+			f"{candidates} derived_candidate (of {len(seen)} agent-originated approvals)"
+		)

--- a/jarvis/patches/v2_03_backfill_finding_result_class.py
+++ b/jarvis/patches/v2_03_backfill_finding_result_class.py
@@ -1,0 +1,90 @@
+"""PP-1: backfill ``result_class`` on pre-existing Jarvis Agent Finding rows.
+
+``result_class`` is a NEW ``reqd`` Select. Schema-sync adds the column nullable
+(so ``migrate`` itself passes), but the moment any code path ``doc.save()``s a
+legacy finding, Frappe would ``MandatoryError`` — so every existing row must be
+stamped BEFORE enforcement matters. Same trap the A13 ``run_as_user`` backfill
+handled.
+
+Conservative classification (never silently upgrade a legacy row to a fact):
+
+  * default ``observed_fact`` — a direct record fact;
+  * ``derived_candidate`` (+ ``confirmation_status = unconfirmed``) when the row's
+    ``title``/``detail_md`` carries a match/estimate/exposure marker OR a strong
+    verb (saved/recovered/prevented/...) — the value may be a candidate, not a
+    realised fact, so it is held below "fact".
+
+No legacy row is backfilled to ``confirmed_outcome`` (reserved for the PP-5
+ledger). Raw ``db.set_value`` (never ``doc.save()``) so the new set-once / reqd
+controller guard is not tripped mid-migrate. Idempotent: only rows whose
+``result_class`` is still NULL/empty are touched, so a re-run is a no-op.
+"""
+
+import frappe
+
+FINDING = "Jarvis Agent Finding"
+
+# Lower-cased substrings that mark a value as a match/estimate/exposure (a
+# candidate) rather than a direct record read.
+_CANDIDATE_MARKERS = (
+	"match",
+	"estimate",
+	"estimated",
+	"exposure",
+	"likely",
+	"probable",
+	"candidate",
+	"fuzzy",
+	"approx",
+	"potential",
+	"suspected",
+)
+
+# Strong verbs (PP-1) — their presence means the row asserts an outcome it has
+# no provenance for, so it is held at derived_candidate, never observed_fact.
+_STRONG_VERBS = (
+	"saved",
+	"recovered",
+	"prevented",
+	"actually paid",
+	"replaces",
+)
+
+
+def _looks_like_candidate(text: str) -> bool:
+	t = (text or "").lower()
+	return any(m in t for m in _CANDIDATE_MARKERS) or any(v in t for v in _STRONG_VERBS)
+
+
+def execute():
+	if not frappe.db.has_column(FINDING, "result_class"):
+		return
+
+	rows = frappe.get_all(
+		FINDING,
+		filters={"result_class": ["in", [None, ""]]},
+		fields=["name", "title", "detail_md", "result_class"],
+	)
+	facts = candidates = 0
+	for r in rows:
+		if (r.result_class or "").strip():
+			continue  # already classed (belt-and-braces against a partial deploy)
+		blob = f"{r.title or ''}\n{r.detail_md or ''}"
+		if _looks_like_candidate(blob):
+			frappe.db.set_value(
+				FINDING,
+				r.name,
+				{"result_class": "derived_candidate", "confirmation_status": "unconfirmed"},
+				update_modified=False,
+			)
+			candidates += 1
+		else:
+			frappe.db.set_value(FINDING, r.name, "result_class", "observed_fact", update_modified=False)
+			facts += 1
+
+	frappe.db.commit()
+	if rows:
+		frappe.logger("jarvis").info(
+			f"PP-1 result_class backfill: {facts} observed_fact, {candidates} derived_candidate "
+			f"(of {len(rows)} legacy findings)"
+		)

--- a/jarvis/patches/v2_03_backfill_installation_activation.py
+++ b/jarvis/patches/v2_03_backfill_installation_activation.py
@@ -1,0 +1,79 @@
+"""PP-4 / PP-6 / PP-3: backfill activation + reviewer + installable on existing
+Jarvis Agent Installation rows.
+
+Three new fields need grandfathering on the POPULATED installation table:
+
+  * ``reviewer`` (NEW ``reqd`` Link) — same ``MandatoryError`` trap as the A13
+    ``run_as_user`` backfill: a legacy row with a NULL reqd field raises the
+    moment any code ``doc.save()``s it. Stamp ``reviewer = run_as_user`` (the
+    identity that already sees the agent's output; fall back to ``owner``).
+
+  * ``activation_state`` (NEW Select, default ``shadow``). DELIBERATE DECISION:
+    existing installs are put into SHADOW, not grandfathered to ``live``. The
+    contract gives no explicit migration note here, and the codebase convention
+    is behaviour-preserving — but PP-4 is a BEFORE-LAUNCH gate whose whole point
+    is that nothing surfaces a customer-facing attestation without a named
+    reviewer's explicit sign-off, and PP-6 sets the initial live-module ceiling
+    to 1. Grandfathering N pre-existing installs to ``live`` would (a) create a
+    live population that never went through reviewer promotion, defeating the
+    PP-4 gate on day one, and (b) put every customer instantly over the PP-6
+    ceiling with no admin justification. Shadow-first is consistent with both.
+    Consequence: existing installs stop surfacing to the general owner until a
+    reviewer promotes them — an intended behaviour change under the launch gate.
+    (Frappe's ``ADD COLUMN ... DEFAULT 'shadow'`` already stamps legacy rows
+    ``shadow``; this patch only belt-and-braces any NULL/empty value.)
+
+  * ``installable`` (NEW Check, default 1) — the default applies on insert only;
+    stamp existing rows to 1 (min_apps was satisfied at their install time).
+
+Raw ``db.set_value`` (never ``doc.save()``) so the reqd/controller guards are
+not tripped mid-migrate. Idempotent: only NULL/empty fields are filled; a re-run
+is a no-op. Rows whose ``run_as_user`` and ``owner`` are both empty are logged +
+skipped (they stay un-backfilled and fail closed at run time).
+"""
+
+import frappe
+
+INSTALLATION = "Jarvis Agent Installation"
+
+
+def execute():
+	have_reviewer = frappe.db.has_column(INSTALLATION, "reviewer")
+	have_state = frappe.db.has_column(INSTALLATION, "activation_state")
+	have_installable = frappe.db.has_column(INSTALLATION, "installable")
+	if not (have_reviewer or have_state or have_installable):
+		return
+
+	rows = frappe.get_all(
+		INSTALLATION,
+		fields=["name", "owner", "run_as_user", "reviewer", "activation_state", "installable"],
+	)
+	skipped = []
+	for r in rows:
+		# activation_state: shadow-first for legacy rows (see module docstring).
+		if have_state and not (r.activation_state or "").strip():
+			frappe.db.set_value(INSTALLATION, r.name, "activation_state", "shadow", update_modified=False)
+
+		# installable: legacy rows passed their min_apps gate at install time.
+		if have_installable and r.installable in (None, ""):
+			frappe.db.set_value(INSTALLATION, r.name, "installable", 1, update_modified=False)
+
+		# reviewer (reqd): stamp run_as_user, then owner.
+		if have_reviewer and not (r.reviewer or "").strip():
+			reviewer = (r.run_as_user or "").strip() or (r.owner or "").strip()
+			if not reviewer:
+				skipped.append(r.name)
+				continue
+			frappe.db.set_value(INSTALLATION, r.name, "reviewer", reviewer, update_modified=False)
+
+	frappe.db.commit()
+
+	if skipped:
+		frappe.log_error(
+			title="jarvis PP-4 backfill: installation reviewer skipped (no run_as_user/owner)",
+			message=(
+				"These Jarvis Agent Installation rows had neither run_as_user nor owner, "
+				"so reviewer was NOT backfilled; they fail closed until an admin sets a "
+				"reviewer:\n  " + "\n  ".join(skipped)
+			),
+		)

--- a/jarvis/tests/test_agent_dashboard_wire.py
+++ b/jarvis/tests/test_agent_dashboard_wire.py
@@ -117,6 +117,12 @@ class TestAgentDashboardWire(unittest.TestCase):
 				"agent": AGENT,
 				"enabled": 1,
 				"run_as_user": cls.owner,
+				# PP-4: these wire tests assert the LIVE owner-facing attestation surface
+				# ("No exceptions were found", owner-owned dashboard). A shadow install
+				# would (correctly) suppress the clean attestation and re-home the output
+				# to the reviewer, so activate live for this attestation fixture.
+				"reviewer": cls.owner,
+				"activation_state": "live",
 				"schedule_enabled": 0,
 				"config": json.dumps({"company": COMPANY, "fiscal_year": FY}),
 			}
@@ -207,6 +213,9 @@ class TestAgentDashboardWire(unittest.TestCase):
 			"ref_name": COMPANY,
 			"amount": 1000.0,
 			"severity": "blocker",
+			# PP-1: every evaluator finding carries its epistemic result_class or it is
+			# dropped at the tool boundary (a TB imbalance is a direct record fact).
+			"result_class": "observed_fact",
 			"note": "Trial balance does not balance: debits vs credits out by 1000.00.",
 		}
 
@@ -243,8 +252,15 @@ class TestAgentDashboardWire(unittest.TestCase):
 	def test_all_clear_run_still_gets_a_dashboard(self):
 		sk = "agent:agent-close-auditor:dash-clear"
 		self._mk_run(sk)
+		# PP-2: a genuine all-clear must evaluate EVERY declared required check (the
+		# authoritative bar is the listing's rule_tokens). A subset-coverage run is
+		# correctly partial and suppresses the "No exceptions" attestation.
+		declared = json.loads(frappe.db.get_value(LISTING, AGENT, "rule_tokens") or "[]")
 		out = self._call_record(
-			sk, findings=[], coverage={TB_TOKEN: "evaluated"}, scope={"company": COMPANY, "fiscal_year": FY}
+			sk,
+			findings=[],
+			coverage={t: "evaluated" for t in declared},
+			scope={"company": COMPANY, "fiscal_year": FY},
 		)
 		self.assertEqual(out["status"], "completed")
 		self.assertTrue(out["dashboard"])

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -104,6 +104,28 @@ class TestAgentsMarketplace(unittest.TestCase):
 		if frappe.db.exists("Role", "Accounts User"):
 			for u in (cls.owner, cls.other, cls.admin):
 				_give_role(u, "Accounts User")
+		# State-independence on a shared bench site: the manual/scheduled run budget
+		# (_over_run_budget) enforces a TENANT-WIDE monthly ceiling that counts every
+		# NON-FAILED Jarvis Agent Run across the whole site — including residue other
+		# platform-test modules leave behind (their record_delegate_run commits
+		# mid-test, so FrappeTestCase cannot roll those rows back). That aggregate can
+		# refuse this module's legitimate run_agent_now dispatch ("Monthly agent-run
+		# budget reached") even though this module cleans its OWN runs every setUp.
+		# None of these tests exercise the budget-exceeded path, so lift the budget
+		# out of the way for the module and restore it in tearDownClass — the tests
+		# then assert identity/authZ, not another module's leftover row count.
+		cls._orig_run_budget = frappe.db.get_single_value("Jarvis Settings", "agent_run_budget_monthly")
+		frappe.db.set_single_value("Jarvis Settings", "agent_run_budget_monthly", 1000000)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value(
+			"Jarvis Settings", "agent_run_budget_monthly", getattr(cls, "_orig_run_budget", None)
+		)
+		frappe.db.commit()
+		super().tearDownClass()
 
 	def setUp(self):
 		frappe.set_user("Administrator")

--- a/jarvis/tests/test_chat_endpoint_gating.py
+++ b/jarvis/tests/test_chat_endpoint_gating.py
@@ -49,6 +49,13 @@ _GUARD_CALL_SUBSTRS = (
 	# fact gated harder than the sweep's own baseline.
 	"require_jarvis_admin",
 	"require_skill_reviewer",  # PART 2 TASK 12: skill-reviewer/admin gate (org-wide apply)
+	# Admin-level access CHECK (bool), the analogue of has_jarvis_access below. The
+	# reviewer-or-admin endpoints (agents_api.promote_installation /
+	# demote_installation) gate in-body on `me != doc.reviewer and not
+	# has_jarvis_admin_access(me)` -> frappe.throw(PermissionError) — a gate STRICTER
+	# than require_jarvis_user (the caller must be the named reviewer or a Jarvis
+	# Admin), so without this entry the sweep false-positived them as ungated.
+	"has_jarvis_admin_access",
 	"_require_system_user",
 	"only_for",  # frappe.only_for(...) — an SM/role gate, stricter than Jarvis User
 	"_guard",  # learned_api._guard / _admin_guard (reviewer/admin role gate)

--- a/jarvis/tests/test_platform_activation.py
+++ b/jarvis/tests/test_platform_activation.py
@@ -1,0 +1,459 @@
+"""Phase-C runtime tests for the platform prerequisites PP-4 + PP-6.
+
+  * PP-4 — preview/shadow activation. A freshly installed capability is ``shadow``;
+    its runs execute and write findings/dashboards, but those are visible ONLY to
+    the named reviewer (the general owner surface cannot read them — enforced on the
+    finding read path, not just the SPA filter); no outward clean/compliant
+    attestation renders in shadow even when the coverage verdict is
+    ``evaluated_clean``. Promotion to live is by the named reviewer's explicit
+    sign-off (recorded with who/when + a PP-5 provenance event); a non-authorised
+    user is refused; after promotion the owner surface opens. A demotion/kill path
+    returns it to shadow.
+  * PP-6 — global activation budget. The default ceiling is 1: with one live module
+    a second promotion is refused. A Jarvis Admin may raise the ceiling to 2 (the
+    stage maximum) with a recorded reviewer-capacity justification + an audited
+    provenance event; a non-admin raise is refused; a value above 2 is rejected.
+  * PP-6 — meter anti-cherry-picking (bench scope): a saved dashboard carries the
+    coverage/integrity digest in-body (screenshot-safe); no meter output renders a
+    strong verb (saved/recovered/prevented).
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_activation
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_permissions, agent_runs, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+PROVENANCE = "Jarvis Agent Provenance Event"
+SETTINGS = "Jarvis Settings"
+
+SLUG = "platform-activation-test-agent"
+TOKEN = "tok_pa_1"
+
+# The test customers whose per-customer activation-ceiling grants must be cleared
+# between runs. The grant lives on the APPEND-ONLY provenance ledger (a Jarvis
+# Admin's ``activation_ceiling_raised`` event keyed to the customer), which the
+# controller refuses to delete — so a prior run's ceiling raise would otherwise
+# PERMANENTLY lift this customer's ceiling to 2 and defeat the default-ceiling
+# budget assertion (``test_budget_refuses_second_live_at_ceiling_one``). Raw
+# ``frappe.db.delete`` bypasses the append-only ``on_trash`` guard, which is
+# legitimate for test teardown of the module's own residue.
+_TEST_CUSTOMERS = ("pa-owner@example.com", "pa-owner2@example.com")
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.insert(ignore_permissions=True)
+		u.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Platform Activation Test Agent",
+				"rule_tokens": json.dumps([TOKEN]),
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return SLUG
+
+
+def _mk_installation(owner: str, reviewer: str, activation_state: str = "shadow") -> object:
+	name = frappe.db.get_value(INSTALLATION, {"agent": SLUG, "owner": owner}, "name")
+	if name:
+		return frappe.get_doc(INSTALLATION, name)
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": SLUG,
+			"run_as_user": owner,
+			"reviewer": reviewer,
+			"activation_state": activation_state,
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_run(owner: str, inst) -> object:
+	doc = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": SLUG,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": frappe.generate_hash(length=24),
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _finding(**over) -> dict:
+	f = {
+		"token": TOKEN,
+		"ref_doctype": "Company",
+		"ref_name": over.pop("ref_name", "PA-Ref"),
+		"amount": 100,
+		"severity": "note",
+		"note": "an authored finding note",
+		"result_class": "observed_fact",
+	}
+	f.update(over)
+	return f
+
+
+def _wipe():
+	slugs = [SLUG, SLUG + "-b"]
+	for dt in (FINDING, RUN):
+		for n in frappe.get_all(dt, filters={"agent": ["in", slugs]}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+	for n in frappe.get_all(
+		INSTALLATION, filters={"agent": ["in", slugs]}, pluck="name", ignore_permissions=True
+	):
+		frappe.delete_doc(INSTALLATION, n, force=True, ignore_permissions=True)
+	# Clear this module's per-customer ceiling grants from the append-only ledger so
+	# every test starts at the default ceiling of 1, independent of prior test runs
+	# or sibling-test order (raw delete bypasses the append-only on_trash guard).
+	frappe.db.delete(
+		PROVENANCE,
+		{"event_type": "activation_ceiling_raised", "result_link_name": ["in", _TEST_CUSTOMERS]},
+	)
+	frappe.db.set_single_value(SETTINGS, "activation_module_ceiling", 1)
+	frappe.db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# PP-4 — shadow visibility (the read-path gating is the security property)
+# --------------------------------------------------------------------------- #
+class TestPP4ShadowVisibility(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("pa-owner@example.com")
+		cls.reviewer = _mk_user("pa-reviewer@example.com")
+		_mk_listing()
+		cls.company = frappe.db.get_value("Company", {}, "name")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		self.inst = _mk_installation(self.owner, self.reviewer, activation_state="shadow")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def _record(self, inst, findings, **kw):
+		run = _mk_run(inst.owner, inst)
+		return agent_runs.record_delegate_run(
+			run,
+			inst,
+			findings,
+			coverage={TOKEN: "evaluated"},
+			scope={"company": self.company},
+			**kw,
+		)
+
+	def test_shadow_finding_hidden_from_owner_visible_to_reviewer(self):
+		"""The core PP-4 security property: a shadow run's findings are re-homed to the
+		reviewer, so the finding READ PATH (the permission-query + has_permission
+		hooks) hides them from the general owner and shows them to the named reviewer.
+		A non-reviewer user cannot read shadow findings."""
+		self._record(self.inst, [_finding()])
+		fname = frappe.db.get_value(FINDING, {"agent": SLUG}, "name")
+		self.assertIsNotNone(fname)
+		self.assertEqual(frappe.db.get_value(FINDING, fname, "owner"), self.reviewer)
+
+		# The OWNER (not the reviewer) cannot read it on the finding read path.
+		frappe.set_user(self.owner)
+		self.assertEqual(frappe.get_list(FINDING, filters={"name": fname}, pluck="name"), [])
+		self.assertFalse(
+			agent_permissions.has_finding_permission(frappe.get_doc(FINDING, fname), "read", self.owner)
+		)
+
+		# The named REVIEWER can.
+		frappe.set_user(self.reviewer)
+		self.assertEqual(frappe.get_list(FINDING, filters={"name": fname}, pluck="name"), [fname])
+		self.assertTrue(
+			agent_permissions.has_finding_permission(frappe.get_doc(FINDING, fname), "read", self.reviewer)
+		)
+
+	def test_shadow_run_hidden_from_owner_visible_to_reviewer(self):
+		run = self._record(self.inst, [_finding()])
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "owner"), self.reviewer)
+		frappe.set_user(self.owner)
+		self.assertEqual(frappe.get_list(RUN, filters={"name": run.name}, pluck="name"), [])
+		frappe.set_user(self.reviewer)
+		self.assertEqual(frappe.get_list(RUN, filters={"name": run.name}, pluck="name"), [run.name])
+
+	def test_no_clean_attestation_in_shadow_even_when_evaluated_clean(self):
+		"""A shadow run with an empty, fully-evaluated coverage set computes
+		result_state == evaluated_clean, but the rendered artifact issues NO outward
+		clean/compliant attestation."""
+		run = self._record(self.inst, [])
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "result_state"), "evaluated_clean")
+		html = agent_runs._fallback_dashboard_html(
+			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "", result_state="evaluated_clean", shadow=True
+		)
+		self.assertNotIn("No exceptions were found", html)
+		self.assertNotIn("Evaluated — clean coverage", html)
+		self.assertIn("Preview (shadow)", html)
+		self.assertIn('data-result-state="shadow"', html)
+
+	def test_live_finding_visible_to_owner(self):
+		"""Control: a LIVE installation's findings stay on the owner surface."""
+		inst = frappe.get_doc(INSTALLATION, self.inst.name)
+		inst.activation_state = "live"
+		inst.flags.promoting = True
+		inst.save(ignore_permissions=True)
+		frappe.db.commit()
+		self._record(inst, [_finding()])
+		fname = frappe.db.get_value(FINDING, {"agent": SLUG}, "name")
+		self.assertEqual(frappe.db.get_value(FINDING, fname, "owner"), self.owner)
+		frappe.set_user(self.owner)
+		self.assertEqual(frappe.get_list(FINDING, filters={"name": fname}, pluck="name"), [fname])
+
+
+# --------------------------------------------------------------------------- #
+# PP-4 — promotion (reviewer sign-off, audit) + PP-6 budget
+# --------------------------------------------------------------------------- #
+class TestPP4PromotionAndPP6Budget(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("pa-owner2@example.com")
+		cls.reviewer = _mk_user("pa-reviewer2@example.com")
+		cls.stranger = _mk_user("pa-stranger@example.com")
+		_mk_listing()
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		self.inst = _mk_installation(self.owner, self.reviewer, activation_state="shadow")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def test_activation_state_cannot_flip_via_plain_save(self):
+		"""The flag flips ONLY via the promotion path (guarded in the controller)."""
+		inst = frappe.get_doc(INSTALLATION, self.inst.name)
+		inst.activation_state = "live"
+		with self.assertRaises(frappe.PermissionError):
+			inst.save(ignore_permissions=True)
+
+	def test_reviewer_promotes_with_audit_and_provenance(self):
+		frappe.set_user(self.reviewer)
+		res = agents_api.promote_installation(self.inst.name, justification="reviewed 10 samples, all clean")
+		self.assertTrue(res["ok"])
+		frappe.set_user("Administrator")
+		inst = frappe.get_doc(INSTALLATION, self.inst.name)
+		self.assertEqual(inst.activation_state, "live")
+		self.assertEqual(inst.promoted_by, self.reviewer)
+		self.assertTrue(inst.promoted_at)
+		ev = frappe.get_all(
+			PROVENANCE,
+			filters={"installation": self.inst.name, "event_type": "agent_promoted_to_live"},
+			fields=["reviewing_human", "preparation_mode"],
+		)
+		self.assertEqual(len(ev), 1)
+		self.assertEqual(ev[0].reviewing_human, self.reviewer)
+		self.assertEqual(ev[0].preparation_mode, "live")
+
+	def test_promotion_by_non_authorised_user_refused(self):
+		frappe.set_user(self.stranger)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.inst.name, "activation_state"), "shadow")
+
+	def test_budget_refuses_second_live_at_ceiling_one(self):
+		"""Default ceiling 1: promoting a second module to live for the same customer
+		is refused until the ceiling is raised."""
+		inst2 = self._second_install()
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(self.inst.name)  # first -> live (ok)
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.promote_installation(inst2.name)  # second -> refused (budget)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst2.name, "activation_state"), "shadow")
+
+	def test_ceiling_raise_admin_only_audited_then_second_promotes(self):
+		inst2 = self._second_install()
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(self.inst.name)
+
+		# a non-admin raise is refused
+		frappe.set_user(self.owner)
+		with self.assertRaises(frappe.PermissionError):
+			agents_api.raise_activation_ceiling(self.owner, "need a second pack")
+
+		# a value above the stage maximum is rejected
+		frappe.set_user("Administrator")
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.raise_activation_ceiling(self.owner, "go to three", new_ceiling=3)
+
+		# an admin raise to 2 for THIS customer records an audited, customer-bound
+		# provenance event. Provenance is append-only (uncleanable between runs), so key
+		# the assertion on a unique justification and assert existence, not an absolute
+		# count. reviewing_human is now the system-verified capacity reviewer (covering
+		# two packs), initiating_human the admin who granted it.
+		just = f"reviewer covers a second pack {frappe.generate_hash(length=8)}"
+		res = agents_api.raise_activation_ceiling(self.owner, just)
+		self.assertEqual(res["data"]["activation_module_ceiling"], 2)
+		self.assertEqual(res["data"]["customer"], self.owner)
+		ev = frappe.get_all(
+			PROVENANCE,
+			filters={"event_type": "activation_ceiling_raised", "detail": ["like", f"%{just}%"]},
+			fields=["detail", "reviewing_human", "initiating_human", "result_link_name"],
+		)
+		self.assertEqual(len(ev), 1)
+		self.assertEqual(ev[0].reviewing_human, self.reviewer)
+		self.assertEqual(ev[0].initiating_human, "Administrator")
+		self.assertEqual(ev[0].result_link_name, self.owner)
+		self.assertIn(just, ev[0].detail)
+
+		# now the second module promotes within the raised ceiling
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(inst2.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst2.name, "activation_state"), "live")
+
+	def test_promotion_opens_owner_surface(self):
+		company = frappe.db.get_value("Company", {}, "name")
+		run = _mk_run(self.owner, self.inst)
+		agent_runs.record_delegate_run(
+			run, self.inst, [_finding()], coverage={TOKEN: "evaluated"}, scope={"company": company}
+		)
+		fname = frappe.db.get_value(FINDING, {"agent": SLUG}, "name")
+		self.assertEqual(frappe.db.get_value(FINDING, fname, "owner"), self.reviewer)  # shadow
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		# re-homed to the owner — the owner surface now sees it
+		self.assertEqual(frappe.db.get_value(FINDING, fname, "owner"), self.owner)
+		frappe.set_user(self.owner)
+		self.assertEqual(frappe.get_list(FINDING, filters={"name": fname}, pluck="name"), [fname])
+
+	def test_demotion_returns_to_shadow_and_frees_budget(self):
+		"""The kill path: a live installation is demoted back to shadow, the promotion
+		stamp is cleared, and the freed budget slot allows a fresh promotion again."""
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.inst.name, "activation_state"), "live")
+		frappe.set_user(self.reviewer)
+		res = agents_api.demote_installation(self.inst.name, reason="too many false positives")
+		self.assertTrue(res["ok"])
+		frappe.set_user("Administrator")
+		inst = frappe.get_doc(INSTALLATION, self.inst.name)
+		self.assertEqual(inst.activation_state, "shadow")
+		self.assertIsNone(inst.promoted_by)
+		# the freed slot allows a fresh promotion under the default ceiling of 1
+		frappe.set_user(self.reviewer)
+		agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.inst.name, "activation_state"), "live")
+
+	def _second_install(self) -> object:
+		"""A genuinely distinct second installation (a second listing) for the same
+		owner, so the per-customer live count reaches two."""
+		slug2 = SLUG + "-b"
+		if not frappe.db.exists(LISTING, slug2):
+			frappe.get_doc(
+				{
+					"doctype": LISTING,
+					"agent_slug": slug2,
+					"title": "Platform Activation Test Agent B",
+					"rule_tokens": json.dumps([TOKEN]),
+					"doctypes_required": json.dumps([]),
+				}
+			).insert(ignore_permissions=True)
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": slug2,
+				"run_as_user": self.owner,
+				"reviewer": self.reviewer,
+				"activation_state": "shadow",
+			}
+		)
+		doc.owner = self.owner
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(INSTALLATION, doc.name, "owner", self.owner, update_modified=False)
+		frappe.db.commit()
+		return frappe.get_doc(INSTALLATION, doc.name)
+
+
+# --------------------------------------------------------------------------- #
+# PP-6 — meter anti-cherry-picking (bench scope): digest + strong-verb gate
+# --------------------------------------------------------------------------- #
+class TestPP6MeterBenchScope(FrappeTestCase):
+	def test_integrity_digest_is_stamped_in_body(self):
+		html = agent_runs._fallback_dashboard_html(
+			"Meter",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"3/6/12-month windows complete",
+			result_state="evaluated_clean",
+			integrity_digest="abc123def456",
+		)
+		self.assertIn("data-digest-block", html)
+		self.assertIn("Coverage &amp; integrity digest", html)
+		self.assertIn("abc123def456", html)
+		self.assertIn("computed server-side", html)
+
+	def test_no_strong_verb_in_meter_output(self):
+		"""A meter/evaluator finding is never confirmed_outcome, so a strong verb in
+		its authored note is neutralised in the rendered artifact."""
+		findings = [
+			{
+				"severity": "note",
+				"result_class": "observed_fact",
+				"note": "this run saved 5,000 and recovered 200",
+				"ref_doctype": "Company",
+				"ref_name": "X",
+				"amount": 0,
+			}
+		]
+		html = agent_runs._fallback_dashboard_html(
+			"Meter", findings, {"blocker": 0, "warning": 0, "note": 1}, "", result_state="partial"
+		)
+		self.assertNotIn("saved 5,000", html)
+		self.assertNotIn("recovered 200", html)

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -1,0 +1,341 @@
+"""Panel-hardening tests for ``jarvis.chat.agents_api`` (PP-1 / PP-4 / PP-6).
+
+Covers the three adversarial-panel findings fixed on the agents SPA endpoints:
+
+  * PP-1 read-path strong-verb gate (findings #2/#5): ``list_findings`` serves the
+    stored authored ``title``/``detail_md`` through the SAME shared helper the
+    fallback dashboard uses, so a "saved/recovered/prevented" token on any row that
+    is NOT a ``confirmed_outcome`` with a resolving provenance link is neutralised
+    server-side — no read surface can emit an unearned strong verb — and every row
+    carries its ``result_class`` + class-conditional metadata for the SPA badge.
+  * PP-6 per-customer ceiling (finding #3): the activation-ceiling raise is bound to
+    ONE named customer and system-verifies that customer's reviewer covers two packs;
+    a raise for customer A never unlocks a second live module for customer B.
+  * PP-6 promotion TOCTOU (finding #1): promotion serializes on a per-customer redis
+    lock; when the lock is unavailable the promotion refuses rather than racing the
+    budget check.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_agents_api_hardening
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+FINDING = "Jarvis Agent Finding"
+PROVENANCE = "Jarvis Agent Provenance Event"
+SETTINGS = "Jarvis Settings"
+
+PREFIX = "hardening-h-"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.insert(ignore_permissions=True)
+		u.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing(slug: str) -> str:
+	if not frappe.db.exists(LISTING, slug):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": slug,
+				"title": f"Hardening {slug}",
+				"rule_tokens": json.dumps(["tok"]),
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return slug
+
+
+def _mk_install(owner: str, slug: str, reviewer: str, activation_state: str = "shadow") -> object:
+	_mk_listing(slug)
+	name = frappe.db.get_value(INSTALLATION, {"agent": slug, "owner": owner}, "name")
+	if name:
+		return frappe.get_doc(INSTALLATION, name)
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": slug,
+			"run_as_user": owner,
+			"reviewer": reviewer,
+			"activation_state": activation_state,
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_finding(owner: str, slug: str, **over) -> object:
+	f = {
+		"doctype": FINDING,
+		"agent": slug,
+		"rule_id": "R1",
+		"severity": "note",
+		"result_class": "observed_fact",
+		"title": "a plain title",
+		"detail_md": "a plain detail",
+		"state": "open",
+	}
+	f.update(over)
+	doc = frappe.get_doc(f)
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(FINDING, doc.name, "owner", owner, update_modified=False)
+	return frappe.get_doc(FINDING, doc.name)
+
+
+def _wipe(slugs) -> None:
+	for n in frappe.get_all(FINDING, filters={"agent": ["in", slugs]}, pluck="name", ignore_permissions=True):
+		frappe.delete_doc(FINDING, n, force=True, ignore_permissions=True)
+	for n in frappe.get_all(
+		INSTALLATION, filters={"agent": ["in", slugs]}, pluck="name", ignore_permissions=True
+	):
+		frappe.delete_doc(INSTALLATION, n, force=True, ignore_permissions=True)
+	frappe.db.set_single_value(SETTINGS, "activation_module_ceiling", 1)
+	frappe.db.commit()
+
+
+@contextmanager
+def _lock_denied(*a, **k):
+	"""Stand-in for ``redis_lock`` that never grants the lock (simulates a concurrent
+	activation change already holding it)."""
+	yield False
+
+
+# --------------------------------------------------------------------------- #
+# PP-1 — list_findings read-path strong-verb gate + class metadata
+# --------------------------------------------------------------------------- #
+class TestListFindingsStrongVerbGate(FrappeTestCase):
+	SLUG = PREFIX + "lf"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.user = _mk_user("h-lf-owner@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+
+	def _rows(self):
+		frappe.set_user(self.user)
+		try:
+			return agents_api.list_findings()["rows"]
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_strong_verb_neutralised_on_observed_fact(self):
+		"""An observed_fact whose authored note says 'recovered X' is delivered to the
+		SPA with the strong verb NEUTRALISED (never intact) on both title and detail."""
+		_mk_finding(
+			self.user,
+			self.SLUG,
+			result_class="observed_fact",
+			title="recovered 5,00,000 from vendor",
+			detail_md="We recovered 500000 and saved 20000 in duplicate payments.",
+		)
+		rows = self._rows()
+		self.assertEqual(len(rows), 1)
+		r = rows[0]
+		self.assertEqual(r["result_class"], "observed_fact")
+		for field in ("title", "detail_md"):
+			self.assertNotIn("recovered", r[field].lower())
+			self.assertNotIn("saved", r[field].lower())
+			self.assertIn("[unverified]", r[field])
+
+	def test_confirmed_outcome_with_provenance_keeps_verb(self):
+		"""Control: a genuine confirmed_outcome row WITH a resolving outcome_provenance
+		link keeps the strong verb — the gate neutralises only UNEARNED claims."""
+		ev = agents_api._append_provenance_event(event_type="transaction_posted", agent=self.SLUG)
+		_mk_finding(
+			self.user,
+			self.SLUG,
+			result_class="confirmed_outcome",
+			outcome_provenance=ev,
+			title="recovered 5,00,000",
+			detail_md="recovered 500000 confirmed by ledger",
+		)
+		r = self._rows()[0]
+		self.assertEqual(r["result_class"], "confirmed_outcome")
+		self.assertIn("recovered", r["detail_md"].lower())
+		self.assertNotIn("[unverified]", r["detail_md"])
+
+	def test_class_conditional_metadata_rides_on_each_row(self):
+		"""A derived_candidate is no longer visually indistinguishable from an
+		observed_fact: its confidence / match_basis / false_positive_path /
+		confirmation_status ride on the read row for the SPA badge."""
+		_mk_finding(
+			self.user,
+			self.SLUG,
+			result_class="derived_candidate",
+			confidence=80,
+			match_basis="2B-match",
+			false_positive_path="vendor alias",
+			confirmation_status="unconfirmed",
+			title="candidate mismatch",
+			detail_md="a possible duplicate",
+		)
+		r = self._rows()[0]
+		self.assertEqual(r["result_class"], "derived_candidate")
+		self.assertEqual(r["match_basis"], "2B-match")
+		self.assertEqual(r["false_positive_path"], "vendor alias")
+		self.assertEqual(r["confirmation_status"], "unconfirmed")
+		self.assertIn("confidence", r)
+
+
+# --------------------------------------------------------------------------- #
+# PP-6 — per-customer activation ceiling (finding #3)
+# --------------------------------------------------------------------------- #
+class TestPerCustomerCeiling(FrappeTestCase):
+	A1 = PREFIX + "a1"
+	A2 = PREFIX + "a2"
+	B1 = PREFIX + "b1"
+	B2 = PREFIX + "b2"
+	C1 = PREFIX + "c1"
+	ALL = (A1, A2, B1, B2, C1)
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.cust_a = _mk_user("h-cust-a@example.com")
+		cls.rev_a = _mk_user("h-rev-a@example.com")
+		cls.cust_b = _mk_user("h-cust-b@example.com")
+		cls.rev_b = _mk_user("h-rev-b@example.com")
+		cls.cust_c = _mk_user("h-cust-c@example.com")
+		cls.rev_c = _mk_user("h-rev-c@example.com")
+		for s in cls.ALL:
+			_mk_listing(s)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe(list(self.ALL))
+		# customer A + B each cover two packs (a reviewer of record on two distinct
+		# agents); customer C covers only one pack.
+		_mk_install(self.cust_a, self.A1, self.rev_a)
+		_mk_install(self.cust_a, self.A2, self.rev_a)
+		self.b1 = _mk_install(self.cust_b, self.B1, self.rev_b)
+		self.b2 = _mk_install(self.cust_b, self.B2, self.rev_b)
+		_mk_install(self.cust_c, self.C1, self.rev_c)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe(list(self.ALL))
+
+	def test_raise_for_a_does_not_unlock_b(self):
+		"""The core isolation property: raising customer A's ceiling to 2 leaves
+		customer B at the default 1 — B's second promotion is still refused."""
+		frappe.set_user("Administrator")
+		agents_api.raise_activation_ceiling(self.cust_a, "A's reviewer covers two packs")
+
+		self.assertEqual(agents_api._activation_ceiling(self.cust_a), 2)
+		self.assertEqual(agents_api._activation_ceiling(self.cust_b), 1)
+
+		# B promotes its first module (ok) but the second is refused — the A-grant
+		# never leaked to B.
+		frappe.set_user(self.rev_b)
+		agents_api.promote_installation(self.b1.name)
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.promote_installation(self.b2.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.b2.name, "activation_state"), "shadow")
+
+	def test_reviewer_capacity_gate_blocks_single_pack_customer(self):
+		"""A raise for a customer whose reviewer covers only ONE pack is refused by
+		the system-verified capacity gate (not just a free-text justification)."""
+		frappe.set_user("Administrator")
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.raise_activation_ceiling(self.cust_c, "please just trust me")
+		self.assertEqual(agents_api._activation_ceiling(self.cust_c), 1)
+
+	def test_raise_requires_a_real_named_customer(self):
+		frappe.set_user("Administrator")
+		with self.assertRaises(frappe.ValidationError):
+			agents_api.raise_activation_ceiling("", "no customer named")
+
+
+# --------------------------------------------------------------------------- #
+# PP-6 — promotion budget TOCTOU serialization (finding #1)
+# --------------------------------------------------------------------------- #
+class TestPromotionLockSerialization(FrappeTestCase):
+	SLUG = PREFIX + "lock"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("h-lock-owner@example.com")
+		cls.reviewer = _mk_user("h-lock-rev@example.com")
+		_mk_listing(cls.SLUG)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+		self.inst = _mk_install(self.owner, self.SLUG, self.reviewer)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe([self.SLUG])
+
+	def test_promotion_refused_when_activation_lock_unavailable(self):
+		"""The budget check is serialized on a per-customer lock; when the lock is held
+		elsewhere the promotion refuses rather than racing the read-check-flip window,
+		and the row stays shadow."""
+		frappe.set_user(self.reviewer)
+		with patch("jarvis._redis_lock.redis_lock", _lock_denied):
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.inst.name, "activation_state"), "shadow")
+
+	def test_promotion_holds_the_per_owner_lock(self):
+		"""The lock is keyed on the OWNER (customer), so all of a customer's activation
+		changes serialize against each other."""
+		seen = {}
+
+		@contextmanager
+		def _spy(name, **k):
+			seen["name"] = name
+			yield True
+
+		frappe.set_user(self.reviewer)
+		with patch("jarvis._redis_lock.redis_lock", _spy):
+			agents_api.promote_installation(self.inst.name)
+		frappe.set_user("Administrator")
+		self.assertEqual(seen["name"], f"jarvis_agent_activation:{self.owner}")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, self.inst.name, "activation_state"), "live")

--- a/jarvis/tests/test_platform_false_clean.py
+++ b/jarvis/tests/test_platform_false_clean.py
@@ -26,6 +26,9 @@ from jarvis.chat import agent_runs
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+PROVENANCE = "Jarvis Agent Provenance Event"
+DASHBOARD = "Jarvis Dashboard"
 
 SLUG = "platform-false-clean-test-agent"
 TOK_A = "tok_fc_a"
@@ -91,6 +94,26 @@ def _mk_run(owner: str) -> object:
 	return doc
 
 
+def _wipe_residue() -> None:
+	"""Slug-scoped teardown: remove every Run / Finding / Provenance / Dashboard row
+	this module persisted under its test-agent slug, so run-persistence residue never
+	accrues on the shared site. Belt-and-suspenders alongside the ``frappe.flags.in_test``
+	commit gate. Mirrors ``test_platform_activation._wipe``: raw ``frappe.db.delete`` +
+	commit (which also bypasses the append-only Provenance ``on_trash`` guard, legitimate
+	for deleting this module's OWN test residue)."""
+	dashboards = [
+		d
+		for d in frappe.get_all(RUN, filters={"agent": SLUG}, pluck="dashboard", ignore_permissions=True)
+		if d
+	]
+	frappe.db.delete(RUN, {"agent": SLUG})
+	frappe.db.delete(FINDING, {"agent": SLUG})
+	frappe.db.delete(PROVENANCE, {"agent": SLUG})
+	if dashboards:
+		frappe.db.delete(DASHBOARD, {"name": ["in", dashboards]})
+	frappe.db.commit()
+
+
 # --------------------------------------------------------------------------- #
 # PP-3 — the placeholder is filled, never leaked (unit, via _coverage_summary)
 # --------------------------------------------------------------------------- #
@@ -140,6 +163,12 @@ class TestPP2FalseCleanGate(FrappeTestCase):
 		cls.company = frappe.db.get_value("Company", {}, "name")
 		cls.inst = _mk_installation(cls.owner)
 		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe_residue()
+		super().tearDownClass()
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -195,6 +224,12 @@ class TestPP3CoverageNoteIsCustomerText(FrappeTestCase):
 		cls.company = frappe.db.get_value("Company", {}, "name")
 		cls.inst = _mk_installation(cls.owner)
 		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe_residue()
+		super().tearDownClass()
 
 	def setUp(self):
 		frappe.set_user("Administrator")

--- a/jarvis/tests/test_platform_false_clean.py
+++ b/jarvis/tests/test_platform_false_clean.py
@@ -1,0 +1,218 @@
+"""Regression tests for the three coverage-truthfulness defects fixed in
+``jarvis/chat/agent_runs.py`` (PP-2 / PP-3):
+
+  * The PP-2 false-clean gate — the required-check set is the agent's DECLARED
+    rule-token manifest (authoritative), NOT the writeback-supplied coverage keys.
+    A delegate under-reporting (empty / narrow / fabricated) coverage can never
+    earn ``evaluated_clean``.
+  * The PP-3 placeholder leak — coverage-gap remediation text substitutes the
+    typed manifest ``detail`` (or a neutral noun) into the ``{app}`` / ``{setting}``
+    placeholder, so a literal brace-string never reaches the customer.
+  * The PP-3 coverage_note — the amber "Partial scan" banner string carries the
+    customer remediation sentence, not the raw internal reason-code enum slug.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_false_clean
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_runs
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+
+SLUG = "platform-false-clean-test-agent"
+TOK_A = "tok_fc_a"
+TOK_B = "tok_fc_b"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Platform False-Clean Test Agent",
+				# DECLARED required manifest: TWO tokens (the authoritative bar).
+				"rule_tokens": json.dumps([TOK_A, TOK_B]),
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return SLUG
+
+
+def _mk_installation(owner: str) -> object:
+	name = frappe.db.get_value(INSTALLATION, {"agent": SLUG, "owner": owner}, "name")
+	if name:
+		return frappe.get_doc(INSTALLATION, name)
+	doc = frappe.get_doc({"doctype": INSTALLATION, "agent": SLUG, "run_as_user": owner, "reviewer": owner})
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_run(owner: str) -> object:
+	doc = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": SLUG,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": frappe.generate_hash(length=24),
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+# --------------------------------------------------------------------------- #
+# PP-3 — the placeholder is filled, never leaked (unit, via _coverage_summary)
+# --------------------------------------------------------------------------- #
+class TestPP3PlaceholderNeverLeaks(FrappeTestCase):
+	def test_detail_fills_placeholder(self):
+		_, notes = agent_runs._coverage_summary(
+			{
+				TOK_A: {
+					"state": "not_evaluable",
+					"reason_code": "app_absent_or_ineligible",
+					"detail": "India Compliance",
+				}
+			}
+		)
+		rem = notes[0]["remediation"]
+		self.assertIn("India Compliance", rem)
+		self.assertNotIn("{app}", rem)
+		self.assertNotIn("{", rem)
+
+	def test_missing_detail_uses_neutral_noun(self):
+		_, notes = agent_runs._coverage_summary(
+			{TOK_A: {"state": "not_evaluable", "reason_code": "configuration_missing"}}
+		)
+		rem = notes[0]["remediation"]
+		self.assertNotIn("{setting}", rem)
+		self.assertIn("the required setting", rem)
+
+	def test_no_placeholder_code_passes_through(self):
+		_, notes = agent_runs._coverage_summary(
+			{TOK_A: {"state": "not_evaluable", "reason_code": "rule_expired"}}
+		)
+		# ``rule_expired`` has no placeholder — text is unchanged and brace-free.
+		self.assertNotIn("{", notes[0]["remediation"])
+		self.assertIn("pending review", notes[0]["remediation"])
+
+
+# --------------------------------------------------------------------------- #
+# PP-2 — the required bar is the DECLARED manifest, not the coverage keys
+# --------------------------------------------------------------------------- #
+class TestPP2FalseCleanGate(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("fc-owner@example.com")
+		_mk_listing()
+		cls.company = frappe.db.get_value("Company", {}, "name")
+		cls.inst = _mk_installation(cls.owner)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def _record(self, coverage, findings=None):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run, self.inst, findings or [], coverage=coverage, scope={"company": self.company}
+		)
+		run.reload()
+		return run
+
+	def test_full_declared_coverage_is_clean(self):
+		run = self._record({TOK_A: "evaluated", TOK_B: "evaluated"})
+		self.assertEqual(run.result_state, "evaluated_clean")
+		# The authoritative required set is the DECLARED manifest, not the coverage keys.
+		blob = json.loads(run.coverage_json)
+		self.assertEqual(blob["required_tokens"], sorted([TOK_A, TOK_B]))
+
+	def test_empty_manifest_is_not_evaluable_never_clean(self):
+		# The exact false-clean PP-2 closes: an evaluator emits NO coverage + zero
+		# findings — it must not earn ``evaluated_clean``.
+		run = self._record({})
+		self.assertNotEqual(run.result_state, "evaluated_clean")
+		self.assertEqual(run.result_state, "not_evaluable")
+
+	def test_narrow_manifest_is_partial_never_clean(self):
+		# Only ONE of the two declared checks came back evaluated; zero findings.
+		run = self._record({TOK_A: "evaluated"})
+		self.assertNotEqual(run.result_state, "evaluated_clean")
+		self.assertEqual(run.result_state, "partial")
+
+	def test_fabricated_coverage_key_cannot_define_its_own_bar(self):
+		# An evaluator reports a token OUTSIDE the declared manifest as evaluated. It
+		# does not cover any declared required check → not_evaluable, never clean.
+		run = self._record({"tok_not_declared": "evaluated"})
+		self.assertNotEqual(run.result_state, "evaluated_clean")
+		self.assertEqual(run.result_state, "not_evaluable")
+		blob = json.loads(run.coverage_json)
+		self.assertEqual(blob["required_tokens"], sorted([TOK_A, TOK_B]))
+
+
+# --------------------------------------------------------------------------- #
+# PP-3 — the coverage_note banner carries remediation text, not the enum slug
+# --------------------------------------------------------------------------- #
+class TestPP3CoverageNoteIsCustomerText(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("fc-owner@example.com")
+		_mk_listing()
+		cls.company = frappe.db.get_value("Company", {}, "name")
+		cls.inst = _mk_installation(cls.owner)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def test_coverage_note_shows_remediation_not_reason_code(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[],
+			coverage={
+				TOK_A: {"state": "not_evaluable", "reason_code": "configuration_missing"},
+				TOK_B: "evaluated",
+			},
+			scope={"company": self.company},
+		)
+		run.reload()
+		note = run.coverage_note or ""
+		# the customer remediation sentence, NOT the internal enum slug
+		self.assertIn("Configure", note)
+		self.assertNotIn("configuration_missing", note)

--- a/jarvis/tests/test_platform_launch_provenance.py
+++ b/jarvis/tests/test_platform_launch_provenance.py
@@ -1,0 +1,210 @@
+"""PP-5 — launch-time provenance is STAMPED at run creation, not just guarded.
+
+The Round-4 panel found that ``_launch_audit`` created the ``Jarvis Agent Run``
+without ever setting the three immutable launch facts
+(``bundle_version`` / ``preparation_mode`` / ``initiating_human``), so they were
+always empty in production: ``preparation_mode`` never snapshotted the
+installation's ``activation_state``, ``initiating_human`` was unrecoverable on
+manual runs, and the controller's set-once guard could never engage because the
+stored value was always empty.
+
+These tests launch a REAL run through the shared ``_launch_audit`` path (the
+exact path the scheduler and ``run_agent_now`` take) and assert the stamped
+values — not merely that the controller guard fires when a value is pre-injected
+(that is covered by ``test_platform_writeback``). ``admin_client.post_agent_run``
+is stubbed so the dispatch returns without a live fleet, mirroring
+``test_agent_identity``.
+"""
+
+import unittest
+
+import frappe
+
+from jarvis.chat import agent_catalog, agent_scheduler, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+SESSION = "Jarvis Chat Session"
+AGENT = "close-auditor"
+
+
+def _ensure_user(email: str, extra_roles: tuple = ()) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert()
+	frappe.db.set_value("User", email, "enabled", 1, update_modified=False)
+	have = set(frappe.get_roles(email))
+	want = {"Jarvis User", *extra_roles}
+	missing = [r for r in want if r not in have]
+	if missing:
+		frappe.get_doc("User", email).add_roles(*missing)
+	# close-auditor declares doctypes_required (GL Entry / Account / Company); the
+	# run-as A12 gate needs the run-as user to hold those reads. Accounts User grants
+	# them without conferring Jarvis roles.
+	if frappe.db.exists("Role", "Accounts User") and "Accounts User" not in have:
+		frappe.get_doc("User", email).add_roles("Accounts User")
+	frappe.clear_cache(user=email)
+	frappe.db.commit()
+	return email
+
+
+def _install_as(owner: str) -> str:
+	original = frappe.session.user
+	frappe.set_user(owner)
+	try:
+		return agents_api.install_agent(AGENT)["data"]["name"]
+	finally:
+		frappe.set_user(original)
+
+
+class TestPlatformLaunchProvenance(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		agent_catalog.sync_agent_listings()
+		cls.owner = _ensure_user("plp-owner@example.com")
+		cls.listing_version = frappe.db.get_value(LISTING, AGENT, "version")
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._cleanup()
+		# Stub the fleet dispatch so _launch_audit completes without a live fleet.
+		import jarvis.admin_client as admin_client
+
+		self._orig_post = admin_client.post_agent_run
+		admin_client.post_agent_run = lambda **kw: {"run_id": kw.get("run_id"), "status": "queued"}
+
+	def tearDown(self):
+		import jarvis.admin_client as admin_client
+
+		admin_client.post_agent_run = self._orig_post
+		frappe.set_user("Administrator")
+		frappe.db.rollback()
+		self._cleanup()
+
+	def _cleanup(self):
+		frappe.db.delete(
+			"Jarvis Agent Allowed Role",
+			{"parenttype": LISTING, "parentfield": "allowed_roles"},
+		)
+		for dt in (RUN, INSTALLATION):
+			for n in frappe.get_all(dt, filters={"owner": self.owner}, pluck="name"):
+				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+		for n in frappe.get_all(SESSION, filters={"user": self.owner}, pluck="name"):
+			frappe.delete_doc(SESSION, n, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	# ------------------------------------------------------------------ #
+	# A MANUAL launch stamps all three immutable facts (PP-5 acceptance 1)
+	# ------------------------------------------------------------------ #
+	def test_manual_launch_stamps_all_three_facts(self):
+		inst_name = _install_as(self.owner)  # self-map: run_as == owner == triggerer
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		frappe.set_user(self.owner)
+		try:
+			result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+		run = result["run"]
+
+		vals = frappe.db.get_value(
+			RUN, run, ["bundle_version", "preparation_mode", "initiating_human"], as_dict=True
+		)
+		# bundle_version is the SNAPSHOT of the installed version (== listing.version
+		# at install), stamped even though listing/installation versions are mutable.
+		self.assertEqual(vals.bundle_version, inst.installed_version)
+		self.assertEqual(vals.bundle_version, self.listing_version)
+		# preparation_mode snapshots the installation's activation_state (fresh
+		# install is always shadow — PP-4).
+		self.assertEqual(vals.preparation_mode, "shadow")
+		# initiating_human is the human who triggered the manual run (self-mapped, so
+		# the run-as session user IS the triggerer here).
+		self.assertEqual(vals.initiating_human, self.owner)
+
+	# ------------------------------------------------------------------ #
+	# A SCHEDULED launch stamps bundle/prep but NO initiating_human
+	# ------------------------------------------------------------------ #
+	def test_scheduled_launch_has_no_initiating_human(self):
+		inst_name = _install_as(self.owner)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		# Mirror the scheduler's S1 hinge: the audit is created inside set_user(run_as).
+		frappe.set_user(self.owner)
+		try:
+			result = agent_scheduler._launch_audit(inst, trigger="scheduled")
+		finally:
+			frappe.set_user("Administrator")
+		run = result["run"]
+
+		vals = frappe.db.get_value(
+			RUN, run, ["bundle_version", "preparation_mode", "initiating_human"], as_dict=True
+		)
+		self.assertEqual(vals.bundle_version, inst.installed_version)
+		self.assertEqual(vals.preparation_mode, "shadow")
+		# No human initiated a cron run.
+		self.assertFalse(vals.initiating_human)
+
+	# ------------------------------------------------------------------ #
+	# The STAMPED value now engages the controller's set-once guard
+	# (the finding: the guard "never even engages because stored is empty")
+	# ------------------------------------------------------------------ #
+	def test_stamped_bundle_version_is_immutable(self):
+		inst_name = _install_as(self.owner)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		frappe.set_user(self.owner)
+		try:
+			result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+		run = result["run"]
+
+		# stored is now NON-empty, so the PP-5 guard engages on an ORM re-save.
+		doc = frappe.get_doc(RUN, run)
+		doc.bundle_version = "tampered-9.9.9"
+		with self.assertRaises(frappe.PermissionError):
+			doc.save(ignore_permissions=True)
+
+	# ------------------------------------------------------------------ #
+	# preparation_mode is a SNAPSHOT: a later promotion does not rewrite it
+	# ------------------------------------------------------------------ #
+	def test_preparation_mode_snapshots_shadow_even_when_installed_state_changes(self):
+		inst_name = _install_as(self.owner)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		frappe.set_user(self.owner)
+		try:
+			result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+		run = result["run"]
+
+		self.assertEqual(frappe.db.get_value(RUN, run, "preparation_mode"), "shadow")
+		# Even if the installation is later flipped live, the run's stamped snapshot
+		# stays shadow (raw set_value on the install; the run field is immutable).
+		frappe.db.set_value(INSTALLATION, inst_name, "activation_state", "live", update_modified=False)
+		frappe.db.commit()
+		self.assertEqual(frappe.db.get_value(RUN, run, "preparation_mode"), "shadow")

--- a/jarvis/tests/test_platform_provenance_perms.py
+++ b/jarvis/tests/test_platform_provenance_perms.py
@@ -1,0 +1,128 @@
+"""PP-5 provenance ledger — permission scoping (panel blocker fix).
+
+The ``Jarvis Agent Provenance Event`` ledger references ``installation``,
+``reviewing_human``, ``initiating_human`` and ``detail`` (promotion sign-offs
+and the PP-6 reviewer-capacity justifications). It previously granted the
+``Jarvis User`` role ``if_owner`` read with NO ``permission_query_conditions`` /
+``has_permission`` hook registered in ``hooks.py`` — the same anti-pattern the
+security-review parts eliminated. Because the ledger writer inserts events with
+``ignore_permissions`` (agents_api._append_provenance_event) the row ``owner`` is
+whoever/whatever was in session at append time, so ``if_owner`` was neither a
+reliable nor a sufficient tenant boundary: a cross-tenant / PII leak over
+generic REST GET ``/api/resource/Jarvis Agent Provenance Event``.
+
+The fix drops the ``Jarvis User`` read grant entirely from the doctype: the
+ledger is now readable only by the oversight tier (System Manager, Jarvis Admin,
+Administrator). No user-facing surface reads the ledger over generic REST today
+(events are written server-side and the promotion / ceiling-raise APIs return
+only the event name), so nothing legitimate depends on the dropped grant.
+
+These tests assert the boundary directly: a plain Jarvis User can neither list
+nor open a provenance event, while the oversight tier still can.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+PROVENANCE = "Jarvis Agent Provenance Event"
+
+USER_A = "ppprov-usera@example.com"
+ADMIN_USER = "ppprov-admin@example.com"
+PFX = "ppprov"
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+def _ensure_user(email: str, roles: list[str]) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": PFX,
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	# Force the exact role set (drop System Manager so the role gates are real).
+	if "System Manager" in set(frappe.get_roles(email)):
+		frappe.get_doc("User", email).remove_roles("System Manager")
+	have = set(frappe.get_roles(email))
+	add = [r for r in roles if r not in have]
+	if add:
+		frappe.get_doc("User", email).add_roles(*add)
+	strip = [
+		r
+		for r in ("Jarvis User", "Jarvis Skill Reviewer", "Jarvis Admin")
+		if r not in roles and r in set(frappe.get_roles(email))
+	]
+	if strip:
+		frappe.get_doc("User", email).remove_roles(*strip)
+	return email
+
+
+def _mk_event(**fields) -> str:
+	doc = frappe.get_doc({"doctype": PROVENANCE, "event_type": "run_launched", **fields})
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestProvenanceLedgerScoping(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(USER_A, ["Jarvis User"])
+		_ensure_user(ADMIN_USER, ["Jarvis User", "Jarvis Admin"])
+		# An event whose owner is a *foreign* user, carrying reviewer sign-off PII.
+		cls.event = _mk_event(
+			reviewing_human=ADMIN_USER,
+			initiating_human=ADMIN_USER,
+			detail=f"{PFX} reviewer-capacity justification (sensitive)",
+			event_type="agent_promoted_to_live",
+		)
+		# Re-home the row owner to USER_A to prove even if_owner would have leaked.
+		frappe.db.set_value(PROVENANCE, cls.event, "owner", USER_A, update_modified=False)
+
+	def test_jarvis_user_cannot_list_provenance_events(self):
+		with _as(USER_A):
+			self.assertFalse(
+				frappe.has_permission(PROVENANCE, "read", user=USER_A),
+				"Jarvis User must have NO read grant on the provenance ledger",
+			)
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_list(PROVENANCE, filters={"detail": ["like", f"{PFX}%"]}, pluck="name")
+
+	def test_jarvis_user_cannot_open_a_provenance_event(self):
+		with _as(USER_A):
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_doc(PROVENANCE, self.event).check_permission("read")
+
+	def test_admin_tier_still_reads_the_ledger(self):
+		with _as(ADMIN_USER):
+			self.assertTrue(frappe.has_permission(PROVENANCE, "read", user=ADMIN_USER))
+			names = set(frappe.get_list(PROVENANCE, filters={"detail": ["like", f"{PFX}%"]}, pluck="name"))
+		self.assertIn(self.event, names)
+
+	def test_system_manager_reads_the_ledger(self):
+		with _as("Administrator"):
+			names = set(frappe.get_list(PROVENANCE, filters={"detail": ["like", f"{PFX}%"]}, pluck="name"))
+		self.assertIn(self.event, names)

--- a/jarvis/tests/test_platform_schema.py
+++ b/jarvis/tests/test_platform_schema.py
@@ -1,0 +1,237 @@
+"""Phase-A schema checks for the platform prerequisites (PP-1..PP-6).
+
+Asserts the doctype fields, Select enums, the new provenance-event doctype, the
+Settings ceiling, and the shared ``coverage_reasons`` enum module all exist with
+the EXACT contract names later phases build on. Schema-only — the runtime
+enforcement (set-once, writeback drops, strong-verb gating, append-only writes)
+is covered by the per-PP behaviour tests.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import coverage_reasons as cr
+
+
+def _field(doctype: str, fieldname: str):
+	return frappe.get_meta(doctype).get_field(fieldname)
+
+
+def _options(doctype: str, fieldname: str) -> list:
+	f = _field(doctype, fieldname)
+	return [o for o in (f.options or "").split("\n") if o]
+
+
+class TestPlatformSchemaEnums(FrappeTestCase):
+	def test_result_class_enum(self):
+		self.assertEqual(
+			cr.RESULT_CLASSES,
+			("observed_fact", "derived_candidate", "legal_scenario", "confirmed_outcome"),
+		)
+		self.assertEqual(cr.RESERVED_RESULT_CLASS, "confirmed_outcome")
+		self.assertEqual(cr.DEFAULT_RESULT_CLASS, "observed_fact")
+
+	def test_run_state_enum(self):
+		self.assertEqual(
+			cr.RUN_STATES,
+			("evaluated_clean", "partial", "not_evaluable", "failed"),
+		)
+		self.assertEqual(cr.CLEAN_RUN_STATE, "evaluated_clean")
+
+	def test_reason_code_enum_is_the_closed_nine(self):
+		self.assertEqual(
+			set(cr.REASON_CODES),
+			{
+				"app_absent_or_ineligible",
+				"permission_slice",
+				"configuration_missing",
+				"record_coverage_insufficient",
+				"source_stale",
+				"rule_expired",
+				"external_evidence_absent",
+				"run_truncated_watermark",
+				"unsupported_customisation",
+			},
+		)
+		# every code carries the full metadata contract
+		for code, meta in cr.REASON_CODES.items():
+			self.assertIn("remediation", meta, code)
+			self.assertIn("retryable", meta, code)
+			self.assertIn("routing", meta, code)
+			self.assertIsInstance(meta["retryable"], bool, code)
+
+	def test_reason_code_coercion_fail_safe(self):
+		self.assertEqual(cr.coerce_reason_code("source_stale"), ("source_stale", ""))
+		# an unknown string is coerced, never dropped; raw preserved in detail
+		code, detail = cr.coerce_reason_code("some novel gibberish")
+		self.assertEqual(code, "unsupported_customisation")
+		self.assertEqual(detail, "some novel gibberish")
+
+	def test_result_class_required_metadata(self):
+		self.assertEqual(cr.required_metadata_for("observed_fact"), ())
+		self.assertEqual(
+			cr.required_metadata_for("derived_candidate"),
+			("confidence", "match_basis", "false_positive_path"),
+		)
+		self.assertEqual(
+			cr.required_metadata_for("legal_scenario"),
+			("rule_version", "source", "reviewer"),
+		)
+		# a derived_candidate row missing metadata is reported missing
+		self.assertEqual(
+			set(cr.missing_metadata("derived_candidate", {"confidence": 90})),
+			{"match_basis", "false_positive_path"},
+		)
+
+
+class TestPlatformSchemaFindingFields(FrappeTestCase):
+	DT = "Jarvis Agent Finding"
+
+	def test_result_class_field(self):
+		f = _field(self.DT, "result_class")
+		self.assertIsNotNone(f)
+		self.assertEqual(f.fieldtype, "Select")
+		self.assertEqual(f.reqd, 1)
+		self.assertEqual(_options(self.DT, "result_class"), list(cr.RESULT_CLASSES))
+
+	def test_derived_candidate_metadata_fields(self):
+		for fn, ft in (
+			("confidence", "Percent"),
+			("match_basis", "Small Text"),
+			("false_positive_path", "Small Text"),
+			("confirmation_status", "Select"),
+		):
+			f = _field(self.DT, fn)
+			self.assertIsNotNone(f, fn)
+			self.assertEqual(f.fieldtype, ft, fn)
+		self.assertEqual(_options(self.DT, "confirmation_status"), list(cr.CONFIRMATION_STATUSES))
+
+	def test_legal_scenario_metadata_fields(self):
+		for fn in ("rule_version", "assumptions", "known_exceptions", "source", "reviewer"):
+			self.assertIsNotNone(_field(self.DT, fn), fn)
+
+	def test_provenance_fields(self):
+		for fn in (
+			"outcome_provenance",
+			"resolved_by",
+			"resolved_at",
+			"resolution_kind",
+			"result_link_doctype",
+			"result_link_name",
+		):
+			self.assertIsNotNone(_field(self.DT, fn), fn)
+		self.assertEqual(
+			_options(self.DT, "resolution_kind"),
+			["human", "auto_coverage", "auto_watermark"],
+		)
+
+
+class TestPlatformSchemaRunFields(FrappeTestCase):
+	DT = "Jarvis Agent Run"
+
+	def test_result_state_field(self):
+		f = _field(self.DT, "result_state")
+		self.assertIsNotNone(f)
+		self.assertEqual(f.fieldtype, "Select")
+		self.assertEqual(f.read_only, 1)
+		self.assertEqual(_options(self.DT, "result_state"), list(cr.RUN_STATES))
+
+	def test_pp5_launch_fields(self):
+		for fn in ("bundle_version", "preparation_mode", "initiating_human"):
+			f = _field(self.DT, fn)
+			self.assertIsNotNone(f, fn)
+			self.assertEqual(f.read_only, 1, fn)
+		self.assertEqual(_options(self.DT, "preparation_mode"), ["shadow", "live"])
+
+
+class TestPlatformSchemaApprovalFields(FrappeTestCase):
+	DT = "Jarvis Approval Request"
+
+	def test_pp5_and_pp1_fields(self):
+		for fn in ("agent", "run", "preparation_mode", "result_class"):
+			self.assertIsNotNone(_field(self.DT, fn), fn)
+		# result_class is NOT reqd on approvals (human requests leave it blank)
+		self.assertFalse(_field(self.DT, "result_class").reqd)
+		self.assertEqual(_options(self.DT, "result_class"), list(cr.RESULT_CLASSES))
+
+
+class TestPlatformSchemaInstallationFields(FrappeTestCase):
+	DT = "Jarvis Agent Installation"
+
+	def test_pp4_activation_fields(self):
+		f = _field(self.DT, "activation_state")
+		self.assertIsNotNone(f)
+		self.assertEqual(_options(self.DT, "activation_state"), ["shadow", "live"])
+		self.assertEqual(f.default, "shadow")
+		reviewer = _field(self.DT, "reviewer")
+		self.assertIsNotNone(reviewer)
+		self.assertEqual(reviewer.reqd, 1)
+		for fn in ("promoted_by", "promoted_at"):
+			self.assertIsNotNone(_field(self.DT, fn), fn)
+
+	def test_pp3_installable_fields(self):
+		f = _field(self.DT, "installable")
+		self.assertIsNotNone(f)
+		self.assertEqual(f.fieldtype, "Check")
+		nir = _field(self.DT, "not_installable_reason")
+		self.assertIsNotNone(nir)
+		# the closed reason enum is a subset of its options
+		self.assertTrue(set(cr.REASON_CODES).issubset(set(_options(self.DT, "not_installable_reason"))))
+
+
+class TestPlatformSchemaSettingsAndProvenance(FrappeTestCase):
+	def test_activation_module_ceiling(self):
+		f = _field("Jarvis Settings", "activation_module_ceiling")
+		self.assertIsNotNone(f)
+		self.assertEqual(f.fieldtype, "Int")
+		self.assertEqual(str(f.default), "1")
+
+	def test_provenance_event_doctype_and_fields(self):
+		self.assertTrue(frappe.db.exists("DocType", "Jarvis Agent Provenance Event"))
+		meta = frappe.get_meta("Jarvis Agent Provenance Event")
+		for fn in (
+			"event_type",
+			"agent",
+			"bundle_version",
+			"run",
+			"installation",
+			"preparation_mode",
+			"initiating_human",
+			"reviewing_human",
+			"outcome",
+			"finding",
+			"approval",
+			"result_link_doctype",
+			"result_link_name",
+			"occurred_at",
+		):
+			self.assertIsNotNone(meta.get_field(fn), fn)
+		event_opts = [o for o in (meta.get_field("event_type").options or "").split("\n") if o]
+		for required in (
+			"run_launched",
+			"finding_raised",
+			"approval_requested",
+			"approval_decided",
+			"draft_created",
+			"transaction_posted",
+			"finding_resolved",
+			"agent_promoted_to_live",
+			"incident_raised",
+		):
+			self.assertIn(required, event_opts, required)
+
+	def test_provenance_event_is_append_only(self):
+		ev = frappe.get_doc(
+			{
+				"doctype": "Jarvis Agent Provenance Event",
+				"event_type": "run_launched",
+			}
+		).insert(ignore_permissions=True)
+		self.assertTrue(ev.occurred_at)
+		# a persisted event cannot be modified...
+		ev.detail = "tampered"
+		with self.assertRaises(frappe.PermissionError):
+			ev.save(ignore_permissions=True)
+		# ...nor deleted (even with permissions ignored)
+		with self.assertRaises(frappe.PermissionError):
+			frappe.delete_doc("Jarvis Agent Provenance Event", ev.name, ignore_permissions=True, force=True)

--- a/jarvis/tests/test_platform_shadow_dashboard.py
+++ b/jarvis/tests/test_platform_shadow_dashboard.py
@@ -1,0 +1,220 @@
+"""PP-4 regression: a delegate-AUTHORED dashboard (``jarvis__save_agent_dashboard``)
+must carry the SAME shadow enforcement as the server-generated fallback.
+
+The panel finding: the authored dashboard WINS the precedence in
+``record_delegate_run`` (richer artifact), but ``save_agent_dashboard`` created it
+with NO ``owner_override`` and never routed the authored HTML through the shadow
+gate. On a SHADOW installation that left the primary dashboard owner-owned (visible
+on the general owner surface) and free to render an outward clean/compliant
+attestation — exactly what PP-4 forbids.
+
+These tests drive the tool exactly as the plugin path would (session_key resolved
+from context to the run) and assert:
+
+  * shadow → the authored dashboard is re-homed to the named reviewer (owner surface
+    cannot read it; the reviewer can), the preview banner is stamped in-body, and a
+    PP-1 strong verb the author emitted is neutralised;
+  * live (control) → unchanged: the authored dashboard stays owner-owned with no
+    preview banner.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_shadow_dashboard
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import dashboard_permissions
+from jarvis.tools import _agent_run_ctx
+from jarvis.tools.save_agent_dashboard import save_agent_dashboard
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+DASHBOARD = "Jarvis Dashboard"
+
+SLUG = "platform-shadow-dash-agent"
+TOKEN = "tok_sd_1"
+
+# Authored HTML carrying BOTH an outward compliant claim and a PP-1 strong verb —
+# the shadow gate must neutralise the verb and stamp the preview banner.
+AUTHORED_HTML = (
+	"<!doctype html><html><head><title>Close</title></head>"
+	"<body><h1>Fully compliant close</h1>"
+	"<p>This run recovered 5,000 and prevented a misstatement.</p></body></html>"
+)
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.insert(ignore_permissions=True)
+		u.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Platform Shadow Dashboard Agent",
+				"rule_tokens": json.dumps([TOKEN]),
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return SLUG
+
+
+def _mk_installation(owner: str, reviewer: str, activation_state: str) -> object:
+	# A new installation always activates in shadow (controller-enforced). For the
+	# LIVE fixture, flip the flag directly on the row (bypassing the promotion path)
+	# so this test exercises only the dashboard-ownership behaviour.
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": SLUG,
+			"run_as_user": owner,
+			"reviewer": reviewer,
+			"activation_state": "shadow",
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	if activation_state == "live":
+		frappe.db.set_value(INSTALLATION, doc.name, "activation_state", "live", update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_run(owner: str, inst, session_key: str) -> str:
+	doc = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": SLUG,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": session_key,
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(RUN, doc.name, "owner", owner, update_modified=False)
+	return doc.name
+
+
+def _wipe():
+	for dt in (RUN, DASHBOARD, INSTALLATION):
+		filt = {"agent": SLUG} if dt in (RUN, INSTALLATION) else {"dashboard_title": ["like", "%"]}
+		if dt == DASHBOARD:
+			# Only the dashboards this suite's runs created (owned by our two users).
+			names = frappe.get_all(
+				DASHBOARD,
+				filters={"owner": ["in", ["sd-owner@example.com", "sd-reviewer@example.com"]]},
+				pluck="name",
+				ignore_permissions=True,
+			)
+		else:
+			names = frappe.get_all(dt, filters=filt, pluck="name", ignore_permissions=True)
+		for n in names:
+			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+class TestPP4ShadowAuthoredDashboard(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("sd-owner@example.com")
+		cls.reviewer = _mk_user("sd-reviewer@example.com")
+		_mk_listing()
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_agent_run_ctx.clear_session_key()
+		_wipe()
+
+	def _call_save(self, owner, session_key, **kwargs):
+		frappe.set_user(owner)
+		_agent_run_ctx.set_session_key(session_key)
+		try:
+			return save_agent_dashboard(**kwargs)
+		finally:
+			_agent_run_ctx.clear_session_key()
+			frappe.set_user("Administrator")
+
+	# ------------------------------------------------------------------ #
+	# shadow: re-home to reviewer + preview banner + strong-verb neutralise
+	# ------------------------------------------------------------------ #
+	def test_shadow_authored_dashboard_rehomed_and_gated(self):
+		inst = _mk_installation(self.owner, self.reviewer, "shadow")
+		sk = "agent:shadow-dash:" + frappe.generate_hash(length=8)
+		run = _mk_run(self.owner, inst, sk)
+
+		out = self._call_save(self.owner, sk, html=AUTHORED_HTML, title="Close Summary")
+		dash = out["dashboard"]
+		self.assertTrue(dash)
+		self.assertEqual(frappe.db.get_value(RUN, run, "dashboard"), dash)
+
+		d = frappe.get_doc(DASHBOARD, dash)
+		# (1) re-homed to the named reviewer — NOT the general owner surface.
+		self.assertEqual(d.owner, self.reviewer)
+		self.assertEqual(d.target_user, self.reviewer)
+
+		# read path: the general owner cannot read it; the reviewer can.
+		self.assertFalse(dashboard_permissions.can_read_dashboard(d, self.owner))
+		self.assertTrue(dashboard_permissions.can_read_dashboard(d, self.reviewer))
+
+		# (2) the in-body preview banner is stamped, screenshot-safe.
+		self.assertIn("Preview (shadow)", d.html)
+		self.assertIn('data-result-state="shadow"', d.html)
+		# the banner sits INSIDE the body (after <body>), not as detachable chrome.
+		self.assertLess(d.html.lower().find("<body"), d.html.find("Preview (shadow)"))
+
+		# (2b) the authored strong verbs are neutralised (never confirmed_outcome).
+		self.assertNotIn("recovered 5,000", d.html)
+		self.assertNotIn("prevented a misstatement", d.html)
+
+	# ------------------------------------------------------------------ #
+	# live control: authored dashboard unchanged (owner-owned, no banner)
+	# ------------------------------------------------------------------ #
+	def test_live_authored_dashboard_owner_owned_no_banner(self):
+		inst = _mk_installation(self.owner, self.reviewer, "live")
+		sk = "agent:live-dash:" + frappe.generate_hash(length=8)
+		run = _mk_run(self.owner, inst, sk)
+
+		out = self._call_save(self.owner, sk, html=AUTHORED_HTML, title="Close Summary")
+		dash = out["dashboard"]
+		self.assertEqual(frappe.db.get_value(RUN, run, "dashboard"), dash)
+
+		d = frappe.get_doc(DASHBOARD, dash)
+		# live: stays on the owner surface (visibility owner == installer owner).
+		self.assertEqual(d.owner, self.owner)
+		self.assertEqual(d.target_user, self.owner)
+		self.assertTrue(dashboard_permissions.can_read_dashboard(d, self.owner))
+		# no shadow preview banner — the authored artifact is presented as-is.
+		self.assertNotIn("Preview (shadow)", d.html)
+		self.assertIn("Fully compliant close", d.html)

--- a/jarvis/tests/test_platform_writeback.py
+++ b/jarvis/tests/test_platform_writeback.py
@@ -41,6 +41,32 @@ DASHBOARD = "Jarvis Dashboard"
 
 SLUG = "platform-writeback-test-agent"
 TOKEN = "tok_pw_1"
+WB_COMPANY = "Jarvis Writeback Test Co"
+
+
+def _ensure_company() -> str:
+	"""A bare Company row (a fresh CI site — restored from a frappe+erpnext+hrms
+	dump — never ran the erpnext setup wizard, so it has NO Company). We only need a
+	row that exists() so a Company-keyed finding ref verifies (Company is
+	existence-checked, not read-gated), and a non-empty company string so the A16
+	coverage-scoped auto-resolve is in-scope. Mirrors
+	test_agent_dashboard_wire._ensure_company."""
+	if not frappe.db.exists("Company", WB_COMPANY):
+		c = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": WB_COMPANY,
+				"abbr": "JWBTC",
+				"default_currency": "INR",
+				"country": "India",
+			}
+		)
+		c.name = WB_COMPANY
+		c.flags.ignore_links = True
+		c.flags.ignore_mandatory = True
+		c.db_insert()
+		frappe.db.commit()
+	return WB_COMPANY
 
 
 def _mk_user(email: str) -> str:
@@ -156,8 +182,17 @@ class TestPP1ResultClassValidation(FrappeTestCase):
 		super().setUpClass()
 		# The ref-existence gate runs before the result_class gate (a nonexistent
 		# ref is dropped first), so use a real, existence-exempt Company ref to
-		# isolate the class-validation branch under test.
-		cls.company = frappe.db.get_value("Company", {}, "name")
+		# isolate the class-validation branch under test. Create the row ourselves —
+		# a fresh CI site has NO Company, and `get_value("Company", {})` would return
+		# None (every _ok_ref would then drop as "ref does not exist" before the
+		# result_class branch is ever reached).
+		cls.company = _ensure_company()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.sql("delete from `tabCompany` where name=%s", WB_COMPANY)
+		frappe.db.commit()
+		super().tearDownClass()
 
 	def _ok_ref(self, **over):
 		return _finding(ref_doctype="Company", ref_name=self.company, **over)
@@ -377,7 +412,10 @@ class TestWritebackIntegration(FrappeTestCase):
 		frappe.set_user("Administrator")
 		cls.owner = _mk_user("pw-owner@example.com")
 		_mk_listing()
-		cls.company = frappe.db.get_value("Company", {}, "name")
+		# Real, non-empty company: the A16 auto-resolve is company-scoped and skips a
+		# scopeless/empty-company run, so a fresh CI site's None here would leave the
+		# open finding unresolved. Create the row so the scope matches.
+		cls.company = _ensure_company()
 		cls.inst = _mk_installation(cls.owner)
 		frappe.db.commit()
 
@@ -385,6 +423,8 @@ class TestWritebackIntegration(FrappeTestCase):
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
 		_wipe_residue()
+		frappe.db.sql("delete from `tabCompany` where name=%s", WB_COMPANY)
+		frappe.db.commit()
 		super().tearDownClass()
 
 	def setUp(self):

--- a/jarvis/tests/test_platform_writeback.py
+++ b/jarvis/tests/test_platform_writeback.py
@@ -1,0 +1,469 @@
+"""Phase-B runtime tests for the platform prerequisites (PP-1/2/3/5).
+
+These assert the WRITEBACK enforcement the schema (Phase A) only declared:
+
+  * PP-1 — ``record_agent_run`` requires a valid ``result_class`` per finding,
+    rejects the reserved ``confirmed_outcome`` from the evaluator path, rejects a
+    candidate/legal row missing its class-conditional metadata; ``result_class`` is
+    set-once at the controller; strong verbs are unreachable in rendered output
+    unless the row is ``confirmed_outcome`` with resolving outcome provenance.
+  * PP-2 — a run resolves EXACTLY one coverage-verdict ``result_state`` at
+    writeback; the clean "No exceptions were found" sentence is UNREACHABLE unless
+    ``evaluated_clean``; the state renders in-body (screenshot-safe).
+  * PP-3 — typed reason codes round-trip through the coverage manifest, an unknown
+    code is coerced (never dropped), and each code's remediation text surfaces in
+    the rendered degradation section.
+  * PP-5 — run launch-time facts (bundle_version / preparation_mode /
+    initiating_human) are immutable once stamped; A16 auto-resolve stamps
+    ``resolution_kind = auto_coverage`` + ``resolved_at``; provenance events are
+    append-only.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_writeback
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_runs
+from jarvis.chat import coverage_reasons as cr
+from jarvis.tools.record_agent_run import _validate_findings
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+
+SLUG = "platform-writeback-test-agent"
+TOKEN = "tok_pw_1"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Platform Writeback Test Agent",
+				"rule_tokens": json.dumps([TOKEN]),
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return SLUG
+
+
+def _mk_installation(owner: str) -> object:
+	name = frappe.db.get_value(INSTALLATION, {"agent": SLUG, "owner": owner}, "name")
+	if name:
+		return frappe.get_doc(INSTALLATION, name)
+	doc = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": SLUG,
+			"run_as_user": owner,
+			"reviewer": owner,
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_run(owner: str, **extra) -> object:
+	vals = {
+		"doctype": RUN,
+		"agent": SLUG,
+		"trigger": "manual",
+		"status": "running",
+		"started_at": frappe.utils.now(),
+		"session_key": frappe.generate_hash(length=24),
+	}
+	vals.update(extra)
+	doc = frappe.get_doc(vals)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _finding(**over) -> dict:
+	f = {
+		"token": TOKEN,
+		"ref_doctype": "Company",
+		"ref_name": "PW-Ref",
+		"amount": 100,
+		"severity": "note",
+		"note": "an authored finding note",
+		"result_class": "observed_fact",
+	}
+	f.update(over)
+	return f
+
+
+# --------------------------------------------------------------------------- #
+# PP-1 — result-class validation (the reject paths) at the tool boundary
+# --------------------------------------------------------------------------- #
+class TestPP1ResultClassValidation(FrappeTestCase):
+	TOKENS = {TOKEN}
+	REFS = {"Company", "Account"}
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# The ref-existence gate runs before the result_class gate (a nonexistent
+		# ref is dropped first), so use a real, existence-exempt Company ref to
+		# isolate the class-validation branch under test.
+		cls.company = frappe.db.get_value("Company", {}, "name")
+
+	def _ok_ref(self, **over):
+		return _finding(ref_doctype="Company", ref_name=self.company, **over)
+
+	def _drop_reason(self, f):
+		valid, dropped = _validate_findings([f], self.TOKENS, self.REFS)
+		self.assertEqual(valid, [], "expected the row to be dropped")
+		self.assertEqual(len(dropped), 1)
+		return dropped[0]["reason"]
+
+	def test_missing_result_class_is_dropped(self):
+		f = self._ok_ref()
+		f.pop("result_class")
+		self.assertIn("result_class", self._drop_reason(f))
+
+	def test_invalid_result_class_is_dropped(self):
+		self.assertIn("result_class", self._drop_reason(self._ok_ref(result_class="wat")))
+
+	def test_confirmed_outcome_from_evaluator_is_dropped(self):
+		reason = self._drop_reason(self._ok_ref(result_class="confirmed_outcome"))
+		self.assertIn("may not emit confirmed_outcome", reason)
+
+	def test_derived_candidate_missing_metadata_is_dropped(self):
+		reason = self._drop_reason(self._ok_ref(result_class="derived_candidate", confidence=90))
+		self.assertIn("derived_candidate missing", reason)
+		self.assertIn("match_basis", reason)
+		self.assertIn("false_positive_path", reason)
+
+	def test_legal_scenario_missing_metadata_is_dropped(self):
+		reason = self._drop_reason(self._ok_ref(result_class="legal_scenario", rule_version="v1"))
+		self.assertIn("legal_scenario missing", reason)
+		self.assertIn("source", reason)
+		self.assertIn("reviewer", reason)
+
+	def test_complete_rows_pass(self):
+		obs = self._ok_ref()
+		cand = self._ok_ref(
+			result_class="derived_candidate",
+			confidence=90,
+			match_basis="2B-match",
+			false_positive_path="vendor alias",
+		)
+		legal = self._ok_ref(
+			result_class="legal_scenario",
+			rule_version="GST-2024",
+			source="Sec 16(2)",
+			reviewer="Administrator",
+		)
+		valid, dropped = _validate_findings([obs, cand, legal], self.TOKENS, self.REFS)
+		self.assertEqual(dropped, [])
+		self.assertEqual(len(valid), 3)
+
+
+# --------------------------------------------------------------------------- #
+# PP-1 — strong-verb gating (a shared helper refuses the token)
+# --------------------------------------------------------------------------- #
+class TestPP1StrongVerbHelper(FrappeTestCase):
+	def test_verb_stripped_for_non_confirmed_class(self):
+		out = cr.render_value_text("We saved 5,000 and recovered 200", "observed_fact")
+		self.assertNotIn("saved", out)
+		self.assertNotIn("recovered", out)
+		self.assertIn(cr.STRONG_VERB_REPLACEMENT, out)
+
+	def test_verb_allowed_only_for_confirmed_outcome_with_provenance(self):
+		txt = "recovered 5,000"
+		# confirmed_outcome + resolving provenance → the verb renders verbatim
+		self.assertEqual(cr.render_value_text(txt, "confirmed_outcome", outcome_provenance="EVENT-1"), txt)
+		# confirmed_outcome WITHOUT provenance → still gated
+		self.assertNotIn("recovered", cr.render_value_text(txt, "confirmed_outcome"))
+
+	def test_strict_mode_raises(self):
+		with self.assertRaises(ValueError):
+			cr.render_value_text("prevented a duplicate payment", "observed_fact", strict=True)
+
+	def test_no_verb_text_passes_through(self):
+		self.assertEqual(cr.render_value_text("a plain note", "observed_fact"), "a plain note")
+
+
+# --------------------------------------------------------------------------- #
+# PP-2 — the one coverage-verdict resolved at writeback + render gating
+# --------------------------------------------------------------------------- #
+class TestPP2RunStateResolution(FrappeTestCase):
+	def test_evaluated_clean_only_when_complete_and_no_gate(self):
+		self.assertEqual(
+			cr.resolve_run_state(required_tokens={"a"}, evaluated_tokens={"a"}, partial=False),
+			"evaluated_clean",
+		)
+
+	def test_all_required_not_evaluable_is_not_evaluable(self):
+		self.assertEqual(
+			cr.resolve_run_state(required_tokens={"a", "b"}, evaluated_tokens=set(), partial=True),
+			"not_evaluable",
+		)
+
+	def test_some_evaluated_incomplete_is_partial(self):
+		self.assertEqual(
+			cr.resolve_run_state(required_tokens={"a", "b"}, evaluated_tokens={"a"}, partial=True),
+			"partial",
+		)
+
+	def test_exec_failure_is_failed(self):
+		self.assertEqual(
+			cr.resolve_run_state(required_tokens={"a"}, evaluated_tokens=set(), partial=True, failed=True),
+			"failed",
+		)
+
+
+class TestPP2FalseCleanUnreachable(FrappeTestCase):
+	def _html(self, result_state, notes=None):
+		return agent_runs._fallback_dashboard_html(
+			"T",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"",
+			result_state=result_state,
+			coverage_notes=notes,
+		)
+
+	def test_clean_sentence_only_for_evaluated_clean(self):
+		self.assertIn("No exceptions were found", self._html("evaluated_clean"))
+
+	def test_partial_hides_clean_sentence(self):
+		html = self._html("partial")
+		self.assertNotIn("No exceptions were found", html)
+		self.assertIn("absence of findings is not a clean result", html)
+
+	def test_not_evaluable_hides_clean_sentence(self):
+		html = self._html("not_evaluable")
+		self.assertNotIn("No exceptions were found", html)
+		self.assertIn("could not evaluate the required checks", html)
+
+	def test_failed_hides_clean_sentence(self):
+		self.assertNotIn("No exceptions were found", self._html("failed"))
+
+	def test_state_survives_banner_strip(self):
+		"""PP-2 export/screenshot safety: the state is in the document body, not only
+		in the detachable partial banner. Strip the banner and the state persists."""
+		html = agent_runs._fallback_dashboard_html(
+			"T",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"scoped visibility — findings not auto-resolved",
+			result_state="partial",
+		)
+		# remove the banner substring entirely
+		banner_marker = "Partial run — "
+		self.assertIn(banner_marker, html)
+		stripped = html.split(banner_marker)[0] + html.split(banner_marker)[1].split("</div>", 1)[1]
+		self.assertIn('data-result-state="partial"', stripped)
+		self.assertIn("Partial coverage", stripped)
+
+
+# --------------------------------------------------------------------------- #
+# PP-3 — typed reason codes at writeback + remediation surfacing
+# --------------------------------------------------------------------------- #
+class TestPP3TypedReasonCodes(FrappeTestCase):
+	def test_all_nine_codes_round_trip(self):
+		coverage = {
+			f"tok_{i}": {"state": "not_evaluable", "reason_code": code}
+			for i, code in enumerate(cr.REASON_CODES)
+		}
+		evaluated, notes = agent_runs._coverage_summary(coverage)
+		self.assertEqual(evaluated, set())
+		by_code = {n["reason_code"] for n in notes}
+		self.assertEqual(by_code, set(cr.REASON_CODES))
+		for n in notes:
+			# PP-3: the surfaced remediation is customer-facing text with NO literal
+			# ``{app}``/``{setting}`` placeholder brace leaked (the round-trip supplies no
+			# detail, so a neutral noun fills any placeholder).
+			self.assertTrue(n["remediation"])
+			self.assertNotIn("{", n["remediation"])
+			self.assertEqual(n["retryable"], cr.is_retryable(n["reason_code"]))
+			self.assertEqual(n["routing"], cr.routing_for(n["reason_code"]))
+
+	def test_unknown_code_coerced_never_dropped(self):
+		_, notes = agent_runs._coverage_summary(
+			{"tokX": {"state": "not_evaluable", "reason_code": "novel gibberish"}}
+		)
+		self.assertEqual(len(notes), 1)
+		self.assertEqual(notes[0]["reason_code"], "unsupported_customisation")
+		self.assertEqual(notes[0]["detail"], "novel gibberish")
+
+	def test_legacy_free_string_parsed(self):
+		evaluated, notes = agent_runs._coverage_summary(
+			{"tokA": "evaluated", "tokB": "not_evaluable(source_stale)", "tokC": "truncated"}
+		)
+		self.assertEqual(evaluated, {"tokA"})
+		codes = {n["token"]: n["reason_code"] for n in notes}
+		self.assertEqual(codes["tokB"], "source_stale")
+		self.assertEqual(codes["tokC"], "run_truncated_watermark")
+
+	def test_remediation_renders_in_degradation_section(self):
+		_, notes = agent_runs._coverage_summary(
+			{"tokZ": {"state": "not_evaluable", "reason_code": "configuration_missing"}}
+		)
+		html = agent_runs._fallback_dashboard_html(
+			"T",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"x",
+			result_state="not_evaluable",
+			coverage_notes=notes,
+		)
+		self.assertIn("Coverage gaps", html)
+		self.assertIn("configuration_missing", html)
+		self.assertIn("Configure", html)  # from the remediation template
+		self.assertNotIn("{setting}", html)  # PP-3: the placeholder brace never leaks
+
+
+# --------------------------------------------------------------------------- #
+# PP-1/2/5 — end-to-end writeback + controller immutability guards
+# --------------------------------------------------------------------------- #
+class TestWritebackIntegration(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("pw-owner@example.com")
+		_mk_listing()
+		cls.company = frappe.db.get_value("Company", {}, "name")
+		cls.inst = _mk_installation(cls.owner)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		for n in frappe.get_all(FINDING, filters={"agent": SLUG}, pluck="name"):
+			frappe.delete_doc(FINDING, n, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	# ---- PP-1 persistence + set-once -------------------------------------- #
+	def test_result_class_persisted_and_set_once(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[_finding(result_class="observed_fact")],
+			coverage={TOKEN: "evaluated"},
+			scope={"company": self.company},
+		)
+		name = frappe.db.get_value(FINDING, {"agent": SLUG}, "name")
+		self.assertEqual(frappe.db.get_value(FINDING, name, "result_class"), "observed_fact")
+
+		# set-once: a second save that changes result_class raises (controller guard)
+		fd = frappe.get_doc(FINDING, name)
+		fd.result_class = "legal_scenario"
+		with self.assertRaises(frappe.PermissionError):
+			fd.save(ignore_permissions=True)
+
+	# ---- PP-2 result_state resolved + persisted --------------------------- #
+	def test_evaluated_clean_persisted_when_complete_and_empty(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run, self.inst, [], coverage={TOKEN: "evaluated"}, scope={"company": self.company}
+		)
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "result_state"), "evaluated_clean")
+
+	def test_not_evaluable_persisted_when_all_required_unevaluated(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[],
+			coverage={TOKEN: {"state": "not_evaluable", "reason_code": "configuration_missing"}},
+			scope={"company": self.company},
+		)
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "result_state"), "not_evaluable")
+
+	def test_truncated_empty_run_is_partial_not_clean(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run, self.inst, [], coverage={TOKEN: "evaluated"}, truncated=True, scope={"company": self.company}
+		)
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "result_state"), "partial")
+		blob = json.loads(frappe.db.get_value(RUN, run.name, "coverage_json"))
+		self.assertEqual(blob["result_state"], "partial")
+		self.assertEqual(blob["required_tokens"], [TOKEN])
+
+	# ---- PP-5 auto-resolve provenance + launch immutability --------------- #
+	def test_auto_resolve_stamps_resolution_provenance(self):
+		# run 1 raises an open finding under the company scope
+		run1 = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run1,
+			self.inst,
+			[_finding(result_class="observed_fact")],
+			coverage={TOKEN: "evaluated"},
+			scope={"company": self.company},
+		)
+		name = frappe.db.get_value(FINDING, {"agent": SLUG, "state": "open"}, "name")
+		self.assertIsNotNone(name)
+		frappe.db.set_value(FINDING, name, "company", self.company, update_modified=False)
+
+		# run 2 evaluates the same token with the finding no longer present → A16
+		# coverage-scoped auto-resolve closes it and stamps machine provenance.
+		run2 = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run2, self.inst, [], coverage={TOKEN: "evaluated"}, scope={"company": self.company}
+		)
+		fd = frappe.get_doc(FINDING, name)
+		self.assertEqual(fd.state, "resolved")
+		self.assertEqual(fd.resolution_kind, "auto_coverage")
+		self.assertTrue(fd.resolved_at)
+
+	def test_run_launch_fields_are_immutable(self):
+		run = _mk_run(
+			self.owner,
+			bundle_version="1.0.0",
+			preparation_mode="shadow",
+			initiating_human=self.owner,
+		)
+		self.assertEqual(frappe.db.get_value(RUN, run.name, "bundle_version"), "1.0.0")
+		run.reload()
+		run.bundle_version = "2.0.0"
+		with self.assertRaises(frappe.PermissionError):
+			run.save(ignore_permissions=True)
+
+
+# --------------------------------------------------------------------------- #
+# PP-5 — the provenance ledger is append-only (the confirmed_outcome writer)
+# --------------------------------------------------------------------------- #
+class TestPP5ProvenanceAppendOnly(FrappeTestCase):
+	DT = "Jarvis Agent Provenance Event"
+
+	def test_event_cannot_be_modified_or_deleted(self):
+		ev = frappe.get_doc({"doctype": self.DT, "event_type": "run_launched"}).insert(
+			ignore_permissions=True
+		)
+		self.assertTrue(ev.occurred_at)
+		ev.detail = "tampered"
+		with self.assertRaises(frappe.PermissionError):
+			ev.save(ignore_permissions=True)
+		with self.assertRaises(frappe.PermissionError):
+			frappe.delete_doc(self.DT, ev.name, ignore_permissions=True, force=True)

--- a/jarvis/tests/test_platform_writeback.py
+++ b/jarvis/tests/test_platform_writeback.py
@@ -36,6 +36,8 @@ LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
 FINDING = "Jarvis Agent Finding"
+PROVENANCE = "Jarvis Agent Provenance Event"
+DASHBOARD = "Jarvis Dashboard"
 
 SLUG = "platform-writeback-test-agent"
 TOKEN = "tok_pw_1"
@@ -118,6 +120,28 @@ def _finding(**over) -> dict:
 	}
 	f.update(over)
 	return f
+
+
+def _wipe_residue() -> None:
+	"""Slug-scoped teardown: remove every Run / Finding / Provenance / Dashboard row
+	this module persisted under its test-agent slug, so run-persistence residue never
+	accrues on the shared site. Belt-and-suspenders alongside the ``frappe.flags.in_test``
+	commit gate — this module's ``setUp`` commits per test, which would otherwise make a
+	prior test's in-transaction run/dashboard durable past the class-end rollback. Mirrors
+	``test_platform_activation._wipe``: raw ``frappe.db.delete`` + commit (which also
+	bypasses the append-only Provenance ``on_trash`` guard, legitimate for deleting this
+	module's OWN test residue)."""
+	dashboards = [
+		d
+		for d in frappe.get_all(RUN, filters={"agent": SLUG}, pluck="dashboard", ignore_permissions=True)
+		if d
+	]
+	frappe.db.delete(RUN, {"agent": SLUG})
+	frappe.db.delete(FINDING, {"agent": SLUG})
+	frappe.db.delete(PROVENANCE, {"agent": SLUG})
+	if dashboards:
+		frappe.db.delete(DASHBOARD, {"name": ["in", dashboards]})
+	frappe.db.commit()
 
 
 # --------------------------------------------------------------------------- #
@@ -356,6 +380,12 @@ class TestWritebackIntegration(FrappeTestCase):
 		cls.company = frappe.db.get_value("Company", {}, "name")
 		cls.inst = _mk_installation(cls.owner)
 		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe_residue()
+		super().tearDownClass()
 
 	def setUp(self):
 		frappe.set_user("Administrator")

--- a/jarvis/tools/record_agent_run.py
+++ b/jarvis/tools/record_agent_run.py
@@ -31,6 +31,7 @@ import json
 
 import frappe
 
+from jarvis.chat import coverage_reasons as cr
 from jarvis.exceptions import InvalidArgumentError
 
 RUN = "Jarvis Agent Run"
@@ -80,10 +81,32 @@ def _ref_verifiable(ref_doctype: str, ref_name: str) -> tuple[bool, str]:
 	return True, ""
 
 
+def _validate_result_class(f: dict) -> str | None:
+	"""PP-1: the per-finding epistemic-class gate. Returns a drop reason string,
+	or ``None`` when the row's ``result_class`` contract is satisfied.
+
+	  (a) ``result_class`` must be present and in the fixed four-class enum;
+	  (b) ``confirmed_outcome`` is RESERVED — an evaluator may never emit it (it is
+	      written only by the PP-5 provenance ledger), so it is dropped here;
+	  (c) a ``derived_candidate`` / ``legal_scenario`` row must carry its
+	      class-conditional metadata (confidence/match_basis/false_positive_path
+	      resp. rule_version/source/reviewer), else it is dropped."""
+	rc = f.get("result_class")
+	if not cr.is_result_class(rc):
+		return "missing/invalid result_class"
+	if rc == cr.RESERVED_RESULT_CLASS:
+		return "evaluator may not emit confirmed_outcome"
+	missing = cr.missing_metadata(rc, f)
+	if missing:
+		return f"{rc} missing {', '.join(missing)}"
+	return None
+
+
 def _validate_findings(raw_findings: list, token_set: set, allowed_refs: set):
 	"""Split evaluator findings into (valid, dropped). A row is valid iff its
 	token is a known agent token, its ref_doctype is allowed, its ref exists for
-	the run-as user, amount is numeric and severity is known. Dropped rows carry a
+	the run-as user, amount is numeric, severity is known, and it carries a valid
+	PP-1 ``result_class`` with its class-conditional metadata. Dropped rows carry a
 	reason so the Run coverage names the rejected refs (A16 — never a silent zero
 	pass, never persist an unverifiable row)."""
 	valid, dropped = [], []
@@ -110,6 +133,8 @@ def _validate_findings(raw_findings: list, token_set: set, allowed_refs: set):
 				ok, why = _ref_verifiable(rdt, rname)
 				if not ok:
 					reason = why
+			if reason is None:
+				reason = _validate_result_class(f)
 		if reason:
 			dropped.append({"ref_doctype": rdt, "ref_name": rname, "reason": reason, "token": token})
 		else:
@@ -130,9 +155,19 @@ def record_agent_run(
 	"""Land a delegate's evaluator output on its running Jarvis Agent Run.
 
 	Args (all from the evaluator's JSON, passed verbatim by the delegate):
-	  findings: list of ``{token, ref_doctype, ref_name, amount, severity, note}``.
-	  coverage: per-rule manifest ``{token: "evaluated"|"not_evaluable(reason)"|
-	    "truncated"}`` — gates coverage-scoped auto-resolve (A16).
+	  findings: list of ``{token, ref_doctype, ref_name, amount, severity, note,
+	    result_class, ...}``. ``result_class`` (PP-1) is REQUIRED per row and must be
+	    one of ``observed_fact|derived_candidate|legal_scenario`` — an evaluator may
+	    NOT emit ``confirmed_outcome`` (reserved for the PP-5 ledger). A
+	    ``derived_candidate`` must carry ``confidence``/``match_basis``/
+	    ``false_positive_path``; a ``legal_scenario`` must carry ``rule_version``/
+	    ``source``/``reviewer``. A row missing/failing any of these is DROPPED and the
+	    run goes partial (same path as an unverifiable ref).
+	  coverage: per-check manifest — either the typed form
+	    ``{token: {state, reason_code, detail}}`` (PP-3) or the legacy string form
+	    ``{token: "evaluated"|"not_evaluable(reason)"|"truncated"}``; a reason outside
+	    the closed PP-3 enum is coerced to ``unsupported_customisation`` (never
+	    dropped). Gates coverage-scoped auto-resolve (A16) and the PP-2 run state.
 	  scope: the resolved run scope ``{company, fiscal_year, from_date, to_date,
 	    ...}`` — company is stamped on each Finding + scopes auto-resolve + the
 	    watermark recompute.

--- a/jarvis/tools/save_agent_dashboard.py
+++ b/jarvis/tools/save_agent_dashboard.py
@@ -182,7 +182,11 @@ def save_agent_dashboard(
 			{"owner": visibility_owner, "target_user": visibility_owner},
 			update_modified=False,
 		)
-	frappe.db.commit()
+	# Skip the commit under FrappeTestCase so the enclosing transaction rolls back at
+	# teardown (no leaked Dashboard/Run rows); same-connection asserts still see the
+	# uncommitted writes.
+	if not frappe.flags.in_test:
+		frappe.db.commit()
 
 	return {
 		"run": run_doc.name,

--- a/jarvis/tools/save_agent_dashboard.py
+++ b/jarvis/tools/save_agent_dashboard.py
@@ -37,6 +37,48 @@ from jarvis.exceptions import InvalidArgumentError
 RUN = "Jarvis Agent Run"
 INSTALLATION = "Jarvis Agent Installation"
 
+# PP-4 shadow attestation gate for a delegate-AUTHORED dashboard. Same wording as
+# the fallback preview banner (``agent_runs._fallback_dashboard_html``) so a
+# reviewer sees one consistent "this is a preview, not a compliant attestation"
+# label. Injected into the document BODY (screenshot-safe, not a detachable chrome
+# element) and carrying ``data-result-state="shadow"`` like the fallback state block.
+_SHADOW_BANNER = (
+	'<div data-result-state="shadow" data-shadow-preview="1" '
+	'style="display:block;margin:0 0 16px;padding:8px 14px;border-radius:8px;'
+	'font-size:13px;font-weight:600;color:#3730a3;background:#e0e7ff">'
+	"Preview (shadow) — not a compliant attestation. Visible to the named reviewer "
+	"only; no clean or compliant claim is issued while this capability is in preview."
+	"</div>"
+)
+
+
+def _shadow_gate_html(html: str) -> str:
+	"""Route a delegate-AUTHORED dashboard through the PP-4 shadow gate.
+
+	An authored dashboard bypasses the fallback builder's shadow handling, so a
+	shadow preview could otherwise present the delegate's OWN clean/compliant
+	attestation on the (re-homed) reviewer surface. This makes the authored artifact
+	unambiguously a preview:
+
+	  (a) neutralises any PP-1 strong verb the author emitted — an authored dashboard
+	      is never a ``confirmed_outcome`` row, so ``render_value_text`` strips
+	      saved/recovered/prevented/… (applied to the whole HTML string: strong verbs
+	      live in visible copy, not HTML syntax, so the claim is stripped without
+	      breaking markup); and
+	  (b) injects the non-detachable preview banner into the document body, right
+	      after ``<body …>`` when present, else at the top.
+	"""
+	from jarvis.chat import coverage_reasons as cr
+
+	# result_class is None → strong_verb_allowed is False → the verb is neutralised.
+	safe = cr.render_value_text(html, None)
+	idx = safe.lower().find("<body")
+	if idx != -1:
+		close = safe.find(">", idx)
+		if close != -1:
+			return safe[: close + 1] + _SHADOW_BANNER + safe[close + 1 :]
+	return _SHADOW_BANNER + safe
+
 
 def save_agent_dashboard(
 	html: str,
@@ -96,14 +138,50 @@ def save_agent_dashboard(
 	inst = frappe.get_doc(INSTALLATION, run_row.installation)
 	run_doc = frappe.get_doc(RUN, run_row.name)
 
+	# PP-4: the delegate-authored dashboard WINS the precedence in
+	# ``record_delegate_run`` (richer artifact), so it must carry the SAME shadow
+	# enforcement the fallback path applies — otherwise a shadow installation's
+	# authored dashboard lands owner-owned (visible on the general owner surface) and
+	# can render an outward clean/compliant attestation. Two enforcements, mirroring
+	# ``agent_runs.record_delegate_run``:
+	#   (1) re-home the saved dashboard to the visibility owner (the named reviewer
+	#       while shadow, the installer once live) so shadow output never reaches the
+	#       general owner surface; and
+	#   (2) while shadow, route the authored HTML through the attestation gate — the
+	#       preview banner + PP-1 strong-verb neutralisation — so no compliant claim
+	#       is presented while the capability is in preview.
+	visibility_owner = agent_runs._visibility_owner(inst)
+	shadow = (inst.get("activation_state") or "shadow") == "shadow"
+	persist_html = _shadow_gate_html(html) if shadow else html
+
 	try:
 		dashboard = agent_runs.persist_agent_dashboard(
-			run_doc, inst, html, title=title, description=description
+			run_doc,
+			inst,
+			persist_html,
+			title=title,
+			description=description,
+			owner_override=visibility_owner,
 		)
 	except frappe.ValidationError as e:
 		# Caps/scope errors from the DocType controller — give the delegate a
 		# clean, non-fatal message (the run's findings writeback still proceeds).
 		raise InvalidArgumentError(str(e))
+
+	# PP-4 enforcement (1), made effective: Frappe stamps ``owner = session.user`` at
+	# insert (``document.set_user_and_timestamp``), OVERWRITING the pre-set
+	# ``owner_override`` on the DB owner column. A shadow run is impersonated as the
+	# run_as_user, so the saved dashboard would otherwise be owner-owned and readable
+	# on the general owner surface (and ``can_read_dashboard`` grants the row owner
+	# regardless of scope). Re-home the persisted row's ``owner`` AND ``target_user``
+	# to the visibility owner so — while shadow — only the named reviewer sees it.
+	if visibility_owner and frappe.db.get_value("Jarvis Dashboard", dashboard, "owner") != visibility_owner:
+		frappe.db.set_value(
+			"Jarvis Dashboard",
+			dashboard,
+			{"owner": visibility_owner, "target_user": visibility_owner},
+			update_modified=False,
+		)
 	frappe.db.commit()
 
 	return {


### PR DESCRIPTION
Implements all six launch-blocking platform prerequisites from `jarvis-agents-catalog-plan/build/01-PLATFORM-PREREQS.md` (codex Round-4 P0 gates). Stacked on #366.

- PP-1 structured result classes (writeback-validated; `confirmed_outcome` unreachable from evaluator input; strong-verb gating on every read surface)
- PP-2 truthful coverage states (closed 4-state enum; false-clean structurally unreachable; in-body, screenshot-safe)
- PP-3 typed `not_evaluable` reason codes + remediation
- PP-4 shadow activation (reviewer-only visibility, audited promotion/demotion)
- PP-5 append-only provenance ledger + launch-time stamping
- PP-6 per-customer activation ceiling (race-serialized) + meter anti-cherry-picking (bench slice)

Adversarial + UX panel ran pre-PR: 6 blockers + 6 majors fixed with dedicated regression tests. 11 modules / 103 tests green on patterntest; migrations idempotent.

**Test-residue permanent fix (0c1147f):** the two persistence-path `frappe.db.commit()` sites (`agent_runs.py:952`, `save_agent_dashboard.py:185`) are now gated on `frappe.flags.in_test`, restoring FrappeTestCase rollback for every agent test by construction; `test_platform_writeback` + `test_platform_false_clean` additionally got slug-scoped `tearDownClass` cleanup (defense in depth — writeback's own per-test `setUp` commit is swept by it). **Proven, not asserted:** after retroactively clearing 12 legacy runs + 11 dashboards, a clean-baseline double run of both modules measured Run/Provenance/Dashboard deltas of exactly 0/0/0. Regression sweep (7 modules, 82 tests) green; ruff clean, no whole-file churn.

Known residual (out of scope here): sibling modules (activation / launch_provenance / marketplace) still accrue a few provenance rows per sweep (+7 observed) — same teardown pattern applies if we want them zeroed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsMjkHXYiK5TDokQyAoFh