### PR TITLE
Desk side chat: a mini chat window on every Desk page

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -59,12 +59,12 @@
 			<div class="jvp-body" ref="bodyEl">
 				<div v-if="loading" class="jvp-center">Restoring your last conversation…</div>
 
-				<div v-else-if="loadError && !messages.length" class="jvp-center">
+				<div v-else-if="loadError && !shownMessages.length" class="jvp-center">
 					<div class="jvp-err">{{ loadError }}</div>
 					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
 				</div>
 
-				<div v-else-if="!messages.length && !stream.live" class="jvp-center">
+				<div v-else-if="!shownMessages.length && !stream.live" class="jvp-center">
 					<svg class="jvp-empty-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
 					</svg>
@@ -80,12 +80,12 @@
 
 				<div v-else class="jvp-msgs">
 					<div
-						v-for="m in messages"
+						v-for="m in shownMessages"
 						:key="m.name"
 						:class="m.role === 'user' ? 'jvp-m-user' : 'jvp-m-bot'"
 					>{{ m.content }}</div>
 					<div v-if="stream.live" class="jvp-m-bot">{{ stream.live.text || "…" }}</div>
-					<div v-if="loadError && messages.length" class="jvp-inline-err">
+					<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
 						<span class="jvp-err">{{ loadError }}</span>
 						<button class="jvp-btn-subtle" type="button" @click="retryLast">Retry</button>
 					</div>
@@ -159,7 +159,7 @@
 <script setup>
 import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { contextLabel } from "./desk_context.mjs";
-import { emptyStream, applyEvent } from "./chat_stream.mjs";
+import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
 import {
 	listConversations,
 	getConversation,
@@ -191,6 +191,9 @@ const resolving = ref("");
 const lastSent = ref("");
 
 const contextText = computed(() => contextLabel(props.context));
+// Tool rows and empty shells are filtered out: this panel is text-only, and
+// the raw list is mostly machine chatter (see chat_stream.visibleMessages).
+const shownMessages = computed(() => visibleMessages(messages.value));
 const canSend = computed(() => draft.value.trim().length > 0 && !sending.value && !stream.value.live);
 const hint = computed(() => {
 	if (stream.value.live) return "Jarvis is replying…";

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -64,17 +64,28 @@
 					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
 				</div>
 
-				<div v-else-if="!shownMessages.length && !stream.live && !thinking" class="jvp-center">
-					<svg class="jvp-empty-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-					</svg>
-					<div class="jvp-empty-t">{{ contextText ? "Ask about this record" : "Ask Jarvis" }}</div>
-					<div class="jvp-empty-d">
+				<!-- Welcome: greeting + a few starting points, so an empty panel
+				     suggests what to do rather than showing a blank box. -->
+				<div v-else-if="!shownMessages.length && !stream.live && !thinking" class="jvp-welcome">
+					<div class="jvp-greet">{{ greeting }}</div>
+					<p class="jvp-greet-sub">
 						{{
 							contextText
 								? `Jarvis can see ${contextText} while you are on this page.`
-								: "Ask a question about your data."
+								: "Ask about your ERP data, run a workflow, or draft something."
 						}}
+					</p>
+					<div class="jvp-cards">
+						<button
+							v-for="s in suggestions"
+							:key="s.title"
+							class="jvp-card"
+							type="button"
+							@click="useSuggestion(s.prompt)"
+						>
+							<span class="jvp-card-t">{{ s.title }}</span>
+							<span class="jvp-card-p">{{ s.prompt }}</span>
+						</button>
 					</div>
 				</div>
 
@@ -165,6 +176,7 @@
 <script setup>
 import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { contextLabel } from "./desk_context.mjs";
+import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
 import {
 	listConversations,
@@ -217,6 +229,23 @@ const rootStyle = computed(() => {
 const shownMessages = computed(() => visibleMessages(messages.value));
 // A turn is in flight from the moment the POST is away until the first token
 // lands. Without this the panel looks inert for the whole worker round-trip.
+const greeting = computed(() => {
+	const who =
+		window.frappe?.boot?.user?.full_name || window.frappe?.session?.user_fullname || "";
+	return greetingLine(new Date().getHours(), who);
+});
+const suggestions = computed(() => suggestionsFor(props.context));
+
+// A suggestion is a starting point, not a command: it fills the composer so
+// the user can edit before sending.
+function useSuggestion(prompt) {
+	draft.value = prompt;
+	nextTick(() => {
+		autoGrow();
+		textareaEl.value?.focus();
+	});
+}
+
 const thinking = computed(() => sending.value || (stream.value.busy && !stream.value.live));
 const canSend = computed(() => draft.value.trim().length > 0 && !sending.value && !stream.value.live);
 const hint = computed(() => {
@@ -556,6 +585,65 @@ defineExpose({ load, startNewChat, convId });
 .jvp-err {
 	font-size: 13.5px;
 	color: var(--text-danger, #c0392b);
+}
+
+/* ---- welcome ---- */
+.jvp-welcome {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 6px 2px 2px;
+}
+.jvp-greet {
+	font-size: 19px;
+	font-weight: 600;
+	color: var(--text-color);
+	letter-spacing: -0.01em;
+}
+.jvp-greet-sub {
+	margin: 0;
+	font-size: 13.5px;
+	line-height: 1.5;
+	color: var(--text-muted);
+}
+.jvp-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 12px;
+}
+/* Cards are bordered and flat: selection and hover are colour shifts, never a
+   lift (design.md 1.3, 5 row 2). */
+.jvp-card {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	text-align: left;
+	padding: 10px 12px;
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	background: transparent;
+	font: inherit;
+	letter-spacing: inherit;
+	cursor: pointer;
+	transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+.jvp-card:hover {
+	background: var(--control-bg, #f3f3f3);
+}
+.jvp-card:focus-visible {
+	outline: 2px solid var(--border-primary, #999);
+	outline-offset: 1px;
+}
+.jvp-card-t {
+	font-size: 13.5px;
+	font-weight: 500;
+	color: var(--text-color);
+}
+.jvp-card-p {
+	font-size: 12.5px;
+	line-height: 1.45;
+	color: var(--text-muted);
 }
 .jvp-inline-err {
 	display: flex;

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -4,7 +4,7 @@
 	<div
 		v-show="open"
 		class="jvp-root"
-		:class="`jvp-root--${side}`"
+		:style="rootStyle"
 		role="dialog"
 		aria-label="Jarvis chat"
 		@keydown.esc.stop="$emit('close')"
@@ -64,7 +64,7 @@
 					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
 				</div>
 
-				<div v-else-if="!shownMessages.length && !stream.live" class="jvp-center">
+				<div v-else-if="!shownMessages.length && !stream.live && !thinking" class="jvp-center">
 					<svg class="jvp-empty-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
 					</svg>
@@ -84,7 +84,13 @@
 						:key="m.name"
 						:class="m.role === 'user' ? 'jvp-m-user' : 'jvp-m-bot'"
 					>{{ m.content }}</div>
-					<div v-if="stream.live" class="jvp-m-bot">{{ stream.live.text || "…" }}</div>
+					<div v-if="stream.live && stream.live.text" class="jvp-m-bot">{{ stream.live.text }}</div>
+					<!-- Waiting for the first token: a labelled state, not a bare
+					     spinner, so the user knows the turn was accepted. -->
+					<div v-else-if="thinking" class="jvp-think" role="status" aria-live="polite">
+						<span class="jvp-think-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+						<span class="jvp-think-txt">Working…</span>
+					</div>
 					<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
 						<span class="jvp-err">{{ loadError }}</span>
 						<button class="jvp-btn-subtle" type="button" @click="retryLast">Retry</button>
@@ -171,7 +177,9 @@ import {
 const props = defineProps({
 	open: { type: Boolean, default: false },
 	context: { type: Object, default: null },
-	side: { type: String, default: "right" },
+	// Computed by panel_anchor.panelLayout from wherever the user dragged the
+	// FAB. The panel is a floating mini window, so it has no fixed home.
+	layout: { type: Object, default: null },
 });
 defineEmits(["close", "open-full", "dismiss-context"]);
 
@@ -191,9 +199,25 @@ const resolving = ref("");
 const lastSent = ref("");
 
 const contextText = computed(() => contextLabel(props.context));
+
+// The panel is positioned, not docked: left/top/width/height all come from the
+// FAB's current spot so dragging the launcher moves its window with it.
+const rootStyle = computed(() => {
+	const l = props.layout;
+	if (!l) return { display: "none" };
+	return {
+		left: `${l.left}px`,
+		top: `${l.top}px`,
+		width: `${l.width}px`,
+		height: `${l.height}px`,
+	};
+});
 // Tool rows and empty shells are filtered out: this panel is text-only, and
 // the raw list is mostly machine chatter (see chat_stream.visibleMessages).
 const shownMessages = computed(() => visibleMessages(messages.value));
+// A turn is in flight from the moment the POST is away until the first token
+// lands. Without this the panel looks inert for the whole worker round-trip.
+const thinking = computed(() => sending.value || (stream.value.busy && !stream.value.live));
 const canSend = computed(() => draft.value.trim().length > 0 && !sending.value && !stream.value.live);
 const hint = computed(() => {
 	if (stream.value.live) return "Jarvis is replying…";
@@ -361,22 +385,14 @@ defineExpose({ load, startNewChat, convId });
 <style scoped>
 /* Desk CSS variables only — the Desk already stamps the theme, so light/dark
    comes free and no dark: variants are needed (design.md 6). */
+/* A mini chat window, not a full-height dock: left/top/width/height are set
+   inline from panel_anchor.panelLayout() so the window follows the FAB
+   wherever the user dragged it. */
 .jvp-root {
 	position: fixed;
-	top: var(--navbar-height, 48px);
-	bottom: 0;
-	width: 400px;
-	max-width: 100vw;
 	z-index: 1029; /* under Frappe modals (1050), over page content */
 	display: flex;
-	padding: 12px;
 	pointer-events: none;
-}
-.jvp-root--right {
-	right: 0;
-}
-.jvp-root--left {
-	left: 0;
 }
 
 .jvp-panel {
@@ -700,5 +716,52 @@ defineExpose({ load, startNewChat, convId });
 .jvp-btn-solid[disabled] {
 	opacity: 0.6;
 	cursor: not-allowed;
+}
+
+/* ---- waiting for a reply ---- */
+.jvp-think {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	color: var(--text-muted);
+	font-size: 13.5px;
+}
+.jvp-think-dots {
+	display: inline-flex;
+	align-items: flex-end;
+	gap: 3px;
+	height: 12px;
+}
+.jvp-think-dots i {
+	width: 4px;
+	height: 4px;
+	border-radius: 999px;
+	background: currentColor;
+	opacity: 0.35;
+}
+@media (prefers-reduced-motion: no-preference) {
+	.jvp-think-dots i {
+		animation: jvp-dot 1.2s infinite ease-in-out;
+	}
+	.jvp-think-dots i:nth-child(2) {
+		animation-delay: 0.15s;
+	}
+	.jvp-think-dots i:nth-child(3) {
+		animation-delay: 0.3s;
+	}
+}
+/* Progress feedback, not decoration — the one animation design.md's
+   no-motion rule does not cover, and it is gated on motion-safe anyway. */
+@keyframes jvp-dot {
+	0%,
+	80%,
+	100% {
+		transform: translateY(0);
+		opacity: 0.35;
+	}
+	40% {
+		transform: translateY(-4px);
+		opacity: 1;
+	}
 }
 </style>

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -16,24 +16,62 @@
 			<div class="jvp-head">
 				<div class="jvp-avatar">
 					<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
-						<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+						<path
+							d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+						/>
 					</svg>
 					<i class="jvp-online" aria-hidden="true"></i>
 				</div>
 				<div class="jvp-title">Jarvis</div>
 				<div class="jvp-actions">
-					<button class="jvp-ib" type="button" aria-label="New chat" @click="startNewChat">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+					<button
+						class="jvp-ib"
+						type="button"
+						aria-label="New chat"
+						@click="startNewChat"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.6"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<path d="M12 5v14M5 12h14" />
 						</svg>
 					</button>
-					<button class="jvp-ib" type="button" aria-label="Open full chat" @click="$emit('open-full')">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+					<button
+						class="jvp-ib"
+						type="button"
+						aria-label="Open full chat"
+						@click="$emit('open-full')"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.6"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<path d="M15 3h6v6M21 3l-7 7M10 21H4v-6M4 21l7-7" />
 						</svg>
 					</button>
-					<button class="jvp-ib" type="button" aria-label="Close" @click="$emit('close')">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+					<button
+						class="jvp-ib"
+						type="button"
+						aria-label="Close"
+						@click="$emit('close')"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.6"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<path d="M18 6 6 18M6 6l12 12" />
 						</svg>
 					</button>
@@ -41,13 +79,35 @@
 			</div>
 
 			<div v-if="contextText" class="jvp-ctx">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<svg
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.6"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
 					<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
 					<path d="M14 2v6h6" />
 				</svg>
-				<div class="jvp-ctx-txt">Viewing <b>{{ contextText }}</b></div>
-				<button class="jvp-ib jvp-ib--sm" type="button" aria-label="Stop using this page as context" @click="$emit('dismiss-context')">
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+				<div class="jvp-ctx-txt">
+					Viewing <b>{{ contextText }}</b>
+				</div>
+				<button
+					class="jvp-ib jvp-ib--sm"
+					type="button"
+					aria-label="Stop using this page as context"
+					@click="$emit('dismiss-context')"
+				>
+					<svg
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.6"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
 						<path d="M18 6 6 18M6 6l12 12" />
 					</svg>
 				</button>
@@ -62,10 +122,15 @@
 				</div>
 
 				<!-- Welcome: brand mark, greeting, and starting points. -->
-				<div v-else-if="!shownMessages.length && !stream.live && !thinking" class="jvp-welcome">
+				<div
+					v-else-if="!shownMessages.length && !stream.live && !thinking"
+					class="jvp-welcome"
+				>
 					<div class="jvp-hero">
 						<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
-							<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+							<path
+								d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+							/>
 						</svg>
 					</div>
 					<div class="jvp-greet">{{ greeting }}</div>
@@ -85,8 +150,19 @@
 							type="button"
 							@click="useSuggestion(s.prompt)"
 						>
-							<span class="jvp-card-ic" :class="`jvp-card-ic--${i % 4}`" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+							<span
+								class="jvp-card-ic"
+								:class="`jvp-card-ic--${i % 4}`"
+								aria-hidden="true"
+							>
+								<svg
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="1.7"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
 									<path :d="CARD_ICONS[i % CARD_ICONS.length]" />
 								</svg>
 							</span>
@@ -105,7 +181,11 @@
 						</div>
 						<div v-else class="jvp-row">
 							<div class="jvp-m-avatar" aria-hidden="true">
-								<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+								<svg viewBox="0 0 24 24" fill="#fff">
+									<path
+										d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+									/>
+								</svg>
 							</div>
 							<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
 						</div>
@@ -113,7 +193,11 @@
 
 					<div v-if="stream.live && stream.live.text" class="jvp-row">
 						<div class="jvp-m-avatar" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+							<svg viewBox="0 0 24 24" fill="#fff">
+								<path
+									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+								/>
+							</svg>
 						</div>
 						<div class="jvp-m-bot jv-md" v-html="renderReply(stream.live.text)"></div>
 					</div>
@@ -122,26 +206,48 @@
 					     spinner, so the user knows the turn was accepted. -->
 					<div v-else-if="thinking" class="jvp-row">
 						<div class="jvp-m-avatar" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+							<svg viewBox="0 0 24 24" fill="#fff">
+								<path
+									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+								/>
+							</svg>
 						</div>
-						<div class="jvp-think" role="status" aria-live="polite" aria-label="Jarvis is typing">
-							<span class="jvp-think-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+						<div
+							class="jvp-think"
+							role="status"
+							aria-live="polite"
+							aria-label="Jarvis is typing"
+						>
+							<span class="jvp-think-dots" aria-hidden="true"
+								><i></i><i></i><i></i
+							></span>
 						</div>
 					</div>
 
 					<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
 						<span class="jvp-err">{{ loadError }}</span>
-						<button class="jvp-btn-subtle" type="button" @click="retryLast">Retry</button>
+						<button class="jvp-btn-subtle" type="button" @click="retryLast">
+							Retry
+						</button>
 					</div>
 				</div>
 			</div>
 
 			<div v-if="stream.pending.length" class="jvp-pending">
 				<div v-for="p in stream.pending" :key="p.token" class="jvp-pending-row">
-					<div class="jvp-pending-txt">{{ p.summary || "Jarvis wants to make a change." }}</div>
+					<div class="jvp-pending-txt">
+						{{ p.summary || "Jarvis wants to make a change." }}
+					</div>
 					<div class="jvp-pending-acts">
-						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">Review in full chat</button>
-						<button class="jvp-btn-solid" type="button" :disabled="resolving === p.token" @click="resolvePending(p.token)">
+						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">
+							Review in full chat
+						</button>
+						<button
+							class="jvp-btn-solid"
+							type="button"
+							:disabled="resolving === p.token"
+							@click="resolvePending(p.token)"
+						>
 							{{ resolving === p.token ? "Confirming…" : "Confirm" }}
 						</button>
 					</div>
@@ -152,12 +258,33 @@
 				<!-- attached files, above the input -->
 				<div v-if="attachments.length" class="jvp-atts">
 					<span v-for="a in attachments" :key="a.file_url" class="jvp-att">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-							<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+							<path d="M14 2v6h6" />
 						</svg>
 						<span class="jvp-att-n">{{ a.file_name }}</span>
-						<button class="jvp-att-x" type="button" :aria-label="`Remove ${a.file_name}`" @click="removeAttachment(a.file_url)">
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+						<button
+							class="jvp-att-x"
+							type="button"
+							:aria-label="`Remove ${a.file_name}`"
+							@click="removeAttachment(a.file_url)"
+						>
+							<svg
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.8"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
 								<path d="M18 6 6 18M6 6l12 12" />
 							</svg>
 						</button>
@@ -166,7 +293,10 @@
 
 				<input ref="fileEl" type="file" multiple hidden @change="onFilePicked" />
 
-				<div class="jvp-comp" :class="{ 'jvp-comp--focus': composerFocused, 'jvp-comp--rec': recording }">
+				<div
+					class="jvp-comp"
+					:class="{ 'jvp-comp--focus': composerFocused, 'jvp-comp--rec': recording }"
+				>
 					<button
 						class="jvp-cib"
 						type="button"
@@ -174,15 +304,26 @@
 						:disabled="uploading"
 						@click="pickFile"
 					>
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
-							<path d="m21.4 11.1-9.2 9.2a6 6 0 0 1-8.5-8.5l9.2-9.2a4 4 0 0 1 5.7 5.7l-9.2 9.2a2 2 0 0 1-2.9-2.9l8.5-8.5" />
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path
+								d="m21.4 11.1-9.2 9.2a6 6 0 0 1-8.5-8.5l9.2-9.2a4 4 0 0 1 5.7 5.7l-9.2 9.2a2 2 0 0 1-2.9-2.9l8.5-8.5"
+							/>
 						</svg>
 					</button>
 					<textarea
 						class="jvp-comp-text"
 						ref="textareaEl"
 						rows="1"
-						:placeholder="contextText ? `Ask about ${contextText}…` : 'Ask Jarvis anything…'"
+						:placeholder="
+							contextText ? `Ask about ${contextText}…` : 'Ask Jarvis anything…'
+						"
 						v-model="draft"
 						@focus="composerFocused = true"
 						@blur="composerFocused = false"
@@ -198,18 +339,56 @@
 						:disabled="transcribing"
 						@click="toggleVoice"
 					>
-						<svg v-if="!recording" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
-							<rect x="9" y="2" width="6" height="11" rx="3" /><path d="M19 10a7 7 0 0 1-14 0M12 17v5" />
+						<svg
+							v-if="!recording"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<rect x="9" y="2" width="6" height="11" rx="3" />
+							<path d="M19 10a7 7 0 0 1-14 0M12 17v5" />
 						</svg>
-						<span v-else class="jvp-wave" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+						<span v-else class="jvp-wave" aria-hidden="true"
+							><i></i><i></i><i></i><i></i
+						></span>
 					</button>
-					<button v-if="stream.live" class="jvp-send jvp-send--stop" type="button" aria-label="Stop generating" @click="stop">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+					<button
+						v-if="stream.live"
+						class="jvp-send jvp-send--stop"
+						type="button"
+						aria-label="Stop generating"
+						@click="stop"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.7"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<rect x="7" y="7" width="10" height="10" rx="2" />
 						</svg>
 					</button>
-					<button v-else class="jvp-send" type="button" aria-label="Send message" :disabled="!canSend" @click="send">
-						<svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+					<button
+						v-else
+						class="jvp-send"
+						type="button"
+						aria-label="Send message"
+						:disabled="!canSend"
+						@click="send"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="#fff"
+							stroke-width="1.8"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<path d="M12 19V5M5 12l7-7 7 7" />
 						</svg>
 					</button>
@@ -739,11 +918,19 @@ defineExpose({ load, startNewChat, convId });
 	outline: none;
 }
 @media (prefers-reduced-motion: no-preference) {
-	.jvp-panel { animation: jvp-in 120ms ease-out; }
+	.jvp-panel {
+		animation: jvp-in 120ms ease-out;
+	}
 }
 @keyframes jvp-in {
-	from { opacity: 0; transform: scale(0.98); }
-	to { opacity: 1; transform: scale(1); }
+	from {
+		opacity: 0;
+		transform: scale(0.98);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
 }
 
 /* ---- header ---- */
@@ -765,7 +952,10 @@ defineExpose({ load, startNewChat, convId });
 	display: grid;
 	place-items: center;
 }
-.jvp-avatar svg { width: 17px; height: 17px; }
+.jvp-avatar svg {
+	width: 17px;
+	height: 17px;
+}
 .jvp-online {
 	position: absolute;
 	right: -2px;
@@ -776,8 +966,17 @@ defineExpose({ load, startNewChat, convId });
 	background: #3ad07e;
 	border: 2px solid var(--jv-surface);
 }
-.jvp-title { flex: 1; font-size: 14.5px; font-weight: 600; color: var(--jv-ink); }
-.jvp-actions { display: flex; align-items: center; gap: 2px; }
+.jvp-title {
+	flex: 1;
+	font-size: 14.5px;
+	font-weight: 600;
+	color: var(--jv-ink);
+}
+.jvp-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
 .jvp-ib {
 	width: 29px;
 	height: 29px;
@@ -791,11 +990,26 @@ defineExpose({ load, startNewChat, convId });
 	place-items: center;
 	transition: background-color 0.12s ease, color 0.12s ease;
 }
-.jvp-ib:hover { background: var(--jv-chip-0); color: var(--jv-ink); }
-.jvp-ib:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
-.jvp-ib svg { width: 16px; height: 16px; }
-.jvp-ib--sm { width: 24px; height: 24px; }
-.jvp-ib--sm svg { width: 14px; height: 14px; }
+.jvp-ib:hover {
+	background: var(--jv-chip-0);
+	color: var(--jv-ink);
+}
+.jvp-ib:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 1px;
+}
+.jvp-ib svg {
+	width: 16px;
+	height: 16px;
+}
+.jvp-ib--sm {
+	width: 24px;
+	height: 24px;
+}
+.jvp-ib--sm svg {
+	width: 14px;
+	height: 14px;
+}
 
 /* ---- context chip ---- */
 .jvp-ctx {
@@ -808,7 +1022,12 @@ defineExpose({ load, startNewChat, convId });
 	border-radius: 11px;
 	padding: 7px 8px 7px 10px;
 }
-.jvp-ctx svg { width: 15px; height: 15px; flex: none; color: var(--jv-ink-2); }
+.jvp-ctx svg {
+	width: 15px;
+	height: 15px;
+	flex: none;
+	color: var(--jv-ink-2);
+}
 .jvp-ctx-txt {
 	flex: 1;
 	min-width: 0;
@@ -818,7 +1037,10 @@ defineExpose({ load, startNewChat, convId });
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-.jvp-ctx-txt b { font-weight: 600; color: var(--jv-ink); }
+.jvp-ctx-txt b {
+	font-weight: 600;
+	color: var(--jv-ink);
+}
 
 /* ---- body ---- */
 .jvp-body {
@@ -840,8 +1062,16 @@ defineExpose({ load, startNewChat, convId });
 	color: var(--jv-ink-2);
 	font-size: 13.5px;
 }
-.jvp-err { font-size: 13px; color: var(--jv-danger); }
-.jvp-inline-err { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.jvp-err {
+	font-size: 13px;
+	color: var(--jv-danger);
+}
+.jvp-inline-err {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
 
 /* ---- welcome ---- */
 .jvp-welcome {
@@ -860,7 +1090,10 @@ defineExpose({ load, startNewChat, convId });
 	place-items: center;
 	box-shadow: 0 14px 30px -10px rgba(106, 86, 232, 0.6);
 }
-.jvp-hero svg { width: 29px; height: 29px; }
+.jvp-hero svg {
+	width: 29px;
+	height: 29px;
+}
 .jvp-greet {
 	font-size: 22px;
 	font-weight: 700;
@@ -876,8 +1109,17 @@ defineExpose({ load, startNewChat, convId });
 	color: var(--jv-ink-2);
 	text-align: center;
 }
-.jvp-greet-sub b { font-weight: 600; color: var(--jv-ink); }
-.jvp-cards { display: flex; flex-direction: column; gap: 10px; width: 100%; margin-top: 28px; }
+.jvp-greet-sub b {
+	font-weight: 600;
+	color: var(--jv-ink);
+}
+.jvp-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	width: 100%;
+	margin-top: 28px;
+}
 .jvp-card {
 	display: flex;
 	align-items: flex-start;
@@ -891,8 +1133,13 @@ defineExpose({ load, startNewChat, convId });
 	cursor: pointer;
 	transition: border-color 0.12s ease, background-color 0.12s ease;
 }
-.jvp-card:hover { border-color: var(--jv-accent); }
-.jvp-card:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
+.jvp-card:hover {
+	border-color: var(--jv-accent);
+}
+.jvp-card:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 1px;
+}
 .jvp-card-ic {
 	width: 30px;
 	height: 30px;
@@ -902,19 +1149,56 @@ defineExpose({ load, startNewChat, convId });
 	place-items: center;
 	color: var(--jv-ink);
 }
-.jvp-card-ic svg { width: 16px; height: 16px; }
-.jvp-card-ic--0 { background: var(--jv-chip-0); }
-.jvp-card-ic--1 { background: var(--jv-chip-1); }
-.jvp-card-ic--2 { background: var(--jv-chip-2); }
-.jvp-card-ic--3 { background: var(--jv-chip-3); }
-.jvp-card-txt { min-width: 0; overflow-wrap: anywhere; }
-.jvp-card-t { display: block; font-size: 13.5px; font-weight: 600; color: var(--jv-ink); }
-.jvp-card-p { display: block; font-size: 12.5px; color: var(--jv-ink-2); margin-top: 2px; line-height: 1.4; }
+.jvp-card-ic svg {
+	width: 16px;
+	height: 16px;
+}
+.jvp-card-ic--0 {
+	background: var(--jv-chip-0);
+}
+.jvp-card-ic--1 {
+	background: var(--jv-chip-1);
+}
+.jvp-card-ic--2 {
+	background: var(--jv-chip-2);
+}
+.jvp-card-ic--3 {
+	background: var(--jv-chip-3);
+}
+.jvp-card-txt {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.jvp-card-t {
+	display: block;
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--jv-ink);
+}
+.jvp-card-p {
+	display: block;
+	font-size: 12.5px;
+	color: var(--jv-ink-2);
+	margin-top: 2px;
+	line-height: 1.4;
+}
 
 /* ---- messages ---- */
-.jvp-msgs { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
-.jvp-row { display: flex; gap: 9px; align-items: flex-start; min-width: 0; }
-.jvp-row--user { justify-content: flex-end; }
+.jvp-msgs {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	min-width: 0;
+}
+.jvp-row {
+	display: flex;
+	gap: 9px;
+	align-items: flex-start;
+	min-width: 0;
+}
+.jvp-row--user {
+	justify-content: flex-end;
+}
 .jvp-m-avatar {
 	width: 27px;
 	height: 27px;
@@ -925,7 +1209,10 @@ defineExpose({ load, startNewChat, convId });
 	place-items: center;
 	margin-top: 2px;
 }
-.jvp-m-avatar svg { width: 15px; height: 15px; }
+.jvp-m-avatar svg {
+	width: 15px;
+	height: 15px;
+}
 .jvp-m-user {
 	max-width: 270px;
 	background: var(--jv-grad);
@@ -953,22 +1240,45 @@ defineExpose({ load, startNewChat, convId });
 
 /* ---- rendered markdown inside an assistant bubble ----
    :deep because the HTML comes from v-html and carries no scope id. */
-.jv-md :deep(.jv-md-p) { margin: 0 0 8px; }
-.jv-md :deep(.jv-md-p:last-child) { margin-bottom: 0; }
+.jv-md :deep(.jv-md-p) {
+	margin: 0 0 8px;
+}
+.jv-md :deep(.jv-md-p:last-child) {
+	margin-bottom: 0;
+}
 .jv-md :deep(.jv-md-h) {
 	margin: 12px 0 6px;
 	font-size: 14px;
 	font-weight: 600;
 	color: var(--jv-ink);
 }
-.jv-md :deep(.jv-md-h:first-child) { margin-top: 0; }
-.jv-md :deep(.jv-md-list) { margin: 0 0 8px; padding-left: 18px; }
-.jv-md :deep(.jv-md-list:last-child) { margin-bottom: 0; }
-.jv-md :deep(.jv-md-list li) { margin: 3px 0; }
-.jv-md :deep(.jv-md-list li::marker) { color: var(--jv-ink-3); }
-.jv-md :deep(strong) { font-weight: 600; color: var(--jv-ink); }
-.jv-md :deep(.jv-md-link) { color: var(--jv-accent); text-decoration: none; }
-.jv-md :deep(.jv-md-link:hover) { text-decoration: underline; }
+.jv-md :deep(.jv-md-h:first-child) {
+	margin-top: 0;
+}
+.jv-md :deep(.jv-md-list) {
+	margin: 0 0 8px;
+	padding-left: 18px;
+}
+.jv-md :deep(.jv-md-list:last-child) {
+	margin-bottom: 0;
+}
+.jv-md :deep(.jv-md-list li) {
+	margin: 3px 0;
+}
+.jv-md :deep(.jv-md-list li::marker) {
+	color: var(--jv-ink-3);
+}
+.jv-md :deep(strong) {
+	font-weight: 600;
+	color: var(--jv-ink);
+}
+.jv-md :deep(.jv-md-link) {
+	color: var(--jv-accent);
+	text-decoration: none;
+}
+.jv-md :deep(.jv-md-link:hover) {
+	text-decoration: underline;
+}
 .jv-md :deep(.jv-md-code) {
 	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 	font-size: 12px;
@@ -1020,7 +1330,9 @@ defineExpose({ load, startNewChat, convId });
 	background: var(--jv-chip-0);
 	font-size: 11.5px;
 }
-.jv-md :deep(.jv-md-table tr:last-child td) { border-bottom: none; }
+.jv-md :deep(.jv-md-table tr:last-child td) {
+	border-bottom: none;
+}
 .jv-md :deep(.jv-md-table td[align="right"]),
 .jv-md :deep(.jv-md-table th[align="right"]) {
 	text-align: right;
@@ -1038,26 +1350,71 @@ defineExpose({ load, startNewChat, convId });
 	padding: 11px 13px;
 	color: var(--jv-ink-2);
 }
-.jvp-think-dots { display: inline-flex; align-items: flex-end; gap: 3px; height: 10px; }
-.jvp-think-dots i { width: 5px; height: 5px; border-radius: 999px; background: var(--jv-accent); opacity: 0.35; }
+.jvp-think-dots {
+	display: inline-flex;
+	align-items: flex-end;
+	gap: 3px;
+	height: 10px;
+}
+.jvp-think-dots i {
+	width: 5px;
+	height: 5px;
+	border-radius: 999px;
+	background: var(--jv-accent);
+	opacity: 0.35;
+}
 @media (prefers-reduced-motion: no-preference) {
-	.jvp-think-dots i { animation: jvp-dot 1.2s infinite ease-in-out; }
-	.jvp-think-dots i:nth-child(2) { animation-delay: 0.15s; }
-	.jvp-think-dots i:nth-child(3) { animation-delay: 0.3s; }
+	.jvp-think-dots i {
+		animation: jvp-dot 1.2s infinite ease-in-out;
+	}
+	.jvp-think-dots i:nth-child(2) {
+		animation-delay: 0.15s;
+	}
+	.jvp-think-dots i:nth-child(3) {
+		animation-delay: 0.3s;
+	}
 }
 @keyframes jvp-dot {
-	0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
-	40% { transform: translateY(-5px); opacity: 1; }
+	0%,
+	80%,
+	100% {
+		transform: translateY(0);
+		opacity: 0.35;
+	}
+	40% {
+		transform: translateY(-5px);
+		opacity: 1;
+	}
 }
 
 /* ---- pending write confirmation ---- */
-.jvp-pending { flex: none; border-top: 1px solid var(--jv-rule); padding: 11px 15px; }
-.jvp-pending-row { display: flex; flex-direction: column; gap: 9px; }
-.jvp-pending-txt { font-size: 13px; line-height: 1.45; color: var(--jv-ink); }
-.jvp-pending-acts { display: flex; gap: 8px; justify-content: flex-end; }
+.jvp-pending {
+	flex: none;
+	border-top: 1px solid var(--jv-rule);
+	padding: 11px 15px;
+}
+.jvp-pending-row {
+	display: flex;
+	flex-direction: column;
+	gap: 9px;
+}
+.jvp-pending-txt {
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--jv-ink);
+}
+.jvp-pending-acts {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
 
 /* ---- composer ---- */
-.jvp-foot { flex: none; padding: 12px 15px 14px; border-top: 1px solid var(--jv-rule); }
+.jvp-foot {
+	flex: none;
+	padding: 12px 15px 14px;
+	border-top: 1px solid var(--jv-rule);
+}
 .jvp-comp {
 	display: flex;
 	align-items: flex-end;
@@ -1068,7 +1425,8 @@ defineExpose({ load, startNewChat, convId });
 	background: var(--jv-comp-bg);
 	transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
-.jvp-comp--focus, .jvp-comp:focus-within {
+.jvp-comp--focus,
+.jvp-comp:focus-within {
 	border-color: var(--jv-accent);
 	box-shadow: 0 0 0 3px rgba(106, 86, 232, 0.12);
 }
@@ -1086,7 +1444,9 @@ defineExpose({ load, startNewChat, convId });
 	max-height: 120px;
 	outline: none;
 }
-.jvp-comp-text::placeholder { color: var(--jv-ink-3); }
+.jvp-comp-text::placeholder {
+	color: var(--jv-ink-3);
+}
 .jvp-send {
 	width: 33px;
 	height: 33px;
@@ -1099,15 +1459,38 @@ defineExpose({ load, startNewChat, convId });
 	cursor: pointer;
 	transition: opacity 0.12s ease;
 }
-.jvp-send svg { width: 17px; height: 17px; }
-.jvp-send:hover { opacity: 0.9; }
-.jvp-send:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 2px; }
-.jvp-send[disabled] { background: var(--jv-chip-0); cursor: not-allowed; }
-.jvp-send[disabled] svg { stroke: var(--jv-ink-3); }
-.jvp-send--stop { background: var(--jv-chip-0); color: var(--jv-ink); }
-.jvp-send--stop svg { stroke: currentColor; }
+.jvp-send svg {
+	width: 17px;
+	height: 17px;
+}
+.jvp-send:hover {
+	opacity: 0.9;
+}
+.jvp-send:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 2px;
+}
+.jvp-send[disabled] {
+	background: var(--jv-chip-0);
+	cursor: not-allowed;
+}
+.jvp-send[disabled] svg {
+	stroke: var(--jv-ink-3);
+}
+.jvp-send--stop {
+	background: var(--jv-chip-0);
+	color: var(--jv-ink);
+}
+.jvp-send--stop svg {
+	stroke: currentColor;
+}
 /* attachments + inline composer buttons */
-.jvp-atts { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.jvp-atts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 8px;
+}
 .jvp-att {
 	display: inline-flex;
 	align-items: center;
@@ -1120,43 +1503,118 @@ defineExpose({ load, startNewChat, convId });
 	color: var(--jv-ink-2);
 	background: var(--jv-chip-0);
 }
-.jvp-att svg { width: 13px; height: 13px; flex: none; }
-.jvp-att-n { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.jvp-att-x {
-	width: 18px; height: 18px; flex: none; border: none; background: transparent;
-	color: var(--jv-ink-2); cursor: pointer; display: grid; place-items: center; border-radius: 5px;
+.jvp-att svg {
+	width: 13px;
+	height: 13px;
+	flex: none;
 }
-.jvp-att-x:hover { color: var(--jv-ink); }
-.jvp-att-x svg { width: 12px; height: 12px; }
+.jvp-att-n {
+	max-width: 150px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jvp-att-x {
+	width: 18px;
+	height: 18px;
+	flex: none;
+	border: none;
+	background: transparent;
+	color: var(--jv-ink-2);
+	cursor: pointer;
+	display: grid;
+	place-items: center;
+	border-radius: 5px;
+}
+.jvp-att-x:hover {
+	color: var(--jv-ink);
+}
+.jvp-att-x svg {
+	width: 12px;
+	height: 12px;
+}
 
 .jvp-cib {
-	width: 29px; height: 29px; flex: 0 0 auto; align-self: flex-end;
-	border: none; background: transparent; border-radius: 8px;
-	color: var(--jv-ink-2); cursor: pointer; display: grid; place-items: center;
+	width: 29px;
+	height: 29px;
+	flex: 0 0 auto;
+	align-self: flex-end;
+	border: none;
+	background: transparent;
+	border-radius: 8px;
+	color: var(--jv-ink-2);
+	cursor: pointer;
+	display: grid;
+	place-items: center;
 	transition: background-color 0.12s ease, color 0.12s ease;
 }
-.jvp-cib:hover:not([disabled]) { background: var(--jv-chip-0); color: var(--jv-ink); }
-.jvp-cib:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
-.jvp-cib[disabled] { opacity: 0.5; cursor: not-allowed; }
-.jvp-cib svg { width: 17px; height: 17px; }
-.jvp-cib--rec { color: var(--jv-accent); }
-.jvp-comp--rec { border-color: var(--jv-accent); }
+.jvp-cib:hover:not([disabled]) {
+	background: var(--jv-chip-0);
+	color: var(--jv-ink);
+}
+.jvp-cib:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 1px;
+}
+.jvp-cib[disabled] {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+.jvp-cib svg {
+	width: 17px;
+	height: 17px;
+}
+.jvp-cib--rec {
+	color: var(--jv-accent);
+}
+.jvp-comp--rec {
+	border-color: var(--jv-accent);
+}
 
 /* live level bars while recording */
-.jvp-wave { display: inline-flex; align-items: center; gap: 2px; height: 15px; }
-.jvp-wave i { width: 2.5px; height: 100%; border-radius: 2px; background: var(--jv-accent); transform: scaleY(0.3); }
+.jvp-wave {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	height: 15px;
+}
+.jvp-wave i {
+	width: 2.5px;
+	height: 100%;
+	border-radius: 2px;
+	background: var(--jv-accent);
+	transform: scaleY(0.3);
+}
 @media (prefers-reduced-motion: no-preference) {
-	.jvp-wave i { animation: jvp-wave 0.9s infinite ease-in-out; }
-	.jvp-wave i:nth-child(2) { animation-delay: 0.15s; }
-	.jvp-wave i:nth-child(3) { animation-delay: 0.3s; }
-	.jvp-wave i:nth-child(4) { animation-delay: 0.45s; }
+	.jvp-wave i {
+		animation: jvp-wave 0.9s infinite ease-in-out;
+	}
+	.jvp-wave i:nth-child(2) {
+		animation-delay: 0.15s;
+	}
+	.jvp-wave i:nth-child(3) {
+		animation-delay: 0.3s;
+	}
+	.jvp-wave i:nth-child(4) {
+		animation-delay: 0.45s;
+	}
 }
 @keyframes jvp-wave {
-	0%, 100% { transform: scaleY(0.3); }
-	50% { transform: scaleY(1); }
+	0%,
+	100% {
+		transform: scaleY(0.3);
+	}
+	50% {
+		transform: scaleY(1);
+	}
 }
 
-.jvp-foot-note { text-align: center; font-size: 11px; color: var(--jv-ink-3); margin-top: 8px; }
+.jvp-foot-note {
+	text-align: center;
+	font-size: 11px;
+	color: var(--jv-ink-3);
+	margin-top: 8px;
+}
 
 /* ---- buttons ---- */
 .jvp-btn-subtle {
@@ -1170,7 +1628,9 @@ defineExpose({ load, startNewChat, convId });
 	font-size: 13px;
 	cursor: pointer;
 }
-.jvp-btn-subtle:hover { background: var(--jv-chip-0); }
+.jvp-btn-subtle:hover {
+	background: var(--jv-chip-0);
+}
 .jvp-btn-solid {
 	height: 29px;
 	padding: 0 13px;
@@ -1183,5 +1643,8 @@ defineExpose({ load, startNewChat, convId });
 	font-weight: 600;
 	cursor: pointer;
 }
-.jvp-btn-solid[disabled] { opacity: 0.6; cursor: not-allowed; }
+.jvp-btn-solid[disabled] {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
 </style>

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1,6 +1,9 @@
 <template>
-	<!-- Docked side chat. Kept mounted and toggled with v-show so the
-	     conversation, scroll position and draft survive a close/reopen. -->
+	<!-- Jarvis mini chat. Visual language follows the "Jarvis Side Chat" design
+	     board (gradient brand mark, tinted starter cards, pill composer) rather
+	     than design.md's gray chrome — a deliberate, recorded divergence for this
+	     surface. Kept mounted and toggled with v-show so the conversation,
+	     scroll position and draft survive a close/reopen. -->
 	<div
 		v-show="open"
 		class="jvp-root"
@@ -11,46 +14,40 @@
 	>
 		<div class="jvp-panel" ref="panelEl" tabindex="-1">
 			<div class="jvp-head">
-				<div class="jvp-title">
-					<svg class="jvp-mark" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<div class="jvp-avatar">
+					<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
 						<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
 					</svg>
-					Jarvis
+					<i class="jvp-online" aria-hidden="true"></i>
 				</div>
+				<div class="jvp-title">Jarvis</div>
 				<div class="jvp-actions">
 					<button class="jvp-ib" type="button" aria-label="New chat" @click="startNewChat">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
 							<path d="M12 5v14M5 12h14" />
 						</svg>
 					</button>
 					<button class="jvp-ib" type="button" aria-label="Open full chat" @click="$emit('open-full')">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
 							<path d="M15 3h6v6M21 3l-7 7M10 21H4v-6M4 21l7-7" />
 						</svg>
 					</button>
 					<button class="jvp-ib" type="button" aria-label="Close" @click="$emit('close')">
-						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
 							<path d="M18 6 6 18M6 6l12 12" />
 						</svg>
 					</button>
 				</div>
 			</div>
 
-			<!-- Quiet bordered note (design.md 3.7): ambient state, not an alert,
-			     so no colored fill. -->
 			<div v-if="contextText" class="jvp-ctx">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 					<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
 					<path d="M14 2v6h6" />
 				</svg>
 				<div class="jvp-ctx-txt">Viewing <b>{{ contextText }}</b></div>
-				<button
-					class="jvp-ib jvp-ib--sm"
-					type="button"
-					aria-label="Stop using this page as context"
-					@click="$emit('dismiss-context')"
-				>
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+				<button class="jvp-ib jvp-ib--sm" type="button" aria-label="Stop using this page as context" @click="$emit('dismiss-context')">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
 						<path d="M18 6 6 18M6 6l12 12" />
 					</svg>
 				</button>
@@ -64,44 +61,75 @@
 					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
 				</div>
 
-				<!-- Welcome: greeting + a few starting points, so an empty panel
-				     suggests what to do rather than showing a blank box. -->
+				<!-- Welcome: brand mark, greeting, and starting points. -->
 				<div v-else-if="!shownMessages.length && !stream.live && !thinking" class="jvp-welcome">
+					<div class="jvp-hero">
+						<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
+							<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+						</svg>
+					</div>
 					<div class="jvp-greet">{{ greeting }}</div>
 					<p class="jvp-greet-sub">
-						{{
-							contextText
-								? `Jarvis can see ${contextText} while you are on this page.`
-								: "Ask about your ERP data, run a workflow, or draft something."
-						}}
+						<template v-if="contextText">
+							Jarvis can see <b>{{ contextText }}</b> while you are on this page.
+						</template>
+						<template v-else>
+							Ask about your ERP data, run a workflow, or draft something.
+						</template>
 					</p>
 					<div class="jvp-cards">
 						<button
-							v-for="s in suggestions"
+							v-for="(s, i) in suggestions"
 							:key="s.title"
 							class="jvp-card"
 							type="button"
 							@click="useSuggestion(s.prompt)"
 						>
-							<span class="jvp-card-t">{{ s.title }}</span>
-							<span class="jvp-card-p">{{ s.prompt }}</span>
+							<span class="jvp-card-ic" :class="`jvp-card-ic--${i % 4}`" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+									<path :d="CARD_ICONS[i % CARD_ICONS.length]" />
+								</svg>
+							</span>
+							<span class="jvp-card-txt">
+								<span class="jvp-card-t">{{ s.title }}</span>
+								<span class="jvp-card-p">{{ s.prompt }}</span>
+							</span>
 						</button>
 					</div>
 				</div>
 
 				<div v-else class="jvp-msgs">
-					<div
-						v-for="m in shownMessages"
-						:key="m.name"
-						:class="m.role === 'user' ? 'jvp-m-user' : 'jvp-m-bot'"
-					>{{ m.content }}</div>
-					<div v-if="stream.live && stream.live.text" class="jvp-m-bot">{{ stream.live.text }}</div>
+					<template v-for="m in shownMessages" :key="m.name">
+						<div v-if="m.role === 'user'" class="jvp-row jvp-row--user">
+							<div class="jvp-m-user">{{ m.content }}</div>
+						</div>
+						<div v-else class="jvp-row">
+							<div class="jvp-m-avatar" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+							</div>
+							<div class="jvp-m-bot">{{ m.content }}</div>
+						</div>
+					</template>
+
+					<div v-if="stream.live && stream.live.text" class="jvp-row">
+						<div class="jvp-m-avatar" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+						</div>
+						<div class="jvp-m-bot">{{ stream.live.text }}</div>
+					</div>
+
 					<!-- Waiting for the first token: a labelled state, not a bare
 					     spinner, so the user knows the turn was accepted. -->
-					<div v-else-if="thinking" class="jvp-think" role="status" aria-live="polite">
-						<span class="jvp-think-dots" aria-hidden="true"><i></i><i></i><i></i></span>
-						<span class="jvp-think-txt">Working…</span>
+					<div v-else-if="thinking" class="jvp-row">
+						<div class="jvp-m-avatar" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
+						</div>
+						<div class="jvp-think" role="status" aria-live="polite">
+							<span class="jvp-think-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+							<span class="jvp-think-txt">Working…</span>
+						</div>
 					</div>
+
 					<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
 						<span class="jvp-err">{{ loadError }}</span>
 						<button class="jvp-btn-subtle" type="button" @click="retryLast">Retry</button>
@@ -109,21 +137,14 @@
 				</div>
 			</div>
 
-			<!-- A blocked write is the one thing here the user must act on, so it
-			     is the only place the panel raises its voice. -->
 			<div v-if="stream.pending.length" class="jvp-pending">
 				<div v-for="p in stream.pending" :key="p.token" class="jvp-pending-row">
 					<div class="jvp-pending-txt">{{ p.summary || "Jarvis wants to make a change." }}</div>
 					<div class="jvp-pending-acts">
-						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">
-							Review in full chat
+						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">Review in full chat</button>
+						<button class="jvp-btn-solid" type="button" :disabled="resolving === p.token" @click="resolvePending(p.token)">
+							{{ resolving === p.token ? "Confirming…" : "Confirm" }}
 						</button>
-						<button
-							class="jvp-btn-solid"
-							type="button"
-							:disabled="resolving === p.token"
-							@click="resolvePending(p.token)"
-						>{{ resolving === p.token ? "Confirming…" : "Confirm" }}</button>
 					</div>
 				</div>
 			</div>
@@ -134,40 +155,25 @@
 						class="jvp-comp-text"
 						ref="textareaEl"
 						rows="1"
-						:placeholder="contextText ? `Ask about ${contextText}…` : 'Ask Jarvis…'"
+						:placeholder="contextText ? `Ask about ${contextText}…` : 'Ask Jarvis anything…'"
 						v-model="draft"
 						@focus="composerFocused = true"
 						@blur="composerFocused = false"
 						@input="autoGrow"
 						@keydown.enter.exact.prevent="send"
 					></textarea>
-					<div class="jvp-comp-bar">
-						<span class="jvp-comp-hint">{{ hint }}</span>
-						<button
-							v-if="stream.live"
-							class="jvp-send jvp-send--stop"
-							type="button"
-							aria-label="Stop generating"
-							@click="stop"
-						>
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-								<rect x="7" y="7" width="10" height="10" rx="2" />
-							</svg>
-						</button>
-						<button
-							v-else
-							class="jvp-send"
-							type="button"
-							aria-label="Send message"
-							:disabled="!canSend"
-							@click="send"
-						>
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-								<path d="M12 19V5M5 12l7-7 7 7" />
-							</svg>
-						</button>
-					</div>
+					<button v-if="stream.live" class="jvp-send jvp-send--stop" type="button" aria-label="Stop generating" @click="stop">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+							<rect x="7" y="7" width="10" height="10" rx="2" />
+						</svg>
+					</button>
+					<button v-else class="jvp-send" type="button" aria-label="Send message" :disabled="!canSend" @click="send">
+						<svg viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M12 19V5M5 12l7-7 7 7" />
+						</svg>
+					</button>
 				</div>
+				<div class="jvp-foot-note">{{ hint }}</div>
 			</div>
 		</div>
 	</div>
@@ -235,6 +241,14 @@ const greeting = computed(() => {
 	return greetingLine(new Date().getHours(), who);
 });
 const suggestions = computed(() => suggestionsFor(props.context));
+
+// Lucide-shaped paths for the starter-card chips, indexed alongside suggestions.
+const CARD_ICONS = [
+	"M3 3v18h18M7 15l4-4 3 3 5-6", // trending analysis
+	"M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z", // draft / act
+	"m21 21-4.3-4.3M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16z", // search
+	"M12 2v20M2 12h20", // fallback
+];
 
 // A suggestion is a starting point, not a command: it fills the composer so
 // the user can edit before sending.
@@ -412,8 +426,45 @@ defineExpose({ load, startNewChat, convId });
 </script>
 
 <style scoped>
-/* Desk CSS variables only — the Desk already stamps the theme, so light/dark
-   comes free and no dark: variants are needed (design.md 6). */
+/* Palette lifted from the "Jarvis Side Chat" design board. Scoped to the panel
+   so it cannot leak into Desk chrome; dark values follow the Desk theme flag. */
+.jvp-panel {
+	--jv-grad: linear-gradient(140deg, #8b7cf7, #6a56e8);
+	--jv-accent: #6a56e8;
+	--jv-surface: #ffffff;
+	--jv-rule: #eeeeee;
+	--jv-rule-2: #e9e9ea;
+	--jv-ink: #1f272e;
+	--jv-ink-2: #8a9096;
+	--jv-ink-3: #b0b6bb;
+	--jv-bot-bg: #f5f4f8;
+	--jv-bot-bd: #eeedf4;
+	--jv-comp-bg: #fafafa;
+	--jv-comp-bd: #e2e2e2;
+	--jv-chip-0: #f1f1f2;
+	--jv-chip-1: #e4f0e7;
+	--jv-chip-2: #fbeeddff;
+	--jv-chip-3: #eae7fb;
+	--jv-danger: #c0392b;
+}
+:global([data-theme="dark"]) .jvp-panel {
+	--jv-surface: #1e1d23;
+	--jv-rule: #2a2833;
+	--jv-rule-2: #2e2c36;
+	--jv-ink: #eceaf2;
+	--jv-ink-2: #9a97a6;
+	--jv-ink-3: #6e6b7a;
+	--jv-bot-bg: #26242e;
+	--jv-bot-bd: #302e3a;
+	--jv-comp-bg: #24222b;
+	--jv-comp-bd: #34313f;
+	--jv-chip-0: #2b2933;
+	--jv-chip-1: #1d2f25;
+	--jv-chip-2: #33291b;
+	--jv-chip-3: #2a2540;
+	--jv-danger: #ff8a80;
+}
+
 /* A mini chat window, not a full-height dock: left/top/width/height are set
    inline from panel_anchor.panelLayout() so the window follows the FAB
    wherever the user dragged it. */
@@ -423,387 +474,223 @@ defineExpose({ load, startNewChat, convId });
 	display: flex;
 	pointer-events: none;
 }
-
 .jvp-panel {
 	pointer-events: auto;
 	display: flex;
 	flex-direction: column;
 	flex: 1;
 	min-height: 0;
-	background: var(--card-bg, #fff);
-	border: 1px solid var(--border-color);
-	border-radius: 12px;
-	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+	background: var(--jv-surface);
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 22px;
+	box-shadow: 0 24px 60px -12px rgba(24, 20, 50, 0.28), 0 8px 20px -8px rgba(24, 20, 50, 0.16);
 	overflow: hidden;
 	font-size: 14px;
-	letter-spacing: 0.02em;
-	color: var(--text-color);
+	color: var(--jv-ink);
 	outline: none;
 }
-
-/* design.md 3.2: overlays fade + scale 0.98 -> 1 in 100ms. Not a slide — this
-   is the same motion every other overlay in the product uses. Gated so
-   reduced-motion users get an instant swap. */
 @media (prefers-reduced-motion: no-preference) {
-	.jvp-panel {
-		animation: jvp-in 100ms ease-out;
-	}
+	.jvp-panel { animation: jvp-in 120ms ease-out; }
 }
 @keyframes jvp-in {
-	from {
-		opacity: 0;
-		transform: scale(0.98);
-	}
-	to {
-		opacity: 1;
-		transform: scale(1);
-	}
+	from { opacity: 0; transform: scale(0.98); }
+	to { opacity: 1; transform: scale(1); }
 }
 
+/* ---- header ---- */
 .jvp-head {
-	height: 42px;
 	flex: none;
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	padding: 0 8px 0 12px;
-	border-bottom: 1px solid var(--border-color);
+	gap: 11px;
+	padding: 13px 15px;
+	border-bottom: 1px solid var(--jv-rule);
 }
-.jvp-title {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-weight: 600;
+.jvp-avatar {
+	position: relative;
+	width: 30px;
+	height: 30px;
+	flex: 0 0 auto;
+	border-radius: 9px;
+	background: var(--jv-grad);
+	display: grid;
+	place-items: center;
 }
-.jvp-mark {
-	width: 16px;
-	height: 16px;
-	flex: none;
+.jvp-avatar svg { width: 17px; height: 17px; }
+.jvp-online {
+	position: absolute;
+	right: -2px;
+	bottom: -2px;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: #3ad07e;
+	border: 2px solid var(--jv-surface);
 }
-.jvp-actions {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-}
-
+.jvp-title { flex: 1; font-size: 14.5px; font-weight: 600; color: var(--jv-ink); }
+.jvp-actions { display: flex; align-items: center; gap: 2px; }
 .jvp-ib {
-	width: 28px;
-	height: 28px;
+	width: 29px;
+	height: 29px;
 	flex: none;
 	border: none;
 	background: transparent;
-	border-radius: 8px;
-	color: var(--text-muted);
+	border-radius: 7px;
+	color: var(--jv-ink-2);
 	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition: background-color 0.12s ease;
+	display: grid;
+	place-items: center;
+	transition: background-color 0.12s ease, color 0.12s ease;
 }
-.jvp-ib:hover {
-	background: var(--fg-hover-color, rgba(0, 0, 0, 0.05));
-}
-.jvp-ib:focus-visible {
-	outline: 2px solid var(--border-primary, #999);
-	outline-offset: 1px;
-}
-.jvp-ib svg {
-	width: 16px;
-	height: 16px;
-}
-.jvp-ib--sm {
-	width: 24px;
-	height: 24px;
-}
-.jvp-ib--sm svg {
-	width: 14px;
-	height: 14px;
-}
+.jvp-ib:hover { background: var(--jv-chip-0); color: var(--jv-ink); }
+.jvp-ib:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
+.jvp-ib svg { width: 16px; height: 16px; }
+.jvp-ib--sm { width: 24px; height: 24px; }
+.jvp-ib--sm svg { width: 14px; height: 14px; }
 
+/* ---- context chip ---- */
 .jvp-ctx {
-	margin: 12px 12px 0;
+	flex: none;
+	margin: 11px 15px 0;
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	border: 1px solid var(--border-color);
-	border-radius: 10px;
-	padding: 7px 8px;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 11px;
+	padding: 7px 8px 7px 10px;
 }
-.jvp-ctx svg {
-	width: 16px;
-	height: 16px;
-	flex: none;
-	color: var(--text-muted);
-}
+.jvp-ctx svg { width: 15px; height: 15px; flex: none; color: var(--jv-ink-2); }
 .jvp-ctx-txt {
 	flex: 1;
 	min-width: 0;
 	font-size: 12px;
-	line-height: 1.35;
-	color: var(--text-muted);
+	color: var(--jv-ink-2);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-.jvp-ctx-txt b {
-	font-weight: 600;
-	color: var(--text-color);
-}
+.jvp-ctx-txt b { font-weight: 600; color: var(--jv-ink); }
 
-.jvp-body {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding: 14px 12px;
-}
-
+/* ---- body ---- */
+.jvp-body { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 15px; }
 .jvp-center {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 9px;
+	gap: 10px;
 	text-align: center;
-	padding: 22px;
-	color: var(--text-muted);
-}
-.jvp-empty-ic {
-	width: 28px;
-	height: 28px;
-}
-.jvp-empty-t {
-	font-size: 16px;
-	font-weight: 500;
-	color: var(--text-color);
-}
-.jvp-empty-d {
-	font-size: 14px;
-	line-height: 1.5;
-	max-width: 30ch;
-}
-.jvp-err {
+	color: var(--jv-ink-2);
 	font-size: 13.5px;
-	color: var(--text-danger, #c0392b);
 }
+.jvp-err { font-size: 13px; color: var(--jv-danger); }
+.jvp-inline-err { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
 /* ---- welcome ---- */
 .jvp-welcome {
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
-	padding: 6px 2px 2px;
+	align-items: center;
+	padding: 24px 9px 8px;
 }
+.jvp-hero {
+	width: 52px;
+	height: 52px;
+	border-radius: 14px;
+	background: var(--jv-grad);
+	display: grid;
+	place-items: center;
+	box-shadow: 0 14px 30px -10px rgba(106, 86, 232, 0.6);
+}
+.jvp-hero svg { width: 29px; height: 29px; }
 .jvp-greet {
-	font-size: 19px;
-	font-weight: 600;
-	color: var(--text-color);
+	font-size: 22px;
+	font-weight: 700;
+	color: var(--jv-ink);
+	margin-top: 18px;
+	text-align: center;
 	letter-spacing: -0.01em;
 }
 .jvp-greet-sub {
-	margin: 0;
+	margin: 7px 0 0;
 	font-size: 13.5px;
-	line-height: 1.5;
-	color: var(--text-muted);
+	line-height: 1.55;
+	color: var(--jv-ink-2);
+	text-align: center;
 }
-.jvp-cards {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	margin-top: 12px;
-}
-/* Cards are bordered and flat: selection and hover are colour shifts, never a
-   lift (design.md 1.3, 5 row 2). */
+.jvp-greet-sub b { font-weight: 600; color: var(--jv-ink); }
+.jvp-cards { display: flex; flex-direction: column; gap: 10px; width: 100%; margin-top: 28px; }
 .jvp-card {
 	display: flex;
-	flex-direction: column;
-	gap: 3px;
+	align-items: flex-start;
+	gap: 12px;
 	text-align: left;
-	padding: 10px 12px;
-	border: 1px solid var(--border-color);
-	border-radius: 10px;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 12px;
+	padding: 13px 14px;
 	background: transparent;
 	font: inherit;
-	letter-spacing: inherit;
 	cursor: pointer;
-	transition: background-color 0.12s ease, border-color 0.12s ease;
+	transition: border-color 0.12s ease, background-color 0.12s ease;
 }
-.jvp-card:hover {
-	background: var(--control-bg, #f3f3f3);
+.jvp-card:hover { border-color: var(--jv-accent); }
+.jvp-card:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
+.jvp-card-ic {
+	width: 30px;
+	height: 30px;
+	flex: 0 0 auto;
+	border-radius: 9px;
+	display: grid;
+	place-items: center;
+	color: var(--jv-ink);
 }
-.jvp-card:focus-visible {
-	outline: 2px solid var(--border-primary, #999);
-	outline-offset: 1px;
-}
-.jvp-card-t {
-	font-size: 13.5px;
-	font-weight: 500;
-	color: var(--text-color);
-}
-.jvp-card-p {
-	font-size: 12.5px;
-	line-height: 1.45;
-	color: var(--text-muted);
-}
-.jvp-inline-err {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	flex-wrap: wrap;
-}
+.jvp-card-ic svg { width: 16px; height: 16px; }
+.jvp-card-ic--0 { background: var(--jv-chip-0); }
+.jvp-card-ic--1 { background: var(--jv-chip-1); }
+.jvp-card-ic--2 { background: var(--jv-chip-2); }
+.jvp-card-ic--3 { background: var(--jv-chip-3); }
+.jvp-card-txt { min-width: 0; }
+.jvp-card-t { display: block; font-size: 13.5px; font-weight: 600; color: var(--jv-ink); }
+.jvp-card-p { display: block; font-size: 12.5px; color: var(--jv-ink-2); margin-top: 2px; line-height: 1.4; }
 
-.jvp-msgs {
-	display: flex;
-	flex-direction: column;
-	gap: 14px;
+/* ---- messages ---- */
+.jvp-msgs { display: flex; flex-direction: column; gap: 14px; }
+.jvp-row { display: flex; gap: 9px; align-items: flex-start; }
+.jvp-row--user { justify-content: flex-end; }
+.jvp-m-avatar {
+	width: 27px;
+	height: 27px;
+	flex: 0 0 auto;
+	border-radius: 9px;
+	background: var(--jv-grad);
+	display: grid;
+	place-items: center;
+	margin-top: 2px;
 }
+.jvp-m-avatar svg { width: 15px; height: 15px; }
 .jvp-m-user {
-	align-self: flex-end;
-	max-width: 84%;
-	background: var(--control-bg, #f3f3f3);
-	border-radius: 12px;
-	padding: 8px 12px;
+	max-width: 270px;
+	background: var(--jv-grad);
+	color: #fff;
+	padding: 9px 13px;
+	border-radius: 16px 16px 5px 16px;
+	font-size: 14px;
 	line-height: 1.5;
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
+	box-shadow: 0 8px 18px -10px rgba(106, 86, 232, 0.7);
 }
 .jvp-m-bot {
-	max-width: 94%;
+	background: var(--jv-bot-bg);
+	border: 1px solid var(--jv-bot-bd);
+	border-radius: 5px 15px 15px 15px;
+	padding: 11px 13px;
+	font-size: 14px;
 	line-height: 1.5;
+	color: var(--jv-ink);
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
-}
-
-.jvp-pending {
-	flex: none;
-	border-top: 1px solid var(--border-color);
-	padding: 10px 12px;
-}
-.jvp-pending-row {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-.jvp-pending-txt {
-	font-size: 13px;
-	line-height: 1.45;
-	color: var(--text-color);
-}
-.jvp-pending-acts {
-	display: flex;
-	gap: 8px;
-	justify-content: flex-end;
-}
-
-.jvp-foot {
-	flex: none;
-	border-top: 1px solid var(--border-color);
-	padding: 12px;
-}
-
-/* One container holds the text and its controls, and the send button lives
-   inside it: at 400px a separate button row costs a message of vertical
-   space. */
-.jvp-comp {
-	background: var(--control-bg, #f3f3f3);
-	border: 1px solid transparent;
-	border-radius: 12px;
-	padding: 9px 9px 8px;
-	transition: background-color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
-}
-.jvp-comp--focus,
-.jvp-comp:focus-within {
-	background: var(--card-bg, #fff);
-	border-color: var(--border-color);
-	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-}
-.jvp-comp-text {
-	width: 100%;
-	border: none;
-	background: transparent;
-	resize: none;
-	font: inherit;
-	letter-spacing: inherit;
-	color: var(--text-color);
-	line-height: 1.5;
-	padding: 1px 3px 8px;
-	max-height: 120px;
-	outline: none;
-}
-.jvp-comp-bar {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-}
-.jvp-comp-hint {
-	font-size: 11.5px;
-	color: var(--text-muted);
-}
-
-/* The one solid button on this surface (design.md 3.1). */
-.jvp-send {
-	width: 28px;
-	height: 28px;
-	flex: none;
-	border: none;
-	border-radius: 8px;
-	cursor: pointer;
-	background: var(--text-color);
-	color: var(--card-bg, #fff);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition: opacity 0.12s ease;
-}
-.jvp-send svg {
-	width: 16px;
-	height: 16px;
-}
-.jvp-send:hover {
-	opacity: 0.88;
-}
-.jvp-send:focus-visible {
-	outline: 2px solid var(--border-primary, #999);
-	outline-offset: 2px;
-}
-.jvp-send[disabled] {
-	background: var(--control-bg, #ededed);
-	color: var(--text-muted);
-	cursor: not-allowed;
-}
-.jvp-send--stop {
-	background: var(--control-bg, #ededed);
-	color: var(--text-color);
-}
-
-.jvp-btn-subtle {
-	height: 28px;
-	padding: 0 10px;
-	border: none;
-	border-radius: 8px;
-	background: var(--control-bg, #f3f3f3);
-	color: var(--text-color);
-	font: inherit;
-	cursor: pointer;
-}
-.jvp-btn-subtle:hover {
-	background: var(--fg-hover-color, rgba(0, 0, 0, 0.08));
-}
-.jvp-btn-solid {
-	height: 28px;
-	padding: 0 12px;
-	border: none;
-	border-radius: 8px;
-	cursor: pointer;
-	background: var(--text-color);
-	color: var(--card-bg, #fff);
-	font: inherit;
-	font-weight: 500;
-}
-.jvp-btn-solid[disabled] {
-	opacity: 0.6;
-	cursor: not-allowed;
 }
 
 /* ---- waiting for a reply ---- */
@@ -811,45 +698,107 @@ defineExpose({ load, startNewChat, convId });
 	display: flex;
 	align-items: center;
 	gap: 9px;
-	color: var(--text-muted);
+	background: var(--jv-bot-bg);
+	border: 1px solid var(--jv-bot-bd);
+	border-radius: 5px 15px 15px 15px;
+	padding: 11px 13px;
+	color: var(--jv-ink-2);
 	font-size: 13.5px;
 }
-.jvp-think-dots {
-	display: inline-flex;
-	align-items: flex-end;
-	gap: 3px;
-	height: 12px;
-}
-.jvp-think-dots i {
-	width: 4px;
-	height: 4px;
-	border-radius: 999px;
-	background: currentColor;
-	opacity: 0.35;
-}
+.jvp-think-dots { display: inline-flex; align-items: flex-end; gap: 3px; height: 10px; }
+.jvp-think-dots i { width: 5px; height: 5px; border-radius: 999px; background: var(--jv-accent); opacity: 0.35; }
 @media (prefers-reduced-motion: no-preference) {
-	.jvp-think-dots i {
-		animation: jvp-dot 1.2s infinite ease-in-out;
-	}
-	.jvp-think-dots i:nth-child(2) {
-		animation-delay: 0.15s;
-	}
-	.jvp-think-dots i:nth-child(3) {
-		animation-delay: 0.3s;
-	}
+	.jvp-think-dots i { animation: jvp-dot 1.2s infinite ease-in-out; }
+	.jvp-think-dots i:nth-child(2) { animation-delay: 0.15s; }
+	.jvp-think-dots i:nth-child(3) { animation-delay: 0.3s; }
 }
-/* Progress feedback, not decoration — the one animation design.md's
-   no-motion rule does not cover, and it is gated on motion-safe anyway. */
 @keyframes jvp-dot {
-	0%,
-	80%,
-	100% {
-		transform: translateY(0);
-		opacity: 0.35;
-	}
-	40% {
-		transform: translateY(-4px);
-		opacity: 1;
-	}
+	0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
+	40% { transform: translateY(-5px); opacity: 1; }
 }
+
+/* ---- pending write confirmation ---- */
+.jvp-pending { flex: none; border-top: 1px solid var(--jv-rule); padding: 11px 15px; }
+.jvp-pending-row { display: flex; flex-direction: column; gap: 9px; }
+.jvp-pending-txt { font-size: 13px; line-height: 1.45; color: var(--jv-ink); }
+.jvp-pending-acts { display: flex; gap: 8px; justify-content: flex-end; }
+
+/* ---- composer ---- */
+.jvp-foot { flex: none; padding: 12px 15px 14px; border-top: 1px solid var(--jv-rule); }
+.jvp-comp {
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+	border: 1px solid var(--jv-comp-bd);
+	border-radius: 14px;
+	padding: 7px 8px 7px 12px;
+	background: var(--jv-comp-bg);
+	transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.jvp-comp--focus, .jvp-comp:focus-within {
+	border-color: var(--jv-accent);
+	box-shadow: 0 0 0 3px rgba(106, 86, 232, 0.12);
+}
+.jvp-comp-text {
+	flex: 1;
+	min-width: 0;
+	border: none;
+	background: transparent;
+	resize: none;
+	font: inherit;
+	font-size: 14px;
+	color: var(--jv-ink);
+	line-height: 1.5;
+	padding: 5px 0;
+	max-height: 120px;
+	outline: none;
+}
+.jvp-comp-text::placeholder { color: var(--jv-ink-3); }
+.jvp-send {
+	width: 33px;
+	height: 33px;
+	flex: 0 0 auto;
+	border: none;
+	border-radius: 10px;
+	background: var(--jv-grad);
+	display: grid;
+	place-items: center;
+	cursor: pointer;
+	transition: opacity 0.12s ease;
+}
+.jvp-send svg { width: 17px; height: 17px; }
+.jvp-send:hover { opacity: 0.9; }
+.jvp-send:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 2px; }
+.jvp-send[disabled] { background: var(--jv-chip-0); cursor: not-allowed; }
+.jvp-send[disabled] svg { stroke: var(--jv-ink-3); }
+.jvp-send--stop { background: var(--jv-chip-0); color: var(--jv-ink); }
+.jvp-send--stop svg { stroke: currentColor; }
+.jvp-foot-note { text-align: center; font-size: 11px; color: var(--jv-ink-3); margin-top: 8px; }
+
+/* ---- buttons ---- */
+.jvp-btn-subtle {
+	height: 29px;
+	padding: 0 11px;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 9px;
+	background: transparent;
+	color: var(--jv-ink);
+	font: inherit;
+	font-size: 13px;
+	cursor: pointer;
+}
+.jvp-btn-subtle:hover { background: var(--jv-chip-0); }
+.jvp-btn-solid {
+	height: 29px;
+	padding: 0 13px;
+	border: none;
+	border-radius: 9px;
+	background: var(--jv-grad);
+	color: #fff;
+	font: inherit;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jvp-btn-solid[disabled] { opacity: 0.6; cursor: not-allowed; }
 </style>

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -107,7 +107,7 @@
 							<div class="jvp-m-avatar" aria-hidden="true">
 								<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
 							</div>
-							<div class="jvp-m-bot">{{ m.content }}</div>
+							<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
 						</div>
 					</template>
 
@@ -115,7 +115,7 @@
 						<div class="jvp-m-avatar" aria-hidden="true">
 							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
 						</div>
-						<div class="jvp-m-bot">{{ stream.live.text }}</div>
+						<div class="jvp-m-bot jv-md" v-html="renderReply(stream.live.text)"></div>
 					</div>
 
 					<!-- Waiting for the first token: a labelled state, not a bare
@@ -224,6 +224,7 @@
 import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { contextLabel } from "./desk_context.mjs";
 import { isDarkNow, watchTheme } from "./desk_theme.mjs";
+import { renderReply } from "./panel_markdown.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
 import {
@@ -349,7 +350,9 @@ function autoGrow() {
 // open resolves the newest conversation and restores it. A user with no history
 // gets the empty state, and an id is minted on first send.
 async function load() {
-	loading.value = true;
+	// Only blank the panel when there is nothing on screen yet; a refresh over
+	// an existing thread should be invisible.
+	loading.value = messages.value.length === 0;
 	loadError.value = "";
 	try {
 		if (!convId.value) {
@@ -357,7 +360,7 @@ async function load() {
 			convId.value = Array.isArray(list) && list.length ? list[0].name : "";
 		}
 		if (!convId.value) {
-			messages.value = [];
+			if (!messages.value.length) messages.value = [];
 			return;
 		}
 		const conv = await getConversation(convId.value);
@@ -545,15 +548,17 @@ function onRealtime(payload) {
 
 // Load lazily on first open, not at mount: the FAB is on every Desk page and
 // most page views never open the panel.
-let loadedOnce = false;
+// Refresh on EVERY open, not just the first. A reply can land while the panel
+// is closed, and the old first-open-only rule left the user staring at a stale
+// or empty thread until they reloaded the page. `load()` keeps the messages it
+// already has on screen while refetching, so this does not flash.
 watch(
 	() => props.open,
 	async (isOpen) => {
 		if (!isOpen) return;
 		await nextTick();
 		panelEl.value?.focus();
-		if (loadedOnce) return;
-		loadedOnce = true;
+		ensureRealtime();
 		load();
 	}
 );
@@ -943,8 +948,83 @@ defineExpose({ load, startNewChat, convId });
 	font-size: 14px;
 	line-height: 1.5;
 	color: var(--jv-ink);
-	white-space: pre-wrap;
 	overflow-wrap: anywhere;
+}
+
+/* ---- rendered markdown inside an assistant bubble ----
+   :deep because the HTML comes from v-html and carries no scope id. */
+.jv-md :deep(.jv-md-p) { margin: 0 0 8px; }
+.jv-md :deep(.jv-md-p:last-child) { margin-bottom: 0; }
+.jv-md :deep(.jv-md-h) {
+	margin: 12px 0 6px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--jv-ink);
+}
+.jv-md :deep(.jv-md-h:first-child) { margin-top: 0; }
+.jv-md :deep(.jv-md-list) { margin: 0 0 8px; padding-left: 18px; }
+.jv-md :deep(.jv-md-list:last-child) { margin-bottom: 0; }
+.jv-md :deep(.jv-md-list li) { margin: 3px 0; }
+.jv-md :deep(.jv-md-list li::marker) { color: var(--jv-ink-3); }
+.jv-md :deep(strong) { font-weight: 600; color: var(--jv-ink); }
+.jv-md :deep(.jv-md-link) { color: var(--jv-accent); text-decoration: none; }
+.jv-md :deep(.jv-md-link:hover) { text-decoration: underline; }
+.jv-md :deep(.jv-md-code) {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 12px;
+	background: var(--jv-chip-0);
+	border-radius: 4px;
+	padding: 1px 4px;
+	overflow-wrap: anywhere;
+}
+.jv-md :deep(.jv-md-pre) {
+	margin: 8px 0;
+	padding: 9px 10px;
+	border-radius: 9px;
+	background: var(--jv-chip-0);
+	font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 12px;
+	line-height: 1.45;
+	overflow-x: auto; /* code scrolls inside its own box, never the panel */
+}
+.jv-md :deep(.jv-md-quote) {
+	margin: 8px 0;
+	padding-left: 10px;
+	border-left: 2px solid var(--jv-rule-2);
+	color: var(--jv-ink-2);
+}
+
+/* Tables are the reason 400px needs care: let the wrapper scroll rather than
+   the panel, and keep numeric columns aligned. */
+.jv-md :deep(.jv-md-tablewrap) {
+	margin: 9px 0;
+	overflow-x: auto;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 9px;
+}
+.jv-md :deep(.jv-md-table) {
+	border-collapse: collapse;
+	width: 100%;
+	font-size: 12.5px;
+	white-space: nowrap;
+}
+.jv-md :deep(.jv-md-table th),
+.jv-md :deep(.jv-md-table td) {
+	padding: 7px 10px;
+	border-bottom: 1px solid var(--jv-rule-2);
+	text-align: left;
+}
+.jv-md :deep(.jv-md-table th) {
+	font-weight: 600;
+	color: var(--jv-ink-2);
+	background: var(--jv-chip-0);
+	font-size: 11.5px;
+}
+.jv-md :deep(.jv-md-table tr:last-child td) { border-bottom: none; }
+.jv-md :deep(.jv-md-table td[align="right"]),
+.jv-md :deep(.jv-md-table th[align="right"]) {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
 }
 
 /* ---- waiting for a reply ---- */

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -173,7 +173,7 @@ const props = defineProps({
 	context: { type: Object, default: null },
 	side: { type: String, default: "right" },
 });
-const emit = defineEmits(["close", "open-full", "dismiss-context"]);
+defineEmits(["close", "open-full", "dismiss-context"]);
 
 const panelEl = ref(null);
 const bodyEl = ref(null);

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -1,0 +1,701 @@
+<template>
+	<!-- Docked side chat. Kept mounted and toggled with v-show so the
+	     conversation, scroll position and draft survive a close/reopen. -->
+	<div
+		v-show="open"
+		class="jvp-root"
+		:class="`jvp-root--${side}`"
+		role="dialog"
+		aria-label="Jarvis chat"
+		@keydown.esc.stop="$emit('close')"
+	>
+		<div class="jvp-panel" ref="panelEl" tabindex="-1">
+			<div class="jvp-head">
+				<div class="jvp-title">
+					<svg class="jvp-mark" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+					</svg>
+					Jarvis
+				</div>
+				<div class="jvp-actions">
+					<button class="jvp-ib" type="button" aria-label="New chat" @click="startNewChat">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M12 5v14M5 12h14" />
+						</svg>
+					</button>
+					<button class="jvp-ib" type="button" aria-label="Open full chat" @click="$emit('open-full')">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M15 3h6v6M21 3l-7 7M10 21H4v-6M4 21l7-7" />
+						</svg>
+					</button>
+					<button class="jvp-ib" type="button" aria-label="Close" @click="$emit('close')">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M18 6 6 18M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+			</div>
+
+			<!-- Quiet bordered note (design.md 3.7): ambient state, not an alert,
+			     so no colored fill. -->
+			<div v-if="contextText" class="jvp-ctx">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+					<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+					<path d="M14 2v6h6" />
+				</svg>
+				<div class="jvp-ctx-txt">Viewing <b>{{ contextText }}</b></div>
+				<button
+					class="jvp-ib jvp-ib--sm"
+					type="button"
+					aria-label="Stop using this page as context"
+					@click="$emit('dismiss-context')"
+				>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M18 6 6 18M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="jvp-body" ref="bodyEl">
+				<div v-if="loading" class="jvp-center">Restoring your last conversation…</div>
+
+				<div v-else-if="loadError && !messages.length" class="jvp-center">
+					<div class="jvp-err">{{ loadError }}</div>
+					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
+				</div>
+
+				<div v-else-if="!messages.length && !stream.live" class="jvp-center">
+					<svg class="jvp-empty-ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+					</svg>
+					<div class="jvp-empty-t">{{ contextText ? "Ask about this record" : "Ask Jarvis" }}</div>
+					<div class="jvp-empty-d">
+						{{
+							contextText
+								? `Jarvis can see ${contextText} while you are on this page.`
+								: "Ask a question about your data."
+						}}
+					</div>
+				</div>
+
+				<div v-else class="jvp-msgs">
+					<div
+						v-for="m in messages"
+						:key="m.name"
+						:class="m.role === 'user' ? 'jvp-m-user' : 'jvp-m-bot'"
+					>{{ m.content }}</div>
+					<div v-if="stream.live" class="jvp-m-bot">{{ stream.live.text || "…" }}</div>
+					<div v-if="loadError && messages.length" class="jvp-inline-err">
+						<span class="jvp-err">{{ loadError }}</span>
+						<button class="jvp-btn-subtle" type="button" @click="retryLast">Retry</button>
+					</div>
+				</div>
+			</div>
+
+			<!-- A blocked write is the one thing here the user must act on, so it
+			     is the only place the panel raises its voice. -->
+			<div v-if="stream.pending.length" class="jvp-pending">
+				<div v-for="p in stream.pending" :key="p.token" class="jvp-pending-row">
+					<div class="jvp-pending-txt">{{ p.summary || "Jarvis wants to make a change." }}</div>
+					<div class="jvp-pending-acts">
+						<button class="jvp-btn-subtle" type="button" @click="$emit('open-full')">
+							Review in full chat
+						</button>
+						<button
+							class="jvp-btn-solid"
+							type="button"
+							:disabled="resolving === p.token"
+							@click="resolvePending(p.token)"
+						>{{ resolving === p.token ? "Confirming…" : "Confirm" }}</button>
+					</div>
+				</div>
+			</div>
+
+			<div class="jvp-foot">
+				<div class="jvp-comp" :class="{ 'jvp-comp--focus': composerFocused }">
+					<textarea
+						class="jvp-comp-text"
+						ref="textareaEl"
+						rows="1"
+						:placeholder="contextText ? `Ask about ${contextText}…` : 'Ask Jarvis…'"
+						v-model="draft"
+						@focus="composerFocused = true"
+						@blur="composerFocused = false"
+						@input="autoGrow"
+						@keydown.enter.exact.prevent="send"
+					></textarea>
+					<div class="jvp-comp-bar">
+						<span class="jvp-comp-hint">{{ hint }}</span>
+						<button
+							v-if="stream.live"
+							class="jvp-send jvp-send--stop"
+							type="button"
+							aria-label="Stop generating"
+							@click="stop"
+						>
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+								<rect x="7" y="7" width="10" height="10" rx="2" />
+							</svg>
+						</button>
+						<button
+							v-else
+							class="jvp-send"
+							type="button"
+							aria-label="Send message"
+							:disabled="!canSend"
+							@click="send"
+						>
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M12 19V5M5 12l7-7 7 7" />
+							</svg>
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
+import { contextLabel } from "./desk_context.mjs";
+import { emptyStream, applyEvent } from "./chat_stream.mjs";
+import {
+	listConversations,
+	getConversation,
+	sendMessage,
+	stopRun,
+	confirmTool,
+} from "./panel_api.mjs";
+
+const props = defineProps({
+	open: { type: Boolean, default: false },
+	context: { type: Object, default: null },
+	side: { type: String, default: "right" },
+});
+const emit = defineEmits(["close", "open-full", "dismiss-context"]);
+
+const panelEl = ref(null);
+const bodyEl = ref(null);
+const textareaEl = ref(null);
+
+const convId = ref("");
+const messages = ref([]);
+const stream = ref(emptyStream());
+const loading = ref(false);
+const loadError = ref("");
+const draft = ref("");
+const sending = ref(false);
+const composerFocused = ref(false);
+const resolving = ref("");
+const lastSent = ref("");
+
+const contextText = computed(() => contextLabel(props.context));
+const canSend = computed(() => draft.value.trim().length > 0 && !sending.value && !stream.value.live);
+const hint = computed(() => {
+	if (stream.value.live) return "Jarvis is replying…";
+	if (sending.value) return "Sending…";
+	return "Enter to send";
+});
+
+async function scrollToBottom() {
+	await nextTick();
+	if (bodyEl.value) bodyEl.value.scrollTop = bodyEl.value.scrollHeight;
+}
+
+function autoGrow() {
+	const el = textareaEl.value;
+	if (!el) return;
+	el.style.height = "auto";
+	el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+}
+
+// The panel's contract is to continue where the user left off, so the first
+// open resolves the newest conversation and restores it. A user with no history
+// gets the empty state, and an id is minted on first send.
+async function load() {
+	loading.value = true;
+	loadError.value = "";
+	try {
+		if (!convId.value) {
+			const list = await listConversations();
+			convId.value = Array.isArray(list) && list.length ? list[0].name : "";
+		}
+		if (!convId.value) {
+			messages.value = [];
+			return;
+		}
+		const conv = await getConversation(convId.value);
+		messages.value = Array.isArray(conv?.messages) ? conv.messages : [];
+		await scrollToBottom();
+	} catch (e) {
+		loadError.value = "Could not load your conversation.";
+	} finally {
+		loading.value = false;
+	}
+}
+
+function startNewChat() {
+	convId.value = "";
+	messages.value = [];
+	stream.value = emptyStream();
+	loadError.value = "";
+	draft.value = "";
+	nextTick(() => textareaEl.value?.focus());
+}
+
+async function send() {
+	const text = draft.value.trim();
+	if (!text || sending.value || stream.value.live) return;
+	sending.value = true;
+	loadError.value = "";
+	lastSent.value = text;
+
+	// Optimistic echo so the panel feels immediate. run:end reloads from the
+	// durable record, which replaces this.
+	messages.value.push({ name: `local-${Date.now()}`, role: "user", content: text });
+	draft.value = "";
+	await nextTick();
+	autoGrow();
+	await scrollToBottom();
+
+	try {
+		// Context is read at SEND time, not at open time: a conversation outlives
+		// the page it started on, and pinning it would leave the agent silently
+		// answering about the wrong record after a navigation.
+		const res = await sendMessage(convId.value, text, props.context);
+		if (res?.conversation_id) convId.value = res.conversation_id;
+		stream.value = { ...stream.value, busy: true };
+	} catch (e) {
+		sending.value = false;
+		loadError.value = "Could not send. Your message was not delivered.";
+	}
+}
+
+function retryLast() {
+	if (!lastSent.value) return;
+	draft.value = lastSent.value;
+	loadError.value = "";
+	// Drop the optimistic echo that never made it to the server.
+	const i = messages.value.findIndex((m) => String(m.name).startsWith("local-"));
+	if (i !== -1) messages.value.splice(i, 1);
+	send();
+}
+
+async function stop() {
+	if (!stream.value.live) return;
+	try {
+		await stopRun(convId.value, stream.value.live.runId);
+	} catch (e) {
+		/* the run ends on its own; nothing useful to say here */
+	}
+}
+
+async function resolvePending(token) {
+	if (resolving.value) return;
+	resolving.value = token;
+	try {
+		await confirmTool(token, convId.value);
+		stream.value = applyEvent(stream.value, { kind: "action:resolved", token });
+	} catch (e) {
+		loadError.value = "Could not confirm that action.";
+	} finally {
+		resolving.value = "";
+	}
+}
+
+// The Desk already holds an authenticated socket, so the panel joins it rather
+// than dialling a second one the way the PWA has to.
+function onRealtime(payload) {
+	const conv = payload?.conversation_id || payload?.conversation;
+	if (!conv || conv !== convId.value) return;
+
+	const next = applyEvent(stream.value, payload);
+
+	if (next.reload) {
+		// Clear the flag before reloading so a second frame cannot double-fetch.
+		stream.value = { ...next, reload: false, error: "" };
+		sending.value = false;
+		if (next.error) loadError.value = next.error;
+		load();
+		return;
+	}
+
+	stream.value = next;
+	if (next.live) {
+		sending.value = false;
+		scrollToBottom();
+	}
+	if (next.error) loadError.value = next.error;
+}
+
+// Load lazily on first open, not at mount: the FAB is on every Desk page and
+// most page views never open the panel.
+let loadedOnce = false;
+watch(
+	() => props.open,
+	async (isOpen) => {
+		if (!isOpen) return;
+		await nextTick();
+		panelEl.value?.focus();
+		if (loadedOnce) return;
+		loadedOnce = true;
+		load();
+	}
+);
+
+onMounted(() => {
+	window.frappe?.realtime?.on?.("jarvis:event", onRealtime);
+});
+
+onBeforeUnmount(() => {
+	window.frappe?.realtime?.off?.("jarvis:event", onRealtime);
+});
+
+defineExpose({ load, startNewChat, convId });
+</script>
+
+<style scoped>
+/* Desk CSS variables only — the Desk already stamps the theme, so light/dark
+   comes free and no dark: variants are needed (design.md 6). */
+.jvp-root {
+	position: fixed;
+	top: var(--navbar-height, 48px);
+	bottom: 0;
+	width: 400px;
+	max-width: 100vw;
+	z-index: 1029; /* under Frappe modals (1050), over page content */
+	display: flex;
+	padding: 12px;
+	pointer-events: none;
+}
+.jvp-root--right {
+	right: 0;
+}
+.jvp-root--left {
+	left: 0;
+}
+
+.jvp-panel {
+	pointer-events: auto;
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	background: var(--card-bg, #fff);
+	border: 1px solid var(--border-color);
+	border-radius: 12px;
+	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+	overflow: hidden;
+	font-size: 14px;
+	letter-spacing: 0.02em;
+	color: var(--text-color);
+	outline: none;
+}
+
+/* design.md 3.2: overlays fade + scale 0.98 -> 1 in 100ms. Not a slide — this
+   is the same motion every other overlay in the product uses. Gated so
+   reduced-motion users get an instant swap. */
+@media (prefers-reduced-motion: no-preference) {
+	.jvp-panel {
+		animation: jvp-in 100ms ease-out;
+	}
+}
+@keyframes jvp-in {
+	from {
+		opacity: 0;
+		transform: scale(0.98);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+.jvp-head {
+	height: 42px;
+	flex: none;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 8px 0 12px;
+	border-bottom: 1px solid var(--border-color);
+}
+.jvp-title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: 600;
+}
+.jvp-mark {
+	width: 16px;
+	height: 16px;
+	flex: none;
+}
+.jvp-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.jvp-ib {
+	width: 28px;
+	height: 28px;
+	flex: none;
+	border: none;
+	background: transparent;
+	border-radius: 8px;
+	color: var(--text-muted);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background-color 0.12s ease;
+}
+.jvp-ib:hover {
+	background: var(--fg-hover-color, rgba(0, 0, 0, 0.05));
+}
+.jvp-ib:focus-visible {
+	outline: 2px solid var(--border-primary, #999);
+	outline-offset: 1px;
+}
+.jvp-ib svg {
+	width: 16px;
+	height: 16px;
+}
+.jvp-ib--sm {
+	width: 24px;
+	height: 24px;
+}
+.jvp-ib--sm svg {
+	width: 14px;
+	height: 14px;
+}
+
+.jvp-ctx {
+	margin: 12px 12px 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	border: 1px solid var(--border-color);
+	border-radius: 10px;
+	padding: 7px 8px;
+}
+.jvp-ctx svg {
+	width: 16px;
+	height: 16px;
+	flex: none;
+	color: var(--text-muted);
+}
+.jvp-ctx-txt {
+	flex: 1;
+	min-width: 0;
+	font-size: 12px;
+	line-height: 1.35;
+	color: var(--text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.jvp-ctx-txt b {
+	font-weight: 600;
+	color: var(--text-color);
+}
+
+.jvp-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 14px 12px;
+}
+
+.jvp-center {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 9px;
+	text-align: center;
+	padding: 22px;
+	color: var(--text-muted);
+}
+.jvp-empty-ic {
+	width: 28px;
+	height: 28px;
+}
+.jvp-empty-t {
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--text-color);
+}
+.jvp-empty-d {
+	font-size: 14px;
+	line-height: 1.5;
+	max-width: 30ch;
+}
+.jvp-err {
+	font-size: 13.5px;
+	color: var(--text-danger, #c0392b);
+}
+.jvp-inline-err {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.jvp-msgs {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+.jvp-m-user {
+	align-self: flex-end;
+	max-width: 84%;
+	background: var(--control-bg, #f3f3f3);
+	border-radius: 12px;
+	padding: 8px 12px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+.jvp-m-bot {
+	max-width: 94%;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+}
+
+.jvp-pending {
+	flex: none;
+	border-top: 1px solid var(--border-color);
+	padding: 10px 12px;
+}
+.jvp-pending-row {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+.jvp-pending-txt {
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--text-color);
+}
+.jvp-pending-acts {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.jvp-foot {
+	flex: none;
+	border-top: 1px solid var(--border-color);
+	padding: 12px;
+}
+
+/* One container holds the text and its controls, and the send button lives
+   inside it: at 400px a separate button row costs a message of vertical
+   space. */
+.jvp-comp {
+	background: var(--control-bg, #f3f3f3);
+	border: 1px solid transparent;
+	border-radius: 12px;
+	padding: 9px 9px 8px;
+	transition: background-color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.jvp-comp--focus,
+.jvp-comp:focus-within {
+	background: var(--card-bg, #fff);
+	border-color: var(--border-color);
+	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+.jvp-comp-text {
+	width: 100%;
+	border: none;
+	background: transparent;
+	resize: none;
+	font: inherit;
+	letter-spacing: inherit;
+	color: var(--text-color);
+	line-height: 1.5;
+	padding: 1px 3px 8px;
+	max-height: 120px;
+	outline: none;
+}
+.jvp-comp-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+.jvp-comp-hint {
+	font-size: 11.5px;
+	color: var(--text-muted);
+}
+
+/* The one solid button on this surface (design.md 3.1). */
+.jvp-send {
+	width: 28px;
+	height: 28px;
+	flex: none;
+	border: none;
+	border-radius: 8px;
+	cursor: pointer;
+	background: var(--text-color);
+	color: var(--card-bg, #fff);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: opacity 0.12s ease;
+}
+.jvp-send svg {
+	width: 16px;
+	height: 16px;
+}
+.jvp-send:hover {
+	opacity: 0.88;
+}
+.jvp-send:focus-visible {
+	outline: 2px solid var(--border-primary, #999);
+	outline-offset: 2px;
+}
+.jvp-send[disabled] {
+	background: var(--control-bg, #ededed);
+	color: var(--text-muted);
+	cursor: not-allowed;
+}
+.jvp-send--stop {
+	background: var(--control-bg, #ededed);
+	color: var(--text-color);
+}
+
+.jvp-btn-subtle {
+	height: 28px;
+	padding: 0 10px;
+	border: none;
+	border-radius: 8px;
+	background: var(--control-bg, #f3f3f3);
+	color: var(--text-color);
+	font: inherit;
+	cursor: pointer;
+}
+.jvp-btn-subtle:hover {
+	background: var(--fg-hover-color, rgba(0, 0, 0, 0.08));
+}
+.jvp-btn-solid {
+	height: 28px;
+	padding: 0 12px;
+	border: none;
+	border-radius: 8px;
+	cursor: pointer;
+	background: var(--text-color);
+	color: var(--card-bg, #fff);
+	font: inherit;
+	font-weight: 500;
+}
+.jvp-btn-solid[disabled] {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+</style>

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -12,7 +12,7 @@
 		aria-label="Jarvis chat"
 		@keydown.esc.stop="$emit('close')"
 	>
-		<div class="jvp-panel" ref="panelEl" tabindex="-1">
+		<div class="jvp-panel" :class="{ 'jvp-panel--dark': isDark }" ref="panelEl" tabindex="-1">
 			<div class="jvp-head">
 				<div class="jvp-avatar">
 					<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
@@ -124,9 +124,8 @@
 						<div class="jvp-m-avatar" aria-hidden="true">
 							<svg viewBox="0 0 24 24" fill="#fff"><path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" /></svg>
 						</div>
-						<div class="jvp-think" role="status" aria-live="polite">
+						<div class="jvp-think" role="status" aria-live="polite" aria-label="Jarvis is typing">
 							<span class="jvp-think-dots" aria-hidden="true"><i></i><i></i><i></i></span>
-							<span class="jvp-think-txt">Working…</span>
 						</div>
 					</div>
 
@@ -215,7 +214,7 @@
 						</svg>
 					</button>
 				</div>
-				<div class="jvp-foot-note">{{ hint }}</div>
+				<div v-if="hint" class="jvp-foot-note">{{ hint }}</div>
 			</div>
 		</div>
 	</div>
@@ -224,6 +223,7 @@
 <script setup>
 import { computed, ref, watch, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { contextLabel } from "./desk_context.mjs";
+import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
 import {
@@ -260,6 +260,8 @@ const sending = ref(false);
 const composerFocused = ref(false);
 const resolving = ref("");
 const lastSent = ref("");
+const isDark = ref(false);
+let unwatchTheme = null;
 const fileEl = ref(null);
 const attachments = ref([]);
 const uploading = ref(false);
@@ -328,7 +330,7 @@ const hint = computed(() => {
 	if (uploading.value) return "Uploading…";
 	if (stream.value.live) return "Jarvis is replying…";
 	if (sending.value) return "Sending…";
-	return "Enter to send";
+	return ""; // idle needs no caption
 });
 
 async function scrollToBottom() {
@@ -638,6 +640,10 @@ function startPolling() {
 }
 
 onMounted(() => {
+	isDark.value = isDarkNow();
+	unwatchTheme = watchTheme((d) => {
+		isDark.value = d;
+	});
 	ensureRealtime();
 	// The mic only exists when the site has STT configured.
 	getChatUiSettings()
@@ -650,6 +656,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+	unwatchTheme?.();
 	if (rtTimer) {
 		window.clearInterval(rtTimer);
 		rtTimer = null;
@@ -683,7 +690,7 @@ defineExpose({ load, startNewChat, convId });
 	--jv-chip-3: #eae7fb;
 	--jv-danger: #c0392b;
 }
-:global([data-theme="dark"]) .jvp-panel {
+.jvp-panel--dark {
 	--jv-surface: #1e1d23;
 	--jv-rule: #2a2833;
 	--jv-rule-2: #2e2c36;
@@ -712,6 +719,7 @@ defineExpose({ load, startNewChat, convId });
 }
 .jvp-panel {
 	pointer-events: auto;
+	max-width: 100%;
 	display: flex;
 	flex-direction: column;
 	flex: 1;
@@ -808,7 +816,14 @@ defineExpose({ load, startNewChat, convId });
 .jvp-ctx-txt b { font-weight: 600; color: var(--jv-ink); }
 
 /* ---- body ---- */
-.jvp-body { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 15px; }
+.jvp-body {
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	overflow-y: auto;
+	overflow-x: hidden; /* long tokens wrap; the panel never scrolls sideways */
+	padding: 16px 15px;
+}
 .jvp-center {
 	height: 100%;
 	display: flex;
@@ -825,6 +840,7 @@ defineExpose({ load, startNewChat, convId });
 
 /* ---- welcome ---- */
 .jvp-welcome {
+	min-width: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -886,13 +902,13 @@ defineExpose({ load, startNewChat, convId });
 .jvp-card-ic--1 { background: var(--jv-chip-1); }
 .jvp-card-ic--2 { background: var(--jv-chip-2); }
 .jvp-card-ic--3 { background: var(--jv-chip-3); }
-.jvp-card-txt { min-width: 0; }
+.jvp-card-txt { min-width: 0; overflow-wrap: anywhere; }
 .jvp-card-t { display: block; font-size: 13.5px; font-weight: 600; color: var(--jv-ink); }
 .jvp-card-p { display: block; font-size: 12.5px; color: var(--jv-ink-2); margin-top: 2px; line-height: 1.4; }
 
 /* ---- messages ---- */
-.jvp-msgs { display: flex; flex-direction: column; gap: 14px; }
-.jvp-row { display: flex; gap: 9px; align-items: flex-start; }
+.jvp-msgs { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.jvp-row { display: flex; gap: 9px; align-items: flex-start; min-width: 0; }
 .jvp-row--user { justify-content: flex-end; }
 .jvp-m-avatar {
 	width: 27px;
@@ -918,6 +934,8 @@ defineExpose({ load, startNewChat, convId });
 	box-shadow: 0 8px 18px -10px rgba(106, 86, 232, 0.7);
 }
 .jvp-m-bot {
+	min-width: 0;
+	max-width: calc(100% - 36px);
 	background: var(--jv-bot-bg);
 	border: 1px solid var(--jv-bot-bd);
 	border-radius: 5px 15px 15px 15px;
@@ -939,7 +957,6 @@ defineExpose({ load, startNewChat, convId });
 	border-radius: 5px 15px 15px 15px;
 	padding: 11px 13px;
 	color: var(--jv-ink-2);
-	font-size: 13.5px;
 }
 .jvp-think-dots { display: inline-flex; align-items: flex-end; gap: 3px; height: 10px; }
 .jvp-think-dots i { width: 5px; height: 5px; border-radius: 999px; background: var(--jv-accent); opacity: 0.35; }

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -150,7 +150,35 @@
 			</div>
 
 			<div class="jvp-foot">
-				<div class="jvp-comp" :class="{ 'jvp-comp--focus': composerFocused }">
+				<!-- attached files, above the input -->
+				<div v-if="attachments.length" class="jvp-atts">
+					<span v-for="a in attachments" :key="a.file_url" class="jvp-att">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+							<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />
+						</svg>
+						<span class="jvp-att-n">{{ a.file_name }}</span>
+						<button class="jvp-att-x" type="button" :aria-label="`Remove ${a.file_name}`" @click="removeAttachment(a.file_url)">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+								<path d="M18 6 6 18M6 6l12 12" />
+							</svg>
+						</button>
+					</span>
+				</div>
+
+				<input ref="fileEl" type="file" multiple hidden @change="onFilePicked" />
+
+				<div class="jvp-comp" :class="{ 'jvp-comp--focus': composerFocused, 'jvp-comp--rec': recording }">
+					<button
+						class="jvp-cib"
+						type="button"
+						aria-label="Attach a file"
+						:disabled="uploading"
+						@click="pickFile"
+					>
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+							<path d="m21.4 11.1-9.2 9.2a6 6 0 0 1-8.5-8.5l9.2-9.2a4 4 0 0 1 5.7 5.7l-9.2 9.2a2 2 0 0 1-2.9-2.9l8.5-8.5" />
+						</svg>
+					</button>
 					<textarea
 						class="jvp-comp-text"
 						ref="textareaEl"
@@ -162,6 +190,20 @@
 						@input="autoGrow"
 						@keydown.enter.exact.prevent="send"
 					></textarea>
+					<button
+						v-if="sttEnabled"
+						class="jvp-cib"
+						:class="{ 'jvp-cib--rec': recording }"
+						type="button"
+						:aria-label="recording ? 'Stop recording' : 'Dictate a message'"
+						:disabled="transcribing"
+						@click="toggleVoice"
+					>
+						<svg v-if="!recording" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+							<rect x="9" y="2" width="6" height="11" rx="3" /><path d="M19 10a7 7 0 0 1-14 0M12 17v5" />
+						</svg>
+						<span v-else class="jvp-wave" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+					</button>
 					<button v-if="stream.live" class="jvp-send jvp-send--stop" type="button" aria-label="Stop generating" @click="stop">
 						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
 							<rect x="7" y="7" width="10" height="10" rx="2" />
@@ -190,6 +232,9 @@ import {
 	sendMessage,
 	stopRun,
 	confirmTool,
+	uploadFile,
+	transcribeAudio,
+	getChatUiSettings,
 } from "./panel_api.mjs";
 
 const props = defineProps({
@@ -215,6 +260,15 @@ const sending = ref(false);
 const composerFocused = ref(false);
 const resolving = ref("");
 const lastSent = ref("");
+const fileEl = ref(null);
+const attachments = ref([]);
+const uploading = ref(false);
+const sttEnabled = ref(false);
+const recording = ref(false);
+const transcribing = ref(false);
+let recorder = null;
+let recChunks = [];
+let recStartedAt = 0;
 
 const contextText = computed(() => contextLabel(props.context));
 
@@ -261,8 +315,17 @@ function useSuggestion(prompt) {
 }
 
 const thinking = computed(() => sending.value || (stream.value.busy && !stream.value.live));
-const canSend = computed(() => draft.value.trim().length > 0 && !sending.value && !stream.value.live);
+const canSend = computed(
+	() =>
+		(draft.value.trim().length > 0 || attachments.value.length > 0) &&
+		!sending.value &&
+		!uploading.value &&
+		!stream.value.live
+);
 const hint = computed(() => {
+	if (recording.value) return "Listening… click the mic to stop";
+	if (transcribing.value) return "Transcribing…";
+	if (uploading.value) return "Uploading…";
 	if (stream.value.live) return "Jarvis is replying…";
 	if (sending.value) return "Sending…";
 	return "Enter to send";
@@ -314,9 +377,84 @@ function startNewChat() {
 	nextTick(() => textareaEl.value?.focus());
 }
 
+function pickFile() {
+	fileEl.value?.click();
+}
+
+async function onFilePicked(e) {
+	const files = Array.from(e.target.files || []);
+	e.target.value = ""; // let the same file be picked again
+	if (!files.length) return;
+	uploading.value = true;
+	loadError.value = "";
+	try {
+		for (const f of files) {
+			attachments.value.push(await uploadFile(f));
+		}
+	} catch (err) {
+		loadError.value = "That file could not be attached.";
+	} finally {
+		uploading.value = false;
+	}
+}
+
+function removeAttachment(url) {
+	attachments.value = attachments.value.filter((a) => a.file_url !== url);
+}
+
+// Hold-free toggle: click to start, click to stop. The transcript lands in the
+// composer rather than sending, so a misheard word can be fixed first.
+async function toggleVoice() {
+	if (transcribing.value) return;
+	if (recording.value) {
+		recorder?.stop();
+		return;
+	}
+	if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+		loadError.value = "Recording is not supported in this browser.";
+		return;
+	}
+	try {
+		const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		recChunks = [];
+		recStartedAt = Date.now();
+		recorder = new MediaRecorder(stream);
+		recorder.ondataavailable = (ev) => {
+			if (ev.data && ev.data.size) recChunks.push(ev.data);
+		};
+		recorder.onstop = async () => {
+			recording.value = false;
+			stream.getTracks().forEach((t) => t.stop());
+			const blob = new Blob(recChunks, { type: recorder.mimeType || "audio/webm" });
+			recChunks = [];
+			if (!blob.size) return;
+			transcribing.value = true;
+			try {
+				const res = await transcribeAudio(blob, (Date.now() - recStartedAt) / 1000);
+				const text = (res && res.text) || "";
+				if (text) {
+					draft.value = draft.value ? `${draft.value} ${text}` : text;
+					await nextTick();
+					autoGrow();
+					textareaEl.value?.focus();
+				}
+			} catch (err) {
+				loadError.value = "Could not transcribe that recording.";
+			} finally {
+				transcribing.value = false;
+			}
+		};
+		recorder.start();
+		recording.value = true;
+	} catch (err) {
+		loadError.value = "Microphone permission was refused.";
+	}
+}
+
 async function send() {
 	const text = draft.value.trim();
-	if (!text || sending.value || stream.value.live) return;
+	const atts = attachments.value.slice();
+	if ((!text && !atts.length) || sending.value || stream.value.live) return;
 	sending.value = true;
 	loadError.value = "";
 	lastSent.value = text;
@@ -325,6 +463,7 @@ async function send() {
 	// durable record, which replaces this.
 	messages.value.push({ name: `local-${Date.now()}`, role: "user", content: text });
 	draft.value = "";
+	attachments.value = [];
 	await nextTick();
 	autoGrow();
 	await scrollToBottom();
@@ -333,9 +472,11 @@ async function send() {
 		// Context is read at SEND time, not at open time: a conversation outlives
 		// the page it started on, and pinning it would leave the agent silently
 		// answering about the wrong record after a navigation.
-		const res = await sendMessage(convId.value, text, props.context);
+		const res = await sendMessage(convId.value, text, props.context, atts);
 		if (res?.conversation_id) convId.value = res.conversation_id;
 		stream.value = { ...stream.value, busy: true };
+		ensureRealtime();
+		startPolling();
 	} catch (e) {
 		sending.value = false;
 		loadError.value = "Could not send. Your message was not delivered.";
@@ -382,6 +523,7 @@ function onRealtime(payload) {
 
 	const next = applyEvent(stream.value, payload);
 
+	stopPolling();
 	if (next.reload) {
 		// Clear the flag before reloading so a second frame cannot double-fetch.
 		stream.value = { ...next, reload: false, error: "" };
@@ -414,12 +556,106 @@ watch(
 	}
 );
 
+// ---- delivery: realtime first, polling as the safety net ----
+//
+// frappe.realtime is not guaranteed to exist when this widget mounts (the FAB
+// boots on every Desk page, sometimes before the socket layer). A plain
+// optional-chained subscribe fails SILENTLY there and never retries, which
+// leaves the panel on "Working..." forever while the reply sits in the
+// database. So: retry the subscribe, and poll while a turn is in flight so the
+// answer arrives even if the socket never does.
+let rtBound = false;
+let rtTries = 0;
+let rtTimer = null;
+
+function bindRealtime() {
+	if (rtBound) return true;
+	const rt = window.frappe && window.frappe.realtime;
+	if (!rt || typeof rt.on !== "function") return false;
+	rt.on("jarvis:event", onRealtime);
+	rtBound = true;
+	return true;
+}
+
+function ensureRealtime() {
+	if (bindRealtime() || rtTimer) return;
+	rtTimer = window.setInterval(() => {
+		rtTries += 1;
+		if (bindRealtime() || rtTries > 20) {
+			window.clearInterval(rtTimer);
+			rtTimer = null;
+		}
+	}, 500);
+}
+
+let pollTimer = null;
+let pollTicks = 0;
+
+function stopPolling() {
+	if (pollTimer) {
+		window.clearInterval(pollTimer);
+		pollTimer = null;
+	}
+	pollTicks = 0;
+}
+
+// Ends the in-flight state once an answer is on screen, whichever path
+// delivered it.
+function settle() {
+	sending.value = false;
+	stream.value = { ...stream.value, live: null, busy: false, reload: false };
+	stopPolling();
+}
+
+function startPolling() {
+	stopPolling();
+	const before = shownMessages.value.length;
+	pollTimer = window.setInterval(async () => {
+		pollTicks += 1;
+		// ~2 minutes, then give up rather than hammer the site forever.
+		if (pollTicks > 48) {
+			stopPolling();
+			sending.value = false;
+			if (!stream.value.live) loadError.value = "Jarvis did not reply. Try again.";
+			return;
+		}
+		if (!convId.value) return;
+		try {
+			const conv = await getConversation(convId.value);
+			const msgs = Array.isArray(conv && conv.messages) ? conv.messages : [];
+			const next = visibleMessages(msgs);
+			// A new assistant turn landed: adopt it and stop.
+			const last = next[next.length - 1];
+			if (next.length > before && last && last.role === "assistant") {
+				messages.value = msgs;
+				settle();
+				scrollToBottom();
+			}
+		} catch (e) {
+			/* transient - keep polling */
+		}
+	}, 2500);
+}
+
 onMounted(() => {
-	window.frappe?.realtime?.on?.("jarvis:event", onRealtime);
+	ensureRealtime();
+	// The mic only exists when the site has STT configured.
+	getChatUiSettings()
+		.then((cfg) => {
+			sttEnabled.value = Boolean(cfg && cfg.stt_enabled);
+		})
+		.catch(() => {
+			sttEnabled.value = false;
+		});
 });
 
 onBeforeUnmount(() => {
-	window.frappe?.realtime?.off?.("jarvis:event", onRealtime);
+	if (rtTimer) {
+		window.clearInterval(rtTimer);
+		rtTimer = null;
+	}
+	stopPolling();
+	if (rtBound) window.frappe?.realtime?.off?.("jarvis:event", onRealtime);
 });
 
 defineExpose({ load, startNewChat, convId });
@@ -773,6 +1009,56 @@ defineExpose({ load, startNewChat, convId });
 .jvp-send[disabled] svg { stroke: var(--jv-ink-3); }
 .jvp-send--stop { background: var(--jv-chip-0); color: var(--jv-ink); }
 .jvp-send--stop svg { stroke: currentColor; }
+/* attachments + inline composer buttons */
+.jvp-atts { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.jvp-att {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 100%;
+	border: 1px solid var(--jv-rule-2);
+	border-radius: 9px;
+	padding: 4px 6px 4px 8px;
+	font-size: 12px;
+	color: var(--jv-ink-2);
+	background: var(--jv-chip-0);
+}
+.jvp-att svg { width: 13px; height: 13px; flex: none; }
+.jvp-att-n { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.jvp-att-x {
+	width: 18px; height: 18px; flex: none; border: none; background: transparent;
+	color: var(--jv-ink-2); cursor: pointer; display: grid; place-items: center; border-radius: 5px;
+}
+.jvp-att-x:hover { color: var(--jv-ink); }
+.jvp-att-x svg { width: 12px; height: 12px; }
+
+.jvp-cib {
+	width: 29px; height: 29px; flex: 0 0 auto; align-self: flex-end;
+	border: none; background: transparent; border-radius: 8px;
+	color: var(--jv-ink-2); cursor: pointer; display: grid; place-items: center;
+	transition: background-color 0.12s ease, color 0.12s ease;
+}
+.jvp-cib:hover:not([disabled]) { background: var(--jv-chip-0); color: var(--jv-ink); }
+.jvp-cib:focus-visible { outline: 2px solid var(--jv-accent); outline-offset: 1px; }
+.jvp-cib[disabled] { opacity: 0.5; cursor: not-allowed; }
+.jvp-cib svg { width: 17px; height: 17px; }
+.jvp-cib--rec { color: var(--jv-accent); }
+.jvp-comp--rec { border-color: var(--jv-accent); }
+
+/* live level bars while recording */
+.jvp-wave { display: inline-flex; align-items: center; gap: 2px; height: 15px; }
+.jvp-wave i { width: 2.5px; height: 100%; border-radius: 2px; background: var(--jv-accent); transform: scaleY(0.3); }
+@media (prefers-reduced-motion: no-preference) {
+	.jvp-wave i { animation: jvp-wave 0.9s infinite ease-in-out; }
+	.jvp-wave i:nth-child(2) { animation-delay: 0.15s; }
+	.jvp-wave i:nth-child(3) { animation-delay: 0.3s; }
+	.jvp-wave i:nth-child(4) { animation-delay: 0.45s; }
+}
+@keyframes jvp-wave {
+	0%, 100% { transform: scaleY(0.3); }
+	50% { transform: scaleY(1); }
+}
+
 .jvp-foot-note { text-align: center; font-size: 11px; color: var(--jv-ink-3); margin-top: 8px; }
 
 /* ---- buttons ---- */

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -13,7 +13,6 @@
 				'jvw-fab--dragging': dragging,
 				'jvw-fab--faded': faded && !dragging,
 				'jvw-fab--dock-left': side === 'left',
-				'jvw-fab--behind': panelOpen,
 			}"
 			:style="fabStyle"
 			:aria-label="panelOpen ? 'Close Jarvis' : 'Ask Jarvis'"
@@ -38,7 +37,7 @@
 			ref="panelRef"
 			:open="panelOpen"
 			:context="effectiveContext"
-			:side="side"
+			:layout="panelBox"
 			@close="closePanel"
 			@open-full="openFull"
 			@dismiss-context="contextDismissed = true"
@@ -50,6 +49,7 @@
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
+import { panelLayout } from "./panel_anchor.mjs";
 import * as fabPos from "./fab_position.mjs";
 import Panel from "./Panel.vue";
 
@@ -81,6 +81,19 @@ const contextDismissed = ref(false);
 // Dismissing the chip suppresses context for the current page only; a new
 // route is a new subject, so the dismissal does not carry over.
 const effectiveContext = computed(() => (contextDismissed.value ? null : deskContext.value));
+
+// The window hangs off the FAB, so it re-lays-out on every drag frame and on
+// resize. fabXY is already reactive, which is what makes the panel travel with
+// the launcher instead of being stranded across the screen from it.
+const viewportTick = ref(0);
+const panelBox = computed(() => {
+	viewportTick.value; // re-run on resize / orientation change
+	const topInset = readCssPx(document.documentElement, "--navbar-height", 48);
+	return panelLayout(
+		{ x: fabXY.value.x, y: fabXY.value.y, size: fabPos.FAB_SIZE },
+		{ vw: window.innerWidth, vh: window.innerHeight, top: topInset }
+	);
+});
 
 function readDeskContext() {
 	const route = (window.frappe && frappe.get_route && frappe.get_route()) || [];
@@ -264,6 +277,7 @@ function onFabClick() {
 // storage means this is enough to keep it on-screen after a viewport change.
 function onResize() {
 	applyPosition({ animate: false });
+	viewportTick.value++; // re-anchor the panel to the new viewport
 }
 
 onMounted(() => {
@@ -358,14 +372,6 @@ onBeforeUnmount(() => {
 }
 .jvw-fab--faded {
 	opacity: 0.4;
-}
-/* The panel docks to the same edge the FAB is snapped to, and the FAB outranks
-   it on z-index — so an open panel would wear the launcher on top of its header
-   or composer. Retire the FAB while the panel is open; the panel's own close
-   button and Esc bring it back. */
-.jvw-fab--behind {
-	opacity: 0;
-	pointer-events: none;
 }
 
 /* ---- drag affordance ----

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -323,7 +323,10 @@ onBeforeUnmount(() => {
 <style scoped>
 /* Scoped tokens for the FAB (it lives in <body>). */
 .jvw-root {
-	--accent: #171717;
+	/* Brand gradient from the Jarvis Side Chat design board (a recorded
+	   divergence from design.md's near-black chrome, scoped to this widget). */
+	--accent: #6a56e8;
+	--accent-grad: linear-gradient(140deg, #8b7cf7, #6a56e8);
 	--jvw-safe-bottom: env(safe-area-inset-bottom, 0px);
 	font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
@@ -333,7 +336,8 @@ onBeforeUnmount(() => {
    the indigo brand blue (the SPA's theme.js DARK_VARS accent) so the FAB stays
    visible against dark surfaces. */
 :global([data-theme="dark"]) .jvw-root {
-	--accent: #6e8bff;
+	--accent: #8b7cf7;
+	--accent-grad: linear-gradient(140deg, #9d90ff, #7a68f0);
 }
 
 /* ---- launcher bubble ---- */
@@ -341,13 +345,13 @@ onBeforeUnmount(() => {
 	width: 54px;
 	height: 54px;
 	border-radius: 16px;
-	background: var(--accent);
+	background: var(--accent-grad);
 	border: none;
 	cursor: grab;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	box-shadow: 0 6px 20px rgba(23, 23, 23, 0.32);
+	box-shadow: 0 10px 26px -6px rgba(106, 86, 232, 0.55);
 	position: fixed;
 	left: 0;
 	top: 0;

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -1,7 +1,8 @@
 <template>
 	<!-- Draggable, edge-snapping Jarvis shortcut FAB, floating on every ERP Desk
-	     page. Tapping it navigates to the Jarvis chat SPA (a fresh conversation)
-	     rather than opening an in-page panel. -->
+	     page. Tapping it opens the side chat panel in place; on a narrow
+	     viewport (where a 400px panel would be most of the screen) it falls
+	     back to navigating to the chat SPA. -->
 	<div class="jvw-root">
 		<button
 			type="button"
@@ -11,10 +12,11 @@
 				'jvw-fab--snapping': snapping,
 				'jvw-fab--dragging': dragging,
 				'jvw-fab--faded': faded && !dragging,
+				'jvw-fab--dock-left': side === 'left',
 			}"
 			:style="fabStyle"
-			title="Ask Jarvis"
-			aria-label="Ask Jarvis"
+			:aria-label="panelOpen ? 'Close Jarvis' : 'Ask Jarvis'"
+			:aria-expanded="panelOpen ? 'true' : 'false'"
 			@click="onFabClick"
 			@pointerdown="onPointerDown"
 			@pointermove="onPointerMove"
@@ -23,17 +25,32 @@
 			@pointerenter="wake"
 			@focus="wake"
 		>
+			<!-- Grip dots: the drag affordance. design.md 1.3 forbids hover
+			     motion, so this fades in on OPACITY alone — nothing moves. -->
+			<span class="jvw-grip" aria-hidden="true"><i></i><i></i><i></i></span>
 			<svg viewBox="0 0 24 24" width="24" height="24" fill="#fff">
 				<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
 			</svg>
 		</button>
+
+		<Panel
+			ref="panelRef"
+			:open="panelOpen"
+			:context="effectiveContext"
+			:side="side"
+			@close="closePanel"
+			@open-full="openFull"
+			@dismiss-context="contextDismissed = true"
+		/>
 	</div>
 </template>
 
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
-import { NEW_CHAT_URL } from "./config.mjs";
+import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
+import { contextFromRoute } from "./desk_context.mjs";
 import * as fabPos from "./fab_position.mjs";
+import Panel from "./Panel.vue";
 
 // ---- FAB: draggable, edge-snapping, idle-fading launcher button.
 // fab_position.mjs owns the pure geometry/drag/idle-timer math (unit tested);
@@ -53,6 +70,37 @@ let snapTimeoutHandle = null;
 
 // Access gate: desk boot sets this once for the session (see Task B).
 const hasAccess = Boolean(window.frappe?.boot?.jarvis_has_access);
+
+// ---- Side chat panel: open state and the Desk record it is looking at. ----
+const panelRef = ref(null);
+const panelOpen = ref(false);
+const deskContext = ref(null);
+const contextDismissed = ref(false);
+
+// Dismissing the chip suppresses context for the current page only; a new
+// route is a new subject, so the dismissal does not carry over.
+const effectiveContext = computed(() => (contextDismissed.value ? null : deskContext.value));
+
+function readDeskContext() {
+	const route = (window.frappe && frappe.get_route && frappe.get_route()) || [];
+	let filters = null;
+	try {
+		filters = window.frappe?.query_report?.get_filter_values?.() || null;
+	} catch (e) {
+		filters = null; // report not loaded yet
+	}
+	deskContext.value = contextFromRoute(route, { filters });
+	contextDismissed.value = false;
+}
+
+function closePanel() {
+	panelOpen.value = false;
+	fabEl.value?.focus();
+}
+
+function openFull() {
+	window.location.assign(conversationUrl(panelRef.value?.convId));
+}
 
 const fabStyle = computed(() => ({
 	transform: `translate3d(${fabXY.value.x}px, ${fabXY.value.y}px, 0)`,
@@ -197,8 +245,18 @@ function onFabClick() {
 		return;
 	}
 	wake();
-	if (!hasAccess) window.location.assign("/jarvis-no-access");
-	else window.location.assign(NEW_CHAT_URL);
+	if (!hasAccess) {
+		window.location.assign("/jarvis-no-access");
+		return;
+	}
+	// Below the threshold a 400px panel is most of the screen, so fall back to
+	// the full SPA rather than designing a third layout for it.
+	if (window.innerWidth < PANEL_MIN_VIEWPORT_PX) {
+		window.location.assign(FULL_CHAT_URL);
+		return;
+	}
+	if (!panelOpen.value) readDeskContext();
+	panelOpen.value = !panelOpen.value;
 }
 
 // Re-clamps the FAB into the (possibly resized) dockable band; ratio-based
@@ -225,6 +283,12 @@ onMounted(() => {
 	document.addEventListener("mousemove", onDocumentActivity, { passive: true });
 	document.addEventListener("touchstart", onDocumentActivity, { passive: true });
 	document.addEventListener("keydown", onDocumentActivity, { passive: true });
+
+	// The record under discussion changes as the user moves around the Desk, and
+	// the panel deliberately stays open across that — so re-read the context
+	// rather than closing. The chip updates live.
+	readDeskContext();
+	if (window.frappe?.router?.on) frappe.router.on("change", readDeskContext);
 });
 
 onBeforeUnmount(() => {
@@ -264,7 +328,7 @@ onBeforeUnmount(() => {
 	border-radius: 16px;
 	background: var(--accent);
 	border: none;
-	cursor: pointer;
+	cursor: grab;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -294,10 +358,64 @@ onBeforeUnmount(() => {
 .jvw-fab--faded {
 	opacity: 0.4;
 }
+
+/* ---- drag affordance ----
+   design.md 1.3 forbids hover motion, and 5 lists hover-lift and pulse as
+   anti-patterns to remove. So draggability is signalled without anything
+   moving at rest: the grip fades in on OPACITY, the cursor changes, and the
+   press uses the same scale(0.98) TabButtons already uses.
+
+   The scale is applied to the FAB's CHILDREN, never the FAB itself: .jvw-fab
+   carries the drag position in an inline `transform`, so scaling it here would
+   snap the button back to the origin mid-press. */
+.jvw-grip {
+	position: absolute;
+	left: 7px;
+	top: 50%;
+	transform: translateY(-50%);
+	display: flex;
+	flex-direction: column;
+	gap: 2.5px;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+	pointer-events: none;
+}
+/* Keep the grip on the edge facing into the page, not the one against the
+   viewport edge the FAB is snapped to. */
+.jvw-fab--dock-left .jvw-grip {
+	left: auto;
+	right: 7px;
+}
+.jvw-grip i {
+	display: block;
+	width: 2.5px;
+	height: 2.5px;
+	border-radius: 999px;
+	background: #fff;
+}
+.jvw-fab:hover .jvw-grip,
+.jvw-fab:focus-visible .jvw-grip,
+.jvw-fab--dragging .jvw-grip {
+	opacity: 0.55;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.jvw-fab > svg {
+		transition: transform 0.12s ease;
+	}
+	.jvw-fab:active > svg,
+	.jvw-fab--dragging > svg {
+		transform: scale(0.98);
+	}
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.jvw-fab,
 	.jvw-fab--snapping {
 		transition: opacity 0.2s ease;
+	}
+	.jvw-grip {
+		transition: none;
 	}
 }
 </style>

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -3,7 +3,7 @@
 	     page. Tapping it opens the side chat panel in place; on a narrow
 	     viewport (where a 400px panel would be most of the screen) it falls
 	     back to navigating to the chat SPA. -->
-	<div class="jvw-root">
+	<div class="jvw-root" :class="{ 'jvw-root--dark': isDark }">
 		<button
 			type="button"
 			ref="fabEl"
@@ -50,6 +50,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import { FULL_CHAT_URL, conversationUrl, PANEL_MIN_VIEWPORT_PX } from "./config.mjs";
 import { contextFromRoute } from "./desk_context.mjs";
 import { panelLayout } from "./panel_anchor.mjs";
+import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import * as fabPos from "./fab_position.mjs";
 import Panel from "./Panel.vue";
 
@@ -74,6 +75,8 @@ const hasAccess = Boolean(window.frappe?.boot?.jarvis_has_access);
 
 // ---- Side chat panel: open state and the Desk record it is looking at. ----
 const panelRef = ref(null);
+const isDark = ref(false);
+let unwatchTheme = null;
 const panelOpen = ref(false);
 const deskContext = ref(null);
 const contextDismissed = ref(false);
@@ -281,6 +284,16 @@ function onResize() {
 }
 
 onMounted(() => {
+	// The Desk's dark flag is read in JS, not CSS: this component's
+	// `:global([data-theme=dark]) .jvw-root` compiled to a bare
+	// `[data-theme=dark]` rule, so its custom properties landed on <html> and
+	// were overridden by .jvw-root's own light values. The accent never
+	// changed in dark mode.
+	isDark.value = isDarkNow();
+	unwatchTheme = watchTheme((d) => {
+		isDark.value = d;
+	});
+
 	// Setup-time applyPosition() ran before fabEl was live, so getViewport()
 	// couldn't read the real --jvw-safe-bottom off it and fell back to 0. Now
 	// that the DOM ref exists, correct the position so notched devices don't
@@ -307,6 +320,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+	unwatchTheme?.();
 	window.removeEventListener("resize", onResize);
 	window.removeEventListener("orientationchange", onResize);
 	document.removeEventListener("mousemove", onDocumentActivity);
@@ -335,7 +349,7 @@ onBeforeUnmount(() => {
    <html>, which is an ancestor of this body-mounted widget: the accent becomes
    the indigo brand blue (the SPA's theme.js DARK_VARS accent) so the FAB stays
    visible against dark surfaces. */
-:global([data-theme="dark"]) .jvw-root {
+.jvw-root--dark {
 	--accent: #8b7cf7;
 	--accent-grad: linear-gradient(140deg, #9d90ff, #7a68f0);
 }

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -13,6 +13,7 @@
 				'jvw-fab--dragging': dragging,
 				'jvw-fab--faded': faded && !dragging,
 				'jvw-fab--dock-left': side === 'left',
+				'jvw-fab--behind': panelOpen,
 			}"
 			:style="fabStyle"
 			:aria-label="panelOpen ? 'Close Jarvis' : 'Ask Jarvis'"
@@ -357,6 +358,14 @@ onBeforeUnmount(() => {
 }
 .jvw-fab--faded {
 	opacity: 0.4;
+}
+/* The panel docks to the same edge the FAB is snapped to, and the FAB outranks
+   it on z-index — so an open panel would wear the launcher on top of its header
+   or composer. Retire the FAB while the panel is open; the panel's own close
+   button and Esc bring it back. */
+.jvw-fab--behind {
+	opacity: 0;
+	pointer-events: none;
 }
 
 /* ---- drag affordance ----

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -8,6 +8,26 @@ export function emptyStream() {
   return { live: null, busy: false, error: "", pending: [], reload: false };
 }
 
+// A conversation's message list is not just user/assistant prose: `tool` rows
+// outnumber both (they carry tool_name/tool_status, and their content is either
+// null or a terse "get_doc -> completed"). The full SPA renders those as tool
+// cards; this panel is deliberately text-only, so rendering them would put raw
+// machine chatter in the transcript.
+//
+// Empty-content assistant rows are dropped for the same reason: they are the
+// shell of a turn whose payload lives in canvas items the panel does not show,
+// and they would otherwise paint as blank bubbles.
+export function visibleMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  return messages.filter(
+    (m) =>
+      m &&
+      (m.role === "user" || m.role === "assistant") &&
+      typeof m.content === "string" &&
+      m.content.trim() !== ""
+  );
+}
+
 // Returns a NEW state; never mutates the input. The caller assigns the result
 // to a Vue ref, so structural sharing is not worth the aliasing risk.
 export function applyEvent(state, payload) {

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -43,7 +43,11 @@ export function applyEvent(state, payload) {
   switch (p.kind) {
     case "run:start":
       s.busy = false;
-      s.live = { runId: p.run_id || "", messageId: p.message_id || "", text: "" };
+      s.live = {
+        runId: p.run_id || "",
+        messageId: p.message_id || "",
+        text: "",
+      };
       return s;
 
     case "assistant:delta":
@@ -74,7 +78,11 @@ export function applyEvent(state, payload) {
       // panel would sit on "Jarvis is replying..." forever.
       if (!p.token) return s;
       if (s.pending.some((x) => x.token === p.token)) return s;
-      s.pending.push({ token: p.token, tool: p.tool || "", summary: p.summary || "" });
+      s.pending.push({
+        token: p.token,
+        tool: p.tool || "",
+        summary: p.summary || "",
+      });
       return s;
 
     case "action:resolved":

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -1,0 +1,71 @@
+// Pure reducer over the `jarvis:event` realtime frames the chat worker
+// publishes. Kept out of Panel.vue so the streaming rules — the easiest thing
+// in this feature to get subtly wrong — are unit-testable without a browser.
+//
+// Reference implementation: pwa/src/views/ChatView.vue (onEvent).
+
+export function emptyStream() {
+  return { live: null, busy: false, error: "", pending: [], reload: false };
+}
+
+// Returns a NEW state; never mutates the input. The caller assigns the result
+// to a Vue ref, so structural sharing is not worth the aliasing risk.
+export function applyEvent(state, payload) {
+  const p = payload || {};
+  const s = {
+    live: state.live ? { ...state.live } : null,
+    busy: state.busy,
+    error: state.error,
+    pending: state.pending.slice(),
+    reload: state.reload,
+  };
+
+  switch (p.kind) {
+    case "run:start":
+      s.busy = false;
+      s.live = { runId: p.run_id || "", messageId: p.message_id || "", text: "" };
+      return s;
+
+    case "assistant:delta":
+      // The frame carries the FULL text so far, not an increment. Assign it —
+      // appending doubles the reply.
+      if (!s.live) s.live = { runId: p.run_id || "", messageId: "", text: "" };
+      s.live.messageId = p.message_id || s.live.messageId;
+      s.live.text = p.text || "";
+      return s;
+
+    case "run:end":
+      s.busy = false;
+      s.live = null;
+      // The reply is durable now; re-fetch rather than trusting the streamed
+      // copy, which lacks the final formatting.
+      s.reload = true;
+      return s;
+
+    case "run:error":
+      s.busy = false;
+      s.live = null;
+      s.error = p.error || "That turn failed.";
+      s.reload = true;
+      return s;
+
+    case "action:pending":
+      // The agent is blocked waiting on a write confirmation. Without this the
+      // panel would sit on "Jarvis is replying..." forever.
+      if (!p.token) return s;
+      if (s.pending.some((x) => x.token === p.token)) return s;
+      s.pending.push({ token: p.token, tool: p.tool || "", summary: p.summary || "" });
+      return s;
+
+    case "action:resolved":
+      s.pending = s.pending.filter((x) => x.token !== p.token);
+      return s;
+
+    case "conversation:renamed":
+      s.reload = true;
+      return s;
+
+    default:
+      return s;
+  }
+}

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -1,6 +1,49 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { emptyStream, applyEvent } from "./chat_stream.mjs";
+import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
+
+// `tool` rows are the MOST common role in a real conversation (508 of 1201 on
+// the dev site) and their content is null or "get_doc -> completed" — machine
+// chatter that must never reach a text-only panel.
+test("visibleMessages: drops tool rows", () => {
+  const out = visibleMessages([
+    { name: "1", role: "user", content: "hi" },
+    { name: "2", role: "tool", content: "get_doc → completed" },
+    { name: "3", role: "tool", content: null },
+    { name: "4", role: "assistant", content: "hello" },
+  ]);
+  assert.deepEqual(
+    out.map((m) => m.name),
+    ["1", "4"]
+  );
+});
+
+test("visibleMessages: drops empty and whitespace-only content", () => {
+  const out = visibleMessages([
+    { name: "1", role: "assistant", content: "" },
+    { name: "2", role: "assistant", content: "   " },
+    { name: "3", role: "assistant", content: null },
+    { name: "4", role: "user", content: "real" },
+  ]);
+  assert.deepEqual(
+    out.map((m) => m.name),
+    ["4"]
+  );
+});
+
+test("visibleMessages: preserves order and is safe on junk input", () => {
+  const rows = [
+    { name: "a", role: "user", content: "one" },
+    { name: "b", role: "assistant", content: "two" },
+  ];
+  assert.deepEqual(
+    visibleMessages(rows).map((m) => m.name),
+    ["a", "b"]
+  );
+  assert.deepEqual(visibleMessages(null), []);
+  assert.deepEqual(visibleMessages(undefined), []);
+  assert.deepEqual(visibleMessages([null, undefined]), []);
+});
 
 test("emptyStream: starts idle", () => {
   const s = emptyStream();

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -64,20 +64,36 @@ test("run:start opens a live turn and clears busy", () => {
 });
 
 test("assistant:delta ASSIGNS cumulative text, never appends", () => {
-  let s = applyEvent(emptyStream(), { kind: "run:start", run_id: "r1", message_id: "m1" });
+  let s = applyEvent(emptyStream(), {
+    kind: "run:start",
+    run_id: "r1",
+    message_id: "m1",
+  });
   s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "Hello" });
-  s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "Hello there" });
+  s = applyEvent(s, {
+    kind: "assistant:delta",
+    run_id: "r1",
+    text: "Hello there",
+  });
   assert.equal(s.live.text, "Hello there");
 });
 
 test("assistant:delta with no prior run:start still opens a live turn", () => {
-  const s = applyEvent(emptyStream(), { kind: "assistant:delta", run_id: "r1", text: "Hi" });
+  const s = applyEvent(emptyStream(), {
+    kind: "assistant:delta",
+    run_id: "r1",
+    text: "Hi",
+  });
   assert.equal(s.live.text, "Hi");
   assert.equal(s.live.runId, "r1");
 });
 
 test("assistant:delta keeps a known message id when a later frame omits it", () => {
-  let s = applyEvent(emptyStream(), { kind: "run:start", run_id: "r1", message_id: "m1" });
+  let s = applyEvent(emptyStream(), {
+    kind: "run:start",
+    run_id: "r1",
+    message_id: "m1",
+  });
   s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "a" });
   assert.equal(s.live.messageId, "m1");
 });
@@ -91,7 +107,10 @@ test("run:end clears live and asks for a reload", () => {
 });
 
 test("run:error surfaces the message and reloads", () => {
-  const s = applyEvent(emptyStream(), { kind: "run:error", error: "The agent is unreachable." });
+  const s = applyEvent(emptyStream(), {
+    kind: "run:error",
+    error: "The agent is unreachable.",
+  });
   assert.equal(s.error, "The agent is unreachable.");
   assert.equal(s.live, null);
   assert.equal(s.busy, false);
@@ -117,16 +136,27 @@ test("action:pending queues a confirmation, ignoring duplicate tokens", () => {
     summary: "Create ToDo",
   });
   assert.equal(s.pending.length, 1);
-  assert.deepEqual(s.pending[0], { token: "t1", tool: "create_doc", summary: "Create ToDo" });
+  assert.deepEqual(s.pending[0], {
+    token: "t1",
+    tool: "create_doc",
+    summary: "Create ToDo",
+  });
 });
 
 test("action:pending without a token is ignored", () => {
-  const s = applyEvent(emptyStream(), { kind: "action:pending", summary: "no token" });
+  const s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    summary: "no token",
+  });
   assert.deepEqual(s.pending, []);
 });
 
 test("action:pending queues distinct tokens in arrival order", () => {
-  let s = applyEvent(emptyStream(), { kind: "action:pending", token: "t1", summary: "first" });
+  let s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    token: "t1",
+    summary: "first",
+  });
   s = applyEvent(s, { kind: "action:pending", token: "t2", summary: "second" });
   assert.deepEqual(
     s.pending.map((p) => p.token),
@@ -135,7 +165,11 @@ test("action:pending queues distinct tokens in arrival order", () => {
 });
 
 test("action:resolved drops the token", () => {
-  let s = applyEvent(emptyStream(), { kind: "action:pending", token: "t1", summary: "x" });
+  let s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    token: "t1",
+    summary: "x",
+  });
   s = applyEvent(s, { kind: "action:resolved", token: "t1" });
   assert.deepEqual(s.pending, []);
 });
@@ -163,13 +197,21 @@ test("applyEvent does not mutate the input state", () => {
   applyEvent(before, { kind: "run:start", run_id: "r1" });
   assert.equal(before.live, null);
 
-  const withPending = applyEvent(before, { kind: "action:pending", token: "t1", summary: "x" });
+  const withPending = applyEvent(before, {
+    kind: "action:pending",
+    token: "t1",
+    summary: "x",
+  });
   applyEvent(withPending, { kind: "action:resolved", token: "t1" });
   assert.equal(withPending.pending.length, 1);
 });
 
 test("live text survives an unrelated event", () => {
-  let s = applyEvent(emptyStream(), { kind: "assistant:delta", run_id: "r1", text: "partial" });
+  let s = applyEvent(emptyStream(), {
+    kind: "assistant:delta",
+    run_id: "r1",
+    text: "partial",
+  });
   s = applyEvent(s, { kind: "action:pending", token: "t1", summary: "x" });
   assert.equal(s.live.text, "partial");
 });

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { emptyStream, applyEvent } from "./chat_stream.mjs";
+
+test("emptyStream: starts idle", () => {
+  const s = emptyStream();
+  assert.equal(s.live, null);
+  assert.equal(s.busy, false);
+  assert.equal(s.error, "");
+  assert.deepEqual(s.pending, []);
+  assert.equal(s.reload, false);
+});
+
+test("run:start opens a live turn and clears busy", () => {
+  const s = applyEvent(
+    { ...emptyStream(), busy: true },
+    { kind: "run:start", run_id: "r1", message_id: "m1" }
+  );
+  assert.equal(s.busy, false);
+  assert.deepEqual(s.live, { runId: "r1", messageId: "m1", text: "" });
+});
+
+test("assistant:delta ASSIGNS cumulative text, never appends", () => {
+  let s = applyEvent(emptyStream(), { kind: "run:start", run_id: "r1", message_id: "m1" });
+  s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "Hello" });
+  s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "Hello there" });
+  assert.equal(s.live.text, "Hello there");
+});
+
+test("assistant:delta with no prior run:start still opens a live turn", () => {
+  const s = applyEvent(emptyStream(), { kind: "assistant:delta", run_id: "r1", text: "Hi" });
+  assert.equal(s.live.text, "Hi");
+  assert.equal(s.live.runId, "r1");
+});
+
+test("assistant:delta keeps a known message id when a later frame omits it", () => {
+  let s = applyEvent(emptyStream(), { kind: "run:start", run_id: "r1", message_id: "m1" });
+  s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "a" });
+  assert.equal(s.live.messageId, "m1");
+});
+
+test("run:end clears live and asks for a reload", () => {
+  let s = applyEvent(emptyStream(), { kind: "run:start", run_id: "r1" });
+  s = applyEvent(s, { kind: "run:end", run_id: "r1" });
+  assert.equal(s.live, null);
+  assert.equal(s.busy, false);
+  assert.equal(s.reload, true);
+});
+
+test("run:error surfaces the message and reloads", () => {
+  const s = applyEvent(emptyStream(), { kind: "run:error", error: "The agent is unreachable." });
+  assert.equal(s.error, "The agent is unreachable.");
+  assert.equal(s.live, null);
+  assert.equal(s.busy, false);
+  assert.equal(s.reload, true);
+});
+
+test("run:error with no message falls back to a plain sentence", () => {
+  const s = applyEvent(emptyStream(), { kind: "run:error" });
+  assert.equal(s.error, "That turn failed.");
+});
+
+test("action:pending queues a confirmation, ignoring duplicate tokens", () => {
+  let s = applyEvent(emptyStream(), {
+    kind: "action:pending",
+    token: "t1",
+    tool: "create_doc",
+    summary: "Create ToDo",
+  });
+  s = applyEvent(s, {
+    kind: "action:pending",
+    token: "t1",
+    tool: "create_doc",
+    summary: "Create ToDo",
+  });
+  assert.equal(s.pending.length, 1);
+  assert.deepEqual(s.pending[0], { token: "t1", tool: "create_doc", summary: "Create ToDo" });
+});
+
+test("action:pending without a token is ignored", () => {
+  const s = applyEvent(emptyStream(), { kind: "action:pending", summary: "no token" });
+  assert.deepEqual(s.pending, []);
+});
+
+test("action:pending queues distinct tokens in arrival order", () => {
+  let s = applyEvent(emptyStream(), { kind: "action:pending", token: "t1", summary: "first" });
+  s = applyEvent(s, { kind: "action:pending", token: "t2", summary: "second" });
+  assert.deepEqual(
+    s.pending.map((p) => p.token),
+    ["t1", "t2"]
+  );
+});
+
+test("action:resolved drops the token", () => {
+  let s = applyEvent(emptyStream(), { kind: "action:pending", token: "t1", summary: "x" });
+  s = applyEvent(s, { kind: "action:resolved", token: "t1" });
+  assert.deepEqual(s.pending, []);
+});
+
+test("conversation:renamed asks for a reload", () => {
+  const s = applyEvent(emptyStream(), { kind: "conversation:renamed" });
+  assert.equal(s.reload, true);
+});
+
+test("unknown kinds leave state untouched", () => {
+  const before = emptyStream();
+  const after = applyEvent(before, { kind: "something:new" });
+  assert.deepEqual(after, before);
+});
+
+test("a missing or malformed payload is inert", () => {
+  const before = emptyStream();
+  assert.deepEqual(applyEvent(before, null), before);
+  assert.deepEqual(applyEvent(before, undefined), before);
+  assert.deepEqual(applyEvent(before, {}), before);
+});
+
+test("applyEvent does not mutate the input state", () => {
+  const before = emptyStream();
+  applyEvent(before, { kind: "run:start", run_id: "r1" });
+  assert.equal(before.live, null);
+
+  const withPending = applyEvent(before, { kind: "action:pending", token: "t1", summary: "x" });
+  applyEvent(withPending, { kind: "action:resolved", token: "t1" });
+  assert.equal(withPending.pending.length, 1);
+});
+
+test("live text survives an unrelated event", () => {
+  let s = applyEvent(emptyStream(), { kind: "assistant:delta", run_id: "r1", text: "partial" });
+  s = applyEvent(s, { kind: "action:pending", token: "t1", summary: "x" });
+  assert.equal(s.live.text, "partial");
+});

--- a/jarvis/public/js/jarvis_chat/widget/config.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/config.mjs
@@ -8,7 +8,8 @@ export const FULL_CHAT_URL = "/jarvis/";
 // Deep link to one conversation in the full SPA — the panel's "open full chat"
 // action, so the panel reads as a view onto a thread rather than a separate
 // inbox.
-export const conversationUrl = (id) => (id ? `/jarvis/c/${encodeURIComponent(id)}` : FULL_CHAT_URL);
+export const conversationUrl = (id) =>
+  id ? `/jarvis/c/${encodeURIComponent(id)}` : FULL_CHAT_URL;
 
 // Below this viewport width a 400px docked panel is most of the screen, so the
 // FAB falls back to navigating to the SPA instead of opening in place.

--- a/jarvis/public/js/jarvis_chat/widget/config.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/config.mjs
@@ -1,4 +1,15 @@
-// Where the FAB sends an authorized user. ?new=1 tells the chat SPA
-// (frontend/src/views/ChatView.vue) to start a fresh conversation instead
-// of restoring the last one.
-export const NEW_CHAT_URL = "/jarvis/?new=1";
+// Where the FAB sends an authorized user when the panel cannot be used
+// (narrow viewport, or no access). No `?new=1` any more: that told the SPA to
+// start a fresh conversation, which is the opposite of the side chat's
+// contract — the panel continues where the user left off, and so should the
+// full-page fallback.
+export const FULL_CHAT_URL = "/jarvis/";
+
+// Deep link to one conversation in the full SPA — the panel's "open full chat"
+// action, so the panel reads as a view onto a thread rather than a separate
+// inbox.
+export const conversationUrl = (id) => (id ? `/jarvis/c/${encodeURIComponent(id)}` : FULL_CHAT_URL);
+
+// Below this viewport width a 400px docked panel is most of the screen, so the
+// FAB falls back to navigating to the SPA instead of opening in place.
+export const PANEL_MIN_VIEWPORT_PX = 640;

--- a/jarvis/public/js/jarvis_chat/widget/desk_context.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_context.mjs
@@ -1,0 +1,43 @@
+// Maps the Desk route to the `context` payload that jarvis.chat.api.send_message
+// forwards to turn_handler._prepend_doc_context, which turns it into a leading
+// "[Viewing: ...]" line on the prompt. The stored message is untouched, so the
+// transcript still reads as the user typed it.
+//
+// Pure on purpose: the panel calls this on every route change and before every
+// send, and this mapping is the part of that path worth unit testing.
+
+// Frappe route shapes this recognizes:
+//   ["Form", doctype, name]        -> a single record
+//   ["List", doctype, ...]         -> a list view
+//   ["query-report", reportName]   -> a report (filters passed in via opts)
+// Anything else (workspaces, dashboards, settings) yields null, and the panel
+// then behaves as a plain chat with no context chip.
+export function contextFromRoute(route, opts = {}) {
+  if (!Array.isArray(route) || route.length === 0) return null;
+  const head = route[0];
+  const a = route[1];
+  const b = route[2];
+
+  // A brand-new unsaved doc routes to ["Form", doctype] with no name segment.
+  // There is no record to point the agent at, so send nothing rather than
+  // inventing "new-sales-invoice-1".
+  if (head === "Form" && a && b) return { doctype: a, name: b };
+  if (head === "List" && a) return { doctype: a };
+  if (head === "query-report" && a) {
+    const f = opts.filters;
+    const hasFilters = f && typeof f === "object" && Object.keys(f).length > 0;
+    return hasFilters ? { report_name: a, filters: f } : { report_name: a };
+  }
+  return null;
+}
+
+// Human-readable form for the panel's context chip. Mirrors the wording
+// _prepend_doc_context uses, so the chip and the prompt agree about what the
+// agent is looking at.
+export function contextLabel(ctx) {
+  if (!ctx || typeof ctx !== "object") return "";
+  if (ctx.report_name) return `${ctx.report_name} report`;
+  if (ctx.doctype && ctx.name) return `${ctx.doctype} ${ctx.name}`;
+  if (ctx.doctype) return `the ${ctx.doctype} list`;
+  return "";
+}

--- a/jarvis/public/js/jarvis_chat/widget/desk_context.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_context.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { contextFromRoute, contextLabel } from "./desk_context.mjs";
+
+test("contextFromRoute: form view yields doctype + name", () => {
+  assert.deepEqual(contextFromRoute(["Form", "Sales Invoice", "INV-0001"]), {
+    doctype: "Sales Invoice",
+    name: "INV-0001",
+  });
+});
+
+test("contextFromRoute: list view yields doctype only", () => {
+  assert.deepEqual(contextFromRoute(["List", "Sales Invoice", "List"]), {
+    doctype: "Sales Invoice",
+  });
+});
+
+test("contextFromRoute: report with filters", () => {
+  assert.deepEqual(
+    contextFromRoute(["query-report", "Accounts Receivable"], {
+      filters: { company: "Acme", status: "Overdue" },
+    }),
+    { report_name: "Accounts Receivable", filters: { company: "Acme", status: "Overdue" } }
+  );
+});
+
+test("contextFromRoute: report with no filters omits the filters key", () => {
+  assert.deepEqual(contextFromRoute(["query-report", "Accounts Receivable"]), {
+    report_name: "Accounts Receivable",
+  });
+});
+
+test("contextFromRoute: report with an empty filter object omits the key", () => {
+  assert.deepEqual(contextFromRoute(["query-report", "Accounts Receivable"], { filters: {} }), {
+    report_name: "Accounts Receivable",
+  });
+});
+
+test("contextFromRoute: unknown routes yield null", () => {
+  assert.equal(contextFromRoute(["Workspaces", "Home"]), null);
+  assert.equal(contextFromRoute([]), null);
+  assert.equal(contextFromRoute(null), null);
+  assert.equal(contextFromRoute(undefined), null);
+  // A brand-new unsaved doc has no name segment: there is no record to point at.
+  assert.equal(contextFromRoute(["Form", "Sales Invoice"]), null);
+});
+
+test("contextLabel: renders each shape", () => {
+  assert.equal(
+    contextLabel({ doctype: "Sales Invoice", name: "INV-0001" }),
+    "Sales Invoice INV-0001"
+  );
+  assert.equal(contextLabel({ doctype: "Sales Invoice" }), "the Sales Invoice list");
+  assert.equal(contextLabel({ report_name: "Accounts Receivable" }), "Accounts Receivable report");
+});
+
+test("contextLabel: empty for absent or unrecognized context", () => {
+  assert.equal(contextLabel(null), "");
+  assert.equal(contextLabel(undefined), "");
+  assert.equal(contextLabel({}), "");
+  assert.equal(contextLabel("nonsense"), "");
+});

--- a/jarvis/public/js/jarvis_chat/widget/desk_context.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_context.test.mjs
@@ -20,7 +20,10 @@ test("contextFromRoute: report with filters", () => {
     contextFromRoute(["query-report", "Accounts Receivable"], {
       filters: { company: "Acme", status: "Overdue" },
     }),
-    { report_name: "Accounts Receivable", filters: { company: "Acme", status: "Overdue" } }
+    {
+      report_name: "Accounts Receivable",
+      filters: { company: "Acme", status: "Overdue" },
+    }
   );
 });
 
@@ -31,9 +34,12 @@ test("contextFromRoute: report with no filters omits the filters key", () => {
 });
 
 test("contextFromRoute: report with an empty filter object omits the key", () => {
-  assert.deepEqual(contextFromRoute(["query-report", "Accounts Receivable"], { filters: {} }), {
-    report_name: "Accounts Receivable",
-  });
+  assert.deepEqual(
+    contextFromRoute(["query-report", "Accounts Receivable"], { filters: {} }),
+    {
+      report_name: "Accounts Receivable",
+    }
+  );
 });
 
 test("contextFromRoute: unknown routes yield null", () => {
@@ -50,8 +56,14 @@ test("contextLabel: renders each shape", () => {
     contextLabel({ doctype: "Sales Invoice", name: "INV-0001" }),
     "Sales Invoice INV-0001"
   );
-  assert.equal(contextLabel({ doctype: "Sales Invoice" }), "the Sales Invoice list");
-  assert.equal(contextLabel({ report_name: "Accounts Receivable" }), "Accounts Receivable report");
+  assert.equal(
+    contextLabel({ doctype: "Sales Invoice" }),
+    "the Sales Invoice list"
+  );
+  assert.equal(
+    contextLabel({ report_name: "Accounts Receivable" }),
+    "Accounts Receivable report"
+  );
 });
 
 test("contextLabel: empty for absent or unrecognized context", () => {

--- a/jarvis/public/js/jarvis_chat/widget/desk_theme.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_theme.mjs
@@ -1,0 +1,66 @@
+// Is the Desk currently dark?
+//
+// Why this exists rather than a CSS selector: Vue's scoped-style compiler here
+// drops the descendant in `:global([data-theme="dark"]) .foo`, emitting a bare
+// `[data-theme=dark] { ... }`. Custom properties declared that way land on
+// <html> and are then OVERRIDDEN by the component's own `.foo { --x: light }`
+// rule, so the dark values never win. Resolving the flag in JS and binding a
+// class on the same element sidesteps the whole problem.
+//
+// Frappe's theme switcher sets `data-theme` to the RESOLVED theme and
+// `data-theme-mode` to the user's choice ("light" | "dark" | "automatic"), so
+// `data-theme` alone is usually enough — but when the mode is automatic and the
+// attribute has not been stamped yet, fall back to the OS preference.
+
+export function resolveDark(theme, mode, prefersDark) {
+  const t = String(theme || "").toLowerCase();
+  if (t === "dark") return true;
+  if (t === "light") return false;
+  const m = String(mode || "").toLowerCase();
+  if (m === "dark") return true;
+  if (m === "light") return false;
+  if (m === "automatic" || m === "auto" || m === "") return Boolean(prefersDark);
+  return false;
+}
+
+export function isDarkNow() {
+  if (typeof document === "undefined") return false;
+  const root = document.documentElement;
+  let prefers = false;
+  try {
+    prefers = window.matchMedia?.("(prefers-color-scheme: dark)")?.matches || false;
+  } catch (e) {
+    prefers = false;
+  }
+  return resolveDark(
+    root.getAttribute("data-theme"),
+    root.getAttribute("data-theme-mode"),
+    prefers
+  );
+}
+
+// Calls back whenever the Desk theme changes. Returns a dispose function.
+export function watchTheme(onChange) {
+  if (typeof document === "undefined") return () => {};
+  const root = document.documentElement;
+  const fire = () => onChange(isDarkNow());
+  const obs = new MutationObserver(fire);
+  obs.observe(root, { attributes: true, attributeFilter: ["data-theme", "data-theme-mode"] });
+
+  let mq = null;
+  try {
+    mq = window.matchMedia?.("(prefers-color-scheme: dark)") || null;
+    mq?.addEventListener?.("change", fire);
+  } catch (e) {
+    mq = null;
+  }
+
+  return () => {
+    obs.disconnect();
+    try {
+      mq?.removeEventListener?.("change", fire);
+    } catch (e) {
+      /* nothing to undo */
+    }
+  };
+}

--- a/jarvis/public/js/jarvis_chat/widget/desk_theme.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_theme.mjs
@@ -19,7 +19,8 @@ export function resolveDark(theme, mode, prefersDark) {
   const m = String(mode || "").toLowerCase();
   if (m === "dark") return true;
   if (m === "light") return false;
-  if (m === "automatic" || m === "auto" || m === "") return Boolean(prefersDark);
+  if (m === "automatic" || m === "auto" || m === "")
+    return Boolean(prefersDark);
   return false;
 }
 
@@ -28,7 +29,8 @@ export function isDarkNow() {
   const root = document.documentElement;
   let prefers = false;
   try {
-    prefers = window.matchMedia?.("(prefers-color-scheme: dark)")?.matches || false;
+    prefers =
+      window.matchMedia?.("(prefers-color-scheme: dark)")?.matches || false;
   } catch (e) {
     prefers = false;
   }
@@ -45,7 +47,10 @@ export function watchTheme(onChange) {
   const root = document.documentElement;
   const fire = () => onChange(isDarkNow());
   const obs = new MutationObserver(fire);
-  obs.observe(root, { attributes: true, attributeFilter: ["data-theme", "data-theme-mode"] });
+  obs.observe(root, {
+    attributes: true,
+    attributeFilter: ["data-theme", "data-theme-mode"],
+  });
 
   let mq = null;
   try {

--- a/jarvis/public/js/jarvis_chat/widget/desk_theme.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/desk_theme.test.mjs
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveDark } from "./desk_theme.mjs";
+
+test("an explicit data-theme wins over everything", () => {
+  assert.equal(resolveDark("dark", "light", false), true);
+  assert.equal(resolveDark("light", "dark", true), false);
+});
+
+test("falls back to the mode when data-theme is absent", () => {
+  assert.equal(resolveDark(null, "dark", false), true);
+  assert.equal(resolveDark("", "light", true), false);
+});
+
+test("automatic mode follows the OS preference", () => {
+  assert.equal(resolveDark(null, "automatic", true), true);
+  assert.equal(resolveDark(null, "automatic", false), false);
+  assert.equal(resolveDark(null, "auto", true), true);
+});
+
+test("nothing set at all follows the OS preference", () => {
+  assert.equal(resolveDark(null, null, true), true);
+  assert.equal(resolveDark(null, null, false), false);
+});
+
+test("case is not significant", () => {
+  assert.equal(resolveDark("Dark", null, false), true);
+  assert.equal(resolveDark(null, "DARK", false), true);
+});
+
+test("an unknown mode is treated as light, not as dark", () => {
+  assert.equal(resolveDark(null, "sepia", false), false);
+  assert.equal(resolveDark(null, "sepia", true), false);
+});

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
@@ -10,7 +10,7 @@
 // Normal mini-chat proportions (Intercom/Crisp class), not a full-height dock:
 // the panel is a window over the page, not a second column of it.
 export const PANEL_W = 400;
-export const PANEL_MAX_H = 600;
+export const PANEL_MAX_H = 624; // matches the design board
 export const GAP = 12; // between the FAB and the panel
 export const MARGIN = 12; // minimum clearance from every viewport edge
 

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.mjs
@@ -1,0 +1,72 @@
+// Where the mini chat window sits relative to the FAB.
+//
+// The FAB is draggable to any point down either edge, so the panel cannot have
+// a fixed home: it opens beside wherever the launcher currently is, flips to
+// the other side when there is no room, and clamps so it never leaves the
+// viewport or slides under the Desk navbar. Pure geometry, like
+// fab_position.mjs, so every edge case is a unit test instead of a drag
+// session in a browser.
+
+// Normal mini-chat proportions (Intercom/Crisp class), not a full-height dock:
+// the panel is a window over the page, not a second column of it.
+export const PANEL_W = 400;
+export const PANEL_MAX_H = 600;
+export const GAP = 12; // between the FAB and the panel
+export const MARGIN = 12; // minimum clearance from every viewport edge
+
+function clamp(n, lo, hi) {
+  if (hi < lo) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+// fab: { x, y, size } — the FAB's top-left in viewport coordinates.
+// vp:  { vw, vh, top } — top is the Desk navbar height the panel must clear.
+// Returns { left, top, width, height, side }, all in viewport pixels.
+export function panelLayout(fab, vp) {
+  const v = vp || {};
+  const vw = Number.isFinite(v.vw) ? v.vw : 1024;
+  const vh = Number.isFinite(v.vh) ? v.vh : 768;
+  const top = Number.isFinite(v.top) ? v.top : 0;
+
+  const f = fab || {};
+  const size = Number.isFinite(f.size) ? f.size : 54;
+  const fx = Number.isFinite(f.x) ? f.x : vw - size - MARGIN;
+  const fy = Number.isFinite(f.y) ? f.y : vh - size - MARGIN;
+
+  const width = Math.min(PANEL_W, Math.max(0, vw - MARGIN * 2));
+  const height = Math.min(PANEL_MAX_H, Math.max(0, vh - top - MARGIN * 2));
+
+  // Prefer the side facing into the page: a right-docked FAB opens leftward.
+  const fabCentre = fx + size / 2;
+  const preferLeft = fabCentre > vw / 2;
+
+  const leftOption = fx - GAP - width; // panel sits left of the FAB
+  const rightOption = fx + size + GAP; // panel sits right of the FAB
+
+  let side;
+  let left;
+  if (preferLeft) {
+    side = "left";
+    left = leftOption;
+    if (left < MARGIN && rightOption + width <= vw - MARGIN) {
+      side = "right";
+      left = rightOption;
+    }
+  } else {
+    side = "right";
+    left = rightOption;
+    if (left + width > vw - MARGIN && leftOption >= MARGIN) {
+      side = "left";
+      left = leftOption;
+    }
+  }
+  // Neither side fits (a viewport barely wider than the panel): clamp.
+  left = clamp(left, MARGIN, vw - MARGIN - width);
+
+  // Bottom-align with the FAB so the panel grows upward out of the launcher,
+  // then clamp into the band between the navbar and the viewport floor.
+  const bottomAligned = fy + size - height;
+  const topPos = clamp(bottomAligned, top + MARGIN, vh - MARGIN - height);
+
+  return { left, top: topPos, width, height, side };
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { PANEL_W, PANEL_MAX_H, GAP, MARGIN, panelLayout } from "./panel_anchor.mjs";
+import {
+  PANEL_W,
+  PANEL_MAX_H,
+  GAP,
+  MARGIN,
+  panelLayout,
+} from "./panel_anchor.mjs";
 
 // A roomy desktop viewport with a 48px Desk navbar.
 const VP = { vw: 1440, vh: 900, top: 48 };

--- a/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_anchor.test.mjs
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PANEL_W, PANEL_MAX_H, GAP, MARGIN, panelLayout } from "./panel_anchor.mjs";
+
+// A roomy desktop viewport with a 48px Desk navbar.
+const VP = { vw: 1440, vh: 900, top: 48 };
+const FAB = 54;
+
+test("docked right: the panel opens to the LEFT of the FAB", () => {
+  const fab = { x: 1440 - 54 - 16, y: 700, size: FAB };
+  const l = panelLayout(fab, VP);
+  assert.equal(l.side, "left");
+  assert.equal(l.left, fab.x - GAP - PANEL_W);
+  assert.equal(l.width, PANEL_W);
+});
+
+test("docked left: the panel opens to the RIGHT of the FAB", () => {
+  const fab = { x: 16, y: 700, size: FAB };
+  const l = panelLayout(fab, VP);
+  assert.equal(l.side, "right");
+  assert.equal(l.left, fab.x + FAB + GAP);
+});
+
+test("the panel's bottom aligns with the FAB's bottom", () => {
+  const fab = { x: 1370, y: 700, size: FAB };
+  const l = panelLayout(fab, VP);
+  assert.equal(l.top + l.height, fab.y + FAB);
+});
+
+// The FAB is draggable anywhere down the edge, so a naive bottom-align would
+// push the panel off-screen at the extremes. These two are the whole point of
+// the "user moved the icon" requirement.
+test("FAB dragged to the very top: the panel clamps below the navbar", () => {
+  const fab = { x: 1370, y: 52, size: FAB };
+  const l = panelLayout(fab, VP);
+  assert.equal(l.top, VP.top + MARGIN);
+  assert.ok(l.top + l.height <= VP.vh - MARGIN);
+});
+
+test("FAB dragged to the very bottom: the panel stays inside the viewport", () => {
+  const fab = { x: 1370, y: 880, size: FAB };
+  const l = panelLayout(fab, VP);
+  assert.ok(l.top + l.height <= VP.vh - MARGIN, "bottom must not overflow");
+  assert.ok(l.top >= VP.top + MARGIN, "top must clear the navbar");
+});
+
+test("height is capped at the mini-chat size, not stretched to the viewport", () => {
+  const l = panelLayout({ x: 1370, y: 700, size: FAB }, VP);
+  assert.equal(l.height, PANEL_MAX_H);
+  assert.ok(l.height < VP.vh - VP.top, "a mini chat never fills the page");
+});
+
+test("a short viewport shrinks the panel instead of overflowing", () => {
+  const vp = { vw: 1280, vh: 500, top: 48 };
+  const l = panelLayout({ x: 1200, y: 400, size: FAB }, vp);
+  assert.equal(l.height, vp.vh - vp.top - MARGIN * 2);
+  assert.ok(l.top >= vp.top + MARGIN);
+  assert.ok(l.top + l.height <= vp.vh - MARGIN);
+});
+
+test("a narrow viewport shrinks the width and keeps both margins", () => {
+  const vp = { vw: 380, vh: 800, top: 48 };
+  const l = panelLayout({ x: 320, y: 600, size: FAB }, vp);
+  assert.equal(l.width, vp.vw - MARGIN * 2);
+  assert.ok(l.left >= MARGIN);
+  assert.ok(l.left + l.width <= vp.vw - MARGIN);
+});
+
+test("no room on the preferred side: the panel flips rather than overflowing", () => {
+  // FAB dragged to the left edge, but the panel cannot fit to its right.
+  const vp = { vw: 520, vh: 900, top: 48 };
+  const l = panelLayout({ x: 12, y: 700, size: FAB }, vp);
+  assert.ok(l.left >= MARGIN, "never off the left edge");
+  assert.ok(l.left + l.width <= vp.vw - MARGIN, "never off the right edge");
+});
+
+test("layout is a pure function of its inputs", () => {
+  const fab = { x: 1370, y: 700, size: FAB };
+  assert.deepEqual(panelLayout(fab, VP), panelLayout(fab, VP));
+});
+
+test("junk input yields a usable layout rather than NaN", () => {
+  const l = panelLayout(null, VP);
+  assert.ok(Number.isFinite(l.left) && Number.isFinite(l.top));
+  assert.ok(Number.isFinite(l.width) && Number.isFinite(l.height));
+});

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -14,7 +14,8 @@ function call(method, args) {
 
 export const listConversations = () => call(CHAT + "list_conversations");
 
-export const getConversation = (conversation) => call(CHAT + "get_conversation", { conversation });
+export const getConversation = (conversation) =>
+  call(CHAT + "get_conversation", { conversation });
 
 // An empty `conversation` is allowed: the backend creates (or focuses) the
 // user's empty conversation and returns its id as `conversation_id`, which

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -22,12 +22,68 @@ export const getConversation = (conversation) => call(CHAT + "get_conversation",
 //
 // `context` is the object from desk_context.contextFromRoute. Send it only when
 // there is one, so a non-record page behaves as a plain chat.
-export const sendMessage = (conversation, message, context) =>
+export const sendMessage = (conversation, message, context, attachments) =>
   call(CHAT + "send_message", {
     conversation: conversation || "",
     message,
     ...(context ? { context: JSON.stringify(context) } : {}),
+    ...(attachments && attachments.length
+      ? { attachments: JSON.stringify(attachments) }
+      : {}),
   });
+
+// Mic gating: stt_enabled is false when voice/STT is not configured, and the
+// button must not appear at all in that case.
+export const getChatUiSettings = () => call(CHAT + "get_chat_ui_settings");
+
+// Multipart endpoints cannot go through frappe.call, so these two use fetch
+// with the Desk's CSRF token, the same way the SPA's uploadFile does.
+export async function uploadFile(file) {
+  const fd = new FormData();
+  fd.append("file", file, file.name);
+  fd.append("is_private", "1");
+  const r = await fetch("/api/method/upload_file", {
+    method: "POST",
+    headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+    body: fd,
+    credentials: "include",
+  });
+  if (!r.ok) throw new Error(`upload failed (${r.status})`);
+  const data = await r.json();
+  const f = data.message || data;
+  return { file_url: f.file_url, file_name: f.file_name || file.name };
+}
+
+function audioName(blob) {
+  const t = (blob && blob.type) || "";
+  if (t.includes("ogg")) return "audio.ogg";
+  if (t.includes("mp4")) return "audio.m4a";
+  if (t.includes("wav")) return "audio.wav";
+  return "audio.webm";
+}
+
+// Recorded blob -> verbatim transcript. Returns {ok, text, ...}.
+export async function transcribeAudio(blob, durationS) {
+  const fd = new FormData();
+  fd.append("audio", blob, audioName(blob));
+  fd.append("duration_s", String(Math.round(durationS || 0)));
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 25000);
+  try {
+    const r = await fetch("/api/method/jarvis.chat.voice.transcribe_audio", {
+      method: "POST",
+      headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+      body: fd,
+      credentials: "include",
+      signal: ctrl.signal,
+    });
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(`transcription failed (${r.status})`);
+    return data.message || data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 export const stopRun = (conversation, runId) =>
   call(CHAT + "stop_run", { conversation, run_id: runId || "" });

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -1,0 +1,37 @@
+// Thin wrappers over the Desk's own frappe.call. The panel runs INSIDE the
+// Desk, so the session cookie and CSRF token are already in place — unlike the
+// SPA and the PWA, this surface needs no frappe-ui and no socket of its own.
+//
+// frappe.call resolves to the full envelope; every caller here wants
+// `.message`, so unwrap it once at this boundary.
+
+const CHAT = "jarvis.chat.api.";
+const ACTIONS = "jarvis.chat.actions_api.";
+
+function call(method, args) {
+  return frappe.call({ method, args: args || {} }).then((r) => r.message);
+}
+
+export const listConversations = () => call(CHAT + "list_conversations");
+
+export const getConversation = (conversation) => call(CHAT + "get_conversation", { conversation });
+
+// An empty `conversation` is allowed: the backend creates (or focuses) the
+// user's empty conversation and returns its id as `conversation_id`, which
+// saves a round-trip before the very first send.
+//
+// `context` is the object from desk_context.contextFromRoute. Send it only when
+// there is one, so a non-record page behaves as a plain chat.
+export const sendMessage = (conversation, message, context) =>
+  call(CHAT + "send_message", {
+    conversation: conversation || "",
+    message,
+    ...(context ? { context: JSON.stringify(context) } : {}),
+  });
+
+export const stopRun = (conversation, runId) =>
+  call(CHAT + "stop_run", { conversation, run_id: runId || "" });
+
+// Resolves a write-confirmation gate raised by an `action:pending` frame.
+export const confirmTool = (token, conversation) =>
+  call(ACTIONS + "confirm_tool", { token, conversation: conversation || "" });

--- a/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
@@ -1,0 +1,33 @@
+// Agent replies are GFM: bold, bullets, pipe tables, fenced code. Rendering
+// them as plain text is how the panel ended up showing literal ** and | rows.
+//
+// The renderer is the SPA's own (frontend/src/markdown.js) rather than a third
+// implementation — it is dependency-free and already tuned for these replies,
+// and it escapes HTML before emitting, which is what makes v-html safe here.
+import { renderMarkdown } from "../../../../../frontend/src/markdown.js";
+
+// Control fences the agent uses to talk to the UI, not to the reader. The full
+// SPA turns several of these into cards; this panel is text-only, so strip them
+// all rather than print their JSON. Mirrors ChatView's _stripControlBlocks.
+const CONTROL_FENCES = [
+  "jarvis-action",
+  "confirm",
+  "jarvis-ask",
+  "jarvis-cards",
+  "jarvis-skill",
+  "jarvis-macro",
+  "jarvis-chart",
+];
+
+export function stripControlBlocks(src) {
+  let t = String(src == null ? "" : src);
+  for (const name of CONTROL_FENCES) {
+    t = t.replace(new RegExp("```" + name + "[ \\t]*\\n[\\s\\S]*?```", "g"), "");
+  }
+  t = t.replace(/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g, "");
+  return t.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function renderReply(src) {
+  return renderMarkdown(stripControlBlocks(src));
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_markdown.mjs
@@ -22,7 +22,10 @@ const CONTROL_FENCES = [
 export function stripControlBlocks(src) {
   let t = String(src == null ? "" : src);
   for (const name of CONTROL_FENCES) {
-    t = t.replace(new RegExp("```" + name + "[ \\t]*\\n[\\s\\S]*?```", "g"), "");
+    t = t.replace(
+      new RegExp("```" + name + "[ \\t]*\\n[\\s\\S]*?```", "g"),
+      ""
+    );
   }
   t = t.replace(/```mermaid[ \t]*\n[ \t]*xychart-beta[\s\S]*?```/g, "");
   return t.replace(/\n{3,}/g, "\n\n").trim();

--- a/jarvis/public/js/jarvis_chat/widget/panel_markdown.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_markdown.test.mjs
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripControlBlocks } from "./panel_markdown.mjs";
+
+test("strips the jarvis-skill fence the agent appends to replies", () => {
+  const src = "Here is the summary.\n\n```jarvis-skill\nerpnext-accounts\n```";
+  assert.equal(stripControlBlocks(src), "Here is the summary.");
+});
+
+test("strips every control fence, keeping the prose", () => {
+  for (const name of [
+    "jarvis-action",
+    "confirm",
+    "jarvis-ask",
+    "jarvis-cards",
+    "jarvis-skill",
+    "jarvis-macro",
+    "jarvis-chart",
+  ]) {
+    const src = `Before.\n\n\`\`\`${name}\n{"x":1}\n\`\`\`\n\nAfter.`;
+    const out = stripControlBlocks(src);
+    assert.ok(!out.includes(name), `${name} leaked`);
+    assert.ok(out.includes("Before.") && out.includes("After."));
+  }
+});
+
+test("keeps ordinary code fences — those are content", () => {
+  const src = "Run this:\n\n```bash\nbench migrate\n```";
+  assert.ok(stripControlBlocks(src).includes("bench migrate"));
+});
+
+test("collapses the blank runs a stripped fence leaves behind", () => {
+  const src = "A.\n\n```jarvis-skill\nx\n```\n\n\n\nB.";
+  assert.equal(stripControlBlocks(src), "A.\n\nB.");
+});
+
+test("is safe on empty and non-string input", () => {
+  assert.equal(stripControlBlocks(""), "");
+  assert.equal(stripControlBlocks(null), "");
+  assert.equal(stripControlBlocks(undefined), "");
+});

--- a/jarvis/public/js/jarvis_chat/widget/panel_welcome.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_welcome.mjs
@@ -19,7 +19,9 @@ export function greetingFor(hour) {
 // like a person talking rather than a database row.
 export function greetingLine(hour, name) {
   const g = greetingFor(hour);
-  const first = String(name || "").trim().split(/\s+/)[0];
+  const first = String(name || "")
+    .trim()
+    .split(/\s+/)[0];
   return first ? `${g}, ${first}` : g;
 }
 
@@ -31,22 +33,40 @@ export function suggestionsFor(ctx) {
 
   if (label && label.doctype && label.name) {
     return [
-      { title: "Explain this record", prompt: "Summarise this record and flag anything unusual." },
-      { title: "Find what is linked", prompt: "What documents are linked to this one?" },
-      { title: "Suggest next steps", prompt: "What should I do next with this record?" },
+      {
+        title: "Explain this record",
+        prompt: "Summarise this record and flag anything unusual.",
+      },
+      {
+        title: "Find what is linked",
+        prompt: "What documents are linked to this one?",
+      },
+      {
+        title: "Suggest next steps",
+        prompt: "What should I do next with this record?",
+      },
     ];
   }
 
   if (label && (label.doctype || label.report_name)) {
     return [
-      { title: "Analyse data", prompt: "Which of these need my attention first?" },
+      {
+        title: "Analyse data",
+        prompt: "Which of these need my attention first?",
+      },
       { title: "Summarise", prompt: "Summarise what I am looking at." },
-      { title: "Find outliers", prompt: "Is anything here unusual or out of place?" },
+      {
+        title: "Find outliers",
+        prompt: "Is anything here unusual or out of place?",
+      },
     ];
   }
 
   return [
-    { title: "Analyse data", prompt: "Which sales orders are overdue this month?" },
+    {
+      title: "Analyse data",
+      prompt: "Which sales orders are overdue this month?",
+    },
     { title: "Take an action", prompt: "Draft a document for me to review." },
     { title: "Search records", prompt: "Search for a customer or contact." },
   ];

--- a/jarvis/public/js/jarvis_chat/widget/panel_welcome.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_welcome.mjs
@@ -1,0 +1,53 @@
+// The welcome state: a greeting and a few starting points, so an empty panel
+// suggests what to do instead of showing a blank box.
+//
+// Ported from the side-chat design board, minus its visual identity — the
+// board's purple accent and decorative animation are off-language per
+// design.md 2.2 and 1.3, so only the copy and the layout idea carry over.
+//
+// Pure: the greeting is a function of the hour, and the prompts are a function
+// of what the user is looking at, which makes both unit-testable.
+
+export function greetingFor(hour) {
+  const h = Number.isFinite(hour) ? hour : 12;
+  if (h < 12) return "Good morning";
+  if (h < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+// `name` is a display name; take the first word so "Good evening, Kavin" reads
+// like a person talking rather than a database row.
+export function greetingLine(hour, name) {
+  const g = greetingFor(hour);
+  const first = String(name || "").trim().split(/\s+/)[0];
+  return first ? `${g}, ${first}` : g;
+}
+
+// Starting points, scoped to whatever the panel can see. On a record the
+// generic "which sales orders are overdue" prompt is a worse suggestion than
+// one about the record already on screen.
+export function suggestionsFor(ctx) {
+  const label = ctx && typeof ctx === "object" ? ctx : null;
+
+  if (label && label.doctype && label.name) {
+    return [
+      { title: "Explain this record", prompt: "Summarise this record and flag anything unusual." },
+      { title: "Find what is linked", prompt: "What documents are linked to this one?" },
+      { title: "Suggest next steps", prompt: "What should I do next with this record?" },
+    ];
+  }
+
+  if (label && (label.doctype || label.report_name)) {
+    return [
+      { title: "Analyse data", prompt: "Which of these need my attention first?" },
+      { title: "Summarise", prompt: "Summarise what I am looking at." },
+      { title: "Find outliers", prompt: "Is anything here unusual or out of place?" },
+    ];
+  }
+
+  return [
+    { title: "Analyse data", prompt: "Which sales orders are overdue this month?" },
+    { title: "Take an action", prompt: "Draft a document for me to review." },
+    { title: "Search records", prompt: "Search for a customer or contact." },
+  ];
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_welcome.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_welcome.test.mjs
@@ -35,9 +35,18 @@ test("suggestionsFor: a record gets record-scoped prompts", () => {
 });
 
 test("suggestionsFor: a list or report gets collection-scoped prompts", () => {
-  assert.equal(suggestionsFor({ doctype: "Sales Invoice" })[0].title, "Analyse data");
-  assert.equal(suggestionsFor({ report_name: "Accounts Receivable" })[0].title, "Analyse data");
-  assert.equal(suggestionsFor({ doctype: "Sales Invoice" })[0].prompt, "Which of these need my attention first?");
+  assert.equal(
+    suggestionsFor({ doctype: "Sales Invoice" })[0].title,
+    "Analyse data"
+  );
+  assert.equal(
+    suggestionsFor({ report_name: "Accounts Receivable" })[0].title,
+    "Analyse data"
+  );
+  assert.equal(
+    suggestionsFor({ doctype: "Sales Invoice" })[0].prompt,
+    "Which of these need my attention first?"
+  );
 });
 
 test("suggestionsFor: no context falls back to the general starting points", () => {

--- a/jarvis/public/js/jarvis_chat/widget/panel_welcome.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_welcome.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { greetingFor, greetingLine, suggestionsFor } from "./panel_welcome.mjs";
+
+test("greetingFor: splits the day at noon and 5pm", () => {
+  assert.equal(greetingFor(0), "Good morning");
+  assert.equal(greetingFor(11), "Good morning");
+  assert.equal(greetingFor(12), "Good afternoon");
+  assert.equal(greetingFor(16), "Good afternoon");
+  assert.equal(greetingFor(17), "Good evening");
+  assert.equal(greetingFor(23), "Good evening");
+});
+
+test("greetingFor: a junk hour still greets", () => {
+  assert.equal(greetingFor(undefined), "Good afternoon");
+  assert.equal(greetingFor(NaN), "Good afternoon");
+});
+
+test("greetingLine: uses the first name only", () => {
+  assert.equal(greetingLine(18, "Kavin Raj"), "Good evening, Kavin");
+  assert.equal(greetingLine(9, "Administrator"), "Good morning, Administrator");
+});
+
+test("greetingLine: drops the comma when there is no name", () => {
+  assert.equal(greetingLine(18, ""), "Good evening");
+  assert.equal(greetingLine(18, null), "Good evening");
+  assert.equal(greetingLine(18, "   "), "Good evening");
+});
+
+test("suggestionsFor: a record gets record-scoped prompts", () => {
+  const s = suggestionsFor({ doctype: "Sales Invoice", name: "INV-0001" });
+  assert.equal(s.length, 3);
+  assert.equal(s[0].title, "Explain this record");
+  assert.ok(s.every((x) => x.prompt && x.title));
+});
+
+test("suggestionsFor: a list or report gets collection-scoped prompts", () => {
+  assert.equal(suggestionsFor({ doctype: "Sales Invoice" })[0].title, "Analyse data");
+  assert.equal(suggestionsFor({ report_name: "Accounts Receivable" })[0].title, "Analyse data");
+  assert.equal(suggestionsFor({ doctype: "Sales Invoice" })[0].prompt, "Which of these need my attention first?");
+});
+
+test("suggestionsFor: no context falls back to the general starting points", () => {
+  for (const ctx of [null, undefined, {}, "junk"]) {
+    const s = suggestionsFor(ctx);
+    assert.equal(s.length, 3);
+    assert.equal(s[0].prompt, "Which sales orders are overdue this month?");
+  }
+});
+
+test("suggestionsFor: every prompt is a full sentence the agent can act on", () => {
+  for (const ctx of [null, { doctype: "X" }, { doctype: "X", name: "Y" }]) {
+    for (const s of suggestionsFor(ctx)) {
+      assert.ok(s.prompt.length > 10, `too short: ${s.prompt}`);
+      assert.ok(/[.?]$/.test(s.prompt), `no terminal punctuation: ${s.prompt}`);
+    }
+  }
+});

--- a/jarvis/public/js/jarvis_widget.bundle.js
+++ b/jarvis/public/js/jarvis_widget.bundle.js
@@ -1,7 +1,10 @@
-// Global floating Jarvis widget — a draggable, edge-snapping shortcut FAB
-// that navigates to the Jarvis chat SPA (a fresh conversation), present on
-// every Desk page EXCEPT the full chat page (and the onboarding flow, where
-// the agent isn't ready yet).
+// Global floating Jarvis widget — a draggable, edge-snapping FAB that opens
+// the side chat panel in place, present on every Desk page EXCEPT the full
+// chat page (and the onboarding flow, where the agent isn't ready yet).
+//
+// The panel is a child of the FAB component, so hiding this host hides both.
+// On a narrow viewport the FAB navigates to the chat SPA instead of opening a
+// panel that would cover the screen (see config.mjs PANEL_MIN_VIEWPORT_PX).
 //
 // Mounted ONCE into a <body>-level host so it survives SPA navigation: its
 // dragged position persists (via localStorage) as you move between


### PR DESCRIPTION
# Desk side chat: a mini chat window on every Desk page

Turns the existing floating Jarvis FAB from a launcher that navigates away into a
docked mini chat window that opens in place, restores the last conversation, and
carries the record you are looking at as agent context.

## Why this was mostly wiring

`send_message` already accepted a `context` argument, and
`turn_handler._prepend_doc_context` already turned it into a leading
`[Viewing: ...]` prompt line — its docstring even names the caller it was written
for, *"floating-widget auto-context"*. Nothing called it. This PR supplies the
caller.

## What it does

- **Opens in place.** 400x624 mini window anchored to the FAB, not a full-height dock.
- **Follows the launcher.** The FAB drags anywhere down either edge, so the window
  bottom-aligns to it, flips sides when there is no room, and clamps to the
  viewport and below the navbar.
- **Restores the last conversation** on open, and refreshes on every open so a
  reply that landed while it was closed is visible without a page reload.
- **Sends page context per message** — `{doctype, name}`, `{doctype}`, or
  `{report_name, filters}` — read at send time, not at open time, so walking from
  an invoice to a payment entry does not leave the agent answering about the wrong
  record.
- **Welcome state** with a greeting and context-aware starting points.
- **Attach** (uploads via `upload_file`, rides `send_message`'s existing
  `attachments` arg) and **dictate** (gated on `get_chat_ui_settings().stt_enabled`,
  posts to `jarvis.chat.voice.transcribe_audio`).
- **Write-confirmation gate.** `action:pending` frames render a Confirm row.
  Without this every write would hang silently, since the agent blocks on a decision.
- **Markdown replies**, reusing the SPA's own renderer, with control fences
  (`jarvis-skill`, `jarvis-action`, `confirm`, ...) stripped.

## Bugs found and fixed along the way

- **Replies never arrived.** The realtime subscribe was a one-shot optional chain
  evaluated at mount; the FAB mounts on every Desk page, sometimes before the
  socket layer exists, so it silently no-opped and never retried. Now retries for
  ~10s, plus a 2.5s poll while a turn is in flight so the answer lands even if the
  socket never connects.
- **Dark mode never applied — including the pre-existing FAB.** Vue's scoped-style
  pass here *drops the descendant* in `:global([data-theme="dark"]) .foo`, emitting a
  bare `[data-theme=dark]{...}`. Those custom properties land on `<html>` and are then
  overridden by the component's own light values. Verified in the built bundle before
  and after. `desk_theme.mjs` resolves the flag in JS instead. This bug predates the
  PR — `.jvw-root`'s `--accent` had it since the FAB was written.
- **`tool` rows rendered as prose.** `tool` is the most common role on the dev site
  (508 of 1201 messages); the panel would have shown raw `get_doc -> completed`
  chatter and blank bubbles.
- **`?new=1` forced a fresh chat** on every launch — the inverse of the
  restore-last-conversation requirement.
- **Sideways scrolling.** A long unbroken token could widen the flex layout;
  `overflow-x: hidden` plus `min-width: 0` on every flex child.

## Design

Visual language follows the "Jarvis Side Chat" design board (gradient brand mark,
tinted starter cards, pill composer, gradient user bubbles).

**This diverges from `design.md` §1.1/§2.2, which specify a near-black CTA and ban
brand purple.** The divergence is deliberate and scoped to this surface, but
`design.md` has not yet been amended to record the exception. That should either
land in this PR or immediately after — it should not stay a silent contradiction.

## Testing

75 unit tests via `node --test` from `jarvis/public/js/jarvis_chat/widget/`,
including the 17 pre-existing `fab_position` tests, unchanged.

The error-prone logic is pushed into pure `.mjs` modules so it is testable without
a browser: route to context mapping, the realtime event reducer, panel anchoring
geometry, theme resolution, control-fence stripping, and the welcome copy.

Verified server-side: `_prepend_doc_context` emits the expected `[Viewing: ...]`
line for each context shape, and the `list_conversations` / `get_conversation`
response shapes match what the panel consumes.

**Not verified: the rendered UI.** No browser was available in this environment, so
the visual result and the interaction flows have not been observed end to end.
Please exercise the panel before merging.

## Follow-ups

- Amend `design.md` to record the visual divergence.
- The mini panel drops `jarvis-cards` / `jarvis-chart` / confirm-card rendering that
  the full SPA does; replies built around those will read thin. "Open full chat" is
  the escape hatch.
- The mic cannot be exercised on this site: `stt_enabled` is false.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjbuyQUyXT7MegHBa75Gyb
