### PR TITLE
fix(chat): tell openclaw when WE picked the model, so failover survives

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -689,15 +689,32 @@ class OpenclawSession:
 		session_key: str,
 		model_ref: str,
 		*,
+		source: str = "user",
 		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
 	) -> None:
 		"""Point the session at ``model_ref`` (``"<provider>/<model>"`` or
 		bare ``"<model>"``) via ``sessions.patch``. chat.send has no per-turn
 		model param, so per-conversation overrides are applied to the session
-		before the send."""
+		before the send.
+
+		``source`` MUST be ``"auto"`` when WE picked the model rather than the
+		customer. openclaw drops the agent's entire model.fallbacks chain for an
+		overridden session unless the override declares itself automatic. From the
+		2026.6.8 bundle -- the sessions.patch handler:
+
+		    entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user"
+
+		and ``resolveEffectiveModelFallbacks`` returns ``[]`` for any non-"auto"
+		override. Omitting the field is therefore NOT neutral: it reads as "user" and
+		silently disables failover (see ``turn_handler._session_model_for``).
+		"""
 		self._request(
 			"sessions.patch",
-			{"key": session_key, "model": model_ref},
+			{
+				"key": session_key,
+				"model": model_ref,
+				"modelOverrideSource": "auto" if source == "auto" else "user",
+			},
 			timeout_s=timeout_s,
 		)
 

--- a/jarvis/chat/prepare.py
+++ b/jarvis/chat/prepare.py
@@ -135,7 +135,7 @@ def run_prepare(run_id: str, relay_target_id: str | None = None) -> dict:
 		return {"ok": False, "reason": "self_host"}
 
 	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
-	effective_model, oauth_provider_id = turn_handler._session_model_for(conv)
+	effective_model, oauth_provider_id, model_source = turn_handler._session_model_for(conv)
 	managed_attachments = turn_handler._to_managed_attachments(ap.vision_parts) if ap.vision_parts else None
 
 	if not conv.session_key:
@@ -170,7 +170,7 @@ def run_prepare(run_id: str, relay_target_id: str | None = None) -> dict:
 			if effective_model:
 				model_ref = f"{oauth_provider_id}/{effective_model}" if oauth_provider_id else effective_model
 				try:
-					sess.set_session_model(session_key, model_ref)
+					sess.set_session_model(session_key, model_ref, source=model_source)
 				except OpenclawUnreachableError:
 					raise
 				except Exception:

--- a/jarvis/chat/relay_mux.py
+++ b/jarvis/chat/relay_mux.py
@@ -632,11 +632,29 @@ class RelayMux:
 		return self.issue_rpc("chat.send", params, timeout_s=timeout_s)
 
 	def set_session_model(
-		self, session_key: str, model_ref: str, *, timeout_s: float = DEFAULT_RPC_TIMEOUT_S
+		self,
+		session_key: str,
+		model_ref: str,
+		*,
+		source: str = "user",
+		timeout_s: float = DEFAULT_RPC_TIMEOUT_S,
 	) -> PendingRpc:
 		"""``sessions.patch`` — per-conversation model override, issued mid-stream
-		without stealing any lane's frames."""
-		return self.issue_rpc("sessions.patch", {"key": session_key, "model": model_ref}, timeout_s=timeout_s)
+		without stealing any lane's frames.
+
+		``source="auto"`` when WE picked the model; omitting it reads as "user" and
+		makes openclaw drop the agent's model.fallbacks chain. Same contract as
+		``OpenclawSession.set_session_model`` — see its docstring for the bundle
+		reference."""
+		return self.issue_rpc(
+			"sessions.patch",
+			{
+				"key": session_key,
+				"model": model_ref,
+				"modelOverrideSource": "auto" if source == "auto" else "user",
+			},
+			timeout_s=timeout_s,
+		)
 
 	def abort(
 		self, session_key: str, run_id: str | None = None, *, timeout_s: float = DEFAULT_RPC_TIMEOUT_S

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -326,9 +326,14 @@ def _resolve_model_and_provider(conv) -> tuple[str, str | None]:
 	return effective_model, provider
 
 
-def _session_model_for(conv) -> tuple[str, str | None]:
+def _session_model_for(conv) -> tuple[str, str | None, str]:
 	"""The model to PATCH THE SESSION to -- a different question from
 	_resolve_model_and_provider's, and the distinction is the whole fix.
+
+	Returns ``(model, provider, source)``. ``source`` is ``"user"`` when the
+	conversation actually asked for this model and ``"auto"`` when WE picked it on
+	the customer's behalf, and it is load-bearing rather than informational: see
+	the note on the pool branch below.
 
 	_resolve_model_and_provider answers "what model does this conversation want", where
 	"" means "no opinion, let the agent's configured default stand". Two other callers
@@ -355,19 +360,41 @@ def _session_model_for(conv) -> tuple[str, str | None]:
 	with `model_not_found` -- and because that is an explicit bad-id rejection rather than
 	an upstream failure, openclaw's native failover never engages. Name the pool's PRIMARY
 	real model instead; the container's own model.fallbacks chain covers the rest.
+
+	...but ONLY if we also tell openclaw we picked it. Naming a model makes the session
+	model-OVERRIDDEN, and openclaw drops the whole fallback chain for an overridden
+	session unless the override is flagged as automatic. From its 2026.6.8 bundle:
+
+	    resolveEffectiveModelFallbacks:
+	      if (!hasSessionModelOverride) return agentFallbacksOverride;   // no pin: chain applies
+	      if (!(modelOverrideSource === "auto" || ...)) return [];       // pinned: NO chain
+
+	so an unflagged pin yields zero candidates, `fallbackConfigured` false, and the run
+	surfaces the upstream error instead of failing over. Measured live 2026-07-28: a real
+	429 on the primary logged `decision=candidate_failed reason=rate_limit next=none` with
+	a perfectly good second model configured. That is this function naming a model and the
+	patch not saying who chose it -- hence ``source``, which the caller forwards as
+	``sessions.patch``'s ``modelOverrideSource``.
+
+	"user" stays the default for a real pin ON PURPOSE: someone who explicitly selects
+	Gemini should get an error, not a silent switch to another vendor mid-conversation.
 	"""
 	model, provider = _resolve_model_and_provider(conv)
 	if model:
-		return model, provider
+		return model, provider, "user"  # the conversation asked for this one
 	settings = frappe.get_single("Jarvis Settings")
 	if getattr(settings, "proxy_active", 0):
-		return POOL_VIRTUAL_MODEL, None  # Bifrost expands it into the chain
+		# Bifrost expands the placeholder into the chain itself, so the chain does not
+		# depend on openclaw's fallbacks here -- but this IS still our choice, not the
+		# customer's, and mislabelling it "user" would be wrong if the pool ever moves
+		# off Bifrost.
+		return POOL_VIRTUAL_MODEL, None, "auto"
 	primary = pool_primary_model(settings)
 	if primary:
-		return primary, None  # openclaw-direct pool: name a model it really has
+		return primary, None, "auto"  # openclaw-direct pool: we chose it, keep the chain
 	# Direct mode already resolves to settings.llm_model, so "" here means the site has
 	# no model configured at all -- nothing useful to patch. Unchanged behaviour.
-	return model, provider
+	return model, provider, "user"
 
 
 def _thinking_prefix(thinking_override: str | None) -> str:
@@ -939,7 +966,7 @@ def handle_chat_send(payload: dict) -> None:
 			# retry inside this turn because tokens may have already
 			# streamed to the UI by the time the failure surfaces.
 			gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
-			effective_model, oauth_provider_id = _session_model_for(conv)
+			effective_model, oauth_provider_id, model_source = _session_model_for(conv)
 			if not conv.session_key:
 				# First turn of this conversation pays session-create and is the
 				# most cold-start-prone (a dormant container takes ~10-25s to
@@ -982,7 +1009,7 @@ def handle_chat_send(payload: dict) -> None:
 							f"{oauth_provider_id}/{effective_model}" if oauth_provider_id else effective_model
 						)
 						try:
-							sess.set_session_model(conv.session_key, model_ref)
+							sess.set_session_model(conv.session_key, model_ref, source=model_source)
 						except OpenclawUnreachableError:
 							raise
 						except Exception:

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -286,7 +286,7 @@ class TestRelayTurnEvents(FrappeTestCase):
 
 
 class TestSetSessionModel(FrappeTestCase):
-	def test_sends_exact_sessions_patch_params(self):
+	def _capture(self, *args, **kwargs):
 		sess = OpenclawSession.__new__(OpenclawSession)
 		captured = {}
 
@@ -296,6 +296,33 @@ class TestSetSessionModel(FrappeTestCase):
 			return {"ok": True, "payload": {}}
 
 		sess._request = fake_request
-		sess.set_session_model("sk", "openai/gpt-4o")
+		sess.set_session_model(*args, **kwargs)
+		return captured
+
+	def test_sends_exact_sessions_patch_params(self):
+		captured = self._capture("sk", "openai/gpt-4o")
 		self.assertEqual(captured["method"], "sessions.patch")
-		self.assertEqual(captured["params"], {"key": "sk", "model": "openai/gpt-4o"})
+		self.assertEqual(
+			captured["params"],
+			{"key": "sk", "model": "openai/gpt-4o", "modelOverrideSource": "user"},
+		)
+
+	def test_an_auto_chosen_model_is_flagged_on_the_wire(self):
+		"""``modelOverrideSource`` is what keeps openclaw's failover alive.
+
+		Its sessions.patch handler reads
+		``modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user"``
+		and ``resolveEffectiveModelFallbacks`` returns ``[]`` for a non-"auto"
+		override. Omitting the field is therefore NOT neutral: it reads as "user"
+		and silently disables the agent's entire model.fallbacks chain, which is
+		exactly how a live 429 produced ``next=none`` on 2026-07-28.
+		"""
+		captured = self._capture("sk", "gemini/gemini-3.6-flash", source="auto")
+		self.assertEqual(captured["params"]["modelOverrideSource"], "auto")
+
+	def test_an_unrecognised_source_degrades_to_user_not_auto(self):
+		"""Fail closed: only a literal "auto" unlocks the fallback chain, so a typo
+		or some future source name can never silently re-route a model the customer
+		pinned on purpose to a different vendor."""
+		captured = self._capture("sk", "openai/gpt-4o", source="sometimes")
+		self.assertEqual(captured["params"]["modelOverrideSource"], "user")

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -2616,7 +2616,7 @@ class TestFT5ChatWorkerPoolAwareness(_RT3SettingsTestCase):
 
 		self._pool_of_two()
 		conv = self._make_conv(model_override="")
-		model, provider = _session_model_for(conv)
+		model, provider, source = _session_model_for(conv)
 		self.assertEqual(model, "gpt-4o", "must be the pool's primary (order 0), a real model id")
 		self.assertNotEqual(model, POOL_VIRTUAL_MODEL, "no Bifrost is deployed to expand the placeholder")
 		self.assertTrue(
@@ -2631,7 +2631,7 @@ class TestFT5ChatWorkerPoolAwareness(_RT3SettingsTestCase):
 
 		self._pool_with_subscription()
 		conv = self._make_conv(model_override="")
-		model, provider = _session_model_for(conv)
+		model, provider, source = _session_model_for(conv)
 		self.assertEqual(model, POOL_VIRTUAL_MODEL)
 		self.assertIsNone(provider)
 
@@ -2642,7 +2642,7 @@ class TestFT5ChatWorkerPoolAwareness(_RT3SettingsTestCase):
 
 		self._pool_of_two()
 		conv = self._make_conv(model_override="a-model-the-customer-deleted")
-		model, provider = _session_model_for(conv)
+		model, provider, source = _session_model_for(conv)
 		self.assertEqual(model, "gpt-4o")
 		self.assertIsNone(provider)
 
@@ -2663,7 +2663,7 @@ class TestFT5ChatWorkerPoolAwareness(_RT3SettingsTestCase):
 		)
 		settings = frappe.get_single("Jarvis Settings")
 		self.assertEqual(int(settings.proxy_active or 0), 0)
-		model, _ = _session_model_for(self._make_conv(model_override=""))
+		model, _, source = _session_model_for(self._make_conv(model_override=""))
 		self.assertEqual(model, "gpt-4o")
 
 	def test_session_model_for_honours_a_valid_pin(self):
@@ -2671,9 +2671,41 @@ class TestFT5ChatWorkerPoolAwareness(_RT3SettingsTestCase):
 
 		self._pool_of_two()
 		conv = self._make_conv(model_override="gpt-3.5-turbo")
-		model, provider = _session_model_for(conv)
+		model, provider, source = _session_model_for(conv)
 		self.assertEqual(model, "gpt-3.5-turbo")
 		self.assertIsNone(provider)
+		self.assertEqual(source, "user", "an explicit pin is the customer's own choice")
+
+	def test_a_model_we_chose_is_sourced_auto_so_failover_survives(self):
+		"""``source`` is load-bearing, not documentation.
+
+		Naming a model makes the openclaw session model-OVERRIDDEN, and its
+		``resolveEffectiveModelFallbacks`` returns ``[]`` for any override whose
+		``modelOverrideSource`` is not "auto". That zeroes the fallback candidates,
+		makes ``fallbackConfigured`` false, and turns a recoverable upstream failure
+		into a surfaced error. Measured live 2026-07-28: a real 429 on the pool
+		primary logged ``decision=candidate_failed reason=rate_limit next=none``
+		with a healthy second model configured, because this patch said "user".
+
+		So every model WE pick on the customer's behalf must report "auto".
+		"""
+		from jarvis.chat.worker import POOL_VIRTUAL_MODEL, _session_model_for
+
+		# openclaw-direct pool, no pin: we name the primary, so we chose it.
+		self._pool_of_two()
+		_, _, source = _session_model_for(self._make_conv(model_override=""))
+		self.assertEqual(source, "auto")
+
+		# A pin naming a model the customer has since deleted also resets to the
+		# primary -- that reset is our decision, not theirs.
+		_, _, source = _session_model_for(self._make_conv(model_override="deleted-model"))
+		self.assertEqual(source, "auto")
+
+		# The Bifrost path names the placeholder; still our choice, not the customer's.
+		self._pool_with_subscription()
+		model, _, source = _session_model_for(self._make_conv(model_override=""))
+		self.assertEqual(model, POOL_VIRTUAL_MODEL)
+		self.assertEqual(source, "auto")
 
 	def test_pool_mode_validates_override_against_enabled_models(self):
 		"""Pool mode, model_override in enabled models → override returned."""


### PR DESCRIPTION
## The bug

A BYO api-key pool **never failed over**. Measured live on `jarvis.proxy` with two real vendor keys: a genuine 429 on the pool primary, with a healthy second model configured, produced

```
[model-fallback/decision] decision=candidate_failed
  requested=gemini-0/gemini-2.5-pro  reason=rate_limit  next=none
```

and surfaced the error to the customer instead of switching vendors.

This matters beyond one tenant: **openclaw-native failover is the entire premise of retiring the per-tenant CLIProxyAPI/Bifrost sidecars.** On the evidence above it looked like the premise was false.

## It was ours, and it is one field

Read out of the shipped 2026.6.8 bundle rather than inferred. `resolveEffectiveModelFallbacks`:

```js
if (!hasSessionModelOverride) return agentFallbacksOverride;   // no pin -> chain applies
if (!(modelOverrideSource === "auto" || ...)) return [];       // pinned -> NO chain
```

and the `sessions.patch` handler:

```js
entry.modelOverrideSource = patch.modelOverrideSource === "auto" ? "auto" : "user";
```

Naming a model makes the session model-**overridden**, and an override that does not declare itself automatic drops the agent's whole `model.fallbacks` chain: zero candidates, `fallbackConfigured` false, `resolveRunFailoverDecision` returns `surface_error`. **Omitting the field is not neutral — it reads as `"user"`.**

We began naming a model on every unpinned turn in #299/#498, for good reasons: openclaw remembers a session's model across turns, so "send nothing" left a stale pin live forever, and the `jarvis-pool` placeholder is a hard `model_not_found` against a sidecar-free container. That fix was correct. It just never told openclaw *who chose the model*.

## The change

`_session_model_for` returns `(model, provider, source)`; both transports forward it as `modelOverrideSource`.

`"user"` remains the default **on purpose** — someone who explicitly selects Gemini should get an error, not a silent switch to another vendor mid-conversation. Only a literal `"auto"` unlocks the chain, so a typo or a future source name fails closed.

Both "we chose it" cases report `auto`: an unpinned pool turn, and resetting a pin naming a model the customer has since deleted.

## Tests

Three new, and all fail against the current code (the first two raise on the old signature/arity):

- wire payload carries `modelOverrideSource: "auto"` when we picked the model
- an unrecognised source degrades to `"user"`, never `"auto"`
- `_session_model_for` reports `auto` for both auto paths and `user` for a real pin

The pre-existing exact-params test was asserting the old wire contract and is updated to the new one.

## Verification still owed

Re-run the live failover with the primary on `gemini-2.5-pro` (a guaranteed 429 on a free key) and confirm the log shows `candidate_succeeded` on the second vendor instead of `next=none`. I'll post that here before marking ready.