### PR TITLE
fix(chat): share one model-pin allowlist between the two write paths

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -79,6 +79,22 @@ from jarvis._subscription_models import (
 
 _ALLOWED_THINKING = {"", "low", "medium", "high"}
 
+
+def _allowed_pin_models(settings) -> set[str]:
+	"""Every model id a conversation may be pinned to for this tenant: the provider's
+	subscription allowlist unioned with every enabled row of the LLM pool
+	(Jarvis Settings.models). The pool matters because a subscription/pool customer
+	stores llm_provider="", for which _SUBSCRIPTION_MODELS yields [] -- so checking
+	only that rejects every pin. Single source of truth so the two write paths
+	(set_conversation_model and send_message) cannot drift apart again.
+	"""
+	allowed = set(_SUBSCRIPTION_MODELS.get(settings.llm_provider, []))
+	allowed |= {
+		(m.model or "").strip() for m in (settings.models or []) if m.enabled and (m.model or "").strip()
+	}
+	return allowed
+
+
 # Curated dashboard canvas theme keys (lowercase) the builder may forward in the
 # send context — a literal allow-list (not passthrough), mirrors the DocType
 # `theme` Select + frontend/src/lib/dashboardThemes.js.
@@ -952,8 +968,12 @@ def send_message(
 	# worker may pick up the run before the DB write commits.)
 	if model_override:
 		settings = frappe.get_single("Jarvis Settings")
-		allowed = _SUBSCRIPTION_MODELS.get(settings.llm_provider, [])
-		if model_override not in allowed:
+		# Union of subscription allowlist + enabled pool rows (see _allowed_pin_models).
+		# Previously this checked only _SUBSCRIPTION_MODELS, which is [] for a
+		# subscription/pool tenant (llm_provider=""), so every pin sent through this
+		# path -- the PWA new-chat path -- was rejected even though
+		# set_conversation_model already accepted it.
+		if model_override not in _allowed_pin_models(settings):
 			return {
 				"ok": False,
 				"reason": f"model {model_override!r} is not valid for {settings.llm_provider!r}",
@@ -1597,16 +1617,9 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 		frappe.db.commit()
 		return {"ok": True, "data": {"effective_model": settings.llm_model or ""}}
 
-	# A pin must name a model the customer actually has. Two sources, unioned:
-	# the provider's subscription allowlist, and every enabled row of the LLM
-	# pool (Jarvis Settings.models). The pool matters because a subscription
-	# customer stores llm_provider="", for which _SUBSCRIPTION_MODELS yields []
-	# - so before this union EVERY pin was rejected as "unknown_model" and the
-	# picker could not set a model at all.
-	allowed = set(_SUBSCRIPTION_MODELS.get(settings.llm_provider, []))
-	allowed |= {
-		(m.model or "").strip() for m in (settings.models or []) if m.enabled and (m.model or "").strip()
-	}
+	# A pin must name a model the customer actually has (subscription allowlist unioned
+	# with the enabled LLM-pool rows). send_message applies the identical check.
+	allowed = _allowed_pin_models(settings)
 	if model not in allowed:
 		return {
 			"ok": False,

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -6,6 +6,8 @@ real chat history previously wiped that history; the fixture user keeps
 test cleanups scoped to disposable rows.
 """
 
+import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import frappe
@@ -1048,3 +1050,37 @@ class TestConversationOwnershipEnforcement(_ChatTestCase):
 			self.assertTrue(send_message(self.conv, "hello")["ok"])
 			self.assertTrue(retry_message(self.asst_msg)["ok"])
 		self.assertTrue(archive_conversation(self.conv)["ok"])
+
+
+class TestAllowedPinModels(unittest.TestCase):
+	"""_allowed_pin_models is the single source of truth both set_conversation_model
+	and send_message validate against, so the two cannot drift (the send_message path
+	used to check only the subscription allowlist and rejected every pool pin)."""
+
+	@staticmethod
+	def _settings(provider, pool):
+		return SimpleNamespace(
+			llm_provider=provider,
+			models=[SimpleNamespace(model=m, enabled=e) for m, e in pool],
+		)
+
+	def test_pool_rows_are_unioned_for_a_subscription_tenant(self):
+		from jarvis.chat import api
+
+		# A subscription/pool tenant stores llm_provider="", so the subscription
+		# allowlist is empty and the pin must be accepted from the enabled pool rows.
+		with patch.object(api, "_SUBSCRIPTION_MODELS", {"": [], "OpenAI": ["gpt-5.6"]}):
+			allowed = api._allowed_pin_models(
+				self._settings("", [("claude-sonnet-5", 1), ("glm-4.7", 1), ("retired", 0)])
+			)
+		self.assertIn("claude-sonnet-5", allowed)
+		self.assertIn("glm-4.7", allowed)
+		self.assertNotIn("retired", allowed)  # disabled pool rows are excluded
+		self.assertNotIn("gpt-5.6", allowed)  # not this tenant's subscription list
+
+	def test_subscription_models_are_included(self):
+		from jarvis.chat import api
+
+		with patch.object(api, "_SUBSCRIPTION_MODELS", {"OpenAI": ["gpt-5.6", "gpt-5.5"]}):
+			allowed = api._allowed_pin_models(self._settings("OpenAI", []))
+		self.assertEqual(allowed, {"gpt-5.6", "gpt-5.5"})


### PR DESCRIPTION
## What

`send_message`'s inline `model_override` check validated only against `_SUBSCRIPTION_MODELS`, but `set_conversation_model` validates against that **unioned** with the enabled LLM-pool rows. A subscription/pool tenant stores `llm_provider=""`, so the subscription list is empty and `send_message` (the **PWA new-chat** path) rejected every pinned model even though the desktop picker already accepted it.

Fix: extract the union into one `_allowed_pin_models()` helper used by **both** paths, so they cannot drift again.

## Scope (narrowed after review)

An earlier draft also added a direct-mode stale-pin fallback in `turn_handler`. A high code-review found it **silently substitutes a model on the macro path** (macros set `model_override` directly, bypassing the allowlist), so it was **dropped**. A correct version must distinguish "removed from the catalog" from "valid but not pooled", and only matters once a model is actually removed — deferred.

## Tests + CI

`TestAllowedPinModels`: pool-row union, disabled-row exclusion, subscription inclusion. All existing `set_conversation_model` tests unchanged.

Local CI (this repo's real ci.yml in docker) on commit `d90b6bd8`: **PASS — lint 4/4, all four shards 9/9, coverage 5/5**. Report posted as a comment. Green **locally only** (hosted Actions is billing-exhausted; the comment sets no check and runs linux/arm64 vs GitHub's amd64).

https://claude.ai/code/session_01L2wrSyotAhtDHXWq72f67m