### PR TITLE
fix(permissions): honest is_custom, seed install-only roles, guard chat isolation

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -203,6 +203,12 @@ website_redirects = [
 # login so the provider prompt cache is warm before the chat page even loads.
 on_session_creation = ["jarvis.chat.prewarm.warm_on_login"]
 
+# A fresh install runs THIS and never after_migrate, so anything a day-1 site
+# needs that DocType sync does not produce has to be seeded here: the roles no
+# DocType names ("Knowledge Wiki Manager", the two support roles) plus the
+# Personalisation Settings defaults. See jarvis/install.py.
+after_install = "jarvis.install.after_install"
+
 # Keep the Agents Marketplace catalog (Jarvis Agent Listing) in lockstep with
 # the BUNDLED jarvis/agents/registry.json on every migrate (never a runtime
 # fetch — bundles are reviewed deploy artifacts, adversarial S2).

--- a/jarvis/install.py
+++ b/jarvis/install.py
@@ -23,9 +23,40 @@ Mirrors ``jarvis_admin_v2/install.py``, which exists for the same reason.
 
 import frappe
 
+from jarvis.chat.wiki_permissions import WIKI_MANAGER_ROLE
 from jarvis.learning.roles import after_migrate as seed_roles_and_settings
+from jarvis.permissions import JARVIS_SUPPORT_ADMIN_ROLE, JARVIS_SUPPORT_USER_ROLE
+
+# The roles no DocType names, i.e. the ones that exist ONLY because this hook
+# (or a later migrate) seeded them. Verified below because the seeder cannot
+# report its own failure -- see after_install.
+_INSTALL_ONLY_ROLES = (
+	WIKI_MANAGER_ROLE,
+	JARVIS_SUPPORT_USER_ROLE,
+	JARVIS_SUPPORT_ADMIN_ROLE,
+)
 
 
 def after_install() -> None:
 	seed_roles_and_settings()
 	frappe.db.commit()
+
+	# seed_roles_and_settings is best-effort BY DESIGN: it wraps its body in
+	# try/except + log_error and never re-raises, because a failed seed must
+	# never abort a `bench migrate`. At INSTALL time that same property is a
+	# trap -- a transient failure would log quietly, this hook would commit and
+	# return, install_app would report success, and the tenant would land in
+	# exactly the half-seeded state this hook exists to prevent, discovered only
+	# when a user hits a permission wall.
+	#
+	# So verify, and fail the install loudly instead. A provisioning run that
+	# fails and gets retried beats a tenant that is silently missing its wiki
+	# and support roles.
+	missing = [r for r in _INSTALL_ONLY_ROLES if not frappe.db.exists("Role", r)]
+	if missing:
+		frappe.throw(
+			"jarvis after_install could not seed required roles: "
+			+ ", ".join(missing)
+			+ ". The seeder swallows its own errors; see the 'jarvis wiki roles "
+			"seed failed' Error Log entry for the cause."
+		)

--- a/jarvis/install.py
+++ b/jarvis/install.py
@@ -1,0 +1,31 @@
+"""after_install hook - seed what a fresh site cannot get any other way.
+
+``install_app`` runs ``after_install`` but NEVER ``after_migrate``, and it marks
+every patch complete without executing it (``frappe/installer.py``). So a site
+that is installed and not yet migrated only has what DocType sync produced.
+
+DocType sync auto-creates any role named in a permission row
+(``core/doctype/doctype/doctype.py``), which covers "Jarvis User" (16 DocTypes),
+"Jarvis Admin" (10) and "Jarvis Skill Reviewer" (1). Named in NO DocType, and so
+absent on such a site before this hook existed:
+
+  * "Knowledge Wiki Manager"  (wiki curator rights, wiki_permissions.py)
+  * "Jarvis Support User" / "Jarvis Support Admin"  (support panel scope)
+
+Observed live on a freshly reinstalled tenant: all three synced roles present,
+all three of the above missing.
+
+Reuses the migrate-time seeder rather than duplicating it, so the two entry
+points cannot drift. Idempotent: every seeder inside is exists-guarded.
+
+Mirrors ``jarvis_admin_v2/install.py``, which exists for the same reason.
+"""
+
+import frappe
+
+from jarvis.learning.roles import after_migrate as seed_roles_and_settings
+
+
+def after_install() -> None:
+	seed_roles_and_settings()
+	frappe.db.commit()

--- a/jarvis/permissions.py
+++ b/jarvis/permissions.py
@@ -85,8 +85,14 @@ def ensure_jarvis_user_role() -> None:
 
 	Mostly belt-and-braces: 16 DocTypes name this role in a permission row and
 	DocType sync auto-creates any role it finds there, so the role already exists
-	by the time the after_migrate seed calls this. Kept so the definition (and
-	``is_custom``) lives in exactly one place.
+	by the time the after_migrate seed calls this. Kept so the definition lives in
+	exactly one place.
+
+	``is_custom`` is 0 deliberately: the role ships WITH the app (DocType sync
+	materializes it from the permission rows), so it is not a user-defined custom
+	role. It also has to match what sync actually creates -- sync wins the race,
+	so a mismatched value here would never be applied and would misdescribe every
+	live site.
 
 	NOTE: :func:`grant_onboarding_admin` is the ONLY code path that grants this
 	role, and it grants it alongside ``Jarvis Admin`` (the admin role is additive
@@ -98,7 +104,7 @@ def ensure_jarvis_user_role() -> None:
 				"doctype": "Role",
 				"role_name": JARVIS_USER_ROLE,
 				"desk_access": 1,
-				"is_custom": 1,
+				"is_custom": 0,
 			}
 		).insert(ignore_permissions=True)
 
@@ -151,16 +157,21 @@ def require_jarvis_access(user: str | None = None) -> None:
 
 
 def ensure_jarvis_admin_role() -> None:
-	"""Idempotently create the ``Jarvis Admin`` role (desk-access, custom).
+	"""Idempotently create the ``Jarvis Admin`` role (desk-access).
 	Definition lives here (single source of truth); the after_migrate seed
-	calls this so the role exists on every migrated site."""
+	calls this so the role exists on every migrated site.
+
+	``is_custom`` is 0 for the same reason as :func:`ensure_jarvis_user_role`:
+	10 DocTypes name this role, so DocType sync creates it first and this
+	exists-guard never fires on a real site. The declared value has to match
+	what sync produces or it merely misdescribes reality."""
 	if not frappe.db.exists("Role", JARVIS_ADMIN_ROLE):
 		frappe.get_doc(
 			{
 				"doctype": "Role",
 				"role_name": JARVIS_ADMIN_ROLE,
 				"desk_access": 1,
-				"is_custom": 1,
+				"is_custom": 0,
 			}
 		).insert(ignore_permissions=True)
 

--- a/jarvis/tests/test_chat_isolation.py
+++ b/jarvis/tests/test_chat_isolation.py
@@ -1,0 +1,145 @@
+"""Cross-user isolation for Jarvis Conversation / Jarvis Chat Message.
+
+WHY THIS EXISTS: the DocType rows are deliberately broad. "Jarvis User" holds
+read/write/create/delete on Jarvis Chat Message with if_owner=0, i.e. the role
+layer alone would let any Jarvis user touch ANY message. The ONLY thing scoping
+a user to their own chats is the pair of hooks in jarvis/chat/chat_permissions.py
+(permission_query_conditions for lists, has_permission for single docs).
+
+That makes those hooks load-bearing rather than defence in depth: if one is
+unregistered, renamed, or returns "" for a non-Administrator, every user's
+private chat history becomes readable and deletable by every other user, and no
+DocType-level rule would catch it. These tests assert the observable outcome
+(user B cannot see or touch user A's rows) rather than the hook internals, so
+they fail on ANY regression that reopens the hole.
+
+Hermetic: both fixture users and every row created here are removed in
+tearDownClass.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.permissions import JARVIS_USER_ROLE, ensure_jarvis_user_role
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+
+USER_A = "jarvis-iso-a@example.com"
+USER_B = "jarvis-iso-b@example.com"
+
+
+def _ensure_user(email: str) -> None:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Iso",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	frappe.get_doc("User", email).add_roles(JARVIS_USER_ROLE)
+
+
+class TestChatCrossUserIsolation(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		ensure_jarvis_user_role()
+		_ensure_user(USER_A)
+		_ensure_user(USER_B)
+
+		# A conversation + message owned by A, created AS A so `owner` is A.
+		frappe.set_user(USER_A)
+		cls.conv_a = frappe.get_doc({"doctype": CONV, "title": "A private"}).insert().name
+		cls.msg_a = (
+			frappe.get_doc(
+				{
+					"doctype": MSG,
+					"conversation": cls.conv_a,
+					"seq": 1,
+					"role": "user",
+					"content": "A's secret",
+					"streaming": 0,
+				}
+			)
+			.insert()
+			.name
+		)
+		frappe.set_user("Administrator")
+		frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.set_user("Administrator")
+		for dt, name in ((MSG, cls.msg_a), (CONV, cls.conv_a)):
+			if frappe.db.exists(dt, name):
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+		for email in (USER_A, USER_B):
+			if frappe.db.exists("User", email):
+				frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+		frappe.db.commit()
+		super().tearDownClass()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	# -- lists (permission_query_conditions) --------------------------------- #
+	#
+	# frappe.get_list, NEVER frappe.get_all: get_all is documented as "will not
+	# check for permissions" (it is get_list with ignore_permissions), so it
+	# skips permission_query_conditions entirely and would pass this file
+	# vacuously. get_list is also what the generic REST surface
+	# (/api/resource/<doctype>) actually runs, which is the exposure being
+	# guarded here.
+
+	def test_b_cannot_list_as_conversation(self):
+		frappe.set_user(USER_B)
+		names = frappe.get_list(CONV, pluck="name", limit=0)
+		self.assertNotIn(self.conv_a, names, "user B can list user A's conversation")
+
+	def test_b_cannot_list_as_message(self):
+		frappe.set_user(USER_B)
+		names = frappe.get_list(MSG, pluck="name", limit=0)
+		self.assertNotIn(self.msg_a, names, "user B can list user A's chat message")
+
+	def test_b_cannot_reach_as_message_by_explicit_filter(self):
+		"""Filtering straight at the row must not bypass the scoping."""
+		frappe.set_user(USER_B)
+		rows = frappe.get_list(MSG, filters={"name": self.msg_a}, pluck="name")
+		self.assertEqual(rows, [], "explicit filter leaked user A's message")
+
+	# -- single docs (has_permission) ---------------------------------------- #
+
+	def test_b_cannot_read_as_conversation_doc(self):
+		frappe.set_user(USER_B)
+		self.assertFalse(
+			frappe.has_permission(CONV, "read", doc=self.conv_a, user=USER_B),
+			"user B has read permission on user A's conversation",
+		)
+
+	def test_b_cannot_read_as_message_doc(self):
+		frappe.set_user(USER_B)
+		self.assertFalse(
+			frappe.has_permission(MSG, "read", doc=self.msg_a, user=USER_B),
+			"user B has read permission on user A's message",
+		)
+
+	def test_b_cannot_delete_as_message_doc(self):
+		frappe.set_user(USER_B)
+		self.assertFalse(
+			frappe.has_permission(MSG, "delete", doc=self.msg_a, user=USER_B),
+			"user B has delete permission on user A's message",
+		)
+
+	# -- the owner still works (guards against an over-tight fix) ------------ #
+
+	def test_a_can_still_read_own_rows(self):
+		frappe.set_user(USER_A)
+		self.assertIn(self.conv_a, frappe.get_list(CONV, pluck="name", limit=0))
+		self.assertIn(self.msg_a, frappe.get_list(MSG, pluck="name", limit=0))
+		self.assertTrue(frappe.has_permission(CONV, "read", doc=self.conv_a, user=USER_A))
+		self.assertTrue(frappe.has_permission(MSG, "read", doc=self.msg_a, user=USER_A))

--- a/jarvis/tests/test_personalise_doctypes.py
+++ b/jarvis/tests/test_personalise_doctypes.py
@@ -31,6 +31,7 @@ caller.
 from __future__ import annotations
 
 import contextlib
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -147,6 +148,54 @@ class TestPersonaliseRoleSeeding(PersonaliseDoctypeTestCase):
 			self.assertTrue(frappe.db.exists("Role", role), role)
 			self.assertEqual(frappe.db.get_value("Role", role, "desk_access"), 1, role)
 			self.assertEqual(frappe.db.get_value("Role", role, "is_custom"), 0, role)
+
+	def test_app_roles_are_not_marked_custom(self):
+		"""``is_custom`` must stay 0 on every role the APP ships.
+
+		All four are created by DocType sync (each is named in at least one
+		permission row), which stamps is_custom=0. The ensure_* helpers in
+		jarvis/permissions.py declare the same 0 so the two definitions agree.
+		Nothing in Frappe enforces that agreement, so this test is the guard: if
+		a future Frappe changes what sync stamps, or someone flips a helper back
+		to 1, the mismatch surfaces here instead of silently misdescribing every
+		live site.
+
+		Deliberately EXCLUDES the two support roles: no DocType names them, so
+		ensure_support_roles genuinely creates them and its is_custom=1 does take
+		effect. That asymmetry is real, and is spelled out here so it does not
+		get "fixed" by accident."""
+		learning_roles.after_migrate()
+		for role in (
+			"Jarvis User",
+			"Jarvis Admin",
+			"Jarvis Skill Reviewer",
+			"Knowledge Wiki Manager",
+		):
+			self.assertTrue(frappe.db.exists("Role", role), role)
+			self.assertEqual(frappe.db.get_value("Role", role, "is_custom"), 0, role)
+
+	def test_after_install_leaves_every_install_only_role_present(self):
+		"""The install path must end with the roles no DocType names."""
+		from jarvis.install import _INSTALL_ONLY_ROLES, after_install
+
+		after_install()  # idempotent
+		for role in _INSTALL_ONLY_ROLES:
+			self.assertTrue(frappe.db.exists("Role", role), role)
+
+	def test_after_install_raises_when_seeding_did_not_land(self):
+		"""The verification in after_install must be REAL.
+
+		Its seeder (learning.roles.after_migrate) catches everything and only
+		log_errors, never re-raising, because a failed seed must not abort a
+		migrate. At install time that would silently produce the half-seeded
+		tenant the hook exists to prevent, so after_install re-checks and
+		throws. This asserts the throw actually happens rather than the check
+		being decorative."""
+		from jarvis import install
+
+		with patch.object(install, "_INSTALL_ONLY_ROLES", ("Jarvis Nonexistent Probe Role",)):
+			with self.assertRaises(frappe.ValidationError):
+				install.after_install()
 
 	def test_settings_defaults_backfilled_when_row_absent(self):
 		"""Row-existence probe, not a value test: an absent tabSingles row for


### PR DESCRIPTION
Three fixes from a systematic audit of the permission model against Frappe's own rules. The audit's other checks passed, so this is the residue rather than a rewrite.

## 1. `is_custom` was dead, misleading config

`ensure_jarvis_user_role()` and `ensure_jarvis_admin_role()` declared `is_custom=1`. They never applied it. 16 and 10 DocTypes respectively name those roles in a permission row, and DocType sync creates any such role first (`core/doctype/doctype/doctype.py`), so the helpers' exists-guard always short-circuits.

Evidence it never took effect:

- Both live sites report `is_custom=0` for all three Jarvis roles.
- `test_personalise_doctypes.py:149` already asserts `is_custom == 0` for `Jarvis Admin`, and passes.

Set to 0 so the declaration matches what sync produces. 0 is also the semantically correct value: these ship with the app, they are not user-defined custom roles.

## 2. Roles no DocType names were missing on fresh installs

`install_app` runs `after_install` and **never** `after_migrate`. Any role seeded only by `learning.roles.after_migrate` is therefore absent until someone runs `bench migrate`. That covers:

- `Knowledge Wiki Manager` (curator rights, `wiki_permissions.py:77`)
- `Jarvis Support User` / `Jarvis Support Admin` (support panel scope)

**Confirmed live, not theoretical.** The `jarvis.proxy` tenant was reinstalled on 2026-07-22: 771 Patch Log rows stamped within two minutes, the `set_all_patches_as_completed` fingerprint. It had all three sync-created roles and none of the three above. No Error Log entry, so the seeder had not failed, it had never run.

Adds an `after_install` hook that **reuses** the migrate-time seeder rather than duplicating it, so the two entry points cannot drift. Mirrors `jarvis_admin_v2/install.py`, which exists for exactly this reason. The live tenant has been seeded by hand; this stops it recurring on the next provision.

Note this revisits an earlier "no install script" decision, which was made on the belief that every needed role auto-creates. That turned out to be true for three roles and false for three others.

## 3. Cross-user chat isolation had no test

`Jarvis User` holds read/write/create/delete on `Jarvis Chat Message` with `if_owner=0`. The role layer alone would let any Jarvis user read and delete **any** message. The only thing scoping a user to their own chats is the hook pair in `chat_permissions.py`.

That makes those hooks load-bearing rather than defense in depth, with nothing asserting they stay wired. A rename, an unregistered hook, or an early `return ""` would silently expose every user's chat history and no DocType rule would catch it.

`test_chat_isolation.py` asserts user B can neither list, filter to, read, nor delete user A's conversation and message, and that A still reaches their own rows (guarding against an over-tight fix).

**Verified non-vacuous by mutation.** With the hooks neutered:

```
BASELINE  (hooks intact)   B sees msg in get_list: False | B has_permission: False
MUTATED   (hooks neutered) B sees msg in get_list: True  | B has_permission: True
```

Both assertions flip, so the test fails on a real regression.

It uses `frappe.get_list` throughout, never `frappe.get_all`. `get_all` is documented as "will **not** check for permissions" and skips `permission_query_conditions` entirely; an earlier draft used it and passed vacuously. `get_list` is also what `/api/resource/<doctype>` actually runs, which is the exposure being guarded.

## Audit findings deliberately NOT changed

- **Role `All` on three DocTypes.** Frappe's `ALL_USER_ROLE = "All"  # This includes website users too.` conflicts with the policy that portal users never reach Jarvis. In practice the hooks clamp it: the two promotion requests are read-only with `if_owner`, and Personalise Question's `has_permission` forces the target to be the caller. Layering inconsistency, not a hole.
- **`is_custom=1` on the two support roles.** Unlike items above this is *not* dead: no DocType names them, so `ensure_support_roles()` genuinely creates them and the value applies. Changing it would alter live behaviour and create drift between existing and new sites. Flagged for a separate decision.
- **`read` without `report`** on all 25 rows. Uniform, so deliberate hardening for a custom SPA.

## Testing

`bench --site site.jarvis run-tests --module jarvis.tests.test_chat_isolation` passes 7/7 locally, plus the mutation check above. Per CLAUDE.md the local bench is role-polluted, so CI is the authority for permission work.

https://claude.ai/code/session_014z9pu5Yvquz2ntxLxaKBCr