### PR TITLE
fix(chat): JF-002 — one canonical turn-effect vocabulary

### DIFF
--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -37,21 +37,14 @@ TURN = "Jarvis Chat Turn"
 MSG = "Jarvis Chat Message"
 CONV = "Jarvis Conversation"
 
-# Canonical run order. Effects NOT in a turn's required set claim as "done"
+# Canonical run order = the ONE canonical vocabulary, in its declared order (never a
+# local literal — ``turn_state.EFFECT_NAMES`` is the single authority, and _RUNNERS
+# below must cover it exactly). Effects NOT in a turn's required set claim as "done"
 # (no ledger row) and are skipped — so a single ordered pass covers both the
 # relay:final full set and the errored/cancelled minimal set. terminal_publish
-# (CDX-12) runs FIRST so a lost/failed settlement terminal publish is re-delivered
-# before the slower enrichment effects.
-_EFFECT_ORDER = (
-	"terminal_publish",
-	"rich_outputs",
-	"chat_asks",
-	"macro_advance",
-	"auto_title",
-	"wiki_nudge",
-	"usage",
-	"telemetry_flush",
-)
+# (CDX-12) is FIRST in the canon so a lost/failed settlement terminal publish is
+# re-delivered before the slower enrichment effects.
+_EFFECT_ORDER = ts.EFFECT_NAMES
 
 
 class _UsageRetry(Exception):

--- a/jarvis/chat/settlement.py
+++ b/jarvis/chat/settlement.py
@@ -39,22 +39,17 @@ TURN = "Jarvis Chat Turn"
 MSG = "Jarvis Chat Message"
 CONV = "Jarvis Conversation"
 
-# The owed-enrichment set fixed at settlement (OAR-9). A relay:final success owes
-# the full set; an errored/cancelled terminal owes the macro-advance + telemetry
+# The owed-enrichment set fixed at settlement (OAR-9), expressed over the ONE
+# canonical vocabulary ``turn_state.EFFECT_NAMES`` (never a local literal — the
+# insert seam rejects any name outside it). A relay:final success owes the FULL
+# vocabulary; an errored/cancelled terminal owes the macro-advance + telemetry
 # hooks (there is no rich output/title/usage to enrich, and its reply is already
 # terminal — finalize NEVER un-settles it). BOTH sets owe terminal_publish (CDX-12 /
 # R-5): the idempotent terminal re-publish backstop so a lost settlement terminal
 # (run:end / run:error) is redelivered off the durable row, on success AND error.
-FINAL_EFFECTS = (
-	"terminal_publish",
-	"rich_outputs",
-	"usage",
-	"chat_asks",
-	"macro_advance",
-	"auto_title",
-	"wiki_nudge",
-	"telemetry_flush",
-)
+# If an effect is ever added that a SUCCESS does not owe, this stops being the whole
+# canon and must become an explicit subset of ``ts.EFFECT_NAMES``.
+FINAL_EFFECTS = ts.EFFECT_NAMES
 TERMINAL_EFFECTS = ("terminal_publish", "macro_advance", "telemetry_flush")
 
 

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -87,14 +87,22 @@ LEASE_TTL_S = 30
 # System age-out for a queued turn (SUX-5).
 QUEUED_MAX_AGE_S = 15 * 60
 
-# The full possible enrichment set (D2 §1a + R-4). Settlement inserts the SUBSET
-# a given turn actually owes (its outcome decides the set, OAR-9).
+# THE canonical turn-effect vocabulary (D2 §1a + R-4) — the SINGLE authority every
+# other site derives from: settlement's owed sets (`settlement.FINAL_EFFECTS` /
+# `TERMINAL_EFFECTS`), finalize's run order + runner table, and the Jarvis Turn Effect
+# DocType `effect_name` description. Settlement inserts the SUBSET a given turn
+# actually owes (its outcome decides the set, OAR-9) and `insert_required_effects`
+# rejects any name not listed here, so a typo can never become an effect that is
+# owed but never run. The ORDER is finalize's canonical run order: terminal_publish
+# FIRST (CDX-12 — the terminal re-publish backstop beats the slower enrichment).
 EFFECT_NAMES = (
 	"terminal_publish",
-	"usage",
-	"auto_title",
 	"rich_outputs",
+	"chat_asks",
 	"macro_advance",
+	"auto_title",
+	"wiki_nudge",
+	"usage",
 	"telemetry_flush",
 )
 
@@ -992,14 +1000,33 @@ def _effect_name(run_id: str, effect_name: str) -> str:
 	return f"{run_id}::{effect_name}"
 
 
+def validate_effect_names(effect_names) -> tuple[str, ...]:
+	"""Fail CLOSED on the effect vocabulary: every name must be in ``EFFECT_NAMES``.
+	An unknown name is a caller bug (a typo, or an effect added to settlement without
+	adding it to the canon) whose only silent outcome would be a ledger row no
+	finalize runner ever claims — an effect that is owed forever and never runs, and
+	on the success path a turn that force-dones its way to ``done`` having skipped
+	real enrichment. Raise LOUDLY instead. Returns the validated names as a tuple."""
+	names = tuple(effect_names or ())
+	unknown = [n for n in names if n not in EFFECT_NAMES]
+	if unknown:
+		raise ValueError(
+			f"unknown turn effect(s) {unknown!r}: not in the canonical "
+			f"turn_state.EFFECT_NAMES {list(EFFECT_NAMES)!r}"
+		)
+	return names
+
+
 def insert_required_effects(run_id: str, effect_names) -> int:
 	"""Effect ledger — INSERT the required rows at settlement (OAR-9), idempotently:
 	the composite name PK (``turn::effect_name``) makes a duplicate a no-op. This
-	fixes the owed-enrichment set atomically the instant the slot is released.
-	Returns the count freshly inserted. No commit (runs inside the settlement
-	txn)."""
+	fixes the owed-enrichment set atomically the instant the slot is released. Every
+	name is validated against the canonical ``EFFECT_NAMES`` BEFORE the first insert,
+	so an unknown name raises with NOTHING written (no partially-populated ledger for
+	the finalize_done guard to wait on). Returns the count freshly inserted. No commit
+	(runs inside the settlement txn)."""
 	inserted = 0
-	for name in effect_names or ():
+	for name in validate_effect_names(effect_names):
 		try:
 			doc = frappe.get_doc(
 				{"doctype": EFFECT, "turn": run_id, "effect_name": name, "status": "pending", "attempts": 0}

--- a/jarvis/jarvis/doctype/jarvis_turn_effect/jarvis_turn_effect.json
+++ b/jarvis/jarvis/doctype/jarvis_turn_effect/jarvis_turn_effect.json
@@ -32,7 +32,7 @@
    "length": 64,
    "reqd": 1,
    "in_list_view": 1,
-   "description": "One of auto_title/rich_outputs/macro_advance/telemetry_flush/terminal_publish/usage; part of the UNIQUE (turn, effect_name) enforced via the composite doc name (D2 §1a)."
+   "description": "One of the canonical turn-effect vocabulary jarvis.chat.turn_state.EFFECT_NAMES = [terminal_publish, rich_outputs, chat_asks, macro_advance, auto_title, wiki_nudge, usage, telemetry_flush] (that tuple is the single authority; any other name is rejected at insert by turn_state.insert_required_effects). Part of the UNIQUE (turn, effect_name) enforced via the composite doc name (D2 §1a)."
   },
   {
    "fieldname": "status",

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -17,6 +17,10 @@ Covers the WP-1a acceptance set:
   released, prepare refs dropped); NOT NULL -> adopt (epoch re-stamp).
 * Effect-ledger idempotency + force-done at FINALIZE_MAX_ATTEMPTS=3 + the
   finalize_done all-effects-done guard.
+* JF-002: the ONE canonical effect vocabulary - EFFECT_NAMES is the single
+  authority (settlement's owed sets, finalize's run order + runners and the
+  DocType description all derive from it) and the insert seam fails CLOSED on
+  any name outside it.
 * The canonical lock-order dev assertion (OAR-6).
 * R-14 isolation-level assertion: the settlement CAS and dual-acquisition run
   under BOTH READ COMMITTED and REPEATABLE READ (set per-connection).
@@ -1134,6 +1138,79 @@ class TestEffectLedger(_TurnStateTestCase):
 		self.assertEqual(
 			ts.claim_effect(rid, "not_required")[0], "done", "no such required row => nothing owed"
 		)
+
+
+# --------------------------------------------------------------------------- #
+# JF-002: ONE canonical turn-effect vocabulary. EFFECT_NAMES is the single
+# authority; settlement, finalize and the DocType description all derive from it,
+# and the insert seam fails CLOSED on anything outside it.
+# --------------------------------------------------------------------------- #
+
+
+class TestEffectVocabulary(_TurnStateTestCase):
+	def test_insert_rejects_unknown_effect_and_writes_nothing(self):
+		# An effect name outside the canon is a caller bug: raise LOUDLY rather than
+		# leave a ledger row no finalize runner will ever claim.
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		rid = f"ts_vocab_{frappe.generate_hash(length=6)}"
+		self._mk_turn(conv, rid, seed, "finalizing", version=3)
+		with self.assertRaises(ValueError) as cm:
+			ts.insert_required_effects(rid, ("terminal_publish", "auto_titel"))
+		self.assertIn("auto_titel", str(cm.exception))
+		frappe.db.rollback()
+		# Validation runs BEFORE the first insert: the valid name that preceded the
+		# typo was NOT written (no partially-populated ledger).
+		self.assertEqual(frappe.db.count(EFFECT, {"turn": rid}), 0)
+		# The canonical names still insert normally.
+		self.assertEqual(ts.insert_required_effects(rid, ("terminal_publish",)), 1)
+		frappe.db.commit()
+
+	def test_validate_effect_names_accepts_the_whole_canon(self):
+		self.assertEqual(ts.validate_effect_names(ts.EFFECT_NAMES), tuple(ts.EFFECT_NAMES))
+		self.assertEqual(ts.validate_effect_names(None), ())
+		with self.assertRaises(ValueError):
+			ts.validate_effect_names(["usage", ""])
+
+	def test_settlement_owed_sets_are_drawn_from_the_canon(self):
+		# Adding a ninth effect to settlement without adding it to EFFECT_NAMES fails
+		# HERE (and at insert), instead of silently never running.
+		from jarvis.chat import settlement
+
+		self.assertEqual(tuple(settlement.FINAL_EFFECTS), tuple(ts.EFFECT_NAMES))
+		self.assertTrue(
+			set(settlement.TERMINAL_EFFECTS).issubset(set(ts.EFFECT_NAMES)),
+			f"TERMINAL_EFFECTS {settlement.TERMINAL_EFFECTS} escapes the canon {ts.EFFECT_NAMES}",
+		)
+		self.assertIn("terminal_publish", settlement.TERMINAL_EFFECTS, "CDX-12 backstop is always owed")
+
+	def test_finalize_runs_exactly_the_canon(self):
+		# Every canonical effect has a runner and every runner is canonical — a name
+		# in one and not the other is an effect that is owed but never applied (or a
+		# runner nothing can ever reach).
+		from jarvis.chat import finalize
+
+		self.assertEqual(set(finalize._RUNNERS), set(ts.EFFECT_NAMES))
+		self.assertEqual(tuple(finalize._EFFECT_ORDER), tuple(ts.EFFECT_NAMES))
+		self.assertEqual(ts.EFFECT_NAMES[0], "terminal_publish", "CDX-12: the backstop runs first")
+		self.assertEqual(len(set(ts.EFFECT_NAMES)), len(ts.EFFECT_NAMES), "no duplicate effect name")
+
+	def test_doctype_description_matches_the_canon(self):
+		# The Jarvis Turn Effect description enumerates the vocabulary for whoever
+		# reads the DocType; this pins it to EFFECT_NAMES so it cannot drift again.
+		import json as _json
+		import re
+
+		path = frappe.get_app_path(
+			"jarvis", "jarvis", "doctype", "jarvis_turn_effect", "jarvis_turn_effect.json"
+		)
+		with open(path) as fh:
+			meta = _json.load(fh)
+		desc = next(f for f in meta["fields"] if f["fieldname"] == "effect_name")["description"]
+		match = re.search(r"EFFECT_NAMES = \[([^\]]+)\]", desc)
+		self.assertIsNotNone(match, f"description must enumerate 'EFFECT_NAMES = [...]': {desc!r}")
+		listed = tuple(n.strip() for n in match.group(1).split(","))
+		self.assertEqual(listed, tuple(ts.EFFECT_NAMES))
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Defect (JF-002, verified on develop 2026-07-26)

The turn-effect vocabulary lived in **four** places with no authority relationship:

| site | listed |
|---|---|
| `settlement.FINAL_EFFECTS` | 8 (incl. `chat_asks`, `wiki_nudge`) |
| `finalize._EFFECT_ORDER` / `_RUNNERS` | 8 |
| `turn_state.EFFECT_NAMES` | **6** |
| `Jarvis Turn Effect.effect_name` description | **6** |

Nothing validated an insert against `EFFECT_NAMES`, so the drift was silent. The
failure mode it leaves open: a typo'd effect name becomes a ledger row that no
finalize runner ever claims — owed forever, force-done after 3 cycles, with the
real enrichment silently skipped and the turn still reaching `done`.

## Fix — one authority

`turn_state.EFFECT_NAMES` is now THE canon. Import direction: settlement and
finalize already `from jarvis.chat import turn_state as ts` (turn_state is the
CAS primitive library both sit on and owns the effect ledger), so the canon
belongs there and the two callers derive from it — no new import edges, no cycle.

- **`jarvis/chat/turn_state.py`** — `EFFECT_NAMES` = the full **eight** names, in
  finalize's canonical run order (`terminal_publish` first, CDX-12). New
  `validate_effect_names()`; `insert_required_effects` validates **every** name
  **before the first insert** — unknown name ⇒ loud `ValueError` with *nothing*
  written (fail closed; no half-populated ledger for the `finalize_done`
  all-effects-done guard to wait on).
- **`jarvis/chat/settlement.py`** — local 8-name literal killed:
  `FINAL_EFFECTS = ts.EFFECT_NAMES`. `TERMINAL_EFFECTS` stays the explicit
  errored/cancelled subset (a real subset choice, not a vocabulary).
- **`jarvis/chat/finalize.py`** — local 8-name literal killed:
  `_EFFECT_ORDER = ts.EFFECT_NAMES`.
- **`jarvis_turn_effect.json`** — description enumerates the canon in a
  machine-checkable form and names `EFFECT_NAMES` as the authority.
- No settlement/finalize *logic* touched beyond the literal source.

## Tests

New `TestEffectVocabulary` in `jarvis/tests/test_turn_state.py`:

1. unknown effect ⇒ `ValueError`, **and** the valid name that preceded it is not written;
2. the whole canon validates; `None` ⇒ `()`;
3. settlement's owed sets are drawn from the canon (`FINAL_EFFECTS == EFFECT_NAMES`, `TERMINAL_EFFECTS ⊆ EFFECT_NAMES`);
4. finalize runs *exactly* the canon (`set(_RUNNERS) == set(EFFECT_NAMES)`, order preserved, `terminal_publish` first, no dupes);
5. the DocType description matches `EFFECT_NAMES` name-for-name and in order.

Together (3)+(4) are the anti-drift gate: adding a ninth effect to settlement or
finalize without adding it to the canon fails the suite, and reaching production
it would fail closed at the insert seam.

**Negative control run:** with `TERMINAL_EFFECTS` temporarily given a bogus ninth
name, `test_settlement_owed_sets_are_drawn_from_the_canon` failed as designed
(`... escapes the canon ...`); reverted before commit.

## Verification (run locally against this branch)

Bench executed with `PYTHONPATH=<worktree>` so the branch shadows the editable
install (confirmed via `jarvis.__file__` + the 8-name `EFFECT_NAMES`), site
`patterntest.localhost`:

| module | result |
|---|---|
| `jarvis.tests.test_turn_state` | **57 passed** (incl. the 5 new) |
| `jarvis.tests.test_pump_pipeline` | **37 passed** |
| `jarvis.tests.test_pump` | **57 passed** |
| `jarvis.tests.test_chat_admission` | **11 passed** |
| `jarvis.tests.test_flag_matrix` | **9 passed** |

`ruff check`, `ruff check --select=I` and `ruff format --check` clean on the four
Python files (no whole-file reformat). GitHub Actions CI on this repo is a real
gate and will re-run the sharded suite.

## Risks

- `insert_required_effects` can now raise where it never did. Only reachable via a
  name outside the canon (all call sites pass module constants covered by the new
  tests), and it raises before any write, but it is a behaviour change on the
  settlement path — that is the fail-closed choice the defect calls for.
- `FINAL_EFFECTS` is now *identical* to the canon. If an effect is ever added that a
  `relay:final` success does **not** owe, it must become an explicit subset again —
  flagged in the comment and asserted by test (3).
- DocType description change only; no schema change, no patch, no migration needed
  beyond the normal `bench migrate` doctype sync.