### PR TITLE
(For Logesh Review) fix(mobile): JF-016 — per-device, revocable mobile credentials

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -383,6 +383,17 @@ scheduler_events = {
 	],
 }
 
+# ---------------------------------------------------------------------------
+# Per-device mobile credentials (JF-016)
+# ---------------------------------------------------------------------------
+# The Jarvis mobile app authenticates with a REVOCABLE per-device token
+# (`Authorization: token jmd:<token_id>:<secret>`) instead of the user's
+# account-wide Frappe api_key/api_secret. Core's api-key parser declines a
+# three-segment token, so this hook — which Frappe runs right after it — is
+# what resolves the token to a user. Cheap for every other request: one header
+# read plus a prefix test. See jarvis/mobile/device_auth.py.
+auth_hooks = ["jarvis.mobile.device_auth.authenticate_device_token"]
+
 # Python type annotations on whitelisted endpoints
 # ------------------------------------------------
 # Auto-update controller files with type annotations + require all

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -374,6 +374,10 @@ scheduler_events = {
 		# bench's month-to-date per-user + per-model usage rollup to admin. Self-
 		# gating (skips self-hosted / unconfigured / not-onboarded); never raises.
 		"jarvis.chat.usage_push.push_usage_rollup",
+		# JF-016 hygiene: revocation only flips `enabled`, so the mobile-device
+		# table is append-only without this. Deletes DISABLED rows past the
+		# 90-day retention window; live credentials are never touched.
+		"jarvis.mobile.device_auth.prune_revoked_devices",
 	],
 	"weekly": [
 		# Wiki v2 health check: deterministic lint over Active pages

--- a/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.json
+++ b/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.json
@@ -1,0 +1,139 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-26 09:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "device_label",
+  "platform",
+  "enabled",
+  "last_used",
+  "token_id",
+  "secret_hash",
+  "revoked_at",
+  "revoked_by",
+  "revoked_reason"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "reqd": 1,
+   "read_only": 1,
+   "set_only_once": 1,
+   "search_index": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Owner of the paired device. The token authenticates AS this user."
+  },
+  {
+   "fieldname": "device_label",
+   "fieldtype": "Data",
+   "label": "Device",
+   "length": 140,
+   "in_list_view": 1,
+   "description": "Human-readable name the phone reported at pairing (e.g. \"Pixel 8\"). Client-supplied, so display-only - never trusted for any decision."
+  },
+  {
+   "fieldname": "platform",
+   "fieldtype": "Data",
+   "label": "Platform",
+   "length": 40,
+   "in_list_view": 1,
+   "description": "Client-reported platform (ios / android / web / unknown). Display-only."
+  },
+  {
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled",
+   "default": "1",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "0 = revoked. The auth hook refuses a disabled row, so flipping this kills exactly this one device."
+  },
+  {
+   "fieldname": "last_used",
+   "fieldtype": "Datetime",
+   "label": "Last Used",
+   "read_only": 1,
+   "in_list_view": 1,
+   "description": "Stamped by the auth hook at most once per throttle window (see jarvis/mobile/device_auth.py), so it is approximate by design - one write per request would be unacceptable on the hot path."
+  },
+  {
+   "fieldname": "token_id",
+   "fieldtype": "Data",
+   "label": "Token ID",
+   "length": 64,
+   "reqd": 1,
+   "unique": 1,
+   "read_only": 1,
+   "set_only_once": 1,
+   "no_copy": 1,
+   "description": "Public half of the device token (`jmd:<token_id>:<secret>`). Not a secret: it only identifies the row to look up."
+  },
+  {
+   "fieldname": "secret_hash",
+   "fieldtype": "Data",
+   "label": "Secret Hash",
+   "length": 64,
+   "reqd": 1,
+   "read_only": 1,
+   "set_only_once": 1,
+   "no_copy": 1,
+   "hidden": 1,
+   "description": "HMAC-SHA256 of the secret, keyed by token_id. The plaintext secret is returned exactly once, at pairing, and NEVER stored - a database dump yields no usable credential."
+  },
+  {
+   "fieldname": "revoked_at",
+   "fieldtype": "Datetime",
+   "label": "Revoked At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "revoked_by",
+   "fieldtype": "Data",
+   "label": "Revoked By",
+   "length": 140,
+   "read_only": 1,
+   "description": "Session user at revocation time - a Data SNAPSHOT, not a Link, so the audit trail outlives the account."
+  },
+  {
+   "fieldname": "revoked_reason",
+   "fieldtype": "Data",
+   "label": "Revoked Reason",
+   "length": 140,
+   "read_only": 1
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-26 09:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Mobile Device",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "role": "Jarvis User",
+   "if_owner": 1
+  },
+  {
+   "read": 1,
+   "write": 1,
+   "delete": 1,
+   "role": "System Manager"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.py
+++ b/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.py
@@ -1,0 +1,32 @@
+"""Jarvis Mobile Device DocType controller (JF-016).
+
+One row per paired phone. It holds the PUBLIC half of a device credential
+(``token_id``) plus a SHA-256 of ``<token_id>:<secret>`` — the plaintext secret
+is handed to the phone exactly once, at pairing, and never stored, so a
+database dump yields no usable credential.
+
+Rows are written only by ``jarvis.mobile.device_auth`` (mint / revoke); the
+doctype perms are read-if_owner for Jarvis User and full for System Manager,
+so a user can see their own device inventory in Desk but cannot re-enable a
+revoked device by writing the row.
+"""
+
+import frappe
+from frappe.model.document import Document
+
+MAX_LABEL_CHARS = 140
+MAX_PLATFORM_CHARS = 40
+
+
+class JarvisMobileDevice(Document):
+	def validate(self) -> None:
+		if not self.token_id or not self.secret_hash:
+			frappe.throw("A Jarvis Mobile Device needs both a token id and a hashed secret.")
+		# Client-supplied strings: bounded here so a hostile pairing payload
+		# cannot store an oversized label (the columns are 140/40 wide).
+		self.device_label = (self.device_label or "").strip()[:MAX_LABEL_CHARS] or "Mobile device"
+		self.platform = (self.platform or "").strip()[:MAX_PLATFORM_CHARS].lower() or "unknown"
+		if self.enabled:
+			self.revoked_at = None
+			self.revoked_by = None
+			self.revoked_reason = None

--- a/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.py
+++ b/jarvis/jarvis/doctype/jarvis_mobile_device/jarvis_mobile_device.py
@@ -1,14 +1,17 @@
 """Jarvis Mobile Device DocType controller (JF-016).
 
 One row per paired phone. It holds the PUBLIC half of a device credential
-(``token_id``) plus a SHA-256 of ``<token_id>:<secret>`` — the plaintext secret
-is handed to the phone exactly once, at pairing, and never stored, so a
-database dump yields no usable credential.
+(``token_id``) plus ``HMAC-SHA256(key=token_id, msg=secret)`` — keyed, not a
+plain ``sha256(token_id + ":" + secret)``, because concatenation is ambiguous
+across the separator. The plaintext secret is handed to the phone exactly once,
+at pairing, and never stored, so a database dump yields no usable credential.
 
 Rows are written only by ``jarvis.mobile.device_auth`` (mint / revoke); the
 doctype perms are read-if_owner for Jarvis User and full for System Manager,
 so a user can see their own device inventory in Desk but cannot re-enable a
-revoked device by writing the row.
+revoked device by writing the row. Revoked rows are deleted after
+``device_auth.REVOKED_RETENTION_DAYS`` by the daily
+``prune_revoked_devices`` job.
 """
 
 import frappe

--- a/jarvis/mobile/auth.py
+++ b/jarvis/mobile/auth.py
@@ -3,16 +3,20 @@
 Onboarding (issue #224): the phone scans a QR shown in the Jarvis web app to
 learn the *site connection details* (no typing a workspace URL), then signs in
 with email + password once. That login establishes a short-lived cookie session
-purely to call `get_mobile_token`, which returns a durable API key/secret; from
-then on the app authenticates every request (and the realtime socket) with
-`Authorization: token key:secret` — stateless, no idle-timeout. The password is
-never stored; on logout the phone re-signs-in (the site is remembered).
+purely to call `get_mobile_token`, which returns a durable credential; from then
+on the app authenticates every request (and the realtime socket) with
+`Authorization: token <credential>` — stateless, no idle-timeout. The password
+is never stored; on logout the phone re-signs-in (the site is remembered).
 
-`get_mobile_token` is idempotent: if the user already has an api_key/api_secret
-it returns the EXISTING pair (decrypted) and does NOT rotate it, so a user's
-existing API integrations keep working. Keys are only generated when missing.
-This differs from frappe.core.doctype.user.user.generate_keys, which is
-System-Manager gated AND rotates the secret on every call.
+JF-016: that credential is now a PER-DEVICE token (`jmd:<id>:<secret>`, see
+`jarvis/mobile/device_auth.py`), NOT the user's account-wide Frappe
+api_key/api_secret. Each pairing mints its own `Jarvis Mobile Device` row with
+only a HASH of the secret at rest, so a phone can be revoked on its own —
+logout actually revokes something, a lost handset can be killed from any other
+device, and none of it disturbs the user's other API integrations. This module
+no longer reads or writes `User.api_key`/`User.api_secret` at all; installs that
+already hold a global keypair keep working through ordinary Frappe token auth
+(nothing here revokes it), and the app moves onto a device token at next login.
 """
 
 import json
@@ -22,52 +26,123 @@ from io import BytesIO
 from urllib.parse import urlparse
 
 import frappe
+from frappe.utils import cint
+
+from jarvis.mobile import device_auth
 
 # Bumped if the QR payload shape changes so old app builds can reject it cleanly.
 PAIRING_PAYLOAD_VERSION = 1
 
+# Pairing mints a durable credential, so it is throttled per user (a stolen
+# cookie session should not be able to farm an unbounded fleet of tokens, and a
+# looping client should not fill the device inventory). The window is per user
+# rather than per IP so a whole office behind one NAT is not one budget.
+PAIRING_LIMIT = 10
+PAIRING_WINDOW_SECONDS = 15 * 60
 
-@frappe.whitelist(methods=["POST"])
-def get_mobile_token() -> dict:
-	"""Return the logged-in user's durable api_key/api_secret (creating them only
-	if absent — never rotating an existing secret).
 
-	Returns the plaintext secret so the phone can store it. Only ever acts on the
-	session user, never an arbitrary `user` argument. Also returns `site` (the
-	real Frappe site name) so the client targets the realtime namespace correctly
-	when the workspace is reached via a bare IP.
-	"""
+def _require_system_user() -> str:
+	"""Return the session user, or raise.
+
+	PART 4 REVISED, TASK 41: a Website/portal user has no legitimate use for the
+	Jarvis mobile endpoints (PART 1 TASK 6: portal users are a lower-trust
+	population, and Frappe's own generate_keys is System-Manager gated), so a
+	non-Desk user cannot self-mint or manage a durable credential here. Every
+	endpoint in this module acts on the SESSION user only — never on a `user`
+	argument."""
+	from jarvis.permissions import is_system_user
+
 	user = frappe.session.user
 	if not user or user == "Guest":
 		raise frappe.AuthenticationError
-
-	# PART 4 REVISED, TASK 41: a Website/portal user has no legitimate use for the
-	# Jarvis mobile app's token endpoint (PART 1 TASK 6: portal users are a
-	# lower-trust population, and Frappe's own generate_keys is SM-gated). This
-	# stays session-user-only + idempotent, but refuses a non-Desk user
-	# self-minting a durable credential here.
-	from jarvis.permissions import is_system_user
 
 	if not is_system_user(user):
 		frappe.throw(
 			"The Jarvis mobile token is available to Jarvis app (Desk) users only.",
 			frappe.PermissionError,
 		)
+	return user
 
-	doc = frappe.get_doc("User", user)
-	existing_secret = doc.get_password("api_secret", raise_exception=False) if doc.api_key else None
 
-	if doc.api_key and existing_secret:
-		# Reuse — rotating would break the user's existing API integrations.
-		secret = existing_secret
-	else:
-		secret = frappe.generate_hash(length=15)
-		if not doc.api_key:
-			doc.api_key = frappe.generate_hash(length=15)
-		doc.api_secret = secret
-		doc.save(ignore_permissions=True)
+def _pairing_cache_key(user: str):
+	return frappe.cache.make_key(f"jarvis_mobile_pairing:{user}")
 
-	return {"api_key": doc.api_key, "api_secret": secret, "site": frappe.local.site}
+
+def _throttle_pairing(user: str) -> None:
+	"""Reject a pairing storm. Mirrors frappe.rate_limiter's counter shape but
+	keyed by user instead of IP."""
+	key = _pairing_cache_key(user)
+	if not frappe.cache.get(key):
+		frappe.cache.setex(key, PAIRING_WINDOW_SECONDS, 0)
+	if cint(frappe.cache.incrby(key, 1)) > PAIRING_LIMIT:
+		frappe.throw(
+			"Too many pairing attempts. Please try again in a few minutes.",
+			frappe.RateLimitExceededError,
+		)
+
+
+@frappe.whitelist(methods=["POST"])
+def get_mobile_token(device_label: str | None = None, platform: str | None = None) -> dict:
+	"""Mint a NEW per-device credential for the logged-in user.
+
+	Returns the plaintext secret exactly once — it is only ever stored hashed —
+	so re-pairing a phone always produces a fresh token and never resurrects an
+	old one.
+
+	Back-compat with shipped app builds: the response still carries
+	`api_key`/`api_secret`, because those builds join them into
+	`Authorization: token <api_key>:<api_secret>`. `api_key` is
+	`jmd:<token_id>` and `api_secret` is the device secret, so that join
+	reproduces exactly the `jmd:<token_id>:<secret>` device token — an
+	un-updated app upgrades onto a revocable credential with no client change.
+	Newer builds should read `device_token` + `device` instead.
+
+	Also returns `site` (the real Frappe site name) so the client targets the
+	realtime namespace correctly when the workspace is reached via a bare IP.
+	"""
+	user = _require_system_user()
+	_throttle_pairing(user)
+
+	minted = device_auth.mint(user, device_label=device_label, platform=platform)
+	return {
+		"api_key": f"{device_auth.DEVICE_TOKEN_PREFIX}:{minted['token_id']}",
+		"api_secret": minted["secret"],
+		"device_token": minted["token"],
+		"device": minted["token_id"],
+		"device_label": minted["device_label"],
+		"site": frappe.local.site,
+	}
+
+
+@frappe.whitelist()
+def list_mobile_devices() -> list[dict]:
+	"""The session user's paired-device inventory (no secrets, own rows only)."""
+	user = _require_system_user()
+	return device_auth.list_devices(user)
+
+
+@frappe.whitelist(methods=["POST"])
+def revoke_mobile_device(device: str) -> dict:
+	"""Revoke ONE paired device by its token id.
+
+	`device` must belong to the session user; anything else raises
+	PermissionError, so this cannot revoke — or probe for — another account's
+	devices. Revoking the device that is making this very call is the normal
+	logout path: the next request with that token is a 401."""
+	user = _require_system_user()
+	revoked = device_auth.revoke(user, device)
+	return {"revoked": 1 if revoked else 0, "device": device}
+
+
+@frappe.whitelist(methods=["POST"])
+def revoke_all_mobile_devices(keep_current: int = 0) -> dict:
+	"""Revoke every paired device of the session user ("sign out everywhere").
+
+	`keep_current=1` spares the device making the call — only meaningful when
+	the call itself is authenticated by a device token."""
+	user = _require_system_user()
+	keep = device_auth.current_device_token_id() if cint(keep_current) else None
+	return {"revoked": device_auth.revoke_all(user, except_token_id=keep)}
 
 
 def _lan_ip() -> str | None:

--- a/jarvis/mobile/auth.py
+++ b/jarvis/mobile/auth.py
@@ -12,8 +12,9 @@ JF-016: that credential is now a PER-DEVICE token (`jmd:<id>:<secret>`, see
 `jarvis/mobile/device_auth.py`), NOT the user's account-wide Frappe
 api_key/api_secret. Each pairing mints its own `Jarvis Mobile Device` row with
 only a HASH of the secret at rest, so a phone can be revoked on its own —
-logout actually revokes something, a lost handset can be killed from any other
-device, and none of it disturbs the user's other API integrations. This module
+logout actually revokes something, a lost handset can be killed (selectively
+from the web app, or wholesale from any other phone via "sign out everywhere"),
+and none of it disturbs the user's other API integrations. This module
 no longer reads or writes `User.api_key`/`User.api_secret` at all; installs that
 already hold a global keypair keep working through ordinary Frappe token auth
 (nothing here revokes it), and the app moves onto a device token at next login.
@@ -101,6 +102,14 @@ def get_mobile_token(device_label: str | None = None, platform: str | None = Non
 	realtime namespace correctly when the workspace is reached via a bare IP.
 	"""
 	user = _require_system_user()
+	# A device token may NOT mint a sibling. Otherwise a stolen phone breeds
+	# credentials that survive revoking the phone they came from, and "kill the
+	# lost handset" stops meaning anything. Nothing legitimate mints while
+	# holding one: the client's login() clears the stored token before it signs
+	# in (mobile src/api/client.ts, step 0 of `login`), so every real pairing is
+	# authenticated by the password the user just typed.
+	if device_auth.current_device_token_id():
+		frappe.throw("Sign in with your password to pair this device.", frappe.PermissionError)
 	_throttle_pairing(user)
 
 	minted = device_auth.mint(user, device_label=device_label, platform=platform)
@@ -116,7 +125,11 @@ def get_mobile_token(device_label: str | None = None, platform: str | None = Non
 
 @frappe.whitelist()
 def list_mobile_devices() -> list[dict]:
-	"""The session user's paired-device inventory (no secrets, own rows only)."""
+	"""The session user's paired-device inventory (no secrets, own rows only).
+
+	Readable from a device-token session too — the phone's Devices screen is
+	built on it. That grants nothing: a caller holding a device token already
+	has the user's whole API surface, and the inventory carries no secret."""
 	user = _require_system_user()
 	return device_auth.list_devices(user)
 
@@ -128,21 +141,38 @@ def revoke_mobile_device(device: str) -> dict:
 	`device` must belong to the session user; anything else raises
 	PermissionError, so this cannot revoke — or probe for — another account's
 	devices. Revoking the device that is making this very call is the normal
-	logout path: the next request with that token is a 401."""
+	logout path: the next request with that token is a 401.
+
+	A request authenticated BY a device token may revoke ONLY itself. Letting it
+	pick off siblings would restore, one row at a time, exactly the eviction
+	primitive that dropping `keep_current` from `revoke_all_mobile_devices`
+	removes: a stolen phone kills the user's real handset and keeps its own
+	access. Selective remote revocation is a password-session act (the Jarvis
+	web app / Desk); from a phone the answer is `revoke_all_mobile_devices`,
+	which always includes the caller."""
 	user = _require_system_user()
+	current = device_auth.current_device_token_id()
+	if current and device and device != current:
+		frappe.throw(
+			"Sign in with your password on the Jarvis web app to sign out another device. "
+			'From this device, use "Sign out everywhere".',
+			frappe.PermissionError,
+		)
 	revoked = device_auth.revoke(user, device)
 	return {"revoked": 1 if revoked else 0, "device": device}
 
 
 @frappe.whitelist(methods=["POST"])
-def revoke_all_mobile_devices(keep_current: int = 0) -> dict:
+def revoke_all_mobile_devices() -> dict:
 	"""Revoke every paired device of the session user ("sign out everywhere").
 
-	`keep_current=1` spares the device making the call — only meaningful when
-	the call itself is authenticated by a device token."""
+	Always includes the device making the call — there is no "spare this one"
+	option, because that turned this endpoint into a one-request lockout for
+	anyone holding a stolen token. Signing yourself out too is what makes it
+	safe to expose on the phone the user still holds, and it costs them one
+	re-login with a password the thief does not have."""
 	user = _require_system_user()
-	keep = device_auth.current_device_token_id() if cint(keep_current) else None
-	return {"revoked": device_auth.revoke_all(user, except_token_id=keep)}
+	return {"revoked": device_auth.revoke_all(user)}
 
 
 def _lan_ip() -> str | None:

--- a/jarvis/mobile/device_auth.py
+++ b/jarvis/mobile/device_auth.py
@@ -1,0 +1,339 @@
+"""Per-device, revocable mobile credentials (JF-016).
+
+Before this module the phone was handed the user's account-wide Frappe
+``api_key``/``api_secret``: not device-scoped, so logging out revoked nothing,
+revoking it broke every other API integration the user owned, and there was no
+expiry and no device inventory. Pairing now mints a credential that belongs to
+ONE phone.
+
+Token wire format
+-----------------
+``jmd:<token_id>:<secret>`` presented as ``Authorization: token jmd:<id>:<sec>``.
+
+Three colon-separated segments is not cosmetic — it is the integration point.
+``frappe.auth.validate_auth_via_api_keys`` does ``api_key, api_secret =
+auth_token.split(":")``, which raises ``ValueError`` on a three-segment token
+and is swallowed by that function's ``except (AttributeError, TypeError,
+ValueError): pass``. So core's api-key path cleanly declines a device token
+(instead of raising ``AuthenticationError`` for an unknown key, which a
+two-segment format would have done BEFORE any app hook could run) and
+``validate_auth_via_hooks`` then reaches ``authenticate_device_token`` below.
+The prefix also makes a device token unmistakable in a log or a bug report.
+
+Storage
+-------
+Only ``HMAC-SHA256(key=token_id, msg=secret)`` is persisted, on the ``Jarvis
+Mobile Device`` row. The token id is the per-row salt; HMAC rather than
+``sha256(token_id + ":" + secret)`` because plain concatenation is ambiguous
+(``("a", "b:c")`` and ``("a:b", "c")`` would hash identically). The secret is
+192 bits from ``secrets.token_hex``, so one hash round is the right primitive:
+there is no low-entropy input to grind, and a KDF would burn real CPU on every
+authenticated request. Comparison is constant-time.
+
+Realtime
+--------
+Frappe's socket.io middleware forwards the client's ``Authorization`` header to
+``/api/method/frappe.realtime.get_user_info`` — an ordinary HTTP request — so
+the hook below authenticates the realtime handshake with no extra work.
+``frappe.set_user`` leaves ``session.data.user_type`` empty and core already
+falls back to a cached ``User.user_type`` read for exactly that case.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import frappe
+
+DEVICE_DOCTYPE = "Jarvis Mobile Device"
+
+#: Wire prefix; also the reason core's api-key parser declines the token.
+DEVICE_TOKEN_PREFIX = "jmd"
+
+TOKEN_ID_LENGTH = 24  # 96 bits — an identifier, not a secret
+SECRET_LENGTH = 48  # 192 bits from secrets.token_hex
+
+#: ``last_used`` is telemetry for the device inventory, not an audit clock: one
+#: write per authenticated request would be a hot-path disaster, so it is
+#: stamped at most once per window per device.
+LAST_USED_THROTTLE_SECONDS = 300
+
+#: Ceiling on live devices per user. Re-pairing the same phone mints a new row
+#: (the old secret is unrecoverable), so without a cap a user who reinstalls
+#: repeatedly accumulates live credentials forever.
+MAX_DEVICES_PER_USER = 20
+
+#: Frappe rolls the transaction back at the end of a read-only request, so a
+#: ``last_used`` stamp taken during auth on one of these needs its own commit.
+_READ_ONLY_METHODS = ("GET", "HEAD", "OPTIONS")
+
+_AUDIT_LOGGER = "jarvis.mobile_device_audit"
+
+
+# --------------------------------------------------------------------------- #
+# Token format
+# --------------------------------------------------------------------------- #
+def _hash_secret(token_id: str, secret: str) -> str:
+	"""Keyed SHA-256 of the secret, salted with the (unique) token id.
+
+	HMAC, not ``sha256(token_id + ":" + secret)``: concatenation is ambiguous —
+	``("a", "b:c")`` and ``("a:b", "c")`` would collide."""
+	return hmac.new(token_id.encode(), secret.encode(), hashlib.sha256).hexdigest()
+
+
+def format_token(token_id: str, secret: str) -> str:
+	return f"{DEVICE_TOKEN_PREFIX}:{token_id}:{secret}"
+
+
+def parse_token(raw: str | None) -> tuple[str, str] | None:
+	"""Split a device token into ``(token_id, secret)``; ``None`` if the string
+	is not one (an ordinary Frappe ``key:secret`` pair returns ``None``, which
+	is what keeps the two credential kinds from ever crossing paths)."""
+	if not raw:
+		return None
+	parts = raw.strip().split(":")
+	if len(parts) != 3 or parts[0] != DEVICE_TOKEN_PREFIX:
+		return None
+	token_id, secret = parts[1], parts[2]
+	if not token_id or not secret:
+		return None
+	return token_id, secret
+
+
+def is_device_token(raw: str | None) -> bool:
+	return parse_token(raw) is not None
+
+
+def current_device_token_id() -> str | None:
+	"""Token id that authenticated THIS request, if a device token did."""
+	return frappe.local.flags.get("jarvis_mobile_device")
+
+
+# --------------------------------------------------------------------------- #
+# Mint
+# --------------------------------------------------------------------------- #
+def mint(user: str, device_label: str | None = None, platform: str | None = None) -> dict:
+	"""Create a NEW credential for one device and return the plaintext ONCE.
+
+	Every pairing gets its own row + its own secret — nothing is ever reused,
+	so two phones can never hold the same credential and revoking one cannot
+	affect the other."""
+	token_id = frappe.generate_hash(length=TOKEN_ID_LENGTH)
+	secret = frappe.generate_hash(length=SECRET_LENGTH)
+	doc = frappe.get_doc(
+		{
+			"doctype": DEVICE_DOCTYPE,
+			"user": user,
+			"device_label": device_label,
+			"platform": platform,
+			"token_id": token_id,
+			"secret_hash": _hash_secret(token_id, secret),
+			"enabled": 1,
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	_prune(user, keep_token_id=token_id)
+	_audit("mint", user=user, token_id=token_id, device=doc.device_label, platform=doc.platform)
+	return {
+		"name": doc.name,
+		"token_id": token_id,
+		"secret": secret,
+		"token": format_token(token_id, secret),
+		"device_label": doc.device_label,
+		"platform": doc.platform,
+	}
+
+
+def _prune(user: str, keep_token_id: str) -> None:
+	"""Revoke the oldest live devices past ``MAX_DEVICES_PER_USER``."""
+	rows = frappe.get_all(
+		DEVICE_DOCTYPE,
+		filters={"user": user, "enabled": 1},
+		fields=["name", "token_id"],
+		order_by="creation desc, name desc",
+		limit_page_length=0,
+	)
+	for row in rows[MAX_DEVICES_PER_USER:]:
+		if row.token_id == keep_token_id:
+			continue
+		_disable(row.name, "device limit reached")
+		_audit("prune", user=user, token_id=row.token_id)
+
+
+# --------------------------------------------------------------------------- #
+# Authenticate
+# --------------------------------------------------------------------------- #
+def resolve(raw: str | None) -> dict | None:
+	"""Resolve a device token to ``{"user", "token_id", "name"}``.
+
+	Returns ``None`` — never a partially-trusted result — for anything that is
+	not a live token belonging to an enabled user. Fails CLOSED."""
+	parsed = parse_token(raw)
+	if not parsed:
+		return None
+	token_id, secret = parsed
+	row = frappe.db.get_value(
+		DEVICE_DOCTYPE,
+		{"token_id": token_id},
+		["name", "user", "secret_hash", "enabled", "last_used"],
+		as_dict=True,
+	)
+	# Hash unconditionally so an unknown token id and a wrong secret cost the
+	# same, then compare in constant time.
+	presented = _hash_secret(token_id, secret)
+	if not row or not hmac.compare_digest(row.secret_hash or "", presented):
+		return None
+	if not row.enabled:
+		return None
+	if not row.user or not frappe.db.get_value("User", row.user, "enabled"):
+		return None
+	_touch(row.name, row.last_used)
+	return {"user": row.user, "token_id": token_id, "name": row.name}
+
+
+def authenticate_device_token() -> None:
+	"""``auth_hooks`` entry — authenticate ``Authorization: token jmd:<id>:<s>``.
+
+	Runs after core's api-key path declined the token (see the module
+	docstring). On failure it deliberately does nothing: the session stays
+	Guest and ``frappe.auth.validate_auth`` turns a presented-but-unusable
+	Authorization header into a 401 by itself."""
+	if not getattr(frappe.local, "request", None):
+		return
+	header = frappe.get_request_header("Authorization", "") or ""
+	parts = header.split(" ", 1)
+	if len(parts) != 2 or parts[0].lower() != "token":
+		return
+	if not is_device_token(parts[1]):
+		return
+
+	# An already-established cookie session wins, exactly as core's api-key
+	# path does (it only sets the user when the resumed session is Guest).
+	login_manager = getattr(frappe.local, "login_manager", None)
+	if login_manager is not None and login_manager.user not in ("", "Guest"):
+		return
+
+	device = resolve(parts[1])
+	if not device:
+		return
+
+	# frappe.set_user() resets form_dict; core's api-key path restores it and so
+	# must we, or every argument of the request is lost.
+	form_dict = frappe.local.form_dict
+	frappe.set_user(device["user"])
+	frappe.local.form_dict = form_dict
+	frappe.local.flags.jarvis_mobile_device = device["token_id"]
+
+
+def _touch(name: str, last_used) -> None:
+	"""Best-effort throttled ``last_used`` stamp. Never raises into auth."""
+	now = frappe.utils.now_datetime()
+	if last_used:
+		try:
+			if (now - frappe.utils.get_datetime(last_used)).total_seconds() < LAST_USED_THROTTLE_SECONDS:
+				return
+		except Exception:
+			pass
+	try:
+		frappe.db.set_value(DEVICE_DOCTYPE, name, "last_used", now, update_modified=False)
+		request = getattr(frappe.local, "request", None)
+		if request is not None and request.method in _READ_ONLY_METHODS:
+			# Auth runs before the handler, so nothing else is pending yet and
+			# this commit is contained to the one column above.
+			frappe.db.commit()
+	except Exception:
+		frappe.logger("jarvis.mobile").debug(f"last_used stamp failed for {name}", exc_info=True)
+
+
+# --------------------------------------------------------------------------- #
+# Inventory + revocation
+# --------------------------------------------------------------------------- #
+def list_devices(user: str) -> list[dict]:
+	"""The user's device inventory. Never exposes ``secret_hash``."""
+	rows = frappe.get_all(
+		DEVICE_DOCTYPE,
+		filters={"user": user},
+		fields=[
+			"token_id",
+			"device_label",
+			"platform",
+			"enabled",
+			"last_used",
+			"creation",
+			"revoked_at",
+		],
+		order_by="creation desc",
+		limit_page_length=0,
+	)
+	current = current_device_token_id()
+	for row in rows:
+		row["current"] = 1 if current and row["token_id"] == current else 0
+	return rows
+
+
+def revoke(user: str, token_id: str, reason: str = "revoked by user") -> bool:
+	"""Revoke ONE of ``user``'s devices. Returns False if already revoked.
+
+	A row belonging to somebody else is indistinguishable from a row that does
+	not exist — both raise PermissionError, so this can never be used to probe
+	another account's device inventory."""
+	row = (
+		frappe.db.get_value(
+			DEVICE_DOCTYPE, {"token_id": token_id}, ["name", "user", "enabled"], as_dict=True
+		)
+		if token_id
+		else None
+	)
+	if not row or row.user != user:
+		frappe.throw("Unknown device.", frappe.PermissionError)
+	if not row.enabled:
+		return False
+	_disable(row.name, reason)
+	_audit("revoke", user=user, token_id=token_id, reason=reason)
+	return True
+
+
+def revoke_all(user: str, except_token_id: str | None = None, reason: str = "revoked by user") -> int:
+	"""Revoke every live device of ``user`` (optionally sparing one)."""
+	rows = frappe.get_all(
+		DEVICE_DOCTYPE,
+		filters={"user": user, "enabled": 1},
+		fields=["name", "token_id"],
+		limit_page_length=0,
+	)
+	count = 0
+	for row in rows:
+		if except_token_id and row.token_id == except_token_id:
+			continue
+		_disable(row.name, reason)
+		_audit("revoke", user=user, token_id=row.token_id, reason=reason)
+		count += 1
+	return count
+
+
+def _disable(name: str, reason: str) -> None:
+	doc = frappe.get_doc(DEVICE_DOCTYPE, name)
+	doc.enabled = 0
+	doc.revoked_at = frappe.utils.now_datetime()
+	doc.revoked_by = frappe.session.user
+	doc.revoked_reason = (reason or "")[:140]
+	doc.save(ignore_permissions=True)
+
+
+def _audit(action: str, **fields) -> None:
+	"""Structured audit line. Mirrors jarvis/audit.py: a logger rather than a
+	doc insert, so it is transaction-safe and can never raise into the caller.
+	The durable, queryable trail is the row itself (revoked_at / revoked_by /
+	revoked_reason plus the doctype's Version history)."""
+	try:
+		entry = {
+			"ts": frappe.utils.now(),
+			"action": action,
+			"actor": getattr(frappe.session, "user", None),
+			**fields,
+		}
+		frappe.logger(_AUDIT_LOGGER).info(json.dumps(entry, default=str))
+	except Exception:
+		pass

--- a/jarvis/mobile/device_auth.py
+++ b/jarvis/mobile/device_auth.py
@@ -37,6 +37,28 @@ Frappe's socket.io middleware forwards the client's ``Authorization`` header to
 the hook below authenticates the realtime handshake with no extra work.
 ``frappe.set_user`` leaves ``session.data.user_type`` empty and core already
 falls back to a cached ``User.user_type`` read for exactly that case.
+
+auth_hooks ordering (constraint, not a bug)
+-------------------------------------------
+``frappe.get_hooks("auth_hooks")`` iterates ``installed_apps`` order, so any
+app whose own auth hook makes a decision from ``frappe.session.user`` must be
+installed AFTER jarvis or it will see a still-Guest session and act on it
+before the device token has been resolved. The live example is helpdesk's
+``helpdesk.auth.authenticate``, which raises ``PermissionError`` for non-Desk
+users on ``/api/`` paths outside its own namespace when ``block_endpoints`` is
+set in site config — on a site with both apps in the wrong order and that flag
+on, device-token requests would 403 before this hook ran. Ordinary api-key auth
+is immune because core resolves it inside ``validate_auth_via_api_keys``, ahead
+of every hook. No bench today runs that combination; the constraint is recorded
+here because it is invisible from either app on its own.
+
+Who may do what (adversarial P1-6 / P1-7)
+-----------------------------------------
+A request authenticated BY a device token is a *lower-trust* session than a
+password/cookie one: the credential lives on a handset that can be lost. So it
+may not mint a sibling token (``jarvis.mobile.auth.get_mobile_token`` refuses
+it) and it may not revoke another device selectively — only itself, or every
+device at once including itself (see ``revoke_all``).
 """
 
 from __future__ import annotations
@@ -64,6 +86,15 @@ LAST_USED_THROTTLE_SECONDS = 300
 #: (the old secret is unrecoverable), so without a cap a user who reinstalls
 #: repeatedly accumulates live credentials forever.
 MAX_DEVICES_PER_USER = 20
+
+#: Revoked rows are kept this long so "which phone was killed, when, by whom"
+#: is still answerable afterwards, then deleted: an inventory that only ever
+#: grows is its own defect (adversarial P2-12).
+REVOKED_RETENTION_DAYS = 90
+
+#: Ceiling on one scheduler pass, so a large backlog drains over several days
+#: instead of in one long transaction.
+PRUNE_BATCH_LIMIT = 500
 
 #: Frappe rolls the transaction back at the end of a read-only request, so a
 #: ``last_used`` stamp taken during auth on one of these needs its own commit.
@@ -293,22 +324,69 @@ def revoke(user: str, token_id: str, reason: str = "revoked by user") -> bool:
 	return True
 
 
-def revoke_all(user: str, except_token_id: str | None = None, reason: str = "revoked by user") -> int:
-	"""Revoke every live device of ``user`` (optionally sparing one)."""
+def revoke_all(user: str, reason: str = "revoked by user") -> int:
+	"""Revoke EVERY live device of ``user`` — the caller's own included.
+
+	There is deliberately no "spare this one" option. It existed (``keep_current``)
+	and it made "sign out everywhere" a one-request lockout primitive for whoever
+	held a stolen token: evict every legitimate device, keep your own. Nuking your
+	own access alongside everybody else's is acceptable; preserving it is not."""
 	rows = frappe.get_all(
 		DEVICE_DOCTYPE,
 		filters={"user": user, "enabled": 1},
 		fields=["name", "token_id"],
 		limit_page_length=0,
 	)
-	count = 0
 	for row in rows:
-		if except_token_id and row.token_id == except_token_id:
-			continue
 		_disable(row.name, reason)
 		_audit("revoke", user=user, token_id=row.token_id, reason=reason)
-		count += 1
-	return count
+	return len(rows)
+
+
+def prune_revoked_devices() -> int:
+	"""Daily scheduler job — delete revoked rows past the retention window.
+
+	Revocation only flips ``enabled``, so without this the table is append-only:
+	every reinstall, every logout and every ``revoke_all`` leaves a row behind
+	forever. Only DISABLED rows are ever touched, so a live credential can never
+	be deleted out from under a phone by this job. Rows disabled outside this
+	module (a System Manager unticking ``enabled`` in Desk) carry no
+	``revoked_at``, so they fall back to ``modified`` rather than being immortal.
+	"""
+	cutoff = frappe.utils.add_days(frappe.utils.now_datetime(), -REVOKED_RETENTION_DAYS)
+	names = frappe.get_all(
+		DEVICE_DOCTYPE,
+		filters={"enabled": 0, "revoked_at": ["<", cutoff]},
+		pluck="name",
+		order_by="revoked_at asc",
+		limit=PRUNE_BATCH_LIMIT,
+	)
+	if len(names) < PRUNE_BATCH_LIMIT:
+		names += frappe.get_all(
+			DEVICE_DOCTYPE,
+			filters={"enabled": 0, "revoked_at": ["is", "not set"], "modified": ["<", cutoff]},
+			pluck="name",
+			order_by="modified asc",
+			limit=PRUNE_BATCH_LIMIT - len(names),
+		)
+
+	deleted = 0
+	for name in names:
+		try:
+			frappe.delete_doc(
+				DEVICE_DOCTYPE,
+				name,
+				ignore_permissions=True,
+				force=True,
+				delete_permanently=True,
+			)
+			deleted += 1
+		except Exception:
+			frappe.logger("jarvis.mobile").warning(f"could not prune device row {name}", exc_info=True)
+	if deleted:
+		frappe.db.commit()
+		_audit("prune_revoked", deleted=deleted, retention_days=REVOKED_RETENTION_DAYS)
+	return deleted
 
 
 def _disable(name: str, reason: str) -> None:

--- a/jarvis/mobile/device_auth.py
+++ b/jarvis/mobile/device_auth.py
@@ -280,9 +280,7 @@ def revoke(user: str, token_id: str, reason: str = "revoked by user") -> bool:
 	not exist — both raise PermissionError, so this can never be used to probe
 	another account's device inventory."""
 	row = (
-		frappe.db.get_value(
-			DEVICE_DOCTYPE, {"token_id": token_id}, ["name", "user", "enabled"], as_dict=True
-		)
+		frappe.db.get_value(DEVICE_DOCTYPE, {"token_id": token_id}, ["name", "user", "enabled"], as_dict=True)
 		if token_id
 		else None
 	)

--- a/jarvis/tests/test_mobile_device_auth.py
+++ b/jarvis/tests/test_mobile_device_auth.py
@@ -16,7 +16,8 @@ Four things have to hold at once, and each has a test here:
    proves that is not hypothetical).
 3. Revoking one device kills exactly that device, leaving the user's other
    devices AND the untouched global keypair working.
-4. Nothing recoverable is at rest: only a salted SHA-256 of the secret.
+4. Nothing recoverable is at rest: only an HMAC-SHA256 of the secret, keyed by
+   the token id.
 """
 
 from __future__ import annotations
@@ -328,7 +329,11 @@ class TestAuthHook(MobileDeviceBase):
 		# Pre-stamp last_used so the throttled stamp short-circuits and this
 		# read-only request takes no write (and therefore no commit) path.
 		frappe.db.set_value(
-			DEVICE_DOCTYPE, {"token_id": minted["token_id"]}, "last_used", now_datetime(), update_modified=False
+			DEVICE_DOCTYPE,
+			{"token_id": minted["token_id"]},
+			"last_used",
+			now_datetime(),
+			update_modified=False,
 		)
 		with _request(f"token {minted['token']}", method="GET"):
 			device_auth.authenticate_device_token()
@@ -355,7 +360,10 @@ class TestRevocation(MobileDeviceBase):
 		self.assertEqual(device_auth.resolve(other_user["token"])["user"], USER_B)
 
 		row = frappe.db.get_value(
-			DEVICE_DOCTYPE, {"token_id": phone["token_id"]}, ["enabled", "revoked_at", "revoked_by"], as_dict=True
+			DEVICE_DOCTYPE,
+			{"token_id": phone["token_id"]},
+			["enabled", "revoked_at", "revoked_by"],
+			as_dict=True,
 		)
 		self.assertEqual(row.enabled, 0)
 		self.assertIsNotNone(row.revoked_at)

--- a/jarvis/tests/test_mobile_device_auth.py
+++ b/jarvis/tests/test_mobile_device_auth.py
@@ -6,7 +6,7 @@ device-scoped (two phones shared one credential), logout revoked nothing, and
 revoking it to kill a lost handset broke every other API integration the user
 owned.
 
-Four things have to hold at once, and each has a test here:
+Six things have to hold at once, and each has a test here:
 
 1. Pairing mints a NEW credential per device and NEVER discloses the global
    api_secret.
@@ -18,6 +18,11 @@ Four things have to hold at once, and each has a test here:
    devices AND the untouched global keypair working.
 4. Nothing recoverable is at rest: only an HMAC-SHA256 of the secret, keyed by
    the token id.
+5. A session authenticated BY a device token is lower-trust than a password
+   session: it cannot mint a sibling token, and it cannot revoke a sibling
+   device selectively — only itself, or everything including itself. Both
+   holes were live and both let a stolen phone outlive its own revocation.
+6. Revoked rows do not accumulate forever.
 """
 
 from __future__ import annotations
@@ -405,7 +410,7 @@ class TestRevocation(MobileDeviceBase):
 		with _as(USER_A), self.assertRaises(frappe.PermissionError):
 			mobile_auth.revoke_mobile_device(frappe.generate_hash(length=24))
 
-	def test_revoke_all(self):
+	def test_revoke_all_from_a_password_session_kills_every_device(self):
 		tokens = [device_auth.mint(USER_A, f"phone-{i}") for i in range(3)]
 		survivor = device_auth.mint(USER_B, "Other user")
 
@@ -416,13 +421,16 @@ class TestRevocation(MobileDeviceBase):
 			self.assertIsNone(device_auth.resolve(token["token"]))
 		self.assertEqual(device_auth.resolve(survivor["token"])["user"], USER_B)
 
-	def test_revoke_all_can_spare_the_calling_device(self):
-		keep = device_auth.mint(USER_A, "This phone")
+	def test_revoke_all_from_a_device_session_takes_the_caller_with_it(self):
+		"""Sign-out-everywhere from a phone must NOT spare the phone it was called
+		from. `keep_current` used to do exactly that, which made one POST with a
+		stolen token evict every legitimate device and preserve the thief's."""
+		caller = device_auth.mint(USER_A, "This phone")
 		other = device_auth.mint(USER_A, "Old phone")
-		with _request(f"token {keep['token']}"):
+		with _request(f"token {caller['token']}"):
 			device_auth.authenticate_device_token()
-			self.assertEqual(mobile_auth.revoke_all_mobile_devices(keep_current=1)["revoked"], 1)
-		self.assertEqual(device_auth.resolve(keep["token"])["user"], USER_A)
+			self.assertEqual(mobile_auth.revoke_all_mobile_devices()["revoked"], 2)
+		self.assertIsNone(device_auth.resolve(caller["token"]), "the calling device must be revoked too")
 		self.assertIsNone(device_auth.resolve(other["token"]))
 
 	def test_inventory_lists_only_own_devices_and_no_secret(self):
@@ -436,7 +444,128 @@ class TestRevocation(MobileDeviceBase):
 
 
 # --------------------------------------------------------------------------- #
-# 5. Storage + last_used
+# 5. A device-token session is lower-trust than a password session
+# --------------------------------------------------------------------------- #
+class TestDeviceSessionTrustBoundary(MobileDeviceBase):
+	"""A device token lives on a handset that can be lost, so it may not do the
+	two things that would let a stolen phone outlive its own revocation: mint a
+	sibling credential, or pick another device off while sparing itself."""
+
+	def test_a_device_token_cannot_mint_a_sibling(self):
+		"""Nothing legitimate hits this path: the mobile client's `login()`
+		clears the stored token before it signs in (src/api/client.ts, step 0 of
+		`login`), so every real pairing is authenticated by the password just
+		typed. Without the guard, a stolen token mints siblings that survive
+		revoking the phone they came from."""
+		stolen = device_auth.mint(USER_A, "Stolen phone")
+		with _request(f"token {stolen['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, USER_A)
+			with self.assertRaises(frappe.PermissionError):
+				mobile_auth.get_mobile_token(device_label="Sibling")
+		self.assertEqual(
+			frappe.db.count(DEVICE_DOCTYPE, {"user": USER_A, "enabled": 1}),
+			1,
+			"no sibling row may be created",
+		)
+
+	def test_a_password_session_still_pairs(self):
+		"""The negative control for the guard above: pairing itself is untouched
+		when the session is not a device-token one."""
+		with _as(USER_A):
+			minted = mobile_auth.get_mobile_token(device_label="New phone")
+		self.assertEqual(device_auth.resolve(minted["device_token"])["user"], USER_A)
+
+	def test_a_device_token_cannot_revoke_a_sibling(self):
+		"""The retail version of the eviction attack: without this, a thief
+		loops revoke-one over the inventory and keeps their own access — exactly
+		what dropping `keep_current` from revoke-all was meant to prevent."""
+		stolen = device_auth.mint(USER_A, "Stolen phone")
+		victim = device_auth.mint(USER_A, "Real phone")
+		with _request(f"token {stolen['token']}"):
+			device_auth.authenticate_device_token()
+			with self.assertRaises(frappe.PermissionError):
+				mobile_auth.revoke_mobile_device(victim["token_id"])
+		self.assertEqual(device_auth.resolve(victim["token"])["user"], USER_A)
+		self.assertEqual(device_auth.resolve(stolen["token"])["user"], USER_A)
+
+	def test_a_device_token_may_revoke_itself(self):
+		"""The ordinary sign-out path — the app revokes its own credential."""
+		phone = device_auth.mint(USER_A, "This phone")
+		other = device_auth.mint(USER_A, "Other phone")
+		with _request(f"token {phone['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(mobile_auth.revoke_mobile_device(phone["token_id"])["revoked"], 1)
+		self.assertIsNone(device_auth.resolve(phone["token"]))
+		self.assertEqual(device_auth.resolve(other["token"])["user"], USER_A)
+
+	def test_a_password_session_may_revoke_any_own_device(self):
+		"""Selective remote revocation stays possible — from the web app / Desk,
+		where the session is authenticated by the password a thief lacks."""
+		lost = device_auth.mint(USER_A, "Lost phone")
+		kept = device_auth.mint(USER_A, "Desk browser")
+		with _as(USER_A):
+			self.assertEqual(mobile_auth.revoke_mobile_device(lost["token_id"])["revoked"], 1)
+		self.assertIsNone(device_auth.resolve(lost["token"]))
+		self.assertEqual(device_auth.resolve(kept["token"])["user"], USER_A)
+
+	def test_inventory_is_readable_from_a_device_session_and_marks_the_caller(self):
+		"""The phone's Devices screen runs on this: it needs to know which row is
+		the handset in the user's hand."""
+		here = device_auth.mint(USER_A, "This phone")
+		device_auth.mint(USER_A, "Other phone")
+		with _request(f"token {here['token']}"):
+			device_auth.authenticate_device_token()
+			rows = mobile_auth.list_mobile_devices()
+		current = [r for r in rows if r["current"]]
+		self.assertEqual(len(rows), 2)
+		self.assertEqual([r["token_id"] for r in current], [here["token_id"]])
+
+
+# --------------------------------------------------------------------------- #
+# 6. Revoked-row hygiene
+# --------------------------------------------------------------------------- #
+class TestRevokedRowPruning(MobileDeviceBase):
+	def _age(self, token_id: str, field: str, days: int) -> str:
+		name = frappe.db.get_value(DEVICE_DOCTYPE, {"token_id": token_id}, "name")
+		frappe.db.set_value(
+			DEVICE_DOCTYPE, name, field, add_to_date(now_datetime(), days=-days), update_modified=False
+		)
+		return name
+
+	def test_old_revoked_rows_are_deleted_and_live_ones_are_not(self):
+		old = device_auth.mint(USER_A, "Ancient phone")
+		recent = device_auth.mint(USER_A, "Yesterday's phone")
+		live = device_auth.mint(USER_A, "Working phone")
+		with _as(USER_A):
+			mobile_auth.revoke_mobile_device(old["token_id"])
+			mobile_auth.revoke_mobile_device(recent["token_id"])
+		self._age(old["token_id"], "revoked_at", device_auth.REVOKED_RETENTION_DAYS + 5)
+		# A live credential is never deleted by the sweep, however old it is.
+		self._age(live["token_id"], "modified", device_auth.REVOKED_RETENTION_DAYS * 4)
+
+		# Not an equality check: the sweep is site-wide, so unrelated garbage
+		# left by another test on this site may be collected in the same pass.
+		self.assertGreaterEqual(device_auth.prune_revoked_devices(), 1)
+
+		self.assertFalse(frappe.db.exists(DEVICE_DOCTYPE, {"token_id": old["token_id"]}))
+		self.assertTrue(frappe.db.exists(DEVICE_DOCTYPE, {"token_id": recent["token_id"]}))
+		self.assertEqual(device_auth.resolve(live["token"])["user"], USER_A)
+
+	def test_rows_disabled_outside_the_module_are_not_immortal(self):
+		"""A System Manager unticking `enabled` in Desk leaves no revoked_at, so
+		the sweep falls back to `modified`."""
+		orphan = device_auth.mint(USER_A, "Disabled in Desk")
+		name = frappe.db.get_value(DEVICE_DOCTYPE, {"token_id": orphan["token_id"]}, "name")
+		frappe.db.set_value(DEVICE_DOCTYPE, name, "enabled", 0, update_modified=False)
+		self._age(orphan["token_id"], "modified", device_auth.REVOKED_RETENTION_DAYS + 5)
+
+		self.assertGreaterEqual(device_auth.prune_revoked_devices(), 1)
+		self.assertFalse(frappe.db.exists(DEVICE_DOCTYPE, name))
+
+
+# --------------------------------------------------------------------------- #
+# 7. Storage + last_used
 # --------------------------------------------------------------------------- #
 class TestStorageAndTelemetry(MobileDeviceBase):
 	def test_secret_is_hashed_at_rest(self):

--- a/jarvis/tests/test_mobile_device_auth.py
+++ b/jarvis/tests/test_mobile_device_auth.py
@@ -1,0 +1,480 @@
+"""JF-016 — per-device, revocable mobile credentials.
+
+The defect these tests pin down: `jarvis.mobile.auth.get_mobile_token` used to
+hand the phone the user's account-wide Frappe api_key/api_secret. It was not
+device-scoped (two phones shared one credential), logout revoked nothing, and
+revoking it to kill a lost handset broke every other API integration the user
+owned.
+
+Four things have to hold at once, and each has a test here:
+
+1. Pairing mints a NEW credential per device and NEVER discloses the global
+   api_secret.
+2. The three-segment `jmd:<id>:<secret>` shape is load-bearing — core's
+   api-key parser must DECLINE it (a two-segment unknown key raises
+   AuthenticationError before any app hook can run; the negative control below
+   proves that is not hypothetical).
+3. Revoking one device kills exactly that device, leaving the user's other
+   devices AND the untouched global keypair working.
+4. Nothing recoverable is at rest: only a salted SHA-256 of the secret.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+from types import SimpleNamespace
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_to_date, get_datetime, now_datetime
+
+from jarvis.mobile import auth as mobile_auth
+from jarvis.mobile import device_auth
+
+DEVICE_DOCTYPE = device_auth.DEVICE_DOCTYPE
+
+USER_A = "jf016-usera@example.com"
+USER_B = "jf016-userb@example.com"
+DISABLED = "jf016-disabled@example.com"
+WEBSITE = "jf016-website@example.com"
+PFX = "jf016"
+
+_MANAGEABLE = {"System Manager", "Jarvis User", "Jarvis Admin", "Jarvis Skill Reviewer"}
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+@contextlib.contextmanager
+def _request(authorization: str | None, method: str = "POST", session_user: str = "Guest"):
+	"""Minimal stand-in for a live request so the auth hook can be exercised.
+
+	`frappe.get_request_header` reads `frappe.local.request.headers`, and the
+	hook mirrors core by consulting `frappe.local.login_manager.user`, so both
+	are what a request has to provide."""
+	sentinel = object()
+	prev_request = getattr(frappe.local, "request", sentinel)
+	prev_login_manager = getattr(frappe.local, "login_manager", sentinel)
+	prev_user = frappe.session.user
+	prev_device = frappe.local.flags.get("jarvis_mobile_device")
+
+	headers = {"Authorization": authorization} if authorization else {}
+	frappe.local.request = SimpleNamespace(method=method, headers=headers)
+	frappe.local.login_manager = SimpleNamespace(user=session_user)
+	frappe.local.flags.jarvis_mobile_device = None
+	frappe.set_user(session_user)
+	try:
+		yield
+	finally:
+		frappe.set_user(prev_user)
+		frappe.local.flags.jarvis_mobile_device = prev_device
+		_restore(frappe.local, "request", prev_request, sentinel)
+		_restore(frappe.local, "login_manager", prev_login_manager, sentinel)
+
+
+def _restore(target, attr: str, value, sentinel) -> None:
+	"""Put an attribute back exactly as it was — ABSENT if it was absent, since
+	a leftover None would make `hasattr(frappe.local, "login_manager")` lie."""
+	if value is sentinel:
+		with contextlib.suppress(AttributeError):
+			delattr(target, attr)
+	else:
+		setattr(target, attr, value)
+
+
+def _ensure_user(email: str, roles: list[str], user_type: str = "System User", enabled: int = 1) -> str:
+	from jarvis.permissions import ensure_jarvis_user_role
+
+	ensure_jarvis_user_role()
+	if not frappe.db.exists("User", email):
+		doc = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": PFX,
+				"send_welcome_email": 0,
+				"enabled": 1,
+				"user_type": user_type,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+	frappe.db.set_value("User", email, {"user_type": user_type, "enabled": 1})
+	desired = set(roles)
+	current = set(frappe.get_roles(email))
+	doc = frappe.get_doc("User", email)
+	if desired - current:
+		doc.add_roles(*(desired - current))
+	if (_MANAGEABLE & current) - desired:
+		doc.remove_roles(*((_MANAGEABLE & current) - desired))
+	# `enabled` last: add_roles/remove_roles save the User doc, and a disabled
+	# user cannot be saved without tripping core's validation.
+	frappe.db.set_value("User", email, "enabled", enabled)
+	frappe.clear_cache(user=email)
+	return email
+
+
+class MobileDeviceBase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		_ensure_user(USER_A, ["Jarvis User"])
+		_ensure_user(USER_B, ["Jarvis User"])
+		_ensure_user(DISABLED, ["Jarvis User"], enabled=0)
+		_ensure_user(WEBSITE, [], user_type="Website User")
+
+	def setUp(self):
+		super().setUp()
+		for user in (USER_A, USER_B, DISABLED, WEBSITE):
+			frappe.db.delete(DEVICE_DOCTYPE, {"user": user})
+			frappe.cache.delete(mobile_auth._pairing_cache_key(user))
+		frappe.local.flags.jarvis_mobile_device = None
+
+
+# --------------------------------------------------------------------------- #
+# 1. Pairing mints a per-device credential
+# --------------------------------------------------------------------------- #
+class TestPairingMintsPerDeviceTokens(MobileDeviceBase):
+	def test_each_pairing_issues_a_distinct_token(self):
+		with _as(USER_A):
+			first = mobile_auth.get_mobile_token(device_label="Pixel 8", platform="android")
+			second = mobile_auth.get_mobile_token(device_label="iPad", platform="ios")
+
+		self.assertNotEqual(first["device"], second["device"])
+		self.assertNotEqual(first["api_secret"], second["api_secret"])
+		self.assertNotEqual(first["device_token"], second["device_token"])
+		# Both are live, and both authenticate as the same user.
+		self.assertEqual(device_auth.resolve(first["device_token"])["user"], USER_A)
+		self.assertEqual(device_auth.resolve(second["device_token"])["user"], USER_A)
+		self.assertEqual(
+			frappe.db.count(DEVICE_DOCTYPE, {"user": USER_A, "enabled": 1}),
+			2,
+			"each pairing must create its own device row",
+		)
+
+	def test_legacy_api_key_secret_pair_joins_into_the_device_token(self):
+		"""Shipped app builds send `token <api_key>:<api_secret>` — that join
+		has to reproduce the device token exactly, or an un-updated app breaks
+		on upgrade."""
+		with _as(USER_A):
+			minted = mobile_auth.get_mobile_token(device_label="Old build")
+		joined = f"{minted['api_key']}:{minted['api_secret']}"
+		self.assertEqual(joined, minted["device_token"])
+		self.assertTrue(joined.startswith(f"{device_auth.DEVICE_TOKEN_PREFIX}:"))
+		self.assertEqual(device_auth.resolve(joined)["user"], USER_A)
+
+	def test_response_never_carries_the_global_api_secret(self):
+		global_secret = frappe.generate_hash(length=15)
+		user = frappe.get_doc("User", USER_A)
+		user.api_key = frappe.generate_hash(length=15)
+		user.api_secret = global_secret
+		user.save(ignore_permissions=True)
+
+		with _as(USER_A):
+			minted = mobile_auth.get_mobile_token(device_label="Phone")
+
+		self.assertNotEqual(minted["api_secret"], global_secret)
+		self.assertNotIn(global_secret, minted["device_token"])
+		# ...and the global pair is left exactly as it was (rotating it would
+		# break the user's other API integrations).
+		from frappe.utils.password import get_decrypted_password
+
+		self.assertEqual(
+			get_decrypted_password("User", USER_A, "api_secret", raise_exception=False),
+			global_secret,
+		)
+		self.assertEqual(frappe.db.get_value("User", USER_A, "api_key"), user.api_key)
+
+	def test_device_label_and_platform_are_bounded(self):
+		with _as(USER_A):
+			minted = mobile_auth.get_mobile_token(device_label="x" * 500, platform="ANDROID" * 40)
+		row = frappe.db.get_value(
+			DEVICE_DOCTYPE, {"token_id": minted["device"]}, ["device_label", "platform"], as_dict=True
+		)
+		self.assertLessEqual(len(row.device_label), 140)
+		self.assertLessEqual(len(row.platform), 40)
+		self.assertEqual(row.platform, row.platform.lower())
+
+	def test_website_user_cannot_pair(self):
+		with _as(WEBSITE), self.assertRaises(frappe.PermissionError):
+			mobile_auth.get_mobile_token(device_label="Portal phone")
+
+	def test_guest_cannot_pair(self):
+		with _as("Guest"), self.assertRaises(frappe.AuthenticationError):
+			mobile_auth.get_mobile_token()
+
+	def test_pairing_is_rate_limited_per_user(self):
+		# A throwaway identity so the counter is clean regardless of what else
+		# ran on this site in the last window.
+		who = f"jf016-throttle-{frappe.generate_hash(length=8)}@example.com"
+		frappe.cache.delete(mobile_auth._pairing_cache_key(who))
+		try:
+			for _ in range(mobile_auth.PAIRING_LIMIT):
+				mobile_auth._throttle_pairing(who)
+			with self.assertRaises(frappe.RateLimitExceededError):
+				mobile_auth._throttle_pairing(who)
+		finally:
+			frappe.cache.delete(mobile_auth._pairing_cache_key(who))
+
+	def test_device_limit_prunes_the_oldest_live_device(self):
+		minted = [device_auth.mint(USER_A, f"phone-{i}") for i in range(device_auth.MAX_DEVICES_PER_USER + 2)]
+		live = frappe.db.count(DEVICE_DOCTYPE, {"user": USER_A, "enabled": 1})
+		self.assertEqual(live, device_auth.MAX_DEVICES_PER_USER)
+		self.assertIsNone(device_auth.resolve(minted[0]["token"]), "oldest device should be pruned")
+		self.assertIsNotNone(device_auth.resolve(minted[-1]["token"]), "newest device must survive")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Token shape: core's api-key parser must decline it
+# --------------------------------------------------------------------------- #
+class TestTokenShape(MobileDeviceBase):
+	def test_core_api_key_path_declines_a_device_token(self):
+		from frappe.auth import validate_auth_via_api_keys
+
+		minted = device_auth.mint(USER_A, "Phone")
+		with _request(f"token {minted['token']}"):
+			# Must NOT raise: three segments trip the ValueError that core
+			# swallows, so the request survives to reach the auth hooks.
+			validate_auth_via_api_keys(["token", minted["token"]])
+			self.assertEqual(frappe.session.user, "Guest")
+
+	def test_two_segment_unknown_key_still_raises_in_core(self):
+		"""Negative control for the shape decision: had the device token been a
+		plain `key:secret`, core would 401 it before any app hook ran."""
+		from frappe.auth import validate_auth_via_api_keys
+
+		with _request("token deadbeef:cafebabe"), self.assertRaises(frappe.AuthenticationError):
+			validate_auth_via_api_keys(["token", "deadbeef:cafebabe"])
+
+	def test_parse_token_rejects_a_frappe_keypair(self):
+		self.assertIsNone(device_auth.parse_token("abc123:def456"))
+		self.assertIsNone(device_auth.parse_token("jmd:onlyid"))
+		self.assertIsNone(device_auth.parse_token("other:id:secret"))
+		self.assertIsNone(device_auth.parse_token("jmd::secret"))
+		self.assertIsNone(device_auth.parse_token(""))
+		self.assertIsNone(device_auth.parse_token(None))
+		self.assertEqual(device_auth.parse_token("jmd:id:secret"), ("id", "secret"))
+
+
+# --------------------------------------------------------------------------- #
+# 3. The auth hook
+# --------------------------------------------------------------------------- #
+class TestAuthHook(MobileDeviceBase):
+	def test_valid_token_authenticates_as_the_user(self):
+		minted = device_auth.mint(USER_A, "Phone")
+		with _request(f"token {minted['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, USER_A)
+			self.assertEqual(device_auth.current_device_token_id(), minted["token_id"])
+
+	def test_tampered_secret_fails_closed(self):
+		minted = device_auth.mint(USER_A, "Phone")
+		forged = device_auth.format_token(minted["token_id"], frappe.generate_hash(length=48))
+		with _request(f"token {forged}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, "Guest")
+
+	def test_unknown_token_id_fails_closed(self):
+		with _request(f"token jmd:{frappe.generate_hash(length=24)}:{frappe.generate_hash(length=48)}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, "Guest")
+
+	def test_non_token_authorization_is_left_alone(self):
+		minted = device_auth.mint(USER_A, "Phone")
+		with _request(f"Bearer {minted['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, "Guest")
+
+	def test_established_cookie_session_wins(self):
+		"""Mirrors core's api-key path, which only sets the user when the
+		resumed session is still Guest."""
+		minted = device_auth.mint(USER_A, "Phone")
+		with _request(f"token {minted['token']}", session_user=USER_B):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, USER_B)
+			self.assertIsNone(device_auth.current_device_token_id())
+
+	def test_form_dict_survives_authentication(self):
+		"""frappe.set_user() wipes form_dict; losing it would drop every
+		argument of the request."""
+		minted = device_auth.mint(USER_A, "Phone")
+		with _request(f"token {minted['token']}"):
+			frappe.local.form_dict = frappe._dict({"cmd": "some.method", "conversation": "abc"})
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.local.form_dict.get("conversation"), "abc")
+
+	def test_disabled_user_token_is_refused(self):
+		minted = device_auth.mint(DISABLED, "Phone")
+		self.assertIsNone(device_auth.resolve(minted["token"]))
+		with _request(f"token {minted['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, "Guest")
+
+	def test_realtime_handshake_get_authenticates(self):
+		"""The socket.io polling handshake is a GET that Frappe's realtime
+		middleware replays against /api/method/frappe.realtime.get_user_info
+		with the same Authorization header, so the hook has to serve it too.
+		`user_type` is absent from a set_user() session by design — core falls
+		back to a cached User read for exactly this case."""
+		minted = device_auth.mint(USER_A, "Phone")
+		# Pre-stamp last_used so the throttled stamp short-circuits and this
+		# read-only request takes no write (and therefore no commit) path.
+		frappe.db.set_value(
+			DEVICE_DOCTYPE, {"token_id": minted["token_id"]}, "last_used", now_datetime(), update_modified=False
+		)
+		with _request(f"token {minted['token']}", method="GET"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(frappe.session.user, USER_A)
+			self.assertFalse(frappe.session.data.get("user_type"))
+			self.assertEqual(frappe.get_cached_value("User", frappe.session.user, "user_type"), "System User")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Revocation
+# --------------------------------------------------------------------------- #
+class TestRevocation(MobileDeviceBase):
+	def test_revoke_one_kills_exactly_that_device(self):
+		phone = device_auth.mint(USER_A, "Phone")
+		tablet = device_auth.mint(USER_A, "Tablet")
+		other_user = device_auth.mint(USER_B, "Phone")
+
+		with _as(USER_A):
+			result = mobile_auth.revoke_mobile_device(phone["token_id"])
+		self.assertEqual(result["revoked"], 1)
+
+		self.assertIsNone(device_auth.resolve(phone["token"]), "revoked device still authenticates")
+		self.assertEqual(device_auth.resolve(tablet["token"])["user"], USER_A)
+		self.assertEqual(device_auth.resolve(other_user["token"])["user"], USER_B)
+
+		row = frappe.db.get_value(
+			DEVICE_DOCTYPE, {"token_id": phone["token_id"]}, ["enabled", "revoked_at", "revoked_by"], as_dict=True
+		)
+		self.assertEqual(row.enabled, 0)
+		self.assertIsNotNone(row.revoked_at)
+		self.assertEqual(row.revoked_by, USER_A)
+
+	def test_revoking_a_device_leaves_the_global_keypair_working(self):
+		"""The whole point of the fix: killing a lost handset must not break
+		the user's other API integrations."""
+		from frappe.auth import validate_api_key_secret
+
+		global_secret = frappe.generate_hash(length=15)
+		user = frappe.get_doc("User", USER_A)
+		user.api_key = frappe.generate_hash(length=15)
+		user.api_secret = global_secret
+		user.save(ignore_permissions=True)
+
+		phone = device_auth.mint(USER_A, "Phone")
+		with _as(USER_A):
+			mobile_auth.revoke_mobile_device(phone["token_id"])
+
+		self.assertIsNone(device_auth.resolve(phone["token"]))
+		with _request(f"token {user.api_key}:{global_secret}"):
+			validate_api_key_secret(user.api_key, global_secret)
+			self.assertEqual(frappe.session.user, USER_A)
+
+	def test_revoke_is_idempotent(self):
+		phone = device_auth.mint(USER_A, "Phone")
+		with _as(USER_A):
+			self.assertEqual(mobile_auth.revoke_mobile_device(phone["token_id"])["revoked"], 1)
+			self.assertEqual(mobile_auth.revoke_mobile_device(phone["token_id"])["revoked"], 0)
+
+	def test_cannot_revoke_another_users_device(self):
+		victim = device_auth.mint(USER_B, "Victim phone")
+		with _as(USER_A), self.assertRaises(frappe.PermissionError):
+			mobile_auth.revoke_mobile_device(victim["token_id"])
+		self.assertEqual(device_auth.resolve(victim["token"])["user"], USER_B)
+
+	def test_unknown_device_is_indistinguishable_from_someone_elses(self):
+		with _as(USER_A), self.assertRaises(frappe.PermissionError):
+			mobile_auth.revoke_mobile_device(frappe.generate_hash(length=24))
+
+	def test_revoke_all(self):
+		tokens = [device_auth.mint(USER_A, f"phone-{i}") for i in range(3)]
+		survivor = device_auth.mint(USER_B, "Other user")
+
+		with _as(USER_A):
+			self.assertEqual(mobile_auth.revoke_all_mobile_devices()["revoked"], 3)
+
+		for token in tokens:
+			self.assertIsNone(device_auth.resolve(token["token"]))
+		self.assertEqual(device_auth.resolve(survivor["token"])["user"], USER_B)
+
+	def test_revoke_all_can_spare_the_calling_device(self):
+		keep = device_auth.mint(USER_A, "This phone")
+		other = device_auth.mint(USER_A, "Old phone")
+		with _request(f"token {keep['token']}"):
+			device_auth.authenticate_device_token()
+			self.assertEqual(mobile_auth.revoke_all_mobile_devices(keep_current=1)["revoked"], 1)
+		self.assertEqual(device_auth.resolve(keep["token"])["user"], USER_A)
+		self.assertIsNone(device_auth.resolve(other["token"]))
+
+	def test_inventory_lists_only_own_devices_and_no_secret(self):
+		mine = device_auth.mint(USER_A, "Phone")
+		device_auth.mint(USER_B, "Other phone")
+		with _as(USER_A):
+			rows = mobile_auth.list_mobile_devices()
+		self.assertEqual([r["token_id"] for r in rows], [mine["token_id"]])
+		self.assertNotIn("secret_hash", rows[0])
+		self.assertEqual(rows[0]["device_label"], "Phone")
+
+
+# --------------------------------------------------------------------------- #
+# 5. Storage + last_used
+# --------------------------------------------------------------------------- #
+class TestStorageAndTelemetry(MobileDeviceBase):
+	def test_secret_is_hashed_at_rest(self):
+		minted = device_auth.mint(USER_A, "Phone")
+		secret = minted["secret"]
+		row = frappe.db.sql(
+			f"select * from `tab{DEVICE_DOCTYPE}` where token_id = %s",
+			(minted["token_id"],),
+			as_dict=True,
+		)[0]
+		for field, value in row.items():
+			if isinstance(value, str):
+				self.assertNotIn(secret, value, f"plaintext secret leaked into `{field}`")
+		self.assertEqual(
+			row["secret_hash"],
+			hmac.new(minted["token_id"].encode(), secret.encode(), hashlib.sha256).hexdigest(),
+		)
+		# Salt binding is unambiguous: a token id / secret split cannot be
+		# shifted across the boundary to produce the same digest.
+		self.assertNotEqual(device_auth._hash_secret("a", "b:c"), device_auth._hash_secret("a:b", "c"))
+		# Not a Password field either — nothing recoverable in __Auth.
+		self.assertEqual(
+			frappe.db.sql("select count(*) from `__Auth` where doctype = %s", (DEVICE_DOCTYPE,))[0][0],
+			0,
+		)
+
+	def test_last_used_is_throttled(self):
+		minted = device_auth.mint(USER_A, "Phone")
+		name = frappe.db.get_value(DEVICE_DOCTYPE, {"token_id": minted["token_id"]}, "name")
+
+		device_auth.resolve(minted["token"])
+		first = frappe.db.get_value(DEVICE_DOCTYPE, name, "last_used")
+		self.assertIsNotNone(first, "first authentication should stamp last_used")
+
+		device_auth.resolve(minted["token"])
+		self.assertEqual(
+			frappe.db.get_value(DEVICE_DOCTYPE, name, "last_used"),
+			first,
+			"a second authentication inside the window must not write",
+		)
+
+		stale = add_to_date(now_datetime(), seconds=-(device_auth.LAST_USED_THROTTLE_SECONDS + 60))
+		frappe.db.set_value(DEVICE_DOCTYPE, name, "last_used", stale, update_modified=False)
+		device_auth.resolve(minted["token"])
+		self.assertGreater(
+			get_datetime(frappe.db.get_value(DEVICE_DOCTYPE, name, "last_used")),
+			get_datetime(stale),
+			"an authentication past the window must refresh last_used",
+		)


### PR DESCRIPTION
## Defect (JF-016, verified on `develop`)

`jarvis/mobile/auth.py:get_mobile_token` returned the user's **account-wide**
Frappe `api_key`/`api_secret` to the phone.

* Not device-scoped — two handsets share one credential.
* Logging out revoked nothing; the credential outlived the session forever.
* Killing a lost phone meant rotating a secret that **every other API
  integration the user owned** was also using.
* No expiry, no device inventory, no way to see or cut off a single device.

## Root cause

Pairing minted (or reused) the *account* credential instead of a *device*
credential. There was no per-device identity to revoke, so revocation had to be
account-wide by construction.

## The fix

**New `Jarvis Mobile Device` doctype** — user, client-reported label/platform,
public `token_id`, `secret_hash`, `enabled`, `last_used`,
`revoked_at`/`revoked_by`/`revoked_reason`. Only
`HMAC-SHA256(key=token_id, msg=secret)` is at rest (HMAC rather than
`sha256(token_id + ":" + secret)` — plain concatenation is ambiguous, `("a",
"b:c")` and `("a:b", "c")` would collide). The plaintext secret is returned
exactly once, at pairing, and never stored, so a database dump yields no usable
credential. Perms: read-`if_owner` for Jarvis User, full for System Manager;
`in_create` so nothing hand-creates a row in Desk.

**Token wire format `jmd:<token_id>:<secret>`.** Three colon-separated segments
is the integration point, not cosmetics. Core's
`frappe.auth.validate_auth_via_api_keys` does
`api_key, api_secret = auth_token.split(":")`, which raises `ValueError` on a
three-segment token — swallowed by that function's
`except (AttributeError, TypeError, ValueError): pass`. So core cleanly
*declines* the token and `validate_auth_via_hooks` gets to run. A two-segment
`key:secret` format would instead have raised `AuthenticationError` for an
unknown key **before any app hook could run**; there is a negative-control test
for exactly that, so nobody "simplifies" the format later.

**`auth_hooks` entry `jarvis.mobile.device_auth.authenticate_device_token`** —
constant-time compare, refuses a disabled row or a disabled user, restores
`form_dict` across `frappe.set_user` (core's api-key path does the same, and
skipping it drops every argument of the request), yields to an already
established cookie session exactly as core does, and **fails closed**: it simply
does not set a user, and `validate_auth` turns a presented-but-unusable
Authorization header into a 401 on its own. Cost for every non-mobile request is
one header read plus a prefix test.

**Realtime is covered.** Frappe's socket.io middleware forwards the client's
`Authorization` header to `/api/method/frappe.realtime.get_user_info`, an
ordinary HTTP request, so the same hook authenticates the polling handshake.
`frappe.set_user` leaves `session.data.user_type` empty and core already falls
back to a cached `User.user_type` read for precisely that case — covered by a
GET-shaped test.

**`last_used`** is stamped at most once per 5 minutes per device (one write per
authenticated request would be a hot-path disaster), with its own commit on
read-only requests because Frappe rolls those back at request end. Best-effort:
it can never raise into auth.

**Revocation + inventory** — `revoke_mobile_device`, `revoke_all_mobile_devices`
(with `keep_current`), `list_mobile_devices`. Session user only, own rows only;
another account's device is indistinguishable from a nonexistent one, so the
endpoint cannot be used to probe someone else's inventory. Pairing is throttled
per user (per user, not per IP, so an office behind one NAT is not one budget),
live devices per user are capped with the oldest pruned, and every mint, prune
and revocation is audit-logged; the durable trail is the row itself plus its
Version history.

## Back-compat (no forced migration)

* The global `api_key`/`api_secret` is **no longer read or written** here and
  nothing revokes it — existing API consumers are completely untouched, and
  ordinary Frappe token auth keeps working for them.
* The response still carries `api_key`/`api_secret` because shipped app builds
  join them into `Authorization: token <api_key>:<api_secret>`. `api_key` is
  `jmd:<token_id>` and `api_secret` the device secret, so that join reproduces
  the device token exactly — an un-updated app upgrades onto a revocable
  credential with **no client change**. Newer builds read `device_token` +
  `device`.

## Tests

`jarvis/tests/test_mobile_device_auth.py` — 29 tests, all green:

* pairing issues a distinct token per device; the legacy `key:secret` join
  reproduces the device token; the response never carries the global secret and
  leaves the global keypair byte-identical; label/platform bounded; Website user
  and Guest refused; pairing throttled; device cap prunes the oldest.
* core's api-key path declines a device token **and** the two-segment negative
  control still raises in core; `parse_token` rejects a Frappe keypair.
* hook: valid token authenticates; tampered secret, unknown id, non-`token`
  scheme and disabled user all fail closed; cookie session wins; `form_dict`
  survives; GET realtime-handshake shape authenticates.
* revoke-one kills exactly that device and leaves the user's other device, the
  other user's device and the global keypair working; idempotent; cross-user and
  unknown both refused identically; revoke-all; revoke-all sparing the caller;
  inventory is own-rows-only and carries no hash.
* storage: no plaintext anywhere in the row, nothing in `__Auth`, digest matches
  the keyed HMAC, salt binding unambiguous; `last_used` throttling in both
  directions.

Guard suites re-run green against this branch: `test_whitelist_annotations`,
`test_part4_security` (endpoint-gating sweep), `test_role_gates`,
`test_chat_endpoint_gating`.

**This branch adds a DocType, so the review bench needs `bench --site <test
site> migrate` before `run-tests`.**

## Client

`Aerele-RnD/jarvis_mobile` branch `fix/jf016-per-device-mobile-tokens` stores
the device token + id, revokes on logout, and clears a stale credential before
sign-in.


---

# Round 2 — adversarial review remediation (P1-6, P1-7, P2-11, P2-12)

Verdict was **SHIP-WITH-P1S**: the mechanism checks out, but a stolen phone
could outlive its own revocation, so the fix did not deliver the revocation it
promised. Four changes.

## 1. A device token may not mint a sibling (P1-6)

`get_mobile_token` now refuses a request that is itself authenticated by a
device token:

> Sign in with your password to pair this device.

The original justification — "shipped app builds re-mint while holding a
possibly stale token" — was wrong, and the client in the paired PR refutes it:
`mintToken()` is called from exactly one place, `login()`, and `login()` begins
by clearing the stored token. Every real pairing is authenticated by the
password just typed. Without the guard, a stolen token mints siblings that
survive revoking the phone they came from, and "kill the lost handset" means
nothing.

## 2. Sign-out-everywhere always includes the caller (P1-7 scenario B)

`keep_current` is **gone** — from the endpoint and from
`device_auth.revoke_all`. Sparing the caller made one POST an instant-lockout
primitive: evict every legitimate device, keep your own. A caller who nukes
their own access along with everybody else's is acceptable; one who preserves it
is not.

Removing the parameter is back-compatible: `frappe.get_newargs` drops kwargs a
whitelisted function does not declare, so a caller still sending
`keep_current=1` gets the (now correct) full sweep rather than a TypeError.

The endpoint stays callable **from a device-token session** on purpose — that is
what makes "sign out everywhere" a real answer on the phone the user still
holds, which is what the UX review needed for the lost-phone story.

## 3. Revoke-one from a device session may target only itself

Not separately filed, but it falls straight out of #2: with revoke-all fixed and
revoke-one unrestricted, the same eviction just runs one row at a time. So a
request authenticated by a device token may revoke only that device. Selective
remote revocation is a password-session act — the Jarvis web app / Desk, where
the session is authenticated by a password the thief does not have.

`list_mobile_devices` stays open to device sessions: the phone's Devices screen
is built on it, it carries no secret, and a caller holding a device token
already has the user's whole API surface.

P1-7 scenario A (mint 10, wait, mint 10 more, let `_prune` evict the victim) is
closed by #1 — there is no minting from a device token at all.

## 4. Hygiene (P2-11, P2-12)

* **Revoked rows are no longer immortal.** New daily job
  `jarvis.mobile.device_auth.prune_revoked_devices` deletes **disabled** rows
  past `REVOKED_RETENTION_DAYS = 90`, batched at 500 per pass. Rows disabled
  outside the module (a System Manager unticking `enabled` in Desk) carry no
  `revoked_at`, so the sweep falls back to `modified`. A live credential is
  never touched.
* **Docstring truth.** The controller claimed "SHA-256 of `<token_id>:<secret>`"
  where the code is HMAC — corrected, since that file is the first thing a
  reviewer reads.
* **auth_hooks ordering (P2-11)** is now recorded in `device_auth`'s module
  docstring: `get_hooks` iterates `installed_apps` order, so an app whose auth
  hook decides from `frappe.session.user` — helpdesk's `authenticate`, under
  `block_endpoints` — must install after jarvis. Not reachable on any bench
  today; invisible from either app alone, hence written down.

Not addressed, still open by design: **token expiry** (P2-12) — the motivation
lists it as a defect this fix does not close.

## Tests

`jarvis.tests.test_mobile_device_auth` is now **37 tests (was 29), all green**.
New:

* a device token cannot mint a sibling — and no row is created;
* a password session still pairs (the negative control for that guard);
* a device token cannot revoke a sibling — the victim's device survives;
* a device token *can* revoke itself (the ordinary sign-out path);
* a password session can revoke any of its own devices;
* revoke-all from a device session takes the caller with it;
* revoke-all from a password session kills every device;
* the inventory is readable from a device session and marks the caller;
* old revoked rows are deleted, recent ones and live ones are not;
* rows disabled outside the module are not immortal.

Guard suites re-run green against this branch: `test_whitelist_annotations`
(1), `test_part4_security` (22), `test_role_gates` (6),
`test_chat_endpoint_gating` (1). `ruff check` + `ruff format --check` clean on
every touched file; no whole-file reformatting.

## Client

The paired `jarvis_mobile` PR (#7) grows the Devices section and the
signed-out toast that the UX review blocked on. Merge **this** first.
