### PR TITLE
fix(plugin-auth): JF-014 — reject unsigned plugin requests by default

### DIFF
--- a/jarvis/_plugin_auth.py
+++ b/jarvis/_plugin_auth.py
@@ -45,10 +45,17 @@ unsigned bearer-only requests). It exists only for self-hosted benches
 whose openclaw plugin has not been upgraded yet, it WARN-logs the
 sunset date on every request it lets through, and it bumps a per-day
 Redis counter (``jarvis:plugin_unsigned_allowed:<YYYY-MM-DD>``) so an
-operator can confirm the field is quiet before turning it off. Requests
-rejected while the flag is off land in the Error Log under
-"plugin_auth: unsigned request rejected". The flag itself is scheduled
-for removal on 2026-10-01 (``_UNSIGNED_SUNSET_DATE``).
+operator can confirm the field is quiet before turning it off. While the
+hatch is on, ``unsigned_escape_hatch_status`` surfaces that count as an
+advisory row in the self-host "Test connection" checks (jarvis.selfhost)
+so the operator sees it in the product, not only in the logs. The flag
+itself is scheduled for removal on 2026-10-01 (``_UNSIGNED_SUNSET_DATE``).
+
+Requests rejected while the flag is off land in the Error Log under
+"plugin_auth: unsigned request rejected", throttled to one row per
+session per minute: an un-upgraded plugin retries every tool call, so an
+unthrottled audit would fill the Error Log with thousands of copies of
+one fact. The reject itself is never throttled.
 """
 
 from __future__ import annotations
@@ -67,7 +74,10 @@ _NONCE_REDIS_PREFIX = "jarvis:plugin_nonce:"
 _ALLOW_UNSIGNED_CONF_KEY = "jarvis_plugin_allow_unsigned"
 _UNSIGNED_SUNSET_DATE = "2026-10-01"
 _UNSIGNED_COUNTER_PREFIX = "jarvis:plugin_unsigned_allowed:"
-_UNSIGNED_COUNTER_TTL_S = 7 * 24 * 60 * 60
+_UNSIGNED_COUNTER_DAYS = 7
+_UNSIGNED_COUNTER_TTL_S = _UNSIGNED_COUNTER_DAYS * 24 * 60 * 60
+_UNSIGNED_AUDIT_GATE_PREFIX = "jarvis:plugin_unsigned_audit:"
+_UNSIGNED_AUDIT_GATE_TTL_S = 60
 
 
 class PluginAuthError(Exception):
@@ -205,16 +215,20 @@ def validate_plugin_request(body_bytes: bytes) -> str:
 			"unknown" if allowed_today is None else allowed_today,
 		)
 	else:
-		_audit_log(
-			"plugin_auth: unsigned request rejected",
-			f"remote_ip={caller_ip!r} session={session_key!r}; no signature headers "
-			f"and {_ALLOW_UNSIGNED_CONF_KEY} is off",
-		)
+		if _should_audit_unsigned_reject(session_key):
+			_audit_log(
+				"plugin_auth: unsigned request rejected",
+				f"remote_ip={caller_ip!r} session={session_key!r}; no signature headers "
+				f"and {_ALLOW_UNSIGNED_CONF_KEY} is off",
+			)
 		raise PluginAuthError(
 			http_status=400,
 			code="InvalidArgumentError",
 			message="signature headers required; provide all of "
-			"X-Jarvis-Signature/X-Jarvis-Nonce/X-Jarvis-Timestamp",
+			"X-Jarvis-Signature/X-Jarvis-Nonce/X-Jarvis-Timestamp. Upgrade the "
+			"openclaw plugin to a signing build, or run `bench --site <site> "
+			f"set-config {_ALLOW_UNSIGNED_CONF_KEY} 1` as a stopgap until that "
+			f"flag is removed on {_UNSIGNED_SUNSET_DATE}.",
 		)
 
 	# 5. Rate limit per session_key (after signature validation so the
@@ -277,6 +291,65 @@ def _allow_unsigned() -> bool:
 	except Exception:
 		return False
 	return str(raw or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _should_audit_unsigned_reject(session_key: str) -> bool:
+	"""One "unsigned request rejected" Error Log row per session per minute.
+
+	A bench whose plugin predates signing rejects EVERY tool call, so an
+	unthrottled audit turns one operator fact into thousands of rows. The
+	reject itself is unconditional; only the row is gated. Fails OPEN (log
+	it) when the cache is unreachable, so a Redis outage can never make the
+	audit trail quieter than it should be.
+	"""
+	try:
+		cache = frappe.cache()
+		key = _UNSIGNED_AUDIT_GATE_PREFIX + (session_key or "-")
+		return bool(cache.set(key, b"1", nx=True, ex=_UNSIGNED_AUDIT_GATE_TTL_S))
+	except Exception:
+		return True
+
+
+def unsigned_escape_hatch_status() -> dict | None:
+	"""Operator-facing state of the deprecated unsigned-plugin escape hatch.
+
+	Returns None when the hatch is off - the enforcing default, nothing to
+	advise about. When it is on, returns the conf key, the removal date, the
+	counter window and how many unsigned calls it let through over that
+	window (``recent_allowed`` is None when the cache is unreachable).
+	Consumed by jarvis.selfhost.config_checks so the sunset is visible in
+	the product, not only in the bench logs.
+	"""
+	if not _allow_unsigned():
+		return None
+	return {
+		"conf_key": _ALLOW_UNSIGNED_CONF_KEY,
+		"sunset_date": _UNSIGNED_SUNSET_DATE,
+		"window_days": _UNSIGNED_COUNTER_DAYS,
+		"recent_allowed": _unsigned_allowed_recent(),
+	}
+
+
+def _unsigned_allowed_recent() -> int | None:
+	"""Unsigned requests allowed across the counter's retention window.
+
+	Reads the same raw (un-pickled) keys ``_record_unsigned_allowed`` writes
+	with ``incr``, so it must use ``cache.get``, not ``get_value``. Returns
+	None when the cache is unreachable - the caller says "unknown" rather
+	than an untrue zero.
+	"""
+	try:
+		cache = frappe.cache()
+		total = 0
+		for offset in range(_UNSIGNED_COUNTER_DAYS):
+			day = frappe.utils.add_days(frappe.utils.today(), -offset)
+			raw = cache.get(_UNSIGNED_COUNTER_PREFIX + str(day))
+			if raw is None:
+				continue
+			total += int(raw.decode() if isinstance(raw, bytes) else raw)
+		return total
+	except Exception:
+		return None
 
 
 def _record_unsigned_allowed() -> int | None:

--- a/jarvis/_plugin_auth.py
+++ b/jarvis/_plugin_auth.py
@@ -8,8 +8,8 @@ Layered defenses against the C2 attack surface (2026-06-16 review):
      row so an operator can grep for brute-force attempts. The caller IP
      is recorded for triage context even though the IP itself is not
      used as an enforcement gate.
-  3. Optional HMAC signature (Phase 2) - if the plugin presents
-     X-Jarvis-Signature + X-Jarvis-Nonce + X-Jarvis-Timestamp, the
+  3. Required HMAC signature (Phase 2) - the plugin must present
+     X-Jarvis-Signature + X-Jarvis-Nonce + X-Jarvis-Timestamp, and the
      bench validates a signed canonical request and dedupes the nonce
      in Redis. Replay-proof. A leaked agent_token alone is no longer
      enough to forge a request - the attacker also needs the HMAC key
@@ -29,10 +29,26 @@ window, with replay killed by Redis-backed nonce dedup. The operational
 cost (every multi-host deployment maintaining CIDRs through cloud IP
 churn) outweighed the marginal protection.
 
-Plugin clients that don't send signatures keep working with a
-warn-log. The plugin repo (jarvis-openclaw-plugin) gets a separate PR
-to emit signatures; once all containers in the field are upgraded the
-legacy path is removed.
+Signature rollout / sunset (JF-014, 2026-07-26)
+-----------------------------------------------
+The signature started life as opt-in: a request carrying none of the
+three headers was accepted on bearer + session alone, which meant a
+captured agent_token replayed arbitrary unsigned tool bodies forever -
+exactly the blast radius the signature exists to close. Every managed
+container in the field now runs a plugin build that signs every call,
+so the default is now ENFORCE: no signature headers is a reject with
+the same 400 InvalidArgumentError shape as partial headers.
+
+The single escape hatch is the site_config key
+``jarvis_plugin_allow_unsigned`` (absent or 0 = enforce; 1 = accept
+unsigned bearer-only requests). It exists only for self-hosted benches
+whose openclaw plugin has not been upgraded yet, it WARN-logs the
+sunset date on every request it lets through, and it bumps a per-day
+Redis counter (``jarvis:plugin_unsigned_allowed:<YYYY-MM-DD>``) so an
+operator can confirm the field is quiet before turning it off. Requests
+rejected while the flag is off land in the Error Log under
+"plugin_auth: unsigned request rejected". The flag itself is scheduled
+for removal on 2026-10-01 (``_UNSIGNED_SUNSET_DATE``).
 """
 
 from __future__ import annotations
@@ -46,6 +62,12 @@ import frappe
 _MAX_CLOCK_SKEW_S = 60
 _NONCE_TTL_S = 120
 _NONCE_REDIS_PREFIX = "jarvis:plugin_nonce:"
+
+# JF-014 unsigned-request sunset. See the module docstring.
+_ALLOW_UNSIGNED_CONF_KEY = "jarvis_plugin_allow_unsigned"
+_UNSIGNED_SUNSET_DATE = "2026-10-01"
+_UNSIGNED_COUNTER_PREFIX = "jarvis:plugin_unsigned_allowed:"
+_UNSIGNED_COUNTER_TTL_S = 7 * 24 * 60 * 60
 
 
 class PluginAuthError(Exception):
@@ -140,16 +162,18 @@ def validate_plugin_request(body_bytes: bytes) -> str:
 			message="X-Jarvis-Session header required when using X-Jarvis-Token",
 		)
 
-	# 4. HMAC signature (Phase 2) - validated if all three headers are
-	# present. Plugin clients without signature support keep working but
-	# get a warn-log so operators can track the rollout.
+	# 4. HMAC signature (Phase 2) - REQUIRED unless the deprecated
+	# site_config escape hatch is on. See the module docstring for the
+	# rollout story.
 	sig = (headers.get("X-Jarvis-Signature") or "").strip()
 	nonce = (headers.get("X-Jarvis-Nonce") or "").strip()
 	ts_str = (headers.get("X-Jarvis-Timestamp") or "").strip()
 	if sig or nonce or ts_str:
 		# Partial signature headers are ALWAYS a reject - either you sign
 		# the request properly or you don't sign at all. Partial = client
-		# bug at best, downgrade-attack attempt at worst.
+		# bug at best, downgrade-attack attempt at worst. Not even the
+		# escape hatch relaxes this: it re-enables *unsigned* requests,
+		# never half-signed ones.
 		if not (sig and nonce and ts_str):
 			raise PluginAuthError(
 				http_status=400,
@@ -165,14 +189,32 @@ def validate_plugin_request(body_bytes: bytes) -> str:
 			nonce=nonce,
 			timestamp_str=ts_str,
 		)
-	else:
-		# Legacy bearer-only path. Log once so operators can see how many
-		# unsigned requests are still in flight before deprecation.
-		frappe.logger().info(
-			"plugin_auth: legacy bearer-only request from %s (session=%s); "
-			"plugin should be upgraded to send signed requests",
+	elif _allow_unsigned():
+		# Deprecated bearer-only path, explicitly re-enabled by the
+		# operator. WARN + a per-day counter so the stragglers are
+		# visible before the flag is turned off for good.
+		allowed_today = _record_unsigned_allowed()
+		frappe.logger().warning(
+			"plugin_auth: DEPRECATED unsigned request allowed by site_config "
+			"%s (removal %s); caller=%s session=%s unsigned_today=%s; upgrade "
+			"the openclaw plugin so it signs every call",
+			_ALLOW_UNSIGNED_CONF_KEY,
+			_UNSIGNED_SUNSET_DATE,
 			caller_ip,
 			session_key,
+			"unknown" if allowed_today is None else allowed_today,
+		)
+	else:
+		_audit_log(
+			"plugin_auth: unsigned request rejected",
+			f"remote_ip={caller_ip!r} session={session_key!r}; no signature headers "
+			f"and {_ALLOW_UNSIGNED_CONF_KEY} is off",
+		)
+		raise PluginAuthError(
+			http_status=400,
+			code="InvalidArgumentError",
+			message="signature headers required; provide all of "
+			"X-Jarvis-Signature/X-Jarvis-Nonce/X-Jarvis-Timestamp",
 		)
 
 	# 5. Rate limit per session_key (after signature validation so the
@@ -220,6 +262,39 @@ def _caller_ip() -> str:
 		if val:
 			return str(val).strip()
 	return ""
+
+
+def _allow_unsigned() -> bool:
+	"""True iff site_config re-enables the deprecated unsigned path.
+
+	Read with an explicit ``0`` default and truthiness decided on an
+	allowlist of literals: the flag is a security downgrade, so anything
+	we don't positively recognise as "on" (absent key, 0, "", "no", a
+	NULL-ish read, a raising conf) means ENFORCE.
+	"""
+	try:
+		raw = frappe.conf.get(_ALLOW_UNSIGNED_CONF_KEY, 0)
+	except Exception:
+		return False
+	return str(raw or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _record_unsigned_allowed() -> int | None:
+	"""Bump the per-day counter of legacy-allowed unsigned requests.
+
+	Returns the running count for today, or None when the cache is
+	unreachable. Best-effort observability only - it must never fail a
+	request that auth has already decided to allow.
+	"""
+	try:
+		cache = frappe.cache()
+		key = _UNSIGNED_COUNTER_PREFIX + frappe.utils.today()
+		count = int(cache.incr(key))
+		if count == 1:
+			cache.expire(key, _UNSIGNED_COUNTER_TTL_S)
+		return count
+	except Exception:
+		return None
 
 
 def _agent_token() -> str:

--- a/jarvis/selfhost.py
+++ b/jarvis/selfhost.py
@@ -176,7 +176,8 @@ def validate_connection(base_url: str, token: str, *, deep: bool = False) -> dic
 
 # --- deterministic config checks (no network, no LLM) --------------------
 # Surfaced in "Test connection" so a user sees the two most common self-host
-# tool failures (unset tool user / missing gateway token) BEFORE they chat.
+# tool failures (unset tool user / missing gateway token) BEFORE they chat,
+# plus the JF-014 unsigned-plugin escape hatch when an operator has it on.
 
 
 def _tool_user_ok(user: str) -> tuple[bool, str]:
@@ -191,6 +192,37 @@ def _tool_user_ok(user: str) -> tuple[bool, str]:
 	if not frappe.db.get_value("User", user, "enabled"):
 		return False, f"{user!r} is not an enabled Frappe user"
 	return True, f"tool user {user!r} (non-admin, enabled)"
+
+
+def _unsigned_plugin_check() -> dict | None:
+	"""Advisory row for the deprecated unsigned-plugin escape hatch (JF-014).
+
+	Returns None on an enforcing bench (the default) so the check list stays
+	quiet; a row only appears once an operator has turned
+	``jarvis_plugin_allow_unsigned`` on, which is a security downgrade with a
+	fixed removal date. Best-effort: never break "Test connection"."""
+	try:
+		from jarvis._plugin_auth import unsigned_escape_hatch_status
+
+		status = unsigned_escape_hatch_status()
+	except Exception:
+		return None
+	if not status:
+		return None
+	n = status.get("recent_allowed")
+	days = status.get("window_days")
+	if n is None:
+		seen = f"call count unavailable (cache unreachable), window {days}d"
+	elif n:
+		seen = f"{n} unsigned plugin call(s) allowed in the last {days} days"
+	else:
+		seen = f"no unsigned plugin calls in the last {days} days — safe to turn off"
+	return _check(
+		"plugin_signature_enforced",
+		False,
+		f"site_config {status['conf_key']} is ON: {seen}. Upgrade the openclaw "
+		f"plugin to a signing build — the flag is removed on {status['sunset_date']}.",
+	)
 
 
 def config_checks(token: str, tool_user: str = "") -> list[dict]:
@@ -209,6 +241,9 @@ def config_checks(token: str, tool_user: str = "") -> list[dict]:
 		user = (getattr(s, "selfhost_tool_user", "") or "").strip()
 	ok, detail = _tool_user_ok(user)
 	checks.append(_check("tool_user", ok, detail))
+	unsigned = _unsigned_plugin_check()
+	if unsigned:
+		checks.append(unsigned)
 	return checks
 
 

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -564,6 +564,11 @@ class TestJF014UnsignedPathRetired(_PluginAuthTestBase):
 	arbitrary unsigned tool bodies. Enforcement is now the default; the
 	site_config key ``jarvis_plugin_allow_unsigned`` is the documented,
 	WARN-logged escape hatch for un-upgraded self-hosted plugins.
+
+	The trailing block covers the review remediation: the reject is the
+	operator's only signal, so it carries the remedy; the audit row behind
+	it is throttled; and the hatch's usage count is readable for the
+	self-host advisory.
 	"""
 
 	CONF_KEY = "jarvis_plugin_allow_unsigned"
@@ -571,13 +576,28 @@ class TestJF014UnsignedPathRetired(_PluginAuthTestBase):
 
 	def setUp(self):
 		super().setUp()
+		from jarvis import _plugin_auth
+
 		# The rate-limit counter is keyed on the session, which this class
 		# shares with TestC2RateLimit - and that class deliberately leaves
-		# the bucket exhausted for up to 60s.
+		# the bucket exhausted for up to 60s. The audit gate is likewise
+		# per-session with a 60s TTL, so it must not leak across tests.
 		try:
-			frappe.cache().delete(f"jarvis:plugin_rl:{self.SESSION_KEY}")
+			cache = frappe.cache()
+			cache.delete(f"jarvis:plugin_rl:{self.SESSION_KEY}")
+			for key in self._audit_gate_keys():
+				cache.delete(key)
+			cache.delete(_plugin_auth._UNSIGNED_COUNTER_PREFIX + frappe.utils.today())
 		except Exception:
 			pass
+
+	def _audit_gate_keys(self):
+		from jarvis import _plugin_auth
+
+		return [
+			_plugin_auth._UNSIGNED_AUDIT_GATE_PREFIX + self.SESSION_KEY,
+			_plugin_auth._UNSIGNED_AUDIT_GATE_PREFIX + self.SESSION_KEY + ":other",
+		]
 
 	def _conf(self, value):
 		"""Set the escape-hatch site_config key for the duration of the
@@ -667,6 +687,88 @@ class TestJF014UnsignedPathRetired(_PluginAuthTestBase):
 			self.assertTrue(self._call(sign=False)["ok"])
 		raw = cache.get(key)
 		self.assertEqual(int(raw.decode() if isinstance(raw, bytes) else raw), 2)
+
+	# --- review remediation: UX P0-1 (remedy in the message) + adversarial
+	# P2-7 (throttle the reject audit) + UX P1-1 (operator-visible count).
+
+	def test_reject_message_carries_the_remedy(self):
+		"""The 400 is the operator's ONLY signal - it must name both the
+		real fix and the exact stopgap command, with the removal date."""
+		from jarvis import _plugin_auth
+
+		with self._conf(self._ABSENT):
+			result = self._call(sign=False)
+		msg = result["error"]["message"]
+		self.assertFalse(result["ok"], msg=result)
+		self.assertIn("signature headers required", msg)
+		self.assertIn("Upgrade the openclaw plugin", msg)
+		self.assertIn(f"bench --site <site> set-config {self.CONF_KEY} 1", msg)
+		self.assertIn(_plugin_auth._UNSIGNED_SUNSET_DATE, msg)
+
+	def test_unsigned_reject_audit_is_throttled_per_session(self):
+		"""Every reject still happens; only the Error Log row is gated."""
+		from jarvis import _plugin_auth
+
+		with self._conf(self._ABSENT), patch.object(_plugin_auth, "_audit_log") as audit:
+			for _ in range(5):
+				self.assertFalse(self._call(sign=False)["ok"])
+			self.assertEqual(audit.call_count, 1, msg=audit.call_args_list)
+			self.assertEqual(audit.call_args.args[0], "plugin_auth: unsigned request rejected")
+			# A different session is a different operator symptom: not gated.
+			headers = {
+				"X-Jarvis-Token": self.TOKEN,
+				"X-Jarvis-Session": self.SESSION_KEY + ":other",
+			}
+			with self._with_headers(headers):
+				with patch("jarvis.api._persist_and_publish_tool_call"):
+					self.assertFalse(call_tool(tool="get_schema", args={"doctype": "Customer"})["ok"])
+			self.assertEqual(audit.call_count, 2, msg=audit.call_args_list)
+
+	def test_audit_gate_fails_open_when_cache_is_unreachable(self):
+		"""A Redis outage must never make the audit trail quieter."""
+		from jarvis import _plugin_auth
+
+		with patch.object(_plugin_auth.frappe, "cache", side_effect=RuntimeError("redis down")):
+			self.assertTrue(_plugin_auth._should_audit_unsigned_reject("s1"))
+			self.assertTrue(_plugin_auth._should_audit_unsigned_reject("s1"))
+
+	def test_escape_hatch_status_is_none_while_enforcing(self):
+		from jarvis import _plugin_auth
+
+		with self._conf(self._ABSENT):
+			self.assertIsNone(_plugin_auth.unsigned_escape_hatch_status())
+
+	def test_escape_hatch_status_reports_recent_allowed_count(self):
+		"""Feeds the self-host advisory row (UX P1-1) - the count must be
+		read back from the same raw keys the allow path increments."""
+		from jarvis import _plugin_auth
+
+		cache = frappe.cache()
+		today = frappe.utils.today()
+		yesterday = frappe.utils.add_days(today, -1)
+		try:
+			cache.delete(_plugin_auth._UNSIGNED_COUNTER_PREFIX + today)
+			cache.delete(_plugin_auth._UNSIGNED_COUNTER_PREFIX + str(yesterday))
+		except Exception:
+			self.skipTest("cache unavailable")
+		cache.set(_plugin_auth._UNSIGNED_COUNTER_PREFIX + str(yesterday), b"3", ex=60)
+		with self._conf(1):
+			self.assertTrue(self._call(sign=False)["ok"])
+			status = _plugin_auth.unsigned_escape_hatch_status()
+		self.assertEqual(status["conf_key"], self.CONF_KEY)
+		self.assertEqual(status["sunset_date"], _plugin_auth._UNSIGNED_SUNSET_DATE)
+		self.assertEqual(status["window_days"], _plugin_auth._UNSIGNED_COUNTER_DAYS)
+		# 1 from the call just made today + the 3 seeded for yesterday.
+		self.assertEqual(status["recent_allowed"], 4)
+		cache.delete(_plugin_auth._UNSIGNED_COUNTER_PREFIX + str(yesterday))
+
+	def test_escape_hatch_status_says_unknown_when_cache_is_unreachable(self):
+		from jarvis import _plugin_auth
+
+		with self._conf(1), patch.object(_plugin_auth.frappe, "cache", side_effect=RuntimeError("down")):
+			status = _plugin_auth.unsigned_escape_hatch_status()
+		self.assertIsNotNone(status)
+		self.assertIsNone(status["recent_allowed"])
 
 
 class TestRotateAgentTokenEndpoint(FrappeTestCase):

--- a/jarvis/tests/test_api.py
+++ b/jarvis/tests/test_api.py
@@ -45,6 +45,32 @@ class _FakeRequest:
 		return self._body
 
 
+SIGNATURE_HEADERS = ("X-Jarvis-Signature", "X-Jarvis-Nonce", "X-Jarvis-Timestamp")
+
+
+def sign_plugin_headers(token: str, session_key: str, body: bytes = b"") -> dict[str, str]:
+	"""Build the three signature headers the bench now requires (JF-014).
+
+	Mirrors ``signRequest`` in jarvis-openclaw-plugin's frappe-client.ts:
+	HMAC-SHA256 over "session | sha256(body) | nonce | timestamp", keyed by
+	the gateway token. A fresh nonce per call keeps the Redis dedup window
+	from rejecting back-to-back calls in the same test.
+	"""
+	import hashlib
+	import hmac as _hmac
+	import secrets
+	import time
+
+	nonce = secrets.token_hex(16)
+	ts = str(int(time.time()))
+	canonical = "|".join([session_key, hashlib.sha256(body).hexdigest(), nonce, ts]).encode("utf-8")
+	return {
+		"X-Jarvis-Signature": _hmac.new(token.encode("utf-8"), canonical, hashlib.sha256).hexdigest(),
+		"X-Jarvis-Nonce": nonce,
+		"X-Jarvis-Timestamp": ts,
+	}
+
+
 class TestCallToolPluginAuth(FrappeTestCase):
 	"""Plugin-auth path: X-Jarvis-Token + X-Jarvis-Session → Frappe resolves
 	the user from Jarvis Chat Session and dispatches as them.
@@ -86,13 +112,34 @@ class TestCallToolPluginAuth(FrappeTestCase):
 		frappe.db.commit()
 		super().tearDownClass()
 
-	def _with_headers(self, headers: dict[str, str], *, body: bytes = b"", request_ip: str = "127.0.0.1"):
+	def _with_headers(
+		self,
+		headers: dict[str, str],
+		*,
+		body: bytes = b"",
+		request_ip: str = "127.0.0.1",
+		sign: bool = True,
+	):
 		"""Context manager: fakes ``frappe.request`` AND
 		``frappe.local.request_ip``. Defaults to loopback so the
 		C2 IP-allowlist check passes; tests targeting the IP path
 		pass a different ``request_ip``.
+
+		Since JF-014 the bench requires signed plugin requests, so bearer +
+		session headers are auto-signed here (what every shipped plugin
+		build does). These tests are about session→user resolution, not the
+		signature; ``sign=False`` opts out.
 		"""
 		import contextlib
+
+		if (
+			sign
+			and headers.get("X-Jarvis-Token")
+			and headers.get("X-Jarvis-Session")
+			and not any(h in headers for h in SIGNATURE_HEADERS)
+		):
+			headers = dict(headers)
+			headers.update(sign_plugin_headers(headers["X-Jarvis-Token"], headers["X-Jarvis-Session"], body))
 
 		req_patch = patch.object(frappe, "request", _FakeRequest(headers, body=body), create=True)
 
@@ -359,13 +406,18 @@ class _PluginAuthTestBase(FrappeTestCase):
 
 		return _combined()
 
-	def _call(self, *, request_ip="127.0.0.1", extra_headers=None, body=b""):
+	def _call(self, *, request_ip="127.0.0.1", extra_headers=None, body=b"", sign=True):
 		headers = {
 			"X-Jarvis-Token": self.TOKEN,
 			"X-Jarvis-Session": self.SESSION_KEY,
 		}
 		if extra_headers:
 			headers.update(extra_headers)
+		# JF-014: signed is the production default. Tests that drive the
+		# signature themselves already supply the headers; the legacy
+		# bearer-only path is exercised explicitly with sign=False.
+		if sign and not any(h in headers for h in SIGNATURE_HEADERS):
+			headers.update(sign_plugin_headers(self.TOKEN, self.SESSION_KEY, body))
 		with self._with_headers(headers, body=body, request_ip=request_ip):
 			with patch("jarvis.api._persist_and_publish_tool_call"):
 				return call_tool(tool="get_schema", args={"doctype": "Customer"})
@@ -502,6 +554,119 @@ class TestC2HmacSignature(_PluginAuthTestBase):
 		self.assertFalse(result["ok"])
 		self.assertEqual(result["error"]["code"], "AuthenticationError")
 		self.assertIn("nonce", result["error"]["message"].lower())
+
+
+class TestJF014UnsignedPathRetired(_PluginAuthTestBase):
+	"""JF-014 (2026-07-26): the unsigned bearer-only path is retired.
+
+	A request carrying none of the three signature headers used to be
+	accepted on bearer + session alone, so a captured agent_token replayed
+	arbitrary unsigned tool bodies. Enforcement is now the default; the
+	site_config key ``jarvis_plugin_allow_unsigned`` is the documented,
+	WARN-logged escape hatch for un-upgraded self-hosted plugins.
+	"""
+
+	CONF_KEY = "jarvis_plugin_allow_unsigned"
+	_ABSENT = object()
+
+	def setUp(self):
+		super().setUp()
+		# The rate-limit counter is keyed on the session, which this class
+		# shares with TestC2RateLimit - and that class deliberately leaves
+		# the bucket exhausted for up to 60s.
+		try:
+			frappe.cache().delete(f"jarvis:plugin_rl:{self.SESSION_KEY}")
+		except Exception:
+			pass
+
+	def _conf(self, value):
+		"""Set the escape-hatch site_config key for the duration of the
+		block. ``value=self._ABSENT`` removes the key entirely (the state
+		of every bench that never opted in)."""
+		import contextlib
+
+		@contextlib.contextmanager
+		def _ctx():
+			conf = frappe.local.conf
+			missing = object()
+			prior = conf.get(self.CONF_KEY, missing)
+			if value is self._ABSENT:
+				conf.pop(self.CONF_KEY, None)
+			else:
+				conf[self.CONF_KEY] = value
+			try:
+				yield
+			finally:
+				if prior is missing:
+					conf.pop(self.CONF_KEY, None)
+				else:
+					conf[self.CONF_KEY] = prior
+
+		return _ctx()
+
+	def test_unsigned_request_rejected_by_default(self):
+		"""The enforcement guard: delete the reject branch in
+		_plugin_auth and this test fails."""
+		with self._conf(self._ABSENT):
+			result = self._call(sign=False)
+		self.assertFalse(result["ok"], msg=result)
+		self.assertEqual(result["error"]["code"], "InvalidArgumentError")
+		self.assertEqual(frappe.local.response.http_status_code, 400)
+		self.assertIn("signature headers required", result["error"]["message"])
+
+	def test_signed_request_still_accepted_with_flag_off(self):
+		"""No regression for the path every shipped plugin build uses."""
+		with self._conf(self._ABSENT):
+			result = self._call()
+		self.assertTrue(result["ok"], msg=result)
+
+	def test_off_or_junk_flag_values_keep_enforcement(self):
+		"""Fail closed: only an explicit on-literal re-opens the path."""
+		for value in (self._ABSENT, 0, "0", "", None, False, "false", "no", "maybe"):
+			with self.subTest(flag=value), self._conf(value):
+				result = self._call(sign=False)
+				self.assertFalse(result["ok"], msg=f"flag={value!r} allowed an unsigned request")
+				self.assertEqual(result["error"]["code"], "InvalidArgumentError")
+
+	def test_partial_signature_headers_rejected_regardless_of_flag(self):
+		"""The escape hatch re-enables *unsigned* requests, never
+		half-signed ones - that shape is a downgrade attempt."""
+		for value in (self._ABSENT, 0, 1):
+			with self.subTest(flag=value), self._conf(value):
+				result = self._call(extra_headers={"X-Jarvis-Signature": "a" * 64})
+				self.assertFalse(result["ok"], msg=f"flag={value!r} allowed partial headers")
+				self.assertEqual(result["error"]["code"], "InvalidArgumentError")
+				self.assertIn("partial signature", result["error"]["message"].lower())
+
+	def test_unsigned_allowed_when_flag_on_and_warns_with_sunset_date(self):
+		from unittest.mock import MagicMock
+
+		from jarvis import _plugin_auth
+
+		logger = MagicMock()
+		with self._conf(1), patch.object(_plugin_auth.frappe, "logger", return_value=logger):
+			result = self._call(sign=False)
+		self.assertTrue(result["ok"], msg=result)
+		warned = " ".join(str(arg) for call in logger.warning.call_args_list for arg in call.args)
+		self.assertIn("DEPRECATED unsigned request", warned)
+		self.assertIn(_plugin_auth._UNSIGNED_SUNSET_DATE, warned)
+		self.assertIn(self.CONF_KEY, warned)
+
+	def test_legacy_allowed_requests_are_counted(self):
+		"""Operators need a number to watch before flipping the flag off."""
+		from jarvis import _plugin_auth
+
+		cache = frappe.cache()
+		key = _plugin_auth._UNSIGNED_COUNTER_PREFIX + frappe.utils.today()
+		try:
+			cache.delete(key)
+		except Exception:
+			self.skipTest("cache unavailable")
+		with self._conf(1):
+			self.assertTrue(self._call(sign=False)["ok"])
+			self.assertTrue(self._call(sign=False)["ok"])
+		raw = cache.get(key)
+		self.assertEqual(int(raw.decode() if isinstance(raw, bytes) else raw), 2)
 
 
 class TestRotateAgentTokenEndpoint(FrappeTestCase):

--- a/jarvis/tests/test_api_chat_session_header.py
+++ b/jarvis/tests/test_api_chat_session_header.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.api import call_tool
+from jarvis.tests.test_api import sign_plugin_headers
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
@@ -21,6 +22,17 @@ class _FakeRequest:
 
 	def get_data(self, cache: bool = True) -> bytes:
 		return self._body
+
+
+def _plugin_headers(session_key: str, body: bytes = b"") -> dict:
+	"""Bearer + session + the signature headers the bench requires since
+	JF-014 (unsigned plugin requests are rejected by default)."""
+	headers = {
+		"X-Jarvis-Token": PLUGIN_TOKEN,
+		"X-Jarvis-Session": session_key,
+	}
+	headers.update(sign_plugin_headers(PLUGIN_TOKEN, session_key, body))
+	return headers
 
 
 import contextlib
@@ -99,12 +111,7 @@ class TestCallToolWithSessionHeader(FrappeTestCase):
 		_cleanup_for_session(self.session_key)
 
 	def test_session_header_persists_tool_message(self):
-		req = _FakeRequest(
-			{
-				"X-Jarvis-Token": PLUGIN_TOKEN,
-				"X-Jarvis-Session": self.session_key,
-			}
-		)
+		req = _FakeRequest(_plugin_headers(self.session_key))
 		with _patch_request(req):
 			with patch("jarvis.api.publish_realtime_tool_result"):
 				result = call_tool("get_schema", args={"doctype": "Customer"})
@@ -120,12 +127,7 @@ class TestCallToolWithSessionHeader(FrappeTestCase):
 		self.assertEqual(tools[0]["tool_status"], "completed")
 
 	def test_session_header_publishes_realtime_tool_result(self):
-		req = _FakeRequest(
-			{
-				"X-Jarvis-Token": PLUGIN_TOKEN,
-				"X-Jarvis-Session": self.session_key,
-			}
-		)
+		req = _FakeRequest(_plugin_headers(self.session_key))
 		with _patch_request(req):
 			with patch("jarvis.api.publish_realtime_tool_result") as pub:
 				call_tool("get_schema", args={"doctype": "Customer"})
@@ -147,12 +149,7 @@ class TestCallToolWithSessionHeader(FrappeTestCase):
 	def test_unknown_session_now_rejected(self):
 		"""Without a Chat Session row we have no user to dispatch as - fail
 		fast rather than silently fall back to a different identity."""
-		req = _FakeRequest(
-			{
-				"X-Jarvis-Token": PLUGIN_TOKEN,
-				"X-Jarvis-Session": "agent:nonexistent",
-			}
-		)
+		req = _FakeRequest(_plugin_headers("agent:nonexistent"))
 		with _patch_request(req):
 			result = call_tool("get_schema", args={"doctype": "Customer"})
 		self.assertFalse(result["ok"])

--- a/jarvis/tests/test_selfhost.py
+++ b/jarvis/tests/test_selfhost.py
@@ -323,6 +323,94 @@ class TestConfigChecks(unittest.TestCase):
 		self.assertTrue(self._run("tok", stored="carol@example.com")["tool_user"])
 
 
+class TestUnsignedPluginAdvisory(unittest.TestCase):
+	"""JF-014 review UX P1-1: an operator who turned the unsigned-plugin
+	escape hatch on must see it (and how much it is being used) in the
+	product's own "Test connection" checks, not only in the bench log."""
+
+	CHECK = "plugin_signature_enforced"
+
+	def _row(self, status):
+		with mock.patch("jarvis._plugin_auth.unsigned_escape_hatch_status", return_value=status):
+			return selfhost._unsigned_plugin_check()
+
+	def _rows_via_config_checks(self, status):
+		fake = _FakeSettings(selfhost_tool_user="alice@example.com")
+		with (
+			mock.patch("jarvis._plugin_auth.unsigned_escape_hatch_status", return_value=status),
+			mock.patch("jarvis.selfhost.frappe") as fr,
+		):
+			fr.get_single.return_value = fake
+			fr.db.get_value.return_value = 1
+			return selfhost.config_checks("tok", "alice@example.com")
+
+	def test_no_row_while_enforcing(self):
+		"""The default bench must not grow a permanent scary row."""
+		self.assertIsNone(self._row(None))
+		checks = self._rows_via_config_checks(None)
+		self.assertNotIn(self.CHECK, [c["check"] for c in checks])
+
+	def test_row_reports_recent_count_and_sunset(self):
+		row = self._row(
+			{
+				"conf_key": "jarvis_plugin_allow_unsigned",
+				"sunset_date": "2026-10-01",
+				"window_days": 7,
+				"recent_allowed": 12,
+			}
+		)
+		self.assertEqual(row["check"], self.CHECK)
+		self.assertFalse(row["ok"])
+		self.assertIn("jarvis_plugin_allow_unsigned is ON", row["detail"])
+		self.assertIn("12 unsigned plugin call(s) allowed in the last 7 days", row["detail"])
+		self.assertIn("2026-10-01", row["detail"])
+
+	def test_zero_recent_calls_says_safe_to_turn_off(self):
+		row = self._row(
+			{
+				"conf_key": "jarvis_plugin_allow_unsigned",
+				"sunset_date": "2026-10-01",
+				"window_days": 7,
+				"recent_allowed": 0,
+			}
+		)
+		self.assertFalse(row["ok"])
+		self.assertIn("safe to turn off", row["detail"])
+
+	def test_unknown_count_is_not_reported_as_zero(self):
+		row = self._row(
+			{
+				"conf_key": "jarvis_plugin_allow_unsigned",
+				"sunset_date": "2026-10-01",
+				"window_days": 7,
+				"recent_allowed": None,
+			}
+		)
+		self.assertIn("call count unavailable", row["detail"])
+		self.assertNotIn("safe to turn off", row["detail"])
+
+	def test_row_is_advisory_in_test_connection(self):
+		"""It must never flip the connection verdict - it is a warning about
+		a deprecation, not a broken openclaw."""
+		checks = self._rows_via_config_checks(
+			{
+				"conf_key": "jarvis_plugin_allow_unsigned",
+				"sunset_date": "2026-10-01",
+				"window_days": 7,
+				"recent_allowed": 3,
+			}
+		)
+		names = [c["check"] for c in checks]
+		self.assertIn(self.CHECK, names)
+		# config_checks rows are tagged advisory by test_connection, which is
+		# what keeps result["ok"] about the openclaw connection alone.
+		self.assertEqual([c["check"] for c in checks if not c["ok"]], [self.CHECK])
+
+	def test_status_lookup_failure_never_breaks_test_connection(self):
+		with mock.patch("jarvis._plugin_auth.unsigned_escape_hatch_status", side_effect=RuntimeError("boom")):
+			self.assertIsNone(selfhost._unsigned_plugin_check())
+
+
 class TestProbeToolCallback(unittest.TestCase):
 	"""Opt-in end-to-end probe: induce a jarvis__* tool call over HTTP and
 	confirm the openclaw->Frappe callback landed (counter advanced)."""


### PR DESCRIPTION
## Defect (JF-014, High)

`jarvis/_plugin_auth.py` validated the Phase-2 HMAC signature **only when at least one
of the three signature headers was present**:

```python
if sig or nonce or ts_str:
    ...validate (partial headers -> 400)...
else:
    frappe.logger().info("plugin_auth: legacy bearer-only request ...")   # accepted
```

A `call_tool` request that carried **none** of `X-Jarvis-Signature` /
`X-Jarvis-Nonce` / `X-Jarvis-Timestamp` was therefore accepted on bearer + session
alone, with nothing but an info log to show for it. Consequences:

- A captured `agent_token` replayed **arbitrary unsigned tool bodies** against any
  session key, for as long as the token lived — the exact blast radius the signature,
  the nonce dedup and the ±60s timestamp window exist to close.
- The check was trivially downgradable: partial headers were rejected, so an attacker
  simply sent **zero** signature headers instead of two.
- Since the IP allowlist was removed (2026-06-19), the signature was the only layer
  standing between a leaked bearer and full tool execution as the session's user.

## Root cause

A migration-era compatibility fallback. When the signature shipped, no plugin build
emitted one, so the bench accepted unsigned requests during rollout — and the sunset
was never scheduled or executed. Every managed container in the field now runs a
plugin build that signs **every** call (`signRequest` in the plugin's
`frappe-client.ts` is on the unconditional path in `callFrappeTool`), so the fallback
no longer protects anything we ship; it only widened the attack surface.

## Fix

1. **Default is ENFORCE.** No signature headers now rejects with the same fail-closed
   shape as partial headers — `400` / `InvalidArgumentError` — plus an Error Log row
   (`plugin_auth: unsigned request rejected`) carrying the caller IP and session for
   triage. Partial headers keep their existing reject and message.
2. **One documented escape hatch** for self-hosted benches running an un-upgraded
   plugin: the site_config key `jarvis_plugin_allow_unsigned`. Read with an explicit
   `0` default; only an explicit on-literal (`1`, `true`, `yes`, `on`) re-opens the
   path. Absent key, `0`, `""`, `None`, `False`, junk values, or a conf read that
   raises all mean ENFORCE. (Deliberately a site_config key, not a Check field —
   the v16 `get_single_value`-on-Check gotcha makes "NULL means default" unreadable,
   and a downgrade switch should be an explicit, greppable operator act.)
3. **Observability before the flag disappears.** Every request the hatch lets through
   WARN-logs the conf key, the caller, the session and the `2026-10-01` removal date,
   and bumps a per-day Redis counter `jarvis:plugin_unsigned_allowed:<YYYY-MM-DD>`
   (7-day TTL) so an operator can watch the stragglers drain to zero before turning
   the flag off. The counter is best-effort: a cache failure never fails a request
   auth has already decided to allow.
4. **The escape hatch does not relax the partial-header rule** — it re-enables
   *unsigned* requests, never half-signed ones.
5. Module docstring documents the rollout story, the flag and the sunset.

No change to the signed path, the bearer/expiry/session checks, or the rate limiter.

## Tests

New `TestJF014UnsignedPathRetired` in `jarvis/tests/test_api.py`:

- `test_unsigned_request_rejected_by_default` — the enforcement guard: delete the
  reject branch and this test fails.
- `test_off_or_junk_flag_values_keep_enforcement` — fail-closed across
  absent / `0` / `"0"` / `""` / `None` / `False` / `"false"` / `"no"` / `"maybe"`.
- `test_partial_signature_headers_rejected_regardless_of_flag` — flag off *and* on.
- `test_unsigned_allowed_when_flag_on_and_warns_with_sunset_date` — accepted, and the
  WARN names the conf key and the removal date.
- `test_legacy_allowed_requests_are_counted` — the per-day counter increments.
- `test_signed_request_still_accepted_with_flag_off` — no regression on the path
  every shipped plugin build uses.

The pre-existing plugin-auth tests posted bearer-only requests, which is no longer a
valid request shape. They now sign the way the plugin does — a shared
`sign_plugin_headers` helper mirrors the plugin's canonical string
(`session | sha256(body) | nonce | timestamp`, HMAC-SHA256 keyed by the gateway
token) with a fresh nonce per call. Tests whose subject is the *reject* path
(wrong token, missing session) are untouched: they fail before the signature step.

Run locally on the branch: `ruff check` + `ruff format --check` on the three touched
files, `compileall`, and a standalone harness that drives `validate_plugin_request`
with a faked `frappe` across all 24 accept/reject permutations above (all pass).
`jarvis.tests.test_api` and `jarvis.tests.test_api_chat_session_header` need a bench
run; full-suite CI covers both.

## Operator notes / rollout

- Managed fleet: no action. Every pod's plugin signs.
- A self-hosted bench on an old plugin build starts getting `400 InvalidArgumentError
  "signature headers required"` on tool calls, with one Error Log row per attempt.
  The fix is to upgrade the plugin; the stopgap is
  `bench --site <site> set-config jarvis_plugin_allow_unsigned 1`, which is scheduled
  for removal on 2026-10-01.
