### PR TITLE
Point the default fleet admin endpoint at fleet.klerk.in

### DIFF
--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -32,7 +32,7 @@ boot_session = "jarvis.boot.set_jarvis_boot"
 # change this string + ship a new release.
 # (``DEFAULT_ADMIN_URL`` is re-exported by ``jarvis.admin_client`` so existing
 # imports keep working - resolved lazily via module __getattr__ below.)
-_DEFAULT_ADMIN_URL_FALLBACK = "https://admin.klerk.in"
+_DEFAULT_ADMIN_URL_FALLBACK = "https://fleet.klerk.in"
 
 
 def get_default_admin_url() -> str:


### PR DESCRIPTION
One-line change: the hardcoded fallback admin URL (`_DEFAULT_ADMIN_URL_FALLBACK` in `jarvis/hooks.py`) moves from `admin.klerk.in` to `https://fleet.klerk.in`.

This fallback is only consulted when `jarvis_admin_url` is set in neither site config nor Jarvis Settings (the fresh-install case) — deployments with an explicit config are unaffected. It's the single source of truth: `admin_client._admin_url` resolves through `hooks.get_default_admin_url()`, and the tests (`test_admin_client`) assert against the constant symbolically, so nothing else changes.