### PR TITLE
feat(support): embedded Support panel + backend (Plan 3 B+C)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -356,3 +356,33 @@ export const fileboxDeleteBulk = (conversations) =>
 	call("jarvis.chat.filebox.delete_inbound_bulk", {
 		conversations: JSON.stringify(conversations || []),
 	});
+
+// --- Support panel (Plan 3) -------------------------------------------------
+export const supportListTickets = () => call("jarvis.support.api.list_tickets");
+export const supportCreateTicket = (subject, body) =>
+	call("jarvis.support.api.create_ticket", { subject, body: body || "" });
+export const supportGetThread = (ticket) => call("jarvis.support.api.get_thread", { ticket });
+export const supportReply = (ticket, body) => call("jarvis.support.api.reply", { ticket, body });
+export const supportCloseTicket = (ticket) => call("jarvis.support.api.close_ticket", { ticket });
+export const supportAwaitingCount = () => call("jarvis.support.api.awaiting_count");
+
+// Same-origin GET so <img>/<a> resolve against the bench; session cookie authenticates.
+export const supportDownloadUrl = (ticket, fileUrl) =>
+	`/api/method/jarvis.support.media.download?ticket=${encodeURIComponent(
+		ticket
+	)}&file_url=${encodeURIComponent(fileUrl)}`;
+
+export async function supportUpload(ticket, file) {
+	const fd = new FormData();
+	fd.append("ticket", ticket);
+	fd.append("file", file, file.name);
+	const r = await fetch("/api/method/jarvis.support.media.upload", {
+		method: "POST",
+		headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+		body: fd,
+		credentials: "include",
+	});
+	const data = await r.json();
+	const msg = data.message || data;
+	return msg.data || msg;
+}

--- a/frontend/src/components/shell/UserMenu.vue
+++ b/frontend/src/components/shell/UserMenu.vue
@@ -39,11 +39,13 @@
 <script setup>
 // Sidebar header (DESIGN-V3 §3.2.1): brand + session user, HD's UserMenu
 // pattern. Dropdown: Settings (D9) · Switch to Desk · Change theme · Log out.
-import { computed, inject } from "vue";
+import { computed, inject, ref, onMounted, onUnmounted } from "vue";
+import { useRouter } from "vue-router";
 import { Dropdown, FeatherIcon } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
+import { supportAwaitingCount } from "@/api";
 
 defineProps({
 	isCollapsed: { type: Boolean, default: false },
@@ -52,6 +54,28 @@ defineProps({
 const store = useShellStore();
 const session = inject("$session");
 const { effectiveDark, toggleTheme } = useJarvisTheme();
+
+// Support panel (Plan 3 C3/C4): dual kill-switch + an SPA-driven awaiting-count badge.
+const router = useRouter();
+const supportOn = window.support_available && window.has_support_access;
+const awaiting = ref(0);
+let pollTimer = null;
+async function pollAwaiting() {
+	try {
+		const r = await supportAwaitingCount();
+		awaiting.value = (r.data && r.data.count) || 0;
+	} catch (e) {
+		/* support is best-effort — never surface a boot error */
+	}
+}
+onMounted(() => {
+	if (!supportOn) return;
+	pollAwaiting();
+	pollTimer = setInterval(pollAwaiting, 60000);
+});
+onUnmounted(() => {
+	if (pollTimer) clearInterval(pollTimer);
+});
 
 function cookie(name) {
 	// URLSearchParams already percent-decodes; decoding AGAIN throws URIError
@@ -67,6 +91,15 @@ const menuOptions = computed(() => [
 		hideLabel: true,
 		items: [
 			{ label: "Settings", icon: "settings", onClick: () => store.openSettings() },
+			...(supportOn
+				? [
+						{
+							label: awaiting.value ? `Support (${awaiting.value})` : "Support",
+							icon: "life-buoy",
+							onClick: () => router.push({ name: "Support" }),
+						},
+				  ]
+				: []),
 			{
 				label: "Switch to Desk",
 				icon: "grid",

--- a/frontend/src/pages/support/SupportPage.vue
+++ b/frontend/src/pages/support/SupportPage.vue
@@ -1,0 +1,269 @@
+<template>
+	<div class="flex h-full">
+		<!-- Ticket list -->
+		<aside class="w-72 shrink-0 border-r border-gray-200 flex flex-col">
+			<div class="p-3 border-b border-gray-200 flex items-center justify-between">
+				<h2 class="font-semibold text-gray-800">Support</h2>
+				<button class="text-sm px-2 py-1 rounded bg-gray-900 text-white" @click="startNew">
+					New
+				</button>
+			</div>
+			<div class="flex-1 overflow-y-auto">
+				<p v-if="!tickets.length" class="p-3 text-sm text-gray-500">No tickets yet.</p>
+				<button
+					v-for="t in tickets"
+					:key="t.name"
+					class="w-full text-left px-3 py-2 border-b border-gray-100 hover:bg-gray-50"
+					:class="{ 'bg-gray-100': selected && selected.name === t.name }"
+					@click="openTicket(t)"
+				>
+					<div class="text-sm font-medium text-gray-800 truncate">{{ t.subject }}</div>
+					<div class="text-xs text-gray-500">{{ t.status }}</div>
+				</button>
+			</div>
+		</aside>
+
+		<!-- Detail -->
+		<section class="flex-1 flex flex-col min-w-0">
+			<!-- New ticket -->
+			<div v-if="view === 'new'" class="p-4 max-w-2xl">
+				<h3 class="font-semibold mb-3">New support ticket</h3>
+				<input
+					v-model="newSubject"
+					placeholder="Subject"
+					class="w-full border rounded px-3 py-2 mb-2"
+				/>
+				<textarea
+					v-model="newBody"
+					placeholder="Describe your issue…"
+					rows="6"
+					class="w-full border rounded px-3 py-2 mb-2"
+				></textarea>
+				<input type="file" @change="onNewFile" class="mb-3 block text-sm" />
+				<div class="flex gap-2">
+					<button
+						class="px-3 py-2 rounded bg-gray-900 text-white text-sm disabled:opacity-50"
+						:disabled="!newSubject || busy"
+						@click="createTicket"
+					>
+						Submit
+					</button>
+					<button class="px-3 py-2 rounded border text-sm" @click="view = 'none'">
+						Cancel
+					</button>
+				</div>
+			</div>
+
+			<!-- Thread -->
+			<template v-else-if="selected">
+				<header class="p-3 border-b border-gray-200 flex items-center justify-between">
+					<div class="min-w-0">
+						<div class="font-medium text-gray-800 truncate">
+							{{ selected.subject }}
+						</div>
+						<div class="text-xs text-gray-500">{{ selected.status }}</div>
+					</div>
+					<button
+						v-if="selected.status !== 'Closed'"
+						class="text-sm px-2 py-1 rounded border"
+						:disabled="busy"
+						@click="closeTicket"
+					>
+						Close ticket
+					</button>
+				</header>
+
+				<div class="flex-1 overflow-y-auto p-4 space-y-4">
+					<div v-if="ticketAttachments.length" class="text-sm">
+						<div class="text-xs uppercase text-gray-400 mb-1">Attachments</div>
+						<ul class="space-y-1">
+							<li v-for="a in ticketAttachments" :key="a.file_url">
+								<component :is="attachmentEl(a)" v-bind="attachmentProps(a)" />
+							</li>
+						</ul>
+					</div>
+
+					<div
+						v-for="(m, i) in messages"
+						:key="i"
+						class="rounded border border-gray-100 p-3"
+						:class="m.sent_or_received === 'Sent' ? 'bg-blue-50' : 'bg-white'"
+					>
+						<div class="text-xs text-gray-500 mb-1">
+							{{ m.sent_or_received === "Sent" ? "Support" : "You" }} ·
+							{{ m.creation }}
+						</div>
+						<!-- Sanitized + URL-rewritten agent/customer HTML -->
+						<div
+							class="prose prose-sm max-w-none"
+							v-html="renderMessage(m.content)"
+						></div>
+						<ul v-if="m.attachments && m.attachments.length" class="mt-2 space-y-1">
+							<li v-for="a in m.attachments" :key="a.file_url">
+								<component :is="attachmentEl(a)" v-bind="attachmentProps(a)" />
+							</li>
+						</ul>
+					</div>
+				</div>
+
+				<footer class="border-t border-gray-200 p-3">
+					<textarea
+						v-model="replyBody"
+						placeholder="Type your reply…"
+						rows="2"
+						class="w-full border rounded px-3 py-2 mb-2"
+					></textarea>
+					<div class="flex items-center gap-2">
+						<input type="file" @change="onReplyFile" class="text-sm" />
+						<button
+							class="ml-auto px-3 py-2 rounded bg-gray-900 text-white text-sm disabled:opacity-50"
+							:disabled="(!replyBody && !replyFile) || busy"
+							@click="sendReply"
+						>
+							Send
+						</button>
+					</div>
+				</footer>
+			</template>
+
+			<div v-else class="flex-1 grid place-items-center text-gray-400 text-sm">
+				Select a ticket, or start a new one.
+			</div>
+		</section>
+	</div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import DOMPurify from "dompurify";
+import {
+	supportListTickets,
+	supportGetThread,
+	supportCreateTicket,
+	supportReply,
+	supportCloseTicket,
+	supportUpload,
+	supportDownloadUrl,
+} from "@/api";
+
+const tickets = ref([]);
+const selected = ref(null);
+const messages = ref([]);
+const ticketAttachments = ref([]);
+const view = ref("none");
+const busy = ref(false);
+
+const newSubject = ref("");
+const newBody = ref("");
+const newFile = ref(null);
+const replyBody = ref("");
+const replyFile = ref(null);
+
+function onNewFile(e) {
+	newFile.value = e.target.files[0] || null;
+}
+function onReplyFile(e) {
+	replyFile.value = e.target.files[0] || null;
+}
+
+async function loadTickets() {
+	const r = await supportListTickets();
+	tickets.value = (r.data && r.data.tickets) || [];
+}
+
+async function openTicket(t) {
+	selected.value = t;
+	view.value = "thread";
+	const r = await supportGetThread(t.name);
+	messages.value = (r.data && r.data.messages) || [];
+	ticketAttachments.value = (r.data && r.data.ticket_attachments) || [];
+}
+
+function startNew() {
+	view.value = "new";
+	selected.value = null;
+	newSubject.value = "";
+	newBody.value = "";
+	newFile.value = null;
+}
+
+async function createTicket() {
+	busy.value = true;
+	try {
+		const r = await supportCreateTicket(newSubject.value, newBody.value);
+		const ticket = r.data && r.data.ticket;
+		if (ticket && newFile.value) await supportUpload(ticket, newFile.value);
+		await loadTickets();
+		const t = tickets.value.find((x) => x.name === ticket);
+		if (t) await openTicket(t);
+		else view.value = "none";
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function sendReply() {
+	busy.value = true;
+	try {
+		if (replyFile.value) {
+			await supportUpload(selected.value.name, replyFile.value);
+			replyFile.value = null;
+		}
+		if (replyBody.value) {
+			await supportReply(selected.value.name, replyBody.value);
+			replyBody.value = "";
+		}
+		await openTicket(selected.value);
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function closeTicket() {
+	busy.value = true;
+	try {
+		await supportCloseTicket(selected.value.name);
+		await openTicket(selected.value);
+		await loadTickets();
+	} finally {
+		busy.value = false;
+	}
+}
+
+// Sanitize (layer 2), then P5: rewrite relative /files/ + /private/files/ src/href to the
+// same-origin download proxy, and strip srcset — so inline agent images/links resolve.
+function renderMessage(html) {
+	const clean = DOMPurify.sanitize(html || "");
+	if (!selected.value) return clean;
+	const doc = new DOMParser().parseFromString(clean, "text/html");
+	doc.querySelectorAll("img[src], a[href]").forEach((el) => {
+		const attr = el.tagName === "IMG" ? "src" : "href";
+		const v = el.getAttribute(attr) || "";
+		if (v.startsWith("/files/") || v.startsWith("/private/files/")) {
+			el.setAttribute(attr, supportDownloadUrl(selected.value.name, v));
+		}
+		el.removeAttribute("srcset");
+	});
+	return doc.body.innerHTML;
+}
+
+function isImage(name) {
+	return /\.(png|jpe?g|gif|webp|avif|bmp)$/i.test(name || "");
+}
+function attachmentEl(a) {
+	return isImage(a.file_name) ? "img" : "a";
+}
+function attachmentProps(a) {
+	const url = supportDownloadUrl(selected.value.name, a.file_url);
+	return isImage(a.file_name)
+		? { src: url, class: "max-w-xs rounded border", alt: a.file_name }
+		: {
+				href: url,
+				target: "_blank",
+				class: "text-blue-600 underline text-sm",
+				innerHTML: a.file_name,
+		  };
+}
+
+onMounted(loadTickets);
+</script>

--- a/frontend/src/pages/support/SupportPage.vue
+++ b/frontend/src/pages/support/SupportPage.vue
@@ -39,7 +39,7 @@
 					rows="6"
 					class="w-full border rounded px-3 py-2 mb-2"
 				></textarea>
-				<input type="file" @change="onNewFile" class="mb-3 block text-sm" />
+				<input type="file" class="mb-3 block text-sm" @change="onNewFile" />
 				<div class="flex gap-2">
 					<button
 						class="px-3 py-2 rounded bg-gray-900 text-white text-sm disabled:opacity-50"
@@ -78,7 +78,20 @@
 						<div class="text-xs uppercase text-gray-400 mb-1">Attachments</div>
 						<ul class="space-y-1">
 							<li v-for="a in ticketAttachments" :key="a.file_url">
-								<component :is="attachmentEl(a)" v-bind="attachmentProps(a)" />
+								<img
+									v-if="isImage(a.file_name)"
+									:src="dl(a.file_url)"
+									:alt="a.file_name"
+									class="max-w-xs rounded border"
+								/>
+								<a
+									v-else
+									:href="dl(a.file_url)"
+									target="_blank"
+									rel="noopener"
+									class="text-blue-600 underline text-sm"
+									>{{ a.file_name }}</a
+								>
 							</li>
 						</ul>
 					</div>
@@ -93,14 +106,27 @@
 							{{ m.sent_or_received === "Sent" ? "Support" : "You" }} ·
 							{{ m.creation }}
 						</div>
-						<!-- Sanitized + URL-rewritten agent/customer HTML -->
+						<!-- Rewrite THEN sanitize (sanitize is the last transform) -->
 						<div
 							class="prose prose-sm max-w-none"
 							v-html="renderMessage(m.content)"
 						></div>
 						<ul v-if="m.attachments && m.attachments.length" class="mt-2 space-y-1">
 							<li v-for="a in m.attachments" :key="a.file_url">
-								<component :is="attachmentEl(a)" v-bind="attachmentProps(a)" />
+								<img
+									v-if="isImage(a.file_name)"
+									:src="dl(a.file_url)"
+									:alt="a.file_name"
+									class="max-w-xs rounded border"
+								/>
+								<a
+									v-else
+									:href="dl(a.file_url)"
+									target="_blank"
+									rel="noopener"
+									class="text-blue-600 underline text-sm"
+									>{{ a.file_name }}</a
+								>
 							</li>
 						</ul>
 					</div>
@@ -114,7 +140,7 @@
 						class="w-full border rounded px-3 py-2 mb-2"
 					></textarea>
 					<div class="flex items-center gap-2">
-						<input type="file" @change="onReplyFile" class="text-sm" />
+						<input type="file" class="text-sm" @change="onReplyFile" />
 						<button
 							class="ml-auto px-3 py-2 rounded bg-gray-900 text-white text-sm disabled:opacity-50"
 							:disabled="(!replyBody && !replyFile) || busy"
@@ -164,6 +190,13 @@ function onNewFile(e) {
 }
 function onReplyFile(e) {
 	replyFile.value = e.target.files[0] || null;
+}
+
+function dl(fileUrl) {
+	return selected.value ? supportDownloadUrl(selected.value.name, fileUrl) : "";
+}
+function isImage(name) {
+	return /\.(png|jpe?g|gif|webp|avif|bmp)$/i.test(name || "");
 }
 
 async function loadTickets() {
@@ -222,47 +255,32 @@ async function sendReply() {
 async function closeTicket() {
 	busy.value = true;
 	try {
-		await supportCloseTicket(selected.value.name);
-		await openTicket(selected.value);
+		const name = selected.value.name;
+		await supportCloseTicket(name);
 		await loadTickets();
+		// R1-8: re-point `selected` at the refreshed row so the header status reflects Closed.
+		const t = tickets.value.find((x) => x.name === name);
+		if (t) await openTicket(t);
 	} finally {
 		busy.value = false;
 	}
 }
 
-// Sanitize (layer 2), then P5: rewrite relative /files/ + /private/files/ src/href to the
-// same-origin download proxy, and strip srcset — so inline agent images/links resolve.
+// R1-4: rewrite inline /files/ + /private/files/ src/href to the same-origin download proxy and
+// strip srcset FIRST, then DOMPurify.sanitize as the LAST transform (no post-sanitize mutation).
 function renderMessage(html) {
-	const clean = DOMPurify.sanitize(html || "");
-	if (!selected.value) return clean;
-	const doc = new DOMParser().parseFromString(clean, "text/html");
-	doc.querySelectorAll("img[src], a[href]").forEach((el) => {
-		const attr = el.tagName === "IMG" ? "src" : "href";
-		const v = el.getAttribute(attr) || "";
-		if (v.startsWith("/files/") || v.startsWith("/private/files/")) {
-			el.setAttribute(attr, supportDownloadUrl(selected.value.name, v));
-		}
-		el.removeAttribute("srcset");
-	});
-	return doc.body.innerHTML;
-}
-
-function isImage(name) {
-	return /\.(png|jpe?g|gif|webp|avif|bmp)$/i.test(name || "");
-}
-function attachmentEl(a) {
-	return isImage(a.file_name) ? "img" : "a";
-}
-function attachmentProps(a) {
-	const url = supportDownloadUrl(selected.value.name, a.file_url);
-	return isImage(a.file_name)
-		? { src: url, class: "max-w-xs rounded border", alt: a.file_name }
-		: {
-				href: url,
-				target: "_blank",
-				class: "text-blue-600 underline text-sm",
-				innerHTML: a.file_name,
-		  };
+	const doc = new DOMParser().parseFromString(html || "", "text/html");
+	if (selected.value) {
+		doc.querySelectorAll("img[src], a[href]").forEach((el) => {
+			const attr = el.tagName === "IMG" ? "src" : "href";
+			const v = el.getAttribute(attr) || "";
+			if (v.startsWith("/files/") || v.startsWith("/private/files/")) {
+				el.setAttribute(attr, supportDownloadUrl(selected.value.name, v));
+			}
+			el.removeAttribute("srcset");
+		});
+	}
+	return DOMPurify.sanitize(doc.body.innerHTML);
 }
 
 onMounted(loadTickets);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -46,6 +46,19 @@ const routes = [
 		},
 	},
 	{
+		path: "/support",
+		name: "Support",
+		component: () => import("@/pages/support/SupportPage.vue"),
+		// Dual kill-switch (P2): support must be enabled fleet-wide AND the user must have access.
+		beforeEnter: (to, from, next) => {
+			next(
+				window.support_available && window.has_support_access
+					? undefined
+					: { name: "Chat" }
+			);
+		},
+	},
+	{
 		path: "/macros",
 		name: "MacrosList",
 		component: () => import("@/pages/macros/MacrosList.vue"),

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -328,6 +328,148 @@ def get_connection(*, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 	return _post(path=_m("api.tenant.get_connection"), body={}, timeout_s=timeout_s)
 
 
+# --------------------------------------------------------------------------- #
+# Support panel proxies (Plan 3 B2). The customer bench forwards requesting_user +
+# scope to the control-plane support endpoints, which re-derive the customer from the
+# API key. JSON calls ride _post; only download needs raw bytes (see _authenticated_raw).
+# --------------------------------------------------------------------------- #
+
+_SUPPORT_TIMEOUT_S = 30
+
+
+def support_status(*, timeout_s: int = 8) -> dict:
+	return _post(path=_m("support.api.support_status"), body={}, timeout_s=timeout_s)
+
+
+def support_list_tickets(*, requesting_user: str, scope: str) -> dict:
+	return _post(
+		path=_m("support.api.list_tickets"),
+		body={"requesting_user": requesting_user, "scope": scope},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_create_ticket(
+	*, subject: str, body: str, requesting_user: str, scope: str, tenant_id=None
+) -> dict:
+	return _post(
+		path=_m("support.api.create_ticket"),
+		body={
+			"subject": subject,
+			"body": body,
+			"requesting_user": requesting_user,
+			"scope": scope,
+			"tenant_id": tenant_id,
+		},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_get_thread(*, ticket: str, requesting_user: str, scope: str) -> dict:
+	return _post(
+		path=_m("support.api.get_thread"),
+		body={"ticket": ticket, "requesting_user": requesting_user, "scope": scope},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_reply(*, ticket: str, body: str, requesting_user: str, scope: str) -> dict:
+	return _post(
+		path=_m("support.api.reply"),
+		body={"ticket": ticket, "body": body, "requesting_user": requesting_user, "scope": scope},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_close_ticket(*, ticket: str, requesting_user: str, scope: str) -> dict:
+	return _post(
+		path=_m("support.api.close_ticket"),
+		body={"ticket": ticket, "requesting_user": requesting_user, "scope": scope},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_awaiting_count(*, requesting_user: str, scope: str) -> dict:
+	return _post(
+		path=_m("support.api.awaiting_count"),
+		body={"requesting_user": requesting_user, "scope": scope},
+		timeout_s=_SUPPORT_TIMEOUT_S,
+	)
+
+
+def support_upload(*, ticket: str, filename: str, content_b64: str, requesting_user: str, scope: str) -> dict:
+	# Bytes ride b64-in-JSON (the CP media.upload decodes) -> plain _post, no binary helper.
+	return _post(
+		path=_m("support.media.upload"),
+		body={
+			"ticket": ticket,
+			"filename": filename,
+			"content_b64": content_b64,
+			"requesting_user": requesting_user,
+			"scope": scope,
+		},
+		timeout_s=DEFAULT_TIMEOUT_S,
+	)
+
+
+def support_download(*, ticket: str, file_url: str, requesting_user: str, scope: str):
+	"""Raw streamed fetch of a Helpdesk file via the CP proxy. Returns
+	(content_bytes, content_type, content_disposition)."""
+	resp = _authenticated_raw(
+		_m("support.media.download"),
+		{"ticket": ticket, "file_url": file_url, "requesting_user": requesting_user, "scope": scope},
+		timeout_s=DEFAULT_TIMEOUT_S,
+	)
+	return (
+		resp.content,
+		resp.headers.get("Content-Type", "application/octet-stream"),
+		resp.headers.get("Content-Disposition"),
+	)
+
+
+def _authenticated_raw(path: str, body: dict, *, timeout_s: int):
+	"""Auth ladder (bearer -> 401 re-mint -> legacy fallback) around a RAW POST, returning the
+	requests.Response so the caller can read bytes (P3 — _do_post is JSON-only, so it can't be
+	reused for streamed media; the ladder is replicated here rather than refactoring the critical
+	_post path). Verified against _post's ladder semantics."""
+	settings = frappe.get_single("Jarvis Settings")
+	admin_url = _admin_url(settings)
+	url = admin_url + path
+
+	def _send(headers):
+		try:
+			return requests.post(url, json=body, headers=headers, timeout=timeout_s, stream=True)
+		except (requests.ConnectionError, requests.Timeout) as e:
+			raise AdminUnreachableError("admin is unreachable; check network / service status") from e
+
+	access_token = _admin_access_token(settings, admin_url)
+	if access_token:
+		resp = _send({"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"})
+		if resp.status_code not in (401, 403):
+			return resp
+		if resp.status_code == 403:
+			raise AdminAuthError("admin returned 403", status_code=403)
+		access_token = _admin_access_token(settings, admin_url, force_refresh=True)
+		if access_token:
+			resp = _send({"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"})
+			if resp.status_code not in (401, 403):
+				return resp
+			if resp.status_code == 403:
+				raise AdminAuthError("admin returned 403", status_code=403)
+		frappe.cache().delete_value(_OAUTH_CACHE_KEY)
+
+	api_key = (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip()
+	api_secret = (settings.get_password("jarvis_admin_api_secret", raise_exception=False) or "").strip()
+	if not api_key or not api_secret:
+		raise AdminAuthError("not onboarded (no OAuth password and no api_key/secret)")
+	resp = _send({"Authorization": f"token {api_key}:{api_secret}", "Content-Type": "application/json"})
+	if resp.status_code in (401, 403):
+		raise AdminAuthError(f"admin returned {resp.status_code}", status_code=resp.status_code)
+	if resp.status_code >= 400:
+		raise AdminUnreachableError(f"admin returned {resp.status_code}")
+	return resp
+
+
 def renew() -> dict:
 	"""Existing customer pays again to extend (manual one-shot). Returns admin's
 	data dict {razorpay_order_id, razorpay_key_id, amount_inr} for Checkout."""

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -427,11 +427,29 @@ def support_download(*, ticket: str, file_url: str, requesting_user: str, scope:
 	)
 
 
+def _raise_for_admin_raw(resp):
+	"""Status routing for a RAW Response, mirroring _do_post's envelope routing (R1-3): 2xx returns
+	the Response; 401/403 -> AdminAuthError (drives the ladder); 429 -> AdminRateLimitedError; other
+	4xx -> AdminValidationError; 5xx -> AdminUnreachableError. DRIFT-GUARD: keep in sync with
+	_do_post's status branches — mirror any change there in both places."""
+	if resp.status_code < 400:
+		return resp
+	if resp.status_code in (401, 403):
+		raise AdminAuthError(f"admin returned {resp.status_code}", status_code=resp.status_code)
+	if resp.status_code == 429:
+		raise AdminRateLimitedError("rate_limited")
+	if resp.status_code < 500:
+		raise AdminValidationError(
+			_scrub_secrets((resp.text or "")[:_MAX_MESSAGE_CHARS]) or f"admin returned {resp.status_code}"
+		)
+	raise AdminUnreachableError(f"admin returned {resp.status_code}")
+
+
 def _authenticated_raw(path: str, body: dict, *, timeout_s: int):
-	"""Auth ladder (bearer -> 401 re-mint -> legacy fallback) around a RAW POST, returning the
-	requests.Response so the caller can read bytes (P3 — _do_post is JSON-only, so it can't be
-	reused for streamed media; the ladder is replicated here rather than refactoring the critical
-	_post path). Verified against _post's ladder semantics."""
+	"""Auth ladder (bearer -> 401 re-mint -> 403-terminal -> legacy fallback) around a RAW POST,
+	returning the requests.Response so the caller can read bytes (P3 — _do_post is JSON-only, so it
+	can't be reused for streamed media). DRIFT-GUARD: this replicates _post's ladder; mirror any
+	change to _post's auth ladder here too. Error status routing is in _raise_for_admin_raw."""
 	settings = frappe.get_single("Jarvis Settings")
 	admin_url = _admin_url(settings)
 	url = admin_url + path
@@ -442,32 +460,28 @@ def _authenticated_raw(path: str, body: dict, *, timeout_s: int):
 		except (requests.ConnectionError, requests.Timeout) as e:
 			raise AdminUnreachableError("admin is unreachable; check network / service status") from e
 
+	bearer = {"Content-Type": "application/json"}
 	access_token = _admin_access_token(settings, admin_url)
 	if access_token:
-		resp = _send({"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"})
-		if resp.status_code not in (401, 403):
-			return resp
-		if resp.status_code == 403:
-			raise AdminAuthError("admin returned 403", status_code=403)
-		access_token = _admin_access_token(settings, admin_url, force_refresh=True)
-		if access_token:
-			resp = _send({"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"})
-			if resp.status_code not in (401, 403):
-				return resp
-			if resp.status_code == 403:
-				raise AdminAuthError("admin returned 403", status_code=403)
-		frappe.cache().delete_value(_OAUTH_CACHE_KEY)
+		try:
+			return _raise_for_admin_raw(_send({**bearer, "Authorization": f"Bearer {access_token}"}))
+		except AdminAuthError as e:
+			if e.status_code == 403:
+				raise  # authorization denial, not a stale token — terminal
+			access_token = _admin_access_token(settings, admin_url, force_refresh=True)
+			if access_token:
+				try:
+					return _raise_for_admin_raw(_send({**bearer, "Authorization": f"Bearer {access_token}"}))
+				except AdminAuthError as retry_err:
+					if retry_err.status_code == 403:
+						raise
+			frappe.cache().delete_value(_OAUTH_CACHE_KEY)
 
 	api_key = (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip()
 	api_secret = (settings.get_password("jarvis_admin_api_secret", raise_exception=False) or "").strip()
 	if not api_key or not api_secret:
 		raise AdminAuthError("not onboarded (no OAuth password and no api_key/secret)")
-	resp = _send({"Authorization": f"token {api_key}:{api_secret}", "Content-Type": "application/json"})
-	if resp.status_code in (401, 403):
-		raise AdminAuthError(f"admin returned {resp.status_code}", status_code=resp.status_code)
-	if resp.status_code >= 400:
-		raise AdminUnreachableError(f"admin returned {resp.status_code}")
-	return resp
+	return _raise_for_admin_raw(_send({**bearer, "Authorization": f"token {api_key}:{api_secret}"}))
 
 
 def renew() -> dict:
@@ -1041,6 +1055,9 @@ def _post(path: str, body: dict, *, timeout_s: int = DEFAULT_TIMEOUT_S) -> dict:
 
 	Folds the Settings + admin-URL read here so public wrappers stay one-liners
 	(one Settings load per call).
+
+	DRIFT-GUARD: _authenticated_raw (media, raw/streamed responses) replicates this
+	bearer->401-remint->403-terminal->legacy ladder; mirror any change here there too.
 	"""
 	settings = frappe.get_single("Jarvis Settings")
 	admin_url = _admin_url(settings)

--- a/jarvis/learning/roles.py
+++ b/jarvis/learning/roles.py
@@ -26,9 +26,11 @@ from frappe.utils import cint
 
 from jarvis.permissions import (
 	JARVIS_ADMIN_ROLE,
+	JARVIS_SUPPORT_USER_ROLE,
 	JARVIS_USER_ROLE,
 	ensure_jarvis_admin_role,
 	ensure_jarvis_user_role,
+	ensure_support_roles,
 )
 
 _DT_CACHE_KEY = "jarvis_learning_roles_for_doctype"
@@ -219,6 +221,11 @@ def after_migrate() -> None:
 		# definition in jarvis/permissions.py. Idempotent.
 		if not frappe.db.exists("Role", JARVIS_ADMIN_ROLE):
 			ensure_jarvis_admin_role()
+			created = True
+		# Support panel roles (single-source in jarvis/permissions.py). The default grant to
+		# chat users happens lazily at boot (www/jarvis.py) so we never mass-iterate users here.
+		if not frappe.db.exists("Role", JARVIS_SUPPORT_USER_ROLE):
+			ensure_support_roles()
 			created = True
 		if created:
 			frappe.db.commit()

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -44,6 +44,13 @@ JARVIS_ACCESS_ROLES = ("System Manager", JARVIS_USER_ROLE, JARVIS_ADMIN_ROLE)
 # implicitly allowed by has_jarvis_admin_access).
 JARVIS_ADMIN_ROLES = ("System Manager", JARVIS_ADMIN_ROLE)
 
+# Support panel roles. Support User sees only tickets they raised (scope=own); Support Admin
+# (and System Manager) see the whole tenant's queue (scope=all). Enforced in code here + at
+# the control-plane proxy; no DocPerm rows.
+JARVIS_SUPPORT_USER_ROLE = "Jarvis Support User"
+JARVIS_SUPPORT_ADMIN_ROLE = "Jarvis Support Admin"
+_SUPPORT_ALL_ROLES = ("System Manager", JARVIS_SUPPORT_ADMIN_ROLE)
+
 # Reviewer set authorized for org-wide skill / pattern / wiki effects (security
 # review PART 2, TASK 15 — RATIFIED). Housed in this lightweight module (no heavy
 # imports) so the Jarvis Custom Skill controller / skill_permissions can import it
@@ -202,6 +209,53 @@ def grant_onboarding_admin(user: str | None = None) -> None:
 				"role": JARVIS_ADMIN_ROLE,
 			}
 		).insert(ignore_permissions=True)
+
+
+def ensure_support_roles() -> None:
+	"""Idempotently create the two support panel roles (desk-access)."""
+	for role_name in (JARVIS_SUPPORT_USER_ROLE, JARVIS_SUPPORT_ADMIN_ROLE):
+		if not frappe.db.exists("Role", role_name):
+			frappe.get_doc(
+				{"doctype": "Role", "role_name": role_name, "desk_access": 1, "is_custom": 1}
+			).insert(ignore_permissions=True)
+
+
+def support_scope(user: str | None = None) -> str | None:
+	"""``"all"`` for System Manager / Support Admin, ``"own"`` for Support User, else ``None``
+	(no support access). The bench forwards this to the control plane as a filter."""
+	user = user or frappe.session.user
+	roles = set(frappe.get_roles(user))
+	if user == "Administrator" or (set(_SUPPORT_ALL_ROLES) & roles):
+		return "all"
+	if JARVIS_SUPPORT_USER_ROLE in roles:
+		return "own"
+	return None
+
+
+def grant_default_support(user: str | None = None) -> None:
+	"""Grant ``Jarvis Support User`` to a chat user so support isn't dark by default (P2).
+	Idempotent; never Administrator/Guest; only if they hold no support role already."""
+	ensure_support_roles()
+	user = user or frappe.session.user
+	if not user or user in ("Administrator", "Guest"):
+		return
+	if support_scope(user) is not None:
+		return
+	if not frappe.db.exists(
+		"Has Role", {"parenttype": "User", "parent": user, "role": JARVIS_SUPPORT_USER_ROLE}
+	):
+		frappe.get_doc(
+			{
+				"doctype": "Has Role",
+				"parenttype": "User",
+				"parentfield": "roles",
+				"parent": user,
+				"role": JARVIS_SUPPORT_USER_ROLE,
+			}
+		).insert(ignore_permissions=True)
+		# Invalidate the role cache so support_scope() sees the grant in the SAME request
+		# (the lazy grant-at-boot then computes has_support_access right after).
+		frappe.clear_cache(user=user)
 
 
 def require_jarvis_user(fn):

--- a/jarvis/support/api.py
+++ b/jarvis/support/api.py
@@ -1,0 +1,98 @@
+"""Bench-side support endpoints (Plan 3 B3).
+
+Role-gated: the caller's scope (own|all) is derived here from their bench roles and forwarded to
+the control-plane proxy along with their identity. The control plane re-derives the customer from
+the API key, so a role-less caller can't reach another customer's data. Admin-side errors are
+surfaced as clean toasts via _surface. House envelope: {"ok": True, "data": ...}.
+"""
+
+import frappe
+
+from jarvis import admin_client
+from jarvis.onboarding import _surface
+from jarvis.permissions import support_scope
+
+
+def _scope() -> str:
+	scope = support_scope()
+	if scope is None:
+		frappe.throw("You don't have Jarvis support access.", frappe.PermissionError)
+	return scope
+
+
+@frappe.whitelist()
+def list_tickets() -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(admin_client.support_list_tickets, requesting_user=frappe.session.user, scope=scope),
+	}
+
+
+@frappe.whitelist()
+def create_ticket(subject: str, body: str = "") -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_create_ticket,
+			subject=subject,
+			body=body or "",
+			requesting_user=frappe.session.user,
+			scope=scope,
+		),
+	}
+
+
+@frappe.whitelist()
+def get_thread(ticket: str) -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_get_thread,
+			ticket=ticket,
+			requesting_user=frappe.session.user,
+			scope=scope,
+		),
+	}
+
+
+@frappe.whitelist()
+def reply(ticket: str, body: str) -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_reply,
+			ticket=ticket,
+			body=body,
+			requesting_user=frappe.session.user,
+			scope=scope,
+		),
+	}
+
+
+@frappe.whitelist()
+def close_ticket(ticket: str) -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_close_ticket,
+			ticket=ticket,
+			requesting_user=frappe.session.user,
+			scope=scope,
+		),
+	}
+
+
+@frappe.whitelist()
+def awaiting_count() -> dict:
+	scope = _scope()
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_awaiting_count, requesting_user=frappe.session.user, scope=scope
+		),
+	}

--- a/jarvis/support/media.py
+++ b/jarvis/support/media.py
@@ -1,0 +1,63 @@
+"""Bench-side media proxy (Plan 3 B4).
+
+download streams a Helpdesk file from the control plane back to the browser (same-origin, so the
+SPA can point <img>/<a> at it). upload reads the posted file, base64s it, and forwards to the CP
+(which decodes, caps, allowlist-checks, and attaches it to the ticket). Role-gated like api.py.
+"""
+
+import base64
+
+import frappe
+from werkzeug.wrappers import Response
+
+from jarvis import admin_client
+from jarvis.onboarding import _surface
+from jarvis.permissions import support_scope
+
+_MAX_BYTES = 25 * 1024 * 1024
+
+
+def _scope() -> str:
+	scope = support_scope()
+	if scope is None:
+		frappe.throw("You don't have Jarvis support access.", frappe.PermissionError)
+	return scope
+
+
+@frappe.whitelist()
+def download(ticket: str, file_url: str):
+	scope = _scope()
+	content, content_type, disposition = _surface(
+		admin_client.support_download,
+		ticket=ticket,
+		file_url=file_url,
+		requesting_user=frappe.session.user,
+		scope=scope,
+	)
+	out = Response(content, content_type=content_type)
+	out.headers["Content-Disposition"] = disposition or "attachment"
+	out.headers["X-Content-Type-Options"] = "nosniff"
+	return out
+
+
+@frappe.whitelist()
+def upload(ticket: str) -> dict:
+	scope = _scope()
+	f = frappe.request.files.get("file") if frappe.request else None
+	if not f:
+		frappe.throw("no file provided")
+	content = f.read()
+	if len(content) > _MAX_BYTES:
+		frappe.throw("file too large")
+	content_b64 = base64.b64encode(content).decode("ascii")
+	return {
+		"ok": True,
+		"data": _surface(
+			admin_client.support_upload,
+			ticket=ticket,
+			filename=f.filename,
+			content_b64=content_b64,
+			requesting_user=frappe.session.user,
+			scope=scope,
+		),
+	}

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -163,3 +163,22 @@ class TestSupportBoot(FrappeTestCase):
 
 		with patch("jarvis.admin_client.support_status", return_value={"available": True}):
 			self.assertTrue(jw._support_available())
+
+
+class TestAuthenticatedRawErrors(FrappeTestCase):
+	def test_bearer_4xx_raises_validation_not_returned_as_success(self):
+		# R1-3: a CP 404/413/500 on the bearer path must raise, not come back as a 200 body.
+		from jarvis.exceptions import AdminValidationError
+
+		settings = MagicMock()
+		settings.get_password.side_effect = lambda f, **k: None
+		r404 = MagicMock(status_code=404, text="not found")
+		with (
+			patch("frappe.get_single", return_value=settings),
+			patch.object(admin_client, "_admin_url", return_value="http://cp"),
+			patch.object(admin_client, "_admin_access_token", return_value="tok"),
+			patch.object(admin_client, "requests") as rq,
+		):
+			rq.post.return_value = r404
+			with self.assertRaises(AdminValidationError):
+				admin_client._authenticated_raw("/p", {}, timeout_s=10)

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -144,3 +144,22 @@ class TestSupportBenchEndpoints(FrappeTestCase):
 			out = smedia.upload(ticket="T1")
 			self.assertTrue(out["ok"])
 			self.assertEqual(up.call_args.kwargs["content_b64"], base64.b64encode(b"hi").decode())
+
+
+class TestSupportBoot(FrappeTestCase):
+	def setUp(self):
+		frappe.cache().delete_value("jarvis:support_available")
+
+	def test_support_available_false_on_error_and_cached(self):
+		from jarvis.www import jarvis as jw
+
+		with patch("jarvis.admin_client.support_status", side_effect=Exception("down")) as ss:
+			self.assertFalse(jw._support_available())
+			self.assertFalse(jw._support_available())  # cached, not re-called
+			self.assertEqual(ss.call_count, 1)
+
+	def test_support_available_true_when_status_available(self):
+		from jarvis.www import jarvis as jw
+
+		with patch("jarvis.admin_client.support_status", return_value={"available": True}):
+			self.assertTrue(jw._support_available())

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -43,3 +43,8 @@ class TestSupportScope(FrappeTestCase):
 		self.assertIsNone(support_scope(u))
 		grant_default_support(u)
 		self.assertEqual(support_scope(u), "own")
+
+	def test_default_grant_skips_administrator_and_guest(self):
+		for u in ("Administrator", "Guest"):
+			grant_default_support(u)
+			self.assertFalse(frappe.db.exists("Has Role", {"parent": u, "role": JARVIS_SUPPORT_USER_ROLE}))

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -88,3 +88,59 @@ class TestAdminClientSupport(FrappeTestCase):
 			resp = admin_client._authenticated_raw("/p", {}, timeout_s=10)
 			self.assertIs(resp, r200)
 			self.assertIn("token k:s", rq.post.call_args.kwargs["headers"]["Authorization"])
+
+
+class TestSupportBenchEndpoints(FrappeTestCase):
+	def test_list_refused_without_scope(self):
+		from jarvis.support import api as sapi
+
+		with patch("jarvis.support.api.support_scope", return_value=None):
+			with self.assertRaises(frappe.PermissionError):
+				sapi.list_tickets()
+
+	def test_list_forwards_user_and_scope(self):
+		from jarvis.support import api as sapi
+
+		with (
+			patch("jarvis.support.api.support_scope", return_value="own"),
+			patch.object(sapi.admin_client, "support_list_tickets", return_value={"tickets": []}) as f,
+		):
+			out = sapi.list_tickets()
+			self.assertTrue(out["ok"])
+			self.assertEqual(f.call_args.kwargs["scope"], "own")
+			self.assertEqual(f.call_args.kwargs["requesting_user"], frappe.session.user)
+
+	def test_download_returns_response(self):
+		from jarvis.support import media as smedia
+
+		with (
+			patch("jarvis.support.media.support_scope", return_value="own"),
+			patch.object(
+				smedia.admin_client,
+				"support_download",
+				return_value=(b"png", "image/png", "inline; filename=x"),
+			),
+		):
+			out = smedia.download(ticket="T1", file_url="/f/x.png")
+			self.assertEqual(out.headers["Content-Type"], "image/png")
+			self.assertEqual(out.get_data(), b"png")
+
+	def test_upload_forwards_b64(self):
+		import base64
+
+		from jarvis.support import media as smedia
+
+		req = MagicMock()
+		f = MagicMock()
+		f.filename = "x.png"
+		f.read.return_value = b"hi"
+		req.files.get.return_value = f
+		frappe.local.request = req
+		self.addCleanup(lambda: setattr(frappe.local, "request", None))
+		with (
+			patch("jarvis.support.media.support_scope", return_value="own"),
+			patch.object(smedia.admin_client, "support_upload", return_value={"file_url": "/f/x"}) as up,
+		):
+			out = smedia.upload(ticket="T1")
+			self.assertTrue(out["ok"])
+			self.assertEqual(up.call_args.kwargs["content_b64"], base64.b64encode(b"hi").decode())

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis import admin_client
 from jarvis.permissions import (
 	JARVIS_SUPPORT_ADMIN_ROLE,
 	JARVIS_SUPPORT_USER_ROLE,
@@ -48,3 +51,40 @@ class TestSupportScope(FrappeTestCase):
 		for u in ("Administrator", "Guest"):
 			grant_default_support(u)
 			self.assertFalse(frappe.db.exists("Has Role", {"parent": u, "role": JARVIS_SUPPORT_USER_ROLE}))
+
+
+class TestAdminClientSupport(FrappeTestCase):
+	def test_list_tickets_posts_to_support_path(self):
+		with patch.object(admin_client, "_post", return_value={"ok": True, "data": {"tickets": []}}) as post:
+			admin_client.support_list_tickets(requesting_user="u@x", scope="own")
+			self.assertIn("support.api.list_tickets", post.call_args.kwargs["path"])
+			self.assertEqual(post.call_args.kwargs["body"]["scope"], "own")
+
+	def test_upload_posts_b64_via_support_path(self):
+		with patch.object(
+			admin_client, "_post", return_value={"ok": True, "data": {"file_url": "/f/x"}}
+		) as post:
+			admin_client.support_upload(
+				ticket="T1", filename="x.png", content_b64="aGk=", requesting_user="u@x", scope="own"
+			)
+			self.assertIn("support.media.upload", post.call_args.kwargs["path"])
+			self.assertEqual(post.call_args.kwargs["body"]["content_b64"], "aGk=")
+
+	def test_authenticated_raw_remints_on_401_then_legacy(self):
+		# bearer 401 -> re-mint bearer 401 -> legacy token 200 (preserves _post's ladder)
+		settings = MagicMock()
+		settings.get_password.side_effect = lambda f, **k: {
+			"jarvis_admin_api_key": "k",
+			"jarvis_admin_api_secret": "s",
+		}.get(f)
+		r401, r200 = MagicMock(status_code=401), MagicMock(status_code=200)
+		with (
+			patch("frappe.get_single", return_value=settings),
+			patch.object(admin_client, "_admin_url", return_value="http://cp"),
+			patch.object(admin_client, "_admin_access_token", side_effect=["tok1", "tok2"]),
+			patch.object(admin_client, "requests") as rq,
+		):
+			rq.post.side_effect = [r401, r401, r200]
+			resp = admin_client._authenticated_raw("/p", {}, timeout_s=10)
+			self.assertIs(resp, r200)
+			self.assertIn("token k:s", rq.post.call_args.kwargs["headers"]["Authorization"])

--- a/jarvis/tests/test_support_bench.py
+++ b/jarvis/tests/test_support_bench.py
@@ -1,0 +1,45 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.permissions import (
+	JARVIS_SUPPORT_ADMIN_ROLE,
+	JARVIS_SUPPORT_USER_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_support_roles,
+	grant_default_support,
+	support_scope,
+)
+
+
+def _user(roles):
+	u = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": f"{frappe.generate_hash(length=8)}@sup.test",
+			"first_name": "S",
+			"send_welcome_email": 0,
+		}
+	)
+	for r in roles:
+		u.append("roles", {"role": r})
+	return u.insert(ignore_permissions=True).name
+
+
+class TestSupportScope(FrappeTestCase):
+	def setUp(self):
+		ensure_support_roles()
+
+	def test_none_without_role(self):
+		self.assertIsNone(support_scope(_user([])))
+
+	def test_own_for_support_user(self):
+		self.assertEqual(support_scope(_user([JARVIS_SUPPORT_USER_ROLE])), "own")
+
+	def test_all_for_support_admin(self):
+		self.assertEqual(support_scope(_user([JARVIS_SUPPORT_ADMIN_ROLE])), "all")
+
+	def test_default_grant_gives_own_to_jarvis_user(self):
+		u = _user([JARVIS_USER_ROLE])
+		self.assertIsNone(support_scope(u))
+		grant_default_support(u)
+		self.assertEqual(support_scope(u), "own")

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -11,6 +11,8 @@ no_cache = 1
 
 _SUPPORT_AVAILABLE_CACHE_KEY = "jarvis:support_available"
 _SUPPORT_AVAILABLE_TTL_S = 300
+# R1-7: negative-cache a transient CP blip for a shorter window so support reappears promptly.
+_SUPPORT_UNAVAILABLE_TTL_S = 60
 
 
 def _support_available() -> bool:
@@ -27,9 +29,8 @@ def _support_available() -> bool:
 		available = bool(admin_client.support_status(timeout_s=8).get("available"))
 	except Exception:
 		available = False
-	cache.set_value(
-		_SUPPORT_AVAILABLE_CACHE_KEY, "1" if available else "0", expires_in_sec=_SUPPORT_AVAILABLE_TTL_S
-	)
+	ttl = _SUPPORT_AVAILABLE_TTL_S if available else _SUPPORT_UNAVAILABLE_TTL_S
+	cache.set_value(_SUPPORT_AVAILABLE_CACHE_KEY, "1" if available else "0", expires_in_sec=ttl)
 	return available
 
 

--- a/jarvis/www/jarvis.py
+++ b/jarvis/www/jarvis.py
@@ -1,8 +1,36 @@
 import frappe
 
-from jarvis.permissions import has_jarvis_access, has_jarvis_admin_access
+from jarvis.permissions import (
+	grant_default_support,
+	has_jarvis_access,
+	has_jarvis_admin_access,
+	support_scope,
+)
 
 no_cache = 1
+
+_SUPPORT_AVAILABLE_CACHE_KEY = "jarvis:support_available"
+_SUPPORT_AVAILABLE_TTL_S = 300
+
+
+def _support_available() -> bool:
+	"""Fleet-wide support kill switch, Redis-cached (P8) so boot never blocks on a CP round-trip.
+	Uses support_status (relaxed auth) — NOT get_connection, which 403s suspended customers (P7).
+	Any failure ⇒ False (button hidden, never an error)."""
+	cache = frappe.cache()
+	cached = cache.get_value(_SUPPORT_AVAILABLE_CACHE_KEY)
+	if cached is not None:
+		return cached == "1"
+	try:
+		from jarvis import admin_client
+
+		available = bool(admin_client.support_status(timeout_s=8).get("available"))
+	except Exception:
+		available = False
+	cache.set_value(
+		_SUPPORT_AVAILABLE_CACHE_KEY, "1" if available else "0", expires_in_sec=_SUPPORT_AVAILABLE_TTL_S
+	)
+	return available
 
 
 def get_context(context):
@@ -41,5 +69,13 @@ def get_context(context):
 		# first routed render on a settings request.
 		"time_zone": frappe.utils.get_system_timezone(),
 	}
+
+	# Support panel gating (Plan 3 B5). Lazy-grant the default support role to this chat user so
+	# support isn't dark (P2 — grant_default_support clears the role cache so support_scope sees
+	# it in this same request), then expose both the per-user access flag and the fleet kill switch.
+	grant_default_support()
+	context.boot["has_support_access"] = support_scope() is not None
+	context.boot["support_available"] = _support_available()
+
 	frappe.db.commit()
 	return context


### PR DESCRIPTION
## Jarvis customer-support — embedded Support panel + backend

The customer side of the support feature: a `/support` panel in the chat SPA that proxies to the control plane. **No new customer-side secret** — it rides the existing bench→control-plane API-key channel.

### Backend
- Two roles (`Jarvis Support User` / `Jarvis Support Admin`) + `support_scope()`; `Jarvis Support User` auto-granted to chat users (lazy, at boot, with a role-cache clear so it lands in-request).
- `admin_client` support proxies + `_authenticated_raw` — the bearer→re-mint→legacy auth ladder for streamed media (routes CP 4xx/5xx as errors, mirrors `_do_post`).
- Role-gated whitelisted endpoints (`jarvis/support/api.py`) + media proxy (download stream + upload).
- Boot flags: `support_available` (cached kill switch, `support_status`) + `has_support_access`.

### Frontend
- `/support` route (dual-gated) + `SupportPage.vue` (list / thread / compose / media).
- Agent HTML through **DOMPurify** (sanitize as the last transform) + the inline `/files/`→download-proxy URL rewrite.
- Attachment filenames rendered as **escaped text** (no `innerHTML` sink).
- **Support** entry below Settings in the user menu; SPA-driven awaiting-count badge (~60s poll).

### Tests
15 bench tests green on `jarvis-test.localhost`; frontend builds clean.

### Pairs with
- `Aerele-RnD/jarvis-admin-v2` `feat/support-control-plane` (#92).
- The `jarvis_helpdesk` app on the Helpdesk site.

### Deferred to go-live (Fable-blessed, not defects)
Rate-limiting, audit logging, the live round-trip smoke, and the CSP (C5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)