### PR TITLE
Self-serve instant workspace reset (tenant side)

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -40,6 +40,15 @@ export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
 
+// ---- workspace reset (customer self-serve, admin-gated) --------------------
+export const requestWorkspaceReset = (reason, opts = {}) =>
+	call("jarvis.onboarding.request_workspace_reset", {
+		reason: reason || "",
+		wipe_data: opts.wipeData ? 1 : 0,
+		revoke_llm: opts.revokeLlm ? 1 : 0,
+	});
+export const workspaceResetState = () => call("jarvis.onboarding.workspace_reset_state");
+
 // --- Per-user chat settings + real (measured) usage tracking, incl. the
 // tenant-admin usage table (design doc §4/§6). All return the house
 // {ok, data} / {ok:false, reason} envelope — unlike getUsage above, which is

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -144,10 +144,10 @@
 					<span class="text-base font-medium text-ink-gray-8">Reset workspace</span>
 					<span class="max-w-lg text-p-sm text-ink-gray-6">
 						Destroys this workspace's container and attaches a fresh one, then
-						reconnects automatically — use it when the workspace is stuck or
-						won't connect. Chat is unavailable while it runs (usually a few
-						minutes). Your subscription, chat history and AI connections are
-						kept unless you tick the options.
+						reconnects automatically — use it when the workspace is stuck or won't
+						connect. Chat is unavailable while it runs (usually a few minutes). Your
+						subscription, chat history and AI connections are kept unless you tick the
+						options.
 					</span>
 				</div>
 				<Button
@@ -178,8 +178,8 @@
 							Also delete workspace content
 						</span>
 						<span class="block text-p-sm text-ink-gray-6">
-							Permanently deletes chats, skills, macros, triggers, learned
-							patterns, wiki pages and dashboards. Cannot be undone.
+							Permanently deletes chats, skills, macros, triggers, learned patterns,
+							wiki pages and dashboards. Cannot be undone.
 						</span>
 					</span>
 				</label>
@@ -190,8 +190,8 @@
 							Also disconnect AI model connections
 						</span>
 						<span class="block text-p-sm text-ink-gray-6">
-							Removes every connected model and key; you'll set them up again
-							after the reset.
+							Removes every connected model and key; you'll set them up again after
+							the reset.
 						</span>
 					</span>
 				</label>
@@ -397,7 +397,9 @@ const resetNote = computed(() => {
 });
 
 async function doReset() {
-	const parts = ["Chat will stop working until the workspace reconnects (usually a few minutes)."];
+	const parts = [
+		"Chat will stop working until the workspace reconnects (usually a few minutes).",
+	];
 	if (wipeData.value) {
 		parts.push(
 			"All chats, skills, macros, triggers, learned patterns, wiki pages and dashboards will be permanently deleted. This cannot be undone."

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -133,13 +133,87 @@
 				@click="onClearAllHistory"
 			/>
 		</div>
+
+		<!-- Reset workspace (jarvis.onboarding.*): self-serve container rebuild.
+		     Admin-tier only; the red solid lives in the useConfirm dialog, per the
+		     danger-zone rule above. While a reset runs the pane polls back to
+		     Ready and hard-reloads /jarvis (drops the memoized readiness verdict). -->
+		<template v-if="isSM">
+			<div class="mt-6 flex items-start justify-between gap-4">
+				<div class="flex flex-col gap-0.5">
+					<span class="text-base font-medium text-ink-gray-8">Reset workspace</span>
+					<span class="max-w-lg text-p-sm text-ink-gray-6">
+						Destroys this workspace's container and attaches a fresh one, then
+						reconnects automatically — use it when the workspace is stuck or
+						won't connect. Chat is unavailable while it runs (usually a few
+						minutes). Your subscription, chat history and AI connections are
+						kept unless you tick the options.
+					</span>
+				</div>
+				<Button
+					v-if="!resetting"
+					variant="subtle"
+					theme="red"
+					:label="resetOpen ? 'Close' : 'Reset workspace'"
+					@click="resetOpen = !resetOpen"
+				/>
+			</div>
+
+			<div v-if="resetting" class="mt-3">
+				<Badge :label="resetStatusLabel" theme="blue" variant="subtle" />
+				<p class="mt-2 text-p-sm text-ink-gray-6">{{ resetNote }}</p>
+			</div>
+
+			<div v-else-if="resetOpen" class="mt-3 max-w-lg">
+				<textarea
+					v-model="resetReason"
+					rows="2"
+					class="w-full rounded-md border bg-surface-white p-2 text-p-sm text-ink-gray-8"
+					placeholder="What's wrong? (optional)"
+				/>
+				<label class="mt-3 flex cursor-pointer items-start gap-2.5">
+					<input v-model="wipeData" type="checkbox" class="mt-0.5" />
+					<span>
+						<span class="block text-p-sm font-medium text-ink-gray-8">
+							Also delete workspace content
+						</span>
+						<span class="block text-p-sm text-ink-gray-6">
+							Permanently deletes chats, skills, macros, triggers, learned
+							patterns, wiki pages and dashboards. Cannot be undone.
+						</span>
+					</span>
+				</label>
+				<label class="mt-2 flex cursor-pointer items-start gap-2.5">
+					<input v-model="revokeLlm" type="checkbox" class="mt-0.5" />
+					<span>
+						<span class="block text-p-sm font-medium text-ink-gray-8">
+							Also disconnect AI model connections
+						</span>
+						<span class="block text-p-sm text-ink-gray-6">
+							Removes every connected model and key; you'll set them up again
+							after the reset.
+						</span>
+					</span>
+				</label>
+				<Button
+					class="mt-3"
+					variant="subtle"
+					theme="red"
+					label="Reset workspace"
+					iconLeft="refresh-cw"
+					:loading="resetBusy"
+					@click="doReset"
+				/>
+			</div>
+		</template>
 	</SettingsPane>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
-import { Badge, Button } from "frappe-ui";
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { Badge, Button, toast } from "frappe-ui";
 import { useShellStore } from "@/stores/shell";
+import { useConfirm } from "@/composables/useConfirm";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import KvRow from "@/components/settings/KvRow.vue";
 import ToggleRow from "@/components/settings/ToggleRow.vue";
@@ -294,4 +368,123 @@ async function onClearAllHistory() {
 		clearing.value = false;
 	}
 }
+
+// -- Reset workspace (danger zone) -----------------------------------------
+const { confirm } = useConfirm();
+const resetOpen = ref(false);
+const resetReason = ref("");
+const resetBusy = ref(false);
+const resetting = ref(false);
+const resetState = ref({});
+const wipeData = ref(false);
+const revokeLlm = ref(false);
+
+// Poll every 3s while resetting, up to 15 min; the tenant-side */5 cron backstop
+// converges a closed tab, so timing out here just stops the spinner.
+const POLL_MS = 3000;
+const POLL_BUDGET_MS = 15 * 60 * 1000;
+let pollTimer = null;
+let pollStarted = 0;
+
+const resetStatusLabel = computed(() =>
+	resetState.value.status === "Pending Capacity"
+		? "Waiting for capacity…"
+		: "Rebuilding your workspace…"
+);
+const resetNote = computed(() => {
+	if (resetState.value.message) return resetState.value.message;
+	return "This usually takes a few minutes. You can leave this page open — chat reloads when the workspace is back.";
+});
+
+async function doReset() {
+	const parts = ["Chat will stop working until the workspace reconnects (usually a few minutes)."];
+	if (wipeData.value) {
+		parts.push(
+			"All chats, skills, macros, triggers, learned patterns, wiki pages and dashboards will be permanently deleted. This cannot be undone."
+		);
+	} else {
+		parts.push("Your subscription and chat history are kept.");
+	}
+	if (revokeLlm.value) {
+		parts.push(
+			"Your AI model connections will be disconnected — you'll set them up again after the reset."
+		);
+	}
+	const ok = await confirm({
+		title: "Reset workspace?",
+		message: parts.join(" "),
+		confirmLabel: "Reset workspace",
+		danger: true,
+	});
+	if (!ok) return;
+	resetBusy.value = true;
+	try {
+		const out =
+			(await api.requestWorkspaceReset(resetReason.value, {
+				wipeData: wipeData.value,
+				revokeLlm: revokeLlm.value,
+			})) || {};
+		resetReason.value = "";
+		resetOpen.value = false;
+		resetState.value = out;
+		resetting.value = true;
+		toast.success("Resetting your workspace.");
+		startPoll();
+	} catch (e) {
+		toast.error((e && e.messages && e.messages[0]) || "Could not reset the workspace.");
+	} finally {
+		resetBusy.value = false;
+	}
+}
+
+function startPoll() {
+	stopPoll();
+	pollStarted = Date.now();
+	pollTimer = setInterval(pollReset, POLL_MS);
+}
+
+function stopPoll() {
+	if (pollTimer) clearInterval(pollTimer);
+	pollTimer = null;
+}
+
+async function pollReset() {
+	if (Date.now() - pollStarted > POLL_BUDGET_MS) {
+		stopPoll();
+		resetting.value = false;
+		toast.error("The reset is taking longer than expected. Check back in a few minutes.");
+		return;
+	}
+	let s;
+	try {
+		s = (await api.workspaceResetState()) || {};
+	} catch (e) {
+		return; // transient — the container is mid-rebuild; keep polling
+	}
+	resetState.value = s;
+	if (s.ready) {
+		stopPoll();
+		toast.success("Workspace is back — reloading.");
+		// Full reload drops the memoized readiness verdict (same ending as the
+		// onboarding wizard).
+		setTimeout(() => window.location.assign("/jarvis/"), 800);
+	}
+}
+
+async function resumeResetIfInFlight() {
+	if (!isSM) return;
+	try {
+		const s = (await api.workspaceResetState()) || {};
+		if (s.resetting && !s.ready) {
+			resetState.value = s;
+			resetting.value = true;
+			startPoll();
+		}
+	} catch (e) {
+		/* no in-flight reset to resume */
+	}
+}
+
+onMounted(resumeResetIfInFlight);
+onBeforeUnmount(stopPoll);
 </script>

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -75,13 +75,21 @@ export async function billingNoticeOf() {
 // wants "what do I tell the customer" never has to know the raw {ready, reason,
 // detail} shape checkReady() resolves to.
 //
-// Deliberately scoped to ONLY container_provisioning: "subscription_suspended" has
+// Scoped to container_provisioning + llm_credentials: "subscription_suspended" has
 // its own dedicated copy (suspensionNotice/SUSPENDED_FALLBACK in steps.js) with a
-// Renew call to action, which is wrong for this reason (nothing to renew via US when
-// the customer's OWN LLM account merely ran out of quota) - a caller must not paint
-// this detail into that banner's "Chat is paused" framing.
+// Renew call to action, which is wrong for these reasons (nothing to renew via US
+// when the customer's OWN LLM account merely ran out of quota) - a caller must not
+// paint this detail into that banner's "Chat is paused" framing.
+//
+// "llm_credentials" (no key/model configured, or creds revoked — e.g. after a
+// workspace reset with "disconnect AI model connections") has no backend detail,
+// so it gets a fixed actionable sentence; without it the chat renders NO hint at
+// all and a send just queues against the stub LLM.
 export async function readinessDetailOf() {
 	const r = await checkReady();
-	if (!r || r.ready || r.reason !== "container_provisioning") return "";
-	return r.detail || "";
+	if (!r || r.ready) return "";
+	if (r.reason === "container_provisioning") return r.detail || "";
+	if (r.reason === "llm_credentials")
+		return "No AI model is connected. Connect one in Settings → AI models to start chatting.";
+	return "";
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7045,6 +7045,18 @@ async function send(textArg, resendAck) {
 				setTimeout(() => window.location.reload(), 1500);
 				return;
 			}
+			if (r.reason === "workspace_resetting") {
+				notify(`${agentName} is being reset. Chat will be back in a few minutes.`, {
+					type: "warning",
+				});
+				return;
+			}
+			if (r.reason === "llm_not_configured") {
+				notify("No AI model is connected. Connect one in Settings → AI models.", {
+					type: "warning",
+				});
+				return;
+			}
 			notify(
 				r.reason === "usage_limit"
 					? `Monthly usage limit reached. Ask your ${agentName} admin to raise your limit.`

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -923,6 +923,23 @@ def post_subscription_disconnect() -> dict:
 	)
 
 
+# --------------------------------------------------------------------------- #
+# Workspace reset proxies. The customer bench forwards to the control plane,
+# which re-derives the customer from the api_key. ``_post`` already unwraps the
+# admin's {ok, data} envelope to the inner data dict (see _do_post), so these
+# return it directly — do NOT ``.get("data")`` again (that double-unwraps to {}).
+# --------------------------------------------------------------------------- #
+def reset_workspace(reason: str = "") -> dict:
+	"""Self-serve container rebuild (keeps customer + subscription + site data).
+	Container-recreate class op — destroy + warm-pool claim happen inline."""
+	return _post(path=_m("api.tenant_request.reset_workspace"), body={"reason": reason}, timeout_s=180)
+
+
+def reset_workspace_state() -> dict:
+	"""Latest workspace-reset request state (for the SPA poll)."""
+	return _post(path=_m("api.tenant_request.get_request_state"), body={}, timeout_s=8)
+
+
 def post_update_llm_pool(*, spec: dict, api_keys: dict, oauth_blobs: dict) -> dict:
 	"""POST a PoolSpec + separated secrets to admin → fleet-agent → openclaw.
 

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -71,10 +71,14 @@ def _workspace_resetting() -> bool:
 		s = frappe.get_single("Jarvis Settings")
 		return not s.get("agent_url") and (s.get("last_sync_status") or "").startswith(_RESETTING_STATUS)
 	except Exception:
-		frappe.log_error(
-			title="jarvis policy: workspace-reset check failed (allowing send)",
-			message=frappe.get_traceback(),
-		)
+		# See _over_model_limit: don't let a logging failure defeat fail-open.
+		try:
+			frappe.log_error(
+				title="jarvis policy: workspace-reset check failed (allowing send)",
+				message=frappe.get_traceback(),
+			)
+		except Exception:
+			pass
 		return False
 
 
@@ -102,10 +106,14 @@ def _llm_not_configured() -> bool:
 		model = (s.get("llm_model") or "").strip()
 		return not (key and provider and model)
 	except Exception:
-		frappe.log_error(
-			title="jarvis policy: llm-configured check failed (allowing send)",
-			message=frappe.get_traceback(),
-		)
+		# See _over_model_limit: don't let a logging failure defeat fail-open.
+		try:
+			frappe.log_error(
+				title="jarvis policy: llm-configured check failed (allowing send)",
+				message=frappe.get_traceback(),
+			)
+		except Exception:
+			pass
 		return False
 
 

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -29,6 +29,10 @@ def validate_can_send(user: str, model: str | None = None) -> tuple[bool, str | 
 		return False, "subscription_suspended"
 	if _release_update_required():
 		return False, "release_update_required"
+	if _workspace_resetting():
+		return False, "workspace_resetting"
+	if _llm_not_configured():
+		return False, "llm_not_configured"
 	# Per-model cap: only when a concrete model is known. ``model`` is resolved
 	# in chat.api (which knows the conversation) and passed in as a plain string,
 	# so policy never imports turn_handler (no import cycle). Pool "Auto" resolves
@@ -52,6 +56,48 @@ def _release_update_required() -> bool:
 	except Exception:
 		frappe.log_error(
 			title="jarvis policy: release-notice check failed (allowing send)",
+			message=frappe.get_traceback(),
+		)
+		return False
+
+
+def _workspace_resetting() -> bool:
+	"""True while a self-serve workspace reset is rebuilding the container
+	(transport cleared + resetting marker set). Without this a send throws a raw
+	"openclaw is not configured" instead of a gated state. Fails OPEN."""
+	try:
+		from jarvis.onboarding import _RESETTING_STATUS
+
+		s = frappe.get_single("Jarvis Settings")
+		return not s.get("agent_url") and (s.get("last_sync_status") or "").startswith(_RESETTING_STATUS)
+	except Exception:
+		frappe.log_error(
+			title="jarvis policy: workspace-reset check failed (allowing send)",
+			message=frappe.get_traceback(),
+		)
+		return False
+
+
+def _llm_not_configured() -> bool:
+	"""True when NO LLM connection is configured at all (never set up, or revoked
+	via the workspace-reset "disconnect AI model connections" option). Mirrors
+	account.is_ready_for_chat's local llm_credentials branch — without this gate a
+	send queues against the container's stub key and hangs instead of telling the
+	customer to connect a model. Fails OPEN."""
+	try:
+		s = frappe.get_single("Jarvis Settings")
+		if s.get("proxy_active"):
+			return False  # a pool is configured; pool health is admin's concern
+		mode = (s.get("llm_auth_mode") or "api_key").strip() or "api_key"
+		if mode in ("subscription", "oauth"):
+			return not s.get("llm_oauth_connected_at")
+		key = s.get_password("llm_api_key", raise_exception=False) or ""
+		provider = (s.get("llm_provider") or "").strip()
+		model = (s.get("llm_model") or "").strip()
+		return not (key and provider and model)
+	except Exception:
+		frappe.log_error(
+			title="jarvis policy: llm-configured check failed (allowing send)",
 			message=frappe.get_traceback(),
 		)
 		return False

--- a/jarvis/chat/policy.py
+++ b/jarvis/chat/policy.py
@@ -83,8 +83,14 @@ def _llm_not_configured() -> bool:
 	via the workspace-reset "disconnect AI model connections" option). Mirrors
 	account.is_ready_for_chat's local llm_credentials branch — without this gate a
 	send queues against the container's stub key and hangs instead of telling the
-	customer to connect a model. Fails OPEN."""
+	customer to connect a model. Fails OPEN.
+
+	Skipped under test unless a test opts in via
+	``frappe.flags.test_llm_configured_gate``: the CI site has no LLM configured,
+	so this gate would otherwise reject every chat test's send."""
 	try:
+		if frappe.flags.in_test and not frappe.flags.test_llm_configured_gate:
+			return False
 		s = frappe.get_single("Jarvis Settings")
 		if s.get("proxy_active"):
 			return False  # a pool is configured; pool health is admin's concern

--- a/jarvis/commands/__init__.py
+++ b/jarvis/commands/__init__.py
@@ -1,0 +1,52 @@
+"""Bench CLI commands for the jarvis app (auto-discovered via ``commands``)."""
+
+import click
+
+import frappe
+from frappe.commands import get_site, pass_context
+
+
+@click.command("reset-onboarding")
+@click.option("--force", is_flag=True, help="Skip the confirmation prompt.")
+@click.option(
+	"--keep-data",
+	is_flag=True,
+	help="Keep workspace content (chats, skills, macros, ...); only clear the connection + LLM setup.",
+)
+@pass_context
+def reset_onboarding(context, force, keep_data):
+	"""Completely flush this site's Jarvis setup so the onboarding wizard can
+	run fresh (DEV): connection + LLM credentials, and — unless --keep-data —
+	all workspace content (chats, skills, macros, triggers, learning, wiki,
+	dashboards). Admin-side records are NOT touched - use the admin's Purge
+	customer for that."""
+	site = get_site(context)
+	frappe.init(site)
+	frappe.connect()
+	try:
+		if not force:
+			what = (
+				"the local connection + LLM credentials (workspace content is kept)"
+				if keep_data
+				else "the local connection + LLM credentials AND ALL workspace content "
+				"(chats, skills, macros, triggers, learning, wiki, dashboards)"
+			)
+			click.confirm(
+				f"Reset Jarvis onboarding on {site}? This clears {what}. "
+				"Admin-side records are not touched.",
+				abort=True,
+			)
+		from jarvis.dev import reset_onboarding as _reset
+
+		data = _reset(wipe_data=not keep_data).get("data", {})
+		cleared = data.get("cleared_fields", [])
+		wiped = data.get("wiped_doctypes", [])
+		msg = f"Onboarding reset on {site} - cleared {len(cleared)} field(s)"
+		if wiped:
+			msg += f", wiped {len(wiped)} content doctype(s)"
+		click.echo(msg + ".")
+	finally:
+		frappe.destroy()
+
+
+commands = [reset_onboarding]

--- a/jarvis/commands/__init__.py
+++ b/jarvis/commands/__init__.py
@@ -1,7 +1,6 @@
 """Bench CLI commands for the jarvis app (auto-discovered via ``commands``)."""
 
 import click
-
 import frappe
 from frappe.commands import get_site, pass_context
 
@@ -32,8 +31,7 @@ def reset_onboarding(context, force, keep_data):
 				"(chats, skills, macros, triggers, learning, wiki, dashboards)"
 			)
 			click.confirm(
-				f"Reset Jarvis onboarding on {site}? This clears {what}. "
-				"Admin-side records are not touched.",
+				f"Reset Jarvis onboarding on {site}? This clears {what}. Admin-side records are not touched.",
 				abort=True,
 			)
 		from jarvis.dev import reset_onboarding as _reset

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -1,8 +1,8 @@
 """Dev-only helpers for the customer bench.
 
-Gated by the System Manager role. Used by the Jarvis Settings form to wipe
-local state so the operator can run the onboarding wizard fresh without
-manual DB surgery.
+Gated by the System Manager role. Exposed as the ``bench reset-onboarding``
+command (``jarvis.commands``) to wipe local state so the operator can run the
+onboarding wizard fresh without manual DB surgery.
 
 Companion to ``jarvis_admin_v2.api.dev.purge_customer`` on the admin side -
 the admin button wipes admin-side records; this clears the customer bench.
@@ -57,10 +57,15 @@ _RESET_CLEAR_FIELDS = (
 )
 
 
-@frappe.whitelist()
-def reset_onboarding() -> dict:
+def reset_onboarding(wipe_data: bool = False) -> dict:
 	"""Wipe local Jarvis Settings connection + LLM credentials so the
 	customer bench can run the onboarding wizard from step 1 again.
+
+	``wipe_data`` additionally deletes all workspace content (chats, skills,
+	macros, triggers, learning artifacts, wiki, dashboards — the same
+	``onboarding._WIPE_DOCTYPES`` set the self-serve reset offers) for a true
+	factory reset. The ``bench reset-onboarding`` CLI passes it by default;
+	programmatic callers must opt in.
 
 	Preserved (these are settings, not onboarded session state):
 	  - jarvis_admin_url        (so the bench remembers which admin to point at)
@@ -70,7 +75,7 @@ def reset_onboarding() -> dict:
 	    stays valid - it's a Select field, can't be blank)
 
 	Does NOT call the admin-side purge - use
-	``jarvis_admin_v2.api.dev.purge_customer`` on admin for that. Both buttons
+	``jarvis_admin_v2.api.dev.purge_customer`` on admin for that. The two
 	together give a clean two-step reset; this one alone is enough when the
 	admin record was already removed or never created.
 	"""
@@ -135,9 +140,18 @@ def reset_onboarding() -> dict:
 		"proxy_recommended",
 		"models",
 	]
+	wiped: list = []
+	if wipe_data:
+		from jarvis.onboarding import _WIPE_DOCTYPES, _wipe_workspace_content
+
+		_wipe_workspace_content()
+		frappe.db.commit()
+		wiped = list(_WIPE_DOCTYPES)
+
 	return {
 		"ok": True,
 		"data": {
 			"cleared_fields": list(_RESET_CLEAR_FIELDS) + _extra_cleared + ["llm_provider"],
+			"wiped_doctypes": wiped,
 		},
 	}

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -271,6 +271,10 @@ scheduler_events = {
 			# moment chat_readiness reads Ready. Without this, a pending apply
 			# that outlives the in-job 120s poll is a permanent dead-end.
 			"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.reconcile_pending_llm_sync",
+			# Workspace-reset convergence backstop: if the customer closed the tab
+			# mid-reset, pull the new container's connection once admin reports
+			# Ready (same shape as reconcile_pending_llm_sync above).
+			"jarvis.onboarding.reconcile_pending_workspace_reset",
 			# 2026-07 latency plan, Phase 1.4: was */30, which left the
 			# provider prompt cache (5-10 min retention) cold for most of
 			# each half-hour. Every 5 min + a 4-min cooldown in prewarm.py

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -313,4 +313,3 @@ function openSelfHostDialog(frm) {
 	});
 	d.show();
 }
-

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.js
@@ -97,19 +97,9 @@ frappe.ui.form.on("Jarvis Settings", {
 			__("Diagnostics")
 		);
 
-		// DEV-only reset: visible to System Manager only. The server
-		// re-checks the same role via frappe.only_for, so this client-side
-		// check is purely a visibility convenience (sandbox mode, the
-		// former extra gate, was removed as a dead feature).
-		if (frappe.user.has_role("System Manager")) {
-			frm.add_custom_button(
-				__("Reset onboarding (DEV)"),
-				() => {
-					confirmAndReset(frm);
-				},
-				__("Diagnostics")
-			);
-		}
+		// Reset onboarding moved to the `bench reset-onboarding` CLI command
+		// (jarvis.commands); a destructive dev reset no longer belongs on the
+		// HTTP form.
 
 		frm.add_custom_button(
 			__("Force Resync"),
@@ -324,60 +314,3 @@ function openSelfHostDialog(frm) {
 	d.show();
 }
 
-function confirmAndReset(frm) {
-	const d = new frappe.ui.Dialog({
-		title: __("Reset onboarding (irreversible)"),
-		fields: [
-			{
-				fieldtype: "HTML",
-				fieldname: "warn",
-				options: `<p>This clears local connection + LLM credentials so the onboarding
-				wizard restarts from step 1:</p>
-				<ul>
-				  <li>Admin API key &amp; secret</li>
-				  <li>Agent URL, token, container paths</li>
-				  <li>Chat device pairing (keys + token)</li>
-				  <li>LLM model / API key / base URL (provider resets to Anthropic)</li>
-				  <li>Last sync timestamp + status</li>
-				</ul>
-				<p>Preserved: Admin URL, monthly budget, sampling settings.</p>
-				<p>Does NOT touch admin-side records - use the admin's
-				<i>Purge customer (DEV)</i> button for that.</p>
-				<p>Type <b>RESET</b> to confirm:</p>`,
-			},
-			{ fieldtype: "Data", fieldname: "confirm", label: __("Confirm"), reqd: 1 },
-		],
-		primary_action_label: __("Reset"),
-		primary_action(values) {
-			if ((values.confirm || "").trim() !== "RESET") {
-				frappe.msgprint({
-					message: __("Type RESET exactly to confirm."),
-					indicator: "red",
-				});
-				return;
-			}
-			d.disable_primary_action();
-			frappe
-				.call({ method: "jarvis.dev.reset_onboarding" })
-				.then((r) => {
-					d.hide();
-					const n = (
-						(r && r.message && r.message.data && r.message.data.cleared_fields) ||
-						[]
-					).length;
-					frappe.show_alert({
-						message: __(
-							"Onboarding reset - cleared {0} field(s). Go to /app/jarvis-onboarding to start fresh.",
-							[n]
-						),
-						indicator: "green",
-					});
-					frm.reload_doc();
-				})
-				.catch(() => {
-					d.enable_primary_action();
-				});
-		},
-	});
-	d.show();
-}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -594,6 +594,7 @@ def _workspace_reset_poll() -> dict:
 		req = admin_client.reset_workspace_state() or {}
 	except Exception:
 		pass  # audit-row state is advisory; readiness below is the real signal
+
 	def _resetting() -> bool:
 		return (settings.get("last_sync_status") or "").startswith(_RESETTING_STATUS)
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -5,6 +5,7 @@ never holds admin creds). admin_client returns already-unwrapped admin data."""
 import json
 
 import frappe
+from frappe.utils import cint
 
 from jarvis import admin_client, release_notice
 from jarvis.exceptions import (
@@ -448,6 +449,201 @@ def renew(provider: str | None = None) -> dict:
 	"""
 	require_jarvis_admin()
 	return _surface(admin_client.renew, provider=provider)
+
+
+_RESETTING_STATUS = "pending: resetting workspace"
+# Variant marker when the customer also revoked their LLM connections: the poll
+# then completes on "container reachable" (readiness can never reach Ready with
+# no LLM configured) and the wizard gate owns the rest.
+_RESETTING_RECONNECT_LLM_STATUS = _RESETTING_STATUS + " (reconnect llm)"
+
+# Customer content wiped by the "also delete my data" reset option. Raw table
+# deletes (single-tenant DB, no hooks) — the dev.reset_onboarding precedent.
+# Deliberately NOT wiped: Jarvis Settings, user settings/usage, agent listings/
+# installations, relay pump, File rows.
+_WIPE_DOCTYPES = (
+	# chats
+	"Jarvis Chat Message",
+	"Jarvis Chat Turn",
+	"Jarvis Turn Effect",
+	"Jarvis Chat Session",
+	"Jarvis Conversation",
+	"Jarvis Voice Note",
+	# skills
+	"Jarvis Custom Skill Allowed Role",
+	"Jarvis Custom Skill Share",
+	"Jarvis Custom Skill",
+	"Jarvis Skill Promotion Request",
+	"Jarvis Shared Skill Slug",
+	# macros + triggers + approvals
+	"Jarvis Macro Step",
+	"Jarvis Macro Run",
+	"Jarvis Macro",
+	"Jarvis Trigger Activity",
+	"Jarvis Trigger",
+	"Jarvis Approval Request",
+	# learning artifacts
+	"Jarvis Learned Pattern Role",
+	"Jarvis Learned Pattern",
+	"Jarvis Pattern Run",
+	"Jarvis Pattern Snapshot",
+	"Jarvis Pattern Detector State",
+	"Jarvis Personalise Question Rule",
+	"Jarvis Personalise Question",
+	"Jarvis App Learning Run",
+	# wiki + dashboards
+	"Jarvis Wiki Page",
+	"Jarvis Wiki Graph History",
+	"Jarvis Wiki Promotion Request",
+	"Jarvis Dashboard Source",
+	"Jarvis Dashboard",
+)
+
+
+@frappe.whitelist()
+def request_workspace_reset(reason: str = "", wipe_data: bool = False, revoke_llm: bool = False) -> dict:
+	"""Self-serve workspace reset: the control plane rebuilds the container NOW
+	(subscription kept), then this site disconnects its agent transport and polls
+	``workspace_reset_state`` back to Ready.
+
+	``wipe_data`` also deletes workspace content (chats, skills, macros,
+	triggers, learning artifacts, wiki, dashboards). ``revoke_llm`` also clears
+	every LLM connection (pool models, subscription accounts, keys, synced
+	markers) so the customer sets up their AI model fresh after the reset.
+	Both run only AFTER the control plane accepted the reset.
+
+	Gated on System Manager, like the rest of onboarding."""
+	require_jarvis_admin()
+	settings = frappe.get_single("Jarvis Settings")
+	# Tear down the container-side OAuth auth-profile while the old container is
+	# still reachable (same ordering as dev.reset_onboarding). Best-effort — a
+	# dead container is often the very reason for the reset.
+	if settings.get("agent_url"):
+		try:
+			admin_client.post_subscription_disconnect()
+		except Exception:
+			pass
+	out = _surface(admin_client.reset_workspace, reason)
+	if cint(wipe_data):
+		_wipe_workspace_content()
+	if cint(revoke_llm):
+		_revoke_llm_connections(settings)
+	_disconnect_agent_transport(settings, reconnect_llm=bool(cint(revoke_llm)))
+	return out
+
+
+def _wipe_workspace_content() -> None:
+	for dt in _WIPE_DOCTYPES:
+		frappe.db.delete(dt)
+
+
+def _revoke_llm_connections(settings) -> None:
+	"""The LLM subset of dev.reset_onboarding: clear direct creds, OAuth state,
+	the models[] pool (subscription blobs live encrypted ON those rows) and the
+	synced markers — is_ready_for_chat then routes to the LLM setup step. db_set
+	only, so on_update never fires mid-reset. Admin creds untouched."""
+	from jarvis._password_utils import clear_settings_password
+
+	for f in ("llm_model", "llm_base_url", "llm_auth_mode", "llm_oauth_account_email", "preset"):
+		settings.db_set(f, "")
+	clear_settings_password(settings, "llm_api_key")
+	for f in ("llm_oauth_connected_at", "llm_pool_synced_at", "llm_direct_synced_at"):
+		settings.db_set(f, None)
+	settings.db_set("proxy_active", 0)
+	settings.db_set("proxy_recommended", 0)
+	settings.db_set("llm_provider", "Anthropic")  # Select field — can't be blank
+	frappe.db.delete(
+		"Jarvis LLM Pool Model",
+		{"parent": "Jarvis Settings", "parenttype": "Jarvis Settings", "parentfield": "models"},
+	)
+
+
+def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:
+	"""Clear the agent transport so chat gates on admin's chat_readiness while
+	the container is rebuilt. Keeps admin creds and (unless the customer revoked
+	them) the LLM config + ``*_synced_at`` markers — the control plane carries
+	those onto the new container; clearing them would eject the customer into
+	the setup wizard."""
+	from jarvis._password_utils import clear_settings_password
+	from jarvis.account import _bust_chat_gate
+	from jarvis.chat.device import clear_credentials
+
+	settings.db_set("agent_url", "")
+	clear_settings_password(settings, "agent_token")
+	clear_credentials()
+	settings.db_set(
+		"last_sync_status", _RESETTING_RECONNECT_LLM_STATUS if reconnect_llm else _RESETTING_STATUS
+	)
+	_bust_chat_gate()
+	frappe.db.commit()
+
+
+@frappe.whitelist()
+def workspace_reset_state() -> dict:
+	"""Poll endpoint for the reset card: admin request state + serving readiness.
+	When admin reports the new container Ready, persists the fresh connection and
+	clears the resetting marker — chat works again with no manual steps."""
+	require_jarvis_admin()
+	return _workspace_reset_poll()
+
+
+def _workspace_reset_poll() -> dict:
+	settings = frappe.get_single("Jarvis Settings")
+	req: dict = {}
+	try:
+		req = admin_client.reset_workspace_state() or {}
+	except Exception:
+		pass  # audit-row state is advisory; readiness below is the real signal
+	def _resetting() -> bool:
+		return (settings.get("last_sync_status") or "").startswith(_RESETTING_STATUS)
+
+	def _reconnect_llm() -> bool:
+		return (settings.get("last_sync_status") or "").startswith(_RESETTING_RECONNECT_LLM_STATUS)
+
+	try:
+		data = admin_client.get_connection(timeout_s=8) or {}
+	except Exception:
+		return {
+			"ready": False,
+			"resetting": _resetting(),
+			"status": req.get("status") or "",
+			"message": req.get("message") or "",
+		}
+	# With the LLM revoked, readiness can never reach Ready (nothing configured);
+	# "container reachable" completes the reset and the wizard gate owns the rest.
+	ready = bool(data.get("agent_url")) and (data.get("chat_readiness") == "Ready" or _reconnect_llm())
+	if ready and _resetting():
+		from jarvis.account import _bust_chat_gate
+
+		write_connection(data)
+		settings.db_set("last_sync_status", "ok (workspace reset)")
+		_bust_chat_gate()
+		frappe.db.commit()
+	elif _resetting() and data.get("agent_url") and not (settings.get("agent_url") or ""):
+		# New container reachable but not Ready yet: reconnect the transport and,
+		# for a pool tenant, re-push the stored spec + subscription blobs — OAuth
+		# creds never ride a rebuild, so without this a subscription pool stays
+		# "blocked" forever. Hands convergence to the standard pending-applying
+		# machinery (marker replaced; runs once — agent_url is set after this).
+		write_connection(data)
+		if settings.get("proxy_active"):
+			settings._enqueue_pool_sync()
+		frappe.db.commit()
+	return {
+		"ready": ready,
+		"resetting": _resetting(),
+		"status": req.get("status") or "",
+		"message": req.get("message") or "",
+		"tenant_status": data.get("tenant_status") or "",
+	}
+
+
+def reconcile_pending_workspace_reset() -> None:
+	"""*/5 backstop: converge a reset whose tab was closed mid-poll."""
+	s = frappe.get_single("Jarvis Settings")
+	if not (s.get("last_sync_status") or "").startswith(_RESETTING_STATUS):
+		return
+	_workspace_reset_poll()
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -13,6 +13,15 @@ _ENTITLED = {"ready": True, "reason": None}
 _SUSPENDED = {"ready": False, "reason": "subscription_suspended", "detail": "Your subscription has expired."}
 
 
+def _patch_llm_configured(test):
+	"""Neutralize the llm-configured gate so tests don't depend on whether the
+	test site happens to have an LLM set up. Its own coverage lives in
+	TestLlmConfiguredGate."""
+	p = patch("jarvis.chat.policy._llm_not_configured", return_value=False)
+	p.start()
+	test.addCleanup(p.stop)
+
+
 class TestValidateCanSend(FrappeTestCase):
 	def setUp(self):
 		self._gate = patch.object(account, "_admin_chat_gate", return_value=_ENTITLED)
@@ -23,6 +32,7 @@ class TestValidateCanSend(FrappeTestCase):
 		self._rn = patch("jarvis.release_notice.boot_payload", return_value={"active": False})
 		self._rn.start()
 		self.addCleanup(self._rn.stop)
+		_patch_llm_configured(self)
 
 	def test_release_notice_blocks_send(self):
 		"""Server-side half of the gate: the full-page block only latches at boot,
@@ -70,6 +80,9 @@ class TestSubscriptionGate(FrappeTestCase):
 	deadline retrying a socket into a stopped container - surfacing to the
 	customer as "the assistant may be starting up"."""
 
+	def setUp(self):
+		_patch_llm_configured(self)
+
 	def test_suspended_subscription_rejects_the_send(self):
 		with patch.object(account, "_admin_chat_gate", return_value=_SUSPENDED):
 			ok, reason = validate_can_send("someone@example.invalid")
@@ -101,3 +114,115 @@ class TestSubscriptionGate(FrappeTestCase):
 			ok, _ = validate_can_send("Guest")
 		self.assertFalse(ok)
 		gate.assert_not_called()
+
+
+class TestWorkspaceResetGate(FrappeTestCase):
+	"""The mid-reset send gate: transport cleared + resetting marker set."""
+
+	def setUp(self):
+		self._gate = patch.object(account, "_admin_chat_gate", return_value=_ENTITLED)
+		self._gate.start()
+		self.addCleanup(self._gate.stop)
+		self._rn = patch("jarvis.release_notice.boot_payload", return_value={"active": False})
+		self._rn.start()
+		self.addCleanup(self._rn.stop)
+		_patch_llm_configured(self)
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		self._prev = {"agent_url": s.agent_url or "", "last_sync_status": s.last_sync_status or ""}
+		self.addCleanup(self._restore)
+
+	def _restore(self):
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		for f, v in self._prev.items():
+			s.db_set(f, v, update_modified=False)
+		frappe.db.commit()
+
+	def _set(self, agent_url, status):
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("agent_url", agent_url, update_modified=False)
+		s.db_set("last_sync_status", status, update_modified=False)
+		frappe.db.commit()
+
+	def test_resetting_blocks_send(self):
+		from jarvis.onboarding import _RESETTING_STATUS
+
+		self._set("", _RESETTING_STATUS)
+		ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "workspace_resetting")
+
+	def test_reconnected_workspace_sends_again(self):
+		from jarvis.onboarding import _RESETTING_STATUS
+
+		# agent_url back (connection re-synced) -> gate opens even before the
+		# marker flips, matching the fail-open posture.
+		self._set("ws://localhost:19000", _RESETTING_STATUS)
+		ok, reason = validate_can_send("Administrator")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+
+class TestLlmConfiguredGate(FrappeTestCase):
+	"""The no-LLM send gate (fresh workspace / post-revoke): reject cleanly
+	instead of queuing a turn against the container's stub key."""
+
+	_FIELDS = ("llm_provider", "llm_model", "llm_auth_mode", "proxy_active")
+
+	def setUp(self):
+		self._gate = patch.object(account, "_admin_chat_gate", return_value=_ENTITLED)
+		self._gate.start()
+		self.addCleanup(self._gate.stop)
+		self._rn = patch("jarvis.release_notice.boot_payload", return_value={"active": False})
+		self._rn.start()
+		self.addCleanup(self._rn.stop)
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		self._prev = {f: s.get(f) or ("" if f != "proxy_active" else 0) for f in self._FIELDS}
+		self.addCleanup(self._restore)
+
+	def _restore(self):
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		for f, v in self._prev.items():
+			s.db_set(f, v, update_modified=False)
+		frappe.db.commit()
+
+	def _set(self, **kv):
+		import frappe
+
+		s = frappe.get_single("Jarvis Settings")
+		for f, v in kv.items():
+			s.db_set(f, v, update_modified=False)
+		frappe.db.commit()
+
+	def test_no_llm_configured_rejects_the_send(self):
+		import frappe.model.document
+
+		self._set(llm_provider="", llm_model="", llm_auth_mode="", proxy_active=0)
+		with patch.object(frappe.model.document.Document, "get_password", return_value=""):
+			ok, reason = validate_can_send("Administrator")
+		self.assertFalse(ok)
+		self.assertEqual(reason, "llm_not_configured")
+
+	def test_configured_direct_llm_sends(self):
+		import frappe.model.document
+
+		self._set(llm_provider="Anthropic", llm_model="claude-sonnet-5", llm_auth_mode="api_key", proxy_active=0)
+		with patch.object(frappe.model.document.Document, "get_password", return_value="k"):
+			ok, reason = validate_can_send("Administrator")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)
+
+	def test_pool_tenant_is_not_gated_locally(self):
+		self._set(llm_provider="", llm_model="", llm_auth_mode="", proxy_active=1)
+		ok, reason = validate_can_send("Administrator")
+		self.assertTrue(ok)
+		self.assertIsNone(reason)

--- a/jarvis/tests/test_chat_policy.py
+++ b/jarvis/tests/test_chat_policy.py
@@ -183,6 +183,10 @@ class TestLlmConfiguredGate(FrappeTestCase):
 		self.addCleanup(self._rn.stop)
 		import frappe
 
+		# The gate is a no-op under test unless a test opts in (the CI site has
+		# no LLM configured); these tests ARE its coverage, so opt in.
+		frappe.flags.test_llm_configured_gate = True
+		self.addCleanup(lambda: setattr(frappe.flags, "test_llm_configured_gate", False))
 		s = frappe.get_single("Jarvis Settings")
 		self._prev = {f: s.get(f) or ("" if f != "proxy_active" else 0) for f in self._FIELDS}
 		self.addCleanup(self._restore)
@@ -215,7 +219,9 @@ class TestLlmConfiguredGate(FrappeTestCase):
 	def test_configured_direct_llm_sends(self):
 		import frappe.model.document
 
-		self._set(llm_provider="Anthropic", llm_model="claude-sonnet-5", llm_auth_mode="api_key", proxy_active=0)
+		self._set(
+			llm_provider="Anthropic", llm_model="claude-sonnet-5", llm_auth_mode="api_key", proxy_active=0
+		)
 		with patch.object(frappe.model.document.Document, "get_password", return_value="k"):
 			ok, reason = validate_can_send("Administrator")
 		self.assertTrue(ok)

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -117,3 +117,41 @@ class TestResetOnboardingGuards(FrappeTestCase):
 		frappe.set_user("Guest")
 		with self.assertRaises(frappe.PermissionError):
 			reset_onboarding()
+
+
+class TestResetOnboardingWipe(FrappeTestCase):
+	"""wipe_data=True (the CLI default) also factory-resets workspace content."""
+
+	def setUp(self):
+		self._snap = _snapshot()
+		_seed_onboarded_state()
+		frappe.db.delete("Jarvis Macro", {"macro_name": "dev-reset-wipe"})
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "dev-reset-wipe"})
+		conv.flags.ignore_mandatory = True
+		conv.flags.ignore_links = True
+		conv.insert(ignore_permissions=True)
+		macro = frappe.get_doc(
+			{"doctype": "Jarvis Macro", "macro_name": "dev-reset-wipe", "steps": [{"prompt": "hi"}]}
+		)
+		macro.flags.ignore_mandatory = True
+		macro.flags.ignore_links = True
+		macro.insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.db.delete("Jarvis Conversation", {"title": "dev-reset-wipe"})
+		frappe.db.delete("Jarvis Macro", {"macro_name": "dev-reset-wipe"})
+		frappe.db.commit()
+		_restore(self._snap)
+
+	def test_wipe_data_deletes_content(self):
+		out = reset_onboarding(wipe_data=True)
+		self.assertTrue(out["data"]["wiped_doctypes"])
+		self.assertEqual(frappe.db.count("Jarvis Conversation"), 0)
+		self.assertEqual(frappe.db.count("Jarvis Macro"), 0)
+
+	def test_default_keeps_content(self):
+		out = reset_onboarding()
+		self.assertEqual(out["data"]["wiped_doctypes"], [])
+		self.assertEqual(frappe.db.count("Jarvis Conversation", {"title": "dev-reset-wipe"}), 1)
+		self.assertEqual(frappe.db.count("Jarvis Macro", {"macro_name": "dev-reset-wipe"}), 1)

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -569,13 +569,27 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 class TestWorkspaceReset(FrappeTestCase):
 	"""Self-serve reset: transport cleared, admin creds + synced markers kept."""
 
+	# Everything the reset/revoke paths mutate. llm_auth_mode is MANDATORY on the
+	# doctype: leaving it blank (db_set bypasses validation) breaks the next full
+	# Jarvis Settings save in an unrelated suite (test_part4_security's fence).
 	_FIELDS = _SNAPSHOTTED_FIELDS + (
 		"last_sync_status",
 		"llm_pool_synced_at",
+		"llm_direct_synced_at",
 		"chat_device_id",
 		"chat_device_public_key",
 		"chat_device_private_key",
 		"chat_device_token",
+		"llm_provider",
+		"llm_model",
+		"llm_base_url",
+		"llm_auth_mode",
+		"llm_api_key",
+		"llm_oauth_account_email",
+		"llm_oauth_connected_at",
+		"preset",
+		"proxy_active",
+		"proxy_recommended",
 	)
 
 	def setUp(self):
@@ -590,6 +604,10 @@ class TestWorkspaceReset(FrappeTestCase):
 				else s.get(f)
 			)
 			self._snap[f] = v or ""
+		# The revoke path deletes the models[] child rows — snapshot to re-insert.
+		self._pool_rows = frappe.get_all(
+			"Jarvis LLM Pool Model", filters={"parent": "Jarvis Settings"}, fields=["*"]
+		)
 		_set_token("tok")
 		s.db_set("agent_url", "ws://localhost:19000")
 		s.db_set("chat_device_id", "dev-1")
@@ -598,6 +616,13 @@ class TestWorkspaceReset(FrappeTestCase):
 
 	def tearDown(self):
 		_restore_settings(self._snap)
+		frappe.db.delete("Jarvis LLM Pool Model", {"parent": "Jarvis Settings"})
+		for row in self._pool_rows:
+			doc = frappe.get_doc(dict(row, doctype="Jarvis LLM Pool Model", name=None))
+			doc.flags.ignore_mandatory = True
+			doc.flags.ignore_links = True
+			doc.insert(ignore_permissions=True)
+		frappe.db.commit()
 
 	def test_reset_disconnects_transport_and_keeps_creds(self):
 		with (

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -564,3 +564,234 @@ class TestGetLlmSyncStatus(FrappeTestCase):
 			s.db_set("last_model_statuses", bad, update_modified=False)
 			frappe.db.commit()
 			self.assertEqual(onboarding.get_llm_sync_status()["model_statuses"], [])
+
+
+class TestWorkspaceReset(FrappeTestCase):
+	"""Self-serve reset: transport cleared, admin creds + synced markers kept."""
+
+	_FIELDS = _SNAPSHOTTED_FIELDS + (
+		"last_sync_status",
+		"llm_pool_synced_at",
+		"chat_device_id",
+		"chat_device_public_key",
+		"chat_device_private_key",
+		"chat_device_token",
+	)
+
+	def setUp(self):
+		s = frappe.get_single("Jarvis Settings")
+		self._snap = _snapshot_settings()
+		for f in self._FIELDS:
+			if f in self._snap:
+				continue
+			v = (
+				s.get_password(f, raise_exception=False)
+				if f.endswith(("_key", "_secret", "_token", "_password"))
+				else s.get(f)
+			)
+			self._snap[f] = v or ""
+		_set_token("tok")
+		s.db_set("agent_url", "ws://localhost:19000")
+		s.db_set("chat_device_id", "dev-1")
+		s.db_set("llm_pool_synced_at", "2026-01-01 00:00:00")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+
+	def test_reset_disconnects_transport_and_keeps_creds(self):
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect") as disc,
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				return_value={"status": "Applied", "tenant": "t-new"},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.request_workspace_reset(reason="stuck")
+		disc.assert_called_once()
+		self.assertEqual(out["status"], "Applied")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.agent_url)
+		self.assertFalse(s.chat_device_id)
+		self.assertEqual(s.last_sync_status, onboarding._RESETTING_STATUS)
+		# The control plane carries these; clearing them would eject to the wizard.
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+		self.assertTrue(s.llm_pool_synced_at)
+
+	def test_reset_admin_failure_leaves_transport(self):
+		from jarvis.admin_client import AdminUnreachableError
+
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				side_effect=AdminUnreachableError("down"),
+			),
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.request_workspace_reset()
+		self.assertEqual(frappe.get_single("Jarvis Settings").agent_url, "ws://localhost:19000")
+
+	def test_poll_converges_when_ready(self):
+		frappe.get_single("Jarvis Settings").db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		frappe.db.commit()
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Ready",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+					"tenant_status": "running",
+				},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertTrue(out["ready"])
+		self.assertFalse(out["resetting"])
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.agent_url, "ws://localhost:19100")
+		self.assertEqual(s.last_sync_status, "ok (workspace reset)")
+
+	def test_poll_reports_resetting_while_not_ready(self):
+		frappe.get_single("Jarvis Settings").db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		frappe.db.commit()
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Pending Capacity", "message": "provisioning shortly"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={"chat_readiness": "Configuring"},
+			),
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertFalse(out["ready"])
+		self.assertTrue(out["resetting"])
+		self.assertEqual(out["status"], "Pending Capacity")
+
+	def test_poll_reconnects_and_repushes_pool_when_container_up(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("last_sync_status", onboarding._RESETTING_STATUS)
+		s.db_set("agent_url", "")
+		s.db_set("proxy_active", 1)
+		frappe.db.commit()
+		try:
+			with (
+				patch(
+					"jarvis.onboarding.admin_client.reset_workspace_state",
+					return_value={"status": "Applied"},
+				),
+				patch(
+					"jarvis.onboarding.admin_client.get_connection",
+					return_value={
+						"chat_readiness": "Configuring",
+						"agent_url": "ws://localhost:19100",
+						"agent_token": "t2",
+					},
+				),
+				patch(
+					"jarvis.jarvis.doctype.jarvis_settings.jarvis_settings.JarvisSettings._enqueue_pool_sync"
+				) as push,
+			):
+				out = onboarding.workspace_reset_state()
+			push.assert_called_once()
+			self.assertFalse(out["ready"])
+			self.assertEqual(frappe.get_single("Jarvis Settings").agent_url, "ws://localhost:19100")
+		finally:
+			frappe.get_single("Jarvis Settings").db_set("proxy_active", 0)
+			frappe.db.commit()
+
+	def test_reset_wipe_data_deletes_content(self):
+		frappe.db.delete("Jarvis Macro", {"macro_name": "wipe-me"})
+		frappe.db.commit()
+		conv = frappe.get_doc({"doctype": "Jarvis Conversation", "title": "wipe-me"})
+		conv.flags.ignore_mandatory = True
+		conv.flags.ignore_links = True
+		conv.insert(ignore_permissions=True)
+		macro = frappe.get_doc(
+			{"doctype": "Jarvis Macro", "macro_name": "wipe-me", "steps": [{"prompt": "hello"}]}
+		)
+		macro.flags.ignore_mandatory = True
+		macro.flags.ignore_links = True
+		macro.insert(ignore_permissions=True)
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				return_value={"status": "Applied", "tenant": "t-new"},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.request_workspace_reset(wipe_data=True)
+		self.assertEqual(frappe.db.count("Jarvis Conversation"), 0)
+		self.assertEqual(frappe.db.count("Jarvis Macro"), 0)
+
+	def test_reset_revoke_llm_clears_connections(self):
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("llm_model", "claude-sonnet-5")
+		s.db_set("proxy_active", 1)
+		s.db_set("llm_pool_synced_at", "2026-01-01 00:00:00")
+		pm = frappe.get_doc(
+			{
+				"doctype": "Jarvis LLM Pool Model",
+				"parent": "Jarvis Settings",
+				"parenttype": "Jarvis Settings",
+				"parentfield": "models",
+				"model": "gpt-5.5",
+			}
+		)
+		pm.flags.ignore_mandatory = True
+		pm.flags.ignore_links = True
+		pm.insert(ignore_permissions=True)
+		frappe.db.commit()
+		with (
+			patch("jarvis.onboarding.admin_client.post_subscription_disconnect"),
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace",
+				return_value={"status": "Applied", "tenant": "t-new"},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			onboarding.request_workspace_reset(revoke_llm=True)
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.llm_model)
+		self.assertFalse(s.proxy_active)
+		self.assertFalse(s.llm_pool_synced_at)
+		self.assertEqual(s.llm_provider, "Anthropic")
+		self.assertEqual(frappe.db.count("Jarvis LLM Pool Model", {"parent": "Jarvis Settings"}), 0)
+		self.assertEqual(s.last_sync_status, onboarding._RESETTING_RECONNECT_LLM_STATUS)
+		# Admin creds must survive — only the LLM connections are revoked.
+		self.assertTrue(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_poll_completes_on_container_up_when_llm_revoked(self):
+		frappe.get_single("Jarvis Settings").db_set(
+			"last_sync_status", onboarding._RESETTING_RECONNECT_LLM_STATUS
+		)
+		frappe.db.commit()
+		with (
+			patch(
+				"jarvis.onboarding.admin_client.reset_workspace_state",
+				return_value={"status": "Applied"},
+			),
+			patch(
+				"jarvis.onboarding.admin_client.get_connection",
+				return_value={
+					"chat_readiness": "Configuring",
+					"agent_url": "ws://localhost:19100",
+					"agent_token": "t2",
+				},
+			),
+			patch("jarvis.account._bust_chat_gate"),
+		):
+			out = onboarding.workspace_reset_state()
+		self.assertTrue(out["ready"])
+		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, "ok (workspace reset)")


### PR DESCRIPTION
One click in **Settings → General → Danger zone** resets a broken workspace: the control plane destroys the container, attaches a fresh one, and this bench disconnects its agent transport, polls back to Ready and reconnects — **subscription and chat history kept**. Counterpart to Aerele-RnD/jarvis-admin-v2#127 (control plane).

Two opt-in checkboxes (both run only after the control plane accepted the reset):
- **Also delete workspace content** — chats, skills, macros, triggers, learned patterns, wiki pages, dashboards (raw table deletes; File rows and agent installations kept).
- **Also disconnect AI model connections** — clears direct creds, OAuth state, pool models (incl. encrypted subscription blobs) and the synced markers; the customer reconnects via the wizard afterwards. Admin creds are never touched.

## How it works

- `admin_client.reset_workspace / reset_workspace_state` proxies (180s container-recreate class / 8s poll).
- `onboarding.request_workspace_reset`: best-effort `post_subscription_disconnect` while the old container is alive → admin reset (failure = nothing local changed) → **transport-only disconnect** (`agent_url`, `agent_token` via `clear_settings_password`, chat-device creds) + `pending: resetting workspace` marker + chat-gate bust. LLM config and `llm_*_synced_at` markers are deliberately kept — clearing them ejects the customer into the setup wizard.
- `onboarding.workspace_reset_state` poll: once the new container is reachable it reconnects the transport and, for a pool tenant, re-pushes the stored spec + subscription blobs via `_enqueue_pool_sync` — **OAuth never rides a rebuild**, without this a subscription-only pool stays "blocked" forever. With the revoke option the poll completes on "container reachable" (readiness can never reach Ready with no LLM configured). `*/5` cron `reconcile_pending_workspace_reset` converges a closed tab.
- `chat/policy`: new `workspace_resetting` and `llm_not_configured` send gates — a mid-reset or LLM-less send gets a clean rejection toast instead of queuing a turn against the container's stub key. Both fail open.
- `readiness.js`: `llm_credentials` now paints an actionable "No AI model is connected…" banner (previously only `container_provisioning` rendered anything — a revoked/never-configured tenant got no hint at all).
- `GeneralPane`: "Reset workspace" row in the existing danger zone (red solid lives in the `useConfirm` dialog per the house rule); 3s poll (15 min budget, Pending-Capacity copy passes through) then a full reload of /jarvis to drop the memoized readiness verdict; resumes off the server-side `resetting` flag on mount.

Rebased onto current develop: the reset card was originally built on the (now deleted) ConnectionPane and was relocated into GeneralPane's danger zone; the ConfirmDialog stacking fix this feature also needed turned out to be already fixed on develop (#435) and is not duplicated here.

## Testing

- `jarvis.tests.test_onboarding_sync` 37/37 (TestWorkspaceReset: disconnect contract, admin-failure leaves transport, poll converge, pool re-push, wipe, revoke, revoke-marker completion).
- `jarvis.tests.test_chat_policy` 16/16 (TestWorkspaceResetGate + TestLlmConfiguredGate).
- Frontend builds clean against current develop.
- Live E2E (pre-rebase, on the local admin plane): reset → destroy → provision → carry → converge → auto-reload → chat replied on the rebuilt container with history intact; warm-claim and cold-provision paths, plus wipe/revoke options, exercised end-to-end.

## Second commit: `bench reset-onboarding` full-flush CLI

The dev reset moves off the Jarvis Settings desk button (whitelist dropped) onto a bench command, and becomes a true factory reset:

```
bench --site <site> reset-onboarding [--force] [--keep-data]
```

- **Default = complete client-side flush**: connection + LLM credentials AND all workspace content (the same `onboarding._WIPE_DOCTYPES` set the self-serve reset offers), so a re-onboard starts truly clean.
- `--keep-data` preserves content (the old behavior); programmatic callers of `dev.reset_onboarding` keep the old default (`wipe_data=False`).
- Admin-side records untouched — `purge_customer` remains the admin half of the two-step dev reset.
- `test_dev` 5/5; both CLI modes smoke-tested on a test site (`cleared 21 field(s), wiped 30 content doctype(s)`).
