### PR TITLE
feat(chat): dual persona (Jarvis/Jara) + composer model/effort & persona pickers

### DIFF
--- a/frontend/src/components/chat/CheckMark.vue
+++ b/frontend/src/components/chat/CheckMark.vue
@@ -1,0 +1,26 @@
+<template>
+	<!-- Selected-row check glyph, shared by the composer pills so the SVG is not
+	     forked (was an inline template SVG in PersonaPill and an h() render in
+	     ModelEffortPicker). Colour follows the surrounding text. -->
+	<svg
+		class="jv-check"
+		width="15"
+		height="15"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2.2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		aria-hidden="true"
+	>
+		<path d="M20 6 9 17l-5-5" />
+	</svg>
+</template>
+
+<style scoped>
+.jv-check {
+	flex: none;
+	color: var(--text);
+}
+</style>

--- a/frontend/src/components/chat/Composer.vue
+++ b/frontend/src/components/chat/Composer.vue
@@ -227,62 +227,66 @@
 					</svg>
 				</button>
 			</slot>
-			<span
-				style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px"
-				>{{ busy ? "Stop" : "Enter ↵" }}</span
-			>
-			<button
-				v-if="busy"
-				@click="emit('stop')"
-				title="Stop generating"
-				style="
-					width: 32px;
-					height: 32px;
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					background: var(--cta);
-					border: none;
-					border-radius: 8px;
-					cursor: pointer;
-				"
-			>
-				<svg width="13" height="13" viewBox="0 0 24 24" fill="var(--cta-fg)">
-					<rect x="6" y="6" width="12" height="12" rx="2.5" />
-				</svg>
-			</button>
-			<button
-				v-else
-				class="jv-sendbtn"
-				:class="{ ready: sendable }"
-				@click="emit('submit')"
-				:disabled="!sendable"
-				:title="sendTitle || null"
-				:style="{
-					width: '32px',
-					height: '32px',
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					background: sendable ? 'var(--cta)' : 'var(--surface-3)',
-					border: 'none',
-					borderRadius: '8px',
-					cursor: sendable ? 'pointer' : 'default',
-				}"
-			>
-				<svg
-					width="16"
-					height="16"
-					viewBox="0 0 24 24"
-					fill="none"
-					:stroke="sendable ? 'var(--cta-fg)' : 'var(--text-3)'"
-					stroke-width="2.1"
-					stroke-linecap="round"
-					stroke-linejoin="round"
+			<div style="margin-left: auto; display: flex; align-items: center; gap: 6px">
+				<!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
+				     between the left cluster and the Enter hint + send button. -->
+				<slot name="right-toolbar" />
+				<span style="font-size: 11px; color: var(--text-3); margin-right: 2px">{{
+					busy ? "Stop" : "Enter ↵"
+				}}</span>
+				<button
+					v-if="busy"
+					@click="emit('stop')"
+					title="Stop generating"
+					style="
+						width: 32px;
+						height: 32px;
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						background: var(--cta);
+						border: none;
+						border-radius: 8px;
+						cursor: pointer;
+					"
 				>
-					<path d="M12 19V5M5 12l7-7 7 7" />
-				</svg>
-			</button>
+					<svg width="13" height="13" viewBox="0 0 24 24" fill="var(--cta-fg)">
+						<rect x="6" y="6" width="12" height="12" rx="2.5" />
+					</svg>
+				</button>
+				<button
+					v-else
+					class="jv-sendbtn"
+					:class="{ ready: sendable }"
+					@click="emit('submit')"
+					:disabled="!sendable"
+					:title="sendTitle || null"
+					:style="{
+						width: '32px',
+						height: '32px',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						background: sendable ? 'var(--cta)' : 'var(--surface-3)',
+						border: 'none',
+						borderRadius: '8px',
+						cursor: sendable ? 'pointer' : 'default',
+					}"
+				>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						:stroke="sendable ? 'var(--cta-fg)' : 'var(--text-3)'"
+						stroke-width="2.1"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M12 19V5M5 12l7-7 7 7" />
+					</svg>
+				</button>
+			</div>
 		</div>
 	</div>
 	<div

--- a/frontend/src/components/chat/ModelEffortPicker.vue
+++ b/frontend/src/components/chat/ModelEffortPicker.vue
@@ -1,0 +1,399 @@
+<template>
+	<div ref="rootRef" class="mep">
+		<!-- trigger pill: sits in the composer's bottom-left toolbar -->
+		<button
+			ref="triggerRef"
+			class="mep-pill"
+			type="button"
+			:aria-expanded="open"
+			title="Model and effort"
+			@click="open = !open"
+		>
+			<svg
+				width="13"
+				height="13"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.7"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<ellipse cx="12" cy="5" rx="9" ry="3" />
+				<path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5" />
+				<path d="M3 12c0 1.7 4 3 9 3s9-1.3 9-3" />
+			</svg>
+			<span class="mep-model">{{ pillModel }}</span>
+			<!-- kept in layout (visibility, not v-if) so toggling thinkingOverride
+			     does not shift the Enter hint / Send button beside this pill -->
+			<span class="mep-dot" :class="{ 'mep-hide': !thinkingOverride }">·</span>
+			<span class="mep-effort" :class="{ 'mep-hide': !thinkingOverride }">{{
+				effortLabel
+			}}</span>
+			<svg
+				class="mep-caret"
+				width="12"
+				height="12"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.9"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="m6 9 6 6 6-6" />
+			</svg>
+		</button>
+
+		<!-- dropdown: opens UPWARD (the pill lives at the bottom of the screen) -->
+		<div v-if="open" class="mep-menu" role="menu">
+			<!-- models -->
+			<template v-for="(g, gi) in modelsByProvider" :key="g.provider">
+				<div v-if="showProviders" class="mep-head">{{ g.provider }}</div>
+				<button
+					v-if="gi === 0"
+					class="mep-item"
+					role="menuitemradio"
+					:aria-checked="!modelOverride"
+					@click="onModel('')"
+				>
+					<span class="mep-item-body">
+						<span class="mep-name">Auto</span>
+						<span class="mep-desc"
+							>Let {{ assistantName }} choose · {{ defaultModel || "default" }}</span
+						>
+					</span>
+					<CheckMark v-if="!modelOverride" />
+				</button>
+				<button
+					v-for="r in g.models"
+					:key="g.provider + '/' + r.model"
+					class="mep-item"
+					role="menuitemradio"
+					:aria-checked="r.model === modelOverride"
+					@click="onModel(r.model)"
+				>
+					<span class="mep-item-body">
+						<span class="mep-name">{{ r.model }}</span>
+						<span v-if="r.tier" class="mep-desc">{{ r.tier }}</span>
+					</span>
+					<CheckMark v-if="r.model === modelOverride" />
+				</button>
+			</template>
+
+			<div class="mep-div" />
+
+			<!-- effort → side flyout (wrapper keeps the flyout a SIBLING of the row
+			     button, never nested inside it — interactive-in-button is invalid) -->
+			<div class="mep-sub" @mouseenter="cancelEffortClose" @mouseleave="scheduleEffortClose">
+				<button
+					class="mep-item"
+					:class="{ open: effortOpen }"
+					aria-haspopup="menu"
+					:aria-expanded="effortOpen"
+					@click="effortOpen = !effortOpen"
+					@mouseenter="effortOpen = true"
+				>
+					<span class="mep-item-body"><span class="mep-name">Effort</span></span>
+					<span class="mep-val">{{ effortLabel }}</span>
+					<svg
+						width="13"
+						height="13"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.9"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="m9 18 6-6-6-6" />
+					</svg>
+				</button>
+
+				<div v-if="effortOpen" class="mep-flyout">
+					<div class="mep-fly-head">
+						Higher effort means more thorough responses, but takes longer and uses your
+						limits faster.
+					</div>
+					<button
+						class="mep-item"
+						role="menuitemradio"
+						:aria-checked="!thinkingOverride"
+						@click="onEffort('')"
+					>
+						<span class="mep-item-body"><span class="mep-name">Auto</span></span>
+						<span class="mep-tag">Default</span>
+						<CheckMark v-if="!thinkingOverride" />
+					</button>
+					<button
+						v-for="lvl in thinkingLevels"
+						:key="lvl"
+						class="mep-item"
+						role="menuitemradio"
+						:aria-checked="lvl === thinkingOverride"
+						@click="onEffort(lvl)"
+					>
+						<span class="mep-item-body"
+							><span class="mep-name mep-cap">{{ lvl }}</span></span
+						>
+						<CheckMark v-if="lvl === thinkingOverride" />
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+// Model + effort picker for the composer (Claude-web style): a pill in the
+// input's bottom-left toolbar that opens UPWARD into a model list plus an
+// "Effort" side-flyout. Presentational + self-managed open state only — the
+// host (ChatView) owns the data and the persistence, passed via props and
+// select-model / select-thinking emits (mirrors how <Composer> was extracted).
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { agentName } from "@/branding";
+import { useDismissable } from "@/composables/useDismissable";
+import CheckMark from "@/components/chat/CheckMark.vue";
+
+const props = defineProps({
+	modelOverride: { type: String, default: "" },
+	defaultModel: { type: String, default: "" },
+	thinkingOverride: { type: String, default: "" },
+	thinkingLevels: { type: Array, default: () => ["low", "medium", "high"] },
+	modelsByProvider: { type: Array, default: () => [] },
+	showProviders: { type: Boolean, default: false },
+});
+const emit = defineEmits(["select-model", "select-thinking"]);
+
+const assistantName = agentName;
+const open = ref(false);
+const effortOpen = ref(false);
+const rootRef = ref(null);
+const triggerRef = ref(null);
+
+const pillModel = computed(() => props.modelOverride || props.defaultModel || "Auto");
+const effortLabel = computed(() => {
+	const t = props.thinkingOverride;
+	return t ? t.charAt(0).toUpperCase() + t.slice(1) : "Auto";
+});
+
+function onModel(m) {
+	emit("select-model", m);
+	close();
+	triggerRef.value?.focus();
+}
+function onEffort(level) {
+	emit("select-thinking", level);
+	close();
+	triggerRef.value?.focus();
+}
+function close() {
+	open.value = false;
+	effortOpen.value = false;
+	cancelEffortClose();
+}
+
+// The 8px gap between the "Effort" row and its flyout (.mep-flyout, positioned
+// to the side) is empty space outside .mep-sub's own box, so crossing it fired
+// mouseleave and closed the flyout before a deliberate hover-then-click could
+// ever land. A short close delay, cancelled on re-entry (the flyout re-enters
+// .mep-sub too, since it is nested inside it), gives the pointer time to
+// travel across.
+let effortCloseTimer = null;
+function scheduleEffortClose() {
+	cancelEffortClose();
+	effortCloseTimer = setTimeout(() => {
+		effortOpen.value = false;
+		effortCloseTimer = null;
+	}, 180);
+}
+function cancelEffortClose() {
+	if (effortCloseTimer) {
+		clearTimeout(effortCloseTimer);
+		effortCloseTimer = null;
+	}
+}
+onBeforeUnmount(cancelEffortClose);
+
+// Outside-click / Escape dismissal via the shared composable; `close()` also
+// collapses the effort flyout. The extra watch covers the pill-toggle path
+// (open flipped false without going through close()).
+useDismissable(rootRef, open, close, triggerRef);
+watch(open, (isOpen) => {
+	if (!isOpen) {
+		effortOpen.value = false;
+		cancelEffortClose();
+	}
+});
+</script>
+
+<style scoped>
+.mep {
+	position: relative;
+	display: inline-flex;
+}
+
+/* ---- trigger pill (matches the composer's neutral chrome) ---- */
+.mep-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 30px;
+	padding: 0 10px;
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	cursor: pointer;
+	color: var(--text-2);
+	font-family: inherit;
+	font-size: 12px;
+	font-weight: 500;
+	transition: background-color 0.12s, border-color 0.12s;
+}
+.mep-pill:hover {
+	background: var(--surface-2);
+}
+.mep-pill:focus-visible {
+	outline: 2px solid var(--text);
+	outline-offset: 2px;
+}
+.mep-model {
+	max-width: 22ch;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.mep-dot {
+	color: var(--text-3);
+}
+.mep-effort {
+	color: var(--text-3);
+	font-weight: 450;
+}
+.mep-hide {
+	visibility: hidden;
+}
+.mep-caret {
+	color: var(--text-3);
+	margin-left: 1px;
+}
+
+/* ---- dropdown, opening upward ---- */
+.mep-menu {
+	position: absolute;
+	bottom: calc(100% + 8px);
+	right: 0;
+	min-width: 250px;
+	max-width: 320px;
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 12px;
+	box-shadow: 0 12px 34px rgba(20, 20, 30, 0.18);
+	padding: 5px;
+	z-index: 60;
+}
+.mep-head {
+	padding: 6px 9px 4px;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--text-3);
+}
+.mep-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 8px 9px;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--text);
+	font-family: inherit;
+	font-size: 13px;
+	text-align: left;
+	cursor: pointer;
+}
+.mep-item:hover,
+.mep-item.open {
+	background: var(--surface-1);
+}
+.mep-item-body {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+.mep-name {
+	font-weight: 500;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.mep-cap {
+	text-transform: capitalize;
+}
+.mep-desc {
+	font-size: 11.5px;
+	font-weight: 450;
+	color: var(--text-3);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.mep-div {
+	height: 1px;
+	background: var(--border);
+	margin: 5px 4px;
+}
+
+/* ---- effort submenu row + flyout ---- */
+.mep-sub {
+	position: relative;
+}
+.mep-val {
+	font-size: 12px;
+	color: var(--text-3);
+}
+.mep-flyout {
+	position: absolute;
+	right: calc(100% + 8px);
+	bottom: -6px;
+	width: 232px;
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 12px;
+	box-shadow: 0 12px 34px rgba(20, 20, 30, 0.18);
+	padding: 5px;
+	cursor: default;
+}
+.mep-fly-head {
+	padding: 8px 9px 10px;
+	font-size: 11.5px;
+	line-height: 1.4;
+	color: var(--text-3);
+}
+.mep-tag {
+	font-size: 10px;
+	font-weight: 600;
+	color: var(--text-3);
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 5px;
+	padding: 1px 5px;
+}
+
+@media (max-width: 560px) {
+	/* no room for a side flyout on narrow screens — drop it below the row */
+	.mep-flyout {
+		left: 0;
+		right: 0;
+		bottom: auto;
+		top: calc(100% + 4px);
+		width: auto;
+	}
+}
+</style>

--- a/frontend/src/components/chat/ModelEffortPicker.vue
+++ b/frontend/src/components/chat/ModelEffortPicker.vue
@@ -86,12 +86,19 @@
 			<!-- effort → side flyout (wrapper keeps the flyout a SIBLING of the row
 			     button, never nested inside it — interactive-in-button is invalid) -->
 			<div class="mep-sub" @mouseenter="cancelEffortClose" @mouseleave="scheduleEffortClose">
+				<!-- click OPENS, it does not toggle. For a mouse user the pointer order
+				     is mouseenter (opens) then click, so a toggling click would close
+				     what the hover just opened and the flyout could never open by
+				     click. Both intents here are "open"; closing is mouseleave (the
+				     .mep-sub delay), outside-click / Escape (useDismissable), or
+				     picking a level. Keyboard users open with Enter and close with
+				     Escape. -->
 				<button
 					class="mep-item"
 					:class="{ open: effortOpen }"
 					aria-haspopup="menu"
 					:aria-expanded="effortOpen"
-					@click="effortOpen = !effortOpen"
+					@click="effortOpen = true"
 					@mouseenter="effortOpen = true"
 				>
 					<span class="mep-item-body"><span class="mep-name">Effort</span></span>

--- a/frontend/src/components/chat/PersonaPill.vue
+++ b/frontend/src/components/chat/PersonaPill.vue
@@ -1,0 +1,254 @@
+<template>
+	<div ref="rootRef" class="pep">
+		<!-- trigger pill: sits in the composer toolbar, next to the model pill -->
+		<button
+			ref="triggerRef"
+			class="pep-pill"
+			type="button"
+			:aria-expanded="open"
+			:title="`Persona: ${persona}`"
+			@click="open = !open"
+		>
+			<span class="pep-orb sm" :class="persona.toLowerCase()" aria-hidden="true">
+				<JarvisMark v-if="persona === 'Jarvis'" :size="18" :radius="9" />
+				<svg v-else viewBox="0 0 24 24" fill="#fff">
+					<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+				</svg>
+			</span>
+			<span class="pep-name">{{ persona }}</span>
+			<svg
+				class="pep-caret"
+				width="12"
+				height="12"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.9"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="m6 9 6 6 6-6" />
+			</svg>
+		</button>
+
+		<!-- dropdown, opening UPWARD (matches the model picker) -->
+		<div v-if="open" class="pep-menu" role="menu">
+			<button
+				v-for="opt in options"
+				:key="opt.value"
+				class="pep-item"
+				role="menuitemradio"
+				:aria-checked="persona === opt.value"
+				@click="pick(opt.value)"
+			>
+				<span class="pep-orb" :class="opt.value.toLowerCase()" aria-hidden="true">
+					<JarvisMark v-if="opt.value === 'Jarvis'" :size="24" :radius="12" />
+					<svg v-else viewBox="0 0 24 24" fill="#fff">
+						<path
+							d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z"
+						/>
+					</svg>
+				</span>
+				<span class="pep-body">
+					<span class="pep-item-name">{{ opt.name }}</span>
+					<span class="pep-desc">{{ opt.desc }}</span>
+				</span>
+				<CheckMark v-if="persona === opt.value" />
+			</button>
+			<div class="pep-note">
+				Persona is voice only. It applies to every chat and device, and takes effect from
+				the next message.
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup>
+// Persona picker for the composer — same interaction as the model pill
+// (ModelEffortPicker): a pill in the input toolbar opening a compact upward
+// dropdown of the two personas, each with its living mark. Tone only, never
+// tools or permissions. Reads/writes the shell store (roams to the server).
+import { computed, ref } from "vue";
+import { useShellStore } from "@/stores/shell";
+import { useDismissable } from "@/composables/useDismissable";
+import CheckMark from "@/components/chat/CheckMark.vue";
+import JarvisMark from "@/components/JarvisMark.vue";
+
+const store = useShellStore();
+const open = ref(false);
+const rootRef = ref(null);
+const triggerRef = ref(null);
+
+const persona = computed(() => store.preferredPersona);
+const options = [
+	{ value: "Jarvis", name: "Jarvis", desc: "steady · direct" },
+	{ value: "Jara", name: "Jara", desc: "calm · warm" },
+];
+
+function pick(v) {
+	store.setPreferredPersona(v);
+	open.value = false;
+	triggerRef.value?.focus();
+}
+useDismissable(rootRef, open, undefined, triggerRef);
+</script>
+
+<style scoped>
+.pep {
+	position: relative;
+	display: inline-flex;
+}
+
+/* ---- trigger pill ---- */
+.pep-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	height: 30px;
+	padding: 0 11px 0 8px;
+	background: var(--surface-1);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	cursor: pointer;
+	color: var(--text-2);
+	font-family: inherit;
+	font-size: 12px;
+	font-weight: 500;
+	transition: background-color 0.12s, border-color 0.12s;
+}
+.pep-pill:hover {
+	background: var(--surface-2);
+}
+.pep-pill:focus-visible {
+	outline: 2px solid var(--text);
+	outline-offset: 2px;
+}
+.pep-name {
+	color: var(--text-2);
+}
+.pep-caret {
+	color: var(--text-3);
+}
+
+/* ---- the living mark ---- */
+.pep-orb {
+	position: relative;
+	display: grid;
+	place-items: center;
+	width: 24px;
+	height: 24px;
+	flex: none;
+	border-radius: 50%;
+}
+.pep-orb.sm {
+	width: 18px;
+	height: 18px;
+}
+.pep-orb svg {
+	width: 55%;
+	height: 55%;
+	filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.22));
+}
+.pep-orb.jarvis {
+	background: radial-gradient(
+			circle at 34% 30%,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0) 60%
+		),
+		var(--brand-grad, linear-gradient(140deg, #6e8bff, #8b5cf6));
+	box-shadow: 0 0 10px rgba(124, 116, 246, 0.4);
+}
+.pep-orb.jara {
+	background: radial-gradient(
+			circle at 34% 30%,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0) 60%
+		),
+		linear-gradient(140deg, #9d7cea, #6846e3);
+	box-shadow: 0 0 10px rgba(124, 92, 234, 0.4);
+}
+
+/* ---- dropdown ---- */
+.pep-menu {
+	position: absolute;
+	bottom: calc(100% + 8px);
+	left: 0;
+	min-width: 236px;
+	background: var(--surface);
+	border: 1px solid var(--border-2);
+	border-radius: 12px;
+	box-shadow: 0 12px 34px rgba(20, 20, 30, 0.18);
+	padding: 5px;
+	z-index: 60;
+}
+.pep-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 8px 9px;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--text);
+	font-family: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.pep-item:hover {
+	background: var(--surface-1);
+}
+.pep-body {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	flex: 1;
+	min-width: 0;
+}
+.pep-item-name {
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text);
+}
+.pep-desc {
+	font-size: 11.5px;
+	font-weight: 450;
+	color: var(--text-3);
+	text-transform: capitalize;
+}
+.pep-note {
+	padding: 8px 9px 4px;
+	font-size: 11.5px;
+	font-weight: 450;
+	line-height: 1.4;
+	color: var(--text-3);
+}
+
+/* a touch of life: the dropdown marks breathe gently (motion-safe) */
+@media (prefers-reduced-motion: no-preference) {
+	.pep-menu .pep-orb.jarvis {
+		animation: pep-pulse 2.6s ease-in-out infinite;
+	}
+	.pep-menu .pep-orb.jara {
+		animation: pep-drift 4.4s ease-in-out infinite;
+	}
+}
+@keyframes pep-pulse {
+	0%,
+	100% {
+		transform: scale(1);
+	}
+	50% {
+		transform: scale(1.06);
+	}
+}
+@keyframes pep-drift {
+	0%,
+	100% {
+		transform: translateY(0) scale(1.01, 0.99);
+	}
+	50% {
+		transform: translateY(-1.5px) scale(0.99, 1.01);
+	}
+}
+</style>

--- a/frontend/src/components/chat/PersonaPill.vue
+++ b/frontend/src/components/chat/PersonaPill.vue
@@ -167,6 +167,15 @@ useDismissable(rootRef, open, undefined, triggerRef);
 		linear-gradient(140deg, #9d7cea, #6846e3);
 	box-shadow: 0 0 10px rgba(124, 92, 234, 0.4);
 }
+/* The Jarvis orb renders <JarvisMark>, whose default .jv-mark paints its own
+   opaque brand gradient at the full orb size - which covered .pep-orb.jarvis's
+   radial highlight, so the Jarvis orb read flat while Jara's white star (a bare
+   SVG over the same orb) glowed. Drop the nested mark's own background so the
+   orb's highlight shows through behind the star, matching Jara. A tenant
+   whitelabel logo (.jv-mark-img) is exempt - an image must stay opaque. */
+.pep-orb.jarvis :deep(.jv-mark:not(.jv-mark-img)) {
+	background: transparent;
+}
 
 /* ---- dropdown ---- */
 .pep-menu {

--- a/frontend/src/composables/useDismissable.js
+++ b/frontend/src/composables/useDismissable.js
@@ -1,0 +1,76 @@
+import { onBeforeUnmount, watch } from "vue";
+
+/**
+ * Dismiss an open dropdown/menu on an outside click, a focusout past the
+ * root, or the Escape key.
+ *
+ * Shared by the composer pills (PersonaPill, ModelEffortPicker) so the
+ * click-outside + Escape + focusout + listener-cleanup logic lives in one
+ * place instead of being re-implemented per component.
+ *
+ * @param {import('vue').Ref<HTMLElement|null>} rootRef     element that defines "inside"
+ * @param {import('vue').Ref<boolean>} open                 the open-state ref to watch
+ * @param {() => void} [onDismiss]                           runs on dismissal; defaults to
+ *                                                           closing `open`. Pass a custom fn
+ *                                                           when closing also clears sub-state.
+ * @param {import('vue').Ref<HTMLElement|null>} [triggerRef] the trigger button, refocused on
+ *                                                           Escape so keyboard and
+ *                                                           screen-reader users land back where
+ *                                                           they opened the menu from. Not used
+ *                                                           for outside-click/focusout dismissal,
+ *                                                           since focus there is already moving
+ *                                                           somewhere on purpose.
+ *
+ * Listeners are attached only while `open` is true and removed on close and on
+ * unmount. The click listener uses capture (true) so it fires before inner
+ * handlers stop propagation, matching the pre-extraction behaviour.
+ */
+export function useDismissable(rootRef, open, onDismiss, triggerRef) {
+	const dismiss =
+		onDismiss ||
+		(() => {
+			open.value = false;
+		});
+
+	function onDocClick(e) {
+		if (rootRef.value && !rootRef.value.contains(e.target)) dismiss();
+	}
+	function onKey(e) {
+		if (e.key === "Escape") {
+			// ChatView's global key handler (onGlobalKey) opens with
+			// `if (e.defaultPrevented) return;` so this must claim the key,
+			// otherwise Escape would also fall through to it and cancel
+			// dictation in the same keystroke that closes the menu.
+			e.preventDefault();
+			dismiss();
+			triggerRef?.value?.focus();
+		}
+	}
+	function onFocusOut(e) {
+		// relatedTarget is also null when focus moves to a non-focusable node
+		// inside the menu (separators, labels), not just when it leaves the
+		// document entirely, so treating that as "outside" would dismiss a
+		// menu the user just clicked into. Outside clicks are still covered by
+		// the capture-phase click listener above, and a real tab-out always
+		// supplies a relatedTarget.
+		if (!e.relatedTarget) return;
+		if (rootRef.value && !rootRef.value.contains(e.relatedTarget)) dismiss();
+	}
+
+	watch(open, (isOpen) => {
+		if (isOpen) {
+			document.addEventListener("click", onDocClick, true);
+			document.addEventListener("keydown", onKey);
+			rootRef.value?.addEventListener("focusout", onFocusOut);
+		} else {
+			document.removeEventListener("click", onDocClick, true);
+			document.removeEventListener("keydown", onKey);
+			rootRef.value?.removeEventListener("focusout", onFocusOut);
+		}
+	});
+	onBeforeUnmount(() => {
+		document.removeEventListener("click", onDocClick, true);
+		document.removeEventListener("keydown", onKey);
+		rootRef.value?.removeEventListener("focusout", onFocusOut);
+	});
+}

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -68,7 +68,14 @@ function clearSettingsActions() {
 // trust signal, so hide it only when the user has explicitly turned it off
 // ("0"). The server-side default matches (Jarvis User Settings.activity_detail
 // defaults to 1) so the first get_my_settings sync can't flip a fresh device.
-const _storedActivityDetail = localStorage.getItem("jarvis-activity-detail");
+function _lsGet(key) {
+	try {
+		return localStorage.getItem(key);
+	} catch (e) {
+		return null;
+	}
+}
+const _storedActivityDetail = _lsGet("jarvis-activity-detail");
 const activityDetail = ref(_storedActivityDetail === null ? true : _storedActivityDetail === "1");
 // `persist:false` is used only by syncSettingsFromServer, to apply a value
 // that already came FROM the server without immediately POSTing it back.
@@ -89,9 +96,58 @@ function setActivityDetail(v, { persist = true } = {}) {
 		);
 	}
 }
+// Per-user persona voice (Jarvis default / Jara). Same localStorage-cache +
+// roaming-server pattern as activityDetail; a string, default "Jarvis". Voice
+// only — the agent's tools, permissions, and behaviour are identical either way.
+const _storedPersona = _lsGet("jarvis-preferred-persona");
+const preferredPersona = ref(_storedPersona === "Jara" ? "Jara" : "Jarvis");
+// In-flight counter for persona server writes (N3): incremented right before
+// each api.updateMySettings persona POST, decremented when it settles. While
+// non-zero, the persist:false adopt-from-server path (mount reconcile /
+// GeneralPane's syncSettingsFromServer) must not overwrite the ref +
+// localStorage, or it can clobber a write the user just made that hasn't
+// round-tripped yet.
+let _personaWritesInflight = 0;
+// Request-sequence guard (N4): only the most recently issued POST may roll
+// back on failure, so a stale rejected request can't stomp a newer accepted
+// value.
+let _personaSeq = 0;
+function setPreferredPersona(v, { persist = true } = {}) {
+	const persona = v === "Jara" ? "Jara" : "Jarvis";
+	if (!persist && _personaWritesInflight > 0) return;
+	const prev = preferredPersona.value;
+	preferredPersona.value = persona;
+	try {
+		localStorage.setItem("jarvis-preferred-persona", persona);
+	} catch (e) {
+		// localStorage throws in private mode and when the quota is full.
+		// The preference is a nicety; losing it must never break the picker.
+	}
+	if (persist) {
+		const seq = ++_personaSeq;
+		// Fire-and-forget, same as renameConversation/toggleStar: roll back both
+		// the ref and the cache on failure so a device that never actually wrote
+		// the server value doesn't keep showing it as current.
+		_personaWritesInflight++;
+		api.updateMySettings({ preferred_persona: persona })
+			.catch(() => {
+				if (seq !== _personaSeq) return;
+				preferredPersona.value = prev;
+				try {
+					localStorage.setItem("jarvis-preferred-persona", prev);
+				} catch (_e) {
+					// see above: localStorage write failures are non-fatal
+				}
+				toast.error("Couldn't switch to " + persona + " - still using " + prev + ".");
+			})
+			.finally(() => {
+				_personaWritesInflight--;
+			});
+	}
+}
 const notifyEnabled = ref(
 	typeof Notification !== "undefined" &&
-		localStorage.getItem("jarvis-notify") === "1" &&
+		_lsGet("jarvis-notify") === "1" &&
 		Notification.permission === "granted"
 );
 async function toggleNotify() {
@@ -146,6 +202,8 @@ function syncSettingsFromServer(data) {
 			// The preference is a nicety; losing it must never break the toggle.
 		}
 	}
+	if (data.preferred_persona !== undefined)
+		setPreferredPersona(data.preferred_persona, { persist: false });
 }
 
 // Sidebar collapse: persisted preference (same localStorage key/values as
@@ -330,6 +388,7 @@ const store = reactive({
 	settingsActions,
 	activityDetail,
 	notifyEnabled,
+	preferredPersona,
 	pendingNewChat,
 	paletteOpen,
 	moreMenuOpen,
@@ -350,6 +409,7 @@ const store = reactive({
 	registerSettingsActions,
 	clearSettingsActions,
 	setActivityDetail,
+	setPreferredPersona,
 	toggleNotify,
 	syncSettingsFromServer,
 	applyRemoteRename,

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -112,10 +112,21 @@ let _personaWritesInflight = 0;
 // back on failure, so a stale rejected request can't stomp a newer accepted
 // value.
 let _personaSeq = 0;
+// The last value the SERVER confirmed - a successful write, or a value the
+// server pushed via syncSettingsFromServer. Rollback restores THIS, not the ref
+// value at call time: during rapid toggles that ref may itself be an unconfirmed
+// optimistic value, so rolling back to it could strand the pill on a value the
+// server never accepted. Initialised to the booted local value as the baseline.
+let _personaConfirmed = preferredPersona.value;
+// Upper bound on how long a persona POST may hold the reconcile guard. Without
+// it, one hung (never-settling) request would pin _personaWritesInflight above 0
+// for the rest of the session, silently and permanently disabling every
+// persist:false reconcile (cross-tab / cross-device sync). The seq guard still
+// prevents a late real settlement from rolling back a newer value.
+const PERSONA_WRITE_TIMEOUT_MS = 15000;
 function setPreferredPersona(v, { persist = true } = {}) {
 	const persona = v === "Jara" ? "Jara" : "Jarvis";
 	if (!persist && _personaWritesInflight > 0) return;
-	const prev = preferredPersona.value;
 	preferredPersona.value = persona;
 	try {
 		localStorage.setItem("jarvis-preferred-persona", persona);
@@ -123,27 +134,63 @@ function setPreferredPersona(v, { persist = true } = {}) {
 		// localStorage throws in private mode and when the quota is full.
 		// The preference is a nicety; losing it must never break the picker.
 	}
-	if (persist) {
-		const seq = ++_personaSeq;
-		// Fire-and-forget, same as renameConversation/toggleStar: roll back both
-		// the ref and the cache on failure so a device that never actually wrote
-		// the server value doesn't keep showing it as current.
-		_personaWritesInflight++;
-		api.updateMySettings({ preferred_persona: persona })
-			.catch(() => {
-				if (seq !== _personaSeq) return;
-				preferredPersona.value = prev;
-				try {
-					localStorage.setItem("jarvis-preferred-persona", prev);
-				} catch (_e) {
-					// see above: localStorage write failures are non-fatal
-				}
-				toast.error("Couldn't switch to " + persona + " - still using " + prev + ".");
-			})
-			.finally(() => {
-				_personaWritesInflight--;
-			});
+	if (!persist) {
+		// This IS the server's value (mount reconcile / GeneralPane sync), so it
+		// becomes the confirmed baseline a later failed write rolls back to.
+		_personaConfirmed = persona;
+		return;
 	}
+	const seq = ++_personaSeq;
+	// Fire-and-forget, same as renameConversation/toggleStar: on failure roll the
+	// ref + cache back to the last server-confirmed value so a device that never
+	// actually wrote the server value doesn't keep showing it as current.
+	_personaWritesInflight++;
+	let settled = false;
+	let timer = null;
+	const release = () => {
+		if (settled) return;
+		settled = true;
+		if (timer) clearTimeout(timer);
+		_personaWritesInflight = Math.max(0, _personaWritesInflight - 1);
+	};
+	api.updateMySettings({ preferred_persona: persona })
+		.then(() => {
+			if (seq !== _personaSeq) return;
+			// Server accepted this value: make it authoritative for BOTH the ref and
+			// the confirmed baseline. Re-asserting the ref matters because the
+			// timeout below can force-release the in-flight guard before a slow POST
+			// settles, letting a persist:false reconcile set the ref back to the
+			// pre-write value; without this the pill would stay stale after the POST
+			// finally succeeds. On the normal path the ref is already `persona`, so
+			// this is a no-op. (Ordering vs a reconcile is best-effort: _personaSeq
+			// tracks only local writes, so in the rare window of a >timeout hang plus
+			// a genuine cross-device change landing via reconcile, a still-current
+			// local write re-asserts its own value; it self-heals on the next
+			// reconcile - far rarer and milder than the stale pill this closes.)
+			_personaConfirmed = persona;
+			preferredPersona.value = persona;
+			try {
+				localStorage.setItem("jarvis-preferred-persona", persona);
+			} catch (_e) {
+				// see above: localStorage write failures are non-fatal
+			}
+		})
+		.catch(() => {
+			if (seq !== _personaSeq) return;
+			preferredPersona.value = _personaConfirmed;
+			try {
+				localStorage.setItem("jarvis-preferred-persona", _personaConfirmed);
+			} catch (_e) {
+				// see above: localStorage write failures are non-fatal
+			}
+			toast.error(
+				"Couldn't switch to " + persona + " - still using " + _personaConfirmed + "."
+			);
+		})
+		.finally(release);
+	// Safety net: force-release the guard after the bound even if the POST never
+	// settles, so the reconcile path can always recover. Cleared on settle.
+	timer = setTimeout(release, PERSONA_WRITE_TIMEOUT_MS);
 }
 const notifyEnabled = ref(
 	typeof Notification !== "undefined" &&

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -125,254 +125,6 @@
 							>Save as macro</span
 						>
 					</button>
-					<!-- Model picker: switch the LLM model for this conversation -->
-					<div class="jv-modelmenu-wrap" style="position: relative">
-						<button
-							class="jv-modelpill"
-							@click="modelMenuOpen = !modelMenuOpen"
-							title="Model and effort"
-							style="
-								display: flex;
-								align-items: center;
-								gap: 7px;
-								padding: 5px 10px;
-								background: var(--surface-1);
-								border: 1px solid var(--border);
-								border-radius: 20px;
-								cursor: pointer;
-								font-family: inherit;
-							"
-						>
-							<svg
-								width="13"
-								height="13"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="var(--text-2)"
-								stroke-width="1.7"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<ellipse cx="12" cy="5" rx="9" ry="3" />
-								<path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5" />
-								<path d="M3 12c0 1.7 4 3 9 3s9-1.3 9-3" />
-							</svg>
-							<span
-								style="font-size: 12px; color: var(--text-2); font-weight: 500"
-								>{{ modelLabel }}</span
-							>
-							<span
-								v-if="thinkingOverride"
-								style="font-size: 11px; color: var(--text-3); font-weight: 450"
-								>· {{ thinkingOverride }}</span
-							>
-							<svg
-								width="12"
-								height="12"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="var(--text-3)"
-								stroke-width="1.9"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="m6 9 6 6 6-6" />
-							</svg>
-						</button>
-						<div
-							v-if="modelMenuOpen"
-							style="
-								position: absolute;
-								top: calc(100% + 6px);
-								right: 0;
-								min-width: 224px;
-								background: var(--surface);
-								border: 1px solid var(--border-2);
-								border-radius: 10px;
-								box-shadow: 0 8px 24px rgba(20, 20, 30, 0.14);
-								padding: 5px;
-								z-index: 30;
-							"
-						>
-							<!-- Effort first: it is the control that always applies, even when the
-								     customer has exactly one configured model. Levels come from the server
-								     (thinking_levels) because Jarvis Conversation.thinking_override is a
-								     Select - offering a level it rejects would fail the save. -->
-							<div
-								style="
-									padding: 3px 9px 6px;
-									font-size: 10px;
-									color: var(--text-3);
-									font-weight: 600;
-									text-transform: uppercase;
-									letter-spacing: 0.03em;
-								"
-							>
-								Effort
-							</div>
-							<button
-								class="jv-menuitem"
-								:class="{ on: !thinkingOverride }"
-								@click="selectThinking('')"
-							>
-								<svg
-									width="14"
-									height="14"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.8"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									style="flex: none"
-								>
-									<path
-										d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"
-									/>
-								</svg>
-								<span style="flex: 1">Auto</span>
-								<svg
-									v-if="!thinkingOverride"
-									width="14"
-									height="14"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="var(--text)"
-									stroke-width="2.2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									style="flex: none"
-								>
-									<path d="M20 6 9 17l-5-5" />
-								</svg>
-							</button>
-							<button
-								v-for="lvl in thinkingLevels"
-								:key="lvl"
-								class="jv-menuitem"
-								:class="{ on: lvl === thinkingOverride }"
-								@click="selectThinking(lvl)"
-							>
-								<span style="flex: 1; text-transform: capitalize">{{ lvl }}</span>
-								<svg
-									v-if="lvl === thinkingOverride"
-									width="14"
-									height="14"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="var(--text)"
-									stroke-width="2.2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									style="flex: none"
-								>
-									<path d="M20 6 9 17l-5-5" />
-								</svg>
-							</button>
-							<template v-if="pickableModels.length">
-								<!-- Auto: let Jarvis pick, divided from the explicit models. Clearing the pin
-								     is openclaw's "/model default": the session stops overriding the configured
-								     primary and inherits it again. -->
-								<button
-									class="jv-menuitem"
-									:class="{ on: !modelOverride }"
-									@click="selectModel('')"
-								>
-									<svg
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.8"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										style="flex: none"
-									>
-										<path
-											d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"
-										/>
-									</svg>
-									<span style="flex: 1"
-										>Auto
-										<span style="color: var(--text-3); font-weight: 450"
-											>· {{ ui.llm_model || "default" }}</span
-										></span
-									>
-									<svg
-										v-if="!modelOverride"
-										width="14"
-										height="14"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="var(--text)"
-										stroke-width="2.2"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										style="flex: none"
-									>
-										<path d="M20 6 9 17l-5-5" />
-									</svg>
-								</button>
-								<!-- One group per provider, but only labelled by provider when the customer
-								     actually has more than one. A subscription pool stores provider="" on every
-								     row, so a single flat "Model" header is the honest rendering there. -->
-								<template v-for="g in modelsByProvider" :key="g.provider">
-									<div
-										style="
-											height: 1px;
-											background: var(--border);
-											margin: 5px 2px;
-										"
-									></div>
-									<div
-										style="
-											padding: 3px 9px 6px;
-											font-size: 10px;
-											color: var(--text-3);
-											font-weight: 600;
-											text-transform: uppercase;
-											letter-spacing: 0.03em;
-										"
-									>
-										{{ showProviders ? g.provider : "Model" }}
-									</div>
-									<button
-										v-for="r in g.models"
-										:key="g.provider + '/' + r.model"
-										class="jv-menuitem"
-										:class="{ on: r.model === modelOverride }"
-										@click="selectModel(r.model)"
-									>
-										<span style="flex: 1">{{ r.model }}</span>
-										<span
-											v-if="r.tier"
-											style="
-												font-size: 10px;
-												color: var(--text-3);
-												margin-right: 6px;
-											"
-											>{{ r.tier }}</span
-										>
-										<svg
-											v-if="r.model === modelOverride"
-											width="14"
-											height="14"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="var(--text)"
-											stroke-width="2.2"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											style="flex: none"
-										>
-											<path d="M20 6 9 17l-5-5" />
-										</svg>
-									</button>
-								</template>
-							</template>
-						</div>
-					</div>
 					<!-- Connect phone: shows a QR the mobile app scans to onboard -->
 					<button
 						class="jv-iconbtn"
@@ -2673,74 +2425,6 @@
 							</div>
 						</template>
 						<template #left-toolbar="{ pickFiles }">
-							<!-- dictation mic (hidden unless the backend reports STT configured) -->
-							<template v-if="ui.stt_enabled && micRec.supported">
-								<button
-									class="jv-iconbtn jv-micbtn"
-									:class="{ rec: micState === 'recording' }"
-									:title="
-										micState === 'recording'
-											? 'Stop dictation'
-											: 'Dictate (voice to text)'
-									"
-									@click="micState === 'recording' ? stopMic() : startMic()"
-									style="
-										width: 30px;
-										height: 30px;
-										display: flex;
-										align-items: center;
-										justify-content: center;
-										background: transparent;
-										border: none;
-										border-radius: 7px;
-										cursor: pointer;
-										color: var(--text-3);
-									"
-								>
-									<svg
-										width="17"
-										height="17"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.7"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<path
-											d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"
-										/>
-										<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-										<path d="M12 19v3" />
-									</svg>
-								</button>
-								<template v-if="micState === 'recording'">
-									<span class="jv-mic-live"
-										><span class="jv-mic-dot"></span>{{ micClock }}</span
-									>
-									<button
-										class="jv-mic-cancel"
-										title="Cancel recording (Esc) — throws this whole recording away; text already in the box is kept"
-										aria-label="Cancel recording"
-										@click="cancelMic"
-									>
-										<svg
-											width="12"
-											height="12"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="currentColor"
-											stroke-width="2.2"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-										>
-											<path d="M18 6 6 18M6 6l12 12" />
-										</svg>
-									</button>
-								</template>
-								<!-- the transcribing indicator lives in #below-input, where the words
-							     will actually land — one pill per recording, not a count here. -->
-							</template>
 							<button
 								class="jv-iconbtn"
 								title="Attach file"
@@ -2773,6 +2457,7 @@
 									/>
 								</svg>
 							</button>
+							<PersonaPill v-if="ui.persona_enabled" />
 							<button
 								v-if="ui.wiki_enabled"
 								class="jv-iconbtn"
@@ -2856,6 +2541,86 @@
 									<line x1="4.93" y1="19.07" x2="9.17" y2="14.83" />
 								</svg>
 							</button>
+						</template>
+						<template #right-toolbar>
+							<!-- dictation mic (hidden unless the backend reports STT configured) -->
+							<template v-if="ui.stt_enabled && micRec.supported">
+								<button
+									class="jv-iconbtn jv-micbtn"
+									:class="{ rec: micState === 'recording' }"
+									:title="
+										micState === 'recording'
+											? 'Stop dictation'
+											: 'Dictate (voice to text)'
+									"
+									@click="micState === 'recording' ? stopMic() : startMic()"
+									style="
+										width: 30px;
+										height: 30px;
+										display: flex;
+										align-items: center;
+										justify-content: center;
+										background: transparent;
+										border: none;
+										border-radius: 7px;
+										cursor: pointer;
+										color: var(--text-3);
+									"
+								>
+									<svg
+										width="17"
+										height="17"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.7"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<path
+											d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"
+										/>
+										<path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+										<path d="M12 19v3" />
+									</svg>
+								</button>
+								<template v-if="micState === 'recording'">
+									<span class="jv-mic-live"
+										><span class="jv-mic-dot"></span>{{ micClock }}</span
+									>
+									<button
+										class="jv-mic-cancel"
+										title="Cancel recording (Esc) — throws this whole recording away; text already in the box is kept"
+										aria-label="Cancel recording"
+										@click="cancelMic"
+									>
+										<svg
+											width="12"
+											height="12"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="2.2"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+										>
+											<path d="M18 6 6 18M6 6l12 12" />
+										</svg>
+									</button>
+								</template>
+								<!-- the transcribing indicator lives in #below-input, where the words
+							     will actually land — one pill per recording, not a count here. -->
+							</template>
+							<ModelEffortPicker
+								:model-override="modelOverride"
+								:default-model="ui.llm_model || ''"
+								:thinking-override="thinkingOverride"
+								:thinking-levels="thinkingLevels"
+								:models-by-provider="modelsByProvider"
+								:show-providers="showProviders"
+								@select-model="selectModel"
+								@select-thinking="selectThinking"
+							/>
 						</template>
 					</Composer>
 				</div>
@@ -3622,6 +3387,8 @@ import PendingCard from "@/components/PendingCard.vue";
 import ReceiptChip from "@/components/ReceiptChip.vue";
 import Message from "@/components/chat/Message.vue";
 import Composer from "@/components/chat/Composer.vue";
+import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
+import PersonaPill from "@/components/chat/PersonaPill.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
@@ -3809,7 +3576,6 @@ function announceSR(msg) {
 // <ConfirmDialog> in AppShell) — this view just calls confirm(). Escape/backdrop
 // dismissal and rendering are owned by that component.
 const { confirm } = useConfirm();
-const modelMenuOpen = ref(false);
 const showConnect = ref(false);
 // One-shot "ground on wiki": when armed, the NEXT message carries a
 // context.ground_wiki flag so the backend injects relevant wiki page bodies
@@ -6898,7 +6664,6 @@ function openErpDesk() {
 	window.open("/app", "_blank");
 }
 async function selectModel(m) {
-	modelMenuOpen.value = false;
 	const prev = modelOverride.value;
 	modelOverride.value = m;
 	if (currentId.value) {
@@ -6914,7 +6679,6 @@ async function selectModel(m) {
 }
 
 async function selectThinking(level) {
-	modelMenuOpen.value = false;
 	const prev = thinkingOverride.value;
 	thinkingOverride.value = level;
 	if (currentId.value) {
@@ -6927,7 +6691,6 @@ async function selectThinking(level) {
 	}
 }
 function onDocClick(e) {
-	if (!e.target.closest(".jv-modelmenu-wrap")) modelMenuOpen.value = false;
 	if (!e.target.closest(".jv-composer")) mention.value = { ...mention.value, open: false };
 }
 async function retry(messageId) {
@@ -8717,6 +8480,12 @@ onMounted(async () => {
 		if (busy.value) nowMs.value = Date.now();
 	}, 1000);
 	ui.value = (await uiP) || {};
+	// Reconcile the persona pill with the server's current value, so a persona
+	// switched on another device shows up here too. Adopt only, never a write
+	// (persist:false), since this is us catching up to the server, not a change.
+	if (ui.value.preferred_persona !== undefined) {
+		store.setPreferredPersona(ui.value.preferred_persona, { persist: false });
+	}
 	// Offer recovery of any recording a prior session left un-transcribed (a tab
 	// crash / accidental reload) — only when dictation is actually enabled.
 	// _ensureVoiceSession FIRST: it mints _voiceSessionId, which is what excludes

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2457,6 +2457,11 @@
 									/>
 								</svg>
 							</button>
+							<!-- persona_enabled is read once at mount (boot payload). If an admin
+							     flips the fleet-wide kill switch mid-session the pill can linger
+							     until reload, but the server clause (_persona_clause) re-reads the
+							     switch every turn, so behaviour is always correct - this is
+							     voice-only cosmetic lag that self-heals on the next boot. -->
 							<PersonaPill v-if="ui.persona_enabled" />
 							<button
 								v-if="ui.wiki_enabled"

--- a/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
+++ b/frontend/tests/support-extraction/__snapshots__/composer.test.js.snap
@@ -28,9 +28,13 @@ exports[`composer renders identically (light) 1`] = `
 			     still open this component's own hidden file input. The fallback is
 			     the plain attach button the generic composer ships with. --><button data-v-680708eb="" class="jv-iconbtn" title="Attach file" style="width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; background: transparent; border-radius: 7px; cursor: pointer; color: var(--text-3);"><svg data-v-680708eb="" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
           <path data-v-680708eb="" d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.19a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49"></path>
-        </svg></button><span data-v-680708eb="" style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
-          <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
         </svg></button>
+      <div data-v-680708eb="" style="margin-left: auto; display: flex; align-items: center; gap: 6px;">
+        <!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
+				     between the left cluster and the Enter hint + send button. --><span data-v-680708eb="" style="font-size: 11px; color: var(--text-3); margin-right: 2px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+            <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
+          </svg></button>
+      </div>
     </div>
   </div>
   <div data-v-680708eb="" style="text-align: center; font-size: 10.5px; color: var(--text-3); margin-top: 8px;">Jarvis can make mistakes.</div>
@@ -65,9 +69,13 @@ exports[`dark render 1`] = `
 			     still open this component's own hidden file input. The fallback is
 			     the plain attach button the generic composer ships with. --><button data-v-680708eb="" class="jv-iconbtn" title="Attach file" style="width: 30px; height: 30px; display: flex; align-items: center; justify-content: center; background: transparent; border-radius: 7px; cursor: pointer; color: var(--text-3);"><svg data-v-680708eb="" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
           <path data-v-680708eb="" d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3.5 3.5 0 0 1 4.95 4.95l-9.2 9.19a1.5 1.5 0 0 1-2.12-2.12l8.49-8.49"></path>
-        </svg></button><span data-v-680708eb="" style="margin-left: auto; font-size: 11px; color: var(--text-3); margin-right: 4px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
-          <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
         </svg></button>
+      <div data-v-680708eb="" style="margin-left: auto; display: flex; align-items: center; gap: 6px;">
+        <!-- Host buttons on the RIGHT (chat: dictation mic + model picker),
+				     between the left cluster and the Enter hint + send button. --><span data-v-680708eb="" style="font-size: 11px; color: var(--text-3); margin-right: 2px;">Enter ↵</span><button data-v-680708eb="" class="jv-sendbtn ready" style="width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; background: var(--cta); border-radius: 8px; cursor: pointer;"><svg data-v-680708eb="" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--cta-fg)" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+            <path data-v-680708eb="" d="M12 19V5M5 12l7-7 7 7"></path>
+          </svg></button>
+      </div>
     </div>
   </div>
   <!--v-if-->

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1438,6 +1438,14 @@ def get_chat_ui_settings() -> dict:
 		# Composer "ground on wiki" pill gating: shown only when the wiki feature
 		# is on AND the org has at least one Active page (best-effort).
 		"wiki_enabled": _wiki_enabled_flag(),
+		# Persona pill gating: a real kill switch (Jarvis Settings.persona_enabled,
+		# default on), read here AND in _persona_clause so flipping it off both hides
+		# the pill and stops the clause - never a client-only half-switch (N7).
+		"persona_enabled": _persona_feature_enabled(),
+		# The server's current persona for this user, so the SPA can reconcile a
+		# localStorage-booted pill to the row at mount. Best-effort like the sibling
+		# gates (N8): a migrate-lag missing column must not 500 the whole bootstrap.
+		"preferred_persona": _current_user_persona(),
 		# auto-apply is per-conversation now (issue #186); the frontend reads
 		# ``auto_apply`` from the conversation payload, not this global endpoint.
 	}
@@ -1454,6 +1462,34 @@ def _wiki_enabled_flag() -> bool:
 		return bool(wiki_enabled() and _has_active_pages())
 	except Exception:
 		return False
+
+
+def _current_user_persona() -> str:
+	"""The caller's stored persona for the boot payload. Best-effort like the
+	sibling bootstrap keys (N8): a migrate-lag missing column, or any read error,
+	must not 500 the whole endpoint - fall back to the default so ChatView still
+	gets its model picker, timezone, and the rest of `ui`."""
+	try:
+		return (
+			frappe.db.get_value("Jarvis User Settings", {"user": frappe.session.user}, "preferred_persona")
+			or "Jarvis"
+		)
+	except Exception:
+		return "Jarvis"
+
+
+def _persona_feature_enabled() -> bool:
+	"""The persona kill switch for the boot payload. Best-effort like the sibling
+	gates (N8): default ON, an explicit 0 is the only OFF, and a migrate-lag
+	missing field/value must not 500 the bootstrap or invert the pill vs the
+	clause. Uses get_single_value (returns None when unset) so it matches
+	_persona_clause's None-is-ON semantics exactly rather than a bare attribute
+	read that would AttributeError before the column syncs."""
+	try:
+		val = frappe.db.get_single_value("Jarvis Settings", "persona_enabled")
+	except Exception:
+		return True
+	return val is None or bool(frappe.utils.cint(val))
 
 
 @frappe.whitelist()

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1406,7 +1406,7 @@ def get_chat_ui_settings() -> dict:
 	# providers==[] and the UI hides the provider group.
 	providers = sorted({r["provider"] for r in pool if r["provider"]})
 
-	return {
+	ui = {
 		"llm_auth_mode": settings.llm_auth_mode or "api_key",
 		"llm_provider": settings.llm_provider or "",
 		"llm_model": settings.llm_model or "",
@@ -1442,13 +1442,18 @@ def get_chat_ui_settings() -> dict:
 		# default on), read here AND in _persona_clause so flipping it off both hides
 		# the pill and stops the clause - never a client-only half-switch (N7).
 		"persona_enabled": _persona_feature_enabled(),
-		# The server's current persona for this user, so the SPA can reconcile a
-		# localStorage-booted pill to the row at mount. Best-effort like the sibling
-		# gates (N8): a migrate-lag missing column must not 500 the whole bootstrap.
-		"preferred_persona": _current_user_persona(),
 		# auto-apply is per-conversation now (issue #186); the frontend reads
 		# ``auto_apply`` from the conversation payload, not this global endpoint.
 	}
+	# The server's current persona, so the SPA can reconcile a localStorage-booted
+	# pill to the row at mount. Only sent when we could actually read it: on a read
+	# failure _current_user_persona returns None and we OMIT the key, because the
+	# client reconciles (and caches) only when the key is present - so a transient
+	# failure keeps the current pill instead of pinning it to a wrong default.
+	persona = _current_user_persona()
+	if persona is not None:
+		ui["preferred_persona"] = persona
+	return ui
 
 
 def _wiki_enabled_flag() -> bool:
@@ -1464,32 +1469,39 @@ def _wiki_enabled_flag() -> bool:
 		return False
 
 
-def _current_user_persona() -> str:
-	"""The caller's stored persona for the boot payload. Best-effort like the
-	sibling bootstrap keys (N8): a migrate-lag missing column, or any read error,
-	must not 500 the whole endpoint - fall back to the default so ChatView still
-	gets its model picker, timezone, and the rest of `ui`."""
+def _current_user_persona() -> str | None:
+	"""The caller's stored persona for the boot payload, or None if it can't be
+	read. A real read (including a user with no row) yields the actual value,
+	defaulting to "Jarvis"; a FAILURE returns None so get_chat_ui_settings OMITS
+	the preferred_persona key and the SPA keeps its current pill rather than
+	adopting-and-caching a wrong default. The old code returned "Jarvis" on error,
+	which the persist:false reconcile wrote to localStorage - so a transient read
+	failure could pin the pill to Jarvis while turns still came back as Jara.
+	Contrast _wiki_enabled_flag, whose fallback only hides a pill, never mutates
+	client state."""
 	try:
 		return (
 			frappe.db.get_value("Jarvis User Settings", {"user": frappe.session.user}, "preferred_persona")
 			or "Jarvis"
 		)
 	except Exception:
-		return "Jarvis"
+		return None
 
 
 def _persona_feature_enabled() -> bool:
-	"""The persona kill switch for the boot payload. Best-effort like the sibling
-	gates (N8): default ON, an explicit 0 is the only OFF, and a migrate-lag
-	missing field/value must not 500 the bootstrap or invert the pill vs the
-	clause. Uses get_single_value (returns None when unset) so it matches
-	_persona_clause's None-is-ON semantics exactly rather than a bare attribute
-	read that would AttributeError before the column syncs."""
+	"""The persona kill switch for the boot payload: default ON, only an explicit
+	stored 0 is OFF. Delegates to the canonical NULL=ON probe in turn_handler so
+	the pill and the clause read the switch identically (N7). Wrapped best-effort
+	(N8): a read failure shows the pill rather than 500-ing the whole bootstrap.
+	The probe uses a tabSingles row check, not get_single_value - the latter
+	coerces an unset Check to 0, which had shipped the feature OFF for every
+	un-backfilled bench and fresh install."""
 	try:
-		val = frappe.db.get_single_value("Jarvis Settings", "persona_enabled")
+		from jarvis.chat.turn_handler import persona_feature_enabled
+
+		return persona_feature_enabled()
 	except Exception:
 		return True
-	return val is None or bool(frappe.utils.cint(val))
 
 
 @frappe.whitelist()

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -477,6 +477,37 @@ def _assistant_name_clause(settings) -> str:
 	return f"; assistant name: {safe}"
 
 
+def _persona_clause(chat_user: str) -> str:
+	"""Per-user persona voice folded into the trusted [Context:] line so the agent
+	adopts the chosen voice (AGENTS.md "Personas"). ONLY the non-default persona is
+	signalled: Jarvis/unset -> "" so the default turn is byte-identical to before
+	this feature and pays zero per-turn tokens (like _assistant_name_clause). We
+	emit only the known alternate value, never the raw stored string - the bracket
+	is trusted/system, so a stray DB value must not flow into it verbatim.
+
+	Gated by the Jarvis Settings.persona_enabled kill switch: an explicit 0 turns
+	the feature off (pill hidden by get_chat_ui_settings, clause silent here), so a
+	flipped-off bench stops injecting the token for already-opted-in users (N7)."""
+	try:
+		enabled = frappe.db.get_single_value("Jarvis Settings", "persona_enabled")
+		if enabled is not None and not frappe.utils.cint(enabled):
+			return ""
+		persona = frappe.db.get_value("Jarvis User Settings", {"user": chat_user}, "preferred_persona")
+	except Exception as e:
+		# A site-wide lookup failure would degrade every Jara user invisibly. Log at
+		# WARNING (this repo's loggers default above DEBUG, so .debug never emits -
+		# see latency.py), wrapped so a logging failure can never defeat the fail-open
+		# return (mirrors policy.py's G2 guard). Lazy %s, zero happy-path cost.
+		try:
+			frappe.logger("jarvis").warning("_persona_clause lookup failed for %s: %s", chat_user, e)
+		except Exception:
+			pass
+		return ""
+	if (persona or "").strip() == "Jara":
+		return "; persona: Jara"
+	return ""
+
+
 def _advance_macro(conversation_id: str, *, errored: bool) -> None:
 	"""Chaining hook for the macro engine: if this conversation is a running
 	macro, advance it (enqueue the next step, or finish). Best-effort — a macro
@@ -590,6 +621,10 @@ def assemble_prompt(
 	# Whitelabel assistant name (Phase 3): folded into the trusted [Context:] line
 	# so the agent refers to itself by the customer's chosen name. "" when unset.
 	assistant_name_clause = _assistant_name_clause(settings)
+	# Per-user persona voice (Jarvis default / Jara), folded into the trusted
+	# [Context:] line like the assistant name. "" for the default, so the turn is
+	# unchanged for everyone who has not picked Jara.
+	persona_clause = _persona_clause(chat_user)
 	# Personal custom skills + org wiki notes (voice & wiki feature). Both
 	# clauses are best-effort ("" on any failure — a clause bug must never
 	# break a turn) and size-capped (~700 chars combined). Lazy imports so a
@@ -669,7 +704,7 @@ def assemble_prompt(
 		# (skill_clause) stays intentional and is not demoted. The
 		# customizations clause is org-level too, so it sits with the org
 		# clauses - before personal, which stays last.
-		f"[Context: today is {today}{locale_clause}{assistant_name_clause}; chat user: {chat_user}"
+		f"[Context: today is {today}{locale_clause}{assistant_name_clause}{persona_clause}; chat user: {chat_user}"
 		f"; conv: {conversation_id}{auto_apply}{skill_clause}{learned_clause}"
 		f"{wiki_notes_clause}{custom_site_clause}{personal_clause}{notes_clause}]"
 		f"{ground_block}"

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -477,6 +477,29 @@ def _assistant_name_clause(settings) -> str:
 	return f"; assistant name: {safe}"
 
 
+def persona_feature_enabled() -> bool:
+	"""The persona kill switch (``Jarvis Settings.persona_enabled``), NULL=ON.
+
+	Probes the ``tabSingles`` row directly instead of
+	``frappe.db.get_single_value``: for a Check field the latter coerces an unset
+	value to 0 via ``cint()`` (``personalise_api._single_bool`` and ``wiki.py``
+	document this exact trap), which is indistinguishable from an admin explicitly
+	disabling it - so an un-backfilled bench and a fresh install (which never runs
+	patches) would both read the feature as OFF. Here "no row" is the default
+	(ON); only a stored 0 is OFF. The probe never touches the meta, so it also
+	cannot throw in the migrate window before the field syncs - unlike
+	get_single_value, which raises on a missing meta field and would invert the
+	pill against the clause. Read here AND by the boot payload (N7) so the same
+	switch value drives both."""
+	row = frappe.db.sql(
+		"select value from tabSingles where doctype=%s and field=%s",
+		("Jarvis Settings", "persona_enabled"),
+	)
+	if not row:
+		return True
+	return bool(frappe.utils.cint(row[0][0]))
+
+
 def _persona_clause(chat_user: str) -> str:
 	"""Per-user persona voice folded into the trusted [Context:] line so the agent
 	adopts the chosen voice (AGENTS.md "Personas"). ONLY the non-default persona is
@@ -485,21 +508,22 @@ def _persona_clause(chat_user: str) -> str:
 	emit only the known alternate value, never the raw stored string - the bracket
 	is trusted/system, so a stray DB value must not flow into it verbatim.
 
-	Gated by the Jarvis Settings.persona_enabled kill switch: an explicit 0 turns
-	the feature off (pill hidden by get_chat_ui_settings, clause silent here), so a
-	flipped-off bench stops injecting the token for already-opted-in users (N7)."""
+	Gated by the Jarvis Settings.persona_enabled kill switch (NULL=ON, see
+	persona_feature_enabled): an explicit 0 turns the feature off (pill hidden by
+	get_chat_ui_settings, clause silent here), so a flipped-off bench stops
+	injecting the token for already-opted-in users (N7)."""
 	try:
-		enabled = frappe.db.get_single_value("Jarvis Settings", "persona_enabled")
-		if enabled is not None and not frappe.utils.cint(enabled):
+		if not persona_feature_enabled():
 			return ""
 		persona = frappe.db.get_value("Jarvis User Settings", {"user": chat_user}, "preferred_persona")
 	except Exception as e:
 		# A site-wide lookup failure would degrade every Jara user invisibly. Log at
-		# WARNING (this repo's loggers default above DEBUG, so .debug never emits -
-		# see latency.py), wrapped so a logging failure can never defeat the fail-open
+		# ERROR: production loggers run under supervisor with _dev_server False, so
+		# the default level is ERROR (40) and .warning/.debug never emit - see
+		# latency.py. Wrapped so a logging failure can never defeat the fail-open
 		# return (mirrors policy.py's G2 guard). Lazy %s, zero happy-path cost.
 		try:
-			frappe.logger("jarvis").warning("_persona_clause lookup failed for %s: %s", chat_user, e)
+			frappe.logger("jarvis").error("_persona_clause lookup failed for %s: %s", chat_user, e)
 		except Exception:
 			pass
 		return ""

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -108,7 +108,10 @@ def _settings_payload(doc) -> dict:
 		"user": doc.user,
 		"notify_enabled": cint(doc.notify_enabled),
 		"activity_detail": cint(doc.activity_detail),
-		"preferred_persona": doc.preferred_persona or "Jarvis",
+		# getattr, not a bare read: in the migrate window before preferred_persona
+		# syncs onto the doc's meta, doc.preferred_persona would AttributeError and
+		# 500 get_my_settings / update_my_settings. Default to Jarvis like the rest.
+		"preferred_persona": getattr(doc, "preferred_persona", None) or "Jarvis",
 		"monthly_token_limit": cint(doc.monthly_token_limit),
 		"usage_month": doc.usage_month,
 		"month_tokens": _month_tokens_effective(doc.usage_month, doc.month_tokens),
@@ -251,7 +254,8 @@ def admin_set_user_model_limit(user: str, model: str, monthly_token_limit: int =
 	Admins only (server re-checks; the SPA gate is UX)."""
 	require_jarvis_admin()
 	# Coerce before the db calls: a dict `user` would otherwise turn the identity
-	# check into a filter match, and a list `model` would 500 on .strip() (N10).
+	# check into a filter match, and a non-string `model` would crash the per-model
+	# lookup - a list reaches frappe.db.get_value as filters and unpacks wrong (N10).
 	user = _s(user)
 	if not user or not frappe.db.exists("User", user):
 		return {"ok": False, "reason": "unknown_user"}

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -21,7 +21,19 @@ from jarvis.chat import openclaw_session_pool, usage
 from jarvis.exceptions import OpenclawUnreachableError
 from jarvis.permissions import require_jarvis_access, require_jarvis_admin
 
+# NOTE: `from __future__ import annotations` above turns every annotation in this
+# module into a STRING, and frappe's transform_parameter_types skips string
+# annotations - so the whitelist arg-type gate does NOT coerce or validate inputs
+# here. Each endpoint must defensively coerce its own string args through _s()
+# below; never rely on the declared parameter types for runtime safety.
 USER_SETTINGS = "Jarvis User Settings"
+
+
+def _s(x) -> str:
+	"""Coerce a whitelisted string arg to trimmed text. The runtime type gate is
+	off in this module (see the NOTE above), so a hostile list/dict must be forced
+	to text before it reaches .strip() or a filter-shaped db call."""
+	return str(x or "").strip()
 
 
 def _month_tokens_effective(usage_month: str | None, month_tokens) -> int:
@@ -96,6 +108,7 @@ def _settings_payload(doc) -> dict:
 		"user": doc.user,
 		"notify_enabled": cint(doc.notify_enabled),
 		"activity_detail": cint(doc.activity_detail),
+		"preferred_persona": doc.preferred_persona or "Jarvis",
 		"monthly_token_limit": cint(doc.monthly_token_limit),
 		"usage_month": doc.usage_month,
 		"month_tokens": _month_tokens_effective(doc.usage_month, doc.month_tokens),
@@ -118,7 +131,11 @@ def get_my_settings() -> dict:
 
 
 @frappe.whitelist()
-def update_my_settings(notify_enabled: int | None = None, activity_detail: int | None = None) -> dict:
+def update_my_settings(
+	notify_enabled: int | None = None,
+	activity_detail: int | None = None,
+	preferred_persona: str | None = None,
+) -> dict:
 	"""Update the caller's own chat preferences only. The usage limit and
 	counters (permlevel 1 / read-only) are never writable here."""
 	require_jarvis_access()
@@ -127,6 +144,18 @@ def update_my_settings(notify_enabled: int | None = None, activity_detail: int |
 		doc.notify_enabled = 1 if sbool(notify_enabled) else 0
 	if activity_detail is not None:
 		doc.activity_detail = 1 if sbool(activity_detail) else 0
+	if preferred_persona is not None:
+		# Blank clears back to the default; otherwise it must be a known persona
+		# (this value rides the trusted [Context:] line in turn_handler).
+		# _s() coerces a hostile non-string before .strip() (see the module NOTE);
+		# without it a list/dict would 500 the endpoint on AttributeError.
+		persona = _s(preferred_persona) or "Jarvis"
+		if persona not in ("Jarvis", "Jara"):
+			# Fixed-enum message that reflects NOTHING back (house style for small
+			# enums): naming the valid set is clearer than echoing the bad value,
+			# and reflecting nothing removes the self-XSS vector entirely.
+			frappe.throw(frappe._("Persona must be Jarvis or Jara."))
+		doc.preferred_persona = persona
 	# ignore_permissions: the row is owner-scoped by construction (we loaded the
 	# caller's own row), and only permlevel-0 pref fields are touched here.
 	doc.save(ignore_permissions=True)
@@ -196,6 +225,9 @@ def admin_set_user_limit(user: str, monthly_token_limit: int = 0) -> dict:
 	"""Set a user's monthly token cap (0 = unlimited), creating the settings
 	row if absent. Admins only."""
 	require_jarvis_admin()
+	# Coerce before the db calls: a dict `user` would turn the identity check into
+	# a filter match (see the module NOTE / N10).
+	user = _s(user)
 	if not user or not frappe.db.exists("User", user):
 		return {"ok": False, "reason": "unknown_user"}
 	limit = max(0, cint(monthly_token_limit))
@@ -218,9 +250,12 @@ def admin_set_user_model_limit(user: str, model: str, monthly_token_limit: int =
 	settings row + current-month child row if absent. Mirrors admin_set_user_limit.
 	Admins only (server re-checks; the SPA gate is UX)."""
 	require_jarvis_admin()
+	# Coerce before the db calls: a dict `user` would otherwise turn the identity
+	# check into a filter match, and a list `model` would 500 on .strip() (N10).
+	user = _s(user)
 	if not user or not frappe.db.exists("User", user):
 		return {"ok": False, "reason": "unknown_user"}
-	model = (model or "").strip()
+	model = _s(model)
 	if not model:
 		return {"ok": False, "reason": "invalid_model"}
 	limit = max(0, cint(monthly_token_limit))

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -48,6 +48,7 @@
   "voice_wiki_section",
   "voice_features_enabled",
   "wiki_enabled",
+  "persona_enabled",
   "wiki_nudge_cooldown_hours",
   "voice_notes_last_processed_at",
   "voice_notes_last_process_status",
@@ -369,6 +370,13 @@
    "label": "Enable Business Wiki",
    "default": "1",
    "description": "Business wiki pages + post-turn wiki nudges. Readers treat an unset value as ON."
+  },
+  {
+   "fieldname": "persona_enabled",
+   "fieldtype": "Check",
+   "label": "Enable Persona Picker",
+   "default": "1",
+   "description": "Jarvis/Jara voice picker in the composer. An explicit 0 hides the pill and stops the persona clause fleet-wide. Readers treat an unset value as ON."
   },
   {
    "fieldname": "wiki_nudge_cooldown_hours",

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -12,6 +12,7 @@
     "prefs_section",
     "notify_enabled",
     "activity_detail",
+    "preferred_persona",
     "app_state_section",
     "business_greeting_state",
     "business_greeting_chat_count",
@@ -58,6 +59,14 @@
       "fieldtype": "Check",
       "label": "Show Activity Detail",
       "default": "1"
+    },
+    {
+      "fieldname": "preferred_persona",
+      "fieldtype": "Select",
+      "label": "Assistant Persona",
+      "options": "Jarvis\nJara",
+      "default": "Jarvis",
+      "description": "Which persona voice this user chats with: Jarvis (default) or Jara (calmer, more jovial). Voice only - same tools, permissions, and behaviour."
     },
     { "fieldname": "app_state_section", "fieldtype": "Section Break", "label": "App State" },
     {

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -37,3 +37,4 @@ jarvis.patches.v2_06_retire_app_learning_runs
 jarvis.patches.v2_06_skill_promotion_marker_and_shared_slug
 jarvis.patches.v2_07_agent_run_capability_snapshot
 jarvis.patches.v2_08_drop_jarvis_account_page
+jarvis.patches.v2_09_backfill_persona_enabled

--- a/jarvis/patches/v2_09_backfill_persona_enabled.py
+++ b/jarvis/patches/v2_09_backfill_persona_enabled.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+	"""Turn the persona picker ON for benches whose Jarvis Settings Single predates
+	the persona_enabled field. A new Check added to an existing Single is not
+	auto-defaulted, so the column reads 0; fresh installs get 1 from the field
+	default and never run patches, so both paths converge on ON. An admin can still
+	set it to 0 afterward to disable the persona feature fleet-wide (N7)."""
+	# Jarvis Settings is a Single (data in tabSingles, no tab<Doctype> table), so
+	# gate on the meta field, not a column check.
+	if not frappe.get_meta("Jarvis Settings").has_field("persona_enabled"):
+		return
+	frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)

--- a/jarvis/patches/v2_09_backfill_persona_enabled.py
+++ b/jarvis/patches/v2_09_backfill_persona_enabled.py
@@ -2,13 +2,34 @@ import frappe
 
 
 def execute():
-	"""Turn the persona picker ON for benches whose Jarvis Settings Single predates
-	the persona_enabled field. A new Check added to an existing Single is not
-	auto-defaulted, so the column reads 0; fresh installs get 1 from the field
-	default and never run patches, so both paths converge on ON. An admin can still
-	set it to 0 afterward to disable the persona feature fleet-wide (N7)."""
-	# Jarvis Settings is a Single (data in tabSingles, no tab<Doctype> table), so
-	# gate on the meta field, not a column check.
+	"""Seed persona_enabled=1 for benches whose Jarvis Settings Single predates
+	the field, so BOTH the read and the write paths default to ON.
+
+	The NULL=ON readers (``turn_handler.persona_feature_enabled``) already treat a
+	missing row as ON, but that alone is not enough: a full
+	``Jarvis Settings.save()`` (e.g. the onboarding LLM connect / re-sync) runs the
+	unset Check through ``get_valid_dict``, which coerces it to 0 and writes an
+	explicit "0" row - silently flipping the feature OFF with no admin action.
+	Seeding a real "1" row before any such save prevents that.
+
+	Row-existence probe, not a value test - mirrors
+	``learning.roles._seed_personalise_settings_defaults`` (the same v16
+	get_single_value coercion): seed ONLY when the row is absent, so a re-run
+	never clobbers an admin's explicit 0, and pass ``update_modified=False`` so the
+	backfill does not bump ``Jarvis Settings.modified``. Fresh installs get "1"
+	from the field default on first insert (``_set_defaults``) and never run
+	patches, so both paths converge on ON.
+
+	Jarvis Settings is a Single (data in tabSingles, no tab<Doctype> table), so
+	gate on the meta field, not a column check.
+	"""
 	if not frappe.get_meta("Jarvis Settings").has_field("persona_enabled"):
 		return
-	frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)
+	row = frappe.db.sql(
+		"select value from tabSingles where doctype=%s and field=%s",
+		("Jarvis Settings", "persona_enabled"),
+	)
+	if row:
+		# Already has a row - possibly an admin's explicit 0. Never clobber it.
+		return
+	frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1, update_modified=False)

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -227,6 +227,31 @@ class TestAdminGate(_UsageTestBase):
 		self.assertFalse(out["ok"])
 		self.assertEqual(out["reason"], "unknown_user")
 
+	def test_admin_limit_coerces_non_string_user_and_model(self):
+		# N10/I10: `user`/`model` must be string-coerced (_s) BEFORE the identity
+		# check. A raw dict `user` would be read by frappe.db.exists as FILTERS, so
+		# a crafted {"name": <real user>} could match and mutate a row the caller
+		# never named. With _s() the dict stringifies and never matches; a list
+		# `model` would 500 on .strip() without it. A revert at either site fails
+		# here.
+		out = user_settings_api.admin_set_user_limit(user={"name": USER_A}, monthly_token_limit=999)
+		self.assertFalse(out["ok"])
+		self.assertEqual(out["reason"], "unknown_user")
+		# The filter-match path must not have created / mutated USER_A's row.
+		self.assertFalse(frappe.db.exists(USETT, {"user": USER_A}))
+		out2 = user_settings_api.admin_set_user_model_limit(
+			user={"name": USER_A}, model="gpt-x", monthly_token_limit=999
+		)
+		self.assertFalse(out2["ok"])
+		self.assertEqual(out2["reason"], "unknown_user")
+		# A list `model` must be coerced (not .strip()ed raw, which 500s). The point
+		# of _s() at this site is crash-safety, so the call must simply not raise -
+		# it accepts the string coercion. A revert makes this line raise instead.
+		out3 = user_settings_api.admin_set_user_model_limit(
+			user=USER_A, model=["gpt-x"], monthly_token_limit=999
+		)
+		self.assertTrue(out3["ok"])
+
 	def test_admin_list_includes_row(self):
 		user_settings_api.admin_set_user_limit(user=USER_A, monthly_token_limit=99)
 		out = user_settings_api.admin_list_user_usage()
@@ -742,3 +767,111 @@ class TestPersonaPreference(_UsageTestBase):
 			frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)
 		# Re-enabled: the clause returns for the opted-in user.
 		self.assertEqual(_persona_clause(USER_A), "; persona: Jara")
+
+	def test_persona_enabled_defaults_on_without_singles_row(self):
+		# The C1 regression: frappe.db.get_single_value coerces an unset Check to 0,
+		# so an un-backfilled bench and a fresh install (which never runs patches)
+		# both read the switch as OFF. With NO tabSingles row, NULL=ON must hold at
+		# every reader: pill shown, clause active. Deleting the row is what the old
+		# test never did - a migrate-written row made ON look real.
+		from jarvis.chat.api import _persona_feature_enabled as boot_enabled
+		from jarvis.chat.api import get_chat_ui_settings
+		from jarvis.chat.turn_handler import _persona_clause, persona_feature_enabled
+
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		frappe.set_user("Administrator")
+		frappe.db.sql(
+			"delete from tabSingles where doctype=%s and field=%s",
+			("Jarvis Settings", "persona_enabled"),
+		)
+		self.assertTrue(persona_feature_enabled())  # NULL=ON at the source probe
+		self.assertTrue(boot_enabled())  # boot pill fails to ON, not OFF
+		frappe.set_user(USER_A)
+		self.assertTrue(get_chat_ui_settings()["persona_enabled"])
+		frappe.set_user("Administrator")
+		self.assertEqual(_persona_clause(USER_A), "; persona: Jara")  # clause active
+
+	def test_persona_readers_fail_open_on_db_error(self):
+		# A transient read failure must neither 500 the boot nor silently flip the
+		# feature: the pill defaults ON, the clause stays silent. Swap frappe.db.sql
+		# directly rather than mock.patch, which these persona tests avoid for the
+		# py3.14 walk_packages import trap.
+		from jarvis.chat.api import _persona_feature_enabled as boot_enabled
+		from jarvis.chat.turn_handler import _persona_clause
+
+		orig_sql = frappe.db.sql
+
+		def boom(*a, **k):
+			raise RuntimeError("db down")
+
+		frappe.db.sql = boom
+		try:
+			self.assertTrue(boot_enabled())  # boot pill fails open ON
+			self.assertEqual(_persona_clause(USER_A), "")  # clause fails silent
+		finally:
+			frappe.db.sql = orig_sql
+
+	def test_current_user_persona_none_on_error_omits_boot_key(self):
+		# I7: a failed persona read must return None so get_chat_ui_settings OMITS
+		# preferred_persona - the SPA reconciles (and caches) only when the key is
+		# present, so omitting it keeps the current pill instead of pinning it to a
+		# wrong default. The old code returned the "Jarvis" sentinel, which the
+		# persist:false reconcile wrote to localStorage.
+		from jarvis.chat import api as chat_api
+
+		orig_gv = frappe.db.get_value
+
+		def boom(*a, **k):
+			raise RuntimeError("boom")
+
+		frappe.db.get_value = boom
+		try:
+			self.assertIsNone(chat_api._current_user_persona())
+		finally:
+			frappe.db.get_value = orig_gv
+
+		# And the payload drops the key entirely (not a None value) when unreadable.
+		frappe.set_user(USER_A)
+		orig_helper = chat_api._current_user_persona
+		chat_api._current_user_persona = lambda: None
+		try:
+			ui = chat_api.get_chat_ui_settings()
+			self.assertNotIn("preferred_persona", ui)
+			self.assertTrue(ui["persona_enabled"])  # switch still reported
+		finally:
+			chat_api._current_user_persona = orig_helper
+			frappe.set_user("Administrator")
+
+	def test_backfill_seeds_when_absent_and_never_clobbers_admin_zero(self):
+		# The backfill protects the WRITE path: a full Jarvis Settings.save()
+		# coerces an unset Check to 0 (get_valid_dict), which would flip the switch
+		# OFF. Seeding a real 1 row prevents that - but ONLY when the row is absent,
+		# so an admin's explicit 0 is never clobbered on a re-run (idempotent).
+		from jarvis.patches.v2_09_backfill_persona_enabled import execute as backfill
+
+		q = ("Jarvis Settings", "persona_enabled")
+		sel = "select value from tabSingles where doctype=%s and field=%s"
+		frappe.db.sql("delete from tabSingles where doctype=%s and field=%s", q)
+		backfill()
+		self.assertEqual(int(frappe.db.sql(sel, q)[0][0]), 1)  # absent -> seeded 1
+		frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 0)
+		backfill()
+		self.assertEqual(int(frappe.db.sql(sel, q)[0][0]), 0)  # explicit 0 preserved
+		frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)
+
+	def test_full_settings_save_keeps_persona_on_after_backfill(self):
+		# End-to-end write-path regression: on an un-backfilled bench a full
+		# Jarvis Settings save would coerce persona_enabled to 0; once the backfill
+		# has seeded a real 1 row, the same save preserves ON.
+		from jarvis.chat.turn_handler import persona_feature_enabled
+		from jarvis.patches.v2_09_backfill_persona_enabled import execute as backfill
+
+		frappe.db.sql(
+			"delete from tabSingles where doctype=%s and field=%s",
+			("Jarvis Settings", "persona_enabled"),
+		)
+		backfill()
+		frappe.get_single("Jarvis Settings").save(ignore_permissions=True)
+		self.assertTrue(persona_feature_enabled())
+		frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)

--- a/jarvis/tests/test_user_settings.py
+++ b/jarvis/tests/test_user_settings.py
@@ -564,3 +564,181 @@ class TestMeasuredUsage(_UsageTestBase):
 			m = _measured_usage(USER_A)
 		mock_rows.assert_called_once_with(USER_A)
 		self.assertEqual(m["per_model"], sentinel)
+
+
+# --------------------------------------------------------------------------- #
+# 8. Persona preference (per-user voice) + the trusted [Context:] clause
+# --------------------------------------------------------------------------- #
+class TestPersonaPreference(_UsageTestBase):
+	"""preferred_persona picks Jarvis (default) or Jara. Only the non-default
+	value rides the trusted [Context:] line (turn_handler._persona_clause), and
+	the default path stays byte-identical to before the feature."""
+
+	def test_default_is_jarvis_and_clause_empty(self):
+		from jarvis.chat.turn_handler import _persona_clause
+
+		# No row at all: clause is empty (default) and never raises.
+		self.assertEqual(_persona_clause(USER_A), "")
+		# Lazy-created row defaults to Jarvis; the payload reflects it.
+		frappe.set_user(USER_A)
+		out = user_settings_api.get_my_settings()
+		self.assertEqual(out["data"]["preferred_persona"], "Jarvis")
+		frappe.set_user("Administrator")
+		self.assertEqual(_persona_clause(USER_A), "")
+
+	def test_update_to_jara_persists_and_emits_clause(self):
+		from jarvis.chat.turn_handler import _persona_clause
+
+		frappe.set_user(USER_A)
+		out = user_settings_api.update_my_settings(preferred_persona="Jara")
+		self.assertEqual(out["data"]["preferred_persona"], "Jara")
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "preferred_persona"), "Jara")
+		self.assertEqual(_persona_clause(USER_A), "; persona: Jara")
+
+	def test_switch_back_to_jarvis_clears_clause(self):
+		from jarvis.chat.turn_handler import _persona_clause
+
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		user_settings_api.update_my_settings(preferred_persona="Jarvis")
+		frappe.set_user("Administrator")
+		self.assertEqual(_persona_clause(USER_A), "")
+
+	def test_unknown_persona_rejected(self):
+		frappe.set_user(USER_A)
+		with self.assertRaises(frappe.ValidationError):
+			user_settings_api.update_my_settings(preferred_persona="Loki")
+		frappe.set_user("Administrator")
+		# Nothing persisted from the rejected write.
+		self.assertIn(
+			frappe.db.get_value(USETT, {"user": USER_A}, "preferred_persona") or "Jarvis",
+			("Jarvis", None),
+		)
+
+	def test_unknown_persona_message_does_not_reflect_input(self):
+		# The rejection is a fixed-enum sentence that echoes NOTHING back, so a
+		# hostile value can never be reflected - the self-XSS F11 guards against.
+		# A refactor to an f-string that interpolates the value would fail here.
+		frappe.set_user(USER_A)
+		with self.assertRaises(frappe.ValidationError) as cm:
+			user_settings_api.update_my_settings(preferred_persona="<img src=x onerror=alert(1)>")
+		frappe.set_user("Administrator")
+		msg = str(cm.exception)
+		self.assertNotIn("<img", msg)
+		self.assertNotIn("onerror", msg)
+		self.assertIn("Jarvis or Jara", msg)
+
+	def test_non_string_persona_does_not_500(self):
+		# This module's arg-type gate is not enforced at runtime (from __future__
+		# import annotations), so a hostile non-string reaches the handler raw. It
+		# must be coerced, not .strip()ed directly (which 500s on AttributeError).
+		frappe.set_user(USER_A)
+		# Structured values reject cleanly as a ValidationError, never a 500.
+		for bad in (["Jara"], {"persona": "Jara"}):
+			with self.assertRaises(frappe.ValidationError):
+				user_settings_api.update_my_settings(preferred_persona=bad)
+		# Falsy non-strings take the blank-clears-to-default path (store Jarvis).
+		for falsy in (0, False, []):
+			user_settings_api.update_my_settings(preferred_persona=falsy)
+			self.assertEqual(user_settings_api.get_my_settings()["data"]["preferred_persona"], "Jarvis")
+		frappe.set_user("Administrator")
+
+	def test_persona_update_touches_only_own_row(self):
+		usage.get_or_create_user_settings(USER_B)
+		frappe.db.commit()
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		frappe.set_user("Administrator")
+		self.assertEqual(
+			frappe.db.get_value(USETT, {"user": USER_B}, "preferred_persona") or "Jarvis", "Jarvis"
+		)
+
+	def test_persona_pref_leaves_other_prefs_untouched(self):
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(notify_enabled=0)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		out = user_settings_api.get_my_settings()
+		# The persona-only update must not disturb the earlier notify choice.
+		self.assertEqual(out["data"]["notify_enabled"], 0)
+		self.assertEqual(out["data"]["preferred_persona"], "Jara")
+		frappe.set_user("Administrator")
+
+	def _assembled_prompt_for(self, persona_user):
+		"""Insert a real conversation + message owned by ``persona_user`` and run the
+		shared, read-only ``assemble_prompt`` (the ONE place the [Context:] bracket
+		is built). Returns the assembled prompt string. conv/msg are cleaned up."""
+		from jarvis.chat.turn_handler import CONV, MSG, assemble_prompt
+
+		conv = frappe.get_doc({"doctype": CONV, "title": "persona-test", "auto_apply": 0}).insert(
+			ignore_permissions=True
+		)
+		self.addCleanup(lambda: frappe.delete_doc(CONV, conv.name, force=True, ignore_permissions=True))
+		msg = frappe.get_doc(
+			{"doctype": MSG, "conversation": conv.name, "seq": 1, "role": "user", "content": "hello"}
+		).insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc(MSG, msg.name, force=True, ignore_permissions=True))
+		# chat_user - and thus the persona lookup - derives from the message owner.
+		frappe.db.set_value(MSG, msg.name, "owner", persona_user, update_modified=False)
+		ap = assemble_prompt(
+			conv,
+			message_id=msg.name,
+			conversation_id=conv.name,
+			context={},
+			attachments=[],
+			user=persona_user,
+		)
+		return ap.user_message
+
+	def test_context_line_positions_persona_and_pins_byte_identical_default(self):
+		# Jara: the clause lands in the trusted [Context:] bracket immediately
+		# before "; chat user:", i.e. AFTER the date / locale / assistant-name
+		# clauses (the fixed f-string order in assemble_prompt). This pins both the
+		# presence AND the position.
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		frappe.set_user("Administrator")
+		jara_prompt = self._assembled_prompt_for(USER_A)
+		self.assertIn("; persona: Jara; chat user:", jara_prompt)
+		# EXACTLY one persona segment: a duplicated {persona_clause}{persona_clause}
+		# merge slip still satisfies the assertIn above, so pin the count too.
+		self.assertEqual(jara_prompt.count("persona:"), 1)
+
+		# Default user (USER_B, untouched): the assembled turn is byte-identical to
+		# before the feature - the bracket carries NO persona segment at all.
+		default_prompt = self._assembled_prompt_for(USER_B)
+		self.assertNotIn("persona:", default_prompt)
+		self.assertIn("; chat user:", default_prompt)  # assembly sanity
+
+	def test_chat_ui_settings_exposes_persona(self):
+		# get_chat_ui_settings feeds the SPA pill: it must reflect the server's
+		# current persona (for the cross-device reconcile) and the enabled flag (N11).
+		from jarvis.chat.api import get_chat_ui_settings
+
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		ui = get_chat_ui_settings()
+		self.assertEqual(ui["preferred_persona"], "Jara")
+		self.assertTrue(ui["persona_enabled"])  # default on
+		frappe.set_user("Administrator")
+
+	def test_persona_kill_switch_stops_pill_and_clause(self):
+		# Flipping Jarvis Settings.persona_enabled off must BOTH hide the pill and
+		# silence the clause, so an already-opted-in user stops getting the token
+		# (N7). Driven via set_single_value, NOT mock.patch (py3.14 import trap).
+		from jarvis.chat.api import get_chat_ui_settings
+		from jarvis.chat.turn_handler import _persona_clause
+
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(preferred_persona="Jara")
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 0)
+		try:
+			self.assertEqual(_persona_clause(USER_A), "")
+			frappe.set_user(USER_A)
+			self.assertFalse(get_chat_ui_settings()["persona_enabled"])
+			frappe.set_user("Administrator")
+		finally:
+			frappe.db.set_single_value("Jarvis Settings", "persona_enabled", 1)
+		# Re-enabled: the clause returns for the opted-in user.
+		self.assertEqual(_persona_clause(USER_A), "; persona: Jara")


### PR DESCRIPTION
## What

Adds a second persona, **Jara** (calmer, more jovial tone — identical tools, permissions and data), as a per-user choice, and moves the model/effort and persona selectors into the chat composer (ChatGPT / Claude-web style).

## Changes

**Backend**
- `Jarvis User Settings`: new `preferred_persona` Select (Jarvis default / Jara).
- `turn_handler._persona_clause`: folds the chosen persona into the trusted `[Context:]` line each turn via a fresh DB read. Jarvis/unset emits nothing, so the default turn stays byte-identical and pays zero extra tokens.
- `user_settings_api`: read + validated write of `preferred_persona`.

**Frontend**
- `ModelEffortPicker`: composer pill → model list + an **Effort** side-flyout. Opens upward and, being right-docked, leftward so it never clips the screen edge.
- `PersonaPill`: composer pill → Jarvis / Jara dropdown, each with its living mark.
- `Composer`: new `#right-toolbar` slot. Toolbar split — **left:** attach + persona; **right:** dictation mic + model/effort + send.
- Removes the model/effort control from the top bar and the interim settings-pane persona picker.

## Switching behaviour
Persona is read fresh from the DB on every turn, so switching takes effect on the **next message** — no reload, no reprovisioning.

## Testing
- `vitest`: 43/43 (composer snapshots updated for the new toolbar structure).
- Persona-preference unit tests in `test_user_settings.py`.
- SPA build green.

## Note
The companion `jarvis-persona` change (AGENTS.md "Personas" section defining Jara + version bump) ships separately and is reseeded via the Fleet Console.

---
## Deploy (corrected runbook)
Persona v0.63.0 must land FIRST:
1. From admin (jarvis_admin_v2): `fleet.content.push_content(cell=..., bundles=["persona"], restart=1)` — bumps `persona/current` to v0.63.0 and rolls tenant restarts. `restart=1` is mandatory (a pin bump is inert until the entrypoint re-runs the RO bind-mount symlinks). **`reseed_persona` is wrong here**: it is restart-only and re-applies whatever version is already pinned.
2. Verify `content_status` reports v0.63.0 on every host.
3. Deploy the bench: `bench --site <site> migrate` (preferred_persona + persona_enabled fields, patch v2_09) + SPA rebuild.
