### PR TITLE
fix(chat): size the chat.send ack window for inlined text, park on ack timeout

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -1029,7 +1029,13 @@ class OpenclawSession:
 						details=details if isinstance(details, dict) else None,
 					)
 				return frame
-		raise OpenclawUnreachableError(f"{method} timed out")
+		# Tagged so callers can tell an AMBIGUOUS outcome from a definite one:
+		# the request frame was already written, so the peer may well have
+		# accepted and acted on it - we just never saw the response. chat.send
+		# uses this to park for snapshot recovery instead of reporting a false
+		# error (see turn_handler). A rejection or a dead socket is definite
+		# and raises without this code.
+		raise OpenclawUnreachableError(f"{method} timed out", code="ack-timeout")
 
 	def _recv(self, timeout_s: float) -> dict | None:
 		"""Read one frame from the WS, parse JSON, or return None on a soft

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -65,6 +65,23 @@ MSG = "Jarvis Chat Message"
 _ASSISTANT_BATCH_SIZE = 10
 _ASSISTANT_BATCH_INTERVAL_MS = 250
 
+# chat.send ack budget. openclaw ingests and PREPROCESSES the whole message
+# before it acks the RPC, so this window has to cover the payload, not just
+# the WS round-trip. Two contributions, because a message grows two ways:
+#   - vision parts: each PDF page is rasterized + resized inside the RPC
+#     (measured 22s for a 4-page invoice).
+#   - inlined text: a CSV/TXT/JSON/MD attachment is folded into the prompt
+#     body (up to _MAX_INLINE_CHARS) and never becomes a vision part, so it
+#     used to add nothing to the budget while adding ~20k chars to the send.
+#     That is the "timed out in the UI, answered in the transcript" split
+#     brain: the bench gave up at 10s, openclaw completed the turn anyway.
+# The base also absorbs cold-session bootstrap (persona + skills catalog) on
+# a first turn, which is when the old flat 10s was tightest.
+_ACK_TIMEOUT_BASE_S = 30.0
+_ACK_TIMEOUT_PER_VISION_PART_S = 30.0
+_ACK_TIMEOUT_PER_INLINED_CHAR_S = 10.0 / 10_000  # ~10s per 10k inlined chars
+_ACK_TIMEOUT_CEILING_S = 180.0
+
 
 def persist_rich_outputs(
 	assistant_msg_name: str,
@@ -653,7 +670,14 @@ def handle_chat_send(payload: dict) -> None:
 		and _vision_enabled(settings)
 		and vision.supports_vision(settings.llm_provider)
 	)
+	# Measure how much the attachments grew the PROMPT, not just how many
+	# vision parts they produced. Text files (CSV/TXT/JSON/MD/logs) and the
+	# vision-off PDF text fallback are inlined into user_message and leave
+	# vision_parts empty, so growth is the only signal that the send is big.
+	# Feeds _ack_timeout_s() below.
+	_prompt_chars_before_attachments = len(user_message)
 	user_message, vision_parts = _prepare_attachments(user_message, attachments, vision_ok)
+	inlined_prompt_chars = max(0, len(user_message) - _prompt_chars_before_attachments)
 	# The /think directive: self-hosted still inlines it as the FIRST bytes
 	# of the message body (openclaw's leading-directive parser strips it
 	# from there); managed sends it as the chat_send ``thinking`` param
@@ -871,33 +895,54 @@ def handle_chat_send(payload: dict) -> None:
 							message=frappe.get_traceback(),
 						)
 					managed_attachments = _to_managed_attachments(vision_parts) if vision_parts else None
-					# openclaw preprocesses attachments BEFORE acking chat.send
-					# (each PDF page is rasterized + resized inside the RPC:
-					# measured 22s for a 4-page invoice). The default 10s ack
-					# timeout made every document send fail with
-					# "chat.send timed out" while the gateway completed the
-					# turn anyway. Scale the ack window with the payload.
-					ack_timeout = 10.0 + (30.0 * len(managed_attachments) if managed_attachments else 0.0)
-					ack = (
-						sess.chat_send(
-							conv.session_key,
-							user_message,
-							run_id,
-							thinking=(conv.thinking_override or "").strip() or None,
-							attachments=managed_attachments,
-							timeout_s=min(ack_timeout, 180.0),
+					ack_timeout = _ack_timeout_s(len(managed_attachments or []), inlined_prompt_chars)
+					ack_timed_out = False
+					try:
+						ack = (
+							sess.chat_send(
+								conv.session_key,
+								user_message,
+								run_id,
+								thinking=(conv.thinking_override or "").strip() or None,
+								attachments=managed_attachments,
+								timeout_s=ack_timeout,
+							)
+							or {}
 						)
-						or {}
-					)
+					except OpenclawUnreachableError as e:
+						# The ack window closed with the request frame already on
+						# the wire. openclaw routinely ACCEPTS the message and runs
+						# the whole turn while the bench is still waiting, so
+						# erroring here is a false negative: the user sees
+						# "chat.send timed out" while the transcript shows a
+						# finished answer, and a retry re-runs under a FRESH run_id
+						# (dedupe keys off run_id) and can duplicate writes. Park
+						# for snapshot recovery instead - the seq watermark was
+						# captured BEFORE the send, so recovery can tell this turn's
+						# messages from the previous turn's. Only the TIMEOUT is
+						# ambiguous; a rejection or a dead socket never reached the
+						# agent, so those still raise onto the real-error path.
+						if getattr(e, "code", None) != "ack-timeout":
+							raise
+						ack = {}
+						ack_timed_out = True
 					# chat.send delivered our message (incl. any drained notes) -
 					# drop exactly the notes we folded in (by id), so the correction
 					# is delivered once, not re-nagged, without clobbering a discard
 					# appended mid-turn or one a concurrent continuation delivered. A
 					# pre-ack failure raises OpenclawUnreachableError below instead of
-					# reaching here, leaving the notes for retry.
-					if drained_notes:
+					# reaching here, leaving the notes for retry. An ack TIMEOUT is
+					# excluded for the same reason: delivery is unproven there, and
+					# re-nagging a correction is a much cheaper mistake than silently
+					# dropping one.
+					if drained_notes and not ack_timed_out:
 						agent_notes.clear(conversation_id, drained_ids)
-					if ack.get("status") == "ok":
+					if ack_timed_out:
+						# Same park-and-recover path as a dropped stream, handled
+						# below AFTER this pool checkout releases the per-gateway
+						# lock so the recovery round-trip never blocks other turns.
+						terminal = {"kind": "relay:interrupted", "reason": "ack-timeout"}
+					elif ack.get("status") == "ok":
 						# Cached replay of a completed run (same run_id
 						# re-enqueued after the worker died post-completion).
 						# No events will follow; finalize from the durable
@@ -1398,6 +1443,23 @@ def _vision_enabled(settings) -> bool:
 	defaults to ON), mirroring selfhost_stream."""
 	v = settings.vision_attachments_enabled
 	return v is None or bool(v)
+
+
+def _ack_timeout_s(vision_part_count: int, inlined_prompt_chars: int) -> float:
+	"""Wall-clock window to wait for the ``chat.send`` ack, sized from the payload.
+
+	openclaw ingests and preprocesses the whole message before it acks, so a
+	big send needs a bigger window. Giving up early is a FALSE negative - the
+	gateway goes on to run the turn while the bench reports a timeout - so the
+	window errs generous and is bounded by ``_ACK_TIMEOUT_CEILING_S`` to keep a
+	genuinely wedged gateway from stalling a turn for minutes. A dead socket or
+	a refused connection still fails fast; they raise instead of waiting."""
+	return min(
+		_ACK_TIMEOUT_BASE_S
+		+ _ACK_TIMEOUT_PER_VISION_PART_S * max(0, vision_part_count)
+		+ _ACK_TIMEOUT_PER_INLINED_CHAR_S * max(0, inlined_prompt_chars),
+		_ACK_TIMEOUT_CEILING_S,
+	)
 
 
 def _to_managed_attachments(vision_parts: list[dict]) -> list[dict]:

--- a/jarvis/tests/test_chat_worker.py
+++ b/jarvis/tests/test_chat_worker.py
@@ -10,9 +10,10 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat import openclaw_session_pool
+from jarvis.chat import openclaw_session_pool, turn_handler
 from jarvis.chat.api import create_conversation, get_conversation, send_message
 from jarvis.chat.worker import run_agent_turn
+from jarvis.exceptions import OpenclawUnreachableError
 from jarvis.tests.test_chat_api import (
 	TEST_USER,
 	_cleanup_user_conversations,
@@ -1166,16 +1167,115 @@ class TestOverflowParksForRecovery(FrappeTestCase):
 
 
 class TestChatSendAttachmentTimeout(FrappeTestCase):
-	"""openclaw preprocesses attachments (PDF page raster + resize) BEFORE
-	acking chat.send - 22s measured for a 4-page invoice vs the 10s default
-	ack timeout, so every document send errored 'chat.send timed out' while
-	the gateway ran the turn anyway. The ack window must scale with the
-	attachment count (and stay default without attachments)."""
+	"""openclaw ingests and preprocesses the message BEFORE acking chat.send,
+	so the ack window must scale with the payload. Two ways a send gets big:
+	vision parts (PDF page raster + resize - 22s measured for a 4-page
+	invoice) and INLINED TEXT (a CSV/TXT/JSON attachment is folded into the
+	prompt body and never becomes a vision part). Sizing the window off
+	vision parts alone left text attachments on the bare default, which is
+	how a CSV send errored 'chat.send timed out' in the UI while the
+	transcript showed the gateway completing the turn."""
 
-	def test_ack_timeout_scales_with_attachments(self):
-		src = open(frappe.get_app_path("jarvis", "chat", "turn_handler.py")).read()
-		self.assertIn("ack_timeout = 10.0 + (30.0 * len(managed_attachments)", src)
-		self.assertIn("timeout_s=min(ack_timeout, 180.0)", src)
+	def test_bare_send_uses_the_base_window(self):
+		self.assertEqual(turn_handler._ack_timeout_s(0, 0), turn_handler._ACK_TIMEOUT_BASE_S)
+
+	def test_vision_parts_extend_the_window(self):
+		self.assertEqual(
+			turn_handler._ack_timeout_s(2, 0),
+			turn_handler._ACK_TIMEOUT_BASE_S + 2 * turn_handler._ACK_TIMEOUT_PER_VISION_PART_S,
+		)
+
+	def test_inlined_text_extends_the_window(self):
+		"""The regression this fix exists for: a 20k-char CSV carries zero
+		vision parts, so the old formula gave it the bare default."""
+		csv_sized = turn_handler._ack_timeout_s(0, 20_000)
+		self.assertGreater(csv_sized, turn_handler._ACK_TIMEOUT_BASE_S)
+		# Materially bigger, not a rounding artifact.
+		self.assertGreaterEqual(csv_sized - turn_handler._ACK_TIMEOUT_BASE_S, 15.0)
+
+	def test_window_is_clamped(self):
+		"""A pathological payload must not stall a turn for minutes against a
+		genuinely wedged gateway."""
+		self.assertEqual(
+			turn_handler._ack_timeout_s(100, 10_000_000),
+			turn_handler._ACK_TIMEOUT_CEILING_S,
+		)
+
+	def test_negative_counts_never_shrink_the_window(self):
+		self.assertEqual(turn_handler._ack_timeout_s(-5, -5), turn_handler._ACK_TIMEOUT_BASE_S)
+
+	def test_text_attachment_produces_no_vision_parts(self):
+		"""Anchors the premise: the inlined-char count is the ONLY signal a
+		text attachment gives, so the budget has to read it."""
+		before = "hi"
+		msg, parts = turn_handler._prepare_attachments(before, None, vision_ok=True)
+		self.assertEqual(parts, [])
+		self.assertEqual(len(msg) - len(before), 0)
+
+
+class TestChatSendAckTimeoutParks(FrappeTestCase):
+	"""A chat.send ACK timeout is ambiguous: the request frame was already on
+	the wire, and openclaw routinely accepts the message and runs the whole
+	turn while the bench is still waiting. Erroring there is a false negative
+	(user sees a timeout, transcript shows a finished answer) and invites a
+	retry that re-runs under a fresh run_id and can duplicate writes. It must
+	park for snapshot recovery instead. A REJECTION or a dead socket never
+	reached the agent, so those must still error."""
+
+	def setUp(self):
+		openclaw_session_pool._POOL.clear()
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		self.conv, self.user_msg = _make_conversation_with_user_message()
+
+	def tearDown(self):
+		_cleanup_user_conversations()
+		frappe.set_user(self._orig_user)
+
+	def _run_with_send_raising(self, exc):
+		fake_sess = MagicMock()
+		fake_sess.chat_send.side_effect = exc
+		with patch("jarvis.chat.openclaw_session_pool.OpenclawSession.connect", return_value=fake_sess):
+			with patch("jarvis.chat.turn_recovery.recover_now") as recover_now:
+				with patch("jarvis.chat.worker.publish_to_user") as pub:
+					run_agent_turn(self.conv, self.user_msg, run_id="r1")
+		row = frappe.db.get_value(
+			MSG,
+			{"conversation": self.conv, "role": "assistant"},
+			["recovering", "streaming", "error"],
+			as_dict=True,
+		)
+		return row, [c.args[1]["kind"] for c in pub.call_args_list], recover_now
+
+	def test_ack_timeout_parks_instead_of_erroring(self):
+		row, kinds, recover_now = self._run_with_send_raising(
+			OpenclawUnreachableError("chat.send timed out", code="ack-timeout")
+		)
+		self.assertEqual(row["recovering"], 1)
+		# Spinner stays up; turn_recovery finalizes from the gateway snapshot.
+		self.assertEqual(row["streaming"], 1)
+		self.assertFalse(row["error"])
+		self.assertIn("run:recovering", kinds)
+		self.assertNotIn("run:error", kinds)
+		recover_now.assert_called_once_with(self.conv)
+
+	def test_rejection_still_errors(self):
+		"""Guards the blast radius: only the ambiguous timeout parks."""
+		row, kinds, _ = self._run_with_send_raising(
+			OpenclawUnreachableError("chat.send rejected: bad-request: nope", code="bad-request")
+		)
+		self.assertEqual(row["recovering"], 0)
+		self.assertTrue(row["error"])
+		self.assertIn("run:error", kinds)
+		self.assertNotIn("run:recovering", kinds)
+
+	def test_untagged_transport_failure_still_errors(self):
+		row, kinds, _ = self._run_with_send_raising(OpenclawUnreachableError("openclaw WS closed: gone"))
+		self.assertEqual(row["recovering"], 0)
+		self.assertTrue(row["error"])
+		self.assertIn("run:error", kinds)
 
 
 class TestRelayOverflowParks(FrappeTestCase):


### PR DESCRIPTION
## The bug

A tenant attached a CSV in chat ("make the timesheet with given csv file"). The **fleet transcript shows the turn succeeding** - openclaw ran 7 model round-trips and 13 tool calls and produced the confirmation card at 08:22:14 - but the **UI showed a timeout error**. Agent finished, bench reported failure.

> Note: the transcript's `took 2m 03s` on the 44-token final row and `model 3m 13s` > `turn 1m 56s` are debugger **artifacts** (a row with no `durationMs` falls back to whole-turn elapsed; the footer sums parallel tools serially). Real final step was ~11s. Not the bug.

## Root cause

Two defects, one visible symptom.

**1. The ack window only counted vision attachments.**

```python
ack_timeout = 10.0 + (30.0 * len(managed_attachments) if managed_attachments else 0.0)
```

`_prepare_attachments` routes PDFs and images into `vision_parts`, but every other text file - CSV, TXT, JSON, MD, logs - takes the `else` branch and is **inlined into the prompt body** up to `_MAX_INLINE_CHARS` (20k). Inlined text produces **no vision part**, so it grew the send dramatically while contributing **nothing** to the budget, leaving it on the bare **10s** default. The transcript's first model call shows **33.3k input tokens, `0 cached`** - a cold session.

The scaling fix added for PDFs (comment at the same site: *"The default 10s ack timeout made every document send fail with 'chat.send timed out' while the gateway completed the turn anyway"*) never covered text attachments. This finishes it.

**2. An ack timeout was reported as a hard error.**

The request frame is already on the wire when the window closes, so openclaw routinely accepts the message and runs the turn while the bench gives up. The existing comment names the gray zone: *"a DELIVERED send whose ack was lost lands here too."* Worse, the suggested retry re-runs under a **fresh `run_id`**, so retrying a timed-out document send can **duplicate writes** (two sets of Tasks, a second Timesheet).

## The fix

- New `_ack_timeout_s(vision_part_count, inlined_prompt_chars)` sizes the window off **both** contributions, clamped at 180s. Base lifted 10s -> 30s to absorb cold-session bootstrap.
- The call site measures prompt growth around `_prepare_attachments`, which also catches the vision-off PDF text-extraction path (it inlines too).
- `_request` tags the timeout `code="ack-timeout"`; `chat_send` parks for snapshot recovery through the **existing** `relay:interrupted` path rather than erroring. The pre-send seq watermark already makes this safe.
- **Blast radius held:** rejections and dead sockets are unambiguous and still error fast. Drained agent notes are deliberately NOT cleared on an ack timeout - delivery is unproven, and re-nagging a correction beats silently dropping one.

## Tests

Replaces the brittle source-text assertions in `TestChatSendAttachmentTimeout` with behavioural tests of `_ack_timeout_s`, and adds `TestChatSendAckTimeoutParks` for the park plus both must-still-error cases.

**Mutation-tested.** Reverting each behaviour fails exactly one test and no guard test:

| Mutation | Result |
|---|---|
| stop counting inlined text | `test_inlined_text_extends_the_window` fails, only |
| never park (always raise) | `test_ack_timeout_parks_instead_of_erroring` fails, only |

Green: `test_chat_worker` 47, `test_turn_recovery` 37, `test_relay_consumer` 15, `test_turn_handler` 7, `test_turn_handler_thinking` 5, `test_session_lifecycle` 40.

Two `lc-attach.txt` failures in `test_vision_attachments` / `test_untrusted_fence` are **pre-existing** - verified failing identically with these changes stashed. Stale `File` row colliding on `file_url` in the local test site; unrelated to this PR.

## Not verified here

Step 0 of the diagnosis - confirming the literal `chat.send timed out` string in the affected tenant's Error Log - needs a live fleet bench I can't reach. The defect is real on inspection regardless.

## Separately found, not fixed here

- **Traefik defaults on non-cloud-init hosts.** `jarvis_admin_v2` cloud-init sets `respondingTimeouts` to 660s; hosts built from the fleet-agent manual runbook (or v1) get Traefik v3 defaults - **60s readTimeout, 180s idleTimeout** - on the WSS entrypoint the chat relay rides. Worth checking `/etc/traefik/traefik.yml` on affected hosts.
- **openclaw's `DEFAULT_LLM_IDLE_TIMEOUT_MS = 120_000`** is a compiled-in default; `openclaw.json.j2` sets no `timeoutSeconds`. Per-gap, so normal turns survive, but it also bounds first-event on a cold cache with the 64k skills prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)