### PR TITLE
feat(tools): non-blocking holiday advisory on employee-date writes

### DIFF
--- a/jarvis/tests/test_holiday_advisory.py
+++ b/jarvis/tests/test_holiday_advisory.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools import _holiday_advisory as ha
+
+HL = "JV Holiday Advisory Test"
+NAMED_DATE = "2026-08-15"  # Independence Day (weekly_off = 0)
+WOFF_DATE = "2026-08-16"  # a Sunday (weekly_off = 1)
+PLAIN_DATE = "2026-08-17"  # ordinary working day
+
+
+def _doc(doctype, **fields):
+	return frappe._dict(doctype=doctype, **fields)
+
+
+class TestHolidayAdvisory(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		frappe.set_user("Administrator")
+		if frappe.db.exists("Holiday List", HL):
+			frappe.delete_doc("Holiday List", HL, force=True, ignore_permissions=True)
+		frappe.get_doc(
+			{
+				"doctype": "Holiday List",
+				"holiday_list_name": HL,
+				"from_date": "2026-01-01",
+				"to_date": "2026-12-31",
+				"holidays": [
+					{"holiday_date": NAMED_DATE, "description": "Independence Day", "weekly_off": 0},
+					{"holiday_date": WOFF_DATE, "description": "Sunday", "weekly_off": 1},
+				],
+			}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+
+	def setUp(self):
+		# Every test resolves any employee to the fixture holiday list.
+		self._p = patch.object(ha, "get_holiday_list_for_employee", return_value=HL)
+		self._p.start()
+
+	def tearDown(self):
+		self._p.stop()
+
+	def test_doctype_not_in_map_is_silent(self):
+		self.assertEqual(ha.advisories_for_doc(_doc("Sales Invoice", posting_date=NAMED_DATE)), [])
+
+	def test_named_holiday_single_date_warns(self):
+		out = ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE))
+		self.assertEqual(len(out), 1)
+		self.assertIn("holiday", out[0])
+		self.assertIn("Independence Day", out[0])
+		self.assertIn(NAMED_DATE, out[0])
+
+	def test_weekly_off_is_labelled_distinctly(self):
+		out = ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=WOFF_DATE))
+		self.assertEqual(len(out), 1)
+		self.assertIn("weekly off", out[0])
+
+	def test_ordinary_date_is_silent(self):
+		self.assertEqual(
+			ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=PLAIN_DATE)), []
+		)
+
+	def test_missing_employee_is_silent(self):
+		self.assertEqual(ha.advisories_for_doc(_doc("Attendance", attendance_date=NAMED_DATE)), [])
+
+	def test_range_names_each_holiday_day(self):
+		out = ha.advisories_for_doc(
+			_doc("Leave Application", employee="EMP-1", from_date=NAMED_DATE, to_date=WOFF_DATE)
+		)
+		# both the named holiday and the weekly-off fall in the span
+		self.assertEqual(len(out), 2)
+		self.assertTrue(any("Independence Day" in w for w in out))
+		self.assertTrue(any("weekly off" in w for w in out))
+
+	def test_datetime_field_is_normalised_to_date(self):
+		out = ha.advisories_for_doc(_doc("Employee Checkin", employee="EMP-1", time=f"{NAMED_DATE} 09:30:00"))
+		self.assertEqual(len(out), 1)
+
+	def test_no_holiday_list_is_silent(self):
+		with patch.object(ha, "get_holiday_list_for_employee", return_value=None):
+			self.assertEqual(
+				ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE)), []
+			)
+
+	def test_erpnext_absent_is_silent(self):
+		with patch.object(ha, "get_holiday_list_for_employee", None):
+			self.assertEqual(
+				ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE)), []
+			)
+
+	def test_attach_adds_warnings_only_when_present(self):
+		r = ha.attach({"name": "X"}, _doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE))
+		self.assertIn("warnings", r)
+		self.assertEqual(len(r["warnings"]), 1)
+		r2 = ha.attach({"name": "Y"}, _doc("Attendance", employee="EMP-1", attendance_date=PLAIN_DATE))
+		self.assertNotIn("warnings", r2)
+
+	def test_internal_error_is_swallowed(self):
+		with patch.object(ha, "get_holiday_list_for_employee", side_effect=RuntimeError("boom")):
+			self.assertEqual(
+				ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE)), []
+			)

--- a/jarvis/tests/test_holiday_advisory.py
+++ b/jarvis/tests/test_holiday_advisory.py
@@ -128,6 +128,7 @@ class TestHolidayAdvisory(FrappeTestCase):
 	def test_swallow_preserves_pre_existing_message(self):
 		"""F3: the never-raise swallow must drop only messages THIS call pushed,
 		never a msgprint the successful write itself emitted."""
+		self.addCleanup(setattr, frappe.local, "message_log", [])
 		frappe.local.message_log = [{"message": "the write's own message"}]
 		before = len(frappe.local.message_log)
 		with patch.object(ha, "get_holiday_list_for_employee", side_effect=RuntimeError("boom")):

--- a/jarvis/tests/test_holiday_advisory.py
+++ b/jarvis/tests/test_holiday_advisory.py
@@ -104,3 +104,33 @@ class TestHolidayAdvisory(FrappeTestCase):
 			self.assertEqual(
 				ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE)), []
 			)
+
+	def test_resolver_resolved_as_of_activity_date(self):
+		"""F1: the holiday list is resolved AS OF the activity date (as_on), not
+		today - so a backdated attendance uses the list in effect then, not now."""
+		from frappe.utils import getdate
+
+		with patch.object(ha, "get_holiday_list_for_employee", return_value=HL) as m:
+			ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE))
+		m.assert_called_once_with("EMP-1", raise_exception=False, as_on=getdate(NAMED_DATE))
+
+	def test_attach_survives_non_list_warnings_field(self):
+		"""F2: a curated doctype with a Custom Field named `warnings` puts a
+		non-list value in as_dict(); attach must NOT raise (never break the write)."""
+		doc = _doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE)
+		r = ha.attach({"name": "X", "warnings": None}, doc)
+		self.assertIsInstance(r["warnings"], list)
+		self.assertEqual(len(r["warnings"]), 1)
+		r2 = ha.attach({"name": "Y", "warnings": "a stringy custom field"}, doc)
+		self.assertIsInstance(r2["warnings"], list)
+		self.assertEqual(len(r2["warnings"]), 1)
+
+	def test_swallow_preserves_pre_existing_message(self):
+		"""F3: the never-raise swallow must drop only messages THIS call pushed,
+		never a msgprint the successful write itself emitted."""
+		frappe.local.message_log = [{"message": "the write's own message"}]
+		before = len(frappe.local.message_log)
+		with patch.object(ha, "get_holiday_list_for_employee", side_effect=RuntimeError("boom")):
+			ha.advisories_for_doc(_doc("Attendance", employee="EMP-1", attendance_date=NAMED_DATE))
+		self.assertEqual(len(frappe.local.message_log), before)
+		self.assertTrue(any("the write's own message" in str(m) for m in frappe.local.message_log))

--- a/jarvis/tests/test_holiday_advisory_wiring.py
+++ b/jarvis/tests/test_holiday_advisory_wiring.py
@@ -49,3 +49,46 @@ class TestAdvisoryWiringSingle(FrappeTestCase):
 		):
 			out = update_doc(doctype="Attendance", name="ATT-1", changes={"status": "Present"})
 		self.assertEqual(out.get("warnings"), ["W2"])
+
+	def test_batch_create_attaches_per_record_warnings(self):
+		from jarvis.tools.create_doc import create_doc
+
+		created_docs = [
+			frappe._dict(doctype="Attendance", name="ATT-1"),
+			frappe._dict(doctype="Attendance", name="ATT-2"),
+		]
+		it = iter(created_docs)
+		with (
+			patch("jarvis.tools.create_doc._insert_one", side_effect=lambda dt, v: next(it)),
+			patch("jarvis.tools.create_doc._validate_create_args"),
+			patch.object(ha, "advisories_for_doc", side_effect=[["W-A"], []]),
+		):
+			out = create_doc(
+				docs=[
+					{"doctype": "Attendance", "values": {"employee": "E1"}},
+					{"doctype": "Attendance", "values": {"employee": "E2"}},
+				]
+			)
+		self.assertEqual(out["created"][0].get("warnings"), ["W-A"])
+		self.assertNotIn("warnings", out["created"][1])
+
+	def test_batch_update_aggregates_warnings(self):
+		from jarvis.tools.update_doc import update_doc
+
+		docs = [
+			frappe._dict(doctype="Attendance", name="ATT-1"),
+			frappe._dict(doctype="Attendance", name="ATT-2"),
+		]
+		it = iter(docs)
+		with (
+			patch("jarvis.tools.update_doc._update_one", side_effect=lambda dt, n, c: next(it)),
+			patch.object(ha, "advisories_for_doc", side_effect=[["W-1"], ["W-2"]]),
+		):
+			out = update_doc(
+				doctype="Attendance",
+				updates=[
+					{"name": "ATT-1", "changes": {"status": "Present"}},
+					{"name": "ATT-2", "changes": {"status": "Present"}},
+				],
+			)
+		self.assertEqual(sorted(out.get("warnings", [])), ["W-1", "W-2"])

--- a/jarvis/tests/test_holiday_advisory_wiring.py
+++ b/jarvis/tests/test_holiday_advisory_wiring.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.tools import _holiday_advisory as ha
+from jarvis.tools.create_doc import create_doc
+from jarvis.tools.update_doc import update_doc
+
+
+class TestAdvisoryWiringSingle(FrappeTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def test_create_single_attaches_warnings(self):
+		# Stub the write primitive so we don't need a real Attendance fixture,
+		# and stub the advisory so we assert ONLY the wiring.
+		fake = frappe._dict(doctype="Attendance", employee="EMP-1")
+		fake.as_dict = lambda: {"doctype": "Attendance", "name": "ATT-1"}
+		fake.apply_fieldlevel_read_permissions = lambda: None
+		with (
+			patch("jarvis.tools.create_doc._insert_one", return_value=fake),
+			patch("jarvis.tools.create_doc._validate_create_args"),
+			patch.object(ha, "advisories_for_doc", return_value=["W1"]),
+		):
+			out = create_doc(doctype="Attendance", values={"employee": "EMP-1"})
+		self.assertEqual(out.get("warnings"), ["W1"])
+
+	def test_create_single_no_warning_key_when_empty(self):
+		fake = frappe._dict(doctype="ToDo")
+		fake.as_dict = lambda: {"doctype": "ToDo", "name": "TD-1"}
+		fake.apply_fieldlevel_read_permissions = lambda: None
+		with (
+			patch("jarvis.tools.create_doc._insert_one", return_value=fake),
+			patch("jarvis.tools.create_doc._validate_create_args"),
+			patch.object(ha, "advisories_for_doc", return_value=[]),
+		):
+			out = create_doc(doctype="ToDo", values={"description": "x"})
+		self.assertNotIn("warnings", out)
+
+	def test_update_single_attaches_warnings(self):
+		fake = frappe._dict(doctype="Attendance", employee="EMP-1")
+		fake.as_dict = lambda: {"doctype": "Attendance", "name": "ATT-1"}
+		fake.apply_fieldlevel_read_permissions = lambda: None
+		with (
+			patch("jarvis.tools.update_doc._update_one", return_value=fake),
+			patch("jarvis.tools.update_doc.require_doctype_and_name"),
+			patch.object(ha, "advisories_for_doc", return_value=["W2"]),
+		):
+			out = update_doc(doctype="Attendance", name="ATT-1", changes={"status": "Present"})
+		self.assertEqual(out.get("warnings"), ["W2"])

--- a/jarvis/tools/_holiday_advisory.py
+++ b/jarvis/tools/_holiday_advisory.py
@@ -45,15 +45,13 @@ def _advisory_line(who: str, holiday: dict) -> str:
 
 def advisories_for_doc(doc) -> list[str]:
 	"""Advisory strings for a just-written doc, or [] (never raises)."""
+	mark = len(frappe.local.message_log) if getattr(frappe.local, "message_log", None) else 0
 	try:
 		spec = CURATED_MAP.get(getattr(doc, "doctype", None))
 		if not spec or get_holiday_list_for_employee is None:
 			return []
 		employee = doc.get(spec["employee"])
 		if not employee:
-			return []
-		holiday_list = get_holiday_list_for_employee(employee, raise_exception=False)
-		if not holiday_list:
 			return []
 		who = _who(doc, employee)
 		out: list[str] = []
@@ -65,6 +63,13 @@ def advisories_for_doc(doc) -> list[str]:
 			end = getdate(doc.get(end_field)) if end_field and doc.get(end_field) else start
 			if end < start:
 				start, end = end, start
+			# Resolve the holiday list AS OF the activity date, not today. Lists are
+			# yearly and (under HRMS) assigned per period via Holiday List Assignment,
+			# so a backdated attendance or a mid-year reassignment must use the list
+			# in effect THEN. ERPNext's vanilla resolver accepts and ignores as_on.
+			holiday_list = get_holiday_list_for_employee(employee, raise_exception=False, as_on=start)
+			if not holiday_list:
+				continue
 			holidays = frappe.get_all(
 				"Holiday",
 				filters={"parent": holiday_list, "holiday_date": ("between", [start, end])},
@@ -74,8 +79,12 @@ def advisories_for_doc(doc) -> list[str]:
 			out.extend(_advisory_line(who, h) for h in holidays)
 		return out
 	except Exception:
-		# Advisory must never break a write; swallow and stay silent.
-		frappe.clear_last_message()
+		# Advisory must never break a write. Drop only the messages THIS call pushed
+		# (e.g. a frappe.throw in the swallowed path) back to the pre-call mark, never
+		# the successful write's own msgprints.
+		log = getattr(frappe.local, "message_log", None)
+		if log is not None and len(log) > mark:
+			del log[mark:]
 		return []
 
 
@@ -87,5 +96,13 @@ def attach(result: dict, doc) -> dict:
 	"""
 	advisories = advisories_for_doc(doc)
 	if advisories:
-		result.setdefault("warnings", []).extend(advisories)
+		# Never assume ``warnings`` is absent or a list: a curated doctype could
+		# carry a Custom Field literally named ``warnings`` (its value lands in
+		# ``as_dict()``). setdefault().extend() would then AttributeError and break
+		# the write — the one invariant we must not pierce. Extend a list, else set.
+		existing = result.get("warnings")
+		if isinstance(existing, list):
+			existing.extend(advisories)
+		else:
+			result["warnings"] = advisories
 	return result

--- a/jarvis/tools/_holiday_advisory.py
+++ b/jarvis/tools/_holiday_advisory.py
@@ -14,7 +14,7 @@ import frappe
 from frappe.utils import getdate
 
 try:
-	# The official resolver: Employee.holiday_list, else Department/Company default.
+	# The official resolver: Employee.holiday_list, else the Company default.
 	from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 except ImportError:  # erpnext not installed on this bench -> feature is a no-op
 	get_holiday_list_for_employee = None

--- a/jarvis/tools/_holiday_advisory.py
+++ b/jarvis/tools/_holiday_advisory.py
@@ -1,0 +1,91 @@
+"""Non-blocking holiday advisory for employee-date writes.
+
+When a write touches a curated HR doctype that pairs an Employee with an
+activity date, we look that date up against the employee's holiday list
+(ERPNext resolution: Employee.holiday_list -> Company.default_holiday_list)
+and, if it lands on a holiday or weekly-off, attach a human-readable warning
+to the tool result. It NEVER blocks and NEVER raises into the write path: any
+failure (no erpnext, no holiday list, bad data) returns no advisory.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe.utils import getdate
+
+try:
+	# The official resolver: Employee.holiday_list, else Department/Company default.
+	from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
+except ImportError:  # erpnext not installed on this bench -> feature is a no-op
+	get_holiday_list_for_employee = None
+
+# doctype -> {employee field, list of (start_field, end_field_or_None) spans}.
+# A None end_field means a single date; a pair means an inclusive range. Only
+# doctypes where a date genuinely means "a day this employee is expected to be
+# doing something" — deliberately NOT payroll periods, comp-off (working a
+# holiday is the point), or identity dates (DOB/DOJ/relieving).
+CURATED_MAP: dict[str, dict] = {
+	"Attendance": {"employee": "employee", "spans": [("attendance_date", None)]},
+	"Attendance Request": {"employee": "employee", "spans": [("from_date", "to_date")]},
+	"Employee Checkin": {"employee": "employee", "spans": [("time", None)]},
+	"Shift Assignment": {"employee": "employee", "spans": [("start_date", "end_date")]},
+	"Leave Application": {"employee": "employee", "spans": [("from_date", "to_date")]},
+}
+
+
+def _who(doc, employee: str) -> str:
+	return doc.get("employee_name") or employee
+
+
+def _advisory_line(who: str, holiday: dict) -> str:
+	kind = "weekly off" if holiday.get("weekly_off") else "holiday"
+	desc = holiday.get("description") or kind
+	return f"{who}: {holiday['holiday_date']} is a {kind} ({desc}) on their holiday list."
+
+
+def advisories_for_doc(doc) -> list[str]:
+	"""Advisory strings for a just-written doc, or [] (never raises)."""
+	try:
+		spec = CURATED_MAP.get(getattr(doc, "doctype", None))
+		if not spec or get_holiday_list_for_employee is None:
+			return []
+		employee = doc.get(spec["employee"])
+		if not employee:
+			return []
+		holiday_list = get_holiday_list_for_employee(employee, raise_exception=False)
+		if not holiday_list:
+			return []
+		who = _who(doc, employee)
+		out: list[str] = []
+		for start_field, end_field in spec["spans"]:
+			start_raw = doc.get(start_field)
+			if not start_raw:
+				continue
+			start = getdate(start_raw)
+			end = getdate(doc.get(end_field)) if end_field and doc.get(end_field) else start
+			if end < start:
+				start, end = end, start
+			holidays = frappe.get_all(
+				"Holiday",
+				filters={"parent": holiday_list, "holiday_date": ("between", [start, end])},
+				fields=["holiday_date", "description", "weekly_off"],
+				order_by="holiday_date",
+			)
+			out.extend(_advisory_line(who, h) for h in holidays)
+		return out
+	except Exception:
+		# Advisory must never break a write; swallow and stay silent.
+		frappe.clear_last_message()
+		return []
+
+
+def attach(result: dict, doc) -> dict:
+	"""Append holiday advisories to a write-tool result under ``warnings``.
+
+	Non-mutating on the no-advisory path (no ``warnings`` key added), so a doc
+	dict without holidays is byte-identical to today's output.
+	"""
+	advisories = advisories_for_doc(doc)
+	if advisories:
+		result.setdefault("warnings", []).extend(advisories)
+	return result

--- a/jarvis/tools/create_doc.py
+++ b/jarvis/tools/create_doc.py
@@ -31,6 +31,7 @@ Safety bounds (same shape as update_doc, adapted for create):
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
+from jarvis.tools import _holiday_advisory
 from jarvis.tools._bulk import _MAX_BATCH, run_atomic_batch
 from jarvis.tools._delegate_write_caps import enforce_create
 
@@ -110,7 +111,7 @@ def create_doc(
 	_validate_create_args(doctype, values)
 	doc = _insert_one(doctype, values)
 	doc.apply_fieldlevel_read_permissions()
-	return doc.as_dict()
+	return _holiday_advisory.attach(doc.as_dict(), doc)
 
 
 def _create_batch(docs: list, notes: list | None = None) -> dict:

--- a/jarvis/tools/create_doc.py
+++ b/jarvis/tools/create_doc.py
@@ -134,7 +134,8 @@ def _create_batch(docs: list, notes: list | None = None) -> dict:
 
 	def _do(item: dict) -> dict:
 		doc = _insert_one(item["doctype"], item["values"])
-		return {"doctype": doc.doctype, "name": doc.name}
+		row = {"doctype": doc.doctype, "name": doc.name}
+		return _holiday_advisory.attach(row, doc)
 
 	created = run_atomic_batch(docs, _do, label=lambda d: d.get("doctype"))
 	return {"created": created, "notes": list(notes) if isinstance(notes, list) else []}

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -29,7 +29,7 @@ Safety bounds enforced here (on top of Frappe's standard validation):
 import frappe
 
 from jarvis.exceptions import InvalidArgumentError, PermissionDeniedError
-from jarvis.tools import require_doctype_and_name
+from jarvis.tools import _holiday_advisory, require_doctype_and_name
 from jarvis.tools._bulk import run_atomic_batch
 from jarvis.tools._delegate_write_caps import enforce_update
 
@@ -103,7 +103,7 @@ def update_doc(
 	require_doctype_and_name(doctype, name)
 	doc = _update_one(doctype, name, changes)
 	doc.apply_fieldlevel_read_permissions()
-	return doc.as_dict()
+	return _holiday_advisory.attach(doc.as_dict(), doc)
 
 
 def _update_batch(doctype: str, updates: list) -> dict:

--- a/jarvis/tools/update_doc.py
+++ b/jarvis/tools/update_doc.py
@@ -118,9 +118,15 @@ def _update_batch(doctype: str, updates: list) -> dict:
 		if not isinstance(item, dict) or not item.get("name"):
 			raise InvalidArgumentError(f"updates[{i}] must be a dict with a name + changes")
 
+	warnings: list[str] = []
+
 	def _do(item: dict) -> str:
-		_update_one(doctype, item["name"], item.get("changes"))
+		doc = _update_one(doctype, item["name"], item.get("changes"))
+		warnings.extend(_holiday_advisory.advisories_for_doc(doc))
 		return item["name"]
 
 	updated = run_atomic_batch(updates, _do, label=lambda u: u.get("name"))
-	return {"doctype": doctype, "updated": updated, "count": len(updated)}
+	result = {"doctype": doctype, "updated": updated, "count": len(updated)}
+	if warnings:
+		result["warnings"] = warnings
+	return result


### PR DESCRIPTION
## What

Customer ask: whenever Jarvis touches an employee record on a date-related thing, it should **check that employee's holiday list and warn (never block)**.

When a Jarvis *write* touches a curated HR doctype on an employee's activity date that is a **holiday or weekly-off**, the tool result now carries a non-blocking `warnings` list (e.g. *"Priya: 2026-08-15 is a holiday (Independence Day) on their holiday list."*). Detection is deterministic code — not a persona instruction.

Pairs with `jarvis-persona` PR (a one-line nudge telling the agent to relay `warnings`). **Merge this first / same window.**

## Scope

Curated `doctype → (employee field, date span(s))` map — deliberately tight, so we don't warn on identity dates (DOB/DOJ/relieving), payroll periods, or comp-off (working a holiday is the point):
- **Attendance** (attendance_date), **Attendance Request** (from/to), **Employee Checkin** (time), **Shift Assignment** (start/end), **Leave Application** (from/to).

Warns on **both named holidays and weekly-offs**, labelled distinctly. Ranges name each affected day. Reuses ERPNext's holiday-list resolver (`get_holiday_list_for_employee`), then queries `Holiday` rows for the `weekly_off` flag.

## Guarantees

- **Never blocks, never raises into the write path** — any internal failure returns no advisory.
- **Silent no-op** without erpnext / holiday list / employee, or for any non-curated doctype.
- **Byte-identical output for every non-HR write** — `attach` adds nothing when there are no advisories.

## Surface (no plugin change)

`warnings` rides inside the tool result `data`. Confirmed live on every path: on a direct/auto-apply write it reaches the agent intact; on a gated write the park-time preview carries it to the model *before* confirmation and the human's receipt chip shows it. (Deferred follow-up: the post-confirm continuation text is name-only — a pre-existing limitation, not part of this feature.)

## Review

Cyclic Fable review to green (2 cycles). Cycle 1 found three defects, all fixed + mutation-verified:
- **F1** — the holiday list was resolved as of *today*, not the activity date; a **backdated attendance** (the flagship attendance-regularization case) under HRMS silently checked the wrong year's list. Now `as_on=<activity date>`.
- **F2** — `attach()` could **crash the write** if a doctype had a Custom Field named `warnings`; guarded (piercing the never-break-a-write invariant).
- **F3** — the never-raise handler could swallow the write's *own* message; now truncates only what the advisory pushed.

## Tests

`test_holiday_advisory` **14** + `test_holiday_advisory_wiring` **5**, and the `test_create_doc`/`test_create_docs`/`test_update_doc` regressions green on `jarvis-test.localhost`. Every security/correctness guard mutation-verified.

## Deferred (non-blocking, noted in review)

- Gated-write post-confirm continuation text (name-only) — pre-existing.
- A range straddling a Holiday-List-Assignment boundary resolves against the start-date list (same limitation HRMS's own helpers have; fail-quiet).
- Advisory volume cap for very long spans ("first N + more").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
