### PR TITLE
fix(onboarding): gate the Set-up-Jarvis desk nudge on ERPNext setup being complete

### DIFF
--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -3,10 +3,12 @@
 // user to finish setup and start easing their ERP workflows. Replaces the old
 // top banner with a friendlier, on-brand "Jarvis is chatting" bubble thread.
 //
-// Reads `frappe.boot.jarvis_onboarded` (set in jarvis.boot.set_jarvis_boot).
-// Shows only for a not-onboarded System Manager; dismissal is per-tab-session
-// (sessionStorage) so it returns next fresh session until setup is finished.
-// Loaded on every Desk page via hooks.app_include_js.
+// Reads `frappe.boot.jarvis_onboarded` (set in jarvis.boot.set_jarvis_boot)
+// and `frappe.boot.sysdefaults.setup_complete` (frappe.is_setup_complete()).
+// Shows only for a not-onboarded System Manager AFTER ERPNext's own setup
+// wizard is finished, so it never pops over the wizard. Dismissal is
+// per-tab-session (sessionStorage) so it returns next fresh session until
+// setup is finished. Loaded on every Desk page via hooks.app_include_js.
 
 (function () {
 	if (window.__jarvisOnboardingBanner) return;
@@ -21,6 +23,11 @@
 	function shouldShow() {
 		if (!window.frappe || !frappe.boot) return false;
 		if (frappe.boot.jarvis_onboarded !== false) return false;
+		// ERPNext's own setup wizard must be finished first: completing it
+		// creates the first Company. Until then the desk IS the setup wizard,
+		// so nudging the user to set up Jarvis on top of it is just noise.
+		// frappe.boot.sysdefaults.setup_complete is frappe.is_setup_complete().
+		if ((frappe.boot.sysdefaults || {}).setup_complete != 1) return false;
 		if (!frappe.user || !frappe.user.has_role || !frappe.user.has_role("System Manager"))
 			return false;
 		try {
@@ -137,7 +144,7 @@
 				cta.textContent = "Set up Jarvis →";
 				b.appendChild(cta);
 				return b;
-			})
+			}),
 		);
 
 		// Tail pointing down toward the chat launcher.

--- a/jarvis/public/js/jarvis_onboarding_banner.bundle.js
+++ b/jarvis/public/js/jarvis_onboarding_banner.bundle.js
@@ -144,7 +144,7 @@
 				cta.textContent = "Set up Jarvis →";
 				b.appendChild(cta);
 				return b;
-			}),
+			})
 		);
 
 		// Tail pointing down toward the chat launcher.


### PR DESCRIPTION
## What

Gate the "Set up Jarvis" desk nudge so it only appears **after** ERPNext's own setup wizard is finished. It was popping over the Welcome / Company setup wizard on fresh sites.

## Why

The nudge (`jarvis_onboarding_banner.bundle.js`) showed whenever the user was a not-onboarded System Manager. On a fresh site that condition is true *during* the ERPNext setup wizard, so the "Hey, set me up" bubble appeared on top of the Welcome step (see the reported screenshot). It never checked whether ERPNext itself was set up.

## Change

Add one gate in `shouldShow()`:

```js
if ((frappe.boot.sysdefaults || {}).setup_complete != 1) return false;
```

`frappe.boot.sysdefaults.setup_complete` is `frappe.is_setup_complete()`, which flips to `true` once the setup wizard completes and the first Company is created. A missing value fails safe to hidden.

Post-onboarding hiding is unchanged: `frappe.boot.jarvis_onboarded !== false` already suppresses the nudge once `is_ready_for_chat().ready` is true, so it does not return after Jarvis onboarding.

## Verification

- `frappe.is_setup_complete()` returns a boolean: `true` on a set-up site (jarvis.proxy), `false` on a fresh one (site.jarvis, `setup_complete=0`). The `!= 1` gate shows on `true` (JS `true == 1`) and hides on `false`/missing.
- Source-only change; `public/dist` is gitignored and rebuilt by CI / `bench build`.

## Note

Reading "show after company creation" as "show once ERPNext setup is complete (first Company exists)". If you literally want a company count threshold (e.g. 2+), say so and I'll switch the gate to a company count.

https://claude.ai/code/session_01SQP9soragWeg78WzaRimoj
