### PR TITLE
fix(build): fetch a real per-session csrf_token for vite serve

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -98,6 +98,15 @@ function devBootFlags() {
 // before the slower one's transformIndexHtml ran; AsyncLocalStorage gives
 // each request its own store instead, so there is no cross-request race to
 // reason about.
+//
+// Residual trust assumption: fetchSessionCsrfToken() (below) picks its fetch
+// target from the request's own Host header. server.allowedHosts: true (#462)
+// means Vite itself will accept any Host, so without isKnownSiteHost()'s
+// check this would be an unauthenticated header choosing where the user's
+// session cookie gets sent. isKnownSiteHost() narrows that from "any host" to
+// "a host this bench actually has a site for" before the cookie is ever
+// forwarded anywhere. That does not make the Host header trusted, it only
+// bounds the blast radius to this bench's own configured sites.
 const csrfRequestContext = new AsyncLocalStorage();
 
 function devCsrfToken() {
@@ -177,10 +186,47 @@ function getWebserverPort() {
 	}
 }
 
+// Host header, stripped to bare hostname. Handles the IPv6-literal form
+// (`[::1]:8095`, brackets required by RFC 3986 so the literal's own colons
+// don't collide with the port separator) — split(":")[0] alone would yield
+// "[" for that form. Plain hostnames only ever have one colon (the port), so
+// splitting on the first one is enough for the common case.
+function hostnameFromHeader(hostHeader) {
+	if (!hostHeader) return "";
+	if (hostHeader.startsWith("[")) {
+		const end = hostHeader.indexOf("]");
+		return end === -1 ? "" : hostHeader.slice(1, end);
+	}
+	return hostHeader.split(":")[0];
+}
+
+// Is `host` one of THIS bench's actual sites? Read from sites/ directly
+// (a directory is a site iff it has its own site_config.json — the same
+// signal frappe's own bench CLI uses) rather than hardcoding names, so a
+// newly-created site doesn't have to be taught to this file. `localhost` /
+// `127.0.0.1` are deliberately never in this list: bench is Host-routed, so
+// the backend itself already 404s both today ("<host> does not exist") —
+// this isn't a new restriction, just not silently pretending they'd work.
+const SITE_NAME_PATTERN = /^[a-zA-Z0-9.-]+$/; // Frappe site names are domain-like; also rules out "../" before it ever reaches path.join
+function isKnownSiteHost(host) {
+	if (!host || !SITE_NAME_PATTERN.test(host)) return false;
+	const benchRoot = findBenchRoot(__dirname);
+	return !!benchRoot && fs.existsSync(path.join(benchRoot, "sites", host, "site_config.json"));
+}
+
 async function fetchSessionCsrfToken(req, logger) {
 	const cookie = req.headers.cookie;
-	const host = (req.headers.host || "").split(":")[0];
+	const host = hostnameFromHeader(req.headers.host);
 	if (!cookie || !host) return null; // no session cookie forwarded (not logged in yet) — nothing to look up
+
+	// Fail closed: server.allowedHosts: true (from #462) means Vite itself
+	// accepts any Host header, and this function forwards the request's
+	// session cookie to wherever `host` points. Left unchecked, that's an
+	// unauthenticated header choosing the destination for a credential — so
+	// only ever fetch for a host this bench actually hosts. An unrecognised
+	// host gets no token and no crash, same as a request with no cookie: the
+	// page loads exactly as it does for a logged-out session today.
+	if (!isKnownSiteHost(host)) return null;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 5000);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import frappeui from "frappe-ui/vite";
 import path from "path";
+import fs from "fs";
+import { AsyncLocalStorage } from "async_hooks";
 
 // DEV-ONLY SHIM — grants no server-side privilege whatsoever.
 //
@@ -23,13 +25,10 @@ import path from "path";
 // actually an admin still gets 403s from the real API calls; this only
 // unlocks the client-side rail so the panes are reachable to look at.
 //
-// csrf_token is deliberately NOT part of this shim: it's read at API-call
-// time (not at module-load time, unlike the two flags above), Frappe has no
-// clean endpoint to fetch a bare token for an SPA that skipped the
-// server-rendered boot, and a fabricated value would silently fail Frappe's
-// session-bound CSRF check. Net effect: panes render for visual review, but
-// Save/write actions through the dev server still fail — verify writes
-// against a served page (e.g. http://jarvis.proxy:8002/jarvis) instead.
+// csrf_token used to be deliberately excluded from this shim (Frappe has no
+// clean bare-token endpoint, and a fabricated value would silently fail the
+// session-bound CSRF check). devCsrfToken() below closes that gap for real,
+// by fetching the actual per-session token instead of fabricating one.
 function devBootFlags() {
 	const FLAGS = { is_system_manager: true, is_jarvis_admin: true };
 	return {
@@ -64,6 +63,158 @@ function devBootFlags() {
 	};
 }
 
+// DEV-ONLY SHIM — grants no server-side privilege whatsoever.
+//
+// window.csrf_token is undefined on `vite serve` for the same reason the two
+// boot flags above are: the real value only ever gets baked in by Frappe's
+// Jinja render of jarvis/www/jarvis.html (context.boot.csrf_token =
+// frappe.sessions.get_csrf_token(), see jarvis/www/jarvis.py), and vite serves
+// its own frontend/index.html instead. frappe-ui's call() (utils/call.js)
+// reads window.csrf_token at CALL time, not at module load, so every write
+// AND every whitelisted read that isn't allow_guest gets rejected with
+// frappe.exceptions.CSRFTokenError before this shim: settings panes render
+// their chrome but stay empty or show an error state forever.
+//
+// The fix is to fetch the token for real rather than fabricate one — a fake
+// value would fail the session-bound check just as loudly as no value, but
+// more confusingly. So this asks the SAME backend for the SAME thing it would
+// hand the browser on a normal page load: a request to this site's own
+// server-rendered /jarvis, with the browser's session cookie forwarded,
+// scrape the csrf_token straight out of the boot script jinjaBootData put
+// there. That means this only ever succeeds for a request carrying a cookie
+// for a session that already has Jarvis access (frappe.sessions.get_csrf_token
+// is session-scoped, not per-page) — no new authorization boundary is opened.
+//
+// This has to be split across two plugin hooks because Vite's dev-mode
+// transformIndexHtml hook (unlike the build-mode one) is only ever handed
+// {path, filename, server, originalUrl} — no request object, so no cookies.
+// configureServer() below registers a middleware (added directly, so Vite
+// installs it BEFORE its own internal ones, including the one that serves
+// index.html and fires transformIndexHtml) that does the fetch and stashes
+// the result in an AsyncLocalStorage store for transformIndexHtml to read
+// back. A plain module-level variable would do the same job on a single
+// serialized request stream, but two page loads racing their backend fetches
+// (e.g. two tabs opened together) could then clobber each other's token
+// before the slower one's transformIndexHtml ran; AsyncLocalStorage gives
+// each request its own store instead, so there is no cross-request race to
+// reason about.
+const csrfRequestContext = new AsyncLocalStorage();
+
+function devCsrfToken() {
+	return {
+		name: "jarvis-dev-csrf-token",
+		apply: "serve", // vite never invokes this hook for `vite build`
+		configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				// Only a real document navigation (full load / hard refresh) needs
+				// this: SPA route changes never hit the server, and the app's own
+				// XHR/fetch calls to /api/... ask for JSON, not text/html, so this
+				// never fires per API call — only once per page load.
+				if (req.method !== "GET" || !(req.headers.accept || "").includes("text/html")) {
+					return next();
+				}
+				const store = { token: null };
+				csrfRequestContext.run(store, () => {
+					fetchSessionCsrfToken(req, server.config.logger)
+						.then((token) => {
+							store.token = token;
+						})
+						.finally(next);
+				});
+			});
+		},
+		transformIndexHtml() {
+			const token = csrfRequestContext.getStore()?.token;
+			if (!token) return []; // no session cookie, no access, or the backend fetch failed — leave undefined, same as before this shim
+			return [
+				{
+					tag: "script",
+					injectTo: "body", // same spot jinjaBootData uses in the real build
+					children: [
+						"// DEV-ONLY SHIM (jarvis-dev-csrf-token, frontend/vite.config.js).",
+						"// NOT auth: this is the real per-session token, fetched server-side",
+						"// from this same backend's own /jarvis render — the backend still",
+						"// authenticates the session cookie and authorizes every request",
+						"// exactly as it does for a served page. Never present in a build.",
+						`if (typeof window.csrf_token === "undefined") window.csrf_token = ${JSON.stringify(
+							token
+						)};`,
+					].join("\n"),
+				},
+			];
+		},
+	};
+}
+
+// Walks up from `dir` looking for the bench root (the directory that has both
+// `sites/` and `apps/` as children) — same signal frappe-ui's own vite plugin
+// uses (frappe-ui/vite/utils.js findBenchPath), reimplemented here because
+// that file isn't part of frappe-ui's package "exports" map. Walking up
+// (rather than a fixed relative depth) is what makes this work unchanged from
+// a git worktree nested arbitrarily deeper than frontend/../../..
+function findBenchRoot(dir) {
+	for (;;) {
+		if (fs.existsSync(path.join(dir, "sites")) && fs.existsSync(path.join(dir, "apps"))) {
+			return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) return null; // reached filesystem root without finding one
+		dir = parent;
+	}
+}
+
+function getWebserverPort() {
+	if (process.env.FRAPPE_WEB_SERVER_PORT) {
+		return Number(process.env.FRAPPE_WEB_SERVER_PORT);
+	}
+	const benchRoot = findBenchRoot(__dirname);
+	const configPath = benchRoot && path.join(benchRoot, "sites", "common_site_config.json");
+	if (!configPath || !fs.existsSync(configPath)) return 8000; // matches frappeProxy()'s own fallback
+	try {
+		return JSON.parse(fs.readFileSync(configPath, "utf-8")).webserver_port || 8000;
+	} catch {
+		return 8000;
+	}
+}
+
+async function fetchSessionCsrfToken(req, logger) {
+	const cookie = req.headers.cookie;
+	const host = (req.headers.host || "").split(":")[0];
+	if (!cookie || !host) return null; // no session cookie forwarded (not logged in yet) — nothing to look up
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 5000);
+	try {
+		// Bench is Host-routed, so hit the SAME site the browser asked vite for.
+		// This is a direct request to the real Frappe webserver, not through
+		// vite's own /api proxy: that proxy only covers desk|app|login|api|assets
+		// |files|private (see frappe-ui/vite/frappeProxy.js) — /jarvis is vite's
+		// own SPA route, never proxied.
+		const response = await fetch(`http://${host}:${getWebserverPort()}/jarvis`, {
+			headers: { Cookie: cookie },
+			// A guest or a session without Jarvis access gets a 30x from
+			// jarvis/www/jarvis.py's has_jarvis_access() gate, to /app or
+			// /jarvis-no-access. Treat that as "no token" rather than following
+			// it — the redirect target's markup carries no csrf_token of ours.
+			redirect: "manual",
+			signal: controller.signal,
+		});
+		if (response.status !== 200) return null;
+		const html = await response.text();
+		// frappe-ui's jinjaBootData plugin renders context.boot.csrf_token as
+		// window["csrf_token"] = <tojson>; — see jarvis/www/jarvis.py.
+		const match = html.match(/window\["csrf_token"\]\s*=\s*("(?:[^"\\]|\\.)*")/);
+		return match ? JSON.parse(match[1]) : null;
+	} catch (error) {
+		logger.warn(`[jarvis-dev-csrf-token] could not fetch a real token: ${error.message}`, {
+			timestamp: true,
+		});
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 export default defineConfig({
 	plugins: [
 		frappeui({
@@ -76,6 +227,7 @@ export default defineConfig({
 		}),
 		vue(),
 		devBootFlags(),
+		devCsrfToken(),
 	],
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary

Third and final piece of the dev-server work (after #462, the `~icons/lucide` crash
fix, and #466, the admin boot-flag shim). With both of those merged the dev server
serves the SPA and the admin-gated settings panes are reachable, but every API call
through it still failed. `window.csrf_token` is undefined on `vite serve`, and
frappe-ui's `call()` always issues a POST (even for reads), so every call was
rejected with `frappe.exceptions.CSRFTokenError: Invalid Request` before reaching the
handler. Visible symptom: settings panes render their chrome but stay empty or show
an error state, e.g. the AI models pane showing "Couldn't load your AI connection"
instead of real data. Dev verification covered layout, theming and error states only,
never populated content, never saving.

## Approach taken

Went with option 1 from the brief: have the dev server fetch the backend's own
server-rendered `/jarvis` page, forwarding the browser's session cookie, and take the
real `csrf_token` out of it. `jarvis/www/jarvis.py` sets
`context.boot["csrf_token"] = frappe.sessions.get_csrf_token()`, and frappe-ui's
`jinjaBootData` plugin renders that as `window["csrf_token"] = "...";` in the real
page. `devCsrfToken()` fetches that same page directly from the backend (bench is
Host-routed, so it hits `http://<host-from-request>:<webserver_port>/jarvis`, the
real Frappe process, not through vite's own `/api` proxy since `/jarvis` is vite's own
SPA route and is never proxied) and scrapes the token out with a regex, then injects
it the same way #466 injects the two boot flags: only if `window.csrf_token` is not
already defined.

This only ever succeeds for a request carrying a cookie for a session that already
has Jarvis access (`get_csrf_token` is session-scoped, not per-page, and
`has_jarvis_access()`'s redirect on a guest/unauthorized session yields a non-200,
which is treated as "no token"). No new authorization boundary opens. The backend
still authenticates the session and authorizes every request exactly as it does for a
served page.

I did not go with option 2 (a bootstrap script racing the app's first call). Frappe-ui
does read `window.csrf_token` at call time rather than module load
(`frappe-ui/src/utils/call.js`), so a bootstrap fetch racing the app boot is less
dangerous than it first looks: a call issued before the bootstrap script resolves just
goes out with no CSRF header and 403s, and then works after the token lands. But that
still means the first render is flaky in a way that depends on exact network timing
between two independent async operations, and it does not fix option 2's own
weakness: a bootstrap script running client-side still has to hit some backend
endpoint to get the token, and it would have needed the same
fetch-`/jarvis`-and-scrape trick anyway since Frappe has no bare-token endpoint. Doing
that fetch server-side instead, inside `transformIndexHtml`, means the token is
already in the HTML before the browser ever parses it: synchronous from the page's
point of view, with no race to reason about, at the cost of one extra localhost
round-trip added to full-page loads (not per API call, since SPA route changes never
hit the server again).

## Implementation notes

Vite's dev-mode `transformIndexHtml` hook is only ever handed
`{path, filename, server, originalUrl}`, no request object, so no way to read the
incoming cookie there directly (confirmed against the installed vite@5.4.21 source).
So this is split across two plugin hooks: `configureServer()` registers a middleware
directly (not returned as a function), which is what makes Vite install it *before*
its own internal middlewares, including the one that serves `index.html` and fires
`transformIndexHtml`. That middleware does the backend fetch and stashes the result in
an `AsyncLocalStorage` store scoped to the request, which `transformIndexHtml` reads
back. A plain module-level variable would work for a single serialized request
stream, but two page loads racing their backend fetches (two tabs opened together)
could then let a faster request's token clobber a slower one's before its
`transformIndexHtml` ran. `AsyncLocalStorage` gives each request its own store, so
there's no cross-request race to reason about.

The middleware only does the fetch for `GET` requests with `Accept: text/html` (a
real document navigation), so it does not fire per API call and does not fire for
asset requests, module fetches, or the HMR websocket.

`getWebserverPort()` re-derives the bench's real Frappe port by walking up from the
config file's own location looking for a directory with both `sites/` and `apps/` as
children, the same signal frappe-ui's own `frappeProxy()` plugin uses internally
(`frappe-ui/vite/utils.js`, `findBenchPath`). That file isn't part of frappe-ui's
package `exports` map, so it can't be imported directly; walking up from `__dirname`
rather than hardcoding a relative depth is also what makes this keep working
unchanged from a git worktree nested arbitrarily deeper than a plain checkout.

## Hard requirements checklist

- **Real token, never fabricated.** `devCsrfToken()` never invents a value. If the
  cookie is missing, the fetch fails, or the backend redirects (no Jarvis access),
  it returns `null` and injects nothing, same as before this PR.
- **Dev only, provably absent from a build.** Both plugins are guarded with
  `apply: "serve"`, which Vite never invokes for `vite build`. See the build proof
  below: grepping the entire built output for every shim marker returns zero matches.
- **Did not weaken the shared site.** No site config was touched. `ignore_csrf` is
  untouched everywhere.
- **Never overrides a real value.** `if (typeof window.csrf_token === "undefined")`,
  same pattern #466 already uses for the two boot flags.
- **Commented as a dev shim, no server-side privilege.** Both the source comment and
  the injected script tag itself say so explicitly.

## Verification (curl only, no browser tool used)

Per the task constraint, no browser tool was used anywhere in this session.

**Getting a session cookie legitimately:** created a disposable test user
(`dev-csrf-verify@example.com`, System Manager role) via `bench --site jarvis.proxy
console`, logged in through Frappe's real `/api/method/login` endpoint with curl to
get a genuine `sid` cookie (the same endpoint a browser login form hits), used that
cookie for every check below, then deleted the user afterward
(`frappe.delete_doc("User", ..., force=True)`, confirmed gone via
`frappe.db.exists`). Nothing was left behind on the shared tenant.

Dev server started from this worktree on port 8095 (8082 and 8083 were already held
by two other worktrees' running dev servers, `jarvis-dev-server-icon-fix` and
`jarvis-dev-server-admin-flags`, both left untouched). The committed `vite.config.js`
has no hardcoded port; 8095 came from a separate untracked `vite.config.verify.js`
used only to run this instance without colliding, never part of the diff.

Real token present in the served HTML, and it matches the token the backend's own
`/jarvis` page renders for the same session:

```
$ curl -s -b cookies.txt -H "Host: jarvis.proxy:8095" -H "Accept: text/html" \
    http://jarvis.proxy:8095/jarvis | grep -o 'window\.csrf_token[^;]*;'
window.csrf_token === "undefined") window.csrf_token = "73bd46d7c95d171db0f784caf8dba03a2ae519803edebdcb4cc34289";

$ curl -s -b cookies.txt -H "Host: jarvis.proxy" http://127.0.0.1:8002/jarvis \
    | grep -o 'window\["csrf_token"\][^;]*;'
window["csrf_token"] = "73bd46d7c95d171db0f784caf8dba03a2ae519803edebdcb4cc34289";
```

An actual authenticated API call now succeeds through the dev server, using that
token exactly the way frappe-ui's `call()` would send it:

```
$ curl -s -b cookies.txt -H "Host: jarvis.proxy:8095" -X POST \
    -H "X-Frappe-CSRF-Token: 73bd46d7c95d171db0f784caf8dba03a2ae519803edebdcb4cc34289" \
    -d '{}' http://jarvis.proxy:8095/api/method/jarvis.account.is_ready_for_chat
{"message":{"ready":true,"reason":null,"billing_notice":{}}}
```

Same check for the two panes named in the brief, both real endpoints the pane
components actually call (`getDirectSubscriptionStatus` / `getBranding` in
`frontend/src/api.js`):

```
$ curl ... http://jarvis.proxy:8095/api/method/jarvis.oauth.api.get_direct_subscription_status
{"message":{"is_direct_subscription":false,"connected":false,"auth_mode":"api_key", ...}}

$ curl ... http://jarvis.proxy:8095/api/method/jarvis.branding.get_branding
{"message":{"ok":true,"data":{"agent_name":"","brand_logo_url":"","brand_favicon_url":""}}}
```

Negative control, same request with no token / a fabricated one, still rejected
exactly like before this PR (server-side enforcement is untouched):

```
$ curl ... -H "X-Frappe-CSRF-Token: totally-fake-token" -d '{}' \
    http://jarvis.proxy:8095/api/method/jarvis.account.is_ready_for_chat
{"exception":"frappe.exceptions.CSRFTokenError: Invalid Request", ...}
```

Production build, then grep the built output for every shim marker (expect nothing):

```
$ npm run build
✓ 5160 modules transformed, built in 25.34s

$ grep -rn 'typeof window.csrf_token === "undefined"\|jarvis-dev-csrf-token\|jarvis-dev-boot-flags\|fetchSessionCsrfToken\|DEV-ONLY SHIM' \
    jarvis/public/frontend jarvis/www/jarvis.html
(zero matches)
```

`jarvis/www/jarvis.html` after build still only has the real Jinja boot loop
(`{% for key in boot %}`), the actual production mechanism, untouched.

## Pre-commit

```
$ pre-commit run --files frontend/vite.config.js
don't commit to branch....................................................Passed
check for merge conflicts.................................................Passed
prettier...................................................................Passed
eslint......................................................................Passed
```

## CI

No local CI evidence. The `jarvis-ci` harness OOMs on this machine (one suite runs 12
containers on a 9.7 GB Colima VM), so this was opened with `JCI_SKIP=1`. Hosted GitHub
Actions is the real gate and is currently working despite a stale "billing exhausted"
message in a local hook; the checks on this PR are what should be trusted.

## For the coordinating session

Dev server is up at `http://jarvis.proxy:8095/jarvis` (this worktree,
`fix/dev-server-csrf-token`). AI models and Branding panes should now load real data
instead of their error states. No browser tool was used to check this from this
session, curl only, per the task constraint.
