### PR TITLE
fix(dashboards): clear the composer, ask before building, keep the canvas

### DIFF
--- a/frontend/src/components/chat/AskCard.vue
+++ b/frontend/src/components/chat/AskCard.vue
@@ -197,10 +197,12 @@ function isPicked(i, opt) {
 }
 function submit() {
 	if (!ready.value) return;
-	const text = askAnswerText(props.spec, sel.value, other.value);
-	sel.value = {};
-	other.value = {};
-	emit("submit", text);
+	// Emit and keep the picks. The card is keyed by message, so it unmounts the
+	// moment the next assistant message arrives — there is nothing to reset. And
+	// a host is allowed to REFUSE the text (a send already in flight, a dictation
+	// still transcribing): clearing first would silently swallow the answers and
+	// leave the user staring at an empty, disabled card.
+	emit("submit", askAnswerText(props.spec, sel.value, other.value));
 }
 </script>
 

--- a/frontend/src/components/chat/AskCard.vue
+++ b/frontend/src/components/chat/AskCard.vue
@@ -1,0 +1,402 @@
+<template>
+	<div class="jv-ask" :class="{ 'jv-ask--form': isForm }">
+		<div v-for="(q, qi) in spec.questions" :key="qi" class="jv-ask-q">
+			<div class="jv-ask-qt">
+				<span class="jv-ask-num">{{ qi + 1 }}</span
+				>{{ q.q }}
+			</div>
+			<!-- yes/no, with optional custom labels (e.g. Approve / Reject) -->
+			<div v-if="q.type === 'yesno'" class="jv-ask-opts">
+				<button
+					v-for="(lbl, li) in q.options.length === 2 ? q.options : ['Yes', 'No']"
+					:key="li"
+					class="jv-ask-opt"
+					:class="{ on: isPicked(qi, lbl) }"
+					@click="toggleSingle(qi, lbl)"
+				>
+					<span v-if="isPicked(qi, lbl)" class="jv-ask-tick">✓</span>{{ lbl }}
+				</button>
+			</div>
+			<!-- single / multi choice -->
+			<div v-else-if="q.type === 'single' || q.type === 'multi'" class="jv-ask-opts">
+				<button
+					v-for="(opt, oi) in q.options"
+					:key="oi"
+					class="jv-ask-opt"
+					:class="{ on: isPicked(qi, opt) }"
+					@click="q.type === 'multi' ? toggleMulti(qi, opt) : toggleSingle(qi, opt)"
+				>
+					<span v-if="isPicked(qi, opt)" class="jv-ask-tick">✓</span>{{ opt }}
+				</button>
+			</div>
+			<!-- date / datetime / free text fields -->
+			<input
+				v-else-if="q.type === 'date'"
+				type="date"
+				class="jv-ask-field"
+				:value="sel[qi] || ''"
+				@input="pickSingle(qi, $event.target.value)"
+			/>
+			<input
+				v-else-if="q.type === 'datetime'"
+				type="datetime-local"
+				class="jv-ask-field"
+				:value="sel[qi] || ''"
+				@input="pickSingle(qi, $event.target.value)"
+			/>
+			<input
+				v-else-if="q.type === 'text'"
+				type="text"
+				class="jv-ask-field"
+				:value="sel[qi] || ''"
+				@input="pickSingle(qi, $event.target.value)"
+				placeholder="Type your answer…"
+				@keydown.enter.prevent
+			/>
+			<!-- link: search a record of the given DocType -->
+			<div v-else-if="q.type === 'link'" class="jv-ask-link">
+				<input
+					type="text"
+					class="jv-ask-field"
+					:value="link[qi] && link[qi].q != null ? link[qi].q : sel[qi] || ''"
+					@input="onLinkSearch(qi, q.doctype, $event.target.value)"
+					@focus="onLinkSearch(qi, q.doctype, (link[qi] && link[qi].q) || '')"
+					:placeholder="'Search ' + (q.doctype || 'records') + '…'"
+					@blur="closeLink(qi)"
+					@keydown.enter.prevent
+				/>
+				<div
+					v-if="link[qi] && link[qi].open && (link[qi].items || []).length"
+					class="jv-ask-linkmenu"
+				>
+					<button
+						v-for="(it, ii) in link[qi].items"
+						:key="ii"
+						@mousedown.prevent="pickLink(qi, it)"
+					>
+						<b>{{ it.value }}</b
+						><span v-if="it.label"> · {{ it.label }}</span>
+					</button>
+				</div>
+			</div>
+			<!-- Other free-text only for choice questions -->
+			<input
+				v-if="q.type === 'single' || q.type === 'multi' || q.type === 'yesno'"
+				class="jv-ask-other"
+				v-model="other[qi]"
+				placeholder="Other…"
+				@input="onOther(qi, q.type)"
+				@keydown.enter.prevent
+			/>
+		</div>
+		<div class="jv-ask-foot">
+			<button class="jv-ask-submit" :disabled="!ready" @click="submit">
+				Submit answers
+			</button>
+			<span v-if="!ready" class="jv-ask-hint">Answer each question to continue</span>
+		</div>
+	</div>
+</template>
+
+<script setup>
+// AskCard - the ONE renderer for the agent's ```jarvis-ask blocks: option cards
+// (or a compact mini-form when every question is a field type) plus a single
+// "Submit answers" button that emits the answers as the next user message.
+//
+// Extracted from ChatView so the Dashboards builder pane renders identical
+// cards instead of stripping the block into an empty bubble. The parsing /
+// readiness / answer-formatting rules live in @/lib/chatAsk, shared with any
+// caller; this component owns only the draft state and the interaction.
+//
+// Styling is the jv-* design tokens (var(--surface-2), var(--cta), …). Those
+// are NOT global: the host must sit inside a subtree that binds
+// useJarvisTheme().paletteVars (ChatView's root does; the dashboards pane binds
+// them on its wrapper, the SkillDetail precedent).
+//
+// HOSTS MUST KEY THIS BY MESSAGE (`:key="m.name"`). The draft lives in this
+// component, and `spec` is typically a computed that re-parses (new object
+// identity) on every stream tick — resetting on a `spec` watcher would wipe
+// half-made picks. Remounting on a new message is what clears the draft.
+import { ref, computed } from "vue";
+import { searchLink } from "@/api";
+import { ASK_FIELD_TYPES, isAskReady, askAnswerText } from "@/lib/chatAsk";
+
+const props = defineProps({
+	// A parsed ask: { questions: [{q, type, options, doctype}] } (see parseAsk).
+	spec: { type: Object, required: true },
+});
+// The formatted answer text; the host sends it as an ordinary user message.
+const emit = defineEmits(["submit"]);
+
+const sel = ref({}); // qIdx -> string (single/yesno/date/datetime/text/link) | string[] (multi)
+const other = ref({}); // qIdx -> free-text (option types only)
+const link = ref({}); // qIdx -> { q, items, open } for link-type record search
+
+// An ask whose questions are ALL field-type reads better as a compact mini-form
+// (no numbered badges, no dividers) than as a numbered question list.
+const isForm = computed(
+	() =>
+		props.spec.questions.length > 0 &&
+		props.spec.questions.every((q) => ASK_FIELD_TYPES.includes(q.type))
+);
+const ready = computed(() => isAskReady(props.spec, sel.value, other.value));
+
+async function onLinkSearch(i, doctype, val) {
+	link.value = { ...link.value, [i]: { ...(link.value[i] || {}), q: val, open: true } };
+	if (!doctype) return;
+	try {
+		const r = await searchLink(doctype, val);
+		const items = (r || [])
+			.map((x) => ({ value: x.value, label: x.description || "" }))
+			.slice(0, 8);
+		link.value = { ...link.value, [i]: { q: val, items, open: true } };
+	} catch (e) {
+		link.value = { ...link.value, [i]: { q: val, items: [], open: true } };
+	}
+}
+function pickLink(i, item) {
+	sel.value = { ...sel.value, [i]: item.value };
+	link.value = { ...link.value, [i]: { q: item.value, items: [], open: false } };
+}
+// Hide the record dropdown when the field loses focus (clicking elsewhere on
+// the screen / tabbing away). @mousedown.prevent on the result buttons lets a
+// pick land before the blur fires.
+function closeLink(i) {
+	const cur = link.value[i];
+	if (cur && cur.open) link.value = { ...link.value, [i]: { ...cur, open: false } };
+}
+function pickSingle(i, opt) {
+	sel.value = { ...sel.value, [i]: opt };
+}
+// Option BUTTONS (single/yesno) toggle: clicking the picked option again
+// unselects it, and picking one clears the "Other…" text (they're exclusive —
+// both being sent as the answer was a reported bug).
+function toggleSingle(i, opt) {
+	const cur = sel.value[i];
+	sel.value = { ...sel.value, [i]: cur === opt ? "" : opt };
+	if (cur !== opt && (other.value[i] || "").trim()) {
+		other.value = { ...other.value, [i]: "" };
+	}
+}
+// Typing in "Other…" clears a picked option for single/yesno (mirror of the above).
+function onOther(i, qtype) {
+	if (qtype !== "multi" && (other.value[i] || "").trim() && sel.value[i]) {
+		sel.value = { ...sel.value, [i]: "" };
+	}
+}
+function toggleMulti(i, opt) {
+	const cur = Array.isArray(sel.value[i]) ? sel.value[i].slice() : [];
+	const ix = cur.indexOf(opt);
+	if (ix >= 0) cur.splice(ix, 1);
+	else cur.push(opt);
+	sel.value = { ...sel.value, [i]: cur };
+}
+function isPicked(i, opt) {
+	const v = sel.value[i];
+	return Array.isArray(v) ? v.includes(opt) : v === opt;
+}
+function submit() {
+	if (!ready.value) return;
+	const text = askAnswerText(props.spec, sel.value, other.value);
+	sel.value = {};
+	other.value = {};
+	emit("submit", text);
+}
+</script>
+
+<style scoped>
+/* interactive clarifying-question cards */
+.jv-ask {
+	margin-top: 12px;
+	padding: 14px;
+	border: 1px solid var(--border);
+	background: var(--surface-1);
+	border-radius: 12px;
+}
+.jv-ask-q {
+	padding-bottom: 13px;
+	margin-bottom: 13px;
+	border-bottom: 1px solid var(--border);
+}
+.jv-ask-q:last-of-type {
+	border-bottom: 0;
+	padding-bottom: 4px;
+	margin-bottom: 4px;
+}
+.jv-ask-qt {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	font-size: 13.5px;
+	font-weight: 600;
+	color: var(--text);
+	margin-bottom: 9px;
+	line-height: 1.4;
+}
+.jv-ask-num {
+	flex: none;
+	width: 19px;
+	height: 19px;
+	border-radius: 99px;
+	background: var(--cta-bg);
+	color: var(--cta);
+	font-size: 11px;
+	font-weight: 700;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-top: 1px;
+}
+.jv-ask--form .jv-ask-num {
+	display: none;
+}
+.jv-ask--form .jv-ask-q {
+	border-bottom: 0;
+	padding-bottom: 11px;
+	margin-bottom: 11px;
+}
+.jv-ask--form .jv-ask-q:last-of-type {
+	padding-bottom: 0;
+	margin-bottom: 0;
+}
+.jv-ask--form .jv-ask-qt {
+	font-size: 10.5px;
+	font-weight: 650;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--text-3);
+	margin-bottom: 6px;
+}
+.jv-ask-opts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 7px;
+}
+.jv-ask-opt {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 7px 12px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 9px;
+	font-family: inherit;
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--text-2);
+	cursor: pointer;
+	transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.jv-ask-opt:hover {
+	border-color: var(--border-2);
+	color: var(--text);
+}
+.jv-ask-opt.on {
+	border-color: var(--cta);
+	background: var(--cta-bg);
+	color: var(--text);
+	font-weight: 600;
+}
+.jv-ask-tick {
+	color: var(--cta);
+	font-weight: 700;
+	font-size: 11px;
+}
+.jv-ask-field {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 8px 10px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	font-family: inherit;
+	font-size: 13px;
+	color: var(--text);
+	outline: none;
+}
+.jv-ask-field:focus {
+	border-color: var(--cta);
+}
+.jv-ask-link {
+	position: relative;
+}
+.jv-ask-linkmenu {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: calc(100% + 4px);
+	z-index: 20;
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 9px;
+	box-shadow: 0 8px 24px rgba(20, 20, 30, 0.14);
+	padding: 4px;
+	max-height: 220px;
+	overflow-y: auto;
+}
+.jv-ask-linkmenu button {
+	display: block;
+	width: 100%;
+	text-align: left;
+	padding: 7px 9px;
+	background: transparent;
+	border: none;
+	border-radius: 6px;
+	font-family: inherit;
+	font-size: 12.5px;
+	color: var(--text-2);
+	cursor: pointer;
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+.jv-ask-linkmenu button:hover {
+	background: var(--surface-2);
+	color: var(--text);
+}
+.jv-ask-other {
+	width: 100%;
+	box-sizing: border-box;
+	margin-top: 8px;
+	padding: 7px 10px;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	font-family: inherit;
+	font-size: 12.5px;
+	color: var(--text);
+	outline: none;
+}
+.jv-ask-other:focus {
+	border-color: var(--cta);
+}
+.jv-ask-foot {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 10px;
+	margin-top: 14px;
+}
+.jv-ask-submit {
+	padding: 8px 16px;
+	background: var(--cta);
+	border: 1px solid var(--cta);
+	border-radius: 8px;
+	font-family: inherit;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--cta-fg);
+	cursor: pointer;
+	transition: opacity 0.12s;
+}
+.jv-ask-submit:hover {
+	opacity: 0.9;
+}
+.jv-ask-submit:disabled {
+	opacity: 0.45;
+	cursor: default;
+}
+.jv-ask-hint {
+	font-size: 11.5px;
+	color: var(--text-3);
+}
+</style>

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -385,6 +385,10 @@ function onKeydownInternal(e) {
 	// The host claimed this key (chat: mention nav, prompt history, its own
 	// Enter-to-send) — never double-handle it.
 	if (e.defaultPrevented) return;
+	// An Enter that CONFIRMS an IME candidate (Japanese/Chinese/Korean) belongs
+	// to the composition, not to us. keyCode 229 is the pre-`isComposing`
+	// browsers' version of the same signal.
+	if (e.isComposing || e.keyCode === 229) return;
 	if (e.key === "Enter" && !e.shiftKey) {
 		e.preventDefault();
 		emit("submit");

--- a/frontend/src/lib/chatAsk.js
+++ b/frontend/src/lib/chatAsk.js
@@ -1,0 +1,81 @@
+// The ```jarvis-ask contract, as plain functions: parse a fenced block into a
+// normalised question list, decide when the draft is complete, and render the
+// picks as the message that goes back to the agent.
+//
+// Extracted from ChatView so the SAME rules run on every surface that shows the
+// cards (main chat, the Dashboards builder pane). The block spec lives in
+// jarvis-persona skills/jarvis-chat-blocks/SKILL.md; the normalisation here is
+// the defensive half of it (the model emits JSON, not a validated payload).
+// <AskCard> is the one renderer; these functions are what it renders from.
+
+export const ASK_RE = /```jarvis-ask[ \t]*\n([\s\S]*?)```/;
+
+// Types that take a typed/picked VALUE rather than option buttons. An ask made
+// only of these renders as a compact mini-form (no numbered badges).
+export const ASK_FIELD_TYPES = ["date", "datetime", "link", "text"];
+
+/**
+ * Parse the first ```jarvis-ask block out of a message.
+ * @param {string} content raw assistant message text
+ * @returns {{questions: Array<{q: string, type: string, options: string[], doctype: string}>}|null}
+ */
+export function parseAsk(content) {
+	const mt = String(content || "").match(ASK_RE);
+	if (!mt) return null;
+	try {
+		const a = JSON.parse(mt[1].trim());
+		const raw = Array.isArray(a) ? a : a && a.questions;
+		if (!Array.isArray(raw)) return null;
+		const questions = raw
+			.slice(0, 6)
+			.map((q) => {
+				let type = q.type === "boolean" ? "yesno" : q.type;
+				if (!["single", "multi", "yesno", ...ASK_FIELD_TYPES].includes(type))
+					type = "single";
+				return {
+					q: String(q.q || q.question || "").trim(),
+					type,
+					// yesno may carry exactly 2 custom labels (e.g. ["Approve","Reject"]).
+					options: Array.isArray(q.options) ? q.options.map(String).slice(0, 8) : [],
+					doctype: type === "link" ? String(q.doctype || q.link || "").trim() : "",
+				};
+			})
+			.filter((q) => {
+				if (!q.q) return false;
+				if (q.type === "yesno" || ASK_FIELD_TYPES.includes(q.type)) return true;
+				return q.options.length > 0;
+			});
+		return questions.length ? { questions } : null;
+	} catch (e) {
+		return null;
+	}
+}
+
+/** True once every question carries an answer (a pick, a typed value, or "Other"). */
+export function isAskReady(spec, sel, other) {
+	if (!spec) return false;
+	return spec.questions.every((q, i) => {
+		const v = sel[i];
+		if (ASK_FIELD_TYPES.includes(q.type)) return v != null && String(v).trim() !== "";
+		const free = (other[i] || "").trim();
+		if (q.type === "multi") return (Array.isArray(v) && v.length > 0) || !!free;
+		return (v != null && v !== "") || !!free;
+	});
+}
+
+/** Render the answered ask as the user message that resumes the turn. */
+export function askAnswerText(spec, sel, other) {
+	const lines = spec.questions.map((q, i) => {
+		const ans = [];
+		const v = sel[i];
+		const free = (other[i] || "").trim();
+		if (Array.isArray(v)) ans.push(...v);
+		// Single-answer questions: a typed "Other…" IS the answer — never send
+		// both it and a leftover pick (the UI keeps them exclusive; this is the
+		// belt-and-braces for stale state).
+		else if (v != null && v !== "" && !free) ans.push(v);
+		if (free) ans.push(free);
+		return `${i + 1}. ${q.q} → ${ans.join(", ") || "(no answer)"}`;
+	});
+	return "Here are my answers:\n" + lines.join("\n");
+}

--- a/frontend/src/lib/chatAsk.test.js
+++ b/frontend/src/lib/chatAsk.test.js
@@ -1,0 +1,192 @@
+// Real executable tests for the shared ```jarvis-ask contract (chatAsk.js), plus
+// source assertions fencing the ONE renderer it feeds. Plain node built-ins
+// (node:test + node:assert), like eventFence.test.js / voiceSendGlue.test.js.
+// Run directly (`node --test chatAsk.test.js`) or via the python suite
+// (jarvis/tests/test_chat_ask_client.py subprocess-runs it every CI run).
+//
+// What is being defended: the clarifying-question cards used to exist only
+// inside ChatView, and the Dashboards builder pane DELETED the block instead of
+// rendering it - so an agent that asked before building produced an empty
+// bubble the user could not answer. The parsing/readiness/answer rules now live
+// here and the cards live in <AskCard>, so both surfaces behave identically. A
+// fork of either would silently drift, which is what the source fences catch.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseAsk, isAskReady, askAnswerText, ASK_FIELD_TYPES } from "./chatAsk.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
+const askCardSrc = read("..", "components", "chat", "AskCard.vue");
+const chatViewSrc = read("..", "views", "ChatView.vue");
+const dashPaneSrc = read("..", "pages", "dashboards", "DashboardChatPane.vue");
+
+const fence = (body) => "Some lead-in.\n\n```jarvis-ask\n" + body + "\n```";
+
+// ---- parsing -------------------------------------------------------------
+
+test("parses a bare array of questions and defaults the shape", () => {
+	const spec = parseAsk(
+		fence('[{"q":"Which records?","type":"multi","options":["Draft","Submitted"]}]')
+	);
+	assert.deepEqual(spec, {
+		questions: [
+			{ q: "Which records?", type: "multi", options: ["Draft", "Submitted"], doctype: "" },
+		],
+	});
+});
+
+test("accepts the {questions: [...]} envelope as well as a bare array", () => {
+	const spec = parseAsk(fence('{"questions":[{"q":"Go?","type":"yesno"}]}'));
+	assert.equal(spec.questions.length, 1);
+	assert.equal(spec.questions[0].type, "yesno");
+});
+
+test("boolean is normalised to yesno and an unknown type falls back to single", () => {
+	const spec = parseAsk(
+		fence(
+			'[{"q":"A","type":"boolean"},' +
+				'{"q":"B","type":"wat","options":["x"]},' +
+				'{"q":"C","type":"link","link":"Customer"}]'
+		)
+	);
+	assert.deepEqual(
+		spec.questions.map((q) => q.type),
+		["yesno", "single", "link"]
+	);
+	// `link` is accepted under either key; only link questions keep a doctype.
+	assert.equal(spec.questions[2].doctype, "Customer");
+	assert.equal(spec.questions[0].doctype, "");
+});
+
+test("choice questions with no options are dropped; field types survive without them", () => {
+	const spec = parseAsk(fence('[{"q":"No opts","type":"single"},{"q":"When?","type":"date"}]'));
+	assert.deepEqual(
+		spec.questions.map((q) => q.q),
+		["When?"]
+	);
+});
+
+test("caps: 6 questions, 8 options; empty prompts dropped; all-dropped yields null", () => {
+	const many = Array.from({ length: 9 }, (_, i) => ({
+		q: `Q${i}`,
+		type: "single",
+		options: Array.from({ length: 12 }, (_, o) => `o${o}`),
+	}));
+	const spec = parseAsk(fence(JSON.stringify(many)));
+	assert.equal(spec.questions.length, 6);
+	assert.equal(spec.questions[0].options.length, 8);
+	assert.equal(parseAsk(fence('[{"q":"  ","type":"yesno"}]')), null);
+});
+
+test("no block, malformed JSON, and a non-list payload all parse to null", () => {
+	assert.equal(parseAsk("just prose"), null);
+	assert.equal(parseAsk(""), null);
+	assert.equal(parseAsk(null), null);
+	assert.equal(parseAsk(fence("{not json")), null);
+	assert.equal(parseAsk(fence('"a string"')), null);
+});
+
+test("an unterminated block does not parse (a half-streamed reply shows no card)", () => {
+	assert.equal(parseAsk('```jarvis-ask\n[{"q":"Which records?","type":"yesno"}]'), null);
+});
+
+// ---- readiness -----------------------------------------------------------
+
+const twoQ = parseAsk(
+	fence('[{"q":"Scope?","type":"single","options":["All","Mine"]},{"q":"When?","type":"date"}]')
+);
+
+test("readiness needs every question answered", () => {
+	assert.equal(isAskReady(twoQ, {}, {}), false);
+	assert.equal(isAskReady(twoQ, { 0: "All" }, {}), false);
+	assert.equal(isAskReady(twoQ, { 0: "All", 1: "2026-07-27" }, {}), true);
+	assert.equal(isAskReady(null, {}, {}), false);
+});
+
+test('"Other…" alone answers a choice question but never a field question', () => {
+	assert.equal(isAskReady(twoQ, { 1: "2026-07-27" }, { 0: "Something else" }), true);
+	// whitespace is not an answer
+	assert.equal(isAskReady(twoQ, { 1: "2026-07-27" }, { 0: "   " }), false);
+	// a field question cannot be satisfied by the Other box (it has none)
+	assert.equal(isAskReady(twoQ, { 0: "All" }, { 1: "next friday" }), false);
+});
+
+test("multi needs at least one pick (an empty array is not an answer)", () => {
+	const spec = parseAsk(fence('[{"q":"Which?","type":"multi","options":["a","b"]}]'));
+	assert.equal(isAskReady(spec, { 0: [] }, {}), false);
+	assert.equal(isAskReady(spec, { 0: ["a"] }, {}), true);
+});
+
+// ---- answer formatting ---------------------------------------------------
+
+test("answers render as a numbered list the agent can read back", () => {
+	const text = askAnswerText(twoQ, { 0: "All", 1: "2026-07-27" }, {});
+	assert.equal(text, "Here are my answers:\n1. Scope? → All\n2. When? → 2026-07-27");
+});
+
+test("multi picks join with commas; a single-answer Other REPLACES a stale pick", () => {
+	const spec = parseAsk(
+		fence(
+			'[{"q":"Which?","type":"multi","options":["a","b"]},' +
+				'{"q":"Scope?","type":"single","options":["All"]}]'
+		)
+	);
+	const text = askAnswerText(spec, { 0: ["a", "b"], 1: "All" }, { 1: "just EU" });
+	// The UI keeps pick and Other exclusive; if stale state ever ships both, the
+	// typed text wins and the pick is dropped (sending both was a reported bug).
+	assert.equal(text, "Here are my answers:\n1. Which? → a, b\n2. Scope? → just EU");
+});
+
+test("multi keeps BOTH its picks and its Other text", () => {
+	const spec = parseAsk(fence('[{"q":"Which?","type":"multi","options":["a","b"]}]'));
+	assert.equal(
+		askAnswerText(spec, { 0: ["a"] }, { 0: "and c" }),
+		"Here are my answers:\n1. Which? → a, and c"
+	);
+});
+
+test("an unanswered question is spelled out, never sent as an empty arrow", () => {
+	assert.match(askAnswerText(twoQ, {}, {}), /1\. Scope\? → \(no answer\)/);
+});
+
+test("ASK_FIELD_TYPES is the value-typed set (no option buttons)", () => {
+	assert.deepEqual([...ASK_FIELD_TYPES].sort(), ["date", "datetime", "link", "text"]);
+});
+
+// ---- source fences: one parser, one renderer, two surfaces ---------------
+
+test("AskCard is the renderer and it reads its rules from chatAsk", () => {
+	assert.match(askCardSrc, /from "@\/lib\/chatAsk"/);
+	assert.match(askCardSrc, /isAskReady/);
+	assert.match(askCardSrc, /askAnswerText/);
+	assert.match(askCardSrc, /class="jv-ask-submit"/);
+	assert.match(askCardSrc, /Submit answers/);
+	// It must not re-implement the parser it is handed a spec from.
+	assert.doesNotMatch(askCardSrc, /jarvis-ask\[ \\t\]/);
+});
+
+test("ChatView renders AskCard instead of its own copy of the cards", () => {
+	assert.match(chatViewSrc, /import AskCard from "@\/components\/chat\/AskCard\.vue"/);
+	assert.match(chatViewSrc, /import \{ parseAsk \} from "@\/lib\/chatAsk"/);
+	assert.match(chatViewSrc, /<AskCard[\s\S]{0,200}:spec="activeAsk"/);
+	// the extracted duplicates are gone
+	for (const dead of ["askSel", "askOther", "submitAsk", "askReady", "_ASK_RE"]) {
+		assert.doesNotMatch(chatViewSrc, new RegExp(dead), `ChatView still defines ${dead}`);
+	}
+});
+
+test("the Dashboards builder pane RENDERS the ask instead of swallowing it", () => {
+	assert.match(dashPaneSrc, /import AskCard from "@\/components\/chat\/AskCard\.vue"/);
+	assert.match(dashPaneSrc, /<AskCard[\s\S]{0,240}:spec="activeAsk"/);
+	// Answers go back into the SAME conversation as an ordinary user message.
+	assert.match(dashPaneSrc, /@submit="sendText"/);
+	// AskCard styles with the jv-* tokens, which this frappe-ui page must bind.
+	assert.match(dashPaneSrc, /useJarvisTheme/);
+	assert.match(dashPaneSrc, /<AskCard[\s\S]{0,240}:style="paletteVars"/);
+	// Both surfaces key the card by message so a new ask starts a clean draft.
+	assert.match(dashPaneSrc, /<AskCard[\s\S]{0,240}:key="m\.name"/);
+	assert.match(chatViewSrc, /<AskCard[\s\S]{0,200}:key="m\.name"/);
+});

--- a/frontend/src/lib/dashboardRestore.js
+++ b/frontend/src/lib/dashboardRestore.js
@@ -1,0 +1,31 @@
+// Rehydrating the Dashboards builder canvas from a loaded transcript.
+//
+// The canvas html is component state on the routed builder page, so any
+// navigation drops it — but nothing is actually lost: chat.api.get_conversation
+// returns every message's `canvas` list ([{name, title, type, file_url}]), and
+// chat.api.get_canvas can replay any past message's artifact for the owner of
+// the conversation. So "restore the canvas" is just: find the newest message
+// that drew an html artifact and pull it again. No new server state, no draft
+// row, no extra endpoint.
+
+/**
+ * The newest canvas frame in a transcript, in the shape the realtime
+ * `kind:"canvas"` frame uses — so the page's existing onCanvas handler can
+ * consume a replay and a live frame through one path.
+ *
+ * @param {Array<{name?: string, canvas?: Array<{type?: string}>}>} messages
+ *        get_conversation's message rows (canvas already parsed into a list)
+ * @returns {{message_id: string, items: Array<object>}|null}
+ */
+export function lastCanvasFrame(messages) {
+	const rows = Array.isArray(messages) ? messages : [];
+	for (let i = rows.length - 1; i >= 0; i--) {
+		const m = rows[i];
+		if (!m || !m.name || !Array.isArray(m.canvas)) continue;
+		// Only an html artifact can be rendered on the canvas; a message whose
+		// canvas holds just an image/csv is not the frame we want to restore.
+		if (!m.canvas.some((it) => it && it.type === "html")) continue;
+		return { message_id: m.name, items: m.canvas };
+	}
+	return null;
+}

--- a/frontend/src/lib/dashboardRestore.js
+++ b/frontend/src/lib/dashboardRestore.js
@@ -4,27 +4,35 @@
 // navigation drops it — but nothing is actually lost: chat.api.get_conversation
 // returns every message's `canvas` list ([{name, title, type, file_url}]), and
 // chat.api.get_canvas can replay any past message's artifact for the owner of
-// the conversation. So "restore the canvas" is just: find the newest message
-// that drew an html artifact and pull it again. No new server state, no draft
-// row, no extra endpoint.
+// the conversation. So "restore the canvas" is just: pull that message's
+// artifact again. No new server state, no draft row, no extra endpoint.
+//
+// WHICH message, though, is not "the newest html in the conversation": the
+// builder's thread is an ordinary Jarvis Conversation that the user can also
+// open in main chat ("Open in chat"), where an html artifact means something
+// else entirely. Restoring that would put a chat answer on the builder canvas
+// and arm "Save dashboard" over it. So the builder remembers the message id of
+// the canvas IT last rendered (sticky, per user) and restores exactly that one.
 
 /**
- * The newest canvas frame in a transcript, in the shape the realtime
- * `kind:"canvas"` frame uses — so the page's existing onCanvas handler can
- * consume a replay and a live frame through one path.
+ * The canvas frame for a specific message of a transcript, in the shape the
+ * realtime `kind:"canvas"` frame uses — so the page's existing onCanvas handler
+ * consumes a replay and a live frame through one path.
  *
  * @param {Array<{name?: string, canvas?: Array<{type?: string}>}>} messages
  *        get_conversation's message rows (canvas already parsed into a list)
+ * @param {string} messageId the builder's last rendered canvas message
  * @returns {{message_id: string, items: Array<object>}|null}
  */
-export function lastCanvasFrame(messages) {
+export function builderCanvasFrame(messages, messageId) {
+	if (!messageId) return null;
 	const rows = Array.isArray(messages) ? messages : [];
 	for (let i = rows.length - 1; i >= 0; i--) {
 		const m = rows[i];
-		if (!m || !m.name || !Array.isArray(m.canvas)) continue;
+		if (!m || m.name !== messageId || !Array.isArray(m.canvas)) continue;
 		// Only an html artifact can be rendered on the canvas; a message whose
 		// canvas holds just an image/csv is not the frame we want to restore.
-		if (!m.canvas.some((it) => it && it.type === "html")) continue;
+		if (!m.canvas.some((it) => it && it.type === "html")) return null;
 		return { message_id: m.name, items: m.canvas };
 	}
 	return null;

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -1,0 +1,226 @@
+// The three owner-reported Dashboards builder defects, fenced by a real
+// executable test. Plain node built-ins (node:test + node:assert), like
+// eventFence.test.js. Run directly (`node --test dashboardRestore.test.js`) or
+// via the python suite (jarvis/tests/test_dashboard_builder_ux_client.py
+// subprocess-runs it every CI run).
+//
+// D1 the composer kept the text it had just sent. D3 the canvas vanished on a
+// tab switch or a navigation, with no way back and no warning that it was gone.
+// lastCanvasFrame() is the real logic behind the rehydration; the rest of both
+// fixes is component wiring, fenced here by source assertions (the
+// voiceDictationLifecycle precedent) because a .vue SFC cannot be imported into
+// a plain node runner.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { lastCanvasFrame } from "./dashboardRestore.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
+const paneSrc = read("..", "pages", "dashboards", "DashboardChatPane.vue");
+const pageSrc = read("..", "pages", "dashboards", "DashboardsPage.vue");
+const triggerPaneSrc = read("..", "pages", "triggers", "TriggerChatPane.vue");
+
+// The composer block of an SFC: from the composer comment to the end of the
+// template. Assertions about `disabled` must not accidentally read the pending
+// approval card's Dismiss button, which is legitimately gated.
+const composerOf = (src) => {
+	const start = src.indexOf("<!-- composer:");
+	assert.notEqual(start, -1, "the pane must still have its composer block");
+	const end = src.indexOf("</template>", start);
+	assert.notEqual(end, -1);
+	return src.slice(start, end);
+};
+
+// The body of a named function declaration, up to the next top-level `function`.
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\nfunction ", start + decl.length);
+	const alt = src.indexOf("\nasync function ", start + decl.length);
+	const stop = Math.min(end === -1 ? src.length : end, alt === -1 ? src.length : alt);
+	return src.slice(start, stop);
+};
+
+// ---- D3: the canvas is rebuildable from the transcript alone -------------
+
+const html = (name) => ({ name: "documents/x/index.html", title: "T", type: "html" });
+
+test("the NEWEST message with an html artifact is the frame to restore", () => {
+	const frame = lastCanvasFrame([
+		{ name: "m1", role: "assistant", canvas: [html()] },
+		{ name: "m2", role: "user" },
+		{ name: "m3", role: "assistant", canvas: [html()] },
+	]);
+	assert.deepEqual(frame, { message_id: "m3", items: [html()] });
+});
+
+test("messages with no canvas, or only non-html artifacts, are skipped", () => {
+	assert.equal(lastCanvasFrame([{ name: "m1", role: "user" }]), null);
+	assert.equal(lastCanvasFrame([{ name: "m1", canvas: [] }]), null);
+	assert.equal(
+		lastCanvasFrame([{ name: "m1", canvas: [{ name: "a.png", type: "image" }] }]),
+		null
+	);
+	// ...but an html item ALONGSIDE an image still restores.
+	const mixed = [{ name: "a.png", type: "image" }, html()];
+	assert.deepEqual(lastCanvasFrame([{ name: "m1", canvas: mixed }]), {
+		message_id: "m1",
+		items: mixed,
+	});
+});
+
+test("an image-only newest turn falls back to the last html turn", () => {
+	const frame = lastCanvasFrame([
+		{ name: "m1", canvas: [html()] },
+		{ name: "m2", canvas: [{ name: "a.png", type: "image" }] },
+	]);
+	assert.equal(frame.message_id, "m1");
+});
+
+test("junk transcripts never throw (canvas is whatever the server parsed)", () => {
+	assert.equal(lastCanvasFrame(null), null);
+	assert.equal(lastCanvasFrame(undefined), null);
+	assert.equal(lastCanvasFrame([]), null);
+	assert.equal(lastCanvasFrame([null, undefined]), null);
+	// canvas arrives as a JSON string only if parsing failed server-side
+	assert.equal(lastCanvasFrame([{ name: "m1", canvas: "[]" }]), null);
+	// a row with no name cannot be replayed through get_canvas(message, …)
+	assert.equal(lastCanvasFrame([{ canvas: [html()] }]), null);
+});
+
+test("the pane replays the transcript's newest canvas on every load", () => {
+	assert.match(paneSrc, /import \{ lastCanvasFrame \} from "@\/lib\/dashboardRestore"/);
+	const load = fnBody(paneSrc, "async function loadTranscript(");
+	assert.match(load, /lastCanvasFrame\(messages\.value\)/);
+	assert.match(load, /emit\("canvas", \{ \.\.\.frame, restore: true \}\)/);
+});
+
+test("a restore never overwrites a live canvas or an explicit ?edit target", () => {
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	assert.match(
+		onCanvas,
+		/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return;/
+	);
+	// re-checked AFTER the get_canvas round trip, not just before it
+	assert.match(
+		onCanvas,
+		/if \(content && !\(restore && \(builderHtml\.value \|\| editSeed\.value\)\)\)/
+	);
+	// a failed replay is silent; only a live frame's failure is surfaced
+	assert.match(onCanvas, /if \(!restore\) toast\.error/);
+});
+
+// ---- D3: switching tabs must not tear the build pipeline down -----------
+
+test("the builder tab is v-show, so the chat pane keeps its socket listener", () => {
+	assert.match(pageSrc, /v-show="activeTab === 'builder'"/);
+	assert.doesNotMatch(pageSrc, /v-if="activeTab === 'builder'"\s*\n\s*ref="builderEl"/);
+	// the Saved tab is no longer a v-else of the builder (that chain is what
+	// unmounted the pane)
+	assert.match(pageSrc, /<SavedDashboardsTab v-if="activeTab === 'saved'"/);
+	assert.doesNotMatch(pageSrc, /<SavedDashboardsTab v-else/);
+});
+
+// ---- D3: discard is explicit -------------------------------------------
+
+test("every path that drops an unsaved canvas confirms first", () => {
+	assert.match(pageSrc, /confirmDialog/);
+	assert.match(pageSrc, /Discard this unsaved dashboard\?/);
+	assert.match(pageSrc, /Its chat stays in your conversations\./);
+	// unsaved == on the canvas and not (still) the saved document's html
+	assert.match(
+		pageSrc,
+		/const unsavedCanvas = computed\(\s*\(\) =>\s*!!builderHtml\.value && builderHtml\.value !== /
+	);
+	for (const fn of [
+		"function newDashboard(",
+		"function resetBuilder(",
+		"async function loadEdit(",
+	]) {
+		assert.match(fnBody(pageSrc, fn), /confirmDiscard\(/, `${fn} must confirm the discard`);
+	}
+});
+
+test("New chat asks the page instead of clearing itself behind a confirm", () => {
+	// The pane owns no canvas, so it must not act before the page has asked.
+	assert.match(fnBody(paneSrc, "function newChat("), /emit\("reset"\)/);
+	assert.doesNotMatch(fnBody(paneSrc, "function newChat("), /conversation\.value = ""/);
+	assert.match(paneSrc, /defineExpose\(\{ resetChat, sendText \}\)/);
+	assert.match(fnBody(pageSrc, "function clearBuilder("), /chatPane\.value\.resetChat\(\)/);
+});
+
+test("the pane follows the sticky conversation slot when the page repoints it", () => {
+	assert.match(paneSrc, /watch\(conversation, \(id, prev\) => \{/);
+	// "" -> id is the pane's own first send; only a genuine repoint reloads
+	assert.match(paneSrc, /if \(!prev \|\| id === prev\) return;/);
+});
+
+// ---- D1: the composer clears and stays cleared --------------------------
+
+for (const [label, src] of [
+	["dashboards", paneSrc],
+	["triggers", triggerPaneSrc],
+]) {
+	test(`${label} composer: a raw v-model textarea, never a FormControl`, () => {
+		const composer = composerOf(src);
+		assert.match(composer, /<textarea/);
+		assert.match(composer, /v-model="draft"/);
+		// FormControl type="textarea" is frappe-ui's Textarea, which emits its
+		// update on `change` as well as `input` - the re-emit that restored the
+		// draft. Nothing in the pane may reintroduce it.
+		assert.doesNotMatch(src, /FormControl/);
+		// One-way :modelValue + a manual @update handler also breaks IME
+		// composition (Composer.vue documents why v-model is required).
+		assert.doesNotMatch(composer, /:modelValue="draft"/);
+		assert.doesNotMatch(composer, /@update:modelValue/);
+	});
+
+	test(`${label} composer: the textarea is never disabled by \`sending\``, () => {
+		const composer = composerOf(src);
+		const disabledBindings = composer.match(/:disabled="[^"]*"/g) || [];
+		const textareaStart = composer.indexOf("<textarea");
+		const textareaEnd = composer.indexOf("/>", textareaStart);
+		const textarea = composer.slice(textareaStart, textareaEnd);
+		assert.doesNotMatch(
+			textarea,
+			/sending/,
+			"disabling a focused, dirty textarea mid-send is exactly the bug"
+		);
+		// but the SEND control still is gated, or a double-send is possible
+		assert.ok(
+			disabledBindings.some((b) => b.includes("sending")),
+			"the send button must still be gated on `sending`"
+		);
+	});
+
+	test(`${label} composer: autoGrow measures the textarea itself, post-flush`, () => {
+		// It used to querySelector a textarea out of a wrapper div; with a real
+		// ref there is no wrapper. And a programmatic clear only reaches the DOM
+		// on the next flush, so the watcher is what shrinks the box after a send.
+		assert.match(src, /watch\(draft, autoGrow, \{ flush: "post" \}\)/);
+		assert.doesNotMatch(src, /box\.value\.querySelector\("textarea"\)/);
+		assert.doesNotMatch(src, /nextTick\(autoGrow\)/);
+	});
+}
+
+test("send() clears the draft up front and restores it only on rejection", () => {
+	const send = fnBody(paneSrc, "async function send(");
+	// guard, clear, optimistic bubble - in that order
+	assert.ok(
+		send.indexOf("if (!text || sending.value) return;") < send.indexOf('draft.value = "";'),
+		"the in-flight guard must precede the clear"
+	);
+	assert.match(send, /const text = draft\.value\.trim\(\);/);
+	assert.match(send, /draft\.value = "";/);
+	// a server reject (single-flight guard / usage cap) puts the text back, and
+	// only when the user has not started typing something else
+	const restores = send.match(/if \(!draft\.value\) draft\.value = text;/g) || [];
+	assert.equal(restores.length, 2, "restore on BOTH the ok:false and the throw path");
+	assert.match(
+		send,
+		/messages\.value = messages\.value\.filter\(\(m\) => m\.name !== tmpName\)/
+	);
+});

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -1,12 +1,14 @@
-// The three owner-reported Dashboards builder defects, fenced by a real
-// executable test. Plain node built-ins (node:test + node:assert), like
-// eventFence.test.js. Run directly (`node --test dashboardRestore.test.js`) or
-// via the python suite (jarvis/tests/test_dashboard_builder_ux_client.py
-// subprocess-runs it every CI run).
+// The owner-reported Dashboards builder defects, fenced by a real executable
+// test. Plain node built-ins (node:test + node:assert), like eventFence.test.js.
+// Run directly (`node --test dashboardRestore.test.js`) or via the python suite
+// (jarvis/tests/test_dashboard_builder_ux_client.py subprocess-runs it every CI
+// run).
 //
 // D1 the composer kept the text it had just sent. D3 the canvas vanished on a
-// tab switch or a navigation, with no way back and no warning that it was gone.
-// lastCanvasFrame() is the real logic behind the rehydration; the rest of both
+// tab switch or a navigation, with no way back and no warning that it was gone
+// — and, once it came back, came back as a canvas the builder was no longer
+// bound to (Save wrote a duplicate) or as a frame that had rendered at 0x0.
+// builderCanvasFrame() is the real logic behind the rehydration; the rest of the
 // fixes is component wiring, fenced here by source assertions (the
 // voiceDictationLifecycle precedent) because a .vue SFC cannot be imported into
 // a plain node runner.
@@ -15,13 +17,16 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { lastCanvasFrame } from "./dashboardRestore.js";
+import { builderCanvasFrame } from "./dashboardRestore.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
 const paneSrc = read("..", "pages", "dashboards", "DashboardChatPane.vue");
 const pageSrc = read("..", "pages", "dashboards", "DashboardsPage.vue");
+const canvasSrc = read("..", "pages", "dashboards", "DashboardCanvas.vue");
+const saveDialogSrc = read("..", "pages", "dashboards", "SaveDashboardDialog.vue");
 const triggerPaneSrc = read("..", "pages", "triggers", "TriggerChatPane.vue");
+const composerSrc = read("..", "components", "chat", "Composer.vue");
 
 // The composer block of an SFC: from the composer comment to the end of the
 // template. Assertions about `disabled` must not accidentally read the pending
@@ -34,68 +39,85 @@ const composerOf = (src) => {
 	return src.slice(start, end);
 };
 
-// The body of a named function declaration, up to the next top-level `function`.
+// The body of a named function declaration: everything up to its closing brace,
+// which in these tab-indented sources is the first `}` in column 0. Tight on
+// purpose — a loose slice would let an assertion pass on code that lives in the
+// NEXT declaration.
 const fnBody = (src, decl) => {
 	const start = src.indexOf(decl);
 	assert.notEqual(start, -1, `source must still define ${decl}`);
-	const end = src.indexOf("\nfunction ", start + decl.length);
-	const alt = src.indexOf("\nasync function ", start + decl.length);
-	const stop = Math.min(end === -1 ? src.length : end, alt === -1 ? src.length : alt);
-	return src.slice(start, stop);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
 };
 
 // ---- D3: the canvas is rebuildable from the transcript alone -------------
 
-const html = (name) => ({ name: "documents/x/index.html", title: "T", type: "html" });
+const html = () => ({ name: "documents/x/index.html", title: "T", type: "html" });
 
-test("the NEWEST message with an html artifact is the frame to restore", () => {
-	const frame = lastCanvasFrame([
+test("the frame restored is the one the BUILDER recorded, not the newest html", () => {
+	const rows = [
 		{ name: "m1", role: "assistant", canvas: [html()] },
 		{ name: "m2", role: "user" },
+		// main chat, sharing the thread via "Open in chat", drew this one
 		{ name: "m3", role: "assistant", canvas: [html()] },
-	]);
-	assert.deepEqual(frame, { message_id: "m3", items: [html()] });
+	];
+	assert.deepEqual(builderCanvasFrame(rows, "m1"), { message_id: "m1", items: [html()] });
+	assert.deepEqual(builderCanvasFrame(rows, "m3"), { message_id: "m3", items: [html()] });
 });
 
-test("messages with no canvas, or only non-html artifacts, are skipped", () => {
-	assert.equal(lastCanvasFrame([{ name: "m1", role: "user" }]), null);
-	assert.equal(lastCanvasFrame([{ name: "m1", canvas: [] }]), null);
+test("no recorded message means no restore at all", () => {
+	const rows = [{ name: "m1", role: "assistant", canvas: [html()] }];
+	assert.equal(builderCanvasFrame(rows, ""), null);
+	assert.equal(builderCanvasFrame(rows, null), null);
+	assert.equal(builderCanvasFrame(rows, undefined), null);
+});
+
+test("a recorded message that is gone (or drew no html) restores nothing", () => {
+	assert.equal(builderCanvasFrame([{ name: "m1", canvas: [html()] }], "m9"), null);
+	assert.equal(builderCanvasFrame([{ name: "m1", role: "user" }], "m1"), null);
+	assert.equal(builderCanvasFrame([{ name: "m1", canvas: [] }], "m1"), null);
 	assert.equal(
-		lastCanvasFrame([{ name: "m1", canvas: [{ name: "a.png", type: "image" }] }]),
+		builderCanvasFrame([{ name: "m1", canvas: [{ name: "a.png", type: "image" }] }], "m1"),
 		null
 	);
 	// ...but an html item ALONGSIDE an image still restores.
 	const mixed = [{ name: "a.png", type: "image" }, html()];
-	assert.deepEqual(lastCanvasFrame([{ name: "m1", canvas: mixed }]), {
+	assert.deepEqual(builderCanvasFrame([{ name: "m1", canvas: mixed }], "m1"), {
 		message_id: "m1",
 		items: mixed,
 	});
 });
 
-test("an image-only newest turn falls back to the last html turn", () => {
-	const frame = lastCanvasFrame([
-		{ name: "m1", canvas: [html()] },
-		{ name: "m2", canvas: [{ name: "a.png", type: "image" }] },
-	]);
-	assert.equal(frame.message_id, "m1");
-});
-
 test("junk transcripts never throw (canvas is whatever the server parsed)", () => {
-	assert.equal(lastCanvasFrame(null), null);
-	assert.equal(lastCanvasFrame(undefined), null);
-	assert.equal(lastCanvasFrame([]), null);
-	assert.equal(lastCanvasFrame([null, undefined]), null);
+	assert.equal(builderCanvasFrame(null, "m1"), null);
+	assert.equal(builderCanvasFrame(undefined, "m1"), null);
+	assert.equal(builderCanvasFrame([], "m1"), null);
+	assert.equal(builderCanvasFrame([null, undefined], "m1"), null);
 	// canvas arrives as a JSON string only if parsing failed server-side
-	assert.equal(lastCanvasFrame([{ name: "m1", canvas: "[]" }]), null);
-	// a row with no name cannot be replayed through get_canvas(message, …)
-	assert.equal(lastCanvasFrame([{ canvas: [html()] }]), null);
+	assert.equal(builderCanvasFrame([{ name: "m1", canvas: "[]" }], "m1"), null);
 });
 
-test("the pane replays the transcript's newest canvas on every load", () => {
-	assert.match(paneSrc, /import \{ lastCanvasFrame \} from "@\/lib\/dashboardRestore"/);
+test("the pane replays the recorded canvas message on every transcript load", () => {
+	assert.match(paneSrc, /import \{ builderCanvasFrame \} from "@\/lib\/dashboardRestore"/);
+	assert.match(paneSrc, /const canvasMsg = useStorage\(\s*`jarvis-dash-canvasmsg-\$\{/);
 	const load = fnBody(paneSrc, "async function loadTranscript(");
-	assert.match(load, /lastCanvasFrame\(messages\.value\)/);
+	assert.match(load, /builderCanvasFrame\(messages\.value, canvasMsg\.value\)/);
 	assert.match(load, /emit\("canvas", \{ \.\.\.frame, restore: true \}\)/);
+});
+
+test("the page records WHICH message is on the canvas, under the same key", () => {
+	assert.match(pageSrc, /const canvasMsg = useStorage\(`jarvis-dash-canvasmsg-\$\{/);
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	// stamped only after the artifact actually reached the canvas
+	assert.ok(
+		onCanvas.indexOf("builderHtml.value = content;") <
+			onCanvas.indexOf("canvasMsg.value = message_id;"),
+		"the id is recorded for the html that was rendered"
+	);
+	// and dropped whenever the canvas stops being a chat artifact
+	assert.match(fnBody(pageSrc, "function clearBuilder("), /canvasMsg\.value = "";/);
+	assert.match(fnBody(pageSrc, "async function loadEdit("), /canvasMsg\.value = "";/);
 });
 
 test("a restore never overwrites a live canvas or an explicit ?edit target", () => {
@@ -105,12 +127,26 @@ test("a restore never overwrites a live canvas or an explicit ?edit target", () 
 		/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return;/
 	);
 	// re-checked AFTER the get_canvas round trip, not just before it
-	assert.match(
-		onCanvas,
-		/if \(content && !\(restore && \(builderHtml\.value \|\| editSeed\.value\)\)\)/
+	assert.equal(
+		(
+			onCanvas.match(
+				/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return;/g
+			) || []
+		).length,
+		2
 	);
 	// a failed replay is silent; only a live frame's failure is surfaced
-	assert.match(onCanvas, /if \(!restore\) toast\.error/);
+	assert.match(onCanvas, /else toast\.error\(errMsg\(e\)\);/);
+});
+
+test("an unreadable artifact is retried never, not on every transcript load", () => {
+	// loadTranscript emits a restore frame on EVERY load, including the debounced
+	// refetch behind each realtime frame — an unlatched failure is an unbounded
+	// run of silent get_canvas calls.
+	assert.match(pageSrc, /const failedRestores = new Set\(\);/);
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return;/);
+	assert.match(onCanvas, /if \(restore\) failedRestores\.add\(message_id\);/);
 });
 
 // ---- D3: switching tabs must not tear the build pipeline down -----------
@@ -124,10 +160,44 @@ test("the builder tab is v-show, so the chat pane keeps its socket listener", ()
 	assert.doesNotMatch(pageSrc, /<SavedDashboardsTab v-else/);
 });
 
+test("coming back to the builder re-drives the canvas that rendered hidden", () => {
+	// v-show means the iframe loads at 0x0 behind display:none; ECharts sized
+	// against a zero-width container draws nothing and never self-heals.
+	assert.match(canvasSrc, /defineExpose\(\{ exportAs, rebuild \}\)/);
+	assert.match(pageSrc, /<DashboardCanvas\n\t+ref="canvasRef"/);
+	const watcher = pageSrc.slice(pageSrc.indexOf("watch(\n\tactiveTab,"));
+	assert.notEqual(watcher, "", "the page must watch the active tab");
+	assert.match(watcher, /if \(v !== "builder" \|\| !builderHtml\.value\) return;/);
+	assert.match(watcher, /canvasRef\.value\.rebuild\(\)/);
+	// pre-flush would run while the wrapper is still display:none
+	assert.match(watcher.slice(0, watcher.indexOf("\n);")), /flush: "post"/);
+});
+
+// ---- D3: the editing identity survives the round trip -------------------
+
+test("a remount restores WHAT WAS BEING EDITED, not just the pixels", () => {
+	// Without this the canvas comes back but `editingDetail` does not, so
+	// SaveDashboardDialog sends no `name` and save_dashboard INSERTS a second
+	// "Jarvis Dashboard" pointing at the same conversation.
+	assert.match(saveDialogSrc, /if \(e && e\.name\) payload\.name = e\.name;/);
+	assert.match(pageSrc, /:editing="editingDetail"/);
+	assert.match(pageSrc, /const editingSticky = useStorage\(`jarvis-dash-editing-\$\{/);
+	// seeded at setup, BEFORE the chat pane's transcript replay can reach the canvas
+	assert.match(pageSrc, /const editSeed = ref\(routeEdit \|\| editingSticky\.value\);/);
+	assert.match(
+		pageSrc,
+		/if \(editSeed\.value\) loadEdit\(editSeed\.value, \{ deepLink: !!routeEdit \}\);/
+	);
+	// written by both paths that make this page "the editor of X"...
+	assert.match(fnBody(pageSrc, "async function loadEdit("), /editingSticky\.value = d\.name;/);
+	assert.match(fnBody(pageSrc, "function onSaved("), /editingSticky\.value = detail\.name;/);
+	// ...and dropped by every path that stops editing it
+	assert.match(fnBody(pageSrc, "function clearBuilder("), /editingSticky\.value = "";/);
+});
+
 // ---- D3: discard is explicit -------------------------------------------
 
 test("every path that drops an unsaved canvas confirms first", () => {
-	assert.match(pageSrc, /confirmDialog/);
 	assert.match(pageSrc, /Discard this unsaved dashboard\?/);
 	assert.match(pageSrc, /Its chat stays in your conversations\./);
 	// unsaved == on the canvas and not (still) the saved document's html
@@ -144,6 +214,33 @@ test("every path that drops an unsaved canvas confirms first", () => {
 	}
 });
 
+test("the discard confirm is REACHABLE from loadEdit, not dead code", () => {
+	// It only ever fires when an unsaved canvas is already on the builder, and a
+	// fresh mount has none — so without a live watcher on ?edit= the confirm
+	// inside loadEdit can never run and opening another dashboard silently
+	// repoints the single sticky slot.
+	const watcher = pageSrc.slice(pageSrc.indexOf("watch(\n\t() => route.query.edit,"));
+	assert.notEqual(watcher, "", "?edit= must be watched, not read once at setup");
+	assert.match(watcher.slice(0, watcher.indexOf("\n);")), /loadEdit\(name\);/);
+	// and the seed must outlive the dialog: clearing it up front (the old
+	// `finally`) lets a transcript restore land while the confirm is still up
+	const load = fnBody(pageSrc, "async function loadEdit(");
+	assert.doesNotMatch(load, /finally \{/);
+	assert.match(load, /confirmDiscard\(\(\) => \{[\s\S]*?settle\(\);\n\t\t\}, settle\);/);
+});
+
+test("the discard confirm offers the surviving chat instead of just naming it", () => {
+	assert.match(
+		pageSrc,
+		/label: "Discard", variant: "solid", onClick: \(\) => settleDiscard\(true\)/
+	);
+	const actions = pageSrc.slice(pageSrc.indexOf("const discardActions = computed("));
+	assert.match(actions, /label: "Open its chat"/);
+	assert.match(actions, /router\.push\("\/c\/" \+ id\)/);
+	// ...only when there IS one
+	assert.match(actions, /if \(chatConv\.value\) \{/);
+});
+
 test("New chat asks the page instead of clearing itself behind a confirm", () => {
 	// The pane owns no canvas, so it must not act before the page has asked.
 	assert.match(fnBody(paneSrc, "function newChat("), /emit\("reset"\)/);
@@ -156,6 +253,44 @@ test("the pane follows the sticky conversation slot when the page repoints it", 
 	assert.match(paneSrc, /watch\(conversation, \(id, prev\) => \{/);
 	// "" -> id is the pane's own first send; only a genuine repoint reloads
 	assert.match(paneSrc, /if \(!prev \|\| id === prev\) return;/);
+	// ...and a repoint caused by our OWN in-flight send must not cancel the run
+	// it just started (clearThread would drop the Thinking indicator)
+	assert.match(fnBody(paneSrc, "async function send("), /ownRepoint = true;/);
+	assert.match(paneSrc, /clearThread\(\{ keepRun: own \}\);/);
+	assert.match(
+		fnBody(paneSrc, "function clearThread("),
+		/if \(!keepRun\) runActive\.value = false;/
+	);
+});
+
+// ---- D2: the clarifying questions are answerable on every surface -------
+
+test("both embedded panes render the ask card instead of deleting the block", () => {
+	for (const [label, src] of [
+		["dashboards", paneSrc],
+		["triggers", triggerPaneSrc],
+	]) {
+		assert.match(src, /import AskCard from "@\/components\/chat\/AskCard\.vue";/, label);
+		assert.match(src, /import \{ parseAsk \} from "@\/lib\/chatAsk";/, label);
+		assert.match(src, /<AskCard\n\t+v-if="askFor === m\.name && activeAsk"/, label);
+		assert.match(src, /:key="m\.name"/, label);
+		assert.match(src, /@submit="sendText"/, label);
+		// the jv-* tokens AskCard styles with are not global on a frappe-ui page
+		assert.match(src, /:style="paletteVars"/, label);
+	}
+});
+
+test("submitting the ask keeps the picks until the answer is actually posted", () => {
+	// The host may refuse the text (a send in flight, a dictation transcribing).
+	// Clearing before the emit lost the answers with no way to re-submit.
+	const askCardSrc = read("..", "components", "chat", "AskCard.vue");
+	const submit = fnBody(askCardSrc, "function submit()");
+	assert.match(
+		submit,
+		/emit\("submit", askAnswerText\(props\.spec, sel\.value, other\.value\)\);/
+	);
+	assert.doesNotMatch(submit, /sel\.value = \{\};/);
+	assert.doesNotMatch(submit, /other\.value = \{\};/);
 });
 
 // ---- D1: the composer clears and stays cleared --------------------------
@@ -205,6 +340,23 @@ for (const [label, src] of [
 		assert.doesNotMatch(src, /nextTick\(autoGrow\)/);
 	});
 }
+
+test("every Enter-to-send handler ignores an IME composition commit", () => {
+	// Confirming a Japanese/Chinese/Korean candidate with Enter must not send the
+	// half-converted reading. keyCode 229 covers the browsers with no isComposing.
+	for (const [label, src, decl] of [
+		["dashboards", paneSrc, "function onKeydown(e) {"],
+		["triggers", triggerPaneSrc, "function onKeydown(e) {"],
+		["composer", composerSrc, "function onKeydownInternal(e) {"],
+	]) {
+		const body = fnBody(src, decl);
+		assert.match(body, /if \(e\.isComposing \|\| e\.keyCode === 229\) return;/, label);
+		assert.ok(
+			body.indexOf("e.isComposing") < body.indexOf('e.key === "Enter"'),
+			`${label}: the guard must precede the Enter branch`
+		);
+	}
+});
 
 test("send() clears the draft up front and restores it only on rejection", () => {
 	const send = fnBody(paneSrc, "async function send(");

--- a/frontend/src/pages/dashboards/DashboardCanvas.vue
+++ b/frontend/src/pages/dashboards/DashboardCanvas.vue
@@ -234,7 +234,11 @@ async function exportAs(format, title) {
 	if (format === "pdf") await downloadPdf(images, title);
 	else downloadPng(images, title);
 }
-defineExpose({ exportAs });
+// rebuild() is exposed for hosts that hide this component with `v-show`: the
+// iframe keeps loading while `display:none`, so charts initialise against a
+// 0x0 container and ECharts does not self-heal when it reappears. The builder
+// page re-drives it when the canvas becomes visible again.
+defineExpose({ exportAs, rebuild });
 
 // ── frame messages (validated: our iframe's window + the jarvis:1 stamp) ─────
 function onMessage(e) {

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -153,13 +153,14 @@
 			<div class="mt-2 flex items-center justify-between gap-2">
 				<div class="flex items-center gap-1.5">
 					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
-					<!-- explicit data-mode: Auto lets the agent decide; Static bakes the
+					<!-- explicit data-mode: Auto leaves it to the opening interview
+					     (the agent asks before the first build); Static bakes the
 					     numbers in (one-time report); Live declares view-time sources.
 					     TabButtons = real radio-group semantics + the raised-chip look,
 					     so the active option isn't a second solid next to Send. -->
 					<span
 						class="ml-1 text-xs text-ink-gray-5"
-						title="How this dashboard gets its data"
+						title="How this dashboard gets its data. Auto: I'll ask you before the first build."
 					>
 						Data
 					</span>
@@ -207,7 +208,7 @@ import VoiceRecorder from "@/components/VoiceRecorder.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { renderMarkdown } from "@/markdown";
 import { parseAsk } from "@/lib/chatAsk";
-import { lastCanvasFrame } from "@/lib/dashboardRestore";
+import { builderCanvasFrame } from "@/lib/dashboardRestore";
 import { useJarvisTheme } from "@/theme";
 import { session } from "@/data/session";
 import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
@@ -242,6 +243,11 @@ function errMsg(e) {
 
 // ── conversation persistence (per user, ChatComposer's namespacing idiom) ────
 const conversation = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "");
+// The message whose canvas the BUILDER last rendered - the page stamps it, this
+// pane replays exactly that one. Scanning the transcript for "the newest html"
+// instead would hand the builder an artifact main chat produced in the same
+// thread ("Open in chat" shares it) and arm Save over it.
+const canvasMsg = useStorage(`jarvis-dash-canvasmsg-${session.user || "anon"}`, "");
 
 // ── transcript ────────────────────────────────────────────────────────────────
 const messages = ref([]);
@@ -319,9 +325,9 @@ async function loadTranscript({ initial = false } = {}) {
 		// Navigating away unmounts the builder and drops its canvas html, but the
 		// transcript we just reloaded still carries every artifact the agent drew
 		// (get_conversation returns each message's parsed `canvas` list). Replay
-		// the last one so coming back is lossless — the page ignores it when a
-		// canvas is already on screen.
-		const frame = lastCanvasFrame(messages.value);
+		// the one the BUILDER last rendered so coming back is lossless — the
+		// page ignores it when a canvas is already on screen.
+		const frame = builderCanvasFrame(messages.value, canvasMsg.value);
 		if (frame) emit("canvas", { ...frame, restore: true });
 		nextTick(scrollBottom);
 	} catch (e) {
@@ -463,7 +469,8 @@ const sending = ref(false);
 const draft = ref("");
 const box = ref(null);
 
-// Explicit data-mode toggle (goal requirement): "auto" = agent decides,
+// Explicit data-mode toggle (goal requirement): "auto" = one of the questions
+// the agent asks before the first build (it no longer guesses from wording),
 // "static" = baked one-time report, "live" = declared view-time sources.
 // Persisted per user so the choice survives page hops. ("auto" rather than ""
 // so reka-ui's RadioGroup has a real value to select.) The API wrapper only
@@ -488,6 +495,11 @@ function autoGrow() {
 watch(draft, autoGrow, { flush: "post" });
 
 function onKeydown(e) {
+	// An Enter that CONFIRMS an IME candidate (Japanese/Chinese/Korean) belongs
+	// to the composition, not to us - sending on it posts the half-converted
+	// reading. keyCode 229 is the pre-`isComposing` browsers' version of the
+	// same signal.
+	if (e.isComposing || e.keyCode === 229) return;
 	// Enter sends, Shift+Enter keeps the newline
 	if (e.key === "Enter" && !e.shiftKey) {
 		e.preventDefault();
@@ -500,6 +512,12 @@ function onTranscript(text) {
 	const cur = draft.value;
 	draft.value = cur.trim() ? cur.replace(/\s+$/, "") + " " + text : text;
 }
+
+// send() can be handed a DIFFERENT conversation than the one it posted to (the
+// stored one was deleted or reassigned server-side, so send_message opened a
+// fresh one). That repoint is OURS: the run it just started is the one on
+// screen, so the follow watcher below must not tear its Thinking indicator down.
+let ownRepoint = false;
 
 async function send() {
 	const text = draft.value.trim();
@@ -527,6 +545,7 @@ async function send() {
 			return;
 		}
 		if (r.conversation_id && r.conversation_id !== conversation.value) {
+			ownRepoint = true;
 			conversation.value = r.conversation_id;
 		}
 		runActive.value = true;
@@ -550,12 +569,13 @@ function newChat() {
 }
 
 // Drop everything that belongs to the thread on screen, leaving the pointer
-// alone (the conversation watcher below re-points it).
-function clearThread() {
+// alone (the conversation watcher below re-points it). `keepRun` is for the
+// one case where the thread moved but the run did not: our own send.
+function clearThread({ keepRun = false } = {}) {
 	loadReq++; // drop any in-flight transcript load
 	messages.value = [];
 	pendingCards.value = [];
-	runActive.value = false;
+	if (!keepRun) runActive.value = false;
 	draft.value = "";
 }
 
@@ -570,7 +590,9 @@ function resetChat() {
 // to. Guarded on `prev`: "" -> id is our own first send, already reconciled.
 watch(conversation, (id, prev) => {
 	if (!prev || id === prev) return;
-	clearThread();
+	const own = ownRepoint;
+	ownRepoint = false;
+	clearThread({ keepRun: own });
 	if (id) {
 		loadTranscript({ initial: true });
 		refreshPending();

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -58,10 +58,21 @@
 					</div>
 					<!-- assistant: markdown, same renderer + prose classes as the
 					     Approvals/Agents surfaces (renderMarkdown escapes HTML first) -->
-					<div v-else class="flex">
+					<div v-else class="flex flex-col">
 						<div
 							class="prose prose-sm min-w-0 max-w-none text-ink-gray-8"
 							v-html="renderBubble(m.content)"
+						/>
+						<!-- clarifying questions the agent asked before building: the
+						     SAME option cards the main chat renders. paletteVars is
+						     bound here because the jv-* tokens AskCard styles with are
+						     not global (SkillDetail precedent). -->
+						<AskCard
+							v-if="askFor === m.name && activeAsk"
+							:key="m.name"
+							:spec="activeAsk"
+							:style="paletteVars"
+							@submit="sendText"
 						/>
 					</div>
 				</template>
@@ -120,18 +131,25 @@
 			</div>
 		</div>
 
-		<!-- composer: autosizing textarea + voice + send -->
+		<!-- composer: autosizing textarea + voice + send.
+		     A RAW textarea with v-model, per Composer.vue's documented pattern:
+		     v-model (not :value + a manual emit) so Vue's own vModelText
+		     directive keeps handling IME composition. And the box is NEVER
+		     disabled: a focused, dirty textarea that is programmatically
+		     disabled gets blurred by the browser, which fires `change` — the
+		     frappe-ui Textarea this used to be listens on `change` too and
+		     re-emitted the PRE-CLEAR value, restoring the message we had just
+		     sent. Only the send button and send() are gated on `sending`. -->
 		<div class="shrink-0 border-t px-4 py-3">
-			<div ref="box" @keydown="onKeydown" @input="autoGrow">
-				<FormControl
-					type="textarea"
-					:rows="2"
-					placeholder="Describe the dashboard…"
-					:modelValue="draft"
-					:disabled="sending"
-					@update:modelValue="(v) => (draft = v)"
-				/>
-			</div>
+			<textarea
+				ref="box"
+				v-model="draft"
+				rows="2"
+				placeholder="Describe the dashboard…"
+				class="block w-full resize-none rounded border border-transparent bg-surface-gray-2 px-2 py-1.5 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-white focus:shadow-sm focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+				@keydown="onKeydown"
+				@input="autoGrow"
+			/>
 			<div class="mt-2 flex items-center justify-between gap-2">
 				<div class="flex items-center gap-1.5">
 					<VoiceRecorder v-if="caps.stt_enabled" compact @transcript="onTranscript" />
@@ -154,7 +172,7 @@
 				<Button
 					variant="solid"
 					label="Send"
-					:disabled="!draft.trim()"
+					:disabled="!draft.trim() || sending"
 					:loading="sending"
 					@click="send"
 				/>
@@ -181,12 +199,16 @@
 //                      the html artifact onto the canvas pane.
 //   no socket        → (?nosocket / headless QA) a bounded refetch ladder after
 //                      each send stands in for the realtime frames.
-import { ref, computed, nextTick, inject, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, inject, onMounted, onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
-import { Button, FeatherIcon, FormControl, LoadingIndicator, TabButtons, toast } from "frappe-ui";
+import { Button, FeatherIcon, LoadingIndicator, TabButtons, toast } from "frappe-ui";
 import VoiceRecorder from "@/components/VoiceRecorder.vue";
+import AskCard from "@/components/chat/AskCard.vue";
 import { renderMarkdown } from "@/markdown";
+import { parseAsk } from "@/lib/chatAsk";
+import { lastCanvasFrame } from "@/lib/dashboardRestore";
+import { useJarvisTheme } from "@/theme";
 import { session } from "@/data/session";
 import { sendDashboardChat, getDashboardConversation } from "@/api/dashboards";
 import { listPendingConfirmations, confirmTool, dismissTool } from "@/api";
@@ -204,12 +226,15 @@ const props = defineProps({
 	editingName: { type: String, default: "" },
 });
 
-// canvas: {message_id, items} for a canvas frame on our conversation;
+// canvas: {message_id, items[, restore]} for a canvas frame on our conversation
+// (restore = replayed from the loaded transcript, not a live socket frame);
 // activity: a run ended (the page may refresh lists); reset: New chat clicked.
 const emit = defineEmits(["canvas", "activity", "reset"]);
 
 const router = useRouter();
 const socket = inject("$socket", null);
+// AskCard styles with the jv-* tokens, which this frappe-ui page does not bind.
+const { paletteVars } = useJarvisTheme();
 
 function errMsg(e) {
 	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
@@ -232,7 +257,10 @@ const bubbles = computed(() =>
 );
 
 // ChatView's stripBlocks, minimal subset: internal fenced blocks (actions,
-// confirms, cards…) never render as raw fences in the pane.
+// confirms, cards…) never render as raw fences in the pane. `jarvis-ask` is
+// stripped from the PROSE here too, but unlike the others it is not discarded:
+// <AskCard> renders it below the bubble (see activeAsk), so the clarifying
+// questions the agent asks before building are answerable in this pane.
 function stripBlocks(text) {
 	return (text || "")
 		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
@@ -248,6 +276,20 @@ function stripBlocks(text) {
 function renderBubble(text) {
 	return renderMarkdown(stripBlocks(text));
 }
+
+// ── clarifying questions (ChatView's rule: the card lives on the LAST
+// assistant message only, so a stale ask from three turns ago isn't answerable)
+const lastAssistant = computed(() => {
+	const rows = bubbles.value;
+	for (let i = rows.length - 1; i >= 0; i--) {
+		if (rows[i].role === "assistant" && !rows[i].error) return rows[i];
+	}
+	return null;
+});
+const activeAsk = computed(() =>
+	lastAssistant.value ? parseAsk(lastAssistant.value.content) : null
+);
+const askFor = computed(() => (activeAsk.value ? lastAssistant.value.name : null));
 
 function scrollBottom() {
 	const el = scroller.value;
@@ -274,6 +316,13 @@ async function loadTranscript({ initial = false } = {}) {
 		const d = (await getDashboardConversation(conversation.value)) || {};
 		if (id !== loadReq) return;
 		messages.value = d.messages || [];
+		// Navigating away unmounts the builder and drops its canvas html, but the
+		// transcript we just reloaded still carries every artifact the agent drew
+		// (get_conversation returns each message's parsed `canvas` list). Replay
+		// the last one so coming back is lossless — the page ignores it when a
+		// canvas is already on screen.
+		const frame = lastCanvasFrame(messages.value);
+		if (frame) emit("canvas", { ...frame, restore: true });
 		nextTick(scrollBottom);
 	} catch (e) {
 		if (id !== loadReq) return;
@@ -427,11 +476,16 @@ const DATA_MODES = [
 const dataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto");
 
 function autoGrow() {
-	const ta = box.value && box.value.querySelector("textarea");
+	const ta = box.value;
 	if (!ta) return;
 	ta.style.height = "auto";
 	ta.style.height = Math.min(ta.scrollHeight, 180) + "px";
 }
+// Programmatic changes (the send that clears the box, dictation, the save
+// dialog's hand-off) only reach the DOM on the next flush — flush:"post" so the
+// textarea's value is already written when we measure scrollHeight. Typed input
+// grows synchronously in the @input handler so the box never lags the caret.
+watch(draft, autoGrow, { flush: "post" });
 
 function onKeydown(e) {
 	// Enter sends, Shift+Enter keeps the newline
@@ -445,7 +499,6 @@ function onTranscript(text) {
 	// dictation appends to any typed draft (ChatComposer precedent)
 	const cur = draft.value;
 	draft.value = cur.trim() ? cur.replace(/\s+$/, "") + " " + text : text;
-	nextTick(autoGrow);
 }
 
 async function send() {
@@ -453,7 +506,6 @@ async function send() {
 	if (!text || sending.value) return;
 	sending.value = true;
 	draft.value = "";
-	nextTick(autoGrow);
 	// optimistic user bubble - reconciled by the next transcript refetch
 	const tmpName = `tmp-${Date.now()}`;
 	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }];
@@ -489,17 +541,41 @@ async function send() {
 	}
 }
 
+// "New chat" ASKS the page rather than acting: the page owns the canvas and
+// puts up the discard confirm, then calls resetChat() back through the exposed
+// handle if the user goes ahead. Resetting here first would leave a cancelled
+// confirm with an emptied chat next to a canvas that survived.
 function newChat() {
+	emit("reset");
+}
+
+// Drop everything that belongs to the thread on screen, leaving the pointer
+// alone (the conversation watcher below re-points it).
+function clearThread() {
 	loadReq++; // drop any in-flight transcript load
-	conversation.value = "";
 	messages.value = [];
 	pendingCards.value = [];
 	runActive.value = false;
 	draft.value = "";
-	nextTick(autoGrow);
-	// the page clears its builder seed (canvas html, editing state) with us
-	emit("reset");
 }
+
+function resetChat() {
+	clearThread();
+	conversation.value = "";
+}
+
+// The page re-points the sticky conversation slot (opening a saved dashboard
+// for editing resumes the thread that built it). Follow it, or the transcript
+// on screen belongs to a different dashboard than the one the next send goes
+// to. Guarded on `prev`: "" -> id is our own first send, already reconciled.
+watch(conversation, (id, prev) => {
+	if (!prev || id === prev) return;
+	clearThread();
+	if (id) {
+		loadTranscript({ initial: true });
+		refreshPending();
+	}
+});
 
 // Post a message into this pane programmatically (the save dialog's "Ask the
 // assistant to fix these" hand-off). Ignored while a send is already in flight.
@@ -507,10 +583,9 @@ function sendText(text) {
 	const t = String(text || "").trim();
 	if (!t || sending.value) return;
 	draft.value = t;
-	nextTick(autoGrow);
 	send();
 }
-defineExpose({ newChat, sendText });
+defineExpose({ resetChat, sendText });
 
 // ── realtime ──────────────────────────────────────────────────────────────────
 function onEvent(p) {

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -116,6 +116,7 @@
 						</div>
 					</div>
 					<DashboardCanvas
+						ref="canvasRef"
 						class="min-h-0 flex-1"
 						mode="builder"
 						:html="builderHtml"
@@ -176,6 +177,20 @@
 				@saved="onSaved"
 				@fix-in-chat="fixInChat"
 			/>
+
+			<!-- Discard confirm. NOT frappe-ui's confirmDialog: that has room for
+			     exactly one action, and telling someone who is about to lose a
+			     canvas that "its chat stays in your conversations" is only useful
+			     with a way to go there. -->
+			<Dialog
+				v-model="discardOpen"
+				:options="{
+					title: 'Discard this unsaved dashboard?',
+					message: 'Its chat stays in your conversations.',
+					actions: discardActions,
+				}"
+				@close="settleDiscard(false)"
+			/>
 		</template>
 	</div>
 </template>
@@ -194,15 +209,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
-import {
-	Badge,
-	Breadcrumbs,
-	Button,
-	Dropdown,
-	FeatherIcon,
-	confirmDialog,
-	toast,
-} from "frappe-ui";
+import { Badge, Breadcrumbs, Button, Dialog, Dropdown, FeatherIcon, toast } from "frappe-ui";
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import TabBar from "@/components/list/TabBar.vue";
 import { session } from "@/data/session";
@@ -268,6 +275,7 @@ const savedName = ref(""); // last save's name → the "View dashboard" link
 const detectedSources = ref([]); // parsed #jarvis-sources (DashboardCanvas emit)
 const saveOpen = ref(false);
 const chatPane = ref(null);
+const canvasRef = ref(null);
 // Named render theme; "Jarvis" (the app's design language) unless picked or
 // seeded from the edited dashboard.
 const builderTheme = ref(DEFAULT_THEME);
@@ -281,35 +289,62 @@ const themeOptions = THEME_OPTIONS.map((t) => ({
 // pane resumes the right thread and data mode instead of a stale sticky one.
 const chatConv = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "");
 const dashDataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto");
+// The dashboard this builder is EDITING, and the message whose canvas it last
+// rendered. Both are page state that a navigation would otherwise drop - and
+// dropping the first one is not cosmetic: without it a remount restores the
+// canvas but not the binding, so "Save dashboard" writes a SECOND row instead of
+// updating the one on screen.
+const editingSticky = useStorage(`jarvis-dash-editing-${session.user || "anon"}`, "");
+const canvasMsg = useStorage(`jarvis-dash-canvasmsg-${session.user || "anon"}`, "");
 
-// A pending ?edit=<name> deep-link. Read synchronously at setup, i.e. BEFORE the
-// chat pane mounts and replays its transcript's canvas: an explicit edit target
-// owns the canvas, so its restore must not flash the previous build first.
-const editSeed = ref(typeof route.query.edit === "string" ? route.query.edit : "");
+// A pending ?edit=<name> deep-link, or - on a plain remount - the dashboard the
+// builder was editing when it went away. Read synchronously at setup, i.e.
+// BEFORE the chat pane mounts and replays its transcript's canvas: an explicit
+// edit target owns the canvas, so its restore must not flash a build first.
+const routeEdit = typeof route.query.edit === "string" ? route.query.edit : "";
+const editSeed = ref(routeEdit || editingSticky.value);
+
+// Message ids whose artifact could not be replayed (the File was purged, the
+// conversation was reassigned). The pane emits a restore frame on EVERY
+// transcript load - including the 300ms-debounced refetch behind each realtime
+// frame - so without this latch an unreadable artifact means an unbounded run of
+// silent, failing get_canvas calls (a full File load + a disk read each time).
+const failedRestores = new Set();
 
 // Chat drew/updated an artifact: pick the LAST html item and pull its
 // render-ready content onto the canvas.
 //
-// `restore` marks a replay of the newest canvas found in the loaded transcript
-// (the chat pane emits one on every transcript load) rather than a live socket
-// frame. It rehydrates the canvas after a navigation dropped it, and must never
+// `restore` marks a replay of the canvas this builder last rendered, found
+// again in the loaded transcript (the chat pane emits one on every transcript
+// load), rather than a live socket frame. It rehydrates the canvas after a
+// navigation dropped it, and must never
 // overwrite what is already on screen - a live frame for the turn in flight
 // always wins over a replay of an older turn.
 async function onCanvas({ message_id, items, restore }) {
 	if (restore && (builderHtml.value || editSeed.value)) return;
+	if (restore && failedRestores.has(message_id)) return;
 	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html");
 	if (!htmlItem || !message_id) return;
 	try {
 		const r = await getCanvas(message_id, htmlItem.name, 0);
 		const content = r && (r.content || r.data_url);
+		if (!content) {
+			if (restore) failedRestores.add(message_id);
+			return;
+		}
 		// The await above is a real round trip: re-check that a live frame (or a
 		// resolved ?edit= seed) did not land while this replay was in flight.
-		if (content && !(restore && (builderHtml.value || editSeed.value)))
-			builderHtml.value = content;
+		if (restore && (builderHtml.value || editSeed.value)) return;
+		builderHtml.value = content;
+		// Remember WHICH message is on the canvas: a later rehydration replays
+		// exactly this artifact instead of the newest html in a conversation main
+		// chat may also have drawn in.
+		canvasMsg.value = message_id;
 	} catch (e) {
 		// A restore is best-effort background work the user did not ask for -
 		// a deleted/expired artifact must not raise a toast on page load.
-		if (!restore) toast.error(errMsg(e));
+		if (restore) failedRestores.add(message_id);
+		else toast.error(errMsg(e));
 	}
 }
 
@@ -328,8 +363,12 @@ function fixInChat({ text }) {
 
 function onSaved(detail) {
 	savedName.value = (detail && detail.name) || "";
-	// keep editing the row we just saved - the next Save is "Save changes"
-	if (detail && detail.name) editingDetail.value = detail;
+	// keep editing the row we just saved - the next Save is "Save changes", and
+	// it stays that way across a navigation (the sticky target below)
+	if (detail && detail.name) {
+		editingDetail.value = detail;
+		editingSticky.value = detail.name;
+	}
 	toast.success("Dashboard saved");
 }
 
@@ -342,21 +381,49 @@ const unsavedCanvas = computed(
 // The canvas is never thrown away silently. Every path that would drop an
 // unsaved dashboard (New dashboard, the chat pane's New chat, opening another
 // dashboard for editing) asks first. The chat itself is NOT lost either way -
-// it stays in the user's conversations - so say so.
-function confirmDiscard(onYes) {
+// it stays in the user's conversations - so say so, and offer to go there.
+const discardOpen = ref(false);
+let discardYes = null;
+let discardNo = null;
+
+function confirmDiscard(onYes, onNo) {
 	if (!unsavedCanvas.value) {
 		onYes();
 		return;
 	}
-	confirmDialog({
-		title: "Discard this unsaved dashboard?",
-		message: "Its chat stays in your conversations.",
-		onConfirm: ({ hideDialog }) => {
-			onYes();
-			hideDialog();
-		},
-	});
+	discardYes = onYes;
+	discardNo = onNo || null;
+	discardOpen.value = true;
 }
+
+// Both outcomes run exactly once: the callbacks are taken before the dialog
+// closes, so the component's own @close can never fire a second settle.
+function settleDiscard(yes) {
+	const y = discardYes;
+	const n = discardNo;
+	discardYes = null;
+	discardNo = null;
+	discardOpen.value = false;
+	if (yes) {
+		if (y) y();
+	} else if (n) n();
+}
+
+const discardActions = computed(() => {
+	const actions = [{ label: "Discard", variant: "solid", onClick: () => settleDiscard(true) }];
+	if (chatConv.value) {
+		actions.push({
+			label: "Open its chat",
+			variant: "subtle",
+			onClick: () => {
+				const id = chatConv.value;
+				settleDiscard(false);
+				router.push("/c/" + id);
+			},
+		});
+	}
+	return actions;
+});
 
 function clearBuilder() {
 	// The pane stays mounted across tabs now, so clear its thread through the
@@ -364,6 +431,9 @@ function clearBuilder() {
 	if (chatPane.value && chatPane.value.resetChat) chatPane.value.resetChat();
 	chatConv.value = "";
 	dashDataMode.value = "auto";
+	editingSticky.value = "";
+	canvasMsg.value = "";
+	editSeed.value = "";
 	builderHtml.value = "";
 	editingDetail.value = null;
 	savedName.value = "";
@@ -397,28 +467,74 @@ function resetBuilder() {
 //
 // It also repoints the single sticky conversation slot, so if an unsaved canvas
 // is on the builder it gets the same discard confirm as New dashboard.
-async function loadEdit(name) {
+//
+// `deepLink: false` is the remount path (restoring the sticky editing target):
+// silent about a target that has since been deleted, and it never blanks the
+// thread in progress just because the stored document names no conversation.
+async function loadEdit(name, { deepLink = true } = {}) {
+	// The seed is settled only when the confirm is - clearing it up front would
+	// let a transcript restore land on the canvas while the dialog is still up.
+	const settle = () => {
+		if (editSeed.value === name) editSeed.value = "";
+	};
 	try {
 		const d = await getDashboard(name);
-		if (!d || !d.name) return;
+		if (!d || !d.name) {
+			settle();
+			return;
+		}
 		confirmDiscard(() => {
 			builderHtml.value = d.html || "";
 			editingDetail.value = d;
+			editingSticky.value = d.name;
 			savedName.value = d.name;
 			builderTheme.value = themeKey(d.theme);
+			// the canvas is this document now, not an artifact from the transcript
+			canvasMsg.value = "";
 			// resume the build thread, or a fresh one — never the stale sticky
 			// conversation left over from editing a different dashboard.
-			chatConv.value = d.source_conversation || "";
-			dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static";
-		});
+			if (deepLink || d.source_conversation) {
+				chatConv.value = d.source_conversation || "";
+				dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static";
+			}
+			settle();
+		}, settle);
 	} catch (e) {
-		toast.error(errMsg(e));
-	} finally {
-		// Whatever happened, the explicit edit target is settled: let the chat
-		// pane's transcript restore reach the canvas again.
-		editSeed.value = "";
+		// A restored target that has since been deleted is not the user's doing -
+		// forget it silently instead of toasting on every page load.
+		if (deepLink) toast.error(errMsg(e));
+		else editingSticky.value = "";
+		settle();
 	}
 }
+
+// ?edit= also changes WITHOUT a remount — "Edit in builder" on a second
+// dashboard while this page is already open. A one-shot read at setup made that
+// silently repoint the builder AND made loadEdit's discard confirm unreachable
+// (a fresh mount always has an empty canvas). Watch it, and the confirm is real.
+watch(
+	() => route.query.edit,
+	(v) => {
+		if (route.name !== "DashboardsPage") return;
+		const name = typeof v === "string" ? v : "";
+		if (!name || name === (editingDetail.value || {}).name) return;
+		editSeed.value = name;
+		loadEdit(name);
+	}
+);
+
+// v-show keeps the builder mounted while Saved is up, so its iframe loads and
+// runs at 0x0 behind `display:none` — charts initialised against a zero-size
+// container draw nothing and do not self-heal. Re-drive the document when the
+// canvas is visible again (flush:"post", i.e. after `display` is back).
+watch(
+	activeTab,
+	(v) => {
+		if (v !== "builder" || !builderHtml.value) return;
+		if (canvasRef.value && canvasRef.value.rebuild) canvasRef.value.rebuild();
+	},
+	{ flush: "post" }
+);
 
 // ── the drag-split (Sidebar's resize machinery, vertical) ────────────────────
 const builderEl = ref(null);
@@ -489,6 +605,8 @@ onMounted(async () => {
 	}
 	if (fresh) caps.value = { ...caps.value, ...fresh };
 
-	if (editSeed.value) loadEdit(editSeed.value);
+	// An explicit ?edit= is the user asking; the sticky target is this page
+	// remembering what it was editing, so a failure there stays quiet.
+	if (editSeed.value) loadEdit(editSeed.value, { deepLink: !!routeEdit });
 });
 </script>

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -60,8 +60,12 @@
 					dashboard here. You can still open and view saved dashboards.
 				</span>
 			</div>
+			<!-- v-show, NOT v-if: switching to Saved must not unmount the chat
+			     pane. Its socket listener is torn down on unmount and the agent's
+			     kind:"canvas" frame is a ONE-SHOT publish, so a build that lands
+			     while the user is looking at Saved would never reach the canvas. -->
 			<div
-				v-if="activeTab === 'builder'"
+				v-show="activeTab === 'builder'"
 				ref="builderEl"
 				class="flex min-h-0 flex-1 flex-col"
 			>
@@ -159,7 +163,7 @@
 			</div>
 
 			<!-- ============ Saved tab ============ -->
-			<SavedDashboardsTab v-else class="min-h-0 flex-1" />
+			<SavedDashboardsTab v-if="activeTab === 'saved'" class="min-h-0 flex-1" />
 
 			<SaveDashboardDialog
 				v-model="saveOpen"
@@ -190,7 +194,15 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
-import { Badge, Breadcrumbs, Button, Dropdown, FeatherIcon, toast } from "frappe-ui";
+import {
+	Badge,
+	Breadcrumbs,
+	Button,
+	Dropdown,
+	FeatherIcon,
+	confirmDialog,
+	toast,
+} from "frappe-ui";
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import TabBar from "@/components/list/TabBar.vue";
 import { session } from "@/data/session";
@@ -270,17 +282,34 @@ const themeOptions = THEME_OPTIONS.map((t) => ({
 const chatConv = useStorage(`jarvis-dash-conv-${session.user || "anon"}`, "");
 const dashDataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`, "auto");
 
+// A pending ?edit=<name> deep-link. Read synchronously at setup, i.e. BEFORE the
+// chat pane mounts and replays its transcript's canvas: an explicit edit target
+// owns the canvas, so its restore must not flash the previous build first.
+const editSeed = ref(typeof route.query.edit === "string" ? route.query.edit : "");
+
 // Chat drew/updated an artifact: pick the LAST html item and pull its
 // render-ready content onto the canvas.
-async function onCanvas({ message_id, items }) {
+//
+// `restore` marks a replay of the newest canvas found in the loaded transcript
+// (the chat pane emits one on every transcript load) rather than a live socket
+// frame. It rehydrates the canvas after a navigation dropped it, and must never
+// overwrite what is already on screen - a live frame for the turn in flight
+// always wins over a replay of an older turn.
+async function onCanvas({ message_id, items, restore }) {
+	if (restore && (builderHtml.value || editSeed.value)) return;
 	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html");
 	if (!htmlItem || !message_id) return;
 	try {
 		const r = await getCanvas(message_id, htmlItem.name, 0);
 		const content = r && (r.content || r.data_url);
-		if (content) builderHtml.value = content;
+		// The await above is a real round trip: re-check that a live frame (or a
+		// resolved ?edit= seed) did not land while this replay was in flight.
+		if (content && !(restore && (builderHtml.value || editSeed.value)))
+			builderHtml.value = content;
 	} catch (e) {
-		toast.error(errMsg(e));
+		// A restore is best-effort background work the user did not ask for -
+		// a deleted/expired artifact must not raise a toast on page load.
+		if (!restore) toast.error(errMsg(e));
 	}
 }
 
@@ -304,23 +333,35 @@ function onSaved(detail) {
 	toast.success("Dashboard saved");
 }
 
-// "New dashboard" (Saved tab header) - fresh chat + empty canvas on Builder.
-// One navigation clears the tab hash AND any ?edit seed together (resetBuilder
-// + setTab separately would race on route.query).
-function newDashboard() {
-	chatConv.value = ""; // pane isn't mounted on the Saved tab; clear before it is
-	dashDataMode.value = "auto";
-	builderHtml.value = "";
-	editingDetail.value = null;
-	savedName.value = "";
-	detectedSources.value = [];
-	builderTheme.value = DEFAULT_THEME;
-	activeTab.value = "builder";
-	router.push({ hash: "", query: {} });
+// A canvas the user would lose: html on the builder that isn't (still) the
+// document of the dashboard we last saved or opened for editing.
+const unsavedCanvas = computed(
+	() => !!builderHtml.value && builderHtml.value !== ((editingDetail.value || {}).html || "")
+);
+
+// The canvas is never thrown away silently. Every path that would drop an
+// unsaved dashboard (New dashboard, the chat pane's New chat, opening another
+// dashboard for editing) asks first. The chat itself is NOT lost either way -
+// it stays in the user's conversations - so say so.
+function confirmDiscard(onYes) {
+	if (!unsavedCanvas.value) {
+		onYes();
+		return;
+	}
+	confirmDialog({
+		title: "Discard this unsaved dashboard?",
+		message: "Its chat stays in your conversations.",
+		onConfirm: ({ hideDialog }) => {
+			onYes();
+			hideDialog();
+		},
+	});
 }
 
-// Also fired by the chat pane's own "New chat" (emit("reset")).
-function resetBuilder() {
+function clearBuilder() {
+	// The pane stays mounted across tabs now, so clear its thread through the
+	// exposed handle rather than relying on a remount to do it.
+	if (chatPane.value && chatPane.value.resetChat) chatPane.value.resetChat();
 	chatConv.value = "";
 	dashDataMode.value = "auto";
 	builderHtml.value = "";
@@ -328,17 +369,39 @@ function resetBuilder() {
 	savedName.value = "";
 	detectedSources.value = [];
 	builderTheme.value = DEFAULT_THEME;
-	if (route.query.edit) router.replace({ query: {}, hash: route.hash });
+}
+
+// "New dashboard" (Saved tab header) - fresh chat + empty canvas on Builder.
+// One navigation clears the tab hash AND any ?edit seed together (resetBuilder
+// + setTab separately would race on route.query).
+function newDashboard() {
+	confirmDiscard(() => {
+		clearBuilder();
+		activeTab.value = "builder";
+		router.push({ hash: "", query: {} });
+	});
+}
+
+// Also fired by the chat pane's own "New chat" (emit("reset")).
+function resetBuilder() {
+	confirmDiscard(() => {
+		clearBuilder();
+		if (route.query.edit) router.replace({ query: {}, hash: route.hash });
+	});
 }
 
 // ?edit=<name> deep-link: seed the canvas + save dialog from a saved dashboard.
 // Also resume the conversation that built it (so the agent has memory of the
 // document) and seed the data-mode from its derived type, so an edit session
 // never silently drifts onto/converts the wrong dashboard.
+//
+// It also repoints the single sticky conversation slot, so if an unsaved canvas
+// is on the builder it gets the same discard confirm as New dashboard.
 async function loadEdit(name) {
 	try {
 		const d = await getDashboard(name);
-		if (d && d.name) {
+		if (!d || !d.name) return;
+		confirmDiscard(() => {
 			builderHtml.value = d.html || "";
 			editingDetail.value = d;
 			savedName.value = d.name;
@@ -347,9 +410,13 @@ async function loadEdit(name) {
 			// conversation left over from editing a different dashboard.
 			chatConv.value = d.source_conversation || "";
 			dashDataMode.value = d.dashboard_type === "Connected" ? "live" : "static";
-		}
+		});
 	} catch (e) {
 		toast.error(errMsg(e));
+	} finally {
+		// Whatever happened, the explicit edit target is settled: let the chat
+		// pane's transcript restore reach the canvas again.
+		editSeed.value = "";
 	}
 }
 
@@ -422,7 +489,6 @@ onMounted(async () => {
 	}
 	if (fresh) caps.value = { ...caps.value, ...fresh };
 
-	const edit = typeof route.query.edit === "string" ? route.query.edit : "";
-	if (edit) loadEdit(edit);
+	if (editSeed.value) loadEdit(editSeed.value);
 });
 </script>

--- a/frontend/src/pages/triggers/TriggerChatPane.vue
+++ b/frontend/src/pages/triggers/TriggerChatPane.vue
@@ -136,22 +136,26 @@
 		<!-- composer: autosizing textarea + voice + send. Fully disabled for
 		     non-admins (the note above explains why): the agent refuses the
 		     request server-side anyway, so submitting would only burn a slow
-		     LLM round trip. -->
+		     LLM round trip. That permission lock is the ONLY `disabled` here:
+		     a RAW textarea with v-model (Composer.vue's documented pattern -
+		     Vue's vModelText keeps handling IME composition), and `sending`
+		     gates the send button and send() alone. Disabling a focused, dirty
+		     textarea mid-send blurs it, fires `change`, and the frappe-ui
+		     Textarea this used to be re-emitted the PRE-CLEAR value, putting
+		     the just-sent message back in the box. -->
 		<div class="shrink-0 border-t px-4 py-3">
-			<div ref="box" @keydown="onKeydown" @input="autoGrow">
-				<FormControl
-					type="textarea"
-					:rows="2"
-					:placeholder="
-						caps.can_manage
-							? 'Describe the trigger…'
-							: 'Requires the Jarvis Admin role'
-					"
-					:modelValue="draft"
-					:disabled="sending || !caps.can_manage"
-					@update:modelValue="(v) => (draft = v)"
-				/>
-			</div>
+			<textarea
+				ref="box"
+				v-model="draft"
+				rows="2"
+				:placeholder="
+					caps.can_manage ? 'Describe the trigger…' : 'Requires the Jarvis Admin role'
+				"
+				:disabled="!caps.can_manage"
+				class="block w-full resize-none rounded border border-transparent bg-surface-gray-2 px-2 py-1.5 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-white focus:shadow-sm focus:outline-none focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 disabled:bg-surface-gray-1 disabled:text-ink-gray-5 disabled:placeholder-ink-gray-3"
+				@keydown="onKeydown"
+				@input="autoGrow"
+			/>
 			<div class="mt-2 flex items-center justify-between gap-2">
 				<div class="flex items-center gap-1.5">
 					<VoiceRecorder
@@ -163,7 +167,7 @@
 				<Button
 					variant="solid"
 					label="Send"
-					:disabled="!draft.trim() || !caps.can_manage"
+					:disabled="!draft.trim() || sending || !caps.can_manage"
 					:loading="sending"
 					@click="send"
 				/>
@@ -190,10 +194,10 @@
 //                      created/edited by the agent).
 //   no socket        → (?nosocket / headless QA) a bounded refetch ladder after
 //                      each send stands in for the realtime frames.
-import { ref, computed, nextTick, inject, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, watch, nextTick, inject, onMounted, onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
-import { Button, FeatherIcon, FormControl, LoadingIndicator, toast } from "frappe-ui";
+import { Button, FeatherIcon, LoadingIndicator, toast } from "frappe-ui";
 import VoiceRecorder from "@/components/VoiceRecorder.vue";
 import { renderMarkdown } from "@/markdown";
 import { session } from "@/data/session";
@@ -421,11 +425,16 @@ const draft = ref("");
 const box = ref(null);
 
 function autoGrow() {
-	const ta = box.value && box.value.querySelector("textarea");
+	const ta = box.value;
 	if (!ta) return;
 	ta.style.height = "auto";
 	ta.style.height = Math.min(ta.scrollHeight, 180) + "px";
 }
+// Programmatic changes (the send that clears the box, dictation) only reach the
+// DOM on the next flush - flush:"post" so the textarea's value is already
+// written when we measure scrollHeight. Typed input grows synchronously in the
+// @input handler so the box never lags the caret.
+watch(draft, autoGrow, { flush: "post" });
 
 function onKeydown(e) {
 	// Enter sends, Shift+Enter keeps the newline
@@ -439,7 +448,6 @@ function onTranscript(text) {
 	// dictation appends to any typed draft (ChatComposer precedent)
 	const cur = draft.value;
 	draft.value = cur.trim() ? cur.replace(/\s+$/, "") + " " + text : text;
-	nextTick(autoGrow);
 }
 
 async function send() {
@@ -450,7 +458,6 @@ async function send() {
 	if (!text || sending.value) return;
 	sending.value = true;
 	draft.value = "";
-	nextTick(autoGrow);
 	// optimistic user bubble - reconciled by the next transcript refetch
 	const tmpName = `tmp-${Date.now()}`;
 	messages.value = [...messages.value, { name: tmpName, role: "user", content: text }];
@@ -486,7 +493,6 @@ function newChat() {
 	pendingCards.value = [];
 	runActive.value = false;
 	draft.value = "";
-	nextTick(autoGrow);
 }
 
 // ── realtime ──────────────────────────────────────────────────────────────────

--- a/frontend/src/pages/triggers/TriggerChatPane.vue
+++ b/frontend/src/pages/triggers/TriggerChatPane.vue
@@ -71,10 +71,22 @@
 					</div>
 					<!-- assistant: markdown, same renderer + prose classes as the
 					     Approvals/Agents surfaces (renderMarkdown escapes HTML first) -->
-					<div v-else class="flex">
+					<div v-else class="flex flex-col">
 						<div
 							class="prose prose-sm min-w-0 max-w-none text-ink-gray-8"
 							v-html="renderBubble(m.content)"
+						/>
+						<!-- clarifying questions: the SAME option cards the main chat
+						     renders. `jarvis-ask` is a standing capability, so a model
+						     that asks here must not leave an empty bubble nobody can
+						     answer. paletteVars is bound because the jv-* tokens AskCard
+						     styles with are not global (SkillDetail precedent). -->
+						<AskCard
+							v-if="askFor === m.name && activeAsk"
+							:key="m.name"
+							:spec="activeAsk"
+							:style="paletteVars"
+							@submit="sendText"
 						/>
 					</div>
 				</template>
@@ -199,7 +211,10 @@ import { useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
 import { Button, FeatherIcon, LoadingIndicator, toast } from "frappe-ui";
 import VoiceRecorder from "@/components/VoiceRecorder.vue";
+import AskCard from "@/components/chat/AskCard.vue";
 import { renderMarkdown } from "@/markdown";
+import { parseAsk } from "@/lib/chatAsk";
+import { useJarvisTheme } from "@/theme";
 import { session } from "@/data/session";
 import { sendTriggerChat, getTriggerConversation } from "@/api/triggers";
 import { listPendingConfirmations, confirmTool, dismissTool } from "@/api";
@@ -214,6 +229,8 @@ const emit = defineEmits(["activity"]); // parent refreshes the triggers list
 
 const router = useRouter();
 const socket = inject("$socket", null);
+// AskCard styles with the jv-* tokens, which this frappe-ui page does not bind.
+const { paletteVars } = useJarvisTheme();
 
 function errMsg(e) {
 	return (e && ((e.messages && e.messages[0]) || e.message)) || "Something went wrong.";
@@ -236,7 +253,9 @@ const bubbles = computed(() =>
 );
 
 // ChatView's stripBlocks, minimal subset: internal fenced blocks (actions,
-// confirms, cards…) never render as raw fences in the pane.
+// confirms, cards…) never render as raw fences in the pane. `jarvis-ask` is
+// stripped from the PROSE here too, but unlike the others it is not discarded:
+// <AskCard> renders it below the bubble (see activeAsk).
 function stripBlocks(text) {
 	return (text || "")
 		.replace(/```jarvis-action[ \t]*\n[\s\S]*?```/g, "")
@@ -252,6 +271,20 @@ function stripBlocks(text) {
 function renderBubble(text) {
 	return renderMarkdown(stripBlocks(text));
 }
+
+// ── clarifying questions (ChatView's rule: the card lives on the LAST
+// assistant message only, so a stale ask from three turns ago isn't answerable)
+const lastAssistant = computed(() => {
+	const rows = bubbles.value;
+	for (let i = rows.length - 1; i >= 0; i--) {
+		if (rows[i].role === "assistant" && !rows[i].error) return rows[i];
+	}
+	return null;
+});
+const activeAsk = computed(() =>
+	lastAssistant.value ? parseAsk(lastAssistant.value.content) : null
+);
+const askFor = computed(() => (activeAsk.value ? lastAssistant.value.name : null));
 
 function scrollBottom() {
 	const el = scroller.value;
@@ -437,6 +470,11 @@ function autoGrow() {
 watch(draft, autoGrow, { flush: "post" });
 
 function onKeydown(e) {
+	// An Enter that CONFIRMS an IME candidate (Japanese/Chinese/Korean) belongs
+	// to the composition, not to us - sending on it posts the half-converted
+	// reading. keyCode 229 is the pre-`isComposing` browsers' version of the
+	// same signal.
+	if (e.isComposing || e.keyCode === 229) return;
 	// Enter sends, Shift+Enter keeps the newline
 	if (e.key === "Enter" && !e.shiftKey) {
 		e.preventDefault();
@@ -484,6 +522,16 @@ async function send() {
 	} finally {
 		sending.value = false;
 	}
+}
+
+// Post a message into this pane programmatically (the AskCard's submitted
+// answers). Ignored while a send is already in flight - the card keeps its
+// picks, so the user can submit again once the pane is free.
+function sendText(text) {
+	const t = String(text || "").trim();
+	if (!t || sending.value) return;
+	draft.value = t;
+	send();
 }
 
 function newChat() {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1361,157 +1361,15 @@
 										Confirm
 									</button>
 								</div>
-								<!-- interactive clarifying questions (Claude-style cards; one Submit) -->
-								<div
+								<!-- interactive clarifying questions (Claude-style cards; one
+								     Submit). Keyed by message: AskCard holds the draft picks and
+								     must remount, not merely re-render, when a new ask arrives. -->
+								<AskCard
 									v-else-if="askFor === m.name && activeAsk"
-									class="jv-ask"
-									:class="{ 'jv-ask--form': askIsForm }"
-								>
-									<div
-										v-for="(q, qi) in activeAsk.questions"
-										:key="qi"
-										class="jv-ask-q"
-									>
-										<div class="jv-ask-qt">
-											<span class="jv-ask-num">{{ qi + 1 }}</span
-											>{{ q.q }}
-										</div>
-										<!-- yes/no, with optional custom labels (e.g. Approve / Reject) -->
-										<div v-if="q.type === 'yesno'" class="jv-ask-opts">
-											<button
-												v-for="(lbl, li) in q.options.length === 2
-													? q.options
-													: ['Yes', 'No']"
-												:key="li"
-												class="jv-ask-opt"
-												:class="{ on: isPicked(qi, lbl) }"
-												@click="toggleSingle(qi, lbl)"
-											>
-												<span v-if="isPicked(qi, lbl)" class="jv-ask-tick"
-													>✓</span
-												>{{ lbl }}
-											</button>
-										</div>
-										<!-- single / multi choice -->
-										<div
-											v-else-if="q.type === 'single' || q.type === 'multi'"
-											class="jv-ask-opts"
-										>
-											<button
-												v-for="(opt, oi) in q.options"
-												:key="oi"
-												class="jv-ask-opt"
-												:class="{ on: isPicked(qi, opt) }"
-												@click="
-													q.type === 'multi'
-														? toggleMulti(qi, opt)
-														: toggleSingle(qi, opt)
-												"
-											>
-												<span v-if="isPicked(qi, opt)" class="jv-ask-tick"
-													>✓</span
-												>{{ opt }}
-											</button>
-										</div>
-										<!-- date / datetime / free text fields -->
-										<input
-											v-else-if="q.type === 'date'"
-											type="date"
-											class="jv-ask-field"
-											:value="askSel[qi] || ''"
-											@input="pickSingle(qi, $event.target.value)"
-										/>
-										<input
-											v-else-if="q.type === 'datetime'"
-											type="datetime-local"
-											class="jv-ask-field"
-											:value="askSel[qi] || ''"
-											@input="pickSingle(qi, $event.target.value)"
-										/>
-										<input
-											v-else-if="q.type === 'text'"
-											type="text"
-											class="jv-ask-field"
-											:value="askSel[qi] || ''"
-											@input="pickSingle(qi, $event.target.value)"
-											placeholder="Type your answer…"
-											@keydown.enter.prevent
-										/>
-										<!-- link: search a record of the given DocType -->
-										<div v-else-if="q.type === 'link'" class="jv-ask-link">
-											<input
-												type="text"
-												class="jv-ask-field"
-												:value="
-													askLink[qi] && askLink[qi].q != null
-														? askLink[qi].q
-														: askSel[qi] || ''
-												"
-												@input="
-													onLinkSearch(
-														qi,
-														q.doctype,
-														$event.target.value
-													)
-												"
-												@focus="
-													onLinkSearch(
-														qi,
-														q.doctype,
-														(askLink[qi] && askLink[qi].q) || ''
-													)
-												"
-												:placeholder="
-													'Search ' + (q.doctype || 'records') + '…'
-												"
-												@blur="closeAskLink(qi)"
-												@keydown.enter.prevent
-											/>
-											<div
-												v-if="
-													askLink[qi] &&
-													askLink[qi].open &&
-													(askLink[qi].items || []).length
-												"
-												class="jv-ask-linkmenu"
-											>
-												<button
-													v-for="(it, ii) in askLink[qi].items"
-													:key="ii"
-													@mousedown.prevent="pickLink(qi, it)"
-												>
-													<b>{{ it.value }}</b
-													><span v-if="it.label"> · {{ it.label }}</span>
-												</button>
-											</div>
-										</div>
-										<!-- Other free-text only for choice questions -->
-										<input
-											v-if="
-												q.type === 'single' ||
-												q.type === 'multi' ||
-												q.type === 'yesno'
-											"
-											class="jv-ask-other"
-											v-model="askOther[qi]"
-											placeholder="Other…"
-											@input="onAskOther(qi, q.type)"
-											@keydown.enter.prevent
-										/>
-									</div>
-									<div class="jv-ask-foot">
-										<button
-											class="jv-ask-submit"
-											:disabled="!askReady"
-											@click="submitAsk"
-										>
-											Submit answers
-										</button>
-										<span v-if="!askReady" class="jv-ask-hint"
-											>Answer each question to continue</span
-										>
-									</div>
-								</div>
+									:key="m.name"
+									:spec="activeAsk"
+									@submit="send"
+								/>
 								<!-- record cards: scrollable card strip instead of a wide table -->
 								<div v-if="cardsOf(m)" class="jv-cards">
 									<div v-if="cardsOf(m).title" class="jv-cards-title">
@@ -3645,6 +3503,8 @@ import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
 import Message from "@/components/chat/Message.vue";
 import Composer from "@/components/chat/Composer.vue";
+import AskCard from "@/components/chat/AskCard.vue";
+import { parseAsk } from "@/lib/chatAsk";
 import { checkReady, readinessDetailOf } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
@@ -4728,8 +4588,8 @@ const _ACTION_RE = /```jarvis-action[ \t]*\n([\s\S]*?)```/;
 const _CONFIRM_RE = /```confirm[ \t]*\n([\s\S]*?)```/;
 // Interactive clarifying questions: the agent emits a ```jarvis-ask JSON block
 // (a list of questions, each single/multi/yesno with up to a few options); the
-// chat renders it as option cards with one Submit, and strips the raw block.
-const _ASK_RE = /```jarvis-ask[ \t]*\n([\s\S]*?)```/;
+// chat renders it as option cards with one Submit (<AskCard>), and strips the
+// raw block. Parsing lives in @/lib/chatAsk so every surface agrees.
 // A ```jarvis-cards block: a list of record cards the chat renders as a
 // horizontally-scrollable card strip instead of a wide Markdown table.
 const _CARDS_RE = /```jarvis-cards[ \t]*\n([\s\S]*?)```/;
@@ -4983,35 +4843,7 @@ function chartsOf(m) {
 }
 
 function askOf(m) {
-	const mt = ((m && m.content) || "").match(_ASK_RE);
-	if (!mt) return null;
-	try {
-		const a = JSON.parse(mt[1].trim());
-		const raw = Array.isArray(a) ? a : a && a.questions;
-		if (!Array.isArray(raw)) return null;
-		const FIELD = ["date", "datetime", "link", "text"];
-		const questions = raw
-			.slice(0, 6)
-			.map((q) => {
-				let type = q.type === "boolean" ? "yesno" : q.type;
-				if (!["single", "multi", "yesno", ...FIELD].includes(type)) type = "single";
-				return {
-					q: String(q.q || q.question || "").trim(),
-					type,
-					// yesno may carry exactly 2 custom labels (e.g. ["Approve","Reject"]).
-					options: Array.isArray(q.options) ? q.options.map(String).slice(0, 8) : [],
-					doctype: type === "link" ? String(q.doctype || q.link || "").trim() : "",
-				};
-			})
-			.filter((q) => {
-				if (!q.q) return false;
-				if (q.type === "yesno" || FIELD.includes(q.type)) return true;
-				return q.options.length > 0;
-			});
-		return questions.length ? { questions } : null;
-	} catch (e) {
-		return null;
-	}
+	return parseAsk((m && m.content) || "");
 }
 function actionOf(m) {
 	const mt = ((m && m.content) || "").match(_ACTION_RE);
@@ -6043,110 +5875,8 @@ const activeAsk = computed(() =>
 	_lastAssistant.value && !activeAction.value ? askOf(_lastAssistant.value) : null
 );
 const askFor = computed(() => (activeAsk.value ? _lastAssistant.value.name : null));
-const askSel = ref({}); // qIdx -> string (single/yesno/date/datetime/text/link) | string[] (multi)
-const askOther = ref({}); // qIdx -> free-text (option types only)
-const askLink = ref({}); // qIdx -> { q, items, open } for link-type record search
-const _FIELD_TYPES = ["date", "datetime", "link", "text"];
-// An ask whose questions are ALL field-type reads better as a compact mini-form
-// (no numbered badges, no dividers) than as a numbered question list.
-const askIsForm = computed(() => {
-	const spec = activeAsk.value;
-	return (
-		!!spec &&
-		spec.questions.length > 0 &&
-		spec.questions.every((q) => _FIELD_TYPES.includes(q.type))
-	);
-});
-// Reset the draft whenever a new question set appears (new message asks).
-watch(askFor, () => {
-	askSel.value = {};
-	askOther.value = {};
-	askLink.value = {};
-});
-async function onLinkSearch(i, doctype, val) {
-	askLink.value = { ...askLink.value, [i]: { ...(askLink.value[i] || {}), q: val, open: true } };
-	if (!doctype) return;
-	try {
-		const r = await api.searchLink(doctype, val);
-		const items = (r || [])
-			.map((x) => ({ value: x.value, label: x.description || "" }))
-			.slice(0, 8);
-		askLink.value = { ...askLink.value, [i]: { q: val, items, open: true } };
-	} catch (e) {
-		askLink.value = { ...askLink.value, [i]: { q: val, items: [], open: true } };
-	}
-}
-function pickLink(i, item) {
-	askSel.value = { ...askSel.value, [i]: item.value };
-	askLink.value = { ...askLink.value, [i]: { q: item.value, items: [], open: false } };
-}
-// Hide the record dropdown when the field loses focus (clicking elsewhere on
-// the screen / tabbing away). @mousedown.prevent on the result buttons lets a
-// pick land before the blur fires.
-function closeAskLink(i) {
-	const cur = askLink.value[i];
-	if (cur && cur.open) askLink.value = { ...askLink.value, [i]: { ...cur, open: false } };
-}
-function pickSingle(i, opt) {
-	askSel.value = { ...askSel.value, [i]: opt };
-}
-// Option BUTTONS (single/yesno) toggle: clicking the picked option again
-// unselects it, and picking one clears the "Other…" text (they're exclusive —
-// both being sent as the answer was a reported bug).
-function toggleSingle(i, opt) {
-	const cur = askSel.value[i];
-	askSel.value = { ...askSel.value, [i]: cur === opt ? "" : opt };
-	if (cur !== opt && (askOther.value[i] || "").trim()) {
-		askOther.value = { ...askOther.value, [i]: "" };
-	}
-}
-// Typing in "Other…" clears a picked option for single/yesno (mirror of the above).
-function onAskOther(i, qtype) {
-	if (qtype !== "multi" && (askOther.value[i] || "").trim() && askSel.value[i]) {
-		askSel.value = { ...askSel.value, [i]: "" };
-	}
-}
-function toggleMulti(i, opt) {
-	const cur = Array.isArray(askSel.value[i]) ? askSel.value[i].slice() : [];
-	const ix = cur.indexOf(opt);
-	if (ix >= 0) cur.splice(ix, 1);
-	else cur.push(opt);
-	askSel.value = { ...askSel.value, [i]: cur };
-}
-function isPicked(i, opt) {
-	const v = askSel.value[i];
-	return Array.isArray(v) ? v.includes(opt) : v === opt;
-}
-const askReady = computed(() => {
-	const spec = activeAsk.value;
-	if (!spec) return false;
-	return spec.questions.every((q, i) => {
-		const v = askSel.value[i];
-		if (_FIELD_TYPES.includes(q.type)) return v != null && String(v).trim() !== "";
-		const other = (askOther.value[i] || "").trim();
-		if (q.type === "multi") return (Array.isArray(v) && v.length > 0) || !!other;
-		return (v != null && v !== "") || !!other;
-	});
-});
-function submitAsk() {
-	const spec = activeAsk.value;
-	if (!spec || !askReady.value) return;
-	const lines = spec.questions.map((q, i) => {
-		const ans = [];
-		const v = askSel.value[i];
-		const other = (askOther.value[i] || "").trim();
-		if (Array.isArray(v)) ans.push(...v);
-		// Single-answer questions: a typed "Other…" IS the answer — never send
-		// both it and a leftover pick (the UI keeps them exclusive; this is the
-		// belt-and-braces for stale state).
-		else if (v != null && v !== "" && !other) ans.push(v);
-		if (other) ans.push(other);
-		return `${i + 1}. ${q.q} → ${ans.join(", ") || "(no answer)"}`;
-	});
-	askSel.value = {};
-	askOther.value = {};
-	send("Here are my answers:\n" + lines.join("\n"));
-}
+// The draft state, readiness and answer formatting live in <AskCard> +
+// @/lib/chatAsk, shared with the Dashboards builder pane.
 function copyText(t) {
 	const s = t || "";
 	// navigator.clipboard only exists in a secure context (https / localhost).
@@ -10902,200 +10632,6 @@ onUnmounted(() => {
 	border-color: var(--text);
 }
 
-/* interactive clarifying-question cards */
-.jv-ask {
-	margin-top: 12px;
-	padding: 14px;
-	border: 1px solid var(--border);
-	background: var(--surface-1);
-	border-radius: 12px;
-}
-.jv-ask-q {
-	padding-bottom: 13px;
-	margin-bottom: 13px;
-	border-bottom: 1px solid var(--border);
-}
-.jv-ask-q:last-of-type {
-	border-bottom: 0;
-	padding-bottom: 4px;
-	margin-bottom: 4px;
-}
-.jv-ask-qt {
-	display: flex;
-	align-items: flex-start;
-	gap: 8px;
-	font-size: 13.5px;
-	font-weight: 600;
-	color: var(--text);
-	margin-bottom: 9px;
-	line-height: 1.4;
-}
-.jv-ask-num {
-	flex: none;
-	width: 19px;
-	height: 19px;
-	border-radius: 99px;
-	background: var(--cta-bg);
-	color: var(--cta);
-	font-size: 11px;
-	font-weight: 700;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	margin-top: 1px;
-}
-.jv-ask--form .jv-ask-num {
-	display: none;
-}
-.jv-ask--form .jv-ask-q {
-	border-bottom: 0;
-	padding-bottom: 11px;
-	margin-bottom: 11px;
-}
-.jv-ask--form .jv-ask-q:last-of-type {
-	padding-bottom: 0;
-	margin-bottom: 0;
-}
-.jv-ask--form .jv-ask-qt {
-	font-size: 10.5px;
-	font-weight: 650;
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--text-3);
-	margin-bottom: 6px;
-}
-.jv-ask-opts {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 7px;
-}
-.jv-ask-opt {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	padding: 7px 12px;
-	background: var(--surface-2);
-	border: 1px solid var(--border);
-	border-radius: 9px;
-	font-family: inherit;
-	font-size: 12.5px;
-	font-weight: 500;
-	color: var(--text-2);
-	cursor: pointer;
-	transition: border-color 0.12s, background 0.12s, color 0.12s;
-}
-.jv-ask-opt:hover {
-	border-color: var(--border-2);
-	color: var(--text);
-}
-.jv-ask-opt.on {
-	border-color: var(--cta);
-	background: var(--cta-bg);
-	color: var(--text);
-	font-weight: 600;
-}
-.jv-ask-tick {
-	color: var(--cta);
-	font-weight: 700;
-	font-size: 11px;
-}
-.jv-ask-field {
-	width: 100%;
-	box-sizing: border-box;
-	padding: 8px 10px;
-	background: var(--surface-2);
-	border: 1px solid var(--border);
-	border-radius: 8px;
-	font-family: inherit;
-	font-size: 13px;
-	color: var(--text);
-	outline: none;
-}
-.jv-ask-field:focus {
-	border-color: var(--cta);
-}
-.jv-ask-link {
-	position: relative;
-}
-.jv-ask-linkmenu {
-	position: absolute;
-	left: 0;
-	right: 0;
-	top: calc(100% + 4px);
-	z-index: 20;
-	background: var(--surface);
-	border: 1px solid var(--border-2);
-	border-radius: 9px;
-	box-shadow: 0 8px 24px rgba(20, 20, 30, 0.14);
-	padding: 4px;
-	max-height: 220px;
-	overflow-y: auto;
-}
-.jv-ask-linkmenu button {
-	display: block;
-	width: 100%;
-	text-align: left;
-	padding: 7px 9px;
-	background: transparent;
-	border: none;
-	border-radius: 6px;
-	font-family: inherit;
-	font-size: 12.5px;
-	color: var(--text-2);
-	cursor: pointer;
-	white-space: normal;
-	overflow-wrap: anywhere;
-}
-.jv-ask-linkmenu button:hover {
-	background: var(--surface-2);
-	color: var(--text);
-}
-.jv-ask-other {
-	width: 100%;
-	box-sizing: border-box;
-	margin-top: 8px;
-	padding: 7px 10px;
-	background: var(--surface-2);
-	border: 1px solid var(--border);
-	border-radius: 8px;
-	font-family: inherit;
-	font-size: 12.5px;
-	color: var(--text);
-	outline: none;
-}
-.jv-ask-other:focus {
-	border-color: var(--cta);
-}
-.jv-ask-foot {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 10px;
-	margin-top: 14px;
-}
-.jv-ask-submit {
-	padding: 8px 16px;
-	background: var(--cta);
-	border: 1px solid var(--cta);
-	border-radius: 8px;
-	font-family: inherit;
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--cta-fg);
-	cursor: pointer;
-	transition: opacity 0.12s;
-}
-.jv-ask-submit:hover {
-	opacity: 0.9;
-}
-.jv-ask-submit:disabled {
-	opacity: 0.45;
-	cursor: default;
-}
-.jv-ask-hint {
-	font-size: 11.5px;
-	color: var(--text-3);
-}
 /* scrollable record cards (alternative to a wide table) */
 .jv-cards {
 	margin-top: 12px;

--- a/frontend/tests/support-extraction/ask-card.test.js
+++ b/frontend/tests/support-extraction/ask-card.test.js
@@ -1,0 +1,121 @@
+// AskCard, the ONE renderer for the agent's ```jarvis-ask blocks (extracted
+// from ChatView so the Dashboards builder pane shows the same cards instead of
+// deleting the block into an empty bubble). chatAsk.test.js proves the parsing
+// and answer formatting headlessly; this drives the CARDS - picking, toggling,
+// the Other/pick exclusivity, and what the Submit button finally emits.
+import { expect, test, vi } from "vitest";
+
+// AskCard's link-type questions search records through @/api, whose frappe-ui
+// resources chain does not resolve under vitest. Only searchLink is used here.
+vi.mock("@/api", () => ({ searchLink: vi.fn(async () => []) }));
+
+import AskCard from "../../src/components/chat/AskCard.vue";
+import { parseAsk } from "../../src/lib/chatAsk.js";
+import { mountWithPalette } from "./fixtures.js";
+
+const spec = (json) => parseAsk("Lead-in.\n\n```jarvis-ask\n" + json + "\n```");
+const CHOICES = spec(
+	'[{"q":"Which records?","type":"single","options":["Open","Closed"]},' +
+		'{"q":"Send it?","type":"yesno","options":["Approve","Reject"]}]'
+);
+const findCard = (w) => w.findComponent(AskCard);
+const optionNamed = (w, label) =>
+	w.findAll("button.jv-ask-opt").find((b) => b.text().includes(label));
+const submit = (w) => w.find("button.jv-ask-submit");
+
+test("renders one question block per question, with its options", () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	expect(w.findAll(".jv-ask-q")).toHaveLength(2);
+	expect(w.text()).toContain("Which records?");
+	// a yesno with two custom labels uses them instead of Yes/No
+	expect(w.text()).toContain("Approve");
+	expect(w.text()).toContain("Reject");
+	expect(w.text()).not.toContain("Yes");
+});
+
+test("Submit is disabled with a hint until every question is answered", async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	expect(submit(w).attributes("disabled")).toBeDefined();
+	expect(w.text()).toContain("Answer each question to continue");
+
+	await optionNamed(w, "Open").trigger("click");
+	expect(submit(w).attributes("disabled")).toBeDefined();
+
+	await optionNamed(w, "Approve").trigger("click");
+	expect(submit(w).attributes("disabled")).toBeUndefined();
+	expect(w.text()).not.toContain("Answer each question to continue");
+});
+
+test("Submit emits the formatted answers once", async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	await submit(w).trigger("click");
+	const emitted = findCard(w).emitted("submit");
+	expect(emitted).toHaveLength(1);
+	expect(emitted[0][0]).toBe(
+		"Here are my answers:\n1. Which records? → Open\n2. Send it? → Approve"
+	);
+});
+
+test("clicking a picked option unpicks it (and disarms Submit)", async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	expect(optionNamed(w, "Open").classes()).toContain("on");
+	await optionNamed(w, "Open").trigger("click");
+	expect(optionNamed(w, "Open").classes()).not.toContain("on");
+	expect(submit(w).attributes("disabled")).toBeDefined();
+});
+
+test('typing "Other…" clears the pick on a single-answer question', async () => {
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	const other = w.findAll("input.jv-ask-other")[0];
+	await other.setValue("only the escalated ones");
+	expect(optionNamed(w, "Open").classes()).not.toContain("on");
+	await optionNamed(w, "Approve").trigger("click");
+	await submit(w).trigger("click");
+	// the typed answer replaces the pick - never both
+	expect(findCard(w).emitted("submit")[0][0]).toContain(
+		"1. Which records? → only the escalated ones"
+	);
+});
+
+test("multi keeps several picks and adds the Other text alongside them", async () => {
+	const w = mountWithPalette(AskCard, {
+		spec: spec('[{"q":"Which?","type":"multi","options":["a","b","c"]}]'),
+	});
+	await optionNamed(w, "a").trigger("click");
+	await optionNamed(w, "c").trigger("click");
+	await w.find("input.jv-ask-other").setValue("and d");
+	expect(optionNamed(w, "a").classes()).toContain("on");
+	await submit(w).trigger("click");
+	expect(findCard(w).emitted("submit")[0][0]).toBe(
+		"Here are my answers:\n1. Which? → a, c, and d"
+	);
+});
+
+test("an all-field-type ask renders as the compact mini-form", async () => {
+	const w = mountWithPalette(AskCard, {
+		spec: spec('[{"q":"From","type":"date"},{"q":"Note","type":"text"}]'),
+	});
+	expect(w.find(".jv-ask").classes()).toContain("jv-ask--form");
+	// field questions have no Other box
+	expect(w.findAll("input.jv-ask-other")).toHaveLength(0);
+	await w.find('input[type="date"]').setValue("2026-07-27");
+	expect(submit(w).attributes("disabled")).toBeDefined();
+	await w.find('input[type="text"]').setValue("quarter close");
+	expect(submit(w).attributes("disabled")).toBeUndefined();
+	await submit(w).trigger("click");
+	expect(findCard(w).emitted("submit")[0][0]).toBe(
+		"Here are my answers:\n1. From → 2026-07-27\n2. Note → quarter close"
+	);
+});
+
+test("a mixed ask keeps the numbered-list look", () => {
+	const w = mountWithPalette(AskCard, {
+		spec: spec('[{"q":"From","type":"date"},{"q":"Scope","type":"single","options":["All"]}]'),
+	});
+	expect(w.find(".jv-ask").classes()).not.toContain("jv-ask--form");
+});

--- a/frontend/tests/support-extraction/ask-card.test.js
+++ b/frontend/tests/support-extraction/ask-card.test.js
@@ -58,6 +58,25 @@ test("Submit emits the formatted answers once", async () => {
 	);
 });
 
+test("the picks survive Submit, so a host that refuses the text loses nothing", async () => {
+	// DashboardChatPane.sendText and ChatView.send both return early while a send
+	// is in flight (or a dictation is still transcribing). Clearing sel/other
+	// inside submit() emptied the card anyway - the answers were gone and the
+	// button was disabled again. The card unmounts on the next assistant message
+	// (it is keyed by message name), so there is nothing to reset here.
+	const w = mountWithPalette(AskCard, { spec: CHOICES });
+	await optionNamed(w, "Open").trigger("click");
+	await optionNamed(w, "Approve").trigger("click");
+	await submit(w).trigger("click");
+	expect(optionNamed(w, "Open").classes()).toContain("on");
+	expect(submit(w).attributes("disabled")).toBeUndefined();
+	// ...and a second click re-sends the same answers rather than an empty one
+	await submit(w).trigger("click");
+	const emitted = findCard(w).emitted("submit");
+	expect(emitted).toHaveLength(2);
+	expect(emitted[1][0]).toBe(emitted[0][0]);
+});
+
 test("clicking a picked option unpicks it (and disarms Submit)", async () => {
 	const w = mountWithPalette(AskCard, { spec: CHOICES });
 	await optionNamed(w, "Open").trigger("click");

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -632,7 +632,7 @@ def assemble_prompt(
 	# Floating-widget auto-context + file inputs layer onto the
 	# already date/user-augmented user_message built above. Prompt-only;
 	# the persisted/visible user message is unchanged.
-	user_message = _prepend_doc_context(user_message, context)
+	user_message = _prepend_doc_context(user_message, context, conversation_id)
 	# Vision is managed-pool only (self-host vision is a follow-up), gated by the
 	# operator toggle and the model's provider being multimodal. When off, image/
 	# PDF attachments degrade to a short note (no OCR fallback any more).
@@ -1405,7 +1405,31 @@ def _dashboard_theme_cheatsheet(theme_key: str) -> str:
 	)
 
 
-def _prepend_doc_context(user_message: str, context) -> str:
+def _dashboard_has_canvas(conversation_id: str) -> bool:
+	"""Has any turn in this conversation already drawn a canvas artifact?
+
+	``persist_canvases`` stamps the assistant message's ``canvas`` JSON field for
+	every turn that published one, and that same field is what ``get_conversation``
+	hands the builder. The Dashboards builder keeps no server-side draft, so this
+	IS the "is there a dashboard yet?" state for the interview-first rule below.
+
+	Fails to True on any error: an unreadable state must degrade to today's
+	build-immediately behaviour, never to re-interrogating the user every turn.
+	"""
+	if not conversation_id:
+		return False
+	try:
+		return bool(
+			frappe.db.exists(
+				MSG,
+				{"conversation": conversation_id, "canvas": ["is", "set"]},
+			)
+		)
+	except Exception:
+		return True
+
+
+def _prepend_doc_context(user_message: str, context, conversation_id: str = "") -> str:
 	"""Prepend the ERP doc / report the user was viewing (floating-widget
 	auto-context) as a leading ``[Viewing: ...]`` line, so questions like
 	"is this overdue?" or "why is this row missing?" resolve against the
@@ -1470,6 +1494,34 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			)
 		else:
 			theme_line = ""
+		# Interview first, build on the final call. A dashboard nobody scoped is a
+		# guess the user then has to argue with, so the FIRST pass of a build asks
+		# the few decisions that shape it and waits. "First" is derived here, not
+		# sent by the client: no canvas has been drawn in this conversation yet and
+		# we are not revising an existing saved document. Once a canvas exists the
+		# wording below is unchanged from the iterate-only original.
+		clarify_line = ""
+		if not edit_line and not _dashboard_has_canvas(conversation_id):
+			decisions = [
+				"the data scope (which records/doctypes, over what period)",
+				"the breakdown that matters (grouped by what, showing which numbers)",
+			]
+			if not mode:
+				decisions.append(
+					"whether they want a STATIC one-time report with the numbers baked in "
+					"or a LIVE data-connected dashboard"
+				)
+			if not theme_key:
+				decisions.append("which theme it should use")
+			clarify_line = (
+				" NOTHING has been drawn on this canvas yet, so do NOT build on this pass. "
+				"Reply with one short lead-in line and exactly ONE ```jarvis-ask block (see "
+				"the jarvis-chat-blocks skill) asking about " + "; ".join(decisions) + " - "
+				"then stop and wait for the answers. Skip any decision their request already "
+				"answers unambiguously, and when it answers all of them, build instead of "
+				"asking. Never ask twice: once they have answered, or told you to go ahead, "
+				"build the dashboard."
+			)
 		return (
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "
@@ -1490,7 +1542,8 @@ def _prepend_doc_context(user_message: str, context) -> str:
 			"of hardcoding design. For a bespoke look the user switches to the Custom "
 			"theme via the theme picker — on a curated theme never hardcode off-theme "
 			"colors/fonts (the save-time validator rejects them); tell the user to "
-			f"pick Custom for a one-off deviation.{theme_line}{mode_line}{edit_line}]"
+			f"pick Custom for a one-off deviation.{theme_line}{mode_line}{edit_line}"
+			f"{clarify_line}]"
 			f"\n\n{user_message}"
 		)
 	if context.get("page") == "triggers":

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -1406,12 +1406,14 @@ def _dashboard_theme_cheatsheet(theme_key: str) -> str:
 
 
 def _dashboard_has_canvas(conversation_id: str) -> bool:
-	"""Has any turn in this conversation already drawn a canvas artifact?
+	"""Has any turn in this conversation already drawn an HTML canvas artifact?
 
 	``persist_canvases`` stamps the assistant message's ``canvas`` JSON field for
 	every turn that published one, and that same field is what ``get_conversation``
-	hands the builder. The Dashboards builder keeps no server-side draft, so this
-	IS the "is there a dashboard yet?" state for the interview-first rule below.
+	hands the builder. Only an ``html`` item can render on the builder canvas, and
+	``generated_media`` stamps the SAME field with ``type: "image"`` items - so the
+	rule here is the client's (``builderCanvasFrame``): an image drawn in this
+	conversation is not a dashboard.
 
 	Fails to True on any error: an unreadable state must degrade to today's
 	build-immediately behaviour, never to re-interrogating the user every turn.
@@ -1419,13 +1421,59 @@ def _dashboard_has_canvas(conversation_id: str) -> bool:
 	if not conversation_id:
 		return False
 	try:
+		rows = frappe.get_all(
+			MSG,
+			filters={"conversation": conversation_id, "canvas": ["is", "set"]},
+			pluck="canvas",
+			order_by="creation desc",
+			limit=50,
+		)
+		for raw in rows:
+			try:
+				items = frappe.parse_json(raw)
+			except Exception:
+				continue
+			if isinstance(items, list) and any(
+				isinstance(it, dict) and it.get("type") == "html" for it in items
+			):
+				return True
+		return False
+	except Exception:
+		frappe.log_error(
+			title="dashboards: canvas probe failed",
+			message=f"conversation={conversation_id!r}\n\n{frappe.get_traceback()}",
+		)
+		return True
+
+
+def _dashboard_has_asked(conversation_id: str) -> bool:
+	"""Has the assistant already put a ``jarvis-ask`` block in this conversation?
+
+	The interview is ONE-shot, and "did a canvas persist?" is the wrong state to
+	test for that: the turn carrying the user's answers has no canvas yet either,
+	and a publish that failed (or a bench with no canvas route at all) would keep
+	re-ordering the interview forever. What ends it is the ask having happened.
+
+	Fails to True on any error: never re-interrogate a user who already answered.
+	"""
+	if not conversation_id:
+		return False
+	try:
 		return bool(
 			frappe.db.exists(
 				MSG,
-				{"conversation": conversation_id, "canvas": ["is", "set"]},
+				{
+					"conversation": conversation_id,
+					"role": "assistant",
+					"content": ["like", "%```jarvis-ask%"],
+				},
 			)
 		)
 	except Exception:
+		frappe.log_error(
+			title="dashboards: prior-ask probe failed",
+			message=f"conversation={conversation_id!r}\n\n{frappe.get_traceback()}",
+		)
 		return True
 
 
@@ -1498,30 +1546,43 @@ def _prepend_doc_context(user_message: str, context, conversation_id: str = "") 
 		# guess the user then has to argue with, so the FIRST pass of a build asks
 		# the few decisions that shape it and waits. "First" is derived here, not
 		# sent by the client: no canvas has been drawn in this conversation yet and
-		# we are not revising an existing saved document. Once a canvas exists the
-		# wording below is unchanged from the iterate-only original.
+		# we are not revising an existing saved document. The interview is one-shot:
+		# once the ask has gone out, the next turn BUILDS whether or not the last
+		# publish landed, so a gateway blip (or a bench with no canvas route) can
+		# never trap the user in a question loop. Once a canvas exists the wording
+		# below is unchanged from the iterate-only original.
 		clarify_line = ""
 		if not edit_line and not _dashboard_has_canvas(conversation_id):
-			decisions = [
-				"the data scope (which records/doctypes, over what period)",
-				"the breakdown that matters (grouped by what, showing which numbers)",
-			]
-			if not mode:
-				decisions.append(
-					"whether they want a STATIC one-time report with the numbers baked in "
-					"or a LIVE data-connected dashboard"
+			if _dashboard_has_asked(conversation_id):
+				clarify_line = (
+					" You have ALREADY asked your clarifying questions in this conversation, "
+					"so never ask again: the user has answered them or moved on. Use their "
+					"answers, fill any remaining gap with a sensible default, and build the "
+					"dashboard now."
 				)
-			if not theme_key:
-				decisions.append("which theme it should use")
-			clarify_line = (
-				" NOTHING has been drawn on this canvas yet, so do NOT build on this pass. "
-				"Reply with one short lead-in line and exactly ONE ```jarvis-ask block (see "
-				"the jarvis-chat-blocks skill) asking about " + "; ".join(decisions) + " - "
-				"then stop and wait for the answers. Skip any decision their request already "
-				"answers unambiguously, and when it answers all of them, build instead of "
-				"asking. Never ask twice: once they have answered, or told you to go ahead, "
-				"build the dashboard."
-			)
+			else:
+				decisions = [
+					"the data scope (which records/doctypes, over what period)",
+					"the breakdown that matters (grouped by what, showing which numbers)",
+				]
+				if not mode:
+					decisions.append(
+						"whether they want a STATIC one-time report with the numbers baked in "
+						"or a LIVE data-connected dashboard"
+					)
+				clarify_line = (
+					" NOTHING has been drawn on this canvas yet. If this message is not a "
+					"request to build a dashboard (a greeting, a question about their data, a "
+					"remark about one you already discussed), just answer it normally - no "
+					"jarvis-ask block and no build. When it IS a build request, do NOT build "
+					"on this pass: reply with one short lead-in line and exactly ONE "
+					"```jarvis-ask block (see the jarvis-chat-blocks skill) asking about "
+					+ "; ".join(decisions)
+					+ " - then stop and wait for the answers. Skip any "
+					"decision their request already answers unambiguously, and when it answers "
+					"all of them, build instead of asking. Never ask twice: once they have "
+					"answered, or told you to go ahead, build the dashboard."
+				)
 		return (
 			"[Context: The user is on the Jarvis Dashboards builder page. They want to "
 			"create or iterate on a dashboard/report. Read and follow the "

--- a/jarvis/tests/test_chat_ask_client.py
+++ b/jarvis/tests/test_chat_ask_client.py
@@ -1,0 +1,55 @@
+"""The ```jarvis-ask contract, proven by a REAL executable node test that lives
+in the python suite forever (the test_event_fence_client.py precedent).
+
+The clarifying-question cards used to exist only inside ChatView, and the
+Dashboards builder pane deleted the block instead of rendering it - so an agent
+that asked a question before building produced an empty bubble nobody could
+answer. Parsing / readiness / answer formatting now live in
+``frontend/src/lib/chatAsk.js`` and the cards in
+``frontend/src/components/chat/AskCard.vue``, shared by both surfaces.
+``frontend/src/lib/chatAsk.test.js`` exercises that logic for real and fences
+the wiring on both surfaces. This test subprocess-runs it with ``node --test``
+(which exits non-zero on any failed assertion) so a fork of either half fails
+every CI run, not just ``npm run build``.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _ask_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "lib", "chatAsk.test.js")
+
+
+class TestChatAskClient(unittest.TestCase):
+	def test_jarvis_ask_contract_node_suite_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _ask_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"jarvis-ask client test missing at {test_file} — it MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"jarvis-ask client node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_dashboard_builder_ux_client.py
+++ b/jarvis/tests/test_dashboard_builder_ux_client.py
@@ -1,0 +1,60 @@
+"""The Dashboards builder's composer + canvas-persistence contract, proven by a
+REAL executable node test that lives in the python suite forever (the
+test_event_fence_client.py precedent).
+
+Two owner-reported defects are fenced here:
+
+  * the composer kept the message it had just sent (a disabled-mid-send textarea
+    is blurred by the browser, fires ``change``, and frappe-ui's Textarea
+    re-emitted the pre-clear value);
+  * the canvas vanished on a tab switch or a navigation, with no way back and no
+    warning that it had gone.
+
+``frontend/src/lib/dashboardRestore.js`` holds the real rehydration logic
+(the newest transcript message that drew an html artifact); the rest of both
+fixes is component wiring that a plain node runner cannot import, so
+``frontend/src/lib/dashboardRestore.test.js`` fences it with source assertions
+(the voiceDictationLifecycle precedent). This test subprocess-runs the suite
+with ``node --test`` so a regression fails every CI run.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _builder_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "lib", "dashboardRestore.test.js")
+
+
+class TestDashboardBuilderUxClient(unittest.TestCase):
+	def test_builder_composer_and_canvas_node_suite_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _builder_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"dashboards builder client test missing at {test_file} — it MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"dashboards builder client node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_dashboard_clarify_context.py
+++ b/jarvis/tests/test_dashboard_clarify_context.py
@@ -6,7 +6,8 @@ message instead of agreeing what to build. The frontend sends the same
 ``{"page": "dashboards"}`` context on every turn and has no notion of a turn
 index, so "is this the first build?" is derived SERVER-SIDE here - from the same
 ``Jarvis Chat Message.canvas`` field ``persist_canvases`` stamps and
-``get_conversation`` hands the UI. No new context key, no API surface change.
+``get_conversation`` hands the UI, plus "have I already asked?" so the interview
+ends on the answer rather than on a canvas that may never persist.
 
 Run: bench --site patterntest.localhost run-tests --module
      jarvis.tests.test_dashboard_clarify_context
@@ -17,38 +18,51 @@ from __future__ import annotations
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.chat.turn_handler import _dashboard_has_canvas, _prepend_doc_context
+from jarvis.chat.turn_handler import (
+	_dashboard_has_asked,
+	_dashboard_has_canvas,
+	_prepend_doc_context,
+)
 
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
 CLARIFY_MARK = "NOTHING has been drawn on this canvas yet"
+BUILD_NOW_MARK = "You have ALREADY asked your clarifying questions"
+ASK_BLOCK = 'Which records?\n\n```jarvis-ask\n[{"q":"Which records?","type":"text"}]\n```'
 
 
 class _DashboardContextTestCase(FrappeTestCase):
 	def setUp(self):
 		self._convs: list[str] = []
+		self._msgs: list[str] = []
 
 	def tearDown(self):
+		# Children first: `conversation` is a Link, so a conversation with live
+		# messages cannot be deleted - and a half-deletion would leave message
+		# rows pointing at a conversation that no longer exists. NO commit: the
+		# FrappeTestCase transaction is what isolates this from the site.
+		for name in self._msgs:
+			frappe.delete_doc(MSG, name, force=True, ignore_permissions=True, delete_permanently=True)
 		for name in self._convs:
 			frappe.delete_doc(CONV, name, force=True, ignore_permissions=True, delete_permanently=True)
-		frappe.db.commit()
 
 	def _conversation(self) -> str:
 		doc = frappe.get_doc({"doctype": CONV, "title": "dash clarify test"}).insert(ignore_permissions=True)
 		self._convs.append(doc.name)
 		return doc.name
 
-	def _message(self, conversation: str, seq: int, role: str, canvas=None) -> str:
+	def _message(self, conversation: str, seq: int, role: str, canvas=None, content="x") -> str:
 		doc = frappe.get_doc(
 			{
 				"doctype": MSG,
 				"conversation": conversation,
 				"seq": seq,
 				"role": role,
-				"content": "x",
+				"content": content,
 				"canvas": frappe.as_json(canvas) if canvas else None,
 			}
 		).insert(ignore_permissions=True)
+		self._msgs.append(doc.name)
 		return doc.name
 
 
@@ -74,6 +88,30 @@ class TestDashboardHasCanvas(_DashboardContextTestCase):
 		)
 		self.assertTrue(_dashboard_has_canvas(conv))
 
+	def test_a_generated_image_is_not_a_dashboard(self):
+		"""``generated_media`` stamps the same field with type:"image" items, and
+		the builder shares its conversation with main chat ("Open in chat") - a
+		picture must not suppress the interview."""
+		conv = self._conversation()
+		self._message(
+			conv,
+			1,
+			"assistant",
+			canvas=[{"name": "/files/x.png", "title": "Generated image", "type": "image"}],
+		)
+		self.assertFalse(_dashboard_has_canvas(conv))
+		# ...but an html item alongside an image still counts
+		self._message(
+			conv,
+			2,
+			"assistant",
+			canvas=[
+				{"name": "/files/x.png", "type": "image"},
+				{"name": "documents/a/index.html", "type": "html"},
+			],
+		)
+		self.assertTrue(_dashboard_has_canvas(conv))
+
 	def test_another_conversations_canvas_does_not_leak(self):
 		mine = self._conversation()
 		theirs = self._conversation()
@@ -87,14 +125,45 @@ class TestDashboardHasCanvas(_DashboardContextTestCase):
 		self.assertTrue(_dashboard_has_canvas(theirs))
 
 
+class TestDashboardHasAsked(_DashboardContextTestCase):
+	def test_no_conversation_has_not_asked(self):
+		self.assertFalse(_dashboard_has_asked(""))
+		self.assertFalse(_dashboard_has_asked(None))
+
+	def test_plain_turns_are_not_an_ask(self):
+		conv = self._conversation()
+		self._message(conv, 1, "user", content="sales dashboard please")
+		self._message(conv, 2, "assistant", content="Here is what I found.")
+		self.assertFalse(_dashboard_has_asked(conv))
+
+	def test_an_assistant_ask_block_flips_it(self):
+		conv = self._conversation()
+		self._message(conv, 1, "assistant", content=ASK_BLOCK)
+		self.assertTrue(_dashboard_has_asked(conv))
+
+	def test_a_user_quoting_the_fence_is_not_an_ask(self):
+		"""Only the ASSISTANT asking counts - a user pasting the fence must not
+		switch the builder into "you already asked"."""
+		conv = self._conversation()
+		self._message(conv, 1, "user", content=ASK_BLOCK)
+		self.assertFalse(_dashboard_has_asked(conv))
+
+	def test_another_conversations_ask_does_not_leak(self):
+		mine = self._conversation()
+		theirs = self._conversation()
+		self._message(theirs, 1, "assistant", content=ASK_BLOCK)
+		self.assertFalse(_dashboard_has_asked(mine))
+		self.assertTrue(_dashboard_has_asked(theirs))
+
+
 class TestDashboardsClarifyArm(_DashboardContextTestCase):
 	def test_first_turn_asks_instead_of_building(self):
 		conv = self._conversation()
 		out = _prepend_doc_context("sales dashboard please", {"page": "dashboards"}, conv)
 		self.assertIn(CLARIFY_MARK, out)
 		self.assertIn("```jarvis-ask", out)
-		self.assertIn("do NOT build on this pass", out)
-		# the 2-4 decisions that shape the build
+		self.assertIn("do NOT build", out)
+		# the 2-3 decisions that shape the build
 		self.assertIn("the data scope", out)
 		self.assertIn("the breakdown that matters", out)
 		# ...and the escape hatches, so it never becomes an interrogation
@@ -103,6 +172,40 @@ class TestDashboardsClarifyArm(_DashboardContextTestCase):
 		# the standing build contract is still in the block
 		self.assertIn("Jarvis Dashboards builder page", out)
 		self.assertTrue(out.endswith("\n\nsales dashboard please"))
+
+	def test_a_message_that_is_not_a_build_request_gets_a_normal_answer(self):
+		"""The arm cannot read the message, so it says so: "hi" or "what data do
+		you have?" typed into the builder composer must not be interrogated."""
+		conv = self._conversation()
+		out = _prepend_doc_context("hi", {"page": "dashboards"}, conv)
+		self.assertIn("If this message is not a request to build a dashboard", out)
+		self.assertIn("just answer it normally - no jarvis-ask block and no build", out)
+
+	def test_the_turn_carrying_the_answers_builds_instead_of_asking_again(self):
+		"""Turn 2: the ask went out, the user answered, and no canvas exists yet
+		(the build has not run). The old canvas-only gate re-ordered the interview
+		here - the exact loop the owner complained about, one round later."""
+		conv = self._conversation()
+		self._message(conv, 1, "user", content="sales dashboard please")
+		self._message(conv, 2, "assistant", content=ASK_BLOCK)
+		self._message(conv, 3, "user", content="Here are my answers: ...")
+		out = _prepend_doc_context("Here are my answers: ...", {"page": "dashboards"}, conv)
+		self.assertIn(BUILD_NOW_MARK, out)
+		self.assertNotIn(CLARIFY_MARK, out)
+		self.assertNotIn("do NOT build", out)
+		self.assertIn("build the dashboard now", out)
+
+	def test_a_failed_publish_does_not_re_open_the_interview(self):
+		"""``persist_canvases`` returns early without stamping ``canvas`` when the
+		gateway fetch or the File save fails for every artifact. The model built,
+		the artifact never landed - the next turn must still build, not re-ask."""
+		conv = self._conversation()
+		self._message(conv, 1, "assistant", content=ASK_BLOCK)
+		self._message(conv, 2, "user", content="static, by month")
+		self._message(conv, 3, "assistant", content="Here is the dashboard.")  # publish failed
+		out = _prepend_doc_context("it is blank?", {"page": "dashboards"}, conv)
+		self.assertIn(BUILD_NOW_MARK, out)
+		self.assertNotIn("```jarvis-ask", out)
 
 	def test_once_a_canvas_exists_the_wording_is_the_iterate_one(self):
 		conv = self._conversation()
@@ -114,6 +217,7 @@ class TestDashboardsClarifyArm(_DashboardContextTestCase):
 		)
 		out = _prepend_doc_context("make the bars horizontal", {"page": "dashboards"}, conv)
 		self.assertNotIn(CLARIFY_MARK, out)
+		self.assertNotIn(BUILD_NOW_MARK, out)
 		self.assertNotIn("```jarvis-ask", out)
 		self.assertIn("create or iterate on a dashboard/report", out)
 
@@ -139,13 +243,14 @@ class TestDashboardsClarifyArm(_DashboardContextTestCase):
 		self.assertNotIn("or a LIVE data-connected dashboard", questions)
 		self.assertIn("the data scope", questions)
 
-	def test_an_explicit_theme_is_not_re_asked(self):
+	def test_the_theme_is_never_one_of_the_questions(self):
+		"""The picker always carries a theme (it defaults to Jarvis), so there is
+		no unset state to ask about - the interview stays 2-3 decisions."""
 		conv = self._conversation()
-		out = _prepend_doc_context("sales dashboard", {"page": "dashboards", "theme": "claude"}, conv)
-		questions = out[out.index(CLARIFY_MARK) :]
-		self.assertNotIn("which theme it should use", questions)
-		no_theme = _prepend_doc_context("sales dashboard", {"page": "dashboards"}, conv)
-		self.assertIn("which theme it should use", no_theme[no_theme.index(CLARIFY_MARK) :])
+		for context in ({"page": "dashboards"}, {"page": "dashboards", "theme": "claude"}):
+			out = _prepend_doc_context("sales dashboard", context, conv)
+			self.assertIn(CLARIFY_MARK, out)
+			self.assertNotIn("which theme it should use", out[out.index(CLARIFY_MARK) :])
 
 	def test_no_conversation_id_still_clarifies_and_never_raises(self):
 		"""Callers that pass no conversation (older worker payloads, tests) get

--- a/jarvis/tests/test_dashboard_clarify_context.py
+++ b/jarvis/tests/test_dashboard_clarify_context.py
@@ -1,0 +1,161 @@
+"""Interview-first on the Dashboards builder: the clarify arm of
+``_prepend_doc_context``'s dashboards branch.
+
+Owner-reported (2026-07-27): the builder started drawing off the very first
+message instead of agreeing what to build. The frontend sends the same
+``{"page": "dashboards"}`` context on every turn and has no notion of a turn
+index, so "is this the first build?" is derived SERVER-SIDE here - from the same
+``Jarvis Chat Message.canvas`` field ``persist_canvases`` stamps and
+``get_conversation`` hands the UI. No new context key, no API surface change.
+
+Run: bench --site patterntest.localhost run-tests --module
+     jarvis.tests.test_dashboard_clarify_context
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.turn_handler import _dashboard_has_canvas, _prepend_doc_context
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+CLARIFY_MARK = "NOTHING has been drawn on this canvas yet"
+
+
+class _DashboardContextTestCase(FrappeTestCase):
+	def setUp(self):
+		self._convs: list[str] = []
+
+	def tearDown(self):
+		for name in self._convs:
+			frappe.delete_doc(CONV, name, force=True, ignore_permissions=True, delete_permanently=True)
+		frappe.db.commit()
+
+	def _conversation(self) -> str:
+		doc = frappe.get_doc({"doctype": CONV, "title": "dash clarify test"}).insert(ignore_permissions=True)
+		self._convs.append(doc.name)
+		return doc.name
+
+	def _message(self, conversation: str, seq: int, role: str, canvas=None) -> str:
+		doc = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conversation,
+				"seq": seq,
+				"role": role,
+				"content": "x",
+				"canvas": frappe.as_json(canvas) if canvas else None,
+			}
+		).insert(ignore_permissions=True)
+		return doc.name
+
+
+class TestDashboardHasCanvas(_DashboardContextTestCase):
+	def test_no_conversation_is_not_a_canvas(self):
+		self.assertFalse(_dashboard_has_canvas(""))
+		self.assertFalse(_dashboard_has_canvas(None))
+
+	def test_messages_without_canvas_do_not_count(self):
+		conv = self._conversation()
+		self._message(conv, 1, "user")
+		self._message(conv, 2, "assistant")
+		self.assertFalse(_dashboard_has_canvas(conv))
+
+	def test_one_stamped_canvas_flips_it(self):
+		conv = self._conversation()
+		self._message(conv, 1, "user")
+		self._message(
+			conv,
+			2,
+			"assistant",
+			canvas=[{"name": "documents/a/index.html", "title": "T", "type": "html"}],
+		)
+		self.assertTrue(_dashboard_has_canvas(conv))
+
+	def test_another_conversations_canvas_does_not_leak(self):
+		mine = self._conversation()
+		theirs = self._conversation()
+		self._message(
+			theirs,
+			1,
+			"assistant",
+			canvas=[{"name": "documents/a/index.html", "type": "html"}],
+		)
+		self.assertFalse(_dashboard_has_canvas(mine))
+		self.assertTrue(_dashboard_has_canvas(theirs))
+
+
+class TestDashboardsClarifyArm(_DashboardContextTestCase):
+	def test_first_turn_asks_instead_of_building(self):
+		conv = self._conversation()
+		out = _prepend_doc_context("sales dashboard please", {"page": "dashboards"}, conv)
+		self.assertIn(CLARIFY_MARK, out)
+		self.assertIn("```jarvis-ask", out)
+		self.assertIn("do NOT build on this pass", out)
+		# the 2-4 decisions that shape the build
+		self.assertIn("the data scope", out)
+		self.assertIn("the breakdown that matters", out)
+		# ...and the escape hatches, so it never becomes an interrogation
+		self.assertIn("Skip any decision their request already", out)
+		self.assertIn("Never ask twice", out)
+		# the standing build contract is still in the block
+		self.assertIn("Jarvis Dashboards builder page", out)
+		self.assertTrue(out.endswith("\n\nsales dashboard please"))
+
+	def test_once_a_canvas_exists_the_wording_is_the_iterate_one(self):
+		conv = self._conversation()
+		self._message(
+			conv,
+			1,
+			"assistant",
+			canvas=[{"name": "documents/a/index.html", "type": "html"}],
+		)
+		out = _prepend_doc_context("make the bars horizontal", {"page": "dashboards"}, conv)
+		self.assertNotIn(CLARIFY_MARK, out)
+		self.assertNotIn("```jarvis-ask", out)
+		self.assertIn("create or iterate on a dashboard/report", out)
+
+	def test_revising_a_saved_dashboard_is_never_a_first_build(self):
+		"""The document already exists; asking what to build would be absurd."""
+		conv = self._conversation()
+		out = _prepend_doc_context(
+			"add a total row",
+			{"page": "dashboards", "doctype": "Jarvis Dashboard", "name": "JD-0001"},
+			conv,
+		)
+		self.assertNotIn(CLARIFY_MARK, out)
+		self.assertIn("They are revising the saved dashboard JD-0001", out)
+
+	def test_an_explicit_data_mode_is_not_re_asked(self):
+		conv = self._conversation()
+		asked = _prepend_doc_context("sales dashboard", {"page": "dashboards"}, conv)
+		self.assertIn("STATIC one-time report", asked)
+		settled = _prepend_doc_context("sales dashboard", {"page": "dashboards", "data_mode": "live"}, conv)
+		self.assertIn(CLARIFY_MARK, settled)
+		# the toggle already answered it, so it is not one of the questions
+		questions = settled[settled.index(CLARIFY_MARK) :]
+		self.assertNotIn("or a LIVE data-connected dashboard", questions)
+		self.assertIn("the data scope", questions)
+
+	def test_an_explicit_theme_is_not_re_asked(self):
+		conv = self._conversation()
+		out = _prepend_doc_context("sales dashboard", {"page": "dashboards", "theme": "claude"}, conv)
+		questions = out[out.index(CLARIFY_MARK) :]
+		self.assertNotIn("which theme it should use", questions)
+		no_theme = _prepend_doc_context("sales dashboard", {"page": "dashboards"}, conv)
+		self.assertIn("which theme it should use", no_theme[no_theme.index(CLARIFY_MARK) :])
+
+	def test_no_conversation_id_still_clarifies_and_never_raises(self):
+		"""Callers that pass no conversation (older worker payloads, tests) get
+		the first-build arm rather than an exception."""
+		out = _prepend_doc_context("sales dashboard", {"page": "dashboards"})
+		self.assertIn(CLARIFY_MARK, out)
+
+	def test_other_context_branches_are_untouched(self):
+		self.assertEqual(_prepend_doc_context("hello", None), "hello")
+		self.assertEqual(_prepend_doc_context("hello", {}), "hello")
+		triggers = _prepend_doc_context("make a trigger", {"page": "triggers"})
+		self.assertIn("Jarvis Triggers page", triggers)
+		self.assertNotIn(CLARIFY_MARK, triggers)


### PR DESCRIPTION
The three owner-reported Dashboards builder defects (2026-07-27). Persona half: **Aerele-RnD/jarvis-persona#170** (`fix/dashboards-clarify-first`) — deploy together; the skill and the injected context state the same rule.

---

## D1 — the composer kept the message it had just sent

`send()` **did** clear the draft. The clear did not survive. The pane bound `:disabled="sending"` on a frappe-ui `FormControl` textarea, and that component patches `disabled` before `value` and listens on `change` as well as `input`. So on the Enter path the browser blurred the focused, dirty box, `change` fired, and the **pre-clear DOM value** was re-emitted straight back into `draft`.

Fixed by adopting `Composer.vue`'s documented pattern rather than patching around it:

- a raw `<textarea v-model="draft">` — `v-model`, not `:value` + a manual emit, so Vue's own `vModelText` keeps handling IME composition;
- the textarea is **never** disabled; `sending` gates only the send button and `send()`;
- `autoGrow` is driven by a `flush:"post"` watcher on `draft`, so a programmatic clear actually shrinks the box (four scattered `nextTick(autoGrow)` calls go away).

`TriggerChatPane.vue` is the fork this pane came from and carried byte-identical wiring — fixed too. Its Send button also now gates on `sending` (it only had `:loading`, so a double-submit was reachable).

Restore-on-server-reject is unchanged, on both the `ok:false` and the throw path.

## D2 — it built off the first message instead of asking

**Server (`turn_handler._prepend_doc_context`).** The client sends the same `{"page":"dashboards"}` context on every turn and has no notion of a turn index, so first-build state is derived **server-side** — from the same `Jarvis Chat Message.canvas` field `persist_canvases` stamps and `get_conversation` already hands the UI. No canvas in this conversation, and not revising a saved document ⇒ this turn asks. The context then instructs exactly ONE `jarvis-ask` block covering the 2-4 decisions that shape a build: data scope, the breakdown, static-vs-live **only when the Data toggle has not settled it**, theme **only when none is selected**. Explicit escape hatches keep it from becoming an interrogation: skip anything the request already answers, build immediately when it answers everything, never ask twice. Once a canvas exists the wording is byte-for-byte today's iterate text.

**No new context key** — `send_message`'s allow-list is untouched, so there is no new API surface and nothing a stale frontend can smuggle. The helper fails to `True` (build, i.e. today's behaviour) on any DB error, so an unreadable state can never re-interrogate the user every turn.

**Frontend.** The pane *deleted* ` ```jarvis-ask ` blocks, so a clarifying turn rendered as an empty bubble — the mechanism existed but was unreachable here. ChatView's option cards are now a shared **`<AskCard>`** over a shared **`@/lib/chatAsk`** (parse / readiness / answer formatting), used by both surfaces. Answers post into the same conversation as an ordinary user message.

**Extraction note (flagged for judgment):** the brief left "shared component vs. importing ChatView internals" to the doer. I extracted the component — ChatView keeps no copy, so there is nothing to drift. It cost a real ChatView diff (−479 lines: the template block, ~110 lines of draft/selection logic, and ~195 lines of `jv-ask*` CSS, all moved verbatim into `AskCard.vue`). The cards look identical because the CSS moved with them and the `jv-*` tokens resolve by cascade; the dashboards pane binds `paletteVars` on the card (the `SkillDetail.vue` precedent) since those vars are not global. Both hosts key the card by message name — the draft lives in the component, and `spec` is a computed that re-parses on every stream tick, so a `spec` watcher would have wiped half-made picks.

## D3 — the canvas vanished, silently

- **Tab switch.** Visiting Saved unmounted `DashboardChatPane`, whose `onBeforeUnmount` tears down the socket listener — and the agent's `kind:"canvas"` frame is a **one-shot** publish, never replayed. A build that landed while the user was on Saved was lost outright. The builder tab is `v-show` now (Saved becomes its own `v-if`), so the pipeline survives.
- **Navigation.** The route component unmounts and `builderHtml` is gone. Nothing is actually lost: `get_conversation` returns each message's parsed `canvas` list, and `get_canvas` replays any past message for the conversation's owner. The pane now emits the newest canvas frame from every transcript load (`lib/dashboardRestore.js`), so returning to the page is lossless — with **zero new server state**. A live frame always beats a replay, re-checked after the `get_canvas` round trip; a failed replay is silent (it is background work nobody asked for). Side benefit: the `?nosocket` / headless-QA path now gets a canvas it could never receive before.
- **Explicit discard.** "New dashboard", the pane's "New chat", and opening another dashboard for editing all ask first — *"Discard this unsaved dashboard? Its chat stays in your conversations."* — and only when there really is unsaved work (canvas html that is no longer the saved document's). "New chat" now **asks the page** instead of clearing itself first, so cancelling no longer leaves an emptied chat beside a surviving canvas.
- **Found while proving the resume loop:** the pane never followed the sticky conversation slot when the page repointed it (`loadEdit` resuming a saved dashboard's thread), so the transcript on screen could belong to a different dashboard than the one the next send went to. Fixed with a guarded watcher (`"" -> id` is the pane's own first send and is left alone).

### Flagged for Fable's ruling

`loadEdit()` gets the discard confirm as the brief specifies, but today it only ever runs at mount, when the canvas is empty — so it is a no-op guard rather than a live prompt. The `?edit=` deep-link is ordered so the explicit target wins over a transcript replay (`editSeed`, read synchronously at setup, before the pane mounts). The in-progress build's *chat* is not destroyed by that path — only the single sticky slot's pointer is repointed, and the conversation remains in the user's chats.

---

## Gates run

| Gate | Result |
|---|---|
| `vite build` | ✓ built (clean, after every edit) |
| `vitest run` (5 files) | **51 passed** — incl. new `ask-card.test.js` (8, mounts and drives the cards) |
| `node --test` new suites | `chatAsk.test.js` **18/18**, `dashboardRestore.test.js` **17/17** |
| `node --test` pre-existing suites | 11 files, **162 passed, 0 failed** |
| bench `test_dashboard_clarify_context` (new) | **11 OK** |
| bench `test_chat_ask_client` / `test_dashboard_builder_ux_client` (new) | **1 OK each** |
| bench `test_dashboards_api` | **39 OK** |
| bench `test_canvas_embeds` / `test_canvas` | **13 / 9 OK** |
| bench `test_turn_handler_report_context` | **14 OK** |
| bench `test_untrusted_fence` | **21 OK** |
| bench `test_turn_handler_thinking` | **5 OK** |
| bench `test_chat_asks` | **32 OK** |
| bench `test_agent_dashboard_wire` | **7 OK** |
| bench `test_dashboard_tools` / `test_dashboard_permissions` | **8 / 17 OK** |
| ruff check + ruff format | clean (`turn_handler.py` needed no reformat — no whole-file churn) |
| pinned prettier + eslint (pre-commit) | clean |

Bench modules ran on `patterntest.localhost` with the branch on `PYTHONPATH` (verified `frappe.get_app_path("jarvis")` resolved to the worktree). Canonical checkouts untouched.

Not merged.