### PR TITLE
Wizard path to reconnect a fresh bench to an existing paid subscription

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -38,6 +38,12 @@ export const setAutoApply = (conversation, value) =>
 // null/zeros until then (design doc §6, UsagePane's "Measured usage" block).
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
+// ---- account reconnect (fresh bench -> existing paid subscription) ---------
+export const startAccountReconnect = (email) =>
+	call("jarvis.onboarding.start_account_reconnect", { email });
+export const checkAccountReconnect = (requestId) =>
+	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId });
+
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
 
 // ---- workspace reset (customer self-serve, admin-gated) --------------------

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -41,8 +41,8 @@ export const getUsage = (conversation) =>
 // ---- account reconnect (fresh bench -> existing paid subscription) ---------
 export const startAccountReconnect = (email) =>
 	call("jarvis.onboarding.start_account_reconnect", { email });
-export const checkAccountReconnect = (requestId) =>
-	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId });
+export const checkAccountReconnect = (requestId, code) =>
+	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId, code: code || "" });
 
 export const isReadyForChat = () => call("jarvis.account.is_ready_for_chat");
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -391,6 +391,41 @@
 									/>
 								</div>
 							</template>
+							<template v-else-if="state.payPhase === 'reconnect'">
+								<div class="ob-body">
+									<div class="ob-head">
+										<h1>Check your email</h1>
+										<p>
+											We sent a reconnect link to
+											<b>{{ state.email || "your email" }}</b
+											>. Approving it connects this site to your existing
+											subscription — nothing to pay again. Waiting for your
+											approval…
+										</p>
+									</div>
+									<div class="mt-2.5 flex justify-center">
+										<JvSpinner :size="56" />
+									</div>
+									<p class="text-center text-p-sm text-ink-gray-5">
+										The link expires in 1 hour and signs your old site out. If
+										your inbox is unreachable, contact support — an operator
+										can approve the reconnect instead.
+									</p>
+									<Banner
+										v-if="state.payErr"
+										type="error"
+										:message="state.payErr"
+									/>
+								</div>
+								<div class="ob-foot">
+									<button class="ob-back" @click="cancelReconnect">
+										<FeatherIcon
+											name="chevron-left"
+											class="h-3.5 w-3.5 text-ink-gray-5"
+										/>Back
+									</button>
+								</div>
+							</template>
 							<template v-else-if="state.successData">
 								<div class="ob-body">
 									<div class="ob-head">
@@ -560,6 +595,21 @@
 										:message="state.payErr"
 										class="mx-auto mt-3.5 max-w-[560px]"
 									/>
+									<div
+										v-if="state.reconnectOffered && !state.payBusy"
+										class="mx-auto mt-2 max-w-[560px] text-center"
+									>
+										<Button
+											variant="subtle"
+											label="Already subscribed? Reconnect this site"
+											@click="startReconnect"
+										/>
+										<p class="mt-1.5 text-p-sm text-ink-gray-5">
+											We'll email a link to {{ state.email }} — approving it
+											connects this site to your existing subscription.
+											Nothing to pay again.
+										</p>
+									</div>
 								</div>
 								<div class="ob-foot">
 									<button
@@ -861,6 +911,8 @@ import {
 	getLlmSyncStatus,
 	listPlans,
 	listPaymentProviders,
+	startAccountReconnect,
+	checkAccountReconnect,
 	startSignup,
 	finishPayment,
 	saveSelfHosted,
@@ -928,7 +980,9 @@ const state = reactive({
 	plansLoading: false,
 	plansErr: "",
 	// pay (renderPay / renderVerifyEmail / startPay / openCheckout)
-	payPhase: "review", // "review" | "verify" - mirrors desk's step-3 vs "check your email" sub-screen
+	payPhase: "review", // "review" | "verify" | "reconnect" - step-3 sub-screens
+	reconnectOffered: false,
+	reconnectRequestId: "",
 	paymentProvider: "razorpay", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
 	// Gateways the operator has actually enabled, narrowed to what this build
 	// can render. Starts as razorpay-only so the step is never briefly empty
@@ -1354,6 +1408,10 @@ async function runStartPay() {
 	} catch (e) {
 		state.payBusy = false;
 		state.payErr = errMsg(e);
+		// The duplicate-email rejection on a FRESH bench (no stored creds to
+		// auto-resume with) usually means "my old site died" - offer the
+		// reconnect path instead of the dead end.
+		state.reconnectOffered = /already registered or pending/i.test(state.payErr);
 	}
 }
 
@@ -1393,6 +1451,62 @@ async function onVerifyCheck() {
 	} catch (e) {
 		state.payBusy = false;
 		state.payErr = errMsg(e);
+	}
+}
+
+function cancelReconnect() {
+	state.payPhase = "review";
+	state.payErr = "";
+	state.reconnectRequestId = "";
+}
+
+// "Already subscribed? Reconnect this site": start the admin-side magic-link
+// flow and switch the pay step into the waiting screen. The poll below rides
+// until the customer clicks the emailed link (or an operator approves).
+async function startReconnect() {
+	state.payErr = "";
+	state.reconnectOffered = false;
+	state.payBusy = true;
+	try {
+		const d = await startAccountReconnect(state.email);
+		state.reconnectRequestId = (d && d.request) || "";
+		state.payPhase = "reconnect";
+		pollReconnect();
+	} catch (e) {
+		state.payErr = errMsg(e);
+		state.reconnectOffered = true;
+	} finally {
+		state.payBusy = false;
+	}
+}
+
+async function pollReconnect() {
+	const deadline = Date.now() + 10 * 60 * 1000;
+	while (state.payPhase === "reconnect" && Date.now() < deadline) {
+		try {
+			const d = await checkAccountReconnect(state.reconnectRequestId);
+			if (d && d.status === "connected") {
+				// Same handoff as a completed payment: poll sync_connection to the
+				// customer's EXISTING container, then continue to the LLM step
+				// (this fresh site has no local LLM config to reuse).
+				state.successData = {};
+				await proceedAfterPay();
+				return;
+			}
+			if (d && d.status === "expired") {
+				state.payErr = "The reconnect request expired. Start it again.";
+				state.payPhase = "review";
+				state.reconnectOffered = true;
+				return;
+			}
+		} catch (e) {
+			/* transient admin hiccup - keep polling */
+		}
+		await _sleep(3000);
+	}
+	if (state.payPhase === "reconnect") {
+		state.payErr =
+			"Still waiting for the email approval. Click the link in your inbox, then this page will continue automatically.";
 	}
 }
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -403,14 +403,31 @@
 											approval…
 										</p>
 									</div>
-									<div class="mt-2.5 flex justify-center">
-										<JvSpinner :size="56" />
-									</div>
-									<p class="text-center text-p-sm text-ink-gray-5">
-										The link expires in 1 hour and signs your old site out. If
-										your inbox is unreachable, contact support — an operator
-										can approve the reconnect instead.
-									</p>
+									<template v-if="state.reconnectAwaitingCode">
+										<p class="text-center text-p-sm text-ink-gray-6">
+											Approved. Enter the code shown on the confirmation page
+											(or given to you by support) to finish.
+										</p>
+										<FormControl
+											class="mx-auto mt-2 max-w-[260px]"
+											type="text"
+											variant="outline"
+											label="Confirmation code"
+											v-model="state.reconnectCode"
+											placeholder="ABCD2345"
+											@keydown.enter="submitReconnectCode"
+										/>
+									</template>
+									<template v-else>
+										<div class="mt-2.5 flex justify-center">
+											<JvSpinner :size="56" />
+										</div>
+										<p class="text-center text-p-sm text-ink-gray-5">
+											The link expires in 1 hour and signs your old site out.
+											If your inbox is unreachable, contact support — an
+											operator can approve the reconnect instead.
+										</p>
+									</template>
 									<Banner
 										v-if="state.payErr"
 										type="error"
@@ -424,6 +441,15 @@
 											class="h-3.5 w-3.5 text-ink-gray-5"
 										/>Back
 									</button>
+									<Button
+										v-if="state.reconnectAwaitingCode"
+										variant="solid"
+										:loading="state.payBusy"
+										loading-text="Working…"
+										:disabled="!state.reconnectCode.trim()"
+										label="Finish reconnect"
+										@click="submitReconnectCode"
+									/>
 								</div>
 							</template>
 							<template v-else-if="state.successData">
@@ -983,6 +1009,8 @@ const state = reactive({
 	payPhase: "review", // "review" | "verify" | "reconnect" - step-3 sub-screens
 	reconnectOffered: false,
 	reconnectRequestId: "",
+	reconnectCode: "",
+	reconnectAwaitingCode: false,
 	paymentProvider: "razorpay", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
 	// Gateways the operator has actually enabled, narrowed to what this build
 	// can render. Starts as razorpay-only so the step is never briefly empty
@@ -1458,6 +1486,37 @@ function cancelReconnect() {
 	state.payPhase = "review";
 	state.payErr = "";
 	state.reconnectRequestId = "";
+	state.reconnectCode = "";
+	state.reconnectAwaitingCode = false;
+}
+
+// The code the customer read off the confirmation page (or got from support).
+// Wrong code => admin keeps answering awaiting_code, so just say so and let
+// them retype rather than restarting the whole reconnect.
+async function submitReconnectCode() {
+	if (!state.reconnectCode.trim()) return;
+	state.payErr = "";
+	state.payBusy = true;
+	try {
+		const d = await checkAccountReconnect(
+			state.reconnectRequestId,
+			state.reconnectCode.trim()
+		);
+		if (d && d.status === "connected") {
+			state.successData = {};
+			state.payBusy = false;
+			await proceedAfterPay();
+			return;
+		}
+		state.payErr =
+			d && d.status === "expired"
+				? "The reconnect request expired. Start it again."
+				: "That code didn't match. Check the confirmation page and try again.";
+	} catch (e) {
+		state.payErr = errMsg(e);
+	} finally {
+		state.payBusy = false;
+	}
 }
 
 // "Already subscribed? Reconnect this site": start the admin-side magic-link
@@ -1466,6 +1525,8 @@ function cancelReconnect() {
 async function startReconnect() {
 	state.payErr = "";
 	state.reconnectOffered = false;
+	state.reconnectCode = "";
+	state.reconnectAwaitingCode = false;
 	state.payBusy = true;
 	try {
 		const d = await startAccountReconnect(state.email);
@@ -1484,7 +1545,16 @@ async function pollReconnect() {
 	const deadline = Date.now() + 10 * 60 * 1000;
 	while (state.payPhase === "reconnect" && Date.now() < deadline) {
 		try {
-			const d = await checkAccountReconnect(state.reconnectRequestId);
+			const d = await checkAccountReconnect(state.reconnectRequestId, state.reconnectCode);
+			// Re-check AFTER the await: "Back" may have fired while it was in
+			// flight, and acting then would override the user's cancel.
+			if (state.payPhase !== "reconnect") return;
+			if (d && d.status === "awaiting_code") {
+				// Confirmed on the customer's side; stop spinning and ask for the
+				// code that binds delivery to whoever clicked (anti-phishing).
+				state.reconnectAwaitingCode = true;
+				return;
+			}
 			if (d && d.status === "connected") {
 				// Same handoff as a completed payment: poll sync_connection to the
 				// customer's EXISTING container, then continue to the LLM step

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -394,40 +394,28 @@
 							<template v-else-if="state.payPhase === 'reconnect'">
 								<div class="ob-body">
 									<div class="ob-head">
-										<h1>Check your email</h1>
+										<h1>Enter your reconnect code</h1>
 										<p>
-											We sent a reconnect link to
+											We emailed a code to
 											<b>{{ state.email || "your email" }}</b
-											>. Approving it connects this site to your existing
-											subscription — nothing to pay again. Waiting for your
-											approval…
+											>. Enter it here to connect this site to your existing
+											subscription — nothing to pay again.
 										</p>
 									</div>
-									<template v-if="state.reconnectAwaitingCode">
-										<p class="text-center text-p-sm text-ink-gray-6">
-											Approved. Enter the code shown on the confirmation page
-											(or given to you by support) to finish.
-										</p>
-										<FormControl
-											class="mx-auto mt-2 max-w-[260px]"
-											type="text"
-											variant="outline"
-											label="Confirmation code"
-											v-model="state.reconnectCode"
-											placeholder="ABCD2345"
-											@keydown.enter="submitReconnectCode"
-										/>
-									</template>
-									<template v-else>
-										<div class="mt-2.5 flex justify-center">
-											<JvSpinner :size="56" />
-										</div>
-										<p class="text-center text-p-sm text-ink-gray-5">
-											The link expires in 1 hour and signs your old site out.
-											If your inbox is unreachable, contact support — an
-											operator can approve the reconnect instead.
-										</p>
-									</template>
+									<FormControl
+										class="mx-auto mt-2 max-w-[260px]"
+										type="text"
+										variant="outline"
+										label="Reconnect code"
+										v-model="state.reconnectCode"
+										placeholder="ABCD2345"
+										@keydown.enter="submitReconnectCode"
+									/>
+									<p class="text-center text-p-sm text-ink-gray-5">
+										The code expires in 1 hour. Using it signs your old site
+										out. If you can't reach that inbox, contact support — they
+										can issue the code another way.
+									</p>
 									<Banner
 										v-if="state.payErr"
 										type="error"
@@ -442,7 +430,6 @@
 										/>Back
 									</button>
 									<Button
-										v-if="state.reconnectAwaitingCode"
 										variant="solid"
 										:loading="state.payBusy"
 										loading-text="Working…"
@@ -1010,7 +997,6 @@ const state = reactive({
 	reconnectOffered: false,
 	reconnectRequestId: "",
 	reconnectCode: "",
-	reconnectAwaitingCode: false,
 	paymentProvider: "razorpay", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
 	// Gateways the operator has actually enabled, narrowed to what this build
 	// can render. Starts as razorpay-only so the step is never briefly empty
@@ -1487,7 +1473,6 @@ function cancelReconnect() {
 	state.payErr = "";
 	state.reconnectRequestId = "";
 	state.reconnectCode = "";
-	state.reconnectAwaitingCode = false;
 }
 
 // The code the customer read off the confirmation page (or got from support).
@@ -1526,57 +1511,16 @@ async function startReconnect() {
 	state.payErr = "";
 	state.reconnectOffered = false;
 	state.reconnectCode = "";
-	state.reconnectAwaitingCode = false;
 	state.payBusy = true;
 	try {
 		const d = await startAccountReconnect(state.email);
 		state.reconnectRequestId = (d && d.request) || "";
 		state.payPhase = "reconnect";
-		pollReconnect();
 	} catch (e) {
 		state.payErr = errMsg(e);
 		state.reconnectOffered = true;
 	} finally {
 		state.payBusy = false;
-	}
-}
-
-async function pollReconnect() {
-	const deadline = Date.now() + 10 * 60 * 1000;
-	while (state.payPhase === "reconnect" && Date.now() < deadline) {
-		try {
-			const d = await checkAccountReconnect(state.reconnectRequestId, state.reconnectCode);
-			// Re-check AFTER the await: "Back" may have fired while it was in
-			// flight, and acting then would override the user's cancel.
-			if (state.payPhase !== "reconnect") return;
-			if (d && d.status === "awaiting_code") {
-				// Confirmed on the customer's side; stop spinning and ask for the
-				// code that binds delivery to whoever clicked (anti-phishing).
-				state.reconnectAwaitingCode = true;
-				return;
-			}
-			if (d && d.status === "connected") {
-				// Same handoff as a completed payment: poll sync_connection to the
-				// customer's EXISTING container, then continue to the LLM step
-				// (this fresh site has no local LLM config to reuse).
-				state.successData = {};
-				await proceedAfterPay();
-				return;
-			}
-			if (d && d.status === "expired") {
-				state.payErr = "The reconnect request expired. Start it again.";
-				state.payPhase = "review";
-				state.reconnectOffered = true;
-				return;
-			}
-		} catch (e) {
-			/* transient admin hiccup - keep polling */
-		}
-		await _sleep(3000);
-	}
-	if (state.payPhase === "reconnect") {
-		state.payErr =
-			"Still waiting for the email approval. Click the link in your inbox, then this page will continue automatically.";
 	}
 }
 

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -225,20 +225,24 @@ def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
 
 def request_account_reconnect(email: str) -> dict:
 	"""Guest: start a fresh-bench reconnect to an EXISTING paid account (wiped
-	site recovery). Admin emails a magic link to the registered address and
-	returns an opaque request_id to poll — the response is identical whether or
-	not the email matches an account. Nothing is re-paid."""
+	site recovery). Admin emails a CODE to the registered address and returns an
+	opaque request_id to poll — the response is identical whether or not the
+	email matches an account. Nothing is re-paid."""
 	return _post_guest(
 		path=_m("billing.reconnect.request_account_reconnect"),
 		body={"email": email, "frappe_site_url": frappe.utils.get_url()},
 	)
 
 
-def get_reconnect_state(request_id: str) -> dict:
-	"""Guest poll for the reconnect: {status: pending|expired} or
-	{status: ready, api_key, api_secret, customer, customer_password} once the
-	customer clicked the link (or an operator approved)."""
-	return _post_guest(path=_m("billing.reconnect.get_reconnect_state"), body={"request_id": request_id})
+def get_reconnect_state(request_id: str, code: str = "") -> dict:
+	"""Guest poll for the reconnect. Statuses: ``pending``, ``awaiting_code``
+	(the customer must type the code mailed to them, or one support issued),
+	``ready`` (+ api_key, api_secret, customer, customer_password), ``expired``.
+	The code is what releases the credentials - request_id alone never does."""
+	return _post_guest(
+		path=_m("billing.reconnect.get_reconnect_state"),
+		body={"request_id": request_id, "code": code},
+	)
 
 
 def get_signup_payment_state() -> dict:

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -223,6 +223,24 @@ def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
 
 
+def request_account_reconnect(email: str) -> dict:
+	"""Guest: start a fresh-bench reconnect to an EXISTING paid account (wiped
+	site recovery). Admin emails a magic link to the registered address and
+	returns an opaque request_id to poll — the response is identical whether or
+	not the email matches an account. Nothing is re-paid."""
+	return _post_guest(
+		path=_m("billing.reconnect.request_account_reconnect"),
+		body={"email": email, "frappe_site_url": frappe.utils.get_url()},
+	)
+
+
+def get_reconnect_state(request_id: str) -> dict:
+	"""Guest poll for the reconnect: {status: pending|expired} or
+	{status: ready, api_key, api_secret, customer, customer_password} once the
+	customer clicked the link (or an operator approved)."""
+	return _post_guest(path=_m("billing.reconnect.get_reconnect_state"), body={"request_id": request_id})
+
+
 def get_signup_payment_state() -> dict:
 	"""Authenticated poll. Returns one of:
 	    {pending_verification: True}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -507,6 +507,41 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 
 
 @frappe.whitelist()
+def start_account_reconnect(email: str) -> dict:
+	"""Fresh-bench recovery: ask admin to email a reconnect link to the
+	REGISTERED address of an existing paid account (wiped-site scenario — the
+	duplicate-email guard blocks re-signup, and nothing should be re-paid).
+	Returns {request, message}; the wizard polls ``check_account_reconnect``.
+	Same System-Manager gating as the rest of onboarding."""
+	require_jarvis_admin()
+	_require_admin_url()
+	return _surface(admin_client.request_account_reconnect, email)
+
+
+@frappe.whitelist()
+def check_account_reconnect(request_id: str) -> dict:
+	"""Poll the reconnect. Once the customer clicks the emailed link (or an
+	operator approves), admin delivers rotated credentials — persist them and
+	grant the onboarding admin role, exactly like a fresh signup would. The
+	wizard then rides the normal sync_connection path to the customer's
+	EXISTING container; only the LLM step needs re-doing on this fresh site."""
+	require_jarvis_admin()
+	data = _surface(admin_client.get_reconnect_state, request_id) or {}
+	if data.get("status") != "ready":
+		return {"status": data.get("status") or "expired"}
+	write_connection(
+		{
+			"api_key": data.get("api_key", ""),
+			"api_secret": data.get("api_secret", ""),
+			"customer": data.get("customer", ""),
+			"customer_password": data.get("customer_password", ""),
+		}
+	)
+	grant_onboarding_admin()
+	return {"status": "connected"}
+
+
+@frappe.whitelist()
 def get_account_defaults() -> dict:
 	"""Prefill for the onboarding Account step so the customer doesn't retype what
 	the site already knows: the caller's email + a default company. Company is the

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -519,14 +519,15 @@ def start_account_reconnect(email: str) -> dict:
 
 
 @frappe.whitelist()
-def check_account_reconnect(request_id: str) -> dict:
+def check_account_reconnect(request_id: str, code: str = "") -> dict:
 	"""Poll the reconnect. Once the customer clicks the emailed link (or an
-	operator approves), admin delivers rotated credentials — persist them and
+	operator approves) AND the customer relays the confirmation code shown to
+	them, admin delivers rotated credentials — persist them and
 	grant the onboarding admin role, exactly like a fresh signup would. The
 	wizard then rides the normal sync_connection path to the customer's
 	EXISTING container; only the LLM step needs re-doing on this fresh site."""
 	require_jarvis_admin()
-	data = _surface(admin_client.get_reconnect_state, request_id) or {}
+	data = _surface(admin_client.get_reconnect_state, request_id, code) or {}
 	if data.get("status") != "ready":
 		return {"status": data.get("status") or "expired"}
 	write_connection(

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -508,11 +508,12 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 
 @frappe.whitelist()
 def start_account_reconnect(email: str) -> dict:
-	"""Fresh-bench recovery: ask admin to email a reconnect link to the
+	"""Fresh-bench recovery: ask admin to email a reconnect CODE to the
 	REGISTERED address of an existing paid account (wiped-site scenario — the
 	duplicate-email guard blocks re-signup, and nothing should be re-paid).
-	Returns {request, message}; the wizard polls ``check_account_reconnect``.
-	Same System-Manager gating as the rest of onboarding."""
+	Returns {request, message}; the customer then types the code, which
+	``check_account_reconnect`` redeems. Same System-Manager gating as the rest
+	of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
 	return _surface(admin_client.request_account_reconnect, email)
@@ -520,9 +521,9 @@ def start_account_reconnect(email: str) -> dict:
 
 @frappe.whitelist()
 def check_account_reconnect(request_id: str, code: str = "") -> dict:
-	"""Poll the reconnect. Once the customer clicks the emailed link (or an
-	operator approves) AND the customer relays the confirmation code shown to
-	them, admin delivers rotated credentials — persist them and
+	"""Redeem the reconnect code the customer received by email (or from
+	support). Only a correct code releases anything: admin then rotates and
+	delivers the credentials — persist them and
 	grant the onboarding admin role, exactly like a fresh signup would. The
 	wizard then rides the normal sync_connection path to the customer's
 	EXISTING container; only the LLM step needs re-doing on this fresh site."""

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -838,18 +838,12 @@ class TestSignupResumeFallback(FrappeTestCase):
 
 	_DUP = "An account with this email is already registered or pending."
 
-
-class TestAccountReconnect(FrappeTestCase):
-	"""Fresh-bench reconnect wrappers (admin_client mocked)."""
-
 	def setUp(self):
 		self._snap = _snapshot_settings()
 		s = frappe.get_single("Jarvis Settings")
 		_set_token("tok")
 		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		s.db_set("jarvis_admin_customer_email", "resume-me@example.com")
-
-		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		frappe.db.commit()
 
 	def tearDown(self):
@@ -903,6 +897,19 @@ class TestAccountReconnect(FrappeTestCase):
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		self.assertIn("already registered", str(ctx.exception))
+
+
+class TestAccountReconnect(FrappeTestCase):
+	"""Fresh-bench reconnect wrappers (admin_client mocked)."""
+
+	def setUp(self):
+		self._snap = _snapshot_settings()
+		s = frappe.get_single("Jarvis Settings")
+		s.db_set("jarvis_admin_url", "https://fleet.example.test")
+		frappe.db.commit()
+
+	def tearDown(self):
+		_restore_settings(self._snap)
 
 	def test_start_proxies_request(self):
 		with patch(

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -944,6 +944,27 @@ class TestAccountReconnect(FrappeTestCase):
 		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False), "new-key")
 		self.assertEqual(s.jarvis_admin_customer_email, "someone@example.com")
 
+	def test_check_awaiting_code_writes_nothing(self):
+		"""Confirmed but not yet unlocked: the code binds delivery to whoever
+		clicked, so nothing is persisted until it matches."""
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={"status": "awaiting_code"},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "awaiting_code")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_check_passes_code_through(self):
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={"status": "awaiting_code"},
+		) as poll:
+			onboarding.check_account_reconnect("rid-1", "ABCD2345")
+		poll.assert_called_once_with("rid-1", "ABCD2345")
+
 	def test_check_expired_passthrough(self):
 		with patch(
 			"jarvis.onboarding.admin_client.get_reconnect_state",

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -849,7 +849,6 @@ class TestAccountReconnect(FrappeTestCase):
 		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		s.db_set("jarvis_admin_customer_email", "resume-me@example.com")
 
-
 		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		frappe.db.commit()
 
@@ -904,7 +903,6 @@ class TestAccountReconnect(FrappeTestCase):
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		self.assertIn("already registered", str(ctx.exception))
-
 
 	def test_start_proxies_request(self):
 		with patch(

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -838,12 +838,19 @@ class TestSignupResumeFallback(FrappeTestCase):
 
 	_DUP = "An account with this email is already registered or pending."
 
+
+class TestAccountReconnect(FrappeTestCase):
+	"""Fresh-bench reconnect wrappers (admin_client mocked)."""
+
 	def setUp(self):
 		self._snap = _snapshot_settings()
 		s = frappe.get_single("Jarvis Settings")
 		_set_token("tok")
 		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		s.db_set("jarvis_admin_customer_email", "resume-me@example.com")
+
+
+		s.db_set("jarvis_admin_url", "https://fleet.example.test")
 		frappe.db.commit()
 
 	def tearDown(self):
@@ -897,3 +904,50 @@ class TestSignupResumeFallback(FrappeTestCase):
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
 		self.assertIn("already registered", str(ctx.exception))
+
+
+	def test_start_proxies_request(self):
+		with patch(
+			"jarvis.onboarding.admin_client.request_account_reconnect",
+			return_value={"request": "rid-1", "message": "check your email"},
+		) as req:
+			out = onboarding.start_account_reconnect("someone@example.com")
+		req.assert_called_once_with("someone@example.com")
+		self.assertEqual(out["request"], "rid-1")
+
+	def test_check_pending_writes_nothing(self):
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={"status": "pending"},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "pending")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertFalse(s.get_password("jarvis_admin_api_key", raise_exception=False))
+
+	def test_check_ready_persists_rotated_credentials(self):
+		_set_token("")
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={
+				"status": "ready",
+				"api_key": "new-key",
+				"api_secret": "new-secret",
+				"customer": "someone@example.com",
+				"customer_password": "new-pass",
+			},
+		):
+			out = onboarding.check_account_reconnect("rid-1")
+		self.assertEqual(out["status"], "connected")
+		s = frappe.get_single("Jarvis Settings")
+		self.assertEqual(s.get_password("jarvis_admin_api_key", raise_exception=False), "new-key")
+		self.assertEqual(s.jarvis_admin_customer_email, "someone@example.com")
+
+	def test_check_expired_passthrough(self):
+		with patch(
+			"jarvis.onboarding.admin_client.get_reconnect_state",
+			return_value={"status": "expired"},
+		):
+			out = onboarding.check_account_reconnect("rid-x")
+		self.assertEqual(out["status"], "expired")


### PR DESCRIPTION
Companion to Aerele-RnD/jarvis-admin-v2#131. Disaster recovery for the *"my Frappe site died"* scenario: the customer already **paid**, but the rebuilt bench holds no credentials — signup dead-ends on the duplicate-email guard, and the only workaround was paying again under a different email.

When that rejection hits a bench with nothing to auto-resume (#511 covers the has-credentials case), the pay step offers **"Already subscribed? Reconnect this site"**:

1. `start_account_reconnect(email)` asks admin to email a **reconnect code** to the *registered* address (no link — nothing to click, nothing to phish; the response is identical whether or not the email exists).
2. The wizard asks for that code.
3. `check_account_reconnect(request_id, code)` redeems it: admin rotates the credentials (signing the dead site out), the bench persists them, grants the onboarding admin role, and rides the normal `proceedAfterPay` handoff to the customer's **existing container**.

Support can issue a code out-of-band when the inbox itself is unreachable (admin#133) — the same input accepts it.

Subscription untouched — **nothing re-paid**. Honest limits: chat history died with the old site DB, and the wizard resumes at the LLM step (a fresh site has no local LLM config to reuse).

Tests: `test_onboarding_sync` +6 (start proxy, pending/awaiting-code persist nothing, code passed through, ready persists rotated creds, expired passthrough); frontend builds clean.
