### PR TITLE
fix(chat): surface terminal agent failures instead of a silent empty bubble (+ reaper data-loss regression guard)

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -218,6 +218,56 @@ def _chat_final_text(payload: dict) -> str | None:
 	return None
 
 
+# openclaw marks an assistant turn that FAILED before producing any content
+# with ``stopReason == "error"`` and (in the raw transcript) this sentinel text
+# block. A terminal model failure - notably a precheck "Context overflow:
+# prompt too large for the model", which then deletes the session so there is
+# no auto-compact retry - is broadcast as a ``chat`` event with
+# ``state == "final"`` (NOT ``state == "error"``) whose projected display
+# message keeps ``stopReason == "error"`` but has empty (sentinel-stripped)
+# content. Without the guard below, ``relay_turn_events`` would map that to a
+# plain ``relay:final`` and the turn handler would write a silent, empty,
+# error-less assistant bubble (observed live 2026-07-21). Detecting it here, at
+# the openclaw->bench event boundary, lets the EXISTING relay:error path stamp
+# the row's ``error`` field so the user sees an honest failure.
+_STREAM_ERROR_SENTINEL = "[assistant turn failed before producing content]"
+
+# User-facing text stamped on the assistant row's ``error`` field (and shown in
+# the chat) for such a failed final. Generic on purpose: a ``state == "final"``
+# event carries no ``errorMessage`` (only ``stopReason``), so the exact cause
+# cannot be named here; a context window too small for the conversation is the
+# common one. Must NOT contain "context overflow" (that substring reroutes the
+# turn handler into the auto-compact park-for-recovery branch, which never
+# lands for a terminal precheck failure) or "aborted".
+FAILED_FINAL_ERROR = (
+	"The assistant could not complete this response and the turn ended "
+	"without any output. This can happen when the conversation is too long "
+	"for the current model, or the model hit an error. Please try again, or "
+	"start a new chat."
+)
+
+
+def _chat_final_failed(payload: dict, text: str | None) -> bool:
+	"""True when a ``state == "final"`` chat event actually represents a FAILED
+	turn that produced NO real answer: its only content is the stream-error
+	sentinel, or (with no visible text) the assistant message carries
+	``stopReason == "error"``. Such a "final" must surface as an error, not a
+	silent empty bubble.
+
+	Guards two non-failures:
+	  * a real (possibly partial) answer is kept even when the turn also flagged
+	    an error, so a streamed reply is never hidden behind an error;
+	  * a genuinely successful turn that emitted only rich outputs (canvas /
+	    image, no prose) has no text and ``stopReason`` != "error", so it stays a
+	    normal empty-text relay:final."""
+	if isinstance(text, str) and text.strip() == _STREAM_ERROR_SENTINEL:
+		return True
+	if text:
+		return False
+	msg = payload.get("message")
+	return isinstance(msg, dict) and msg.get("stopReason") == "error"
+
+
 def _persisted_device_id() -> str:
 	"""Cheap unauthenticated read of Jarvis Settings.chat_device_id.
 
@@ -669,8 +719,14 @@ class OpenclawSession:
 
 		NEVER raises after entry. Terminal yields:
 		  {"kind": "relay:final", "text": str|None}
-		  {"kind": "relay:error", "state": "error"|"aborted", "error": str}
+		  {"kind": "relay:error", "state": "error"|"aborted"|"failed_final", "error": str}
 		  {"kind": "relay:interrupted", "reason": "transport"|"deadline", ...}
+
+		A ``state == "final"`` event whose assistant turn actually failed
+		(stopReason error / stream-error sentinel, e.g. a precheck context
+		overflow that deletes the session) is remapped to a ``failed_final``
+		relay:error so it stamps an honest error instead of a silent empty
+		final. See _chat_final_failed.
 		"""
 		deadline = time.monotonic() + soft_deadline_s
 		while True:
@@ -700,7 +756,18 @@ class OpenclawSession:
 					continue
 				state = payload.get("state")
 				if state == "final":
-					yield {"kind": "relay:final", "text": _chat_final_text(payload)}
+					text = _chat_final_text(payload)
+					# A "final" whose assistant turn actually FAILED (stopReason
+					# error / stream-error sentinel) is surfaced as a terminal
+					# error, not a silent empty bubble. See _chat_final_failed.
+					if _chat_final_failed(payload, text):
+						yield {
+							"kind": "relay:error",
+							"state": "failed_final",
+							"error": FAILED_FINAL_ERROR,
+						}
+						return
+					yield {"kind": "relay:final", "text": text}
 					return
 				if state in ("error", "aborted"):
 					yield {

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -281,6 +281,14 @@ def _reap_empty(sess, budget: int, summary: dict) -> int:
 		  AND c.starred = 0
 		  AND c.file_box = 0
 		  AND c.last_active_at IS NOT NULL AND c.last_active_at < %(cutoff)s
+		  -- HARD DATA-LOSS GUARD: only a conversation with ZERO messages is ever
+		  -- reapable. A conversation that holds ANY message - a user message, or
+		  -- even an assistant row from a turn that FAILED (a terminal agent error
+		  -- leaves an errored/empty assistant row; see turn_handler + the
+		  -- openclaw_client failed_final mapping) - is real chat history and is
+		  -- never auto-deleted. Do NOT loosen this to reap "conversations whose
+		  -- turns all failed / produced no visible content": that would delete the
+		  -- user's message. Empty ones may go; anything with a message stays.
 		  AND NOT EXISTS (
 			SELECT 1 FROM `tabJarvis Chat Message` m WHERE m.conversation = c.name
 		  )

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -1319,3 +1319,64 @@ class TestRunAgentTurnAborted(FrappeTestCase):
 		self.assertEqual(row["stopped"], 0)
 		self.assertEqual(row["content"], "all done")
 		self.assertEqual(row["streaming"], 0)
+
+
+class TestRunAgentTurnFailedFinal(FrappeTestCase):
+	"""A terminal agent failure that openclaw reports as state="final" with an
+	empty message (stopReason error) - e.g. a precheck context overflow that
+	deletes the session, so there is no auto-compact retry - must land as an
+	honest error on the assistant row, never a silent empty bubble.
+
+	openclaw_client.relay_turn_events remaps that final to a relay:error with
+	state="failed_final"; this exercises the full turn so the row's `error`
+	field and the run:error publish are both verified.
+	"""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _run(self, relay_events):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = lambda sk, msg, idem, **kw: {
+			"runId": idem,
+			"status": "started",
+		}
+		fake_sess.relay_turn_events.return_value = _fake_event_stream(relay_events)
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.worker.publish_to_user") as pub:
+				run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		return pub
+
+	def _assistant_row(self, fields):
+		return frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			fields,
+			as_dict=isinstance(fields, list),
+		)
+
+	def test_failed_final_stamps_error_and_is_not_recovering(self):
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		pub = self._run([{"kind": "relay:error", "state": "failed_final", "error": FAILED_FINAL_ERROR}])
+		row = self._assistant_row(["content", "error", "streaming", "recovering"])
+		# The core of the bug: error must be set, not NULL, on a terminal failure.
+		self.assertEqual(row["error"], FAILED_FINAL_ERROR)
+		self.assertFalse((row["content"] or "").strip())
+		self.assertEqual(row["streaming"], 0)
+		# It is terminal, NOT parked for snapshot recovery.
+		self.assertFalse(row["recovering"])
+		# The user is told, via a run:error (no silent empty run:end-only turn).
+		kinds = [c.args[1]["kind"] for c in pub.call_args_list]
+		self.assertIn("run:error", kinds)
+		err_pub = next(c.args[1] for c in pub.call_args_list if c.args[1]["kind"] == "run:error")
+		self.assertEqual(err_pub["error"], FAILED_FINAL_ERROR)

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -164,6 +164,98 @@ class TestRelayTurnEvents(FrappeTestCase):
 			],
 		)
 
+	def test_final_stop_reason_error_empty_content_yields_relay_error(self):
+		# A terminal agent failure (e.g. a precheck context overflow that then
+		# deletes the session) is broadcast as state="final" with an EMPTY,
+		# sentinel-stripped message that keeps stopReason="error". It must NOT
+		# read as a silent successful empty final; it must surface as an error
+		# so the turn handler stamps the assistant row's `error` field.
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		sess = self._sess(
+			[
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={"role": "assistant", "content": [], "stopReason": "error"},
+				),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(
+			out,
+			[{"kind": "relay:error", "state": "failed_final", "error": FAILED_FINAL_ERROR}],
+		)
+
+	def test_final_stream_error_sentinel_content_yields_relay_error(self):
+		# Some openclaw builds leave the sentinel text block in the projected
+		# final message instead of stripping it. That is still a failed turn,
+		# not a real answer, so it maps to the same failed_final error rather
+		# than rendering the raw sentinel as the assistant's reply.
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		sess = self._sess(
+			[
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={
+						"role": "assistant",
+						"content": [
+							{
+								"type": "text",
+								"text": "[assistant turn failed before producing content]",
+							}
+						],
+					},
+				),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(
+			out,
+			[{"kind": "relay:error", "state": "failed_final", "error": FAILED_FINAL_ERROR}],
+		)
+
+	def test_final_empty_content_without_error_stop_reason_stays_final(self):
+		# A genuinely successful turn that produced only rich outputs (no prose)
+		# has empty text and a non-error stopReason. It must stay a normal
+		# empty-text relay:final, never be misclassified as a failure.
+		sess = self._sess(
+			[
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={"role": "assistant", "content": [], "stopReason": "end_turn"},
+				),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
+
+	def test_final_real_text_with_error_stop_reason_keeps_the_answer(self):
+		# A partial answer that also flagged an error must NOT be hidden behind
+		# an error bubble: the streamed reply wins and stays a relay:final.
+		sess = self._sess(
+			[
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={
+						"role": "assistant",
+						"content": [{"type": "text", "text": "here is the partial answer"}],
+						"stopReason": "error",
+					},
+				),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": "here is the partial answer"}])
+
 	def test_transport_drop_yields_interrupted_transport_and_does_not_raise(self):
 		sess = self._sess([OpenclawUnreachableError("ws closed mid-stream")])
 		# The generator swallows the exception, so the pool's

--- a/jarvis/tests/test_session_lifecycle.py
+++ b/jarvis/tests/test_session_lifecycle.py
@@ -335,6 +335,44 @@ class TestSessionLifecycle(FrappeTestCase):
 		self.assertEqual(summary["empty_reaped"], 0)
 		self.assertTrue(frappe.db.exists(CONV, name))
 
+	def test_chat_with_user_message_and_failed_turn_never_reaped(self):
+		# Incident regression (2026-07-21): a conversation whose only assistant
+		# turn FAILED (a terminal agent error - here an empty, errored assistant
+		# row, the exact shape a failed turn leaves behind) still holds the user's
+		# message and is real chat history. The any-message reap filter must spare
+		# it even when every time/status predicate matches, so a failed turn can
+		# never make the user's message auto-deletable. (The live deletion in that
+		# incident was e2e/manual cleanup of a probe conversation, NOT this reaper;
+		# this pins the invariant so a future "reap failed-turn-only conversations"
+		# change cannot regress into deleting user messages.)
+		name = self._conv(idle_days=10)  # matches status/starred/file_box/idle
+		frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": name,
+				"seq": 1,
+				"role": "user",
+				"content": "Reply with exactly one word: PONG",
+			}
+		).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": name,
+				"seq": 2,
+				"role": "assistant",
+				"content": "",  # failed turn: no visible content ...
+				"error": "The model could not complete this response.",  # ... but errored
+				"streaming": 0,
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		summary = self._run(_fake_sess())
+		self.assertEqual(summary["empty_reaped"], 0)
+		self.assertTrue(frappe.db.exists(CONV, name))
+		# The user's message specifically survives.
+		self.assertTrue(frappe.db.exists(MSG, {"conversation": name, "role": "user"}))
+
 	def test_empty_chat_with_stray_session_freed_then_reaped(self):
 		"""Defensive: a 0-message chat carrying a session (idle within the 30-day
 		session window but past the 7-day empty window) has its stray session


### PR DESCRIPTION
## What and why

Root-cause and fix for a failed-turn lifecycle bug verified live on 2026-07-21 (tenant `jarvis-pool-0655cb`, site `jarvis.proxy`): a chat turn hit a terminal agent error inside openclaw ("Context overflow: prompt too large for the model (precheck)", qwen2.5:3b, ~35k prompt vs 32k window), openclaw deleted the session, and the customer site persisted the assistant row with EMPTY `content` and `error = NULL` (`streaming = 0`). The chat showed a silent empty assistant bubble with only a duration.

## A. Terminal agent failure was dropped (the fix)

In the managed relay path, completion comes only from the run-scoped openclaw `chat` event; agent `lifecycle` frames are dropped. openclaw ends a turn that FAILED before producing content with `stopReason = "error"` (and, in transcripts, a `[assistant turn failed before producing content]` sentinel). A terminal precheck context overflow, which then deletes the session so there is no auto-compact retry, is broadcast as a `chat` event with `state = "final"` (NOT `state = "error"`) whose projected display message keeps `stopReason = "error"` but has empty, sentinel-stripped content.

`OpenclawSession.relay_turn_events` mapped that to a plain `relay:final`, so `turn_handler` treated it as a successful empty turn: it left `content = ""`, flipped `streaming = 0`, and never set `error`. That is exactly the observed row (conversation `lkos0dnjcg`, message `lkto8d01ls`: `content = ""`, `error = NULL`).

Fix, at the openclaw to bench event boundary (`jarvis/chat/openclaw_client.py`): detect a failed final (`stopReason == "error"`, or the stream-error sentinel, with no real text) and remap it to a `failed_final` `relay:error`. The existing `relay:error` path in `turn_handler` then stamps the row's `error` field and publishes `run:error`, so the user sees an honest failure instead of a silent bubble. Guards keep a real (partial) answer and a rich-output-only turn as normal `relay:final`s. This does not contain the substring "context overflow", so it does not trip the auto-compact park-for-recovery branch (which never lands for a terminal precheck failure).

Tests: `test_relay_consumer.py` (mapping: failed final by stopReason and by sentinel -> `relay:error`; empty-but-successful and partial-answer cases stay `relay:final`) and `test_chat_worker.py` (`TestRunAgentTurnFailedFinal`: the full turn stamps `error`, is not left recovering, and publishes `run:error`).

## B. Conversation deletion: root cause was NOT a production auto-pruner

DB ground truth from `jarvis.proxy` (`tabDeleted Document`): conversation `lkos0dnjcg` had `file_box = 0`, title "Reply with exactly one word: PONG" (the e2e health probe from `.claude/e2e/full-jarvis.md`), session_key `agent:main:dashboard:...`. It and an empty New Chat (`oml4018ift`) were deleted as **Administrator** via `delete_doc` (archived), within ~2 seconds of each other, about 7 minutes after creation. That is e2e / manual cleanup of probe conversations, not a retention/pruning bug.

The only production auto-pruner, `session_lifecycle._reap_empty`, cannot delete a conversation that holds any message: it selects only ZERO-message chats idle past `EMPTY_GRACE_DAYS` (7 days), excludes any messaged row via `NOT EXISTS(message)`, and re-checks before the destructive delete. That invariant is already covered by `test_nonempty_idle_chat_not_reaped`.

Because a failed turn now leaves an errored/empty assistant row, a future change that reaped "conversations whose turns all failed / produced no visible content" would be the exact data-loss risk. This PR documents the any-message filter as the hard data-loss guard and adds a regression test in the incident's exact shape (user message + failed/empty assistant turn -> never reaped). No production behavior change.

## C. Measured usage stays 0 (filed, not fixed here)

Multi-factor design/robustness issue (`admin_sync_usage` reports context size, not accumulated usage; `record_turn_usage` drops usage on totalTokensFresh lag, session churn, recovered turns, and unmapped agent-main sessions). Filed as #375.

## Scope note

The `jarvis-openclaw-plugin` is the ERP tool surface and does not touch the chat event stream, so no plugin change was needed; the fix is entirely on the jarvis side of the openclaw event contract.

## Verification

All affected modules pass locally against the worktree (`PYTHONPATH` override): `test_relay_consumer` (15), `test_chat_worker` (39, incl. the new failed-final class and the untouched overflow-parks tests), `test_session_lifecycle` (40). `ruff check` and `ruff format --check` clean on all changed files. CI (fresh DB) is the authority.
