### PR TITLE
fix(settings): ConfirmDialog opens behind the settings dialog and traps the user (fixes #435)

### DIFF
--- a/frontend/src/components/shell/ConfirmDialog.vue
+++ b/frontend/src/components/shell/ConfirmDialog.vue
@@ -1,40 +1,51 @@
 <template>
 	<!-- App-wide confirmation modal. Mounted ONCE in AppShell; driven entirely by
-       the shared useConfirm() state. Its own z-index is 200 so it clears the
-       settings overlay (z-index 60) — a Remove/Delete inside that modal is still
-       confirmable. Applies paletteVars + jv-dark on its root (jv- vars aren't
-       global). See composables/useConfirm.js for the promise-based API. -->
-	<transition name="jv-confirm-fade">
-		<div
-			v-if="state"
-			class="jv-confirm-overlay jv-root"
-			:class="{ 'jv-dark': dark }"
-			:style="paletteVars"
-			@click.self="settleConfirm(false)"
-		>
+       the shared useConfirm() state. Its own z-index is 200 so a Remove/Delete
+       inside the settings modal is still confirmable. Applies paletteVars +
+       jv-dark on its root (jv- vars aren't global). See composables/useConfirm.js
+       for the promise-based API.
+
+       Teleported to <body>: the settings dialog migrated to frappe-ui's Dialog
+       (reka DialogPortal renders into <body> at z-index 60, see main.css
+       .dialog-overlay). An overlay left inline in AppShell is trapped in the
+       app-root stacking context and paints BEHIND that body-level portal however
+       high its own z-index, so this overlay must live at <body> too. There it is
+       a sibling of the settings portal and z-index 200 > 60 actually wins.
+       Without it the confirm opens behind the settings dialog with its buttons
+       unclickable (jarvis#435). -->
+	<Teleport to="body">
+		<transition name="jv-confirm-fade">
 			<div
-				class="jv-cdialog"
-				role="alertdialog"
-				aria-modal="true"
-				aria-labelledby="jv-confirm-title"
+				v-if="state"
+				class="jv-confirm-overlay jv-root"
+				:class="{ 'jv-dark': dark }"
+				:style="paletteVars"
+				@click.self="settleConfirm(false)"
 			>
-				<div id="jv-confirm-title" class="jv-cdialog-title">{{ state.title }}</div>
-				<div v-if="state.message" class="jv-cdialog-msg">{{ state.message }}</div>
-				<div class="jv-cdialog-foot">
-					<button class="jv-btn jv-btn--ghost" @click="settleConfirm(false)">
-						{{ state.cancelLabel }}
-					</button>
-					<button
-						class="jv-btn"
-						:class="state.danger ? 'jv-btn--danger' : 'jv-btn--primary'"
-						@click="settleConfirm(true)"
-					>
-						{{ state.confirmLabel }}
-					</button>
+				<div
+					class="jv-cdialog"
+					role="alertdialog"
+					aria-modal="true"
+					aria-labelledby="jv-confirm-title"
+				>
+					<div id="jv-confirm-title" class="jv-cdialog-title">{{ state.title }}</div>
+					<div v-if="state.message" class="jv-cdialog-msg">{{ state.message }}</div>
+					<div class="jv-cdialog-foot">
+						<button class="jv-btn jv-btn--ghost" @click="settleConfirm(false)">
+							{{ state.cancelLabel }}
+						</button>
+						<button
+							class="jv-btn"
+							:class="state.danger ? 'jv-btn--danger' : 'jv-btn--primary'"
+							@click="settleConfirm(true)"
+						>
+							{{ state.confirmLabel }}
+						</button>
+					</div>
 				</div>
 			</div>
-		</div>
-	</transition>
+		</transition>
+	</Teleport>
 </template>
 
 <script setup>


### PR DESCRIPTION
## What

Teleport the shell `ConfirmDialog` to `<body>` so it renders **above** the settings dialog again.

Fixes #435.

## Why

The settings dialog migrated to frappe-ui's `Dialog` in #405. frappe-ui/reka renders that dialog through `DialogPortal` into `<body>`, and its overlay (`main.css .dialog-overlay`) is `z-index: 60`. The shell `ConfirmDialog` stayed mounted inline in `AppShell` at `z-index: 200`, which traps it inside the app-root stacking context. A `z-index: 200` inside the app root cannot rise above a `z-index: 60` element that lives at `<body>`, so the confirm painted **behind** the settings dialog. Its Cancel / destructive buttons were covered and unclickable, and Escape did not dismiss it, so triggering "Delete all chat history" (or "Cancel subscription") from Settings trapped the user until a reload.

The `ConfirmDialog` comment already assumed it would clear the settings overlay via `z-index: 200`; this change makes that assumption true again by moving it to the same stacking level as the settings portal.

## Change

Wrap the overlay in `<Teleport to="body">` (one component, `ConfirmDialog.vue`). Now the confirm overlay is a `<body>`-level sibling of the settings portal, where `z-index: 200 > 60` wins. No behavior/z-index/palette changes otherwise.

## Verification

- **Root cause measured in-browser** (before fix): `elementFromPoint` at the open confirm's center returned a settings-dialog node (`topIsInsideSettingsDialog: true`), confirming occlusion; the confirm overlay was `z-index: 200` inline while the settings overlay was `z-index: 60` at `<body>`.
- **Builds clean** (`vite build`, 36s, no new errors).
- Final on-device click-through is a quick check on a fresh JS bundle (the running dev bench was serving a cached bundle during testing, so a full live click-through was deferred; the stacking fix is structural).

https://claude.ai/code/session_01SQP9soragWeg78WzaRimoj
