### PR TITLE
chat: Phase 0 durable admission control (Relay Pump WP-0)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -165,6 +165,21 @@ export async function stopRun(conversation, runId) {
 	return call("jarvis.chat.api.stop_run", { conversation, run_id: runId || "" });
 }
 
+// Phase-0 admission (chat concurrency): cancel a turn that is still QUEUED
+// (behind other turns, not yet dispatched). Owner-checked server-side.
+export const cancelQueuedTurn = (runId) =>
+	call("jarvis.chat.admission.cancel_queued_turn", { run_id: runId });
+
+// Poll-on-focus fallback for the queued chip: returns {state, position}.
+export const getQueuePosition = (runId) =>
+	call("jarvis.chat.admission.queue_position", { run_id: runId });
+
+// Server-truth resync for the queued chip (SUXI-1): the conversation's own
+// non-terminal turn, if any. Rebuilds the chip after a reload / conversation
+// switch / second tab / WS reconnect (the queued chip is otherwise client-only).
+export const getActiveTurn = (conversation) =>
+	call("jarvis.chat.admission.active_turn_for_conversation", { conversation });
+
 // Mentions: reuse Frappe's built-in Link-field search (no custom backend).
 export const searchLink = (doctype, txt) =>
 	call("frappe.desk.search.search_link", { doctype, txt: txt || "", page_length: 8 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -956,8 +956,30 @@
 										</div>
 									</div>
 								</div>
+								<!-- Phase-0 admission (SUXI-4): a cancelled/aged-out queued turn
+								     leaves a durable marker. Render it as a MUTED note, not the
+								     red error alert - the user (or the system) cancelled it; it
+								     is not a failure. -->
 								<div
-									v-if="m.error"
+									v-if="m.error && errorInfo(m).code === 'cancelled'"
+									role="status"
+									style="
+										display: flex;
+										align-items: center;
+										gap: 8px;
+										font-size: 12.5px;
+										color: var(--text-3);
+										padding: 2px 0;
+									"
+								>
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+										<circle cx="12" cy="12" r="9" />
+										<path d="M15 9l-6 6M9 9l6 6" />
+									</svg>
+									<span>{{ m.error }}</span>
+								</div>
+								<div
+									v-else-if="m.error"
 									role="alert"
 									style="
 										border: 1px solid var(--red-bd);
@@ -1972,6 +1994,72 @@
 									<path d="M12 3a9 9 0 1 0 9 9" />
 								</svg>
 								<span>{{ recoveringLabel }}</span>
+							</div>
+						</div>
+					</div>
+
+					<!-- SUX-3: immediate "change saved" acknowledgment after a confirm
+					     write, so the card doesn't vanish into silence while the
+					     continuation turn queues. Auto-clears (~3.5s). -->
+					<div
+						v-if="confirmedAck"
+						role="status"
+						aria-live="polite"
+						style="
+							display: flex;
+							align-items: center;
+							gap: 7px;
+							font-size: 12px;
+							color: var(--text-3);
+							padding-left: 40px;
+						"
+					>
+						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M20 6 9 17l-5-5" />
+						</svg>
+						<span>Change saved</span>
+					</div>
+
+					<!-- Phase-0 admission (chat concurrency): the just-sent turn is
+					     QUEUED behind others (all in-flight slots taken). The composer
+					     stays unlocked; this chip shows the approximate position and a
+					     Cancel affordance. Retired when the turn is promoted (run:start),
+					     cancelled, or aged out. -->
+					<div v-if="queuedTurn" style="display: flex; gap: 12px">
+						<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
+						<div style="flex: 1; min-width: 0; padding-top: 3px">
+							<div
+								role="status"
+								aria-live="polite"
+								style="
+									display: flex;
+									align-items: center;
+									gap: 10px;
+									font-size: 12px;
+									color: var(--text-3);
+								"
+							>
+								<svg
+									class="jv-spin"
+									width="13"
+									height="13"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="var(--text-3)"
+									stroke-width="2.4"
+									stroke-linecap="round"
+								>
+									<path d="M12 3a9 9 0 1 0 9 9" />
+								</svg>
+								<span>{{ queuedChipLabel(queuedTurn.position) }}</span>
+								<button
+									type="button"
+									class="jv-queued-cancel"
+									aria-label="Cancel this queued message"
+									@click="cancelQueued"
+								>
+									Cancel
+								</button>
 							</div>
 						</div>
 					</div>
@@ -3501,6 +3589,10 @@ const currentId = ref(null);
 watch(currentId, (id) => {
 	store.currentConvId = id;
 	if (id) store.clearUnread(id);
+	// Phase-0 admission: the queued chip belongs to the conversation we sent
+	// from; never carry it into a different chat.
+	queuedTurn.value = null;
+	confirmedAck.value = false;
 	try {
 		id
 			? localStorage.setItem("jarvis-last-conv", id)
@@ -3520,6 +3612,17 @@ const histIdx = ref(null);
 const histDraft = ref("");
 const sending = ref(false);
 const waiting = ref(false);
+// Phase-0 admission (chat concurrency): when a send is accepted but QUEUED
+// (all in-flight slots taken), the reply hasn't started - we show a "~N ahead"
+// chip with a Cancel button instead of the streaming spinner. Cleared when the
+// turn is promoted (run:start), cancelled, or errors out.
+// { run_id, message_id, position } | null
+const queuedTurn = ref(null);
+// Transient "Change saved" acknowledgment after a confirm write (SUX-3), shown
+// immediately so the card doesn't vanish into silence while the continuation
+// turn queues. Auto-clears.
+const confirmedAck = ref(false);
+let _confirmedAckTimer = null;
 const ui = ref({});
 // Renew-banner copy when the subscription has lapsed; null while entitled.
 // The composer is disabled alongside it (no send can succeed while stopped).
@@ -3992,9 +4095,38 @@ const ERROR_HEADLINES = {
 	provider: "The model is busy right now",
 	"recovery-expired": "This took too long, so I stopped waiting",
 	internal: "Something went wrong",
+	cancelled: "This message was cancelled",
 };
+// Phase-0 admission (chat concurrency): the ONLY place a Turn's internal state
+// name maps to user-facing copy (SUX-8). No raw internal state name
+// ("dispatching", "queued", …) ever renders in the UI. `queued` takes a
+// position and reads "~N ahead" (approximate, SUX-2).
+// Phase-0 WIRES `queued` (the chip) and `cancelled` (cancelQueued toast + the
+// turn:cancelled fallback). `dispatching`/`errored`/`done` are defined for the
+// full state set but are NOT reached in Phase 0 (run:start jumps straight to the
+// pre-existing "Thinking…" UI; reply errors flow through ERROR_HEADLINES; a done
+// reply renders normally) — kept so the mapping is complete for WP-1 (SUXI-7).
+const TURN_STATE_COPY = {
+	queued: (pos) => (pos && pos > 0 ? `Queued — ~${pos} ahead` : "Queued"),
+	dispatching: () => "Starting…",
+	cancelled: () => "Cancelled",
+	errored: () => "Something went wrong",
+	done: () => "",
+};
+function queuedChipLabel(pos) {
+	return TURN_STATE_COPY.queued(pos);
+}
 function classifyErrorCode(raw) {
 	const low = (raw || "").toLowerCase();
+	// Phase-0 admission cancel markers (SUXI-4): a queued turn cancelled by the
+	// user or aged out by the system leaves a durable transcript marker so a
+	// later reload shows WHY there's no reply (not a silent drop). Classified as
+	// "cancelled" so it renders as a muted note, NOT a red "something went wrong".
+	if (
+		low.startsWith("you cancelled this message") ||
+		low.startsWith("waited too long in the queue")
+	)
+		return "cancelled";
 	if (
 		low.includes("ws open failed") ||
 		low.includes("unreachable") ||
@@ -4022,6 +4154,7 @@ function errorInfo(m) {
 	const meta = errorMeta.value[m.name] || {};
 	const code = meta.code || classifyErrorCode(m.error);
 	return {
+		code,
 		headline: ERROR_HEADLINES[code] || "Something went wrong",
 		noChange: meta.changed_data === false,
 	};
@@ -5394,6 +5527,16 @@ async function applyDraft(submitFlag, model = draftPanel.value) {
 		closeDraftPanel();
 		await loadConversation(currentId.value);
 		store.loadConversations();
+		// SUX-3/SUXI-2: the continuation turn queued — show the chip + lock the
+		// composer instead of the card vanishing into silence.
+		if (r && r.queued) {
+			queuedTurn.value = {
+				run_id: r.run_id,
+				message_id: r.message_id,
+				position: r.queued_position || null,
+			};
+			sending.value = true;
+		}
 	} catch (e) {
 		p.applying = false;
 		p.error = {
@@ -5476,9 +5619,13 @@ onMounted(() => {
 	_expiryTick = setInterval(() => {
 		pendingNowMs.value = Date.now();
 	}, 15000);
+	// Phase-0 admission: refresh the queued chip's position when the tab
+	// regains focus (poll-on-focus fallback for a missed queue:position push).
+	window.addEventListener("focus", refreshQueuePositionOnFocus);
 });
 onUnmounted(() => {
 	if (_expiryTick) clearInterval(_expiryTick);
+	window.removeEventListener("focus", refreshQueuePositionOnFocus);
 });
 function pendingExpiredOf(pa) {
 	return pendingExpiry(pa && pa.expires_at, pendingNowMs.value).expired;
@@ -5552,6 +5699,17 @@ async function confirmPending(pa) {
 		removePending(token);
 		await loadConversation(currentId.value);
 		store.loadConversations();
+		// SUX-3/SUXI-2: the continuation turn queued (all slots taken). Show the
+		// standard queued chip + lock the composer so the card doesn't vanish into
+		// silence after the "Change saved" ack clears (mirrors send()'s r.queued).
+		if (r && r.queued) {
+			queuedTurn.value = {
+				run_id: r.run_id,
+				message_id: r.message_id,
+				position: r.queued_position || null,
+			};
+			sending.value = true;
+		}
 	} catch (e) {
 		const card = cardById();
 		if (card)
@@ -5611,6 +5769,41 @@ async function resyncPendingConfirmations(id) {
 			run_id: it.run_id || null,
 			expires_at: it.expires_at || null,
 		});
+	}
+}
+
+// Resync the queued chip from server truth (SUXI-1). The chip + its Cancel
+// affordance are otherwise client-only state, lost on reload / conversation
+// switch / a second tab / a WS reconnect — leaving a still-queued turn with no
+// visible position and no way to cancel, and a re-enabled empty composer that
+// invites a duplicate send. Mirrors resyncPendingConfirmations: called from
+// loadConversation. Repopulates queuedTurn (and keeps the composer locked) when
+// the conversation's own turn is queued; a dispatching turn is covered by
+// loadConversation's existing streaming resume.
+async function resyncQueuedTurn(id) {
+	if (!id) return;
+	let active = null;
+	try {
+		const r = await api.getActiveTurn(id);
+		active = (r && r.ok && r.active) || null;
+	} catch (e) {
+		return; // best-effort — never block the load
+	}
+	if (currentId.value !== id) return; // navigated away while the request was in flight
+	if (active && active.state === "queued") {
+		queuedTurn.value = {
+			run_id: active.run_id,
+			message_id: active.message_id,
+			position: active.position || null,
+		};
+		// Keep the composer locked while a turn is queued so the re-enabled empty
+		// composer can't invite a duplicate send.
+		sending.value = true;
+		waiting.value = false;
+	} else if (queuedTurn.value) {
+		// The turn we were showing has since dispatched/settled — drop the chip;
+		// the streaming/run:end events reconcile the rest.
+		queuedTurn.value = null;
 	}
 }
 
@@ -6106,6 +6299,9 @@ async function loadConversation(id) {
 	// confirmations (R3 fix for #3 - survives reload / reconnect).
 	pendingActions.value = pendingActions.value.filter((pa) => pa.conversation === id);
 	resyncPendingConfirmations(id);
+	// SUXI-1: rebuild the queued chip from server truth (reload / switch / second
+	// tab / reconnect all lose the client-only chip otherwise).
+	resyncQueuedTurn(id);
 	// Seed Up/Down recall from THIS conversation's past prompts. Without this,
 	// promptHistory only held prompts typed in the current page session, so
 	// after a reload or when opening an existing chat the arrows did nothing.
@@ -6597,6 +6793,18 @@ async function send(textArg) {
 		}
 		// Send accepted — the one-shot grounding is now consumed.
 		if (groundWiki) groundNextTurn.value = false;
+		// Phase-0 admission: the send was accepted but QUEUED (all slots taken).
+		// Show the "~N ahead" chip + Cancel instead of the streaming spinner; the
+		// reply begins when a slot frees (run:start clears queuedTurn). Position
+		// refreshes via the queue:position realtime event + poll-on-focus.
+		if (r && r.queued) {
+			queuedTurn.value = {
+				run_id: r.run_id,
+				message_id: r.message_id,
+				position: r.queued_position || null,
+			};
+			waiting.value = false; // not streaming yet — the chip carries the state
+		}
 		if (r?.conversation_id && (currentId.value || "") === sentFrom) {
 			// Still on the chat we sent from — safe to reconcile it. Adopt the
 			// server's id when it differs (a brand-new chat that just got its id, or
@@ -6747,12 +6955,44 @@ function onEvent(p) {
 			currentRunId.value = p.run_id;
 			currentMsgId.value = p.message_id;
 			recovering.value = null;
+			// Phase-0 admission: a queued turn just got promoted and is now
+			// streaming — retire the "~N ahead" chip.
+			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			runStartMs.value = Date.now();
 			nowMs.value = Date.now();
 			activeTools.value = [];
 			waiting.value = true;
 			statusPhase.value = "model";
 			store.streamingConvId = p.conversation_id || currentId.value;
+			break;
+		case "queue:position":
+			// Phase-0 admission: this queued turn's approximate position shifted
+			// (someone ahead settled / cancelled). Update the chip.
+			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id)
+				queuedTurn.value = { ...queuedTurn.value, position: p.position };
+			break;
+		case "turn:cancelled":
+			// A queued turn was cancelled (by this user, or system age-out).
+			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) {
+				queuedTurn.value = null;
+				sending.value = false;
+				waiting.value = false;
+				// SUXI-3: surface WHY the message disappeared (system age-out reason,
+				// or the cancel reason) instead of a silently emptied composer. Routed
+				// through the state->copy table (SUXI-7). Guarded by the chip check so
+				// the tab that itself clicked Cancel (chip already cleared) doesn't
+				// double-toast on top of its own optimistic "Cancelled.".
+				notify(p.reason || TURN_STATE_COPY.cancelled(), { type: "info" });
+			}
+			break;
+		case "action:confirmed":
+			// SUX-3: a confirm write was saved. Acknowledge immediately so the
+			// card doesn't vanish into silence while the continuation turn queues.
+			confirmedAck.value = true;
+			if (_confirmedAckTimer) clearTimeout(_confirmedAckTimer);
+			_confirmedAckTimer = setTimeout(() => {
+				confirmedAck.value = false;
+			}, 3500);
 			break;
 		case "assistant:delta": {
 			waiting.value = false;
@@ -6800,6 +7040,8 @@ function onEvent(p) {
 			break;
 		}
 		case "run:end": {
+			// Defensive: if a promoted turn's run:start was missed, retire the chip.
+			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			const m = messages.value.find((x) => x.name === p.message_id);
 			if (m) m.streaming = false;
 			// Stamp metrics keyed by message_id so they survive the reload below.
@@ -6856,6 +7098,7 @@ function onEvent(p) {
 			break;
 		}
 		case "run:error":
+			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			if (p.message_id) {
 				errorMeta.value = {
 					...errorMeta.value,
@@ -6901,6 +7144,53 @@ function stopRun() {
 	recovering.value = null;
 	if (cid) api.stopRun(cid, rid).catch(() => {});
 	notify("Stopped.");
+}
+
+// Phase-0 admission: cancel a turn that is still QUEUED (behind others, not yet
+// dispatched). Optimistically retires the chip; the server CASes queued ->
+// cancelled and publishes turn:cancelled to reconcile other tabs.
+async function cancelQueued() {
+	const q = queuedTurn.value;
+	if (!q) return;
+	queuedTurn.value = null;
+	sending.value = false;
+	waiting.value = false;
+	try {
+		const r = await api.cancelQueuedTurn(q.run_id);
+		if (r && r.ok === false) {
+			// It already started (a slot freed the instant we clicked). We
+			// optimistically cleared sending/waiting above; re-lock the composer so
+			// it reflects the now-streaming reply (run:end resets it) — otherwise the
+			// composer stays enabled during a live turn (SUXI-6).
+			sending.value = true;
+			notify(r.reason || "That reply already started.", { type: "info" });
+		} else {
+			// SUXI-7: route the toast through the state->copy table.
+			notify(`${TURN_STATE_COPY.cancelled()}.`);
+		}
+	} catch (e) {
+		notifyActionError("Couldn't cancel the queued message", e);
+	}
+}
+
+// Poll-on-focus fallback (SUX-2): when the tab regains focus, refresh the queued
+// chip's position in case a realtime queue:position push was missed.
+async function refreshQueuePositionOnFocus() {
+	const q = queuedTurn.value;
+	if (!q) return;
+	try {
+		const r = await api.getQueuePosition(q.run_id);
+		if (!r || r.ok === false) return;
+		if (r.state !== "queued") {
+			// Promoted or settled while we were away — the stream/end events will
+			// reconcile; drop the stale chip.
+			if (queuedTurn.value && queuedTurn.value.run_id === q.run_id) queuedTurn.value = null;
+		} else if (queuedTurn.value && queuedTurn.value.run_id === q.run_id) {
+			queuedTurn.value = { ...queuedTurn.value, position: r.position };
+		}
+	} catch {
+		/* best-effort */
+	}
 }
 
 // ---- voice dictation (composer mic) ----
@@ -8060,6 +8350,25 @@ onUnmounted(() => {
 	to {
 		transform: rotate(360deg);
 	}
+}
+/* Phase-0 admission: Cancel affordance on the queued chip. Text-button idiom
+   (design.md), muted until hover. */
+.jv-queued-cancel {
+	appearance: none;
+	background: transparent;
+	border: none;
+	padding: 2px 6px;
+	margin: 0;
+	font: inherit;
+	font-size: 12px;
+	color: var(--text-3);
+	text-decoration: underline;
+	cursor: pointer;
+	border-radius: 5px;
+}
+.jv-queued-cancel:hover {
+	color: var(--text-1);
+	background: var(--surface-gray-2, rgba(0, 0, 0, 0.05));
 }
 /* thinking dots — classed so reduced-motion can disable them (UX #13) */
 .jv-tdot {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -972,7 +972,16 @@
 										padding: 2px 0;
 									"
 								>
-									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+									<svg
+										width="14"
+										height="14"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
 										<circle cx="12" cy="12" r="9" />
 										<path d="M15 9l-6 6M9 9l6 6" />
 									</svg>
@@ -2014,7 +2023,16 @@
 							padding-left: 40px;
 						"
 					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+						<svg
+							width="13"
+							height="13"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.4"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<path d="M20 6 9 17l-5-5" />
 						</svg>
 						<span>Change saved</span>

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -308,15 +308,31 @@ def apply_action(action: dict | str | None = None) -> dict:
 		# The mutation is already committed - a receipt hiccup must not
 		# report failure (the SPA would retry and duplicate the create).
 		frappe.log_error(title="apply_action receipt failed", message=frappe.get_traceback())
+	# SUX-3: acknowledge the synchronous write IMMEDIATELY ("Change saved"),
+	# decoupled from the reply queue - the continuation turn below then renders
+	# the standard queued chip with its position. Flag-gated + best-effort.
+	from jarvis.chat import admission
+
+	admission.publish_action_confirmed(conversation)
+	_cont = None
 	if do_continue:
 		try:
-			enqueue_continuation(conversation, receipt)
+			_cont = enqueue_continuation(conversation, receipt)
 		except Exception:
 			# Best-effort like the receipt: the write is committed, and the
 			# user can always nudge the agent manually if dispatch hiccups.
 			frappe.log_error(title="apply_action continuation failed", message=frappe.get_traceback())
 	slug = doctype.lower().replace(" ", "-")
-	return {"ok": True, "verb": verb, "name": name, "doc_url": f"/app/{slug}/{name}"}
+	resp = {"ok": True, "verb": verb, "name": name, "doc_url": f"/app/{slug}/{name}"}
+	# SUX-3/SUXI-2: when the continuation turn queued (all slots taken), thread
+	# its run_id + position so the SPA renders the standard queued chip instead
+	# of the card vanishing into silence after the "Change saved" ack clears.
+	if _cont and _cont.get("queued"):
+		resp["queued"] = True
+		resp["queued_position"] = _cont.get("queued_position")
+		resp["run_id"] = _cont.get("run_id")
+		resp["message_id"] = _cont.get("message_id")
+	return resp
 
 
 _INVALID_CONFIRM = {
@@ -441,10 +457,27 @@ def confirm_tool(token: str, conversation: str | None = None) -> dict:
 		# continue flag here, and the post-write acknowledgment is part of
 		# the persona's write recipes. On failure the rolled-back-write scaffold
 		# makes the agent explain + stop instead of auto-retrying. Best-effort.
+		# SUX-3: on a SUCCESSFUL confirm, acknowledge the write immediately so
+		# the card doesn't vanish into silence while the continuation queues.
+		# A failed confirm skips this - the failed scaffold explains instead.
+		if ok:
+			from jarvis.chat import admission
+
+			admission.publish_action_confirmed(conv)
+		_cont = None
 		try:
-			enqueue_continuation(conv, _confirm_receipt_text(record, result), failed=not ok)
+			_cont = enqueue_continuation(conv, _confirm_receipt_text(record, result), failed=not ok)
 		except Exception:
 			frappe.log_error(title="confirm_tool continuation failed", message=frappe.get_traceback())
+		# SUX-3/SUXI-2: thread the queued continuation's position onto a SUCCESSFUL
+		# confirm result so the SPA shows the queued chip (the card doesn't vanish
+		# into silence while the continuation sits queued). A failed confirm keeps
+		# its error envelope untouched.
+		if ok and isinstance(result, dict) and _cont and _cont.get("queued"):
+			result["queued"] = True
+			result["queued_position"] = _cont.get("queued_position")
+			result["run_id"] = _cont.get("run_id")
+			result["message_id"] = _cont.get("message_id")
 
 	return result
 

--- a/jarvis/chat/admission.py
+++ b/jarvis/chat/admission.py
@@ -518,8 +518,17 @@ def accept_or_queue(
 
 	if admit:
 		# Enqueue the legacy turn job AFTER the durable commit (mirrors the
-		# _dispatch_turn after_commit invariant).
-		dispatch()
+		# _dispatch_turn after_commit invariant). CDX-9: if the broker is down,
+		# compensate (dispatching -> queued + release) so the turn stays durably
+		# queued for the sweep/promoter instead of pinning a credit on a job that
+		# never existed.
+		try:
+			dispatch()
+		except Exception:
+			frappe.log_error(title="admission.accept dispatch", message=frappe.get_traceback())
+			_compensate_failed_dispatch(run_id, target)
+			pos = _position_of(run_id, target)
+			return {"ok": True, "dispatched": False, "run_id": run_id, "queued_position": pos}
 		return {"ok": True, "dispatched": True, "run_id": run_id, "queued_position": None}
 
 	pos = _position_of(run_id, target)
@@ -548,6 +557,29 @@ def _cas_dispatch(run_id: str) -> bool:
 		)
 		== 1
 	)
+
+
+def _compensate_failed_dispatch(run_id: str, target: str) -> None:
+	"""CDX-9: the RQ enqueue failed AFTER the admission commit. Return the slot
+	immediately: CAS the exact ``dispatching`` attempt back to ``queued``, CLEAR the
+	reservation, and republish positions - otherwise the credit is pinned until the
+	reservation TTL and capacity silently shrinks under repeated broker failures."""
+	try:
+		_run_cas(
+			f"""UPDATE `tab{TURN}`
+			SET state='queued', reserved=0, dispatching_at=NULL,
+			    reservation_expires_at=NULL, version=version+1
+			WHERE name=%(r)s AND state='dispatching'""",
+			{"r": run_id},
+		)
+		frappe.db.commit()
+	except Exception:
+		frappe.log_error(title="admission.compensate_failed_dispatch", message=frappe.get_traceback())
+		return
+	try:
+		_publish_queue_positions(target)
+	except Exception:
+		pass
 
 
 def _dispatch_promoted(row: dict) -> None:
@@ -618,7 +650,11 @@ def promote_next(target: str | None = None) -> int:
 			_dispatch_promoted(row)
 			_telemetry("promote", run_id=row["run_id"], target=target, queue_wait_ms=wait_ms)
 		except Exception:
+			# CDX-9: enqueue failed after the promotion commit - compensate (CAS
+			# dispatching -> queued + release the credit) instead of only logging,
+			# so the next promoter can retry the turn.
 			frappe.log_error(title="admission.promote dispatch", message=frappe.get_traceback())
+			_compensate_failed_dispatch(row["run_id"], target)
 
 	# Positions shifted for everyone still queued.
 	try:

--- a/jarvis/chat/admission.py
+++ b/jarvis/chat/admission.py
@@ -1,0 +1,1141 @@
+"""Phase-0 durable admission control (chat concurrency, WP-0).
+
+The reported incident: when every in-flight chat slot is taken, a new send
+becomes an invisible multi-minute RQ wait (or starves the site). Phase 0
+kills that in the CURRENT transport - no pump, no WS/relay changes. A send
+that cannot dispatch becomes a durable ``queued`` Jarvis Chat Turn with a
+visible position and a cancel affordance; the legacy per-turn job path is
+still the executor for admitted turns.
+
+Design (binding: ../wp-d D2/D3 + PANEL-DISPOSITIONS OAR/SUX):
+
+* MariaDB is the only authority. Every state change is a version-CAS
+  (``WHERE state=X AND version=V``) whose affected-rows count is the success
+  signal. Redis is never authoritative.
+* The admission serializer takes ``SELECT ... FOR UPDATE`` on the per-shard
+  ``Jarvis Relay Pump`` control row (OAR-1). Lock order (OAR-6, normative):
+  control-row -> conversation -> turn -> message.
+* Dual-signal active check (OAR-11): a conversation/shard is busy on a
+  Turn-row ``dispatching`` OR a legacy fresh-``streaming`` assistant Message
+  with no owning Turn row (the flag can flip mid-traffic, so legacy turns
+  always coexist in Phase 0).
+* Flag OFF (``jarvis_phase0_admission_enabled``, default off) => byte-
+  identical legacy behavior: the gate is a cheap ``frappe.conf`` read that
+  short-circuits before any Turn row or admission query. No schema traffic
+  on the hot path.
+
+Phase-0 simplifications (recorded for WP-1):
+
+* ``relay_target_id`` is a single site-wide shard (``"default"``) - one
+  gateway per bench. WP-1 derives real per-container ids; the schema keys on
+  ``relay_target_id`` from day one so that is additive.
+* ``dispatching`` covers the whole legacy job lifetime; the reservation IS
+  the ``dispatching`` row itself, and ``reservation_expires_at`` guards only
+  a crashed/lost enqueue.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import frappe
+
+from jarvis.chat.events import publish_to_user
+from jarvis.permissions import require_jarvis_access
+
+TURN = "Jarvis Chat Turn"
+PUMP = "Jarvis Relay Pump"
+MSG = "Jarvis Chat Message"
+CONV = "Jarvis Conversation"
+
+FLAG = "jarvis_phase0_admission_enabled"
+
+# One gateway per bench in Phase 0 -> one site-wide admission shard.
+DEFAULT_RELAY_TARGET = "default"
+
+# Container main-lane ceiling (fleet agents.defaults.maxConcurrent, default 4).
+DEFAULT_MAX_INFLIGHT = 4
+
+# Accept-time overload guard (SUX-5): reject (no row) past this queued depth.
+MAX_QUEUE_DEPTH = 25
+
+# Sweep age-out (SUX-5): a queued turn older than this is system-cancelled.
+QUEUED_MAX_AGE_S = 15 * 60
+
+# Durable transcript marker copy (SUXI-4).
+USER_CANCEL_REASON = "You cancelled this message before it was answered."
+AGE_OUT_REASON = "Waited too long in the queue and was cancelled. Please try again."
+
+# Crashed-enqueue guard: a dispatching turn whose enqueue was lost is returned
+# to the queue after this many seconds. Deliberately >> the worker turn timeout
+# (720s) so a legitimately long live turn is never reclaimed.
+RESERVE_TTL_S = 900
+
+# Legacy fresh-streaming window (mirrors api._INFLIGHT_FRESH_SECONDS).
+_INFLIGHT_FRESH_SECONDS = 180
+
+_ACTIVE_STATES = ("queued", "dispatching")
+
+
+# --------------------------------------------------------------------------- #
+# Flag / shard helpers
+# --------------------------------------------------------------------------- #
+
+
+def admission_enabled() -> bool:
+	"""Cheap conf read (no DB). The single gate that keeps flag-OFF behavior
+	byte-identical: callers short-circuit to the legacy dispatch path."""
+	return bool(frappe.conf.get(FLAG))
+
+
+def relay_target_id(conversation: str | None = None) -> str:
+	"""The admission shard for a conversation. Phase 0: one site-wide shard."""
+	return DEFAULT_RELAY_TARGET
+
+
+def _max_inflight() -> int:
+	try:
+		v = int(frappe.conf.get("jarvis_site_max_inflight_turns") or 0)
+	except (TypeError, ValueError):
+		v = 0
+	return v if v > 0 else DEFAULT_MAX_INFLIGHT
+
+
+def _now() -> str:
+	return frappe.utils.now()
+
+
+def _fresh_cutoff() -> str:
+	return frappe.utils.add_to_date(None, seconds=-_INFLIGHT_FRESH_SECONDS)
+
+
+def _ensure_control_row(target: str) -> None:
+	"""Get-or-create the shard control row OUTSIDE the serializing lock so the
+	FOR UPDATE below always has a row to lock."""
+	if frappe.db.exists(PUMP, target):
+		return
+	try:
+		doc = frappe.get_doc({"doctype": PUMP, "relay_target_id": target})
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		frappe.db.commit()
+	except frappe.DuplicateEntryError:
+		frappe.db.rollback()
+
+
+def _lock_shard(target: str) -> None:
+	"""Serialize the credit read + admit decision across every sender and the
+	promoter for this shard (OAR-1).
+
+	Correctness under REPEATABLE READ: the inflight/queued COUNTs that follow
+	MUST see data committed by whoever held this lock before us. InnoDB
+	establishes a transaction's consistent-read snapshot at its first
+	NON-locking read, so we commit here to start a FRESH transaction - making
+	the ``SELECT ... FOR UPDATE`` the first statement. The lock then blocks
+	until the prior holder commits, and the first non-locking COUNT after it
+	takes its snapshot AFTER that commit (verified on patterntest under both
+	READ COMMITTED and REPEATABLE READ). Callers commit their own durable work
+	BEFORE entering admission, so this commit never drops pending state."""
+	_ensure_control_row(target)
+	frappe.db.commit()
+	frappe.db.sql(
+		f"SELECT name FROM `tab{PUMP}` WHERE name=%(t)s FOR UPDATE",
+		{"t": target},
+	)
+
+
+def on_conversation_trash(doc, method=None) -> None:
+	"""doc_events hook: cascade-delete a deleted conversation's Turn rows so a
+	removed conversation never leaves ghost queued/dispatching rows in the
+	admission shard. Best-effort - never blocks the trash."""
+	try:
+		frappe.db.delete(TURN, {"conversation": doc.name})
+	except Exception:
+		frappe.log_error(title="admission.on_conversation_trash", message=frappe.get_traceback())
+
+
+def _lock_conversation(conversation: str) -> None:
+	"""Second lock in the canonical order; defends per-conversation
+	single-flight / seq (OAR-6)."""
+	frappe.db.sql(
+		f"SELECT name FROM `tab{CONV}` WHERE name=%(c)s FOR UPDATE",
+		{"c": conversation},
+	)
+
+
+def _run_cas(sql: str, params: dict) -> int:
+	"""Run a CAS UPDATE and return affected rows (read BEFORE commit, as
+	turn_recovery._conditional_clear does - commit can reset the cursor)."""
+	frappe.db.sql(sql, params)
+	cursor = getattr(frappe.db, "_cursor", None)
+	return int(cursor.rowcount) if cursor else 0
+
+
+# --------------------------------------------------------------------------- #
+# Dual-signal counting (OAR-11)
+# --------------------------------------------------------------------------- #
+
+
+def _turn_dispatching_count(target: str) -> int:
+	return frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tab{TURN}` WHERE relay_target_id=%(t)s AND state='dispatching'",
+		{"t": target},
+	)[0][0]
+
+
+def _turn_dispatching_count_by_class(target: str, turn_class: str) -> int:
+	return frappe.db.sql(
+		f"""SELECT COUNT(*) FROM `tab{TURN}`
+		WHERE relay_target_id=%(t)s AND state='dispatching' AND turn_class=%(k)s""",
+		{"t": target, "k": turn_class},
+	)[0][0]
+
+
+def _legacy_streaming_count(target: str) -> int:
+	"""Conversations whose newest assistant Message is fresh-``streaming`` and
+	have NO owning ``dispatching`` Turn row - turns that started before the flag
+	flipped on. The ``NOT EXISTS`` de-dups only against a ``dispatching`` Turn
+	(the row that actually OWNS a stream); a merely ``queued`` Turn owns no
+	stream, so it must NOT hide a live legacy turn from the shard count (OARI-2 -
+	previously ``state IN ('queued','dispatching')`` let the caller's own queued
+	row zero out a coexisting legacy stream). Phase-0 shard is site-wide, so
+	every conversation belongs to ``target``.
+
+	Freshness is approximated from the assistant row's own ``modified`` (rather
+	than the conversation's newest-of-any-role, as api._conversation_busy uses);
+	a tool-heavy turn can look briefly stale, at worst under-counting by one
+	during a flag flip - a transitional signal, documented."""
+	return frappe.db.sql(
+		f"""
+		SELECT COUNT(*) FROM (
+			SELECT m.conversation
+			FROM `tab{MSG}` m
+			INNER JOIN (
+				SELECT conversation, MAX(seq) AS mseq
+				FROM `tab{MSG}` WHERE role='assistant' GROUP BY conversation
+			) latest ON latest.conversation = m.conversation AND latest.mseq = m.seq
+			WHERE m.role='assistant' AND m.streaming=1 AND m.recovering=0
+			  AND m.modified > %(fresh)s
+			  AND NOT EXISTS (
+					SELECT 1 FROM `tab{TURN}` t
+					WHERE t.conversation = m.conversation AND t.state='dispatching'
+			  )
+		) x
+		""",
+		{"fresh": _fresh_cutoff()},
+	)[0][0]
+
+
+def _shard_inflight(target: str) -> int:
+	"""Dual-signal inflight = Turn-row dispatching + legacy fresh-streaming."""
+	return _turn_dispatching_count(target) + _legacy_streaming_count(target)
+
+
+def _shard_queued_depth(target: str) -> int:
+	return frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tab{TURN}` WHERE relay_target_id=%(t)s AND state='queued'",
+		{"t": target},
+	)[0][0]
+
+
+def shard_overloaded(conversation: str | None = None) -> bool:
+	"""Cheap unlocked pre-check so send_message can reject BEFORE inserting the
+	user Message (avoids an orphan row). The authoritative overload check runs
+	under the shard lock inside accept_or_queue."""
+	return _shard_queued_depth(relay_target_id(conversation)) >= MAX_QUEUE_DEPTH
+
+
+def _conv_has_other_active_turn(conversation: str, run_id: str) -> bool:
+	"""Any other non-terminal (queued/dispatching) Turn row on this conversation."""
+	return bool(
+		frappe.db.sql(
+			f"""SELECT 1 FROM `tab{TURN}`
+			WHERE conversation=%(c)s AND name!=%(r)s AND state IN ('queued','dispatching')
+			LIMIT 1""",
+			{"c": conversation, "r": run_id},
+		)
+	)
+
+
+def _conv_legacy_busy(conversation: str) -> bool:
+	"""Legacy single-flight signal: a fresh streaming assistant row on this
+	conversation (a turn that started before the flag flipped on, or a mid-flight
+	self-hop). At every call site the *current* turn has no assistant row of its
+	own yet (accept: the queued row was just inserted; promote: the candidate is
+	queued), and a Turn-owned ``dispatching`` turn is already caught by
+	``_conv_has_other_active_turn``, so a plain ``_conversation_busy`` is the
+	correct legacy probe.
+
+	OARI-2: the previous body subtracted "our own Turn row" via
+	``_conv_has_other_active_turn(conversation, run_id="")`` - but the ``""``
+	sentinel made ``name != ''`` exclude nothing, so the inner query counted the
+	just-inserted queued row and always returned True, making this guard return
+	False (dead) at BOTH call sites. Dropping the subtraction restores the
+	OAR-11 coexistence interlock."""
+	from jarvis.chat.api import _conversation_busy
+
+	return _conversation_busy(conversation)
+
+
+# --------------------------------------------------------------------------- #
+# Position / publishing
+# --------------------------------------------------------------------------- #
+
+
+def _queued_ordered(target: str) -> list[dict]:
+	return frappe.db.sql(
+		f"""
+		SELECT t.run_id, t.conversation, t.seed_message, t.turn_class, c.owner
+		FROM `tab{TURN}` t
+		INNER JOIN `tab{CONV}` c ON c.name = t.conversation
+		WHERE t.relay_target_id=%(t)s AND t.state='queued'
+		ORDER BY CASE t.turn_class WHEN 'interactive' THEN 0 ELSE 1 END,
+		         t.enqueued_at ASC, t.run_id ASC
+		""",
+		{"t": target},
+		as_dict=True,
+	)
+
+
+def _position_of(run_id: str, target: str) -> int | None:
+	"""1-based rank among queued turns of the shard (interactive ahead of
+	background, then FIFO). None when the run is not queued."""
+	for i, r in enumerate(_queued_ordered(target), start=1):
+		if r["run_id"] == run_id:
+			return i
+	return None
+
+
+def _publish_queue_positions(target: str) -> None:
+	"""Push queue:position to every queued turn's owner (bounded fan-out,
+	SUX-2). Position labeled approximate in the UI ('~N ahead')."""
+	for i, r in enumerate(_queued_ordered(target), start=1):
+		try:
+			publish_to_user(
+				r["owner"],
+				{
+					"kind": "queue:position",
+					"conversation_id": r["conversation"],
+					"run_id": r["run_id"],
+					"message_id": r["seed_message"],
+					"position": i,
+				},
+			)
+		except Exception:
+			pass
+
+
+def publish_action_confirmed(conversation: str, owner: str | None = None, run_id: str | None = None) -> None:
+	"""SUX-3: on a synchronous confirm write, tell the user 'change saved'
+	immediately - decoupled from the continuation turn, which then renders the
+	standard queued chip. Best-effort. Flag-gated so flag-OFF stays byte-
+	identical (no extra realtime event)."""
+	if not admission_enabled():
+		return
+	try:
+		user = owner or frappe.db.get_value(CONV, conversation, "owner")
+		if not user:
+			return
+		publish_to_user(
+			user,
+			{
+				"kind": "action:confirmed",
+				"conversation_id": conversation,
+				"run_id": run_id or "",
+				"message": "Change saved",
+			},
+		)
+	except Exception:
+		pass
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry (feeds C1-C6 later; existing latency channel + log lines)
+# --------------------------------------------------------------------------- #
+
+
+def _telemetry(event: str, **fields) -> None:
+	try:
+		from jarvis.chat.latency import get_logger
+
+		parts = " ".join(f"{k}={v}" for k, v in fields.items())
+		get_logger().info("admission %s %s", event, parts)
+	except Exception:
+		pass
+
+
+# --------------------------------------------------------------------------- #
+# accept_or_queue - the one chokepoint (all four _dispatch_turn callers)
+# --------------------------------------------------------------------------- #
+
+
+def accept_or_queue(
+	*,
+	conversation: str,
+	run_id: str,
+	seed_message: str | None,
+	turn_class: str = "interactive",
+	dispatch,
+	dispatch_payload: dict | None = None,
+	seed_content: str | None = None,
+	exempt_overload: bool = False,
+) -> dict:
+	"""Admit or durably queue one turn. Returns one of:
+
+	  {"ok": True, "dispatched": True,  "run_id", "queued_position": None}
+	  {"ok": True, "dispatched": False, "run_id", "queued_position": N}
+	  {"ok": False, "overloaded": True, "reason": <friendly copy>}
+
+	``seed_message`` is the already-committed user Message (send/retry/orphan/
+	macro all insert it before dispatch today - OAR-3's retry/orphan reuse is
+	automatic here since no caller asks admission to insert). ``seed_content``
+	+ ``seed_message=None`` is the WP-1 insert branch, wired but unused in
+	Phase-0's legacy integration.
+
+	``exempt_overload`` (SUXI-2 ruling): a confirm continuation is the follow-up
+	of an ALREADY-committed write - it must never be rejected by the accept-time
+	overload guard, only queued. The front-door senders (send/retry) keep the
+	depth-25 backpressure; ``enqueue_continuation`` passes True so a continuation
+	always queues with a visible position, never silently drops.
+
+	``dispatch`` is a zero-arg callable that runs the legacy ``_dispatch_turn``
+	for this turn; it is invoked ONLY on the admit path and ONLY after the
+	admission txn commits."""
+	target = relay_target_id(conversation)
+	turn_class = turn_class if turn_class in ("interactive", "background") else "interactive"
+	payload_json = json.dumps(dispatch_payload) if dispatch_payload else None
+
+	_lock_shard(target)
+	_lock_conversation(conversation)
+
+	# OARI-11: everything below runs while holding the shard + conversation FOR
+	# UPDATE locks. The two designed early-returns (overload reject, duplicate
+	# replay) roll back explicitly before returning; an UNEXPECTED failure must
+	# also release the locks immediately (not linger until request/job teardown),
+	# so the whole locked section is guarded - rollback + re-raise (never mask).
+	try:
+		# Overload guard (SUX-5): authoritative check under the shard lock. No row.
+		# A confirm continuation (exempt_overload) skips it - it always queues.
+		if not exempt_overload and _shard_queued_depth(target) >= MAX_QUEUE_DEPTH:
+			frappe.db.rollback()
+			_telemetry("overload_reject", run_id=run_id, target=target)
+			return {
+				"ok": False,
+				"overloaded": True,
+				"reason": frappe._("The site is busy — please try again in a moment."),
+			}
+
+		# Seed the user Message if the caller delegated it (WP-1 branch; unused in
+		# Phase-0 wiring because every legacy caller inserts before dispatch).
+		if not seed_message:
+			seq = (
+				frappe.db.sql(
+					f"SELECT MAX(seq) FROM `tab{MSG}` WHERE conversation=%(c)s", {"c": conversation}
+				)[0][0]
+				or 0
+			) + 1
+			msg = frappe.get_doc(
+				{
+					"doctype": MSG,
+					"conversation": conversation,
+					"seq": seq,
+					"role": "user",
+					"content": seed_content or "",
+					"streaming": 0,
+				}
+			)
+			msg.flags.ignore_permissions = True
+			msg.insert()
+			seed_message = msg.name
+
+		# Insert the durable Turn row (idempotent on the run_id PK).
+		try:
+			turn = frappe.get_doc(
+				{
+					"doctype": TURN,
+					"run_id": run_id,
+					"conversation": conversation,
+					"relay_target_id": target,
+					"turn_class": turn_class,
+					"state": "queued",
+					"version": 0,
+					"seed_message": seed_message,
+					"dispatch_payload": payload_json,
+					"enqueued_at": _now(),
+				}
+			)
+			turn.flags.ignore_permissions = True
+			turn.insert()
+		except frappe.DuplicateEntryError:
+			# Same send replayed (double-click / retry-after-ack): already accepted.
+			frappe.db.rollback()
+			return {
+				"ok": True,
+				"dispatched": False,
+				"run_id": run_id,
+				"duplicate": True,
+				"queued_position": None,
+			}
+
+		# Admit decision: dispatch iff nothing else is live on this conversation
+		# (single-flight) AND the shard has a free credit.
+		conv_busy = _conv_has_other_active_turn(conversation, run_id) or _conv_legacy_busy(conversation)
+		inflight = _shard_inflight(target)
+		queue_depth_at_accept = _shard_queued_depth(target)
+		admit = (not conv_busy) and (inflight < _max_inflight())
+
+		if admit:
+			affected = _run_cas(
+				f"""UPDATE `tab{TURN}`
+				SET state='dispatching', reserved=1, dispatching_at=%(now)s,
+				    reservation_expires_at=%(exp)s, version=version+1
+				WHERE name=%(r)s AND state='queued' AND version=0""",
+				{
+					"r": run_id,
+					"now": _now(),
+					"exp": frappe.utils.add_to_date(None, seconds=RESERVE_TTL_S),
+				},
+			)
+			if affected != 1:
+				# Lost a race to a concurrent promoter (should not happen under the
+				# shard lock); fall back to queued and let promotion pick it up.
+				admit = False
+
+		frappe.db.commit()  # releases both locks; row is durable
+	except Exception:
+		frappe.db.rollback()  # release the FOR UPDATE locks on an unexpected failure
+		raise
+
+	_telemetry(
+		"accept",
+		run_id=run_id,
+		target=target,
+		turn_class=turn_class,
+		admitted=int(admit),
+		admission_queue_depth=queue_depth_at_accept,
+	)
+
+	if admit:
+		# Enqueue the legacy turn job AFTER the durable commit (mirrors the
+		# _dispatch_turn after_commit invariant).
+		dispatch()
+		return {"ok": True, "dispatched": True, "run_id": run_id, "queued_position": None}
+
+	pos = _position_of(run_id, target)
+	# A new queued turn changes nobody else's position, so no shard-wide
+	# republish is needed here; the caller returns this turn's own position.
+	return {"ok": True, "dispatched": False, "run_id": run_id, "queued_position": pos}
+
+
+# --------------------------------------------------------------------------- #
+# promote_next - weighted, background-floor, per-conversation single-flight
+# --------------------------------------------------------------------------- #
+
+
+def _cas_dispatch(run_id: str) -> bool:
+	return (
+		_run_cas(
+			f"""UPDATE `tab{TURN}`
+			SET state='dispatching', reserved=1, dispatching_at=%(now)s,
+			    reservation_expires_at=%(exp)s, version=version+1
+			WHERE name=%(r)s AND state='queued'""",
+			{
+				"r": run_id,
+				"now": _now(),
+				"exp": frappe.utils.add_to_date(None, seconds=RESERVE_TTL_S),
+			},
+		)
+		== 1
+	)
+
+
+def _dispatch_promoted(row: dict) -> None:
+	"""Re-dispatch a promoted queued turn via the legacy path, reconstructing
+	attachments/context from the stored dispatch_payload."""
+	from jarvis.chat import api
+
+	kwargs = {
+		"conversation_id": row["conversation"],
+		"message_id": row["seed_message"],
+		"run_id": row["run_id"],
+		"enqueued_at_ms": int(time.time() * 1000),
+	}
+	extra = row.get("dispatch_payload")
+	if extra:
+		try:
+			parsed = json.loads(extra)
+			if isinstance(parsed, dict):
+				if parsed.get("attachments"):
+					kwargs["attachments"] = parsed["attachments"]
+				if parsed.get("context"):
+					kwargs["context"] = parsed["context"]
+		except Exception:
+			pass
+	api._dispatch_turn(kwargs, interactive=(row.get("turn_class") == "interactive"))
+
+
+def promote_next(target: str | None = None) -> int:
+	"""Dispatch as many eligible queued turns as free credits allow. Weighted
+	classes with a background floor of 1 (SUX-4a): when background turns are
+	queued, interactive holds at most ``ceiling - 1`` credits. Per-conversation
+	single-flight respected. Returns the number promoted. Best-effort - never
+	raises into a terminal hook.
+
+	OARI-4: flag-gated so a flag-OFF sweep never issues a FRESH dispatch. With
+	the flag off, existing Turn rows still drain to terminal via the sweep's
+	reconcile/age-out duties (which only settle/cancel existing rows), but no
+	queued row is ever promoted onto a worker - disabling admission is a true
+	kill switch for new dispatch, not just for new rows."""
+	if not admission_enabled():
+		return 0
+	if target is None:
+		target = DEFAULT_RELAY_TARGET
+	promoted_rows: list[dict] = []
+	try:
+		_lock_shard(target)
+		cap = _max_inflight()
+		promoted_convs: set[str] = set()
+
+		while _shard_inflight(target) < cap:
+			candidate = _pick_next(target, cap, promoted_convs)
+			if not candidate:
+				break
+			if _cas_dispatch(candidate["run_id"]):
+				promoted_rows.append(candidate)
+				promoted_convs.add(candidate["conversation"])
+			# else lost the row; loop re-reads and tries the next candidate
+
+		frappe.db.commit()  # release the shard lock before enqueueing
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(title="admission.promote_next", message=frappe.get_traceback())
+		return 0
+
+	for row in promoted_rows:
+		try:
+			wait_ms = _queue_wait_ms(row["run_id"])
+			_dispatch_promoted(row)
+			_telemetry("promote", run_id=row["run_id"], target=target, queue_wait_ms=wait_ms)
+		except Exception:
+			frappe.log_error(title="admission.promote dispatch", message=frappe.get_traceback())
+
+	# Positions shifted for everyone still queued.
+	try:
+		_publish_queue_positions(target)
+	except Exception:
+		pass
+	return len(promoted_rows)
+
+
+def _pick_next(target: str, cap: int, promoted_convs: set[str]) -> dict | None:
+	"""Choose the next queued turn to promote, honoring the background floor
+	and per-conversation single-flight. Reads a small ordered batch and filters
+	in Python (bounded work: at most a handful of credits per round)."""
+	rows = frappe.db.sql(
+		f"""
+		SELECT t.run_id, t.conversation, t.seed_message, t.turn_class, t.dispatch_payload
+		FROM `tab{TURN}` t
+		WHERE t.relay_target_id=%(t)s AND t.state='queued'
+		ORDER BY t.enqueued_at ASC, t.run_id ASC
+		LIMIT 200
+		""",
+		{"t": target},
+		as_dict=True,
+	)
+
+	def eligible(r: dict) -> bool:
+		conv = r["conversation"]
+		if conv in promoted_convs:
+			return False
+		if _conv_has_other_active_turn(conv, r["run_id"]):
+			return False
+		if _conv_legacy_busy(conv):
+			return False
+		return True
+
+	interactive = next((r for r in rows if r["turn_class"] == "interactive" and eligible(r)), None)
+	background = next((r for r in rows if r["turn_class"] == "background" and eligible(r)), None)
+
+	if interactive and background:
+		# Background floor: reserve at least one credit for background work when
+		# any is queued - interactive may hold at most cap-1 credits. Only for
+		# cap>=2: at cap 1 the floor "int_inflight >= cap-1" degenerates to ">= 0"
+		# (always true) and would hand the SOLE credit to background over a
+		# waiting interactive turn, inverting priority (OARI-8). With one credit
+		# there is no room to reserve a floor, so interactive wins.
+		int_inflight = _turn_dispatching_count_by_class(target, "interactive")
+		if cap >= 2 and int_inflight >= cap - 1:
+			return background
+		return interactive
+	return interactive or background
+
+
+def _queue_wait_ms(run_id: str) -> int:
+	row = frappe.db.get_value(TURN, run_id, ["enqueued_at", "dispatching_at"], as_dict=True)
+	if not row or not row.get("enqueued_at") or not row.get("dispatching_at"):
+		return 0
+	try:
+		delta = frappe.utils.get_datetime(row["dispatching_at"]) - frappe.utils.get_datetime(
+			row["enqueued_at"]
+		)
+		return int(delta.total_seconds() * 1000)
+	except Exception:
+		return 0
+
+
+# --------------------------------------------------------------------------- #
+# Terminal hooks (worker + recovery) - CAS + best-effort promote
+# --------------------------------------------------------------------------- #
+
+
+def settle_turn(run_id: str, terminal_state: str, error: str | None = None) -> None:
+	"""Mark a dispatching Turn terminal (done/errored/cancelled) then promote.
+	Called AFTER the legacy terminal commit points, OUTSIDE the brittle region.
+	Guarded by the flag so flag-OFF is byte-identical. Best-effort: never
+	breaks the turn."""
+	if not admission_enabled():
+		return
+	try:
+		affected = _run_cas(
+			f"""UPDATE `tab{TURN}`
+			SET state=%(s)s, reserved=0, cancel_requested=0, done_at=%(now)s,
+			    error=%(err)s, version=version+1
+			WHERE name=%(r)s AND state='dispatching'""",
+			{"s": terminal_state, "now": _now(), "err": (error or "")[:1000], "r": run_id},
+		)
+		target = frappe.db.get_value(TURN, run_id, "relay_target_id") or DEFAULT_RELAY_TARGET
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(title="admission.settle_turn", message=frappe.get_traceback())
+		return
+	if affected == 1:
+		promote_next(target)
+
+
+def settle_conversation_dispatching(
+	conversation: str, terminal_state: str, error: str | None = None
+) -> None:
+	"""Recovery-path settle: close the (single-flight) dispatching Turn on this
+	conversation. turn_recovery works off Message rows and has no run_id, so we
+	settle by conversation - per-conversation single-flight makes this
+	unambiguous. Best-effort + flag-gated."""
+	if not admission_enabled():
+		return
+	try:
+		run_id = frappe.db.get_value(
+			TURN, {"conversation": conversation, "state": "dispatching"}, "name"
+		)
+	except Exception:
+		run_id = None
+	if run_id:
+		settle_turn(run_id, terminal_state, error=error)
+
+
+def mark_cancel_requested(conversation: str) -> None:
+	"""stop_run hook: record cancel intent on the dispatching Turn (D2's
+	dispatching->cancel-intent transition). NOT terminal - the legacy worker's
+	aborted-terminal settles + promotes. Flag-gated, best-effort."""
+	if not admission_enabled():
+		return
+	try:
+		run_id = frappe.db.get_value(
+			TURN, {"conversation": conversation, "state": "dispatching"}, "name"
+		)
+		if run_id:
+			_run_cas(
+				f"""UPDATE `tab{TURN}` SET cancel_requested=1, version=version+1
+				WHERE name=%(r)s AND state='dispatching'""",
+				{"r": run_id},
+			)
+			frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Web endpoints - cancel + poll position
+# --------------------------------------------------------------------------- #
+
+
+def _assert_owner(conversation: str) -> str:
+	owner = frappe.db.get_value(CONV, conversation, "owner")
+	if owner is None:
+		raise frappe.DoesNotExistError(f"conversation {conversation!r} not found")
+	if owner != frappe.session.user and "System Manager" not in frappe.get_roles():
+		raise frappe.PermissionError("not your conversation")
+	return owner
+
+
+@frappe.whitelist()
+def cancel_queued_turn(run_id: str) -> dict:
+	"""Owner-checked cancel of a queued turn: CAS queued->cancelled, publish
+	turn:cancelled, republish positions. Frees no slot (a queued turn holds
+	none) but renumbers the queue."""
+	require_jarvis_access()
+	row = frappe.db.get_value(
+		TURN, run_id, ["conversation", "state", "relay_target_id", "seed_message"], as_dict=True
+	)
+	if not row:
+		return {"ok": False, "reason": frappe._("This turn no longer exists.")}
+	owner = _assert_owner(row["conversation"])
+	affected = _run_cas(
+		f"""UPDATE `tab{TURN}` SET state='cancelled', cancel_requested=1, done_at=%(now)s,
+		version=version+1 WHERE name=%(r)s AND state='queued'""",
+		{"r": run_id, "now": _now()},
+	)
+	frappe.db.commit()
+	if affected != 1:
+		return {"ok": False, "reason": frappe._("This turn already started or was cancelled.")}
+	try:
+		publish_to_user(
+			owner,
+			{
+				"kind": "turn:cancelled",
+				"conversation_id": row["conversation"],
+				"run_id": run_id,
+				"message_id": row["seed_message"],
+				"reason": USER_CANCEL_REASON,
+			},
+		)
+	except Exception:
+		pass
+	# SUXI-4: durable transcript marker so a later reload shows the send was
+	# cancelled (not silently dropped).
+	_write_cancel_marker(row["conversation"], USER_CANCEL_REASON)
+	target = row["relay_target_id"] or DEFAULT_RELAY_TARGET
+	# A cancel can free capacity indirectly (an over-cap conversation clears) -
+	# best-effort promote + republish positions.
+	promote_next(target)
+	return {"ok": True, "run_id": run_id}
+
+
+@frappe.whitelist()
+def queue_position(run_id: str) -> dict:
+	"""Poll-on-focus fallback for the queued chip. Owner-checked. Returns the
+	current state and (when queued) the approximate position."""
+	require_jarvis_access()
+	row = frappe.db.get_value(
+		TURN, run_id, ["conversation", "state", "relay_target_id"], as_dict=True
+	)
+	if not row:
+		return {"ok": False, "reason": frappe._("This turn no longer exists.")}
+	_assert_owner(row["conversation"])
+	pos = _position_of(run_id, row["relay_target_id"] or DEFAULT_RELAY_TARGET) if row["state"] == "queued" else None
+	return {"ok": True, "run_id": run_id, "state": row["state"], "position": pos}
+
+
+@frappe.whitelist()
+def active_turn_for_conversation(conversation: str) -> dict:
+	"""SUXI-1 server-truth resync for the queued chip. Owner-checked. Returns the
+	conversation's own QUEUED turn (the one the chip represents), if any, so a
+	client that lost ``queuedTurn`` (reload, conversation switch, second tab, WS
+	reconnect) can rebuild it from server truth - the same pattern as
+	``resyncPendingConfirmations``. Conversations are owner-scoped, so this turn
+	IS the caller's own. A ``dispatching`` turn is deliberately NOT returned here:
+	loadConversation's existing streaming resume already shows its "Thinking…"
+	state from the assistant placeholder; the chip is only for a not-yet-running
+	queued turn. Returns ``{"ok": True, "active": None}`` when nothing is queued.
+	The earliest-enqueued queued turn (position closest to 1) is reported."""
+	require_jarvis_access()
+	_assert_owner(conversation)
+	row = frappe.db.get_value(
+		TURN,
+		{"conversation": conversation, "state": "queued"},
+		["run_id", "seed_message", "relay_target_id"],
+		as_dict=True,
+		order_by="enqueued_at asc",
+	)
+	if not row:
+		return {"ok": True, "active": None}
+	pos = _position_of(row["run_id"], row["relay_target_id"] or DEFAULT_RELAY_TARGET)
+	return {
+		"ok": True,
+		"active": {
+			"run_id": row["run_id"],
+			"state": "queued",
+			"message_id": row["seed_message"],
+			"position": pos,
+		},
+	}
+
+
+def _write_cancel_marker(conversation: str, reason: str) -> None:
+	"""SUXI-4: leave a durable assistant marker Message when a queued turn is
+	cancelled (user-initiated or system age-out) so a later reload shows WHY the
+	send has no reply - indistinguishable otherwise from a silently dropped send.
+	Reuses the error-card pattern (``error`` field) so the transcript renders it
+	as a card with a Retry affordance. seq is allocated under the conversation
+	FOR UPDATE lock (R-9 discipline) so it never collides with a concurrent
+	writer on the same conversation. Best-effort - never blocks the cancel."""
+	try:
+		_lock_conversation(conversation)
+		seq = (
+			frappe.db.sql(
+				f"SELECT MAX(seq) FROM `tab{MSG}` WHERE conversation=%(c)s", {"c": conversation}
+			)[0][0]
+			or 0
+		) + 1
+		marker = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conversation,
+				"seq": seq,
+				"role": "assistant",
+				"content": "",
+				"streaming": 0,
+				"error": reason,
+			}
+		)
+		marker.flags.ignore_permissions = True
+		marker.insert()
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(title="admission._write_cancel_marker", message=frappe.get_traceback())
+
+
+# --------------------------------------------------------------------------- #
+# Sweep (scheduler backstop) - reservation expiry, age-out, Turn/Message reconcile
+# --------------------------------------------------------------------------- #
+
+
+def sweep() -> dict:
+	"""Backstop tick (hooks cron). Runs whenever any non-terminal Turn rows
+	exist (so a flag flip-off still gets its rows reconciled), else a cheap
+	no-op. Three duties:
+
+	  1. Reservation expiry: a dispatching turn whose enqueue was lost (expired
+	     reservation, no live assistant activity of ITS OWN) returns to queued;
+	     a stopped turn (cancel_requested) is cancelled, not re-queued (OARI-6).
+	  2. Turn-vs-Message reconcile: a dispatching turn whose OWN assistant
+	     Message (seq > seed.seq) already settled/errored is closed to match
+	     Message truth; an orphaned turn whose own placeholder is a stale
+	     streaming row past a lost worker (reservation expired) is closed errored
+	     to free its credit (OARI-1/OARI-3). The legacy transport is the executor.
+	  3. Age-out: a queued turn older than QUEUED_MAX_AGE_S is system-cancelled
+	     with a recorded reason.
+
+	Then re-promote and republish positions. Never raises.
+
+	Flag-OFF drain semantics (OARI-4): the three settle/reclaim/age-out duties
+	still run so residual rows from a flag flip-off DRAIN to terminal, but
+	``promote_next`` is flag-gated so NO fresh dispatch is issued while the flag
+	is off. Disabling admission therefore stops all new dispatch immediately;
+	the leftover rows settle themselves out. accept_or_queue is never reached
+	with the flag off (all four callers gate on ``admission_enabled`` first), so
+	no NEW rows are created - the flag-OFF hot path stays byte-identical."""
+	summary = {"reclaimed": 0, "reconciled": 0, "aged_out": 0, "promoted": 0}
+	try:
+		open_count = frappe.db.sql(
+			f"SELECT COUNT(*) FROM `tab{TURN}` WHERE state IN ('queued','dispatching')"
+		)[0][0]
+	except Exception:
+		return summary
+	if not open_count:
+		return summary
+
+	targets: set[str] = set()
+	try:
+		summary["reconciled"] += _sweep_reconcile(targets)
+		summary["reclaimed"] += _sweep_reservations(targets)
+		summary["aged_out"] += _sweep_age_out(targets)
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(title="admission.sweep", message=frappe.get_traceback())
+
+	for target in targets or {DEFAULT_RELAY_TARGET}:
+		try:
+			summary["promoted"] += promote_next(target)
+		except Exception:
+			pass
+	return summary
+
+
+def _sweep_reconcile(targets: set[str]) -> int:
+	"""Close dispatching turns whose OWN assistant Message (seq > seed.seq)
+	already settled/errored, or whose own placeholder is a stale streaming row
+	past a lost worker. Message truth wins.
+
+	OARI-1: the reconcile is scoped to THIS turn's output (an assistant row
+	strictly after the turn's seed user row). Keying on the conversation's newest
+	assistant of ANY turn silently CLOSED a just-sent later turn as 'done' the
+	moment a sweep landed while its own placeholder had not been written yet -
+	losing a real user send with no reply and no error, and (in the placeholder
+	window) over-promoting into same-session double-occupancy. When the turn has
+	produced NOTHING of its own, reconcile leaves it: a lost enqueue is reclaimed
+	by _sweep_reservations, a live turn mid-placeholder is untouched.
+
+	OARI-3: an orphaned dispatching turn whose only OWN assistant is a stale
+	streaming placeholder (worker provably dead - reservation past the 900s TTL,
+	well beyond the 720s worker cap) is closed errored so a post-deploy batch of
+	orphans frees its shard credits instead of pinning them for extra cycles."""
+	rows = frappe.db.sql(
+		f"""
+		SELECT t.run_id, t.conversation, t.relay_target_id, t.seed_message,
+		       t.reservation_expires_at
+		FROM `tab{TURN}` t
+		WHERE t.state='dispatching'
+		""",
+		as_dict=True,
+	)
+	now = _now()
+	fresh = _fresh_cutoff()
+	closed = 0
+	for r in rows:
+		# THIS turn's own latest assistant (strictly after its seed user row).
+		latest = frappe.db.sql(
+			f"""SELECT streaming, recovering, error, modified FROM `tab{MSG}`
+			WHERE conversation=%(c)s AND role='assistant'
+			  AND seq > (SELECT seq FROM `tab{MSG}` WHERE name=%(seed)s)
+			ORDER BY seq DESC LIMIT 1""",
+			{"c": r["conversation"], "seed": r["seed_message"]},
+			as_dict=True,
+		)
+		if not latest:
+			# Nothing of its OWN yet - a PRIOR turn's assistant is NOT this turn.
+			# Do NOT close it (that was the OARI-1 silent-loss bug); leave it for
+			# reservation-reclaim or a live placeholder to arrive.
+			continue
+		a = latest[0]
+		if a.get("recovering"):
+			continue  # parked for background recovery - recovery finalize settles it
+		if a.get("streaming"):
+			# Own placeholder still streaming. Close ONLY a provably-dead orphan
+			# (reservation expired AND the placeholder has gone stale past the
+			# freshness window); a live or not-yet-expired turn is left alone so a
+			# live long turn is never false-closed (OARI-3).
+			exp = r.get("reservation_expires_at")
+			expired = bool(exp) and frappe.utils.get_datetime(exp) < frappe.utils.get_datetime(now)
+			mod = a.get("modified")
+			stale = bool(mod) and frappe.utils.get_datetime(mod) < frappe.utils.get_datetime(fresh)
+			if expired and stale:
+				state = "errored"
+			else:
+				continue
+		else:
+			# Settled or errored assistant row but the Turn is still dispatching.
+			state = "errored" if a.get("error") else "done"
+		affected = _run_cas(
+			f"""UPDATE `tab{TURN}` SET state=%(s)s, reserved=0, done_at=%(now)s,
+			was_recovered=1, version=version+1 WHERE run_id=%(r)s AND state='dispatching'""",
+			{"s": state, "now": now, "r": r["run_id"]},
+		)
+		if affected == 1:
+			closed += 1
+			targets.add(r["relay_target_id"] or DEFAULT_RELAY_TARGET)
+	if closed:
+		frappe.db.commit()
+	return closed
+
+
+def _sweep_reservations(targets: set[str]) -> int:
+	"""Reclaim dispatching turns whose reservation expired AND that never
+	produced assistant activity OF THEIR OWN (seq > seed.seq) - a lost/crashed
+	enqueue - returning them to queued for a fresh promotion.
+
+	OARI-1: scoped to this turn's output (seq > seed.seq). The old ``role=
+	'assistant' LIMIT 1`` matched ANY assistant row on the conversation, so on a
+	multi-turn conversation a lost enqueue was NEVER reclaimed (an earlier turn's
+	assistant made ``has_assistant`` true) - the reclaim path the brief promises
+	only worked on first-turn conversations.
+
+	OARI-6: a stopped turn (``cancel_requested``) whose worker died before making
+	a placeholder is CANCELLED (terminal), never re-dispatched - a turn the user
+	explicitly stopped must not run again."""
+	rows = frappe.db.sql(
+		f"""
+		SELECT t.run_id, t.conversation, t.relay_target_id, t.seed_message,
+		       t.cancel_requested
+		FROM `tab{TURN}` t
+		WHERE t.state='dispatching' AND t.reservation_expires_at IS NOT NULL
+		  AND t.reservation_expires_at < %(now)s
+		""",
+		{"now": _now()},
+		as_dict=True,
+	)
+	reclaimed = 0
+	for r in rows:
+		has_own_assistant = frappe.db.sql(
+			f"""SELECT 1 FROM `tab{MSG}`
+			WHERE conversation=%(c)s AND role='assistant'
+			  AND seq > (SELECT seq FROM `tab{MSG}` WHERE name=%(seed)s) LIMIT 1""",
+			{"c": r["conversation"], "seed": r["seed_message"]},
+		)
+		if has_own_assistant:
+			continue  # reconcile owns this case
+		if int(r.get("cancel_requested") or 0):
+			# OARI-6: stopped-then-crashed - cancel it, never re-dispatch.
+			affected = _run_cas(
+				f"""UPDATE `tab{TURN}` SET state='cancelled', reserved=0, done_at=%(now)s,
+				was_recovered=1, version=version+1
+				WHERE run_id=%(r)s AND state='dispatching'
+				  AND reservation_expires_at IS NOT NULL AND reservation_expires_at < %(now)s""",
+				{"r": r["run_id"], "now": _now()},
+			)
+			if affected == 1:
+				reclaimed += 1
+				targets.add(r["relay_target_id"] or DEFAULT_RELAY_TARGET)
+			continue
+		affected = _run_cas(
+			f"""UPDATE `tab{TURN}`
+			SET state='queued', reserved=0, dispatching_at=NULL,
+			    reservation_expires_at=NULL, was_recovered=1, version=version+1
+			WHERE run_id=%(r)s AND state='dispatching'
+			  AND reservation_expires_at IS NOT NULL AND reservation_expires_at < %(now)s""",
+			{"r": r["run_id"], "now": _now()},
+		)
+		if affected == 1:
+			reclaimed += 1
+			targets.add(r["relay_target_id"] or DEFAULT_RELAY_TARGET)
+	if reclaimed:
+		frappe.db.commit()
+	return reclaimed
+
+
+def _sweep_age_out(targets: set[str]) -> int:
+	"""System-cancel queued turns older than QUEUED_MAX_AGE_S with a recorded
+	reason + publish (SUX-5)."""
+	cutoff = frappe.utils.add_to_date(None, seconds=-QUEUED_MAX_AGE_S)
+	rows = frappe.db.sql(
+		f"""
+		SELECT t.run_id, t.conversation, t.relay_target_id, t.seed_message, c.owner
+		FROM `tab{TURN}` t INNER JOIN `tab{CONV}` c ON c.name = t.conversation
+		WHERE t.state='queued' AND t.enqueued_at IS NOT NULL AND t.enqueued_at < %(cut)s
+		""",
+		{"cut": cutoff},
+		as_dict=True,
+	)
+	reason = AGE_OUT_REASON
+	cancelled = 0
+	for r in rows:
+		affected = _run_cas(
+			f"""UPDATE `tab{TURN}` SET state='cancelled', cancel_reason=%(reason)s,
+			done_at=%(now)s, version=version+1 WHERE run_id=%(r)s AND state='queued'""",
+			{"reason": reason, "now": _now(), "r": r["run_id"]},
+		)
+		if affected != 1:
+			continue
+		# Make the cancel durable BEFORE the side-effects: _write_cancel_marker
+		# runs its own txn (and rolls back on failure), which would otherwise
+		# undo an uncommitted CAS.
+		frappe.db.commit()
+		cancelled += 1
+		targets.add(r["relay_target_id"] or DEFAULT_RELAY_TARGET)
+		try:
+			publish_to_user(
+				r["owner"],
+				{
+					"kind": "turn:cancelled",
+					"conversation_id": r["conversation"],
+					"run_id": r["run_id"],
+					"message_id": r["seed_message"],
+					"reason": reason,
+				},
+			)
+		except Exception:
+			pass
+		# SUXI-4: durable transcript marker (survives the next-morning reload).
+		_write_cancel_marker(r["conversation"], reason)
+	return cancelled

--- a/jarvis/chat/admission.py
+++ b/jarvis/chat/admission.py
@@ -714,9 +714,7 @@ def settle_turn(run_id: str, terminal_state: str, error: str | None = None) -> N
 		promote_next(target)
 
 
-def settle_conversation_dispatching(
-	conversation: str, terminal_state: str, error: str | None = None
-) -> None:
+def settle_conversation_dispatching(conversation: str, terminal_state: str, error: str | None = None) -> None:
 	"""Recovery-path settle: close the (single-flight) dispatching Turn on this
 	conversation. turn_recovery works off Message rows and has no run_id, so we
 	settle by conversation - per-conversation single-flight makes this
@@ -724,9 +722,7 @@ def settle_conversation_dispatching(
 	if not admission_enabled():
 		return
 	try:
-		run_id = frappe.db.get_value(
-			TURN, {"conversation": conversation, "state": "dispatching"}, "name"
-		)
+		run_id = frappe.db.get_value(TURN, {"conversation": conversation, "state": "dispatching"}, "name")
 	except Exception:
 		run_id = None
 	if run_id:
@@ -740,9 +736,7 @@ def mark_cancel_requested(conversation: str) -> None:
 	if not admission_enabled():
 		return
 	try:
-		run_id = frappe.db.get_value(
-			TURN, {"conversation": conversation, "state": "dispatching"}, "name"
-		)
+		run_id = frappe.db.get_value(TURN, {"conversation": conversation, "state": "dispatching"}, "name")
 		if run_id:
 			_run_cas(
 				f"""UPDATE `tab{TURN}` SET cancel_requested=1, version=version+1
@@ -816,13 +810,15 @@ def queue_position(run_id: str) -> dict:
 	"""Poll-on-focus fallback for the queued chip. Owner-checked. Returns the
 	current state and (when queued) the approximate position."""
 	require_jarvis_access()
-	row = frappe.db.get_value(
-		TURN, run_id, ["conversation", "state", "relay_target_id"], as_dict=True
-	)
+	row = frappe.db.get_value(TURN, run_id, ["conversation", "state", "relay_target_id"], as_dict=True)
 	if not row:
 		return {"ok": False, "reason": frappe._("This turn no longer exists.")}
 	_assert_owner(row["conversation"])
-	pos = _position_of(run_id, row["relay_target_id"] or DEFAULT_RELAY_TARGET) if row["state"] == "queued" else None
+	pos = (
+		_position_of(run_id, row["relay_target_id"] or DEFAULT_RELAY_TARGET)
+		if row["state"] == "queued"
+		else None
+	)
 	return {"ok": True, "run_id": run_id, "state": row["state"], "position": pos}
 
 
@@ -872,9 +868,9 @@ def _write_cancel_marker(conversation: str, reason: str) -> None:
 	try:
 		_lock_conversation(conversation)
 		seq = (
-			frappe.db.sql(
-				f"SELECT MAX(seq) FROM `tab{MSG}` WHERE conversation=%(c)s", {"c": conversation}
-			)[0][0]
+			frappe.db.sql(f"SELECT MAX(seq) FROM `tab{MSG}` WHERE conversation=%(c)s", {"c": conversation})[
+				0
+			][0]
 			or 0
 		) + 1
 		marker = frappe.get_doc(

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -10,7 +10,7 @@ from urllib.parse import quote
 
 import frappe
 
-from jarvis.chat import user_settings_api
+from jarvis.chat import admission, user_settings_api
 from jarvis.chat.usage import current_month_key as _usage_month_key
 from jarvis.permissions import (
 	has_jarvis_access,
@@ -929,7 +929,16 @@ def send_message(
 	# conversation (extra tab / double-send / a retry racing a live turn) -
 	# they would otherwise run in parallel on the same openclaw session. Placed
 	# after ownership so the reject is clean (no user row inserted yet).
-	if _conversation_busy(conversation):
+	#
+	# Phase-0 admission (flag ON): the busy case is no longer a reject - the
+	# second turn becomes a durable QUEUED turn with a visible position. So skip
+	# the legacy reject and let accept_or_queue serialize + queue it. We still
+	# reject up front on OVERLOAD (queue too deep) before inserting the user row,
+	# so an overloaded site never accretes orphaned messages.
+	if admission.admission_enabled():
+		if admission.shard_overloaded(conversation):
+			return {"ok": False, "reason": _("The site is busy — please try again in a moment.")}
+	elif _conversation_busy(conversation):
 		return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
 
 	# Apply model override BEFORE enqueueing so the worker sees the new value
@@ -1111,7 +1120,43 @@ def send_message(
 	# Dispatch the turn (see _dispatch_turn for the Node-RQ vs Python-pubsub
 	# routing rationale). `background` marks unattended turns (File Box
 	# drops) that must not jump ahead of a human's queued question.
-	_dispatch_turn(enqueue_kwargs, interactive=not int(background or 0))
+	#
+	# Phase-0 admission (flag ON): route the dispatch through the one
+	# accept_or_queue chokepoint. It inserts the durable Turn row under the
+	# shard+conversation locks and either dispatches now (a free credit) or
+	# leaves the turn QUEUED with a position. The seed Message is already
+	# committed above, so this is the OAR-3 "existing seed" branch.
+	_adm = None
+	_interactive = not int(background or 0)
+	if admission.admission_enabled():
+		_dispatch_payload = {}
+		if atts:
+			_dispatch_payload["attachments"] = atts
+		if enqueue_kwargs.get("context"):
+			_dispatch_payload["context"] = enqueue_kwargs["context"]
+		_adm = admission.accept_or_queue(
+			conversation=conversation,
+			run_id=run_id,
+			seed_message=msg_doc.name,
+			turn_class="interactive" if _interactive else "background",
+			dispatch=lambda: _dispatch_turn(enqueue_kwargs, interactive=_interactive),
+			dispatch_payload=_dispatch_payload or None,
+		)
+		if _adm.get("overloaded"):
+			# Rare race: the cheap pre-check passed but the locked check found the
+			# queue full. The user Message is already committed (a separate txn,
+			# untouched by admission's rollback), so it would otherwise reappear on
+			# reload as a permanently-unanswered orphan send (SUXI-5/OARI-7). Delete
+			# it so an overloaded site leaves no dangling user row, then surface the
+			# busy copy so the composer doesn't hang on a reply that will never come.
+			try:
+				frappe.delete_doc(MSG, msg_doc.name, ignore_permissions=True, force=True)
+				frappe.db.commit()
+			except Exception:
+				frappe.log_error(title="send_message overload seed cleanup", message=frappe.get_traceback())
+			return {"ok": False, "reason": _adm.get("reason")}
+	else:
+		_dispatch_turn(enqueue_kwargs, interactive=_interactive)
 
 	# Latency telemetry (plan Phase 0): one line per send so the web-request
 	# segments are measurable. total_ms should now sit in the tens of ms even
@@ -1125,12 +1170,20 @@ def send_message(
 		int((time.monotonic() - t0) * 1000),
 	)
 
-	return {
+	result = {
 		"ok": True,
 		"run_id": run_id,
 		"message_id": msg_doc.name,
 		"conversation_id": conversation,
 	}
+	# Phase-0 admission: tell the SPA when the turn is queued (not yet
+	# streaming) so it renders the "~N ahead" chip + cancel affordance instead
+	# of a spinner that would otherwise wait for a run:start that only arrives
+	# on promotion.
+	if _adm is not None and not _adm.get("dispatched", True):
+		result["queued"] = True
+		result["queued_position"] = _adm.get("queued_position")
+	return result
 
 
 @frappe.whitelist()
@@ -1552,7 +1605,12 @@ def retry_message(message: str) -> dict:
 	# inserted by the RQ worker under a different session user, so the
 	# conversation's owner is the authority, not the message row's owner.
 	_get_owned_conversation(doc.conversation)
-	if _conversation_busy(doc.conversation):
+	# Flag ON: a retry racing a live turn QUEUES (accept_or_queue) rather than
+	# rejecting; flag OFF keeps the legacy single-flight reject.
+	if admission.admission_enabled():
+		if admission.shard_overloaded(doc.conversation):
+			return {"ok": False, "reason": _("The site is busy — please try again in a moment.")}
+	elif _conversation_busy(doc.conversation):
 		return {"ok": False, "reason": _("a reply is already in progress - hang on a moment")}
 	if doc.role != "assistant":
 		return {"ok": False, "reason": _("only assistant messages can be retried")}
@@ -1585,6 +1643,24 @@ def retry_message(message: str) -> dict:
 		"run_id": run_id,
 		"enqueued_at_ms": int(time.time() * 1000),
 	}
+	# Phase-0 admission (flag ON): retry reuses the EXISTING user message as the
+	# seed (OAR-3) - no new user row, no seq allocation - and routes through the
+	# admission chokepoint so a retry at cap queues fairly.
+	if admission.admission_enabled():
+		_adm = admission.accept_or_queue(
+			conversation=doc.conversation,
+			run_id=run_id,
+			seed_message=user_msg_id,
+			turn_class="interactive",
+			dispatch=lambda: _dispatch_turn(payload),
+		)
+		if _adm.get("overloaded"):
+			return {"ok": False, "reason": _adm.get("reason")}
+		out = {"ok": True, "run_id": run_id}
+		if not _adm.get("dispatched", True):
+			out["queued"] = True
+			out["queued_position"] = _adm.get("queued_position")
+		return out
 	_dispatch_turn(payload)
 	return {"ok": True, "run_id": run_id}
 
@@ -1599,6 +1675,12 @@ def stop_run(conversation: str, run_id: str | None = None) -> dict:
 	abort RPC) - the UI stop stands alone there."""
 	require_jarvis_access()
 	conv = _get_owned_conversation(conversation)
+	# Phase-0 admission (flag ON): record cancel intent on this conversation's
+	# dispatching Turn row (D2's dispatching->cancel-intent transition). This is
+	# NOT terminal - the legacy worker observes openclaw's aborted-terminal and
+	# settles the Turn (cancelled) + promotes the next queued turn there. Marking
+	# intent here just makes support/telemetry honest. Best-effort + flag-gated.
+	admission.mark_cancel_requested(conversation)
 	# F6: a stopped run's parked cards must not linger or resurface on resync.
 	# Sweep this owner's live confirmation tokens for the conversation (best-effort).
 	try:
@@ -1702,16 +1784,35 @@ def _redispatch_orphan(
 	``attachments``/``context`` are recovered from the dead job's kwargs
 	when it still exists - they ride only the enqueue payload, so dropping
 	them would resume the turn blind to its own file."""
+	run_id = uuid.uuid4().hex[:12]
 	payload = {
 		"conversation_id": conversation_id,
 		"message_id": message_id,
-		"run_id": uuid.uuid4().hex[:12],
+		"run_id": run_id,
 		"enqueued_at_ms": int(time.time() * 1000),
 	}
 	if attachments:
 		payload["attachments"] = attachments
 	if context:
 		payload["context"] = context
+	# Phase-0 admission (flag ON): the orphan re-dispatch reuses the EXISTING
+	# seed message (OAR-3) and goes through the admission gate at background
+	# class so a re-dispatch at cap queues instead of piling onto a full shard.
+	if admission.admission_enabled():
+		_dispatch_payload = {}
+		if attachments:
+			_dispatch_payload["attachments"] = attachments
+		if context:
+			_dispatch_payload["context"] = context
+		admission.accept_or_queue(
+			conversation=conversation_id,
+			run_id=run_id,
+			seed_message=message_id,
+			turn_class="background",
+			dispatch=lambda: _dispatch_turn(payload, interactive=False),
+			dispatch_payload=_dispatch_payload or None,
+		)
+		return
 	_dispatch_turn(payload, interactive=False)
 
 
@@ -1794,6 +1895,7 @@ def _enqueue_turn(
 	thinking_override: str | None = None,
 	hidden: bool = False,
 	interactive: bool = True,
+	exempt_overload: bool = False,
 ) -> dict:
 	"""Persist a user message + dispatch an agent turn for ``prompt`` (no
 	attachments / no auto-context). The macro engine (``jarvis.chat.macros``) uses
@@ -1840,15 +1942,35 @@ def _enqueue_turn(
 	frappe.db.commit()
 
 	run_id = uuid.uuid4().hex[:12]
-	_dispatch_turn(
-		{
-			"conversation_id": conversation,
-			"message_id": msg_doc.name,
-			"run_id": run_id,
-		},
-		interactive=interactive,
-	)
-	return {"run_id": run_id, "message_id": msg_doc.name}
+	_kwargs = {
+		"conversation_id": conversation,
+		"message_id": msg_doc.name,
+		"run_id": run_id,
+	}
+	# Phase-0 admission (flag ON): macro steps AND confirm continuations run
+	# through this path. R-7 closes the continuation bypass - they take a normal
+	# admission credit and single-flight like any send, so two rapid confirms
+	# run one continuation and QUEUE the second with a visible position. The seed
+	# user Message is inserted+committed above, so this is the OAR-3 existing-seed
+	# branch. The admission result (queued/queued_position) is RETURNED (SUXI-2)
+	# so the caller (apply_action / confirm_tool) can render the standard queued
+	# chip instead of leaving the card to vanish into silence.
+	out = {"run_id": run_id, "message_id": msg_doc.name}
+	if admission.admission_enabled():
+		_adm = admission.accept_or_queue(
+			conversation=conversation,
+			run_id=run_id,
+			seed_message=msg_doc.name,
+			turn_class="interactive" if interactive else "background",
+			dispatch=lambda: _dispatch_turn(_kwargs, interactive=interactive),
+			exempt_overload=exempt_overload,
+		)
+		if not _adm.get("dispatched", True):
+			out["queued"] = True
+			out["queued_position"] = _adm.get("queued_position")
+		return out
+	_dispatch_turn(_kwargs, interactive=interactive)
+	return out
 
 
 # The continuation prompt after a human Apply/Confirm. The scaffold is
@@ -1908,7 +2030,10 @@ def enqueue_continuation(conversation: str, receipt: str, *, failed: bool = Fals
 
 	safe = _safe_label_name(receipt)
 	scaffold = _CONTINUATION_PROMPT_FAILED if failed else _CONTINUATION_PROMPT
-	return _enqueue_turn(conversation, scaffold.format(receipt=safe), hidden=True)
+	# SUXI-2 ruling: a continuation of an already-committed write is EXEMPT from
+	# the accept-time overload rejection - it always queues (with a visible
+	# position), never silently drops. The front-door senders keep backpressure.
+	return _enqueue_turn(conversation, scaffold.format(receipt=safe), hidden=True, exempt_overload=True)
 
 
 def _ensure_session_key(user: str, sess: OpenclawSession | None = None) -> str:

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -431,6 +431,20 @@ def _advance_macro(conversation_id: str, *, errored: bool) -> None:
 		frappe.log_error(title="jarvis app-learning turn hook failed", message=frappe.get_traceback())
 
 
+def _admission_settle(run_id: str, state: str, error: str | None = None) -> None:
+	"""Phase-0 admission terminal hook: mark this turn's durable Turn row
+	terminal (CAS) and promote the next queued turn. Flag-gated + best-effort
+	inside admission.settle_turn, so flag-OFF is byte-identical and a Phase-0
+	failure never affects the legacy turn. Called ONLY at the legacy terminal
+	commit points and ALWAYS outside the brittle slice region (:996-:1022)."""
+	try:
+		from jarvis.chat import admission
+
+		admission.settle_turn(run_id, state, error=error)
+	except Exception:
+		frappe.log_error(title="admission settle hook", message=frappe.get_traceback())
+
+
 def handle_chat_send(payload: dict) -> None:
 	"""Drive one agent turn end to end.
 
@@ -806,6 +820,7 @@ def handle_chat_send(payload: dict) -> None:
 			except OpenclawUnreachableError as e:
 				_publish_run_error(str(e), changed_data=False, exc=e)
 				_advance_macro(conversation_id, errored=True)
+				_admission_settle(run_id, "errored", str(e))
 				return
 			finally:
 				selfhost.clear_active_turn(tool_user, run_id)
@@ -991,6 +1006,7 @@ def handle_chat_send(payload: dict) -> None:
 				# confined to the ghost-run-already-finished case.
 				_publish_run_error(str(e), changed_data=False, exc=e)
 				_advance_macro(conversation_id, errored=True)
+				_admission_settle(run_id, "errored", str(e))
 				return
 
 			if terminal["kind"] == "relay:error":
@@ -1049,9 +1065,11 @@ def handle_chat_send(payload: dict) -> None:
 						},
 					)
 					_advance_macro(conversation_id, errored=True)
+					_admission_settle(run_id, "cancelled")
 					return
 				_publish_run_error(err_text)
 				_advance_macro(conversation_id, errored=True)
+				_admission_settle(run_id, "errored", err_text)
 				return
 			if terminal["kind"] == "relay:interrupted":
 				# Deadline, transport drop, or exhausted stream after a
@@ -1136,14 +1154,19 @@ def handle_chat_send(payload: dict) -> None:
 			# original exception that RQ should see.
 			pass
 		_advance_macro(conversation_id, errored=True)
+		# Backstop terminal: settle the Turn row errored + promote before the
+		# re-raise so a queued turn never waits on a crashed worker. Best-effort
+		# inside _admission_settle - it never masks the re-raised exception.
+		_admission_settle(run_id, "errored", f"unexpected worker error: {type(e).__name__}")
 		raise
 	# A turn can end "cleanly" (no exception) yet be an LLM-level failure — an
 	# openclaw lifecycle:error frame (quota/cooldown/provider error) ends the
 	# stream normally after _mark_errored stamped the message. So the macro's
 	# errored signal is the assistant message's error field, not the code path.
+	_turn_errored = bool(frappe.db.get_value(MSG, assistant_msg.name, "error"))
 	_advance_macro(
 		conversation_id,
-		errored=bool(frappe.db.get_value(MSG, assistant_msg.name, "error")),
+		errored=_turn_errored,
 	)
 	_publish_to_user(
 		user,
@@ -1154,6 +1177,10 @@ def handle_chat_send(payload: dict) -> None:
 			"run_id": run_id,
 		},
 	)
+	# Phase-0 admission terminal hook for the clean-exit path: done on a real
+	# reply, errored when an lifecycle:error stamped the message (the same
+	# signal _advance_macro used above). Promotes the next queued turn.
+	_admission_settle(run_id, "errored" if _turn_errored else "done")
 
 	# Latency telemetry summary (plan Phase 0). first_delta_ms is the number
 	# users feel: worker start → first visible token. pre_reply_tool_calls

--- a/jarvis/chat/turn_recovery.py
+++ b/jarvis/chat/turn_recovery.py
@@ -181,6 +181,12 @@ def _finalize(row: dict, text: str) -> None:
 	):
 		return  # another cycle already finalized this row
 	conv, owner, name = row["conversation"], row["owner"], row["name"]
+	# Phase-0 admission: a recovered turn is a terminal settlement of the
+	# conversation's dispatching Turn row - close it (done) + promote the next
+	# queued turn. Flag-gated + best-effort inside admission (self-host / flag-off
+	# are unaffected). Keyed by conversation because recovery works off Message
+	# rows and per-conversation single-flight makes the dispatching turn unique.
+	_admission_settle_conv(conv, "done")
 	publish_to_user(
 		owner,
 		{
@@ -248,6 +254,16 @@ def _finalize(row: dict, text: str) -> None:
 		)
 
 
+def _admission_settle_conv(conversation: str, state: str, error: str | None = None) -> None:
+	"""Phase-0 admission recovery hook (flag-gated + best-effort)."""
+	try:
+		from jarvis.chat import admission
+
+		admission.settle_conversation_dispatching(conversation, state, error=error)
+	except Exception:
+		frappe.log_error(title="admission recovery settle", message=frappe.get_traceback())
+
+
 def _error(row: dict, message: str) -> None:
 	if not _conditional_clear(
 		row["name"],
@@ -259,6 +275,7 @@ def _error(row: dict, message: str) -> None:
 		},
 	):
 		return
+	_admission_settle_conv(row["conversation"], "errored", message)
 	publish_to_user(
 		row["owner"],
 		{

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -235,6 +235,12 @@ scheduler_events = {
 	"cron": {
 		"*/5 * * * *": [
 			"jarvis.chat.stale_scan.scan_and_mark_errored",
+			# Phase-0 admission backstop (chat concurrency, WP-0): reclaim lost
+			# reservations, reconcile dispatching Turn rows against Message truth,
+			# age-out stale queued turns, then re-promote. Cheap no-op when no
+			# non-terminal Turn rows exist (so it costs one COUNT when the feature
+			# is off or idle).
+			"jarvis.chat.admission.sweep",
 			# Onboarding convergence safety net (review P0-2): when an LLM
 			# apply parked at "pending: admin applying config" (admin accepted
 			# it and its reconcile is converging server-side), probe
@@ -389,6 +395,13 @@ doc_events["Jarvis Wiki Page"] = {
 # save, inactive rules no-op).
 doc_events["Jarvis Personalise Question Rule"] = {
 	"on_update": "jarvis.learning.questions.on_rule_update",
+}
+
+# Phase-0 admission (chat concurrency, WP-0): a deleted conversation must not
+# leave orphaned Jarvis Chat Turn rows behind (they would linger as ghost queued/
+# dispatching rows in the admission shard). Cascade-delete them on trash.
+doc_events["Jarvis Conversation"] = {
+	"on_trash": "jarvis.chat.admission.on_conversation_trash",
 }
 
 # ---------------------------------------------------------------------------

--- a/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.json
@@ -1,0 +1,198 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:run_id",
+ "creation": "2026-07-22 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "run_id",
+  "conversation",
+  "relay_target_id",
+  "turn_class",
+  "state",
+  "version",
+  "seed_message",
+  "assistant_message",
+  "reserved",
+  "reservation_expires_at",
+  "cancel_requested",
+  "cancel_reason",
+  "was_recovered",
+  "error",
+  "dispatch_payload",
+  "enqueued_at",
+  "dispatching_at",
+  "done_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "run_id",
+   "fieldtype": "Data",
+   "label": "Run ID",
+   "reqd": 1,
+   "unique": 1,
+   "in_list_view": 1,
+   "length": 32,
+   "description": "Server-minted idempotency key for this send; immutable; the doctype name."
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Link",
+   "label": "Conversation",
+   "options": "Jarvis Conversation",
+   "reqd": 1,
+   "search_index": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Owning conversation; per-conversation single-flight scopes on it."
+  },
+  {
+   "fieldname": "relay_target_id",
+   "fieldtype": "Data",
+   "label": "Relay Target ID",
+   "reqd": 1,
+   "search_index": 1,
+   "in_standard_filter": 1,
+   "length": 140,
+   "description": "Container/gateway shard; admission credits key on it. Phase 0 uses one site-wide shard."
+  },
+  {
+   "fieldname": "turn_class",
+   "fieldtype": "Select",
+   "label": "Turn Class",
+   "options": "interactive\nbackground",
+   "default": "interactive",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Fairness class: interactive (typed/retry/continuation) vs background (File Box / app-learning)."
+  },
+  {
+   "fieldname": "state",
+   "fieldtype": "Select",
+   "label": "State",
+   "options": "queued\ndispatching\ndone\nerrored\ncancelled",
+   "default": "queued",
+   "reqd": 1,
+   "search_index": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Phase-0 state machine: queued -> dispatching -> done|errored|cancelled."
+  },
+  {
+   "fieldname": "version",
+   "fieldtype": "Int",
+   "label": "Version",
+   "default": "0",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "Optimistic-concurrency token; bumped on every transition; the actor-fence half of every CAS."
+  },
+  {
+   "fieldname": "seed_message",
+   "fieldtype": "Link",
+   "label": "Seed Message",
+   "options": "Jarvis Chat Message",
+   "reqd": 1,
+   "search_index": 1,
+   "description": "The user message row that seeded this turn."
+  },
+  {
+   "fieldname": "assistant_message",
+   "fieldtype": "Link",
+   "label": "Assistant Message",
+   "options": "Jarvis Chat Message",
+   "description": "The assistant row deltas stream into; null until the worker creates the placeholder."
+  },
+  {
+   "fieldname": "reserved",
+   "fieldtype": "Check",
+   "label": "Reserved",
+   "default": "0",
+   "description": "Holds one admission credit. In Phase 0 the dispatching row itself is the reservation."
+  },
+  {
+   "fieldname": "reservation_expires_at",
+   "fieldtype": "Datetime",
+   "label": "Reservation Expires At",
+   "search_index": 1,
+   "description": "A dispatching turn whose enqueue was lost is returned to the queue after this instant (crashed-enqueue guard)."
+  },
+  {
+   "fieldname": "cancel_requested",
+   "fieldtype": "Check",
+   "label": "Cancel Requested",
+   "default": "0",
+   "description": "Set by stop_run on an in-flight turn; the legacy worker's aborted-terminal settles it."
+  },
+  {
+   "fieldname": "cancel_reason",
+   "fieldtype": "Small Text",
+   "label": "Cancel Reason",
+   "description": "Recorded reason when the sweep system-cancels an aged-out queued turn."
+  },
+  {
+   "fieldname": "was_recovered",
+   "fieldtype": "Check",
+   "label": "Was Recovered",
+   "default": "0",
+   "description": "Set when the sweep re-dispatched or reconciled this turn."
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Small Text",
+   "label": "Error",
+   "description": "User-facing error payload on errored terminal. Mirrors Message.error."
+  },
+  {
+   "fieldname": "dispatch_payload",
+   "fieldtype": "Long Text",
+   "label": "Dispatch Payload",
+   "description": "JSON of the extra enqueue kwargs (attachments/context) so a queued turn re-dispatches with them on promotion."
+  },
+  {
+   "fieldname": "enqueued_at",
+   "fieldtype": "Datetime",
+   "label": "Enqueued At",
+   "in_list_view": 1,
+   "description": "Stamped at (none)->queued; queue_wait_ms baseline."
+  },
+  {
+   "fieldname": "dispatching_at",
+   "fieldtype": "Datetime",
+   "label": "Dispatching At",
+   "in_list_view": 1,
+   "description": "Stamped at queued->dispatching; admission-credit confirm point."
+  },
+  {
+   "fieldname": "done_at",
+   "fieldtype": "Datetime",
+   "label": "Done At",
+   "in_list_view": 1,
+   "description": "Stamped at the terminal transition; retention/GC timestamp."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-22 00:00:00.000000",
+ "module": "Jarvis",
+ "name": "Jarvis Chat Turn",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Jarvis Admin"
+  }
+ ],
+ "quick_entry": 0,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.py
+++ b/jarvis/jarvis/doctype/jarvis_chat_turn/jarvis_chat_turn.py
@@ -1,0 +1,18 @@
+"""Jarvis Chat Turn DocType controller.
+
+Server-owned durable turn record for Phase-0 admission control
+(jarvis.chat.admission). Every mutation goes through a server path with
+``ignore_permissions=True`` and version-CAS discipline; there is no
+end-user create/write/delete. The controller is intentionally minimal -
+all invariants are enforced by the admission module's CAS statements, not
+by ORM validation (the hot path never uses ``save()``).
+"""
+
+import frappe
+from frappe.model.document import Document
+
+
+class JarvisChatTurn(Document):
+	# Minimal controller. run_id is the autoname field (name == run_id), so a
+	# duplicate send collides on primary-key insert - the idempotency guard.
+	pass

--- a/jarvis/jarvis/doctype/jarvis_relay_pump/jarvis_relay_pump.json
+++ b/jarvis/jarvis/doctype/jarvis_relay_pump/jarvis_relay_pump.json
@@ -1,0 +1,45 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:relay_target_id",
+ "creation": "2026-07-22 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "relay_target_id"
+ ],
+ "fields": [
+  {
+   "fieldname": "relay_target_id",
+   "fieldtype": "Data",
+   "label": "Relay Target ID",
+   "reqd": 1,
+   "unique": 1,
+   "in_list_view": 1,
+   "length": 140,
+   "description": "The shard key; the container/gateway this pump serves. Phase-0 minimal control row: the admission serializer takes SELECT ... FOR UPDATE on it. Pump fields arrive in WP-1."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-22 00:00:00.000000",
+ "module": "Jarvis",
+ "name": "Jarvis Relay Pump",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "role": "Jarvis Admin"
+  }
+ ],
+ "quick_entry": 0,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_relay_pump/jarvis_relay_pump.py
+++ b/jarvis/jarvis/doctype/jarvis_relay_pump/jarvis_relay_pump.py
@@ -1,0 +1,15 @@
+"""Jarvis Relay Pump DocType controller.
+
+Phase-0 minimal per-shard control row. The admission serializer
+(jarvis.chat.admission) takes ``SELECT ... FOR UPDATE`` on this row to
+serialize the credit read + admit decision across all senders and the
+promoter for a given ``relay_target_id`` (OAR-1). Lease/epoch/pump fields
+arrive additively in WP-1.
+"""
+
+import frappe
+from frappe.model.document import Document
+
+
+class JarvisRelayPump(Document):
+	pass

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -31,3 +31,4 @@ jarvis.patches.v2_02_unique_model_usage_row
 jarvis.patches.v2_03_backfill_finding_result_class
 jarvis.patches.v2_03_backfill_installation_activation
 jarvis.patches.v2_03_backfill_approval_provenance
+jarvis.patches.v2_04_chat_turn_admission_indexes

--- a/jarvis/patches/v2_04_chat_turn_admission_indexes.py
+++ b/jarvis/patches/v2_04_chat_turn_admission_indexes.py
@@ -1,0 +1,24 @@
+"""Composite indexes on Jarvis Chat Turn for the Phase-0 admission query
+shapes (jarvis.chat.admission). Frappe's doctype JSON only expresses
+single-column indexes; the admission COUNT/scan queries want these
+composites:
+
+  (state, relay_target_id) - the shard inflight COUNT + queued scan.
+  (conversation, state)    - the per-conversation single-flight lookup.
+  (reserved, reservation_expires_at) - the crashed-enqueue reclaim sweep.
+
+add_index is idempotent (no-ops when the index already exists), so this is
+safe to re-run on an upgraded site.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.table_exists("Jarvis Chat Turn"):
+		return
+	frappe.db.add_index("Jarvis Chat Turn", ["state", "relay_target_id"], index_name="state_relay")
+	frappe.db.add_index("Jarvis Chat Turn", ["conversation", "state"], index_name="conv_state")
+	frappe.db.add_index(
+		"Jarvis Chat Turn", ["reserved", "reservation_expires_at"], index_name="reserved_expiry"
+	)

--- a/jarvis/tests/harness/README.md
+++ b/jarvis/tests/harness/README.md
@@ -1,0 +1,74 @@
+# WP-2 chat-concurrency measurement harness (Stage A)
+
+New-files-only measurement machinery for the owner's six production criteria
+(C1–C6, `BUILD-DIRECTIVE.md §1`) + the differential-trace corpus. It measures
+the **current (legacy, worker-per-turn)** chat transport against a deterministic
+local WS gateway, so the Relay Pump (WP-1) has a clean baseline to beat.
+
+Zero product-code edits. Everything lives under `jarvis/tests/harness/`.
+
+## What's here
+
+| file | role |
+|---|---|
+| `fake_gateway.py` | Real `websockets` server on `127.0.0.1:<port>` speaking the openclaw protocol subset (S2). Deterministic transcript playback; configurable token cadence, ack delay, ack-timeout, WS-drop, and a per-session-FIFO → global-lane (`maxConcurrent=4`) admission sim that produces the C4 dwell. Ack fires BEFORE lane admission (S2 (a)). |
+| `transcripts.py` + `fixtures/transcripts/*.json` | The 8 scripted transcripts (success, tool-heavy, confirmation-card, overflow-compaction, abort, ack-timeout, ws-drop, recovered) as fixture data. `python -m ...transcripts` re-exports the JSON. |
+| `trace_recorder.py` | Per-turn timestamped trace (job lifecycle + gateway ack/lane/first-frame/terminal + REAL realtime publishes + DB-write summaries) → JSON. Each run gets a timing-free `signature` = the Stage-B equivalence key. |
+| `turn_runner.py` | The faithful legacy turn: REAL `OpenclawSession` transport → REAL `_AssistantContentBatcher` + `_handle_event` (real DB commits + real publish fan-out). `WorkerPool(size=2)` = the 2-background-worker starvation bed. |
+| `probes.py` | Metric probes: first_token (from submit + from send), queue_wait, flush-gap (C3) + publish-gap, dwell (C4), the p50/p95/p99 summarizer, a REAL RQ canary (short+long every 10s) + Desk HTTP probe (C6), a real background flood, and stop-click→visible-stop (SUX-12). |
+| `run_baseline.py` | The orchestrator: all scenarios, the flag ON/OFF incident via the REAL `accept_or_queue` chokepoint, machine-readable + human results. |
+| `probe_real_gateway.py` | R-21 guard: read-only assertion of the protocol facts against the pinned openclaw 2026.6.8 image in a THROWAWAY `--network none --rm` container. |
+
+## How to re-run everything (the pilot will)
+
+All commands from the bench root `/home/vignesh/frappe-bench`. The
+`JARVIS_ALLOW_REAL_NETWORK_IN_TESTS=1` env var is **required**: the jarvis
+test-network guard blocks even the loopback socket to the fake gateway
+(`127.0.0.1`). The harness only ever connects to that loopback fake — never a
+real tenant.
+
+### 1. The full legacy baseline (writes JSON + traces to `--out`)
+
+```bash
+JARVIS_ALLOW_REAL_NETWORK_IN_TESTS=1 \
+  env/bin/python apps/jarvis/jarvis/tests/harness/run_baseline.py --full \
+  --out /home/vignesh/jarvis/jarvis-chat-concurrency-design/implementation/wp-2/baseline
+```
+
+Flags: `--quick` (small N for iteration), `--full` (recorded-baseline N),
+`--only concurrency,burst,storm,canary,smoke` (subset), `--site` (default
+`patterntest.localhost`). Runtime ≈ 6–7 min full, ≈ 90 s quick-minus-canary.
+
+Outputs in `--out`:
+- `baseline_results.json` — every scenario's p50/p95/p99 + meta.
+- `trace_*.json` — the per-turn trace corpus (Stage-B diff unit).
+- `r21_real_gateway_probe.json` — the R-21 result.
+
+### 2. The R-21 real-gateway guard (once per run; needs docker + the image)
+
+```bash
+env/bin/python apps/jarvis/jarvis/tests/harness/probe_real_gateway.py
+```
+
+### 3. Re-export the transcript fixtures
+
+```bash
+env/bin/python -c "from jarvis.tests.harness import transcripts as t; t.dump_fixtures()"
+```
+
+## Fidelity model (read before trusting a number)
+
+- **Transport / relay / batching = REAL bench code** over a real socket. First-token,
+  flush-gap (C3), dwell (C4), ack, terminal outcomes are all real.
+- **The 2-worker pool is a SIMULATION** (a bounded thread executor running the real
+  relay path), not real RQ/supervisor. It reproduces worker-per-turn starvation
+  exactly, which is the point; but it does NOT model RQ scheduler latency or
+  fork-per-job connect cost. See the baseline report's caveats.
+- **Phase-0 admission (flag ON) is driven through the REAL `accept_or_queue`** — the
+  admit/queue/reject decisions, cap-4, and promotion-on-terminal are genuine.
+- **Connect cost is localhost-cheap** (~4 ms) vs a real 50–200 ms WAN connect; the
+  harness measures the streaming/batching layer faithfully, not real connect.
+- Nothing durable is mutated: admission flag + cap are process-only overrides,
+  `ensure_paired` is stubbed process-wide, the gateway URL is passed straight to the
+  transport (Jarvis Settings is never written). Teardown restores everything and
+  clears the harness's own rows (+ the site-wide shard baseline on patterntest).

--- a/jarvis/tests/harness/__init__.py
+++ b/jarvis/tests/harness/__init__.py
@@ -1,0 +1,66 @@
+"""WP-2 chat-concurrency measurement harness (Stage A: legacy baseline).
+
+NEW FILES ONLY — this package edits no product code. It measures the CURRENT
+(legacy, worker-per-turn) chat transport against a deterministic local WS
+gateway that reproduces the openclaw protocol subset the bench uses (S2), so
+the owner's six production criteria (C1–C6, BUILD-DIRECTIVE §1) get a clean
+baseline the Relay Pump must later beat.
+
+Layers of fidelity (stated up front, and again in every report):
+
+  * Transport / relay / batching — REAL bench code. The harness drives the
+    real ``jarvis.chat.openclaw_client.OpenclawSession`` (real handshake,
+    ``chat_send``, ``relay_turn_events``) over a real socket into
+    ``fake_gateway.FakeGateway``, and feeds the frames through the real
+    ``jarvis.chat.turn_handler._AssistantContentBatcher`` +
+    ``_handle_event`` (real DB writes + real ``publish_to_user`` fan-out).
+    Every millisecond of streaming, batching and DB-commit cadence is real.
+
+  * Concurrency / worker pool — SIMULATED (a bounded thread executor), NOT
+    real RQ. The legacy model is worker-per-turn: each worker is held for a
+    whole turn. A size-2 pool therefore reproduces the exact 2-background-
+    worker starvation the pump removes. This is the ``2-worker config
+    simulated`` the brief calls for. Caveats live in the baseline report.
+
+Nothing here mutates durable bench state. The admission flag is overridden
+per-process only; ``ensure_paired`` is stubbed process-wide; the gateway URL
+is passed directly to the transport (Jarvis Settings is never written).
+"""
+
+from __future__ import annotations
+
+import os
+
+BENCH_ROOT = "/home/vignesh/frappe-bench"
+SITES_PATH = os.path.join(BENCH_ROOT, "sites")
+DEFAULT_SITE = "patterntest.localhost"
+
+# Fixture user the harness owns (mirrors the WP-0 admission-test fixture user
+# pattern so cleanup is symmetrical and site-wide-shard-safe).
+HARNESS_USER = "jarvis-harness@example.com"
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TURN = "Jarvis Chat Turn"
+PUMP = "Jarvis Relay Pump"
+
+_frappe_ready = False
+
+
+def bootstrap(site: str = DEFAULT_SITE):
+	"""Init + connect frappe for a standalone harness script (idempotent).
+
+	Standalone scripts must run with the sites directory resolvable; we chdir
+	into it so ``frappe.init`` finds the site and writes its logs under the
+	site path (matching how ``bench execute`` behaves).
+	"""
+	global _frappe_ready
+	import frappe
+
+	if _frappe_ready and getattr(frappe.local, "site", None) == site:
+		return frappe
+	os.chdir(SITES_PATH)
+	frappe.init(site=site)
+	frappe.connect()
+	_frappe_ready = True
+	return frappe

--- a/jarvis/tests/harness/fake_gateway.py
+++ b/jarvis/tests/harness/fake_gateway.py
@@ -1,0 +1,479 @@
+"""FakeGateway — a local WS server speaking the openclaw protocol subset the
+bench uses, with deterministic transcript playback and configurable faults.
+
+It is a REAL ``websockets`` server on ``127.0.0.1:<port>`` (reachable by the
+real ``jarvis.chat.openclaw_client.OpenclawSession`` over a real socket), so
+the whole bench transport + relay path is exercised — no frame mocking.
+
+Protocol subset (grounded in spike S2 + the transport client):
+
+  handshake        connect.challenge event -> connect req -> hello-ok res
+  sessions.create  -> {"key": ...}
+  sessions.patch   -> ok            (per-conversation model override)
+  sessions.get     -> {"messages": [...]}   (seq watermark / recovery tail)
+  chat.history     -> {"messages": [...]}   (recovery snapshot)
+  sessions.list    -> {"sessions": [{"key","hasActiveRun"}...]}
+  sessions.messages.subscribe -> ok
+  chat.send        -> ACK {"runId","status"} BEFORE lane admission (S2 (a)),
+                      then broadcast agent frames + a terminal chat event
+  chat.abort       -> ok, and the in-flight run terminates "aborted"
+
+Lane semantics (S2 (a)+(d)): the ack fires at ACCEPT time, before the run is
+enqueued. Playback then goes per-session FIFO -> a global ``main`` lane capped
+at ``max_concurrent`` (default 4). The gap between ack and the first streamed
+frame is the C4 dwell proxy; it grows when > max_concurrent runs contend.
+
+Config knobs (per gateway, overridable per-run via ``arm``):
+  cadence_ms          spacing between streamed frames (token cadence)
+  ack_delay_ms        normal ack latency
+  ack_timeout_hold_ms hold before responding when ack_behavior == "timeout"
+  max_concurrent      global main-lane cap (openclaw default 4)
+  lane_sim            enable the FIFO->lane admission gating (dwell)
+  lane_dwell_ms       extra artificial dwell added while holding a lane slot
+                      (simulate a busy container even below the cap)
+
+Everything is deterministic given the same transcripts, cadence and arm order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+
+import websockets
+
+from jarvis.tests.harness import transcripts as _transcripts
+
+
+@dataclass
+class RunTimeline:
+	run_id: str
+	session_key: str = ""
+	transcript: str = ""
+	ack_ts: float | None = None  # monotonic; ack sent (accept time)
+	lane_admit_ts: float | None = None  # monotonic; admitted to main lane
+	first_frame_ts: float | None = None  # monotonic; first streamed frame
+	terminal_ts: float | None = None
+	terminal_kind: str = ""
+	frames_sent: int = 0
+	aborted: bool = False
+
+	def dwell_ms(self) -> float | None:
+		if self.ack_ts is None or self.lane_admit_ts is None:
+			return None
+		return (self.lane_admit_ts - self.ack_ts) * 1000.0
+
+	def ack_to_first_frame_ms(self) -> float | None:
+		if self.ack_ts is None or self.first_frame_ts is None:
+			return None
+		return (self.first_frame_ts - self.ack_ts) * 1000.0
+
+
+class FakeGateway:
+	def __init__(
+		self,
+		*,
+		cadence_ms: float = 25.0,
+		ack_delay_ms: float = 2.0,
+		ack_timeout_hold_ms: float = 2000.0,
+		max_concurrent: int = 4,
+		lane_sim: bool = True,
+		lane_dwell_ms: float = 0.0,
+		host: str = "127.0.0.1",
+	):
+		self.cadence_ms = cadence_ms
+		self.ack_delay_ms = ack_delay_ms
+		self.ack_timeout_hold_ms = ack_timeout_hold_ms
+		self.max_concurrent = max_concurrent
+		self.lane_sim = lane_sim
+		self.lane_dwell_ms = lane_dwell_ms
+		self.host = host
+
+		self.port: int | None = None
+		self._loop: asyncio.AbstractEventLoop | None = None
+		self._thread: threading.Thread | None = None
+		self._ready = threading.Event()
+		self._stop = None  # asyncio.Future set in loop
+
+		# cross-thread state
+		self._state_lock = threading.Lock()
+		self._armed: dict[str, dict] = {}  # run_id -> {transcript, overrides}
+		self._timelines: dict[str, RunTimeline] = {}
+		self._sessions: dict[str, dict] = {}  # session_key -> {has_active_run}
+
+		# in-loop lane state (created lazily inside the loop)
+		self._lane_sema: asyncio.Semaphore | None = None
+		self._session_locks: dict[str, asyncio.Lock] = {}
+		self._abort_events: dict[str, asyncio.Event] = {}
+		self._active_main = 0  # observed concurrent lane occupancy (for assertions)
+		self._max_observed_main = 0
+
+	# ---- lifecycle --------------------------------------------------------
+
+	@property
+	def ws_url(self) -> str:
+		return f"ws://{self.host}:{self.port}"
+
+	def start(self, timeout: float = 5.0) -> "FakeGateway":
+		self._thread = threading.Thread(target=self._run, name="fake-gateway", daemon=True)
+		self._thread.start()
+		if not self._ready.wait(timeout):
+			raise RuntimeError("FakeGateway failed to start")
+		return self
+
+	def stop(self) -> None:
+		if self._loop and self._stop and not self._stop.done():
+			self._loop.call_soon_threadsafe(self._stop.set_result, True)
+		if self._thread:
+			self._thread.join(timeout=5)
+
+	def _run(self) -> None:
+		loop = asyncio.new_event_loop()
+		asyncio.set_event_loop(loop)
+		self._loop = loop
+		loop.run_until_complete(self._serve())
+
+	async def _serve(self) -> None:
+		self._lane_sema = asyncio.Semaphore(self.max_concurrent)
+		self._stop = self._loop.create_future()
+		server = await websockets.serve(self._handler, self.host, 0, max_size=8 * 1024 * 1024)
+		self.port = server.sockets[0].getsockname()[1]
+		self._ready.set()
+		try:
+			await self._stop
+		finally:
+			server.close()
+			await server.wait_closed()
+
+	async def _handler(self, ws):
+		send_lock = asyncio.Lock()
+
+		async def send_json(obj: dict) -> None:
+			async with send_lock:
+				await ws.send(json.dumps(obj))
+
+		# 1. challenge
+		await send_json(
+			{"type": "event", "event": "connect.challenge", "payload": {"nonce": uuid.uuid4().hex}}
+		)
+
+		try:
+			async for raw in ws:
+				try:
+					frame = json.loads(raw)
+				except json.JSONDecodeError:
+					continue
+				if frame.get("type") != "req":
+					continue
+				await self._dispatch(ws, send_json, frame)
+		except websockets.ConnectionClosed:
+			return
+
+	async def _dispatch(self, ws, send_json, frame: dict) -> None:
+		method = frame.get("method")
+		rid = frame.get("id")
+		params = frame.get("params") or {}
+
+		if method == "connect":
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": {}})
+			return
+		if method == "sessions.create":
+			key = f"sess-{uuid.uuid4().hex[:12]}"
+			with self._state_lock:
+				self._sessions[key] = {"has_active_run": False}
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": {"key": key}})
+			return
+		if method in ("sessions.patch", "sessions.messages.subscribe", "sessions.delete"):
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": {}})
+			return
+		if method in ("sessions.get", "chat.history"):
+			key = params.get("key") or params.get("sessionKey")
+			await send_json(
+				{"type": "res", "id": rid, "ok": True, "payload": {"messages": self._history_for(key)}}
+			)
+			return
+		if method == "sessions.list":
+			with self._state_lock:
+				rows = [{"key": k, "hasActiveRun": v["has_active_run"]} for k, v in self._sessions.items()]
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": {"sessions": rows}})
+			return
+		if method == "chat.abort":
+			sk = params.get("sessionKey")
+			run_id = params.get("runId")
+			self._signal_abort(sk, run_id)
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": {}})
+			return
+		if method == "chat.send":
+			await self._handle_chat_send(ws, send_json, rid, params)
+			return
+		# default ok for anything unmodelled
+		await send_json({"type": "res", "id": rid, "ok": True, "payload": {}})
+
+	# ---- chat.send: ack (pre-lane) then playback --------------------------
+
+	async def _handle_chat_send(self, ws, send_json, rid: str, params: dict) -> None:
+		run_id = params.get("idempotencyKey")
+		session_key = params.get("sessionKey")
+		armed = self._get_armed(run_id)
+		tname = armed["transcript"]
+		transcript = _transcripts.get(tname)
+		overrides = armed.get("overrides") or {}
+		ack_behavior = overrides.get("ack_behavior") or transcript.get("ack_behavior", "normal")
+
+		tl = RunTimeline(run_id=run_id, session_key=session_key, transcript=tname)
+		with self._state_lock:
+			self._timelines[run_id] = tl
+			if session_key in self._sessions:
+				self._sessions[session_key]["has_active_run"] = True
+
+		if ack_behavior == "timeout":
+			# Hold the ack past the client window; the bench parks. Still finish
+			# server-side (the transcript "completed" but no one is listening on
+			# the ack — the run would be recoverable from the durable tail).
+			await asyncio.sleep(self.ack_timeout_hold_ms / 1000.0)
+
+		ack_payload = dict(transcript.get("ack") or {"status": "started"})
+		ack_payload["runId"] = run_id
+		tl.ack_ts = time.monotonic()
+		try:
+			await send_json({"type": "res", "id": rid, "ok": True, "payload": ack_payload})
+		except websockets.ConnectionClosed:
+			return
+
+		if ack_behavior == "timeout":
+			# The client already gave up; mark terminal for bookkeeping, no stream.
+			tl.terminal_kind = "ack-timeout(server-late-ack)"
+			tl.terminal_ts = time.monotonic()
+			self._clear_active(session_key)
+			return
+
+		# Playback runs as its own task so the read loop keeps serving
+		# chat.abort while the stream is in flight.
+		self._loop.create_task(self._playback(ws, send_json, tl, transcript, overrides))
+
+	async def _playback(self, ws, send_json, tl: RunTimeline, transcript: dict, overrides: dict) -> None:
+		session_key = tl.session_key
+		run_id = tl.run_id
+		cadence = overrides.get("cadence_ms", self.cadence_ms) / 1000.0
+		lane_dwell = overrides.get("lane_dwell_ms", self.lane_dwell_ms) / 1000.0
+		abort_ev = self._get_abort_event(run_id)
+
+		# per-session FIFO -> global main lane (S2). Ack already fired above.
+		sess_lock = self._get_session_lock(session_key)
+		try:
+			if self.lane_sim:
+				async with sess_lock:
+					async with self._lane_sema:
+						self._enter_main()
+						tl.lane_admit_ts = time.monotonic()
+						if lane_dwell:
+							await asyncio.sleep(lane_dwell)
+						await self._stream_frames(ws, send_json, tl, transcript, overrides, cadence, abort_ev)
+						self._exit_main()
+			else:
+				tl.lane_admit_ts = time.monotonic()
+				await self._stream_frames(ws, send_json, tl, transcript, overrides, cadence, abort_ev)
+		except websockets.ConnectionClosed:
+			tl.terminal_kind = tl.terminal_kind or "ws-closed"
+			tl.terminal_ts = time.monotonic()
+		finally:
+			self._clear_active(session_key)
+
+	async def _stream_frames(self, ws, send_json, tl, transcript, overrides, cadence, abort_ev) -> None:
+		run_id = tl.run_id
+		inject = overrides.get("inject") or transcript.get("inject") or {}
+		drop_after = inject.get("drop_after_frame")
+		frames = transcript.get("frames") or []
+
+		for idx, fr in enumerate(frames):
+			if abort_ev.is_set():
+				await self._emit_terminal(send_json, tl, {"kind": "aborted"})
+				return
+			op = fr.get("op")
+			if op == "pause":
+				await asyncio.sleep(fr.get("ms", 0) / 1000.0)
+				continue
+
+			await asyncio.sleep(cadence)
+			payload = self._frame_payload(run_id, op, fr)
+			if payload is None:
+				continue
+			if tl.first_frame_ts is None:
+				tl.first_frame_ts = time.monotonic()
+			await send_json({"type": "event", "event": "agent", "payload": payload})
+			tl.frames_sent += 1
+
+			if drop_after is not None and idx >= drop_after:
+				# WS-drop injection: close the socket mid-stream.
+				tl.terminal_kind = "ws-drop"
+				tl.terminal_ts = time.monotonic()
+				await ws.close(code=1011, reason="fake-gateway injected drop")
+				return
+
+		# normal terminal
+		if abort_ev.is_set():
+			await self._emit_terminal(send_json, tl, {"kind": "aborted"})
+			return
+		await self._emit_terminal(
+			send_json, tl, transcript.get("terminal") or {"kind": "final", "text": None}
+		)
+
+	def _frame_payload(self, run_id: str, op: str, fr: dict) -> dict | None:
+		if op == "assistant":
+			return {
+				"runId": run_id,
+				"stream": "assistant",
+				"data": {"text": fr.get("text", ""), "delta": fr.get("delta", "")},
+			}
+		if op == "tool_start":
+			return {
+				"runId": run_id,
+				"stream": "item",
+				"data": {
+					"kind": "tool",
+					"phase": "start",
+					"name": fr.get("name"),
+					"toolCallId": fr.get("call_id"),
+					"title": fr.get("title"),
+				},
+			}
+		if op == "tool_end":
+			return {
+				"runId": run_id,
+				"stream": "item",
+				"data": {
+					"kind": "tool",
+					"phase": "end",
+					"name": fr.get("name"),
+					"toolCallId": fr.get("call_id"),
+					"status": fr.get("status", "completed"),
+				},
+			}
+		if op == "lifecycle_error":
+			return {
+				"runId": run_id,
+				"stream": "lifecycle",
+				"data": {"phase": "error", "error": fr.get("error")},
+			}
+		return None
+
+	async def _emit_terminal(self, send_json, tl: RunTimeline, terminal: dict) -> None:
+		kind = terminal.get("kind", "final")
+		run_id = tl.run_id
+		session_key = tl.session_key
+		payload = {"runId": run_id, "sessionKey": session_key}
+		if kind == "final":
+			text = terminal.get("text")
+			content = [{"type": "text", "text": text}] if text else []
+			payload.update({"state": "final", "message": {"content": content}})
+		elif kind == "failed_final":
+			payload.update({"state": "final", "message": {"content": [], "stopReason": "error"}})
+		elif kind == "aborted":
+			tl.aborted = True
+			payload.update({"state": "aborted", "errorMessage": "aborted by user"})
+		else:  # error
+			payload.update(
+				{
+					"state": terminal.get("state", "error"),
+					"errorMessage": terminal.get("errorMessage", "run error"),
+				}
+			)
+		tl.terminal_kind = kind
+		tl.terminal_ts = time.monotonic()
+		try:
+			await send_json({"type": "event", "event": "chat", "payload": payload})
+		except websockets.ConnectionClosed:
+			pass
+
+	# ---- helpers ----------------------------------------------------------
+
+	def _history_for(self, session_key: str | None) -> list:
+		# Used for the pre-send seq watermark (empty tail => watermark 0) and,
+		# for the "recovered" fixture, the post-drop recovery snapshot: if a run
+		# on this session was armed with inject.recover_via == "history", the
+		# durable transcript still holds the complete answer, so surface it as a
+		# role=assistant tail message the way sessions.get / chat.history would
+		# (openclaw stamps __openclaw:{seq,id}). Stage-B recovery probes read it.
+		if not session_key:
+			return []
+		with self._state_lock:
+			runs = [tl for tl in self._timelines.values() if tl.session_key == session_key]
+			armed = dict(self._armed)
+		seq = 1
+		tail: list = []
+		for tl in runs:
+			inject = (armed.get(tl.run_id) or {}).get("overrides", {}).get("inject")
+			if not inject:
+				inject = (
+					_transcripts.get(tl.transcript).get("inject")
+					if tl.transcript in _transcripts.TRANSCRIPTS
+					else None
+				)
+			if inject and inject.get("recover_via") == "history" and inject.get("final_text"):
+				tail.append(
+					{
+						"role": "assistant",
+						"content": inject["final_text"],
+						"__openclaw": {"seq": seq, "id": f"rec-{tl.run_id}"},
+					}
+				)
+				seq += 1
+		return tail
+
+	def _get_armed(self, run_id: str) -> dict:
+		with self._state_lock:
+			return self._armed.get(run_id) or {"transcript": "success", "overrides": {}}
+
+	def _get_abort_event(self, run_id: str) -> asyncio.Event:
+		ev = self._abort_events.get(run_id)
+		if ev is None:
+			ev = asyncio.Event()
+			self._abort_events[run_id] = ev
+		return ev
+
+	def _get_session_lock(self, session_key: str) -> asyncio.Lock:
+		lock = self._session_locks.get(session_key)
+		if lock is None:
+			lock = asyncio.Lock()
+			self._session_locks[session_key] = lock
+		return lock
+
+	def _signal_abort(self, session_key: str | None, run_id: str | None) -> None:
+		# Called from the read loop (in-loop). Set the abort event(s).
+		if run_id and run_id in self._abort_events:
+			self._abort_events[run_id].set()
+			return
+		# abort-all-on-session: signal every armed run on this session
+		for rid, tl in list(self._timelines.items()):
+			if tl.session_key == session_key and tl.terminal_ts is None:
+				self._get_abort_event(rid).set()
+
+	def _enter_main(self) -> None:
+		self._active_main += 1
+		self._max_observed_main = max(self._max_observed_main, self._active_main)
+
+	def _exit_main(self) -> None:
+		self._active_main -= 1
+
+	def _clear_active(self, session_key: str | None) -> None:
+		with self._state_lock:
+			if session_key in self._sessions:
+				self._sessions[session_key]["has_active_run"] = False
+
+	# ---- public arm / introspection (thread-safe) -------------------------
+
+	def arm(self, run_id: str, transcript: str = "success", **overrides) -> None:
+		"""Register the transcript (and per-run overrides) to play for run_id."""
+		with self._state_lock:
+			self._armed[run_id] = {"transcript": transcript, "overrides": overrides}
+
+	def timeline(self, run_id: str) -> RunTimeline | None:
+		with self._state_lock:
+			return self._timelines.get(run_id)
+
+	def max_observed_main(self) -> int:
+		return self._max_observed_main

--- a/jarvis/tests/harness/fixtures/transcripts/abort.json
+++ b/jarvis/tests/harness/fixtures/transcripts/abort.json
@@ -1,0 +1,48 @@
+{
+  "name": "abort",
+  "description": "Partial stream then a user stop; terminal aborted (also emitted on chat.abort). Drives the stop-click->visible-stop probe.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "Starting the",
+      "delta": "Starting the"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now,",
+      "delta": " export now,"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now, this will",
+      "delta": " this will"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now, this will take a",
+      "delta": " take a"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now, this will take a few moments",
+      "delta": " few moments"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now, this will take a few moments as I",
+      "delta": " as I"
+    },
+    {
+      "op": "assistant",
+      "text": "Starting the export now, this will take a few moments as I gather",
+      "delta": " gather"
+    }
+  ],
+  "terminal": {
+    "kind": "aborted"
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/ack-timeout.json
+++ b/jarvis/tests/harness/fixtures/transcripts/ack-timeout.json
@@ -1,0 +1,164 @@
+{
+  "name": "ack-timeout",
+  "description": "chat.send ack delayed past the client window -> OpenclawUnreachable(ack-timeout) -> bench parks; the transcript still completes server-side.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "timeout",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "Here is",
+      "delta": "Here is"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary",
+      "delta": " the summary"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked",
+      "delta": " you asked"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The",
+      "delta": " for. The"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue",
+      "delta": " three overdue"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total",
+      "delta": " invoices total"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two",
+      "delta": " forty two"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees",
+      "delta": " thousand rupees"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two",
+      "delta": " across two"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and",
+      "delta": " customers, and"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest",
+      "delta": " the oldest"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen",
+      "delta": " is eighteen"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past",
+      "delta": " days past"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due",
+      "delta": " its due"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I",
+      "delta": " date. I"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise",
+      "delta": " would prioritise"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme",
+      "delta": " the Acme"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first",
+      "delta": " invoice first"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it",
+      "delta": " because it"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both",
+      "delta": " is both"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest",
+      "delta": " the largest"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the",
+      "delta": " and the"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then",
+      "delta": " oldest, then"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up",
+      "delta": " follow up"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the",
+      "delta": " on the"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller",
+      "delta": " two smaller"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices",
+      "delta": " Globex invoices"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in",
+      "delta": " together in"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single",
+      "delta": " a single"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single reminder.",
+      "delta": " reminder."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single reminder."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/confirmation-card.json
+++ b/jarvis/tests/harness/fixtures/transcripts/confirmation-card.json
@@ -1,0 +1,79 @@
+{
+  "name": "confirmation-card",
+  "description": "Assistant proposes a change and opens a confirmation card (jarvis__update_doc, confirm-gated); terminal final leaves the card awaiting the user.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "I have",
+      "delta": "I have"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a",
+      "delta": " prepared a"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder",
+      "delta": " payment reminder"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the",
+      "delta": " for the"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue",
+      "delta": " Acme overdue"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please",
+      "delta": " invoice. Please"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the",
+      "delta": " review the"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the draft below",
+      "delta": " draft below"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the draft below and confirm",
+      "delta": " and confirm"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the draft below and confirm before I",
+      "delta": " before I"
+    },
+    {
+      "op": "assistant",
+      "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the draft below and confirm before I send it.",
+      "delta": " send it."
+    },
+    {
+      "op": "tool_start",
+      "name": "jarvis__update_doc",
+      "call_id": "c1",
+      "title": "update_doc Payment Reminder (needs confirm)"
+    },
+    {
+      "op": "pause",
+      "ms": 120
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "I have prepared a payment reminder for the Acme overdue invoice. Please review the draft below and confirm before I send it."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/overflow-compaction.json
+++ b/jarvis/tests/harness/fixtures/transcripts/overflow-compaction.json
@@ -1,0 +1,127 @@
+{
+  "name": "overflow-compaction",
+  "description": "Mid-stream context-overflow lifecycle error, a compaction pause, then the answer streams and terminal final. NOTE: on the MANAGED relay path relay_turn_events drops lifecycle frames, so the bench sees a longer turn that resolves to final (openclaw auto-compacts internally); the run:recovering UX is a self-host-path (stream_agent_turn) behavior. The lifecycle_error frame is retained so the self-host consumer + Stage-B differential still exercise it.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "Reading the",
+      "delta": "Reading the"
+    },
+    {
+      "op": "assistant",
+      "text": "Reading the full thread",
+      "delta": " full thread"
+    },
+    {
+      "op": "assistant",
+      "text": "Reading the full thread history to",
+      "delta": " history to"
+    },
+    {
+      "op": "assistant",
+      "text": "Reading the full thread history to answer accurately.",
+      "delta": " answer accurately."
+    },
+    {
+      "op": "lifecycle_error",
+      "error": "Context overflow: prompt too large for the model; auto-compacting"
+    },
+    {
+      "op": "pause",
+      "ms": 600
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for",
+      "delta": "Thanks for"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014",
+      "delta": " waiting \u2014"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted",
+      "delta": " I compacted"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older",
+      "delta": " the older"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and",
+      "delta": " context and"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is",
+      "delta": " here is"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer:",
+      "delta": " the answer:"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation",
+      "delta": " the reconciliation"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for",
+      "delta": " matches for"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but",
+      "delta": " all but"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line,",
+      "delta": " one line,"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is",
+      "delta": " which is"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by",
+      "delta": " off by"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by ninety rupees",
+      "delta": " ninety rupees"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by ninety rupees due to",
+      "delta": " due to"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by ninety rupees due to a rounding",
+      "delta": " a rounding"
+    },
+    {
+      "op": "assistant",
+      "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by ninety rupees due to a rounding difference.",
+      "delta": " difference."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "Thanks for waiting \u2014 I compacted the older context and here is the answer: the reconciliation matches for all but one line, which is off by ninety rupees due to a rounding difference."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/recovered.json
+++ b/jarvis/tests/harness/fixtures/transcripts/recovered.json
@@ -1,0 +1,74 @@
+{
+  "name": "recovered",
+  "description": "Mid-stream drop whose durable transcript still holds the complete answer; snapshot recovery finalizes it (Stage-B recovery fixture).",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "The month-end",
+      "delta": "The month-end"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist",
+      "delta": " close checklist"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete:",
+      "delta": " is complete:"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals",
+      "delta": " all journals"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted,",
+      "delta": " are posted,"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank",
+      "delta": " the bank"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties",
+      "delta": " reconciliation ties"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and",
+      "delta": " out, and"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial",
+      "delta": " the trial"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is",
+      "delta": " balance is"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is in balance.",
+      "delta": " in balance."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is in balance."
+  },
+  "inject": {
+    "drop_after_frame": 5,
+    "recover_via": "history",
+    "final_text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is in balance."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/success.json
+++ b/jarvis/tests/harness/fixtures/transcripts/success.json
@@ -1,0 +1,164 @@
+{
+  "name": "success",
+  "description": "Clean single-answer turn, no tools, terminal final.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "Here is",
+      "delta": "Here is"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary",
+      "delta": " the summary"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked",
+      "delta": " you asked"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The",
+      "delta": " for. The"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue",
+      "delta": " three overdue"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total",
+      "delta": " invoices total"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two",
+      "delta": " forty two"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees",
+      "delta": " thousand rupees"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two",
+      "delta": " across two"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and",
+      "delta": " customers, and"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest",
+      "delta": " the oldest"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen",
+      "delta": " is eighteen"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past",
+      "delta": " days past"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due",
+      "delta": " its due"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I",
+      "delta": " date. I"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise",
+      "delta": " would prioritise"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme",
+      "delta": " the Acme"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first",
+      "delta": " invoice first"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it",
+      "delta": " because it"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both",
+      "delta": " is both"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest",
+      "delta": " the largest"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the",
+      "delta": " and the"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then",
+      "delta": " oldest, then"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up",
+      "delta": " follow up"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the",
+      "delta": " on the"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller",
+      "delta": " two smaller"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices",
+      "delta": " Globex invoices"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in",
+      "delta": " together in"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single",
+      "delta": " a single"
+    },
+    {
+      "op": "assistant",
+      "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single reminder.",
+      "delta": " reminder."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "Here is the summary you asked for. The three overdue invoices total forty two thousand rupees across two customers, and the oldest is eighteen days past its due date. I would prioritise the Acme invoice first because it is both the largest and the oldest, then follow up on the two smaller Globex invoices together in a single reminder."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/tool-heavy.json
+++ b/jarvis/tests/harness/fixtures/transcripts/tool-heavy.json
@@ -1,0 +1,159 @@
+{
+  "name": "tool-heavy",
+  "description": "Assistant text interleaved with three tool call round-trips (two jarvis__, one built-in browser), terminal final.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "Let me",
+      "delta": "Let me"
+    },
+    {
+      "op": "assistant",
+      "text": "Let me pull the",
+      "delta": " pull the"
+    },
+    {
+      "op": "assistant",
+      "text": "Let me pull the current figures",
+      "delta": " current figures"
+    },
+    {
+      "op": "assistant",
+      "text": "Let me pull the current figures for you.",
+      "delta": " for you."
+    },
+    {
+      "op": "tool_start",
+      "name": "jarvis__get_list",
+      "call_id": "t1",
+      "title": "get_list Sales Invoice"
+    },
+    {
+      "op": "pause",
+      "ms": 180
+    },
+    {
+      "op": "tool_end",
+      "call_id": "t1",
+      "status": "completed"
+    },
+    {
+      "op": "assistant",
+      "text": "Got the",
+      "delta": "Got the"
+    },
+    {
+      "op": "assistant",
+      "text": "Got the invoice list.",
+      "delta": " invoice list."
+    },
+    {
+      "op": "assistant",
+      "text": "Got the invoice list. Now checking",
+      "delta": " Now checking"
+    },
+    {
+      "op": "assistant",
+      "text": "Got the invoice list. Now checking the customer",
+      "delta": " the customer"
+    },
+    {
+      "op": "assistant",
+      "text": "Got the invoice list. Now checking the customer balances.",
+      "delta": " balances."
+    },
+    {
+      "op": "tool_start",
+      "name": "jarvis__query",
+      "call_id": "t2",
+      "title": "query Customer balances"
+    },
+    {
+      "op": "pause",
+      "ms": 220
+    },
+    {
+      "op": "tool_end",
+      "call_id": "t2",
+      "status": "completed"
+    },
+    {
+      "op": "tool_start",
+      "name": "browser",
+      "call_id": "t3",
+      "title": "open dashboard"
+    },
+    {
+      "op": "pause",
+      "ms": 150
+    },
+    {
+      "op": "tool_end",
+      "call_id": "t3",
+      "status": "completed"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the",
+      "delta": "Across the"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers",
+      "delta": " two customers"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have",
+      "delta": " you have"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open",
+      "delta": " three open"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth",
+      "delta": " invoices worth"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two",
+      "delta": " forty two"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two thousand rupees.",
+      "delta": " thousand rupees."
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two thousand rupees. Acme is",
+      "delta": " Acme is"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two thousand rupees. Acme is the largest",
+      "delta": " the largest"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two thousand rupees. Acme is the largest exposure at",
+      "delta": " exposure at"
+    },
+    {
+      "op": "assistant",
+      "text": "Across the two customers you have three open invoices worth forty two thousand rupees. Acme is the largest exposure at thirty thousand.",
+      "delta": " thirty thousand."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "Across the two customers you have three open invoices worth forty two thousand rupees. Acme is the largest exposure at thirty thousand."
+  }
+}

--- a/jarvis/tests/harness/fixtures/transcripts/ws-drop.json
+++ b/jarvis/tests/harness/fixtures/transcripts/ws-drop.json
@@ -1,0 +1,72 @@
+{
+  "name": "ws-drop",
+  "description": "Gateway closes the WS mid-stream -> relay:interrupted reason=transport; pooled connection is evicted.",
+  "ack": {
+    "status": "started"
+  },
+  "ack_behavior": "normal",
+  "frames": [
+    {
+      "op": "assistant",
+      "text": "The month-end",
+      "delta": "The month-end"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist",
+      "delta": " close checklist"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete:",
+      "delta": " is complete:"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals",
+      "delta": " all journals"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted,",
+      "delta": " are posted,"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank",
+      "delta": " the bank"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties",
+      "delta": " reconciliation ties"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and",
+      "delta": " out, and"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial",
+      "delta": " the trial"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is",
+      "delta": " balance is"
+    },
+    {
+      "op": "assistant",
+      "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is in balance.",
+      "delta": " in balance."
+    }
+  ],
+  "terminal": {
+    "kind": "final",
+    "text": "The month-end close checklist is complete: all journals are posted, the bank reconciliation ties out, and the trial balance is in balance."
+  },
+  "inject": {
+    "drop_after_frame": 3
+  }
+}

--- a/jarvis/tests/harness/probe_real_gateway.py
+++ b/jarvis/tests/harness/probe_real_gateway.py
@@ -1,0 +1,107 @@
+"""R-21 guard — re-assert the protocol facts the fake gateway reproduces
+against the REAL pinned openclaw 2026.6.8 runtime, read-only, in a THROWAWAY
+container (never the running pool).
+
+Methodology matches spikes S1/S2 (which established the ordering + payload facts
+at file:line against the vendored source and asserted SYMBOL PRESENCE in the
+2026.6.8 image): here we re-confirm, in the image the pool actually runs, that
+the tokens the harness depends on are present in /app/dist —
+
+  * ack semantics       chat.send handler + idempotencyKey (ack runId echoes it)
+                        + the lane-admission primitive enqueueCommandInLane
+                        (its presence + S2's line-level ordering is the
+                        "ack BEFORE lane admission" authority)
+  * sessions.list flag  hasActiveRun (accept-inclusive per-session flag)
+  * lane cap            maxConcurrent (main-lane default 4)
+  * terminal metadata   stopReason + timeoutPhase + aborted (the lifecycle
+                        end/error discriminators S1 relied on)
+  * chat terminal state final / aborted / error broadcast states
+
+Run: JARVIS-agnostic; needs docker + the local image. Read-only:
+``docker run --rm --network none --entrypoint /bin/sh`` greps and exits; the
+container is discarded. The running pool containers are never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+IMAGE = "ghcr.io/openclaw/openclaw:2026.6.8"
+
+# token -> what it evidences
+REQUIRED = {
+	"chat.send": "chat.send handler present",
+	"idempotencyKey": "ack runId echoes caller idempotencyKey (S2 a)",
+	"enqueueCommandInLane": "lane-admission primitive (post-ack; S2 a ordering)",
+	"hasActiveRun": "sessions.list accept-inclusive active-run flag (S2 b)",
+	"maxConcurrent": "main-lane concurrency cap, default 4 (S2 d)",
+	"stopReason": "lifecycle terminal metadata key (S1)",
+	"timeoutPhase": "turn-timeout terminal metadata key (S1)",
+	"aborted": "user-abort terminal discriminator (S1)",
+}
+
+
+def _grep_count(token: str) -> tuple[int, str]:
+	"""Return (file_count, first_file) for token across /app/dist, via a
+	throwaway container. Non-zero file_count == present."""
+	# -rl lists files containing the token; -F fixed-string (dots are literal).
+	cmd = [
+		"docker",
+		"run",
+		"--rm",
+		"--network",
+		"none",
+		"--entrypoint",
+		"/bin/sh",
+		IMAGE,
+		"-c",
+		f"grep -rlF -- '{token}' /app/dist 2>/dev/null | head -50",
+	]
+	try:
+		out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+	except subprocess.TimeoutExpired:
+		return (-1, "TIMEOUT")
+	files = [ln for ln in out.stdout.splitlines() if ln.strip()]
+	first = files[0] if files else ""
+	return (len(files), first)
+
+
+def run() -> dict:
+	# image present?
+	have = subprocess.run(["docker", "images", "-q", IMAGE], capture_output=True, text=True).stdout.strip()
+	if not have:
+		return {"ok": False, "error": f"image {IMAGE} not present locally; cannot run R-21 probe"}
+
+	results = {}
+	all_pass = True
+	for token, why in REQUIRED.items():
+		count, first = _grep_count(token)
+		present = count > 0
+		all_pass = all_pass and present
+		results[token] = {"present": present, "files": count, "example": first, "evidence": why}
+
+	return {
+		"ok": all_pass,
+		"image": IMAGE,
+		"method": "throwaway `docker run --rm --network none`; read-only grep of /app/dist; running pool untouched",
+		"note": (
+			"S2 line-verified the ack-BEFORE-lane-enqueue ordering (chat-DFeIryVW.js respond(true,ackPayload) "
+			"at ~:2520 precedes embedded-agent enqueueCommandInLane) against 2026.6.11 source; this probe "
+			"re-confirms the symbols exist in the pinned 2026.6.8 image the pool runs (parity), matching the "
+			"S1/S2 presence-assertion methodology. A behavioral ordering probe against the live stack was "
+			"deliberately NOT run (R-21 is read-only)."
+		),
+		"results": results,
+	}
+
+
+def main():
+	r = run()
+	print(json.dumps(r, indent=2))
+	sys.exit(0 if r.get("ok") else 1)
+
+
+if __name__ == "__main__":
+	main()

--- a/jarvis/tests/harness/probes.py
+++ b/jarvis/tests/harness/probes.py
@@ -1,0 +1,319 @@
+"""Metric probes for the six production criteria (C1–C6).
+
+Two kinds:
+
+  * Trace extractors — pure functions over TurnResult lists + the TraceRecorder:
+      first_token (from submit AND from send), queue_wait, flush-gap series
+      (C3, DB-commit cadence + publish cadence), dispatch->first-event dwell
+      (C4), and the p50/p95/p99 summarizer.
+
+  * Live probes — real work against the running bench:
+      CanaryProbe  — enqueues short+long RQ canaries every 10s to the REAL
+                     workers and times their wait, plus a real Desk HTTP GET
+                     (C6). background_flood() generates real RQ occupancy so
+                     the canary is measured under load, not just idle.
+      measure_stop_visible — stop-click -> visible aborted terminal (SUX-12).
+
+Percentiles use linear interpolation (numpy-free). All wall-clock probes are
+repeated; the caller states N in the report.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+import time
+import urllib.request
+import uuid
+
+# --------------------------------------------------------------------------- #
+# percentile + summary
+# --------------------------------------------------------------------------- #
+
+
+def percentile(values, p: float):
+	xs = sorted(v for v in values if v is not None)
+	if not xs:
+		return None
+	if len(xs) == 1:
+		return xs[0]
+	k = (len(xs) - 1) * (p / 100.0)
+	lo = int(k)
+	hi = min(lo + 1, len(xs) - 1)
+	frac = k - lo
+	return xs[lo] + (xs[hi] - xs[lo]) * frac
+
+
+def summarize(values) -> dict:
+	xs = [v for v in values if v is not None]
+	if not xs:
+		return {"n": 0, "min": None, "p50": None, "p95": None, "p99": None, "max": None, "mean": None}
+	return {
+		"n": len(xs),
+		"min": round(min(xs), 2),
+		"p50": round(percentile(xs, 50), 2),
+		"p95": round(percentile(xs, 95), 2),
+		"p99": round(percentile(xs, 99), 2),
+		"max": round(max(xs), 2),
+		"mean": round(sum(xs) / len(xs), 2),
+	}
+
+
+# --------------------------------------------------------------------------- #
+# trace extractors
+# --------------------------------------------------------------------------- #
+
+
+def first_token_from_submit(results) -> list:
+	return [r.first_token_from_submit_ms() for r in results]
+
+
+def first_token_from_send(results) -> list:
+	return [r.first_token_from_send_ms() for r in results]
+
+
+def queue_wait(results) -> list:
+	return [r.queue_wait_ms() for r in results]
+
+
+def total(results) -> list:
+	return [r.total_ms() for r in results]
+
+
+def _gap_series(recorder, run_id, source, kind) -> list:
+	evs = [e for e in recorder.events_for(run_id) if e.source == source and (kind is None or e.kind == kind)]
+	gaps = []
+	for a, b in itertools.pairwise(evs):
+		gaps.append((b.t_mono - a.t_mono) * 1000.0)
+	return gaps
+
+
+def flush_gap_series(recorder, run_id) -> list:
+	"""C3: inter-DB-commit gap between successive assistant content flushes
+	(the coalesced batcher cadence, _ASSISTANT_BATCH_INTERVAL_MS=250)."""
+	return _gap_series(recorder, run_id, "db", "msg.content.flush")
+
+
+def publish_gap_series(recorder, run_id) -> list:
+	"""Companion to C3: inter-publish gap (assistant:delta fires per token)."""
+	return _gap_series(recorder, run_id, "publish", "assistant:delta")
+
+
+def all_flush_gaps(recorder, run_ids) -> list:
+	out = []
+	for rid in run_ids:
+		out.extend(flush_gap_series(recorder, rid))
+	return out
+
+
+def all_publish_gaps(recorder, run_ids) -> list:
+	out = []
+	for rid in run_ids:
+		out.extend(publish_gap_series(recorder, rid))
+	return out
+
+
+def dwell_series(gateway, run_ids) -> list:
+	"""C4: per-run gateway dwell (ack -> lane admit), the main-lane queueing
+	proxy under the simulated maxConcurrent cap."""
+	out = []
+	for rid in run_ids:
+		tl = gateway.timeline(rid)
+		if tl:
+			d = tl.dwell_ms()
+			if d is not None:
+				out.append(d)
+	return out
+
+
+def ack_to_first_frame_series(gateway, run_ids) -> list:
+	out = []
+	for rid in run_ids:
+		tl = gateway.timeline(rid)
+		if tl:
+			d = tl.ack_to_first_frame_ms()
+			if d is not None:
+				out.append(d)
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# C6 live canary — REAL RQ jobs + Desk HTTP
+# --------------------------------------------------------------------------- #
+
+# Module-level RQ job targets (must be importable by the worker process).
+
+
+def _canary_job(token: str, enqueued_ms: int) -> None:
+	import frappe
+
+	frappe.cache().set_value(f"harness:canary:{token}", int(time.time() * 1000), expires_in_sec=180)
+
+
+def _filler_job(work_ms: int, token: str) -> None:
+	"""Real occupancy: a little DB work + a bounded sleep, to hold an RQ worker
+	the way a chat turn holds one. Models chat-worker occupancy for C6."""
+	import frappe
+
+	try:
+		frappe.db.count("Jarvis Chat Message")
+	except Exception:
+		pass
+	time.sleep(max(0, work_ms) / 1000.0)
+	try:
+		frappe.cache().set_value(f"harness:filler:{token}", int(time.time() * 1000), expires_in_sec=180)
+	except Exception:
+		pass
+
+
+def _enqueue_canary(queue_name: str) -> dict:
+	import frappe
+
+	token = uuid.uuid4().hex[:12]
+	enq_ms = int(time.time() * 1000)
+	frappe.enqueue(
+		"jarvis.tests.harness.probes._canary_job",
+		queue=queue_name,
+		token=token,
+		enqueued_ms=enq_ms,
+		job_id=f"harness-canary-{token}",
+	)
+	# poll for execution
+	deadline = time.time() + 65
+	start_ms = None
+	while time.time() < deadline:
+		v = frappe.cache().get_value(f"harness:canary:{token}")
+		if v:
+			start_ms = int(v)
+			break
+		time.sleep(0.05)
+	if start_ms is None:
+		return {"queue": queue_name, "wait_ms": None, "starved": True}
+	return {"queue": queue_name, "wait_ms": max(0, start_ms - enq_ms), "starved": (start_ms - enq_ms) > 60000}
+
+
+def desk_http_probe(url: str, host: str) -> dict:
+	req = urllib.request.Request(url, headers={"Host": host})
+	t0 = time.monotonic()
+	try:
+		with urllib.request.urlopen(req, timeout=15) as r:
+			code = getattr(r, "status", r.getcode())
+			r.read(256)
+		return {"ok": True, "code": code, "ms": (time.monotonic() - t0) * 1000.0}
+	except Exception as e:
+		return {"ok": False, "err": str(e), "ms": (time.monotonic() - t0) * 1000.0}
+
+
+class CanaryProbe:
+	"""Every ``cadence_s`` (default 10, per C6): a short + long RQ canary and a
+	Desk HTTP GET, timing the wait. Runs in its own thread + frappe connection."""
+
+	def __init__(self, site: str, *, cadence_s: float = 10.0, desk_url: str, desk_host: str):
+		self.site = site
+		self.cadence_s = cadence_s
+		self.desk_url = desk_url
+		self.desk_host = desk_host
+		self._stop = threading.Event()
+		self._thread = None
+		self.samples: list[dict] = []
+		self._lock = threading.Lock()
+
+	def _loop(self) -> None:
+		import frappe
+
+		frappe.init(site=self.site)
+		frappe.connect()
+		try:
+			while not self._stop.is_set():
+				t_wall = time.time()
+				short = _enqueue_canary("short")
+				long_ = _enqueue_canary("long")
+				desk = desk_http_probe(self.desk_url, self.desk_host)
+				with self._lock:
+					self.samples.append({"t": t_wall, "short": short, "long": long_, "desk": desk})
+				self._stop.wait(self.cadence_s)
+		finally:
+			frappe.destroy()
+
+	def start(self) -> "CanaryProbe":
+		self._thread = threading.Thread(target=self._loop, name="harness-canary", daemon=True)
+		self._thread.start()
+		return self
+
+	def stop(self) -> None:
+		self._stop.set()
+		if self._thread:
+			self._thread.join(timeout=70)
+
+	def series(self) -> dict:
+		with self._lock:
+			s = list(self.samples)
+		return {
+			"short_wait_ms": [x["short"]["wait_ms"] for x in s],
+			"long_wait_ms": [x["long"]["wait_ms"] for x in s],
+			"desk_ms": [x["desk"]["ms"] for x in s if x["desk"].get("ok")],
+			"desk_failures": sum(1 for x in s if not x["desk"].get("ok")),
+			"starved": sum(1 for x in s if x["short"].get("starved") or x["long"].get("starved")),
+			"count": len(s),
+		}
+
+
+def background_flood(site: str, n: int, *, queue_name: str = "jarvis_chat", work_ms: int = 800) -> list[str]:
+	"""Enqueue n real filler jobs to occupy RQ workers (C6 load). Returns the
+	tokens (for optional completion tracking)."""
+	import frappe
+
+	tokens = []
+	for _ in range(n):
+		token = uuid.uuid4().hex[:12]
+		frappe.enqueue(
+			"jarvis.tests.harness.probes._filler_job",
+			queue=queue_name,
+			work_ms=work_ms,
+			token=token,
+			job_id=f"harness-filler-{token}",
+		)
+		tokens.append(token)
+	return tokens
+
+
+# --------------------------------------------------------------------------- #
+# stop-click -> visible-stop (SUX-12)
+# --------------------------------------------------------------------------- #
+
+
+def measure_stop_visible(gateway, *, cadence_ms: float = 25.0, abort_after_frames: int = 2) -> dict:
+	"""Start an abort-transcript turn, let a few frames stream, send chat.abort
+	from a SECOND connection (web process aborting the worker's run), and
+	measure the time to the visible aborted terminal."""
+	from jarvis.chat.openclaw_client import OpenclawSession, OpenclawUnreachableError
+
+	run_id = f"stopvis-{uuid.uuid4().hex[:8]}"
+	gateway.arm(run_id, "abort", cadence_ms=cadence_ms)
+	sess = OpenclawSession.connect(gateway.ws_url)
+	try:
+		sk = sess.create_session()
+		ack = sess.chat_send(sk, "export please", run_id)
+		t_abort = None
+		stop_ms = None
+		seen = 0
+		for ev in sess.relay_turn_events(sk, ack.get("runId") or run_id, soft_deadline_s=10):
+			kind = ev.get("kind")
+			if kind in ("assistant", "tool"):
+				seen += 1
+				if seen == abort_after_frames and t_abort is None:
+					t_abort = time.monotonic()
+					s2 = OpenclawSession.connect(gateway.ws_url)
+					try:
+						s2.chat_abort(sk)
+					finally:
+						s2.close()
+			if str(kind or "").startswith("relay:"):
+				if t_abort is not None:
+					stop_ms = (time.monotonic() - t_abort) * 1000.0
+				return {"terminal": kind, "state": ev.get("state"), "stop_visible_ms": stop_ms}
+		return {"terminal": None, "stop_visible_ms": None}
+	except OpenclawUnreachableError as e:
+		return {"terminal": "unreachable", "error": str(e), "stop_visible_ms": None}
+	finally:
+		sess.close()

--- a/jarvis/tests/harness/probes.py
+++ b/jarvis/tests/harness/probes.py
@@ -140,56 +140,38 @@ def ack_to_first_frame_series(gateway, run_ids) -> list:
 # --------------------------------------------------------------------------- #
 # C6 live canary — REAL RQ jobs + Desk HTTP
 # --------------------------------------------------------------------------- #
+#
+# IMPORTANT: the canary + flood targets must be CORE-frappe functions, not
+# harness code. The running RQ workers were started before this harness module
+# existed and RQ workers do not hot-reload, so they cannot import
+# jarvis.tests.harness.*. We therefore enqueue a trivial core function and read
+# the wait from the RQ job's own enqueued_at/started_at timestamps (populated by
+# the worker) rather than having our code run in the worker. This keeps C6 real
+# without restarting the pool's workers (which would mutate running state).
 
-# Module-level RQ job targets (must be importable by the worker process).
-
-
-def _canary_job(token: str, enqueued_ms: int) -> None:
-	import frappe
-
-	frappe.cache().set_value(f"harness:canary:{token}", int(time.time() * 1000), expires_in_sec=180)
-
-
-def _filler_job(work_ms: int, token: str) -> None:
-	"""Real occupancy: a little DB work + a bounded sleep, to hold an RQ worker
-	the way a chat turn holds one. Models chat-worker occupancy for C6."""
-	import frappe
-
-	try:
-		frappe.db.count("Jarvis Chat Message")
-	except Exception:
-		pass
-	time.sleep(max(0, work_ms) / 1000.0)
-	try:
-		frappe.cache().set_value(f"harness:filler:{token}", int(time.time() * 1000), expires_in_sec=180)
-	except Exception:
-		pass
+_CORE_NOOP = "frappe.utils.data.now_datetime"  # pure, present in every frappe worker
 
 
 def _enqueue_canary(queue_name: str) -> dict:
 	import frappe
 
 	token = uuid.uuid4().hex[:12]
-	enq_ms = int(time.time() * 1000)
-	frappe.enqueue(
-		"jarvis.tests.harness.probes._canary_job",
-		queue=queue_name,
-		token=token,
-		enqueued_ms=enq_ms,
-		job_id=f"harness-canary-{token}",
-	)
-	# poll for execution
+	job = frappe.enqueue(_CORE_NOOP, queue=queue_name, job_id=f"harness-canary-{token}")
 	deadline = time.time() + 65
-	start_ms = None
 	while time.time() < deadline:
-		v = frappe.cache().get_value(f"harness:canary:{token}")
-		if v:
-			start_ms = int(v)
+		try:
+			job.refresh()
+		except Exception:
+			break
+		st = str(job.get_status())
+		if st.endswith("FINISHED") or st.endswith("FAILED") or st in ("finished", "failed"):
 			break
 		time.sleep(0.05)
-	if start_ms is None:
+	enq, started = getattr(job, "enqueued_at", None), getattr(job, "started_at", None)
+	if not enq or not started:
 		return {"queue": queue_name, "wait_ms": None, "starved": True}
-	return {"queue": queue_name, "wait_ms": max(0, start_ms - enq_ms), "starved": (start_ms - enq_ms) > 60000}
+	wait_ms = (started - enq).total_seconds() * 1000.0
+	return {"queue": queue_name, "wait_ms": max(0.0, wait_ms), "starved": wait_ms > 60000}
 
 
 def desk_http_probe(url: str, host: str) -> dict:
@@ -258,23 +240,53 @@ class CanaryProbe:
 		}
 
 
-def background_flood(site: str, n: int, *, queue_name: str = "jarvis_chat", work_ms: int = 800) -> list[str]:
-	"""Enqueue n real filler jobs to occupy RQ workers (C6 load). Returns the
-	tokens (for optional completion tracking)."""
+def background_flood(site: str, n: int, *, queue_name: str = "jarvis_chat", work_ms: int = 0) -> int:
+	"""Enqueue n core no-op jobs to build a real FIFO backlog on ``queue_name``
+	(C6 load). Uses a core function (see _CORE_NOOP note) so the pre-existing
+	workers can run it. ``work_ms`` is accepted for signature stability but the
+	core no-op is quick; sustained load comes from re-flooding (FloodPump)."""
 	import frappe
 
-	tokens = []
 	for _ in range(n):
-		token = uuid.uuid4().hex[:12]
-		frappe.enqueue(
-			"jarvis.tests.harness.probes._filler_job",
-			queue=queue_name,
-			work_ms=work_ms,
-			token=token,
-			job_id=f"harness-filler-{token}",
-		)
-		tokens.append(token)
-	return tokens
+		frappe.enqueue(_CORE_NOOP, queue=queue_name, job_id=f"harness-flood-{uuid.uuid4().hex[:12]}")
+	return n
+
+
+class FloodPump:
+	"""Sustains a real RQ backlog for the load window by re-flooding target
+	queues every ``interval_s``. Its own thread + frappe connection."""
+
+	def __init__(self, site: str, queues: list[str], *, per_burst: int = 120, interval_s: float = 1.0):
+		self.site = site
+		self.queues = queues
+		self.per_burst = per_burst
+		self.interval_s = interval_s
+		self._stop = threading.Event()
+		self._thread = None
+		self.total = 0
+
+	def _loop(self):
+		import frappe
+
+		frappe.init(site=self.site)
+		frappe.connect()
+		try:
+			while not self._stop.is_set():
+				for q in self.queues:
+					self.total += background_flood(self.site, self.per_burst, queue_name=q)
+				self._stop.wait(self.interval_s)
+		finally:
+			frappe.destroy()
+
+	def start(self):
+		self._thread = threading.Thread(target=self._loop, name="harness-flood", daemon=True)
+		self._thread.start()
+		return self
+
+	def stop(self):
+		self._stop.set()
+		if self._thread:
+			self._thread.join(timeout=10)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/harness/run_baseline.py
+++ b/jarvis/tests/harness/run_baseline.py
@@ -484,7 +484,9 @@ def scenario_canary_c6(h: Harness, gateway: FakeGateway):
 	rec = TraceRecorder(label="c6_load")
 	R.set_active_recorder(rec)
 	pool = R.WorkerPool(2, h.site, gateway, rec, flag_value=0).start()
-	flood = P.FloodPump(h.site, ["jarvis_chat", "long"], per_burst=(30 if h.quick else 80), interval_s=2.0).start()
+	flood = P.FloodPump(
+		h.site, ["jarvis_chat", "long"], per_burst=(30 if h.quick else 80), interval_s=2.0
+	).start()
 	convs = [h.mk_conv() for _ in range(4)]
 	for c in convs:
 		h.warm_session(c, gateway)

--- a/jarvis/tests/harness/run_baseline.py
+++ b/jarvis/tests/harness/run_baseline.py
@@ -1,0 +1,651 @@
+"""run_baseline — the orchestrated LEGACY baseline (Stage A).
+
+Runs the current worker-per-turn transport against the FakeGateway on a 2-worker
+config and captures the C1/C3/C4/C5/C6 series + the trace corpus + the incident
+scenario (10-send burst) BOTH with Phase-0 admission OFF and ON, so the
+before/after Phase-0 story is on record before the pump exists.
+
+Usage (from the bench):
+    JARVIS_ALLOW_REAL_NETWORK_IN_TESTS=1 \\
+      env/bin/python apps/jarvis/jarvis/tests/harness/run_baseline.py \\
+      [--quick] [--full] [--site patterntest.localhost] [--out <dir>]
+
+The env var is required because the jarvis test-network guard blocks even the
+LOOPBACK socket to the fake gateway (127.0.0.1); the harness never touches a
+real tenant. Nothing durable is mutated: the admission flag + cap are process-
+only overrides, ensure_paired is stubbed process-wide, and the gateway URL is
+passed straight to the transport (Jarvis Settings is never written). Teardown
+restores everything and clears the harness's own rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import threading
+import time
+import uuid
+
+os.environ.setdefault("JARVIS_ALLOW_REAL_NETWORK_IN_TESTS", "1")
+
+from jarvis.tests.harness import (
+	CONV,
+	DEFAULT_SITE,
+	HARNESS_USER,
+	MSG,
+	TURN,
+	bootstrap,
+)
+from jarvis.tests.harness import probes as P
+from jarvis.tests.harness import transcripts as T
+from jarvis.tests.harness import turn_runner as R
+from jarvis.tests.harness.fake_gateway import FakeGateway
+from jarvis.tests.harness.trace_recorder import TraceRecorder
+from jarvis.tests.harness.turn_runner import TurnSpec
+
+DESK_URL = "http://127.0.0.1:8000/api/method/ping"
+DESK_HOST = "patterntest.localhost"
+
+
+# --------------------------------------------------------------------------- #
+# fixtures / setup / teardown
+# --------------------------------------------------------------------------- #
+
+
+class Harness:
+	def __init__(self, site: str, out_dir: str, *, quick: bool = False):
+		self.site = site
+		self.out_dir = out_dir
+		self.quick = quick
+		self.frappe = None
+		self._restore_stubs = None
+		self.results: dict = {}
+		self.caveats: list[str] = []
+		self.durable_flag = None
+		self.durable_cap = None
+		self._seq_counter = 1000
+		self._seq_lock = threading.Lock()
+
+	# ---- lifecycle ----
+
+	def setup(self):
+		self.frappe = bootstrap(self.site)
+		frappe = self.frappe
+		if self.site != "patterntest.localhost":
+			self.caveats.append(
+				f"Ran on {self.site}, not patterntest.localhost — the site-wide-shard cleanup "
+				"was NOT applied (guarded to patterntest); stray rows could perturb admission counts."
+			)
+		self._ensure_user()
+		self._restore_stubs = R.install_stubs()
+		from jarvis.chat import admission
+
+		self.durable_flag = frappe.conf.get(admission.FLAG)
+		self.durable_cap = frappe.conf.get("jarvis_site_max_inflight_turns")
+		self._cleanup()
+
+	def teardown(self):
+		try:
+			self._cleanup()
+		finally:
+			if self._restore_stubs:
+				self._restore_stubs()
+
+	def _ensure_user(self):
+		frappe = self.frappe
+		if frappe.db.exists("User", HARNESS_USER):
+			return
+		doc = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": HARNESS_USER,
+				"first_name": "Harness",
+				"last_name": "Bench",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		doc.add_roles("System Manager", "Jarvis User")
+		frappe.db.commit()
+
+	def _cleanup(self):
+		frappe = self.frappe
+		for name in frappe.get_all(CONV, filters={"owner": HARNESS_USER}, pluck="name"):
+			frappe.db.delete(TURN, {"conversation": name})
+			frappe.db.delete(MSG, {"conversation": name})
+			frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+		if self.site == "patterntest.localhost":
+			# site-wide shard baseline (dedicated test site only), mirrors WP-0 _cleanup
+			from jarvis.chat import admission
+
+			frappe.db.delete(TURN, {"state": ["in", ("queued", "dispatching")]})
+			stale = frappe.utils.add_to_date(None, seconds=-(admission._INFLIGHT_FRESH_SECONDS + 600))
+			frappe.db.sql(
+				"""UPDATE `tabJarvis Chat Message` SET modified=%(old)s
+                   WHERE role='assistant' AND streaming=1 AND recovering=0 AND modified > %(fresh)s""",
+				{"old": stale, "fresh": admission._fresh_cutoff()},
+			)
+		frappe.db.commit()
+
+	def reset_shard_baseline(self):
+		"""Clear the site-wide admission shard of stray non-terminal Turn rows
+		and age stray fresh-streaming placeholders out of the freshness window,
+		so admission counts (dual-signal inflight) start clean for an
+		admission-sensitive scenario. patterntest (dedicated dev site) only —
+		this is exactly the WP-0 test _cleanup shard-baseline step. On any other
+		site it is a no-op and a caveat is recorded."""
+		if self.site != "patterntest.localhost":
+			return
+		from jarvis.chat import admission
+
+		frappe = self.frappe
+		frappe.db.delete(TURN, {"state": ["in", ("queued", "dispatching")]})
+		stale = frappe.utils.add_to_date(None, seconds=-(admission._INFLIGHT_FRESH_SECONDS + 600))
+		frappe.db.sql(
+			"""UPDATE `tabJarvis Chat Message` SET modified=%(old)s
+               WHERE role='assistant' AND streaming=1 AND recovering=0 AND modified > %(fresh)s""",
+			{"old": stale, "fresh": admission._fresh_cutoff()},
+		)
+		frappe.db.commit()
+
+	# ---- row helpers ----
+
+	def mk_conv(self) -> str:
+		frappe = self.frappe
+		frappe.set_user(HARNESS_USER)
+		doc = frappe.get_doc({"doctype": CONV, "title": "harness", "status": "Active"})
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		frappe.db.commit()
+		return doc.name
+
+	def mk_seed(self, conv: str, seq: int | None = None) -> str:
+		frappe = self.frappe
+		if seq is None:
+			with self._seq_lock:
+				self._seq_counter += 1
+				seq = self._seq_counter
+		doc = frappe.get_doc(
+			{"doctype": MSG, "conversation": conv, "seq": seq, "role": "user", "content": "hi"}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		frappe.db.commit()
+		return doc.name
+
+	def warm_session(self, conv: str, gateway: FakeGateway):
+		"""Pre-create the gateway session so the measured turn is WARM (skips
+		session-create)."""
+		from jarvis.chat.openclaw_client import OpenclawSession
+
+		sess = OpenclawSession.connect(gateway.ws_url)
+		try:
+			sk = sess.create_session()
+			self.frappe.db.set_value(CONV, conv, "session_key", sk)
+			self.frappe.db.commit()
+		finally:
+			sess.close()
+
+	# ---- run a synchronous wave on the pool ----
+
+	def run_wave(self, pool, specs: list[TurnSpec], timeout=120) -> list:
+		events = []
+		for s in specs:
+			ev = threading.Event()
+			events.append((s, ev))
+			pool.submit(s, ev)
+		for s, ev in events:
+			ev.wait(timeout)
+		return [pool.result(s.run_id) for s, _ in events]
+
+	def rid(self, tag: str) -> str:
+		return f"{tag}-{uuid.uuid4().hex[:10]}"
+
+
+# --------------------------------------------------------------------------- #
+# scenarios
+# --------------------------------------------------------------------------- #
+
+
+def scenario_concurrency(h: Harness, gateway: FakeGateway, *, transcript="success"):
+	"""C1 (N=1 warm), C3 (flush-gap), C4 (dwell), C5-shape (N=4,6): first-token
+	at 1/2/4/6 concurrent sends on a 2-worker pool."""
+	levels = [1, 2, 4, 6]
+	target = 20 if h.quick else 48
+	rec = TraceRecorder(label="concurrency")
+	R.set_active_recorder(rec)
+	pool = R.WorkerPool(2, h.site, gateway, rec, flag_value=0).start()
+
+	out = {}
+	for N in levels:
+		reps = max(4, math.ceil(target / N))
+		# distinct warm convs, reused across reps
+		convs = []
+		for _ in range(N):
+			c = h.mk_conv()
+			h.mk_seed(c)
+			h.warm_session(c, gateway)
+			convs.append(c)
+		results = []
+		for _ in range(reps):
+			specs = [
+				TurnSpec(
+					run_id=h.rid(f"conc{N}"),
+					conversation_id=c,
+					seed_message=h.mk_seed(c),
+					transcript=transcript,
+					soft_deadline_s=30,
+				)
+				for i, c in enumerate(convs)
+			]
+			results.extend(r for r in h.run_wave(pool, specs) if r is not None)
+		run_ids = [r.run_id for r in results]
+		out[f"N={N}"] = {
+			"samples": len(results),
+			"reps": reps,
+			"first_token_from_submit_ms": P.summarize(P.first_token_from_submit(results)),
+			"first_token_from_send_ms": P.summarize(P.first_token_from_send(results)),
+			"total_ms": P.summarize(P.total(results)),
+			"flush_gap_ms_C3": P.summarize(P.all_flush_gaps(rec, run_ids)),
+			"publish_gap_ms": P.summarize(P.all_publish_gaps(rec, run_ids)),
+			"dwell_ms_C4": P.summarize(P.dwell_series(gateway, run_ids)),
+			"terminals": _terminal_counts(results),
+		}
+	pool.stop()
+	rec.attach_gateway(gateway)
+	rec.dump(os.path.join(h.out_dir, "trace_concurrency.json"))
+	return out
+
+
+def scenario_burst_incident(h: Harness, gateway: FakeGateway):
+	"""The incident: a 10-send burst on a 2-worker pool, measured BOTH with
+	Phase-0 admission OFF (pure legacy) and ON (real accept_or_queue, cap 4).
+	Reports first-token-from-request (the full user-perceived wait) for each,
+	plus the paced 10-in-60s variant (C5 shape)."""
+	n = 10
+	reps = 2 if h.quick else 5
+	from jarvis.chat import admission
+	from jarvis.chat import api as chat_api
+
+	def _one_burst_flag_off(rec, pool, paced_window_s=None):
+		convs = [h.mk_conv() for _ in range(n)]
+		for c in convs:
+			h.mk_seed(c)
+			h.warm_session(c, gateway)
+		specs = []
+		req_times = {}
+		for i, c in enumerate(convs):
+			rid = h.rid("burstoff")
+			specs.append(
+				TurnSpec(
+					run_id=rid,
+					conversation_id=c,
+					seed_message=h.mk_seed(c),
+					transcript="success",
+					soft_deadline_s=30,
+				)
+			)
+		events = []
+		for i, s in enumerate(specs):
+			req_times[s.run_id] = time.monotonic()
+			ev = threading.Event()
+			events.append((s, ev))
+			pool.submit(s, ev)
+			if paced_window_s:
+				time.sleep(paced_window_s / n)
+		for s, ev in events:
+			ev.wait(120)
+		results = [pool.result(s.run_id) for s, _ in events]
+		return [r for r in results if r], req_times
+
+	def _one_burst_flag_on(rec, pool):
+		# real admission: accept_or_queue (cap 4) -> dispatch to pool; settle on
+		# terminal promotes the next queued turn (also to the pool).
+		h.reset_shard_baseline()  # clean cap-4 admission each rep
+		frappe = h.frappe
+		frappe.set_user(HARNESS_USER)
+		frappe.local.conf[admission.FLAG] = 1
+		frappe.local.conf["jarvis_site_max_inflight_turns"] = 4
+		admission._ensure_control_row(admission.DEFAULT_RELAY_TARGET)
+
+		run_tmpl: dict = {}
+		req_times: dict = {}
+
+		def pool_dispatch(kwargs, interactive=True):
+			rid = kwargs["run_id"]
+			spec = TurnSpec(
+				run_id=rid,
+				conversation_id=kwargs["conversation_id"],
+				seed_message=kwargs["message_id"],
+				transcript=run_tmpl.get(rid, "success"),
+				turn_class="interactive" if interactive else "background",
+				settle_on_terminal=True,
+				soft_deadline_s=30,
+			)
+			pool.submit(spec)
+
+		orig_dispatch = chat_api._dispatch_turn
+		chat_api._dispatch_turn = pool_dispatch
+		admit_count = queue_count = reject_count = 0
+		try:
+			convs = [h.mk_conv() for _ in range(n)]
+			for c in convs:
+				h.warm_session(c, gateway)
+			for i, c in enumerate(convs):
+				rid = h.rid("burston")
+				run_tmpl[rid] = "success"
+				seed = h.mk_seed(c)
+				req_times[rid] = time.monotonic()
+				res = admission.accept_or_queue(
+					conversation=c,
+					run_id=rid,
+					seed_message=seed,
+					turn_class="interactive",
+					dispatch=(
+						lambda kw={"run_id": rid, "conversation_id": c, "message_id": seed}: pool_dispatch(
+							kw, interactive=True
+						)
+					),
+				)
+				if not res.get("ok"):
+					reject_count += 1
+				elif res.get("dispatched"):
+					admit_count += 1
+				else:
+					queue_count += 1
+			pool.drain(180)
+		finally:
+			chat_api._dispatch_turn = orig_dispatch
+		results = [pool.result(rid) for rid in req_times if pool.result(rid)]
+		return results, req_times, {"admitted": admit_count, "queued": queue_count, "rejected": reject_count}
+
+	# --- FLAG OFF (near-simultaneous burst) ---
+	h.reset_shard_baseline()
+	rec_off = TraceRecorder(label="burst_flag_off")
+	R.set_active_recorder(rec_off)
+	pool_off = R.WorkerPool(2, h.site, gateway, rec_off, flag_value=0).start()
+	off_ft_req, off_ft_send = [], []
+	for _ in range(reps):
+		results, req_times = _one_burst_flag_off(rec_off, pool_off)
+		off_ft_req += [_from_req(r, req_times) for r in results]
+		off_ft_send += [r.first_token_from_send_ms() for r in results]
+	# paced 10-in-60s (C5 shape) — one pass
+	paced_window = 6 if h.quick else 60
+	paced_results, paced_req = _one_burst_flag_off(rec_off, pool_off, paced_window_s=paced_window)
+	pool_off.stop()
+	rec_off.attach_gateway(gateway)
+	rec_off.dump(os.path.join(h.out_dir, "trace_burst_flag_off.json"))
+
+	# --- FLAG ON (real admission cap 4) ---
+	h.reset_shard_baseline()
+	rec_on = TraceRecorder(label="burst_flag_on")
+	R.set_active_recorder(rec_on)
+	pool_on = R.WorkerPool(2, h.site, gateway, rec_on, flag_value=1).start()
+	on_ft_req, on_admit = [], {"admitted": 0, "queued": 0, "rejected": 0}
+	on_qwait = []
+	for _ in range(reps):
+		results, req_times, counts = _one_burst_flag_on(rec_on, pool_on)
+		on_ft_req += [_from_req(r, req_times) for r in results]
+		on_qwait += [r.queue_wait_ms() for r in results]
+		for k in on_admit:
+			on_admit[k] += counts[k]
+	pool_on.stop()
+	rec_on.attach_gateway(gateway)
+	rec_on.dump(os.path.join(h.out_dir, "trace_burst_flag_on.json"))
+	# restore process cap override
+	h.frappe.local.conf.pop("jarvis_site_max_inflight_turns", None)
+	h.frappe.local.conf[admission.FLAG] = h.durable_flag
+
+	return {
+		"n_per_burst": n,
+		"reps": reps,
+		"flag_off": {
+			"first_token_from_request_ms": P.summarize(off_ft_req),
+			"first_token_from_send_ms": P.summarize(off_ft_send),
+			"samples": len(off_ft_req),
+		},
+		"flag_on_phase0": {
+			"first_token_from_request_ms": P.summarize(on_ft_req),
+			"pool_wait_ms": P.summarize(on_qwait),
+			"admission_disposition_totals": on_admit,
+			"samples": len(on_ft_req),
+		},
+		"paced_10_in_60s_C5": {
+			"window_s": paced_window,
+			"first_token_from_request_ms": P.summarize([_from_req(r, paced_req) for r in paced_results]),
+			"samples": len(paced_results),
+		},
+	}
+
+
+def scenario_confirmation_storm(h: Harness, gateway: FakeGateway):
+	"""Confirmation-card storm: many confirm turns concurrently on 2 workers."""
+	n = 6 if h.quick else 10
+	reps = 2 if h.quick else 4
+	rec = TraceRecorder(label="confirmation_storm")
+	R.set_active_recorder(rec)
+	pool = R.WorkerPool(2, h.site, gateway, rec, flag_value=0).start()
+	convs = [h.mk_conv() for _ in range(n)]
+	for c in convs:
+		h.warm_session(c, gateway)
+	results = []
+	for _ in range(reps):
+		specs = [
+			TurnSpec(
+				run_id=h.rid("confstorm"),
+				conversation_id=c,
+				seed_message=h.mk_seed(c),
+				transcript="confirmation-card",
+				soft_deadline_s=30,
+			)
+			for i, c in enumerate(convs)
+		]
+		results.extend(r for r in h.run_wave(pool, specs) if r is not None)
+	pool.stop()
+	rec.attach_gateway(gateway)
+	rec.dump(os.path.join(h.out_dir, "trace_confirmation_storm.json"))
+	run_ids = [r.run_id for r in results]
+	return {
+		"n_per_storm": n,
+		"reps": reps,
+		"samples": len(results),
+		"first_token_from_submit_ms": P.summarize(P.first_token_from_submit(results)),
+		"total_ms": P.summarize(P.total(results)),
+		"flush_gap_ms_C3": P.summarize(P.all_flush_gaps(rec, run_ids)),
+		"terminals": _terminal_counts(results),
+	}
+
+
+def scenario_canary_c6(h: Harness, gateway: FakeGateway):
+	"""C6: real short+long RQ canaries + Desk HTTP every 10s, idle baseline vs
+	under a real RQ background flood (OCR-class). Also drives an in-process
+	interactive turn set during the load window for realism."""
+	idle_s = 20 if h.quick else 60
+	load_s = 20 if h.quick else 60
+	flood_n = 20 if h.quick else 60
+
+	canary = P.CanaryProbe(h.site, cadence_s=10.0, desk_url=DESK_URL, desk_host=DESK_HOST).start()
+
+	# idle baseline window
+	time.sleep(idle_s)
+	idle = canary.series()
+	idle_snapshot = {k: v for k, v in idle.items()}
+
+	# load window: real RQ flood + in-process interactive turns
+	rec = TraceRecorder(label="c6_load")
+	R.set_active_recorder(rec)
+	pool = R.WorkerPool(2, h.site, gateway, rec, flag_value=0).start()
+	P.background_flood(h.site, flood_n, queue_name="jarvis_chat", work_ms=800)
+	P.background_flood(h.site, flood_n // 2, queue_name="long", work_ms=800)
+	convs = [h.mk_conv() for _ in range(4)]
+	for c in convs:
+		h.warm_session(c, gateway)
+	t_end = time.time() + load_s
+	while time.time() < t_end:
+		specs = [
+			TurnSpec(
+				run_id=h.rid("c6turn"),
+				conversation_id=c,
+				seed_message=h.mk_seed(c),
+				transcript="tool-heavy",
+				soft_deadline_s=30,
+			)
+			for c in convs
+		]
+		h.run_wave(pool, specs, timeout=60)
+	pool.stop()
+	canary.stop()
+	full = canary.series()
+	# derive load-window samples = full minus idle-window count
+	idle_ct = idle_snapshot["count"]
+
+	def _tail(key):
+		return full[key][idle_ct:] if isinstance(full.get(key), list) else full.get(key)
+
+	load_snapshot = {
+		"short_wait_ms": P.summarize(_tail("short_wait_ms")),
+		"long_wait_ms": P.summarize(_tail("long_wait_ms")),
+		"desk_ms": P.summarize(_tail("desk_ms")),
+		"samples": full["count"] - idle_ct,
+		"starved_total": full["starved"],
+		"desk_failures_total": full["desk_failures"],
+	}
+	return {
+		"idle_window_s": idle_s,
+		"load_window_s": load_s,
+		"flood_jobs": flood_n + flood_n // 2,
+		"idle": {
+			"short_wait_ms": P.summarize(idle_snapshot["short_wait_ms"]),
+			"long_wait_ms": P.summarize(idle_snapshot["long_wait_ms"]),
+			"desk_ms": P.summarize(idle_snapshot["desk_ms"]),
+			"samples": idle_snapshot["count"],
+		},
+		"under_load": load_snapshot,
+	}
+
+
+def scenario_transcript_smoke(h: Harness, gateway: FakeGateway):
+	"""Correctness smoke: each of the 8 transcripts produces its expected
+	terminal kind + a stop->visible-stop measurement (SUX-12)."""
+	rec = TraceRecorder(label="transcript_smoke")
+	R.set_active_recorder(rec)
+	pool = R.WorkerPool(1, h.site, gateway, rec, flag_value=0).start()
+	out = {}
+	for name in T.NAMES:
+		c = h.mk_conv()
+		h.warm_session(c, gateway)
+		seed = h.mk_seed(c)
+		spec = TurnSpec(
+			run_id=h.rid(f"smoke-{name}"),
+			conversation_id=c,
+			seed_message=seed,
+			transcript=name,
+			soft_deadline_s=15,
+			ack_timeout_s=(0.5 if name == "ack-timeout" else None),
+			overrides=({"ack_timeout_hold_ms": 1500} if name == "ack-timeout" else {}),
+		)
+		res = h.run_wave(pool, [spec])[0]
+		out[name] = {
+			"terminal": res.terminal if res else None,
+			"relay_state": res.relay_state if res else None,
+		}
+	pool.stop()
+	rec.attach_gateway(gateway)
+	rec.dump(os.path.join(h.out_dir, "trace_transcript_smoke.json"))
+
+	stop = P.measure_stop_visible(gateway)
+	out["_stop_click_visible_stop_SUX12"] = stop
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def _from_req(result, req_times):
+	if result is None or result.t_first_frame is None:
+		return None
+	t_req = req_times.get(result.run_id)
+	if t_req is None:
+		return None
+	return (result.t_first_frame - t_req) * 1000.0
+
+
+def _terminal_counts(results) -> dict:
+	from collections import Counter
+
+	return dict(Counter(r.terminal for r in results))
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+
+
+def main():
+	ap = argparse.ArgumentParser()
+	ap.add_argument("--site", default=DEFAULT_SITE)
+	ap.add_argument("--out", default=None)
+	ap.add_argument("--quick", action="store_true", help="small N for iteration")
+	ap.add_argument("--full", action="store_true", help="recorded-baseline N")
+	ap.add_argument("--only", default=None, help="comma list: concurrency,burst,storm,canary,smoke")
+	args = ap.parse_args()
+
+	out_dir = args.out or "/home/vignesh/jarvis/jarvis-chat-concurrency-design/implementation/wp-2/baseline"
+	os.makedirs(out_dir, exist_ok=True)
+	quick = args.quick and not args.full
+
+	h = Harness(args.site, out_dir, quick=quick)
+	h.setup()
+	gateway = FakeGateway(cadence_ms=25.0, max_concurrent=4, lane_sim=True).start()
+	only = set(args.only.split(",")) if args.only else None
+	started = time.time()
+	try:
+		h.results["meta"] = {
+			"site": args.site,
+			"started_wall": time.strftime("%Y-%m-%d %H:%M:%S"),
+			"mode": "quick" if quick else "full",
+			"pool_size": 2,
+			"gateway": {"cadence_ms": 25.0, "max_concurrent": 4, "lane_sim": True},
+			"durable_flag": h.durable_flag,
+			"durable_cap": h.durable_cap,
+			"batch_interval_ms": _batch_const("_ASSISTANT_BATCH_INTERVAL_MS"),
+			"batch_size": _batch_const("_ASSISTANT_BATCH_SIZE"),
+		}
+		if not only or "smoke" in only:
+			h.results["transcript_smoke"] = scenario_transcript_smoke(h, gateway)
+		if not only or "concurrency" in only:
+			h.results["concurrency"] = scenario_concurrency(h, gateway)
+		if not only or "burst" in only:
+			h.results["burst_incident"] = scenario_burst_incident(h, gateway)
+		if not only or "storm" in only:
+			h.results["confirmation_storm"] = scenario_confirmation_storm(h, gateway)
+		if not only or "canary" in only:
+			h.results["canary_c6"] = scenario_canary_c6(h, gateway)
+		h.results["meta"]["gateway_max_observed_main_lane"] = gateway.max_observed_main()
+		h.results["meta"]["elapsed_s"] = round(time.time() - started, 1)
+		h.results["caveats"] = h.caveats
+	finally:
+		gateway.stop()
+		h.teardown()
+
+	res_path = os.path.join(out_dir, "baseline_results.json")
+	with open(res_path, "w") as fh:
+		json.dump(h.results, fh, indent=2, default=str)
+	print("wrote", res_path, f"({h.results['meta'].get('elapsed_s')}s)")
+	print(json.dumps(h.results, indent=2, default=str)[:4000])
+
+
+def _batch_const(name):
+	from jarvis.chat import turn_handler
+
+	return getattr(turn_handler, name, None)
+
+
+if __name__ == "__main__":
+	main()

--- a/jarvis/tests/harness/run_baseline.py
+++ b/jarvis/tests/harness/run_baseline.py
@@ -461,26 +461,30 @@ def scenario_confirmation_storm(h: Harness, gateway: FakeGateway):
 
 
 def scenario_canary_c6(h: Harness, gateway: FakeGateway):
-	"""C6: real short+long RQ canaries + Desk HTTP every 10s, idle baseline vs
-	under a real RQ background flood (OCR-class). Also drives an in-process
-	interactive turn set during the load window for realism."""
-	idle_s = 20 if h.quick else 60
-	load_s = 20 if h.quick else 60
-	flood_n = 20 if h.quick else 60
+	"""C6: real short+long RQ canaries + Desk HTTP every ~7s, idle baseline vs a
+	sustained REAL RQ backlog (FloodPump) on jarvis_chat (chat-load model) +
+	long (probe-validity: shows the canary CAN detect a backed-up queue). Wait is
+	read from each job's own RQ enqueued_at/started_at timestamps (the running
+	workers predate this module and cannot import harness code — see probes note).
+	In-process tool-heavy turns run during load so the DB the Desk probe also
+	uses is under real chat-shaped write pressure."""
+	idle_s = 20 if h.quick else 56
+	load_s = 20 if h.quick else 56
+	cadence = 7.0
 
-	canary = P.CanaryProbe(h.site, cadence_s=10.0, desk_url=DESK_URL, desk_host=DESK_HOST).start()
+	canary = P.CanaryProbe(h.site, cadence_s=cadence, desk_url=DESK_URL, desk_host=DESK_HOST).start()
 
 	# idle baseline window
 	time.sleep(idle_s)
-	idle = canary.series()
-	idle_snapshot = {k: v for k, v in idle.items()}
+	with canary._lock:
+		idle_ct = len(canary.samples)
+		idle_samples = list(canary.samples)
 
-	# load window: real RQ flood + in-process interactive turns
+	# load window: sustained RQ backlog + in-process chat-shaped turns
 	rec = TraceRecorder(label="c6_load")
 	R.set_active_recorder(rec)
 	pool = R.WorkerPool(2, h.site, gateway, rec, flag_value=0).start()
-	P.background_flood(h.site, flood_n, queue_name="jarvis_chat", work_ms=800)
-	P.background_flood(h.site, flood_n // 2, queue_name="long", work_ms=800)
+	flood = P.FloodPump(h.site, ["jarvis_chat", "long"], per_burst=(30 if h.quick else 80), interval_s=2.0).start()
 	convs = [h.mk_conv() for _ in range(4)]
 	for c in convs:
 		h.warm_session(c, gateway)
@@ -497,34 +501,43 @@ def scenario_canary_c6(h: Harness, gateway: FakeGateway):
 			for c in convs
 		]
 		h.run_wave(pool, specs, timeout=60)
+	flood.stop()
 	pool.stop()
 	canary.stop()
-	full = canary.series()
-	# derive load-window samples = full minus idle-window count
-	idle_ct = idle_snapshot["count"]
 
-	def _tail(key):
-		return full[key][idle_ct:] if isinstance(full.get(key), list) else full.get(key)
+	with canary._lock:
+		all_samples = list(canary.samples)
+	load_samples = all_samples[idle_ct:]
 
-	load_snapshot = {
-		"short_wait_ms": P.summarize(_tail("short_wait_ms")),
-		"long_wait_ms": P.summarize(_tail("long_wait_ms")),
-		"desk_ms": P.summarize(_tail("desk_ms")),
-		"samples": full["count"] - idle_ct,
-		"starved_total": full["starved"],
-		"desk_failures_total": full["desk_failures"],
-	}
+	def _agg(samples, key, sub="wait_ms"):
+		if key == "desk":
+			return P.summarize([s["desk"]["ms"] for s in samples if s["desk"].get("ok")])
+		return P.summarize([s[key][sub] for s in samples])
+
+	def _starved(samples):
+		return sum(1 for s in samples if s["short"].get("starved") or s["long"].get("starved"))
+
 	return {
 		"idle_window_s": idle_s,
 		"load_window_s": load_s,
-		"flood_jobs": flood_n + flood_n // 2,
+		"canary_cadence_s": cadence,
+		"flood_queues": ["jarvis_chat", "long"],
+		"flood_jobs_total": flood.total,
+		"wait_ms_derivation": "RQ job started_at - enqueued_at (worker-populated); no harness code runs in the worker",
 		"idle": {
-			"short_wait_ms": P.summarize(idle_snapshot["short_wait_ms"]),
-			"long_wait_ms": P.summarize(idle_snapshot["long_wait_ms"]),
-			"desk_ms": P.summarize(idle_snapshot["desk_ms"]),
-			"samples": idle_snapshot["count"],
+			"short_wait_ms": _agg(idle_samples, "short"),
+			"long_wait_ms": _agg(idle_samples, "long"),
+			"desk_ms": _agg(idle_samples, "desk"),
+			"samples": len(idle_samples),
+			"starved": _starved(idle_samples),
 		},
-		"under_load": load_snapshot,
+		"under_load": {
+			"short_wait_ms": _agg(load_samples, "short"),
+			"long_wait_ms": _agg(load_samples, "long"),
+			"desk_ms": _agg(load_samples, "desk"),
+			"samples": len(load_samples),
+			"starved": _starved(load_samples),
+		},
 	}
 
 

--- a/jarvis/tests/harness/trace_recorder.py
+++ b/jarvis/tests/harness/trace_recorder.py
@@ -1,0 +1,179 @@
+"""TraceRecorder — per-turn timestamped bench-event traces.
+
+Captures, for every run, the ordered sequence of things the bench does during
+a turn — the diffable unit for legacy-vs-pump equivalence (Stage B):
+
+  * job lifecycle        submit / start / end  (worker-pool executor)
+  * gateway server-side  ack / lane_admit / first_frame / terminal
+                         (merged from the FakeGateway RunTimeline at dump)
+  * realtime publishes   assistant:delta / tool:start / tool:end / run:error /
+                         run:recovering / ... (the REAL turn_handler fan-out,
+                         captured by stubbing jarvis.chat.worker.publish_to_user)
+  * DB-write summaries   msg.content.flush (real _AssistantContentBatcher
+                         commits) + tool-row writes (encoded 1:1 by the
+                         tool:start/tool:end publishes that carry a message_id)
+
+Each run also gets a normalized ``signature`` — ordered publish kinds, DB-write
+count, tool count, terminal kind — the whitelist-diffable equivalence key
+(timing + batch boundaries allowed to differ; content / kinds / terminal /
+side-effect counts must match).
+
+Thread-safe: worker threads append concurrently; timestamps are monotonic
+(ordering within a run) plus wall-clock (human reading).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Event:
+	run_id: str
+	seq: int
+	t_mono: float
+	t_wall: float
+	source: str  # job | gateway | publish | db
+	kind: str
+	detail: dict | None = None
+
+
+@dataclass
+class TraceRecorder:
+	label: str = ""
+	_events: list[_Event] = field(default_factory=list)
+	_lock: threading.Lock = field(default_factory=threading.Lock)
+	_seq: int = 0
+	t0_mono: float = field(default_factory=time.monotonic)
+
+	def record(
+		self, run_id: str, source: str, kind: str, detail: dict | None = None, t_mono: float | None = None
+	) -> None:
+		ev = _Event(
+			run_id=run_id,
+			seq=0,
+			t_mono=t_mono if t_mono is not None else time.monotonic(),
+			t_wall=time.time(),
+			source=source,
+			kind=kind,
+			detail=detail,
+		)
+		with self._lock:
+			self._seq += 1
+			ev.seq = self._seq
+			self._events.append(ev)
+
+	# convenience wrappers
+	def job(self, run_id: str, kind: str, detail: dict | None = None, t_mono: float | None = None) -> None:
+		self.record(run_id, "job", kind, detail, t_mono)
+
+	def publish(self, run_id: str, kind: str, detail: dict | None = None) -> None:
+		self.record(run_id, "publish", kind, detail)
+
+	def db(self, run_id: str, kind: str, detail: dict | None = None) -> None:
+		self.record(run_id, "db", kind, detail)
+
+	# ---- gateway merge ----------------------------------------------------
+
+	def attach_gateway(self, gateway) -> None:
+		"""Merge each run's server-side timeline (ack/lane/first-frame/terminal)
+		into the trace, using the gateway's monotonic clock (same process)."""
+		for run_id in self.run_ids():
+			tl = gateway.timeline(run_id)
+			if not tl:
+				continue
+			if tl.ack_ts is not None:
+				self.record(run_id, "gateway", "ack", {"transcript": tl.transcript}, t_mono=tl.ack_ts)
+			if tl.lane_admit_ts is not None:
+				self.record(
+					run_id, "gateway", "lane_admit", {"dwell_ms": tl.dwell_ms()}, t_mono=tl.lane_admit_ts
+				)
+			if tl.first_frame_ts is not None:
+				self.record(run_id, "gateway", "first_frame", None, t_mono=tl.first_frame_ts)
+			if tl.terminal_ts is not None:
+				self.record(
+					run_id,
+					"gateway",
+					"terminal",
+					{"kind": tl.terminal_kind, "frames": tl.frames_sent},
+					t_mono=tl.terminal_ts,
+				)
+
+	# ---- queries ----------------------------------------------------------
+
+	def run_ids(self) -> list[str]:
+		with self._lock:
+			seen = []
+			s = set()
+			for ev in self._events:
+				if ev.run_id not in s:
+					s.add(ev.run_id)
+					seen.append(ev.run_id)
+		return seen
+
+	def events_for(self, run_id: str) -> list[_Event]:
+		with self._lock:
+			evs = [e for e in self._events if e.run_id == run_id]
+		return sorted(evs, key=lambda e: (e.t_mono, e.seq))
+
+	def signature(self, run_id: str) -> dict:
+		"""The Stage-B equivalence key: content-bearing, timing-free."""
+		evs = self.events_for(run_id)
+		publishes = [e.kind for e in evs if e.source == "publish"]
+		db_writes = sum(1 for e in evs if e.source == "db")
+		tools = sum(1 for e in evs if e.source == "publish" and e.kind == "tool:start")
+		terminal = next(
+			(
+				e.detail.get("kind")
+				for e in reversed(evs)
+				if e.source == "gateway" and e.kind == "terminal" and e.detail
+			),
+			None,
+		)
+		relay_terminal = next(
+			(
+				e.detail.get("relay_kind")
+				for e in reversed(evs)
+				if e.source == "job" and e.kind == "end" and e.detail
+			),
+			None,
+		)
+		return {
+			"publish_kinds": publishes,
+			"publish_kind_counts": dict(Counter(publishes)),
+			"db_write_count": db_writes,
+			"tool_count": tools,
+			"gateway_terminal": terminal,
+			"relay_terminal": relay_terminal,
+		}
+
+	# ---- dump -------------------------------------------------------------
+
+	def to_dict(self) -> dict:
+		runs = {}
+		for run_id in self.run_ids():
+			evs = self.events_for(run_id)
+			base = evs[0].t_mono if evs else 0.0
+			runs[run_id] = {
+				"events": [
+					{
+						"rel_ms": round((e.t_mono - base) * 1000.0, 3),
+						"t_wall": e.t_wall,
+						"source": e.source,
+						"kind": e.kind,
+						"detail": e.detail,
+					}
+					for e in evs
+				],
+				"signature": self.signature(run_id),
+			}
+		return {"label": self.label, "run_count": len(runs), "runs": runs}
+
+	def dump(self, path: str) -> str:
+		with open(path, "w") as fh:
+			json.dump(self.to_dict(), fh, indent=2, default=str)
+		return path

--- a/jarvis/tests/harness/transcripts.py
+++ b/jarvis/tests/harness/transcripts.py
@@ -1,0 +1,291 @@
+"""The 8 scripted transcripts (fixture data) for the differential harness.
+
+These are the deterministic openclaw run playbacks the fake gateway streams.
+Each transcript models one row of the WP-2 matrix:
+
+    success, tool-heavy, confirmation-card, overflow/compaction,
+    abort, ack-timeout, ws-drop, recovered
+
+A transcript is a plain dict (JSON-serialisable) with:
+
+  name          str
+  description   str
+  ack           {"status": "started"} | {"status": "in_flight"} | ...
+  ack_behavior  "normal" | "timeout"   (timeout: delay the ack past the
+                client ack window so the bench parks for snapshot recovery)
+  frames        ordered list of ops the gateway plays AFTER the ack, once the
+                run is admitted to the (simulated) main lane:
+                  {"op":"assistant","text":<cumulative>,"delta":<incremental>}
+                  {"op":"tool_start","name","call_id","title"}
+                  {"op":"tool_end","call_id","status"}
+                  {"op":"lifecycle_error","error":<str>}   (non-terminal on the
+                      bench: "context overflow" reroutes to run:recovering)
+                  {"op":"pause","ms":<int>}                (explicit extra dwell)
+  terminal      {"kind":"final","text":<str|None>}
+                | {"kind":"error","state":"error","errorMessage":<str>}
+                | {"kind":"aborted"}                      (also emitted on
+                    chat.abort regardless of scripted point)
+                | {"kind":"failed_final","stopReason":"error"}
+  inject        optional fault: {"drop_after_frame": <idx>}  (WS-drop) |
+                {"recover_via":"history","final_text":<str>} (recovered:
+                    stream is cut, the durable transcript still holds the
+                    full answer for a snapshot-recovery finalize)
+
+``text`` on the terminal final is the authoritative answer
+(``_chat_final_text`` joins message.content). The gateway derives the chat
+final ``message.content`` block from it.
+
+The transcripts are built in Python (the maintainable source of truth) and can
+be exported to ``fixtures/transcripts/*.json`` via ``dump_fixtures()`` for
+inspection / diffing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "transcripts")
+
+
+def _stream_text(full: str, chunk_words: int = 2) -> list[dict]:
+	"""Expand a full answer into cumulative assistant deltas (word-chunked),
+	exactly the shape openclaw emits (stream=assistant, cumulative text +
+	incremental delta)."""
+	words = full.split(" ")
+	frames: list[dict] = []
+	acc: list[str] = []
+	i = 0
+	while i < len(words):
+		chunk = words[i : i + chunk_words]
+		i += chunk_words
+		delta = (" " if acc else "") + " ".join(chunk)
+		acc.extend(chunk)
+		frames.append({"op": "assistant", "text": " ".join(acc), "delta": delta})
+	return frames
+
+
+_SUCCESS_TEXT = (
+	"Here is the summary you asked for. The three overdue invoices total "
+	"forty two thousand rupees across two customers, and the oldest is "
+	"eighteen days past its due date. I would prioritise the Acme invoice "
+	"first because it is both the largest and the oldest, then follow up on "
+	"the two smaller Globex invoices together in a single reminder."
+)
+
+_TOOL_INTRO = "Let me pull the current figures for you."
+_TOOL_MID = "Got the invoice list. Now checking the customer balances."
+_TOOL_ANSWER = (
+	"Across the two customers you have three open invoices worth forty two "
+	"thousand rupees. Acme is the largest exposure at thirty thousand."
+)
+
+_CONFIRM_TEXT = (
+	"I have prepared a payment reminder for the Acme overdue invoice. Please "
+	"review the draft below and confirm before I send it."
+)
+
+_OVERFLOW_PRE = "Reading the full thread history to answer accurately."
+_OVERFLOW_POST = (
+	"Thanks for waiting — I compacted the older context and here is the "
+	"answer: the reconciliation matches for all but one line, which is off "
+	"by ninety rupees due to a rounding difference."
+)
+
+_RECOVERED_TEXT = (
+	"The month-end close checklist is complete: all journals are posted, the "
+	"bank reconciliation ties out, and the trial balance is in balance."
+)
+
+_ABORT_PARTIAL = "Starting the export now, this will take a few moments as I gather"
+
+
+def _build() -> dict[str, dict]:
+	t: dict[str, dict] = {}
+
+	# 1. success — a clean answer, no tools.
+	t["success"] = {
+		"name": "success",
+		"description": "Clean single-answer turn, no tools, terminal final.",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": _stream_text(_SUCCESS_TEXT),
+		"terminal": {"kind": "final", "text": _SUCCESS_TEXT},
+	}
+
+	# 2. tool-heavy — assistant + 3 tool round-trips interleaved.
+	tool_frames: list[dict] = []
+	tool_frames += _stream_text(_TOOL_INTRO)
+	tool_frames += [
+		{"op": "tool_start", "name": "jarvis__get_list", "call_id": "t1", "title": "get_list Sales Invoice"},
+		{"op": "pause", "ms": 180},
+		{"op": "tool_end", "call_id": "t1", "status": "completed"},
+	]
+	tool_frames += _stream_text(_TOOL_MID)
+	tool_frames += [
+		{"op": "tool_start", "name": "jarvis__query", "call_id": "t2", "title": "query Customer balances"},
+		{"op": "pause", "ms": 220},
+		{"op": "tool_end", "call_id": "t2", "status": "completed"},
+		{"op": "tool_start", "name": "browser", "call_id": "t3", "title": "open dashboard"},
+		{"op": "pause", "ms": 150},
+		{"op": "tool_end", "call_id": "t3", "status": "completed"},
+	]
+	tool_frames += _stream_text(_TOOL_ANSWER)
+	t["tool-heavy"] = {
+		"name": "tool-heavy",
+		"description": "Assistant text interleaved with three tool call round-trips (two jarvis__, one built-in browser), terminal final.",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": tool_frames,
+		"terminal": {"kind": "final", "text": _TOOL_ANSWER},
+	}
+
+	# 3. confirmation-card — assistant text + a confirm-gated jarvis tool that
+	#    stays "running" (the bench renders the card and awaits the user); the
+	#    run ends final with the draft prepared. Used for the storm scenario.
+	confirm_frames: list[dict] = []
+	confirm_frames += _stream_text(_CONFIRM_TEXT)
+	confirm_frames += [
+		{
+			"op": "tool_start",
+			"name": "jarvis__update_doc",
+			"call_id": "c1",
+			"title": "update_doc Payment Reminder (needs confirm)",
+		},
+		{"op": "pause", "ms": 120},
+	]
+	t["confirmation-card"] = {
+		"name": "confirmation-card",
+		"description": "Assistant proposes a change and opens a confirmation card (jarvis__update_doc, confirm-gated); terminal final leaves the card awaiting the user.",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": confirm_frames,
+		"terminal": {"kind": "final", "text": _CONFIRM_TEXT},
+	}
+
+	# 4. overflow/compaction — a mid-stream context-overflow lifecycle error
+	#    (the bench marks run:recovering and KEEPS streaming), a compaction
+	#    pause, then the real answer and a terminal final.
+	overflow_frames: list[dict] = []
+	overflow_frames += _stream_text(_OVERFLOW_PRE)
+	overflow_frames += [
+		{
+			"op": "lifecycle_error",
+			"error": "Context overflow: prompt too large for the model; auto-compacting",
+		},
+		{"op": "pause", "ms": 600},
+	]
+	overflow_frames += _stream_text(_OVERFLOW_POST)
+	t["overflow-compaction"] = {
+		"name": "overflow-compaction",
+		"description": (
+			"Mid-stream context-overflow lifecycle error, a compaction pause, then the answer "
+			"streams and terminal final. NOTE: on the MANAGED relay path relay_turn_events drops "
+			"lifecycle frames, so the bench sees a longer turn that resolves to final (openclaw "
+			"auto-compacts internally); the run:recovering UX is a self-host-path (stream_agent_turn) "
+			"behavior. The lifecycle_error frame is retained so the self-host consumer + Stage-B "
+			"differential still exercise it."
+		),
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": overflow_frames,
+		"terminal": {"kind": "final", "text": _OVERFLOW_POST},
+	}
+
+	# 5. abort — a partial stream, then the user stops it; the gateway emits an
+	#    aborted terminal (also emitted immediately on receiving chat.abort).
+	abort_frames = _stream_text(_ABORT_PARTIAL)
+	t["abort"] = {
+		"name": "abort",
+		"description": "Partial stream then a user stop; terminal aborted (also emitted on chat.abort). Drives the stop-click->visible-stop probe.",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": abort_frames,
+		"terminal": {"kind": "aborted"},
+	}
+
+	# 6. ack-timeout — the gateway delays the chat.send response past the
+	#    client's ack window; the bench parks for snapshot recovery
+	#    (relay:interrupted reason=ack-timeout). openclaw still ran the turn,
+	#    so the durable transcript holds the answer.
+	t["ack-timeout"] = {
+		"name": "ack-timeout",
+		"description": "chat.send ack delayed past the client window -> OpenclawUnreachable(ack-timeout) -> bench parks; the transcript still completes server-side.",
+		"ack": {"status": "started"},
+		"ack_behavior": "timeout",
+		"frames": _stream_text(_SUCCESS_TEXT),
+		"terminal": {"kind": "final", "text": _SUCCESS_TEXT},
+	}
+
+	# 7. ws-drop — the gateway closes the socket mid-stream; the relay yields
+	#    relay:interrupted reason=transport and the pool evicts the corpse.
+	dropdrop_frames = _stream_text(_RECOVERED_TEXT)
+	t["ws-drop"] = {
+		"name": "ws-drop",
+		"description": "Gateway closes the WS mid-stream -> relay:interrupted reason=transport; pooled connection is evicted.",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": dropdrop_frames,
+		"terminal": {"kind": "final", "text": _RECOVERED_TEXT},
+		"inject": {"drop_after_frame": max(1, len(dropdrop_frames) // 3)},
+	}
+
+	# 8. recovered — like ws-drop, but the durable transcript (chat.history /
+	#    sessions.get) still holds the full answer, so snapshot recovery can
+	#    finalize it. The fixture records the recovery final text so Stage-B
+	#    recovery probes can assert the resolved outcome.
+	recovered_frames = _stream_text(_RECOVERED_TEXT)
+	t["recovered"] = {
+		"name": "recovered",
+		"description": "Mid-stream drop whose durable transcript still holds the complete answer; snapshot recovery finalizes it (Stage-B recovery fixture).",
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": recovered_frames,
+		"terminal": {"kind": "final", "text": _RECOVERED_TEXT},
+		"inject": {
+			"drop_after_frame": max(1, len(recovered_frames) // 2),
+			"recover_via": "history",
+			"final_text": _RECOVERED_TEXT,
+		},
+	}
+
+	return t
+
+
+TRANSCRIPTS: dict[str, dict] = _build()
+
+# The 8 canonical names, in matrix order.
+NAMES = [
+	"success",
+	"tool-heavy",
+	"confirmation-card",
+	"overflow-compaction",
+	"abort",
+	"ack-timeout",
+	"ws-drop",
+	"recovered",
+]
+
+
+def get(name: str) -> dict:
+	if name not in TRANSCRIPTS:
+		raise KeyError(f"unknown transcript {name!r}; have {sorted(TRANSCRIPTS)}")
+	return TRANSCRIPTS[name]
+
+
+def dump_fixtures(out_dir: str = FIXTURE_DIR) -> list[str]:
+	"""Write each transcript to fixtures/transcripts/<name>.json (inspectable
+	data). Returns the paths written."""
+	os.makedirs(out_dir, exist_ok=True)
+	written = []
+	for name in NAMES:
+		path = os.path.join(out_dir, f"{name}.json")
+		with open(path, "w") as fh:
+			json.dump(TRANSCRIPTS[name], fh, indent=2)
+		written.append(path)
+	return written
+
+
+if __name__ == "__main__":
+	for p in dump_fixtures():
+		print("wrote", p)

--- a/jarvis/tests/harness/turn_runner.py
+++ b/jarvis/tests/harness/turn_runner.py
@@ -1,0 +1,432 @@
+"""turn_runner — the faithful legacy managed-relay reproduction + worker pool.
+
+A harness "turn" runs the REAL bench transport and streaming path:
+
+  checkout/connect (real OpenclawSession)
+    -> create_session / watermark read (faithful pre-send RPCs)
+    -> chat_send                       (real ack)
+    -> relay_turn_events               (real relay)
+       feeding real turn_handler._handle_event + a recording subclass of the
+       real _AssistantContentBatcher (real DB commits + real publish fan-out)
+    -> terminal finalize               (streaming=0 / _mark_errored)
+
+The only things NOT exercised are the ~1000-line pre-stream preamble of
+handle_chat_send (model resolution, vision, context injection, admission) —
+one-time per-conversation setup, not the streaming latency the C-criteria
+measure. Admission (flag ON) is driven separately by the orchestrator through
+the REAL accept_or_queue chokepoint.
+
+A "worker" is a thread holding one turn end-to-end (legacy worker-per-turn).
+``WorkerPool(size=2)`` is therefore the 2-background-worker starvation bed.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+
+from jarvis.tests.harness import CONV, HARNESS_USER, MSG
+
+# ---- process-wide stubs (thread-safe: plain module-attribute swaps) --------
+
+
+def _b64u(raw: bytes) -> str:
+	return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def make_creds():
+	from cryptography.hazmat.primitives import serialization
+	from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+	from jarvis.chat.device import ChatDeviceCredentials
+
+	priv = Ed25519PrivateKey.generate()
+	pub_raw = priv.public_key().public_bytes(
+		encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+	)
+	return ChatDeviceCredentials(
+		device_id=hashlib.sha256(pub_raw).hexdigest(),
+		public_key=_b64u(pub_raw),
+		private_key=priv,
+		device_token="tok-harness",
+	)
+
+
+# The publish stub records into whichever recorder is active for the current
+# scenario. A module global lets the process-wide stub target per-scenario
+# recorders without re-patching each time (thread-safe: single reference swap).
+_ACTIVE_RECORDER = None
+
+
+def set_active_recorder(recorder) -> None:
+	global _ACTIVE_RECORDER
+	_ACTIVE_RECORDER = recorder
+
+
+def install_stubs():
+	"""Swap ensure_paired (avoid real device pairing) + publish_to_user (record
+	the realtime fan-out instead of hitting socketio). Returns a restore fn.
+	Point the recorder with set_active_recorder() per scenario."""
+	import jarvis.chat.openclaw_client as oc
+	import jarvis.chat.worker as worker
+
+	orig_ensure = oc.ensure_paired
+	orig_publish = worker.publish_to_user
+
+	def _stub_ensure():
+		return make_creds()
+
+	def _rec_publish(user, payload):
+		rec = _ACTIVE_RECORDER
+		if rec is None:
+			return
+		kind = payload.get("kind", "?")
+		run_id = payload.get("run_id") or "?"
+		detail = {"user": user}
+		if "tool_name" in payload:
+			detail["tool_name"] = payload.get("tool_name")
+		if payload.get("message_id") is not None:
+			detail["message_id"] = payload.get("message_id")
+		if kind.startswith("assistant"):
+			detail["len"] = len(payload.get("text") or "")
+		rec.publish(run_id, kind, detail)
+
+	oc.ensure_paired = _stub_ensure
+	# turn_handler dereferences publish through the worker module at call time,
+	# so rebinding here redirects every outbound publish (documented in worker.py).
+	worker.publish_to_user = _rec_publish
+
+	def restore():
+		oc.ensure_paired = orig_ensure
+		worker.publish_to_user = orig_publish
+
+	return restore
+
+
+# ---- recording batcher (real DB write, records the flush) ------------------
+
+
+def _recording_batcher(msg_name, run_id, recorder):
+	from jarvis.chat.turn_handler import _AssistantContentBatcher
+
+	class _RecordingBatcher(_AssistantContentBatcher):
+		def flush(self) -> bool:
+			did = super().flush()
+			if did:
+				recorder.db(run_id, "msg.content.flush", {"msg": msg_name})
+			return did
+
+	return _RecordingBatcher(msg_name)
+
+
+# ---- turn spec / result ----------------------------------------------------
+
+
+@dataclass
+class TurnSpec:
+	run_id: str
+	conversation_id: str
+	seed_message: str
+	transcript: str = "success"
+	turn_class: str = "interactive"
+	user: str = HARNESS_USER
+	overrides: dict = field(default_factory=dict)
+	soft_deadline_s: float = 30.0
+	ack_timeout_s: float | None = None  # short client ack window (ack-timeout tests)
+	settle_on_terminal: bool = False  # flag-ON: call admission.settle_turn
+	connect_mode: str = "per_turn"  # per_turn (fork-per-job) | pool (nofork)
+	t_submit: float | None = None
+
+
+@dataclass
+class TurnResult:
+	run_id: str
+	transcript: str
+	conversation: str
+	t_submit: float | None = None
+	t_start: float | None = None
+	t_send: float | None = None
+	t_first_frame: float | None = None
+	t_end: float | None = None
+	terminal: str | None = None
+	relay_state: str | None = None
+	error: str | None = None
+
+	def first_token_from_submit_ms(self):
+		if self.t_submit is None or self.t_first_frame is None:
+			return None
+		return (self.t_first_frame - self.t_submit) * 1000.0
+
+	def first_token_from_send_ms(self):
+		if self.t_send is None or self.t_first_frame is None:
+			return None
+		return (self.t_first_frame - self.t_send) * 1000.0
+
+	def queue_wait_ms(self):
+		if self.t_submit is None or self.t_start is None:
+			return None
+		return (self.t_start - self.t_submit) * 1000.0
+
+	def total_ms(self):
+		if self.t_submit is None or self.t_end is None:
+			return None
+		return (self.t_end - self.t_submit) * 1000.0
+
+
+# ---- the faithful turn -----------------------------------------------------
+
+
+def run_turn(spec: TurnSpec, gateway, recorder) -> TurnResult:
+	import frappe
+
+	from jarvis.chat import openclaw_session_pool, turn_handler
+	from jarvis.chat.openclaw_client import OpenclawSession
+	from jarvis.exceptions import OpenclawUnreachableError
+
+	res = TurnResult(run_id=spec.run_id, transcript=spec.transcript, conversation=spec.conversation_id)
+	res.t_submit = spec.t_submit
+	res.t_start = time.monotonic()
+	recorder.job(
+		spec.run_id,
+		"start",
+		{"conversation": spec.conversation_id, "transcript": spec.transcript},
+		t_mono=res.t_start,
+	)
+
+	frappe.set_user(spec.user)
+	conv = frappe.get_doc(CONV, spec.conversation_id)
+	assistant = turn_handler._create_assistant_placeholder(conv)
+	recorder.db(spec.run_id, "assistant.placeholder.insert", {"msg": assistant.name})
+
+	gateway.arm(spec.run_id, spec.transcript, **(spec.overrides or {}))
+
+	def _do(sess: "OpenclawSession") -> None:
+		if not conv.session_key:
+			sk = sess.create_session()
+			frappe.db.set_value(CONV, conv.name, "session_key", sk)
+			frappe.db.commit()
+			conv.session_key = sk
+		# faithful pre-send watermark read
+		try:
+			sess.get_session_messages(conv.session_key, limit=5)
+		except OpenclawUnreachableError:
+			raise
+
+		res.t_send = time.monotonic()
+		ack_to = spec.ack_timeout_s if spec.ack_timeout_s is not None else 30.0
+		try:
+			ack = sess.chat_send(conv.session_key, "harness turn", spec.run_id, timeout_s=ack_to) or {}
+		except OpenclawUnreachableError as e:
+			if getattr(e, "code", None) != "ack-timeout":
+				raise
+			res.terminal = "relay:interrupted"
+			res.relay_state = "ack-timeout"
+			recorder.job(
+				spec.run_id, "end", {"relay_kind": "relay:interrupted", "relay_state": "ack-timeout"}
+			)
+			return
+
+		batcher = _recording_batcher(assistant.name, spec.run_id, recorder)
+		tool_map: dict[str, str] = {}
+		terminal = {"kind": "relay:interrupted", "reason": "stream-exhausted"}
+		for ev in sess.relay_turn_events(
+			conv.session_key, ack.get("runId") or spec.run_id, soft_deadline_s=spec.soft_deadline_s
+		):
+			kind = ev.get("kind")
+			if str(kind or "").startswith("relay:"):
+				terminal = ev
+				break
+			if res.t_first_frame is None and kind in ("assistant", "tool"):
+				res.t_first_frame = time.monotonic()
+			turn_handler._handle_event(
+				ev,
+				conversation_id=conv.name,
+				assistant_msg_name=assistant.name,
+				tool_msg_by_call_id=tool_map,
+				user=spec.user,
+				run_id=spec.run_id,
+				batcher=batcher,
+			)
+		batcher.flush()
+		res.terminal = terminal.get("kind")
+		res.relay_state = terminal.get("state") or terminal.get("reason")
+		_finalize(assistant.name, terminal, recorder, spec.run_id)
+		recorder.job(spec.run_id, "end", {"relay_kind": res.terminal, "relay_state": res.relay_state})
+
+	try:
+		if spec.connect_mode == "pool":
+			with openclaw_session_pool.checkout(gateway.ws_url) as sess:
+				_do(sess)
+		else:
+			sess = OpenclawSession.connect(gateway.ws_url)
+			try:
+				_do(sess)
+			finally:
+				sess.close()
+	except OpenclawUnreachableError as e:
+		res.terminal = "unreachable"
+		res.error = str(e)
+		recorder.job(spec.run_id, "end", {"relay_kind": "unreachable", "error": str(e)})
+	except Exception as e:  # never let one turn kill the pool
+		res.terminal = "harness-error"
+		res.error = repr(e)
+		recorder.job(spec.run_id, "end", {"relay_kind": "harness-error", "error": repr(e)})
+
+	res.t_end = time.monotonic()
+
+	if spec.settle_on_terminal:
+		_settle(spec, res)
+	return res
+
+
+def _finalize(msg_name: str, terminal: dict, recorder, run_id: str) -> None:
+	"""Mirror the worker's terminal DB write (streaming=0 / _mark_errored)."""
+	import frappe
+
+	from jarvis.chat import turn_handler
+
+	kind = terminal.get("kind")
+	if kind == "relay:final":
+		frappe.db.set_value(MSG, msg_name, "streaming", 0)
+		frappe.db.commit()
+		recorder.db(run_id, "msg.finalize", {"msg": msg_name})
+	elif kind == "relay:error":
+		turn_handler._mark_errored(msg_name, terminal.get("error") or terminal.get("state") or "error")
+		recorder.db(run_id, "msg.errored", {"msg": msg_name})
+	# relay:interrupted -> leave streaming=1 (recovery/sweep territory)
+
+
+def _settle(spec: TurnSpec, res: TurnResult) -> None:
+	from jarvis.chat import admission
+
+	kind, state = res.terminal, (res.relay_state or "")
+	if kind == "relay:final":
+		term = "done"
+	elif kind == "relay:error" and state == "aborted":
+		term = "cancelled"
+	elif kind in ("relay:error", "unreachable", "harness-error"):
+		term = "errored"
+	else:  # interrupted / parked
+		term = "errored"
+	try:
+		admission.settle_turn(spec.run_id, term)
+	except Exception:
+		pass
+
+
+# ---- worker pool -----------------------------------------------------------
+
+
+class WorkerPool:
+	"""Bounded thread pool; each worker holds one turn end-to-end (legacy
+	worker-per-turn). Each worker thread owns its own frappe DB connection and
+	an optional per-process admission flag override."""
+
+	def __init__(self, size: int, site: str, gateway, recorder, *, flag_value: int | None = None):
+		self.size = size
+		self.site = site
+		self.gateway = gateway
+		self.recorder = recorder
+		self.flag_value = flag_value
+		self._q: "queue.Queue" = queue.Queue()
+		self._threads: list[threading.Thread] = []
+		self._results: dict[str, TurnResult] = {}
+		self._rlock = threading.Lock()
+		self._started = False
+		self._submitted = 0
+		self._completed = 0
+		self._clock = threading.Lock()
+
+	def start(self) -> "WorkerPool":
+		for i in range(self.size):
+			th = threading.Thread(target=self._loop, name=f"harness-worker-{i}", daemon=True)
+			th.start()
+			self._threads.append(th)
+		self._started = True
+		return self
+
+	def _loop(self) -> None:
+		import frappe
+
+		frappe.init(site=self.site)
+		frappe.connect()
+		if self.flag_value is not None:
+			from jarvis.chat import admission
+
+			frappe.local.conf[admission.FLAG] = self.flag_value
+		try:
+			while True:
+				item = self._q.get()
+				if item is None:
+					return
+				spec, done = item
+				try:
+					res = run_turn(spec, self.gateway, self.recorder)
+					with self._rlock:
+						self._results[spec.run_id] = res
+				except Exception as e:  # pragma: no cover - defensive
+					with self._rlock:
+						self._results[spec.run_id] = TurnResult(
+							run_id=spec.run_id,
+							transcript=spec.transcript,
+							conversation=spec.conversation_id,
+							terminal="pool-error",
+							error=repr(e),
+						)
+				finally:
+					try:
+						frappe.db.commit()
+					except Exception:
+						pass
+					with self._clock:
+						self._completed += 1
+					if done is not None:
+						done.set()
+		finally:
+			frappe.destroy()
+
+	def submit(self, spec: TurnSpec, done: threading.Event | None = None) -> None:
+		spec.t_submit = time.monotonic()
+		with self._clock:
+			self._submitted += 1
+		self.recorder.job(
+			spec.run_id,
+			"submit",
+			{"transcript": spec.transcript, "class": spec.turn_class},
+			t_mono=spec.t_submit,
+		)
+		self._q.put((spec, done))
+
+	def result(self, run_id: str) -> TurnResult | None:
+		with self._rlock:
+			return self._results.get(run_id)
+
+	def all_results(self) -> dict[str, TurnResult]:
+		with self._rlock:
+			return dict(self._results)
+
+	def drain(self, timeout: float = 120.0) -> bool:
+		"""Wait until every submitted turn has completed. Promotion (flag ON)
+		submits follow-on turns from inside run_turn BEFORE the completing turn
+		increments _completed, so _completed == _submitted only when quiescent."""
+		deadline = time.monotonic() + timeout
+		while time.monotonic() < deadline:
+			with self._clock:
+				quiescent = self._completed >= self._submitted and self._q.empty()
+			if quiescent:
+				time.sleep(0.05)
+				with self._clock:
+					if self._completed >= self._submitted and self._q.empty():
+						return True
+			time.sleep(0.02)
+		return False
+
+	def stop(self) -> None:
+		for _ in self._threads:
+			self._q.put(None)
+		for th in self._threads:
+			th.join(timeout=5)

--- a/jarvis/tests/test_chat_admission.py
+++ b/jarvis/tests/test_chat_admission.py
@@ -1,0 +1,762 @@
+"""Tests for jarvis.chat.admission - Phase-0 durable admission control (WP-0).
+
+Covers every acceptance check in the WP-0 direction brief:
+
+* Two simultaneous sends at cap 1 -> exactly one dispatching, one queued
+  (threaded, barrier-synchronized, real DB row locks).
+* Promotion on terminal within the same request cycle (no sweep).
+* Burst of 6 at cap 4 -> 4 dispatch / 2 queue; cancel renumbers positions.
+* Continuation (confirm path) at cap queues, does NOT bypass admission (R-7).
+* All four _dispatch_turn callers gated (send / retry / orphan / macro).
+* Reservation expiry: a lost enqueue is returned to dispatchable by the sweep.
+* Dual-signal coexistence: a legacy fresh-streaming Message counts as inflight.
+* Flag OFF -> byte-identical legacy behavior (no Turn rows, no gating).
+* Background floor: interactive holds at most ceiling-1 when background queued.
+
+Tests run as a dedicated fixture user and clean up their own Turn / Pump /
+Conversation rows. Cap is controlled by patching admission._max_inflight
+(process-wide, so child threads see it too); real dispatch is stubbed by
+patching jarvis.chat.api._dispatch_turn so no RQ jobs are enqueued.
+"""
+
+import threading
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import admission
+from jarvis.chat import api as chat_api
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+TURN = "Jarvis Chat Turn"
+PUMP = "Jarvis Relay Pump"
+TEST_USER = "jarvis-admission-test@example.com"
+
+
+def _ensure_test_user(user: str = TEST_USER) -> None:
+	if frappe.db.exists("User", user):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": user,
+			"first_name": "Admission",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	doc.add_roles("System Manager", "Jarvis User")
+	frappe.db.commit()
+
+
+def _cleanup(user: str = TEST_USER) -> None:
+	for name in frappe.get_all(CONV, filters={"owner": user}, pluck="name"):
+		frappe.db.delete(TURN, {"conversation": name})
+		frappe.db.delete(MSG, {"conversation": name})
+		frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+	# Phase-0 admission is a SITE-WIDE single-shard mechanism, so its counts see
+	# ALL non-terminal Turn rows and ALL fresh-streaming placeholders on the whole
+	# site - not just this test user's. A stray abandoned `dispatching` row from
+	# real dev traffic, or a fresh-streaming placeholder left by another test
+	# module within the 180s window, would inflate _shard_inflight /
+	# _shard_queued_depth (and the sweep summaries) and make the cap-sensitive
+	# tests flaky (turns that should dispatch stay queued). Establish a clean shard
+	# baseline: drop stray non-terminal Turn rows and age stray fresh-streaming
+	# placeholders out of the freshness window. Safe on the dedicated test site -
+	# these are abandoned rows the sweep would settle anyway; no conversation or
+	# message CONTENT is touched (only a streaming placeholder's `modified` stamp).
+	frappe.db.delete(TURN, {"state": ["in", ("queued", "dispatching")]})
+	stale = frappe.utils.add_to_date(None, seconds=-(admission._INFLIGHT_FRESH_SECONDS + 600))
+	frappe.db.sql(
+		"""UPDATE `tabJarvis Chat Message`
+		SET modified=%(old)s
+		WHERE role='assistant' AND streaming=1 AND recovering=0 AND modified > %(fresh)s""",
+		{"old": stale, "fresh": admission._fresh_cutoff()},
+	)
+	frappe.db.commit()
+
+
+class _AdmissionTestCase(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup()
+		# Force the flag ON for THIS suite regardless of the site's setting, so
+		# the ON-behavior tests are deterministic even when run on a flag-OFF site.
+		self._flag_patch = patch.dict(frappe.local.conf, {admission.FLAG: 1})
+		self._flag_patch.start()
+		self.assertTrue(admission.admission_enabled())
+		admission._ensure_control_row(admission.DEFAULT_RELAY_TARGET)
+
+	def tearDown(self):
+		self._flag_patch.stop()
+		_cleanup()
+		frappe.set_user(self._orig_user)
+
+	# ---- helpers ----------------------------------------------------------- #
+
+	def _mk_conv(self) -> str:
+		doc = frappe.get_doc({"doctype": CONV, "title": "New chat", "status": "Active"})
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		frappe.db.commit()
+		return doc.name
+
+	def _mk_msg(self, conv: str, seq: int, role: str = "user", content: str = "hi", **extra) -> str:
+		doc = frappe.get_doc(
+			{"doctype": MSG, "conversation": conv, "seq": seq, "role": role, "content": content, **extra}
+		)
+		doc.flags.ignore_permissions = True
+		doc.insert()
+		frappe.db.commit()
+		return doc.name
+
+	def _accept(self, conv: str, run_id: str, seed: str, turn_class: str = "interactive", calls=None):
+		return admission.accept_or_queue(
+			conversation=conv,
+			run_id=run_id,
+			seed_message=seed,
+			turn_class=turn_class,
+			dispatch=(lambda: calls.append(run_id)) if calls is not None else (lambda: None),
+		)
+
+	def _state(self, run_id: str) -> str:
+		return frappe.db.get_value(TURN, run_id, "state")
+
+	def _insert_turn(self, conv: str, run_id: str, seed: str, state: str, **extra) -> None:
+		row = {
+			"doctype": TURN,
+			"run_id": run_id,
+			"conversation": conv,
+			"relay_target_id": admission.DEFAULT_RELAY_TARGET,
+			"turn_class": "interactive",
+			"state": state,
+			"version": 1 if state != "queued" else 0,
+			"seed_message": seed,
+			"enqueued_at": frappe.utils.now(),
+		}
+		row.update(extra)
+		frappe.get_doc(row).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+
+# --------------------------------------------------------------------------- #
+
+
+class TestAcceptOrQueueBasics(_AdmissionTestCase):
+	def test_single_send_dispatches(self):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		calls = []
+		with patch.object(admission, "_max_inflight", return_value=4):
+			res = self._accept(conv, "run1", seed, calls=calls)
+		self.assertTrue(res["ok"])
+		self.assertTrue(res["dispatched"])
+		self.assertEqual(self._state("run1"), "dispatching")
+		self.assertEqual(calls, ["run1"])  # dispatch fired exactly once
+		row = frappe.db.get_value(TURN, "run1", ["reserved", "seed_message"], as_dict=True)
+		self.assertEqual(row["reserved"], 1)
+		self.assertEqual(row["seed_message"], seed)
+
+	def test_second_send_same_conversation_queues(self):
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		s2 = self._mk_msg(conv, 2)
+		with patch.object(admission, "_max_inflight", return_value=4):
+			self._accept(conv, "run1", s1)
+			res = self._accept(conv, "run2", s2)
+		# Single-flight: even with shard capacity, a second turn on the SAME
+		# conversation queues behind the first.
+		self.assertFalse(res["dispatched"])
+		self.assertEqual(self._state("run2"), "queued")
+		self.assertEqual(res["queued_position"], 1)
+
+	def test_duplicate_run_id_is_idempotent(self):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		with patch.object(admission, "_max_inflight", return_value=4):
+			self._accept(conv, "dup", seed)
+			res = self._accept(conv, "dup", seed)
+		self.assertTrue(res.get("duplicate"))
+		self.assertEqual(frappe.db.count(TURN, {"run_id": "dup"}), 1)
+
+
+class TestSimultaneousSendsCASRace(_AdmissionTestCase):
+	def test_two_simultaneous_sends_cap_one(self):
+		"""Barrier-synchronized threads, real separate DB connections, cap 1:
+		exactly one dispatching + one queued position 1 (no double-admit)."""
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		s2 = self._mk_msg(conv, 2)
+		site = frappe.local.site
+		barrier = threading.Barrier(2)
+		results: dict[str, dict] = {}
+		errors: list = []
+
+		def worker(run_id: str, seed: str):
+			frappe.init(site=site)
+			frappe.connect()
+			frappe.set_user(TEST_USER)
+			try:
+				barrier.wait(timeout=10)
+				results[run_id] = admission.accept_or_queue(
+					conversation=conv,
+					run_id=run_id,
+					seed_message=seed,
+					turn_class="interactive",
+					dispatch=lambda: None,
+				)
+			except Exception as e:
+				errors.append(e)
+			finally:
+				try:
+					frappe.db.commit()
+				finally:
+					frappe.destroy()
+
+		with patch.object(admission, "_max_inflight", return_value=1):
+			t1 = threading.Thread(target=worker, args=("A", s1))
+			t2 = threading.Thread(target=worker, args=("B", s2))
+			t1.start()
+			t2.start()
+			t1.join(timeout=20)
+			t2.join(timeout=20)
+
+		self.assertEqual(errors, [], f"worker error: {errors}")
+		states = sorted(frappe.db.get_value(TURN, r, "state") for r in ("A", "B"))
+		self.assertEqual(states, ["dispatching", "queued"], "exactly one dispatching, one queued")
+		# The queued one reports position 1.
+		queued = next(r for r in ("A", "B") if frappe.db.get_value(TURN, r, "state") == "queued")
+		self.assertEqual(admission._position_of(queued, admission.DEFAULT_RELAY_TARGET), 1)
+
+
+class TestPromotionOnTerminal(_AdmissionTestCase):
+	def test_terminal_promotes_next_in_same_cycle(self):
+		conv_a = self._mk_conv()
+		conv_b = self._mk_conv()
+		sa = self._mk_msg(conv_a, 1)
+		sb = self._mk_msg(conv_b, 1)
+		dispatched = []
+		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		):
+			self._accept(conv_a, "A", sa)  # dispatches (cap 1)
+			res_b = self._accept(conv_b, "B", sb)  # queues (shard full)
+			self.assertFalse(res_b["dispatched"])
+			self.assertEqual(self._state("B"), "queued")
+			# Terminal on A -> B promoted within THIS call (no sweep).
+			admission.settle_turn("A", "done")
+		self.assertEqual(self._state("A"), "done")
+		self.assertEqual(self._state("B"), "dispatching")
+		self.assertIn("B", dispatched)
+
+
+class TestBurstAndCancel(_AdmissionTestCase):
+	def test_burst_six_at_cap_four_positions_and_cancel(self):
+		convs = [self._mk_conv() for _ in range(6)]
+		seeds = [self._mk_msg(c, 1) for c in convs]
+		runs = [f"r{i}" for i in range(6)]
+		with patch.object(admission, "_max_inflight", return_value=4):
+			results = [self._accept(convs[i], runs[i], seeds[i]) for i in range(6)]
+		dispatched = [runs[i] for i in range(6) if results[i]["dispatched"]]
+		queued = [runs[i] for i in range(6) if not results[i]["dispatched"]]
+		self.assertEqual(len(dispatched), 4, "4 dispatch at cap 4")
+		self.assertEqual(len(queued), 2, "2 queue")
+		# Positions 1 and 2 (FIFO).
+		self.assertEqual(results[4]["queued_position"], 1)
+		self.assertEqual(results[5]["queued_position"], 2)
+		# Cancel the position-1 queued turn -> the other becomes position 1.
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			out = admission.cancel_queued_turn(runs[4])
+		self.assertTrue(out["ok"])
+		self.assertEqual(self._state(runs[4]), "cancelled")
+		self.assertEqual(admission._position_of(runs[5], admission.DEFAULT_RELAY_TARGET), 1)
+
+
+class TestContinuationNoBypass(_AdmissionTestCase):
+	def test_continuation_queues_at_cap_and_does_not_bypass(self):
+		"""R-7: enqueue_continuation routes through admission. At cap, the
+		continuation becomes a durable queued turn instead of a privileged
+		bypass that runs concurrently."""
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		dispatched = []
+		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		):
+			# Occupy the single credit with a live turn on this conversation.
+			self._accept(conv, "live", s1)
+			self.assertEqual(self._state("live"), "dispatching")
+			# A confirm continuation now must queue (not bypass).
+			out = chat_api.enqueue_continuation(conv, "created ORD-001")
+		run_id = out["run_id"]
+		self.assertEqual(self._state(run_id), "queued")
+		# It never dispatched while the live turn holds the credit.
+		self.assertNotIn(run_id, dispatched)
+
+
+class TestFourCallersGated(_AdmissionTestCase):
+	def test_send_message_creates_turn(self):
+		conv = self._mk_conv()
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			res = chat_api.send_message(conversation=conv, message="hello there")
+		self.assertTrue(res["ok"])
+		self.assertTrue(frappe.db.exists(TURN, res["run_id"]))
+		self.assertEqual(
+			frappe.db.get_value(TURN, res["run_id"], "turn_class"), "interactive"
+		)
+
+	def test_retry_message_creates_turn_reusing_seed(self):
+		conv = self._mk_conv()
+		u = self._mk_msg(conv, 1, role="user", content="do it")
+		a = self._mk_msg(conv, 2, role="assistant", content="", error="boom")
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			res = chat_api.retry_message(a)
+		self.assertTrue(res["ok"])
+		self.assertTrue(frappe.db.exists(TURN, res["run_id"]))
+		# OAR-3: retry reuses the EXISTING user message; no new user row.
+		self.assertEqual(frappe.db.get_value(TURN, res["run_id"], "seed_message"), u)
+		self.assertEqual(frappe.db.count(MSG, {"conversation": conv, "role": "user"}), 1)
+
+	def test_redispatch_orphan_creates_background_turn(self):
+		conv = self._mk_conv()
+		u = self._mk_msg(conv, 1)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			chat_api._redispatch_orphan(conv, u)
+		row = frappe.db.get_value(
+			TURN, {"conversation": conv, "seed_message": u}, ["turn_class", "state"], as_dict=True
+		)
+		self.assertIsNotNone(row)
+		self.assertEqual(row["turn_class"], "background")
+
+	def test_enqueue_turn_macro_caller_creates_turn(self):
+		conv = self._mk_conv()
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			out = chat_api._enqueue_turn(conv, "macro step", hidden=True)
+		self.assertTrue(frappe.db.exists(TURN, out["run_id"]))
+
+
+class TestReservationExpiry(_AdmissionTestCase):
+	def _mk_dispatching_turn(self, conv, seed, run_id, *, reservation_at, **extra):
+		row = {
+			"doctype": TURN,
+			"run_id": run_id,
+			"conversation": conv,
+			"relay_target_id": admission.DEFAULT_RELAY_TARGET,
+			"turn_class": "interactive",
+			"state": "dispatching",
+			"version": 1,
+			"seed_message": seed,
+			"reserved": 1,
+			"reservation_expires_at": reservation_at,
+			"dispatching_at": reservation_at,
+			"enqueued_at": reservation_at,
+		}
+		row.update(extra)
+		frappe.get_doc(row).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def test_sweep_reclaims_lost_dispatch(self):
+		"""A turn dispatched (reserved) whose enqueue was lost - no assistant
+		activity OF ITS OWN, reservation expired - is returned to queued by the
+		sweep. OARI-1: this now uses a NON-first-turn conversation (a PRIOR turn
+		settled before it) - the reviewer showed the old first-turn-only fixture
+		hid the reconcile/reclaim scoping bug (a first turn has no prior assistant
+		so `if not latest: continue` masked it)."""
+		conv = self._mk_conv()
+		# Prior turn 1: settled (user seq1 + assistant seq2, no error).
+		self._mk_msg(conv, 1, role="user", content="first")
+		self._mk_msg(conv, 2, role="assistant", content="reply one", streaming=0)
+		# Turn 2: this turn's seed (user seq3); its enqueue was lost - NO assistant
+		# row of its OWN (nothing with seq > 3).
+		seed = self._mk_msg(conv, 3, role="user", content="second")
+		past = frappe.utils.add_to_date(None, seconds=-60)
+		self._mk_dispatching_turn(conv, seed, "lost", reservation_at=past)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			summary = admission.sweep()
+		self.assertGreaterEqual(summary["reclaimed"], 1)
+		# It must be RECLAIMED (queued, or re-promoted to dispatching by the same
+		# sweep) - NEVER closed 'done' on the strength of turn 1's assistant row.
+		self.assertIn(self._state("lost"), ("queued", "dispatching"))
+		self.assertNotEqual(self._state("lost"), "done")
+		self.assertEqual(summary["reconciled"], 0, "must reclaim, not reconcile-close")
+		row = frappe.db.get_value(TURN, "lost", ["was_recovered"], as_dict=True)
+		self.assertEqual(row["was_recovered"], 1)
+
+	def test_sweep_does_not_close_turn_on_prior_settled_assistant(self):
+		"""OARI-1 narrow-window / probe B: a dispatching turn whose latest assistant
+		on the conversation is a PRIOR settled turn - and whose OWN placeholder has
+		not been written yet - must NOT be reconcile-closed 'done' (silent turn
+		loss + over-promotion). With a FRESH reservation it also isn't reclaimed:
+		it stays dispatching, untouched, waiting for its worker."""
+		conv = self._mk_conv()
+		self._mk_msg(conv, 1, role="user", content="first")
+		self._mk_msg(conv, 2, role="assistant", content="reply one", streaming=0)
+		seed = self._mk_msg(conv, 3, role="user", content="second")
+		future = frappe.utils.add_to_date(None, seconds=admission.RESERVE_TTL_S)
+		self._mk_dispatching_turn(conv, seed, "live2", reservation_at=future)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			summary = admission.sweep()
+		self.assertEqual(self._state("live2"), "dispatching", "live turn must not be closed")
+		self.assertEqual(summary["reconciled"], 0)
+		self.assertEqual(summary["reclaimed"], 0)
+
+	def test_sweep_closes_orphaned_stale_streaming_turn(self):
+		"""OARI-3: a dispatching turn whose OWN placeholder is a stale streaming
+		row past a lost worker (reservation expired >> the worker cap) is closed
+		errored so a post-deploy orphan frees its shard credit instead of pinning
+		it. A live turn (fresh) is covered by the sibling test below."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1, role="user", content="q")
+		# This turn's OWN placeholder: streaming, but stale (modified far in the
+		# past, past the freshness window).
+		stale = frappe.utils.add_to_date(None, seconds=-(admission._INFLIGHT_FRESH_SECONDS + 120))
+		amsg = self._mk_msg(conv, 2, role="assistant", content="", streaming=1, recovering=0)
+		frappe.db.set_value(MSG, amsg, "modified", stale, update_modified=False)
+		frappe.db.commit()
+		self._mk_dispatching_turn(
+			conv, seed, "orphan", reservation_at=frappe.utils.add_to_date(None, seconds=-60)
+		)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			summary = admission.sweep()
+		self.assertGreaterEqual(summary["reconciled"], 1)
+		self.assertEqual(self._state("orphan"), "errored")
+
+	def test_sweep_leaves_live_streaming_turn(self):
+		"""OARI-3 safety: a dispatching turn whose OWN placeholder is FRESH
+		streaming (worker actively producing) is NEVER closed - closing it would
+		free the credit and promote a second turn onto the same live session."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1, role="user", content="q")
+		self._mk_msg(conv, 2, role="assistant", content="thinking", streaming=1, recovering=0)
+		# Even with an expired reservation, a FRESH placeholder means live.
+		self._mk_dispatching_turn(
+			conv, seed, "livestream", reservation_at=frappe.utils.add_to_date(None, seconds=-60)
+		)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			admission.sweep()
+		self.assertEqual(self._state("livestream"), "dispatching")
+
+	def test_sweep_reservation_honors_cancel_requested(self):
+		"""OARI-6: a stopped turn (cancel_requested) whose worker died before a
+		placeholder must be CANCELLED by the reclaim sweep, never re-dispatched."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1, role="user", content="q")
+		past = frappe.utils.add_to_date(None, seconds=-60)
+		self._mk_dispatching_turn(conv, seed, "stopped", reservation_at=past, cancel_requested=1)
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			admission.sweep()
+		self.assertEqual(self._state("stopped"), "cancelled")
+
+
+class TestTurnMessageReconcile(_AdmissionTestCase):
+	def test_sweep_closes_dispatching_turn_when_message_settled(self):
+		"""Message truth wins: an assistant Message already settled but the Turn
+		still dispatching (missed terminal hook / flag flipped off mid-turn) is
+		closed by the reconcile sweep."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		self._mk_msg(conv, 2, role="assistant", content="done", streaming=0)
+		frappe.get_doc(
+			{
+				"doctype": TURN,
+				"run_id": "stuck",
+				"conversation": conv,
+				"relay_target_id": admission.DEFAULT_RELAY_TARGET,
+				"turn_class": "interactive",
+				"state": "dispatching",
+				"version": 1,
+				"seed_message": seed,
+				"reserved": 1,
+				"dispatching_at": frappe.utils.now(),
+				"enqueued_at": frappe.utils.now(),
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			summary = admission.sweep()
+		self.assertGreaterEqual(summary["reconciled"], 1)
+		self.assertEqual(self._state("stuck"), "done")
+
+
+class TestDualSignalCoexistence(_AdmissionTestCase):
+	def test_legacy_streaming_counts_as_inflight(self):
+		"""OAR-11: a legacy fresh-streaming assistant Message with no owning
+		Turn row counts toward shard inflight, so a new send at cap 1 queues."""
+		legacy_conv = self._mk_conv()
+		self._mk_msg(legacy_conv, 1, role="user")
+		# Fresh streaming assistant, no Turn row -> the legacy signal.
+		self._mk_msg(legacy_conv, 2, role="assistant", content="...", streaming=1, recovering=0)
+		self.assertGreaterEqual(admission._legacy_streaming_count(admission.DEFAULT_RELAY_TARGET), 1)
+
+		other = self._mk_conv()
+		seed = self._mk_msg(other, 1)
+		with patch.object(admission, "_max_inflight", return_value=1):
+			res = self._accept(other, "newrun", seed)
+		self.assertFalse(res["dispatched"], "legacy inflight fills cap 1 -> new send queues")
+		self.assertEqual(self._state("newrun"), "queued")
+
+
+class TestBackgroundFloor(_AdmissionTestCase):
+	def test_background_gets_floor_when_interactive_would_take_last_credit(self):
+		"""SUX-4a: with background queued, interactive holds at most cap-1
+		credits - promote_next gives the last credit to background."""
+		# cap 2. Fill one credit with an interactive dispatching turn, then queue
+		# one interactive + one background; promotion of the last credit must go
+		# to background (interactive capped at cap-1 = 1).
+		c_live = self._mk_conv()
+		c_int = self._mk_conv()
+		c_bg = self._mk_conv()
+		s_live = self._mk_msg(c_live, 1)
+		s_int = self._mk_msg(c_int, 1)
+		s_bg = self._mk_msg(c_bg, 1)
+		dispatched = []
+		with patch.object(admission, "_max_inflight", return_value=2), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		):
+			self._accept(c_live, "live", s_live, turn_class="interactive")  # dispatches (1/2)
+			# Force both to queue by accepting while a credit is free but making
+			# them queue via direct insert at queued, then promote.
+			self._accept(c_int, "qi", s_int, turn_class="interactive")  # dispatches (2/2)
+			self._accept(c_bg, "qb", s_bg, turn_class="background")  # queues (full)
+			self.assertEqual(self._state("qb"), "queued")
+			# Free one credit; the queued background turn should win it over any
+			# future interactive because interactive already holds cap-1.
+			admission.settle_turn("qi", "done")
+		# qb (background) promoted into the freed credit.
+		self.assertEqual(self._state("qb"), "dispatching")
+
+
+class TestFlagOffByteIdentical(_AdmissionTestCase):
+	def test_flag_off_creates_no_turn_rows_and_dispatches_legacy(self):
+		conv = self._mk_conv()
+		dispatched = []
+		with patch.dict(frappe.local.conf, {admission.FLAG: 0}), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		):
+			self.assertFalse(admission.admission_enabled())
+			res = chat_api.send_message(conversation=conv, message="hi there")
+		self.assertTrue(res["ok"])
+		# No Turn row written, and NOT queued: byte-identical legacy dispatch.
+		self.assertNotIn("queued", res)
+		self.assertEqual(frappe.db.count(TURN, {"conversation": conv}), 0)
+		self.assertEqual(dispatched, [res["run_id"]])
+
+
+class TestLegacyCoexistenceGuard(_AdmissionTestCase):
+	def test_same_conversation_legacy_stream_blocks_new_send(self):
+		"""OARI-2 / OAR-11: a legacy fresh-streaming turn (no Turn row, dispatched
+		before the flag flipped on) on conversation X must block a NEW send on the
+		SAME X from dispatching - it queues instead. The old _conv_legacy_busy was
+		dead (run_id='' sentinel counted the caller's own just-inserted row), so
+		this double-admitted onto one openclaw session."""
+		conv = self._mk_conv()
+		self._mk_msg(conv, 1, role="user")
+		# Legacy fresh streaming assistant, NO owning Turn row.
+		self._mk_msg(conv, 2, role="assistant", content="...", streaming=1, recovering=0)
+		# The legacy-busy signal must now FIRE for this conversation.
+		self.assertTrue(admission._conv_legacy_busy(conv))
+		seed = self._mk_msg(conv, 3, role="user")
+		with patch.object(admission, "_max_inflight", return_value=4):
+			res = self._accept(conv, "newrun", seed)
+		self.assertFalse(res["dispatched"], "must not double-admit onto the legacy session")
+		self.assertEqual(self._state("newrun"), "queued")
+
+	def test_queued_row_does_not_hide_legacy_from_shard_count(self):
+		"""OARI-2 shard undercount: a merely QUEUED Turn row on a conversation must
+		not zero out that conversation's coexisting legacy stream in
+		_legacy_streaming_count (the NOT EXISTS now matches only 'dispatching')."""
+		conv = self._mk_conv()
+		self._mk_msg(conv, 1, role="user")
+		self._mk_msg(conv, 2, role="assistant", content="...", streaming=1, recovering=0)
+		self._insert_turn(conv, "q_on_legacy", self._mk_msg(conv, 3, role="user"), "queued")
+		self.assertGreaterEqual(
+			admission._legacy_streaming_count(admission.DEFAULT_RELAY_TARGET),
+			1,
+			"a queued row must not hide the legacy stream from the shard count",
+		)
+
+
+class TestFlagOffDrainInertia(_AdmissionTestCase):
+	def test_flag_off_sweep_drains_existing_but_dispatches_nothing(self):
+		"""OARI-4: with the flag OFF and residual rows present, the sweep may still
+		SETTLE/reconcile existing rows (drain-to-empty) but must dispatch NOTHING
+		new (promote_next is flag-gated), and accept_or_queue never runs."""
+		# A dispatching turn whose OWN message settled -> reconcile drains it.
+		conv_a = self._mk_conv()
+		seed_a = self._mk_msg(conv_a, 1, role="user")
+		self._mk_msg(conv_a, 2, role="assistant", content="done", streaming=0)
+		self._insert_turn(conv_a, "resid", seed_a, "dispatching", reserved=1, dispatching_at=frappe.utils.now())
+		# A queued turn on another conversation -> must NOT be promoted/dispatched.
+		conv_b = self._mk_conv()
+		seed_b = self._mk_msg(conv_b, 1, role="user")
+		self._insert_turn(conv_b, "qidle", seed_b, "queued")
+		dispatched = []
+		with patch.dict(frappe.local.conf, {admission.FLAG: 0}), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(1)
+		):
+			self.assertFalse(admission.admission_enabled())
+			summary = admission.sweep()
+		self.assertEqual(dispatched, [], "flag OFF issues NO fresh dispatch")
+		self.assertEqual(summary["promoted"], 0)
+		# Existing rows drain: the settled dispatching turn reconciles to done...
+		self.assertEqual(self._state("resid"), "done")
+		# ...the queued turn is NOT promoted (stays queued).
+		self.assertEqual(self._state("qidle"), "queued")
+
+
+class TestOverloadSeedCleanup(_AdmissionTestCase):
+	def test_send_overload_after_commit_deletes_seed(self):
+		"""OARI-7 / SUXI-5: when the cheap pre-check passes but the authoritative
+		locked check rejects on overload, the already-committed user Message is
+		DELETED - no dangling unanswered send reappears on reload."""
+		conv_fill = self._mk_conv()
+		self._insert_turn(conv_fill, "fill", self._mk_msg(conv_fill, 1, role="user"), "queued")
+		conv = self._mk_conv()
+		with patch.object(admission, "MAX_QUEUE_DEPTH", 1), patch.object(
+			admission, "shard_overloaded", return_value=False
+		), patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			res = chat_api.send_message(conversation=conv, message="hello there")
+		self.assertFalse(res["ok"])
+		self.assertIn("busy", res["reason"].lower())
+		# The orphan user Message was cleaned up, and no Turn row leaked.
+		self.assertEqual(frappe.db.count(MSG, {"conversation": conv, "role": "user"}), 0)
+		self.assertEqual(frappe.db.count(TURN, {"conversation": conv}), 0)
+
+
+class TestCapOneFairness(_AdmissionTestCase):
+	def test_cap_one_interactive_not_starved_by_background(self):
+		"""OARI-8: at cap 1 the sole credit must go to a waiting INTERACTIVE turn,
+		not always to background. The old floor 'int_inflight >= cap-1' degenerated
+		to '>= 0' (always true) and handed the single credit to background."""
+		c_int = self._mk_conv()
+		c_bg = self._mk_conv()
+		self._insert_turn(c_int, "i1", self._mk_msg(c_int, 1), "queued", turn_class="interactive")
+		self._insert_turn(c_bg, "b1", self._mk_msg(c_bg, 1), "queued", turn_class="background")
+		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		):
+			admission.promote_next(admission.DEFAULT_RELAY_TARGET)
+		self.assertEqual(self._state("i1"), "dispatching", "interactive wins the sole credit")
+		self.assertEqual(self._state("b1"), "queued")
+
+
+class TestActiveTurnResync(_AdmissionTestCase):
+	def test_active_turn_returns_queued(self):
+		"""SUXI-1: the resync endpoint returns the conversation's own queued turn
+		(run_id + position) so a client that lost the chip rebuilds it."""
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		s2 = self._mk_msg(conv, 2)
+		with patch.object(admission, "_max_inflight", return_value=4):
+			self._accept(conv, "live", s1)  # dispatches
+			self._accept(conv, "q1", s2)  # queues (single-flight)
+		out = admission.active_turn_for_conversation(conv)
+		self.assertTrue(out["ok"])
+		self.assertIsNotNone(out["active"])
+		self.assertEqual(out["active"]["run_id"], "q1")
+		self.assertEqual(out["active"]["state"], "queued")
+		self.assertEqual(out["active"]["position"], 1)
+		self.assertEqual(out["active"]["message_id"], s2)
+
+	def test_active_turn_none_when_idle(self):
+		conv = self._mk_conv()
+		out = admission.active_turn_for_conversation(conv)
+		self.assertTrue(out["ok"])
+		self.assertIsNone(out["active"])
+
+
+class TestContinuationChip(_AdmissionTestCase):
+	def test_continuation_queues_at_cap_returns_position(self):
+		"""SUXI-2: a confirm continuation that queues at cap RETURNS its queued
+		position so apply_action/confirm_tool can render the chip (not silence)."""
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		):
+			self._accept(conv, "live", s1)  # occupies the single credit
+			out = chat_api.enqueue_continuation(conv, "created ORD-001")
+		self.assertTrue(out.get("queued"))
+		self.assertEqual(out.get("queued_position"), 1)
+		self.assertEqual(self._state(out["run_id"]), "queued")
+
+	def test_continuation_exempt_from_overload(self):
+		"""SUXI-2 ruling: a continuation is EXEMPT from the depth-25 overload
+		rejection - it ALWAYS queues (never silently dropped), even when the shard
+		queue is at/over the cap. A fresh send at that depth would be rejected."""
+		# Fill the shard queue to the (patched) cap on OTHER conversations so the
+		# overload guard WOULD reject a fresh send.
+		fill_conv = self._mk_conv()
+		self._insert_turn(fill_conv, "fillA", self._mk_msg(fill_conv, 1, role="user"), "queued")
+		# Occupy the continuation's own conversation with a live turn so it
+		# single-flights (queues rather than dispatching into a free credit).
+		conv = self._mk_conv()
+		self._insert_turn(
+			conv,
+			"convlive",
+			self._mk_msg(conv, 1, role="user"),
+			"dispatching",
+			reserved=1,
+			dispatching_at=frappe.utils.now(),
+		)
+		with patch.object(admission, "MAX_QUEUE_DEPTH", 1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		):
+			out = chat_api.enqueue_continuation(conv, "created ORD-002")
+		# Not rejected (a fresh send at this depth would be): a durable queued Turn
+		# row exists for the continuation.
+		self.assertTrue(frappe.db.exists(TURN, out["run_id"]))
+		self.assertEqual(self._state(out["run_id"]), "queued")
+		self.assertTrue(out.get("queued"))
+
+
+class TestCancelDurableMarker(_AdmissionTestCase):
+	def test_user_cancel_writes_durable_marker(self):
+		"""SUXI-4: cancelling a queued turn leaves a durable assistant marker
+		(error-card pattern) so a later reload shows the send was cancelled - not
+		indistinguishable from a silently dropped message."""
+		conv = self._mk_conv()
+		s1 = self._mk_msg(conv, 1)
+		s2 = self._mk_msg(conv, 2)
+		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
+			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		):
+			self._accept(conv, "live", s1)
+			self._accept(conv, "q1", s2)
+			self.assertEqual(self._state("q1"), "queued")
+			admission.cancel_queued_turn("q1")
+		self.assertEqual(self._state("q1"), "cancelled")
+		markers = frappe.get_all(
+			MSG,
+			filters={"conversation": conv, "role": "assistant", "error": admission.USER_CANCEL_REASON},
+			pluck="name",
+		)
+		self.assertEqual(len(markers), 1, "one durable cancel marker on the transcript")
+
+	def test_age_out_writes_durable_marker(self):
+		"""SUXI-4 + SUX-5: a system age-out records its reason both on the Turn row
+		and as a durable transcript marker."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		self._insert_turn(conv, "old", seed, "queued")
+		# Age the queued row past the max-age threshold.
+		past = frappe.utils.add_to_date(None, seconds=-(admission.QUEUED_MAX_AGE_S + 120))
+		frappe.db.set_value(TURN, "old", "enqueued_at", past, update_modified=False)
+		frappe.db.commit()
+		with patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+			summary = admission.sweep()
+		self.assertGreaterEqual(summary["aged_out"], 1)
+		self.assertEqual(self._state("old"), "cancelled")
+		markers = frappe.get_all(
+			MSG,
+			filters={"conversation": conv, "role": "assistant", "error": admission.AGE_OUT_REASON},
+			pluck="name",
+		)
+		self.assertEqual(len(markers), 1, "age-out leaves a durable transcript marker")

--- a/jarvis/tests/test_chat_admission.py
+++ b/jarvis/tests/test_chat_admission.py
@@ -243,8 +243,11 @@ class TestPromotionOnTerminal(_AdmissionTestCase):
 		sa = self._mk_msg(conv_a, 1)
 		sb = self._mk_msg(conv_b, 1)
 		dispatched = []
-		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		with (
+			patch.object(admission, "_max_inflight", return_value=1),
+			patch.object(
+				chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+			),
 		):
 			self._accept(conv_a, "A", sa)  # dispatches (cap 1)
 			res_b = self._accept(conv_b, "B", sb)  # queues (shard full)
@@ -287,8 +290,11 @@ class TestContinuationNoBypass(_AdmissionTestCase):
 		conv = self._mk_conv()
 		s1 = self._mk_msg(conv, 1)
 		dispatched = []
-		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		with (
+			patch.object(admission, "_max_inflight", return_value=1),
+			patch.object(
+				chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+			),
 		):
 			# Occupy the single credit with a live turn on this conversation.
 			self._accept(conv, "live", s1)
@@ -308,9 +314,7 @@ class TestFourCallersGated(_AdmissionTestCase):
 			res = chat_api.send_message(conversation=conv, message="hello there")
 		self.assertTrue(res["ok"])
 		self.assertTrue(frappe.db.exists(TURN, res["run_id"]))
-		self.assertEqual(
-			frappe.db.get_value(TURN, res["run_id"], "turn_class"), "interactive"
-		)
+		self.assertEqual(frappe.db.get_value(TURN, res["run_id"], "turn_class"), "interactive")
 
 	def test_retry_message_creates_turn_reusing_seed(self):
 		conv = self._mk_conv()
@@ -517,8 +521,11 @@ class TestBackgroundFloor(_AdmissionTestCase):
 		s_int = self._mk_msg(c_int, 1)
 		s_bg = self._mk_msg(c_bg, 1)
 		dispatched = []
-		with patch.object(admission, "_max_inflight", return_value=2), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		with (
+			patch.object(admission, "_max_inflight", return_value=2),
+			patch.object(
+				chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+			),
 		):
 			self._accept(c_live, "live", s_live, turn_class="interactive")  # dispatches (1/2)
 			# Force both to queue by accepting while a credit is free but making
@@ -537,8 +544,11 @@ class TestFlagOffByteIdentical(_AdmissionTestCase):
 	def test_flag_off_creates_no_turn_rows_and_dispatches_legacy(self):
 		conv = self._mk_conv()
 		dispatched = []
-		with patch.dict(frappe.local.conf, {admission.FLAG: 0}), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+		with (
+			patch.dict(frappe.local.conf, {admission.FLAG: 0}),
+			patch.object(
+				chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(a[0]["run_id"])
+			),
 		):
 			self.assertFalse(admission.admission_enabled())
 			res = chat_api.send_message(conversation=conv, message="hi there")
@@ -592,14 +602,17 @@ class TestFlagOffDrainInertia(_AdmissionTestCase):
 		conv_a = self._mk_conv()
 		seed_a = self._mk_msg(conv_a, 1, role="user")
 		self._mk_msg(conv_a, 2, role="assistant", content="done", streaming=0)
-		self._insert_turn(conv_a, "resid", seed_a, "dispatching", reserved=1, dispatching_at=frappe.utils.now())
+		self._insert_turn(
+			conv_a, "resid", seed_a, "dispatching", reserved=1, dispatching_at=frappe.utils.now()
+		)
 		# A queued turn on another conversation -> must NOT be promoted/dispatched.
 		conv_b = self._mk_conv()
 		seed_b = self._mk_msg(conv_b, 1, role="user")
 		self._insert_turn(conv_b, "qidle", seed_b, "queued")
 		dispatched = []
-		with patch.dict(frappe.local.conf, {admission.FLAG: 0}), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(1)
+		with (
+			patch.dict(frappe.local.conf, {admission.FLAG: 0}),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: dispatched.append(1)),
 		):
 			self.assertFalse(admission.admission_enabled())
 			summary = admission.sweep()
@@ -619,9 +632,11 @@ class TestOverloadSeedCleanup(_AdmissionTestCase):
 		conv_fill = self._mk_conv()
 		self._insert_turn(conv_fill, "fill", self._mk_msg(conv_fill, 1, role="user"), "queued")
 		conv = self._mk_conv()
-		with patch.object(admission, "MAX_QUEUE_DEPTH", 1), patch.object(
-			admission, "shard_overloaded", return_value=False
-		), patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None):
+		with (
+			patch.object(admission, "MAX_QUEUE_DEPTH", 1),
+			patch.object(admission, "shard_overloaded", return_value=False),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None),
+		):
 			res = chat_api.send_message(conversation=conv, message="hello there")
 		self.assertFalse(res["ok"])
 		self.assertIn("busy", res["reason"].lower())
@@ -639,8 +654,9 @@ class TestCapOneFairness(_AdmissionTestCase):
 		c_bg = self._mk_conv()
 		self._insert_turn(c_int, "i1", self._mk_msg(c_int, 1), "queued", turn_class="interactive")
 		self._insert_turn(c_bg, "b1", self._mk_msg(c_bg, 1), "queued", turn_class="background")
-		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		with (
+			patch.object(admission, "_max_inflight", return_value=1),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None),
 		):
 			admission.promote_next(admission.DEFAULT_RELAY_TARGET)
 		self.assertEqual(self._state("i1"), "dispatching", "interactive wins the sole credit")
@@ -678,8 +694,9 @@ class TestContinuationChip(_AdmissionTestCase):
 		position so apply_action/confirm_tool can render the chip (not silence)."""
 		conv = self._mk_conv()
 		s1 = self._mk_msg(conv, 1)
-		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		with (
+			patch.object(admission, "_max_inflight", return_value=1),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None),
 		):
 			self._accept(conv, "live", s1)  # occupies the single credit
 			out = chat_api.enqueue_continuation(conv, "created ORD-001")
@@ -706,8 +723,9 @@ class TestContinuationChip(_AdmissionTestCase):
 			reserved=1,
 			dispatching_at=frappe.utils.now(),
 		)
-		with patch.object(admission, "MAX_QUEUE_DEPTH", 1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		with (
+			patch.object(admission, "MAX_QUEUE_DEPTH", 1),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None),
 		):
 			out = chat_api.enqueue_continuation(conv, "created ORD-002")
 		# Not rejected (a fresh send at this depth would be): a durable queued Turn
@@ -725,8 +743,9 @@ class TestCancelDurableMarker(_AdmissionTestCase):
 		conv = self._mk_conv()
 		s1 = self._mk_msg(conv, 1)
 		s2 = self._mk_msg(conv, 2)
-		with patch.object(admission, "_max_inflight", return_value=1), patch.object(
-			chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None
+		with (
+			patch.object(admission, "_max_inflight", return_value=1),
+			patch.object(chat_api, "_dispatch_turn", side_effect=lambda *a, **k: None),
 		):
 			self._accept(conv, "live", s1)
 			self._accept(conv, "q1", s2)

--- a/jarvis/tests/test_chat_admission.py
+++ b/jarvis/tests/test_chat_admission.py
@@ -779,3 +779,53 @@ class TestCancelDurableMarker(_AdmissionTestCase):
 			pluck="name",
 		)
 		self.assertEqual(len(markers), 1, "age-out leaves a durable transcript marker")
+
+
+class TestEnqueueFailureCompensation(_AdmissionTestCase):
+	"""CDX-9: a dispatch-enqueue failure after the admission commit must CAS the
+	turn back to queued and release its credit - on BOTH the accept path and the
+	promotion path - instead of pinning a credit until the reservation TTL."""
+
+	def test_accept_path_compensates_on_enqueue_failure(self):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		def boom():
+			raise RuntimeError("broker down")
+
+		out = admission.accept_or_queue(
+			conversation=conv,
+			run_id="cdx9-accept",
+			seed_message=seed,
+			turn_class="interactive",
+			dispatch=boom,
+		)
+		self.assertFalse(out["dispatched"])
+		self.assertIsNotNone(out["queued_position"])
+		row = frappe.db.get_value(
+			"Jarvis Chat Turn", "cdx9-accept", ["state", "reserved"], as_dict=True
+		)
+		self.assertEqual(row.state, "queued")
+		self.assertEqual(int(row.reserved), 0)
+
+	def test_promote_path_compensates_on_enqueue_failure(self):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		with patch.object(admission, "_max_inflight", return_value=0):
+			admission.accept_or_queue(
+				conversation=conv,
+				run_id="cdx9-promote",
+				seed_message=seed,
+				turn_class="interactive",
+				dispatch=lambda: None,
+			)
+		self.assertEqual(frappe.db.get_value("Jarvis Chat Turn", "cdx9-promote", "state"), "queued")
+		with (
+			patch.object(admission, "_dispatch_promoted", side_effect=RuntimeError("broker down")),
+			patch.object(admission, "_max_inflight", return_value=4),
+		):
+			admission.promote_next()
+		row = frappe.db.get_value(
+			"Jarvis Chat Turn", "cdx9-promote", ["state", "reserved"], as_dict=True
+		)
+		self.assertEqual(row.state, "queued")
+		self.assertEqual(int(row.reserved), 0)

--- a/jarvis/tests/test_chat_admission.py
+++ b/jarvis/tests/test_chat_admission.py
@@ -789,6 +789,7 @@ class TestEnqueueFailureCompensation(_AdmissionTestCase):
 	def test_accept_path_compensates_on_enqueue_failure(self):
 		conv = self._mk_conv()
 		seed = self._mk_msg(conv, 1)
+
 		def boom():
 			raise RuntimeError("broker down")
 
@@ -801,9 +802,7 @@ class TestEnqueueFailureCompensation(_AdmissionTestCase):
 		)
 		self.assertFalse(out["dispatched"])
 		self.assertIsNotNone(out["queued_position"])
-		row = frappe.db.get_value(
-			"Jarvis Chat Turn", "cdx9-accept", ["state", "reserved"], as_dict=True
-		)
+		row = frappe.db.get_value("Jarvis Chat Turn", "cdx9-accept", ["state", "reserved"], as_dict=True)
 		self.assertEqual(row.state, "queued")
 		self.assertEqual(int(row.reserved), 0)
 
@@ -824,8 +823,6 @@ class TestEnqueueFailureCompensation(_AdmissionTestCase):
 			patch.object(admission, "_max_inflight", return_value=4),
 		):
 			admission.promote_next()
-		row = frappe.db.get_value(
-			"Jarvis Chat Turn", "cdx9-promote", ["state", "reserved"], as_dict=True
-		)
+		row = frappe.db.get_value("Jarvis Chat Turn", "cdx9-promote", ["state", "reserved"], as_dict=True)
 		self.assertEqual(row.state, "queued")
 		self.assertEqual(int(row.reserved), 0)


### PR DESCRIPTION
## What

Phase 0 of the chat-concurrency (Relay Pump) workstream: durable admission control in the current transport. Fixes the reported incident class — two users parked at confirmation cards no longer kill a 2-worker site; excess sends become durable queued turns with an honest, approximate position and cancellation instead of invisible RQ waits.

## How

- **Doctypes:** `Jarvis Chat Turn` (server-owned, Phase-0 core subset of the designed schema; read = System Manager + Jarvis Admin) and `Jarvis Relay Pump` (per-shard control row). Composite indexes via patch; all admission reads EXPLAIN-verified index-covered.
- **One chokepoint:** `accept_or_queue` gates all four `_dispatch_turn` callers under the shard control-row `FOR UPDATE` (double-admit race closed at the shard, not the conversation) with commit-first REPEATABLE-READ snapshot discipline. Confirm continuations lose their single-flight bypass; they queue like any turn but are exempt from overload rejection (a committed write's follow-up is never dropped).
- **Promotion:** weighted classes with background floor 1, per-conversation single-flight, position fan-out on every promotion/settlement/cancel; 5-minute sweep for reservation reclaim (scoped to this turn's own output), Turn↔Message reconcile, and 15-minute age-out with a surfaced reason.
- **UI:** queued chip ("~N ahead") + cancel + server-truth resync (reload / conversation switch / second tab / WS reconnect), post-confirm "Change saved" acknowledgment, state→copy table (no raw internal states).
- **Flag:** `jarvis_phase0_admission_enabled` default OFF = byte-identical legacy behavior (differential-tested; zero Turn rows created).

## Verification

- 31 admission tests (threaded CAS race stable ×5, flag-off differential, legacy-coexistence, reclaim/reconcile regressions) + full chat suite green with flag ON and OFF; brittle relay:error slice test intact.
- Dual panel review (Sonnet UX + Opus adversarial), 20 findings fixed, both re-checks **ACCEPT** — including empirical re-probes of the P0s (silent turn loss, same-session double-admit).
- Design record: `Aerele-RnD/jarvis-chat-concurrency-design` → `implementation/wp-0/` (direction brief, implementation report + fix round, both reviews with re-check sections).

Part 1 of the Relay Pump plan (binding spec §8–§10 in the design repo). WP-1 (the pump transport) follows on top of this schema additively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJsMjkHXYiK5TDokQyAoFh