### PR TITLE
fix(chat): tell the truth about voice clips a send left behind

### DIFF
--- a/design.md
+++ b/design.md
@@ -547,6 +547,31 @@ three times. Recipe:
 - A `FormControl` paste field (never a bare `<textarea>`), inline `ErrorMessage` for
   expired/invalid-nonce errors, countdown hint in `text-p-sm text-ink-gray-5`.
 
+### 4.5 Voice capture — two surfaces, two retention models (say which one you are)
+
+Jarvis has **two** voice-recording surfaces with deliberately different contracts, and a user who
+learns one carries its expectations to the other. State which one a new surface implements.
+
+- **Chat composer dictation** (`useChunkedRecorder` + `utils/voiceChunkQueue.js`, ChatView): long
+  takes chunked into self-contained clips, transcribed independently, **audio retained** in an
+  IndexedDB mirror until its text is part of an accepted send. Anything unresolved is **visible and
+  actionable as a chip** — a failed clip (Retry/Download/✕), a clip edited out before sending
+  (Restore/Download/✕), a clip whose audio could not be saved (Download/Retry) — plus a
+  previous-session recovery banner. Nothing is ever removed silently except the success path
+  (chips clear on the send that carried their words; no toast — that would be noise on the common
+  case).
+- **Single-shot capture** (`useAudioRecorder`, `VoiceRecorder.vue` — wiki nudge, Business tab):
+  record → transcribe → text, **no retention, no chips, no recovery**. A failure is a toast and a
+  re-record, and the audio is gone.
+
+Rules for either: chip copy must distinguish "not sent yet" from "already sent without this"
+(identical copy for both is what makes a correctly-retained clip read as a stuck one); an action's
+tooltip must promise only what it can do *now* (Retry cannot edit a message that has already been
+sent — it builds a follow-up); and a leave/close warning may claim loss **only** when something is
+genuinely at risk — durably mirrored, re-offerable clips must not arm it (a warning that cries
+wolf gets trained away). If a new surface wants the chip model, reuse the queue rather than growing
+a third contract.
+
 ---
 
 ## 5. Do / Don't — current Jarvis anti-patterns

--- a/frontend/src/utils/voiceChipLifecycle.test.js
+++ b/frontend/src/utils/voiceChipLifecycle.test.js
@@ -1,0 +1,294 @@
+// UX chip-lifecycle wiring: the ChatView half of the voice-clip retention story.
+//
+// The queue primitive's half (markSentWithoutClip, snapshot().failed[].sentWithout,
+// hasUnfinishedReason) is proven behaviorally in voiceChunkQueue.test.js against the real module.
+// What CANNOT be proven there is whether ChatView actually calls it at the right moment and says
+// the right thing: the composer is a single-file component with no harness in this app (no vitest,
+// no @vue/test-utils; mounting it would need a router, a socket and the whole api surface), so —
+// exactly like pwa/src/lib/pumpFence.test.js — the wiring is asserted against the SOURCE.
+//
+// Crude, but a real regression guard: it fails the moment the send-time gap confirm is removed or
+// moved after the strip, the sent-without flagging drifts out of the accepted-send branch, a chip's
+// copy stops branching on `sentWithout`, the retry-after-send toast disappears, or the leave guard
+// goes back to arming on "anything outstanding" (the cry-wolf warning UX-3 removed).
+//
+// It also fences the ONE path this change must not regress: the done-clip
+// captureSentInPayload → acknowledge release, which has its own extensive suites.
+//
+// Run: `node --test voiceChipLifecycle.test.js`, or via the python suite
+// (jarvis/tests/test_voice_chip_lifecycle_client.py subprocess-runs it every CI run).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createVoiceChunkQueue } from "./voiceChunkQueue.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CHAT_VIEW = path.join(HERE, "..", "views", "ChatView.vue");
+const src = fs.readFileSync(CHAT_VIEW, "utf8");
+
+function sendBody() {
+	const start = src.indexOf("async function send(textArg, resendAck) {");
+	assert.notEqual(start, -1, "ChatView must still define send(textArg, resendAck)");
+	const end = src.indexOf("\nfunction openProactive()", start);
+	assert.notEqual(end, -1, "could not find the end of send()");
+	return src.slice(start, end);
+}
+
+// ── the ⟦clip N⟧ token has ONE definition ───────────────────────────────────────
+test("the gap token is read and stripped through the SAME regex — tokens found == tokens stripped", () => {
+	assert.match(
+		src,
+		/const _GAP_TOKEN_RE = \/⟦clip \\d\+⟧\/g;/,
+		"the token shape must stay a single constant"
+	);
+	assert.match(
+		src,
+		/function _stripGapTokens\(s\) \{\n\treturn \(s \|\| ""\)\.replace\(_GAP_TOKEN_RE, ""\)/,
+		"the strip must use the shared constant"
+	);
+	assert.match(
+		src,
+		/function _gapSeqsIn\(s\) \{[\s\S]*?matchAll\(_GAP_TOKEN_RE\)/,
+		"…and so must the seq reader, or a send could strip a token it never counted"
+	);
+	// seq+1 is the chip's label AND the token's number: the reader must undo that, not guess.
+	assert.match(
+		src,
+		/function _gapSeqsIn\(s\) \{[\s\S]*?out\.push\(n - 1\);/,
+		"_gapSeqsIn must convert the token's 1-based clip number back to the 0-based seq"
+	);
+});
+
+// ── UX-2: the send-time gap confirmation, BEFORE anything is stripped or sent ───
+test("send() confirms before sending a payload that is missing a clip's words — ahead of the strip", () => {
+	const body = sendBody();
+	const read = body.indexOf("let _gapSeqsInText = fromMain ? _gapSeqsIn(input.value) : [];");
+	const confirmAt = body.indexOf('title: "Send without part of what you said?"');
+	const strip = body.indexOf("const text = _stripGapTokens(fromMain ? input.value : textArg);");
+	const post = body.indexOf("await api.sendMessage(");
+	assert.notEqual(read, -1, "the gap seqs must be read from the RAW composer text");
+	assert.notEqual(confirmAt, -1, "the send-time gap confirmation is missing");
+	assert.notEqual(strip, -1, "send() must still strip the placeholders from the payload");
+	assert.ok(read < confirmAt, "the confirm needs the seqs it is confirming about");
+	assert.ok(
+		confirmAt < strip && confirmAt < post,
+		"the confirm must run BEFORE the tokens are stripped and before the POST — after either, " +
+			"the words are already gone from a message the user never agreed to send incomplete"
+	);
+	assert.match(
+		body,
+		/"One voice clip didn't transcribe, so part of your dictation is missing from this message\. Send anyway, or fix it first\?"/,
+		"the single-gap copy must name what is actually missing"
+	);
+	assert.match(
+		body,
+		/confirmLabel: "Send anyway",\n\t\t\tcancelLabel: "Review first",/,
+		"Review first must be the cancel path — cancelling returns to the composer, it does not send"
+	);
+	assert.match(
+		body,
+		/if \(!ok\) return; \/\/ focus returns to the composer/,
+		"cancel must ABORT the send, leaving the placeholder + chip in place to act on"
+	);
+	// A resend is re-sending a payload the user already chose to send with the gap in it.
+	assert.match(
+		body,
+		/let _gapSeqsInText = fromMain \?/,
+		"the confirm (and the flagging) is fromMain-only — a resendFailed must not re-ask"
+	);
+});
+
+// ── UX-1: flag the sent-without clips, but ONLY on an accepted send ─────────────
+test("send() flags sent-without clips only in the accepted-send branch, after the release", () => {
+	const body = sendBody();
+	const ack = body.indexOf("if (_voiceAck) voiceQueue?.acknowledge(_voiceAck);");
+	const mark = body.indexOf("voiceQueue.markSentWithoutClip(_gapSeq)");
+	const rejected = body.indexOf("if (r && r.ok === false) {");
+	assert.notEqual(ack, -1, "the done-clip release must still run on acceptance (fenced path)");
+	assert.notEqual(mark, -1, "failed clips carried by an accepted send must be flagged");
+	assert.ok(
+		rejected !== -1 && mark > rejected,
+		"the flagging must sit after the rejection branch — a rejected send left the words in the composer"
+	);
+	assert.ok(
+		mark > ack,
+		"flag alongside the release, in the same accepted-send branch, so both describe the SAME payload"
+	);
+	assert.match(
+		body,
+		/if \(fromMain && voiceQueue\)\n\t\t\tfor \(const _gapSeq of _gapSeqsInText\) voiceQueue\.markSentWithoutClip\(_gapSeq\);/,
+		"every gap the payload carried is flagged (the queue ignores any that is no longer failed)"
+	);
+});
+
+// ── UX-1: the chip's copy branches on sentWithout ───────────────────────────────
+test("the failed chip and its Retry tooltip branch on sentWithout", () => {
+	assert.match(
+		src,
+		/{{ failedChipLabel\(f\) }}/,
+		"the failed chip's label must come from the branching helper, not a fixed string"
+	);
+	assert.match(
+		src,
+		/:title="failedChipRetryTitle\(f\)"/,
+		"…and so must its Retry tooltip: post-send it can only build a follow-up"
+	);
+	assert.match(
+		src,
+		/f\.sentWithout\n\t\t\? `Clip \$\{f\.seq \+ 1\} was missing from your last message`\n\t\t: `Clip \$\{f\.seq \+ 1\} didn't transcribe`/,
+		"the two states must read differently — identical copy is what makes a retained clip look stuck"
+	);
+	assert.match(
+		src,
+		/f\.sentWithout\n\t\t\? "Transcribe and add as a follow-up message"/,
+		"the post-send tooltip must not promise to edit a message that has already gone"
+	);
+	assert.match(
+		src,
+		/: "Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong"/,
+		"the PRE-send tooltip is unchanged — it is accurate while the placeholder is still there"
+	);
+});
+
+// ── UX-4: the retry-after-send append is explained ──────────────────────────────
+test("_replaceGapPlaceholder toasts when it appends instead of replacing", () => {
+	const start = src.indexOf("function _replaceGapPlaceholder(seq, text, clip) {");
+	assert.notEqual(start, -1, "ChatView must still define _replaceGapPlaceholder");
+	const body = src.slice(start, src.indexOf("\nfunction _removeGapPlaceholder", start));
+	assert.match(
+		body,
+		/appendedInstead = !!t;\n\t\treturn t \? _joinAppend\(prev, t\) : prev;/,
+		"the fallback-append branch (token gone — the message already left) must be detectable"
+	);
+	assert.match(
+		body,
+		/if \(appendedInstead\)\n\t\tnotify\(`Recovered text for Clip \$\{seq \+ 1\} added to your draft\.`, \{ type: "info" \}\);/,
+		"…and announced, or unexplained text just appears in an otherwise-empty composer"
+	);
+	assert.ok(
+		body.indexOf("appendedInstead = !!t") < body.indexOf("if (appendedInstead)"),
+		"the flag is set inside the mutation and read after it"
+	);
+	// The IN-PLACE replacement is the normal path and must stay silent.
+	assert.match(
+		body,
+		/if \(prev\.includes\(tok\)\) \{\n\t\t\treturn t\n\t\t\t\t\? prev\.split\(tok\)\.join\(t\)/,
+		"a token that IS still there is replaced in place, with no toast"
+	);
+});
+
+// ── UX-3: the leave guard arms on the REASON, not on "anything outstanding" ─────
+test("the leave guard blocks only for a live loss risk, and keeps its copy verbatim for that case", () => {
+	assert.match(
+		src,
+		/function _voiceGuardReason\(\) \{/,
+		"the guard must read the queue's reason, not a bare boolean"
+	);
+	assert.match(
+		src,
+		/return \(voiceQueue && voiceQueue\.hasUnfinishedReason\(\)\) \|\| null;/,
+		"the reason comes from the queue — one source of truth for what is at risk"
+	);
+	assert.doesNotMatch(
+		src,
+		/voiceQueue\.hasUnfinished\(\)/,
+		"the old arm-on-anything predicate must be gone from the guard path (it cried wolf for " +
+			"terminally-failed clips whose audio is durably mirrored)"
+	);
+	assert.match(
+		src,
+		/function _beforeUnloadVoice\(e\) \{\n\tif \(_voiceGuardReason\(\) === "live"\) \{/,
+		"beforeunload arms for a live risk ONLY"
+	);
+	assert.match(
+		src,
+		/onBeforeRouteLeave\(async \(\) => \{\n\tif \(_voiceGuardReason\(\) !== "live"\) return true;/,
+		"…and so does the route-leave confirm: unresolved must not block navigation at all"
+	);
+	// The live case is a REAL risk — its copy is accurate and stays exactly as it was.
+	assert.match(
+		src,
+		/title: "Leave with un-transcribed audio\?",\n\t\tmessage:\n\t\t\t"Some dictated voice clips haven't finished transcribing\. Leaving now may lose audio that hasn't been saved yet\. Leave anyway\?",/,
+		"the live-risk copy is unchanged — it was always accurate for that case"
+	);
+	// A recording (or a take starting) is live before any clip exists.
+	assert.match(
+		src,
+		/micState\.value === "recording" \|\|[\s\S]*?micRec\.starting\n\t\)\n\t\treturn "live";/,
+		"a live take still arms the guard before the queue has anything in it"
+	);
+});
+
+// ── the fenced path: the done-clip release is untouched ─────────────────────────
+test("the done-clip captureSentInPayload → acknowledge release is untouched", () => {
+	const body = sendBody();
+	assert.match(
+		body,
+		/const _voiceAck =\n\t\tresendAck \|\|\n\t\t\(fromMain && voiceQueue \? voiceQueue\.captureSentInPayload\(_sentScope, text\) : null\);/,
+		"the payload-bound token is still captured from the EXACT outgoing text, before the POST"
+	);
+	assert.ok(
+		body.indexOf("voiceQueue.captureSentInPayload(_sentScope, text)") <
+			body.indexOf("await api.sendMessage("),
+		"…and still captured BEFORE the POST (R2-1: a clip committing mid-flight is not released)"
+	);
+	assert.match(
+		body,
+		/if \(fromMain && voiceQueue\) voiceQueue\.markUnsentOrphans\(_sentScope, _voiceAck\);/,
+		"the edited-out retained-clip path (VR4-1) is unchanged"
+	);
+});
+
+// ── decision parity: the queue behaves the way the wiring above assumes ─────────
+test("parity: a stripped gap + a released done clip leave exactly one flagged chip and no live guard", async () => {
+	const flush = () => new Promise((r) => setTimeout(r, 0));
+	const settle = [];
+	const q = createVoiceChunkQueue({
+		transcribe: (clip) => new Promise((res, rej) => settle.push({ seq: clip.seq, res, rej })),
+		mirror: {
+			store: new Map(),
+			put(c) {
+				this.store.set(c.seq, c);
+			},
+			delete(s) {
+				this.store.delete(s);
+			},
+			all() {
+				return [...this.store.values()];
+			},
+		},
+		retainUntilSent: true,
+		concurrency: 2,
+		maxAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "c1" });
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "c1" });
+	await flush();
+	settle.find((s) => s.seq === a).rej(new Error("timeout"));
+	settle.find((s) => s.seq === b).res("the rest of it");
+	await flush();
+
+	// What ChatView does on an accepted send: composer held "⟦clip 1⟧ the rest of it".
+	const raw = `⟦clip ${a + 1}⟧ the rest of it`;
+	const seqs = [...raw.matchAll(/⟦clip \d+⟧/g)].map((m) => Number(m[0].replace(/\D+/g, "")) - 1);
+	assert.deepEqual(seqs, [a], "the raw composer text names exactly the failed clip");
+	const payload = raw
+		.replace(/⟦clip \d+⟧/g, "")
+		.replace(/ {2,}/g, " ")
+		.trim();
+	q.acknowledge(q.captureSentInPayload("c1", payload));
+	for (const s of seqs) q.markSentWithoutClip(s);
+	await flush();
+
+	const snap = q.snapshot();
+	assert.equal(snap.failed.length, 1, "one chip remains — the clip whose words never went out");
+	assert.equal(snap.failed[0].sentWithout, true, "…and it says so");
+	assert.equal(snap.done, 0, "the delivered clip was released, exactly as before");
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"nothing is at risk: the remaining audio is durably mirrored, so navigation is not blocked"
+	);
+});

--- a/frontend/src/utils/voiceChunkQueue.js
+++ b/frontend/src/utils/voiceChunkQueue.js
@@ -29,6 +29,11 @@
 //     or (under `retainUntilSent`, which the composer sets because a draft is volatile
 //     until sent) on acknowledge()/discard. A `failed` clip is RETAINED either way (for the
 //     Retry/Download chip and reload recovery).
+//   * an HONEST retention story — a retained clip is not automatically a STUCK one. A failed clip
+//     whose placeholder rode out in an ACCEPTED send is flagged `sentWithout`
+//     (markSentWithoutClip) so the composer can tell "not sent yet" from "sent, minus this chunk",
+//     and hasUnfinishedReason() separates a genuine "live" loss risk from a merely "unresolved"
+//     (durably mirrored, re-offered on reload) one so the leave guard never warns about safe audio.
 //
 // Chunk record state machine (per seq):
 //
@@ -656,6 +661,21 @@ export function createVoiceChunkQueue(deps = {}) {
 		if (changed) _safe(onChange);
 	}
 
+	// UX-1: the payload that just left carried this failed clip's in-place ⟦clip N⟧ placeholder,
+	// which the composer STRIPPED on the way out — so the sent, immutable message is missing this
+	// clip's words and nothing else records that. Flag the record so its chip can say so instead of
+	// reading like leftover clutter next to an already-answered message, and so its Retry can
+	// promise a follow-up rather than an edit of a message that has already gone. Only a terminal
+	// `failed` clip can be sent-WITHOUT: a `done` clip's text WAS in the payload, and releasing it
+	// is acknowledge()'s job (untouched here). The audio stays retained either way.
+	function markSentWithoutClip(seq) {
+		if (disposed) return;
+		const rec = records.get(seq);
+		if (!rec || rec.state !== "failed" || rec.sentWithout) return;
+		rec.sentWithout = true;
+		_safe(onChange);
+	}
+
 	// VR4-1: the user chose Restore on a retained clip — its transcript is going back into the
 	// composer, so it is a normal un-sent draft clip again (the next send's payload match releases
 	// it). Clears the orphaned flag so its chip disappears; the audio is untouched.
@@ -672,6 +692,9 @@ export function createVoiceChunkQueue(deps = {}) {
 		let running = 0;
 		let done = 0;
 		let total = 0;
+		// [{seq, clip, sentWithout}] — `sentWithout` (UX-1) marks a failed clip whose placeholder rode
+		// out in an ACCEPTED send: the chip's copy branches on it ("was missing from your last
+		// message" vs "didn't transcribe"), because those two states are otherwise indistinguishable.
 		const failed = [];
 		// [{seq, clip, text}] — committed clips edited OUT of a sent message (VR4-1): actionable
 		// retained clips the composer renders Restore/Download/Discard for, so the audio is
@@ -688,7 +711,8 @@ export function createVoiceChunkQueue(deps = {}) {
 			else if (rec.state === "done") {
 				done += 1;
 				if (rec.orphaned) retained.push({ seq: rec.seq, clip: rec.clip, text: rec.text });
-			} else if (rec.state === "failed") failed.push({ seq: rec.seq, clip: rec.clip });
+			} else if (rec.state === "failed")
+				failed.push({ seq: rec.seq, clip: rec.clip, sentWithout: !!rec.sentWithout });
 			if (rec.persist === "failed") unpersisted.push({ seq: rec.seq, clip: rec.clip });
 		}
 		return {
@@ -703,21 +727,51 @@ export function createVoiceChunkQueue(deps = {}) {
 		};
 	}
 
-	// True while ANY clip is still un-safe — the composer uses this to arm the beforeunload
-	// + route-leave guard so audio is never silently lost on navigation. Un-safe means:
-	// still pending / in flight / failed (transcription incomplete); OR, under
-	// retainUntilSent, committed but still mirrored — its transcript lives only in an
-	// un-sent, volatile draft (finding 6). A discarded tombstone is safe.
-	function hasUnfinished() {
+	// WHY anything is still outstanding — the distinction the composer's leave guard needs so it
+	// stops crying wolf (UX-3). Returns:
+	//   "live"       — leaving now can genuinely LOSE something: a clip still pending/in flight
+	//                  (its transcription is mid-air), a clip whose audio could NOT be confirmed
+	//                  durably mirrored (persist === "failed" — nothing to recover it from), or,
+	//                  under retainUntilSent, a committed clip whose transcript exists ONLY in this
+	//                  volatile, un-sent draft.
+	//   "unresolved" — only terminal clips the user hasn't dealt with remain: a `failed` clip, or a
+	//                  committed clip that was already sent-without/edited out. Every one of them is
+	//                  durably mirrored and re-offered by the recovery banner next visit, so leaving
+	//                  loses NOTHING — loss-framed copy here is factually wrong and trains users to
+	//                  click through the warning that does matter.
+	//   null         — nothing outstanding at all.
+	// A discarded tombstone is always safe.
+	function hasUnfinishedReason() {
+		let unresolved = false;
 		for (const rec of records.values()) {
 			if (rec.state === "discarded") continue;
 			// VR5-2: a clip whose audio isn't confirmed durable is UN-safe regardless of its
 			// transcription state — the guard must stay armed until it persists or is discarded.
-			if (rec.persist === "failed") return true;
-			if (rec.state !== "done") return true;
-			if (retainUntilSent && rec.committed) return true;
+			if (rec.persist === "failed") return "live";
+			if (rec.state === "pending" || rec.state === "inflight") return "live";
+			if (rec.state === "failed") {
+				// "Durably mirrored" is the ENTIRE justification for not warning about a failed
+				// clip — so it has to be CONFIRMED, not merely in flight (a mirror write that has
+				// not settled yet may still fail, and then there is nothing to recover from).
+				if (rec.persist === "persisting") return "live";
+				unresolved = true; // terminal + confirmed durable: actionable, nothing at risk
+				continue;
+			}
+			if (retainUntilSent && rec.committed) {
+				// A resurrected sent-without clip's words are back in the draft, but its audio is
+				// still mirrored and re-offered on reload — terminal-unresolved, not at-risk.
+				if (rec.sentWithout) unresolved = true;
+				else return "live";
+			}
 		}
-		return false;
+		return unresolved ? "unresolved" : null;
+	}
+
+	// True while ANY clip is still un-safe OR merely unresolved — kept as the coarse predicate for
+	// callers that only need "is anything outstanding". The composer arms its guard off
+	// hasUnfinishedReason() instead, so a terminally-failed clip no longer raises a loss warning.
+	function hasUnfinished() {
+		return hasUnfinishedReason() !== null;
 	}
 
 	function getClip(seq) {
@@ -748,9 +802,11 @@ export function createVoiceChunkQueue(deps = {}) {
 		acknowledge,
 		reassignScope,
 		markUnsentOrphans,
+		markSentWithoutClip,
 		unorphan,
 		snapshot,
 		hasUnfinished,
+		hasUnfinishedReason,
 		getClip,
 		dispose,
 	};

--- a/frontend/src/utils/voiceChunkQueue.test.js
+++ b/frontend/src/utils/voiceChunkQueue.test.js
@@ -1406,3 +1406,270 @@ test("VR5-2: with no mirror injected, there is no persistence gating (opt-out co
 		"commits and clears exactly as before (no mirror to retain)"
 	);
 });
+
+// ── (32) UX-1: a failed clip whose ⟦clip N⟧ placeholder rode out in an ACCEPTED send is flagged
+//        `sentWithout`, so its chip can say "was missing from your last message" instead of being
+//        indistinguishable from a not-yet-sent gap. Only a terminal FAILED clip can be flagged;
+//        the done-clip captureSentInPayload/acknowledge release path is untouched. ───────────────
+test("UX-1: markSentWithoutClip flags only a failed clip, surfaces in snapshot().failed, and never touches the done-clip release", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 2,
+		maxAttempts: 1, // one shot: a rejection is terminal
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" }); // will fail
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" }); // will succeed
+	await flush();
+	tx.reject(a, new Error("timeout"));
+	tx.resolve(b, "the second half");
+	await flush();
+
+	let snap = q.snapshot();
+	assert.equal(snap.failed.length, 1, "clip A is the failed chip");
+	assert.equal(
+		snap.failed[0].sentWithout,
+		false,
+		"pre-send it is a plain gap — the chip keeps its 'didn't transcribe' copy"
+	);
+
+	// The composer stripped ⟦clip 1⟧ and sent "the second half". A: flagged; B: released.
+	q.markSentWithoutClip(a);
+	q.acknowledge(q.captureSentInPayload("chatA", "the second half"));
+	await flush();
+
+	snap = q.snapshot();
+	assert.equal(
+		snap.failed.length,
+		1,
+		"the failed clip is still RETAINED — a send never drops it"
+	);
+	assert.equal(snap.failed[0].seq, a);
+	assert.equal(
+		snap.failed[0].sentWithout,
+		true,
+		"…but now flagged: the message it belonged to has already gone"
+	);
+	assert.ok(mirror.store.has(a), "its audio is untouched — Download/Retry still work");
+	assert.ok(!mirror.store.has(b), "the DONE clip's release path is unchanged (mirror cleared)");
+	assert.equal(snap.done, 0, "clip B's record was released by acknowledge, exactly as before");
+
+	// A done or pending clip is NOT flaggable — only a terminal failed one was sent without.
+	const c = q.enqueue({ blob: "c", durationS: 15, conversationId: "chatA" });
+	await flush();
+	q.markSentWithoutClip(c); // still inflight
+	assert.equal(
+		q.snapshot().failed.length,
+		1,
+		"an in-flight clip is not a gap — flagging it is a no-op"
+	);
+	tx.resolve(c, "third");
+	await flush();
+	q.markSentWithoutClip(c); // now done
+	assert.equal(q.snapshot().done, 1, "a done clip stays done — never re-labelled as a gap");
+});
+
+// ── (33) UX-3: hasUnfinishedReason splits "leaving can LOSE something" from "there is something
+//        unresolved but durably mirrored", so the leave guard stops warning about safe audio.
+//        hasUnfinished() stays exactly as coarse as it was (reason !== null). ───────────────────
+test("UX-3: hasUnfinishedReason distinguishes a live loss risk from a merely-unresolved clip", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+	});
+	assert.equal(q.hasUnfinishedReason(), null, "empty queue: nothing outstanding");
+
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "live", "a clip mid-transcription can still be lost");
+
+	tx.resolve(a, "hello there");
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"committed but un-sent: the transcript exists only in a volatile draft"
+	);
+
+	q.acknowledge(q.captureSentInPayload("chatA", "hello there"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "sent → released → nothing outstanding");
+
+	// A terminally-failed clip: actionable, but its audio is durably mirrored and the recovery
+	// banner re-offers it — leaving loses NOTHING, so it must not raise a loss warning.
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(b, new Error("boom"));
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"a terminal failed clip is unresolved, NOT a live loss risk"
+	);
+	assert.equal(q.hasUnfinished(), true, "the coarse predicate still reports it as outstanding");
+	assert.ok(mirror.store.has(b), "because it is still durably mirrored");
+
+	// A live clip alongside an unresolved one wins: "live" is the stronger claim.
+	const c = q.enqueue({ blob: "c", durationS: 15, conversationId: "chatA" });
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "live", "any live clip outranks an unresolved one");
+	tx.reject(c, new Error("boom"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "unresolved", "…and drops back once it goes terminal");
+
+	q.discard(b);
+	q.discard(c);
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "Discard resolves them — no forever-armed guard");
+	assert.equal(q.hasUnfinished(), false, "and the coarse predicate agrees");
+});
+
+// ── (34) UX-3: an UNPERSISTABLE clip is "live" whatever its transcription state — there is no
+//        durable copy to re-offer, which is the whole reason the guard exists. ──────────────────
+test("UX-3: a clip whose audio could not be mirrored is always a LIVE risk, never merely unresolved", async () => {
+	const tx = makeTranscriber();
+	const mirror = {
+		store: new Map(),
+		put() {
+			return Promise.resolve(false); // never confirms durability
+		},
+		delete() {},
+		all() {
+			return [];
+		},
+	};
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+		mirrorPutAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	for (let i = 0; i < 6; i++) await flush();
+	assert.equal(q.snapshot().unpersisted.length, 1, "the un-saved-audio chip is showing");
+	tx.reject(a, new Error("boom"));
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"failed AND unpersistable — nothing durable exists, so leaving genuinely loses it"
+	);
+	q.markSentWithoutClip(a);
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"sent-without does not downgrade a clip whose audio was never saved"
+	);
+});
+
+// ── (35) UX-3: a sent-without clip the user RETRIES commits into the current draft. Its audio is
+//        still mirrored and re-offered on reload, so it stays "unresolved" — the guard does not
+//        re-arm with loss copy for a message that has already gone. ──────────────────────────────
+test("UX-3: a retried sent-without clip commits as a follow-up draft and stays unresolved, not live", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const commits = [];
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+		onCommit: (seq, text, clip, replace) => commits.push([seq, text, !!replace]),
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(a, new Error("boom")); // a fails → the cursor crosses it (gap placeholder)
+	await flush();
+	tx.resolve(b, "second half");
+	await flush();
+	q.markSentWithoutClip(a);
+	q.acknowledge(q.captureSentInPayload("chatA", "second half"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "unresolved", "only the sent-without gap remains");
+
+	// The user hits Retry on the post-send chip; this time it transcribes.
+	q.retry(a);
+	await flush();
+	tx.resolve(a, "first half");
+	await flush();
+	assert.deepEqual(
+		commits,
+		[
+			[b, "second half", false],
+			[a, "first half", true],
+		],
+		"the resurrected clip commits with replace=true (the composer appends it as a follow-up)"
+	);
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"its audio is still mirrored and re-offerable — no loss-framed warning for an already-sent gap"
+	);
+	assert.ok(
+		mirror.store.has(a),
+		"and the audio is retained until the follow-up is actually sent"
+	);
+	q.acknowledge(q.captureSentInPayload("chatA", "first half"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "sending the follow-up releases it for good");
+});
+
+// ── (36) UX-3: "durably mirrored" is the whole reason a failed clip does not warn — so it must be
+//        CONFIRMED. While its mirror write is still in flight the clip is treated as LIVE. ───────
+test("UX-3: a failed clip whose mirror write has not confirmed yet is LIVE, not unresolved", async () => {
+	const tx = makeTranscriber();
+	let settlePut = null;
+	const mirror = {
+		store: new Map(),
+		put(clip) {
+			return new Promise((res) => {
+				settlePut = () => {
+					this.store.set(clip.seq, clip);
+					res();
+				};
+			});
+		},
+		delete(seq) {
+			this.store.delete(seq);
+		},
+		all() {
+			return [...this.store.values()];
+		},
+	};
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(a, new Error("boom"));
+	await flush();
+	assert.equal(q.snapshot().failed.length, 1, "the clip is terminally failed");
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"its audio is NOT yet confirmed durable — leaving now could still lose it"
+	);
+	settlePut();
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"once the write confirms, it is merely unresolved — the recovery banner re-offers it"
+	);
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2526,7 +2526,10 @@
 							</div>
 							<!-- failed-clip chips: a chunk exhausted its retry budget. Retry drops the
 						     recovered words back into the in-place ⟦clip N⟧ placeholder where they
-						     belong (VUX-2), not at the composer end. ✕ discards the clip (confirmed). -->
+						     belong (VUX-2), not at the composer end. ✕ discards the clip (confirmed).
+						     UX-1: once the message carrying the placeholder has been SENT, the chip's
+						     label + Retry tooltip switch to the post-send wording (sentWithout) — the
+						     two states are otherwise indistinguishable and the chip reads as stuck. -->
 							<div
 								v-if="ui.stt_enabled && voiceQ.failed.length"
 								style="
@@ -2552,10 +2555,10 @@
 										border: 1px solid rgba(220, 150, 40, 0.32);
 									"
 								>
-									Clip {{ f.seq + 1 }} didn't transcribe
+									{{ failedChipLabel(f) }}
 									<button
 										class="jv-voicechip-act"
-										title="Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong"
+										:title="failedChipRetryTitle(f)"
 										@click="retryClip(f.seq)"
 									>
 										Retry
@@ -6912,6 +6915,28 @@ async function send(textArg, resendAck) {
 	// retained audio mirror + leave guard can be released (finding 6).
 	const _sentScope = _currentScope();
 	const fromMain = typeof textArg !== "string";
+	// UX-2 (silent content loss): the ⟦clip N⟧ placeholders below are stripped from the payload, so
+	// the sent message — and its permanent history entry — reads as fluent, complete prose while
+	// actually missing what those clips recorded. Ask ONCE before that happens, and let the user
+	// back out to the composer where both the placeholder and the clip's chip are still sitting.
+	// Read from the RAW composer text (pre-strip) — that is where the tokens still exist. Only for a
+	// main-composer send: a resendFailed is re-sending a payload the user already chose to send with
+	// the gap in it, and a programmatic send carries no composer state to review.
+	let _gapSeqsInText = fromMain ? _gapSeqsIn(input.value) : [];
+	if (_gapSeqsInText.length && (_stripGapTokens(input.value) || pendingFiles.value.length)) {
+		const ok = await confirm({
+			title: "Send without part of what you said?",
+			message:
+				_gapSeqsInText.length === 1
+					? "One voice clip didn't transcribe, so part of your dictation is missing from this message. Send anyway, or fix it first?"
+					: `${_gapSeqsInText.length} voice clips didn't transcribe, so parts of your dictation are missing from this message. Send anyway, or fix them first?`,
+			confirmLabel: "Send anyway",
+			cancelLabel: "Review first",
+		});
+		if (!ok) return; // focus returns to the composer — placeholder + chip both still actionable
+		// The composer stays editable behind the modal, so re-read what is ACTUALLY going out.
+		_gapSeqsInText = _gapSeqsIn(input.value);
+	}
 	// Strip any pending-gap placeholder tokens (⟦clip N⟧) so a failed clip's marker never
 	// rides out in a sent message; its chip stays, so the audio is still recoverable. `text` is the
 	// EXACT voice-derived payload the POST will carry — so it's what the release token binds to.
@@ -7064,6 +7089,12 @@ async function send(textArg, resendAck) {
 		// and a failed-bubble resend (carrying the original token) releases its delivered records
 		// here too. A programmatic send with no token leaves input.value intact and releases none.
 		if (_voiceAck) voiceQueue?.acknowledge(_voiceAck);
+		// UX-1: this accepted payload carried (and stripped) these failed clips' placeholders, so the
+		// message that just left is missing their words. Flag them — their chips must now read "was
+		// missing from your last message" instead of looking like leftover clutter, and their Retry
+		// must promise a follow-up rather than an edit of a message that has already gone.
+		if (fromMain && voiceQueue)
+			for (const _gapSeq of _gapSeqsInText) voiceQueue.markSentWithoutClip(_gapSeq);
 		// Phase-0 admission: the send was accepted but QUEUED (all slots taken).
 		// Show the "~N ahead" chip + Cancel instead of the streaming spinner; the
 		// reply begins when a slot frees (run:start clears queuedTurn). Position
@@ -7634,6 +7665,18 @@ const _GAP_TOKEN_RE = /⟦clip \d+⟧/g;
 function _stripGapTokens(s) {
 	return (s || "").replace(_GAP_TOKEN_RE, "").replace(/ {2,}/g, " ").trim();
 }
+// The failed clips whose placeholders are sitting in `s`, as 0-based seqs (the token renders
+// seq+1, matching the chip label). Read from the RAW composer text BEFORE _stripGapTokens erases
+// them: it is the only record of WHICH clips' words an outgoing message will be missing.
+// matchAll clones the regex, so the shared /g literal's lastIndex is never left dangling.
+function _gapSeqsIn(s) {
+	const out = [];
+	for (const m of String(s || "").matchAll(_GAP_TOKEN_RE)) {
+		const n = Number(m[0].replace(/\D+/g, ""));
+		if (Number.isFinite(n) && n >= 1) out.push(n - 1);
+	}
+	return out;
+}
 function _joinAppend(prev, t) {
 	return prev.trim() ? prev.replace(/\s+$/, "") + " " + t : t;
 }
@@ -7697,14 +7740,22 @@ function _replaceGapPlaceholder(seq, text, clip) {
 	const t = (text || "").trim();
 	if (t) _takeCommitted += t.length;
 	const tok = _gapToken(seq);
+	let appendedInstead = false;
 	_mutateComposerFor(_clipConvId(clip), (prev) => {
 		if (prev.includes(tok)) {
 			return t
 				? prev.split(tok).join(t)
 				: prev.split(tok).join(" ").replace(/ {2,}/g, " ").trim();
 		}
+		appendedInstead = !!t;
 		return t ? _joinAppend(prev, t) : prev;
 	});
+	// UX-4: the token is gone — typically because the message carrying it was already SENT and the
+	// composer cleared — so the recovered words land at the END of the current draft instead of back
+	// in place. Say so, or unexplained text just appears in an otherwise-empty composer and sits
+	// there until the user notices it (or navigates away and abandons it).
+	if (appendedInstead)
+		notify(`Recovered text for Clip ${seq + 1} added to your draft.`, { type: "info" });
 }
 // The user discarded a failed clip: drop its placeholder from the composer.
 function _removeGapPlaceholder(seq, clip) {
@@ -7820,6 +7871,18 @@ async function cancelMic() {
 }
 
 // ---- failed-clip chip actions ----
+// UX-1: a failed clip's chip means two different things and must not read the same for both. Before
+// the send it is a gap the user can still fix in place; after an accepted send it is a hole in a
+// message that has already gone, and Retry can only ever build a follow-up (the sent message is
+// immutable and the composer that held its placeholder was cleared).
+const failedChipLabel = (f) =>
+	f.sentWithout
+		? `Clip ${f.seq + 1} was missing from your last message`
+		: `Clip ${f.seq + 1} didn't transcribe`;
+const failedChipRetryTitle = (f) =>
+	f.sentWithout
+		? "Transcribe and add as a follow-up message"
+		: "Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong";
 function retryClip(seq) {
 	if (voiceQueue) voiceQueue.retry(seq);
 }
@@ -7980,30 +8043,36 @@ async function discardOrphans() {
 }
 
 // ---- never-lost navigation guard ----
-// Fire ONLY for genuinely-volatile work (VUX-11 strict ruling): a live recording, or a
-// clip still pending/in-flight/failed in the in-memory queue. A recovery banner is
-// deliberately NOT counted — those clips are durably persisted in the IndexedDB mirror,
-// scoped to this user + conversation, and the banner re-offers them on return, so
-// navigation loses nothing (the leave-confirm's "may lose audio" copy would be false
-// for them). Discard/Later resolve the banner explicitly instead.
-function _voiceHasUnfinished() {
-	return (
-		!!(voiceQueue && voiceQueue.hasUnfinished()) ||
+// Fire ONLY for genuinely-volatile work (VUX-11 strict ruling): a live recording, a take
+// starting, or a clip the queue calls "live" — still pending/in-flight, un-persistable, or
+// committed into this volatile un-sent draft. A recovery banner is deliberately NOT counted —
+// those clips are durably persisted in the IndexedDB mirror, scoped to this user + conversation,
+// and the banner re-offers them on return, so navigation loses nothing (the leave-confirm's "may
+// lose audio" copy would be false for them). Discard/Later resolve the banner explicitly instead.
+// UX-3: for exactly that reason the guard arms on the queue's REASON, not on "anything
+// outstanding". A terminally-failed or sent-without clip is mirrored just as durably, so the same
+// loss-framed copy is just as false for it — and a warning that cries wolf is one users learn to
+// click through, weakening it for the live case that matters. "unresolved" therefore does not
+// block navigation at all: its chips and the recovery banner already carry it.
+function _voiceGuardReason() {
+	if (
 		micState.value === "recording" ||
 		// The permission prompt is open (getUserMedia pending): a take is starting but
 		// micState hasn't flipped to 'recording' yet — cover navigation during it (finding 2).
-		!!micRec.starting
-	);
+		micRec.starting
+	)
+		return "live";
+	return (voiceQueue && voiceQueue.hasUnfinishedReason()) || null;
 }
 function _beforeUnloadVoice(e) {
-	if (_voiceHasUnfinished()) {
+	if (_voiceGuardReason() === "live") {
 		e.preventDefault();
 		e.returnValue = "";
 		return "";
 	}
 }
 onBeforeRouteLeave(async () => {
-	if (!_voiceHasUnfinished()) return true;
+	if (_voiceGuardReason() !== "live") return true;
 	return await confirm({
 		title: "Leave with un-transcribed audio?",
 		message:
@@ -8406,8 +8475,8 @@ onMounted(async () => {
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);
 	window.addEventListener("keydown", onGlobalKey);
-	// Never-lost guard: warn on tab close/reload while any dictated clip is
-	// un-transcribed (armed/disarmed dynamically by _voiceHasUnfinished()).
+	// Never-lost guard: warn on tab close/reload while dictated audio is genuinely at risk
+	// (armed/disarmed dynamically by _voiceGuardReason() === "live").
 	window.addEventListener("beforeunload", _beforeUnloadVoice);
 	_thinkTimer = setInterval(() => {
 		thinkTick.value = busy.value ? thinkTick.value + 1 : 0;

--- a/jarvis/tests/test_voice_chip_lifecycle_client.py
+++ b/jarvis/tests/test_voice_chip_lifecycle_client.py
@@ -1,0 +1,65 @@
+"""The composer's voice-chip LIFECYCLE contract, proven by a REAL executable node test that lives
+in the python suite forever (the eventFence / voiceChunkQueue / voiceSendGlue precedent).
+
+The delete-after-send mechanism was never the bug: a failed clip is deliberately never released by
+a send (its words never made it into the payload), but nothing told the user that — the chip read
+identically to a stuck one, the sent message silently dropped the missing words with no marker and
+no confirmation, Retry promised to fix a message that had already gone, and the leave guard warned
+about losing audio that was in fact durably mirrored. The fixes span the queue primitive
+(``frontend/src/utils/voiceChunkQueue.js``: markSentWithoutClip, ``snapshot().failed[].sentWithout``,
+hasUnfinishedReason) and ChatView's wiring of it.
+
+The queue half is proven behaviorally by ``voiceChunkQueue.test.js``. The ChatView half cannot be:
+the single-file component has no harness in this app, so — exactly as ``pwa/src/lib/pumpFence.test.js``
+does for the Relay-Pump fence — ``frontend/src/utils/voiceChipLifecycle.test.js`` asserts the wiring
+against the SOURCE (the confirm runs before the strip and the POST; the sent-without flagging sits in
+the accepted-send branch beside the release; the chip copy + Retry tooltip branch on ``sentWithout``;
+the retry-after-send append is announced; the leave guard blocks only for a ``"live"`` reason), plus a
+decision-parity walk against the real queue. It also fences the done-clip
+captureSentInPayload → acknowledge release, the one path this work must not regress.
+
+This subprocess-runs it with ``node --test`` (which exits non-zero on any failed assertion) so the
+contract is enforced by every CI run, not just by ``npm run build``.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _lifecycle_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "utils", "voiceChipLifecycle.test.js")
+
+
+class TestVoiceChipLifecycleClient(unittest.TestCase):
+	def test_client_voice_chip_lifecycle_node_walk_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _lifecycle_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"voice chip-lifecycle test missing at {test_file} — the composer wiring walk MUST ship with the change",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		# node --test exits non-zero on ANY failed assertion; surface its output on failure.
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"client voice chip-lifecycle node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)


### PR DESCRIPTION
Implements the BEHAVIOR SPEC of `fix-phase-20260726/REVIEW-UX-VOICE-CHIPS.md` (findings 1–5), with one directed amendment (below).

## The problem

The owner's report ("chips don't clear after send") is real, but the delete-after-send mechanism is **not** the bug — `captureSentInPayload` → `acknowledge()` releases done clips correctly and stays untouched here. The gap is that a **failed** clip is deliberately never released by a send (its words never made it into the payload) and **nothing told the user that**:

- the chip read exactly like a stuck leftover — nothing distinguished "not sent yet" from "sent, minus this chunk";
- the sent message (and its permanent history entry) read as fluent, complete prose while silently missing a chunk of dictation — no marker, no confirmation;
- Retry's tooltip promised the words would "drop back into the message, where they belong", but post-send the composer was already cleared, so they landed as unexplained text in an empty draft;
- the leave/close warning claimed audio "may be lost" for a clip that had terminally failed and was **durably mirrored** — factually wrong, and it trains users to click through the warning that matters.

## What changed

**`frontend/src/utils/voiceChunkQueue.js`**
- `markSentWithoutClip(seq)` — flags a terminal `failed` clip whose `⟦clip N⟧` placeholder rode out in an accepted send. `snapshot().failed` entries now carry `sentWithout`.
- `hasUnfinishedReason()` → `null | "live" | "unresolved"` — separates a genuine loss risk (pending/inflight, unpersistable, or a transcript that exists only in a volatile un-sent draft) from a merely-unresolved, confirmed-durable clip. `hasUnfinished()` is kept as the coarse predicate on top of it, unchanged in meaning.

**`frontend/src/views/ChatView.vue`**
- Send-time gap confirmation, **before** the strip and the POST: *"Send without part of what you said?"* / "Send anyway" / "Review first". Cancel aborts the send with the placeholder and chip still in place. `fromMain` only (a `resendFailed` re-sends a payload the user already chose to send with the gap).
- Flags the carried gaps via `markSentWithoutClip` in the accepted-send branch, beside the existing release, so both describe the same payload.
- Chip label and Retry tooltip branch on `sentWithout` ("Clip N was missing from your last message" / "Transcribe and add as a follow-up message"). Pre-send copy unchanged.
- `_replaceGapPlaceholder` toasts when it falls back to appending (token gone — the message already left), so recovered text never appears unexplained.
- The leave guard arms on `_voiceGuardReason() === "live"` for both `beforeunload` and `onBeforeRouteLeave`. Live copy is verbatim unchanged.

**`design.md` §4.5** — the two voice-capture surfaces (chat composer chunked-with-chips vs. single-shot `useAudioRecorder`) and their different retention models, plus the copy/tooltip/leave-warning rules, so a third contract isn't invented by accident (finding 5, P2, doc-only as specified).

## Amendment applied (directed)

Spec item 5 offered new non-loss-framed copy for the `"unresolved"` case. Per the direction given, `"unresolved"` does **not** block navigation at all — no confirm, no `beforeunload` arming; the chips and the recovery banner already carry it. The hard guard with the current copy stays only for `"live"`.

## Out of scope, untouched (and fenced by a test)

`captureSent` / `captureSentInPayload` / `acknowledge` for done clips, the recovery-banner flow, and the retained ("was edited out") chip copy.

## Tests

- `voiceChunkQueue.test.js`: 33 → 38 (5 new walks: sent-without flagging + snapshot shape + the fenced done-clip release; the reason split; unpersistable-is-always-live; a retried sent-without clip committing as a follow-up; a failed clip whose mirror write hasn't confirmed yet is live). **38/38 pass.**
- `voiceChipLifecycle.test.js` (new, the `pumpFence.test.js` source-assertion precedent — ChatView cannot be mounted in this app): confirm-before-strip-and-POST ordering, flagging inside the accepted-send branch, chip copy branching, the retry toast, guard-on-reason, plus a decision-parity walk against the real queue and a fence on the release path. **8/8 pass.** Run in CI by `jarvis/tests/test_voice_chip_lifecycle_client.py`.
- Unregressed: `voiceSendGlue.test.js` 11/11, `clipMirror.test.js` 7/7, `eventFence.test.js` 8/8.
- `npx vite build` green; `pre-commit run --files …` (pinned prettier, eslint, ruff) green.

Bench modules to run: `jarvis.tests.test_voice_chunk_queue_client`, `jarvis.tests.test_voice_chip_lifecycle_client`, `jarvis.tests.test_voice_send_glue_client` (they subprocess the node suites above).