### PR TITLE
ci: shard the test suite 4 ways to halve PR wall clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,12 @@ jobs:
         # leg pays again) also stops paying for itself: 6 shards costs 4 more runner-minutes
         # per run to save a further ~20s of wall clock.
         #
-        # If you change this list, change --total-builds in the test step to match.
+        # If you change this list, THREE things have to move together, not two:
+        #   1. this list
+        #   2. --total-builds in the test step below
+        #   3. the shard-count guard in the `coverage` job at the bottom of this file
+        # Miss (3) and every run fails with "expected N shard files" long after the change
+        # looks correct.
         shard: [1, 2, 3, 4]
 
     container:
@@ -280,7 +285,16 @@ jobs:
           python-version: "3.11"
 
       - name: Install coverage
-        run: pip install coverage
+        run: |
+          # Pinned to match frappe's own constraint (apps/frappe/pyproject.toml:
+          # "coverage~=7.10.0"), which is what the ci-base image's venv resolves and
+          # therefore what WROTE these data files.
+          #
+          # Unpinned, this job installs the newest 7.x (7.13 at the time of writing) and
+          # reads files written by 7.10. That happens to work because coverage's sqlite
+          # schema is stable across 7.x, but a version that cannot read them would NOT fail
+          # this job loudly. See the combine step for why.
+          pip install 'coverage~=7.10.0'
 
       - name: Download every shard's coverage
         uses: actions/download-artifact@v4
@@ -301,13 +315,30 @@ jobs:
           cd covdata
           echo "shard data files:"; ls -l
 
-          # Guard against a silently-partial combine. Four shards must contribute four
-          # files; anything less means an upload was dropped and the resulting percentage
-          # would be meaningless but still plausible-looking.
+          # Guard 1: every shard must have UPLOADED. Keep this count in step with the
+          # matrix list at the top of this file (see the note there: three places move
+          # together).
           found=$(ls coverage-data-* 2>/dev/null | wc -l)
           [ "${found}" -eq 4 ] || { echo "expected 4 shard files, got ${found}"; exit 1; }
 
-          coverage combine coverage-data-*
+          # Guard 2: every shard must have been READ. These are different failures, and
+          # guard 1 cannot catch this one, because the file downloads fine and fails later
+          # at read time.
+          #
+          # `coverage combine` is not all-or-nothing. Per file it catches CoverageException,
+          # calls data._warn(...), and carries on; it only raises when NOTHING combined
+          # ("if strict and not combined_any: raise NoDataError"). So one unreadable shard
+          # silently drops a quarter of the data, and --fail-under then passes judgement on
+          # a partial dataset. That is precisely the silent under-report this job exists to
+          # prevent, so treat any warning as fatal rather than advisory.
+          out=$(coverage combine coverage-data-* 2>&1); rc=$?
+          echo "${out}"
+          [ "${rc}" -eq 0 ] || exit "${rc}"
+          if printf '%s' "${out}" | grep -qiE "warning|couldn't use"; then
+            echo "::error::coverage combine could not read every shard; refusing to gate a partial dataset"
+            exit 1
+          fi
+
           # Enforced coverage floor. Baseline on 2026-07-02 was 87% (incl. test files, with
           # the 9 quarantined tests skipped). Ratchet UP over time; never down.
           coverage report --fail-under=85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ name: CI
 # The from-scratch build still runs nightly in ci-nightly.yml, so upstream version-16 breakage is
 # caught within a day — it just no longer sits in the PR critical path. If that job is red and this
 # one is green, suspect upstream rather than the PR.
+#
+# What was left after that was one serial step: the test run itself, 304s of a 399s job. It is now
+# sharded 4 ways via `bench run-parallel-tests`, taking the job to ~3m45s. The remaining ~90s is
+# per-shard setup (image pull + site restore) that every leg pays again and that no amount of
+# sharding removes. That floor is exactly why the shard count is 4 and not 8; see the `matrix:`
+# comment for the measured split.
+#
+# Because each shard only covers about a quarter of the code, the coverage floor moved OUT of the
+# test job and into the separate `coverage` job, which combines all four data files and gates once.
 
 on:
   workflow_dispatch:
@@ -60,6 +69,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
+    strategy:
+      # Never fail-fast. The default cancels the surviving shards on the first failure, so
+      # you see one broken shard instead of all of them, and a cancelled leg reports as
+      # neutral rather than failed. That is the same regression-hiding behaviour the
+      # `cancel-in-progress` guard above already exists to avoid.
+      fail-fast: false
+      matrix:
+        # 4 is the balance point, not an arbitrary pick. Frappe shards per test FILE
+        # weighted by that file's `def test_` count, and its splitter is greedy and
+        # order-preserving, so it starves the LAST shard as the count climbs. Measured
+        # against this suite (176 files, 3560 tests):
+        #
+        #   N=2  [1782, 1778]                    spread    4
+        #   N=4  [899, 891, 893, 877]            spread   22
+        #   N=6  [636, 621, 598, 631, 594, 480]  spread  156
+        #
+        # Past 4, the ~90s of per-shard setup below (image pull + site restore, which every
+        # leg pays again) also stops paying for itself: 6 shards costs 4 more runner-minutes
+        # per run to save a further ~20s of wall clock.
+        #
+        # If you change this list, change --total-builds in the test step to match.
+        shard: [1, 2, 3, 4]
+
     container:
       image: ghcr.io/aerele-rnd/jarvis-ci-base:v16
       # bench hard-exits as root (bench/cli.py -> change_uid: "You should not run this command as
@@ -68,6 +100,17 @@ jobs:
       options: --user 1001
       env:
         HOME: /home/ci
+        # ParallelTestRunner.print_result (frappe/parallel_test_runner.py) only fails the
+        # process when CI is set:
+        #
+        #   if self.test_result.failures or self.test_result.errors:
+        #       if os.environ.get("CI"):
+        #           sys.exit(1)
+        #
+        # Actions does inject CI=true, so this is belt-and-braces. But the failure mode it
+        # guards against is a shard reporting GREEN on a failing suite, which is the worst
+        # outcome this workflow could produce. Set it explicitly rather than inherit it.
+        CI: "true"
       # The package is currently PRIVATE. It is linked to this repo, so GITHUB_TOKEN + `packages:
       # read` pulls it on same-repo runs (verified). Credentials are harmless once it is public.
       #
@@ -181,12 +224,90 @@ jobs:
             echo "${apps}" | grep -q "\"${a}\"" || { echo "missing app: ${a}"; exit 1; }
           done
 
-      - name: Run tests + coverage
+      - name: Run tests + coverage (shard ${{ matrix.shard }} of 4)
         working-directory: /opt/frappe-bench
         run: |
           # coverage + gevent are already in the image's venv (gevent is needed by
           # jarvis/realtime/handlers.py with socketio_backend=python, and its tests).
-          bench --site test_site run-tests --app jarvis --coverage
+          #
+          # The coverage flag is spelled --with-coverage on THIS command. run-tests spells
+          # the same thing --coverage (frappe/commands/testing.py). They are two different
+          # click commands; do not "fix" one to match the other.
+          bench --site test_site run-parallel-tests \
+            --app jarvis \
+            --build-number ${{ matrix.shard }} \
+            --total-builds 4 \
+            --with-coverage
+
+      - name: Stash this shard's coverage under a non-hidden name
+        working-directory: /opt/frappe-bench
+        run: |
+          # frappe's CodeCoverage writes the default data file, which lands at
+          # sites/.coverage. Renaming off the leading dot is deliberate: upload-artifact@v4
+          # EXCLUDES hidden files by default, so uploading `.coverage.N` silently produces
+          # an empty artifact and the combine job below then fails on "No data to report"
+          # long after the real cause scrolled past.
+          mv sites/.coverage "sites/coverage-data-${{ matrix.shard }}"
+
+      - name: Upload this shard's coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.shard }}
+          path: /opt/frappe-bench/sites/coverage-data-${{ matrix.shard }}
+          retention-days: 1
+          if-no-files-found: error
+
+  # The coverage floor cannot be enforced inside a shard: each one exercises roughly a
+  # quarter of the code, so all four would "fail" a 85% gate. Combine first, gate once.
+  #
+  # `needs: tests` against a matrix runs this only when EVERY leg succeeded, which is the
+  # behaviour we want. A failing shard should surface as one honest test failure, not as a
+  # test failure plus a bogus coverage failure caused by the missing quarter.
+  #
+  # Deliberately NOT in the base image: this needs python and `coverage` and nothing else
+  # from the bench, so running it here skips a second 65s image pull.
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: app
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install coverage
+        run: pip install coverage
+
+      - name: Download every shard's coverage
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: covdata
+
+      - name: Combine and enforce the floor
+        run: |
+          # All four shards ran the same image, so their data files agree on one absolute
+          # source path: /opt/frappe-bench/apps/jarvis. `coverage report` has to read those
+          # sources to count statements, so the checkout is placed at that exact path.
+          # Cheaper and far less fragile than a [paths] remap in a .coveragerc.
+          sudo mkdir -p /opt/frappe-bench/apps
+          sudo cp -r app /opt/frappe-bench/apps/jarvis
+
+          cd covdata
+          echo "shard data files:"; ls -l
+
+          # Guard against a silently-partial combine. Four shards must contribute four
+          # files; anything less means an upload was dropped and the resulting percentage
+          # would be meaningless but still plausible-looking.
+          found=$(ls coverage-data-* 2>/dev/null | wc -l)
+          [ "${found}" -eq 4 ] || { echo "expected 4 shard files, got ${found}"; exit 1; }
+
+          coverage combine coverage-data-*
           # Enforced coverage floor. Baseline on 2026-07-02 was 87% (incl. test files, with
           # the 9 quarantined tests skipped). Ratchet UP over time; never down.
-          ./env/bin/coverage report --data-file=sites/.coverage --fail-under=85
+          coverage report --fail-under=85

--- a/jarvis/tests/test_actions_api.py
+++ b/jarvis/tests/test_actions_api.py
@@ -585,9 +585,47 @@ class TestConfirmEmptyConversationToken(FrappeTestCase):
 		self.assertEqual(self._roles(other), [])  # nothing injected
 
 
+def _purge_pending_confirmations(owner: str) -> None:
+	"""Drop every live pending-confirmation token for ``owner`` from Redis.
+
+	Uses pending_confirm's key helpers directly on purpose. Its own public
+	clear_for_conversation() leaves conversation-less tokens alone by design, and
+	those are exactly the ones that leak across test files.
+	"""
+	from jarvis.chat import pending_confirm
+
+	cache = frappe.cache()
+	try:
+		members = cache.smembers(pending_confirm._owner_key(owner)) or set()
+	except Exception:
+		# A cache blip here must not fail the test before it has run.
+		return
+	for m in members:
+		token = m.decode() if isinstance(m, bytes) else m
+		cache.delete_value(pending_confirm._key(token))
+	cache.delete_value(pending_confirm._owner_key(owner))
+
+
 class TestListPendingConfirmations(FrappeTestCase):
 	"""F2/F3: resync returns the park-time preview verbatim (no side-effecting
 	dry-run recompute) and one bad record cannot 500 the whole endpoint."""
+
+	def setUp(self):
+		super().setUp()
+		# Pending confirmations live in REDIS (jarvis.chat.pending_confirm), not
+		# the DB, so FrappeTestCase's transaction rollback does NOT clear them.
+		# Anything an earlier test FILE minted for Administrator is still live for
+		# the full 900s TTL, and these tests assert exact list lengths.
+		#
+		# Filtering the assertions by conversation would not fix it: list_for_owner
+		# deliberately surfaces conversation-less records ("") under ANY
+		# conversation filter (see its F1 note), and that is exactly the shape
+		# test_action_pending leaves behind.
+		#
+		# This was latent until CI began sharding. The serial runner groups tests
+		# by category, the parallel runner walks files alphabetically, and only the
+		# alphabetical order happens to run test_action_pending.py first.
+		_purge_pending_confirmations("Administrator")
 
 	def _conv(self) -> str:
 		conv = _make_conversation()


### PR DESCRIPTION
## Why

The test step was the last serial thing in the CI job. Measured on green develop run [29909631537](https://github.com/Aerele-RnD/jarvis/actions/runs/29909631537): **304s of a 399s run (76%)** was one single-threaded step. The other ~90s is per-shard setup that every leg pays again, which is why the shard count has a sweet spot rather than scaling forever.

## Measured result

Not projections. Run [29913929997](https://github.com/Aerele-RnD/jarvis/actions/runs/29913929997), fully green:

| | Serial (develop) | Sharded (this PR) |
|---|---|---|
| Wall clock | 404s | **231s** |
| Coverage TOTAL | 60162 stmts / 4842 missed / **92%** | 60176 stmts / 4859 missed / **92%** |

**43% faster, with identical coverage.** The 14 extra statements are this PR's own test helper. Per-shard test steps were 64s / 66s / 113s / 48s, confirming the ~90s fixed floor.

## What

Shard via frappe's `bench run-parallel-tests`, which splits per test file weighted by that file's `def test_` count. Verified by dry-running all four shards that the partition covers all **176 test files exactly once, zero overlap, zero gaps**, balancing to a 22-point spread of `[899, 891, 893, 877]` of 3560 tests.

Why 4: the splitter is greedy and order-preserving, so it starves the last shard as the count climbs (`N=6` spreads 156), and past 4 the fixed floor stops paying back. 6 shards costs 4 more runner-minutes per run to buy ~20s.

## Coverage

The `--fail-under=85` floor cannot run inside a shard, since each covers a quarter of the code. It moves to a `coverage` job that combines all four and gates once. `needs: tests` runs it only when every leg succeeded, so a failing shard gives one honest test failure instead of a bogus coverage failure. Verified in practice: on the first run a shard failed and this job correctly **skipped** rather than emitting a wrong number.

Two guards, because they catch different failures:
1. **Upload count.** All 4 shards must have uploaded.
2. **Read success.** `coverage combine` is not all-or-nothing: per file it catches `CoverageException`, warns, and continues, raising only when *nothing* combined. Reproduced locally with 2 valid files and 1 corrupt: **combine exits rc=0** and the 85% gate would have passed on three-quarters of the data. Any combine warning is now fatal.

`coverage` is also pinned to frappe's own `~=7.10.0`. That drift was live, not hypothetical: the image venv resolves 7.10.7 while an unpinned install was pulling 7.15.2. Now byte-identical to the writer.

## A latent bug this surfaced

`TestListPendingConfirmations` was always order-dependent and passed only by luck. Pending confirmations live in **Redis**, not the DB, so `FrappeTestCase`'s rollback never cleared them, and the 900s TTL outlives the ~300s suite. Shard 1 hit `4 != 1` carrying `test_action_pending`'s fixtures verbatim.

The serial runner groups tests by category; the parallel runner walks files alphabetically, and only that order puts `test_action_pending.py` first. Fixed by purging the owner's tokens in `setUp`. Note that filtering assertions by conversation would *not* work: `list_for_owner` deliberately surfaces conversation-less records under any filter (its F1 note), which is exactly the leaking shape.

## Notes for review

- The `tests` check becomes `tests (1)` through `tests (4)`. No branch protection or rulesets exist today so nothing breaks; if required checks are added later you'll want a small aggregate job. Left out as YAGNI.
- Shard count lives in three places (matrix list, `--total-builds`, coverage count guard). The matrix comment now says so; it previously named only two.
- Not addressed: cutting the 304s itself. `--lightmode` skips the per-method type-checker decoration and may be a real share of runtime, but it changes test semantics and needs measuring first.

https://claude.ai/code/session_01Y2zFZex9DmrAyBZFsJFnSs