### PR TITLE
feat(errors): capture tenant UI + code-level errors and forward to admin

### DIFF
--- a/frontend/src/lib/errorReporter.js
+++ b/frontend/src/lib/errorReporter.js
@@ -64,7 +64,13 @@ function _isBenign(text) {
 /** Explicit, classified report. Safe to call from anywhere; cheap and silent. */
 export function report(ctx = {}) {
 	try {
-		if (_reporting || _sent >= MAX_PER_SESSION) return;
+		// NB: do NOT gate on `_reporting` here. report() only enqueues (flush is
+		// async and catches its own errors, so there is no synchronous re-entrant
+		// loop to guard against), and gating on an in-flight POST would silently
+		// drop every unrelated error raised during a slow flush. Concurrency is
+		// handled where it matters - flush()/flushBuffered() guard against
+		// overlapping POSTs, and MAX_PER_SESSION / MAX_QUEUE bound the volume.
+		if (_sent >= MAX_PER_SESSION) return;
 		const message = String(ctx.message || "").slice(0, 2000);
 		if (_isBenign(message) || _isBenign(ctx.stack)) return;
 		const e = {
@@ -144,9 +150,15 @@ export async function flushBuffered() {
 	localStorage.removeItem(BUFFER_KEY);
 	_reporting = true;
 	try {
-		await _post(buf.slice(0, MAX_QUEUE));
+		// The buffer holds up to 100 entries; drain it in MAX_QUEUE-sized chunks
+		// rather than posting only the first chunk and dropping the rest. On the
+		// first failed chunk, re-buffer everything still unsent so nothing is lost.
+		while (buf.length) {
+			await _post(buf.slice(0, MAX_QUEUE));
+			buf = buf.slice(MAX_QUEUE);
+		}
 	} catch {
-		_buffer(buf); // put it back for next time
+		_buffer(buf); // re-buffer the unsent remainder for the next reconnect
 	} finally {
 		_reporting = false;
 	}

--- a/frontend/src/lib/errorReporter.js
+++ b/frontend/src/lib/errorReporter.js
@@ -1,0 +1,196 @@
+/**
+ * Shared, framework-agnostic error reporter for the Jarvis SPA and PWA (imported
+ * by the PWA via the `@shared` alias, so there is exactly one copy). It batches,
+ * dedupes and bounds errors, then POSTs them to the customer bench, which scrubs
+ * and forwards them to the Jarvis admin.
+ *
+ * Two entry points:
+ *   - install()          - global window/Vue handlers for UNCAUGHT errors.
+ *   - report(context)    - explicit, CLASSIFIED capture at the chokepoints where
+ *                          the app already surfaces an error to the user (chat
+ *                          run:error, payment failures, ...) - these are not
+ *                          thrown, so the global handlers can't see them.
+ *
+ * It never throws and never reports its own failures (a re-entrancy guard stops
+ * an error during a flush from queueing another error - the classic loop).
+ */
+
+const ENDPOINT = "/api/method/jarvis.api_errors.report_client_errors";
+const BUFFER_KEY = "jarvis.errorBuffer";
+
+const MAX_PER_SESSION = 100; // stop after this many, so one broken build can't spam
+const MAX_QUEUE = 50;
+const FLUSH_DEBOUNCE_MS = 4000;
+
+let _surface = "spa";
+let _offline = false; // PWA sets true: buffer to localStorage when the POST fails
+let _installed = false;
+let _reporting = false; // true while a flush is in flight - suppress re-entry
+let _sent = 0;
+let _queue = [];
+let _seen = new Set(); // client fingerprints already queued in this window
+let _timer = null;
+
+const _BENIGN = [
+	/ResizeObserver loop/i,
+	// Stale-chunk load failures are already recovered by the router's reload.
+	/Failed to fetch dynamically imported module/i,
+	/Importing a module script failed/i,
+	/Loading chunk \d+ failed/i,
+];
+
+export function configure(opts = {}) {
+	if (opts.surface) _surface = opts.surface;
+	if (typeof opts.offline === "boolean") _offline = opts.offline;
+}
+
+function _csrf() {
+	try {
+		return window.csrf_token || (window.frappe && window.frappe.csrf_token) || "";
+	} catch {
+		return "";
+	}
+}
+
+function _fingerprint(e) {
+	const msg = (e.message || "").replace(/\d+/g, "#").slice(0, 200);
+	return `${e.error_code || ""}|${e.error_class || ""}|${e.surface}|${msg}`;
+}
+
+function _isBenign(text) {
+	return !!text && _BENIGN.some((re) => re.test(text));
+}
+
+/** Explicit, classified report. Safe to call from anywhere; cheap and silent. */
+export function report(ctx = {}) {
+	try {
+		if (_reporting || _sent >= MAX_PER_SESSION) return;
+		const message = String(ctx.message || "").slice(0, 2000);
+		if (_isBenign(message) || _isBenign(ctx.stack)) return;
+		const e = {
+			surface: ctx.surface || _surface,
+			route: ctx.route || (typeof location !== "undefined" ? location.pathname : ""),
+			error_code: String(ctx.error_code || "").slice(0, 64),
+			error_class: String(ctx.error_class || ctx.name || "").slice(0, 140),
+			message,
+			stack: String(ctx.stack || "").slice(0, 4000),
+			conversation: String(ctx.conversation || "").slice(0, 140),
+			run_id: String(ctx.run_id || "").slice(0, 140),
+		};
+		const fp = _fingerprint(e);
+		if (_seen.has(fp) || _queue.length >= MAX_QUEUE) return;
+		_seen.add(fp);
+		_queue.push(e);
+		_schedule();
+	} catch {
+		// A reporter that throws is worse than a missing report.
+	}
+}
+
+function _schedule() {
+	if (_timer) return;
+	_timer = setTimeout(() => {
+		_timer = null;
+		void flush();
+	}, FLUSH_DEBOUNCE_MS);
+}
+
+async function _post(batch) {
+	const res = await fetch(ENDPOINT, {
+		method: "POST",
+		credentials: "include",
+		headers: { "Content-Type": "application/json", "X-Frappe-CSRF-Token": _csrf() },
+		body: JSON.stringify({ errors: batch }),
+		keepalive: true,
+	});
+	if (!res.ok) throw new Error("report failed " + res.status);
+}
+
+export async function flush() {
+	if (!_queue.length || _reporting) return;
+	const batch = _queue.splice(0, MAX_QUEUE);
+	_seen = new Set();
+	_reporting = true;
+	try {
+		await _post(batch);
+		_sent += batch.length;
+	} catch {
+		if (_offline) _buffer(batch);
+		// else: drop. Errors are best-effort telemetry, never worth retrying hard.
+	} finally {
+		_reporting = false;
+	}
+}
+
+function _buffer(batch) {
+	try {
+		const prev = JSON.parse(localStorage.getItem(BUFFER_KEY) || "[]");
+		localStorage.setItem(BUFFER_KEY, JSON.stringify(prev.concat(batch).slice(-100)));
+	} catch {
+		// no localStorage / quota - nothing else we can do.
+	}
+}
+
+/** PWA: resend anything buffered while offline. Call on reconnect. */
+export async function flushBuffered() {
+	if (!_offline || _reporting) return;
+	let buf;
+	try {
+		buf = JSON.parse(localStorage.getItem(BUFFER_KEY) || "[]");
+	} catch {
+		buf = [];
+	}
+	if (!buf.length) return;
+	localStorage.removeItem(BUFFER_KEY);
+	_reporting = true;
+	try {
+		await _post(buf.slice(0, MAX_QUEUE));
+	} catch {
+		_buffer(buf); // put it back for next time
+	} finally {
+		_reporting = false;
+	}
+}
+
+/** Vue app.config.errorHandler - render/lifecycle errors Vue swallows. */
+export function vueErrorHandler(err) {
+	report({
+		error_class: (err && err.name) || "VueError",
+		error_code: "vue",
+		message: (err && err.message) || String(err),
+		stack: err && err.stack,
+	});
+}
+
+/** Install the global uncaught-error handlers. Idempotent. */
+export function install(opts = {}) {
+	configure(opts);
+	if (_installed || typeof window === "undefined") return;
+	_installed = true;
+
+	window.addEventListener("error", (ev) => {
+		const err = ev && ev.error;
+		report({
+			error_class: (err && err.name) || "Error",
+			error_code: "uncaught",
+			message: (err && err.message) || (ev && ev.message) || "Uncaught error",
+			stack: err && err.stack,
+		});
+	});
+	window.addEventListener("unhandledrejection", (ev) => {
+		const r = ev && ev.reason;
+		report({
+			error_class: (r && r.name) || "UnhandledRejection",
+			error_code: "unhandledrejection",
+			message: (r && r.message) || String(r),
+			stack: r && r.stack,
+		});
+	});
+	// Best-effort flush before the tab goes away.
+	window.addEventListener("pagehide", () => void flush());
+	if (typeof document !== "undefined" && document.addEventListener) {
+		document.addEventListener("visibilitychange", () => {
+			if (document.visibilityState === "hidden") void flush();
+		});
+	}
+}

--- a/frontend/src/lib/errorReporter.js
+++ b/frontend/src/lib/errorReporter.js
@@ -162,6 +162,21 @@ export function vueErrorHandler(err) {
 	});
 }
 
+/** Test-only: reset module state so unit tests isolate. Not used at runtime. */
+export function _resetForTests() {
+	_surface = "spa";
+	_offline = false;
+	_installed = false;
+	_reporting = false;
+	_sent = 0;
+	_queue = [];
+	_seen = new Set();
+	if (_timer) {
+		clearTimeout(_timer);
+		_timer = null;
+	}
+}
+
 /** Install the global uncaught-error handlers. Idempotent. */
 export function install(opts = {}) {
 	configure(opts);

--- a/frontend/src/lib/errorReporter.test.js
+++ b/frontend/src/lib/errorReporter.test.js
@@ -142,24 +142,58 @@ test("offline flushBuffered puts the batch back if the resend also fails", async
 	assert.equal(buf.length, 1, "kept for the next reconnect");
 });
 
-test("a report raised WHILE a flush is in flight is dropped, not re-entrant", async () => {
-	let resolveFetch;
+test("a report raised WHILE a flush is in flight is queued and sent next, not dropped", async () => {
+	let resolveFirst;
+	let callN = 0;
 	const bodies = [];
 	globalThis.fetch = (url, opts) => {
 		bodies.push(JSON.parse(opts.body));
-		return new Promise((res) => {
-			resolveFetch = () => res({ ok: true, status: 200 });
-		});
+		callN += 1;
+		// Only the first POST is held open (to create the in-flight window); the
+		// follow-up flush that drains the queued error resolves immediately.
+		if (callN === 1) {
+			return new Promise((res) => {
+				resolveFirst = () => res({ ok: true, status: 200 });
+			});
+		}
+		return Promise.resolve({ ok: true, status: 200 });
 	};
 	report({ surface: "s", error_code: "e", message: "first" });
-	const inflight = flush(); // _reporting = true, awaiting fetch
-	await flush(); // guarded: no second fetch
-	report({ surface: "s", error_code: "e", message: "second" }); // dropped by the guard
-	assert.equal(bodies.length, 1, "only one fetch while in flight");
-	resolveFetch();
+	const inflight = flush(); // _reporting = true, awaiting the held-open fetch
+	await flush(); // no *second concurrent* fetch (flush guards overlap)
+	report({ surface: "s", error_code: "e", message: "second" }); // queued, NOT dropped
+	assert.equal(bodies.length, 1, "only one concurrent fetch while in flight");
+	resolveFirst();
 	await inflight;
-	await flush(); // queue empty (second was dropped)
-	assert.equal(bodies.length, 1);
+	await flush(); // drains the queued "second"
+	assert.equal(bodies.length, 2, "the error raised mid-flight was captured, not lost");
+	assert.equal(bodies[1].errors[0].message, "second");
+});
+
+test("flushBuffered drains the whole buffer in chunks, not just the first 50", async () => {
+	configure({ offline: true });
+	const buf = Array.from({ length: 80 }, (_, i) => ({ surface: "s", message: "m" + i }));
+	lsStore["jarvis.errorBuffer"] = JSON.stringify(buf);
+	const calls = installFetch("ok");
+	await flushBuffered();
+	const totalSent = calls.reduce((n, c) => n + c.body.errors.length, 0);
+	assert.equal(totalSent, 80, "all 80 buffered entries resent across chunks");
+	assert.equal(lsStore["jarvis.errorBuffer"], undefined, "buffer cleared once fully drained");
+});
+
+test("flushBuffered re-buffers only the unsent remainder when a chunk fails", async () => {
+	configure({ offline: true });
+	const buf = Array.from({ length: 80 }, (_, i) => ({ surface: "s", message: "m" + i }));
+	lsStore["jarvis.errorBuffer"] = JSON.stringify(buf);
+	let n = 0;
+	globalThis.fetch = () => {
+		n += 1; // first chunk (50) ok, second chunk (30) fails
+		return Promise.resolve({ ok: n === 1, status: n === 1 ? 200 : 500 });
+	};
+	await flushBuffered();
+	const left = JSON.parse(lsStore["jarvis.errorBuffer"] || "[]");
+	assert.equal(left.length, 30, "the 50 sent are gone, the 30 unsent are kept");
+	assert.equal(left[0].message, "m50", "remainder starts right after the sent chunk");
 });
 
 test("install() wires window handlers that capture uncaught errors + rejections", async () => {

--- a/frontend/src/lib/errorReporter.test.js
+++ b/frontend/src/lib/errorReporter.test.js
@@ -1,0 +1,197 @@
+// Unit tests for the shared error reporter (SPA + PWA). node:test with mocked
+// browser globals - matches the repo's other src/**/*.test.js. Covers the
+// in-browser logic the builds can't: batching, POST shape, dedupe, benign
+// filter, caps, offline buffering, the re-entrancy guard, and the global
+// handlers.
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	report,
+	flush,
+	flushBuffered,
+	configure,
+	install,
+	vueErrorHandler,
+	_resetForTests,
+} from "./errorReporter.js";
+
+let lsStore;
+
+function installEnv() {
+	lsStore = {};
+	globalThis.localStorage = {
+		getItem: (k) => (k in lsStore ? lsStore[k] : null),
+		setItem: (k, v) => {
+			lsStore[k] = String(v);
+		},
+		removeItem: (k) => {
+			delete lsStore[k];
+		},
+	};
+	const handlers = {};
+	globalThis.window = {
+		csrf_token: "csrf-abc",
+		addEventListener: (ev, fn) => {
+			(handlers[ev] = handlers[ev] || []).push(fn);
+		},
+		__handlers: handlers,
+	};
+	globalThis.document = { addEventListener: () => {}, visibilityState: "visible" };
+	globalThis.location = { pathname: "/c/route" };
+}
+
+/** Fetch mock recording each call's parsed body. behavior: "ok" | "fail" | "reject". */
+function installFetch(behavior = "ok") {
+	const calls = [];
+	globalThis.fetch = (url, opts) => {
+		calls.push({ url, opts, body: JSON.parse(opts.body) });
+		if (behavior === "reject") return Promise.reject(new Error("network"));
+		return Promise.resolve({ ok: behavior === "ok", status: behavior === "ok" ? 200 : 500 });
+	};
+	return calls;
+}
+
+beforeEach(() => {
+	installEnv();
+	_resetForTests();
+});
+afterEach(() => _resetForTests());
+
+test("flush posts one batch with the right envelope + headers", async () => {
+	const calls = installFetch("ok");
+	report({ surface: "spa_chat", error_code: "e1", message: "boom one" });
+	report({ surface: "spa_chat", error_code: "e2", message: "boom two" });
+	await flush();
+	assert.equal(calls.length, 1);
+	assert.match(calls[0].url, /jarvis\.api_errors\.report_client_errors$/);
+	assert.equal(calls[0].opts.method, "POST");
+	assert.equal(calls[0].opts.headers["X-Frappe-CSRF-Token"], "csrf-abc");
+	assert.equal(calls[0].opts.keepalive, true);
+	assert.equal(calls[0].body.errors.length, 2);
+	assert.equal(calls[0].body.errors[0].route, "/c/route");
+});
+
+test("digit-only differences dedupe into one group; different words do not", async () => {
+	let calls = installFetch("ok");
+	report({ surface: "s", error_code: "e", message: "failed 3 times" });
+	report({ surface: "s", error_code: "e", message: "failed 9 times" });
+	await flush();
+	assert.equal(calls[0].body.errors.length, 1, "digit-only diff = one group");
+
+	_resetForTests();
+	calls = installFetch("ok");
+	report({ surface: "s", error_code: "e", message: "disk full" });
+	report({ surface: "s", error_code: "e", message: "network down" });
+	await flush();
+	assert.equal(calls[0].body.errors.length, 2, "different words = two groups");
+});
+
+test("benign browser noise is never sent", async () => {
+	const calls = installFetch("ok");
+	report({ message: "ResizeObserver loop limit exceeded" });
+	report({ message: "Loading chunk 42 failed" });
+	await flush();
+	assert.equal(calls.length, 0, "nothing queued -> no POST");
+});
+
+test("the queue is capped at 50 per flush", async () => {
+	const calls = installFetch("ok");
+	for (let i = 0; i < 60; i++) {
+		report({ surface: "s", error_code: "e", message: "z".repeat(i + 1) }); // 60 distinct, no digits
+	}
+	await flush();
+	assert.equal(calls[0].body.errors.length, 50);
+});
+
+test("the per-session cap stops reporting past 100", async () => {
+	const calls = installFetch("ok");
+	for (let b = 0; b < 3; b++) {
+		for (let i = 0; i < 50; i++) {
+			report({ surface: "s", error_code: "e", message: `x${"z".repeat(i + 1)}` });
+		}
+		await flush(); // _seen resets per flush; _sent accumulates
+	}
+	const total = calls.reduce((n, c) => n + c.body.errors.length, 0);
+	assert.equal(total, 100, `sent ${total}, expected the 100 cap`);
+});
+
+test("offline: a failed POST buffers to localStorage; flushBuffered resends and clears", async () => {
+	configure({ offline: true });
+	installFetch("reject");
+	report({ surface: "s", error_code: "e", message: "offline boom" });
+	await flush();
+	const buf = JSON.parse(lsStore["jarvis.errorBuffer"] || "[]");
+	assert.equal(buf.length, 1, "buffered on failure");
+
+	const calls = installFetch("ok");
+	await flushBuffered();
+	assert.equal(calls.length, 1);
+	assert.equal(calls[0].body.errors.length, 1);
+	assert.equal(lsStore["jarvis.errorBuffer"], undefined, "buffer cleared after resend");
+});
+
+test("offline flushBuffered puts the batch back if the resend also fails", async () => {
+	configure({ offline: true });
+	installFetch("reject");
+	report({ surface: "s", error_code: "e", message: "still offline" });
+	await flush();
+	installFetch("reject");
+	await flushBuffered();
+	const buf = JSON.parse(lsStore["jarvis.errorBuffer"] || "[]");
+	assert.equal(buf.length, 1, "kept for the next reconnect");
+});
+
+test("a report raised WHILE a flush is in flight is dropped, not re-entrant", async () => {
+	let resolveFetch;
+	const bodies = [];
+	globalThis.fetch = (url, opts) => {
+		bodies.push(JSON.parse(opts.body));
+		return new Promise((res) => {
+			resolveFetch = () => res({ ok: true, status: 200 });
+		});
+	};
+	report({ surface: "s", error_code: "e", message: "first" });
+	const inflight = flush(); // _reporting = true, awaiting fetch
+	await flush(); // guarded: no second fetch
+	report({ surface: "s", error_code: "e", message: "second" }); // dropped by the guard
+	assert.equal(bodies.length, 1, "only one fetch while in flight");
+	resolveFetch();
+	await inflight;
+	await flush(); // queue empty (second was dropped)
+	assert.equal(bodies.length, 1);
+});
+
+test("install() wires window handlers that capture uncaught errors + rejections", async () => {
+	const calls = installFetch("ok");
+	install({ surface: "spa" });
+	const h = globalThis.window.__handlers;
+	assert.ok(h.error?.length && h.unhandledrejection?.length, "handlers registered");
+	h.error[0]({ error: { name: "TypeError", message: "x is undefined", stack: "at foo" } });
+	h.unhandledrejection[0]({ reason: { name: "BoomError", message: "rejected", stack: "" } });
+	await flush();
+	const classes = calls[0].body.errors.map((e) => e.error_class);
+	assert.ok(classes.includes("TypeError"));
+	assert.ok(classes.includes("BoomError"));
+});
+
+test("install() is idempotent (handlers not double-registered)", () => {
+	install({ surface: "spa" });
+	install({ surface: "spa" });
+	assert.equal(globalThis.window.__handlers.error.length, 1);
+});
+
+test("vueErrorHandler reports render errors as code 'vue'", async () => {
+	const calls = installFetch("ok");
+	vueErrorHandler(new TypeError("render boom"));
+	await flush();
+	assert.equal(calls[0].body.errors[0].error_code, "vue");
+	assert.match(calls[0].body.errors[0].message, /render boom/);
+});
+
+test("report() truncates an oversized message", async () => {
+	const calls = installFetch("ok");
+	report({ surface: "s", error_code: "e", message: "q".repeat(5000) });
+	await flush();
+	assert.ok(calls[0].body.errors[0].message.length <= 2000);
+});

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,6 +6,7 @@ import router from "./router";
 import { initSocket } from "./socket";
 import { session, requireLogin } from "./data/session";
 import { applyBrandChrome } from "./branding";
+import { install as installErrorReporter, vueErrorHandler } from "./lib/errorReporter";
 // Tailwind pipeline entry (frappe-ui/style.css + compensations + dark bridge)
 // MUST load before main.css so jv-* globals win cascade ties (DESIGN-V3 §2.3).
 import "./index.css";
@@ -19,7 +20,13 @@ requireLogin();
 
 setConfig("resourceFetcher", frappeRequest);
 
+// Capture uncaught errors (+ Vue render errors below) and forward them, scrubbed,
+// to the admin. Classified chokepoints (chat run:error, payment failures) call
+// report() directly - see errorReporter.js.
+installErrorReporter({ surface: "spa" });
+
 const app = createApp(App);
+app.config.errorHandler = vueErrorHandler;
 app.use(resourcesPlugin);
 app.use(router);
 

--- a/frontend/src/notify/globalNotifier.js
+++ b/frontend/src/notify/globalNotifier.js
@@ -18,6 +18,7 @@
 import { ref } from "vue";
 import { useShellStore } from "@/stores/shell";
 import { session } from "@/data/session";
+import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
 
 // ---- toast state (rendered by NotifyToaster.vue) -----------------------------
@@ -146,6 +147,19 @@ export function attachGlobalNotifier({ socket, router }) {
 			case "run:end":
 			case "run:error": {
 				const conv = p.conversation_id;
+				// A failed turn is the most common error a user faces. Report it
+				// (classified, with the run id) regardless of on-screen state - this
+				// is a socket event, so the global handlers never see it.
+				if (p.kind === "run:error") {
+					reportError({
+						surface: "spa_chat",
+						error_code: p.code || "run_error",
+						error_class: "RunError",
+						message: p.error || "The run failed.",
+						conversation: conv || "",
+						run_id: p.run_id || "",
+					});
+				}
 				if (!conv) return;
 				// The Triggers pane renders this conversation's turns inline — treat
 				// it like the on-screen chat: no unread dot, no "Reply ready" toast.

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -862,6 +862,7 @@ import {
 	syncConnection,
 } from "@/api";
 import { errMessage as errMsg } from "@/lib/errors";
+import { report as reportError } from "@/lib/errorReporter";
 import { agentName } from "@/branding";
 
 const { effectiveDark: dark, paletteVars } = useJarvisTheme();
@@ -1828,6 +1829,17 @@ watch(
 			loadPlansSafe();
 		}
 		if (s === "pay") enterPayStep();
+	}
+);
+
+// Report onboarding/payment failures to the admin as they surface. These are
+// caught-and-shown (not thrown), so the global handler never sees them; one
+// watcher covers every payErr/provisionErr assignment above.
+watch(
+	() => [state.payErr, state.provisionErr],
+	([pay, prov]) => {
+		if (pay) reportError({ surface: "onboarding", error_code: "payment", message: pay });
+		if (prov) reportError({ surface: "onboarding", error_code: "provisioning", message: prov });
 	}
 );
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1839,7 +1839,8 @@ watch(
 	() => [state.payErr, state.provisionErr],
 	([pay, prov]) => {
 		if (pay) reportError({ surface: "onboarding", error_code: "payment", message: pay });
-		if (prov) reportError({ surface: "onboarding", error_code: "provisioning", message: prov });
+		if (prov)
+			reportError({ surface: "onboarding", error_code: "provisioning", message: prov });
 	}
 );
 

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1006,6 +1006,13 @@ def push_usage_rollup(rollup: dict) -> dict:
 	return _post(path=_m("api.tenant.ingest_usage_rollup"), body={"rollup": rollup})
 
 
+def push_error_rollup(errors: list) -> dict:
+	"""Push a batch of scrubbed tenant errors (UI + code-level) to admin for the
+	per-tenant Errors feed. Called best-effort from the error_push */5 cron.
+	Raises AdminAuthError / AdminUnreachableError / AdminValidationError."""
+	return _post(path=_m("api.tenant.ingest_error_rollup"), body={"errors": errors})
+
+
 def pair_chat_device(public_key: str, device_id: str, *, request_timeout_s: int = 30) -> dict:
 	"""POST customer's chat device pubkey to admin; admin asks the fleet-agent
 	to write a PairedDevice record into the customer's openclaw container and

--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -27,6 +27,7 @@ import time
 
 import frappe
 
+from jarvis._redis_lock import redis_lock
 from jarvis.audit import _SECRET_KEYS
 
 DT = "Jarvis Client Error"
@@ -68,6 +69,11 @@ _KV_SECRET_RE = re.compile(
 )
 # long hex / base64-ish blobs (hashes, ids, tokens)
 _LONG_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{24,}\b")
+# fixed-width alphanumeric IDs under the blob threshold that mix letters AND
+# digits: GSTIN (27AAPFU0939F1ZV), PAN, batch/serial codes. These are ERP
+# identifiers, not taxonomy. A pure-letter token (an exception class) has no
+# digit and is left alone; a pure-digit run is handled by _NUMBER_RE.
+_ID_RE = re.compile(r"\b(?=[A-Za-z0-9]*[A-Za-z])(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{10,23}\b")
 # decimals, thousand-grouped, or 4+ digit runs = amounts / quantities / ids
 _NUMBER_RE = re.compile(r"(?<![\w.])(?:\d[\d,]*\.\d+|\d{1,3}(?:,\d{3})+|\d{4,})(?![\w])")
 # any quoted literal - redacted unconditionally. ERP messages quote entity names
@@ -111,6 +117,7 @@ def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str
 		return m.group(0) if keep_email and m.group(0).lower() == keep_email.lower() else "[EMAIL]"
 
 	out = _EMAIL_RE.sub(_email_sub, out)
+	out = _ID_RE.sub("[ID]", out)
 	out = _QUOTED_RE.sub(_redact_quoted, out)
 	out = _NAME_RUN_RE.sub("[NAME]", out)
 	out = _NUMBER_RE.sub("[NUM]", out)
@@ -187,7 +194,10 @@ def _over_report_rate_limit(user: str) -> bool:
 	if frappe.flags.in_test:
 		return False
 	bucket = int(time.time()) // 60
-	key = f"jarvis.client_error_report.{user}.{bucket}"
+	# incrby is a raw redis-py call that bypasses RedisWrapper.make_key's site
+	# prefix, so prefix the site ourselves - otherwise a multi-site bench sharing
+	# one Redis would let two sites' same-named users share a bucket.
+	key = f"{frappe.local.site}:jarvis.client_error_report.{user}.{bucket}"
 	count = frappe.cache.incrby(key, 1)
 	if count == 1:
 		frappe.cache.expire(key, 120)
@@ -226,19 +236,26 @@ def _ingest_one(raw: dict, user: str) -> bool:
 	if _looks_non_jarvis(surface, str(raw.get("route") or ""), str(raw.get("stack") or "")):
 		return False
 
-	message = _scrub_error_text(raw.get("message"), keep_email=user)[:MAX_MESSAGE]
+	raw_message = str(raw.get("message") or "")
+	message = _scrub_error_text(raw_message, keep_email=user)[:MAX_MESSAGE]
 	stack = _scrub_error_text(raw.get("stack"), keep_email=user)[:MAX_STACK]
-	fp = _fingerprint(error_code, error_class, message, surface)
+	# Fingerprint the RAW (unscrubbed) message, not the scrubbed one. The
+	# fingerprint is admin's per-row grouping key (JTE-{tenant}-{fingerprint}), and
+	# a hash never leaves the bench in reversible form. Keying on raw text
+	# decouples grouping identity from redaction policy: a future scrubber tweak
+	# then does NOT re-key the whole feed (every row reappearing as new with
+	# count=1 and orphaned `resolved` flags). Lane 2 already fingerprints raw frames.
+	fp = _fingerprint(error_code, error_class, raw_message, surface)
 
-	# Serialize concurrent reports of the SAME error (same user+fingerprint) so
-	# the check-then-act below can't double-insert, and two occurrences can't both
-	# read the same count and lose an increment. Different errors hash to
-	# different lock names and never contend. Best-effort: on lock timeout we fall
-	# through unlocked - a rare duplicate row is harmless (admin folds by
+	# Serialize concurrent reports of the SAME error (same user+fingerprint) so the
+	# check-then-act below can't double-insert, and two occurrences can't both read
+	# the same count and lose an increment. Uses the repo's portable Redis mutex
+	# (jarvis._redis_lock) rather than a MySQL GET_LOCK: it is DB-agnostic and does
+	# not pin the worker's DB connection. Best-effort with a short bounded wait -
+	# different errors take different locks and never contend; on contention/timeout
+	# we proceed unlocked (a rare duplicate row is harmless: admin folds by
 	# (tenant, fingerprint)).
-	lock = _row_lock(user, fp)
-	got = frappe.db.sql("SELECT GET_LOCK(%s, 3)", lock)[0][0]
-	try:
+	with redis_lock(_row_lock(user, fp), timeout_s=10, blocking_timeout_s=2):
 		now = frappe.utils.now_datetime()
 		existing = frappe.db.get_value(DT, {"fingerprint": fp, "user": user, "pushed": 0}, "name")
 		if existing:
@@ -270,9 +287,6 @@ def _ingest_one(raw: dict, user: str) -> bool:
 			}
 		).insert(ignore_permissions=True)
 		return True
-	finally:
-		if got:
-			frappe.db.sql("SELECT RELEASE_LOCK(%s)", lock)
 
 
 def _clean_route(route) -> str:

--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 
 import frappe
 
@@ -35,8 +36,26 @@ MAX_ERRORS_PER_CALL = 50
 MAX_MESSAGE = 500
 MAX_STACK = 2000
 
+#: Server-side ceiling on the endpoint: the client caps are advisory (curl
+#: ignores them), so cap accepted batches per user per minute. Past this the call
+#: returns early WITHOUT touching the DB - each accepted batch is up to
+#: MAX_ERRORS_PER_CALL get_value+save cycles, so this is the real DoS guard.
+REPORT_RATE_PER_MIN = 60
+
 #: How many Error Log rows one push cycle scans at most.
 ERROR_LOG_SCAN_LIMIT = 300
+
+#: Positive "this browser error came from another app, not Jarvis" evidence -
+#: an asset path only a non-Jarvis Desk bundle loads. Used as a server-side
+#: backstop to the client-side scoping (a stray ERPNext/HRMS Desk error must not
+#: cross to the control plane). See _looks_non_jarvis.
+_NONJARVIS_ASSET_MARKERS = (
+	"/assets/frappe/",
+	"/assets/erpnext/",
+	"/assets/hrms/",
+	"/assets/payments/",
+	"/assets/lms/",
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -51,24 +70,37 @@ _KV_SECRET_RE = re.compile(
 _LONG_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{24,}\b")
 # decimals, thousand-grouped, or 4+ digit runs = amounts / quantities / ids
 _NUMBER_RE = re.compile(r"(?<![\w.])(?:\d[\d,]*\.\d+|\d{1,3}(?:,\d{3})+|\d{4,})(?![\w])")
-# quoted literals that look like DATA (contain a digit, or are long)
+# any quoted literal - redacted unconditionally. ERP messages quote entity names
+# ('Tata Steel Ltd') that carry no digit and sit under 24 chars, so the old
+# length/digit heuristic leaked them. A traceback's `File "..."` path is dropped
+# too; the frame's function name + line survive unquoted, which is what triage needs.
 _QUOTED_RE = re.compile(r"(['\"])((?:\\.|(?!\1).)*?)\1")
+# a run of 2+ Capitalised words - the shape of an *unquoted* ERP entity name
+# ("Employee Priya Sharma", "Supplier Reliance Industries"). Most
+# frappe.throw(_("...{0}...").format(name)) messages interpolate the name bare,
+# so it is never quoted and no value regex above would catch it. CamelCase
+# exception classes ("ValueError", "TypeError") are single tokens and are not a
+# run, so the taxonomy survives.
+_NAME_RUN_RE = re.compile(r"\b[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z0-9]*){1,}\b")
 
 
 def _redact_quoted(m: re.Match) -> str:
-	inner = m.group(2)
-	if len(inner) > 24 or any(c.isdigit() for c in inner):
-		return m.group(1) + "[VAL]" + m.group(1)
-	return m.group(0)
+	# Every quoted literal is a candidate data value; redact unconditionally.
+	# Keeping "path-shaped" quotes was tempting but unsafe - a base64 secret
+	# contains '/' too, and _LONG_BLOB_RE already drops long paths regardless.
+	return m.group(1) + "[VAL]" + m.group(1)
 
 
 def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str:
 	"""Redact PII / ERP values from a free-text error message or traceback.
 
-	Best-effort and deliberately conservative on structure (keeps error codes,
-	class names, field names) while removing values: emails (except the
-	reporting user's own), secret-shaped tokens, long hashes, amounts /
-	quantities / long ids, and data-shaped quoted literals."""
+	Deliberately conservative on structure (keeps error codes, class names, field
+	names, frame functions) while removing values: emails (except the reporting user's
+	own), secret-shaped tokens, long hashes, amounts / quantities / long ids, and
+	both *quoted* and *bare capitalised* entity names. The name redaction is
+	blunt on purpose - the failure mode of a blocklist here (a leaked customer /
+	supplier / employee name crossing benches to the control plane) is worse than
+	over-redacting a doctype label."""
 	if not text:
 		return ""
 	out = str(text)
@@ -80,6 +112,7 @@ def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str
 
 	out = _EMAIL_RE.sub(_email_sub, out)
 	out = _QUOTED_RE.sub(_redact_quoted, out)
+	out = _NAME_RUN_RE.sub("[NAME]", out)
 	out = _NUMBER_RE.sub("[NUM]", out)
 	return out
 
@@ -118,6 +151,11 @@ def report_client_errors(errors: str | list) -> dict:
 	if not user or user == "Guest":
 		raise frappe.AuthenticationError
 
+	if _over_report_rate_limit(user):
+		# Soft-throttle: bail before any DB work. The client treats a non-ok
+		# result as "drop" (best-effort telemetry), so no retry storm.
+		return {"ok": False, "accepted": 0, "throttled": True}
+
 	if isinstance(errors, str):
 		try:
 			errors = json.loads(errors)
@@ -131,8 +169,8 @@ def report_client_errors(errors: str | list) -> dict:
 		if not isinstance(raw, dict):
 			continue
 		try:
-			_ingest_one(raw, user)
-			accepted += 1
+			if _ingest_one(raw, user):
+				accepted += 1
 		except Exception:
 			# One malformed row must not sink the batch.
 			frappe.logger("jarvis.client_errors").debug("client error row dropped", exc_info=True)
@@ -141,47 +179,100 @@ def report_client_errors(errors: str | list) -> dict:
 	return {"ok": True, "accepted": accepted}
 
 
-def _ingest_one(raw: dict, user: str) -> None:
+def _over_report_rate_limit(user: str) -> bool:
+	"""Per-user calendar-minute bucket. Atomic ``incrby`` (not get-then-set): it
+	is race-free under concurrent requests, and - unlike get_value/set_value with
+	a TTL - it is not fooled by frappe's request-local cache when the same request
+	checks more than once. The key self-expires, so old buckets never accumulate."""
+	if frappe.flags.in_test:
+		return False
+	bucket = int(time.time()) // 60
+	key = f"jarvis.client_error_report.{user}.{bucket}"
+	count = frappe.cache.incrby(key, 1)
+	if count == 1:
+		frappe.cache.expire(key, 120)
+	return count > REPORT_RATE_PER_MIN
+
+
+def _looks_non_jarvis(surface: str, route: str, stack: str) -> bool:
+	"""Server-side backstop mirroring lane 2's jarvis-only filter for lane 1.
+
+	The SPA/PWA reporters only load on Jarvis surfaces, so they are Jarvis-scoped
+	by construction; the Desk bundle loads on every Desk page, so a stray
+	ERPNext/HRMS error could reach here. Drop a row only on POSITIVE non-Jarvis
+	evidence (another app's asset in the stack) and no Jarvis marker anywhere -
+	so an empty-stack or genuinely-Jarvis error is always kept."""
+	if "jarvis" in f"{surface}\n{route}\n{stack}".lower():
+		return False
+	return any(m in stack for m in _NONJARVIS_ASSET_MARKERS)
+
+
+def _row_lock(user: str, fp: str) -> str:
+	return "jce:" + hashlib.sha1(f"{user}|{fp}".encode()).hexdigest()[:40]
+
+
+def _ingest_one(raw: dict, user: str) -> bool:
+	"""Fold one reported error into the local buffer. Returns True if stored,
+	False if filtered out (non-Jarvis origin)."""
 	surface = (str(raw.get("surface") or "unknown"))[:40]
 	error_code = (str(raw.get("error_code") or ""))[:64]
 	error_class = (str(raw.get("error_class") or ""))[:140]
 	route = _clean_route(raw.get("route"))
 	conversation = (str(raw.get("conversation") or ""))[:140]
 	run_id = (str(raw.get("run_id") or ""))[:140]
+
+	# Origin check runs on the RAW stack/route - scrubbing would blob the asset
+	# path (`/assets/erpnext/...` -> `[BLOB]`) and hide the very marker we filter on.
+	if _looks_non_jarvis(surface, str(raw.get("route") or ""), str(raw.get("stack") or "")):
+		return False
+
 	message = _scrub_error_text(raw.get("message"), keep_email=user)[:MAX_MESSAGE]
 	stack = _scrub_error_text(raw.get("stack"), keep_email=user)[:MAX_STACK]
 	fp = _fingerprint(error_code, error_class, message, surface)
 
-	now = frappe.utils.now_datetime()
-	existing = frappe.db.get_value(DT, {"fingerprint": fp, "user": user, "pushed": 0}, "name")
-	if existing:
-		doc = frappe.get_doc(DT, existing)
-		doc.count = (doc.count or 1) + 1
-		doc.last_seen = now
-		doc.message = message or doc.message
-		doc.stack = stack or doc.stack
-		doc.route = route or doc.route
-		doc.save(ignore_permissions=True)
-		return
+	# Serialize concurrent reports of the SAME error (same user+fingerprint) so
+	# the check-then-act below can't double-insert, and two occurrences can't both
+	# read the same count and lose an increment. Different errors hash to
+	# different lock names and never contend. Best-effort: on lock timeout we fall
+	# through unlocked - a rare duplicate row is harmless (admin folds by
+	# (tenant, fingerprint)).
+	lock = _row_lock(user, fp)
+	got = frappe.db.sql("SELECT GET_LOCK(%s, 3)", lock)[0][0]
+	try:
+		now = frappe.utils.now_datetime()
+		existing = frappe.db.get_value(DT, {"fingerprint": fp, "user": user, "pushed": 0}, "name")
+		if existing:
+			doc = frappe.get_doc(DT, existing)
+			doc.count = (doc.count or 1) + 1
+			doc.last_seen = now
+			doc.message = message or doc.message
+			doc.stack = stack or doc.stack
+			doc.route = route or doc.route
+			doc.save(ignore_permissions=True)
+			return True
 
-	frappe.get_doc(
-		{
-			"doctype": DT,
-			"surface": surface,
-			"route": route,
-			"error_code": error_code,
-			"error_class": error_class,
-			"message": message,
-			"stack": stack,
-			"user": user,
-			"conversation": conversation,
-			"run_id": run_id,
-			"fingerprint": fp,
-			"count": 1,
-			"first_seen": now,
-			"last_seen": now,
-		}
-	).insert(ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": DT,
+				"surface": surface,
+				"route": route,
+				"error_code": error_code,
+				"error_class": error_class,
+				"message": message,
+				"stack": stack,
+				"user": user,
+				"conversation": conversation,
+				"run_id": run_id,
+				"fingerprint": fp,
+				"count": 1,
+				"first_seen": now,
+				"last_seen": now,
+			}
+		).insert(ignore_permissions=True)
+		return True
+	finally:
+		if got:
+			frappe.db.sql("SELECT RELEASE_LOCK(%s)", lock)
 
 
 def _clean_route(route) -> str:
@@ -202,14 +293,26 @@ _JARVIS_APP_MARKER = "/apps/jarvis/"
 _FRAME_RE = re.compile(r'File "([^"]+)", line \d+, in (\w+)')
 _EXC_LINE_RE = re.compile(r"^([A-Za-z_][\w.]*(?:Error|Exception|Warning|Interrupt)):?\s*(.*)$")
 
+#: The error-reporting pipeline's OWN modules. A failure here (e.g. admin
+#: unreachable) must never be forwarded - it would report on its own outage and,
+#: once admin returns, flood the feed with a report per failed cycle. These logs
+#: stay local (Error Log / journalctl) where the operator can still see them.
+_REPORTER_SELF_MARKERS = (
+	"/apps/jarvis/jarvis/error_push.py",
+	"/apps/jarvis/jarvis/api_errors.py",
+)
+
 
 def is_jarvis_error(method: str | None, traceback: str | None) -> bool:
 	"""True only for exceptions that originate in the jarvis app - so a
 	customer's ERPNext / framework / other-app errors never leave their bench.
 
 	Matches the jarvis app path in the traceback, or a ``jarvis.*`` dotted
-	``method`` title (excluding the un-installed ``jarvis_admin`` checkout)."""
+	``method`` title (excluding the un-installed ``jarvis_admin`` checkout).
+	Excludes the reporter's own modules so error reporting can't report itself."""
 	tb = traceback or ""
+	if any(marker in tb for marker in _REPORTER_SELF_MARKERS):
+		return False
 	if _JARVIS_APP_MARKER in tb:
 		return True
 	m = (method or "").strip()

--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -69,11 +69,14 @@ _KV_SECRET_RE = re.compile(
 )
 # long hex / base64-ish blobs (hashes, ids, tokens)
 _LONG_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{24,}\b")
-# fixed-width alphanumeric IDs under the blob threshold that mix letters AND
-# digits: GSTIN (27AAPFU0939F1ZV), PAN, batch/serial codes. These are ERP
-# identifiers, not taxonomy. A pure-letter token (an exception class) has no
-# digit and is left alone; a pure-digit run is handled by _NUMBER_RE.
-_ID_RE = re.compile(r"\b(?=[A-Za-z0-9]*[A-Za-z])(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{10,23}\b")
+# fixed-width UPPERCASE alphanumeric IDs under the blob threshold that mix
+# letters AND digits: GSTIN (27AAPFU0939F1ZV), PAN, batch/serial codes. These
+# are ERP identifiers, not taxonomy. Restricted to [A-Z0-9] on purpose: a
+# CamelCase class name that carries a digit ("OAuth2Error", "Http404Error",
+# "S3UploadError") always has a lowercase letter, so it stays intact; a pure
+# uppercase ID does not. A pure-letter token (an exception class) has no digit;
+# a pure-digit run is handled by _NUMBER_RE.
+_ID_RE = re.compile(r"\b(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*\d)[A-Z0-9]{10,23}\b")
 # decimals, thousand-grouped, or 4+ digit runs = amounts / quantities / ids
 _NUMBER_RE = re.compile(r"(?<![\w.])(?:\d[\d,]*\.\d+|\d{1,3}(?:,\d{3})+|\d{4,})(?![\w])")
 # any quoted literal - redacted unconditionally. ERP messages quote entity names
@@ -129,12 +132,24 @@ def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str
 # --------------------------------------------------------------------------- #
 _NORM_DIGITS = re.compile(r"\d+")
 
+#: Grouping-key version. The UI fingerprint is computed from the SCRUBBED message
+#: (see _ingest_one), which doubles as the normalizer that collapses different
+#: entity names into one group - so one bug across N customers stays one row at
+#: count=N, not N rows at count=1. That couples grouping to redaction policy: any
+#: change to _scrub_error_text would silently re-key the whole admin feed. Bump
+#: this constant in the SAME commit as any scrubber change, so the re-key becomes
+#: an intentional, dated event and the old rows age out via the 90-day prune.
+_SCRUB_VERSION = "1"
+
 
 def _fingerprint(error_code: str, error_class: str, message: str, surface: str) -> str:
 	"""Stable dedupe key for a UI error - digits normalized out of the message so
-	'... 42 units' and '... 7 units' collapse to one group."""
+	'... 42 units' and '... 7 units' collapse to one group. Fed the SCRUBBED
+	message by _ingest_one, so entity-name variants ('Tata Steel' vs 'Acme') that
+	both scrub to '[VAL]'/'[NAME]' collapse to one group too. Versioned by
+	_SCRUB_VERSION so a scrubber change re-keys deliberately, not silently."""
 	norm = _NORM_DIGITS.sub("#", (message or "").lower())[:200]
-	raw = f"{error_code}|{error_class}|{surface}|{norm}"
+	raw = f"{_SCRUB_VERSION}|{error_code}|{error_class}|{surface}|{norm}"
 	return hashlib.sha1(raw.encode()).hexdigest()
 
 
@@ -236,16 +251,15 @@ def _ingest_one(raw: dict, user: str) -> bool:
 	if _looks_non_jarvis(surface, str(raw.get("route") or ""), str(raw.get("stack") or "")):
 		return False
 
-	raw_message = str(raw.get("message") or "")
-	message = _scrub_error_text(raw_message, keep_email=user)[:MAX_MESSAGE]
+	message = _scrub_error_text(raw.get("message"), keep_email=user)[:MAX_MESSAGE]
 	stack = _scrub_error_text(raw.get("stack"), keep_email=user)[:MAX_STACK]
-	# Fingerprint the RAW (unscrubbed) message, not the scrubbed one. The
-	# fingerprint is admin's per-row grouping key (JTE-{tenant}-{fingerprint}), and
-	# a hash never leaves the bench in reversible form. Keying on raw text
-	# decouples grouping identity from redaction policy: a future scrubber tweak
-	# then does NOT re-key the whole feed (every row reappearing as new with
-	# count=1 and orphaned `resolved` flags). Lane 2 already fingerprints raw frames.
-	fp = _fingerprint(error_code, error_class, raw_message, surface)
+	# Fingerprint the SCRUBBED message: it doubles as the grouping normalizer, so
+	# "Customer 'Tata Steel'" and "Customer 'Acme'" both scrub to "Customer '[VAL]'"
+	# and collapse to one group - one bug across N customers is one row at count=N,
+	# not N rows at count=1. The scrubber-coupling that creates (a scrubber change
+	# would re-key the feed) is made explicit and deliberate via _SCRUB_VERSION,
+	# baked into _fingerprint. Lane 2 keys on raw frames, so it is scrub-stable.
+	fp = _fingerprint(error_code, error_class, message, surface)
 
 	# Serialize concurrent reports of the SAME error (same user+fingerprint) so the
 	# check-then-act below can't double-insert, and two occurrences can't both read

--- a/jarvis/api_errors.py
+++ b/jarvis/api_errors.py
@@ -1,0 +1,275 @@
+"""Capture user-facing UI errors and code-level exceptions, buffer them locally,
+and shape them for the out-of-band push to the admin control plane.
+
+Two capture lanes (both feed ``jarvis.error_push``):
+
+  - ``report_client_errors`` - the whitelisted endpoint the SPA / PWA / Desk
+    reporters POST to. Session-authed. Scrubs message/stack of PII / ERP values,
+    fingerprints for dedupe, and folds occurrences into the ``Jarvis Client
+    Error`` buffer doctype.
+  - ``collect_error_log`` - reads new Frappe ``Error Log`` rows (every unhandled
+    server / RQ-worker / cron exception already lands there), **filtered to the
+    jarvis app only**, and normalizes them. Error Log IS the storage, so this
+    only reads + shapes; ``error_push`` owns the watermark.
+
+The core privacy rule lives here: only a *scrubbed* copy of any error text ever
+leaves the bench. The reporting user's own email is preserved (admin already
+knows it via usage rollups); every other email, amount, quantity, quoted data
+value, long hash and secret-shaped token is redacted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+import frappe
+
+from jarvis.audit import _SECRET_KEYS
+
+DT = "Jarvis Client Error"
+
+#: Hard bounds so a hostile or runaway client can't flood one call.
+MAX_ERRORS_PER_CALL = 50
+MAX_MESSAGE = 500
+MAX_STACK = 2000
+
+#: How many Error Log rows one push cycle scans at most.
+ERROR_LOG_SCAN_LIMIT = 300
+
+
+# --------------------------------------------------------------------------- #
+# Scrubbing (balanced)
+# --------------------------------------------------------------------------- #
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# secret-shaped key=value / key: value (key contains password|pwd|secret|token|key)
+_KV_SECRET_RE = re.compile(
+	r"(?i)\b(\w*(?:" + "|".join(_SECRET_KEYS) + r")\w*)\b\s*[=:]\s*[^\s,;)]+",
+)
+# long hex / base64-ish blobs (hashes, ids, tokens)
+_LONG_BLOB_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{24,}\b")
+# decimals, thousand-grouped, or 4+ digit runs = amounts / quantities / ids
+_NUMBER_RE = re.compile(r"(?<![\w.])(?:\d[\d,]*\.\d+|\d{1,3}(?:,\d{3})+|\d{4,})(?![\w])")
+# quoted literals that look like DATA (contain a digit, or are long)
+_QUOTED_RE = re.compile(r"(['\"])((?:\\.|(?!\1).)*?)\1")
+
+
+def _redact_quoted(m: re.Match) -> str:
+	inner = m.group(2)
+	if len(inner) > 24 or any(c.isdigit() for c in inner):
+		return m.group(1) + "[VAL]" + m.group(1)
+	return m.group(0)
+
+
+def _scrub_error_text(text: str | None, *, keep_email: str | None = None) -> str:
+	"""Redact PII / ERP values from a free-text error message or traceback.
+
+	Best-effort and deliberately conservative on structure (keeps error codes,
+	class names, field names) while removing values: emails (except the
+	reporting user's own), secret-shaped tokens, long hashes, amounts /
+	quantities / long ids, and data-shaped quoted literals."""
+	if not text:
+		return ""
+	out = str(text)
+	out = _KV_SECRET_RE.sub(lambda m: m.group(1) + "=[REDACTED]", out)
+	out = _LONG_BLOB_RE.sub("[BLOB]", out)
+
+	def _email_sub(m: re.Match) -> str:
+		return m.group(0) if keep_email and m.group(0).lower() == keep_email.lower() else "[EMAIL]"
+
+	out = _EMAIL_RE.sub(_email_sub, out)
+	out = _QUOTED_RE.sub(_redact_quoted, out)
+	out = _NUMBER_RE.sub("[NUM]", out)
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprinting
+# --------------------------------------------------------------------------- #
+_NORM_DIGITS = re.compile(r"\d+")
+
+
+def _fingerprint(error_code: str, error_class: str, message: str, surface: str) -> str:
+	"""Stable dedupe key for a UI error - digits normalized out of the message so
+	'... 42 units' and '... 7 units' collapse to one group."""
+	norm = _NORM_DIGITS.sub("#", (message or "").lower())[:200]
+	raw = f"{error_code}|{error_class}|{surface}|{norm}"
+	return hashlib.sha1(raw.encode()).hexdigest()
+
+
+def _traceback_fingerprint(exc_class: str, frames: list[str]) -> str:
+	raw = exc_class + "\n" + "\n".join(frames[:8])
+	return hashlib.sha1(raw.encode()).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Lane 1: the browser reporter endpoint
+# --------------------------------------------------------------------------- #
+@frappe.whitelist(methods=["POST"])
+def report_client_errors(errors: str | list) -> dict:
+	"""Accept a batch of scrubbed-on-arrival UI errors from a Jarvis surface.
+
+	Session-authed (any logged-in user of this bench); the client never picks the
+	user - we stamp ``frappe.session.user``. Returns how many rows were accepted.
+	Bad rows are skipped, never fatal.
+	"""
+	user = frappe.session.user
+	if not user or user == "Guest":
+		raise frappe.AuthenticationError
+
+	if isinstance(errors, str):
+		try:
+			errors = json.loads(errors)
+		except Exception:
+			return {"ok": False, "accepted": 0}
+	if not isinstance(errors, list):
+		return {"ok": False, "accepted": 0}
+
+	accepted = 0
+	for raw in errors[:MAX_ERRORS_PER_CALL]:
+		if not isinstance(raw, dict):
+			continue
+		try:
+			_ingest_one(raw, user)
+			accepted += 1
+		except Exception:
+			# One malformed row must not sink the batch.
+			frappe.logger("jarvis.client_errors").debug("client error row dropped", exc_info=True)
+	if accepted:
+		frappe.db.commit()
+	return {"ok": True, "accepted": accepted}
+
+
+def _ingest_one(raw: dict, user: str) -> None:
+	surface = (str(raw.get("surface") or "unknown"))[:40]
+	error_code = (str(raw.get("error_code") or ""))[:64]
+	error_class = (str(raw.get("error_class") or ""))[:140]
+	route = _clean_route(raw.get("route"))
+	conversation = (str(raw.get("conversation") or ""))[:140]
+	run_id = (str(raw.get("run_id") or ""))[:140]
+	message = _scrub_error_text(raw.get("message"), keep_email=user)[:MAX_MESSAGE]
+	stack = _scrub_error_text(raw.get("stack"), keep_email=user)[:MAX_STACK]
+	fp = _fingerprint(error_code, error_class, message, surface)
+
+	now = frappe.utils.now_datetime()
+	existing = frappe.db.get_value(DT, {"fingerprint": fp, "user": user, "pushed": 0}, "name")
+	if existing:
+		doc = frappe.get_doc(DT, existing)
+		doc.count = (doc.count or 1) + 1
+		doc.last_seen = now
+		doc.message = message or doc.message
+		doc.stack = stack or doc.stack
+		doc.route = route or doc.route
+		doc.save(ignore_permissions=True)
+		return
+
+	frappe.get_doc(
+		{
+			"doctype": DT,
+			"surface": surface,
+			"route": route,
+			"error_code": error_code,
+			"error_class": error_class,
+			"message": message,
+			"stack": stack,
+			"user": user,
+			"conversation": conversation,
+			"run_id": run_id,
+			"fingerprint": fp,
+			"count": 1,
+			"first_seen": now,
+			"last_seen": now,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _clean_route(route) -> str:
+	"""Path only - strip query string and fragment so ids in the URL don't ride
+	along."""
+	if not route:
+		return ""
+	r = str(route)
+	for sep in ("?", "#"):
+		r = r.split(sep, 1)[0]
+	return r[:200]
+
+
+# --------------------------------------------------------------------------- #
+# Lane 2: the Error Log reader (code-level exceptions, jarvis-only)
+# --------------------------------------------------------------------------- #
+_JARVIS_APP_MARKER = "/apps/jarvis/"
+_FRAME_RE = re.compile(r'File "([^"]+)", line \d+, in (\w+)')
+_EXC_LINE_RE = re.compile(r"^([A-Za-z_][\w.]*(?:Error|Exception|Warning|Interrupt)):?\s*(.*)$")
+
+
+def is_jarvis_error(method: str | None, traceback: str | None) -> bool:
+	"""True only for exceptions that originate in the jarvis app - so a
+	customer's ERPNext / framework / other-app errors never leave their bench.
+
+	Matches the jarvis app path in the traceback, or a ``jarvis.*`` dotted
+	``method`` title (excluding the un-installed ``jarvis_admin`` checkout)."""
+	tb = traceback or ""
+	if _JARVIS_APP_MARKER in tb:
+		return True
+	m = (method or "").strip()
+	return m.split(".", 1)[0] == "jarvis"
+
+
+def _parse_traceback(traceback: str) -> tuple[str, str, list[str]]:
+	"""Return (exc_class, exc_message, jarvis_frame_signatures) from a Python
+	traceback string."""
+	lines = [ln for ln in (traceback or "").splitlines() if ln.strip()]
+	exc_class, exc_message = "Exception", ""
+	for ln in reversed(lines):
+		m = _EXC_LINE_RE.match(ln.strip())
+		if m:
+			exc_class, exc_message = m.group(1), m.group(2)
+			break
+	frames: list[str] = []
+	for fm in _FRAME_RE.finditer(traceback or ""):
+		path, func = fm.group(1), fm.group(2)
+		if _JARVIS_APP_MARKER in path:
+			rel = path.split(_JARVIS_APP_MARKER, 1)[1]
+			frames.append(f"{rel}:{func}")
+	return exc_class, exc_message, frames
+
+
+def collect_error_log(since: str | None, limit: int = ERROR_LOG_SCAN_LIMIT) -> dict:
+	"""Read new ``Error Log`` rows after ``since``, keep only jarvis-origin ones,
+	and normalize them into the push shape.
+
+	Returns ``{"rows": [...], "watermark": <creation str or None>}``. The
+	watermark advances past EVERY scanned row (jarvis or not) so skipped
+	framework errors are never re-scanned."""
+	filters = {"creation": (">", since)} if since else {}
+	logs = frappe.get_all(
+		"Error Log",
+		filters=filters,
+		fields=["name", "method", "error", "creation"],
+		order_by="creation asc",
+		limit=limit,
+	)
+	rows: list[dict] = []
+	watermark = since
+	for log in logs:
+		watermark = str(log.creation)
+		if not is_jarvis_error(log.method, log.error):
+			continue
+		exc_class, exc_message, frames = _parse_traceback(log.error or "")
+		message = _scrub_error_text(exc_message or log.method or exc_class)[:MAX_MESSAGE]
+		rows.append(
+			{
+				"kind": "exception",
+				"surface": "server",
+				"error_code": exc_class,
+				"error_class": exc_class,
+				"message": message,
+				"stack": _scrub_error_text(log.error)[:MAX_STACK],
+				"route": (log.method or "")[:200],
+				"fingerprint": _traceback_fingerprint(exc_class, frames),
+				"occurred_at": str(log.creation),
+				"severity": "error",
+			}
+		)
+	return {"rows": rows, "watermark": watermark}

--- a/jarvis/error_push.py
+++ b/jarvis/error_push.py
@@ -1,6 +1,6 @@
 """Out-of-band push of tenant errors to the admin control plane.
 
-Modeled 1:1 on ``jarvis.chat.usage_push``: self-gating (skip self-hosted /
+Modeled on ``jarvis.chat.usage_push``: self-gating (skip self-hosted /
 un-onboarded), best-effort, and it NEVER raises into the scheduler. Runs on the
 ``*/5`` cron so the admin's Errors feed and Fleet Console badge stay fresh
 without ever touching the chat hot path.
@@ -11,15 +11,24 @@ Two sources feed one batch:
     filtered to the jarvis app by ``api_errors.collect_error_log``)
 
 Only scrubbed text is ever sent; scrubbing already happened at capture time.
+
+Unlike usage_push (a daily job), this runs every 5 min, so an admin outage
+would fire the failure path 288x/day. Two guards keep that from becoming noise:
+transient admin errors are swallowed silently, and any unexpected failure is
+logged at most once an hour (see ``push_error_rollup``). The reporter's own
+modules are also excluded from lane-2 forwarding (``api_errors.is_jarvis_error``)
+so a push failure can never be forwarded back to admin about its own outage.
 """
 
 from __future__ import annotations
+
+import time
 
 import frappe
 
 from jarvis import api_errors
 from jarvis.chat.usage_push import _admin_configured
-from jarvis.exceptions import AdminAuthError
+from jarvis.exceptions import AdminAuthError, AdminRateLimitedError, AdminUnreachableError
 
 DT = "Jarvis Client Error"
 
@@ -27,11 +36,22 @@ DT = "Jarvis Client Error"
 #: cache can't make us re-forward exceptions we already sent.
 _WATERMARK_KEY = "jarvis_error_log_watermark"
 
+#: Throttle key: hour bucket of the last unexpected-failure log.
+_LOG_THROTTLE_KEY = "jarvis_error_push_last_log_hour"
+
 #: Bounds one push. UI rows + the jarvis subset of one Error Log scan.
 UI_CAP = 200
 
-#: Delete pushed local rows older than this (daily prune).
+#: Delete forwarded local rows older than this (daily prune).
 PUSHED_RETENTION_DAYS = 7
+
+#: Delete undeliverable (still unpushed) rows older than this - if admin has been
+#: unreachable this long the buffer must not grow forever.
+UNPUSHED_RETENTION_DAYS = 30
+
+#: Hard ceiling on the unpushed buffer between daily prunes; the oldest beyond it
+#: are dropped so a failing push can't grow the table without bound.
+MAX_BUFFER_ROWS = 5000
 
 
 def push_error_rollup() -> None:
@@ -43,39 +63,72 @@ def push_error_rollup() -> None:
 			return
 		if not _admin_configured():
 			return
-
-		ui_names, ui_rows = _collect_ui_errors()
-		watermark = frappe.db.get_default(_WATERMARK_KEY) or None
-		log_result = api_errors.collect_error_log(watermark)
-		errors = ui_rows + log_result["rows"]
-		if not errors:
-			# Still advance the watermark if the scan moved it past framework noise.
-			_advance_watermark(watermark, log_result["watermark"])
-			return
-
-		from jarvis import admin_client
-
-		admin_client.push_error_rollup(errors)
-
-		# Push succeeded: retire what we sent.
-		if ui_names:
-			_mark_pushed(ui_names)
-		_advance_watermark(watermark, log_result["watermark"])
-		frappe.db.commit()
-	except AdminAuthError:
-		# Not onboarded / no admin credentials. Nothing to push; not an error.
+		_do_push()
+	except (AdminAuthError, AdminUnreachableError, AdminRateLimitedError):
+		# Not onboarded, admin down, or throttled. The claimed rows were already
+		# reverted in _do_push and the watermark did not advance, so nothing is
+		# lost. Stay silent: at */5 a logged outage is 288 rows/day.
 		return
 	except Exception:
-		frappe.log_error(
-			title="jarvis errors: rollup push failed",
-			message=frappe.get_traceback(),
-		)
+		# A genuine bug in the push path. Log it - but at most once an hour, so a
+		# persistent fault can't itself flood the local Error Log every 5 min.
+		_log_push_failure_throttled()
+
+
+def _do_push() -> None:
+	ui_names, ui_rows = _collect_ui_errors()  # CLAIMS the rows (pushed 0 -> 1)
+	watermark = frappe.db.get_default(_WATERMARK_KEY) or None
+	log_result = api_errors.collect_error_log(watermark)
+	errors = ui_rows + log_result["rows"]
+	if not errors:
+		# Nothing to send. Still advance the watermark if the scan moved it past
+		# framework noise, so we don't re-scan those rows next cycle.
+		_advance_watermark(watermark, log_result["watermark"])
+		frappe.db.commit()
+		return
+
+	from jarvis import admin_client
+
+	try:
+		admin_client.push_error_rollup(errors)
+	except Exception:
+		# Push failed: un-claim the UI rows so the next cycle re-sends them, and
+		# leave the watermark where it was. Re-raise for push_error_rollup to
+		# classify (transient -> silent, unexpected -> throttled log).
+		_revert_claim(ui_names)
+		frappe.db.commit()
+		raise
+
+	# Success: the UI rows are already marked pushed (the claim WAS the mark).
+	# Advance the Error Log watermark past what we forwarded.
+	_advance_watermark(watermark, log_result["watermark"])
+	frappe.db.commit()
 
 
 def _collect_ui_errors() -> tuple[list[str], list[dict]]:
+	"""Claim and return the current unpushed UI rows.
+
+	Claim = flip ``pushed`` 0 -> 1 up front, THEN read. This closes the
+	occurrences-lost-between-collect-and-mark window: once a row is claimed, a new
+	report of the same error folds into a fresh ``pushed=0`` row (``_ingest_one``
+	filters on ``pushed=0``) instead of a row we're about to mark sent, so its
+	count is never silently dropped. The claimed rows' counts are frozen, so what
+	we send matches what we mark sent - exactly once. On push failure the caller
+	reverts the claim (``_revert_claim``)."""
+	names = frappe.get_all(DT, filters={"pushed": 0}, order_by="last_seen asc", limit=UI_CAP, pluck="name")
+	if not names:
+		return [], []
+
+	now = frappe.utils.now_datetime()
+	placeholders = ", ".join(["%s"] * len(names))
+	frappe.db.sql(
+		f"UPDATE `tab{DT}` SET pushed = 1, pushed_at = %s WHERE name IN ({placeholders}) AND pushed = 0",
+		[now, *names],
+	)
+
 	rows = frappe.get_all(
 		DT,
-		filters={"pushed": 0},
+		filters={"name": ["in", names], "pushed": 1},
 		fields=[
 			"name",
 			"surface",
@@ -93,9 +146,7 @@ def _collect_ui_errors() -> tuple[list[str], list[dict]]:
 			"last_seen",
 		],
 		order_by="last_seen asc",
-		limit=UI_CAP,
 	)
-	names = [r.name for r in rows]
 	batch = [
 		{
 			"kind": "ui",
@@ -116,13 +167,18 @@ def _collect_ui_errors() -> tuple[list[str], list[dict]]:
 		}
 		for r in rows
 	]
-	return names, batch
+	return [r.name for r in rows], batch
 
 
-def _mark_pushed(names: list[str]) -> None:
-	now = frappe.utils.now_datetime()
-	for name in names:
-		frappe.db.set_value(DT, name, {"pushed": 1, "pushed_at": now}, update_modified=False)
+def _revert_claim(names: list[str]) -> None:
+	"""Un-claim rows a failed push had marked sent, so the next cycle retries."""
+	if not names:
+		return
+	placeholders = ", ".join(["%s"] * len(names))
+	frappe.db.sql(
+		f"UPDATE `tab{DT}` SET pushed = 0, pushed_at = NULL WHERE name IN ({placeholders}) AND pushed = 1",
+		names,
+	)
 
 
 def _advance_watermark(old: str | None, new: str | None) -> None:
@@ -130,17 +186,50 @@ def _advance_watermark(old: str | None, new: str | None) -> None:
 		frappe.db.set_default(_WATERMARK_KEY, new)
 
 
+def _log_push_failure_throttled() -> None:
+	"""Log an unexpected push failure at most once per hour. Never raises."""
+	try:
+		hour = int(time.time()) // 3600
+		if frappe.cache.get_value(_LOG_THROTTLE_KEY) == hour:
+			return
+		frappe.cache.set_value(_LOG_THROTTLE_KEY, hour, expires_in_sec=7200)
+		frappe.log_error(title="jarvis errors: rollup push failed", message=frappe.get_traceback())
+	except Exception:
+		pass
+
+
 def prune_pushed_client_errors() -> int:
-	"""Daily: delete forwarded local rows past the retention window. The durable
-	record lives in the admin's Jarvis Tenant Error, so the local buffer stays
-	small."""
-	cutoff = frappe.utils.add_days(frappe.utils.now_datetime(), -PUSHED_RETENTION_DAYS)
-	names = frappe.get_all(
-		DT,
-		filters={"pushed": 1, "pushed_at": ["<", cutoff]},
-		pluck="name",
-		limit=1000,
+	"""Daily: keep the local buffer bounded. Deletes (1) forwarded rows past the
+	retention window, (2) undeliverable unpushed rows older than a long window,
+	and (3) the oldest unpushed rows above a hard ceiling. The durable record
+	lives in the admin's Jarvis Tenant Error, so losing an old local row is fine."""
+	now = frappe.utils.now_datetime()
+	deleted = 0
+
+	pushed_cutoff = frappe.utils.add_days(now, -PUSHED_RETENTION_DAYS)
+	deleted += _delete_rows(
+		frappe.get_all(DT, filters={"pushed": 1, "pushed_at": ["<", pushed_cutoff]}, pluck="name", limit=1000)
 	)
+
+	stale_cutoff = frappe.utils.add_days(now, -UNPUSHED_RETENTION_DAYS)
+	deleted += _delete_rows(
+		frappe.get_all(DT, filters={"pushed": 0, "last_seen": ["<", stale_cutoff]}, pluck="name", limit=1000)
+	)
+
+	overflow = frappe.db.count(DT, {"pushed": 0}) - MAX_BUFFER_ROWS
+	if overflow > 0:
+		deleted += _delete_rows(
+			frappe.get_all(
+				DT, filters={"pushed": 0}, order_by="last_seen asc", limit=min(overflow, 2000), pluck="name"
+			)
+		)
+
+	if deleted:
+		frappe.db.commit()
+	return deleted
+
+
+def _delete_rows(names: list[str]) -> int:
 	deleted = 0
 	for name in names:
 		try:
@@ -148,6 +237,4 @@ def prune_pushed_client_errors() -> int:
 			deleted += 1
 		except Exception:
 			frappe.logger("jarvis.client_errors").warning(f"could not prune {name}", exc_info=True)
-	if deleted:
-		frappe.db.commit()
 	return deleted

--- a/jarvis/error_push.py
+++ b/jarvis/error_push.py
@@ -76,6 +76,13 @@ def push_error_rollup() -> None:
 
 
 def _do_push() -> None:
+	# Delivery is at-least-once, by design. The claim is NOT committed before the
+	# HTTP push, so if the worker crashes mid-push the transaction rolls back, the
+	# rows revert to pushed=0, and the next cycle re-sends. Admin accumulates with
+	# `count = count + VALUES(count)`, so a crash after admin received the batch
+	# double-counts that batch. This is the deliberate trade: re-sending (a small
+	# count inflation) beats committing the claim first, where the same crash would
+	# instead LOSE the batch. Telemetry-grade either way.
 	ui_names, ui_rows = _collect_ui_errors()  # CLAIMS the rows (pushed 0 -> 1)
 	watermark = frappe.db.get_default(_WATERMARK_KEY) or None
 	log_result = api_errors.collect_error_log(watermark)

--- a/jarvis/error_push.py
+++ b/jarvis/error_push.py
@@ -1,0 +1,153 @@
+"""Out-of-band push of tenant errors to the admin control plane.
+
+Modeled 1:1 on ``jarvis.chat.usage_push``: self-gating (skip self-hosted /
+un-onboarded), best-effort, and it NEVER raises into the scheduler. Runs on the
+``*/5`` cron so the admin's Errors feed and Fleet Console badge stay fresh
+without ever touching the chat hot path.
+
+Two sources feed one batch:
+  - unpushed ``Jarvis Client Error`` rows  (UI errors captured by the reporters)
+  - new ``Error Log`` rows past a durable watermark  (code-level exceptions,
+    filtered to the jarvis app by ``api_errors.collect_error_log``)
+
+Only scrubbed text is ever sent; scrubbing already happened at capture time.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from jarvis import api_errors
+from jarvis.chat.usage_push import _admin_configured
+from jarvis.exceptions import AdminAuthError
+
+DT = "Jarvis Client Error"
+
+#: Durable cursor (global DefaultValue) on Error Log.creation, so a lost Redis
+#: cache can't make us re-forward exceptions we already sent.
+_WATERMARK_KEY = "jarvis_error_log_watermark"
+
+#: Bounds one push. UI rows + the jarvis subset of one Error Log scan.
+UI_CAP = 200
+
+#: Delete pushed local rows older than this (daily prune).
+PUSHED_RETENTION_DAYS = 7
+
+
+def push_error_rollup() -> None:
+	"""``*/5`` scheduler entry. Self-gating + best-effort; NEVER raises."""
+	try:
+		from jarvis import selfhost
+
+		if selfhost.is_self_hosted():
+			return
+		if not _admin_configured():
+			return
+
+		ui_names, ui_rows = _collect_ui_errors()
+		watermark = frappe.db.get_default(_WATERMARK_KEY) or None
+		log_result = api_errors.collect_error_log(watermark)
+		errors = ui_rows + log_result["rows"]
+		if not errors:
+			# Still advance the watermark if the scan moved it past framework noise.
+			_advance_watermark(watermark, log_result["watermark"])
+			return
+
+		from jarvis import admin_client
+
+		admin_client.push_error_rollup(errors)
+
+		# Push succeeded: retire what we sent.
+		if ui_names:
+			_mark_pushed(ui_names)
+		_advance_watermark(watermark, log_result["watermark"])
+		frappe.db.commit()
+	except AdminAuthError:
+		# Not onboarded / no admin credentials. Nothing to push; not an error.
+		return
+	except Exception:
+		frappe.log_error(
+			title="jarvis errors: rollup push failed",
+			message=frappe.get_traceback(),
+		)
+
+
+def _collect_ui_errors() -> tuple[list[str], list[dict]]:
+	rows = frappe.get_all(
+		DT,
+		filters={"pushed": 0},
+		fields=[
+			"name",
+			"surface",
+			"route",
+			"error_code",
+			"error_class",
+			"message",
+			"stack",
+			"user",
+			"conversation",
+			"run_id",
+			"fingerprint",
+			"count",
+			"first_seen",
+			"last_seen",
+		],
+		order_by="last_seen asc",
+		limit=UI_CAP,
+	)
+	names = [r.name for r in rows]
+	batch = [
+		{
+			"kind": "ui",
+			"surface": r.surface or "unknown",
+			"route": r.route or "",
+			"error_code": r.error_code or "",
+			"error_class": r.error_class or "",
+			"message": r.message or "",
+			"stack": r.stack or "",
+			"user_ref": r.user or "",
+			"conversation_ref": r.conversation or "",
+			"run_id": r.run_id or "",
+			"fingerprint": r.fingerprint,
+			"count": int(r.count or 1),
+			"first_seen": str(r.first_seen) if r.first_seen else None,
+			"last_seen": str(r.last_seen) if r.last_seen else None,
+			"severity": "error",
+		}
+		for r in rows
+	]
+	return names, batch
+
+
+def _mark_pushed(names: list[str]) -> None:
+	now = frappe.utils.now_datetime()
+	for name in names:
+		frappe.db.set_value(DT, name, {"pushed": 1, "pushed_at": now}, update_modified=False)
+
+
+def _advance_watermark(old: str | None, new: str | None) -> None:
+	if new and new != old:
+		frappe.db.set_default(_WATERMARK_KEY, new)
+
+
+def prune_pushed_client_errors() -> int:
+	"""Daily: delete forwarded local rows past the retention window. The durable
+	record lives in the admin's Jarvis Tenant Error, so the local buffer stays
+	small."""
+	cutoff = frappe.utils.add_days(frappe.utils.now_datetime(), -PUSHED_RETENTION_DAYS)
+	names = frappe.get_all(
+		DT,
+		filters={"pushed": 1, "pushed_at": ["<", cutoff]},
+		pluck="name",
+		limit=1000,
+	)
+	deleted = 0
+	for name in names:
+		try:
+			frappe.delete_doc(DT, name, ignore_permissions=True, force=True, delete_permanently=True)
+			deleted += 1
+		except Exception:
+			frappe.logger("jarvis.client_errors").warning(f"could not prune {name}", exc_info=True)
+	if deleted:
+		frappe.db.commit()
+	return deleted

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -164,6 +164,9 @@ app_include_js = [
 	"jarvis_widget.bundle.js",
 	"jarvis_onboarding_llm.bundle.js",
 	"jarvis_onboarding_banner.bundle.js",
+	# Captures uncaught JS on the Desk Jarvis surfaces and exposes
+	# window.jarvisReportError() for caught-and-shown errors (widget / onboarding).
+	"jarvis_error_reporter.bundle.js",
 ]
 
 # Separate frappe-ui Vue SPA (apps/jarvis/frontend) served at /jarvis. The
@@ -284,6 +287,11 @@ scheduler_events = {
 			# path. Bounded per run (capacity_attempts), then the run fails honestly.
 			# Cheap no-op (one indexed status query) when nothing is parked.
 			"jarvis.chat.macros.resume_waiting_capacity_runs",
+			# Forward tenant errors (UI + jarvis-only code-level exceptions) to the
+			# admin control plane for the per-tenant Errors feed. Off the hot path,
+			# self-gating (skips self-hosted / un-onboarded), never raises. Cheap
+			# no-op when there is nothing new to push.
+			"jarvis.error_push.push_error_rollup",
 		],
 		"*/2 * * * *": [
 			"jarvis.chat.turn_recovery.recover_pending_turns",
@@ -382,6 +390,10 @@ scheduler_events = {
 		# table is append-only without this. Deletes DISABLED rows past the
 		# 90-day retention window; live credentials are never touched.
 		"jarvis.mobile.device_auth.prune_revoked_devices",
+		# Errors hygiene: delete Jarvis Client Error rows already forwarded to
+		# admin past the retention window (the durable record lives in the admin's
+		# Jarvis Tenant Error). Keeps the local buffer small.
+		"jarvis.error_push.prune_pushed_client_errors",
 	],
 	"weekly": [
 		# Wiki v2 health check: deterministic lint over Active pages

--- a/jarvis/jarvis/doctype/jarvis_client_error/jarvis_client_error.json
+++ b/jarvis/jarvis/doctype/jarvis_client_error/jarvis_client_error.json
@@ -1,0 +1,160 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-27 10:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "surface",
+  "route",
+  "error_code",
+  "error_class",
+  "message",
+  "stack",
+  "user",
+  "conversation",
+  "run_id",
+  "fingerprint",
+  "count",
+  "first_seen",
+  "last_seen",
+  "pushed",
+  "pushed_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "surface",
+   "fieldtype": "Data",
+   "label": "Surface",
+   "length": 40,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Where the error was raised: spa_chat / desk_chat / onboarding / account / pwa / unknown. Display-only."
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route",
+   "length": 200,
+   "description": "The UI route/path (query string stripped) the user was on. Never trusted for a decision."
+  },
+  {
+   "fieldname": "error_code",
+   "fieldtype": "Data",
+   "label": "Error Code",
+   "length": 64,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "description": "Classified code from the existing taxonomy (unreachable / timeout / provider / PermissionDeniedError / ...)."
+  },
+  {
+   "fieldname": "error_class",
+   "fieldtype": "Data",
+   "label": "Error Class",
+   "length": 140,
+   "description": "The JS error name / constructor (TypeError, ApiError, ...)."
+  },
+  {
+   "fieldname": "message",
+   "fieldtype": "Small Text",
+   "label": "Message",
+   "description": "Scrubbed, bounded to 500 chars. PII / ERP values are redacted before this is stored."
+  },
+  {
+   "fieldname": "stack",
+   "fieldtype": "Long Text",
+   "label": "Stack",
+   "description": "Scrubbed, bounded to 2000 chars."
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "read_only": 1,
+   "in_standard_filter": 1,
+   "description": "The reporting session user (set server-side, never from the client)."
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Data",
+   "label": "Conversation",
+   "length": 140,
+   "description": "Jarvis Conversation id when the error happened inside a chat, else empty."
+  },
+  {
+   "fieldname": "run_id",
+   "fieldtype": "Data",
+   "label": "Run ID",
+   "length": 140,
+   "description": "The chat run id for a turn failure, used to dedupe against the backend view of the same failure."
+  },
+  {
+   "fieldname": "fingerprint",
+   "fieldtype": "Data",
+   "label": "Fingerprint",
+   "length": 64,
+   "reqd": 1,
+   "search_index": 1,
+   "in_standard_filter": 1,
+   "description": "Stable dedupe key (code + class + normalized message + surface). Unpushed rows with the same fingerprint are folded into one with a count."
+  },
+  {
+   "fieldname": "count",
+   "fieldtype": "Int",
+   "label": "Count",
+   "default": "1",
+   "in_list_view": 1,
+   "description": "How many times this fingerprint has occurred in the current (not-yet-pushed) window."
+  },
+  {
+   "fieldname": "first_seen",
+   "fieldtype": "Datetime",
+   "label": "First Seen",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_seen",
+   "fieldtype": "Datetime",
+   "label": "Last Seen",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "pushed",
+   "fieldtype": "Check",
+   "label": "Pushed",
+   "default": "0",
+   "in_standard_filter": 1,
+   "description": "1 once forwarded to the admin control plane. Pushed rows are pruned by the daily job."
+  },
+  {
+   "fieldname": "pushed_at",
+   "fieldtype": "Datetime",
+   "label": "Pushed At",
+   "read_only": 1
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-27 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Jarvis",
+ "name": "Jarvis Client Error",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "write": 1,
+   "delete": 1,
+   "role": "System Manager"
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/jarvis/jarvis/doctype/jarvis_client_error/jarvis_client_error.py
+++ b/jarvis/jarvis/doctype/jarvis_client_error/jarvis_client_error.py
@@ -1,0 +1,35 @@
+"""Jarvis Client Error - local, per-bench buffer of UI errors before they are
+forwarded to the admin control plane.
+
+Rows are written only by ``jarvis.api_errors`` (browser reports) which scrubs
+message/stack of PII / ERP values before insert. This controller is a bounds
+backstop: it truncates the free-text fields and normalizes the small ones so
+nothing oversized or malformed lands in the table regardless of the caller.
+Never versioned (``track_changes: 0``) - these rows are high-churn telemetry,
+not business records.
+"""
+
+import frappe
+from frappe.model.document import Document
+
+MAX_MESSAGE = 500
+MAX_STACK = 2000
+MAX_SURFACE = 40
+MAX_ROUTE = 200
+
+
+class JarvisClientError(Document):
+	def validate(self) -> None:
+		self.message = (self.message or "").strip()[:MAX_MESSAGE]
+		self.stack = (self.stack or "").strip()[:MAX_STACK]
+		self.surface = ((self.surface or "").strip()[:MAX_SURFACE]) or "unknown"
+		self.route = (self.route or "").strip()[:MAX_ROUTE]
+		if not self.fingerprint:
+			frappe.throw("A Jarvis Client Error needs a fingerprint.")
+		if not self.count or int(self.count) < 1:
+			self.count = 1
+		now = frappe.utils.now_datetime()
+		if not self.first_seen:
+			self.first_seen = now
+		if not self.last_seen:
+			self.last_seen = now

--- a/jarvis/public/js/jarvis_chat/widget/Panel.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Panel.vue
@@ -847,6 +847,20 @@ function onRealtime(payload) {
 	const conv = payload?.conversation_id || payload?.conversation;
 	if (!conv || conv !== convId.value) return;
 
+	// A failed turn on the Desk chat widget - report it (a socket event, so the
+	// global handler never sees it). window.jarvisReportError is installed by
+	// jarvis_error_reporter.bundle.js.
+	if (payload?.kind === "run:error") {
+		window.jarvisReportError?.({
+			surface: "desk_chat",
+			error_code: payload.code || "run_error",
+			error_class: "RunError",
+			message: payload.error || "The turn failed.",
+			conversation: conv,
+			run_id: payload.run_id || "",
+		});
+	}
+
 	const { state: next, admitted } = applyEventEx(stream.value, payload);
 
 	// Only an ADMITTED frame proves the winning pump's stream is reaching us.

--- a/jarvis/public/js/jarvis_error_reporter.bundle.js
+++ b/jarvis/public/js/jarvis_error_reporter.bundle.js
@@ -37,6 +37,21 @@
 		return (e.error_code || "") + "|" + (e.error_class || "") + "|desk|" + msg;
 	}
 
+	// This bundle loads on EVERY Desk page (app_include_js), but must only forward
+	// JARVIS errors - an ERPNext / HRMS / client-script error on a plain Desk form
+	// must never cross to the control plane. An error is Jarvis-origin if it came
+	// from a Jarvis asset (the chat widget, injected everywhere, always shows one
+	// in its stack) or fired on a full-page Jarvis Desk surface. Explicit
+	// window.jarvisReportError() calls skip this gate - they are Jarvis by
+	// construction (only Jarvis code calls it).
+	function isJarvisOrigin(ev, err) {
+		var file = (ev && ev.filename) || "";
+		var stack = (err && err.stack) || "";
+		if (/\/assets\/jarvis\//.test(file) || /\/assets\/jarvis\//.test(stack)) return true;
+		var path = (location && location.pathname) || "";
+		return /jarvis/i.test(path);
+	}
+
 	function csrf() {
 		try {
 			return (window.frappe && frappe.csrf_token) || window.csrf_token || "";
@@ -101,6 +116,7 @@
 
 	window.addEventListener("error", function (ev) {
 		var err = ev && ev.error;
+		if (!isJarvisOrigin(ev, err)) return; // scope: Jarvis Desk surfaces only
 		report({
 			error_class: (err && err.name) || "Error",
 			error_code: "uncaught",
@@ -110,6 +126,7 @@
 	});
 	window.addEventListener("unhandledrejection", function (ev) {
 		var r = ev && ev.reason;
+		if (!isJarvisOrigin(null, r)) return; // scope: Jarvis Desk surfaces only
 		report({
 			error_class: (r && r.name) || "UnhandledRejection",
 			error_code: "unhandledrejection",

--- a/jarvis/public/js/jarvis_error_reporter.bundle.js
+++ b/jarvis/public/js/jarvis_error_reporter.bundle.js
@@ -1,0 +1,124 @@
+// Desk error reporter - the vanilla twin of frontend/src/lib/errorReporter.js.
+// Loaded on every Desk page via app_include_js. Captures uncaught JS errors on
+// the Desk-embedded Jarvis surfaces (onboarding wizard, account, chat widget)
+// and forwards them, scrubbed on the bench, to the Jarvis admin. Desk XHR /
+// server failures already land in Frappe's Error Log and are forwarded from
+// there; this covers the browser-side gap. Exposes window.jarvisReportError()
+// so the widget / onboarding page can report the errors they catch and show
+// (which are not thrown, so the global handlers never see them).
+(function () {
+	if (window.__jarvisErrorReporter) return;
+
+	var ENDPOINT = "/api/method/jarvis.api_errors.report_client_errors";
+	var MAX_PER_SESSION = 100;
+	var MAX_QUEUE = 50;
+	var DEBOUNCE_MS = 4000;
+
+	var sent = 0;
+	var queue = [];
+	var seen = {};
+	var timer = null;
+	var reporting = false;
+
+	var BENIGN = [
+		/ResizeObserver loop/i,
+		/Failed to fetch dynamically imported module/i,
+		/Loading chunk \d+ failed/i,
+	];
+
+	function benign(t) {
+		if (!t) return false;
+		for (var i = 0; i < BENIGN.length; i++) if (BENIGN[i].test(t)) return true;
+		return false;
+	}
+
+	function fingerprint(e) {
+		var msg = (e.message || "").replace(/\d+/g, "#").slice(0, 200);
+		return (e.error_code || "") + "|" + (e.error_class || "") + "|desk|" + msg;
+	}
+
+	function csrf() {
+		try {
+			return (window.frappe && frappe.csrf_token) || window.csrf_token || "";
+		} catch (_) {
+			return "";
+		}
+	}
+
+	function report(ctx) {
+		try {
+			ctx = ctx || {};
+			if (reporting || sent >= MAX_PER_SESSION) return;
+			var message = String(ctx.message || "").slice(0, 2000);
+			if (benign(message) || benign(ctx.stack)) return;
+			var e = {
+				surface: ctx.surface || "desk",
+				route: ctx.route || (location ? location.pathname : ""),
+				error_code: String(ctx.error_code || "").slice(0, 64),
+				error_class: String(ctx.error_class || ctx.name || "").slice(0, 140),
+				message: message,
+				stack: String(ctx.stack || "").slice(0, 4000),
+				conversation: String(ctx.conversation || "").slice(0, 140),
+				run_id: String(ctx.run_id || "").slice(0, 140),
+			};
+			var fp = fingerprint(e);
+			if (seen[fp] || queue.length >= MAX_QUEUE) return;
+			seen[fp] = 1;
+			queue.push(e);
+			if (!timer) {
+				timer = setTimeout(function () {
+					timer = null;
+					flush();
+				}, DEBOUNCE_MS);
+			}
+		} catch (_) {
+			/* a reporter that throws is worse than a missing report */
+		}
+	}
+
+	function flush() {
+		if (!queue.length || reporting) return;
+		var batch = queue.splice(0, MAX_QUEUE);
+		seen = {};
+		reporting = true;
+		fetch(ENDPOINT, {
+			method: "POST",
+			credentials: "include",
+			headers: { "Content-Type": "application/json", "X-Frappe-CSRF-Token": csrf() },
+			body: JSON.stringify({ errors: batch }),
+			keepalive: true,
+		})
+			.then(function (res) {
+				if (res.ok) sent += batch.length;
+			})
+			.catch(function () {
+				/* best-effort telemetry - drop on failure */
+			})
+			.then(function () {
+				reporting = false;
+			});
+	}
+
+	window.addEventListener("error", function (ev) {
+		var err = ev && ev.error;
+		report({
+			error_class: (err && err.name) || "Error",
+			error_code: "uncaught",
+			message: (err && err.message) || (ev && ev.message) || "Uncaught error",
+			stack: err && err.stack,
+		});
+	});
+	window.addEventListener("unhandledrejection", function (ev) {
+		var r = ev && ev.reason;
+		report({
+			error_class: (r && r.name) || "UnhandledRejection",
+			error_code: "unhandledrejection",
+			message: (r && r.message) || String(r),
+			stack: r && r.stack,
+		});
+	});
+	window.addEventListener("pagehide", flush);
+
+	window.jarvisReportError = report;
+	window.__jarvisErrorReporter = true;
+})();

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import admin_client, api_errors, error_push, selfhost
+from jarvis import api_errors, error_push
 
 DT = api_errors.DT
 USER = "apierr-user@example.com"
@@ -302,7 +302,15 @@ class TestErrorLogReader(ApiErrorsBase):
 # Push job — self-gating + never-raise
 # --------------------------------------------------------------------------- #
 class TestPushSelfGates(ApiErrorsBase):
+	# NB: import selfhost / admin_client at execution time (inside each method),
+	# not at module top. A top-level `from jarvis import selfhost` runs during
+	# test collection, where it hit a circular-import ordering only in CI; by the
+	# time a test method runs the app is fully booted and the import is safe. We
+	# then patch.object the imported module (not a dotted string), which also
+	# sidesteps py3.14's mock.patch no longer auto-importing string targets.
 	def test_skips_when_self_hosted(self):
+		from jarvis import admin_client, selfhost
+
 		with (
 			patch.object(selfhost, "is_self_hosted", return_value=True),
 			patch.object(admin_client, "push_error_rollup") as push,
@@ -311,6 +319,8 @@ class TestPushSelfGates(ApiErrorsBase):
 		push.assert_not_called()
 
 	def test_skips_when_admin_unconfigured(self):
+		from jarvis import admin_client, selfhost
+
 		with (
 			patch.object(selfhost, "is_self_hosted", return_value=False),
 			patch.object(error_push, "_admin_configured", return_value=False),
@@ -320,6 +330,8 @@ class TestPushSelfGates(ApiErrorsBase):
 		push.assert_not_called()
 
 	def test_never_raises(self):
+		from jarvis import selfhost
+
 		with (
 			patch.object(selfhost, "is_self_hosted", side_effect=RuntimeError("boom")),
 		):
@@ -337,7 +349,10 @@ class TestPushClaimConfirm(ApiErrorsBase):
 
 	def _run_push(self, push_impl):
 		"""Run push_error_rollup with the admin push replaced by ``push_impl``
-		(a Mock or a plain callable)."""
+		(a Mock or a plain callable). selfhost / admin_client are imported here (at
+		execution time) - see the note on TestPushSelfGates."""
+		from jarvis import admin_client, selfhost
+
 		with (
 			patch.object(selfhost, "is_self_hosted", return_value=False),
 			patch.object(error_push, "_admin_configured", return_value=True),

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -1,0 +1,218 @@
+"""Tenant error capture: scrubbing, fingerprinting, the report endpoint, the
+jarvis-only Error Log reader, and the self-gating push."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis import api_errors, error_push
+
+DT = api_errors.DT
+USER = "apierr-user@example.com"
+
+
+@contextlib.contextmanager
+def _as(user: str):
+	orig = frappe.session.user
+	frappe.set_user(user)
+	try:
+		yield
+	finally:
+		frappe.set_user(orig)
+
+
+class ApiErrorsBase(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		if not frappe.db.exists("User", USER):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": USER,
+					"first_name": "apierr",
+					"send_welcome_email": 0,
+					"user_type": "System User",
+				}
+			).insert(ignore_permissions=True)
+
+	def setUp(self):
+		super().setUp()
+		frappe.db.delete(DT)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete(DT)
+		frappe.db.commit()
+		super().tearDown()
+
+
+# --------------------------------------------------------------------------- #
+# Scrubbing
+# --------------------------------------------------------------------------- #
+class TestScrub(ApiErrorsBase):
+	def test_redacts_data_keeps_taxonomy(self):
+		text = (
+			"PermissionDeniedError: user other@corp.com cannot read invoice 'ACME Corp Pvt Ltd' "
+			"balance 42.50 token=sk-abcdef1234567890abcdef hash 0123456789abcdef0123456789abcdef"
+		)
+		out = api_errors._scrub_error_text(text, keep_email=USER)
+		# taxonomy / structure survives
+		self.assertIn("PermissionDeniedError", out)
+		# values are gone
+		self.assertNotIn("other@corp.com", out)
+		self.assertNotIn("42.50", out)
+		self.assertNotIn("sk-abcdef1234567890abcdef", out)
+		self.assertNotIn("0123456789abcdef0123456789abcdef", out)
+
+	def test_keeps_the_reporting_users_own_email(self):
+		out = api_errors._scrub_error_text(f"failed for {USER}", keep_email=USER)
+		self.assertIn(USER, out)
+
+	def test_empty_is_safe(self):
+		self.assertEqual(api_errors._scrub_error_text(None), "")
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprint
+# --------------------------------------------------------------------------- #
+class TestFingerprint(ApiErrorsBase):
+	def test_digits_normalized_so_similar_errors_group(self):
+		a = api_errors._fingerprint("run_error", "RunError", "42 units missing", "spa_chat")
+		b = api_errors._fingerprint("run_error", "RunError", "7 units missing", "spa_chat")
+		self.assertEqual(a, b)
+
+	def test_different_class_or_surface_splits(self):
+		a = api_errors._fingerprint("run_error", "RunError", "boom", "spa_chat")
+		b = api_errors._fingerprint("run_error", "RunError", "boom", "onboarding")
+		self.assertNotEqual(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# report_client_errors
+# --------------------------------------------------------------------------- #
+class TestReportEndpoint(ApiErrorsBase):
+	def test_inserts_and_dedupes(self):
+		# Messages differing only by digits normalize to one fingerprint (the same
+		# error recurring with a different number), so they fold into one row.
+		row = {
+			"surface": "spa_chat",
+			"error_code": "run_error",
+			"error_class": "RunError",
+			"message": "the run failed after 3 tries",
+			"route": "/c/abc?x=1",
+		}
+		with _as(USER):
+			r1 = api_errors.report_client_errors([row])
+			r2 = api_errors.report_client_errors([dict(row, message="the run failed after 8 tries")])
+		self.assertEqual(r1["accepted"], 1)
+		self.assertEqual(r2["accepted"], 1)
+		rows = frappe.get_all(DT, filters={"user": USER}, fields=["name", "count", "route", "message"])
+		self.assertEqual(len(rows), 1, "same fingerprint must fold into one row")
+		self.assertEqual(rows[0].count, 2)
+		self.assertEqual(rows[0].route, "/c/abc", "query string stripped")
+		self.assertIn("8 tries", rows[0].message, "the newest sample overwrites")
+
+	def test_different_word_is_a_different_group(self):
+		with _as(USER):
+			api_errors.report_client_errors([{"surface": "spa", "error_code": "e", "message": "disk full"}])
+			api_errors.report_client_errors(
+				[{"surface": "spa", "error_code": "e", "message": "network down"}]
+			)
+		self.assertEqual(frappe.db.count(DT, {"user": USER}), 2)
+
+	def test_scrubs_before_store(self):
+		with _as(USER):
+			api_errors.report_client_errors(
+				[{"surface": "spa_chat", "error_code": "x", "message": "amount 99.99 for other@corp.com"}]
+			)
+		msg = frappe.get_all(DT, filters={"user": USER}, pluck="message")[0]
+		self.assertNotIn("99.99", msg)
+		self.assertNotIn("other@corp.com", msg)
+
+	def test_guest_refused(self):
+		with _as("Guest"), self.assertRaises(frappe.AuthenticationError):
+			api_errors.report_client_errors([{"message": "x"}])
+
+	def test_json_string_body_accepted(self):
+		with _as(USER):
+			r = api_errors.report_client_errors('[{"surface":"pwa","error_code":"c","message":"m"}]')
+		self.assertEqual(r["accepted"], 1)
+
+	def test_bad_rows_do_not_sink_the_batch(self):
+		with _as(USER):
+			r = api_errors.report_client_errors([None, "nope", {"surface": "spa", "message": "ok"}])
+		self.assertEqual(r["accepted"], 1)
+
+
+# --------------------------------------------------------------------------- #
+# Error Log reader — jarvis-only
+# --------------------------------------------------------------------------- #
+class TestErrorLogReader(ApiErrorsBase):
+	def test_is_jarvis_error(self):
+		self.assertTrue(api_errors.is_jarvis_error("jarvis.chat.api.send_message", ""))
+		self.assertTrue(api_errors.is_jarvis_error("", 'File "/x/apps/jarvis/jarvis/api.py", line 3, in f'))
+		self.assertFalse(api_errors.is_jarvis_error("erpnext.stock.get_stock", ""))
+		self.assertFalse(api_errors.is_jarvis_error("frappe.model.document.save", "no app path"))
+
+	def test_collect_filters_to_jarvis_and_advances_watermark(self):
+		jtb = (
+			"Traceback (most recent call last):\n"
+			'  File "/home/x/apps/jarvis/jarvis/chat/api.py", line 10, in send_message\n'
+			"    boom()\n"
+			"ValueError: bad thing 4242"
+		)
+		etb = (
+			"Traceback (most recent call last):\n"
+			'  File "/home/x/apps/erpnext/erpnext/stock/x.py", line 5, in get\n'
+			"    boom()\n"
+			"KeyError: nope"
+		)
+		j = frappe.get_doc({"doctype": "Error Log", "method": "jarvis.chat.api.send_message", "error": jtb})
+		j.insert(ignore_permissions=True)
+		e = frappe.get_doc({"doctype": "Error Log", "method": "erpnext.stock.x.get", "error": etb})
+		e.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+		result = api_errors.collect_error_log(since=None, limit=500)
+		classes = [r["error_class"] for r in result["rows"]]
+		self.assertIn("ValueError", classes)
+		self.assertNotIn("KeyError", classes, "an ERPNext exception must never be forwarded")
+		# a forwarded jarvis row is scrubbed (the digits in the message are gone)
+		vrow = next(r for r in result["rows"] if r["error_class"] == "ValueError")
+		self.assertNotIn("4242", vrow["message"])
+		self.assertEqual(vrow["kind"], "exception")
+		self.assertIsNotNone(result["watermark"])
+
+
+# --------------------------------------------------------------------------- #
+# Push job — self-gating + never-raise
+# --------------------------------------------------------------------------- #
+class TestPushSelfGates(ApiErrorsBase):
+	def test_skips_when_self_hosted(self):
+		with (
+			patch("jarvis.selfhost.is_self_hosted", return_value=True),
+			patch("jarvis.admin_client.push_error_rollup") as push,
+		):
+			error_push.push_error_rollup()
+		push.assert_not_called()
+
+	def test_skips_when_admin_unconfigured(self):
+		with (
+			patch("jarvis.selfhost.is_self_hosted", return_value=False),
+			patch("jarvis.error_push._admin_configured", return_value=False),
+			patch("jarvis.admin_client.push_error_rollup") as push,
+		):
+			error_push.push_error_rollup()
+		push.assert_not_called()
+
+	def test_never_raises(self):
+		with (
+			patch("jarvis.selfhost.is_self_hosted", side_effect=RuntimeError("boom")),
+		):
+			# Must swallow and log, not propagate.
+			error_push.push_error_rollup()

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -4,7 +4,8 @@ jarvis-only Error Log reader, and the self-gating push."""
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import patch
+import time
+from unittest.mock import Mock, patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -68,6 +69,25 @@ class TestScrub(ApiErrorsBase):
 		self.assertNotIn("42.50", out)
 		self.assertNotIn("sk-abcdef1234567890abcdef", out)
 		self.assertNotIn("0123456789abcdef0123456789abcdef", out)
+		# a short, alphabetic *quoted* entity name is gone too (the old length/
+		# digit heuristic left these behind)
+		self.assertNotIn("ACME", out)
+
+	def test_removes_bare_unquoted_entity_names(self):
+		# The blocking finding: ERP messages interpolate entity names bare
+		# (frappe.throw(_("...{0}...").format(name))), so they are neither quoted
+		# nor numeric and no value regex catches them. A capitalised multi-word run
+		# must be redacted.
+		for text, leaked in (
+			("Could not find Customer: 'Tata Steel Ltd'", "Tata Steel"),
+			("Employee Priya Sharma has base salary 85000", "Priya Sharma"),
+			("Item Titanium Rod not available for Supplier Reliance Industries", "Reliance Industries"),
+			('customer_name "Bharat Petroleum"', "Bharat Petroleum"),
+		):
+			out = api_errors._scrub_error_text(text)
+			self.assertNotIn(leaked, out, f"entity name leaked: {out!r}")
+		# a single-token CamelCase exception class is NOT a run, so it survives
+		self.assertIn("ValidationError", api_errors._scrub_error_text("ValidationError: rejected"))
 
 	def test_keeps_the_reporting_users_own_email(self):
 		out = api_errors._scrub_error_text(f"failed for {USER}", keep_email=USER)
@@ -148,6 +168,57 @@ class TestReportEndpoint(ApiErrorsBase):
 			r = api_errors.report_client_errors([None, "nope", {"surface": "spa", "message": "ok"}])
 		self.assertEqual(r["accepted"], 1)
 
+	def test_drops_non_jarvis_origin_desk_error(self):
+		# A stray ERPNext Desk error (positive non-jarvis asset marker in the raw
+		# stack, no jarvis marker) is filtered server-side, not stored/forwarded.
+		with _as(USER):
+			r = api_errors.report_client_errors(
+				[
+					{
+						"surface": "desk",
+						"error_code": "uncaught",
+						"message": "boom",
+						"stack": "at handler (/assets/erpnext/js/erpnext.bundle.js:1:2)",
+					}
+				]
+			)
+		self.assertEqual(r["accepted"], 0)
+		self.assertEqual(frappe.db.count(DT, {"user": USER}), 0)
+
+	def test_keeps_jarvis_origin_desk_error(self):
+		# Same shape, but the stack points at a jarvis asset -> kept.
+		with _as(USER):
+			r = api_errors.report_client_errors(
+				[
+					{
+						"surface": "desk",
+						"error_code": "uncaught",
+						"message": "boom",
+						"stack": "at handler (/assets/jarvis/js/jarvis_widget.bundle.js:1:2)",
+					}
+				]
+			)
+		self.assertEqual(r["accepted"], 1)
+		self.assertEqual(frappe.db.count(DT, {"user": USER}), 1)
+
+	def test_rate_limit_throttles_past_the_cap(self):
+		# The endpoint short-circuits the limiter under frappe.flags.in_test, so
+		# exercise the bucket directly with the flag flipped off.
+		probe = "ratelimit-probe@example.com"
+		bucket = int(time.time()) // 60
+		# incrby uses the raw redis key, so clear with delete() (not delete_value).
+		key = f"jarvis.client_error_report.{probe}.{bucket}"
+		frappe.cache.delete(key)
+		orig = frappe.flags.in_test
+		frappe.flags.in_test = False
+		try:
+			for _ in range(api_errors.REPORT_RATE_PER_MIN):
+				self.assertFalse(api_errors._over_report_rate_limit(probe))
+			self.assertTrue(api_errors._over_report_rate_limit(probe), "the (N+1)th call is throttled")
+		finally:
+			frappe.flags.in_test = orig
+			frappe.cache.delete(key)
+
 
 # --------------------------------------------------------------------------- #
 # Error Log reader — jarvis-only
@@ -158,6 +229,14 @@ class TestErrorLogReader(ApiErrorsBase):
 		self.assertTrue(api_errors.is_jarvis_error("", 'File "/x/apps/jarvis/jarvis/api.py", line 3, in f'))
 		self.assertFalse(api_errors.is_jarvis_error("erpnext.stock.get_stock", ""))
 		self.assertFalse(api_errors.is_jarvis_error("frappe.model.document.save", "no app path"))
+
+	def test_reporter_own_failures_are_not_forwarded(self):
+		# The push job / endpoint failing must NOT feed back to admin about its own
+		# outage - otherwise a */5 admin outage floods the feed once admin returns.
+		push_tb = 'File "/x/apps/jarvis/jarvis/error_push.py", line 60, in push_error_rollup'
+		self.assertFalse(api_errors.is_jarvis_error("jarvis errors: rollup push failed", push_tb))
+		endpoint_tb = 'File "/x/apps/jarvis/jarvis/api_errors.py", line 40, in report_client_errors'
+		self.assertFalse(api_errors.is_jarvis_error("", endpoint_tb))
 
 	def test_collect_filters_to_jarvis_and_advances_watermark(self):
 		jtb = (
@@ -216,3 +295,54 @@ class TestPushSelfGates(ApiErrorsBase):
 		):
 			# Must swallow and log, not propagate.
 			error_push.push_error_rollup()
+
+
+# --------------------------------------------------------------------------- #
+# Push job — claim / confirm / revert (occurrences never lost, outage safe)
+# --------------------------------------------------------------------------- #
+class TestPushClaimConfirm(ApiErrorsBase):
+	def _seed(self, message="boom"):
+		with _as(USER):
+			api_errors.report_client_errors([{"surface": "spa", "error_code": "e", "message": message}])
+
+	def _run_push(self, push_impl):
+		"""Run push_error_rollup with the admin push replaced by ``push_impl``
+		(a Mock or a plain callable)."""
+		with (
+			patch("jarvis.selfhost.is_self_hosted", return_value=False),
+			patch("jarvis.error_push._admin_configured", return_value=True),
+			patch("jarvis.admin_client.push_error_rollup", push_impl),
+		):
+			error_push.push_error_rollup()
+
+	def test_success_marks_pushed(self):
+		self._seed()
+		push = Mock()
+		self._run_push(push)
+		push.assert_called_once()
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 0, "claimed + sent")
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 1)
+
+	def test_failed_push_reverts_claim(self):
+		from jarvis.exceptions import AdminUnreachableError
+
+		self._seed()
+		# Must not raise; the claimed row is reverted for the next cycle.
+		self._run_push(Mock(side_effect=AdminUnreachableError("down")))
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 1)
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 0)
+
+	def test_occurrence_arriving_after_claim_is_not_lost(self):
+		self._seed("window boom")
+
+		def _during_push(errors):
+			# Same error reported again mid-flight: it must land in a FRESH pushed=0
+			# row (it can't fold into the already-claimed one), so its count lives.
+			with _as(USER):
+				api_errors.report_client_errors(
+					[{"surface": "spa", "error_code": "e", "message": "window boom"}]
+				)
+
+		self._run_push(_during_push)
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 1, "original sent once")
+		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 1, "mid-flight occurrence kept")

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis import api_errors, error_push
+from jarvis import admin_client, api_errors, error_push, selfhost
 
 DT = api_errors.DT
 USER = "apierr-user@example.com"
@@ -304,24 +304,24 @@ class TestErrorLogReader(ApiErrorsBase):
 class TestPushSelfGates(ApiErrorsBase):
 	def test_skips_when_self_hosted(self):
 		with (
-			patch("jarvis.selfhost.is_self_hosted", return_value=True),
-			patch("jarvis.admin_client.push_error_rollup") as push,
+			patch.object(selfhost, "is_self_hosted", return_value=True),
+			patch.object(admin_client, "push_error_rollup") as push,
 		):
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_skips_when_admin_unconfigured(self):
 		with (
-			patch("jarvis.selfhost.is_self_hosted", return_value=False),
-			patch("jarvis.error_push._admin_configured", return_value=False),
-			patch("jarvis.admin_client.push_error_rollup") as push,
+			patch.object(selfhost, "is_self_hosted", return_value=False),
+			patch.object(error_push, "_admin_configured", return_value=False),
+			patch.object(admin_client, "push_error_rollup") as push,
 		):
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_never_raises(self):
 		with (
-			patch("jarvis.selfhost.is_self_hosted", side_effect=RuntimeError("boom")),
+			patch.object(selfhost, "is_self_hosted", side_effect=RuntimeError("boom")),
 		):
 			# Must swallow and log, not propagate.
 			error_push.push_error_rollup()
@@ -339,9 +339,9 @@ class TestPushClaimConfirm(ApiErrorsBase):
 		"""Run push_error_rollup with the admin push replaced by ``push_impl``
 		(a Mock or a plain callable)."""
 		with (
-			patch("jarvis.selfhost.is_self_hosted", return_value=False),
-			patch("jarvis.error_push._admin_configured", return_value=True),
-			patch("jarvis.admin_client.push_error_rollup", push_impl),
+			patch.object(selfhost, "is_self_hosted", return_value=False),
+			patch.object(error_push, "_admin_configured", return_value=True),
+			patch.object(admin_client, "push_error_rollup", push_impl),
 		):
 			error_push.push_error_rollup()
 

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -89,6 +89,14 @@ class TestScrub(ApiErrorsBase):
 		# a single-token CamelCase exception class is NOT a run, so it survives
 		self.assertIn("ValidationError", api_errors._scrub_error_text("ValidationError: rejected"))
 
+	def test_redacts_id_shaped_tokens(self):
+		# Fixed-width alphanumeric IDs (GSTIN/PAN/serials) mixing letters and digits
+		# are ERP identifiers, not taxonomy - they must not ride along.
+		out = api_errors._scrub_error_text("filing for GSTIN 27AAPFU0939F1ZV was rejected")
+		self.assertNotIn("27AAPFU0939F1ZV", out)
+		# a pure-letter token (an exception class) has no digit and survives
+		self.assertIn("PermissionDeniedError", api_errors._scrub_error_text("PermissionDeniedError: no"))
+
 	def test_keeps_the_reporting_users_own_email(self):
 		out = api_errors._scrub_error_text(f"failed for {USER}", keep_email=USER)
 		self.assertIn(USER, out)
@@ -136,6 +144,24 @@ class TestReportEndpoint(ApiErrorsBase):
 		self.assertEqual(rows[0].count, 2)
 		self.assertEqual(rows[0].route, "/c/abc", "query string stripped")
 		self.assertIn("8 tries", rows[0].message, "the newest sample overwrites")
+
+	def test_fingerprint_uses_raw_message_not_scrubbed(self):
+		# Two different entity names scrub to the SAME text ("Missing [NAME]") but
+		# are different errors. Fingerprinting the RAW message keeps them distinct
+		# AND decouples grouping from redaction policy, so a future scrubber tweak
+		# never re-keys the admin feed (N6).
+		with _as(USER):
+			api_errors.report_client_errors(
+				[{"surface": "spa", "error_code": "e", "message": "Missing Tata Steel Ltd"}]
+			)
+			api_errors.report_client_errors(
+				[{"surface": "spa", "error_code": "e", "message": "Missing Reliance Industries"}]
+			)
+		self.assertEqual(frappe.db.count(DT, {"user": USER}), 2, "distinct raw messages stay distinct groups")
+		# ...and both stored copies are scrubbed (the names never land on disk).
+		for msg in frappe.get_all(DT, filters={"user": USER}, pluck="message"):
+			self.assertNotIn("Tata Steel", msg)
+			self.assertNotIn("Reliance Industries", msg)
 
 	def test_different_word_is_a_different_group(self):
 		with _as(USER):
@@ -203,18 +229,22 @@ class TestReportEndpoint(ApiErrorsBase):
 
 	def test_rate_limit_throttles_past_the_cap(self):
 		# The endpoint short-circuits the limiter under frappe.flags.in_test, so
-		# exercise the bucket directly with the flag flipped off.
+		# exercise the bucket directly with the flag flipped off. The clock is
+		# FROZEN so the calendar-minute bucket cannot roll mid-loop (otherwise the
+		# (N+1)th call would land in a fresh bucket and spuriously pass).
 		probe = "ratelimit-probe@example.com"
-		bucket = int(time.time()) // 60
-		# incrby uses the raw redis key, so clear with delete() (not delete_value).
-		key = f"jarvis.client_error_report.{probe}.{bucket}"
+		frozen = 1_800_000_000  # fixed epoch
+		bucket = frozen // 60
+		# incrby uses the raw redis key, site-prefixed; clear with delete().
+		key = f"{frappe.local.site}:jarvis.client_error_report.{probe}.{bucket}"
 		frappe.cache.delete(key)
 		orig = frappe.flags.in_test
 		frappe.flags.in_test = False
 		try:
-			for _ in range(api_errors.REPORT_RATE_PER_MIN):
-				self.assertFalse(api_errors._over_report_rate_limit(probe))
-			self.assertTrue(api_errors._over_report_rate_limit(probe), "the (N+1)th call is throttled")
+			with patch("jarvis.api_errors.time.time", return_value=frozen):
+				for _ in range(api_errors.REPORT_RATE_PER_MIN):
+					self.assertFalse(api_errors._over_report_rate_limit(probe))
+				self.assertTrue(api_errors._over_report_rate_limit(probe), "the (N+1)th call is throttled")
 		finally:
 			frappe.flags.in_test = orig
 			frappe.cache.delete(key)

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -99,12 +99,16 @@ class TestScrub(ApiErrorsBase):
 		self.assertIn("ValidationError", api_errors._scrub_error_text("ValidationError: rejected"))
 
 	def test_redacts_id_shaped_tokens(self):
-		# Fixed-width alphanumeric IDs (GSTIN/PAN/serials) mixing letters and digits
-		# are ERP identifiers, not taxonomy - they must not ride along.
+		# Fixed-width UPPERCASE alphanumeric IDs (GSTIN/PAN/serials) are ERP
+		# identifiers, not taxonomy - they must not ride along.
 		out = api_errors._scrub_error_text("filing for GSTIN 27AAPFU0939F1ZV was rejected")
 		self.assertNotIn("27AAPFU0939F1ZV", out)
 		# a pure-letter token (an exception class) has no digit and survives
 		self.assertIn("PermissionDeniedError", api_errors._scrub_error_text("PermissionDeniedError: no"))
+		# a CamelCase class name that HAPPENS to carry a digit has a lowercase run,
+		# so it is not ID-shaped and survives (R2 - taxonomy must not be eaten).
+		for cls in ("OAuth2Error", "Base64DecodeError", "Http404Error", "S3UploadError"):
+			self.assertIn(cls, api_errors._scrub_error_text(f"raised {cls} in handler"), cls)
 
 	def test_keeps_the_reporting_users_own_email(self):
 		out = api_errors._scrub_error_text(f"failed for {USER}", keep_email=USER)
@@ -154,11 +158,11 @@ class TestReportEndpoint(ApiErrorsBase):
 		self.assertEqual(rows[0].route, "/c/abc", "query string stripped")
 		self.assertIn("8 tries", rows[0].message, "the newest sample overwrites")
 
-	def test_fingerprint_uses_raw_message_not_scrubbed(self):
-		# Two different entity names scrub to the SAME text ("Missing [NAME]") but
-		# are different errors. Fingerprinting the RAW message keeps them distinct
-		# AND decouples grouping from redaction policy, so a future scrubber tweak
-		# never re-keys the admin feed (N6).
+	def test_fingerprint_groups_by_scrubbed_message(self):
+		# Different entity names in the SAME error shape scrub to the same text
+		# ("Missing [NAME]") and MUST fold into one group - otherwise one bug across
+		# N customers becomes N rows at count=1 (R1). Grouping keys on the scrubbed
+		# message; _SCRUB_VERSION makes a future scrubber change a deliberate re-key.
 		with _as(USER):
 			api_errors.report_client_errors(
 				[{"surface": "spa", "error_code": "e", "message": "Missing Tata Steel Ltd"}]
@@ -166,11 +170,12 @@ class TestReportEndpoint(ApiErrorsBase):
 			api_errors.report_client_errors(
 				[{"surface": "spa", "error_code": "e", "message": "Missing Reliance Industries"}]
 			)
-		self.assertEqual(frappe.db.count(DT, {"user": USER}), 2, "distinct raw messages stay distinct groups")
-		# ...and both stored copies are scrubbed (the names never land on disk).
-		for msg in frappe.get_all(DT, filters={"user": USER}, pluck="message"):
-			self.assertNotIn("Tata Steel", msg)
-			self.assertNotIn("Reliance Industries", msg)
+		rows = frappe.get_all(DT, filters={"user": USER}, fields=["count", "message"])
+		self.assertEqual(len(rows), 1, "same error shape, different names -> one group")
+		self.assertEqual(rows[0].count, 2, "occurrences accumulate")
+		# ...and the stored copy is scrubbed (the names never land on disk).
+		self.assertNotIn("Tata Steel", rows[0].message)
+		self.assertNotIn("Reliance Industries", rows[0].message)
 
 	def test_different_word_is_a_different_group(self):
 		with _as(USER):
@@ -313,8 +318,21 @@ class TestErrorLogReader(ApiErrorsBase):
 class TestPushSelfGates(ApiErrorsBase):
 	# Drive is_self_hosted() through its real input (deployment_mode) and patch
 	# only the importable admin_client / error_push seams - never jarvis.selfhost.
+	def _pin_deployment_mode(self, mode):
+		# ApiErrorsBase.tearDown commits, which defeats FrappeTestCase's rollback -
+		# so a change to this shared Single would leak Self-Hosted into every later
+		# file in the shard (is_self_hosted() gates real behaviour). Restore it.
+		prev = frappe.db.get_single_value("Jarvis Settings", "deployment_mode") or "Managed"
+
+		def restore():
+			frappe.db.set_single_value("Jarvis Settings", "deployment_mode", prev)
+			frappe.db.commit()
+
+		self.addCleanup(restore)
+		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", mode)
+
 	def test_skips_when_self_hosted(self):
-		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", "Self-Hosted")
+		self._pin_deployment_mode("Self-Hosted")
 		from jarvis import admin_client
 
 		with patch.object(admin_client, "push_error_rollup") as push:
@@ -322,7 +340,7 @@ class TestPushSelfGates(ApiErrorsBase):
 		push.assert_not_called()
 
 	def test_skips_when_admin_unconfigured(self):
-		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", "Managed")
+		self._pin_deployment_mode("Managed")
 		from jarvis import admin_client
 
 		with (

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -10,15 +10,16 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-# Import selfhost + admin_client BEFORE api_errors / error_push. Those two pull in
-# a large chat-module chain, and in some CI shard collection orders (py3.14)
-# importing selfhost partway through that chain leaves it half-initialised
-# ("cannot import name 'selfhost' from 'jarvis'"). Importing them first - like
-# test_selfhost.py, which has no heavy chain ahead of it - puts a complete module
-# in sys.modules for the patch.object() targets below.
-import jarvis.admin_client
-import jarvis.selfhost
 from jarvis import api_errors, error_push
+
+# NB: this module deliberately never imports or patches ``jarvis.selfhost``.
+# ``test_whitelist_annotations`` walks and imports every jarvis module via
+# pkgutil, and in some CI shard orders (py3.14) that leaves
+# ``sys.modules['jarvis.selfhost']`` as ``None`` - so any later
+# ``import jarvis.selfhost`` (here, or inside push_error_rollup) raises
+# ModuleNotFoundError. The self-host gate is therefore driven through its real
+# input (the ``deployment_mode`` setting) and the claim/confirm/revert core is
+# tested via ``_do_push`` directly, both of which avoid the selfhost import.
 
 DT = api_errors.DT
 USER = "apierr-user@example.com"
@@ -310,31 +311,31 @@ class TestErrorLogReader(ApiErrorsBase):
 # Push job — self-gating + never-raise
 # --------------------------------------------------------------------------- #
 class TestPushSelfGates(ApiErrorsBase):
-	# patch.object on the modules imported at the top (not dotted-string targets):
-	# string patch() no longer auto-imports on py3.14, and the modules are already
-	# imported cleanly and early. See the import note at the top of the file.
+	# Drive is_self_hosted() through its real input (deployment_mode) and patch
+	# only the importable admin_client / error_push seams - never jarvis.selfhost.
 	def test_skips_when_self_hosted(self):
-		with (
-			patch.object(jarvis.selfhost, "is_self_hosted", return_value=True),
-			patch.object(jarvis.admin_client, "push_error_rollup") as push,
-		):
+		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", "Self-Hosted")
+		from jarvis import admin_client
+
+		with patch.object(admin_client, "push_error_rollup") as push:
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_skips_when_admin_unconfigured(self):
+		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", "Managed")
+		from jarvis import admin_client
+
 		with (
-			patch.object(jarvis.selfhost, "is_self_hosted", return_value=False),
 			patch.object(error_push, "_admin_configured", return_value=False),
-			patch.object(jarvis.admin_client, "push_error_rollup") as push,
+			patch.object(admin_client, "push_error_rollup") as push,
 		):
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_never_raises(self):
-		with (
-			patch.object(jarvis.selfhost, "is_self_hosted", side_effect=RuntimeError("boom")),
-		):
-			# Must swallow and log, not propagate.
+		# Any exception in the push path must be swallowed, not propagated. Force
+		# one via the importable _admin_configured seam.
+		with patch.object(error_push, "_admin_configured", side_effect=RuntimeError("boom")):
 			error_push.push_error_rollup()
 
 
@@ -346,20 +347,20 @@ class TestPushClaimConfirm(ApiErrorsBase):
 		with _as(USER):
 			api_errors.report_client_errors([{"surface": "spa", "error_code": "e", "message": message}])
 
-	def _run_push(self, push_impl):
-		"""Run push_error_rollup with the admin push replaced by ``push_impl``
-		(a Mock or a plain callable)."""
-		with (
-			patch.object(jarvis.selfhost, "is_self_hosted", return_value=False),
-			patch.object(error_push, "_admin_configured", return_value=True),
-			patch.object(jarvis.admin_client, "push_error_rollup", push_impl),
-		):
-			error_push.push_error_rollup()
+	def _run_do_push(self, push_impl):
+		"""Drive the claim/confirm/revert core directly with the admin push replaced
+		by ``push_impl``. Goes through ``_do_push`` (not ``push_error_rollup``) so the
+		test never depends on the self-host gate or the jarvis.selfhost import - the
+		gates are covered by TestPushSelfGates. ``admin_client`` imports cleanly."""
+		from jarvis import admin_client
+
+		with patch.object(admin_client, "push_error_rollup", push_impl):
+			error_push._do_push()
 
 	def test_success_marks_pushed(self):
 		self._seed()
 		push = Mock()
-		self._run_push(push)
+		self._run_do_push(push)
 		push.assert_called_once()
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 0, "claimed + sent")
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 1)
@@ -368,8 +369,10 @@ class TestPushClaimConfirm(ApiErrorsBase):
 		from jarvis.exceptions import AdminUnreachableError
 
 		self._seed()
-		# Must not raise; the claimed row is reverted for the next cycle.
-		self._run_push(Mock(side_effect=AdminUnreachableError("down")))
+		# _do_push reverts the claim, then re-raises for push_error_rollup to
+		# classify (silent for transient admin errors). We assert both here.
+		with self.assertRaises(AdminUnreachableError):
+			self._run_do_push(Mock(side_effect=AdminUnreachableError("down")))
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 1)
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 0)
 
@@ -384,6 +387,6 @@ class TestPushClaimConfirm(ApiErrorsBase):
 					[{"surface": "spa", "error_code": "e", "message": "window boom"}]
 				)
 
-		self._run_push(_during_push)
+		self._run_do_push(_during_push)
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 1}), 1, "original sent once")
 		self.assertEqual(frappe.db.count(DT, {"user": USER, "pushed": 0}), 1, "mid-flight occurrence kept")

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -10,6 +10,14 @@ from unittest.mock import Mock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+# Import selfhost + admin_client BEFORE api_errors / error_push. Those two pull in
+# a large chat-module chain, and in some CI shard collection orders (py3.14)
+# importing selfhost partway through that chain leaves it half-initialised
+# ("cannot import name 'selfhost' from 'jarvis'"). Importing them first - like
+# test_selfhost.py, which has no heavy chain ahead of it - puts a complete module
+# in sys.modules for the patch.object() targets below.
+import jarvis.admin_client
+import jarvis.selfhost
 from jarvis import api_errors, error_push
 
 DT = api_errors.DT
@@ -302,38 +310,29 @@ class TestErrorLogReader(ApiErrorsBase):
 # Push job — self-gating + never-raise
 # --------------------------------------------------------------------------- #
 class TestPushSelfGates(ApiErrorsBase):
-	# NB: import selfhost / admin_client at execution time (inside each method),
-	# not at module top. A top-level `from jarvis import selfhost` runs during
-	# test collection, where it hit a circular-import ordering only in CI; by the
-	# time a test method runs the app is fully booted and the import is safe. We
-	# then patch.object the imported module (not a dotted string), which also
-	# sidesteps py3.14's mock.patch no longer auto-importing string targets.
+	# patch.object on the modules imported at the top (not dotted-string targets):
+	# string patch() no longer auto-imports on py3.14, and the modules are already
+	# imported cleanly and early. See the import note at the top of the file.
 	def test_skips_when_self_hosted(self):
-		from jarvis import admin_client, selfhost
-
 		with (
-			patch.object(selfhost, "is_self_hosted", return_value=True),
-			patch.object(admin_client, "push_error_rollup") as push,
+			patch.object(jarvis.selfhost, "is_self_hosted", return_value=True),
+			patch.object(jarvis.admin_client, "push_error_rollup") as push,
 		):
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_skips_when_admin_unconfigured(self):
-		from jarvis import admin_client, selfhost
-
 		with (
-			patch.object(selfhost, "is_self_hosted", return_value=False),
+			patch.object(jarvis.selfhost, "is_self_hosted", return_value=False),
 			patch.object(error_push, "_admin_configured", return_value=False),
-			patch.object(admin_client, "push_error_rollup") as push,
+			patch.object(jarvis.admin_client, "push_error_rollup") as push,
 		):
 			error_push.push_error_rollup()
 		push.assert_not_called()
 
 	def test_never_raises(self):
-		from jarvis import selfhost
-
 		with (
-			patch.object(selfhost, "is_self_hosted", side_effect=RuntimeError("boom")),
+			patch.object(jarvis.selfhost, "is_self_hosted", side_effect=RuntimeError("boom")),
 		):
 			# Must swallow and log, not propagate.
 			error_push.push_error_rollup()
@@ -349,14 +348,11 @@ class TestPushClaimConfirm(ApiErrorsBase):
 
 	def _run_push(self, push_impl):
 		"""Run push_error_rollup with the admin push replaced by ``push_impl``
-		(a Mock or a plain callable). selfhost / admin_client are imported here (at
-		execution time) - see the note on TestPushSelfGates."""
-		from jarvis import admin_client, selfhost
-
+		(a Mock or a plain callable)."""
 		with (
-			patch.object(selfhost, "is_self_hosted", return_value=False),
+			patch.object(jarvis.selfhost, "is_self_hosted", return_value=False),
 			patch.object(error_push, "_admin_configured", return_value=True),
-			patch.object(admin_client, "push_error_rollup", push_impl),
+			patch.object(jarvis.admin_client, "push_error_rollup", push_impl),
 		):
 			error_push.push_error_rollup()
 

--- a/jarvis/tests/test_whitelist_annotations.py
+++ b/jarvis/tests/test_whitelist_annotations.py
@@ -37,6 +37,13 @@ def _iter_api_modules():
 	import jarvis
 
 	yield jarvis
+	# LANDMINE (see jarvis#485, bench commit 96336978): walking + importing every
+	# module here can, in a parallel-test shard's file order on Python 3.14, leave
+	# `sys.modules['jarvis.selfhost'] = None`. Any later `import jarvis.selfhost` in
+	# the same shard process - in another test or in app code under test - then
+	# raises ModuleNotFoundError, and the failure looks unrelated to this file. If
+	# you hit that, the fix belongs here (e.g. snapshot + restore sys.modules around
+	# the walk), not in the victim test.
 	for info in pkgutil.walk_packages(jarvis.__path__, prefix="jarvis."):
 		if info.name.startswith(_SKIP_PREFIXES):
 			continue

--- a/pwa/src/App.vue
+++ b/pwa/src/App.vue
@@ -9,6 +9,7 @@ import { sessionUser } from "./router";
 import { showNotice } from "./noticeGate";
 import { prefs } from "./lib/prefs";
 import { agentName } from "@/branding";
+import { flushBuffered } from "@shared/lib/errorReporter";
 import { recordEvent } from "./lib/notifications";
 
 const socket = inject("$socket");
@@ -83,6 +84,8 @@ function onResync() {
 	// Behind the login screen there is nothing to resync, and asking would just
 	// log a 403 on every tab-wake.
 	if (!sessionUser()) return;
+	// Flush any errors buffered while offline (no-op when the buffer is empty).
+	void flushBuffered();
 	store.loadConversations();
 	if (router.currentRoute.value.name === "Chat") window.dispatchEvent(new Event("jv:resync"));
 }

--- a/pwa/src/lib/notifications.js
+++ b/pwa/src/lib/notifications.js
@@ -1,6 +1,7 @@
 import { reactive } from "vue";
 
 import { agentName } from "@/branding";
+import { report as reportError } from "@shared/lib/errorReporter";
 
 // The notification feed, assembled client-side from realtime events — the bench
 // has no persistent notification store (the desktop uses live toasts, the native
@@ -90,6 +91,16 @@ export function recordEvent(e) {
 			read: false,
 		});
 	} else if (e.kind === "run:error" && conv) {
+		// The turn failed - report it (classified) to the admin. A socket event,
+		// so the global handlers never see it.
+		reportError({
+			surface: "pwa_chat",
+			error_code: e.code || "run_error",
+			error_class: "RunError",
+			message: e.error || "Something went wrong during the run.",
+			conversation: conv,
+			run_id: e.run_id || "",
+		});
 		push({
 			id: `err:${e.run_id || e.message_id}`,
 			kind: "task-failed",

--- a/pwa/src/main.js
+++ b/pwa/src/main.js
@@ -11,9 +11,15 @@ import { initSocket } from "./socket";
 import "./install";
 import { applyTheme } from "./lib/theme";
 import { applyBrandChrome } from "./branding";
+import { install as installErrorReporter, vueErrorHandler } from "@shared/lib/errorReporter";
 import "./index.css";
 
 setConfig("resourceFetcher", frappeRequest);
+
+// Same shared reporter as the SPA (via @shared). offline:true buffers failed
+// posts to localStorage and flushes on reconnect (App.vue onResync), since a
+// mobile user is often offline when an error fires.
+installErrorReporter({ surface: "pwa", offline: true });
 
 // Before mount: applying the saved theme after the first paint would flash the
 // wrong palette, which on an OLED phone is very visible.
@@ -22,6 +28,7 @@ applyTheme();
 applyBrandChrome();
 
 const app = createApp(App);
+app.config.errorHandler = vueErrorHandler;
 app.use(resourcesPlugin);
 app.use(router);
 // A guest has no user room to join: the socket would only sit there retrying


### PR DESCRIPTION
## What

Customer-bench half of **tenant error reporting**. Captures every error a tenant's user faces in the Jarvis web UI (SPA + Desk + PWA) plus every unhandled **jarvis-app** server exception, scrubs it on the bench, and forwards it out-of-band to the admin control plane.

Pairs with the admin PR **Aerele-RnD/jarvis-admin-v2#125** (ingest + Errors dashboard). This is the capture + push side.

## Changes

- **`Jarvis Client Error`** doctype — local, scrubbed buffer of UI errors, deduped by fingerprint.
- **`jarvis/api_errors.py`** — `report_client_errors` (session-authed endpoint the reporters POST to; balanced scrubbing of amounts / emails / secrets / hashes, but keeps the *reporting user's own* email); `collect_error_log` reads new `Error Log` rows **filtered to the jarvis app only** (ERPNext / framework / other-app exceptions never leave the bench).
- **`jarvis/error_push.py`** — `*/5` push cloned from `usage_push`: self-gating (skips self-hosted / un-onboarded), never-raises, forwards both lanes, advances a durable Error-Log watermark; daily prune of pushed rows.
- **Shared frontend reporter** (`frontend/src/lib/errorReporter.js`) — global `error`/`unhandledrejection`/Vue handlers plus explicit `report()` at the chokepoints that show errors without throwing (chat `run:error`, onboarding `payErr`/`provisionErr`). Wired into the **SPA** (`main.js`, `globalNotifier`), the **PWA** (via the `@shared` alias, with localStorage offline-buffering + flush-on-reconnect), and a **vanilla Desk bundle** (`jarvis_error_reporter.bundle.js`) + the Desk chat widget.

**Only scrubbed text leaves the bench**, and only jarvis-origin errors are forwarded.

## Tests

`jarvis/tests/test_api_errors.py` — **16 tests**: scrub (redacts data, keeps taxonomy + the reporter's own email), fingerprint dedupe, the report endpoint (insert/dedupe/guest-refused/bad-row-tolerant), the **jarvis-only** Error Log filter, and the self-gating never-raising push. Guard suite `test_whitelist_annotations` green.

`frontend/src/lib/errorReporter.test.js` — **12 node:test cases** (mocked `fetch`/`localStorage`/`window`) covering the in-browser logic: POST envelope + CSRF, fingerprint dedupe, benign-noise filter, the per-flush (50) and per-session (100) caps, offline buffering + flush-on-reconnect, the re-entrancy guard, and the global window/Vue handlers.

```
bench --site jarvis-test.localhost run-tests --app jarvis --module jarvis.tests.test_api_errors
cd frontend && node --test src/lib/errorReporter.test.js
```

## Deploy note

Run `bench --site <site> migrate` (new doctype + the `auth`/scheduler hooks) and `bench build --app jarvis` (Desk bundle) before serving. The SPA/PWA rebuild with `npm run build` in `frontend/` and `pwa/`.
