### PR TITLE
fix(onboarding): honest dev-signup failure + bench operator flow

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -435,6 +435,30 @@
 									<div v-if="state.devActive" class="jv-ob-devnote">
 										Developer mode: payment is skipped (dev signup).
 									</div>
+									<div
+										v-if="state.devBlocked"
+										class="jv-ob-devblock"
+										role="alert"
+									>
+										<p class="jv-ob-devblock-title">
+											Dev signup runs from the bench, not the browser
+										</p>
+										<p class="jv-ob-devblock-body">
+											This admin has turned off browser dev signup on
+											purpose. An operator finishes it in two bench
+											commands, then reload this page.
+										</p>
+										<ol class="jv-ob-devblock-steps">
+											<li>
+												<span>On the admin bench, print the connection:</span>
+												<code>{{ devAdminCmd }}</code>
+											</li>
+											<li>
+												<span>On this bench, apply the JSON it printed:</span>
+												<code>{{ devApplyCmd }}</code>
+											</li>
+										</ol>
+									</div>
 									<Banner
 										v-if="state.payErr"
 										type="error"
@@ -861,6 +885,10 @@ const state = reactive({
 	// with empty args).
 	reconciledConnect: false,
 	devActive: null, // UX-only mirror of desk's boot-time `dev`; null until probed on entering "pay"
+	// True when dev signup failed because the admin has un-whitelisted
+	// dev_force_signup (the deliberate free-container backdoor close). We then
+	// render the bench operator flow instead of the generic red error banner.
+	devBlocked: false,
 	successData: null,
 	// provisioning gate: after pay, the openclaw container is still spinning up.
 	// We block entry to the Connect step until it's running (else save_llm_pool
@@ -915,6 +943,24 @@ const payCta = computed(() => {
 	if (isTrialPlan.value) return "Start free trial";
 	return isFreePlan.value ? "Sign up" : `Pay ${inr(selectedPlan.value.price_inr)}`;
 });
+
+// Bench commands shown when the admin has un-whitelisted dev_force_signup
+// (state.devBlocked). Bound as text (Vue escapes it), so the literal angle
+// brackets render as-is. The admin command is prefilled with the details the
+// customer already entered; the apply command's data object is the JSON the
+// admin command prints.
+const devAdminCmd = computed(
+	() =>
+		"bench --site <admin-site> execute jarvis_admin_v2.billing.signup.dev_force_signup --kwargs '" +
+		JSON.stringify({
+			email: state.email || "...",
+			company_name: state.company || "...",
+			plan: state.planName || "...",
+		}) +
+		"'",
+);
+const devApplyCmd =
+	'bench --site <this-site> execute jarvis.onboarding.apply_dev_connection --kwargs \'{"data": { ...paste the JSON from step 1... }}\'';
 
 // Review-card labels (preview .rev): "Pro · Monthly" plan row and a plain
 // amount in the emphasized total row.
@@ -1170,6 +1216,7 @@ async function enterPayStep() {
 // stale cached "true" must never skip a real charge either.
 async function onPayClick() {
 	state.payErr = "";
+	state.devBlocked = false;
 	// Guard against a signup with empty args: on a reconciled resume (or any
 	// state loss) there is no local plan/email/company, and startSignup(email,
 	// company, null) would create a broken signup upstream.
@@ -1198,7 +1245,16 @@ async function runDevOnboard() {
 		await proceedAfterPay(); // gate on provisioning before → "connect"
 	} catch (e) {
 		state.payBusy = false;
-		state.payErr = errMsg(e);
+		const msg = errMsg(e);
+		// Admin has un-whitelisted dev_force_signup (deliberate backdoor close).
+		// The backend now points at the bench operator flow and names
+		// apply_dev_connection in the message; detect that stable token and show
+		// the two-command instructions instead of the generic red error.
+		if (/apply_dev_connection/.test(msg)) {
+			state.devBlocked = true;
+		} else {
+			state.payErr = msg;
+		}
 	}
 }
 
@@ -2132,6 +2188,48 @@ onMounted(async () => {
 	padding: 8px 12px;
 	margin: 14px auto 0;
 	max-width: 560px;
+}
+.jv-ob-devblock {
+	font-size: 12.5px;
+	color: var(--text-2);
+	background: var(--amber-bg);
+	border: 1px solid var(--amber-bd);
+	border-radius: 8px;
+	padding: 12px 14px;
+	margin: 14px auto 0;
+	max-width: 560px;
+	text-align: left;
+}
+.jv-ob-devblock-title {
+	margin: 0 0 6px;
+	font-weight: 560;
+	color: var(--amber);
+}
+.jv-ob-devblock-body {
+	margin: 0 0 10px;
+}
+.jv-ob-devblock-steps {
+	margin: 0;
+	padding-left: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+.jv-ob-devblock-steps li {
+	line-height: 1.5;
+}
+.jv-ob-devblock-steps code {
+	display: block;
+	margin-top: 5px;
+	padding: 7px 9px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 11.5px;
+	color: var(--text);
+	white-space: pre-wrap;
+	word-break: break-all;
 }
 
 /* ---- Connect ---- */

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -445,16 +445,22 @@
 										</p>
 										<p class="jv-ob-devblock-body">
 											This admin has turned off browser dev signup on
-											purpose. An operator finishes it in two bench
-											commands, then reload this page.
+											purpose. An operator finishes it in two bench commands,
+											then reload this page.
 										</p>
 										<ol class="jv-ob-devblock-steps">
 											<li>
-												<span>On the admin bench, print the connection:</span>
+												<span
+													>On the admin bench, print the
+													connection:</span
+												>
 												<code>{{ devAdminCmd }}</code>
 											</li>
 											<li>
-												<span>On this bench, apply the JSON it printed:</span>
+												<span
+													>On this bench, apply the JSON it
+													printed:</span
+												>
 												<code>{{ devApplyCmd }}</code>
 											</li>
 										</ol>
@@ -957,10 +963,10 @@ const devAdminCmd = computed(
 			company_name: state.company || "...",
 			plan: state.planName || "...",
 		}) +
-		"'",
+		"'"
 );
 const devApplyCmd =
-	'bench --site <this-site> execute jarvis.onboarding.apply_dev_connection --kwargs \'{"data": { ...paste the JSON from step 1... }}\'';
+	"bench --site <this-site> execute jarvis.onboarding.apply_dev_connection --kwargs '{\"data\": { ...paste the JSON from step 1... }}'";
 
 // Review-card labels (preview .rev): "Pro · Monthly" plan row and a plain
 // amount in the emphasized total row.

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -65,6 +65,25 @@ def _require_https_site_url() -> None:
 		)
 
 
+def _throw_admin_error(e) -> None:
+	"""Map one already-raised admin_client exception to the clean frappe.throw
+	the onboarding page renders. Extracted from _surface so a caller can inspect
+	the raised error first (dev_onboard needs to catch the admin-blocked
+	dev-signup case) and then fall back to the identical mapping for every other
+	admin-side failure. Always raises."""
+	if isinstance(e, AdminValidationError):
+		frappe.throw(str(e))
+	if isinstance(e, AdminAuthError):
+		frappe.throw(f"admin authentication failed; check the bench's admin credentials. ({e})")
+	if isinstance(e, AdminUnreachableError):
+		frappe.throw(f"admin is unreachable right now; try again in a moment. ({e})")
+	if isinstance(e, AdminRateLimitedError):
+		retry = e.retry_after_seconds or 0
+		retry_str = f"retry in {retry}s" if retry > 0 else "retry shortly"
+		frappe.throw(f"admin rate-limited the request; {retry_str}.")
+	raise e
+
+
 def _surface(fn, *args, **kwargs):
 	"""Run an admin_client call; re-raise every admin-side error as a clean
 	frappe.ValidationError so the onboarding page renders a red toast with
@@ -86,16 +105,8 @@ def _surface(fn, *args, **kwargs):
 	"""
 	try:
 		return fn(*args, **kwargs)
-	except AdminValidationError as e:
-		frappe.throw(str(e))
-	except AdminAuthError as e:
-		frappe.throw(f"admin authentication failed; check the bench's admin credentials. ({e})")
-	except AdminUnreachableError as e:
-		frappe.throw(f"admin is unreachable right now; try again in a moment. ({e})")
-	except AdminRateLimitedError as e:
-		retry = e.retry_after_seconds or 0
-		retry_str = f"retry in {retry}s" if retry > 0 else "retry shortly"
-		frappe.throw(f"admin rate-limited the request; {retry_str}.")
+	except (AdminValidationError, AdminAuthError, AdminUnreachableError, AdminRateLimitedError) as e:
+		_throw_admin_error(e)
 
 
 def write_connection(data: dict) -> None:
@@ -704,6 +715,39 @@ def _reconcile_pending_applying(settings) -> str | None:
 	return settings.get("last_sync_status")
 
 
+# Admin v2 deliberately removed @frappe.whitelist from dev_force_signup (commit
+# 7391d1f, "close the free-container backdoor"; a test in
+# jarvis_admin_v2/tests/test_whitelist_role_gates.py pins the decorator gone). A
+# guest HTTP POST to it therefore fails with Frappe's "... is not whitelisted".
+# The block is intentional and stays on the admin side; the customer side must
+# stop mislabeling it as a credential problem and point at the documented bench
+# flow instead (jarvis_admin_v2/docs/local-setup.md: an operator runs
+# dev_force_signup via `bench execute` on the admin bench, then applies the
+# returned connection on the customer bench with apply_dev_connection below).
+_DEV_SIGNUP_BLOCKED_HINT = (
+	"Dev signup cannot run from the browser: this admin has disabled the guest "
+	"dev_force_signup endpoint on purpose (it closed a free-container backdoor). "
+	"Finish dev onboarding from the bench in two steps. "
+	"1) On the ADMIN bench, print the connection: "
+	"bench --site <admin-site> execute "
+	"jarvis_admin_v2.billing.signup.dev_force_signup "
+	'--kwargs \'{"email": "...", "company_name": "...", "plan": "..."}\'. '
+	"2) On THIS bench, apply the JSON it printed: "
+	"bench --site <this-site> execute jarvis.onboarding.apply_dev_connection "
+	"--kwargs '{\"data\": {...}}'. Then reload this page."
+)
+
+
+def _is_admin_dev_signup_blocked(e: Exception) -> bool:
+	"""True when admin refused the guest dev-signup POST because dev_force_signup
+	is no longer whitelisted. The refusal reaches us as an admin auth/validation
+	error carrying Frappe's "... is not whitelisted" text; match that signal (not
+	the exception class) so an older admin v1 that STILL whitelists the endpoint
+	keeps working on the normal path, while a modern admin gets the operator
+	flow instead of the misleading "check the bench's admin credentials" toast."""
+	return "not whitelisted" in str(e or "").lower()
+
+
 @frappe.whitelist()
 def dev_onboard(email: str, company: str, plan: str) -> dict:
 	"""Local Razorpay-free onboarding: dev_force_signup → store token+connection.
@@ -721,6 +765,14 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 	wrong value into the wrong site's Jarvis Settings. Force the operator to
 	set it deliberately.
 
+	Modern admin builds (v2) un-whitelist dev_force_signup, so the guest HTTP
+	call fails with "... is not whitelisted". When that happens this raises the
+	operator bench flow (_DEV_SIGNUP_BLOCKED_HINT) instead of the misleading
+	credential toast, and no half-written connection is persisted. An older
+	admin v1 that still whitelists the endpoint is unaffected: only the
+	not-whitelisted signal is intercepted; the successful path is preserved.
+	See ``apply_dev_connection`` for the bench half of the operator flow.
+
 	Gated on System Manager in addition to the sandbox_mode check.
 	"""
 	# STAYS SM-only (PART 4 REVISED, TASK 48): the dev-onboard shortcut GATE is
@@ -736,9 +788,77 @@ def dev_onboard(email: str, company: str, plan: str) -> dict:
 			"Settings -> Enable Sandbox Mode before retrying."
 		)
 	_require_admin_url()
-	data = _surface(admin_client.dev_signup, email, company, plan)
+	try:
+		data = admin_client.dev_signup(email, company, plan)
+	except (AdminValidationError, AdminAuthError, AdminUnreachableError, AdminRateLimitedError) as e:
+		# The admin-blocked case is NOT a credential failure. Surface the real
+		# cause + the bench operator flow; let every other admin error keep its
+		# existing clean toast via the shared mapper.
+		if _is_admin_dev_signup_blocked(e):
+			frappe.throw(_DEV_SIGNUP_BLOCKED_HINT, title="Dev signup blocked by admin")
+		_throw_admin_error(e)
 	write_connection(data)
 	# PART 4 REVISED, TASK 48: sandbox parity with the paid path — grant the dev
 	# onboarder Jarvis Admin. The GATE above stays SM + sandbox.
 	grant_onboarding_admin()
 	return data
+
+
+def apply_dev_connection(data: dict | str) -> dict:
+	"""Bench-only companion to dev_onboard for the operator dev-signup flow.
+
+	Admin v2 deliberately un-whitelisted dev_force_signup (commit 7391d1f,
+	"close the free-container backdoor"), so the browser can no longer complete
+	a Razorpay-free dev signup. The documented replacement
+	(jarvis_admin_v2/docs/local-setup.md) is: an operator runs dev_force_signup
+	via ``bench execute`` on the ADMIN bench, then applies the returned
+	connection on the customer bench. This is that second step, so the whole
+	operator flow lands in one command on the customer side::
+
+	    bench --site <site> execute jarvis.onboarding.apply_dev_connection \\
+	        --kwargs '{"data": {"customer": "...", "api_key": "...", ...}}'
+
+	``data`` is admin's dev_force_signup return dict (keys: customer, api_key,
+	api_secret, customer_password, agent_url, agent_token, tenant, subscription,
+	tenant_status). It writes the native admin credentials + container
+	connection, grants the onboarding admin, commits, and returns (and prints)
+	``is_ready_for_chat()`` so the operator sees whether chat is now unblocked.
+
+	Guarded exactly like dev_onboard, minus the HTTP surface: NO
+	``@frappe.whitelist`` (a plain function, so it is never reachable over HTTP;
+	the only caller is ``bench execute``), AND it requires sandbox mode so it can
+	never be used to inject an admin connection onto a production bench. It is
+	the write half of dev_onboard, which is why it carries the same sandbox gate.
+	"""
+	from jarvis.account import is_ready_for_chat
+	from jarvis.dev import is_sandbox_mode
+
+	if not is_sandbox_mode():
+		raise frappe.ValidationError(
+			"apply_dev_connection requires sandbox mode. Enable Jarvis Settings "
+			"-> Enable Sandbox Mode on this bench, then re-run it."
+		)
+	if isinstance(data, str):
+		# `bench execute --kwargs` already JSON-parses the value, but tolerate a
+		# double-encoded string (data handed in as a JSON string) as well.
+		data = json.loads(data)
+	if not isinstance(data, dict):
+		raise frappe.ValidationError(
+			"apply_dev_connection needs a `data` object (admin's dev_force_signup "
+			"JSON). Pass it as --kwargs '{\"data\": {...}}'."
+		)
+	if not (data.get("api_key") and data.get("api_secret")):
+		raise frappe.ValidationError(
+			"The dev connection is missing api_key / api_secret. Paste the full "
+			"JSON that admin's dev_force_signup printed into the `data` object."
+		)
+
+	write_connection(data)
+	# Sandbox parity with dev_onboard's paid-path grant. Under `bench execute`
+	# the session user is Administrator, which grant_onboarding_admin no-ops on,
+	# so this only grants when invoked as a real user; kept for symmetry.
+	grant_onboarding_admin()
+	frappe.db.commit()
+	ready = is_ready_for_chat()
+	print(f"[apply_dev_connection] connection stored; is_ready_for_chat={ready}")
+	return ready

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -628,3 +628,157 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 			s.db_set("last_model_statuses", bad, update_modified=False)
 			frappe.db.commit()
 			self.assertEqual(onboarding.get_llm_sync_status()["model_statuses"], [])
+
+
+class TestApplyDevConnection(FrappeTestCase):
+	"""jarvis.onboarding.apply_dev_connection - the bench-only companion that
+	finishes the operator dev-signup flow. Admin v2 un-whitelisted
+	dev_force_signup (closed the free-container backdoor), so the browser can no
+	longer POST it as guest; an operator runs dev_force_signup on the admin bench
+	via `bench execute` and applies its JSON here."""
+
+	# The full key set admin's dev_force_signup returns.
+	_DEV_DATA = {
+		"customer": "dev@example.com",
+		"api_key": "dev-key",
+		"api_secret": "dev-secret",
+		"customer_password": "dev-pw",
+		"agent_url": "ws://localhost:19003",
+		"agent_token": "dev-agent-token",
+		"tenant": "T-DEV-1",
+		"subscription": "Annual Plan",
+		"tenant_status": "running",
+	}
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		self._orig_sandbox = frappe.db.get_single_value("Jarvis Settings", "sandbox_mode")
+		_set_token("")
+
+	def tearDown(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", self._orig_sandbox or 0)
+		frappe.db.commit()
+		_restore_settings(self._snap)
+
+	def _sandbox(self, on: bool):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", 1 if on else 0)
+		frappe.db.commit()
+
+	def test_happy_path_writes_connection_and_returns_readiness(self):
+		"""Sandbox on + a valid dict: the native creds + container connection are
+		persisted, and the return is is_ready_for_chat()'s {ready, reason} shape."""
+		self._sandbox(True)
+		out = onboarding.apply_dev_connection(dict(self._DEV_DATA))
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key"), "dev-key")
+		self.assertEqual(s.get_password("jarvis_admin_api_secret"), "dev-secret")
+		self.assertEqual(s.agent_url, "ws://localhost:19003")
+		self.assertEqual(s.get_password("agent_token"), "dev-agent-token")
+		self.assertEqual(s.get("jarvis_admin_customer_email"), "dev@example.com")
+		self.assertIsInstance(out, dict)
+		self.assertIn("ready", out)
+		self.assertIn("reason", out)
+
+	def test_accepts_json_string_data(self):
+		"""A double-encoded string (data handed in as JSON text) is parsed too."""
+		import json
+
+		self._sandbox(True)
+		onboarding.apply_dev_connection(json.dumps(self._DEV_DATA))
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key"), "dev-key")
+
+	def test_rejects_when_sandbox_off(self):
+		"""Same gate as dev_onboard: refuse unless sandbox mode is on, and write
+		nothing (never inject an admin connection onto a production bench)."""
+		self._sandbox(False)
+		with self.assertRaises(frappe.ValidationError):
+			onboarding.apply_dev_connection(dict(self._DEV_DATA))
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False) or "", "")
+
+	def test_rejects_malformed_dicts(self):
+		"""Non-dict input and a dict missing the required credential keys both
+		fail fast with a ValidationError and persist nothing."""
+		self._sandbox(True)
+		with self.assertRaises(frappe.ValidationError):
+			onboarding.apply_dev_connection(["not", "a", "dict"])
+		with self.assertRaises(frappe.ValidationError):
+			onboarding.apply_dev_connection({"agent_url": "ws://h:1"})
+		with self.assertRaises(frappe.ValidationError):
+			onboarding.apply_dev_connection({"api_key": "k"})  # missing api_secret
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False) or "", "")
+
+
+class TestDevOnboardAdminBlocked(FrappeTestCase):
+	"""When admin has un-whitelisted dev_force_signup, dev_onboard must surface
+	the operator bench flow, NOT the misleading 'check admin credentials' toast,
+	and must not persist a half-written connection."""
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		self._orig_sandbox = frappe.db.get_single_value("Jarvis Settings", "sandbox_mode")
+		_set_token("")
+		frappe.db.set_value(
+			"Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "http://admin.example.com"
+		)
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", 1)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "sandbox_mode", self._orig_sandbox or 0)
+		frappe.db.commit()
+		_restore_settings(self._snap)
+
+	def test_surfaces_operator_flow_when_not_whitelisted(self):
+		"""The "... is not whitelisted" refusal (whichever admin exception carries
+		it) is intercepted: the message names apply_dev_connection and NOT the
+		credential toast, and no connection is written."""
+		from jarvis.exceptions import AdminAuthError
+
+		with patch(
+			"jarvis.onboarding.admin_client.dev_signup",
+			side_effect=AdminAuthError("dev_force_signup is not whitelisted.", status_code=403),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				onboarding.dev_onboard("e@x.com", "Co", "Annual Plan")
+		msg = str(ctx.exception)
+		self.assertIn("apply_dev_connection", msg)
+		self.assertNotIn("check the bench's admin credentials", msg)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False) or "", "")
+
+	def test_other_admin_errors_keep_their_clean_toast(self):
+		"""Regression guard: a NON-block admin failure must NOT be swallowed into
+		the operator-flow message; it keeps its own clean toast."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		with patch(
+			"jarvis.onboarding.admin_client.dev_signup",
+			side_effect=AdminUnreachableError("boom"),
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				onboarding.dev_onboard("e@x.com", "Co", "Annual Plan")
+		msg = str(ctx.exception)
+		self.assertIn("unreachable", msg)
+		self.assertNotIn("apply_dev_connection", msg)
+
+	def test_admin_v1_that_still_whitelists_succeeds(self):
+		"""Backwards compat: an older admin v1 that still whitelists
+		dev_force_signup returns a connection normally; dev_onboard persists it
+		(no interception)."""
+		with patch(
+			"jarvis.onboarding.admin_client.dev_signup",
+			return_value={
+				"customer": "v1@x.com",
+				"api_key": "v1-key",
+				"api_secret": "v1-secret",
+				"agent_url": "ws://localhost:19009",
+				"agent_token": "v1-tok",
+			},
+		):
+			onboarding.dev_onboard("e@x.com", "Co", "Annual Plan")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key"), "v1-key")
+		self.assertEqual(s.agent_url, "ws://localhost:19009")


### PR DESCRIPTION
## The bug

With `Jarvis Settings.sandbox_mode = 1`, the onboarding wizard's Pay step shows a **Dev signup & connect** button. It calls `jarvis.onboarding.dev_onboard` -> `admin_client.dev_signup`, which POSTs as guest to admin's `jarvis_admin_v2.billing.signup.dev_force_signup`.

Admin v2 deliberately removed `@frappe.whitelist` from `dev_force_signup` (admin commit 7391d1f, "close the free-container backdoor"; a test in `jarvis_admin_v2/tests/test_whitelist_role_gates.py` pins the decorator gone). So the guest POST always fails with Frappe's `... is not whitelisted`. The client classified that as an auth failure and showed the misleading toast:

> admin authentication failed; check the bench's admin credentials. (... dev_force_signup is not whitelisted.)

The customer-side dev path can therefore never succeed, and the error sends operators chasing a non-existent credential bug.

## Security constraint (unchanged)

The admin-side block is intentional and stays. This PR does **not** add any new admin HTTP endpoint. The documented replacement (`jarvis_admin_v2/docs/local-setup.md`) is: an operator runs `dev_force_signup` via `bench execute` on the admin bench, then applies the returned connection on the customer bench. This PR only improves the customer (`jarvis`) side.

## The fix

1. **`dev_onboard` fails honestly.** It now detects the not-whitelisted refusal and raises an actionable message that names the real cause and points at the operator flow, instead of the credential toast. Every other admin error keeps its existing clean message (the mapping was extracted into a shared `_throw_admin_error`). Backwards compatible: only the `not whitelisted` signal is intercepted, so an older admin v1 that still whitelists the endpoint keeps working on the success path. No half-written connection is persisted on the blocked path.

2. **New bench companion `apply_dev_connection(data)`.** Applies admin's `dev_force_signup` JSON (keys: `customer, api_key, api_secret, customer_password, agent_url, agent_token, tenant, subscription, tenant_status`) via the existing `write_connection` + `grant_onboarding_admin`, commits, and prints/returns `is_ready_for_chat()`. Guarded exactly like `dev_onboard`: **NOT** `@frappe.whitelist` (bench-only, never reachable over HTTP) and requires sandbox mode. Finishes the operator flow in one customer-side command:

   ```
   bench --site <site> execute jarvis.onboarding.apply_dev_connection \
     --kwargs '{"data": {"customer": "...", "api_key": "...", ...}}'
   ```

3. **Wizard UI.** When dev signup fails with the admin-blocked error, the Pay step renders the two bench commands (admin-side prefilled with the entered email/company/plan) instead of the generic red banner.

## Tests

`jarvis/tests/test_onboarding_sync.py`:
- `apply_dev_connection`: happy path (writes creds + connection, returns readiness), JSON-string input, rejects when sandbox off (writes nothing), rejects malformed dicts.
- `dev_onboard`: surfaces the operator flow when not-whitelisted (no half-write), other admin errors keep their clean toast, and an admin v1 that still whitelists succeeds.

Written to pass on a fresh CI DB (snapshot/restore of Jarvis Settings; assertions do not depend on role-polluted local state). Local `ruff check` + `ruff format` clean. Bench tests were not run against the live local bench: the worktree is not the installed app, and running against the shared local site would not exercise worktree code, so CI is the authority.

## Files changed

- `jarvis/onboarding.py`
- `frontend/src/views/OnboardingView.vue`
- `jarvis/tests/test_onboarding_sync.py`