### PR TITLE
refactor(onboarding): migrate OnboardingGate, Banner, SetupNeuralNet to frappe-ui

### DIFF
--- a/frontend/src/components/Banner.vue
+++ b/frontend/src/components/Banner.vue
@@ -1,183 +1,88 @@
 <!--
-  Reusable inline banner (approved design: error-toast-system-preview.html,
-  section 2 "Inline banner - contextual, actionable errors"). Sits in a fixed
+  Reusable inline banner (design.md §3.7 "Banners & notices"). Sits in a fixed
   slot on a screen (a form step, a blocked action) instead of loose colored
   text. Icon tile + title/message body + an optional #action slot for a
-  Retry-style button. Ported from the preview's .banner / .banner.error /
-  .banner.warning CSS; .banner.info / .banner.success extrapolated from the
-  same file's .toast.info / .toast.success color pairing (the preview only
-  demoed error + warning banners, but all four states share the toast
-  palette).
+  Retry-style button. Wired into onboarding's error/notice surfaces (9 spots
+  in OnboardingView.vue) and ChatView's billing/paused banners — the
+  type/title/message props and the default/#action slots are a stable API
+  that every call site depends on; only the internal styling below changed.
 -->
 <template>
-	<div class="jv-banner" :class="`jv-banner--${type}`">
-		<span class="jv-banner-ic" aria-hidden="true">
-			<svg
-				width="15"
-				height="15"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				:stroke-width="type === 'success' ? 2.6 : 2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<template v-if="type === 'error'">
-					<circle cx="12" cy="12" r="9" />
-					<path d="M12 8v5M12 16h.01" />
-				</template>
-				<template v-else-if="type === 'warning'">
-					<path
-						d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h16.9a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"
-					/>
-					<path d="M12 9v4M12 17h.01" />
-				</template>
-				<template v-else-if="type === 'success'">
-					<path d="M20 6 9 17l-5-5" />
-				</template>
-				<template v-else>
-					<circle cx="12" cy="12" r="9" />
-					<path d="M12 16v-5M12 8h.01" />
-				</template>
-			</svg>
+	<div class="flex items-start gap-2.5 rounded-md p-2.5" :class="variant.fill">
+		<span
+			class="grid size-6.5 shrink-0 place-items-center rounded-lg border bg-surface-white"
+			:class="variant.border"
+			aria-hidden="true"
+		>
+			<FeatherIcon :name="variant.icon" class="size-3.5" :class="variant.ink" />
 		</span>
-		<div class="jv-banner-bd">
+		<div class="min-w-0 flex-1">
 			<template v-if="title">
-				<div class="jv-banner-tt">{{ title }}</div>
-				<div v-if="message" class="jv-banner-ms">{{ message }}</div>
+				<div class="text-sm font-semibold" :class="variant.ink">{{ title }}</div>
+				<div v-if="message" class="mt-0.5 text-p-xs text-ink-gray-7">{{ message }}</div>
 			</template>
 			<!-- No title: the message reads as the primary line so a message-only
 				 banner (the common case here) doesn't look like a blank card with a
 				 muted second line. -->
-			<div v-else class="jv-banner-tt">{{ message }}</div>
+			<div v-else class="text-sm font-semibold" :class="variant.ink">{{ message }}</div>
 			<!-- Optional extra body (hint line, a details expander): renders nothing
 				 when no default slot is passed, so existing message-only callers are
 				 unaffected. -->
 			<slot />
 		</div>
-		<div v-if="$slots.action" class="jv-banner-act">
+		<div v-if="$slots.action" class="mt-0.5 flex shrink-0 items-center gap-2">
 			<slot name="action" />
 		</div>
 	</div>
 </template>
 
 <script setup>
-defineProps({
+import { computed } from "vue";
+import { FeatherIcon } from "frappe-ui";
+
+const props = defineProps({
 	type: { type: String, default: "error" }, // error | warning | info | success
 	title: { type: String, default: "" },
 	message: { type: String, default: "" },
 });
+
+// Typed fill + ink, straight off design.md §3.7's banner recipe and the same
+// red/amber/green/blue ramps frappe-ui's own Badge uses (bg-surface-{hue}-2 +
+// text-ink-{hue}-3, confirmed against Badge.vue's subtle theme map). Error
+// uses ink-red-3 rather than Badge's ink-red-4 — design.md §2.1 documents
+// red-3 specifically as "error-banner ink", red-4 as badge/general error text.
+//
+// Info is the real blue ramp, not --cta: the old jv-* version painted "info"
+// with --cta/--cta-bg to dodge a since-fixed gap where --info was never
+// defined, but PR #294 repointed --cta off indigo to near-black/near-white,
+// so an "info" banner was silently rendering as a near-black/near-white card.
+// Using text-ink-blue-3 / bg-surface-blue-2 here is the fix, not a stylistic
+// swap.
+const VARIANTS = {
+	error: {
+		fill: "bg-surface-red-2",
+		border: "border-outline-red-2",
+		ink: "text-ink-red-3",
+		icon: "alert-circle",
+	},
+	warning: {
+		fill: "bg-surface-amber-2",
+		border: "border-outline-amber-2",
+		ink: "text-ink-amber-3",
+		icon: "alert-triangle",
+	},
+	success: {
+		fill: "bg-surface-green-2",
+		border: "border-outline-green-2",
+		ink: "text-ink-green-3",
+		icon: "check-circle",
+	},
+	info: {
+		fill: "bg-surface-blue-2",
+		border: "border-outline-blue-1",
+		ink: "text-ink-blue-3",
+		icon: "info",
+	},
+};
+const variant = computed(() => VARIANTS[props.type] || VARIANTS.error);
 </script>
-
-<style scoped>
-.jv-banner {
-	display: flex;
-	gap: 11px;
-	align-items: flex-start;
-	border-radius: 11px;
-	padding: 11px 13px;
-	animation: jv-banner-in 0.25s ease;
-}
-@keyframes jv-banner-in {
-	from {
-		opacity: 0;
-		transform: translateY(-4px);
-	}
-	to {
-		opacity: 1;
-		transform: none;
-	}
-}
-.jv-banner-ic {
-	width: 26px;
-	height: 26px;
-	border-radius: 8px;
-	flex: none;
-	display: grid;
-	place-items: center;
-}
-.jv-banner-bd {
-	flex: 1;
-	min-width: 0;
-}
-.jv-banner-tt {
-	font-size: 13px;
-	font-weight: 600;
-	line-height: 1.3;
-}
-.jv-banner-ms {
-	font-size: 12.5px;
-	color: var(--text-2);
-	line-height: 1.5;
-	margin-top: 2px;
-}
-.jv-banner-act {
-	flex: none;
-	display: flex;
-	gap: 8px;
-	align-items: center;
-	margin-top: 1px;
-}
-
-.jv-banner--error {
-	background: var(--red-bg);
-	border: 1px solid var(--red-bd);
-}
-.jv-banner--error .jv-banner-ic {
-	background: var(--surface);
-	color: var(--red);
-	border: 1px solid var(--red-bd);
-}
-.jv-banner--error .jv-banner-tt {
-	color: var(--red);
-}
-
-.jv-banner--warning {
-	background: var(--amber-bg);
-	border: 1px solid var(--amber-bd);
-}
-.jv-banner--warning .jv-banner-ic {
-	background: var(--surface);
-	color: var(--amber);
-	border: 1px solid var(--amber-bd);
-}
-.jv-banner--warning .jv-banner-tt {
-	color: var(--amber);
-}
-
-/* Info uses the theme's accent (--cta: indigo in light, lighter blue in dark),
-   matching how the success/warning variants use --green/--amber. The old
-   var(--info, #6e8bff) hardcoded the dark-mode blue into BOTH themes because
-   --info was never defined. */
-.jv-banner--info {
-	background: var(--cta-bg);
-	border: 1px solid var(--cta-bd);
-}
-.jv-banner--info .jv-banner-ic {
-	background: var(--surface);
-	color: var(--cta);
-	border: 1px solid var(--cta-bd);
-}
-.jv-banner--info .jv-banner-tt {
-	color: var(--cta);
-}
-
-.jv-banner--success {
-	background: var(--green-bg);
-	border: 1px solid var(--green-bd);
-}
-.jv-banner--success .jv-banner-ic {
-	background: var(--surface);
-	color: var(--green);
-	border: 1px solid var(--green-bd);
-}
-.jv-banner--success .jv-banner-tt {
-	color: var(--green);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.jv-banner {
-		animation: none;
-	}
-}
-</style>

--- a/frontend/src/components/shell/OnboardingGate.vue
+++ b/frontend/src/components/shell/OnboardingGate.vue
@@ -3,41 +3,54 @@
 	     sidebar + routed page whenever the workspace hasn't finished onboarding.
 	     No app chrome — a not-yet-connected workspace has nothing to navigate to.
 	     A rendered gate, never a redirect, so it can't reintroduce the old
-	     desk↔SPA onboarding loop. -->
-	<div class="jv-gate">
-		<!-- Decorative framing orbs (mirrors OnboardingView) — aria-hidden, no
-		     pointer events; quiet brand tint that reads on light and dark. -->
-		<div class="jv-gate-bg" aria-hidden="true">
-			<div class="jv-gate-orb jv-gate-orb-tl"></div>
-			<div class="jv-gate-orb jv-gate-orb-br"></div>
-		</div>
+	     desk↔SPA onboarding loop.
 
-		<div class="jv-gate-card">
-			<JarvisMark :size="56" :radius="14" class="jv-gate-logo" />
+	     No decorative background orbs or gradient CTA here (design.md §4.3 CTA
+	     discipline / §5 anti-pattern 4): the brand-asset exception in §2.2 covers
+	     the Jarvis mark's own gradient and the onboarding "processing" canvas,
+	     not a page-level poster background. -->
+	<div class="flex flex-1 items-center justify-center overflow-hidden bg-surface-white p-6">
+		<div class="flex w-full max-w-md flex-col items-center text-center">
+			<JarvisMark :size="56" :radius="14" class="mb-6" />
 
-			<h1 class="jv-gate-title">Finish setting up {{ agentName }}</h1>
+			<h1 class="mb-2.5 text-2xl font-semibold leading-tight text-ink-gray-9">
+				Finish setting up {{ agentName }}
+			</h1>
 
-			<p v-if="isSystemManager" class="jv-gate-sub">
+			<p v-if="isSystemManager" class="mb-7 text-p-base text-ink-gray-6">
 				This workspace isn't connected to an AI agent yet. Complete a short setup to start
 				chatting with {{ agentName }} about your ERPNext data.
 			</p>
-			<p v-else class="jv-gate-sub">
+			<p v-else class="mb-7 text-p-base text-ink-gray-6">
 				{{ agentName }} isn't set up for this workspace yet. Please ask your administrator
 				(a System Manager) to complete onboarding.
 			</p>
 
-			<button v-if="isSystemManager" class="jv-gate-btn" @click="goOnboard">
-				Complete setup
-				<span class="jv-gate-arrow" aria-hidden="true">→</span>
-			</button>
+			<Button
+				v-if="isSystemManager"
+				variant="solid"
+				size="lg"
+				label="Complete setup"
+				iconRight="arrow-right"
+				@click="goOnboard"
+			/>
 
-			<button class="jv-gate-ghost" @click="switchToDesk">Switch to Desk</button>
+			<!-- Onboarding footer-nav convention (design.md §4.3): a secondary path
+			     under the card is plain muted text, not a Button. -->
+			<button
+				type="button"
+				class="mt-3.5 text-p-sm text-ink-gray-5 hover:text-ink-gray-7"
+				@click="switchToDesk"
+			>
+				Switch to Desk
+			</button>
 		</div>
 	</div>
 </template>
 
 <script setup>
 import { useRouter } from "vue-router";
+import { Button } from "frappe-ui";
 import JarvisMark from "@/components/JarvisMark.vue";
 import { agentName } from "@/branding";
 
@@ -61,114 +74,3 @@ function switchToDesk() {
 	window.location.href = "/app";
 }
 </script>
-
-<style scoped>
-.jv-gate {
-	position: relative;
-	flex: 1;
-	display: grid;
-	place-items: center;
-	width: 100%;
-	height: 100%;
-	overflow: hidden;
-	background: var(--surface-white, #fff);
-	padding: 24px;
-}
-
-.jv-gate-bg {
-	position: absolute;
-	inset: 0;
-	pointer-events: none;
-}
-.jv-gate-orb {
-	position: absolute;
-	width: 460px;
-	height: 460px;
-	border-radius: 50%;
-	filter: blur(40px);
-	opacity: 0.5;
-}
-.jv-gate-orb-tl {
-	top: -160px;
-	left: -160px;
-	background: radial-gradient(circle at 30% 30%, rgba(110, 139, 255, 0.28), transparent 70%);
-}
-.jv-gate-orb-br {
-	bottom: -180px;
-	right: -160px;
-	background: radial-gradient(circle at 70% 70%, rgba(139, 92, 246, 0.24), transparent 70%);
-}
-
-.jv-gate-card {
-	position: relative;
-	z-index: 1;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	text-align: center;
-	max-width: 440px;
-	width: 100%;
-}
-
-.jv-gate-logo {
-	box-shadow: 0 8px 24px rgba(110, 92, 246, 0.28);
-	margin-bottom: 24px;
-}
-
-.jv-gate-title {
-	font-size: 24px;
-	font-weight: 600;
-	line-height: 1.25;
-	color: var(--ink-gray-9, #171717);
-	margin: 0 0 10px;
-}
-
-.jv-gate-sub {
-	font-size: 15px;
-	line-height: 1.55;
-	color: var(--ink-gray-6, #6b7280);
-	margin: 0 0 28px;
-}
-
-.jv-gate-btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-	padding: 10px 22px;
-	border: none;
-	border-radius: 9px;
-	font-size: 15px;
-	font-weight: 500;
-	color: #fff;
-	cursor: pointer;
-	background: linear-gradient(135deg, #6e8bff, #8b5cf6);
-	box-shadow: 0 6px 18px rgba(110, 92, 246, 0.3);
-	transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-.jv-gate-btn:hover {
-	transform: translateY(-1px);
-	box-shadow: 0 10px 24px rgba(110, 92, 246, 0.38);
-}
-.jv-gate-btn:active {
-	transform: translateY(0);
-}
-.jv-gate-arrow {
-	font-size: 16px;
-	line-height: 1;
-}
-
-.jv-gate-ghost {
-	margin-top: 14px;
-	padding: 6px 12px;
-	border: none;
-	background: transparent;
-	font-size: 13px;
-	color: var(--ink-gray-5, #9ca3af);
-	cursor: pointer;
-	border-radius: 7px;
-	transition: color 0.15s ease;
-}
-.jv-gate-ghost:hover {
-	color: var(--ink-gray-7, #4b5563);
-}
-</style>

--- a/frontend/src/onboarding/SetupNeuralNet.vue
+++ b/frontend/src/onboarding/SetupNeuralNet.vue
@@ -3,9 +3,14 @@
 		 --surface-3) via getComputedStyle on THIS element, not document.documentElement.
 		 Those vars are inline-applied on an ancestor (.jv-ob-root's paletteVars in
 		 OnboardingView.vue), not on :root, so they only resolve correctly once
-		 inherited down to a node inside that scope - this component's root div. -->
-	<div ref="rootEl" class="jv-setup-net">
-		<canvas ref="canvasEl"></canvas>
+		 inherited down to a node inside that scope - this component's root div.
+
+		 Both this div and the canvas fill via absolute + inset-0 (NOT h-full on
+		 the div): the parent .jv-ob-setup-net uses min-height, and percentage
+		 heights don't resolve against min-height, so h-full collapsed the canvas
+		 to 0px and nothing drew. Do not change this to h-full. -->
+	<div ref="rootEl" class="absolute inset-0">
+		<canvas ref="canvasEl" class="absolute inset-0 block h-full w-full"></canvas>
 	</div>
 </template>
 
@@ -345,20 +350,3 @@ watch(
 	}
 );
 </script>
-
-<style scoped>
-/* Fill the wrapper via absolute inset (NOT height:100%): the parent
-   .jv-ob-setup-net uses min-height, and % heights don't resolve against
-   min-height, so height:100% collapsed the canvas to 0px and nothing drew. */
-.jv-setup-net {
-	position: absolute;
-	inset: 0;
-}
-.jv-setup-net canvas {
-	position: absolute;
-	inset: 0;
-	width: 100%;
-	height: 100%;
-	display: block;
-}
-</style>


### PR DESCRIPTION
## Summary

Part A of jarvis-admin-v2#65 stage 2 (the onboarding half of "Consistent Frappe UI with
onboarding and settings page"). Stage 1 (settings panes) is merged. This migrates the three
small onboarding files off the legacy `jv-*` class palette onto Tailwind + frappe-ui semantic
tokens, following the pattern set by stage 1's `AiModelsPane`/`BrandingPane` migration
(`0016acaa`) and the already-migrated `GeneralPane.vue`/`ConnectionPane.vue`.

`OnboardingView.vue` (2639 lines, 66 legacy classes) is deliberately **not** touched. It is the
paid signup funnel and gets its own PR (part B) with its own review, landing against this
already-migrated set of shared pieces.

Measured with `grep -oE 'class="[^"]*"' FILE.vue | grep -oE '\bjv-[a-z0-9-]+' | sort -u`
(class attributes only, so explanatory-comment mentions of `jv-*` don't inflate the count):

| File | Before | After |
|---|---|---|
| `OnboardingGate.vue` | 12 | 0 |
| `Banner.vue` | 7 | 0 |
| `SetupNeuralNet.vue` | 1 | 0 |

### OnboardingGate.vue

Full rewrite to Tailwind + frappe-ui `Button`. This drops the decorative background orbs and
the gradient CTA button, per design.md's own anti-pattern table (#4: no decorative blurred
orbs, no gradient CTA, outside the brand-asset exception in §2.2 that covers only the Jarvis
mark's own gradient and the SetupNeuralNet processing canvas) and the §4.3 onboarding CTA
discipline (near-black solid button; the secondary "Switch to Desk" path is plain muted text,
matching the documented "back/skip are plain text links" footer-nav convention). The strict
truthy `isSystemManager` check that matches the `/onboarding` route guard exactly is untouched
byte for byte - this is presentation-only work, the comment explaining why is preserved.

### Banner.vue

Same `type`/`title`/`message` props and `default`/`#action` slots preserved - checked against
every call site (9 in `OnboardingView.vue`, 3 in `ChatView.vue`, 12 total). Internals reskinned
onto design.md §3.7's banner recipe; hand-pasted per-type SVG paths replaced with frappe-ui
`FeatherIcon`.

This also fixes a live bug, not just a style pass: the old "info" variant painted itself with
`--cta`/`--cta-bg` (a workaround from when `--info` was never defined). PR #294 later repointed
`--cta` off indigo to near-black/near-white, so every "info" banner has since been silently
rendering as a near-black/near-white card instead of blue. It now uses the real blue ramp
(`text-ink-blue-3` / `bg-surface-blue-2`, matching Badge's blue theme), which is the fix.

### SetupNeuralNet.vue

Its one legacy class (`jv-setup-net`) was pure `absolute; inset: 0` positioning CSS, unrelated
to the component's palette-var reads (`readColors()` queries `getComputedStyle` directly, not
this class) or to the ResizeObserver / v-show-mounts-hidden fix documented in the file's own
comments. Converted 1:1 to Tailwind utility classes on the div and the canvas; the JS
animation/measurement logic is untouched. The load-bearing absolute+inset-0-not-h-full
technique, and the fact that `--text-3`/`--surface`/`--surface-3` still depend on
`OnboardingView.vue` binding `paletteVars` on an ancestor, are both called out in an expanded
comment so they survive part B's migration of that file.

## Verification

- `pre-commit run --files <changed>` (prettier 2.7.1) passes.
- `npm run build` succeeds: 5180 modules transformed.
- A vite dev server was started from this worktree against `site.jarvis` (not the live
  checkout). All three changed modules transform cleanly with no errors, and the compiled
  production CSS was checked to contain every semantic class this migration introduces
  (`bg-surface-{red,amber,green,blue}-2`, the matching `border-outline-*` classes,
  `text-ink-{red,amber,green,blue}-3`, `size-6.5` compiling to the same 26px as the original
  icon tile).
- Could **not** visually confirm the gate's actual render: reaching it needs an authenticated
  Frappe session against `site.jarvis`, whose admin credentials are placeholder
  (jarvis#408, pre-existing, not touched here). No browser tool was used at any point in this
  session, per the coordinating session's instruction - that verification is deferred to the
  coordinating session's own visual pass in both themes.

## No local CI evidence

The local `jarvis-ci` harness was intentionally not run for this PR - it OOMs on this machine
(one of its suites is 12 containers on a 9.7 GB Colima VM). Hosted GitHub Actions is the real
gate and is currently working (the "billing exhausted" message in the local pre-PR hook is
stale). This PR was opened with `JCI_SKIP=1` for that reason.

## Test plan

- [ ] Coordinating session: visual pass on the onboarding gate poster and the four Banner
      variants (error/warning/info/success) in both light and dark themes, screenshots to
      `docs/ui-review/`.
- [ ] Confirm the "info" banner now renders blue, not near-black/near-white, in both themes.
- [ ] Confirm SetupNeuralNet's canvas animation still starts and redraws correctly when its
      `v-show` container becomes visible.

Claude-Session: https://claude.ai/code/session_01BXaYUhmfKv15hAw4KY5tQF
