### PR TITLE
R5 P0 closure: render gate, envelope registry, min_apps gate, delegate write capabilities

### DIFF
--- a/jarvis/agents/registry.json
+++ b/jarvis/agents/registry.json
@@ -116,6 +116,17 @@
         "Item"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        },
+        {
+          "doctype": "Purchase Invoice",
+          "mode": "draft"
+        }
+      ],
+      "rule_pack": "ap-exception-family",
       "timeout_s": 600,
       "min_apps": [
         "erpnext"
@@ -170,6 +181,17 @@
         "Communication"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        },
+        {
+          "doctype": "Dunning",
+          "mode": "draft"
+        }
+      ],
+      "rule_pack": "revops-hygiene",
       "timeout_s": 600,
       "min_apps": [
         "erpnext"
@@ -223,6 +245,8 @@
         "ali-lwp-9c21",
         "ali-punch-7d14"
       ],
+      "writes": null,
+      "rule_pack": "payroll-integrity",
       "timeout_s": 1800,
       "min_apps": [
         "hrms"
@@ -272,6 +296,17 @@
         "Jarvis Approval Request"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        },
+        {
+          "doctype": "Payment Entry",
+          "mode": "draft"
+        }
+      ],
+      "rule_pack": "finance-close-control",
       "timeout_s": 1200,
       "min_apps": [
         "erpnext"
@@ -329,6 +364,8 @@
         "bm-fc-1d7a",
         "bm-inv-6b03"
       ],
+      "writes": null,
+      "rule_pack": "measurement",
       "timeout_s": 3600,
       "min_apps": [
         "erpnext"
@@ -368,6 +405,8 @@
         "bmhd-lat-4c19",
         "bmhd-win-9e2f"
       ],
+      "writes": null,
+      "rule_pack": "measurement",
       "timeout_s": 900,
       "min_apps": [
         "erpnext",
@@ -411,6 +450,8 @@
         "bmh-ovl-7d12",
         "bmh-win-3ab8"
       ],
+      "writes": null,
+      "rule_pack": "measurement",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -428,7 +469,7 @@
       "domain": "india-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Scans your cash payments and cash receipts and lists the ones that cross India's income-tax cash limits: expenses paid in cash above ₹10,000 to one payee in a day (₹35,000 for transporters), and cash received of ₹2,00,000 or more in aggregate from one person. Ships a monthly preventive worklist and a pre-flighted Form 3CD data pack. Read-only breach-candidate list for your CA to review; never edits a voucher, books anything, files a return, or decides that any payment is actually disallowed or penalised.",
       "tools_required": [
@@ -465,6 +506,8 @@
         "s40a3_disallowance_measure",
         "s40a3_limits"
       ],
+      "writes": null,
+      "rule_pack": "india-compliance-workbench",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -515,6 +558,8 @@
         "ca-cl-a4e6",
         "ca-cl-c058"
       ],
+      "writes": null,
+      "rule_pack": "finance-close-control",
       "timeout_s": 2400,
       "min_apps": [
         "erpnext"
@@ -563,6 +608,17 @@
         "Stock Ledger Entry"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        },
+        {
+          "doctype": "Stock Reconciliation",
+          "mode": "draft"
+        }
+      ],
+      "rule_pack": "inventory-health",
       "timeout_s": 600,
       "min_apps": [
         "erpnext"
@@ -613,6 +669,8 @@
         "dsa-shelf-b7e5",
         "dsa-turn-9c48"
       ],
+      "writes": null,
+      "rule_pack": "inventory-health",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -662,6 +720,8 @@
         "dp-quiet-3f88",
         "dp-rank-a20e"
       ],
+      "writes": null,
+      "rule_pack": "revops-hygiene",
       "timeout_s": 1800,
       "min_apps": [
         "crm"
@@ -678,7 +738,7 @@
       "domain": "ap",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Read-only AP hygiene sweep. Retrospectively surfaces duplicate-payment candidates — payments that appear to have been made twice (same vendor, same amount, close dates, look-alike references) — pairing documents and cross-checking settlement evidence. Also flags near-duplicate purchase invoices, one vendor entered as two masters, check-digit-invalid GSTIN/PAN, and bank-detail changes just before a payment. Hands finance a ranked, evidence-linked candidate worklist and dashboard. Never edits a master, touches a payment, or decides claw-backs.",
       "tools_required": [
@@ -719,6 +779,8 @@
         "gst_gstin_checkdigit_algorithm",
         "pan_format"
       ],
+      "writes": null,
+      "rule_pack": "ap-exception-family",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -735,7 +797,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "For batch-tracked pharma/FMCG/food stock: replays each day's outward movements to catch FEFO violations — a dispatch that skipped an older-expiry batch that still had stock — and lists on-hand batches inside the near-expiry and past-expiry horizon, ranked by value. Read-only; hyperlinks every finding to its batch and dispatch. Never touches stock, holds a shipment, or writes off a batch.",
       "tools_required": [
@@ -769,6 +831,8 @@
         "gdp_near_expiry_horizon_convention",
         "shelf_life_horizon_fraction"
       ],
+      "writes": null,
+      "rule_pack": "inventory-health",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -821,6 +885,8 @@
         "fad-mat-7c21",
         "fad-salv-b1a6"
       ],
+      "writes": null,
+      "rule_pack": "finance-close-control",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -873,6 +939,8 @@
         "grn-offpo-3d51",
         "grn-uomtol-4b17"
       ],
+      "writes": null,
+      "rule_pack": "inventory-health",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -889,7 +957,7 @@
       "domain": "gst-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Works only the residue left after india_compliance's Purchase Reconciliation Tool: ranks the unmatched, mismatched and aged rows between your GSTR-2B ledger and your purchase register by rupees, groups them into a supplier follow-up worklist, and tracks the ageing window per invoice. Read-only; never edits an invoice, files a return, or decides what you may claim.",
       "tools_required": [
@@ -924,6 +992,8 @@
         "rule37_180d",
         "s16_4_window"
       ],
+      "writes": null,
+      "rule_pack": "india-compliance-workbench",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -941,7 +1011,7 @@
       "domain": "gst-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Pre-file data-quality worklist for your GST returns: on an india_compliance bench it works only the manual-override and data-import residue — lines with a blank or short HSN, invoices whose place-of-supply contradicts the tax head charged, one HSN billed at inconsistent rates across the period, and a books-vs-return tie-out where GSTR-1/3B are generated through india_compliance. Read-only; ranks the residue by rupees. Never edits an invoice, amends or files a return, and asserts no filing-correctness verdict.",
       "tools_required": [
@@ -978,6 +1048,8 @@
         "hsn_digit_thresholds",
         "notified_rcm_categories"
       ],
+      "writes": null,
+      "rule_pack": "india-compliance-workbench",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -1031,6 +1103,8 @@
         "lh-shm-8a73",
         "lh-sla-5c40"
       ],
+      "writes": null,
+      "rule_pack": "revops-hygiene",
       "timeout_s": 900,
       "min_apps": [
         "crm"
@@ -1082,6 +1156,8 @@
         "ls-sign-9c14",
         "ls-susp-3d7a"
       ],
+      "writes": null,
+      "rule_pack": "finance-close-control",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -1098,7 +1174,7 @@
       "domain": "india-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "For suppliers you have already classified as Micro/Small MSME, this overlays each open payable's elapsed days against its 15/45-day window and projects whether it will still be unpaid on 31-March, when s.43B(h) defers the deduction. Ships a pay-before-year-end worklist on top of ERPNext's native AP Ageing report. Read-only; never records a payment, edits a voucher, classifies a supplier, or decides what you may deduct.",
       "tools_required": [
@@ -1131,6 +1207,8 @@
         "msmed_s15_windows",
         "s43bh_yearend_test"
       ],
+      "writes": null,
+      "rule_pack": "india-compliance-workbench",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -1188,6 +1266,8 @@
         "nsv-spike-4b1c",
         "nsv-tieout-7d92"
       ],
+      "writes": null,
+      "rule_pack": "inventory-health",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -1246,6 +1326,8 @@
         "pp-pbo-3d71",
         "pp-swg-2ed8"
       ],
+      "writes": null,
+      "rule_pack": "payroll-integrity",
       "timeout_s": 1800,
       "min_apps": [
         "hrms"
@@ -1297,6 +1379,17 @@
         "Purchase Order Item"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        },
+        {
+          "doctype": "Material Request",
+          "mode": "draft"
+        }
+      ],
+      "rule_pack": "inventory-health",
       "timeout_s": 600,
       "min_apps": [
         "erpnext"
@@ -1345,6 +1438,8 @@
         "sb-stat-4d81",
         "sb-win-1e4a"
       ],
+      "writes": null,
+      "rule_pack": "helpdesk-queue",
       "timeout_s": 1800,
       "min_apps": [
         "helpdesk"
@@ -1361,7 +1456,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Reads your computed Salary Slips each month before the PF/ESI/PT deposit and surfaces the employees whose statutory deduction lines don't reconcile with their reconstructed wage bases — PF against the ceiling, ESI at the eligibility boundary and its mid-period continuity, PT against the state slab, LWF presence, and bonus/gratuity eligibility transitions. UAN/ESI identity and challan/portal deposit evidence come only from sources you declare at install; checks needing them stay not-evaluable until then. Read-only; never edits a slip or files a return; a named reviewer owns every decision.",
       "tools_required": [
@@ -1399,6 +1494,8 @@
         "pt_slabs_karnataka",
         "pt_slabs_maharashtra"
       ],
+      "writes": null,
+      "rule_pack": "payroll-integrity",
       "timeout_s": 1800,
       "min_apps": [
         "hrms"
@@ -1415,7 +1512,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Extends the Statutory Payroll auditor onto your own recorded PF/ESI deposit bookings: it reads the Journal Entry or Payment Entry you post against your PF/ESI liability account and reports whether that booking is dated on or before the effective-dated deposit due date. Installable only where ERPNext and HRMS are present. Read-only; reports a booked-liability date only, never that a deposit reached EPFO/ESIC, and never books, edits, or deposits. Custom challan doctypes and portal receipts are not read here; they enter as a declared import artifact.",
       "tools_required": [
@@ -1443,6 +1540,8 @@
         "s14b_damages_table",
         "s7q_interest_table"
       ],
+      "writes": null,
+      "rule_pack": "payroll-integrity",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -1489,6 +1588,8 @@
       "rule_tokens": [
         "sv-vtol-7b2c"
       ],
+      "writes": null,
+      "rule_pack": "inventory-health",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"
@@ -1505,7 +1606,7 @@
       "domain": "tds-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Prepares your monthly TDS/TCS data before each deposit due date and before each 26Q/24Q quarter: reconciles the TDS booked in your ledger against the challan payments recorded in your books, tracks each supplier's running total against the section thresholds, checks the rate deducted against the effective section rate, and lists the deductee fields your return is missing. Read-only worklist; never edits a voucher, books TDS, deposits a challan, files a return, or decides what is legally deductible.",
       "tools_required": [
@@ -1543,6 +1644,8 @@
         "section_rates",
         "section_thresholds"
       ],
+      "writes": null,
+      "rule_pack": "india-compliance-workbench",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext",
@@ -1591,6 +1694,13 @@
         "HD Agent"
       ],
       "rule_tokens": [],
+      "writes": [
+        {
+          "doctype": "Jarvis Approval Request",
+          "mode": "approval-request"
+        }
+      ],
+      "rule_pack": "helpdesk-queue",
       "timeout_s": 300,
       "min_apps": [
         "helpdesk"
@@ -1607,7 +1717,7 @@
       "domain": "ap",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "status": "Published",
       "description": "Ranks the vendor sub-ledger exceptions worth a human look at AP close: suppliers sitting in a debit balance, advances left unlinked to an invoice, goods received but not yet billed, and any gap between the supplier-wise balances and the creditors control account. A book-to-book self-consistency check with per-finding provenance and a saved worklist. Read-only; never books an entry, clears a balance, or releases a payment.",
       "tools_required": [
@@ -1648,6 +1758,8 @@
         "vl-stale-ageing-5f17",
         "vl-tieout-tol-a9e3"
       ],
+      "writes": null,
+      "rule_pack": "finance-close-control",
       "timeout_s": 1800,
       "min_apps": [
         "erpnext"

--- a/jarvis/agents/registry.json
+++ b/jarvis/agents/registry.json
@@ -186,7 +186,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "Published",
       "description": "Read-only pre-payroll integrity checks across your attendance and leave records: cross-references marked Attendance, biometric check-ins, approved Leave Applications, and leave balances per employee to surface unaccounted working days, leave taken without approval, check-in-vs-mark mismatches, and over-drawn balances before payroll runs. Reproducible; never marks attendance, approves leave, edits a balance, or touches payroll.",
       "tools_required": [
@@ -288,7 +288,7 @@
       "domain": "measurement",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "Published",
       "description": "Reads 6-12 months of your own ERP history and reports the facts that size everything else: how long receipts take to become invoices, how quickly sales invoices get settled, how many entries were reversed, what your books already carry under interest and late-fee heads, how much stock is aged, and how many documents you process each period. Read-only; writes nothing, decides nothing, and never labels anything good or bad - it reports what your database already knows.",
       "tools_required": [
@@ -345,7 +345,7 @@
       "domain": "measurement",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Extends the Retrospective Baseline Meter onto Helpdesk records: how quickly tickets get a first response, how quickly they get resolved, and how many tickets you handle each period. Installable only where Helpdesk is present. Read-only; reads timestamps, statuses, and counts - never ticket conversation content.",
       "tools_required": [
@@ -385,7 +385,7 @@
       "domain": "measurement",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Extends the Retrospective Baseline Meter onto HRMS payroll records: how often payroll was re-run for the same period, how many corrections were booked as additional salary, and how many salary slips were changed after submission. Installable only where HRMS is present. Read-only; reports run counts, correction counts, and dates - never individual pay values.",
       "tools_required": [
@@ -428,7 +428,7 @@
       "domain": "india-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Scans your cash payments and cash receipts and lists the ones that cross India's income-tax cash limits: expenses paid in cash above ₹10,000 to one payee in a day (₹35,000 for transporters), and cash received of ₹2,00,000 or more in aggregate from one person. Ships a monthly preventive worklist and a pre-flighted Form 3CD data pack. Read-only breach-candidate list for your CA to review; never edits a voucher, books anything, files a return, or decides that any payment is actually disallowed or penalised.",
       "tools_required": [
@@ -482,7 +482,7 @@
       "domain": "close",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "status": "Published",
       "description": "Read-only period-end integrity checks: the trial balance must balance (opening and closing), and no ledger may carry a material balance on the wrong side of its group. Structural and reproducible — the same books yield the same findings every run. Never writes; reports and hands off.",
       "tools_required": [
@@ -579,7 +579,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Read-only inventory-ageing review: derives each item's last genuine outward movement, buckets it by age, separates slow-moving from non-moving and dead stock, overlays batch-expiry write-off candidates, and totals the working capital frozen per ageing bucket and warehouse. Ships a ranked disposition worklist and dashboard. Never moves, adjusts, or writes off stock, and never sets a write-down value.",
       "tools_required": [
@@ -629,7 +629,7 @@
       "domain": "crm",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Weekly read-only pipeline-hygiene scrub of your open CRM deals: surfaces deals that have gone quiet, aged in their current stage, run past their expected close date, or have no next step scheduled, then ranks them into a per-owner worklist so the forecast reflects deals that are actually moving. Never edits a deal, moves a stage, changes a date, or creates a task.",
       "tools_required": [
@@ -678,7 +678,7 @@
       "domain": "ap",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Read-only AP hygiene sweep. Retrospectively surfaces duplicate-payment candidates — payments that appear to have been made twice (same vendor, same amount, close dates, look-alike references) — pairing documents and cross-checking settlement evidence. Also flags near-duplicate purchase invoices, one vendor entered as two masters, check-digit-invalid GSTIN/PAN, and bank-detail changes just before a payment. Hands finance a ranked, evidence-linked candidate worklist and dashboard. Never edits a master, touches a payment, or decides claw-backs.",
       "tools_required": [
@@ -735,7 +735,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "For batch-tracked pharma/FMCG/food stock: replays each day's outward movements to catch FEFO violations — a dispatch that skipped an older-expiry batch that still had stock — and lists on-hand batches inside the near-expiry and past-expiry horizon, ranked by value. Read-only; hyperlinks every finding to its batch and dispatch. Never touches stock, holds a shipment, or writes off a batch.",
       "tools_required": [
@@ -785,7 +785,7 @@
       "domain": "accounting",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "Published",
       "description": "Read-only month-end fixed-asset integrity checks: ties every due depreciation schedule row to its posted journal, reconciles scheduled vs posted depreciation, lists zero / near-salvage assets still in use as write-off candidates, and ages capital-work-in-progress not yet placed in service. Produces a reproducible, provenance-linked worklist and dashboard. Never edits the register, posts a journal, or signs the close.",
       "tools_required": [
@@ -837,7 +837,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "Published",
       "description": "Sweeps goods receipts (Purchase Receipts) for receiving-discipline gaps: UOM-conversion anomalies that distort stock quantity, receipts missing the batch/serial capture the Item mandates, ageing received-but-not-billed (GRNI) balances, and direct receipts booked with no Purchase Order to match against. Ranks each gap with a rupee or count figure and hyperlinks it to the offending receipt line. Read-only; never edits a receipt, posts, chases a vendor, or touches stock or valuation.",
       "tools_required": [
@@ -889,7 +889,7 @@
       "domain": "gst-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Works only the residue left after india_compliance's Purchase Reconciliation Tool: ranks the unmatched, mismatched and aged rows between your GSTR-2B ledger and your purchase register by rupees, groups them into a supplier follow-up worklist, and tracks the ageing window per invoice. Read-only; never edits an invoice, files a return, or decides what you may claim.",
       "tools_required": [
@@ -941,7 +941,7 @@
       "domain": "gst-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Pre-file data-quality worklist for your GST returns: on an india_compliance bench it works only the manual-override and data-import residue — lines with a blank or short HSN, invoices whose place-of-supply contradicts the tax head charged, one HSN billed at inconsistent rates across the period, and a books-vs-return tie-out where GSTR-1/3B are generated through india_compliance. Read-only; ranks the residue by rupees. Never edits an invoice, amends or files a return, and asserts no filing-correctness verdict.",
       "tools_required": [
@@ -995,7 +995,7 @@
       "domain": "crm",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Read-only hygiene sweep of your Frappe CRM: finds duplicate and near-duplicate leads (the same person entered twice across leads and deals), flags leads marked converted with no matching deal, and surfaces uncontactable, unassigned, or SLA-breached leads into a ranked worklist. Never merges, edits, assigns, or deletes a record — it hands sales-ops the exceptions and a human decides.",
       "tools_required": [
@@ -1047,7 +1047,7 @@
       "domain": "accounting",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Read-only pre-close ledger scrutiny: scans your general ledger for postings worth a human look — uncleared suspense/clearing balances, dormant accounts that moved, balances on the wrong side of an account, round-number plugs, and possible duplicate manual journal entries. Isolates human-authored journals from system-generated ones. Hands your accountant a ranked, evidence-linked worklist and a dashboard. Never edits the ledger, never books a correction, never decides whether a flag is truly an error.",
       "tools_required": [
@@ -1098,7 +1098,7 @@
       "domain": "india-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "For suppliers you have already classified as Micro/Small MSME, this overlays each open payable's elapsed days against its 15/45-day window and projects whether it will still be unpaid on 31-March, when s.43B(h) defers the deduction. Ships a pay-before-year-end worklist on top of ERPNext's native AP Ageing report. Read-only; never records a payment, edits a voucher, classifies a supplier, or decides what you may deduct.",
       "tools_required": [
@@ -1148,7 +1148,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Runs ERPNext's stock-value vs account-value comparison on a schedule and works the residue: flags negative on-hand balances, zero-rate receipts, abnormal valuation-rate jumps, internal stock-value inconsistencies, and where your perpetual stock value drifts from its stock-in-hand GL account. Ranks each exception by rupees with a link to the offending ledger row. Read-only; never adjusts a quantity, books a journal entry, or posts a stock reconciliation.",
       "tools_required": [
@@ -1204,7 +1204,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "Published",
       "description": "Read-only pre-run check on your drafted salary slips, run just before you submit payroll. It flags what changed or was overridden after HRMS computed them at generation: an eligible employee missing from the batch, a rostered employee with no slip, post-generation attendance edits the draft no longer reflects, manual payment_days overrides, manually created slips, mover proration that looks off, and net-pay swings versus last month with no attendance or structure cause. Hands you a ranked worklist; never edits a slip, regularises attendance, submits payroll, or draws any statutory conclusion.",
       "tools_required": [
@@ -1313,7 +1313,7 @@
       "domain": "helpdesk",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "A scheduled, reproducible queue-health sweep for Frappe Helpdesk. Reads each ticket's already-stored SLA state and folds breached, about-to-breach, unassigned, unacknowledged, reopened and stalled tickets into one de-duplicated, severity-ranked worklist, hyperlinked to each ticket with the deadline it missed and its age. Read-only; never reassigns, replies, re-prioritises, or closes a ticket.",
       "tools_required": [
@@ -1361,7 +1361,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Reads your computed Salary Slips each month before the PF/ESI/PT deposit and surfaces the employees whose statutory deduction lines don't reconcile with their reconstructed wage bases — PF against the ceiling, ESI at the eligibility boundary and its mid-period continuity, PT against the state slab, LWF presence, and bonus/gratuity eligibility transitions. UAN/ESI identity and challan/portal deposit evidence come only from sources you declare at install; checks needing them stay not-evaluable until then. Read-only; never edits a slip or files a return; a named reviewer owns every decision.",
       "tools_required": [
@@ -1415,7 +1415,7 @@
       "domain": "hrms-payroll",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Extends the Statutory Payroll auditor onto your own recorded PF/ESI deposit bookings: it reads the Journal Entry or Payment Entry you post against your PF/ESI liability account and reports whether that booking is dated on or before the effective-dated deposit due date. Installable only where ERPNext and HRMS are present. Read-only; reports a booked-liability date only, never that a deposit reached EPFO/ESIC, and never books, edits, or deposits. Custom challan doctypes and portal receipts are not read here; they enter as a declared import artifact.",
       "tools_required": [
@@ -1460,7 +1460,7 @@
       "domain": "inventory-count",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Reconciles a physical stock count against system on-hand: ranks the SKUs whose counted quantity differs from the system by rupees-at-risk into an investigation worklist. Requires a docstatus=0 physical-count source (manufactured by the paired cycle-count-planner-operator). Read-only; never posts a stock reconciliation, adjusts a quantity, guesses a cause, or touches valuation. Negative-stock and valuation-integrity classes are owned by negative-stock-valuation-auditor, not here.",
       "tools_required": [
@@ -1505,7 +1505,7 @@
       "domain": "tds-compliance",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Prepares your monthly TDS/TCS data before each deposit due date and before each 26Q/24Q quarter: reconciles the TDS booked in your ledger against the challan payments recorded in your books, tracks each supplier's running total against the section thresholds, checks the rate deducted against the effective section rate, and lists the deductee fields your return is missing. Read-only worklist; never edits a voucher, books TDS, deposits a challan, files a return, or decides what is legally deductible.",
       "tools_required": [
@@ -1607,7 +1607,7 @@
       "domain": "ap",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "status": "Published",
       "description": "Ranks the vendor sub-ledger exceptions worth a human look at AP close: suppliers sitting in a debit balance, advances left unlinked to an invoice, goods received but not yet billed, and any gap between the supplier-wise balances and the creditors control account. A book-to-book self-consistency check with per-finding provenance and a saved worklist. Read-only; never books an entry, clears a balance, or releases a payment.",
       "tools_required": [

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -24,6 +24,8 @@ import os
 
 import frappe
 
+from jarvis.chat.agent_installability import reconcile_installations
+
 LISTING = "Jarvis Agent Listing"
 
 _AGENTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "agents")
@@ -177,11 +179,17 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	installs = frappe.get_all(
 		"Jarvis Agent Installation",
 		filters=filters,
-		fields=["agent", "owner"],
+		fields=["agent", "owner", "installable"],
 		order_by="agent asc",
 	)
 	payload = []
 	for row in installs:
+		# R5-J8: a reconcile marks an install ``installable=0`` (never deletes) when
+		# a min_apps dependency vanished AFTER install while it was still enabled.
+		# Its enablement signal must not reach the container — the run gates already
+		# refuse it, and pushing it would install a bundle whose data is absent.
+		if not frappe.utils.cint(row.installable):
+			continue
 		listing = frappe.db.get_value(
 			LISTING,
 			row.agent,
@@ -241,5 +249,17 @@ def after_migrate() -> None:
 	except Exception:
 		frappe.log_error(
 			title="jarvis agent catalog: after_migrate sync failed",
+			message=frappe.get_traceback(),
+		)
+	# R5-J8: an app install/uninstall runs a migrate, so this is the reconcile
+	# point — re-mark every installation installable/not against the current site.
+	# Independent try/except: a reconcile hiccup must never fail a migration and
+	# must run even if the catalog sync above raised.
+	try:
+		rec = reconcile_installations()
+		frappe.logger("jarvis").info(f"agent installability reconciled: {rec}")
+	except Exception:
+		frappe.log_error(
+			title="jarvis agent catalog: after_migrate installability reconcile failed",
 			message=frappe.get_traceback(),
 		)

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -98,6 +98,18 @@ def sync_agent_listings() -> dict:
 			# legacy agents. Mirrors the bundle store's rules.ids.json.
 			"rule_tokens": frappe.as_json(a.get("rule_tokens") or []),
 			"min_apps": frappe.as_json(a.get("min_apps") or []),
+			# R5-J9: the declarative operator write contract (manifest.writes[] —
+			# non-IP {doctype, mode} metadata the exporter emits). create_doc/
+			# update_doc bind a delegate call to it. Tolerant of an OLD registry
+			# that predates the field (``.get`` -> empty list): an operator whose
+			# registry carries no writes stays refused every write (fail-closed),
+			# an auditor's is always empty. NEVER a rule body/threshold.
+			"writes": frappe.as_json(a.get("writes") or []),
+			# R5-J11(c): the canonical pack-membership id (a NAME, never the as-coded
+			# predicate) the reviewer two-pack activation gate counts DISTINCT non-empty
+			# values of. Tolerant of an old registry that predates it (``.get`` -> "");
+			# an empty pack id contributes nothing to the distinct-pack count.
+			"rule_pack": (a.get("rule_pack") or "").strip(),
 			# A2: NEVER write a SKILL body into the customer DB — the proprietary
 			# playbook lives only in the private admin bundle store. Every listing
 			# is a body-free stub.

--- a/jarvis/chat/agent_installability.py
+++ b/jarvis/chat/agent_installability.py
@@ -1,0 +1,148 @@
+"""min_apps / required-DocType installability gate (PP-3, R5-P0-05 / R5-J8).
+
+A marketplace capability is INSTALLABLE only when every app in the listing's
+``min_apps`` is installed on the site AND every DocType the listing declares as
+required actually exists. Absence is an install-time NOT-INSTALLABLE STATE
+(typed reason ``app_absent_or_ineligible``) — never a run coverage result: a
+non-installable capability produces no run and no finding.
+
+Two enforcement surfaces, one predicate (``evaluate_installability``):
+
+  * INSTALL TIME — ``install_agent`` and the ``Jarvis Agent Installation``
+    controller ``validate()`` refuse a fresh install when the predicate fails,
+    stamping ``installable`` / ``not_installable_reason`` on the row.
+  * AFTER AN APP/CATALOG CHANGE — ``reconcile_installations`` (wired into
+    ``agent_catalog.after_migrate``) re-evaluates EVERY existing installation and
+    marks it ``installable=0`` + reason when a dependency has since disappeared.
+    It NEVER deletes a row (an install may still reference a retired app once the
+    app is reinstalled the next reconcile clears the flag).
+
+Downstream, the enable / schedule / run-now gates and the container push payload
+refuse / exclude a non-installable row so a dependency that vanished after
+install can never silently keep running.
+
+Test seam — installability reads installed apps through the module-local
+``installed_apps`` accessor, NOT ``frappe.get_installed_apps`` directly, so a
+test can simulate app absence/removal by patching THIS function. Patching the
+framework helper globally breaks Frappe's own hook resolution (the same reason
+``jarvis.site_profile.apps`` keeps its ``_installed_apps`` seam), so the seam is
+the supported simulation point.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe import _
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+
+# The single typed reason this gate ever stamps / throws (a closed-enum member of
+# jarvis_agent_installation.not_installable_reason and coverage_reasons).
+APP_ABSENT = "app_absent_or_ineligible"
+
+
+def installed_apps() -> set[str]:
+	"""The site's installed apps as a set (test seam — patch HERE to simulate
+	absence/removal, never ``frappe.get_installed_apps`` globally). Fails toward
+	the empty set so a lookup hiccup marks a min_apps agent not-installable rather
+	than silently installable."""
+	try:
+		return set(frappe.get_installed_apps())
+	except Exception:
+		frappe.log_error(title="jarvis agent installability: get_installed_apps failed")
+		return set()
+
+
+def _json_list(raw) -> list[str]:
+	try:
+		vals = frappe.parse_json(raw) if raw else []
+	except Exception:
+		vals = []
+	if not isinstance(vals, list):
+		return []
+	return [v.strip() for v in vals if isinstance(v, str) and v.strip()]
+
+
+def min_apps_for(agent: str) -> list[str]:
+	"""The listing's declared ``min_apps`` (deduped, trimmed)."""
+	return _json_list(frappe.db.get_value(LISTING, agent, "min_apps"))
+
+
+def required_doctypes_for(agent: str) -> list[str]:
+	"""The listing's declared ``doctypes_required`` (UNFILTERED — absence is a
+	gate signal, not something to silently drop; the controller preflight decides
+	what to do with a missing one)."""
+	return _json_list(frappe.db.get_value(LISTING, agent, "doctypes_required"))
+
+
+def missing_dependencies(agent: str) -> tuple[list[str], list[str]]:
+	"""``(missing_apps, missing_doctypes)`` for ``agent`` against the current
+	site. A min_app is missing when it is not in ``installed_apps()``; a required
+	DocType is missing when no ``DocType`` row exists for it."""
+	installed = installed_apps()
+	missing_apps = sorted(a for a in min_apps_for(agent) if a not in installed)
+	missing_dts = sorted(d for d in required_doctypes_for(agent) if not frappe.db.exists("DocType", d))
+	return missing_apps, missing_dts
+
+
+def evaluate_installability(agent: str) -> tuple[bool, str | None, str | None]:
+	"""``(installable, reason, detail)``. ``reason``/``detail`` are ``None`` when
+	installable. The predicate: ``min_apps ⊆ installed_apps`` AND every required
+	DocType exists."""
+	missing_apps, missing_dts = missing_dependencies(agent)
+	if not missing_apps and not missing_dts:
+		return True, None, None
+	bits: list[str] = []
+	if missing_apps:
+		bits.append("app(s) {0}".format(", ".join(missing_apps)))
+	if missing_dts:
+		bits.append("DocType(s) {0}".format(", ".join(missing_dts)))
+	detail = "{0} not present on this site".format("; ".join(bits))
+	return False, APP_ABSENT, detail
+
+
+def assert_installable(agent: str) -> None:
+	"""Refuse (``frappe.throw``) when ``agent`` is not installable on this site,
+	surfacing the missing dependency. The typed reason is ``app_absent_or_
+	ineligible`` — the caller stamps the row; this only guards the throw."""
+	ok, _reason, detail = evaluate_installability(agent)
+	if not ok:
+		frappe.throw(
+			_("This agent requires {0}; it cannot be installed or run here.").format(detail),
+			title=_("Agent not installable"),
+		)
+
+
+def reconcile_installations() -> dict:
+	"""Re-evaluate EVERY installation against the current site and persist
+	``installable`` / ``not_installable_reason`` where it changed. Never deletes a
+	row. Idempotent; wired into ``agent_catalog.after_migrate`` so an app install/
+	uninstall (which runs a migrate) or a catalog change re-marks affected rows.
+
+	Uses ``frappe.db.set_value`` (not ``doc.save``) so it bypasses the controller
+	activation/run-as validators — a reconcile must never be blocked by unrelated
+	row state — and never bumps ``modified``."""
+	rows = frappe.get_all(
+		INSTALLATION,
+		fields=["name", "agent", "installable", "not_installable_reason"],
+	)
+	changed = 0
+	for r in rows:
+		ok, reason, _detail = evaluate_installability(r.agent)
+		new_installable = 1 if ok else 0
+		new_reason = "" if ok else reason
+		cur_installable = frappe.utils.cint(r.installable)
+		cur_reason = r.not_installable_reason or ""
+		if cur_installable == new_installable and cur_reason == new_reason:
+			continue
+		frappe.db.set_value(
+			INSTALLATION,
+			r.name,
+			{"installable": new_installable, "not_installable_reason": new_reason},
+			update_modified=False,
+		)
+		changed += 1
+	if changed:
+		frappe.db.commit()
+	return {"reconciled": len(rows), "changed": changed}

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -126,11 +126,7 @@ def _clean_attestation_allowed(result_state: str, findings_count, *, shadow: boo
 	read "no exceptions", closing the false-clean render R4-P0-03/R5 targeted. The
 	sentence is also unconditionally suppressed while the installation is in
 	shadow/preview (PP-4 — a preview issues no outward attestation)."""
-	return (
-		not shadow
-		and result_state == cr.CLEAN_RUN_STATE
-		and int(findings_count or 0) == 0
-	)
+	return not shadow and result_state == cr.CLEAN_RUN_STATE and int(findings_count or 0) == 0
 
 
 def _fallback_dashboard_html(
@@ -220,9 +216,7 @@ def _fallback_dashboard_html(
 			# Not both conditions met: never the clean sentence. An evaluated_clean
 			# verdict with findings present (condition 2 failed) is downgraded to the
 			# non-clean partial-style sentence rather than the "no exceptions" claim.
-			state_for_sentence = (
-				result_state if result_state != cr.CLEAN_RUN_STATE else "partial"
-			)
+			state_for_sentence = result_state if result_state != cr.CLEAN_RUN_STATE else "partial"
 			sentence = _EMPTY_SENTENCE.get(state_for_sentence, _EMPTY_SENTENCE["partial"])
 		rows = (
 			'<tr><td colspan="5" style="padding:14px 10px;color:var(--jarvis-muted,#6b7280)">'

--- a/jarvis/chat/agent_runs.py
+++ b/jarvis/chat/agent_runs.py
@@ -110,6 +110,29 @@ _EMPTY_SENTENCE = {
 }
 
 
+def _clean_attestation_allowed(result_state: str, findings_count, *, shadow: bool) -> bool:
+	"""R5-J1 TWO-CONDITION render gate for the "No exceptions were found" sentence
+	(and any equivalent clean/compliant attestation).
+
+	``run_state`` alone is a COVERAGE verdict — a completed close that surfaced
+	exceptions is still ``evaluated_clean`` (``coverage_reasons.RUN_STATES``). The
+	absence-of-exceptions claim is a SEPARATE, stronger statement, so it may render
+	ONLY when BOTH hold:
+
+	  1. ``result_state == evaluated_clean`` (every required check evaluated), AND
+	  2. the run persisted ZERO findings (``findings_count == 0``).
+
+	A run that evaluated full coverage but DID persist findings therefore can never
+	read "no exceptions", closing the false-clean render R4-P0-03/R5 targeted. The
+	sentence is also unconditionally suppressed while the installation is in
+	shadow/preview (PP-4 — a preview issues no outward attestation)."""
+	return (
+		not shadow
+		and result_state == cr.CLEAN_RUN_STATE
+		and int(findings_count or 0) == 0
+	)
+
+
 def _fallback_dashboard_html(
 	title: str,
 	findings: list,
@@ -177,16 +200,30 @@ def _fallback_dashboard_html(
 			f'<td style="padding:8px 10px;text-align:right;white-space:nowrap">{amt}</td></tr>'
 		)
 	if not rows:
-		# PP-4: in shadow the clean "No exceptions were found" sentence is UNREACHABLE
-		# even when result_state == evaluated_clean — a preview run issues no outward
-		# clean/compliant claim. Otherwise the sentence is PP-2 state-conditional.
+		# R5-J1 two-condition render gate: the clean "No exceptions were found"
+		# sentence renders ONLY when result_state == evaluated_clean AND the run
+		# persisted ZERO findings (``total``), and NEVER while shadow (PP-4 — a
+		# preview issues no outward attestation). ``_clean_attestation_allowed``
+		# is the single predicate both conditions flow through, so a run that
+		# persisted findings can never read "no exceptions" even under full
+		# coverage. For every other case the PP-2 state-conditional (non-clean)
+		# sentence renders; ``evaluated_clean`` WITH findings can never reach the
+		# clean sentence because condition 2 fails.
 		if shadow:
 			sentence = (
 				"Preview (shadow) run — findings are visible to the reviewer only; "
 				"no clean or compliant attestation is issued while this capability is in preview."
 			)
+		elif _clean_attestation_allowed(result_state, total, shadow=shadow):
+			sentence = _EMPTY_SENTENCE["evaluated_clean"]
 		else:
-			sentence = _EMPTY_SENTENCE.get(result_state, _EMPTY_SENTENCE["partial"])
+			# Not both conditions met: never the clean sentence. An evaluated_clean
+			# verdict with findings present (condition 2 failed) is downgraded to the
+			# non-clean partial-style sentence rather than the "no exceptions" claim.
+			state_for_sentence = (
+				result_state if result_state != cr.CLEAN_RUN_STATE else "partial"
+			)
+			sentence = _EMPTY_SENTENCE.get(state_for_sentence, _EMPTY_SENTENCE["partial"])
 		rows = (
 			'<tr><td colspan="5" style="padding:14px 10px;color:var(--jarvis-muted,#6b7280)">'
 			f"{_esc(sentence)}</td></tr>"

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -97,7 +97,9 @@ def run_due_agent_audits() -> None:
 		# disappeared after install (the row is kept, not deleted); its run has no
 		# data. Record why + consume the slot so the cadence does not busy-retry.
 		if not frappe.utils.cint(row.installable):
-			_record_failed(row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)")
+			_record_failed(
+				row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)"
+			)
 			_advance(row, now)
 			continue
 

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -68,7 +68,15 @@ def run_due_agent_audits() -> None:
 	due = frappe.get_all(
 		INSTALLATION,
 		filters={"enabled": 1, "schedule_enabled": 1, "next_run_at": ["<=", now]},
-		fields=["name", "owner", "run_as_user", "agent", "schedule_frequency", "schedule_time"],
+		fields=[
+			"name",
+			"owner",
+			"run_as_user",
+			"agent",
+			"schedule_frequency",
+			"schedule_time",
+			"installable",
+		],
 	)
 	if not due:
 		return
@@ -83,6 +91,15 @@ def run_due_agent_audits() -> None:
 			_advance(row, now)
 			continue
 		seen.add(key)
+
+		# R5-J8: never dispatch a scheduled run for a non-installable capability. A
+		# reconcile marks an install installable=0 when a min_apps dependency
+		# disappeared after install (the row is kept, not deleted); its run has no
+		# data. Record why + consume the slot so the cadence does not busy-retry.
+		if not frappe.utils.cint(row.installable):
+			_record_failed(row, "scheduled audit skipped: capability not installable (app_absent_or_ineligible)")
+			_advance(row, now)
+			continue
 
 		# Only auditor agents run scheduled scans; an operator install with a
 		# schedule set just consumes its slot (it drafts through the board, not

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -912,14 +912,22 @@ def _verify_reviewer_two_pack_capacity(customer: str) -> str:
 	module needs a named reviewer who can own it, so require this customer to have a
 	single named ``reviewer`` who is the reviewer-of-record across installations
 	spanning at least TWO DISTINCT packs. Returns that reviewer; throws if none
-	qualifies. Pack identity is the listing ``rule_pack`` (falling back to the agent
-	slug when a listing declares no pack), so two distinct agents count as two packs."""
+	qualifies.
+
+	R5-J11(c): pack identity is the listing's CANONICAL ``rule_pack`` (a curated
+	pack-membership name synced from the registry) and NOTHING ELSE — the former
+	agent-slug fallback is gone. Two agents in the SAME pack (or two agents whose
+	listings declare NO pack) therefore no longer masquerade as two packs: an empty/
+	missing pack id contributes nothing, so competency is never inferred from agent
+	count (codex R5-P1-02)."""
 	rows = frappe.get_all(INSTALLATION, filters={"owner": customer}, fields=["reviewer", "agent"])
 	packs_by_reviewer: dict[str, set] = {}
 	for r in rows:
 		if not r.reviewer:
 			continue
-		pack = frappe.db.get_value(LISTING, r.agent, "rule_pack") or r.agent
+		pack = (frappe.db.get_value(LISTING, r.agent, "rule_pack") or "").strip()
+		if not pack:
+			continue  # no canonical pack -> contributes nothing (never the slug)
 		packs_by_reviewer.setdefault(r.reviewer, set()).add(pack)
 	for reviewer, packs in packs_by_reviewer.items():
 		if len(packs) >= 2:

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -560,6 +560,13 @@ def install_agent(agent_slug: str) -> dict:
 		frappe.throw(_("This agent is not available to install."))
 	if frappe.db.exists(INSTALLATION, {"owner": me, "agent": listing.name}):
 		frappe.throw(_("You have already installed this agent."))
+	# R5-J8: refuse when the listing's min_apps are not all installed / a required
+	# DocType is absent (typed reason app_absent_or_ineligible). The controller
+	# validate() re-enforces this on every surface; catch it here for a clean,
+	# pre-insert message. A non-installable capability produces no install row.
+	from jarvis.chat.agent_installability import assert_installable
+
+	assert_installable(listing.name)
 
 	sched = {}
 	try:
@@ -613,6 +620,13 @@ def set_enabled(installation: str, enabled: int) -> dict:
 	bundle only reaches the container on the next Apply)."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3 owner-gate
+	# R5-J8: never enable a non-installable capability (a min_apps dependency
+	# absent at install, or one that vanished after install and was reconciled to
+	# installable=0). Disabling is always allowed.
+	if int(enabled or 0):
+		from jarvis.chat.agent_installability import assert_installable
+
+		assert_installable(doc.agent)
 	doc.enabled = int(enabled or 0)
 	doc.save()
 	_mark_catalog_dirty()
@@ -637,6 +651,12 @@ def set_schedule(
 	Recomputes ``next_run_at`` when the schedule is enabled."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3 owner-gate
+	# R5-J8: turning a schedule ON is a run commitment — refuse it for a
+	# non-installable capability (a scheduled run would only fail its preflight).
+	if int(schedule_enabled or 0):
+		from jarvis.chat.agent_installability import assert_installable
+
+		assert_installable(doc.agent)
 	if schedule_enabled is not None:
 		doc.schedule_enabled = int(schedule_enabled or 0)
 	if schedule_frequency is not None:
@@ -809,6 +829,12 @@ def run_agent_now(installation: str) -> dict:
 		)
 	if not doc.enabled:
 		frappe.throw(_("Enable the agent before running it."))
+	# R5-J8: refuse an on-demand run for a non-installable capability — a required
+	# app/DocType that was absent at install or vanished afterward means the run
+	# has no data to evaluate (typed reason app_absent_or_ineligible).
+	from jarvis.chat.agent_installability import assert_installable
+
+	assert_installable(doc.agent)
 	if frappe.db.get_value(LISTING, doc.agent, "nature") != "Auditor":
 		frappe.throw(_("Only auditor agents run on demand; operators draft through the Approval Board."))
 	from jarvis.chat.agent_scheduler import _launch_audit, _over_run_budget, _valid_owner

--- a/jarvis/chat/coverage_reasons.py
+++ b/jarvis/chat/coverage_reasons.py
@@ -80,13 +80,26 @@ STRONG_VERBS = (
 # PP-2 — coverage-verdict run states
 # --------------------------------------------------------------------------- #
 RUN_STATES = (
-	"evaluated_clean",  # every required rule evaluated AND no findings
+	# COVERAGE verdict, NOT a licence to say "clean": every required rule evaluated
+	# to completion. Findings MAY still be present under evaluated_clean (a completed
+	# close that surfaced exceptions) — the verdict is a coverage axis, so
+	# ``evaluated_clean`` does NOT imply zero findings (R5-J1). The old "AND no
+	# findings" gloss conflated the coverage verdict with the render gate below.
+	"evaluated_clean",  # coverage verdict: every required rule evaluated to completion
 	"partial",  # some required rules evaluated, result incomplete
 	"not_evaluable",  # no conclusion possible for the required checks
 	"failed",  # the run produced no result (exec failure)
 )
 
-#: The ONLY run state under which "no exceptions were found" may render.
+#: The coverage verdict that is a PRECONDITION for the "no exceptions were found"
+#: sentence (and any equivalent clean/compliant attestation) — but NOT on its own
+#: sufficient. R5-J1 TWO-CONDITION RENDER RULE: that sentence may render ONLY when
+#: ``run_state == evaluated_clean`` AND the run persisted ZERO findings. A run that
+#: evaluated every required check but DID persist findings is still
+#: ``evaluated_clean`` (the coverage verdict) yet must NEVER read "no exceptions" —
+#: the render layer (``agent_runs._clean_attestation_allowed``) enforces the second
+#: condition, so the coverage verdict and the absence-of-exceptions claim can never
+#: be conflated.
 CLEAN_RUN_STATE = "evaluated_clean"
 
 

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -42,6 +42,7 @@ _GL_SCOPED_DIMENSIONS = (
 class JarvisAgentInstallation(Document):
 	def validate(self):
 		self._default_reviewer()
+		self._guard_installability()
 		self._validate_unique_per_owner()
 		self._validate_owner_cap()
 		self._validate_run_as_user()
@@ -62,6 +63,43 @@ class JarvisAgentInstallation(Document):
 		Frappe's mandatory check, so it satisfies ``reqd`` on every surface."""
 		if not (self.reviewer or "").strip():
 			self.reviewer = self.run_as_user or self.owner or frappe.session.user
+
+	def _guard_installability(self):
+		"""PP-3 / R5-J8: a capability is INSTALLABLE only when its listing's
+		``min_apps`` are all installed AND its required DocTypes all exist. This is
+		the authoritative install-time gate — it runs on EVERY insert/save regardless
+		of surface (SPA / Desk / import / test), so an absent dependency can never
+		enter through a path ``install_agent`` does not own.
+
+		On a FRESH install an unmet dependency is refused (typed reason
+		``app_absent_or_ineligible``) and the row is never created. For an EXISTING
+		row the reconcile hook owns the ``installable`` flag (it marks a row 0 when an
+		app disappears AFTER install, without deleting it); here we only refuse
+		flipping such a row to ``enabled`` — the run/push gates cover the rest. A
+		save that neither installs nor enables (e.g. a config edit on an already
+		non-installable row) is left alone so it can still be repaired/uninstalled."""
+		from jarvis.chat.agent_installability import evaluate_installability
+
+		ok, reason, detail = evaluate_installability(self.agent)
+		if self.is_new():
+			if not ok:
+				self.installable = 0
+				self.not_installable_reason = reason
+				frappe.throw(
+					_("This agent requires {0}; it cannot be installed here.").format(detail),
+					title=_("Agent not installable"),
+				)
+			self.installable = 1
+			self.not_installable_reason = ""
+			return
+		# Existing row: never re-throw merely for being non-installable (reconcile
+		# stamped it; the row must stay editable/uninstallable). But forbid ENABLING
+		# a non-installable capability on ANY surface.
+		if frappe.utils.cint(self.get("enabled")) and not ok:
+			frappe.throw(
+				_("This agent requires {0}; enable it once the dependency is present.").format(detail),
+				title=_("Agent not installable"),
+			)
 
 	def _guard_activation_transition(self):
 		"""PP-4 / PP-6: ``activation_state`` is THE flag. A fresh install is always
@@ -233,6 +271,17 @@ class JarvisAgentInstallation(Document):
 		(fail-closed on a missing read); detect a GL-dimension User Permission and
 		stamp ``scoped_visibility`` (a flag + message for now, not a hard refuse)."""
 		for dt in self._required_doctypes():
+			# R5-J8: an ABSENT required DocType is no longer silently skipped — a
+			# missing app takes its DocTypes with it, and skipping them let a
+			# capability install/run without its data. An absent required DocType
+			# fails the preflight with the SAME typed reason as min_apps
+			# (``app_absent_or_ineligible``), and guards has_permission from a bogus
+			# doctype name.
+			if not frappe.db.exists("DocType", dt):
+				frappe.throw(
+					_("This agent requires DocType {0}, which is not present on this site.").format(dt),
+					title=_("Agent not installable"),
+				)
 			if not frappe.has_permission(dt, "read", user=target):
 				frappe.throw(
 					_("Run-as user {0} lacks read access to {1}, which this agent requires.").format(
@@ -242,16 +291,17 @@ class JarvisAgentInstallation(Document):
 		self.scoped_visibility = 1 if self._detect_scoped_visibility(target) else 0
 
 	def _required_doctypes(self) -> list[str]:
+		# R5-J8: return the FULL declared set (trimmed, non-empty strings) — no
+		# longer silently drop DocTypes that do not exist. Absence is a gate signal
+		# the preflight above acts on, not something to hide.
 		raw = frappe.db.get_value(LISTING, self.agent, "doctypes_required")
 		try:
 			vals = frappe.parse_json(raw) if raw else []
 		except Exception:
 			vals = []
-		# Guard has_permission against a bogus catalog entry; a non-existent
-		# required doctype is a bundle-authoring bug, not a user-perm failure.
-		return [
-			d for d in vals if isinstance(d, str) and d.strip() and frappe.db.exists("DocType", d.strip())
-		]
+		if not isinstance(vals, list):
+			return []
+		return [d.strip() for d in vals if isinstance(d, str) and d.strip()]
 
 	def _detect_scoped_visibility(self, target: str) -> bool:
 		from frappe.permissions import get_user_permissions

--- a/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_listing/jarvis_agent_listing.json
@@ -20,6 +20,7 @@
   "rule_tokens",
   "min_apps",
   "rule_pack",
+  "writes",
   "skill_bundle",
   "default_schedule",
   "validated_for_fy",
@@ -117,7 +118,13 @@
    "fieldname": "rule_pack",
    "fieldtype": "Data",
    "label": "Rule Pack",
-   "description": "Legacy rule-pack identifier. Unused by delegate agents (their evaluation logic lives in the private admin bundle store)."
+   "description": "R5-J11(c) canonical pack membership id for this agent (curated pack map: the 14 domains map onto the 7 packs + measurement). Declarative, non-IP — it is a pack NAME only, never the as-coded predicate. Synced from registry.rule_pack. The reviewer two-pack activation-ceiling gate counts DISTINCT non-empty rule_pack values (never the agent slug), so an empty pack id contributes nothing to the count."
+  },
+  {
+   "fieldname": "writes",
+   "fieldtype": "Small Text",
+   "label": "Writes (JSON)",
+   "description": "R5-J9 declarative operator write contract: JSON array of {doctype, mode} (mode: draft|approval-request; an optional operation/operations key narrows to create|update) the operator is permitted to write. Non-IP metadata mirrored from the bundle-store manifest.writes[]. NULL/empty for auditors (which are refused any write). create_doc/update_doc bind a delegate call to this contract BEFORE Frappe permission checks: a delegate may only create/update a declared doctype, only docstatus==0, and updates only on rows it owns."
   },
   {
    "fieldname": "skill_bundle",

--- a/jarvis/tests/learning/test_e2e_flow.py
+++ b/jarvis/tests/learning/test_e2e_flow.py
@@ -44,6 +44,15 @@ class TestPatternLearningE2E(FrappeTestCase):
 		for n in getattr(cls, "_parked", []):
 			if frappe.db.exists("Jarvis Custom Skill", n):
 				frappe.db.set_value("Jarvis Custom Skill", n, "enabled", 1, update_modified=False)
+		# drop the dedicated role users this suite owns (best-effort; the helper
+		# self-heals their roles on the next run, so a link-blocked delete is fine)
+		for _role in ("Sales User", "Accounts User"):
+			_email = f"e2e-{_role.lower().replace(' ', '-')}@example.com"
+			if frappe.db.exists("User", _email):
+				try:
+					frappe.delete_doc("User", _email, force=True, ignore_permissions=True)
+				except Exception:
+					pass
 		frappe.db.commit()
 		super().tearDownClass()
 
@@ -158,14 +167,28 @@ class TestPatternLearningE2E(FrappeTestCase):
 
 
 def _user_with_role(role):
-	"""Return an existing enabled user holding `role`, or Administrator as a fallback."""
-	users = frappe.get_all("Has Role", filters={"role": role, "parenttype": "User"}, pluck="parent", limit=5)
-	for u in users:
-		if u not in ("Administrator", "Guest") and frappe.db.get_value("User", u, "enabled"):
-			return u
-	# create a throwaway user for the role
+	"""Return a dedicated, enabled test user holding EXACTLY ``role``.
+
+	Turn-injection scoping is asserted both ways, so the mismatched-role user
+	must hold the target role yet be NEITHER privileged (Administrator / System
+	Manager, which ``learned_skill_clause`` auto-passes) NOR a holder of the
+	positive role. An ambient bench user cannot promise that: on a shared dev
+	box - or a multi-module CI run where an earlier suite commits fixtures - the
+	first ``Has Role`` match for e.g. "Accounts User" is frequently a user that
+	also carries System Manager, which folds every managed skill into the clause
+	and defeats scoping (the historical flake: acct_clause == sales_clause). So
+	we own the user outright - deterministic email, roles reconciled to exactly
+	the target, enabled, per-user roles cache dropped - making the assertion
+	independent of suite ordering and ambient residue.
+	"""
 	email = f"e2e-{role.lower().replace(' ', '-')}@example.com"
-	if not frappe.db.exists("User", email):
+	if frappe.db.exists("User", email):
+		u = frappe.get_doc("User", email)
+		u.enabled = 1
+		u.set("roles", [{"role": role}])
+		u.flags.ignore_permissions = True
+		u.save()
+	else:
 		u = frappe.get_doc(
 			{
 				"doctype": "User",
@@ -177,5 +200,8 @@ def _user_with_role(role):
 		)
 		u.flags.ignore_permissions = True
 		u.insert()
-		frappe.db.commit()
+	frappe.db.commit()
+	# roles ride frappe.get_roles' per-user redis cache, which is NOT bypassed
+	# under in_test; drop it so learned_skill_clause reads the reconciled set.
+	frappe.clear_cache(user=email)
 	return email

--- a/jarvis/tests/test_platform_activation.py
+++ b/jarvis/tests/test_platform_activation.py
@@ -76,8 +76,16 @@ def _mk_listing() -> str:
 				"title": "Platform Activation Test Agent",
 				"rule_tokens": json.dumps([TOKEN]),
 				"doctypes_required": json.dumps([]),
+				# R5-J11(c): a CANONICAL pack id. The reviewer two-pack ceiling gate now
+				# counts distinct non-empty rule_pack values (never the agent slug), so the
+				# activation-ceiling tests must give SLUG and SLUG-b DISTINCT canonical packs
+				# to legitimately reach a two-pack reviewer competency.
+				"rule_pack": "pack-activation-a",
 			}
 		).insert(ignore_permissions=True)
+	# The listing persists across runs (never wiped); ensure the canonical pack is set
+	# even on a row created by a pre-R5-J11(c) run so the two-pack gate can qualify.
+	frappe.db.set_value(LISTING, SLUG, "rule_pack", "pack-activation-a", update_modified=False)
 	return SLUG
 
 
@@ -402,8 +410,14 @@ class TestPP4PromotionAndPP6Budget(FrappeTestCase):
 					"title": "Platform Activation Test Agent B",
 					"rule_tokens": json.dumps([TOKEN]),
 					"doctypes_required": json.dumps([]),
+					# R5-J11(c): a DISTINCT canonical pack from SLUG so the reviewer covers
+					# two distinct non-empty packs (the two-pack ceiling gate no longer
+					# infers a pack from the agent slug).
+					"rule_pack": "pack-activation-b",
 				}
 			).insert(ignore_permissions=True)
+		# Ensure the canonical pack is set even on a listing left by a pre-R5-J11(c) run.
+		frappe.db.set_value(LISTING, slug2, "rule_pack", "pack-activation-b", update_modified=False)
 		doc = frappe.get_doc(
 			{
 				"doctype": INSTALLATION,

--- a/jarvis/tests/test_platform_agents_api_hardening.py
+++ b/jarvis/tests/test_platform_agents_api_hardening.py
@@ -56,6 +56,10 @@ def _mk_user(email: str) -> str:
 
 
 def _mk_listing(slug: str) -> str:
+	# One synthetic pack per agent: the two-pack ceiling preflight counts distinct
+	# non-empty rule_pack values (R5-P1-02 — the agent-slug fallback is gone), so
+	# the "reviewer covers two packs" scaffolding these tests rely on must declare
+	# real pack ids. Distinct-per-slug preserves the original intent exactly.
 	if not frappe.db.exists(LISTING, slug):
 		frappe.get_doc(
 			{
@@ -64,8 +68,12 @@ def _mk_listing(slug: str) -> str:
 				"title": f"Hardening {slug}",
 				"rule_tokens": json.dumps(["tok"]),
 				"doctypes_required": json.dumps([]),
+				"rule_pack": f"pack-{slug}",
 			}
 		).insert(ignore_permissions=True)
+	else:
+		# A listing left by an earlier run may predate the rule_pack field.
+		frappe.db.set_value(LISTING, slug, "rule_pack", f"pack-{slug}", update_modified=False)
 	return slug
 
 

--- a/jarvis/tests/test_platform_min_apps.py
+++ b/jarvis/tests/test_platform_min_apps.py
@@ -111,7 +111,9 @@ def _install_as(owner: str, slug: str) -> str:
 
 def _wipe():
 	for dt in (RUN, INSTALLATION):
-		for n in frappe.get_all(dt, filters={"agent": ["in", _ALL_SLUGS]}, pluck="name", ignore_permissions=True):
+		for n in frappe.get_all(
+			dt, filters={"agent": ["in", _ALL_SLUGS]}, pluck="name", ignore_permissions=True
+		):
 			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
 	for slug in _ALL_SLUGS:
 		if frappe.db.exists(LISTING, slug):
@@ -174,9 +176,7 @@ class TestMinAppsGate(FrappeTestCase):
 		with self.assertRaises(frappe.ValidationError):
 			_install_as(self.owner, SLUG_MISS_APP)
 		# No install row is created for a non-installable capability.
-		self.assertFalse(
-			frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_APP})
-		)
+		self.assertFalse(frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_APP}))
 
 	def test_install_refused_when_required_doctype_absent(self):
 		"""Previously this installed (the absent DocType was filtered out); now it
@@ -184,9 +184,7 @@ class TestMinAppsGate(FrappeTestCase):
 		_mk_listing(SLUG_MISS_DT, doctypes_required=[PHANTOM_DOCTYPE])
 		with self.assertRaises(frappe.ValidationError):
 			_install_as(self.owner, SLUG_MISS_DT)
-		self.assertFalse(
-			frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_DT})
-		)
+		self.assertFalse(frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_DT}))
 
 	def test_controller_enforces_on_direct_insert(self):
 		"""The gate lives in validate(), so a Desk/import/direct insert is refused
@@ -218,9 +216,7 @@ class TestMinAppsGate(FrappeTestCase):
 		# The phantom app is "removed": reconcile against the real site (no phantom).
 		res = agent_installability.reconcile_installations()
 		self.assertGreaterEqual(res["changed"], 1)
-		row = frappe.db.get_value(
-			INSTALLATION, inst, ["installable", "not_installable_reason"], as_dict=True
-		)
+		row = frappe.db.get_value(INSTALLATION, inst, ["installable", "not_installable_reason"], as_dict=True)
 		self.assertEqual(row.installable, 0)
 		self.assertEqual(row.not_installable_reason, "app_absent_or_ineligible")
 		# NEVER deleted — the row survives so a reinstall can restore it.

--- a/jarvis/tests/test_platform_min_apps.py
+++ b/jarvis/tests/test_platform_min_apps.py
@@ -1,0 +1,360 @@
+"""R5-P0-05 / R5-J8 — min_apps + required-DocType installability gate.
+
+A marketplace capability is INSTALLABLE only when every app in its listing's
+``min_apps`` is installed AND every required DocType exists. Absence is an
+install-time NOT-INSTALLABLE state (typed reason ``app_absent_or_ineligible``),
+never a run coverage result. This module proves:
+
+  * INSTALL refuses an unmet min_apps subset (initial absence) and an absent
+    required DocType — with the typed reason, and no install row is created.
+  * The ``_required_doctypes`` preflight STOPS silently filtering absent
+    DocTypes (an absent required DocType now fails, where it used to install).
+  * A RECONCILE (the migrate/app-change hook) marks an EXISTING install
+    ``installable=0`` + reason when a dependency disappears AFTER install, never
+    deleting the row, and clears it again when the dependency returns.
+  * ENABLE / SCHEDULE / RUN-NOW refuse a non-installable capability.
+  * The container push payload EXCLUDES, and the scheduler due-loop SKIPS, a
+    non-installable enabled install (a dependency that vanished after install).
+  * A non-installable install is still repairable/uninstallable.
+
+App absence/removal is simulated by patching the module-local
+``agent_installability.installed_apps`` seam (patching ``frappe.get_installed_apps``
+globally breaks Frappe's own hook resolution). A phantom app id
+(``PHANTOM_APP``) that is never really installed keeps every reconcile scoped to
+THIS module's install — reconcile is a whole-site sweep, so it must never flip a
+sibling agent whose real dependency is unchanged.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_min_apps
+"""
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_catalog, agent_installability, agent_scheduler, agents_api
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+
+# A min_app id that is never really installed on any site — the scoped lever for
+# simulating an app that was present at install then removed.
+PHANTOM_APP = "min_apps_test_phantom_app"
+PHANTOM_DOCTYPE = "Min Apps Test Phantom DocType"
+
+SLUG_MISS_APP = "min-apps-test-missing-app"
+SLUG_MISS_DT = "min-apps-test-missing-doctype"
+SLUG_REMOVABLE = "min-apps-test-removable"  # min_apps includes PHANTOM_APP
+
+_ALL_SLUGS = (SLUG_MISS_APP, SLUG_MISS_DT, SLUG_REMOVABLE)
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		)
+		u.insert(ignore_permissions=True)
+		u.add_roles("Jarvis User")
+	return email
+
+
+def _mk_listing(slug: str, *, min_apps=None, doctypes_required=None) -> str:
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": LISTING,
+			"agent_slug": slug,
+			"title": slug.replace("-", " ").title(),
+			"nature": "Auditor",
+			"status": "Published",
+			"delivery": "delegate",
+			"version": "1.0.0",
+			"min_apps": json.dumps(min_apps or []),
+			"doctypes_required": json.dumps(doctypes_required or []),
+			"rule_tokens": json.dumps([]),
+		}
+	).insert(ignore_permissions=True)
+	return slug
+
+
+def _installed_plus_phantom():
+	"""The real installed apps PLUS the phantom — the 'app present' world."""
+	return set(frappe.get_installed_apps()) | {PHANTOM_APP}
+
+
+def _patch_apps(app_set):
+	return patch.object(agent_installability, "installed_apps", return_value=set(app_set))
+
+
+def _install_as(owner: str, slug: str) -> str:
+	original = frappe.session.user
+	frappe.set_user(owner)
+	try:
+		res = agents_api.install_agent(slug)
+		return res["data"]["name"]
+	finally:
+		frappe.set_user(original)
+
+
+def _wipe():
+	for dt in (RUN, INSTALLATION):
+		for n in frappe.get_all(dt, filters={"agent": ["in", _ALL_SLUGS]}, pluck="name", ignore_permissions=True):
+			frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+	for slug in _ALL_SLUGS:
+		if frappe.db.exists(LISTING, slug):
+			frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.db.commit()
+
+
+class TestMinAppsGate(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("min-apps-owner@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_wipe()
+
+	# ------------------------------------------------------------------ #
+	# unit predicate
+	# ------------------------------------------------------------------ #
+	def test_predicate_and_reason(self):
+		_mk_listing(SLUG_MISS_APP, min_apps=[PHANTOM_APP])
+		ok, reason, detail = agent_installability.evaluate_installability(SLUG_MISS_APP)
+		self.assertFalse(ok)
+		self.assertEqual(reason, "app_absent_or_ineligible")
+		self.assertIn(PHANTOM_APP, detail)
+
+		_mk_listing(SLUG_MISS_DT, doctypes_required=[PHANTOM_DOCTYPE])
+		ok2, reason2, detail2 = agent_installability.evaluate_installability(SLUG_MISS_DT)
+		self.assertFalse(ok2)
+		self.assertEqual(reason2, "app_absent_or_ineligible")
+		self.assertIn(PHANTOM_DOCTYPE, detail2)
+
+		# erpnext is installed on the bench; an erpnext-only agent is installable.
+		_mk_listing(SLUG_REMOVABLE, min_apps=["erpnext"])
+		ok3, reason3, _ = agent_installability.evaluate_installability(SLUG_REMOVABLE)
+		self.assertTrue(ok3)
+		self.assertIsNone(reason3)
+
+	def test_required_doctypes_no_longer_filters_absent(self):
+		"""R5-J8: the controller's _required_doctypes returns the FULL declared
+		set — absent DocTypes are no longer silently dropped."""
+		_mk_listing(SLUG_MISS_DT, doctypes_required=["Company", PHANTOM_DOCTYPE])
+		# required_doctypes_for is the unfiltered reader the controller mirrors.
+		got = agent_installability.required_doctypes_for(SLUG_MISS_DT)
+		self.assertIn("Company", got)
+		self.assertIn(PHANTOM_DOCTYPE, got)
+
+	# ------------------------------------------------------------------ #
+	# initial absence — install refuses
+	# ------------------------------------------------------------------ #
+	def test_install_refused_when_min_app_absent(self):
+		_mk_listing(SLUG_MISS_APP, min_apps=[PHANTOM_APP])
+		with self.assertRaises(frappe.ValidationError):
+			_install_as(self.owner, SLUG_MISS_APP)
+		# No install row is created for a non-installable capability.
+		self.assertFalse(
+			frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_APP})
+		)
+
+	def test_install_refused_when_required_doctype_absent(self):
+		"""Previously this installed (the absent DocType was filtered out); now it
+		fails the preflight with the same typed reason."""
+		_mk_listing(SLUG_MISS_DT, doctypes_required=[PHANTOM_DOCTYPE])
+		with self.assertRaises(frappe.ValidationError):
+			_install_as(self.owner, SLUG_MISS_DT)
+		self.assertFalse(
+			frappe.db.exists(INSTALLATION, {"owner": self.owner, "agent": SLUG_MISS_DT})
+		)
+
+	def test_controller_enforces_on_direct_insert(self):
+		"""The gate lives in validate(), so a Desk/import/direct insert is refused
+		too, not only the install_agent endpoint."""
+		_mk_listing(SLUG_MISS_APP, min_apps=[PHANTOM_APP])
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": SLUG_MISS_APP,
+				"run_as_user": self.owner,
+				"reviewer": self.owner,
+				"activation_state": "shadow",
+			}
+		)
+		doc.owner = self.owner
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	# ------------------------------------------------------------------ #
+	# app-removal-after-install — reconcile marks installable=0, never deletes
+	# ------------------------------------------------------------------ #
+	def test_reconcile_marks_non_installable_after_app_removed(self):
+		_mk_listing(SLUG_REMOVABLE, min_apps=["erpnext", PHANTOM_APP])
+		# Install while the phantom app is "present".
+		with _patch_apps(_installed_plus_phantom()):
+			inst = _install_as(self.owner, SLUG_REMOVABLE)
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "installable"), 1)
+
+		# The phantom app is "removed": reconcile against the real site (no phantom).
+		res = agent_installability.reconcile_installations()
+		self.assertGreaterEqual(res["changed"], 1)
+		row = frappe.db.get_value(
+			INSTALLATION, inst, ["installable", "not_installable_reason"], as_dict=True
+		)
+		self.assertEqual(row.installable, 0)
+		self.assertEqual(row.not_installable_reason, "app_absent_or_ineligible")
+		# NEVER deleted — the row survives so a reinstall can restore it.
+		self.assertTrue(frappe.db.exists(INSTALLATION, inst))
+
+		# The app returns: reconcile clears the flag and the reason.
+		with _patch_apps(_installed_plus_phantom()):
+			agent_installability.reconcile_installations()
+		row2 = frappe.db.get_value(
+			INSTALLATION, inst, ["installable", "not_installable_reason"], as_dict=True
+		)
+		self.assertEqual(row2.installable, 1)
+		self.assertIn(row2.not_installable_reason, (None, ""))
+
+	def test_reconcile_leaves_installable_siblings_untouched(self):
+		"""A whole-site reconcile driven by the phantom's absence must not flip an
+		agent whose real dependency (erpnext) is unchanged."""
+		_mk_listing(SLUG_REMOVABLE, min_apps=["erpnext", PHANTOM_APP])
+		_mk_listing(SLUG_MISS_APP, min_apps=["erpnext"])  # reuse slug as an erpnext sibling
+		with _patch_apps(_installed_plus_phantom()):
+			removable = _install_as(self.owner, SLUG_REMOVABLE)
+			sibling = _install_as(self.owner, SLUG_MISS_APP)
+		agent_installability.reconcile_installations()
+		self.assertEqual(frappe.db.get_value(INSTALLATION, removable, "installable"), 0)
+		self.assertEqual(frappe.db.get_value(INSTALLATION, sibling, "installable"), 1)
+
+	# ------------------------------------------------------------------ #
+	# enable / schedule / run-now refuse a non-installable capability
+	# ------------------------------------------------------------------ #
+	def _install_removable_enabled_off(self) -> str:
+		_mk_listing(SLUG_REMOVABLE, min_apps=["erpnext", PHANTOM_APP])
+		with _patch_apps(_installed_plus_phantom()):
+			return _install_as(self.owner, SLUG_REMOVABLE)
+
+	def test_enable_refused_when_not_installable(self):
+		inst = self._install_removable_enabled_off()
+		frappe.set_user(self.owner)
+		try:
+			# Phantom absent (no patch) -> the live predicate refuses enabling.
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_enabled(inst, 1)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "enabled"), 0)
+
+	def test_schedule_enable_refused_when_not_installable(self):
+		inst = self._install_removable_enabled_off()
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_schedule(inst, schedule_enabled=1, schedule_frequency="daily")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_run_now_refused_when_not_installable(self):
+		inst = self._install_removable_enabled_off()
+		# Simulate 'was enabled while installable, app later removed'.
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1, update_modified=False)
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.run_agent_now(inst)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_enable_still_allowed_when_installable(self):
+		inst = self._install_removable_enabled_off()
+		frappe.set_user(self.owner)
+		try:
+			with _patch_apps(_installed_plus_phantom()):
+				agents_api.set_enabled(inst, 1)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "enabled"), 1)
+
+	# ------------------------------------------------------------------ #
+	# push payload + scheduler exclude a reconciled non-installable row
+	# ------------------------------------------------------------------ #
+	def test_push_payload_excludes_non_installable(self):
+		inst = self._install_removable_enabled_off()
+		frappe.db.set_value(
+			INSTALLATION,
+			inst,
+			{"enabled": 1, "installable": 0, "not_installable_reason": "app_absent_or_ineligible"},
+			update_modified=False,
+		)
+		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
+		slugs = {p["slug"] for p in payload}
+		self.assertNotIn(f"agent-{SLUG_REMOVABLE}", slugs)
+
+	def test_scheduler_skips_non_installable(self):
+		inst = self._install_removable_enabled_off()
+		past = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1)
+		frappe.db.set_value(
+			INSTALLATION,
+			inst,
+			{
+				"enabled": 1,
+				"schedule_enabled": 1,
+				"schedule_frequency": "daily",
+				"schedule_time": "09:00:00",
+				"next_run_at": past,
+				"installable": 0,
+				"not_installable_reason": "app_absent_or_ineligible",
+			},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		agent_scheduler.run_due_agent_audits()
+		# Skipped: no dispatched (running/complete) run; a failed record explains why.
+		live = frappe.get_all(
+			RUN, filters={"installation": inst, "status": ["in", ("running", "complete")]}, pluck="name"
+		)
+		self.assertEqual(live, [])
+		failed = frappe.get_all(RUN, filters={"installation": inst, "status": "failed"}, fields=["error"])
+		self.assertTrue(any("app_absent_or_ineligible" in (f.error or "") for f in failed))
+		# The slot was consumed — next_run_at advanced into the future.
+		nxt = frappe.db.get_value(INSTALLATION, inst, "next_run_at")
+		self.assertGreater(frappe.utils.get_datetime(nxt), frappe.utils.now_datetime())
+
+	# ------------------------------------------------------------------ #
+	# a non-installable install is still repairable / uninstallable
+	# ------------------------------------------------------------------ #
+	def test_non_installable_install_can_be_uninstalled(self):
+		inst = self._install_removable_enabled_off()
+		frappe.db.set_value(
+			INSTALLATION,
+			inst,
+			{"installable": 0, "not_installable_reason": "app_absent_or_ineligible"},
+			update_modified=False,
+		)
+		frappe.set_user(self.owner)
+		try:
+			agents_api.uninstall_agent(inst)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertFalse(frappe.db.exists(INSTALLATION, inst))

--- a/jarvis/tests/test_platform_render_gate.py
+++ b/jarvis/tests/test_platform_render_gate.py
@@ -132,29 +132,19 @@ def _wipe_residue() -> None:
 # --------------------------------------------------------------------------- #
 class TestCleanAttestationPredicate(FrappeTestCase):
 	def test_clean_and_zero_findings_allows_sentence(self):
-		self.assertTrue(
-			agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=False)
-		)
+		self.assertTrue(agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=False))
 
 	def test_clean_but_findings_present_suppresses_sentence(self):
 		# THE R5-J1 gate: full coverage (evaluated_clean) but findings > 0 => no claim.
-		self.assertFalse(
-			agent_runs._clean_attestation_allowed("evaluated_clean", 4, shadow=False)
-		)
-		self.assertFalse(
-			agent_runs._clean_attestation_allowed("evaluated_clean", 1, shadow=False)
-		)
+		self.assertFalse(agent_runs._clean_attestation_allowed("evaluated_clean", 4, shadow=False))
+		self.assertFalse(agent_runs._clean_attestation_allowed("evaluated_clean", 1, shadow=False))
 
 	def test_non_clean_state_never_allows_sentence(self):
 		for state in ("partial", "not_evaluable", "failed"):
-			self.assertFalse(
-				agent_runs._clean_attestation_allowed(state, 0, shadow=False), state
-			)
+			self.assertFalse(agent_runs._clean_attestation_allowed(state, 0, shadow=False), state)
 
 	def test_shadow_never_allows_sentence(self):
-		self.assertFalse(
-			agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=True)
-		)
+		self.assertFalse(agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=True))
 
 
 # --------------------------------------------------------------------------- #
@@ -174,7 +164,10 @@ class TestFallbackDashboardRenderGate(FrappeTestCase):
 
 	def test_clean_state_zero_findings_renders_sentence(self):
 		html = agent_runs._fallback_dashboard_html(
-			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "",
+			"T",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"",
 			result_state="evaluated_clean",
 		)
 		self.assertIn(CLEAN_SENTENCE, html)
@@ -185,7 +178,10 @@ class TestFallbackDashboardRenderGate(FrappeTestCase):
 		# coverage HEADING still renders (the coverage verdict is honest — R5-J1),
 		# but the "No exceptions were found" SENTENCE must NOT.
 		html = agent_runs._fallback_dashboard_html(
-			"T", [self._finding()], {"blocker": 1, "warning": 0, "note": 0}, "",
+			"T",
+			[self._finding()],
+			{"blocker": 1, "warning": 0, "note": 0},
+			"",
 			result_state="evaluated_clean",
 		)
 		self.assertNotIn(CLEAN_SENTENCE, html)
@@ -193,7 +189,10 @@ class TestFallbackDashboardRenderGate(FrappeTestCase):
 
 	def test_partial_zero_findings_never_clean_sentence(self):
 		html = agent_runs._fallback_dashboard_html(
-			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "",
+			"T",
+			[],
+			{"blocker": 0, "warning": 0, "note": 0},
+			"",
 			result_state="partial",
 		)
 		self.assertNotIn(CLEAN_SENTENCE, html)

--- a/jarvis/tests/test_platform_render_gate.py
+++ b/jarvis/tests/test_platform_render_gate.py
@@ -1,0 +1,274 @@
+"""Regression tests for the R5-J1 two-condition "no exceptions" render gate
+(``jarvis/chat/agent_runs.py``).
+
+``run_state`` is a COVERAGE verdict: a completed close that surfaced exceptions is
+still ``evaluated_clean`` (``coverage_reasons.RUN_STATES``). The absence-of-exceptions
+sentence ("No exceptions were found") is a stronger, separate claim and may render
+ONLY when BOTH hold:
+
+  1. ``result_state == evaluated_clean`` (every required check evaluated), AND
+  2. the run persisted ZERO findings.
+
+These tests prove that a run with FULL coverage but findings PRESENT resolves
+``evaluated_clean`` (legal — close-auditor's golden shape) yet its truthful fallback
+dashboard never emits the clean sentence — closing the false-clean render
+R4-P0-03/R5 targeted — while the clean coverage HEADING (the coverage verdict) still
+renders honestly alongside the findings.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_render_gate
+"""
+
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_runs
+from jarvis.chat import coverage_reasons as cr
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+FINDING = "Jarvis Agent Finding"
+PROVENANCE = "Jarvis Agent Provenance Event"
+DASHBOARD = "Jarvis Dashboard"
+
+SLUG = "platform-render-gate-test-agent"
+TOK_A = "tok_rg_a"
+TOK_B = "tok_rg_b"
+
+CLEAN_SENTENCE = "No exceptions were found"
+CLEAN_HEADING = "Evaluated — clean coverage"
+
+
+def _mk_user(email: str) -> str:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	return email
+
+
+def _mk_listing() -> str:
+	if not frappe.db.exists(LISTING, SLUG):
+		frappe.get_doc(
+			{
+				"doctype": LISTING,
+				"agent_slug": SLUG,
+				"title": "Platform Render-Gate Test Agent",
+				# DECLARED required manifest: two tokens (the authoritative bar).
+				"rule_tokens": json.dumps([TOK_A, TOK_B]),
+				# Empty required set: the installation preflight then needs no run-as read
+				# grant. record_delegate_run persists findings as-passed (the tool, not
+				# this path, gates ref doctypes), so a Company-ref finding still lands.
+				"doctypes_required": json.dumps([]),
+			}
+		).insert(ignore_permissions=True)
+	return SLUG
+
+
+def _mk_installation(owner: str) -> object:
+	name = frappe.db.get_value(INSTALLATION, {"agent": SLUG, "owner": owner}, "name")
+	if name:
+		return frappe.get_doc(INSTALLATION, name)
+	doc = frappe.get_doc({"doctype": INSTALLATION, "agent": SLUG, "run_as_user": owner, "reviewer": owner})
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value(INSTALLATION, doc.name, "owner", owner, update_modified=False)
+	# Promote to live so the fallback dashboard issues an outward attestation (shadow
+	# would suppress the clean sentence for a different, PP-4 reason — we test the
+	# R5-J1 findings-count gate, not the shadow gate, here).
+	frappe.db.set_value(INSTALLATION, doc.name, "activation_state", "live", update_modified=False)
+	return frappe.get_doc(INSTALLATION, doc.name)
+
+
+def _mk_run(owner: str) -> object:
+	doc = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": SLUG,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": frappe.generate_hash(length=24),
+		}
+	)
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _wipe_residue() -> None:
+	"""Slug-scoped teardown (mirrors test_platform_false_clean._wipe_residue): remove
+	every Run / Finding / Provenance / Dashboard row this module persisted under its
+	test-agent slug. Raw delete + commit (also bypasses the append-only Provenance
+	on_trash guard, legitimate for this module's OWN test residue)."""
+	dashboards = [
+		d
+		for d in frappe.get_all(RUN, filters={"agent": SLUG}, pluck="dashboard", ignore_permissions=True)
+		if d
+	]
+	frappe.db.delete(RUN, {"agent": SLUG})
+	frappe.db.delete(FINDING, {"agent": SLUG})
+	frappe.db.delete(PROVENANCE, {"agent": SLUG})
+	if dashboards:
+		frappe.db.delete(DASHBOARD, {"name": ["in", dashboards]})
+	frappe.db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# Unit — the two-condition predicate itself
+# --------------------------------------------------------------------------- #
+class TestCleanAttestationPredicate(FrappeTestCase):
+	def test_clean_and_zero_findings_allows_sentence(self):
+		self.assertTrue(
+			agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=False)
+		)
+
+	def test_clean_but_findings_present_suppresses_sentence(self):
+		# THE R5-J1 gate: full coverage (evaluated_clean) but findings > 0 => no claim.
+		self.assertFalse(
+			agent_runs._clean_attestation_allowed("evaluated_clean", 4, shadow=False)
+		)
+		self.assertFalse(
+			agent_runs._clean_attestation_allowed("evaluated_clean", 1, shadow=False)
+		)
+
+	def test_non_clean_state_never_allows_sentence(self):
+		for state in ("partial", "not_evaluable", "failed"):
+			self.assertFalse(
+				agent_runs._clean_attestation_allowed(state, 0, shadow=False), state
+			)
+
+	def test_shadow_never_allows_sentence(self):
+		self.assertFalse(
+			agent_runs._clean_attestation_allowed("evaluated_clean", 0, shadow=True)
+		)
+
+
+# --------------------------------------------------------------------------- #
+# Unit — the render itself (the truthful fallback dashboard path)
+# --------------------------------------------------------------------------- #
+class TestFallbackDashboardRenderGate(FrappeTestCase):
+	def _finding(self):
+		return {
+			"token": TOK_A,
+			"ref_doctype": "Company",
+			"ref_name": "Acme",
+			"amount": 100.0,
+			"severity": "blocker",
+			"result_class": "observed_fact",
+			"note": "Trial balance does not balance.",
+		}
+
+	def test_clean_state_zero_findings_renders_sentence(self):
+		html = agent_runs._fallback_dashboard_html(
+			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "",
+			result_state="evaluated_clean",
+		)
+		self.assertIn(CLEAN_SENTENCE, html)
+		self.assertIn(CLEAN_HEADING, html)
+
+	def test_clean_state_with_findings_suppresses_sentence(self):
+		# FULL coverage verdict (evaluated_clean) but findings PRESENT: the clean
+		# coverage HEADING still renders (the coverage verdict is honest — R5-J1),
+		# but the "No exceptions were found" SENTENCE must NOT.
+		html = agent_runs._fallback_dashboard_html(
+			"T", [self._finding()], {"blocker": 1, "warning": 0, "note": 0}, "",
+			result_state="evaluated_clean",
+		)
+		self.assertNotIn(CLEAN_SENTENCE, html)
+		self.assertIn(CLEAN_HEADING, html)  # coverage verdict heading is legal
+
+	def test_partial_zero_findings_never_clean_sentence(self):
+		html = agent_runs._fallback_dashboard_html(
+			"T", [], {"blocker": 0, "warning": 0, "note": 0}, "",
+			result_state="partial",
+		)
+		self.assertNotIn(CLEAN_SENTENCE, html)
+
+
+# --------------------------------------------------------------------------- #
+# Integration — through record_delegate_run: full coverage + findings present
+# resolves evaluated_clean, but the persisted dashboard omits the clean sentence.
+# --------------------------------------------------------------------------- #
+class TestRenderGateEndToEnd(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.owner = _mk_user("rg-owner@example.com")
+		_mk_listing()
+		cls.company = frappe.db.get_value("Company", {}, "name")
+		cls.inst = _mk_installation(cls.owner)
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		_wipe_residue()
+		super().tearDownClass()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def _dashboard_html(self, run) -> str:
+		run.reload()
+		name = frappe.db.get_value(RUN, run.name, "dashboard")
+		self.assertTrue(name, "run produced no dashboard")
+		return frappe.db.get_value(DASHBOARD, name, "html") or ""
+
+	def test_full_coverage_with_findings_is_clean_verdict_but_no_sentence(self):
+		run = _mk_run(self.owner)
+		finding = {
+			"token": TOK_A,
+			"ref_doctype": "Company",
+			"ref_name": self.company,
+			"amount": 100.0,
+			"severity": "blocker",
+			"result_class": "observed_fact",
+			"note": "Trial balance does not balance.",
+		}
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[finding],
+			coverage={TOK_A: "evaluated", TOK_B: "evaluated"},
+			scope={"company": self.company},
+		)
+		run.reload()
+		# COVERAGE verdict is clean (every declared check evaluated) — legal per R5-J1.
+		self.assertEqual(run.result_state, "evaluated_clean")
+		# A finding persisted.
+		persisted = frappe.get_all(FINDING, filters={"run": run.name}, ignore_permissions=True)
+		self.assertEqual(len(persisted), 1)
+		# The truthful fallback dashboard shows the findings table, NEVER the clean
+		# "No exceptions were found" sentence (condition 2 — zero findings — fails).
+		html = self._dashboard_html(run)
+		self.assertNotIn(CLEAN_SENTENCE, html)
+
+	def test_full_coverage_zero_findings_is_clean_and_renders_sentence(self):
+		run = _mk_run(self.owner)
+		agent_runs.record_delegate_run(
+			run,
+			self.inst,
+			[],
+			coverage={TOK_A: "evaluated", TOK_B: "evaluated"},
+			scope={"company": self.company},
+		)
+		run.reload()
+		self.assertEqual(run.result_state, "evaluated_clean")
+		html = self._dashboard_html(run)
+		# BOTH conditions met (clean verdict + zero findings) => sentence renders.
+		self.assertIn(CLEAN_SENTENCE, html)

--- a/jarvis/tests/test_platform_write_caps.py
+++ b/jarvis/tests/test_platform_write_caps.py
@@ -258,7 +258,9 @@ class TestPackDerivedCeiling(FrappeTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		for slug in (self.A, self.B):
-			for n in frappe.get_all(INSTALLATION, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+			for n in frappe.get_all(
+				INSTALLATION, filters={"agent": slug}, pluck="name", ignore_permissions=True
+			):
 				frappe.delete_doc(INSTALLATION, n, force=True, ignore_permissions=True)
 			if frappe.db.exists(LISTING, slug):
 				frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)

--- a/jarvis/tests/test_platform_write_caps.py
+++ b/jarvis/tests/test_platform_write_caps.py
@@ -1,0 +1,352 @@
+"""R5-J9 + R5-J11(c) — delegate write capabilities and pack-derived ceiling counting.
+
+R5-P0-04 (operator ``writes[]`` are runtime capabilities): a ``jarvis__create_doc`` /
+``jarvis__update_doc`` call arriving over a DELEGATE run session is bounded by the
+agent's declared ``writes[]`` contract BEFORE any Frappe permission check —
+
+  * an AUDITOR (empty ``writes``) is refused every write outright;
+  * an OPERATOR may create/update ONLY a doctype in ``writes[]``, ONLY a draft
+    (``docstatus == 0``), and updates ONLY a row it owns (its run-as identity);
+  * a NON-delegate caller (standard chat / macro / test — no bound Run) is left
+    completely untouched.
+
+R5-P1-02 (``_verify_reviewer_two_pack_capacity`` slug fallback): the reviewer
+two-pack activation-ceiling gate now counts DISTINCT non-empty canonical
+``rule_pack`` values and never infers a pack from the agent slug, so two agents in
+one pack (or two agents with no declared pack) no longer masquerade as two packs.
+
+Also covers ``agent_catalog.sync_agent_listings`` storing the registry ``writes[]``
+and ``rule_pack`` (tolerant of a registry that predates the fields).
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_write_caps
+"""
+
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import agent_catalog, agents_api
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.tools import _agent_run_ctx
+from jarvis.tools.create_doc import create_doc
+from jarvis.tools.update_doc import update_doc
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+
+OP_SLUG = "wc-operator"
+AUD_SLUG = "wc-auditor"
+WRITES = [{"doctype": "ToDo", "mode": "draft"}]  # the operator's declared contract
+
+
+def _mk_user(email: str, roles=("System Manager",)) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	existing = {r.role for r in frappe.get_doc("User", email).roles}
+	for role in roles:
+		if role not in existing:
+			frappe.get_doc("User", email).add_roles(role)
+	return email
+
+
+def _mk_listing(slug: str, nature: str, writes, rule_pack: str = "") -> None:
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": LISTING,
+			"agent_slug": slug,
+			"title": f"WriteCaps {slug}",
+			"nature": nature,
+			"delivery": "delegate",
+			"status": "Published",
+			"rule_tokens": json.dumps([]),
+			"doctypes_required": json.dumps([w["doctype"] for w in (writes or [])]),
+			"writes": json.dumps(writes or []),
+			"rule_pack": rule_pack,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _mk_install_and_run(slug: str, run_as: str, session_key: str) -> str:
+	"""A running Jarvis Agent Run bound to ``session_key`` (the delegate identity
+	the write tools resolve). Returns the run name."""
+	inst = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": slug,
+			"run_as_user": run_as,
+			"activation_state": "shadow",
+		}
+	)
+	inst.owner = run_as
+	inst.flags.ignore_permissions = True
+	inst.insert(ignore_permissions=True)
+	run = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": slug,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": session_key,
+		}
+	)
+	run.owner = run_as
+	run.flags.ignore_permissions = True
+	run.insert(ignore_permissions=True)
+	return run.name
+
+
+def _mk_todo(owner: str, description: str = "wc todo") -> str:
+	doc = frappe.get_doc({"doctype": "ToDo", "description": description})
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value("ToDo", doc.name, "owner", owner, update_modified=False)
+	return doc.name
+
+
+def _wipe():
+	for slug in (OP_SLUG, AUD_SLUG):
+		for dt in (RUN, INSTALLATION):
+			for n in frappe.get_all(dt, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+		if frappe.db.exists(LISTING, slug):
+			frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+
+
+# --------------------------------------------------------------------------- #
+# R5-J9 — delegate write-capability enforcement
+# --------------------------------------------------------------------------- #
+class TestDelegateWriteCaps(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.run_as = _mk_user("wc-runas@example.com")
+		cls.other = _mk_user("wc-other@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		_mk_listing(OP_SLUG, "Operator", WRITES, rule_pack="pack-wc-a")
+		_mk_listing(AUD_SLUG, "Auditor", [], rule_pack="")
+		self.op_key = f"agent:agent-{OP_SLUG}:wc-op-run"
+		self.aud_key = f"agent:agent-{AUD_SLUG}:wc-aud-run"
+		_mk_install_and_run(OP_SLUG, self.run_as, self.op_key)
+		_mk_install_and_run(AUD_SLUG, self.run_as, self.aud_key)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def _as_delegate(self, session_key: str):
+		"""Enter the delegate dispatch context: the run-as identity + its session_key
+		stashed exactly as the plugin dispatcher (api.py) would."""
+		frappe.set_user(self.run_as)
+		_agent_run_ctx.set_session_key(session_key)
+
+	# --- the four adversarial cases ---------------------------------------- #
+	def test_operator_out_of_contract_doctype_refused(self):
+		"""An operator whose contract is ToDo-only cannot create/update a doctype it
+		never declared (the R5-P0-04 cross-doctype mutation)."""
+		self._as_delegate(self.op_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			create_doc("Note", {"title": "x"})
+		self.assertIn("declared write contract", str(ctx.exception))
+		# update of an out-of-contract doctype is refused before it even loads the doc
+		with self.assertRaises(PermissionDeniedError):
+			update_doc("Note", "whatever", {"title": "y"})
+
+	def test_operator_submitted_doc_refused(self):
+		"""An operator may only touch DRAFTS — a submitted (docstatus != 0) row of a
+		DECLARED doctype is still refused."""
+		frappe.set_user("Administrator")
+		name = _mk_todo(self.run_as)
+		frappe.db.set_value("ToDo", name, "docstatus", 1)  # simulate a submitted row
+		self._as_delegate(self.op_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			update_doc("ToDo", name, {"description": "edit"})
+		self.assertIn("DRAFT", str(ctx.exception).upper())
+
+	def test_operator_foreign_owned_doc_refused(self):
+		"""An operator may update only rows OWNED by its run-as identity — a draft of a
+		declared doctype owned by another identity is refused."""
+		frappe.set_user("Administrator")
+		name = _mk_todo(self.other)  # owned by someone else
+		self._as_delegate(self.op_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			update_doc("ToDo", name, {"description": "edit"})
+		self.assertIn("owned by another identity", str(ctx.exception))
+
+	def test_auditor_create_refused_outright(self):
+		"""An auditor (null/empty writes) is refused every write — it holds no write
+		capability regardless of the target doctype."""
+		self._as_delegate(self.aud_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			create_doc("ToDo", {"description": "x"})
+		self.assertIn("no declared write capability", str(ctx.exception))
+
+	# --- the positive delegate paths (the gate must not over-block) -------- #
+	def test_operator_creates_declared_doctype(self):
+		self._as_delegate(self.op_key)
+		res = create_doc("ToDo", {"description": "operator draft"})
+		self.assertEqual(res["doctype"], "ToDo")
+		self.assertTrue(res["name"])
+
+	def test_operator_updates_own_declared_draft(self):
+		frappe.set_user("Administrator")
+		name = _mk_todo(self.run_as)
+		self._as_delegate(self.op_key)
+		res = update_doc("ToDo", name, {"description": "edited by operator"})
+		self.assertEqual(res["name"], name)
+		self.assertEqual(frappe.db.get_value("ToDo", name, "description"), "edited by operator")
+
+	# --- non-delegate regression ------------------------------------------- #
+	def test_non_delegate_session_untouched(self):
+		"""No session_key in context -> not a delegate -> the write proceeds under the
+		ordinary Frappe permission engine only (no capability gate)."""
+		frappe.set_user(self.run_as)
+		_agent_run_ctx.clear_session_key()
+		res = create_doc("Note", {"title": "ordinary note"})  # not a delegate: any perm-ok doctype
+		self.assertEqual(res["doctype"], "Note")
+
+	def test_unbound_session_key_is_not_a_delegate(self):
+		"""A session_key with NO bound Run is not a delegate — the write tools leave it
+		untouched (a normal chat session_key never matches Run.session_key)."""
+		frappe.set_user(self.run_as)
+		_agent_run_ctx.set_session_key("chat-session-with-no-agent-run")
+		res = create_doc("Note", {"title": "chat note"})
+		self.assertEqual(res["doctype"], "Note")
+
+
+# --------------------------------------------------------------------------- #
+# R5-J11(c) — pack-derived ceiling counting (no slug fallback)
+# --------------------------------------------------------------------------- #
+class TestPackDerivedCeiling(FrappeTestCase):
+	CUSTOMER = "wc-pack-owner@example.com"
+	REVIEWER = "wc-pack-reviewer@example.com"
+	A = "wc-pack-a"
+	B = "wc-pack-b"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		_mk_user(cls.CUSTOMER)
+		_mk_user(cls.REVIEWER)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for slug in (self.A, self.B):
+			for n in frappe.get_all(INSTALLATION, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+				frappe.delete_doc(INSTALLATION, n, force=True, ignore_permissions=True)
+			if frappe.db.exists(LISTING, slug):
+				frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+
+	def _install(self, slug: str, rule_pack: str) -> None:
+		_mk_listing(slug, "Auditor", [], rule_pack=rule_pack)
+		doc = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": slug,
+				"run_as_user": self.CUSTOMER,
+				"reviewer": self.REVIEWER,
+				"activation_state": "shadow",
+			}
+		)
+		doc.owner = self.CUSTOMER
+		doc.flags.ignore_permissions = True
+		doc.insert(ignore_permissions=True)
+		frappe.db.set_value(INSTALLATION, doc.name, "owner", self.CUSTOMER, update_modified=False)
+
+	def test_two_distinct_packs_qualify(self):
+		self._install(self.A, "pack-one")
+		self._install(self.B, "pack-two")
+		self.assertEqual(agents_api._verify_reviewer_two_pack_capacity(self.CUSTOMER), self.REVIEWER)
+
+	def test_two_agents_same_pack_do_not_qualify(self):
+		self._install(self.A, "pack-one")
+		self._install(self.B, "pack-one")  # same canonical pack
+		with self.assertRaises(frappe.ValidationError):
+			agents_api._verify_reviewer_two_pack_capacity(self.CUSTOMER)
+
+	def test_empty_pack_ids_never_inferred_from_slug(self):
+		"""The R5-P1-02 regression: two DISTINCT agent slugs with NO canonical pack must
+		NOT count as two packs (the slug fallback is gone)."""
+		self._install(self.A, "")
+		self._install(self.B, "")
+		with self.assertRaises(frappe.ValidationError):
+			agents_api._verify_reviewer_two_pack_capacity(self.CUSTOMER)
+
+
+# --------------------------------------------------------------------------- #
+# sync stores writes[] + rule_pack (tolerant of a registry that predates them)
+# --------------------------------------------------------------------------- #
+class TestSyncStoresWritesAndPack(FrappeTestCase):
+	SYNC_OP = "wc-sync-operator"
+	SYNC_PLAIN = "wc-sync-plain"
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for slug in (self.SYNC_OP, self.SYNC_PLAIN):
+			if frappe.db.exists(LISTING, slug):
+				frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+		# Restore the real listings the synthetic-registry sync round-tripped.
+		agent_catalog.sync_agent_listings()
+		frappe.db.commit()
+
+	def test_sync_stores_writes_and_pack_and_tolerates_absence(self):
+		"""A synthetic registry (superset of the real one, so no real listing is
+		spuriously deprecated) proves the sync STORES writes[]/rule_pack when present
+		and stores empty when absent (an older registry lacking the fields)."""
+		real = agent_catalog._load_registry()
+		synth = {
+			"publisher": real.get("publisher"),
+			"agents": list(real.get("agents") or [])
+			+ [
+				{
+					"agent_slug": self.SYNC_OP,
+					"title": "Sync Operator",
+					"nature": "operator",
+					"writes": [{"doctype": "Material Request", "mode": "draft"}],
+					"rule_pack": "pack-sync-x",
+					"doctypes_required": ["Material Request"],
+				},
+				{
+					# predates writes/rule_pack entirely -> must be tolerated (empty)
+					"agent_slug": self.SYNC_PLAIN,
+					"title": "Sync Plain",
+					"nature": "auditor",
+				},
+			],
+		}
+		with patch.object(agent_catalog, "_load_registry", return_value=synth):
+			agent_catalog.sync_agent_listings()
+
+		op = frappe.db.get_value(LISTING, self.SYNC_OP, ["writes", "rule_pack"], as_dict=True)
+		self.assertEqual(json.loads(op.writes), [{"doctype": "Material Request", "mode": "draft"}])
+		self.assertEqual(op.rule_pack, "pack-sync-x")
+
+		plain = frappe.db.get_value(LISTING, self.SYNC_PLAIN, ["writes", "rule_pack"], as_dict=True)
+		self.assertEqual(json.loads(plain.writes), [])  # tolerant: absent -> empty list
+		self.assertIn(plain.rule_pack, (None, ""))  # tolerant: absent -> empty

--- a/jarvis/tools/_delegate_write_caps.py
+++ b/jarvis/tools/_delegate_write_caps.py
@@ -1,0 +1,165 @@
+"""R5-J9 — session-bound WRITE capabilities for delegate agents.
+
+Codex R5-P0-04: the marketplace agents' declared ``writes[]`` were metadata only.
+An operator (or an auditor) that received ``jarvis__create_doc`` / ``jarvis__update_doc``
+could write ANY doctype the run-as user's ordinary Frappe roles allowed — the
+manifest contract was never a runtime boundary, only a model instruction.
+
+This module closes that seam. When a write tool runs OVER A DELEGATE RUN SESSION
+(the pre-created ``Jarvis Agent Run`` whose ``session_key`` the plugin dispatcher
+stashed on ``frappe.local`` — see ``_agent_run_ctx``), the write is bounded by the
+agent's DECLARED contract, enforced BEFORE any Frappe permission check:
+
+  * The caller's delegate identity is resolved the SAME way ``record_agent_run``
+    resolves its run — ``Jarvis Agent Run.session_key == <caller session_key>``
+    (never a model-supplied id, so a delegate can only ever act as its own run).
+    A session with no bound Run is NOT a delegate: standard chat / macro / test
+    callers are left completely untouched (``resolve_delegate`` returns None and
+    the enforce_* helpers are no-ops).
+  * AUDITORS (``writes`` null/empty) are refused every write outright.
+  * OPERATORS may create/update ONLY a doctype declared in ``writes[]`` (with the
+    operation, when a writes entry narrows it), ONLY while the target is a draft
+    (``docstatus == 0``), and — for updates — ONLY a row OWNED BY the run-as
+    identity. Everything else raises ``PermissionDeniedError``.
+
+The ``writes[]`` contract is DECLARATIVE, non-IP (a list of ``{doctype, mode}``;
+``mode`` ∈ {draft, approval-request}) mirrored from the bundle-store manifest —
+never a rule body/threshold. Storage: ``Jarvis Agent Listing.writes`` (JSON),
+populated by ``agent_catalog.sync_agent_listings``.
+"""
+
+import json
+
+import frappe
+
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.tools._agent_run_ctx import get_session_key
+
+RUN = "Jarvis Agent Run"
+LISTING = "Jarvis Agent Listing"
+
+
+def _parse_writes(raw) -> list:
+	"""The listing's ``writes`` JSON -> a list of ``{doctype, mode, ...}`` dicts.
+	A malformed / non-list value is treated as an EMPTY contract (fail-closed:
+	an operator with an unreadable contract writes nothing)."""
+	if not raw:
+		return []
+	if isinstance(raw, list):
+		parsed = raw
+	else:
+		try:
+			parsed = json.loads(raw)
+		except (TypeError, ValueError):
+			return []
+	return [w for w in parsed if isinstance(w, dict) and w.get("doctype")] if isinstance(parsed, list) else []
+
+
+def resolve_delegate() -> dict | None:
+	"""The delegate capability for the CURRENT tool call, or None when the caller
+	is not a delegate (standard chat, macro, direct-Python, or a test that set no
+	session_key).
+
+	Delegate iff a ``Jarvis Agent Run`` row is bound to the caller's session_key
+	(``Run.session_key`` only ever holds the ``agent:agent-<slug>:<run>`` shape a
+	delegate launch mints, so the lookup itself is the discriminator — a normal
+	chat session_key never matches). ``run_as`` is the impersonated identity the
+	dispatcher already switched the session to (``frappe.session.user``), i.e. the
+	Run's run-as user — the ownership axis update enforcement gates on.
+
+	Returns ``{agent, nature, writes, run_as}`` or None.
+	"""
+	session_key = get_session_key()
+	if not session_key:
+		return None
+	run = frappe.db.get_value(
+		RUN,
+		{"session_key": session_key},
+		["name", "agent"],
+		as_dict=True,
+	)
+	if not run or not run.agent:
+		return None  # no delegate run bound -> not a delegate; leave the caller untouched
+	listing = frappe.db.get_value(LISTING, run.agent, ["nature", "writes"], as_dict=True) or {}
+	return {
+		"agent": run.agent,
+		"nature": (listing.get("nature") or "").strip().lower(),
+		"writes": _parse_writes(listing.get("writes")),
+		"run_as": frappe.session.user,
+	}
+
+
+def _match(writes: list, doctype: str, operation: str) -> dict | None:
+	"""The declared ``writes[]`` entry authorising ``operation`` on ``doctype``, or
+	None. Matches doctype exactly; an entry MAY narrow the allowed operation via an
+	optional ``operation`` (str) or ``operations`` (list) key — absent means the
+	declared doctype permits both create and update (the manifest today carries only
+	``{doctype, mode}``, so both are allowed for a declared doctype)."""
+	for w in writes:
+		if w.get("doctype") != doctype:
+			continue
+		ops = w.get("operations") or w.get("operation")
+		if ops is None:
+			return w  # unrestricted: both create + update allowed for this doctype
+		if isinstance(ops, str):
+			ops = [ops]
+		if operation in {str(o).strip().lower() for o in ops}:
+			return w
+	return None
+
+
+def _refuse_non_operator(cap: dict, operation: str, doctype: str) -> None:
+	"""Refuse a write from a caller that is not a write-capable operator (an auditor,
+	or an operator whose contract is empty). Raised BEFORE Frappe permission checks."""
+	if cap["nature"] != "operator" or not cap["writes"]:
+		raise PermissionDeniedError(
+			f"agent '{cap['agent']}' is not permitted to {operation} documents "
+			f"(no declared write capability); refusing {doctype}"
+		)
+
+
+def enforce_create(doctype: str) -> None:
+	"""R5-J9 gate for a delegate create. No-op for non-delegate callers. A create is
+	inherently a draft (``docstatus`` is a refused protected field on the way in), so
+	the docstatus==0 constraint is structural; there is no owner constraint on create."""
+	cap = resolve_delegate()
+	if cap is None:
+		return
+	_refuse_non_operator(cap, "create", doctype)
+	if _match(cap["writes"], doctype, "create") is None:
+		raise PermissionDeniedError(
+			f"agent '{cap['agent']}' may not create '{doctype}' — it is not in the "
+			f"agent's declared write contract"
+		)
+
+
+def enforce_update(doctype: str, name: str) -> None:
+	"""R5-J9 gate for a delegate update. No-op for non-delegate callers. An operator
+	may update ONLY a declared doctype, ONLY a draft (``docstatus == 0``), and ONLY a
+	row it owns (the run-as identity). Enforced BEFORE Frappe permission checks — the
+	docstatus/owner probe uses a permission-agnostic ``db.get_value`` so the contract
+	boundary is decided independently of the run-as user's roles."""
+	cap = resolve_delegate()
+	if cap is None:
+		return
+	_refuse_non_operator(cap, "update", doctype)
+	if _match(cap["writes"], doctype, "update") is None:
+		raise PermissionDeniedError(
+			f"agent '{cap['agent']}' may not update '{doctype}' — it is not in the "
+			f"agent's declared write contract"
+		)
+	row = frappe.db.get_value(doctype, name, ["docstatus", "owner"], as_dict=True)
+	if row is None:
+		# The doc does not exist; defer to update_doc's own get_doc, which raises a
+		# clearer DoesNotExistError. Nothing to bound here.
+		return
+	if frappe.utils.cint(row.docstatus) != 0:
+		raise PermissionDeniedError(
+			f"agent '{cap['agent']}' may only update DRAFT documents; "
+			f"{doctype} '{name}' is submitted/cancelled (docstatus {row.docstatus})"
+		)
+	if row.owner != cap["run_as"]:
+		raise PermissionDeniedError(
+			f"agent '{cap['agent']}' may only update documents it created; "
+			f"{doctype} '{name}' is owned by another identity"
+		)

--- a/jarvis/tools/create_doc.py
+++ b/jarvis/tools/create_doc.py
@@ -32,6 +32,7 @@ import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools._bulk import _MAX_BATCH, run_atomic_batch
+from jarvis.tools._delegate_write_caps import enforce_create
 
 # `name` is intentionally NOT in this list: DocTypes that use autoname=prompt
 # (or autoname=field:<x>) need it set in `values`. Frappe's autoname handling
@@ -63,6 +64,12 @@ def _validate_create_args(doctype: str, values: dict) -> None:
 	protected = sorted(set(values.keys()) & PROTECTED_FIELDS)
 	if protected:
 		raise InvalidArgumentError(f"refusing to write protected field(s): {', '.join(protected)}")
+
+	# R5-J9: bind a DELEGATE agent's create to its declared writes[] contract BEFORE
+	# the Frappe permission check below (a no-op for non-delegate callers). An auditor
+	# is refused outright; an operator may create only a doctype in its contract. The
+	# create is structurally a draft (docstatus is a refused protected field).
+	enforce_create(doctype)
 
 	if not frappe.has_permission(doctype, ptype="create"):
 		raise PermissionDeniedError(f"no create permission on {doctype}")

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -31,6 +31,7 @@ import frappe
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
 from jarvis.tools import require_doctype_and_name
 from jarvis.tools._bulk import run_atomic_batch
+from jarvis.tools._delegate_write_caps import enforce_update
 
 # Fields Frappe maintains itself or that govern DocType identity. An LLM
 # rewriting these would corrupt the row.
@@ -61,6 +62,12 @@ def _update_one(doctype: str, name: str, changes: dict) -> "frappe.model.documen
 	protected = sorted(set(changes.keys()) & PROTECTED_FIELDS)
 	if protected:
 		raise InvalidArgumentError(f"refusing to write protected field(s): {', '.join(protected)}")
+
+	# R5-J9: bind a DELEGATE agent's update to its declared writes[] contract BEFORE
+	# the Frappe permission check below (a no-op for non-delegate callers). An auditor
+	# is refused outright; an operator may update only a declared doctype, only a draft
+	# (docstatus==0), and only a row owned by its run-as identity.
+	enforce_update(doctype, name)
 
 	if not frappe.has_permission(doctype, ptype="write", doc=name):
 		raise PermissionDeniedError(f"no write permission on {doctype} '{name}'")


### PR DESCRIPTION
Bench side of the codex Round-5 P0 closure (rulings: `jarvis-agents-catalog-plan/build/DECISIONS-R5.md`). Stacks on #383 — **merge this PR into `feat/agents-registry-launch` first**, then #383 into develop (squash-stack order).

## What lands

- **R5-J1 render gate** (closes the false-clean render half of R4-P0-03): "no exceptions" renders only when `run_state == evaluated_clean` **and** zero persisted findings — enforced in the fallback-dashboard path, `coverage_reasons` enum comment amended, +9 render-gate tests.
- **R5-J8 / R5-P0-05**: `min_apps` is now a real install/enable gate with the typed `app_absent_or_ineligible` reason; reconcile marks existing installs `installable=0` on app absence (never deletes); enable/schedule/run-now/apply refuse non-installable rows; `_required_doctypes` no longer silently filters absent DocTypes. +14 tests (app absence simulated via patch, both initial and post-install).
- **R5-J9 / R5-P0-04**: delegate write capabilities — `create_doc`/`update_doc` resolve the calling delegate session (the same run-session linkage `record_agent_run` uses) and enforce the listing's declarative `writes[]` **before** Frappe permission checks: auditors refused outright; operators bound to declared doctype+operation, `docstatus == 0`, and own-row updates. Non-delegate sessions untouched (regression-tested). +12 tests incl. the four adversarial cases.
- **R5-J11(c) / R5-P1-02**: activation-ceiling "two packs" counting requires distinct non-empty `rule_pack` (slug fallback removed); listing gains `writes` + populated `rule_pack` from the registry.
- **Registry syncs** from the store (WP-2 envelope version bumps + WP-3 `writes`/`rule_pack`; `rule_tokens` byte-identical throughout).

## Verification

patterntest suite tally at head: **104/104** (marketplace 18, min_apps 14, write_caps 12, activation 13, writeback 30, false_clean 8, render_gate 9). Live E2E on patterntest proved the actual refusals: hrms-absent install refused with the typed reason; operator's out-of-contract/submitted/foreign-owned writes refused; auditor create refused; normal-user regression clean; persisted findings + dashboards free of forbidden statutory strings; same-pack ceiling raise refused.

Companion PRs (other repos): store commits `8b27953`/`e1e14f9`/`c0a2d30` (CI green), fleet-agent #151 (deploy first), admin-v2 #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsMjkHXYiK5TDokQyAoFh