### PR TITLE
fix(agents): JF-021 — record the human who triggered a manual agent run

### DIFF
--- a/jarvis/_session.py
+++ b/jarvis/_session.py
@@ -30,6 +30,27 @@ from contextlib import contextmanager
 
 import frappe
 
+# The pre-impersonation (authenticated) session user for this request/job, parked
+# on frappe.local so it dies with the request. Set by ``impersonate`` only.
+_AUTH_USER_ATTR = "jarvis_authenticated_user"
+
+
+def authenticated_user() -> str:
+	"""The user this request/job AUTHENTICATED as - the session user BEFORE any
+	:func:`impersonate` switch (the OUTERMOST one, when switches nest).
+
+	Provenance must never be read from ambient session state after an identity
+	switch: inside ``impersonate`` ``frappe.session.user`` is the impersonated
+	identity, so stamping it records the wrong human. Callers that record WHO
+	acted read it from here instead.
+
+	Falls back to the live session user when nothing is impersonating, so a plain
+	request path (or a background job) answers the same question correctly. Only
+	:func:`impersonate` maintains the marker - a bare ``frappe.set_user`` switch
+	is invisible to it, which is the other reason HTTP paths must use this seam.
+	"""
+	return getattr(frappe.local, _AUTH_USER_ATTR, None) or frappe.session.user
+
 
 @contextmanager
 def impersonate(user: str | None):
@@ -54,12 +75,19 @@ def impersonate(user: str | None):
 	# frappe.set_user REPLACES local.session.data with a fresh dict rather than
 	# mutating it, so this reference to the original inner dict stays valid.
 	orig_data = frappe.session.data
+	# Remember who the request was authenticated as, for authenticated_user(). The
+	# OUTERMOST switch wins (nested impersonation must not re-anchor the identity on
+	# an already-impersonated user), and the previous marker - not None - is what the
+	# finally restores, so unwinding a nested switch leaves the outer one intact.
+	outer_auth = getattr(frappe.local, _AUTH_USER_ATTR, None)
 	# set_user is inside the try so a mid-switch failure still restores the
 	# caller's session in the finally (never leave it gutted / half-switched).
 	try:
+		setattr(frappe.local, _AUTH_USER_ATTR, outer_auth or orig_user)
 		frappe.set_user(user)
 		yield
 	finally:
+		setattr(frappe.local, _AUTH_USER_ATTR, outer_auth)
 		frappe.set_user(orig_user)
 		frappe.local.session.sid = orig_sid
 		frappe.local.session.data = orig_data

--- a/jarvis/chat/agent_scheduler.py
+++ b/jarvis/chat/agent_scheduler.py
@@ -36,6 +36,7 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime
 
+from jarvis._session import authenticated_user
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.macro_scheduler import compute_next_run
 
@@ -196,7 +197,9 @@ def run_due_agent_audits() -> None:
 		try:
 			frappe.set_user(run_as)
 			inst = frappe.get_doc(INSTALLATION, row.name)
-			_launch_audit(inst, trigger="scheduled", source_apps=source_apps)
+			# initiating_human=None is EXPLICIT (JF-021): a cron run is unattended, so
+			# it has no initiating human — the scheduler user (Administrator) is not one.
+			_launch_audit(inst, trigger="scheduled", source_apps=source_apps, initiating_human=None)
 			frappe.set_user(original_user)
 			_advance(row, now)  # O4: advance ONLY after a successful enqueue
 		except Exception:
@@ -348,12 +351,64 @@ def _stale_candidates(cutoff) -> list:
 # --------------------------------------------------------------------------- #
 # shared launch (scheduler + manual run_agent_now take the SAME path)
 # --------------------------------------------------------------------------- #
-def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> dict:
+def _resolve_initiating_human(trigger: str, initiating_human: str | None) -> str | None:
+	"""JF-021 — the validated human to stamp as a run's immutable ``initiating_human``.
+
+	Provenance is PASSED IN, never read from ambient session state. By the time
+	``_launch_audit`` runs, BOTH launch paths have already switched the session to the
+	installation's ``run_as_user``, so ``frappe.session.user`` is the EXECUTING identity;
+	stamping it misattributed every manual run whose triggerer != run-as user, forever
+	(the field is immutable once inserted).
+
+	Fail-closed rules:
+
+	* **scheduled** — no human initiates a cron run, so the field stays empty. A caller
+	  that supplies one is REFUSED rather than believed (attributing an unattended run
+	  to a person is exactly the lie this field exists to prevent).
+	* **manual** — the identity must equal the AUTHENTICATED session user of this
+	  request (``jarvis._session.authenticated_user`` — the user as of BEFORE any
+	  ``impersonate`` switch). A supplied value can therefore only ever CONFIRM what the
+	  server already knows; it can never introduce a third identity, so nothing
+	  client-reachable can forge attribution. Omitting it resolves to that same
+	  authenticated user (the in-process callers that never impersonate).
+	* the resolved identity must be a real ENABLED User and never Guest — an
+	  unattributable "human" is refused, not stamped.
+	"""
+	if trigger != "manual":
+		if initiating_human:
+			frappe.throw(_("A scheduled agent run has no initiating human."))
+		return None
+
+	# The pre-impersonation session user: the server's own answer to "who triggered
+	# this", derived independently of whatever the caller passed.
+	actual = (authenticated_user() or "").strip()
+	human = (initiating_human or actual).strip()
+	if human != actual:
+		frappe.throw(
+			_("An agent run can only be attributed to the user who triggered it."),
+			frappe.PermissionError,
+		)
+	if human in ("", "Guest") or not frappe.db.get_value("User", human, "enabled"):
+		frappe.throw(_("A manual agent run must be attributable to an enabled user."))
+	return human
+
+
+def _launch_audit(
+	inst,
+	trigger: str,
+	source_apps: list[str] | None = None,
+	initiating_human: str | None = None,
+) -> dict:
 	"""Create the audit conversation + a ``running`` Jarvis Agent Run + enqueue
 	the triggering turn. MUST run as the installation owner (the scheduler
 	set_user's it; run_agent_now is already the owner). Returns
 	``{run, conversation, session_key}``. Identity/budget guards + next_run_at
 	advancement are the caller's job.
+
+	``initiating_human`` (JF-021) is the human who triggered a MANUAL run, captured by
+	the caller BEFORE it impersonated the run-as user and validated here by
+	``_resolve_initiating_human``. The scheduler passes ``None`` — a cron run has no
+	initiating human.
 
 	``source_apps`` (CX5-2) is the Custom App Learning run's ADMIN-AUTHORIZED app
 	selection, already validated by the caller (``app_source.validate_source_apps``).
@@ -389,6 +444,11 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 			)
 		)
 
+	# JF-021: validate the launch-time provenance identity BEFORE any row is inserted,
+	# for the same reason as the run-as guard above — a refused launch must leave no
+	# orphan conversation/run behind.
+	initiating_human = _resolve_initiating_human(trigger, initiating_human)
+
 	# Fresh conversation. ROW ownership is the human owner (reassigned below) so
 	# if_owner visibility works; the ERP-read identity is the run-as user.
 	# ignore_permissions matches the macro engine.
@@ -405,13 +465,12 @@ def _launch_audit(inst, trigger: str, source_apps: list[str] | None = None) -> d
 	#     (shadow|live) at launch, so a run made in shadow is forever attributable as
 	#     such even after the install is later promoted.
 	#   * initiating_human — the human who triggered a MANUAL run; None for a
-	#     scheduled cron run (no human initiated it). On the manual path the caller has
-	#     switched the session to the run-as user, so frappe.session.user is the
-	#     triggering human ONLY on a self-mapped install (run_as == triggerer); see the
-	#     cross-file note for the run_as != triggerer case.
+	#     scheduled cron run (no human initiated it). Resolved above from the caller's
+	#     EXPLICIT argument, never from frappe.session.user: the session here is the
+	#     run-as user, which is a different person whenever the triggerer did not run
+	#     their own self-mapped install (JF-021).
 	bundle_version = inst.installed_version or listing.version or None
 	preparation_mode = inst.activation_state or "shadow"
-	initiating_human = frappe.session.user if trigger == "manual" else None
 
 	run = frappe.get_doc(
 		{

--- a/jarvis/chat/agents_api.py
+++ b/jarvis/chat/agents_api.py
@@ -16,7 +16,7 @@ Enable / schedule are pure DB writes (no container restart — O6); only Apply
 import frappe
 from frappe import _
 
-from jarvis._session import impersonate
+from jarvis._session import authenticated_user, impersonate
 from jarvis.chat import coverage_reasons as cr
 from jarvis.chat.agent_activity import log_activity
 from jarvis.chat.agent_catalog import build_agent_push_payload
@@ -831,7 +831,8 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	another owner's audit cannot run ERP reads with elevated rights. This mirrors
 	the scheduler's S1 identity hinge on the manual path. Run/finding ROW
 	ownership stays the human owner (``_launch_audit``); only the ERP-read
-	identity is the run-as user."""
+	identity is the run-as user; and the TRIGGERING human is recorded separately as
+	the run's immutable ``initiating_human`` (JF-021) — three distinct identities."""
 	doc = frappe.get_doc(INSTALLATION, installation)
 	doc.check_permission("write")  # S3: who may trigger
 	# R1-F3: no ``or doc.owner`` fallback. A blank run-as user is a MISCONFIGURED
@@ -938,6 +939,14 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 		frappe.throw(_("Cannot run this audit as its run-as user (identity guard)."))
 
 	original_user = frappe.session.user
+	# JF-021: the run's IMMUTABLE launch provenance identity, captured HERE — before
+	# the impersonation below — and passed EXPLICITLY into the launch. _launch_audit
+	# used to read frappe.session.user, which by then is the RUN-AS user: every manual
+	# run a System Manager triggered on someone else's install permanently recorded the
+	# wrong person in a field no correction can reach. This is never a client argument
+	# (run_agent_now takes no such parameter) and the launch re-derives + verifies it
+	# against the authenticated session user, so it can only confirm, never forge.
+	triggering_human = authenticated_user()
 	# impersonate is session-safe (a bare frappe.set_user in this HTTP path
 	# would gut the caller's cookie session and log them out) and no-ops when
 	# the run-as user IS the caller (self-mapped manual run). get_doc does NOT
@@ -946,7 +955,9 @@ def run_agent_now(installation: str, options: str | dict | None = None) -> dict:
 	with impersonate(run_as if run_as != original_user else None):
 		if run_as != original_user:
 			doc = frappe.get_doc(INSTALLATION, installation)  # re-fetch under run_as
-		result = _launch_audit(doc, trigger="manual", source_apps=source_apps)
+		result = _launch_audit(
+			doc, trigger="manual", source_apps=source_apps, initiating_human=triggering_human
+		)
 	return {"ok": True, "data": result}
 
 

--- a/jarvis/tests/test_platform_launch_provenance.py
+++ b/jarvis/tests/test_platform_launch_provenance.py
@@ -14,17 +14,28 @@ values — not merely that the controller guard fires when a value is pre-inject
 (that is covered by ``test_platform_writeback``). ``admin_client.post_agent_run``
 is stubbed so the dispatch returns without a live fleet, mirroring
 ``test_agent_identity``.
+
+JF-021 extends this: the stamped ``initiating_human`` was read from
+``frappe.session.user`` INSIDE the launch, i.e. AFTER both paths impersonate the
+installation's ``run_as_user`` — so a manual run triggered by a System Manager on
+someone else's install permanently recorded the run-as user as the person who
+asked for it. The identity is now passed in explicitly and verified against the
+authenticated (pre-impersonation) session user, so the three identities a run has
+— triggerer / row owner / run-as — stay distinct and correct.
 """
 
 import unittest
+from unittest import mock
 
 import frappe
 
+from jarvis._session import authenticated_user, impersonate
 from jarvis.chat import agent_catalog, agent_scheduler, agents_api
 
 LISTING = "Jarvis Agent Listing"
 INSTALLATION = "Jarvis Agent Installation"
 RUN = "Jarvis Agent Run"
+CONV = "Jarvis Conversation"
 SESSION = "Jarvis Chat Session"
 AGENT = "close-auditor"
 
@@ -77,6 +88,10 @@ class TestPlatformLaunchProvenance(unittest.TestCase):
 		frappe.set_user("Administrator")
 		agent_catalog.sync_agent_listings()
 		cls.owner = _ensure_user("plp-owner@example.com")
+		# JF-021 three-identity cast: A triggers (a System Manager, so it may trigger
+		# someone else's install), B owns the install, C is the run-as identity.
+		cls.triggerer = _ensure_user("plp-triggerer@example.com", ("System Manager",))
+		cls.runas = _ensure_user("plp-runas@example.com")
 		cls.listing_version = frappe.db.get_value(LISTING, AGENT, "version")
 
 	def setUp(self):
@@ -101,10 +116,13 @@ class TestPlatformLaunchProvenance(unittest.TestCase):
 			"Jarvis Agent Allowed Role",
 			{"parenttype": LISTING, "parentfield": "allowed_roles"},
 		)
+		# Rows land on the owner (reassigned) but a run-as launch mints its per-run
+		# session under the RUN-AS user, so every identity in the cast is swept.
+		cast = (self.owner, self.triggerer, self.runas)
 		for dt in (RUN, INSTALLATION):
-			for n in frappe.get_all(dt, filters={"owner": self.owner}, pluck="name"):
+			for n in frappe.get_all(dt, filters={"owner": ["in", cast]}, pluck="name"):
 				frappe.delete_doc(dt, n, force=True, ignore_permissions=True)
-		for n in frappe.get_all(SESSION, filters={"user": self.owner}, pluck="name"):
+		for n in frappe.get_all(SESSION, filters={"user": ["in", cast]}, pluck="name"):
 			frappe.delete_doc(SESSION, n, force=True, ignore_permissions=True)
 		frappe.db.commit()
 
@@ -208,3 +226,168 @@ class TestPlatformLaunchProvenance(unittest.TestCase):
 		frappe.db.set_value(INSTALLATION, inst_name, "activation_state", "live", update_modified=False)
 		frappe.db.commit()
 		self.assertEqual(frappe.db.get_value(RUN, run, "preparation_mode"), "shadow")
+
+	# ------------------------------------------------------------------ #
+	# JF-021 — THE DEFECT: triggerer A, owner B, run-as C on a MANUAL run
+	# ------------------------------------------------------------------ #
+	def test_manual_run_records_the_triggerer_not_the_run_as_user(self):
+		inst_name = _install_as(self.owner)  # B owns the install
+		frappe.set_user("Administrator")
+		agents_api.set_run_as_user(inst_name, self.runas)  # C is the executing identity
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+
+		import jarvis.admin_client as admin_client
+
+		captured = {}
+
+		def _cap(**kw):
+			captured["user"] = frappe.session.user
+			return {"run_id": kw.get("run_id"), "status": "queued"}
+
+		admin_client.post_agent_run = _cap
+		frappe.set_user(self.triggerer)  # A (a System Manager) triggers B's install
+		try:
+			result = agents_api.run_agent_now(inst_name)
+			# The caller's own session is intact after the impersonated launch.
+			self.assertEqual(frappe.session.user, self.triggerer)
+		finally:
+			frappe.set_user("Administrator")
+		run = result["data"]["run"]
+
+		# THE FIX: the immutable provenance names the human who asked for the run...
+		self.assertEqual(frappe.db.get_value(RUN, run, "initiating_human"), self.triggerer)
+		# ...not the run-as user the session had been switched to (the old behaviour),
+		# and not the row owner either.
+		self.assertNotEqual(frappe.db.get_value(RUN, run, "initiating_human"), self.runas)
+		self.assertNotEqual(frappe.db.get_value(RUN, run, "initiating_human"), self.owner)
+
+		# The other two identities are UNCHANGED by the fix: the turn still dispatches
+		# under the run-as user and the rows still belong to the human owner.
+		self.assertEqual(captured.get("user"), self.runas)
+		sk = frappe.db.get_value(RUN, run, "session_key")
+		self.assertEqual(frappe.db.get_value(SESSION, {"session_key": sk}, "user"), self.runas)
+		self.assertEqual(frappe.db.get_value(RUN, run, "owner"), self.owner)
+		self.assertEqual(frappe.db.get_value(CONV, result["data"]["conversation"], "owner"), self.owner)
+
+	# ------------------------------------------------------------------ #
+	# JF-021 — an attribution that is not the authenticated triggerer is
+	# REFUSED (never trusted), and refused before any row exists
+	# ------------------------------------------------------------------ #
+	def test_manual_launch_refuses_an_attribution_that_is_not_the_triggerer(self):
+		inst_name = _install_as(self.owner)  # self-mapped: run_as == owner
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+		convs_before = frappe.db.count(CONV)
+
+		frappe.set_user(self.owner)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				agent_scheduler._launch_audit(inst, trigger="manual", initiating_human=self.runas)
+		finally:
+			frappe.set_user("Administrator")
+
+		# Refused BEFORE the conversation/run were inserted, so nothing is orphaned.
+		self.assertEqual(frappe.get_all(RUN, filters={"installation": inst_name}, pluck="name"), [])
+		self.assertEqual(frappe.db.count(CONV), convs_before)
+
+	def test_manual_launch_refuses_an_unattributable_identity(self):
+		"""Guest / a deleted user / a disabled user is not a human this run can be
+		attributed to — the launch refuses rather than stamping it."""
+		disabled = _ensure_user("plp-disabled@example.com")
+		frappe.db.set_value("User", disabled, "enabled", 0, update_modified=False)
+		frappe.db.commit()
+		try:
+			for who in ("Guest", "plp-ghost@example.com", disabled):
+				with mock.patch.object(agent_scheduler, "authenticated_user", return_value=who):
+					with self.assertRaises(frappe.ValidationError):
+						agent_scheduler._resolve_initiating_human("manual", who)
+		finally:
+			frappe.db.set_value("User", disabled, "enabled", 1, update_modified=False)
+			frappe.db.commit()
+
+	# ------------------------------------------------------------------ #
+	# JF-021 — scheduled attribution semantics are UNCHANGED
+	# ------------------------------------------------------------------ #
+	def test_scheduled_launch_refuses_an_initiating_human(self):
+		inst_name = _install_as(self.owner)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		frappe.set_user(self.owner)
+		try:
+			# A cron run is unattended: claiming a human initiated it is refused, not
+			# quietly stamped. (The scheduler itself always passes None.)
+			with self.assertRaises(frappe.ValidationError):
+				agent_scheduler._launch_audit(inst, trigger="scheduled", initiating_human=self.owner)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.get_all(RUN, filters={"installation": inst_name}, pluck="name"), [])
+		self.assertIsNone(agent_scheduler._resolve_initiating_human("scheduled", None))
+
+	# ------------------------------------------------------------------ #
+	# JF-021 — the corrected value is still IMMUTABLE once stamped
+	# ------------------------------------------------------------------ #
+	def test_stamped_initiating_human_is_immutable(self):
+		inst_name = _install_as(self.owner)
+		frappe.db.set_value(INSTALLATION, inst_name, "enabled", 1, update_modified=False)
+		frappe.db.commit()
+		inst = frappe.get_doc(INSTALLATION, inst_name)
+
+		frappe.set_user(self.owner)
+		try:
+			result = agent_scheduler._launch_audit(inst, trigger="manual", initiating_human=self.owner)
+		finally:
+			frappe.set_user("Administrator")
+		run = result["run"]
+		self.assertEqual(frappe.db.get_value(RUN, run, "initiating_human"), self.owner)
+
+		doc = frappe.get_doc(RUN, run)
+		doc.initiating_human = self.runas
+		with self.assertRaises(frappe.PermissionError):
+			doc.save(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value(RUN, run, "initiating_human"), self.owner)
+
+
+class TestAuthenticatedUserSeam(unittest.TestCase):
+	"""JF-021 — ``impersonate`` must keep the AUTHENTICATED identity recoverable.
+
+	This is the seam the launch validates against: provenance can only be checked
+	server-side if "who is this request really" survives an identity switch.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls.a = _ensure_user("plp-seam-a@example.com")
+		cls.b = _ensure_user("plp-seam-b@example.com")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_authenticated_user_is_the_pre_impersonation_user(self):
+		frappe.set_user(self.a)
+		self.assertEqual(authenticated_user(), self.a)  # nothing impersonating
+		with impersonate(self.b):
+			self.assertEqual(frappe.session.user, self.b)
+			self.assertEqual(authenticated_user(), self.a)
+			with impersonate("Administrator"):
+				# Nested switches never re-anchor the identity: the OUTERMOST wins.
+				self.assertEqual(frappe.session.user, "Administrator")
+				self.assertEqual(authenticated_user(), self.a)
+			self.assertEqual(authenticated_user(), self.a)
+		self.assertEqual(frappe.session.user, self.a)
+		self.assertEqual(authenticated_user(), self.a)
+
+	def test_marker_does_not_leak_when_the_block_raises(self):
+		frappe.set_user(self.a)
+		with self.assertRaises(RuntimeError):
+			with impersonate(self.b):
+				raise RuntimeError("boom")
+		self.assertEqual(frappe.session.user, self.a)
+		# A stale marker would keep answering "a" for every later caller in this
+		# request/worker — including the next user's manual run.
+		frappe.set_user(self.b)
+		self.assertEqual(authenticated_user(), self.b)


### PR DESCRIPTION
## Defect (JF-021, High)

A `Jarvis Agent Run` records three *different* identities: the **row owner** (the
customer the run belongs to), the **run-as user** (the identity every `jarvis__*`
ERP read is permission-bounded to), and `initiating_human` — the human who asked
for the run, stamped immutably at launch (PP-5).

On the manual path the third one was wrong. `run_agent_now` correctly switches the
session to the installation's `run_as_user` before launching, and `_launch_audit`
then stamped `initiating_human = frappe.session.user` — which by that point is the
**run-as user**, not the person who clicked Run now. So whenever the triggerer was
not the run-as user — a System Manager running another owner's install, or any
cross-user run-as mapping — the run permanently attributed itself to the wrong
person. The field is immutable by design, so nothing can correct it afterwards, and
the audit trail says a person asked for a scan they never asked for.

A regression test pinned against the pre-fix code reproduces it exactly:
`initiating_human` came back as the run-as user where the triggerer was a different
System Manager.

## Root cause

Provenance was read from **ambient session state after an identity switch** instead
of being passed explicitly. The launch function had no way to know who the request
was authenticated as, because that fact was overwritten by the impersonation that
has to happen first.

## Fix

* `_launch_audit(inst, trigger, source_apps=None, initiating_human=None)` — the
  identity is now an explicit argument. `run_agent_now` captures the authenticated
  user **before** it impersonates and passes it through; the scheduler passes
  `None` explicitly (a cron run is unattended — scheduled attribution semantics are
  unchanged).
* `_resolve_initiating_human()` validates it server-side, fail-closed:
  * a manual attribution must **equal the authenticated (pre-impersonation) session
    user** — a supplied value can only ever confirm what the server already knows,
    never introduce a third identity;
  * it must be a real **enabled** `User` and never `Guest`;
  * a scheduled run may not carry one at all.

  Validation runs **before any row is inserted**, so a refused launch leaves no
  orphan conversation/run (same discipline as the existing blank-run-as guard).
* Nothing client-reachable can set this: `run_agent_now` takes no such parameter.
* `jarvis/_session.py` gains `authenticated_user()`. `impersonate()` now remembers
  the **outermost** pre-switch identity on `frappe.local` (restored in the same
  `finally` that restores the session, so it never leaks across requests or nested
  switches). That is what makes the validation a genuine server-side check rather
  than a re-read of the state the switch already overwrote.

## Tests

`jarvis/tests/test_platform_launch_provenance.py`:

* **the defect**: triggerer A (System Manager) / owner B / run-as C, end-to-end
  through `run_agent_now` → `initiating_human == A`, and the two identities the fix
  must NOT disturb are asserted unchanged (turn dispatched as C, per-run session
  bound to C, run + conversation owned by B);
* a manual attribution that is not the authenticated triggerer is refused
  (`PermissionError`) with no orphan run/conversation created;
* `Guest` / a non-existent user / a disabled user are refused, not stamped;
* a scheduled launch carrying an `initiating_human` is refused; `None` stays `None`;
* the corrected value is still immutable once stamped (ORM re-save raises, stored
  value unchanged);
* `authenticated_user()` seam: correct inside impersonation, outermost wins when
  nested, restored on exit, and no stale marker when the block raises.

Run against `patterntest.localhost` — 11/11 in this module, plus green:
`test_agent_identity` 7, `test_agents_marketplace` 36, `test_app_learning_agent` 59,
`test_platform_writeback` 30, `test_platform_schema` 17, `test_platform_min_apps` 14,
`test_actions_api` 27, `test_api` 16, `test_chat_api` 5. Negative check: reverting
only the production line makes the new tests fail as described above.

## Known follow-up

Runs created before this fix keep whatever was stamped then (the field is immutable
by design, so there is no backfill). Only historical rows where triggerer != run-as
are affected; new runs are correct.
