### PR TITLE
fix(onboarding): ride the default admin URL instead of hard-failing

### DIFF
--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -14,26 +14,20 @@ from jarvis.exceptions import (
 	AdminUnreachableError,
 	AdminValidationError,
 )
+from jarvis.hooks import get_default_admin_url
 from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
 
 
 def _require_admin_url() -> None:
-	"""Raise ValidationError if no admin URL is configured deliberately.
+	"""Block onboarding only if no admin URL resolves at all.
 
-	start_signup must target a deliberately-chosen control plane. The admin
-	URL resolves (admin_client._admin_url ->
-	hooks.get_default_admin_url) in this order: (1) ``jarvis_admin_url`` in
-	site_config / common_site_config (via frappe.conf), (2) Jarvis Settings.
-	jarvis_admin_url per-customer override, (3) the hardcoded fallback for
-	fresh installs. Silently falling through to (3) on a multi-site bench may
-	land the wrong tenancy, so require (1) or (2) to be set - only (3)-alone is
-	the fail-fast case. (1) wins when both are set (site config is the
-	deployment's source of truth; a stale doctype value must not mask it).
+	get_default_admin_url() returns ``jarvis_admin_url`` from site_config (via
+	frappe.conf) or the bench-wide ``_DEFAULT_ADMIN_URL_FALLBACK``, so a
+	deployment relying on that default is allowed - this raises only when even
+	the default is empty. (admin_client._admin_url additionally honours the
+	Jarvis Settings per-customer override at call time.)
 	"""
-	configured = (frappe.db.get_single_value("Jarvis Settings", "jarvis_admin_url") or "").strip() or (
-		frappe.conf.get("jarvis_admin_url") or ""
-	).strip()
-	if not configured:
+	if not (get_default_admin_url() or "").strip():
 		raise frappe.ValidationError(
 			"No Jarvis Admin URL configured. Set Jarvis Settings -> Jarvis "
 			"Admin URL, or 'jarvis_admin_url' in site_config.json, before "

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -182,19 +182,28 @@ class TestSyncConnection(FrappeTestCase):
 		self.assertFalse(out["synced"])
 		self.assertEqual(out["reason"], "not onboarded")
 
-	def test_start_signup_throws_when_admin_url_blank(self):
-		"""start_signup requires the admin URL to be set deliberately before
-		any signup attempt."""
+	def test_start_signup_throws_only_when_no_admin_url_resolves(self):
+		"""start_signup blocks only when even the bench-wide default resolves
+		empty; a normal blank-config deployment rides the default (below)."""
 		_set_token("")
 		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
 		frappe.db.commit()
 		with (
 			patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}),
+			patch("jarvis.onboarding.get_default_admin_url", return_value=""),
 			patch("jarvis.onboarding.admin_client.signup") as mock_signup,
 		):
 			with self.assertRaises(frappe.ValidationError):
 				onboarding.start_signup("e4@x.com", "Co", "Annual Plan")
 			mock_signup.assert_not_called()
+
+	def test_require_admin_url_allows_default_fallback(self):
+		"""With no explicit jarvis_admin_url, onboarding rides the bench-wide
+		default instead of blocking (deliberate change)."""
+		frappe.db.set_value("Jarvis Settings", "Jarvis Settings", "jarvis_admin_url", "")
+		frappe.db.commit()
+		with patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}):
+			onboarding._require_admin_url()  # non-empty default → must not raise
 
 	def test_write_connection_ignores_legacy_api_token(self):
 		"""If admin returns the old api_token key, write_connection should NOT
@@ -417,8 +426,8 @@ class TestSignupEmailVerification(FrappeTestCase):
 		)
 
 	def test_check_signup_payment_state_requires_admin_url(self):
-		# Same pre-flight guard as start_signup - misconfigured bench
-		# shouldn't silently route to DEFAULT_ADMIN_URL.
+		# Same pre-flight guard as start_signup: blocks only when even the
+		# bench-wide default admin URL resolves empty.
 		frappe.db.set_value(
 			"Jarvis Settings",
 			"Jarvis Settings",
@@ -428,6 +437,7 @@ class TestSignupEmailVerification(FrappeTestCase):
 		frappe.db.commit()
 		with (
 			patch.dict(frappe.local.conf, {"jarvis_admin_url": ""}),
+			patch("jarvis.onboarding.get_default_admin_url", return_value=""),
 			patch(
 				"jarvis.onboarding.admin_client.get_signup_payment_state",
 			) as mock_call,


### PR DESCRIPTION
## What

`_require_admin_url()` hard-failed onboarding — `start_signup` and `check_signup_payment_state` returned a 500 (`No Jarvis Admin URL configured`) whenever `jarvis_admin_url` was set in **neither** Jarvis Settings **nor** site_config — even though `get_default_admin_url()` already resolves a usable bench-wide default (`_DEFAULT_ADMIN_URL_FALLBACK`).

## Change

- `_require_admin_url()` now validates `get_default_admin_url()` (explicit config → else the bench-wide default). It stays a guard, but raises **only when even the default resolves empty**.
- Tests retargeted to the new contract, plus a positive test that a blank-config deployment rides the default.

No change to `_DEFAULT_ADMIN_URL_FALLBACK` itself.

## Why

The old fail-fast guarded against "a multi-site bench landing the wrong tenancy," but each Jarvis tenant bench is single-site, so a blank config should ride the default instead of erroring out.

## Tests

`test_onboarding_sync` 38/38 and `test_admin_client` 58/58 (local, `test_jarvis`).
