### PR TITLE
Fix: two users enabling one agent bricked the whole bench agent push (+ no way to disable a legacy install)

### DIFF
--- a/frontend/src/pages/agents/AgentDetail.vue
+++ b/frontend/src/pages/agents/AgentDetail.vue
@@ -384,6 +384,18 @@
 								:label="row.enabled ? 'Enabled' : 'Disabled'"
 							/>
 							<div
+								v-else-if="column.key === 'run_as_user'"
+								class="truncate text-base"
+							>
+								<span v-if="row.run_as_user">{{ row.run_as_user }}</span>
+								<Badge
+									v-else
+									variant="subtle"
+									theme="orange"
+									label="No run-as user"
+								/>
+							</div>
+							<div
 								v-else-if="column.key === 'last_run_at'"
 								class="truncate text-base"
 							>
@@ -475,6 +487,10 @@ const FREQUENCY_OPTIONS = [
 ];
 const INSTALL_COLUMNS = [
 	{ label: "Owner", key: "owner", width: 2 },
+	// The EXECUTING identity, distinct from the owner. A blank one is a legacy /
+	// misconfigured row that every dispatch path refuses to run, so it is surfaced
+	// here (as a badge) to give an admin an in-product path to the offending row.
+	{ label: "Runs as", key: "run_as_user", width: 2 },
 	{ label: "Enabled", key: "enabled", width: "7rem" },
 	{ label: "Last run", key: "last_run_at", width: "8rem" },
 	{ label: "Sync", key: "sync_status", width: "7rem" },

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -205,8 +205,38 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		order_by="agent asc, name asc",
 	)
 	payload = []
-	seen_slugs: set[str] = set()
+	# De-dupe key: the LISTING DOCNAME (``row.agent``), not the emitted slug, so the
+	# short-circuit below can run BEFORE any query. The two are the same key —
+	# ``Jarvis Agent Listing`` is named ``field:agent_slug`` and ``agent_slug`` is
+	# ``unique: 1`` (a DB index), so docname <-> agent_slug is a bijection, and
+	# frappe re-pins the field to the name on every ORM save
+	# (``base_document._sync_autoname_field``, called from ``_validate``). Deduping
+	# on either therefore ships exactly the same set of slugs.
+	seen_agents: set[str] = set()
 	for row in installs:
+		# De-dupe by AGENT. An install is per-(owner, agent) but the container's
+		# agent_skills namespace is per-slug, so two users who each install AND
+		# enable the same agent produce two rows for ONE slug. Admin REJECTS a
+		# payload carrying a duplicate slug outright ("invalid: duplicate agent
+		# skill slug '<x>'"), which kills EVERY agent push from the bench — not just
+		# the duplicated agent.
+		#
+		# Checked FIRST, before the listing lookup and the RBAC gate: once an agent
+		# has been emitted the outcome cannot change — no later row can add or
+		# remove it — so the work those gates do for a second row of the same agent
+		# is spent purely to reach a `continue`. That work is a ``get_value`` on the
+		# listing PLUS ``_user_allowed_for_agent``, which is itself an N+1 on the
+		# allowed-role child table; and this function runs TWICE per Apply (the
+		# endpoint and again in the background job), so at 20 owners x 20 installs
+		# the short-circuit saves ~800 round-trips.
+		#
+		# UNION semantics are unaffected: ``seen_agents`` is only added to AFTER
+		# every gate has passed, so a row blocked by one of them leaves its agent
+		# unseen and the next candidate is still evaluated in full. The slug ships
+		# as soon as ANY enabled install clears the gates.
+		if row.agent in seen_agents:
+			continue
+
 		# R5-J8: a reconcile marks an install ``installable=0`` (never deletes) when
 		# a min_apps dependency vanished AFTER install while it was still enabled.
 		# Its enablement signal must not reach the container — the run gates already
@@ -224,23 +254,13 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		if not _user_allowed_for_agent(row.agent, row.owner):
 			continue
 
-		# De-dupe by SLUG. An install is per-(owner, agent) but the container's
-		# agent_skills namespace is per-slug, so two users who each install AND
-		# enable the same agent produce two rows for ONE slug. Admin REJECTS a
-		# payload carrying a duplicate slug outright ("invalid: duplicate agent
-		# skill slug '<x>'"), which kills EVERY agent push from the bench — not
-		# just the duplicated agent. Emit each slug exactly once, with UNION
-		# semantics: the per-install gates above (installable / Published /
-		# owner-RBAC) are evaluated for every row, and the slug ships as soon as
-		# ANY of them clears. Safe to collapse because the entry below is derived
-		# purely from the listing row plus the bundled registry — it carries NO
-		# per-install data, and ``agent_slug`` is unique + the listing's docname
-		# (naming_rule By fieldname), so every row for a slug yields a byte-
-		# identical entry.
+		# Every gate has passed, so this agent is emitted and no later row for it can
+		# change that: mark it seen. Collapsing the rows is safe because the entry
+		# below is derived purely from the listing row plus the bundled registry —
+		# it carries NO per-install data — so every row for an agent would yield a
+		# byte-identical entry.
+		seen_agents.add(row.agent)
 		slug = f"{AGENT_PREFIX}{listing.agent_slug}"
-		if slug in seen_slugs:
-			continue
-		seen_slugs.add(slug)
 
 		# A2 enablement signal — body-free. Admin resolves the SKILL from the
 		# private bundle store by slug (Phase 2C). The body NEVER leaves it.

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -170,7 +170,12 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	RBAC (defense in depth): an enabled install whose OWNER's roles no longer
 	permit the agent is EXCLUDED from the push — the scheduler / run-now gates
 	already refuse to run it, but its enablement signal must not reach the
-	container either."""
+	container either.
+
+	Installs are per-(owner, agent) but the payload is bench-global and keyed by
+	SLUG, so two users each enabling the SAME agent are ONE entry, not two —
+	emitted with UNION semantics (the slug ships if ANY enabled install clears the
+	gates)."""
 	# Lazy import — agents_api imports build_agent_push_payload from this module
 	# at module level, so a top-level back-import would be circular.
 	from jarvis.chat.agents_api import _user_allowed_for_agent
@@ -192,9 +197,15 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		"Jarvis Agent Installation",
 		filters=filters,
 		fields=["agent", "owner", "installable"],
-		order_by="agent asc",
+		# ``agent`` alone is not a total order once two owners install the same
+		# agent; the ``name`` tiebreak makes the iteration — and therefore which
+		# install wins the de-dupe below — stable across runs. The payload is a
+		# FULL RECONCILE that admin/fleet diffs against the container's current
+		# roster, so a wobbling order would read as a change.
+		order_by="agent asc, name asc",
 	)
 	payload = []
+	seen_slugs: set[str] = set()
 	for row in installs:
 		# R5-J8: a reconcile marks an install ``installable=0`` (never deletes) when
 		# a min_apps dependency vanished AFTER install while it was still enabled.
@@ -213,12 +224,30 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		if not _user_allowed_for_agent(row.agent, row.owner):
 			continue
 
+		# De-dupe by SLUG. An install is per-(owner, agent) but the container's
+		# agent_skills namespace is per-slug, so two users who each install AND
+		# enable the same agent produce two rows for ONE slug. Admin REJECTS a
+		# payload carrying a duplicate slug outright ("invalid: duplicate agent
+		# skill slug '<x>'"), which kills EVERY agent push from the bench — not
+		# just the duplicated agent. Emit each slug exactly once, with UNION
+		# semantics: the per-install gates above (installable / Published /
+		# owner-RBAC) are evaluated for every row, and the slug ships as soon as
+		# ANY of them clears. Safe to collapse because the entry below is derived
+		# purely from the listing row plus the bundled registry — it carries NO
+		# per-install data, and ``agent_slug`` is unique + the listing's docname
+		# (naming_rule By fieldname), so every row for a slug yields a byte-
+		# identical entry.
+		slug = f"{AGENT_PREFIX}{listing.agent_slug}"
+		if slug in seen_slugs:
+			continue
+		seen_slugs.add(slug)
+
 		# A2 enablement signal — body-free. Admin resolves the SKILL from the
 		# private bundle store by slug (Phase 2C). The body NEVER leaves it.
 		meta = reg_by_slug.get(listing.agent_slug) or {}
 		payload.append(
 			{
-				"slug": f"{AGENT_PREFIX}{listing.agent_slug}",
+				"slug": slug,
 				"delivery": "delegate",
 				"tools_allow": meta.get("tools_allow") or [],
 				"model": meta.get("model") or None,

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -170,7 +170,9 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	RBAC (defense in depth): an enabled install whose OWNER's roles no longer
 	permit the agent is EXCLUDED from the push — the scheduler / run-now gates
 	already refuse to run it, but its enablement signal must not reach the
-	container either.
+	container either. Identity (CX1-1, the same reasoning): an enabled install with
+	a BLANK run-as user is EXCLUDED too — R1-F3 refuses it at every dispatch path,
+	so pushing it would advertise an agent this bench can never run.
 
 	Installs are per-(owner, agent) but the payload is bench-global and keyed by
 	SLUG, so two users each enabling the SAME agent are ONE entry, not two —
@@ -196,7 +198,7 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 	installs = frappe.get_all(
 		"Jarvis Agent Installation",
 		filters=filters,
-		fields=["agent", "owner", "installable"],
+		fields=["agent", "owner", "installable", "run_as_user"],
 		# ``agent`` alone is not a total order once two owners install the same
 		# agent; the ``name`` tiebreak makes the iteration — and therefore which
 		# install wins the de-dupe below — stable across runs. The payload is a
@@ -243,6 +245,25 @@ def build_agent_push_payload(owner: str | None = None) -> list[dict]:
 		# refuse it, and pushing it would install a bundle whose data is absent.
 		if not frappe.utils.cint(row.installable):
 			continue
+
+		# CX1-1: an enabled install with a BLANK run-as user has no executing
+		# identity, so R1-F3 makes every dispatch path refuse it (the scheduler, the
+		# manual run-now, and ``_launch_audit`` — the choke point both funnel
+		# through). Its enablement signal must not reach the container either: the
+		# push would provision the delegate, seat it in the container roster and the
+		# tenant's agent_roster, and so advertise an agent this bench will NEVER run.
+		# Same reasoning as the installability gate above and the RBAC gate below —
+		# schema relaxation (``run_as_user`` is no longer ``reqd``, so a legacy row
+		# stays disableable) must not leave a misconfigured row eligible for the
+		# fleet reconcile just because it is still flagged enabled.
+		#
+		# A PER-ROW gate, like every other one here: it disqualifies THIS row only
+		# and ``continue``s before ``seen_agents.add``, so UNION semantics hold in
+		# both directions — a blank row never suppresses a valid install of the same
+		# agent by another owner, and a blank row alone never ships the slug.
+		if not (row.run_as_user or "").strip():
+			continue
+
 		listing = frappe.db.get_value(
 			LISTING,
 			row.agent,

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -33,6 +33,7 @@ trigger takes the EXACT same code path as the scheduler.
 from datetime import timedelta
 
 import frappe
+from frappe import _
 from frappe.utils import now_datetime
 
 from jarvis.chat.agent_activity import log_activity
@@ -111,9 +112,22 @@ def run_due_agent_audits() -> None:
 			continue
 
 		# Phase 1 identity: the audit executes AS the install's run_as_user (its
-		# jarvis__* reads are permission-bounded to that user). Falls back to
-		# owner for installs from before run_as_user / the A13 backfill.
-		run_as = row.run_as_user or row.owner
+		# jarvis__* reads are permission-bounded to that user).
+		#
+		# R1-F3: there is deliberately NO ``or row.owner`` fallback. A blank
+		# run_as_user means the install is MISCONFIGURED, not that it should run as
+		# the row owner: the owner is an identity ``_validate_run_as_escalation``
+		# never litigated, so binding an unattended run to it would execute ERP
+		# reads under rights nobody vetted. Refuse, record WHY, and CONSUME the slot
+		# — retrying hourly would just relog the same failure 24x/day and can never
+		# fix itself; a human has to set a run-as user or disable the install.
+		run_as = (row.run_as_user or "").strip()
+		if not run_as:
+			_record_failed(
+				row, "scheduled audit skipped: no run-as user on this install (set one, or disable it)"
+			)
+			_advance(row, now)
+			continue
 
 		# S1 fail-closed identity guard — never bind a scheduled audit turn to
 		# Administrator / Guest / a disabled RUN-AS user.
@@ -232,7 +246,26 @@ def _launch_audit(inst, trigger: str) -> dict:
 	# run_agent_now) has already switched the session to this user, so
 	# frappe.session.user == run_as_user here — scope + watermark below are
 	# resolved AS the run-as user (permission-bounded).
-	run_as_user = inst.run_as_user or owner
+	#
+	# R1-F3: the LAST line of defence, and the reason no ``or owner`` fallback
+	# survives anywhere on the run path. ``run_as_user`` is no longer ``reqd`` (a
+	# legacy row carrying none must stay DISABLEABLE) and the controller check that
+	# replaced it lives in ``validate()``, which frappe skips WHOLESALE under
+	# ``flags.ignore_validate`` (``run_before_save_methods`` returns early;
+	# ``_validate`` — the ``reqd`` enforcer — is what always runs). So a future
+	# seeder/importer adopting that flag could persist an ENABLED install with no
+	# executing identity. Refuse to dispatch it rather than falling back to the row
+	# OWNER: that identity was never litigated by the escalation guard, so the
+	# fallback amounts to a privilege grant nobody reviewed. Thrown BEFORE any row
+	# is inserted, so a refused launch leaves no orphan conversation/run.
+	run_as_user = (inst.run_as_user or "").strip()
+	if not run_as_user:
+		frappe.throw(
+			_(
+				"This agent installation has no run-as user, so there is no identity to run "
+				"it as. Set a run-as user on the installation, or disable it."
+			)
+		)
 
 	# Fresh conversation. ROW ownership is the human owner (reassigned below) so
 	# if_owner visibility works; the ERP-read identity is the run-as user.

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -817,11 +817,24 @@ def run_agent_now(installation: str) -> dict:
 	identity is the run-as user."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3: who may trigger
-	run_as = doc.run_as_user or doc.owner
+	# R1-F3: no ``or doc.owner`` fallback. A blank run-as user is a MISCONFIGURED
+	# install, and defaulting to the row owner would run this audit's ERP reads as
+	# an identity the A4 escalation guard never litigated — a privilege grant
+	# nobody reviewed. Refuse explicitly (and before the RBAC helper, which would
+	# otherwise be asked to rule on an empty user) so the operator sees WHICH row
+	# is wrong instead of getting a silent owner-privileged run.
+	run_as = (doc.run_as_user or "").strip()
+	if not run_as:
+		frappe.throw(
+			_(
+				"This agent has no run-as user, so there is no identity to run it as. Set a "
+				"run-as user on the installation, or disable it."
+			)
+		)
 	# RBAC: the audit executes AS the RUN-AS user, so it is THAT identity's roles
 	# that must permit the agent (gotcha #8 — the executing identity is gated, not
-	# the triggerer). Defaults to owner for installs from before run_as_user. SM
-	# run-as users pass via the System Manager bypass inside the helper.
+	# the triggerer). SM run-as users pass via the System Manager bypass inside the
+	# helper.
 	if not _user_allowed_for_agent(doc.agent, run_as):
 		frappe.throw(
 			_("The run-as user's roles do not permit running this agent."),

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -473,6 +473,7 @@ def get_agent_admin_overview() -> dict:
 			"name",
 			"agent",
 			"owner",
+			"run_as_user",
 			"enabled",
 			"schedule_enabled",
 			"schedule_frequency",
@@ -486,6 +487,11 @@ def get_agent_admin_overview() -> dict:
 			{
 				"installation": i.name,
 				"owner": i.owner,
+				# R1-S2: the EXECUTING identity, distinct from the row owner. A blank
+				# one is a legacy/misconfigured row — the dispatch paths refuse to run
+				# it (R1-F3) — so an admin reading an Apply or run failure needs to see
+				# WHICH row it is here, rather than having to open raw Desk.
+				"run_as_user": i.run_as_user or None,
 				"enabled": int(i.enabled or 0),
 				"schedule_enabled": int(i.schedule_enabled or 0),
 				"schedule_frequency": i.schedule_frequency,

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.json
@@ -50,9 +50,9 @@
    "fieldtype": "Link",
    "label": "Run As User",
    "options": "User",
-   "reqd": 1,
+   "mandatory_depends_on": "eval:doc.enabled",
    "in_list_view": 1,
-   "description": "The Frappe user this agent's runs execute AS: every jarvis__* ERP read is permission-bounded to this user (company scope, role perms), decoupled from the row owner. A non-admin installer may only map the agent to run as themselves; any cross-user mapping needs Jarvis Admin, and binding to a System Manager needs a System Manager. Defaults to the installer."
+   "description": "The Frappe user this agent's runs execute AS: every jarvis__* ERP read is permission-bounded to this user (company scope, role perms), decoupled from the row owner. Required to ENABLE the install (enforced in validate(); a disabled install runs nothing, and legacy rows carrying no run-as user must stay disableable). A non-admin installer may only map the agent to run as themselves; any cross-user mapping needs Jarvis Admin, and binding to a System Manager needs a System Manager. Defaults to the installer."
   },
   {
    "default": "0",
@@ -186,7 +186,7 @@
  ],
  "index_web_pages_for_search": 0,
  "links": [],
- "modified": "2026-07-04 20:30:00.000000",
+ "modified": "2026-07-25 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Jarvis",
  "name": "Jarvis Agent Installation",

--- a/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_installation/jarvis_agent_installation.py
@@ -215,13 +215,32 @@ class JarvisAgentInstallation(Document):
 	# the bench trusts the per-run Jarvis Chat Session row and enforces NOTHING
 	# at call_tool, so install-time is the only place a low-priv installer can be
 	# stopped from mapping the agent to run as a high-priv user (data exfil).
+	#
+	# A NON-EMPTY mapping is litigated regardless of ``enabled``: a disabled row
+	# must never be usable to stage an unvetted run_as_user that a later enable
+	# would wave through (the "unchanged mapping" short-circuit below would skip
+	# it). Only the BLANK case is conditional on enabled.
 	# ------------------------------------------------------------------ #
 	def _validate_run_as_user(self):
 		target = (self.run_as_user or "").strip()
 		if not target:
-			# reqd:1 also enforces this; the explicit throw keeps the escalation
-			# block below from ever running against a None.
-			frappe.throw(_("Run-as user is required."))
+			# An ENABLED install must name the identity its runs execute as, so a
+			# blank one is still refused on that path (and the explicit throw keeps
+			# the escalation block below from ever running against a None). A
+			# DISABLED install runs nothing — the scheduler filters on enabled=1 —
+			# so it needs no executing identity, and refusing a blank one there had
+			# a real cost: legacy rows predate the field and carry NULL, and since
+			# ``agents_api.set_enabled`` disables through ``doc.save()`` -> validate(),
+			# an unconditional throw made such a row impossible to DISABLE through
+			# any supported surface. That is the only escape from a bench whose
+			# agent push a legacy row has broken, so it must stay open.
+			#
+			# NOTE: this is the authoritative check — the field's Desk-side
+			# ``mandatory_depends_on: eval:doc.enabled`` is a form cue only
+			# (frappe evaluates it in JS, never in _validate_mandatory).
+			if frappe.utils.cint(self.get("enabled")):
+				frappe.throw(_("Run-as user is required."))
+			return
 
 		# Only re-litigate the mapping when it is actually being (re)assigned.
 		# An unrelated save (enable / schedule / config) on a row whose

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -966,9 +966,7 @@ class TestAgentsMarketplace(unittest.TestCase):
 				frappe.db.set_value(INSTALLATION, n, "next_run_at", ts, update_modified=False)
 			frappe.db.commit()
 
-		runs = frappe.get_all(
-			RUN, filters={"installation": inst_name}, fields=["owner", "status", "error"]
-		)
+		runs = frappe.get_all(RUN, filters={"installation": inst_name}, fields=["owner", "status", "error"])
 		self.assertEqual(len(runs), 1)
 		self.assertEqual(runs[0]["status"], "failed")  # never "running"
 		self.assertEqual(runs[0]["owner"], self.owner)  # the customer sees WHY

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -640,3 +640,147 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self._restrict("close-auditor", [])  # clear -> included again
 		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
 		self.assertTrue(any(p["slug"] == "agent-close-auditor" for p in payload))
+
+	# ------------------------------------------------------------------ #
+	# (i) P0-B — the payload is keyed by SLUG, installs are per-(owner, agent)
+	#
+	# Two users each enabling the same agent used to emit the slug TWICE; admin
+	# rejects a duplicate slug outright ("invalid: duplicate agent skill slug"),
+	# which killed EVERY agent push from the bench, not just that agent.
+	# ------------------------------------------------------------------ #
+	def _enable_for(self, owner: str, slug: str) -> str:
+		inst = _install_as(owner, slug)
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 1)
+		frappe.db.commit()
+		return inst
+
+	def _count_slug(self, payload: list, slug: str) -> int:
+		return sum(1 for p in payload if p["slug"] == slug)
+
+	def test_push_payload_emits_one_entry_per_slug_across_owners(self):
+		"""P0-B: two owners, same agent, both enabled -> the slug appears ONCE."""
+		self._enable_for(self.owner, "close-auditor")
+		self._enable_for(self.other, "close-auditor")
+
+		payload = agent_catalog.build_agent_push_payload()  # bench-global, as the push is
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+		# ...and the payload as a whole carries no duplicate slug at all, which is
+		# exactly what admin validates.
+		slugs = [p["slug"] for p in payload]
+		self.assertEqual(len(slugs), len(set(slugs)), f"duplicate slug in payload: {slugs}")
+
+	def test_push_payload_dedupe_is_union_not_last_wins(self):
+		"""A slug ships if ANY enabled install clears the gates — a blocked or
+		non-installable sibling row must not suppress a qualifying one."""
+		self._enable_for(self.owner, "close-auditor")
+		blocked = self._enable_for(self.other, "close-auditor")
+
+		# (a) RBAC: only self.owner holds ROLE_X, so self.other's row is excluded.
+		self._restrict("close-auditor", [ROLE_X])
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+
+		# ...and once BOTH rows qualify again it is still ONE entry, not two.
+		self._restrict("close-auditor", [])
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+
+		# (b) installability: self.other's row is reconciled non-installable.
+		frappe.db.set_value(
+			INSTALLATION,
+			blocked,
+			{"installable": 0, "not_installable_reason": "app_absent_or_ineligible"},
+			update_modified=False,
+		)
+		frappe.db.commit()
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+
+	def test_push_payload_omits_slug_whose_only_install_is_unpublished(self):
+		self._enable_for(self.owner, "close-auditor")
+		frappe.set_user("Administrator")
+		try:
+			agents_api.set_listing_status("close-auditor", "Coming Soon")
+			payload = agent_catalog.build_agent_push_payload(owner=self.owner)
+			self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)
+		finally:
+			agents_api.set_listing_status("close-auditor", "Published")  # restore
+
+	def test_push_payload_order_is_deterministic(self):
+		"""The payload is a full reconcile that admin/fleet diffs, so a rebuild of
+		unchanged data must produce a byte-identical list."""
+		self._enable_for(self.owner, "close-auditor")
+		self._enable_for(self.other, "close-auditor")
+		self._enable_for(self.owner, "ledger-scrutiny-auditor")
+
+		first = agent_catalog.build_agent_push_payload()
+		second = agent_catalog.build_agent_push_payload()
+		self.assertEqual(first, second)
+		slugs = [p["slug"] for p in first]
+		self.assertEqual(slugs, sorted(slugs))
+
+	# ------------------------------------------------------------------ #
+	# (j) P0-B part 2 — a legacy install (run_as_user NULL) must be DISABLEABLE
+	#
+	# Without this there is no UI escape from a bricked push: set_enabled saves
+	# the doc, validate() demanded a run-as user, and reqd:1 blocked it too.
+	# ------------------------------------------------------------------ #
+	def _make_legacy_enabled(self, owner: str, slug: str) -> str:
+		"""An install as it exists on benches that predate run_as_user: enabled,
+		with a NULL executing identity."""
+		inst = _install_as(owner, slug)
+		frappe.db.set_value(INSTALLATION, inst, {"enabled": 1, "run_as_user": None}, update_modified=False)
+		frappe.db.commit()
+		return inst
+
+	def test_legacy_install_without_run_as_user_can_be_disabled(self):
+		inst = self._make_legacy_enabled(self.owner, "close-auditor")
+		frappe.set_user(self.owner)
+		try:
+			res = agents_api.set_enabled(inst, 0)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(res["data"]["enabled"], 0)
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "enabled"), 0)
+		# The escape actually clears the push: the slug is gone from the payload.
+		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)
+
+	def test_enabling_without_run_as_user_still_throws(self):
+		inst = self._make_legacy_enabled(self.owner, "close-auditor")
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.ValidationError):
+				agents_api.set_enabled(inst, 1)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "enabled"), 0)
+
+	def test_run_as_escalation_guard_still_blocks_cross_user_mapping(self):
+		"""A4: a non-admin owner may map the agent only to THEMSELVES — unchanged
+		by the blank-is-ok-while-disabled relaxation."""
+		inst = _install_as(self.owner, "close-auditor")
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.set_run_as_user(inst, self.other)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(INSTALLATION, inst, "run_as_user"), self.owner)
+
+	def test_run_as_escalation_guard_holds_on_a_disabled_legacy_row(self):
+		"""The blank short-circuit must not become a staging ground: assigning a
+		run_as_user to a DISABLED row is litigated exactly as on an enabled one,
+		so a later enable cannot wave an unvetted mapping through."""
+		inst = self._make_legacy_enabled(self.owner, "close-auditor")
+		frappe.db.set_value(INSTALLATION, inst, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				agents_api.set_run_as_user(inst, self.admin)  # a System Manager
+		finally:
+			frappe.set_user("Administrator")
+		self.assertIsNone(frappe.db.get_value(INSTALLATION, inst, "run_as_user") or None)

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -1002,3 +1002,54 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self.assertTrue(res["ok"])
 		self.assertEqual(captured.get("user"), self.owner)
 		self.assertEqual(frappe.db.get_value(RUN, res["data"]["run"], "status"), "running")
+
+	# ------------------------------------------------------------------ #
+	# (l) CX1-1 — a blank-identity install must not reach the CONTAINER either
+	#
+	# The gap left between the schema relaxation and global push eligibility:
+	# R1-F3 makes every RUN path refuse an enabled install with no run-as user,
+	# but the push payload never looked at the field, so the slug still shipped —
+	# provisioning the delegate, seating it in the container roster and the
+	# tenant's agent_roster, and advertising an agent the bench can never run.
+	# ------------------------------------------------------------------ #
+	def test_push_payload_omits_slug_whose_only_install_has_no_run_as_user(self):
+		"""An enabled-but-blank install is the ONLY install of the slug -> the slug
+		is absent from the payload entirely."""
+		inst = self._make_legacy_enabled(self.owner, "close-auditor")
+		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)
+
+		# ...and it is the BLANK IDENTITY that excluded it, not some unrelated gate:
+		# give the very same row a run-as user and the same build ships the slug.
+		frappe.db.set_value(INSTALLATION, inst, "run_as_user", self.owner, update_modified=False)
+		frappe.db.commit()
+		payload = agent_catalog.build_agent_push_payload(owner=self.owner)
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+
+	def test_push_payload_union_survives_a_blank_run_as_user_sibling(self):
+		"""UNION semantics: owner A valid + owner B blank, SAME slug -> the slug
+		still ships, exactly ONCE. The blank row must disqualify only itself."""
+		a = self._enable_for(self.owner, "close-auditor")
+		b = self._enable_for(self.other, "close-auditor")
+		# Installs are hash-named and the build iterates ``agent asc, name asc``, so
+		# blank whichever row sorts FIRST: that is the ordering in which a gate that
+		# wrongly suppressed the agent would actually bite (the blank row reached
+		# BEFORE the valid one).
+		frappe.db.set_value(INSTALLATION, min(a, b), "run_as_user", None, update_modified=False)
+		frappe.db.commit()
+
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+		slugs = [p["slug"] for p in payload]
+		self.assertEqual(len(slugs), len(set(slugs)), f"duplicate slug in payload: {slugs}")
+
+		# The surviving entry is the normal, complete enablement signal.
+		entry = next(p for p in payload if p["slug"] == "agent-close-auditor")
+		self.assertEqual(entry["delivery"], "delegate")
+
+		# Blanking the OTHER row too (no valid install left) drops the slug — proof
+		# the entry above came from the qualifying sibling, not from a leaky gate.
+		frappe.db.set_value(INSTALLATION, max(a, b), "run_as_user", None, update_modified=False)
+		frappe.db.commit()
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 0)

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -720,6 +720,63 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self.assertEqual(slugs, sorted(slugs))
 
 	# ------------------------------------------------------------------ #
+	# R1-F2 — the de-dupe short-circuits BEFORE the per-row queries
+	# ------------------------------------------------------------------ #
+	def test_push_payload_short_circuit_preserves_the_slug_set(self):
+		"""The short-circuit skips WORK, never an OUTCOME.
+
+		Oracle: a per-OWNER build can never short-circuit — (owner, agent) is
+		unique, so each such build sees at most one row per agent — which makes the
+		union of the per-owner builds an independent reference for what the
+		bench-global (short-circuiting) build must ship."""
+		self._enable_for(self.owner, "close-auditor")
+		self._enable_for(self.other, "close-auditor")
+		self._enable_for(self.other, "ledger-scrutiny-auditor")
+		# A blocked sibling that must not suppress the qualifying row (union).
+		blocked = self._enable_for(self.admin, "close-auditor")
+		frappe.db.set_value(
+			INSTALLATION,
+			blocked,
+			{"installable": 0, "not_installable_reason": "app_absent_or_ineligible"},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+		owners = {r.owner for r in frappe.get_all(INSTALLATION, filters={"enabled": 1}, fields=["owner"])}
+		reference = set()
+		for o in owners:
+			reference |= {p["slug"] for p in agent_catalog.build_agent_push_payload(owner=o)}
+
+		payload = agent_catalog.build_agent_push_payload()
+		self.assertEqual({p["slug"] for p in payload}, reference)
+		# ...and still exactly one entry per slug.
+		slugs = [p["slug"] for p in payload]
+		self.assertEqual(len(slugs), len(set(slugs)), f"duplicate slug in payload: {slugs}")
+		self.assertIn("agent-close-auditor", reference)
+		self.assertIn("agent-ledger-scrutiny-auditor", reference)
+
+	def test_push_payload_short_circuit_skips_the_per_row_rbac_query(self):
+		"""The RBAC gate (an N+1 on the allowed-role child table) is evaluated once
+		per distinct AGENT, not once per install row."""
+		self._enable_for(self.owner, "close-auditor")
+		self._enable_for(self.other, "close-auditor")
+		self._enable_for(self.admin, "close-auditor")
+
+		calls = []
+		orig = agents_api._user_allowed_for_agent
+		agents_api._user_allowed_for_agent = lambda listing, user=None: (
+			calls.append(listing) or orig(listing, user)
+		)
+		try:
+			payload = agent_catalog.build_agent_push_payload()
+		finally:
+			agents_api._user_allowed_for_agent = orig
+
+		close_calls = [c for c in calls if c == "close-auditor"]
+		self.assertEqual(len(close_calls), 1, f"RBAC gate re-run per install row: {calls}")
+		self.assertEqual(self._count_slug(payload, "agent-close-auditor"), 1)
+
+	# ------------------------------------------------------------------ #
 	# (j) P0-B part 2 — a legacy install (run_as_user NULL) must be DISABLEABLE
 	#
 	# Without this there is no UI escape from a bricked push: set_enabled saves

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -784,3 +784,144 @@ class TestAgentsMarketplace(unittest.TestCase):
 		finally:
 			frappe.set_user("Administrator")
 		self.assertIsNone(frappe.db.get_value(INSTALLATION, inst, "run_as_user") or None)
+
+	# ------------------------------------------------------------------ #
+	# (k) R1-F3 — a blank run_as_user is REFUSED at every DISPATCH entry point
+	#
+	# ``reqd`` on run_as_user had to go (a disabled legacy row must stay
+	# DISABLEABLE) and the controller check that replaced it lives in validate(),
+	# which frappe skips WHOLESALE under ``flags.ignore_validate``
+	# (run_before_save_methods returns early; ``_validate`` — the reqd enforcer —
+	# is the one that always runs). An ENABLED install with no executing identity
+	# is therefore persistable by a future seeder/importer, and the old
+	# ``run_as_user or owner`` fallback would have silently bound its ERP reads to
+	# the row OWNER — an identity ``_validate_run_as_escalation`` never litigated.
+	# Every dispatch path must refuse instead, diagnosably.
+	# ------------------------------------------------------------------ #
+	def _no_dispatch(self, **kw):
+		raise AssertionError("an install with no run-as user must never reach dispatch")
+
+	def test_launch_audit_refuses_blank_run_as_user(self):
+		"""The shared choke point BOTH dispatch paths funnel through."""
+		import jarvis.admin_client as admin_client
+
+		inst_name = self._make_legacy_enabled(self.owner, "close-auditor")
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+		convs_before = frappe.db.count("Jarvis Conversation")
+
+		orig_run = admin_client.post_agent_run
+		admin_client.post_agent_run = self._no_dispatch
+		try:
+			frappe.set_user(self.owner)
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig_run
+
+		self.assertIn("run-as user", str(ctx.exception))
+		# Refused BEFORE anything is written — no orphan conversation, no orphan Run.
+		self.assertEqual(frappe.db.count("Jarvis Conversation"), convs_before)
+		self.assertEqual(frappe.get_all(RUN, filters={"installation": inst_name}, pluck="name"), [])
+
+	def test_run_agent_now_refuses_blank_run_as_user(self):
+		"""Manual entry point — refused, never silently run as the row owner."""
+		import jarvis.admin_client as admin_client
+
+		inst_name = self._make_legacy_enabled(self.owner, "close-auditor")
+		orig_run = admin_client.post_agent_run
+		admin_client.post_agent_run = self._no_dispatch
+		try:
+			frappe.set_user(self.owner)
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				agents_api.run_agent_now(inst_name)
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig_run
+
+		self.assertIn("run-as user", str(ctx.exception))
+		self.assertEqual(frappe.get_all(RUN, filters={"installation": inst_name}, pluck="name"), [])
+
+	def test_scheduler_refuses_blank_run_as_user_and_consumes_the_slot(self):
+		"""Scheduled entry point — skipped with a RECORDED reason (an operator has
+		to be able to diagnose it), and the slot is consumed so a misconfiguration
+		does not busy-retry every hour for ever."""
+		from frappe.utils import add_days, now_datetime
+
+		import jarvis.admin_client as admin_client
+
+		inst_name = self._make_legacy_enabled(self.owner, "close-auditor")
+		now = now_datetime()
+		frappe.db.set_value(
+			INSTALLATION,
+			inst_name,
+			{"schedule_enabled": 1, "schedule_frequency": "daily", "next_run_at": add_days(now, -1)},
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+		# Insulate from any OTHER due installation on this (dev) site: park their
+		# slots and restore afterwards, so the cron run only touches ours.
+		parked = {
+			r.name: r.next_run_at
+			for r in frappe.get_all(
+				INSTALLATION,
+				filters={
+					"enabled": 1,
+					"schedule_enabled": 1,
+					"next_run_at": ["<=", now],
+					"name": ["!=", inst_name],
+				},
+				fields=["name", "next_run_at"],
+			)
+		}
+		for n in parked:
+			frappe.db.set_value(INSTALLATION, n, "next_run_at", add_days(now, 2), update_modified=False)
+		frappe.db.commit()
+
+		orig_run = admin_client.post_agent_run
+		admin_client.post_agent_run = self._no_dispatch
+		try:
+			agent_scheduler.run_due_agent_audits()
+		finally:
+			admin_client.post_agent_run = orig_run
+			for n, ts in parked.items():
+				frappe.db.set_value(INSTALLATION, n, "next_run_at", ts, update_modified=False)
+			frappe.db.commit()
+
+		runs = frappe.get_all(
+			RUN, filters={"installation": inst_name}, fields=["owner", "status", "error"]
+		)
+		self.assertEqual(len(runs), 1)
+		self.assertEqual(runs[0]["status"], "failed")  # never "running"
+		self.assertEqual(runs[0]["owner"], self.owner)  # the customer sees WHY
+		self.assertIn("no run-as user", runs[0]["error"])
+		# The slot was consumed: next_run_at advanced into the future.
+		row = frappe.db.get_value(INSTALLATION, inst_name, ["next_run_at", "last_run_at"], as_dict=True)
+		self.assertIsNotNone(row.last_run_at)
+		self.assertGreater(row.next_run_at, now)
+
+	def test_dispatch_paths_are_unchanged_for_a_valid_run_as_user(self):
+		"""The refusal must not perturb the normal case: an install carrying a
+		valid run-as user still dispatches, under THAT identity."""
+		import jarvis.admin_client as admin_client
+
+		inst_name = self._enable_for(self.owner, "close-auditor")
+		captured = {}
+		orig_run = admin_client.post_agent_run
+
+		def _cap(**kw):
+			captured["user"] = frappe.session.user
+			return {"run_id": kw.get("run_id"), "status": "queued"}
+
+		admin_client.post_agent_run = _cap
+		try:
+			frappe.set_user(self.owner)
+			res = agents_api.run_agent_now(inst_name)
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig_run
+
+		self.assertTrue(res["ok"])
+		self.assertEqual(captured.get("user"), self.owner)
+		self.assertEqual(frappe.db.get_value(RUN, res["data"]["run"], "status"), "running")

--- a/jarvis/tests/test_agents_marketplace.py
+++ b/jarvis/tests/test_agents_marketplace.py
@@ -532,6 +532,7 @@ class TestAgentsMarketplace(unittest.TestCase):
 		self.assertEqual(install_row["owner"], self.owner)
 		for key in (
 			"enabled",
+			"run_as_user",
 			"schedule_enabled",
 			"schedule_frequency",
 			"next_run_at",
@@ -539,6 +540,25 @@ class TestAgentsMarketplace(unittest.TestCase):
 			"sync_status",
 		):
 			self.assertIn(key, install_row)
+
+	def test_admin_overview_surfaces_run_as_user_including_blank(self):
+		"""R1-S2: the cross-owner Admin feed carries the EXECUTING identity, so an
+		admin reading an Apply/run failure can see WHICH install is misconfigured
+		without dropping to raw Desk. A blank one must arrive as a falsy value (the
+		badge case), not be omitted."""
+		good = self._enable_for(self.owner, "close-auditor")
+		legacy = self._make_legacy_enabled(self.other, "close-auditor")
+
+		frappe.set_user(self.admin)  # a System Manager
+		try:
+			out = agents_api.get_agent_admin_overview()
+		finally:
+			frappe.set_user("Administrator")
+
+		rows = {i["installation"]: i for lst in out["listings"] for i in lst["installs"]}
+		self.assertEqual(rows[good]["run_as_user"], self.owner)
+		self.assertIn(legacy, rows)
+		self.assertFalse(rows[legacy]["run_as_user"])
 
 	# ------------------------------------------------------------------ #
 	# (g) RBAC — scheduler skips an owner whose roles were revoked


### PR DESCRIPTION
## What

Fixes a P0 where **two users enabling the same agent bricked a bench's entire agent push**, with no supported way out.

Pairs with **Aerele-RnD/jarvis-admin-v2#116** (`fix/activity-log-agent-run`).

## The P0

`build_agent_push_payload` is bench-global and keyed by agent **slug**, but installs are per-(owner, agent). Two users each installing *and* enabling the same agent emitted the same slug twice; admin rejects a duplicate-slug payload outright, which killed **every** agent push from that bench — not just the duplicated agent. Observed live:

```
Jarvis Settings.agent_skills_sync_status =
  failed: invalid: duplicate agent skill slug 'agent-bank-recon-operator'
```

**And there was no escape hatch.** The offending rows were legacy, carrying `run_as_user = NULL`. `set_enabled(…, 0)` goes through `doc.save()` → `validate()` → an unconditional "Run-as user is required" throw, so such a row could not be **disabled** through any supported surface. Recovery required a raw DB write.

## The fix

- **De-dupe by slug with union semantics** — every per-install gate (`installable`, listing `Published`, owner RBAC) is still evaluated for each row, and a slug ships as soon as any row clears them. Safe to collapse because the payload entry derives purely from the listing + bundled registry and carries no per-install data; `agent_slug` is `unique:1` *and* the listing's autoname, so slug ↔ listing is a bijection.
- **A disabled install no longer requires a run-as user.** Only the *blank* branch is conditional on `enabled`; a non-empty mapping is still litigated on every save — so a disabled row cannot be used to stage an unvetted `run_as_user` for a later enable to wave through.
- **Blank identity is refused at dispatch**, not silently run as the row owner. `run_as_user or owner` was a privilege grant nobody reviewed — the owner identity was never litigated by the escalation guard. Closed at all three entry points, with `_launch_audit` throwing before the conversation insert so a refusal leaves no orphan rows.
- **A blank-identity install no longer reaches the container roster** — it was still being provisioned as a delegate that every run path then refused.
- `run_as_user` surfaced on the Admin tab so a misconfigured row is diagnosable in-product.

## Review trail

Sonnet UX panel + Opus adversarial panel. **The run-as escalation guard was attacked directly and held** — no sequence (create/save/enable/disable/re-enable, `db_set` vs `save`, `frappe.client.*`, ORM flags, the unchanged-mapping short-circuit) lands an enabled install with an un-entitled identity. De-dupe union semantics, determinism and the downstream roster contract were also cleared.

The blank-identity-reaches-the-roster finding came from a **Codex round that hung before completing** — salvaged from its partial log. Codex failed 8 times on this workstream overall.

## ⚠️ Opened with caution

- **Codex closure was capped, not completed** (see the companion PR). This branch got one partial Codex round, whose single finding is fixed here.
- **A permission asymmetry is filed, not fixed:** a Jarvis Admin can *see* every owner's install on the Admin tab but cannot disable or fix one — only a System Manager can. So the new "no run-as user" badge improves diagnosis without granting action. Granting the operator role cross-owner write is a permission-model decision that deserves its own review.
- No push-notification exists for a failed apply; discoverability is entirely pull (a banner on a page someone must think to open). Pre-existing, filed separately.

## Tests

249 green across 19 modules (baseline 187). Each fix proven load-bearing by reverting the mechanism and confirming the specific test fails — the de-dupe revert reproduces the duplicate payload verbatim.

⚠️ **Note for reviewers:** `patterntest.localhost` was found carrying stale doctype meta predating this branch, so *earlier* green runs of `test_agents_marketplace` on that site were against the wrong schema. Re-verified after migrating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
