### PR TITLE
fix(frontend): make the SPA build from a git worktree

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -172,6 +172,26 @@ function findBenchRoot(dir) {
 	}
 }
 
+// src/socket.js imports the bench's common_site_config.json by a FIXED relative
+// depth ("../../../../sites/..."), which only resolves when frontend/ sits at
+// apps/<app>/frontend. From a git worktree it is nested deeper
+// (.claude/worktrees/<name>/frontend), the specifier lands somewhere that does
+// not exist, and the whole build dies on "Could not resolve". findBenchRoot
+// already walks up rather than counting levels, which is exactly the property
+// the depth-based specifier lacks, so point the alias at the file it found.
+//
+// Aliased here rather than edited in socket.js so the source keeps a plain
+// relative import that still resolves for anyone reading it, and so this stays
+// one build-config concern in one place.
+function commonSiteConfigPath() {
+	const benchRoot = findBenchRoot(__dirname);
+	return benchRoot
+		? path.join(benchRoot, "sites", "common_site_config.json")
+		: // No bench above us (a bare checkout, CI without a bench). Fall back to
+		  // the original literal so the failure mode is unchanged rather than new.
+		  path.resolve(__dirname, "../../../../sites/common_site_config.json");
+}
+
 function getWebserverPort() {
 	if (process.env.FRAPPE_WEB_SERVER_PORT) {
 		return Number(process.env.FRAPPE_WEB_SERVER_PORT);
@@ -278,6 +298,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),
+			"../../../../sites/common_site_config.json": commonSiteConfigPath(),
 		},
 		// wiki-graph-core is a self-contained file: package (own vue in its
 		// node_modules); dedupe keeps a single Vue instance shared with the app.


### PR DESCRIPTION
## Why

`npm run build` fails from any git worktree:

```
Could not resolve "../../../../sites/common_site_config.json" from "src/socket.js"
```

`socket.js` reaches the bench's `common_site_config.json` by counting four levels up, which only lands correctly when `frontend/` sits at `apps/<app>/frontend`. A worktree nests it deeper (`.claude/worktrees/<name>/frontend`), so the specifier points at a directory that does not exist and the build dies.

## Fix

`vite.config.js` already had the answer and was not using it here. `findBenchRoot` walks up looking for a real bench rather than counting levels, and its own comment says that is exactly what "makes this work unchanged from a git worktree nested arbitrarily deeper". It was only wired to the dev-server port. An alias now points the specifier at the file it locates.

Aliased in the build config rather than edited in `socket.js`, so the source keeps a plain relative import that still reads correctly, and this stays one build-config concern in one place. With no bench above it (a bare checkout, CI without a bench) it falls back to the original literal, so that failure mode is unchanged rather than newly introduced.

## Why it went unnoticed

`node_modules` is usually symlinked into a worktree from the real checkout, and a build there can resolve out of the shared vite cache. Worktree builds therefore appear to pass until the cache goes cold, which makes "the build is clean" an unreliable check from a worktree until this is fixed. Two separate pieces of work hit it independently.

## Verification

- Build from a worktree: now succeeds (21s), previously failed outright
- Build from the real checkout: still succeeds (16s), no regression
- `socket.js` untouched; the diff is `vite.config.js` only

https://claude.ai/code/session_01WLXuBvzxvSt2WqHQRXdRBz