### PR TITLE
fix(build): inject dev-only boot flags so admin panes render on vite serve

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -35,7 +35,7 @@ function devBootFlags() {
 	return {
 		name: "jarvis-dev-boot-flags",
 		apply: "serve", // vite never invokes this hook for `vite build`
-		transformIndexHtml(html) {
+		transformIndexHtml() {
 			const assignments = Object.entries(FLAGS)
 				.map(
 					([key, value]) =>
@@ -43,21 +43,23 @@ function devBootFlags() {
 							value
 						)};`
 				)
-				.join("\n\t\t\t");
-			return html.replace(
-				'<div id="app"></div>',
-				[
-					'<div id="app"></div>',
-					"\t\t<!-- DEV-ONLY SHIM (jarvis-dev-boot-flags, frontend/vite.config.js).",
-					"\t\t     NOT auth — grants zero server-side privilege, every admin API",
-					"\t\t     still re-checks permissions. Fills the boot flags Frappe would",
-					"\t\t     inject via www/jarvis.html so admin-gated settings panes are",
-					"\t\t     reachable on `vite serve`. Never present in a build. -->",
-					"\t\t<script>",
-					`\t\t\t${assignments}`,
-					"\t\t</script>",
-				].join("\n")
-			);
+				.join("\n");
+			// Returning tags (rather than a string.replace on the raw html) means
+			// this can't silently no-op if index.html's markup ever changes shape.
+			return [
+				{
+					tag: "script",
+					injectTo: "body", // same spot jinjaBootData uses in the real build
+					children: [
+						"// DEV-ONLY SHIM (jarvis-dev-boot-flags, frontend/vite.config.js).",
+						"// NOT auth: grants zero server-side privilege, every admin API",
+						"// still re-checks permissions. Fills the boot flags Frappe would",
+						"// inject via www/jarvis.html so admin-gated settings panes are",
+						"// reachable on `vite serve`. Never present in a build.",
+						assignments,
+					].join("\n"),
+				},
+			];
 		},
 	};
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -25,5 +25,9 @@ export default defineConfig({
 	},
 	optimizeDeps: {
 		include: ["frappe-ui > feather-icons", "showdown", "engine.io-client"],
+		exclude: ["frappe-ui"],
+	},
+	server: {
+		allowedHosts: true,
 	},
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,65 @@ import vue from "@vitejs/plugin-vue";
 import frappeui from "frappe-ui/vite";
 import path from "path";
 
+// DEV-ONLY SHIM — grants no server-side privilege whatsoever.
+//
+// Frappe injects window.is_system_manager / window.is_jarvis_admin (and
+// csrf_token, etc.) into jarvis/www/jarvis.html at render time via
+// jinjaBootData (see jarvis/www/jarvis.py). `vite serve` serves its own
+// frontend/index.html instead, which never goes through that Jinja render,
+// so those flags are simply undefined. SettingsDialog.vue, OnboardingGate.vue,
+// AiModelsPane.vue, etc. read window.is_system_manager / window.is_jarvis_admin
+// at component-setup time (before any user interaction), so the ACCOUNT AND
+// BILLING settings rail (Plan and billing, AI models, Connection, Billing and
+// metering, Branding) never renders on the dev server without this.
+//
+// This plugin fills ONLY those two flags, ONLY on `vite serve` (never
+// `vite build`), and ONLY when a flag isn't already set. It does not touch
+// the backend, does not create a session, and does not forge a CSRF token —
+// every admin API these panes call still re-checks require_jarvis_admin() /
+// System Manager server-side (jarvis/permissions.py). A user who is not
+// actually an admin still gets 403s from the real API calls; this only
+// unlocks the client-side rail so the panes are reachable to look at.
+//
+// csrf_token is deliberately NOT part of this shim: it's read at API-call
+// time (not at module-load time, unlike the two flags above), Frappe has no
+// clean endpoint to fetch a bare token for an SPA that skipped the
+// server-rendered boot, and a fabricated value would silently fail Frappe's
+// session-bound CSRF check. Net effect: panes render for visual review, but
+// Save/write actions through the dev server still fail — verify writes
+// against a served page (e.g. http://jarvis.proxy:8002/jarvis) instead.
+function devBootFlags() {
+	const FLAGS = { is_system_manager: true, is_jarvis_admin: true };
+	return {
+		name: "jarvis-dev-boot-flags",
+		apply: "serve", // vite never invokes this hook for `vite build`
+		transformIndexHtml(html) {
+			const assignments = Object.entries(FLAGS)
+				.map(
+					([key, value]) =>
+						`if (typeof window.${key} === "undefined") window.${key} = ${JSON.stringify(
+							value
+						)};`
+				)
+				.join("\n\t\t\t");
+			return html.replace(
+				'<div id="app"></div>',
+				[
+					'<div id="app"></div>',
+					"\t\t<!-- DEV-ONLY SHIM (jarvis-dev-boot-flags, frontend/vite.config.js).",
+					"\t\t     NOT auth — grants zero server-side privilege, every admin API",
+					"\t\t     still re-checks permissions. Fills the boot flags Frappe would",
+					"\t\t     inject via www/jarvis.html so admin-gated settings panes are",
+					"\t\t     reachable on `vite serve`. Never present in a build. -->",
+					"\t\t<script>",
+					`\t\t\t${assignments}`,
+					"\t\t</script>",
+				].join("\n")
+			);
+		},
+	};
+}
+
 export default defineConfig({
 	plugins: [
 		frappeui({
@@ -14,6 +73,7 @@ export default defineConfig({
 			},
 		}),
 		vue(),
+		devBootFlags(),
 	],
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary

Follow up to #462 (the `~icons/lucide` dev server crash fix). With that fixed the vite dev server serves the SPA correctly, but the admin gated settings panes are still unreachable there: the Account and billing rail group (Plan and billing, AI models, Connection, Billing and metering, Branding) never renders because `window.is_system_manager` and `window.is_jarvis_admin` are `undefined` on `vite serve`.

Frappe injects those two flags into `jarvis/www/jarvis.html` via jinjaBootData at render time (`jarvis/www/jarvis.py`). `vite serve` renders its own `frontend/index.html` instead, which never goes through that Jinja pass, so the flags are simply absent. `SettingsDialog.vue`, `OnboardingGate.vue`, `AiModelsPane.vue`, etc. read those two flags at component setup time, so setting them later from the browser console does not help, they have to be present before app code runs.

This matters right now because #461 migrated `AiModelsPane.vue` and `BrandingPane.vue`, and neither can be visually verified against the dev server as things stand.

## Change

Added a small `devBootFlags()` vite plugin in `frontend/vite.config.js` that fills in just those two flags via `transformIndexHtml`, guarded with `apply: "serve"` so Vite never invokes the hook for `vite build`. It only sets a flag when it is not already defined, so it can never clobber a real value. The hook returns an `HtmlTagDescriptor` for Vite to inject rather than doing its own `html.replace` on a literal string, so it cannot silently no-op if `frontend/index.html`'s markup ever changes shape (self-review fix in the second commit).

This grants no server side privilege whatsoever. Every admin API these panes call still re-checks `require_jarvis_admin()` / System Manager on the backend (`jarvis/permissions.py`). A user who is not actually an admin still gets a real 403 from the real API calls. This only unlocks the client side rail gate so the panes are reachable to look at.

`csrf_token` is intentionally left out of the shim. It is read at API call time, not module load time (unlike the two flags above), so it did not need to be present synchronously the way `is_system_manager`/`is_jarvis_admin` do. Frappe has no clean endpoint to source a bare CSRF token for an SPA that skipped the server rendered boot, and a fabricated value would just fail Frappe's session bound CSRF check silently. Net effect: the panes render for visual review on the dev server, but Save/write actions through the dev server still fail. Verify writes against a served page instead (e.g. `http://jarvis.proxy:8002/jarvis`).

## Verification (curl only, no browser tool used)

Dev server started from this worktree (`FRAPPE_WEB_SERVER_PORT=8002 npx vite --force --host`, auto-fell back to port 8083 since 8082 was in use by another running session):

```
$ curl -s -H "Host: jarvis.proxy:8083" http://localhost:8083/jarvis/ | tail -12
        <!-- frappe-ui's jinjaBootData plugin injects window.<bootkey> = ... here at
             build time; Frappe fills the values at /jarvis via www/jarvis.py. -->
        <script type="module" src="/src/main.js"></script>
        <script>// DEV-ONLY SHIM (jarvis-dev-boot-flags, frontend/vite.config.js).
// NOT auth: grants zero server-side privilege, every admin API
// still re-checks permissions. Fills the boot flags Frappe would
// inject via www/jarvis.html so admin-gated settings panes are
// reachable on `vite serve`. Never present in a build.
if (typeof window.is_system_manager === "undefined") window.is_system_manager = true;
if (typeof window.is_jarvis_admin === "undefined") window.is_jarvis_admin = true;</script>
    </body>
</html>
```

API proxy to the real backend still works correctly through the same dev server (webserver_port is derived from `FRAPPE_WEB_SERVER_PORT`, independent of vite's own listen port):

```
$ curl -s -H "Host: jarvis.proxy" http://localhost:8083/api/method/ping
{"message":"pong"}
```

Production build, then grep the built output for the shim's unique markers (expect nothing):

```
$ npm run build
  5160 modules transformed, built in 55.86s
  (one pre-existing warning, unrelated to this change: some chunks are
  larger than 500 kB after minification, e.g. mermaid/echarts/3d-force-graph)

$ grep -rn "jarvis-dev-boot-flags\|DEV-ONLY SHIM" jarvis/public/frontend/ jarvis/www/jarvis.html
  (no output, exit 1 both times)
```

`jarvis/www/jarvis.html` after build still only has the real Jinja boot loop (`{% for key in boot %}`), no shim.

## Pre-commit

```
$ pre-commit run --files frontend/vite.config.js
trim trailing whitespace.............................(no files to check)Skipped
don't commit to branch...................................................Passed
check for merge conflicts.................................................Passed
prettier...................................................................Passed
eslint......................................................................Passed
```

## CI

No local CI evidence. The `jarvis-ci` harness OOMs on this machine (one suite runs 12 containers on a 9.7 GB Colima VM), so this was opened with `JCI_SKIP=1`. Hosted GitHub Actions is the real gate and is currently working despite a stale "billing exhausted" message in a local hook; the checks on this PR are what should be trusted.

## Notes for reviewers

This branch is stacked on `fix/worktree-dev-server-icon-scan` (#462, open at the time of this PR). Until #462 merges into `develop`, this PR's diff includes that commit too; it will shrink to just the change above once #462 lands.
