### PR TITLE
fix(permissions): make Jarvis Admin additive so its holder can actually chat

### DIFF
--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -81,9 +81,10 @@ def ensure_jarvis_user_role() -> None:
 	by the time the after_migrate seed calls this. Kept so the definition (and
 	``is_custom``) lives in exactly one place.
 
-	NOTE: no code grants this role. Onboarding grants ``Jarvis Admin`` instead
-	(:func:`grant_onboarding_admin`), which also passes the access gate; a
-	tenant's additional users are granted ``Jarvis User`` by hand in Desk."""
+	NOTE: :func:`grant_onboarding_admin` is the ONLY code path that grants this
+	role, and it grants it alongside ``Jarvis Admin`` (the admin role is additive
+	and owns no chat permission rows of its own). A tenant's additional users are
+	granted ``Jarvis User`` by hand in Desk."""
 	if not frappe.db.exists("Role", JARVIS_USER_ROLE):
 		frappe.get_doc(
 			{
@@ -206,6 +207,12 @@ def grant_onboarding_admin(user: str | None = None) -> None:
 	user = user or frappe.session.user
 	if not user or user in ("Administrator", "Guest"):
 		return
+	# Deliberately NOT User.add_roles(): that calls save(), running the whole
+	# User validation chain inside the signup / payment path, where an unrelated
+	# validation error would abort onboarding. The row insert is surgical, and
+	# set_system_user() (the reason add_roles is usually preferable) is moot here
+	# because every caller is already a System User — require_jarvis_admin gates
+	# all four call sites.
 	granted = False
 	for role in (JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE):
 		if frappe.db.exists("Has Role", {"parenttype": "User", "parent": user, "role": role}):

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -182,33 +182,48 @@ def require_jarvis_admin(user: str | None = None) -> None:
 
 
 def grant_onboarding_admin(user: str | None = None) -> None:
-	"""Grant ``Jarvis Admin`` to the onboarding/paying user (security review
-	PART 4 REVISED, TASK 44/48).
+	"""Grant ``Jarvis Admin`` AND ``Jarvis User`` to the onboarding/paying user
+	(security review PART 4 REVISED, TASK 44/48).
 
-	Grants ONLY ``Jarvis Admin`` — NOT ``Jarvis User`` — because
-	:data:`JARVIS_ACCESS_ROLES` already includes ``Jarvis Admin``, so a user
-	holding only ``Jarvis Admin`` still passes :func:`has_jarvis_access` and every
-	``@require_jarvis_user`` endpoint (they are not locked out of the chat surface
-	they administer).
+	``Jarvis Admin`` is ADDITIVE — it means "admin rights on top of a normal
+	user", never a standalone identity. An earlier revision granted it alone,
+	reasoning that :data:`JARVIS_ACCESS_ROLES` contains it so the holder still
+	passes :func:`has_jarvis_access` and every ``@require_jarvis_user`` endpoint.
+	That holds at the GATE layer and fails at the DOCTYPE layer: ``Jarvis Admin``
+	carries no permission row on ``Jarvis Conversation`` or ``Jarvis Chat
+	Message`` (nor on Approval Request, Custom Skill, Macro, Macro Run, Voice
+	Note or the three Agent doctypes), so such a user passed the gate, reached
+	``send_message`` and then failed on the message insert. Granting both roles
+	fixes all ten at once and keeps the two roles from having to be maintained in
+	lockstep.
 
-	The role name AND the target-user resolution are server-hardcoded (no
-	caller-supplied role), so the ``ignore_permissions`` insert carries NO
-	privilege-escalation vector. Idempotent — a no-op when the role is already
-	held; never grants to Administrator / Guest."""
+	The role names AND the target-user resolution are server-hardcoded (no
+	caller-supplied role), so the ``ignore_permissions`` inserts carry NO
+	privilege-escalation vector. Idempotent — already-held roles are skipped;
+	never grants to Administrator / Guest."""
 	ensure_jarvis_admin_role()
+	ensure_jarvis_user_role()
 	user = user or frappe.session.user
 	if not user or user in ("Administrator", "Guest"):
 		return
-	if not frappe.db.exists("Has Role", {"parenttype": "User", "parent": user, "role": JARVIS_ADMIN_ROLE}):
+	granted = False
+	for role in (JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE):
+		if frappe.db.exists("Has Role", {"parenttype": "User", "parent": user, "role": role}):
+			continue
 		frappe.get_doc(
 			{
 				"doctype": "Has Role",
 				"parenttype": "User",
 				"parentfield": "roles",
 				"parent": user,
-				"role": JARVIS_ADMIN_ROLE,
+				"role": role,
 			}
 		).insert(ignore_permissions=True)
+		granted = True
+	if granted:
+		# frappe.get_roles is cached per user; without this the caller can read a
+		# stale role list for the rest of the request (and beyond).
+		frappe.clear_cache(user=user)
 
 
 def require_jarvis_user(fn):

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -40,6 +40,7 @@ ADMIN = "p4-admin@example.com"  # Jarvis Admin, NOT System Manager
 SM = "p4-sm@example.com"  # System Manager (real, not Administrator)
 WEBSITE = "p4-website@example.com"  # Website (portal) user
 GRANTEE = "p4-grantee@example.com"  # Jarvis User with NO Jarvis Admin (grant target)
+BARE = "p4-bare@example.com"  # NEITHER Jarvis role — additive-grant target
 AGENT_SLUG = "p4-test-agent"
 PFX = "p4"
 
@@ -98,6 +99,10 @@ class Part4Base(FrappeTestCase):
 		_ensure_user(ADMIN, ["Jarvis Admin"])  # NOT System Manager
 		_ensure_user(SM, ["System Manager"])
 		_ensure_user(GRANTEE, ["Jarvis User"])  # no Jarvis Admin yet
+		# Holds NEITHER role, so the additive grant can be observed from zero.
+		# _ensure_user pins user_type, so it stays a System User despite no
+		# desk-access role.
+		_ensure_user(BARE, [])
 		_ensure_user(WEBSITE, [], user_type="Website User")
 		if not frappe.db.exists(LISTING, AGENT_SLUG):
 			frappe.get_doc(
@@ -168,22 +173,41 @@ class TestOnboardingGrant(Part4Base):
 		def _rows(role):
 			return frappe.db.count(
 				"Has Role",
-				{"parenttype": "User", "parent": GRANTEE, "role": role},
+				{"parenttype": "User", "parent": BARE, "role": role},
 			)
 
+		# BARE holds neither role (GRANTEE is seeded WITH "Jarvis User", so it
+		# cannot show the additive grant from zero).
 		self.assertEqual(_rows("Jarvis Admin"), 0)
 		self.assertEqual(_rows("Jarvis User"), 0)
-		grant_onboarding_admin(GRANTEE)
+		grant_onboarding_admin(BARE)
 		self.assertEqual(_rows("Jarvis Admin"), 1)
 		self.assertEqual(_rows("Jarvis User"), 1)
 		# The helper invalidates the role cache itself, so no clear_cache here.
-		roles = frappe.get_roles(GRANTEE)
+		roles = frappe.get_roles(BARE)
 		self.assertIn("Jarvis Admin", roles)
 		self.assertIn("Jarvis User", roles)
 		# Idempotent: a second call adds no duplicate rows.
-		grant_onboarding_admin(GRANTEE)
+		grant_onboarding_admin(BARE)
 		self.assertEqual(_rows("Jarvis Admin"), 1)
 		self.assertEqual(_rows("Jarvis User"), 1)
+
+	def test_grant_tops_up_a_partially_granted_user(self):
+		"""GRANTEE already holds "Jarvis User" only. The grant must add the
+		missing "Jarvis Admin" without duplicating the role it already has."""
+		from jarvis.permissions import grant_onboarding_admin
+
+		def _rows(role):
+			return frappe.db.count(
+				"Has Role",
+				{"parenttype": "User", "parent": GRANTEE, "role": role},
+			)
+
+		self.assertEqual(_rows("Jarvis User"), 1)
+		self.assertEqual(_rows("Jarvis Admin"), 0)
+		grant_onboarding_admin(GRANTEE)
+		self.assertEqual(_rows("Jarvis User"), 1)
+		self.assertEqual(_rows("Jarvis Admin"), 1)
 
 	def test_grant_never_touches_administrator_or_guest(self):
 		from jarvis.permissions import grant_onboarding_admin

--- a/jarvis/tests/test_part4_security.py
+++ b/jarvis/tests/test_part4_security.py
@@ -158,23 +158,32 @@ class TestAdminTierGate(Part4Base):
 # TASK 44/48 — grant_onboarding_admin
 # --------------------------------------------------------------------------- #
 class TestOnboardingGrant(Part4Base):
-	def test_grant_is_idempotent_and_only_jarvis_admin(self):
+	def test_grant_is_idempotent_and_additive(self):
+		"""Both roles are granted. "Jarvis Admin" is admin rights ON TOP of a
+		normal user: alone it passes the access gate but owns no permission row
+		on Jarvis Conversation / Jarvis Chat Message, so the holder could reach
+		send_message and then fail on the insert."""
 		from jarvis.permissions import grant_onboarding_admin
 
-		def _rows():
+		def _rows(role):
 			return frappe.db.count(
 				"Has Role",
-				{"parenttype": "User", "parent": GRANTEE, "role": "Jarvis Admin"},
+				{"parenttype": "User", "parent": GRANTEE, "role": role},
 			)
 
-		self.assertEqual(_rows(), 0)
+		self.assertEqual(_rows("Jarvis Admin"), 0)
+		self.assertEqual(_rows("Jarvis User"), 0)
 		grant_onboarding_admin(GRANTEE)
-		self.assertEqual(_rows(), 1)
-		frappe.clear_cache(user=GRANTEE)
-		self.assertIn("Jarvis Admin", frappe.get_roles(GRANTEE))
-		# Idempotent: a second call adds no duplicate row.
+		self.assertEqual(_rows("Jarvis Admin"), 1)
+		self.assertEqual(_rows("Jarvis User"), 1)
+		# The helper invalidates the role cache itself, so no clear_cache here.
+		roles = frappe.get_roles(GRANTEE)
+		self.assertIn("Jarvis Admin", roles)
+		self.assertIn("Jarvis User", roles)
+		# Idempotent: a second call adds no duplicate rows.
 		grant_onboarding_admin(GRANTEE)
-		self.assertEqual(_rows(), 1)
+		self.assertEqual(_rows("Jarvis Admin"), 1)
+		self.assertEqual(_rows("Jarvis User"), 1)
 
 	def test_grant_never_touches_administrator_or_guest(self):
 		from jarvis.permissions import grant_onboarding_admin


### PR DESCRIPTION
Makes `Jarvis Admin` an additive role rather than a standalone one, by granting `Jarvis User` alongside it. One-line behaviour change; the rest is the docstring and test that encode why.

## The bug

`grant_onboarding_admin()` granted **only** `Jarvis Admin`, with this stated reasoning:

> Grants ONLY `Jarvis Admin`, NOT `Jarvis User`, because `JARVIS_ACCESS_ROLES` already includes `Jarvis Admin`, so a user holding only `Jarvis Admin` still passes `has_jarvis_access` and every `@require_jarvis_user` endpoint (they are not locked out of the chat surface they administer).

That is true at the **gate** layer and false at the **DocType** layer.

`Jarvis Admin` has no permission row on `Jarvis Conversation` or `Jarvis Chat Message`. Both carry rows for `Jarvis User` and `System Manager` only. So a user holding just `Jarvis Admin` passes `has_jarvis_access()`, passes the decorator, reaches `send_message`, and then raises `PermissionError` on `msg_doc.insert()` at `chat/api.py`. That insert runs with permission checks on; `ignore_permissions` is set only when `_delegated` is true, which is the scheduler and approval-resume path, not a human send.

## Scope of the gap

Ten DocTypes where `Jarvis User` has rights and `Jarvis Admin` has none:

| DocType | Jarvis User rights |
|---|---|
| Jarvis Conversation | read, write, create, delete (if_owner) |
| Jarvis Chat Message | read, write, create, delete |
| Jarvis Approval Request | read, write, create |
| Jarvis Custom Skill | read, write, create, delete |
| Jarvis Macro | read, write, create, delete (if_owner) |
| Jarvis Macro Run | read, write, create, delete (if_owner) |
| Jarvis Voice Note | read, write, create, delete (if_owner) |
| Jarvis Agent Finding | read, write (if_owner) |
| Jarvis Agent Activity | read (if_owner) |
| Jarvis Agent Run | read (if_owner) |

Fixing only the two chat DocTypes would produce a worse failure mode: chat sends, then the first write approval fails.

## Why additive rather than duplicating rows

Frappe roles compose additively. Granting both means `Jarvis Admin` reads as "admin rights on top of a normal user", which is how it is used everywhere else, and fixes all ten at once. Copying ten permission rows onto the second role would instead require keeping two roles in lockstep on every future DocType, and the bug returns the first time someone forgets.

## Privacy check

Adding chat access to a tenant admin does **not** expose other users' conversations. `chat_permissions.conversation_query_conditions` scopes every caller except `Administrator` to their own rows, and its docstring is explicit that System Manager is deliberately not expanded to org-wide private chats. The DocType row is broad; the hook is the real control and it is owner-scoped.

## Also fixed

`grant_onboarding_admin()` never called `frappe.clear_cache(user=...)`. `frappe.get_roles` is cached per user, so the caller could read a stale role list after the grant. Added, guarded so it only fires when something was actually granted.

## Impact

Masked in production today because whoever onboards is the site owner and therefore System Manager, which carries its own permission rows. It would surface the moment a tenant admin granted `Jarvis Admin` to a colleague, which the role name actively invites. No remediation patch is included, per the decision on #386 to keep role grants manual; any pre-existing `Jarvis Admin`-only user needs `Jarvis User` ticked once in Desk.

## Testing

`test_grant_is_idempotent_and_only_jarvis_admin` renamed to `test_grant_is_idempotent_and_additive` and extended to assert both roles are granted, both are idempotent, and the helper invalidates the role cache itself. Verified `test_dashboard_permissions.test_manageable_roles` is unaffected: it covers `manageable_roles()` and never calls the grant helper.

https://claude.ai/code/session_014z9pu5Yvquz2ntxLxaKBCr