### PR TITLE
feat(dashboards): open a builder conversation's dashboard from main chat

### DIFF
--- a/frontend/src/api/dashboards.js
+++ b/frontend/src/api/dashboards.js
@@ -49,6 +49,12 @@ export const saveDashboard = (payload = {}) =>
 
 export const deleteDashboard = (name) => call(DB + "delete_dashboard", { name }).then(unwrap);
 
+// The saved dashboard a conversation built, for main chat's "Open in Dashboards"
+// affordance. -> {name, dashboard_title} | {} (an unsaved build is the normal
+// empty answer, not an error). Throws if the caller does not own the chat.
+export const dashboardForConversation = (conversation) =>
+	call(DB + "dashboard_for_conversation", { conversation }).then(unwrap);
+
 // View-mode data: executes the SERVER-stored spec for one named source.
 // -> {ok:true, data:{source_name, tool, rows, columns? (run_report only),
 //     truncated, took_ms}}

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -62,18 +62,29 @@ export function isNewerStamp(a, b) {
  * at unreachable. Compared on `creation`, not `modified`: editing the saved row
  * later must not re-hijack clicks on builds that came after it.
  *
+ * A message with a canvas and NO `creation` is the row being streamed into
+ * right now: main chat mints it client-side from the first delta and the
+ * realtime `canvas` frame attaches the artifact to it, so it carries no server
+ * stamp until the next transcript load. That row is by definition the newest
+ * thing in the thread — and the build the user just watched appear is exactly
+ * the one they are most likely to click — so it promotes. An unreadable stamp
+ * is a different story (an old server, not a live frame) and keeps the
+ * pre-existing `?edit=` behaviour, as does a saved row that reports no
+ * `creation` of its own.
+ *
  * @param {{dashboard: {name?: string, creation?: string}|null, conversation: string, messageId: string, messageCreation?: string}} arg
  * @returns {{path: string, query: object}} a vue-router location
  */
 export function dashboardOpenRoute({ dashboard, conversation, messageId, messageCreation }) {
 	const saved = (dashboard && dashboard.name) || "";
-	if (saved && !isNewerStamp(messageCreation, dashboard.creation)) {
-		return { path: "/dashboards", query: { edit: saved } };
-	}
-	return {
+	const promote = {
 		path: "/dashboards",
 		query: { chat: conversation || "", canvas: messageId || "" },
 	};
+	if (!saved) return promote;
+	if (!messageCreation) return promote;
+	if (isNewerStamp(messageCreation, dashboard.creation)) return promote;
+	return { path: "/dashboards", query: { edit: saved } };
 }
 
 /**

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -211,8 +211,9 @@ export function resumesAdoption({ routeEdit, adoptedRow, editingSticky, canvasMs
  * The identity a promotion comes away with.
  *
  * `dash` is the row main chat named, `detail` what `get_dashboard` answered for
- * it (null when the fetch failed), `priorName` the identity the builder already
- * had. Three rules, in order:
+ * it (null when the fetch failed), `gone` whether that failure was a definitive
+ * "no such row for you", `priorName` the identity the builder already had.
+ * Three rules, in order:
  *
  * - Adopt only an EDITABLE row. `dash` arrives on a URL and `get_dashboard` is
  *   read-gated, while `save_dashboard` demands owner/admin — so an Org- or
@@ -223,20 +224,24 @@ export function resumesAdoption({ routeEdit, adoptedRow, editingSticky, canvasMs
  *   that the row is kept (see wouldDiscardOnPromotion); clearing it on a blip
  *   breaks that promise silently and the next Save writes the duplicate anyway.
  *   A fetch that answered "you may not edit this" is not a blip — it is the
- *   rule above, and it wins.
+ *   rule above, and it wins. Neither is a 404/403: `get_dashboard` is read-
+ *   gated, so a deleted row (or one this user may no longer touch) THROWS
+ *   rather than answering `can_edit: false`, and `gone` is how the caller says
+ *   the fetch DID answer. The identity naming that row is forgotten — the same
+ *   thing the remount path does with a sticky it can no longer resolve.
  * - Anything else degrades to the identity-less promotion that shipped before.
  *
  * The row's `theme` rides along: the agent must design for the theme the row
  * actually has, and the save-time validator re-lints the html against it — a
  * Slate row saved with the picker left on the default is rejected outright.
  *
- * @param {{dash?: string, detail: {name?: string, can_edit?: boolean|number, theme?: string}|null, priorName?: string}} arg
+ * @param {{dash?: string, detail: {name?: string, can_edit?: boolean|number, theme?: string}|null, priorName?: string, gone?: boolean}} arg
  * @returns {{adopted: object|null, keepPrior: boolean, name: string, theme: string}}
  */
-export function adoptionIdentity({ dash, detail, priorName }) {
+export function adoptionIdentity({ dash, detail, priorName, gone }) {
 	const answered = !!(detail && detail.name);
 	const adopted = dash && answered && detail.can_edit ? detail : null;
-	const keepPrior = !answered && !!dash && !!priorName && priorName === dash;
+	const keepPrior = !answered && !gone && !!dash && !!priorName && priorName === dash;
 	return {
 		adopted,
 		keepPrior,

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -13,9 +13,11 @@
 // property of the conversation plus the item type, never of the html itself.
 //
 // Both ends of the hand-off keep their decisions here, as pure functions: what
-// main chat routes to, and what the builder would cost the user by accepting
-// the promotion. A .vue SFC cannot be imported into the plain node test runner,
-// so logic that lives in one is logic nothing can test behaviourally.
+// main chat routes to, what the builder would cost the user by accepting the
+// promotion, and what identity it comes away with. A .vue SFC cannot be
+// imported into the plain node test runner, so logic that lives in one is logic
+// nothing can test behaviourally.
+import { themeKey } from "./dashboardThemes.js";
 
 /**
  * Does this canvas item, in this conversation, get the affordance?
@@ -150,4 +152,95 @@ export function wouldDiscardOnPromotion({
 	if (unsavedCanvas) return true;
 	if (losesEditing) return true;
 	return !!(chatConv && chatConv !== conv && canvasMsg);
+}
+
+// ── adoption: the SAVE identity is not the REVISION identity ────────────────
+//
+// An adopted promotion holds two documents at once. The canvas shows the build
+// the user clicked — a later iteration than the row it belongs to — while the
+// row supplies the identity, so "Save changes" reconciles them instead of
+// writing a duplicate. Until that Save (or an `?edit=` that loads the row's own
+// html), the TRANSCRIPT is the current document and the stored row is history.
+// Everything below follows from that one asymmetry.
+
+/**
+ * What the builder chat tells the agent it is revising.
+ *
+ * NOT the Save target. `sendDashboardChat`'s editing name becomes a
+ * `{doctype, name}` context, and the turn handler turns that into "they are
+ * revising the saved dashboard <name> — call jarvis__get_doc … then produce the
+ * full revised document". Pointed at a row the canvas is already AHEAD of, that
+ * instruction makes the next small tweak ("make the totals bold") rebuild from
+ * the STORED html: the promoted build is silently reverted, and — because the
+ * adoption also armed Save — the next Save writes that reversion over the row.
+ *
+ * So while an adoption is active the agent is told nothing and revises from the
+ * transcript, exactly as an identity-less promotion does. The moment the two
+ * documents are one again, the name goes back on.
+ *
+ * @param {{editingName: string, adoptionActive: boolean}} arg
+ */
+export function agentRevisionTarget({ editingName, adoptionActive }) {
+	return adoptionActive ? "" : editingName || "";
+}
+
+/**
+ * Is this mount resuming an adopted promotion rather than an edit session?
+ *
+ * Every route change remounts the builder (there is no <KeepAlive>), so "promote
+ * → hop to the chat → come back" is an ordinary move. The sticky editing target
+ * alone cannot tell the two states apart, and read as an edit target it sends
+ * the mount through `loadEdit`, which puts the ROW's html on the canvas and
+ * clears the canvas message — answering with an older document than the one the
+ * user left, and forgetting the promoted build.
+ *
+ * The adopted state has its own signature: the row an adoption named, the same
+ * row still the sticky target, plus the canvas message and the thread it was
+ * promoted from. All four, or it is an ordinary edit session (`loadEdit` clears
+ * the canvas message precisely because the canvas is the row's document then).
+ * An explicit `?edit=` is the user asking for a document and always wins.
+ *
+ * @param {{routeEdit: string, adoptedRow: string, editingSticky: string, canvasMsg: string, chatConv: string}} arg
+ */
+export function resumesAdoption({ routeEdit, adoptedRow, editingSticky, canvasMsg, chatConv }) {
+	if (routeEdit) return false;
+	return !!adoptedRow && adoptedRow === editingSticky && !!canvasMsg && !!chatConv;
+}
+
+/**
+ * The identity a promotion comes away with.
+ *
+ * `dash` is the row main chat named, `detail` what `get_dashboard` answered for
+ * it (null when the fetch failed), `priorName` the identity the builder already
+ * had. Three rules, in order:
+ *
+ * - Adopt only an EDITABLE row. `dash` arrives on a URL and `get_dashboard` is
+ *   read-gated, while `save_dashboard` demands owner/admin — so an Org- or
+ *   Role-scoped row this user may merely read would otherwise get the badge and
+ *   a "Save changes" that throws a PermissionError after the dialog is filled.
+ * - A fetch that never ANSWERED, while `dash` is the identity the builder
+ *   already had, keeps that identity. The confirm was SKIPPED on the promise
+ *   that the row is kept (see wouldDiscardOnPromotion); clearing it on a blip
+ *   breaks that promise silently and the next Save writes the duplicate anyway.
+ *   A fetch that answered "you may not edit this" is not a blip — it is the
+ *   rule above, and it wins.
+ * - Anything else degrades to the identity-less promotion that shipped before.
+ *
+ * The row's `theme` rides along: the agent must design for the theme the row
+ * actually has, and the save-time validator re-lints the html against it — a
+ * Slate row saved with the picker left on the default is rejected outright.
+ *
+ * @param {{dash?: string, detail: {name?: string, can_edit?: boolean|number, theme?: string}|null, priorName?: string}} arg
+ * @returns {{adopted: object|null, keepPrior: boolean, name: string, theme: string}}
+ */
+export function adoptionIdentity({ dash, detail, priorName }) {
+	const answered = !!(detail && detail.name);
+	const adopted = dash && answered && detail.can_edit ? detail : null;
+	const keepPrior = !answered && !!dash && !!priorName && priorName === dash;
+	return {
+		adopted,
+		keepPrior,
+		name: adopted ? adopted.name : keepPrior ? priorName : "",
+		theme: adopted ? themeKey(adopted.theme) : "",
+	};
 }

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -11,10 +11,39 @@
 // builder side). The marker lives on the CONVERSATION — `origin_page`, stamped
 // server-side from the builder's send context — so the affordance is a
 // property of the conversation plus the item type, never of the html itself.
+//
+// Both ends of the hand-off keep their decisions here, as pure functions: what
+// main chat routes to, and what the builder would cost the user by accepting
+// the promotion. A .vue SFC cannot be imported into the plain node test runner,
+// so logic that lives in one is logic nothing can test behaviourally.
 
 /** Does this canvas item, in this conversation, get the affordance? */
 export function canOpenInDashboards(originPage, cv) {
 	return originPage === "dashboards" && !!cv && cv.type === "html";
+}
+
+// Frappe timestamps arrive as "YYYY-MM-DD HH:MM:SS[.ffffff]" — same server,
+// same format on both sides of the comparison. Normalised to a fixed-width key
+// so a string compare is exact. Date.parse is deliberately NOT used: its
+// handling of more than three fractional-second digits is implementation-
+// defined, and these values carry six.
+function stampKey(v) {
+	const m = (typeof v === "string" ? v : "")
+		.trim()
+		.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?/);
+	if (!m) return "";
+	return m.slice(1, 7).join("") + "." + (m[7] || "").padEnd(6, "0").slice(0, 6);
+}
+
+/**
+ * Is `a` strictly later than `b`? Unreadable/absent on either side answers
+ * `false` — the caller's fallback is the pre-existing behaviour, so an old
+ * server that returns no `creation` degrades to it instead of misrouting.
+ */
+export function isNewerStamp(a, b) {
+	const ka = stampKey(a);
+	const kb = stampKey(b);
+	return !!ka && !!kb && ka > kb;
 }
 
 /**
@@ -26,14 +55,46 @@ export function canOpenInDashboards(originPage, cv) {
  * builder is asked to promote THIS artifact instead (`?chat=&canvas=`) and
  * replays it from the transcript.
  *
- * @param {{dashboard: {name?: string}|null, conversation: string, messageId: string}} arg
+ * The clicked message wins over an older save. A conversation keeps iterating
+ * after its first save, so "this conversation has a dashboard" is not "this
+ * artifact IS that dashboard" — routing a click on a newer, never-saved build
+ * to `?edit=` opens a different document and leaves the one the user pointed
+ * at unreachable. Compared on `creation`, not `modified`: editing the saved row
+ * later must not re-hijack clicks on builds that came after it.
+ *
+ * @param {{dashboard: {name?: string, creation?: string}|null, conversation: string, messageId: string, messageCreation?: string}} arg
  * @returns {{path: string, query: object}} a vue-router location
  */
-export function dashboardOpenRoute({ dashboard, conversation, messageId }) {
+export function dashboardOpenRoute({ dashboard, conversation, messageId, messageCreation }) {
 	const saved = (dashboard && dashboard.name) || "";
-	if (saved) return { path: "/dashboards", query: { edit: saved } };
+	if (saved && !isNewerStamp(messageCreation, dashboard.creation)) {
+		return { path: "/dashboards", query: { edit: saved } };
+	}
 	return {
 		path: "/dashboards",
 		query: { chat: conversation || "", canvas: messageId || "" },
 	};
+}
+
+/**
+ * Would accepting a `?chat=&canvas=` promotion cost the user something they
+ * have to own? (DashboardsPage's discard confirm, extracted so it is testable.)
+ *
+ * Re-opening the builder's OWN thread is free: both messages live in the same
+ * transcript, so repointing the canvas at another of them loses nothing — and
+ * that is the feature's primary path, where a confirm is pure noise (its
+ * "Open its chat" action would even bounce the user back where they started).
+ * WITH an editing identity it is not free: accepting flips Save from
+ * update-in-place to create-new, which is a real change the user must own.
+ *
+ * A different conversation keeps the full guard: an unsaved canvas, an editing
+ * target, or another thread's restored canvas are all things to ask about.
+ *
+ * @param {{conv: string, chatConv: string, canvasMsg: string, unsavedCanvas: boolean, editing: boolean}} arg
+ */
+export function wouldDiscardOnPromotion({ conv, chatConv, canvasMsg, unsavedCanvas, editing }) {
+	if (chatConv && chatConv === conv) return !!editing;
+	if (unsavedCanvas) return true;
+	if (editing) return true;
+	return !!(chatConv && chatConv !== conv && canvasMsg);
 }

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -17,9 +17,27 @@
 // the promotion. A .vue SFC cannot be imported into the plain node test runner,
 // so logic that lives in one is logic nothing can test behaviourally.
 
-/** Does this canvas item, in this conversation, get the affordance? */
-export function canOpenInDashboards(originPage, cv) {
-	return originPage === "dashboards" && !!cv && cv.type === "html";
+/**
+ * Does this canvas item, in this conversation, get the affordance?
+ *
+ * `originPage` is read from a conversation fetch that lands one full round trip
+ * after `currentId` already names the conversation being switched to, so the
+ * value on its own is not enough: it must be BOUND to the conversation it was
+ * read for (`originOf`). Until the new conversation's fetch lands — and forever,
+ * if that fetch rejects — the pair does not match and the gate stays closed,
+ * which is the fail-closed half. The other half is that a refresh of the
+ * conversation ALREADY on screen (a `message:enriched` reload, the resync on
+ * every tab focus) never invalidates anything, so the button does not blink out
+ * from under the user at the moment it is most likely to be clicked.
+ *
+ * Same shape as the preview header's own `artifact.conv === currentId` gate.
+ *
+ * @param {{originPage: string, originOf: string, conversation: string, cv: {type?: string}|null}} arg
+ */
+export function canOpenInDashboards({ originPage, originOf, conversation, cv }) {
+	if (originPage !== "dashboards") return false;
+	if (!conversation || originOf !== conversation) return false;
+	return !!cv && cv.type === "html";
 }
 
 // Frappe timestamps arrive as "YYYY-MM-DD HH:MM:SS[.ffffff]" — same server,
@@ -72,6 +90,13 @@ export function isNewerStamp(a, b) {
  * pre-existing `?edit=` behaviour, as does a saved row that reports no
  * `creation` of its own.
  *
+ * Promoting DESPITE a saved row carries that row's name along (`&dash=`). The
+ * conversation already has an identity — the build being promoted is a later
+ * iteration of the SAME dashboard, not a different one — so the builder adopts
+ * it and "Save changes" updates that row instead of writing a second one for
+ * content the first already holds. Only this fork can carry it: with no saved
+ * row there is nothing to adopt, and `?edit=` opens the row directly.
+ *
  * @param {{dashboard: {name?: string, creation?: string}|null, conversation: string, messageId: string, messageCreation?: string}} arg
  * @returns {{path: string, query: object}} a vue-router location
  */
@@ -82,8 +107,9 @@ export function dashboardOpenRoute({ dashboard, conversation, messageId, message
 		query: { chat: conversation || "", canvas: messageId || "" },
 	};
 	if (!saved) return promote;
-	if (!messageCreation) return promote;
-	if (isNewerStamp(messageCreation, dashboard.creation)) return promote;
+	const adopt = { path: "/dashboards", query: { ...promote.query, dash: saved } };
+	if (!messageCreation) return adopt;
+	if (isNewerStamp(messageCreation, dashboard.creation)) return adopt;
 	return { path: "/dashboards", query: { edit: saved } };
 }
 
@@ -101,11 +127,27 @@ export function dashboardOpenRoute({ dashboard, conversation, messageId, message
  * A different conversation keeps the full guard: an unsaved canvas, an editing
  * target, or another thread's restored canvas are all things to ask about.
  *
- * @param {{conv: string, chatConv: string, canvasMsg: string, unsavedCanvas: boolean, editing: boolean}} arg
+ * An ADOPTION (`dash` — the saved row this build belongs to) changes only the
+ * editing leg: the identity is not being thrown away, it is being kept, or a
+ * builder that had none is upgrading to update-in-place. Nothing to own, so
+ * nothing to ask. A DIFFERENT row is still a real editing session being
+ * replaced, and every other leg of the guard is untouched — an adoption does
+ * not licence discarding another thread's unsaved canvas.
+ *
+ * @param {{conv: string, chatConv: string, canvasMsg: string, unsavedCanvas: boolean, editing: boolean, editingName?: string, dash?: string}} arg
  */
-export function wouldDiscardOnPromotion({ conv, chatConv, canvasMsg, unsavedCanvas, editing }) {
-	if (chatConv && chatConv === conv) return !!editing;
+export function wouldDiscardOnPromotion({
+	conv,
+	chatConv,
+	canvasMsg,
+	unsavedCanvas,
+	editing,
+	editingName,
+	dash,
+}) {
+	const losesEditing = dash ? !!editingName && editingName !== dash : !!editing;
+	if (chatConv && chatConv === conv) return losesEditing;
 	if (unsavedCanvas) return true;
-	if (editing) return true;
+	if (losesEditing) return true;
 	return !!(chatConv && chatConv !== conv && canvasMsg);
 }

--- a/frontend/src/lib/dashboardOpen.js
+++ b/frontend/src/lib/dashboardOpen.js
@@ -1,0 +1,39 @@
+// "Open in Dashboards" — the way back from a builder conversation in MAIN CHAT.
+//
+// The Dashboards builder's thread is an ordinary Jarvis Conversation, so it
+// also shows up in the main chat list. Opened there, the agent's html artifact
+// renders as a static preview: main chat's canvas has no query-tool bridge, so
+// nothing in it fetches data. That is accepted — what was missing is the door
+// back to the page where the same document DOES run with data.
+//
+// Nothing in a message says "this is a dashboard": an html canvas in main chat
+// is just an html canvas (dashboardRestore.js documents the same trap on the
+// builder side). The marker lives on the CONVERSATION — `origin_page`, stamped
+// server-side from the builder's send context — so the affordance is a
+// property of the conversation plus the item type, never of the html itself.
+
+/** Does this canvas item, in this conversation, get the affordance? */
+export function canOpenInDashboards(originPage, cv) {
+	return originPage === "dashboards" && !!cv && cv.type === "html";
+}
+
+/**
+ * Where the affordance goes.
+ *
+ * A saved dashboard bound to this conversation opens IN PLACE (`?edit=`): the
+ * builder loads the stored document, runs its sources live, and saves back
+ * over the same row. With no saved row there is nothing to edit, so the
+ * builder is asked to promote THIS artifact instead (`?chat=&canvas=`) and
+ * replays it from the transcript.
+ *
+ * @param {{dashboard: {name?: string}|null, conversation: string, messageId: string}} arg
+ * @returns {{path: string, query: object}} a vue-router location
+ */
+export function dashboardOpenRoute({ dashboard, conversation, messageId }) {
+	const saved = (dashboard && dashboard.name) || "";
+	if (saved) return { path: "/dashboards", query: { edit: saved } };
+	return {
+		path: "/dashboards",
+		query: { chat: conversation || "", canvas: messageId || "" },
+	};
+}

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -20,9 +20,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+	adoptionIdentity,
+	agentRevisionTarget,
 	canOpenInDashboards,
 	dashboardOpenRoute,
 	isNewerStamp,
+	resumesAdoption,
 	wouldDiscardOnPromotion,
 } from "./dashboardOpen.js";
 
@@ -385,6 +388,132 @@ test("an adoption does not licence discarding the OTHER legs of the guard", () =
 	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "" }), false);
 });
 
+// ---- adoption: the SAVE identity is not the REVISION identity -------------
+
+const DETAIL = { name: "DASH-1", can_edit: true, theme: "Graphite", html: "<h1>old</h1>" };
+
+test("an adopted promotion tells the agent NOTHING about the row it adopted", () => {
+	// The canvas holds a build the adopted row is BEHIND. Naming that row in the
+	// send makes the turn handler instruct the agent to call jarvis__get_doc and
+	// "produce the full revised document" from the STORED html — so the next
+	// "make the totals bold" republishes the older document, reverting the build
+	// the user promoted, and the Save the adoption armed then writes that
+	// reversion over the row. The transcript is the current document here.
+	assert.equal(agentRevisionTarget({ editingName: "DASH-1", adoptionActive: true }), "");
+	// An ordinary edit session is untouched: there the row IS what is on the
+	// canvas, and reading it back is exactly right.
+	assert.equal(agentRevisionTarget({ editingName: "DASH-1", adoptionActive: false }), "DASH-1");
+	// ...so the name comes back the moment the two documents are one — the first
+	// successful Save, or an ?edit= that loads the row's own html (both clear the
+	// adoption, which is all this reads).
+	assert.equal(agentRevisionTarget({ editingName: "DASH-2", adoptionActive: false }), "DASH-2");
+	// nothing to name, either way
+	assert.equal(agentRevisionTarget({ editingName: "", adoptionActive: true }), "");
+	assert.equal(agentRevisionTarget({ editingName: "", adoptionActive: false }), "");
+	assert.equal(agentRevisionTarget({ editingName: undefined, adoptionActive: false }), "");
+});
+
+test("a remount mid-adoption resumes it instead of re-opening the saved row", () => {
+	// Every route change remounts the builder (no <KeepAlive> anywhere), so
+	// "promote → hop to the chat to re-read it → come back" is an ordinary move.
+	const adopted = {
+		routeEdit: "",
+		adoptedRow: "DASH-1",
+		editingSticky: "DASH-1",
+		canvasMsg: "M2",
+		chatConv: "C",
+	};
+	assert.equal(resumesAdoption(adopted), true);
+	// An ordinary edit session cannot wear this signature: loadEdit clears the
+	// canvas message precisely because the canvas becomes the row's document.
+	assert.equal(resumesAdoption({ ...adopted, adoptedRow: "", canvasMsg: "" }), false);
+	// ...nor can a sticky edit target with no adoption behind it
+	assert.equal(resumesAdoption({ ...adopted, adoptedRow: "" }), false);
+	// half-states are not the signature: all four, or the ?edit= path
+	assert.equal(resumesAdoption({ ...adopted, canvasMsg: "" }), false);
+	assert.equal(resumesAdoption({ ...adopted, chatConv: "" }), false);
+	// the sticky target moved on (another dashboard was opened for editing)
+	assert.equal(resumesAdoption({ ...adopted, editingSticky: "DASH-2" }), false);
+	assert.equal(resumesAdoption({ ...adopted, editingSticky: "" }), false);
+	// an explicit ?edit= is the user asking for a document, and always wins
+	assert.equal(resumesAdoption({ ...adopted, routeEdit: "DASH-3" }), false);
+	assert.equal(resumesAdoption({ ...adopted, routeEdit: "DASH-1" }), false);
+});
+
+test("only an EDITABLE row is adopted", () => {
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: DETAIL }).name, "DASH-1");
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: DETAIL }).adopted, DETAIL);
+	// get_dashboard is read-gated while save_dashboard demands owner/admin, and
+	// `dash` arrives on a URL — so an Org/Role row this user may merely READ would
+	// otherwise get the "Editing <their title>" badge and a "Save changes" that
+	// throws a PermissionError only after the dialog has been filled in.
+	for (const can_edit of [false, 0, undefined, null]) {
+		const r = adoptionIdentity({ dash: "DASH-1", detail: { ...DETAIL, can_edit } });
+		assert.equal(r.adopted, null);
+		assert.equal(r.name, "");
+	}
+	// nothing named, nothing answered
+	assert.equal(adoptionIdentity({ dash: "", detail: DETAIL }).name, "");
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: null }).name, "");
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: {} }).name, "");
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: undefined }).adopted, null);
+});
+
+test("the adoption designs for, and saves against, the ROW's theme", () => {
+	// The picker sits on the product default on a fresh mount, and the save-time
+	// validator re-lints the html against whatever theme the save sends: a Slate
+	// row promoted and saved is otherwise rejected outright, or silently
+	// converted. The agent is told the same theme, so it designs for it too.
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: DETAIL }).theme, "graphite");
+	// the capitalised label the DocType stores → the lowercase key the SPA uses
+	const themed = (theme) => adoptionIdentity({ dash: "DASH-1", detail: { ...DETAIL, theme } });
+	assert.equal(themed("Jarvis").theme, "jarvis");
+	assert.equal(themed("Custom").theme, "custom");
+	// an unknown/absent label falls back to the product default, never to nothing
+	assert.equal(themed("").theme, "jarvis");
+	assert.equal(themed(undefined).theme, "jarvis");
+	// no adoption, no theme: "" leaves the picker exactly where the user left it
+	assert.equal(adoptionIdentity({ dash: "DASH-1", detail: null }).theme, "");
+	assert.equal(
+		adoptionIdentity({ dash: "DASH-1", detail: { ...DETAIL, can_edit: false } }).theme,
+		""
+	);
+});
+
+test("a fetch blip keeps the identity the skipped confirm promised to keep", () => {
+	// wouldDiscardOnPromotion skips the dialog when the builder is already editing
+	// the row being adopted, on the promise that the identity is KEPT. A transient
+	// get_dashboard failure must not break that promise silently: the next Save
+	// would write the very duplicate the adoption exists to prevent, and no
+	// confirm was ever shown.
+	const blip = adoptionIdentity({ dash: "DASH-1", detail: null, priorName: "DASH-1" });
+	assert.equal(blip.keepPrior, true);
+	assert.equal(blip.name, "DASH-1");
+	assert.equal(blip.adopted, null); // no detail to show — the name is what survives
+	// a DIFFERENT prior identity was confirmed away, so it does not survive
+	const other = adoptionIdentity({ dash: "DASH-1", detail: null, priorName: "DASH-2" });
+	assert.equal(other.keepPrior, false);
+	assert.equal(other.name, "");
+	// no prior identity, nothing to keep
+	assert.equal(
+		adoptionIdentity({ dash: "DASH-1", detail: null, priorName: "" }).keepPrior,
+		false
+	);
+	// a successful adoption always answers with the fetched row
+	const ok = adoptionIdentity({ dash: "DASH-1", detail: DETAIL, priorName: "DASH-1" });
+	assert.equal(ok.keepPrior, false);
+	assert.equal(ok.adopted, DETAIL);
+	// ...and a fetch that ANSWERED "you may not edit this" is not a blip: it is
+	// the can_edit rule, and it wins over the promise
+	const denied = adoptionIdentity({
+		dash: "DASH-1",
+		detail: { ...DETAIL, can_edit: false },
+		priorName: "DASH-1",
+	});
+	assert.equal(denied.keepPrior, false);
+	assert.equal(denied.name, "");
+});
+
 // ---- main chat: the affordance is conversation state, not html-sniffing ----
 
 test("ChatView binds the origin to the conversation it was read for", () => {
@@ -660,10 +789,11 @@ test("accepting takes over the thread, the identity and the stale data-mode", ()
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
 	for (const line of [
-		/editingSticky\.value = adopted \? adopted\.name : "";/,
-		/editingDetail\.value = adopted;/,
+		/editingSticky\.value = identity\.name;/,
+		/adoptedRow\.value = identity\.name;/,
+		/if \(!identity\.keepPrior\) \{\n\t\t\teditingDetail\.value = identity\.adopted;/,
+		/savedName\.value = identity\.name;/,
 		/editSeed\.value = "";/,
-		/savedName\.value = adopted \? adopted\.name : "";/,
 		/chatConv\.value = conversation;/,
 		/canvasMsg\.value = messageId;/,
 		/dashDataMode\.value = "auto";/,
@@ -713,24 +843,92 @@ test("the promotion ADOPTS the saved row main chat named", () => {
 	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
 	assert.match(
 		accept,
-		/if \(dash\) \{\n\t\t\ttry \{\n\t\t\t\tconst d = await getDashboard\(dash\);/
+		/if \(dash\) \{\n\t\t\ttry \{\n\t\t\t\tdetail = await getDashboard\(dash\);/
 	);
-	assert.match(accept, /if \(d && d\.name\) adopted = d;/);
+	// the identity it comes away with is decided by the pure function above, on
+	// what the fetch answered and what the builder already had
+	assert.match(accept, /const priorName = editingName\(\);/);
+	assert.match(accept, /const identity = adoptionIdentity\(\{ dash, detail, priorName \}\);/);
 	// a name that fails the (permission-gated) fetch degrades to the identity-less
 	// promotion — a URL-supplied `dash` is never a dead click, and never a trusted
 	// one either
-	assert.match(accept, /\} catch \(e\) \{\n\t\t\t\tadopted = null;/);
+	assert.match(accept, /\} catch \(e\) \{\n\t\t\t\tdetail = null;/);
 	// the adopted row supplies the IDENTITY only: its html must never reach the
 	// canvas, or the promotion answers with the saved document instead of the
 	// build the user clicked
-	assert.doesNotMatch(accept, /builderHtml\.value = (adopted|d)\b/);
+	assert.doesNotMatch(accept, /builderHtml\.value = (identity|detail|adopted)\b/);
 	assert.doesNotMatch(accept, /\.html\b/);
 	// ...and the identity is what makes Save update in place — the dialog reads it
-	// off editingDetail
-	assert.match(pageSrc, /:editing-name="editingDetail \? editingDetail\.name : ''"/);
+	// off editingDetail, while the AGENT is told nothing (agentEditingName)
+	assert.match(pageSrc, /:editing-name="agentEditingName"/);
 	assert.match(pageSrc, /:editing="editingDetail"/);
+	// the row's theme rides along, so the first "Save changes" re-lints against
+	// the theme the row actually has instead of the picker's default
+	assert.match(accept, /if \(identity\.theme\) builderTheme\.value = identity\.theme;/);
 	// the query it arrived on is dropped with the rest of the promotion keys
 	assert.match(fnBody(pageSrc, "function stripPromotionQuery("), /delete q\.dash;/);
+});
+
+test("the two identities are bound separately, and the adoption ends where they meet", () => {
+	// Save reads the full detail; the agent reads agentEditingName, which is empty
+	// for as long as the canvas is ahead of the row.
+	assert.match(pageSrc, /:editing-name="agentEditingName"/);
+	assert.match(pageSrc, /:editing="editingDetail"/);
+	assert.match(pageSrc, /const agentEditingName = computed\(\(\) =>/);
+	assert.match(pageSrc, /editingName: \(editingDetail\.value \|\| \{\}\)\.name \|\| "",/);
+	assert.match(pageSrc, /adoptionActive: !!adoptedRow\.value,/);
+	// explicit state, not inferred from timestamps — and sticky, because the
+	// remount has to be able to tell the two states apart (resumesAdoption)
+	assert.match(
+		pageSrc,
+		/const adoptedRow = useStorage\(`jarvis-dash-adopted-\$\{session\.user \|\| "anon"\}`, ""\);/
+	);
+	// it ends exactly where the row and the canvas become one document again:
+	// the first successful Save, an ?edit= load, or a builder that was cleared
+	assert.match(fnBody(pageSrc, "function onSaved("), /adoptedRow\.value = "";/);
+	assert.match(fnBody(pageSrc, "async function loadEdit("), /adoptedRow\.value = "";/);
+	assert.match(fnBody(pageSrc, "function clearBuilder("), /adoptedRow\.value = "";/);
+	// the send itself takes the pane's prop, so the suppression reaches the agent
+	assert.match(paneSrc, /editingName: \{ type: String, default: "" \},/);
+	assert.match(paneSrc, /props\.editingName,/);
+	assert.match(apiSrc, /if \(editingName\) \{/);
+});
+
+test("the adoption resume restores the identity WITHOUT the row's html", () => {
+	// loadEdit is the wrong restore here: it puts the STORED document on the
+	// canvas and clears the canvas message, so the user comes back to an older
+	// build than the one they left and the promoted one is only in the transcript.
+	const resume = fnBody(pageSrc, "async function resumeAdoption(");
+	assert.match(resume, /d = await getDashboard\(name\);/);
+	assert.doesNotMatch(resume, /builderHtml\.value/);
+	assert.doesNotMatch(resume, /canvasMsg\.value/);
+	assert.match(resume, /if \(d && d\.name && d\.can_edit\) \{/);
+	assert.match(resume, /editingDetail\.value = d;/);
+	assert.match(resume, /builderTheme\.value = themeKey\(d\.theme\);/);
+	assert.match(resume, /adoptedRow\.value = d\.name;/);
+	// a deleted (or no-longer-ours) row is forgotten silently, as loadEdit's
+	// remount path does; a blip keeps the identity for the next mount to retry
+	assert.match(resume, /if \(isGoneError\(e\)\) \{/);
+	assert.match(fnBody(pageSrc, "function isGoneError("), /isPermissionError\(e\)/);
+	// the decision is taken at SETUP, like the edit seed — the pane mounts first
+	assert.match(pageSrc, /const adoptionResume = resumesAdoption\(\{/);
+	assert.match(pageSrc, /adoptedRow: adoptedRow\.value,/);
+	// ...and the seed is left EMPTY on that path, or onCanvas drops the pane's
+	// transcript restore and the canvas comes back blank
+	assert.match(
+		pageSrc,
+		/const editSeed = ref\(routeEdit \|\| \(adoptionResume \? "" : editingSticky\.value\)\);/
+	);
+	// the mount takes it ahead of the ?edit= path, and so does the fallback a
+	// declined/failed promotion runs
+	assert.match(pageSrc, /if \(adoptionResume\) \{\n\t\t\tresumeAdoption\(adoptedRow\.value\);/);
+	const mount = fnBody(pageSrc, "onMounted(async () => {");
+	assert.ok(
+		mount.indexOf("resumeAdoption(adoptedRow.value)") <
+			mount.indexOf("loadEdit(editSeed.value"),
+		"the adopted state is restored instead of the edit seed, not after it"
+	);
+	assert.match(mount, /promoteFromChat\(routeChat, routeCanvas, \{ fallback: normalMount/);
 });
 
 test("a promotion that would cost the user something confirms first", () => {
@@ -752,7 +950,10 @@ test("a promotion that would cost the user something confirms first", () => {
 		pageSrc,
 		/const editingName = \(\) =>\n\teditingSticky\.value \|\| \(editingDetail\.value \|\| \{\}\)\.name \|\| editSeed\.value \|\| "";/
 	);
-	assert.match(pageSrc, /import \{ wouldDiscardOnPromotion \} from "@\/lib\/dashboardOpen";/);
+	assert.match(
+		pageSrc,
+		/import \{\n\tadoptionIdentity,\n\tagentRevisionTarget,\n\tresumesAdoption,\n\twouldDiscardOnPromotion,\n\} from "@\/lib\/dashboardOpen";/
+	);
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	// `force` is required: confirmDiscard short-circuits on !unsavedCanvas, so an
 	// editing target alone would never reach the dialog

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -46,24 +46,59 @@ const fnBody = (src, decl) => {
 
 // ---- who gets the affordance ---------------------------------------------
 
+// A conversation whose origin has been read and belongs to the thread on screen.
+const gate = (o) =>
+	canOpenInDashboards({
+		originPage: "dashboards",
+		originOf: "c1",
+		conversation: "c1",
+		cv: { type: "html" },
+		...o,
+	});
+
 test("only an html artifact of a DASHBOARDS conversation gets the button", () => {
-	assert.equal(canOpenInDashboards("dashboards", { type: "html" }), true);
+	assert.equal(gate({}), true);
 	// same conversation, other artifact types: untouched
-	assert.equal(canOpenInDashboards("dashboards", { type: "image" }), false);
-	assert.equal(canOpenInDashboards("dashboards", { type: "pdf" }), false);
-	assert.equal(canOpenInDashboards("dashboards", { type: "svg" }), false);
-	assert.equal(canOpenInDashboards("dashboards", { type: "file" }), false);
+	assert.equal(gate({ cv: { type: "image" } }), false);
+	assert.equal(gate({ cv: { type: "pdf" } }), false);
+	assert.equal(gate({ cv: { type: "svg" } }), false);
+	assert.equal(gate({ cv: { type: "file" } }), false);
 	// same artifact, other conversations: untouched. Triggers conversations are
 	// stamped too, but this change ships the dashboards button only.
-	assert.equal(canOpenInDashboards("triggers", { type: "html" }), false);
-	assert.equal(canOpenInDashboards("", { type: "html" }), false);
-	assert.equal(canOpenInDashboards(undefined, { type: "html" }), false);
+	assert.equal(gate({ originPage: "triggers" }), false);
+	assert.equal(gate({ originPage: "" }), false);
+	assert.equal(gate({ originPage: undefined }), false);
 });
 
 test("a junk canvas item never throws", () => {
-	assert.equal(canOpenInDashboards("dashboards", null), false);
-	assert.equal(canOpenInDashboards("dashboards", undefined), false);
-	assert.equal(canOpenInDashboards("dashboards", {}), false);
+	assert.equal(gate({ cv: null }), false);
+	assert.equal(gate({ cv: undefined }), false);
+	assert.equal(gate({ cv: {} }), false);
+});
+
+test("the origin is BOUND to the conversation it was read for", () => {
+	// Refreshing the conversation already on screen (message:enriched fires one
+	// immediately after every canvas enrichment; onResync on every socket connect
+	// and every tab focus) writes nothing until its answer lands, and what it then
+	// writes is the same pair — so the button never blinks out from under a user
+	// at the moment they are most likely to click it.
+	assert.equal(gate({}), true);
+	// A SWITCH moves currentId a full round trip ahead of the new origin. Until
+	// that fetch lands the pair still describes the PREVIOUS conversation — whose
+	// transcript is still the one on screen — so the gate is closed.
+	assert.equal(gate({ conversation: "c2" }), false);
+	// ...and opens for c2 only once c2's own fetch has written its own pair
+	assert.equal(gate({ originOf: "c2", conversation: "c2" }), true);
+	assert.equal(gate({ originPage: "", originOf: "c2", conversation: "c2" }), false);
+	// A fetch that REJECTS (a blip, a 500, an abort on tab wake) writes neither
+	// half, so the binding stays on the conversation it was read for and the gate
+	// stays closed for the one switched to — instead of offering the way back over
+	// a thread nothing has vouched for.
+	assert.equal(gate({ originOf: "c1", conversation: "c2" }), false);
+	// the id-less states (welcome screen, a dropped conversation) satisfy nothing
+	assert.equal(gate({ originOf: "", conversation: "" }), false);
+	assert.equal(gate({ originOf: null, conversation: null }), false);
+	assert.equal(gate({ originOf: undefined, conversation: undefined }), false);
 });
 
 // ---- where it goes --------------------------------------------------------
@@ -128,7 +163,7 @@ test("a build made AFTER the save wins the click, saved row or not", () => {
 			messageId: "m2",
 			messageCreation: AFTER,
 		}),
-		{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
+		{ path: "/dashboards", query: { chat: "c1", canvas: "m2", dash: "DASH-1" } }
 	);
 });
 
@@ -143,7 +178,41 @@ test("editing the saved row later must not re-hijack clicks on newer builds", ()
 			messageId: "m2",
 			messageCreation: AFTER,
 		}),
-		{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
+		{ path: "/dashboards", query: { chat: "c1", canvas: "m2", dash: "DASH-1" } }
+	);
+});
+
+test("a promotion DESPITE a saved row carries that row's identity", () => {
+	// The build being promoted is a later iteration of the same dashboard, not a
+	// different one. Without the name the builder promotes with no identity, so
+	// the next "Save" writes a SECOND row for content the first already holds —
+	// which on the live-tweak path (no stamp yet) is every single click.
+	for (const messageCreation of [AFTER, undefined, "", null]) {
+		assert.equal(
+			dashboardOpenRoute({
+				dashboard: SAVED,
+				conversation: "c1",
+				messageId: "m2",
+				messageCreation,
+			}).query.dash,
+			"DASH-1"
+		);
+	}
+	// nothing to adopt with no saved row, and ?edit= opens the row itself
+	assert.equal(
+		"dash" in
+			dashboardOpenRoute({ dashboard: null, conversation: "c1", messageId: "m1" }).query,
+		false
+	);
+	assert.equal(
+		"dash" in
+			dashboardOpenRoute({
+				dashboard: SAVED,
+				conversation: "c1",
+				messageId: "m1",
+				messageCreation: BEFORE,
+			}).query,
+		false
 	);
 });
 
@@ -162,7 +231,7 @@ test("the build still being streamed promotes: no stamp yet means it IS the newe
 				messageId: "m2",
 				messageCreation,
 			}),
-			{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
+			{ path: "/dashboards", query: { chat: "c1", canvas: "m2", dash: "DASH-1" } }
 		);
 	}
 });
@@ -275,45 +344,104 @@ test("a different conversation keeps the full guard", () => {
 	);
 });
 
+test("an ADOPTION does not discard the identity it names, so it does not ask", () => {
+	// The live-tweak path: the thread already has a saved dashboard, the user
+	// clicks the build they just watched appear, and the promotion carries that
+	// row's name. Nothing is lost — the session either continues (same row) or
+	// upgrades from no identity to update-in-place — so the "Discard" modal here
+	// would be asking the user to own something that is not happening.
+	const editing = { ...SAME, editing: true, editingName: "DASH-1" };
+	assert.equal(wouldDiscardOnPromotion({ ...editing, dash: "DASH-1" }), false);
+	// a builder with no identity at all, adopting one
+	assert.equal(
+		wouldDiscardOnPromotion({ ...SAME, editing: false, editingName: "", dash: "DASH-1" }),
+		false
+	);
+	// a DIFFERENT row IS a real editing session being replaced
+	assert.equal(wouldDiscardOnPromotion({ ...editing, dash: "DASH-2" }), true);
+	// ...and with no `dash` at all the shipped rules stand unchanged: the same
+	// thread with an identity confirms, because that identity is foreign by
+	// construction (a row belonging to this conversation would have been the one
+	// main chat looked up).
+	assert.equal(wouldDiscardOnPromotion({ ...editing }), true);
+	assert.equal(wouldDiscardOnPromotion({ ...SAME, editingName: "" }), false);
+});
+
+test("an adoption does not licence discarding the OTHER legs of the guard", () => {
+	// `dash` answers "is the editing identity lost?", nothing else. Another
+	// thread's unsaved canvas is still another thread's unsaved canvas.
+	const other = {
+		conv: "D",
+		chatConv: "C",
+		canvasMsg: "M1",
+		unsavedCanvas: false,
+		editing: false,
+		editingName: "",
+		dash: "DASH-1",
+	};
+	assert.equal(wouldDiscardOnPromotion(other), true);
+	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "", unsavedCanvas: true }), true);
+	// ...but a builder holding nothing still does not need a dialog
+	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "" }), false);
+});
+
 // ---- main chat: the affordance is conversation state, not html-sniffing ----
 
-test("ChatView reads the conversation's origin_page and clears it on switch", () => {
+test("ChatView binds the origin to the conversation it was read for", () => {
 	assert.match(
 		chatSrc,
 		/import \{ canOpenInDashboards, dashboardOpenRoute \} from "@\/lib\/dashboardOpen";/
 	);
 	assert.match(chatSrc, /const originPage = ref\(""\);/);
+	assert.match(chatSrc, /const originOf = ref\(""\);/);
 	const load = fnBody(chatSrc, "async function loadConversation(");
-	assert.match(load, /originPage\.value = d\?\.conversation\?\.origin_page \|\| "";/);
-	// the reset runs BEFORE the round trip, on every path. `messages` is only
-	// replaced when the response lands, so for one full RTT the PREVIOUS
-	// conversation's cards are on screen under the new currentId — and a fetch
-	// that rejects would otherwise leave the old origin standing for the session
-	assert.match(load, /originPage\.value = "";/);
-	assert.ok(
-		load.indexOf('originPage.value = "";') < load.indexOf("if (!id) {"),
-		"the reset belongs above the `if (!id)` arm, not inside it"
+	// the two halves are written together, and only once the fetch has answered
+	assert.match(
+		load,
+		/originPage\.value = d\?\.conversation\?\.origin_page \|\| "";\n\toriginOf\.value = id;/
 	);
 	assert.ok(
-		load.indexOf('originPage.value = "";') < load.indexOf("await api.getConversation(id)"),
-		"the reset must precede the fetch"
+		load.indexOf("await api.getConversation(id)") < load.indexOf("originOf.value = id;"),
+		"the pair is written from the response, not before it"
 	);
+	// NOTHING blanks the pair ahead of the round trip. Eight of loadConversation's
+	// call sites refresh the conversation already on screen (message:enriched
+	// after every canvas enrichment, onResync on every socket connect and tab
+	// focus) — a pre-fetch blanking removes "Open in Dashboards" from the DOM for
+	// a full RTT there, and for good when that refetch rejects.
+	const preFetch = load.slice(0, load.indexOf("const d = await api.getConversation(id)"));
+	assert.equal(
+		(preFetch.match(/originPage\.value = "";/g) || []).length,
+		1,
+		"the only pre-fetch reset is the id-less arm's own"
+	);
+	const idArm = preFetch.slice(preFetch.indexOf("if (!id) {"));
+	assert.match(idArm, /originPage\.value = "";\n\t\toriginOf\.value = "";/);
+	// the gate reads the binding, exactly as the preview header reads artifact.conv
+	const gate = fnBody(chatSrc, "function canOpenDash(");
+	assert.match(gate, /originPage: originPage\.value,/);
+	assert.match(gate, /originOf: originOf\.value,/);
+	assert.match(gate, /conversation: currentId\.value,/);
 });
 
-test("every path that swaps the conversation out resets originPage too", () => {
-	// loadConversation is the only OTHER writer, and it does not run on these
-	// four: the route watcher no-ops when currentId is already the new id, and
-	// the boot arm is the failure of the load itself. A stale "dashboards" here
-	// puts the button on an ordinary chat's html — with Save armed over it once
-	// the builder promotes it.
+test("every path that swaps the conversation out resets the pair too", () => {
+	// Defence in depth behind the binding: loadConversation is the only OTHER
+	// writer and it does not run on any of these (the route watcher no-ops when
+	// currentId already equals the new id; the boot arm is the failure of the load
+	// itself). A stale "dashboards" left here would need only a matching id to put
+	// the button on an ordinary chat's html — with Save armed over it once the
+	// builder promotes it.
 	const nc = fnBody(chatSrc, "async function newChat(");
-	assert.match(nc, /messages\.value = \[\];\n\t\/\/[^]*?originPage\.value = "";/);
+	assert.match(nc, /messages\.value = \[\];\n\t\/\/[^]*?originPage\.value = "";\n\toriginOf/);
 	const clear = fnBody(chatSrc, "async function clearAllHistory(");
-	assert.match(clear, /messages\.value = \[\];\s*originPage\.value = "";/);
+	assert.match(
+		clear,
+		/messages\.value = \[\];\s*originPage\.value = "";\s*originOf\.value = "";/
+	);
 	// the boot arm that drops a conversation which has since vanished
 	assert.match(
 		chatSrc,
-		/currentId\.value = null;\s*messages\.value = \[\];\s*originPage\.value = "";/
+		/currentId\.value = null;\s*messages\.value = \[\];\s*originPage\.value = "";\s*originOf\.value = "";/
 	);
 	// ...and the watcher that drops it when it is deleted from the sidebar while
 	// open: the user's next send adopts the server id directly, so nothing
@@ -323,9 +451,22 @@ test("every path that swaps the conversation out resets originPage too", () => {
 	assert.notEqual(vanishBody, "", "the vanished-conversation watcher must still exist");
 	assert.match(vanishBody, /currentId\.value = null;/);
 	assert.match(vanishBody, /originPage\.value = "";/);
-	// five writers of the empty value, no more: loadConversation's pre-fetch
-	// reset plus the four above (a sixth would mean a path nobody reviewed)
-	assert.equal((chatSrc.match(/originPage\.value = "";/g) || []).length, 5);
+	// ...and the send that ADOPTS a different id: a human send into a conversation
+	// the server can no longer find falls back to a fresh one and returns its id
+	// (jarvis/chat/api.py), and loadConversation runs on neither side of that
+	const send = fnBody(chatSrc, "async function send(");
+	const adopt = send.slice(send.indexOf("if (r.conversation_id !== currentId.value) {"));
+	assert.notEqual(adopt, "", "the send-adopt fallback must still exist");
+	assert.match(adopt, /currentId\.value = r\.conversation_id;[^]*?originPage\.value = "";/);
+	assert.match(adopt, /originOf\.value = "";/);
+	// six writers of the empty value, no more: the id-less arm plus the five swap
+	// sites above (a seventh would mean a path nobody reviewed)
+	assert.equal((chatSrc.match(/originPage\.value = "";/g) || []).length, 6);
+	// and the binding is dropped with it, every time — one write is never enough
+	assert.equal(
+		(chatSrc.match(/originOf\.value = "";/g) || []).length,
+		(chatSrc.match(/originPage\.value = "";/g) || []).length
+	);
 });
 
 test("the open artifact carries the conversation it was opened from", () => {
@@ -410,15 +551,23 @@ test("main chat never writes the builder's sticky slots", () => {
 test("the deep-link is read at setup AND watched, like ?edit=", () => {
 	assert.match(pageSrc, /const routeChat = typeof route\.query\.chat === "string"/);
 	assert.match(pageSrc, /const routeCanvas = typeof route\.query\.canvas === "string"/);
+	assert.match(pageSrc, /const routeDash = typeof route\.query\.dash === "string"/);
 	const watcher = pageSrc.slice(
 		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
 	);
 	assert.notEqual(watcher, "", "?chat=&canvas= must be watched, not read once at setup");
-	assert.match(watcher.slice(0, watcher.indexOf("\n);")), /promoteFromChat\(conv, msg\);/);
+	const body = watcher.slice(0, watcher.indexOf("\n);"));
+	assert.match(body, /promoteFromChat\(conv, msg, \{ dash \}\);/);
+	// `dash` rides along in the same route push, so it is read at fire time rather
+	// than watched — but it must be read, or the live deep-link adopts nothing
+	assert.match(
+		body,
+		/const dash = typeof route\.query\.dash === "string" \? route\.query\.dash : "";/
+	);
 	// and the mount path runs it too
 	assert.match(
 		pageSrc,
-		/promoteFromChat\(routeChat, routeCanvas, \{ fallback: normalMount \}\)/
+		/promoteFromChat\(routeChat, routeCanvas, \{ fallback: normalMount, dash: routeDash \}\)/
 	);
 });
 
@@ -504,17 +653,17 @@ test("the promotion is validated against the transcript, not the link", () => {
 	assert.match(giveUp, /if \(fallback\) fallback\(\);/);
 });
 
-test("accepting clears the editing identity and the stale data-mode", () => {
+test("accepting takes over the thread, the identity and the stale data-mode", () => {
 	// Without this, Save writes the promoted canvas back over whatever dashboard
 	// the builder happened to be editing — and the next send declares a
 	// static/live intent the user never expressed for THIS dashboard.
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
 	for (const line of [
-		/editingSticky\.value = "";/,
-		/editingDetail\.value = null;/,
+		/editingSticky\.value = adopted \? adopted\.name : "";/,
+		/editingDetail\.value = adopted;/,
 		/editSeed\.value = "";/,
-		/savedName\.value = "";/,
+		/savedName\.value = adopted \? adopted\.name : "";/,
 		/chatConv\.value = conversation;/,
 		/canvasMsg\.value = messageId;/,
 		/dashDataMode\.value = "auto";/,
@@ -552,6 +701,38 @@ test("a promoted artifact whose content is gone says so, and shows nothing", () 
 	assert.doesNotMatch(onCanvas, /(?<!return false;\n\t)\breturn;/);
 });
 
+test("the promotion ADOPTS the saved row main chat named", () => {
+	// The live-tweak click on a thread that already has a dashboard: the build is
+	// newer than the row, so it promotes — but it is the SAME dashboard, and
+	// dropping the identity makes the next Save write a duplicate.
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	assert.match(
+		promote,
+		/async function promoteFromChat\(conversation, messageId, \{ fallback = null, dash = "" \} = \{\}\)/
+	);
+	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
+	assert.match(
+		accept,
+		/if \(dash\) \{\n\t\t\ttry \{\n\t\t\t\tconst d = await getDashboard\(dash\);/
+	);
+	assert.match(accept, /if \(d && d\.name\) adopted = d;/);
+	// a name that fails the (permission-gated) fetch degrades to the identity-less
+	// promotion — a URL-supplied `dash` is never a dead click, and never a trusted
+	// one either
+	assert.match(accept, /\} catch \(e\) \{\n\t\t\t\tadopted = null;/);
+	// the adopted row supplies the IDENTITY only: its html must never reach the
+	// canvas, or the promotion answers with the saved document instead of the
+	// build the user clicked
+	assert.doesNotMatch(accept, /builderHtml\.value = (adopted|d)\b/);
+	assert.doesNotMatch(accept, /\.html\b/);
+	// ...and the identity is what makes Save update in place — the dialog reads it
+	// off editingDetail
+	assert.match(pageSrc, /:editing-name="editingDetail \? editingDetail\.name : ''"/);
+	assert.match(pageSrc, /:editing="editingDetail"/);
+	// the query it arrived on is dropped with the rest of the promotion keys
+	assert.match(fnBody(pageSrc, "function stripPromotionQuery("), /delete q\.dash;/);
+});
+
 test("a promotion that would cost the user something confirms first", () => {
 	// The rules themselves are unit-tested above; this fences the wiring.
 	const guard = fnBody(pageSrc, "function promotionWouldDiscard(");
@@ -563,6 +744,14 @@ test("a promotion that would cost the user something confirms first", () => {
 		guard,
 		/editing: !!\(editingSticky\.value \|\| editingDetail\.value \|\| editSeed\.value\),/
 	);
+	// the adoption matrix needs the identity by NAME, and the name it is being
+	// compared against
+	assert.match(guard, /editingName: editingName\(\),/);
+	assert.match(guard, /\bdash,/);
+	assert.match(
+		pageSrc,
+		/const editingName = \(\) =>\n\teditingSticky\.value \|\| \(editingDetail\.value \|\| \{\}\)\.name \|\| editSeed\.value \|\| "";/
+	);
 	assert.match(pageSrc, /import \{ wouldDiscardOnPromotion \} from "@\/lib\/dashboardOpen";/);
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	// `force` is required: confirmDiscard short-circuits on !unsavedCanvas, so an
@@ -571,7 +760,7 @@ test("a promotion that would cost the user something confirms first", () => {
 	assert.match(promote, /copy: PROMOTE_COPY,/);
 	assert.match(
 		promote,
-		/if \(!promotionWouldDiscard\(conversation\)\) \{\n\t\tawait accept\(\);/
+		/if \(!promotionWouldDiscard\(conversation, dash\)\) \{\n\t\tawait accept\(\);/
 	);
 	// the dialog's copy is per-call now, and the promotion's says the chat lives on
 	assert.match(pageSrc, /const discardCopy = ref\(DISCARD_COPY\);/);

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -1,0 +1,319 @@
+// "Open in Dashboards" — the owner-reported gap between main chat and the
+// Dashboards builder, fenced by a real executable test. Plain node built-ins
+// (node:test + node:assert), like dashboardRestore.test.js. Run directly
+// (`node --test dashboardOpen.test.js`) or via the python suite
+// (jarvis/tests/test_dashboard_open_from_chat_client.py subprocess-runs it
+// every CI run).
+//
+// The builder's conversation shows up in the main chat list. Opening it there
+// shows the prompt and the dashboard, but that canvas never runs its queries —
+// accepted — so what was missing was a way back to the page where it does.
+// canOpenInDashboards()/dashboardOpenRoute() are the real logic; the rest is
+// component wiring, fenced here by source assertions (the dashboardRestore
+// precedent) because a .vue SFC cannot be imported into a plain node runner.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { canOpenInDashboards, dashboardOpenRoute } from "./dashboardOpen.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
+const chatSrc = read("..", "views", "ChatView.vue");
+const pageSrc = read("..", "pages", "dashboards", "DashboardsPage.vue");
+const apiSrc = read("..", "api", "dashboards.js");
+
+// The body of a named declaration: everything up to its closing brace, which in
+// these tab-indented sources is the first `}` in column 0 (dashboardRestore's
+// helper — a loose slice would let an assertion pass on the NEXT declaration).
+const fnBody = (src, decl) => {
+	const start = src.indexOf(decl);
+	assert.notEqual(start, -1, `source must still define ${decl}`);
+	const end = src.indexOf("\n}", start + decl.length);
+	assert.notEqual(end, -1, `${decl} must close at the top level`);
+	return src.slice(start, end);
+};
+
+// ---- who gets the affordance ---------------------------------------------
+
+test("only an html artifact of a DASHBOARDS conversation gets the button", () => {
+	assert.equal(canOpenInDashboards("dashboards", { type: "html" }), true);
+	// same conversation, other artifact types: untouched
+	assert.equal(canOpenInDashboards("dashboards", { type: "image" }), false);
+	assert.equal(canOpenInDashboards("dashboards", { type: "pdf" }), false);
+	assert.equal(canOpenInDashboards("dashboards", { type: "svg" }), false);
+	assert.equal(canOpenInDashboards("dashboards", { type: "file" }), false);
+	// same artifact, other conversations: untouched. Triggers conversations are
+	// stamped too, but this change ships the dashboards button only.
+	assert.equal(canOpenInDashboards("triggers", { type: "html" }), false);
+	assert.equal(canOpenInDashboards("", { type: "html" }), false);
+	assert.equal(canOpenInDashboards(undefined, { type: "html" }), false);
+});
+
+test("a junk canvas item never throws", () => {
+	assert.equal(canOpenInDashboards("dashboards", null), false);
+	assert.equal(canOpenInDashboards("dashboards", undefined), false);
+	assert.equal(canOpenInDashboards("dashboards", {}), false);
+});
+
+// ---- where it goes --------------------------------------------------------
+
+test("a saved dashboard opens IN PLACE, so Save keeps updating that row", () => {
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: { name: "DASH-1", dashboard_title: "Sales" },
+			conversation: "c1",
+			messageId: "m1",
+		}),
+		{ path: "/dashboards", query: { edit: "DASH-1" } }
+	);
+});
+
+test("an unsaved build is promoted from the transcript instead", () => {
+	const promote = { path: "/dashboards", query: { chat: "c1", canvas: "m1" } };
+	assert.deepEqual(
+		dashboardOpenRoute({ dashboard: null, conversation: "c1", messageId: "m1" }),
+		promote
+	);
+	// {} is the server's ordinary "no saved dashboard" answer, not an error
+	assert.deepEqual(
+		dashboardOpenRoute({ dashboard: {}, conversation: "c1", messageId: "m1" }),
+		promote
+	);
+	assert.deepEqual(
+		dashboardOpenRoute({ dashboard: { name: "" }, conversation: "c1", messageId: "m1" }),
+		promote
+	);
+	// ...and a lookup that never resolved (undefined) still routes somewhere
+	assert.deepEqual(
+		dashboardOpenRoute({ dashboard: undefined, conversation: "c1", messageId: "m1" }),
+		promote
+	);
+});
+
+// ---- main chat: the affordance is conversation state, not html-sniffing ----
+
+test("ChatView reads the conversation's origin_page and clears it on switch", () => {
+	assert.match(
+		chatSrc,
+		/import \{ canOpenInDashboards, dashboardOpenRoute \} from "@\/lib\/dashboardOpen";/
+	);
+	assert.match(chatSrc, /const originPage = ref\(""\);/);
+	const load = fnBody(chatSrc, "async function loadConversation(");
+	assert.match(load, /originPage\.value = d\?\.conversation\?\.origin_page \|\| "";/);
+	// the no-conversation arm must reset it, or the button survives onto a chat
+	// that has no dashboards at all
+	assert.match(load, /originPage\.value = "";/);
+	assert.ok(
+		load.indexOf('originPage.value = "";') <
+			load.indexOf("originPage.value = d?.conversation?.origin_page"),
+		"the reset belongs to the `if (!id)` arm, above the load"
+	);
+});
+
+test("the inline card offers it as a SIBLING button, never nested in the card", () => {
+	// .jv-artifact is itself a <button>; a button inside a button is invalid
+	// HTML and browsers drop it out of the card entirely.
+	assert.match(chatSrc, /<div v-else class="jv-artifact-group">/);
+	const group = chatSrc.slice(
+		chatSrc.indexOf('<div v-else class="jv-artifact-group">'),
+		chatSrc.indexOf("</template>", chatSrc.indexOf('<div v-else class="jv-artifact-group">'))
+	);
+	assert.match(group, /class="jv-artifact"/);
+	assert.match(group, /v-if="canOpenDash\(cv\)"/);
+	assert.match(group, /@click="openInDashboards\(m, cv\)"/);
+	assert.match(group, /Open in Dashboards/);
+	// the button closes the card's <button> first
+	assert.ok(
+		group.indexOf("</button>") < group.indexOf('v-if="canOpenDash(cv)"'),
+		"the affordance must follow the card, not live inside it"
+	);
+});
+
+test("the open preview panel offers the same hand-off for the open artifact", () => {
+	const head = chatSrc.slice(
+		chatSrc.indexOf('<div class="jv-artifact-head">'),
+		chatSrc.indexOf('<div class="jv-artifact-body">')
+	);
+	assert.notEqual(head, "", "the artifact preview header must still exist");
+	assert.match(head, /v-if="canOpenDash\(artifact\.cv\)"/);
+	assert.match(head, /@click="openInDashboards\(artifact\.m, artifact\.cv\)"/);
+	assert.match(head, /aria-label="Open in Dashboards"/);
+	// alongside the existing open/download actions, not instead of them
+	assert.match(head, /title="Open in new tab"/);
+	assert.match(head, /title="Download"/);
+});
+
+test("a failed lookup degrades to the promotion route — never a dead button", () => {
+	const open = fnBody(chatSrc, "async function openInDashboards(");
+	assert.match(open, /dashboard = await dashboardForConversation\(conv\);/);
+	assert.match(open, /catch \(e\) \{/);
+	// the catch must not return: it falls through with no saved dashboard
+	const afterCatch = open.slice(open.indexOf("catch (e) {"));
+	assert.doesNotMatch(afterCatch, /\breturn;/);
+	assert.match(open, /dashboard = null;/);
+	assert.match(
+		open,
+		/router\.push\(dashboardOpenRoute\(\{ dashboard, conversation: conv, messageId: m\.name \}\)\);/
+	);
+	// the panel is closed on the way out; leaving it up over the new page is a
+	// modal stranded on a route that never opened it
+	assert.ok(
+		open.indexOf("closeArtifact();") < open.indexOf("router.push("),
+		"close the preview before navigating"
+	);
+	assert.match(apiSrc, /export const dashboardForConversation = \(conversation\) =>/);
+	assert.match(
+		apiSrc,
+		/call\(DB \+ "dashboard_for_conversation", \{ conversation \}\)\.then\(unwrap\)/
+	);
+});
+
+test("main chat never writes the builder's sticky slots", () => {
+	// The builder owns jarvis-dash-* storage; ChatView routes and nothing else,
+	// or two surfaces end up fighting over one slot.
+	assert.doesNotMatch(chatSrc, /jarvis-dash-/);
+});
+
+// ---- the builder: promoting ?chat=&canvas= --------------------------------
+
+test("the deep-link is read at setup AND watched, like ?edit=", () => {
+	assert.match(pageSrc, /const routeChat = typeof route\.query\.chat === "string"/);
+	assert.match(pageSrc, /const routeCanvas = typeof route\.query\.canvas === "string"/);
+	const watcher = pageSrc.slice(
+		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
+	);
+	assert.notEqual(watcher, "", "?chat=&canvas= must be watched, not read once at setup");
+	assert.match(watcher.slice(0, watcher.indexOf("\n);")), /promoteFromChat\(conv, msg\);/);
+	// and the mount path runs it too
+	assert.match(
+		pageSrc,
+		/promoteFromChat\(routeChat, routeCanvas, \{ fallback: normalMount \}\)/
+	);
+});
+
+test("?edit= wins over ?chat=, and says so", () => {
+	const watcher = pageSrc.slice(
+		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
+	);
+	const body = watcher.slice(0, watcher.indexOf("\n);"));
+	assert.match(body, /if \(route\.query\.edit\) \{/);
+	assert.match(body, /console\.warn\(/);
+	assert.ok(
+		body.indexOf("route.query.edit") < body.indexOf("promoteFromChat("),
+		"the ?edit= check must precede the promotion"
+	);
+	// the mount path makes the same call
+	assert.match(pageSrc, /if \(routeEdit && routeChat\) \{\n\t\tconsole\.warn\(/);
+	assert.match(pageSrc, /if \(!routeEdit && routeChat && routeCanvas\) \{/);
+});
+
+test("the promotion is validated against the transcript, not the link", () => {
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	assert.match(pageSrc, /import \{ builderCanvasFrame \} from "@\/lib\/dashboardRestore";/);
+	assert.match(promote, /await getDashboardConversation\(conversation\)/);
+	assert.match(promote, /frame = builderCanvasFrame\(d\.messages \|\| \[\], messageId\);/);
+	// a message that is gone, or never drew html, says so and leaves the builder
+	// as it was
+	assert.match(promote, /if \(!frame\) \{\n\t\tgiveUp\(/);
+	assert.match(promote, /giveUp\(errMsg\(e\)\);/);
+	const giveUp = promote.slice(promote.indexOf("const giveUp = "));
+	assert.match(giveUp, /stripPromotionQuery\(\);/);
+	assert.match(giveUp, /if \(fallback\) fallback\(\);/);
+});
+
+test("accepting clears the editing identity before repointing the builder", () => {
+	// Without this, Save writes the promoted canvas back over whatever dashboard
+	// the builder happened to be editing.
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
+	for (const line of [
+		/editingSticky\.value = "";/,
+		/editingDetail\.value = null;/,
+		/editSeed\.value = "";/,
+		/savedName\.value = "";/,
+		/chatConv\.value = conversation;/,
+		/canvasMsg\.value = messageId;/,
+	]) {
+		assert.match(accept, line);
+	}
+	// the canvas is rebuilt through the normal frame path — that is what re-runs
+	// the html with the query tools, i.e. "shown with data"
+	assert.match(
+		accept,
+		/const rendered = await onCanvas\(\{ message_id: frame\.message_id, items: frame\.items \}\);/
+	);
+	// ...and an artifact whose File has since gone must not leave the PREVIOUS
+	// document on the canvas with Save armed over the new thread
+	assert.match(accept, /if \(!rendered\) builderHtml\.value = "";/);
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	assert.match(onCanvas, /canvasMsg\.value = message_id;\n\t\treturn true;/);
+	// every other exit says "nothing was rendered"
+	assert.doesNotMatch(onCanvas, /(?<!return false;\n\t)\breturn;/);
+	// clearing builderHtml BEFORE the fetch would unblock the pane's own
+	// transcript restore and let an older frame race this one onto the canvas —
+	// the only clear allowed is the post-fetch one above
+	assert.ok(
+		accept.indexOf("await onCanvas(") < accept.indexOf('builderHtml.value = "";'),
+		"builderHtml is only cleared after the artifact failed to arrive"
+	);
+	assert.equal((accept.match(/builderHtml\.value = "";/g) || []).length, 1);
+});
+
+test("a promotion that would cost the user something confirms first", () => {
+	const guard = fnBody(pageSrc, "function promotionWouldDiscard(");
+	assert.match(guard, /if \(unsavedCanvas\.value\) return true;/);
+	assert.match(
+		guard,
+		/if \(editingSticky\.value \|\| editingDetail\.value \|\| editSeed\.value\) return true;/
+	);
+	assert.match(
+		guard,
+		/return !!\(chatConv\.value && chatConv\.value !== conv && canvasMsg\.value\);/
+	);
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	// `force` is required: confirmDiscard short-circuits on !unsavedCanvas, so an
+	// editing target alone would never reach the dialog
+	assert.match(
+		promote,
+		/confirmDiscard\(accept, \(\) => giveUp\(""\), \{ force: true, copy: PROMOTE_COPY \}\);/
+	);
+	assert.match(
+		promote,
+		/if \(!promotionWouldDiscard\(conversation\)\) \{\n\t\tawait accept\(\);/
+	);
+	// the dialog's copy is per-call now, and the promotion's says the chat lives on
+	assert.match(pageSrc, /const discardCopy = ref\(DISCARD_COPY\);/);
+	assert.match(pageSrc, /title: discardCopy\.title,/);
+	assert.match(pageSrc, /message: discardCopy\.message,/);
+	assert.match(pageSrc, /Its chat stays in your conversations\./);
+	// and the default is restored when the dialog settles, or the next plain
+	// discard inherits the promotion's wording
+	assert.match(fnBody(pageSrc, "function settleDiscard("), /discardCopy\.value = DISCARD_COPY;/);
+});
+
+test("the query is stripped once the promotion settles, both ways", () => {
+	// The ?edit= lesson: clearing the seed before the confirm resolves lets a
+	// restore land mid-dialog. Same rule here — the route write happens on the
+	// settled path, never up front.
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
+	assert.match(accept, /stripPromotionQuery\(""\);/);
+	assert.ok(
+		accept.indexOf("await onCanvas(") < accept.indexOf("stripPromotionQuery("),
+		"strip after the canvas has settled"
+	);
+	const strip = fnBody(pageSrc, "function stripPromotionQuery(");
+	assert.match(strip, /delete q\.chat;/);
+	assert.match(strip, /delete q\.canvas;/);
+	assert.match(strip, /router\.replace\(\{ query: q, hash \}\);/);
+	// re-entrancy: the watcher re-fires on unrelated route writes, and a confirm
+	// dialog spans several of them
+	assert.match(pageSrc, /let promoting = "";/);
+	assert.match(promote, /if \(key === promoting\) return;/);
+	assert.match(promote, /promoting = key;/);
+	// ...but a declined or failed promotion can be asked for again
+	const giveUp = promote.slice(promote.indexOf("const giveUp = "));
+	assert.match(giveUp, /promoting = "";/);
+});

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -1023,7 +1023,16 @@ test("a kept identity repairs itself the moment the user asks to save", () => {
 	assert.match(open, /adoptedRow\.value = "";/);
 	// this await is a window like every other: New chat / ?edit= can land in it
 	assert.match(open, /if \(adoptedRow\.value === name\) \{/);
-	assert.match(open, /if \(!builderHtml\.value\) return;/);
+	// ...and a discard confirm raised inside it owns the screen — the Save dialog
+	// must not stack on top of it
+	assert.match(open, /if \(!builderHtml\.value \|\| discardOpen\.value\) return;/);
+	// the repaired row brings its THEME with it (a repair only runs on a fresh
+	// mount, DEFAULT_THEME picker) — but never over a theme the user picked this
+	// session, or "re-theme my dashboard" would be silently undone
+	assert.match(
+		open,
+		/if \(builderTheme\.value === DEFAULT_THEME\)\n\t\t\t\t\t\tbuilderTheme\.value = themeKey\(d\.theme\);/
+	);
 	// one attempt, not one per click — and the button says it is working
 	assert.match(open, /if \(!builderHtml\.value \|\| repairing\.value\) return;/);
 	assert.match(open, /repairing\.value = true;/);

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -147,10 +147,14 @@ test("editing the saved row later must not re-hijack clicks on newer builds", ()
 	);
 });
 
-test("an unknown timestamp keeps the pre-existing ?edit= behaviour", () => {
-	// A server that predates the `creation` field (or a message row without one)
-	// must degrade to what shipped, not misroute on a guess.
-	for (const messageCreation of [undefined, "", null, "nonsense"]) {
+test("the build still being streamed promotes: no stamp yet means it IS the newest", () => {
+	// Main chat mints the assistant row from the first delta ({name, role,
+	// content, streaming}) and the realtime `canvas` frame hangs the artifact on
+	// that same row, so it carries no server `creation` until the next transcript
+	// load. That is the normal state at the exact moment the card appears — the
+	// likeliest moment to click it — and ?edit= there answers with the older
+	// saved row instead of the build the user just watched being drawn.
+	for (const messageCreation of [undefined, "", null]) {
 		assert.deepEqual(
 			dashboardOpenRoute({
 				dashboard: SAVED,
@@ -158,9 +162,24 @@ test("an unknown timestamp keeps the pre-existing ?edit= behaviour", () => {
 				messageId: "m2",
 				messageCreation,
 			}),
-			{ path: "/dashboards", query: { edit: "DASH-1" } }
+			{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
 		);
 	}
+});
+
+test("an unreadable stamp keeps the pre-existing ?edit= behaviour", () => {
+	// A stamp that is present but unparseable is an old/odd server, not a live
+	// frame: degrade to what shipped rather than guessing.
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: SAVED,
+			conversation: "c1",
+			messageId: "m2",
+			messageCreation: "nonsense",
+		}),
+		{ path: "/dashboards", query: { edit: "DASH-1" } }
+	);
+	// ...and so does a saved row that reports no `creation` of its own
 	assert.deepEqual(
 		dashboardOpenRoute({
 			dashboard: { name: "DASH-1" },
@@ -266,19 +285,24 @@ test("ChatView reads the conversation's origin_page and clears it on switch", ()
 	assert.match(chatSrc, /const originPage = ref\(""\);/);
 	const load = fnBody(chatSrc, "async function loadConversation(");
 	assert.match(load, /originPage\.value = d\?\.conversation\?\.origin_page \|\| "";/);
-	// the no-conversation arm must reset it, or the button survives onto a chat
-	// that has no dashboards at all
+	// the reset runs BEFORE the round trip, on every path. `messages` is only
+	// replaced when the response lands, so for one full RTT the PREVIOUS
+	// conversation's cards are on screen under the new currentId — and a fetch
+	// that rejects would otherwise leave the old origin standing for the session
 	assert.match(load, /originPage\.value = "";/);
 	assert.ok(
-		load.indexOf('originPage.value = "";') <
-			load.indexOf("originPage.value = d?.conversation?.origin_page"),
-		"the reset belongs to the `if (!id)` arm, above the load"
+		load.indexOf('originPage.value = "";') < load.indexOf("if (!id) {"),
+		"the reset belongs above the `if (!id)` arm, not inside it"
+	);
+	assert.ok(
+		load.indexOf('originPage.value = "";') < load.indexOf("await api.getConversation(id)"),
+		"the reset must precede the fetch"
 	);
 });
 
 test("every path that swaps the conversation out resets originPage too", () => {
 	// loadConversation is the only OTHER writer, and it does not run on these
-	// three: the route watcher no-ops when currentId is already the new id, and
+	// four: the route watcher no-ops when currentId is already the new id, and
 	// the boot arm is the failure of the load itself. A stale "dashboards" here
 	// puts the button on an ordinary chat's html — with Save armed over it once
 	// the builder promotes it.
@@ -291,9 +315,17 @@ test("every path that swaps the conversation out resets originPage too", () => {
 		chatSrc,
 		/currentId\.value = null;\s*messages\.value = \[\];\s*originPage\.value = "";/
 	);
-	// four writers of the empty value, no more: loadConversation's !id arm plus
-	// the three above (a fifth would mean a path nobody reviewed)
-	assert.equal((chatSrc.match(/originPage\.value = "";/g) || []).length, 4);
+	// ...and the watcher that drops it when it is deleted from the sidebar while
+	// open: the user's next send adopts the server id directly, so nothing
+	// re-reads the conversation and the origin would follow them onto it
+	const vanish = chatSrc.slice(chatSrc.indexOf("watch(\n\t() => store.conversations,"));
+	const vanishBody = vanish.slice(0, vanish.indexOf("\n);"));
+	assert.notEqual(vanishBody, "", "the vanished-conversation watcher must still exist");
+	assert.match(vanishBody, /currentId\.value = null;/);
+	assert.match(vanishBody, /originPage\.value = "";/);
+	// five writers of the empty value, no more: loadConversation's pre-fetch
+	// reset plus the four above (a sixth would mean a path nobody reviewed)
+	assert.equal((chatSrc.match(/originPage\.value = "";/g) || []).length, 5);
 });
 
 test("the open artifact carries the conversation it was opened from", () => {
@@ -418,15 +450,25 @@ test("a pending promotion holds the pane's restore off, exactly as ?edit= does",
 	);
 	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
 	assert.match(accept, /promotionPending\.value = false;/);
-	// the live watcher arms it before handing over
+	// The hold is armed inside promoteFromChat, BELOW its dedupe check. The query
+	// watcher wakes on any route write and would re-arm with a pair already in
+	// flight — a call that then dedupes away, leaving an armed hold nothing is
+	// going to settle and the pane's restore blocked for the life of the page.
+	assert.ok(
+		promote.indexOf("if (key === promoting) return;") <
+			promote.indexOf("promotionPending.value = true;"),
+		"arm the hold below the dedupe check"
+	);
+	// ...and still above the first await, so no restore can slip in ahead of it
+	assert.ok(
+		promote.indexOf("promotionPending.value = true;") < promote.indexOf("await "),
+		"arm the hold synchronously, before anything yields"
+	);
 	const watcher = pageSrc.slice(
 		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
 	);
 	const body = watcher.slice(0, watcher.indexOf("\n);"));
-	assert.ok(
-		body.indexOf("promotionPending.value = true;") < body.indexOf("promoteFromChat("),
-		"arm the hold before the promotion, not after"
-	);
+	assert.doesNotMatch(body, /promotionPending\.value = true;/);
 	// ...and a mount that will NOT promote releases the setup-time hold, or the
 	// pane's restore stays blocked for the life of the page
 	assert.match(pageSrc, /promotionPending\.value = false;\n\t\tnormalMount\(\);/);
@@ -525,10 +567,8 @@ test("a promotion that would cost the user something confirms first", () => {
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	// `force` is required: confirmDiscard short-circuits on !unsavedCanvas, so an
 	// editing target alone would never reach the dialog
-	assert.match(
-		promote,
-		/confirmDiscard\(accept, \(\) => giveUp\(""\), \{ force: true, copy: PROMOTE_COPY \}\);/
-	);
+	assert.match(promote, /confirmDiscard\(accept, \(\) => giveUp\(""\), \{\n\t\tforce: true,/);
+	assert.match(promote, /copy: PROMOTE_COPY,/);
 	assert.match(
 		promote,
 		/if \(!promotionWouldDiscard\(conversation\)\) \{\n\t\tawait accept\(\);/
@@ -541,6 +581,23 @@ test("a promotion that would cost the user something confirms first", () => {
 	// and the default is restored when the dialog settles, or the next plain
 	// discard inherits the promotion's wording
 	assert.match(fnBody(pageSrc, "function settleDiscard("), /discardCopy\.value = DISCARD_COPY;/);
+});
+
+test("that confirm never offers to open the chat it was clicked from", () => {
+	// "Open its chat" is the escape hatch to the thread the builder is holding —
+	// an escape only while that is somewhere else. In the case these rules
+	// deliberately still confirm (the builder's OWN thread, with an editing
+	// identity at stake), it is the conversation the user clicked "Open in
+	// Dashboards" in, so the action lands them straight back there.
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	assert.match(promote, /offerChat: chatConv\.value !== conversation,/);
+	assert.match(pageSrc, /const discardOfferChat = ref\(true\);/);
+	assert.match(pageSrc, /if \(chatConv\.value && discardOfferChat\.value\) \{/);
+	const confirm = fnBody(pageSrc, "function confirmDiscard(");
+	assert.match(confirm, /offerChat = true/);
+	assert.match(confirm, /discardOfferChat\.value = offerChat;/);
+	// per-call, exactly like the copy: the next plain discard gets it back
+	assert.match(fnBody(pageSrc, "function settleDiscard("), /discardOfferChat\.value = true;/);
 });
 
 test("the query is stripped once the promotion settles, both ways", () => {
@@ -566,4 +623,7 @@ test("the query is stripped once the promotion settles, both ways", () => {
 	// ...but a declined or failed promotion can be asked for again
 	const giveUp = promote.slice(promote.indexOf("const giveUp = "));
 	assert.match(giveUp, /promoting = "";/);
+	// ...and so can an ACCEPTED one: a key left behind dedupes every later
+	// request for that same pair into silence for the life of the page
+	assert.match(accept, /promoting = "";/);
 });

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -514,6 +514,33 @@ test("a fetch blip keeps the identity the skipped confirm promised to keep", () 
 	assert.equal(denied.name, "");
 });
 
+test("a row that is GONE answered — it is not the blip that keeps the identity", () => {
+	// The carve-out above ("a fetch that answered 'you may not edit this'") does
+	// not cover the case that actually happens: get_dashboard is read-gated, so a
+	// deleted row, or one whose access was revoked mid-session, THROWS — it never
+	// comes back as can_edit:false. Read as a blip it would keep an identity whose
+	// row no longer exists, and "Save changes" then throws DoesNotExistError /
+	// PermissionError with the dialog already filled in.
+	const gone = { dash: "DASH-1", detail: null, priorName: "DASH-1", gone: true };
+	assert.equal(adoptionIdentity(gone).keepPrior, false);
+	assert.equal(adoptionIdentity(gone).name, "");
+	assert.equal(adoptionIdentity(gone).adopted, null);
+	// a fetch that never answered is still a blip, and still keeps the promise
+	assert.equal(adoptionIdentity({ ...gone, gone: false }).keepPrior, true);
+	assert.equal(adoptionIdentity({ ...gone, gone: false }).name, "DASH-1");
+	// absent reads as "not gone": nothing is kept that was not kept before
+	assert.equal(adoptionIdentity({ ...gone, gone: undefined }).keepPrior, true);
+	// and it never overrides a fetch that DID answer with a row
+	assert.equal(adoptionIdentity({ ...gone, detail: DETAIL }).adopted, DETAIL);
+	assert.equal(adoptionIdentity({ ...gone, detail: DETAIL }).name, "DASH-1");
+	// the funnel classifies with the same isGoneError the remount path uses —
+	// without it every error arrives as `detail = null` and is read as a blip
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	assert.match(promote, /gone = isGoneError\(e\);/);
+	assert.match(promote, /adoptionIdentity\(\{ dash, detail, priorName, gone \}\)/);
+	assert.match(fnBody(pageSrc, "function isGoneError("), /isPermissionError\(e\)/);
+});
+
 // ---- main chat: the affordance is conversation state, not html-sniffing ----
 
 test("ChatView binds the origin to the conversation it was read for", () => {
@@ -848,11 +875,14 @@ test("the promotion ADOPTS the saved row main chat named", () => {
 	// the identity it comes away with is decided by the pure function above, on
 	// what the fetch answered and what the builder already had
 	assert.match(accept, /const priorName = editingName\(\);/);
-	assert.match(accept, /const identity = adoptionIdentity\(\{ dash, detail, priorName \}\);/);
+	assert.match(
+		accept,
+		/const identity = adoptionIdentity\(\{ dash, detail, priorName, gone \}\);/
+	);
 	// a name that fails the (permission-gated) fetch degrades to the identity-less
 	// promotion — a URL-supplied `dash` is never a dead click, and never a trusted
 	// one either
-	assert.match(accept, /\} catch \(e\) \{\n\t\t\t\tdetail = null;/);
+	assert.match(accept, /gone = isGoneError\(e\);\n\t\t\t\tdetail = null;/);
 	// the adopted row supplies the IDENTITY only: its html must never reach the
 	// canvas, or the promotion answers with the saved document instead of the
 	// build the user clicked
@@ -929,6 +959,112 @@ test("the adoption resume restores the identity WITHOUT the row's html", () => {
 		"the adopted state is restored instead of the edit seed, not after it"
 	);
 	assert.match(mount, /promoteFromChat\(routeChat, routeCanvas, \{ fallback: normalMount/);
+});
+
+test("an identity discarded while the resume was in flight stays discarded", () => {
+	// The window is real and wide: the caps probe ahead of this can sleep a full
+	// second and retry before resumeAdoption even starts, and the pane's "New
+	// chat" sits on screen throughout. It runs clearBuilder — which short-circuits
+	// the confirm, because the canvas is still empty — so the user is looking at a
+	// builder they believe is fresh when the fetch lands. Writing the identity
+	// then attaches DASH-7 to whatever they build next, the dialog silently reads
+	// "Save changes", and the save overwrites DASH-7's html, sources and title.
+	const resume = fnBody(pageSrc, "async function resumeAdoption(");
+	const bail = "if (adoptedRow.value !== name) return;";
+	assert.equal(
+		(resume.match(/if \(adoptedRow\.value !== name\) return;/g) || []).length,
+		2,
+		"both branches re-check after the await, not just one"
+	);
+	// the catch branch: the re-check comes before it forgets a gone row
+	const failure = resume.slice(resume.indexOf("} catch (e) {"));
+	assert.ok(
+		failure.indexOf(bail) >= 0 &&
+			failure.indexOf(bail) < failure.indexOf("if (isGoneError(e))"),
+		"the catch branch bails before it writes"
+	);
+	// the success branch: before every write it makes
+	const success = resume.slice(resume.lastIndexOf(bail));
+	for (const write of [
+		"editingDetail.value = d;",
+		"editingSticky.value = d.name;",
+		"savedName.value = d.name;",
+		"builderTheme.value = themeKey(d.theme);",
+		"adoptedRow.value = d.name;",
+	]) {
+		assert.ok(success.includes(write), `the success writes follow the re-check: ${write}`);
+	}
+	// ...including the "gone, or no longer editable" tail
+	assert.ok(
+		success.lastIndexOf('adoptedRow.value = "";') >
+			success.indexOf("adoptedRow.value = d.name;"),
+		"the not-editable tail is inside the re-checked region too"
+	);
+});
+
+test("a kept identity repairs itself the moment the user asks to save", () => {
+	// The blip branch above keeps a NAME. Nothing reads it: the dialog's title,
+	// its "Save changes" label and the `name` on the payload all come off
+	// `editingDetail`, which a fresh mount has none of — so the promise "the row
+	// is kept" ends in the duplicate it was made to prevent. One repair fetch, at
+	// the only moment it matters.
+	const open = fnBody(pageSrc, "async function openSave(");
+	assert.match(open, /const name = adoptedRow\.value;/);
+	assert.match(open, /if \(name && !editingDetail\.value\) \{/);
+	assert.match(open, /const d = await getDashboard\(name\);/);
+	// success: the detail lands, so Save updates in place
+	assert.match(
+		open,
+		/if \(d && d\.name && d\.can_edit\) \{\n\t\t\t\t\teditingDetail\.value = d;/
+	);
+	// gone, or no longer editable: drop the identity rather than offer a "Save
+	// changes" that throws once the dialog has been filled in
+	assert.match(open, /if \(adoptedRow\.value === name && isGoneError\(e\)\) \{/);
+	assert.match(open, /adoptedRow\.value = "";/);
+	// this await is a window like every other: New chat / ?edit= can land in it
+	assert.match(open, /if \(adoptedRow\.value === name\) \{/);
+	assert.match(open, /if \(!builderHtml\.value\) return;/);
+	// one attempt, not one per click — and the button says it is working
+	assert.match(open, /if \(!builderHtml\.value \|\| repairing\.value\) return;/);
+	assert.match(open, /repairing\.value = true;/);
+	assert.match(open, /\} finally \{\n\t\t\trepairing\.value = false;/);
+	assert.match(pageSrc, /:loading="repairing"/);
+	// and the comment that claimed the blip branch kept the promise on its own
+	// now points at the mechanism that actually does
+	assert.match(fnBody(pageSrc, "async function resumeAdoption("), /openSave\(\)/);
+});
+
+test("an adoption whose artifact is gone falls back to the row it adopted", () => {
+	// accept() blanks the canvas when the promoted artifact cannot be fetched, but
+	// keeps the identity — so the next mount restores "Editing X", replays the
+	// same dead message, and latches: empty canvas, badge, Save disabled, every
+	// time. The build is unrecoverable; the ROW still holds a document.
+	const failed = fnBody(pageSrc, "function restoreFailed(");
+	assert.match(failed, /failedRestores\.add\(message_id\);/);
+	assert.match(failed, /if \(message_id !== canvasMsg\.value \|\| !adoptedRow\.value\) return;/);
+	assert.match(failed, /editSeed\.value = name;/);
+	assert.match(failed, /loadEdit\(name, \{ deepLink: false \}\);/);
+	// the latch is set FIRST, so the pane's next transcript load cannot re-enter
+	// this (onCanvas drops a latched message before it fetches anything)
+	assert.ok(
+		failed.indexOf("failedRestores.add(message_id);") < failed.indexOf("loadEdit(name,"),
+		"the loop guard goes up before the fallback runs"
+	);
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	assert.equal(
+		(onCanvas.match(/if \(restore\) restoreFailed\(message_id\);/g) || []).length,
+		2,
+		"both failure branches — no content, and a thrown fetch"
+	);
+	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return false;/);
+	// loadEdit is what ends the adoption: the canvas becomes the row's own html,
+	// so the two documents are one again
+	const edit = fnBody(pageSrc, "async function loadEdit(");
+	assert.match(edit, /adoptedRow\.value = "";/);
+	assert.match(edit, /canvasMsg\.value = "";/);
+	// a live frame's failure is untouched — it toasts, and there is no stale
+	// identity to fall back from
+	assert.match(onCanvas, /else toast\.error\(errMsg\(e\)\);/);
 });
 
 test("a promotion that would cost the user something confirms first", () => {

--- a/frontend/src/lib/dashboardOpen.test.js
+++ b/frontend/src/lib/dashboardOpen.test.js
@@ -8,20 +8,29 @@
 // The builder's conversation shows up in the main chat list. Opening it there
 // shows the prompt and the dashboard, but that canvas never runs its queries —
 // accepted — so what was missing was a way back to the page where it does.
-// canOpenInDashboards()/dashboardOpenRoute() are the real logic; the rest is
-// component wiring, fenced here by source assertions (the dashboardRestore
-// precedent) because a .vue SFC cannot be imported into a plain node runner.
+// Every DECISION the feature makes is a pure function in dashboardOpen.js and
+// is tested by behaviour below: who gets the affordance, where a click goes
+// (including which of two documents wins on time), and what a promotion would
+// cost the user. Only component WIRING is fenced by source assertions (the
+// dashboardRestore precedent), because a .vue SFC cannot be imported into a
+// plain node runner.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { canOpenInDashboards, dashboardOpenRoute } from "./dashboardOpen.js";
+import {
+	canOpenInDashboards,
+	dashboardOpenRoute,
+	isNewerStamp,
+	wouldDiscardOnPromotion,
+} from "./dashboardOpen.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
 const chatSrc = read("..", "views", "ChatView.vue");
 const pageSrc = read("..", "pages", "dashboards", "DashboardsPage.vue");
+const paneSrc = read("..", "pages", "dashboards", "DashboardChatPane.vue");
 const apiSrc = read("..", "api", "dashboards.js");
 
 // The body of a named declaration: everything up to its closing brace, which in
@@ -59,12 +68,27 @@ test("a junk canvas item never throws", () => {
 
 // ---- where it goes --------------------------------------------------------
 
+const SAVED = { name: "DASH-1", dashboard_title: "Sales", creation: "2026-07-27 10:00:00.000000" };
+const BEFORE = "2026-07-27 09:59:59.999999";
+const AFTER = "2026-07-27 10:00:00.000001";
+
 test("a saved dashboard opens IN PLACE, so Save keeps updating that row", () => {
 	assert.deepEqual(
 		dashboardOpenRoute({
-			dashboard: { name: "DASH-1", dashboard_title: "Sales" },
+			dashboard: SAVED,
 			conversation: "c1",
 			messageId: "m1",
+			messageCreation: BEFORE,
+		}),
+		{ path: "/dashboards", query: { edit: "DASH-1" } }
+	);
+	// the artifact that IS the saved document (same instant) is not "newer"
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: SAVED,
+			conversation: "c1",
+			messageId: "m1",
+			messageCreation: SAVED.creation,
 		}),
 		{ path: "/dashboards", query: { edit: "DASH-1" } }
 	);
@@ -92,6 +116,146 @@ test("an unsaved build is promoted from the transcript instead", () => {
 	);
 });
 
+test("a build made AFTER the save wins the click, saved row or not", () => {
+	// The thread keeps iterating after its first save: "this conversation has a
+	// dashboard" is not "this artifact IS that dashboard". Routing a newer
+	// artifact to ?edit= answers with a different document and leaves the one
+	// the user pointed at unreachable (every later click routes the same way).
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: SAVED,
+			conversation: "c1",
+			messageId: "m2",
+			messageCreation: AFTER,
+		}),
+		{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
+	);
+});
+
+test("editing the saved row later must not re-hijack clicks on newer builds", () => {
+	// The comparison is on `creation`, never `modified` — otherwise touching the
+	// old dashboard once puts it back in front of every artifact built since.
+	const editedJustNow = { ...SAVED, modified: "2099-01-01 00:00:00.000000" };
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: editedJustNow,
+			conversation: "c1",
+			messageId: "m2",
+			messageCreation: AFTER,
+		}),
+		{ path: "/dashboards", query: { chat: "c1", canvas: "m2" } }
+	);
+});
+
+test("an unknown timestamp keeps the pre-existing ?edit= behaviour", () => {
+	// A server that predates the `creation` field (or a message row without one)
+	// must degrade to what shipped, not misroute on a guess.
+	for (const messageCreation of [undefined, "", null, "nonsense"]) {
+		assert.deepEqual(
+			dashboardOpenRoute({
+				dashboard: SAVED,
+				conversation: "c1",
+				messageId: "m2",
+				messageCreation,
+			}),
+			{ path: "/dashboards", query: { edit: "DASH-1" } }
+		);
+	}
+	assert.deepEqual(
+		dashboardOpenRoute({
+			dashboard: { name: "DASH-1" },
+			conversation: "c1",
+			messageId: "m2",
+			messageCreation: AFTER,
+		}),
+		{ path: "/dashboards", query: { edit: "DASH-1" } }
+	);
+});
+
+test("frappe timestamps compare exactly, microseconds and all", () => {
+	assert.equal(isNewerStamp("2026-07-27 10:00:00.000002", "2026-07-27 10:00:00.000001"), true);
+	assert.equal(isNewerStamp("2026-07-27 10:00:00.000001", "2026-07-27 10:00:00.000002"), false);
+	// equal is not newer, however the two sides spell it
+	assert.equal(isNewerStamp("2026-07-27 10:00:00", "2026-07-27 10:00:00.000000"), false);
+	assert.equal(isNewerStamp("2026-07-27 10:00:01", "2026-07-27 10:00:00.999999"), true);
+	// dates and months carry, not just the time
+	assert.equal(isNewerStamp("2026-08-01 00:00:00", "2026-07-31 23:59:59.999999"), true);
+	assert.equal(isNewerStamp("2026-07-31 23:59:59.999999", "2026-08-01 00:00:00"), false);
+	// the ISO separator the wire sometimes uses
+	assert.equal(isNewerStamp("2026-07-27T10:00:01", "2026-07-27 10:00:00"), true);
+	// anything unreadable answers "not newer" on either side
+	for (const bad of ["", null, undefined, "not a date", 12345, {}]) {
+		assert.equal(isNewerStamp(bad, "2026-07-27 10:00:00"), false);
+		assert.equal(isNewerStamp("2026-07-27 10:00:00", bad), false);
+	}
+});
+
+// ---- what a promotion would cost -----------------------------------------
+
+const SAME = { conv: "C", chatConv: "C", canvasMsg: "M1", unsavedCanvas: false, editing: false };
+
+test("re-opening the builder's OWN thread never confirms", () => {
+	// The feature's primary path: the user built here, went to main chat, and
+	// clicked the way back. Both messages live in one transcript, so repointing
+	// the canvas loses nothing — and a confirm here is worse than noise, since
+	// its "Open its chat" action lands back in the chat they clicked from.
+	assert.equal(wouldDiscardOnPromotion(SAME), false);
+	// the restored canvas of that same thread reads as "unsaved" on a fresh
+	// mount (editingDetail is null) — still nothing to lose
+	assert.equal(wouldDiscardOnPromotion({ ...SAME, unsavedCanvas: true }), false);
+	// a DIFFERENT message of the same thread, and a builder with no canvas yet
+	assert.equal(
+		wouldDiscardOnPromotion({ ...SAME, canvasMsg: "M2", unsavedCanvas: true }),
+		false
+	);
+	assert.equal(wouldDiscardOnPromotion({ ...SAME, canvasMsg: "" }), false);
+});
+
+test("the same thread WITH an editing identity still confirms", () => {
+	// Accepting flips Save from update-in-place to create-new. That is a real
+	// identity change and the user has to own it.
+	assert.equal(wouldDiscardOnPromotion({ ...SAME, editing: true }), true);
+	assert.equal(wouldDiscardOnPromotion({ ...SAME, editing: true, unsavedCanvas: true }), true);
+});
+
+test("a different conversation keeps the full guard", () => {
+	const other = {
+		conv: "D",
+		chatConv: "C",
+		canvasMsg: "M1",
+		unsavedCanvas: false,
+		editing: false,
+	};
+	// another thread's restored canvas
+	assert.equal(wouldDiscardOnPromotion(other), true);
+	// an unsaved canvas, or an editing target, on their own
+	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "", unsavedCanvas: true }), true);
+	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "", editing: true }), true);
+	// ...but a builder holding nothing is not worth a dialog
+	assert.equal(wouldDiscardOnPromotion({ ...other, canvasMsg: "" }), false);
+	assert.equal(
+		wouldDiscardOnPromotion({
+			conv: "D",
+			chatConv: "",
+			canvasMsg: "",
+			unsavedCanvas: false,
+			editing: false,
+		}),
+		false
+	);
+	// a fresh builder that has an unsaved canvas but no thread still asks
+	assert.equal(
+		wouldDiscardOnPromotion({
+			conv: "D",
+			chatConv: "",
+			canvasMsg: "",
+			unsavedCanvas: true,
+			editing: false,
+		}),
+		true
+	);
+});
+
 // ---- main chat: the affordance is conversation state, not html-sniffing ----
 
 test("ChatView reads the conversation's origin_page and clears it on switch", () => {
@@ -110,6 +274,39 @@ test("ChatView reads the conversation's origin_page and clears it on switch", ()
 			load.indexOf("originPage.value = d?.conversation?.origin_page"),
 		"the reset belongs to the `if (!id)` arm, above the load"
 	);
+});
+
+test("every path that swaps the conversation out resets originPage too", () => {
+	// loadConversation is the only OTHER writer, and it does not run on these
+	// three: the route watcher no-ops when currentId is already the new id, and
+	// the boot arm is the failure of the load itself. A stale "dashboards" here
+	// puts the button on an ordinary chat's html — with Save armed over it once
+	// the builder promotes it.
+	const nc = fnBody(chatSrc, "async function newChat(");
+	assert.match(nc, /messages\.value = \[\];\n\t\/\/[^]*?originPage\.value = "";/);
+	const clear = fnBody(chatSrc, "async function clearAllHistory(");
+	assert.match(clear, /messages\.value = \[\];\s*originPage\.value = "";/);
+	// the boot arm that drops a conversation which has since vanished
+	assert.match(
+		chatSrc,
+		/currentId\.value = null;\s*messages\.value = \[\];\s*originPage\.value = "";/
+	);
+	// four writers of the empty value, no more: loadConversation's !id arm plus
+	// the three above (a fifth would mean a path nobody reviewed)
+	assert.equal((chatSrc.match(/originPage\.value = "";/g) || []).length, 4);
+});
+
+test("the open artifact carries the conversation it was opened from", () => {
+	// The preview overlay is absolute inside ChatView, so the AppShell sidebar
+	// stays clickable behind it: without the stamp the header's hand-off pairs
+	// the CURRENT conversation with the PREVIOUS one's message id.
+	const open = fnBody(chatSrc, "async function openArtifact(");
+	assert.match(open, /const conv = currentId\.value;/);
+	const assigns = open.match(/artifact\.value = \{[^}]*\}/g) || [];
+	assert.equal(assigns.length, 7, "every artifact.value assignment must be accounted for");
+	for (const a of assigns) assert.match(a, /\bconv,/);
+	// the sheet switcher re-assigns a spread copy, so it keeps the stamp
+	assert.match(chatSrc, /artifact\.value = \{ \.\.\.artifact\.value, sheetIdx: si \};/);
 });
 
 test("the inline card offers it as a SIBLING button, never nested in the card", () => {
@@ -131,13 +328,13 @@ test("the inline card offers it as a SIBLING button, never nested in the card", 
 	);
 });
 
-test("the open preview panel offers the same hand-off for the open artifact", () => {
+test("the open preview panel offers the same hand-off, for its OWN conversation", () => {
 	const head = chatSrc.slice(
 		chatSrc.indexOf('<div class="jv-artifact-head">'),
 		chatSrc.indexOf('<div class="jv-artifact-body">')
 	);
 	assert.notEqual(head, "", "the artifact preview header must still exist");
-	assert.match(head, /v-if="canOpenDash\(artifact\.cv\)"/);
+	assert.match(head, /v-if="canOpenDash\(artifact\.cv\) && artifact\.conv === currentId"/);
 	assert.match(head, /@click="openInDashboards\(artifact\.m, artifact\.cv\)"/);
 	assert.match(head, /aria-label="Open in Dashboards"/);
 	// alongside the existing open/download actions, not instead of them
@@ -153,10 +350,10 @@ test("a failed lookup degrades to the promotion route — never a dead button", 
 	const afterCatch = open.slice(open.indexOf("catch (e) {"));
 	assert.doesNotMatch(afterCatch, /\breturn;/);
 	assert.match(open, /dashboard = null;/);
-	assert.match(
-		open,
-		/router\.push\(dashboardOpenRoute\(\{ dashboard, conversation: conv, messageId: m\.name \}\)\);/
-	);
+	// the clicked message's own creation decides the fork
+	assert.match(open, /messageId: m\.name,/);
+	assert.match(open, /messageCreation: m\.creation,/);
+	assert.match(open, /router\.push\(\s*dashboardOpenRoute\(\{/);
 	// the panel is closed on the way out; leaving it up over the new page is a
 	// modal stranded on a route that never opened it
 	assert.ok(
@@ -193,6 +390,48 @@ test("the deep-link is read at setup AND watched, like ?edit=", () => {
 	);
 });
 
+test("a pending promotion holds the pane's restore off, exactly as ?edit= does", () => {
+	// The pane's onMounted fires BEFORE this page's, and the promotion waits on
+	// the caps probe — so the transcript restore reliably lands first, and its
+	// canvas then reads as unsaved work to the discard guard. routeChat/
+	// routeCanvas were already read at setup for this; the hold is what uses it.
+	assert.match(pageSrc, /const promotionPending = ref\(!!\(routeChat && routeCanvas\)\);/);
+	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
+	assert.equal(
+		(onCanvas.match(/promotionPending\.value/g) || []).length,
+		2,
+		"both restore guards — before AND after the get_canvas round trip"
+	);
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	const giveUp = promote.slice(
+		promote.indexOf("const giveUp = "),
+		promote.indexOf("// Validate against the transcript")
+	);
+	assert.match(giveUp, /promotionPending\.value = false;/);
+	// a decline must leave the builder AS IT WAS: the frame the pane emitted
+	// while the hold was up was dropped, so ask for it again
+	assert.match(giveUp, /chatPane\.value\.restoreCanvas\(\)/);
+	assert.match(paneSrc, /defineExpose\(\{ resetChat, sendText, restoreCanvas \}\);/);
+	assert.match(
+		fnBody(paneSrc, "function restoreCanvas("),
+		/emit\("canvas", \{ \.\.\.frame, restore: true \}\)/
+	);
+	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
+	assert.match(accept, /promotionPending\.value = false;/);
+	// the live watcher arms it before handing over
+	const watcher = pageSrc.slice(
+		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
+	);
+	const body = watcher.slice(0, watcher.indexOf("\n);"));
+	assert.ok(
+		body.indexOf("promotionPending.value = true;") < body.indexOf("promoteFromChat("),
+		"arm the hold before the promotion, not after"
+	);
+	// ...and a mount that will NOT promote releases the setup-time hold, or the
+	// pane's restore stays blocked for the life of the page
+	assert.match(pageSrc, /promotionPending\.value = false;\n\t\tnormalMount\(\);/);
+});
+
 test("?edit= wins over ?chat=, and says so", () => {
 	const watcher = pageSrc.slice(
 		pageSrc.indexOf("watch(\n\t() => [route.query.chat, route.query.canvas],")
@@ -223,9 +462,10 @@ test("the promotion is validated against the transcript, not the link", () => {
 	assert.match(giveUp, /if \(fallback\) fallback\(\);/);
 });
 
-test("accepting clears the editing identity before repointing the builder", () => {
+test("accepting clears the editing identity and the stale data-mode", () => {
 	// Without this, Save writes the promoted canvas back over whatever dashboard
-	// the builder happened to be editing.
+	// the builder happened to be editing — and the next send declares a
+	// static/live intent the user never expressed for THIS dashboard.
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
 	for (const line of [
@@ -235,6 +475,7 @@ test("accepting clears the editing identity before repointing the builder", () =
 		/savedName\.value = "";/,
 		/chatConv\.value = conversation;/,
 		/canvasMsg\.value = messageId;/,
+		/dashDataMode\.value = "auto";/,
 	]) {
 		assert.match(accept, line);
 	}
@@ -244,34 +485,43 @@ test("accepting clears the editing identity before repointing the builder", () =
 		accept,
 		/const rendered = await onCanvas\(\{ message_id: frame\.message_id, items: frame\.items \}\);/
 	);
-	// ...and an artifact whose File has since gone must not leave the PREVIOUS
-	// document on the canvas with Save armed over the new thread
-	assert.match(accept, /if \(!rendered\) builderHtml\.value = "";/);
+});
+
+test("a promoted artifact whose content is gone says so, and shows nothing", () => {
+	// An empty canvas alone is indistinguishable from "nothing built yet", and
+	// the query is already stripped by then — there would be no way to tell the
+	// click did anything. Leaving the PREVIOUS document up instead would arm
+	// Save over html that has nothing to do with the thread now underneath it.
+	const promote = fnBody(pageSrc, "async function promoteFromChat(");
+	const accept = promote.slice(promote.indexOf("const accept = async () => {"));
+	assert.match(accept, /if \(!rendered\) \{\n\t\t\tbuilderHtml\.value = "";/);
+	assert.match(accept, /toast\.error\("Couldn't load that dashboard's content/);
+	// builderHtml is NOT cleared before the fetch: promotionPending already holds
+	// the pane's restore off, so the only reason to keep the old document up is
+	// to avoid flashing an empty canvas on the way to the new one
+	assert.ok(
+		accept.indexOf("await onCanvas(") < accept.indexOf('builderHtml.value = "";'),
+		"the canvas is cleared only after the artifact failed to arrive"
+	);
+	assert.equal((accept.match(/builderHtml\.value = "";/g) || []).length, 1);
 	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
 	assert.match(onCanvas, /canvasMsg\.value = message_id;\n\t\treturn true;/);
 	// every other exit says "nothing was rendered"
 	assert.doesNotMatch(onCanvas, /(?<!return false;\n\t)\breturn;/);
-	// clearing builderHtml BEFORE the fetch would unblock the pane's own
-	// transcript restore and let an older frame race this one onto the canvas —
-	// the only clear allowed is the post-fetch one above
-	assert.ok(
-		accept.indexOf("await onCanvas(") < accept.indexOf('builderHtml.value = "";'),
-		"builderHtml is only cleared after the artifact failed to arrive"
-	);
-	assert.equal((accept.match(/builderHtml\.value = "";/g) || []).length, 1);
 });
 
 test("a promotion that would cost the user something confirms first", () => {
+	// The rules themselves are unit-tested above; this fences the wiring.
 	const guard = fnBody(pageSrc, "function promotionWouldDiscard(");
-	assert.match(guard, /if \(unsavedCanvas\.value\) return true;/);
+	assert.match(guard, /return wouldDiscardOnPromotion\(\{/);
+	assert.match(guard, /chatConv: chatConv\.value,/);
+	assert.match(guard, /canvasMsg: canvasMsg\.value,/);
+	assert.match(guard, /unsavedCanvas: unsavedCanvas\.value,/);
 	assert.match(
 		guard,
-		/if \(editingSticky\.value \|\| editingDetail\.value \|\| editSeed\.value\) return true;/
+		/editing: !!\(editingSticky\.value \|\| editingDetail\.value \|\| editSeed\.value\),/
 	);
-	assert.match(
-		guard,
-		/return !!\(chatConv\.value && chatConv\.value !== conv && canvasMsg\.value\);/
-	);
+	assert.match(pageSrc, /import \{ wouldDiscardOnPromotion \} from "@\/lib\/dashboardOpen";/);
 	const promote = fnBody(pageSrc, "async function promoteFromChat(");
 	// `force` is required: confirmDiscard short-circuits on !unsavedCanvas, so an
 	// editing target alone would never reach the dialog

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -124,13 +124,13 @@ test("a restore never overwrites a live canvas or an explicit ?edit target", () 
 	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
 	assert.match(
 		onCanvas,
-		/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return;/
+		/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return false;/
 	);
 	// re-checked AFTER the get_canvas round trip, not just before it
 	assert.equal(
 		(
 			onCanvas.match(
-				/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return;/g
+				/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return false;/g
 			) || []
 		).length,
 		2
@@ -145,7 +145,7 @@ test("an unreadable artifact is retried never, not on every transcript load", ()
 	// run of silent get_canvas calls.
 	assert.match(pageSrc, /const failedRestores = new Set\(\);/);
 	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
-	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return;/);
+	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return false;/);
 	assert.match(onCanvas, /if \(restore\) failedRestores\.add\(message_id\);/);
 });
 

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -138,7 +138,10 @@ test("an unreadable artifact is retried never, not on every transcript load", ()
 	assert.match(pageSrc, /const failedRestores = new Set\(\);/);
 	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
 	assert.match(onCanvas, /if \(restore && failedRestores\.has\(message_id\)\) return false;/);
-	assert.match(onCanvas, /if \(restore\) failedRestores\.add\(message_id\);/);
+	// the latch moved into restoreFailed(), which an ADOPTION also self-heals from
+	// (dashboardOpen.test.js owns that half) — it is still the first thing it does
+	assert.match(onCanvas, /if \(restore\) restoreFailed\(message_id\);/);
+	assert.match(fnBody(pageSrc, "function restoreFailed("), /failedRestores\.add\(message_id\);/);
 });
 
 // ---- D3: switching tabs must not tear the build pipeline down -----------

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -174,8 +174,14 @@ test("a remount restores WHAT WAS BEING EDITED, not just the pixels", () => {
 	assert.match(saveDialogSrc, /if \(e && e\.name\) payload\.name = e\.name;/);
 	assert.match(pageSrc, /:editing="editingDetail"/);
 	assert.match(pageSrc, /const editingSticky = useStorage\(`jarvis-dash-editing-\$\{/);
-	// seeded at setup, BEFORE the chat pane's transcript replay can reach the canvas
-	assert.match(pageSrc, /const editSeed = ref\(routeEdit \|\| editingSticky\.value\);/);
+	// seeded at setup, BEFORE the chat pane's transcript replay can reach the
+	// canvas. The one exception is a builder that went away mid-ADOPTION, where
+	// the canvas WAS the transcript's build and the stored row is behind it
+	// (dashboardOpen.test.js owns that path) — the identity still comes back.
+	assert.match(
+		pageSrc,
+		/const editSeed = ref\(routeEdit \|\| \(adoptionResume \? "" : editingSticky\.value\)\);/
+	);
 	assert.match(
 		pageSrc,
 		/if \(editSeed\.value\) loadEdit\(editSeed\.value, \{ deepLink: !!routeEdit \}\);/

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -229,8 +229,10 @@ test("the discard confirm offers the surviving chat instead of just naming it", 
 	const actions = pageSrc.slice(pageSrc.indexOf("const discardActions = computed("));
 	assert.match(actions, /label: "Open its chat"/);
 	assert.match(actions, /router\.push\("\/c\/" \+ id\)/);
-	// ...only when there IS one
-	assert.match(actions, /if \(chatConv\.value\) \{/);
+	// ...only when there IS one, and only when going there is actually an escape
+	// (a caller already acting on that same conversation drops it — see
+	// dashboardOpen.test.js for the promotion that would otherwise loop)
+	assert.match(actions, /if \(chatConv\.value && discardOfferChat\.value\) \{/);
 });
 
 test("New chat asks the page instead of clearing itself behind a confirm", () => {

--- a/frontend/src/lib/dashboardRestore.test.js
+++ b/frontend/src/lib/dashboardRestore.test.js
@@ -120,21 +120,13 @@ test("the page records WHICH message is on the canvas, under the same key", () =
 	assert.match(fnBody(pageSrc, "async function loadEdit("), /canvasMsg\.value = "";/);
 });
 
-test("a restore never overwrites a live canvas or an explicit ?edit target", () => {
+test("a restore never overwrites a live canvas, an ?edit target or a promotion", () => {
 	const onCanvas = fnBody(pageSrc, "async function onCanvas(");
-	assert.match(
-		onCanvas,
-		/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return false;/
-	);
+	const guard =
+		/if \(restore && \(builderHtml\.value \|\| editSeed\.value \|\| promotionPending\.value\)\)\s*\n?\s*return false;/;
+	assert.match(onCanvas, guard);
 	// re-checked AFTER the get_canvas round trip, not just before it
-	assert.equal(
-		(
-			onCanvas.match(
-				/if \(restore && \(builderHtml\.value \|\| editSeed\.value\)\) return false;/g
-			) || []
-		).length,
-		2
-	);
+	assert.equal((onCanvas.match(new RegExp(guard.source, "g")) || []).length, 2);
 	// a failed replay is silent; only a live frame's failure is surfaced
 	assert.match(onCanvas, /else toast\.error\(errMsg\(e\)\);/);
 });
@@ -245,7 +237,7 @@ test("New chat asks the page instead of clearing itself behind a confirm", () =>
 	// The pane owns no canvas, so it must not act before the page has asked.
 	assert.match(fnBody(paneSrc, "function newChat("), /emit\("reset"\)/);
 	assert.doesNotMatch(fnBody(paneSrc, "function newChat("), /conversation\.value = ""/);
-	assert.match(paneSrc, /defineExpose\(\{ resetChat, sendText \}\)/);
+	assert.match(paneSrc, /defineExpose\(\{ resetChat, sendText, restoreCanvas \}\)/);
 	assert.match(fnBody(pageSrc, "function clearBuilder("), /chatPane\.value\.resetChat\(\)/);
 });
 

--- a/frontend/src/pages/dashboards/DashboardChatPane.vue
+++ b/frontend/src/pages/dashboards/DashboardChatPane.vue
@@ -607,7 +607,16 @@ function sendText(text) {
 	draft.value = t;
 	send();
 }
-defineExpose({ resetChat, sendText });
+// Re-issue the transcript's restore frame. The page holds restores off while a
+// ?chat=&canvas= promotion is in flight (an explicit deep-link owns the canvas);
+// if that promotion is then declined or fails, the frame this pane already
+// emitted has been dropped, and the builder would sit empty until some later
+// transcript load. Declining must leave the builder as it was, so ask again.
+function restoreCanvas() {
+	const frame = builderCanvasFrame(messages.value, canvasMsg.value);
+	if (frame) emit("canvas", { ...frame, restore: true });
+}
+defineExpose({ resetChat, sendText, restoreCanvas });
 
 // ── realtime ──────────────────────────────────────────────────────────────────
 function onEvent(p) {

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -157,7 +157,7 @@
 					:style="{ height: chatPct + '%' }"
 					:caps="caps"
 					:theme="builderTheme"
-					:editing-name="editingDetail ? editingDetail.name : ''"
+					:editing-name="agentEditingName"
 					@canvas="onCanvas"
 					@reset="resetBuilder"
 				/>
@@ -219,7 +219,12 @@ import { getCanvas } from "@/api";
 import { agentName } from "@/branding";
 import { getDashboardsCaps, getDashboard, getDashboardConversation } from "@/api/dashboards";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
-import { wouldDiscardOnPromotion } from "@/lib/dashboardOpen";
+import {
+	adoptionIdentity,
+	agentRevisionTarget,
+	resumesAdoption,
+	wouldDiscardOnPromotion,
+} from "@/lib/dashboardOpen";
 import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes";
 import DashboardCanvas from "./DashboardCanvas.vue";
 import DashboardChatPane from "./DashboardChatPane.vue";
@@ -300,13 +305,42 @@ const dashDataMode = useStorage(`jarvis-dash-datamode-${session.user || "anon"}`
 // updating the one on screen.
 const editingSticky = useStorage(`jarvis-dash-editing-${session.user || "anon"}`, "");
 const canvasMsg = useStorage(`jarvis-dash-canvasmsg-${session.user || "anon"}`, "");
+// The row an ADOPTED promotion is bound to, while the canvas still holds the
+// promoted build. Sticky like the two above, and for the same reason: a remount
+// has to be able to tell "editing that row" from "holding a build that row is
+// behind". Empty again the moment the two are one document - after a Save, or
+// after ?edit= puts the row's own html on the canvas.
+const adoptedRow = useStorage(`jarvis-dash-adopted-${session.user || "anon"}`, "");
+
+// What the builder chat tells the AGENT it is revising - not the same as what
+// Save updates while an adoption is active. See agentRevisionTarget().
+const agentEditingName = computed(() =>
+	agentRevisionTarget({
+		editingName: (editingDetail.value || {}).name || "",
+		adoptionActive: !!adoptedRow.value,
+	})
+);
 
 // A pending ?edit=<name> deep-link, or - on a plain remount - the dashboard the
 // builder was editing when it went away. Read synchronously at setup, i.e.
 // BEFORE the chat pane mounts and replays its transcript's canvas: an explicit
 // edit target owns the canvas, so its restore must not flash a build first.
 const routeEdit = typeof route.query.edit === "string" ? route.query.edit : "";
-const editSeed = ref(routeEdit || editingSticky.value);
+// ...unless this mount is resuming an ADOPTED promotion, where the canvas the
+// user left was the transcript's build and not the row's html. Then the seed is
+// deliberately empty, so the pane's own transcript restore is the thing that
+// refills the canvas (onCanvas holds restores off while a seed is pending) and
+// resumeAdoption() brings back the identity WITHOUT the stored document.
+// Decided synchronously here, from the sticky slots, for the same reason the
+// seed is: the pane mounts first.
+const adoptionResume = resumesAdoption({
+	routeEdit,
+	adoptedRow: adoptedRow.value,
+	editingSticky: editingSticky.value,
+	canvasMsg: canvasMsg.value,
+	chatConv: chatConv.value,
+});
+const editSeed = ref(routeEdit || (adoptionResume ? "" : editingSticky.value));
 
 // ?chat=<conversation>&canvas=<message>: main chat handing a builder
 // conversation's artifact back here ("Open in Dashboards"). Read at setup for
@@ -404,6 +438,9 @@ function onSaved(detail) {
 	if (detail && detail.name) {
 		editingDetail.value = detail;
 		editingSticky.value = detail.name;
+		// The row now HOLDS the canvas: the two documents an adoption was keeping
+		// apart are one again, so the agent is told what it is revising from here on.
+		adoptedRow.value = "";
 	}
 	toast.success("Dashboard saved");
 }
@@ -494,6 +531,7 @@ function clearBuilder() {
 	chatConv.value = "";
 	dashDataMode.value = "auto";
 	editingSticky.value = "";
+	adoptedRow.value = "";
 	canvasMsg.value = "";
 	editSeed.value = "";
 	builderHtml.value = "";
@@ -553,6 +591,9 @@ async function loadEdit(name, { deepLink = true } = {}) {
 			builderTheme.value = themeKey(d.theme);
 			// the canvas is this document now, not an artifact from the transcript
 			canvasMsg.value = "";
+			// ...so whatever the builder was holding is no longer ahead of its row:
+			// the agent revises this document by name again.
+			adoptedRow.value = "";
 			// resume the build thread, or a fresh one — never the stale sticky
 			// conversation left over from editing a different dashboard.
 			if (deepLink || d.source_conversation) {
@@ -584,6 +625,48 @@ watch(
 		loadEdit(name);
 	}
 );
+
+// Permanent enough to forget a stored target over: the row was deleted, or this
+// user may no longer touch it. Anything else is a blip the next mount retries.
+function isGoneError(e) {
+	return (
+		!!(e && (e.status === 404 || e.exc_type === "DoesNotExistError")) || isPermissionError(e)
+	);
+}
+
+// The third mount path: coming back to an ADOPTED promotion (resumesAdoption
+// above). What was on the canvas is the transcript's build, NEWER than the row
+// it adopted, so loadEdit is the wrong restore - it would answer with the row's
+// stored html and drop the build the user was looking at. Restore the identity
+// alone (badge, theme, Save-in-place) and let the pane's transcript restore
+// replay the canvas, which it can because `editSeed` was left empty at setup.
+async function resumeAdoption(name) {
+	let d = null;
+	try {
+		d = await getDashboard(name);
+	} catch (e) {
+		// A blip keeps the identity: the next mount retries, and dropping it here
+		// would quietly arm the next Save to write a duplicate of that very row.
+		if (isGoneError(e)) {
+			editingSticky.value = "";
+			adoptedRow.value = "";
+		}
+		return;
+	}
+	if (d && d.name && d.can_edit) {
+		editingDetail.value = d;
+		editingSticky.value = d.name;
+		savedName.value = d.name;
+		builderTheme.value = themeKey(d.theme);
+		adoptedRow.value = d.name;
+		return;
+	}
+	// Gone, or readable but no longer editable: the canvas is still the user's
+	// build, so keep it and let Save write a row of its own rather than offer a
+	// "Save changes" that throws on submit.
+	editingSticky.value = "";
+	adoptedRow.value = "";
+}
 
 // ── ?chat=&canvas= — promoting a chat artifact onto the builder ──────────────
 // Main chat can open a builder conversation like any other, but its canvas only
@@ -684,22 +767,37 @@ async function promoteFromChat(conversation, messageId, { fallback = null, dash 
 		// the row only supplies the identity, so the badge names it and the next
 		// Save updates it in place instead of creating a duplicate. The fetch is
 		// permission-gated server-side, so a foreign or deleted name simply fails
-		// here and the promotion degrades to the identity-less one it was before.
-		let adopted = null;
+		// here; adoptionIdentity() decides what that failure costs.
+		const priorName = editingName();
+		let detail = null;
 		if (dash) {
 			try {
-				const d = await getDashboard(dash);
-				if (d && d.name) adopted = d;
+				detail = await getDashboard(dash);
 			} catch (e) {
-				adopted = null;
+				detail = null;
 			}
 		}
+		const identity = adoptionIdentity({ dash, detail, priorName });
 		// The builder is this conversation's now - anything else it was editing is
 		// over, or Save would write back onto the wrong dashboard.
-		editingSticky.value = adopted ? adopted.name : "";
-		editingDetail.value = adopted;
+		editingSticky.value = identity.name;
+		// SAVE identity armed, revision identity NOT: the canvas holds a build the
+		// row is behind, so the agent keeps working from the transcript until a
+		// Save reconciles the two (agentEditingName).
+		adoptedRow.value = identity.name;
+		// `keepPrior` is a fetch that blipped on the row the builder ALREADY had:
+		// the skipped confirm promised to keep that identity, so the sticky name
+		// above stands and the detail already in hand is left alone rather than
+		// nulled. Every other outcome takes what the fetch answered.
+		if (!identity.keepPrior) {
+			editingDetail.value = identity.adopted;
+			savedName.value = identity.name;
+		}
+		// Design for, and re-lint against, the theme the ROW actually has - a Save
+		// with the picker left on the default rewrites the row's look, and the
+		// validator rejects the html outright when the two disagree.
+		if (identity.theme) builderTheme.value = identity.theme;
 		editSeed.value = "";
-		savedName.value = adopted ? adopted.name : "";
 		detectedSources.value = [];
 		chatConv.value = conversation;
 		canvasMsg.value = messageId;
@@ -849,8 +947,14 @@ onMounted(async () => {
 	if (fresh) caps.value = { ...caps.value, ...fresh };
 
 	// An explicit ?edit= is the user asking; the sticky target is this page
-	// remembering what it was editing, so a failure there stays quiet.
+	// remembering what it was editing, so a failure there stays quiet. A builder
+	// that went away mid-ADOPTION remembers something else - a row its canvas is
+	// ahead of - and resumes that instead of re-opening the row's document.
 	const normalMount = () => {
+		if (adoptionResume) {
+			resumeAdoption(adoptedRow.value);
+			return;
+		}
 		if (editSeed.value) loadEdit(editSeed.value, { deepLink: !!routeEdit });
 	};
 	// ?edit= wins over ?chat=: it names a saved document, the promotion only a

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -320,7 +320,9 @@ const routeCanvas = typeof route.query.canvas === "string" ? route.query.canvas 
 // BEFORE this page's, and the promotion waits on the caps probe, so without
 // this the restore reliably wins the race - and its canvas then reads as
 // "unsaved work" to the discard guard, popping a confirm over the very document
-// the user asked to open. Cleared when the promotion settles, either way.
+// the user asked to open. Taken here for the mount path (the promotion itself
+// only starts after the caps probe) and by promoteFromChat for a live
+// deep-link; cleared when the promotion settles, either way.
 const promotionPending = ref(!!(routeChat && routeCanvas));
 
 // Message ids whose artifact could not be replayed (the File was purged, the
@@ -423,15 +425,24 @@ const PROMOTE_COPY = {
 	message: "Opening this chat's dashboard replaces it. Its chat stays in your conversations.",
 };
 const discardCopy = ref(DISCARD_COPY);
+// "Open its chat" is an escape hatch to the thread the builder is holding — it
+// is only an escape when that is somewhere ELSE. A caller that is already
+// acting on that same conversation turns it into a loop, so it can drop it.
+const discardOfferChat = ref(true);
 
 // `force` is for callers whose own state (an editing target, another chat's
 // restored canvas) is worth confirming even when `unsavedCanvas` is false.
-function confirmDiscard(onYes, onNo, { force = false, copy = DISCARD_COPY } = {}) {
+function confirmDiscard(
+	onYes,
+	onNo,
+	{ force = false, copy = DISCARD_COPY, offerChat = true } = {}
+) {
 	if (!force && !unsavedCanvas.value) {
 		onYes();
 		return;
 	}
 	discardCopy.value = copy;
+	discardOfferChat.value = offerChat;
 	discardYes = onYes;
 	discardNo = onNo || null;
 	discardOpen.value = true;
@@ -446,6 +457,7 @@ function settleDiscard(yes) {
 	discardNo = null;
 	discardOpen.value = false;
 	discardCopy.value = DISCARD_COPY;
+	discardOfferChat.value = true;
 	if (yes) {
 		if (y) y();
 	} else if (n) n();
@@ -453,7 +465,7 @@ function settleDiscard(yes) {
 
 const discardActions = computed(() => {
 	const actions = [{ label: "Discard", variant: "solid", onClick: () => settleDiscard(true) }];
-	if (chatConv.value) {
+	if (chatConv.value && discardOfferChat.value) {
 		actions.push({
 			label: "Open its chat",
 			variant: "subtle",
@@ -600,11 +612,10 @@ function promotionWouldDiscard(conv) {
 	});
 }
 
-// The (conversation, message) being promoted, or the one already promoted:
-// the query watcher re-fires on unrelated route writes (a tab hash push carries
-// the query along), and a confirm dialog is open across several of them.
-// Cleared when a promotion is declined or fails, so the same link can be tried
-// again.
+// The (conversation, message) promotion IN FLIGHT: the query watcher re-fires
+// on unrelated route writes (a tab hash push carries the query along), and a
+// confirm dialog is open across several of them. Cleared on every settled path
+// - accepted, declined or failed - so the same link can be asked for again.
 let promoting = "";
 
 async function promoteFromChat(conversation, messageId, { fallback = null } = {}) {
@@ -612,6 +623,12 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 	const key = conversation + "::" + messageId;
 	if (key === promoting) return;
 	promoting = key;
+	// The hold goes up here, BELOW the dedupe, not in the watcher: that watcher
+	// wakes on any route write and re-arms with the same pair, and an arm whose
+	// call then dedupes away has nothing left to clear it - the pane's transcript
+	// restore would stay blocked for the life of the page. Still synchronous,
+	// nothing awaits above it, so the pane's restore cannot slip in first.
+	promotionPending.value = true;
 	const giveUp = (msg) => {
 		if (msg) toast.error(msg);
 		promotionPending.value = false;
@@ -668,13 +685,25 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 			toast.error("Couldn't load that dashboard's content — it may have expired.");
 		}
 		promotionPending.value = false;
+		// Settled: release the re-entrancy key, exactly as giveUp does. It guards
+		// a promotion IN FLIGHT, not one that finished - left set, asking for the
+		// same pair again (the same card, a second time in this page session)
+		// would dedupe into silence.
+		promoting = "";
 		stripPromotionQuery("");
 	};
 	if (!promotionWouldDiscard(conversation)) {
 		await accept();
 		return;
 	}
-	confirmDiscard(accept, () => giveUp(""), { force: true, copy: PROMOTE_COPY });
+	confirmDiscard(accept, () => giveUp(""), {
+		force: true,
+		copy: PROMOTE_COPY,
+		// The builder is already holding the very conversation being promoted
+		// (the same-thread-with-an-editing-identity case), so "Open its chat"
+		// would land the user back in the chat they clicked the button in.
+		offerChat: chatConv.value !== conversation,
+	});
 }
 
 // Live, for the same reason ?edit= is: the builder may already be open.
@@ -689,7 +718,8 @@ watch(
 			console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
 			return;
 		}
-		promotionPending.value = true;
+		// The hold is armed inside promoteFromChat, below its dedupe check - see
+		// there for why it cannot be armed from this watcher.
 		promoteFromChat(conv, msg);
 	}
 );

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -464,6 +464,11 @@ async function openSave() {
 				if (d && d.name && d.can_edit) {
 					editingDetail.value = d;
 					savedName.value = d.name;
+					// The repair only ever runs on a fresh mount, where the picker still
+					// holds the default — but a user who re-themed this session owns the
+					// picker, so seed the row's theme only over the untouched default.
+					if (builderTheme.value === DEFAULT_THEME)
+						builderTheme.value = themeKey(d.theme);
 				} else {
 					editingSticky.value = "";
 					adoptedRow.value = "";
@@ -478,8 +483,9 @@ async function openSave() {
 			repairing.value = false;
 		}
 		// ...and the canvas can be gone with it, in which case there is nothing to
-		// save any more
-		if (!builderHtml.value) return;
+		// save any more — and a discard confirm raised mid-repair owns the screen,
+		// so the dialog must not stack on top of it
+		if (!builderHtml.value || discardOpen.value) return;
 	}
 	saveOpen.value = true;
 }

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -314,6 +314,14 @@ const editSeed = ref(routeEdit || editingSticky.value);
 // honours the deep-link too.
 const routeChat = typeof route.query.chat === "string" ? route.query.chat : "";
 const routeCanvas = typeof route.query.canvas === "string" ? route.query.canvas : "";
+// ...and `dash=<name>`: the saved dashboard this conversation already has, sent
+// only when main chat promotes a build made AFTER it. The promotion ADOPTS that
+// row - badge and "Save changes" keep pointing at it - instead of dropping the
+// identity and writing a second row for the same dashboard. User-influencable
+// (it is a URL), and deliberately not trusted: the only thing done with it is a
+// permission-gated get_dashboard, so an unknown or foreign name simply fails and
+// degrades to an identity-less promotion.
+const routeDash = typeof route.query.dash === "string" ? route.query.dash : "";
 // A promotion the page owes the user but has not finished, held exactly like
 // `editSeed`: an explicit deep-link owns the canvas, so the chat pane's own
 // transcript restore must not land on it first. The pane's onMounted fires
@@ -583,8 +591,11 @@ watch(
 // Dashboards" sends the pair here, and the ordinary restore path takes over:
 // the same artifact, rendered by DashboardCanvas, which does run it.
 //
-// A saved dashboard never comes this way (main chat routes those to ?edit=), so
-// the promotion always lands on a build the user has not saved yet.
+// The DOCUMENT that arrives is never a saved one (main chat routes those to
+// ?edit=): it is a build made after the last save, or before any. Its IDENTITY
+// can be, though - `&dash=` names the row the conversation already has, and the
+// promotion adopts it so a live tweak saves back onto that dashboard instead of
+// forking a second one.
 
 // Drop the promotion keys once it has settled, so a reload/back does not replay
 // it — the editSeed discipline, one route write.
@@ -594,21 +605,33 @@ function stripPromotionQuery(hash = route.hash) {
 	const q = { ...route.query };
 	delete q.chat;
 	delete q.canvas;
+	delete q.dash;
 	router.replace({ query: q, hash });
 }
+
+// The dashboard this builder is editing, by NAME - the three slots in the order
+// they settle (the sticky target, the loaded detail, a seed whose loadEdit is
+// still in flight). Only the adoption matrix needs the name; `editing` below
+// stays the wider "is there any editing state at all" flag.
+const editingName = () =>
+	editingSticky.value || (editingDetail.value || {}).name || editSeed.value || "";
 
 // What the promotion would overwrite. Wider than `unsavedCanvas` on purpose: it
 // also takes the thread and the editing identity, so a saved dashboard open for
 // editing, or another conversation's restored canvas, is worth asking about -
-// but re-opening the builder's OWN thread costs nothing and must not ask. The
-// rules live in lib/dashboardOpen.js so they are testable outside the SFC.
-function promotionWouldDiscard(conv) {
+// but re-opening the builder's OWN thread costs nothing and must not ask. An
+// adoption (`dash`) keeps the identity it names, so there is nothing to own
+// there either. The rules live in lib/dashboardOpen.js so they are testable
+// outside the SFC.
+function promotionWouldDiscard(conv, dash = "") {
 	return wouldDiscardOnPromotion({
 		conv,
 		chatConv: chatConv.value,
 		canvasMsg: canvasMsg.value,
 		unsavedCanvas: unsavedCanvas.value,
 		editing: !!(editingSticky.value || editingDetail.value || editSeed.value),
+		editingName: editingName(),
+		dash,
 	});
 }
 
@@ -618,7 +641,7 @@ function promotionWouldDiscard(conv) {
 // - accepted, declined or failed - so the same link can be asked for again.
 let promoting = "";
 
-async function promoteFromChat(conversation, messageId, { fallback = null } = {}) {
+async function promoteFromChat(conversation, messageId, { fallback = null, dash = "" } = {}) {
 	if (!conversation || !messageId) return;
 	const key = conversation + "::" + messageId;
 	if (key === promoting) return;
@@ -655,12 +678,28 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 		return;
 	}
 	const accept = async () => {
-		// The builder is this conversation's now - anything it was editing is
+		// ADOPT the saved row this build belongs to, when main chat named one. Its
+		// detail is fetched exactly as loadEdit does - but its html never reaches
+		// the canvas: the promoted frame is the document the user asked for, and
+		// the row only supplies the identity, so the badge names it and the next
+		// Save updates it in place instead of creating a duplicate. The fetch is
+		// permission-gated server-side, so a foreign or deleted name simply fails
+		// here and the promotion degrades to the identity-less one it was before.
+		let adopted = null;
+		if (dash) {
+			try {
+				const d = await getDashboard(dash);
+				if (d && d.name) adopted = d;
+			} catch (e) {
+				adopted = null;
+			}
+		}
+		// The builder is this conversation's now - anything else it was editing is
 		// over, or Save would write back onto the wrong dashboard.
-		editingSticky.value = "";
-		editingDetail.value = null;
+		editingSticky.value = adopted ? adopted.name : "";
+		editingDetail.value = adopted;
 		editSeed.value = "";
-		savedName.value = "";
+		savedName.value = adopted ? adopted.name : "";
 		detectedSources.value = [];
 		chatConv.value = conversation;
 		canvasMsg.value = messageId;
@@ -692,7 +731,7 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 		promoting = "";
 		stripPromotionQuery("");
 	};
-	if (!promotionWouldDiscard(conversation)) {
+	if (!promotionWouldDiscard(conversation, dash)) {
 		await accept();
 		return;
 	}
@@ -719,8 +758,11 @@ watch(
 			return;
 		}
 		// The hold is armed inside promoteFromChat, below its dedupe check - see
-		// there for why it cannot be armed from this watcher.
-		promoteFromChat(conv, msg);
+		// there for why it cannot be armed from this watcher. `dash` is read here
+		// rather than watched: it only ever arrives written together with the pair
+		// above, in the single route push main chat makes.
+		const dash = typeof route.query.dash === "string" ? route.query.dash : "";
+		promoteFromChat(conv, msg, { dash });
 	}
 );
 
@@ -818,7 +860,7 @@ onMounted(async () => {
 		console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
 	}
 	if (!routeEdit && routeChat && routeCanvas) {
-		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount });
+		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount, dash: routeDash });
 	} else {
 		// No promotion will run on this mount (?edit= won, or the pair is half
 		// present): release the hold taken at setup, or the pane's restore stays

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -111,6 +111,7 @@
 								variant="solid"
 								label="Save dashboard"
 								:disabled="!builderHtml"
+								:loading="repairing"
 								@click="openSave"
 							/>
 						</div>
@@ -374,6 +375,28 @@ const promotionPending = ref(!!(routeChat && routeCanvas));
 // silent, failing get_canvas calls (a full File load + a disk read each time).
 const failedRestores = new Set();
 
+// A restore frame that could not be replayed. The latch is the loop guard above;
+// what follows it is the self-heal an ADOPTION needs.
+//
+// An adopted promotion keeps the identity of a row whose html it never loaded,
+// so an artifact that has since been purged leaves the builder with nothing to
+// show and nothing to fall back to: an empty canvas under an "Editing X" badge,
+// Save disabled, and the same outcome on every later mount. The promoted build
+// is genuinely unrecoverable — but the ROW still holds a document, and opening
+// it is what the mount would have done before the adoption existed. loadEdit
+// ends the adoption on its own (the canvas becomes the row's own html, so the
+// two are one document again and `canvasMsg`/`adoptedRow` are cleared), and the
+// latch means this can run at most once per message.
+function restoreFailed(message_id) {
+	failedRestores.add(message_id);
+	if (message_id !== canvasMsg.value || !adoptedRow.value) return;
+	const name = adoptedRow.value;
+	// the seed discipline the other loadEdit callers follow: it holds further
+	// restores off the canvas until this one settles, and loadEdit clears it
+	editSeed.value = name;
+	loadEdit(name, { deepLink: false });
+}
+
 // Chat drew/updated an artifact: pick the LAST html item and pull its
 // render-ready content onto the canvas.
 //
@@ -395,7 +418,7 @@ async function onCanvas({ message_id, items, restore }) {
 		const r = await getCanvas(message_id, htmlItem.name, 0);
 		const content = r && (r.content || r.data_url);
 		if (!content) {
-			if (restore) failedRestores.add(message_id);
+			if (restore) restoreFailed(message_id);
 			return false;
 		}
 		// The await above is a real round trip: re-check that a live frame (or a
@@ -412,14 +435,52 @@ async function onCanvas({ message_id, items, restore }) {
 	} catch (e) {
 		// A restore is best-effort background work the user did not ask for -
 		// a deleted/expired artifact must not raise a toast on page load.
-		if (restore) failedRestores.add(message_id);
+		if (restore) restoreFailed(message_id);
 		else toast.error(errMsg(e));
 		return false;
 	}
 }
 
-function openSave() {
-	if (!builderHtml.value) return;
+// A kept identity is a NAME without a detail (resumeAdoption's blip branch), and
+// the Save dialog updates in place off the DETAIL — so on its own that name
+// keeps nothing: the dialog would title itself "Save dashboard" and insert the
+// duplicate the adoption exists to prevent. The moment the user asks to save is
+// the one place a repair is worth a round trip, so take it, once: the row comes
+// back and Save updates it in place; the row is gone (or no longer this user's)
+// and the identity goes with it, because a new row beats a "Save changes" that
+// throws on submit; another blip changes nothing and the save proceeds as it
+// would have.
+const repairing = ref(false);
+async function openSave() {
+	if (!builderHtml.value || repairing.value) return;
+	const name = adoptedRow.value;
+	if (name && !editingDetail.value) {
+		repairing.value = true;
+		try {
+			const d = await getDashboard(name);
+			// a real round trip: the identity may have been discarded (New chat) or
+			// replaced (?edit=) while this was in flight
+			if (adoptedRow.value === name) {
+				if (d && d.name && d.can_edit) {
+					editingDetail.value = d;
+					savedName.value = d.name;
+				} else {
+					editingSticky.value = "";
+					adoptedRow.value = "";
+				}
+			}
+		} catch (e) {
+			if (adoptedRow.value === name && isGoneError(e)) {
+				editingSticky.value = "";
+				adoptedRow.value = "";
+			}
+		} finally {
+			repairing.value = false;
+		}
+		// ...and the canvas can be gone with it, in which case there is nothing to
+		// save any more
+		if (!builderHtml.value) return;
+	}
 	saveOpen.value = true;
 }
 
@@ -645,14 +706,24 @@ async function resumeAdoption(name) {
 	try {
 		d = await getDashboard(name);
 	} catch (e) {
-		// A blip keeps the identity: the next mount retries, and dropping it here
-		// would quietly arm the next Save to write a duplicate of that very row.
+		// This mount's own await is a real window - the caps probe alone can sleep a
+		// second before this even starts - and "New chat" is one click away in the
+		// pane throughout it. A builder cleared meanwhile DISCARDED this identity,
+		// and a discarded identity must stay discarded: re-attaching it here arms
+		// the next Save over a row that has nothing to do with what is now on the
+		// canvas.
+		if (adoptedRow.value !== name) return;
+		// A blip keeps the NAME for the next mount to retry. The name alone is not
+		// yet a Save target - the dialog updates in place off `editingDetail`, which
+		// this mount has none of - so what actually keeps the promise is the one
+		// repair attempt openSave() makes when it finds a name without a detail.
 		if (isGoneError(e)) {
 			editingSticky.value = "";
 			adoptedRow.value = "";
 		}
 		return;
 	}
+	if (adoptedRow.value !== name) return;
 	if (d && d.name && d.can_edit) {
 		editingDetail.value = d;
 		editingSticky.value = d.name;
@@ -770,14 +841,22 @@ async function promoteFromChat(conversation, messageId, { fallback = null, dash 
 		// here; adoptionIdentity() decides what that failure costs.
 		const priorName = editingName();
 		let detail = null;
+		let gone = false;
 		if (dash) {
 			try {
 				detail = await getDashboard(dash);
 			} catch (e) {
+				// Not every failure is a blip. get_dashboard is read-gated, so a
+				// deleted row - or one this user may no longer touch - THROWS rather
+				// than answering `can_edit: false`, and that is an answer: the
+				// identity naming it is forgotten, exactly as the remount path does
+				// with a sticky it can no longer resolve. Only a fetch that never
+				// answered at all can reach `keepPrior`.
+				gone = isGoneError(e);
 				detail = null;
 			}
 		}
-		const identity = adoptionIdentity({ dash, detail, priorName });
+		const identity = adoptionIdentity({ dash, detail, priorName, gone });
 		// The builder is this conversation's now - anything else it was editing is
 		// over, or Save would write back onto the wrong dashboard.
 		editingSticky.value = identity.name;

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -185,8 +185,8 @@
 			<Dialog
 				v-model="discardOpen"
 				:options="{
-					title: 'Discard this unsaved dashboard?',
-					message: 'Its chat stays in your conversations.',
+					title: discardCopy.title,
+					message: discardCopy.message,
 					actions: discardActions,
 				}"
 				@close="settleDiscard(false)"
@@ -202,7 +202,9 @@
 // tab is the core UX: the sandboxed canvas on top, the assistant chat below,
 // split by a draggable divider (persisted %). The chat's canvas frames pull
 // the agent's html artifact onto the canvas; Save opens the scope/title
-// dialog; ?edit=<name> seeds the canvas from a saved dashboard for editing.
+// dialog; ?edit=<name> seeds the canvas from a saved dashboard for editing, and
+// ?chat=<conversation>&canvas=<message> promotes a build the user found in main
+// chat back onto this builder, where it renders WITH its data.
 // Probe failures follow the TriggersPage rule: a genuine 403 shows the
 // no-access state; a transient 500/network blip retries once and otherwise
 // proceeds with default caps rather than blocking an authorized user.
@@ -215,7 +217,8 @@ import TabBar from "@/components/list/TabBar.vue";
 import { session } from "@/data/session";
 import { getCanvas } from "@/api";
 import { agentName } from "@/branding";
-import { getDashboardsCaps, getDashboard } from "@/api/dashboards";
+import { getDashboardsCaps, getDashboard, getDashboardConversation } from "@/api/dashboards";
+import { builderCanvasFrame } from "@/lib/dashboardRestore";
 import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes";
 import DashboardCanvas from "./DashboardCanvas.vue";
 import DashboardChatPane from "./DashboardChatPane.vue";
@@ -304,6 +307,13 @@ const canvasMsg = useStorage(`jarvis-dash-canvasmsg-${session.user || "anon"}`, 
 const routeEdit = typeof route.query.edit === "string" ? route.query.edit : "";
 const editSeed = ref(routeEdit || editingSticky.value);
 
+// ?chat=<conversation>&canvas=<message>: main chat handing a builder
+// conversation's artifact back here ("Open in Dashboards"). Read at setup for
+// the same reason as ?edit=, and watched below so an already-mounted builder
+// honours the deep-link too.
+const routeChat = typeof route.query.chat === "string" ? route.query.chat : "";
+const routeCanvas = typeof route.query.canvas === "string" ? route.query.canvas : "";
+
 // Message ids whose artifact could not be replayed (the File was purged, the
 // conversation was reassigned). The pane emits a restore frame on EVERY
 // transcript load - including the 300ms-debounced refetch behind each realtime
@@ -320,31 +330,36 @@ const failedRestores = new Set();
 // navigation dropped it, and must never
 // overwrite what is already on screen - a live frame for the turn in flight
 // always wins over a replay of an older turn.
+// Answers whether the artifact actually reached the canvas, so a caller that
+// repointed the builder at it (the ?chat= promotion) can tell a render from a
+// no-op instead of leaving the previous document on screen under a new thread.
 async function onCanvas({ message_id, items, restore }) {
-	if (restore && (builderHtml.value || editSeed.value)) return;
-	if (restore && failedRestores.has(message_id)) return;
+	if (restore && (builderHtml.value || editSeed.value)) return false;
+	if (restore && failedRestores.has(message_id)) return false;
 	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html");
-	if (!htmlItem || !message_id) return;
+	if (!htmlItem || !message_id) return false;
 	try {
 		const r = await getCanvas(message_id, htmlItem.name, 0);
 		const content = r && (r.content || r.data_url);
 		if (!content) {
 			if (restore) failedRestores.add(message_id);
-			return;
+			return false;
 		}
 		// The await above is a real round trip: re-check that a live frame (or a
 		// resolved ?edit= seed) did not land while this replay was in flight.
-		if (restore && (builderHtml.value || editSeed.value)) return;
+		if (restore && (builderHtml.value || editSeed.value)) return false;
 		builderHtml.value = content;
 		// Remember WHICH message is on the canvas: a later rehydration replays
 		// exactly this artifact instead of the newest html in a conversation main
 		// chat may also have drawn in.
 		canvasMsg.value = message_id;
+		return true;
 	} catch (e) {
 		// A restore is best-effort background work the user did not ask for -
 		// a deleted/expired artifact must not raise a toast on page load.
 		if (restore) failedRestores.add(message_id);
 		else toast.error(errMsg(e));
+		return false;
 	}
 }
 
@@ -386,11 +401,26 @@ const discardOpen = ref(false);
 let discardYes = null;
 let discardNo = null;
 
-function confirmDiscard(onYes, onNo) {
-	if (!unsavedCanvas.value) {
+const DISCARD_COPY = {
+	title: "Discard this unsaved dashboard?",
+	message: "Its chat stays in your conversations.",
+};
+// The ?chat= promotion replaces the whole builder (canvas AND thread), which is
+// worth confirming even when the canvas on screen is a saved document.
+const PROMOTE_COPY = {
+	title: "Discard what's in the builder?",
+	message: "Opening this chat's dashboard replaces it. Its chat stays in your conversations.",
+};
+const discardCopy = ref(DISCARD_COPY);
+
+// `force` is for callers whose own state (an editing target, another chat's
+// restored canvas) is worth confirming even when `unsavedCanvas` is false.
+function confirmDiscard(onYes, onNo, { force = false, copy = DISCARD_COPY } = {}) {
+	if (!force && !unsavedCanvas.value) {
 		onYes();
 		return;
 	}
+	discardCopy.value = copy;
 	discardYes = onYes;
 	discardNo = onNo || null;
 	discardOpen.value = true;
@@ -404,6 +434,7 @@ function settleDiscard(yes) {
 	discardYes = null;
 	discardNo = null;
 	discardOpen.value = false;
+	discardCopy.value = DISCARD_COPY;
 	if (yes) {
 		if (y) y();
 	} else if (n) n();
@@ -523,6 +554,112 @@ watch(
 	}
 );
 
+// ── ?chat=&canvas= — promoting a chat artifact onto the builder ──────────────
+// Main chat can open a builder conversation like any other, but its canvas only
+// PREVIEWS the document; nothing there runs the query tools. "Open in
+// Dashboards" sends the pair here, and the ordinary restore path takes over:
+// the same artifact, rendered by DashboardCanvas, which does run it.
+//
+// A saved dashboard never comes this way (main chat routes those to ?edit=), so
+// the promotion always lands on a build the user has not saved yet.
+
+// Drop the promotion keys once it has settled, so a reload/back does not replay
+// it — the editSeed discipline, one route write.
+function stripPromotionQuery(hash = route.hash) {
+	if (route.name !== "DashboardsPage") return;
+	if (route.query.chat === undefined && route.query.canvas === undefined) return;
+	const q = { ...route.query };
+	delete q.chat;
+	delete q.canvas;
+	router.replace({ query: q, hash });
+}
+
+// What the promotion would overwrite. Wider than `unsavedCanvas` on purpose: it
+// also takes the thread and the editing identity, so a saved dashboard open for
+// editing, or another conversation's restored canvas, is worth asking about.
+function promotionWouldDiscard(conv) {
+	if (unsavedCanvas.value) return true;
+	if (editingSticky.value || editingDetail.value || editSeed.value) return true;
+	return !!(chatConv.value && chatConv.value !== conv && canvasMsg.value);
+}
+
+// The (conversation, message) being promoted, or the one already promoted:
+// the query watcher re-fires on unrelated route writes (a tab hash push carries
+// the query along), and a confirm dialog is open across several of them.
+// Cleared when a promotion is declined or fails, so the same link can be tried
+// again.
+let promoting = "";
+
+async function promoteFromChat(conversation, messageId, { fallback = null } = {}) {
+	if (!conversation || !messageId) return;
+	const key = conversation + "::" + messageId;
+	if (key === promoting) return;
+	promoting = key;
+	const giveUp = (msg) => {
+		if (msg) toast.error(msg);
+		stripPromotionQuery();
+		promoting = "";
+		if (fallback) fallback();
+	};
+	// Validate against the transcript, not the link: the message must still
+	// exist and must still carry an html artifact.
+	let frame = null;
+	try {
+		const d = (await getDashboardConversation(conversation)) || {};
+		frame = builderCanvasFrame(d.messages || [], messageId);
+	} catch (e) {
+		giveUp(errMsg(e));
+		return;
+	}
+	if (!frame) {
+		giveUp("That dashboard is no longer in this chat.");
+		return;
+	}
+	const accept = async () => {
+		// The builder is this conversation's now - anything it was editing is
+		// over, or Save would write back onto the wrong dashboard.
+		editingSticky.value = "";
+		editingDetail.value = null;
+		editSeed.value = "";
+		savedName.value = "";
+		detectedSources.value = [];
+		chatConv.value = conversation;
+		canvasMsg.value = messageId;
+		activeTab.value = "builder";
+		// builderHtml is deliberately NOT cleared first: while it holds the old
+		// document, the pane's own transcript restore stays blocked, so only this
+		// frame can reach the canvas. onCanvas fetches the artifact and renders it
+		// through DashboardCanvas - which is what runs the queries as the viewer.
+		const rendered = await onCanvas({ message_id: frame.message_id, items: frame.items });
+		// The artifact was in the transcript a moment ago, so a failure here means
+		// its File is gone. Leaving the previous document on the canvas would arm
+		// Save over html that has nothing to do with the thread now underneath it.
+		if (!rendered) builderHtml.value = "";
+		stripPromotionQuery("");
+	};
+	if (!promotionWouldDiscard(conversation)) {
+		await accept();
+		return;
+	}
+	confirmDiscard(accept, () => giveUp(""), { force: true, copy: PROMOTE_COPY });
+}
+
+// Live, for the same reason ?edit= is: the builder may already be open.
+watch(
+	() => [route.query.chat, route.query.canvas],
+	([c, m]) => {
+		if (route.name !== "DashboardsPage") return;
+		const conv = typeof c === "string" ? c : "";
+		const msg = typeof m === "string" ? m : "";
+		if (!conv || !msg) return;
+		if (route.query.edit) {
+			console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
+			return;
+		}
+		promoteFromChat(conv, msg);
+	}
+);
+
 // v-show keeps the builder mounted while Saved is up, so its iframe loads and
 // runs at 0x0 behind `display:none` — charts initialised against a zero-size
 // container draw nothing and do not self-heal. Re-drive the document when the
@@ -607,6 +744,19 @@ onMounted(async () => {
 
 	// An explicit ?edit= is the user asking; the sticky target is this page
 	// remembering what it was editing, so a failure there stays quiet.
-	if (editSeed.value) loadEdit(editSeed.value, { deepLink: !!routeEdit });
+	const normalMount = () => {
+		if (editSeed.value) loadEdit(editSeed.value, { deepLink: !!routeEdit });
+	};
+	// ?edit= wins over ?chat=: it names a saved document, the promotion only a
+	// draft. Declining or failing the promotion falls back to what this mount
+	// would otherwise have done.
+	if (routeEdit && routeChat) {
+		console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
+	}
+	if (!routeEdit && routeChat && routeCanvas) {
+		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount });
+	} else {
+		normalMount();
+	}
 });
 </script>

--- a/frontend/src/pages/dashboards/DashboardsPage.vue
+++ b/frontend/src/pages/dashboards/DashboardsPage.vue
@@ -219,6 +219,7 @@ import { getCanvas } from "@/api";
 import { agentName } from "@/branding";
 import { getDashboardsCaps, getDashboard, getDashboardConversation } from "@/api/dashboards";
 import { builderCanvasFrame } from "@/lib/dashboardRestore";
+import { wouldDiscardOnPromotion } from "@/lib/dashboardOpen";
 import { DEFAULT_THEME, THEME_OPTIONS, themeKey, themeLabel } from "@/lib/dashboardThemes";
 import DashboardCanvas from "./DashboardCanvas.vue";
 import DashboardChatPane from "./DashboardChatPane.vue";
@@ -313,6 +314,14 @@ const editSeed = ref(routeEdit || editingSticky.value);
 // honours the deep-link too.
 const routeChat = typeof route.query.chat === "string" ? route.query.chat : "";
 const routeCanvas = typeof route.query.canvas === "string" ? route.query.canvas : "";
+// A promotion the page owes the user but has not finished, held exactly like
+// `editSeed`: an explicit deep-link owns the canvas, so the chat pane's own
+// transcript restore must not land on it first. The pane's onMounted fires
+// BEFORE this page's, and the promotion waits on the caps probe, so without
+// this the restore reliably wins the race - and its canvas then reads as
+// "unsaved work" to the discard guard, popping a confirm over the very document
+// the user asked to open. Cleared when the promotion settles, either way.
+const promotionPending = ref(!!(routeChat && routeCanvas));
 
 // Message ids whose artifact could not be replayed (the File was purged, the
 // conversation was reassigned). The pane emits a restore frame on EVERY
@@ -334,7 +343,7 @@ const failedRestores = new Set();
 // repointed the builder at it (the ?chat= promotion) can tell a render from a
 // no-op instead of leaving the previous document on screen under a new thread.
 async function onCanvas({ message_id, items, restore }) {
-	if (restore && (builderHtml.value || editSeed.value)) return false;
+	if (restore && (builderHtml.value || editSeed.value || promotionPending.value)) return false;
 	if (restore && failedRestores.has(message_id)) return false;
 	const htmlItem = [...(items || [])].reverse().find((it) => it && it.type === "html");
 	if (!htmlItem || !message_id) return false;
@@ -346,8 +355,10 @@ async function onCanvas({ message_id, items, restore }) {
 			return false;
 		}
 		// The await above is a real round trip: re-check that a live frame (or a
-		// resolved ?edit= seed) did not land while this replay was in flight.
-		if (restore && (builderHtml.value || editSeed.value)) return false;
+		// resolved ?edit= seed, or a promotion that started meanwhile) did not
+		// land while this replay was in flight.
+		if (restore && (builderHtml.value || editSeed.value || promotionPending.value))
+			return false;
 		builderHtml.value = content;
 		// Remember WHICH message is on the canvas: a later rehydration replays
 		// exactly this artifact instead of the newest html in a conversation main
@@ -576,11 +587,17 @@ function stripPromotionQuery(hash = route.hash) {
 
 // What the promotion would overwrite. Wider than `unsavedCanvas` on purpose: it
 // also takes the thread and the editing identity, so a saved dashboard open for
-// editing, or another conversation's restored canvas, is worth asking about.
+// editing, or another conversation's restored canvas, is worth asking about -
+// but re-opening the builder's OWN thread costs nothing and must not ask. The
+// rules live in lib/dashboardOpen.js so they are testable outside the SFC.
 function promotionWouldDiscard(conv) {
-	if (unsavedCanvas.value) return true;
-	if (editingSticky.value || editingDetail.value || editSeed.value) return true;
-	return !!(chatConv.value && chatConv.value !== conv && canvasMsg.value);
+	return wouldDiscardOnPromotion({
+		conv,
+		chatConv: chatConv.value,
+		canvasMsg: canvasMsg.value,
+		unsavedCanvas: unsavedCanvas.value,
+		editing: !!(editingSticky.value || editingDetail.value || editSeed.value),
+	});
 }
 
 // The (conversation, message) being promoted, or the one already promoted:
@@ -597,6 +614,11 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 	promoting = key;
 	const giveUp = (msg) => {
 		if (msg) toast.error(msg);
+		promotionPending.value = false;
+		// The hold above dropped the restore frame the pane emitted while this
+		// promotion was in flight. Declining (or failing) must leave the builder
+		// as it was, not empty, so ask the pane for that frame again.
+		if (chatPane.value && chatPane.value.restoreCanvas) chatPane.value.restoreCanvas();
 		stripPromotionQuery();
 		promoting = "";
 		if (fallback) fallback();
@@ -625,16 +647,27 @@ async function promoteFromChat(conversation, messageId, { fallback = null } = {}
 		detectedSources.value = [];
 		chatConv.value = conversation;
 		canvasMsg.value = messageId;
+		// The sticky data-mode belongs to the build the builder was on. Carried
+		// into a promoted one it declares an intent the user never expressed - a
+		// "static" left over from a baked report tells the agent to freeze the
+		// numbers of the live dashboard just promoted. Neutral, as clearBuilder.
+		dashDataMode.value = "auto";
 		activeTab.value = "builder";
-		// builderHtml is deliberately NOT cleared first: while it holds the old
-		// document, the pane's own transcript restore stays blocked, so only this
-		// frame can reach the canvas. onCanvas fetches the artifact and renders it
-		// through DashboardCanvas - which is what runs the queries as the viewer.
+		// The pane's own transcript restore is held off by promotionPending, so
+		// only this frame can reach the canvas. onCanvas fetches the artifact and
+		// renders it through DashboardCanvas - which is what runs the queries as
+		// the viewer.
 		const rendered = await onCanvas({ message_id: frame.message_id, items: frame.items });
 		// The artifact was in the transcript a moment ago, so a failure here means
 		// its File is gone. Leaving the previous document on the canvas would arm
-		// Save over html that has nothing to do with the thread now underneath it.
-		if (!rendered) builderHtml.value = "";
+		// Save over html that has nothing to do with the thread now underneath it -
+		// and an empty canvas alone reads as "nothing built yet", so say what
+		// happened instead of failing silently.
+		if (!rendered) {
+			builderHtml.value = "";
+			toast.error("Couldn't load that dashboard's content — it may have expired.");
+		}
+		promotionPending.value = false;
 		stripPromotionQuery("");
 	};
 	if (!promotionWouldDiscard(conversation)) {
@@ -656,6 +689,7 @@ watch(
 			console.warn("dashboards: ?edit= wins over ?chat=&canvas=; the promotion is ignored");
 			return;
 		}
+		promotionPending.value = true;
 		promoteFromChat(conv, msg);
 	}
 );
@@ -756,6 +790,10 @@ onMounted(async () => {
 	if (!routeEdit && routeChat && routeCanvas) {
 		promoteFromChat(routeChat, routeCanvas, { fallback: normalMount });
 	} else {
+		// No promotion will run on this mount (?edit= won, or the pair is half
+		// present): release the hold taken at setup, or the pane's restore stays
+		// blocked for the life of the page.
+		promotionPending.value = false;
 		normalMount();
 	}
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3703,6 +3703,15 @@ const autoApplyNote = ref("");
 // this list; this is the only thing that says its html artifacts are
 // dashboards, and it is what gates the "Open in Dashboards" affordance.
 const originPage = ref("");
+// ...and WHICH conversation that origin was read for. get_conversation answers a
+// full round trip after currentId already names the conversation being switched
+// to, so the flag alone would still be describing the previous thread while the
+// previous thread's cards are on screen. Written together with originPage, only
+// when the fetch lands, and compared against currentId at the gate: a switch (or
+// a fetch that never lands) fails closed, while a refresh of the conversation
+// already open — message:enriched, the resync on every tab focus — invalidates
+// nothing.
+const originOf = ref("");
 // The <Composer> instance. It owns the textarea and auto-grow; this view still
 // owns everything around them, so it reaches in for the two things a parent
 // legitimately needs: `composerRef.value.el` (the raw textarea, for the caret
@@ -4511,6 +4520,7 @@ async function clearAllHistory() {
 		await api.clearChatHistory();
 		messages.value = [];
 		originPage.value = "";
+		originOf.value = "";
 		currentId.value = "";
 		settingsOpen.value = false;
 		newChat(); // also reloads store.conversations
@@ -6200,7 +6210,12 @@ async function openArtifact(m, cv) {
 // over to it — as the saved dashboard it became, or as this exact canvas message
 // for the builder to replay.
 function canOpenDash(cv) {
-	return canOpenInDashboards(originPage.value, cv);
+	return canOpenInDashboards({
+		originPage: originPage.value,
+		originOf: originOf.value,
+		conversation: currentId.value,
+		cv,
+	});
 }
 async function openInDashboards(m, cv) {
 	const conv = currentId.value;
@@ -6218,6 +6233,8 @@ async function openInDashboards(m, cv) {
 	// m.creation decides the fork: a conversation keeps building after its first
 	// save, so a click on a LATER artifact must promote that artifact, not reopen
 	// the older saved row (which would silently answer with a different document).
+	// The saved row's name rides along on that fork (`dash`) so the builder can
+	// keep editing it rather than starting a second row for the same dashboard.
 	router.push(
 		dashboardOpenRoute({
 			dashboard,
@@ -6377,16 +6394,10 @@ async function loadConversation(id) {
 	// One-shot wiki grounding is per-turn: never carry an armed pill into a
 	// different conversation (matches how modelOverride/auto-apply reload here).
 	groundNextTurn.value = false;
-	// Dropped BEFORE the round trip, not after it. `messages` is only replaced
-	// when the response lands, so for one full RTT the screen still shows the
-	// PREVIOUS conversation's transcript while currentId already names the new
-	// one — a "dashboards" origin left standing over it offers "Open in
-	// Dashboards" on the old thread's card, and a click there pairs this
-	// conversation with that message. Clearing up front also means a fetch that
-	// rejects (deleted mid-click, a 500) strands no origin at all.
-	originPage.value = "";
 	if (!id) {
 		messages.value = [];
+		originPage.value = "";
+		originOf.value = "";
 		modelOverride.value = "";
 		thinkingOverride.value = "";
 		promptHistory.value = [];
@@ -6413,7 +6424,15 @@ async function loadConversation(id) {
 	// saved pin always rendered as "Auto" after a reload.
 	modelOverride.value = d?.conversation?.model_override || "";
 	thinkingOverride.value = d?.conversation?.thinking_override || "";
+	// The origin and the conversation it was read for, written as a pair — the
+	// gate compares the second against currentId, so neither is ever trusted
+	// alone. Nothing above blanks them: a refresh of the conversation already on
+	// screen (message:enriched fires one right after every canvas enrichment,
+	// onResync on every tab focus) would otherwise pull "Open in Dashboards" out
+	// of the DOM for a full RTT at exactly the moment it is most likely to be
+	// clicked — and leave it gone for good when that refetch rejects.
 	originPage.value = d?.conversation?.origin_page || "";
+	originOf.value = id;
 	// Per-conversation auto-apply + a fresh confirm-card slate for this chat
 	// (issue #186): a pending write from another conversation must not linger.
 	convAutoApply.value = !!(d?.conversation && d.conversation.auto_apply);
@@ -6755,6 +6774,7 @@ async function newChat() {
 	// origin survives onto a brand-new one — and the first html the agent draws
 	// there would offer "Open in Dashboards" over an ordinary chat's artifact.
 	originPage.value = "";
+	originOf.value = "";
 	// VR5-3: _promoteNewChatScope above moved any sentinel-scoped failed bubble (+ its voice-release
 	// token) onto the real id, but the route watcher no-ops here (currentId already equals this id),
 	// so loadConversation()'s pending-bubble peek never runs — re-inject them now, exactly as
@@ -7076,6 +7096,15 @@ async function send(textArg, resendAck) {
 				// yank a user who switched away — that is the ONLY part gated on visibility.
 				if (r.conversation_id !== currentId.value) {
 					currentId.value = r.conversation_id;
+					// A send into a conversation the server can no longer find falls back
+					// to a FRESH one (chat/api.py), and nothing re-reads the conversation
+					// here: loadConversation doesn't run, and the route watcher no-ops
+					// because currentId already equals the new id. The origin binding
+					// fails the gate closed on its own, but the pair is dropped together
+					// on every other swap and this is one — a builder origin left behind
+					// on an ordinary chat is the shape this fence exists for.
+					originPage.value = "";
+					originOf.value = "";
 					if (route.params.id !== r.conversation_id)
 						router.replace("/c/" + r.conversation_id);
 				}
@@ -8505,6 +8534,7 @@ watch(
 			// already equals it — so a builder origin left here would follow the
 			// user onto the next, ordinary chat.
 			originPage.value = "";
+			originOf.value = "";
 			resetRunState();
 			if (route.params.id) router.replace({ name: "Chat" });
 		}
@@ -8631,6 +8661,7 @@ onMounted(async () => {
 					currentId.value = null;
 					messages.value = [];
 					originPage.value = "";
+					originOf.value = "";
 					try {
 						localStorage.removeItem("jarvis-last-conv");
 					} catch (_e) {}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -6377,9 +6377,16 @@ async function loadConversation(id) {
 	// One-shot wiki grounding is per-turn: never carry an armed pill into a
 	// different conversation (matches how modelOverride/auto-apply reload here).
 	groundNextTurn.value = false;
+	// Dropped BEFORE the round trip, not after it. `messages` is only replaced
+	// when the response lands, so for one full RTT the screen still shows the
+	// PREVIOUS conversation's transcript while currentId already names the new
+	// one — a "dashboards" origin left standing over it offers "Open in
+	// Dashboards" on the old thread's card, and a click there pairs this
+	// conversation with that message. Clearing up front also means a fetch that
+	// rejects (deleted mid-click, a 500) strands no origin at all.
+	originPage.value = "";
 	if (!id) {
 		messages.value = [];
-		originPage.value = "";
 		modelOverride.value = "";
 		thinkingOverride.value = "";
 		promptHistory.value = [];
@@ -8493,6 +8500,11 @@ watch(
 		if (!list.some((c) => c.name === currentId.value)) {
 			currentId.value = null;
 			messages.value = [];
+			// loadConversation never runs on this path — the next send adopts the
+			// server id directly and the route watcher no-ops because currentId
+			// already equals it — so a builder origin left here would follow the
+			// user onto the next, ordinary chat.
+			originPage.value = "";
 			resetRunState();
 			if (route.params.id) router.replace({ name: "Chat" });
 		}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -3011,9 +3011,12 @@
 							</svg>
 						</a>
 						<!-- the same hand-off as the inline card, for the artifact that is
-						     already open: this preview does not run the dashboard -->
+						     already open: this preview does not run the dashboard. The
+						     conversation check is not belt-and-braces: this panel survives
+						     a switch in the sidebar behind it, and the hand-off pairs the
+						     CURRENT conversation with the OPEN artifact's message -->
 						<button
-							v-if="canOpenDash(artifact.cv)"
+							v-if="canOpenDash(artifact.cv) && artifact.conv === currentId"
 							class="jv-art-act"
 							@click="openInDashboards(artifact.m, artifact.cv)"
 							title="Open in Dashboards"
@@ -4507,6 +4510,7 @@ async function clearAllHistory() {
 	try {
 		await api.clearChatHistory();
 		messages.value = [];
+		originPage.value = "";
 		currentId.value = "";
 		settingsOpen.value = false;
 		newChat(); // also reloads store.conversations
@@ -6128,7 +6132,13 @@ function cvFile(cv) {
 }
 // ---- artifact preview side panel (ChatGPT/Claude-style: click a card → slide-
 // in panel on the right; PDF/image render directly, xlsx/csv as a table) ----
-const artifact = ref(null); // { m, cv, url, kind, content?, sheets?, sheetIdx?, text? }
+// { m, cv, url, kind, conv, content?, sheets?, sheetIdx?, text? }
+// `conv` is the conversation the artifact was opened FROM. The overlay is
+// absolutely positioned inside the ChatView container, so the AppShell's
+// conversation sidebar stays clickable behind it: the panel routinely outlives
+// the conversation it belongs to, and any action that mixes it with the current
+// conversation (the Dashboards hand-off) would act on a mismatched pair.
+const artifact = ref(null);
 const artifactPanelEl = ref(null);
 // Move focus into the panel when it opens so keyboard users land inside it
 // and Escape closes it right away (handled in onGlobalKey).
@@ -6152,36 +6162,37 @@ function setSheet(si) {
 async function openArtifact(m, cv) {
 	const url = cv.file_url || cvOf(m, cv);
 	const t = cv.type;
+	const conv = currentId.value;
 	if (t === "pdf" || t === "image") {
-		artifact.value = { m, cv, url, kind: t };
+		artifact.value = { m, cv, url, conv, kind: t };
 		return;
 	}
 	if (t === "html" || t === "svg") {
 		let content = cvOf(m, cv);
 		if (!content) {
-			artifact.value = { m, cv, url, kind: "loading" };
+			artifact.value = { m, cv, url, conv, kind: "loading" };
 			await ensureCanvas(m);
 			content = cvOf(m, cv);
 		}
-		artifact.value = { m, cv, url, kind: content ? t : "nopreview", content };
+		artifact.value = { m, cv, url, conv, kind: content ? t : "nopreview", content };
 		return;
 	}
 	// "file" (xlsx / csv / txt / …) → ask the backend for a tabular/text preview.
-	artifact.value = { m, cv, url, kind: "loading" };
+	artifact.value = { m, cv, url, conv, kind: "loading" };
 	try {
 		const r = await api.previewFile(cv.file_url);
 		if (r && r.kind === "table" && Array.isArray(r.sheets) && r.sheets.length) {
-			artifact.value = { m, cv, url, kind: "table", sheets: r.sheets, sheetIdx: 0 };
+			artifact.value = { m, cv, url, conv, kind: "table", sheets: r.sheets, sheetIdx: 0 };
 			return;
 		}
 		if (r && r.kind === "text") {
-			artifact.value = { m, cv, url, kind: "text", text: r.text || "" };
+			artifact.value = { m, cv, url, conv, kind: "text", text: r.text || "" };
 			return;
 		}
 	} catch (e) {
 		/* fall through to download-only */
 	}
-	artifact.value = { m, cv, url, kind: "nopreview" };
+	artifact.value = { m, cv, url, conv, kind: "nopreview" };
 }
 // ---- "Open in Dashboards" (a Dashboards-builder conversation opened here) ----
 // The preview in this thread renders the document but never runs it: main chat's
@@ -6204,7 +6215,17 @@ async function openInDashboards(m, cv) {
 		dashboard = null;
 	}
 	closeArtifact();
-	router.push(dashboardOpenRoute({ dashboard, conversation: conv, messageId: m.name }));
+	// m.creation decides the fork: a conversation keeps building after its first
+	// save, so a click on a LATER artifact must promote that artifact, not reopen
+	// the older saved row (which would silently answer with a different document).
+	router.push(
+		dashboardOpenRoute({
+			dashboard,
+			conversation: conv,
+			messageId: m.name,
+			messageCreation: m.creation,
+		})
+	);
 }
 // Lazily fetch each artifact's render payload (srcdoc content for html/svg, a
 // data-url for pdf/image/file) and cache it.
@@ -6722,6 +6743,11 @@ async function newChat() {
 	// and a later send can release the records by the real scope instead of stranding them (R2-2/R3-2).
 	if (currentId.value) _promoteNewChatScope(currentId.value);
 	messages.value = [];
+	// loadConversation is the only other writer and the route watcher no-ops here
+	// (currentId already equals this id), so without this the previous chat's
+	// origin survives onto a brand-new one — and the first html the agent draws
+	// there would offer "Open in Dashboards" over an ordinary chat's artifact.
+	originPage.value = "";
 	// VR5-3: _promoteNewChatScope above moved any sentinel-scoped failed bubble (+ its voice-release
 	// token) onto the real id, but the route watcher no-ops here (currentId already equals this id),
 	// so loadConversation()'s pending-bubble peek never runs — re-inject them now, exactly as
@@ -8592,6 +8618,7 @@ onMounted(async () => {
 					// hard-deleted after EMPTY_GRACE_DAYS, so a stale bookmark is routine.
 					currentId.value = null;
 					messages.value = [];
+					originPage.value = "";
 					try {
 						localStorage.removeItem("jarvis-last-conv");
 					} catch (_e) {}

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1512,50 +1512,76 @@
 										>
 									</button>
 									<!-- everything else → the file card -->
-									<button
-										v-else
-										class="jv-artifact"
-										@click="openArtifact(m, cv)"
-										:title="'Open ' + cv.title"
-									>
-										<span class="jv-artifact-ic" :class="'t-' + cv.type">
+									<div v-else class="jv-artifact-group">
+										<button
+											class="jv-artifact"
+											@click="openArtifact(m, cv)"
+											:title="'Open ' + cv.title"
+										>
+											<span class="jv-artifact-ic" :class="'t-' + cv.type">
+												<svg
+													width="17"
+													height="17"
+													viewBox="0 0 24 24"
+													fill="none"
+													stroke="currentColor"
+													stroke-width="1.7"
+													stroke-linecap="round"
+													stroke-linejoin="round"
+												>
+													<path
+														d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+													/>
+													<path d="M14 2v6h6" />
+												</svg>
+											</span>
+											<span class="jv-artifact-txt">
+												<span class="jv-artifact-title">{{
+													cv.title
+												}}</span>
+												<span class="jv-artifact-sub"
+													>{{ (cv.type || "file").toUpperCase() }} · open
+													preview</span
+												>
+											</span>
 											<svg
-												width="17"
-												height="17"
+												class="jv-artifact-go"
+												width="15"
+												height="15"
 												viewBox="0 0 24 24"
 												fill="none"
 												stroke="currentColor"
-												stroke-width="1.7"
+												stroke-width="1.8"
 												stroke-linecap="round"
 												stroke-linejoin="round"
 											>
-												<path
-													d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
-												/>
-												<path d="M14 2v6h6" />
+												<path d="M9 18l6-6-6-6" />
 											</svg>
-										</span>
-										<span class="jv-artifact-txt">
-											<span class="jv-artifact-title">{{ cv.title }}</span>
-											<span class="jv-artifact-sub"
-												>{{ (cv.type || "file").toUpperCase() }} · open
-												preview</span
-											>
-										</span>
-										<svg
-											class="jv-artifact-go"
-											width="15"
-											height="15"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="currentColor"
-											stroke-width="1.8"
-											stroke-linecap="round"
-											stroke-linejoin="round"
+										</button>
+										<!-- a Dashboards build opened in main chat: the card
+										     above previews the document but never runs its
+										     queries — the builder does -->
+										<button
+											v-if="canOpenDash(cv)"
+											class="jv-artifact-open"
+											@click="openInDashboards(m, cv)"
+											title="Open this dashboard in Dashboards, with its data"
 										>
-											<path d="M9 18l6-6-6-6" />
-										</svg>
-									</button>
+											<svg
+												width="13"
+												height="13"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="1.9"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											>
+												<path d="M18 20V10M12 20V4M6 20v-6" />
+											</svg>
+											Open in Dashboards
+										</button>
+									</div>
 								</template>
 								<div v-if="skillsUsedOf(m).length" class="jv-skillused">
 									<span
@@ -2984,6 +3010,28 @@
 								/>
 							</svg>
 						</a>
+						<!-- the same hand-off as the inline card, for the artifact that is
+						     already open: this preview does not run the dashboard -->
+						<button
+							v-if="canOpenDash(artifact.cv)"
+							class="jv-art-act"
+							@click="openInDashboards(artifact.m, artifact.cv)"
+							title="Open in Dashboards"
+							aria-label="Open in Dashboards"
+						>
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.8"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<path d="M18 20V10M12 20V4M6 20v-6" />
+							</svg>
+						</button>
 						<span class="jv-art-divider" aria-hidden="true"></span>
 						<button
 							class="jv-art-close"
@@ -3544,6 +3592,8 @@ import Message from "@/components/chat/Message.vue";
 import Composer from "@/components/chat/Composer.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
+import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
+import { dashboardForConversation } from "@/api/dashboards";
 import { checkReady, readinessDetailOf } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
@@ -3645,6 +3695,11 @@ function dismissBillingAlert() {
 // THIS chat. autoApplyNote surfaces the admin-only-enable message.
 const convAutoApply = ref(false);
 const autoApplyNote = ref("");
+// Which builder page started this thread ("dashboards" / "triggers" / ""),
+// from get_conversation. A Dashboards build is an ordinary conversation in
+// this list; this is the only thing that says its html artifacts are
+// dashboards, and it is what gates the "Open in Dashboards" affordance.
+const originPage = ref("");
 // The <Composer> instance. It owns the textarea and auto-grow; this view still
 // owns everything around them, so it reaches in for the two things a parent
 // legitimately needs: `composerRef.value.el` (the raw textarea, for the caret
@@ -6128,6 +6183,29 @@ async function openArtifact(m, cv) {
 	}
 	artifact.value = { m, cv, url, kind: "nopreview" };
 }
+// ---- "Open in Dashboards" (a Dashboards-builder conversation opened here) ----
+// The preview in this thread renders the document but never runs it: main chat's
+// canvas has no query-tool bridge. The Dashboards page does, so hand the artifact
+// over to it — as the saved dashboard it became, or as this exact canvas message
+// for the builder to replay.
+function canOpenDash(cv) {
+	return canOpenInDashboards(originPage.value, cv);
+}
+async function openInDashboards(m, cv) {
+	const conv = currentId.value;
+	if (!conv || !canOpenDash(cv)) return;
+	let dashboard = null;
+	try {
+		dashboard = await dashboardForConversation(conv);
+	} catch (e) {
+		// A lookup that fails (offline, a dashboard since moved out of scope)
+		// must never leave a dead button: fall through to the builder promotion,
+		// which needs nothing but the transcript.
+		dashboard = null;
+	}
+	closeArtifact();
+	router.push(dashboardOpenRoute({ dashboard, conversation: conv, messageId: m.name }));
+}
 // Lazily fetch each artifact's render payload (srcdoc content for html/svg, a
 // data-url for pdf/image/file) and cache it.
 async function ensureCanvas(m) {
@@ -6280,6 +6358,7 @@ async function loadConversation(id) {
 	groundNextTurn.value = false;
 	if (!id) {
 		messages.value = [];
+		originPage.value = "";
 		modelOverride.value = "";
 		thinkingOverride.value = "";
 		promptHistory.value = [];
@@ -6306,6 +6385,7 @@ async function loadConversation(id) {
 	// saved pin always rendered as "Auto" after a reload.
 	modelOverride.value = d?.conversation?.model_override || "";
 	thinkingOverride.value = d?.conversation?.thinking_override || "";
+	originPage.value = d?.conversation?.origin_page || "";
 	// Per-conversation auto-apply + a fresh confirm-card slate for this chat
 	// (issue #186): a pending write from another conversation must not linger.
 	convAutoApply.value = !!(d?.conversation && d.conversation.auto_apply);
@@ -10635,6 +10715,36 @@ onUnmounted(() => {
 .jv-artifact-go {
 	color: var(--text-3);
 	flex: none;
+}
+/* the card plus its follow-on action ("Open in Dashboards"), so the button is a
+   SIBLING of the card, never nested inside that <button> */
+.jv-artifact-group {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+}
+/* secondary by design.md's rule (one solid action per surface): the card is the
+   primary affordance, this is the quieter way out to the builder */
+.jv-artifact-open {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 6px;
+	padding: 5px 10px;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--surface-1);
+	font-family: inherit;
+	font-size: 12px;
+	font-weight: 550;
+	color: var(--text-2);
+	cursor: pointer;
+	transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.jv-artifact-open:hover {
+	border-color: var(--border-2);
+	background: var(--surface-2);
+	color: var(--text);
 }
 
 /* confirm / cancel card for a pending ERP-mutating action */

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1065,6 +1065,27 @@ def send_message(
 	# worker creates it on its pooled connection and inserts the Jarvis Chat
 	# Session row BEFORE streaming starts (2026-07 latency plan, Phase 1.1).
 	first_turn = 1 if not conv_doc.session_key else 0
+
+	# Remember which builder page this thread came from. A builder conversation is
+	# an ordinary Jarvis Conversation that also shows up in the main chat list,
+	# where nothing else tells a dashboard artifact apart from any other html
+	# canvas - so the origin has to be data, not client state. Stamped on EVERY
+	# qualifying send rather than at creation, so a thread that predates the field
+	# self-heals the next time the user chats from the builder.
+	#
+	# It rides the save+commit below deliberately: admission.accept_or_queue rolls
+	# back on its overload-reject and duplicate-replay paths, so a stamp written
+	# after that commit would be silently discarded on a busy site. The parse is
+	# side-effect-free and reads the same two-value literal allow-list the enqueue
+	# payload applies further down.
+	if context and not (conv_doc.get("origin_page") or ""):
+		try:
+			_octx = frappe.parse_json(context)
+			if isinstance(_octx, dict) and _octx.get("page") in ("triggers", "dashboards"):
+				conv_doc.origin_page = _octx["page"]
+		except Exception:
+			pass
+
 	if _delegated:
 		conv_doc.flags.ignore_permissions = True
 	conv_doc.save()
@@ -1136,15 +1157,6 @@ def send_message(
 					# that theme's token+recipe cheatsheet). Literal allow-list.
 					if ctx["page"] == "dashboards" and ctx.get("theme") in _DASHBOARD_THEME_KEYS:
 						enqueue_kwargs["context"]["theme"] = ctx["theme"]
-					# Remember which builder page this thread came from. A builder
-					# conversation is an ordinary Jarvis Conversation that also shows
-					# up in the main chat list, where nothing else tells a dashboard
-					# artifact apart from any other html canvas — so the origin has
-					# to be data, not client state. Stamped on EVERY qualifying send
-					# rather than at creation, so a thread that predates the field
-					# self-heals the next time the user chats from the builder.
-					if not (conv_doc.get("origin_page") or ""):
-						conv_doc.db_set("origin_page", ctx["page"], update_modified=False)
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -605,6 +605,10 @@ def get_conversation(conversation: str) -> dict:
 			# "" means inherit Jarvis Settings; the picker renders that as "Auto".
 			"thinking_override": doc.thinking_override or "",
 			"auto_apply": int(doc.auto_apply or 0),
+			# "dashboards" / "triggers" when this thread was started from a
+			# builder page; "" for an ordinary chat. The SPA reads it to offer
+			# "Open in Dashboards" on a builder conversation's html artifacts.
+			"origin_page": doc.get("origin_page") or "",
 			"last_active_at": doc.last_active_at,
 		},
 		"messages": messages,
@@ -1132,6 +1136,15 @@ def send_message(
 					# that theme's token+recipe cheatsheet). Literal allow-list.
 					if ctx["page"] == "dashboards" and ctx.get("theme") in _DASHBOARD_THEME_KEYS:
 						enqueue_kwargs["context"]["theme"] = ctx["theme"]
+					# Remember which builder page this thread came from. A builder
+					# conversation is an ordinary Jarvis Conversation that also shows
+					# up in the main chat list, where nothing else tells a dashboard
+					# artifact apart from any other html canvas — so the origin has
+					# to be data, not client state. Stamped on EVERY qualifying send
+					# rather than at creation, so a thread that predates the field
+					# self-heals the next time the user chats from the builder.
+					if not (conv_doc.get("origin_page") or ""):
+						conv_doc.db_set("origin_page", ctx["page"], update_modified=False)
 				# Persist the viewing-context doc ref on the user message row
 				# so post-turn entity extraction (jarvis.chat.entities) sees
 				# what the user was looking at, not just what tools touched.

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -271,6 +271,42 @@ def get_dashboard(name: str) -> dict:
 	return {"ok": True, "data": _dashboard_detail(doc)}
 
 
+@frappe.whitelist()
+@require_jarvis_user
+def dashboard_for_conversation(conversation: str) -> dict:
+	"""The saved dashboard this conversation built, if there is one.
+
+	Main chat offers "Open in Dashboards" on a builder conversation's html
+	artifact: a saved dashboard opens in place (``?edit=``), an unsaved canvas
+	is promoted onto the builder from the transcript instead. This is the
+	lookup behind that fork, so ``{}`` is an ordinary answer, not an error.
+
+	Permission: the CALLER must own the conversation (conversations are
+	strictly private - the same gate ``chat.api.get_conversation`` applies),
+	and the dashboard row goes through ``frappe.get_list`` - NOT get_all,
+	which sets ignore_permissions and would skip the
+	permission_query_conditions hook that applies the scope-visibility matrix.
+	A dashboard that has since moved out of the caller's reach therefore reads
+	as "none" rather than leaking its title.
+	"""
+	from jarvis.chat.api import _get_owned_conversation
+
+	_get_owned_conversation(conversation)  # non-owner: PermissionError
+	rows = frappe.get_list(
+		DASHBOARD,
+		filters={"source_conversation": conversation},
+		fields=["name", "dashboard_title"],
+		order_by="modified desc",
+		limit=1,
+	)
+	if not rows:
+		return {"ok": True, "data": {}}
+	return {
+		"ok": True,
+		"data": {"name": rows[0].name, "dashboard_title": rows[0].dashboard_title or ""},
+	}
+
+
 # --------------------------------------------------------------------------- #
 # save / delete
 # --------------------------------------------------------------------------- #

--- a/jarvis/chat/dashboards_api.py
+++ b/jarvis/chat/dashboards_api.py
@@ -288,22 +288,36 @@ def dashboard_for_conversation(conversation: str) -> dict:
 	permission_query_conditions hook that applies the scope-visibility matrix.
 	A dashboard that has since moved out of the caller's reach therefore reads
 	as "none" rather than leaking its title.
+
+	``owner`` is in the filters as well: ``source_conversation`` is a
+	client-settable payload field, so an Org-scope dashboard carrying someone
+	else's conversation id would otherwise be visible on THEIR "Open in
+	Dashboards". The caller provably owns the conversation, so nobody else can
+	legitimately have built from it.
+
+	``creation`` is returned (and ordered on, not ``modified``): the caller
+	compares it against the clicked message's own creation, so merely EDITING
+	an old dashboard cannot re-hijack a click on a newer unsaved build.
 	"""
 	from jarvis.chat.api import _get_owned_conversation
 
 	_get_owned_conversation(conversation)  # non-owner: PermissionError
 	rows = frappe.get_list(
 		DASHBOARD,
-		filters={"source_conversation": conversation},
-		fields=["name", "dashboard_title"],
-		order_by="modified desc",
+		filters={"source_conversation": conversation, "owner": frappe.session.user},
+		fields=["name", "dashboard_title", "creation"],
+		order_by="creation desc",
 		limit=1,
 	)
 	if not rows:
 		return {"ok": True, "data": {}}
 	return {
 		"ok": True,
-		"data": {"name": rows[0].name, "dashboard_title": rows[0].dashboard_title or ""},
+		"data": {
+			"name": rows[0].name,
+			"dashboard_title": rows[0].dashboard_title or "",
+			"creation": str(rows[0].creation or ""),
+		},
 	}
 
 

--- a/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
+++ b/jarvis/jarvis/doctype/jarvis_conversation/jarvis_conversation.json
@@ -17,7 +17,8 @@
   "starred",
   "pending_agent_notes",
   "auto_expired",
-  "expired_at"
+  "expired_at",
+  "origin_page"
  ],
  "fields": [
   {
@@ -116,6 +117,15 @@
    "no_copy": 1,
    "read_only": 1,
    "description": "When the retention sweep archived this conversation. Drives the follow-on hard-purge horizon (permanently delete archived chats expired longer than a second, longer window)."
+  },
+  {
+   "fieldname": "origin_page",
+   "fieldtype": "Data",
+   "label": "Origin Page",
+   "hidden": 1,
+   "no_copy": 1,
+   "read_only": 1,
+   "description": "The builder page this conversation was started from (\"dashboards\" / \"triggers\"), stamped by jarvis.chat.api.send_message from the context allow-list. The builder chats are ordinary conversations that also show up in the main chat list, where nothing else distinguishes a dashboard artifact from any other html canvas - this is that marker. Server-set only."
   }
  ],
  "permissions": [

--- a/jarvis/tests/test_dashboard_open_from_chat_client.py
+++ b/jarvis/tests/test_dashboard_open_from_chat_client.py
@@ -1,0 +1,57 @@
+"""The "Open in Dashboards" contract, proven by a REAL executable node test
+that lives in the python suite forever (the test_dashboard_builder_ux_client.py
+precedent).
+
+The owner-reported gap: the Dashboards builder's conversation shows up in the
+main chat list, and opening it there shows the prompt and the dashboard — but
+main chat's canvas never runs the document's queries, and nothing offered a way
+to the page that does.
+
+``frontend/src/lib/dashboardOpen.js`` holds the real logic (who gets the
+affordance, and where it routes); the rest — main chat's two surfaces and the
+builder's ?chat=&canvas= promotion — is component wiring that a plain node
+runner cannot import, so ``frontend/src/lib/dashboardOpen.test.js`` fences it
+with source assertions. This test subprocess-runs the suite with ``node --test``
+so a regression fails every CI run.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _open_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "lib", "dashboardOpen.test.js")
+
+
+class TestDashboardOpenFromChatClient(unittest.TestCase):
+	def test_open_in_dashboards_node_suite_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _open_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"open-in-dashboards client test missing at {test_file} — it MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"open-in-dashboards client node test FAILED:\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -13,6 +13,7 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat.api import search_workspace, send_message
 from jarvis.chat.dashboards_api import (
+	dashboard_for_conversation,
 	delete_dashboard,
 	get_dashboard,
 	get_dashboards_caps,
@@ -811,3 +812,142 @@ class TestWorkspaceSearchAndContext(_DashboardsApiTestCase):
 				}
 			),
 		)
+
+
+class TestOriginPageStamp(_DashboardsApiTestCase):
+	"""``Jarvis Conversation.origin_page`` — the durable marker that says a chat
+	came from a builder page. The builder's thread is an ordinary conversation
+	that also shows up in the main chat list, where nothing else tells a
+	dashboard artifact apart from any other html canvas."""
+
+	def _conv(self, user: str, title: str = "origin stamp test") -> str:
+		frappe.set_user(user)
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": title}).insert(
+			ignore_permissions=True
+		)
+		self._convs.append(conv.name)
+		return conv.name
+
+	def _send(self, conv: str, message: str, context: dict | None = None):
+		with (
+			patch("jarvis.chat.api.validate_can_send", return_value=(True, "")),
+			patch("jarvis.chat.api._dispatch_turn"),
+			# Same pinning as test_send_message_context_dashboards_allowlist: the
+			# pump branch never reaches _dispatch_turn, and the context allow-list
+			# (where the stamp lives) runs either way.
+			patch("jarvis.chat.admission.turn_machine_enabled", return_value=False),
+		):
+			return send_message(
+				conv,
+				message,
+				context=frappe.as_json(context) if context is not None else None,
+			)
+
+	def _origin(self, conv: str) -> str:
+		return frappe.db.get_value("Jarvis Conversation", conv, "origin_page") or ""
+
+	def test_dashboards_send_stamps_the_conversation(self):
+		conv = self._conv(PLAIN_A)
+		self.assertTrue(self._send(conv, "build me a dashboard", {"page": "dashboards"})["ok"])
+		self.assertEqual(self._origin(conv), "dashboards")
+
+	def test_triggers_send_stamps_the_conversation(self):
+		# Triggers conversations are stamped too (the marker is data, not a UI
+		# decision); only the dashboards button ships in this change.
+		conv = self._conv(PLAIN_A)
+		self.assertTrue(self._send(conv, "when an invoice is submitted…", {"page": "triggers"})["ok"])
+		self.assertEqual(self._origin(conv), "triggers")
+
+	def test_an_ordinary_send_stamps_nothing(self):
+		conv = self._conv(PLAIN_A)
+		self.assertTrue(self._send(conv, "hello")["ok"])
+		self.assertEqual(self._origin(conv), "")
+		# a doc-viewing context is not a builder page either
+		self.assertTrue(self._send(conv, "what is this?", {"doctype": "ToDo", "name": "x"})["ok"])
+		self.assertEqual(self._origin(conv), "")
+		# and a page outside the allow-list is dropped whole
+		self.assertTrue(self._send(conv, "hi", {"page": "evil"})["ok"])
+		self.assertEqual(self._origin(conv), "")
+
+	def test_an_older_conversation_self_heals_on_the_next_builder_send(self):
+		# No backfill patch exists (the origin was never persisted before this
+		# field), so the stamp has to happen on EVERY qualifying send, not only
+		# at creation.
+		conv = self._conv(PLAIN_A)
+		self.assertTrue(self._send(conv, "first, before the field existed")["ok"])
+		self.assertEqual(self._origin(conv), "")
+		self.assertTrue(self._send(conv, "now from the builder", {"page": "dashboards"})["ok"])
+		self.assertEqual(self._origin(conv), "dashboards")
+
+	def test_the_stamp_is_written_once_and_never_flips(self):
+		conv = self._conv(PLAIN_A)
+		self._send(conv, "build me a dashboard", {"page": "dashboards"})
+		self._send(conv, "and again", {"page": "triggers"})
+		self.assertEqual(self._origin(conv), "dashboards")
+
+	def test_get_conversation_returns_origin_page(self):
+		from jarvis.chat.api import get_conversation
+
+		conv = self._conv(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(get_conversation(conv)["conversation"]["origin_page"], "")
+		self._send(conv, "build me a dashboard", {"page": "dashboards"})
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(get_conversation(conv)["conversation"]["origin_page"], "dashboards")
+
+
+class TestDashboardForConversation(_DashboardsApiTestCase):
+	"""The lookup behind main chat's "Open in Dashboards": saved dashboard ->
+	open it in place; nothing saved -> the builder promotes the transcript's
+	canvas instead. ``{}`` is an ordinary answer, not an error."""
+
+	def _conv(self, user: str) -> str:
+		frappe.set_user(user)
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "dash build"}).insert(
+			ignore_permissions=True
+		)
+		self._convs.append(conv.name)
+		return conv.name
+
+	def test_owner_gets_the_dashboard_built_from_the_conversation(self):
+		conv = self._conv(PLAIN_A)
+		d = self._mk_static(PLAIN_A, title="from chat", source_conversation=conv)
+		frappe.set_user(PLAIN_A)
+		out = dashboard_for_conversation(conv)
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"], {"name": d["name"], "dashboard_title": "from chat"})
+
+	def test_no_saved_dashboard_is_an_empty_answer(self):
+		conv = self._conv(PLAIN_A)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(dashboard_for_conversation(conv)["data"], {})
+
+	def test_several_saves_answer_with_the_newest(self):
+		conv = self._conv(PLAIN_A)
+		self._mk_static(PLAIN_A, title="older", source_conversation=conv)
+		newer = self._mk_static(PLAIN_A, title="newer", source_conversation=conv)
+		# `modified` has second resolution on some backends - order the pair
+		# explicitly so the assertion is about the ORDER BY, not the clock.
+		frappe.db.set_value(
+			DASHBOARD, newer["name"], "modified", "2099-01-01 00:00:00", update_modified=False
+		)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(dashboard_for_conversation(conv)["data"]["name"], newer["name"])
+
+	def test_another_users_conversation_is_a_permission_error(self):
+		conv = self._conv(PLAIN_A)
+		self._mk_static(PLAIN_A, title="theirs", source_conversation=conv)
+		frappe.set_user(PLAIN_B)
+		self.assertRaises(frappe.PermissionError, dashboard_for_conversation, conv)
+
+	def test_a_dashboard_out_of_the_callers_scope_reads_as_none(self):
+		# The conversation is A's, but the dashboard bound to it is B's private
+		# one: A must get "nothing saved", not B's title.
+		conv = self._conv(PLAIN_A)
+		self._mk_static(PLAIN_B, title="not for A", source_conversation=conv)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(dashboard_for_conversation(conv)["data"], {})
+
+	def test_a_missing_conversation_does_not_exist(self):
+		frappe.set_user(PLAIN_A)
+		self.assertRaises(frappe.DoesNotExistError, dashboard_for_conversation, "no-such-conversation")

--- a/jarvis/tests/test_dashboards_api.py
+++ b/jarvis/tests/test_dashboards_api.py
@@ -895,6 +895,44 @@ class TestOriginPageStamp(_DashboardsApiTestCase):
 		frappe.set_user(PLAIN_A)
 		self.assertEqual(get_conversation(conv)["conversation"]["origin_page"], "dashboards")
 
+	def test_the_stamp_survives_an_admission_rollback(self):
+		"""``admission.accept_or_queue`` rolls back on its overload-reject and
+		duplicate-replay paths. The stamp rides the conversation's own
+		save+commit, which happens BEFORE that call, so a busy site cannot
+		silently drop it (it would otherwise only self-heal on a later send).
+
+		accept_or_queue is stubbed rather than driven: reaching the real
+		overload branch needs the shard/conversation locks plus a site whose
+		predispatch state says machine-active. What matters here is only that
+		the rollback lands AFTER the stamp is committed, which the stub
+		reproduces exactly (admission.py rolls back and returns this shape).
+		"""
+		conv = self._conv(PLAIN_A)
+
+		def _reject(**kwargs):
+			frappe.db.rollback()
+			return {"ok": False, "overloaded": True, "reason": "busy"}
+
+		def _duplicate(**kwargs):
+			frappe.db.rollback()
+			return {"ok": True, "dispatched": False, "duplicate": True, "queued_position": None}
+
+		for stub, expect_ok in ((_reject, False), (_duplicate, True)):
+			frappe.db.set_value("Jarvis Conversation", conv, "origin_page", "", update_modified=False)
+			frappe.db.commit()
+			frappe.set_user(PLAIN_A)
+			with (
+				patch("jarvis.chat.api.validate_can_send", return_value=(True, "")),
+				patch("jarvis.chat.admission.turn_machine_enabled", return_value=True),
+				patch("jarvis.chat.admission.shard_overloaded", return_value=False),
+				patch("jarvis.chat.admission.accept_or_queue", side_effect=stub),
+			):
+				out = send_message(
+					conv, "build me a dashboard", context=frappe.as_json({"page": "dashboards"})
+				)
+			self.assertEqual(out["ok"], expect_ok)
+			self.assertEqual(self._origin(conv), "dashboards")
+
 
 class TestDashboardForConversation(_DashboardsApiTestCase):
 	"""The lookup behind main chat's "Open in Dashboards": saved dashboard ->
@@ -915,7 +953,14 @@ class TestDashboardForConversation(_DashboardsApiTestCase):
 		frappe.set_user(PLAIN_A)
 		out = dashboard_for_conversation(conv)
 		self.assertTrue(out["ok"])
-		self.assertEqual(out["data"], {"name": d["name"], "dashboard_title": "from chat"})
+		self.assertEqual(out["data"]["name"], d["name"])
+		self.assertEqual(out["data"]["dashboard_title"], "from chat")
+		# `creation` travels so the caller can compare it against the clicked
+		# message's own creation (a later build must not open the older row).
+		self.assertEqual(
+			out["data"]["creation"],
+			str(frappe.db.get_value(DASHBOARD, d["name"], "creation")),
+		)
 
 	def test_no_saved_dashboard_is_an_empty_answer(self):
 		conv = self._conv(PLAIN_A)
@@ -924,15 +969,53 @@ class TestDashboardForConversation(_DashboardsApiTestCase):
 
 	def test_several_saves_answer_with_the_newest(self):
 		conv = self._conv(PLAIN_A)
-		self._mk_static(PLAIN_A, title="older", source_conversation=conv)
+		older = self._mk_static(PLAIN_A, title="older", source_conversation=conv)
 		newer = self._mk_static(PLAIN_A, title="newer", source_conversation=conv)
-		# `modified` has second resolution on some backends - order the pair
-		# explicitly so the assertion is about the ORDER BY, not the clock.
+		# Order the pair explicitly so the assertion is about the ORDER BY, not
+		# about how fast two inserts run.
 		frappe.db.set_value(
-			DASHBOARD, newer["name"], "modified", "2099-01-01 00:00:00", update_modified=False
+			DASHBOARD, older["name"], "creation", "2020-01-01 00:00:00", update_modified=False
+		)
+		frappe.db.set_value(
+			DASHBOARD, newer["name"], "creation", "2020-01-02 00:00:00", update_modified=False
 		)
 		frappe.set_user(PLAIN_A)
 		self.assertEqual(dashboard_for_conversation(conv)["data"]["name"], newer["name"])
+
+	def test_editing_an_older_dashboard_does_not_promote_it_over_a_newer_one(self):
+		# `creation desc`, not `modified desc`: merely touching the old row must
+		# not put it back in front of one built after it.
+		conv = self._conv(PLAIN_A)
+		older = self._mk_static(PLAIN_A, title="older", source_conversation=conv)
+		newer = self._mk_static(PLAIN_A, title="newer", source_conversation=conv)
+		frappe.db.set_value(
+			DASHBOARD, older["name"], "creation", "2020-01-01 00:00:00", update_modified=False
+		)
+		frappe.db.set_value(
+			DASHBOARD, newer["name"], "creation", "2020-01-02 00:00:00", update_modified=False
+		)
+		frappe.db.set_value(
+			DASHBOARD, older["name"], "modified", "2099-01-01 00:00:00", update_modified=False
+		)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(dashboard_for_conversation(conv)["data"]["name"], newer["name"])
+
+	def test_another_users_org_dashboard_bound_to_this_conversation_is_ignored(self):
+		# `source_conversation` is a client-settable payload field with no
+		# ownership validation, and an Org-scope row is visible to everyone -
+		# so without the owner filter, a row bound to A's conversation id by
+		# somebody else would answer A's "Open in Dashboards".
+		conv = self._conv(PLAIN_A)
+		planted = self._mk_static(ADMIN_USER, title="planted", scope="Org", source_conversation=conv)
+		frappe.set_user(PLAIN_A)
+		# visible to A (Org scope), and still not the answer
+		self.assertTrue(frappe.get_list(DASHBOARD, filters={"name": planted["name"]}))
+		self.assertEqual(dashboard_for_conversation(conv)["data"], {})
+		# A's own save wins outright, even though the plant is newer
+		mine = self._mk_static(PLAIN_A, title="mine", source_conversation=conv)
+		frappe.db.set_value(DASHBOARD, mine["name"], "creation", "2020-01-01 00:00:00", update_modified=False)
+		frappe.set_user(PLAIN_A)
+		self.assertEqual(dashboard_for_conversation(conv)["data"]["name"], mine["name"])
 
 	def test_another_users_conversation_is_a_permission_error(self):
 		conv = self._conv(PLAIN_A)


### PR DESCRIPTION
Owner report (2026-07-27): the builder's conversation shows up in the main chat
list. Opening it there shows the prompt and the dashboard output, but the canvas
there does not fetch/run data — which is accepted — *"but at least, I should have
a button to go to dashboard page from here with that output, shown with data."*

Follow-on to the D-series dashboards work (#481).

## Root cause

Nothing persisted "this conversation belongs to the Dashboards builder".
`Jarvis Conversation` had no origin field, `Jarvis Chat Message` stores no send
context, and the builder's `context {"page":"dashboards"}` was parsed by
`send_message`'s allow-list, forwarded to the worker, and then dropped. So
`ChatView` could not tell a dashboard html artifact from any other html canvas
(the trap `frontend/src/lib/dashboardRestore.js` already documents on the
builder side).

## Server

* `Jarvis Conversation.origin_page` — Data, hidden, read-only, server-set.
* `send_message` stamps it from the context allow-list it already parses, for
  `page in {"dashboards","triggers"}`, **on every qualifying send** rather than
  at creation — so a thread created before this field existed self-heals the
  next time the user chats from the builder. Written once; it never flips.
* **No backfill patch.** The origin was never persisted, so no honest backfill
  exists; inventing a heuristic one ("this conversation has an html artifact")
  would mislabel ordinary chats. Older builder threads heal on their next send.
* `get_conversation` returns `origin_page` ("" default) in the envelope.
* New `dashboards_api.dashboard_for_conversation(conversation)` →
  `{name, dashboard_title}` of the newest caller-visible `Jarvis Dashboard`
  whose `source_conversation` is that chat, else `{}`. Gate: the caller must own
  the conversation (`_get_owned_conversation`, the `get_conversation` rule), and
  the row goes through `frappe.get_list` — **not** `get_all`, which sets
  `ignore_permissions` and would skip the scope-visibility query hook. A
  dashboard out of the caller's reach reads as "none", never a leaked title.

## Main chat (ChatView)

When the loaded conversation's `origin_page === "dashboards"`, every **html**
canvas item gets an "Open in Dashboards" affordance — on the inline artifact
card (a sibling button, not nested inside the card's `<button>`) and in the
artifact preview panel header next to open/download. Non-html items and
non-dashboards conversations are untouched; triggers conversations are stamped
but get no button in this change.

Click → `dashboard_for_conversation`:

* saved hit → `/dashboards?edit=<name>` (the existing deep-link, which loads the
  stored document with live data and saves in place; sticky slots stay
  `loadEdit`'s business — ChatView routes and never touches `jarvis-dash-*`);
* no hit → `/dashboards?chat=<conv>&canvas=<msgId>`;
* lookup failure (network / scope) degrades to the promotion route — never a
  dead button.

## Builder (DashboardsPage) — the `?chat=&canvas=` promotion

Handled at setup **and** by a live watcher, so an already-open builder honours
the link. It validates lazily against the transcript (`builderCanvasFrame`), and
a message that is gone or drew no html toasts and falls back to normal mount
behaviour. If the promotion would cost the user something — an unsaved canvas,
an editing target, or another conversation's restored canvas — the page's
discard confirm is reused with copy adapted to the promotion ("its chat stays in
your conversations", plus the existing "Open its chat" action). Accepting clears
the editing identity, repoints the sticky conversation + canvas message, and
runs the normal restore path, which is what makes the owner's "shown with data"
true: `DashboardCanvas` re-runs the html with the query tools as the viewer.
The query is stripped only once the promotion settles (the ?edit "clear after
the confirm resolves" lesson). `?edit=` wins over `?chat=`, with a console.warn.

`onCanvas` now answers whether the artifact actually reached the canvas, so a
promotion whose File has since been purged cannot leave the previous document on
screen with Save armed over a thread it has nothing to do with.

The interview logic is untouched: a promoted conversation that already has a
canvas still trips `_dashboard_has_canvas`, so the agent iterates instead of
re-interviewing (`test_dashboard_clarify_context`, 20 tests, green).

## Tests (all run, real output in the report)

* `bench --site patterntest.localhost run-tests --module jarvis.tests.test_dashboards_api` — **51 passed** (12 new: stamp on dashboards / triggers / not otherwise, self-heal, stamp-once, `get_conversation` envelope; `dashboard_for_conversation` owner-hit / newest-of-several / other-user PermissionError / no-dashboard `{}` / out-of-scope `{}` / missing conversation).
* `…test_dashboard_open_from_chat_client` — 1 passed (subprocess-runs the new node suite in CI forever, the `test_dashboard_builder_ux_client` precedent).
* `…test_dashboard_builder_ux_client`, `…test_dashboard_clarify_context`, `…test_canvas`, `…test_canvas_embeds`, `…test_agent_dashboard_wire`, `…test_dashboard_permissions` — all green.
* All 22 `node --test` suites under `frontend/src` — green, including the new `dashboardOpen.test.js` (15) and `dashboardRestore.test.js` (26).
* `vitest run tests/support-extraction` — 248 passed.
* `vite build` — clean. Pinned pre-commit (ruff + prettier + eslint) — clean on `--all-files`.

**Pre-existing, not from this branch:** `jarvis.tests.test_chat_api` fails
`test_unknown_override_rejected` and `test_unknown_model_rejected` identically on
`origin/develop` without this branch (an unknown model id is accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxn1qvS9817vFv6gmLYEoN
