### PR TITLE
fix: three UI e2e defects (blank-page routes, direct-mode Connection pane, optional local-provider key)

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -354,7 +354,10 @@
 						</div>
 						<div class="jv-pool-field">
 							<label class="jv-pool-lab"
-								>API key<span v-if="isLocalProviderRow(panelRow)" class="jv-pool-opt">
+								>API key<span
+									v-if="isLocalProviderRow(panelRow)"
+									class="jv-pool-opt"
+								>
 									(optional)</span
 								></label
 							>
@@ -366,8 +369,8 @@
 									panelRow.hasKey
 										? 'key set, re-enter to change'
 										: isLocalProviderRow(panelRow)
-											? 'Not required for local providers'
-											: 'API key'
+										? 'Not required for local providers'
+										: 'API key'
 								"
 								class="jv-cfg-inp"
 							/>
@@ -1165,8 +1168,8 @@
 								m.hasKey
 									? 'key set, re-enter to change'
 									: isLocalProviderRow(m)
-										? 'Not required for local providers'
-										: 'API key'
+									? 'Not required for local providers'
+									: 'API key'
 							"
 						/>
 						<input

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -353,13 +353,21 @@
 							/>
 						</div>
 						<div class="jv-pool-field">
-							<label class="jv-pool-lab">API key</label>
+							<label class="jv-pool-lab"
+								>API key<span v-if="isLocalProviderRow(panelRow)" class="jv-pool-opt">
+									(optional)</span
+								></label
+							>
 							<input
 								v-model="panelRow.apiKey"
 								:disabled="!editable"
 								type="password"
 								:placeholder="
-									panelRow.hasKey ? 'key set, re-enter to change' : 'API key'
+									panelRow.hasKey
+										? 'key set, re-enter to change'
+										: isLocalProviderRow(panelRow)
+											? 'Not required for local providers'
+											: 'API key'
 								"
 								class="jv-cfg-inp"
 							/>
@@ -1153,7 +1161,13 @@
 							v-model="m.apiKey"
 							:disabled="!editable"
 							type="password"
-							:placeholder="m.hasKey ? 'key set, re-enter to change' : 'API key'"
+							:placeholder="
+								m.hasKey
+									? 'key set, re-enter to change'
+									: isLocalProviderRow(m)
+										? 'API key (optional for local providers)'
+										: 'API key'
+							"
 						/>
 						<input
 							v-model="m.baseUrl"
@@ -1555,6 +1569,7 @@ import {
 	defaultSubscriptionModel,
 	apiKeyModelHealth,
 	isCodeOnlyPaste,
+	effectiveApiKey,
 } from "@/llm/pool";
 import { errMessage as _err } from "@/lib/errors";
 import { useConfirm } from "@/composables/useConfirm";
@@ -1626,7 +1641,7 @@ const ready = computed(() => {
 	return !!(
 		(r.provider || "").trim() &&
 		(r.model || "").trim() &&
-		((r.apiKey || "").trim() || r.hasKey)
+		((r.apiKey || "").trim() || r.hasKey || isLocalProviderRow(r))
 	);
 });
 const credTypes = [
@@ -2049,7 +2064,8 @@ function testBlockedReason(row) {
 	if (!row) return "Nothing to test";
 	if (!(row.provider || "").trim()) return "Choose a provider to test";
 	if (!(row.model || "").trim()) return "Enter a model id to test";
-	if (!(row.apiKey || "").trim())
+	// Local providers (Ollama, vLLM) take no key - nothing blocks the probe.
+	if (!(row.apiKey || "").trim() && !isLocalProviderRow(row))
 		return row.hasKey ? "Re-enter the key to test it" : "Enter an API key to test";
 	return "";
 }
@@ -2838,7 +2854,7 @@ function buildSaveModels(sourceRows) {
 		const m = {
 			provider: (r.provider || "").trim(),
 			model: (r.model || "").trim(),
-			api_key: (r.apiKey || "").trim(),
+			api_key: effectiveApiKey(r.provider, r.apiKey, r.hasKey),
 			order: i,
 		};
 		if (r.hasKey) m.has_key = true; // let validatePool + backend merge keep a stored key on re-save

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1165,7 +1165,7 @@
 								m.hasKey
 									? 'key set, re-enter to change'
 									: isLocalProviderRow(m)
-										? 'API key (optional for local providers)'
+										? 'Not required for local providers'
 										: 'API key'
 							"
 						/>
@@ -1570,6 +1570,7 @@ import {
 	apiKeyModelHealth,
 	isCodeOnlyPaste,
 	effectiveApiKey,
+	LOCAL_PROVIDER_IDS,
 } from "@/llm/pool";
 import { errMessage as _err } from "@/lib/errors";
 import { useConfirm } from "@/composables/useConfirm";
@@ -2048,11 +2049,11 @@ function openEdit(i) {
 // ---- pre-save "Test" (API-key rows only) ---------------------------------
 // Provider ids whose usual endpoint only makes sense reached from INSIDE the
 // tenant's bifrost container (localhost / a customer LAN), never from this
-// browser's bench - MUST match jarvis.llm_key_probe.LOCAL_PROVIDER_IDS. The
-// button still runs (a customer CAN point "vllm"/"ollama" at a real public
-// URL), this only softens the promise with an upfront disclaimer instead of
-// silently implying a guarantee the bench can't make.
-const LOCAL_PROVIDER_IDS = new Set(["ollama", "vllm"]);
+// browser's bench - LOCAL_PROVIDER_IDS is shared with pool.js's own key-
+// optionality check (both MUST match jarvis.llm_key_probe.LOCAL_PROVIDER_IDS).
+// The Test button still runs (a customer CAN point "vllm"/"ollama" at a real
+// public URL), this only softens the promise with an upfront disclaimer
+// instead of silently implying a guarantee the bench can't make.
 function isLocalProviderRow(row) {
 	return !!(row && LOCAL_PROVIDER_IDS.has(providerId(row.provider)));
 }
@@ -2343,6 +2344,16 @@ function onProviderChange(m, newProvider) {
 	const d = PROVIDER_DEFAULTS[m.provider] || {};
 	m.model = d.model || "";
 	m.baseUrl = d.baseUrl || "";
+	// A stored key (hasKey) belongs to the OLD provider's key_ref, not this one -
+	// carrying it forward would either merge the wrong provider's secret on save
+	// (onboarding.py's merge-by-provider fallback keys on the NEW provider, so it
+	// actually finds nothing) or, for a fresh switch to Ollama/vLLM, leave the row
+	// looking "has a key" while save sends a blank api_key - reproducing the exact
+	// "api_key is blank on an enabled model" rejection this switch already causes
+	// between any two providers. Same reasoning as onUpstreamChange dropping
+	// connected accounts on a subscription upstream switch, just below.
+	m.hasKey = false;
+	m.apiKey = "";
 }
 // Provider switch on a subscription row in the simplified onboarding editor:
 // re-default the (hidden) model AND drop any already-connected account, which is

--- a/frontend/src/components/settings/ConnectionPane.vue
+++ b/frontend/src/components/settings/ConnectionPane.vue
@@ -11,21 +11,15 @@
 				Connection status is unavailable right now.
 				<button type="button" class="jv-mon-retry" @click="load">Retry</button>
 			</div>
-			<div v-else-if="!applicable" class="jv-mon-note">
-				Connection details apply to multi-model (proxy) setups. This tenant runs a single
-				model (direct), so there is no proxy connection to report.
-			</div>
 			<template v-else>
 				<div class="jv-mon-kv">
 					<span>Status</span>
-					<b :class="conn.auth_present ? 'jv-ok' : 'jv-warn'">{{
-						conn.auth_present ? "Connected" : "Not connected"
-					}}</b>
+					<b :class="statusClass">{{ statusLabel }}</b>
 				</div>
 				<div v-if="conn.default_model" class="jv-mon-kv">
 					<span>Model</span><b>{{ conn.default_model }}</b>
 				</div>
-				<div v-if="conn.oauth_expires_at" class="jv-mon-kv">
+				<div v-if="isProxy && conn.oauth_expires_at" class="jv-mon-kv">
 					<span>Expires</span><b>{{ expiresLabel }}</b>
 				</div>
 			</template>
@@ -54,18 +48,22 @@ const expiresLabel = computed(() => {
 	return ms ? new Date(Number(ms)).toLocaleString() : "—";
 });
 
-// Connection is only meaningful for proxy tenants. get_llm_connection_status
-// returns proxy auth/profile fields; a direct (single-model) tenant has none
-// of them, so treat an empty payload as "not applicable" rather than a
-// misleading "Not connected".
-const applicable = computed(() => {
-	const c = conn.value || {};
-	return !!(
-		c.auth_present ||
-		c.default_model ||
-		c.oauth_expires_at ||
-		(Array.isArray(c.profile_ids) && c.profile_ids.length)
-	);
+// get_llm_connection_status now short-circuits server-side for a DIRECT
+// (single-model) tenant instead of surfacing the raw proxy-auth payload, so
+// `proxy_active` tells the two states apart explicitly - no more guessing
+// from which fields happen to be populated (that heuristic used to misread
+// a direct tenant's own default_model as "connection details present" and
+// render an orange "Not connected" even though chat worked fine).
+const isProxy = computed(() => !!conn.value.proxy_active);
+const statusLabel = computed(() => {
+	if (!isProxy.value) return "Direct";
+	return conn.value.auth_present ? "Connected" : "Not connected";
+});
+// Direct is a mode, not a warning - neutral text, no jv-ok/jv-warn tint
+// (matches BillingMeteringPane's uncoloured "Mode" row for the same value).
+const statusClass = computed(() => {
+	if (!isProxy.value) return "";
+	return conn.value.auth_present ? "jv-ok" : "jv-warn";
 });
 
 async function load() {

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -161,12 +161,18 @@ const autoApplyNote = computed(() => (ctx.value && ctx.value.autoApplyNote) || "
 // never a 403 → "—".
 const isSM = !!(window.is_system_manager || window.is_jarvis_admin);
 const connStatus = ref(null);
+// get_llm_connection_status short-circuits server-side for a DIRECT (single-
+// model) tenant and reports that via proxy_active, rather than the raw proxy-
+// auth payload - the same fix as ConnectionPane.vue. Without this, a direct
+// tenant's own auth_present:false read as "Not connected" here too.
+const isProxy = computed(() => !!(connStatus.value && connStatus.value.proxy_active));
 const connected = computed(() =>
-	isSM ? !!(connStatus.value && connStatus.value.auth_present) : true
+	isSM ? !!(connStatus.value && isProxy.value && connStatus.value.auth_present) : true
 );
 const statusLabel = computed(() => {
 	if (!isSM) return "Connected";
 	if (!connStatus.value) return "—";
+	if (!isProxy.value) return "Direct";
 	return connected.value ? "Connected" : "Not connected";
 });
 

--- a/frontend/src/components/shell/SettingsDialog.vue
+++ b/frontend/src/components/shell/SettingsDialog.vue
@@ -373,7 +373,7 @@ const DESCRIPTIONS = {
 	shortcuts: "Keyboard shortcuts available in chat.",
 	plan: "Your subscription, renewal and upgrade options.",
 	aimodels: "The AI connection that powers Jarvis.",
-	connection: "Proxy connection status for this workspace.",
+	connection: "Connection status for this workspace.",
 	billing: "Live usage and cost across the model pool.",
 };
 

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -181,9 +181,9 @@ export const isCodeOnlyPaste = (upstreamOrLabel) => _CODE_ONLY_PASTE.has(upstrea
 // (standard api.z.ai/api/paas/v4 vs coding-plan api.z.ai/api/coding/paas/v4).
 const NEEDS_BASE_URL = new Set(["openai_compat", "vllm", "zai", "zai_coding"]);
 // Providers with no auth of their own - Ollama/vLLM run inside or next to the
-// tenant's container (loopback / LAN), so there is no key to bring. MUST match
-// jarvis.llm_key_probe.LOCAL_PROVIDER_IDS and LlmPoolEditor.vue's own copy
-// (kept local there for its Test-button disclaimer, which predates this one).
+// tenant's container (loopback / LAN), so there is no key to bring. Shared
+// with LlmPoolEditor.vue's Test-button disclaimer (predates this export) -
+// MUST also match jarvis.llm_key_probe.LOCAL_PROVIDER_IDS on the Python side.
 export const LOCAL_PROVIDER_IDS = new Set(["ollama", "vllm"]);
 export function providerLabel(id) {
 	return _LABEL_BY_ID[id] || id || "";

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -47,7 +47,7 @@ export function buildCustomModels(rows) {
 			const m = {
 				provider: r.provider.trim(),
 				model: r.model.trim(),
-				api_key: (r.apiKey || "").trim(),
+				api_key: effectiveApiKey(r.provider, r.apiKey, r.hasKey),
 				order: i,
 			};
 			if (r.hasKey) m.has_key = true;
@@ -115,8 +115,10 @@ export function validatePool(models, preset) {
 				error: `Model ${m.model}: ${m.provider} needs a Base URL (its custom endpoint).`,
 			};
 		}
-		// A freshly-entered key OR a previously-saved key (has_key; merged back on save).
-		if (!(m.api_key || "").trim() && !m.has_key)
+		// A freshly-entered key OR a previously-saved key (has_key; merged back on
+		// save). Local providers (Ollama, vLLM) run inside/near the container with
+		// no auth of their own - a key is optional, not a value to make up.
+		if (!(m.api_key || "").trim() && !m.has_key && !LOCAL_PROVIDER_IDS.has(pid))
 			return { ok: false, error: `Model ${m.model} needs an API key.` };
 	}
 	return { ok: true, error: "" };
@@ -178,11 +180,31 @@ export const isCodeOnlyPaste = (upstreamOrLabel) => _CODE_ONLY_PASTE.has(upstrea
 // have no native Bifrost provider, so each needs its own Z.ai base_url
 // (standard api.z.ai/api/paas/v4 vs coding-plan api.z.ai/api/coding/paas/v4).
 const NEEDS_BASE_URL = new Set(["openai_compat", "vllm", "zai", "zai_coding"]);
+// Providers with no auth of their own - Ollama/vLLM run inside or next to the
+// tenant's container (loopback / LAN), so there is no key to bring. MUST match
+// jarvis.llm_key_probe.LOCAL_PROVIDER_IDS and LlmPoolEditor.vue's own copy
+// (kept local there for its Test-button disclaimer, which predates this one).
+export const LOCAL_PROVIDER_IDS = new Set(["ollama", "vllm"]);
 export function providerLabel(id) {
 	return _LABEL_BY_ID[id] || id || "";
 }
 export function providerId(label) {
 	return _ID_BY_LABEL[label] || label || "";
+}
+// The api_key value to persist for one API-key row. A real typed key always
+// wins; an unchanged has_key row sends "" (the merge-on-save convention - see
+// buildCustomModels/buildSaveModels callers, "let backend merge keep a stored
+// key on re-save"). Only a BLANK, never-saved key on a local provider (Ollama
+// / vLLM) gets the placeholder: the backend's dangling-key_ref guard
+// (pool_serialize.validate_models) requires a non-empty api_key on every
+// enabled api_key model regardless of provider, and local providers don't
+// authenticate with it anyway, so a fixed, harmless placeholder satisfies
+// that contract without asking the customer to invent one.
+export function effectiveApiKey(providerRaw, apiKey, hasKey) {
+	const trimmed = (apiKey || "").trim();
+	if (trimmed || hasKey) return trimmed;
+	const pid = _ID_BY_LABEL[providerRaw] || (providerRaw || "").trim().toLowerCase();
+	return LOCAL_PROVIDER_IDS.has(pid) ? "local" : "";
 }
 
 // ---- config -> editor rows -------------------------------------------------

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -12,6 +12,7 @@ import {
 import { PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig } from "./pool.js";
 import { defaultSubscriptionModel } from "./pool.js";
 import { apiKeyModelHealth } from "./pool.js";
+import { LOCAL_PROVIDER_IDS, effectiveApiKey } from "./pool.js";
 
 test("defaultSubscriptionModel: per-upstream default, openai fallback", () => {
 	assert.equal(defaultSubscriptionModel("openai"), "gpt-5.5");
@@ -87,6 +88,15 @@ test("buildCustomModels: order = row index; trims; drops incomplete rows", () =>
 		[0, 1]
 	);
 	assert.equal(models[0].api_key, "sk-o");
+});
+test("buildCustomModels: Ollama/vLLM row with no typed key gets the 'local' placeholder", () => {
+	const rows = [
+		{ provider: "Ollama (local)", model: "llama3", apiKey: "", baseUrl: "" },
+		{ provider: "openai", model: "gpt-5.5", apiKey: "sk-o" },
+	];
+	const models = buildCustomModels(rows);
+	assert.equal(models[0].api_key, "local");
+	assert.equal(models[1].api_key, "sk-o");
 });
 test("buildCustomModels: emits base_url when present, omits when blank", () => {
 	const rows = [
@@ -175,6 +185,42 @@ test("validatePool: api_key model with neither key nor has_key is invalid", () =
 		validatePool([{ provider: "openai", model: "gpt-5.5", api_key: "" }], null).ok,
 		false
 	);
+});
+test("validatePool: Ollama/vLLM don't need a key (label or id, blank api_key)", () => {
+	assert.equal(
+		validatePool([{ provider: "Ollama (local)", model: "llama3", api_key: "" }], null).ok,
+		true
+	);
+	assert.equal(
+		validatePool(
+			[{ provider: "vllm", model: "qwen2.5", api_key: "", base_url: "http://localhost:8000/v1" }],
+			null
+		).ok,
+		true
+	);
+	// vLLM still needs its base_url - only the key is optional.
+	assert.equal(
+		validatePool([{ provider: "vllm", model: "qwen2.5", api_key: "" }], null).ok,
+		false
+	);
+	// A normal provider is unaffected.
+	assert.equal(
+		validatePool([{ provider: "openai", model: "gpt-5.5", api_key: "" }], null).ok,
+		false
+	);
+});
+test("effectiveApiKey: local providers get a placeholder only when blank and unsaved", () => {
+	assert.equal(effectiveApiKey("Ollama (local)", "", false), "local");
+	assert.equal(effectiveApiKey("vllm", "", false), "local");
+	// A typed key always wins.
+	assert.equal(effectiveApiKey("ollama", "sk-real", false), "sk-real");
+	// An already-saved key (has_key) is left blank so the backend keeps it.
+	assert.equal(effectiveApiKey("ollama", "", true), "");
+	// A non-local provider stays blank (validatePool rejects it separately).
+	assert.equal(effectiveApiKey("openai", "", false), "");
+});
+test("LOCAL_PROVIDER_IDS: exactly ollama + vllm", () => {
+	assert.deepEqual([...LOCAL_PROVIDER_IDS].sort(), ["ollama", "vllm"]);
 });
 test("validatePool: OpenAI-Compatible / vLLM require a base_url (label or id)", () => {
 	// Claude-CLI shim path: provider set, model + key present, but no base_url.

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -193,7 +193,14 @@ test("validatePool: Ollama/vLLM don't need a key (label or id, blank api_key)", 
 	);
 	assert.equal(
 		validatePool(
-			[{ provider: "vllm", model: "qwen2.5", api_key: "", base_url: "http://localhost:8000/v1" }],
+			[
+				{
+					provider: "vllm",
+					model: "qwen2.5",
+					api_key: "",
+					base_url: "http://localhost:8000/v1",
+				},
+			],
 			null
 		).ok,
 		true

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -133,6 +133,15 @@ const routes = [
 		component: () => import("@/pages/agents/AgentDetail.vue"),
 		props: true,
 	},
+	// Catch-all: an unknown path (e.g. the retired desk deep-link
+	// "/jarvis/account" - its content now lives in the SPA settings dialog)
+	// used to render a blank white screen. Vue Router 4 ranks a static path
+	// above a wildcard regardless of registration order, so this cannot
+	// shadow any route above it - it only ever matches when nothing else
+	// did. This is a plain path redirect, unrelated to the beforeEach
+	// onboarding guard below (which only ever redirects AWAY FROM
+	// /onboarding, never forces a user INTO it - see the D11 note there).
+	{ path: "/:pathMatch(.*)*", name: "NotFound", redirect: "/" },
 ];
 
 // Served under /jarvis (website_route_rules catch-all → www/jarvis page).

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -216,7 +216,7 @@ def get_llm_connection_status() -> dict:
 	contract field names. Never returns token material. System-Manager only.
 
 	DIRECT tenants (proxy_active=0, no Bifrost/cliproxy sidecar) short-circuit
-	before the admin round-trip, mirroring get_llm_usage above — there is no
+	before the admin round-trip, mirroring get_llm_usage above - there is no
 	proxy auth profile to report. Before this, the raw admin payload's
 	leftover fields (a stale/default default_model with auth_profile_present
 	false) made the SPA's ConnectionPane render a misleading orange "Not

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -213,11 +213,28 @@ def get_llm_usage() -> dict:
 def get_llm_connection_status() -> dict:
 	"""Connection card for the Monitor tab: auth profile present + OAuth expiry.
 	Wrapper over admin_client.post_llm_auth_status, remapped to the customer
-	contract field names. Never returns token material. System-Manager only."""
+	contract field names. Never returns token material. System-Manager only.
+
+	DIRECT tenants (proxy_active=0, no Bifrost/cliproxy sidecar) short-circuit
+	before the admin round-trip, mirroring get_llm_usage above — there is no
+	proxy auth profile to report. Before this, the raw admin payload's
+	leftover fields (a stale/default default_model with auth_profile_present
+	false) made the SPA's ConnectionPane render a misleading orange "Not
+	connected" for a direct tenant whose chat verifiably works."""
 	require_jarvis_admin()
+	settings = frappe.get_single("Jarvis Settings")
+	if not getattr(settings, "proxy_active", 0):
+		return {
+			"proxy_active": False,
+			"auth_present": False,
+			"oauth_expires_at": None,
+			"profile_ids": [],
+			"default_model": settings.get("llm_model") or "",
+		}
 	raw = _surface(admin_client.post_llm_auth_status) or {}
 	data = raw.get("data", raw) or {}
 	return {
+		"proxy_active": True,
 		"auth_present": bool(data.get("auth_profile_present")),
 		"oauth_expires_at": data.get("openai_profile_expires_ms"),
 		"profile_ids": data.get("profile_ids", []),

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -1698,10 +1698,16 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					},
 				};
 			}
+			const P = window.jarvis_onboarding_llm || {};
 			const m = {
 				provider: (r.provider || "").trim(),
 				model: (r.model || "").trim(),
-				api_key: (r.apiKey || "").trim(),
+				// Local providers (Ollama, vLLM) take no key; effectiveApiKey fills a
+				// harmless placeholder instead of an empty string so this still clears
+				// the backend's blank-api_key guard, matching validatePool above.
+				api_key: P.effectiveApiKey
+					? P.effectiveApiKey(r.provider, r.apiKey, r.has_key)
+					: (r.apiKey || "").trim(),
 				order: i,
 			};
 			const b = (r.baseUrl || "").trim();

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -268,8 +268,11 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				// Managed tenants: account management now lives in the Jarvis SPA.
 				// Redirect there unless ?billing=1 (the billing/upgrade flow is not
 				// yet in the SPA — Phase 2). Self-hosted tenants above keep this page.
+				// "/jarvis/account" is a retired route (the account page's content
+				// moved into the SPA settings dialog, which has no URL deep-link
+				// scheme to open a specific pane) - repoint to the SPA root.
 				if (!new URLSearchParams(window.location.search).get("billing")) {
-					window.location.replace("/jarvis/account");
+					window.location.replace("/jarvis/");
 					return null;
 				}
 

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -1491,7 +1491,11 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 			const p = $(this).val();
 			const d = PROVIDER_DEFAULTS[p] || {};
 			const row = ui.customRows[i] || {};
-			const patch = { provider: p };
+			// A stored key (has_key) belongs to the OLD provider's key_ref - carry it
+			// forward and a switch to Ollama/vLLM with no retyped key would still send
+			// a blank api_key while has_key=true, hitting the exact "blank api_key"
+			// rejection this whole editor exists to avoid for local providers.
+			const patch = { provider: p, has_key: false, apiKey: "" };
 			if (!(row.model || "").trim() && d.model) patch.model = d.model;
 			if (!(row.baseUrl || "").trim() && d.baseUrl) patch.baseUrl = d.baseUrl;
 			ui.customRows[i] = Object.assign({}, row, patch);

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -62,7 +62,16 @@ class TestGetLlmUsage(FrappeTestCase):
 
 
 class TestGetLlmConnectionStatus(FrappeTestCase):
+	def setUp(self):
+		self._proxy = frappe.db.get_single_value("Jarvis Settings", "proxy_active")
+
+	def tearDown(self):
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", self._proxy or 0)
+		frappe.db.commit()
+
 	def test_remaps_admin_auth_status_fields(self):
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 1)
+		frappe.db.commit()
 		raw = {
 			"ok": True,
 			"data": {
@@ -75,6 +84,21 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		with patch.object(admin_client, "post_llm_auth_status", return_value=raw) as m:
 			out = account.get_llm_connection_status()
 		m.assert_called_once_with()
+		self.assertEqual(out["proxy_active"], True)
 		self.assertEqual(out["auth_present"], True)
 		self.assertEqual(out["oauth_expires_at"], 1893456000000)
 		self.assertEqual(out["default_model"], "gpt-5.5")
+
+	def test_direct_tenant_short_circuits_without_admin_call(self):
+		# A DIRECT (single-model) tenant has no proxy auth profile to report -
+		# the SPA's ConnectionPane used to render this as a misleading orange
+		# "Not connected" instead of an accurate "Direct" state.
+		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_model", "gpt-4o")
+		frappe.db.commit()
+		with patch.object(admin_client, "post_llm_auth_status") as m:
+			out = account.get_llm_connection_status()
+		m.assert_not_called()
+		self.assertEqual(out["proxy_active"], False)
+		self.assertEqual(out["auth_present"], False)
+		self.assertEqual(out["default_model"], "gpt-4o")

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -64,9 +64,11 @@ class TestGetLlmUsage(FrappeTestCase):
 class TestGetLlmConnectionStatus(FrappeTestCase):
 	def setUp(self):
 		self._proxy = frappe.db.get_single_value("Jarvis Settings", "proxy_active")
+		self._llm_model = frappe.db.get_single_value("Jarvis Settings", "llm_model")
 
 	def tearDown(self):
 		frappe.db.set_single_value("Jarvis Settings", "proxy_active", self._proxy or 0)
+		frappe.db.set_single_value("Jarvis Settings", "llm_model", self._llm_model or "")
 		frappe.db.commit()
 
 	def test_remaps_admin_auth_status_fields(self):


### PR DESCRIPTION
## Summary

Three small, unrelated UI defects found in today's live e2e run.

### 1. Unknown SPA routes rendered a blank white page

`frontend/src/router/index.js` had no catch-all route. `/jarvis/account` (a
previously valid path, still referenced from the desk app) matched nothing
and users landed on pure white.

- Added `{ path: "/:pathMatch(.*)*", name: "NotFound", redirect: "/" }` as
  the last route. vue-router 4 ranks a static path above a wildcard
  regardless of registration order, so this cannot shadow any existing
  route or interact with the `beforeEach` onboarding guard (which only ever
  redirects a fully-onboarded user away from `/onboarding`, never forces a
  not-ready user into it - the deliberate anti-D11-loop behavior documented
  in that file).
- `jarvis/jarvis/page/jarvis_account/jarvis_account.js` still hard-redirected
  managed tenants to the now-dead `/jarvis/account` (the account page's
  content moved into the SPA settings dialog, which has no URL scheme to
  deep-link a specific pane - confirmed by reading the router and
  `SettingsDialog.vue`/`shell.js`, so none was invented). Repointed to
  `/jarvis/`.
- Searched both desk JS and Python for other `"/jarvis/account"` references;
  this was the only literal one.

**Before:** visiting `/jarvis/account` (or any other unknown SPA path) -> blank white screen.
**After:** redirects to Chat (`/`).

### 2. Connection pane showed "Not connected" for a working DIRECT tenant

`get_llm_connection_status` always round-tripped to admin's proxy-auth
endpoint, even for a DIRECT (single-model, no proxy sidecar) tenant that
has no proxy auth profile at all. The leftover payload (a `default_model`
with `auth_profile_present` false) made `ConnectionPane.vue` infer
"connection details are present" and render an orange **Not connected**
for a tenant whose chat verifiably works.

- `jarvis/account.py::get_llm_connection_status` now short-circuits on
  `proxy_active=0` (mirrors the existing `get_llm_usage` pattern just above
  it) and returns an explicit `proxy_active` flag instead of making the
  frontend guess the mode from which fields are populated.
- `ConnectionPane.vue` now renders **Direct** with neutral styling (no
  green/amber tint - matches `BillingMeteringPane.vue`'s existing
  uncolored "Mode" row for the same value) plus the model line, and keeps
  the real Connected/Not connected proxy states unchanged.
- Dropped the stale "Proxy connection status for this workspace" subtitle
  in `SettingsDialog.vue` for a mode-neutral one.
- Added `TestGetLlmConnectionStatus.test_direct_tenant_short_circuits_without_admin_call`
  next to the existing `get_llm_usage` test of the same shape.
- **Follow-up (code review):** `GeneralPane.vue`'s always-visible "Status"
  row reads the same endpoint and had the identical bug (`auth_present:false`
  read as "Not connected" for a direct tenant, just without the alarming
  color - it already used neutral gray for "not connected"). Applied the
  same `proxy_active`-aware fix there too.

**Before:** Connection pane on a direct tenant -> Status: **Not connected** (orange).
**After:** Status: **Direct** (neutral) + Model line; proxy tenants unaffected.

### 3. API key required even for local providers (Ollama, vLLM)

The onboarding Connect step and the AI-models editor both required a
non-empty API key for every provider, including Ollama (local) and vLLM
(local), which authenticate with nothing - customers had to type a junk
value to get past validation.

- `frontend/src/llm/pool.js`: `validatePool` now skips the key requirement
  for a new `LOCAL_PROVIDER_IDS` set (`ollama`, `vllm` - matches the naming
  already used by `jarvis.llm_key_probe.LOCAL_PROVIDER_IDS`). vLLM still
  requires its `base_url` - only the key becomes optional.
- A new `effectiveApiKey()` helper fills a fixed `"local"` placeholder only
  when the row is genuinely blank (never typed, no stored key), so the
  payload sent to `save_llm_pool` still clears the backend's existing
  dangling-`key_ref` guard (`pool_serialize.validate_models`) without
  touching that backend contract, per the "if unsure, send a placeholder
  from the frontend" guidance - a typed key or an existing stored key
  (`has_key`) always wins over the placeholder.
- Wired into both editor surfaces: the onboarding single-model grid and the
  settings row panel (including the Test-button gate), plus the legacy
  desk Custom-mode builder (`jarvis_account.js`), which shares the same
  `validatePool` via the `jarvis_onboarding_llm` bundle.
- API key fields now say "(optional)" / "Not required for local providers"
  for these two providers.
- Added unit tests in `pool.test.js` (`validatePool`, `effectiveApiKey`,
  `buildCustomModels`, `LOCAL_PROVIDER_IDS`).

**Before:** Save blocked with "Model X needs an API key" for a bare Ollama/vLLM row.
**After:** Save succeeds with no key typed; field reads "Not required for local providers".

## Code review (sonnet, 4 pooled finders + independent re-verification)

Ran a pooled review round (routing correctness, backend-contract correctness,
local-provider key logic correctness, and cleanup) before finalizing, then
personally re-verified every candidate against the actual code. One follow-up
commit addresses everything that held up:

- **Real bug (high confidence, fixed):** `LlmPoolEditor.vue`'s
  `onProviderChange` (and the desk page's equivalent `.ja-custom-prov`
  handler) reset `model`/`base_url` on a provider switch but left a stale
  `hasKey`/`has_key` + `apiKey` from the OLD provider in place. Editing an
  existing keyed row and switching its provider to Ollama/vLLM without
  retyping a key reproduced the exact "api_key is blank on an enabled model"
  rejection issue 3 exists to eliminate - the local-provider placeholder
  never engaged because `hasKey` already looked satisfied. Both handlers now
  clear the stored-key state on any provider change, matching how
  `onUpstreamChange` already clears connected accounts on a subscription
  upstream switch.
- **Real bug (fixed):** the new direct-tenant test in `test_llm_monitor.py`
  committed a temporary `llm_model` value but only restored `proxy_active`
  in `tearDown`, leaking `"gpt-4o"` into `Jarvis Settings` for the rest of
  the suite run.
- **Cleanup (fixed):** deduplicated `LOCAL_PROVIDER_IDS` - `LlmPoolEditor.vue`
  now imports the set from `pool.js` instead of keeping its own copy.
- **Cleanup (fixed):** standardized the two "no key needed" placeholder
  strings (onboarding grid vs. settings panel) on one wording.
- Routing-angle finder: no defects found (verified vue-router 4 resolves
  `redirect` before guards run, and static paths always outrank the
  wildcard regardless of array order).

## Test plan

- [x] `node --test src/llm/pool.js` unit tests - 53/53 pass (includes 4 new tests)
- [x] `bench --site site.jarvis run-tests --module jarvis.tests.test_llm_monitor` - 5/5 pass (includes 1 new test), via `PYTHONPATH` pointed at this worktree
- [x] `bench --site site.jarvis run-tests --module jarvis.tests.test_role_gates` - unaffected, 6/6 pass
- [x] `bench --site site.jarvis run-tests --module jarvis.tests.test_llm_pool_endpoints` - unaffected, 18/18 pass
- [x] `ruff check` / `ruff format --check` on all changed Python files - clean
- [x] `cd frontend && npx vite build` - succeeds (439 modules, no errors) after the documented `wiki-graph-core` worktree workaround, re-run clean after the review follow-up commit
- [ ] Live e2e re-check on `jarvis.proxy` (a direct-mode tenant) for the Connection pane, and an onboarding run picking Ollama/vLLM with no key

## Risks

- Issue 1's catch-all is scoped to unknown paths only; verified by reading
  vue-router 4's ranking behavior and the existing route list rather than
  live-testing every route, since CI/build was the available signal in
  this worktree.
- Issue 3 leaves the desk page's separate hand-rolled "Quick" single-model
  editor (`bindLlm`/`doSaveApiKeyCreds`, calling `save_llm_creds`) as-is -
  it is a legacy path only reachable via `/app/jarvis-account?billing=1`
  and out of the two named surfaces (onboarding Connect step, AI-models
  editor). It still requires a typed key for local providers there.
- No backend (`pool_serialize.py`) changes were made for issue 3, by
  design - the frontend placeholder keeps the existing dangling-key_ref
  guard intact everywhere else.
- Manual/live e2e (checkbox above) has not been run yet - the automated
  test plan and a production build are the evidence so far.
