### PR TITLE
Hard-gate a never-onboarded workspace back to the wizard

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -46,11 +46,17 @@ export async function isWorkspaceReady() {
 // (llm_direct_synced_at never stamped). Same permanence guarantee — once a
 // direct config confirms once, the marker is permanent — so it belongs here
 // too, never on the degraded-banner path.
+// "llm_setup" is the server-decided hard variant of llm_credentials: creds
+// missing AND nothing ever synced AND the subscription never went Active — a
+// half-finished signup (e.g. failed payment), not an established workspace.
+// The soft/hard split lives server-side (_llm_missing_verdict) because only
+// admin knows the subscription state.
 const NOT_ONBOARDED_REASONS = new Set([
 	"signup",
 	"selfhost_connection",
 	"llm_pool_provisioning",
 	"llm_provisioning",
+	"llm_setup",
 ]);
 
 // True only when the workspace has NOT completed onboarding at all — the single

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -251,9 +251,12 @@ def _llm_missing_verdict(settings) -> dict:
 		sub_status = (admin_client.get_connection(timeout_s=8) or {}).get("subscription_status") or ""
 	except Exception:
 		sub_status = ""
-	if not sub_status or sub_status == "Active":
-		return {"ready": False, "reason": "llm_credentials"}
-	return {"ready": False, "reason": "llm_setup"}
+	# Hard-gate ONLY the never-paid shapes. Active is established (the revoke
+	# case); Suspended/Cancelled stay SOFT too — the renew/suspension banner
+	# path owns them, and the wizard would dead-end them at the dedup guard.
+	if sub_status in ("none", "Pending Payment", "Pending Verification"):
+		return {"ready": False, "reason": "llm_setup"}
+	return {"ready": False, "reason": "llm_credentials"}
 
 
 @frappe.whitelist()

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -120,7 +120,12 @@ def is_ready_for_chat() -> dict:
 	- ``"llm_credentials"`` - signup done, but LLM creds for the active
 	  auth mode are missing. api_key mode needs llm_api_key + llm_provider +
 	  llm_model; subscription / oauth modes need llm_oauth_connected_at
-	  (the timestamp set when the oauth grant completes).
+	  (the timestamp set when the oauth grant completes). Soft: banner, not
+	  the wizard gate — the workspace was established and stays reachable.
+	- ``"llm_setup"`` - creds missing AND this workspace never completed
+	  onboarding: no LLM config ever confirmed and the subscription never
+	  went Active (e.g. a failed-payment signup). Hard: routes back to the
+	  wizard — chat cannot work and there is no history to protect.
 	- ``"llm_pool_provisioning"`` - a pool is configured (pool mode) but
 	  no sync has ever applied it to the container (first sync pending or
 	  failed).
@@ -190,7 +195,7 @@ def is_ready_for_chat() -> dict:
 		provider = (getattr(settings, "llm_provider", "") or "").strip()
 		model = (getattr(settings, "llm_model", "") or "").strip()
 		if not (llm_key and provider and model):
-			return {"ready": False, "reason": "llm_credentials"}
+			return _llm_missing_verdict(settings)
 		# Local key/provider/model presence is config INTENT (committed at save,
 		# before the async admin apply runs) — it does NOT prove the container ever
 		# received the creds. Gate on evidence of a CONFIRMED apply instead
@@ -208,12 +213,47 @@ def is_ready_for_chat() -> dict:
 		# set (read-only) when the oauth grant completes and the admin
 		# pushes the auth-profile blob to the container.
 		if not getattr(settings, "llm_oauth_connected_at", None):
-			return {"ready": False, "reason": "llm_credentials"}
+			return _llm_missing_verdict(settings)
 	else:
 		# Unknown auth_mode - treat as misconfigured; the wizard owns it.
 		return {"ready": False, "reason": "llm_credentials"}
 
 	return _admin_chat_gate()
+
+
+def _llm_missing_verdict(settings) -> dict:
+	"""LLM creds absent for the active mode: wizard or banner?
+
+	An ESTABLISHED workspace gets the soft ``llm_credentials`` banner — any LLM
+	config ever confirmed (a synced/connected marker survives creds expiry), or
+	an Active subscription (the workspace-reset "disconnect AI model
+	connections" option clears every marker; its owner reconnects via
+	Settings -> AI models, and the wizard would dead-end them at signup's
+	duplicate guard). Never lock such a workspace away from chat + history over
+	a recoverable credential problem.
+
+	A workspace that has NEVER had a working LLM and whose subscription never
+	went Active is still MID-ONBOARDING (e.g. a failed-payment signup, refresh):
+	``llm_setup`` hard-gates back to the wizard — chat cannot work there, and
+	the half-created signup resumes via start_signup's authenticated fallback.
+	Subscription state comes from admin; fail OPEN to the soft banner when it
+	is unknown/unreachable."""
+	never_synced = not (
+		getattr(settings, "llm_direct_synced_at", None)
+		or getattr(settings, "llm_pool_synced_at", None)
+		or getattr(settings, "llm_oauth_connected_at", None)
+	)
+	if not never_synced:
+		return {"ready": False, "reason": "llm_credentials"}
+	try:
+		from jarvis import admin_client
+
+		sub_status = (admin_client.get_connection(timeout_s=8) or {}).get("subscription_status") or ""
+	except Exception:
+		sub_status = ""
+	if not sub_status or sub_status == "Active":
+		return {"ready": False, "reason": "llm_credentials"}
+	return {"ready": False, "reason": "llm_setup"}
 
 
 @frappe.whitelist()

--- a/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/panel_readiness.mjs
@@ -28,9 +28,13 @@
 // Whichever way it is fixed, fix frontend/src/onboarding/readiness.js in the
 // same change: divergence between these two files is exactly the bug this
 // module exists to close.
+// "llm_setup" is the server-decided HARD variant of llm_credentials (creds
+// missing + nothing ever synced + subscription never Active): a half-finished
+// signup, where chat cannot work at all.
 const NOT_ONBOARDED_REASONS = new Set([
   "signup",
   "selfhost_connection",
+  "llm_setup",
   "llm_pool_provisioning",
   "llm_provisioning",
 ]);

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -332,6 +332,12 @@ class TestLlmMissingVerdict(FrappeTestCase):
 		out, _ = self._verdict(self._S(), conn={"subscription_status": "Active"})
 		self.assertEqual(out["reason"], "llm_credentials")
 
+	def test_suspended_sub_stays_soft(self):
+		# Suspended is an ESTABLISHED account — the renew banner owns it; the
+		# wizard would dead-end it at signup's duplicate guard.
+		out, _ = self._verdict(self._S(), conn={"subscription_status": "Suspended"})
+		self.assertEqual(out["reason"], "llm_credentials")
+
 	def test_admin_unreachable_fails_open_to_soft(self):
 		out, _ = self._verdict(self._S(), raises=RuntimeError("admin down"))
 		self.assertEqual(out["reason"], "llm_credentials")

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -296,3 +296,46 @@ class TestAdminChatGate(FrappeTestCase):
 		with patch.object(admin_client, "get_connection", return_value={"chat_readiness": "Provisioning"}):
 			account._admin_chat_gate()
 		self.assertIsNone(frappe.cache().get_value(account._CHAT_GATE_CACHE_KEY))
+
+
+class TestLlmMissingVerdict(FrappeTestCase):
+	"""_llm_missing_verdict — the wizard-vs-banner split when LLM creds are
+	absent. Only a never-synced workspace whose subscription never went Active
+	hard-gates back to the wizard; everything else (and every failure mode)
+	stays on the soft banner."""
+
+	class _S:
+		llm_direct_synced_at = None
+		llm_pool_synced_at = None
+		llm_oauth_connected_at = None
+
+	def _verdict(self, settings, conn=None, raises=None):
+		kw = {"side_effect": raises} if raises else {"return_value": conn or {}}
+		with patch.object(admin_client, "get_connection", **kw) as gc:
+			out = account._llm_missing_verdict(settings)
+		return out, gc
+
+	def test_ever_synced_stays_soft_without_admin_call(self):
+		s = self._S()
+		s.llm_pool_synced_at = "2026-01-01 00:00:00"
+		out, gc = self._verdict(s)
+		self.assertEqual(out["reason"], "llm_credentials")
+		gc.assert_not_called()
+
+	def test_never_synced_pending_payment_hard_gates(self):
+		out, _ = self._verdict(self._S(), conn={"subscription_status": "Pending Payment"})
+		self.assertEqual(out["reason"], "llm_setup")
+
+	def test_never_synced_active_sub_stays_soft(self):
+		# The workspace-reset revoke option clears every marker on an Active
+		# customer — they reconnect via Settings, never the wizard.
+		out, _ = self._verdict(self._S(), conn={"subscription_status": "Active"})
+		self.assertEqual(out["reason"], "llm_credentials")
+
+	def test_admin_unreachable_fails_open_to_soft(self):
+		out, _ = self._verdict(self._S(), raises=RuntimeError("admin down"))
+		self.assertEqual(out["reason"], "llm_credentials")
+
+	def test_unknown_subscription_status_fails_open_to_soft(self):
+		out, _ = self._verdict(self._S(), conn={})
+		self.assertEqual(out["reason"], "llm_credentials")


### PR DESCRIPTION
Second half of the failed-payment-signup scenario (first half: #511 + jarvis-admin-v2#129): after a signup whose payment failed, a refresh landed the customer in **chat** — missing LLM creds read as `llm_credentials`, which is deliberately a *soft* banner so an established workspace with expired/rotated creds is never locked away from its history. But a workspace that never completed onboarding has no history to protect and a chat that cannot work.

New server-decided split in `account._llm_missing_verdict`:

- creds missing **and** no LLM config ever confirmed (no `llm_direct_synced_at`, no `llm_pool_synced_at`, no `llm_oauth_connected_at`) **and** the subscription never went Active → new hard reason **`llm_setup`**, added to `readiness.js` `NOT_ONBOARDED_REASONS` so the wizard gate owns it. From there the half-created signup resumes cleanly via #511's authenticated fallback.
- An **Active** subscription stays soft even with every marker cleared — that's exactly the workspace-reset *"disconnect AI model connections"* option, whose owner reconnects via Settings → AI models (the wizard would dead-end them at the signup dedup).
- Fails **open** to the soft banner when admin is unreachable or the status is unknown — same posture as the rest of readiness.

The split lives server-side because only admin knows the subscription state; the admin round-trip happens only in the narrow creds-missing + never-synced branch.

Tests: `test_account` **24/24** (5 new: ever-synced short-circuits without an admin call, Pending Payment hard-gates, Active stays soft, unreachable/unknown fail open).