### PR TITLE
fix(chat): client-side near-silence gate for dictation (stacks on #464)

### DIFF
--- a/design.md
+++ b/design.md
@@ -547,6 +547,31 @@ three times. Recipe:
 - A `FormControl` paste field (never a bare `<textarea>`), inline `ErrorMessage` for
   expired/invalid-nonce errors, countdown hint in `text-p-sm text-ink-gray-5`.
 
+### 4.5 Voice capture — two surfaces, two retention models (say which one you are)
+
+Jarvis has **two** voice-recording surfaces with deliberately different contracts, and a user who
+learns one carries its expectations to the other. State which one a new surface implements.
+
+- **Chat composer dictation** (`useChunkedRecorder` + `utils/voiceChunkQueue.js`, ChatView): long
+  takes chunked into self-contained clips, transcribed independently, **audio retained** in an
+  IndexedDB mirror until its text is part of an accepted send. Anything unresolved is **visible and
+  actionable as a chip** — a failed clip (Retry/Download/✕), a clip edited out before sending
+  (Restore/Download/✕), a clip whose audio could not be saved (Download/Retry) — plus a
+  previous-session recovery banner. Nothing is ever removed silently except the success path
+  (chips clear on the send that carried their words; no toast — that would be noise on the common
+  case).
+- **Single-shot capture** (`useAudioRecorder`, `VoiceRecorder.vue` — wiki nudge, Business tab):
+  record → transcribe → text, **no retention, no chips, no recovery**. A failure is a toast and a
+  re-record, and the audio is gone.
+
+Rules for either: chip copy must distinguish "not sent yet" from "already sent without this"
+(identical copy for both is what makes a correctly-retained clip read as a stuck one); an action's
+tooltip must promise only what it can do *now* (Retry cannot edit a message that has already been
+sent — it builds a follow-up); and a leave/close warning may claim loss **only** when something is
+genuinely at risk — durably mirrored, re-offerable clips must not arm it (a warning that cries
+wolf gets trained away). If a new surface wants the chip model, reuse the queue rather than growing
+a third contract.
+
 ---
 
 ## 5. Do / Don't — current Jarvis anti-patterns

--- a/frontend/src/composables/useChunkedRecorder.js
+++ b/frontend/src/composables/useChunkedRecorder.js
@@ -11,16 +11,23 @@
 // Cost: a tens-of-ms inter-cycle gap where a boundary word can clip — accepted per
 // the owner spec (chunking is what makes long sessions safe).
 //
-// Each finished clip is handed to opts.onClip({ blob, durationS, mimeType }); the
+// Each finished clip is handed to opts.onClip({ blob, durationS, mimeType, peakRms }); the
 // composer feeds it straight into voiceChunkQueue, which STAMPS the monotonic `seq`
 // (single seq authority — the recorder deliberately does NOT number clips, so it can
 // never collide with recovery on a seq). This composable owns ONLY the browser
-// recorder plumbing (unit-tested logic lives in voiceChunkQueue.js; the recorder
-// itself is validated by the real-mic QA script).
+// recorder plumbing (unit-tested logic lives in voiceChunkQueue.js / voiceSilenceGate.js;
+// the recorder itself is validated by the real-mic QA script).
+//
+// `peakRms` is the loudest RMS an AnalyserNode saw on the SAME MediaStream during THIS
+// clip's cycle — the composer's near-silence gate (voiceSilenceGate.js) reads it to drop a
+// pause-only clip before it can be transcribed into a whisper hallucination. It is OMITTED
+// whenever the meter couldn't measure (no WebAudio, a suspended context), and the gate
+// treats a missing measurement as "transcribe" — the meter never costs audio.
 //
 // There is deliberately NO 300 s hard cap here (unlike useAudioRecorder) — chunking
 // makes long sessions safe, so the mic stays live until the user stops.
 import { reactive, ref } from "vue";
+import { createRmsMeter } from "@/utils/voiceSilenceGate";
 
 const MIME_PREFS = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg;codecs=opus"];
 const DEFAULT_CHUNK_MS = 15000;
@@ -46,6 +53,7 @@ export function useChunkedRecorder(opts = {}) {
 
 	let stream = null;
 	let recorder = null;
+	let meter = null; // peak-RMS meter on the same stream; null until start(), never required
 	let chunks = [];
 	let mime = "";
 	// Cancellation generation covering the pending getUserMedia (finding 2). start() captures
@@ -64,6 +72,12 @@ export function useChunkedRecorder(opts = {}) {
 	let settle = null; // resolver for a stop()/cancel() awaiting the final onstop
 
 	function _releaseStream() {
+		try {
+			meter?.stop();
+		} catch (e) {
+			/* already torn down */
+		}
+		meter = null;
 		try {
 			stream?.getTracks().forEach((t) => t.stop());
 		} catch (e) {
@@ -136,6 +150,13 @@ export function useChunkedRecorder(opts = {}) {
 		};
 		recorder.onerror = () => _fail("Recording failed. Try again.");
 		recorder.onstop = _onStop;
+		// Peak RMS is PER CLIP: zero it as the new cycle's recorder starts, so a loud
+		// sentence in clip N never keeps clip N+1's silence from being gated.
+		try {
+			meter?.reset();
+		} catch (e) {
+			/* a meter that misbehaves just stops measuring; it must not break recording */
+		}
 		cycleStartedAt = Date.now();
 		recorder.start(); // NO timeslice — the whole cycle is one self-contained file
 	}
@@ -147,6 +168,14 @@ export function useChunkedRecorder(opts = {}) {
 		const dur = Math.max(0, Math.round((Date.now() - cycleStartedAt) / 1000));
 		const built = chunks.length ? new Blob(chunks, { type: mimeType }) : null;
 		chunks = [];
+		// Read the cycle's peak BEFORE the next _newRecorder() resets it. `undefined` means the
+		// meter couldn't measure this clip — the gate then transcribes it (never-drop-audio).
+		let peakRms;
+		try {
+			peakRms = meter ? meter.peak() : undefined;
+		} catch (e) {
+			peakRms = undefined;
+		}
 
 		if (localAction === "cancel") {
 			// Discard ONLY this in-progress snippet; clips already emitted this session
@@ -160,7 +189,10 @@ export function useChunkedRecorder(opts = {}) {
 		}
 
 		if (built && built.size) {
-			onClip({ blob: built, durationS: dur, mimeType });
+			const clip = { blob: built, durationS: dur, mimeType };
+			// Only carry a REAL measurement — an absent key is what tells the gate "unmeasured".
+			if (typeof peakRms === "number") clip.peakRms = peakRms;
+			onClip(clip);
 		}
 
 		if (localAction === "rotate" && state.value === "recording") {
@@ -223,6 +255,10 @@ export function useChunkedRecorder(opts = {}) {
 		}
 		stream = acquired;
 		mime = _pickMime();
+		// The near-silence meter rides the SAME stream. createRmsMeter NEVER throws — an
+		// unavailable/failing WebAudio returns a meter that measures nothing, and an unmeasured
+		// clip is always transcribed — so recording is never gated on it.
+		meter = createRmsMeter(stream);
 		try {
 			_newRecorder();
 		} catch (e) {

--- a/frontend/src/utils/voiceChipLifecycle.test.js
+++ b/frontend/src/utils/voiceChipLifecycle.test.js
@@ -23,6 +23,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createVoiceChunkQueue } from "./voiceChunkQueue.js";
+import { isNearSilent } from "./voiceSilenceGate.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CHAT_VIEW = path.join(HERE, "..", "views", "ChatView.vue");
@@ -291,4 +292,46 @@ test("parity: a stripped gap + a released done clip leave exactly one flagged ch
 		"unresolved",
 		"nothing is at risk: the remaining audio is durably mirrored, so navigation is not blocked"
 	);
+});
+
+// ── the near-silence gate produces NO chip lifecycle at all ─────────────────────
+// The gate itself (threshold, meter, degrade-safety) is proven in voiceSilenceGate.test.js.
+// What belongs HERE is the chip consequence: a dictation pause is not a failed clip, not a
+// retained clip and not an unsaved clip — it must leave the composer's chip row exactly as it
+// found it. A gate that dropped clips into any of those states would swap one hallucinated
+// phrase for a permanent row of "Clip N didn't transcribe" chips after every pause.
+test("a gated pause creates no chip, no placeholder and no guard — unlike a failed clip", async () => {
+	const flush = () => new Promise((r) => setTimeout(r, 0));
+	const asked = [];
+	const gaps = [];
+	const q = createVoiceChunkQueue({
+		transcribe: (clip) => {
+			asked.push(clip.seq);
+			return Promise.resolve("spoken words");
+		},
+		retainUntilSent: true,
+		onGap: (seq) => gaps.push(seq),
+	});
+	// ChatView's micRec.onClip, replicated (voiceSilenceGate.test.js fences the replication).
+	const handoff = (clip) => {
+		if (isNearSilent(clip.peakRms)) return;
+		q.enqueue({ ...clip, conversationId: "c1" });
+	};
+	handoff({ blob: "pause", durationS: 15, peakRms: 0 });
+	await flush();
+	let snap = q.snapshot();
+	assert.deepEqual(asked, [], "a pause is never uploaded, so it can never hallucinate a phrase");
+	assert.equal(snap.failed.length, 0, "…and never becomes a 'didn't transcribe' chip");
+	assert.equal(snap.retained.length, 0, "…nor a retained-clip chip");
+	assert.equal(snap.unpersisted.length, 0, "…nor an unsaved-audio chip");
+	assert.deepEqual(gaps, [], "…and drops no ⟦clip⟧ placeholder into the message");
+	assert.equal(q.hasUnfinishedReason(), null, "…so the leave guard stays disarmed");
+
+	// A clip that was merely QUIET-ish (above the threshold) still gets the full lifecycle: the
+	// gate is not allowed to grow into a general "probably nothing" filter.
+	handoff({ blob: "speech", durationS: 15, peakRms: 0.05 });
+	await flush();
+	snap = q.snapshot();
+	assert.deepEqual(asked, [0], "the audible clip is transcribed as it always was");
+	assert.equal(snap.done, 1);
 });

--- a/frontend/src/utils/voiceChipLifecycle.test.js
+++ b/frontend/src/utils/voiceChipLifecycle.test.js
@@ -1,0 +1,294 @@
+// UX chip-lifecycle wiring: the ChatView half of the voice-clip retention story.
+//
+// The queue primitive's half (markSentWithoutClip, snapshot().failed[].sentWithout,
+// hasUnfinishedReason) is proven behaviorally in voiceChunkQueue.test.js against the real module.
+// What CANNOT be proven there is whether ChatView actually calls it at the right moment and says
+// the right thing: the composer is a single-file component with no harness in this app (no vitest,
+// no @vue/test-utils; mounting it would need a router, a socket and the whole api surface), so —
+// exactly like pwa/src/lib/pumpFence.test.js — the wiring is asserted against the SOURCE.
+//
+// Crude, but a real regression guard: it fails the moment the send-time gap confirm is removed or
+// moved after the strip, the sent-without flagging drifts out of the accepted-send branch, a chip's
+// copy stops branching on `sentWithout`, the retry-after-send toast disappears, or the leave guard
+// goes back to arming on "anything outstanding" (the cry-wolf warning UX-3 removed).
+//
+// It also fences the ONE path this change must not regress: the done-clip
+// captureSentInPayload → acknowledge release, which has its own extensive suites.
+//
+// Run: `node --test voiceChipLifecycle.test.js`, or via the python suite
+// (jarvis/tests/test_voice_chip_lifecycle_client.py subprocess-runs it every CI run).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createVoiceChunkQueue } from "./voiceChunkQueue.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CHAT_VIEW = path.join(HERE, "..", "views", "ChatView.vue");
+const src = fs.readFileSync(CHAT_VIEW, "utf8");
+
+function sendBody() {
+	const start = src.indexOf("async function send(textArg, resendAck) {");
+	assert.notEqual(start, -1, "ChatView must still define send(textArg, resendAck)");
+	const end = src.indexOf("\nfunction openProactive()", start);
+	assert.notEqual(end, -1, "could not find the end of send()");
+	return src.slice(start, end);
+}
+
+// ── the ⟦clip N⟧ token has ONE definition ───────────────────────────────────────
+test("the gap token is read and stripped through the SAME regex — tokens found == tokens stripped", () => {
+	assert.match(
+		src,
+		/const _GAP_TOKEN_RE = \/⟦clip \\d\+⟧\/g;/,
+		"the token shape must stay a single constant"
+	);
+	assert.match(
+		src,
+		/function _stripGapTokens\(s\) \{\n\treturn \(s \|\| ""\)\.replace\(_GAP_TOKEN_RE, ""\)/,
+		"the strip must use the shared constant"
+	);
+	assert.match(
+		src,
+		/function _gapSeqsIn\(s\) \{[\s\S]*?matchAll\(_GAP_TOKEN_RE\)/,
+		"…and so must the seq reader, or a send could strip a token it never counted"
+	);
+	// seq+1 is the chip's label AND the token's number: the reader must undo that, not guess.
+	assert.match(
+		src,
+		/function _gapSeqsIn\(s\) \{[\s\S]*?out\.push\(n - 1\);/,
+		"_gapSeqsIn must convert the token's 1-based clip number back to the 0-based seq"
+	);
+});
+
+// ── UX-2: the send-time gap confirmation, BEFORE anything is stripped or sent ───
+test("send() confirms before sending a payload that is missing a clip's words — ahead of the strip", () => {
+	const body = sendBody();
+	const read = body.indexOf("let _gapSeqsInText = fromMain ? _gapSeqsIn(input.value) : [];");
+	const confirmAt = body.indexOf('title: "Send without part of what you said?"');
+	const strip = body.indexOf("const text = _stripGapTokens(fromMain ? input.value : textArg);");
+	const post = body.indexOf("await api.sendMessage(");
+	assert.notEqual(read, -1, "the gap seqs must be read from the RAW composer text");
+	assert.notEqual(confirmAt, -1, "the send-time gap confirmation is missing");
+	assert.notEqual(strip, -1, "send() must still strip the placeholders from the payload");
+	assert.ok(read < confirmAt, "the confirm needs the seqs it is confirming about");
+	assert.ok(
+		confirmAt < strip && confirmAt < post,
+		"the confirm must run BEFORE the tokens are stripped and before the POST — after either, " +
+			"the words are already gone from a message the user never agreed to send incomplete"
+	);
+	assert.match(
+		body,
+		/"One voice clip didn't transcribe, so part of your dictation is missing from this message\. Send anyway, or fix it first\?"/,
+		"the single-gap copy must name what is actually missing"
+	);
+	assert.match(
+		body,
+		/confirmLabel: "Send anyway",\n\t\t\tcancelLabel: "Review first",/,
+		"Review first must be the cancel path — cancelling returns to the composer, it does not send"
+	);
+	assert.match(
+		body,
+		/if \(!ok\) return; \/\/ focus returns to the composer/,
+		"cancel must ABORT the send, leaving the placeholder + chip in place to act on"
+	);
+	// A resend is re-sending a payload the user already chose to send with the gap in it.
+	assert.match(
+		body,
+		/let _gapSeqsInText = fromMain \?/,
+		"the confirm (and the flagging) is fromMain-only — a resendFailed must not re-ask"
+	);
+});
+
+// ── UX-1: flag the sent-without clips, but ONLY on an accepted send ─────────────
+test("send() flags sent-without clips only in the accepted-send branch, after the release", () => {
+	const body = sendBody();
+	const ack = body.indexOf("if (_voiceAck) voiceQueue?.acknowledge(_voiceAck);");
+	const mark = body.indexOf("voiceQueue.markSentWithoutClip(_gapSeq)");
+	const rejected = body.indexOf("if (r && r.ok === false) {");
+	assert.notEqual(ack, -1, "the done-clip release must still run on acceptance (fenced path)");
+	assert.notEqual(mark, -1, "failed clips carried by an accepted send must be flagged");
+	assert.ok(
+		rejected !== -1 && mark > rejected,
+		"the flagging must sit after the rejection branch — a rejected send left the words in the composer"
+	);
+	assert.ok(
+		mark > ack,
+		"flag alongside the release, in the same accepted-send branch, so both describe the SAME payload"
+	);
+	assert.match(
+		body,
+		/if \(fromMain && voiceQueue\)\n\t\t\tfor \(const _gapSeq of _gapSeqsInText\) voiceQueue\.markSentWithoutClip\(_gapSeq\);/,
+		"every gap the payload carried is flagged (the queue ignores any that is no longer failed)"
+	);
+});
+
+// ── UX-1: the chip's copy branches on sentWithout ───────────────────────────────
+test("the failed chip and its Retry tooltip branch on sentWithout", () => {
+	assert.match(
+		src,
+		/{{ failedChipLabel\(f\) }}/,
+		"the failed chip's label must come from the branching helper, not a fixed string"
+	);
+	assert.match(
+		src,
+		/:title="failedChipRetryTitle\(f\)"/,
+		"…and so must its Retry tooltip: post-send it can only build a follow-up"
+	);
+	assert.match(
+		src,
+		/f\.sentWithout\n\t\t\? `Clip \$\{f\.seq \+ 1\} was missing from your last message`\n\t\t: `Clip \$\{f\.seq \+ 1\} didn't transcribe`/,
+		"the two states must read differently — identical copy is what makes a retained clip look stuck"
+	);
+	assert.match(
+		src,
+		/f\.sentWithout\n\t\t\? "Transcribe and add as a follow-up message"/,
+		"the post-send tooltip must not promise to edit a message that has already gone"
+	);
+	assert.match(
+		src,
+		/: "Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong"/,
+		"the PRE-send tooltip is unchanged — it is accurate while the placeholder is still there"
+	);
+});
+
+// ── UX-4: the retry-after-send append is explained ──────────────────────────────
+test("_replaceGapPlaceholder toasts when it appends instead of replacing", () => {
+	const start = src.indexOf("function _replaceGapPlaceholder(seq, text, clip) {");
+	assert.notEqual(start, -1, "ChatView must still define _replaceGapPlaceholder");
+	const body = src.slice(start, src.indexOf("\nfunction _removeGapPlaceholder", start));
+	assert.match(
+		body,
+		/appendedInstead = !!t;\n\t\treturn t \? _joinAppend\(prev, t\) : prev;/,
+		"the fallback-append branch (token gone — the message already left) must be detectable"
+	);
+	assert.match(
+		body,
+		/if \(appendedInstead\)\n\t\tnotify\(`Recovered text for Clip \$\{seq \+ 1\} added to your draft\.`, \{ type: "info" \}\);/,
+		"…and announced, or unexplained text just appears in an otherwise-empty composer"
+	);
+	assert.ok(
+		body.indexOf("appendedInstead = !!t") < body.indexOf("if (appendedInstead)"),
+		"the flag is set inside the mutation and read after it"
+	);
+	// The IN-PLACE replacement is the normal path and must stay silent.
+	assert.match(
+		body,
+		/if \(prev\.includes\(tok\)\) \{\n\t\t\treturn t\n\t\t\t\t\? prev\.split\(tok\)\.join\(t\)/,
+		"a token that IS still there is replaced in place, with no toast"
+	);
+});
+
+// ── UX-3: the leave guard arms on the REASON, not on "anything outstanding" ─────
+test("the leave guard blocks only for a live loss risk, and keeps its copy verbatim for that case", () => {
+	assert.match(
+		src,
+		/function _voiceGuardReason\(\) \{/,
+		"the guard must read the queue's reason, not a bare boolean"
+	);
+	assert.match(
+		src,
+		/return \(voiceQueue && voiceQueue\.hasUnfinishedReason\(\)\) \|\| null;/,
+		"the reason comes from the queue — one source of truth for what is at risk"
+	);
+	assert.doesNotMatch(
+		src,
+		/voiceQueue\.hasUnfinished\(\)/,
+		"the old arm-on-anything predicate must be gone from the guard path (it cried wolf for " +
+			"terminally-failed clips whose audio is durably mirrored)"
+	);
+	assert.match(
+		src,
+		/function _beforeUnloadVoice\(e\) \{\n\tif \(_voiceGuardReason\(\) === "live"\) \{/,
+		"beforeunload arms for a live risk ONLY"
+	);
+	assert.match(
+		src,
+		/onBeforeRouteLeave\(async \(\) => \{\n\tif \(_voiceGuardReason\(\) !== "live"\) return true;/,
+		"…and so does the route-leave confirm: unresolved must not block navigation at all"
+	);
+	// The live case is a REAL risk — its copy is accurate and stays exactly as it was.
+	assert.match(
+		src,
+		/title: "Leave with un-transcribed audio\?",\n\t\tmessage:\n\t\t\t"Some dictated voice clips haven't finished transcribing\. Leaving now may lose audio that hasn't been saved yet\. Leave anyway\?",/,
+		"the live-risk copy is unchanged — it was always accurate for that case"
+	);
+	// A recording (or a take starting) is live before any clip exists.
+	assert.match(
+		src,
+		/micState\.value === "recording" \|\|[\s\S]*?micRec\.starting\n\t\)\n\t\treturn "live";/,
+		"a live take still arms the guard before the queue has anything in it"
+	);
+});
+
+// ── the fenced path: the done-clip release is untouched ─────────────────────────
+test("the done-clip captureSentInPayload → acknowledge release is untouched", () => {
+	const body = sendBody();
+	assert.match(
+		body,
+		/const _voiceAck =\n\t\tresendAck \|\|\n\t\t\(fromMain && voiceQueue \? voiceQueue\.captureSentInPayload\(_sentScope, text\) : null\);/,
+		"the payload-bound token is still captured from the EXACT outgoing text, before the POST"
+	);
+	assert.ok(
+		body.indexOf("voiceQueue.captureSentInPayload(_sentScope, text)") <
+			body.indexOf("await api.sendMessage("),
+		"…and still captured BEFORE the POST (R2-1: a clip committing mid-flight is not released)"
+	);
+	assert.match(
+		body,
+		/if \(fromMain && voiceQueue\) voiceQueue\.markUnsentOrphans\(_sentScope, _voiceAck\);/,
+		"the edited-out retained-clip path (VR4-1) is unchanged"
+	);
+});
+
+// ── decision parity: the queue behaves the way the wiring above assumes ─────────
+test("parity: a stripped gap + a released done clip leave exactly one flagged chip and no live guard", async () => {
+	const flush = () => new Promise((r) => setTimeout(r, 0));
+	const settle = [];
+	const q = createVoiceChunkQueue({
+		transcribe: (clip) => new Promise((res, rej) => settle.push({ seq: clip.seq, res, rej })),
+		mirror: {
+			store: new Map(),
+			put(c) {
+				this.store.set(c.seq, c);
+			},
+			delete(s) {
+				this.store.delete(s);
+			},
+			all() {
+				return [...this.store.values()];
+			},
+		},
+		retainUntilSent: true,
+		concurrency: 2,
+		maxAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "c1" });
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "c1" });
+	await flush();
+	settle.find((s) => s.seq === a).rej(new Error("timeout"));
+	settle.find((s) => s.seq === b).res("the rest of it");
+	await flush();
+
+	// What ChatView does on an accepted send: composer held "⟦clip 1⟧ the rest of it".
+	const raw = `⟦clip ${a + 1}⟧ the rest of it`;
+	const seqs = [...raw.matchAll(/⟦clip \d+⟧/g)].map((m) => Number(m[0].replace(/\D+/g, "")) - 1);
+	assert.deepEqual(seqs, [a], "the raw composer text names exactly the failed clip");
+	const payload = raw
+		.replace(/⟦clip \d+⟧/g, "")
+		.replace(/ {2,}/g, " ")
+		.trim();
+	q.acknowledge(q.captureSentInPayload("c1", payload));
+	for (const s of seqs) q.markSentWithoutClip(s);
+	await flush();
+
+	const snap = q.snapshot();
+	assert.equal(snap.failed.length, 1, "one chip remains — the clip whose words never went out");
+	assert.equal(snap.failed[0].sentWithout, true, "…and it says so");
+	assert.equal(snap.done, 0, "the delivered clip was released, exactly as before");
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"nothing is at risk: the remaining audio is durably mirrored, so navigation is not blocked"
+	);
+});

--- a/frontend/src/utils/voiceChunkQueue.js
+++ b/frontend/src/utils/voiceChunkQueue.js
@@ -29,6 +29,11 @@
 //     or (under `retainUntilSent`, which the composer sets because a draft is volatile
 //     until sent) on acknowledge()/discard. A `failed` clip is RETAINED either way (for the
 //     Retry/Download chip and reload recovery).
+//   * an HONEST retention story — a retained clip is not automatically a STUCK one. A failed clip
+//     whose placeholder rode out in an ACCEPTED send is flagged `sentWithout`
+//     (markSentWithoutClip) so the composer can tell "not sent yet" from "sent, minus this chunk",
+//     and hasUnfinishedReason() separates a genuine "live" loss risk from a merely "unresolved"
+//     (durably mirrored, re-offered on reload) one so the leave guard never warns about safe audio.
 //
 // Chunk record state machine (per seq):
 //
@@ -656,6 +661,21 @@ export function createVoiceChunkQueue(deps = {}) {
 		if (changed) _safe(onChange);
 	}
 
+	// UX-1: the payload that just left carried this failed clip's in-place ⟦clip N⟧ placeholder,
+	// which the composer STRIPPED on the way out — so the sent, immutable message is missing this
+	// clip's words and nothing else records that. Flag the record so its chip can say so instead of
+	// reading like leftover clutter next to an already-answered message, and so its Retry can
+	// promise a follow-up rather than an edit of a message that has already gone. Only a terminal
+	// `failed` clip can be sent-WITHOUT: a `done` clip's text WAS in the payload, and releasing it
+	// is acknowledge()'s job (untouched here). The audio stays retained either way.
+	function markSentWithoutClip(seq) {
+		if (disposed) return;
+		const rec = records.get(seq);
+		if (!rec || rec.state !== "failed" || rec.sentWithout) return;
+		rec.sentWithout = true;
+		_safe(onChange);
+	}
+
 	// VR4-1: the user chose Restore on a retained clip — its transcript is going back into the
 	// composer, so it is a normal un-sent draft clip again (the next send's payload match releases
 	// it). Clears the orphaned flag so its chip disappears; the audio is untouched.
@@ -672,6 +692,9 @@ export function createVoiceChunkQueue(deps = {}) {
 		let running = 0;
 		let done = 0;
 		let total = 0;
+		// [{seq, clip, sentWithout}] — `sentWithout` (UX-1) marks a failed clip whose placeholder rode
+		// out in an ACCEPTED send: the chip's copy branches on it ("was missing from your last
+		// message" vs "didn't transcribe"), because those two states are otherwise indistinguishable.
 		const failed = [];
 		// [{seq, clip, text}] — committed clips edited OUT of a sent message (VR4-1): actionable
 		// retained clips the composer renders Restore/Download/Discard for, so the audio is
@@ -688,7 +711,8 @@ export function createVoiceChunkQueue(deps = {}) {
 			else if (rec.state === "done") {
 				done += 1;
 				if (rec.orphaned) retained.push({ seq: rec.seq, clip: rec.clip, text: rec.text });
-			} else if (rec.state === "failed") failed.push({ seq: rec.seq, clip: rec.clip });
+			} else if (rec.state === "failed")
+				failed.push({ seq: rec.seq, clip: rec.clip, sentWithout: !!rec.sentWithout });
 			if (rec.persist === "failed") unpersisted.push({ seq: rec.seq, clip: rec.clip });
 		}
 		return {
@@ -703,21 +727,51 @@ export function createVoiceChunkQueue(deps = {}) {
 		};
 	}
 
-	// True while ANY clip is still un-safe — the composer uses this to arm the beforeunload
-	// + route-leave guard so audio is never silently lost on navigation. Un-safe means:
-	// still pending / in flight / failed (transcription incomplete); OR, under
-	// retainUntilSent, committed but still mirrored — its transcript lives only in an
-	// un-sent, volatile draft (finding 6). A discarded tombstone is safe.
-	function hasUnfinished() {
+	// WHY anything is still outstanding — the distinction the composer's leave guard needs so it
+	// stops crying wolf (UX-3). Returns:
+	//   "live"       — leaving now can genuinely LOSE something: a clip still pending/in flight
+	//                  (its transcription is mid-air), a clip whose audio could NOT be confirmed
+	//                  durably mirrored (persist === "failed" — nothing to recover it from), or,
+	//                  under retainUntilSent, a committed clip whose transcript exists ONLY in this
+	//                  volatile, un-sent draft.
+	//   "unresolved" — only terminal clips the user hasn't dealt with remain: a `failed` clip, or a
+	//                  committed clip that was already sent-without/edited out. Every one of them is
+	//                  durably mirrored and re-offered by the recovery banner next visit, so leaving
+	//                  loses NOTHING — loss-framed copy here is factually wrong and trains users to
+	//                  click through the warning that does matter.
+	//   null         — nothing outstanding at all.
+	// A discarded tombstone is always safe.
+	function hasUnfinishedReason() {
+		let unresolved = false;
 		for (const rec of records.values()) {
 			if (rec.state === "discarded") continue;
 			// VR5-2: a clip whose audio isn't confirmed durable is UN-safe regardless of its
 			// transcription state — the guard must stay armed until it persists or is discarded.
-			if (rec.persist === "failed") return true;
-			if (rec.state !== "done") return true;
-			if (retainUntilSent && rec.committed) return true;
+			if (rec.persist === "failed") return "live";
+			if (rec.state === "pending" || rec.state === "inflight") return "live";
+			if (rec.state === "failed") {
+				// "Durably mirrored" is the ENTIRE justification for not warning about a failed
+				// clip — so it has to be CONFIRMED, not merely in flight (a mirror write that has
+				// not settled yet may still fail, and then there is nothing to recover from).
+				if (rec.persist === "persisting") return "live";
+				unresolved = true; // terminal + confirmed durable: actionable, nothing at risk
+				continue;
+			}
+			if (retainUntilSent && rec.committed) {
+				// A resurrected sent-without clip's words are back in the draft, but its audio is
+				// still mirrored and re-offered on reload — terminal-unresolved, not at-risk.
+				if (rec.sentWithout) unresolved = true;
+				else return "live";
+			}
 		}
-		return false;
+		return unresolved ? "unresolved" : null;
+	}
+
+	// True while ANY clip is still un-safe OR merely unresolved — kept as the coarse predicate for
+	// callers that only need "is anything outstanding". The composer arms its guard off
+	// hasUnfinishedReason() instead, so a terminally-failed clip no longer raises a loss warning.
+	function hasUnfinished() {
+		return hasUnfinishedReason() !== null;
 	}
 
 	function getClip(seq) {
@@ -748,9 +802,11 @@ export function createVoiceChunkQueue(deps = {}) {
 		acknowledge,
 		reassignScope,
 		markUnsentOrphans,
+		markSentWithoutClip,
 		unorphan,
 		snapshot,
 		hasUnfinished,
+		hasUnfinishedReason,
 		getClip,
 		dispose,
 	};

--- a/frontend/src/utils/voiceChunkQueue.test.js
+++ b/frontend/src/utils/voiceChunkQueue.test.js
@@ -1406,3 +1406,270 @@ test("VR5-2: with no mirror injected, there is no persistence gating (opt-out co
 		"commits and clears exactly as before (no mirror to retain)"
 	);
 });
+
+// ── (32) UX-1: a failed clip whose ⟦clip N⟧ placeholder rode out in an ACCEPTED send is flagged
+//        `sentWithout`, so its chip can say "was missing from your last message" instead of being
+//        indistinguishable from a not-yet-sent gap. Only a terminal FAILED clip can be flagged;
+//        the done-clip captureSentInPayload/acknowledge release path is untouched. ───────────────
+test("UX-1: markSentWithoutClip flags only a failed clip, surfaces in snapshot().failed, and never touches the done-clip release", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 2,
+		maxAttempts: 1, // one shot: a rejection is terminal
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" }); // will fail
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" }); // will succeed
+	await flush();
+	tx.reject(a, new Error("timeout"));
+	tx.resolve(b, "the second half");
+	await flush();
+
+	let snap = q.snapshot();
+	assert.equal(snap.failed.length, 1, "clip A is the failed chip");
+	assert.equal(
+		snap.failed[0].sentWithout,
+		false,
+		"pre-send it is a plain gap — the chip keeps its 'didn't transcribe' copy"
+	);
+
+	// The composer stripped ⟦clip 1⟧ and sent "the second half". A: flagged; B: released.
+	q.markSentWithoutClip(a);
+	q.acknowledge(q.captureSentInPayload("chatA", "the second half"));
+	await flush();
+
+	snap = q.snapshot();
+	assert.equal(
+		snap.failed.length,
+		1,
+		"the failed clip is still RETAINED — a send never drops it"
+	);
+	assert.equal(snap.failed[0].seq, a);
+	assert.equal(
+		snap.failed[0].sentWithout,
+		true,
+		"…but now flagged: the message it belonged to has already gone"
+	);
+	assert.ok(mirror.store.has(a), "its audio is untouched — Download/Retry still work");
+	assert.ok(!mirror.store.has(b), "the DONE clip's release path is unchanged (mirror cleared)");
+	assert.equal(snap.done, 0, "clip B's record was released by acknowledge, exactly as before");
+
+	// A done or pending clip is NOT flaggable — only a terminal failed one was sent without.
+	const c = q.enqueue({ blob: "c", durationS: 15, conversationId: "chatA" });
+	await flush();
+	q.markSentWithoutClip(c); // still inflight
+	assert.equal(
+		q.snapshot().failed.length,
+		1,
+		"an in-flight clip is not a gap — flagging it is a no-op"
+	);
+	tx.resolve(c, "third");
+	await flush();
+	q.markSentWithoutClip(c); // now done
+	assert.equal(q.snapshot().done, 1, "a done clip stays done — never re-labelled as a gap");
+});
+
+// ── (33) UX-3: hasUnfinishedReason splits "leaving can LOSE something" from "there is something
+//        unresolved but durably mirrored", so the leave guard stops warning about safe audio.
+//        hasUnfinished() stays exactly as coarse as it was (reason !== null). ───────────────────
+test("UX-3: hasUnfinishedReason distinguishes a live loss risk from a merely-unresolved clip", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+	});
+	assert.equal(q.hasUnfinishedReason(), null, "empty queue: nothing outstanding");
+
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "live", "a clip mid-transcription can still be lost");
+
+	tx.resolve(a, "hello there");
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"committed but un-sent: the transcript exists only in a volatile draft"
+	);
+
+	q.acknowledge(q.captureSentInPayload("chatA", "hello there"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "sent → released → nothing outstanding");
+
+	// A terminally-failed clip: actionable, but its audio is durably mirrored and the recovery
+	// banner re-offers it — leaving loses NOTHING, so it must not raise a loss warning.
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(b, new Error("boom"));
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"a terminal failed clip is unresolved, NOT a live loss risk"
+	);
+	assert.equal(q.hasUnfinished(), true, "the coarse predicate still reports it as outstanding");
+	assert.ok(mirror.store.has(b), "because it is still durably mirrored");
+
+	// A live clip alongside an unresolved one wins: "live" is the stronger claim.
+	const c = q.enqueue({ blob: "c", durationS: 15, conversationId: "chatA" });
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "live", "any live clip outranks an unresolved one");
+	tx.reject(c, new Error("boom"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "unresolved", "…and drops back once it goes terminal");
+
+	q.discard(b);
+	q.discard(c);
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "Discard resolves them — no forever-armed guard");
+	assert.equal(q.hasUnfinished(), false, "and the coarse predicate agrees");
+});
+
+// ── (34) UX-3: an UNPERSISTABLE clip is "live" whatever its transcription state — there is no
+//        durable copy to re-offer, which is the whole reason the guard exists. ──────────────────
+test("UX-3: a clip whose audio could not be mirrored is always a LIVE risk, never merely unresolved", async () => {
+	const tx = makeTranscriber();
+	const mirror = {
+		store: new Map(),
+		put() {
+			return Promise.resolve(false); // never confirms durability
+		},
+		delete() {},
+		all() {
+			return [];
+		},
+	};
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+		mirrorPutAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	for (let i = 0; i < 6; i++) await flush();
+	assert.equal(q.snapshot().unpersisted.length, 1, "the un-saved-audio chip is showing");
+	tx.reject(a, new Error("boom"));
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"failed AND unpersistable — nothing durable exists, so leaving genuinely loses it"
+	);
+	q.markSentWithoutClip(a);
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"sent-without does not downgrade a clip whose audio was never saved"
+	);
+});
+
+// ── (35) UX-3: a sent-without clip the user RETRIES commits into the current draft. Its audio is
+//        still mirrored and re-offered on reload, so it stays "unresolved" — the guard does not
+//        re-arm with loss copy for a message that has already gone. ──────────────────────────────
+test("UX-3: a retried sent-without clip commits as a follow-up draft and stays unresolved, not live", async () => {
+	const tx = makeTranscriber();
+	const mirror = makeMirror();
+	const commits = [];
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+		onCommit: (seq, text, clip, replace) => commits.push([seq, text, !!replace]),
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	const b = q.enqueue({ blob: "b", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(a, new Error("boom")); // a fails → the cursor crosses it (gap placeholder)
+	await flush();
+	tx.resolve(b, "second half");
+	await flush();
+	q.markSentWithoutClip(a);
+	q.acknowledge(q.captureSentInPayload("chatA", "second half"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), "unresolved", "only the sent-without gap remains");
+
+	// The user hits Retry on the post-send chip; this time it transcribes.
+	q.retry(a);
+	await flush();
+	tx.resolve(a, "first half");
+	await flush();
+	assert.deepEqual(
+		commits,
+		[
+			[b, "second half", false],
+			[a, "first half", true],
+		],
+		"the resurrected clip commits with replace=true (the composer appends it as a follow-up)"
+	);
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"its audio is still mirrored and re-offerable — no loss-framed warning for an already-sent gap"
+	);
+	assert.ok(
+		mirror.store.has(a),
+		"and the audio is retained until the follow-up is actually sent"
+	);
+	q.acknowledge(q.captureSentInPayload("chatA", "first half"));
+	await flush();
+	assert.equal(q.hasUnfinishedReason(), null, "sending the follow-up releases it for good");
+});
+
+// ── (36) UX-3: "durably mirrored" is the whole reason a failed clip does not warn — so it must be
+//        CONFIRMED. While its mirror write is still in flight the clip is treated as LIVE. ───────
+test("UX-3: a failed clip whose mirror write has not confirmed yet is LIVE, not unresolved", async () => {
+	const tx = makeTranscriber();
+	let settlePut = null;
+	const mirror = {
+		store: new Map(),
+		put(clip) {
+			return new Promise((res) => {
+				settlePut = () => {
+					this.store.set(clip.seq, clip);
+					res();
+				};
+			});
+		},
+		delete(seq) {
+			this.store.delete(seq);
+		},
+		all() {
+			return [...this.store.values()];
+		},
+	};
+	const q = createVoiceChunkQueue({
+		transcribe: tx.fn,
+		mirror,
+		retainUntilSent: true,
+		concurrency: 1,
+		maxAttempts: 1,
+	});
+	const a = q.enqueue({ blob: "a", durationS: 15, conversationId: "chatA" });
+	await flush();
+	tx.reject(a, new Error("boom"));
+	await flush();
+	assert.equal(q.snapshot().failed.length, 1, "the clip is terminally failed");
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"live",
+		"its audio is NOT yet confirmed durable — leaving now could still lose it"
+	);
+	settlePut();
+	await flush();
+	assert.equal(
+		q.hasUnfinishedReason(),
+		"unresolved",
+		"once the write confirms, it is merely unresolved — the recovery banner re-offers it"
+	);
+});

--- a/frontend/src/utils/voiceSilenceGate.js
+++ b/frontend/src/utils/voiceSilenceGate.js
@@ -1,0 +1,181 @@
+// voiceSilenceGate — the CLIENT-SIDE near-silence gate for chunked voice dictation.
+//
+// whisper-large-v3-turbo deterministically HALLUCINATES on near-silent audio: a 15 s
+// pure-silence webm transcribes as "Thank you." (3/3 on the probe). The chunked recorder
+// rotates a clip every ~15 s whether or not anybody spoke, and pauses mid-dictation are
+// routine — so without a gate the composer gets confident little phrases injected that the
+// user never said.
+//
+// It CANNOT be filtered server-side: OpenRouter's transcription endpoint does not pass
+// through verbose_json / no_speech_prob (probed — it 400s), and a phrase blocklist was
+// vetoed because it would swallow the same words when a user genuinely dictates them. So the
+// gate lives at the microphone instead: measured near-silence never leaves the browser.
+//
+// Two plain pieces, both dependency-injected so `node --test` can drive them without a
+// browser (the voiceChunkQueue.js precedent):
+//   createRmsMeter(stream, deps) — an AnalyserNode riding the SAME MediaStream as the
+//                                  MediaRecorder, tracking peak RMS across a clip.
+//   isNearSilent(peakRms)        — the decision, biased hard toward TRANSCRIBING.
+//
+// The invariant that outranks the feature: ABSENCE OF MEASUREMENT MUST NEVER DROP AUDIO.
+// Every failure mode — no AudioContext, a constructor or graph call that throws, a context
+// the browser suspended (its analyser reads all-zero, which would look exactly like silence),
+// a clip that ended before the first sample — reports the peak as `undefined`, and
+// isNearSilent(undefined) is false. Only a real, positive measurement below the threshold
+// skips a clip; everything else is uploaded exactly as it is today.
+
+// Peak RMS below this is treated as true near-silence. AnalyserNode time-domain samples are
+// nominally [-1, 1], so this is ~0.5% of full scale (≈ -46 dBFS) — far under any speech that
+// could plausibly transcribe (even a close whisper sits well above it) and comfortably over
+// the noise floor getUserMedia leaves after Chrome's default noise suppression. It is the PEAK
+// across the whole ~15 s clip, so a single word anywhere in the clip clears it; skipping needs
+// the ENTIRE clip to be inaudible. Deliberately conservative: a too-low threshold merely
+// restores today's behaviour (transcribe, risk a hallucination), a too-high one deletes speech.
+export const SILENCE_PEAK_RMS = 0.005;
+
+// AnalyserNode window size. 4096 samples ≈ 85 ms at 48 kHz, so at SAMPLE_MS = 100 the meter
+// observes ~85% of the clip's timeline — a short word can't slip between two windows.
+const FFT_SIZE = 4096;
+const SAMPLE_MS = 100; // 10 Hz; one 4096-float RMS per tick is negligible work
+
+const noop = () => {};
+
+// A meter that measured nothing and therefore never skips anything. Returned for every
+// unavailable / failed WebAudio path so callers need no capability branching of their own.
+const DEAD_METER = Object.freeze({
+	available: false,
+	peak: () => undefined,
+	reset: noop,
+	stop: noop,
+});
+
+// Attach a peak-RMS meter to `stream` (the SAME MediaStream the MediaRecorder is recording,
+// so the measurement describes exactly the audio in the clip).
+//
+// deps (all optional — real browsers need none):
+//   AudioContext   constructor override (tests inject a fake)
+//   setInterval / clearInterval   timer overrides
+//   sampleMs       sampling period, default 100 ms
+//
+// Returns { available, peak(), reset(), stop() }. `peak()` is the highest RMS seen since the
+// last reset(), or `undefined` when the measurement can't be trusted. `reset()` is called at
+// each clip boundary so the peak is PER CLIP; `stop()` tears the graph down with the stream.
+export function createRmsMeter(stream, deps = {}) {
+	const Ctx =
+		deps.AudioContext ||
+		(typeof window !== "undefined" && (window.AudioContext || window.webkitAudioContext));
+	const setIntervalFn =
+		deps.setInterval || (typeof setInterval === "function" ? setInterval : null);
+	const clearIntervalFn =
+		deps.clearInterval || (typeof clearInterval === "function" ? clearInterval : null);
+	const sampleMs = Math.max(20, deps.sampleMs || SAMPLE_MS);
+	if (!stream || !Ctx || !setIntervalFn || !clearIntervalFn) return DEAD_METER;
+
+	let ctx = null;
+	let source = null;
+	let analyser = null;
+	let sink = null;
+	let buf = null;
+	try {
+		ctx = new Ctx();
+		source = ctx.createMediaStreamSource(stream);
+		analyser = ctx.createAnalyser();
+		analyser.fftSize = FFT_SIZE;
+		source.connect(analyser);
+		buf = new Float32Array(analyser.fftSize);
+	} catch (e) {
+		try {
+			ctx && ctx.close && ctx.close();
+		} catch (e2) {
+			/* nothing to close */
+		}
+		return DEAD_METER; // no measurement → isNearSilent(undefined) → nothing is ever skipped
+	}
+	// A WebAudio graph is rendered because something PULLS it from the destination. The
+	// mic-meter recipe of leaving the analyser dangling works in the browsers we ship to, but a
+	// graph that is silently never pulled reads all-zero — which is indistinguishable from
+	// silence and would drop every clip. Terminate the chain in a MUTED gain node so the pull is
+	// guaranteed; gain 0 means nothing is ever audible (and no mic→speaker feedback loop).
+	try {
+		sink = ctx.createGain();
+		sink.gain.value = 0;
+		analyser.connect(sink);
+		sink.connect(ctx.destination);
+	} catch (e) {
+		sink = null; // best-effort; the analyser still works everywhere we've measured
+	}
+	// An AudioContext can start suspended (autoplay policy). start() runs off a user gesture so
+	// this should be a no-op, but resume anyway — and peak() re-checks state, so a context that
+	// stays suspended reports "unmeasured" rather than a bogus zero.
+	try {
+		Promise.resolve(ctx.resume && ctx.resume()).catch(noop);
+	} catch (e) {
+		/* best-effort */
+	}
+
+	let peak = 0;
+	let samples = 0;
+	function _sample() {
+		try {
+			analyser.getFloatTimeDomainData(buf);
+		} catch (e) {
+			return; // a read that throws contributes no sample; peak() stays honest about that
+		}
+		let sum = 0;
+		for (let i = 0; i < buf.length; i++) sum += buf[i] * buf[i];
+		const rms = Math.sqrt(sum / buf.length);
+		if (Number.isFinite(rms)) {
+			if (rms > peak) peak = rms;
+			samples += 1;
+		}
+	}
+	let timer = setIntervalFn(_sample, sampleMs);
+
+	return {
+		available: true,
+		peak() {
+			// Nothing sampled yet (a clip shorter than one tick, or every read threw): UNMEASURED.
+			if (!samples) return undefined;
+			// A suspended/closed context feeds the analyser nothing but zeros. Reporting that as
+			// silence would drop real speech, so an un-running context is UNMEASURED too.
+			if (ctx.state && ctx.state !== "running") return undefined;
+			return peak;
+		},
+		reset() {
+			peak = 0;
+			samples = 0;
+		},
+		stop() {
+			if (timer != null) {
+				try {
+					clearIntervalFn(timer);
+				} catch (e) {
+					/* already cleared */
+				}
+				timer = null;
+			}
+			for (const node of [source, analyser, sink]) {
+				try {
+					node && node.disconnect && node.disconnect();
+				} catch (e) {
+					/* already disconnected */
+				}
+			}
+			try {
+				Promise.resolve(ctx.close && ctx.close()).catch(noop);
+			} catch (e) {
+				/* already closed */
+			}
+		},
+	};
+}
+
+// Is this clip's measured peak RMS true near-silence — i.e. safe to drop WITHOUT transcribing?
+//
+// False for anything that isn't a finite number, so every unmeasured clip (no meter, suspended
+// context, undefined/null/NaN/a string) is transcribed. Strictly `<` the threshold, so a clip
+// sitting exactly ON the boundary is transcribed too: every tie goes to keeping the audio.
+export function isNearSilent(peakRms, threshold = SILENCE_PEAK_RMS) {
+	if (typeof peakRms !== "number" || !Number.isFinite(peakRms)) return false;
+	return peakRms < threshold;
+}

--- a/frontend/src/utils/voiceSilenceGate.test.js
+++ b/frontend/src/utils/voiceSilenceGate.test.js
@@ -1,0 +1,488 @@
+// Real executable test for the client-side near-silence gate (voiceSilenceGate.js) and for
+// the recorder→composer wiring that carries it. Plain node built-ins (node:test +
+// node:assert), like voiceChunkQueue.test.js / voiceSendGlue.test.js. Run directly
+// (`node --test voiceSilenceGate.test.js`) or via the python suite
+// (jarvis/tests/test_voice_silence_gate_client.py subprocess-runs it every CI run).
+//
+// What is being defended: whisper-large-v3-turbo hallucinates a confident phrase onto silent
+// audio ("Thank you." 3/3 on a pure-silence 15 s webm), the provider exposes no
+// no_speech_prob to filter on server-side, and a phrase blocklist was vetoed — so a measured
+// pause must be dropped in the BROWSER, before any upload. And the counter-invariant that
+// matters more: a clip the meter could not measure must ALWAYS be transcribed.
+//
+// The meter's WebAudio graph and the composer's clip handoff are both driven here: the graph
+// against injected fakes (deps-injection, so no browser is needed), the handoff against the
+// REAL createVoiceChunkQueue, plus source assertions that fence the ChatView/recorder wiring
+// the replica stands in for (the voiceChipLifecycle.test.js precedent).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRmsMeter, isNearSilent, SILENCE_PEAK_RMS } from "./voiceSilenceGate.js";
+import { createVoiceChunkQueue } from "./voiceChunkQueue.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CHAT_VIEW = path.join(HERE, "..", "views", "ChatView.vue");
+const RECORDER = path.join(HERE, "..", "composables", "useChunkedRecorder.js");
+const chatSrc = fs.readFileSync(CHAT_VIEW, "utf8");
+const recSrc = fs.readFileSync(RECORDER, "utf8");
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+// A whole fake WebAudio stack + fake timers, so the meter's real code runs with no browser.
+// `level` is the constant sample value the analyser reports, so RMS == |level| exactly and a
+// test can name the peak it expects instead of approximating one.
+function makeAudioStack(opts = {}) {
+	const log = [];
+	let level = 0;
+	const timers = [];
+	class FakeNode {
+		constructor(kind) {
+			this.kind = kind;
+		}
+		connect() {
+			log.push(`${this.kind}:connect`);
+		}
+		disconnect() {
+			log.push(`${this.kind}:disconnect`);
+		}
+	}
+	class FakeAnalyser extends FakeNode {
+		constructor() {
+			super("analyser");
+			this.fftSize = 2048;
+		}
+		getFloatTimeDomainData(buf) {
+			if (opts.readThrows) throw new Error("analyser is gone");
+			for (let i = 0; i < buf.length; i++) buf[i] = level;
+		}
+	}
+	class FakeAudioContext {
+		constructor() {
+			if (opts.ctorThrows) throw new Error("AudioContext unavailable");
+			this.state = opts.state || "running";
+			this.destination = new FakeNode("destination");
+			log.push("ctx:new");
+		}
+		createMediaStreamSource() {
+			if (opts.sourceThrows) throw new Error("stream refused");
+			return new FakeNode("source");
+		}
+		createAnalyser() {
+			return new FakeAnalyser();
+		}
+		createGain() {
+			if (opts.gainThrows) throw new Error("no gain node");
+			const g = new FakeNode("gain");
+			g.gain = { value: 1 };
+			return g;
+		}
+		resume() {
+			log.push("ctx:resume");
+			return Promise.resolve();
+		}
+		close() {
+			log.push("ctx:close");
+			return Promise.resolve();
+		}
+		_suspend() {
+			this.state = "suspended";
+		}
+	}
+	const ctxs = [];
+	class Tracked extends FakeAudioContext {
+		constructor() {
+			super();
+			ctxs.push(this);
+		}
+	}
+	return {
+		log,
+		ctxs,
+		deps: {
+			AudioContext: Tracked,
+			setInterval: (fn) => {
+				timers.push(fn);
+				return timers.length;
+			},
+			clearInterval: (id) => {
+				log.push(`clear:${id}`);
+				timers[id - 1] = null;
+			},
+		},
+		setLevel(v) {
+			level = v;
+		},
+		tick(n = 1) {
+			for (let i = 0; i < n; i++) for (const fn of timers) if (fn) fn();
+		},
+	};
+}
+
+const STREAM = { id: "fake-stream" }; // opaque to the meter — it only hands it to WebAudio
+
+// ── isNearSilent: the decision, biased hard toward transcribing ────────────────────────────
+test("isNearSilent skips ONLY a real measurement under the threshold", () => {
+	assert.equal(isNearSilent(0), true, "digital silence is silence");
+	assert.equal(isNearSilent(SILENCE_PEAK_RMS / 2), true, "well under the threshold is silence");
+	assert.equal(isNearSilent(0.2), false, "speech-level audio is transcribed");
+	assert.equal(
+		isNearSilent(SILENCE_PEAK_RMS * 1.5),
+		false,
+		"above the threshold is transcribed"
+	);
+});
+
+test("the threshold boundary keeps the audio: exactly AT the threshold is NOT silent", () => {
+	assert.equal(
+		isNearSilent(SILENCE_PEAK_RMS),
+		false,
+		"the comparison must be strictly `<` — a tie has to go to transcribing, never to dropping"
+	);
+	// One ULP below still skips, so the boundary is a real boundary and not a dead zone.
+	const justUnder = SILENCE_PEAK_RMS - Number.EPSILON * SILENCE_PEAK_RMS;
+	assert.ok(justUnder < SILENCE_PEAK_RMS);
+	assert.equal(isNearSilent(justUnder), true);
+});
+
+test("an UNMEASURED clip is never silent — absence of measurement must not drop audio", () => {
+	for (const v of [undefined, null, NaN, Infinity, "0", "", false, {}, []]) {
+		assert.equal(
+			isNearSilent(v),
+			false,
+			`peakRms ${String(v)} is not a measurement — the clip must still be transcribed`
+		);
+	}
+});
+
+test("the threshold is conservative: far below any plausible speech level", () => {
+	assert.ok(SILENCE_PEAK_RMS > 0, "a zero threshold could never gate anything");
+	assert.ok(
+		SILENCE_PEAK_RMS <= 0.01,
+		"peak RMS 0.01 (~-40 dBFS) is already quiet speech territory — the gate must stay under it"
+	);
+});
+
+// ── createRmsMeter: the WebAudio half ──────────────────────────────────────────────────────
+test("the meter tracks the loudest RMS across the cycle, not the last one", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.equal(m.available, true);
+	a.setLevel(0.3);
+	a.tick();
+	a.setLevel(0.0);
+	a.tick(5); // a long pause AFTER a word must not erase the word
+	assert.ok(Math.abs(m.peak() - 0.3) < 1e-6, `peak should be 0.3, got ${m.peak()}`);
+	assert.equal(isNearSilent(m.peak()), false, "a clip containing a word is transcribed");
+});
+
+test("a whole cycle of true silence measures as silent", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	a.setLevel(0);
+	a.tick(10);
+	assert.equal(m.peak(), 0);
+	assert.equal(isNearSilent(m.peak()), true);
+});
+
+test("reset() makes the peak PER CLIP — a loud clip doesn't shield the next one", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	a.setLevel(0.4);
+	a.tick(3);
+	assert.equal(isNearSilent(m.peak()), false);
+	m.reset(); // the recorder calls this as each new cycle's MediaRecorder starts
+	assert.equal(
+		m.peak(),
+		undefined,
+		"straight after a reset nothing is sampled yet — UNMEASURED"
+	);
+	a.setLevel(0);
+	a.tick(4);
+	assert.equal(m.peak(), 0);
+	assert.equal(isNearSilent(m.peak()), true, "the silent cycle after a loud one is gated");
+});
+
+test("a clip that ends before the first sample is UNMEASURED, not silent", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.equal(m.peak(), undefined, "no ticks yet — nothing was measured");
+	assert.equal(isNearSilent(m.peak()), false, "…so the clip is transcribed");
+});
+
+test("a SUSPENDED AudioContext reads all-zero — that must report UNMEASURED, never silence", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	a.setLevel(0.5);
+	a.tick(2);
+	assert.equal(isNearSilent(m.peak()), false);
+	a.ctxs[0]._suspend(); // autoplay policy / device change parks the context mid-take
+	a.setLevel(0);
+	a.tick(2);
+	assert.equal(
+		m.peak(),
+		undefined,
+		"a parked context's zeros look exactly like silence — reporting them would delete real speech"
+	);
+	assert.equal(isNearSilent(m.peak()), false);
+});
+
+test("an analyser read that throws contributes no sample — UNMEASURED, and never throws out", () => {
+	const a = makeAudioStack({ readThrows: true });
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.doesNotThrow(() => a.tick(3));
+	assert.equal(m.peak(), undefined);
+	assert.equal(isNearSilent(m.peak()), false);
+});
+
+test("no AudioContext at all → a dead meter that measures nothing and skips nothing", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, { ...a.deps, AudioContext: null });
+	assert.equal(m.available, false);
+	assert.equal(m.peak(), undefined);
+	assert.doesNotThrow(() => {
+		m.reset();
+		m.stop();
+	});
+	assert.equal(isNearSilent(m.peak()), false);
+});
+
+test("a throwing AudioContext constructor degrades to the dead meter", () => {
+	const a = makeAudioStack({ ctorThrows: true });
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.equal(m.available, false);
+	assert.equal(m.peak(), undefined);
+});
+
+test("a throwing createMediaStreamSource degrades AND closes the context it opened", () => {
+	const a = makeAudioStack({ sourceThrows: true });
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.equal(m.available, false);
+	assert.equal(m.peak(), undefined);
+	assert.ok(
+		a.log.includes("ctx:close"),
+		"a half-built graph must not leak an open AudioContext"
+	);
+});
+
+test("a missing stream degrades to the dead meter (no graph is even attempted)", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(null, a.deps);
+	assert.equal(m.available, false);
+	assert.equal(a.log.includes("ctx:new"), false);
+});
+
+test("the muted pull-sink is best-effort: createGain throwing still leaves a working meter", () => {
+	const a = makeAudioStack({ gainThrows: true });
+	const m = createRmsMeter(STREAM, a.deps);
+	assert.equal(m.available, true, "no gain node is not a reason to stop measuring");
+	a.setLevel(0.25);
+	a.tick(2);
+	assert.ok(Math.abs(m.peak() - 0.25) < 1e-6);
+});
+
+test("the sink is MUTED and terminates at the destination (guaranteed pull, no feedback)", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	// gain 0: the mic is never routed audibly back to the speakers.
+	assert.equal(a.log.filter((l) => l === "gain:connect").length, 1);
+	m.stop();
+});
+
+test("stop() clears the timer, disconnects the graph and closes the context", () => {
+	const a = makeAudioStack();
+	const m = createRmsMeter(STREAM, a.deps);
+	a.setLevel(0.4);
+	a.tick();
+	m.stop();
+	assert.ok(
+		a.log.some((l) => l.startsWith("clear:")),
+		"the sampling interval must be cleared"
+	);
+	assert.ok(a.log.includes("source:disconnect"));
+	assert.ok(a.log.includes("analyser:disconnect"));
+	assert.ok(a.log.includes("ctx:close"));
+	a.tick(3); // a cleared timer must genuinely stop sampling
+	assert.doesNotThrow(() => m.stop(), "a second stop() (dispose after stop) must be safe");
+});
+
+// ── the clip handoff, end to end against the REAL queue ────────────────────────────────────
+// Mirrors ChatView's micRec.onClip exactly (the source assertions below fence the mirroring).
+function makeHandoff() {
+	const asked = [];
+	const commits = [];
+	const gaps = [];
+	const fails = [];
+	const skipped = [];
+	const q = createVoiceChunkQueue({
+		transcribe: (clip) => {
+			asked.push(clip.seq);
+			return Promise.resolve("hello there");
+		},
+		retainUntilSent: true,
+		maxAttempts: 2,
+		onCommit: (seq, text) => commits.push([seq, text]),
+		onGap: (seq) => gaps.push(seq),
+		onFail: (seq) => fails.push(seq),
+	});
+	return {
+		q,
+		asked,
+		commits,
+		gaps,
+		fails,
+		skipped,
+		onClip(clip) {
+			if (isNearSilent(clip.peakRms)) {
+				skipped.push(clip);
+				return;
+			}
+			q.enqueue({ ...clip, conversationId: "chatA" });
+		},
+	};
+}
+
+test("END TO END: a measured-silent clip is dropped — no transcribe, no chip, no placeholder", async () => {
+	const h = makeHandoff();
+	h.onClip({ blob: "silence", durationS: 15, peakRms: 0 });
+	await flush();
+	assert.deepEqual(h.asked, [], "a silent clip must never reach the transcription endpoint");
+	assert.deepEqual(h.commits, [], "it contributes no text");
+	assert.deepEqual(h.gaps, [], "and leaves NO ⟦clip⟧ placeholder in the composer");
+	assert.deepEqual(h.fails, [], "it is not a failure — nothing failed, nothing happened");
+	const snap = h.q.snapshot();
+	assert.equal(snap.total, 0, "the queue never saw it");
+	assert.equal(snap.failed.length, 0, "so there is no chip to show");
+	assert.equal(snap.unpersisted.length, 0);
+	assert.equal(snap.hasUnfinished, false);
+	assert.equal(h.q.hasUnfinishedReason(), null, "and the leave guard is not armed by a pause");
+	assert.equal(h.skipped.length, 1);
+});
+
+test("END TO END: a clip with speech in it passes the gate and transcribes normally", async () => {
+	const h = makeHandoff();
+	h.onClip({ blob: "speech", durationS: 15, peakRms: 0.18 });
+	await flush();
+	assert.deepEqual(h.asked, [0], "the loud clip is transcribed");
+	assert.deepEqual(h.commits, [[0, "hello there"]]);
+	assert.deepEqual(h.gaps, []);
+});
+
+test("END TO END: an UNMEASURED clip (no meter) is always transcribed", async () => {
+	const h = makeHandoff();
+	h.onClip({ blob: "unknown", durationS: 15 }); // no peakRms key at all
+	h.onClip({ blob: "unknown2", durationS: 15, peakRms: undefined });
+	await flush();
+	assert.deepEqual(h.asked, [0, 1], "no measurement means no skipping — both clips go up");
+	assert.equal(h.skipped.length, 0);
+});
+
+test("END TO END: skipping a pause does NOT disturb the seq order of the clips around it", async () => {
+	const h = makeHandoff();
+	h.onClip({ blob: "a", durationS: 15, peakRms: 0.2 });
+	h.onClip({ blob: "pause", durationS: 15, peakRms: 0.0004 });
+	h.onClip({ blob: "b", durationS: 15, peakRms: 0.2 });
+	await flush();
+	assert.deepEqual(
+		h.asked,
+		[0, 1],
+		"the two spoken clips take seqs 0 and 1 — the pause takes none"
+	);
+	assert.deepEqual(
+		h.commits.map(([seq]) => seq),
+		[0, 1],
+		"both commit contiguously; the dropped pause leaves no hole for the cursor to stall on"
+	);
+	assert.equal(h.q.snapshot().total, 2);
+});
+
+// ── the wiring the replica above stands in for ─────────────────────────────────────────────
+test("ChatView's onClip runs the gate BEFORE the queue ever sees the clip", () => {
+	const start = chatSrc.indexOf("const micRec = useChunkedRecorder({");
+	assert.notEqual(start, -1, "ChatView must still build the chunked recorder");
+	const end = chatSrc.indexOf("\nasync function startMic()", start);
+	assert.notEqual(end, -1, "could not find the end of the recorder wiring");
+	const body = chatSrc.slice(start, end);
+	const gate = body.indexOf("if (isNearSilent(clip.peakRms)) {");
+	const enqueue = body.indexOf("voiceQueue.enqueue(");
+	assert.notEqual(gate, -1, "the near-silence gate is missing from the clip handoff");
+	assert.notEqual(enqueue, -1, "the handoff must still enqueue non-silent clips");
+	assert.ok(
+		gate < enqueue,
+		"gating AFTER the enqueue would upload the silence anyway — the whole point is that a " +
+			"pause never leaves the browser"
+	);
+	assert.match(
+		body,
+		/if \(isNearSilent\(clip\.peakRms\)\) \{[\s\S]*?return;\n/,
+		"a gated clip must RETURN — it may not fall through into the queue"
+	);
+	assert.match(
+		chatSrc,
+		/import \{ isNearSilent \} from "@\/utils\/voiceSilenceGate";/,
+		"the gate must be the shared module, not a re-implemented threshold in the view"
+	);
+	// The gated path must not fabricate any of the artifacts a real clip produces.
+	const gatedBlock = body.slice(gate, enqueue);
+	for (const forbidden of ["_insertGapPlaceholder", "notify(", "_takeCommitted", "onFail"]) {
+		assert.equal(
+			gatedBlock.includes(forbidden),
+			false,
+			`a skipped pause must not ${forbidden} — it produces no chip, no placeholder, no toast`
+		);
+	}
+});
+
+test("the recorder measures on the SAME stream and stamps only a REAL measurement", () => {
+	assert.match(
+		recSrc,
+		/import \{ createRmsMeter \} from "@\/utils\/voiceSilenceGate";/,
+		"the recorder must use the shared meter"
+	);
+	const meterAt = recSrc.indexOf("meter = createRmsMeter(stream);");
+	assert.notEqual(meterAt, -1, "the meter must ride the SAME MediaStream as the MediaRecorder");
+	const firstRecorder = recSrc.indexOf("_newRecorder();", meterAt);
+	assert.notEqual(firstRecorder, -1);
+	assert.ok(
+		meterAt < firstRecorder,
+		"the meter has to exist before the first cycle starts, or clip 1 is always unmeasured"
+	);
+	assert.match(
+		recSrc,
+		/if \(typeof peakRms === "number"\) clip\.peakRms = peakRms;/,
+		"only a real number may be stamped — an unmeasured clip must carry NO peakRms key"
+	);
+});
+
+test("the recorder resets the peak per cycle and reads it before the next cycle overwrites it", () => {
+	const newRec = recSrc.slice(
+		recSrc.indexOf("function _newRecorder()"),
+		recSrc.indexOf("function _onStop()")
+	);
+	assert.match(
+		newRec,
+		/meter\?\.reset\(\)/,
+		"each cycle must start from a clean peak, or one loud clip shields every later pause"
+	);
+	const onStop = recSrc.slice(
+		recSrc.indexOf("function _onStop()"),
+		recSrc.indexOf("async function start()")
+	);
+	const read = onStop.indexOf("meter.peak()");
+	const emit = onStop.indexOf("onClip(clip);");
+	const restart = onStop.indexOf("_newRecorder();");
+	assert.notEqual(read, -1, "the finished cycle's peak must be read in _onStop");
+	assert.notEqual(emit, -1);
+	assert.notEqual(restart, -1);
+	assert.ok(read < emit && read < restart, "read the peak BEFORE the next cycle resets it");
+});
+
+test("releasing the stream tears the meter down with it (no orphan AudioContext)", () => {
+	const release = recSrc.slice(
+		recSrc.indexOf("function _releaseStream()"),
+		recSrc.indexOf("function _clearTimers()")
+	);
+	assert.match(release, /meter\?\.stop\(\)/, "the meter must die with the stream it measures");
+	assert.match(release, /meter = null;/);
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3554,6 +3554,7 @@ import { agentName } from "@/branding";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
 import { useChunkedRecorder } from "@/composables/useChunkedRecorder";
 import { createVoiceChunkQueue } from "@/utils/voiceChunkQueue";
+import { isNearSilent } from "@/utils/voiceSilenceGate";
 import {
 	promoteNewChatScope,
 	planRejectedSend,
@@ -7830,7 +7831,21 @@ const micRec = useChunkedRecorder({
 	// The queue stamps `seq` (single authority); we tag each clip with the conversation
 	// it was spoken in so recovery/late commits route to the right chat.
 	onClip: (clip) => {
-		if (voiceQueue) voiceQueue.enqueue({ ...clip, conversationId: _micConvId });
+		if (!voiceQueue) return;
+		// NEAR-SILENCE GATE (voiceSilenceGate.js). whisper hallucinates confident phrases
+		// ("Thank you.") onto silent audio and the provider exposes no no_speech_prob to filter
+		// on, so a clip the recorder MEASURED as a pure pause is dropped right here: never
+		// uploaded, no text, no ⟦clip⟧ placeholder, no chip, not a failure — it simply never
+		// happened. A clip with no measurement (no WebAudio / suspended context) is always
+		// enqueued: absence of measurement must never cost audio.
+		if (isNearSilent(clip.peakRms)) {
+			console.debug("[voice] near-silent clip skipped", {
+				durationS: clip.durationS,
+				peakRms: clip.peakRms,
+			});
+			return;
+		}
+		voiceQueue.enqueue({ ...clip, conversationId: _micConvId });
 	},
 });
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2526,7 +2526,10 @@
 							</div>
 							<!-- failed-clip chips: a chunk exhausted its retry budget. Retry drops the
 						     recovered words back into the in-place ⟦clip N⟧ placeholder where they
-						     belong (VUX-2), not at the composer end. ✕ discards the clip (confirmed). -->
+						     belong (VUX-2), not at the composer end. ✕ discards the clip (confirmed).
+						     UX-1: once the message carrying the placeholder has been SENT, the chip's
+						     label + Retry tooltip switch to the post-send wording (sentWithout) — the
+						     two states are otherwise indistinguishable and the chip reads as stuck. -->
 							<div
 								v-if="ui.stt_enabled && voiceQ.failed.length"
 								style="
@@ -2552,10 +2555,10 @@
 										border: 1px solid rgba(220, 150, 40, 0.32);
 									"
 								>
-									Clip {{ f.seq + 1 }} didn't transcribe
+									{{ failedChipLabel(f) }}
 									<button
 										class="jv-voicechip-act"
-										title="Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong"
+										:title="failedChipRetryTitle(f)"
 										@click="retryClip(f.seq)"
 									>
 										Retry
@@ -6912,6 +6915,28 @@ async function send(textArg, resendAck) {
 	// retained audio mirror + leave guard can be released (finding 6).
 	const _sentScope = _currentScope();
 	const fromMain = typeof textArg !== "string";
+	// UX-2 (silent content loss): the ⟦clip N⟧ placeholders below are stripped from the payload, so
+	// the sent message — and its permanent history entry — reads as fluent, complete prose while
+	// actually missing what those clips recorded. Ask ONCE before that happens, and let the user
+	// back out to the composer where both the placeholder and the clip's chip are still sitting.
+	// Read from the RAW composer text (pre-strip) — that is where the tokens still exist. Only for a
+	// main-composer send: a resendFailed is re-sending a payload the user already chose to send with
+	// the gap in it, and a programmatic send carries no composer state to review.
+	let _gapSeqsInText = fromMain ? _gapSeqsIn(input.value) : [];
+	if (_gapSeqsInText.length && (_stripGapTokens(input.value) || pendingFiles.value.length)) {
+		const ok = await confirm({
+			title: "Send without part of what you said?",
+			message:
+				_gapSeqsInText.length === 1
+					? "One voice clip didn't transcribe, so part of your dictation is missing from this message. Send anyway, or fix it first?"
+					: `${_gapSeqsInText.length} voice clips didn't transcribe, so parts of your dictation are missing from this message. Send anyway, or fix them first?`,
+			confirmLabel: "Send anyway",
+			cancelLabel: "Review first",
+		});
+		if (!ok) return; // focus returns to the composer — placeholder + chip both still actionable
+		// The composer stays editable behind the modal, so re-read what is ACTUALLY going out.
+		_gapSeqsInText = _gapSeqsIn(input.value);
+	}
 	// Strip any pending-gap placeholder tokens (⟦clip N⟧) so a failed clip's marker never
 	// rides out in a sent message; its chip stays, so the audio is still recoverable. `text` is the
 	// EXACT voice-derived payload the POST will carry — so it's what the release token binds to.
@@ -7064,6 +7089,12 @@ async function send(textArg, resendAck) {
 		// and a failed-bubble resend (carrying the original token) releases its delivered records
 		// here too. A programmatic send with no token leaves input.value intact and releases none.
 		if (_voiceAck) voiceQueue?.acknowledge(_voiceAck);
+		// UX-1: this accepted payload carried (and stripped) these failed clips' placeholders, so the
+		// message that just left is missing their words. Flag them — their chips must now read "was
+		// missing from your last message" instead of looking like leftover clutter, and their Retry
+		// must promise a follow-up rather than an edit of a message that has already gone.
+		if (fromMain && voiceQueue)
+			for (const _gapSeq of _gapSeqsInText) voiceQueue.markSentWithoutClip(_gapSeq);
 		// Phase-0 admission: the send was accepted but QUEUED (all slots taken).
 		// Show the "~N ahead" chip + Cancel instead of the streaming spinner; the
 		// reply begins when a slot frees (run:start clears queuedTurn). Position
@@ -7634,6 +7665,18 @@ const _GAP_TOKEN_RE = /⟦clip \d+⟧/g;
 function _stripGapTokens(s) {
 	return (s || "").replace(_GAP_TOKEN_RE, "").replace(/ {2,}/g, " ").trim();
 }
+// The failed clips whose placeholders are sitting in `s`, as 0-based seqs (the token renders
+// seq+1, matching the chip label). Read from the RAW composer text BEFORE _stripGapTokens erases
+// them: it is the only record of WHICH clips' words an outgoing message will be missing.
+// matchAll clones the regex, so the shared /g literal's lastIndex is never left dangling.
+function _gapSeqsIn(s) {
+	const out = [];
+	for (const m of String(s || "").matchAll(_GAP_TOKEN_RE)) {
+		const n = Number(m[0].replace(/\D+/g, ""));
+		if (Number.isFinite(n) && n >= 1) out.push(n - 1);
+	}
+	return out;
+}
 function _joinAppend(prev, t) {
 	return prev.trim() ? prev.replace(/\s+$/, "") + " " + t : t;
 }
@@ -7697,14 +7740,22 @@ function _replaceGapPlaceholder(seq, text, clip) {
 	const t = (text || "").trim();
 	if (t) _takeCommitted += t.length;
 	const tok = _gapToken(seq);
+	let appendedInstead = false;
 	_mutateComposerFor(_clipConvId(clip), (prev) => {
 		if (prev.includes(tok)) {
 			return t
 				? prev.split(tok).join(t)
 				: prev.split(tok).join(" ").replace(/ {2,}/g, " ").trim();
 		}
+		appendedInstead = !!t;
 		return t ? _joinAppend(prev, t) : prev;
 	});
+	// UX-4: the token is gone — typically because the message carrying it was already SENT and the
+	// composer cleared — so the recovered words land at the END of the current draft instead of back
+	// in place. Say so, or unexplained text just appears in an otherwise-empty composer and sits
+	// there until the user notices it (or navigates away and abandons it).
+	if (appendedInstead)
+		notify(`Recovered text for Clip ${seq + 1} added to your draft.`, { type: "info" });
 }
 // The user discarded a failed clip: drop its placeholder from the composer.
 function _removeGapPlaceholder(seq, clip) {
@@ -7820,6 +7871,18 @@ async function cancelMic() {
 }
 
 // ---- failed-clip chip actions ----
+// UX-1: a failed clip's chip means two different things and must not read the same for both. Before
+// the send it is a gap the user can still fix in place; after an accepted send it is a hole in a
+// message that has already gone, and Retry can only ever build a follow-up (the sent message is
+// immutable and the composer that held its placeholder was cleared).
+const failedChipLabel = (f) =>
+	f.sentWithout
+		? `Clip ${f.seq + 1} was missing from your last message`
+		: `Clip ${f.seq + 1} didn't transcribe`;
+const failedChipRetryTitle = (f) =>
+	f.sentWithout
+		? "Transcribe and add as a follow-up message"
+		: "Transcribe again — the words drop back into the ⟦clip⟧ placeholder in the message, where they belong";
 function retryClip(seq) {
 	if (voiceQueue) voiceQueue.retry(seq);
 }
@@ -7980,30 +8043,36 @@ async function discardOrphans() {
 }
 
 // ---- never-lost navigation guard ----
-// Fire ONLY for genuinely-volatile work (VUX-11 strict ruling): a live recording, or a
-// clip still pending/in-flight/failed in the in-memory queue. A recovery banner is
-// deliberately NOT counted — those clips are durably persisted in the IndexedDB mirror,
-// scoped to this user + conversation, and the banner re-offers them on return, so
-// navigation loses nothing (the leave-confirm's "may lose audio" copy would be false
-// for them). Discard/Later resolve the banner explicitly instead.
-function _voiceHasUnfinished() {
-	return (
-		!!(voiceQueue && voiceQueue.hasUnfinished()) ||
+// Fire ONLY for genuinely-volatile work (VUX-11 strict ruling): a live recording, a take
+// starting, or a clip the queue calls "live" — still pending/in-flight, un-persistable, or
+// committed into this volatile un-sent draft. A recovery banner is deliberately NOT counted —
+// those clips are durably persisted in the IndexedDB mirror, scoped to this user + conversation,
+// and the banner re-offers them on return, so navigation loses nothing (the leave-confirm's "may
+// lose audio" copy would be false for them). Discard/Later resolve the banner explicitly instead.
+// UX-3: for exactly that reason the guard arms on the queue's REASON, not on "anything
+// outstanding". A terminally-failed or sent-without clip is mirrored just as durably, so the same
+// loss-framed copy is just as false for it — and a warning that cries wolf is one users learn to
+// click through, weakening it for the live case that matters. "unresolved" therefore does not
+// block navigation at all: its chips and the recovery banner already carry it.
+function _voiceGuardReason() {
+	if (
 		micState.value === "recording" ||
 		// The permission prompt is open (getUserMedia pending): a take is starting but
 		// micState hasn't flipped to 'recording' yet — cover navigation during it (finding 2).
-		!!micRec.starting
-	);
+		micRec.starting
+	)
+		return "live";
+	return (voiceQueue && voiceQueue.hasUnfinishedReason()) || null;
 }
 function _beforeUnloadVoice(e) {
-	if (_voiceHasUnfinished()) {
+	if (_voiceGuardReason() === "live") {
 		e.preventDefault();
 		e.returnValue = "";
 		return "";
 	}
 }
 onBeforeRouteLeave(async () => {
-	if (!_voiceHasUnfinished()) return true;
+	if (_voiceGuardReason() !== "live") return true;
 	return await confirm({
 		title: "Leave with un-transcribed audio?",
 		message:
@@ -8406,8 +8475,8 @@ onMounted(async () => {
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);
 	window.addEventListener("keydown", onGlobalKey);
-	// Never-lost guard: warn on tab close/reload while any dictated clip is
-	// un-transcribed (armed/disarmed dynamically by _voiceHasUnfinished()).
+	// Never-lost guard: warn on tab close/reload while dictated audio is genuinely at risk
+	// (armed/disarmed dynamically by _voiceGuardReason() === "live").
 	window.addEventListener("beforeunload", _beforeUnloadVoice);
 	_thinkTimer = setInterval(() => {
 		thinkTick.value = busy.value ? thinkTick.value + 1 : 0;

--- a/jarvis/tests/test_voice_chip_lifecycle_client.py
+++ b/jarvis/tests/test_voice_chip_lifecycle_client.py
@@ -1,0 +1,65 @@
+"""The composer's voice-chip LIFECYCLE contract, proven by a REAL executable node test that lives
+in the python suite forever (the eventFence / voiceChunkQueue / voiceSendGlue precedent).
+
+The delete-after-send mechanism was never the bug: a failed clip is deliberately never released by
+a send (its words never made it into the payload), but nothing told the user that — the chip read
+identically to a stuck one, the sent message silently dropped the missing words with no marker and
+no confirmation, Retry promised to fix a message that had already gone, and the leave guard warned
+about losing audio that was in fact durably mirrored. The fixes span the queue primitive
+(``frontend/src/utils/voiceChunkQueue.js``: markSentWithoutClip, ``snapshot().failed[].sentWithout``,
+hasUnfinishedReason) and ChatView's wiring of it.
+
+The queue half is proven behaviorally by ``voiceChunkQueue.test.js``. The ChatView half cannot be:
+the single-file component has no harness in this app, so — exactly as ``pwa/src/lib/pumpFence.test.js``
+does for the Relay-Pump fence — ``frontend/src/utils/voiceChipLifecycle.test.js`` asserts the wiring
+against the SOURCE (the confirm runs before the strip and the POST; the sent-without flagging sits in
+the accepted-send branch beside the release; the chip copy + Retry tooltip branch on ``sentWithout``;
+the retry-after-send append is announced; the leave guard blocks only for a ``"live"`` reason), plus a
+decision-parity walk against the real queue. It also fences the done-clip
+captureSentInPayload → acknowledge release, the one path this work must not regress.
+
+This subprocess-runs it with ``node --test`` (which exits non-zero on any failed assertion) so the
+contract is enforced by every CI run, not just by ``npm run build``.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _lifecycle_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "utils", "voiceChipLifecycle.test.js")
+
+
+class TestVoiceChipLifecycleClient(unittest.TestCase):
+	def test_client_voice_chip_lifecycle_node_walk_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _lifecycle_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"voice chip-lifecycle test missing at {test_file} — the composer wiring walk MUST ship with the change",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		# node --test exits non-zero on ANY failed assertion; surface its output on failure.
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"client voice chip-lifecycle node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_voice_silence_gate_client.py
+++ b/jarvis/tests/test_voice_silence_gate_client.py
@@ -1,0 +1,67 @@
+"""The client-side near-silence gate for chunked dictation, proven by a REAL executable node
+test that lives in the python suite forever (the eventFence / voiceChunkQueue precedent).
+
+whisper-large-v3-turbo deterministically HALLUCINATES on near-silent audio — a pure-silence
+15 s webm transcribes as "Thank you." (3/3 on the probe) — and the chunked recorder rotates a
+clip every ~15 s whether or not anybody spoke, so an ordinary dictation pause would inject
+phrases the user never said into the composer. It cannot be filtered server-side: OpenRouter's
+transcription endpoint does not pass through ``verbose_json`` / ``no_speech_prob``, and a
+phrase blocklist was vetoed because it would swallow the same words when a user genuinely
+dictates them. So the gate is client-side: ``frontend/src/composables/useChunkedRecorder.js``
+runs a WebAudio AnalyserNode on the SAME MediaStream as the MediaRecorder and stamps each
+rotated clip with its peak RMS, and ChatView drops a clip measured below the threshold WITHOUT
+an API call — no text, no ⟦clip⟧ placeholder, no chip, not a failure.
+
+The decision + the meter live in a plain, importable module
+(``frontend/src/utils/voiceSilenceGate.js``) so they are testable without a browser.
+``frontend/src/utils/voiceSilenceGate.test.js`` drives them against injected WebAudio fakes and
+stitches the gate to the REAL voiceChunkQueue: a measured-silent clip is dropped end to end; a
+spoken clip transcribes; and every failure mode of the meter (no AudioContext, a constructor or
+graph call that throws, a suspended context, a clip shorter than one sample) reports UNMEASURED
+so the clip is still uploaded — absence of measurement must never cost audio.
+
+This subprocess-runs it with ``node --test`` (which exits non-zero on any failed assertion) so
+the client contract is enforced by every CI run, not just by ``npm run build``.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _gate_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "utils", "voiceSilenceGate.test.js")
+
+
+class TestVoiceSilenceGateClient(unittest.TestCase):
+	def test_client_voice_silence_gate_node_walk_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _gate_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"voice silence-gate test missing at {test_file} — the gate MUST ship with its walk",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		# node --test exits non-zero on ANY failed assertion; surface its output on failure.
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"client voice silence-gate node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)


### PR DESCRIPTION
> **Stacks on #464** (`fix/voice-chip-lifecycle`) — this branch is based on it because #464 owns the latest `voiceChunkQueue.js` / `ChatView.vue` voice glue. **Merge #464 first**; this PR's diff against `develop` will then be only the silence gate.

## Why

Desktop chunked dictation is moving to `whisper-large-v3-turbo` via OpenRouter's transcription endpoint (#463). That model **deterministically hallucinates on near-silent audio** — a pure-silence 15 s webm transcribes as `"Thank you."` 3/3 on today's probe.

The chunked recorder rotates a clip every ~15 s *whether or not anybody spoke*, and pauses mid-dictation are routine. Without a gate, every pause injects a confident little phrase the user never said into the composer.

It cannot be filtered server-side:
- OpenRouter does **not** pass through `verbose_json` / `no_speech_prob` (probed: it 400s), so there is no confidence signal to threshold on.
- A server-side artifact blocklist was vetoed — it would eat the same phrases when a user *genuinely* dictates them.

So the gate is client-side, at the microphone: measured near-silence never leaves the browser.

## What

- **`frontend/src/utils/voiceSilenceGate.js` (new)** — `createRmsMeter(stream, deps)` runs a WebAudio `AnalyserNode` on a MediaStream, sampling peak RMS at 10 Hz (4096-sample window ≈ 85 ms, so ~85% of the clip's timeline is observed and a short word can't slip between two windows). `isNearSilent(peakRms)` is the decision: strictly `<` a conservative **0.005** peak-RMS threshold (~-46 dBFS). The peak is taken across the **whole clip**, so one word anywhere in it clears the gate — skipping requires the entire 15 s to be inaudible. WebAudio and the timers are dependency-injected so `node --test` drives the real graph code without a browser.
- **`useChunkedRecorder.js`** — attaches the meter to the **same** `MediaStream` the `MediaRecorder` is recording, resets the peak at each cycle boundary (per-clip peak) and stamps each rotated clip with its measured `peakRms` (alongside the existing `durationS`). The meter is torn down with the stream.
- **`ChatView.vue`** — the clip handoff gates before the queue: a clip measured as near-silence is resolved **without an API call**. It contributes no text, leaves no `⟦clip⟧` placeholder, creates no chip, is not a failure and does not arm the leave guard — it simply never happened. A `console.debug` breadcrumb notes the skip (no new telemetry).

## The invariant that outranks the feature

**Absence of measurement must never drop audio.** Every failure mode reports UNMEASURED, and an unmeasured clip is uploaded exactly as it is today:

- no `AudioContext` / `webkitAudioContext` at all
- a constructor or graph call that throws (the half-built context is closed, not leaked)
- an analyser read that throws
- a clip that ended before the first sample
- **a context the browser suspended** — its analyser reads all-zero, which is indistinguishable from silence; `peak()` re-checks `ctx.state` so a parked context can never be mistaken for a pause

The analyser chain also terminates in a **muted** (`gain = 0`) node connected to the destination, so a browser that only renders a *pulled* graph cannot feed the analyser zeros and gate an entire session. Gain 0 means nothing is audible and there is no mic→speaker feedback path.

Every tie goes to keeping the audio: the comparison is strictly `<`, so a clip sitting exactly on the threshold is transcribed.

## Tests

25 new walks in `frontend/src/utils/voiceSilenceGate.test.js` (`node --test`, the `voiceChunkQueue.test.js` precedent), run in CI by the new `jarvis/tests/test_voice_silence_gate_client.py`:

- the decision table and the threshold boundary (at-threshold transcribes, one ULP under skips)
- every unmeasured/degrade path above, including the suspended-context trap
- the per-cycle peak reset (a loud clip must not shield the next clip's silence)
- **end to end against the real `voiceChunkQueue`**: a measured-silent clip makes no transcribe call, produces no chip, no placeholder, no failure and no armed guard; a loud clip runs the normal lifecycle; an unmeasured clip is always transcribed; a dropped pause doesn't disturb the seq ordering of the clips around it
- source assertions fencing the ChatView/recorder wiring the harness stands in for (gate strictly before `enqueue`, meter on the same stream, peak read before the next cycle resets it, meter torn down with the stream)

`voiceChipLifecycle.test.js` gains the chip consequence: a gated pause leaves the chip row exactly as it found it.

Run locally, all green: `voiceSilenceGate` + `voiceChipLifecycle` + `voiceChunkQueue` + `voiceSendGlue` = **83/83 pass**; `vite build` ✓ (1m 26s); pinned `pre-commit run prettier` + `ruff` + `eslint` pass.

## Risk notes

- The threshold is a judgement call. It errs low on purpose: too low merely restores today's behaviour (transcribe, risk a hallucination); too high deletes speech. Worth one real-mic pass confirming a normal pause measures under 0.005 and quiet/distant speech measures over it.
- The muted destination sink is the deliberate belt against a non-pulled graph; it keeps an output path open while recording.