### PR TITLE
fix(voice-notes): accept the native app's capture source (JF-020)

### DIFF
--- a/jarvis/chat/voice_notes_api.py
+++ b/jarvis/chat/voice_notes_api.py
@@ -1,4 +1,5 @@
-"""SPA-facing endpoints for Jarvis Voice Note (Business tab + chat nudge).
+"""Client-facing endpoints for Jarvis Voice Note (Business tab, chat nudge,
+native app).
 
 Owner-scoped CRUD over ``Jarvis Voice Note`` rows plus the Business-tab status
 card and the SM-only "process now" trigger for the daily voice-facts sweep
@@ -6,8 +7,9 @@ card and the SM-only "process now" trigger for the daily voice-facts sweep
 ``jarvis.chat.voice.transcribe_audio``; these endpoints only persist and list
 the resulting transcripts.
 
-All endpoints reject Guest and require a System User (the feature is Desk-SPA
-only, mirroring the ``jarvis.chat.voice`` gate). ``Jarvis Wiki Page`` /
+All endpoints reject Guest and require a System User (mirroring the
+``jarvis.chat.voice`` gate); the native app authenticates the same user with a
+device API token, so it clears the same gate. ``Jarvis Wiki Page`` /
 ``jarvis.chat.wiki`` integration is best-effort lazy-imported: a Conversation
 note whose immediate ingest enqueue fails is picked up by the daily sweep.
 """
@@ -26,7 +28,14 @@ _SETTINGS = "Jarvis Settings"
 
 _EXCERPT_LEN = 300
 _CONTEXT_TYPES = ("Business", "Conversation")
-_SOURCES = ("Business Tab", "Chat Nudge")
+# Capture surfaces allowed to persist a note through this endpoint. MUST stay a
+# subset of the ``source`` Select options on Jarvis Voice Note (frappe rejects an
+# off-list Select value at insert) and MUST keep covering every surface a shipped
+# client sends: "Mobile" is what jarvis_mobile's src/api/endpoints.ts saveVoiceNote
+# posts. Anything not listed here is an Org-scoped capture for the daily sweep
+# (jarvis.learning.voice_facts treats only "Personalise"/question-linked notes as
+# private), so widening this list widens what reaches the shared Org wiki.
+_SOURCES = ("Business Tab", "Chat Nudge", "Mobile")
 _STATUSES = ("New", "Processed", "Archived")
 _MAX_ENTITIES = 20
 _SEARCH_MAX = 140

--- a/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.json
+++ b/jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.json
@@ -97,8 +97,9 @@
       "fieldname": "source",
       "fieldtype": "Select",
       "label": "Source",
-      "options": "Business Tab\nChat Nudge\nPersonalise",
-      "default": "Business Tab"
+      "options": "Business Tab\nChat Nudge\nPersonalise\nMobile",
+      "default": "Business Tab",
+      "description": "Capture surface. This is the union; each endpoint allowlist (voice_notes_api._SOURCES, personalise_api._NOTE_SOURCES) is a subset of it."
     },
     {
       "fieldname": "status",

--- a/jarvis/learning/voice_facts.py
+++ b/jarvis/learning/voice_facts.py
@@ -229,6 +229,18 @@ def _housekeeping() -> None:
 # --------------------------------------------------------------------------- #
 # extraction
 # --------------------------------------------------------------------------- #
+def _is_personalise_note(source: str | None, question: str | None) -> bool:
+	"""The provenance test that decides a note's wiki SCOPE, in ONE place.
+
+	True = the note's facts stay PRIVATE to its owner (User-scope page); False =
+	they are an Org contribution and reach the shared Org page. Only an explicit
+	"Personalise" capture or an answer linked to a Personalise question is
+	private - every other capture surface (Business Tab / Chat Nudge / Mobile) is
+	Org-sourced. Adding a source to ``voice_notes_api._SOURCES`` therefore adds an
+	ORG contributor unless it is also named here."""
+	return (source == "Personalise") or bool(question)
+
+
 def _load_business_batches() -> tuple[list[dict], int]:
 	"""New Business notes grouped per (owner, personalise) into
 	<=MAX_NOTES_PER_BATCH chunks, capped at MAX_BATCHES_PER_RUN batches per run.
@@ -248,8 +260,7 @@ def _load_business_batches() -> tuple[list[dict], int]:
 	)
 	by_group: dict[tuple[str, bool], list] = {}
 	for r in rows:
-		personalise = (r.source == "Personalise") or bool(r.question)
-		by_group.setdefault((r.owner, personalise), []).append(r)
+		by_group.setdefault((r.owner, _is_personalise_note(r.source, r.question)), []).append(r)
 
 	batches: list[dict] = []
 	for key in sorted(by_group, key=lambda k: (k[0], k[1])):
@@ -430,7 +441,7 @@ def _merge_fact(facts: dict, fact: dict, batch: dict) -> None:
 			# Org page (crossing User->Org is an explicit Review promotion,
 			# DESIGN.md 1). Track the two provenance cohorts SEPARATELY (never a
 			# single collapsed flag) so a statement seen by both a Personalise
-			# owner and an Org source (Business Tab / Chat Nudge) fans each
+			# owner and an Org source (Business Tab / Chat Nudge / Mobile) fans each
 			# Personalise owner out to their own User page while only the
 			# Org-sourced contribution lands on the Org page.
 			"personalise_users": {owner} if personalise else set(),
@@ -601,7 +612,7 @@ def _apply_context_facts(context_facts: list[dict]) -> int:
 	to their OWN User-scope page (default_scope="User", target_user=owner -
 	invisible to others), and a fact may fan out to several such owners; a
 	Personalise contribution NEVER lands on the shared Org page. Only Org-sourced
-	contributions (Business Tab / Chat Nudge) keep today's Org behavior exactly
+	contributions (Business Tab / Chat Nudge / Mobile) keep today's Org behavior exactly
 	(the positional 3-arg call, unchanged). A statement seen by both cohorts
 	writes to BOTH targets - privately to each Personalise owner, and to Org for
 	the Org-sourced half."""

--- a/jarvis/tests/test_voice_notes_crud.py
+++ b/jarvis/tests/test_voice_notes_crud.py
@@ -1,7 +1,8 @@
 """Tests for the Skills-page IA v2 voice-note CRUD extensions
 (``jarvis.chat.voice_notes_api``): ``update_voice_note`` (owner-only AND
 status ``New`` only, so the edited transcript re-feeds the daily sweep
-untouched) and the escaped ``search`` param on ``list_my_voice_notes_page``.
+untouched) and the escaped ``search`` param on ``list_my_voice_notes_page``,
+plus the ``source`` contract every shipped client depends on.
 
 Sibling of test_voice_facts.py (same fixture/idiom set: insert-as-owner,
 System User fixtures, ``_as`` set_user wrap, explicit cleanup); the sweep and
@@ -240,3 +241,72 @@ class TestVoiceNotesSearch(VoiceNotesCrudTestCase):
 		with _as(USER_A):
 			page = voice_notes_api.list_my_voice_notes_page(search="x" * 140 + "z")
 		self.assertEqual(page["total"], 1)
+
+
+# --------------------------------------------------------------------------- #
+# save_voice_note `source` contract (JF-020)
+# --------------------------------------------------------------------------- #
+# Every capture surface that ships a client sending an explicit `source`. Each
+# entry names the client file that sends it, so deleting a value from
+# voice_notes_api._SOURCES fails here with the surface it would break instead of
+# silently 417-ing that client in the field:
+#
+#   Business Tab  frontend/src/api/voice.js         (web SPA, Personalise tab)
+#   Chat Nudge    frontend/src/views/ChatView.vue   (post-turn "remember this?")
+#   Mobile        jarvis_mobile src/api/endpoints.ts saveVoiceNote
+#                 (repo Aerele-RnD/jarvis_mobile)
+#
+# The PWA (pwa/src/api.js) deliberately sends NO source and rides the server
+# default, so it is not listed.
+CLIENT_SOURCES = {
+	"Business Tab": "frontend/src/api/voice.js",
+	"Chat Nudge": "frontend/src/views/ChatView.vue",
+	"Mobile": "jarvis_mobile src/api/endpoints.ts (saveVoiceNote)",
+}
+
+
+class TestVoiceNoteSourceContract(VoiceNotesCrudTestCase):
+	def test_every_shipped_client_source_is_accepted(self):
+		for source, client in CLIENT_SOURCES.items():
+			self.assertIn(
+				source,
+				voice_notes_api._SOURCES,
+				msg=f"{source!r} was dropped from voice_notes_api._SOURCES - {client} now 417s",
+			)
+
+	def test_allowlist_is_a_subset_of_the_doctype_options(self):
+		# frappe rejects an off-list Select value at insert, so an allowlist entry
+		# missing from the doctype would pass validation here and then explode on
+		# doc.insert() for the caller.
+		options = frappe.get_meta(NOTE).get_field("source").options.split("\n")
+		for source in voice_notes_api._SOURCES:
+			self.assertIn(source, options)
+
+	def test_each_allowed_source_round_trips(self):
+		# End-to-end through the endpoint (not just the constant): proves frappe's
+		# Select validation accepts the value on a real insert.
+		with _as(USER_A):
+			for source in voice_notes_api._SOURCES:
+				out = voice_notes_api.save_voice_note(
+					transcript=f"note captured from {source}",
+					context_type="Business",
+					source=source,
+				)
+				self.assertEqual(frappe.db.get_value(NOTE, out["name"], "source"), source)
+
+	def test_unknown_source_is_still_rejected(self):
+		# Fail closed: the allowlist grew, it did not become a passthrough.
+		with _as(USER_A), self.assertRaises(frappe.ValidationError):
+			voice_notes_api.save_voice_note(transcript="from nowhere", source="Telepathy")
+		self.assertEqual(frappe.db.count(NOTE, {"owner": USER_A}), 0)
+
+	def test_mobile_capture_is_org_scoped_not_private(self):
+		# Scope invariant: a phone capture is the Business tab on a phone, so its
+		# facts belong on the shared Org wiki exactly like a desktop capture -
+		# only "Personalise"/question-linked notes are private to their owner.
+		from jarvis.learning import voice_facts
+
+		for source in voice_notes_api._SOURCES:
+			self.assertFalse(voice_facts._is_personalise_note(source, None))
+		self.assertTrue(voice_facts._is_personalise_note("Personalise", None))
+		self.assertTrue(voice_facts._is_personalise_note("Mobile", "JPQ-0001"))

--- a/pwa/src/api.js
+++ b/pwa/src/api.js
@@ -65,14 +65,12 @@ const VN = "jarvis.chat.voice_notes_api.";
 export const getBusinessStatus = () => call(VN + "get_business_status");
 export const listVoiceNotes = (start = 0, page_length = 20, search = "") =>
 	call(VN + "list_my_voice_notes_page", { start, page_length, ...(search ? { search } : {}) });
-// `source` is deliberately NOT sent: the server allowlist is exactly
-// ("Business Tab", "Chat Nudge") — voice_notes_api._SOURCES — and anything else
-// is rejected with "Invalid source". Letting the server apply its own default
-// keeps this call correct even if that list changes.
-//
-// (The native app sends source: "Mobile" here, which this backend rejects — so
-// note capture is broken in jarvis_mobile against this bench. Reported, not
-// fixed here: different repo.)
+// `source` is deliberately NOT sent: it is a server allowlist
+// (voice_notes_api._SOURCES) and anything off it is rejected with "Invalid
+// source". Letting the server apply its own default keeps this call correct
+// even as that list changes. (The native app does send source: "Mobile", which
+// the allowlist now carries — see the contract test in
+// jarvis/tests/test_voice_notes_crud.py.)
 export const saveVoiceNote = (transcript, duration_s = 0) =>
 	call(VN + "save_voice_note", { transcript, context_type: "Business", duration_s });
 export const deleteVoiceNote = (name) => call(VN + "delete_voice_note", { name });


### PR DESCRIPTION
## The bug

The native app posts `source: "Mobile"` to `jarvis.chat.voice_notes_api.save_voice_note`
(`jarvis_mobile` → `src/api/endpoints.ts`, `saveVoiceNote`). The server allowlist was
`("Business Tab", "Chat Nudge")`, so **every** Personalise capture from the phone threw
`Invalid source` and no note was ever saved. Typed or dictated, it failed the same way.

## Root cause

Not a validation bug — a contract gap. `_SOURCES` enumerates capture surfaces, and the
mobile surface was never added when the native client shipped. Nothing on the server
noticed, because nothing on the server knew that client existed.

## What changed

| File | Why |
|---|---|
| `jarvis/chat/voice_notes_api.py` | `"Mobile"` added to `_SOURCES`, with a comment stating the two invariants the list has to hold (subset of the doctype Select; superset of what shipped clients send). |
| `jarvis/jarvis/doctype/jarvis_voice_note/jarvis_voice_note.json` | `source` Select gains `Mobile`. **Required**: frappe rejects an off-list Select value at `insert()`, so the allowlist alone would have moved the failure from the endpoint to the doc save. |
| `jarvis/learning/voice_facts.py` | The sweep's provenance test (`source == "Personalise" or question`) extracted into `_is_personalise_note`, so the wiki-scope rule is one named, testable thing instead of an inline expression. No behaviour change. |
| `jarvis/tests/test_voice_notes_crud.py` | New `TestVoiceNoteSourceContract`. |
| `pwa/src/api.js` | Comment update — it documented this exact breakage as known-and-unfixed. |

## Scope invariant (the thing worth checking)

`"Mobile"` is **Org-sourced**, exactly like a Business Tab capture: a phone capture is
the Business tab on a phone. Only `"Personalise"` / question-linked notes stay private to
their owner and fork to a User-scope wiki page. A test asserts this directly, so a future
source added to `_SOURCES` cannot silently change where a user's facts land.

`personalise_api._NOTE_SOURCES` was deliberately **not** widened — no client posts
`Mobile` there, and an allowlist entry with no caller is dead surface.

## The contract test

`TestVoiceNoteSourceContract` enumerates every source a shipped client sends and names
the client file for each. Deleting one fails with the surface it would break, rather than
417-ing that client in the field — which is precisely how this bug survived. It also
asserts the allowlist is a subset of the doctype options, round-trips every allowed source
through the real endpoint, and checks an unknown source is still rejected (the list grew,
it did not become a passthrough).

## Deploy note

**Requires `bench migrate`** — the Select options change. Without it, `save_voice_note`
passes its own check and then fails inside `doc.insert()`.

## Tests

Run against this branch on `patterntest.localhost` (bench shadowed with
`PYTHONPATH=<worktree>`, verified via `jarvis.__file__`), after reloading the doctype:

- `jarvis.tests.test_voice_notes_crud` — 18 passed (5 new)
- `jarvis.tests.test_voice_facts` — 22 passed
- `jarvis.tests.test_personalise_pipeline` — 38 passed
- `jarvis.tests.test_personalise_api` — 84 passed
- `jarvis.tests.test_wiki` — 26 passed
- `jarvis.tests.test_review_api_rework` — 25 passed
- `jarvis.tests.test_personalise_doctypes` — 46/47; the one failure
  (`test_app_roles_are_not_marked_custom`: `Jarvis User` has `is_custom=1`) is **pre-existing
  site state** — it fails identically on unmodified `develop` on the same site.

Also: `ruff check` + `ruff format --check` clean on the touched files, `prettier@2.7.1 --check`
clean on `pwa/src/api.js`, JSON valid.

## Client side

`jarvis_mobile` already sends the exact string `"Mobile"` — no client change needed. A
comment pinning it to this allowlist goes in with
Aerele-RnD/jarvis_mobile#`fix/jf019-jf020-native-contract-fixes`.