### PR TITLE
feat(settings): Disconnect Jarvis from AI

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -209,6 +209,11 @@ export const saveLlmPool = (models, preset = null, routingMode = "failover") =>
 		preset: preset || "",
 		routing_mode: routingMode,
 	});
+// Tear the whole AI connection down: deletes every stored credential on the
+// bench (models[] rows + the legacy flat fields) and asks admin to delete them
+// from the workspace container. NOT "save an empty pool" - saveLlmPool refuses
+// an empty list on purpose. Idempotent. Returns { disconnected: true }.
+export const disconnectLlm = () => call("jarvis.onboarding.disconnect_llm");
 // Pre-save "Test" probe for ONE api-key model row (never persists, never
 // touches the fleet/container - see jarvis/llm_key_probe.py). args:
 // {provider, model, api_key, base_url}. Returns

--- a/frontend/src/components/LlmPoolEditor.spec.js
+++ b/frontend/src/components/LlmPoolEditor.spec.js
@@ -26,6 +26,7 @@ const api = vi.hoisted(() => ({
 	getPresetCatalog: vi.fn(),
 	getModelCatalogUi: vi.fn(),
 	saveLlmPool: vi.fn(),
+	disconnectLlm: vi.fn(),
 	testLlmApiKey: vi.fn(),
 	disconnectSubscription: vi.fn(),
 	getDirectSubscriptionStatus: vi.fn(),
@@ -103,6 +104,15 @@ beforeEach(() => {
 		serverPool.models = clone(models);
 		serverPool.preset = preset || "";
 		return {};
+	});
+	// disconnect_llm empties the pool server-side; the reseed that follows has to
+	// see that, or the editor would keep showing the models it just deleted.
+	api.disconnectLlm.mockImplementation(async () => {
+		serverPool.models = [];
+		serverPool.preset = "";
+		serverPool.proxy_active = false;
+		syncStatus = { ...syncStatus, last_sync_status: "disconnected", pending: false };
+		return { disconnected: true };
 	});
 });
 
@@ -278,8 +288,10 @@ describe("an in-progress add survives an unrelated apply (defect 2)", () => {
 		await w.vm.remove(0);
 		await idle();
 
+		// Still the LAST model, so this is a disconnect - a half-typed row nobody
+		// pressed Connect on is not the spare that would have made it a plain Remove.
 		expect(api.saveLlmPool).not.toHaveBeenCalled();
-		expect(w.vm.applyResult.text).toMatch(/only model/i);
+		expect(api.disconnectLlm).toHaveBeenCalledTimes(1);
 	});
 
 	it("still sends a row whose write already landed", async () => {
@@ -316,6 +328,81 @@ describe("an in-progress add survives an unrelated apply (defect 2)", () => {
 		await idle();
 
 		expect(savedModels().map((m) => m.model)).toContain("gpt-4o-mini");
+	});
+});
+
+describe("removing the last model disconnects the workspace", () => {
+	it("calls disconnect instead of saving a pool the server would refuse", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor();
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(api.disconnectLlm).toHaveBeenCalledTimes(1);
+		// save_llm_pool rejects an empty list, so reaching it at all would be the bug.
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
+		expect(w.vm.applyResult.kind).toBe("ok");
+		expect(w.vm.applyResult.text).toMatch(/^Disconnected/);
+	});
+
+	it("keeps Remove as an ordinary edit while another model is left", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0), keyModel("anthropic", "claude-sonnet-4", 1)]);
+		const w = await mountEditor();
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(api.disconnectLlm).not.toHaveBeenCalled();
+		expect(savedModels().map((m) => m.model)).toEqual(["claude-sonnet-4"]);
+	});
+
+	it("labels the action for what it will do before it is pressed", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0), keyModel("anthropic", "claude-sonnet-4", 1)]);
+		const w = await mountEditor();
+		expect(w.vm.isLastConnectedRow(w.vm.rows[0])).toBe(false);
+
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const only = await mountEditor();
+		expect(only.vm.isLastConnectedRow(only.vm.rows[0])).toBe(true);
+	});
+
+	it("does nothing without a confirmation", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		answer.confirm = false;
+		const w = await mountEditor();
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(api.disconnectLlm).not.toHaveBeenCalled();
+		expect(w.vm.rows).toHaveLength(1);
+	});
+
+	it("reports a failed disconnect instead of claiming the keys are gone", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		api.disconnectLlm.mockRejectedValue(new Error("admin unreachable"));
+		const w = await mountEditor();
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(w.vm.applyResult.kind).toBe("failed");
+		expect(w.vm.busy.active).toBe(false);
+		// The pool is untouched on screen because it is untouched on the server.
+		expect(w.vm.rows[0].model).toBe("gpt-4o");
+	});
+
+	it("is never offered in onboarding, which has nothing to disconnect from", async () => {
+		setPool([keyModel("openai", "gpt-4o", 0)]);
+		const w = await mountEditor({ modes: ["quick"], footerless: true });
+		expect(w.vm.isLastConnectedRow(w.vm.rows[0])).toBe(false);
+
+		await w.vm.remove(0);
+		await idle();
+
+		expect(api.disconnectLlm).not.toHaveBeenCalled();
+		expect(api.saveLlmPool).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -204,13 +204,22 @@
 					>
 						Replace key
 					</button>
+					<!-- One button, two meanings, and the label says which BEFORE it is
+			         pressed: with other models left this drops one entry from the
+			         failover list; on the last one there is no list left to edit and it
+			         tears the whole connection down instead. -->
 					<button
 						v-if="canEdit"
 						:disabled="!editable"
 						@click="remove(i)"
 						class="jv-btn jv-btn--sm jv-btn--ghost jv-pool-disc"
+						:title="
+							isLastConnectedRow(row)
+								? 'Delete your keys and connected accounts everywhere'
+								: 'Remove this model from the failover list'
+						"
 					>
-						Remove
+						{{ isLastConnectedRow(row) ? "Disconnect" : "Remove" }}
 					</button>
 				</span>
 			</div>
@@ -2623,24 +2632,32 @@ async function applyOrder() {
 	// already put the old order back, and the baseline must stay valid for the retry.
 	if (persisted) orderBaseline.value = null;
 }
+// The models that actually count as a connection. An open "+ Add a model" panel has
+// already put a placeholder in the list and it must not read as a second model - not
+// even once the customer has typed a provider and key into it, since nothing about it
+// is connected until they press Connect.
+function filledRows() {
+	const pending = pendingAddRow();
+	return rows.value.filter((x) => !isRowEmpty(x) && x !== pending);
+}
+// True when removing this row would empty the pool, which is a disconnect rather than
+// an edit. Drives BOTH the row action's label and where remove() routes, so the button
+// says what it is about to do before it is pressed. Never in onboarding (footerless):
+// there is no connection to tear down there yet, and its wizard footer owns the save.
+function isLastConnectedRow(row) {
+	if (props.footerless || !row || isRowEmpty(row)) return false;
+	const filled = filledRows();
+	return filled.length <= 1 && filled[0] === row;
+}
 async function remove(i) {
 	const r = rows.value[i];
 	if (!r || busy.value.active) return;
-	// save_llm_pool rejects an empty pool server-side, and taking the agent's last
-	// model away is a disconnect, not an edit (a separate flow, not this one). Say so
-	// instead of letting the customer walk into a validation error they cannot clear.
-	// Counted over FILLED rows, because an open "+ Add a model" panel has already put
-	// a placeholder in the list and it must not read as a second model - not even once
-	// the customer has typed a provider and key into it, since nothing about it is
-	// connected until they press Connect.
-	const pending = pendingAddRow();
-	const filled = rows.value.filter((x) => !isRowEmpty(x) && x !== pending);
-	if (!props.footerless && !isRowEmpty(r) && filled.length <= 1) {
-		setApplyResult({
-			kind: "failed",
-			text: "This is your only model, so removing it would leave nothing to answer with. Add another model first.",
-			detail: "",
-		});
+	// save_llm_pool rejects an empty pool server-side, and so does the fleet agent.
+	// Taking the agent's last model away is therefore a different operation, not a
+	// smaller edit: it goes through disconnect_llm, which deletes the credentials
+	// everywhere instead of writing a pool nobody will accept.
+	if (isLastConnectedRow(r)) {
+		await disconnect();
 		return;
 	}
 	const label = rowModelLabel(r);
@@ -2662,6 +2679,54 @@ async function remove(i) {
 	if (props.footerless) return;
 	await runApply({ revertRows: before, keepPendingAdd: true });
 }
+// Tear the whole connection down: every stored key and connected account, on this
+// bench AND in the workspace container.
+//
+// Worded for the outcome, not the mechanism. "Remove your last model" describes an
+// edit to a list; what actually happens is that the workspace stops having AI, and
+// that is what the customer has to agree to. Remove keeps its own narrower meaning
+// (drop one entry from the failover list) and is still what the button says whenever
+// another model would be left behind.
+//
+// Runs through the same busy/inert overlay as an apply: it re-renders the tenant
+// config and restarts the container exactly like one, so the editor must not accept
+// edits while it is in flight.
+async function disconnect() {
+	if (busy.value.active) return;
+	if (
+		!(await confirm({
+			title: `Disconnect ${agentName} from AI?`,
+			message: `Your API keys and connected accounts will be permanently deleted from ${agentName} and from your workspace container. Chat will stop working until you connect a model. Your chat history, skills and macros are kept.`,
+			confirmLabel: "Disconnect",
+			danger: true,
+		}))
+	)
+		return;
+	err.value = "";
+	setApplyResult(null);
+	setBusy("Disconnecting…");
+	try {
+		await api.disconnectLlm();
+	} catch (e) {
+		setApplyResult({ kind: "failed", text: "Could not disconnect.", detail: _err(e) });
+		return;
+	} finally {
+		setBusy("");
+	}
+	// No startPolling: there is no apply to converge on. disconnect_llm calls admin
+	// synchronously and only clears the bench once admin has confirmed, so by the time
+	// it returns the outcome is already final.
+	setApplyResult({
+		kind: "ok",
+		text: "Disconnected. Your keys and connected accounts have been deleted.",
+		detail: "",
+	});
+	await load();
+	// Same signal an apply emits, so the host pane re-reads its own state (the DIRECT
+	// subscription probe in particular, which a disconnect also clears).
+	emit("saved", sync.value);
+}
+
 // Disconnecting an account persists itself, like every other mutating action here.
 //
 // It used to only filter the local array: the chip vanished, nothing was written, and
@@ -2681,21 +2746,18 @@ async function removeAccount(m, idx) {
 	}
 	const last = prev.length === 1;
 	// An accountless subscription row cannot answer a turn, so prunedForSave drops it
-	// and the model leaves the failover list along with its last account. Refuse when
-	// that would empty the pool - same wall remove() puts up, for the same reason, and
-	// far clearer than validatePool's "Model <id> needs at least one connected account"
-	// on a model id this editor never showed the customer.
-	if (last) {
-		const pending = pendingAddRow();
-		const filled = rows.value.filter((x) => !isRowEmpty(x) && x !== pending);
-		if (filled.length <= 1) {
-			setApplyResult({
-				kind: "failed",
-				text: "This is the only account on your only model, so disconnecting it would leave nothing to answer with. Add another model first.",
-				detail: "",
-			});
-			return;
-		}
+	// and the model leaves the failover list along with its last account. That would
+	// empty the pool, which this path cannot express - save_llm_pool refuses an empty
+	// list. Point at the two things that CAN be done instead, one of which is now the
+	// row's own Disconnect. Still far clearer than validatePool's "Model <id> needs at
+	// least one connected account" on a model id this editor never showed the customer.
+	if (last && filledRows().length <= 1) {
+		setApplyResult({
+			kind: "failed",
+			text: "This is the only account on your only model. Use Disconnect on the model to delete it everywhere, or add another model first.",
+			detail: "",
+		});
+		return;
 	}
 	const who = accountLabel(prev[idx]);
 	if (

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -160,11 +160,15 @@ const hasConversation = computed(() => !!(ctx.value && ctx.value.conversationId)
 // the configured model, not "Auto". Everything else in this block (Provider,
 // Auth mode, Status) is workspace-level, so this row now matches them.
 // Non-admins have no connStatus and keep the conversation label as before.
-const modelLabel = computed(
-	() =>
-		(connStatus.value && connStatus.value.default_model) ||
-		(ctx.value && ctx.value.modelLabel) ||
-		"Auto"
+// A disconnected workspace has no model, and the "Auto" fallback below would
+// claim one - it is a placeholder for "the conversation did not name a model",
+// which is a different thing from "there is no model".
+const modelLabel = computed(() =>
+	disconnected.value
+		? "—"
+		: (connStatus.value && connStatus.value.default_model) ||
+		  (ctx.value && ctx.value.modelLabel) ||
+		  "Auto"
 );
 const ui = computed(() => (ctx.value && ctx.value.ui) || {});
 const convAutoApply = computed(() => !!(ctx.value && ctx.value.convAutoApply));
@@ -211,17 +215,25 @@ const expiresLabel = computed(() => {
 const connected = computed(() =>
 	isSM ? !!(connStatus.value && isProxy.value && connStatus.value.auth_present) : true
 );
+// No model configured at all: the workspace was disconnected (or never
+// connected). Checked BEFORE isProxy below for the same reason the server
+// computes it before its own DIRECT short-circuit: a disconnected tenant is
+// proxy_active:false, so without this it would read as a healthy "Direct".
+const disconnected = computed(() => !!(connStatus.value && connStatus.value.disconnected));
 const statusLabel = computed(() => {
 	if (!isSM) return "Connected";
 	if (!connStatus.value) return "—";
+	if (disconnected.value) return "Disconnected";
 	if (!isProxy.value) return "Direct";
 	return connected.value ? "Connected" : "Not connected";
 });
 // design.md §3.8 status map: connected is green, a plain direct tenant is
-// neutral, an actual failure is red.
+// neutral, an actual failure is red. Disconnected is orange (warning), not red:
+// nothing is broken, the customer chose this and can undo it in AI models.
 const statusTheme = computed(() => {
 	if (!isSM) return "green";
 	if (!connStatus.value) return "gray";
+	if (disconnected.value) return "orange";
 	if (!isProxy.value) return "gray";
 	return connected.value ? "green" : "red";
 });

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -84,22 +84,26 @@ export async function billingNoticeOf() {
 // wants "what do I tell the customer" never has to know the raw {ready, reason,
 // detail} shape checkReady() resolves to.
 //
-// Scoped to container_provisioning + llm_credentials: "subscription_suspended" has
-// its own dedicated copy (suspensionNotice/SUSPENDED_FALLBACK in steps.js) with a
-// Renew call to action, which is wrong for these reasons (nothing to renew via US
-// when the customer's OWN LLM account merely ran out of quota) - a caller must not
+// Scoped to container_provisioning ALONE: "subscription_suspended" has its own
+// dedicated copy (suspensionNotice/SUSPENDED_FALLBACK in steps.js) with a Renew
+// call to action, which is wrong for this reason (nothing to renew via US when
+// the customer's OWN LLM account merely ran out of quota) - a caller must not
 // paint this detail into that banner's "Chat is paused" framing.
 //
-// "llm_credentials" (no key/model configured, or creds revoked — e.g. after a
-// workspace reset with "disconnect AI model connections") has no backend detail,
-// so it gets a fixed actionable sentence; without it the chat renders NO hint at
-// all and a send just queues against the stub LLM.
+// "llm_credentials" is deliberately NOT handled here, and re-adding it is a
+// REGRESSION (pinned by readiness.spec.js). It used to return a fixed sentence
+// as a stopgap, from before needsLlmConnection() and the "No AI connected"
+// banner existed. Two accessors firing for one reason meant the caller rendered
+// two banners for the same state, and the generic CTA-less one won the v-else-if
+// race in ChatView - so the customer whose AI is disconnected got "Chat may not
+// work yet" with no way back to the AI models pane, which is the exact case the
+// dedicated banner was built for. One reason, one accessor: this one answers
+// "what did the backend say", needsLlmConnection() below answers "is there an
+// AI attached at all".
 export async function readinessDetailOf() {
 	const r = await checkReady();
 	if (!r || r.ready) return "";
 	if (r.reason === "container_provisioning") return r.detail || "";
-	if (r.reason === "llm_credentials")
-		return "No AI model is connected. Connect one in Settings → AI models to start chatting.";
 	return "";
 }
 

--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -7,8 +7,10 @@ import { isOnboardComplete } from "@/onboarding/steps.js";
 // poster when the workspace was NEVER set up). Sharing one in-flight promise
 // keeps it to a SINGLE backend round-trip.
 //
-// No cache-reset helper is needed: OnboardingView hard-reloads to /jarvis/ on
-// completion, which re-mounts the SPA and drops this module-level cache.
+// OnboardingView hard-reloads to /jarvis/ on completion, which re-mounts the SPA
+// and drops this cache; that covers the wizard. It does NOT cover changes made
+// in-app, which is why forgetReady() below exists: connecting or disconnecting a
+// model from the settings dialog changes this verdict without leaving the page.
 let readyPromise = null;
 
 // Fail-open: if the backend check THROWS, treat the workspace as ready so a
@@ -19,6 +21,13 @@ export function checkReady() {
 		readyPromise = isReadyForChat().catch(() => ({ ready: true }));
 	}
 	return readyPromise;
+}
+
+// Drop the memoized verdict so the NEXT checkReady() asks the backend again.
+// Deliberately not a re-fetch: the callers that care re-read straight afterwards,
+// and a caller that does not must not pay for a round-trip it never reads.
+export function forgetReady() {
+	readyPromise = null;
 }
 
 // Resolves true once the workspace is chat-ready. Used by the router guard.
@@ -84,4 +93,20 @@ export async function readinessDetailOf() {
 	const r = await checkReady();
 	if (!r || r.ready || r.reason !== "container_provisioning") return "";
 	return r.detail || "";
+}
+
+// True when the workspace is not chat-ready specifically because it has no usable
+// LLM credential - the customer disconnected their AI, or the credential the
+// workspace was using expired or was revoked. A sibling accessor rather than a
+// widening of readinessDetailOf above, because that one answers "what did the
+// backend say about this" and is_ready_for_chat sends no `detail` for this reason:
+// there is nothing to quote, only a state to name.
+//
+// This deliberately does NOT belong in NOT_ONBOARDED_REASONS (see the comment
+// there). The full-screen gate poster is for a workspace that was never set up;
+// this one HAS been set up and merely has no AI attached right now, so it keeps its
+// chat history, its settings and every other route, and gets a banner instead.
+export async function needsLlmConnection() {
+	const r = await checkReady();
+	return !!(r && !r.ready && r.reason === "llm_credentials");
 }

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// readiness.js reaches the backend through @/api.js, whose real module pulls in
+// frappe-ui. The factory form of vi.mock keeps that module out of the graph
+// entirely, so these tests exercise the verdict logic and nothing else.
+const isReadyForChat = vi.fn();
+vi.mock("@/api.js", () => ({ isReadyForChat: (...a) => isReadyForChat(...a) }));
+
+const { readinessDetailOf, needsLlmConnection, forgetReady } = await import("./readiness.js");
+
+// The verdict is memoized for the page load, so every case has to start clean.
+beforeEach(() => {
+	forgetReady();
+	isReadyForChat.mockReset();
+});
+
+const verdict = (v) => isReadyForChat.mockResolvedValue(v);
+
+/**
+ * ChatView renders the not-ready banners as ONE v-else-if chain, so at most one
+ * of these two accessors may answer for any given reason. When both answered for
+ * "llm_credentials" the generic, button-less "Chat may not work yet" banner won
+ * the chain and the actionable "No AI connected" banner (the only route back to
+ * the AI models pane) could never appear. These tests pin the split so a future
+ * edit cannot silently shadow it again.
+ */
+describe("readiness verdict ownership", () => {
+	it("gives llm_credentials to needsLlmConnection ALONE", async () => {
+		// is_ready_for_chat sends no `detail` for this reason (jarvis/account.py):
+		// there is nothing to quote, only a state to name.
+		verdict({ ready: false, reason: "llm_credentials" });
+		expect(await needsLlmConnection()).toBe(true);
+		expect(await readinessDetailOf()).toBe("");
+	});
+
+	it("still hands llm_credentials to needsLlmConnection when a detail leaks in", async () => {
+		// Defensive: readinessDetailOf must key off the REASON, not the presence of
+		// a detail string, or a future backend that starts sending one for this
+		// reason would re-create the shadowing bug.
+		verdict({ ready: false, reason: "llm_credentials", detail: "Anything at all." });
+		expect(await needsLlmConnection()).toBe(true);
+		expect(await readinessDetailOf()).toBe("");
+	});
+
+	it("keeps container_provisioning on the generic banner, not the AI one", async () => {
+		verdict({
+			ready: false,
+			reason: "container_provisioning",
+			detail: "Your OpenAI account has reached its usage limit.",
+		});
+		expect(await readinessDetailOf()).toBe("Your OpenAI account has reached its usage limit.");
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
+	it("leaves subscription_suspended to its own Renew banner", async () => {
+		verdict({ ready: false, reason: "subscription_suspended", detail: "Renew to continue." });
+		expect(await readinessDetailOf()).toBe("");
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
+	it("shows neither banner on a ready workspace", async () => {
+		verdict({ ready: true, reason: null });
+		expect(await readinessDetailOf()).toBe("");
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
+	it("shows neither banner when the check throws (fail-open)", async () => {
+		isReadyForChat.mockRejectedValue(new Error("admin unreachable"));
+		expect(await readinessDetailOf()).toBe("");
+		expect(await needsLlmConnection()).toBe(false);
+	});
+
+	// The exhaustive form of the rule above: whatever account.py answers, the two
+	// accessors must never BOTH claim the same verdict.
+	it("never lets both accessors claim one reason", async () => {
+		const reasons = [
+			"signup",
+			"selfhost_connection",
+			"llm_credentials",
+			"llm_pool_provisioning",
+			"llm_provisioning",
+			"container_provisioning",
+			"subscription_suspended",
+			null,
+		];
+		for (const reason of reasons) {
+			forgetReady();
+			verdict({ ready: false, reason, detail: "d" });
+			const both = !!(await readinessDetailOf()) && (await needsLlmConnection());
+			expect(both, `reason ${reason} is claimed by both accessors`).toBe(false);
+		}
+	});
+});
+
+/**
+ * The banner stack in ChatView is a v-else-if chain, so its SOURCE ORDER is the
+ * behaviour. Mounting ChatView to assert this is not viable (it is the largest
+ * component in the app and boots sockets, so this reads the template instead,
+ * the same trick dashboardOpen.test.js already uses on this file).
+ */
+describe("ChatView banner chain order", () => {
+	const HERE = path.dirname(fileURLToPath(import.meta.url));
+	const chatSrc = fs.readFileSync(path.join(HERE, "..", "views", "ChatView.vue"), "utf8");
+
+	it("tests the specific No-AI banner before the generic not-ready one", () => {
+		const specific = chatSrc.indexOf('v-else-if="noAiConnected"');
+		const generic = chatSrc.indexOf('v-else-if="notReadyNotice"');
+		expect(specific, "ChatView must still render the noAiConnected banner").not.toBe(-1);
+		expect(generic, "ChatView must still render the notReadyNotice banner").not.toBe(-1);
+		// Specific before generic: the No-AI banner carries the "Connect a model"
+		// call to action, so a generic banner ahead of it in the chain leaves a
+		// disconnected customer with no discoverable way back to the AI models pane.
+		expect(specific).toBeLessThan(generic);
+	});
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2069,6 +2069,27 @@
 					:message="notReadyNotice"
 					style="margin-bottom: 10px"
 				/>
+				<!-- No model configured: the workspace was disconnected, or its credential
+					 expired. The composer is disabled alongside this (see canSend) - every
+					 send would fail at the agent, and letting it be tried just turns a clear
+					 explanation into an error the customer has to interpret. -->
+				<Banner
+					v-else-if="noAiConnected"
+					type="warning"
+					title="No AI connected"
+					message="Connect a model to start chatting again"
+					style="margin-bottom: 10px"
+				>
+					<template #action>
+						<button
+							v-if="canConnectModel"
+							class="jv-btn jv-btn--sm"
+							@click="goConnectModel"
+						>
+							Connect a model
+						</button>
+					</template>
+				</Banner>
 
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
@@ -3597,7 +3618,12 @@ import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { dashboardForConversation } from "@/api/dashboards";
-import { checkReady, readinessDetailOf } from "@/onboarding/readiness.js";
+import {
+	checkReady,
+	readinessDetailOf,
+	needsLlmConnection,
+	forgetReady,
+} from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
 import { billingNoticeOf } from "@/onboarding/readiness.js";
@@ -3677,6 +3703,21 @@ const suspendedNotice = ref(null);
 // onboarding's "Continue to Jarvis" while genuinely not ready used to land here to
 // dead silence - the real reason existed the whole time, nobody rendered it).
 const notReadyNotice = ref("");
+// No AI connected at all (is_ready_for_chat reason "llm_credentials"): the customer
+// disconnected their model, or the credential expired. Until now this reason was
+// handled by NEITHER the onboarding gate (correctly - see readiness.js) nor any
+// banner, so the workspace looked fine and every send failed on arrival. Its own
+// flag rather than reusing notReadyNotice: that one carries admin's sentence about a
+// container, and this one has its own copy and its own call to action.
+const noAiConnected = ref(false);
+// Connecting a model is gated on require_jarvis_admin() server-side. A member who
+// cannot reach the AI models pane still gets the banner (their chat IS broken and
+// they should know why), just without a button that would only bounce them back to
+// General.
+const canConnectModel = !!(window.is_jarvis_admin || window.is_system_manager);
+function goConnectModel() {
+	store.openSettings("aimodels");
+}
 // Billing lifecycle banner. Dismissal is session-only (a ref, not storage): the
 // pre-expiry nudge should return on the next visit, since the deadline has not.
 const billingNotice = ref({});
@@ -3827,7 +3868,20 @@ const settingsTab = ref("overview");
 watch(
 	() => store.settingsOpen,
 	async (open) => {
-		if (!open) return;
+		if (!open) {
+			// The AI models pane lives in this dialog, so connecting or disconnecting a
+			// model happens while chat is still mounted behind it. The readiness verdict
+			// is memoized for the page load, so without dropping it here the composer
+			// would stay dead after a reconnect, or stay live after a disconnect until
+			// the customer reloaded. Best-effort, exactly like the boot read.
+			forgetReady();
+			try {
+				noAiConnected.value = await needsLlmConnection();
+			} catch (e) {
+				/* leave the last known state */
+			}
+			return;
+		}
 		try {
 			usage.value = await api.getUsage(currentId.value);
 		} catch (e) {
@@ -4658,6 +4712,9 @@ const canSend = computed(
 		!sending.value &&
 		// Suspended: the server rejects every send, so keep the button dead.
 		!suspendedNotice.value &&
+		// No model configured: nothing on the other end can answer, so prevent the
+		// send rather than reporting the failure after the fact.
+		!noAiConnected.value &&
 		// A dictation that hasn't landed yet blocks the send inside send() anyway (its words
 		// would be dropped). Disable the button too, with the reason on its tooltip: leaving it
 		// lit and swallowing the click behind a fading toast is the button lying about what it
@@ -6925,6 +6982,14 @@ async function send(textArg, resendAck) {
 	const _failedAtSend = fromMain && voiceStore ? voiceStore.failedIdsForScope(_sentScope) : [];
 	const attachments = fromMain ? pendingFiles.value.slice() : [];
 	if ((!text && !attachments.length) || sending.value) return;
+	// canSend already darkens the Send button, but Enter routes here directly (onKey
+	// preventDefaults and calls send()), and a programmatic send never sees the button
+	// at all. With no model connected the turn can only fail at the agent, so refuse it
+	// here and keep the banner's own wording rather than surfacing a backend error.
+	if (noAiConnected.value) {
+		notify("No AI connected. Connect a model to start chatting again.", { type: "info" });
+		return;
+	}
 	if (text && promptHistory.value[promptHistory.value.length - 1] !== text) {
 		promptHistory.value.push(text); // for Up/Down recall
 	}
@@ -8585,6 +8650,14 @@ onMounted(async () => {
 	readinessDetailOf()
 		.then((detail) => {
 			notReadyNotice.value = detail;
+		})
+		.catch(() => {});
+	// ...and the llm_credentials half of the same boot promise. Same fail-open
+	// posture: an unreachable backend leaves this false and chat behaves as before,
+	// because wrongly disabling a working composer is worse than a failed send.
+	needsLlmConnection()
+		.then((v) => {
+			noAiConnected.value = v;
 		})
 		.catch(() => {});
 	document.addEventListener("pointerdown", onDocClick);

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2057,22 +2057,18 @@
 						<button class="jv-btn jv-btn--sm" @click="goRenew">Renew</button>
 					</template>
 				</Banner>
-				<!-- Not chat-ready for a NON-billing reason (e.g. the connected LLM account
-					 itself is out of quota, or a container is still coming up). No CTA: unlike
-					 a lapsed subscription there's nothing to renew via us here - the detail
-					 IS the admin's own diagnosis (jarvis.account.is_ready_for_chat), not a
-					 guess this UI is making up. -->
-				<Banner
-					v-else-if="notReadyNotice"
-					type="warning"
-					title="Chat may not work yet"
-					:message="notReadyNotice"
-					style="margin-bottom: 10px"
-				/>
 				<!-- No model configured: the workspace was disconnected, or its credential
 					 expired. The composer is disabled alongside this (see canSend) - every
 					 send would fail at the agent, and letting it be tried just turns a clear
-					 explanation into an error the customer has to interpret. -->
+					 explanation into an error the customer has to interpret.
+
+					 ORDER MATTERS, and it is pinned by readiness.spec.js. This banner is the
+					 SPECIFIC one and carries the only route back to the AI models pane, so it
+					 must be tested before the generic notReadyNotice below or a generic,
+					 CTA-less banner shadows it. readiness.js keeps the two verdicts mutually
+					 exclusive as well (llm_credentials belongs to needsLlmConnection alone),
+					 so this cannot swallow an unrelated not-ready state such as
+					 container_provisioning either. -->
 				<Banner
 					v-else-if="noAiConnected"
 					type="warning"
@@ -2090,6 +2086,18 @@
 						</button>
 					</template>
 				</Banner>
+				<!-- Not chat-ready for a NON-billing reason (e.g. the connected LLM account
+					 itself is out of quota, or a container is still coming up). No CTA: unlike
+					 a lapsed subscription there's nothing to renew via us here - the detail
+					 IS the admin's own diagnosis (jarvis.account.is_ready_for_chat), not a
+					 guess this UI is making up. -->
+				<Banner
+					v-else-if="notReadyNotice"
+					type="warning"
+					title="Chat may not work yet"
+					:message="notReadyNotice"
+					style="margin-bottom: 10px"
+				/>
 
 				<!-- floats just above the composer; jumps the thread to the newest message -->
 				<transition name="jv-sd">
@@ -3864,6 +3872,24 @@ const settingsOpen = computed({
 	},
 });
 const settingsTab = ref("overview");
+// AI models is the ONLY pane that can change the chat-readiness verdict: every
+// connect, rotate and disconnect goes through LlmPoolEditor, which only that pane
+// renders (SettingsDialog.vue PANES). Closing the dialog is one of the most common
+// actions in the app, so remember whether that pane was actually opened during
+// this visit rather than paying for a readiness round-trip every time someone
+// glances at the theme and closes. Tracked across the whole visit, not read at
+// close time, because the customer can disconnect and then navigate to another
+// pane before closing.
+let aiModelsPaneVisited = false;
+const SETTINGS_READINESS_SECTION = "aimodels";
+watch(
+	() => store.settingsSection,
+	(section) => {
+		if (store.settingsOpen && section === SETTINGS_READINESS_SECTION) {
+			aiModelsPaneVisited = true;
+		}
+	}
+);
 // Load usage stats whenever the dialog opens (was openSettings()).
 watch(
 	() => store.settingsOpen,
@@ -3874,6 +3900,8 @@ watch(
 			// is memoized for the page load, so without dropping it here the composer
 			// would stay dead after a reconnect, or stay live after a disconnect until
 			// the customer reloaded. Best-effort, exactly like the boot read.
+			if (!aiModelsPaneVisited) return;
+			aiModelsPaneVisited = false;
 			forgetReady();
 			try {
 				noAiConnected.value = await needsLlmConnection();
@@ -3882,6 +3910,13 @@ watch(
 			}
 			return;
 		}
+		// openSettings(section) writes both refs in the same tick, so the section
+		// watcher above may not fire for a dialog opened DIRECTLY on AI models (the
+		// "Connect a model" banner button does exactly that, and the section is
+		// sticky, so it can already hold "aimodels" from a previous visit). Seed the
+		// flag from the section the dialog is opening on instead of relying on a
+		// change event that may never come.
+		aiModelsPaneVisited = store.settingsSection === SETTINGS_READINESS_SECTION;
 		try {
 			usage.value = await api.getUsage(currentId.value);
 		} catch (e) {

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -244,12 +244,30 @@ def get_llm_connection_status() -> dict:
 	proxy auth profile to report. Before this, the raw admin payload's
 	leftover fields (a stale/default default_model with auth_profile_present
 	false) made the SPA's ConnectionPane render a misleading orange "Not
-	connected" for a direct tenant whose chat verifiably works."""
+	connected" for a direct tenant whose chat verifiably works.
+
+	``disconnected`` is the third state, and it has to be computed FIRST. The
+	DIRECT short-circuit above returns before any admin round-trip, so a tenant
+	whose connection was torn down (jarvis.onboarding.disconnect_llm) would
+	otherwise fall into it and report a healthy-looking "Direct" while chat is
+	dead. It is derived here rather than added to ``chat_readiness``: that field
+	is a shared admin/bench contract with exactly four values, and the bench
+	already knows its own config is empty without asking anybody."""
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
+	if not _has_llm_config(settings):
+		return {
+			"proxy_active": False,
+			"disconnected": True,
+			"auth_present": False,
+			"oauth_expires_at": None,
+			"profile_ids": [],
+			"default_model": "",
+		}
 	if not getattr(settings, "proxy_active", 0):
 		return {
 			"proxy_active": False,
+			"disconnected": False,
 			"auth_present": False,
 			"oauth_expires_at": None,
 			"profile_ids": [],
@@ -259,11 +277,28 @@ def get_llm_connection_status() -> dict:
 	data = raw.get("data", raw) or {}
 	return {
 		"proxy_active": True,
+		"disconnected": False,
 		"auth_present": bool(data.get("auth_profile_present")),
 		"oauth_expires_at": data.get("openai_profile_expires_ms"),
 		"profile_ids": data.get("profile_ids", []),
 		"default_model": data.get("default_model", ""),
 	}
+
+
+def _has_llm_config(settings) -> bool:
+	"""True when this workspace still has an AI connection configured.
+
+	The flat llm_provider / llm_model pair is the mirror on_update keeps of
+	models[0], so it covers pool and direct tenants alike. models[] is checked
+	too because a table whose rows are all DISABLED leaves the mirror blank while
+	the credentials are still stored - that is a paused pool, not a disconnected
+	workspace, and it must not read as one. proxy_active is checked for the same
+	reason from the other direction: it is DERIVED from the config at save time
+	(compute_proxy_active) and reset to 0 whenever the config goes away, so a set
+	flag is by itself proof that a pool exists, whatever the mirrors say."""
+	provider = (settings.get("llm_provider") or "").strip()
+	model = (settings.get("llm_model") or "").strip()
+	return bool(provider or model or settings.get("models") or getattr(settings, "proxy_active", 0))
 
 
 @frappe.whitelist()

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -923,6 +923,30 @@ def post_subscription_disconnect() -> dict:
 	)
 
 
+def post_disconnect_llm() -> dict:
+	"""POST to admin to delete EVERY LLM credential from the customer's container:
+	the pool spec and its sidecar keys, /secrets/llm.key, and any auth profile.
+
+	Wider than post_subscription_disconnect above, which only drops the DIRECT
+	chat-subscription auth profile and leaves an api-key pool serving. This is the
+	whole connection coming down, so nothing is left that could answer a turn.
+
+	Idempotent - a tenant with nothing configured is a no-op success, so a repeat
+	call (or a retry after a read timeout) is safe.
+
+	Rides the shared DEFAULT_TIMEOUT_S like post_update_llm_pool: admin re-renders
+	the tenant config and restarts the container on this path too, which sits above
+	the admin's own admin->agent budget.
+
+	Raises:
+		AdminAuthError, AdminUnreachableError, AdminValidationError
+	"""
+	return _post(
+		path=_m("api.tenant.disconnect_llm"),
+		body={},
+	)
+
+
 def post_update_llm_pool(*, spec: dict, api_keys: dict, oauth_blobs: dict) -> dict:
 	"""POST a PoolSpec + separated secrets to admin → fleet-agent → openclaw.
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -312,6 +312,115 @@ def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: s
 	}
 
 
+# Every Jarvis Settings field that names or dates the LLM connection, and the
+# value that means "there is no connection". The api_key Password fields are NOT
+# here - clearing a Password needs its __Auth row dropped too, so they go through
+# _clear_llm_secrets below.
+#
+# llm_pool_synced_at / llm_direct_synced_at look like history rather than
+# credentials, but they are cleared deliberately: is_ready_for_chat treats a
+# stamped marker as "this tenant has applied at least once, so keep chat open
+# through a transient pending". Leaving them set would let the NEXT connection
+# open chat before its first apply is confirmed - exactly the split-brain the
+# markers exist to prevent. A disconnect ends that history.
+_DISCONNECTED_LLM_FIELDS = {
+	"llm_provider": "",
+	"llm_model": "",
+	"llm_base_url": "",
+	"llm_auth_mode": "api_key",
+	"llm_oauth_account_email": "",
+	"llm_oauth_connected_at": None,
+	"preset": "",
+	"proxy_active": 0,
+	"proxy_recommended": 0,
+	"llm_pool_synced_at": None,
+	"llm_direct_synced_at": None,
+	# Same marker jarvis.oauth.api.disconnect writes. humaniseSyncStatus does not
+	# recognise it, which is correct here: the editor's status strip hides itself
+	# rather than reporting on an apply that no longer has a subject.
+	"last_sync_status": "disconnected",
+	"last_subscription_status": "",
+	"last_sync_warnings": "[]",
+	"last_model_statuses": "[]",
+}
+
+_POOL_MODEL_DOCTYPE = "Jarvis LLM Pool Model"
+
+
+@frappe.whitelist()
+def disconnect_llm() -> dict:
+	"""Tear the customer's whole LLM connection down: delete every credential this
+	bench stores AND ask admin to delete them from the container.
+
+	Deliberately NOT expressed as "save an empty pool". save_llm_pool rejects an
+	empty list, and so does the fleet agent, because an empty pool reaching the
+	apply path is almost always a bug rather than an intention. A separate method
+	keeps that guard intact, cannot be reached by accident from an edit, and gives
+	the destructive action its own auditable name in the logs.
+
+	Admin goes FIRST and its failure aborts the whole thing. The other order would
+	leave a bench that reads "disconnected" in front of a container still holding
+	live keys and still answering turns - the customer would believe their
+	credentials were deleted when they were not, which is the one outcome this
+	feature cannot have.
+
+	Idempotent: a tenant with nothing configured clears nothing and still succeeds
+	(admin's endpoint is idempotent for the same reason).
+	"""
+	require_jarvis_admin()
+	from jarvis import selfhost
+
+	settings = frappe.get_single("Jarvis Settings")
+	# Only call admin when there is an admin tenancy to call. A self-hosted bench
+	# has no control plane at all, and an un-onboarded one has no credentials for
+	# it, so admin_client would raise AdminAuthError("not onboarded") on what is
+	# otherwise a perfectly valid local wipe.
+	if not selfhost.is_self_hosted() and _has_admin_credentials(settings):
+		_surface(admin_client.post_disconnect_llm)
+
+	_clear_llm_secrets(settings)
+	for field, value in _DISCONNECTED_LLM_FIELDS.items():
+		settings.db_set(field, value, update_modified=False)
+	frappe.db.commit()
+	return {"disconnected": True, "last_sync_status": "disconnected"}
+
+
+def _has_admin_credentials(settings) -> bool:
+	"""True when this bench holds credentials for the control plane. Mirrors the
+	un-onboarded short-circuit in reconcile_pending_llm_sync: either the api-key
+	pair or the OAuth password is enough to authenticate a call."""
+	api_key = (settings.get_password("jarvis_admin_api_key", raise_exception=False) or "").strip()
+	customer_pw = (
+		settings.get_password("jarvis_admin_customer_password", raise_exception=False) or ""
+	).strip()
+	return bool(api_key or customer_pw)
+
+
+def _clear_llm_secrets(settings) -> None:
+	"""Delete every stored LLM credential: the models[] child rows (whose api_key
+	and subscription_accounts are Password fields) and the legacy flat llm_api_key.
+
+	Password fields keep the real value in __Auth, keyed by (doctype, row name) -
+	the doctype column only ever holds a mask. Frappe cleans __Auth in
+	frappe.delete_doc, which does not apply here: child rows of a Single are
+	removed by Document.update_child_table with a bare SQL DELETE that never looks
+	at __Auth. So clearing models[] the ordinary way leaves the encrypted keys
+	behind, readable by anything that knows a deleted row's name. Drop them by hand,
+	before the rows themselves.
+
+	The sweep is by DOCTYPE, not by row name: Jarvis LLM Pool Model is a child of
+	the Jarvis Settings Single and of nothing else, so every one of its __Auth rows
+	belongs to the connection being torn down - including any orphaned by an
+	earlier ordinary pool save. "Removed from everywhere" has to mean those too.
+	"""
+	from jarvis._password_utils import clear_settings_password
+
+	frappe.db.delete("__Auth", {"doctype": _POOL_MODEL_DOCTYPE})
+	frappe.db.delete(_POOL_MODEL_DOCTYPE, {"parenttype": "Jarvis Settings", "parent": "Jarvis Settings"})
+	settings.set("models", [])
+	clear_settings_password(settings, "llm_api_key")
+
+
 @frappe.whitelist()
 def start_signup(email: str, company: str, plan: str, provider: str | None = None) -> dict:
 	"""Guest signup → store the api_token → return the Razorpay handles for Checkout.

--- a/jarvis/tests/test_disconnect_llm.py
+++ b/jarvis/tests/test_disconnect_llm.py
@@ -1,0 +1,290 @@
+"""jarvis.onboarding.disconnect_llm - the customer-side half of Disconnect.
+
+The interesting assertions here are about what is GONE afterwards, and the one
+that matters most is __Auth: a Password field keeps its real value in that table
+and only a mask in the doctype row, so a "cleared" credential that still has an
+__Auth row is not cleared at all. Frappe cleans __Auth in frappe.delete_doc,
+which never runs for child rows of a Single (Document.update_child_table deletes
+them with a bare SQL DELETE), so these tests read the table directly rather than
+trusting get_password to tell the truth about it.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.utils.password import get_decrypted_password
+
+from jarvis import account, admin_client, onboarding
+from jarvis.exceptions import AdminUnreachableError
+from jarvis.tests.test_settings_on_update import _reset_settings
+from jarvis.tests.test_unified_llm_config import _RT3SettingsTestCase
+
+_POOL = [
+	{
+		"provider": "openai",
+		"model": "gpt-5.5",
+		"api_key": "sk-first",
+		"base_url": "",
+		"tier": "strong",
+		"order": 0,
+	},
+	{
+		"provider": "anthropic",
+		"model": "claude-sonnet-4",
+		"api_key": "sk-second",
+		"base_url": "",
+		"tier": "strong",
+		"order": 1,
+	},
+]
+
+
+def _pool_auth_rows() -> int:
+	"""__Auth rows holding a models[] child-row secret (api_key /
+	subscription_accounts). Jarvis LLM Pool Model is a child of the Jarvis
+	Settings Single and of nothing else, so this counts exactly the pool's
+	encrypted credentials."""
+	return frappe.db.sql("select count(*) from `__Auth` where doctype = %s", ("Jarvis LLM Pool Model",))[0][0]
+
+
+class TestDisconnectLlm(_RT3SettingsTestCase):
+	def setUp(self):
+		super().setUp()
+		self._clear_models()
+		_reset_settings()
+		frappe.db.commit()
+
+	def _seed_pool(self):
+		"""Write a real two-model pool through the ordinary save path, so the
+		credentials under test were stored exactly the way a customer's are."""
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
+			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
+		):
+			onboarding.save_llm_pool(frappe.as_json(_POOL), preset=None, routing_mode="failover")
+
+	# ---- the credentials really go -------------------------------------- #
+
+	def test_deletes_pool_rows_and_their_auth_secrets(self):
+		self._seed_pool()
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(len(settings.get("models")), 2)
+		self.assertEqual(settings.models[0].get_password("api_key"), "sk-first")
+		self.assertGreaterEqual(_pool_auth_rows(), 2, "seeding must produce encrypted row secrets")
+
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.get("models") or [], [])
+		# The point of the whole test: the rows are gone AND so is the ciphertext.
+		# Clearing models[] the ordinary way leaves these behind.
+		self.assertEqual(_pool_auth_rows(), 0)
+
+	def test_clears_the_legacy_flat_api_key_including_its_auth_row(self):
+		self._seed_pool()
+		# on_update mirrors models[0]'s key into the legacy Password field.
+		self.assertEqual(
+			get_decrypted_password("Jarvis Settings", "Jarvis Settings", "llm_api_key", False),
+			"sk-first",
+		)
+
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		self.assertFalse(
+			get_decrypted_password("Jarvis Settings", "Jarvis Settings", "llm_api_key", False),
+			"llm_api_key must not survive in __Auth after a disconnect",
+		)
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertFalse(settings.get_password("llm_api_key", raise_exception=False))
+
+	def test_clears_the_mirrored_legacy_fields(self):
+		self._seed_pool()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.get("llm_provider") or "", "")
+		self.assertEqual(settings.get("llm_model") or "", "")
+		self.assertEqual(settings.get("llm_base_url") or "", "")
+		self.assertEqual(settings.get("llm_auth_mode") or "", "api_key")
+		self.assertEqual(settings.get("llm_oauth_account_email") or "", "")
+		self.assertIsNone(settings.get("llm_oauth_connected_at"))
+		self.assertEqual(settings.get("preset") or "", "")
+		self.assertFalse(settings.get("proxy_active"))
+		# The apply markers go too: is_ready_for_chat reads a stamped marker as "this
+		# tenant has applied before, keep chat open through a pending re-save", which
+		# would wrongly open chat for the NEXT connection before its first apply.
+		self.assertIsNone(settings.get("llm_pool_synced_at"))
+		self.assertIsNone(settings.get("llm_direct_synced_at"))
+
+	def test_clears_the_oauth_blob_of_a_subscription_pool(self):
+		models = [
+			{
+				"provider": "openai",
+				"model": "gpt-5.5",
+				"order": 0,
+				"subscription": {
+					"rotation": "sticky",
+					"accounts": [
+						{
+							"upstream": "openai",
+							"account_ref": "SUB_a",
+							"label": "a@x.com",
+							"oauth_blob": '{"refresh_token": "rt-secret"}',
+						}
+					],
+				},
+			},
+			{
+				"provider": "openai",
+				"model": "gpt-5.4",
+				"api_key": "sk-backup",
+				"order": 1,
+			},
+		]
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool", return_value={"action": "pool_update"}),
+			patch("jarvis.admin_client.post_update_llm_creds", return_value={"action": "restart"}),
+		):
+			onboarding.save_llm_pool(frappe.as_json(models), preset=None, routing_mode="failover")
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertIn("rt-secret", settings.models[0].get_password("subscription_accounts") or "")
+
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		self.assertEqual(_pool_auth_rows(), 0)
+
+	# ---- the container is told -------------------------------------------- #
+
+	def test_calls_admin_so_the_deletion_reaches_the_container(self):
+		self._seed_pool()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}) as m:
+			onboarding.disconnect_llm()
+		m.assert_called_once_with()
+
+	def test_admin_failure_aborts_and_keeps_the_credentials(self):
+		"""Admin first, and its failure is terminal. The other order would leave a
+		bench reading "disconnected" in front of a container still holding live keys
+		- telling the customer their credentials were deleted when they were not."""
+		self._seed_pool()
+		with patch(
+			"jarvis.admin_client.post_disconnect_llm",
+			side_effect=AdminUnreachableError("read timeout"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				onboarding.disconnect_llm()
+
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(len(settings.get("models")), 2)
+		self.assertEqual(settings.models[0].get_password("api_key"), "sk-first")
+		self.assertGreaterEqual(_pool_auth_rows(), 2)
+
+	# ---- idempotence ------------------------------------------------------ #
+
+	def test_disconnecting_twice_succeeds(self):
+		self._seed_pool()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}) as m:
+			onboarding.disconnect_llm()
+			out = onboarding.disconnect_llm()
+		self.assertEqual(m.call_count, 2)
+		self.assertTrue(out["disconnected"])
+		self.assertEqual(_pool_auth_rows(), 0)
+
+	def test_disconnecting_an_unconfigured_tenant_succeeds(self):
+		settings = frappe.get_single("Jarvis Settings")
+		for field in ("llm_provider", "llm_model", "llm_base_url", "llm_api_key"):
+			settings.db_set(field, "", update_modified=False)
+		frappe.db.commit()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			out = onboarding.disconnect_llm()
+		self.assertTrue(out["disconnected"])
+
+	def test_skips_the_admin_call_when_the_bench_is_not_onboarded(self):
+		"""No control plane to call: admin_client would raise
+		AdminAuthError("not onboarded") on what is otherwise a valid local wipe.
+
+		The predicate is patched rather than the fields cleared: this suite shares
+		the Jarvis Settings Single with the live site, and really clearing the admin
+		credentials means dropping their __Auth rows - which the class teardown
+		cannot put back for jarvis_admin_customer_password. _has_admin_credentials
+		itself is covered below."""
+		with (
+			patch("jarvis.onboarding._has_admin_credentials", return_value=False),
+			patch("jarvis.admin_client.post_disconnect_llm") as m,
+		):
+			out = onboarding.disconnect_llm()
+		m.assert_not_called()
+		self.assertTrue(out["disconnected"])
+
+	def test_skips_the_admin_call_on_a_self_hosted_bench(self):
+		with (
+			patch("jarvis.selfhost.is_self_hosted", return_value=True),
+			patch("jarvis.admin_client.post_disconnect_llm") as m,
+		):
+			out = onboarding.disconnect_llm()
+		m.assert_not_called()
+		self.assertTrue(out["disconnected"])
+
+	def test_admin_credentials_predicate_accepts_either_auth_shape(self):
+		class _Stub:
+			def __init__(self, **values):
+				self._values = values
+
+			def get_password(self, field, raise_exception=True):
+				return self._values.get(field, "")
+
+		self.assertFalse(onboarding._has_admin_credentials(_Stub()))
+		self.assertFalse(
+			onboarding._has_admin_credentials(
+				_Stub(jarvis_admin_api_key="  ", jarvis_admin_customer_password="")
+			)
+		)
+		self.assertTrue(onboarding._has_admin_credentials(_Stub(jarvis_admin_api_key="ak-1")))
+		# OAuth password only: the shape a verified signup lands on.
+		self.assertTrue(onboarding._has_admin_credentials(_Stub(jarvis_admin_customer_password="pw-1")))
+
+	# ---- what the rest of the app sees afterwards -------------------------- #
+
+	def test_chat_readiness_reports_llm_credentials(self):
+		"""Pins the behaviour the disconnected banner keys off. is_ready_for_chat
+		already returned this reason for a blank api_key config; this makes sure a
+		disconnect lands on that path rather than on llm_pool_provisioning (which
+		would send the customer to the full-screen onboarding gate instead)."""
+		self._seed_pool()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		with patch.object(admin_client, "get_connection", return_value={}):
+			verdict = account.is_ready_for_chat()
+		self.assertFalse(verdict["ready"])
+		self.assertEqual(verdict["reason"], "llm_credentials")
+
+	def test_connection_status_reports_disconnected_without_an_admin_call(self):
+		self._seed_pool()
+		with patch("jarvis.admin_client.post_disconnect_llm", return_value={"ok": True}):
+			onboarding.disconnect_llm()
+
+		with patch.object(admin_client, "post_llm_auth_status") as m:
+			out = account.get_llm_connection_status()
+		m.assert_not_called()
+		self.assertTrue(out["disconnected"])
+		self.assertFalse(out["proxy_active"])
+		self.assertEqual(out["default_model"], "")
+
+	def test_a_configured_direct_tenant_is_not_disconnected(self):
+		"""The Direct short-circuit returns before the admin round-trip, so the
+		disconnected state has to be computed ahead of it - but not AT its expense."""
+		settings = frappe.get_single("Jarvis Settings")
+		settings.db_set("proxy_active", 0, update_modified=False)
+		settings.db_set("llm_provider", "openai", update_modified=False)
+		settings.db_set("llm_model", "gpt-4o", update_modified=False)
+		frappe.db.commit()
+
+		with patch.object(admin_client, "post_llm_auth_status") as m:
+			out = account.get_llm_connection_status()
+		m.assert_not_called()
+		self.assertFalse(out["disconnected"])
+		self.assertEqual(out["default_model"], "gpt-4o")


### PR DESCRIPTION
> **Cross-plane.** Needs `jarvis-fleet-agent` (contract 1.20) and `jarvis_admin_v2` `disconnect_llm` deployed FIRST, and a `bench migrate` on the admin site. Companion PRs in those repos.

## Why

Removing your last model was refused outright, because a real disconnect has to clear credentials from the container and that was out of scope. So a customer who wanted to stop using Jarvis could only ever *replace* their last model, never leave.

## Remove and Disconnect are different words for different outcomes

And the row tells you which one you are about to get **before** you click: the action reads **Remove** while another model would remain, and **Disconnect** on the last one.

- **Remove** drops one entry from the failover list. Chat keeps working.
- **Disconnect** deletes credentials everywhere and stops chat, behind a confirm that names the consequence rather than asking "are you sure": *"Your API keys and connected accounts will be permanently deleted from Jarvis and from your workspace container. Chat will stop working until you connect a model. Your chat history, skills and macros are kept."*

## It fixes a credential leak that predates it

`disconnect_llm` sweeps `__Auth`, and that sweep matters beyond this feature.

Frappe only cleans `__Auth` inside `delete_doc`, which **never runs for child rows of a Single** — `Document.update_child_table` deletes them with a bare query. So `s.set("models", [])` + `save()` leaves every encrypted `api_key` and `subscription_accounts` blob behind, and they accumulate on **every ordinary pool save**.

Measured on `jarvis.proxy`: **16 `__Auth` rows for `Jarvis LLM Pool Model` against 2 live rows**, so 14 orphaned encrypted secrets sitting in the database. The sweep is by doctype rather than by row, so it collects those older orphans too.

The tests read `__Auth` directly rather than trusting `get_password`, because `get_password` is exactly what the bug made lie.

## Ordering

Admin is called **first** and its failure is terminal. The other order would leave a bench reporting "disconnected" in front of a container still serving live keys.

## Connection status reads "Disconnected"

Computed bench-side and checked **before** the DIRECT short-circuit, or a torn-down tenant keeps reporting a healthy-looking "Direct" while chat is dead. **No fifth `chat_readiness` value** — that enum is a shared admin/bench contract.

The predicate could not be "provider and model are blank" as originally specced. It also has to count `models[]` (a disabled-only pool still holds credentials: that is a *paused* pool, not a disconnected workspace) and `proxy_active` (whose flag is itself proof a pool exists). Without the `proxy_active` term an existing `test_llm_monitor` case breaks.

## A disconnected workspace says so in chat

`llm_credentials` was handled by neither the onboarding gate nor the banner, so chat just failed on send with no explanation. Deliberately **not** added to `NOT_ONBOARDED_REASONS`: that reason also fires when a working workspace's credentials later expire, and hard-blocking the whole app there would be wrong.

Three things the original plan got wrong, found while building:

1. `readinessDetailOf` could not be widened — `is_ready_for_chat` sends no `detail` for `llm_credentials`, so it would return `""` and the banner would never fire. There is no sentence to quote, only a state to name.
2. **Disabling the send control does not prevent the send.** Enter bypasses it entirely, so `send()` needed its own guard.
3. `checkReady` is memoized per page load, and disconnect happens in the settings dialog *over* the chat view, so without invalidation the banner only appeared after a reload.

Onboarding is unaffected: Disconnect is never offered in `footerless` mode, pinned by a test.

## Verification

- vitest 287 passing, node:test 401 passing, vite build clean, ruff clean
- New `jarvis/tests/test_disconnect_llm.py` (14 tests) + 6 new editor specs
- Backend regression sweep green across `llm_monitor`, `llm_pool_endpoints`, `unified_llm_config`, `settings_on_update`, `onboarding_sync`, `oauth_api`, `admin_client`

https://claude.ai/code/session_01WLXuBvzxvSt2WqHQRXdRBz