### PR TITLE
fix(settings): ConfirmDialog receives clicks over the modal settings dialog (completes #435)

### DIFF
--- a/frontend/src/components/shell/ConfirmDialog.vue
+++ b/frontend/src/components/shell/ConfirmDialog.vue
@@ -81,6 +81,13 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKey, true));
 	position: fixed;
 	inset: 0;
 	z-index: 200;
+	/* The settings dialog is a MODAL frappe-ui/reka Dialog, and while it is open
+	   reka sets `pointer-events: none` inline on <body> so nothing outside the
+	   modal can be clicked. This overlay is teleported to <body>, so it inherits
+	   that lock: it paints correctly above the settings dialog but every click
+	   falls through, leaving Cancel/confirm dead. Opting back in is what makes
+	   the buttons reachable. Teleport alone was not enough (jarvis#435). */
+	pointer-events: auto;
 	background: rgba(15, 15, 22, 0.34);
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## What

Add `pointer-events: auto` to the shell `ConfirmDialog` overlay. **Completes #435** — #438 was necessary but not sufficient.

## Why #438 alone did not fix it

#438 teleported the confirm overlay to `<body>` so it stops being trapped in the app-root stacking context. That part works: the confirm now *paints* above the settings dialog.

But it was still unusable. The settings dialog is a **modal** frappe-ui/reka `Dialog`, and while it is open reka sets `pointer-events: none` **inline on `<body>`** so nothing outside the modal can be clicked. The teleported overlay is a direct child of `<body>`, so it inherits that lock. Result: the confirm rendered correctly on top while every click fell straight through it — Cancel and the destructive action were both dead, and Escape did not dismiss it either, so the only way out was a page reload.

This is why the original issue reproduced even after #438 shipped.

## Change

One property on `.jv-confirm-overlay`:

```css
pointer-events: auto;
```

A child may re-enable pointer events under a `pointer-events: none` ancestor, so this restores interactivity for the confirm **without** unlocking the rest of the page — the modal lock on `<body>` stays intact.

## Verification (live, on jarvis.proxy, deployed build)

Measured in-browser with the built bundle loaded (`index-Bo5yaI73.js`), settings dialog open, `Delete all` triggered:

```
bodyPointerEvents:      "none"        <- modal lock still intact (correct)
overlayPointerEvents:   "auto"        <- the fix
overlayParent:          "BODY"        <- #438 teleport
overlayZ:               "200"
topAtConfirmCenter:     "jv-cdialog-msg"
topIsInsideConfirm:     true          <- was false before
buttons: [ {Cancel, clickable: true}, {Delete everything, clickable: true} ]
```

Before this change, on the same build, both buttons measured `clickable: false` and the top element at the confirm's centre was a settings-dialog text node.

Also confirmed by real interaction, not just measurement: a real mouse click on **Cancel** dismisses the confirm, `body` returns to `pointer-events: auto`, and no data is deleted (conversation count unchanged). Settled-state rendering verified visually: opaque dialog surface, backdrop dimming the settings dialog, no bleed-through.

## Note for the reviewer

Dismissing the confirm also closes the settings dialog underneath it (the click counts as "outside" for reka's outside-click detection). That is a separate, pre-existing UX wrinkle that only became reachable now that the confirm is clickable at all — not addressed here. Happy to file it separately if you want it changed.

https://claude.ai/code/session_01SQP9soragWeg78WzaRimoj
