### PR TITLE
agents: registry sync — fefo 0.2.2 (R5-J12)

### DIFF
--- a/jarvis/agents/registry.json
+++ b/jarvis/agents/registry.json
@@ -797,7 +797,7 @@
       "domain": "inventory",
       "nature": "auditor",
       "delivery": "delegate",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "status": "Published",
       "description": "For batch-tracked pharma/FMCG/food stock: replays each day's outward movements to catch FEFO violations — a dispatch that skipped an older-expiry batch that still had stock — and lists on-hand batches inside the near-expiry and past-expiry horizon, ranked by value. Read-only; hyperlinks every finding to its batch and dispatch. Never touches stock, holds a shipment, or writes off a batch.",
       "tools_required": [


### PR DESCRIPTION
One-line registry sync from the bundle store (Aerele-RnD/jarvis-agents master `2faa087`, CI green): fefo-expiry-compliance-auditor 0.2.1 → 0.2.2.

The bump is the R5-J12 closure fix — codex's closure review held R5-P0-06 open on fefo's finding notes stating the 180-day governed constant; per the amended J10 ruling (DECISIONS-R5 §R5-J12) the notes are de-quantified and `horizon_days` is suppressed when it equals a rules-file constant (kept for genuine per-item derivations). Store-side: exact-match sub-1000 leak fixtures + three-artifact policy reconciliation. `rule_tokens` byte-identical for all 31 agents; this PR is data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsMjkHXYiK5TDokQyAoFh