### PR TITLE
feat(billing): role-aware expiry banner in chat (before expiry, grace, expired)

### DIFF
--- a/frontend/src/account/format.js
+++ b/frontend/src/account/format.js
@@ -97,3 +97,31 @@ export function renewalLabel(currentPeriodEnd, daysRemaining) {
 	if (d <= 0) return `Expired ${date}`;
 	return `Renews ${date} · ${d} day${d === 1 ? "" : "s"} left`;
 }
+
+// Billing lifecycle banner, or null when there is nothing to say. The server
+// sends BOTH audiences' wording because it authenticates the customer, not the
+// individual - only the bench knows who is looking, so the pick happens here.
+const BILLING_TONE = { expiring: "info", grace: "warning", expired: "warning" };
+const BILLING_TITLE = {
+	expiring: "Plan ending soon",
+	grace: "Payment overdue",
+	expired: "Chat is paused",
+};
+
+export function billingBanner(notice, canRenew) {
+	const phase = (notice && notice.phase) || "";
+	if (!BILLING_TONE[phase]) return null;
+	const message = (canRenew ? notice.admin_message : notice.member_message) || "";
+	if (!message) return null;
+	return {
+		phase,
+		type: BILLING_TONE[phase],
+		title: BILLING_TITLE[phase],
+		message,
+		// Renewing is the admin's action; a member has nothing to click.
+		showRenew: !!canRenew,
+		// Only the pre-expiry nudge is dismissible. Grace is the last window in
+		// which paying still helps, and expired already blocks chat.
+		dismissible: phase === "expiring",
+	};
+}

--- a/frontend/src/account/format.test.js
+++ b/frontend/src/account/format.test.js
@@ -12,6 +12,7 @@ import {
 	cancellationNotice,
 	shortDate,
 	cancelPillLabel,
+	billingBanner,
 } from "./format.js";
 
 test("statusLabel: maps known states, passes through unknown", () => {
@@ -96,4 +97,42 @@ test("cancelPillLabel: glanceable end date, not the ambiguous 'Cancelling'", () 
 	assert.equal(cancelPillLabel("2026-08-21 12:56:09"), "Ends 21 Aug");
 	assert.equal(cancelPillLabel(""), "Ending");
 	assert.equal(cancelPillLabel(null), "Ending");
+});
+
+const _notice = (phase) => ({
+	phase,
+	admin_message: "ADMIN COPY",
+	member_message: "MEMBER COPY",
+});
+
+test("billingBanner: says nothing without a usable phase", () => {
+	assert.equal(billingBanner(null, true), null);
+	assert.equal(billingBanner({}, true), null);
+	assert.equal(billingBanner({ phase: "active" }, true), null);
+});
+
+test("billingBanner: picks the wording for whoever is looking", () => {
+	assert.equal(billingBanner(_notice("expiring"), true).message, "ADMIN COPY");
+	assert.equal(billingBanner(_notice("expiring"), false).message, "MEMBER COPY");
+});
+
+test("billingBanner: only offers Renew to someone who can renew", () => {
+	assert.equal(billingBanner(_notice("expired"), true).showRenew, true);
+	assert.equal(billingBanner(_notice("expired"), false).showRenew, false);
+});
+
+test("billingBanner: only the pre-expiry nudge is dismissible", () => {
+	// Grace is the last window in which paying still helps; expired blocks chat.
+	assert.equal(billingBanner(_notice("expiring"), true).dismissible, true);
+	assert.equal(billingBanner(_notice("grace"), true).dismissible, false);
+	assert.equal(billingBanner(_notice("expired"), true).dismissible, false);
+});
+
+test("billingBanner: tone escalates across the lifecycle", () => {
+	assert.equal(billingBanner(_notice("expiring"), true).type, "info");
+	assert.equal(billingBanner(_notice("grace"), true).type, "warning");
+});
+
+test("billingBanner: says nothing when this audience has no copy", () => {
+	assert.equal(billingBanner({ phase: "grace", admin_message: "x" }, false), null);
 });

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -61,3 +61,9 @@ export async function needsOnboarding() {
 	if (isOnboardComplete(resp)) return false;
 	return NOT_ONBOARDED_REASONS.has(resp && resp.reason);
 }
+
+// Billing banner payload from the same memoized verdict - no extra round-trip.
+export async function billingNoticeOf() {
+	const r = await checkReady();
+	return (r && r.billing_notice) || {};
+}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4022,7 +4022,10 @@ const liveStatus = computed(() => {
 // hiccup. Both mean "still working, in the background" — not an error.
 // Renew CTA → Settings ▸ Plan & billing, the only surface that takes payment.
 function goRenew() {
-	store.openSettings("plan");
+	// Straight to our renewal flow (the Desk billing page's Razorpay checkout),
+	// not the settings pane the customer would then have to click through. The
+	// Renew button only shows for someone who can actually renew.
+	window.location.assign("/app/jarvis-account?billing=1");
 }
 const recoveringLabel = computed(() =>
 	recovering.value && recovering.value.reason === "compacting"

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2075,9 +2075,37 @@
 					background: var(--surface);
 				"
 			>
+				<!-- Billing lifecycle: before expiry, during grace, and after.
+					 Replaces (not stacks with) the suspended banner - its copy is
+					 the admin wording, which is wrong for a member who cannot
+					 renew. -->
+				<Banner
+					v-if="billingAlert"
+					:type="billingAlert.type"
+					:title="billingAlert.title"
+					:message="billingAlert.message"
+					style="margin-bottom: 10px"
+				>
+					<template #action>
+						<button
+							v-if="billingAlert.showRenew"
+							class="jv-btn jv-btn--sm"
+							@click="goRenew"
+						>
+							Renew
+						</button>
+						<button
+							v-if="billingAlert.dismissible"
+							class="jv-btn jv-btn--sm jv-btn--ghost"
+							@click="dismissBillingAlert"
+						>
+							Dismiss
+						</button>
+					</template>
+				</Banner>
 				<!-- Lapsed sub: container stopped, so every send would fail. -->
 				<Banner
-					v-if="suspendedNotice"
+					v-else-if="suspendedNotice"
 					type="warning"
 					title="Chat is paused"
 					:message="suspendedNotice"
@@ -3470,6 +3498,8 @@ import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
 import { checkReady } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
+import { billingBanner } from "@/account/format.js";
+import { billingNoticeOf } from "@/onboarding/readiness.js";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
 import { displayName } from "@/lib/user";
@@ -3524,6 +3554,22 @@ const ui = ref({});
 // Renew-banner copy when the subscription has lapsed; null while entitled.
 // The composer is disabled alongside it (no send can succeed while stopped).
 const suspendedNotice = ref(null);
+// Billing lifecycle banner. Dismissal is session-only (a ref, not storage): the
+// pre-expiry nudge should return on the next visit, since the deadline has not.
+const billingNotice = ref({});
+const billingDismissedPhase = ref("");
+// Renewing is gated on require_jarvis_admin(), which accepts Jarvis Admin OR
+// System Manager - match it, or a System Manager who CAN renew is told to ask
+// their admin.
+const canRenewPlan = !!(window.is_jarvis_admin || window.is_system_manager);
+const billingAlert = computed(() => {
+	const b = billingBanner(billingNotice.value, canRenewPlan);
+	if (!b || billingDismissedPhase.value === b.phase) return null;
+	return b;
+});
+function dismissBillingAlert() {
+	billingDismissedPhase.value = (billingAlert.value && billingAlert.value.phase) || "";
+}
 // Per-conversation "auto-apply changes" (issue #186): seeded from
 // get_conversation().conversation.auto_apply on each load; the toggle reflects
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.
@@ -7334,6 +7380,13 @@ onMounted(async () => {
 	// legacy #hash deep-links moved to the router, §9.)
 	const uiP = api.getChatUiSettings().catch(() => null);
 	const convsP = store.loadConversations().catch(() => {});
+	// Billing banner rides the memoized readiness verdict already fetched for
+	// this page load - no extra round-trip. Never blocks the mount.
+	billingNoticeOf()
+		.then((n) => {
+			billingNotice.value = n || {};
+		})
+		.catch(() => {});
 	socket?.on("jarvis:event", onEvent);
 	socket?.on("connect", onResync);
 	document.addEventListener("visibilitychange", onVisibility);

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -47,26 +47,35 @@ def _admin_chat_gate() -> dict:
 	  error clears on the very next load rather than sticking for the TTL.
 	"""
 	cache = frappe.cache()
-	if cache.get_value(_CHAT_GATE_CACHE_KEY):
-		return {"ready": True, "reason": None}
+	cached = cache.get_value(_CHAT_GATE_CACHE_KEY)
+	if cached:
+		# The billing banner rides the cached verdict. Caching a bare flag would
+		# hide an expiring/grace notice for the whole TTL on every ready load.
+		# Tolerate the pre-upgrade shape (a bare 1) rather than re-asking admin.
+		notice = cached.get("notice") if isinstance(cached, dict) else {}
+		return {"ready": True, "reason": None, "billing_notice": notice or {}}
 	try:
 		conn = admin_client.get_connection(timeout_s=8) or {}
 	except Exception:
 		# Fail open on ANY admin error; deliberately no negative cache.
-		return {"ready": True, "reason": None}
+		return {"ready": True, "reason": None, "billing_notice": {}}
+	notice = conn.get("billing_notice") or {}
 	if "chat_readiness" in conn and conn["chat_readiness"] != "Ready":
 		suspended = conn["chat_readiness"] == "Suspended"
 		return {
 			"ready": False,
 			"reason": "subscription_suspended" if suspended else "container_provisioning",
+			# Carried even when blocked: "detail" is the ADMIN wording, and a
+			# member who cannot renew needs a different call to action.
+			"billing_notice": notice,
 			# Admin owns the wording (jarvis_admin_v2.billing.entitlement) so the
 			# two sides can't drift into different explanations. A v1/older admin
 			# sends no reason; the SPA falls back to its own copy.
 			"detail": conn.get("chat_readiness_reason") or "",
 		}
 	# Reachable + (Ready, or v1-absent) → allow and cache the positive verdict.
-	cache.set_value(_CHAT_GATE_CACHE_KEY, 1, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
-	return {"ready": True, "reason": None}
+	cache.set_value(_CHAT_GATE_CACHE_KEY, {"notice": notice}, expires_in_sec=_CHAT_GATE_CACHE_TTL_S)
+	return {"ready": True, "reason": None, "billing_notice": notice}
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -157,7 +157,7 @@ class TestAdminChatGate(FrappeTestCase):
 		) as gc:
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "container_provisioning", "detail": ""},
+				{"ready": False, "reason": "container_provisioning", "detail": "", "billing_notice": {}},
 			)
 		# Uses the short 8s budget so a slow admin can't stall the SPA/boot path.
 		gc.assert_called_once_with(timeout_s=8)
@@ -180,6 +180,7 @@ class TestAdminChatGate(FrappeTestCase):
 					"ready": False,
 					"reason": "subscription_suspended",
 					"detail": "Your subscription has expired.",
+					"billing_notice": {},
 				},
 			)
 
@@ -189,19 +190,23 @@ class TestAdminChatGate(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Suspended"}):
 			self.assertEqual(
 				account._admin_chat_gate(),
-				{"ready": False, "reason": "subscription_suspended", "detail": ""},
+				{"ready": False, "reason": "subscription_suspended", "detail": "", "billing_notice": {}},
 			)
 
 	def test_allows_when_admin_ready(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}):
-			self.assertEqual(account._admin_chat_gate(), {"ready": True, "reason": None})
+			self.assertEqual(
+				account._admin_chat_gate(), {"ready": True, "reason": None, "billing_notice": {}}
+			)
 
 	def test_v1_tolerant_when_key_absent(self):
 		# v1 admin (or a v2 not surfacing chat_readiness) → no opinion → allow.
 		with patch.object(
 			admin_client, "get_connection", return_value={"agent_url": "ws://x", "tenant_status": "running"}
 		):
-			self.assertEqual(account._admin_chat_gate(), {"ready": True, "reason": None})
+			self.assertEqual(
+				account._admin_chat_gate(), {"ready": True, "reason": None, "billing_notice": {}}
+			)
 
 	def test_fails_open_on_admin_error(self):
 		from jarvis.exceptions import AdminUnreachableError
@@ -209,10 +214,30 @@ class TestAdminChatGate(FrappeTestCase):
 		with patch.object(
 			admin_client, "get_connection", side_effect=AdminUnreachableError("admin is unreachable")
 		):
-			self.assertEqual(account._admin_chat_gate(), {"ready": True, "reason": None})
+			self.assertEqual(
+				account._admin_chat_gate(), {"ready": True, "reason": None, "billing_notice": {}}
+			)
 		# Fail-open verdict must NOT be negative-cached: a recovered admin is
 		# re-probed on the next call rather than being blocked for the TTL.
 		self.assertIsNone(frappe.cache().get_value(account._CHAT_GATE_CACHE_KEY))
+
+	def test_billing_notice_is_passed_through(self):
+		# The expiry banner rides this verdict; admin owns the wording, the gate
+		# only forwards it - on both the ready and the suspended paths.
+		notice = {"phase": "expiring", "admin_message": "ends soon", "member_message": "ask admin"}
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={"chat_readiness": "Ready", "billing_notice": notice},
+		):
+			self.assertEqual(account._admin_chat_gate()["billing_notice"], notice)
+		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+		with patch.object(
+			admin_client,
+			"get_connection",
+			return_value={"chat_readiness": "Suspended", "billing_notice": notice},
+		):
+			self.assertEqual(account._admin_chat_gate()["billing_notice"], notice)
 
 	def test_positive_verdict_is_cached(self):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Ready"}) as gc:


### PR DESCRIPTION
Bench half of the expiry banners. Needs Aerele-RnD/jarvis-admin-v2#95, which sends `billing_notice`; without it nothing renders and today's behaviour is unchanged.

## The gap

A customer learned their plan had lapsed by **being blocked from chat**. Nothing warned beforehand, and the grace window was entirely silent — the one period where paying still saves them. There's no email infrastructure either, so in-app is the only surface available.

## What renders

Chat only, driven by `billing_notice`:

| Phase | Tone | Renew button | Dismissible | Blocks chat |
|---|---|---|---|---|
| `expiring` (≤7 days) | info | admins only | **yes**, session | no |
| `grace` (Past Due) | warning | admins only | no | **no** |
| `expired` | warning | admins only | no | yes (existing) |

`expiring` and `grace` must never block sending — `Past Due` is in `ENTITLED_STATUSES` precisely so a late payer keeps working.

## Why the copy is picked here

Admin authenticates the **customer**, not the individual user — one API key per site — so it cannot know who is looking. It sends both audiences' wording; the bench picks. Admins are told to renew, members to ask their admin, because they cannot.

**Audience = whoever passes the renew gate.** `require_jarvis_admin()` accepts Jarvis Admin **or** System Manager, so the banner matches it exactly. Gating strictly on the `Jarvis Admin` role would tell a System Manager — who can renew — to ask their admin, i.e. themselves.

## It replaces the suspended banner, not stacks with it

The existing banner shows `chat_readiness_reason`, which is the **admin** wording. A member reading *"Renew to restore access"* cannot act on it. The billing banner supersedes it and the old one remains as the fallback for an admin that sends no notice.

## No extra round-trip

The notice rides the memoized readiness verdict the page already fetches. `_admin_chat_gate` now caches it **alongside** the positive verdict — caching a bare flag would have hidden the banner for the whole 120s TTL on every ready load. The pre-upgrade cached shape (a bare `1`) is tolerated rather than triggering a re-ask.

## Dismissal

Session-only (a ref, not storage) and only for the pre-expiry nudge, so it returns on the next visit — the deadline hasn't moved.

## Tests

6 new cases in `format.test.js` (**19/19 pass**): audience selection, Renew only for those who can renew, dismissible only for `expiring`, tone escalation, and silence when this audience has no copy. `bench build --app jarvis` verified — the new strings are in the shipped bundle.