### PR TITLE
Resume a failed-payment signup instead of dead-ending on the dedup error

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -211,6 +211,18 @@ def signup(
 	return _post_guest(path=_m("billing.signup.signup"), body=body)
 
 
+def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
+	"""Authenticated failed-payment resume: re-issues checkout handles for the
+	caller's own Pending Payment signup, optionally on a different plan/provider.
+	Returns the same checkout-fields shape as signup's sync path (no credentials
+	— the bench already holds them; that's how this call authenticates).
+	Raises AdminValidationError when there is nothing to resume (409)."""
+	body: dict = {"plan": plan}
+	if provider:
+		body["provider"] = provider
+	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
+
+
 def get_signup_payment_state() -> dict:
 	"""Authenticated poll. Returns one of:
 	    {pending_verification: True}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -340,7 +340,13 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	"""
 	require_jarvis_admin()
 	_require_admin_url()
-	data = _surface(admin_client.signup, email, company, plan, provider=provider)
+	try:
+		data = _surface(admin_client.signup, email, company, plan, provider=provider)
+	except frappe.ValidationError as e:
+		resumed = _try_resume_pending_signup(e, email, plan, provider)
+		if resumed is None:
+			raise
+		data = resumed
 	# Persist whatever credentials the response carries. The guard also fires
 	# on ``customer`` so the OAuth grant username is stored even if a future
 	# admin response shape omits api_key/api_secret. write_connection skips
@@ -363,6 +369,31 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	# be the SM site owner — a plain Jarvis User is rejected before reaching here.
 	grant_onboarding_admin()
 	return data
+
+
+def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None) -> dict | None:
+	"""Failed-payment retry: when guest signup is rejected as a duplicate and
+	this bench already holds credentials for THAT email (persisted by the first
+	attempt), resume the pending signup through admin's authenticated
+	``resume_pending_signup`` — same plan or a newly chosen one — instead of
+	dead-ending the wizard on "already registered or pending".
+
+	Returns admin's checkout payload, or None when the fallback doesn't apply
+	(different email, no stored creds, or a non-duplicate error) so the caller
+	re-raises the original error. A resume that itself fails (e.g. the customer
+	is Active — a real duplicate) also returns None: the original duplicate
+	error is the honest message for that case."""
+	if "already registered or pending" not in str(err):
+		return None
+	settings = frappe.get_single("Jarvis Settings")
+	stored_email = (settings.get("jarvis_admin_customer_email") or "").strip().lower()
+	has_creds = bool(settings.get_password("jarvis_admin_api_key", raise_exception=False))
+	if not has_creds or stored_email != (email or "").strip().lower():
+		return None
+	try:
+		return admin_client.resume_pending_signup(plan, provider=provider)
+	except Exception:
+		return None
 
 
 @frappe.whitelist()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -393,6 +393,13 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 	try:
 		return admin_client.resume_pending_signup(plan, provider=provider)
 	except Exception:
+		# Deliberate fallthrough to the original duplicate error (a rejected
+		# resume usually means a REAL duplicate), but leave a trace so a broken
+		# resume path is debuggable rather than invisible.
+		frappe.log_error(
+			title="signup resume fallback failed (showing original duplicate error)",
+			message=frappe.get_traceback(),
+		)
 		return None
 
 

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -820,3 +820,70 @@ class TestWorkspaceReset(FrappeTestCase):
 			out = onboarding.workspace_reset_state()
 		self.assertTrue(out["ready"])
 		self.assertEqual(frappe.get_single("Jarvis Settings").last_sync_status, "ok (workspace reset)")
+
+
+class TestSignupResumeFallback(FrappeTestCase):
+	"""Failed-payment retry: the dedup rejection falls back to the authenticated
+	resume only when this bench holds creds for that same email."""
+
+	_DUP = "An account with this email is already registered or pending."
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		s = frappe.get_single("Jarvis Settings")
+		_set_token("tok")
+		s.db_set("jarvis_admin_url", "https://fleet.example.test")
+		s.db_set("jarvis_admin_customer_email", "resume-me@example.com")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
+
+	def _signup_raises(self, msg):
+		from jarvis.exceptions import AdminValidationError
+
+		return patch("jarvis.onboarding.admin_client.signup", side_effect=AdminValidationError(msg))
+
+	def test_dedup_with_matching_creds_resumes(self):
+		with (
+			self._signup_raises(self._DUP),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				return_value={"payment_provider": "razorpay", "razorpay_order_id": "order_R2"},
+			) as resume,
+		):
+			out = onboarding.start_signup("Resume-Me@example.com ", "Co", "some-plan")
+		resume.assert_called_once_with("some-plan", provider=None)
+		self.assertEqual(out["razorpay_order_id"], "order_R2")
+
+	def test_dedup_with_different_email_reraises(self):
+		with (
+			self._signup_raises(self._DUP),
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("someone-else@example.com", "Co", "some-plan")
+		resume.assert_not_called()
+
+	def test_non_dedup_error_reraises(self):
+		with (
+			self._signup_raises("Unsupported payment provider."),
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError),
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_not_called()
+
+	def test_failed_resume_reraises_original_duplicate(self):
+		from jarvis.exceptions import AdminValidationError
+
+		with (
+			self._signup_raises(self._DUP),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				side_effect=AdminValidationError("signup is not awaiting payment; nothing to resume"),
+			),
+			self.assertRaises(frappe.ValidationError) as ctx,
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		self.assertIn("already registered", str(ctx.exception))


### PR DESCRIPTION
Scenario: full client flush → fresh signup → **payment fails** → the customer retries the wizard → guest `signup()` hits admin's dedup guard, which counts their **own Pending Payment row** as a duplicate → onboarding dead-ends on *"already registered or pending"* until an operator purges the email.

`start_signup` now falls back to admin's **authenticated** `resume_pending_signup` (companion PR: Aerele-RnD/jarvis-admin-v2#129) — but only under strict conditions:

- the failure is the duplicate-email rejection, **and**
- this bench already holds api credentials for **exactly that email** (persisted by the first signup attempt — those creds are how the resume authenticates; ownership proven, nothing re-disclosed).

The retry may pick a **different plan/provider** — the resume re-points the pending subscription and returns fresh checkout handles in the same response shape, so the wizard proceeds to Pay with no SPA changes. Every other failure — different email, no stored creds, or the resume itself rejected (a *real* duplicate: the customer is Active) — re-raises the original error unchanged, so the guest dedup guard's security posture is untouched.

Tests: `test_onboarding_sync` **41/41** (4 new: resume on match, different-email re-raise, non-dedup re-raise, failed-resume re-raises the original duplicate).