### PR TITLE
fix(agents): JF-017 — enforce the delegate capability contract at the bench

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -705,7 +705,7 @@
 						     e.g. a delegate refused on its very first call. Rendered here
 						     because the Activity accordion cannot hold it. -->
 						<div
-							v-if="m.role === 'tool' && !m.action_outcome"
+							v-if="m.role === 'tool' && orphanToolFailures[m.name]"
 							class="jv-toolfail"
 							role="alert"
 						>
@@ -729,10 +729,13 @@
 									{{ toolLabel(m.tool_name) }} didn't run
 								</div>
 								<div class="jv-toolfail-msg">
-									{{ toolFailParts(m).message }}
+									{{ orphanToolFailures[m.name].message }}
 								</div>
-								<div v-if="toolFailParts(m).hint" class="jv-toolfail-hint">
-									{{ toolFailParts(m).hint }}
+								<div
+									v-if="orphanToolFailures[m.name].hint"
+									class="jv-toolfail-hint"
+								>
+									{{ orphanToolFailures[m.name].hint }}
 								</div>
 							</div>
 						</div>
@@ -4350,20 +4353,37 @@ const modelsByProvider = computed(() => {
 const currentTitle = computed(
 	() => store.conversations.find((c) => c.name === currentId.value)?.title || "New chat"
 );
-// A FAILED tool call with no assistant turn ahead of it in the thread. The
-// Activity accordion is anchored to an assistant message, so a tool row that
-// arrives before any assistant text has nowhere to hang and renders NOWHERE —
-// which is exactly the shape an autonomous delegate produces when its very first
-// call is refused. Those rows are surfaced inline instead; everything else keeps
-// the accordion behaviour untouched.
-const orphanToolErrors = computed(() => {
-	const out = new Set();
+// A FAILED tool call with no assistant turn ahead of it in the thread, keyed by
+// message name → the copy to render. The Activity accordion is anchored to an
+// assistant message, so a tool row that arrives before any assistant text has
+// nowhere to hang and renders NOWHERE — which is exactly the shape an autonomous
+// delegate produces when its very first call is refused. Those rows are surfaced
+// inline instead; everything else keeps the accordion behaviour untouched. The
+// server writes plain, customer-facing text into error.message / error.hint for
+// this surface, so both are shown as-is.
+const orphanToolFailures = computed(() => {
+	const out = {};
 	let cur = null;
 	for (const m of messages.value) {
 		if (m.role === "user") cur = null;
 		else if (m.role === "assistant") cur = m.name;
-		else if (m.role === "tool" && !cur && !m.action_outcome && m.tool_status === "error")
-			out.add(m.name);
+		else if (m.role === "tool" && !cur && !m.action_outcome && m.tool_status === "error") {
+			let v = m.tool_result;
+			if (typeof v === "string") {
+				try {
+					v = JSON.parse(v);
+				} catch (e) {
+					v = null;
+				}
+			}
+			const err = (v && v.error) || {};
+			out[m.name] = {
+				message:
+					(typeof err.message === "string" && err.message.trim()) ||
+					"This step couldn't be completed.",
+				hint: (typeof err.hint === "string" && err.hint.trim()) || "",
+			};
+		}
 	}
 	return out;
 });
@@ -4373,7 +4393,7 @@ const visibleMessages = computed(() =>
 		// inline in the thread; every OTHER role=tool row belongs to the collapsed
 		// Activity accordion, not the main thread — except an orphaned FAILURE,
 		// which the accordion cannot hold.
-		if (m.role === "tool") return !!m.action_outcome || orphanToolErrors.value.has(m.name);
+		if (m.role === "tool") return !!m.action_outcome || !!orphanToolFailures.value[m.name];
 		if (m.role !== "user" && m.role !== "assistant") return false;
 		// Hide a blank streaming placeholder. The live "Working on it…" indicator
 		// below the thread already renders the assistant logo + status for the
@@ -4517,24 +4537,6 @@ function activityNames(assistantName) {
 	return (activityByAssistant.value[assistantName] || [])
 		.map((t) => toolLabel(t.tool_name))
 		.join(", ");
-}
-// The failure copy for an orphaned tool row: what happened, then the remedy. The
-// server writes plain, customer-facing text into error.message/error.hint for
-// exactly this surface, so both are shown as-is; the fallback covers a row whose
-// result won't parse.
-function toolFailParts(m) {
-	let v = m.tool_result;
-	if (typeof v === "string") {
-		try {
-			v = JSON.parse(v);
-		} catch (e) {
-			v = null;
-		}
-	}
-	const err = (v && v.error) || {};
-	const message = typeof err.message === "string" ? err.message.trim() : "";
-	const hint = typeof err.hint === "string" ? err.hint.trim() : "";
-	return { message: message || "This step couldn't be completed.", hint };
 }
 // args/result are stored as JSON strings — pretty-print, and trim very large
 // payloads so a 10k-row result doesn't blow up the chat.

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -701,9 +701,44 @@
 						<div v-if="dayDividers[mi]" class="jv-daydivider">
 							<span>{{ dayDividers[mi] }}</span>
 						</div>
+						<!-- an orphaned tool FAILURE (no assistant turn to hang it off) —
+						     e.g. a delegate refused on its very first call. Rendered here
+						     because the Activity accordion cannot hold it. -->
+						<div
+							v-if="m.role === 'tool' && !m.action_outcome"
+							class="jv-toolfail"
+							role="alert"
+						>
+							<svg
+								class="jv-toolfail-ico"
+								width="15"
+								height="15"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-hidden="true"
+							>
+								<circle cx="12" cy="12" r="9" />
+								<path d="M12 7.5v5.5M12 16.2v.2" />
+							</svg>
+							<div class="jv-toolfail-main">
+								<div class="jv-toolfail-title">
+									{{ toolLabel(m.tool_name) }} didn't run
+								</div>
+								<div class="jv-toolfail-msg">
+									{{ toolFailParts(m).message }}
+								</div>
+								<div v-if="toolFailParts(m).hint" class="jv-toolfail-hint">
+									{{ toolFailParts(m).hint }}
+								</div>
+							</div>
+						</div>
 						<!-- receipt chip: a confirmed / discarded / failed gated write, shown
 						     inline in place of the confirmation card that used to vanish -->
-						<ReceiptChip v-if="m.role === 'tool'" :message="m" />
+						<ReceiptChip v-else-if="m.role === 'tool'" :message="m" />
 						<!-- user -->
 						<Message
 							v-else-if="m.role === 'user'"
@@ -4315,12 +4350,30 @@ const modelsByProvider = computed(() => {
 const currentTitle = computed(
 	() => store.conversations.find((c) => c.name === currentId.value)?.title || "New chat"
 );
+// A FAILED tool call with no assistant turn ahead of it in the thread. The
+// Activity accordion is anchored to an assistant message, so a tool row that
+// arrives before any assistant text has nowhere to hang and renders NOWHERE —
+// which is exactly the shape an autonomous delegate produces when its very first
+// call is refused. Those rows are surfaced inline instead; everything else keeps
+// the accordion behaviour untouched.
+const orphanToolErrors = computed(() => {
+	const out = new Set();
+	let cur = null;
+	for (const m of messages.value) {
+		if (m.role === "user") cur = null;
+		else if (m.role === "assistant") cur = m.name;
+		else if (m.role === "tool" && !cur && !m.action_outcome && m.tool_status === "error")
+			out.add(m.name);
+	}
+	return out;
+});
 const visibleMessages = computed(() =>
 	messages.value.filter((m) => {
 		// Receipt-chip rows (a confirmed / discarded / failed gated write) render
 		// inline in the thread; every OTHER role=tool row belongs to the collapsed
-		// Activity accordion, not the main thread.
-		if (m.role === "tool") return !!m.action_outcome;
+		// Activity accordion, not the main thread — except an orphaned FAILURE,
+		// which the accordion cannot hold.
+		if (m.role === "tool") return !!m.action_outcome || orphanToolErrors.value.has(m.name);
 		if (m.role !== "user" && m.role !== "assistant") return false;
 		// Hide a blank streaming placeholder. The live "Working on it…" indicator
 		// below the thread already renders the assistant logo + status for the
@@ -4464,6 +4517,24 @@ function activityNames(assistantName) {
 	return (activityByAssistant.value[assistantName] || [])
 		.map((t) => toolLabel(t.tool_name))
 		.join(", ");
+}
+// The failure copy for an orphaned tool row: what happened, then the remedy. The
+// server writes plain, customer-facing text into error.message/error.hint for
+// exactly this surface, so both are shown as-is; the fallback covers a row whose
+// result won't parse.
+function toolFailParts(m) {
+	let v = m.tool_result;
+	if (typeof v === "string") {
+		try {
+			v = JSON.parse(v);
+		} catch (e) {
+			v = null;
+		}
+	}
+	const err = (v && v.error) || {};
+	const message = typeof err.message === "string" ? err.message.trim() : "";
+	const hint = typeof err.hint === "string" ? err.hint.trim() : "";
+	return { message: message || "This step couldn't be completed.", hint };
 }
 // args/result are stored as JSON strings — pretty-print, and trim very large
 // payloads so a 10k-row result doesn't blow up the chat.
@@ -8979,6 +9050,43 @@ onUnmounted(() => {
 	overflow-x: auto;
 	max-height: 320px;
 	overflow-y: auto;
+}
+/* an orphaned tool failure surfaced inline (no assistant turn to hang it off) */
+.jv-toolfail {
+	display: flex;
+	align-items: flex-start;
+	gap: 9px;
+	margin: 4px 0;
+	padding: 9px 13px;
+	border: 1px solid var(--red-bd, color-mix(in srgb, var(--red) 32%, var(--border)));
+	border-radius: 11px;
+	background: var(--red-bg, var(--surface-2));
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--text);
+}
+.jv-toolfail-ico {
+	flex: none;
+	margin-top: 1px;
+	color: var(--red);
+}
+.jv-toolfail-main {
+	min-width: 0;
+}
+.jv-toolfail-title {
+	font-weight: 550;
+	overflow-wrap: anywhere;
+}
+.jv-toolfail-msg {
+	margin-top: 2px;
+	color: var(--text-2);
+	overflow-wrap: anywhere;
+}
+.jv-toolfail-hint {
+	margin-top: 3px;
+	font-size: 12.5px;
+	color: var(--text-3);
+	overflow-wrap: anywhere;
 }
 .jv-meta span {
 	display: inline-flex;

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -198,7 +198,7 @@ def _dispatch_from_session(
 	"""
 	# impersonate is session-safe: a bare frappe.set_user in this HTTP path
 	# would gut the caller's cookie session sid + data and log them out.
-	from jarvis.tools import _agent_run_ctx
+	from jarvis.tools import _agent_run_ctx, _delegate_capability
 
 	# Expose the caller's session_key to the tool for this dispatch (the LLM
 	# never authors it — it is the delegate's opaque bearer, delivered over the
@@ -210,6 +210,33 @@ def _dispatch_from_session(
 	_agent_run_ctx.set_session_key(session_key)
 	try:
 		with impersonate(user):
+			# JF-017 — the delegate capability gate, BEFORE anything is dispatched.
+			# When this session resolves to a marketplace-agent run, the only tools it
+			# may call are the ones its manifest declared and the bench snapshotted
+			# onto the run at launch. The container's tools.allow is configuration
+			# (fleet renders it into openclaw.json); it is not authorization, so a
+			# compromised container/plugin or a leaked run bearer would otherwise
+			# reach ANY registered tool the run-as user's Frappe roles permit. Fails
+			# closed: a run with no snapshot and no legacy marker is refused outright.
+			# Non-delegate sessions (ordinary chat) resolve to None and are untouched.
+			denial = _delegate_capability.tool_denial(session_key, tool)
+			if denial:
+				result = _error("CapabilityDeniedError", denial)
+				audit.record(
+					tool=tool,
+					args={},
+					ok=False,
+					error_code="CapabilityDeniedError",
+					error_message=denial,
+				)
+				_persist_and_publish_tool_call(
+					session_key=session_key,
+					tool=tool,
+					args={},
+					result=result,
+					tool_call_id=tool_call_id,
+				)
+				return result
 			# Parse args up front so persist_and_publish gets the same
 			# dict shape the tool ran against (or the empty dict on a
 			# malformed-args rejection).

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -8,7 +8,7 @@ from jarvis import audit, telemetry
 from jarvis._http import validate_bearer as _validate_bearer
 from jarvis._plugin_auth import PluginAuthError, validate_plugin_request
 from jarvis._session import impersonate
-from jarvis.exceptions import InvalidArgumentError, JarvisError
+from jarvis.exceptions import CapabilityDeniedError, InvalidArgumentError, JarvisError
 from jarvis.permissions import has_jarvis_access
 from jarvis.tools.registry import dispatch
 
@@ -221,7 +221,12 @@ def _dispatch_from_session(
 			# Non-delegate sessions (ordinary chat) resolve to None and are untouched.
 			denial = _delegate_capability.tool_denial(session_key, tool)
 			if denial:
-				result = _error("CapabilityDeniedError", denial)
+				code = CapabilityDeniedError.__name__
+				hint = _hint_for(code, "")
+				# The DELEGATE reads this one: the contract vocabulary, and (inside the
+				# message, the only field the plugin relays to the model) the fact that
+				# retrying can never help because the snapshot is fixed for the run.
+				result = _error(code, denial["message"], hint=hint)
 				# What was ATTEMPTED is the forensic value of a refusal, so record the
 				# args too — scrubbed + truncated by audit.record. Parsed only here,
 				# inside the deny branch, so the gate itself stays the first thing that
@@ -234,16 +239,27 @@ def _dispatch_from_session(
 					tool=tool,
 					args=attempted,
 					ok=False,
-					error_code="CapabilityDeniedError",
-					error_message=denial,
+					error_code=code,
+					error_message=denial["message"],
 				)
+				# The CUSTOMER reads this one. The transcript receipt renders verbatim
+				# in chat, so it carries plain language plus the remedy — the contract
+				# wording stays in the audit trail and the delegate's envelope above.
 				_persist_and_publish_tool_call(
 					session_key=session_key,
 					tool=tool,
 					args=attempted,
-					result=result,
+					result=_error(code, denial["chat_message"], hint=hint),
 					tool_call_id=tool_call_id,
 				)
+				if denial["fatal"]:
+					# This run's contract authorises NOTHING — record_agent_run included
+					# — so it can never finish itself. Terminalize it NOW with the real
+					# reason instead of leaving it "running" for the 3h stale-run sweep
+					# to mislabel as a timeout.
+					from jarvis.chat import agent_scheduler
+
+					agent_scheduler.fail_run(denial["run"], denial["run_error"])
 				return result
 			# Parse args up front so persist_and_publish gets the same
 			# dict shape the tool ran against (or the empty dict on a
@@ -884,6 +900,14 @@ _ERROR_HINTS = {
 	),
 	"InvalidArgumentError": (
 		"Some of the values need attention - check the highlighted fields and try again."
+	),
+	# JF-017. The agent's tool surface is fixed when it is published, so unlike a
+	# permission denial there is nothing the USER can change - the remedy is the
+	# bundle. (The delegate's own "retrying will not help" instruction rides in the
+	# message; the plugin relays only code + message to the model.)
+	"CapabilityDeniedError": (
+		"This agent can only use the tools it was published with. Ask your "
+		"administrator to review the agent's bundle if it needs another one."
 	),
 }
 # Frappe's User-Permission link denial reads "...not allowed to access this X

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -222,9 +222,17 @@ def _dispatch_from_session(
 			denial = _delegate_capability.tool_denial(session_key, tool)
 			if denial:
 				result = _error("CapabilityDeniedError", denial)
+				# What was ATTEMPTED is the forensic value of a refusal, so record the
+				# args too — scrubbed + truncated by audit.record. Parsed only here,
+				# inside the deny branch, so the gate itself stays the first thing that
+				# runs and a malformed-args call is still refused on the contract.
+				try:
+					attempted = _parse_args(args)
+				except JarvisError:
+					attempted = {}
 				audit.record(
 					tool=tool,
-					args={},
+					args=attempted,
 					ok=False,
 					error_code="CapabilityDeniedError",
 					error_message=denial,
@@ -232,7 +240,7 @@ def _dispatch_from_session(
 				_persist_and_publish_tool_call(
 					session_key=session_key,
 					tool=tool,
-					args={},
+					args=attempted,
 					result=result,
 					tool_call_id=tool_call_id,
 				)

--- a/jarvis/chat/agent_catalog.py
+++ b/jarvis/chat/agent_catalog.py
@@ -339,6 +339,31 @@ def registry_timeout_s(agent_slug: str, default: int = 600) -> int:
 	return default
 
 
+def registry_tools_allow(agent_slug: str) -> list[str]:
+	"""The agent's DECLARED tool surface from the BUNDLED registry, verbatim.
+
+	The same metadata ``build_agent_push_payload`` echoes into the container's
+	enablement signal — the manifest's ``tools_allow``, openclaw-facing ids
+	(``jarvis__get_doc``) plus the container-side tools (``exec``/``canvas``/
+	``message``) the bench never serves. JF-017 snapshots this onto the run at
+	launch and enforces it bench-side, so it is no longer just the container's
+	configuration.
+
+	Returns ``[]`` for an unknown slug or a malformed entry — under a ``snapshot``
+	contract that authorises NOTHING, which is the intended fail-closed outcome for
+	a run whose bundle the bench cannot describe."""
+	slug = (agent_slug or "").strip()
+	if not slug:
+		return []
+	for a in _load_registry().get("agents") or []:
+		if (a.get("agent_slug") or "").strip() == slug:
+			declared = a.get("tools_allow")
+			if not isinstance(declared, list):
+				return []
+			return [str(t).strip() for t in declared if str(t or "").strip()]
+	return []
+
+
 def after_migrate() -> None:
 	"""hooks.after_migrate entry: keep the catalog in lockstep with the bundled
 	registry on every migrate. Best-effort — a catalog hiccup must never fail a

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -303,29 +303,18 @@ def reap_stale_agent_runs() -> int:
 				frappe.db.commit()
 				reaped += 1
 				continue
-			frappe.db.set_value(
-				RUN,
+			# The row lock is already held and the compare-and-set above has already
+			# established that the row is still ``running``, so this goes straight to
+			# the shared terminalization tail.
+			_terminalize_failed(
 				r.name,
-				{
-					"status": "failed",
-					"finished_at": frappe.utils.now(),
-					"error": "run exceeded max duration; reaped by the stale-run sweep (A8 backstop)",
-				},
-				update_modified=False,
-			)
-			frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
-			# A8: the session bearer must not outlive the (now-failed) run.
-			agent_runs.teardown_run_session(cur.session_key)
-			log_activity(
 				agent=cur.agent,
-				agent_title=frappe.db.get_value(LISTING, cur.agent, "title"),
 				installation=cur.installation,
-				action="run_failed",
-				run=r.name,
-				detail="reaped: run exceeded max duration",
+				session_key=cur.session_key,
 				owner=cur.owner,
+				error="run exceeded max duration; reaped by the stale-run sweep (A8 backstop)",
+				detail="reaped: run exceeded max duration",
 			)
-			frappe.db.commit()
 			reaped += 1
 		except Exception:
 			frappe.log_error(
@@ -344,6 +333,97 @@ def _stale_candidates(cutoff) -> list:
 		filters={"status": "running", "started_at": ["<", cutoff]},
 		fields=["name", "session_key", "owner", "agent", "installation", "pages_written"],
 	)
+
+
+def _terminalize_failed(
+	run_name: str,
+	*,
+	agent: str | None,
+	installation: str | None,
+	session_key: str | None,
+	owner: str | None,
+	error: str,
+	detail: str | None = None,
+) -> None:
+	"""Stamp a run ``failed`` + tear down its bearer + log the activity — the tail
+	shared by every path that kills a RUNNING run.
+
+	The caller must already have established that the row is still ``running``:
+	the reaper holds the row lock from its compare-and-set, ``fail_run`` takes one.
+	Ordering is load-bearing — the status write is committed (releasing the row
+	lock) BEFORE the session teardown, so a teardown never runs under the lock."""
+	from jarvis.chat import agent_runs
+
+	frappe.db.set_value(
+		RUN,
+		run_name,
+		{
+			"status": "failed",
+			"finished_at": frappe.utils.now(),
+			"error": (error or "")[:140],
+		},
+		update_modified=False,
+	)
+	frappe.db.commit()  # win + release the row lock BEFORE tearing down the session
+	# A8: the session bearer must not outlive the (now-failed) run.
+	agent_runs.teardown_run_session(session_key)
+	log_activity(
+		agent=agent,
+		agent_title=frappe.db.get_value(LISTING, agent, "title") if agent else "",
+		installation=installation,
+		action="run_failed",
+		run=run_name,
+		detail=(detail or error or "")[:140],
+		owner=owner,
+	)
+	frappe.db.commit()
+
+
+def fail_run(run_name: str, error: str, *, detail: str | None = None) -> bool:
+	"""Terminalize a RUNNING agent run as ``failed`` with ``error``. Returns True
+	iff this call is the one that transitioned it.
+
+	The honest-failure entry point for a run that is provably dead before it can
+	finalize itself — today, a delegate whose capability contract authorises no
+	tool at all (JF-017), which is refused on every call INCLUDING the
+	``record_agent_run`` writeback. Without this the row would sit ``running``
+	until the 3h stale-run sweep relabelled it "exceeded max duration", sending
+	the customer after a timeout that never happened.
+
+	Same discipline as the sweep: commit first so the ``FOR UPDATE`` opens the
+	read view, compare-and-set on ``status='running'`` under the row lock so a
+	concurrent finish is never overwritten with ``failed``. Best-effort — a
+	failure to record the failure must never take down the caller's response."""
+	if not run_name:
+		return False
+	try:
+		frappe.db.commit()  # REPEATABLE-READ discipline: FOR UPDATE goes first
+		cur = frappe.db.get_value(
+			RUN,
+			run_name,
+			["status", "agent", "installation", "session_key", "owner"],
+			as_dict=True,
+			for_update=True,
+		)
+		if not cur or cur.status != "running":
+			frappe.db.commit()  # release the lock; a concurrent finish already won
+			return False
+		_terminalize_failed(
+			run_name,
+			agent=cur.agent,
+			installation=cur.installation,
+			session_key=cur.session_key,
+			owner=cur.owner,
+			error=error,
+			detail=detail,
+		)
+		return True
+	except Exception:
+		frappe.log_error(
+			title=f"jarvis agent: run failure stamp failed: {run_name}",
+			message=frappe.get_traceback(),
+		)
+		return False
 
 
 # --------------------------------------------------------------------------- #
@@ -390,6 +470,26 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 			)
 		)
 
+	# JF-017: the run's CAPABILITY CONTRACT. Resolved HERE, before any row exists,
+	# because an empty declared surface is not a runnable state: the bench would
+	# refuse every call the delegate makes — record_agent_run included — so the run
+	# could never finalize itself and would sit "running" until the 3h stale-run
+	# sweep relabelled it a timeout it never hit. Refuse the LAUNCH instead, with
+	# the real reason, and leave no orphan conversation/run behind (same discipline
+	# as the run_as_user guard above). Imported inside the function so the bundled
+	# registry stays the one seam tests inject a declared surface at.
+	from jarvis.chat.agent_catalog import registry_tools_allow
+
+	declared_tools = registry_tools_allow(listing.agent_slug)
+	if not declared_tools:
+		frappe.throw(
+			_(
+				"This agent's bundle declares no tools, so the run would be refused at "
+				"every step and could never finish. Reinstall or update the agent, or "
+				"contact support — nothing was started."
+			)
+		)
+
 	# Fresh conversation. ROW ownership is the human owner (reassigned below) so
 	# if_owner visibility works; the ERP-read identity is the run-as user.
 	# ignore_permissions matches the macro engine.
@@ -414,13 +514,13 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 	preparation_mode = inst.activation_state or "shadow"
 	initiating_human = frappe.session.user if trigger == "manual" else None
 
-	# JF-017: the run's CAPABILITY CONTRACT, snapshotted in the same insert and
-	# under the same immutability guard — the declared ``tools_allow`` (bundled
-	# registry) plus the listing's ``nature``/``writes`` as they stand RIGHT NOW.
-	# From here on the bench authorises this run's tool calls against the snapshot,
-	# never against the mutable listing, so neither a listing edit mid-run nor a
-	# compromised container can widen what an in-flight run may do.
-	capability = _delegate_capability.contract_for_launch(listing)
+	# Stamped in the same insert and under the same immutability guard — the
+	# declared ``tools_allow`` resolved above plus the listing's ``nature``/
+	# ``writes`` as they stand RIGHT NOW. From here on the bench authorises this
+	# run's tool calls against the snapshot, never against the mutable listing, so
+	# neither a listing edit mid-run nor a compromised container can widen what an
+	# in-flight run may do.
+	capability = _delegate_capability.contract_for_launch(listing, declared_tools)
 
 	run = frappe.get_doc(
 		{

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -38,6 +38,7 @@ from frappe.utils import now_datetime
 
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.macro_scheduler import compute_next_run
+from jarvis.tools import _delegate_capability
 
 INSTALLATION = "Jarvis Agent Installation"
 LISTING = "Jarvis Agent Listing"
@@ -413,6 +414,14 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 	preparation_mode = inst.activation_state or "shadow"
 	initiating_human = frappe.session.user if trigger == "manual" else None
 
+	# JF-017: the run's CAPABILITY CONTRACT, snapshotted in the same insert and
+	# under the same immutability guard — the declared ``tools_allow`` (bundled
+	# registry) plus the listing's ``nature``/``writes`` as they stand RIGHT NOW.
+	# From here on the bench authorises this run's tool calls against the snapshot,
+	# never against the mutable listing, so neither a listing edit mid-run nor a
+	# compromised container can widen what an in-flight run may do.
+	capability = _delegate_capability.contract_for_launch(listing)
+
 	run = frappe.get_doc(
 		{
 			"doctype": RUN,
@@ -425,6 +434,7 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 			"bundle_version": bundle_version,
 			"preparation_mode": preparation_mode,
 			"initiating_human": initiating_human,
+			**capability,
 		}
 	)
 	run.flags.ignore_permissions = True

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -10,6 +10,19 @@ class PermissionDeniedError(JarvisError):
 	"""Raised when the calling user lacks permission for the requested operation."""
 
 
+class CapabilityDeniedError(JarvisError):
+	"""JF-017 — a marketplace-agent delegate called a tool outside the capability
+	contract snapshotted onto its ``Jarvis Agent Run`` at launch.
+
+	Deliberately NOT a ``PermissionDeniedError``: the run-as user's Frappe rights
+	are irrelevant here. The AGENT never declared the tool, and the snapshot is
+	immutable for the life of the run — so unlike a permission denial (which an
+	administrator can resolve mid-run) the answer is FIXED. Retrying, renaming the
+	tool or changing the arguments can never turn it into a yes; that is what the
+	``_ERROR_HINTS`` entry tells the delegate, so it stops burning turns on it.
+	"""
+
+
 class InvalidArgumentError(JarvisError):
 	"""Raised when tool arguments fail validation."""
 

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.json
@@ -12,6 +12,10 @@
   "bundle_version",
   "preparation_mode",
   "initiating_human",
+  "capability_contract",
+  "tools_allow_json",
+  "capability_nature",
+  "capability_writes_json",
   "status",
   "result_state",
   "started_at",
@@ -112,7 +116,8 @@
    "fieldtype": "Data",
    "label": "Session Key",
    "read_only": 1,
-   "description": "The opaque per-run Jarvis Chat Session key minted for this run (e.g. agent:<slug>:<run>). Resolves the run-as user for the delegate's jarvis__* calls. Bearer-sensitive; torn down after the run (Phase 4)."
+   "search_index": 1,
+   "description": "The opaque per-run Jarvis Chat Session key minted for this run (e.g. agent:<slug>:<run>). Resolves the run-as user for the delegate's jarvis__* calls. Bearer-sensitive; torn down after the run (Phase 4). Indexed: JF-017 resolves the capability contract from it on EVERY plugin tool call."
   },
   {
    "fieldname": "dashboard",
@@ -228,6 +233,39 @@
    "read_only": 1,
    "no_copy": 1,
    "description": "PP-5 — the human who triggered a manual run (distinct from the run-as user and from the reassigned owner)."
+  },
+  {
+   "fieldname": "capability_contract",
+   "fieldtype": "Select",
+   "label": "Capability Contract",
+   "options": "\nsnapshot\nlegacy",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "JF-017 — which capability regime governs this run. 'snapshot': the three fields below are the authority (a tool outside tools_allow_json is refused at dispatch). 'legacy': the run predates the guard, so no tools_allow gate applies and the write caps read the live listing. Blank on a run created AFTER the guard landed means no launch stamped it: everything is refused."
+  },
+  {
+   "fieldname": "tools_allow_json",
+   "fieldtype": "Small Text",
+   "label": "Tools Allow JSON",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "JF-017 — the EXACT tools_allow the agent's bundled manifest declared, snapshotted at launch. The bench refuses any jarvis__* call outside it before dispatch, so a compromised container/plugin holding this run's session bearer cannot reach a tool the agent never declared. Immutable once stamped."
+  },
+  {
+   "fieldname": "capability_nature",
+   "fieldtype": "Data",
+   "label": "Capability Nature",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "JF-017 — the listing's nature (auditor|operator|scribe) AT LAUNCH. The delegate write caps read this instead of the mutable listing, so re-naturing a listing mid-run cannot grant an in-flight run new write authority."
+  },
+  {
+   "fieldname": "capability_writes_json",
+   "fieldtype": "Small Text",
+   "label": "Capability Writes JSON",
+   "read_only": 1,
+   "no_copy": 1,
+   "description": "JF-017 — the declarative operator write contract ([{doctype, mode}]) AT LAUNCH. The create/update capability gate binds to this snapshot, never to the current Jarvis Agent Listing.writes."
   }
  ],
  "index_web_pages_for_search": 0,

--- a/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.py
+++ b/jarvis/jarvis/doctype/jarvis_agent_run/jarvis_agent_run.py
@@ -19,10 +19,20 @@ from frappe.model.document import Document
 # triggered it. The engine stamps them at launch and updates run lifecycle via
 # raw ``db.set_value`` (which bypasses this controller); any ORM save that tries
 # to change a stamped launch fact is refused.
+#
+# JF-017 extends the same protection to the run's CAPABILITY CONTRACT (which tools
+# it may call, its nature, its declared writes). That contract is the run's
+# authorization, so it has to be at least as immutable as its provenance: if it
+# could be edited after launch, snapshotting it would buy nothing over reading the
+# mutable listing.
 _IMMUTABLE_LAUNCH_FIELDS = (
 	"bundle_version",
 	"preparation_mode",
 	"initiating_human",
+	"capability_contract",
+	"tools_allow_json",
+	"capability_nature",
+	"capability_writes_json",
 )
 
 

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -35,3 +35,4 @@ jarvis.patches.v2_04_chat_turn_admission_indexes
 jarvis.patches.v2_05_relay_pump_transport_mode
 jarvis.patches.v2_06_retire_app_learning_runs
 jarvis.patches.v2_06_skill_promotion_marker_and_shared_slug
+jarvis.patches.v2_07_agent_run_capability_snapshot

--- a/jarvis/patches/v2_07_agent_run_capability_snapshot.py
+++ b/jarvis/patches/v2_07_agent_run_capability_snapshot.py
@@ -1,0 +1,41 @@
+"""JF-017: mark every PRE-EXISTING ``Jarvis Agent Run`` as a legacy capability run.
+
+From this deploy on, ``agent_scheduler._launch_audit`` snapshots the run's
+capability contract (``tools_allow_json`` / ``capability_nature`` /
+``capability_writes_json``) onto the row and ``jarvis.api`` refuses any delegate
+tool call outside it. Rows that already exist carry no snapshot, so without this
+patch an in-flight run would be refused every tool the moment the code lands —
+the guard would fail closed on runs it was never meant to judge.
+
+Stamping them ``legacy`` says so explicitly: no tools_allow gate, and the write
+caps keep resolving nature/writes from the live listing, exactly the regime those
+runs launched under. It is a one-shot marker, never re-applied — a run created
+AFTER this patch either carries a real snapshot or is refused (a blank contract on
+a post-cutover row means something bypassed ``_launch_audit``).
+
+The cutover instant itself is this patch's own ``Patch Log`` row: a blank-contract
+run created before it (one that raced the deploy — new code serving before migrate
+finished) is still granted the legacy fallback, one created after it is not. See
+``jarvis.tools._delegate_capability``.
+
+RAW SQL, not ``doc.save()``: the controller stamps these fields immutable, and a
+per-row ORM save over the whole run history would be slow and would re-run
+validation against rows the migrate has not finished touching.
+"""
+
+import frappe
+
+RUN = "Jarvis Agent Run"
+
+
+def execute():
+	# The column exists after post_model_sync; guard anyway so a partial deploy
+	# state can never 500 the patch.
+	if not frappe.db.has_column(RUN, "capability_contract"):
+		return
+	frappe.db.sql(
+		"""update `tabJarvis Agent Run`
+		   set capability_contract = 'legacy'
+		   where capability_contract is null or capability_contract = ''"""
+	)
+	frappe.db.commit()

--- a/jarvis/tests/test_platform_capability_contract.py
+++ b/jarvis/tests/test_platform_capability_contract.py
@@ -1,0 +1,618 @@
+"""JF-017 — the delegate capability contract is snapshotted at launch and enforced
+at the bench.
+
+The defect: a session-bound plugin call from a delegate run reached
+``jarvis.api._run_tool`` without EVER being compared against the agent's declared
+``tools_allow``. The container's ``tools.allow`` is CONFIGURATION (fleet renders it
+into openclaw.json); it is not authorization, so a compromised container/plugin or
+a leaked per-run session bearer could call ANY registered tool the run-as user's
+Frappe roles permitted. And the write guard read the CURRENT (mutable)
+``Jarvis Agent Listing.nature``/``.writes``, so editing a listing re-authorised an
+IN-FLIGHT run.
+
+What is proven here:
+  * a REGISTERED but UNDECLARED tool is refused over a delegate session, with the
+    ``CapabilityDeniedError`` code, and never dispatched — while the SAME tool
+    succeeds for the same user on a non-delegate session;
+  * the run's authority is fixed at launch: re-naturing the listing, editing its
+    ``writes``, or widening the bundled registry mid-run changes NOTHING for an
+    in-flight run, in either direction;
+  * auditor/operator write caps are driven by the run SNAPSHOT;
+  * a legacy run (stamped by ``v2_07_agent_run_capability_snapshot``) still
+    executes exactly as it did before the guard;
+  * a run with NO contract created after the cutover is refused (fail closed);
+  * ``_launch_audit`` actually stamps the contract, and the controller refuses to
+    let it be edited afterwards.
+
+Run:
+  bench --site patterntest.localhost run-tests --app jarvis \
+    --module jarvis.tests.test_platform_capability_contract
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api
+from jarvis.chat import agent_catalog, agent_scheduler
+from jarvis.exceptions import PermissionDeniedError
+from jarvis.tools import _agent_run_ctx, _delegate_capability
+from jarvis.tools.create_doc import create_doc
+
+LISTING = "Jarvis Agent Listing"
+INSTALLATION = "Jarvis Agent Installation"
+RUN = "Jarvis Agent Run"
+PATCH_LOG = "Patch Log"
+
+AUD_SLUG = "cc-auditor"
+OP_SLUG = "cc-operator"
+OP_WRITES = [{"doctype": "ToDo", "mode": "draft"}]
+
+# What the auditor's manifest declared: two reads + the writeback pair + the
+# container-side tools the bench never serves.
+AUD_TOOLS_ALLOW = [
+	"jarvis__get_schema",
+	"jarvis__query",
+	"jarvis__record_agent_run",
+	"exec",
+	"canvas",
+	"message",
+]
+OP_TOOLS_ALLOW = ["jarvis__get_schema", "jarvis__create_doc", "canvas", "message"]
+
+
+def _mk_user(email: str, roles=("System Manager",)) -> str:
+	if not frappe.db.exists("User", email):
+		u = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": email.split("@")[0],
+				"send_welcome_email": 0,
+			}
+		)
+		u.flags.ignore_permissions = True
+		u.insert(ignore_permissions=True)
+	existing = {r.role for r in frappe.get_doc("User", email).roles}
+	for role in roles:
+		if role not in existing:
+			frappe.get_doc("User", email).add_roles(role)
+	return email
+
+
+def _mk_listing(slug: str, nature: str, writes) -> None:
+	"""A dependency-free published listing (no min_apps / doctypes_required), so the
+	install-time installability preflight passes on any bench."""
+	if frappe.db.exists(LISTING, slug):
+		frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": LISTING,
+			"agent_slug": slug,
+			"title": f"Capability {slug}",
+			"nature": nature,
+			"delivery": "delegate",
+			"status": "Published",
+			"version": "0.1.0",
+			"rule_tokens": json.dumps([]),
+			"min_apps": json.dumps([]),
+			"doctypes_required": json.dumps([]),
+			"writes": json.dumps(writes or []),
+		}
+	).insert(ignore_permissions=True)
+
+
+def _mk_run(slug: str, run_as: str, session_key: str, contract: dict) -> str:
+	"""A running Jarvis Agent Run bound to ``session_key`` carrying ``contract`` —
+	the shape ``_launch_audit`` stamps (or a deliberately degenerate one)."""
+	inst = frappe.get_doc(
+		{
+			"doctype": INSTALLATION,
+			"agent": slug,
+			"run_as_user": run_as,
+			"activation_state": "shadow",
+		}
+	)
+	inst.owner = run_as
+	inst.flags.ignore_permissions = True
+	inst.insert(ignore_permissions=True)
+	run = frappe.get_doc(
+		{
+			"doctype": RUN,
+			"agent": slug,
+			"installation": inst.name,
+			"trigger": "manual",
+			"status": "running",
+			"started_at": frappe.utils.now(),
+			"session_key": session_key,
+			**contract,
+		}
+	)
+	run.owner = run_as
+	run.flags.ignore_permissions = True
+	run.insert(ignore_permissions=True)
+	return run.name
+
+
+def _snapshot(tools_allow: list, nature: str, writes: list) -> dict:
+	return {
+		"capability_contract": _delegate_capability.CONTRACT_SNAPSHOT,
+		"tools_allow_json": json.dumps(tools_allow),
+		"capability_nature": nature,
+		"capability_writes_json": json.dumps(writes),
+	}
+
+
+def _mk_todo(owner: str) -> str:
+	doc = frappe.get_doc({"doctype": "ToDo", "description": "capability contract todo"})
+	doc.owner = owner
+	doc.flags.ignore_permissions = True
+	doc.insert(ignore_permissions=True)
+	frappe.db.set_value("ToDo", doc.name, "owner", owner, update_modified=False)
+	return doc.name
+
+
+def _wipe():
+	for slug in (AUD_SLUG, OP_SLUG):
+		for dt in (RUN, INSTALLATION):
+			for n in frappe.get_all(dt, filters={"agent": slug}, pluck="name", ignore_permissions=True):
+				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+		if frappe.db.exists(LISTING, slug):
+			frappe.delete_doc(LISTING, slug, force=True, ignore_permissions=True)
+
+
+class _DelegateCase(FrappeTestCase):
+	"""Shared fixture: an auditor run and an operator run, each carrying the launch
+	snapshot, plus the helpers to enter a delegate dispatch context."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		cls.run_as = _mk_user("cc-runas@example.com")
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		_wipe()
+		_mk_listing(AUD_SLUG, "Auditor", [])
+		_mk_listing(OP_SLUG, "Operator", OP_WRITES)
+		self.aud_key = f"agent:agent-{AUD_SLUG}:cc-aud-run"
+		self.op_key = f"agent:agent-{OP_SLUG}:cc-op-run"
+		self.aud_run = _mk_run(AUD_SLUG, self.run_as, self.aud_key, _snapshot(AUD_TOOLS_ALLOW, "auditor", []))
+		self.op_run = _mk_run(
+			OP_SLUG, self.run_as, self.op_key, _snapshot(OP_TOOLS_ALLOW, "operator", OP_WRITES)
+		)
+
+	def tearDown(self):
+		_agent_run_ctx.clear_session_key()
+		frappe.set_user("Administrator")
+		_wipe()
+
+	def _as_delegate(self, session_key: str):
+		"""The tool-side context the plugin dispatcher establishes: the run-as
+		identity plus its session_key on frappe.local."""
+		frappe.set_user(self.run_as)
+		_agent_run_ctx.set_session_key(session_key)
+
+	def _dispatch(self, session_key: str, tool: str, args: dict | None = None) -> dict:
+		"""The REAL plugin dispatch entry point (impersonation, capability gate,
+		_run_tool, receipt) — not a hand-rolled stand-in for it."""
+		return api._dispatch_from_session(self.run_as, session_key, tool, args or {})
+
+
+# --------------------------------------------------------------------------- #
+# the tools_allow gate
+# --------------------------------------------------------------------------- #
+class TestDelegateToolAllowGate(_DelegateCase):
+	def test_declared_tool_is_dispatched(self):
+		"""The gate must not over-block: a DECLARED tool runs normally."""
+		res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+
+	def test_registered_but_undeclared_read_tool_is_refused(self):
+		"""THE defect. ``get_doc`` is registered and the run-as user (a System
+		Manager) may read the row — but the auditor never declared it, so the bench
+		refuses the call before dispatch."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		res = self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": todo})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+		self.assertIn("capability contract", res["error"]["message"])
+
+	def test_same_tool_succeeds_for_the_same_user_off_the_delegate_session(self):
+		"""Control for the test above: the refusal is the CONTRACT, not the user's
+		permissions — the identical call on a non-delegate session succeeds."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		res = self._dispatch("chat-session-with-no-agent-run", "get_doc", {"doctype": "ToDo", "name": todo})
+		self.assertTrue(res["ok"], res)
+
+	def test_destructive_tool_is_refused_and_never_dispatched(self):
+		"""The headline threat: a leaked run bearer driving ``delete_doc``. It must be
+		refused by the contract, and dispatch must never be reached (a gated write
+		would otherwise park a confirmation card)."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		with mock.patch.object(api, "_run_tool") as run_tool:
+			res = self._dispatch(self.aud_key, "delete_doc", {"doctype": "ToDo", "name": todo})
+		run_tool.assert_not_called()
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_container_side_entries_do_not_grant_bench_tools(self):
+		"""``exec``/``canvas``/``message`` are openclaw's own tools. They ride in the
+		manifest list but must never satisfy a bench tool name."""
+		for tool in ("exec", "canvas", "message"):
+			res = self._dispatch(self.aud_key, tool, {})
+			self.assertFalse(res["ok"], f"{tool} was allowed")
+			self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_registry_widened_midrun_does_not_widen_an_inflight_run(self):
+		"""Authority is the SNAPSHOT. Even a bundled registry that now declares every
+		tool leaves an in-flight run exactly as it was launched."""
+		wide = ["jarvis__" + t for t in ("get_schema", "get_doc", "delete_doc")]
+		with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=wide):
+			res = self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": "whatever"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_non_delegate_session_is_untouched(self):
+		"""A chat session_key with no bound Run is not a delegate — no gate at all."""
+		res = self._dispatch("chat-session-with-no-agent-run", "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+
+	def test_empty_snapshot_authorises_nothing(self):
+		"""Fail-closed: a snapshot the bench could not populate (unknown/retired
+		bundle) refuses every tool rather than defaulting to open."""
+		frappe.db.set_value(RUN, self.aud_run, "tools_allow_json", "[]", update_modified=False)
+		res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_unparseable_snapshot_authorises_nothing(self):
+		frappe.db.set_value(RUN, self.aud_run, "tools_allow_json", "not json", update_modified=False)
+		res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+
+# --------------------------------------------------------------------------- #
+# legacy runs + the cutover boundary
+# --------------------------------------------------------------------------- #
+class TestLegacyRunFallback(_DelegateCase):
+	def _undeclared_call(self) -> dict:
+		"""``get_doc`` on a readable row — refused under a snapshot (it is not in the
+		auditor's declared surface), so it is the honest probe for "is this run being
+		gated at all"."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		return self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": todo})
+
+	def test_legacy_run_still_executes_undeclared_tools(self):
+		"""A run in flight when the guard landed keeps the regime it launched under:
+		the patch stamps it ``legacy`` and no tools_allow gate applies."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": "legacy", "tools_allow_json": None},
+			update_modified=False,
+		)
+		res = self._undeclared_call()
+		self.assertTrue(res["ok"], res)
+
+	def test_blank_contract_after_the_cutover_is_refused(self):
+		"""A run created AFTER the patch with no snapshot never happened via
+		``_launch_audit``. It buys no legacy authority."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": None, "tools_allow_json": None},
+			update_modified=False,
+		)
+		before = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-1)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=before):
+			res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_blank_contract_before_the_cutover_is_legacy(self):
+		"""The deploy-race grace: a run created before the patch ran (new code already
+		serving, migrate not finished) is still treated as legacy."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": None, "tools_allow_json": None},
+			update_modified=False,
+		)
+		after = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=1)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=after):
+			res = self._undeclared_call()
+		self.assertTrue(res["ok"], res)
+
+	def test_blank_contract_ignores_the_snapshot_columns(self):
+		"""Only the marker makes the snapshot columns trustworthy. A row whose columns
+		are populated but whose marker is blank holds NO authority — otherwise a row
+		planted with a hand-written tools_allow would authorise itself."""
+		frappe.db.set_value(RUN, self.aud_run, "capability_contract", None, update_modified=False)
+		before = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-1)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=before):
+			res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_no_recorded_cutover_refuses_a_blank_contract(self):
+		"""No Patch Log row -> nothing to grandfather -> refuse (fail closed)."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": None, "tools_allow_json": None},
+			update_modified=False,
+		)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=None):
+			res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_cutoff_is_read_from_the_patch_log(self):
+		"""The cutover instant is the patch's own Patch Log row — not a constant that
+		could drift from when the guard actually landed on this site."""
+		created = False
+		if not frappe.db.exists(PATCH_LOG, {"patch": _delegate_capability.LEGACY_CUTOFF_PATCH}):
+			frappe.get_doc({"doctype": PATCH_LOG, "patch": _delegate_capability.LEGACY_CUTOFF_PATCH}).insert(
+				ignore_permissions=True
+			)
+			created = True
+		try:
+			expected = frappe.db.get_value(
+				PATCH_LOG, {"patch": _delegate_capability.LEGACY_CUTOFF_PATCH}, "creation"
+			)
+			self.assertEqual(_delegate_capability._legacy_cutoff(), expected)
+		finally:
+			if created:
+				frappe.delete_doc(
+					PATCH_LOG,
+					frappe.db.get_value(
+						PATCH_LOG, {"patch": _delegate_capability.LEGACY_CUTOFF_PATCH}, "name"
+					),
+					force=True,
+					ignore_permissions=True,
+				)
+
+
+# --------------------------------------------------------------------------- #
+# write caps are driven by the snapshot, not the live listing
+# --------------------------------------------------------------------------- #
+class TestWriteCapsFromSnapshot(_DelegateCase):
+	def test_operator_creates_a_snapshotted_doctype(self):
+		self._as_delegate(self.op_key)
+		res = create_doc("ToDo", {"description": "operator draft"})
+		self.assertEqual(res["doctype"], "ToDo")
+
+	def test_auditor_is_refused_every_write_from_its_snapshot(self):
+		self._as_delegate(self.aud_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			create_doc("ToDo", {"description": "auditor write"})
+		self.assertIn("no declared write capability", str(ctx.exception))
+
+	def test_renaturing_the_listing_midrun_grants_nothing(self):
+		"""THE mid-run mutation. Flipping the auditor's listing to Operator and giving
+		it a write contract must NOT reach the in-flight run."""
+		frappe.db.set_value(
+			LISTING,
+			AUD_SLUG,
+			{"nature": "Operator", "writes": json.dumps(OP_WRITES)},
+			update_modified=False,
+		)
+		self._as_delegate(self.aud_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			create_doc("ToDo", {"description": "escalated mid-run"})
+		self.assertIn("no declared write capability", str(ctx.exception))
+
+	def test_widening_listing_writes_midrun_grants_nothing(self):
+		"""An operator's contract cannot be extended to a new doctype mid-run."""
+		frappe.db.set_value(
+			LISTING,
+			OP_SLUG,
+			"writes",
+			json.dumps(OP_WRITES + [{"doctype": "Note", "mode": "draft"}]),
+			update_modified=False,
+		)
+		self._as_delegate(self.op_key)
+		with self.assertRaises(PermissionDeniedError) as ctx:
+			create_doc("Note", {"title": "smuggled in mid-run"})
+		self.assertIn("declared write contract", str(ctx.exception))
+
+	def test_emptying_listing_writes_midrun_revokes_nothing(self):
+		"""Immutability cuts both ways: a listing edit must not silently BREAK an
+		in-flight operator either."""
+		frappe.db.set_value(LISTING, OP_SLUG, "writes", json.dumps([]), update_modified=False)
+		self._as_delegate(self.op_key)
+		res = create_doc("ToDo", {"description": "still authorised"})
+		self.assertEqual(res["doctype"], "ToDo")
+
+	def test_blank_contract_operator_writes_nothing(self):
+		"""A post-cutover run with no contract marker has no write authority either —
+		its snapshot columns are not consulted, so it is refused like an auditor."""
+		frappe.db.set_value(RUN, self.op_run, "capability_contract", None, update_modified=False)
+		before = frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-1)
+		self._as_delegate(self.op_key)
+		with (
+			mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=before),
+			self.assertRaises(PermissionDeniedError) as ctx,
+		):
+			create_doc("ToDo", {"description": "unstamped run"})
+		self.assertIn("no declared write capability", str(ctx.exception))
+
+	def test_legacy_run_write_caps_follow_the_live_listing(self):
+		"""The grandfathered regime, documented: a legacy run has no snapshot, so its
+		write caps resolve against the listing exactly as they did pre-JF-017."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{
+				"capability_contract": "legacy",
+				"capability_nature": None,
+				"capability_writes_json": None,
+			},
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			LISTING,
+			AUD_SLUG,
+			{"nature": "Operator", "writes": json.dumps(OP_WRITES)},
+			update_modified=False,
+		)
+		self._as_delegate(self.aud_key)
+		res = create_doc("ToDo", {"description": "legacy run, live listing"})
+		self.assertEqual(res["doctype"], "ToDo")
+
+
+# --------------------------------------------------------------------------- #
+# the snapshot is stamped at launch and cannot be edited afterwards
+# --------------------------------------------------------------------------- #
+class TestLaunchStampsTheContract(unittest.TestCase):
+	"""``_launch_audit`` commits, so this class cleans up after itself rather than
+	relying on a test-case rollback. The listing is synthetic and dependency-free so
+	the install preflight passes on any bench; the DECLARED surface is injected at
+	the one seam ``contract_for_launch`` reads it from."""
+
+	SLUG = "cc-launch-agent"
+	OWNER = "cc-launch-owner@example.com"
+	DECLARED = ["jarvis__get_schema", "jarvis__record_agent_run", "exec", "canvas", "message"]
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		_mk_user(cls.OWNER)
+		frappe.db.commit()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self.created: list[tuple[str, str]] = []
+		_mk_listing(self.SLUG, "Auditor", [])
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for dt, name in self.created:
+			try:
+				frappe.delete_doc(dt, name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for dt in ("Jarvis Agent Activity", RUN, INSTALLATION):
+			if not frappe.db.exists("DocType", dt):
+				continue
+			for n in frappe.get_all(dt, filters={"agent": self.SLUG}, pluck="name"):
+				try:
+					frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
+				except Exception:
+					pass
+		if frappe.db.exists(LISTING, self.SLUG):
+			frappe.delete_doc(LISTING, self.SLUG, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+	def _launch(self) -> str:
+		import jarvis.admin_client as admin_client
+
+		inst = frappe.get_doc(
+			{
+				"doctype": INSTALLATION,
+				"agent": self.SLUG,
+				"run_as_user": self.OWNER,
+				"activation_state": "shadow",
+				"enabled": 1,
+			}
+		)
+		inst.owner = self.OWNER
+		inst.flags.ignore_permissions = True
+		inst.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		orig = admin_client.post_agent_run
+		admin_client.post_agent_run = lambda **kw: {"run_id": kw.get("run_id"), "status": "queued"}
+		frappe.set_user(self.OWNER)
+		try:
+			with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=self.DECLARED):
+				result = agent_scheduler._launch_audit(inst, trigger="manual")
+		finally:
+			frappe.set_user("Administrator")
+			admin_client.post_agent_run = orig
+		# Deleted before the run/installation sweep in tearDown (the Run links them).
+		self.created.append((RUN, result["run"]))
+		self.created.append(("Jarvis Conversation", result["conversation"]))
+		session = frappe.db.get_value("Jarvis Chat Session", {"session_key": result["session_key"]}, "name")
+		if session:
+			self.created.append(("Jarvis Chat Session", session))
+		return result["run"]
+
+	def test_launch_stamps_the_declared_contract(self):
+		run = self._launch()
+		row = frappe.db.get_value(
+			RUN,
+			run,
+			["capability_contract", "tools_allow_json", "capability_nature", "capability_writes_json"],
+			as_dict=True,
+		)
+		self.assertEqual(row.capability_contract, "snapshot")
+		self.assertEqual(row.capability_nature, "auditor")
+		self.assertEqual(json.loads(row.capability_writes_json), [])
+		# Stored VERBATIM — the declared list is the run's provenance, so the
+		# openclaw-facing ids and the container-side entries are kept as-is.
+		self.assertEqual(json.loads(row.tools_allow_json), self.DECLARED)
+
+	def test_the_stamped_contract_is_immutable(self):
+		run = self._launch()
+		doc = frappe.get_doc(RUN, run)
+		doc.tools_allow_json = json.dumps(["jarvis__delete_doc"])
+		with self.assertRaises(frappe.PermissionError):
+			doc.save(ignore_permissions=True)
+
+	def test_a_launched_run_refuses_an_undeclared_tool(self):
+		"""End to end: launch for real, then drive the real dispatch path."""
+		run = self._launch()
+		session_key = frappe.db.get_value(RUN, run, "session_key")
+		res = api._dispatch_from_session(self.OWNER, session_key, "delete_doc", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_a_launched_run_dispatches_a_declared_tool(self):
+		run = self._launch()
+		session_key = frappe.db.get_value(RUN, run, "session_key")
+		res = api._dispatch_from_session(self.OWNER, session_key, "get_schema", {"doctype": "ToDo"})
+		self.assertTrue(res["ok"], res)
+
+
+# --------------------------------------------------------------------------- #
+# registry sourcing
+# --------------------------------------------------------------------------- #
+class TestRegistryToolsAllow(FrappeTestCase):
+	def test_unknown_slug_yields_an_empty_surface(self):
+		self.assertEqual(agent_catalog.registry_tools_allow("no-such-agent"), [])
+		self.assertEqual(agent_catalog.registry_tools_allow(""), [])
+
+	def test_malformed_entry_yields_an_empty_surface(self):
+		synth = {"agents": [{"agent_slug": "cc-bad", "tools_allow": "jarvis__delete_doc"}]}
+		with mock.patch.object(agent_catalog, "_load_registry", return_value=synth):
+			self.assertEqual(agent_catalog.registry_tools_allow("cc-bad"), [])
+
+	def test_every_bundled_agent_declares_a_surface(self):
+		"""A bundled agent with no declared tools would be snapshotted as authorising
+		nothing — a launch that can never do anything. Catch it here, not in prod."""
+		for a in agent_catalog._load_registry().get("agents") or []:
+			slug = (a.get("agent_slug") or "").strip()
+			self.assertTrue(agent_catalog.registry_tools_allow(slug), f"{slug} declares no tools_allow")
+
+	def test_normalize_strips_only_the_jarvis_prefix(self):
+		self.assertEqual(_delegate_capability.normalize_tool("jarvis__get_doc"), "get_doc")
+		self.assertEqual(_delegate_capability.normalize_tool("exec"), "exec")
+		self.assertEqual(_delegate_capability.normalize_tool("  jarvis__query  "), "query")
+		self.assertEqual(_delegate_capability.normalize_tool(None), "")
+
+	def test_bench_tools_ignores_container_side_entries(self):
+		declared = ["jarvis__get_doc", "exec", "canvas", "message", "", None]
+		self.assertEqual(_delegate_capability.bench_tools(declared), {"get_doc"})

--- a/jarvis/tests/test_platform_capability_contract.py
+++ b/jarvis/tests/test_platform_capability_contract.py
@@ -821,12 +821,19 @@ class TestRegistryToolsAllow(FrappeTestCase):
 		with mock.patch.object(agent_catalog, "_load_registry", return_value=synth):
 			self.assertEqual(agent_catalog.registry_tools_allow("cc-bad"), [])
 
-	def test_every_bundled_agent_declares_a_surface(self):
-		"""A bundled agent with no declared tools would be snapshotted as authorising
-		nothing — a launch that can never do anything. Catch it here, not in prod."""
+	def test_every_bundled_agent_declares_a_usable_bench_surface(self):
+		"""A bundled agent with no declared tools is now refused at LAUNCH, and one
+		that declares only container-side tools (``exec``/``canvas``/``message``)
+		launches but is fatally refused at its first call. Either is a shipped agent
+		nobody can run — catch it here, not in prod."""
 		for a in agent_catalog._load_registry().get("agents") or []:
 			slug = (a.get("agent_slug") or "").strip()
-			self.assertTrue(agent_catalog.registry_tools_allow(slug), f"{slug} declares no tools_allow")
+			declared = agent_catalog.registry_tools_allow(slug)
+			self.assertTrue(declared, f"{slug} declares no tools_allow")
+			self.assertTrue(
+				_delegate_capability.bench_tools(declared),
+				f"{slug} declares no jarvis__ tool, so every bench call would be refused",
+			)
 
 	def test_normalize_strips_only_the_jarvis_prefix(self):
 		self.assertEqual(_delegate_capability.normalize_tool("jarvis__get_doc"), "get_doc")

--- a/jarvis/tests/test_platform_capability_contract.py
+++ b/jarvis/tests/test_platform_capability_contract.py
@@ -20,9 +20,17 @@ What is proven here:
   * auditor/operator write caps are driven by the run SNAPSHOT;
   * a legacy run (stamped by ``v2_07_agent_run_capability_snapshot``) still
     executes exactly as it did before the guard;
-  * a run with NO contract created after the cutover is refused (fail closed);
+  * a run with NO contract created after the cutover is refused (fail closed) —
+    but one created inside the bounded deploy window (migrate done, workers not
+    yet restarted) is NOT, because that run is a deploy artefact, not a forgery;
   * ``_launch_audit`` actually stamps the contract, and the controller refuses to
-    let it be edited afterwards.
+    let it be edited afterwards;
+  * a bundle that declares NO tool surface is refused at LAUNCH — no conversation,
+    no run, no bearer — and a run that somehow reaches dispatch with no usable
+    surface is FAILED at its first refusal with an honest error, never left
+    ``running`` for the 3h stale-run sweep to relabel as a timeout;
+  * the customer's transcript gets plain language while the delegate's envelope
+    keeps the contract wording plus the "retrying will not help" hint.
 
 Run:
   bench --site patterntest.localhost run-tests --app jarvis \
@@ -38,13 +46,17 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import api
 from jarvis.chat import agent_catalog, agent_scheduler
-from jarvis.exceptions import PermissionDeniedError
+from jarvis.exceptions import CapabilityDeniedError, JarvisError, PermissionDeniedError
 from jarvis.tools import _agent_run_ctx, _delegate_capability
 from jarvis.tools.create_doc import create_doc
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
+ACTIVITY = "Jarvis Agent Activity"
+CONVERSATION = "Jarvis Conversation"
+MESSAGE = "Jarvis Chat Message"
+SESSION = "Jarvis Chat Session"
 PATCH_LOG = "Patch Log"
 
 AUD_SLUG = "cc-auditor"
@@ -157,7 +169,9 @@ def _mk_todo(owner: str) -> str:
 
 def _wipe():
 	for slug in (AUD_SLUG, OP_SLUG):
-		for dt in (RUN, INSTALLATION):
+		# A fatal refusal terminalizes the run, which COMMITS and logs an activity row,
+		# so this fixture cannot rely on the test-case rollback for those two doctypes.
+		for dt in (ACTIVITY, RUN, INSTALLATION):
 			for n in frappe.get_all(dt, filters={"agent": slug}, pluck="name", ignore_permissions=True):
 				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
 		if frappe.db.exists(LISTING, slug):
@@ -190,6 +204,8 @@ class _DelegateCase(FrappeTestCase):
 	def tearDown(self):
 		_agent_run_ctx.clear_session_key()
 		frappe.set_user("Administrator")
+		for key in (self.aud_key, self.op_key):
+			frappe.db.delete(SESSION, {"session_key": key})
 		_wipe()
 
 	def _as_delegate(self, session_key: str):
@@ -282,6 +298,136 @@ class TestDelegateToolAllowGate(_DelegateCase):
 
 
 # --------------------------------------------------------------------------- #
+# a run that can never call anything is FAILED, not left hanging
+# --------------------------------------------------------------------------- #
+class TestBrickedRunIsFailedAtOnce(_DelegateCase):
+	"""A contract that authorises no bench tool refuses EVERY call — including the
+	``record_agent_run`` writeback that finalizes the run. Left alone the row would
+	sit ``running`` until the 3h stale-run sweep stamped "run exceeded max duration"
+	on it, which is false and sends the reader after a timeout that never happened.
+	It is terminalized at the first refusal instead, with the real reason."""
+
+	def _brick(self) -> None:
+		frappe.db.set_value(RUN, self.aud_run, "tools_allow_json", "[]", update_modified=False)
+
+	def test_the_first_refusal_fails_the_run_with_an_honest_error(self):
+		self._brick()
+		res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		row = frappe.db.get_value(RUN, self.aud_run, ["status", "error", "finished_at"], as_dict=True)
+		self.assertEqual(row.status, "failed")
+		self.assertIn("authorises no tools", row.error)
+		# The reaper's wording is the LIE this replaces — it must not appear.
+		self.assertNotIn("max duration", row.error)
+		self.assertIsNotNone(row.finished_at)
+
+	def test_the_bearer_does_not_outlive_the_failed_run(self):
+		"""A8: terminalizing must take the per-run session row with it, so the
+		refused run's bearer stops resolving to the run-as user."""
+		agent_scheduler._mint_run_session(self.aud_key, self.run_as)
+		self.assertTrue(frappe.db.exists(SESSION, {"session_key": self.aud_key}))
+		self._brick()
+		self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(frappe.db.exists(SESSION, {"session_key": self.aud_key}))
+
+	def test_a_merely_undeclared_tool_leaves_the_run_running(self):
+		"""The narrow case must stay narrow: an agent WITH a tool surface reaching for
+		one tool outside it is a model mistake, not a dead run. It keeps going."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		res = self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": todo})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(frappe.db.get_value(RUN, self.aud_run, "status"), "running")
+
+	def test_fail_run_never_overwrites_a_finalized_run(self):
+		"""Compare-and-set: a run a concurrent ``record_agent_run`` already completed
+		is never flipped to failed by this path."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"status": "completed", "finished_at": frappe.utils.now()},
+			update_modified=False,
+		)
+		self.assertFalse(agent_scheduler.fail_run(self.aud_run, "should not land"))
+		row = frappe.db.get_value(RUN, self.aud_run, ["status", "error"], as_dict=True)
+		self.assertEqual(row.status, "completed")
+		self.assertFalse(row.error)
+
+
+# --------------------------------------------------------------------------- #
+# what the CUSTOMER reads vs what the DELEGATE reads
+# --------------------------------------------------------------------------- #
+class TestDenialCopyAndVocabulary(_DelegateCase):
+	def test_capability_denied_is_in_the_error_vocabulary(self):
+		"""P2-5: the wire code names a real exception class and has a canon
+		``_ERROR_HINTS`` entry. It is NOT a permission denial — no administrator can
+		grant the tool mid-run, so the remedy is the bundle."""
+		self.assertTrue(issubclass(CapabilityDeniedError, JarvisError))
+		self.assertFalse(issubclass(CapabilityDeniedError, PermissionDeniedError))
+		hint = api._ERROR_HINTS.get(CapabilityDeniedError.__name__, "")
+		self.assertIn("bundle", hint)
+
+	def test_the_delegate_is_told_that_retrying_cannot_help(self):
+		"""The no-retry instruction has to be in the MESSAGE: the openclaw plugin
+		relays a failed tool call to the model as ``"<code>: <message>"`` and drops
+		every other envelope field, so a hint-only fix would never reach the delegate
+		and it would retry at the rate limit until the run timed out."""
+		frappe.set_user("Administrator")
+		todo = _mk_todo(self.run_as)
+		res = self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": todo})
+		self.assertEqual(res["error"]["code"], CapabilityDeniedError.__name__)
+		self.assertIn("capability contract", res["error"]["message"])
+		self.assertIn("will not help", res["error"]["message"])
+		self.assertIn("bundle", res["error"]["hint"])
+
+	def test_the_chat_receipt_is_plain_language_not_contract_jargon(self):
+		"""The transcript receipt renders verbatim in chat. "the tool is not in the
+		capability contract snapshotted for this run at launch" is implementation
+		vocabulary and must not be what a customer reads; the contract wording stays
+		in the delegate's envelope + the audit trail."""
+		frappe.set_user("Administrator")
+		conv = frappe.get_doc(
+			{
+				"doctype": CONVERSATION,
+				"title": "cc denial transcript",
+				"status": "Active",
+				"session_key": self.aud_key,
+			}
+		)
+		conv.flags.ignore_permissions = True
+		conv.insert(ignore_permissions=True)
+		# persist_tool_receipt COMMITS, so the rows outlive the test-case rollback.
+		self.addCleanup(self._drop_conversation, conv.name)
+		todo = _mk_todo(self.run_as)
+
+		res = self._dispatch(self.aud_key, "get_doc", {"doctype": "ToDo", "name": todo})
+
+		rows = frappe.get_all(
+			MESSAGE,
+			filters={"conversation": conv.name, "role": "tool"},
+			fields=["tool_status", "tool_result"],
+			ignore_permissions=True,
+		)
+		self.assertEqual(len(rows), 1, rows)
+		self.assertEqual(rows[0].tool_status, "error")  # renders as a failure, not a success
+		envelope = json.loads(rows[0].tool_result)["error"]
+		self.assertNotIn("capability contract", envelope["message"])
+		self.assertNotIn("snapshot", envelope["message"].lower())
+		self.assertIn("isn't allowed to use", envelope["message"])
+		self.assertIn("administrator", envelope["hint"])  # and a remedy, not a dead end
+		# not lost, just relocated: the delegate still gets the precise reason
+		self.assertIn("capability contract", res["error"]["message"])
+
+	def _drop_conversation(self, name: str) -> None:
+		frappe.set_user("Administrator")
+		for m in frappe.get_all(MESSAGE, filters={"conversation": name}, pluck="name"):
+			frappe.delete_doc(MESSAGE, m, force=True, ignore_permissions=True)
+		if frappe.db.exists(CONVERSATION, name):
+			frappe.delete_doc(CONVERSATION, name, force=True, ignore_permissions=True)
+		frappe.db.commit()
+
+
+# --------------------------------------------------------------------------- #
 # legacy runs + the cutover boundary
 # --------------------------------------------------------------------------- #
 class TestLegacyRunFallback(_DelegateCase):
@@ -319,6 +465,51 @@ class TestLegacyRunFallback(_DelegateCase):
 			res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
 		self.assertFalse(res["ok"], res)
 		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+
+	def test_blank_contract_inside_the_deploy_window_is_legacy(self):
+		"""``bench migrate`` finishing and the LAST worker restarting are not the same
+		instant. A run launched by a still-old worker in between physically cannot
+		carry a snapshot, and it is not a forgery — refusing it bricks a real customer
+		run on every deploy. It is grandfathered for the bounded grace window."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": None, "tools_allow_json": None},
+			update_modified=False,
+		)
+		# patched 5h ago; the run (created now) is inside the 6h window
+		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-5)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=cutoff):
+			res = self._undeclared_call()
+		self.assertTrue(res["ok"], res)
+
+	def test_blank_contract_past_the_deploy_window_is_refused(self):
+		"""The grace is BOUNDED. Hours after the deploy a blank contract can only mean
+		a launch path that bypassed ``_launch_audit`` (or a planted row) — fail closed,
+		and kill the run rather than let it hang."""
+		frappe.db.set_value(
+			RUN,
+			self.aud_run,
+			{"capability_contract": None, "tools_allow_json": None},
+			update_modified=False,
+		)
+		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-7)
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=cutoff):
+			res = self._dispatch(self.aud_key, "get_schema", {"doctype": "ToDo"})
+		self.assertFalse(res["ok"], res)
+		self.assertEqual(res["error"]["code"], "CapabilityDeniedError")
+		self.assertEqual(frappe.db.get_value(RUN, self.aud_run, "status"), "failed")
+
+	def test_the_grace_boundary_is_the_documented_six_hours(self):
+		"""The exact edge, without a dispatch in the way."""
+		self.assertEqual(_delegate_capability.LEGACY_GRACE_SECONDS, 6 * 3600)
+		cutoff = frappe.utils.now_datetime()
+		grace = _delegate_capability.LEGACY_GRACE_SECONDS
+		with mock.patch.object(_delegate_capability, "_legacy_cutoff", return_value=cutoff):
+			inside = frappe.utils.add_to_date(cutoff, seconds=grace - 60)
+			outside = frappe.utils.add_to_date(cutoff, seconds=grace + 60)
+			self.assertTrue(_delegate_capability._is_pre_patch(inside))
+			self.assertFalse(_delegate_capability._is_pre_patch(outside))
 
 	def test_blank_contract_before_the_cutover_is_legacy(self):
 		"""The deploy-race grace: a run created before the patch ran (new code already
@@ -516,7 +707,7 @@ class TestLaunchStampsTheContract(unittest.TestCase):
 			frappe.delete_doc(LISTING, self.SLUG, force=True, ignore_permissions=True)
 		frappe.db.commit()
 
-	def _launch(self) -> str:
+	def _launch(self, declared: list | None = None) -> str:
 		import jarvis.admin_client as admin_client
 
 		inst = frappe.get_doc(
@@ -537,7 +728,8 @@ class TestLaunchStampsTheContract(unittest.TestCase):
 		admin_client.post_agent_run = lambda **kw: {"run_id": kw.get("run_id"), "status": "queued"}
 		frappe.set_user(self.OWNER)
 		try:
-			with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=self.DECLARED):
+			surface = self.DECLARED if declared is None else declared
+			with mock.patch.object(agent_catalog, "registry_tools_allow", return_value=surface):
 				result = agent_scheduler._launch_audit(inst, trigger="manual")
 		finally:
 			frappe.set_user("Administrator")
@@ -585,6 +777,35 @@ class TestLaunchStampsTheContract(unittest.TestCase):
 		session_key = frappe.db.get_value(RUN, run, "session_key")
 		res = api._dispatch_from_session(self.OWNER, session_key, "get_schema", {"doctype": "ToDo"})
 		self.assertTrue(res["ok"], res)
+
+	# ------------------------------------------------------------------ #
+	# refuse at LAUNCH — the root cause of the bricked run
+	# ------------------------------------------------------------------ #
+	def test_launch_is_refused_when_the_bundle_declares_no_tools(self):
+		"""THE fix for the bricked run. A bundle with no declared surface produces a
+		run that is refused at every step, so it must never START: the human gets a
+		message they can act on instead of a blue "running" card that turns into a
+		false timeout three hours later."""
+		convs_before = frappe.db.count(CONVERSATION)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			self._launch(declared=[])
+		message = str(ctx.exception)
+		self.assertIn("declares no tools", message)
+		self.assertIn("nothing was started", message)
+		# and it is refused BEFORE any row exists — no orphan run, no orphan
+		# conversation, no orphan bearer to clean up.
+		self.assertEqual(frappe.get_all(RUN, filters={"agent": self.SLUG}, pluck="name"), [])
+		self.assertEqual(frappe.db.count(CONVERSATION), convs_before)
+
+	def test_the_launch_refusal_leaves_the_install_runnable_once_fixed(self):
+		"""The refusal is about the BUNDLE, not the install: a repaired/replaced
+		bundle launches the very same installation normally."""
+		with self.assertRaises(frappe.ValidationError):
+			self._launch(declared=[])
+		frappe.db.delete(INSTALLATION, {"agent": self.SLUG})
+		frappe.db.commit()
+		run = self._launch()
+		self.assertEqual(frappe.db.get_value(RUN, run, "capability_contract"), "snapshot")
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_platform_write_caps.py
+++ b/jarvis/tests/test_platform_write_caps.py
@@ -10,6 +10,10 @@ agent's declared ``writes[]`` contract BEFORE any Frappe permission check —
   * a NON-delegate caller (standard chat / macro / test — no bound Run) is left
     completely untouched.
 
+JF-017: the contract the gate reads is the run's LAUNCH SNAPSHOT, so the fixtures
+here stamp one exactly as ``_launch_audit`` does. The snapshot-vs-live-listing
+behaviour itself is covered in ``test_platform_capability_contract``.
+
 R5-P1-02 (``_verify_reviewer_two_pack_capacity`` slug fallback): the reviewer
 two-pack activation-ceiling gate now counts DISTINCT non-empty canonical
 ``rule_pack`` values and never infers a pack from the agent slug, so two agents in
@@ -31,7 +35,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import agent_catalog, agents_api
 from jarvis.exceptions import PermissionDeniedError
-from jarvis.tools import _agent_run_ctx
+from jarvis.tools import _agent_run_ctx, _delegate_capability
 from jarvis.tools.create_doc import create_doc
 from jarvis.tools.update_doc import update_doc
 
@@ -82,9 +86,11 @@ def _mk_listing(slug: str, nature: str, writes, rule_pack: str = "") -> None:
 	).insert(ignore_permissions=True)
 
 
-def _mk_install_and_run(slug: str, run_as: str, session_key: str) -> str:
+def _mk_install_and_run(slug: str, run_as: str, session_key: str, legacy: bool = False) -> str:
 	"""A running Jarvis Agent Run bound to ``session_key`` (the delegate identity
-	the write tools resolve). Returns the run name."""
+	the write tools resolve), carrying the JF-017 capability snapshot ``_launch_audit``
+	stamps. ``legacy=True`` instead marks it a pre-JF-017 run (no snapshot), whose
+	write caps resolve against the LIVE listing. Returns the run name."""
 	inst = frappe.get_doc(
 		{
 			"doctype": INSTALLATION,
@@ -96,6 +102,10 @@ def _mk_install_and_run(slug: str, run_as: str, session_key: str) -> str:
 	inst.owner = run_as
 	inst.flags.ignore_permissions = True
 	inst.insert(ignore_permissions=True)
+	if legacy:
+		contract = {"capability_contract": "legacy"}
+	else:
+		contract = _delegate_capability.contract_for_launch(frappe.get_doc(LISTING, slug))
 	run = frappe.get_doc(
 		{
 			"doctype": RUN,
@@ -105,6 +115,7 @@ def _mk_install_and_run(slug: str, run_as: str, session_key: str) -> str:
 			"status": "running",
 			"started_at": frappe.utils.now(),
 			"session_key": session_key,
+			**contract,
 		}
 	)
 	run.owner = run_as

--- a/jarvis/tools/_delegate_capability.py
+++ b/jarvis/tools/_delegate_capability.py
@@ -1,0 +1,245 @@
+"""JF-017 — the delegate run's CAPABILITY CONTRACT: snapshotted at launch,
+enforced at the BENCH.
+
+Before this module the container-side ``tools.allow`` was the ONLY thing bounding
+which ``jarvis__*`` tools a marketplace-agent delegate could call. That list is
+CONFIGURATION (rendered into openclaw.json by fleet-agent), not authorization: a
+compromised container / plugin, or anyone holding a leaked per-run session bearer,
+could call ANY registered tool the run-as user's Frappe permissions happened to
+allow — ``jarvis__delete_doc`` from an auditor whose contract is four read tools.
+The bench never compared the call against the manifest.
+
+Worse, the write guard (``_delegate_write_caps``) read the CURRENT
+``Jarvis Agent Listing.nature``/``.writes`` at call time, so editing a listing
+mid-run silently re-authorised an IN-FLIGHT run.
+
+The fix is one idea applied twice:
+
+  * **Snapshot at launch.** ``agent_scheduler._launch_audit`` stamps the whole
+    contract onto the ``Jarvis Agent Run`` row — ``tools_allow`` (the exact
+    bundled-registry list), ``nature`` and ``writes`` (from the listing at that
+    instant) — under the SAME immutability guard as the other launch-provenance
+    fields (PP-5 ``bundle_version`` / ``preparation_mode`` / ``initiating_human``).
+  * **Enforce from the snapshot.** ``jarvis.api._dispatch_from_session`` refuses
+    any tool outside the snapshotted ``tools_allow`` BEFORE ``_run_tool``, and
+    ``_delegate_write_caps`` reads nature/writes from the snapshot, never the live
+    listing. A listing edited mid-run therefore cannot change what an in-flight run
+    may do, in either direction.
+
+**Fail closed.** ``capability_contract`` records which regime a run is under:
+
+  * ``snapshot`` — the contract is on the row; it is the authority. An empty /
+    unparseable ``tools_allow_json`` authorises NOTHING.
+  * ``legacy`` — the run pre-dates this change (stamped by
+    ``v2_07_agent_run_capability_snapshot``); no tools_allow gate, and the write
+    caps fall back to the live listing exactly as before, so runs in flight across
+    the deploy are not killed.
+  * blank — a run created after the patch with no contract stamped. That can only
+    mean a launch path that bypassed ``_launch_audit`` (or a forged row), so it is
+    refused outright. The pre-patch grace is bounded by the patch's own
+    ``Patch Log`` timestamp: a blank-contract row created BEFORE the patch ran is
+    treated as legacy (it raced the deploy), one created after is not.
+
+Non-delegate callers are untouched: a session_key with no bound
+``Jarvis Agent Run`` resolves to None and every helper here is a no-op, so
+standard chat / macros / direct-Python keep the ordinary Frappe permission engine
+as their only gate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+RUN = "Jarvis Agent Run"
+LISTING = "Jarvis Agent Listing"
+
+# ``capability_contract`` values (Select on Jarvis Agent Run).
+CONTRACT_SNAPSHOT = "snapshot"
+CONTRACT_LEGACY = "legacy"
+
+# The patch that stamps every pre-existing run ``legacy``. Its Patch Log row's
+# ``creation`` is the cutover instant used to classify a blank-contract row: the
+# ONLY runs allowed the legacy fallback are the ones that already existed when the
+# guard landed.
+LEGACY_CUTOFF_PATCH = "jarvis.patches.v2_07_agent_run_capability_snapshot"
+
+# Registry/manifest tool ids are openclaw-facing (``jarvis__get_doc``); the bench
+# dispatches by the bare tool name (``get_doc``). Entries that are not jarvis tools
+# at all (``exec``, ``canvas``, ``message`` — container-side) simply never match a
+# bench tool name.
+_TOOL_PREFIX = "jarvis__"
+
+
+def normalize_tool(name) -> str:
+	"""A registry/manifest tool id reduced to the bench dispatch name."""
+	value = str(name or "").strip()
+	return value[len(_TOOL_PREFIX) :] if value.startswith(_TOOL_PREFIX) else value
+
+
+def bench_tools(tools_allow) -> set:
+	"""The BENCH tool names a declared surface authorises.
+
+	ONLY ``jarvis__``-prefixed entries count. The rest of a manifest's
+	``tools_allow`` (``exec``, ``canvas``, ``message``) names openclaw's own tools,
+	which never reach ``call_tool`` — so an unprefixed entry must never be able to
+	satisfy a bench tool name, today or the day a bench tool happens to be called
+	``message``."""
+	return {normalize_tool(t) for t in tools_allow if str(t or "").strip().startswith(_TOOL_PREFIX)}
+
+
+def _parse_list(raw) -> list:
+	"""A stored JSON list -> a Python list. Anything else (None, malformed JSON, a
+	dict) -> ``[]``, which authorises nothing under a ``snapshot`` contract."""
+	if not raw:
+		return []
+	if isinstance(raw, list):
+		return list(raw)
+	try:
+		parsed = json.loads(raw)
+	except (TypeError, ValueError):
+		return []
+	return list(parsed) if isinstance(parsed, list) else []
+
+
+def parse_writes(raw) -> list:
+	"""The declarative write contract -> a list of ``{doctype, mode, ...}`` dicts.
+	A malformed / non-list value is an EMPTY contract (fail-closed: an operator with
+	an unreadable contract writes nothing)."""
+	return [w for w in _parse_list(raw) if isinstance(w, dict) and w.get("doctype")]
+
+
+# --------------------------------------------------------------------------- #
+# launch-time snapshot
+# --------------------------------------------------------------------------- #
+def contract_for_launch(listing) -> dict:
+	"""The capability contract to stamp on a run being launched for ``listing``.
+
+	``tools_allow`` comes from the BUNDLED registry (it is delegate metadata that
+	never enters the customer DB — the same source ``build_agent_push_payload``
+	echoes into the container's enablement signal), stored VERBATIM so the run
+	carries the exact declared list as provenance. ``nature``/``writes`` are the
+	listing's values AT THIS INSTANT — the whole point of the snapshot is that a
+	later edit cannot move them.
+
+	Returns the three ``Jarvis Agent Run`` field values plus the contract marker,
+	ready to splat into the insert."""
+	from jarvis.chat.agent_catalog import registry_tools_allow
+
+	return {
+		"capability_contract": CONTRACT_SNAPSHOT,
+		"tools_allow_json": frappe.as_json(registry_tools_allow(listing.agent_slug)),
+		"capability_nature": (listing.nature or "").strip().lower(),
+		"capability_writes_json": frappe.as_json(parse_writes(listing.writes)),
+	}
+
+
+# --------------------------------------------------------------------------- #
+# resolution + enforcement
+# --------------------------------------------------------------------------- #
+def _legacy_cutoff():
+	"""When ``LEGACY_CUTOFF_PATCH`` ran on this site, or None if it has not (yet).
+
+	None means "no grace": on a site where the patch has not run there is nothing
+	to grandfather that the patch would not itself have stamped, so a blank
+	contract is refused."""
+	try:
+		return frappe.db.get_value("Patch Log", {"patch": LEGACY_CUTOFF_PATCH}, "creation")
+	except Exception:
+		return None
+
+
+def _is_pre_patch(run_creation) -> bool:
+	"""True iff a blank-contract run predates the guard and may use the legacy
+	fallback. Bounded by the patch's own timestamp so a run created AFTER the
+	cutover can never buy itself legacy authority by simply having no snapshot."""
+	cutoff = _legacy_cutoff()
+	if not cutoff or not run_creation:
+		return False
+	return frappe.utils.get_datetime(run_creation) < frappe.utils.get_datetime(cutoff)
+
+
+def resolve(session_key: str | None = None) -> dict | None:
+	"""The capability contract governing the CURRENT call, or None when the caller
+	is not a delegate.
+
+	Delegate iff a ``Jarvis Agent Run`` row is bound to the caller's session_key.
+	The session_key is the delegate's opaque HTTPS bearer (never a model-supplied
+	id, so a delegate can only ever act as its own run); ``session_key=None`` reads
+	it from the request-scoped ``_agent_run_ctx``.
+
+	Returns ``{run, agent, legacy, tools_allow, nature, writes, run_as}``. ``legacy``
+	True means no snapshot governs this run — the caller falls back to pre-JF-017
+	behaviour. A run that is neither snapshotted nor legacy yields an EMPTY contract
+	with ``legacy`` False, i.e. everything is refused."""
+	from jarvis.tools._agent_run_ctx import get_session_key
+
+	key = session_key if session_key is not None else get_session_key()
+	if not key:
+		return None
+	run = frappe.db.get_value(
+		RUN,
+		{"session_key": key},
+		[
+			"name",
+			"agent",
+			"creation",
+			"capability_contract",
+			"tools_allow_json",
+			"capability_nature",
+			"capability_writes_json",
+		],
+		as_dict=True,
+	)
+	if not run or not run.agent:
+		return None  # no delegate run bound -> not a delegate; leave the caller untouched
+
+	base = {"run": run.name, "agent": run.agent, "run_as": frappe.session.user}
+	contract = (run.capability_contract or "").strip().lower()
+
+	if contract == CONTRACT_LEGACY or (not contract and _is_pre_patch(run.creation)):
+		# Pre-JF-017 run: nature/writes come from the live listing, as they did
+		# before the snapshot existed, and no tools_allow gate applies.
+		listing = frappe.db.get_value(LISTING, run.agent, ["nature", "writes"], as_dict=True) or {}
+		return {
+			**base,
+			"legacy": True,
+			"tools_allow": [],
+			"nature": (listing.get("nature") or "").strip().lower(),
+			"writes": parse_writes(listing.get("writes")),
+		}
+
+	if contract != CONTRACT_SNAPSHOT:
+		# A post-cutover run with no (or an unrecognised) contract marker: no launch
+		# path stamped it, so it holds NO authority. Deliberately not derived from
+		# whatever sits in the snapshot columns — those are only trustworthy when the
+		# marker says a launch wrote them.
+		return {**base, "legacy": False, "tools_allow": [], "nature": "", "writes": []}
+
+	return {
+		**base,
+		"legacy": False,
+		"tools_allow": _parse_list(run.tools_allow_json),
+		"nature": (run.capability_nature or "").strip().lower(),
+		"writes": parse_writes(run.capability_writes_json),
+	}
+
+
+def tool_denial(session_key: str | None, tool: str) -> str | None:
+	"""The refusal reason when this delegate may not call ``tool``, else None.
+
+	None is also returned for a NON-delegate caller (nothing to enforce) and for a
+	``legacy`` run (no snapshot to enforce against). Everything else is decided by
+	the snapshot alone: a tool absent from it — even one the run-as user's Frappe
+	roles would happily permit — is refused BEFORE dispatch."""
+	cap = resolve(session_key)
+	if cap is None or cap["legacy"]:
+		return None
+	name = normalize_tool(tool)
+	if name and name in bench_tools(cap["tools_allow"]):
+		return None
+	return (
+		f"agent '{cap['agent']}' is not permitted to call '{name or tool}': the tool is "
+		"not in the capability contract snapshotted for this run at launch"
+	)

--- a/jarvis/tools/_delegate_capability.py
+++ b/jarvis/tools/_delegate_capability.py
@@ -37,8 +37,18 @@ The fix is one idea applied twice:
   * blank — a run created after the patch with no contract stamped. That can only
     mean a launch path that bypassed ``_launch_audit`` (or a forged row), so it is
     refused outright. The pre-patch grace is bounded by the patch's own
-    ``Patch Log`` timestamp: a blank-contract row created BEFORE the patch ran is
-    treated as legacy (it raced the deploy), one created after is not.
+    ``Patch Log`` timestamp plus ``LEGACY_GRACE_SECONDS``: a blank-contract row
+    created inside the deploy window is treated as legacy (it raced the migrate /
+    restart), one created after it is not.
+
+**A refused run is a DEAD run, and says so.** A contract that authorises no bench
+tool refuses everything, ``record_agent_run`` included, so the run could never
+finalize itself — it would sit ``running`` until the 3h stale-run sweep stamped
+"exceeded max duration" on it, which is false. So: ``_launch_audit`` refuses the
+LAUNCH outright when the bundled registry declares no tool surface (no
+conversation, no run row, an error the human can act on), and ``tool_denial``
+marks such a refusal ``fatal`` so the dispatcher terminalizes the run at the FIRST
+refused call with the honest reason.
 
 Non-delegate callers are untouched: a session_key with no bound
 ``Jarvis Agent Run`` resolves to None and every helper here is a no-op, so
@@ -64,6 +74,17 @@ CONTRACT_LEGACY = "legacy"
 # ONLY runs allowed the legacy fallback are the ones that already existed when the
 # guard landed.
 LEGACY_CUTOFF_PATCH = "jarvis.patches.v2_07_agent_run_capability_snapshot"
+
+# DEPLOY-WINDOW GRACE. ``bench migrate`` finishing and the LAST worker restarting
+# are not the same instant: in between, workers still running the old code launch
+# runs that physically cannot carry a snapshot (the stamping code isn't loaded),
+# and the reverse order is no better (a pre-migrate insert silently drops the new
+# columns because ``get_valid_columns`` reads the live schema). Either way the
+# window produces blank-contract rows that are NOT forgeries. Grandfather them for
+# a bounded 6h past the patch — far longer than any real rolling restart, far
+# shorter than the horizon on which a planted row would matter, and self-limiting
+# because the runs themselves are terminalized by the 3h stale-run reaper.
+LEGACY_GRACE_SECONDS = 6 * 3600
 
 # Registry/manifest tool ids are openclaw-facing (``jarvis__get_doc``); the bench
 # dispatches by the bare tool name (``get_doc``). Entries that are not jarvis tools
@@ -113,13 +134,15 @@ def parse_writes(raw) -> list:
 # --------------------------------------------------------------------------- #
 # launch-time snapshot
 # --------------------------------------------------------------------------- #
-def contract_for_launch(listing) -> dict:
+def contract_for_launch(listing, tools_allow: list | None = None) -> dict:
 	"""The capability contract to stamp on a run being launched for ``listing``.
 
 	``tools_allow`` comes from the BUNDLED registry (it is delegate metadata that
 	never enters the customer DB — the same source ``build_agent_push_payload``
 	echoes into the container's enablement signal), stored VERBATIM so the run
-	carries the exact declared list as provenance. ``nature``/``writes`` are the
+	carries the exact declared list as provenance. Pass it in when the caller has
+	already resolved it (``_launch_audit`` does, to refuse an empty surface before
+	any row exists); otherwise it is read here. ``nature``/``writes`` are the
 	listing's values AT THIS INSTANT — the whole point of the snapshot is that a
 	later edit cannot move them.
 
@@ -127,9 +150,10 @@ def contract_for_launch(listing) -> dict:
 	ready to splat into the insert."""
 	from jarvis.chat.agent_catalog import registry_tools_allow
 
+	declared = tools_allow if tools_allow is not None else registry_tools_allow(listing.agent_slug)
 	return {
 		"capability_contract": CONTRACT_SNAPSHOT,
-		"tools_allow_json": frappe.as_json(registry_tools_allow(listing.agent_slug)),
+		"tools_allow_json": frappe.as_json(declared),
 		"capability_nature": (listing.nature or "").strip().lower(),
 		"capability_writes_json": frappe.as_json(parse_writes(listing.writes)),
 	}
@@ -151,13 +175,16 @@ def _legacy_cutoff():
 
 
 def _is_pre_patch(run_creation) -> bool:
-	"""True iff a blank-contract run predates the guard and may use the legacy
-	fallback. Bounded by the patch's own timestamp so a run created AFTER the
-	cutover can never buy itself legacy authority by simply having no snapshot."""
+	"""True iff a blank-contract run predates the guard (plus the bounded
+	``LEGACY_GRACE_SECONDS`` deploy window) and may use the legacy fallback.
+
+	Anchored on the patch's own timestamp so a run created long AFTER the cutover
+	can never buy itself legacy authority by simply having no snapshot."""
 	cutoff = _legacy_cutoff()
 	if not cutoff or not run_creation:
 		return False
-	return frappe.utils.get_datetime(run_creation) < frappe.utils.get_datetime(cutoff)
+	deadline = frappe.utils.add_to_date(frappe.utils.get_datetime(cutoff), seconds=LEGACY_GRACE_SECONDS)
+	return frappe.utils.get_datetime(run_creation) < deadline
 
 
 def resolve(session_key: str | None = None) -> dict | None:
@@ -226,20 +253,78 @@ def resolve(session_key: str | None = None) -> dict | None:
 	}
 
 
-def tool_denial(session_key: str | None, tool: str) -> str | None:
-	"""The refusal reason when this delegate may not call ``tool``, else None.
+# The customer reads the chat transcript; the delegate and the audit trail read
+# ``message``. Neither audience is served by showing the other's copy, so the two
+# are written separately (UX P1-2 — "capability contract snapshotted at launch" is
+# implementation vocabulary and has no place in a customer's chat).
+# Message = what happened; the "what you can do" line is the envelope's ``hint``
+# (``api._ERROR_HINTS``), per the house convention.
+_CHAT_NOT_DECLARED = "This agent tried to use a tool it isn't allowed to use, so the step was skipped."
+_CHAT_NO_SURFACE = (
+	"This agent was started without a usable set of tools, so it couldn't do "
+	"anything and the run has been stopped."
+)
+# Stamped on the failed run and shown in the run's error banner. Short (the field
+# is displayed inline) and honest about the REAL cause — the whole point of
+# failing here rather than letting the 3h stale-run sweep call it a timeout.
+_RUN_ERROR_NO_SURFACE = "the agent's capability contract authorises no tools; refused at the first call"
+
+
+def tool_denial(session_key: str | None, tool: str) -> dict | None:
+	"""The refusal for this delegate's ``tool`` call, or None when it may proceed.
 
 	None is also returned for a NON-delegate caller (nothing to enforce) and for a
 	``legacy`` run (no snapshot to enforce against). Everything else is decided by
 	the snapshot alone: a tool absent from it — even one the run-as user's Frappe
-	roles would happily permit — is refused BEFORE dispatch."""
+	roles would happily permit — is refused BEFORE dispatch.
+
+	The refusal is a dict, not a string, because two of its facts are decisions the
+	caller has to make:
+
+	  * ``fatal`` — the contract authorises NO bench tool at all (a blank contract,
+	    an empty/unparseable snapshot, or a bundle whose declared surface is
+	    container-side only). Every call this run will ever make is refused,
+	    INCLUDING the ``record_agent_run`` writeback that finalizes it, so the run
+	    is not merely mistaken, it is dead. The caller must terminalize it rather
+	    than leave it ``running`` for the 3h reaper to mislabel as a timeout.
+	  * ``chat_message`` vs ``message`` — plain language for the customer-visible
+	    transcript, contract vocabulary for the delegate and the audit trail.
+	"""
 	cap = resolve(session_key)
 	if cap is None or cap["legacy"]:
 		return None
+	allowed = bench_tools(cap["tools_allow"])
 	name = normalize_tool(tool)
-	if name and name in bench_tools(cap["tools_allow"]):
+	if name and name in allowed:
 		return None
-	return (
-		f"agent '{cap['agent']}' is not permitted to call '{name or tool}': the tool is "
-		"not in the capability contract snapshotted for this run at launch"
-	)
+	base = {"run": cap["run"], "agent": cap["agent"], "tool": name or str(tool or "")}
+	if not allowed:
+		return {
+			**base,
+			"fatal": True,
+			"message": (
+				f"agent '{cap['agent']}' has no usable tool surface for this run: its "
+				f"capability contract authorises no bench tool, so '{name or tool}' — and "
+				"every other call — is refused. The run has been marked failed; no further "
+				"call can succeed."
+			),
+			"chat_message": _CHAT_NO_SURFACE,
+			"run_error": _RUN_ERROR_NO_SURFACE,
+		}
+	return {
+		**base,
+		"fatal": False,
+		# The no-retry instruction rides in the MESSAGE, not the envelope's ``hint``:
+		# the openclaw plugin relays a failed tool call to the model as
+		# ``"<code>: <message>"`` and drops every other field, so a hint the delegate
+		# must act on has to be in the message or it never arrives. ``hint`` keeps its
+		# usual role — the human-facing "what you can do" line.
+		"message": (
+			f"agent '{cap['agent']}' is not permitted to call '{name or tool}': the tool is "
+			"not in the capability contract snapshotted for this run at launch. That "
+			"contract is fixed for the whole run, so retrying, renaming the tool or "
+			"changing the arguments will not help — continue with the tools you do have."
+		),
+		"chat_message": _CHAT_NOT_DECLARED,
+		"run_error": "",
+	}

--- a/jarvis/tools/_delegate_write_caps.py
+++ b/jarvis/tools/_delegate_write_caps.py
@@ -24,35 +24,24 @@ agent's DECLARED contract, enforced BEFORE any Frappe permission check:
 
 The ``writes[]`` contract is DECLARATIVE, non-IP (a list of ``{doctype, mode}``;
 ``mode`` ∈ {draft, approval-request}) mirrored from the bundle-store manifest —
-never a rule body/threshold. Storage: ``Jarvis Agent Listing.writes`` (JSON),
+never a rule body/threshold. Origin: ``Jarvis Agent Listing.writes`` (JSON),
 populated by ``agent_catalog.sync_agent_listings``.
-"""
 
-import json
+JF-017: ``nature``/``writes`` are now read from the run's LAUNCH SNAPSHOT
+(``Jarvis Agent Run.capability_nature`` / ``.capability_writes_json``), not from
+the live listing. Reading the mutable listing at call time meant anything that
+could edit a listing re-authorised an IN-FLIGHT run mid-flight — widening an
+auditor into an operator, or adding a doctype to an operator's contract, with no
+relaunch. The snapshot is stamped once by ``agent_scheduler._launch_audit`` and is
+immutable thereafter, so a run's write authority is fixed at the instant it was
+launched. Runs that predate the snapshot (``capability_contract == 'legacy'``)
+still resolve against the listing — exactly the behaviour they launched under.
+"""
 
 import frappe
 
 from jarvis.exceptions import PermissionDeniedError
-from jarvis.tools._agent_run_ctx import get_session_key
-
-RUN = "Jarvis Agent Run"
-LISTING = "Jarvis Agent Listing"
-
-
-def _parse_writes(raw) -> list:
-	"""The listing's ``writes`` JSON -> a list of ``{doctype, mode, ...}`` dicts.
-	A malformed / non-list value is treated as an EMPTY contract (fail-closed:
-	an operator with an unreadable contract writes nothing)."""
-	if not raw:
-		return []
-	if isinstance(raw, list):
-		parsed = raw
-	else:
-		try:
-			parsed = json.loads(raw)
-		except (TypeError, ValueError):
-			return []
-	return [w for w in parsed if isinstance(w, dict) and w.get("doctype")] if isinstance(parsed, list) else []
+from jarvis.tools import _delegate_capability
 
 
 def resolve_delegate() -> dict | None:
@@ -69,23 +58,14 @@ def resolve_delegate() -> dict | None:
 
 	Returns ``{agent, nature, writes, run_as}`` or None.
 	"""
-	session_key = get_session_key()
-	if not session_key:
+	cap = _delegate_capability.resolve()
+	if cap is None:
 		return None
-	run = frappe.db.get_value(
-		RUN,
-		{"session_key": session_key},
-		["name", "agent"],
-		as_dict=True,
-	)
-	if not run or not run.agent:
-		return None  # no delegate run bound -> not a delegate; leave the caller untouched
-	listing = frappe.db.get_value(LISTING, run.agent, ["nature", "writes"], as_dict=True) or {}
 	return {
-		"agent": run.agent,
-		"nature": (listing.get("nature") or "").strip().lower(),
-		"writes": _parse_writes(listing.get("writes")),
-		"run_as": frappe.session.user,
+		"agent": cap["agent"],
+		"nature": cap["nature"],
+		"writes": cap["writes"],
+		"run_as": cap["run_as"],
 	}
 
 


### PR DESCRIPTION
## JF-017 — the delegate capability contract was never enforced at the bench

### The defect

A valid, session-bound plugin call from a marketplace-agent delegate run reached
`jarvis.api._run_tool` **without ever being compared against the agent's declared
`tools_allow`**. Before this change `tools_allow` appeared nowhere in `jarvis/api.py`,
`jarvis/tools/_delegate_write_caps.py`, or the `Jarvis Agent Run` doctype.

Consequences:

* The container-side `tools.allow` (rendered into `openclaw.json` by fleet-agent) was the
  only thing bounding a delegate's tool surface. That is **configuration, not
  authorization** — a compromised container or plugin, or anyone holding a leaked per-run
  session bearer, could call **any** registered tool the run's `run_as_user` happened to
  have Frappe permissions for. An auditor whose manifest declares four read tools could
  drive `delete_doc`.
* The write guard read the **current, mutable** `Jarvis Agent Listing.nature` / `.writes`
  at call time, so editing a listing silently re-authorised an **in-flight** run — an
  auditor could be widened into an operator mid-run, with no relaunch.

### Root cause

The run's capability contract was never **snapshotted** and never **enforced bench-side**.
Authority was read from mutable state (the listing) or from a place the bench does not
control at all (the container's config).

### The fix

**Snapshot at launch.** `agent_scheduler._launch_audit` now stamps the whole contract onto
the `Jarvis Agent Run` row in the same insert as the other launch provenance:

| field | source at launch |
|---|---|
| `tools_allow_json` | the bundled registry's declared `tools_allow`, verbatim |
| `capability_nature` | the listing's `nature` at that instant |
| `capability_writes_json` | the listing's `writes[]` at that instant |
| `capability_contract` | `snapshot` |

All four join `_IMMUTABLE_LAUNCH_FIELDS` on the controller, so the run's authorization is
at least as immutable as its provenance (PP-5's `bundle_version` / `preparation_mode` /
`initiating_human`).

**Enforce from the snapshot.**

* `api._dispatch_from_session` resolves the run from the caller's `session_key` and refuses
  any tool outside the snapshot **before** `_run_tool`, returning a `CapabilityDeniedError`
  envelope and writing a structured audit line. Only `jarvis__`-prefixed manifest entries
  can satisfy a bench tool name, so the container-side entries (`exec`, `canvas`,
  `message`) never grant a bench tool. Non-delegate sessions (ordinary chat, macros,
  direct-Python) resolve to `None` and are completely untouched.
* `_delegate_write_caps` reads `nature`/`writes` from the same snapshot, so a listing edit
  changes nothing for an in-flight run — in **either** direction (it cannot widen it, and
  it cannot silently break it either).

**Fail closed.** An empty or unparseable `tools_allow_json` authorises nothing. A run whose
`capability_contract` marker is blank holds **no** authority at all — the snapshot columns
are only trusted when the marker says a launch wrote them.

**Migration.** `v2_07_agent_run_capability_snapshot` stamps every pre-existing run
`legacy`: no `tools_allow` gate, and the write caps keep resolving against the live
listing — exactly the regime those runs launched under, so a deploy cannot kill a run in
flight. The grace is bounded by the patch's own `Patch Log` timestamp: an unstamped run
created **before** the cutover (one that raced the deploy) is treated as legacy, one
created **after** it is refused. New runs always carry a real snapshot.

`Jarvis Agent Run.session_key` also gains a search index — the contract is now resolved
from it on every plugin tool call.

### Tests

New `jarvis/tests/test_platform_capability_contract.py` (36 assertions across 5 classes),
driving the **real** `api._dispatch_from_session` path rather than a stand-in. Each case
fails if the guard is removed:

* **negative** — a registered but undeclared tool (`get_doc`, `delete_doc`) over a valid
  delegate session is refused with `CapabilityDeniedError` and never reaches `_run_tool`;
  the control case proves the same call succeeds for the same user off a delegate session,
  so the refusal is the contract, not the user's permissions;
* **mid-run listing edit** — re-naturing the auditor's listing to Operator with a write
  contract, widening an operator's `writes[]`, and widening the bundled registry all leave
  an in-flight run's authority unchanged; emptying `writes[]` mid-run does not revoke it;
* **write caps from the snapshot** — auditor refused every write, operator confined to its
  snapshotted doctypes;
* **legacy run** — a run stamped `legacy` still executes undeclared tools and still
  resolves its write caps from the live listing;
* **cutover boundary** — blank contract before the recorded cutover is legacy; after it (or
  with no cutover recorded) is refused; blank contract never trusts stray snapshot columns;
* **launch + immutability** — an end-to-end `_launch_audit` stamps the declared contract,
  the controller refuses any later edit of it, and the launched run then refuses an
  undeclared tool over the real dispatch path.

`jarvis/tests/test_platform_write_caps.py` fixtures now stamp the launch snapshot (that is
what the gate reads) and gained a `legacy=True` variant.

Ran locally: `ruff check` clean on every touched file, `ruff format` clean, `compileall`
clean, plus a standalone 20-case exercise of the resolution/denial logic.

**CI green** — lint + all four `run-parallel-tests` shards + coverage. All 31 new tests
executed (shard 3) alongside the existing `test_platform_write_caps`, `test_agent_identity`,
`test_agents_marketplace`, `test_app_learning_agent`, `test_api` and
`test_api_chat_session_header` suites.

### Known behaviour change worth a look

A run whose agent has **no entry in the bundled registry** (e.g. a Deprecated listing whose
registry entry was removed) snapshots an empty `tools_allow` and is therefore refused every
tool. That is the intended fail-closed outcome — such a bundle has no SKILL body to push
either — but it turns a partially-working deprecated run into a hard refusal, and the run
then sits `running` until the stale-run reaper fails it. Refusing at **launch** instead
would be better UX; left out of scope here.
