### PR TITLE
Fix: PWA + Desk widget had no pump fence — a stale delta could rewind the reply, a stale terminal could tear down a live turn (JF-018)

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -480,7 +480,7 @@ import { isDarkNow, watchTheme } from "./desk_theme.mjs";
 import { renderReply } from "./panel_markdown.mjs";
 import { greetingLine, suggestionsFor } from "./panel_welcome.mjs";
 import { classifyReadiness, degradedMessage } from "./panel_readiness.mjs";
-import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
+import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
 import { ONBOARDING_URL } from "./config.mjs";
 import {
 	listConversations,
@@ -660,7 +660,11 @@ async function load() {
 function startNewChat() {
 	convId.value = "";
 	messages.value = [];
-	stream.value = emptyStream();
+	// Keep the fence watermarks: the panel can rebind to the SAME conversation
+	// (list[0]) on reopen, and a wiped fence would readmit a superseded pump's
+	// straggler — the dead-banner resurrection the fence exists to prevent.
+	// New runs get fresh entries; old entries are three ints per run_id.
+	stream.value = { ...emptyStream(), fence: stream.value.fence };
 	loadError.value = "";
 	draft.value = "";
 	nextTick(() => textareaEl.value?.focus());
@@ -843,9 +847,13 @@ function onRealtime(payload) {
 	const conv = payload?.conversation_id || payload?.conversation;
 	if (!conv || conv !== convId.value) return;
 
-	const next = applyEvent(stream.value, payload);
+	const { state: next, admitted } = applyEventEx(stream.value, payload);
 
-	stopPolling();
+	// Only an ADMITTED frame proves the winning pump's stream is reaching us.
+	// A fenced-out straggler must not stand the HTTP fallback down: after a
+	// handoff, stale frames can be the ONLY thing this socket ever sees, and
+	// polling is then the sole path to the finished reply.
+	if (admitted) stopPolling();
 	if (next.reload) {
 		// Clear the flag before reloading so a second frame cannot double-fetch.
 		stream.value = { ...next, reload: false, error: "" };

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -43,6 +43,14 @@ export function visibleMessages(messages) {
 // Returns a NEW state; never mutates the input. The caller assigns the result
 // to a Vue ref, so structural sharing is not worth the aliasing risk.
 export function applyEvent(state, payload) {
+  return applyEventEx(state, payload).state;
+}
+
+// Like applyEvent, but also says whether the fence ADMITTED the frame. The
+// widget's HTTP-polling fallback must only stand down for an admitted frame:
+// a stream of nothing but fenced-out stragglers proves a superseded pump is
+// still talking, not that the winning pump's frames are arriving.
+export function applyEventEx(state, payload) {
   const p = payload || {};
   const s = {
     live: state.live ? { ...state.live } : null,
@@ -59,8 +67,14 @@ export function applyEvent(state, payload) {
   // reply, and a stale run:end/run:error re-closes (or re-errors) a turn that has
   // already moved on. Nothing user-visible is lost: the terminal path reloads the
   // durable conversation over HTTP, which is what the panel actually renders.
-  if (!admitEvent(s.fence, p)) return s;
+  if (!admitEvent(s.fence, p)) return { state: s, admitted: false };
 
+  return { state: applyAdmitted(s, p), admitted: true };
+}
+
+// The per-kind projection, applied only AFTER the fence admitted the frame.
+// `s` is already a safe copy the caller owns.
+function applyAdmitted(s, p) {
   switch (p.kind) {
     case "run:start":
       s.busy = false;

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -36,7 +36,7 @@ export function visibleMessages(messages) {
       m &&
       (m.role === "user" || m.role === "assistant") &&
       typeof m.content === "string" &&
-      m.content.trim() !== ""
+      m.content.trim() !== "",
   );
 }
 

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -36,7 +36,7 @@ export function visibleMessages(messages) {
       m &&
       (m.role === "user" || m.role === "assistant") &&
       typeof m.content === "string" &&
-      m.content.trim() !== "",
+      m.content.trim() !== ""
   );
 }
 

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.mjs
@@ -4,8 +4,20 @@
 //
 // Reference implementation: pwa/src/views/ChatView.vue (onEvent).
 
+import { admitEvent } from "../../shared/pump_fence.mjs";
+
+// `fence` is the Relay-Pump epoch/seq watermark, carried IN the reducer state so
+// this stays a pure function of (state, frame) — Panel.vue holds one state object
+// and never has to know the fence exists.
 export function emptyStream() {
-  return { live: null, busy: false, error: "", pending: [], reload: false };
+  return {
+    live: null,
+    busy: false,
+    error: "",
+    pending: [],
+    reload: false,
+    fence: {},
+  };
 }
 
 // A conversation's message list is not just user/assistant prose: `tool` rows
@@ -38,7 +50,16 @@ export function applyEvent(state, payload) {
     error: state.error,
     pending: state.pending.slice(),
     reload: state.reload,
+    // Shallow copy is enough: admitEvent REPLACES a run's entry, never mutates it.
+    fence: { ...(state.fence || {}) },
   };
+
+  // JF-018: drop a superseded pump's straggler before it can touch the projection.
+  // Deltas carry the FULL text so far, so an out-of-order one silently REWINDS the
+  // reply, and a stale run:end/run:error re-closes (or re-errors) a turn that has
+  // already moved on. Nothing user-visible is lost: the terminal path reloads the
+  // durable conversation over HTTP, which is what the panel actually renders.
+  if (!admitEvent(s.fence, p)) return s;
 
   switch (p.kind) {
     case "run:start":

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
+import {
+  emptyStream,
+  applyEvent,
+  applyEventEx,
+  visibleMessages,
+} from "./chat_stream.mjs";
 
 // `tool` rows are the MOST common role in a real conversation (508 of 1201 on
 // the dev site) and their content is null or "get_doc -> completed" — machine
@@ -14,7 +19,7 @@ test("visibleMessages: drops tool rows", () => {
   ]);
   assert.deepEqual(
     out.map((m) => m.name),
-    ["1", "4"]
+    ["1", "4"],
   );
 });
 
@@ -27,7 +32,7 @@ test("visibleMessages: drops empty and whitespace-only content", () => {
   ]);
   assert.deepEqual(
     out.map((m) => m.name),
-    ["4"]
+    ["4"],
   );
 });
 
@@ -38,7 +43,7 @@ test("visibleMessages: preserves order and is safe on junk input", () => {
   ];
   assert.deepEqual(
     visibleMessages(rows).map((m) => m.name),
-    ["a", "b"]
+    ["a", "b"],
   );
   assert.deepEqual(visibleMessages(null), []);
   assert.deepEqual(visibleMessages(undefined), []);
@@ -57,7 +62,7 @@ test("emptyStream: starts idle", () => {
 test("run:start opens a live turn and clears busy", () => {
   const s = applyEvent(
     { ...emptyStream(), busy: true },
-    { kind: "run:start", run_id: "r1", message_id: "m1" }
+    { kind: "run:start", run_id: "r1", message_id: "m1" },
   );
   assert.equal(s.busy, false);
   assert.deepEqual(s.live, { runId: "r1", messageId: "m1", text: "" });
@@ -160,7 +165,7 @@ test("action:pending queues distinct tokens in arrival order", () => {
   s = applyEvent(s, { kind: "action:pending", token: "t2", summary: "second" });
   assert.deepEqual(
     s.pending.map((p) => p.token),
-    ["t1", "t2"]
+    ["t1", "t2"],
   );
 });
 
@@ -232,7 +237,7 @@ const pumped = (kind, epoch, seq, extra = {}) => ({
 test("fence: a superseded pump's delta cannot rewind the live text", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("run:start", 2, 1, { message_id: "m1" })
+    pumped("run:start", 2, 1, { message_id: "m1" }),
   );
   s = applyEvent(s, pumped("assistant:delta", 2, 2, { text: "Hello there" }));
   // Same run, older epoch, higher seq — the classic post-handoff straggler.
@@ -243,7 +248,7 @@ test("fence: a superseded pump's delta cannot rewind the live text", () => {
 test("fence: a replayed same-epoch delta is dropped", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 3, 5, { text: "full answer" })
+    pumped("assistant:delta", 3, 5, { text: "full answer" }),
   );
   s = applyEvent(s, pumped("assistant:delta", 3, 4, { text: "full" }));
   s = applyEvent(s, pumped("assistant:delta", 3, 5, { text: "full" }));
@@ -253,7 +258,7 @@ test("fence: a replayed same-epoch delta is dropped", () => {
 test("fence: the FIRST terminal settles the turn, the backstop repeat does not re-fire", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 4, 7, { text: "done" })
+    pumped("assistant:delta", 4, 7, { text: "done" }),
   );
   // finalize reproduces the delta watermark's seq — this must still settle.
   s = applyEvent(s, pumped("run:end", 4, 7));
@@ -269,7 +274,7 @@ test("fence: the FIRST terminal settles the turn, the backstop repeat does not r
 test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 5, 1, { text: "a" })
+    pumped("assistant:delta", 5, 1, { text: "a" }),
   );
   s = applyEvent(s, pumped("run:end", 5, 1));
   s = { ...s, reload: false };
@@ -278,7 +283,7 @@ test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
   s = applyEvent(s, pumped("run:start", 6, 1, { message_id: "m2" }));
   s = applyEvent(
     s,
-    pumped("assistant:delta", 6, 2, { text: "recovered answer" })
+    pumped("assistant:delta", 6, 2, { text: "recovered answer" }),
   );
   assert.equal(s.live.text, "recovered answer");
   // Now the losing pump's late terminal arrives. It must NOT wipe the live turn.
@@ -293,7 +298,7 @@ test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
 test("fence: a stale run:start cannot re-open a settled turn", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 7, 3, { text: "final" })
+    pumped("assistant:delta", 7, 3, { text: "final" }),
   );
   s = applyEvent(s, pumped("run:end", 7, 3));
   s = { ...s, reload: false };
@@ -304,7 +309,7 @@ test("fence: a stale run:start cannot re-open a settled turn", () => {
 test("fence: approvals and renames bypass it (they are not pump-sequenced)", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 2, 9, { text: "x" })
+    pumped("assistant:delta", 2, 9, { text: "x" }),
   );
   s = applyEvent(s, {
     kind: "action:pending",
@@ -335,7 +340,7 @@ test("fence: legacy frames with no pump_epoch behave exactly as before", () => {
 test("fence: state is copied, never mutated in place", () => {
   const before = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 1, 1, { text: "a" })
+    pumped("assistant:delta", 1, 1, { text: "a" }),
   );
   const snapshot = JSON.parse(JSON.stringify(before.fence));
   applyEvent(before, pumped("assistant:delta", 1, 2, { text: "ab" }));
@@ -352,21 +357,33 @@ test("fence: a fresh stream (new conversation) starts unfenced", () => {
 });
 
 test("applyEventEx: reports admitted=true for a live frame, false for a fenced straggler", () => {
-  const r1 = applyEventEx(emptyStream(), pumped("assistant:delta", 3, 5, { text: "new" }));
+  const r1 = applyEventEx(
+    emptyStream(),
+    pumped("assistant:delta", 3, 5, { text: "new" }),
+  );
   assert.equal(r1.admitted, true);
   // Older epoch after a handoff: dropped AND reported as dropped, so Panel.vue
   // keeps its HTTP polling fallback armed — a stale-only stream must not stand
   // the safety net down (Wave-B UX P1-2).
-  const r2 = applyEventEx(r1.state, pumped("assistant:delta", 2, 9, { text: "old" }));
+  const r2 = applyEventEx(
+    r1.state,
+    pumped("assistant:delta", 2, 9, { text: "old" }),
+  );
   assert.equal(r2.admitted, false);
   assert.equal(r2.state.live.text, "new");
 });
 
 test("applyEventEx: the backstop terminal repeat is NOT admitted", () => {
-  let r = applyEventEx(emptyStream(), pumped("assistant:delta", 4, 7, { text: "done" }));
+  let r = applyEventEx(
+    emptyStream(),
+    pumped("assistant:delta", 4, 7, { text: "done" }),
+  );
   r = applyEventEx(r.state, pumped("run:end", 4, 7));
   assert.equal(r.admitted, true);
-  const again = applyEventEx({ ...r.state, reload: false }, pumped("run:end", 4, 7));
+  const again = applyEventEx(
+    { ...r.state, reload: false },
+    pumped("run:end", 4, 7),
+  );
   assert.equal(again.admitted, false);
   assert.equal(again.state.reload, false);
 });
@@ -375,10 +392,16 @@ test("fence survives startNewChat's state reset (dead-banner resurrection guard)
   // Panel.vue resets stream state on New Chat but carries the fence forward:
   // reopening the SAME conversation must still drop a superseded pump's stale
   // run:error instead of resurrecting a dead error banner.
-  let s = applyEvent(emptyStream(), pumped("assistant:delta", 6, 3, { text: "hi" }));
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 6, 3, { text: "hi" }),
+  );
   s = applyEvent(s, pumped("run:end", 6, 3));
   const reset = { ...emptyStream(), fence: s.fence };
-  const r = applyEventEx(reset, pumped("run:error", 5, 9, { error: "Relay lost the connection." }));
+  const r = applyEventEx(
+    reset,
+    pumped("run:error", 5, 9, { error: "Relay lost the connection." }),
+  );
   assert.equal(r.admitted, false);
   assert.equal(r.state.error, "");
   assert.equal(r.state.reload, false);

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -215,3 +215,138 @@ test("live text survives an unrelated event", () => {
   s = applyEvent(s, { kind: "action:pending", token: "t1", summary: "x" });
   assert.equal(s.live.text, "partial");
 });
+
+// ── JF-018: Relay-Pump epoch/seq fence ────────────────────────────────────────
+// The panel consumes the same pump-fenced frames as the desktop SPA. The shared
+// comparison ladder has its own exhaustive suite (../../shared/pump_fence.test.mjs
+// — including a parity walk against desktop's copy); these prove the REDUCER wires
+// it in: a straggler must not rewind the live text or re-close a settled turn.
+const pumped = (kind, epoch, seq, extra = {}) => ({
+  kind,
+  run_id: "r1",
+  pump_epoch: epoch,
+  event_seq: seq,
+  ...extra,
+});
+
+test("fence: a superseded pump's delta cannot rewind the live text", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("run:start", 2, 1, { message_id: "m1" })
+  );
+  s = applyEvent(s, pumped("assistant:delta", 2, 2, { text: "Hello there" }));
+  // Same run, older epoch, higher seq — the classic post-handoff straggler.
+  s = applyEvent(s, pumped("assistant:delta", 1, 99, { text: "Hel" }));
+  assert.equal(s.live.text, "Hello there");
+});
+
+test("fence: a replayed same-epoch delta is dropped", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 3, 5, { text: "full answer" })
+  );
+  s = applyEvent(s, pumped("assistant:delta", 3, 4, { text: "full" }));
+  s = applyEvent(s, pumped("assistant:delta", 3, 5, { text: "full" }));
+  assert.equal(s.live.text, "full answer");
+});
+
+test("fence: the FIRST terminal settles the turn, the backstop repeat does not re-fire", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 4, 7, { text: "done" })
+  );
+  // finalize reproduces the delta watermark's seq — this must still settle.
+  s = applyEvent(s, pumped("run:end", 4, 7));
+  assert.equal(s.live, null);
+  assert.equal(s.reload, true);
+  // Panel.vue clears `reload` the moment it acts on it; a re-published terminal
+  // must not set it again and cause a second fetch.
+  s = { ...s, reload: false };
+  s = applyEvent(s, pumped("run:end", 4, 7));
+  assert.equal(s.reload, false);
+});
+
+test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 5, 1, { text: "a" })
+  );
+  s = applyEvent(s, pumped("run:end", 5, 1));
+  s = { ...s, reload: false };
+  // Recovery re-streams at E+1; seq restarts low, which is legitimate and must flow
+  // (the fence resets its watermark on an epoch bump).
+  s = applyEvent(s, pumped("run:start", 6, 1, { message_id: "m2" }));
+  s = applyEvent(
+    s,
+    pumped("assistant:delta", 6, 2, { text: "recovered answer" })
+  );
+  assert.equal(s.live.text, "recovered answer");
+  // Now the losing pump's late terminal arrives. It must NOT wipe the live turn.
+  s = applyEvent(s, pumped("run:end", 5, 9));
+  assert.equal(s.live.text, "recovered answer", "stale run:end dropped");
+  assert.equal(s.reload, false, "…and triggered no reload");
+  s = applyEvent(s, pumped("run:error", 5, 9, { error: "boom" }));
+  assert.equal(s.error, "", "stale run:error dropped");
+  assert.equal(s.live.text, "recovered answer");
+});
+
+test("fence: a stale run:start cannot re-open a settled turn", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 7, 3, { text: "final" })
+  );
+  s = applyEvent(s, pumped("run:end", 7, 3));
+  s = { ...s, reload: false };
+  s = applyEvent(s, pumped("run:start", 6, 1, { message_id: "ghost" }));
+  assert.equal(s.live, null);
+});
+
+test("fence: approvals and renames bypass it (they are not pump-sequenced)", () => {
+  let s = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 2, 9, { text: "x" })
+  );
+  s = applyEvent(s, {
+    kind: "action:pending",
+    token: "t1",
+    pump_epoch: 1,
+    event_seq: 1,
+  });
+  assert.equal(s.pending.length, 1, "a parked write is never fenced away");
+  s = applyEvent(s, {
+    kind: "conversation:renamed",
+    pump_epoch: 1,
+    event_seq: 1,
+  });
+  assert.equal(s.reload, true);
+});
+
+test("fence: legacy frames with no pump_epoch behave exactly as before", () => {
+  let s = applyEvent(emptyStream(), {
+    kind: "assistant:delta",
+    run_id: "r1",
+    text: "one",
+  });
+  s = applyEvent(s, { kind: "assistant:delta", run_id: "r1", text: "two" });
+  assert.equal(s.live.text, "two");
+  assert.deepEqual(s.fence, {});
+});
+
+test("fence: state is copied, never mutated in place", () => {
+  const before = applyEvent(
+    emptyStream(),
+    pumped("assistant:delta", 1, 1, { text: "a" })
+  );
+  const snapshot = JSON.parse(JSON.stringify(before.fence));
+  applyEvent(before, pumped("assistant:delta", 1, 2, { text: "ab" }));
+  assert.deepEqual(before.fence, snapshot);
+});
+
+test("fence: a fresh stream (new conversation) starts unfenced", () => {
+  let s = applyEvent(emptyStream(), pumped("run:end", 9, 9));
+  assert.notDeepEqual(s.fence, {});
+  s = emptyStream();
+  assert.deepEqual(s.fence, {});
+  s = applyEvent(s, pumped("assistant:delta", 1, 1, { text: "new chat" }));
+  assert.equal(s.live.text, "new chat");
+});

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -19,7 +19,7 @@ test("visibleMessages: drops tool rows", () => {
   ]);
   assert.deepEqual(
     out.map((m) => m.name),
-    ["1", "4"],
+    ["1", "4"]
   );
 });
 
@@ -32,7 +32,7 @@ test("visibleMessages: drops empty and whitespace-only content", () => {
   ]);
   assert.deepEqual(
     out.map((m) => m.name),
-    ["4"],
+    ["4"]
   );
 });
 
@@ -43,7 +43,7 @@ test("visibleMessages: preserves order and is safe on junk input", () => {
   ];
   assert.deepEqual(
     visibleMessages(rows).map((m) => m.name),
-    ["a", "b"],
+    ["a", "b"]
   );
   assert.deepEqual(visibleMessages(null), []);
   assert.deepEqual(visibleMessages(undefined), []);
@@ -62,7 +62,7 @@ test("emptyStream: starts idle", () => {
 test("run:start opens a live turn and clears busy", () => {
   const s = applyEvent(
     { ...emptyStream(), busy: true },
-    { kind: "run:start", run_id: "r1", message_id: "m1" },
+    { kind: "run:start", run_id: "r1", message_id: "m1" }
   );
   assert.equal(s.busy, false);
   assert.deepEqual(s.live, { runId: "r1", messageId: "m1", text: "" });
@@ -165,7 +165,7 @@ test("action:pending queues distinct tokens in arrival order", () => {
   s = applyEvent(s, { kind: "action:pending", token: "t2", summary: "second" });
   assert.deepEqual(
     s.pending.map((p) => p.token),
-    ["t1", "t2"],
+    ["t1", "t2"]
   );
 });
 
@@ -237,7 +237,7 @@ const pumped = (kind, epoch, seq, extra = {}) => ({
 test("fence: a superseded pump's delta cannot rewind the live text", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("run:start", 2, 1, { message_id: "m1" }),
+    pumped("run:start", 2, 1, { message_id: "m1" })
   );
   s = applyEvent(s, pumped("assistant:delta", 2, 2, { text: "Hello there" }));
   // Same run, older epoch, higher seq — the classic post-handoff straggler.
@@ -248,7 +248,7 @@ test("fence: a superseded pump's delta cannot rewind the live text", () => {
 test("fence: a replayed same-epoch delta is dropped", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 3, 5, { text: "full answer" }),
+    pumped("assistant:delta", 3, 5, { text: "full answer" })
   );
   s = applyEvent(s, pumped("assistant:delta", 3, 4, { text: "full" }));
   s = applyEvent(s, pumped("assistant:delta", 3, 5, { text: "full" }));
@@ -258,7 +258,7 @@ test("fence: a replayed same-epoch delta is dropped", () => {
 test("fence: the FIRST terminal settles the turn, the backstop repeat does not re-fire", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 4, 7, { text: "done" }),
+    pumped("assistant:delta", 4, 7, { text: "done" })
   );
   // finalize reproduces the delta watermark's seq — this must still settle.
   s = applyEvent(s, pumped("run:end", 4, 7));
@@ -274,7 +274,7 @@ test("fence: the FIRST terminal settles the turn, the backstop repeat does not r
 test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 5, 1, { text: "a" }),
+    pumped("assistant:delta", 5, 1, { text: "a" })
   );
   s = applyEvent(s, pumped("run:end", 5, 1));
   s = { ...s, reload: false };
@@ -283,7 +283,7 @@ test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
   s = applyEvent(s, pumped("run:start", 6, 1, { message_id: "m2" }));
   s = applyEvent(
     s,
-    pumped("assistant:delta", 6, 2, { text: "recovered answer" }),
+    pumped("assistant:delta", 6, 2, { text: "recovered answer" })
   );
   assert.equal(s.live.text, "recovered answer");
   // Now the losing pump's late terminal arrives. It must NOT wipe the live turn.
@@ -298,7 +298,7 @@ test("fence: a stale terminal cannot re-close a turn that has moved on", () => {
 test("fence: a stale run:start cannot re-open a settled turn", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 7, 3, { text: "final" }),
+    pumped("assistant:delta", 7, 3, { text: "final" })
   );
   s = applyEvent(s, pumped("run:end", 7, 3));
   s = { ...s, reload: false };
@@ -309,7 +309,7 @@ test("fence: a stale run:start cannot re-open a settled turn", () => {
 test("fence: approvals and renames bypass it (they are not pump-sequenced)", () => {
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 2, 9, { text: "x" }),
+    pumped("assistant:delta", 2, 9, { text: "x" })
   );
   s = applyEvent(s, {
     kind: "action:pending",
@@ -340,7 +340,7 @@ test("fence: legacy frames with no pump_epoch behave exactly as before", () => {
 test("fence: state is copied, never mutated in place", () => {
   const before = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 1, 1, { text: "a" }),
+    pumped("assistant:delta", 1, 1, { text: "a" })
   );
   const snapshot = JSON.parse(JSON.stringify(before.fence));
   applyEvent(before, pumped("assistant:delta", 1, 2, { text: "ab" }));
@@ -359,7 +359,7 @@ test("fence: a fresh stream (new conversation) starts unfenced", () => {
 test("applyEventEx: reports admitted=true for a live frame, false for a fenced straggler", () => {
   const r1 = applyEventEx(
     emptyStream(),
-    pumped("assistant:delta", 3, 5, { text: "new" }),
+    pumped("assistant:delta", 3, 5, { text: "new" })
   );
   assert.equal(r1.admitted, true);
   // Older epoch after a handoff: dropped AND reported as dropped, so Panel.vue
@@ -367,7 +367,7 @@ test("applyEventEx: reports admitted=true for a live frame, false for a fenced s
   // the safety net down (Wave-B UX P1-2).
   const r2 = applyEventEx(
     r1.state,
-    pumped("assistant:delta", 2, 9, { text: "old" }),
+    pumped("assistant:delta", 2, 9, { text: "old" })
   );
   assert.equal(r2.admitted, false);
   assert.equal(r2.state.live.text, "new");
@@ -376,13 +376,13 @@ test("applyEventEx: reports admitted=true for a live frame, false for a fenced s
 test("applyEventEx: the backstop terminal repeat is NOT admitted", () => {
   let r = applyEventEx(
     emptyStream(),
-    pumped("assistant:delta", 4, 7, { text: "done" }),
+    pumped("assistant:delta", 4, 7, { text: "done" })
   );
   r = applyEventEx(r.state, pumped("run:end", 4, 7));
   assert.equal(r.admitted, true);
   const again = applyEventEx(
     { ...r.state, reload: false },
-    pumped("run:end", 4, 7),
+    pumped("run:end", 4, 7)
   );
   assert.equal(again.admitted, false);
   assert.equal(again.state.reload, false);
@@ -394,13 +394,13 @@ test("fence survives startNewChat's state reset (dead-banner resurrection guard)
   // run:error instead of resurrecting a dead error banner.
   let s = applyEvent(
     emptyStream(),
-    pumped("assistant:delta", 6, 3, { text: "hi" }),
+    pumped("assistant:delta", 6, 3, { text: "hi" })
   );
   s = applyEvent(s, pumped("run:end", 6, 3));
   const reset = { ...emptyStream(), fence: s.fence };
   const r = applyEventEx(
     reset,
-    pumped("run:error", 5, 9, { error: "Relay lost the connection." }),
+    pumped("run:error", 5, 9, { error: "Relay lost the connection." })
   );
   assert.equal(r.admitted, false);
   assert.equal(r.state.error, "");

--- a/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { emptyStream, applyEvent, visibleMessages } from "./chat_stream.mjs";
+import { emptyStream, applyEvent, applyEventEx, visibleMessages } from "./chat_stream.mjs";
 
 // `tool` rows are the MOST common role in a real conversation (508 of 1201 on
 // the dev site) and their content is null or "get_doc -> completed" — machine
@@ -349,4 +349,37 @@ test("fence: a fresh stream (new conversation) starts unfenced", () => {
   assert.deepEqual(s.fence, {});
   s = applyEvent(s, pumped("assistant:delta", 1, 1, { text: "new chat" }));
   assert.equal(s.live.text, "new chat");
+});
+
+test("applyEventEx: reports admitted=true for a live frame, false for a fenced straggler", () => {
+  const r1 = applyEventEx(emptyStream(), pumped("assistant:delta", 3, 5, { text: "new" }));
+  assert.equal(r1.admitted, true);
+  // Older epoch after a handoff: dropped AND reported as dropped, so Panel.vue
+  // keeps its HTTP polling fallback armed — a stale-only stream must not stand
+  // the safety net down (Wave-B UX P1-2).
+  const r2 = applyEventEx(r1.state, pumped("assistant:delta", 2, 9, { text: "old" }));
+  assert.equal(r2.admitted, false);
+  assert.equal(r2.state.live.text, "new");
+});
+
+test("applyEventEx: the backstop terminal repeat is NOT admitted", () => {
+  let r = applyEventEx(emptyStream(), pumped("assistant:delta", 4, 7, { text: "done" }));
+  r = applyEventEx(r.state, pumped("run:end", 4, 7));
+  assert.equal(r.admitted, true);
+  const again = applyEventEx({ ...r.state, reload: false }, pumped("run:end", 4, 7));
+  assert.equal(again.admitted, false);
+  assert.equal(again.state.reload, false);
+});
+
+test("fence survives startNewChat's state reset (dead-banner resurrection guard)", () => {
+  // Panel.vue resets stream state on New Chat but carries the fence forward:
+  // reopening the SAME conversation must still drop a superseded pump's stale
+  // run:error instead of resurrecting a dead error banner.
+  let s = applyEvent(emptyStream(), pumped("assistant:delta", 6, 3, { text: "hi" }));
+  s = applyEvent(s, pumped("run:end", 6, 3));
+  const reset = { ...emptyStream(), fence: s.fence };
+  const r = applyEventEx(reset, pumped("run:error", 5, 9, { error: "Relay lost the connection." }));
+  assert.equal(r.admitted, false);
+  assert.equal(r.state.error, "");
+  assert.equal(r.state.reload, false);
 });

--- a/jarvis/public/js/shared/pump_fence.mjs
+++ b/jarvis/public/js/shared/pump_fence.mjs
@@ -1,0 +1,117 @@
+// The Relay-Pump epoch/seq fence, as a SHARED CONSUMER CONTRACT (JF-018).
+//
+// Every pump-owned realtime frame carries (run_id/turn_id, pump_epoch, event_seq) —
+// see jarvis/chat/turn_state.py publish_fenced(). Without a fence, a superseded
+// pump's late CUMULATIVE delta overwrites a newer projection after a handoff/replay,
+// and a stale terminal re-opens (or re-closes) a settled turn.
+//
+// The desktop SPA has fenced since CDX-3/CDX-12; the PWA and the Desk widget did not,
+// because the logic was written inside desktop's ChatView instead of a module all
+// three surfaces could consume. This file is that module, placed under
+// jarvis/public/js/ because the Desk widget is an esbuild bundle that cannot reach
+// frontend/src or the "@/" alias (see jarvis_chat/widget/panel_readiness.mjs for the
+// same constraint). .mjs so it is unambiguously ESM regardless of the nearest
+// package.json "type".
+//
+// MIRRORED SEMANTICS — this is a copy, not a variation. fenceKey/fenceReject/
+// fenceAccept below reproduce frontend/src/utils/eventFence.js (lines 35-79 at the
+// JF-018 snapshot) EXACTLY, which is itself the extraction of desktop's fence in
+// frontend/src/views/ChatView.vue (pumpFenceReject/pumpFenceAccept, lines 4006-4012,
+// applied at lines 7156-7157, 7174-7175, 7223-7224, 7241-7242, 7254-7255,
+// 7279-7280 and 7380-7381 at that snapshot). Desktop can adopt this module verbatim
+// when JF-013 refactors ChatView; jarvis/tests/test_pump_fence_shared_client.py runs
+// a decision-parity walk against the desktop copy so the two cannot silently drift.
+//
+// State shape: fence = { [runKey]: { epoch, seq, terminated } }
+//   * epoch/seq  — the GREATEST accepted (pump_epoch, event_seq).
+//   * terminated — the highest pump_epoch at which a TERMINAL was accepted (null until
+//                  the first terminal), so a repeat terminal is one-shot.
+//
+// Dropped frames have NO user-visible effect: every terminal path on these surfaces
+// re-fetches the durable conversation over HTTP, which is what converges content.
+
+// The two kinds desktop treats as TERMINAL (ChatView.vue 7279 / 7380 pass isTerminal
+// = true and nothing else does). A terminal latches `terminated` for its epoch.
+export const TERMINAL_KINDS = new Set(["run:end", "run:error"]);
+
+// The kinds desktop puts THROUGH the fence. Everything else (run:status,
+// queue:position, turn:cancelled, action:confirmed, action:pending, action:resolved,
+// canvas, conversation:renamed, message:enriched, …) bypasses it there and must
+// bypass it here — those frames are not pump-sequenced projections of the reply.
+export const FENCED_KINDS = new Set([
+  "run:start",
+  "run:recovering",
+  "assistant:delta",
+  "tool:start",
+  "tool:end",
+  "run:end",
+  "run:error",
+]);
+
+export function createFence() {
+  return {};
+}
+
+export function fenceKey(p) {
+  return p.run_id || p.turn_id || null;
+}
+
+export function fenceReject(fence, p, isTerminal) {
+  if (p.pump_epoch == null) return false; // legacy / non-pump -> accept
+  const k = fenceKey(p);
+  if (!k) return false;
+  const f = fence[k];
+  if (!f) return false;
+  const e = p.pump_epoch;
+  if (f.terminated != null && e < f.terminated) return true; // any event below a higher-epoch terminal
+  // CDX-12: a repeat terminal at an already-terminated (same-or-lower) epoch is one-shot.
+  if (isTerminal && f.terminated != null && e <= f.terminated) return true;
+  if (f.epoch != null && e < f.epoch) return true; // superseded writer
+  if (
+    f.epoch != null &&
+    e === f.epoch &&
+    p.event_seq != null &&
+    f.seq != null
+  ) {
+    if (isTerminal) {
+      // CDX-12: reaching here as a terminal means it is the FIRST terminal at the
+      // current epoch (a repeat was rejected above via `terminated`; a lower-epoch one
+      // via the superseded-writer check). It legitimately shares the delta watermark's
+      // seq, so accept equality — only a terminal STRICTLY BELOW the watermark is stale.
+      if (p.event_seq < f.seq) return true;
+    } else if (p.event_seq <= f.seq) {
+      return true; // duplicate/older NON-terminal frame at the same epoch
+    }
+  }
+  return false;
+}
+
+export function fenceAccept(fence, p, isTerminal) {
+  if (p.pump_epoch == null) return; // legacy / non-pump -> nothing to track
+  const k = fenceKey(p);
+  if (!k) return;
+  const prev = fence[k] || { epoch: null, seq: null, terminated: null };
+  let { epoch, seq, terminated } = prev;
+  const e = p.pump_epoch;
+  if (epoch == null || e > epoch) {
+    epoch = e;
+    seq = p.event_seq != null ? p.event_seq : null; // reset the seq watermark on a new (higher) epoch
+  } else if (e === epoch && p.event_seq != null) {
+    seq = seq == null ? p.event_seq : Math.max(seq, p.event_seq);
+  }
+  if (isTerminal) terminated = terminated == null ? e : Math.max(terminated, e);
+  fence[k] = { epoch, seq, terminated };
+}
+
+// The whole contract in one call, so a consumer cannot forget the accept half (the
+// bug that check-only fences ship with): returns TRUE to apply the frame, FALSE to
+// drop it. Kinds outside FENCED_KINDS are applied WITHOUT touching fence state —
+// identical to desktop, where those cases simply have no fence call.
+export function admitEvent(fence, payload) {
+  const p = payload || {};
+  if (!FENCED_KINDS.has(p.kind)) return true;
+  const isTerminal = TERMINAL_KINDS.has(p.kind);
+  if (fenceReject(fence, p, isTerminal)) return false;
+  fenceAccept(fence, p, isTerminal);
+  return true;
+}

--- a/jarvis/public/js/shared/pump_fence.test.mjs
+++ b/jarvis/public/js/shared/pump_fence.test.mjs
@@ -1,0 +1,334 @@
+// Executable contract test for the SHARED pump fence (JF-018). Plain node built-ins
+// (node:test + node:assert) — no framework. Run directly
+// (`node --test pump_fence.test.mjs`) or via the python suite:
+// jarvis/tests/test_pump_fence_shared_client.py subprocess-runs this, so the fence the
+// PWA and the Desk widget depend on is enforced by every CI run.
+//
+// The last test is the anti-drift guard: it replays an EXHAUSTIVE walk matrix through
+// both this module and desktop's frontend/src/utils/eventFence.js and asserts the two
+// make identical accept/drop decisions and reach identical state. If desktop's fence
+// is ever changed without changing this one (or vice versa), that test fails.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FENCED_KINDS,
+  TERMINAL_KINDS,
+  admitEvent,
+  createFence,
+  fenceAccept,
+  fenceKey,
+  fenceReject,
+} from "./pump_fence.mjs";
+import * as desktop from "../../../../frontend/src/utils/eventFence.js";
+
+// One trip through the low-level pair: reject-check then accept — exactly what
+// admitEvent() and desktop's ChatView handlers do. Returns TRUE when rejected.
+function feed(fence, p, isTerminal) {
+  const rejected = fenceReject(fence, p, isTerminal);
+  if (!rejected) fenceAccept(fence, p, isTerminal);
+  return rejected;
+}
+const ev = (epoch, seq, extra = {}) => ({
+  run_id: "R",
+  pump_epoch: epoch,
+  event_seq: seq,
+  ...extra,
+});
+const delta = (epoch, seq, extra = {}) =>
+  ev(epoch, seq, { kind: "assistant:delta", ...extra });
+const end = (epoch, seq, extra = {}) =>
+  ev(epoch, seq, { kind: "run:end", ...extra });
+
+test("createFence: a fresh fence is empty", () => {
+  assert.deepEqual(createFence(), {});
+});
+
+test("fenceKey: run_id, then turn_id, else null", () => {
+  assert.equal(fenceKey({ run_id: "R" }), "R");
+  assert.equal(fenceKey({ turn_id: "T" }), "T");
+  assert.equal(fenceKey({}), null);
+});
+
+// ── stale epoch ────────────────────────────────────────────────────────────────
+test("stale epoch: a superseded writer's frame is dropped, the current epoch is kept", () => {
+  const fence = createFence();
+  assert.equal(
+    admitEvent(fence, delta(5, 3)),
+    true,
+    "current-epoch delta applied"
+  );
+  assert.equal(
+    admitEvent(fence, delta(4, 99)),
+    false,
+    "E-1 delta dropped even at a higher seq"
+  );
+  assert.equal(
+    fence.R.epoch,
+    5,
+    "the lower epoch did not clobber the watermark"
+  );
+  assert.equal(fence.R.seq, 3, "…nor the seq watermark");
+});
+
+// ── stale seq ──────────────────────────────────────────────────────────────────
+test("stale seq: a replayed/duplicate non-terminal at the same epoch is dropped", () => {
+  const fence = createFence();
+  admitEvent(fence, delta(1, 5));
+  assert.equal(
+    admitEvent(fence, delta(1, 5)),
+    false,
+    "equal-seq replay dropped"
+  );
+  assert.equal(
+    admitEvent(fence, delta(1, 4)),
+    false,
+    "lower-seq straggler dropped"
+  );
+  assert.equal(
+    admitEvent(fence, delta(1, 6)),
+    true,
+    "the next real frame is applied"
+  );
+});
+
+// ── terminal latch ─────────────────────────────────────────────────────────────
+test("terminal latch: the FIRST terminal is applied, the repeat and every later straggler are not", () => {
+  const fence = createFence();
+  assert.equal(admitEvent(fence, delta(5, 10)), true);
+  // The finalize/settlement terminal legitimately reproduces the delta watermark's
+  // seq — it must NOT be mistaken for a duplicate, or the surface never settles.
+  assert.equal(
+    admitEvent(fence, end(5, 10)),
+    true,
+    "first terminal at the watermark applied"
+  );
+  assert.equal(fence.R.terminated, 5);
+  assert.equal(
+    admitEvent(fence, end(5, 10)),
+    false,
+    "backstop re-publish dropped one-shot"
+  );
+  assert.equal(
+    admitEvent(fence, delta(5, 11)),
+    true,
+    "same-epoch progress after a terminal still flows"
+  );
+  assert.equal(
+    admitEvent(fence, delta(4, 99)),
+    false,
+    "post-terminal LOWER-epoch delta dropped"
+  );
+  assert.equal(
+    admitEvent(fence, end(4, 99)),
+    false,
+    "post-terminal LOWER-epoch terminal dropped"
+  );
+  assert.equal(
+    admitEvent(fence, {
+      kind: "run:start",
+      run_id: "R",
+      pump_epoch: 4,
+      event_seq: 1,
+    }),
+    false,
+    "a stale run:start cannot re-open a settled turn"
+  );
+});
+
+test("terminal latch: a terminal STRICTLY below the watermark is still stale", () => {
+  const fence = createFence();
+  admitEvent(fence, delta(2, 10));
+  admitEvent(fence, delta(2, 12));
+  assert.equal(
+    admitEvent(fence, end(2, 8)),
+    false,
+    "seq 8 < watermark 12 dropped"
+  );
+  assert.equal(
+    admitEvent(fence, end(2, 12)),
+    true,
+    "the terminal at the watermark applied"
+  );
+});
+
+// ── epoch bump resets ──────────────────────────────────────────────────────────
+test("epoch bump: a higher epoch RESETS the seq watermark and supersedes a terminal", () => {
+  const fence = createFence();
+  admitEvent(fence, delta(3, 90));
+  admitEvent(fence, end(3, 90));
+  assert.equal(fence.R.terminated, 3);
+  // Recovery re-streams from seq 1 at E+1; those low seqs must not read as stale.
+  assert.equal(
+    admitEvent(fence, delta(4, 1)),
+    true,
+    "recovered delta at a LOWER seq applied"
+  );
+  assert.equal(fence.R.seq, 1, "the watermark reset with the epoch");
+  assert.equal(
+    admitEvent(fence, end(4, 1)),
+    true,
+    "recovered terminal applied"
+  );
+  assert.equal(fence.R.terminated, 4, "the higher-epoch terminal superseded");
+  assert.equal(admitEvent(fence, end(4, 1)), false, "…and is itself one-shot");
+});
+
+// ── run scoping ────────────────────────────────────────────────────────────────
+test("the fence is RUN-scoped: a settled run never gates a different run", () => {
+  const fence = createFence();
+  admitEvent(fence, {
+    kind: "assistant:delta",
+    run_id: "A",
+    pump_epoch: 9,
+    event_seq: 5,
+  });
+  admitEvent(fence, {
+    kind: "run:end",
+    run_id: "A",
+    pump_epoch: 9,
+    event_seq: 5,
+  });
+  assert.equal(
+    admitEvent(fence, {
+      kind: "assistant:delta",
+      run_id: "B",
+      pump_epoch: 1,
+      event_seq: 1,
+    }),
+    true,
+    "a fresh run at a lower epoch is untouched by run A's terminal"
+  );
+});
+
+test("tool frames carry no message_id but ARE fenced (the CDX-3 hole)", () => {
+  const fence = createFence();
+  admitEvent(fence, {
+    kind: "tool:start",
+    run_id: "R",
+    pump_epoch: 2,
+    event_seq: 4,
+  });
+  assert.equal(
+    admitEvent(fence, {
+      kind: "tool:end",
+      run_id: "R",
+      pump_epoch: 1,
+      event_seq: 99,
+    }),
+    false,
+    "a superseded writer's tool:end is dropped"
+  );
+});
+
+// ── bypasses ───────────────────────────────────────────────────────────────────
+test("legacy frames (no pump_epoch) bypass the fence entirely", () => {
+  const fence = createFence();
+  assert.equal(
+    admitEvent(fence, { kind: "assistant:delta", run_id: "R" }),
+    true
+  );
+  assert.equal(admitEvent(fence, { kind: "run:end", run_id: "R" }), true);
+  assert.deepEqual(fence, {}, "no fence entry created for legacy frames");
+});
+
+test("unfenced kinds pass through without touching fence state", () => {
+  const fence = createFence();
+  admitEvent(fence, delta(2, 5));
+  const snapshot = { ...fence.R };
+  for (const kind of [
+    "action:pending",
+    "action:resolved",
+    "conversation:renamed",
+    "canvas",
+    "run:status",
+    "queue:position",
+    "turn:cancelled",
+    "something:new",
+  ]) {
+    assert.equal(
+      admitEvent(fence, { kind, run_id: "R", pump_epoch: 1, event_seq: 1 }),
+      true,
+      `${kind} must bypass the fence`
+    );
+  }
+  assert.deepEqual(
+    fence.R,
+    snapshot,
+    "an unfenced kind left no trace in the fence"
+  );
+});
+
+test("a missing / kind-less payload is admitted and inert", () => {
+  const fence = createFence();
+  assert.equal(admitEvent(fence, null), true);
+  assert.equal(admitEvent(fence, undefined), true);
+  assert.equal(admitEvent(fence, {}), true);
+  assert.deepEqual(fence, {});
+});
+
+test("the fenced/terminal kind sets are the ones desktop uses", () => {
+  assert.deepEqual([...TERMINAL_KINDS].sort(), ["run:end", "run:error"]);
+  assert.deepEqual([...FENCED_KINDS].sort(), [
+    "assistant:delta",
+    "run:end",
+    "run:error",
+    "run:recovering",
+    "run:start",
+    "tool:end",
+    "tool:start",
+  ]);
+  for (const k of TERMINAL_KINDS)
+    assert.ok(FENCED_KINDS.has(k), `${k} must also be fenced`);
+});
+
+// ── anti-drift: identical decisions to desktop's fence ─────────────────────────
+test("PARITY: every walk decides identically in this module and desktop's eventFence.js", () => {
+  // 12 distinct frames (2 epochs x 3 seqs x terminal?) replayed as every ordered
+  // 3-frame walk = 1728 walks, 5184 decisions. Small enough to be exhaustive,
+  // wide enough to catch any divergence in the comparison ladder.
+  const frames = [];
+  for (const epoch of [1, 2]) {
+    for (const seq of [1, 2, 3]) {
+      for (const isTerminal of [false, true])
+        frames.push({ p: ev(epoch, seq), isTerminal });
+    }
+  }
+  let walks = 0;
+  let decisions = 0;
+  for (const a of frames) {
+    for (const b of frames) {
+      for (const c of frames) {
+        const mine = {};
+        const theirs = {};
+        for (const f of [a, b, c]) {
+          const m = feed(mine, f.p, f.isTerminal);
+          const t = desktop.fenceReject(theirs, f.p, f.isTerminal);
+          if (!t) desktop.fenceAccept(theirs, f.p, f.isTerminal);
+          assert.equal(
+            m,
+            t,
+            `decision drift on epoch=${f.p.pump_epoch} seq=${f.p.event_seq} terminal=${f.isTerminal}`
+          );
+          decisions += 1;
+        }
+        assert.deepEqual(mine, theirs, "fence STATE drift after the walk");
+        walks += 1;
+      }
+    }
+  }
+  assert.equal(walks, 1728);
+  assert.equal(decisions, 5184);
+});
+
+test("PARITY: legacy (epoch-less) frames behave identically too", () => {
+  const mine = {};
+  const theirs = {};
+  for (const isTerminal of [false, true]) {
+    const p = { run_id: "R" };
+    assert.equal(
+      feed(mine, p, isTerminal),
+      desktop.fenceReject(theirs, p, isTerminal)
+    );
+  }
+  assert.deepEqual(mine, theirs);
+});

--- a/jarvis/tests/test_pump_fence_shared_client.py
+++ b/jarvis/tests/test_pump_fence_shared_client.py
@@ -39,6 +39,12 @@ class TestPumpFenceSharedClient(unittest.TestCase):
 	def _run_node_test(self, *relative_parts: str) -> None:
 		node = shutil.which("node")
 		if not node:
+			# In CI this suite is the ONLY automated proof of the client fence
+			# (jarvis CI never builds the frontends). A silent skip there would
+			# let the guard rot green — fail loudly instead. Local dev boxes
+			# without node still skip.
+			if os.environ.get("CI"):
+				self.fail("node is required in CI: the fence suites must actually run")
 			self.skipTest("node binary not available on this host")
 		test_file = os.path.join(_app_root(), *relative_parts)
 		self.assertTrue(

--- a/jarvis/tests/test_pump_fence_shared_client.py
+++ b/jarvis/tests/test_pump_fence_shared_client.py
@@ -1,0 +1,73 @@
+"""JF-018 — the Relay-Pump event fence on the PWA and the Desk widget, proven by REAL
+executable node tests that live in the python suite forever.
+
+The desktop SPA has fenced pump-owned realtime frames on (pump_epoch, event_seq) since
+CDX-3/CDX-12, but that logic was written inside desktop's ChatView, so the two other
+surfaces that consume the SAME frames — the mobile PWA and the floating Desk widget —
+had no fence at all. A superseded pump's late CUMULATIVE delta could rewind a newer
+projection after a handoff/replay, and a stale terminal could tear down a turn that had
+already been taken over.
+
+The fence is now a shared consumer contract at ``jarvis/public/js/shared/pump_fence.mjs``
+(that tree, not ``frontend/src``, because the widget is an esbuild bundle which cannot
+reach a Vue app's sources). Three node suites guard it, and this module subprocess-runs
+each one with ``node --test`` (non-zero exit on any failed assertion):
+
+* ``jarvis/public/js/shared/pump_fence.test.mjs`` — the comparison ladder: stale epoch,
+  stale seq, terminal latch + one-shot repeat, epoch-bump watermark reset, run scoping,
+  legacy bypass, PLUS an exhaustive 1728-walk decision-parity check against desktop's
+  ``frontend/src/utils/eventFence.js`` so the two copies cannot silently drift.
+* ``jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs`` — the widget reducer
+  actually applying it.
+* ``pwa/src/lib/pumpFence.test.js`` — the PWA's wiring (it has no component harness, so
+  ChatView's gate is asserted against the source) plus the fence contract it depends on.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _app_root() -> str:
+	return os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+
+
+class TestPumpFenceSharedClient(unittest.TestCase):
+	def _run_node_test(self, *relative_parts: str) -> None:
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = os.path.join(_app_root(), *relative_parts)
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"client fence test missing at {test_file} — it MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=180,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			f"node test FAILED ({os.path.join(*relative_parts)}):\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count, so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)
+
+	def test_shared_fence_module(self):
+		self._run_node_test("jarvis", "public", "js", "shared", "pump_fence.test.mjs")
+
+	def test_widget_reducer_applies_the_fence(self):
+		self._run_node_test("jarvis", "public", "js", "jarvis_chat", "widget", "chat_stream.test.mjs")
+
+	def test_pwa_chatview_is_wired_to_the_fence(self):
+		self._run_node_test("pwa", "src", "lib", "pumpFence.test.js")

--- a/pwa/src/lib/pumpFence.test.js
+++ b/pwa/src/lib/pumpFence.test.js
@@ -49,14 +49,14 @@ test("ChatView imports the SHARED fence, not a local re-implementation", () => {
 	assert.match(
 		src,
 		/import \{ admitEvent \} from "@jsshared\/pump_fence\.mjs";/,
-		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift",
+		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift"
 	);
 	assert.match(
 		src,
 		/import \{ eventFence \} from "\.\.\/lib\/pump_fence_state\.js";/,
 		"the fence instance must be the MODULE-scope singleton — a component-scope " +
 			"fence is destroyed on every route away from chat (no keep-alive) and " +
-			"readmits the stale frames it exists to drop",
+			"readmits the stale frames it exists to drop"
 	);
 });
 
@@ -78,7 +78,7 @@ test("onEvent gates on the fence BEFORE the switch, and returns on a drop", () =
 	const convFilter = body.indexOf("if (conv !== convId.value) return;");
 	assert.ok(
 		convFilter !== -1 && convFilter < gate,
-		"the conversation filter must precede the gate",
+		"the conversation filter must precede the gate"
 	);
 });
 
@@ -87,14 +87,14 @@ test("every pump-sequenced kind ChatView handles is covered by the fence", () =>
 	const kinds = [...body.matchAll(/case "([a-z:]+)":/g)].map((m) => m[1]);
 	assert.ok(
 		kinds.length >= 8,
-		`expected ChatView's switch to still have cases, found ${kinds.length}`,
+		`expected ChatView's switch to still have cases, found ${kinds.length}`
 	);
 	for (const kind of kinds) {
 		assert.ok(
 			FENCED_KINDS.has(kind) || UNFENCED_IN_CHATVIEW.has(kind),
 			`"${kind}" is handled by ChatView but is neither fenced nor a declared bypass — ` +
 				"decide which it is (add it to FENCED_KINDS in pump_fence.mjs, or to " +
-				"UNFENCED_IN_CHATVIEW here with the reason)",
+				"UNFENCED_IN_CHATVIEW here with the reason)"
 		);
 	}
 	// The two teardown kinds must be the fence's terminals, or a stale one re-closes
@@ -138,7 +138,7 @@ test("a stale terminal is dropped (it would clear live + fire a redundant load()
 	assert.equal(
 		admitEvent(fence, f("run:error", 2, 9)),
 		false,
-		"a losing pump's error is dropped",
+		"a losing pump's error is dropped"
 	);
 	// A genuine takeover at E+1 still gets to stream and settle.
 	assert.equal(admitEvent(fence, f("assistant:delta", 4, 1)), true);
@@ -159,6 +159,6 @@ test("approvals are never fenced away", () => {
 	assert.equal(
 		admitEvent(fence, { kind: "action:pending", run_id: "r1", token: "t1", pump_epoch: 1 }),
 		true,
-		"a parked write must reach the UI whatever the pump did",
+		"a parked write must reach the UI whatever the pump did"
 	);
 });

--- a/pwa/src/lib/pumpFence.test.js
+++ b/pwa/src/lib/pumpFence.test.js
@@ -48,10 +48,22 @@ function onEventBody() {
 test("ChatView imports the SHARED fence, not a local re-implementation", () => {
 	assert.match(
 		src,
-		/import \{ admitEvent, createFence \} from "@jsshared\/pump_fence\.mjs";/,
+		/import \{ admitEvent \} from "@jsshared\/pump_fence\.mjs";/,
 		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift"
 	);
-	assert.match(src, /createFence\(\)/, "ChatView must hold a fence instance");
+	assert.match(
+		src,
+		/import \{ eventFence \} from "\.\.\/lib\/pump_fence_state\.js";/,
+		"the fence instance must be the MODULE-scope singleton — a component-scope " +
+			"fence is destroyed on every route away from chat (no keep-alive) and " +
+			"readmits the stale frames it exists to drop"
+	);
+});
+
+test("the fence singleton is module-scope and built on the shared factory", () => {
+	const stateSrc = fs.readFileSync(path.join(HERE, "pump_fence_state.js"), "utf8");
+	assert.match(stateSrc, /import \{ createFence \} from "@jsshared\/pump_fence\.mjs";/);
+	assert.match(stateSrc, /export const eventFence = createFence\(\);/);
 });
 
 test("onEvent gates on the fence BEFORE the switch, and returns on a drop", () => {

--- a/pwa/src/lib/pumpFence.test.js
+++ b/pwa/src/lib/pumpFence.test.js
@@ -1,0 +1,152 @@
+// JF-018: the PWA's half of the Relay-Pump event fence.
+//
+// This is a test with no sibling module on purpose. The fence itself lives in
+// jarvis/public/js/shared/pump_fence.mjs (shared with the Desk widget, which cannot
+// import from a Vue app) and has its own exhaustive suite there, including a
+// decision-parity walk against the desktop SPA's copy. What is UNTESTABLE there is
+// the half that lives in this app: whether ChatView's onEvent actually routes its
+// frames through the fence. The PWA has no component harness — no vitest, no
+// @vue/test-utils, and mounting ChatView would need a router, a socket and the whole
+// api surface — so the wiring is asserted against the SOURCE instead. Crude, but it
+// is a real regression guard: it fails the moment the gate is removed, moved after
+// the switch, or a new pump-sequenced kind is handled without being fenced.
+//
+// It runs under the PWA's own `npm test` (node --test src/lib/*.test.js).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	FENCED_KINDS,
+	TERMINAL_KINDS,
+	admitEvent,
+	createFence,
+} from "../../../jarvis/public/js/shared/pump_fence.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CHAT_VIEW = path.join(HERE, "..", "views", "ChatView.vue");
+const src = fs.readFileSync(CHAT_VIEW, "utf8");
+
+// Kinds ChatView handles that are NOT pump-sequenced projections of the reply, and
+// so must keep bypassing the fence (desktop does the same). Adding a kind here is a
+// deliberate act; forgetting to is what the switch-coverage test below catches.
+const UNFENCED_IN_CHATVIEW = new Set([
+	"action:pending", // a parked write — losing it strands the approval
+	"canvas",
+	"conversation:renamed",
+]);
+
+function onEventBody() {
+	const start = src.indexOf("function onEvent(p) {");
+	assert.notEqual(start, -1, "ChatView must still define onEvent(p)");
+	const end = src.indexOf("\nfunction ", start + 1);
+	assert.notEqual(end, -1, "could not find the end of onEvent");
+	return src.slice(start, end);
+}
+
+test("ChatView imports the SHARED fence, not a local re-implementation", () => {
+	assert.match(
+		src,
+		/import \{ admitEvent, createFence \} from "@jsshared\/pump_fence\.mjs";/,
+		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift"
+	);
+	assert.match(src, /createFence\(\)/, "ChatView must hold a fence instance");
+});
+
+test("onEvent gates on the fence BEFORE the switch, and returns on a drop", () => {
+	const body = onEventBody();
+	const gate = body.indexOf("if (!admitEvent(eventFence, p)) return;");
+	const dispatch = body.indexOf("switch (p.kind) {");
+	assert.notEqual(gate, -1, "the fence gate is missing from onEvent");
+	assert.notEqual(dispatch, -1, "onEvent must still dispatch on p.kind");
+	assert.ok(gate < dispatch, "the gate must run BEFORE any case body mutates state");
+	// The conversation filter still has to come first — fencing frames for other
+	// chats would poison this view's watermarks with another turn's sequence.
+	const convFilter = body.indexOf("if (conv !== convId.value) return;");
+	assert.ok(
+		convFilter !== -1 && convFilter < gate,
+		"the conversation filter must precede the gate"
+	);
+});
+
+test("every pump-sequenced kind ChatView handles is covered by the fence", () => {
+	const body = onEventBody();
+	const kinds = [...body.matchAll(/case "([a-z:]+)":/g)].map((m) => m[1]);
+	assert.ok(
+		kinds.length >= 8,
+		`expected ChatView's switch to still have cases, found ${kinds.length}`
+	);
+	for (const kind of kinds) {
+		assert.ok(
+			FENCED_KINDS.has(kind) || UNFENCED_IN_CHATVIEW.has(kind),
+			`"${kind}" is handled by ChatView but is neither fenced nor a declared bypass — ` +
+				"decide which it is (add it to FENCED_KINDS in pump_fence.mjs, or to " +
+				"UNFENCED_IN_CHATVIEW here with the reason)"
+		);
+	}
+	// The two teardown kinds must be the fence's terminals, or a stale one re-closes
+	// a turn that has already been taken over.
+	for (const terminal of ["run:end", "run:error"]) {
+		assert.ok(kinds.includes(terminal), `ChatView must still handle ${terminal}`);
+		assert.ok(TERMINAL_KINDS.has(terminal), `${terminal} must latch the fence`);
+	}
+});
+
+// The two defects the fence exists to stop, expressed against the shared module
+// with the PWA's own frame shapes.
+test("a superseded pump's cumulative delta is dropped (it would REWIND the reply)", () => {
+	const fence = createFence();
+	const f = (kind, epoch, seq) => ({
+		kind,
+		conversation_id: "c1",
+		run_id: "r1",
+		pump_epoch: epoch,
+		event_seq: seq,
+	});
+	assert.equal(admitEvent(fence, f("run:start", 2, 1)), true);
+	assert.equal(admitEvent(fence, f("assistant:delta", 2, 2)), true);
+	assert.equal(admitEvent(fence, f("assistant:delta", 1, 50)), false, "E-1 straggler dropped");
+	assert.equal(admitEvent(fence, f("assistant:delta", 2, 2)), false, "replay dropped");
+	assert.equal(admitEvent(fence, f("assistant:delta", 2, 3)), true, "real progress still flows");
+});
+
+test("a stale terminal is dropped (it would clear live + fire a redundant load())", () => {
+	const fence = createFence();
+	const f = (kind, epoch, seq) => ({
+		kind,
+		conversation_id: "c1",
+		run_id: "r1",
+		pump_epoch: epoch,
+		event_seq: seq,
+	});
+	admitEvent(fence, f("assistant:delta", 3, 4));
+	assert.equal(admitEvent(fence, f("run:end", 3, 4)), true, "the first terminal must settle");
+	assert.equal(admitEvent(fence, f("run:end", 3, 4)), false, "the backstop repeat is one-shot");
+	assert.equal(
+		admitEvent(fence, f("run:error", 2, 9)),
+		false,
+		"a losing pump's error is dropped"
+	);
+	// A genuine takeover at E+1 still gets to stream and settle.
+	assert.equal(admitEvent(fence, f("assistant:delta", 4, 1)), true);
+	assert.equal(admitEvent(fence, f("run:end", 4, 1)), true);
+});
+
+test("tool frames are fenced too — they carry no message_id to fall back on", () => {
+	const fence = createFence();
+	const f = (kind, epoch, seq) => ({ kind, run_id: "r1", pump_epoch: epoch, event_seq: seq });
+	admitEvent(fence, f("tool:start", 5, 2));
+	assert.equal(admitEvent(fence, f("tool:end", 4, 8)), false);
+	assert.equal(admitEvent(fence, f("tool:end", 5, 3)), true);
+});
+
+test("approvals are never fenced away", () => {
+	const fence = createFence();
+	admitEvent(fence, { kind: "assistant:delta", run_id: "r1", pump_epoch: 9, event_seq: 9 });
+	assert.equal(
+		admitEvent(fence, { kind: "action:pending", run_id: "r1", token: "t1", pump_epoch: 1 }),
+		true,
+		"a parked write must reach the UI whatever the pump did"
+	);
+});

--- a/pwa/src/lib/pumpFence.test.js
+++ b/pwa/src/lib/pumpFence.test.js
@@ -49,14 +49,14 @@ test("ChatView imports the SHARED fence, not a local re-implementation", () => {
 	assert.match(
 		src,
 		/import \{ admitEvent \} from "@jsshared\/pump_fence\.mjs";/,
-		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift"
+		"the fence must come from jarvis/public/js/shared so the widget and the PWA cannot drift",
 	);
 	assert.match(
 		src,
 		/import \{ eventFence \} from "\.\.\/lib\/pump_fence_state\.js";/,
 		"the fence instance must be the MODULE-scope singleton — a component-scope " +
 			"fence is destroyed on every route away from chat (no keep-alive) and " +
-			"readmits the stale frames it exists to drop"
+			"readmits the stale frames it exists to drop",
 	);
 });
 
@@ -78,7 +78,7 @@ test("onEvent gates on the fence BEFORE the switch, and returns on a drop", () =
 	const convFilter = body.indexOf("if (conv !== convId.value) return;");
 	assert.ok(
 		convFilter !== -1 && convFilter < gate,
-		"the conversation filter must precede the gate"
+		"the conversation filter must precede the gate",
 	);
 });
 
@@ -87,14 +87,14 @@ test("every pump-sequenced kind ChatView handles is covered by the fence", () =>
 	const kinds = [...body.matchAll(/case "([a-z:]+)":/g)].map((m) => m[1]);
 	assert.ok(
 		kinds.length >= 8,
-		`expected ChatView's switch to still have cases, found ${kinds.length}`
+		`expected ChatView's switch to still have cases, found ${kinds.length}`,
 	);
 	for (const kind of kinds) {
 		assert.ok(
 			FENCED_KINDS.has(kind) || UNFENCED_IN_CHATVIEW.has(kind),
 			`"${kind}" is handled by ChatView but is neither fenced nor a declared bypass — ` +
 				"decide which it is (add it to FENCED_KINDS in pump_fence.mjs, or to " +
-				"UNFENCED_IN_CHATVIEW here with the reason)"
+				"UNFENCED_IN_CHATVIEW here with the reason)",
 		);
 	}
 	// The two teardown kinds must be the fence's terminals, or a stale one re-closes
@@ -138,7 +138,7 @@ test("a stale terminal is dropped (it would clear live + fire a redundant load()
 	assert.equal(
 		admitEvent(fence, f("run:error", 2, 9)),
 		false,
-		"a losing pump's error is dropped"
+		"a losing pump's error is dropped",
 	);
 	// A genuine takeover at E+1 still gets to stream and settle.
 	assert.equal(admitEvent(fence, f("assistant:delta", 4, 1)), true);
@@ -159,6 +159,6 @@ test("approvals are never fenced away", () => {
 	assert.equal(
 		admitEvent(fence, { kind: "action:pending", run_id: "r1", token: "t1", pump_epoch: 1 }),
 		true,
-		"a parked write must reach the UI whatever the pump did"
+		"a parked write must reach the UI whatever the pump did",
 	);
 });

--- a/pwa/src/lib/pump_fence_state.js
+++ b/pwa/src/lib/pump_fence_state.js
@@ -1,0 +1,17 @@
+// JF-018: the PWA's Relay-Pump fence watermarks, one entry per run_id.
+//
+// MODULE scope on purpose. ChatView is route-mounted, and the PWA router has
+// no <keep-alive>: navigating to /business, /files or / unmounts the component
+// and would destroy a component-scope fence — exactly the window in which a
+// superseded pump's straggler (or the routine duplicate terminal that
+// finalize's terminal_publish re-emits) gets readmitted on return. Desktop
+// never hits this because its ChatView IS the app shell and never unmounts;
+// the widget survives via its own persistent panel state. A module singleton
+// is the PWA's equivalent of "the fence outlives the view".
+//
+// A plain object, not a ref — nothing renders from it, and every delta frame
+// would otherwise pay for a reactive proxy write. Entries are three integers
+// keyed by run_id, so growth across a session is a non-issue.
+import { createFence } from "@jsshared/pump_fence.mjs";
+
+export const eventFence = createFence();

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -15,7 +15,8 @@ import { useRouter } from "vue-router";
 // The desktop SPA's renderer — dependency-free, and sharing it means an agent
 // reply reads identically on both surfaces.
 import { renderMarkdown } from "@shared/markdown.js";
-import { admitEvent, createFence } from "@jsshared/pump_fence.mjs";
+import { admitEvent } from "@jsshared/pump_fence.mjs";
+import { eventFence } from "../lib/pump_fence_state.js";
 import * as api from "../api";
 import { store } from "../store";
 import {
@@ -66,13 +67,11 @@ const live = ref(null); // { runId, messageId, text, tools[] }
 // Stop is a UI-level cancel too — the backend may still finish the turn, so
 // ignore what comes back rather than letting a "stopped" reply reappear.
 const ignoredRuns = ref(new Set());
-// JF-018: the Relay-Pump epoch/seq watermark, one entry per run_id. A plain object,
-// not a ref — nothing renders from it, and every delta frame would otherwise pay for
-// a reactive proxy write. Deliberately NOT cleared when the route switches chats
-// (desktop does the same): the terminal marker has to outlive the view, or coming
-// back to a chat re-opens the stale-frame window it exists to close. Entries are
-// three integers keyed by run_id, so growth is a non-issue.
-const eventFence = createFence();
+// JF-018: the Relay-Pump epoch/seq watermark lives in a MODULE-scope singleton
+// (see ../lib/pump_fence_state.js for why): this component is route-mounted and
+// unmounts on /business, /files or /, so a component-scope fence would be wiped
+// on every route away and readmit the stale frames it exists to drop. The
+// singleton is what actually delivers "the terminal marker outlives the view".
 
 const decision = ref(null);
 const preview = ref(null);

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -15,6 +15,7 @@ import { useRouter } from "vue-router";
 // The desktop SPA's renderer — dependency-free, and sharing it means an agent
 // reply reads identically on both surfaces.
 import { renderMarkdown } from "@shared/markdown.js";
+import { admitEvent, createFence } from "@jsshared/pump_fence.mjs";
 import * as api from "../api";
 import { store } from "../store";
 import {
@@ -65,6 +66,13 @@ const live = ref(null); // { runId, messageId, text, tools[] }
 // Stop is a UI-level cancel too — the backend may still finish the turn, so
 // ignore what comes back rather than letting a "stopped" reply reappear.
 const ignoredRuns = ref(new Set());
+// JF-018: the Relay-Pump epoch/seq watermark, one entry per run_id. A plain object,
+// not a ref — nothing renders from it, and every delta frame would otherwise pay for
+// a reactive proxy write. Deliberately NOT cleared when the route switches chats
+// (desktop does the same): the terminal marker has to outlive the view, or coming
+// back to a chat re-opens the stale-frame window it exists to close. Entries are
+// three integers keyed by run_id, so growth is a non-issue.
+const eventFence = createFence();
 
 const decision = ref(null);
 const preview = ref(null);
@@ -391,6 +399,15 @@ function onEvent(p) {
 	const conv = p.conversation_id || p.conversation;
 	if (conv !== convId.value) return;
 	const ignored = p.run_id ? ignoredRuns.value.has(p.run_id) : false;
+
+	// JF-018: fence out a superseded pump's straggler before it touches anything.
+	// Because a delta carries the CUMULATIVE text, an out-of-order one REWINDS the
+	// reply mid-stream, and a stale run:end/run:error tears down a turn that has
+	// already been taken over. Dropping is invisible to the user: every terminal
+	// path below calls load(), and that durable re-fetch is what converges content.
+	// Same placement and the same kind set as the desktop SPA — see
+	// jarvis/public/js/shared/pump_fence.mjs for the mirrored comparison ladder.
+	if (!admitEvent(eventFence, p)) return;
 
 	switch (p.kind) {
 		case "run:start":

--- a/pwa/vite.config.js
+++ b/pwa/vite.config.js
@@ -96,11 +96,16 @@ export default defineConfig({
 			// means agent replies look the same on both surfaces. It is a
 			// dependency-free module, so importing across apps costs nothing.
 			"@shared": path.resolve(__dirname, "../frontend/src"),
+			// Surface-agnostic chat modules (the Relay-Pump event fence). They live
+			// under jarvis/public/js rather than frontend/src because the Desk widget
+			// is an esbuild bundle that can only reach that tree — see
+			// jarvis/public/js/shared/pump_fence.mjs.
+			"@jsshared": path.resolve(__dirname, "../jarvis/public/js/shared"),
 		},
 		dedupe: ["vue"],
 	},
 	server: {
-		// @shared reaches outside this app's root.
+		// @shared and @jsshared reach outside this app's root.
 		fs: { allow: [".."] },
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## JF-018 — pump correctness fence for the PWA and the embedded widget

**Scope (per the brief):** the two surfaces that live in this repo — the mobile PWA
(`pwa/src/views/ChatView.vue`) and the floating Desk widget
(`jarvis/public/js/jarvis_chat/widget/chat_stream.mjs`). Native mobile is a deferred
follow-up. This is a **correctness fence only** — no queue UI, no recovery UI, no
desktop feature parity.

### The defect

`turn_state.publish_fenced()` stamps every pump-owned realtime frame with
`(run_id/turn_id, pump_epoch, event_seq)` precisely so a client can drop a superseded
writer's straggler. Desktop has done that since CDX-3/CDX-12. The PWA and the widget
consume the **same** frames and had **no fence at all**.

That is not cosmetic here:

* `assistant:delta` carries the **cumulative** text, not an increment. A lower-epoch
  frame landing after a pump handoff or a replay does not lose a token — it **rewinds
  the entire reply** mid-stream.
* A stale `run:end` / `run:error` is worse. On the PWA it clears `live` and fires a
  redundant `load()`; on the widget it clears the live turn and re-raises a dead error
  banner over a turn that has already been taken over.
* Tool frames carry no `message_id`, so nothing else was gating them either.

### Root cause addressed

The fence was built **inside desktop's ChatView** instead of as a shared consumer
contract. This PR makes it one.

### The shared module

`jarvis/public/js/shared/pump_fence.mjs` — plain, dependency-free ESM.

Why that tree and not `frontend/src`: the widget is an **esbuild bundle served into
Desk** and cannot reach a Vue app's sources or the `@/` alias. That constraint is what
forced `panel_readiness.mjs` to be a hand-kept duplicate of
`frontend/src/onboarding/readiness.js`; putting the fence under `jarvis/public/js/`
means all three surfaces can reach it and we do not repeat that mistake. Verified by
actually bundling the widget entry with frappe's own esbuild options (see Tests).

* `fenceKey` / `fenceReject` / `fenceAccept` are copied **verbatim** from
  `frontend/src/utils/eventFence.js` (lines 35–79 at this snapshot), which is itself
  the extraction of `frontend/src/views/ChatView.vue`'s `pumpFenceReject` /
  `pumpFenceAccept` (lines 4006–4012, applied at 7156-7157, 7174-7175, 7223-7224,
  7241-7242, 7254-7255, 7279-7280, 7380-7381). Cited in the module header.
* `admitEvent(fence, payload)` wraps the reject-then-accept pair plus the kind sets, so
  a consumer physically cannot wire up half of the contract (the classic
  "checked but never recorded" fence bug).
* `FENCED_KINDS` = `run:start`, `run:recovering`, `assistant:delta`, `tool:start`,
  `tool:end`, `run:end`, `run:error` — exactly the kinds desktop fences.
  `TERMINAL_KINDS` = `run:end`, `run:error` — exactly the two desktop passes
  `isTerminal: true` for. Everything else (approvals, `canvas`, renames, `run:status`,
  queue events) bypasses, as it does on desktop.
* Legacy frames with no `pump_epoch` bypass entirely — unchanged behaviour.

### Applied

* **PWA** — one gate at the top of `onEvent`, after the conversation filter and before
  the switch. Same placement as desktop.
* **Widget** — one gate at the top of the `applyEvent` reducer. The watermark is
  carried *in* the reducer state (shallow-copied like every other field) so the reducer
  stays pure and `Panel.vue` never has to know the fence exists.

On a drop there is **no user-visible behaviour**: every terminal path on both surfaces
re-fetches the durable conversation over HTTP, and that reconciliation is what
converges content.

### Desktop is untouched

Per requirement 3 — JF-013 owns that refactor. **The module can be adopted by desktop
verbatim**: `fenceReject`/`fenceAccept` are byte-identical to
`frontend/src/utils/eventFence.js`, so that file can become a re-export (or be deleted
and its import path repointed) without touching ChatView's logic. Until then the two
copies are locked together by an **exhaustive 1728-walk decision-parity test**, not by
a comment — every ordered 3-frame walk over {2 epochs × 3 seqs × terminal?} is replayed
through both modules and asserted to produce identical decisions *and* identical state.
Verified to actually bite: flipping one comparison in desktop's copy fails the suite
with `decision drift on epoch=1 seq=1 terminal=true`.

### Tests

`jarvis/tests/test_pump_fence_shared_client.py` subprocess-runs three `node --test`
suites, so all of this is enforced by the python suite on every CI run (same pattern as
the existing `test_event_fence_client.py`):

| suite | covers |
|---|---|
| `jarvis/public/js/shared/pump_fence.test.mjs` (15 tests) | stale epoch, stale seq, terminal latch + one-shot repeat, epoch-bump watermark reset, run scoping, tool frames, legacy bypass, unfenced-kind pass-through, **+ the parity walk** |
| `jarvis/public/js/jarvis_chat/widget/chat_stream.test.mjs` (29 tests, 9 new) | the reducer actually applying it: no rewind, no double reload, no stale teardown, recovery still flows, approvals never fenced away, state never mutated |
| `pwa/src/lib/pumpFence.test.js` (8 tests) | the PWA's wiring |

**On the PWA's coverage, honestly:** the PWA has no component harness — no vitest, no
`@vue/test-utils`, and mounting `ChatView` needs a router, a socket and the whole api
surface. Rather than "document manual verification", the gate is asserted against the
**source**: that ChatView imports the shared module, that the gate sits between the
conversation filter and the switch, and — the useful one — that **every `case` label in
the switch is either in `FENCED_KINDS` or on an explicit bypass list**. Add a new
pump-sequenced kind to that switch without fencing it and the test tells you. Crude,
but it is a real regression guard rather than a promise.

### What was run locally

* `node --test` on all three suites — 15 / 29 / 31 pass (the PWA number is its whole
  `npm test`, i.e. the 8 new tests plus the pre-existing lib suite), 0 fail.
* `bench --site patterntest.localhost run-tests --app jarvis --module jarvis.tests.test_pump_fence_shared_client` → **3 tests, OK**
  (run with `PYTHONPATH=<worktree>` so the bench executed *this branch*, not the
  canonical checkout).
* `... --module jarvis.tests.test_event_fence_client` → **1 test, OK** (desktop's fence
  still green).
* `cd pwa && npm run build` → green; confirmed the fence is present in the emitted
  `ChatView-*.js` chunk.
* `cd frontend && npm run build` → green (untouched, checked for collateral damage).
* **Widget bundle:** reproduced frappe's `bench build` esbuild invocation
  (`get_build_options` from `frappe/esbuild/esbuild.js`, same target / `bundle` /
  `nodePaths` / `esbuild-plugin-vue3`) against this worktree's
  `jarvis_widget.bundle.js` entry → build OK, and the metafile confirms
  `shared/pump_fence.mjs` is in the module graph. Done this way rather than via
  `bench build --app jarvis`, which would have built the canonical checkout on `develop`
  instead of this branch.
* `pre-commit run --from-ref origin/develop --to-ref HEAD` → all hooks pass (prettier,
  eslint, ruff).

### Risks / follow-ups

* **The widget's fence resets on `startNewChat()`** (it calls `emptyStream()`, which now
  includes the watermark). That is the pre-existing full-state reset and it is the right
  bound for the widget's lifetime, but it does mean a brand-new chat starts unfenced —
  correct, since a new conversation has new `run_id`s. The PWA and desktop never reset.
* **`FENCED_KINDS` includes `run:recovering`**, which neither of these two surfaces
  currently handles. Harmless (nothing dispatches it) and it keeps the set identical to
  desktop's, which is what the parity story depends on.
* **Panel.vue's `stopPolling()` still runs on a dropped frame.** Deliberately left
  alone: receiving *any* frame proves realtime is alive, so it is arguably correct, and
  changing it is outside this fence.
* **Native mobile (`jarvis_mobile`) is still unfenced** — deferred per the brief because
  B5 is concurrently touching its chat surface. It should consume this same module (or
  a port of it) in the follow-up.
* Desktop consolidation is JF-013's; the parity test is the interim guard.
