### PR TITLE
feat(catalog): frontend and desk read the admin model catalog

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -182,6 +182,11 @@ export const getDoctypeFields = (doctype) =>
 // --- LLM pool / models config (System-Manager only, gated server-side) ---
 export const getLlmConfig = () => call("jarvis.onboarding.get_llm_config");
 export const getPresetCatalog = () => call("jarvis.onboarding.get_preset_catalog");
+// Admin-managed model catalog slice (api_key_models, subscription_models,
+// default_models) for the pool editor + subscription card. Independent of
+// get_chat_ui_settings so it also works in the onboarding wizard, which never
+// calls that. See jarvis.chat.api.get_model_catalog_ui.
+export const getModelCatalogUi = () => call("jarvis.chat.api.get_model_catalog_ui");
 export const getLlmSyncStatus = () => call("jarvis.onboarding.get_llm_sync_status");
 export const saveLlmPool = (models, preset = null, routingMode = "failover") =>
 	call("jarvis.onboarding.save_llm_pool", {

--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -208,14 +208,25 @@ onMounted(async () => {
 // Built-in fallback: subscription providers offered for a fresh DIRECT connect
 // before the catalog fetch lands or if it fails. Model lists mirror
 // jarvis/_subscription_models.py (codex/gemini-cli catalog).
-const SUB_PROVIDERS = [
+const FALLBACK_SUB_PROVIDERS = [
 	{ provider: "OpenAI", models: ["gpt-5.5", "gpt-5.4"] },
 	{ provider: "Google Gemini", models: ["gemini-2.5-pro", "gemini-2.5-flash"] },
 ];
+// Gated server-side on a non-empty auth_profile_id (R7): supports_subscription
+// is true for xai and moonshot too (cliproxy really does serve their
+// subscription models), but only openai/google-gemini-cli support this card's
+// paste-back connect flow - Kimi is device-code and admin's push_oauth_blob
+// rejects a direct xAI blob outright. Data now, not a literal; the rendered
+// list still stays two entries because the seed only sets auth_profile_id for
+// those two.
+const SUB_PROVIDERS = computed(() => {
+	const rows = modelCatalog.value.subscription_connect_providers || [];
+	return rows.length ? rows : FALLBACK_SUB_PROVIDERS;
+});
 function _defaultProvider() {
-	if (SUB_PROVIDERS.some((p) => p.provider === props.status.provider))
+	if (SUB_PROVIDERS.value.some((p) => p.provider === props.status.provider))
 		return props.status.provider;
-	const byModel = SUB_PROVIDERS.find((p) => p.models.includes(props.status.model));
+	const byModel = SUB_PROVIDERS.value.find((p) => p.models.includes(props.status.model));
 	return byModel ? byModel.provider : "OpenAI";
 }
 const pickProvider = ref(_defaultProvider());
@@ -225,7 +236,9 @@ const pickProvider = ref(_defaultProvider());
 // copy has to follow. Shared with LlmPoolEditor via @/llm/pool.
 const codeOnly = computed(() => isCodeOnlyPaste(status.value.provider || pickProvider.value));
 const pickModels = computed(
-	() => (SUB_PROVIDERS.find((p) => p.provider === pickProvider.value) || SUB_PROVIDERS[0]).models
+	() =>
+		(SUB_PROVIDERS.value.find((p) => p.provider === pickProvider.value) || SUB_PROVIDERS.value[0])
+			.models
 );
 const pickModel = ref(
 	pickModels.value.includes(props.status.model) ? props.status.model : pickModels.value[0]

--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -234,7 +234,12 @@ const pickProvider = ref(_defaultProvider());
 // (which only gates NEW connections), so a tenant already stored as "xAI Grok"
 // can reach this flow. xAI shows a bare code, not a callback URL, so the step-2
 // copy has to follow. Shared with LlmPoolEditor via @/llm/pool.
-const codeOnly = computed(() => isCodeOnlyPaste(status.value.provider || pickProvider.value));
+// props.status, NOT status.value: there is no local `status` ref in this file, so the
+// bare name resolved to the browser global `window.status` (a string). `.value` on it
+// is undefined, so this computed threw every time it evaluated - i.e. whenever the
+// paste-back screen rendered, which is the entire xAI bare-code flow. Every other
+// reference here already uses props.status.
+const codeOnly = computed(() => isCodeOnlyPaste(props.status.provider || pickProvider.value));
 const pickModels = computed(
 	() =>
 		(

--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -237,8 +237,10 @@ const pickProvider = ref(_defaultProvider());
 const codeOnly = computed(() => isCodeOnlyPaste(status.value.provider || pickProvider.value));
 const pickModels = computed(
 	() =>
-		(SUB_PROVIDERS.value.find((p) => p.provider === pickProvider.value) || SUB_PROVIDERS.value[0])
-			.models
+		(
+			SUB_PROVIDERS.value.find((p) => p.provider === pickProvider.value) ||
+			SUB_PROVIDERS.value[0]
+		).models
 );
 const pickModel = ref(
 	pickModels.value.includes(props.status.model) ? props.status.model : pickModels.value[0]

--- a/frontend/src/components/DirectSubscriptionCard.vue
+++ b/frontend/src/components/DirectSubscriptionCard.vue
@@ -170,7 +170,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onBeforeUnmount } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 import * as api from "@/api";
 import { errMessage as _err } from "@/lib/errors";
 import { isCodeOnlyPaste } from "@/llm/pool";
@@ -190,7 +190,23 @@ const props = defineProps({
 // sync). disconnected: the subscription was torn down.
 const emit = defineEmits(["reauthorized", "disconnected"]);
 
-// Subscription providers offered for a fresh DIRECT connect. Model lists mirror
+// Admin-managed model catalog (jarvis.chat.api.get_model_catalog_ui), fetched
+// on mount. subscription_connect_providers is gated on a non-empty
+// auth_profile_id (R7 - openai + google-gemini-cli today), never on
+// supports_subscription, so it never offers a provider whose OAuth blob admin
+// would reject. Falls back to the built-in SUB_PROVIDERS literal below when
+// the fetch fails or hasn't landed yet - never blank.
+const modelCatalog = ref({ subscription_connect_providers: [] });
+onMounted(async () => {
+	try {
+		modelCatalog.value = (await api.getModelCatalogUi()) || modelCatalog.value;
+	} catch (e) {
+		/* built-in SUB_PROVIDERS fallback below covers this */
+	}
+});
+
+// Built-in fallback: subscription providers offered for a fresh DIRECT connect
+// before the catalog fetch lands or if it fails. Model lists mirror
 // jarvis/_subscription_models.py (codex/gemini-cli catalog).
 const SUB_PROVIDERS = [
 	{ provider: "OpenAI", models: ["gpt-5.5", "gpt-5.4"] },

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1610,6 +1610,16 @@ const emit = defineEmits(["saved", "ready", "direct-changed"]);
 // ---- state ---------------------------------------------------------------
 const cfg = ref({ models: [], preset: "", routing_mode: "failover", proxy_active: false });
 const catalog = ref([]);
+// Admin-managed model catalog (jarvis.chat.api.get_model_catalog_ui): api-key
+// suggestions, subscription suggestions, and per-provider defaults. Fetched on
+// mount (see load()) independent of get_chat_ui_settings so this also works in
+// the onboarding wizard, which never calls that. Falls back to the built-in
+// literals below when the fetch fails or hasn't landed yet - never blank.
+const modelCatalog = ref({
+	api_key_models: {},
+	subscription_models: {},
+	default_models: {},
+});
 const rows = ref([]); // canonical camelCase rows (single source of truth)
 const llmMode = ref("quick"); // "quick" | "preset" | "custom"
 const selectedPreset = ref("");
@@ -2857,6 +2867,11 @@ async function load() {
 		catalog.value = (await api.getPresetCatalog()) || [];
 	} catch (e) {
 		/* backend bundled fallback */
+	}
+	try {
+		modelCatalog.value = (await api.getModelCatalogUi()) || modelCatalog.value;
+	} catch (e) {
+		/* built-in literal fallbacks below cover this */
 	}
 }
 

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1570,6 +1570,7 @@ import {
 	providerId,
 	seedRowsFromConfig,
 	defaultSubscriptionModel,
+	subModelSuggestions,
 	apiKeyModelHealth,
 	subscriptionAccountHealth,
 	dirtyAccountHealth,
@@ -1620,6 +1621,13 @@ const modelCatalog = ref({
 	subscription_models: {},
 	default_models: {},
 });
+// Chat-subscription suggestion table derived from the fetched catalog (falls
+// back to pool.js's built-in FALLBACK_SUB_MODELS via subModelSuggestions when
+// empty/unfetched). Passed to every defaultSubscriptionModel(...) call site so
+// an admin-changed subscription default is honoured everywhere, not just here.
+const subscriptionSuggestions = computed(() =>
+	subModelSuggestions(modelCatalog.value.subscription_models)
+);
 const rows = ref([]); // canonical camelCase rows (single source of truth)
 const llmMode = ref("quick"); // "quick" | "preset" | "custom"
 const selectedPreset = ref("");
@@ -1718,31 +1726,19 @@ const pastePlaceholder = (u, ready) => {
 // display LABEL as `provider` (matches seedRowsFromConfig + the desk page).
 const providerOptions = PROVIDER_LABELS.map((p) => p.label);
 
-// ---- model-id suggestions (ported verbatim from jarvis_account.js) -------
-const STATIC_MODEL_SUGGESTIONS = {
-	Anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
-	OpenAI: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-4o"],
-	"Google Gemini": ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"],
-	Mistral: ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
-	Groq: [
-		"llama-3.3-70b-versatile",
-		"openai/gpt-oss-120b",
-		"openai/gpt-oss-20b",
-		"llama-3.1-8b-instant",
-	],
-	"Together AI": ["meta-llama/Llama-3.3-70B-Instruct-Turbo"],
-	DeepSeek: ["deepseek-chat"],
-	"Moonshot (Kimi)": ["kimi-k2.6"],
-	"xAI Grok": ["grok-4.5", "grok-4.3", "grok-build-0.1"],
-	"GLM / Z.ai": ["glm-4.6", "glm-4.7"],
-	"GLM / Z.ai (Coding Plan)": ["glm-4.6", "glm-4.7"],
-	OpenRouter: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
-	"Ollama (local)": ["qwen2.5:3b", "qwen2.5:0.5b", "llama3"],
-	"OpenAI-Compatible": ["claude-sonnet-4-6", "gpt-4o", "qwen2.5:3b", "llama3"],
-};
+// ---- model-id suggestions --------------------------------------------------
+// STATIC_MODEL_SUGGESTIONS (the hardcoded per-provider datalist) is gone: the
+// admin-managed catalog (modelCatalog.value.api_key_models, fetched in load())
+// is now the source, so a model added in the admin desk shows up here with no
+// deploy. See modelSuggestionsForProvider below.
 const PROVIDER_DEFAULTS = {
 	Anthropic: { model: "claude-sonnet-4-6", baseUrl: "https://api.anthropic.com" },
-	OpenAI: { model: "gpt-4o", baseUrl: "https://api.openai.com/v1" },
+	// "gpt-5.5" is this literal's FALLBACK value only, used before the catalog
+	// fetch lands or if it fails - providerDefaultModel() below prefers the
+	// catalog's is_default flag. Previously a stale "gpt-4o" here (fixed
+	// alongside the catalog wiring: PROVIDER_DEFAULTS.OpenAI predates the
+	// gpt-5.x rollout and was never updated).
+	OpenAI: { model: "gpt-5.5", baseUrl: "https://api.openai.com/v1" },
 	"Google Gemini": {
 		model: "gemini-2.5-pro",
 		baseUrl: "https://generativelanguage.googleapis.com",
@@ -1773,6 +1769,15 @@ const PROVIDER_DEFAULTS = {
 function catalogVendorLabel(vid) {
 	return vid === "gemini" ? "Google Gemini" : providerLabel(vid);
 }
+// The api-key-tier model preselected for a provider. Prefers the admin-managed
+// catalog's is_default flag; falls back to the PROVIDER_DEFAULTS literal when
+// the catalog has no default for this label (fetch still pending, failed, or
+// the label has no api-key rows at all).
+function providerDefaultModel(label) {
+	const rows = (modelCatalog.value.api_key_models || {})[label] || [];
+	const flagged = rows.find((m) => m.is_default);
+	return (flagged && flagged.model_id) || (PROVIDER_DEFAULTS[label] || {}).model || "";
+}
 function modelSuggestionsForProvider(provider) {
 	const label = providerLabel(provider || "");
 	const out = [];
@@ -1784,8 +1789,8 @@ function modelSuggestionsForProvider(provider) {
 			if (catalogVendorLabel(m.provider) === label) push(m.model);
 		})
 	);
-	(STATIC_MODEL_SUGGESTIONS[label] || []).forEach(push);
-	push((PROVIDER_DEFAULTS[label] || {}).model);
+	((modelCatalog.value.api_key_models || {})[label] || []).forEach((m) => push(m.model_id));
+	push(providerDefaultModel(label));
 	return out;
 }
 
@@ -2337,7 +2342,7 @@ function setCredType(m, type) {
 		// invalid one). validatePool + save still REQUIRE a model id, so derive it from
 		// the chosen provider. Dropping this would make every subscription save fail
 		// validation with "model is required".
-		m.model = defaultSubscriptionModel(m.upstream);
+		m.model = defaultSubscriptionModel(m.upstream, subscriptionSuggestions.value);
 	} else {
 		// Toggling back to API key: drop the subscription's model id so it doesn't
 		// linger under an API-key provider it does not belong to (a "gpt-5.5" left on
@@ -2345,7 +2350,7 @@ function setCredType(m, type) {
 		// the upstream). This used to be gated on singleMode -- but the SETTINGS editor
 		// hides the subscription model field too, so it needs the same reset; without it
 		// the stale id is invisible AND unsavable-by-hand.
-		m.model = (PROVIDER_DEFAULTS[m.provider] || {}).model || "";
+		m.model = providerDefaultModel(m.provider);
 	}
 }
 function onProviderChange(m, newProvider) {
@@ -2358,7 +2363,7 @@ function onProviderChange(m, newProvider) {
 	// not whatever model was there before. Providers with no default model
 	// (OpenAI-Compatible / vLLM) clear the field so the user types their own.
 	const d = PROVIDER_DEFAULTS[m.provider] || {};
-	m.model = d.model || "";
+	m.model = providerDefaultModel(m.provider);
 	m.baseUrl = d.baseUrl || "";
 	// A stored key (hasKey) belongs to the OLD provider's key_ref, not this one -
 	// carrying it forward would either merge the wrong provider's secret on save
@@ -2381,7 +2386,7 @@ function onUpstreamChange(m) {
 	// it needs the same derivation. Changing provider must also clear the accounts:
 	// an OAuth account is authorized against ONE provider, so keeping OpenAI accounts
 	// on a row switched to Anthropic would ship a pool whose credentials can't serve it.
-	m.model = defaultSubscriptionModel(m.upstream);
+	m.model = defaultSubscriptionModel(m.upstream, subscriptionSuggestions.value);
 	m.accounts = [];
 	m._connect = blankConnect();
 }
@@ -2534,7 +2539,7 @@ async function startConnect(m, reconnectIdx = null, opts = {}) {
 	// Simplified editor hides the model field - make sure a subscription row always
 	// carries a model id so the connect flow never dead-ends on an unfillable field.
 	if (singleMode.value && m.credentialType === "subscription" && !(m.model || "").trim()) {
-		m.model = defaultSubscriptionModel(m.upstream);
+		m.model = defaultSubscriptionModel(m.upstream, subscriptionSuggestions.value);
 	}
 	if (!(m.model || "").trim()) {
 		m._connect = {
@@ -2785,7 +2790,7 @@ function seedRows(config) {
 		// the editors use, so such a row is repairable instead of permanently stuck.
 		const model =
 			r.credentialType === "subscription" && !(r.model || "").trim()
-				? defaultSubscriptionModel(upstream)
+				? defaultSubscriptionModel(upstream, subscriptionSuggestions.value)
 				: r.model;
 		return {
 			...r,

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -62,22 +62,45 @@ export function reorder(list, from, to) {
 	a.splice(to, 0, x);
 	return a;
 }
-// Suggested chat-subscription model ids per upstream (index 0 = the default the
-// onboarding editor uses when it hides the model field). Single source of truth,
-// shared with LlmPoolEditor's datalist so the default + suggestions can't drift.
-export const SUB_MODEL_SUGGESTIONS = {
+// Built-in fallback for chat-subscription model ids per upstream. The catalog is
+// owned by admin now (Jarvis LLM Provider doctype) and arrives via
+// get_chat_ui_settings.subscription_models; this literal is the degraded-mode
+// floor used before the first response lands and when admin is unreachable.
+// Do NOT add models here to make them selectable: add them in the admin desk.
+const FALLBACK_SUB_MODELS = {
 	openai: ["gpt-5.5", "gpt-5.4"],
 	google: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-flash"],
-	// Model ids must exist in cli-proxy-api's v7.2.35 catalogue (grok-4.5 is NOT).
 	xai: ["grok-4.3", "grok-build-0.1"],
 	kimi: ["kimi-k2.7-code", "kimi-k2.6"],
 };
-// Default chat-subscription model for an upstream (SUB_MODEL_SUGGESTIONS[0], with
-// an openai fallback for unmapped upstreams). Onboarding hides the model field
-// (provider is enough), so the row still needs a model id for validatePool + save.
-// Pure + exported for unit tests.
-export function defaultSubscriptionModel(upstream) {
-	return (SUB_MODEL_SUGGESTIONS[upstream] || SUB_MODEL_SUGGESTIONS.openai)[0];
+
+// Provider label (as admin stores it) -> the upstream key the pool editor uses.
+const LABEL_TO_UPSTREAM = {
+	OpenAI: "openai",
+	"Google Gemini": "google",
+	"xAI Grok": "xai",
+	"Kimi (Moonshot)": "kimi",
+};
+
+// Map a get_chat_ui_settings.subscription_models payload (keyed by provider
+// LABEL) to the upstream keys this module uses. Falls back when empty.
+export function subModelSuggestions(apiSubscriptionModels) {
+	const src = apiSubscriptionModels || {};
+	const out = {};
+	for (const [label, models] of Object.entries(src)) {
+		const upstream = LABEL_TO_UPSTREAM[label];
+		if (upstream && Array.isArray(models) && models.length) out[upstream] = models;
+	}
+	return Object.keys(out).length ? out : FALLBACK_SUB_MODELS;
+}
+
+// Default chat-subscription model for an upstream. Synchronous by contract: the
+// onboarding editor calls it before any API response exists, so `catalog` is
+// optional and omitting it yields the built-in fallback.
+export function defaultSubscriptionModel(upstream, catalog) {
+	const table = catalog && Object.keys(catalog).length ? catalog : FALLBACK_SUB_MODELS;
+	const models = table[upstream] || FALLBACK_SUB_MODELS[upstream] || FALLBACK_SUB_MODELS.openai;
+	return models[0];
 }
 export function validatePool(models, preset) {
 	if (!Array.isArray(models) || models.length === 0)

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -10,15 +10,42 @@ import {
 	validatePool,
 } from "./pool.js";
 import { PROVIDER_LABELS, providerLabel, providerId, seedRowsFromConfig } from "./pool.js";
-import { defaultSubscriptionModel } from "./pool.js";
+import { defaultSubscriptionModel, subModelSuggestions } from "./pool.js";
 import { apiKeyModelHealth, subscriptionAccountHealth, dirtyAccountHealth } from "./pool.js";
 import { LOCAL_PROVIDER_IDS, effectiveApiKey } from "./pool.js";
 
-test("defaultSubscriptionModel: per-upstream default, openai fallback", () => {
+test("defaultSubscriptionModel: falls back to built-in defaults with no catalog", () => {
 	assert.equal(defaultSubscriptionModel("openai"), "gpt-5.5");
 	assert.equal(defaultSubscriptionModel("google"), "gemini-2.5-pro");
 	assert.equal(defaultSubscriptionModel("unknown"), "gpt-5.5");
 	assert.equal(defaultSubscriptionModel(undefined), "gpt-5.5");
+});
+
+test("defaultSubscriptionModel: a catalog overrides the built-in default", () => {
+	const catalog = { openai: ["gpt-9.9", "gpt-5.5"] };
+	assert.equal(defaultSubscriptionModel("openai", catalog), "gpt-9.9");
+	// an upstream absent from the catalog still falls back
+	assert.equal(defaultSubscriptionModel("google", catalog), "gemini-2.5-pro");
+});
+
+test("subModelSuggestions: maps an API subscription_models payload to upstream keys", () => {
+	const apiPayload = {
+		OpenAI: ["gpt-9.9"],
+		"Google Gemini": ["gemini-9.9"],
+		"xAI Grok": ["grok-9.9"],
+		"Kimi (Moonshot)": ["kimi-9.9"],
+	};
+	assert.deepEqual(subModelSuggestions(apiPayload), {
+		openai: ["gpt-9.9"],
+		google: ["gemini-9.9"],
+		xai: ["grok-9.9"],
+		kimi: ["kimi-9.9"],
+	});
+});
+
+test("subModelSuggestions: empty or missing payload yields the built-in fallback", () => {
+	assert.equal(subModelSuggestions({}).openai[0], "gpt-5.5");
+	assert.equal(subModelSuggestions(undefined).openai[0], "gpt-5.5");
 });
 
 const LADDER = {

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1156,6 +1156,52 @@ def _api_key_models() -> dict[str, list[dict]]:
 	return out
 
 
+def _subscription_connect_providers() -> list[dict]:
+	"""Providers offering DirectSubscriptionCard's paste-back OAuth connect flow.
+
+	Gated on a non-empty auth_profile_id (R7), NEVER on supports_subscription:
+	that flag is true for xai and moonshot too (cliproxy really does serve their
+	subscription models), but Kimi is device-code (no authorize URL to paste
+	back) and admin's push_oauth_blob rejects a direct xAI blob outright, so
+	both carry no auth_profile_id here. Filtering on supports_subscription
+	would render a connect button that can never succeed.
+	"""
+	from jarvis import admin_client
+
+	out: list[dict] = []
+	for provider in admin_client.get_model_catalog() or []:
+		if not (provider.get("auth_profile_id") or "").strip():
+			continue
+		label = provider.get("subscription_label") or provider.get("label") or ""
+		rows = [m for m in provider.get("models") or [] if m.get("tier") == "subscription"]
+		rows.sort(key=lambda m: (m.get("sort_order") or 0, m.get("model_id") or ""))
+		models = [m["model_id"] for m in rows]
+		if label and models:
+			out.append({"provider": label, "models": models})
+	return out
+
+
+@frappe.whitelist()
+def get_model_catalog_ui() -> dict:
+	"""Catalog slice the pool editor and subscription card need, independent of
+	get_chat_ui_settings so the onboarding wizard (which never calls that) works.
+
+	Deliberately NOT on the chat hot path: mount-time only.
+	"""
+	require_jarvis_access()
+
+	# dict() is MANDATORY here (R9): SUBSCRIPTION_MODELS/DEFAULT_MODEL are Mapping
+	# subclasses, and frappe's json_handler serialises a bare Mapping to its KEYS
+	# with no error. _api_key_models() and _subscription_connect_providers()
+	# already return plain dict/list structures.
+	return {
+		"api_key_models": _api_key_models(),
+		"subscription_models": dict(_SUBSCRIPTION_MODELS),
+		"default_models": dict(_DEFAULT_MODEL),
+		"subscription_connect_providers": _subscription_connect_providers(),
+	}
+
+
 @frappe.whitelist()
 def get_chat_ui_settings() -> dict:
 	"""Return the bench-side LLM settings the chat UI needs to render the

--- a/jarvis/jarvis/page/jarvis_account/jarvis_account.js
+++ b/jarvis/jarvis/page/jarvis_account/jarvis_account.js
@@ -17,9 +17,16 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 
 	// LLM provider defaults - mirror the onboarding wizard's PROVIDER_DEFAULTS
 	// so the section behaves identically there and here.
+	//
+	// The admin-managed catalog (api_key_models, fetched via get_chat_ui_settings
+	// below) carries no base-URL data, so `.baseUrl` here stays the source of
+	// truth. `.model` is this literal's FALLBACK only - providerDefaultModel()
+	// below prefers the catalog's is_default flag, which also fixes this file's
+	// own copy of the stale "gpt-4o" OpenAI default (see LlmPoolEditor.vue's
+	// identical fix).
 	const PROVIDER_DEFAULTS = {
 		Anthropic: { model: "claude-sonnet-4-6", baseUrl: "https://api.anthropic.com" },
-		OpenAI: { model: "gpt-4o", baseUrl: "https://api.openai.com/v1" },
+		OpenAI: { model: "gpt-5.5", baseUrl: "https://api.openai.com/v1" },
 		"Google Gemini": {
 			model: "gemini-2.5-pro",
 			baseUrl: "https://generativelanguage.googleapis.com",
@@ -79,42 +86,31 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	// pickable while arbitrary IDs stay typeable (openai_compat / Ollama / shim
 	// need custom model ids). Suggestions are sourced per provider:
 	//   1) the already-loaded preset catalog (models grouped by vendor id), then
-	//   2) a small static fallback for providers the catalog omits, then
+	//   2) the admin-managed catalog (apiKeyModels, from get_chat_ui_settings), then
 	//   3) the provider's default model. Deduped, catalog-first.
-	// Static fallback keyed by the provider dropdown LABEL.
-	const STATIC_MODEL_SUGGESTIONS = {
-		Anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
-		OpenAI: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-4o"],
-		"Google Gemini": ["gemini-2.5-pro", "gemini-3.5-flash", "gemini-3.1-flash-lite"],
-		Mistral: ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
-		Groq: [
-			"llama-3.3-70b-versatile",
-			"openai/gpt-oss-120b",
-			"openai/gpt-oss-20b",
-			"llama-3.1-8b-instant",
-		],
-		"Together AI": ["meta-llama/Llama-3.3-70B-Instruct-Turbo"],
-		DeepSeek: ["deepseek-chat"],
-		"Moonshot (Kimi)": ["kimi-k2.6"],
-		"xAI Grok": ["grok-4.5", "grok-4.3", "grok-build-0.1"],
-		"GLM / Z.ai": ["glm-4.6", "glm-4.7"],
-		"GLM / Z.ai (Coding Plan)": ["glm-4.6", "glm-4.7"],
-		OpenRouter: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
-		"Ollama (local)": ["qwen2.5:3b", "qwen2.5:0.5b", "llama3"],
-		"OpenAI-Compatible": ["claude-sonnet-4-6", "gpt-4o", "qwen2.5:3b", "llama3"],
-		// vLLM (local): no useful default → plain free-text input.
-	};
-	// Subscription rows suggest the upstream's chat models (keyed by upstream id).
-	const SUB_MODEL_SUGGESTIONS = {
-		openai: ["gpt-5.5", "gpt-5.4"],
-		google: ["gemini-2.5-pro", "gemini-3.5-flash"],
-	};
+	//
+	// STATIC_MODEL_SUGGESTIONS and SUB_MODEL_SUGGESTIONS (the old hardcoded
+	// per-provider datalists) are gone: a model added in the admin desk now
+	// shows up here with no deploy. SUB_MODEL_SUGGESTIONS previously carried
+	// only openai/google, so a tenant on a Grok or Kimi subscription saw no
+	// suggestions at all on this page; subscriptionModels (already fetched
+	// dynamically, see loadInitial) carries all four.
+	//
 	// Preset-catalog vendor ids -> provider dropdown label. The catalog uses
 	// "gemini"; the dropdown label is "Google Gemini" (stored id "google"), so
 	// alias both to the same label. Others fall through to providerLabel.
 	function catalogVendorLabel(vid) {
 		if (vid === "gemini") return "Google Gemini";
 		return providerLabel(vid);
+	}
+	// The api-key-tier model preselected for a provider. Prefers the admin-managed
+	// catalog's is_default flag; falls back to the PROVIDER_DEFAULTS literal when
+	// the catalog has no default for this label (fetch failed, or no api-key rows
+	// at all for it).
+	function providerDefaultModel(label) {
+		const rows = apiKeyModels[label] || [];
+		const flagged = rows.find((m) => m.is_default);
+		return (flagged && flagged.model_id) || (PROVIDER_DEFAULTS[label] || {}).model || "";
 	}
 	// Suggested model ids for an API-key row's provider (label or id).
 	function modelSuggestionsForProvider(provider) {
@@ -128,13 +124,23 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 				if (catalogVendorLabel(m.provider) === label) push(m.model);
 			})
 		);
-		(STATIC_MODEL_SUGGESTIONS[label] || []).forEach(push);
-		push((PROVIDER_DEFAULTS[label] || {}).model);
+		(apiKeyModels[label] || []).forEach((m) => push(m.model_id));
+		push(providerDefaultModel(label));
 		return out;
 	}
+	// Upstream id (openai/google/xai/kimi) -> the subscription-surface provider
+	// LABEL subscriptionModels is keyed by (get_chat_ui_settings /
+	// jarvis/_subscription_models.py). Mirrors LlmPoolEditor.vue's
+	// UPSTREAM_OAUTH_PROVIDER so the two never drift.
+	const UPSTREAM_TO_SUB_LABEL = {
+		openai: "OpenAI",
+		google: "Google Gemini",
+		xai: "xAI Grok",
+		kimi: "Kimi (Moonshot)",
+	};
 	// Suggested model ids for a subscription row's chosen upstream.
 	function subModelSuggestions(upstream) {
-		return SUB_MODEL_SUGGESTIONS[upstream] || [];
+		return subscriptionModels[UPSTREAM_TO_SUB_LABEL[upstream] || ""] || [];
 	}
 	// A <datalist> of model-id suggestions. Empty list → the bound input just
 	// behaves as a plain free-text field.
@@ -189,6 +195,10 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 	const CODE_ONLY_PASTE_PROVIDERS = ["xAI Grok"];
 	const isCodeOnlyPaste = (p) => CODE_ONLY_PASTE_PROVIDERS.indexOf(p) !== -1;
 	let defaultModels = {};
+	// Api-key-tier suggestions (provider label -> [{model_id, label, is_default}]),
+	// same get_chat_ui_settings response as subscriptionModels/defaultModels above.
+	// Replaces the old hardcoded STATIC_MODEL_SUGGESTIONS; see modelSuggestionsForProvider.
+	let apiKeyModels = {};
 	// Preset failover ladders (jarvis.onboarding.get_preset_catalog). Fetched in
 	// loadInitial alongside the pool config so the Preset tab is populated before
 	// the user opens it. Empty on fetch failure → Preset tab shows a fallback line.
@@ -304,6 +314,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 					const cui = (chatUi && chatUi.message) || {};
 					subscriptionModels = cui.subscription_models || {};
 					defaultModels = cui.default_models || {};
+					apiKeyModels = cui.api_key_models || {};
 					presetCatalog = (catalog && catalog.message) || [];
 					// First-paint seed: pick the canonical default for the
 					// initial subProvider so render() doesn't show an empty
@@ -613,7 +624,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 
 	function renderApiKeyPanel(editable, isActiveMode) {
 		const provider = settingsLocal.llm_provider || "Anthropic";
-		const model = settingsLocal.llm_model || (PROVIDER_DEFAULTS[provider] || {}).model || "";
+		const model = settingsLocal.llm_model || providerDefaultModel(provider);
 		const base =
 			settingsLocal.llm_base_url || (PROVIDER_DEFAULTS[provider] || {}).baseUrl || "";
 		const sync = settingsLocal.last_sync_status || "";
@@ -1490,13 +1501,14 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 			const i = +$(this).data("i");
 			const p = $(this).val();
 			const d = PROVIDER_DEFAULTS[p] || {};
+			const defaultModel = providerDefaultModel(p);
 			const row = ui.customRows[i] || {};
 			// A stored key (has_key) belongs to the OLD provider's key_ref - carry it
 			// forward and a switch to Ollama/vLLM with no retyped key would still send
 			// a blank api_key while has_key=true, hitting the exact "blank api_key"
 			// rejection this whole editor exists to avoid for local providers.
 			const patch = { provider: p, has_key: false, apiKey: "" };
-			if (!(row.model || "").trim() && d.model) patch.model = d.model;
+			if (!(row.model || "").trim() && defaultModel) patch.model = defaultModel;
 			if (!(row.baseUrl || "").trim() && d.baseUrl) patch.baseUrl = d.baseUrl;
 			ui.customRows[i] = Object.assign({}, row, patch);
 			rerenderAiCard(editable);
@@ -1888,7 +1900,7 @@ frappe.pages["jarvis-account"].on_page_load = function (wrapper) {
 		$prov.on("change", () => {
 			const p = $prov.val();
 			const d = PROVIDER_DEFAULTS[p] || {};
-			$body.find("#ja-model").val(d.model || "");
+			$body.find("#ja-model").val(providerDefaultModel(p));
 			$body.find("#ja-base").val(d.baseUrl || "");
 		});
 		$body.find("#ja-llm-save").on("click", () => {

--- a/jarvis/tests/test_model_catalog.py
+++ b/jarvis/tests/test_model_catalog.py
@@ -368,3 +368,95 @@ class TestChatUiSettingsServesApiKeyModels(FrappeTestCase):
 			out = get_chat_ui_settings()
 		# _PAYLOAD's only model is subscription-tier, so OpenAI has no api-key rows.
 		self.assertEqual(out["api_key_models"].get("OpenAI", []), [])
+
+
+class TestModelCatalogUiEndpoint(FrappeTestCase):
+	def setUp(self):
+		_clear_model_catalog_cache()
+		_clear_sub_model_cache()
+		self.addCleanup(_clear_model_catalog_cache)
+		self.addCleanup(_clear_sub_model_cache)
+
+	def test_returns_the_three_catalog_slices_as_json_objects(self):
+		import orjson
+		from frappe.utils.response import json_handler
+
+		from jarvis.chat.api import get_model_catalog_ui
+
+		with patch.object(admin_client, "get_model_catalog", return_value=_PAYLOAD):
+			out = get_model_catalog_ui()
+		for key in ("api_key_models", "subscription_models", "default_models"):
+			self.assertIn(key, out)
+			# R9: a bare Mapping would serialise to its KEYS with no error.
+			self.assertIsInstance(out[key], dict)
+			self.assertIsInstance(orjson.loads(orjson.dumps(out[key], default=json_handler)), dict)
+
+	def test_kimi_is_keyed_by_its_subscription_label(self):
+		from jarvis.chat.api import get_model_catalog_ui
+
+		payload = [
+			{
+				"provider_id": "moonshot",
+				"label": "Moonshot (Kimi)",
+				"subscription_label": "Kimi (Moonshot)",
+				"supports_subscription": True,
+				"models": [
+					{
+						"model_id": "kimi-k2.7-code",
+						"label": "kimi-k2.7-code",
+						"tier": "subscription",
+						"is_default": True,
+						"sort_order": 0,
+					}
+				],
+			}
+		]
+		with patch.object(admin_client, "get_model_catalog", return_value=payload):
+			out = get_model_catalog_ui()
+		self.assertIn("Kimi (Moonshot)", out["subscription_models"])
+		self.assertNotIn("Moonshot (Kimi)", out["subscription_models"])
+
+	def test_connect_providers_gate_on_auth_profile_id_not_supports_subscription(self):
+		# R7: supports_subscription is true for xai and moonshot too (cliproxy
+		# really does serve their models), but only openai/google support the
+		# paste-back connect card. Gating on supports_subscription would render
+		# a connect button that can never succeed.
+		from jarvis.chat.api import get_model_catalog_ui
+
+		payload = [
+			{
+				"provider_id": "openai",
+				"label": "OpenAI",
+				"auth_profile_id": "openai",
+				"supports_subscription": True,
+				"models": [
+					{
+						"model_id": "gpt-5.5",
+						"label": "gpt-5.5",
+						"tier": "subscription",
+						"is_default": True,
+						"sort_order": 0,
+					}
+				],
+			},
+			{
+				"provider_id": "xai",
+				"label": "xAI Grok",
+				"auth_profile_id": "",
+				"supports_subscription": True,
+				"models": [
+					{
+						"model_id": "grok-4.3",
+						"label": "grok-4.3",
+						"tier": "subscription",
+						"is_default": True,
+						"sort_order": 0,
+					}
+				],
+			},
+		]
+		with patch.object(admin_client, "get_model_catalog", return_value=payload):
+			out = get_model_catalog_ui()
+		providers = {p["provider"] for p in out["subscription_connect_providers"]}
+		self.assertIn("OpenAI", providers)
+		self.assertNotIn("xAI Grok", providers)


### PR DESCRIPTION
Phase 1 PR 4 of 5, and the **only user-visible one**. Depends on #411 (merged).

This is the last hop. Everything before it shipped dark: the catalog was live and admin-editable, but the picker still read its own hardcoded lists, so adding a model in the desk changed nothing for customers. After this, it does.

## What changes

- **`pool.js`** — `SUB_MODEL_SUGGESTIONS` becomes `subModelSuggestions(payload)`, reading what the API serves. `FALLBACK_SUB_MODELS` remains as the degraded-mode floor.
- **New `get_model_catalog_ui` endpoint** — the pool editor and subscription card never fetched `get_chat_ui_settings`, so this is the plumbing that gap required. It also works in the onboarding wizard, which has no settings call at all.
- **`LlmPoolEditor.vue`** — `STATIC_MODEL_SUGGESTIONS` deleted; the stale `gpt-4o` OpenAI default fixed; all four `defaultSubscriptionModel` call sites now pass the catalog. Until every one of them did, an admin could not change a subscription default at all.
- **`jarvis_account.js`** — the desk page reads the catalog, restoring the xAI and Kimi suggestions it was missing entirely.

## Two things that look wrong but are deliberate

**The connect card still offers exactly two providers.** It gates on a non-empty `auth_profile_id`, NOT on `supports_subscription`. That flag is true for four providers, because cliproxy really does serve xAI and Kimi subscription models. But only OpenAI and Google Gemini can use the paste-back OAuth flow: Kimi is device-code, and admin's `push_oauth_blob` rejects a direct xAI blob. Listing four would ship connect buttons that cannot succeed. The list is data-driven now; it just resolves to two.

**Kimi appears under two different labels in the same response.** `subscription_models` keys it `Kimi (Moonshot)`, `api_key_models` keys it `Moonshot (Kimi)`. Both are correct for their surface. Emitting one where the other belongs coerces a Kimi subscription's model to an empty string and silently defaults the picker to gpt-5.5.

## Also fixes a pre-existing crash

`DirectSubscriptionCard.vue` read `status.value.provider`, but there is no local `status` ref, so it resolved to the browser global `window.status` (a string). `.value` on that is undefined, so the computed **threw every time the paste-back screen rendered** — the entire xAI bare-code flow from #356. Every other reference in the file already used `props.status`. Present identically on develop; found while wiring the catalog in.

## Verification

Local CI, full run on this exact commit `ff22de79`:

| job | result |
|---|---|
| lint | PASS |
| tests-shard1 | 919 tests, 0 failing, 0 errors |
| tests-shard2 | 923 tests, 0 failing, 0 errors |
| tests-shard3 | 951 tests, 0 failing, 0 errors |
| tests-shard4 | 881 tests, 0 failing, 0 errors |
| coverage | **92%** (floor 85), all 4 shards combined |

**3,674 tests, zero failures.** Plus 68 frontend unit tests and a clean `npm run build`.

**This is not a GitHub Actions run.** Hosted Actions is billing-blocked for the org, so this is `jarvis-ci` executing the repo's own `ci.yml` in docker on linux/arm64. It sets no check on this PR. Two structural divergences: architecture (arm64 vs amd64), and credential scope (one token here vs two on GitHub), so token-scope regressions are invisible locally.

Getting this run to happen at all required six fixes to `jarvis-ci`, which could not previously produce a passing run for this repo on **any** commit, including untouched develop. Those ship separately.

Spec: `model-catalog-selfupdate-spec.md` section 6.4.

https://claude.ai/code/session_01L2wrSyotAhtDHXWq72f67m