### PR TITLE
fix(build): exclude frappe-ui from dev dependency pre-scan

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -25,5 +25,9 @@ export default defineConfig({
 	},
 	optimizeDeps: {
 		include: ["frappe-ui > feather-icons", "showdown", "engine.io-client"],
+		exclude: ["frappe-ui"],
+	},
+	server: {
+		allowedHosts: true,
 	},
 });


### PR DESCRIPTION
## What this fixes

Running `vite dev` from a git worktree crashed on the first real page request with 31 unresolved `~icons/lucide/*` imports coming out of frappe-ui's own `TextEditor/commands.js`, hit during esbuild's dependency pre-scan. Nothing in this app imports frappe-ui's TextEditor, so the crash was entirely a side effect of the pre-scan crawling into a part of frappe-ui this app never uses.

Because of that crash, no frontend change could be verified live from a worktree, so UI PRs in this repo have been shipping without live verification. This PR exists specifically to unblock that: it lets a worktree dev server come up cleanly so future frontend PRs can be checked against a real running server instead of only against the build.

## The fix

`frontend/vite.config.js`:
- `optimizeDeps.exclude: ["frappe-ui"]` stops the dependency pre-scan from crawling into frappe-ui's own source, which is what was pulling in the unrelated TextEditor icon imports.
- `server.allowedHosts: true` lets the dev server accept requests whose Host header does not match localhost, which is needed when the server is reached through a worktree path or non-default hostname.

## Why this does not conflict with the existing `optimizeDeps.include`

The config already had `optimizeDeps.include: ["frappe-ui > feather-icons", ...]` for `FeatherIcon.vue`, which does need feather-icons pre-bundled. I confirmed the new `exclude: ["frappe-ui"]` does not break that: Vite treats a scoped `"pkg > subpkg"` specifier as distinct from the bare package name, so excluding `frappe-ui` itself does not pull the nested `frappe-ui > feather-icons` entry out of the optimizer.

Verified live against a worktree dev server on port 8082:
- `node_modules/.vite/deps/_metadata.json` shows `"frappe-ui > feather-icons"` present under `optimized`, and bare `"frappe-ui"` absent (consistent with exclude).
- `curl http://127.0.0.1:8082/node_modules/frappe-ui/src/components/FeatherIcon.vue` returns the transformed module importing `/node_modules/.vite/deps/frappe-ui___feather-icons.js`, i.e. still pre-bundled and resolving correctly.
- `curl http://127.0.0.1:8082/` returns 200, ~2490 bytes, contains `<title>Jarvis Chat</title>`, `/@vite/client`, and `src="/src/main.js"`.
- `curl http://127.0.0.1:8082/src/main.js` transforms cleanly, resolves frappe-ui, no icons error.

## Why this is dev-only

`optimizeDeps` and `server` are both Vite dev-server-only config sections; `vite build` does not read either. Confirmed by actually running the build rather than just citing the docs:

```
npm run build
```
`vite v5.4.21 building for production...`
`5160 modules transformed.`
`built in 21.82s`

No errors. The only warning is the pre-existing "some chunks are larger than 500 kB" advisory, unrelated to this change and present before it.

## Scope

`wiki-graph-core/package-lock.json` had 11 lines of incidental churn (peer-dependency flag additions and a re-resolved `graphology-types` entry) sitting uncommitted alongside this fix in the worktree it came from. That churn is unrelated to the vite config change and to a different package entirely, so it was left out of this PR.

## CI

No local CI evidence on this PR (`JCI_SKIP=1`). The local `jarvis-ci` harness is unreliable for this repo right now: one of its suites runs 12 containers on a 9.7 GB Colima VM and concurrent runs OOM. Hosted GitHub Actions is the real gate here and is working (the "billing exhausted" message in the local pre-PR hook is stale).

Claude-Session: https://claude.ai/code/session_01BXaYUhmfKv15hAw4KY5tQF
