### PR TITLE
chore(onboarding): stop fetching the LLM preset catalog during onboarding

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2868,10 +2868,17 @@ async function load() {
 	} catch (e) {
 		/* non-fatal */
 	}
-	try {
-		catalog.value = (await api.getPresetCatalog()) || [];
-	} catch (e) {
-		/* backend bundled fallback */
+	// Onboarding (singleMode) never renders the preset picker (modes=['quick']
+	// hides the "From a preset" tab, which is disabled/"Soon" anyway) and
+	// nothing in the singleMode branch reads `catalog`, so skip the fetch
+	// there. The Account/Settings editor (!singleMode) still loads it for
+	// resilient-by-default backups (expandApiKeyBackups) and the preset tab.
+	if (!singleMode.value) {
+		try {
+			catalog.value = (await api.getPresetCatalog()) || [];
+		} catch (e) {
+			/* backend bundled fallback */
+		}
 	}
 	try {
 		modelCatalog.value = (await api.getModelCatalogUi()) || modelCatalog.value;


### PR DESCRIPTION
## What

Onboarding runs `LlmPoolEditor` in `singleMode` (`:modes="['quick']"`), which never renders the preset picker (the "From a preset" tab is hidden, and disabled/"Soon" anyway) and never reads `catalog`. But `load()` fired `api.getPresetCatalog()` on **every mount regardless of mode**, so the onboarding connect step was making a real, unused network call to the preset catalog.

Fix (one line): gate the preset fetch behind `!singleMode`. Onboarding no longer calls it; the Account/Settings editor (`!singleMode`) still loads it for the preset tab and resilient-by-default backups.

## Scope

- **Backend untouched**: `get_preset_catalog` and `admin_client.get_preset_catalog` stay (per request: "backend APIs can be there, no client-side calls in onboarding").
- **Separate provider/model catalog untouched**: `getModelCatalogUi`, `subscription_connect_providers` / `DirectSubscriptionCard`, and the model datalist are unaffected.
- Onboarding is visually and behaviorally identical (the preset picker was never shown there); only the unused background fetch is gone.
- Out of scope, left alone: the legacy Frappe desk page `jarvis_account.js` has its own preset consumption.

## Verified

prettier 2.7.1 (CI's version) clean; `@vue/compiler-sfc` compiles the SFC; no dangling preset references remain in the SPA.

Local CI on `6b702d58`: **PASS — lint 4/4, all four shards 9/9, coverage 5/5**. Green locally only (hosted Actions billing-exhausted).

https://claude.ai/code/session_01L2wrSyotAhtDHXWq72f67m