### PR TITLE
refactor(chat): extract Message + Composer as shared components (support UI, PR1/2)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,10 +22,13 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
+        "@vue/test-utils": "^2",
         "autoprefixer": "^10.4.19",
+        "jsdom": "^25",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.15",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^2"
       }
     },
     "../wiki-graph-core": {
@@ -42,7 +45,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -62,6 +64,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -130,6 +146,121 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -640,6 +771,53 @@
         "@swc/helpers": "^0.5.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -704,7 +882,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -718,7 +895,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -728,7 +904,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -736,6 +911,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2141,6 +2334,133 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
@@ -2259,6 +2579,27 @@
       "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vueuse/core": {
       "version": "10.11.1",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
@@ -2347,6 +2688,16 @@
         }
       }
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2357,6 +2708,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -2387,7 +2748,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -2419,7 +2779,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-hidden": {
@@ -2433,6 +2792,23 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.2",
@@ -2470,6 +2846,13 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
@@ -2535,6 +2918,16 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -2607,11 +3000,34 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2658,6 +3074,23 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2672,6 +3105,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2755,6 +3198,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -2769,6 +3225,17 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/core-js": {
       "version": "3.49.0",
@@ -2788,6 +3255,21 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-line-break": {
@@ -2811,6 +3293,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3317,6 +3820,20 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -3338,6 +3855,23 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defaults": {
@@ -3367,6 +3901,16 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3393,14 +3937,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dompurify": {
@@ -3412,6 +3954,28 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/echarts": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
@@ -3422,12 +3986,48 @@
         "zrender": "5.6.1"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.387",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
       "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/engine.io-client": {
       "version": "6.6.6",
@@ -3463,12 +4063,57 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -3553,6 +4198,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -3569,7 +4224,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3597,7 +4251,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3646,6 +4299,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3747,10 +4447,70 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3763,6 +4523,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/grid-layout-plus": {
@@ -3794,11 +4567,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3814,6 +4615,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-to-image": {
@@ -3834,6 +4648,34 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -3890,6 +4732,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/interactjs": {
       "version": "1.10.27",
       "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
@@ -3930,7 +4779,6 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -3949,6 +4797,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3981,6 +4839,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3993,21 +4858,113 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jspdf": {
       "version": "4.2.1",
@@ -4066,7 +5023,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4079,7 +5035,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkifyjs": {
@@ -4127,6 +5082,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -4141,6 +5103,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lucide-static": {
       "version": "0.545.0",
@@ -4169,11 +5138,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4224,7 +5202,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4238,13 +5215,35 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -4263,6 +5262,32 @@
       "license": "MIT",
       "bin": {
         "mini-svg-data-uri": "cli.js"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mlly": {
@@ -4304,7 +5329,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -4340,6 +5364,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4349,11 +5389,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4363,7 +5409,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4419,6 +5464,13 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -4441,24 +5493,86 @@
       ],
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -4489,7 +5603,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4499,7 +5612,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4564,7 +5676,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4582,7 +5693,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4608,7 +5718,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4651,7 +5760,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4677,7 +5785,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4704,7 +5811,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
@@ -4879,6 +5985,23 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -4899,7 +6022,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4952,7 +6074,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -5076,7 +6197,6 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5111,7 +6231,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5197,11 +6316,17 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5253,11 +6378,67 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -5311,6 +6492,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -5321,6 +6509,13 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5330,10 +6525,94 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5364,7 +6643,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -5387,7 +6665,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5409,7 +6686,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5428,11 +6704,17 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -5470,7 +6752,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5483,7 +6764,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5507,7 +6787,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -5517,7 +6796,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -5525,6 +6803,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -5551,6 +6836,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -5559,6 +6874,26 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5570,6 +6905,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-dedent": {
@@ -5585,7 +6946,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -5900,6 +7260,116 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
@@ -5920,6 +7390,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.8.tgz",
+      "integrity": "sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "4.6.4",
@@ -5942,6 +7419,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -5951,15 +7441,197 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wiki-graph-core": {
       "resolved": "../wiki-graph-core",
       "link": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -5981,6 +7653,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test:snap": "vitest run tests/support-extraction",
+    "test:snap:watch": "vitest tests/support-extraction"
   },
   "dependencies": {
     "@vueuse/core": "^10.4.1",
@@ -22,9 +24,12 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/test-utils": "^2",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^25",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.15",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^2"
   }
 }

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -258,7 +258,12 @@
 .jv-mon-kv .jv-ok { color: var(--green); }
 .jv-mon-kv .jv-warn { color: var(--amber); }
 
-/* Header close icon-button — quiet ghost hover (no colour inversion). */
+/* Header close icon-button — quiet ghost hover (no colour inversion).
+   This is the ONLY global `.jv-iconbtn`, and its hover is deliberately NOT the
+   invert used on the chat surface (see the copies scoped to views/ChatView.vue
+   and components/chat/Composer.vue, which carry !important and would beat this
+   rule if they were ever unscoped). Three copies is intentional: sync the two
+   chat ones with each other, leave this one alone. */
 .jv-iconbtn { width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; background: transparent; border: none; border-radius: 8px; cursor: pointer; color: var(--text-3); transition: background-color .15s ease, color .15s ease; }
 .jv-iconbtn:hover { background: var(--surface-2); color: var(--text); }
 

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -361,6 +361,14 @@ watch(() => props.modelValue, autoGrow, { flush: "post" });
 function onInputInternal(e) {
 	// v-model has already pushed the new value up; grow, then hand the host the
 	// raw event (chat parses @/ mentions off the caret here).
+	//
+	// DO NOT "optimise" this call away as redundant with the watcher above. Yes,
+	// a normal keystroke measures twice per input (here, then post-flush) — but
+	// during IME composition Vue's vModelText suppresses the modelValue update
+	// entirely, so the watcher does NOT fire and only this call keeps the box
+	// growing mid-compose (the pre-extraction inline `autoGrow()` did grow).
+	// A dedup flag can't fix that without special-casing the IME path, which is
+	// exactly the path that has no other grower.
 	autoGrow();
 	emit("input", e);
 }
@@ -491,7 +499,21 @@ defineExpose({ el: inputEl, focusInput });
    COPIED, not moved: `.jv-iconbtn` is also worn by chat's header buttons and
    by the mic/wiki/nudge buttons it slots back in here, which carry ChatView's
    scope id — so ChatView keeps its own copy of these rules. This copy styles
-   the default attach button above (the #left-toolbar fallback). */
+   the default attach button above (the #left-toolbar fallback).
+
+   MUST STAY IN SYNC — `.jv-iconbtn` lives in THREE places on purpose:
+     1. here (scoped to Composer — its default attach button)
+     2. `views/ChatView.vue` (scoped — header buttons + the mic/attach/wiki/nudge
+        buttons chat slots BACK into this component, which carry ChatView's
+        scope id, so these rules cannot reach them)
+     3. `assets/settings.css` — GLOBAL, and DELIBERATELY DIFFERENT: the settings
+        dialog wants a quiet ghost hover (--surface-2), not this invert. Do not
+        "unify" it with these two.
+   Hoisting 1+2 into a shared sheet was evaluated and rejected: without the
+   `[data-v-*]` attribute these rules go global, and their `!important` would
+   then beat settings.css's un-!important ghost hover on SettingsDialog's close
+   button — i.e. it would silently restyle the settings dialog. Change the hover
+   here and you MUST make the same edit in ChatView. */
 .jv-iconbtn:hover {
 	background: var(--text) !important;
 	color: var(--surface) !important;

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -1,0 +1,534 @@
+<!--
+  The message composer — presentational generic core only. All state and
+  business logic stay in the host (Task 4 of the PR1 extraction; see
+  docs/superpowers/plans/2026-07-24-support-ui-pr1-extraction.md).
+
+  Built in: the bordered box + auto-growing textarea, Enter/Shift+Enter,
+  attachment chips, the drag-drop overlay, the hidden file input + 📎 button,
+  the "Enter ↵"/"Stop" hint, Send/Stop, and the disclaimer line.
+
+  NOT built in (host-owned, injected via named slots so this component never
+  imports chat's dependency graph): the dictation mic, the @/ mention
+  dropdown, the wiki-ground toggle, the wiki nudge card, the paste hint.
+
+  **This component NEVER uploads.** File pick / drop / paste emit
+  `files-added(File[])` and the host decides upload timing — chat uploads
+  eagerly on attach (its `send()` posts the uploaded `{file_url}`), while the
+  standalone Support page (PR2) holds local Files and uploads on submit
+  (Helpdesk's `media.upload` needs an existing ticket and has no un-attach).
+  Attachment chips render purely from the `attachments` display-objects.
+-->
+<template>
+	<!-- Host content directly above the box, in flow (chat's wiki nudge card). -->
+	<slot name="above" />
+	<div
+		class="jv-composer"
+		@dragover.prevent
+		@dragenter.prevent="onDragEnter"
+		@dragleave.prevent="onDragLeave"
+		@drop.prevent="onDrop"
+		style="
+			position: relative;
+			border: 1.5px solid var(--text);
+			border-radius: 13px;
+			background: var(--surface);
+			box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+			padding: 5px 6px 6px 6px;
+			transition: border-color 0.12s, box-shadow 0.12s;
+		"
+	>
+		<div
+			v-if="dragActive"
+			style="
+				position: absolute;
+				inset: 0;
+				z-index: 40;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				background: var(--cta-bg);
+				border: 2px dashed var(--cta);
+				border-radius: 13px;
+				color: var(--cta);
+				font-size: 13px;
+				font-weight: 600;
+				pointer-events: none;
+			"
+		>
+			Drop image or file to attach
+		</div>
+		<!-- pending attachments: image thumbnails (Claude-style) + file chips.
+		     Purely a projection of the `attachments` prop — an entry with a
+		     `preview_url` is a thumbnail, one with `uploading` is the in-flight
+		     placeholder pill, anything else is a 📎 chip. -->
+		<div
+			v-if="attachments.length"
+			style="display: flex; flex-wrap: wrap; gap: 8px; padding: 6px 4px 2px"
+		>
+			<template v-for="(a, i) in attachments" :key="a.key ?? i">
+				<span
+					v-if="a.uploading"
+					style="font-size: 11.5px; color: var(--text-3); padding: 3px 6px"
+					>Uploading…</span
+				>
+				<span
+					v-else-if="a.preview_url"
+					:title="a.file_name"
+					style="position: relative; display: inline-block; line-height: 0"
+				>
+					<img
+						:src="a.preview_url"
+						alt=""
+						style="
+							width: 52px;
+							height: 52px;
+							object-fit: cover;
+							border-radius: 9px;
+							border: 1px solid var(--border);
+							display: block;
+						"
+					/>
+					<button
+						v-if="a.removable"
+						@click="emit('remove-attachment', i)"
+						title="Remove"
+						style="
+							position: absolute;
+							top: -7px;
+							right: -7px;
+							width: 18px;
+							height: 18px;
+							border-radius: 50%;
+							background: var(--text);
+							color: var(--surface);
+							border: none;
+							cursor: pointer;
+							font-size: 12px;
+							line-height: 1;
+							display: flex;
+							align-items: center;
+							justify-content: center;
+							padding: 0;
+						"
+					>
+						×
+					</button>
+				</span>
+				<span
+					v-else
+					style="
+						display: inline-flex;
+						align-items: center;
+						gap: 5px;
+						font-size: 11.5px;
+						padding: 3px 5px 3px 9px;
+						border-radius: 999px;
+						color: var(--text-2);
+						background: var(--surface-1);
+						border: 1px solid var(--border);
+					"
+					>📎 {{ a.file_name
+					}}<button
+						v-if="a.removable"
+						@click="emit('remove-attachment', i)"
+						style="
+							border: none;
+							background: transparent;
+							cursor: pointer;
+							font-size: 14px;
+							line-height: 1;
+							color: var(--text-3);
+						"
+					>
+						×
+					</button></span
+				>
+			</template>
+		</div>
+		<!-- Host popovers anchored to the box (chat's @/ mention dropdown, which
+		     is absolutely positioned) plus any in-flow notice that belongs
+		     directly above the textarea (chat's paste hint). Placed after the
+		     chips so an in-flow notice lands exactly where chat renders it. -->
+		<slot name="overlay" />
+		<!-- v-model (not :value + a manual emit) so Vue's own vModelText directive
+		     keeps handling IME composition: it suppresses the update mid-compose,
+		     which a hand-rolled binding would not. Its listener is registered
+		     before @input, so the host sees the raw event with the new value
+		     already committed — exactly the order chat had inline. -->
+		<textarea
+			ref="inputEl"
+			v-model="text"
+			@input="onInputInternal"
+			@keydown="onKeydownInternal"
+			@paste="onPasteInternal"
+			rows="1"
+			:placeholder="placeholder"
+			style="
+				width: 100%;
+				border: none;
+				outline: none;
+				resize: none;
+				font-family: inherit;
+				font-size: 14px;
+				line-height: 1.5;
+				color: var(--text);
+				background: transparent;
+				padding: 8px 8px 4px;
+			"
+			:style="{ maxHeight: maxHeight + 'px' }"
+		></textarea>
+		<input
+			ref="fileInputEl"
+			type="file"
+			multiple
+			style="display: none"
+			@change="onFilesPicked"
+		/>
+		<div style="display: flex; align-items: center; gap: 6px; padding: 2px 4px">
+			<!-- Host toolbar buttons on the left (chat: mic + 📎 + wiki-ground).
+			     `pickFiles` is handed down so a host that takes the slot over can
+			     still open this component's own hidden file input. The fallback is
+			     the plain attach button the generic composer ships with. -->
+			<slot name="left-toolbar" :pick-files="pickFiles">
+				<button
+					class="jv-iconbtn"
+					title="Attach file"
+					@click="pickFiles"
+					style="
+						width: 30px;
+						height: 30px;
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						background: transparent;
+						border: none;
+						border-radius: 7px;
+						cursor: pointer;
+						color: var(--text-3);
+					"
+				>
+					<svg
+						width="17"
+						height="17"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.7"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path
+							d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.19a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49"
+						/>
+					</svg>
+				</button>
+			</slot>
+			<span
+				style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px"
+				>{{ busy ? "Stop" : "Enter ↵" }}</span
+			>
+			<button
+				v-if="busy"
+				@click="emit('stop')"
+				title="Stop generating"
+				style="
+					width: 32px;
+					height: 32px;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					background: var(--cta);
+					border: none;
+					border-radius: 8px;
+					cursor: pointer;
+				"
+			>
+				<svg width="13" height="13" viewBox="0 0 24 24" fill="var(--cta-fg)">
+					<rect x="6" y="6" width="12" height="12" rx="2.5" />
+				</svg>
+			</button>
+			<button
+				v-else
+				class="jv-sendbtn"
+				:class="{ ready: sendable }"
+				@click="emit('submit')"
+				:disabled="!sendable"
+				:style="{
+					width: '32px',
+					height: '32px',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					background: sendable ? 'var(--cta)' : 'var(--surface-3)',
+					border: 'none',
+					borderRadius: '8px',
+					cursor: sendable ? 'pointer' : 'default',
+				}"
+			>
+				<svg
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					:stroke="sendable ? 'var(--cta-fg)' : 'var(--text-3)'"
+					stroke-width="2.1"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M12 19V5M5 12l7-7 7 7" />
+				</svg>
+			</button>
+		</div>
+	</div>
+	<div
+		v-if="disclaimer"
+		style="text-align: center; font-size: 10.5px; color: var(--text-3); margin-top: 8px"
+	>
+		{{ disclaimer }}
+	</div>
+	<slot name="footer" />
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue";
+
+const props = defineProps({
+	// The composed text. Use with v-model on the host.
+	modelValue: { type: String, default: "" },
+	// Display-objects ONLY — never File objects, never the host's upload
+	// records: { key, file_name, preview_url, removable, uploading }.
+	// `preview_url` set → image thumbnail; `uploading` → the in-flight pill.
+	attachments: { type: Array, default: () => [] },
+	// A turn is in flight: swaps Send for Stop and the hint for "Stop".
+	busy: { type: Boolean, default: false },
+	// Optional override for whether Send is armed. `null` (the default) derives
+	// it from text/attachments; chat passes its own (it also blocks on
+	// `sending` and a suspended subscription).
+	canSend: { type: Boolean, default: null },
+	placeholder: { type: String, default: "" },
+	// Fine print under the box. Empty string hides the line entirely.
+	disclaimer: { type: String, default: "" },
+	// Auto-grow ceiling, in px — past this the textarea scrolls.
+	maxHeight: { type: Number, default: 140 },
+});
+
+const emit = defineEmits([
+	"update:modelValue",
+	"submit",
+	"stop",
+	// (File[]) — picked, dropped or pasted. The HOST uploads; we never do.
+	"files-added",
+	// (index) — into the `attachments` array as passed in.
+	"remove-attachment",
+	// Raw DOM events, emitted BEFORE this component acts on them, so a host can
+	// preventDefault to take the interaction over (chat's mention navigation,
+	// prompt history and clipboard-image upload all do exactly that).
+	"input",
+	"keydown",
+	"paste",
+]);
+
+const inputEl = ref(null);
+const fileInputEl = ref(null);
+
+// Writable proxy so the textarea can use a real v-model (see the template note).
+const text = computed({
+	get: () => props.modelValue,
+	set: (v) => emit("update:modelValue", v),
+});
+
+const sendable = computed(() =>
+	props.canSend === null
+		? props.modelValue.trim().length > 0 || props.attachments.length > 0
+		: props.canSend
+);
+
+// ---- auto-grow ----
+function autoGrow() {
+	const el = inputEl.value;
+	if (!el) return;
+	el.style.height = "auto";
+	el.style.height = Math.min(el.scrollHeight, props.maxHeight) + "px";
+}
+// Programmatic changes (a restored draft, dictation, prompt-history recall, a
+// send that clears the box) only reach us as a new modelValue — flush:"post"
+// so the textarea's value is already in the DOM when we measure scrollHeight.
+// Typed input is grown synchronously in the handler below instead, so the box
+// never lags a frame behind the caret.
+watch(() => props.modelValue, autoGrow, { flush: "post" });
+
+// ---- textarea events: emit raw FIRST, then act (unless the host took over) ----
+function onInputInternal(e) {
+	// v-model has already pushed the new value up; grow, then hand the host the
+	// raw event (chat parses @/ mentions off the caret here).
+	autoGrow();
+	emit("input", e);
+}
+function onKeydownInternal(e) {
+	emit("keydown", e);
+	// The host claimed this key (chat: mention nav, prompt history, its own
+	// Enter-to-send) — never double-handle it.
+	if (e.defaultPrevented) return;
+	if (e.key === "Enter" && !e.shiftKey) {
+		e.preventDefault();
+		emit("submit");
+	}
+}
+function onPasteInternal(e) {
+	emit("paste", e);
+	if (e.defaultPrevented) return;
+	const cd = e.clipboardData;
+	if (!cd) return;
+	// Screenshots / "Copy image" land in .items; a copied image FILE populates
+	// .files. Check both, .files first. Images only: a pasted non-image file
+	// is left to the browser's normal paste handling.
+	const imgs = [];
+	for (const f of cd.files || []) {
+		if ((f.type || "").startsWith("image/")) imgs.push(f);
+	}
+	if (!imgs.length) {
+		for (const it of cd.items || []) {
+			if (it.kind === "file" && (it.type || "").startsWith("image/")) {
+				const f = it.getAsFile();
+				if (f) imgs.push(f);
+			}
+		}
+	}
+	if (!imgs.length) return;
+	e.preventDefault();
+	emit("files-added", imgs);
+}
+
+// ---- file input ----
+function pickFiles() {
+	fileInputEl.value?.click();
+}
+function onFilesPicked(e) {
+	const picked = Array.from(e.target.files || []);
+	// Reset so re-picking the same file still fires `change`.
+	e.target.value = "";
+	if (picked.length) emit("files-added", picked);
+}
+
+// ---- drag and drop ----
+// dragDepth guards against the flicker from dragenter/leave firing on children.
+const dragActive = ref(false);
+let _dragDepth = 0;
+function onDragEnter() {
+	_dragDepth++;
+	dragActive.value = true;
+}
+function onDragLeave() {
+	_dragDepth = Math.max(0, _dragDepth - 1);
+	if (!_dragDepth) dragActive.value = false;
+}
+function onDrop(e) {
+	_dragDepth = 0;
+	dragActive.value = false;
+	const dropped = Array.from((e.dataTransfer && e.dataTransfer.files) || []);
+	if (dropped.length) emit("files-added", dropped);
+}
+
+function focusInput() {
+	inputEl.value?.focus();
+}
+// `el` is the raw textarea: the host owns caret math (chat's mention insertion
+// and edit-and-resend both setSelectionRange on it).
+defineExpose({ el: inputEl, focusInput });
+</script>
+
+<style scoped>
+/* black focus highlight on the composer */
+.jv-composer:focus-within {
+	border-color: var(--text);
+	box-shadow: 0 0 0 3px rgba(23, 23, 23, 0.07);
+}
+/* The send button inverts to black/white on hover (depends on its base color,
+   so the white icon flips to the surface color). !important beats the inline
+   background. */
+/* Send button: springy lift + arrow nudge on hover, press-in on click, and a
+   one-shot pop when it becomes ready (text entered). */
+.jv-sendbtn {
+	transition: transform 0.16s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.14s ease;
+}
+.jv-sendbtn svg {
+	transition: transform 0.16s ease;
+}
+.jv-sendbtn:not(:disabled):hover {
+	transform: translateY(-2px) scale(1.07);
+}
+.jv-sendbtn:not(:disabled):hover svg {
+	transform: translateY(-2px);
+}
+.jv-sendbtn:not(:disabled):active {
+	transform: scale(0.9);
+}
+.jv-sendbtn.ready {
+	animation: jv-send-pop 0.3s ease;
+}
+/* Vue scopes @keyframes names, so the keyframe and the `animation:` that
+   references it MUST share one scoped block — it travels with .jv-sendbtn. */
+@keyframes jv-send-pop {
+	0% {
+		transform: scale(0.7);
+	}
+	55% {
+		transform: scale(1.15);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+.jv-sendbtn:hover:not(:disabled) {
+	background: var(--text) !important;
+}
+.jv-sendbtn:hover:not(:disabled) svg {
+	stroke: var(--surface) !important;
+}
+/* buttons invert to black/white on hover (theme-adaptive: black on light,
+   white on dark) — var(--text)/var(--surface) flip, with an svg-stroke
+   override so the icon stays visible on the inverted background.
+   COPIED, not moved: `.jv-iconbtn` is also worn by chat's header buttons and
+   by the mic/wiki/nudge buttons it slots back in here, which carry ChatView's
+   scope id — so ChatView keeps its own copy of these rules. This copy styles
+   the default attach button above (the #left-toolbar fallback). */
+.jv-iconbtn:hover {
+	background: var(--text) !important;
+	color: var(--surface) !important;
+}
+.jv-iconbtn:hover svg {
+	stroke: var(--surface) !important;
+}
+/* visible keyboard focus (UX #15) */
+.jv-sendbtn:focus-visible,
+.jv-iconbtn:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
+/* honor reduced-motion (UX #13) */
+@media (prefers-reduced-motion: reduce) {
+	.jv-sendbtn.ready {
+		animation: none;
+	}
+}
+/* Dark mode: a black hover is invisible on the dark surface and the invert
+   would flash a stark white button, so neutral buttons get a subtle elevated
+   grey hover and primaries keep their colour (just brighter). */
+.jv-dark .jv-iconbtn:hover {
+	background: var(--surface-3) !important;
+	color: var(--text) !important;
+	border-color: var(--border-2) !important;
+}
+.jv-dark .jv-iconbtn:hover svg {
+	stroke: var(--text) !important;
+}
+.jv-dark .jv-sendbtn:hover:not(:disabled) {
+	background: var(--cta) !important;
+	color: var(--cta-fg) !important;
+	border-color: var(--cta) !important;
+	filter: brightness(1.18);
+}
+.jv-dark .jv-sendbtn:hover:not(:disabled) svg {
+	stroke: var(--cta-fg) !important;
+}
+</style>

--- a/frontend/src/components/chat/Message.vue
+++ b/frontend/src/components/chat/Message.vue
@@ -268,10 +268,9 @@ const hasBelowBody = computed(() => !!slots["below-body"]);
 </script>
 
 <style scoped>
-/* per-message Copy/Edit bar — revealed on hover. Shared with variant="row"
-   (Task 3), which reuses this exact rule set once the assistant row moves
-   in; ChatView.vue keeps its own copy until that row is extracted, since
-   the not-yet-moved assistant message still needs it there too. */
+/* per-message Copy/Edit bar — revealed on hover. Shared by BOTH variants:
+   the assistant row moved in too, and ChatView's own copies of these rules
+   were deleted with it, so this is now the single definition. */
 .jv-msgbar {
 	display: flex;
 	align-items: center;
@@ -679,6 +678,13 @@ const hasBelowBody = computed(() => !!slots["below-body"]);
    pipeline, so they have none of the jv-md-* classes. Tailwind's preflight
    strips element defaults (list bullets, link underline, table borders), so
    restore them at the element level here. */
+/* Mirrors the .jv-md base rule deliberately: email HTML carries long unbroken
+   strings (tracking URLs, order ids) that would otherwise push the row wide. */
+.jv-md-body.jv-html {
+	min-width: 0;
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
 .jv-md-body.jv-html :deep(p) {
 	margin: 0 0 10px;
 }
@@ -695,7 +701,11 @@ const hasBelowBody = computed(() => !!slots["below-body"]);
 	color: var(--link);
 	text-decoration: underline;
 }
+/* display:block is load-bearing, not cosmetic: overflow does not scroll a
+   display:table box, so without it a wide email table blows out the row
+   instead of scrolling inside it. Same reason the .jv-md twin carries it. */
 .jv-md-body.jv-html :deep(table) {
+	display: block;
 	max-width: 100%;
 	overflow-x: auto;
 	border-collapse: collapse;

--- a/frontend/src/components/chat/Message.vue
+++ b/frontend/src/components/chat/Message.vue
@@ -138,14 +138,94 @@
 		</div>
 	</template>
 	<template v-else>
-		<!-- variant="row" (assistant / support-agent): implemented in Task 3.
-		     Interface (avatar/above-body/below-body slots, html, bodyClass,
-		     sender, role) is already final above; only the template is
-		     pending. -->
+		<div class="jv-amsg" style="display: flex; gap: 12px">
+			<slot name="avatar" />
+			<div style="flex: 1; min-width: 0">
+				<!-- support-agent identity line: name + role + time. Chat's
+				     assistant passes no `sender`, so this never renders there. -->
+				<div v-if="sender" class="jv-msg-who">
+					<b class="jv-msg-name">{{ sender }}</b>
+					<span v-if="role" class="jv-msg-role">{{ role }}</span>
+					<span v-if="timestamp" class="jv-msg-when">{{ timestamp }}</span>
+				</div>
+				<slot name="above-body" />
+				<!-- v-html body: markdown (chat, bodyClass="jv-md") or bare
+				     Helpdesk HTML (support, bodyClass="jv-html"). Both style
+				     blocks live in this component's scoped <style> and use
+				     :deep() because v-html children carry no scope id. The base
+				     font/line/color match chat's assistant body exactly. -->
+				<div
+					class="jv-md-body"
+					:class="bodyClass"
+					style="font-size: 14px; line-height: 1.6; color: var(--text)"
+					v-html="html"
+				></div>
+				<slot name="below-body" />
+				<!-- Built-in trailer (attachments + Copy bar) for consumers that
+				     do NOT take over the post-body region via #below-body — i.e.
+				     the standalone Support page (PR2). Chat provides #below-body
+				     (its canvas loop + metabar live there, byte-identical), so
+				     this stays hidden for chat and never double-renders. -->
+				<template v-if="!hasBelowBody">
+					<template v-for="cv in attachments || []" :key="cv.name">
+						<button
+							v-if="cv.type === 'image' && cv.file_url"
+							class="jv-img-artifact"
+							@click="emit('open-attachment', cv)"
+							:title="'Open ' + cv.title"
+						>
+							<img :src="cv.file_url" :alt="cv.title" loading="lazy" />
+						</button>
+					</template>
+					<div v-if="copyable" class="jv-msgbar">
+						<span v-if="timestamp" class="jv-msgtime" :title="timestampFull">{{
+							timestamp
+						}}</span>
+						<button
+							class="jv-msgbtn"
+							@click="emit('copy')"
+							:title="copied ? 'Copied' : 'Copy'"
+						>
+							<svg
+								v-if="copied"
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="var(--green)"
+								stroke-width="2.2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M20 6 9 17l-5-5" />
+							</svg>
+							<svg
+								v-else
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.8"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<rect x="9" y="9" width="13" height="13" rx="2" />
+								<path
+									d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+								/>
+							</svg>
+						</button>
+					</div>
+				</template>
+			</div>
+		</div>
 	</template>
 </template>
 
 <script setup>
+import { computed, useSlots } from "vue";
+
 defineProps({
 	// 'bubble' (right-aligned chat/support-customer message) | 'row'
 	// (left-aligned assistant/support-agent message with identity + body).
@@ -179,6 +259,12 @@ defineProps({
 });
 
 const emit = defineEmits(["edit", "copy", "retry", "open-attachment"]);
+
+// When a consumer supplies #below-body it OWNS the whole post-body region
+// (chat does — its activity/cards/metabar live there, byte-identical), so the
+// built-in attachments + Copy trailer must yield to avoid double-rendering.
+const slots = useSlots();
+const hasBelowBody = computed(() => !!slots["below-body"]);
 </script>
 
 <style scoped>
@@ -262,5 +348,374 @@ const emit = defineEmits(["edit", "copy", "retry", "open-attachment"]);
 	width: 100%;
 	max-height: 320px;
 	object-fit: cover;
+}
+
+/* ===== variant="row" identity line (support-agent name + role + time) ===== */
+/* Chat's assistant renders no identity line (passes no `sender`). */
+.jv-msg-who {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+.jv-msg-name {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text);
+}
+.jv-msg-role {
+	font-size: 11.5px;
+	color: var(--text-2);
+}
+.jv-msg-when {
+	font-size: 11px;
+	color: var(--text-3);
+}
+
+/* ===== variant="row" chrome: hover Copy bar + image artifacts ===== */
+/* These style BOTH this component's own row markup AND chat's slotted
+   #below-body content (its metabar Copy bar + canvas thumbnails), which carry
+   the PARENT's scope id — so :deep() under the row wrapper is mandatory (a
+   plain scoped rule would stamp data-v-<message> and miss the parent-scoped
+   nodes). The originals were deleted from ChatView.vue; this is their only
+   home now. The bubble variant keeps its own plain copies above. */
+.jv-amsg :deep(.jv-msgbar) {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+	margin-top: 0;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+.jv-amsg:hover :deep(.jv-msgbar) {
+	opacity: 1;
+}
+.jv-amsg :deep(.jv-msgtime) {
+	font-size: 11.5px;
+	color: var(--text-3);
+	padding: 0 3px;
+	cursor: default;
+	user-select: none;
+}
+.jv-amsg :deep(.jv-msgbtn) {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border: none;
+	background: transparent;
+	border-radius: 6px;
+	cursor: pointer;
+	color: var(--text-3);
+}
+.jv-amsg :deep(.jv-msgbtn:hover) {
+	background: var(--surface-2);
+	color: var(--text);
+}
+.jv-amsg :deep(.jv-msgbtn:focus-visible) {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
+/* touch devices can't hover, so always show the Copy bar */
+@media (hover: none) {
+	.jv-amsg :deep(.jv-msgbar) {
+		opacity: 1 !important;
+	}
+}
+.jv-amsg :deep(.jv-img-artifact) {
+	display: block;
+	position: relative;
+	margin-top: 12px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--surface-1);
+	cursor: zoom-in;
+	overflow: hidden;
+	max-width: 380px;
+	line-height: 0;
+}
+.jv-amsg :deep(.jv-img-artifact:hover) {
+	border-color: var(--border-2);
+}
+.jv-amsg :deep(.jv-img-artifact img) {
+	display: block;
+	width: 100%;
+	max-height: 320px;
+	object-fit: cover;
+}
+.jv-amsg :deep(.jv-img-artifact-cap) {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 7px 10px;
+	font-family: inherit;
+	font-size: 11.5px;
+	line-height: 1.3;
+	color: var(--text-3);
+	background: var(--surface);
+	border-top: 1px solid var(--border);
+}
+
+/* ===== variant="row" body: markdown (bodyClass="jv-md") ===== */
+/* Moved verbatim from ChatView.vue's scoped <style> (the assistant markdown
+   body), rewriting the prefix `.jv-md` → `.jv-md-body.jv-md` so it applies
+   only to a markdown body. The body is v-html, so its children carry no scope
+   id → :deep() is mandatory (a plain scoped selector would match nothing).
+   Narrow-window resilience: min-width:0 lets the flex child shrink; wide
+   content (tables, code) scrolls INSIDE its own box. */
+.jv-md-body.jv-md {
+	min-width: 0;
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
+.jv-md-body.jv-md :deep(table) {
+	display: block;
+	max-width: 100%;
+	overflow-x: auto;
+	border-collapse: collapse;
+}
+.jv-md-body.jv-md :deep(pre) {
+	max-width: 100%;
+	overflow-x: auto;
+}
+.jv-md-body.jv-md :deep(img) {
+	max-width: 100%;
+	height: auto;
+}
+.jv-md-body.jv-md :deep(.jv-mermaid) {
+	position: relative;
+	margin: 8px 0 12px;
+	text-align: center;
+	overflow-x: auto;
+}
+.jv-md-body.jv-md :deep(.jv-mermaid svg) {
+	max-width: 100%;
+	height: auto;
+}
+/* skeleton shimmer while a chart hasn't rendered to SVG yet (no data-rendered) —
+   hides the raw mermaid source so the user never sees the markup flash. */
+.jv-md-body.jv-md :deep(.jv-mermaid:not([data-rendered])) {
+	min-height: 196px;
+	color: transparent !important;
+	user-select: none;
+	overflow: hidden;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--surface-1);
+}
+.jv-md-body.jv-md :deep(.jv-mermaid:not([data-rendered])) * {
+	color: transparent !important;
+}
+.jv-md-body.jv-md :deep(.jv-mermaid:not([data-rendered]))::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(100deg, transparent 20%, var(--surface-2) 50%, transparent 80%);
+	background-size: 220% 100%;
+	animation: jv-shimmer 1.25s ease-in-out infinite;
+}
+/* jv-shimmer keyframe moved here with its only consumer (the mermaid skeleton
+   ::after above) — Vue scopes @keyframes names, so the keyframe and the
+   `animation:` that references it MUST share one scoped block. */
+@keyframes jv-shimmer {
+	0% {
+		background-position: 180% 0;
+	}
+	100% {
+		background-position: -180% 0;
+	}
+}
+.jv-md-body.jv-md :deep(.jv-chart-dl) {
+	position: absolute;
+	top: 6px;
+	right: 6px;
+	width: 26px;
+	height: 26px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	background: var(--surface);
+	color: var(--text-3);
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity 0.12s, color 0.12s, background 0.12s;
+}
+.jv-md-body.jv-md :deep(.jv-mermaid:hover .jv-chart-dl) {
+	opacity: 1;
+}
+.jv-md-body.jv-md :deep(.jv-chart-dl:hover) {
+	color: var(--text);
+	background: var(--surface-1);
+	border-color: var(--border-2);
+}
+.jv-md-body.jv-md :deep(.jv-md-pre) {
+	margin: 6px 0 12px;
+	padding: 12px 14px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	overflow-x: auto;
+}
+.jv-md-body.jv-md :deep(.jv-md-pre code) {
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 12px;
+	color: var(--text);
+	white-space: pre;
+}
+/* markdown content → the imported design's table look */
+.jv-md-body.jv-md :deep(.jv-md-p) {
+	margin: 0 0 10px;
+}
+.jv-md-body.jv-md :deep(.jv-md-p:last-child) {
+	margin-bottom: 0;
+}
+.jv-md-body.jv-md :deep(.jv-md-h) {
+	margin: 14px 0 6px;
+	font-weight: 600;
+	color: var(--text);
+}
+.jv-md-body.jv-md :deep(h3.jv-md-h) {
+	font-size: 15px;
+}
+.jv-md-body.jv-md :deep(h4.jv-md-h) {
+	font-size: 14px;
+}
+.jv-md-body.jv-md :deep(h5.jv-md-h),
+.jv-md-body.jv-md :deep(h6.jv-md-h) {
+	font-size: 13px;
+}
+.jv-md-body.jv-md :deep(.jv-md-h:first-child) {
+	margin-top: 0;
+}
+.jv-md-body.jv-md :deep(.jv-md-list) {
+	margin: 0 0 10px;
+	padding-left: 20px;
+}
+.jv-md-body.jv-md :deep(.jv-md-list li) {
+	margin: 2px 0;
+}
+.jv-md-body.jv-md :deep(.jv-md-code) {
+	background: var(--surface-2);
+	padding: 1px 5px;
+	border-radius: 4px;
+	font-size: 12px;
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	overflow-wrap: anywhere;
+}
+.jv-md-body.jv-md :deep(.jv-md-list .jv-md-list) {
+	margin: 2px 0;
+}
+.jv-md-body.jv-md :deep(.jv-md-quote) {
+	margin: 0 0 10px;
+	padding: 2px 0 2px 12px;
+	border-left: 3px solid var(--border-2);
+	color: var(--text-2);
+}
+.jv-md-body.jv-md :deep(del) {
+	opacity: 0.65;
+}
+.jv-md-body.jv-md :deep(.jv-md-link) {
+	color: var(--cta);
+	text-decoration: none;
+	font-weight: 500;
+}
+/* Auto-linked document IDs → open the record in ERPNext Desk. Dashed underline
+   marks them as record links, distinct from plain markdown links. */
+.jv-md-body.jv-md :deep(.jv-doclink) {
+	color: var(--cta);
+	text-decoration: none;
+	font-weight: 550;
+	border-bottom: 1px dashed var(--cta);
+	cursor: pointer;
+	transition: background 0.12s;
+}
+.jv-md-body.jv-md :deep(.jv-doclink:hover) {
+	border-bottom-style: solid;
+	background: var(--cta-bg);
+	border-radius: 3px;
+}
+.jv-md-body.jv-md :deep(.jv-md-tablewrap) {
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	overflow: hidden;
+	margin: 4px 0 10px;
+}
+.jv-md-body.jv-md :deep(.jv-md-table) {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 12.5px;
+}
+.jv-md-body.jv-md :deep(.jv-md-table th) {
+	padding: 8px 13px;
+	font-weight: 550;
+	color: var(--text-3);
+	background: var(--surface-1);
+	border-bottom: 1px solid var(--border);
+}
+.jv-md-body.jv-md :deep(.jv-md-table td) {
+	padding: 9px 13px;
+	border-bottom: 1px solid var(--border);
+	color: var(--text);
+	font-variant-numeric: tabular-nums;
+}
+.jv-md-body.jv-md :deep(.jv-md-table tr:last-child td) {
+	border-bottom: 0;
+}
+/* honor reduced-motion on the markdown body (moved from ChatView's shared
+   reduced-motion block). */
+@media (prefers-reduced-motion: reduce) {
+	.jv-md-body.jv-md :deep(.jv-mermaid:not([data-rendered]))::after {
+		animation: none;
+	}
+}
+
+/* ===== variant="row" body: bare Helpdesk HTML (bodyClass="jv-html") ===== */
+/* Support ticket bodies are raw email HTML, NOT run through the markdown
+   pipeline, so they have none of the jv-md-* classes. Tailwind's preflight
+   strips element defaults (list bullets, link underline, table borders), so
+   restore them at the element level here. */
+.jv-md-body.jv-html :deep(p) {
+	margin: 0 0 10px;
+}
+.jv-md-body.jv-html :deep(ul),
+.jv-md-body.jv-html :deep(ol) {
+	margin: 0 0 10px;
+	padding-left: 22px;
+	list-style: revert;
+}
+.jv-md-body.jv-html :deep(li) {
+	margin: 2px 0;
+}
+.jv-md-body.jv-html :deep(a) {
+	color: var(--link);
+	text-decoration: underline;
+}
+.jv-md-body.jv-html :deep(table) {
+	max-width: 100%;
+	overflow-x: auto;
+	border-collapse: collapse;
+}
+.jv-md-body.jv-html :deep(th),
+.jv-md-body.jv-html :deep(td) {
+	padding: 8px 12px;
+	border: 1px solid var(--border);
+}
+.jv-md-body.jv-html :deep(blockquote) {
+	margin: 0 0 10px;
+	padding: 2px 0 2px 12px;
+	border-left: 3px solid var(--border-2);
+	color: var(--text-2);
+}
+.jv-md-body.jv-html :deep(img) {
+	max-width: 100%;
+	height: auto;
+}
+.jv-md-body.jv-html :deep(pre) {
+	overflow: auto;
 }
 </style>

--- a/frontend/src/components/chat/Message.vue
+++ b/frontend/src/components/chat/Message.vue
@@ -1,0 +1,266 @@
+<!--
+  A single chat/thread message, presentational only — all state and business
+  logic (which message is "copied", failed-send retry, edit-and-resend, the
+  markdown/HTML renderer) live in the parent. Two variants:
+    - "bubble": right-aligned chat user message (implemented here, Task 2 of
+      the PR1 extraction — see docs/superpowers/plans/2026-07-24-support-ui-
+      pr1-extraction.md).
+    - "row": left-aligned assistant/support-agent message with an identity
+      line + markdown/HTML body (Task 3; stubbed here so the props/emits
+      interface is final and Task 3 only has to fill in the template).
+  Shared with the standalone Support page (PR2): a support customer message
+  is also variant="bubble"; a support agent reply is variant="row" with a
+  round human avatar via the #avatar slot (vs. chat's JarvisMark).
+-->
+<template>
+	<template v-if="variant === 'bubble'">
+		<div class="jv-umsg" style="display: flex; flex-direction: column; align-items: flex-end">
+			<div
+				v-if="text"
+				class="jv-ububble"
+				style="
+					max-width: 78%;
+					min-width: 0;
+					background: var(--surface-2);
+					border: 1px solid var(--border);
+					border-radius: 14px 14px 4px 14px;
+					padding: 10px 14px;
+					font-size: 14px;
+					line-height: 1.5;
+					color: var(--text);
+					white-space: pre-wrap;
+					overflow-wrap: anywhere;
+				"
+			>
+				{{ text }}
+			</div>
+			<div
+				v-if="failed"
+				style="
+					display: flex;
+					align-items: center;
+					gap: 8px;
+					margin-top: 4px;
+					font-size: 11.5px;
+					color: var(--red);
+				"
+			>
+				<span>Not sent</span>
+				<button
+					@click="emit('retry')"
+					style="
+						background: none;
+						border: none;
+						color: var(--link);
+						font: inherit;
+						cursor: pointer;
+						padding: 0;
+						text-decoration: underline;
+					"
+				>
+					Retry
+				</button>
+			</div>
+			<!-- attached images → same clickable thumbnail + preview as generated ones -->
+			<template v-for="cv in attachments || []" :key="cv.name">
+				<button
+					v-if="cv.type === 'image' && cv.file_url"
+					class="jv-img-artifact"
+					@click="emit('open-attachment', cv)"
+					:title="'Open ' + cv.title"
+					style="margin-top: 8px; cursor: zoom-in"
+				>
+					<img :src="cv.file_url" :alt="cv.title" loading="lazy" />
+				</button>
+			</template>
+			<div class="jv-msgbar">
+				<!-- sent-time: revealed with the bar on hover; its own hover
+				     (native title) gives the full day-date-month-year-time.
+				     Order: time → edit → copy (edit before copy). -->
+				<span v-if="timestamp" class="jv-msgtime" :title="timestampFull">{{
+					timestamp
+				}}</span>
+				<button
+					v-if="editable"
+					class="jv-msgbtn"
+					@click="emit('edit')"
+					title="Edit & resend"
+				>
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.8"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+						<path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+					</svg>
+				</button>
+				<button
+					v-if="copyable"
+					class="jv-msgbtn"
+					@click="emit('copy')"
+					:title="copied ? 'Copied' : 'Copy'"
+				>
+					<svg
+						v-if="copied"
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="var(--green)"
+						stroke-width="2.2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M20 6 9 17l-5-5" />
+					</svg>
+					<svg
+						v-else
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.8"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<rect x="9" y="9" width="13" height="13" rx="2" />
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+					</svg>
+				</button>
+			</div>
+		</div>
+	</template>
+	<template v-else>
+		<!-- variant="row" (assistant / support-agent): implemented in Task 3.
+		     Interface (avatar/above-body/below-body slots, html, bodyClass,
+		     sender, role) is already final above; only the template is
+		     pending. -->
+	</template>
+</template>
+
+<script setup>
+defineProps({
+	// 'bubble' (right-aligned chat/support-customer message) | 'row'
+	// (left-aligned assistant/support-agent message with identity + body).
+	variant: { type: String, default: "bubble" },
+	// Pre-rendered, sanitized HTML body for variant="row". Chat passes
+	// `render()` + linkify output; support passes DOMPurify'd Helpdesk
+	// Communication HTML (with the /files/ → proxy rewrite already applied).
+	html: { type: String, default: "" },
+	// Which body-style block `html` gets: 'jv-md' (markdown, chat) or
+	// 'jv-html' (bare element HTML, support tickets). variant="row" only.
+	bodyClass: { type: String, default: "jv-md" },
+	// Plain bubble text. variant="bubble" only.
+	text: { type: String, default: "" },
+	// Canvas/attachment records: { name, type, title, file_url, ... }.
+	attachments: { type: Array, default: () => [] },
+	// Identity line for variant="row" — sender name + role (support agent).
+	sender: { type: String, default: "" },
+	role: { type: String, default: "" },
+	// Rendered short time (hover bar) and full date/time (native title).
+	timestamp: { type: String, default: "" },
+	timestampFull: { type: String, default: "" },
+	// Show the Edit-and-resend button (chat user bubbles only).
+	editable: { type: Boolean, default: false },
+	// Show the Copy button.
+	copyable: { type: Boolean, default: true },
+	// The just-copied tick state (parent owns the "which message" bookkeeping).
+	copied: { type: Boolean, default: false },
+	// A failed-to-send user message: shows "Not sent" + Retry instead of the
+	// hover bar.
+	failed: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["edit", "copy", "retry", "open-attachment"]);
+</script>
+
+<style scoped>
+/* per-message Copy/Edit bar — revealed on hover. Shared with variant="row"
+   (Task 3), which reuses this exact rule set once the assistant row moves
+   in; ChatView.vue keeps its own copy until that row is extracted, since
+   the not-yet-moved assistant message still needs it there too. */
+.jv-msgbar {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+	margin-top: 0;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+.jv-umsg:hover .jv-msgbar {
+	opacity: 1;
+}
+.jv-msgtime {
+	font-size: 11.5px;
+	color: var(--text-3);
+	padding: 0 3px;
+	cursor: default;
+	user-select: none;
+}
+.jv-msgbtn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border: none;
+	background: transparent;
+	border-radius: 6px;
+	cursor: pointer;
+	color: var(--text-3);
+}
+.jv-msgbtn:hover {
+	background: var(--surface-2);
+	color: var(--text);
+}
+.jv-msgbtn:focus-visible {
+	outline: 2px solid var(--cta);
+	outline-offset: 2px;
+}
+/* mobile layout (UX #12): inline styles win over class rules, so this
+   overrides with !important, same as ChatView's other mobile overrides. */
+@media (max-width: 640px) {
+	.jv-ububble {
+		max-width: 92% !important;
+	}
+}
+/* touch devices can't hover, so always show per-message actions/timestamps */
+@media (hover: none) {
+	.jv-msgbar {
+		opacity: 1 !important;
+	}
+}
+/* artifact card (in the message) — generated/attached-image thumbnail.
+   Shared with the not-yet-extracted assistant canvas loop in ChatView.vue
+   (which also renders a caption span there), so only the rules this
+   variant="bubble" markup uses (no caption) are duplicated here. */
+.jv-img-artifact {
+	display: block;
+	position: relative;
+	margin-top: 12px;
+	padding: 0;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--surface-1);
+	cursor: zoom-in;
+	overflow: hidden;
+	max-width: 380px;
+	line-height: 0;
+}
+.jv-img-artifact:hover {
+	border-color: var(--border-2);
+}
+.jv-img-artifact img {
+	display: block;
+	width: 100%;
+	max-height: 320px;
+	object-fit: cover;
+}
+</style>

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -19,6 +19,18 @@
 	--brand-grad: linear-gradient(135deg, var(--brand-1), var(--brand-2));
 }
 
+/* Native form controls (select dropdowns, date/time pickers, scrollbars)
+   follow the app theme instead of the OS default — without this, a dark app
+   pops white select menus and calendar popups. Global (not scoped to
+   ChatView) because `.jv-root` is also the palette-vars root for the
+   settings dialog, onboarding, and (PR2) the standalone Support page. */
+.jv-root {
+	color-scheme: light;
+}
+.jv-root.jv-dark {
+	color-scheme: dark;
+}
+
 * {
 	box-sizing: border-box;
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2044,390 +2044,263 @@
 					</button>
 				</transition>
 				<div style="max-width: 1280px; margin: 0 auto">
-					<!-- wiki nudge: "anything worth remembering?" card (realtime wiki:nudge
-					     event, §voice/wiki). Own block ABOVE the composer so it never
-					     shifts the input while a reply is streaming. -->
-					<div v-if="nudge && nudge.conversationId === currentId" class="jv-nudge">
-						<div class="jv-nudge-head">
-							<div class="jv-nudge-q">
-								Anything worth remembering about <b>{{ nudgeLabels }}</b
-								>?
-							</div>
-							<button
-								class="jv-nudge-x"
-								title="Dismiss"
-								aria-label="Dismiss"
-								@click="dismissNudge"
+					<Composer
+						ref="composerRef"
+						v-model="input"
+						:attachments="composerAttachments"
+						:busy="busy"
+						:canSend="canSend"
+						:placeholder="`Ask ${agentName}…   @ to mention a user, / for a doctype or tool`"
+						:disclaimer="`${agentName} can make mistakes. Verify important actions before submitting to ERPNext.`"
+						@submit="send()"
+						@stop="stopRun"
+						@input="onInput"
+						@keydown="onKey"
+						@paste="onPaste"
+						@files-added="uploadFiles"
+						@remove-attachment="removeFile"
+					>
+						<template #above>
+							<!-- wiki nudge: "anything worth remembering?" card (realtime wiki:nudge
+							     event, §voice/wiki). Own block ABOVE the composer so it never
+							     shifts the input while a reply is streaming. -->
+							<div
+								v-if="nudge && nudge.conversationId === currentId"
+								class="jv-nudge"
 							>
-								<svg
-									width="13"
-									height="13"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<path d="M18 6 6 18M6 6l12 12" />
-								</svg>
-							</button>
-						</div>
-						<div v-if="nudge.mode !== 'edit'" class="jv-nudge-actions">
-							<template v-if="ui.stt_enabled && nudgeRec.supported">
-								<button
-									v-if="nudge.mode === 'transcribing'"
-									class="jv-iconbtn jv-micbtn"
-									title="Transcribing…"
-									disabled
-									style="
-										width: 28px;
-										height: 28px;
-										display: flex;
-										align-items: center;
-										justify-content: center;
-										background: transparent;
-										border: none;
-										border-radius: 7px;
-										color: var(--text-3);
-									"
-								>
-									<svg
-										class="jv-spin"
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="var(--cta)"
-										stroke-width="2.4"
-										stroke-linecap="round"
-									>
-										<path d="M12 3a9 9 0 1 0 9 9" />
-									</svg>
-								</button>
-								<!-- labeled, unlike the composer's dictate mic 40px below — two
-								     identical icon-only mics were indistinguishable at a glance -->
-								<button
-									v-else
-									class="jv-iconbtn jv-micbtn"
-									:class="{ rec: nudge.mode === 'recording' }"
-									:title="
-										nudge.mode === 'recording'
-											? 'Stop and transcribe'
-											: `Record a voice note (saved for ${agentName} to learn from)`
-									"
-									@click="
-										nudge.mode === 'recording'
-											? stopNudgeMic()
-											: startNudgeMic()
-									"
-									style="
-										height: 28px;
-										display: flex;
-										align-items: center;
-										justify-content: center;
-										gap: 5px;
-										background: transparent;
-										border: none;
-										border-radius: 7px;
-										cursor: pointer;
-										color: var(--text-3);
-										padding: 0 8px;
-										font-size: 12.5px;
-										font-weight: 600;
-									"
-								>
-									<svg
-										width="15"
-										height="15"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.7"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<path
-											d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"
-										/>
-										<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-										<path d="M12 19v3" />
-									</svg>
-									<span v-if="nudge.mode !== 'recording'">Record answer</span>
-								</button>
-								<template v-if="nudge.mode === 'recording'">
-									<span class="jv-mic-live"
-										><span class="jv-mic-dot"></span>{{ nudgeClock }}</span
-									>
+								<div class="jv-nudge-head">
+									<div class="jv-nudge-q">
+										Anything worth remembering about <b>{{ nudgeLabels }}</b
+										>?
+									</div>
 									<button
-										class="jv-mic-cancel"
-										title="Cancel recording (Esc)"
-										aria-label="Cancel recording"
-										@click="cancelNudgeMic"
+										class="jv-nudge-x"
+										title="Dismiss"
+										aria-label="Dismiss"
+										@click="dismissNudge"
 									>
 										<svg
-											width="12"
-											height="12"
+											width="13"
+											height="13"
 											viewBox="0 0 24 24"
 											fill="none"
 											stroke="currentColor"
-											stroke-width="2.2"
+											stroke-width="2"
 											stroke-linecap="round"
 											stroke-linejoin="round"
 										>
 											<path d="M18 6 6 18M6 6l12 12" />
 										</svg>
 									</button>
+								</div>
+								<div v-if="nudge.mode !== 'edit'" class="jv-nudge-actions">
+									<template v-if="ui.stt_enabled && nudgeRec.supported">
+										<button
+											v-if="nudge.mode === 'transcribing'"
+											class="jv-iconbtn jv-micbtn"
+											title="Transcribing…"
+											disabled
+											style="
+												width: 28px;
+												height: 28px;
+												display: flex;
+												align-items: center;
+												justify-content: center;
+												background: transparent;
+												border: none;
+												border-radius: 7px;
+												color: var(--text-3);
+											"
+										>
+											<svg
+												class="jv-spin"
+												width="14"
+												height="14"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="var(--cta)"
+												stroke-width="2.4"
+												stroke-linecap="round"
+											>
+												<path d="M12 3a9 9 0 1 0 9 9" />
+											</svg>
+										</button>
+										<!-- labeled, unlike the composer's dictate mic 40px below — two
+										     identical icon-only mics were indistinguishable at a glance -->
+										<button
+											v-else
+											class="jv-iconbtn jv-micbtn"
+											:class="{ rec: nudge.mode === 'recording' }"
+											:title="
+												nudge.mode === 'recording'
+													? 'Stop and transcribe'
+													: `Record a voice note (saved for ${agentName} to learn from)`
+											"
+											@click="
+												nudge.mode === 'recording'
+													? stopNudgeMic()
+													: startNudgeMic()
+											"
+											style="
+												height: 28px;
+												display: flex;
+												align-items: center;
+												justify-content: center;
+												gap: 5px;
+												background: transparent;
+												border: none;
+												border-radius: 7px;
+												cursor: pointer;
+												color: var(--text-3);
+												padding: 0 8px;
+												font-size: 12.5px;
+												font-weight: 600;
+											"
+										>
+											<svg
+												width="15"
+												height="15"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="1.7"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											>
+												<path
+													d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"
+												/>
+												<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+												<path d="M12 19v3" />
+											</svg>
+											<span v-if="nudge.mode !== 'recording'"
+												>Record answer</span
+											>
+										</button>
+										<template v-if="nudge.mode === 'recording'">
+											<span class="jv-mic-live"
+												><span class="jv-mic-dot"></span
+												>{{ nudgeClock }}</span
+											>
+											<button
+												class="jv-mic-cancel"
+												title="Cancel recording (Esc)"
+												aria-label="Cancel recording"
+												@click="cancelNudgeMic"
+											>
+												<svg
+													width="12"
+													height="12"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="2.2"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												>
+													<path d="M18 6 6 18M6 6l12 12" />
+												</svg>
+											</button>
+										</template>
+									</template>
+									<button
+										v-if="nudge.mode === 'idle'"
+										class="jv-nudge-type"
+										@click="typeNudge"
+									>
+										Type instead
+									</button>
+								</div>
+								<template v-else>
+									<textarea
+										ref="nudgeTaEl"
+										v-model="nudge.text"
+										rows="3"
+										class="jv-nudge-ta"
+										:placeholder="`What should ${agentName} remember?`"
+									></textarea>
+									<div class="jv-nudge-foot">
+										<button
+											class="jv-btn jv-btn--ghost"
+											style="height: 30px; padding: 0 12px"
+											:disabled="nudge.saving"
+											@click="nudge.mode = 'idle'"
+										>
+											Cancel
+										</button>
+										<button
+											class="jv-btn jv-btn--primary"
+											style="height: 30px; padding: 0 12px"
+											:disabled="nudge.saving || !nudge.text.trim()"
+											@click="saveNudgeNote"
+										>
+											{{ nudge.saving ? "Saving…" : "Save" }}
+										</button>
+									</div>
 								</template>
-							</template>
-							<button
-								v-if="nudge.mode === 'idle'"
-								class="jv-nudge-type"
-								@click="typeNudge"
-							>
-								Type instead
-							</button>
-						</div>
-						<template v-else>
-							<textarea
-								ref="nudgeTaEl"
-								v-model="nudge.text"
-								rows="3"
-								class="jv-nudge-ta"
-								:placeholder="`What should ${agentName} remember?`"
-							></textarea>
-							<div class="jv-nudge-foot">
-								<button
-									class="jv-btn jv-btn--ghost"
-									style="height: 30px; padding: 0 12px"
-									:disabled="nudge.saving"
-									@click="nudge.mode = 'idle'"
-								>
-									Cancel
-								</button>
-								<button
-									class="jv-btn jv-btn--primary"
-									style="height: 30px; padding: 0 12px"
-									:disabled="nudge.saving || !nudge.text.trim()"
-									@click="saveNudgeNote"
-								>
-									{{ nudge.saving ? "Saving…" : "Save" }}
-								</button>
 							</div>
 						</template>
-					</div>
-					<div
-						class="jv-composer"
-						@dragover.prevent
-						@dragenter.prevent="onDragEnter"
-						@dragleave.prevent="onDragLeave"
-						@drop.prevent="onDrop"
-						style="
-							position: relative;
-							border: 1.5px solid var(--text);
-							border-radius: 13px;
-							background: var(--surface);
-							box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
-							padding: 5px 6px 6px 6px;
-							transition: border-color 0.12s, box-shadow 0.12s;
-						"
-					>
-						<div
-							v-if="dragActive"
-							style="
-								position: absolute;
-								inset: 0;
-								z-index: 40;
-								display: flex;
-								align-items: center;
-								justify-content: center;
-								background: var(--cta-bg);
-								border: 2px dashed var(--cta);
-								border-radius: 13px;
-								color: var(--cta);
-								font-size: 13px;
-								font-weight: 600;
-								pointer-events: none;
-							"
-						>
-							Drop image or file to attach
-						</div>
-						<!-- mention dropdown (@ user, / doctype·tool) -->
-						<div
-							v-if="mention.open && mention.items.length"
-							style="
-								position: absolute;
-								bottom: calc(100% + 6px);
-								left: 0;
-								min-width: 248px;
-								max-height: 248px;
-								overflow-y: auto;
-								background: var(--surface);
-								border: 1px solid var(--border-2);
-								border-radius: 10px;
-								box-shadow: 0 10px 28px rgba(20, 20, 30, 0.16);
-								padding: 5px;
-								z-index: 30;
-							"
-						>
-							<button
-								v-for="(it, i) in mention.items"
-								:key="it.value"
-								class="jv-menuitem"
-								:class="{ on: i === mention.index }"
-								@click="applyMention(it)"
-								@mouseenter="mention.index = i"
+						<template #overlay>
+							<!-- mention dropdown (@ user, / doctype·tool) -->
+							<div
+								v-if="mention.open && mention.items.length"
+								style="
+									position: absolute;
+									bottom: calc(100% + 6px);
+									left: 0;
+									min-width: 248px;
+									max-height: 248px;
+									overflow-y: auto;
+									background: var(--surface);
+									border: 1px solid var(--border-2);
+									border-radius: 10px;
+									box-shadow: 0 10px 28px rgba(20, 20, 30, 0.16);
+									padding: 5px;
+									z-index: 30;
+								"
 							>
-								<span
-									style="
-										flex: 1;
-										overflow: hidden;
-										text-overflow: ellipsis;
-										white-space: nowrap;
-									"
-									>{{ mention.type }}{{ it.value }}</span
+								<button
+									v-for="(it, i) in mention.items"
+									:key="it.value"
+									class="jv-menuitem"
+									:class="{ on: i === mention.index }"
+									@click="applyMention(it)"
+									@mouseenter="mention.index = i"
 								>
-								<span
-									style="
-										font-size: 10px;
-										color: var(--text-3);
-										text-transform: uppercase;
-										letter-spacing: 0.03em;
-									"
-									>{{ it.sub }}</span
-								>
-							</button>
-						</div>
-						<!-- pending attachments: image thumbnails (Claude-style) + file chips -->
-						<div
-							v-if="pendingFiles.length || uploading"
-							style="display: flex; flex-wrap: wrap; gap: 8px; padding: 6px 4px 2px"
-						>
-							<template v-for="(f, i) in pendingFiles" :key="i">
-								<span
-									v-if="isImageFile(f)"
-									:title="f.file_name"
-									style="
-										position: relative;
-										display: inline-block;
-										line-height: 0;
-									"
-								>
-									<img
-										:src="f.file_url"
-										alt=""
+									<span
 										style="
-											width: 52px;
-											height: 52px;
-											object-fit: cover;
-											border-radius: 9px;
-											border: 1px solid var(--border);
-											display: block;
+											flex: 1;
+											overflow: hidden;
+											text-overflow: ellipsis;
+											white-space: nowrap;
 										"
-									/>
-									<button
-										@click="removeFile(i)"
-										title="Remove"
-										style="
-											position: absolute;
-											top: -7px;
-											right: -7px;
-											width: 18px;
-											height: 18px;
-											border-radius: 50%;
-											background: var(--text);
-											color: var(--surface);
-											border: none;
-											cursor: pointer;
-											font-size: 12px;
-											line-height: 1;
-											display: flex;
-											align-items: center;
-											justify-content: center;
-											padding: 0;
-										"
+										>{{ mention.type }}{{ it.value }}</span
 									>
-										×
-									</button>
-								</span>
-								<span
-									v-else
-									style="
-										display: inline-flex;
-										align-items: center;
-										gap: 5px;
-										font-size: 11.5px;
-										padding: 3px 5px 3px 9px;
-										border-radius: 999px;
-										color: var(--text-2);
-										background: var(--surface-1);
-										border: 1px solid var(--border);
-									"
-									>📎 {{ f.file_name
-									}}<button
-										@click="removeFile(i)"
+									<span
 										style="
-											border: none;
-											background: transparent;
-											cursor: pointer;
-											font-size: 14px;
-											line-height: 1;
+											font-size: 10px;
 											color: var(--text-3);
+											text-transform: uppercase;
+											letter-spacing: 0.03em;
 										"
+										>{{ it.sub }}</span
 									>
-										×
-									</button></span
-								>
-							</template>
-							<span
-								v-if="uploading"
-								style="font-size: 11.5px; color: var(--text-3); padding: 3px 6px"
-								>Uploading…</span
+								</button>
+							</div>
+							<!-- clipboard held only a file PATH, not the image bytes -->
+							<div
+								v-if="pasteHint"
+								style="
+									font-size: 11.5px;
+									color: var(--amber);
+									padding: 4px 8px;
+									line-height: 1.4;
+								"
 							>
-						</div>
-						<div
-							v-if="pasteHint"
-							style="
-								font-size: 11.5px;
-								color: var(--amber);
-								padding: 4px 8px;
-								line-height: 1.4;
-							"
-						>
-							{{ pasteHint }}
-						</div>
-						<textarea
-							ref="inputEl"
-							v-model="input"
-							@input="onInput"
-							@keydown="onKey"
-							@paste="onPaste"
-							rows="1"
-							:placeholder="`Ask ${agentName}…   @ to mention a user, / for a doctype or tool`"
-							style="
-								width: 100%;
-								border: none;
-								outline: none;
-								resize: none;
-								font-family: inherit;
-								font-size: 14px;
-								line-height: 1.5;
-								color: var(--text);
-								background: transparent;
-								padding: 8px 8px 4px;
-								max-height: 140px;
-							"
-						></textarea>
-						<input
-							ref="fileInput"
-							type="file"
-							multiple
-							style="display: none"
-							@change="onFilesPicked"
-						/>
-						<div
-							style="display: flex; align-items: center; gap: 6px; padding: 2px 4px"
-						>
+								{{ pasteHint }}
+							</div>
+						</template>
+						<template #left-toolbar="{ pickFiles }">
 							<!-- dictation mic (hidden unless the backend reports STT configured) -->
 							<template v-if="ui.stt_enabled && micRec.supported">
 								<button
@@ -2601,84 +2474,8 @@
 								</svg>
 								<span v-if="groundNextTurn">Wiki</span>
 							</button>
-							<span
-								style="
-									margin-left: auto;
-									font-size: 11px;
-									color: var(--text-3);
-									margin-right: 4px;
-								"
-								>{{ busy ? "Stop" : "Enter ↵" }}</span
-							>
-							<button
-								v-if="busy"
-								@click="stopRun"
-								title="Stop generating"
-								style="
-									width: 32px;
-									height: 32px;
-									display: flex;
-									align-items: center;
-									justify-content: center;
-									background: var(--cta);
-									border: none;
-									border-radius: 8px;
-									cursor: pointer;
-								"
-							>
-								<svg
-									width="13"
-									height="13"
-									viewBox="0 0 24 24"
-									fill="var(--cta-fg)"
-								>
-									<rect x="6" y="6" width="12" height="12" rx="2.5" />
-								</svg>
-							</button>
-							<button
-								v-else
-								class="jv-sendbtn"
-								:class="{ ready: canSend }"
-								@click="send()"
-								:disabled="!canSend"
-								:style="{
-									width: '32px',
-									height: '32px',
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'center',
-									background: canSend ? 'var(--cta)' : 'var(--surface-3)',
-									border: 'none',
-									borderRadius: '8px',
-									cursor: canSend ? 'pointer' : 'default',
-								}"
-							>
-								<svg
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									:stroke="canSend ? 'var(--cta-fg)' : 'var(--text-3)'"
-									stroke-width="2.1"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<path d="M12 19V5M5 12l7-7 7 7" />
-								</svg>
-							</button>
-						</div>
-					</div>
-					<div
-						style="
-							text-align: center;
-							font-size: 10.5px;
-							color: var(--text-3);
-							margin-top: 8px;
-						"
-					>
-						{{ agentName }} can make mistakes. Verify important actions before
-						submitting to ERPNext.
-					</div>
+						</template>
+					</Composer>
 				</div>
 			</div>
 		</main>
@@ -3401,6 +3198,7 @@ import Banner from "@/components/Banner.vue";
 import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
 import Message from "@/components/chat/Message.vue";
+import Composer from "@/components/chat/Composer.vue";
 import { checkReady, readinessDetailOf } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
@@ -3487,7 +3285,11 @@ function dismissBillingAlert() {
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.
 const convAutoApply = ref(false);
 const autoApplyNote = ref("");
-const inputEl = ref(null);
+// The <Composer> instance. It owns the textarea and auto-grow; this view still
+// owns everything around them, so it reaches in for the two things a parent
+// legitimately needs: `composerRef.value.el` (the raw textarea, for the caret
+// math behind mention insertion and edit-and-resend) and `focusInput()`.
+const composerRef = ref(null);
 const threadEl = ref(null);
 const threadInnerEl = ref(null);
 const rootEl = ref(null);
@@ -3999,7 +3801,6 @@ const runMeta = ref({}); // { [message_id]: { ms, tools, names } } — survives 
 const canvasContent = ref({}); // { `${msgName}::${canvasName}`: srcdoc html (html/svg) | data-url (pdf/image/file) }
 const pendingFiles = ref([]); // [{ file_url, file_name }] attachments to send
 const uploading = ref(false);
-const fileInput = ref(null);
 const mention = ref({ open: false, type: "", query: "", start: 0, items: [], index: 0 });
 // Tool names for the "Tools available" count + the /tool autocomplete. Seeded
 // with the core set as a fallback, then replaced on mount with the live bench
@@ -5793,8 +5594,7 @@ function copyMsg(id, text) {
 function editCommand(m) {
 	input.value = m.content || "";
 	nextTick(() => {
-		autoGrow();
-		const el = inputEl.value;
+		const el = composerRef.value?.el;
 		if (el) {
 			el.focus();
 			const p = input.value.length;
@@ -5951,12 +5751,8 @@ onBeforeUnmount(() => {
 		threadRO = null;
 	}
 });
-function autoGrow() {
-	const el = inputEl.value;
-	if (!el) return;
-	el.style.height = "auto";
-	el.style.height = Math.min(el.scrollHeight, 140) + "px";
-}
+// Auto-grow now lives in <Composer> (it watches modelValue), so every former
+// autoGrow() call here is gone — only the caret work around them remains.
 function onKey(e) {
 	const mn = mention.value;
 	if (mn.open && mn.items.length) {
@@ -5998,7 +5794,6 @@ function onKey(e) {
 			histIdx.value -= 1;
 			input.value = promptHistory.value[histIdx.value];
 			nextTick(() => {
-				autoGrow();
 				const p = input.value.length;
 				el.setSelectionRange(p, p);
 			});
@@ -6019,7 +5814,6 @@ function onKey(e) {
 			input.value = histDraft.value;
 		}
 		nextTick(() => {
-			autoGrow();
 			const p = input.value.length;
 			el.setSelectionRange(p, p);
 		});
@@ -6329,8 +6123,7 @@ async function selectConversation(id) {
 	if (route.params.id !== id) router.replace("/c/" + id);
 	await loadConversation(id);
 	await nextTick();
-	autoGrow();
-	inputEl.value?.focus();
+	composerRef.value?.focusInput();
 }
 // Surface a failed action (new chat, send, …) as an error toast. String()-coerces
 // the extracted reason so a non-string Frappe error payload can't throw inside the
@@ -6366,15 +6159,14 @@ async function newChat() {
 	// multiple of three - re-probe, but never await it (must never block chat).
 	probeGreeting();
 	await nextTick();
-	inputEl.value?.focus();
+	composerRef.value?.focusInput();
 }
 // Welcome cards drop the prompt into the input (don't send) so the user can
 // tweak it first.
 function fillInput(text) {
 	input.value = text;
 	nextTick(() => {
-		inputEl.value?.focus();
-		autoGrow();
+		composerRef.value?.focusInput();
 	});
 }
 function openErpDesk() {
@@ -6481,7 +6273,6 @@ async function send(textArg) {
 		input.value = "";
 		pendingFiles.value = [];
 		mention.value = { ...mention.value, open: false };
-		nextTick(autoGrow);
 	}
 	// No awaited pre-flight for a brand-new chat (latency plan, Phase 1.3):
 	// the backend's send_message creates/focuses the empty conversation
@@ -6915,8 +6706,7 @@ async function _transcribeToInput(r) {
 			// fillInput pattern, but APPENDING: dictation adds to any typed draft.
 			input.value = input.value.trim() ? input.value.replace(/\s+$/, "") + " " + text : text;
 			nextTick(() => {
-				inputEl.value?.focus();
-				autoGrow();
+				composerRef.value?.focusInput();
 			});
 		} else if (forId) {
 			// The user switched chats mid-transcription: the words belong to the
@@ -7040,11 +6830,26 @@ function dismissNudge() {
 	notify("Okay — won't ask again in this chat for a week.");
 }
 
-// ---- file input ----
-function pickFiles() {
-	fileInput.value?.click();
-}
+// ---- attachments ----
+// Chat uploads EAGERLY, the moment a file is attached: send() posts the
+// uploaded `{file_url, file_name}` records straight through to the backend, so
+// `pendingFiles` must keep exactly that wire shape. <Composer> renders from
+// display-objects instead, so adapt here rather than reshaping the payload.
+// The in-flight "Uploading…" pill is just one more entry.
+const composerAttachments = computed(() => {
+	const chips = pendingFiles.value.map((f, i) => ({
+		key: i,
+		file_name: f.file_name,
+		// Only images get a preview; everything else renders as a 📎 chip.
+		preview_url: isImageFile(f) ? f.file_url : "",
+		removable: true,
+	}));
+	if (uploading.value) chips.push({ key: "uploading", uploading: true });
+	return chips;
+});
 // Shared upload path for the file picker, clipboard paste, and drag-and-drop.
+// The picker and drag-drop now live inside <Composer>, which hands us the raw
+// File[] via @files-added and never uploads anything itself.
 async function uploadFiles(list) {
 	const files = Array.from(list || []);
 	if (!files.length) return;
@@ -7057,29 +6862,7 @@ async function uploadFiles(list) {
 		}
 	}
 	uploading.value = false;
-	inputEl.value?.focus();
-}
-async function onFilesPicked(e) {
-	const picked = Array.from(e.target.files || []);
-	e.target.value = "";
-	await uploadFiles(picked);
-}
-// Drag-and-drop a file/image onto the composer (Claude-style). dragDepth guards
-// against the flicker from dragenter/leave firing on child elements.
-const dragActive = ref(false);
-let _dragDepth = 0;
-function onDragEnter() {
-	_dragDepth++;
-	dragActive.value = true;
-}
-function onDragLeave() {
-	_dragDepth = Math.max(0, _dragDepth - 1);
-	if (!_dragDepth) dragActive.value = false;
-}
-async function onDrop(e) {
-	_dragDepth = 0;
-	dragActive.value = false;
-	await uploadFiles((e.dataTransfer && e.dataTransfer.files) || []);
+	composerRef.value?.focusInput();
 }
 // Transient hint shown when the clipboard holds only a file PATH, not the image
 // bytes (e.g. copying an image FILE from a file manager - the OS exposes only
@@ -7143,7 +6926,7 @@ async function onPaste(e) {
 		}
 	}
 	uploading.value = false;
-	inputEl.value?.focus();
+	composerRef.value?.focusInput();
 }
 function removeFile(i) {
 	pendingFiles.value = pendingFiles.value.filter((_, idx) => idx !== i);
@@ -7156,8 +6939,7 @@ function isImageFile(f) {
 let _mentionSeq = 0;
 function onInput() {
 	histIdx.value = null; // typing exits prompt-history navigation
-	autoGrow();
-	const el = inputEl.value;
+	const el = composerRef.value?.el;
 	if (!el) return;
 	const caret = el.selectionStart;
 	const m = input.value.slice(0, caret).match(/(?:^|\s)([@/])([\w-]*)$/);
@@ -7205,14 +6987,13 @@ async function queryMentions(type, query) {
 }
 function applyMention(item) {
 	if (!item) return;
-	const el = inputEl.value;
+	const el = composerRef.value?.el;
 	const caret = el ? el.selectionStart : input.value.length;
 	const before = input.value.slice(0, mention.value.start);
 	const token = mention.value.type + item.value + " ";
 	input.value = before + token + input.value.slice(caret);
 	mention.value = { ...mention.value, open: false };
 	nextTick(() => {
-		autoGrow();
 		if (el) {
 			const pos = (before + token).length;
 			el.focus();
@@ -7423,10 +7204,9 @@ onMounted(async () => {
 		input.value = prefill.text;
 		_prefillSendContext = prefill.context || null; // rides send()'s context arg
 		await nextTick();
-		autoGrow();
 		if (prefill.autoSend) await send();
 	}
-	inputEl.value?.focus();
+	composerRef.value?.focusInput();
 });
 onBeforeUnmount(() => {
 	socket?.off("jarvis:event", onEvent);
@@ -7512,46 +7292,12 @@ onUnmounted(() => {
    mark was near-black in light and gradient in dark: the same logo in two
    colours, and a third (flat bg-blue-500) in NotifyToaster. One mark, one
    gradient, no !important. */
-/* The send button inverts to black/white on hover (depends on its base color,
-   so the white icon flips to the surface color). !important beats the inline
-   background. */
-/* Send button: springy lift + arrow nudge on hover, press-in on click, and a
-   one-shot pop when it becomes ready (text entered). */
-.jv-sendbtn {
-	transition: transform 0.16s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.14s ease;
-}
-.jv-sendbtn svg {
-	transition: transform 0.16s ease;
-}
-.jv-sendbtn:not(:disabled):hover {
-	transform: translateY(-2px) scale(1.07);
-}
-.jv-sendbtn:not(:disabled):hover svg {
-	transform: translateY(-2px);
-}
-.jv-sendbtn:not(:disabled):active {
-	transform: scale(0.9);
-}
-.jv-sendbtn.ready {
-	animation: jv-send-pop 0.3s ease;
-}
-@keyframes jv-send-pop {
-	0% {
-		transform: scale(0.7);
-	}
-	55% {
-		transform: scale(1.15);
-	}
-	100% {
-		transform: scale(1);
-	}
-}
-.jv-sendbtn:hover:not(:disabled) {
-	background: var(--text) !important;
-}
-.jv-sendbtn:hover:not(:disabled) svg {
-	stroke: var(--surface) !important;
-}
+/* The Send button's rules (.jv-sendbtn + the jv-send-pop keyframe) moved to
+   components/chat/Composer.vue with the button itself. `.jv-iconbtn` below did
+   NOT move — it is still worn by this view's header buttons and by the
+   mic/attach/wiki/nudge buttons it slots back into the Composer, which carry
+   THIS component's scope id. Composer keeps its own copy for its default
+   attach button. */
 .jv-menuitem-danger {
 	color: var(--red);
 }
@@ -7610,12 +7356,9 @@ onUnmounted(() => {
 .jv-menuitem.on {
 	background: var(--surface-1);
 }
-/* black focus highlight on the composer */
-.jv-composer:focus-within {
-	border-color: var(--text);
-	box-shadow: 0 0 0 3px rgba(23, 23, 23, 0.07);
-}
-/* jump-to-latest arrow — floats just above the composer, centered */
+/* jump-to-latest arrow — floats just above the composer, centered.
+   It lives in .jv-composer-wrap (this view), NOT inside <Composer>, so it and
+   its .jv-sd-* transition stay here. */
 .jv-scrolldown {
 	position: absolute;
 	left: 50%;
@@ -8023,7 +7766,6 @@ onUnmounted(() => {
 }
 /* visible keyboard focus (UX #15) */
 .jv-suggest:focus-visible,
-.jv-sendbtn:focus-visible,
 .jv-iconbtn:focus-visible,
 .jv-retry:focus-visible,
 .jv-modelpill:focus-visible {
@@ -8041,9 +7783,6 @@ onUnmounted(() => {
 	}
 	.jv-tool-dot.run,
 	.jv-mic-dot {
-		animation: none;
-	}
-	.jv-sendbtn.ready {
 		animation: none;
 	}
 	.jv-settings,
@@ -10334,16 +10073,12 @@ onUnmounted(() => {
 .jv-dark .jv-modelpill:hover span {
 	color: var(--text) !important;
 }
-.jv-dark .jv-sendbtn:hover:not(:disabled),
 .jv-dark .jv-confirm-yes:hover,
 .jv-dark .jv-action-primary:hover {
 	background: var(--cta) !important;
 	color: var(--cta-fg) !important;
 	border-color: var(--cta) !important;
 	filter: brightness(1.18);
-}
-.jv-dark .jv-sendbtn:hover:not(:disabled) svg {
-	stroke: var(--cta-fg) !important;
 }
 .jv-action-discard {
 	margin-left: auto;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2044,6 +2044,13 @@
 					</button>
 				</transition>
 				<div style="max-width: 1280px; margin: 0 auto">
+					<!-- DO NOT REMOVE `@submit="send()"`: the Send BUTTON's click is
+					     `emit('submit')` inside Composer, so this binding is the
+					     button's ONLY path to send(). (It is Composer's built-in
+					     Enter→submit that is unreachable for chat — onKey
+					     preventDefaults on Enter and calls send() itself — not the
+					     click.) Composer's own test asserts the emit, not this
+					     wiring, so deleting it would kill click-to-send silently. -->
 					<Composer
 						ref="composerRef"
 						v-model="input"
@@ -7313,7 +7320,18 @@ onUnmounted(() => {
 }
 /* buttons invert to black/white on hover (theme-adaptive: black on light,
    white on dark) — var(--text)/var(--surface) flip, with an svg-stroke
-   override so the icon stays visible on the inverted background. */
+   override so the icon stays visible on the inverted background.
+
+   MUST STAY IN SYNC with the identical copy in
+   `components/chat/Composer.vue` (which styles that component's own default
+   attach button; slot content sent back into it carries THIS scope id, so
+   Composer's copy can't reach chat's mic/attach/wiki buttons). A third,
+   DELIBERATELY DIFFERENT `.jv-iconbtn` lives globally in
+   `assets/settings.css` — a quiet ghost hover for the settings dialog; do not
+   unify it with these. Hoisting these two into a shared sheet was evaluated
+   and rejected: unscoped, their `!important` would beat settings.css's
+   un-!important hover and restyle SettingsDialog's close button. Same applies
+   to the `:focus-visible` and `.jv-dark` copies further down this file. */
 .jv-iconbtn:hover {
 	background: var(--text) !important;
 	color: var(--surface) !important;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -705,139 +705,21 @@
 						     inline in place of the confirmation card that used to vanish -->
 						<ReceiptChip v-if="m.role === 'tool'" :message="m" />
 						<!-- user -->
-						<div
+						<Message
 							v-else-if="m.role === 'user'"
-							class="jv-umsg"
-							style="display: flex; flex-direction: column; align-items: flex-end"
-						>
-							<div
-								v-if="m.content"
-								class="jv-ububble"
-								style="
-									max-width: 78%;
-									min-width: 0;
-									background: var(--surface-2);
-									border: 1px solid var(--border);
-									border-radius: 14px 14px 4px 14px;
-									padding: 10px 14px;
-									font-size: 14px;
-									line-height: 1.5;
-									color: var(--text);
-									white-space: pre-wrap;
-									overflow-wrap: anywhere;
-								"
-							>
-								{{ m.content }}
-							</div>
-							<div
-								v-if="m.failed"
-								style="
-									display: flex;
-									align-items: center;
-									gap: 8px;
-									margin-top: 4px;
-									font-size: 11.5px;
-									color: var(--red);
-								"
-							>
-								<span>Not sent</span>
-								<button
-									@click="resendFailed(m)"
-									style="
-										background: none;
-										border: none;
-										color: var(--link);
-										font: inherit;
-										cursor: pointer;
-										padding: 0;
-										text-decoration: underline;
-									"
-								>
-									Retry
-								</button>
-							</div>
-							<!-- attached images → same clickable thumbnail + preview as generated ones -->
-							<template v-for="cv in m.canvas || []" :key="cv.name">
-								<button
-									v-if="cv.type === 'image' && cv.file_url"
-									class="jv-img-artifact"
-									@click="openArtifact(m, cv)"
-									:title="'Open ' + cv.title"
-									style="margin-top: 8px; cursor: zoom-in"
-								>
-									<img :src="cv.file_url" :alt="cv.title" loading="lazy" />
-								</button>
-							</template>
-							<div class="jv-msgbar">
-								<!-- sent-time: revealed with the bar on hover; its own hover
-								     (native title) gives the full day-date-month-year-time.
-								     Order: time → edit → copy (edit before copy). -->
-								<span
-									v-if="msgTime(m)"
-									class="jv-msgtime"
-									:title="msgTimeFull(m)"
-									>{{ msgTime(m) }}</span
-								>
-								<button
-									class="jv-msgbtn"
-									@click="editCommand(m)"
-									title="Edit & resend"
-								>
-									<svg
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.8"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<path
-											d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"
-										/>
-										<path
-											d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"
-										/>
-									</svg>
-								</button>
-								<button
-									class="jv-msgbtn"
-									@click="copyMsg(m.name, m.content)"
-									:title="copiedId === m.name ? 'Copied' : 'Copy'"
-								>
-									<svg
-										v-if="copiedId === m.name"
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="var(--green)"
-										stroke-width="2.2"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<path d="M20 6 9 17l-5-5" />
-									</svg>
-									<svg
-										v-else
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.8"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<rect x="9" y="9" width="13" height="13" rx="2" />
-										<path
-											d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-										/>
-									</svg>
-								</button>
-							</div>
-						</div>
+							variant="bubble"
+							:text="m.content"
+							:attachments="m.canvas"
+							:timestamp="msgTime(m)"
+							:timestampFull="msgTimeFull(m)"
+							editable
+							:copied="copiedId === m.name"
+							:failed="m.failed"
+							@edit="editCommand(m)"
+							@copy="copyMsg(m.name, m.content)"
+							@retry="resendFailed(m)"
+							@open-attachment="openArtifact(m, $event)"
+						/>
 						<!-- assistant -->
 						<div v-else class="jv-amsg" style="display: flex; gap: 12px">
 							<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
@@ -3510,6 +3392,7 @@ import ActionError from "@/components/ActionError.vue";
 import Banner from "@/components/Banner.vue";
 import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
+import Message from "@/components/chat/Message.vue";
 import { checkReady, readinessDetailOf } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
@@ -8086,7 +7969,6 @@ onUnmounted(() => {
 	opacity: 0;
 	transition: opacity 0.12s ease;
 }
-.jv-umsg:hover .jv-msgbar,
 .jv-amsg:hover .jv-msgbar {
 	opacity: 1;
 }
@@ -8218,9 +8100,6 @@ onUnmounted(() => {
 	}
 	.jv-welcome-h1 {
 		font-size: 24px !important;
-	}
-	.jv-ububble {
-		max-width: 92% !important;
 	}
 }
 /* touch devices can't hover, so always show per-message actions/timestamps */

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7612,15 +7612,6 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-/* Native form controls (select dropdowns, date/time pickers, scrollbars)
-   follow the app theme instead of the OS default — without this, a dark app
-   pops white select menus and calendar popups. */
-.jv-root {
-	color-scheme: light;
-}
-.jv-root.jv-dark {
-	color-scheme: dark;
-}
 /* The brand mark is now <JarvisMark> everywhere on this surface (hero, assistant
    avatars, proactive toast), so it carries its own gradient in BOTH themes.
    Deleted with this comment: a `.jv-dark .jv-logo, .jv-dark .jv-toast-ic` rule

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -721,6 +721,9 @@
 							@open-attachment="openArtifact(m, $event)"
 						/>
 						<!-- assistant -->
+						<!-- copied/@copy here drive Message's BUILT-IN trailer, which #below-body
+						     suppresses — chat's real Copy button is in the slotted metabar below.
+						     Kept so both call sites stay interface-identical. -->
 						<Message
 							v-else
 							variant="row"

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -721,9 +721,21 @@
 							@open-attachment="openArtifact(m, $event)"
 						/>
 						<!-- assistant -->
-						<div v-else class="jv-amsg" style="display: flex; gap: 12px">
-							<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
-							<div style="flex: 1; min-width: 0">
+						<Message
+							v-else
+							variant="row"
+							:html="m.error ? '' : render(m.content)"
+							:attachments="m.canvas"
+							:timestamp="msgTime(m)"
+							:timestampFull="msgTimeFull(m)"
+							:copied="copiedId === m.name"
+							@copy="copyMsg(m.name, stripBlocks(m.content))"
+							@open-attachment="openArtifact(m, $event)"
+						>
+							<template #avatar>
+								<JarvisMark :size="28" :radius="7" style="margin-top: 2px" />
+							</template>
+							<template #above-body>
 								<!-- Activity: the tool calls (with input + output) that produced
 								     this answer — openclaw-style, collapsible. -->
 								<div
@@ -936,12 +948,8 @@
 										</button>
 									</div>
 								</div>
-								<div
-									v-else
-									class="jv-md"
-									style="font-size: 14px; line-height: 1.6; color: var(--text)"
-									v-html="render(m.content)"
-								></div>
+							</template>
+							<template #below-body>
 								<!-- The user stopped this reply. A SIBLING of the body, not part of
 								     it: gated only on `stopped`, so it shows for a partial stop
 								     (content present) and an empty one alike, and the renderer can
@@ -1727,8 +1735,8 @@
 										</button>
 									</div>
 								</div>
-							</div>
-						</div>
+							</template>
+						</Message>
 					</template>
 
 					<!-- live tool activity + thinking (Claude Code style) -->
@@ -7960,41 +7968,6 @@ onUnmounted(() => {
 	max-height: 320px;
 	overflow-y: auto;
 }
-/* per-message Copy/Edit bar — revealed on hover */
-.jv-msgbar {
-	display: flex;
-	align-items: center;
-	gap: 3px;
-	margin-top: 0;
-	opacity: 0;
-	transition: opacity 0.12s ease;
-}
-.jv-amsg:hover .jv-msgbar {
-	opacity: 1;
-}
-.jv-msgtime {
-	font-size: 11.5px;
-	color: var(--text-3);
-	padding: 0 3px;
-	cursor: default;
-	user-select: none;
-}
-.jv-msgbtn {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 26px;
-	height: 26px;
-	border: none;
-	background: transparent;
-	border-radius: 6px;
-	cursor: pointer;
-	color: var(--text-3);
-}
-.jv-msgbtn:hover {
-	background: var(--surface-2);
-	color: var(--text);
-}
 .jv-meta span {
 	display: inline-flex;
 	align-items: center;
@@ -8052,7 +8025,6 @@ onUnmounted(() => {
 .jv-suggest:focus-visible,
 .jv-sendbtn:focus-visible,
 .jv-iconbtn:focus-visible,
-.jv-msgbtn:focus-visible,
 .jv-retry:focus-visible,
 .jv-modelpill:focus-visible {
 	outline: 2px solid var(--cta);
@@ -8072,9 +8044,6 @@ onUnmounted(() => {
 		animation: none;
 	}
 	.jv-sendbtn.ready {
-		animation: none;
-	}
-	.jv-md :deep(.jv-mermaid:not([data-rendered]))::after {
 		animation: none;
 	}
 	.jv-settings,
@@ -8100,12 +8069,6 @@ onUnmounted(() => {
 	}
 	.jv-welcome-h1 {
 		font-size: 24px !important;
-	}
-}
-/* touch devices can't hover, so always show per-message actions/timestamps */
-@media (hover: none) {
-	.jv-msgbar {
-		opacity: 1 !important;
 	}
 }
 
@@ -8205,100 +8168,11 @@ onUnmounted(() => {
 	font-weight: 600;
 	color: var(--text);
 }
-/* mermaid diagrams + fenced code blocks in markdown */
-/* Narrow-window resilience: without min-width:0 a flex child refuses to shrink
-   below its content, so on minimize the layout "breaks"; wide content (tables,
-   code) must scroll INSIDE its own box, never squeeze the text around it. */
-.jv-md {
-	min-width: 0;
-	max-width: 100%;
-	overflow-wrap: anywhere;
-}
-.jv-md :deep(table) {
-	display: block;
-	max-width: 100%;
-	overflow-x: auto;
-	border-collapse: collapse;
-}
-.jv-md :deep(pre) {
-	max-width: 100%;
-	overflow-x: auto;
-}
-.jv-md :deep(img) {
-	max-width: 100%;
-	height: auto;
-}
 .jv-cards,
 .jv-action,
 .jv-email {
 	min-width: 0;
 	max-width: 100%;
-}
-.jv-md :deep(.jv-mermaid) {
-	position: relative;
-	margin: 8px 0 12px;
-	text-align: center;
-	overflow-x: auto;
-}
-.jv-md :deep(.jv-mermaid svg) {
-	max-width: 100%;
-	height: auto;
-}
-/* skeleton shimmer while a chart hasn't rendered to SVG yet (no data-rendered) —
-   hides the raw mermaid source so the user never sees the markup flash. */
-.jv-md :deep(.jv-mermaid:not([data-rendered])) {
-	min-height: 196px;
-	color: transparent !important;
-	user-select: none;
-	overflow: hidden;
-	border-radius: 10px;
-	border: 1px solid var(--border);
-	background: var(--surface-1);
-}
-.jv-md :deep(.jv-mermaid:not([data-rendered])) * {
-	color: transparent !important;
-}
-.jv-md :deep(.jv-mermaid:not([data-rendered]))::after {
-	content: "";
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(100deg, transparent 20%, var(--surface-2) 50%, transparent 80%);
-	background-size: 220% 100%;
-	animation: jv-shimmer 1.25s ease-in-out infinite;
-}
-@keyframes jv-shimmer {
-	0% {
-		background-position: 180% 0;
-	}
-	100% {
-		background-position: -180% 0;
-	}
-}
-.jv-md :deep(.jv-chart-dl) {
-	position: absolute;
-	top: 6px;
-	right: 6px;
-	width: 26px;
-	height: 26px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 0;
-	background: var(--surface);
-	color: var(--text-3);
-	border: 1px solid var(--border);
-	border-radius: 6px;
-	cursor: pointer;
-	opacity: 0;
-	transition: opacity 0.12s, color 0.12s, background 0.12s;
-}
-.jv-md :deep(.jv-mermaid:hover .jv-chart-dl) {
-	opacity: 1;
-}
-.jv-md :deep(.jv-chart-dl:hover) {
-	color: var(--text);
-	background: var(--surface-1);
-	border-color: var(--border-2);
 }
 .jv-switch {
 	width: 38px;
@@ -8329,73 +8203,6 @@ onUnmounted(() => {
 .jv-switch.on .jv-switch-knob {
 	left: 18px;
 }
-.jv-md :deep(.jv-md-pre) {
-	margin: 6px 0 12px;
-	padding: 12px 14px;
-	background: var(--surface-2);
-	border: 1px solid var(--border);
-	border-radius: 8px;
-	overflow-x: auto;
-}
-.jv-md :deep(.jv-md-pre code) {
-	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-	font-size: 12px;
-	color: var(--text);
-	white-space: pre;
-}
-
-/* markdown content → the imported design's table look */
-.jv-md :deep(.jv-md-p) {
-	margin: 0 0 10px;
-}
-.jv-md :deep(.jv-md-p:last-child) {
-	margin-bottom: 0;
-}
-.jv-md :deep(.jv-md-h) {
-	margin: 14px 0 6px;
-	font-weight: 600;
-	color: var(--text);
-}
-.jv-md :deep(h3.jv-md-h) {
-	font-size: 15px;
-}
-.jv-md :deep(h4.jv-md-h) {
-	font-size: 14px;
-}
-.jv-md :deep(h5.jv-md-h),
-.jv-md :deep(h6.jv-md-h) {
-	font-size: 13px;
-}
-.jv-md :deep(.jv-md-h:first-child) {
-	margin-top: 0;
-}
-.jv-md :deep(.jv-md-list) {
-	margin: 0 0 10px;
-	padding-left: 20px;
-}
-.jv-md :deep(.jv-md-list li) {
-	margin: 2px 0;
-}
-.jv-md :deep(.jv-md-code) {
-	background: var(--surface-2);
-	padding: 1px 5px;
-	border-radius: 4px;
-	font-size: 12px;
-	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-	overflow-wrap: anywhere;
-}
-.jv-md :deep(.jv-md-list .jv-md-list) {
-	margin: 2px 0;
-}
-.jv-md :deep(.jv-md-quote) {
-	margin: 0 0 10px;
-	padding: 2px 0 2px 12px;
-	border-left: 3px solid var(--border-2);
-	color: var(--text-2);
-}
-.jv-md :deep(del) {
-	opacity: 0.65;
-}
 /* day separators between message groups (UX #23) */
 .jv-daydivider {
 	display: flex;
@@ -8421,53 +8228,6 @@ onUnmounted(() => {
 	border-top: 1px solid var(--border);
 	font-size: 11.5px;
 	color: var(--text-3);
-}
-.jv-md :deep(.jv-md-link) {
-	color: var(--cta);
-	text-decoration: none;
-	font-weight: 500;
-}
-/* Auto-linked document IDs → open the record in ERPNext Desk. Dashed underline
-   marks them as record links, distinct from plain markdown links. */
-.jv-md :deep(.jv-doclink) {
-	color: var(--cta);
-	text-decoration: none;
-	font-weight: 550;
-	border-bottom: 1px dashed var(--cta);
-	cursor: pointer;
-	transition: background 0.12s;
-}
-.jv-md :deep(.jv-doclink:hover) {
-	border-bottom-style: solid;
-	background: var(--cta-bg);
-	border-radius: 3px;
-}
-.jv-md :deep(.jv-md-tablewrap) {
-	border: 1px solid var(--border);
-	border-radius: 10px;
-	overflow: hidden;
-	margin: 4px 0 10px;
-}
-.jv-md :deep(.jv-md-table) {
-	width: 100%;
-	border-collapse: collapse;
-	font-size: 12.5px;
-}
-.jv-md :deep(.jv-md-table th) {
-	padding: 8px 13px;
-	font-weight: 550;
-	color: var(--text-3);
-	background: var(--surface-1);
-	border-bottom: 1px solid var(--border);
-}
-.jv-md :deep(.jv-md-table td) {
-	padding: 9px 13px;
-	border-bottom: 1px solid var(--border);
-	color: var(--text);
-	font-variant-numeric: tabular-nums;
-}
-.jv-md :deep(.jv-md-table tr:last-child td) {
-	border-bottom: 0;
 }
 
 /* ===== settings panel (slide-over console) ===== */
@@ -9627,41 +9387,6 @@ onUnmounted(() => {
 }
 
 /* artifact card (in the message) */
-/* generated-image artifact: clickable thumbnail */
-.jv-img-artifact {
-	display: block;
-	position: relative;
-	margin-top: 12px;
-	padding: 0;
-	border: 1px solid var(--border);
-	border-radius: 12px;
-	background: var(--surface-1);
-	cursor: zoom-in;
-	overflow: hidden;
-	max-width: 380px;
-	line-height: 0;
-}
-.jv-img-artifact:hover {
-	border-color: var(--border-2);
-}
-.jv-img-artifact img {
-	display: block;
-	width: 100%;
-	max-height: 320px;
-	object-fit: cover;
-}
-.jv-img-artifact-cap {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 7px 10px;
-	font-family: inherit;
-	font-size: 11.5px;
-	line-height: 1.3;
-	color: var(--text-3);
-	background: var(--surface);
-	border-top: 1px solid var(--border);
-}
 .jv-artifact {
 	display: flex;
 	align-items: center;

--- a/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
+++ b/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`composer renders identically (light) 1`] = `
+"<div class="jv-root" style="--surface: #ffffff; --surface-1: #f7f7f8; --surface-2: #f1f1f3; --surface-3: #ececef; --border: #e8e8ec; --border-2: #dfdfe4; --text: #171717; --text-2: #4a4a4f; --text-3: #6d6d76; --cta: #1c1c22; --cta-fg: #ffffff; --cta-bg: #f1f1f4; --cta-bd: #e2e2e8; --link: #1579d0; --green: #16a34a; --green-bg: #edf8f0; --green-bd: #cdeed8; --red: #dc2626; --red-bg: #fdf0ef; --red-bd: #f5d4d1; --amber: #d97706; --amber-bg: #fdf6ec; --amber-bd: #f3e2c2;">
+  <!-- Host content directly above the box, in flow (chat's wiki nudge card). -->
+  <div data-v-680708eb="" class="jv-composer" style="position: relative; border: 1.5px solid var(--text); border-radius: 13px; background: var(--surface); box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07); padding: 5px 6px 6px 6px; transition: border-color 0.12s, box-shadow 0.12s;">
+    <!--v-if-->
+    <!-- pending attachments: image thumbnails (Claude-style) + file chips.
+		     Purely a projection of the \`attachments\` prop — an entry with a
+		     \`preview_url\` is a thumbnail, one with \`uploading\` is the in-flight
+		     placeholder pill, anything else is a 📎 chip. -->
+    <!--v-if-->
+    <!-- Host popovers anchored to the box (chat's @/ mention dropdown, which
+		     is absolutely positioned) plus any in-flow notice that belongs
+		     directly above the textarea (chat's paste hint). Placed after the
+		     chips so an in-flow notice lands exactly where chat renders it. -->
+    <!-- v-model (not :value + a manual emit) so Vue's own vModelText directive
+		     keeps handling IME composition: it suppresses the update mid-compose,
+		     which a hand-rolled binding would not. Its listener is registered
+		     before @input, so the host sees the raw event with the new value
+		     already committed — exactly the order chat had inline. --><textarea data-v-680708eb="" rows="1" placeholder="Ask Jarvis…" style="width: 100%; outline: none; resize: none; font-family: inherit; font-size: 14px; line-height: 1.5; color: var(--text); background: transparent; padding: 8px 8px 4px; max-height: 140px;"></textarea><input data-v-680708eb="" type="file" multiple="" style="display: none;">
+    <div data-v-680708eb="" style="display: flex; align-items: center; gap: 6px; padding: 2px 4px;">
+      <!-- Host toolbar buttons on the left (chat: mic + 📎 + wiki-ground).
+			     \`pickFiles\` is handed down so a host that takes the slot over can
+			     still open this component's own hidden file input. The fallback is
+			     the plain attach button the generic composer ships with. --><button data-v-680708eb="" class="jv-iconbtn" title="Attach file" style="width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; background: transparent; border-radius: 7px; cursor: pointer; color: var(--text-3);"><svg data-v-680708eb="" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-680708eb="" d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.19a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49"></path>
+        </svg></button><span data-v-680708eb="" style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
+        </svg></button>
+    </div>
+  </div>
+  <div data-v-680708eb="" style="text-align: center; font-size: 10.5px; color: var(--text-3); margin-top: 8px;">Jarvis can make mistakes.</div>
+</div>"
+`;
+
+exports[`dark render 1`] = `
+"<div class="jv-root jv-dark" style="--surface: #16161a; --surface-1: #1d1d22; --surface-2: #26262d; --surface-3: #30303a; --border: #2c2c34; --border-2: #3a3a45; --text: #ededf2; --text-2: #b6b6c0; --text-3: #7e7e8a; --cta: #ececf0; --cta-fg: #1c1c22; --cta-bg: #26262d; --cta-bd: #3a3a45; --link: #6e8bff; --green: #34d399; --green-bg: #15271f; --green-bd: #214b38; --red: #f87171; --red-bg: #2a1818; --red-bd: #4a2a2a; --amber: #fbbf24; --amber-bg: #2a2315; --amber-bd: #4a3d1f;">
+  <!-- Host content directly above the box, in flow (chat's wiki nudge card). -->
+  <div data-v-680708eb="" class="jv-composer" style="position: relative; border: 1.5px solid var(--text); border-radius: 13px; background: var(--surface); box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07); padding: 5px 6px 6px 6px; transition: border-color 0.12s, box-shadow 0.12s;">
+    <!--v-if-->
+    <!-- pending attachments: image thumbnails (Claude-style) + file chips.
+		     Purely a projection of the \`attachments\` prop — an entry with a
+		     \`preview_url\` is a thumbnail, one with \`uploading\` is the in-flight
+		     placeholder pill, anything else is a 📎 chip. -->
+    <!--v-if-->
+    <!-- Host popovers anchored to the box (chat's @/ mention dropdown, which
+		     is absolutely positioned) plus any in-flow notice that belongs
+		     directly above the textarea (chat's paste hint). Placed after the
+		     chips so an in-flow notice lands exactly where chat renders it. -->
+    <!-- v-model (not :value + a manual emit) so Vue's own vModelText directive
+		     keeps handling IME composition: it suppresses the update mid-compose,
+		     which a hand-rolled binding would not. Its listener is registered
+		     before @input, so the host sees the raw event with the new value
+		     already committed — exactly the order chat had inline. --><textarea data-v-680708eb="" rows="1" placeholder="" style="width: 100%; outline: none; resize: none; font-family: inherit; font-size: 14px; line-height: 1.5; color: var(--text); background: transparent; padding: 8px 8px 4px; max-height: 140px;"></textarea><input data-v-680708eb="" type="file" multiple="" style="display: none;">
+    <div data-v-680708eb="" style="display: flex; align-items: center; gap: 6px; padding: 2px 4px;">
+      <!-- Host toolbar buttons on the left (chat: mic + 📎 + wiki-ground).
+			     \`pickFiles\` is handed down so a host that takes the slot over can
+			     still open this component's own hidden file input. The fallback is
+			     the plain attach button the generic composer ships with. --><button data-v-680708eb="" class="jv-iconbtn" title="Attach file" style="width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; background: transparent; border-radius: 7px; cursor: pointer; color: var(--text-3);"><svg data-v-680708eb="" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-680708eb="" d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.19a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49"></path>
+        </svg></button><span data-v-680708eb="" style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
+        </svg></button>
+    </div>
+  </div>
+  <!--v-if-->
+</div>"
+`;

--- a/frontend/tests/support-extraction/__snapshots__/message-bubble.test.js.snap
+++ b/frontend/tests/support-extraction/__snapshots__/message-bubble.test.js.snap
@@ -1,0 +1,43 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`user bubble renders identically (dark) 1`] = `
+"<div class="jv-root jv-dark" style="--surface: #16161a; --surface-1: #1d1d22; --surface-2: #26262d; --surface-3: #30303a; --border: #2c2c34; --border-2: #3a3a45; --text: #ededf2; --text-2: #b6b6c0; --text-3: #7e7e8a; --cta: #ececf0; --cta-fg: #1c1c22; --cta-bg: #26262d; --cta-bd: #3a3a45; --link: #6e8bff; --green: #34d399; --green-bg: #15271f; --green-bd: #214b38; --red: #f87171; --red-bg: #2a1818; --red-bd: #4a2a2a; --amber: #fbbf24; --amber-bg: #2a2315; --amber-bd: #4a3d1f;">
+  <div data-v-25f0d04f="" class="jv-umsg" style="display: flex; flex-direction: column; align-items: flex-end;">
+    <div data-v-25f0d04f="" class="jv-ububble" style="max-width: 78%; min-width: 0; background: var(--surface-2); border: 1px solid var(--border); border-radius: 14px 14px 4px 14px; padding: 10px 14px; font-size: 14px; line-height: 1.5; color: var(--text); white-space: pre-wrap; overflow-wrap: anywhere;">Can you summarise the attached screenshot and open a ticket for it?</div>
+    <!--v-if-->
+    <!-- attached images → same clickable thumbnail + preview as generated ones --><button data-v-25f0d04f="" class="jv-img-artifact" title="Open screenshot.png" style="margin-top: 8px; cursor: zoom-in;"><img data-v-25f0d04f="" src="/files/screenshot.png" alt="screenshot.png" loading="lazy"></button>
+    <div data-v-25f0d04f="" class="jv-msgbar">
+      <!-- sent-time: revealed with the bar on hover; its own hover
+				     (native title) gives the full day-date-month-year-time.
+				     Order: time → edit → copy (edit before copy). --><span data-v-25f0d04f="" class="jv-msgtime" title="">9:12</span><button data-v-25f0d04f="" class="jv-msgbtn" title="Edit &amp; resend"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-25f0d04f="" d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+          <path data-v-25f0d04f="" d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+        </svg></button><button data-v-25f0d04f="" class="jv-msgbtn" title="Copy"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect data-v-25f0d04f="" x="9" y="9" width="13" height="13" rx="2"></rect>
+          <path data-v-25f0d04f="" d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg></button>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`user bubble renders identically (light) 1`] = `
+"<div class="jv-root" style="--surface: #ffffff; --surface-1: #f7f7f8; --surface-2: #f1f1f3; --surface-3: #ececef; --border: #e8e8ec; --border-2: #dfdfe4; --text: #171717; --text-2: #4a4a4f; --text-3: #6d6d76; --cta: #1c1c22; --cta-fg: #ffffff; --cta-bg: #f1f1f4; --cta-bd: #e2e2e8; --link: #1579d0; --green: #16a34a; --green-bg: #edf8f0; --green-bd: #cdeed8; --red: #dc2626; --red-bg: #fdf0ef; --red-bd: #f5d4d1; --amber: #d97706; --amber-bg: #fdf6ec; --amber-bd: #f3e2c2;">
+  <div data-v-25f0d04f="" class="jv-umsg" style="display: flex; flex-direction: column; align-items: flex-end;">
+    <div data-v-25f0d04f="" class="jv-ububble" style="max-width: 78%; min-width: 0; background: var(--surface-2); border: 1px solid var(--border); border-radius: 14px 14px 4px 14px; padding: 10px 14px; font-size: 14px; line-height: 1.5; color: var(--text); white-space: pre-wrap; overflow-wrap: anywhere;">Can you summarise the attached screenshot and open a ticket for it?</div>
+    <!--v-if-->
+    <!-- attached images → same clickable thumbnail + preview as generated ones --><button data-v-25f0d04f="" class="jv-img-artifact" title="Open screenshot.png" style="margin-top: 8px; cursor: zoom-in;"><img data-v-25f0d04f="" src="/files/screenshot.png" alt="screenshot.png" loading="lazy"></button>
+    <div data-v-25f0d04f="" class="jv-msgbar">
+      <!-- sent-time: revealed with the bar on hover; its own hover
+				     (native title) gives the full day-date-month-year-time.
+				     Order: time → edit → copy (edit before copy). --><span data-v-25f0d04f="" class="jv-msgtime" title="">9:12</span><button data-v-25f0d04f="" class="jv-msgbtn" title="Edit &amp; resend"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path data-v-25f0d04f="" d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+          <path data-v-25f0d04f="" d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+        </svg></button><button data-v-25f0d04f="" class="jv-msgbtn" title="Copy"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect data-v-25f0d04f="" x="9" y="9" width="13" height="13" rx="2"></rect>
+          <path data-v-25f0d04f="" d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg></button>
+    </div>
+  </div>
+</div>"
+`;

--- a/frontend/tests/support-extraction/__snapshots__/message-row.test.js.snap
+++ b/frontend/tests/support-extraction/__snapshots__/message-row.test.js.snap
@@ -1,0 +1,107 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`assistant markdown row renders identically (dark) 1`] = `
+"<div class="jv-root jv-dark" style="--surface: #16161a; --surface-1: #1d1d22; --surface-2: #26262d; --surface-3: #30303a; --border: #2c2c34; --border-2: #3a3a45; --text: #ededf2; --text-2: #b6b6c0; --text-3: #7e7e8a; --cta: #ececf0; --cta-fg: #1c1c22; --cta-bg: #26262d; --cta-bd: #3a3a45; --link: #6e8bff; --green: #34d399; --green-bg: #15271f; --green-bd: #214b38; --red: #f87171; --red-bg: #2a1818; --red-bd: #4a2a2a; --amber: #fbbf24; --amber-bg: #2a2315; --amber-bd: #4a3d1f;">
+  <div data-v-25f0d04f="" class="jv-amsg" style="display: flex; gap: 12px;">
+    <div data-v-25f0d04f="" style="flex: 1 1 0%; min-width: 0;">
+      <!-- support-agent identity line: name + role + time. Chat's
+				     assistant passes no \`sender\`, so this never renders there. -->
+      <!--v-if-->
+      <!-- v-html body: markdown (chat, bodyClass="jv-md") or bare
+				     Helpdesk HTML (support, bodyClass="jv-html"). Both style
+				     blocks live in this component's scoped <style> and use
+				     :deep() because v-html children carry no scope id. The base
+				     font/line/color match chat's assistant body exactly. -->
+      <div data-v-25f0d04f="" class="jv-md-body jv-md" style="font-size: 14px; line-height: 1.6; color: var(--text);">
+        <h4 class="jv-md-h">Summary</h4>
+        <p class="jv-md-p">Here is what I found:</p>
+        <ul class="jv-md-list">
+          <li>First item</li>
+          <li>Second item with <code class="jv-md-code">inline code</code></li>
+        </ul>
+        <pre class="jv-md-pre"><code>console.log('hello');</code></pre>
+        <div class="jv-md-tablewrap">
+          <table class="jv-md-table">
+            <thead>
+              <tr>
+                <th style="text-align:left">Field</th>
+                <th style="text-align:left">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style="text-align:left">Status</td>
+                <td style="text-align:left">Open</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="jv-md-p">See the <a href="https://example.com/ticket/1" target="_blank" rel="noopener" class="jv-md-link">ticket</a> for details.</p>
+        <p class="jv-md-p">![diagram](/files/diagram.png)</p>
+      </div>
+      <!-- Built-in trailer (attachments + Copy bar) for consumers that
+				     do NOT take over the post-body region via #below-body — i.e.
+				     the standalone Support page (PR2). Chat provides #below-body
+				     (its canvas loop + metabar live there, byte-identical), so
+				     this stays hidden for chat and never double-renders. -->
+      <div data-v-25f0d04f="" class="jv-msgbar"><span data-v-25f0d04f="" class="jv-msgtime" title="">9:12</span><button data-v-25f0d04f="" class="jv-msgbtn" title="Copy"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect data-v-25f0d04f="" x="9" y="9" width="13" height="13" rx="2"></rect>
+            <path data-v-25f0d04f="" d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg></button></div>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`assistant markdown row renders identically (light) 1`] = `
+"<div class="jv-root" style="--surface: #ffffff; --surface-1: #f7f7f8; --surface-2: #f1f1f3; --surface-3: #ececef; --border: #e8e8ec; --border-2: #dfdfe4; --text: #171717; --text-2: #4a4a4f; --text-3: #6d6d76; --cta: #1c1c22; --cta-fg: #ffffff; --cta-bg: #f1f1f4; --cta-bd: #e2e2e8; --link: #1579d0; --green: #16a34a; --green-bg: #edf8f0; --green-bd: #cdeed8; --red: #dc2626; --red-bg: #fdf0ef; --red-bd: #f5d4d1; --amber: #d97706; --amber-bg: #fdf6ec; --amber-bd: #f3e2c2;">
+  <div data-v-25f0d04f="" class="jv-amsg" style="display: flex; gap: 12px;">
+    <div data-v-25f0d04f="" style="flex: 1 1 0%; min-width: 0;">
+      <!-- support-agent identity line: name + role + time. Chat's
+				     assistant passes no \`sender\`, so this never renders there. -->
+      <!--v-if-->
+      <!-- v-html body: markdown (chat, bodyClass="jv-md") or bare
+				     Helpdesk HTML (support, bodyClass="jv-html"). Both style
+				     blocks live in this component's scoped <style> and use
+				     :deep() because v-html children carry no scope id. The base
+				     font/line/color match chat's assistant body exactly. -->
+      <div data-v-25f0d04f="" class="jv-md-body jv-md" style="font-size: 14px; line-height: 1.6; color: var(--text);">
+        <h4 class="jv-md-h">Summary</h4>
+        <p class="jv-md-p">Here is what I found:</p>
+        <ul class="jv-md-list">
+          <li>First item</li>
+          <li>Second item with <code class="jv-md-code">inline code</code></li>
+        </ul>
+        <pre class="jv-md-pre"><code>console.log('hello');</code></pre>
+        <div class="jv-md-tablewrap">
+          <table class="jv-md-table">
+            <thead>
+              <tr>
+                <th style="text-align:left">Field</th>
+                <th style="text-align:left">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style="text-align:left">Status</td>
+                <td style="text-align:left">Open</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="jv-md-p">See the <a href="https://example.com/ticket/1" target="_blank" rel="noopener" class="jv-md-link">ticket</a> for details.</p>
+        <p class="jv-md-p">![diagram](/files/diagram.png)</p>
+      </div>
+      <!-- Built-in trailer (attachments + Copy bar) for consumers that
+				     do NOT take over the post-body region via #below-body — i.e.
+				     the standalone Support page (PR2). Chat provides #below-body
+				     (its canvas loop + metabar live there, byte-identical), so
+				     this stays hidden for chat and never double-renders. -->
+      <div data-v-25f0d04f="" class="jv-msgbar"><span data-v-25f0d04f="" class="jv-msgtime" title="">9:12</span><button data-v-25f0d04f="" class="jv-msgbtn" title="Copy"><svg data-v-25f0d04f="" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect data-v-25f0d04f="" x="9" y="9" width="13" height="13" rx="2"></rect>
+            <path data-v-25f0d04f="" d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg></button></div>
+    </div>
+  </div>
+</div>"
+`;

--- a/frontend/tests/support-extraction/composer.test.js
+++ b/frontend/tests/support-extraction/composer.test.js
@@ -1,0 +1,207 @@
+// Task 4 of the PR1 extraction: the Composer generic core. Locks the rendered
+// shape (snapshot) plus the four behaviours the host relies on — Send arming,
+// the Send↔Stop swap, the "Uploading…" pill, and Enter vs Shift+Enter.
+import { expect, test } from "vitest";
+import { h } from "vue";
+import Composer from "../../src/components/chat/Composer.vue";
+import { mountWithPalette } from "./fixtures.js";
+
+const findComposer = (w) => w.findComponent(Composer);
+
+test("composer renders identically (light)", () => {
+	const w = mountWithPalette(Composer, {
+		modelValue: "hi",
+		placeholder: "Ask Jarvis…",
+		disclaimer: "Jarvis can make mistakes.",
+	});
+	expect(w.html()).toMatchSnapshot();
+});
+
+test("Send is armed once there is text", () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi" });
+	const send = w.find(".jv-sendbtn");
+	expect(send.exists()).toBe(true);
+	expect(send.attributes("disabled")).toBeUndefined();
+	expect(send.classes()).toContain("ready");
+});
+
+test("Send is disabled with an empty box and no attachments", () => {
+	const w = mountWithPalette(Composer, { modelValue: "   " });
+	const send = w.find(".jv-sendbtn");
+	expect(send.attributes("disabled")).toBeDefined();
+	expect(send.classes()).not.toContain("ready");
+});
+
+test("an attachment alone arms Send", () => {
+	const w = mountWithPalette(Composer, {
+		modelValue: "",
+		attachments: [{ key: 0, file_name: "a.pdf", removable: true }],
+	});
+	expect(w.find(".jv-sendbtn").attributes("disabled")).toBeUndefined();
+});
+
+test("the canSend prop overrides the derived value", () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi", canSend: false });
+	expect(w.find(".jv-sendbtn").attributes("disabled")).toBeDefined();
+});
+
+test("busy swaps Send for Stop and flips the hint", () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi", busy: true });
+	expect(w.find(".jv-sendbtn").exists()).toBe(false);
+	const stop = w.find('button[title="Stop generating"]');
+	expect(stop.exists()).toBe(true);
+	expect(w.text()).toContain("Stop");
+	expect(w.text()).not.toContain("Enter ↵");
+});
+
+test("Stop emits stop", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi", busy: true });
+	await w.find('button[title="Stop generating"]').trigger("click");
+	expect(findComposer(w).emitted("stop")).toHaveLength(1);
+});
+
+test("an uploading attachment renders the Uploading… pill", () => {
+	const w = mountWithPalette(Composer, {
+		attachments: [{ key: "uploading", uploading: true }],
+	});
+	expect(w.text()).toContain("Uploading…");
+});
+
+test("attachments render an image thumbnail, a file chip, and remove buttons", async () => {
+	const w = mountWithPalette(Composer, {
+		attachments: [
+			{ key: 0, file_name: "shot.png", preview_url: "/files/shot.png", removable: true },
+			{ key: 1, file_name: "report.pdf", removable: false },
+		],
+	});
+	const img = w.find("img");
+	expect(img.attributes("src")).toBe("/files/shot.png");
+	expect(w.text()).toContain("📎 report.pdf");
+	// only the removable one gets an ×
+	const removes = w.findAll("button").filter((b) => b.text() === "×");
+	expect(removes).toHaveLength(1);
+	await removes[0].trigger("click");
+	expect(findComposer(w).emitted("remove-attachment")[0]).toEqual([0]);
+});
+
+test("Enter submits, Shift+Enter does not", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi" });
+	const c = findComposer(w);
+	const ta = w.find("textarea");
+	await ta.trigger("keydown", { key: "Enter", shiftKey: true });
+	expect(c.emitted("submit")).toBeUndefined();
+	await ta.trigger("keydown", { key: "Enter" });
+	expect(c.emitted("submit")).toHaveLength(1);
+});
+
+// The contract chat depends on: the raw keydown reaches the host BEFORE the
+// built-in acts, so a host that claims the key (chat's mention navigation,
+// prompt history and its own Enter-to-send all preventDefault) never gets a
+// second, duplicate submit.
+test("the raw keydown is emitted first, and a host preventDefault suppresses submit", async () => {
+	const seen = [];
+	const w = mountWithPalette(Composer, {
+		modelValue: "hi",
+		onKeydown: (e) => {
+			seen.push(e.key);
+			e.preventDefault();
+		},
+	});
+	const c = findComposer(w);
+	await w.find("textarea").trigger("keydown", { key: "Enter" });
+	expect(seen).toEqual(["Enter"]);
+	expect(c.emitted("submit")).toBeUndefined();
+});
+
+test("a host that does NOT preventDefault still gets the built-in submit", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi", onKeydown: () => {} });
+	await w.find("textarea").trigger("keydown", { key: "Enter" });
+	expect(findComposer(w).emitted("submit")).toHaveLength(1);
+});
+
+test("a host preventDefault on paste suppresses the built-in image extraction", async () => {
+	const file = new File(["x"], "a.png", { type: "image/png" });
+	const w = mountWithPalette(Composer, {
+		modelValue: "",
+		onPaste: (e) => e.preventDefault(),
+	});
+	await w.find("textarea").trigger("paste", { clipboardData: { files: [file], items: [] } });
+	expect(findComposer(w).emitted("files-added")).toBeUndefined();
+});
+
+test("an unclaimed image paste emits files-added", async () => {
+	const file = new File(["x"], "a.png", { type: "image/png" });
+	const w = mountWithPalette(Composer, { modelValue: "" });
+	await w.find("textarea").trigger("paste", { clipboardData: { files: [file], items: [] } });
+	expect(findComposer(w).emitted("files-added")[0][0]).toEqual([file]);
+});
+
+test("typing emits update:modelValue then the raw input event", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "" });
+	const c = findComposer(w);
+	const ta = w.find("textarea");
+	await ta.setValue("ab");
+	expect(c.emitted("update:modelValue")[0]).toEqual(["ab"]);
+	expect(c.emitted("input")).toHaveLength(1);
+});
+
+test("Send click emits submit", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi" });
+	await w.find(".jv-sendbtn").trigger("click");
+	expect(findComposer(w).emitted("submit")).toHaveLength(1);
+});
+
+test("drop emits files-added and never uploads", async () => {
+	const w = mountWithPalette(Composer, { modelValue: "" });
+	const c = findComposer(w);
+	const file = new File(["x"], "a.png", { type: "image/png" });
+	await w.find(".jv-composer").trigger("drop", { dataTransfer: { files: [file] } });
+	expect(c.emitted("files-added")[0][0]).toEqual([file]);
+});
+
+test("the default #left-toolbar is an attach button; a host slot replaces it", () => {
+	const plain = mountWithPalette(Composer, {});
+	expect(plain.find('button[title="Attach file"]').exists()).toBe(true);
+	// Chat takes the slot over (mic + its own 📎 + wiki) and drives the file
+	// input through the `pickFiles` slot prop, so the default must yield.
+	let slotProps = null;
+	const slotted = mountWithPalette(
+		Composer,
+		{},
+		{
+			slots: {
+				"left-toolbar": (p) => {
+					slotProps = p;
+					return h("button", { class: "host-mic" }, "mic");
+				},
+			},
+		}
+	);
+	expect(slotted.find(".host-mic").exists()).toBe(true);
+	expect(slotted.find('button[title="Attach file"]').exists()).toBe(false);
+	expect(typeof slotProps.pickFiles).toBe("function");
+});
+
+test("the #above / #overlay / #footer slots render at their positions", () => {
+	const w = mountWithPalette(
+		Composer,
+		{ disclaimer: "fine print" },
+		{
+			slots: {
+				above: () => h("div", { class: "s-above" }, "nudge"),
+				overlay: () => h("div", { class: "s-overlay" }, "mentions"),
+				footer: () => h("div", { class: "s-footer" }, "foot"),
+			},
+		}
+	);
+	const html = w.html();
+	expect(html.indexOf("s-above")).toBeLessThan(html.indexOf("jv-composer"));
+	// the overlay sits inside the box, above the textarea
+	expect(html.indexOf("s-overlay")).toBeLessThan(html.indexOf("<textarea"));
+	expect(html.indexOf("fine print")).toBeLessThan(html.indexOf("s-footer"));
+});
+
+test("dark render", () => {
+	const w = mountWithPalette(Composer, { modelValue: "hi" }, { dark: true });
+	expect(w.html()).toMatchSnapshot();
+});

--- a/frontend/tests/support-extraction/composer.test.js
+++ b/frontend/tests/support-extraction/composer.test.js
@@ -2,11 +2,22 @@
 // shape (snapshot) plus the four behaviours the host relies on — Send arming,
 // the Send↔Stop swap, the "Uploading…" pill, and Enter vs Shift+Enter.
 import { expect, test } from "vitest";
-import { h } from "vue";
+import { mount } from "@vue/test-utils";
+import { h, ref } from "vue";
 import Composer from "../../src/components/chat/Composer.vue";
 import { mountWithPalette } from "./fixtures.js";
 
 const findComposer = (w) => w.findComponent(Composer);
+
+// `mountWithPalette` bakes props into a wrapper's render fn, so `setProps` on
+// it can't reach the Composer. These tests drive props directly instead (the
+// palette vars are irrelevant to height math and to the expose contract).
+const mountBare = (props = {}) => mount(Composer, { props });
+
+// jsdom never lays anything out, so scrollHeight is a hard 0 — stub it, or
+// auto-grow measures nothing and every assertion below passes vacuously.
+const stubScrollHeight = (el, value) =>
+	Object.defineProperty(el, "scrollHeight", { value, configurable: true });
 
 test("composer renders identically (light)", () => {
 	const w = mountWithPalette(Composer, {
@@ -84,6 +95,30 @@ test("attachments render an image thumbnail, a file chip, and remove buttons", a
 	expect(findComposer(w).emitted("remove-attachment")[0]).toEqual([0]);
 });
 
+// The index alignment that chat's adapter depends on. `pendingFiles` goes over
+// the wire verbatim, so ChatView projects it through a `composerAttachments`
+// computed and appends the "Uploading…" pill LAST; `removeFile(i)` splices
+// `pendingFiles` by that same index. If the pill were ever prepended (or made
+// removable) every × would splice the wrong file. The existing thumbnail/chip
+// test has no pill, so this is the only case that can break.
+test("remove-attachment emits the right index while an Uploading… pill is present", async () => {
+	const w = mountWithPalette(Composer, {
+		attachments: [
+			{ key: 0, file_name: "a.pdf", removable: true },
+			{ key: 1, file_name: "b.pdf", removable: true },
+			{ key: "uploading", uploading: true },
+		],
+	});
+	const c = findComposer(w);
+	expect(w.text()).toContain("Uploading…");
+	// the pill is NOT removable: exactly two × buttons for two real chips
+	const removes = w.findAll("button").filter((b) => b.text() === "×");
+	expect(removes).toHaveLength(2);
+	await removes[1].trigger("click");
+	await removes[0].trigger("click");
+	expect(c.emitted("remove-attachment")).toEqual([[1], [0]]);
+});
+
 test("Enter submits, Shift+Enter does not", async () => {
 	const w = mountWithPalette(Composer, { modelValue: "hi" });
 	const c = findComposer(w);
@@ -136,11 +171,21 @@ test("an unclaimed image paste emits files-added", async () => {
 	expect(findComposer(w).emitted("files-added")[0][0]).toEqual([file]);
 });
 
-test("typing emits update:modelValue then the raw input event", async () => {
-	const w = mountWithPalette(Composer, { modelValue: "" });
+// ORDER is the contract, not just "both fired": v-model's own listener is
+// registered by the directive before @input is patched on, so the host sees the
+// raw `input` event with the new value ALREADY committed upstream. Chat's
+// onInput reads `input.value` to parse @/ mentions off the caret; flip the
+// order and it parses the previous keystroke's text.
+test("typing emits update:modelValue BEFORE the raw input event", async () => {
+	const order = [];
+	const w = mountWithPalette(Composer, {
+		modelValue: "",
+		"onUpdate:modelValue": (v) => order.push(`update:modelValue(${v})`),
+		onInput: () => order.push("input"),
+	});
 	const c = findComposer(w);
-	const ta = w.find("textarea");
-	await ta.setValue("ab");
+	await w.find("textarea").setValue("ab");
+	expect(order).toEqual(["update:modelValue(ab)", "input"]);
 	expect(c.emitted("update:modelValue")[0]).toEqual(["ab"]);
 	expect(c.emitted("input")).toHaveLength(1);
 });
@@ -199,6 +244,83 @@ test("the #above / #overlay / #footer slots render at their positions", () => {
 	// the overlay sits inside the box, above the textarea
 	expect(html.indexOf("s-overlay")).toBeLessThan(html.indexOf("<textarea"));
 	expect(html.indexOf("fine print")).toBeLessThan(html.indexOf("s-footer"));
+});
+
+// ---- auto-grow ----------------------------------------------------------
+// Ten explicit autoGrow() calls in ChatView collapsed into ONE
+// watch(modelValue, autoGrow, {flush:"post"}) plus the inline call in the input
+// handler. Every programmatic set — restored draft, dictation transcript,
+// prompt-history recall, the clear after send — now reaches the textarea only
+// through that watcher, so a dropped watcher or the wrong flush timing (which
+// would measure the pre-update DOM) is a silent regression.
+test("a programmatic modelValue change grows the box, clamped to the default maxHeight", async () => {
+	const w = mountBare({ modelValue: "" });
+	const ta = w.find("textarea");
+	stubScrollHeight(ta.element, 400);
+	await w.setProps({ modelValue: "x\ny\nz" });
+	// 140 is Composer's declared default for the `maxHeight` prop.
+	expect(ta.element.style.height).toBe("140px");
+});
+
+test("a shorter value shrinks the box back (height is recomputed, not only raised)", async () => {
+	const w = mountBare({ modelValue: "" });
+	const ta = w.find("textarea");
+	stubScrollHeight(ta.element, 400);
+	await w.setProps({ modelValue: "x\ny\nz" });
+	expect(ta.element.style.height).toBe("140px");
+	stubScrollHeight(ta.element, 30);
+	await w.setProps({ modelValue: "x" });
+	expect(ta.element.style.height).toBe("30px");
+});
+
+// Guards flush:"post" specifically. scrollHeight here is derived from the
+// element's LIVE value, so a pre-flush watcher measures the textarea before Vue
+// has written the new text into it and lands one value behind.
+test("the watcher measures the textarea AFTER the DOM update (flush: post)", async () => {
+	const w = mountBare({ modelValue: "" });
+	const ta = w.find("textarea");
+	Object.defineProperty(ta.element, "scrollHeight", {
+		get: () => 20 * String(ta.element.value || "").split("\n").length,
+		configurable: true,
+	});
+	await w.setProps({ modelValue: "a\nb\nc" });
+	expect(ta.element.style.height).toBe("60px");
+});
+
+test("the maxHeight prop moves both the auto-grow clamp and the inline max-height", async () => {
+	const w = mountBare({ modelValue: "", maxHeight: 300 });
+	const ta = w.find("textarea");
+	expect(ta.element.style.maxHeight).toBe("300px");
+	stubScrollHeight(ta.element, 400);
+	await w.setProps({ modelValue: "x\ny\nz" });
+	expect(ta.element.style.height).toBe("300px");
+});
+
+// ---- the defineExpose contract ChatView reaches through ------------------
+// 8 × composerRef.value?.focusInput() and 3 × composerRef.value?.el (caret math
+// for mention insertion and edit-and-resend). Both are optional-chained at
+// every call site, so renaming either one fails SILENTLY. Mounted through a
+// template ref, i.e. exactly how ChatView holds it.
+test("expose gives the host the raw textarea as `el` plus focusInput()", () => {
+	const composerRef = ref(null);
+	// attachTo: jsdom only moves activeElement for a node that is in the document.
+	const w = mount(
+		{
+			render() {
+				return h(Composer, { ref: composerRef, modelValue: "hi" });
+			},
+		},
+		{ attachTo: document.body }
+	);
+	const exposed = composerRef.value;
+	expect(exposed).toBeTruthy();
+	// unwrapped by Vue's expose proxy — a live DOM node, not a Ref
+	expect(exposed.el).toBe(w.find("textarea").element);
+	expect(exposed.el.tagName).toBe("TEXTAREA");
+	expect(typeof exposed.focusInput).toBe("function");
+	exposed.focusInput();
+	expect(document.activeElement).toBe(exposed.el);
+	w.unmount();
 });
 
 test("dark render", () => {

--- a/frontend/tests/support-extraction/fixtures.js
+++ b/frontend/tests/support-extraction/fixtures.js
@@ -1,0 +1,86 @@
+// Fixture message data + the mount helper shared by every support-extraction
+// snapshot test. See docs/superpowers/plans/2026-07-24-support-ui-pr1-extraction.md
+// (Task 1) for the contract this file implements.
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import { LIGHT_VARS, DARK_VARS } from "../../src/theme.js";
+
+// A plain user chat bubble with one image attachment, matching the shape of
+// a ChatView message object (`m.content` / `m.canvas`).
+export const USER_MSG = {
+	name: "msg-user-1",
+	role: "user",
+	content: "Can you summarise the attached screenshot and open a ticket for it?",
+	canvas: [
+		{
+			name: "cv-1",
+			type: "image",
+			title: "screenshot.png",
+			file_url: "/files/screenshot.png",
+		},
+	],
+};
+
+// Assistant markdown covering every element the `.jv-md` body styling
+// targets: heading, list, code block, table, link, image.
+export const ASSISTANT_MSG = {
+	name: "msg-assistant-1",
+	role: "assistant",
+	content: [
+		"## Summary",
+		"",
+		"Here is what I found:",
+		"",
+		"- First item",
+		"- Second item with `inline code`",
+		"",
+		"```js",
+		"console.log('hello');",
+		"```",
+		"",
+		"| Field | Value |",
+		"| --- | --- |",
+		"| Status | Open |",
+		"",
+		"See the [ticket](https://example.com/ticket/1) for details.",
+		"",
+		"![diagram](/files/diagram.png)",
+	].join("\n"),
+};
+
+// Bare Helpdesk HTML — no markdown pipeline, just the raw `<p>/<ul>/<a>`
+// tags a Helpdesk ticket body ships as. Exercises the `.jv-html` body seam
+// (Task 3) that restores element-level styling Tailwind preflight strips.
+export const SUPPORT_HTML_MSG = {
+	name: "msg-support-1",
+	role: "assistant",
+	html: [
+		"<p>Thanks for reaching out. Here is what we found:</p>",
+		"<ul><li>Step one</li><li>Step two</li></ul>",
+		'<p>See <a href="https://example.com/kb/1">this article</a> for more.</p>',
+	].join(""),
+};
+
+export const PALETTE_LIGHT = LIGHT_VARS;
+export const PALETTE_DARK = DARK_VARS;
+
+export const varsToStyle = (v) =>
+	Object.entries(v)
+		.map(([k, val]) => `${k}:${val}`)
+		.join(";");
+
+// Mounts `Component` inside a `.jv-root` wrapper with the palette vars bound
+// inline (mirroring ChatView's `:style="paletteVars"` root), so extracted
+// children can resolve `var(--…)` by cascade exactly like they do in the app.
+export function mountWithPalette(Component, props = {}, { dark = false, slots = {} } = {}) {
+	const vars = dark ? DARK_VARS : LIGHT_VARS;
+	return mount({
+		render() {
+			return h(
+				"div",
+				{ class: ["jv-root", { "jv-dark": dark }], style: varsToStyle(vars) },
+				[h(Component, props, slots)]
+			);
+		},
+	});
+}

--- a/frontend/tests/support-extraction/harness.md
+++ b/frontend/tests/support-extraction/harness.md
@@ -1,0 +1,44 @@
+# Support-extraction verification harness
+
+Copy-run this checklist for every extraction task (Tasks 2-4) in
+`docs/superpowers/plans/2026-07-24-support-ui-pr1-extraction.md`. It backs up
+the "chat must be byte-identical" constraint three ways: a vitest snapshot
+(automated), a mechanical CSS orphan-sweep (automated grep, manual read), and
+a manual light/dark/mobile pass (human).
+
+## (a) Orphan-sweep procedure
+
+When a template block moves out of `ChatView.vue` into a shared component,
+every CSS rule that targeted it must move too — nothing should be left
+behind "orphaned" (dead) in `ChatView.vue`'s `<style scoped>`, and nothing
+should be missing from the new component's `<style scoped>`.
+
+For every `class="…"` token used in the moved template:
+
+1. `grep -n '<class>' src/views/ChatView.vue`
+2. For each hit inside the `<style scoped>` block, confirm the class is not
+   the **last selector element** of any remaining rule (e.g. `.jv-umsg:hover
+   .jv-msgbar` is a hit on `jv-msgbar` but is fine to leave if `.jv-msgbar`
+   itself moved — the *trigger* class staying in ChatView is expected; the
+   *rule that paints `.jv-msgbar`* must not remain).
+3. Explicitly re-run the grep against:
+   - the dark-mode block (`.jv-dark …`, roughly `~10589-10700` — locate by
+     content, line numbers drift)
+   - every `@media` block (hover-capability, max-width breakpoints)
+4. Confirm the same rules exist, verbatim or adapted, in the new component's
+   `<style scoped>`.
+5. Zero orphaned rules is the bar — not "close enough".
+
+## (b) Manual pass
+
+Exercise the task's interaction checklist (see the task's own "Orphan sweep
++ manual pass" step in the plan) in all three of:
+
+- **Light** theme
+- **Dark** theme
+- **Mobile** width (≤720px)
+
+Compare against `develop` (pre-extraction) side by side or from memory of
+the last-verified state. The result must be indistinguishable — same
+spacing, same colors, same hover/focus states, same behavior. Any visual or
+behavioral diff is a bug in the extraction, not an acceptable regression.

--- a/frontend/tests/support-extraction/harness.test.js
+++ b/frontend/tests/support-extraction/harness.test.js
@@ -1,0 +1,26 @@
+// Sanity test for the verification harness itself (Task 1, Step 5) — proves
+// mountWithPalette works before any component extraction happens.
+import { expect, test } from "vitest";
+import { h } from "vue";
+import { mountWithPalette } from "./fixtures.js";
+
+const Trivial = {
+	name: "Trivial",
+	render() {
+		return h("div", { class: "trivial-probe" }, "hi");
+	},
+};
+
+test("mountWithPalette wraps the component in .jv-root with palette vars bound", () => {
+	const w = mountWithPalette(Trivial);
+	expect(w.classes()).toContain("jv-root");
+	expect(w.attributes("style")).toContain("--cta:");
+	expect(w.find(".trivial-probe").text()).toBe("hi");
+});
+
+test("mountWithPalette({ dark: true }) adds jv-dark and swaps the palette", () => {
+	const w = mountWithPalette(Trivial, {}, { dark: true });
+	expect(w.classes()).toContain("jv-root");
+	expect(w.classes()).toContain("jv-dark");
+	expect(w.attributes("style")).toContain("--cta:");
+});

--- a/frontend/tests/support-extraction/message-bubble.test.js
+++ b/frontend/tests/support-extraction/message-bubble.test.js
@@ -79,8 +79,9 @@ test("clicking an image attachment emits open-attachment with the canvas record"
 	expect(emitted[0][0]).toEqual(USER_MSG.canvas[0]);
 });
 
-test("variant=row renders nothing yet (Task 3 stub)", () => {
+test("variant=row now renders the assistant body (Task 3, no longer a stub)", () => {
 	const w = mountWithPalette(Message, { variant: "row", html: "<p>hi</p>" });
-	expect(w.find(".jv-umsg").exists()).toBe(false);
-	expect(w.text()).toBe("");
+	expect(w.find(".jv-umsg").exists()).toBe(false); // not the bubble path
+	expect(w.find(".jv-md-body").exists()).toBe(true);
+	expect(w.html()).toContain("hi");
 });

--- a/frontend/tests/support-extraction/message-bubble.test.js
+++ b/frontend/tests/support-extraction/message-bubble.test.js
@@ -1,0 +1,86 @@
+// Snapshot + interaction tests for Message.vue's variant="bubble" path (the
+// chat user row extracted in Task 2 of docs/superpowers/plans/2026-07-24-
+// support-ui-pr1-extraction.md). variant="row" is stubbed empty until Task 3.
+import { expect, test } from "vitest";
+import Message from "../../src/components/chat/Message.vue";
+import { mountWithPalette, USER_MSG } from "./fixtures.js";
+
+test("user bubble renders identically (light)", () => {
+	const w = mountWithPalette(Message, {
+		variant: "bubble",
+		text: USER_MSG.content,
+		attachments: USER_MSG.canvas,
+		timestamp: "9:12",
+		editable: true,
+	});
+	expect(w.html()).toMatchSnapshot();
+});
+
+test("user bubble renders identically (dark)", () => {
+	const w = mountWithPalette(
+		Message,
+		{
+			variant: "bubble",
+			text: USER_MSG.content,
+			attachments: USER_MSG.canvas,
+			timestamp: "9:12",
+			editable: true,
+		},
+		{ dark: true }
+	);
+	expect(w.html()).toMatchSnapshot();
+});
+
+test("failed user bubble shows retry", () => {
+	const w = mountWithPalette(Message, { variant: "bubble", text: "x", failed: true });
+	expect(w.text()).toContain("Not sent");
+	expect(w.text()).toContain("Retry");
+});
+
+test("failed user bubble emits retry on click", async () => {
+	const w = mountWithPalette(Message, { variant: "bubble", text: "x", failed: true });
+	await w.find("button").trigger("click");
+	expect(w.findComponent(Message).emitted("retry")).toBeTruthy();
+});
+
+test("copy button reflects the copied prop and emits copy", async () => {
+	const w = mountWithPalette(Message, { variant: "bubble", text: "hi", copied: true });
+	expect(w.find(".jv-msgtime").exists()).toBe(false); // no timestamp passed
+	const copyBtn = w.findAll(".jv-msgbtn").at(-1);
+	await copyBtn.trigger("click");
+	expect(w.findComponent(Message).emitted("copy")).toBeTruthy();
+});
+
+test("editable gates the Edit button; non-editable hides it", () => {
+	const editableWrap = mountWithPalette(Message, {
+		variant: "bubble",
+		text: "hi",
+		editable: true,
+	});
+	expect(editableWrap.findAll(".jv-msgbtn").length).toBe(2); // edit + copy
+
+	const readOnlyWrap = mountWithPalette(Message, {
+		variant: "bubble",
+		text: "hi",
+		editable: false,
+	});
+	expect(readOnlyWrap.findAll(".jv-msgbtn").length).toBe(1); // copy only
+});
+
+test("clicking an image attachment emits open-attachment with the canvas record", async () => {
+	const w = mountWithPalette(Message, {
+		variant: "bubble",
+		text: "see attached",
+		attachments: USER_MSG.canvas,
+	});
+	await w.find(".jv-img-artifact").trigger("click");
+	const emitted = w.findComponent(Message).emitted("open-attachment");
+	expect(emitted).toBeTruthy();
+	expect(emitted[0][0]).toEqual(USER_MSG.canvas[0]);
+});
+
+test("variant=row renders nothing yet (Task 3 stub)", () => {
+	const w = mountWithPalette(Message, { variant: "row", html: "<p>hi</p>" });
+	expect(w.find(".jv-umsg").exists()).toBe(false);
+	expect(w.text()).toBe("");
+});

--- a/frontend/tests/support-extraction/message-row.test.js
+++ b/frontend/tests/support-extraction/message-row.test.js
@@ -1,0 +1,112 @@
+// Snapshot + interaction tests for Message.vue's variant="row" path (the
+// assistant / support-agent row extracted in Task 3 of docs/superpowers/plans/
+// 2026-07-24-support-ui-pr1-extraction.md). Covers BOTH body seams: the chat
+// markdown body (bodyClass="jv-md") and the bare Helpdesk HTML body
+// (bodyClass="jv-html"), which PR2's Support page relies on.
+import { expect, test } from "vitest";
+import { h } from "vue";
+import Message from "../../src/components/chat/Message.vue";
+import { renderMarkdown } from "../../src/markdown.js";
+import { mountWithPalette, ASSISTANT_MSG, SUPPORT_HTML_MSG } from "./fixtures.js";
+
+test("assistant markdown row renders identically (light)", () => {
+	const w = mountWithPalette(Message, {
+		variant: "row",
+		html: renderMarkdown(ASSISTANT_MSG.content),
+		bodyClass: "jv-md",
+		timestamp: "9:12",
+	});
+	expect(w.html()).toMatchSnapshot();
+});
+
+test("assistant markdown row renders identically (dark)", () => {
+	const w = mountWithPalette(
+		Message,
+		{
+			variant: "row",
+			html: renderMarkdown(ASSISTANT_MSG.content),
+			bodyClass: "jv-md",
+			timestamp: "9:12",
+		},
+		{ dark: true }
+	);
+	expect(w.html()).toMatchSnapshot();
+});
+
+test("markdown body carries the jv-md-body + jv-md seam classes", () => {
+	const w = mountWithPalette(Message, {
+		variant: "row",
+		html: renderMarkdown(ASSISTANT_MSG.content),
+		bodyClass: "jv-md",
+	});
+	const body = w.find(".jv-md-body");
+	expect(body.exists()).toBe(true);
+	expect(body.classes()).toContain("jv-md");
+	// the markdown pipeline produced the classed elements the :deep() rules target
+	expect(body.find(".jv-md-h").exists()).toBe(true);
+	expect(body.find(".jv-md-list").exists()).toBe(true);
+});
+
+test("support HTML row applies the jv-html body seam", () => {
+	const w = mountWithPalette(Message, {
+		variant: "row",
+		html: SUPPORT_HTML_MSG.html,
+		bodyClass: "jv-html",
+		sender: "Priya",
+		role: "Support",
+		timestamp: "9:12",
+	});
+	const body = w.find(".jv-md-body");
+	expect(body.exists()).toBe(true);
+	// the seam class is applied (its :deep block restores element-level styling
+	// that Tailwind preflight strips off bare Helpdesk HTML)
+	expect(body.classes()).toContain("jv-html");
+	expect(body.classes()).not.toContain("jv-md");
+	// the bare list + link actually render under it
+	expect(body.find("ul").exists()).toBe(true);
+	expect(body.find("li").exists()).toBe(true);
+	const a = body.find("a");
+	expect(a.exists()).toBe(true);
+	expect(a.attributes("href")).toBe("https://example.com/kb/1");
+});
+
+test("row shows the identity line only when a sender is passed", () => {
+	const withSender = mountWithPalette(Message, {
+		variant: "row",
+		html: "<p>hi</p>",
+		sender: "Priya",
+		role: "Support",
+	});
+	expect(withSender.find(".jv-msg-who").exists()).toBe(true);
+	expect(withSender.text()).toContain("Priya");
+
+	const noSender = mountWithPalette(Message, { variant: "row", html: "<p>hi</p>" });
+	expect(noSender.find(".jv-msg-who").exists()).toBe(false);
+});
+
+test("row Copy bar emits copy and never offers Edit", async () => {
+	// with no #below-body slot the built-in trailer (support use) renders; the
+	// row is not editable, so there is a Copy button but no Edit button.
+	const w = mountWithPalette(Message, {
+		variant: "row",
+		html: "<p>hi</p>",
+		timestamp: "9:12",
+	});
+	const copyBtn = w.find(".jv-msgbtn");
+	expect(copyBtn.exists()).toBe(true);
+	expect(copyBtn.attributes("title")).toBe("Copy");
+	await copyBtn.trigger("click");
+	expect(w.findComponent(Message).emitted("copy")).toBeTruthy();
+});
+
+test("#below-body slot suppresses the built-in trailer (chat owns that region)", () => {
+	// chat supplies #below-body (its own metabar/canvas live there); the
+	// component must NOT also render its built-in Copy bar, or it would double.
+	const w = mountWithPalette(
+		Message,
+		{ variant: "row", html: "<p>hi</p>", timestamp: "9:12" },
+		{ slots: { "below-body": () => h("div", { class: "chat-metabar" }, "meta") } }
+	);
+	expect(w.find(".chat-metabar").exists()).toBe(true);
+	expect(w.find(".jv-msgbar").exists()).toBe(false); // built-in trailer suppressed
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import vue from "@vitejs/plugin-vue";
+import path from "path";
+
+// `src/theme.js` (and other app modules the extracted components will pull
+// in) import via the `@/…` alias that vite.config.js defines for the real
+// build. vitest doesn't share that config, so it's redeclared here — without
+// it, importing theme.js fails to resolve `@/api`.
+export default defineConfig({
+	plugins: [vue()],
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "src"),
+		},
+	},
+	test: {
+		environment: "jsdom",
+		include: ["tests/support-extraction/**/*.test.js"],
+		globals: true,
+	},
+});


### PR DESCRIPTION
**PR1 of 2** for the support UI rebuild. This one is *extraction only* — it changes nothing about how chat looks or behaves. PR2 builds the new standalone support page on top of what this exposes.

## Why

The support UI is being rebuilt as a standalone, shell-less page (no Jarvis sidebar), list → detail, with human agents on the other end. The binding requirement for it:

> keep it DRY and don't reinvent the wheel everytime, try to reuse the same components from the jarvis chat, **so that any change will affect both end**

That only works if the support page consumes the *actual* chat components. So `Message` and `Composer` come out of the 11.5k-line `ChatView.vue` first, with chat as their first consumer — proving they still render chat exactly as before.

## What's here

| | |
|---|---|
| `components/chat/Message.vue` | `variant="bubble"` (user) and `variant="row"` (assistant). Slots: `#avatar`, `#above-body`, `#below-body`. `bodyClass` selects `jv-md` (markdown) or `jv-html` (raw Helpdesk email HTML — the seam PR2 needs). 36 `.jv-md` rules migrated out of ChatView as `.jv-md-body.jv-md :deep(…)`. |
| `components/chat/Composer.vue` | Generic core only. **It never uploads** — it emits `files-added` and the host owns the upload. Chat's mic, `@`/`/` mentions, wiki-ground, paste hint and nudge card stay in ChatView and are injected through `#left-toolbar` / `#overlay` / `#above` / `#footer`. |
| `tests/support-extraction/` | vitest + jsdom harness, 43 tests, 4 snapshot files. |

`ChatView.vue` is ~1370 lines lighter and consumes both.

## How "chat is unchanged" was established

Every task got a fresh implementer, then an independent reviewer, then a whole-branch adversarial review. Findings were fixed, not waived. What the reviews actually verified rather than assumed:

- **Every moved CSS rule audited to its new home** — zero orphans, zero rules that stopped matching or started matching more, no `.jv-dark` variant left behind, no specificity inversion from splitting grouped selectors. This matters because `<style scoped>` stamps `data-v-*` on the *last* element of a selector, and slot content carries the **parent's** scope id, so slotted nodes need `:deep()`.
- **Wire payload is byte-identical** — `pendingFiles` is passed to `api.sendMessage()` verbatim, so it is deliberately *not* reshaped for display; a computed adapter projects it and a test locks the removal-index alignment with the uploading pill present.
- **No double-send and no double-paste-upload** — chat's `onKey`/`onPaste` `preventDefault()` synchronously before the built-ins can act.
- **Auto-grow runs twice per keystroke on purpose** — `v-model` suppresses updates during IME composition, so the inline call is the only grower mid-compose. Documented at the call site so it doesn't get "optimised" away.

Each new test was mutation-verified: drop the auto-grow watcher, flip `flush:"post"`→pre, rename the exposed `el`, make the uploading pill removable, reorder the emits — each mutation fails exactly one named test.

## ⚠️ One knowing change outside chat

Relocating the `.jv-root` base rules into the shared `main.css` widened `color-scheme` from ChatView-scoped to global. Three other elements carry `jv-root` — `SettingsDialog`, `ConfirmDialog`, `SkillDetail` — and they are siblings of ChatView, so they never got it before. In dark mode their **native** controls (selects, scrollbars, date pickers) now follow the dark scheme instead of rendering browser-default light.

This is almost certainly a fix for the white-select-in-a-dark-dialog blemish, and the relocation is the right seam for PR2 — but it is customer-visible and outside chat, so it is called out rather than buried. It's on the manual checklist below.

## Not yet done

**No browser pass has been run** — jsdom + `npm run build` only. jsdom never computes styles, so the CSS-migration risk is covered by the manual audit above, not by the 43 green tests. Before merge: light/dark/mobile, mic, mention dropdown open **with attachments attached**, wiki toggle, drag/paste, Send↔Stop, prompt-history ↑/↓ on a multi-line recall, focus-after-upload, and the dark settings dialog.

Known deferrals, both argued in review: `.jv-iconbtn` stays triplicated (a plain hoist would flip the settings dialog's Close button to a hard invert — a namespaced hoist is the PR2-or-later cleanup), and these tests aren't wired into CI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)