### PR TITLE
feat(billing): pause chat on a lapsed subscription + Plan & billing polish

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -40,8 +40,20 @@ export function shortDate(dt) {
 	const s = (dt || "").trim().split(" ")[0];
 	const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
 	if (!m) return "";
-	const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-					"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+	const MONTHS = [
+		"Jan",
+		"Feb",
+		"Mar",
+		"Apr",
+		"May",
+		"Jun",
+		"Jul",
+		"Aug",
+		"Sep",
+		"Oct",
+		"Nov",
+		"Dec",
+	];
 	return `${Number(m[3])} ${MONTHS[Number(m[2]) - 1]}`;
 }
 // Pill text while a cancellation is scheduled: a glanceable end date, not the

--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -35,6 +35,22 @@ export function pillTone(status, cancelAtPeriodEnd) {
 export function cancelActionLabel(hasMandate) {
 	return hasMandate ? "Cancel auto-renewal" : "Cancel subscription";
 }
+// Short "D MMM" date for pills/inline chips. "2026-08-21 12:00" -> "21 Aug".
+export function shortDate(dt) {
+	const s = (dt || "").trim().split(" ")[0];
+	const m = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!m) return "";
+	const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+					"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+	return `${Number(m[3])} ${MONTHS[Number(m[2]) - 1]}`;
+}
+// Pill text while a cancellation is scheduled: a glanceable end date, not the
+// ambiguous "Cancelling" (which reads as an in-progress operation). The plan is
+// still Active until then; the date is what the customer actually needs.
+export function cancelPillLabel(accessEndsOn) {
+	const d = shortDate(accessEndsOn);
+	return d ? `Ends ${d}` : "Ending";
+}
 // Banner copy while a cancellation is scheduled.
 export function cancellationNotice(accessEndsOn) {
 	const end = (accessEndsOn || "").trim();

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -82,7 +82,7 @@ test("cancelActionLabel: only promises auto-renewal when one exists", () => {
 test("cancellationNotice: names the end date, degrades without one", () => {
 	assert.equal(
 		cancellationNotice("2026-08-20 16:11:36.216083"),
-		"Your plan ends on 2026-08-20. You keep full access until then.",
+		"Your plan ends on 2026-08-20. You keep full access until then."
 	);
 	assert.match(cancellationNotice(""), /keep full access until then/);
 	assert.match(cancellationNotice(null), /keep full access until then/);

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -10,6 +10,8 @@ import {
 	planSuffix,
 	cancelActionLabel,
 	cancellationNotice,
+	shortDate,
+	cancelPillLabel,
 } from "./format.js";
 
 test("statusLabel: maps known states, passes through unknown", () => {
@@ -84,4 +86,18 @@ test("cancellationNotice: names the end date, degrades without one", () => {
 	);
 	assert.match(cancellationNotice(""), /keep full access until then/);
 	assert.match(cancellationNotice(null), /keep full access until then/);
+});
+
+test("shortDate: D MMM, degrades on junk", () => {
+	assert.equal(shortDate("2026-08-21 12:56:09"), "21 Aug");
+	assert.equal(shortDate("2026-01-05"), "5 Jan");
+	assert.equal(shortDate(""), "");
+	assert.equal(shortDate(null), "");
+	assert.equal(shortDate("not-a-date"), "");
+});
+
+test("cancelPillLabel: glanceable end date, not the ambiguous 'Cancelling'", () => {
+	assert.equal(cancelPillLabel("2026-08-21 12:56:09"), "Ends 21 Aug");
+	assert.equal(cancelPillLabel(""), "Ending");
+	assert.equal(cancelPillLabel(null), "Ending");
 });

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -250,8 +250,7 @@ export const getAccount = () => call("jarvis.account.get_account");
 // BILLING plan lifecycle. Not to be confused with disconnectSubscription
 // above, which drops the LLM PROVIDER subscription (ChatGPT/Claude OAuth).
 // These end / restore the paid Jarvis plan itself.
-export const cancelPlanAtPeriodEnd = () =>
-	call("jarvis.account.cancel_plan_at_period_end");
+export const cancelPlanAtPeriodEnd = () => call("jarvis.account.cancel_plan_at_period_end");
 export const resumePlan = () => call("jarvis.account.resume_plan");
 
 // File input: upload to Frappe's File doctype, return {file_url, file_name}.

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -210,6 +210,9 @@
 .jv-acct-btn-sm:hover { background: var(--surface-3); }
 /* scheduled-cancellation banner: warn-toned, above the plan actions */
 .jv-acct-notice { margin-top: 12px; padding: 9px 11px; border-radius: 8px; background: var(--surface-2); font-size: 12.5px; color: var(--text-2); }
+/* notice with an inline action (the cancellation notice carries Resume) */
+.jv-acct-notice--row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.jv-acct-notice--row > span { min-width: 0; }
 /* plan lifecycle actions (cancel / resume) sit below the feature list */
 .jv-acct-actions { display: flex; gap: 8px; margin-top: 16px; }
 .jv-acct-actions .jv-acct-btn-sm { width: auto; padding: 0 12px; }
@@ -217,6 +220,13 @@
 .jv-acct-link { display: inline-flex; align-items: center; gap: 5px; margin-top: 18px; font-size: 13px; color: var(--link); text-decoration: none; }
 .jv-acct-link:hover { text-decoration: underline; }
 .jv-acct-link svg { flex: none; }
+/* manage footer: billing link left, quiet cancel action right (same baseline) */
+.jv-acct-footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 18px; }
+.jv-acct-footer .jv-acct-link { margin-top: 0; }
+/* cancel: a quiet text link, red only on hover — confirm dialog owns the red */
+.jv-acct-cancel { flex: none; padding: 0; border: 0; background: none; font: inherit; font-size: 13px; color: var(--text-3); cursor: pointer; transition: color .15s ease; }
+.jv-acct-cancel:hover:not(:disabled) { color: var(--red); text-decoration: underline; }
+.jv-acct-cancel:disabled { opacity: .5; cursor: default; }
 .jv-acct-savednote { font-size: 12px; color: var(--text-3); font-weight: 420; }
 .jv-acct-usage-line { font-size: 13px; color: var(--text-2); }
 

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -179,9 +179,7 @@ const cancelling = computed(() => !!account.value.cancel_at_period_end);
 // fresh payment restores service. Distinct from `cancelling` (still entitled).
 const ENDED_STATUSES = new Set(["Expired", "Cancelled"]);
 const ended = computed(() => ENDED_STATUSES.has(account.value.subscription_status));
-const tone = computed(() =>
-	pillTone(account.value.subscription_status, cancelling.value),
-);
+const tone = computed(() => pillTone(account.value.subscription_status, cancelling.value));
 const busy = ref(false);
 const reauthNotice = ref("");
 

--- a/frontend/src/components/settings/PlanBillingPane.vue
+++ b/frontend/src/components/settings/PlanBillingPane.vue
@@ -23,7 +23,9 @@
 							}}
 						</div>
 						<span class="jv-acct-pill" :class="tone">{{
-							statusLabel(account.subscription_status, cancelling)
+							cancelling
+								? cancelPillLabel(account.access_ends_on)
+								: statusLabel(account.subscription_status)
 						}}</span>
 					</div>
 					<div class="jv-acct-renewal">
@@ -32,11 +34,19 @@
 							· Auto-renew on</template
 						>
 					</div>
-					<!-- A scheduled cancellation must be visible on sight: it is the
-						 only affordance that surfaces Resume, and an invisible one
-						 generates support tickets. -->
-					<div v-if="cancelling" class="jv-acct-notice">
-						{{ cancellationNotice(account.access_ends_on) }}
+					<!-- Scheduled cancellation: state it plainly and put Resume right
+						 here, so the one affordance that undoes it is where the customer
+						 is already looking. -->
+					<div v-if="cancelling" class="jv-acct-notice jv-acct-notice--row">
+						<span>{{ cancellationNotice(account.access_ends_on) }}</span>
+						<button
+							type="button"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+							:disabled="busy"
+							@click="doResume"
+						>
+							Resume
+						</button>
 					</div>
 					<ul v-if="planFeatures.length" class="jv-acct-features">
 						<li v-for="(f, i) in planFeatures" :key="i">
@@ -79,45 +89,46 @@
 						</div>
 					</div>
 				</div>
-				<div v-if="account.plan && account.plan.plan_name" class="jv-acct-actions">
+				<!-- Lapsed: renewing is the point (where the chat suspension banner
+					 sends them), so keep it prominent. -->
+				<div v-if="ended" class="jv-acct-actions">
+					<a :href="billingUrl" class="jv-btn jv-btn--primary">Renew subscription</a>
+				</div>
+				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
+
+				<!-- Manage footer: the external billing link, with cancel tucked
+					 beside it as a quiet text link. It stays low-key because the confirm
+					 dialog (danger) owns the deliberate red step; a solid red button here
+					 just makes the pane hostile. Hidden while cancelling (Resume is above)
+					 or ended (nothing to cancel). -->
+				<div class="jv-acct-footer">
+					<a :href="billingUrl" class="jv-acct-link">
+						Manage plan &amp; billing
+						<svg
+							width="13"
+							height="13"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+							<path d="M15 3h6v6" />
+							<path d="M10 14 21 3" />
+						</svg>
+					</a>
 					<button
-						v-if="cancelling"
+						v-if="!cancelling && !ended"
 						type="button"
-						class="jv-acct-btn-sm"
-						:disabled="busy"
-						@click="doResume"
-					>
-						Resume subscription
-					</button>
-					<button
-						v-else
-						type="button"
-						class="jv-btn jv-btn--danger"
+						class="jv-acct-cancel"
 						:disabled="busy"
 						@click="doCancel"
 					>
 						{{ cancelActionLabel(account.has_mandate) }}
 					</button>
 				</div>
-				<div v-if="reauthNotice" class="jv-acct-notice">{{ reauthNotice }}</div>
-
-				<a :href="billingUrl" class="jv-acct-link">
-					Manage plan &amp; billing
-					<svg
-						width="13"
-						height="13"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-						<path d="M15 3h6v6" />
-						<path d="M10 14 21 3" />
-					</svg>
-				</a>
 			</template>
 		</section>
 	</div>
@@ -132,6 +143,7 @@ import {
 	planPriceLabel,
 	renewalLabel,
 	cancelActionLabel,
+	cancelPillLabel,
 	cancellationNotice,
 } from "@/account/format.js";
 import { useConfirm } from "@/composables/useConfirm";
@@ -163,6 +175,10 @@ const upgradePlans = computed(() => account.value.upgrade_plans || []);
 // A plan scheduled to end. Server keeps status "Active" through the paid
 // period, so this flag - not the status - drives the cancelling UI.
 const cancelling = computed(() => !!account.value.cancel_at_period_end);
+// Terminal: paid period over, no access left to cancel and no Resume - only a
+// fresh payment restores service. Distinct from `cancelling` (still entitled).
+const ENDED_STATUSES = new Set(["Expired", "Cancelled"]);
+const ended = computed(() => ENDED_STATUSES.has(account.value.subscription_status));
 const tone = computed(() =>
 	pillTone(account.value.subscription_status, cancelling.value),
 );

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -30,6 +30,19 @@ export function isOnboardComplete(readyResp) {
 	return !!(readyResp && readyResp.ready);
 }
 
+// Used when an older admin sends the Suspended state without a reason string.
+export const SUSPENDED_FALLBACK =
+	"Your subscription is no longer active. Renew to restore access to Jarvis.";
+
+// The renew-banner sentence, or null when not suspended. Kept out of
+// NOT_ONBOARDED_REASONS on purpose: the workspace is set up, not un-onboarded,
+// so it renders normally with a banner rather than the setup poster.
+export function suspensionNotice(readyResp) {
+	if (!readyResp || readyResp.ready) return null;
+	if (readyResp.reason !== "subscription_suspended") return null;
+	return readyResp.detail || SUSPENDED_FALLBACK;
+}
+
 // Branch decision for the "I've verified my email" poll. Admin's
 // get_signup_payment_state (jarvis_admin_v2/billing/signup.py) returns one of
 // THREE shapes: still-pending, paid-plan order handles, or the free/trial

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -8,6 +8,8 @@ import {
 	stepIndex,
 	isOnboardComplete,
 	verifyPollAction,
+	suspensionNotice,
+	SUSPENDED_FALLBACK,
 } from "./steps.js";
 
 test("managed step order", () => {
@@ -96,4 +98,35 @@ test("verifyPollAction: terminal statuses surface as halted", () => {
 test("verifyPollAction: unknown shape asks for a refresh", () => {
 	assert.deepEqual(verifyPollAction({ pending_verification: false }), { kind: "stale" });
 	assert.deepEqual(verifyPollAction({}), { kind: "stale" });
+});
+
+test("suspensionNotice: only fires for a suspended workspace", () => {
+	// Entitled / ready / absent → no banner.
+	assert.equal(suspensionNotice({ ready: true }), null);
+	assert.equal(suspensionNotice(null), null);
+	assert.equal(suspensionNotice(undefined), null);
+	// A different not-ready reason must NOT raise the billing banner — that
+	// would tell a customer mid-provisioning to go pay again.
+	assert.equal(suspensionNotice({ ready: false, reason: "container_provisioning" }), null);
+	assert.equal(suspensionNotice({ ready: false, reason: "llm_credentials" }), null);
+});
+
+test("suspensionNotice: prefers admin's sentence, falls back when absent", () => {
+	assert.equal(
+		suspensionNotice({
+			ready: false,
+			reason: "subscription_suspended",
+			detail: "Your subscription has expired. Renew to restore access to Jarvis.",
+		}),
+		"Your subscription has expired. Renew to restore access to Jarvis."
+	);
+	// Older admin sends the state with no reason string.
+	assert.equal(
+		suspensionNotice({ ready: false, reason: "subscription_suspended" }),
+		SUSPENDED_FALLBACK
+	);
+	assert.equal(
+		suspensionNotice({ ready: false, reason: "subscription_suspended", detail: "" }),
+		SUSPENDED_FALLBACK
+	);
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2075,6 +2075,19 @@
 					background: var(--surface);
 				"
 			>
+				<!-- Lapsed sub: container stopped, so every send would fail. -->
+				<Banner
+					v-if="suspendedNotice"
+					type="warning"
+					title="Chat is paused"
+					:message="suspendedNotice"
+					style="margin-bottom: 10px"
+				>
+					<template #action>
+						<button class="jv-btn jv-btn--sm" @click="goRenew">Renew</button>
+					</template>
+				</Banner>
+
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
 					<button
@@ -3452,8 +3465,11 @@ import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue";
 import JarvisMark from "@/components/JarvisMark.vue";
 import DraftPreview from "@/components/doc/DraftPreview.vue";
 import ActionError from "@/components/ActionError.vue";
+import Banner from "@/components/Banner.vue";
 import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
+import { checkReady } from "@/onboarding/readiness.js";
+import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
 import { displayName } from "@/lib/user";
@@ -3505,6 +3521,9 @@ const histDraft = ref("");
 const sending = ref(false);
 const waiting = ref(false);
 const ui = ref({});
+// Renew-banner copy when the subscription has lapsed; null while entitled.
+// The composer is disabled alongside it (no send can succeed while stopped).
+const suspendedNotice = ref(null);
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.
@@ -3955,6 +3974,10 @@ const liveStatus = computed(() => {
 });
 // Recovery banner copy: compaction (context overflow, retrying) vs a connection
 // hiccup. Both mean "still working, in the background" — not an error.
+// Renew CTA → Settings ▸ Plan & billing, the only surface that takes payment.
+function goRenew() {
+	store.openSettings("plan");
+}
 const recoveringLabel = computed(() =>
 	recovering.value && recovering.value.reason === "compacting"
 		? "That was a big one — reorganizing the conversation and retrying…"
@@ -4292,7 +4315,11 @@ const headerSub = computed(() => {
 	return n ? `${Math.ceil(n / 2)} message${n > 2 ? "s" : ""}` : "ERPNext Assistant";
 });
 const canSend = computed(
-	() => (input.value.trim().length > 0 || pendingFiles.value.length > 0) && !sending.value
+	() =>
+		(input.value.trim().length > 0 || pendingFiles.value.length > 0) &&
+		!sending.value &&
+		// Suspended: the server rejects every send, so keep the button dead.
+		!suspendedNotice.value
 );
 const busy = computed(() => sending.value || waiting.value);
 // A parked write's Confirm dispatches a follow-up agent turn (continuation).
@@ -6436,10 +6463,16 @@ async function retry(messageId) {
 	try {
 		const r = await api.retryMessage(messageId);
 		if (r && r.ok === false) {
-			// e.g. the single-flight guard ("a reply is already in progress").
 			sending.value = false;
 			waiting.value = false;
-			notify(r.reason || "Couldn't retry that.", { type: "error" });
+			// Lapsed sub: raise the persistent banner (as a blocked send does),
+			// not a toast that vanishes before they can renew.
+			if (r.reason === "subscription_suspended") {
+				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+			} else {
+				// e.g. the single-flight guard ("a reply is already in progress").
+				notify(r.reason || "Couldn't retry that.", { type: "error" });
+			}
 		}
 	} catch (e) {
 		sending.value = false;
@@ -6548,6 +6581,12 @@ async function send(textArg) {
 			if (fromMain && !input.value) input.value = text;
 			sending.value = false;
 			waiting.value = false;
+			// Lapsed sub: raise the persistent banner (with its Renew link)
+			// rather than a toast that vanishes before they can act on it.
+			if (r.reason === "subscription_suspended") {
+				if (!suspendedNotice.value) suspendedNotice.value = SUSPENDED_FALLBACK;
+				return;
+			}
 			notify(
 				r.reason === "usage_limit"
 					? "Monthly usage limit reached. Ask your Jarvis admin to raise your limit."
@@ -7303,6 +7342,13 @@ onMounted(async () => {
 	api.listTools()
 		.then((t) => {
 			if (Array.isArray(t) && t.length) jarvisTools.value = t;
+		})
+		.catch(() => {});
+	// Billing banner off the boot readiness promise (memoized, already awaited by
+	// AppShell). Not awaited here: it must never delay painting the chat.
+	checkReady()
+		.then((r) => {
+			suspendedNotice.value = suspensionNotice(r);
 		})
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -18,10 +18,11 @@ from jarvis import admin_client
 from jarvis.onboarding import _surface
 from jarvis.permissions import require_jarvis_admin
 
-# R2-H4 client-side chat-readiness gate. The positive verdict is cached briefly
-# so a boot / SPA-load storm doesn't pay an admin round-trip on every hit.
+# R2-H4 chat-readiness gate, shared by boot, is_ready_for_chat and the send
+# entitlement check. Only "Ready" is cached, so suspension/renewal is still seen
+# promptly; 2 min keeps active-chat admin calls to ~1 per burst.
 _CHAT_GATE_CACHE_KEY = "jarvis:chat_readiness_gate"
-_CHAT_GATE_CACHE_TTL_S = 30
+_CHAT_GATE_CACHE_TTL_S = 120
 
 
 def _admin_chat_gate() -> dict:
@@ -31,9 +32,12 @@ def _admin_chat_gate() -> dict:
 	Called only AFTER the local signup + LLM-credential checks have passed, at
 	the managed ready-exits of ``is_ready_for_chat`` — it is the final gate.
 
-	Returns ``{"ready": True, "reason": None}`` UNLESS the admin is reachable AND
-	reports a ``chat_readiness`` that is PRESENT and != ``"Ready"``, in which case
-	``{"ready": False, "reason": "container_provisioning"}``.
+	Returns ``{"ready": True, "reason": None}`` UNLESS admin is reachable AND
+	reports a ``chat_readiness`` != ``"Ready"``, in which case
+	``{"ready": False, "reason": <code>, "detail": <admin's sentence>}``. The
+	code is ``"subscription_suspended"`` for ``Suspended`` (renew) and
+	``"container_provisioning"`` otherwise (wait) - kept distinct so a suspended
+	customer isn't told to wait for a container that won't come back.
 
 	- v1-tolerance: an ABSENT ``chat_readiness`` key (v1 admin, or a v2 that
 	  doesn't surface it) means the control plane has no opinion → allow.
@@ -51,7 +55,15 @@ def _admin_chat_gate() -> dict:
 		# Fail open on ANY admin error; deliberately no negative cache.
 		return {"ready": True, "reason": None}
 	if "chat_readiness" in conn and conn["chat_readiness"] != "Ready":
-		return {"ready": False, "reason": "container_provisioning"}
+		suspended = conn["chat_readiness"] == "Suspended"
+		return {
+			"ready": False,
+			"reason": "subscription_suspended" if suspended else "container_provisioning",
+			# Admin owns the wording (jarvis_admin_v2.billing.entitlement) so the
+			# two sides can't drift into different explanations. A v1/older admin
+			# sends no reason; the SPA falls back to its own copy.
+			"detail": conn.get("chat_readiness_reason") or "",
+		}
 	# Reachable + (Ready, or v1-absent) → allow and cache the positive verdict.
 	cache.set_value(_CHAT_GATE_CACHE_KEY, 1, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
 	return {"ready": True, "reason": None}
@@ -292,7 +304,7 @@ def resume_plan() -> dict:
 
 
 def _bust_chat_gate() -> None:
-	"""Drop the 30s chat-readiness cache after a billing state change.
+	"""Drop the chat-readiness cache after a billing state change.
 
 	Belt-and-braces: cancelling does not itself change readiness (entitlement
 	runs to period end), but the pane re-reads immediately afterwards and a

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1519,6 +1519,12 @@ def retry_message(message: str) -> dict:
 	the parent conversation.
 	"""
 	require_jarvis_access()
+	# Same entitlement gate as send_message: a retry re-runs a full turn, so a
+	# suspended sub must reject here, not grind the WS-open loop on a stopped
+	# container (the Retry button sits on the very error that loop produces).
+	ok, reason = validate_can_send(frappe.session.user)
+	if not ok:
+		return {"ok": False, "reason": reason}
 	doc = frappe.get_doc(MSG, message)
 	# Ownership is enforced on the PARENT conversation: message rows can be
 	# inserted by the RQ worker under a different session user, so the

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -8,7 +8,8 @@ this module's contract.
 
 Returns (True, None) on success or (False, reason: str) on rejection. The
 reason is a machine code the SPA maps to a human toast; the enforcement
-rejection uses reason ``"usage_limit"``.
+rejection uses reason ``"usage_limit"`` and the billing one
+``"subscription_suspended"``.
 """
 
 from __future__ import annotations
@@ -23,7 +24,25 @@ def validate_can_send(user: str) -> tuple[bool, str | None]:
 		return False, "Guest users cannot use Jarvis chat"
 	if _over_monthly_limit(user):
 		return False, "usage_limit"
+	if _subscription_suspended():
+		return False, "subscription_suspended"
 	return True, None
+
+
+def _subscription_suspended() -> bool:
+	"""True iff admin reports the subscription no longer entitles chat. Reuses
+	_admin_chat_gate's cache; fails OPEN (a control-plane hiccup must never block
+	a paying customer, and self-host has no admin)."""
+	try:
+		from jarvis.account import _admin_chat_gate
+
+		return _admin_chat_gate().get("reason") == "subscription_suspended"
+	except Exception:
+		frappe.log_error(
+			title="jarvis policy: entitlement check failed (allowing send)",
+			message=frappe.get_traceback(),
+		)
+		return False
 
 
 def _over_monthly_limit(user: str) -> bool:

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -142,7 +142,7 @@ class TestAccountGatesFailClosed(FrappeTestCase):
 
 class TestAdminChatGate(FrappeTestCase):
 	"""jarvis.account._admin_chat_gate — the final managed ready-gate for
-	is_ready_for_chat. Fail-open, v1-tolerant, positive verdict cached ~30s.
+	is_ready_for_chat. Fail-open, v1-tolerant, positive verdict cached ~2 min.
 	admin_client.get_connection is mocked."""
 
 	def setUp(self):
@@ -157,10 +157,36 @@ class TestAdminChatGate(FrappeTestCase):
 		) as gc:
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "container_provisioning"},
+				{"ready": False, "reason": "container_provisioning", "detail": ""},
 			)
 		# Uses the short 8s budget so a slow admin can't stall the SPA/boot path.
 		gc.assert_called_once_with(timeout_s=8)
+
+	def test_suspended_is_distinct_from_provisioning(self):
+		"""A revoked subscription must NOT read as "still starting up": that
+		tells the customer to wait for a container that is never coming back
+		instead of renewing."""
+		with patch.object(
+			admin_client, "get_connection",
+			return_value={"chat_readiness": "Suspended",
+						  "chat_readiness_reason": "Your subscription has expired."},
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "subscription_suspended",
+				 "detail": "Your subscription has expired."},
+			)
+
+	def test_suspended_without_reason_still_classifies(self):
+		"""Older admin sends the state with no sentence — the code must still be
+		the billing one; the SPA supplies its own fallback copy."""
+		with patch.object(
+			admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}
+		):
+			self.assertEqual(
+				account._admin_chat_gate(),
+				{"ready": False, "reason": "subscription_suspended", "detail": ""},
+			)
 
 	def test_allows_when_admin_ready(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
@@ -188,7 +214,7 @@ class TestAdminChatGate(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:
 			account._admin_chat_gate()
 			account._admin_chat_gate()
-		# Second call served from the ~30s positive cache → one admin round-trip.
+		# Second call served from the positive cache → one admin round-trip.
 		gc.assert_called_once()
 
 	def test_not_ready_verdict_is_not_cached(self):

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -167,22 +167,26 @@ class TestAdminChatGate(FrappeTestCase):
 		tells the customer to wait for a container that is never coming back
 		instead of renewing."""
 		with patch.object(
-			admin_client, "get_connection",
-			return_value={"chat_readiness": "Suspended",
-						  "chat_readiness_reason": "Your subscription has expired."},
+			admin_client,
+			"get_connection",
+			return_value={
+				"chat_readiness": "Suspended",
+				"chat_readiness_reason": "Your subscription has expired.",
+			},
 		):
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "subscription_suspended",
-				 "detail": "Your subscription has expired."},
+				{
+					"ready": False,
+					"reason": "subscription_suspended",
+					"detail": "Your subscription has expired.",
+				},
 			)
 
 	def test_suspended_without_reason_still_classifies(self):
 		"""Older admin sends the state with no sentence — the code must still be
 		the billing one; the SPA supplies its own fallback copy."""
-		with patch.object(
-			admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}
-		):
+		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}):
 			self.assertEqual(
 				account._admin_chat_gate(),
 				{"ready": False, "reason": "subscription_suspended", "detail": ""},

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -433,6 +433,12 @@ class TestRetryMessage(_ChatTestCase):
 	def setUp(self):
 		super().setUp()
 		self.conv = create_conversation()
+		# retry_message now shares send_message's entitlement gate. Pin it to
+		# "entitled" so these tests don't depend on the live control plane's
+		# current subscription state; the suspended case is tested explicitly.
+		gate = patch("jarvis.account._admin_chat_gate", return_value={"ready": True, "reason": None})
+		gate.start()
+		self.addCleanup(gate.stop)
 
 	def test_routes_through_shared_dispatcher(self):
 		"""Retry must use the SAME dispatcher as send_message (after-commit
@@ -530,6 +536,19 @@ class TestRetryMessage(_ChatTestCase):
 			retry_message(asst_id)
 		after = frappe.utils.get_datetime(frappe.get_value(CONV, self.conv, "last_active_at"))
 		self.assertGreaterEqual(after, before)
+
+	def test_rejects_when_subscription_suspended(self):
+		"""The Retry button sits on the exact error a stopped container produces.
+		A suspended retry must be refused HERE, not dispatched to the worker to
+		grind the 25s WS-open loop and error identically all over again."""
+		_u, asst_id = self._make_turn(self.conv, with_error=True)
+		suspended = {"ready": False, "reason": "subscription_suspended", "detail": "expired"}
+		with patch("jarvis.account._admin_chat_gate", return_value=suspended):
+			with patch("jarvis.chat.api._dispatch_turn") as dispatch:
+				result = retry_message(asst_id)
+		self.assertFalse(result["ok"])
+		self.assertEqual(result["reason"], "subscription_suspended")
+		dispatch.assert_not_called()
 
 
 class TestSetConversationModel(_ChatTestCase):

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -1,18 +1,31 @@
 """Tests for jarvis.chat.policy - the subscription/credits validation seam."""
 
+from unittest.mock import patch
+
 from frappe.tests.utils import FrappeTestCase
 
+import jarvis.account as account
 from jarvis.chat.policy import validate_can_send
+
+# Entitled verdict. Patched in by default so these tests never depend on the
+# live control plane's current subscription state.
+_ENTITLED = {"ready": True, "reason": None}
+_SUSPENDED = {"ready": False, "reason": "subscription_suspended",
+			  "detail": "Your subscription has expired."}
 
 
 class TestValidateCanSend(FrappeTestCase):
+	def setUp(self):
+		self._gate = patch.object(account, "_admin_chat_gate", return_value=_ENTITLED)
+		self._gate.start()
+		self.addCleanup(self._gate.stop)
+
 	def test_administrator_can_send(self):
 		ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
 
-	def test_any_user_can_send_today(self):
-		"""Phase 3 fills in subscription/credit logic. Today any non-empty user is fine."""
+	def test_any_entitled_user_can_send(self):
 		ok, reason = validate_can_send("nobody@example.invalid")
 		self.assertTrue(ok)
 		self.assertIsNone(reason)
@@ -26,3 +39,41 @@ class TestValidateCanSend(FrappeTestCase):
 		ok, reason = validate_can_send("Guest")
 		self.assertFalse(ok)
 		self.assertIsNotNone(reason)
+
+
+class TestSubscriptionGate(FrappeTestCase):
+	"""The entitlement check. Rejecting HERE is the whole point: without it the
+	message is persisted and enqueued, and the worker spends the full WS-open
+	deadline retrying a socket into a stopped container - surfacing to the
+	customer as "the assistant may be starting up"."""
+
+	def test_suspended_subscription_rejects_the_send(self):
+		with patch.object(account, "_admin_chat_gate", return_value=_SUSPENDED):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "subscription_suspended")
+
+	def test_provisioning_does_not_reject(self):
+		"""A container still coming up is NOT a billing block - the send must go
+		through so the existing retry can ride out a dormant container."""
+		with patch.object(
+			account, "_admin_chat_gate",
+			return_value={"ready": False, "reason": "container_provisioning", "detail": ""},
+		):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+	def test_fails_open_when_the_gate_raises(self):
+		"""A control-plane hiccup must never block a paying customer."""
+		with patch.object(account, "_admin_chat_gate", side_effect=RuntimeError("admin down")):
+			ok, reason = validate_can_send("someone@example.invalid")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+	def test_guest_rejected_before_the_admin_round_trip(self):
+		"""Cheap local checks come first - a Guest must not cost an admin call."""
+		with patch.object(account, "_admin_chat_gate") as gate:
+			ok, _ = validate_can_send("Guest")
+		self.assertFalse(ok)
+		gate.assert_not_called()

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -10,8 +10,7 @@ from jarvis.chat.policy import validate_can_send
 # Entitled verdict. Patched in by default so these tests never depend on the
 # live control plane's current subscription state.
 _ENTITLED = {"ready": True, "reason": None}
-_SUSPENDED = {"ready": False, "reason": "subscription_suspended",
-			  "detail": "Your subscription has expired."}
+_SUSPENDED = {"ready": False, "reason": "subscription_suspended", "detail": "Your subscription has expired."}
 
 
 class TestValidateCanSend(FrappeTestCase):
@@ -57,7 +56,8 @@ class TestSubscriptionGate(FrappeTestCase):
 		"""A container still coming up is NOT a billing block - the send must go
 		through so the existing retry can ride out a dormant container."""
 		with patch.object(
-			account, "_admin_chat_gate",
+			account,
+			"_admin_chat_gate",
 			return_value={"ready": False, "reason": "container_provisioning", "detail": ""},
 		):
 			ok, reason = validate_can_send("someone@example.invalid")


### PR DESCRIPTION
## What & why

When a subscription lapses (Expired/Cancelled) admin stops the container, so a chat send used to spend the full 25s WS-open retry loop and surface a misleading **"I couldn't reach the assistant."** This makes lapse a first-class state: block chat instantly with a **"Chat is paused / renew"** banner, and refine the Plan & billing pane so cancellation is a calm, standard flow.

Stacked on #371 (base `feat/subscription-cancellation`); depends on admin `feat/suspended-chat-readiness` (which reports `chat_readiness: "Suspended"`).

## Suspension enforcement
- **`account.py`** — `_admin_chat_gate` now returns `subscription_suspended` vs `container_provisioning` (distinct: *renew* vs *wait*) and passes admin's own reason string through. Gate cache **30s → 120s**, positive-only (renew/suspension still seen promptly), shared with the send path, **fail-open** on any admin error.
- **`chat/policy.py`** — `validate_can_send` rejects a suspended send in ~0.01s instead of letting the worker hit the 25s loop.
- **`chat/api.py`** — `retry_message` runs the same gate; the Retry button sits on the very error the loop produces.
- **`ChatView.vue` / `onboarding/steps.js`** — persistent renew banner, disabled composer, `suspensionNotice`.

## Plan & billing polish
- Cancel moves from a solid-red button to a **quiet footer link** beside "Manage plan & billing" — the confirm dialog owns the deliberate red step.
- The ambiguous **"Cancelling" pill → glanceable "Ends 21 Aug"**; **Resume** lives inside the cancellation notice; an expired plan shows **Renew subscription** (no dead-end "Cancel").

## Tests
`test_chat_policy` (send gate: suspended rejects, provisioning doesn't, fail-open, guest-before-roundtrip), `test_account` (gate suspended-vs-provisioning split), `test_chat_api` (retry rejection), `format.test.js` / `steps.test.js` (shortDate, cancelPillLabel, suspensionNotice). Verified end-to-end in the browser: suspend → banner + blocked send → renew pane; cancel → "Ends" pill + Resume → back to Active.

## Verification
Bench: `test_chat_policy` 8/8, `test_chat_api` 58/58, `test_account` (pre-existing `test_false_when_admin_key_blank` unrelated), JS 25/25. SPA rebuilt clean.
