### PR TITLE
Dashboards: per-theme spec + enforced theme conformance on the generated canvas

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,8 @@
         "dompurify": "^3.4.11",
         "echarts": "^5.5.0",
         "frappe-ui": "0.1.278",
+        "html-to-image": "^1.11.13",
+        "jspdf": "^4.2.1",
         "mermaid": "^11.15.0",
         "socket.io-client": "^4.7.5",
         "vue": "^3.4.21",
@@ -35,10 +37,6 @@
         "graphology-metrics": "^2.4.0",
         "vue": "^3.4.0"
       }
-    },
-    "../wiki-graph-probe": {
-      "version": "0.0.0",
-      "extraneous": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -88,7 +86,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -97,6 +94,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -529,7 +535,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1174,7 +1179,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
       "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1257,7 +1261,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
       "integrity": "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1453,7 +1456,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
       "integrity": "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1641,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz",
       "integrity": "sha512-J48WIl+6YDYTFPhWXUBQk+u7+AKVUqTdvrZOQyPYCGuQMgHrYzgWrI5+HeEifUgXJ5rMIWWP3qytp7KhVVqpDQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1681,7 +1682,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
       "integrity": "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1696,7 +1696,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
       "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -1758,7 +1757,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.27.1.tgz",
       "integrity": "sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2063,6 +2061,19 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2160,7 +2171,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
       "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@vue/compiler-core": "3.5.38",
@@ -2455,6 +2465,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2543,7 +2563,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -2611,6 +2630,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2744,6 +2783,16 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2767,7 +2816,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3168,7 +3216,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3524,6 +3571,17 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3559,6 +3617,12 @@
         "classnames": "^2.2.5",
         "core-js": "^3.1.3"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3734,9 +3798,28 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3810,6 +3893,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3894,7 +3983,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3904,6 +3992,23 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.47",
@@ -4009,7 +4114,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -4297,6 +4401,22 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -4314,6 +4434,13 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4397,7 +4524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4778,6 +4904,16 @@
         "vue": ">= 3.2.0"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4824,6 +4960,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/reka-ui": {
       "version": "2.10.0",
@@ -4936,6 +5079,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/robust-predicates": {
@@ -5120,6 +5273,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5214,12 +5377,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5275,6 +5447,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -5588,6 +5770,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/uuid": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -5607,7 +5799,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5667,7 +5858,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
       "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/compiler-sfc": "3.5.38",
@@ -5689,7 +5879,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "dompurify": "^3.4.11",
     "echarts": "^5.5.0",
     "frappe-ui": "0.1.278",
+    "html-to-image": "^1.11.13",
+    "jspdf": "^4.2.1",
     "mermaid": "^11.15.0",
     "socket.io-client": "^4.7.5",
     "vue": "^3.4.21",

--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -1,0 +1,106 @@
+// Dashboards-page API wrappers - thin bindings around `jarvis.chat.dashboards_api.*`
+// (src/api.js is frozen - new endpoints get per-feature modules under src/api/,
+// the api/triggers.js convention). CRUD endpoints answer with the {ok, data}
+// envelope and are unwrapped here; the two data-execution endpoints
+// (runDashboardSource / callDashboardTool) are passed through UN-unwrapped
+// because their {ok:false, error:{code, message}} arm is load-bearing - the
+// canvas maps those codes onto per-widget errors inside the iframe.
+import { call } from "frappe-ui"
+
+const DB = "jarvis.chat.dashboards_api."
+
+// {ok, data} → data (defensive: a bare payload passes through untouched)
+function unwrap(res) {
+	return res && typeof res === "object" && res.data !== undefined ? res.data : res
+}
+
+// Same request-arg normalizer as src/api.js `_page` (search/filters/sort/paging;
+// `filters` JSON-encoded so the server `frappe.parse_json`s it).
+const _page = (p = {}) => ({
+	search: p.search || "",
+	filters: JSON.stringify(p.filters || {}),
+	sort_field: p.sort_field || "",
+	sort_dir: p.sort_dir || "",
+	start: p.start || 0,
+	page_length: p.page_length || 20,
+})
+
+// ── caps probe ────────────────────────────────────────────────────────────────
+// -> {creatable_scopes: ["User", ...], manageable_roles: [...], max_sources,
+//     max_html_chars, max_rows, canvas_available}
+export const getDashboardsCaps = () => call(DB + "get_dashboards_caps").then(unwrap)
+
+// ── dashboards ────────────────────────────────────────────────────────────────
+// rows: {name, dashboard_title, description, dashboard_type, scope, target_role,
+//        target_user, owner, modified}. Allowed filter keys ONLY: scope,
+// dashboard_type, owner - unknown keys throw, so callers peel `search` out of
+// filters before calling (the MacrosList idiom).
+export const listDashboardsPage = (p) => call(DB + "list_dashboards_page", _page(p)).then(unwrap)
+
+// full detail: rows fields + html, sources:[{source_name, tool, spec}],
+// source_conversation, can_edit
+export const getDashboard = (name) => call(DB + "get_dashboard", { name }).then(unwrap)
+
+// payload keys: {name?, dashboard_title, description?, html, scope?,
+// target_role?, sources?, source_conversation?} - unknown keys throw;
+// dashboard_type is derived server-side. -> full detail
+export const saveDashboard = (payload = {}) =>
+	call(DB + "save_dashboard", { payload: JSON.stringify(payload) }).then(unwrap)
+
+export const deleteDashboard = (name) => call(DB + "delete_dashboard", { name }).then(unwrap)
+
+// View-mode data: executes the SERVER-stored spec for one named source.
+// -> {ok:true, data:{source_name, tool, rows, columns? (run_report only),
+//     truncated, took_ms}}
+//  | {ok:false, error:{code:"PermissionError"|"InvalidArgumentError"|"NotFound"
+//     |"InternalError", message}}   (envelope passed through, NOT unwrapped)
+export const runDashboardSource = (dashboard, source_name) =>
+	call(DB + "run_dashboard_source", { dashboard, source_name })
+
+// Builder-mode ad-hoc data: the iframe's declared spec executed directly via
+// the generic tool endpoint. Client-side whitelist mirrors what dashboards may
+// declare; anything else short-circuits to the same error envelope shape.
+// -> {ok, data} | {ok:false, error:{code, message}}  (NOT unwrapped)
+const DASH_TOOLS = ["query", "get_list", "run_report"]
+export const callDashboardTool = (tool, args = {}) => {
+	if (!DASH_TOOLS.includes(tool)) {
+		return Promise.resolve({
+			ok: false,
+			error: {
+				code: "InvalidArgumentError",
+				message: `Tool "${tool}" is not allowed in dashboards.`,
+			},
+		})
+	}
+	return call("jarvis.api.call_tool", { tool, args: JSON.stringify(args || {}) })
+}
+
+// ── chat pane (existing chat endpoints, reused - the triggers.js shape) ───────
+// api.js#sendMessage only forwards `context` when it carries a doctype, so the
+// dashboards pane binds send_message directly with its page context. Empty
+// conversation is allowed - the backend creates/focuses one and returns its id
+// as `conversation_id`. -> {ok, run_id, message_id, conversation_id} or
+// {ok: false, reason} (NOT the {ok, data} envelope - passed through as-is).
+// dataMode: "static" | "live" | anything else = Auto (backend forwards only the
+// two literal values). editingName: when revising a saved dashboard, its name —
+// forwarded as {doctype, name} so the agent gets a [Viewing:] line and reads the
+// current html/sources before changing them.
+export const sendDashboardChat = (conversation, message, dataMode = "", editingName = "") => {
+	const context = { page: "dashboards" }
+	if (dataMode === "static" || dataMode === "live") context.data_mode = dataMode
+	if (editingName) {
+		context.doctype = "Jarvis Dashboard"
+		context.name = editingName
+	}
+	return call("jarvis.chat.api.send_message", {
+		conversation: conversation || "",
+		message,
+		context: JSON.stringify(context),
+		background: 0,
+	})
+}
+
+// -> {conversation: {name, title, ...}, messages: [{name, seq, role, content,
+//     streaming, error, ...}]} - raises DoesNotExistError for a deleted chat.
+export const getDashboardConversation = (conversation) =>
+	call("jarvis.chat.api.get_conversation", { conversation })

--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -84,10 +84,19 @@ export const callDashboardTool = (tool, args = {}) => {
 // dataMode: "static" | "live" | anything else = Auto (backend forwards only the
 // two literal values). editingName: when revising a saved dashboard, its name —
 // forwarded as {doctype, name} so the agent gets a [Viewing:] line and reads the
-// current html/sources before changing them.
-export const sendDashboardChat = (conversation, message, dataMode = "", editingName = "") => {
+// current html/sources before changing them. theme: the selected theme key
+// (lowercase) — forwarded so the backend tells the agent which theme to design
+// for and the dashboards skill injects that theme's token+recipe cheatsheet.
+export const sendDashboardChat = (
+	conversation,
+	message,
+	dataMode = "",
+	editingName = "",
+	theme = "",
+) => {
 	const context = { page: "dashboards" }
 	if (dataMode === "static" || dataMode === "live") context.data_mode = dataMode
+	if (theme) context.theme = theme
 	if (editingName) {
 		context.doctype = "Jarvis Dashboard"
 		context.name = editingName

--- a/frontend/src/components/FilePreview.vue
+++ b/frontend/src/components/FilePreview.vue
@@ -37,7 +37,7 @@
 				<iframe
 					v-else-if="view.kind === 'html' || view.kind === 'svg'"
 					:srcdoc="view.content"
-					sandbox="allow-scripts allow-popups"
+					sandbox="allow-scripts"
 					class="h-[70vh] w-full bg-surface-white"
 					title="File preview"
 				/>

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -34,6 +34,7 @@
 			<Dialogs />
 			<SettingsDialog />
 			<JarvisCommandPalette />
+			<MoreMenu />
 			<NotifyToaster />
 			<ConfirmDialog />
 		</div>
@@ -57,6 +58,7 @@ import NotifyToaster from "@/notify/NotifyToaster.vue"
 import { needsOnboarding } from "@/onboarding/readiness.js"
 import Sidebar from "./Sidebar.vue"
 import JarvisCommandPalette from "./JarvisCommandPalette.vue"
+import MoreMenu from "./MoreMenu.vue"
 import SettingsDialog from "./SettingsDialog.vue"
 import ConfirmDialog from "./ConfirmDialog.vue"
 import OnboardingGate from "./OnboardingGate.vue"

--- a/frontend/src/components/shell/MoreMenu.vue
+++ b/frontend/src/components/shell/MoreMenu.vue
@@ -42,16 +42,17 @@
 </template>
 
 <script setup>
-// ⌘K palette (DESIGN-V3 §3.5), rebuilt on plain frappe-ui Dialog. The stock
-// CommandPalette in 0.1.278 nests a bare <template> element at its root, which
-// Vue renders as an inert native <template> - its whole Dialog subtree never
-// mounts (no [role=dialog], no errors), so ⌘K and the sidebar Search rows did
-// nothing. Same anatomy as the stock component: search input + grouped list,
-// ↑/↓/Enter keyboard navigation, Esc closes (Dialog's own handling). Opens via
-// store.paletteOpen (sidebar "Search Chat" + tail row) and the Ctrl/⌘+K
-// binding in AppShell's useShortcuts (replaces the stock component's
-// self-owned key, §14 DA-06). Empty query = nav items + 10 recent chats;
-// typing = filtered nav + server title search (D40, 300ms debounce).
+// Sidebar "More" palette — a clone-and-trim of JarvisCommandPalette.vue for
+// the overflow destinations (Dashboards today). Same Dialog anatomy, same
+// keyboard nav, same PaletteItem rows; bound to store.moreMenuOpen. Empty
+// query lists the static destinations; typing filters them and also runs the
+// server search_workspace, keeping ONLY its "dashboards" group (whose items
+// carry spa_route, not a desk route).
+//
+// NOTE (dedupe-later): this is the second palette sharing the input +
+// flatItems/activeIndex/scrollIntoView machinery with JarvisCommandPalette.
+// When a third palette appears, extract a shared usePaletteNav composable
+// rather than cloning a third time.
 import { ref, computed, watch, nextTick } from "vue"
 import { useRouter } from "vue-router"
 import { Dialog, FeatherIcon } from "frappe-ui"
@@ -63,15 +64,14 @@ const store = useShellStore()
 const router = useRouter()
 
 const open = computed({
-	get: () => store.paletteOpen,
-	set: (v) => (store.paletteOpen = v),
+	get: () => store.moreMenuOpen,
+	set: (v) => (store.moreMenuOpen = v),
 })
 
 const inputEl = ref(null)
 const listEl = ref(null)
 const searchQuery = ref("")
-const results = ref([])
-const frappeGroups = ref([])
+const serverGroups = ref([])
 const searching = ref(false)
 const activeIndex = ref(0)
 
@@ -88,80 +88,51 @@ watch(searchQuery, (q) => {
 	const query = (q || "").trim()
 	if (!query) {
 		searching.value = false
-		results.value = []
-		frappeGroups.value = []
+		serverGroups.value = []
 		return
 	}
 	searching.value = true
 	_debounce = setTimeout(async () => {
 		const seq = ++_seq
 		try {
-			// Conversation titles + the Frappe desk (records/reports) in parallel.
-			const [conv, ws] = await Promise.all([
-				apiShell.searchConversations({ search: query, page_length: 20 }),
-				apiShell.searchWorkspace({ search: query, limit: 6 }),
-			])
+			const ws = await apiShell.searchWorkspace({ search: query, limit: 6 })
 			if (seq !== _seq) return // stale response
-			results.value = (conv && conv.rows) || []
-			frappeGroups.value = (ws && ws.groups) || []
+			// Only the SPA-native dashboards group belongs in this palette.
+			serverGroups.value = ((ws && ws.groups) || []).filter((g) => g.key === "dashboards")
 		} catch (e) {
-			if (seq === _seq) {
-				results.value = []
-				frappeGroups.value = []
-			}
+			if (seq === _seq) serverGroups.value = []
 		} finally {
 			if (seq === _seq) searching.value = false
 		}
 	}, 300)
 })
 
-const navItems = computed(() => [
+const destinations = computed(() => [
 	{
-		name: "nav-new-chat",
-		label: "New Chat",
-		icon: "plus",
-		action: () => store.requestNewChat(router),
+		name: "dest-dashboards",
+		label: "Dashboards",
+		icon: "bar-chart-2",
+		action: () => router.push("/dashboards"),
 	},
-	{ name: "nav-chat", label: "Chat", icon: "message-circle", action: () => router.push({ name: "Chat" }) },
-	{ name: "nav-skills", label: "Skills", icon: "zap", action: () => router.push({ name: "SkillsList" }) },
-	{ name: "nav-macros", label: "Macros", icon: "layers", action: () => router.push({ name: "MacrosList" }) },
-	{ name: "nav-files", label: "File Box", icon: "inbox", action: () => router.push({ name: "FilesList" }) },
-	{
-		name: "nav-approvals",
-		label: "Approval Board",
-		icon: "check-square",
-		action: () => router.push({ name: "ApprovalsList" }),
-	},
-	{ name: "nav-agents", label: "Agents", icon: "cpu", action: () => router.push({ name: "AgentsList" }) },
 ])
-
-function chatItem(c) {
-	return {
-		name: c.name,
-		label: c.title || "New chat",
-		icon: "message-circle",
-		last_active_at: c.last_active_at,
-	}
-}
 
 const groups = computed(() => {
 	const q = (searchQuery.value || "").trim().toLowerCase()
 	if (!q) {
-		const out = [{ title: "Jump to", items: navItems.value }]
-		const recents = store.conversations.slice(0, 10).map(chatItem)
-		if (recents.length) out.push({ title: "Recent chats", items: recents })
-		return out
+		return [{ title: "Destinations", items: destinations.value }]
 	}
 	const out = []
-	const nav = navItems.value.filter((it) => it.label.toLowerCase().includes(q))
-	if (nav.length) out.push({ title: "Jump to", items: nav })
-	const chats = searching.value
-		? [{ name: "-loading", label: "Searching…", icon: "loader", disabled: true }]
-		: results.value.map(chatItem)
-	if (chats.length) out.push({ title: "Chats", items: chats })
-	// Frappe desk results (Lists / Records / Reports) after the chats.
-	for (const g of frappeGroups.value) {
-		if (g.items && g.items.length) out.push({ title: g.title, items: g.items })
+	const dest = destinations.value.filter((it) => it.label.toLowerCase().includes(q))
+	if (dest.length) out.push({ title: "Destinations", items: dest })
+	if (searching.value) {
+		out.push({
+			title: "Dashboards",
+			items: [{ name: "-loading", label: "Searching…", icon: "loader", disabled: true }],
+		})
+	} else {
+		for (const g of serverGroups.value) {
+			if (g.items && g.items.length) out.push({ title: g.title, items: g.items })
+		}
 	}
 	return out
 })
@@ -171,8 +142,7 @@ const flatItems = computed(() => groups.value.flatMap((g) => g.items).filter((it
 const activeItem = computed(() => flatItems.value[activeIndex.value] || null)
 const empty = computed(() => !!searchQuery.value.trim() && !searching.value && !flatItems.value.length)
 
-// Any result change (typing, search landing, conversations refresh) resets
-// the cursor to the top row.
+// Any result change (typing, search landing) resets the cursor to the top row.
 watch(groups, () => {
 	activeIndex.value = 0
 })
@@ -208,11 +178,8 @@ function select(item) {
 	if (!item || item.disabled) return
 	open.value = false
 	if (item.action) item.action()
-	// SPA-native results (search_workspace "dashboards" group) navigate in-app.
+	// Server dashboard rows carry spa_route ("/dashboards/<name>") and no route.
 	else if (item.spa_route) router.push(item.spa_route)
-	// Frappe desk records/reports open in a new tab so the chat isn't lost.
-	else if (item.route) window.open(item.route, "_blank", "noopener")
-	else router.push("/c/" + item.name)
 }
 
 // after-leave (Dialog's overlay finished its exit) - wipe for the next open.
@@ -220,8 +187,7 @@ function reset() {
 	clearTimeout(_debounce)
 	_seq++ // invalidate any in-flight search
 	searchQuery.value = ""
-	results.value = []
-	frappeGroups.value = []
+	serverGroups.value = []
 	searching.value = false
 	activeIndex.value = 0
 }

--- a/frontend/src/components/shell/Sidebar.vue
+++ b/frontend/src/components/shell/Sidebar.vue
@@ -63,6 +63,22 @@
 			</div>
 		</nav>
 
+		<!-- 3b. overflow destinations (Dashboards, …) — opens the MoreMenu palette.
+		     Deliberately NOT a navLinks entry: that loop binds :to and this row is
+		     an action. But it DOES light up when the user is on one of its
+		     destinations, so a first-class page reached via More still reads as a
+		     section (not a transient action). -->
+		<nav class="flex flex-col">
+			<SidebarLink
+				label="More"
+				icon="more-horizontal"
+				class="mx-2 my-[1.5px]"
+				:is-collapsed="collapsed"
+				:is-active="onMoreDestination"
+				:on-click="() => (store.moreMenuOpen = true)"
+			/>
+		</nav>
+
 		<!-- 4. recent chats (hidden entirely when collapsed, D6) -->
 		<template v-if="!collapsed">
 			<div class="px-4 pb-2.5 pt-[11px] text-sm text-ink-gray-5">Recent chats</div>
@@ -164,6 +180,10 @@ const route = useRoute()
 const router = useRouter()
 
 const collapsed = computed(() => store.sidebarCollapsed)
+
+// The "More" overflow row lights up on any of its destinations (currently the
+// Dashboards page + detail). Extend the prefix list as destinations are added.
+const onMoreDestination = computed(() => route.path.startsWith("/dashboards"))
 function toggleCollapse() {
 	store.sidebarCollapsed = !store.sidebarCollapsed
 }

--- a/frontend/src/composables/chatPrefill.js
+++ b/frontend/src/composables/chatPrefill.js
@@ -1,12 +1,14 @@
 import { ref } from "vue"
 
-// Cross-view hand-off for "Discuss in chat" (Skills → Review tab). A review
-// row builds a prefilled prompt about a learned pattern, stashes it here and
-// router.push("/"); ChatView consumes it ONCE on mount (and clears it on
+// Cross-view hand-off for "Discuss in chat" (Skills → Review tab, Dashboards
+// → view page). A source surface builds a prefilled prompt, stashes it here
+// and router.push("/"); ChatView consumes it ONCE on mount (and clears it on
 // EVERY mount so a stale prompt can never fire later): it starts a FRESH
 // conversation via newChat(), fills the composer, and when `autoSend` is set
-// sends the text as the user's first message in that conversation. Shape:
-//   { text: string, autoSend: true }
+// sends the text as the user's first message in that conversation. Optional
+// `context` ({doctype, name}) rides the first send as viewing context —
+// api.js#sendMessage forwards it when it carries a doctype. Shape:
+//   { text: string, autoSend: true, context?: {doctype, name} }
 export const pendingChatPrefill = ref(null)
 
 export function setChatPrefill(payload) {

--- a/frontend/src/lib/dashboardExport.js
+++ b/frontend/src/lib/dashboardExport.js
@@ -1,0 +1,74 @@
+// dashboardExport - parent-side halves of the dashboard export flow.
+// DashboardCanvas owns the postMessage plumbing (it posts {type:"export", id,
+// format, lib, pixelRatio} into the sandboxed iframe and resolves the matching
+// export:result frame); this module owns what sits around that exchange:
+//   - loadCaptureLib(): the html-to-image UMD source as a string (dynamic
+//     ?raw import so the capture lib stays out of the main chunk; injected
+//     into the iframe via script.textContent because the iframe's CSP blocks
+//     every external fetch),
+//   - downloadPng(images, title): first captured image → Blob → <a download>,
+//   - downloadPdf(images, title): captured slides → lazy jspdf → one page per
+//     slide, page size = the slide's pixel size.
+
+let _libSource = null
+export async function loadCaptureLib() {
+	if (_libSource == null) {
+		// Bare deep import is fine here - html-to-image has no exports map;
+		// dist/html-to-image.js is the UMD build that installs window.htmlToImage.
+		const mod = await import("html-to-image/dist/html-to-image.js?raw")
+		_libSource = (mod && mod.default) || ""
+	}
+	return _libSource
+}
+
+function slugify(title) {
+	return (
+		String(title || "")
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "dashboard"
+	)
+}
+
+function dataUrlToBlob(dataUrl) {
+	const [meta, b64] = String(dataUrl || "").split(",")
+	const mime = (/data:([^;]+)/.exec(meta) || [])[1] || "image/png"
+	const bin = atob(b64 || "")
+	const bytes = new Uint8Array(bin.length)
+	for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+	return new Blob([bytes], { type: mime })
+}
+
+// images: [{dataUrl, w, h, title}] from the iframe's export:result frame.
+export function downloadPng(images, title) {
+	const img = images && images[0]
+	if (!img || !img.dataUrl) throw new Error("Nothing was captured")
+	const url = URL.createObjectURL(dataUrlToBlob(img.dataUrl))
+	const a = document.createElement("a")
+	a.href = url
+	a.download = slugify(title) + ".png"
+	document.body.appendChild(a)
+	a.click()
+	a.remove()
+	setTimeout(() => URL.revokeObjectURL(url), 10000)
+}
+
+export async function downloadPdf(images, title) {
+	if (!images || !images.length) throw new Error("Nothing was captured")
+	// jspdf only loads when a PDF export actually happens.
+	const { jsPDF } = await import("jspdf")
+	let doc = null
+	for (const img of images) {
+		const w = Math.max(1, Math.round(img.w || 1))
+		const h = Math.max(1, Math.round(img.h || 1))
+		const orientation = w >= h ? "landscape" : "portrait"
+		if (!doc) {
+			// px_scaling: treat px as real pixels (jspdf otherwise rescales 96dpi→72).
+			doc = new jsPDF({ orientation, unit: "px", format: [w, h], hotfixes: ["px_scaling"] })
+		} else {
+			doc.addPage([w, h], orientation)
+		}
+		doc.addImage(img.dataUrl, "PNG", 0, 0, w, h)
+	}
+	doc.save(slugify(title) + ".pdf")
+}

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -1,0 +1,382 @@
+// dashboardSrcdoc - pure string assembly of the sandboxed dashboard iframe's
+// srcdoc (DOM-free so `node --test` covers it). The AI's HTML (full document
+// or fragment) gets a head block injected IN ORDER:
+//   1. the CSP meta (FIRST head child - it must precede every script),
+//   2. <meta charset="utf-8"> (only when we wrap a fragment in our skeleton),
+//   3. the echarts source inline (optional - caller dynamic-imports the 1MB
+//      min build as ?raw and passes the string, keeping this util sync/pure),
+//   4. the bridge runtime inline - BEFORE any user markup, so window.jarvis
+//      exists by the time user scripts run.
+// The srcdoc iframe is sandbox="allow-scripts" with NO allow-same-origin; the
+// CSP blocks all network egress (connect-src 'none', script/style inline-only)
+// so a malicious dashboard can neither phone home nor load remote code.
+//
+// Sources contract (single source of truth): the HTML declares its data needs
+// in a <script type="application/json" id="jarvis-sources"> block; the runtime
+// parses it at boot to resolve jarvis.data("<name>") → {tool, spec}, and the
+// parent parses the SAME block (parseSourcesBlock below) for the save-dialog
+// preview + save payload.
+
+export const CSP_META =
+	'<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; script-src \'unsafe-inline\'; style-src \'unsafe-inline\'; img-src data: blob:; font-src data:; connect-src \'none\'">'
+
+// ── the bridge runtime (inline JS, stringified into the srcdoc) ───────────────
+// window.jarvis API for dashboard HTML:
+//   jarvis.data(name)        → Promise; `query`/`get_list` sources resolve with
+//                              the rows array; `run_report` sources resolve
+//                              with {columns, rows}. Rejections carry .code
+//                              ("PermissionError"|"NotFound"|"Timeout"|...).
+//   jarvis.ready()           → tells the parent boot finished (auto-posted on
+//                              DOMContentLoaded too).
+//   jarvis.renderError(el,e) → quiet inline per-widget error block.
+// Frames OUT: {jarvis:1, v:1, type:"data"|"ready"|"height"|"export:result", ...}
+// Frames IN (validated e.source === window.parent && d.jarvis === 1):
+//   {type:"data:result", id, ok, rows|error} · {type:"theme", dark} ·
+//   {type:"export", id, format:"png"|"slides", lib, pixelRatio}
+export const RUNTIME_JS = `(function () {
+	"use strict";
+	var sources = {}; // name -> {tool, spec}
+	var pending = {}; // data request id -> {resolve, reject, timer}
+	var seq = 0;
+	var exportLibInjected = false;
+
+	function post(msg) {
+		msg.jarvis = 1;
+		msg.v = 1;
+		window.parent.postMessage(msg, "*");
+	}
+
+	function parseSources() {
+		var el = document.getElementById("jarvis-sources");
+		if (!el) return;
+		try {
+			var parsed = JSON.parse(el.textContent || "{}");
+			var list = (parsed && parsed.sources) || [];
+			for (var i = 0; i < list.length; i++) {
+				// LLM-authored blocks drift toward the tool-call surface; fold the
+				// common dialects into the canonical {source_name, tool, spec} shape
+				// (the backend save parser normalizes identically).
+				var s = list[i];
+				if (!s) continue;
+				var name = s.source_name || s.id || s.name;
+				if (!name) continue;
+				var tool = String(s.tool || "").replace(/^jarvis__/, "");
+				var spec = s.spec;
+				if (spec == null && s.args && typeof s.args === "object") {
+					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args;
+				}
+				// double-wrap drift ({"spec":{"spec":{...}}}): unwrap lone spec keys
+				while (
+					spec && typeof spec === "object" && !Array.isArray(spec) &&
+					Object.keys(spec).length === 1 && spec.spec && typeof spec.spec === "object"
+				) {
+					spec = spec.spec;
+				}
+				sources[name] = { tool: tool, spec: spec };
+			}
+		} catch (e) {
+			/* malformed block: jarvis.data() rejects per-name with NotFound */
+		}
+	}
+
+	// Dashboard widget scripts run inline DURING document parsing - often
+	// before the #jarvis-sources block (or the rest of the DOM) exists. Defer
+	// every lookup until the document is fully parsed, then re-parse lazily,
+	// so widget/block ordering never matters.
+	function whenParsed(fn) {
+		if (document.readyState === "loading") {
+			document.addEventListener("DOMContentLoaded", fn);
+		} else {
+			fn();
+		}
+	}
+
+	window.jarvis = {
+		data: function (name) {
+			return new Promise(function (resolve, reject) {
+				whenParsed(function () {
+					var src = sources[name];
+					if (!src) {
+						parseSources();
+						src = sources[name];
+					}
+					if (!src) {
+						var known = Object.keys(sources).join(", ") || "none declared";
+						var e = new Error('Unknown source "' + name + '" (declared: ' + known + ")");
+						e.code = "NotFound";
+						return reject(e);
+					}
+					var id = "d" + ++seq;
+					var timer = setTimeout(function () {
+						delete pending[id];
+						var e = new Error("Timed out loading data");
+						e.code = "Timeout";
+						reject(e);
+					}, 30000);
+					pending[id] = { resolve: resolve, reject: reject, timer: timer };
+					post({ type: "data", id: id, name: name, tool: src.tool, spec: src.spec });
+				});
+			});
+		},
+		ready: function () {
+			post({ type: "ready" });
+		},
+		renderError: function (el, err) {
+			if (!el) return;
+			var msg =
+				err && err.code === "PermissionError"
+					? "No permission to view this data"
+					: "Couldn't load this data";
+			el.innerHTML = "";
+			var d = document.createElement("div");
+			d.textContent = msg;
+			d.style.cssText =
+				"font-family:system-ui,sans-serif;font-size:13px;opacity:.55;padding:12px;text-align:center;";
+			el.appendChild(d);
+		},
+	};
+
+	function captureOne(el, pixelRatio) {
+		return window.htmlToImage
+			.toPng(el, {
+				pixelRatio: pixelRatio,
+				skipFonts: true,
+				backgroundColor: getComputedStyle(document.body).backgroundColor,
+			})
+			.then(function (dataUrl) {
+				return {
+					dataUrl: dataUrl,
+					w: Math.round(el.offsetWidth * pixelRatio),
+					h: Math.round(el.offsetHeight * pixelRatio),
+					title: (el.dataset && el.dataset.title) || "",
+				};
+			});
+	}
+
+	function handleExport(d) {
+		try {
+			if (!exportLibInjected && d.lib) {
+				var s = document.createElement("script");
+				s.textContent = d.lib;
+				document.head.appendChild(s);
+				exportLibInjected = true;
+			}
+			if (!window.htmlToImage) throw new Error("capture library unavailable");
+			var els =
+				d.format === "slides"
+					? Array.prototype.slice.call(document.querySelectorAll("section.slide"))
+					: [];
+			if (!els.length) els = [document.body];
+			var pixelRatio = d.pixelRatio || 2;
+			// Browsers cap canvases near 16384px a side - drop to 1x past that.
+			for (var i = 0; i < els.length; i++) {
+				var max = Math.max(els[i].offsetWidth, els[i].offsetHeight);
+				if (max * pixelRatio > 16384) pixelRatio = 1;
+			}
+			// SEQUENTIAL captures: parallel toPng calls contend for layout/canvas.
+			var images = [];
+			var chain = Promise.resolve();
+			els.forEach(function (el) {
+				chain = chain.then(function () {
+					return captureOne(el, pixelRatio).then(function (img) {
+						images.push(img);
+					});
+				});
+			});
+			chain
+				.then(function () {
+					post({ type: "export:result", id: d.id, ok: true, images: images });
+				})
+				.catch(function (err) {
+					post({
+						type: "export:result",
+						id: d.id,
+						ok: false,
+						error: { code: "CaptureFailed", message: String((err && err.message) || err) },
+					});
+				});
+		} catch (err) {
+			post({
+				type: "export:result",
+				id: d.id,
+				ok: false,
+				error: { code: "CaptureFailed", message: String((err && err.message) || err) },
+			});
+		}
+	}
+
+	window.addEventListener("message", function (e) {
+		if (e.source !== window.parent) return;
+		var d = e.data;
+		if (!d || d.jarvis !== 1) return;
+		if (d.type === "data:result") {
+			var p = pending[d.id];
+			if (!p) return;
+			delete pending[d.id];
+			clearTimeout(p.timer);
+			if (d.ok) p.resolve(d.rows);
+			else {
+				var err = new Error((d.error && d.error.message) || "Couldn't load this data");
+				err.code = (d.error && d.error.code) || "InternalError";
+				p.reject(err);
+			}
+		} else if (d.type === "theme") {
+			document.documentElement.dataset.theme = d.dark ? "dark" : "light";
+			window.dispatchEvent(new CustomEvent("jarvis:theme", { detail: { dark: !!d.dark } }));
+		} else if (d.type === "export") {
+			handleExport(d);
+		}
+	});
+
+	function boot() {
+		parseSources();
+		if (typeof ResizeObserver !== "undefined" && document.body) {
+			new ResizeObserver(function () {
+				post({ type: "height", height: document.body.scrollHeight });
+			}).observe(document.body);
+		}
+		post({ type: "ready" });
+	}
+	if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);
+	else boot();
+})();`
+
+// Any JS inlined into HTML must not terminate its own <script> wrapper.
+function escInline(js) {
+	return String(js || "").replace(/<\/script/gi, "<\\/script")
+}
+
+// Split author HTML into (headInner, bodyInner). We NEVER re-emit the author's
+// own <html>/<head>/<body> tags or anything before them — see buildSrcdoc for
+// why (CSP-ordering: markup before <head> would execute pre-CSP). Anything
+// outside the first <head> and the <body> (e.g. a <script> placed before
+// <head>) is intentionally DROPPED, not run.
+function splitAuthorHtml(src) {
+	const headM = /<head[^>]*>([\s\S]*?)<\/head>/i.exec(src)
+	const bodyM = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(src)
+	if (bodyM) {
+		return { headInner: headM ? headM[1] : "", bodyInner: bodyM[1] }
+	}
+	if (headM) {
+		// <head> but no <body>: body is everything after </head>, minus a
+		// trailing </html>.
+		const after = src
+			.slice(headM.index + headM[0].length)
+			.replace(/<\/html>\s*$/i, "")
+		return { headInner: headM[1], bodyInner: after }
+	}
+	// fragment (no head/body): strip a leading doctype + any stray html tags,
+	// everything is body content.
+	const body = src
+		.replace(/^\s*<!doctype[^>]*>\s*/i, "")
+		.replace(/<\/?html[^>]*>/gi, "")
+	return { headInner: "", bodyInner: body }
+}
+
+// buildSrcdoc(html, {dark, echartsSource, theme}) → the full srcdoc string.
+// Sync + pure: the caller dynamic-imports echarts.min.js?raw only when the
+// html references echarts, so the 1MB source never rides the main chunk.
+//
+// SECURITY — CSP must be the FIRST thing the parser sees. We ALWAYS emit our
+// own <!DOCTYPE html><html><head>CSP+scripts+…</head><body>author</body>
+// shell and only ever place author content INSIDE <head>/<body>, extracted
+// via splitAuthorHtml. We never reuse the author's <html>/<head>/<body> tags.
+// (Injecting CSP *inside* an author's existing <head> is unsafe: a <script>
+// placed before that <head> — e.g. `<html><script>evil</script><head>…` —
+// executes during "before head" parsing, BEFORE the CSP meta, and could open
+// a socket that survives connect-src 'none' and exfiltrate another viewer's
+// bridged data. Wrapping guarantees nothing author-supplied precedes the CSP.)
+export function buildSrcdoc(
+	html,
+	{ dark = false, echartsSource = "", theme: themeSpec = null } = {},
+) {
+	// A named dashboard theme (from lib/dashboardThemes) owns the canvas look
+	// when provided: its CSS variables + base rules are injected BEFORE the
+	// dashboard's own styles (so those win conflicts), a JARVIS_THEME global
+	// exposes the chart palette, and data-theme follows the theme's own
+	// light/dark - independent of the app shell's mode. Without a theme the
+	// legacy dark flag drives data-theme only.
+	const theme = themeSpec ? (themeSpec.dark ? "dark" : "light") : dark ? "dark" : "light"
+	const themeBlock = themeSpec
+		? `<style id="jarvis-theme">${themeSpec.css}</style>` +
+			`<script>window.JARVIS_THEME=${escInline(
+				JSON.stringify({
+					name: themeSpec.key,
+					label: themeSpec.label,
+					dark: !!themeSpec.dark,
+					accent: themeSpec.accent,
+					palette: themeSpec.palette,
+				}),
+			)}<\/script>`
+		: ""
+	const scripts =
+		themeBlock +
+		(echartsSource ? `<script>${escInline(echartsSource)}<\/script>` : "") +
+		`<script>${escInline(RUNTIME_JS)}<\/script>`
+
+	const { headInner, bodyInner } = splitAuthorHtml(String(html || ""))
+	return (
+		`<!DOCTYPE html><html data-theme="${theme}"><head>` +
+		CSP_META +
+		'<meta charset="utf-8">' +
+		scripts +
+		stripHostClient(headInner) +
+		"</head><body>" +
+		stripHostClient(bodyInner) +
+		"</body></html>"
+	)
+}
+
+// Dashboards saved before the gateway host-client strip landed carry a dead
+// openclaw live-reload script (a WebSocket to /__openclaw__/ws). It can't work
+// inside the sandbox (connect-src 'none' blocks it) and just logs a CSP
+// violation on every view — drop any <script> that references the host socket.
+function stripHostClient(html) {
+	return String(html || "").replace(/<script\b[\s\S]*?<\/script>/gi, (m) =>
+		m.includes("__openclaw__/ws") ? "" : m,
+	)
+}
+
+// Parent-side parse of the SAME #jarvis-sources block the runtime reads -
+// feeds the save dialog's detected-sources preview and the save payload.
+// String-based (no DOM) so it is testable and works on the raw html prop.
+// Normalizes the same LLM dialects as the runtime (id/name for source_name,
+// jarvis__ tool prefix, args/args.spec for spec) so preview, save and render
+// always agree. → [{source_name, tool, spec}]
+export function parseSourcesBlock(html) {
+	const m =
+		/<script[^>]*\bid\s*=\s*["']jarvis-sources["'][^>]*>([\s\S]*?)<\/script>/i.exec(
+			String(html || ""),
+		)
+	if (!m) return []
+	try {
+		const parsed = JSON.parse(m[1])
+		const list = (parsed && parsed.sources) || []
+		return list
+			.map((s) => {
+				if (!s) return null
+				const source_name = s.source_name || s.id || s.name
+				if (!source_name) return null
+				const tool = String(s.tool || "").replace(/^jarvis__/, "")
+				let spec = s.spec
+				if (spec == null && s.args && typeof s.args === "object") {
+					spec = s.args.spec && typeof s.args.spec === "object" ? s.args.spec : s.args
+				}
+				// double-wrap drift ({"spec":{"spec":{...}}}): unwrap lone spec keys
+				while (
+					spec &&
+					typeof spec === "object" &&
+					!Array.isArray(spec) &&
+					Object.keys(spec).length === 1 &&
+					spec.spec &&
+					typeof spec.spec === "object"
+				) {
+					spec = spec.spec
+				}
+				return { source_name, tool, spec }
+			})
+			.filter(Boolean)
+	} catch (e) {
+		return []
+	}
+}

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -397,90 +397,224 @@ function tagCloseIndex(src, from) {
 	return -1
 }
 
-// Where a <style> element's RAW-TEXT content ends: the first case-insensitive
-// `</style` that is an appropriate end tag (followed by whitespace, `/`, `>` or
+// Where a raw-text / RCDATA element's content ends: the first case-insensitive
+// `</name` that is an appropriate end tag (followed by whitespace, `/`, `>` or
 // EOF). Returns -1 (content runs to EOF) when there is none — matching the
-// browser, which applies an UNCLOSED <style> to end-of-document.
-function styleRawTextEnd(lower, src, from) {
+// browser, which applies an UNCLOSED <style>/<script>/… to end-of-document.
+function rawTextEnd(lower, src, from, name) {
+	const needle = "</" + name
 	let k = from
 	for (;;) {
-		const e = lower.indexOf("</style", k)
+		const e = lower.indexOf(needle, k)
 		if (e < 0) return -1
-		const nxt = src[e + 7]
+		const nxt = src[e + needle.length]
 		if (nxt === undefined || /[\s/>]/.test(nxt)) return e
-		k = e + 7
+		k = e + needle.length
 	}
 }
 
+// HTML raw-text / RCDATA elements whose content is NOT parsed as markup, so a
+// `<style>` (or a fake `</style>`) appearing inside them is text, never a tag.
+// <style> is handled specially (its CSS is wrapped); the rest are skipped whole.
+// <plaintext> is special-cased in the scanner (it consumes to EOF).
+const RAWTEXT_ELEMENTS = new Set([
+	"script",
+	"style",
+	"textarea",
+	"title",
+	"xmp",
+	"iframe",
+	"noembed",
+	"noframes",
+	"noscript",
+])
+
 // Wrap the inner CSS of every author <style> in `@layer author { … }` so a
 // standard theme's later-declared `@layer theme` wins the cascade regardless of
-// the author's source order or selector specificity. This walks the HTML with a
-// quote- and raw-text-aware scan (NOT a regex — the client wrapper must parse the
-// same surface the iframe browser does, DR2-2): a real <style> start tag ends at
-// its first UNQUOTED `>`, and its content is raw text to the first `</style` (or
-// EOF). An UNCLOSED <style> still applies its CSS to EOF in the browser, so it is
-// layered too and closed with a synthesized `</style>` so it can't swallow our
-// shell's trailing tags (F2). An empty style block is left untouched. A block
-// whose CSS has a stray `}` that would break OUT of `@layer author{}` is DROPPED
-// (emitted as an empty <style>) rather than let through unlayered (F#4) — the
-// save-time validator already rejects this, so this only bites live previews +
-// grandfathered docs that skip validation. Author `@import`, inline `style=`
-// colors and `!important` still beat layers by design — the validator bans those.
+// the author's source order or selector specificity.
+//
+// The AI's HTML is untrusted, so this must find the SAME real <style> elements
+// the iframe browser tokenizes — a substring scan for "<style" desyncs on any
+// "<style" that is not actually a start tag (inside an attribute value, a
+// comment, or a <script>/<textarea> body), which lets a fake "<style" swallow the
+// real "</style>" and leave the real CSS UNLAYERED, outranking @layer theme
+// (DR3-1). So this is a proper HTML tokenizer-state walk, not a hand-scanner over
+// "<style": DATA state advances tag-by-tag; a start tag is consumed to its true
+// end `>` honoring quoted attributes (so a "<style" INSIDE an attribute is part of
+// its tag, never a token); comments (incl. the abrupt-closing `<!-->` / `<!--->`
+// and `--!>` forms), bogus comments and PIs are skipped as units; raw-text /
+// RCDATA elements (<script>, <textarea>, <title>, … and <plaintext> → to EOF) have
+// their bodies skipped whole, so a "<style" inside them is never a tag.
+//
+// Only real <style> elements are rewritten: the start tag ends at its first
+// UNQUOTED `>`, and its content is raw text to the first `</style` (or EOF). An
+// UNCLOSED <style> still applies its CSS to EOF in the browser, so it is layered
+// too and closed with a synthesized `</style>` so it can't swallow our shell's
+// trailing tags (F2). An empty style block is left untouched. A block whose CSS
+// has a stray `}` that would break OUT of `@layer author{}` is DROPPED (emitted as
+// an empty <style>) rather than let through unlayered (F#4) — the save-time
+// validator already rejects this, so this only bites live previews + grandfathered
+// docs that skip validation. Author `@import`, inline `style=` colors and
+// `!important` still beat layers by design — the validator bans those.
 function wrapAuthorStyles(html) {
 	const src = String(html || "")
 	const lower = src.toLowerCase()
+	const n = src.length
 	let out = ""
 	let i = 0
-	while (i < src.length) {
-		const start = lower.indexOf("<style", i)
-		if (start < 0) {
+	while (i < n) {
+		const lt = src.indexOf("<", i)
+		if (lt < 0) {
 			out += src.slice(i)
 			break
 		}
-		// `<style` must be followed by a tag-name terminator (whitespace, `/`, `>`
-		// or EOF) to be a real start tag; otherwise it is e.g. `<styles` — copy the
-		// literal through and keep scanning.
-		const after = src[start + 6]
-		if (after !== undefined && !/[\s/>]/.test(after)) {
-			out += src.slice(i, start + 6)
-			i = start + 6
+		const c1 = src[lt + 1]
+		if (c1 === undefined) {
+			// a trailing `<` is literal text
+			out += src.slice(i)
+			break
+		}
+
+		// `<!…` — comment or other markup declaration.
+		if (c1 === "!") {
+			let end
+			if (src[lt + 2] === "-" && src[lt + 3] === "-") {
+				// a comment: nothing inside is a tag. It ends at `-->` / `--!>`, or —
+				// for the abrupt-closing empty forms — a `>` right after `<!--` /
+				// `<!---`. Ending exactly where the browser does is what prevents a
+				// later real <style> from being swallowed (DR3-1).
+				const p = lt + 4
+				if (src[p] === ">") {
+					end = p + 1
+				} else if (src[p] === "-" && src[p + 1] === ">") {
+					end = p + 2
+				} else {
+					let e = -1
+					let len = 3
+					for (let k = p; k < n; k++) {
+						if (src[k] === "-" && src[k + 1] === "-") {
+							if (src[k + 2] === ">") {
+								e = k
+								len = 3
+								break
+							}
+							if (src[k + 2] === "!" && src[k + 3] === ">") {
+								e = k
+								len = 4
+								break
+							}
+						}
+					}
+					end = e < 0 ? n : e + len
+				}
+			} else {
+				// bogus comment / doctype / CDATA: to the first `>`.
+				const g = src.indexOf(">", lt + 2)
+				end = g < 0 ? n : g + 1
+			}
+			out += src.slice(i, end)
+			i = end
 			continue
 		}
-		const tagEnd = tagCloseIndex(src, start + 6)
+
+		// `</…>` end tag, or `<?…>` PI (a bogus comment): skip to the tag's `>`
+		// (quote-aware for the end tag so a quoted `>` can't close it early).
+		if (c1 === "/") {
+			const e = tagCloseIndex(src, lt + 2)
+			const end = e < 0 ? n : e + 1
+			out += src.slice(i, end)
+			i = end
+			continue
+		}
+		if (c1 === "?") {
+			const g = src.indexOf(">", lt + 2)
+			const end = g < 0 ? n : g + 1
+			out += src.slice(i, end)
+			i = end
+			continue
+		}
+
+		// A start tag must be `<` + ASCII letter; any other `<` is literal text.
+		if (!/[a-zA-Z]/.test(c1)) {
+			out += src.slice(i, lt + 1)
+			i = lt + 1
+			continue
+		}
+
+		// Start tag: read the tag name (to the first whitespace / `/` / `>`), then
+		// find the tag's true end `>` honoring quoted attribute values (so
+		// `<x a=">">` does not end at the quoted `>`, and a `<style` sitting INSIDE
+		// an attribute value is consumed as part of THIS tag — DR3-1).
+		let j = lt + 1
+		while (j < n && !/[\s/>]/.test(src[j])) j++
+		const name = lower.slice(lt + 1, j)
+		const tagEnd = tagCloseIndex(src, j)
 		if (tagEnd < 0) {
-			// unterminated start tag (truncated) — nothing renders as CSS
+			// unterminated start tag (truncated) — nothing after renders as markup
 			out += src.slice(i)
 			break
 		}
-		out += src.slice(i, tagEnd + 1) // pre-style content + the opening tag
-		const contentStart = tagEnd + 1
-		const rawEnd = styleRawTextEnd(lower, src, contentStart)
-		let css
-		let close
-		let next
-		if (rawEnd < 0) {
-			css = src.slice(contentStart)
-			close = "</style>" // unclosed: synthesize a closer (F2)
-			next = src.length
-		} else {
-			css = src.slice(contentStart, rawEnd)
-			const closeEnd = tagCloseIndex(src, rawEnd + 7)
-			if (closeEnd < 0) {
-				close = src.slice(rawEnd)
-				next = src.length
+
+		if (name === "style") {
+			out += src.slice(i, tagEnd + 1) // pre-style content + the opening tag
+			const contentStart = tagEnd + 1
+			const rawEnd = rawTextEnd(lower, src, contentStart, "style")
+			let css
+			let close
+			let next
+			if (rawEnd < 0) {
+				css = src.slice(contentStart)
+				close = "</style>" // unclosed: synthesize a closer (F2)
+				next = n
 			} else {
-				close = src.slice(rawEnd, closeEnd + 1)
-				next = closeEnd + 1
+				css = src.slice(contentStart, rawEnd)
+				const closeEnd = tagCloseIndex(src, rawEnd + "</style".length)
+				if (closeEnd < 0) {
+					close = src.slice(rawEnd)
+					next = n
+				} else {
+					close = src.slice(rawEnd, closeEnd + 1)
+					next = closeEnd + 1
+				}
 			}
+			if (!css.trim()) {
+				out += css + close // empty block: leave untouched
+			} else if (cssEscapesLayer(css)) {
+				out += close // stray-} block dropped, never emitted unlayered (F#4)
+			} else {
+				out += `@layer author{${css}}${close}`
+			}
+			i = next
+			continue
 		}
-		if (!css.trim()) {
-			out += css + close // empty block: leave untouched
-		} else if (cssEscapesLayer(css)) {
-			out += close // stray-} block dropped, never emitted unlayered (F#4)
-		} else {
-			out += `@layer author{${css}}${close}`
+
+		if (name === "plaintext") {
+			// after <plaintext> everything is raw text to EOF — no later tag exists
+			out += src.slice(i)
+			break
 		}
-		i = next
+
+		if (RAWTEXT_ELEMENTS.has(name)) {
+			// a raw-text / RCDATA body (<script>, <textarea>, …): its content is not
+			// markup, so skip it whole — a `<style>` inside is text, not a tag (DR3-1).
+			out += src.slice(i, tagEnd + 1)
+			const contentStart = tagEnd + 1
+			const rawEnd = rawTextEnd(lower, src, contentStart, name)
+			if (rawEnd < 0) {
+				out += src.slice(contentStart)
+				i = n
+				continue
+			}
+			const closeEnd = tagCloseIndex(src, rawEnd + ("</" + name).length)
+			const end = closeEnd < 0 ? n : closeEnd + 1
+			out += src.slice(contentStart, end)
+			i = end
+			continue
+		}
+
+		// Ordinary element: emit the start tag and resume DATA scanning after it.
+		out += src.slice(i, tagEnd + 1)
+		i = tagEnd + 1
 	}
 	return out
 }

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -377,28 +377,112 @@ function cssEscapesLayer(css) {
 	return false
 }
 
+// Find the index of the `>` that ends a tag beginning at `from`, honoring quoted
+// attribute values so a quoted `>` (e.g. `<style data-x=">">`) never closes the
+// tag early. Returns -1 when the tag is unterminated. This is the DR2-2 fix: the
+// prior `<style[^>]*>` regex stopped at the FIRST `>`, even inside a quote, which
+// let `.jd-card{…}` render UNLAYERED and outrank `@layer theme`.
+function tagCloseIndex(src, from) {
+	let quote = ""
+	for (let j = from; j < src.length; j++) {
+		const c = src[j]
+		if (quote) {
+			if (c === quote) quote = ""
+		} else if (c === '"' || c === "'") {
+			quote = c
+		} else if (c === ">") {
+			return j
+		}
+	}
+	return -1
+}
+
+// Where a <style> element's RAW-TEXT content ends: the first case-insensitive
+// `</style` that is an appropriate end tag (followed by whitespace, `/`, `>` or
+// EOF). Returns -1 (content runs to EOF) when there is none — matching the
+// browser, which applies an UNCLOSED <style> to end-of-document.
+function styleRawTextEnd(lower, src, from) {
+	let k = from
+	for (;;) {
+		const e = lower.indexOf("</style", k)
+		if (e < 0) return -1
+		const nxt = src[e + 7]
+		if (nxt === undefined || /[\s/>]/.test(nxt)) return e
+		k = e + 7
+	}
+}
+
 // Wrap the inner CSS of every author <style> in `@layer author { … }` so a
 // standard theme's later-declared `@layer theme` wins the cascade regardless of
-// the author's source order or selector specificity. Non-greedy to the first
-// </style>, the next <style, or end-of-string: an UNCLOSED <style> still applies
-// its CSS to EOF in the browser (raw-text parsing), so it must be layered too, or
-// it would beat `@layer theme` unlayered (F2). A synthesized `</style>` closes an
-// unclosed block so it can't swallow our shell's trailing tags. An empty style
-// block is left untouched. A block whose CSS has a stray `}` that would break OUT
-// of `@layer author{}` is DROPPED (emitted as an empty <style>) rather than let
-// through unlayered (F#4) — the save-time validator already rejects this, so this
-// only bites live previews + grandfathered docs that skip validation. Author
-// `@import`, inline `style=` colors and `!important` still beat layers by design —
-// the save-time validator bans those.
+// the author's source order or selector specificity. This walks the HTML with a
+// quote- and raw-text-aware scan (NOT a regex — the client wrapper must parse the
+// same surface the iframe browser does, DR2-2): a real <style> start tag ends at
+// its first UNQUOTED `>`, and its content is raw text to the first `</style` (or
+// EOF). An UNCLOSED <style> still applies its CSS to EOF in the browser, so it is
+// layered too and closed with a synthesized `</style>` so it can't swallow our
+// shell's trailing tags (F2). An empty style block is left untouched. A block
+// whose CSS has a stray `}` that would break OUT of `@layer author{}` is DROPPED
+// (emitted as an empty <style>) rather than let through unlayered (F#4) — the
+// save-time validator already rejects this, so this only bites live previews +
+// grandfathered docs that skip validation. Author `@import`, inline `style=`
+// colors and `!important` still beat layers by design — the validator bans those.
 function wrapAuthorStyles(html) {
-	return String(html || "").replace(
-		/(<style\b[^>]*>)([\s\S]*?)(<\/style>|(?=<style\b)|$)/gi,
-		(m, open, css, close) => {
-			if (!css.trim()) return m
-			if (cssEscapesLayer(css)) return `${open}${close || "</style>"}`
-			return `${open}@layer author{${css}}${close || "</style>"}`
-		},
-	)
+	const src = String(html || "")
+	const lower = src.toLowerCase()
+	let out = ""
+	let i = 0
+	while (i < src.length) {
+		const start = lower.indexOf("<style", i)
+		if (start < 0) {
+			out += src.slice(i)
+			break
+		}
+		// `<style` must be followed by a tag-name terminator (whitespace, `/`, `>`
+		// or EOF) to be a real start tag; otherwise it is e.g. `<styles` — copy the
+		// literal through and keep scanning.
+		const after = src[start + 6]
+		if (after !== undefined && !/[\s/>]/.test(after)) {
+			out += src.slice(i, start + 6)
+			i = start + 6
+			continue
+		}
+		const tagEnd = tagCloseIndex(src, start + 6)
+		if (tagEnd < 0) {
+			// unterminated start tag (truncated) — nothing renders as CSS
+			out += src.slice(i)
+			break
+		}
+		out += src.slice(i, tagEnd + 1) // pre-style content + the opening tag
+		const contentStart = tagEnd + 1
+		const rawEnd = styleRawTextEnd(lower, src, contentStart)
+		let css
+		let close
+		let next
+		if (rawEnd < 0) {
+			css = src.slice(contentStart)
+			close = "</style>" // unclosed: synthesize a closer (F2)
+			next = src.length
+		} else {
+			css = src.slice(contentStart, rawEnd)
+			const closeEnd = tagCloseIndex(src, rawEnd + 7)
+			if (closeEnd < 0) {
+				close = src.slice(rawEnd)
+				next = src.length
+			} else {
+				close = src.slice(rawEnd, closeEnd + 1)
+				next = closeEnd + 1
+			}
+		}
+		if (!css.trim()) {
+			out += css + close // empty block: leave untouched
+		} else if (cssEscapesLayer(css)) {
+			out += close // stray-} block dropped, never emitted unlayered (F#4)
+		} else {
+			out += `@layer author{${css}}${close}`
+		}
+		i = next
+	}
+	return out
 }
 
 // Dashboards saved before the gateway host-client strip landed carry a dead

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -291,14 +291,25 @@ export function buildSrcdoc(
 	{ dark = false, echartsSource = "", theme: themeSpec = null } = {},
 ) {
 	// A named dashboard theme (from lib/dashboardThemes) owns the canvas look
-	// when provided: its CSS variables + base rules are injected BEFORE the
-	// dashboard's own styles (so those win conflicts), a JARVIS_THEME global
-	// exposes the chart palette, and data-theme follows the theme's own
-	// light/dark - independent of the app shell's mode. Without a theme the
-	// legacy dark flag drives data-theme only.
+	// when provided: its --jd-* variables + named component classes are emitted
+	// in a later-declared `@layer theme` while the author's own <style> is
+	// wrapped in `@layer author` (declared first), so the theme wins the CSS-vs-
+	// CSS battle regardless of author source order or specificity. A JARVIS_THEME
+	// global exposes the chart palette, and data-theme follows the theme's own
+	// light/dark - independent of the app shell's mode. A "Custom" (bespoke)
+	// theme is the opposite: the tokens are injected UNLAYERED and the author's
+	// <style> is left unlayered too, so the author's own design wins (the save-
+	// time validator relaxes the design rules for it but keeps the safety bans).
+	// Without a theme the legacy dark flag drives data-theme only.
 	const theme = themeSpec ? (themeSpec.dark ? "dark" : "light") : dark ? "dark" : "light"
+	const bespoke = !!(themeSpec && themeSpec.bespoke)
+	const themeCss = themeSpec
+		? bespoke
+			? themeSpec.css
+			: `@layer author, theme;@layer theme{${themeSpec.css}}`
+		: ""
 	const themeBlock = themeSpec
-		? `<style id="jarvis-theme">${themeSpec.css}</style>` +
+		? `<style id="jarvis-theme">${themeCss}</style>` +
 			`<script>window.JARVIS_THEME=${escInline(
 				JSON.stringify({
 					name: themeSpec.key,
@@ -315,15 +326,33 @@ export function buildSrcdoc(
 		`<script>${escInline(RUNTIME_JS)}<\/script>`
 
 	const { headInner, bodyInner } = splitAuthorHtml(String(html || ""))
+	// Under a standard (non-bespoke) theme, wrap the author's <style> contents in
+	// `@layer author` so the theme's `@layer theme` wins. Skipped for bespoke /
+	// no-theme, where author CSS stays unlayered and wins.
+	const prep = (s) =>
+		themeSpec && !bespoke ? wrapAuthorStyles(stripHostClient(s)) : stripHostClient(s)
 	return (
 		`<!DOCTYPE html><html data-theme="${theme}"><head>` +
 		CSP_META +
 		'<meta charset="utf-8">' +
 		scripts +
-		stripHostClient(headInner) +
+		prep(headInner) +
 		"</head><body>" +
-		stripHostClient(bodyInner) +
+		prep(bodyInner) +
 		"</body></html>"
+	)
+}
+
+// Wrap the inner CSS of every author <style> in `@layer author { … }` so a
+// standard theme's later-declared `@layer theme` wins the cascade regardless of
+// the author's source order or selector specificity. Non-greedy to the first
+// </style>; an empty style block is left untouched. Author `@import`, inline
+// `style=` colors and `!important` on color/font still beat layers by design —
+// the save-time validator bans exactly those.
+function wrapAuthorStyles(html) {
+	return String(html || "").replace(
+		/(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi,
+		(m, open, css, close) => (css.trim() ? `${open}@layer author{${css}}${close}` : m),
 	)
 }
 

--- a/frontend/src/lib/dashboardSrcdoc.js
+++ b/frontend/src/lib/dashboardSrcdoc.js
@@ -343,16 +343,61 @@ export function buildSrcdoc(
 	)
 }
 
+// True if the CSS contains a `}` with no matching `{` before it — a stray/excess
+// close brace that, once interpolated into `@layer author{ … }`, would terminate
+// the layer early and let the following author rule render UNLAYERED, outranking
+// the theme (F#4). Strings, comments and CSS escapes are skipped so a `}` inside
+// them never counts. An UNCLOSED `{` (depth ends > 0) is safe — it stays contained
+// inside the wrapper — so it is NOT treated as an escape.
+function cssEscapesLayer(css) {
+	const s = String(css || "")
+	let depth = 0
+	for (let i = 0; i < s.length; i++) {
+		const c = s[i]
+		if (c === "\\") {
+			i++ // CSS escape: the next char is never structural
+			continue
+		}
+		if (c === "/" && s[i + 1] === "*") {
+			const end = s.indexOf("*/", i + 2)
+			i = end < 0 ? s.length : end + 1
+			continue
+		}
+		if (c === '"' || c === "'") {
+			i++
+			while (i < s.length && s[i] !== c) {
+				if (s[i] === "\\") i++
+				i++
+			}
+			continue
+		}
+		if (c === "{") depth++
+		else if (c === "}" && --depth < 0) return true
+	}
+	return false
+}
+
 // Wrap the inner CSS of every author <style> in `@layer author { … }` so a
 // standard theme's later-declared `@layer theme` wins the cascade regardless of
 // the author's source order or selector specificity. Non-greedy to the first
-// </style>; an empty style block is left untouched. Author `@import`, inline
-// `style=` colors and `!important` on color/font still beat layers by design —
-// the save-time validator bans exactly those.
+// </style>, the next <style, or end-of-string: an UNCLOSED <style> still applies
+// its CSS to EOF in the browser (raw-text parsing), so it must be layered too, or
+// it would beat `@layer theme` unlayered (F2). A synthesized `</style>` closes an
+// unclosed block so it can't swallow our shell's trailing tags. An empty style
+// block is left untouched. A block whose CSS has a stray `}` that would break OUT
+// of `@layer author{}` is DROPPED (emitted as an empty <style>) rather than let
+// through unlayered (F#4) — the save-time validator already rejects this, so this
+// only bites live previews + grandfathered docs that skip validation. Author
+// `@import`, inline `style=` colors and `!important` still beat layers by design —
+// the save-time validator bans those.
 function wrapAuthorStyles(html) {
 	return String(html || "").replace(
-		/(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi,
-		(m, open, css, close) => (css.trim() ? `${open}@layer author{${css}}${close}` : m),
+		/(<style\b[^>]*>)([\s\S]*?)(<\/style>|(?=<style\b)|$)/gi,
+		(m, open, css, close) => {
+			if (!css.trim()) return m
+			if (cssEscapesLayer(css)) return `${open}${close || "</style>"}`
+			return `${open}@layer author{${css}}${close || "</style>"}`
+		},
 	)
 }
 

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -1,0 +1,198 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { buildSrcdoc, parseSourcesBlock, CSP_META, RUNTIME_JS } from "./dashboardSrcdoc.js"
+
+// A stable marker that only appears where the runtime was inlined.
+const RUNTIME_MARK = "window.jarvis = {"
+
+// Every case is re-wrapped in OUR shell; author head/body inner is extracted,
+// the CSP meta is always the literal first head child, and author content only
+// ever lands inside <head>/<body> AFTER our runtime.
+test("full document with <head>: re-wrapped, CSP first, head/body inner preserved", () => {
+  const out = buildSrcdoc("<!DOCTYPE html><html><head><title>t</title></head><body>USER</body></html>", {})
+  const head = out.indexOf("<head>")
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
+  // CSP is the FIRST head child (immediately after the opening head tag)
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  // author head + body content are preserved, but AFTER the runtime
+  assert.ok(out.includes("<title>t</title>"))
+  assert.ok(out.includes("<body>USER</body>"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("<title>t</title>"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("<html> but no <head>: re-wrapped, CSP first, body preserved", () => {
+  const out = buildSrcdoc('<html lang="en"><body>USER</body></html>', {})
+  const head = out.indexOf("<head>")
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  assert.ok(out.includes("<body>USER</body>"))
+  assert.ok(out.indexOf("</head>") < out.indexOf("USER"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("fragment: doctype stripped, skeleton wrap, charset present, CSP first", () => {
+  const out = buildSrcdoc("<!doctype html>\n<div>USER</div>", {})
+  assert.ok(out.startsWith("<!DOCTYPE html><html"))
+  // the leading user doctype was stripped (only our own remains)
+  assert.equal(out.match(/<!doctype/gi).length, 1)
+  const head = out.indexOf("<head>")
+  assert.equal(out.indexOf(CSP_META), head + "<head>".length)
+  // charset comes right after the CSP
+  assert.equal(out.indexOf('<meta charset="utf-8">'), head + "<head>".length + CSP_META.length)
+  assert.ok(out.includes("<body><div>USER</div></body>"))
+  assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"))
+})
+
+test("charset is always present (fragment or full doc, since we always wrap)", () => {
+  assert.ok(buildSrcdoc("<html><head></head><body></body></html>", {}).includes('<meta charset="utf-8">'))
+  assert.ok(buildSrcdoc("<div>x</div>", {}).includes('<meta charset="utf-8">'))
+})
+
+test("SECURITY: a <script> before <head> is dropped, never runs pre-CSP", () => {
+  // The exploit: author markup before <head> executes during 'before head'
+  // parsing, BEFORE our injected CSP meta. We must drop it entirely.
+  const evil =
+    '<html><script>window.__PWNED=new WebSocket("wss://evil/x")</script>' +
+    "<head><title>ok</title></head><body>USER</body></html>"
+  const out = buildSrcdoc(evil, {})
+  const csp = out.indexOf(CSP_META)
+  // the malicious pre-head script must not survive at all
+  assert.ok(!out.includes("__PWNED"), "pre-head script must be dropped")
+  assert.ok(!out.includes('new WebSocket("wss://evil/x")'))
+  // and nothing whatsoever precedes the CSP except our own shell head
+  assert.ok(out.slice(0, csp).indexOf("<script") < 0, "no script before the CSP meta")
+  // legitimate head/body content survives (after the runtime)
+  assert.ok(out.includes("<title>ok</title>"))
+  assert.ok(out.includes("<body>USER</body>"))
+})
+
+test("runtime script precedes user markup in all three cases", () => {
+  for (const html of [
+    "<html><head></head><body><p>USER</p></body></html>",
+    "<html><body><p>USER</p></body></html>",
+    "<p>USER</p>",
+  ]) {
+    const out = buildSrcdoc(html, {})
+    assert.ok(out.indexOf(RUNTIME_MARK) < out.indexOf("USER"), `runtime after markup for: ${html}`)
+  }
+})
+
+test("</script> in inlined sources is escaped so the wrapper cannot terminate early", () => {
+  const evil = 'console.log("</script><img src=x>")'
+  const out = buildSrcdoc("<div>ok</div>", { echartsSource: evil })
+  assert.ok(out.includes('console.log("<\\/script><img src=x>")'))
+  // the only raw </script> occurrences are our own wrapper closers (2 scripts)
+  assert.equal(out.match(/<\/script>/g).length, 2)
+})
+
+test("runtime itself carries no unescaped </script>", () => {
+  assert.ok(!/<\/script/i.test(RUNTIME_JS))
+})
+
+test("echarts toggle: absent by default, present (before the runtime) when passed", () => {
+  const without = buildSrcdoc("<div></div>", {})
+  assert.ok(!without.includes("ECHARTS_SRC"))
+  const withE = buildSrcdoc("<div></div>", { echartsSource: "/*ECHARTS_SRC*/" })
+  assert.ok(withE.includes("/*ECHARTS_SRC*/"))
+  assert.ok(withE.indexOf("/*ECHARTS_SRC*/") < withE.indexOf(RUNTIME_MARK))
+  assert.ok(withE.indexOf(CSP_META) < withE.indexOf("/*ECHARTS_SRC*/"))
+})
+
+test("theme attribute: set in all cases, replaced when already present", () => {
+  // fragment
+  assert.ok(buildSrcdoc("<p>x</p>", { dark: true }).includes('<html data-theme="dark">'))
+  assert.ok(buildSrcdoc("<p>x</p>", { dark: false }).includes('<html data-theme="light">'))
+  // full doc without the attr
+  const a = buildSrcdoc("<html><head></head><body></body></html>", { dark: true })
+  assert.ok(/<html[^>]*data-theme="dark"[^>]*>/.test(a))
+  // existing attr replaced, not duplicated
+  const b = buildSrcdoc('<html data-theme="light"><head></head><body></body></html>', { dark: true })
+  assert.ok(b.includes('data-theme="dark"'))
+  assert.ok(!b.includes('data-theme="light"'))
+  // html-no-head case too
+  const c = buildSrcdoc("<html><body></body></html>", { dark: true })
+  assert.ok(/<html[^>]*data-theme="dark"[^>]*>/.test(c))
+})
+
+test("parseSourcesBlock: reads the #jarvis-sources block; tolerates absence + bad JSON", () => {
+  const html =
+    '<div></div><script type="application/json" id="jarvis-sources">' +
+    '{"sources":[{"source_name":"overdue","tool":"query","spec":{"q":1}},{"tool":"query"}]}' +
+    "</script>"
+  const sources = parseSourcesBlock(html)
+  assert.equal(sources.length, 1) // the entry without source_name is dropped
+  assert.deepEqual(sources[0], { source_name: "overdue", tool: "query", spec: { q: 1 } })
+  assert.deepEqual(parseSourcesBlock("<div>none</div>"), [])
+  assert.deepEqual(
+    parseSourcesBlock('<script type="application/json" id="jarvis-sources">{oops</script>'),
+    [],
+  )
+})
+
+test("parseSourcesBlock: normalizes the LLM tool-call dialect (id / jarvis__ prefix / args.spec)", () => {
+  const html =
+    '<script type="application/json" id="jarvis-sources">' +
+    '{"sources":[' +
+    '{"id":"monthly_sales","tool":"jarvis__query","refresh":"view","args":{"spec":{"from":"Sales Invoice"}}},' +
+    '{"name":"top5","tool":"jarvis__run_report","args":{"report_name":"Foo","filters":{"a":1}}}' +
+    "]}</script>"
+  const sources = parseSourcesBlock(html)
+  assert.equal(sources.length, 2)
+  assert.deepEqual(sources[0], {
+    source_name: "monthly_sales",
+    tool: "query",
+    spec: { from: "Sales Invoice" },
+  })
+  assert.deepEqual(sources[1], {
+    source_name: "top5",
+    tool: "run_report",
+    spec: { report_name: "Foo", filters: { a: 1 } },
+  })
+})
+
+test("RUNTIME_JS: contains the same dialect normalization", () => {
+  assert.ok(RUNTIME_JS.includes("jarvis__"))
+  assert.ok(RUNTIME_JS.includes("s.args"))
+})
+
+test("buildSrcdoc: named theme injects vars + JARVIS_THEME and owns data-theme", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const out = buildSrcdoc("<html><head></head><body><p>x</p></body></html>", {
+    theme: THEMES.jarvis,
+  })
+  assert.ok(out.includes('<style id="jarvis-theme">'))
+  assert.ok(out.includes("--jd-bg:"))
+  assert.ok(out.includes("window.JARVIS_THEME="))
+  assert.ok(out.includes('"name":"jarvis"'))
+  assert.ok(/<html[^>]*data-theme="light"/.test(out))
+  // theme style must precede the runtime so vars exist before user scripts
+  assert.ok(out.indexOf('id="jarvis-theme"') < out.indexOf("window.jarvis ="))
+  // a dark theme drives data-theme
+  const dark = buildSrcdoc("<p>x</p>", { theme: THEMES.graphite })
+  assert.ok(dark.includes('data-theme="dark"'))
+  // no theme → legacy dark flag behavior unchanged
+  const legacy = buildSrcdoc("<p>x</p>", { dark: true })
+  assert.ok(legacy.includes('data-theme="dark"'))
+  assert.ok(!legacy.includes("jarvis-theme"))
+})
+
+test("parseSourcesBlock: unwraps double-nested spec ({spec:{spec:{...}}})", () => {
+  const html =
+    '<script type="application/json" id="jarvis-sources">' +
+    '{"sources":[{"source_name":"m","tool":"query","spec":{"spec":{"from":"Sales Invoice"}}}]}' +
+    "</script>"
+  const sources = parseSourcesBlock(html)
+  assert.deepEqual(sources[0].spec, { from: "Sales Invoice" })
+})
+
+test("SECURITY: stale openclaw ws-client script is stripped, other scripts kept", () => {
+  const html =
+    "<html><head></head><body><div id=chart></div>" +
+    "<script>renderChart()</script>" +
+    '<script>const ws=new WebSocket("ws://"+location.host+"/__openclaw__/ws");</script>' +
+    "</body></html>"
+  const out = buildSrcdoc(html, {})
+  assert.ok(out.includes("renderChart()"), "legit script kept")
+  assert.ok(!out.includes("__openclaw__/ws"), "host ws-client stripped")
+})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -283,6 +283,32 @@ test("@layer: no-theme (legacy dark flag) path is unchanged — no layers, no th
   assert.ok(out.includes('data-theme="dark"'))
 })
 
+test("@layer: a quoted `>` in a <style> attribute cannot escape @layer author (DR2-2)", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  // The exploit: `<style data-x=">">.jd-card{…}</style>` is valid HTML — the `>`
+  // sits INSIDE a quoted attribute, so the start tag really ends at the LAST `>`.
+  // The prior `<style[^>]*>` regex stopped at the first (quoted) `>`, wrapping it
+  // as `<style data-x=">@layer author{">.jd-card{…}` and leaving `.jd-card`
+  // UNLAYERED, outranking `@layer theme`. The scan-based wrapper keeps it layered.
+  const html = '<style data-x=">">.jd-card{background:var(--jd-negative)}</style>'
+  const out = buildSrcdoc(html, { theme: THEMES.jarvis })
+  // the author CSS is wrapped in @layer author with the quoted attribute intact
+  assert.ok(
+    out.includes('<style data-x=">">@layer author{.jd-card{background:var(--jd-negative)}}</style>'),
+    "quoted-> style content wrapped in @layer author",
+  )
+  // the old-regex escape (layer opener spliced into the attribute, `.jd-card`
+  // left unlayered) must NOT appear
+  assert.ok(!out.includes('data-x=">@layer author{'), "attribute value not mistaken for tag end")
+  assert.ok(out.includes("@layer author, theme;"), "layer order declaration present")
+})
+
+test("@layer: an UNQUOTED-attribute <style> is still wrapped (scan parity)", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const out = buildSrcdoc("<style data-k=v>.a{color:var(--jd-ink)}</style>", { theme: THEMES.insight })
+  assert.ok(out.includes("<style data-k=v>@layer author{.a{color:var(--jd-ink)}}</style>"))
+})
+
 test("SECURITY: stale openclaw ws-client script is stripped, other scripts kept", () => {
   const html =
     "<html><head></head><body><div id=chart></div>" +

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -217,6 +217,50 @@ test("@layer: multiple author <style> blocks are each wrapped; empty ones untouc
   assert.ok(out.includes("<style></style>"))
 })
 
+test("@layer: an UNCLOSED author <style> is still wrapped in @layer author (F2)", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  // no </style>: the browser applies the CSS to EOF, so it must be layered too or
+  // it beats @layer theme unlayered. We wrap it AND synthesize a closing tag.
+  const out = buildSrcdoc("<body><style>.k{color:#0f172a}</body>", { theme: THEMES.jarvis })
+  assert.ok(
+    out.includes("@layer author{.k{color:#0f172a}}</style>"),
+    "unclosed author style wrapped in @layer author and closed",
+  )
+  // the theme still declares author-before-theme + emits its own theme layer,
+  // so the theme wins the cascade over the now-layered author CSS
+  assert.ok(out.includes("@layer author, theme;"), "layer order declaration present")
+  assert.ok(out.includes("@layer theme{"), "theme layer still emitted")
+})
+
+test("@layer: malformed author CSS with a stray } cannot break out to outrank @layer theme (F#4)", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  // A LEADING stray } would close @layer author{} immediately, leaving .jd-card
+  // UNLAYERED and beating @layer theme. The wrapper must NOT emit it unlayered.
+  const out = buildSrcdoc("<body><style>}.jd-card{color:var(--jd-negative)}</style></body>", {
+    theme: THEMES.jarvis,
+  })
+  // the theme layer machinery is intact (theme still wins for well-formed CSS)
+  assert.ok(out.includes("@layer author, theme;"), "layer order declaration present")
+  assert.ok(out.includes("@layer theme{"), "theme layer emitted")
+  // the malicious author rule is dropped — never emitted unlayered, so it cannot
+  // outrank the theme (and it never rode inside @layer author either)
+  assert.ok(
+    !out.includes(".jd-card{color:var(--jd-negative)}"),
+    "stray-} author rule dropped, not emitted unlayered",
+  )
+  assert.ok(!/@layer author\{\}/.test(out), "no empty-then-escaped @layer author remains")
+  // EXCESS trailing } (closes @layer author early, then .after would be unlayered)
+  const out2 = buildSrcdoc(
+    "<body><style>.evil{color:var(--jd-negative)}} .after{color:var(--jd-accent)}</style></body>",
+    { theme: THEMES.jarvis },
+  )
+  assert.ok(!out2.includes("@layer author{.evil"), "excess-} block not wrapped")
+  assert.ok(!/\}\s*\.after\s*\{/.test(out2), "nothing left unlayered after the excess }")
+  // a WELL-FORMED author block under the same theme is still wrapped + layered
+  const ok = buildSrcdoc("<body><style>.jd-card{color:#0f172a}</style></body>", { theme: THEMES.jarvis })
+  assert.ok(ok.includes("@layer author{.jd-card{color:#0f172a}}"), "well-formed CSS still wrapped")
+})
+
 test("@layer: Custom (bespoke) theme does NOT wrap author styles — author design wins", async () => {
   const { THEMES } = await import("./dashboardThemes.js")
   const html = "<style>.jd-card{background:#0f172a}</style><p>x</p>"

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -319,3 +319,55 @@ test("SECURITY: stale openclaw ws-client script is stripped, other scripts kept"
   assert.ok(out.includes("renderChart()"), "legit script kept")
   assert.ok(!out.includes("__openclaw__/ws"), "host ws-client stripped")
 })
+
+// DR3-1: a literal "<style" that is NOT a real start tag (inside an attribute
+// value, a <script>/<textarea> body, or a comment) must not desync the wrapper.
+// The prior hand-scanner searched for "<style" from the DATA position and could
+// treat a fake one as a start tag, swallowing the REAL "</style>" and leaving the
+// real rule UNLAYERED (outranking @layer theme). The tokenizer-state walk keeps
+// every real <style> layered regardless.
+const REAL = ".jd-card{background:var(--jd-negative)}"
+
+test("@layer DR3-1: a fake <style> in an ATTRIBUTE cannot desync — real rule stays layered", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html = `<div data-x="<style>"></div><style>${REAL}</style>`
+  const out = buildSrcdoc(html, { theme: THEMES.jarvis })
+  assert.ok(out.includes(`@layer author{${REAL}}`), "real <style> wrapped in @layer author")
+  // the attribute-borne "<style" is part of the <div> tag, never its own token
+  assert.ok(out.includes('<div data-x="<style>">'), "attribute value preserved intact")
+  // the real rule is NEVER emitted bare (unlayered), which would outrank @layer theme
+  assert.ok(!out.includes(`>${REAL}`) && !out.includes(`}${REAL}`), "real rule not left unlayered")
+  assert.ok(out.includes("@layer author, theme;"), "layer order declaration present")
+})
+
+test("@layer DR3-1: a fake <style>/</style> inside a <script> body is skipped — real rule stays layered", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html = `<script>var s="</style><style>evil{}";</script><style>${REAL}</style>`
+  const out = buildSrcdoc(html, { theme: THEMES.jarvis })
+  assert.ok(out.includes(`@layer author{${REAL}}`), "real <style> after the script stays wrapped")
+  // the script body's fake CSS is never wrapped as author CSS
+  assert.ok(!out.includes("@layer author{evil{}"), "fake in-script style not wrapped")
+  assert.ok(out.includes('var s="</style><style>evil{}";'), "script body preserved verbatim")
+})
+
+test("@layer DR3-1: attribute + script + comment fakes together, then a real style — still layered", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html =
+    `<div title="<style>x{}</style>"></div>` +
+    `<script>document.write("<style>y{}</style>")</script>` +
+    `<!-- <style>z{}</style> -->` +
+    `<style>${REAL}</style>`
+  const out = buildSrcdoc(html, { theme: THEMES.jarvis })
+  assert.ok(out.includes(`@layer author{${REAL}}`), "real rule stays layered past every fake")
+  for (const fake of ["x{}", "y{}", "z{}"]) {
+    assert.ok(!out.includes(`@layer author{${fake}}`), `fake ${fake} not wrapped as author CSS`)
+  }
+})
+
+test("@layer DR3-1: an abrupt-closing empty comment <!--> does not swallow the real style", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  // <!--> is a COMPLETE empty comment in HTML; the <style> after it is REAL, so it
+  // must be wrapped (a naive scan-to-`-->` would skip to EOF and miss it).
+  const out = buildSrcdoc(`<!--><style>${REAL}</style>`, { theme: THEMES.jarvis })
+  assert.ok(out.includes(`@layer author{${REAL}}`), "real style after <!--> stays layered")
+})

--- a/frontend/src/lib/dashboardSrcdoc.test.js
+++ b/frontend/src/lib/dashboardSrcdoc.test.js
@@ -186,6 +186,59 @@ test("parseSourcesBlock: unwraps double-nested spec ({spec:{spec:{...}}})", () =
   assert.deepEqual(sources[0].spec, { from: "Sales Invoice" })
 })
 
+test("@layer: a standard theme wraps author <style> in @layer author and wins via @layer theme", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html =
+    "<html><head><style>.jd-card{background:#0f172a}</style></head><body><p>x</p></body></html>"
+  const out = buildSrcdoc(html, { theme: THEMES.jarvis })
+  // The theme block declares layer order author-before-theme; in CSS @layer the
+  // LAST-listed layer wins, so `author, theme` => theme beats author regardless
+  // of the author's source order or specificity.
+  assert.ok(out.includes("@layer author, theme;"), "layer order declaration present")
+  assert.ok(out.includes("@layer theme{"), "theme base emitted in @layer theme")
+  // the author's own <style> content is wrapped in @layer author (the loser)
+  assert.ok(
+    out.includes("@layer author{.jd-card{background:#0f172a}}"),
+    "author <style> wrapped in @layer author",
+  )
+  // the theme layer carries the tokens, so a jd-card in @layer theme wins color
+  assert.ok(out.indexOf("@layer theme{") < out.indexOf("--jd-bg:"))
+})
+
+test("@layer: multiple author <style> blocks are each wrapped; empty ones untouched", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html =
+    "<head><style>.a{color:var(--jd-ink)}</style></head>" +
+    "<body><style></style><style>.b{color:var(--jd-accent)}</style><p>x</p></body>"
+  const out = buildSrcdoc(html, { theme: THEMES.insight })
+  assert.ok(out.includes("@layer author{.a{color:var(--jd-ink)}}"))
+  assert.ok(out.includes("@layer author{.b{color:var(--jd-accent)}}"))
+  // an empty <style></style> is left as-is (no pointless @layer author{})
+  assert.ok(out.includes("<style></style>"))
+})
+
+test("@layer: Custom (bespoke) theme does NOT wrap author styles — author design wins", async () => {
+  const { THEMES } = await import("./dashboardThemes.js")
+  const html = "<style>.jd-card{background:#0f172a}</style><p>x</p>"
+  const out = buildSrcdoc(html, { theme: THEMES.custom })
+  // author CSS stays unlayered (unwrapped) so the bespoke look wins
+  assert.ok(out.includes(".jd-card{background:#0f172a}"))
+  assert.ok(!out.includes("@layer author{"), "no author layer for bespoke")
+  assert.ok(!out.includes("@layer theme{"), "no theme layer for bespoke")
+  // tokens are still injected (unlayered) so var(--jd-*) resolves, and the
+  // palette global is present
+  assert.ok(out.includes("--jd-bg:"))
+  assert.ok(out.includes('"name":"custom"'))
+})
+
+test("@layer: no-theme (legacy dark flag) path is unchanged — no layers, no theme block", () => {
+  const out = buildSrcdoc("<style>.a{color:red}</style><p>x</p>", { dark: true })
+  assert.ok(!out.includes("@layer"), "no @layer without a theme")
+  assert.ok(!out.includes("jarvis-theme"))
+  assert.ok(out.includes(".a{color:red}"), "author style passed through verbatim")
+  assert.ok(out.includes('data-theme="dark"'))
+})
+
 test("SECURITY: stale openclaw ws-client script is stripped, other scripts kept", () => {
   const html =
     "<html><head></head><body><div id=chart></div>" +

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -1,0 +1,114 @@
+// Named render themes for dashboard canvases. The shell (buildSrcdoc) injects
+// the selected theme as CSS variables + a small base stylesheet ahead of the
+// dashboard's own styles, so the SAME generated HTML re-skins when the user
+// switches themes: the skill instructs the agent to color everything with the
+// --jd-* variables instead of hardcoding.
+//
+// Keys are lowercase (API/theme picker); the DocType stores the capitalized
+// label ("Jarvis" | "Insight" | "Claude" | "Graphite") — use themeKey()/
+// themeLabel() to convert. "Jarvis" is the product default: the app's own
+// design language (design.md — gray-on-white, ink-gray scale, hairlines,
+// near-black accent) so an unprompted dashboard looks native. The agent only
+// deviates from the injected theme when the user explicitly asks about the
+// design; otherwise the standard applies.
+
+const VARS = (v) => `:root{
+--jd-bg:${v.bg};--jd-surface:${v.surface};--jd-ink:${v.ink};--jd-heading:${v.heading || v.ink};--jd-muted:${v.muted};
+--jd-line:${v.line};--jd-accent:${v.accent};--jd-radius:10px;--jd-shadow:${v.shadow};
+--jd-font:${v.font};--jd-font-display:${v.fontDisplay};
+}`
+
+// Modest base rules only — layout stays the dashboard's job; these make an
+// under-styled document look decent and re-skinnable. Injected BEFORE the
+// dashboard's own <style>, so its rules win any conflict.
+const BASE = `
+html,body{background:var(--jd-bg);color:var(--jd-ink);font-family:var(--jd-font);margin:0;}
+h1,h2,h3{font-family:var(--jd-font-display);color:var(--jd-heading,var(--jd-ink));}
+table{border-collapse:collapse;width:100%;}
+th{color:var(--jd-muted);font-weight:600;text-align:left;}
+th,td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
+section.slide{background:var(--jd-bg);}
+`
+
+// System stack only: the sandbox's CSP is `font-src data:` with no network, so
+// a webfont (Inter) can't load inside the canvas - claiming it would silently
+// fall back anyway. The system sans matches design.md's own fallback chain.
+const SANS = `-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif`
+
+export const THEMES = {
+	jarvis: {
+		key: "jarvis",
+		label: "Jarvis",
+		dark: false,
+		accent: "#383838",
+		// Gray-anchored, muted series colors — hue stays informational, the
+		// near-black primary matches the app's solid-CTA gray (design.md §2.1).
+		palette: ["#383838", "#5d78d1", "#4c9a7a", "#d9a53f", "#c25d5d", "#8a7bb8", "#5a99ae", "#a0693f"],
+		css:
+			VARS({
+				bg: "#f8f8f8", surface: "#ffffff", ink: "#383838", heading: "#171717",
+				muted: "#7c7c7c", line: "#ededed", accent: "#383838",
+				shadow: "0 1px 2px rgba(0,0,0,.05)",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+	insight: {
+		key: "insight",
+		label: "Insight",
+		dark: false,
+		accent: "#2490ef",
+		palette: ["#2490ef", "#25b885", "#f5a623", "#e24c4c", "#9b59b6", "#17a2b8", "#fd7e14", "#5856d6"],
+		css:
+			VARS({
+				bg: "#f3f3f3", surface: "#ffffff", ink: "#1f272e", muted: "#6c7680",
+				line: "#e2e2e2", accent: "#2490ef",
+				shadow: "0 1px 2px rgba(25,39,52,.06)",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+	claude: {
+		key: "claude",
+		label: "Claude",
+		dark: false,
+		accent: "#d97757",
+		palette: ["#d97757", "#7d9b76", "#dfa32e", "#6a9bcc", "#b0603f", "#8a7bb8", "#5c8a72", "#c2542e"],
+		css:
+			VARS({
+				bg: "#faf9f5", surface: "#ffffff", ink: "#3d3929", muted: "#83827d",
+				line: "#e8e6dc", accent: "#d97757",
+				shadow: "0 1px 2px rgba(61,57,41,.06)",
+				font: SANS, fontDisplay: `Georgia,"Times New Roman",serif`,
+			}) + BASE,
+	},
+	graphite: {
+		key: "graphite",
+		label: "Graphite",
+		dark: true,
+		accent: "#8ab4f8",
+		palette: ["#8ab4f8", "#4ade80", "#fbbf24", "#f87171", "#c084fc", "#22d3ee", "#fb923c", "#a3e635"],
+		css:
+			VARS({
+				bg: "#191919", surface: "#222222", ink: "#ececec", muted: "#9a9a9a",
+				line: "#333333", accent: "#8ab4f8",
+				shadow: "none",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+}
+
+export const DEFAULT_THEME = "jarvis"
+
+export const THEME_OPTIONS = Object.values(THEMES).map((t) => ({
+	key: t.key,
+	label: t.label,
+}))
+
+// DocType stores the capitalized label; the SPA works in lowercase keys.
+export function themeKey(label) {
+	const k = String(label || "").toLowerCase()
+	return THEMES[k] ? k : DEFAULT_THEME
+}
+
+export function themeLabel(key) {
+	return (THEMES[themeKey(key)] || THEMES[DEFAULT_THEME]).label
+}

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -37,6 +37,7 @@ const VARS = (v) => `:root{
 const BASE = `
 html,body{background:var(--jd-bg);color:var(--jd-ink);font-family:var(--jd-font);margin:0;}
 h1,h2,h3{font-family:var(--jd-font-display);color:var(--jd-heading,var(--jd-ink));}
+h3{font-size:15px;font-weight:600;line-height:1.35;}
 table{border-collapse:collapse;width:100%;}
 th{color:var(--jd-muted);font-weight:600;text-align:left;}
 th,td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
@@ -80,8 +81,8 @@ export const THEMES = {
 		css:
 			VARS({
 				bg: "#f8f8f8", surface: "#ffffff", surface2: "#f2f2f2", ink: "#383838",
-				heading: "#171717", muted: "#7c7c7c", line: "#ededed", accent: "#383838",
-				positive: "#4c9a7a", negative: "#c25d5d", warning: "#d9a53f", info: "#5d78d1",
+				heading: "#171717", muted: "#6e6e6e", line: "#ededed", accent: "#383838",
+				positive: "#3e7d63", negative: "#b25555", warning: "#8e6c29", info: "#556dbe",
 				shadow: "0 1px 2px rgba(0,0,0,.05)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,
@@ -95,8 +96,8 @@ export const THEMES = {
 		css:
 			VARS({
 				bg: "#f3f3f3", surface: "#ffffff", surface2: "#f6f8fa", ink: "#1f272e",
-				heading: "#1f272e", muted: "#6c7680", line: "#e2e2e2", accent: "#2490ef",
-				positive: "#25b885", negative: "#e24c4c", warning: "#f5a623", info: "#2490ef",
+				heading: "#1f272e", muted: "#667079", line: "#e2e2e2", accent: "#2490ef",
+				positive: "#197d5a", negative: "#c24141", warning: "#956515", info: "#1c71bc",
 				shadow: "0 1px 2px rgba(25,39,52,.06)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,
@@ -110,8 +111,8 @@ export const THEMES = {
 		css:
 			VARS({
 				bg: "#faf9f5", surface: "#ffffff", surface2: "#f5f3ec", ink: "#3d3929",
-				heading: "#3d3929", muted: "#83827d", line: "#e8e6dc", accent: "#d97757",
-				positive: "#7d9b76", negative: "#c2542e", warning: "#dfa32e", info: "#6a9bcc",
+				heading: "#3d3929", muted: "#6f6e6a", line: "#e8e6dc", accent: "#d97757",
+				positive: "#61785b", negative: "#bc512d", warning: "#926b1e", info: "#50759a",
 				shadow: "0 1px 2px rgba(61,57,41,.06)",
 				font: SANS, fontDisplay: `Georgia,"Times New Roman",serif`,
 			}) + BASE,
@@ -148,8 +149,8 @@ export const THEMES = {
 		css:
 			VARS({
 				bg: "#f8f8f8", surface: "#ffffff", surface2: "#f2f2f2", ink: "#383838",
-				heading: "#171717", muted: "#7c7c7c", line: "#ededed", accent: "#383838",
-				positive: "#4c9a7a", negative: "#c25d5d", warning: "#d9a53f", info: "#5d78d1",
+				heading: "#171717", muted: "#6e6e6e", line: "#ededed", accent: "#383838",
+				positive: "#3e7d63", negative: "#b25555", warning: "#8e6c29", info: "#556dbe",
 				shadow: "0 1px 2px rgba(0,0,0,.05)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,

--- a/frontend/src/lib/dashboardThemes.js
+++ b/frontend/src/lib/dashboardThemes.js
@@ -1,26 +1,39 @@
 // Named render themes for dashboard canvases. The shell (buildSrcdoc) injects
-// the selected theme as CSS variables + a small base stylesheet ahead of the
-// dashboard's own styles, so the SAME generated HTML re-skins when the user
-// switches themes: the skill instructs the agent to color everything with the
-// --jd-* variables instead of hardcoding.
+// the selected theme as CSS custom properties + a base stylesheet of named
+// component classes, wrapped in a winning `@layer theme` (the author's own
+// <style> is wrapped in `@layer author`, declared first, so the theme wins the
+// CSS-vs-CSS battle regardless of author source order or specificity). The SAME
+// generated HTML re-skins when the user switches themes: the skill instructs the
+// agent to compose the jd-* classes and color everything with the --jd-*
+// variables / window.JARVIS_THEME.palette instead of hardcoding.
+//
+// The machine-enforceable copy of each theme's tokens/palette/scales + the
+// save-time validator's allow-lists lives at jarvis/dashboards/themes/<key>/
+// theme.json (the render_tokens there mirror the --jd-* VARS emits below,
+// byte-for-byte — a sync-guard test fails loudly on drift).
 //
 // Keys are lowercase (API/theme picker); the DocType stores the capitalized
-// label ("Jarvis" | "Insight" | "Claude" | "Graphite") — use themeKey()/
-// themeLabel() to convert. "Jarvis" is the product default: the app's own
-// design language (design.md — gray-on-white, ink-gray scale, hairlines,
-// near-black accent) so an unprompted dashboard looks native. The agent only
-// deviates from the injected theme when the user explicitly asks about the
-// design; otherwise the standard applies.
+// label ("Jarvis" | "Insight" | "Claude" | "Graphite" | "Custom") — use
+// themeKey()/themeLabel() to convert. "Jarvis" is the product default: the
+// app's own design language (gray-on-white, ink-gray scale, hairlines,
+// near-black accent) so an unprompted dashboard looks native. "Custom" is the
+// deliberate bespoke escape hatch: no winning theme layer, so the author's own
+// design wins (the validator relaxes the design rules but keeps the safety bans).
+// For a standard theme the agent only deviates when the user picks Custom.
 
 const VARS = (v) => `:root{
---jd-bg:${v.bg};--jd-surface:${v.surface};--jd-ink:${v.ink};--jd-heading:${v.heading || v.ink};--jd-muted:${v.muted};
---jd-line:${v.line};--jd-accent:${v.accent};--jd-radius:10px;--jd-shadow:${v.shadow};
+--jd-bg:${v.bg};--jd-surface:${v.surface};--jd-surface-2:${v.surface2};--jd-ink:${v.ink};--jd-heading:${v.heading || v.ink};--jd-muted:${v.muted};
+--jd-line:${v.line};--jd-accent:${v.accent};
+--jd-positive:${v.positive};--jd-negative:${v.negative};--jd-warning:${v.warning};--jd-info:${v.info};
+--jd-radius:10px;--jd-shadow:${v.shadow};
 --jd-font:${v.font};--jd-font-display:${v.fontDisplay};
 }`
 
-// Modest base rules only — layout stays the dashboard's job; these make an
-// under-styled document look decent and re-skinnable. Injected BEFORE the
-// dashboard's own <style>, so its rules win any conflict.
+// Base rules: the original element defaults (so an under-styled document looks
+// decent) PLUS the named component classes (jd-page/-header, jd-kpi*, jd-card/
+// -chart-card, jd-table, jd-empty/-error) the skill composes so structure — not
+// just color — stays standard. All color/font/type come from --jd-* tokens.
+// Emitted inside `@layer theme` by buildSrcdoc, so these win over author CSS.
 const BASE = `
 html,body{background:var(--jd-bg);color:var(--jd-ink);font-family:var(--jd-font);margin:0;}
 h1,h2,h3{font-family:var(--jd-font-display);color:var(--jd-heading,var(--jd-ink));}
@@ -28,6 +41,26 @@ table{border-collapse:collapse;width:100%;}
 th{color:var(--jd-muted);font-weight:600;text-align:left;}
 th,td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
 section.slide{background:var(--jd-bg);}
+.jd-page{max-width:1200px;margin:0 auto;padding:24px;}
+.jd-page-header{margin-bottom:24px;}
+.jd-page-header h1{font-size:24px;font-weight:700;line-height:1.2;letter-spacing:-.01em;margin:0 0 4px;}
+.jd-subtitle{color:var(--jd-muted);font-size:13px;}
+.jd-kpi-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px;margin-bottom:24px;}
+.jd-kpi{background:var(--jd-surface);border:1px solid var(--jd-line);border-radius:var(--jd-radius);padding:16px;box-shadow:var(--jd-shadow);}
+.jd-kpi-label{color:var(--jd-muted);font-size:13px;font-weight:600;letter-spacing:.01em;margin-bottom:8px;}
+.jd-kpi-value{color:var(--jd-heading);font-family:var(--jd-font-display);font-size:32px;font-weight:700;line-height:1.15;}
+.jd-kpi-delta{font-size:13px;font-weight:600;}
+.jd-kpi-delta.up{color:var(--jd-positive);}
+.jd-kpi-delta.down{color:var(--jd-negative);}
+.jd-card,.jd-chart-card{background:var(--jd-surface);border:1px solid var(--jd-line);border-radius:var(--jd-radius);padding:16px;box-shadow:var(--jd-shadow);}
+.jd-card-header{font-family:var(--jd-font-display);color:var(--jd-heading);font-size:18px;font-weight:600;margin-bottom:12px;}
+.jd-card-footnote{color:var(--jd-muted);font-size:12px;margin-top:8px;}
+.jd-chart-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px;}
+.jd-table{border-collapse:collapse;width:100%;font-size:14px;}
+.jd-table th{color:var(--jd-muted);font-weight:600;text-align:left;background:var(--jd-surface-2);}
+.jd-table th,.jd-table td{padding:8px 12px;border-bottom:1px solid var(--jd-line);}
+.jd-empty{color:var(--jd-muted);font-size:13px;text-align:center;padding:24px;}
+.jd-error{color:var(--jd-negative);font-size:13px;text-align:center;padding:24px;}
 `
 
 // System stack only: the sandbox's CSP is `font-src data:` with no network, so
@@ -46,8 +79,9 @@ export const THEMES = {
 		palette: ["#383838", "#5d78d1", "#4c9a7a", "#d9a53f", "#c25d5d", "#8a7bb8", "#5a99ae", "#a0693f"],
 		css:
 			VARS({
-				bg: "#f8f8f8", surface: "#ffffff", ink: "#383838", heading: "#171717",
-				muted: "#7c7c7c", line: "#ededed", accent: "#383838",
+				bg: "#f8f8f8", surface: "#ffffff", surface2: "#f2f2f2", ink: "#383838",
+				heading: "#171717", muted: "#7c7c7c", line: "#ededed", accent: "#383838",
+				positive: "#4c9a7a", negative: "#c25d5d", warning: "#d9a53f", info: "#5d78d1",
 				shadow: "0 1px 2px rgba(0,0,0,.05)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,
@@ -60,8 +94,9 @@ export const THEMES = {
 		palette: ["#2490ef", "#25b885", "#f5a623", "#e24c4c", "#9b59b6", "#17a2b8", "#fd7e14", "#5856d6"],
 		css:
 			VARS({
-				bg: "#f3f3f3", surface: "#ffffff", ink: "#1f272e", muted: "#6c7680",
-				line: "#e2e2e2", accent: "#2490ef",
+				bg: "#f3f3f3", surface: "#ffffff", surface2: "#f6f8fa", ink: "#1f272e",
+				heading: "#1f272e", muted: "#6c7680", line: "#e2e2e2", accent: "#2490ef",
+				positive: "#25b885", negative: "#e24c4c", warning: "#f5a623", info: "#2490ef",
 				shadow: "0 1px 2px rgba(25,39,52,.06)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,
@@ -74,8 +109,9 @@ export const THEMES = {
 		palette: ["#d97757", "#7d9b76", "#dfa32e", "#6a9bcc", "#b0603f", "#8a7bb8", "#5c8a72", "#c2542e"],
 		css:
 			VARS({
-				bg: "#faf9f5", surface: "#ffffff", ink: "#3d3929", muted: "#83827d",
-				line: "#e8e6dc", accent: "#d97757",
+				bg: "#faf9f5", surface: "#ffffff", surface2: "#f5f3ec", ink: "#3d3929",
+				heading: "#3d3929", muted: "#83827d", line: "#e8e6dc", accent: "#d97757",
+				positive: "#7d9b76", negative: "#c2542e", warning: "#dfa32e", info: "#6a9bcc",
 				shadow: "0 1px 2px rgba(61,57,41,.06)",
 				font: SANS, fontDisplay: `Georgia,"Times New Roman",serif`,
 			}) + BASE,
@@ -88,9 +124,33 @@ export const THEMES = {
 		palette: ["#8ab4f8", "#4ade80", "#fbbf24", "#f87171", "#c084fc", "#22d3ee", "#fb923c", "#a3e635"],
 		css:
 			VARS({
-				bg: "#191919", surface: "#222222", ink: "#ececec", muted: "#9a9a9a",
-				line: "#333333", accent: "#8ab4f8",
+				bg: "#191919", surface: "#222222", surface2: "#2a2a2a", ink: "#ececec",
+				heading: "#ececec", muted: "#9a9a9a", line: "#333333", accent: "#8ab4f8",
+				positive: "#4ade80", negative: "#f87171", warning: "#fbbf24", info: "#8ab4f8",
 				shadow: "none",
+				font: SANS, fontDisplay: SANS,
+			}) + BASE,
+	},
+	custom: {
+		key: "custom",
+		label: "Custom",
+		dark: false,
+		// Bespoke escape hatch: buildSrcdoc injects the tokens + component classes
+		// UNLAYERED (no winning @layer) and leaves the author's <style> unlayered
+		// too, so the author's own design wins by source order — while a dashboard
+		// that WAS built with the jd-* classes keeps them as defaults instead of
+		// rendering unstyled. The save-time validator relaxes the design rules for
+		// this theme but keeps the safety bans (no external URLs, no @font-face)
+		// absolute. Not synced against a theme.json — it has no design spec.
+		bespoke: true,
+		accent: "#383838",
+		palette: ["#383838", "#5d78d1", "#4c9a7a", "#d9a53f", "#c25d5d", "#8a7bb8", "#5a99ae", "#a0693f"],
+		css:
+			VARS({
+				bg: "#f8f8f8", surface: "#ffffff", surface2: "#f2f2f2", ink: "#383838",
+				heading: "#171717", muted: "#7c7c7c", line: "#ededed", accent: "#383838",
+				positive: "#4c9a7a", negative: "#c25d5d", warning: "#d9a53f", info: "#5d78d1",
+				shadow: "0 1px 2px rgba(0,0,0,.05)",
 				font: SANS, fontDisplay: SANS,
 			}) + BASE,
 	},

--- a/frontend/src/lib/dashboardThemes.sync.test.js
+++ b/frontend/src/lib/dashboardThemes.sync.test.js
@@ -1,0 +1,60 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { THEMES } from "./dashboardThemes.js"
+
+// Sync guard: the render tokens in dashboardThemes.js (the --jd-* the shell
+// injects) MUST match, byte-for-byte, the canonical theme.json specs in the
+// jarvis app (jarvis/dashboards/themes/<key>/theme.json). The Python validator
+// reads those specs for its allow-lists, so any drift here would validate saves
+// against a spec the canvas doesn't actually render — this test fails loudly.
+
+const CURATED = ["jarvis", "insight", "claude", "graphite"]
+
+function loadSpec(key) {
+	const url = new URL(`../../../jarvis/dashboards/themes/${key}/theme.json`, import.meta.url)
+	return JSON.parse(readFileSync(url, "utf8"))
+}
+
+// Extract the --jd-* declarations from the first :root{} block of a theme's css.
+function rootVars(css) {
+	const m = /:root\{([\s\S]*?)\}/.exec(css)
+	assert.ok(m, "theme css must contain a :root{} block")
+	const out = {}
+	for (const dm of m[1].matchAll(/--jd-([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+		out[dm[1]] = dm[2].trim()
+	}
+	return out
+}
+
+for (const key of CURATED) {
+	test(`theme.json <-> dashboardThemes.js sync: ${key}`, () => {
+		const spec = loadSpec(key)
+		const theme = THEMES[key]
+		assert.ok(theme, `THEMES.${key} exists`)
+
+		// identity fields
+		assert.equal(theme.key, spec.key)
+		assert.equal(theme.label, spec.label)
+		assert.equal(theme.dark, spec.dark)
+		assert.equal(theme.accent, spec.accent)
+		assert.deepEqual(theme.palette, spec.palette)
+
+		// every render token in the spec is emitted with the exact same value
+		const vars = rootVars(theme.css)
+		for (const [name, value] of Object.entries(spec.render_tokens)) {
+			assert.equal(vars[name], value, `--jd-${name} value drifted for ${key}`)
+		}
+		// and the css emits no --jd-* token the spec doesn't declare
+		for (const name of Object.keys(vars)) {
+			assert.ok(name in spec.render_tokens, `--jd-${name} in css but not in ${key}/theme.json`)
+		}
+	})
+}
+
+test("Custom theme is bespoke and has no theme.json (validator relaxes design)", () => {
+	assert.ok(THEMES.custom, "THEMES.custom exists")
+	assert.equal(THEMES.custom.bespoke, true)
+	// It is intentionally NOT in the curated/synced set.
+	assert.ok(!CURATED.includes("custom"))
+})

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -1,0 +1,266 @@
+<template>
+	<div class="relative flex h-full min-h-0 w-full flex-col">
+		<!-- §3.8 empty state - builder: "ask in chat"; view: "this is empty" -->
+		<div
+			v-if="!html"
+			class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
+		>
+			<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+			<div class="flex flex-col items-center gap-1">
+				<span class="text-lg font-medium text-ink-gray-8">
+					{{ mode === "builder" ? "Nothing on the canvas yet" : "This dashboard is empty" }}
+				</span>
+				<span class="text-p-base text-ink-gray-6">
+					{{
+						mode === "builder"
+							? "Ask for a dashboard in the chat below."
+							: "It has no saved content to show."
+					}}
+				</span>
+			</div>
+		</div>
+
+		<!-- §3.8 error + retry (srcdoc assembly / echarts chunk load failed) -->
+		<div
+			v-else-if="buildError"
+			class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
+		>
+			<ErrorMessage :message="buildError" />
+			<Button label="Retry" :loading="building" @click="rebuild" />
+		</div>
+
+		<template v-else>
+			<!-- sandbox: allow-scripts ONLY (no allow-same-origin, no allow-popups) -
+			     paired with the srcdoc CSP (no network, inline-only) the dashboard
+			     runs fully isolated; all data arrives over postMessage. -->
+			<iframe
+				ref="frame"
+				:srcdoc="doc"
+				sandbox="allow-scripts"
+				class="w-full border-0"
+				:class="mode === 'view' ? '' : 'min-h-0 flex-1'"
+				:style="mode === 'view' ? { height: frameH + 'px' } : null"
+				title="Dashboard canvas"
+			/>
+			<div
+				v-if="loading"
+				class="absolute inset-0 flex items-center justify-center bg-surface-white/60"
+			>
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+			</div>
+		</template>
+	</div>
+</template>
+
+<script setup>
+// DashboardCanvas - the sandboxed dashboard surface, shared by the builder
+// (mode="builder": fixed pane, sources executed ad-hoc via call_tool from the
+// spec the HTML itself declares) and the saved view page (mode="view": iframe
+// grows to its content, sources executed by name via run_dashboard_source -
+// the SERVER-stored spec is authoritative and the frame's spec is ignored).
+// The srcdoc is assembled by lib/dashboardSrcdoc (CSP + bridge runtime); the
+// echarts source only loads (dynamic ?raw import, its own chunk) when the
+// html actually references echarts. The named dashboard theme (--jd-* vars)
+// owns the canvas look; switching it rebuilds the document.
+import { ref, watch, onMounted, onBeforeUnmount } from "vue"
+import { Button, ErrorMessage, FeatherIcon, LoadingIndicator } from "frappe-ui"
+import { buildSrcdoc, parseSourcesBlock } from "@/lib/dashboardSrcdoc"
+import { THEMES, DEFAULT_THEME, themeKey } from "@/lib/dashboardThemes"
+import { loadCaptureLib, downloadPng, downloadPdf } from "@/lib/dashboardExport"
+import { runDashboardSource, callDashboardTool } from "@/api/dashboards"
+
+const props = defineProps({
+	mode: { type: String, default: "builder" }, // "builder" | "view"
+	html: { type: String, default: "" },
+	dashboard: { type: Object, default: null }, // view mode: {name} at minimum
+	caps: { type: Object, default: () => ({}) },
+	// Named render theme (lib/dashboardThemes key or DocType label). The canvas
+	// look belongs to the dashboard, not the app shell - app dark mode does not
+	// restyle it, the picker does.
+	theme: { type: String, default: DEFAULT_THEME },
+})
+
+// sources: the parsed #jarvis-sources list (save-dialog preview + payload);
+// state: "empty" | "loading" | "ready" | "error" for hosts that care.
+const emit = defineEmits(["sources", "state"])
+
+const frame = ref(null)
+const doc = ref("")
+const loading = ref(false)
+const building = ref(false)
+const buildError = ref("")
+const frameH = ref(480) // view mode: grown by the iframe's height frames
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+function postToFrame(msg) {
+	const fw = frame.value && frame.value.contentWindow
+	if (fw) fw.postMessage({ jarvis: 1, ...msg }, "*")
+}
+
+// ── srcdoc assembly ──────────────────────────────────────────────────────────
+let readyTimer = null
+async function rebuild() {
+	if (!props.html) {
+		doc.value = ""
+		emit("state", "empty")
+		return
+	}
+	building.value = true
+	buildError.value = ""
+	loading.value = true
+	emit("state", "loading")
+	try {
+		let echartsSource = ""
+		if (/\becharts\b/i.test(props.html)) {
+			// Filesystem-relative ?raw import: echarts' exports map blocks bare
+			// deep imports; the raw source ships as its own lazy chunk.
+			const mod = await import("../../../node_modules/echarts/dist/echarts.min.js?raw")
+			echartsSource = (mod && mod.default) || ""
+		}
+		doc.value = buildSrcdoc(props.html, {
+			echartsSource,
+			theme: THEMES[themeKey(props.theme)],
+		})
+		// Safety valve: if the frame never posts ready (user script threw before
+		// our runtime's DOMContentLoaded, etc.) don't spin forever.
+		clearTimeout(readyTimer)
+		readyTimer = setTimeout(() => (loading.value = false), 8000)
+	} catch (e) {
+		buildError.value = errMsg(e)
+		loading.value = false
+		emit("state", "error")
+	} finally {
+		building.value = false
+	}
+}
+
+watch(
+	() => props.html,
+	(h) => {
+		emit("sources", parseSourcesBlock(h))
+		rebuild()
+	},
+	{ immediate: true },
+)
+
+// Theme switches rebuild the document (charts re-init against the new
+// palette) - a full reload is simpler and more reliable than live restyling.
+watch(
+	() => props.theme,
+	() => rebuild(),
+)
+
+// ── data bridge ──────────────────────────────────────────────────────────────
+// run_report results resolve inside the iframe as {columns, rows}; query/
+// get_list results resolve as the plain rows array (documented in RUNTIME_JS).
+function dataPayload(data) {
+	if (data && typeof data === "object" && !Array.isArray(data)) {
+		if (data.columns) return { columns: data.columns, rows: data.rows || [] }
+		if (Array.isArray(data.rows)) return data.rows
+	}
+	return data
+}
+
+async function handleData(d) {
+	let reply
+	try {
+		// call_tool dispatches kwargs: query takes its DSL object under the
+		// `spec` kwarg; get_list/run_report take the object AS their kwargs.
+		const args = d.tool === "query" ? { spec: d.spec } : d.spec
+		const env =
+			props.mode === "view"
+				? await runDashboardSource(props.dashboard && props.dashboard.name, d.name)
+				: await callDashboardTool(d.tool, args)
+		if (env && env.ok) {
+			reply = { ok: true, rows: dataPayload(env.data) }
+		} else {
+			const err = (env && env.error) || {}
+			reply = {
+				ok: false,
+				error: {
+					code: err.code || "InternalError",
+					message: err.message || "Couldn't load this data",
+				},
+			}
+		}
+	} catch (e) {
+		// Thrown (non-envelope) server error - map onto the bridge's codes.
+		const code =
+			e && (e.status === 403 || e.exc_type === "PermissionError")
+				? "PermissionError"
+				: e && (e.status === 404 || e.exc_type === "DoesNotExistError")
+					? "NotFound"
+					: "InternalError"
+		reply = { ok: false, error: { code, message: errMsg(e) } }
+	}
+	// Data failures render per-widget INSIDE the iframe (jarvis.renderError) -
+	// never a toast out here.
+	postToFrame({ type: "data:result", id: d.id, ...reply })
+}
+
+// ── export (lib injection + downloads live in lib/dashboardExport) ───────────
+const pendingExports = {}
+let exportSeq = 0
+
+async function exportAs(format, title) {
+	const lib = await loadCaptureLib()
+	const id = "x" + ++exportSeq
+	const result = new Promise((resolve, reject) => {
+		pendingExports[id] = {
+			resolve,
+			reject,
+			timer: setTimeout(() => {
+				delete pendingExports[id]
+				reject(new Error("Export timed out"))
+			}, 60000),
+		}
+	})
+	// pdf = the slide deck path (section.slide per page); png = one full-body shot
+	postToFrame({ type: "export", id, format: format === "pdf" ? "slides" : "png", lib, pixelRatio: 2 })
+	const images = await result
+	if (format === "pdf") await downloadPdf(images, title)
+	else downloadPng(images, title)
+}
+defineExpose({ exportAs })
+
+// ── frame messages (validated: our iframe's window + the jarvis:1 stamp) ─────
+function onMessage(e) {
+	const fw = frame.value && frame.value.contentWindow
+	if (!fw || e.source !== fw) return
+	const d = e.data
+	if (!d || d.jarvis !== 1) return
+	if (d.type === "ready") {
+		clearTimeout(readyTimer)
+		loading.value = false
+		emit("state", "ready")
+	} else if (d.type === "height") {
+		if (props.mode === "view") frameH.value = Math.max(480, Math.ceil(d.height || 0))
+	} else if (d.type === "data") {
+		handleData(d)
+	} else if (d.type === "export:result") {
+		const p = pendingExports[d.id]
+		if (!p) return
+		delete pendingExports[d.id]
+		clearTimeout(p.timer)
+		if (d.ok) p.resolve(d.images || [])
+		else {
+			const err = new Error((d.error && d.error.message) || "Export failed")
+			err.code = (d.error && d.error.code) || "CaptureFailed"
+			p.reject(err)
+		}
+	}
+}
+
+onMounted(() => window.addEventListener("message", onMessage))
+onBeforeUnmount(() => {
+	window.removeEventListener("message", onMessage)
+	clearTimeout(readyTimer)
+	for (const id of Object.keys(pendingExports)) {
+		clearTimeout(pendingExports[id].timer)
+		delete pendingExports[id]
+	}
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -1,0 +1,532 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden bg-surface-white">
+		<!-- header: title + New chat / Open in chat -->
+		<div class="flex shrink-0 items-start justify-between gap-2 border-b px-4 py-3">
+			<div class="flex min-w-0 flex-col gap-0.5">
+				<span class="text-base font-semibold text-ink-gray-9">Describe a dashboard</span>
+				<span class="text-p-sm text-ink-gray-6">Jarvis draws it on the canvas above</span>
+			</div>
+			<div class="flex shrink-0 items-center gap-1">
+				<Button
+					v-if="conversation"
+					variant="ghost"
+					label="Open in chat"
+					iconLeft="message-circle"
+					@click="router.push('/c/' + conversation)"
+				/>
+				<Button variant="ghost" label="New chat" iconLeft="plus" @click="newChat" />
+			</div>
+		</div>
+
+		<!-- transcript -->
+		<div ref="scroller" class="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+			<div v-if="loadingTranscript && !bubbles.length" class="flex justify-center py-8">
+				<LoadingIndicator class="size-5 text-ink-gray-5" />
+			</div>
+
+			<!-- empty state: nudge toward the natural-language flow -->
+			<div
+				v-else-if="!bubbles.length && !runActive"
+				class="flex h-full flex-col items-center justify-center gap-3 px-2 text-center"
+			>
+				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-base font-medium text-ink-gray-8">Describe a dashboard</span>
+					<span class="text-p-sm text-ink-gray-6">
+						e.g. "Monthly sales by territory with a top-customers table"
+					</span>
+				</div>
+			</div>
+
+			<div v-else class="flex flex-col gap-3">
+				<template v-for="m in bubbles" :key="m.name">
+					<!-- user: right-aligned surface-gray bubble -->
+					<div v-if="m.role === 'user'" class="flex justify-end">
+						<div
+							class="max-w-[85%] whitespace-pre-wrap rounded-lg bg-surface-gray-2 px-3 py-2 text-base text-ink-gray-8"
+						>
+							{{ m.content }}
+						</div>
+					</div>
+					<!-- assistant error: inline red note (ChatView semantics, compact) -->
+					<div v-else-if="m.error" class="flex">
+						<div class="max-w-[95%] text-sm text-ink-red-4">
+							{{ m.content || "That didn't go through. Try again." }}
+						</div>
+					</div>
+					<!-- assistant: markdown, same renderer + prose classes as the
+					     Approvals/Agents surfaces (renderMarkdown escapes HTML first) -->
+					<div v-else class="flex">
+						<div
+							class="prose prose-sm min-w-0 max-w-none text-ink-gray-8"
+							v-html="renderBubble(m.content)"
+						/>
+					</div>
+				</template>
+
+				<!-- thinking indicator: subtle three-dot pulse while a run is active -->
+				<div v-if="runActive" role="status" aria-live="polite" class="flex items-center gap-2 pt-1">
+					<span class="flex gap-1" aria-hidden="true">
+						<span
+							v-for="i in 3"
+							:key="i"
+							class="size-1.5 rounded-full bg-surface-gray-5 motion-safe:animate-pulse"
+							:style="{ animationDelay: (i - 1) * 0.18 + 's' }"
+						/>
+					</span>
+					<span class="text-xs text-ink-gray-5">Thinking…</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- parked ERP-write confirmations (create/update Jarvis Dashboard…):
+		     rendered in-pane so a chat-driven save never dead-ends into the
+		     full chat view just to click Approve -->
+		<div v-if="pendingCards.length" class="flex shrink-0 flex-col gap-2 border-t px-4 py-3">
+			<div
+				v-for="pa in pendingCards"
+				:key="pa.token"
+				class="flex flex-col gap-2 rounded-md p-3 ring-1 ring-outline-gray-modals"
+			>
+				<!-- human headline (+ detail line from the dry-run preview), never
+				     the raw "create_doc doctype=…" tool string -->
+				<div class="flex min-w-0 flex-col gap-0.5">
+					<span class="text-sm font-medium text-ink-gray-8">{{ cardTitle(pa) }}</span>
+					<span v-if="cardMeta(pa)" class="text-xs text-ink-gray-6">{{ cardMeta(pa) }}</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<Button variant="solid" label="Approve" :loading="pa.busy" @click="approve(pa)" />
+					<Button variant="ghost" label="Dismiss" :disabled="pa.busy" @click="dismiss(pa)" />
+				</div>
+			</div>
+		</div>
+
+		<!-- composer: autosizing textarea + voice + send -->
+		<div class="shrink-0 border-t px-4 py-3">
+			<div ref="box" @keydown="onKeydown" @input="autoGrow">
+				<FormControl
+					type="textarea"
+					:rows="2"
+					placeholder="Describe the dashboard…"
+					:modelValue="draft"
+					:disabled="sending"
+					@update:modelValue="(v) => (draft = v)"
+				/>
+			</div>
+			<div class="mt-2 flex items-center justify-between gap-2">
+				<div class="flex items-center gap-1.5">
+					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
+					<!-- explicit data-mode: Auto lets the agent decide; Static bakes the
+					     numbers in (one-time report); Live declares view-time sources.
+					     TabButtons = real radio-group semantics + the raised-chip look,
+					     so the active option isn't a second solid next to Send. -->
+					<span class="ml-1 text-xs text-ink-gray-5" title="How this dashboard gets its data">
+						Data
+					</span>
+					<TabButtons
+						:buttons="DATA_MODES"
+						:model-value="dataMode"
+						@update:model-value="(v) => (dataMode = v || 'auto')"
+					/>
+				</div>
+				<Button
+					variant="solid"
+					label="Send"
+					:disabled="!draft.trim()"
+					:loading="sending"
+					@click="send"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+// DashboardChatPane - the embedded assistant chat on the Dashboards builder
+// tab (bottom pane); a fork of triggers/TriggerChatPane.vue. State machine:
+//   conversation id  → useStorage("jarvis-dash-conv-<user>") - persisted per
+//                      user; "" means no conversation yet.
+//   first send       → send_message(conversation:"", context {"page":"dashboards"})
+//                      creates/focuses one server-side; the returned
+//                      conversation_id is stored.
+//   mount w/ stored  → load its transcript; a 404 (deleted chat) silently
+//                      clears storage and starts fresh.
+//   realtime         → "jarvis:event" frames for OUR conversation schedule a
+//                      debounced (300ms) get_conversation refetch; run:start
+//                      raises run-active, run:end / run:error clear it.
+//                      kind==="canvas" frames for our conversation bubble up
+//                      as emit("canvas", {message_id, items}) - the page pulls
+//                      the html artifact onto the canvas pane.
+//   no socket        → (?nosocket / headless QA) a bounded refetch ladder after
+//                      each send stands in for the realtime frames.
+import { ref, computed, nextTick, inject, onMounted, onBeforeUnmount } from "vue"
+import { useRouter } from "vue-router"
+import { useStorage } from "@vueuse/core"
+import { Button, FeatherIcon, FormControl, LoadingIndicator, TabButtons, toast } from "frappe-ui"
+import VoiceRecorder from "@/components/VoiceRecorder.vue"
+import { renderMarkdown } from "@/markdown"
+import { session } from "@/data/session"
+import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards"
+import { listPendingConfirmations, confirmTool, dismissTool } from "@/api"
+
+// get_dashboards_caps payload (creatable_scopes/manageable_roles feed the save
+// dialog; stt_enabled - when the backend sends it - gates the mic)
+const props = defineProps({
+	caps: { type: Object, default: () => ({}) },
+	// when revising a saved dashboard, its name — forwarded in the send context
+	// so the agent knows which dashboard it is iterating on ("" = a new one).
+	editingName: { type: String, default: "" },
+})
+
+// canvas: {message_id, items} for a canvas frame on our conversation;
+// activity: a run ended (the page may refresh lists); reset: New chat clicked.
+const emit = defineEmits(["canvas", "activity", "reset"])
+
+const router = useRouter()
+const socket = inject("$socket", null)
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+// ── conversation persistence (per user, ChatComposer's namespacing idiom) ────
+const conversation = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "")
+
+// ── transcript ────────────────────────────────────────────────────────────────
+const messages = ref([])
+const loadingTranscript = ref(false)
+const scroller = ref(null)
+
+// user/assistant rows with visible content only (tool rows and internal
+// chatter stay out of this compact pane)
+const bubbles = computed(() =>
+	messages.value.filter(
+		(m) => (m.role === "user" || m.role === "assistant") && String(m.content || "").trim()
+	)
+)
+
+// ChatView's stripBlocks, minimal subset: internal fenced blocks (actions,
+// confirms, cards…) never render as raw fences in the pane.
+function stripBlocks(text) {
+	return (text || "")
+		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```confirm[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-ask[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-cards[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-skill[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-macro[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/```jarvis-chart[ \t]*\n[\s\S]*?```/g, "")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim()
+}
+function renderBubble(text) {
+	return renderMarkdown(stripBlocks(text))
+}
+
+function scrollBottom() {
+	const el = scroller.value
+	if (el) el.scrollTop = el.scrollHeight
+}
+
+function isGone(e) {
+	return !!(
+		e &&
+		(e.status === 404 ||
+			e.exc_type === "DoesNotExistError" ||
+			e.status === 403 ||
+			e.exc_type === "PermissionError")
+	)
+}
+
+// monotonic request id - stale refetches dropped (useListPage idiom)
+let loadReq = 0
+async function loadTranscript({ initial = false } = {}) {
+	const id = ++loadReq
+	if (!conversation.value) return
+	if (initial) loadingTranscript.value = true
+	try {
+		const d = (await getDashboardConversation(conversation.value)) || {}
+		if (id !== loadReq) return
+		messages.value = d.messages || []
+		nextTick(scrollBottom)
+	} catch (e) {
+		if (id !== loadReq) return
+		if (isGone(e)) {
+			// the stored conversation was deleted (or reassigned) - start fresh
+			conversation.value = ""
+			messages.value = []
+			runActive.value = false
+		}
+		// transient errors keep the last-good transcript; the next frame retries
+	} finally {
+		if (id === loadReq) loadingTranscript.value = false
+	}
+}
+
+// debounced refetch driven by realtime frames
+let refetchTimer = null
+function scheduleRefetch() {
+	clearTimeout(refetchTimer)
+	refetchTimer = setTimeout(() => {
+		loadTranscript()
+		refreshPending()
+	}, 300)
+}
+
+// ── parked confirmations (gated ERP writes park for human approval) ──────────
+const pendingCards = ref([])
+
+async function refreshPending() {
+	if (!conversation.value) {
+		pendingCards.value = []
+		return
+	}
+	try {
+		const env = await listPendingConfirmations(conversation.value)
+		const items = (env && env.data && env.data.pending) || []
+		// keep in-flight busy flags across refreshes
+		const busy = new Set(pendingCards.value.filter((c) => c.busy).map((c) => c.token))
+		pendingCards.value = items.map((it) => ({ ...it, busy: busy.has(it.token) }))
+	} catch {
+		// transient - the next frame retries
+	}
+}
+
+function removeCard(token) {
+	pendingCards.value = pendingCards.value.filter((c) => c.token !== token)
+}
+
+// ── pending-card copy ─────────────────────────────────────────────────────────
+// A card only carries what list_pending_confirmations returns (token, tool,
+// preview, summary, conversation, run_id). Rich path: a sandboxed dry-run
+// preview (preview.would = the doc exactly as it would save) names the
+// dashboard and its scope. Fallback: clean the _describe_call line
+// ("create_doc doctype=…" → "Create a …") so the raw tool string never shows.
+const CARD_VERBS = {
+	create_doc: "Create",
+	update_doc: "Update",
+	delete_doc: "Delete",
+	submit_doc: "Submit",
+	cancel_doc: "Cancel",
+}
+const SCOPE_LABELS = { User: "Private", Role: "Shared with a role", Org: "Everyone" }
+function previewDoc(pa) {
+	const w = pa && pa.preview && pa.preview.would
+	return w && typeof w === "object" && !Array.isArray(w) ? w : null
+}
+// _describe_call joins "key=value" pairs with spaces and values may hold
+// spaces ("Jarvis Dashboard") - a value runs until the next key or the end.
+// Anchored on a word boundary so "name=" never matches inside "docname=".
+function summaryArg(s, key) {
+	const m = new RegExp("(?:^|\\s)" + key + "=(.*?)(?=\\s+[a-z_]+=|$)").exec(s || "")
+	return m ? m[1].trim() : ""
+}
+function cardTitle(pa) {
+	const verb = CARD_VERBS[pa.tool]
+	const doc = previewDoc(pa)
+	if (doc && doc.doctype === "Jarvis Dashboard") {
+		return `${verb || "Save"} dashboard: ${doc.dashboard_title || doc.name || "(unnamed)"}`
+	}
+	if (doc && doc.doctype && verb) {
+		const name = verb === "Create" ? "" : doc.name || ""
+		return `${verb} ${doc.doctype}${name ? " · " + name : ""}`
+	}
+	const raw = pa.summary || (pa.preview && pa.preview.summary) || ""
+	const m = /^(create|update|delete|submit|cancel)_doc\b/.exec(raw)
+	if (m) {
+		const v = CARD_VERBS[m[1] + "_doc"]
+		const dt = summaryArg(raw, "doctype")
+		const nm = summaryArg(raw, "name") || summaryArg(raw, "docname")
+		if (dt === "Jarvis Dashboard") return `${v} a dashboard${nm ? ": " + nm : ""}`
+		if (dt) return `${v} ${dt}${nm ? " · " + nm : ""}`
+	}
+	return raw || "Confirm this action"
+}
+function cardMeta(pa) {
+	const doc = previewDoc(pa)
+	if (!doc || doc.doctype !== "Jarvis Dashboard") return ""
+	const scope =
+		doc.scope === "Role" && doc.target_role
+			? `Shared with ${doc.target_role}`
+			: SCOPE_LABELS[doc.scope] || ""
+	return [doc.dashboard_type, scope].filter(Boolean).join(" · ")
+}
+
+async function approve(pa) {
+	pa.busy = true
+	try {
+		const r = await confirmTool(pa.token, conversation.value)
+		if (r && r.ok === false) {
+			toast.error("Couldn't confirm — it may have expired. Ask again in the chat.")
+		}
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		removeCard(pa.token)
+		// the parked run resumes server-side after a confirm: refresh both the
+		// transcript (receipt chip) and anything list-shaped upstream
+		scheduleRefetch()
+		emit("activity")
+	}
+}
+
+async function dismiss(pa) {
+	pa.busy = true
+	try {
+		await dismissTool(pa.token, conversation.value)
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		removeCard(pa.token)
+		scheduleRefetch()
+	}
+}
+
+// ── run state + composer ──────────────────────────────────────────────────────
+const runActive = ref(false)
+const sending = ref(false)
+const draft = ref("")
+const box = ref(null)
+
+// Explicit data-mode toggle (goal requirement): "auto" = agent decides,
+// "static" = baked one-time report, "live" = declared view-time sources.
+// Persisted per user so the choice survives page hops. ("auto" rather than ""
+// so reka-ui's RadioGroup has a real value to select.) The API wrapper only
+// forwards static/live; auto sends no data_mode.
+const DATA_MODES = [
+	{ label: "Auto", value: "auto" },
+	{ label: "Static", value: "static" },
+	{ label: "Live", value: "live" },
+]
+const dataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto")
+
+function autoGrow() {
+	const ta = box.value && box.value.querySelector("textarea")
+	if (!ta) return
+	ta.style.height = "auto"
+	ta.style.height = Math.min(ta.scrollHeight, 180) + "px"
+}
+
+function onKeydown(e) {
+	// Enter sends, Shift+Enter keeps the newline
+	if (e.key === "Enter" && !e.shiftKey) {
+		e.preventDefault()
+		send()
+	}
+}
+
+function onTranscript(text) {
+	// dictation appends to any typed draft (ChatComposer precedent)
+	const cur = draft.value
+	draft.value = cur.trim() ? cur.replace(/\s+$/, "") + " " + text : text
+	nextTick(autoGrow)
+}
+
+async function send() {
+	const text = draft.value.trim()
+	if (!text || sending.value) return
+	sending.value = true
+	draft.value = ""
+	nextTick(autoGrow)
+	// optimistic user bubble - reconciled by the next transcript refetch
+	const tmpName = `tmp-${Date.now()}`
+	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }]
+	nextTick(scrollBottom)
+	try {
+		const r =
+			(await sendDashboardChat(conversation.value, text, dataMode.value, props.editingName)) || {}
+		if (r.ok === false) {
+			// rejected (single-flight guard / usage cap) - nothing persisted
+			messages.value = messages.value.filter((m) => m.name !== tmpName)
+			if (!draft.value) draft.value = text
+			toast.error(r.reason || "Couldn't send your message.")
+			return
+		}
+		if (r.conversation_id && r.conversation_id !== conversation.value) {
+			conversation.value = r.conversation_id
+		}
+		runActive.value = true
+		nextTick(scrollBottom)
+		if (!socket) startNoSocketLadder()
+	} catch (e) {
+		messages.value = messages.value.filter((m) => m.name !== tmpName)
+		if (!draft.value) draft.value = text
+		toast.error(errMsg(e))
+	} finally {
+		sending.value = false
+	}
+}
+
+function newChat() {
+	loadReq++ // drop any in-flight transcript load
+	conversation.value = ""
+	messages.value = []
+	pendingCards.value = []
+	runActive.value = false
+	draft.value = ""
+	nextTick(autoGrow)
+	// the page clears its builder seed (canvas html, editing state) with us
+	emit("reset")
+}
+defineExpose({ newChat })
+
+// ── realtime ──────────────────────────────────────────────────────────────────
+function onEvent(p) {
+	if (!p || !p.kind) return
+	// turn frames carry conversation_id; action:pending frames carry conversation
+	const frameConv = p.conversation_id || p.conversation
+	if (!conversation.value || frameConv !== conversation.value) return
+	// the agent drew/updated an artifact this turn - the page pulls the html
+	// item onto the canvas pane
+	if (p.kind === "canvas") {
+		emit("canvas", { message_id: p.message_id, items: p.items })
+		return
+	}
+	// any frame for OUR conversation refreshes the transcript (debounced)
+	scheduleRefetch()
+	switch (p.kind) {
+		case "run:start":
+			runActive.value = true
+			break
+		case "run:end":
+			runActive.value = false
+			emit("activity")
+			break
+		case "run:error":
+			runActive.value = false
+			break
+	}
+}
+
+// no-socket fallback (?nosocket / headless QA): a bounded refetch ladder after
+// each send; run-active clears when the reply settles (or at the ladder's end).
+let ladderTimers = []
+function startNoSocketLadder() {
+	ladderTimers.forEach(clearTimeout)
+	ladderTimers = [3000, 8000, 15000, 30000, 60000].map((ms, i, arr) =>
+		setTimeout(async () => {
+			await loadTranscript()
+			await refreshPending()
+			const last = bubbles.value[bubbles.value.length - 1]
+			const settled = last && last.role === "assistant" && !last.streaming
+			if (settled || i === arr.length - 1) {
+				runActive.value = false
+				emit("activity")
+			}
+		}, ms)
+	)
+}
+
+onMounted(() => {
+	if (conversation.value) {
+		loadTranscript({ initial: true })
+		refreshPending()
+	}
+	socket && socket.on && socket.on("jarvis:event", onEvent)
+})
+onBeforeUnmount(() => {
+	socket && socket.off && socket.off("jarvis:event", onEvent)
+	clearTimeout(refetchTimer)
+	ladderTimers.forEach(clearTimeout)
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -173,6 +173,9 @@ import { listPendingConfirmations, confirmTool, dismissTool } from "@/api"
 // dialog; stt_enabled - when the backend sends it - gates the mic)
 const props = defineProps({
 	caps: { type: Object, default: () => ({}) },
+	// the selected theme key (lowercase) — forwarded in the send context so the
+	// agent designs FOR that theme (the skill injects its token+recipe cheatsheet).
+	theme: { type: String, default: "jarvis" },
 	// when revising a saved dashboard, its name — forwarded in the send context
 	// so the agent knows which dashboard it is iterating on ("" = a new one).
 	editingName: { type: String, default: "" },
@@ -434,7 +437,13 @@ async function send() {
 	nextTick(scrollBottom)
 	try {
 		const r =
-			(await sendDashboardChat(conversation.value, text, dataMode.value, props.editingName)) || {}
+			(await sendDashboardChat(
+				conversation.value,
+				text,
+				dataMode.value,
+				props.editingName,
+				props.theme,
+			)) || {}
 		if (r.ok === false) {
 			// rejected (single-flight guard / usage cap) - nothing persisted
 			messages.value = messages.value.filter((m) => m.name !== tmpName)

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -477,7 +477,17 @@ function newChat() {
 	// the page clears its builder seed (canvas html, editing state) with us
 	emit("reset")
 }
-defineExpose({ newChat })
+
+// Post a message into this pane programmatically (the save dialog's "Ask the
+// assistant to fix these" hand-off). Ignored while a send is already in flight.
+function sendText(text) {
+	const t = String(text || "").trim()
+	if (!t || sending.value) return
+	draft.value = t
+	nextTick(autoGrow)
+	send()
+}
+defineExpose({ newChat, sendText })
 
 // ── realtime ──────────────────────────────────────────────────────────────────
 function onEvent(p) {

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -1,0 +1,310 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<LayoutHeader>
+			<template #left-header>
+				<Breadcrumbs
+					:items="[
+						{ label: 'Dashboards', route: { name: 'DashboardsPage', hash: '#saved' } },
+						{ label: detail ? detail.dashboard_title || detail.name : id },
+					]"
+				/>
+			</template>
+			<template #right-header>
+				<template v-if="detail">
+					<Dropdown v-if="moreOptions.length" :options="moreOptions">
+						<!-- label → aria-label on icon-only buttons (frappe-ui) -->
+						<Button icon="more-horizontal" variant="ghost" label="Dashboard actions" />
+					</Dropdown>
+					<!-- render theme: editors persist the pick, viewers restyle locally -->
+					<Dropdown :options="themeOptions">
+						<Button
+							variant="ghost"
+							:label="themeLabel(viewTheme)"
+							iconLeft="droplet"
+							iconRight="chevron-down"
+						/>
+					</Dropdown>
+					<Button label="Discuss in chat" iconLeft="message-circle" @click="discussInChat" />
+					<Button
+						v-if="detail.can_edit"
+						label="Edit in builder"
+						iconLeft="edit-2"
+						@click="router.push({ name: 'DashboardsPage', query: { edit: detail.name } })"
+					/>
+					<Dropdown :options="exportOptions">
+						<Button
+							variant="solid"
+							label="Export"
+							iconRight="chevron-down"
+							:loading="exporting"
+						/>
+					</Dropdown>
+				</template>
+			</template>
+		</LayoutHeader>
+
+		<!-- loading -->
+		<div v-if="loading" class="flex flex-1 items-center justify-center">
+			<LoadingIndicator class="size-5 text-ink-gray-5" />
+		</div>
+
+		<!-- §3.8 permission-blocked state -->
+		<div v-else-if="blocked" class="flex flex-1 flex-col items-center justify-center gap-3 px-8">
+			<div class="flex flex-col items-center gap-3 rounded-md border border-dashed p-8 text-center">
+				<FeatherIcon name="alert-triangle" class="size-10 text-ink-red-4" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-lg font-medium text-ink-gray-8">No access to this dashboard</span>
+					<span class="text-p-base text-ink-gray-6">
+						It may be private or shared with a role you don't hold.
+					</span>
+				</div>
+				<Button label="Back to dashboards" iconLeft="arrow-left" @click="goBack" />
+			</div>
+		</div>
+
+		<!-- not found -->
+		<div v-else-if="notFound" class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+			<FeatherIcon name="bar-chart-2" class="size-10 text-ink-gray-4" />
+			<div class="flex flex-col items-center gap-1">
+				<span class="text-lg font-medium text-ink-gray-8">Dashboard not found</span>
+				<span class="text-p-base text-ink-gray-6">It may have been deleted.</span>
+			</div>
+			<Button label="Back to dashboards" iconLeft="arrow-left" @click="goBack" />
+		</div>
+
+		<!-- §3.8 error + retry (transient load failure) -->
+		<div v-else-if="error" class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+			<ErrorMessage :message="error" />
+			<Button label="Retry" :loading="loading" @click="load" />
+		</div>
+
+		<!-- the dashboard -->
+		<div v-else-if="detail" class="min-h-0 flex-1 overflow-y-auto">
+			<div class="flex flex-wrap items-center gap-2 px-5 pt-4">
+				<h1 class="text-lg font-semibold text-ink-gray-9">
+					{{ detail.dashboard_title || detail.name }}
+				</h1>
+				<Badge
+					v-if="detail.dashboard_type"
+					variant="subtle"
+					theme="gray"
+					:label="detail.dashboard_type"
+				/>
+				<Badge
+					v-if="detail.scope === 'Role'"
+					variant="subtle"
+					theme="blue"
+					:label="detail.target_role || 'Role'"
+				/>
+				<Badge v-else-if="detail.scope === 'Org'" variant="subtle" theme="blue" label="Everyone" />
+				<Badge v-else variant="subtle" theme="gray" label="Private" />
+			</div>
+			<p v-if="detail.description" class="px-5 pt-1 text-p-sm text-ink-gray-6">
+				{{ detail.description }}
+			</p>
+			<div class="px-5 py-4">
+				<DashboardCanvas
+					ref="canvas"
+					mode="view"
+					:html="detail.html"
+					:dashboard="{ name: detail.name }"
+					:caps="caps"
+					:theme="viewTheme"
+				/>
+			</div>
+		</div>
+
+		<SaveDashboardDialog
+			v-model="shareOpen"
+			share-only
+			:caps="caps"
+			:html="detail ? detail.html : ''"
+			:sources="detail ? detail.sources || [] : []"
+			:editing="detail"
+			@saved="onShared"
+		/>
+
+		<!-- Hand-rolled so the destructive action is a RED solid button (§3.2);
+		     frappe-ui's confirmDialog helper hardcodes a gray "Confirm". -->
+		<Dialog v-model="deleteOpen" :options="deleteDialogOptions" />
+	</div>
+</template>
+
+<script setup>
+// DashboardView - /dashboards/:id, the read-only render of a saved dashboard.
+// The canvas runs mode="view": data resolves by SOURCE NAME through
+// run_dashboard_source (the server-stored spec is authoritative; whatever spec
+// the html itself declares is ignored here), and the iframe grows to its
+// reported height while this page scrolls. Export captures inside the iframe
+// (html-to-image injected over postMessage - the CSP allows no external
+// fetches) and assembles PNG/PDF downloads out here.
+import { ref, computed, onMounted } from "vue"
+import { useRouter } from "vue-router"
+import {
+	Badge,
+	Breadcrumbs,
+	Button,
+	Dialog,
+	Dropdown,
+	ErrorMessage,
+	FeatherIcon,
+	LoadingIndicator,
+	toast,
+} from "frappe-ui"
+import LayoutHeader from "@/components/LayoutHeader.vue"
+import { setChatPrefill } from "@/composables/chatPrefill"
+import { getDashboard, getDashboardsCaps, deleteDashboard, saveDashboard } from "@/api/dashboards"
+import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes"
+import DashboardCanvas from "./DashboardCanvas.vue"
+import SaveDashboardDialog from "./SaveDashboardDialog.vue"
+
+const props = defineProps({
+	id: { type: String, required: true },
+})
+
+const router = useRouter()
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const detail = ref(null)
+const loading = ref(true)
+const blocked = ref(false)
+const notFound = ref(false)
+const error = ref("")
+const canvas = ref(null)
+const exporting = ref(false)
+const shareOpen = ref(false)
+
+// Render theme: seeded from the saved dashboard; picking restyles immediately
+// and (for editors) persists quietly — viewers just restyle their own view.
+const viewTheme = ref(DEFAULT_THEME)
+const themeOptions = THEME_OPTIONS.map((t) => ({
+	label: t.label,
+	onClick: () => pickTheme(t.key),
+}))
+async function pickTheme(key) {
+	viewTheme.value = key
+	if (!(detail.value && detail.value.can_edit)) return
+	try {
+		await saveDashboard({ name: detail.value.name, theme: themeLabel(key) })
+		detail.value.theme = themeLabel(key)
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
+// caps feed the share dialog's scope options; best-effort (share stays hidden
+// until they land - view/export need nothing from them).
+const caps = ref({ creatable_scopes: [], manageable_roles: [] })
+
+async function load() {
+	loading.value = true
+	blocked.value = false
+	notFound.value = false
+	error.value = ""
+	try {
+		detail.value = (await getDashboard(props.id)) || null
+		if (!detail.value) notFound.value = true
+		else viewTheme.value = themeKey(detail.value.theme)
+	} catch (e) {
+		if (e && (e.status === 403 || e.exc_type === "PermissionError")) blocked.value = true
+		else if (e && (e.status === 404 || e.exc_type === "DoesNotExistError")) notFound.value = true
+		else error.value = errMsg(e)
+	} finally {
+		loading.value = false
+	}
+}
+
+function goBack() {
+	router.push({ name: "DashboardsPage", hash: "#saved" })
+}
+
+// ── header actions ───────────────────────────────────────────────────────────
+const canShare = computed(
+	() => !!(detail.value && detail.value.can_edit && (caps.value.creatable_scopes || []).length > 1)
+)
+
+const moreOptions = computed(() => {
+	const out = []
+	if (canShare.value) out.push({ label: "Share…", icon: "users", onClick: () => (shareOpen.value = true) })
+	if (detail.value && detail.value.can_edit) {
+		out.push({ label: "Delete", icon: "trash-2", theme: "red", onClick: confirmDelete })
+	}
+	return out
+})
+
+const exportOptions = [
+	{ label: "PNG image", onClick: () => doExport("png") },
+	{ label: "PDF slides", onClick: () => doExport("pdf") },
+]
+
+async function doExport(format) {
+	if (exporting.value || !canvas.value) return
+	exporting.value = true
+	try {
+		await canvas.value.exportAs(format, detail.value && detail.value.dashboard_title)
+	} catch (e) {
+		toast.error(errMsg(e))
+	} finally {
+		exporting.value = false
+	}
+}
+
+const deleteOpen = ref(false)
+function confirmDelete() {
+	deleteOpen.value = true
+}
+const deleteDialogOptions = computed(() => {
+	const title = (detail.value && detail.value.dashboard_title) || props.id
+	return {
+		title: "Delete dashboard?",
+		message: `Delete “${title}”? This can't be undone.`,
+		actions: [
+			{
+				label: "Delete dashboard",
+				variant: "solid",
+				theme: "red",
+				onClick: async ({ close }) => {
+					try {
+						await deleteDashboard(props.id)
+						close()
+						toast.success("Dashboard deleted")
+						goBack()
+					} catch (e) {
+						toast.error(errMsg(e))
+					}
+				},
+			},
+		],
+	}
+})
+
+function onShared(fresh) {
+	if (fresh && fresh.name) detail.value = fresh
+	toast.success("Sharing updated")
+}
+
+// Hand the dashboard to the main chat as viewing context (api.js#sendMessage
+// forwards `context` because it carries a doctype) and let ChatView's prefill
+// consumption start a fresh conversation + auto-send.
+function discussInChat() {
+	const title = (detail.value && detail.value.dashboard_title) || props.id
+	setChatPrefill({
+		text: `Let's discuss the dashboard "${title}" — what does it show and what stands out?`,
+		autoSend: true,
+		context: { doctype: "Jarvis Dashboard", name: props.id },
+	})
+	router.push("/")
+}
+
+onMounted(() => {
+	load()
+	getDashboardsCaps()
+		.then((c) => {
+			if (c) caps.value = { ...caps.value, ...c }
+		})
+		.catch(() => {})
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardView.vue
+++ b/frontend/src/pages/dashboards/DashboardView.vue
@@ -179,8 +179,12 @@ const shareOpen = ref(false)
 
 // Render theme: seeded from the saved dashboard; picking restyles immediately
 // and (for editors) persists quietly — viewers just restyle their own view.
+// Custom is EXCLUDED from the VIEW picker: opting a dashboard out of the enforced
+// standard is a deliberate author/build-time choice, not a one-click view action
+// (it would silently downgrade governance on a shared dashboard). It stays in the
+// builder picker where the author owns the document.
 const viewTheme = ref(DEFAULT_THEME)
-const themeOptions = THEME_OPTIONS.map((t) => ({
+const themeOptions = THEME_OPTIONS.filter((t) => t.key !== "custom").map((t) => ({
 	label: t.label,
 	onClick: () => pickTheme(t.key),
 }))

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -1,0 +1,393 @@
+<template>
+	<div class="flex h-full flex-col overflow-hidden">
+		<!-- friendly no-access state: get_dashboards_caps rejected with a real 403
+		     (TriggersPage probe precedent - transient failures retry, never block) -->
+		<template v-if="accessDenied">
+			<div class="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+				<FeatherIcon name="bar-chart-2" class="size-7.5 text-ink-gray-5" />
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-lg font-medium text-ink-gray-8">No access to Dashboards</span>
+					<span class="text-p-base text-ink-gray-6">
+						Ask your Jarvis admin for access to dashboards.
+					</span>
+				</div>
+			</div>
+		</template>
+
+		<template v-else>
+			<!-- THE LayoutHeader for /dashboards (both tabs; SavedDashboardsTab's
+			     ListPage runs show-header=false) -->
+			<LayoutHeader>
+				<template #left-header>
+					<Breadcrumbs :items="[{ label: 'Dashboards', route: { name: 'DashboardsPage' } }]" />
+				</template>
+				<template #right-header>
+					<Button
+						v-if="activeTab === 'saved'"
+						variant="solid"
+						label="New dashboard"
+						iconLeft="plus"
+						@click="newDashboard"
+					/>
+				</template>
+			</LayoutHeader>
+
+			<TabBar class="shrink-0" :tabs="TABS" :model-value="activeTab" @update:model-value="setTab" />
+
+			<!-- ============ Builder tab: canvas over chat, drag-split ============ -->
+			<!-- self-hosted benches have no gateway canvas route, so chat can't
+			     produce a rendered dashboard - say so instead of an eternal empty
+			     canvas (caps.canvas_available from get_dashboards_caps). -->
+			<div
+				v-if="activeTab === 'builder' && caps.canvas_available === false"
+				class="flex items-start gap-2 border-b bg-surface-amber-1 px-4 py-2"
+			>
+				<FeatherIcon name="alert-triangle" class="mt-0.5 size-4 shrink-0 text-ink-amber-3" />
+				<span class="text-sm text-ink-gray-7">
+					Live canvas rendering isn't available on this deployment, so chat can't draw a
+					dashboard here. You can still open and view saved dashboards.
+				</span>
+			</div>
+			<div v-if="activeTab === 'builder'" ref="builderEl" class="flex min-h-0 flex-1 flex-col">
+				<!-- canvas pane (the surface's one solid action lives here) -->
+				<div
+					class="flex min-h-0 flex-1 flex-col"
+					:class="resizing ? 'pointer-events-none select-none' : ''"
+				>
+					<div class="flex shrink-0 items-center justify-between gap-2 border-b px-4 py-2">
+						<div class="flex min-w-0 items-center gap-2">
+							<span class="text-base font-semibold text-ink-gray-9">Canvas</span>
+							<!-- informational (which dashboard is loaded), not a dirty
+							     warning - so gray, not orange (§1.2 hue = meaning) -->
+							<Badge
+								v-if="editingDetail"
+								theme="gray"
+								variant="subtle"
+								:label="`Editing ${editingDetail.dashboard_title || editingDetail.name}`"
+							/>
+						</div>
+						<div class="flex shrink-0 items-center gap-3">
+							<router-link
+								v-if="savedName"
+								:to="{ name: 'DashboardView', params: { id: savedName } }"
+								class="text-sm text-ink-blue-link"
+							>
+								View dashboard
+							</router-link>
+							<!-- named render theme - the dashboard's look, not the app's -->
+							<Dropdown :options="themeOptions">
+								<Button
+								variant="ghost"
+								:label="themeLabel(builderTheme)"
+								iconLeft="droplet"
+								iconRight="chevron-down"
+							/>
+							</Dropdown>
+							<Button
+								variant="solid"
+								label="Save dashboard"
+								:disabled="!builderHtml"
+								@click="openSave"
+							/>
+						</div>
+					</div>
+					<DashboardCanvas
+						class="min-h-0 flex-1"
+						mode="builder"
+						:html="builderHtml"
+						:caps="caps"
+						:theme="builderTheme"
+						@sources="(s) => (detectedSources = s)"
+					/>
+				</div>
+
+				<!-- drag divider (Sidebar's resize pattern, rotated). While dragging,
+				     the canvas wrapper above goes pointer-events-none so the iframe
+				     can't swallow the mousemoves. -->
+				<div
+					class="group relative z-10 flex h-2.5 shrink-0 cursor-row-resize items-center justify-center"
+					role="separator"
+					aria-orientation="horizontal"
+					title="Drag to resize · double-click to reset"
+					@mousedown.prevent="startResize"
+					@dblclick="resetSplit"
+				>
+					<span
+						class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 transition-colors"
+						:class="resizing ? 'bg-surface-gray-4' : 'bg-transparent group-hover:bg-surface-gray-4'"
+					/>
+					<span
+						class="relative h-1 w-7 rounded-full bg-surface-gray-4 transition-opacity"
+						:class="resizing ? 'opacity-100' : 'opacity-30 group-hover:opacity-100'"
+					/>
+				</div>
+
+				<DashboardChatPane
+					ref="chatPane"
+					class="shrink-0 border-t"
+					:style="{ height: chatPct + '%' }"
+					:caps="caps"
+					:editing-name="editingDetail ? editingDetail.name : ''"
+					@canvas="onCanvas"
+					@reset="resetBuilder"
+				/>
+			</div>
+
+			<!-- ============ Saved tab ============ -->
+			<SavedDashboardsTab v-else class="min-h-0 flex-1" />
+
+			<SaveDashboardDialog
+				v-model="saveOpen"
+				:caps="caps"
+				:html="builderHtml"
+				:sources="detectedSources"
+				:editing="editingDetail"
+				:conversation="chatConv"
+				:theme="builderTheme"
+				@saved="onSaved"
+			/>
+		</template>
+	</div>
+</template>
+
+<script setup>
+// DashboardsPage - the routed component for /dashboards: hash-synced tab shell
+// (TriggersPage precedent; no hash or "#builder" = Builder, "#saved" = Saved)
+// plus the single get_dashboards_caps probe that feeds both tabs. The Builder
+// tab is the core UX: the sandboxed canvas on top, the assistant chat below,
+// split by a draggable divider (persisted %). The chat's canvas frames pull
+// the agent's html artifact onto the canvas; Save opens the scope/title
+// dialog; ?edit=<name> seeds the canvas from a saved dashboard for editing.
+// Probe failures follow the TriggersPage rule: a genuine 403 shows the
+// no-access state; a transient 500/network blip retries once and otherwise
+// proceeds with default caps rather than blocking an authorized user.
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { useStorage } from "@vueuse/core"
+import { Badge, Breadcrumbs, Button, Dropdown, FeatherIcon, toast } from "frappe-ui"
+import LayoutHeader from "@/components/LayoutHeader.vue"
+import TabBar from "@/components/list/TabBar.vue"
+import { session } from "@/data/session"
+import { getCanvas } from "@/api"
+import { getDashboardsCaps, getDashboard } from "@/api/dashboards"
+import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes"
+import DashboardCanvas from "./DashboardCanvas.vue"
+import DashboardChatPane from "./DashboardChatPane.vue"
+import SavedDashboardsTab from "./SavedDashboardsTab.vue"
+import SaveDashboardDialog from "./SaveDashboardDialog.vue"
+
+const route = useRoute()
+const router = useRouter()
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const TABS = [
+	{ label: "Builder", value: "builder" },
+	{ label: "Saved", value: "saved" },
+]
+
+// caps flow down reactively - the save dialog's scope options appear once the
+// probe lands; the default keeps a plain User-scoped save path.
+const caps = ref({
+	creatable_scopes: ["User"],
+	manageable_roles: [],
+	max_sources: 0,
+	max_html_chars: 0,
+	max_rows: 0,
+	canvas_available: false,
+})
+const accessDenied = ref(false)
+
+// ── hash-synced tabs (TriggersPage precedent) ────────────────────────────────
+const activeTab = ref("builder")
+function applyHash() {
+	// tolerate suffixed forms like "#saved?x=1"
+	const h = (route.hash || "").replace(/^#/, "").split("?")[0]
+	activeTab.value = h === "saved" ? "saved" : "builder"
+}
+function setTab(v) {
+	if (v === activeTab.value) return
+	activeTab.value = v
+	router.push({ hash: v === "builder" ? "" : `#${v}`, query: route.query })
+}
+applyHash()
+// back/forward restores the tab (guard to this route so other pages' hashes
+// are ignored - the SkillsPage rule)
+watch(
+	() => route.hash,
+	() => {
+		if (route.name === "DashboardsPage") applyHash()
+	}
+)
+
+// ── builder state ────────────────────────────────────────────────────────────
+const builderHtml = ref("")
+const editingDetail = ref(null) // full get_dashboard detail while editing
+const savedName = ref("") // last save's name → the "View dashboard" link
+const detectedSources = ref([]) // parsed #jarvis-sources (DashboardCanvas emit)
+const saveOpen = ref(false)
+const chatPane = ref(null)
+// Named render theme; "Jarvis" (the app's design language) unless picked or
+// seeded from the edited dashboard.
+const builderTheme = ref(DEFAULT_THEME)
+const themeOptions = THEME_OPTIONS.map((t) => ({
+	label: t.label,
+	onClick: () => (builderTheme.value = t.key),
+}))
+
+// Same per-user keys DashboardChatPane persists under (vueuse syncs same-
+// document instances) — the page seeds/clears them around edit/new so the chat
+// pane resumes the right thread and data mode instead of a stale sticky one.
+const chatConv = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "")
+const dashDataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto")
+
+// Chat drew/updated an artifact: pick the LAST html item and pull its
+// render-ready content onto the canvas.
+async function onCanvas({ message_id, items }) {
+	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html")
+	if (!htmlItem || !message_id) return
+	try {
+		const r = await getCanvas(message_id, htmlItem.name, 0)
+		const content = r && (r.content || r.data_url)
+		if (content) builderHtml.value = content
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
+function openSave() {
+	if (!builderHtml.value) return
+	saveOpen.value = true
+}
+
+function onSaved(detail) {
+	savedName.value = (detail && detail.name) || ""
+	// keep editing the row we just saved - the next Save is "Save changes"
+	if (detail && detail.name) editingDetail.value = detail
+	toast.success("Dashboard saved")
+}
+
+// "New dashboard" (Saved tab header) - fresh chat + empty canvas on Builder.
+// One navigation clears the tab hash AND any ?edit seed together (resetBuilder
+// + setTab separately would race on route.query).
+function newDashboard() {
+	chatConv.value = "" // pane isn't mounted on the Saved tab; clear before it is
+	dashDataMode.value = "auto"
+	builderHtml.value = ""
+	editingDetail.value = null
+	savedName.value = ""
+	detectedSources.value = []
+	builderTheme.value = DEFAULT_THEME
+	activeTab.value = "builder"
+	router.push({ hash: "", query: {} })
+}
+
+// Also fired by the chat pane's own "New chat" (emit("reset")).
+function resetBuilder() {
+	chatConv.value = ""
+	dashDataMode.value = "auto"
+	builderHtml.value = ""
+	editingDetail.value = null
+	savedName.value = ""
+	detectedSources.value = []
+	builderTheme.value = DEFAULT_THEME
+	if (route.query.edit) router.replace({ query: {}, hash: route.hash })
+}
+
+// ?edit=<name> deep-link: seed the canvas + save dialog from a saved dashboard.
+// Also resume the conversation that built it (so the agent has memory of the
+// document) and seed the data-mode from its derived type, so an edit session
+// never silently drifts onto/converts the wrong dashboard.
+async function loadEdit(name) {
+	try {
+		const d = await getDashboard(name)
+		if (d && d.name) {
+			builderHtml.value = d.html || ""
+			editingDetail.value = d
+			savedName.value = d.name
+			builderTheme.value = themeKey(d.theme)
+			// resume the build thread, or a fresh one — never the stale sticky
+			// conversation left over from editing a different dashboard.
+			chatConv.value = d.source_conversation || ""
+			dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static"
+		}
+	} catch (e) {
+		toast.error(errMsg(e))
+	}
+}
+
+// ── the drag-split (Sidebar's resize machinery, vertical) ────────────────────
+const builderEl = ref(null)
+const _split = useStorage("jarvis-dash-split", 40)
+const clampPct = (n) => Math.min(70, Math.max(20, Math.round(Number(n) || 40)))
+const chatPct = computed({
+	get: () => clampPct(_split.value),
+	set: (v) => (_split.value = clampPct(v)),
+})
+const resizing = ref(false)
+let startY = 0
+let startPct = 40
+let containerH = 1
+
+function startResize(e) {
+	if (e.button !== 0) return
+	resizing.value = true
+	startY = e.clientY
+	startPct = chatPct.value
+	containerH = (builderEl.value && builderEl.value.getBoundingClientRect().height) || 1
+	window.addEventListener("mousemove", onResize)
+	window.addEventListener("mouseup", stopResize)
+	document.body.style.userSelect = "none"
+	document.body.style.cursor = "row-resize"
+}
+function onResize(e) {
+	chatPct.value = startPct + ((startY - e.clientY) / containerH) * 100
+}
+function stopResize() {
+	if (!resizing.value) return
+	resizing.value = false
+	window.removeEventListener("mousemove", onResize)
+	window.removeEventListener("mouseup", stopResize)
+	document.body.style.userSelect = ""
+	document.body.style.cursor = ""
+}
+function resetSplit() {
+	chatPct.value = 40
+}
+onBeforeUnmount(stopResize)
+
+// ── caps probe (403 vs transient, TriggersPage pattern) ──────────────────────
+function isPermissionError(e) {
+	return !!(e && (e.status === 403 || e.exc_type === "PermissionError"))
+}
+
+onMounted(async () => {
+	let fresh = null
+	try {
+		fresh = await getDashboardsCaps()
+	} catch (e) {
+		if (isPermissionError(e)) {
+			accessDenied.value = true
+			return
+		}
+		// transient (500/network) - retry once before giving up
+		await new Promise((r) => setTimeout(r, 1000))
+		try {
+			fresh = await getDashboardsCaps()
+		} catch (e2) {
+			if (isPermissionError(e2)) {
+				accessDenied.value = true
+				return
+			}
+			// still transient - keep the defaults instead of blocking
+			console.warn("get_dashboards_caps failed twice; keeping default caps", e2)
+		}
+	}
+	if (fresh) caps.value = { ...caps.value, ...fresh }
+
+	const edit = typeof route.query.edit === "string" ? route.query.edit : ""
+	if (edit) loadEdit(edit)
+})
+</script>

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -127,6 +127,7 @@
 					class="shrink-0 border-t"
 					:style="{ height: chatPct + '%' }"
 					:caps="caps"
+					:theme="builderTheme"
 					:editing-name="editingDetail ? editingDetail.name : ''"
 					@canvas="onCanvas"
 					@reset="resetBuilder"

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -146,6 +146,7 @@
 				:conversation="chatConv"
 				:theme="builderTheme"
 				@saved="onSaved"
+				@fix-in-chat="fixInChat"
 			/>
 		</template>
 	</div>
@@ -261,6 +262,14 @@ async function onCanvas({ message_id, items }) {
 function openSave() {
 	if (!builderHtml.value) return
 	saveOpen.value = true
+}
+
+// A theme-rejected save hands its violations back to the model: close the dialog
+// and post the message into the builder chat, so the agent regenerates on-theme
+// without the user relaying CSS jargon (P0-2).
+function fixInChat({ text }) {
+	saveOpen.value = false
+	if (chatPane.value && chatPane.value.sendText) chatPane.value.sendText(text)
 }
 
 function onSaved(detail) {

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -1,0 +1,195 @@
+<template>
+	<Dialog
+		:modelValue="modelValue"
+		:options="{ title: dialogTitle, size: 'md' }"
+		@update:modelValue="(v) => emit('update:modelValue', v)"
+	>
+		<template #body-content>
+			<div class="flex flex-col gap-4">
+				<template v-if="!shareOnly">
+					<div>
+						<FormControl
+							type="text"
+							label="Title"
+							required
+							placeholder="e.g. Monthly sales overview"
+							:modelValue="form.dashboard_title"
+							@update:modelValue="(v) => (form.dashboard_title = v)"
+						/>
+						<ErrorMessage :message="fieldErrors.title" class="mt-1" />
+					</div>
+					<FormControl
+						type="textarea"
+						label="Description"
+						:rows="2"
+						placeholder="What this dashboard shows (optional)"
+						:modelValue="form.description"
+						@update:modelValue="(v) => (form.description = v)"
+					/>
+				</template>
+
+				<FormControl
+					type="select"
+					label="Who can see it"
+					:options="scopeOptions"
+					:modelValue="form.scope"
+					@update:modelValue="(v) => (form.scope = v)"
+				/>
+				<div v-if="form.scope === 'Role'">
+					<FormControl
+						type="select"
+						label="Role"
+						:options="roleOptions"
+						:modelValue="form.target_role"
+						@update:modelValue="(v) => (form.target_role = v)"
+					/>
+					<ErrorMessage :message="fieldErrors.role" class="mt-1" />
+				</div>
+
+				<!-- read-only detected sources (parsed from the canvas html) -->
+				<div v-if="!shareOnly && sources.length" class="flex flex-col gap-1.5">
+					<span class="text-xs text-ink-gray-5">Data sources</span>
+					<div
+						v-for="s in sources"
+						:key="s.source_name"
+						class="flex items-center justify-between rounded-md border px-2.5 py-1.5"
+					>
+						<span class="truncate text-base text-ink-gray-8">{{ s.source_name }}</span>
+						<Badge :label="s.tool" theme="gray" variant="subtle" />
+					</div>
+				</div>
+
+				<ErrorMessage :message="error" />
+			</div>
+		</template>
+
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<Button label="Cancel" :disabled="saving" @click="emit('update:modelValue', false)" />
+				<Button variant="solid" :label="saveLabel" :loading="saving" @click="save" />
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup>
+// SaveDashboardDialog - the builder's save/save-changes form (title,
+// description, visibility scope, read-only detected sources) and, via
+// `shareOnly`, the view page's "Share…" dialog (the same scope section with
+// everything else hidden; the payload re-sends the loaded detail unchanged).
+// Sources come from the parsed #jarvis-sources block (DashboardCanvas emit) -
+// the same list the payload's `sources` key carries.
+import { reactive, ref, computed, watch } from "vue"
+import { Badge, Button, Dialog, ErrorMessage, FormControl } from "frappe-ui"
+import { saveDashboard } from "@/api/dashboards"
+import { themeLabel } from "@/lib/dashboardThemes"
+
+const props = defineProps({
+	modelValue: { type: Boolean, default: false },
+	caps: { type: Object, default: () => ({}) },
+	html: { type: String, default: "" },
+	sources: { type: Array, default: () => [] }, // [{source_name, tool, spec}]
+	// existing detail when editing/sharing: {name, dashboard_title, description,
+	// scope, target_role, source_conversation}
+	editing: { type: Object, default: null },
+	conversation: { type: String, default: "" }, // source_conversation for new saves
+	shareOnly: { type: Boolean, default: false },
+	// active render theme key (lib/dashboardThemes); persisted with the save
+	theme: { type: String, default: "" },
+})
+
+const emit = defineEmits(["update:modelValue", "saved"])
+
+function errMsg(e) {
+	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+const SCOPE_LABELS = { User: "Private", Role: "Shared with a role", Org: "Everyone" }
+
+const scopeOptions = computed(() =>
+	(props.caps.creatable_scopes || ["User"]).map((s) => ({
+		label: SCOPE_LABELS[s] || s,
+		value: s,
+	}))
+)
+const roleOptions = computed(() => [
+	{ label: "Select a role", value: "" },
+	...(props.caps.manageable_roles || []).map((r) => ({ label: r, value: r })),
+])
+
+const dialogTitle = computed(() =>
+	props.shareOnly ? "Share dashboard" : props.editing ? "Save changes" : "Save dashboard"
+)
+const saveLabel = computed(() =>
+	props.shareOnly ? "Update sharing" : props.editing ? "Save changes" : "Save dashboard"
+)
+
+const form = reactive({ dashboard_title: "", description: "", scope: "User", target_role: "" })
+const saving = ref(false)
+const error = ref("")
+const fieldErrors = reactive({ title: "", role: "" })
+
+// (Re)seed on every open so a reopened dialog never shows stale edits.
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (!open) return
+		error.value = ""
+		fieldErrors.title = ""
+		fieldErrors.role = ""
+		const e = props.editing
+		form.dashboard_title = (e && e.dashboard_title) || ""
+		form.description = (e && e.description) || ""
+		const scopes = props.caps.creatable_scopes || ["User"]
+		// private-first: even an admin (whose creatable_scopes lead with Org)
+		// must opt INTO sharing, never share by default
+		form.scope =
+			e && e.scope && scopes.includes(e.scope)
+				? e.scope
+				: scopes.includes("User")
+					? "User"
+					: scopes[0] || "User"
+		form.target_role = (e && e.target_role) || ""
+	}
+)
+
+async function save() {
+	fieldErrors.title = ""
+	fieldErrors.role = ""
+	error.value = ""
+	const e = props.editing
+	const title = props.shareOnly ? (e && e.dashboard_title) || "" : form.dashboard_title.trim()
+	if (!title) {
+		fieldErrors.title = "Give the dashboard a title."
+		return
+	}
+	if (form.scope === "Role" && !form.target_role) {
+		fieldErrors.role = "Pick the role to share with."
+		return
+	}
+	// save_dashboard rejects unknown keys, so the payload carries exactly the
+	// documented set; target_role only rides along for Role scope.
+	const payload = {
+		dashboard_title: title,
+		description: props.shareOnly ? (e && e.description) || "" : form.description || "",
+		html: props.html,
+		scope: form.scope,
+		sources: props.sources,
+		source_conversation: (e && e.source_conversation) || props.conversation || "",
+		// share-only re-sends the stored theme; the builder persists the picker's
+		theme: props.shareOnly ? (e && e.theme) || "Jarvis" : themeLabel(props.theme),
+	}
+	if (e && e.name) payload.name = e.name
+	if (form.scope === "Role") payload.target_role = form.target_role
+	saving.value = true
+	try {
+		const detail = await saveDashboard(payload)
+		emit("saved", detail)
+		emit("update:modelValue", false)
+	} catch (err) {
+		error.value = errMsg(err)
+	} finally {
+		saving.value = false
+	}
+}
+</script>

--- a/frontend/src/pages/dashboards/SaveDashboardDialog.vue
+++ b/frontend/src/pages/dashboards/SaveDashboardDialog.vue
@@ -60,6 +60,15 @@
 				</div>
 
 				<ErrorMessage :message="error" />
+				<!-- theme rejection is recoverable: hand the violations to the model,
+				     so the user never relays CSS jargon (P0-2) -->
+				<div v-if="themeError && !shareOnly" class="flex justify-start">
+					<Button
+						label="Ask the assistant to fix these"
+						iconLeft="message-circle"
+						@click="askAssistantToFix"
+					/>
+				</div>
 			</div>
 		</template>
 
@@ -98,10 +107,19 @@ const props = defineProps({
 	theme: { type: String, default: "" },
 })
 
-const emit = defineEmits(["update:modelValue", "saved"])
+const emit = defineEmits(["update:modelValue", "saved", "fix-in-chat"])
 
 function errMsg(e) {
 	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong."
+}
+
+// A theme-standard rejection (ThemeStandardError) is recoverable via the model:
+// surface the human messages AND offer a one-click hand-off to the builder chat.
+function isThemeError(e) {
+	if (!e) return false
+	if (e.exc_type === "ThemeStandardError") return true
+	const m = (e.messages && e.messages[0]) || e.message || ""
+	return /does not follow the selected theme/i.test(m)
 }
 
 const SCOPE_LABELS = { User: "Private", Role: "Shared with a role", Org: "Everyone" }
@@ -127,29 +145,41 @@ const saveLabel = computed(() =>
 const form = reactive({ dashboard_title: "", description: "", scope: "User", target_role: "" })
 const saving = ref(false)
 const error = ref("")
+const themeError = ref(false)
 const fieldErrors = reactive({ title: "", role: "" })
 
-// (Re)seed on every open so a reopened dialog never shows stale edits.
+function seedForm() {
+	const e = props.editing
+	form.dashboard_title = (e && e.dashboard_title) || ""
+	form.description = (e && e.description) || ""
+	const scopes = props.caps.creatable_scopes || ["User"]
+	// private-first: even an admin (whose creatable_scopes lead with Org) must opt
+	// INTO sharing, never share by default
+	form.scope =
+		e && e.scope && scopes.includes(e.scope)
+			? e.scope
+			: scopes.includes("User")
+				? "User"
+				: scopes[0] || "User"
+	form.target_role = (e && e.target_role) || ""
+}
+
+// Reseed only when the underlying document IDENTITY changes (a different saved
+// dashboard, "New dashboard", or the first save turning a draft into a saved
+// doc) — NOT on every reopen. The new theme validator makes reject→fix→reopen the
+// most common reason a NEW dashboard's dialog opens twice, so preserve whatever
+// title/description/scope the user already typed across that loop (P1-5).
+watch(() => (props.editing && props.editing.name) || "", () => seedForm(), { immediate: true })
+
+// On open, only clear transient error/field state — never the draft fields.
 watch(
 	() => props.modelValue,
 	(open) => {
 		if (!open) return
 		error.value = ""
+		themeError.value = false
 		fieldErrors.title = ""
 		fieldErrors.role = ""
-		const e = props.editing
-		form.dashboard_title = (e && e.dashboard_title) || ""
-		form.description = (e && e.description) || ""
-		const scopes = props.caps.creatable_scopes || ["User"]
-		// private-first: even an admin (whose creatable_scopes lead with Org)
-		// must opt INTO sharing, never share by default
-		form.scope =
-			e && e.scope && scopes.includes(e.scope)
-				? e.scope
-				: scopes.includes("User")
-					? "User"
-					: scopes[0] || "User"
-		form.target_role = (e && e.target_role) || ""
 	}
 )
 
@@ -157,6 +187,7 @@ async function save() {
 	fieldErrors.title = ""
 	fieldErrors.role = ""
 	error.value = ""
+	themeError.value = false
 	const e = props.editing
 	const title = props.shareOnly ? (e && e.dashboard_title) || "" : form.dashboard_title.trim()
 	if (!title) {
@@ -188,8 +219,22 @@ async function save() {
 		emit("update:modelValue", false)
 	} catch (err) {
 		error.value = errMsg(err)
+		themeError.value = isThemeError(err)
 	} finally {
 		saving.value = false
 	}
+}
+
+// Hand the theme violations to the builder chat so the model self-corrects — the
+// user never has to relay CSS jargon. The dialog closes; the parent forwards the
+// text to the chat pane (P0-2).
+function askAssistantToFix() {
+	emit("fix-in-chat", {
+		text:
+			"Saving this dashboard failed the theme check. Please fix these and " +
+			"re-publish the full document:\n\n" +
+			error.value,
+	})
+	emit("update:modelValue", false)
 }
 </script>

--- a/frontend/src/pages/dashboards/SavedDashboardsTab.vue
+++ b/frontend/src/pages/dashboards/SavedDashboardsTab.vue
@@ -1,0 +1,159 @@
+<template>
+	<!-- show-header=false: DashboardsPage owns the single LayoutHeader teleport
+	     (the SkillsPage "exactly one at a time" rule) -->
+	<ListPage
+		:show-header="false"
+		class="min-h-0 flex-1"
+		:columns="columns"
+		:rows="rows"
+		:loading="loading"
+		:total="total"
+		:has-more="hasMore"
+		:quick-filters="quickFilters"
+		:filter-defs="filterDefs"
+		:filters="filters"
+		:sort-options="sortOptions"
+		:sort="sort"
+		:page-length="pageLength"
+		:default-sort="DEFAULT_SORT"
+		:get-row-route="getRowRoute"
+		storage-key="dashboards"
+		:empty-state="emptyState"
+		@update:filters="setFilters"
+		@update:sort="(s) => setSort(s.field, s.dir)"
+		@update:page-length="(v) => (pageLength = v)"
+		@load-more="loadMore"
+		@refresh="resetLoad"
+	>
+		<template #cell-dashboard_title="{ row }">
+			<div class="truncate text-base font-medium text-ink-gray-8">
+				{{ row.dashboard_title || row.name }}
+			</div>
+		</template>
+
+		<template #cell-dashboard_type="{ row }">
+			<Badge
+				v-if="row.dashboard_type"
+				variant="subtle"
+				theme="gray"
+				:label="row.dashboard_type"
+			/>
+			<span v-else class="text-base text-ink-gray-4">-</span>
+		</template>
+
+		<template #cell-scope="{ row }">
+			<Badge
+				v-if="row.scope === 'Role'"
+				variant="subtle"
+				theme="blue"
+				:label="row.target_role || 'Role'"
+			/>
+			<Badge v-else-if="row.scope === 'Org'" variant="subtle" theme="blue" label="Everyone" />
+			<Badge v-else variant="subtle" theme="gray" label="Private" />
+		</template>
+
+		<template #cell-modified="{ row }">
+			<Tooltip v-if="row.modified" :text="exactDate(row.modified)">
+				<div class="truncate text-base">{{ timeAgo(row.modified) }}</div>
+			</Tooltip>
+			<span v-else class="text-base text-ink-gray-4">-</span>
+		</template>
+	</ListPage>
+</template>
+
+<script setup>
+// SavedDashboardsTab - the "Saved" tab body on /dashboards#saved: the standard
+// envelope list (MacrosList wiring minus the TabBar/header - the host page
+// owns those). Rows route to the read-only DashboardView page.
+import { computed } from "vue"
+import { Badge, Tooltip } from "frappe-ui"
+import ListPage from "@/components/list/ListPage.vue"
+import { useListPage } from "@/composables/useListPage"
+import { timeAgo, exactDate } from "@/utils/datetime"
+import { listDashboardsPage } from "@/api/dashboards"
+
+const SCOPE_OPTIONS = [
+	{ label: "All", value: "" },
+	{ label: "Everyone", value: "Org" },
+	{ label: "Shared with a role", value: "Role" },
+	{ label: "Private", value: "User" },
+]
+// dashboard_type is derived server-side: sources present -> Connected.
+const TYPE_OPTIONS = [
+	{ label: "All", value: "" },
+	{ label: "Static", value: "Static" },
+	{ label: "Connected", value: "Connected" },
+]
+
+const columns = [
+	{ label: "Title", key: "dashboard_title", width: 2 },
+	{ label: "Type", key: "dashboard_type", width: "7rem" },
+	{ label: "Visibility", key: "scope", width: "9rem" },
+	{ label: "Owner", key: "owner", width: "10rem" },
+	{ label: "Updated", key: "modified", width: "8rem" },
+]
+
+// search rides the quick-filter strip (MacrosList idiom): it lives in the
+// filters object for a controlled input, and fetchFn moves it onto the
+// envelope's `search` param (the backend throws on unknown filter keys).
+const quickFilters = [
+	{ key: "search", label: "Search dashboards", type: "text" },
+	{ key: "scope", label: "Visibility", type: "select", options: SCOPE_OPTIONS },
+	{ key: "dashboard_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+]
+const filterDefs = [
+	{ key: "scope", label: "Visibility", type: "select", options: SCOPE_OPTIONS },
+	{ key: "dashboard_type", label: "Type", type: "select", options: TYPE_OPTIONS },
+]
+
+const sortOptions = [
+	{ label: "Updated", value: "modified" },
+	{ label: "Title", value: "dashboard_title" },
+	{ label: "Owner", value: "owner" },
+]
+const DEFAULT_SORT = { field: "modified", dir: "desc" }
+
+const {
+	rows,
+	total,
+	hasMore,
+	loading,
+	filters,
+	setFilters,
+	sort,
+	setSort,
+	pageLength,
+	resetLoad,
+	loadMore,
+} = useListPage({
+	fetchFn: (p) => {
+		const { search: q, ...rest } = p.filters || {}
+		return listDashboardsPage({ ...p, search: q || p.search || "", filters: rest })
+	},
+	defaultSort: DEFAULT_SORT,
+	storageKey: "dashboards",
+})
+
+// §3.8: when a search/filter is active but matches nothing, the empty state
+// must point at the filters, not read "you have nothing saved".
+const hasActiveFilter = computed(() =>
+	Boolean((filters.search || "").trim() || filters.scope || filters.dashboard_type),
+)
+const emptyState = computed(() =>
+	hasActiveFilter.value
+		? {
+				icon: "search",
+				title: "No matching dashboards",
+				description: "Change your search terms or filters.",
+			}
+		: {
+				icon: "bar-chart-2",
+				title: "No dashboards yet",
+				description: "Build one with chat in the Builder tab, then save it here.",
+			},
+)
+
+function getRowRoute(row) {
+	return { name: "DashboardView", params: { id: row.name } }
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -76,6 +76,20 @@ const routes = [
 		component: () => import("@/pages/triggers/TriggerDetail.vue"),
 		props: true,
 	},
+	// Dashboards: /dashboards is the hash-tabbed builder/saved shell (no hash or
+	// "#builder" = Builder, "#saved" = Saved); /dashboards/:id renders a saved
+	// dashboard read-only.
+	{
+		path: "/dashboards",
+		name: "DashboardsPage",
+		component: () => import("@/pages/dashboards/DashboardsPage.vue"),
+	},
+	{
+		path: "/dashboards/:id",
+		name: "DashboardView",
+		component: () => import("@/pages/dashboards/DashboardView.vue"),
+		props: true,
+	},
 	{ path: "/files", name: "FilesList", component: () => import("@/pages/files/FilesList.vue") },
 	// §15.2: both approval routes render the two-pane board (the :id row is
 	// selected in place); names kept so nav highlighting + router.push targets

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -31,6 +31,7 @@ const settingsOpen = ref(false) // the shell SettingsDialog binds to this
 const settingsSection = ref("general") // active pane key in the settings dialog
 const pendingNewChat = ref(false) // consumed + cleared by ChatView
 const paletteOpen = ref(false)
+const moreMenuOpen = ref(false) // the sidebar "More" destinations palette (MoreMenu.vue)
 
 // Chat-scoped context published by ChatView WHILE MOUNTED (null otherwise), so
 // the shell-level settings panes can read the current conversation's live stats
@@ -300,6 +301,7 @@ const store = reactive({
 	notifyEnabled,
 	pendingNewChat,
 	paletteOpen,
+	moreMenuOpen,
 	sidebarPref,
 	sidebarCollapsed,
 	sidebarWidth,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -659,7 +659,7 @@
 					<div class="jv-artifact-body">
 						<iframe v-if="artifact.kind === 'pdf'" :src="artifact.url" class="jv-artifact-frame" title="PDF preview"></iframe>
 						<img v-else-if="artifact.kind === 'image'" :src="artifact.url" class="jv-artifact-img" :alt="artifact.cv.title" />
-						<iframe v-else-if="artifact.kind === 'html' || artifact.kind === 'svg'" :srcdoc="artifact.content" sandbox="allow-scripts allow-popups" class="jv-artifact-frame" title="Artifact preview"></iframe>
+						<iframe v-else-if="artifact.kind === 'html' || artifact.kind === 'svg'" :srcdoc="artifact.content" sandbox="allow-scripts" class="jv-artifact-frame" title="Artifact preview"></iframe>
 						<template v-else-if="artifact.kind === 'table'">
 							<div v-if="artifact.sheets.length > 1" class="jv-sheet-tabs">
 								<button v-for="(sh, si) in artifact.sheets" :key="si" :class="{ on: si === artifact.sheetIdx }" @click="setSheet(si)">{{ sh.name }}</button>
@@ -3410,6 +3410,9 @@ function resendFailed(m) {
 	send(txt)
 }
 
+// One-shot viewing context from a "Discuss in chat" hand-off (chatPrefill's
+// optional `context`, e.g. a dashboard): consumed by the first send below.
+let _prefillSendContext = null
 async function send(textArg) {
 	// Don't race an in-flight dictation: sending now would drop the spoken
 	// words (the transcript would land after the message left the composer).
@@ -3463,7 +3466,8 @@ async function send(textArg) {
 		// One-shot wiki grounding: pass the armed flag but only CONSUME it on a
 		// successful send, so a rejected send (and its Retry) keeps grounding armed.
 		const groundWiki = groundNextTurn.value
-		const sendCtx = groundWiki ? { ground_wiki: 1 } : undefined
+		const sendCtx = groundWiki ? { ground_wiki: 1 } : _prefillSendContext || undefined
+		_prefillSendContext = null // one-shot: only the prefill's first send carries it
 		const r = await api.sendMessage(sentFrom, text, undefined, attachments, sendCtx)
 		if (r && r.ok === false) {
 			// The server rejected the send (e.g. the single-flight guard:
@@ -4262,6 +4266,7 @@ onMounted(async () => {
 	// path).
 	if (applyPrefill) {
 		input.value = prefill.text
+		_prefillSendContext = prefill.context || null // rides send()'s context arg
 		await nextTick()
 		autoGrow()
 		if (prefill.autoSend) await send()

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -364,6 +364,44 @@ def _search_pages(search: str, limit: int) -> list[dict]:
 	return out
 
 
+def _search_dashboards(search: str, limit: int) -> list[dict]:
+	"""Jarvis Dashboards, fuzzy-matched (subsequence) over their titles.
+	``frappe.get_list`` applies the Jarvis Dashboard query-conditions hook, so
+	the caller only ever sees dashboards their scope allows. Items carry a
+	``spa_route`` (the Jarvis SPA's own /dashboards page), NOT a desk
+	``route`` — there is no desk view for these."""
+	try:
+		rows = frappe.get_list(
+			"Jarvis Dashboard",
+			fields=["name", "dashboard_title", "dashboard_type", "modified"],
+			order_by="modified desc",
+			# Bounded scan: the palette fires this per keystroke. Fuzzy-rank the
+			# most-recent few hundred rather than every dashboard ever created.
+			limit_page_length=500,
+		)
+	except frappe.PermissionError:
+		return []
+	scored = []
+	for r in rows:
+		s = _fuzzy_score(search, r.get("dashboard_title") or "")
+		if s > 0:
+			scored.append((s, r))
+	scored.sort(key=lambda x: x[0], reverse=True)
+	out: list[dict] = []
+	for _s, r in scored[:limit]:
+		nm = r.get("name")
+		out.append(
+			{
+				"name": f"dashboard::{nm}",
+				"label": r.get("dashboard_title") or nm,
+				"icon": "bar-chart-2",
+				"suffix": "Dashboard",
+				"spa_route": f"/dashboards/{quote(str(nm))}",
+			}
+		)
+	return out
+
+
 def _search_records(search: str, limit: int) -> list[dict]:
 	"""Actual document matches via Frappe global search — full-text over
 	``__global_search``. ``frappe.utils.global_search.search`` is already scoped
@@ -403,15 +441,17 @@ def search_workspace(search: str = "", limit: int = 6) -> dict:
 	"""Full desk search over the caller's Frappe desk for the ⌘K palette,
 	delegated entirely to Frappe's own search (no bespoke matcher):
 
-	  * Lists   — matching doctypes,   via ``frappe.desk.search.search_widget``
-	  * Reports — matching reports,    via ``frappe.desk.search.search_widget``
-	  * Pages   — matching desk pages, via ``frappe.desk.search.search_widget``
-	  * Records — matching documents,  via ``frappe.utils.global_search.search``
+	  * Lists      — matching doctypes,   via ``frappe.desk.search.search_widget``
+	  * Reports    — matching reports,    via ``frappe.desk.search.search_widget``
+	  * Pages      — matching desk pages, via ``frappe.desk.search.search_widget``
+	  * Dashboards — matching Jarvis Dashboards (scope-visible), fuzzy title match
+	  * Records    — matching documents,  via ``frappe.utils.global_search.search``
 
-	Each item carries a ready ``/app/...`` desk route. Permission scoping is
-	Frappe's own (see the helpers). Empty search yields no groups; the palette
-	owns chats/nav.
-	Envelope: ``{groups: [{key, title, items: [{name,label,icon,suffix,route}]}]}``.
+	Each item carries a ready ``/app/...`` desk route — except Dashboards,
+	which carry an SPA-internal ``spa_route`` (no desk view exists for them).
+	Permission scoping is Frappe's own (see the helpers). Empty search yields
+	no groups; the palette owns chats/nav.
+	Envelope: ``{groups: [{key, title, items: [{name,label,icon,suffix,route|spa_route}]}]}``.
 	"""
 	search = (search or "").strip()
 	if not search:
@@ -426,6 +466,7 @@ def search_workspace(search: str = "", limit: int = 6) -> dict:
 		("lists", "Lists", _search_lists(search, limit)),
 		("reports", "Reports", _search_reports(search, limit)),
 		("pages", "Pages", _search_pages(search, limit)),
+		("dashboards", "Dashboards", _search_dashboards(search, limit)),
 		("records", "Records", _search_records(search, limit)),
 	):
 		if items:
@@ -959,9 +1000,9 @@ def send_message(
 		enqueue_kwargs["attachments"] = atts
 	# Floating-widget auto-context: {doctype, name, label} of the doc the user
 	# is viewing, OR {report_name, filters} when the user is on a
-	# query-report route, OR {page: "triggers"} when the user is on the
-	# Triggers page. Only forwarded when present, for the same
-	# not-yet-reloaded worker safety as attachments above. The narrowing
+	# query-report route, OR {page: "triggers"|"dashboards"} when the user is
+	# on the Triggers / Dashboards page. Only forwarded when present, for the
+	# same not-yet-reloaded worker safety as attachments above. The narrowing
 	# here is deliberate (allow-list, not passthrough) so a compromised /
 	# stale frontend can't smuggle arbitrary keys into the worker payload;
 	# every key the prompt-side actually consumes must be listed here.
@@ -970,12 +1011,12 @@ def send_message(
 			ctx = frappe.parse_json(context)
 			# ``ground_wiki`` is the composer's one-shot "ground this turn on the
 			# wiki" flag; it can arrive with no viewing-context doc, so forward the
-			# context payload when EITHER a doc/report ref OR ground_wiki OR the
-			# Triggers-page marker is set.
+			# context payload when EITHER a doc/report ref OR ground_wiki OR a
+			# page marker is set.
 			ground_wiki = 1 if (isinstance(ctx, dict) and frappe.utils.cint(ctx.get("ground_wiki"))) else 0
 			if isinstance(ctx, dict) and (
 				ctx.get("doctype") or ctx.get("report_name") or ground_wiki
-				or ctx.get("page") == "triggers"
+				or ctx.get("page") in ("triggers", "dashboards")
 			):
 				enqueue_kwargs["context"] = {
 					"doctype": ctx.get("doctype") or "",
@@ -989,10 +1030,17 @@ def send_message(
 					# One-shot wiki grounding (allow-listed, boolean only).
 					"ground_wiki": ground_wiki,
 				}
-				# `page` is a literal allow-list of one value (not a
-				# passthrough) — the prompt-side only consumes "triggers".
-				if ctx.get("page") == "triggers":
-					enqueue_kwargs["context"]["page"] = "triggers"
+				# `page` is a literal allow-list of two values (not a
+				# passthrough) — the prompt-side only consumes "triggers"
+				# and "dashboards".
+				if ctx.get("page") in ("triggers", "dashboards"):
+					enqueue_kwargs["context"]["page"] = ctx["page"]
+					# Dashboards builder's explicit data-mode toggle: the user
+					# declared whether they want a baked one-time report or a
+					# live data-connected one. Two literal values; absent =
+					# let the agent decide from the ask.
+					if ctx["page"] == "dashboards" and ctx.get("data_mode") in ("static", "live"):
+						enqueue_kwargs["context"]["data_mode"] = ctx["data_mode"]
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -76,6 +76,11 @@ from jarvis._subscription_models import (
 
 _ALLOWED_THINKING = {"", "low", "medium", "high"}
 
+# Curated dashboard canvas theme keys (lowercase) the builder may forward in the
+# send context — a literal allow-list (not passthrough), mirrors the DocType
+# `theme` Select + frontend/src/lib/dashboardThemes.js.
+_DASHBOARD_THEME_KEYS = {"jarvis", "insight", "claude", "graphite", "custom"}
+
 
 @frappe.whitelist()
 def list_tools() -> list[str]:
@@ -1041,6 +1046,11 @@ def send_message(
 					# let the agent decide from the ask.
 					if ctx["page"] == "dashboards" and ctx.get("data_mode") in ("static", "live"):
 						enqueue_kwargs["context"]["data_mode"] = ctx["data_mode"]
+					# The selected canvas theme key — forwarded so the prompt tells
+					# the agent which theme to design FOR (the dashboards skill injects
+					# that theme's token+recipe cheatsheet). Literal allow-list.
+					if ctx["page"] == "dashboards" and ctx.get("theme") in _DASHBOARD_THEME_KEYS:
+						enqueue_kwargs["context"]["theme"] = ctx["theme"]
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/canvas.py
+++ b/jarvis/chat/canvas.py
@@ -52,18 +52,56 @@ _CANVAS_LINK = re.compile(
 )
 _CANVAS_BARE = re.compile(rf"\S*?canvas/{_PATH}\.(?:{_EXTS})(?![\w])", re.IGNORECASE)
 
+# openclaw 2026.6+ "hosted embed" markers. The runtime's own system prompt
+# teaches the model to publish rich HTML as a hosted canvas document and
+# reference it with ``[embed ref="<id>" title="..." /]`` (or an explicit
+# ``[embed url="/__openclaw__/canvas/..." /]``). The gateway serves ref
+# documents at ``canvas/documents/<id>/index.html``, so refs fold into the
+# same fetch/persist path as plain canvas file references.
+_EMBED_MARKER = re.compile(r"\[embed\s[^\]]*\]", re.IGNORECASE)
+_EMBED_REF = re.compile(
+	r"\[embed\s[^\]]*?\bref=[\"']([\w.\-]+)[\"'][^\]]*\]", re.IGNORECASE
+)
+
+
+def _embed_ref_name(ref: str) -> str:
+	return f"documents/{ref}/index.html"
+
+
+# The canvas host appends its own client script to hosted documents (a
+# live-reload WebSocket + user-action channel on /__openclaw__/ws). Inside
+# the Jarvis sandbox that channel cannot exist — the iframe CSP blocks all
+# egress — so the script is dead weight that logs a CSP violation on every
+# render. Drop any script block that references the host socket.
+_SCRIPT_BLOCK = re.compile(r"<script\b.*?</script>", re.IGNORECASE | re.DOTALL)
+
+
+def _strip_host_client(text: str) -> str:
+	return _SCRIPT_BLOCK.sub(
+		lambda m: "" if "__openclaw__/ws" in m.group(0) else m.group(0), text
+	)
+
 
 def detect_canvas_names(text: str) -> list[str]:
 	"""Return canvas artifact paths referenced in ``text``, de-duplicated, in order.
 
 	Paths keep their subdir (e.g. ``charts/sales.html``) so the gateway fetch
-	hits the right URL.
+	hits the right URL. Hosted-embed refs are mapped to their gateway document
+	path (``documents/<id>/index.html``).
 	"""
 	if not text:
 		return []
 	seen: dict[str, None] = {}
 	for m in _CANVAS_REF.finditer(text):
-		seen.setdefault(m.group(1), None)
+		name = m.group(1)
+		# Reject path traversal: `_PATH` permits `..` segments, so a reply of
+		# `canvas/../../etc/passwd.html` would otherwise be fetched from the
+		# gateway with the bearer token. Only in-tree canvas paths are allowed.
+		if ".." in name.split("/"):
+			continue
+		seen.setdefault(name, None)
+	for m in _EMBED_REF.finditer(text):
+		seen.setdefault(_embed_ref_name(m.group(1)), None)
 	return list(seen)[:_MAX_CANVAS_PER_TURN]
 
 
@@ -132,7 +170,21 @@ def strip_canvas_refs(content: str, names: list[str]) -> str:
 	the user sees clean text + the rendered artifact, not a broken file link."""
 	if not content or not names:
 		return content
-	out = _CANVAS_LINK.sub("", content)
+
+	# Hosted-embed markers first (before the bare-path strip mangles a
+	# url= form into marker residue): drop any [embed ...] whose ref or
+	# embedded canvas url resolved to a persisted artifact.
+	def _drop_embed(m: re.Match) -> str:
+		marker = m.group(0)
+		ref = _EMBED_REF.match(marker)
+		if ref and _embed_ref_name(ref.group(1)) in names:
+			return ""
+		if any(n in marker for n in names):
+			return ""
+		return marker
+
+	out = _EMBED_MARKER.sub(_drop_embed, content)
+	out = _CANVAS_LINK.sub("", out)
 	out = _CANVAS_BARE.sub("", out)
 	out = re.sub(r"[ \t]+([.,;:])", r"\1", out)
 	out = re.sub(r"\n{3,}", "\n\n", out)
@@ -158,6 +210,11 @@ def persist_canvases(
 		if not fetched:
 			continue
 		body, typ = fetched
+		if typ == "html" and name.startswith("documents/"):
+			try:
+				body = _strip_host_client(body.decode("utf-8")).encode("utf-8")
+			except Exception:
+				pass
 		try:
 			file_url = _save_file(assistant_msg_name, name, body)
 		except Exception:

--- a/jarvis/chat/dashboard_permissions.py
+++ b/jarvis/chat/dashboard_permissions.py
@@ -1,0 +1,162 @@
+"""Scope visibility + write matrix for ``Jarvis Dashboard``.
+
+The data-layer twin of ``jarvis/chat/wiki_permissions.py``, registered in
+hooks.py via ``permission_query_conditions`` / ``has_permission``.
+
+Visibility (read) — enforced everywhere (Desk lists via the query-conditions
+hook, per-doc access via the has_permission hook, SPA raw-SQL lists via
+``visible_scope_condition``):
+
+  * Org dashboards: every jarvis user.
+  * Role dashboards: users holding ``target_role`` (+ the admin tier).
+  * User dashboards: ``target_user`` only (+ the admin tier).
+  * Blank/NULL scope is PRIVATE (treated like User via ``target_user``, NOT
+    Org — the opposite of the wiki's blank-scope default: a dashboard that
+    somehow lost its scope must fail closed, not org-wide).
+  * The OWNER always reads their own dashboard regardless of scope.
+
+Write matrix: the owner, or the admin tier (System Manager / Jarvis Admin).
+Delete follows write. The doctype permission rows grant Jarvis User r/w/c/d
+broadly and this hook DENIES non-owner writes — the "grant + deny-hook" shape
+used by Jarvis Trigger. The scope-widening gate (plain users may not create
+Org/Role dashboards) lives in the DocType controller, NOT here: "create"
+reaches the hook without a doc, so it could never inspect the scope.
+
+NOTE on the has_permission hook: on this Frappe version controller hooks can
+only DENY — any falsy return (None included) denies, so this module returns
+an explicit True to defer to the normal role-perm check.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis.chat.wiki_permissions import _NON_TARGETABLE_ROLES
+from jarvis.permissions import JARVIS_ADMIN_ROLE, has_jarvis_admin_access
+
+DASHBOARD = "Jarvis Dashboard"
+
+# ptypes that reveal dashboard content; everything read-shaped maps to
+# visibility (mirrors wiki_permissions).
+_READ_PTYPES = ("read", "select", "print", "email", "export", "share", "report")
+
+
+def _is_sm(user: str) -> bool:
+	# Administrator's get_roles returns every Role, so the explicit check is
+	# just a shortcut; both spellings of "full access" land here.
+	return user == "Administrator" or "System Manager" in frappe.get_roles(user)
+
+
+def _get(doc, field: str):
+	# dict rows (frappe.get_all) and Document both expose .get.
+	return doc.get(field)
+
+
+def can_read_dashboard(doc, user: str | None = None) -> bool:
+	"""Visibility matrix for one dashboard (dict with owner/scope/target_*
+	fields, or a Document)."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return True
+	if (_get(doc, "owner") or "") == user:
+		return True
+	scope = (_get(doc, "scope") or "").strip()
+	if scope == "Org":
+		return True
+	if scope == "Role":
+		target_role = _get(doc, "target_role")
+		return bool(target_role) and target_role in frappe.get_roles(user)
+	# "User" — and blank/None scope, which is PRIVATE (fail closed, not Org).
+	return (_get(doc, "target_user") or "") == user
+
+
+def can_edit_dashboard(doc, user: str | None = None) -> bool:
+	"""Write matrix: the owner, or the admin tier."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return True
+	return (_get(doc, "owner") or "") == user
+
+
+def creatable_scopes(user: str | None = None) -> list[str]:
+	"""Scopes this user may create dashboards in. Personal dashboards for
+	everyone; sharing (Org/Role) is the admin tier's call."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return ["Org", "Role", "User"]
+	return ["User"]
+
+
+def manageable_roles(user: str | None = None) -> list[str]:
+	"""Roles the user may target for Role-scope dashboards: SM targets any
+	enabled desk role; a Jarvis Admin targets roles they hold. The wiki's
+	non-targetable set (framework/blanket roles) is excluded in both cases —
+	targeting e.g. "Desk User" would be an org-wide side door."""
+	user = user or frappe.session.user
+	if _is_sm(user):
+		return [
+			r
+			for r in frappe.get_all(
+				"Role",
+				filters={"disabled": 0, "desk_access": 1},
+				order_by="name asc",
+				pluck="name",
+			)
+			if r not in _NON_TARGETABLE_ROLES
+		]
+	roles = set(frappe.get_roles(user))
+	if JARVIS_ADMIN_ROLE not in roles:
+		return []
+	return sorted(roles - set(_NON_TARGETABLE_ROLES))
+
+
+def visible_scope_condition(user: str | None = None) -> str:
+	"""SQL boolean fragment over ``tabJarvis Dashboard`` implementing the
+	visibility matrix; always a parenthesized valid expression so callers can
+	splice it with ``and``. Values go through frappe.db.escape — role names
+	and user emails are org-author-controlled strings."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return "(1=1)"
+	table = "`tabJarvis Dashboard`"
+	escaped_user = frappe.db.escape(user)
+	clauses = [
+		f"{table}.`owner` = {escaped_user}",
+		f"{table}.`scope` = 'Org'",
+	]
+	roles = [r for r in frappe.get_roles(user) if r]
+	if roles:
+		role_list = ", ".join(frappe.db.escape(r) for r in roles)
+		clauses.append(
+			f"({table}.`scope` = 'Role' and {table}.`target_role` in ({role_list}))"
+		)
+	# Blank/NULL scope is PRIVATE — it rides the target_user clause (and the
+	# owner clause above), never the Org one.
+	clauses.append(
+		f"(coalesce({table}.`scope`, '') in ('', 'User') "
+		f"and {table}.`target_user` = {escaped_user})"
+	)
+	return "(" + " or ".join(clauses) + ")"
+
+
+def dashboard_query_conditions(user: str | None = None) -> str:
+	"""hooks.permission_query_conditions entry — scopes every Desk/ORM list
+	query. Empty string (no restriction) for the admin tier."""
+	user = user or frappe.session.user
+	if has_jarvis_admin_access(user):
+		return ""
+	return visible_scope_condition(user)
+
+
+def has_dashboard_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
+	"""hooks.has_permission entry — per-doc gate. Read-shaped ptypes follow
+	the visibility matrix; write and delete follow the edit matrix; everything
+	else (including "create") defers — hooks can only deny, and the create-time
+	scope gate lives in the DocType controller. True defers to the role-perm
+	check."""
+	user = user or frappe.session.user
+	if ptype in _READ_PTYPES:
+		return can_read_dashboard(doc, user)
+	if ptype in ("write", "delete"):
+		return can_edit_dashboard(doc, user)
+	return True

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -1,0 +1,641 @@
+"""SPA-facing API for the Jarvis Dashboards page.
+
+Whitelisted endpoints for the ``/jarvis`` Dashboards UI: caps probe, paginated
+dashboard list (frozen ``{rows, total, has_more, start, page_length}`` shape
+inside the ``{ok, data}`` envelope), scope-visibility-filtered CRUD, and the
+view-time data runner (``run_dashboard_source`` — always executes the SAVED
+spec as the SESSION user; there is deliberately no spec parameter, so a viewer
+can never smuggle an ad-hoc query through a shared dashboard). Mirrors the
+shape of ``jarvis.chat.triggers_api`` (whose list-page helpers it reuses via
+``jarvis.chat.macros_api``).
+
+Visibility: the list uses raw SQL, which bypasses the ORM permission hooks, so
+``dashboard_permissions.visible_scope_condition()`` is spliced into the WHERE
+for non-admins (the wiki list does the same). Per-doc reads go through
+``doc.check_permission`` (the has_permission hook).
+
+Error contract of ``run_dashboard_source`` (always HTTP 200):
+``{ok: True, data: {source_name, tool, rows[, columns], truncated, took_ms}}``
+or ``{ok: False, error: {code, message}}`` with code one of
+``PermissionError`` / ``InvalidArgumentError`` / ``InternalError`` (internal
+errors are logged server-side and never leak tracebacks).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import frappe
+from frappe import _
+
+from jarvis.chat import dashboard_permissions
+from jarvis.chat.macros_api import _clamp_page, _lk, _load_filters
+from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.permissions import has_jarvis_admin_access, require_jarvis_user
+
+DASHBOARD = "Jarvis Dashboard"
+
+_ALLOWED_TOOLS = {"query", "run_report", "get_list"}
+_MAX_SOURCES = 12
+_MAX_SPEC_CHARS = 32_000
+_MAX_HTML_CHARS = 1_000_000
+# Post-fetch hard cap on rows returned to the dashboard renderer. Sits above
+# the tools' own limits (query/get_list cap at limit<=1000; run_report has no
+# limit) so it only ever bites report results — sliced, never errored.
+DASHBOARD_MAX_ROWS = 2000
+
+# The declared-sources block inside the dashboard HTML document:
+# <script type="application/json" id="jarvis-sources">{"sources": [...]}</script>
+_SOURCES_BLOCK_RE = re.compile(
+	r'<script[^>]*\bid=["\']jarvis-sources["\'][^>]*>(.*?)</script>',
+	re.I | re.S,
+)
+
+# Fields a create/update payload may set. Everything else (owner, target_user
+# — server-derived for User scope, dashboard_type — always derived, timestamps)
+# is server-owned; unknown keys throw.
+_ALLOWED_PAYLOAD_FIELDS = {
+	"name", "dashboard_title", "description", "html", "scope", "target_role",
+	"sources", "source_conversation", "theme",
+}
+
+_SCOPES = {"Org", "Role", "User"}
+_TYPES = {"Static", "Connected"}
+
+_DASHBOARD_FILTERS = {"scope", "dashboard_type", "owner"}
+_DASHBOARD_SORTABLE = {
+	"modified": "modified", "dashboard_title": "dashboard_title",
+	"dashboard_type": "dashboard_type", "scope": "scope", "owner": "owner",
+}
+
+# Per-tool spec key allow-lists (unknown keys throw at save time).
+_GET_LIST_SPEC_KEYS = {"doctype", "fields", "filters", "order_by", "limit", "parent_doctype"}
+_RUN_REPORT_SPEC_KEYS = {"report_name", "filters"}
+
+# A get_list order_by: one or more `fieldname [asc|desc]` tokens, comma-joined.
+# fieldname allows an optional `child_table.field` / backtick-free dotted path.
+_ORDER_BY_RE = re.compile(
+	r"^\s*[a-zA-Z_][\w.]*(?:\s+(?:asc|desc))?"
+	r"(?:\s*,\s*[a-zA-Z_][\w.]*(?:\s+(?:asc|desc))?)*\s*$",
+	re.IGNORECASE,
+)
+
+# Per-request wall-clock ceiling (seconds) for the dashboard data runner, so a
+# heavy report/query can't pin a web worker. MariaDB max_statement_time.
+_SOURCE_STMT_TIMEOUT_S = 20
+
+
+# --------------------------------------------------------------------------- #
+# shared helpers
+# --------------------------------------------------------------------------- #
+def _order_by(sort_field: str, sort_dir: str, sortable: dict, default_field: str) -> str:
+	"""Whitelisted ORDER BY (unknown sort field throws — same strictness as the
+	triggers list)."""
+	field = (sort_field or "").strip() or default_field
+	if field not in sortable:
+		frappe.throw(_("Unknown sort field: {0}").format(field))
+	d = "desc" if (sort_dir or "desc").lower() == "desc" else "asc"
+	return f"`{sortable[field]}` {d}, `name` asc"
+
+
+def _clear_perm_message_noise() -> None:
+	"""Drop any messages ``frappe.has_permission`` pushed onto the message log
+	on a denied path ("User X does not have doctype access …"), so they never
+	leak back to the client in ``_server_messages``. Best-effort."""
+	try:
+		frappe.local.message_log = []
+	except Exception:
+		pass
+
+
+def _error_envelope(code: str, message: str) -> dict:
+	return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def _set_stmt_timeout(seconds: int) -> None:
+	"""Best-effort per-request statement timeout so a heavy dashboard source
+	can't pin a web worker. MariaDB's max_statement_time is a session variable
+	in seconds; a no-op on other backends or if the SET fails."""
+	try:
+		if frappe.db.db_type == "mariadb":
+			frappe.db.sql("SET SESSION max_statement_time = %s", (seconds,))
+	except Exception:
+		pass
+
+
+def _dashboard_detail(doc) -> dict:
+	"""Full dashboard detail for the editor/viewer. ``can_edit`` tells the SPA
+	whether to offer the edit surfaces to this session user."""
+	return {
+		"name": doc.name,
+		"dashboard_title": doc.dashboard_title,
+		"description": doc.description or "",
+		"dashboard_type": doc.dashboard_type,
+		"theme": doc.theme or "Jarvis",
+		"scope": doc.scope,
+		"target_role": doc.target_role or "",
+		"target_user": doc.target_user or "",
+		"html": doc.html or "",
+		"sources": [
+			{"source_name": s.source_name, "tool": s.tool, "spec": s.spec or ""}
+			for s in (doc.sources or [])
+		],
+		"source_conversation": doc.source_conversation or "",
+		"owner": doc.owner,
+		"modified": str(doc.modified),
+		"can_edit": dashboard_permissions.can_edit_dashboard(doc),
+	}
+
+
+# --------------------------------------------------------------------------- #
+# caps probe
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def get_dashboards_caps() -> dict:
+	"""Single gating probe for the Dashboards page: which scopes the caller
+	may create in, which roles they may target, the size caps, and whether the
+	chat side can even produce canvas artifacts on this bench (self-hosted
+	chats have no gateway canvas route)."""
+	from jarvis import selfhost
+
+	stt_enabled = False
+	try:
+		from jarvis.chat import voice
+
+		stt_enabled = bool(voice.stt_config())
+	except Exception:
+		stt_enabled = False
+	return {
+		"ok": True,
+		"data": {
+			"creatable_scopes": dashboard_permissions.creatable_scopes(),
+			"manageable_roles": dashboard_permissions.manageable_roles(),
+			"max_sources": _MAX_SOURCES,
+			"max_html_chars": _MAX_HTML_CHARS,
+			"max_rows": DASHBOARD_MAX_ROWS,
+			"canvas_available": not selfhost.is_self_hosted(),
+			"stt_enabled": stt_enabled,
+		},
+	}
+
+
+# --------------------------------------------------------------------------- #
+# list / detail
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def list_dashboards_page(
+	search: str = "",
+	filters: str = "{}",
+	sort_field: str = "modified",
+	sort_dir: str = "desc",
+	start: int = 0,
+	page_length: int = 20,
+) -> dict:
+	"""Scope-visible dashboards, server-side search / filter / sort / paginate.
+	Raw SQL bypasses the ORM permission hooks, so the visibility fragment is
+	spliced into the WHERE for non-admins. Frozen envelope in ``data``."""
+	start, pl = _clamp_page(start, page_length)
+	f = _load_filters(filters, _DASHBOARD_FILTERS)
+
+	conds = ["1=1"]
+	params: dict = {"start": start, "page_length": pl}
+	if search:
+		params["q"] = f"%{_lk(search)}%"
+		conds.append("(dashboard_title LIKE %(q)s OR description LIKE %(q)s)")
+	if "scope" in f:
+		if f["scope"] not in _SCOPES:
+			frappe.throw(_("Invalid scope filter."))
+		params["scope"] = f["scope"]
+		conds.append("scope = %(scope)s")
+	if "dashboard_type" in f:
+		if f["dashboard_type"] not in _TYPES:
+			frappe.throw(_("Invalid dashboard_type filter."))
+		params["dashboard_type"] = f["dashboard_type"]
+		conds.append("dashboard_type = %(dashboard_type)s")
+	if "owner" in f:
+		params["owner"] = str(f["owner"])
+		conds.append("owner = %(owner)s")
+	if not has_jarvis_admin_access():
+		# Values inside are frappe.db.escape'd; spliced (not parameterized)
+		# because the role list is variable-length — same as the wiki list.
+		conds.append(dashboard_permissions.visible_scope_condition())
+
+	where = " AND ".join(conds)
+	order = _order_by(sort_field, sort_dir, _DASHBOARD_SORTABLE, "modified")
+
+	total = frappe.db.sql(
+		f"SELECT COUNT(*) FROM `tabJarvis Dashboard` WHERE {where}", params
+	)[0][0]
+	rows = frappe.db.sql(
+		f"""SELECT name, dashboard_title, description, dashboard_type, scope,
+		target_role, target_user, owner, modified
+		FROM `tabJarvis Dashboard`
+		WHERE {where}
+		ORDER BY {order}
+		LIMIT %(page_length)s OFFSET %(start)s""",
+		params, as_dict=True,
+	)
+	for r in rows:
+		r["modified"] = str(r["modified"])
+
+	return {
+		"ok": True,
+		"data": {
+			"rows": rows,
+			"total": total,
+			"has_more": start + len(rows) < total,
+			"start": start,
+			"page_length": pl,
+		},
+	}
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def get_dashboard(name: str) -> dict:
+	"""Full detail of one dashboard (read is scope-gated by the has_permission
+	hook via check_permission)."""
+	doc = frappe.get_doc(DASHBOARD, name)
+	doc.check_permission("read")
+	return {"ok": True, "data": _dashboard_detail(doc)}
+
+
+# --------------------------------------------------------------------------- #
+# save / delete
+# --------------------------------------------------------------------------- #
+def _parse_payload(payload: str) -> dict:
+	try:
+		raw = frappe.parse_json(payload)
+	except Exception:
+		raw = None
+	if not isinstance(raw, dict):
+		frappe.throw(_("Payload must be a JSON object."))
+	out: dict = {}
+	for k, v in raw.items():
+		if k not in _ALLOWED_PAYLOAD_FIELDS:
+			frappe.throw(_("Unknown field: {0}").format(k))
+		out[k] = v
+	return out
+
+
+def _parse_sources_block(html: str) -> list:
+	"""Extract the declared sources from the ``jarvis-sources`` JSON block
+	inside the dashboard HTML. No block -> no sources (a Static dashboard).
+	A present-but-broken block throws — silently ignoring it would save a
+	Connected-looking document with no data wiring."""
+	m = _SOURCES_BLOCK_RE.search(html or "")
+	if not m:
+		return []
+	try:
+		parsed = frappe.parse_json(m.group(1).strip())
+	except Exception:
+		parsed = None
+	if not isinstance(parsed, dict) or not isinstance(parsed.get("sources"), list):
+		frappe.throw(
+			_('The jarvis-sources block must be JSON of the shape {"sources": [...]}.')
+		)
+	return parsed["sources"]
+
+
+def _normalize_source_rows(sources) -> list[dict]:
+	"""Coerce an explicit-payload or html-block sources list into child-row
+	dicts. ``spec`` may arrive as a JSON object (the natural authoring shape in
+	the html block) or a pre-serialized string; the child field stores a
+	string. Shape errors throw; content validation happens in the controller
+	via ``_validate_source_row``.
+
+	LLM-authored blocks drift toward the tool-call surface, so the common
+	dialects are folded into the canonical shape rather than rejected:
+	``id``/``name`` for ``source_name``, a ``jarvis__`` tool prefix, and
+	``args``/``args.spec`` for ``spec`` (the runtime bridge normalizes the
+	same way, so stored rows and rendered widgets always agree)."""
+	if not isinstance(sources, list):
+		frappe.throw(_("sources must be a list."))
+	rows: list[dict] = []
+	for i, s in enumerate(sources):
+		if not isinstance(s, dict):
+			frappe.throw(_("sources[{0}] must be an object.").format(i))
+		name = s.get("source_name") or s.get("id") or s.get("name")
+		tool = s.get("tool")
+		if isinstance(tool, str) and tool.startswith("jarvis__"):
+			tool = tool[len("jarvis__"):]
+		spec = s.get("spec")
+		if spec is None:
+			args = s.get("args")
+			if isinstance(args, dict):
+				spec = args.get("spec") if isinstance(args.get("spec"), dict) else args
+		# double-wrap drift ({"spec": {"spec": {...}}}): unwrap lone spec keys
+		while (
+			isinstance(spec, dict)
+			and len(spec) == 1
+			and isinstance(spec.get("spec"), dict)
+		):
+			spec = spec["spec"]
+		if isinstance(spec, (dict, list)):
+			spec = frappe.as_json(spec)
+		rows.append({
+			"source_name": name,
+			"tool": tool,
+			"spec": spec if isinstance(spec, str) else "",
+		})
+	return rows
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def save_dashboard(payload: str) -> dict:
+	"""Create or update a dashboard from a whitelisted-fields JSON payload.
+	``name`` absent -> insert; present -> owner/admin-gated update. An explicit
+	``sources`` list wins; otherwise the sources are (re)parsed from the html's
+	``jarvis-sources`` block whenever html is provided — the html document is
+	the source of truth, so stale child rows never outlive it. Scope gates,
+	caps, per-source validation and the dashboard_type derivation run in the
+	DocType controller."""
+	fields = _parse_payload(payload)
+	name = str(fields.pop("name", None) or "").strip()
+	sources = fields.pop("sources", None)
+	if sources is None and "html" in fields:
+		sources = _parse_sources_block(fields.get("html") or "")
+
+	if name:
+		doc = frappe.get_doc(DASHBOARD, name)
+		if not dashboard_permissions.can_edit_dashboard(doc):
+			frappe.throw(
+				_("Only the dashboard's owner or a Jarvis Admin can edit it."),
+				frappe.PermissionError,
+			)
+		doc.update(fields)
+	else:
+		if not (fields.get("dashboard_title") or "").strip():
+			frappe.throw(_("dashboard_title is required."))
+		if "html" not in fields:
+			frappe.throw(_("html is required."))
+		doc = frappe.get_doc({"doctype": DASHBOARD, **fields})
+
+	if sources is not None:
+		doc.set("sources", [])
+		for row in _normalize_source_rows(sources):
+			doc.append("sources", row)
+
+	if doc.is_new():
+		doc.insert()
+	else:
+		doc.save()
+	frappe.db.commit()
+	return {"ok": True, "data": _dashboard_detail(doc)}
+
+
+@frappe.whitelist()
+@require_jarvis_user
+def delete_dashboard(name: str) -> dict:
+	"""Delete one dashboard (owner or admin tier)."""
+	doc = frappe.get_doc(DASHBOARD, name)
+	if not dashboard_permissions.can_edit_dashboard(doc):
+		frappe.throw(
+			_("Only the dashboard's owner or a Jarvis Admin can delete it."),
+			frappe.PermissionError,
+		)
+	frappe.delete_doc(DASHBOARD, name)
+	frappe.db.commit()
+	return {"ok": True, "data": {"deleted": name}}
+
+
+# --------------------------------------------------------------------------- #
+# per-source spec validation (shared with the DocType controller)
+# --------------------------------------------------------------------------- #
+def _validate_source_row(row: dict) -> None:
+	"""Validate one source row's tool + spec (source_name charset/uniqueness
+	is the controller's job). Everything throws frappe.ValidationError-shaped
+	errors so Desk saves and the SPA get the same clean 417s."""
+	label = row.get("source_name") or "?"
+	tool = (row.get("tool") or "").strip()
+	if tool not in _ALLOWED_TOOLS:
+		frappe.throw(
+			_("Source '{0}': unknown tool '{1}' (allowed: query, run_report, get_list).").format(
+				label, tool
+			)
+		)
+	raw = row.get("spec")
+	if isinstance(raw, str) and len(raw) > _MAX_SPEC_CHARS:
+		frappe.throw(
+			_("Source '{0}': spec must be at most {1} characters.").format(
+				label, _MAX_SPEC_CHARS
+			)
+		)
+	try:
+		spec = frappe.parse_json(raw)
+	except Exception:
+		spec = None
+	if not isinstance(spec, dict):
+		frappe.throw(_("Source '{0}': spec must be a JSON object.").format(label))
+
+	if tool == "query":
+		_validate_query_spec(label, spec)
+	elif tool == "get_list":
+		_validate_get_list_spec(label, spec)
+	else:
+		_validate_run_report_spec(label, spec)
+
+
+def _validate_query_spec(label: str, spec: dict) -> None:
+	"""Reuse the query tool's own validators (shape + doctype existence) so a
+	saved source can't be shaped in a way the runner would reject anyway. The
+	tool raises InvalidArgumentError (not a frappe.ValidationError) — translate
+	to frappe.throw for the save path."""
+	from jarvis.tools.query import _collect_doctypes, _validate_doctype, _validate_spec_shape
+
+	try:
+		_validate_spec_shape(spec)
+		for dt in _collect_doctypes(spec):
+			_validate_doctype(dt)
+	except InvalidArgumentError as e:
+		frappe.throw(_("Source '{0}': {1}").format(label, str(e)))
+	if "limit" in spec:
+		limit = spec["limit"]
+		if isinstance(limit, bool) or not isinstance(limit, int) or not (1 <= limit <= 1000):
+			frappe.throw(
+				_("Source '{0}': limit must be an integer between 1 and 1000.").format(label)
+			)
+
+
+def _validate_get_list_spec(label: str, spec: dict) -> None:
+	unknown = set(spec) - _GET_LIST_SPEC_KEYS
+	if unknown:
+		frappe.throw(
+			_("Source '{0}': unknown get_list spec key(s): {1}").format(
+				label, ", ".join(sorted(unknown))
+			)
+		)
+	doctype = spec.get("doctype")
+	if not isinstance(doctype, str) or not doctype.strip():
+		frappe.throw(_("Source '{0}': doctype is required.").format(label))
+	if not frappe.db.exists("DocType", doctype):
+		frappe.throw(_("Source '{0}': unknown DocType: {1}").format(label, doctype))
+	if "fields" in spec and not (
+		isinstance(spec["fields"], list)
+		and all(isinstance(x, str) for x in spec["fields"])
+	):
+		frappe.throw(_("Source '{0}': fields must be a list of strings.").format(label))
+	if "filters" in spec and not isinstance(spec["filters"], (dict, list)):
+		frappe.throw(_("Source '{0}': filters must be an object or a list.").format(label))
+	if "limit" in spec:
+		limit = spec["limit"]
+		if isinstance(limit, bool) or not isinstance(limit, int) or not (1 <= limit <= 1000):
+			frappe.throw(
+				_("Source '{0}': limit must be an integer between 1 and 1000.").format(label)
+			)
+	# order_by is handed straight to frappe.get_list; validate it ourselves
+	# (whitelisted `fieldname [asc|desc]` tokens) rather than trusting the ORM
+	# to sanitize an order-by expression.
+	if "order_by" in spec:
+		ob = spec["order_by"]
+		if not isinstance(ob, str) or not _ORDER_BY_RE.match(ob.strip()):
+			frappe.throw(
+				_(
+					"Source '{0}': order_by must be 'fieldname' or "
+					"'fieldname asc|desc' (optionally comma-separated)."
+				).format(label)
+			)
+
+
+def _validate_run_report_spec(label: str, spec: dict) -> None:
+	unknown = set(spec) - _RUN_REPORT_SPEC_KEYS
+	if unknown:
+		frappe.throw(
+			_("Source '{0}': unknown run_report spec key(s): {1}").format(
+				label, ", ".join(sorted(unknown))
+			)
+		)
+	report_name = spec.get("report_name")
+	if not isinstance(report_name, str) or not report_name.strip():
+		frappe.throw(_("Source '{0}': report_name is required.").format(label))
+	if not frappe.db.exists("Report", report_name):
+		frappe.throw(_("Source '{0}': unknown Report: {1}").format(label, report_name))
+	if frappe.db.get_value("Report", report_name, "prepared_report"):
+		frappe.throw(
+			_(
+				"Source '{0}': '{1}' runs as a background Prepared Report and cannot "
+				"serve a dashboard live. Pick a report that runs inline."
+			).format(label, report_name)
+		)
+	if "filters" in spec and not isinstance(spec["filters"], dict):
+		frappe.throw(_("Source '{0}': filters must be an object.").format(label))
+
+
+# --------------------------------------------------------------------------- #
+# view-time data runner
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+@require_jarvis_user
+def run_dashboard_source(dashboard: str, source_name: str) -> dict:
+	"""Execute one SAVED data source of a dashboard as the SESSION user.
+
+	Deliberately takes NO spec parameter — the saved child row is the only
+	thing that ever runs, so a shared dashboard can never carry a viewer-
+	supplied query. All record/field-level permissions are the tools' own
+	(query weaves Engine permission conditions; get_list is the ORM;
+	run_report is Frappe's report permission model) — a viewer sees exactly
+	the rows THEY are allowed to see. Errors come back as HTTP-200 envelopes
+	so the dashboard renderer can show a per-tile message."""
+	doc = frappe.get_doc(DASHBOARD, dashboard)
+	try:
+		doc.check_permission("read")
+	except frappe.PermissionError:
+		_clear_perm_message_noise()
+		return _error_envelope(
+			"PermissionError", _("You do not have access to this dashboard.")
+		)
+
+	row = next(
+		(s for s in (doc.sources or []) if s.source_name == source_name), None
+	)
+	if row is None:
+		return _error_envelope(
+			"InvalidArgumentError",
+			_("Unknown source '{0}' on this dashboard.").format(source_name),
+		)
+	try:
+		spec = frappe.parse_json(row.spec)
+	except Exception:
+		spec = None
+	if not isinstance(spec, dict):
+		return _error_envelope(
+			"InvalidArgumentError", _("The saved spec for this source is not valid JSON.")
+		)
+
+	tool = row.tool
+	columns = None
+	t0 = time.monotonic()
+	# Bound the runner's wall-clock so a heavy report/query can't pin a web
+	# worker (MariaDB only; best-effort). Scoped to this whitelisted request.
+	_set_stmt_timeout(_SOURCE_STMT_TIMEOUT_S)
+	try:
+		if tool == "query":
+			from jarvis.tools.query import query as _query
+
+			# rows ONLY — the tool's "sql" debug key must never reach a viewer.
+			rows = list(_query(spec, confirm_large=True).get("rows") or [])
+		elif tool == "get_list":
+			from jarvis.tools.get_list import get_list as _get_list
+
+			kwargs = {k: v for k, v in spec.items() if k in _GET_LIST_SPEC_KEYS}
+			kwargs.setdefault("doctype", "")
+			rows = _get_list(confirm_large=True, **kwargs)
+		elif tool == "run_report":
+			from jarvis.tools.run_report import run_report as _run_report
+
+			res = _run_report(spec.get("report_name") or "", spec.get("filters") or {})
+			if (
+				not isinstance(res, dict)
+				or res.get("prepared_report")
+				or not isinstance(res.get("result"), list)
+			):
+				return _error_envelope(
+					"InvalidArgumentError",
+					_(
+						"This report did not return rows inline (it may run as a "
+						"background Prepared Report), so it cannot serve a dashboard."
+					),
+				)
+			columns = res.get("columns") or []
+			# run_report has no inherent row cap (query/get_list are ≤1000 by the
+			# tools); cap here so a huge report never materializes the full result
+			# set into the browser payload. The post-loop slice still applies.
+			rows = res["result"][: DASHBOARD_MAX_ROWS + 1]
+		else:
+			return _error_envelope(
+				"InvalidArgumentError", _("Unsupported tool: {0}").format(tool)
+			)
+	except (PermissionDeniedError, frappe.PermissionError) as e:
+		# has_permission pushes "no access" lines into the message log on the
+		# denied path; clear them so they never ride back in _server_messages.
+		_clear_perm_message_noise()
+		return _error_envelope("PermissionError", str(e) or "permission denied")
+	except InvalidArgumentError as e:
+		return _error_envelope("InvalidArgumentError", str(e))
+	except Exception:
+		frappe.log_error(
+			title="Jarvis: dashboard source run failed",
+			message=frappe.get_traceback(),
+		)
+		return _error_envelope(
+			"InternalError", _("The data source could not be run. The error was logged.")
+		)
+
+	truncated = False
+	if len(rows) > DASHBOARD_MAX_ROWS:
+		rows = rows[:DASHBOARD_MAX_ROWS]
+		truncated = True
+	data = {
+		"source_name": source_name,
+		"tool": tool,
+		"rows": rows,
+		"truncated": truncated,
+		"took_ms": int((time.monotonic() - t0) * 1000),
+	}
+	if columns is not None:
+		data["columns"] = columns
+	return {"ok": True, "data": data}

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1172,6 +1172,54 @@ def _prepend_doc_context(user_message: str, context) -> str:
 	"""
 	if not isinstance(context, dict):
 		return user_message
+	if context.get("page") == "dashboards":
+		# The builder's explicit data-mode toggle overrides wording-based
+		# inference; absent = the agent decides from the ask.
+		mode = context.get("data_mode")
+		if mode == "static":
+			mode_line = (
+				" The user explicitly chose a STATIC one-time report: fetch the data "
+				"now, bake the numbers into the HTML with an as-of time, and do NOT "
+				"declare a jarvis-sources block."
+			)
+		elif mode == "live":
+			mode_line = (
+				" The user explicitly chose a LIVE data-connected dashboard: declare "
+				"every query in the jarvis-sources block and fetch at view time via "
+				"window.jarvis.data() - never bake the numbers in."
+			)
+		else:
+			mode_line = ""
+		# When revising a saved dashboard, name it so the agent reads the current
+		# document before changing it (instead of building blind).
+		edit_line = ""
+		if (context.get("doctype") or "") == "Jarvis Dashboard" and context.get("name"):
+			edit_line = (
+				f" They are revising the saved dashboard {context['name']} — call "
+				f"jarvis__get_doc on Jarvis Dashboard {context['name']} to read its "
+				"current html and sources, then produce the full revised document."
+			)
+		return (
+			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
+			"create or iterate on a dashboard/report. Read and follow the "
+			"jarvis-dashboards skill before acting. Non-negotiable contract: produce "
+			"ONE complete self-contained HTML document per iteration and publish it as "
+			"a hosted canvas embed; no external resources. Live data sources MUST be "
+			"declared inside the HTML exactly as "
+			'<script type="application/json" id="jarvis-sources">{"sources":[{'
+			'"source_name":"<snake_case>","tool":"query|get_list|run_report",'
+			'"spec":{...}}]}</script> where spec is the bare argument value - for '
+			'query the {"from":...} DSL object itself, for run_report '
+			'{"report_name":...,"filters":{...}}, for get_list {"doctype":...} - '
+			'never nested inside another "spec" or "args" key (test it with the '
+			"matching jarvis__ tool first); widgets "
+			'fetch with window.jarvis.data("<source_name>"). Style with the injected '
+			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
+			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "
+			"of hardcoding design; only deviate when the user explicitly asks about "
+			f"the look.{mode_line}{edit_line}]"
+			f"\n\n{user_message}"
+		)
 	if context.get("page") == "triggers":
 		return (
 			"[Context: The user is on the Jarvis Triggers page. They want to create or "

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1157,6 +1157,40 @@ def _format_report_filters(filters: dict) -> str:
 	return f" with filters {{{body}}}"
 
 
+_THEME_TOKEN_ORDER = (
+	"bg", "surface", "surface-2", "ink", "heading", "muted", "line", "accent",
+	"positive", "negative", "warning", "info",
+)
+
+
+def _dashboard_theme_cheatsheet(theme_key: str) -> str:
+	"""Render the SELECTED curated theme's compact token+palette cheatsheet from
+	its canonical theme.json (jarvis/dashboards/themes/<key>/theme.json), inlined
+	per-turn into the dashboards [Context:] line. Only the chosen theme is
+	rendered — the skill carries the theme-agnostic mechanism, never all four
+	cheatsheets. Empty for an unknown/custom key (custom has no spec)."""
+	try:
+		from jarvis.dashboards import theme_spec
+
+		spec = theme_spec.load_theme(theme_key)
+	except Exception:
+		spec = None
+	if not spec:
+		return ""
+	rt = spec.get("render_tokens", {})
+	toks = " ".join(f"--jd-{k} {rt[k]}" for k in _THEME_TOKEN_ORDER if k in rt)
+	palette = " ".join(spec.get("palette", []))
+	mode = "dark" if spec.get("dark") else "light"
+	fdisp = (rt.get("font-display") or "").lower()
+	headings = "serif" if "serif" in fdisp and "sans-serif" not in fdisp else "system-sans"
+	return (
+		f" {spec.get('label', theme_key)} cheatsheet ({mode}; headings {headings}): "
+		f"tokens {toks}; chart series = window.JARVIS_THEME.palette in order "
+		f"[{palette}]. Compose var(--jd-*) (never hardcode these hexes); "
+		"--jd-muted for secondary/labels, --jd-positive/-negative for status text."
+	)
+
+
 def _prepend_doc_context(user_message: str, context) -> str:
 	"""Prepend the ERP doc / report the user was viewing (floating-widget
 	auto-context) as a leading ``[Viewing: ...]`` line, so questions like
@@ -1199,9 +1233,10 @@ def _prepend_doc_context(user_message: str, context) -> str:
 				f"jarvis__get_doc on Jarvis Dashboard {context['name']} to read its "
 				"current html and sources, then produce the full revised document."
 			)
-		# The selected canvas theme: name it so the agent designs FOR it. The
-		# jarvis-dashboards skill carries each theme's token+recipe cheatsheet;
-		# the save-time validator rejects off-theme output, so composing the jd-*
+		# The selected canvas theme: name it so the agent designs FOR it, and
+		# inline THAT theme's compact token+palette cheatsheet (rendered per-turn
+		# from theme.json — the skill carries only the theme-agnostic mechanism).
+		# The save-time validator rejects off-theme output, so composing the jd-*
 		# classes + --jd-* tokens is the standard, not a suggestion.
 		theme_key = (context.get("theme") or "").strip().lower()
 		if theme_key == "custom":
@@ -1214,10 +1249,10 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			theme_line = (
 				f" The selected theme is '{theme_key}' — design FOR it: compose the "
 				"jd-* component classes and take every color/font from the injected "
-				"--jd-* variables and window.JARVIS_THEME.palette (see that theme's "
-				"cheatsheet in the jarvis-dashboards skill). The save-time validator "
-				"rejects off-theme colors/fonts, @font-face, external URLs and "
-				"prefers-color-scheme, so do not hardcode any of them."
+				"--jd-* variables and window.JARVIS_THEME.palette. The save-time "
+				"validator rejects off-theme colors/fonts, @font-face, external URLs "
+				"and prefers-color-scheme, so do not hardcode any of them."
+				+ _dashboard_theme_cheatsheet(theme_key)
 			)
 		else:
 			theme_line = ""
@@ -1238,8 +1273,10 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			'fetch with window.jarvis.data("<source_name>"). Style with the injected '
 			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
 			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "
-			"of hardcoding design; only deviate when the user explicitly asks about "
-			f"the look.{theme_line}{mode_line}{edit_line}]"
+			"of hardcoding design. For a bespoke look the user switches to the Custom "
+			"theme via the theme picker — on a curated theme never hardcode off-theme "
+			"colors/fonts (the save-time validator rejects them); tell the user to "
+			f"pick Custom for a one-off deviation.{theme_line}{mode_line}{edit_line}]"
 			f"\n\n{user_message}"
 		)
 	if context.get("page") == "triggers":

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1199,6 +1199,28 @@ def _prepend_doc_context(user_message: str, context) -> str:
 				f"jarvis__get_doc on Jarvis Dashboard {context['name']} to read its "
 				"current html and sources, then produce the full revised document."
 			)
+		# The selected canvas theme: name it so the agent designs FOR it. The
+		# jarvis-dashboards skill carries each theme's token+recipe cheatsheet;
+		# the save-time validator rejects off-theme output, so composing the jd-*
+		# classes + --jd-* tokens is the standard, not a suggestion.
+		theme_key = (context.get("theme") or "").strip().lower()
+		if theme_key == "custom":
+			theme_line = (
+				" The user chose the CUSTOM theme: build the bespoke look they "
+				"describe — their own design wins and no standard theme is enforced "
+				"(but never load external resources or @font-face webfonts)."
+			)
+		elif theme_key:
+			theme_line = (
+				f" The selected theme is '{theme_key}' — design FOR it: compose the "
+				"jd-* component classes and take every color/font from the injected "
+				"--jd-* variables and window.JARVIS_THEME.palette (see that theme's "
+				"cheatsheet in the jarvis-dashboards skill). The save-time validator "
+				"rejects off-theme colors/fonts, @font-face, external URLs and "
+				"prefers-color-scheme, so do not hardcode any of them."
+			)
+		else:
+			theme_line = ""
 		return (
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "
@@ -1217,7 +1239,7 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			"--jd-* CSS variables (--jd-bg/-surface/-ink/-heading/-muted/-line/"
 			"-accent/-font) and the window.JARVIS_THEME.palette chart colors instead "
 			"of hardcoding design; only deviate when the user explicitly asks about "
-			f"the look.{mode_line}{edit_line}]"
+			f"the look.{theme_line}{mode_line}{edit_line}]"
 			f"\n\n{user_message}"
 		)
 	if context.get("page") == "triggers":

--- a/jarvis/dashboards/__init__.py
+++ b/jarvis/dashboards/__init__.py
@@ -1,0 +1,9 @@
+"""Curated dashboard-canvas theme specs + the save-time HTML/CSS validator.
+
+Each theme is a directory under ``themes/<key>/`` holding ``theme.json`` (the
+machine-enforceable tokens / palette / scales + the validator allow-lists) and
+``design.md`` (the human recipe and the source for the skill's generation
+cheatsheet). ``theme_spec`` loads the JSON; ``theme_validator`` is a pure,
+frappe-free deterministic linter the ``Jarvis Dashboard`` controller runs on
+every save so no off-theme canvas HTML is ever stored.
+"""

--- a/jarvis/dashboards/theme_spec.py
+++ b/jarvis/dashboards/theme_spec.py
@@ -1,0 +1,45 @@
+"""Load the curated dashboard theme specs
+(``jarvis/dashboards/themes/<key>/theme.json``).
+
+Pure + frappe-free so the validator can be unit-tested standalone. The
+label<->key mapping mirrors ``frontend/src/lib/dashboardThemes.js`` (the DocType
+stores the capitalized label; the specs are keyed lowercase). ``theme.json``'s
+``render_tokens`` mirror the ``--jd-*`` custom properties that file's ``VARS``
+emits — a node sync-guard test fails loudly if the two drift.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from functools import lru_cache
+
+_THEMES_DIR = pathlib.Path(__file__).resolve().parent / "themes"
+
+# Curated theme keys (lowercase). "custom" is the bespoke escape hatch — it has
+# NO theme.json (no design spec); the validator applies only the safety bans.
+CURATED_KEYS = ("jarvis", "insight", "claude", "graphite")
+CUSTOM_KEY = "custom"
+DEFAULT_KEY = "jarvis"
+
+
+@lru_cache(maxsize=None)
+def load_theme(key: str) -> dict | None:
+	"""Return the parsed ``theme.json`` for a lowercase key, or ``None`` when
+	there is no spec (the bespoke ``custom`` theme, or an unknown key)."""
+	k = (key or "").strip().lower()
+	if k not in CURATED_KEYS:
+		return None
+	try:
+		return json.loads((_THEMES_DIR / k / "theme.json").read_text())
+	except (OSError, ValueError):
+		return None
+
+
+def theme_key(label: str) -> str:
+	"""Map a DocType theme label (or key) to the lowercase spec key. Unknown ->
+	the default ('jarvis'); ``custom`` is preserved (it has no spec)."""
+	k = (label or "").strip().lower()
+	if k == CUSTOM_KEY:
+		return CUSTOM_KEY
+	return k if k in CURATED_KEYS else DEFAULT_KEY

--- a/jarvis/dashboards/theme_spec.py
+++ b/jarvis/dashboards/theme_spec.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import pathlib
-from functools import lru_cache
+from functools import cache
 
 _THEMES_DIR = pathlib.Path(__file__).resolve().parent / "themes"
 
@@ -23,7 +23,7 @@ CUSTOM_KEY = "custom"
 DEFAULT_KEY = "jarvis"
 
 
-@lru_cache(maxsize=None)
+@cache
 def load_theme(key: str) -> dict | None:
 	"""Return the parsed ``theme.json`` for a lowercase key, or ``None`` when
 	there is no spec (the bespoke ``custom`` theme, or an unknown key)."""

--- a/jarvis/dashboards/theme_validator.py
+++ b/jarvis/dashboards/theme_validator.py
@@ -1,37 +1,74 @@
 """Deterministic save-time validator for dashboard canvas HTML.
 
-Pure + frappe-free (import-safe without a bench) so it can be unit-tested
-standalone; the ``Jarvis Dashboard`` controller calls
-``validate_dashboard_html`` on every save and throws a structured error when it
-returns violations. NO auto-repair — a rejected save surfaces the reasons and
-the builder's chat loop regenerates.
+Pure + frappe-free (imports nothing from frappe, so it is unit-testable
+standalone); the ``Jarvis Dashboard`` controller calls ``validate_dashboard_html``
+on every save and throws a structured error when it returns violations. NO
+auto-repair — a rejected save surfaces the reasons and the builder's chat loop
+regenerates.
 
-What it enforces (a standard theme):
-  * off-palette color literals in CSS  (hex / rgb / hsl / named, outside the
-    theme's own hexes + an approved white/black/transparent neutral set)
-  * ``font-family`` (or ``font`` shorthand) naming a non-system face
+PARSE-BASED, not regex-over-raw-text. The browser tokenizes + decodes CSS and
+HTML before it applies them, so a raw-spelling regex is trivially bypassed
+(``\\6b``-escapes, ``&#58;`` entities, ``var()`` indirection, unbalanced braces).
+This validator therefore parses the same way the browser does:
+
+  * CSS is tokenized with **tinycss2** — which DECODES escapes (``o\\6b lch`` →
+    ``oklch``, ``@f\\6f nt-face`` → ``@font-face``), SEPARATES the selector prelude
+    from the declaration VALUES (so an id selector ``#abc`` is never read as a hex
+    color), exposes ``!important`` structurally, and reports parse errors so a
+    stray/misplaced ``}`` (which would break out of the ``@layer author {}``
+    wrapper) is detectable.
+  * HTML is parsed with **html5lib** (into an lxml tree) exactly like a browser —
+    it DECODES entities (``https&#58;//…`` → ``https://…``), reads EVERY ``style=``
+    attribute including UNQUOTED ones, reads an unclosed ``<style>`` to
+    end-of-document (raw-text parsing), and surfaces url-bearing attribute values.
+
+What it enforces (a standard theme) — the COLOR + FONT + light/dark contract:
+  * off-palette color VALUES in CSS, in ANY syntax. The policy is an allow-list
+    inversion: a color-valued token that is not (a) an allow-listed theme hex,
+    (b) a ``var(--jd-*)`` token, or (c) an approved white/black/transparent
+    neutral is off-palette — whether written as hex, ``rgb()``/``hsl()``, a modern
+    color function (``oklch/oklab/lab/lch/hwb/color()/color-mix()/device-cmyk()``),
+    or a named CSS color. A ``var()`` in a color value is allowed ONLY when it
+    references a ``--jd-*`` theme token; any other custom-property reference is
+    off-palette (it could resolve to any color).
+  * ``font-family`` (or ``font`` shorthand) naming a non-system face, INCLUDING
+    ``font-family:var(--x)`` where ``--x`` is not a theme font token.
+  * author redefinition of a ``--jd-*`` theme token (only the theme layer owns
+    them).
   * ``@media (prefers-color-scheme)`` and the ``color-scheme`` property
-    (light/dark is driven by the theme's ``data-theme`` ONLY)
-  * ``!important`` on a color/font declaration
-  * off-palette color in an inline ``style=`` attribute
+    (light/dark is driven by the theme's ``data-theme`` ONLY).
+  * ``!important`` ANYWHERE in author CSS (it escapes the theme layer; the theme
+    owns its layer, the author never needs it).
+  * structurally-malformed / brace-unbalanced author CSS (a stray/misplaced ``}``
+    that would break out of the injected ``@layer author {}`` wrapper).
+  * every rule above is applied to inline ``style=`` declarations too, not just
+    ``<style>`` blocks.
 Always enforced (a safety subset, even for the bespoke ``Custom`` theme):
-  * ``@font-face``
-  * external URLs (http/https/protocol-relative resource refs)
+  * ``@font-face`` (incl. escaped ``@f\\6f nt-face``).
+  * external URLs (http/https + protocol-relative ``//``) in any attribute value
+    (entity-decoded), CSS ``url()`` token, or ``@import``. Only the exact XML
+    namespace URIs (``http://www.w3.org/2000/svg`` / ``…/1999/xlink``) are exempt.
 
-Scope + honest limits: color/font rules scan CSS only — ``<style>`` blocks and
-inline ``style=`` attributes — NOT ``<script>`` bodies, so colors set in ECharts
-JS config are governed by the skill's "use window.JARVIS_THEME.palette"
-instruction, not this linter. Detection is regex over comment-stripped CSS
-(``/* */`` in CSS, ``<!-- -->`` in HTML are removed first); it targets the
-enumerable patterns above and is a standard/cleanliness gate layered under the
-hard CSP+sandbox boundary (which is what actually blocks network egress), not an
-exhaustive parser.
+Honest scope + limits: this validator enforces COLOR, font-family, no-``!important``,
+no-``prefers-color-scheme``, well-formed CSS, and the safety bans. It does NOT
+deterministically lint STRUCTURE (spacing / type scale / layout) — structural
+adherence comes from the winning named component classes (emitted in ``@layer
+theme``) plus the generation prompt, not a hard spacing rule. Color/font rules
+scan CSS only — ``<style>`` blocks and inline ``style=`` attributes — NOT
+``<script>`` bodies, so colors set in ECharts JS config are governed by the
+skill's "use window.JARVIS_THEME.palette" instruction, not this linter. It is a
+standard/cleanliness gate layered under the hard CSP+sandbox boundary (which is
+what actually blocks network egress), not an exhaustive engine.
 """
 
 from __future__ import annotations
 
 import re
 from typing import NamedTuple
+
+import html5lib
+import tinycss2
+from tinycss2 import ast
 
 from jarvis.dashboards import theme_spec
 
@@ -62,120 +99,314 @@ class Violation(NamedTuple):
 # Rule codes ------------------------------------------------------------------
 RULE_OFF_PALETTE = "off-palette-color"
 RULE_FONT_FAMILY = "font-family-override"
+RULE_TOKEN_REDEFINE = "token-redefinition"
 RULE_PREFERS_SCHEME = "prefers-color-scheme"
 RULE_COLOR_SCHEME = "color-scheme"
-RULE_IMPORTANT = "important-color-font"
+RULE_IMPORTANT = "important-declaration"
 RULE_INLINE_COLOR = "inline-style-color"
+RULE_MALFORMED = "malformed-css"  # a stray } that would escape @layer author
 RULE_FONT_FACE = "font-face"  # safety
 RULE_EXTERNAL_URL = "external-url"  # safety
 
-# Color-bearing CSS properties (shorthands included). Used for the named-color,
-# inline-color and !important checks.
-_COLOR_PROPS = frozenset({
-	"color", "background", "background-color", "background-image",
-	"border", "border-color", "border-top", "border-right", "border-bottom",
-	"border-left", "border-top-color", "border-right-color",
-	"border-bottom-color", "border-left-color", "outline", "outline-color",
-	"box-shadow", "text-shadow", "fill", "stroke", "caret-color",
-	"column-rule-color", "text-decoration-color", "accent-color",
-})
+# Color-bearing CSS properties (shorthands included). A named/functional color in
+# one of these declaration VALUES is inspected; a hex in any of them is caught too.
+_COLOR_PROPS = frozenset(
+	{
+		"color",
+		"background",
+		"background-color",
+		"background-image",
+		"border",
+		"border-color",
+		"border-top",
+		"border-right",
+		"border-bottom",
+		"border-left",
+		"border-top-color",
+		"border-right-color",
+		"border-bottom-color",
+		"border-left-color",
+		"outline",
+		"outline-color",
+		"box-shadow",
+		"text-shadow",
+		"fill",
+		"stroke",
+		"caret-color",
+		"column-rule",
+		"column-rule-color",
+		"text-decoration",
+		"text-decoration-color",
+		"accent-color",
+		"-webkit-text-fill-color",
+		"-webkit-text-stroke-color",
+		"-webkit-text-stroke",
+		"-webkit-tap-highlight-color",
+		"border-inline-color",
+		"border-block-color",
+		"border-inline-start-color",
+		"border-inline-end-color",
+		"border-block-start-color",
+		"border-block-end-color",
+		"scrollbar-color",
+		"text-emphasis-color",
+		"text-emphasis",
+		"stop-color",
+		"flood-color",
+		"lighting-color",
+	}
+)
 _FONT_PROPS = frozenset({"font-family", "font"})
 
 # Approved neutral hex values (always allowed regardless of theme).
 _APPROVED_HEXES = frozenset({"#ffffff", "#000000"})
 # Approved color keywords (values, not families).
-_APPROVED_COLOR_WORDS = frozenset({
-	"transparent", "currentcolor", "inherit", "initial", "unset", "revert",
-	"white", "black", "none",
-})
+_APPROVED_COLOR_WORDS = frozenset(
+	{
+		"transparent",
+		"currentcolor",
+		"inherit",
+		"initial",
+		"unset",
+		"revert",
+		"white",
+		"black",
+		"none",
+	}
+)
 # Generic font-family keywords (always allowed as families).
-_GENERIC_FAMILIES = frozenset({
-	"serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui",
-	"ui-sans-serif", "ui-serif", "ui-monospace", "ui-rounded", "math", "emoji",
-	"fangsong", "inherit", "initial", "unset", "revert",
-})
+_GENERIC_FAMILIES = frozenset(
+	{
+		"serif",
+		"sans-serif",
+		"monospace",
+		"cursive",
+		"fantasy",
+		"system-ui",
+		"ui-sans-serif",
+		"ui-serif",
+		"ui-monospace",
+		"ui-rounded",
+		"math",
+		"emoji",
+		"fangsong",
+		"inherit",
+		"initial",
+		"unset",
+		"revert",
+	}
+)
+# Modern color functions — never allow-listable, so any occurrence is off-palette.
+_MODERN_COLOR_FNS = frozenset(
+	{
+		"oklch",
+		"oklab",
+		"lab",
+		"lch",
+		"hwb",
+		"color-mix",
+		"device-cmyk",
+		"color",
+	}
+)
+# Exact XML namespace URIs that are identifiers, never fetched — the ONLY http(s)
+# values exempt from the external-URL safety ban (narrowed from "the w3.org host").
+_ALLOWED_XML_NS = frozenset(
+	{
+		"http://www.w3.org/2000/svg",
+		"http://www.w3.org/1999/xlink",
+	}
+)
 
 # Full CSS named-color set (minus the approved neutrals above), used to flag a
 # brand-y named color sitting in a color-bearing declaration value.
-_CSS_NAMED_COLORS = frozenset({
-	"aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
-	"bisque", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood",
-	"cadetblue", "chartreuse", "chocolate", "coral", "cornflowerblue",
-	"cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod",
-	"darkgray", "darkgrey", "darkgreen", "darkkhaki", "darkmagenta",
-	"darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon",
-	"darkseagreen", "darkslateblue", "darkslategray", "darkslategrey",
-	"darkturquoise", "darkviolet", "deeppink", "deepskyblue", "dimgray",
-	"dimgrey", "dodgerblue", "firebrick", "floralwhite", "forestgreen",
-	"fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "grey",
-	"green", "greenyellow", "honeydew", "hotpink", "indianred", "indigo",
-	"ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon",
-	"lightblue", "lightcoral", "lightcyan", "lightgoldenrodyellow", "lightgray",
-	"lightgrey", "lightgreen", "lightpink", "lightsalmon", "lightseagreen",
-	"lightskyblue", "lightslategray", "lightslategrey", "lightsteelblue",
-	"lightyellow", "lime", "limegreen", "linen", "magenta", "maroon",
-	"mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple",
-	"mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise",
-	"mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin",
-	"navajowhite", "navy", "oldlace", "olive", "olivedrab", "orange",
-	"orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise",
-	"palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum",
-	"powderblue", "purple", "rebeccapurple", "red", "rosybrown", "royalblue",
-	"saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna",
-	"silver", "skyblue", "slateblue", "slategray", "slategrey", "snow",
-	"springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise",
-	"violet", "wheat", "whitesmoke", "yellow", "yellowgreen",
-})
+_CSS_NAMED_COLORS = frozenset(
+	{
+		"aliceblue",
+		"antiquewhite",
+		"aqua",
+		"aquamarine",
+		"azure",
+		"beige",
+		"bisque",
+		"blanchedalmond",
+		"blue",
+		"blueviolet",
+		"brown",
+		"burlywood",
+		"cadetblue",
+		"chartreuse",
+		"chocolate",
+		"coral",
+		"cornflowerblue",
+		"cornsilk",
+		"crimson",
+		"cyan",
+		"darkblue",
+		"darkcyan",
+		"darkgoldenrod",
+		"darkgray",
+		"darkgrey",
+		"darkgreen",
+		"darkkhaki",
+		"darkmagenta",
+		"darkolivegreen",
+		"darkorange",
+		"darkorchid",
+		"darkred",
+		"darksalmon",
+		"darkseagreen",
+		"darkslateblue",
+		"darkslategray",
+		"darkslategrey",
+		"darkturquoise",
+		"darkviolet",
+		"deeppink",
+		"deepskyblue",
+		"dimgray",
+		"dimgrey",
+		"dodgerblue",
+		"firebrick",
+		"floralwhite",
+		"forestgreen",
+		"fuchsia",
+		"gainsboro",
+		"ghostwhite",
+		"gold",
+		"goldenrod",
+		"gray",
+		"grey",
+		"green",
+		"greenyellow",
+		"honeydew",
+		"hotpink",
+		"indianred",
+		"indigo",
+		"ivory",
+		"khaki",
+		"lavender",
+		"lavenderblush",
+		"lawngreen",
+		"lemonchiffon",
+		"lightblue",
+		"lightcoral",
+		"lightcyan",
+		"lightgoldenrodyellow",
+		"lightgray",
+		"lightgrey",
+		"lightgreen",
+		"lightpink",
+		"lightsalmon",
+		"lightseagreen",
+		"lightskyblue",
+		"lightslategray",
+		"lightslategrey",
+		"lightsteelblue",
+		"lightyellow",
+		"lime",
+		"limegreen",
+		"linen",
+		"magenta",
+		"maroon",
+		"mediumaquamarine",
+		"mediumblue",
+		"mediumorchid",
+		"mediumpurple",
+		"mediumseagreen",
+		"mediumslateblue",
+		"mediumspringgreen",
+		"mediumturquoise",
+		"mediumvioletred",
+		"midnightblue",
+		"mintcream",
+		"mistyrose",
+		"moccasin",
+		"navajowhite",
+		"navy",
+		"oldlace",
+		"olive",
+		"olivedrab",
+		"orange",
+		"orangered",
+		"orchid",
+		"palegoldenrod",
+		"palegreen",
+		"paleturquoise",
+		"palevioletred",
+		"papayawhip",
+		"peachpuff",
+		"peru",
+		"pink",
+		"plum",
+		"powderblue",
+		"purple",
+		"rebeccapurple",
+		"red",
+		"rosybrown",
+		"royalblue",
+		"saddlebrown",
+		"salmon",
+		"sandybrown",
+		"seagreen",
+		"seashell",
+		"sienna",
+		"silver",
+		"skyblue",
+		"slateblue",
+		"slategray",
+		"slategrey",
+		"snow",
+		"springgreen",
+		"steelblue",
+		"tan",
+		"teal",
+		"thistle",
+		"tomato",
+		"turquoise",
+		"violet",
+		"wheat",
+		"whitesmoke",
+		"yellow",
+		"yellowgreen",
+	}
+)
 
-# ── regexes ──────────────────────────────────────────────────────────────────
-_STYLE_BLOCK_RE = re.compile(r"<style\b[^>]*>([\s\S]*?)</style>", re.I)
-_INLINE_STYLE_RE = re.compile(r"""\bstyle\s*=\s*("([^"]*)"|'([^']*)')""", re.I)
-_CSS_COMMENT_RE = re.compile(r"/\*[\s\S]*?\*/")
-_HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
-# One CSS declaration: `prop: value` up to ; } or {. Skips selectors (their
-# "prop" is a tag/class name, never a color/font property we inspect).
-_DECL_RE = re.compile(r"([-a-zA-Z]+)\s*:\s*([^;{}]*)")
-_HEX_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+# At-rules whose body is a list of RULES (recurse into them for nested checks).
+_RULE_BODY_AT = frozenset(
+	{
+		"media",
+		"supports",
+		"layer",
+		"container",
+		"document",
+		"-moz-document",
+		"scope",
+		"keyframes",
+		"-webkit-keyframes",
+		"-moz-keyframes",
+		"-o-keyframes",
+	}
+)
+
+# Only used to parse an isolated rgb()/hsl() literal's numeric args.
 _RGB_RE = re.compile(r"\brgba?\(\s*([^)]*)\)", re.I)
 _HSL_RE = re.compile(r"\bhsla?\(\s*([^)]*)\)", re.I)
-_FONT_FACE_RE = re.compile(r"@font-face\b", re.I)
-_PREFERS_SCHEME_RE = re.compile(r"@media[^{]*prefers-color-scheme", re.I)
-# `color-scheme:` as its own property — the negative lookbehind keeps it from
-# matching the `color-scheme` tail of `prefers-color-scheme` (its own rule).
-_COLOR_SCHEME_RE = re.compile(r"(?<![-\w])color-scheme\s*:", re.I)
-_FONT_FACE_BLOCK_RE = re.compile(r"@font-face\s*\{[^{}]*\}", re.I)
-# http/https (except W3C XML namespaces, which are identifiers, not fetches).
-_HTTP_URL_RE = re.compile(r"""https?://(?!(?:www\.)?w3\.org/)[^\s"'()<>]+""", re.I)
-# protocol-relative resource references: src/href="//…" or url(//…).
-_PROTO_REL_RE = re.compile(r"""(?:\bsrc|\bhref|\burl\()\s*=?\s*["']?//[^\s"'()<>]+""", re.I)
+# An external/protocol-relative URL anywhere in a (decoded) attribute value.
+_URLISH_RE = re.compile(r"""(?:https?:)?//[^\s"'()<>]+""", re.I)
 
 
-# ── helpers ──────────────────────────────────────────────────────────────────
-def _strip_css_comments(css: str) -> str:
-	return _CSS_COMMENT_RE.sub(" ", css or "")
-
-
-def _style_css(html: str) -> str:
-	"""All author <style> CSS, comment-stripped and joined."""
-	return "\n".join(_strip_css_comments(m.group(1)) for m in _STYLE_BLOCK_RE.finditer(html))
-
-
-def _inline_styles(html: str) -> list[str]:
-	out = []
-	for m in _INLINE_STYLE_RE.finditer(html):
-		out.append(_strip_css_comments(m.group(2) if m.group(2) is not None else (m.group(3) or "")))
-	return out
-
-
+# ── color literal helpers (reused by both CSS and inline passes) ──────────────
 def _norm_hex(h: str) -> str:
-	"""Normalize a #rgb / #rgba / #rrggbb / #rrggbbaa literal to #rrggbb
-	(alpha dropped). Returns '' if not a clean 3/4/6/8-digit hex."""
+	"""Normalize a #rgb / #rgba / #rrggbb / #rrggbbaa literal to #rrggbb (alpha
+	dropped). Returns '' if not a clean 3/4/6/8-digit hex."""
 	s = h[1:]
 	if len(s) in (3, 4):
 		s = "".join(c * 2 for c in s[:3])
 	elif len(s) in (6, 8):
 		s = s[:6]
 	else:
+		return ""
+	if not re.fullmatch(r"[0-9a-fA-F]{6}", s):
 		return ""
 	return "#" + s.lower()
 
@@ -188,24 +419,24 @@ def _rgb_to_hex(inner: str) -> str:
 	if len(parts) < 3:
 		return ""
 	try:
-		rgb = [max(0, min(255, int(round(float(x))))) for x in parts[:3]]
+		rgb = [max(0, min(255, round(float(x)))) for x in parts[:3]]
 	except ValueError:
 		return ""
 	return "#" + "".join(f"{c:02x}" for c in rgb)
 
 
 def _hsl_is_neutral(inner: str) -> bool | None:
-	"""True if an hsl()/hsla() is achromatic black/white (s=0 & l∈{0,100}) —
-	an approved neutral. False if chromatic / non-neutral. None if unparseable."""
+	"""True if an hsl()/hsla() is achromatic black/white (s=0 & l∈{0,100}) — an
+	approved neutral. False if chromatic. None if unparseable."""
 	parts = [p.strip().rstrip("%") for p in re.split(r"[,\s/]+", inner.strip()) if p.strip()]
 	if len(parts) < 3:
 		return None
 	try:
 		s = float(parts[1])
-		l = float(parts[2])
+		lightness = float(parts[2])
 	except ValueError:
 		return None
-	return s == 0 and (l == 0 or l == 100)
+	return s == 0 and (lightness == 0 or lightness == 100)
 
 
 def _color_allowed(literal: str, allowed_hexes: frozenset) -> bool:
@@ -224,158 +455,401 @@ def _color_allowed(literal: str, allowed_hexes: frozenset) -> bool:
 	return False
 
 
-def _iter_decls(css: str):
-	"""Yield (prop_lower, value) declarations from a CSS string."""
-	for m in _DECL_RE.finditer(css):
-		yield m.group(1).lower(), m.group(2).strip()
+def _is_external_url(url: str) -> bool:
+	"""A decoded URL string that the browser would FETCH off-origin. data:/blob:/
+	relative/fragment are fine; the exact SVG/xlink namespaces are exempt."""
+	s = (url or "").strip().lower()
+	if not s or s in _ALLOWED_XML_NS:
+		return False
+	return s.startswith("http://") or s.startswith("https://") or s.startswith("//")
 
 
-def _family_tokens(value: str, shorthand: bool) -> list[str]:
-	"""Candidate font-family names from a font-family value (or a `font`
-	shorthand). For the shorthand, the leading size/line-height/weight tokens of
-	the first comma-segment are dropped (family is the trailing word group)."""
-	segs = [s.strip() for s in value.split(",") if s.strip()]
-	if not segs:
-		return []
-	fams = list(segs)
-	if shorthand:
-		# `font: 700 14px/1.5 "Segoe UI", sans-serif` -> first seg's family is
-		# after the last space run; keep the rest of the segments verbatim.
-		first = segs[0]
-		fams[0] = first.rsplit(" ", 1)[-1] if " " in first and '"' not in first and "'" not in first else first
-	return [f.strip().strip("\"'").lower() for f in fams if f.strip()]
-
-
-# ── individual checks ────────────────────────────────────────────────────────
-def _check_font_face(css: str, out: list) -> None:
-	if _FONT_FACE_RE.search(css):
-		out.append(Violation(
-			RULE_FONT_FACE, "<style>", "@font-face",
-			"@font-face is not allowed — the canvas has no network and must use the system font stack.",
-		))
-
-
-def _check_external_urls(html: str, out: list) -> None:
-	scan = _HTML_COMMENT_RE.sub(" ", html)
-	seen: set = set()
-	for m in _HTTP_URL_RE.finditer(scan):
-		url = m.group(0)[:120]
-		if url in seen:
+def _external_urls_in_text(text: str) -> list[str]:
+	"""External/protocol-relative URLs in a decoded attribute value (skips the
+	exact XML namespace URIs)."""
+	out = []
+	for m in _URLISH_RE.finditer(text or ""):
+		u = m.group(0)
+		if u.lower() in _ALLOWED_XML_NS:
 			continue
-		seen.add(url)
-		out.append(Violation(
-			RULE_EXTERNAL_URL, "html", url,
-			f"External URL '{url}' is not allowed — inline all resources (data: URIs only).",
-		))
-	for m in _PROTO_REL_RE.finditer(scan):
-		frag = m.group(0)[:120]
-		if frag in seen:
+		out.append(u)
+	return out
+
+
+# ── HTML parsing (html5lib → lxml) ────────────────────────────────────────────
+def _parse_html(html: str):
+	return html5lib.parse(html or "", treebuilder="lxml", namespaceHTMLElements=False)
+
+
+def _local_name(tag) -> str:
+	if not isinstance(tag, str):
+		return ""
+	return tag.rsplit("}", 1)[-1].lower()
+
+
+def _style_blocks(tree) -> list[str]:
+	"""Every <style> element's raw CSS text (an unclosed <style> already carries
+	its raw-text-to-EOF content, matching the browser)."""
+	return [(el.text or "") for el in tree.iter() if _local_name(el.tag) == "style"]
+
+
+def _inline_styles(tree) -> list[str]:
+	"""Every element's decoded ``style=`` attribute value (incl. unquoted)."""
+	out = []
+	for el in tree.iter():
+		if not isinstance(el.tag, str):
 			continue
-		seen.add(frag)
-		out.append(Violation(
-			RULE_EXTERNAL_URL, "html", frag,
-			f"Protocol-relative resource '{frag}' is not allowed — inline all resources.",
-		))
+		st = el.get("style")
+		if st:
+			out.append(st)
+	return out
 
 
-def _check_prefers_color_scheme(css: str, out: list) -> None:
-	if _PREFERS_SCHEME_RE.search(css):
-		out.append(Violation(
-			RULE_PREFERS_SCHEME, "<style>", "@media (prefers-color-scheme)",
-			"@media (prefers-color-scheme) is not allowed — light/dark follows the theme's data-theme only.",
-		))
-
-
-def _check_color_scheme(css: str, out: list) -> None:
-	if _COLOR_SCHEME_RE.search(css):
-		out.append(Violation(
-			RULE_COLOR_SCHEME, "<style>", "color-scheme",
-			"The color-scheme property is not allowed — light/dark follows the theme's data-theme only.",
-		))
-
-
-def _check_css_colors(css: str, allowed_hexes: frozenset, out: list) -> None:
-	# Pass A: hex + rgb/hsl literals anywhere in the CSS.
-	for m in _HEX_RE.finditer(css):
-		lit = m.group(0)
-		if not _color_allowed(lit, allowed_hexes):
-			out.append(_off_palette(lit))
-	for m in _RGB_RE.finditer(css):
-		lit = m.group(0)
-		if not _color_allowed(lit, allowed_hexes):
-			out.append(_off_palette(lit))
-	for m in _HSL_RE.finditer(css):
-		lit = m.group(0)
-		if not _color_allowed(lit, allowed_hexes):
-			out.append(_off_palette(lit))
-	# Pass B: named colors, only inside a color-bearing declaration value.
-	for prop, value in _iter_decls(css):
-		if prop not in _COLOR_PROPS:
+def _attr_values(tree):
+	for el in tree.iter():
+		if not isinstance(el.tag, str):
 			continue
-		for word in re.findall(r"[a-zA-Z]+", value):
-			w = word.lower()
-			if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
-				out.append(_off_palette(word))
+		for v in el.attrib.values():
+			if v:
+				yield v
 
 
-def _off_palette(token: str) -> Violation:
+# ── CSS parsing (tinycss2) ────────────────────────────────────────────────────
+def _decls(content):
+	return tinycss2.parse_declaration_list(content or [], skip_comments=True, skip_whitespace=True)
+
+
+def _rules(content):
+	return tinycss2.parse_rule_list(content or [], skip_comments=True, skip_whitespace=True)
+
+
+def _flatten_block(content):
+	"""Yield ('decl', Declaration) / ('atrule', AtRule) from a declaration-block
+	token list, recursing into nested rule bodies. Native CSS nesting puts a
+	nested rule's declarations inside a ``CurlyBracketsBlock`` token of the parent
+	block, so its selector prelude (which may itself contain an id ``#hash``) is
+	never read as a value — only the nested block's declarations are."""
+	for d in _decls(content):
+		if isinstance(d, ast.Declaration):
+			yield ("decl", d)
+		elif isinstance(d, ast.AtRule):
+			yield from _flatten([d])
+	for tok in content or []:
+		if type(tok).__name__ == "CurlyBracketsBlock":
+			yield from _flatten_block(tok.content)
+
+
+def _flatten(rules):
+	"""Depth-first walk yielding ('decl', Declaration) / ('atrule', AtRule) for
+	the whole (possibly nested) rule tree. @font-face is terminal (its body is the
+	face definition, flagged as a safety violation, never recursed)."""
+	for rule in rules:
+		if isinstance(rule, ast.QualifiedRule):
+			yield from _flatten_block(rule.content)
+		elif isinstance(rule, ast.AtRule):
+			yield ("atrule", rule)
+			kw = (rule.lower_at_keyword or "").lower()
+			if kw == "font-face" or rule.content is None:
+				continue
+			if kw in _RULE_BODY_AT:
+				yield from _flatten(_rules(rule.content))
+			else:
+				yield from _flatten_block(rule.content)
+
+
+def _has_structural_error(css: str) -> bool:
+	"""True if the CSS has a stray/misplaced close bracket — a top-level ``}``
+	(or ``)`` / ``]``) with no opener. Such a ``}`` would terminate the injected
+	``@layer author {}`` wrapper early and let the following rule render UNLAYERED,
+	outranking the theme (F#4). An unclosed ``{`` is NOT flagged: it stays
+	contained inside the wrapper, so it cannot escape."""
+	for tok in tinycss2.parse_component_value_list(css or ""):
+		if isinstance(tok, ast.ParseError) and tok.kind in ("}", ")", "]"):
+			return True
+	return False
+
+
+def _first_custom_prop(tokens) -> str | None:
+	for t in tokens:
+		if type(t).__name__ == "IdentToken" and (t.value or "").startswith("--"):
+			return t.value
+	return None
+
+
+def _url_strings(tokens) -> list[str]:
+	"""Every URL a declaration value would fetch: url() tokens and url("…")
+	function-string args, recursively (e.g. inside a gradient / image-set)."""
+	out = []
+	for tok in tokens:
+		tn = type(tok).__name__
+		if tn == "URLToken":
+			out.append(tok.value or "")
+		elif tn == "FunctionBlock":
+			if (tok.lower_name or "").lower() == "url":
+				out += [a.value for a in tok.arguments if type(a).__name__ == "StringToken"]
+			else:
+				out += _url_strings(tok.arguments)
+	return out
+
+
+def _import_urls(prelude) -> list[str]:
+	"""The URL of an @import (string form ``@import "…"`` or ``@import url(…)``)."""
+	out = []
+	for tok in prelude or []:
+		tn = type(tok).__name__
+		if tn == "StringToken":
+			out.append(tok.value or "")
+		elif tn == "URLToken":
+			out.append(tok.value or "")
+		elif tn == "FunctionBlock" and (tok.lower_name or "").lower() == "url":
+			out += [a.value for a in tok.arguments if type(a).__name__ == "StringToken"]
+	return out
+
+
+def _has_prefers_scheme(prelude) -> bool:
+	"""True if a media-query prelude references ``prefers-color-scheme`` (decoded,
+	so an escaped ``prefers-c\\6f lor-scheme`` is caught too)."""
+
+	def idents(tokens):
+		for t in tokens or []:
+			tn = type(t).__name__
+			if tn == "IdentToken":
+				yield (t.value or "").lower()
+			elif tn in ("ParenthesesBlock", "SquareBracketsBlock", "CurlyBracketsBlock"):
+				yield from idents(t.content)
+			elif tn == "FunctionBlock":
+				yield from idents(t.arguments)
+
+	return "prefers-color-scheme" in set(idents(prelude))
+
+
+# ── violation factories ───────────────────────────────────────────────────────
+def _color_violation(token: str, rule: str, location: str) -> Violation:
+	if rule == RULE_INLINE_COLOR:
+		msg = (
+			f"Off-theme color '{token}' in an inline style= — it escapes the theme "
+			"layer; use a var(--jd-*) token in a <style> rule."
+		)
+	else:
+		msg = f"Off-theme color '{token}' — use a var(--jd-*) token or a color from the selected theme."
+	return Violation(rule, location, token, msg)
+
+
+def _external_violation(url: str) -> Violation:
+	u = (url or "")[:120]
 	return Violation(
-		RULE_OFF_PALETTE, "<style>", token,
-		f"Off-theme color '{token}' — use a var(--jd-*) token or a color from the selected theme.",
+		RULE_EXTERNAL_URL,
+		"html",
+		u,
+		f"External URL '{u}' is not allowed — inline all resources (data: URIs only).",
 	)
 
 
-def _check_font_family(css: str, allowed_families: frozenset, out: list) -> None:
-	for prop, value in _iter_decls(css):
-		if prop not in _FONT_PROPS:
+# ── declaration + at-rule checks ──────────────────────────────────────────────
+def _scan_color_tokens(tokens, allowed_hexes, out, *, color_rule, location):
+	"""Flag any color VALUE that is not an allowed theme hex / var(--jd-*) /
+	approved neutral. Recurses into non-color functions (gradients, image-set)."""
+	for tok in tokens:
+		tn = type(tok).__name__
+		if tn == "HashToken":
+			lit = "#" + (tok.value or "")
+			if not _color_allowed(lit, allowed_hexes):
+				out.append(_color_violation(lit, color_rule, location))
+		elif tn == "FunctionBlock":
+			fname = (tok.lower_name or "").lower()
+			if fname in _MODERN_COLOR_FNS:
+				out.append(_color_violation(tinycss2.serialize([tok]).strip(), color_rule, location))
+			elif fname in ("rgb", "rgba", "hsl", "hsla"):
+				lit = tinycss2.serialize([tok]).strip()
+				if not _color_allowed(lit, allowed_hexes):
+					out.append(_color_violation(lit, color_rule, location))
+			elif fname == "var":
+				ref = _first_custom_prop(tok.arguments)
+				if not (ref and ref.lower().startswith("--jd-")):
+					out.append(_color_violation(tinycss2.serialize([tok]).strip(), color_rule, location))
+			else:
+				_scan_color_tokens(
+					tok.arguments, allowed_hexes, out, color_rule=color_rule, location=location
+				)
+		elif tn == "IdentToken":
+			w = (tok.value or "").lower()
+			if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
+				out.append(_color_violation(tok.value, color_rule, location))
+
+
+def _family_candidates(tokens, shorthand):
+	"""(kind, display, var_ref) per comma-separated font-family segment. ``kind``
+	is 'var' (a var() indirection) or 'name' (a literal family)."""
+	segments = [[]]
+	for t in tokens:
+		if type(t).__name__ == "LiteralToken" and t.value == ",":
+			segments.append([])
+		else:
+			segments[-1].append(t)
+	out = []
+	for idx, seg in enumerate(segments):
+		var_fn = next(
+			(t for t in seg if type(t).__name__ == "FunctionBlock" and (t.lower_name or "").lower() == "var"),
+			None,
+		)
+		if var_fn is not None:
+			out.append(("var", tinycss2.serialize([var_fn]).strip(), _first_custom_prop(var_fn.arguments)))
 			continue
-		for fam in _family_tokens(value, shorthand=(prop == "font")):
-			if not fam or fam.startswith("var(") or fam in _GENERIC_FAMILIES or fam in allowed_families:
+		strings = [t for t in seg if type(t).__name__ == "StringToken"]
+		if strings:
+			out.append(("name", strings[-1].value.strip().lower(), None))
+			continue
+		idents = [t for t in seg if type(t).__name__ == "IdentToken"]
+		if not idents:
+			continue
+		if shorthand and idx == 0:
+			# `font:` shorthand — the family is the trailing ident run after the
+			# last size / line-height / numeric token of the first segment.
+			last_num = -1
+			for i, t in enumerate(seg):
+				tn = type(t).__name__
+				if tn in ("NumberToken", "DimensionToken", "PercentageToken") or (
+					tn == "LiteralToken" and t.value == "/"
+				):
+					last_num = i
+			tail = [t.value for t in seg[last_num + 1 :] if type(t).__name__ == "IdentToken"]
+			name = " ".join(tail)
+		else:
+			name = " ".join(t.value for t in idents)
+		out.append(("name", name.strip().lower(), None))
+	return out
+
+
+def _check_font(tokens, shorthand, allowed_families, out, *, location):
+	for kind, display, ref in _family_candidates(tokens, shorthand):
+		if kind == "var":
+			if ref and ref.lower().startswith("--jd-font"):
 				continue
-			# A `font:` shorthand carries size/weight tokens we can't fully model;
-			# only flag a token that looks like a real family name (letters).
-			if prop == "font" and not re.search(r"[a-zA-Z]", fam):
-				continue
-			out.append(Violation(
-				RULE_FONT_FAMILY, "<style>", fam,
+			out.append(
+				Violation(
+					RULE_FONT_FAMILY,
+					location,
+					display,
+					f"Font family '{display}' is not allowed — reference var(--jd-font)/"
+					"var(--jd-font-display) or the system font stack, not another custom property.",
+				)
+			)
+			continue
+		fam = display
+		if not fam or not any(c.isalpha() for c in fam):
+			continue
+		if fam in _GENERIC_FAMILIES or fam in allowed_families:
+			continue
+		out.append(
+			Violation(
+				RULE_FONT_FAMILY,
+				location,
+				fam,
 				f"Font family '{fam}' is not allowed — use var(--jd-font)/var(--jd-font-display) "
 				"or the system font stack.",
-			))
+			)
+		)
 
 
-def _check_important(css: str, out: list) -> None:
-	for prop, value in _iter_decls(css):
-		if "!important" not in value.lower():
-			continue
-		if prop in _COLOR_PROPS or prop in _FONT_PROPS:
-			out.append(Violation(
-				RULE_IMPORTANT, "<style>", f"{prop}: … !important",
-				f"!important on '{prop}' is not allowed — it escapes the theme layer.",
-			))
+def _check_declaration(d, ctx, out, *, color_rule, location):
+	name = d.name or ""
+	lname = (d.lower_name or name).lower()
+
+	# External URLs in a declaration value — always (incl. Custom).
+	for u in _url_strings(d.value):
+		if _is_external_url(u):
+			out.append(_external_violation(u))
+
+	if not ctx["design"]:
+		return
+
+	if lname.startswith("--jd-"):
+		out.append(
+			Violation(
+				RULE_TOKEN_REDEFINE,
+				location,
+				name,
+				f"'{name}' is a theme token — do not redefine it; the selected theme owns "
+				"the --jd-* values. Reference it with var(--jd-*), never reassign it.",
+			)
+		)
+	if d.important:
+		out.append(
+			Violation(
+				RULE_IMPORTANT,
+				location,
+				f"{name}: … !important",
+				f"!important on '{name}' is not allowed — it escapes the theme layer; "
+				"remove it and rely on the theme's own styling.",
+			)
+		)
+	if lname == "color-scheme":
+		out.append(
+			Violation(
+				RULE_COLOR_SCHEME,
+				location,
+				"color-scheme",
+				"The color-scheme property is not allowed — light/dark follows the theme's data-theme only.",
+			)
+		)
+	if lname in _COLOR_PROPS:
+		_scan_color_tokens(d.value, ctx["allowed_hexes"], out, color_rule=color_rule, location=location)
+	if lname in _FONT_PROPS:
+		_check_font(d.value, lname == "font", ctx["allowed_families"], out, location=location)
 
 
-def _check_inline_styles(inline_styles: list, allowed_hexes: frozenset, out: list) -> None:
-	for css in inline_styles:
-		for prop, value in _iter_decls(css):
-			if prop not in _COLOR_PROPS:
-				continue
-			bad = None
-			for lit_m in list(_HEX_RE.finditer(value)) + list(_RGB_RE.finditer(value)) + list(_HSL_RE.finditer(value)):
-				if not _color_allowed(lit_m.group(0), allowed_hexes):
-					bad = lit_m.group(0)
-					break
-			if bad is None:
-				for word in re.findall(r"[a-zA-Z]+", value):
-					w = word.lower()
-					if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
-						bad = word
-						break
-			if bad is not None:
-				out.append(Violation(
-					RULE_INLINE_COLOR, "inline style=", bad,
-					f"Off-theme color '{bad}' in an inline style= — it escapes the theme layer; "
-					"use a var(--jd-*) token in a <style> rule.",
-				))
+def _check_at_rule(rule, ctx, out):
+	kw = (rule.lower_at_keyword or "").lower()
+	if kw == "font-face":
+		out.append(
+			Violation(
+				RULE_FONT_FACE,
+				"<style>",
+				"@font-face",
+				"@font-face is not allowed — the canvas has no network and must use the system font stack.",
+			)
+		)
+		return
+	if kw == "import":
+		for u in _import_urls(rule.prelude):
+			if _is_external_url(u):
+				out.append(_external_violation(u))
+	if ctx["design"] and kw == "media" and _has_prefers_scheme(rule.prelude):
+		out.append(
+			Violation(
+				RULE_PREFERS_SCHEME,
+				"<style>",
+				"@media (prefers-color-scheme)",
+				"@media (prefers-color-scheme) is not allowed — light/dark follows the theme's data-theme only.",
+			)
+		)
+
+
+def _check_style_block(css, ctx, out):
+	# A stray/misplaced } would break out of the @layer author {} wrapper (F#4);
+	# reject it (standard themes only — Custom author CSS is never layer-wrapped).
+	if ctx["design"] and _has_structural_error(css):
+		out.append(
+			Violation(
+				RULE_MALFORMED,
+				"<style>",
+				"unbalanced-braces",
+				"The CSS has unbalanced or misplaced braces — fix the syntax so it can "
+				"be enforced under the theme.",
+			)
+		)
+	rules = tinycss2.parse_stylesheet(css or "", skip_comments=True, skip_whitespace=True)
+	for kind, node in _flatten(rules):
+		if kind == "atrule":
+			_check_at_rule(node, ctx, out)
+		else:
+			_check_declaration(node, ctx, out, color_rule=RULE_OFF_PALETTE, location="<style>")
+
+
+def _check_inline_style(css, ctx, out):
+	for d in _decls(css):
+		if isinstance(d, ast.Declaration):
+			_check_declaration(d, ctx, out, color_rule=RULE_INLINE_COLOR, location="inline style=")
 
 
 # ── public entry point ───────────────────────────────────────────────────────
@@ -388,33 +862,62 @@ def validate_dashboard_html(html: str, theme: str) -> list[Violation]:
 	the default ('jarvis')."""
 	html = html or ""
 	key = theme_spec.theme_key(theme)
-	css = _style_css(html)
+	design = key != theme_spec.CUSTOM_KEY
+
+	try:
+		tree = _parse_html(html)
+	except Exception:
+		# html5lib parses any string like a browser, so this is effectively
+		# unreachable; fail closed (reject) rather than silently pass an
+		# un-scannable document.
+		return [
+			Violation(
+				RULE_MALFORMED,
+				"html",
+				"unparseable",
+				"The dashboard HTML could not be parsed — fix the markup and try again.",
+			)
+		]
+
 	violations: list = []
 
-	# Safety bans — always, including Custom.
-	_check_font_face(css, violations)
-	_check_external_urls(html, violations)
-	if key == theme_spec.CUSTOM_KEY:
-		return violations
+	# Safety: external URLs in any (entity-decoded) attribute value — always.
+	for value in _attr_values(tree):
+		for u in _external_urls_in_text(value):
+			violations.append(_external_violation(u))
 
-	spec = theme_spec.load_theme(key) or theme_spec.load_theme(theme_spec.DEFAULT_KEY)
-	allowed_hexes = frozenset(h.lower() for h in spec["validator"]["allowed_color_hexes"])
-	allowed_families = frozenset(f.lower() for f in spec["validator"]["allowed_font_families"])
+	allowed_hexes: frozenset = frozenset()
+	allowed_families: frozenset = frozenset()
+	if design:
+		spec = theme_spec.load_theme(key) or theme_spec.load_theme(theme_spec.DEFAULT_KEY)
+		allowed_hexes = frozenset(h.lower() for h in spec["validator"]["allowed_color_hexes"])
+		allowed_families = frozenset(f.lower() for f in spec["validator"]["allowed_font_families"])
+	ctx = {"allowed_hexes": allowed_hexes, "allowed_families": allowed_families, "design": design}
 
-	# @font-face is already flagged (safety); drop its block so its internal
-	# `font-family:<face-name>` and any data: src don't double-report as design
-	# violations.
-	css_design = _FONT_FACE_BLOCK_RE.sub(" ", css)
-	_check_prefers_color_scheme(css_design, violations)
-	_check_color_scheme(css_design, violations)
-	_check_css_colors(css_design, allowed_hexes, violations)
-	_check_font_family(css_design, allowed_families, violations)
-	_check_important(css_design, violations)
-	_check_inline_styles(_inline_styles(html), allowed_hexes, violations)
-	return violations
+	for css in _style_blocks(tree):
+		_check_style_block(css, ctx, violations)
+	for css in _inline_styles(tree):
+		_check_inline_style(css, ctx, violations)
+
+	return _dedupe(violations)
+
+
+def _dedupe(violations: list) -> list:
+	"""Drop identical (rule, offending) repeats so a value flagged by two passes
+	surfaces once. Order preserved."""
+	seen: set = set()
+	out: list = []
+	for v in violations:
+		key = (v.rule, v.offending)
+		if key in seen:
+			continue
+		seen.add(key)
+		out.append(v)
+	return out
 
 
 def format_violations(violations: list) -> str:
-	"""Render violations as the human message body for the save-time throw."""
-	lines = [f"- [{v.rule}] {v.message}" for v in violations]
-	return "\n".join(lines)
+	"""Render violations as the human message body for the save-time throw — the
+	human ``.message`` only (the machine-readable ``rule`` code stays in the
+	structured ``Violation`` for the feed-to-model path, never in the modal)."""
+	return "\n".join(f"- {v.message}" for v in violations)

--- a/jarvis/dashboards/theme_validator.py
+++ b/jarvis/dashboards/theme_validator.py
@@ -1,0 +1,420 @@
+"""Deterministic save-time validator for dashboard canvas HTML.
+
+Pure + frappe-free (import-safe without a bench) so it can be unit-tested
+standalone; the ``Jarvis Dashboard`` controller calls
+``validate_dashboard_html`` on every save and throws a structured error when it
+returns violations. NO auto-repair — a rejected save surfaces the reasons and
+the builder's chat loop regenerates.
+
+What it enforces (a standard theme):
+  * off-palette color literals in CSS  (hex / rgb / hsl / named, outside the
+    theme's own hexes + an approved white/black/transparent neutral set)
+  * ``font-family`` (or ``font`` shorthand) naming a non-system face
+  * ``@media (prefers-color-scheme)`` and the ``color-scheme`` property
+    (light/dark is driven by the theme's ``data-theme`` ONLY)
+  * ``!important`` on a color/font declaration
+  * off-palette color in an inline ``style=`` attribute
+Always enforced (a safety subset, even for the bespoke ``Custom`` theme):
+  * ``@font-face``
+  * external URLs (http/https/protocol-relative resource refs)
+
+Scope + honest limits: color/font rules scan CSS only — ``<style>`` blocks and
+inline ``style=`` attributes — NOT ``<script>`` bodies, so colors set in ECharts
+JS config are governed by the skill's "use window.JARVIS_THEME.palette"
+instruction, not this linter. Detection is regex over comment-stripped CSS
+(``/* */`` in CSS, ``<!-- -->`` in HTML are removed first); it targets the
+enumerable patterns above and is a standard/cleanliness gate layered under the
+hard CSP+sandbox boundary (which is what actually blocks network egress), not an
+exhaustive parser.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+from jarvis.dashboards import theme_spec
+
+# Current validator/schema version stamped onto docs that pass. Unstamped docs
+# (0/None) are legacy and grandfathered (never re-validated on read).
+THEME_SCHEMA_VERSION = 1
+
+
+class Violation(NamedTuple):
+	"""One machine-readable rejection. ``rule`` is a stable code; ``location``
+	is where it was found; ``offending`` is the exact token; ``message`` is the
+	human line surfaced in the save error."""
+
+	rule: str
+	location: str
+	offending: str
+	message: str
+
+	def as_dict(self) -> dict:
+		return {
+			"rule": self.rule,
+			"location": self.location,
+			"offending": self.offending,
+			"message": self.message,
+		}
+
+
+# Rule codes ------------------------------------------------------------------
+RULE_OFF_PALETTE = "off-palette-color"
+RULE_FONT_FAMILY = "font-family-override"
+RULE_PREFERS_SCHEME = "prefers-color-scheme"
+RULE_COLOR_SCHEME = "color-scheme"
+RULE_IMPORTANT = "important-color-font"
+RULE_INLINE_COLOR = "inline-style-color"
+RULE_FONT_FACE = "font-face"  # safety
+RULE_EXTERNAL_URL = "external-url"  # safety
+
+# Color-bearing CSS properties (shorthands included). Used for the named-color,
+# inline-color and !important checks.
+_COLOR_PROPS = frozenset({
+	"color", "background", "background-color", "background-image",
+	"border", "border-color", "border-top", "border-right", "border-bottom",
+	"border-left", "border-top-color", "border-right-color",
+	"border-bottom-color", "border-left-color", "outline", "outline-color",
+	"box-shadow", "text-shadow", "fill", "stroke", "caret-color",
+	"column-rule-color", "text-decoration-color", "accent-color",
+})
+_FONT_PROPS = frozenset({"font-family", "font"})
+
+# Approved neutral hex values (always allowed regardless of theme).
+_APPROVED_HEXES = frozenset({"#ffffff", "#000000"})
+# Approved color keywords (values, not families).
+_APPROVED_COLOR_WORDS = frozenset({
+	"transparent", "currentcolor", "inherit", "initial", "unset", "revert",
+	"white", "black", "none",
+})
+# Generic font-family keywords (always allowed as families).
+_GENERIC_FAMILIES = frozenset({
+	"serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui",
+	"ui-sans-serif", "ui-serif", "ui-monospace", "ui-rounded", "math", "emoji",
+	"fangsong", "inherit", "initial", "unset", "revert",
+})
+
+# Full CSS named-color set (minus the approved neutrals above), used to flag a
+# brand-y named color sitting in a color-bearing declaration value.
+_CSS_NAMED_COLORS = frozenset({
+	"aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
+	"bisque", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood",
+	"cadetblue", "chartreuse", "chocolate", "coral", "cornflowerblue",
+	"cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod",
+	"darkgray", "darkgrey", "darkgreen", "darkkhaki", "darkmagenta",
+	"darkolivegreen", "darkorange", "darkorchid", "darkred", "darksalmon",
+	"darkseagreen", "darkslateblue", "darkslategray", "darkslategrey",
+	"darkturquoise", "darkviolet", "deeppink", "deepskyblue", "dimgray",
+	"dimgrey", "dodgerblue", "firebrick", "floralwhite", "forestgreen",
+	"fuchsia", "gainsboro", "ghostwhite", "gold", "goldenrod", "gray", "grey",
+	"green", "greenyellow", "honeydew", "hotpink", "indianred", "indigo",
+	"ivory", "khaki", "lavender", "lavenderblush", "lawngreen", "lemonchiffon",
+	"lightblue", "lightcoral", "lightcyan", "lightgoldenrodyellow", "lightgray",
+	"lightgrey", "lightgreen", "lightpink", "lightsalmon", "lightseagreen",
+	"lightskyblue", "lightslategray", "lightslategrey", "lightsteelblue",
+	"lightyellow", "lime", "limegreen", "linen", "magenta", "maroon",
+	"mediumaquamarine", "mediumblue", "mediumorchid", "mediumpurple",
+	"mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise",
+	"mediumvioletred", "midnightblue", "mintcream", "mistyrose", "moccasin",
+	"navajowhite", "navy", "oldlace", "olive", "olivedrab", "orange",
+	"orangered", "orchid", "palegoldenrod", "palegreen", "paleturquoise",
+	"palevioletred", "papayawhip", "peachpuff", "peru", "pink", "plum",
+	"powderblue", "purple", "rebeccapurple", "red", "rosybrown", "royalblue",
+	"saddlebrown", "salmon", "sandybrown", "seagreen", "seashell", "sienna",
+	"silver", "skyblue", "slateblue", "slategray", "slategrey", "snow",
+	"springgreen", "steelblue", "tan", "teal", "thistle", "tomato", "turquoise",
+	"violet", "wheat", "whitesmoke", "yellow", "yellowgreen",
+})
+
+# ── regexes ──────────────────────────────────────────────────────────────────
+_STYLE_BLOCK_RE = re.compile(r"<style\b[^>]*>([\s\S]*?)</style>", re.I)
+_INLINE_STYLE_RE = re.compile(r"""\bstyle\s*=\s*("([^"]*)"|'([^']*)')""", re.I)
+_CSS_COMMENT_RE = re.compile(r"/\*[\s\S]*?\*/")
+_HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
+# One CSS declaration: `prop: value` up to ; } or {. Skips selectors (their
+# "prop" is a tag/class name, never a color/font property we inspect).
+_DECL_RE = re.compile(r"([-a-zA-Z]+)\s*:\s*([^;{}]*)")
+_HEX_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+_RGB_RE = re.compile(r"\brgba?\(\s*([^)]*)\)", re.I)
+_HSL_RE = re.compile(r"\bhsla?\(\s*([^)]*)\)", re.I)
+_FONT_FACE_RE = re.compile(r"@font-face\b", re.I)
+_PREFERS_SCHEME_RE = re.compile(r"@media[^{]*prefers-color-scheme", re.I)
+# `color-scheme:` as its own property — the negative lookbehind keeps it from
+# matching the `color-scheme` tail of `prefers-color-scheme` (its own rule).
+_COLOR_SCHEME_RE = re.compile(r"(?<![-\w])color-scheme\s*:", re.I)
+_FONT_FACE_BLOCK_RE = re.compile(r"@font-face\s*\{[^{}]*\}", re.I)
+# http/https (except W3C XML namespaces, which are identifiers, not fetches).
+_HTTP_URL_RE = re.compile(r"""https?://(?!(?:www\.)?w3\.org/)[^\s"'()<>]+""", re.I)
+# protocol-relative resource references: src/href="//…" or url(//…).
+_PROTO_REL_RE = re.compile(r"""(?:\bsrc|\bhref|\burl\()\s*=?\s*["']?//[^\s"'()<>]+""", re.I)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+def _strip_css_comments(css: str) -> str:
+	return _CSS_COMMENT_RE.sub(" ", css or "")
+
+
+def _style_css(html: str) -> str:
+	"""All author <style> CSS, comment-stripped and joined."""
+	return "\n".join(_strip_css_comments(m.group(1)) for m in _STYLE_BLOCK_RE.finditer(html))
+
+
+def _inline_styles(html: str) -> list[str]:
+	out = []
+	for m in _INLINE_STYLE_RE.finditer(html):
+		out.append(_strip_css_comments(m.group(2) if m.group(2) is not None else (m.group(3) or "")))
+	return out
+
+
+def _norm_hex(h: str) -> str:
+	"""Normalize a #rgb / #rgba / #rrggbb / #rrggbbaa literal to #rrggbb
+	(alpha dropped). Returns '' if not a clean 3/4/6/8-digit hex."""
+	s = h[1:]
+	if len(s) in (3, 4):
+		s = "".join(c * 2 for c in s[:3])
+	elif len(s) in (6, 8):
+		s = s[:6]
+	else:
+		return ""
+	return "#" + s.lower()
+
+
+def _rgb_to_hex(inner: str) -> str:
+	"""rgb()/rgba() numeric args -> #rrggbb (alpha ignored). '' if unparseable
+	(percentages, calc, var, etc.) — an unparseable functional color is treated
+	as off-palette by the caller."""
+	parts = [p.strip() for p in re.split(r"[,\s/]+", inner.strip()) if p.strip()]
+	if len(parts) < 3:
+		return ""
+	try:
+		rgb = [max(0, min(255, int(round(float(x))))) for x in parts[:3]]
+	except ValueError:
+		return ""
+	return "#" + "".join(f"{c:02x}" for c in rgb)
+
+
+def _hsl_is_neutral(inner: str) -> bool | None:
+	"""True if an hsl()/hsla() is achromatic black/white (s=0 & l∈{0,100}) —
+	an approved neutral. False if chromatic / non-neutral. None if unparseable."""
+	parts = [p.strip().rstrip("%") for p in re.split(r"[,\s/]+", inner.strip()) if p.strip()]
+	if len(parts) < 3:
+		return None
+	try:
+		s = float(parts[1])
+		l = float(parts[2])
+	except ValueError:
+		return None
+	return s == 0 and (l == 0 or l == 100)
+
+
+def _color_allowed(literal: str, allowed_hexes: frozenset) -> bool:
+	"""Is a single hex/rgb/hsl literal within the theme allow-list (+ neutrals)?"""
+	lit = literal.strip().lower()
+	if lit.startswith("#"):
+		h = _norm_hex(lit)
+		return bool(h) and (h in allowed_hexes or h in _APPROVED_HEXES)
+	m = _RGB_RE.fullmatch(lit)
+	if m:
+		h = _rgb_to_hex(m.group(1))
+		return bool(h) and (h in allowed_hexes or h in _APPROVED_HEXES)
+	m = _HSL_RE.fullmatch(lit)
+	if m:
+		return _hsl_is_neutral(m.group(1)) is True
+	return False
+
+
+def _iter_decls(css: str):
+	"""Yield (prop_lower, value) declarations from a CSS string."""
+	for m in _DECL_RE.finditer(css):
+		yield m.group(1).lower(), m.group(2).strip()
+
+
+def _family_tokens(value: str, shorthand: bool) -> list[str]:
+	"""Candidate font-family names from a font-family value (or a `font`
+	shorthand). For the shorthand, the leading size/line-height/weight tokens of
+	the first comma-segment are dropped (family is the trailing word group)."""
+	segs = [s.strip() for s in value.split(",") if s.strip()]
+	if not segs:
+		return []
+	fams = list(segs)
+	if shorthand:
+		# `font: 700 14px/1.5 "Segoe UI", sans-serif` -> first seg's family is
+		# after the last space run; keep the rest of the segments verbatim.
+		first = segs[0]
+		fams[0] = first.rsplit(" ", 1)[-1] if " " in first and '"' not in first and "'" not in first else first
+	return [f.strip().strip("\"'").lower() for f in fams if f.strip()]
+
+
+# ── individual checks ────────────────────────────────────────────────────────
+def _check_font_face(css: str, out: list) -> None:
+	if _FONT_FACE_RE.search(css):
+		out.append(Violation(
+			RULE_FONT_FACE, "<style>", "@font-face",
+			"@font-face is not allowed — the canvas has no network and must use the system font stack.",
+		))
+
+
+def _check_external_urls(html: str, out: list) -> None:
+	scan = _HTML_COMMENT_RE.sub(" ", html)
+	seen: set = set()
+	for m in _HTTP_URL_RE.finditer(scan):
+		url = m.group(0)[:120]
+		if url in seen:
+			continue
+		seen.add(url)
+		out.append(Violation(
+			RULE_EXTERNAL_URL, "html", url,
+			f"External URL '{url}' is not allowed — inline all resources (data: URIs only).",
+		))
+	for m in _PROTO_REL_RE.finditer(scan):
+		frag = m.group(0)[:120]
+		if frag in seen:
+			continue
+		seen.add(frag)
+		out.append(Violation(
+			RULE_EXTERNAL_URL, "html", frag,
+			f"Protocol-relative resource '{frag}' is not allowed — inline all resources.",
+		))
+
+
+def _check_prefers_color_scheme(css: str, out: list) -> None:
+	if _PREFERS_SCHEME_RE.search(css):
+		out.append(Violation(
+			RULE_PREFERS_SCHEME, "<style>", "@media (prefers-color-scheme)",
+			"@media (prefers-color-scheme) is not allowed — light/dark follows the theme's data-theme only.",
+		))
+
+
+def _check_color_scheme(css: str, out: list) -> None:
+	if _COLOR_SCHEME_RE.search(css):
+		out.append(Violation(
+			RULE_COLOR_SCHEME, "<style>", "color-scheme",
+			"The color-scheme property is not allowed — light/dark follows the theme's data-theme only.",
+		))
+
+
+def _check_css_colors(css: str, allowed_hexes: frozenset, out: list) -> None:
+	# Pass A: hex + rgb/hsl literals anywhere in the CSS.
+	for m in _HEX_RE.finditer(css):
+		lit = m.group(0)
+		if not _color_allowed(lit, allowed_hexes):
+			out.append(_off_palette(lit))
+	for m in _RGB_RE.finditer(css):
+		lit = m.group(0)
+		if not _color_allowed(lit, allowed_hexes):
+			out.append(_off_palette(lit))
+	for m in _HSL_RE.finditer(css):
+		lit = m.group(0)
+		if not _color_allowed(lit, allowed_hexes):
+			out.append(_off_palette(lit))
+	# Pass B: named colors, only inside a color-bearing declaration value.
+	for prop, value in _iter_decls(css):
+		if prop not in _COLOR_PROPS:
+			continue
+		for word in re.findall(r"[a-zA-Z]+", value):
+			w = word.lower()
+			if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
+				out.append(_off_palette(word))
+
+
+def _off_palette(token: str) -> Violation:
+	return Violation(
+		RULE_OFF_PALETTE, "<style>", token,
+		f"Off-theme color '{token}' — use a var(--jd-*) token or a color from the selected theme.",
+	)
+
+
+def _check_font_family(css: str, allowed_families: frozenset, out: list) -> None:
+	for prop, value in _iter_decls(css):
+		if prop not in _FONT_PROPS:
+			continue
+		for fam in _family_tokens(value, shorthand=(prop == "font")):
+			if not fam or fam.startswith("var(") or fam in _GENERIC_FAMILIES or fam in allowed_families:
+				continue
+			# A `font:` shorthand carries size/weight tokens we can't fully model;
+			# only flag a token that looks like a real family name (letters).
+			if prop == "font" and not re.search(r"[a-zA-Z]", fam):
+				continue
+			out.append(Violation(
+				RULE_FONT_FAMILY, "<style>", fam,
+				f"Font family '{fam}' is not allowed — use var(--jd-font)/var(--jd-font-display) "
+				"or the system font stack.",
+			))
+
+
+def _check_important(css: str, out: list) -> None:
+	for prop, value in _iter_decls(css):
+		if "!important" not in value.lower():
+			continue
+		if prop in _COLOR_PROPS or prop in _FONT_PROPS:
+			out.append(Violation(
+				RULE_IMPORTANT, "<style>", f"{prop}: … !important",
+				f"!important on '{prop}' is not allowed — it escapes the theme layer.",
+			))
+
+
+def _check_inline_styles(inline_styles: list, allowed_hexes: frozenset, out: list) -> None:
+	for css in inline_styles:
+		for prop, value in _iter_decls(css):
+			if prop not in _COLOR_PROPS:
+				continue
+			bad = None
+			for lit_m in list(_HEX_RE.finditer(value)) + list(_RGB_RE.finditer(value)) + list(_HSL_RE.finditer(value)):
+				if not _color_allowed(lit_m.group(0), allowed_hexes):
+					bad = lit_m.group(0)
+					break
+			if bad is None:
+				for word in re.findall(r"[a-zA-Z]+", value):
+					w = word.lower()
+					if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
+						bad = word
+						break
+			if bad is not None:
+				out.append(Violation(
+					RULE_INLINE_COLOR, "inline style=", bad,
+					f"Off-theme color '{bad}' in an inline style= — it escapes the theme layer; "
+					"use a var(--jd-*) token in a <style> rule.",
+				))
+
+
+# ── public entry point ───────────────────────────────────────────────────────
+def validate_dashboard_html(html: str, theme: str) -> list[Violation]:
+	"""Return the (possibly empty) list of ``Violation`` for a dashboard's HTML
+	under ``theme`` (a DocType label or lowercase key). Pure + deterministic.
+
+	For the bespoke ``Custom`` theme only the safety bans (@font-face, external
+	URLs) apply — the design rules are relaxed. An unknown theme is validated as
+	the default ('jarvis')."""
+	html = html or ""
+	key = theme_spec.theme_key(theme)
+	css = _style_css(html)
+	violations: list = []
+
+	# Safety bans — always, including Custom.
+	_check_font_face(css, violations)
+	_check_external_urls(html, violations)
+	if key == theme_spec.CUSTOM_KEY:
+		return violations
+
+	spec = theme_spec.load_theme(key) or theme_spec.load_theme(theme_spec.DEFAULT_KEY)
+	allowed_hexes = frozenset(h.lower() for h in spec["validator"]["allowed_color_hexes"])
+	allowed_families = frozenset(f.lower() for f in spec["validator"]["allowed_font_families"])
+
+	# @font-face is already flagged (safety); drop its block so its internal
+	# `font-family:<face-name>` and any data: src don't double-report as design
+	# violations.
+	css_design = _FONT_FACE_BLOCK_RE.sub(" ", css)
+	_check_prefers_color_scheme(css_design, violations)
+	_check_color_scheme(css_design, violations)
+	_check_css_colors(css_design, allowed_hexes, violations)
+	_check_font_family(css_design, allowed_families, violations)
+	_check_important(css_design, violations)
+	_check_inline_styles(_inline_styles(html), allowed_hexes, violations)
+	return violations
+
+
+def format_violations(violations: list) -> str:
+	"""Render violations as the human message body for the save-time throw."""
+	lines = [f"- [{v.rule}] {v.message}" for v in violations]
+	return "\n".join(lines)

--- a/jarvis/dashboards/theme_validator.py
+++ b/jarvis/dashboards/theme_validator.py
@@ -161,6 +161,21 @@ _COLOR_PROPS = frozenset(
 		"stop-color",
 		"flood-color",
 		"lighting-color",
+		# color-bearing via drop-shadow() (DR3-3)
+		"filter",
+		"backdrop-filter",
+		"-webkit-filter",
+		"-webkit-backdrop-filter",
+		# color-bearing via a gradient image source (DR3-3)
+		"border-image",
+		"border-image-source",
+		# logical-property border shorthands (analogues of border / border-top…)
+		"border-block",
+		"border-inline",
+		"border-block-start",
+		"border-block-end",
+		"border-inline-start",
+		"border-inline-end",
 	}
 )
 _FONT_PROPS = frozenset({"font-family", "font"})
@@ -455,8 +470,12 @@ _RULE_BODY_AT = frozenset(
 # Only used to parse an isolated rgb()/hsl() literal's numeric args.
 _RGB_RE = re.compile(r"\brgba?\(\s*([^)]*)\)", re.I)
 _HSL_RE = re.compile(r"\bhsla?\(\s*([^)]*)\)", re.I)
-# An external/protocol-relative URL anywhere in a (decoded) attribute value.
-_URLISH_RE = re.compile(r"""(?:https?:)?//[^\s"'()<>]+""", re.I)
+# An external URL anywhere in a (decoded) attribute value: a special-scheme
+# (http/https) prefix followed by ANY number of slash/backslash separators —
+# including zero or one (`http:evil`, `http:/evil`), which the WHATWG URL parser
+# still resolves to an external authority for special schemes (DR3-2) — or a
+# bare protocol-relative `//`.
+_URLISH_RE = re.compile(r"""(?:https?:[\\/]*|//)[^\s"'()<>]+""", re.I)
 # Browser URL preprocessing (WHATWG): ASCII TAB / LF / CR are stripped from the
 # whole URL before parsing, so `https:/<TAB>/evil` resolves to `https://evil`.
 _URL_CONTROL_STRIP = {0x09: None, 0x0A: None, 0x0D: None}
@@ -539,11 +558,14 @@ def _is_external_url(url: str) -> bool:
 	"""A decoded URL string that the browser would FETCH off-origin. data:/blob:/
 	relative/fragment are fine; the exact SVG/xlink namespaces are exempt. The
 	value is canonicalized (control chars stripped, special-scheme backslashes
-	folded) so the exemption + test run on what the browser would actually load."""
+	folded) so the exemption + test run on what the browser would actually load.
+	Rejection is SCHEME-FIRST: any ``http:`` / ``https:`` scheme is external
+	regardless of how many (0, 1, or many) slash/backslash separators follow, since
+	a special scheme resolves to an authority either way (DR3-2)."""
 	s = _canonicalize_url_text(url).strip().lower()
 	if not s or s in _ALLOWED_XML_NS:
 		return False
-	return s.startswith("http://") or s.startswith("https://") or s.startswith("//")
+	return s.startswith("http:") or s.startswith("https:") or s.startswith("//")
 
 
 def _external_urls_in_text(text: str) -> list[str]:
@@ -741,10 +763,22 @@ def _external_violation(url: str) -> Violation:
 
 
 # ── declaration + at-rule checks ──────────────────────────────────────────────
-def _scan_color_tokens(tokens, allowed_hexes, allowed_tokens, out, *, color_rule, location):
+def _scan_color_tokens(
+	tokens, allowed_hexes, allowed_tokens, out, *, color_rule, location, literal_only=False
+):
 	"""Flag any color VALUE that is not an allowed theme hex / existing --jd-*
 	token / approved neutral. Recurses into non-color functions (gradients,
-	image-set) and into a var() fallback expression."""
+	image-set) and into a var() fallback expression.
+
+	``literal_only`` is the durability pass over declarations OUTSIDE the known
+	color-bearing properties (DR3-3): it flags only UNAMBIGUOUS color LITERALS —
+	a ``#hash``, an ``rgb()/hsl()``, or a modern color function — which are colors
+	wherever they appear. It deliberately skips ``var()`` (a bare ``--jd`` rule
+	only makes sense where a color is expected, so ``padding:var(--gap)`` must
+	pass) and bare color-word IDENTS (``background``/``highlight``/… double as
+	custom-idents in ``transition-property``/``animation-name``/…). Those
+	ambiguous forms are enforced only in the enumerated ``_COLOR_PROPS`` full
+	scan."""
 	for tok in tokens:
 		tn = type(tok).__name__
 		if tn == "HashToken":
@@ -760,11 +794,15 @@ def _scan_color_tokens(tokens, allowed_hexes, allowed_tokens, out, *, color_rule
 				if not _color_allowed(lit, allowed_hexes):
 					out.append(_color_violation(lit, color_rule, location))
 			elif fname == "var":
+				if literal_only:
+					continue  # var() is a <color> ref only in a color property (DR3-3)
 				# The referenced token must EXIST in the selected theme (a mere
 				# `--jd-` prefix on a non-existent name would render its fallback);
-				# and a fallback, if present, is validated recursively (DR2-1).
+				# the name is matched CASE-SENSITIVELY because CSS custom-property
+				# names are case-sensitive — `var(--JD-INK)` is unset in the browser
+				# (DR3-4). A fallback, if present, is validated recursively (DR2-1).
 				ref = _first_custom_prop(tok.arguments)
-				if not (ref and ref.lower() in allowed_tokens):
+				if not (ref and ref in allowed_tokens):
 					out.append(_color_violation(tinycss2.serialize([tok]).strip(), color_rule, location))
 				else:
 					fb = _var_fallback_tokens(tok.arguments)
@@ -780,8 +818,11 @@ def _scan_color_tokens(tokens, allowed_hexes, allowed_tokens, out, *, color_rule
 					out,
 					color_rule=color_rule,
 					location=location,
+					literal_only=literal_only,
 				)
 		elif tn == "IdentToken":
+			if literal_only:
+				continue  # bare color-word idents are ambiguous outside a color property
 			# Reject any <color> keyword that is not approved: a conventional named
 			# color OR a CSS system color (DR2-3). Non-color idents (`solid`,
 			# `center`, …) in a color-bearing shorthand are not <color> keywords and
@@ -840,10 +881,11 @@ def _family_candidates(tokens, shorthand):
 def _check_font(tokens, shorthand, allowed_families, allowed_tokens, out, *, location):
 	for kind, display, ref, var_fn in _family_candidates(tokens, shorthand):
 		if kind == "var":
-			# Must reference an EXISTING font token (--jd-font / --jd-font-display);
-			# a fallback, if present, is validated as a font family too (DR2-1).
-			low = (ref or "").lower()
-			if low in _FONT_TOKEN_NAMES and low in allowed_tokens:
+			# Must reference an EXISTING font token (--jd-font / --jd-font-display),
+			# matched CASE-SENSITIVELY — CSS custom-property names are case-sensitive,
+			# so `var(--JD-FONT)` is unset in the browser and must be rejected
+			# (DR3-4). A fallback, if present, is validated as a font family (DR2-1).
+			if ref in _FONT_TOKEN_NAMES and ref in allowed_tokens:
 				fb = _var_fallback_tokens(var_fn.arguments) if var_fn is not None else []
 				if fb:
 					_check_font(fb, False, allowed_families, allowed_tokens, out, location=location)
@@ -923,6 +965,22 @@ def _check_declaration(d, ctx, out, *, color_rule, location):
 			out,
 			color_rule=color_rule,
 			location=location,
+		)
+	elif lname not in _FONT_PROPS and not lname.startswith("--"):
+		# Durability (DR3-3): every OTHER declaration's value is swept for
+		# unambiguous off-palette color LITERALS (#hash / rgb()/hsl() / modern
+		# color functions), so a color-bearing property the enumerated
+		# _COLOR_PROPS list forgot (or a future one) can't reopen the hole. Font
+		# props go to _check_font; custom-property definitions are governed by the
+		# token-redefine + var()-usage rules, not this pass.
+		_scan_color_tokens(
+			d.value,
+			ctx["allowed_hexes"],
+			ctx["allowed_tokens"],
+			out,
+			color_rule=color_rule,
+			location=location,
+			literal_only=True,
 		)
 	if lname in _FONT_PROPS:
 		_check_font(
@@ -1027,7 +1085,9 @@ def validate_dashboard_html(html: str, theme: str) -> list[Violation]:
 		allowed_families = frozenset(f.lower() for f in spec["validator"]["allowed_font_families"])
 		# The EXACT --jd-* render-token names this theme emits (DR2-1): a var()
 		# color/font ref must name one that exists, not merely start with --jd-.
-		allowed_tokens = frozenset("--jd-" + str(name).lower() for name in (spec.get("render_tokens") or {}))
+		# Names are kept verbatim (no case-folding) so the membership test is
+		# case-sensitive against what the theme actually emits (DR3-4).
+		allowed_tokens = frozenset("--jd-" + str(name) for name in (spec.get("render_tokens") or {}))
 	ctx = {
 		"allowed_hexes": allowed_hexes,
 		"allowed_families": allowed_families,

--- a/jarvis/dashboards/theme_validator.py
+++ b/jarvis/dashboards/theme_validator.py
@@ -28,11 +28,15 @@ What it enforces (a standard theme) — the COLOR + FONT + light/dark contract:
     (b) a ``var(--jd-*)`` token, or (c) an approved white/black/transparent
     neutral is off-palette — whether written as hex, ``rgb()``/``hsl()``, a modern
     color function (``oklch/oklab/lab/lch/hwb/color()/color-mix()/device-cmyk()``),
-    or a named CSS color. A ``var()`` in a color value is allowed ONLY when it
-    references a ``--jd-*`` theme token; any other custom-property reference is
-    off-palette (it could resolve to any color).
+    a named CSS color, or a CSS SYSTEM color (``CanvasText``/``Highlight``/…). A
+    ``var()`` in a color value is allowed ONLY when it references a ``--jd-*`` token
+    that EXISTS in the selected theme AND (if it carries a fallback after the first
+    comma) that fallback itself validates — so ``var(--jd-nope,#f00)`` and
+    ``var(--jd-ink, red)`` are both off-palette (the browser would render the bad
+    fallback), while ``var(--jd-ink)`` passes.
   * ``font-family`` (or ``font`` shorthand) naming a non-system face, INCLUDING
-    ``font-family:var(--x)`` where ``--x`` is not a theme font token.
+    ``font-family:var(--x)`` where ``--x`` is not an existing theme font token, or
+    a ``var(--jd-font, …)`` whose fallback names a non-system face.
   * author redefinition of a ``--jd-*`` theme token (only the theme layer owns
     them).
   * ``@media (prefers-color-scheme)`` and the ``color-scheme`` property
@@ -46,8 +50,11 @@ What it enforces (a standard theme) — the COLOR + FONT + light/dark contract:
 Always enforced (a safety subset, even for the bespoke ``Custom`` theme):
   * ``@font-face`` (incl. escaped ``@f\\6f nt-face``).
   * external URLs (http/https + protocol-relative ``//``) in any attribute value
-    (entity-decoded), CSS ``url()`` token, or ``@import``. Only the exact XML
-    namespace URIs (``http://www.w3.org/2000/svg`` / ``…/1999/xlink``) are exempt.
+    (entity-decoded), CSS ``url()`` token, or ``@import`` — after browser URL
+    canonicalization (ASCII TAB/LF/CR stripped, special-scheme backslashes folded)
+    so a control-char-split ``https:/<TAB>/evil`` still resolves + is caught. Only
+    the exact XML namespace URIs (``http://www.w3.org/2000/svg`` / ``…/1999/xlink``)
+    are exempt.
 
 Honest scope + limits: this validator enforces COLOR, font-family, no-``!important``,
 no-``prefers-color-scheme``, well-formed CSS, and the safety bans. It does NOT
@@ -371,6 +378,63 @@ _CSS_NAMED_COLORS = frozenset(
 	}
 )
 
+# CSS SYSTEM colors (current CSS Color 4 + the deprecated CSS2 set). These are
+# NOT in the conventional named-color list yet ARE valid <color> keywords that
+# render an OS/theme-derived color, so they must be rejected in a color context
+# exactly like a named color (DR2-3).
+_CSS_SYSTEM_COLORS = frozenset(
+	{
+		# current (CSS Color Module Level 4)
+		"accentcolor",
+		"accentcolortext",
+		"activetext",
+		"buttonborder",
+		"buttonface",
+		"buttontext",
+		"canvas",
+		"canvastext",
+		"field",
+		"fieldtext",
+		"graytext",
+		"highlight",
+		"highlighttext",
+		"linktext",
+		"mark",
+		"marktext",
+		"selecteditem",
+		"selecteditemtext",
+		"visitedtext",
+		# deprecated (CSS2 system colors)
+		"activeborder",
+		"activecaption",
+		"appworkspace",
+		"background",
+		"buttonhighlight",
+		"buttonshadow",
+		"captiontext",
+		"inactiveborder",
+		"inactivecaption",
+		"inactivecaptiontext",
+		"infobackground",
+		"infotext",
+		"menu",
+		"menutext",
+		"scrollbar",
+		"threeddarkshadow",
+		"threedface",
+		"threedhighlight",
+		"threedlightshadow",
+		"threedshadow",
+		"window",
+		"windowframe",
+		"windowtext",
+	}
+)
+
+# The two render tokens that carry a FONT stack (the only --jd-* a font-family
+# var() may reference); token existence in the theme is checked separately.
+_FONT_TOKEN_NAMES = frozenset({"--jd-font", "--jd-font-display"})
+
 # At-rules whose body is a list of RULES (recurse into them for nested checks).
 _RULE_BODY_AT = frozenset(
 	{
@@ -393,6 +457,13 @@ _RGB_RE = re.compile(r"\brgba?\(\s*([^)]*)\)", re.I)
 _HSL_RE = re.compile(r"\bhsla?\(\s*([^)]*)\)", re.I)
 # An external/protocol-relative URL anywhere in a (decoded) attribute value.
 _URLISH_RE = re.compile(r"""(?:https?:)?//[^\s"'()<>]+""", re.I)
+# Browser URL preprocessing (WHATWG): ASCII TAB / LF / CR are stripped from the
+# whole URL before parsing, so `https:/<TAB>/evil` resolves to `https://evil`.
+_URL_CONTROL_STRIP = {0x09: None, 0x0A: None, 0x0D: None}
+# http(s) is a "special scheme": the URL parser treats `\` as `/`. Normalize
+# only the separator run right after the scheme so `https:\\evil` / `https:/\evil`
+# surface, while an arbitrary `\\` elsewhere is never mistaken for a URL (DR2-4).
+_SCHEME_SLASH_RE = re.compile(r"(https?:)([\\/]+)", re.I)
 
 
 # ── color literal helpers (reused by both CSS and inline passes) ──────────────
@@ -455,10 +526,21 @@ def _color_allowed(literal: str, allowed_hexes: frozenset) -> bool:
 	return False
 
 
+def _canonicalize_url_text(text: str) -> str:
+	"""Apply the browser's URL preprocessing to a decoded string so obfuscated
+	external URLs surface before the external-URL test (DR2-4): strip ASCII
+	TAB/LF/CR (the WHATWG parser removes them anywhere in a URL) and fold a
+	special-scheme backslash run right after ``http(s):`` to ``/``."""
+	s = (text or "").translate(_URL_CONTROL_STRIP)
+	return _SCHEME_SLASH_RE.sub(lambda m: m.group(1) + m.group(2).replace("\\", "/"), s)
+
+
 def _is_external_url(url: str) -> bool:
 	"""A decoded URL string that the browser would FETCH off-origin. data:/blob:/
-	relative/fragment are fine; the exact SVG/xlink namespaces are exempt."""
-	s = (url or "").strip().lower()
+	relative/fragment are fine; the exact SVG/xlink namespaces are exempt. The
+	value is canonicalized (control chars stripped, special-scheme backslashes
+	folded) so the exemption + test run on what the browser would actually load."""
+	s = _canonicalize_url_text(url).strip().lower()
 	if not s or s in _ALLOWED_XML_NS:
 		return False
 	return s.startswith("http://") or s.startswith("https://") or s.startswith("//")
@@ -466,9 +548,11 @@ def _is_external_url(url: str) -> bool:
 
 def _external_urls_in_text(text: str) -> list[str]:
 	"""External/protocol-relative URLs in a decoded attribute value (skips the
-	exact XML namespace URIs)."""
+	exact XML namespace URIs). The text is canonicalized first so a URL split by
+	an entity-decoded control char (``https:/&#x09;/evil`` → ``https://evil``) or
+	a special-scheme backslash still matches."""
 	out = []
-	for m in _URLISH_RE.finditer(text or ""):
+	for m in _URLISH_RE.finditer(_canonicalize_url_text(text)):
 		u = m.group(0)
 		if u.lower() in _ALLOWED_XML_NS:
 			continue
@@ -576,6 +660,17 @@ def _first_custom_prop(tokens) -> str | None:
 	return None
 
 
+def _var_fallback_tokens(arguments) -> list:
+	"""The token list after the FIRST top-level comma in a ``var()``'s arguments —
+	its fallback expression (``[]`` when there is no fallback). The browser renders
+	this when the referenced custom property is unset, so it must be validated too
+	(DR2-1)."""
+	for idx, t in enumerate(arguments or []):
+		if type(t).__name__ == "LiteralToken" and t.value == ",":
+			return list(arguments[idx + 1 :])
+	return []
+
+
 def _url_strings(tokens) -> list[str]:
 	"""Every URL a declaration value would fetch: url() tokens and url("…")
 	function-string args, recursively (e.g. inside a gradient / image-set)."""
@@ -646,9 +741,10 @@ def _external_violation(url: str) -> Violation:
 
 
 # ── declaration + at-rule checks ──────────────────────────────────────────────
-def _scan_color_tokens(tokens, allowed_hexes, out, *, color_rule, location):
-	"""Flag any color VALUE that is not an allowed theme hex / var(--jd-*) /
-	approved neutral. Recurses into non-color functions (gradients, image-set)."""
+def _scan_color_tokens(tokens, allowed_hexes, allowed_tokens, out, *, color_rule, location):
+	"""Flag any color VALUE that is not an allowed theme hex / existing --jd-*
+	token / approved neutral. Recurses into non-color functions (gradients,
+	image-set) and into a var() fallback expression."""
 	for tok in tokens:
 		tn = type(tok).__name__
 		if tn == "HashToken":
@@ -664,22 +760,41 @@ def _scan_color_tokens(tokens, allowed_hexes, out, *, color_rule, location):
 				if not _color_allowed(lit, allowed_hexes):
 					out.append(_color_violation(lit, color_rule, location))
 			elif fname == "var":
+				# The referenced token must EXIST in the selected theme (a mere
+				# `--jd-` prefix on a non-existent name would render its fallback);
+				# and a fallback, if present, is validated recursively (DR2-1).
 				ref = _first_custom_prop(tok.arguments)
-				if not (ref and ref.lower().startswith("--jd-")):
+				if not (ref and ref.lower() in allowed_tokens):
 					out.append(_color_violation(tinycss2.serialize([tok]).strip(), color_rule, location))
+				else:
+					fb = _var_fallback_tokens(tok.arguments)
+					if fb:
+						_scan_color_tokens(
+							fb, allowed_hexes, allowed_tokens, out, color_rule=color_rule, location=location
+						)
 			else:
 				_scan_color_tokens(
-					tok.arguments, allowed_hexes, out, color_rule=color_rule, location=location
+					tok.arguments,
+					allowed_hexes,
+					allowed_tokens,
+					out,
+					color_rule=color_rule,
+					location=location,
 				)
 		elif tn == "IdentToken":
+			# Reject any <color> keyword that is not approved: a conventional named
+			# color OR a CSS system color (DR2-3). Non-color idents (`solid`,
+			# `center`, …) in a color-bearing shorthand are not <color> keywords and
+			# pass through untouched.
 			w = (tok.value or "").lower()
-			if w in _CSS_NAMED_COLORS and w not in _APPROVED_COLOR_WORDS:
+			if w not in _APPROVED_COLOR_WORDS and (w in _CSS_NAMED_COLORS or w in _CSS_SYSTEM_COLORS):
 				out.append(_color_violation(tok.value, color_rule, location))
 
 
 def _family_candidates(tokens, shorthand):
-	"""(kind, display, var_ref) per comma-separated font-family segment. ``kind``
-	is 'var' (a var() indirection) or 'name' (a literal family)."""
+	"""(kind, display, var_ref, var_fn) per comma-separated font-family segment.
+	``kind`` is 'var' (a var() indirection — ``var_fn`` is the FunctionBlock, so
+	its fallback can be validated) or 'name' (a literal family; ``var_fn`` None)."""
 	segments = [[]]
 	for t in tokens:
 		if type(t).__name__ == "LiteralToken" and t.value == ",":
@@ -693,11 +808,13 @@ def _family_candidates(tokens, shorthand):
 			None,
 		)
 		if var_fn is not None:
-			out.append(("var", tinycss2.serialize([var_fn]).strip(), _first_custom_prop(var_fn.arguments)))
+			out.append(
+				("var", tinycss2.serialize([var_fn]).strip(), _first_custom_prop(var_fn.arguments), var_fn)
+			)
 			continue
 		strings = [t for t in seg if type(t).__name__ == "StringToken"]
 		if strings:
-			out.append(("name", strings[-1].value.strip().lower(), None))
+			out.append(("name", strings[-1].value.strip().lower(), None, None))
 			continue
 		idents = [t for t in seg if type(t).__name__ == "IdentToken"]
 		if not idents:
@@ -716,14 +833,20 @@ def _family_candidates(tokens, shorthand):
 			name = " ".join(tail)
 		else:
 			name = " ".join(t.value for t in idents)
-		out.append(("name", name.strip().lower(), None))
+		out.append(("name", name.strip().lower(), None, None))
 	return out
 
 
-def _check_font(tokens, shorthand, allowed_families, out, *, location):
-	for kind, display, ref in _family_candidates(tokens, shorthand):
+def _check_font(tokens, shorthand, allowed_families, allowed_tokens, out, *, location):
+	for kind, display, ref, var_fn in _family_candidates(tokens, shorthand):
 		if kind == "var":
-			if ref and ref.lower().startswith("--jd-font"):
+			# Must reference an EXISTING font token (--jd-font / --jd-font-display);
+			# a fallback, if present, is validated as a font family too (DR2-1).
+			low = (ref or "").lower()
+			if low in _FONT_TOKEN_NAMES and low in allowed_tokens:
+				fb = _var_fallback_tokens(var_fn.arguments) if var_fn is not None else []
+				if fb:
+					_check_font(fb, False, allowed_families, allowed_tokens, out, location=location)
 				continue
 			out.append(
 				Violation(
@@ -793,9 +916,18 @@ def _check_declaration(d, ctx, out, *, color_rule, location):
 			)
 		)
 	if lname in _COLOR_PROPS:
-		_scan_color_tokens(d.value, ctx["allowed_hexes"], out, color_rule=color_rule, location=location)
+		_scan_color_tokens(
+			d.value,
+			ctx["allowed_hexes"],
+			ctx["allowed_tokens"],
+			out,
+			color_rule=color_rule,
+			location=location,
+		)
 	if lname in _FONT_PROPS:
-		_check_font(d.value, lname == "font", ctx["allowed_families"], out, location=location)
+		_check_font(
+			d.value, lname == "font", ctx["allowed_families"], ctx["allowed_tokens"], out, location=location
+		)
 
 
 def _check_at_rule(rule, ctx, out):
@@ -888,11 +1020,20 @@ def validate_dashboard_html(html: str, theme: str) -> list[Violation]:
 
 	allowed_hexes: frozenset = frozenset()
 	allowed_families: frozenset = frozenset()
+	allowed_tokens: frozenset = frozenset()
 	if design:
 		spec = theme_spec.load_theme(key) or theme_spec.load_theme(theme_spec.DEFAULT_KEY)
 		allowed_hexes = frozenset(h.lower() for h in spec["validator"]["allowed_color_hexes"])
 		allowed_families = frozenset(f.lower() for f in spec["validator"]["allowed_font_families"])
-	ctx = {"allowed_hexes": allowed_hexes, "allowed_families": allowed_families, "design": design}
+		# The EXACT --jd-* render-token names this theme emits (DR2-1): a var()
+		# color/font ref must name one that exists, not merely start with --jd-.
+		allowed_tokens = frozenset("--jd-" + str(name).lower() for name in (spec.get("render_tokens") or {}))
+	ctx = {
+		"allowed_hexes": allowed_hexes,
+		"allowed_families": allowed_families,
+		"allowed_tokens": allowed_tokens,
+		"design": design,
+	}
 
 	for css in _style_blocks(tree):
 		_check_style_block(css, ctx, violations)

--- a/jarvis/dashboards/themes/claude/design.md
+++ b/jarvis/dashboards/themes/claude/design.md
@@ -15,8 +15,12 @@ recipe and the source for the generation cheatsheet injected into the
 ## 1. Color tokens
 
 Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
-hardcode a hex. The validator rejects any off-theme color literal (only these
-hexes, plus the approved neutrals white/black/transparent, are allowed).
+hardcode a hex. The validator rejects any off-theme color VALUE in any syntax —
+only these token hexes, the ordered chart palette below, and the approved
+neutrals white/black/transparent are allowed. The status tokens
+(`--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info`) are the text-safe
+status colors (AA on `--jd-surface`), deliberately darker than the vivid
+chart-palette values used for series fills.
 
 | Token | Value | Role |
 | --- | --- | --- |
@@ -25,13 +29,13 @@ hexes, plus the approved neutrals white/black/transparent, are allowed).
 | `--jd-surface-2` | `#f5f3ec` | Subtle fill (table header, insets) |
 | `--jd-ink` | `#3d3929` | Body text |
 | `--jd-heading` | `#3d3929` | Headings |
-| `--jd-muted` | `#83827d` | Secondary / labels |
+| `--jd-muted` | `#6f6e6a` | Secondary / labels |
 | `--jd-line` | `#e8e6dc` | Hairline borders |
 | `--jd-accent` | `#d97757` | Primary accent |
-| `--jd-positive` | `#7d9b76` | Up / good status |
-| `--jd-negative` | `#c2542e` | Down / bad status |
-| `--jd-warning` | `#dfa32e` | Caution status |
-| `--jd-info` | `#6a9bcc` | Informational status |
+| `--jd-positive` | `#61785b` | Up / good status (text) |
+| `--jd-negative` | `#bc512d` | Down / bad status (text) |
+| `--jd-warning` | `#926b1e` | Caution status (text) |
+| `--jd-info` | `#50759a` | Informational status (text) |
 | `--jd-radius` | `10px` | Corner radius |
 | `--jd-shadow` | `0 1px 2px rgba(61,57,41,.06)` | Card shadow |
 
@@ -64,6 +68,7 @@ Exact type scale (px / weight / line-height / letter-spacing):
 | display | 32px | 700 | 1.15 | -0.02em |
 | h1 | 24px | 700 | 1.2 | -0.01em |
 | h2 | 18px | 600 | 1.3 | -0.005em |
+| h3 | 15px | 600 | 1.35 | 0 |
 | label | 13px | 600 | 1.3 | 0.01em |
 | body | 14px | 400 | 1.5 | 0 |
 | caption | 12px | 400 | 1.4 | 0 |
@@ -130,15 +135,29 @@ Minimal skeleton:
 
 ## 7. Accessibility
 
-- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
-  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
-  `--jd-muted` (do not drop muted onto colored fills).
+- Text contrast AA 4.5:1; large text / UI 3:1. The text tokens are tuned to clear
+  4.5:1 on both `--jd-bg` and `--jd-surface`: body on `--jd-ink`, headings on
+  `--jd-heading`, secondary/labels on `--jd-muted`, and the status tokens
+  `--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info` as status TEXT. Those
+  status text tokens are deliberately darker than the vivid chart-palette values
+  (which are for series fills / dots, not body text) — keep them off colored
+  fills. A per-theme contrast test guards every recipe's fg/bg token pair.
 - Units on every number; an as-of date on static data.
 
 ## 8. Forbidden (the validator rejects these)
 
-- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
-- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- Any off-theme color VALUE, in ANY syntax — a hex/rgb/hsl not in §1, a modern
+  color function (`oklch`/`lab`/`lch`/`hwb`/`color()`/`color-mix()`), or a named
+  CSS color — beyond white/black/transparent. Compose `var(--jd-*)` instead.
+- `font-family` naming a non-system face (e.g. Inter), including a `var(--x)`
+  indirection to a non-theme font; any `@font-face`.
+- Redefining a `--jd-*` theme token (only the theme layer owns them).
 - `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
-- External URLs (http/https, protocol-relative); load nothing over the network.
-- Color in an inline `style=` attribute; `!important` on color/font.
+- External URLs (http/https, protocol-relative, `@import "//…"`); load nothing
+  over the network.
+- Color in an inline `style=` attribute; `!important` on ANY declaration.
+
+The validator enforces COLOR, font-family, no-`!important`, no-`prefers-color-scheme`
+and the safety bans — it does NOT lint STRUCTURE. Spacing, the type scale and
+layout stay consistent through the winning component classes (in `@layer theme`)
+and the generation prompt, not a hard spacing rule.

--- a/jarvis/dashboards/themes/claude/design.md
+++ b/jarvis/dashboards/themes/claude/design.md
@@ -1,0 +1,144 @@
+# Claude — dashboard canvas theme
+
+A warm ivory theme: cream page, white cards, a warm brown ink ramp and a terracotta accent, with a serif display face for headings.
+
+This is a **light** theme (`data-theme="light"`). Light/dark is driven **only** by the theme's `data-theme` on `<html>`
+(and the `jarvis:theme` CustomEvent on change) — never by
+`@media (prefers-color-scheme)` or a `color-scheme` declaration, both of which
+the save-time validator rejects.
+
+The machine-enforceable copy of everything below lives in `theme.json` (tokens,
+palette order, scales and the validator allow-lists). This file is the human
+recipe and the source for the generation cheatsheet injected into the
+`jarvis-dashboards` skill.
+
+## 1. Color tokens
+
+Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
+hardcode a hex. The validator rejects any off-theme color literal (only these
+hexes, plus the approved neutrals white/black/transparent, are allowed).
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--jd-bg` | `#faf9f5` | Page background |
+| `--jd-surface` | `#ffffff` | Card / panel background |
+| `--jd-surface-2` | `#f5f3ec` | Subtle fill (table header, insets) |
+| `--jd-ink` | `#3d3929` | Body text |
+| `--jd-heading` | `#3d3929` | Headings |
+| `--jd-muted` | `#83827d` | Secondary / labels |
+| `--jd-line` | `#e8e6dc` | Hairline borders |
+| `--jd-accent` | `#d97757` | Primary accent |
+| `--jd-positive` | `#7d9b76` | Up / good status |
+| `--jd-negative` | `#c2542e` | Down / bad status |
+| `--jd-warning` | `#dfa32e` | Caution status |
+| `--jd-info` | `#6a9bcc` | Informational status |
+| `--jd-radius` | `10px` | Corner radius |
+| `--jd-shadow` | `0 1px 2px rgba(61,57,41,.06)` | Card shadow |
+
+### Categorical chart palette (in order)
+
+Series colors come from `window.JARVIS_THEME.palette` — use it in order, never
+hardcode chart colors. Do not reorder.
+
+| # | Color |
+| --- | --- |
+| 0 | `#d97757` |
+| 1 | `#7d9b76` |
+| 2 | `#dfa32e` |
+| 3 | `#6a9bcc` |
+| 4 | `#b0603f` |
+| 5 | `#8a7bb8` |
+| 6 | `#5c8a72` |
+| 7 | `#c2542e` |
+
+## 2. Typography
+
+Body/UI use the system sans stack; **headings use a serif display face** (`Georgia, "Times New Roman", serif`) exposed as `--jd-font-display`. Webfonts are impossible inside the canvas (the CSP is
+`font-src data:` with no network) and `@font-face` is rejected — never name a
+webfont like Inter.
+
+Exact type scale (px / weight / line-height / letter-spacing):
+
+| Role | Size | Weight | Line-height | Tracking |
+| --- | --- | --- | --- | --- |
+| display | 32px | 700 | 1.15 | -0.02em |
+| h1 | 24px | 700 | 1.2 | -0.01em |
+| h2 | 18px | 600 | 1.3 | -0.005em |
+| label | 13px | 600 | 1.3 | 0.01em |
+| body | 14px | 400 | 1.5 | 0 |
+| caption | 12px | 400 | 1.4 | 0 |
+
+## 3. Spacing, radius, border
+
+- Spacing steps (px): 4 · 8 · 12 · 16 · 24 · 32 · 48. Gutter between cards is
+  24px.
+- Radius: cards use `--jd-radius` (10px); small chips 6px; pills 999px.
+- Borders: 1px hairline in `--jd-line` is the default separator; 2px only for
+  emphasis. No heavy rules.
+
+## 4. Layout grid
+
+- Page: max-width 1200px, centered, 24px gutter
+  (`.jd-page`).
+- KPI row: 4 columns, auto-fit `minmax(200px, 1fr)`
+  (`.jd-kpi-row`).
+- Chart grid: 2 columns, auto-fit
+  `minmax(320px, 1fr)` (`.jd-chart-grid`).
+- Breakpoints (px): sm 640 · md 768
+  · lg 1024 · xl 1280.
+
+## 5. Component recipes (named classes)
+
+The canvas shell injects these classes in a winning `@layer theme` — **compose
+them** instead of restyling; that is what keeps every dashboard structurally
+consistent within the theme. All colors/fonts inside come from tokens.
+
+- `.jd-page` — the centered page frame.
+- `.jd-page-header` — title block; `h1` + optional `.jd-subtitle`.
+- `.jd-kpi-row` > `.jd-kpi` — stat tiles. Inside: `.jd-kpi-label`,
+  `.jd-kpi-value`, `.jd-kpi-delta.up` / `.jd-kpi-delta.down` for the change.
+- `.jd-card` / `.jd-chart-card` — panel chrome; `.jd-card-header` for the title,
+  `.jd-card-footnote` for the as-of / source note.
+- `.jd-chart-grid` — two-up chart layout.
+- `.jd-table` — data table (hairline rows, muted `--jd-surface-2` header).
+- `.jd-empty` / `.jd-error` — empty and error states (error uses
+  `--jd-negative`).
+
+Minimal skeleton:
+
+```html
+<div class="jd-page">
+  <div class="jd-page-header"><h1>Title</h1><div class="jd-subtitle">As of ...</div></div>
+  <div class="jd-kpi-row">
+    <div class="jd-kpi"><div class="jd-kpi-label">Revenue</div>
+      <div class="jd-kpi-value">$1.2M</div>
+      <div class="jd-kpi-delta up">+4.1%</div></div>
+  </div>
+  <div class="jd-chart-grid">
+    <div class="jd-chart-card"><div class="jd-card-header">Trend</div>
+      <div id="trend" style="height:280px"></div></div>
+  </div>
+</div>
+```
+
+## 6. Chart chrome (ECharts)
+
+- Series colors: `window.JARVIS_THEME.palette` in order.
+- Axis labels / legend: `--jd-muted`. Gridlines: `--jd-line`. Text: `--jd-ink`.
+- Tooltip: surface `--jd-surface`, border `--jd-line`, text `--jd-ink`.
+- Re-render on the `jarvis:theme` event if you read tokens at chart-build time.
+
+## 7. Accessibility
+
+- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
+  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
+  `--jd-muted` (do not drop muted onto colored fills).
+- Units on every number; an as-of date on static data.
+
+## 8. Forbidden (the validator rejects these)
+
+- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
+- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
+- External URLs (http/https, protocol-relative); load nothing over the network.
+- Color in an inline `style=` attribute; `!important` on color/font.

--- a/jarvis/dashboards/themes/claude/theme.json
+++ b/jarvis/dashboards/themes/claude/theme.json
@@ -15,10 +15,10 @@
     "#c2542e"
   ],
   "semantic": {
-    "positive": "#7d9b76",
-    "negative": "#c2542e",
-    "warning": "#dfa32e",
-    "info": "#6a9bcc"
+    "positive": "#61785b",
+    "negative": "#bc512d",
+    "warning": "#926b1e",
+    "info": "#50759a"
   },
   "render_tokens": {
     "bg": "#faf9f5",
@@ -26,13 +26,13 @@
     "surface-2": "#f5f3ec",
     "ink": "#3d3929",
     "heading": "#3d3929",
-    "muted": "#83827d",
+    "muted": "#6f6e6a",
     "line": "#e8e6dc",
     "accent": "#d97757",
-    "positive": "#7d9b76",
-    "negative": "#c2542e",
-    "warning": "#dfa32e",
-    "info": "#6a9bcc",
+    "positive": "#61785b",
+    "negative": "#bc512d",
+    "warning": "#926b1e",
+    "info": "#50759a",
     "radius": "10px",
     "shadow": "0 1px 2px rgba(61,57,41,.06)",
     "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
@@ -56,6 +56,12 @@
       "weight": 600,
       "line_height": 1.3,
       "letter_spacing": "-0.005em"
+    },
+    "h3": {
+      "px": 15,
+      "weight": 600,
+      "line_height": 1.35,
+      "letter_spacing": "0"
     },
     "label": {
       "px": 13,
@@ -137,9 +143,13 @@
       "#ffffff",
       "#f5f3ec",
       "#3d3929",
-      "#83827d",
+      "#6f6e6a",
       "#e8e6dc",
       "#d97757",
+      "#61785b",
+      "#bc512d",
+      "#926b1e",
+      "#50759a",
       "#7d9b76",
       "#c2542e",
       "#dfa32e",

--- a/jarvis/dashboards/themes/claude/theme.json
+++ b/jarvis/dashboards/themes/claude/theme.json
@@ -1,0 +1,166 @@
+{
+  "key": "claude",
+  "label": "Claude",
+  "schema_version": 1,
+  "dark": false,
+  "accent": "#d97757",
+  "palette": [
+    "#d97757",
+    "#7d9b76",
+    "#dfa32e",
+    "#6a9bcc",
+    "#b0603f",
+    "#8a7bb8",
+    "#5c8a72",
+    "#c2542e"
+  ],
+  "semantic": {
+    "positive": "#7d9b76",
+    "negative": "#c2542e",
+    "warning": "#dfa32e",
+    "info": "#6a9bcc"
+  },
+  "render_tokens": {
+    "bg": "#faf9f5",
+    "surface": "#ffffff",
+    "surface-2": "#f5f3ec",
+    "ink": "#3d3929",
+    "heading": "#3d3929",
+    "muted": "#83827d",
+    "line": "#e8e6dc",
+    "accent": "#d97757",
+    "positive": "#7d9b76",
+    "negative": "#c2542e",
+    "warning": "#dfa32e",
+    "info": "#6a9bcc",
+    "radius": "10px",
+    "shadow": "0 1px 2px rgba(61,57,41,.06)",
+    "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
+    "font-display": "Georgia,\"Times New Roman\",serif"
+  },
+  "type_scale": {
+    "display": {
+      "px": 32,
+      "weight": 700,
+      "line_height": 1.15,
+      "letter_spacing": "-0.02em"
+    },
+    "h1": {
+      "px": 24,
+      "weight": 700,
+      "line_height": 1.2,
+      "letter_spacing": "-0.01em"
+    },
+    "h2": {
+      "px": 18,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "-0.005em"
+    },
+    "label": {
+      "px": 13,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "0.01em"
+    },
+    "body": {
+      "px": 14,
+      "weight": 400,
+      "line_height": 1.5,
+      "letter_spacing": "0"
+    },
+    "caption": {
+      "px": 12,
+      "weight": 400,
+      "line_height": 1.4,
+      "letter_spacing": "0"
+    }
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "2xl": 32,
+    "3xl": 48
+  },
+  "radius": {
+    "sm": 6,
+    "md": 10,
+    "lg": 14,
+    "pill": 999
+  },
+  "border": {
+    "hairline": 1,
+    "medium": 2
+  },
+  "layout": {
+    "page_max_width": 1200,
+    "gutter": 24,
+    "kpi_columns": 4,
+    "kpi_min_px": 200,
+    "chart_columns": 2,
+    "chart_min_px": 320,
+    "breakpoints": {
+      "sm": 640,
+      "md": 768,
+      "lg": 1024,
+      "xl": 1280
+    }
+  },
+  "a11y": {
+    "text_contrast_min": 4.5,
+    "ui_contrast_min": 3.0
+  },
+  "component_classes": [
+    "jd-page",
+    "jd-page-header",
+    "jd-subtitle",
+    "jd-kpi-row",
+    "jd-kpi",
+    "jd-kpi-label",
+    "jd-kpi-value",
+    "jd-kpi-delta",
+    "jd-card",
+    "jd-chart-card",
+    "jd-card-header",
+    "jd-card-footnote",
+    "jd-chart-grid",
+    "jd-table",
+    "jd-empty",
+    "jd-error"
+  ],
+  "validator": {
+    "allowed_color_hexes": [
+      "#faf9f5",
+      "#ffffff",
+      "#f5f3ec",
+      "#3d3929",
+      "#83827d",
+      "#e8e6dc",
+      "#d97757",
+      "#7d9b76",
+      "#c2542e",
+      "#dfa32e",
+      "#6a9bcc",
+      "#b0603f",
+      "#8a7bb8",
+      "#5c8a72"
+    ],
+    "allowed_font_families": [
+      "-apple-system",
+      "blinkmacsystemfont",
+      "segoe ui",
+      "roboto",
+      "helvetica neue",
+      "arial",
+      "sans-serif",
+      "system-ui",
+      "ui-sans-serif",
+      "georgia",
+      "times new roman",
+      "serif"
+    ]
+  }
+}

--- a/jarvis/dashboards/themes/graphite/design.md
+++ b/jarvis/dashboards/themes/graphite/design.md
@@ -15,8 +15,12 @@ recipe and the source for the generation cheatsheet injected into the
 ## 1. Color tokens
 
 Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
-hardcode a hex. The validator rejects any off-theme color literal (only these
-hexes, plus the approved neutrals white/black/transparent, are allowed).
+hardcode a hex. The validator rejects any off-theme color VALUE in any syntax —
+only these token hexes, the ordered chart palette below, and the approved
+neutrals white/black/transparent are allowed. The status tokens
+(`--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info`) are the text-safe
+status colors (AA on `--jd-surface`), deliberately darker than the vivid
+chart-palette values used for series fills.
 
 | Token | Value | Role |
 | --- | --- | --- |
@@ -64,6 +68,7 @@ Exact type scale (px / weight / line-height / letter-spacing):
 | display | 32px | 700 | 1.15 | -0.02em |
 | h1 | 24px | 700 | 1.2 | -0.01em |
 | h2 | 18px | 600 | 1.3 | -0.005em |
+| h3 | 15px | 600 | 1.35 | 0 |
 | label | 13px | 600 | 1.3 | 0.01em |
 | body | 14px | 400 | 1.5 | 0 |
 | caption | 12px | 400 | 1.4 | 0 |
@@ -130,15 +135,29 @@ Minimal skeleton:
 
 ## 7. Accessibility
 
-- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
-  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
-  `--jd-muted` (do not drop muted onto colored fills).
+- Text contrast AA 4.5:1; large text / UI 3:1. The text tokens are tuned to clear
+  4.5:1 on both `--jd-bg` and `--jd-surface`: body on `--jd-ink`, headings on
+  `--jd-heading`, secondary/labels on `--jd-muted`, and the status tokens
+  `--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info` as status TEXT. Those
+  status text tokens are deliberately darker than the vivid chart-palette values
+  (which are for series fills / dots, not body text) — keep them off colored
+  fills. A per-theme contrast test guards every recipe's fg/bg token pair.
 - Units on every number; an as-of date on static data.
 
 ## 8. Forbidden (the validator rejects these)
 
-- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
-- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- Any off-theme color VALUE, in ANY syntax — a hex/rgb/hsl not in §1, a modern
+  color function (`oklch`/`lab`/`lch`/`hwb`/`color()`/`color-mix()`), or a named
+  CSS color — beyond white/black/transparent. Compose `var(--jd-*)` instead.
+- `font-family` naming a non-system face (e.g. Inter), including a `var(--x)`
+  indirection to a non-theme font; any `@font-face`.
+- Redefining a `--jd-*` theme token (only the theme layer owns them).
 - `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
-- External URLs (http/https, protocol-relative); load nothing over the network.
-- Color in an inline `style=` attribute; `!important` on color/font.
+- External URLs (http/https, protocol-relative, `@import "//…"`); load nothing
+  over the network.
+- Color in an inline `style=` attribute; `!important` on ANY declaration.
+
+The validator enforces COLOR, font-family, no-`!important`, no-`prefers-color-scheme`
+and the safety bans — it does NOT lint STRUCTURE. Spacing, the type scale and
+layout stay consistent through the winning component classes (in `@layer theme`)
+and the generation prompt, not a hard spacing rule.

--- a/jarvis/dashboards/themes/graphite/design.md
+++ b/jarvis/dashboards/themes/graphite/design.md
@@ -1,0 +1,144 @@
+# Graphite — dashboard canvas theme
+
+A dark theme: near-black page, graphite surfaces, a light ink ramp and a soft blue accent. Designed for low-light and wall displays.
+
+This is a **dark** theme (`data-theme="dark"`). Light/dark is driven **only** by the theme's `data-theme` on `<html>`
+(and the `jarvis:theme` CustomEvent on change) — never by
+`@media (prefers-color-scheme)` or a `color-scheme` declaration, both of which
+the save-time validator rejects.
+
+The machine-enforceable copy of everything below lives in `theme.json` (tokens,
+palette order, scales and the validator allow-lists). This file is the human
+recipe and the source for the generation cheatsheet injected into the
+`jarvis-dashboards` skill.
+
+## 1. Color tokens
+
+Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
+hardcode a hex. The validator rejects any off-theme color literal (only these
+hexes, plus the approved neutrals white/black/transparent, are allowed).
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--jd-bg` | `#191919` | Page background |
+| `--jd-surface` | `#222222` | Card / panel background |
+| `--jd-surface-2` | `#2a2a2a` | Subtle fill (table header, insets) |
+| `--jd-ink` | `#ececec` | Body text |
+| `--jd-heading` | `#ececec` | Headings |
+| `--jd-muted` | `#9a9a9a` | Secondary / labels |
+| `--jd-line` | `#333333` | Hairline borders |
+| `--jd-accent` | `#8ab4f8` | Primary accent |
+| `--jd-positive` | `#4ade80` | Up / good status |
+| `--jd-negative` | `#f87171` | Down / bad status |
+| `--jd-warning` | `#fbbf24` | Caution status |
+| `--jd-info` | `#8ab4f8` | Informational status |
+| `--jd-radius` | `10px` | Corner radius |
+| `--jd-shadow` | `none` | Card shadow |
+
+### Categorical chart palette (in order)
+
+Series colors come from `window.JARVIS_THEME.palette` — use it in order, never
+hardcode chart colors. Do not reorder.
+
+| # | Color |
+| --- | --- |
+| 0 | `#8ab4f8` |
+| 1 | `#4ade80` |
+| 2 | `#fbbf24` |
+| 3 | `#f87171` |
+| 4 | `#c084fc` |
+| 5 | `#22d3ee` |
+| 6 | `#fb923c` |
+| 7 | `#a3e635` |
+
+## 2. Typography
+
+Both body and display use the system sans stack (`--jd-font` == `--jd-font-display`). Webfonts are impossible inside the canvas (the CSP is
+`font-src data:` with no network) and `@font-face` is rejected — never name a
+webfont like Inter.
+
+Exact type scale (px / weight / line-height / letter-spacing):
+
+| Role | Size | Weight | Line-height | Tracking |
+| --- | --- | --- | --- | --- |
+| display | 32px | 700 | 1.15 | -0.02em |
+| h1 | 24px | 700 | 1.2 | -0.01em |
+| h2 | 18px | 600 | 1.3 | -0.005em |
+| label | 13px | 600 | 1.3 | 0.01em |
+| body | 14px | 400 | 1.5 | 0 |
+| caption | 12px | 400 | 1.4 | 0 |
+
+## 3. Spacing, radius, border
+
+- Spacing steps (px): 4 · 8 · 12 · 16 · 24 · 32 · 48. Gutter between cards is
+  24px.
+- Radius: cards use `--jd-radius` (10px); small chips 6px; pills 999px.
+- Borders: 1px hairline in `--jd-line` is the default separator; 2px only for
+  emphasis. No heavy rules.
+
+## 4. Layout grid
+
+- Page: max-width 1200px, centered, 24px gutter
+  (`.jd-page`).
+- KPI row: 4 columns, auto-fit `minmax(200px, 1fr)`
+  (`.jd-kpi-row`).
+- Chart grid: 2 columns, auto-fit
+  `minmax(320px, 1fr)` (`.jd-chart-grid`).
+- Breakpoints (px): sm 640 · md 768
+  · lg 1024 · xl 1280.
+
+## 5. Component recipes (named classes)
+
+The canvas shell injects these classes in a winning `@layer theme` — **compose
+them** instead of restyling; that is what keeps every dashboard structurally
+consistent within the theme. All colors/fonts inside come from tokens.
+
+- `.jd-page` — the centered page frame.
+- `.jd-page-header` — title block; `h1` + optional `.jd-subtitle`.
+- `.jd-kpi-row` > `.jd-kpi` — stat tiles. Inside: `.jd-kpi-label`,
+  `.jd-kpi-value`, `.jd-kpi-delta.up` / `.jd-kpi-delta.down` for the change.
+- `.jd-card` / `.jd-chart-card` — panel chrome; `.jd-card-header` for the title,
+  `.jd-card-footnote` for the as-of / source note.
+- `.jd-chart-grid` — two-up chart layout.
+- `.jd-table` — data table (hairline rows, muted `--jd-surface-2` header).
+- `.jd-empty` / `.jd-error` — empty and error states (error uses
+  `--jd-negative`).
+
+Minimal skeleton:
+
+```html
+<div class="jd-page">
+  <div class="jd-page-header"><h1>Title</h1><div class="jd-subtitle">As of ...</div></div>
+  <div class="jd-kpi-row">
+    <div class="jd-kpi"><div class="jd-kpi-label">Revenue</div>
+      <div class="jd-kpi-value">$1.2M</div>
+      <div class="jd-kpi-delta up">+4.1%</div></div>
+  </div>
+  <div class="jd-chart-grid">
+    <div class="jd-chart-card"><div class="jd-card-header">Trend</div>
+      <div id="trend" style="height:280px"></div></div>
+  </div>
+</div>
+```
+
+## 6. Chart chrome (ECharts)
+
+- Series colors: `window.JARVIS_THEME.palette` in order.
+- Axis labels / legend: `--jd-muted`. Gridlines: `--jd-line`. Text: `--jd-ink`.
+- Tooltip: surface `--jd-surface`, border `--jd-line`, text `--jd-ink`.
+- Re-render on the `jarvis:theme` event if you read tokens at chart-build time.
+
+## 7. Accessibility
+
+- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
+  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
+  `--jd-muted` (do not drop muted onto colored fills).
+- Units on every number; an as-of date on static data.
+
+## 8. Forbidden (the validator rejects these)
+
+- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
+- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
+- External URLs (http/https, protocol-relative); load nothing over the network.
+- Color in an inline `style=` attribute; `!important` on color/font.

--- a/jarvis/dashboards/themes/graphite/theme.json
+++ b/jarvis/dashboards/themes/graphite/theme.json
@@ -1,0 +1,163 @@
+{
+  "key": "graphite",
+  "label": "Graphite",
+  "schema_version": 1,
+  "dark": true,
+  "accent": "#8ab4f8",
+  "palette": [
+    "#8ab4f8",
+    "#4ade80",
+    "#fbbf24",
+    "#f87171",
+    "#c084fc",
+    "#22d3ee",
+    "#fb923c",
+    "#a3e635"
+  ],
+  "semantic": {
+    "positive": "#4ade80",
+    "negative": "#f87171",
+    "warning": "#fbbf24",
+    "info": "#8ab4f8"
+  },
+  "render_tokens": {
+    "bg": "#191919",
+    "surface": "#222222",
+    "surface-2": "#2a2a2a",
+    "ink": "#ececec",
+    "heading": "#ececec",
+    "muted": "#9a9a9a",
+    "line": "#333333",
+    "accent": "#8ab4f8",
+    "positive": "#4ade80",
+    "negative": "#f87171",
+    "warning": "#fbbf24",
+    "info": "#8ab4f8",
+    "radius": "10px",
+    "shadow": "none",
+    "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
+    "font-display": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif"
+  },
+  "type_scale": {
+    "display": {
+      "px": 32,
+      "weight": 700,
+      "line_height": 1.15,
+      "letter_spacing": "-0.02em"
+    },
+    "h1": {
+      "px": 24,
+      "weight": 700,
+      "line_height": 1.2,
+      "letter_spacing": "-0.01em"
+    },
+    "h2": {
+      "px": 18,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "-0.005em"
+    },
+    "label": {
+      "px": 13,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "0.01em"
+    },
+    "body": {
+      "px": 14,
+      "weight": 400,
+      "line_height": 1.5,
+      "letter_spacing": "0"
+    },
+    "caption": {
+      "px": 12,
+      "weight": 400,
+      "line_height": 1.4,
+      "letter_spacing": "0"
+    }
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "2xl": 32,
+    "3xl": 48
+  },
+  "radius": {
+    "sm": 6,
+    "md": 10,
+    "lg": 14,
+    "pill": 999
+  },
+  "border": {
+    "hairline": 1,
+    "medium": 2
+  },
+  "layout": {
+    "page_max_width": 1200,
+    "gutter": 24,
+    "kpi_columns": 4,
+    "kpi_min_px": 200,
+    "chart_columns": 2,
+    "chart_min_px": 320,
+    "breakpoints": {
+      "sm": 640,
+      "md": 768,
+      "lg": 1024,
+      "xl": 1280
+    }
+  },
+  "a11y": {
+    "text_contrast_min": 4.5,
+    "ui_contrast_min": 3.0
+  },
+  "component_classes": [
+    "jd-page",
+    "jd-page-header",
+    "jd-subtitle",
+    "jd-kpi-row",
+    "jd-kpi",
+    "jd-kpi-label",
+    "jd-kpi-value",
+    "jd-kpi-delta",
+    "jd-card",
+    "jd-chart-card",
+    "jd-card-header",
+    "jd-card-footnote",
+    "jd-chart-grid",
+    "jd-table",
+    "jd-empty",
+    "jd-error"
+  ],
+  "validator": {
+    "allowed_color_hexes": [
+      "#191919",
+      "#222222",
+      "#2a2a2a",
+      "#ececec",
+      "#9a9a9a",
+      "#333333",
+      "#8ab4f8",
+      "#4ade80",
+      "#f87171",
+      "#fbbf24",
+      "#c084fc",
+      "#22d3ee",
+      "#fb923c",
+      "#a3e635"
+    ],
+    "allowed_font_families": [
+      "-apple-system",
+      "blinkmacsystemfont",
+      "segoe ui",
+      "roboto",
+      "helvetica neue",
+      "arial",
+      "sans-serif",
+      "system-ui",
+      "ui-sans-serif"
+    ]
+  }
+}

--- a/jarvis/dashboards/themes/graphite/theme.json
+++ b/jarvis/dashboards/themes/graphite/theme.json
@@ -57,6 +57,12 @@
       "line_height": 1.3,
       "letter_spacing": "-0.005em"
     },
+    "h3": {
+      "px": 15,
+      "weight": 600,
+      "line_height": 1.35,
+      "letter_spacing": "0"
+    },
     "label": {
       "px": 13,
       "weight": 600,

--- a/jarvis/dashboards/themes/insight/design.md
+++ b/jarvis/dashboards/themes/insight/design.md
@@ -1,0 +1,144 @@
+# Insight — dashboard canvas theme
+
+A Frappe-Insights-style light theme: clean white surfaces, a cool slate ink ramp and a confident blue accent. Reads as a BI console.
+
+This is a **light** theme (`data-theme="light"`). Light/dark is driven **only** by the theme's `data-theme` on `<html>`
+(and the `jarvis:theme` CustomEvent on change) — never by
+`@media (prefers-color-scheme)` or a `color-scheme` declaration, both of which
+the save-time validator rejects.
+
+The machine-enforceable copy of everything below lives in `theme.json` (tokens,
+palette order, scales and the validator allow-lists). This file is the human
+recipe and the source for the generation cheatsheet injected into the
+`jarvis-dashboards` skill.
+
+## 1. Color tokens
+
+Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
+hardcode a hex. The validator rejects any off-theme color literal (only these
+hexes, plus the approved neutrals white/black/transparent, are allowed).
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--jd-bg` | `#f3f3f3` | Page background |
+| `--jd-surface` | `#ffffff` | Card / panel background |
+| `--jd-surface-2` | `#f6f8fa` | Subtle fill (table header, insets) |
+| `--jd-ink` | `#1f272e` | Body text |
+| `--jd-heading` | `#1f272e` | Headings |
+| `--jd-muted` | `#6c7680` | Secondary / labels |
+| `--jd-line` | `#e2e2e2` | Hairline borders |
+| `--jd-accent` | `#2490ef` | Primary accent |
+| `--jd-positive` | `#25b885` | Up / good status |
+| `--jd-negative` | `#e24c4c` | Down / bad status |
+| `--jd-warning` | `#f5a623` | Caution status |
+| `--jd-info` | `#2490ef` | Informational status |
+| `--jd-radius` | `10px` | Corner radius |
+| `--jd-shadow` | `0 1px 2px rgba(25,39,52,.06)` | Card shadow |
+
+### Categorical chart palette (in order)
+
+Series colors come from `window.JARVIS_THEME.palette` — use it in order, never
+hardcode chart colors. Do not reorder.
+
+| # | Color |
+| --- | --- |
+| 0 | `#2490ef` |
+| 1 | `#25b885` |
+| 2 | `#f5a623` |
+| 3 | `#e24c4c` |
+| 4 | `#9b59b6` |
+| 5 | `#17a2b8` |
+| 6 | `#fd7e14` |
+| 7 | `#5856d6` |
+
+## 2. Typography
+
+Both body and display use the system sans stack (`--jd-font` == `--jd-font-display`). Webfonts are impossible inside the canvas (the CSP is
+`font-src data:` with no network) and `@font-face` is rejected — never name a
+webfont like Inter.
+
+Exact type scale (px / weight / line-height / letter-spacing):
+
+| Role | Size | Weight | Line-height | Tracking |
+| --- | --- | --- | --- | --- |
+| display | 32px | 700 | 1.15 | -0.02em |
+| h1 | 24px | 700 | 1.2 | -0.01em |
+| h2 | 18px | 600 | 1.3 | -0.005em |
+| label | 13px | 600 | 1.3 | 0.01em |
+| body | 14px | 400 | 1.5 | 0 |
+| caption | 12px | 400 | 1.4 | 0 |
+
+## 3. Spacing, radius, border
+
+- Spacing steps (px): 4 · 8 · 12 · 16 · 24 · 32 · 48. Gutter between cards is
+  24px.
+- Radius: cards use `--jd-radius` (10px); small chips 6px; pills 999px.
+- Borders: 1px hairline in `--jd-line` is the default separator; 2px only for
+  emphasis. No heavy rules.
+
+## 4. Layout grid
+
+- Page: max-width 1200px, centered, 24px gutter
+  (`.jd-page`).
+- KPI row: 4 columns, auto-fit `minmax(200px, 1fr)`
+  (`.jd-kpi-row`).
+- Chart grid: 2 columns, auto-fit
+  `minmax(320px, 1fr)` (`.jd-chart-grid`).
+- Breakpoints (px): sm 640 · md 768
+  · lg 1024 · xl 1280.
+
+## 5. Component recipes (named classes)
+
+The canvas shell injects these classes in a winning `@layer theme` — **compose
+them** instead of restyling; that is what keeps every dashboard structurally
+consistent within the theme. All colors/fonts inside come from tokens.
+
+- `.jd-page` — the centered page frame.
+- `.jd-page-header` — title block; `h1` + optional `.jd-subtitle`.
+- `.jd-kpi-row` > `.jd-kpi` — stat tiles. Inside: `.jd-kpi-label`,
+  `.jd-kpi-value`, `.jd-kpi-delta.up` / `.jd-kpi-delta.down` for the change.
+- `.jd-card` / `.jd-chart-card` — panel chrome; `.jd-card-header` for the title,
+  `.jd-card-footnote` for the as-of / source note.
+- `.jd-chart-grid` — two-up chart layout.
+- `.jd-table` — data table (hairline rows, muted `--jd-surface-2` header).
+- `.jd-empty` / `.jd-error` — empty and error states (error uses
+  `--jd-negative`).
+
+Minimal skeleton:
+
+```html
+<div class="jd-page">
+  <div class="jd-page-header"><h1>Title</h1><div class="jd-subtitle">As of ...</div></div>
+  <div class="jd-kpi-row">
+    <div class="jd-kpi"><div class="jd-kpi-label">Revenue</div>
+      <div class="jd-kpi-value">$1.2M</div>
+      <div class="jd-kpi-delta up">+4.1%</div></div>
+  </div>
+  <div class="jd-chart-grid">
+    <div class="jd-chart-card"><div class="jd-card-header">Trend</div>
+      <div id="trend" style="height:280px"></div></div>
+  </div>
+</div>
+```
+
+## 6. Chart chrome (ECharts)
+
+- Series colors: `window.JARVIS_THEME.palette` in order.
+- Axis labels / legend: `--jd-muted`. Gridlines: `--jd-line`. Text: `--jd-ink`.
+- Tooltip: surface `--jd-surface`, border `--jd-line`, text `--jd-ink`.
+- Re-render on the `jarvis:theme` event if you read tokens at chart-build time.
+
+## 7. Accessibility
+
+- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
+  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
+  `--jd-muted` (do not drop muted onto colored fills).
+- Units on every number; an as-of date on static data.
+
+## 8. Forbidden (the validator rejects these)
+
+- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
+- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
+- External URLs (http/https, protocol-relative); load nothing over the network.
+- Color in an inline `style=` attribute; `!important` on color/font.

--- a/jarvis/dashboards/themes/insight/design.md
+++ b/jarvis/dashboards/themes/insight/design.md
@@ -15,8 +15,12 @@ recipe and the source for the generation cheatsheet injected into the
 ## 1. Color tokens
 
 Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
-hardcode a hex. The validator rejects any off-theme color literal (only these
-hexes, plus the approved neutrals white/black/transparent, are allowed).
+hardcode a hex. The validator rejects any off-theme color VALUE in any syntax —
+only these token hexes, the ordered chart palette below, and the approved
+neutrals white/black/transparent are allowed. The status tokens
+(`--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info`) are the text-safe
+status colors (AA on `--jd-surface`), deliberately darker than the vivid
+chart-palette values used for series fills.
 
 | Token | Value | Role |
 | --- | --- | --- |
@@ -25,13 +29,13 @@ hexes, plus the approved neutrals white/black/transparent, are allowed).
 | `--jd-surface-2` | `#f6f8fa` | Subtle fill (table header, insets) |
 | `--jd-ink` | `#1f272e` | Body text |
 | `--jd-heading` | `#1f272e` | Headings |
-| `--jd-muted` | `#6c7680` | Secondary / labels |
+| `--jd-muted` | `#667079` | Secondary / labels |
 | `--jd-line` | `#e2e2e2` | Hairline borders |
 | `--jd-accent` | `#2490ef` | Primary accent |
-| `--jd-positive` | `#25b885` | Up / good status |
-| `--jd-negative` | `#e24c4c` | Down / bad status |
-| `--jd-warning` | `#f5a623` | Caution status |
-| `--jd-info` | `#2490ef` | Informational status |
+| `--jd-positive` | `#197d5a` | Up / good status (text) |
+| `--jd-negative` | `#c24141` | Down / bad status (text) |
+| `--jd-warning` | `#956515` | Caution status (text) |
+| `--jd-info` | `#1c71bc` | Informational status (text) |
 | `--jd-radius` | `10px` | Corner radius |
 | `--jd-shadow` | `0 1px 2px rgba(25,39,52,.06)` | Card shadow |
 
@@ -64,6 +68,7 @@ Exact type scale (px / weight / line-height / letter-spacing):
 | display | 32px | 700 | 1.15 | -0.02em |
 | h1 | 24px | 700 | 1.2 | -0.01em |
 | h2 | 18px | 600 | 1.3 | -0.005em |
+| h3 | 15px | 600 | 1.35 | 0 |
 | label | 13px | 600 | 1.3 | 0.01em |
 | body | 14px | 400 | 1.5 | 0 |
 | caption | 12px | 400 | 1.4 | 0 |
@@ -130,15 +135,29 @@ Minimal skeleton:
 
 ## 7. Accessibility
 
-- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
-  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
-  `--jd-muted` (do not drop muted onto colored fills).
+- Text contrast AA 4.5:1; large text / UI 3:1. The text tokens are tuned to clear
+  4.5:1 on both `--jd-bg` and `--jd-surface`: body on `--jd-ink`, headings on
+  `--jd-heading`, secondary/labels on `--jd-muted`, and the status tokens
+  `--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info` as status TEXT. Those
+  status text tokens are deliberately darker than the vivid chart-palette values
+  (which are for series fills / dots, not body text) — keep them off colored
+  fills. A per-theme contrast test guards every recipe's fg/bg token pair.
 - Units on every number; an as-of date on static data.
 
 ## 8. Forbidden (the validator rejects these)
 
-- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
-- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- Any off-theme color VALUE, in ANY syntax — a hex/rgb/hsl not in §1, a modern
+  color function (`oklch`/`lab`/`lch`/`hwb`/`color()`/`color-mix()`), or a named
+  CSS color — beyond white/black/transparent. Compose `var(--jd-*)` instead.
+- `font-family` naming a non-system face (e.g. Inter), including a `var(--x)`
+  indirection to a non-theme font; any `@font-face`.
+- Redefining a `--jd-*` theme token (only the theme layer owns them).
 - `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
-- External URLs (http/https, protocol-relative); load nothing over the network.
-- Color in an inline `style=` attribute; `!important` on color/font.
+- External URLs (http/https, protocol-relative, `@import "//…"`); load nothing
+  over the network.
+- Color in an inline `style=` attribute; `!important` on ANY declaration.
+
+The validator enforces COLOR, font-family, no-`!important`, no-`prefers-color-scheme`
+and the safety bans — it does NOT lint STRUCTURE. Spacing, the type scale and
+layout stay consistent through the winning component classes (in `@layer theme`)
+and the generation prompt, not a hard spacing rule.

--- a/jarvis/dashboards/themes/insight/theme.json
+++ b/jarvis/dashboards/themes/insight/theme.json
@@ -1,0 +1,163 @@
+{
+  "key": "insight",
+  "label": "Insight",
+  "schema_version": 1,
+  "dark": false,
+  "accent": "#2490ef",
+  "palette": [
+    "#2490ef",
+    "#25b885",
+    "#f5a623",
+    "#e24c4c",
+    "#9b59b6",
+    "#17a2b8",
+    "#fd7e14",
+    "#5856d6"
+  ],
+  "semantic": {
+    "positive": "#25b885",
+    "negative": "#e24c4c",
+    "warning": "#f5a623",
+    "info": "#2490ef"
+  },
+  "render_tokens": {
+    "bg": "#f3f3f3",
+    "surface": "#ffffff",
+    "surface-2": "#f6f8fa",
+    "ink": "#1f272e",
+    "heading": "#1f272e",
+    "muted": "#6c7680",
+    "line": "#e2e2e2",
+    "accent": "#2490ef",
+    "positive": "#25b885",
+    "negative": "#e24c4c",
+    "warning": "#f5a623",
+    "info": "#2490ef",
+    "radius": "10px",
+    "shadow": "0 1px 2px rgba(25,39,52,.06)",
+    "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
+    "font-display": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif"
+  },
+  "type_scale": {
+    "display": {
+      "px": 32,
+      "weight": 700,
+      "line_height": 1.15,
+      "letter_spacing": "-0.02em"
+    },
+    "h1": {
+      "px": 24,
+      "weight": 700,
+      "line_height": 1.2,
+      "letter_spacing": "-0.01em"
+    },
+    "h2": {
+      "px": 18,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "-0.005em"
+    },
+    "label": {
+      "px": 13,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "0.01em"
+    },
+    "body": {
+      "px": 14,
+      "weight": 400,
+      "line_height": 1.5,
+      "letter_spacing": "0"
+    },
+    "caption": {
+      "px": 12,
+      "weight": 400,
+      "line_height": 1.4,
+      "letter_spacing": "0"
+    }
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "2xl": 32,
+    "3xl": 48
+  },
+  "radius": {
+    "sm": 6,
+    "md": 10,
+    "lg": 14,
+    "pill": 999
+  },
+  "border": {
+    "hairline": 1,
+    "medium": 2
+  },
+  "layout": {
+    "page_max_width": 1200,
+    "gutter": 24,
+    "kpi_columns": 4,
+    "kpi_min_px": 200,
+    "chart_columns": 2,
+    "chart_min_px": 320,
+    "breakpoints": {
+      "sm": 640,
+      "md": 768,
+      "lg": 1024,
+      "xl": 1280
+    }
+  },
+  "a11y": {
+    "text_contrast_min": 4.5,
+    "ui_contrast_min": 3.0
+  },
+  "component_classes": [
+    "jd-page",
+    "jd-page-header",
+    "jd-subtitle",
+    "jd-kpi-row",
+    "jd-kpi",
+    "jd-kpi-label",
+    "jd-kpi-value",
+    "jd-kpi-delta",
+    "jd-card",
+    "jd-chart-card",
+    "jd-card-header",
+    "jd-card-footnote",
+    "jd-chart-grid",
+    "jd-table",
+    "jd-empty",
+    "jd-error"
+  ],
+  "validator": {
+    "allowed_color_hexes": [
+      "#f3f3f3",
+      "#ffffff",
+      "#f6f8fa",
+      "#1f272e",
+      "#6c7680",
+      "#e2e2e2",
+      "#2490ef",
+      "#25b885",
+      "#e24c4c",
+      "#f5a623",
+      "#9b59b6",
+      "#17a2b8",
+      "#fd7e14",
+      "#5856d6"
+    ],
+    "allowed_font_families": [
+      "-apple-system",
+      "blinkmacsystemfont",
+      "segoe ui",
+      "roboto",
+      "helvetica neue",
+      "arial",
+      "sans-serif",
+      "system-ui",
+      "ui-sans-serif"
+    ]
+  }
+}

--- a/jarvis/dashboards/themes/insight/theme.json
+++ b/jarvis/dashboards/themes/insight/theme.json
@@ -15,10 +15,10 @@
     "#5856d6"
   ],
   "semantic": {
-    "positive": "#25b885",
-    "negative": "#e24c4c",
-    "warning": "#f5a623",
-    "info": "#2490ef"
+    "positive": "#197d5a",
+    "negative": "#c24141",
+    "warning": "#956515",
+    "info": "#1c71bc"
   },
   "render_tokens": {
     "bg": "#f3f3f3",
@@ -26,13 +26,13 @@
     "surface-2": "#f6f8fa",
     "ink": "#1f272e",
     "heading": "#1f272e",
-    "muted": "#6c7680",
+    "muted": "#667079",
     "line": "#e2e2e2",
     "accent": "#2490ef",
-    "positive": "#25b885",
-    "negative": "#e24c4c",
-    "warning": "#f5a623",
-    "info": "#2490ef",
+    "positive": "#197d5a",
+    "negative": "#c24141",
+    "warning": "#956515",
+    "info": "#1c71bc",
     "radius": "10px",
     "shadow": "0 1px 2px rgba(25,39,52,.06)",
     "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
@@ -56,6 +56,12 @@
       "weight": 600,
       "line_height": 1.3,
       "letter_spacing": "-0.005em"
+    },
+    "h3": {
+      "px": 15,
+      "weight": 600,
+      "line_height": 1.35,
+      "letter_spacing": "0"
     },
     "label": {
       "px": 13,
@@ -137,9 +143,13 @@
       "#ffffff",
       "#f6f8fa",
       "#1f272e",
-      "#6c7680",
+      "#667079",
       "#e2e2e2",
       "#2490ef",
+      "#197d5a",
+      "#c24141",
+      "#956515",
+      "#1c71bc",
       "#25b885",
       "#e24c4c",
       "#f5a623",

--- a/jarvis/dashboards/themes/jarvis/design.md
+++ b/jarvis/dashboards/themes/jarvis/design.md
@@ -1,0 +1,144 @@
+# Jarvis — dashboard canvas theme
+
+The app's own design language: gray-on-white, an ink-gray text ramp, hairline borders and a near-black accent. The product default — an unprompted dashboard looks native to Jarvis.
+
+This is a **light** theme (`data-theme="light"`). Light/dark is driven **only** by the theme's `data-theme` on `<html>`
+(and the `jarvis:theme` CustomEvent on change) — never by
+`@media (prefers-color-scheme)` or a `color-scheme` declaration, both of which
+the save-time validator rejects.
+
+The machine-enforceable copy of everything below lives in `theme.json` (tokens,
+palette order, scales and the validator allow-lists). This file is the human
+recipe and the source for the generation cheatsheet injected into the
+`jarvis-dashboards` skill.
+
+## 1. Color tokens
+
+Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
+hardcode a hex. The validator rejects any off-theme color literal (only these
+hexes, plus the approved neutrals white/black/transparent, are allowed).
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--jd-bg` | `#f8f8f8` | Page background |
+| `--jd-surface` | `#ffffff` | Card / panel background |
+| `--jd-surface-2` | `#f2f2f2` | Subtle fill (table header, insets) |
+| `--jd-ink` | `#383838` | Body text |
+| `--jd-heading` | `#171717` | Headings |
+| `--jd-muted` | `#7c7c7c` | Secondary / labels |
+| `--jd-line` | `#ededed` | Hairline borders |
+| `--jd-accent` | `#383838` | Primary accent |
+| `--jd-positive` | `#4c9a7a` | Up / good status |
+| `--jd-negative` | `#c25d5d` | Down / bad status |
+| `--jd-warning` | `#d9a53f` | Caution status |
+| `--jd-info` | `#5d78d1` | Informational status |
+| `--jd-radius` | `10px` | Corner radius |
+| `--jd-shadow` | `0 1px 2px rgba(0,0,0,.05)` | Card shadow |
+
+### Categorical chart palette (in order)
+
+Series colors come from `window.JARVIS_THEME.palette` — use it in order, never
+hardcode chart colors. Do not reorder.
+
+| # | Color |
+| --- | --- |
+| 0 | `#383838` |
+| 1 | `#5d78d1` |
+| 2 | `#4c9a7a` |
+| 3 | `#d9a53f` |
+| 4 | `#c25d5d` |
+| 5 | `#8a7bb8` |
+| 6 | `#5a99ae` |
+| 7 | `#a0693f` |
+
+## 2. Typography
+
+Both body and display use the system sans stack (`--jd-font` == `--jd-font-display`). Webfonts are impossible inside the canvas (the CSP is
+`font-src data:` with no network) and `@font-face` is rejected — never name a
+webfont like Inter.
+
+Exact type scale (px / weight / line-height / letter-spacing):
+
+| Role | Size | Weight | Line-height | Tracking |
+| --- | --- | --- | --- | --- |
+| display | 32px | 700 | 1.15 | -0.02em |
+| h1 | 24px | 700 | 1.2 | -0.01em |
+| h2 | 18px | 600 | 1.3 | -0.005em |
+| label | 13px | 600 | 1.3 | 0.01em |
+| body | 14px | 400 | 1.5 | 0 |
+| caption | 12px | 400 | 1.4 | 0 |
+
+## 3. Spacing, radius, border
+
+- Spacing steps (px): 4 · 8 · 12 · 16 · 24 · 32 · 48. Gutter between cards is
+  24px.
+- Radius: cards use `--jd-radius` (10px); small chips 6px; pills 999px.
+- Borders: 1px hairline in `--jd-line` is the default separator; 2px only for
+  emphasis. No heavy rules.
+
+## 4. Layout grid
+
+- Page: max-width 1200px, centered, 24px gutter
+  (`.jd-page`).
+- KPI row: 4 columns, auto-fit `minmax(200px, 1fr)`
+  (`.jd-kpi-row`).
+- Chart grid: 2 columns, auto-fit
+  `minmax(320px, 1fr)` (`.jd-chart-grid`).
+- Breakpoints (px): sm 640 · md 768
+  · lg 1024 · xl 1280.
+
+## 5. Component recipes (named classes)
+
+The canvas shell injects these classes in a winning `@layer theme` — **compose
+them** instead of restyling; that is what keeps every dashboard structurally
+consistent within the theme. All colors/fonts inside come from tokens.
+
+- `.jd-page` — the centered page frame.
+- `.jd-page-header` — title block; `h1` + optional `.jd-subtitle`.
+- `.jd-kpi-row` > `.jd-kpi` — stat tiles. Inside: `.jd-kpi-label`,
+  `.jd-kpi-value`, `.jd-kpi-delta.up` / `.jd-kpi-delta.down` for the change.
+- `.jd-card` / `.jd-chart-card` — panel chrome; `.jd-card-header` for the title,
+  `.jd-card-footnote` for the as-of / source note.
+- `.jd-chart-grid` — two-up chart layout.
+- `.jd-table` — data table (hairline rows, muted `--jd-surface-2` header).
+- `.jd-empty` / `.jd-error` — empty and error states (error uses
+  `--jd-negative`).
+
+Minimal skeleton:
+
+```html
+<div class="jd-page">
+  <div class="jd-page-header"><h1>Title</h1><div class="jd-subtitle">As of ...</div></div>
+  <div class="jd-kpi-row">
+    <div class="jd-kpi"><div class="jd-kpi-label">Revenue</div>
+      <div class="jd-kpi-value">$1.2M</div>
+      <div class="jd-kpi-delta up">+4.1%</div></div>
+  </div>
+  <div class="jd-chart-grid">
+    <div class="jd-chart-card"><div class="jd-card-header">Trend</div>
+      <div id="trend" style="height:280px"></div></div>
+  </div>
+</div>
+```
+
+## 6. Chart chrome (ECharts)
+
+- Series colors: `window.JARVIS_THEME.palette` in order.
+- Axis labels / legend: `--jd-muted`. Gridlines: `--jd-line`. Text: `--jd-ink`.
+- Tooltip: surface `--jd-surface`, border `--jd-line`, text `--jd-ink`.
+- Re-render on the `jarvis:theme` event if you read tokens at chart-build time.
+
+## 7. Accessibility
+
+- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
+  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
+  `--jd-muted` (do not drop muted onto colored fills).
+- Units on every number; an as-of date on static data.
+
+## 8. Forbidden (the validator rejects these)
+
+- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
+- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
+- External URLs (http/https, protocol-relative); load nothing over the network.
+- Color in an inline `style=` attribute; `!important` on color/font.

--- a/jarvis/dashboards/themes/jarvis/design.md
+++ b/jarvis/dashboards/themes/jarvis/design.md
@@ -15,8 +15,12 @@ recipe and the source for the generation cheatsheet injected into the
 ## 1. Color tokens
 
 Injected as CSS custom properties on `:root`; compose with `var(--jd-*)`, never
-hardcode a hex. The validator rejects any off-theme color literal (only these
-hexes, plus the approved neutrals white/black/transparent, are allowed).
+hardcode a hex. The validator rejects any off-theme color VALUE in any syntax —
+only these token hexes, the ordered chart palette below, and the approved
+neutrals white/black/transparent are allowed. The status tokens
+(`--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info`) are the text-safe
+status colors (AA on `--jd-surface`), deliberately darker than the vivid
+chart-palette values used for series fills.
 
 | Token | Value | Role |
 | --- | --- | --- |
@@ -25,13 +29,13 @@ hexes, plus the approved neutrals white/black/transparent, are allowed).
 | `--jd-surface-2` | `#f2f2f2` | Subtle fill (table header, insets) |
 | `--jd-ink` | `#383838` | Body text |
 | `--jd-heading` | `#171717` | Headings |
-| `--jd-muted` | `#7c7c7c` | Secondary / labels |
+| `--jd-muted` | `#6e6e6e` | Secondary / labels |
 | `--jd-line` | `#ededed` | Hairline borders |
 | `--jd-accent` | `#383838` | Primary accent |
-| `--jd-positive` | `#4c9a7a` | Up / good status |
-| `--jd-negative` | `#c25d5d` | Down / bad status |
-| `--jd-warning` | `#d9a53f` | Caution status |
-| `--jd-info` | `#5d78d1` | Informational status |
+| `--jd-positive` | `#3e7d63` | Up / good status (text) |
+| `--jd-negative` | `#b25555` | Down / bad status (text) |
+| `--jd-warning` | `#8e6c29` | Caution status (text) |
+| `--jd-info` | `#556dbe` | Informational status (text) |
 | `--jd-radius` | `10px` | Corner radius |
 | `--jd-shadow` | `0 1px 2px rgba(0,0,0,.05)` | Card shadow |
 
@@ -64,6 +68,7 @@ Exact type scale (px / weight / line-height / letter-spacing):
 | display | 32px | 700 | 1.15 | -0.02em |
 | h1 | 24px | 700 | 1.2 | -0.01em |
 | h2 | 18px | 600 | 1.3 | -0.005em |
+| h3 | 15px | 600 | 1.35 | 0 |
 | label | 13px | 600 | 1.3 | 0.01em |
 | body | 14px | 400 | 1.5 | 0 |
 | caption | 12px | 400 | 1.4 | 0 |
@@ -130,15 +135,29 @@ Minimal skeleton:
 
 ## 7. Accessibility
 
-- Text contrast AA 4.5:1; large text / UI 3:1. The token ramp already meets this
-  on `--jd-bg`/`--jd-surface`; keep body text on `--jd-ink`, secondary on
-  `--jd-muted` (do not drop muted onto colored fills).
+- Text contrast AA 4.5:1; large text / UI 3:1. The text tokens are tuned to clear
+  4.5:1 on both `--jd-bg` and `--jd-surface`: body on `--jd-ink`, headings on
+  `--jd-heading`, secondary/labels on `--jd-muted`, and the status tokens
+  `--jd-positive`/`--jd-negative`/`--jd-warning`/`--jd-info` as status TEXT. Those
+  status text tokens are deliberately darker than the vivid chart-palette values
+  (which are for series fills / dots, not body text) — keep them off colored
+  fills. A per-theme contrast test guards every recipe's fg/bg token pair.
 - Units on every number; an as-of date on static data.
 
 ## 8. Forbidden (the validator rejects these)
 
-- Off-theme color literals (any hex/rgb/hsl not in §1, beyond white/black/transparent).
-- `font-family` naming a non-system face (e.g. Inter); `@font-face`.
+- Any off-theme color VALUE, in ANY syntax — a hex/rgb/hsl not in §1, a modern
+  color function (`oklch`/`lab`/`lch`/`hwb`/`color()`/`color-mix()`), or a named
+  CSS color — beyond white/black/transparent. Compose `var(--jd-*)` instead.
+- `font-family` naming a non-system face (e.g. Inter), including a `var(--x)`
+  indirection to a non-theme font; any `@font-face`.
+- Redefining a `--jd-*` theme token (only the theme layer owns them).
 - `@media (prefers-color-scheme)` or `color-scheme` (use `data-theme`).
-- External URLs (http/https, protocol-relative); load nothing over the network.
-- Color in an inline `style=` attribute; `!important` on color/font.
+- External URLs (http/https, protocol-relative, `@import "//…"`); load nothing
+  over the network.
+- Color in an inline `style=` attribute; `!important` on ANY declaration.
+
+The validator enforces COLOR, font-family, no-`!important`, no-`prefers-color-scheme`
+and the safety bans — it does NOT lint STRUCTURE. Spacing, the type scale and
+layout stay consistent through the winning component classes (in `@layer theme`)
+and the generation prompt, not a hard spacing rule.

--- a/jarvis/dashboards/themes/jarvis/theme.json
+++ b/jarvis/dashboards/themes/jarvis/theme.json
@@ -15,10 +15,10 @@
     "#a0693f"
   ],
   "semantic": {
-    "positive": "#4c9a7a",
-    "negative": "#c25d5d",
-    "warning": "#d9a53f",
-    "info": "#5d78d1"
+    "positive": "#3e7d63",
+    "negative": "#b25555",
+    "warning": "#8e6c29",
+    "info": "#556dbe"
   },
   "render_tokens": {
     "bg": "#f8f8f8",
@@ -26,13 +26,13 @@
     "surface-2": "#f2f2f2",
     "ink": "#383838",
     "heading": "#171717",
-    "muted": "#7c7c7c",
+    "muted": "#6e6e6e",
     "line": "#ededed",
     "accent": "#383838",
-    "positive": "#4c9a7a",
-    "negative": "#c25d5d",
-    "warning": "#d9a53f",
-    "info": "#5d78d1",
+    "positive": "#3e7d63",
+    "negative": "#b25555",
+    "warning": "#8e6c29",
+    "info": "#556dbe",
     "radius": "10px",
     "shadow": "0 1px 2px rgba(0,0,0,.05)",
     "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
@@ -56,6 +56,12 @@
       "weight": 600,
       "line_height": 1.3,
       "letter_spacing": "-0.005em"
+    },
+    "h3": {
+      "px": 15,
+      "weight": 600,
+      "line_height": 1.35,
+      "letter_spacing": "0"
     },
     "label": {
       "px": 13,
@@ -138,8 +144,12 @@
       "#f2f2f2",
       "#383838",
       "#171717",
-      "#7c7c7c",
+      "#6e6e6e",
       "#ededed",
+      "#3e7d63",
+      "#b25555",
+      "#8e6c29",
+      "#556dbe",
       "#4c9a7a",
       "#c25d5d",
       "#d9a53f",

--- a/jarvis/dashboards/themes/jarvis/theme.json
+++ b/jarvis/dashboards/themes/jarvis/theme.json
@@ -1,0 +1,163 @@
+{
+  "key": "jarvis",
+  "label": "Jarvis",
+  "schema_version": 1,
+  "dark": false,
+  "accent": "#383838",
+  "palette": [
+    "#383838",
+    "#5d78d1",
+    "#4c9a7a",
+    "#d9a53f",
+    "#c25d5d",
+    "#8a7bb8",
+    "#5a99ae",
+    "#a0693f"
+  ],
+  "semantic": {
+    "positive": "#4c9a7a",
+    "negative": "#c25d5d",
+    "warning": "#d9a53f",
+    "info": "#5d78d1"
+  },
+  "render_tokens": {
+    "bg": "#f8f8f8",
+    "surface": "#ffffff",
+    "surface-2": "#f2f2f2",
+    "ink": "#383838",
+    "heading": "#171717",
+    "muted": "#7c7c7c",
+    "line": "#ededed",
+    "accent": "#383838",
+    "positive": "#4c9a7a",
+    "negative": "#c25d5d",
+    "warning": "#d9a53f",
+    "info": "#5d78d1",
+    "radius": "10px",
+    "shadow": "0 1px 2px rgba(0,0,0,.05)",
+    "font": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif",
+    "font-display": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\"Helvetica Neue\",Arial,sans-serif"
+  },
+  "type_scale": {
+    "display": {
+      "px": 32,
+      "weight": 700,
+      "line_height": 1.15,
+      "letter_spacing": "-0.02em"
+    },
+    "h1": {
+      "px": 24,
+      "weight": 700,
+      "line_height": 1.2,
+      "letter_spacing": "-0.01em"
+    },
+    "h2": {
+      "px": 18,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "-0.005em"
+    },
+    "label": {
+      "px": 13,
+      "weight": 600,
+      "line_height": 1.3,
+      "letter_spacing": "0.01em"
+    },
+    "body": {
+      "px": 14,
+      "weight": 400,
+      "line_height": 1.5,
+      "letter_spacing": "0"
+    },
+    "caption": {
+      "px": 12,
+      "weight": 400,
+      "line_height": 1.4,
+      "letter_spacing": "0"
+    }
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "2xl": 32,
+    "3xl": 48
+  },
+  "radius": {
+    "sm": 6,
+    "md": 10,
+    "lg": 14,
+    "pill": 999
+  },
+  "border": {
+    "hairline": 1,
+    "medium": 2
+  },
+  "layout": {
+    "page_max_width": 1200,
+    "gutter": 24,
+    "kpi_columns": 4,
+    "kpi_min_px": 200,
+    "chart_columns": 2,
+    "chart_min_px": 320,
+    "breakpoints": {
+      "sm": 640,
+      "md": 768,
+      "lg": 1024,
+      "xl": 1280
+    }
+  },
+  "a11y": {
+    "text_contrast_min": 4.5,
+    "ui_contrast_min": 3.0
+  },
+  "component_classes": [
+    "jd-page",
+    "jd-page-header",
+    "jd-subtitle",
+    "jd-kpi-row",
+    "jd-kpi",
+    "jd-kpi-label",
+    "jd-kpi-value",
+    "jd-kpi-delta",
+    "jd-card",
+    "jd-chart-card",
+    "jd-card-header",
+    "jd-card-footnote",
+    "jd-chart-grid",
+    "jd-table",
+    "jd-empty",
+    "jd-error"
+  ],
+  "validator": {
+    "allowed_color_hexes": [
+      "#f8f8f8",
+      "#ffffff",
+      "#f2f2f2",
+      "#383838",
+      "#171717",
+      "#7c7c7c",
+      "#ededed",
+      "#4c9a7a",
+      "#c25d5d",
+      "#d9a53f",
+      "#5d78d1",
+      "#8a7bb8",
+      "#5a99ae",
+      "#a0693f"
+    ],
+    "allowed_font_families": [
+      "-apple-system",
+      "blinkmacsystemfont",
+      "segoe ui",
+      "roboto",
+      "helvetica neue",
+      "arial",
+      "sans-serif",
+      "system-ui",
+      "ui-sans-serif"
+    ]
+  }
+}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -523,3 +523,19 @@ has_permission.update({
 	"Jarvis Trigger": "jarvis.chat.trigger_permissions.has_trigger_permission",
 })
 
+# ---------------------------------------------------------------------------
+# Jarvis Dashboard scoping
+# ---------------------------------------------------------------------------
+# The doctype rows grant Jarvis User r/w/c/d broadly; these hooks scope reads
+# to the dashboard's audience (Org / Role / User / owner — blank scope is
+# PRIVATE) and deny writes/deletes to everyone but the owner and the admin
+# tier. The create-time scope-widening gate (plain users may not create
+# Org/Role dashboards) lives in the DocType controller — "create" reaches the
+# hook without a doc.
+permission_query_conditions.update({
+	"Jarvis Dashboard": "jarvis.chat.dashboard_permissions.dashboard_query_conditions",
+})
+has_permission.update({
+	"Jarvis Dashboard": "jarvis.chat.dashboard_permissions.has_dashboard_permission",
+})
+

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
@@ -1,0 +1,137 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-17 09:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "dashboard_title",
+  "description",
+  "dashboard_type",
+  "theme",
+  "scope",
+  "target_role",
+  "target_user",
+  "html",
+  "sources",
+  "source_conversation"
+ ],
+ "fields": [
+  {
+   "fieldname": "dashboard_title",
+   "fieldtype": "Data",
+   "label": "Dashboard Title",
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "Short name shown in the Dashboards list, e.g. 'Monthly Sales Overview'."
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description",
+   "description": "Optional one-line summary of what this dashboard shows."
+  },
+  {
+   "fieldname": "dashboard_type",
+   "fieldtype": "Select",
+   "label": "Dashboard Type",
+   "options": "Static\nConnected",
+   "default": "Static",
+   "in_standard_filter": 1,
+   "description": "Derived server-side: Connected when the dashboard declares data sources (live data at view time), Static otherwise. Never set directly."
+  },
+  {
+   "fieldname": "theme",
+   "fieldtype": "Select",
+   "label": "Theme",
+   "options": "Jarvis\nInsight\nClaude\nGraphite",
+   "default": "Jarvis",
+   "description": "Named render theme injected by the canvas shell as CSS variables. Jarvis = the app's own design language (default), Insight = Frappe-Insights-style light, Claude = warm ivory, Graphite = dark."
+  },
+  {
+   "fieldname": "scope",
+   "fieldtype": "Select",
+   "label": "Scope",
+   "options": "Org\nRole\nUser",
+   "reqd": 1,
+   "default": "User",
+   "in_standard_filter": 1,
+   "description": "Who can see this dashboard: everyone (Org), holders of a role (Role), or one user (User). Org/Role require the Jarvis Admin tier."
+  },
+  {
+   "fieldname": "target_role",
+   "fieldtype": "Link",
+   "options": "Role",
+   "label": "Target Role",
+   "depends_on": "eval:doc.scope=='Role'",
+   "mandatory_depends_on": "eval:doc.scope=='Role'",
+   "description": "Role whose holders can see this dashboard (Role scope only)."
+  },
+  {
+   "fieldname": "target_user",
+   "fieldtype": "Link",
+   "options": "User",
+   "label": "Target User",
+   "depends_on": "eval:doc.scope=='User'",
+   "description": "The single user this dashboard belongs to (User scope; defaults to the owner)."
+  },
+  {
+   "fieldname": "html",
+   "fieldtype": "Code",
+   "options": "HTML",
+   "label": "HTML",
+   "description": "The full self-contained HTML document the dashboard renders (no external resources; data via window.jarvis.data())."
+  },
+  {
+   "fieldname": "sources",
+   "fieldtype": "Table",
+   "options": "Jarvis Dashboard Source",
+   "label": "Data Sources",
+   "description": "Declared data sources served live at view time as the viewing user."
+  },
+  {
+   "fieldname": "source_conversation",
+   "fieldtype": "Data",
+   "label": "Source Conversation",
+   "hidden": 1,
+   "description": "Provenance: the Jarvis conversation id when this dashboard was created via chat."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-17 09:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Dashboard",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Jarvis Admin",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Jarvis User",
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "dashboard_title",
+ "track_changes": 1
+}

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.json
@@ -10,6 +10,7 @@
   "description",
   "dashboard_type",
   "theme",
+  "theme_schema_version",
   "scope",
   "target_role",
   "target_user",
@@ -45,9 +46,19 @@
    "fieldname": "theme",
    "fieldtype": "Select",
    "label": "Theme",
-   "options": "Jarvis\nInsight\nClaude\nGraphite",
+   "options": "Jarvis\nInsight\nClaude\nGraphite\nCustom",
    "default": "Jarvis",
-   "description": "Named render theme injected by the canvas shell as CSS variables. Jarvis = the app's own design language (default), Insight = Frappe-Insights-style light, Claude = warm ivory, Graphite = dark."
+   "description": "Named render theme injected by the canvas shell as CSS variables + component classes in a winning @layer. Jarvis = the app's own design language (default), Insight = Frappe-Insights-style light, Claude = warm ivory, Graphite = dark. Custom = bespoke escape hatch: the author's own design wins and the save-time theme lint relaxes its design rules (the safety bans stay)."
+  },
+  {
+   "fieldname": "theme_schema_version",
+   "fieldtype": "Int",
+   "label": "Theme Schema Version",
+   "default": "0",
+   "read_only": 1,
+   "hidden": 1,
+   "no_copy": 1,
+   "description": "Stamped by the save-time theme validator when the HTML passes (current: 1). 0/unset = legacy dashboard saved before the standard existed; grandfathered (never retro-enforced on read). Never set directly."
   },
   {
    "fieldname": "scope",

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -1,0 +1,154 @@
+"""Jarvis Dashboard DocType controller.
+
+A dashboard is one self-contained HTML document (``html``) plus zero or more
+declared data sources (``sources`` child rows). All user-facing validation
+lives here so it runs on every insert/save whether the write came from the SPA
+API (``jarvis.chat.dashboards_api``), the Desk, chat's doc tools, or a test —
+mirroring ``Jarvis Trigger``.
+
+Enforced here (NOT in the has_permission hook — "create" reaches the hook
+without a doc, so a scope gate there would be bypassable on insert):
+
+  * scope normalization + target field consistency (User -> target_user
+    defaults to the owner; Role -> target_role required; Org -> both cleared).
+  * SCOPE-WIDENING GATE: Org/Role scope needs the Jarvis Admin tier, and a
+    Role scope must target a role the author may manage
+    (``dashboard_permissions.manageable_roles``).
+  * caps: html size, source count, per-source spec size.
+  * per-source validation (name charset/uniqueness here; tool + spec shape via
+    ``dashboards_api._validate_source_row``).
+  * ``dashboard_type`` derivation: sources present -> Connected, else Static.
+
+Read/write visibility is the "grant + deny-hook" shape used by Jarvis Trigger:
+the doctype rows grant Jarvis User r/w/c/d broadly and
+``jarvis.chat.dashboard_permissions`` denies at the ORM (non-owner writes,
+out-of-scope reads).
+"""
+
+import re
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from jarvis.permissions import has_jarvis_admin_access
+
+MAX_TITLE_LEN = 140
+MAX_HTML_CHARS = 1_000_000
+MAX_SOURCES = 12
+MAX_SPEC_CHARS = 32_000
+
+_SCOPES = ("Org", "Role", "User")
+_THEMES = ("Jarvis", "Insight", "Claude", "Graphite")
+_SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class JarvisDashboard(Document):
+	def validate(self):
+		self._validate_title()
+		self._validate_theme()
+		self._validate_scope()
+		self._validate_caps()
+		self._validate_sources()
+		# Derived, never author-set: the html contract is "declared sources ->
+		# live data at view time", so the type simply reflects the sources table.
+		self.dashboard_type = "Connected" if (self.sources or []) else "Static"
+
+	# ------------------------------------------------------------------ #
+	# validate
+	# ------------------------------------------------------------------ #
+	def _validate_title(self):
+		self.dashboard_title = (self.dashboard_title or "").strip()
+		if not self.dashboard_title:
+			frappe.throw(_("Dashboard title is required."))
+		if len(self.dashboard_title) > MAX_TITLE_LEN:
+			frappe.throw(_("Dashboard title must be at most {0} characters.").format(MAX_TITLE_LEN))
+
+	def _validate_theme(self):
+		self.theme = (self.theme or "").strip() or "Jarvis"
+		if self.theme not in _THEMES:
+			frappe.throw(_("Theme must be one of {0}.").format(", ".join(_THEMES)))
+
+	def _validate_scope(self):
+		"""Scope normalization + the SCOPE-WIDENING GATE.
+
+		The gate must live here, not in the has_permission hook: "create" has
+		no doc when the hook runs, so a hook-side gate could never see the
+		scope being created. Runs as the SESSION user — exactly the actor
+		performing the write."""
+		self.scope = (self.scope or "").strip() or "User"
+		if self.scope not in _SCOPES:
+			frappe.throw(_("Scope must be one of Org, Role or User."))
+		if self.scope == "User":
+			self.target_role = None
+			# Pin to the owner — NEVER honor a client-supplied target_user. The SPA
+			# never sends it, but a direct REST/Desk write could otherwise set
+			# target_user to an arbitrary victim, pushing this dashboard into that
+			# user's visible list (visible_scope_condition matches target_user).
+			self.target_user = self.owner or frappe.session.user
+		elif self.scope == "Role":
+			self.target_user = None
+			if not self.target_role:
+				frappe.throw(_("Target role is required for a Role-scoped dashboard."))
+		else:  # Org
+			self.target_role = None
+			self.target_user = None
+
+		if self.scope in ("Org", "Role") and not has_jarvis_admin_access():
+			frappe.throw(
+				_(
+					"You need the Jarvis Admin or System Manager role to share a "
+					"dashboard org-wide or with a role."
+				),
+				frappe.PermissionError,
+			)
+		if self.scope == "Role":
+			from jarvis.chat.dashboard_permissions import manageable_roles
+
+			if self.target_role not in manageable_roles():
+				frappe.throw(
+					_("You cannot target the role '{0}' with a dashboard.").format(
+						self.target_role
+					)
+				)
+
+	def _validate_caps(self):
+		if len(self.html or "") > MAX_HTML_CHARS:
+			frappe.throw(
+				_("Dashboard HTML must be at most {0} characters.").format(MAX_HTML_CHARS)
+			)
+		if len(self.sources or []) > MAX_SOURCES:
+			frappe.throw(
+				_("A dashboard can declare at most {0} data sources.").format(MAX_SOURCES)
+			)
+
+	def _validate_sources(self):
+		"""Name charset + uniqueness here; tool/spec shape per row via the API
+		module's ``_validate_source_row`` (single source of truth shared with
+		``save_dashboard``). Lazy import — the API module imports nothing from
+		this controller, but keeping the import call-time avoids any future
+		module-load cycle."""
+		from jarvis.chat.dashboards_api import _validate_source_row
+
+		seen: set = set()
+		for row in self.sources or []:
+			row.source_name = (row.source_name or "").strip()
+			if not _SOURCE_NAME_RE.match(row.source_name):
+				frappe.throw(
+					_(
+						"Invalid source name '{0}': use 1-64 letters, digits, "
+						"underscores or hyphens."
+					).format(row.source_name)
+				)
+			if row.source_name in seen:
+				frappe.throw(_("Duplicate source name: {0}").format(row.source_name))
+			seen.add(row.source_name)
+			if len(row.spec or "") > MAX_SPEC_CHARS:
+				frappe.throw(
+					_("Source '{0}': spec must be at most {1} characters.").format(
+						row.source_name, MAX_SPEC_CHARS
+					)
+				)
+			_validate_source_row(
+				{"source_name": row.source_name, "tool": row.tool, "spec": row.spec}
+			)

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -40,9 +40,15 @@ MAX_SPEC_CHARS = 32_000
 
 _SCOPES = ("Org", "Role", "User")
 # "Custom" is the bespoke escape hatch: the save-time theme lint relaxes its
-# design rules (palette / font / spacing / light-dark) but keeps the safety bans.
+# design rules (palette / font / light-dark) but keeps the safety bans.
 _THEMES = ("Jarvis", "Insight", "Claude", "Graphite", "Custom")
 _SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class ThemeStandardError(frappe.ValidationError):
+	"""A save rejected because the canvas HTML does not follow the selected
+	theme. A distinct type so the builder can offer 'Ask the assistant to fix
+	these' (surfaced as ``exc_type`` to the SPA) rather than a dead-end error."""
 
 
 class JarvisDashboard(Document):
@@ -74,14 +80,17 @@ class JarvisDashboard(Document):
 
 	def _validate_theme_standard(self):
 		"""Deterministic theme-standard lint on the canvas HTML (colors/fonts/
-		light-dark bans + the always-on safety bans). Runs ONLY when the html is
-		new or changed, so a metadata-only edit to a legacy dashboard (rename,
-		re-scope, theme-picker switch) never re-validates its body — the
-		grandfather rule. On pass, stamp the schema version; docs saved before
-		this landed carry 0/None and are legacy (never retro-enforced on read).
-		No auto-repair: a rejected save surfaces the reasons and the builder's
-		chat loop regenerates."""
-		if not (self.is_new() or self.has_value_changed("html")):
+		light-dark bans + the always-on safety bans). Runs when the html OR the
+		theme changed (or on insert), so switching a saved dashboard's theme
+		re-lints it against the NEW palette — a doc that conformed under one
+		theme's literals must re-conform (via tokens or a re-gen) under the next
+		(F7 / the owner's exact complaint). A pure metadata edit that touches
+		NEITHER html nor theme (rename, re-scope) never re-validates the body —
+		the grandfather rule for legacy (unstamped) docs. On pass, stamp the
+		schema version; docs saved before this landed carry 0/None and are legacy
+		(never retro-enforced on read). No auto-repair: a rejected save surfaces
+		the reasons and the builder's chat loop regenerates."""
+		if not (self.is_new() or self.has_value_changed("html") or self.has_value_changed("theme")):
 			return
 		from jarvis.dashboards.theme_validator import (
 			THEME_SCHEMA_VERSION,
@@ -96,6 +105,7 @@ class JarvisDashboard(Document):
 					"This dashboard's HTML does not follow the selected theme "
 					"('{0}'). Fix these, then regenerate:\n{1}"
 				).format(self.theme or "Jarvis", format_violations(violations)),
+				ThemeStandardError,
 				title=_("Dashboard does not match its theme"),
 			)
 		self.theme_schema_version = THEME_SCHEMA_VERSION

--- a/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard/jarvis_dashboard.py
@@ -39,7 +39,9 @@ MAX_SOURCES = 12
 MAX_SPEC_CHARS = 32_000
 
 _SCOPES = ("Org", "Role", "User")
-_THEMES = ("Jarvis", "Insight", "Claude", "Graphite")
+# "Custom" is the bespoke escape hatch: the save-time theme lint relaxes its
+# design rules (palette / font / spacing / light-dark) but keeps the safety bans.
+_THEMES = ("Jarvis", "Insight", "Claude", "Graphite", "Custom")
 _SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
@@ -50,6 +52,7 @@ class JarvisDashboard(Document):
 		self._validate_scope()
 		self._validate_caps()
 		self._validate_sources()
+		self._validate_theme_standard()
 		# Derived, never author-set: the html contract is "declared sources ->
 		# live data at view time", so the type simply reflects the sources table.
 		self.dashboard_type = "Connected" if (self.sources or []) else "Static"
@@ -68,6 +71,34 @@ class JarvisDashboard(Document):
 		self.theme = (self.theme or "").strip() or "Jarvis"
 		if self.theme not in _THEMES:
 			frappe.throw(_("Theme must be one of {0}.").format(", ".join(_THEMES)))
+
+	def _validate_theme_standard(self):
+		"""Deterministic theme-standard lint on the canvas HTML (colors/fonts/
+		light-dark bans + the always-on safety bans). Runs ONLY when the html is
+		new or changed, so a metadata-only edit to a legacy dashboard (rename,
+		re-scope, theme-picker switch) never re-validates its body — the
+		grandfather rule. On pass, stamp the schema version; docs saved before
+		this landed carry 0/None and are legacy (never retro-enforced on read).
+		No auto-repair: a rejected save surfaces the reasons and the builder's
+		chat loop regenerates."""
+		if not (self.is_new() or self.has_value_changed("html")):
+			return
+		from jarvis.dashboards.theme_validator import (
+			THEME_SCHEMA_VERSION,
+			format_violations,
+			validate_dashboard_html,
+		)
+
+		violations = validate_dashboard_html(self.html or "", self.theme or "Jarvis")
+		if violations:
+			frappe.throw(
+				_(
+					"This dashboard's HTML does not follow the selected theme "
+					"('{0}'). Fix these, then regenerate:\n{1}"
+				).format(self.theme or "Jarvis", format_violations(violations)),
+				title=_("Dashboard does not match its theme"),
+			)
+		self.theme_schema_version = THEME_SCHEMA_VERSION
 
 	def _validate_scope(self):
 		"""Scope normalization + the SCOPE-WIDENING GATE.

--- a/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.json
+++ b/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.json
@@ -1,0 +1,41 @@
+{
+ "doctype": "DocType",
+ "name": "Jarvis Dashboard Source",
+ "module": "Jarvis",
+ "istable": 1,
+ "custom": 0,
+ "engine": "InnoDB",
+ "field_order": [
+  "source_name",
+  "tool",
+  "spec"
+ ],
+ "fields": [
+  {
+   "fieldname": "source_name",
+   "fieldtype": "Data",
+   "label": "Source Name",
+   "reqd": 1,
+   "in_list_view": 1,
+   "description": "Identifier the dashboard HTML uses to request this source's rows (window.jarvis.data(name)). Letters, digits, _ and - only."
+  },
+  {
+   "fieldname": "tool",
+   "fieldtype": "Select",
+   "label": "Tool",
+   "reqd": 1,
+   "in_list_view": 1,
+   "options": "query\nrun_report\nget_list",
+   "description": "Which read tool serves this source at view time (always as the viewing user)."
+  },
+  {
+   "fieldname": "spec",
+   "fieldtype": "Code",
+   "options": "JSON",
+   "label": "Spec",
+   "reqd": 1,
+   "description": "JSON spec for the tool: a structured query spec, {doctype, fields, filters, ...} for get_list, or {report_name, filters} for run_report."
+  }
+ ],
+ "permissions": []
+}

--- a/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.py
+++ b/jarvis/jarvis/doctype/jarvis_dashboard_source/jarvis_dashboard_source.py
@@ -1,0 +1,10 @@
+"""Jarvis Dashboard Source — child row of Jarvis Dashboard (one declared data
+source: name + tool + JSON spec). Validation lives in the parent controller so
+every row is checked in dashboard context (caps, name uniqueness, per-tool spec
+shape)."""
+
+from frappe.model.document import Document
+
+
+class JarvisDashboardSource(Document):
+	pass

--- a/jarvis/tests/test_canvas_embeds.py
+++ b/jarvis/tests/test_canvas_embeds.py
@@ -1,0 +1,95 @@
+"""Hosted-embed marker support in the chat canvas pipeline.
+
+openclaw 2026.6+ teaches the model to publish rich HTML as hosted canvas
+documents referenced by ``[embed ref="<id>" /]`` markers (or an explicit
+``/__openclaw__/canvas/...`` url). These must resolve to the same gateway
+fetch path as plain ``canvas/<path>.<ext>`` references, and the markers must
+be stripped from the visible reply once the artifact is persisted.
+"""
+
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.canvas import detect_canvas_names, strip_canvas_refs
+
+
+class TestCanvasEmbedDetection(FrappeTestCase):
+	def test_embed_ref_maps_to_document_path(self):
+		text = 'Done.\n\n[embed ref="sales-dash-abc123" title="Sales" height="720" /]'
+		self.assertEqual(
+			detect_canvas_names(text), ["documents/sales-dash-abc123/index.html"]
+		)
+
+	def test_embed_url_form_detected_via_canvas_path(self):
+		text = '[embed url="/__openclaw__/canvas/documents/cv_9/index.html" title="X" /]'
+		self.assertEqual(detect_canvas_names(text), ["documents/cv_9/index.html"])
+
+	def test_plain_canvas_path_still_detected_and_deduped(self):
+		text = (
+			"See canvas/charts/foo.html and again canvas/charts/foo.html plus "
+			'[embed ref="bar" /]'
+		)
+		self.assertEqual(
+			detect_canvas_names(text),
+			["charts/foo.html", "documents/bar/index.html"],
+		)
+
+	def test_single_quoted_ref(self):
+		self.assertEqual(
+			detect_canvas_names("[embed ref='q-1' /]"),
+			["documents/q-1/index.html"],
+		)
+
+	def test_cap_still_applies(self):
+		text = "\n".join(f'[embed ref="d{i}" /]' for i in range(12))
+		self.assertEqual(len(detect_canvas_names(text)), 8)
+
+
+class TestCanvasEmbedStripping(FrappeTestCase):
+	def test_persisted_ref_marker_removed(self):
+		text = 'Built it.\n\n[embed ref="sales-1" title="Sales" height="720" /]'
+		out = strip_canvas_refs(text, ["documents/sales-1/index.html"])
+		self.assertEqual(out, "Built it.")
+
+	def test_unpersisted_marker_kept(self):
+		text = 'Built it. [embed ref="other" /]'
+		out = strip_canvas_refs(text, ["documents/sales-1/index.html"])
+		self.assertIn('[embed ref="other" /]', out)
+
+	def test_url_form_marker_removed_without_residue(self):
+		text = 'Done [embed url="/__openclaw__/canvas/documents/cv_9/index.html" title="X" /] end'
+		out = strip_canvas_refs(text, ["documents/cv_9/index.html"])
+		self.assertNotIn("[embed", out)
+		self.assertNotIn("cv_9", out)
+		self.assertIn("Done", out)
+		self.assertIn("end", out)
+
+	def test_plain_path_strip_unchanged(self):
+		text = "Chart at canvas/charts/foo.html for you"
+		out = strip_canvas_refs(text, ["charts/foo.html"])
+		self.assertNotIn("canvas/", out)
+
+
+class TestHostClientStripping(FrappeTestCase):
+	def test_host_socket_script_removed_others_kept(self):
+		from jarvis.chat.canvas import _strip_host_client
+
+		html = (
+			"<html><body><script>renderChart()</script>"
+			'<script>\nconst ws = new WebSocket("ws://" + location.host + "/__openclaw__/ws");\n</script>'
+			"</body></html>"
+		)
+		out = _strip_host_client(html)
+		self.assertIn("renderChart()", out)
+		self.assertNotIn("__openclaw__/ws", out)
+		self.assertNotIn("WebSocket", out)
+
+
+class TestCanvasPathTraversal(FrappeTestCase):
+	def test_dotdot_traversal_rejected(self):
+		self.assertEqual(detect_canvas_names("see canvas/../../etc/passwd.html now"), [])
+
+	def test_dotdot_mid_path_rejected(self):
+		self.assertEqual(detect_canvas_names("canvas/charts/../../secret.html"), [])
+
+	def test_legit_subdir_still_ok(self):
+		self.assertEqual(detect_canvas_names("canvas/charts/sales.html"), ["charts/sales.html"])

--- a/jarvis/tests/test_dashboard_permissions.py
+++ b/jarvis/tests/test_dashboard_permissions.py
@@ -1,0 +1,318 @@
+"""Tests for jarvis.chat.dashboard_permissions + the Jarvis Dashboard
+controller's scope gate.
+
+Fixture users: a Jarvis Admin, two plain jarvis users, one plain user holding
+a custom test role, plus Administrator as the SM tier. Hermetic: every
+dashboard created here is tracked and deleted in tearDown.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.dashboard_permissions import (
+	can_edit_dashboard,
+	can_read_dashboard,
+	creatable_scopes,
+	has_dashboard_permission,
+	manageable_roles,
+)
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.permissions import (
+	JARVIS_ADMIN_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_jarvis_admin_role,
+	ensure_jarvis_user_role,
+)
+from jarvis.tools.get_doc import get_doc as tool_get_doc
+
+DASHBOARD = "Jarvis Dashboard"
+
+ADMIN_USER = "jarvis-dash-admin@example.com"
+PLAIN_A = "jarvis-dash-user-a@example.com"
+PLAIN_B = "jarvis-dash-user-b@example.com"
+ROLE_USER = "jarvis-dash-roleholder@example.com"
+CUSTOM_ROLE = "Jarvis Dash Test Role"
+
+
+def _ensure_user(email: str, roles: list[str]) -> None:
+	"""Create the fixture user if missing; idempotent."""
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": "Dash",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	doc.add_roles(*roles)
+	frappe.db.commit()
+
+
+def _ensure_custom_role() -> None:
+	if not frappe.db.exists("Role", CUSTOM_ROLE):
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": CUSTOM_ROLE,
+			"desk_access": 1,
+			"is_custom": 1,
+		}).insert(ignore_permissions=True)
+
+
+class _DashboardPermTestCase(FrappeTestCase):
+	def setUp(self):
+		ensure_jarvis_user_role()
+		ensure_jarvis_admin_role()
+		_ensure_custom_role()
+		_ensure_user(ADMIN_USER, [JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE, CUSTOM_ROLE])
+		_ensure_user(PLAIN_A, [JARVIS_USER_ROLE])
+		_ensure_user(PLAIN_B, [JARVIS_USER_ROLE])
+		_ensure_user(ROLE_USER, [JARVIS_USER_ROLE, CUSTOM_ROLE])
+		self._orig_user = frappe.session.user
+		self._dashboards: list[str] = []
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+		for name in self._dashboards:
+			if frappe.db.exists(DASHBOARD, name):
+				frappe.delete_doc(DASHBOARD, name, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def _mk(self, scope: str = "User", owner: str | None = None, **kw) -> str:
+		"""Create a dashboard as Administrator (passes every gate); optionally
+		force the owner afterwards (set_user_and_timestamp always stamps the
+		session user on insert, so a foreign owner can only be simulated with a
+		direct db write — validate is not the subject there)."""
+		prev = frappe.session.user
+		frappe.set_user("Administrator")
+		try:
+			doc = frappe.get_doc({
+				"doctype": DASHBOARD,
+				"dashboard_title": kw.pop(
+					"dashboard_title", f"perm-{frappe.generate_hash(length=8)}"
+				),
+				"scope": scope,
+				"html": "<h1>t</h1>",
+				**kw,
+			}).insert()
+			self._dashboards.append(doc.name)
+			if owner:
+				frappe.db.set_value(
+					DASHBOARD, doc.name, "owner", owner, update_modified=False
+				)
+			frappe.db.commit()
+			return doc.name
+		finally:
+			frappe.set_user(prev)
+
+	def _doc(self, name: str):
+		return frappe.get_doc(DASHBOARD, name)
+
+	def _visible_names(self, user: str, names: list[str]) -> set:
+		frappe.set_user(user)
+		rows = frappe.get_list(
+			DASHBOARD, filters={"name": ["in", names]}, pluck="name"
+		)
+		return set(rows)
+
+
+class TestReadMatrix(_DashboardPermTestCase):
+	def test_org_visible_to_all_jarvis_users(self):
+		name = self._mk("Org")
+		doc = self._doc(name)
+		for user in (PLAIN_A, PLAIN_B, ROLE_USER, ADMIN_USER):
+			self.assertTrue(can_read_dashboard(doc, user), user)
+
+	def test_role_visible_only_to_role_holder_and_admins(self):
+		name = self._mk("Role", target_role=CUSTOM_ROLE)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, ROLE_USER))
+		self.assertTrue(can_read_dashboard(doc, ADMIN_USER))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_A))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+
+	def test_user_scope_visible_only_to_target_and_admins(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))
+		self.assertTrue(can_read_dashboard(doc, ADMIN_USER))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+		self.assertFalse(can_read_dashboard(doc, ROLE_USER))
+
+	def test_owner_reads_own_role_scoped_without_holding_role(self):
+		# PLAIN_A does NOT hold CUSTOM_ROLE but owns the dashboard.
+		name = self._mk("Role", target_role=CUSTOM_ROLE, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))
+		self.assertIn(name, self._visible_names(PLAIN_A, [name]))
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+
+	def test_blank_scope_is_private_not_org(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		# Simulate a row that lost its scope (validate would never produce it).
+		frappe.db.set_value(DASHBOARD, name, "scope", "", update_modified=False)
+		frappe.db.commit()
+		doc = self._doc(name)
+		self.assertTrue(can_read_dashboard(doc, PLAIN_A))  # owner + target_user
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))
+		self.assertFalse(can_read_dashboard(doc, ROLE_USER))
+		self.assertNotIn(name, self._visible_names(PLAIN_B, [name]))
+
+	def test_sm_reads_all(self):
+		names = [
+			self._mk("Org"),
+			self._mk("Role", target_role=CUSTOM_ROLE),
+			self._mk("User", target_user=PLAIN_A, owner=PLAIN_A),
+		]
+		for n in names:
+			self.assertTrue(can_read_dashboard(self._doc(n), "Administrator"))
+		self.assertEqual(self._visible_names("Administrator", names), set(names))
+
+	def test_get_list_hook_parity(self):
+		org = self._mk("Org")
+		role = self._mk("Role", target_role=CUSTOM_ROLE)
+		private_a = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		names = [org, role, private_a]
+		self.assertEqual(self._visible_names(PLAIN_A, names), {org, private_a})
+		self.assertEqual(self._visible_names(ROLE_USER, names), {org, role})
+		self.assertEqual(self._visible_names(PLAIN_B, names), {org})
+		self.assertEqual(self._visible_names(ADMIN_USER, names), set(names))
+
+
+class TestWriteMatrix(_DashboardPermTestCase):
+	def test_write_matrix(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertTrue(can_edit_dashboard(doc, PLAIN_A))
+		self.assertFalse(can_edit_dashboard(doc, PLAIN_B))
+		self.assertTrue(can_edit_dashboard(doc, ADMIN_USER))
+		# ORM enforcement: a non-owner write is denied by the hook.
+		frappe.set_user(PLAIN_B)
+		foreign = frappe.get_doc(DASHBOARD, name)
+		foreign.description = "hijack"
+		self.assertRaises(frappe.PermissionError, foreign.save)
+		# The owner's write goes through.
+		frappe.set_user(PLAIN_A)
+		mine = frappe.get_doc(DASHBOARD, name)
+		mine.description = "mine"
+		mine.save()
+		self.assertEqual(
+			frappe.db.get_value(DASHBOARD, name, "description"), "mine"
+		)
+
+	def test_delete_matrix(self):
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		doc = self._doc(name)
+		self.assertFalse(has_dashboard_permission(doc, "delete", PLAIN_B))
+		self.assertTrue(has_dashboard_permission(doc, "delete", PLAIN_A))
+		self.assertTrue(has_dashboard_permission(doc, "delete", ADMIN_USER))
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, frappe.delete_doc, DASHBOARD, name)
+		frappe.set_user(PLAIN_A)
+		frappe.delete_doc(DASHBOARD, name)
+		self.assertFalse(frappe.db.exists(DASHBOARD, name))
+
+	def test_tool_get_doc_denied_on_private_dashboard(self):
+		# The chat-referral path: another user asking the agent to open a
+		# private dashboard must hit the permission wall in jarvis.tools.
+		name = self._mk("User", target_user=PLAIN_A, owner=PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(
+			PermissionDeniedError, tool_get_doc, DASHBOARD, name
+		)
+		frappe.clear_messages()
+
+
+class TestScopeHelpers(_DashboardPermTestCase):
+	def test_creatable_scopes_matrix(self):
+		self.assertEqual(creatable_scopes(PLAIN_A), ["User"])
+		self.assertEqual(creatable_scopes(ADMIN_USER), ["Org", "Role", "User"])
+		self.assertEqual(creatable_scopes("Administrator"), ["Org", "Role", "User"])
+
+	def test_manageable_roles(self):
+		sm_roles = manageable_roles("Administrator")
+		self.assertIn(CUSTOM_ROLE, sm_roles)
+		for blocked in ("System Manager", "All", "Guest", JARVIS_USER_ROLE, JARVIS_ADMIN_ROLE):
+			self.assertNotIn(blocked, sm_roles)
+		admin_roles = manageable_roles(ADMIN_USER)
+		self.assertIn(CUSTOM_ROLE, admin_roles)
+		self.assertNotIn(JARVIS_ADMIN_ROLE, admin_roles)
+		self.assertNotIn(JARVIS_USER_ROLE, admin_roles)
+		self.assertEqual(manageable_roles(PLAIN_A), [])
+
+
+class TestControllerScopeGate(_DashboardPermTestCase):
+	def test_plain_user_cannot_create_org_dashboard(self):
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Org",
+			"html": "<h1>x</h1>",
+		})
+		self.assertRaises(frappe.PermissionError, doc.insert)
+
+	def test_plain_user_cannot_widen_own_to_role(self):
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "User",
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		doc.scope = "Role"
+		doc.target_role = CUSTOM_ROLE
+		self.assertRaises(frappe.PermissionError, doc.save)
+
+	def test_admin_role_scope_with_untargetable_role_throws(self):
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Role",
+			"target_role": "System Manager",  # exists, but never targetable
+			"html": "<h1>x</h1>",
+		})
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_user_scope_autofill_and_scope_switch_clears_counterpart(self):
+		frappe.set_user(ADMIN_USER)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"gate-{frappe.generate_hash(length=8)}",
+			"scope": "Role",
+			"target_role": CUSTOM_ROLE,
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		self.assertFalse(doc.target_user)
+		doc.scope = "User"
+		doc.save()
+		self.assertEqual(doc.target_user, ADMIN_USER)  # auto-filled from owner
+		self.assertFalse(doc.target_role)  # cleared on the switch
+		doc.scope = "Org"
+		doc.save()
+		self.assertFalse(doc.target_user)
+		self.assertFalse(doc.target_role)
+
+	def test_user_scope_pins_target_user_to_owner_ignoring_client_value(self):
+		"""A direct REST/Desk write cannot push a User-scoped dashboard into an
+		arbitrary victim's list — target_user is always forced to the owner."""
+		frappe.set_user(PLAIN_A)
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"pin-{frappe.generate_hash(length=8)}",
+			"scope": "User",
+			# attacker-supplied victim — must be ignored
+			"target_user": PLAIN_B,
+			"html": "<h1>x</h1>",
+		}).insert()
+		self._dashboards.append(doc.name)
+		self.assertEqual(doc.target_user, PLAIN_A)  # pinned to owner, not PLAIN_B
+		# and it is NOT visible to the intended victim
+		from jarvis.chat.dashboard_permissions import can_read_dashboard
+
+		self.assertFalse(can_read_dashboard(doc, PLAIN_B))

--- a/jarvis/tests/test_dashboard_theme_contrast.py
+++ b/jarvis/tests/test_dashboard_theme_contrast.py
@@ -1,0 +1,84 @@
+"""WCAG contrast tests for the curated dashboard themes.
+
+Pure + frappe-free (reads the canonical ``theme.json`` render tokens via
+``theme_spec``), so it runs standalone with
+``python -m unittest jarvis.tests.test_dashboard_theme_contrast`` and guards the
+a11y floor the specs themselves claim (``a11y.text_contrast_min`` 4.5:1 text /
+``ui_contrast_min`` 3:1). It asserts the ACTUAL fg/bg token pair of every text
+recipe the injected stylesheet composes (``dashboardThemes.js`` BASE / the skill
+cheatsheet), so a token value can never regress below the floor unnoticed.
+"""
+
+import unittest
+
+from jarvis.dashboards import theme_spec
+
+CURATED = ("jarvis", "insight", "claude", "graphite")
+
+# Text color recipes the injected BASE stylesheet composes → (fg token, bg token).
+# Every one renders real body/label/status TEXT, so each must clear text_contrast_min.
+#   muted   → .jd-subtitle/.jd-kpi-label/.jd-card-footnote/.jd-empty/th (on bg,
+#             surface and the surface-2 table-header fill)
+#   positive/negative → .jd-kpi-delta.up/.down (on the surface card) + .jd-error
+#             (standalone → checked on bg too)
+#   warning/info → offered as semantic status tokens a model may color text with
+_TEXT_RECIPES = (
+	("ink", "bg"),
+	("ink", "surface"),
+	("heading", "bg"),
+	("heading", "surface"),
+	("muted", "bg"),
+	("muted", "surface"),
+	("muted", "surface-2"),
+	("positive", "surface"),
+	("positive", "bg"),
+	("negative", "surface"),
+	("negative", "bg"),
+	("warning", "surface"),
+	("warning", "bg"),
+	("info", "surface"),
+	("info", "bg"),
+)
+# UI/accent recipes → (fg token, bg token) at ui_contrast_min. The accent is a
+# surface-level accent/fill (chips, borders, chart series), not page-bg text.
+_UI_RECIPES = (("accent", "surface"),)
+
+
+def _lin(c: float) -> float:
+	c = c / 255.0
+	return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _lum(hexv: str) -> float:
+	h = hexv.lstrip("#")
+	r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+	return 0.2126 * _lin(r) + 0.7152 * _lin(g) + 0.0722 * _lin(b)
+
+
+def contrast_ratio(fg: str, bg: str) -> float:
+	hi, lo = max(_lum(fg), _lum(bg)), min(_lum(fg), _lum(bg))
+	return (hi + 0.05) / (lo + 0.05)
+
+
+class TestDashboardThemeContrast(unittest.TestCase):
+	def test_every_text_recipe_meets_aa(self):
+		for key in CURATED:
+			spec = theme_spec.load_theme(key)
+			self.assertIsNotNone(spec, f"{key}/theme.json must load")
+			tokens = spec["render_tokens"]
+			text_min = spec["a11y"]["text_contrast_min"]
+			ui_min = spec["a11y"]["ui_contrast_min"]
+			for fg, bg, mn, kind in [(f, b, text_min, "text") for f, b in _TEXT_RECIPES] + [
+				(f, b, ui_min, "ui") for f, b in _UI_RECIPES
+			]:
+				ratio = contrast_ratio(tokens[fg], tokens[bg])
+				self.assertGreaterEqual(
+					ratio,
+					mn,
+					f"{key}: --jd-{fg} ({tokens[fg]}) on --jd-{bg} ({tokens[bg]}) "
+					f"= {ratio:.2f}:1, below the {kind} floor {mn}:1",
+				)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_dashboard_theme_standard.py
+++ b/jarvis/tests/test_dashboard_theme_standard.py
@@ -12,6 +12,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.dashboards.theme_validator import THEME_SCHEMA_VERSION
+from jarvis.jarvis.doctype.jarvis_dashboard.jarvis_dashboard import ThemeStandardError
 
 DASHBOARD = "Jarvis Dashboard"
 
@@ -30,13 +31,15 @@ class TestDashboardThemeStandard(FrappeTestCase):
 		frappe.db.commit()
 
 	def _mk(self, html: str, theme: str = "Jarvis"):
-		doc = frappe.get_doc({
-			"doctype": DASHBOARD,
-			"dashboard_title": f"vt-{frappe.generate_hash(length=6)}",
-			"html": html,
-			"theme": theme,
-			"scope": "User",
-		})
+		doc = frappe.get_doc(
+			{
+				"doctype": DASHBOARD,
+				"dashboard_title": f"vt-{frappe.generate_hash(length=6)}",
+				"html": html,
+				"theme": theme,
+				"scope": "User",
+			}
+		)
 		return doc
 
 	def _insert(self, html: str, theme: str = "Jarvis"):
@@ -57,7 +60,8 @@ class TestDashboardThemeStandard(FrappeTestCase):
 	# ---- reject off-spec ---------------------------------------------------- #
 	def test_off_palette_color_rejected(self):
 		doc = self._mk("<style>.x{color:#0f172a}</style>")
-		with self.assertRaises(frappe.ValidationError):
+		# a distinct exc type so the SPA can offer "ask the assistant to fix these"
+		with self.assertRaises(ThemeStandardError):
 			doc.insert(ignore_permissions=True)
 
 	def test_hardcoded_font_rejected(self):
@@ -80,12 +84,41 @@ class TestDashboardThemeStandard(FrappeTestCase):
 		self.assertEqual(doc.theme_schema_version, THEME_SCHEMA_VERSION)
 
 	def test_custom_still_rejects_safety_bans(self):
-		font_face = self._mk("<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>", "Custom")
+		font_face = self._mk(
+			"<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>", "Custom"
+		)
 		with self.assertRaises(frappe.ValidationError):
 			font_face.insert(ignore_permissions=True)
 		external = self._mk('<img src="http://evil.example/x.png">', "Custom")
 		with self.assertRaises(frappe.ValidationError):
 			external.insert(ignore_permissions=True)
+
+	# ---- F7: theme-switch re-validates (the owner's exact complaint) --------- #
+	def test_theme_switch_revalidates_literal(self):
+		# Conforms under Jarvis via a literal Jarvis-palette hex (#5d78d1)...
+		doc = self._insert("<style>.k{color:#5d78d1}</style>", theme="Jarvis")
+		self.assertEqual(doc.theme_schema_version, THEME_SCHEMA_VERSION)
+		# ...switching to Insight (a metadata-only save, html unchanged) must
+		# RE-LINT and reject — #5d78d1 is off the Insight palette.
+		doc.theme = "Insight"
+		with self.assertRaises(ThemeStandardError):
+			doc.save(ignore_permissions=True)
+
+	def test_theme_switch_token_doc_reskins(self):
+		# A token-based doc re-skins cleanly on any theme switch (no literals).
+		doc = self._insert("<style>.k{color:var(--jd-ink)}</style>", theme="Jarvis")
+		doc.theme = "Insight"
+		doc.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value(DASHBOARD, doc.name, "theme"), "Insight")
+
+	def test_custom_to_curated_switch_revalidates(self):
+		# Sonnet P1-1: a Custom doc with hardcoded literals is stamped "current";
+		# flipping it to a curated theme must re-lint against that palette.
+		doc = self._insert("<style>.x{color:#0f172a}</style>", theme="Custom")
+		self.assertEqual(doc.theme_schema_version, THEME_SCHEMA_VERSION)
+		doc.theme = "Jarvis"
+		with self.assertRaises(ThemeStandardError):
+			doc.save(ignore_permissions=True)
 
 	# ---- grandfather (legacy, unstamped) ------------------------------------ #
 	def test_legacy_metadata_edit_is_grandfathered(self):
@@ -94,23 +127,23 @@ class TestDashboardThemeStandard(FrappeTestCase):
 		# be). A metadata-only edit (rename) must NOT re-validate the body.
 		doc = self._insert("<div>legacy</div>")
 		frappe.db.set_value(
-			DASHBOARD, doc.name,
+			DASHBOARD,
+			doc.name,
 			{"html": "<style>.x{color:#0f172a}</style>", "theme_schema_version": 0},
 			update_modified=False,
 		)
 		reloaded = frappe.get_doc(DASHBOARD, doc.name)
 		reloaded.dashboard_title = "renamed-legacy"
 		reloaded.save(ignore_permissions=True)  # html unchanged -> grandfathered
-		self.assertEqual(
-			frappe.db.get_value(DASHBOARD, doc.name, "dashboard_title"), "renamed-legacy"
-		)
+		self.assertEqual(frappe.db.get_value(DASHBOARD, doc.name, "dashboard_title"), "renamed-legacy")
 		# still legacy — a metadata edit does not stamp it.
 		self.assertEqual(frappe.db.get_value(DASHBOARD, doc.name, "theme_schema_version"), 0)
 
 	def test_editing_html_on_legacy_revalidates(self):
 		doc = self._insert("<div>legacy</div>")
 		frappe.db.set_value(
-			DASHBOARD, doc.name,
+			DASHBOARD,
+			doc.name,
 			{"html": "<div>legacy</div>", "theme_schema_version": 0},
 			update_modified=False,
 		)

--- a/jarvis/tests/test_dashboard_theme_standard.py
+++ b/jarvis/tests/test_dashboard_theme_standard.py
@@ -1,0 +1,120 @@
+"""Save-path tests for the dashboard theme standard: the controller runs the
+theme validator on every insert / html-changing save, stamps the schema version
+on pass, and grandfathers legacy (unstamped) docs on metadata-only edits.
+
+Needs the DB (DocType controller) so it is a FrappeTestCase — runs at assembly
+under bench, NOT from the worktree (the pure validator behavior is covered
+standalone in test_dashboard_theme_validator.py). Every dashboard created here is
+tracked and force-deleted in tearDown.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.dashboards.theme_validator import THEME_SCHEMA_VERSION
+
+DASHBOARD = "Jarvis Dashboard"
+
+
+class TestDashboardThemeStandard(FrappeTestCase):
+	def setUp(self):
+		self._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		self._dashboards: list[str] = []
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+		for name in self._dashboards:
+			if frappe.db.exists(DASHBOARD, name):
+				frappe.delete_doc(DASHBOARD, name, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def _mk(self, html: str, theme: str = "Jarvis"):
+		doc = frappe.get_doc({
+			"doctype": DASHBOARD,
+			"dashboard_title": f"vt-{frappe.generate_hash(length=6)}",
+			"html": html,
+			"theme": theme,
+			"scope": "User",
+		})
+		return doc
+
+	def _insert(self, html: str, theme: str = "Jarvis"):
+		doc = self._mk(html, theme)
+		doc.insert(ignore_permissions=True)
+		self._dashboards.append(doc.name)
+		return doc
+
+	# ---- conforming + stamp ------------------------------------------------- #
+	def test_conforming_saves_and_is_stamped(self):
+		doc = self._insert('<div class="jd-card">ok</div><style>.jd-card{color:var(--jd-ink)}</style>')
+		self.assertEqual(doc.theme_schema_version, THEME_SCHEMA_VERSION)
+		self.assertEqual(
+			frappe.db.get_value(DASHBOARD, doc.name, "theme_schema_version"),
+			THEME_SCHEMA_VERSION,
+		)
+
+	# ---- reject off-spec ---------------------------------------------------- #
+	def test_off_palette_color_rejected(self):
+		doc = self._mk("<style>.x{color:#0f172a}</style>")
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_hardcoded_font_rejected(self):
+		doc = self._mk("<style>body{font-family:Inter,sans-serif}</style>")
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	def test_prefers_color_scheme_rejected(self):
+		doc = self._mk("<style>@media (prefers-color-scheme: dark){body{color:var(--jd-ink)}}</style>")
+		with self.assertRaises(frappe.ValidationError):
+			doc.insert(ignore_permissions=True)
+
+	# ---- Custom escape hatch ------------------------------------------------ #
+	def test_custom_relaxes_design_rules(self):
+		# off-palette color + hardcoded font are OK under Custom (bespoke look).
+		doc = self._insert(
+			'<style>.x{color:#0f172a;font-family:Inter}</style><div class="x">y</div>',
+			theme="Custom",
+		)
+		self.assertEqual(doc.theme_schema_version, THEME_SCHEMA_VERSION)
+
+	def test_custom_still_rejects_safety_bans(self):
+		font_face = self._mk("<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>", "Custom")
+		with self.assertRaises(frappe.ValidationError):
+			font_face.insert(ignore_permissions=True)
+		external = self._mk('<img src="http://evil.example/x.png">', "Custom")
+		with self.assertRaises(frappe.ValidationError):
+			external.insert(ignore_permissions=True)
+
+	# ---- grandfather (legacy, unstamped) ------------------------------------ #
+	def test_legacy_metadata_edit_is_grandfathered(self):
+		# A conforming doc, then forced to a legacy state at the DB level: the html
+		# is non-conforming and the stamp is cleared (as a pre-standard row would
+		# be). A metadata-only edit (rename) must NOT re-validate the body.
+		doc = self._insert("<div>legacy</div>")
+		frappe.db.set_value(
+			DASHBOARD, doc.name,
+			{"html": "<style>.x{color:#0f172a}</style>", "theme_schema_version": 0},
+			update_modified=False,
+		)
+		reloaded = frappe.get_doc(DASHBOARD, doc.name)
+		reloaded.dashboard_title = "renamed-legacy"
+		reloaded.save(ignore_permissions=True)  # html unchanged -> grandfathered
+		self.assertEqual(
+			frappe.db.get_value(DASHBOARD, doc.name, "dashboard_title"), "renamed-legacy"
+		)
+		# still legacy — a metadata edit does not stamp it.
+		self.assertEqual(frappe.db.get_value(DASHBOARD, doc.name, "theme_schema_version"), 0)
+
+	def test_editing_html_on_legacy_revalidates(self):
+		doc = self._insert("<div>legacy</div>")
+		frappe.db.set_value(
+			DASHBOARD, doc.name,
+			{"html": "<div>legacy</div>", "theme_schema_version": 0},
+			update_modified=False,
+		)
+		reloaded = frappe.get_doc(DASHBOARD, doc.name)
+		reloaded.html = "<style>.x{color:#0f172a}</style>"  # changing html -> re-validate
+		with self.assertRaises(frappe.ValidationError):
+			reloaded.save(ignore_permissions=True)

--- a/jarvis/tests/test_dashboard_theme_validator.py
+++ b/jarvis/tests/test_dashboard_theme_validator.py
@@ -393,5 +393,91 @@ class TestThemeValidatorCodexRound2(unittest.TestCase):
 		)
 
 
+class TestThemeValidatorCodexRound3(unittest.TestCase):
+	"""Round-3 regressions: scheme-first URL rejection (any separator count),
+	generic off-palette color LITERALS in properties the enumerated list forgot,
+	and CASE-SENSITIVE custom-property existence."""
+
+	# ---- DR3-2 single/zero-separator special-scheme URLs ------------------ #
+	def test_zero_and_one_separator_http_url_rejected(self):
+		# Browsers resolve `http:evil` / `http:/evil` / `http:\evil` (and https) to
+		# an external authority — the ban must not require `//`. Checked under Custom
+		# (the safety bans still apply there) across src, url() and @import.
+		for html in (
+			'<img src="http:/evil.example/x.png">',
+			'<img src="http:evil.example/x.png">',
+			'<img src="http:\\evil.example/x.png">',
+			'<img src="https:/evil.example/x.png">',
+			'<style>.x{background:url("http:/evil.example/x.png")}</style>',
+			'<style>.x{background:url("http:evil.example/x.png")}</style>',
+			'<style>@import "http:/evil.example/x.css";</style>',
+			'<style>@import "https:evil.example/x.css";</style>',
+		):
+			self.assertEqual(codes(html, "Custom"), [RULE_EXTERNAL_URL], html)
+
+	def test_scheme_first_keeps_xml_namespace_and_relative_ok(self):
+		# the exact SVG/xlink namespaces and non-http(s) refs still pass.
+		self.assertEqual(
+			codes('<svg xmlns="http://www.w3.org/2000/svg"><rect fill="var(--jd-accent)"/></svg>'), []
+		)
+		self.assertEqual(codes("<style>.x{background:url(data:image/png;base64,AA)}</style>"), [])
+		self.assertEqual(codes('<style>.x{background:url("#grad")}</style>'), [])
+
+	# ---- DR3-3 color literals in properties beyond the enumerated list ----- #
+	def test_system_color_in_filter_rejected(self):
+		self.assertEqual(
+			codes("<style>.k{filter:drop-shadow(0 0 4px Highlight)}</style>"), [RULE_OFF_PALETTE]
+		)
+		self.assertEqual(
+			codes("<style>.k{backdrop-filter:drop-shadow(0 0 4px CanvasText)}</style>"), [RULE_OFF_PALETTE]
+		)
+
+	def test_off_palette_color_in_border_image_rejected(self):
+		self.assertEqual(
+			codes("<style>.k{border-image:linear-gradient(45deg,red,#0f172a) 30}</style>"), [RULE_OFF_PALETTE]
+		)
+		self.assertEqual(
+			codes("<style>.k{border-image-source:linear-gradient(Highlight,red)}</style>"), [RULE_OFF_PALETTE]
+		)
+
+	def test_generic_literal_scan_catches_uncovered_property(self):
+		# durability: a hex literal in a property NOT in the enumerated color list
+		# is still caught by the generic literal sweep.
+		self.assertEqual(
+			codes("<style>.k{-webkit-box-reflect:below 0 linear-gradient(transparent,#ff0000)}</style>"),
+			[RULE_OFF_PALETTE],
+		)
+
+	def test_generic_scan_does_not_false_positive_on_custom_idents(self):
+		# color-WORD idents double as custom-idents / keywords in these properties;
+		# the generic sweep must NOT flag them, nor a var() to an author custom prop.
+		for html in (
+			"<style>.k{transition-property:background}</style>",
+			"<style>.k{transition:background .2s}</style>",
+			"<style>.k{animation-name:red}</style>",
+			"<style>.k{will-change:background}</style>",
+			"<style>.k{padding:var(--gap)}</style>",
+			"<style>.k{--gap:16px;padding:var(--gap)}</style>",
+			"<style>.k{filter:blur(4px)}</style>",
+		):
+			self.assertEqual(codes(html), [], html)
+
+	# ---- DR3-4 CASE-SENSITIVE custom-property existence ------------------- #
+	def test_mismatched_case_jd_var_rejected(self):
+		# CSS custom-property names are case-sensitive; `var(--JD-INK)` is unset in
+		# the browser, so it must NOT be accepted as if `--jd-ink` existed.
+		self.assertEqual(codes("<style>.x{color:var(--JD-INK)}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes("<style>.x{color:var(--Jd-Ink)}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes('<div style="color:var(--JD-INK)">x</div>'), [RULE_INLINE_COLOR])
+
+	def test_mismatched_case_font_var_rejected(self):
+		self.assertEqual(codes("<style>body{font-family:var(--JD-FONT)}</style>"), [RULE_FONT_FAMILY])
+		self.assertEqual(codes("<style>body{font-family:var(--Jd-Font-Display)}</style>"), [RULE_FONT_FAMILY])
+
+	def test_exact_case_jd_var_still_passes(self):
+		self.assertEqual(codes("<style>.x{color:var(--jd-ink)}</style>"), [])
+		self.assertEqual(codes("<style>body{font-family:var(--jd-font)}</style>"), [])
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/jarvis/tests/test_dashboard_theme_validator.py
+++ b/jarvis/tests/test_dashboard_theme_validator.py
@@ -1,0 +1,127 @@
+"""Pure unit tests for jarvis.dashboards.theme_validator.
+
+Frappe-free by design (the validator imports nothing from frappe), so this runs
+standalone with ``python -m unittest jarvis.tests.test_dashboard_theme_validator``
+from the app root as well as under bench. The save-path / grandfather behavior
+that needs the DocType controller lives in test_dashboard_theme_standard.py.
+"""
+
+import unittest
+
+from jarvis.dashboards.theme_validator import (
+	RULE_COLOR_SCHEME,
+	RULE_EXTERNAL_URL,
+	RULE_FONT_FACE,
+	RULE_FONT_FAMILY,
+	RULE_IMPORTANT,
+	RULE_INLINE_COLOR,
+	RULE_OFF_PALETTE,
+	RULE_PREFERS_SCHEME,
+	validate_dashboard_html,
+)
+
+
+def codes(html, theme="Jarvis"):
+	return sorted({v.rule for v in validate_dashboard_html(html, theme)})
+
+
+class TestThemeValidatorConforming(unittest.TestCase):
+	def test_token_based_dashboard_passes(self):
+		html = (
+			'<style>.jd-card{background:var(--jd-surface);color:var(--jd-ink);'
+			"border:1px solid var(--jd-line)}</style>"
+			'<div class="jd-card">x</div>'
+		)
+		self.assertEqual(validate_dashboard_html(html, "Jarvis"), [])
+
+	def test_theme_own_hex_literal_allowed(self):
+		# The ruling permits the theme's own hexes as literals (var() preferred).
+		self.assertEqual(codes("<style>.x{color:#383838}</style>", "Jarvis"), [])
+
+	def test_approved_neutrals_allowed(self):
+		html = "<style>.x{color:white;background:transparent;box-shadow:0 1px 2px rgba(0,0,0,.1)}</style>"
+		self.assertEqual(codes(html), [])
+
+	def test_system_font_and_var_font_allowed(self):
+		self.assertEqual(codes('<style>body{font-family:var(--jd-font)}</style>'), [])
+		self.assertEqual(
+			codes('<style>body{font-family:-apple-system,"Segoe UI",Roboto,sans-serif}</style>'),
+			[],
+		)
+
+	def test_claude_serif_allowed_only_on_claude(self):
+		serif = '<style>h1{font-family:Georgia,"Times New Roman",serif}</style>'
+		self.assertEqual(codes(serif, "Claude"), [])
+		self.assertEqual(codes(serif, "Jarvis"), [RULE_FONT_FAMILY])
+
+	def test_svg_xmlns_not_flagged_as_external(self):
+		html = '<svg xmlns="http://www.w3.org/2000/svg"><rect fill="var(--jd-accent)"/></svg>'
+		self.assertEqual(codes(html), [])
+
+
+class TestThemeValidatorRejects(unittest.TestCase):
+	def test_off_palette_hex(self):
+		vs = validate_dashboard_html("<style>.x{color:#0f172a}</style>", "Jarvis")
+		self.assertEqual([v.rule for v in vs], [RULE_OFF_PALETTE])
+		self.assertEqual(vs[0].offending, "#0f172a")
+
+	def test_off_palette_rgb_and_named(self):
+		self.assertEqual(codes("<style>.x{color:rgb(255,0,0)}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes("<style>.x{background:tomato}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes("<style>.x{color:gray}</style>"), [RULE_OFF_PALETTE])
+
+	def test_font_family_override(self):
+		vs = validate_dashboard_html("<style>body{font-family:Inter,sans-serif}</style>", "Jarvis")
+		self.assertEqual([v.rule for v in vs], [RULE_FONT_FAMILY])
+		self.assertEqual(vs[0].offending, "inter")
+
+	def test_prefers_color_scheme(self):
+		self.assertIn(
+			RULE_PREFERS_SCHEME,
+			codes("<style>@media (prefers-color-scheme: dark){body{color:var(--jd-ink)}}</style>"),
+		)
+
+	def test_color_scheme_property(self):
+		self.assertEqual(codes("<style>:root{color-scheme:light dark}</style>"), [RULE_COLOR_SCHEME])
+
+	def test_font_face_is_safety_ban(self):
+		self.assertEqual(codes("<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>"), [RULE_FONT_FACE])
+
+	def test_external_http_and_protocol_relative(self):
+		self.assertEqual(codes('<img src="http://evil.example/x.png">'), [RULE_EXTERNAL_URL])
+		self.assertEqual(codes('<script src="//cdn.example/x.js"></script>'), [RULE_EXTERNAL_URL])
+
+	def test_inline_style_off_palette_color(self):
+		vs = validate_dashboard_html('<div style="color:#ff0000">x</div>', "Jarvis")
+		self.assertEqual([v.rule for v in vs], [RULE_INLINE_COLOR])
+		self.assertEqual(vs[0].offending, "#ff0000")
+
+	def test_inline_token_and_layout_ok(self):
+		self.assertEqual(codes('<div style="color:var(--jd-accent);width:50%">x</div>'), [])
+		self.assertEqual(codes('<div style="width:50%;padding:8px">x</div>'), [])
+
+	def test_important_on_color_only(self):
+		self.assertEqual(codes("<style>.x{color:var(--jd-accent) !important}</style>"), [RULE_IMPORTANT])
+		self.assertEqual(codes("<style>.x{width:50% !important}</style>"), [])
+
+	def test_structured_violation_shape(self):
+		v = validate_dashboard_html("<style>.x{color:#0f172a}</style>", "Jarvis")[0]
+		d = v.as_dict()
+		self.assertEqual(set(d), {"rule", "location", "offending", "message"})
+		self.assertEqual(d["rule"], RULE_OFF_PALETTE)
+		self.assertEqual(d["location"], "<style>")
+		self.assertEqual(d["offending"], "#0f172a")
+
+
+class TestThemeValidatorCustom(unittest.TestCase):
+	def test_custom_relaxes_design_rules(self):
+		html = '<style>.x{color:#0f172a;font-family:Inter}</style><div style="color:red">y</div>'
+		self.assertEqual(validate_dashboard_html(html, "Custom"), [])
+
+	def test_custom_keeps_safety_bans(self):
+		html = '<style>@font-face{font-family:X}</style><img src="http://x.example/y.png">'
+		self.assertEqual(codes(html, "Custom"), [RULE_EXTERNAL_URL, RULE_FONT_FACE])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/jarvis/tests/test_dashboard_theme_validator.py
+++ b/jarvis/tests/test_dashboard_theme_validator.py
@@ -302,5 +302,96 @@ class TestThemeValidatorCodexRound1(unittest.TestCase):
 		)
 
 
+class TestThemeValidatorCodexRound2(unittest.TestCase):
+	"""Round-2 canonicalization regressions: token EXISTENCE + var() fallbacks,
+	CSS system colors, and browser URL preprocessing (control chars / special-
+	scheme backslashes) — the surfaces beyond raw tokenization."""
+
+	# ---- DR2-1 var() token-existence + fallback validation ---------------- #
+	def test_nonexistent_jd_token_with_fallback_rejected(self):
+		# `--jd-nonexistent` is NOT a render token; the browser renders the #ff0000
+		# fallback. Caught block-level AND inline.
+		self.assertEqual(codes("<style>.x{color:var(--jd-nonexistent,#ff0000)}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(
+			codes('<div style="color:var(--jd-nonexistent,#ff0000)">x</div>'), [RULE_INLINE_COLOR]
+		)
+
+	def test_existing_jd_token_no_fallback_passes(self):
+		self.assertEqual(codes("<style>.x{color:var(--jd-ink)}</style>"), [])
+
+	def test_existing_jd_token_bad_fallback_rejected(self):
+		# the token exists, but a bad fallback (`red`) would still render.
+		self.assertEqual(codes("<style>.x{color:var(--jd-ink, red)}</style>"), [RULE_OFF_PALETTE])
+		# a system-color fallback is caught too.
+		self.assertEqual(codes("<style>.x{color:var(--jd-ink, Highlight)}</style>"), [RULE_OFF_PALETTE])
+
+	def test_existing_jd_token_good_fallback_passes(self):
+		# an approved-hex, benign-keyword, or nested-token fallback is fine.
+		self.assertEqual(codes("<style>.x{color:var(--jd-ink, #383838)}</style>"), [])
+		self.assertEqual(codes("<style>.x{color:var(--jd-line, currentColor)}</style>"), [])
+		self.assertEqual(codes("<style>.x{color:var(--jd-accent, var(--jd-ink))}</style>"), [])
+
+	def test_font_var_token_existence_and_fallback(self):
+		# non-existent font token → rejected.
+		self.assertEqual(codes("<style>body{font-family:var(--jd-nonexistent)}</style>"), [RULE_FONT_FAMILY])
+		# a non-font --jd token in a font-family is not a font token → rejected.
+		self.assertEqual(codes("<style>body{font-family:var(--jd-ink)}</style>"), [RULE_FONT_FAMILY])
+		# existing font token, bad fallback face → rejected.
+		self.assertEqual(
+			codes('<style>body{font-family:var(--jd-font, "Comic Sans MS")}</style>'), [RULE_FONT_FAMILY]
+		)
+		# existing font token, generic / nested-token fallback → passes.
+		self.assertEqual(codes("<style>body{font-family:var(--jd-font, sans-serif)}</style>"), [])
+		self.assertEqual(codes("<style>body{font-family:var(--jd-font, var(--jd-font-display))}</style>"), [])
+
+	# ---- DR2-3 CSS system colors ------------------------------------------ #
+	def test_system_colors_rejected(self):
+		for css in (
+			"<style>.k{color:Highlight}</style>",
+			"<style>.k{color:CanvasText}</style>",
+			"<style>.k{background:AccentColor}</style>",
+			"<style>.k{color:ButtonText}</style>",
+			"<style>.k{color:WindowText}</style>",  # deprecated set
+		):
+			self.assertEqual(codes(css), [RULE_OFF_PALETTE], css)
+
+	def test_benign_keywords_still_pass(self):
+		self.assertEqual(codes("<style>.k{color:currentColor;background:transparent}</style>"), [])
+		self.assertEqual(codes("<style>.k{color:inherit}</style>"), [])
+		# a non-color ident in a color-bearing shorthand is not flagged as a color.
+		self.assertEqual(codes("<style>.k{border:1px solid var(--jd-line)}</style>"), [])
+
+	# ---- DR2-4 URL control-char / backslash canonicalization -------------- #
+	def test_control_char_split_url_rejected_under_custom(self):
+		# src attribute (entity-decoded): https:/<TAB>/evil → https://evil
+		self.assertEqual(codes('<img src="https:/&#x09;/evil.example/x.png">', "Custom"), [RULE_EXTERNAL_URL])
+		# url() in an inline style (attribute is entity-decoded)
+		self.assertEqual(
+			codes("<div style=\"background:url('https:/&#x09;/evil.example/x.png')\">x</div>", "Custom"),
+			[RULE_EXTERNAL_URL],
+		)
+		# url() in a <style> block via a CSS escape (\9 = TAB; raw text isn't
+		# entity-decoded, but tinycss2 decodes the CSS escape).
+		self.assertEqual(
+			codes('<style>.x{background:url("https:/\\9 /evil.example/x.png")}</style>', "Custom"),
+			[RULE_EXTERNAL_URL],
+		)
+		# @import via a CSS escape.
+		self.assertEqual(
+			codes('<style>@import "https:/\\9 /evil.example/x.css";</style>', "Custom"), [RULE_EXTERNAL_URL]
+		)
+
+	def test_special_scheme_backslash_rejected_under_custom(self):
+		# browsers fold `\` to `/` for special schemes: https:\\evil → https://evil
+		self.assertEqual(codes('<img src="https:\\\\evil.example/x.png">', "Custom"), [RULE_EXTERNAL_URL])
+
+	def test_canonicalization_keeps_xml_namespace_exempt(self):
+		# the exemption is applied to the canonical value — svg xmlns still passes.
+		self.assertEqual(
+			codes('<svg xmlns="http://www.w3.org/2000/svg"><rect fill="var(--jd-accent)"/></svg>', "Custom"),
+			[],
+		)
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/jarvis/tests/test_dashboard_theme_validator.py
+++ b/jarvis/tests/test_dashboard_theme_validator.py
@@ -15,8 +15,10 @@ from jarvis.dashboards.theme_validator import (
 	RULE_FONT_FAMILY,
 	RULE_IMPORTANT,
 	RULE_INLINE_COLOR,
+	RULE_MALFORMED,
 	RULE_OFF_PALETTE,
 	RULE_PREFERS_SCHEME,
+	RULE_TOKEN_REDEFINE,
 	validate_dashboard_html,
 )
 
@@ -28,7 +30,7 @@ def codes(html, theme="Jarvis"):
 class TestThemeValidatorConforming(unittest.TestCase):
 	def test_token_based_dashboard_passes(self):
 		html = (
-			'<style>.jd-card{background:var(--jd-surface);color:var(--jd-ink);'
+			"<style>.jd-card{background:var(--jd-surface);color:var(--jd-ink);"
 			"border:1px solid var(--jd-line)}</style>"
 			'<div class="jd-card">x</div>'
 		)
@@ -43,7 +45,7 @@ class TestThemeValidatorConforming(unittest.TestCase):
 		self.assertEqual(codes(html), [])
 
 	def test_system_font_and_var_font_allowed(self):
-		self.assertEqual(codes('<style>body{font-family:var(--jd-font)}</style>'), [])
+		self.assertEqual(codes("<style>body{font-family:var(--jd-font)}</style>"), [])
 		self.assertEqual(
 			codes('<style>body{font-family:-apple-system,"Segoe UI",Roboto,sans-serif}</style>'),
 			[],
@@ -85,7 +87,10 @@ class TestThemeValidatorRejects(unittest.TestCase):
 		self.assertEqual(codes("<style>:root{color-scheme:light dark}</style>"), [RULE_COLOR_SCHEME])
 
 	def test_font_face_is_safety_ban(self):
-		self.assertEqual(codes("<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>"), [RULE_FONT_FACE])
+		self.assertEqual(
+			codes("<style>@font-face{font-family:X;src:url(data:font/woff2;base64,AA)}</style>"),
+			[RULE_FONT_FACE],
+		)
 
 	def test_external_http_and_protocol_relative(self):
 		self.assertEqual(codes('<img src="http://evil.example/x.png">'), [RULE_EXTERNAL_URL])
@@ -100,9 +105,71 @@ class TestThemeValidatorRejects(unittest.TestCase):
 		self.assertEqual(codes('<div style="color:var(--jd-accent);width:50%">x</div>'), [])
 		self.assertEqual(codes('<div style="width:50%;padding:8px">x</div>'), [])
 
-	def test_important_on_color_only(self):
+	def test_important_banned_entirely(self):
+		# hardening: !important escapes the theme layer on ANY property, so it is
+		# banned outright — not just on color/font.
 		self.assertEqual(codes("<style>.x{color:var(--jd-accent) !important}</style>"), [RULE_IMPORTANT])
-		self.assertEqual(codes("<style>.x{width:50% !important}</style>"), [])
+		self.assertEqual(codes("<style>.x{width:50% !important}</style>"), [RULE_IMPORTANT])
+		self.assertEqual(codes("<style>.x{padding:80px !important}</style>"), [RULE_IMPORTANT])
+
+	# ---- F1: modern color functions in any syntax ------------------------- #
+	def test_modern_color_functions_rejected(self):
+		for css in (
+			"<style>.k{color:oklch(0.6 0.25 25)}</style>",
+			"<style>.k{color:oklab(0.5 0.1 0.1)}</style>",
+			"<style>.k{color:lab(50% 80 60)}</style>",
+			"<style>.k{color:lch(50% 80 60)}</style>",
+			"<style>.k{background:hwb(0 0% 0%)}</style>",
+			"<style>.k{color:color(display-p3 1 0 0)}</style>",
+			"<style>.k{color:color-mix(in srgb,red,blue)}</style>",
+		):
+			self.assertIn(RULE_OFF_PALETTE, codes(css), css)
+
+	def test_inline_modern_color_function_rejected(self):
+		self.assertEqual(codes('<div style="color:oklch(0.7 0.2 145)">x</div>'), [RULE_INLINE_COLOR])
+
+	# ---- F2: an unclosed <style> is scanned to EOF ------------------------ #
+	def test_unclosed_style_is_scanned(self):
+		# off-palette color + hardcoded font inside a <style> with no </style>.
+		vs = codes('<body><style>.k{color:#0f172a;font-family:"Comic Sans MS"}</body></html>')
+		self.assertIn(RULE_OFF_PALETTE, vs)
+		self.assertIn(RULE_FONT_FAMILY, vs)
+
+	def test_unclosed_style_conforming_still_passes(self):
+		self.assertEqual(codes("<body><style>.k{color:var(--jd-ink)}"), [])
+
+	# ---- hardening: --jd-* redefinition + !important remap ---------------- #
+	def test_token_redefinition_rejected(self):
+		self.assertIn(RULE_TOKEN_REDEFINE, codes("<style>:root{--jd-ink:#ffffff}</style>"))
+		# the F4 remap (approved-neutral value + !important) is caught by BOTH the
+		# token-redefinition ban and the blanket !important ban.
+		vs = codes("<style>:root{--jd-ink:#ffffff !important}</style>")
+		self.assertIn(RULE_TOKEN_REDEFINE, vs)
+		self.assertIn(RULE_IMPORTANT, vs)
+
+	def test_non_theme_custom_property_allowed(self):
+		# an author's OWN non-jd custom property is fine.
+		self.assertEqual(codes("<style>.x{--gap:16px;padding:var(--gap)}</style>"), [])
+
+	# ---- F5: named colors through extra color properties ------------------ #
+	def test_extra_color_props_named_color_rejected(self):
+		self.assertEqual(codes("<style>.k{-webkit-text-fill-color:red}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes("<style>.k{border-inline-color:crimson}</style>"), [RULE_OFF_PALETTE])
+		self.assertEqual(codes("<style>.k{scrollbar-color:red blue}</style>"), [RULE_OFF_PALETTE])
+
+	# ---- F6: font-family via var() indirection ---------------------------- #
+	def test_font_var_indirection_rejected(self):
+		self.assertEqual(
+			codes('<style>:root{--f:"Comic Sans MS"} .k{font-family:var(--f)}</style>'),
+			[RULE_FONT_FAMILY],
+		)
+
+	def test_theme_font_var_allowed(self):
+		self.assertEqual(codes("<style>body{font-family:var(--jd-font-display)}</style>"), [])
+
+	# ---- F8: protocol-relative @import ------------------------------------ #
+	def test_protocol_relative_import_rejected(self):
+		self.assertEqual(codes('<style>@import "//evil.example/x.css";</style>'), [RULE_EXTERNAL_URL])
 
 	def test_structured_violation_shape(self):
 		v = validate_dashboard_html("<style>.x{color:#0f172a}</style>", "Jarvis")[0]
@@ -115,12 +182,124 @@ class TestThemeValidatorRejects(unittest.TestCase):
 
 class TestThemeValidatorCustom(unittest.TestCase):
 	def test_custom_relaxes_design_rules(self):
-		html = '<style>.x{color:#0f172a;font-family:Inter}</style><div style="color:red">y</div>'
+		# off-palette hex + hardcoded font + inline color + a modern color function
+		# + !important are ALL fine under the bespoke Custom theme.
+		html = (
+			"<style>.x{color:oklch(0.6 0.25 25);font-family:Inter;padding:8px !important}"
+			':root{--jd-ink:#fff}</style><div style="color:red">y</div>'
+		)
 		self.assertEqual(validate_dashboard_html(html, "Custom"), [])
 
 	def test_custom_keeps_safety_bans(self):
 		html = '<style>@font-face{font-family:X}</style><img src="http://x.example/y.png">'
 		self.assertEqual(codes(html, "Custom"), [RULE_EXTERNAL_URL, RULE_FONT_FACE])
+
+	def test_custom_still_rejects_protocol_relative_import(self):
+		self.assertEqual(
+			codes('<style>@import "//evil.example/x.css";</style>', "Custom"), [RULE_EXTERNAL_URL]
+		)
+
+
+class TestThemeValidatorCodexRound1(unittest.TestCase):
+	"""Regressions for the parse-based rewrite: each Codex round-1 bypass now
+	behaves because the validator tokenizes/decodes CSS + HTML the way the browser
+	does, instead of matching raw spelling with regex."""
+
+	# ---- #1 var() color laundering ---------------------------------------- #
+	def test_non_jd_var_in_color_is_off_palette(self):
+		self.assertEqual(codes("<style>:root{--rogue:red}.x{color:var(--rogue)}</style>"), [RULE_OFF_PALETTE])
+
+	def test_non_jd_var_resolving_on_palette_still_off(self):
+		# var() in a color value is allowed ONLY to a --jd-* token, whatever it resolves to.
+		self.assertEqual(codes("<style>:root{--x:#383838}.k{color:var(--x)}</style>"), [RULE_OFF_PALETTE])
+
+	def test_inline_non_jd_var_off_palette(self):
+		self.assertEqual(codes('<div style="color:var(--rogue)">x</div>'), [RULE_INLINE_COLOR])
+
+	def test_jd_var_in_color_allowed(self):
+		self.assertEqual(codes("<style>.k{color:var(--jd-accent)}</style>"), [])
+		self.assertEqual(codes('<div style="color:var(--jd-ink)">x</div>'), [])
+
+	# ---- #2 CSS escapes decode -------------------------------------------- #
+	def test_escaped_modern_color_function_rejected(self):
+		# `o\6b lch(` decodes to oklch(
+		self.assertIn(RULE_OFF_PALETTE, codes("<style>.k{color:o\\6b lch(0.6 0.25 25)}</style>"))
+
+	def test_escaped_font_face_is_safety_ban(self):
+		# `@f\6f nt-face` decodes to @font-face — caught even under Custom.
+		self.assertIn(
+			RULE_FONT_FACE,
+			codes("<style>@f\\6f nt-face{src:url(data:font/woff2;base64,AA)}</style>", "Custom"),
+		)
+
+	# ---- #3 inline styles: full check set, incl. unquoted + entity -------- #
+	def test_inline_token_redefine_and_important(self):
+		vs = codes('<div style="--jd-ink:red;color:var(--jd-ink)!important">x</div>')
+		self.assertIn(RULE_TOKEN_REDEFINE, vs)
+		self.assertIn(RULE_IMPORTANT, vs)
+
+	def test_unquoted_inline_style_color_scanned(self):
+		self.assertEqual(codes("<div style=color:red>x</div>"), [RULE_INLINE_COLOR])
+
+	def test_entity_encoded_inline_color_scanned(self):
+		# `&#114;ed` decodes to `red` inside the style attribute (the browser decodes it).
+		self.assertEqual(codes('<div style="color:&#114;ed">x</div>'), [RULE_INLINE_COLOR])
+
+	# ---- #4 malformed / brace-unbalanced author CSS ----------------------- #
+	def test_stray_leading_brace_rejected(self):
+		# a `}` closes @layer author{} early → the rule would render UNLAYERED.
+		self.assertIn(RULE_MALFORMED, codes("<style>}.jd-card{color:var(--jd-negative)}</style>"))
+
+	def test_excess_trailing_brace_rejected(self):
+		self.assertIn(RULE_MALFORMED, codes("<style>.jd-card{color:var(--jd-ink)}}</style>"))
+
+	def test_wellformed_unclosed_style_is_not_malformed(self):
+		# an unclosed `{` stays contained inside the wrapper — not a brace escape.
+		self.assertNotIn(RULE_MALFORMED, codes("<body><style>.k{color:var(--jd-ink)}"))
+
+	def test_malformed_not_enforced_under_custom(self):
+		# Custom author CSS is never @layer-wrapped, so a stray } cannot escape a
+		# layer; the structural ban does not apply (design relaxed).
+		self.assertNotIn(RULE_MALFORMED, codes("<style>}.x{color:red}</style>", "Custom"))
+
+	# ---- #5 entity-encoded external URL + narrowed W3C exemption ---------- #
+	def test_entity_encoded_external_url_rejected(self):
+		# `https&#58;//` decodes to `https://` — caught even under Custom.
+		self.assertEqual(codes('<img src="https&#58;//evil/x.png">', "Custom"), [RULE_EXTERNAL_URL])
+
+	def test_w3org_non_svg_namespace_rejected(self):
+		# only the EXACT SVG/xlink namespace VALUES are exempt, not the w3.org host.
+		self.assertEqual(codes('<img src="https://www.w3.org/foo.png">'), [RULE_EXTERNAL_URL])
+
+	def test_svg_and_xlink_namespaces_allowed(self):
+		html = (
+			'<svg xmlns="http://www.w3.org/2000/svg" '
+			'xmlns:xlink="http://www.w3.org/1999/xlink"><rect fill="var(--jd-accent)"/></svg>'
+		)
+		self.assertEqual(codes(html), [])
+
+	# ---- #6 hash-like selector / string is NOT a color -------------------- #
+	def test_id_selector_hash_not_read_as_color(self):
+		self.assertEqual(codes("<style>#abc{color:var(--jd-ink)}</style>"), [])
+
+	def test_hash_in_string_content_not_read_as_color(self):
+		self.assertEqual(codes('<style>.x::before{content:"#0f172a"}</style>'), [])
+
+	def test_off_palette_hash_in_value_still_caught(self):
+		# the VALUE position is still inspected (only selectors/strings are exempt).
+		self.assertEqual(codes("<style>.x{color:#abcdef}</style>"), [RULE_OFF_PALETTE])
+
+	# ---- native CSS nesting: nested rule bodies are still scanned --------- #
+	def test_nested_off_palette_rejected(self):
+		self.assertEqual(
+			codes("<style>.a{color:var(--jd-ink);.b{color:#ff0000}}</style>"), [RULE_OFF_PALETTE]
+		)
+
+	def test_nested_tokens_and_id_selector_pass(self):
+		# a nested id selector (#card) is not read as a color; nested tokens pass.
+		self.assertEqual(
+			codes("<style>#card{color:var(--jd-ink);&:hover{color:var(--jd-accent)}}</style>"), []
+		)
 
 
 if __name__ == "__main__":

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -1,0 +1,719 @@
+"""Tests for jarvis.chat.dashboards_api - the SPA-facing Dashboards endpoints.
+
+Fixture users: a Jarvis Admin, two plain jarvis users, plus Administrator as
+the SM tier. A hermetic Query Report fixture (over ToDo) backs the run_report
+paths. Every dashboard / ToDo / conversation created here is tracked and
+deleted in tearDown; no LLM/network calls anywhere on these paths.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import search_workspace, send_message
+from jarvis.chat.dashboards_api import (
+	delete_dashboard,
+	get_dashboard,
+	get_dashboards_caps,
+	list_dashboards_page,
+	run_dashboard_source,
+	save_dashboard,
+)
+from jarvis.permissions import (
+	JARVIS_ADMIN_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_jarvis_admin_role,
+	ensure_jarvis_user_role,
+)
+
+DASHBOARD = "Jarvis Dashboard"
+
+ADMIN_USER = "jarvis-dashapi-admin@example.com"
+PLAIN_A = "jarvis-dashapi-user-a@example.com"
+PLAIN_B = "jarvis-dashapi-user-b@example.com"
+CUSTOM_ROLE = "Jarvis Dash Test Role"
+
+REPORT_NAME = "Jarvis Dash Test Report"
+PREPARED_REPORT_NAME = "Jarvis Dash Prepared Report"
+
+_GET_LIST_SPEC = {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}
+
+_HTML_WITH_BLOCK = (
+	'<div id="app"></div>\n'
+	'<script type="application/json" id="jarvis-sources">'
+	'{"sources": [{"source_name": "todos", "tool": "get_list", '
+	'"spec": {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}}]}'
+	"</script>"
+)
+
+
+def _ensure_user(email: str, roles: list[str]) -> None:
+	"""Create the fixture user if missing; idempotent."""
+	if not frappe.db.exists("User", email):
+		frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": "DashApi",
+			"last_name": "Test",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}).insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	doc.add_roles(*roles)
+	frappe.db.commit()
+
+
+def _ensure_custom_role() -> None:
+	if not frappe.db.exists("Role", CUSTOM_ROLE):
+		frappe.get_doc({
+			"doctype": "Role",
+			"role_name": CUSTOM_ROLE,
+			"desk_access": 1,
+			"is_custom": 1,
+		}).insert(ignore_permissions=True)
+
+
+def _ensure_report(name: str, prepared: int) -> None:
+	"""Hermetic Query Report over ToDo (is_standard No, runs inline unless
+	``prepared``). Idempotent; left in place across tests like the roles."""
+	if frappe.db.exists("Report", name):
+		return
+	frappe.get_doc({
+		"doctype": "Report",
+		"report_name": name,
+		"ref_doctype": "ToDo",
+		"report_type": "Query Report",
+		"is_standard": "No",
+		"query": "select name, description from `tabToDo` order by creation desc limit 5",
+		"prepared_report": prepared,
+		"disabled": 0,
+	}).insert(ignore_permissions=True)
+
+
+class _DashboardsApiTestCase(FrappeTestCase):
+	def setUp(self):
+		ensure_jarvis_user_role()
+		ensure_jarvis_admin_role()
+		_ensure_custom_role()
+		_ensure_user(ADMIN_USER, [JARVIS_ADMIN_ROLE, JARVIS_USER_ROLE, CUSTOM_ROLE])
+		_ensure_user(PLAIN_A, [JARVIS_USER_ROLE])
+		_ensure_user(PLAIN_B, [JARVIS_USER_ROLE])
+		_ensure_report(REPORT_NAME, prepared=0)
+		_ensure_report(PREPARED_REPORT_NAME, prepared=1)
+		frappe.db.commit()
+		self._orig_user = frappe.session.user
+		self._dashboards: list[str] = []
+		self._todos: list[str] = []
+		self._convs: list[str] = []
+
+	def tearDown(self):
+		frappe.set_user(self._orig_user)
+		for name in self._dashboards:
+			if frappe.db.exists(DASHBOARD, name):
+				frappe.delete_doc(DASHBOARD, name, ignore_permissions=True, force=True)
+		for name in self._todos:
+			if frappe.db.exists("ToDo", name):
+				frappe.delete_doc("ToDo", name, ignore_permissions=True, force=True)
+		for name in self._convs:
+			frappe.db.delete("Jarvis Chat Message", {"conversation": name})
+			if frappe.db.exists("Jarvis Conversation", name):
+				frappe.delete_doc(
+					"Jarvis Conversation", name, ignore_permissions=True, force=True
+				)
+		frappe.db.commit()
+
+	def _save(self, payload: dict) -> dict:
+		r = save_dashboard(frappe.as_json(payload))
+		self._dashboards.append(r["data"]["name"])
+		return r["data"]
+
+	def _mk_static(self, user: str, title: str | None = None, **extra) -> dict:
+		frappe.set_user(user)
+		return self._save({
+			"dashboard_title": title or f"dash-{frappe.generate_hash(length=8)}",
+			"html": "<h1>hello</h1>",
+			**extra,
+		})
+
+	def _mk_connected(self, user: str, sources: list, title: str | None = None) -> dict:
+		frappe.set_user(user)
+		return self._save({
+			"dashboard_title": title or f"dash-{frappe.generate_hash(length=8)}",
+			"html": "<h1>data</h1>",
+			"sources": sources,
+		})
+
+	def _mk_todo(self, user: str, description: str = "dash test todo") -> str:
+		todo = frappe.get_doc({
+			"doctype": "ToDo", "description": description, "allocated_to": user,
+		}).insert(ignore_permissions=True)
+		self._todos.append(todo.name)
+		frappe.db.commit()
+		return todo.name
+
+
+class TestCaps(_DashboardsApiTestCase):
+	def test_caps_shape_plain_vs_admin(self):
+		frappe.set_user(PLAIN_A)
+		data = get_dashboards_caps()["data"]
+		self.assertEqual(data["creatable_scopes"], ["User"])
+		self.assertEqual(data["manageable_roles"], [])
+		self.assertEqual(data["max_sources"], 12)
+		self.assertEqual(data["max_html_chars"], 1_000_000)
+		self.assertEqual(data["max_rows"], 2000)
+		self.assertIn(data["canvas_available"], (True, False))
+		frappe.set_user(ADMIN_USER)
+		data = get_dashboards_caps()["data"]
+		self.assertEqual(data["creatable_scopes"], ["Org", "Role", "User"])
+		self.assertIn(CUSTOM_ROLE, data["manageable_roles"])
+
+
+class TestDashboardList(_DashboardsApiTestCase):
+	def test_list_envelope_and_pagination(self):
+		prefix = f"page-{frappe.generate_hash(length=6)}"
+		for i in range(3):
+			self._mk_static(PLAIN_A, title=f"{prefix} {i}")
+		frappe.set_user(PLAIN_A)
+		page = list_dashboards_page(search=prefix, page_length=2)["data"]
+		self.assertEqual(page["total"], 3)
+		self.assertEqual(len(page["rows"]), 2)
+		self.assertTrue(page["has_more"])
+		self.assertEqual(page["start"], 0)
+		self.assertEqual(page["page_length"], 2)
+		page = list_dashboards_page(search=prefix, start=2, page_length=2)["data"]
+		self.assertEqual(len(page["rows"]), 1)
+		self.assertFalse(page["has_more"])
+
+	def test_search_by_title(self):
+		needle = f"needle-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{needle} sales")
+		self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		page = list_dashboards_page(search=needle)["data"]
+		self.assertEqual(page["total"], 1)
+		self.assertEqual(page["rows"][0]["dashboard_title"], f"{needle} sales")
+		self.assertIsInstance(page["rows"][0]["modified"], str)
+
+	def test_filters_scope_type_owner(self):
+		prefix = f"filt-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{prefix} mine")
+		self._mk_connected(
+			ADMIN_USER,
+			[{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}],
+			title=f"{prefix} connected",
+		)
+		frappe.set_user(ADMIN_USER)
+		page = list_dashboards_page(
+			search=prefix,
+			filters=frappe.as_json({"scope": "User", "owner": PLAIN_A}),
+		)["data"]
+		self.assertEqual([r["dashboard_title"] for r in page["rows"]], [f"{prefix} mine"])
+		page = list_dashboards_page(
+			search=prefix, filters=frappe.as_json({"dashboard_type": "Connected"})
+		)["data"]
+		self.assertEqual(
+			[r["dashboard_title"] for r in page["rows"]], [f"{prefix} connected"]
+		)
+		self.assertRaises(
+			frappe.ValidationError,
+			list_dashboards_page,
+			filters=frappe.as_json({"scope": "Bogus"}),
+		)
+
+	def test_unknown_filter_key_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			list_dashboards_page,
+			filters=frappe.as_json({"bogus": 1}),
+		)
+
+	def test_unknown_sort_field_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError, list_dashboards_page, sort_field="html"
+		)
+
+	def test_list_visibility_excludes_others_private(self):
+		prefix = f"vis-{frappe.generate_hash(length=6)}"
+		self._mk_static(PLAIN_A, title=f"{prefix} private")
+		frappe.set_user(PLAIN_B)
+		page = list_dashboards_page(search=prefix)["data"]
+		self.assertEqual(page["total"], 0)
+		self.assertEqual(page["rows"], [])
+		# The admin tier sees it (no visibility splice).
+		frappe.set_user(ADMIN_USER)
+		page = list_dashboards_page(search=prefix)["data"]
+		self.assertEqual(page["total"], 1)
+
+
+class TestDashboardDetail(_DashboardsApiTestCase):
+	def test_get_dashboard_detail(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		detail = get_dashboard(created["name"])["data"]
+		self.assertEqual(detail["name"], created["name"])
+		self.assertEqual(detail["dashboard_type"], "Connected")
+		self.assertEqual(detail["scope"], "User")
+		self.assertEqual(detail["target_user"], PLAIN_A)
+		self.assertEqual(detail["owner"], PLAIN_A)
+		self.assertEqual(detail["html"], "<h1>data</h1>")
+		self.assertEqual(len(detail["sources"]), 1)
+		self.assertEqual(detail["sources"][0]["source_name"], "todos")
+		self.assertEqual(detail["sources"][0]["tool"], "get_list")
+		self.assertEqual(frappe.parse_json(detail["sources"][0]["spec"]), _GET_LIST_SPEC)
+		self.assertIsInstance(detail["modified"], str)
+		self.assertTrue(detail["can_edit"])  # owner
+
+	def test_get_dashboard_denied_and_missing(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, get_dashboard, created["name"])
+		frappe.clear_messages()
+		self.assertRaises(frappe.DoesNotExistError, get_dashboard, "no-such-dash-zz")
+
+
+class TestSaveDashboard(_DashboardsApiTestCase):
+	def test_save_create_static_minimal(self):
+		data = self._mk_static(PLAIN_A)
+		self.assertEqual(data["dashboard_type"], "Static")
+		self.assertEqual(data["scope"], "User")
+		self.assertEqual(data["target_user"], PLAIN_A)  # auto-filled
+		self.assertEqual(data["owner"], PLAIN_A)
+		self.assertEqual(data["sources"], [])
+
+	def test_save_connected_explicit_sources_roundtrip(self):
+		data = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual(len(data["sources"]), 1)
+		self.assertIsInstance(data["sources"][0]["spec"], str)
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_save_parses_jarvis_sources_block_from_html(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"block-{frappe.generate_hash(length=8)}",
+			"html": _HTML_WITH_BLOCK,
+		})
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual([s["source_name"] for s in data["sources"]], ["todos"])
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_save_normalizes_llm_source_dialect(self):
+		"""LLM-authored blocks drift toward the tool-call surface: ``id`` for
+		source_name, a ``jarvis__`` tool prefix, ``args``/``args.spec`` for
+		spec. Save folds them into the canonical child-row shape."""
+		frappe.set_user(PLAIN_A)
+		html = (
+			'<script type="application/json" id="jarvis-sources">'
+			'{"sources": [{"id": "todos", "tool": "jarvis__get_list", "refresh": "view", '
+			'"args": {"spec": {"doctype": "ToDo", "fields": ["name", "description"], "limit": 10}}}]}'
+			"</script>"
+		)
+		data = self._save({
+			"dashboard_title": f"dialect-{frappe.generate_hash(length=8)}",
+			"html": html,
+		})
+		self.assertEqual(data["dashboard_type"], "Connected")
+		self.assertEqual([s["source_name"] for s in data["sources"]], ["todos"])
+		self.assertEqual(data["sources"][0]["tool"], "get_list")
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_unknown_payload_key_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({"dashboard_title": "x", "html": "<p>x</p>", "owner": "evil"}),
+		)
+
+	def test_bad_tool_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "run_sql", "spec": {}}],
+			}),
+		)
+
+	def test_non_json_spec_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "get_list", "spec": "{not json"}],
+			}),
+		)
+
+	def test_bad_query_spec_invalid_op_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "query",
+					"spec": {
+						"from": "ToDo",
+						"where": [{"field": "status", "op": "regexp", "value": "x"}],
+					},
+				}],
+			}),
+		)
+
+	def test_get_list_unknown_doctype_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "get_list",
+					"spec": {"doctype": "No Such Doctype Zzz"},
+				}],
+			}),
+		)
+
+	def test_run_report_unknown_report_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "run_report",
+					"spec": {"report_name": "No Such Report Zzz"},
+				}],
+			}),
+		)
+
+	def test_get_list_bad_order_by_throws(self):
+		"""order_by is passed straight to frappe.get_list; a non fieldname-token
+		value (injection attempt) must be rejected at save."""
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "get_list",
+					"spec": {"doctype": "ToDo", "order_by": "(select 1)"},
+				}],
+			}),
+		)
+
+	def test_get_list_good_order_by_saves(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"ob-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"sources": [{
+				"source_name": "s", "tool": "get_list",
+				"spec": {"doctype": "ToDo", "order_by": "modified desc"},
+			}],
+		})
+		self.assertEqual(data["sources"][0]["source_name"], "s")
+
+	def test_run_report_prepared_report_rejected(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{
+					"source_name": "s", "tool": "run_report",
+					"spec": {"report_name": PREPARED_REPORT_NAME},
+				}],
+			}),
+		)
+
+	def test_spec_over_32k_throws(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>",
+				"sources": [{"source_name": "s", "tool": "get_list", "spec": "x" * 33_000}],
+			}),
+		)
+
+	def test_more_than_12_sources_throws(self):
+		frappe.set_user(PLAIN_A)
+		sources = [
+			{"source_name": f"s{i}", "tool": "get_list", "spec": _GET_LIST_SPEC}
+			for i in range(13)
+		]
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json(
+				{"dashboard_title": "x", "html": "<p>x</p>", "sources": sources}
+			),
+		)
+
+	def test_duplicate_source_name_throws(self):
+		frappe.set_user(PLAIN_A)
+		sources = [
+			{"source_name": "dup", "tool": "get_list", "spec": _GET_LIST_SPEC},
+			{"source_name": "dup", "tool": "get_list", "spec": _GET_LIST_SPEC},
+		]
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json(
+				{"dashboard_title": "x", "html": "<p>x</p>", "sources": sources}
+			),
+		)
+
+	def test_update_by_non_owner_denied(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(
+			frappe.PermissionError,
+			save_dashboard,
+			frappe.as_json({"name": created["name"], "html": "<h1>hijack</h1>"}),
+		)
+
+	def test_owner_update_mutates_html(self):
+		created = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		updated = save_dashboard(
+			frappe.as_json({"name": created["name"], "html": "<h1>v2</h1>"})
+		)["data"]
+		self.assertEqual(updated["html"], "<h1>v2</h1>")
+		self.assertEqual(updated["name"], created["name"])
+
+	def test_delete_matrix(self):
+		mine = self._mk_static(PLAIN_A)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, delete_dashboard, mine["name"])
+		frappe.set_user(PLAIN_A)
+		r = delete_dashboard(mine["name"])
+		self.assertEqual(r["data"], {"deleted": mine["name"]})
+		self.assertFalse(frappe.db.exists(DASHBOARD, mine["name"]))
+		# A Jarvis Admin may delete someone else's.
+		other = self._mk_static(PLAIN_A)
+		frappe.set_user(ADMIN_USER)
+		self.assertTrue(delete_dashboard(other["name"])["ok"])
+		self.assertFalse(frappe.db.exists(DASHBOARD, other["name"]))
+
+
+class TestRunDashboardSource(_DashboardsApiTestCase):
+	def test_get_list_happy_path_envelope(self):
+		self._mk_todo(PLAIN_A)
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		r = run_dashboard_source(created["name"], "todos")
+		self.assertTrue(r["ok"])
+		data = r["data"]
+		self.assertEqual(data["source_name"], "todos")
+		self.assertEqual(data["tool"], "get_list")
+		self.assertIsInstance(data["rows"], list)
+		self.assertTrue(data["rows"])
+		self.assertFalse(data["truncated"])
+		self.assertIsInstance(data["took_ms"], int)
+		self.assertNotIn("columns", data)
+
+	def test_unknown_source_clean_error(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		r = run_dashboard_source(created["name"], "nope")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "InvalidArgumentError")
+		self.assertIn("nope", r["error"]["message"])
+
+	def test_dashboard_read_denied_error(self):
+		created = self._mk_connected(
+			PLAIN_A, [{"source_name": "todos", "tool": "get_list", "spec": _GET_LIST_SPEC}]
+		)
+		frappe.set_user(PLAIN_B)
+		frappe.clear_messages()
+		r = run_dashboard_source(created["name"], "todos")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "PermissionError")
+		self.assertFalse(getattr(frappe.local, "message_log", None))
+
+	def test_in_tool_permission_error_no_leak(self):
+		# Server Script is SM-only: the SAVE succeeds (the spec only checks the
+		# doctype exists) but the RUN, as the viewing user, must deny cleanly.
+		created = self._mk_connected(
+			PLAIN_A,
+			[{
+				"source_name": "scripts", "tool": "get_list",
+				"spec": {"doctype": "Server Script", "limit": 5},
+			}],
+		)
+		frappe.set_user(PLAIN_A)
+		frappe.clear_messages()
+		r = run_dashboard_source(created["name"], "scripts")
+		self.assertFalse(r["ok"])
+		self.assertEqual(r["error"]["code"], "PermissionError")
+		self.assertFalse(getattr(frappe.local, "message_log", None))
+
+	def test_run_report_happy_path_normalized(self):
+		self._mk_todo("Administrator")
+		frappe.set_user("Administrator")
+		created = self._save({
+			"dashboard_title": f"rep-{frappe.generate_hash(length=8)}",
+			"html": "<h1>report</h1>",
+			"sources": [{
+				"source_name": "rep", "tool": "run_report",
+				"spec": {"report_name": REPORT_NAME},
+			}],
+		})
+		r = run_dashboard_source(created["name"], "rep")
+		self.assertTrue(r["ok"])
+		data = r["data"]
+		self.assertEqual(data["tool"], "run_report")
+		self.assertIn("columns", data)
+		self.assertIsInstance(data["columns"], list)
+		self.assertIsInstance(data["rows"], list)
+		self.assertTrue(data["rows"])
+		self.assertIsInstance(data["took_ms"], int)
+
+	def test_truncation_cap(self):
+		self._mk_todo("Administrator", "truncate one")
+		self._mk_todo("Administrator", "truncate two")
+		frappe.set_user("Administrator")
+		created = self._save({
+			"dashboard_title": f"cap-{frappe.generate_hash(length=8)}",
+			"html": "<h1>cap</h1>",
+			"sources": [{
+				"source_name": "todos", "tool": "get_list",
+				"spec": {"doctype": "ToDo", "fields": ["name"], "limit": 100},
+			}],
+		})
+		with patch("jarvis.chat.dashboards_api.DASHBOARD_MAX_ROWS", 1):
+			r = run_dashboard_source(created["name"], "todos")
+		self.assertTrue(r["ok"])
+		self.assertEqual(len(r["data"]["rows"]), 1)
+		self.assertTrue(r["data"]["truncated"])
+
+	def test_response_never_contains_sql(self):
+		# Administrator: ToDo's core permission_query_conditions hook writes a
+		# literal `tabToDo`.allocated_to predicate that breaks under the query
+		# tool's FROM alias for non-admin users (a pre-existing query-tool
+		# limitation, surfaced as an InternalError envelope) — the sql-leak
+		# assertion needs a user whose run actually succeeds.
+		self._mk_todo("Administrator")
+		created = self._mk_connected(
+			"Administrator",
+			[{
+				"source_name": "q", "tool": "query",
+				"spec": {"from": "ToDo", "select": ["name"], "limit": 5},
+			}],
+		)
+		r = run_dashboard_source(created["name"], "q")
+		self.assertTrue(r["ok"])
+		self.assertNotIn("sql", r["data"])
+		self.assertNotIn('"sql"', frappe.as_json(r))
+
+
+class TestWorkspaceSearchAndContext(_DashboardsApiTestCase):
+	def test_search_workspace_dashboard_hit(self):
+		marker = f"zzdashfind{frappe.generate_hash(length=6)}"
+		mine = self._mk_static(PLAIN_A, title=f"{marker} alpha")
+		theirs = self._mk_static(PLAIN_B, title=f"{marker} secret")
+		frappe.set_user(PLAIN_A)
+		groups = search_workspace(search=marker)["groups"]
+		dash = next((g for g in groups if g["key"] == "dashboards"), None)
+		self.assertIsNotNone(dash)
+		self.assertEqual(dash["title"], "Dashboards")
+		names = [i["name"] for i in dash["items"]]
+		self.assertIn(f"dashboard::{mine['name']}", names)
+		self.assertNotIn(f"dashboard::{theirs['name']}", names)
+		item = next(i for i in dash["items"] if i["name"] == f"dashboard::{mine['name']}")
+		self.assertEqual(item["suffix"], "Dashboard")
+		self.assertEqual(item["spa_route"], f"/dashboards/{mine['name']}")
+		self.assertNotIn("route", item)
+
+	def test_send_message_context_dashboards_allowlist(self):
+		frappe.set_user(PLAIN_A)
+		conv = frappe.get_doc({
+			"doctype": "Jarvis Conversation", "title": "dash ctx test",
+		}).insert(ignore_permissions=True)
+		self._convs.append(conv.name)
+		with patch("jarvis.chat.api.validate_can_send", return_value=(True, "")), \
+		     patch("jarvis.chat.api._dispatch_turn") as disp:
+			r = send_message(
+				conv.name, "build me a dashboard",
+				context=frappe.as_json({"page": "dashboards"}),
+			)
+			self.assertTrue(r["ok"])
+			kwargs = disp.call_args[0][0]
+			self.assertEqual(kwargs["context"]["page"], "dashboards")
+			# A page value outside the allow-list forwards NO context at all.
+			r2 = send_message(
+				conv.name, "hello again",
+				context=frappe.as_json({"page": "evil"}),
+			)
+			self.assertTrue(r2["ok"])
+			self.assertNotIn("context", disp.call_args[0][0])
+			# Explicit data-mode toggle: the two literal values forward; junk
+			# does not.
+			r3 = send_message(
+				conv.name, "make it live",
+				context=frappe.as_json({"page": "dashboards", "data_mode": "live"}),
+			)
+			self.assertTrue(r3["ok"])
+			self.assertEqual(disp.call_args[0][0]["context"]["data_mode"], "live")
+			r4 = send_message(
+				conv.name, "make it weird",
+				context=frappe.as_json({"page": "dashboards", "data_mode": "weird"}),
+			)
+			self.assertTrue(r4["ok"])
+			self.assertNotIn("data_mode", disp.call_args[0][0]["context"])
+
+	def test_save_unwraps_double_nested_spec(self):
+		"""The LLM sometimes wraps the tool's kwargs shape into spec
+		({"spec": {"spec": {...}}}); save folds it to the bare argument value."""
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"nest-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"sources": [{
+				"source_name": "todos", "tool": "get_list",
+				"spec": {"spec": dict(_GET_LIST_SPEC)},
+			}],
+		})
+		self.assertEqual(frappe.parse_json(data["sources"][0]["spec"]), _GET_LIST_SPEC)
+
+	def test_theme_roundtrip_and_validation(self):
+		frappe.set_user(PLAIN_A)
+		data = self._save({
+			"dashboard_title": f"theme-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+			"theme": "Claude",
+		})
+		self.assertEqual(data["theme"], "Claude")
+		# omitted -> the Jarvis design-language default
+		data2 = self._save({
+			"dashboard_title": f"theme-{frappe.generate_hash(length=8)}",
+			"html": "<p>x</p>",
+		})
+		self.assertEqual(data2["theme"], "Jarvis")
+		# invalid value throws
+		self.assertRaises(
+			frappe.ValidationError,
+			save_dashboard,
+			frappe.as_json({
+				"dashboard_title": "x", "html": "<p>x</p>", "theme": "Neon",
+			}),
+		)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ dependencies = [
     # PDF -> image rasterization for native LLM vision (jarvis/chat/vision.py).
     # Permissive license only: pypdfium2 (Apache/BSD), NOT PyMuPDF (AGPL).
     "pypdfium2>=4",
+    # Browser-accurate CSS/HTML parsing for the dashboard theme-conformance
+    # validator (jarvis/dashboards/theme_validator.py). A regex over untrusted
+    # canvas CSS/HTML is bypassable (escapes/entities/nesting); the validator must
+    # tokenize the way the browser does. tinycss2 + lxml are transitively present,
+    # but html5lib has no other requirer, so pin all three explicitly for the FC image.
+    "tinycss2>=1.1",
+    "html5lib>=1.1",
 ]
 
 [build-system]


### PR DESCRIPTION
Every dashboard theme now has a canonical `theme.json` + `design.md`, and the AI-generated HTML canvas is **enforced** to follow the selected theme: a winning `@layer` composition, the theme injected into generation, and a **parser-based validator** (tinycss2 + html5lib) that rejects off-spec CSS. `Custom` theme is the explicit opt-out (relaxes design, keeps the safety bans). CSP + sandbox byte-identical (the exfil-P0 boundary untouched); existing dashboards grandfathered.

**Doctrine closure:** Opus build → Sonnet UX + Opus adversarial panel (which *executed* the validator and found the whole regex-vs-tokenizer bypass class) → **3 clean Codex adversarial rounds** (var-laundering, escapes, entity URLs, system colors, case-sensitivity — all fixed + Fable-verified via a first-hand attack matrix). Round 4 hit Codex's cybersecurity filter (it refuses to reason about bypasses over our own validator code); I investigated the hinted residual myself.

**Cap-out:** the client hand-scanner has a possible subtle tokenizer edge — **visual-conformance only, fully CSP-contained** (no exfil/XSS), never produced by the generator. Definitive fix (server-side html5lib wrap) filed as **#427**; PR opened with-caution. Paired with the persona PR for the generation-side SKILL change.

**Assembly:** validator 70 + contrast 1 + save-path 11 tests **OK**; html5lib/tinycss2 import confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)