### PR TITLE
fix(pool): a BYO api-key pool badges direct, not proxy, regardless of size

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -1959,7 +1959,14 @@ const badgeLabel = computed(() => {
 	// api-key OR a lone chat subscription - shows NO badge: it was just noise, and
 	// "Proxy" on a single subscription read as confusing/broken.
 	if (llmMode.value === "preset") return selectedPreset.value ? "Proxy (failover)" : "";
-	if (llmMode.value === "custom") return validModels.value.length >= 2 ? "Proxy (failover)" : "";
+	// A 2+-model custom pool only reads "Proxy (failover)" when badgeMode agrees a
+	// sidecar is actually deployed (some enabled model is a subscription). A pure
+	// BYO api-key pool of any size is openclaw-direct - no proxy, so no badge.
+	// (was: any 2+ rows counted as "Proxy (failover)" regardless of credential type)
+	if (llmMode.value === "custom")
+		return validModels.value.length >= 2 && badgeMode.value === "proxy"
+			? "Proxy (failover)"
+			: "";
 	return ""; // quick = single model
 });
 // Save-bar status pill (Option A - "honest model health"). Reflects the outcome

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -11,8 +11,13 @@ export function deriveMode(models, preset) {
 				m.credentialType === "subscription" ||
 				m.credential_type === "subscription")
 	);
-	if (hasSubscription) return "proxy";
-	return list.length <= 1 && !preset ? "direct" : "proxy";
+	// A preset is picked from a curated ladder that always resolves through the
+	// proxy path, so it stays "proxy" independent of model count. Otherwise mode
+	// mirrors the backend's compute_proxy_active: a proxy sidecar is only
+	// deployed for a subscription model, so a pool of any size that is purely
+	// BYO api keys is "direct" - it renders openclaw-direct with no sidecar.
+	// (was: any 2+-model pool counted as "proxy" regardless of credential type)
+	return hasSubscription || preset ? "proxy" : "direct";
 }
 export function uniqueVendors(entry) {
 	if (entry && Array.isArray(entry.vendors) && entry.vendors.length)

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -68,11 +68,27 @@ const TRIO = {
 	],
 };
 
-test("deriveMode: 1 model & no preset => direct; else proxy", () => {
+test("deriveMode: 1 api-key model & no preset => direct; a preset always => proxy", () => {
 	assert.equal(deriveMode([{ provider: "openai", model: "gpt-5.5" }], null), "direct");
 	assert.equal(deriveMode([{ provider: "openai", model: "gpt-5.5" }], "cost-saver"), "proxy");
-	assert.equal(deriveMode([{}, {}], null), "proxy");
 	assert.equal(deriveMode([], null), "direct");
+});
+test("deriveMode: a pure BYO api-key pool is direct regardless of size (no sidecar deployed)", () => {
+	// Mirrors the backend's compute_proxy_active: a proxy sidecar is only
+	// deployed for a subscription model. A 2+-model pool of api keys alone
+	// renders openclaw-direct, so it must NOT read "proxy" just from the count.
+	assert.equal(deriveMode([{}, {}], null), "direct");
+	assert.equal(
+		deriveMode(
+			[
+				{ provider: "openai", model: "gpt-5.5" },
+				{ provider: "anthropic", model: "claude-opus-4-8" },
+				{ provider: "google", model: "gemini-2.5-pro" },
+			],
+			null
+		),
+		"direct"
+	);
 });
 test("deriveMode: a single subscription model is proxy (needs cliproxy)", () => {
 	assert.equal(
@@ -81,6 +97,18 @@ test("deriveMode: a single subscription model is proxy (needs cliproxy)", () => 
 	);
 	assert.equal(
 		deriveMode([{ model: "gpt-5.5", subscription: { accounts: [] } }], null),
+		"proxy"
+	);
+});
+test("deriveMode: a pool with ANY subscription model is proxy, even mixed with api keys", () => {
+	assert.equal(
+		deriveMode(
+			[
+				{ provider: "openai", model: "gpt-5.5" },
+				{ model: "claude-opus-4-8", credentialType: "subscription" },
+			],
+			null
+		),
 		"proxy"
 	);
 });


### PR DESCRIPTION
## Summary

- `LlmPoolEditor.vue`'s custom-mode badge and `pool.js`'s `deriveMode` both used a pre-#498 rule that equated "2 or more models" with "a proxy sidecar is deployed". A pool of two (or more) BYO API keys displayed "Proxy (failover)" even though the backend correctly reports `proxy_active=0` (`compute_proxy_active()` in `jarvis/jarvis/pool_serialize.py`) and no Bifrost/cliproxy container exists.
- The backend rule is: a proxy sidecar is deployed IFF some enabled model is a subscription. A pure API-key pool of any size is direct (openclaw-direct, no sidecar).
- `deriveMode` now returns `"proxy"` only when the pool has a subscription model or a preset is selected, and `"direct"` otherwise. `badgeLabel`'s custom branch now also checks `badgeMode.value === "proxy"` (which calls the fixed `deriveMode`) alongside the existing 2+ row count, so it no longer badges a pure API-key pool.
- Preserved: a pool with a subscription still reads "Proxy (failover)"; a preset still implies proxy; a single model still shows no badge.

`deriveMode` is also consumed by the desk onboarding page's `jarvis_account.js` (`renderModeBadge`, via the bundled `window.jarvis_onboarding_llm.deriveMode`), so this fixes that display too. Both consumers use the return value only to build a display label; it does not feed anything sent to the backend.

## Test plan
- [x] `node --test frontend/src/llm/pool.test.js` - all 70 tests pass
- [x] Verified the new/changed `deriveMode` tests fail against the pre-fix code (reverted `pool.js` locally, confirmed the assertion fails, restored the fix)
- [x] `npx prettier@2.7.1 --check` on the three changed files (pinned repo version) - all pass
- [x] Hosted GitHub Actions CI (this repo is public, hosted Actions is the gate)