### PR TITLE
fix(widget): gate the desk popup when the workspace is not set up

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -115,18 +115,12 @@
 			</div>
 
 			<div class="jvp-body" ref="bodyEl">
-				<div v-if="loading" class="jvp-center">Restoring your last conversation…</div>
-
-				<div v-else-if="loadError && !shownMessages.length" class="jvp-center">
-					<div class="jvp-err">{{ loadError }}</div>
-					<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
-				</div>
-
-				<!-- Welcome: brand mark, greeting, and starting points. -->
-				<div
-					v-else-if="!shownMessages.length && !stream.live && !thinking"
-					class="jvp-welcome"
-				>
+				<!-- Never onboarded (readiness === "gate"): the panel cannot possibly
+				     chat, so the whole body - welcome, history, composer below - is
+				     replaced by a compact setup nudge instead of a chat box that can
+				     only fail. Mirrors OnboardingGate.vue's full-screen poster, sized
+				     for 400px. -->
+				<div v-if="readiness === 'gate'" class="jvp-nudge">
 					<div class="jvp-hero">
 						<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
 							<path
@@ -134,53 +128,107 @@
 							/>
 						</svg>
 					</div>
-					<div class="jvp-greet">{{ greeting }}</div>
-					<p class="jvp-greet-sub">
-						<template v-if="contextText">
-							Jarvis can see <b>{{ contextText }}</b> while you are on this page.
+					<div class="jvp-nudge-h">Finish setting up {{ brandName }}</div>
+					<p class="jvp-nudge-s">
+						<template v-if="canOnboard">
+							This workspace isn't connected to an AI agent yet. Complete a short
+							setup to start chatting with {{ brandName }} about your ERPNext data.
 						</template>
 						<template v-else>
-							Ask about your ERP data, run a workflow, or draft something.
+							{{ brandName }} isn't set up for this workspace yet. Please ask your
+							administrator (a System Manager) to complete onboarding.
 						</template>
 					</p>
-					<div class="jvp-cards">
-						<button
-							v-for="(s, i) in suggestions"
-							:key="s.title"
-							class="jvp-card"
-							type="button"
-							@click="useSuggestion(s.prompt)"
-						>
-							<span
-								class="jvp-card-ic"
-								:class="`jvp-card-ic--${i % 4}`"
-								aria-hidden="true"
-							>
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.7"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<path :d="CARD_ICONS[i % CARD_ICONS.length]" />
-								</svg>
-							</span>
-							<span class="jvp-card-txt">
-								<span class="jvp-card-t">{{ s.title }}</span>
-								<span class="jvp-card-p">{{ s.prompt }}</span>
-							</span>
-						</button>
-					</div>
+					<button
+						v-if="canOnboard"
+						type="button"
+						class="jvp-nudge-btn"
+						@click="goOnboard"
+					>
+						Complete setup
+						<span aria-hidden="true">→</span>
+					</button>
 				</div>
 
-				<div v-else class="jvp-msgs">
-					<template v-for="m in shownMessages" :key="m.name">
-						<div v-if="m.role === 'user'" class="jvp-row jvp-row--user">
-							<div class="jvp-m-user">{{ m.content }}</div>
+				<template v-else>
+					<div v-if="loading" class="jvp-center">Restoring your last conversation…</div>
+
+					<div v-else-if="loadError && !shownMessages.length" class="jvp-center">
+						<div class="jvp-err">{{ loadError }}</div>
+						<button class="jvp-btn-subtle" type="button" @click="load">Retry</button>
+					</div>
+
+					<!-- Welcome: brand mark, greeting, and starting points. -->
+					<div
+						v-else-if="!shownMessages.length && !stream.live && !thinking"
+						class="jvp-welcome"
+					>
+						<div class="jvp-hero">
+							<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
+								<path
+									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+								/>
+							</svg>
 						</div>
-						<div v-else class="jvp-row">
+						<div class="jvp-greet">{{ greeting }}</div>
+						<p class="jvp-greet-sub">
+							<template v-if="contextText">
+								Jarvis can see <b>{{ contextText }}</b> while you are on this page.
+							</template>
+							<template v-else>
+								Ask about your ERP data, run a workflow, or draft something.
+							</template>
+						</p>
+						<div class="jvp-cards">
+							<button
+								v-for="(s, i) in suggestions"
+								:key="s.title"
+								class="jvp-card"
+								type="button"
+								@click="useSuggestion(s.prompt)"
+							>
+								<span
+									class="jvp-card-ic"
+									:class="`jvp-card-ic--${i % 4}`"
+									aria-hidden="true"
+								>
+									<svg
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.7"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path :d="CARD_ICONS[i % CARD_ICONS.length]" />
+									</svg>
+								</span>
+								<span class="jvp-card-txt">
+									<span class="jvp-card-t">{{ s.title }}</span>
+									<span class="jvp-card-p">{{ s.prompt }}</span>
+								</span>
+							</button>
+						</div>
+					</div>
+
+					<div v-else class="jvp-msgs">
+						<template v-for="m in shownMessages" :key="m.name">
+							<div v-if="m.role === 'user'" class="jvp-row jvp-row--user">
+								<div class="jvp-m-user">{{ m.content }}</div>
+							</div>
+							<div v-else class="jvp-row">
+								<div class="jvp-m-avatar" aria-hidden="true">
+									<svg viewBox="0 0 24 24" fill="#fff">
+										<path
+											d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+										/>
+									</svg>
+								</div>
+								<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
+							</div>
+						</template>
+
+						<div v-if="stream.live && stream.live.text" class="jvp-row">
 							<div class="jvp-m-avatar" aria-hidden="true">
 								<svg viewBox="0 0 24 24" fill="#fff">
 									<path
@@ -188,50 +236,64 @@
 									/>
 								</svg>
 							</div>
-							<div class="jvp-m-bot jv-md" v-html="renderReply(m.content)"></div>
+							<div
+								class="jvp-m-bot jv-md"
+								v-html="renderReply(stream.live.text)"
+							></div>
 						</div>
-					</template>
 
-					<div v-if="stream.live && stream.live.text" class="jvp-row">
-						<div class="jvp-m-avatar" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="#fff">
-								<path
-									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
-								/>
-							</svg>
-						</div>
-						<div class="jvp-m-bot jv-md" v-html="renderReply(stream.live.text)"></div>
-					</div>
-
-					<!-- Waiting for the first token: a labelled state, not a bare
+						<!-- Waiting for the first token: a labelled state, not a bare
 					     spinner, so the user knows the turn was accepted. -->
-					<div v-else-if="thinking" class="jvp-row">
-						<div class="jvp-m-avatar" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="#fff">
-								<path
-									d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
-								/>
-							</svg>
+						<div v-else-if="thinking" class="jvp-row">
+							<div class="jvp-m-avatar" aria-hidden="true">
+								<svg viewBox="0 0 24 24" fill="#fff">
+									<path
+										d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+									/>
+								</svg>
+							</div>
+							<div
+								class="jvp-think"
+								role="status"
+								aria-live="polite"
+								aria-label="Jarvis is typing"
+							>
+								<span class="jvp-think-dots" aria-hidden="true"
+									><i></i><i></i><i></i
+								></span>
+							</div>
 						</div>
-						<div
-							class="jvp-think"
-							role="status"
-							aria-live="polite"
-							aria-label="Jarvis is typing"
-						>
-							<span class="jvp-think-dots" aria-hidden="true"
-								><i></i><i></i><i></i
-							></span>
-						</div>
-					</div>
 
-					<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
-						<span class="jvp-err">{{ loadError }}</span>
-						<button class="jvp-btn-subtle" type="button" @click="retryLast">
-							Retry
-						</button>
+						<div v-if="loadError && shownMessages.length" class="jvp-inline-err">
+							<span class="jvp-err">{{ loadError }}</span>
+							<button class="jvp-btn-subtle" type="button" @click="retryLast">
+								Retry
+							</button>
+						</div>
 					</div>
-				</div>
+				</template>
+			</div>
+
+			<!-- Degraded: onboarded once, but is_ready_for_chat currently says no
+			     (e.g. expired LLM creds, a stalled container). The chat stays fully
+			     usable - unlike the gate above, this is not a hard block - it just
+			     warns that a send may fail right now. -->
+			<div v-if="readiness === 'degraded'" class="jvp-notice">
+				<svg
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.8"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M12 9v4M12 17h.01" />
+					<path
+						d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+					/>
+				</svg>
+				<span>{{ readinessNotice }}</span>
 			</div>
 
 			<div v-if="stream.pending.length" class="jvp-pending">
@@ -255,7 +317,11 @@
 				</div>
 			</div>
 
-			<div class="jvp-foot">
+			<!-- Hidden entirely in the gate state, not merely disabled: there is
+			     nothing to send to yet, and a live-but-disabled composer would
+			     imply chat almost works. The "degraded" state keeps this, on
+			     purpose - see the jvp-notice banner above. -->
+			<div v-if="readiness !== 'gate'" class="jvp-foot">
 				<!-- attached files, above the input -->
 				<div v-if="attachments.length" class="jvp-atts">
 					<span v-for="a in attachments" :key="a.file_url" class="jvp-att">
@@ -406,7 +472,9 @@ import { contextLabel } from "./desk_context.mjs";
 import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { renderReply } from "./panel_markdown.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
+import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
 import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
+import { ONBOARDING_URL } from "./config.mjs";
 import {
 	listConversations,
 	getConversation,
@@ -416,6 +484,7 @@ import {
 	uploadFile,
 	transcribeAudio,
 	getChatUiSettings,
+	isReadyForChat,
 } from "./panel_api.mjs";
 
 const props = defineProps({
@@ -452,6 +521,23 @@ const transcribing = ref(false);
 let recorder = null;
 let recChunks = [];
 let recStartedAt = 0;
+
+// Chat-readiness gate: "ready" | "gate" | "degraded" (panel_readiness.mjs).
+// Resolved ONCE in onMounted below and cached for the panel's lifetime - this
+// component is kept mounted and toggled with v-show (see the template comment
+// up top), so "once per mount" already means "once per Desk page load", not
+// once per open. There is deliberately no poll here: a workspace's onboarding
+// state does not change while a chat panel sits open.
+const readiness = ref("ready");
+const readinessNotice = ref("");
+// Only an admin who can actually reach the wizard gets the CTA button in the
+// gate state, mirroring OnboardingGate.vue's isSystemManager split. Read off
+// frappe.boot.user.roles - core Frappe bootinfo (User.load_user), already
+// present on every Desk page, not a Jarvis boot field - so this needs no
+// backend change. Matches jarvis/permissions.py's JARVIS_ADMIN_ROLES.
+const deskUserRoles = window.frappe?.boot?.user?.roles || [];
+const canOnboard =
+	deskUserRoles.includes("System Manager") || deskUserRoles.includes("Jarvis Admin");
 
 const contextText = computed(() => contextLabel(props.context));
 
@@ -591,6 +677,13 @@ function removeAttachment(url) {
 	attachments.value = attachments.value.filter((a) => a.file_url !== url);
 }
 
+// Same SPA onboarding route OnboardingGate.vue's own "Complete setup" button
+// pushes to (frontend/src/router/index.js "/onboarding"), reached here by a
+// full navigation since the wizard lives in the SPA, not this widget.
+function goOnboard() {
+	window.location.assign(ONBOARDING_URL);
+}
+
 // Hold-free toggle: click to start, click to stop. The transcript lands in the
 // composer rather than sending, so a misheard word can be fixed first.
 async function toggleVoice() {
@@ -641,6 +734,10 @@ async function toggleVoice() {
 }
 
 async function send() {
+	// Belt and braces: the composer is hidden whenever readiness is "gate" (see
+	// the template), but a stray call (e.g. Enter fired before that re-render)
+	// must not reach the backend for a workspace that was never onboarded.
+	if (readiness.value === "gate") return;
 	const text = draft.value.trim();
 	const atts = attachments.value.slice();
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;
@@ -842,6 +939,19 @@ onMounted(() => {
 		.catch(() => {
 			sttEnabled.value = false;
 		});
+	// Resolved once per mount, not on every open/keystroke - see the `readiness`
+	// declaration above for why that is still "once per Desk page load".
+	isReadyForChat()
+		.then((r) => {
+			readiness.value = classifyReadiness(r);
+			readinessNotice.value = readiness.value === "degraded" ? degradedMessage(r) : "";
+		})
+		.catch(() => {
+			// Fail OPEN, same as classifyReadiness(null): a flaky/unreachable check
+			// must never strand a real user behind the gate.
+			readiness.value = classifyReadiness(null);
+			readinessNotice.value = "";
+		});
 });
 
 onBeforeUnmount(() => {
@@ -878,6 +988,9 @@ defineExpose({ load, startNewChat, convId });
 	--jv-chip-2: #fbeeddff;
 	--jv-chip-3: #eae7fb;
 	--jv-danger: #c0392b;
+	--jv-warn: #b7791f;
+	--jv-warn-bg: #fdf3e2;
+	--jv-warn-bd: #f3e0bb;
 }
 .jvp-panel--dark {
 	--jv-surface: #1e1d23;
@@ -895,6 +1008,9 @@ defineExpose({ load, startNewChat, convId });
 	--jv-chip-2: #33291b;
 	--jv-chip-3: #2a2540;
 	--jv-danger: #ff8a80;
+	--jv-warn: #f0c265;
+	--jv-warn-bg: #332a18;
+	--jv-warn-bd: #4a3c22;
 }
 
 /* A mini chat window, not a full-height dock: left/top/width/height are set
@@ -1194,6 +1310,55 @@ defineExpose({ load, startNewChat, convId });
 	line-height: 1.4;
 }
 
+/* ---- onboarding nudge (readiness === "gate") ----
+   Same shell as .jvp-welcome (reuses .jvp-hero) since it replaces it - a
+   compact stand-in for OnboardingGate.vue's full-screen poster. */
+.jvp-nudge {
+	min-width: 0;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	padding: 20px 14px;
+}
+.jvp-nudge-h {
+	font-size: 17px;
+	font-weight: 700;
+	color: var(--jv-ink);
+	margin-top: 16px;
+	letter-spacing: -0.01em;
+}
+.jvp-nudge-s {
+	margin: 8px 0 0;
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--jv-ink-2);
+}
+.jvp-nudge-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 18px;
+	padding: 9px 16px;
+	border: none;
+	border-radius: 10px;
+	background: var(--jv-grad);
+	color: #fff;
+	font: inherit;
+	font-size: 13.5px;
+	font-weight: 600;
+	cursor: pointer;
+}
+.jvp-nudge-btn:hover {
+	opacity: 0.92;
+}
+.jvp-nudge-btn:focus-visible {
+	outline: 2px solid var(--jv-accent);
+	outline-offset: 2px;
+}
+
 /* ---- messages ---- */
 .jvp-msgs {
 	display: flex;
@@ -1396,6 +1561,30 @@ defineExpose({ load, startNewChat, convId });
 		transform: translateY(-5px);
 		opacity: 1;
 	}
+}
+
+/* ---- degraded notice (readiness === "degraded") ----
+   Amber, not the red .jv-danger tokens: this is a warning that a send MIGHT
+   fail, not a report that something already did. */
+.jvp-notice {
+	flex: none;
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	margin: 10px 15px 0;
+	padding: 9px 11px;
+	border: 1px solid var(--jv-warn-bd);
+	border-radius: 11px;
+	background: var(--jv-warn-bg);
+	color: var(--jv-warn);
+	font-size: 12.5px;
+	line-height: 1.5;
+}
+.jvp-notice svg {
+	width: 15px;
+	height: 15px;
+	flex: none;
+	margin-top: 1px;
 }
 
 /* ---- pending write confirmation ---- */

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -320,8 +320,15 @@
 			<!-- Hidden entirely in the gate state, not merely disabled: there is
 			     nothing to send to yet, and a live-but-disabled composer would
 			     imply chat almost works. The "degraded" state keeps this, on
-			     purpose - see the jvp-notice banner above. -->
-			<div v-if="readiness !== 'gate'" class="jvp-foot">
+			     purpose - see the jvp-notice banner above.
+			     Also hidden while the verdict is still unresolved. Rendering a
+			     live composer before the check returns let a user send into a
+			     workspace that turned out to be gated: the send succeeded, then
+			     the gate replaced the body and swallowed the message and any
+			     reply, with no error shown. Waiting costs nothing in practice -
+			     the panel mounts at Desk page load and is toggled with v-show, so
+			     the check has almost always resolved before it is first opened. -->
+			<div v-if="readinessResolved && readiness !== 'gate'" class="jvp-foot">
 				<!-- attached files, above the input -->
 				<div v-if="attachments.length" class="jvp-atts">
 					<span v-for="a in attachments" :key="a.file_url" class="jvp-att">
@@ -522,13 +529,20 @@ let recorder = null;
 let recChunks = [];
 let recStartedAt = 0;
 
-// Chat-readiness gate: "ready" | "gate" | "degraded" (panel_readiness.mjs).
-// Resolved ONCE in onMounted below and cached for the panel's lifetime - this
-// component is kept mounted and toggled with v-show (see the template comment
-// up top), so "once per mount" already means "once per Desk page load", not
-// once per open. There is deliberately no poll here: a workspace's onboarding
-// state does not change while a chat panel sits open.
-const readiness = ref("ready");
+// Chat-readiness gate: null until resolved, then "ready" | "gate" | "degraded"
+// (panel_readiness.mjs). Resolved ONCE in onMounted below and cached for the
+// panel's lifetime - this component is kept mounted and toggled with v-show
+// (see the template comment up top), so "once per mount" already means "once
+// per Desk page load", not once per open. There is deliberately no poll here: a
+// workspace's onboarding state does not change while a chat panel sits open.
+//
+// It starts null, NOT "ready". Defaulting to "ready" rendered a live composer
+// during the round-trip, so on a gated workspace a fast user could send a
+// message that the arriving verdict then hid along with its reply, silently.
+// Mirrors AppShell.vue's `gatedOnboarding = ref(null)` and its `shellReady`
+// hold for the same reason.
+const readiness = ref(null);
+const readinessResolved = computed(() => readiness.value !== null);
 const readinessNotice = ref("");
 // Only an admin who can actually reach the wizard gets the CTA button in the
 // gate state, mirroring OnboardingGate.vue's isSystemManager split. Read off
@@ -684,6 +698,26 @@ function goOnboard() {
 	window.location.assign(ONBOARDING_URL);
 }
 
+// The mic button lives in the footer, and the footer unmounts the moment the
+// readiness verdict comes back "gate". Without this, a recording started during
+// the round-trip loses its only stop control: MediaRecorder and the getUserMedia
+// stream keep running with the mic light on, and onstop never fires, so the
+// audio is lost too. Stop it from outside the template instead.
+function abortRecording() {
+	if (!recording.value) return;
+	try {
+		recorder?.stop();
+	} catch {
+		// Already stopped or torn down; the track cleanup below still matters.
+	}
+	recorder?.stream?.getTracks?.().forEach((t) => t.stop());
+	recording.value = false;
+}
+
+watch(readiness, (v) => {
+	if (v === "gate") abortRecording();
+});
+
 // Hold-free toggle: click to start, click to stop. The transcript lands in the
 // composer rather than sending, so a misheard word can be fixed first.
 async function toggleVoice() {
@@ -734,10 +768,12 @@ async function toggleVoice() {
 }
 
 async function send() {
-	// Belt and braces: the composer is hidden whenever readiness is "gate" (see
-	// the template), but a stray call (e.g. Enter fired before that re-render)
-	// must not reach the backend for a workspace that was never onboarded.
-	if (readiness.value === "gate") return;
+	// Belt and braces: the composer is hidden whenever readiness is "gate" or
+	// still unresolved (see the template), but a stray call (e.g. Enter fired
+	// before that re-render) must not reach the backend for a workspace that was
+	// never onboarded. Unresolved counts too: sending into a verdict that has not
+	// landed is exactly how a message got swallowed by the arriving gate.
+	if (readiness.value === null || readiness.value === "gate") return;
 	const text = draft.value.trim();
 	const atts = attachments.value.slice();
 	if ((!text && !atts.length) || sending.value || stream.value.live) return;
@@ -955,6 +991,9 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+	// A live recording outlives this component otherwise: the mic stays hot and
+	// the getUserMedia tracks are never released.
+	abortRecording();
 	unwatchTheme?.();
 	if (rtTimer) {
 		window.clearInterval(rtTimer);

--- a/jarvis/public/js/jarvis_chat/widget/config.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/config.mjs
@@ -11,6 +11,11 @@ export const FULL_CHAT_URL = "/jarvis/";
 export const conversationUrl = (id) =>
   id ? `/jarvis/c/${encodeURIComponent(id)}` : FULL_CHAT_URL;
 
+// The SPA's onboarding wizard route (frontend/src/router/index.js "/onboarding",
+// mounted under the "/jarvis" base). The panel's setup nudge sends an admin
+// here rather than duplicating the wizard in 400px.
+export const ONBOARDING_URL = "/jarvis/onboarding";
+
 // Below this viewport width a 400px docked panel is most of the screen, so the
 // FAB falls back to navigating to the SPA instead of opening in place.
 export const PANEL_MIN_VIEWPORT_PX = 640;

--- a/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_api.mjs
@@ -7,6 +7,7 @@
 
 const CHAT = "jarvis.chat.api.";
 const ACTIONS = "jarvis.chat.actions_api.";
+const ACCOUNT = "jarvis.account.";
 
 function call(method, args) {
   return frappe.call({ method, args: args || {} }).then((r) => r.message);
@@ -92,3 +93,7 @@ export const stopRun = (conversation, runId) =>
 // Resolves a write-confirmation gate raised by an `action:pending` frame.
 export const confirmTool = (token, conversation) =>
   call(ACTIONS + "confirm_tool", { token, conversation: conversation || "" });
+
+// Chat-readiness verdict ({ready, reason, detail, billing_notice}) - see
+// panel_readiness.mjs for how the panel classifies it into gate/degraded/ready.
+export const isReadyForChat = () => call(ACCOUNT + "is_ready_for_chat");

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -1,0 +1,50 @@
+// Chat-readiness classification for the floating widget panel.
+//
+// DUPLICATED from frontend/src/onboarding/readiness.js by necessity, not by
+// choice: this widget is plain Vue + .mjs served straight into Desk (see
+// jarvis_widget.bundle.js) and cannot import from frontend/src or use the "@/"
+// alias the SPA's Vite build resolves. Keep NOT_ONBOARDED_REASONS and the
+// fail-open contract below in sync with that file BY HAND. See its comments
+// for the full reasoning behind each reason's placement - repeated here only
+// to the extent this module needs it to classify a verdict.
+
+// Reasons meaning the workspace has NEVER completed onboarding at all - the
+// only case that should replace the whole panel with a setup nudge.
+// Deliberately excludes "llm_credentials": that reason ALSO fires when an
+// already-working workspace's LLM creds later expire or rotate, and hard
+// gating such a workspace out of its own chat is wrong. It falls through to
+// "degraded" instead, which keeps the chat usable and only warns.
+const NOT_ONBOARDED_REASONS = new Set([
+  "signup",
+  "selfhost_connection",
+  "llm_pool_provisioning",
+  "llm_provisioning",
+]);
+
+// Three-way verdict the panel renders around:
+//  - "ready"    chat works, render the panel as normal.
+//  - "gate"     never onboarded, replace the body with the setup nudge.
+//  - "degraded" onboarded once but not currently chat-ready (e.g. expired
+//               creds, a paused subscription); keep the composer, add a
+//               banner explaining a send may fail.
+//
+// `resp` is whatever jarvis.account.is_ready_for_chat returned. Fail OPEN to
+// "ready" on a missing/falsy response - a thrown or timed-out check must
+// never strand a real user behind a scary gate (mirrors readiness.js's own
+// checkReady(), which catches the backend call into {ready: true}).
+export function classifyReadiness(resp) {
+  if (!resp || resp.ready) return "ready";
+  return NOT_ONBOARDED_REASONS.has(resp.reason) ? "gate" : "degraded";
+}
+
+// Copy for the degraded banner. Prefers the backend's OWN explanation
+// (`detail`, e.g. admin's chat_readiness_reason for a stalled container or a
+// suspended subscription) over invented text - same precedent as
+// readiness.js's readinessDetailOf(). Most degraded reasons (llm_credentials
+// in particular) carry no `detail`, so those fall back to a generic sentence
+// rather than one guessed per reason code, which would drift from account.py.
+export function degradedMessage(resp) {
+  const detail = (resp && resp.detail) || "";
+  if (detail) return detail;
+  return "Jarvis isn't fully set up, so replies may fail. Ask your administrator to finish reconnecting it.";
+}

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -10,10 +10,24 @@
 
 // Reasons meaning the workspace has NEVER completed onboarding at all - the
 // only case that should replace the whole panel with a setup nudge.
+//
 // Deliberately excludes "llm_credentials": that reason ALSO fires when an
 // already-working workspace's LLM creds later expire or rotate, and hard
 // gating such a workspace out of its own chat is wrong. It falls through to
 // "degraded" instead, which keeps the chat usable and only warns.
+//
+// KNOWN LIMITATION, shared with the SPA rather than introduced here.
+// account.py returns "llm_credentials" for BOTH of those situations: creds that
+// expired (account.py:185) and a subscription/oauth tenant that never connected
+// at all, where llm_oauth_connected_at was never stamped (account.py:203). The
+// two are indistinguishable from this side, so a never-connected tenant is
+// under-gated: it gets the banner rather than the nudge. Gating on it instead
+// would trade that for the worse failure, ejecting working workspaces on a
+// routine credential rotation. Disambiguating needs a distinct reason code from
+// account.py, which is a backend change and deliberately out of scope here.
+// Whichever way it is fixed, fix frontend/src/onboarding/readiness.js in the
+// same change: divergence between these two files is exactly the bug this
+// module exists to close.
 const NOT_ONBOARDED_REASONS = new Set([
   "signup",
   "selfhost_connection",
@@ -37,14 +51,35 @@ export function classifyReadiness(resp) {
   return NOT_ONBOARDED_REASONS.has(resp.reason) ? "gate" : "degraded";
 }
 
-// Copy for the degraded banner. Prefers the backend's OWN explanation
-// (`detail`, e.g. admin's chat_readiness_reason for a stalled container or a
-// suspended subscription) over invented text - same precedent as
-// readiness.js's readinessDetailOf(). Most degraded reasons (llm_credentials
-// in particular) carry no `detail`, so those fall back to a generic sentence
-// rather than one guessed per reason code, which would drift from account.py.
+// Mirrors steps.js's SUSPENDED_FALLBACK verbatim. A lapsed subscription needs a
+// renewal call to action, not the generic "ask your administrator" line: there
+// is nothing an administrator can reconnect when the problem is billing.
+export const SUSPENDED_FALLBACK =
+  "Your subscription is no longer active. Renew to restore access to Jarvis.";
+
+const GENERIC_DEGRADED =
+  "Jarvis isn't fully set up, so replies may fail. Ask your administrator to finish reconnecting it.";
+
+// Copy for the degraded banner, structured to match steps.js's suspensionNotice
+// so the two surfaces cannot drift apart on the same verdict.
+//
+// Per reason, because a single "use detail if present" rule got this wrong:
+//   subscription_suspended  admin's sentence, else the RENEWAL line. account.py
+//                           populates `detail` for this reason as well as for
+//                           container_provisioning, so falling through to the
+//                           generic administrator line stranded a billing
+//                           problem behind advice that cannot fix it.
+//   container_provisioning  admin's sentence when it has one (this is the path
+//                           that carries the quota and cooldown wording), else
+//                           the generic line.
+//   anything else           the generic line. Do NOT print a raw `detail` for
+//                           an unrecognised reason: the reason set is owned by
+//                           account.py and a future addition would leak
+//                           whatever wording it happens to carry.
 export function degradedMessage(resp) {
+  const reason = (resp && resp.reason) || "";
   const detail = (resp && resp.detail) || "";
-  if (detail) return detail;
-  return "Jarvis isn't fully set up, so replies may fail. Ask your administrator to finish reconnecting it.";
+  if (reason === "subscription_suspended") return detail || SUSPENDED_FALLBACK;
+  if (reason === "container_provisioning") return detail || GENERIC_DEGRADED;
+  return GENERIC_DEGRADED;
 }

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
+import {
+  classifyReadiness,
+  degradedMessage,
+  SUSPENDED_FALLBACK,
+} from "./panel_readiness.mjs";
 
 test("classifyReadiness: ready is ready regardless of a leftover reason", () => {
   assert.equal(classifyReadiness({ ready: true, reason: null }), "ready");
@@ -67,5 +71,40 @@ test("degradedMessage: falls back to generic copy when there is no detail", () =
   assert.equal(
     degradedMessage({ ready: false, reason: "llm_credentials", detail: "" }),
     msg
+  );
+});
+
+// A lapsed subscription must not fall through to the generic "ask your
+// administrator" line: no administrator can reconnect their way out of a
+// billing problem. Mirrors steps.js's suspensionNotice.
+test("degradedMessage: a suspended subscription gets the renewal line, not the generic one", () => {
+  assert.equal(
+    degradedMessage({ ready: false, reason: "subscription_suspended" }),
+    SUSPENDED_FALLBACK
+  );
+  assert.match(SUSPENDED_FALLBACK, /Renew/);
+  // admin's own sentence still wins when it has one
+  assert.equal(
+    degradedMessage({
+      ready: false,
+      reason: "subscription_suspended",
+      detail: "Your plan ended on 1 August.",
+    }),
+    "Your plan ended on 1 August."
+  );
+});
+
+// The reason set belongs to account.py. Printing a raw detail for a reason this
+// module does not recognise would leak whatever wording a future backend change
+// happens to attach, into a banner written for a different situation.
+test("degradedMessage: never prints a raw detail for an unrecognised reason", () => {
+  const generic = degradedMessage({ ready: false, reason: "llm_credentials" });
+  assert.equal(
+    degradedMessage({
+      ready: false,
+      reason: "something_new",
+      detail: "internal: shard 4 unreachable",
+    }),
+    generic
   );
 });

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.test.mjs
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
+
+test("classifyReadiness: ready is ready regardless of a leftover reason", () => {
+  assert.equal(classifyReadiness({ ready: true, reason: null }), "ready");
+  assert.equal(classifyReadiness({ ready: true }), "ready");
+});
+
+test("classifyReadiness: never-onboarded reasons gate the whole panel", () => {
+  for (const reason of [
+    "signup",
+    "selfhost_connection",
+    "llm_pool_provisioning",
+    "llm_provisioning",
+  ]) {
+    assert.equal(classifyReadiness({ ready: false, reason }), "gate");
+  }
+});
+
+test("classifyReadiness: llm_credentials degrades, it does NOT gate", () => {
+  // This is the regression this module exists to prevent: llm_credentials
+  // also fires for an already-onboarded workspace whose creds later expire,
+  // so it must never trigger the full "finish setting up" nudge.
+  assert.equal(
+    classifyReadiness({ ready: false, reason: "llm_credentials" }),
+    "degraded"
+  );
+});
+
+test("classifyReadiness: an unrecognised not-ready reason degrades rather than gates", () => {
+  // container_provisioning / subscription_suspended and anything future or
+  // unknown fall here too - only the explicit never-onboarded set gates.
+  assert.equal(
+    classifyReadiness({ ready: false, reason: "container_provisioning" }),
+    "degraded"
+  );
+  assert.equal(
+    classifyReadiness({ ready: false, reason: "subscription_suspended" }),
+    "degraded"
+  );
+  assert.equal(
+    classifyReadiness({ ready: false, reason: "something_new" }),
+    "degraded"
+  );
+});
+
+test("classifyReadiness: fails OPEN on a missing/thrown response", () => {
+  assert.equal(classifyReadiness(null), "ready");
+  assert.equal(classifyReadiness(undefined), "ready");
+});
+
+test("degradedMessage: prefers the backend's own detail sentence", () => {
+  assert.equal(
+    degradedMessage({
+      ready: false,
+      reason: "container_provisioning",
+      detail: "Starting up.",
+    }),
+    "Starting up."
+  );
+});
+
+test("degradedMessage: falls back to generic copy when there is no detail", () => {
+  const msg = degradedMessage({ ready: false, reason: "llm_credentials" });
+  assert.ok(msg.length > 0);
+  assert.equal(
+    degradedMessage({ ready: false, reason: "llm_credentials", detail: "" }),
+    msg
+  );
+});


### PR DESCRIPTION
## The bug

The floating Desk chat rendered a fully working chat interface even when the workspace had never been set up, so a user got a composer that could not possibly deliver a reply. The full window SPA gates this correctly. The popup did not.

Reported from live testing, with the full window showing "Finish setting up Jarvis" while the popup beside it offered starter cards and a composer.

## It is a regression, and the obvious fix would not have worked

`645d231` ("fix(widget): show disconnected state + onboarding nudge when tenant not onboarded") added a gate to `Widget.vue` via an `isOnboarded()` helper in `jarvis_chat/api.js`. That helper no longer exists and the gate was never carried into the newer `Panel.vue`. The widget directory today contains zero readiness checks.

Restoring that gate verbatim would **not** have fixed the reported case. It keyed on `jarvis.account.is_onboarded`, which is true the moment signup writes an admin api_key. The reported workspace was exactly that state:

```
is_onboarded      -> {"onboarded": true}
is_ready_for_chat -> {"ready": false, "reason": "llm_credentials"}
```

Signup done, LLM step outstanding. The old gate would have shown the chat anyway.

## What this does

`Panel.vue` now resolves `is_ready_for_chat` once on mount and classifies it three ways, matching the semantics the SPA already uses:

| State | Meaning | Rendering |
|---|---|---|
| `gate` | never onboarded | replace the body with a setup nudge, hide the composer |
| `degraded` | onboarded once, not currently chat ready | keep the composer, show a notice |
| `ready` | chat works | unchanged |

### Why `llm_credentials` is degraded and not gated

This is the part most likely to be "helpfully" widened later, so it is worth stating plainly. `llm_credentials` also fires when an already working workspace's credentials expire or rotate. Hard gating on it would eject a functioning workspace from its own chat over a recoverable problem. That reasoning is documented at `frontend/src/onboarding/readiness.js:33` and the same `NOT_ONBOARDED_REASONS` set is mirrored here. Please do not add `llm_credentials` to it.

### Duplication, deliberately

The classification lives in a new `panel_readiness.mjs` rather than importing the SPA's. The widget is plain Vue plus `.mjs` served straight into Desk and cannot import from `frontend/src` or resolve the `@/` alias that Vite provides. The duplication is called out in the module header, and both copies must be kept in sync by hand.

### Fail open

A thrown or timed out readiness check renders as `ready`. A flaky backend must never strand a real user behind a gate. This mirrors `checkReady()` in the SPA, which catches its backend call into `{ready: true}` for the same reason.

## Verification

- Widget unit tests: `node --test "*.test.mjs"` in `jarvis/public/js/jarvis_chat/widget`, 82 passed, 0 failed. 75 pre-existing plus 7 new for `panel_readiness.mjs`, including one asserting `llm_credentials` yields `degraded` and not `gate`, and one asserting a thrown/missing response yields `ready`.
- Lint: `pre-commit run --all-files` (prettier 2.7.1, eslint) passes clean on the changed files.
- Local bench suite (`bench --site site.jarvis run-tests --app jarvis --coverage`): coverage 91 percent against the 85 percent floor, PASS. The same run also showed 47 test failures, all outside the areas this PR touches (macro merge, wiki graph concurrency, HRMS reads, comment tagging, chat stale scan, turn recovery, learning snapshots). Tracebacks point to local test data left over from prior runs (duplicate DB keys, a DB lock timing race in a concurrency test), not to this diff, which changes no Python at all. Per this repo's own guidance, local bench state is not authoritative, so this is reported for completeness rather than as a blocker.
- Hosted CI on this PR: lint, all 4 test shards, and coverage all passed.
