### PR TITLE
feat(chat): sweep the openclaw session model pins we wrote ourselves

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -668,6 +668,55 @@ class OpenclawSession:
 		res = self._request("sessions.list", {}, timeout_s=timeout_s)
 		return (res.get("payload") or {}).get("sessions") or []
 
+	def list_sessions_page(
+		self,
+		*,
+		limit: int = 100,
+		offset: int = 0,
+		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> dict:
+		"""One page of ``sessions.list`` with the WHOLE payload, not just the
+		rows: ``sessions`` plus ``defaults`` (the agent's configured model, i.e.
+		what an unpinned session resolves to) and ``hasMore`` / ``nextOffset``.
+
+		``list_sessions`` above drops the envelope and accepts the gateway's own
+		100-row cap. The model-pin sweep needs both halves: ``defaults`` is the
+		only way to tell a pinned session from an unpinned one over the wire
+		(the row carries the RESOLVED model, never the raw override), and a
+		tenant with a long history needs the paging cursor."""
+		res = self._request(
+			"sessions.list",
+			{"limit": limit, "offset": offset},
+			timeout_s=timeout_s,
+		)
+		return res.get("payload") or {}
+
+	def clear_session_model(
+		self,
+		session_key: str,
+		*,
+		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
+	) -> None:
+		"""Drop the session's model override so the agent's configured default -
+		and, crucially, its ``model.fallbacks`` chain - applies again.
+
+		``sessions.patch`` with a NULL model takes openclaw's own isDefault
+		branch (2026.6.8 ``src/sessions/model-overrides.ts``), which deletes
+		``modelOverride``, ``providerOverride`` and ``modelOverrideSource``
+		together with the now-stale runtime model/contextTokens fields, then
+		persists through the gateway's own store writer. Rewriting
+		``sessions.json`` on disk instead would race that writer: the gateway
+		holds the store in memory and rewrites it on every session update.
+
+		NEVER call this for a key the gateway did not just report. Patching an
+		ABSENT key does not fail - openclaw creates the entry, mints a fresh
+		sessionId and drops the label."""
+		self._request(
+			"sessions.patch",
+			{"key": session_key, "model": None},
+			timeout_s=timeout_s,
+		)
+
 	def delete_session(
 		self,
 		session_key: str,

--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -696,7 +696,7 @@ class OpenclawSession:
 		session_key: str,
 		*,
 		timeout_s: float = CONNECT_TIMEOUT_SECONDS,
-	) -> None:
+	) -> dict:
 		"""Drop the session's model override so the agent's configured default -
 		and, crucially, its ``model.fallbacks`` chain - applies again.
 
@@ -708,14 +708,18 @@ class OpenclawSession:
 		``sessions.json`` on disk instead would race that writer: the gateway
 		holds the store in memory and rewrites it on every session update.
 
+		Returns the gateway's post-patch store entry (``payload.entry``) so the
+		caller can VERIFY the override is gone instead of trusting the ack.
+
 		NEVER call this for a key the gateway did not just report. Patching an
 		ABSENT key does not fail - openclaw creates the entry, mints a fresh
 		sessionId and drops the label."""
-		self._request(
+		res = self._request(
 			"sessions.patch",
 			{"key": session_key, "model": None},
 			timeout_s=timeout_s,
 		)
+		return (res.get("payload") or {}).get("entry") or {}
 
 	def delete_session(
 		self,

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -39,17 +39,40 @@ REMEDY, PER CLASS.
     DIFFERENT model            -> REPORT. Bench and container disagree; the next
                                  turn re-patches the session from the row, so
                                  clearing here would only fight it.
-  * no conversation, bench
-    label (title/prewarm/
-    polish) or the agent's own
-    main/heartbeat session     -> CLEAR. Never a customer pick.
-  * no conversation, unknown
-    label                      -> REPORT, never touch. Unattributable.
+  * openclaw's own
+    agent:<id>:main[:heartbeat] -> CLEAR. The built-in poller resumes it on every
+                                 tick, so a pin there fails forever, and it is
+                                 never a customer pick.
+  * a bench throwaway
+    (title / prewarm / polish) -> SKIP. Single-use and reaped within the hour by
+                                 session_lifecycle; touching it would only bump
+                                 the updatedAt that reaper grades on.
+  * anything else with no
+    conversation               -> REPORT, never touch. Unattributable.
+
+WHAT "PINNED" MEANS HERE, HONESTLY. A sessions.list row carries the RESOLVED
+model, never the raw override, and the gateway puts no override field on the wire
+at all - so "resolves to something other than the agent default" is the only
+signal available, and it is exactly the one openclaw's own control UI uses. It
+cannot separate a live override from a STALE RUNTIME RECORD: a session that once
+ran under an earlier render keeps that render's provider in entry.model long
+after the override is gone. Measured on jarvis-pool-bf4097 (2026-07-29): 6
+conversation sessions resolved away from the default, of which 3 held a real
+override and 3 only the stale record.
+
+That is acceptable because the clear is an ASSERTION, not a repair, and it is
+idempotent. On a session with a real override it deletes the override; on one
+with only a stale record it deletes that record (which names a provider the
+container no longer has) and nothing else changes. The cost of a false positive
+is a telemetry reset - entry.model / contextTokens recomputed on the next turn -
+never a behaviour change. Excluding the throwaways keeps that cost off the only
+population where a bumped updatedAt would matter.
 
 Clearing goes through ``sessions.patch {"model": null}`` rather than an edit of
 ``sessions.json`` on disk: the gateway keeps the store in memory and rewrites it
 on every session update, so a host-side edit either loses the race or needs the
-container stopped. See ``OpenclawSession.clear_session_model``.
+container stopped. The patch response echoes the resulting store entry, so every
+clear is verified rather than trusted. See ``OpenclawSession.clear_session_model``.
 
 DRY RUN IS THE DEFAULT. ``run()`` only reports; ``run(apply=True)`` clears, up to
 ``MAX_CLEAR`` pins per invocation::
@@ -91,7 +114,6 @@ _BENCH_LABEL_PREFIXES = ("jarvis-prewarm-", "jarvis-title-", "jarvis-polish-")
 # openclaw's own per-agent session: "agent:<id>:main" and its ":heartbeat"
 # sibling. The heartbeat resumes on every tick, so a pin there fails forever.
 _AGENT_MAIN_PREFIX = "agent:"
-_AGENT_MAIN_SEGMENT = ":main"
 
 
 @dataclass(frozen=True)
@@ -254,8 +276,12 @@ class SessionPinSweep:
 
 		conv = owners.get(key)
 		if conv is None:
-			if label.startswith(_BENCH_LABEL_PREFIXES) or _is_agent_main_key(key):
-				return PinPlan(key, CLEAR, "bench-owned session, never a customer pick", pinned, label)
+			if _is_agent_main_key(key):
+				return PinPlan(
+					key, CLEAR, "openclaw's own main session, never a customer pick", pinned, label
+				)
+			if label.startswith(_BENCH_LABEL_PREFIXES):
+				return PinPlan(key, SKIP, "bench throwaway; session_lifecycle reaps it", pinned, label)
 			return PinPlan(key, REPORT, "no conversation owns this session", pinned, label)
 
 		chosen = (conv.get("model_override") or "").strip()
@@ -282,11 +308,21 @@ class SessionPinSweep:
 				summary.capped += 1
 				continue
 			try:
-				self._sess.clear_session_model(item.key)
+				entry = self._sess.clear_session_model(item.key) or {}
 			except Exception:
 				frappe.log_error(
 					title="session_pin_sweep: clear failed",
 					message=f"session_key={item.key}\n{frappe.get_traceback()}",
+				)
+				summary.errors += 1
+				continue
+			# The patch echoes the resulting store entry: verify rather than
+			# trust the ack. A surviving override means openclaw took a branch
+			# we did not expect, and the operator needs to know before re-running.
+			if entry.get("modelOverride") or entry.get("modelOverrideSource"):
+				frappe.log_error(
+					title="session_pin_sweep: override survived the patch",
+					message=f"session_key={item.key}\nentry={entry}",
 				)
 				summary.errors += 1
 				continue

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -194,13 +194,6 @@ def run(apply: bool = False, max_clear: int = MAX_CLEAR) -> dict:
 	Reports only unless ``apply`` is true. Uses a dedicated connection, never the
 	turn pool - a maintenance sweep must not contend with live chat. Returns the
 	summary dict (also logged) so a ``bench execute`` run shows its work."""
-	from jarvis import selfhost
-
-	if selfhost.is_self_hosted():
-		# A self-hosted tenant is reached over HTTP bearer auth with no device
-		# pairing, so the WS client this sweep uses does not apply there.
-		return SweepSummary(apply=bool(apply), aborted="self-hosted").as_dict()
-
 	settings = frappe.get_single("Jarvis Settings")
 	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 	if not gateway_url:

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -1,0 +1,329 @@
+"""Clear the openclaw session model pins Jarvis wrote on the customer's behalf.
+
+THE POISON. openclaw stores a per-session model override. From its 2026.6.8
+bundle, ``resolveEffectiveModelFallbacks``::
+
+    if (!params.hasSessionModelOverride) return agentFallbacksOverride;
+    if (!(params.modelOverrideSource === "auto" || ...)) return [];
+
+so ANY pin that is not flagged automatic zeroes the failover candidate chain for
+that conversation, permanently. The bench pinned sessions on unpinned "Auto"
+turns too (``turn_handler._session_model_for`` names the pool primary so openclaw
+does not reject the ``jarvis-pool`` placeholder), and every such patch landed as
+``modelOverrideSource: "user"`` - ``sessions.patch`` hardcodes that source and
+its param schema is ``additionalProperties: false``, so there is no way to ask
+for "auto". Fixing the turn path does NOT heal the sessions already poisoned:
+the override lives in the container's session store and survives restarts,
+re-renders and re-provisions.
+
+WHO WROTE A PIN. Inside the container the two are indistinguishable: a customer
+picking Gemini and the bench patching the pool primary produce the byte-identical
+entry, and the gateway does not even put ``modelOverrideSource`` on the wire. The
+disambiguating fact lives HERE, on the bench: ``Jarvis Conversation.model_override``
+is the model the customer actually chose, and empty means Auto. A pinned session
+whose conversation says Auto is therefore ours, by construction. That is why this
+sweep is a bench maintenance command and not a fleet-agent endpoint - the fleet
+plane can see the pins but cannot attribute them.
+
+REMEDY, PER CLASS.
+
+  * conversation on Auto      -> CLEAR. We wrote it; the customer asked for the
+                                 default and its fallback chain.
+  * conversation pins the same
+    model as the session       -> KEEP. A deliberate pick, and openclaw disabling
+                                 failover for it is the product behaviour we
+                                 want: someone who explicitly chooses one vendor
+                                 should see that vendor's error, not a silent
+                                 switch to another one mid-conversation.
+  * conversation pins a
+    DIFFERENT model            -> REPORT. Bench and container disagree; the next
+                                 turn re-patches the session from the row, so
+                                 clearing here would only fight it.
+  * no conversation, bench
+    label (title/prewarm/
+    polish) or the agent's own
+    main/heartbeat session     -> CLEAR. Never a customer pick.
+  * no conversation, unknown
+    label                      -> REPORT, never touch. Unattributable.
+
+Clearing goes through ``sessions.patch {"model": null}`` rather than an edit of
+``sessions.json`` on disk: the gateway keeps the store in memory and rewrites it
+on every session update, so a host-side edit either loses the race or needs the
+container stopped. See ``OpenclawSession.clear_session_model``.
+
+DRY RUN IS THE DEFAULT. ``run()`` only reports; ``run(apply=True)`` clears, up to
+``MAX_CLEAR`` pins per invocation::
+
+    bench --site <site> execute jarvis.chat.session_pin_sweep.run
+    bench --site <site> execute jarvis.chat.session_pin_sweep.run --kwargs "{'apply': True}"
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import frappe
+
+logger = logging.getLogger(__name__)
+
+CONV = "Jarvis Conversation"
+
+# What the sweep decided to do with one pinned session.
+CLEAR = "clear"
+KEEP = "keep"
+REPORT = "report"
+SKIP = "skip"
+
+# Ceiling on pins cleared per apply run. A misclassification cannot unpin a whole
+# tenant in one go; the operator re-runs to drain a genuine backlog.
+MAX_CLEAR = 200
+
+# sessions.list paging. MAX_PAGES bounds a gateway that keeps claiming hasMore.
+PAGE_LIMIT = 100
+MAX_PAGES = 50
+
+# Labels of the throwaway sessions the bench mints for its own turns (mirrors
+# session_lifecycle._THROWAWAY_LABEL_PREFIXES). A real conversation session is
+# always "jarvis-chat-<user>-<ms>", so these prefixes can never collide with one.
+_BENCH_LABEL_PREFIXES = ("jarvis-prewarm-", "jarvis-title-", "jarvis-polish-")
+
+# openclaw's own per-agent session: "agent:<id>:main" and its ":heartbeat"
+# sibling. The heartbeat resumes on every tick, so a pin there fails forever.
+_AGENT_MAIN_PREFIX = "agent:"
+_AGENT_MAIN_SEGMENT = ":main"
+
+
+@dataclass(frozen=True)
+class PinPlan:
+	"""One pinned session and what the sweep would do about it."""
+
+	key: str
+	verb: str
+	reason: str
+	pinned: str
+	label: str = ""
+	conversation: str = ""
+
+	def as_dict(self) -> dict:
+		return {
+			"key": self.key,
+			"verb": self.verb,
+			"reason": self.reason,
+			"pinned": self.pinned,
+			"label": self.label,
+			"conversation": self.conversation,
+		}
+
+
+@dataclass
+class SweepSummary:
+	"""Counters + the full plan, returned to the caller and logged."""
+
+	apply: bool = False
+	default_model: str = ""
+	scanned: int = 0
+	cleared: int = 0
+	capped: int = 0
+	errors: int = 0
+	aborted: str = ""
+	plan: list[PinPlan] = field(default_factory=list)
+
+	def counts(self) -> dict:
+		out = {verb: 0 for verb in (CLEAR, KEEP, REPORT, SKIP)}
+		for item in self.plan:
+			out[item.verb] = out.get(item.verb, 0) + 1
+		return out
+
+	def as_dict(self) -> dict:
+		return {
+			"apply": self.apply,
+			"default_model": self.default_model,
+			"scanned": self.scanned,
+			"pinned": len(self.plan),
+			"cleared": self.cleared,
+			"capped": self.capped,
+			"errors": self.errors,
+			"aborted": self.aborted,
+			"counts": self.counts(),
+			"plan": [item.as_dict() for item in self.plan],
+		}
+
+
+def run(apply: bool = False, max_clear: int = MAX_CLEAR) -> dict:
+	"""Sweep this tenant's gateway for poisoned model pins.
+
+	Reports only unless ``apply`` is true. Uses a dedicated connection, never the
+	turn pool - a maintenance sweep must not contend with live chat. Returns the
+	summary dict (also logged) so a ``bench execute`` run shows its work."""
+	settings = frappe.get_single("Jarvis Settings")
+	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
+	if not gateway_url:
+		return SweepSummary(apply=bool(apply), aborted="no agent_url").as_dict()
+
+	from jarvis.chat.openclaw_client import OpenclawSession
+
+	try:
+		sess = OpenclawSession.connect(gateway_url)
+	except Exception:
+		frappe.log_error(title="session_pin_sweep: connect failed", message=frappe.get_traceback())
+		return SweepSummary(apply=bool(apply), aborted="connect failed").as_dict()
+	try:
+		summary = SessionPinSweep(sess, apply=bool(apply), max_clear=max_clear).run()
+	finally:
+		try:
+			sess.close()
+		except Exception:
+			logger.debug("session_pin_sweep: close failed", exc_info=True)
+	logger.info("session_pin_sweep: %s", summary.as_dict())
+	return summary.as_dict()
+
+
+class SessionPinSweep:
+	"""Classifies every pinned gateway session against the bench's own record of
+	what the customer chose, and (only when applying) clears the pins we wrote."""
+
+	def __init__(self, sess, *, apply: bool = False, max_clear: int = MAX_CLEAR):
+		self._sess = sess
+		self._apply = apply
+		self._max_clear = max(0, int(max_clear))
+
+	def run(self) -> SweepSummary:
+		summary = SweepSummary(apply=self._apply)
+		rows, default_ref = self._read_rows()
+		if not default_ref:
+			# Without the agent's default, EVERY session looks pinned and a blind
+			# apply would unpin the whole tenant. Refuse instead.
+			summary.aborted = "gateway reported no default model"
+			return summary
+		summary.default_model = default_ref
+		summary.scanned = len(rows)
+		owners = self._conversations_by_session_key()
+		for row in rows:
+			plan = self._classify(row, default_ref, owners)
+			if plan is not None:
+				summary.plan.append(plan)
+		if self._apply:
+			self._clear(summary)
+		return summary
+
+	def _read_rows(self) -> tuple[list[dict], str]:
+		"""Every sessions.list row plus the agent's default "provider/model".
+
+		A page that fails mid-way returns what it has: the sweep then reports on
+		fewer sessions rather than none, and re-running picks up the rest."""
+		rows: list[dict] = []
+		default_ref = ""
+		offset = 0
+		for _ in range(MAX_PAGES):
+			try:
+				page = self._sess.list_sessions_page(limit=PAGE_LIMIT, offset=offset)
+			except Exception:
+				frappe.log_error(
+					title="session_pin_sweep: sessions.list failed",
+					message=f"offset={offset}\n{frappe.get_traceback()}",
+				)
+				break
+			default_ref = default_ref or _model_ref(page.get("defaults") or {})
+			batch = page.get("sessions") or []
+			rows.extend(r for r in batch if isinstance(r, dict))
+			next_offset = page.get("nextOffset")
+			if not page.get("hasMore") or not isinstance(next_offset, int) or next_offset <= offset:
+				break
+			offset = next_offset
+		return rows, default_ref
+
+	def _classify(self, row: dict, default_ref: str, owners: dict) -> PinPlan | None:
+		"""The plan for one session row, or None when it carries no pin.
+
+		A row reports the RESOLVED model, so "pinned" means "resolves to
+		something other than the agent default". A session pinned to exactly the
+		default is invisible here - and unreachable through sessions.patch, which
+		clears such a selection instead of storing it."""
+		key = row.get("key") or ""
+		pinned = _model_ref(row)
+		if not key or not pinned or pinned == default_ref:
+			return None
+		label = row.get("label") or ""
+		if row.get("hasActiveRun"):
+			return PinPlan(key, SKIP, "a run is in flight", pinned, label)
+		if not row.get("sessionId"):
+			# Patching an entry with no sessionId makes openclaw mint one and drop
+			# the label. Nothing here is worth that.
+			return PinPlan(key, SKIP, "store entry has no sessionId", pinned, label)
+
+		conv = owners.get(key)
+		if conv is None:
+			if label.startswith(_BENCH_LABEL_PREFIXES) or _is_agent_main_key(key):
+				return PinPlan(key, CLEAR, "bench-owned session, never a customer pick", pinned, label)
+			return PinPlan(key, REPORT, "no conversation owns this session", pinned, label)
+
+		chosen = (conv.get("model_override") or "").strip()
+		if not chosen:
+			return PinPlan(key, CLEAR, "conversation is on Auto", pinned, label, conv["name"])
+		if chosen.casefold() == (row.get("model") or "").strip().casefold():
+			return PinPlan(key, KEEP, "the customer picked this model", pinned, label, conv["name"])
+		return PinPlan(
+			key,
+			REPORT,
+			f"conversation pins {chosen!r}; the next turn re-patches it",
+			pinned,
+			label,
+			conv["name"],
+		)
+
+	def _clear(self, summary: SweepSummary) -> None:
+		"""Issue sessions.patch {"model": null} for every CLEAR plan, up to the
+		cap. One failure never stops the sweep."""
+		for item in summary.plan:
+			if item.verb != CLEAR:
+				continue
+			if summary.cleared >= self._max_clear:
+				summary.capped += 1
+				continue
+			try:
+				self._sess.clear_session_model(item.key)
+			except Exception:
+				frappe.log_error(
+					title="session_pin_sweep: clear failed",
+					message=f"session_key={item.key}\n{frappe.get_traceback()}",
+				)
+				summary.errors += 1
+				continue
+			summary.cleared += 1
+			logger.info("session_pin_sweep: cleared %s (was %s)", item.key, item.pinned)
+
+	def _conversations_by_session_key(self) -> dict[str, dict]:
+		"""session_key -> {name, model_override} for every conversation that
+		holds one. The join key is exact: prepare.py persists the session_key it
+		created onto the row before the first turn can run."""
+		rows = frappe.get_all(
+			CONV,
+			fields=["name", "session_key", "model_override"],
+			filters={"session_key": ["is", "set"]},
+			limit_page_length=0,
+		)
+		return {r["session_key"]: r for r in rows if r.get("session_key")}
+
+
+def _model_ref(row: dict) -> str:
+	"""``"provider/model"`` for a sessions.list row or its defaults block, or ""
+	when the gateway resolved neither. Comparison is case-folded; openclaw ids
+	are lowercase but nothing guarantees it."""
+	provider = (row.get("modelProvider") or "").strip().casefold()
+	model = (row.get("model") or "").strip().casefold()
+	if not model:
+		return ""
+	return f"{provider}/{model}" if provider else model
+
+
+def _is_agent_main_key(key: str) -> bool:
+	"""True for openclaw's own ``agent:<id>:main`` session and its
+	``:heartbeat`` sibling - the built-in poller, never a customer chat."""
+	if not key.startswith(_AGENT_MAIN_PREFIX):
+		return False
+	rest = key[len(_AGENT_MAIN_PREFIX) :]
+	agent_id, sep, tail = rest.partition(":")
+	if not agent_id or not sep:
+		return False
+	return tail == "main" or tail.startswith("main:")

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -74,6 +74,13 @@ on every session update, so a host-side edit either loses the race or needs the
 container stopped. The patch response echoes the resulting store entry, so every
 clear is verified rather than trusted. See ``OpenclawSession.clear_session_model``.
 
+The listing and the patch are seconds apart, and both facts behind a CLEAR can
+move in that window, so each one is rechecked at patch time: the conversation's
+model_override is re-read (a customer who picked a model in between keeps it),
+and the returned entry's sessionId must be the one that was planned against (the
+lifecycle sweep can free a session mid-run, and patching a freed key makes
+openclaw mint a ghost entry instead of failing).
+
 DRY RUN IS THE DEFAULT. ``run()`` only reports; ``run(apply=True)`` clears, up to
 ``MAX_CLEAR`` pins per invocation::
 
@@ -126,6 +133,7 @@ class PinPlan:
 	pinned: str
 	label: str = ""
 	conversation: str = ""
+	session_id: str = ""
 
 	def as_dict(self) -> dict:
 		return {
@@ -135,6 +143,7 @@ class PinPlan:
 			"pinned": self.pinned,
 			"label": self.label,
 			"conversation": self.conversation,
+			"session_id": self.session_id,
 		}
 
 
@@ -147,6 +156,7 @@ class SweepSummary:
 	scanned: int = 0
 	cleared: int = 0
 	capped: int = 0
+	raced: int = 0
 	errors: int = 0
 	aborted: str = ""
 	plan: list[PinPlan] = field(default_factory=list)
@@ -165,6 +175,7 @@ class SweepSummary:
 			"pinned": len(self.plan),
 			"cleared": self.cleared,
 			"capped": self.capped,
+			"raced": self.raced,
 			"errors": self.errors,
 			"aborted": self.aborted,
 			"counts": self.counts(),
@@ -178,6 +189,13 @@ def run(apply: bool = False, max_clear: int = MAX_CLEAR) -> dict:
 	Reports only unless ``apply`` is true. Uses a dedicated connection, never the
 	turn pool - a maintenance sweep must not contend with live chat. Returns the
 	summary dict (also logged) so a ``bench execute`` run shows its work."""
+	from jarvis import selfhost
+
+	if selfhost.is_self_hosted():
+		# A self-hosted tenant is reached over HTTP bearer auth with no device
+		# pairing, so the WS client this sweep uses does not apply there.
+		return SweepSummary(apply=bool(apply), aborted="self-hosted").as_dict()
+
 	settings = frappe.get_single("Jarvis Settings")
 	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 	if not gateway_url:
@@ -233,8 +251,13 @@ class SessionPinSweep:
 		"""Every sessions.list row plus the agent's default "provider/model".
 
 		A page that fails mid-way returns what it has: the sweep then reports on
-		fewer sessions rather than none, and re-running picks up the rest."""
-		rows: list[dict] = []
+		fewer sessions rather than none, and re-running picks up the rest.
+
+		Paging is plain offset against a LIVE store, so a session created between
+		two fetches can shift a row onto a page it was already on. Rows are keyed
+		by session key (last one wins) so a duplicate cannot burn two slots of the
+		clear budget for one session."""
+		by_key: dict[str, dict] = {}
 		default_ref = ""
 		offset = 0
 		for _ in range(MAX_PAGES):
@@ -247,13 +270,14 @@ class SessionPinSweep:
 				)
 				break
 			default_ref = default_ref or _model_ref(page.get("defaults") or {})
-			batch = page.get("sessions") or []
-			rows.extend(r for r in batch if isinstance(r, dict))
+			for row in page.get("sessions") or []:
+				if isinstance(row, dict) and row.get("key"):
+					by_key[row["key"]] = row
 			next_offset = page.get("nextOffset")
 			if not page.get("hasMore") or not isinstance(next_offset, int) or next_offset <= offset:
 				break
 			offset = next_offset
-		return rows, default_ref
+		return list(by_key.values()), default_ref
 
 	def _classify(self, row: dict, default_ref: str, owners: dict) -> PinPlan | None:
 		"""The plan for one session row, or None when it carries no pin.
@@ -267,36 +291,32 @@ class SessionPinSweep:
 		if not key or not pinned or pinned == default_ref:
 			return None
 		label = row.get("label") or ""
+		sid = row.get("sessionId") or ""
+
+		def plan(verb: str, reason: str, conversation: str = "") -> PinPlan:
+			return PinPlan(key, verb, reason, pinned, label, conversation, sid)
+
 		if row.get("hasActiveRun"):
-			return PinPlan(key, SKIP, "a run is in flight", pinned, label)
-		if not row.get("sessionId"):
+			return plan(SKIP, "a run is in flight")
+		if not sid:
 			# Patching an entry with no sessionId makes openclaw mint one and drop
 			# the label. Nothing here is worth that.
-			return PinPlan(key, SKIP, "store entry has no sessionId", pinned, label)
+			return plan(SKIP, "store entry has no sessionId")
 
 		conv = owners.get(key)
 		if conv is None:
 			if _is_agent_main_key(key):
-				return PinPlan(
-					key, CLEAR, "openclaw's own main session, never a customer pick", pinned, label
-				)
+				return plan(CLEAR, "openclaw's own main session, never a customer pick")
 			if label.startswith(_BENCH_LABEL_PREFIXES):
-				return PinPlan(key, SKIP, "bench throwaway; session_lifecycle reaps it", pinned, label)
-			return PinPlan(key, REPORT, "no conversation owns this session", pinned, label)
+				return plan(SKIP, "bench throwaway; session_lifecycle reaps it")
+			return plan(REPORT, "no conversation owns this session")
 
 		chosen = (conv.get("model_override") or "").strip()
 		if not chosen:
-			return PinPlan(key, CLEAR, "conversation is on Auto", pinned, label, conv["name"])
+			return plan(CLEAR, "conversation is on Auto", conv["name"])
 		if chosen.casefold() == (row.get("model") or "").strip().casefold():
-			return PinPlan(key, KEEP, "the customer picked this model", pinned, label, conv["name"])
-		return PinPlan(
-			key,
-			REPORT,
-			f"conversation pins {chosen!r}; the next turn re-patches it",
-			pinned,
-			label,
-			conv["name"],
-		)
+			return plan(KEEP, "the customer picked this model", conv["name"])
+		return plan(REPORT, f"conversation pins {chosen!r}; the next turn re-patches it", conv["name"])
 
 	def _clear(self, summary: SweepSummary) -> None:
 		"""Issue sessions.patch {"model": null} for every CLEAR plan, up to the
@@ -307,6 +327,9 @@ class SessionPinSweep:
 			if summary.cleared >= self._max_clear:
 				summary.capped += 1
 				continue
+			if self._pick_arrived_since_planning(item):
+				summary.raced += 1
+				continue
 			try:
 				entry = self._sess.clear_session_model(item.key) or {}
 			except Exception:
@@ -316,18 +339,49 @@ class SessionPinSweep:
 				)
 				summary.errors += 1
 				continue
-			# The patch echoes the resulting store entry: verify rather than
-			# trust the ack. A surviving override means openclaw took a branch
-			# we did not expect, and the operator needs to know before re-running.
-			if entry.get("modelOverride") or entry.get("modelOverrideSource"):
-				frappe.log_error(
-					title="session_pin_sweep: override survived the patch",
-					message=f"session_key={item.key}\nentry={entry}",
-				)
-				summary.errors += 1
+			if not self._verify(item, entry, summary):
 				continue
 			summary.cleared += 1
 			logger.info("session_pin_sweep: cleared %s (was %s)", item.key, item.pinned)
+
+	def _pick_arrived_since_planning(self, item: PinPlan) -> bool:
+		"""True when the conversation gained an explicit model since the plan was
+		built. The listing and the patch are seconds apart and a customer can
+		choose a model in between; reverting a fresh pick would be worse than
+		leaving one poisoned session for the next run."""
+		if not item.conversation:
+			return False
+		chosen = frappe.db.get_value(CONV, item.conversation, "model_override")
+		return bool((chosen or "").strip())
+
+	def _verify(self, item: PinPlan, entry: dict, summary: SweepSummary) -> bool:
+		"""The patch echoes the resulting store entry, so check it instead of
+		trusting the ack. Two things can be wrong:
+
+		- the override survived, meaning openclaw took a branch we did not expect;
+		- the entry carries a DIFFERENT sessionId, meaning the session was freed
+		  between the listing and the patch and openclaw minted a fresh entry
+		  under that key rather than patching the one we planned against. That
+		  ghost has no override, so only the id comparison catches it. It is an
+		  unreferenced session, which the session_lifecycle orphan sweep reaps.
+
+		Either way: count an error, do not count a fix."""
+		if entry.get("modelOverride") or entry.get("modelOverrideSource"):
+			frappe.log_error(
+				title="session_pin_sweep: override survived the patch",
+				message=f"session_key={item.key}\nentry={entry}",
+			)
+			summary.errors += 1
+			return False
+		got = entry.get("sessionId")
+		if item.session_id and got and got != item.session_id:
+			frappe.log_error(
+				title="session_pin_sweep: patched a session that had been replaced",
+				message=f"session_key={item.key}\nplanned={item.session_id}\ngot={got}",
+			)
+			summary.errors += 1
+			return False
+		return True
 
 	def _conversations_by_session_key(self) -> dict[str, dict]:
 		"""session_key -> {name, model_override} for every conversation that

--- a/jarvis/chat/session_pin_sweep.py
+++ b/jarvis/chat/session_pin_sweep.py
@@ -36,13 +36,18 @@ REMEDY, PER CLASS.
                                  should see that vendor's error, not a silent
                                  switch to another one mid-conversation.
   * conversation pins a
-    DIFFERENT model            -> REPORT. Bench and container disagree; the next
-                                 turn re-patches the session from the row, so
-                                 clearing here would only fight it.
+    DIFFERENT model            -> REPORT. Bench and container disagree, and the
+                                 row is what the customer's model pill reads, so
+                                 unpinning the container behind it would only
+                                 widen the gap. Holds even when the pick names a
+                                 model the tenant no longer offers: that is a
+                                 conversation to repair, not a pin to drop.
   * openclaw's own
-    agent:<id>:main[:heartbeat] -> CLEAR. The built-in poller resumes it on every
-                                 tick, so a pin there fails forever, and it is
-                                 never a customer pick.
+    agent:<id>:main and anything
+    under agent:<id>:main:*     -> CLEAR. The built-in poller resumes the
+                                 heartbeat on every tick, so a pin there fails
+                                 forever, and openclaw owns that whole
+                                 namespace: none of it is a customer pick.
   * a bench throwaway
     (title / prewarm / polish) -> SKIP. Single-use and reaped within the hour by
                                  session_lifecycle; touching it would only bump
@@ -215,7 +220,21 @@ def run(apply: bool = False, max_clear: int = MAX_CLEAR) -> dict:
 			sess.close()
 		except Exception:
 			logger.debug("session_pin_sweep: close failed", exc_info=True)
-	logger.info("session_pin_sweep: %s", summary.as_dict())
+	# Counters only. The plan carries session labels, which embed the customer's
+	# Frappe user, and the conversation names they map to; the DocType treats
+	# session_key as impersonation-sensitive (permlevel 1), so that detail goes
+	# to the operator who ran the command, not into the app log.
+	logger.info(
+		"session_pin_sweep: apply=%s default=%s scanned=%s %s cleared=%s raced=%s errors=%s%s",
+		summary.apply,
+		summary.default_model,
+		summary.scanned,
+		summary.counts(),
+		summary.cleared,
+		summary.raced,
+		summary.errors,
+		f" aborted={summary.aborted}" if summary.aborted else "",
+	)
 	return summary.as_dict()
 
 
@@ -316,7 +335,14 @@ class SessionPinSweep:
 			return plan(CLEAR, "conversation is on Auto", conv["name"])
 		if chosen.casefold() == (row.get("model") or "").strip().casefold():
 			return plan(KEEP, "the customer picked this model", conv["name"])
-		return plan(REPORT, f"conversation pins {chosen!r}; the next turn re-patches it", conv["name"])
+		# REPORT holds even when the pick names a model the tenant no longer
+		# offers. That row is what the customer's model pill reads, so unpinning
+		# the container behind it would only widen the disagreement, and a turn
+		# taken on the conversation re-patches the session from the row anyway.
+		# The repair for a dead pick belongs on the conversation, not here.
+		return plan(
+			REPORT, f"conversation pins {chosen!r}; the bench row decides, not this sweep", conv["name"]
+		)
 
 	def _clear(self, summary: SweepSummary) -> None:
 		"""Issue sessions.patch {"model": null} for every CLEAR plan, up to the
@@ -342,7 +368,7 @@ class SessionPinSweep:
 			if not self._verify(item, entry, summary):
 				continue
 			summary.cleared += 1
-			logger.info("session_pin_sweep: cleared %s (was %s)", item.key, item.pinned)
+			logger.info("session_pin_sweep: cleared a session pinned to %s", item.pinned)
 
 	def _pick_arrived_since_planning(self, item: PinPlan) -> bool:
 		"""True when the conversation gained an explicit model since the plan was
@@ -386,7 +412,13 @@ class SessionPinSweep:
 	def _conversations_by_session_key(self) -> dict[str, dict]:
 		"""session_key -> {name, model_override} for every conversation that
 		holds one. The join key is exact: prepare.py persists the session_key it
-		created onto the row before the first turn can run."""
+		created onto the row before the first turn can run.
+
+		Deliberately uncapped, unlike every budgeted read in session_lifecycle:
+		this is the attribution table, not a work queue. A truncated map would
+		make a real conversation's session look like an unowned orphan, which is
+		the one misclassification that must never happen. It stays small because
+		one site is one tenant and the lifecycle sweep reaps idle rows."""
 		rows = frappe.get_all(
 			CONV,
 			fields=["name", "session_key", "model_override"],
@@ -408,8 +440,12 @@ def _model_ref(row: dict) -> str:
 
 
 def _is_agent_main_key(key: str) -> bool:
-	"""True for openclaw's own ``agent:<id>:main`` session and its
-	``:heartbeat`` sibling - the built-in poller, never a customer chat."""
+	"""True for openclaw's own ``agent:<id>:main`` session and anything scoped
+	under it, ``agent:<id>:main:*`` - today that is the ``:heartbeat`` poller.
+	Never a customer chat, which always lands under ``:dashboard:``.
+
+	The trailing wildcard is deliberate: openclaw owns that namespace and may add
+	siblings, and every one of them is its own bookkeeping."""
 	if not key.startswith(_AGENT_MAIN_PREFIX):
 		return False
 	rest = key[len(_AGENT_MAIN_PREFIX) :]

--- a/jarvis/tests/test_session_pin_sweep.py
+++ b/jarvis/tests/test_session_pin_sweep.py
@@ -56,7 +56,7 @@ def _page(rows, *, defaults=None, has_more=False, next_offset=None):
 def _fake_sess(*pages):
 	sess = MagicMock()
 	sess.list_sessions_page.side_effect = list(pages)
-	sess.clear_session_model.return_value = None
+	sess.clear_session_model.return_value = {}
 	return sess
 
 
@@ -130,10 +130,15 @@ class TestSessionPinSweep(FrappeTestCase):
 		self.assertEqual(summary.plan, [])
 		self.assertEqual(summary.scanned, 1)
 
-	def test_bench_throwaway_orphan_is_cleared(self):
+	def test_bench_throwaway_is_skipped(self):
+		# Single-use and reaped by session_lifecycle within the hour; patching one
+		# would only bump the updatedAt that reaper grades on.
 		key = "agent:main:dashboard:pin-title"
 		row = _row(key, provider="openai_compat-0", model="jarvis-pool", label="jarvis-title-abc123")
-		self.assertEqual(self._verbs(self._sweep(_fake_sess(_page([row])))), {key: CLEAR})
+		sess = _fake_sess(_page([row]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: SKIP})
+		sess.clear_session_model.assert_not_called()
 
 	def test_agent_main_and_heartbeat_are_cleared(self):
 		rows = [
@@ -209,6 +214,18 @@ class TestSessionPinSweep(FrappeTestCase):
 		self.assertEqual(summary.capped, 1)
 		self.assertEqual(sess.clear_session_model.call_count, 2)
 
+	def test_a_surviving_override_counts_as_an_error(self):
+		key = "agent:main:dashboard:pin-stuck"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		sess.clear_session_model.return_value = {
+			"modelOverride": "jarvis-pool",
+			"modelOverrideSource": "user",
+		}
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 0)
+		self.assertEqual(summary.errors, 1)
+
 	def test_one_failed_clear_does_not_stop_the_sweep(self):
 		keys = []
 		for i in range(2):
@@ -217,7 +234,7 @@ class TestSessionPinSweep(FrappeTestCase):
 			keys.append(key)
 		rows = [_row(k, provider="openai_compat-0", model="jarvis-pool") for k in keys]
 		sess = _fake_sess(_page(rows))
-		sess.clear_session_model.side_effect = [RuntimeError("nope"), None]
+		sess.clear_session_model.side_effect = [RuntimeError("nope"), {}]
 		summary = self._sweep(sess, apply=True)
 		self.assertEqual(summary.cleared, 1)
 		self.assertEqual(summary.errors, 1)

--- a/jarvis/tests/test_session_pin_sweep.py
+++ b/jarvis/tests/test_session_pin_sweep.py
@@ -19,7 +19,15 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import session_pin_sweep
-from jarvis.chat.session_pin_sweep import CLEAR, KEEP, REPORT, SKIP, SessionPinSweep
+from jarvis.chat.session_pin_sweep import (
+	CLEAR,
+	KEEP,
+	REPORT,
+	SKIP,
+	SessionPinSweep,
+	_is_agent_main_key,
+	_model_ref,
+)
 
 CONV = "Jarvis Conversation"
 SETTINGS = "Jarvis Settings"
@@ -300,7 +308,10 @@ class TestSessionPinSweep(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, "agent_url", "http://gw.test:18789")
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		try:
-			with patch("jarvis.chat.openclaw_client.OpenclawSession.connect", return_value=sess):
+			with (
+				patch("jarvis.selfhost.is_self_hosted", return_value=False),
+				patch("jarvis.chat.openclaw_client.OpenclawSession.connect", return_value=sess),
+			):
 				out = session_pin_sweep.run()
 		finally:
 			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
@@ -317,9 +328,103 @@ class TestSessionPinSweep(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, "agent_url", "")
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		try:
-			out = session_pin_sweep.run()
+			with patch("jarvis.selfhost.is_self_hosted", return_value=False):
+				out = session_pin_sweep.run()
 		finally:
 			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
 			frappe.clear_document_cache(SETTINGS, SETTINGS)
 			frappe.db.commit()
 		self.assertEqual(out["aborted"], "no agent_url")
+
+	def test_run_on_a_self_hosted_bench_does_nothing(self):
+		with patch("jarvis.selfhost.is_self_hosted", return_value=True):
+			out = session_pin_sweep.run(apply=True)
+		self.assertEqual(out["aborted"], "self-hosted")
+
+	# -- races between the listing and the patch --------------------------- #
+
+	def test_a_pick_made_after_planning_is_not_reverted(self):
+		key = "agent:main:dashboard:pin-race"
+		name = self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+
+		def pick(session_key):
+			raise AssertionError("must not patch a conversation that just got a pick")
+
+		sess.clear_session_model.side_effect = pick
+		# The customer chooses a model between the listing and the patch.
+		original = session_pin_sweep.SessionPinSweep._clear
+
+		def clear_after_pick(inner, summary):
+			frappe.db.set_value(CONV, name, "model_override", "gemini-3.6-flash")
+			frappe.db.commit()
+			return original(inner, summary)
+
+		with patch.object(session_pin_sweep.SessionPinSweep, "_clear", clear_after_pick):
+			summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 0)
+		self.assertEqual(summary.raced, 1)
+		self.assertEqual(summary.errors, 0)
+
+	def test_a_replaced_session_is_an_error_not_a_fix(self):
+		# The lifecycle sweep freed the session mid-run, so openclaw minted a
+		# ghost entry under the key instead of patching the planned one.
+		key = "agent:main:dashboard:pin-ghost"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		sess.clear_session_model.return_value = {"sessionId": "some-other-session"}
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 0)
+		self.assertEqual(summary.errors, 1)
+
+	def test_a_matching_session_id_verifies(self):
+		key = "agent:main:dashboard:pin-samesid"
+		self._conv(key, model_override="")
+		row = _row(key, provider="openai_compat-0", model="jarvis-pool")
+		sess = _fake_sess(_page([row]))
+		sess.clear_session_model.return_value = {"sessionId": row["sessionId"]}
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 1)
+		self.assertEqual(summary.errors, 0)
+
+	def test_a_row_repeated_across_pages_is_cleared_once(self):
+		key = "agent:main:dashboard:pin-dup"
+		self._conv(key, model_override="")
+		row = _row(key, provider="openai_compat-0", model="jarvis-pool")
+		sess = _fake_sess(_page([row], has_more=True, next_offset=1), _page([row]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.scanned, 1)
+		self.assertEqual(sess.clear_session_model.call_count, 1)
+
+	def test_an_endless_cursor_stops_at_max_pages(self):
+		pages = [
+			_page([_row(f"agent:main:dashboard:pin-endless{i}")], has_more=True, next_offset=i + 1)
+			for i in range(session_pin_sweep.MAX_PAGES + 5)
+		]
+		sess = _fake_sess(*pages)
+		self._sweep(sess)
+		self.assertEqual(sess.list_sessions_page.call_count, session_pin_sweep.MAX_PAGES)
+
+	# -- helpers ----------------------------------------------------------- #
+
+	def test_model_ref_shapes(self):
+		self.assertEqual(
+			_model_ref({"modelProvider": "Anthropic-0", "model": "Claude-Sonnet-5"}),
+			"anthropic-0/claude-sonnet-5",
+		)
+		self.assertEqual(_model_ref({"model": "claude-sonnet-5"}), "claude-sonnet-5")
+		self.assertEqual(_model_ref({"modelProvider": "anthropic-0"}), "")
+		self.assertEqual(_model_ref({}), "")
+
+	def test_agent_main_key_shapes(self):
+		for key in ("agent:main:main", "agent:main:main:heartbeat", "agent:other:main"):
+			self.assertTrue(_is_agent_main_key(key), key)
+		for key in (
+			"agent:",
+			"agent:main",
+			"agent:main:maintenance",
+			"agent:main:dashboard:abc",
+			"mainly:main",
+			"",
+		):
+			self.assertFalse(_is_agent_main_key(key), key)

--- a/jarvis/tests/test_session_pin_sweep.py
+++ b/jarvis/tests/test_session_pin_sweep.py
@@ -331,10 +331,7 @@ class TestSessionPinSweep(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, "agent_url", "http://gw.test:18789")
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		try:
-			with (
-				patch("jarvis.selfhost.is_self_hosted", return_value=False),
-				patch("jarvis.chat.openclaw_client.OpenclawSession.connect", return_value=sess),
-			):
+			with patch("jarvis.chat.openclaw_client.OpenclawSession.connect", return_value=sess):
 				out = session_pin_sweep.run()
 		finally:
 			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
@@ -351,18 +348,12 @@ class TestSessionPinSweep(FrappeTestCase):
 		frappe.db.set_single_value(SETTINGS, "agent_url", "")
 		frappe.clear_document_cache(SETTINGS, SETTINGS)
 		try:
-			with patch("jarvis.selfhost.is_self_hosted", return_value=False):
-				out = session_pin_sweep.run()
+			out = session_pin_sweep.run()
 		finally:
 			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
 			frappe.clear_document_cache(SETTINGS, SETTINGS)
 			frappe.db.commit()
 		self.assertEqual(out["aborted"], "no agent_url")
-
-	def test_run_on_a_self_hosted_bench_does_nothing(self):
-		with patch("jarvis.selfhost.is_self_hosted", return_value=True):
-			out = session_pin_sweep.run(apply=True)
-		self.assertEqual(out["aborted"], "self-hosted")
 
 	# -- races between the listing and the patch --------------------------- #
 

--- a/jarvis/tests/test_session_pin_sweep.py
+++ b/jarvis/tests/test_session_pin_sweep.py
@@ -32,6 +32,10 @@ from jarvis.chat.session_pin_sweep import (
 CONV = "Jarvis Conversation"
 SETTINGS = "Jarvis Settings"
 
+# Every conversation fixture in this file keys off this prefix, so setUp can
+# clear residue left by an interrupted run without touching real rows.
+KEY_PREFIX = "agent:main:dashboard:pin-"
+
 DEFAULT_PROVIDER = "anthropic-0"
 DEFAULT_MODEL = "claude-sonnet-5"
 DEFAULTS = {"modelProvider": DEFAULT_PROVIDER, "model": DEFAULT_MODEL}
@@ -71,6 +75,11 @@ def _fake_sess(*pages):
 class TestSessionPinSweep(FrappeTestCase):
 	def setUp(self):
 		self._made = []
+		# session_key is unique on the DocType and _conv commits, so a run killed
+		# mid-test would leave a row that 1062s the next run's insert. Sweep any
+		# residue from this file's own key namespace first.
+		frappe.db.delete(CONV, {"session_key": ["like", f"{KEY_PREFIX}%"]})
+		frappe.db.commit()
 
 	def tearDown(self):
 		for name in self._made:
@@ -126,6 +135,17 @@ class TestSessionPinSweep(FrappeTestCase):
 		key = "agent:main:dashboard:pin-drift"
 		self._conv(key, model_override="gemini-3.6-flash")
 		sess = _fake_sess(_page([_row(key, provider="zai_coding-0", model="claude-sonnet-4-6")]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: REPORT})
+		sess.clear_session_model.assert_not_called()
+
+	def test_a_pick_the_tenant_no_longer_offers_still_holds(self):
+		# The customer's model pill still reads this row, so the sweep does not
+		# unpin the container behind it; repairing a dead pick is the
+		# conversation's business.
+		key = "agent:main:dashboard:pin-dead"
+		self._conv(key, model_override="a-model-nobody-serves-now")
+		sess = _fake_sess(_page([_row(key, provider="vllm", model="claude-sonnet-4-6")]))
 		summary = self._sweep(sess, apply=True)
 		self.assertEqual(self._verbs(summary), {key: REPORT})
 		sess.clear_session_model.assert_not_called()
@@ -230,7 +250,8 @@ class TestSessionPinSweep(FrappeTestCase):
 			"modelOverride": "jarvis-pool",
 			"modelOverrideSource": "user",
 		}
-		summary = self._sweep(sess, apply=True)
+		with patch("frappe.log_error"):
+			summary = self._sweep(sess, apply=True)
 		self.assertEqual(summary.cleared, 0)
 		self.assertEqual(summary.errors, 1)
 
@@ -243,7 +264,8 @@ class TestSessionPinSweep(FrappeTestCase):
 		rows = [_row(k, provider="openai_compat-0", model="jarvis-pool") for k in keys]
 		sess = _fake_sess(_page(rows))
 		sess.clear_session_model.side_effect = [RuntimeError("nope"), {}]
-		summary = self._sweep(sess, apply=True)
+		with patch("frappe.log_error"):
+			summary = self._sweep(sess, apply=True)
 		self.assertEqual(summary.cleared, 1)
 		self.assertEqual(summary.errors, 1)
 		self.assertEqual(sess.clear_session_model.call_count, 2)
@@ -295,7 +317,8 @@ class TestSessionPinSweep(FrappeTestCase):
 			),
 			RuntimeError("gateway went away"),
 		]
-		summary = self._sweep(sess)
+		with patch("frappe.log_error"):
+			summary = self._sweep(sess)
 		self.assertEqual(self._verbs(summary), {key: CLEAR})
 
 	# -- entry point ------------------------------------------------------- #
@@ -344,27 +367,31 @@ class TestSessionPinSweep(FrappeTestCase):
 	# -- races between the listing and the patch --------------------------- #
 
 	def test_a_pick_made_after_planning_is_not_reverted(self):
+		# The plan is built while the conversation is on Auto; the customer picks
+		# a model before the patch goes out. The recheck re-reads the row, so the
+		# fresh pick must survive.
 		key = "agent:main:dashboard:pin-race"
 		name = self._conv(key, model_override="")
 		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		sess.clear_session_model.side_effect = AssertionError("must not revert a fresh pick")
+		real_get_value = frappe.db.get_value
+		landed = []
 
-		def pick(session_key):
-			raise AssertionError("must not patch a conversation that just got a pick")
+		def pick_lands_first(*args, **kwargs):
+			# Fires once, on the recheck's own read, and only then: set_value may
+			# itself read through the patched get_value, so guard against reentry.
+			if not landed and args[:2] == (CONV, name):
+				landed.append(True)
+				frappe.db.set_value(CONV, name, "model_override", "gemini-3.6-flash")
+				frappe.db.commit()
+			return real_get_value(*args, **kwargs)
 
-		sess.clear_session_model.side_effect = pick
-		# The customer chooses a model between the listing and the patch.
-		original = session_pin_sweep.SessionPinSweep._clear
-
-		def clear_after_pick(inner, summary):
-			frappe.db.set_value(CONV, name, "model_override", "gemini-3.6-flash")
-			frappe.db.commit()
-			return original(inner, summary)
-
-		with patch.object(session_pin_sweep.SessionPinSweep, "_clear", clear_after_pick):
+		with patch("frappe.db.get_value", side_effect=pick_lands_first):
 			summary = self._sweep(sess, apply=True)
 		self.assertEqual(summary.cleared, 0)
 		self.assertEqual(summary.raced, 1)
 		self.assertEqual(summary.errors, 0)
+		self.assertEqual(frappe.db.get_value(CONV, name, "model_override"), "gemini-3.6-flash")
 
 	def test_a_replaced_session_is_an_error_not_a_fix(self):
 		# The lifecycle sweep freed the session mid-run, so openclaw minted a
@@ -373,7 +400,8 @@ class TestSessionPinSweep(FrappeTestCase):
 		self._conv(key, model_override="")
 		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
 		sess.clear_session_model.return_value = {"sessionId": "some-other-session"}
-		summary = self._sweep(sess, apply=True)
+		with patch("frappe.log_error"):
+			summary = self._sweep(sess, apply=True)
 		self.assertEqual(summary.cleared, 0)
 		self.assertEqual(summary.errors, 1)
 
@@ -417,7 +445,12 @@ class TestSessionPinSweep(FrappeTestCase):
 		self.assertEqual(_model_ref({}), "")
 
 	def test_agent_main_key_shapes(self):
-		for key in ("agent:main:main", "agent:main:main:heartbeat", "agent:other:main"):
+		for key in (
+			"agent:main:main",
+			"agent:main:main:heartbeat",
+			"agent:main:main:anything-openclaw-adds",
+			"agent:other:main",
+		):
 			self.assertTrue(_is_agent_main_key(key), key)
 		for key in (
 			"agent:",

--- a/jarvis/tests/test_session_pin_sweep.py
+++ b/jarvis/tests/test_session_pin_sweep.py
@@ -1,0 +1,308 @@
+"""Tests for jarvis.chat.session_pin_sweep.
+
+The sweep classifies every PINNED gateway session - one whose resolved model
+differs from the agent default the same sessions.list response reports - against
+``Jarvis Conversation.model_override``, the bench's record of what the customer
+actually chose. Empty means Auto, so a pin on such a conversation is one the
+bench wrote itself and gets cleared; a matching explicit pick is left alone.
+
+The gateway is reached only through OpenclawSession, so these patch it with a
+fake exposing ``list_sessions_page`` / ``clear_session_model``. Conversations are
+real rows on the test site.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import session_pin_sweep
+from jarvis.chat.session_pin_sweep import CLEAR, KEEP, REPORT, SKIP, SessionPinSweep
+
+CONV = "Jarvis Conversation"
+SETTINGS = "Jarvis Settings"
+
+DEFAULT_PROVIDER = "anthropic-0"
+DEFAULT_MODEL = "claude-sonnet-5"
+DEFAULTS = {"modelProvider": DEFAULT_PROVIDER, "model": DEFAULT_MODEL}
+
+
+def _row(key, *, provider=DEFAULT_PROVIDER, model=DEFAULT_MODEL, **extra):
+	"""One sessions.list row. Defaults to an UNPINNED session (resolves to the
+	agent default); pass provider/model to pin it."""
+	row = {
+		"key": key,
+		"modelProvider": provider,
+		"model": model,
+		"sessionId": f"sid-{key[-8:]}",
+		"label": None,
+		"hasActiveRun": False,
+	}
+	row.update(extra)
+	return row
+
+
+def _page(rows, *, defaults=None, has_more=False, next_offset=None):
+	return {
+		"sessions": rows,
+		"defaults": DEFAULTS if defaults is None else defaults,
+		"hasMore": has_more,
+		"nextOffset": next_offset,
+	}
+
+
+def _fake_sess(*pages):
+	sess = MagicMock()
+	sess.list_sessions_page.side_effect = list(pages)
+	sess.clear_session_model.return_value = None
+	return sess
+
+
+class TestSessionPinSweep(FrappeTestCase):
+	def setUp(self):
+		self._made = []
+
+	def tearDown(self):
+		for name in self._made:
+			frappe.db.delete(CONV, {"name": name})
+		frappe.db.commit()
+
+	def _conv(self, session_key, model_override=None):
+		doc = frappe.get_doc(
+			{"doctype": CONV, "title": f"pin-{session_key[-8:]}", "status": "Active"}
+		).insert(ignore_permissions=True)
+		self._made.append(doc.name)
+		frappe.db.set_value(CONV, doc.name, {"session_key": session_key, "model_override": model_override})
+		frappe.db.commit()
+		return doc.name
+
+	def _sweep(self, sess, **kw):
+		return SessionPinSweep(sess, **kw).run()
+
+	def _verbs(self, summary):
+		return {item.key: item.verb for item in summary.plan}
+
+	# -- classification ---------------------------------------------------- #
+
+	def test_auto_conversation_with_a_pin_is_cleared(self):
+		key = "agent:main:dashboard:pin-auto-1"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="claude-sonnet-5")]))
+		summary = self._sweep(sess)
+		self.assertEqual(self._verbs(summary), {key: CLEAR})
+		self.assertEqual(summary.plan[0].pinned, "openai_compat-0/claude-sonnet-5")
+
+	def test_null_model_override_reads_as_auto(self):
+		key = "agent:main:dashboard:pin-auto-2"
+		self._conv(key, model_override=None)
+		sess = _fake_sess(_page([_row(key, provider="zai_coding-0", model="claude-sonnet-4-6")]))
+		self.assertEqual(self._verbs(self._sweep(sess)), {key: CLEAR})
+
+	def test_legacy_pool_placeholder_pin_is_cleared(self):
+		key = "agent:main:dashboard:pin-legacy"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		self.assertEqual(self._verbs(self._sweep(sess)), {key: CLEAR})
+
+	def test_explicit_customer_pick_is_kept(self):
+		key = "agent:main:dashboard:pin-pick"
+		self._conv(key, model_override="gemini-3.6-flash")
+		sess = _fake_sess(_page([_row(key, provider="gemini-1", model="gemini-3.6-flash")]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: KEEP})
+		sess.clear_session_model.assert_not_called()
+
+	def test_pick_mismatch_is_reported_not_touched(self):
+		key = "agent:main:dashboard:pin-drift"
+		self._conv(key, model_override="gemini-3.6-flash")
+		sess = _fake_sess(_page([_row(key, provider="zai_coding-0", model="claude-sonnet-4-6")]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: REPORT})
+		sess.clear_session_model.assert_not_called()
+
+	def test_unpinned_sessions_are_not_planned(self):
+		key = "agent:main:dashboard:pin-clean"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key)]))
+		summary = self._sweep(sess)
+		self.assertEqual(summary.plan, [])
+		self.assertEqual(summary.scanned, 1)
+
+	def test_bench_throwaway_orphan_is_cleared(self):
+		key = "agent:main:dashboard:pin-title"
+		row = _row(key, provider="openai_compat-0", model="jarvis-pool", label="jarvis-title-abc123")
+		self.assertEqual(self._verbs(self._sweep(_fake_sess(_page([row])))), {key: CLEAR})
+
+	def test_agent_main_and_heartbeat_are_cleared(self):
+		rows = [
+			_row("agent:main:main", provider="openai_compat-0", model="jarvis-pool"),
+			_row("agent:main:main:heartbeat", provider="openai_compat-0", model="jarvis-pool"),
+		]
+		verbs = self._verbs(self._sweep(_fake_sess(_page(rows))))
+		self.assertEqual(set(verbs.values()), {CLEAR})
+		self.assertEqual(len(verbs), 2)
+
+	def test_unattributable_orphan_is_reported_not_touched(self):
+		key = "agent:main:dashboard:pin-orphan"
+		row = _row(key, provider="zai_coding-0", model="claude-sonnet-4-6", label="somebody-else")
+		sess = _fake_sess(_page([row]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: REPORT})
+		sess.clear_session_model.assert_not_called()
+
+	def test_in_flight_run_is_skipped(self):
+		key = "agent:main:dashboard:pin-busy"
+		self._conv(key, model_override="")
+		row = _row(key, provider="openai_compat-0", model="jarvis-pool", hasActiveRun=True)
+		sess = _fake_sess(_page([row]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: SKIP})
+		sess.clear_session_model.assert_not_called()
+
+	def test_entry_without_session_id_is_skipped(self):
+		# Patching one makes openclaw mint a fresh sessionId and drop the label.
+		key = "agent:main:dashboard:pin-nosid"
+		self._conv(key, model_override="")
+		row = _row(key, provider="openai_compat-0", model="jarvis-pool", sessionId=None)
+		sess = _fake_sess(_page([row]))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(self._verbs(summary), {key: SKIP})
+		sess.clear_session_model.assert_not_called()
+
+	# -- apply / dry run --------------------------------------------------- #
+
+	def test_dry_run_issues_no_rpc(self):
+		key = "agent:main:dashboard:pin-dry"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		summary = self._sweep(sess)
+		self.assertEqual(summary.cleared, 0)
+		self.assertFalse(summary.apply)
+		sess.clear_session_model.assert_not_called()
+
+	def test_apply_clears_only_the_clear_plans(self):
+		auto = "agent:main:dashboard:pin-a1"
+		pick = "agent:main:dashboard:pin-a2"
+		self._conv(auto, model_override="")
+		self._conv(pick, model_override="gemini-3.6-flash")
+		rows = [
+			_row(auto, provider="openai_compat-0", model="jarvis-pool"),
+			_row(pick, provider="gemini-1", model="gemini-3.6-flash"),
+		]
+		sess = _fake_sess(_page(rows))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 1)
+		sess.clear_session_model.assert_called_once_with(auto)
+
+	def test_max_clear_caps_the_run(self):
+		keys = []
+		for i in range(3):
+			key = f"agent:main:dashboard:pin-cap{i}"
+			self._conv(key, model_override="")
+			keys.append(key)
+		rows = [_row(k, provider="openai_compat-0", model="jarvis-pool") for k in keys]
+		sess = _fake_sess(_page(rows))
+		summary = self._sweep(sess, apply=True, max_clear=2)
+		self.assertEqual(summary.cleared, 2)
+		self.assertEqual(summary.capped, 1)
+		self.assertEqual(sess.clear_session_model.call_count, 2)
+
+	def test_one_failed_clear_does_not_stop_the_sweep(self):
+		keys = []
+		for i in range(2):
+			key = f"agent:main:dashboard:pin-err{i}"
+			self._conv(key, model_override="")
+			keys.append(key)
+		rows = [_row(k, provider="openai_compat-0", model="jarvis-pool") for k in keys]
+		sess = _fake_sess(_page(rows))
+		sess.clear_session_model.side_effect = [RuntimeError("nope"), None]
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.cleared, 1)
+		self.assertEqual(summary.errors, 1)
+		self.assertEqual(sess.clear_session_model.call_count, 2)
+
+	# -- transport --------------------------------------------------------- #
+
+	def test_missing_defaults_aborts_before_any_clear(self):
+		key = "agent:main:dashboard:pin-nodef"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")], defaults={}))
+		summary = self._sweep(sess, apply=True)
+		self.assertEqual(summary.aborted, "gateway reported no default model")
+		self.assertEqual(summary.plan, [])
+		sess.clear_session_model.assert_not_called()
+
+	def test_pages_are_followed(self):
+		first = "agent:main:dashboard:pin-p1"
+		second = "agent:main:dashboard:pin-p2"
+		self._conv(first, model_override="")
+		self._conv(second, model_override="")
+		sess = _fake_sess(
+			_page(
+				[_row(first, provider="openai_compat-0", model="jarvis-pool")],
+				has_more=True,
+				next_offset=1,
+			),
+			_page([_row(second, provider="openai_compat-0", model="jarvis-pool")]),
+		)
+		summary = self._sweep(sess)
+		self.assertEqual(summary.scanned, 2)
+		self.assertEqual(set(self._verbs(summary)), {first, second})
+		self.assertEqual(sess.list_sessions_page.call_count, 2)
+
+	def test_a_stalled_cursor_does_not_loop(self):
+		key = "agent:main:dashboard:pin-stall"
+		sess = _fake_sess(_page([_row(key)], has_more=True, next_offset=0))
+		self.assertEqual(self._sweep(sess).scanned, 1)
+		self.assertEqual(sess.list_sessions_page.call_count, 1)
+
+	def test_list_failure_reports_what_it_has(self):
+		key = "agent:main:dashboard:pin-half"
+		self._conv(key, model_override="")
+		sess = MagicMock()
+		sess.list_sessions_page.side_effect = [
+			_page(
+				[_row(key, provider="openai_compat-0", model="jarvis-pool")],
+				has_more=True,
+				next_offset=1,
+			),
+			RuntimeError("gateway went away"),
+		]
+		summary = self._sweep(sess)
+		self.assertEqual(self._verbs(summary), {key: CLEAR})
+
+	# -- entry point ------------------------------------------------------- #
+
+	def test_run_defaults_to_dry_run(self):
+		key = "agent:main:dashboard:pin-entry"
+		self._conv(key, model_override="")
+		sess = _fake_sess(_page([_row(key, provider="openai_compat-0", model="jarvis-pool")]))
+		orig = frappe.db.get_single_value(SETTINGS, "agent_url")
+		frappe.db.set_single_value(SETTINGS, "agent_url", "http://gw.test:18789")
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		try:
+			with patch("jarvis.chat.openclaw_client.OpenclawSession.connect", return_value=sess):
+				out = session_pin_sweep.run()
+		finally:
+			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
+			frappe.clear_document_cache(SETTINGS, SETTINGS)
+			frappe.db.commit()
+		self.assertFalse(out["apply"])
+		self.assertEqual(out["cleared"], 0)
+		self.assertEqual(out["counts"][CLEAR], 1)
+		sess.clear_session_model.assert_not_called()
+		sess.close.assert_called_once()
+
+	def test_run_without_agent_url_aborts(self):
+		orig = frappe.db.get_single_value(SETTINGS, "agent_url")
+		frappe.db.set_single_value(SETTINGS, "agent_url", "")
+		frappe.clear_document_cache(SETTINGS, SETTINGS)
+		try:
+			out = session_pin_sweep.run()
+		finally:
+			frappe.db.set_single_value(SETTINGS, "agent_url", orig or "")
+			frappe.clear_document_cache(SETTINGS, SETTINGS)
+			frappe.db.commit()
+		self.assertEqual(out["aborted"], "no agent_url")


### PR DESCRIPTION
## The defect this heals

openclaw stores a per-session model override. From the 2026.6.8 bundle,
`resolveEffectiveModelFallbacks`:

```js
if (!params.hasSessionModelOverride) return agentFallbacksOverride;
if (!(params.modelOverrideSource === "auto" || ...)) return [];
```

Any pin that is not flagged automatic returns **zero** failover candidates for that
conversation, permanently. The bench pinned sessions on unpinned "Auto" turns too
(`turn_handler._session_model_for` names the pool primary so openclaw does not reject the
`jarvis-pool` placeholder), and every such patch landed as `modelOverrideSource: "user"`.

Fixing the turn path does not heal what is already pinned. The override lives in the
container's session store and outlives restarts, re-renders and re-provisions. This PR is
the cleanup, not the fix.

## Where it lives, and why

The customer app, as a bench maintenance command. Attribution is the whole problem and it
is only possible here:

- Inside the container a customer's pick and a bench-written pin are byte-identical, and
  the gateway does not put `modelOverrideSource` on the wire at all.
- On the bench, `Jarvis Conversation.model_override` records what the customer actually
  chose. Empty means Auto, so a pinned session whose conversation is on Auto is ours by
  construction.

A fleet-agent endpoint can see the pins but cannot attribute them, so it would have to
unpin blindly and would silently revert deliberate customer picks.

## Remedy per class

| class | verb | why |
|---|---|---|
| conversation on Auto | **clear** | we wrote it; the customer asked for the default and its chain |
| conversation pins the same model | **keep** | deliberate pick, and openclaw disabling failover for it is the product behaviour we want |
| conversation pins a different model | **report** | bench and container disagree; the next turn re-patches it |
| `agent:<id>:main[:heartbeat]` | **clear** | the built-in poller resumes it every tick, so a pin there fails forever |
| bench throwaway (title/prewarm/polish) | **skip** | single-use, and `session_lifecycle` reaps them on the `updatedAt` a patch would bump |
| anything else with no conversation | **report** | unattributable, never touched |

Rewriting `modelOverrideSource` to `"auto"` was considered and rejected. It leaves a dead
provider as the chain primary so every turn still starts with a guaranteed failure; it
fabricates the auto-failover provenance openclaw's primary-probe machinery reads; and
`sessions.patch` rejects the field outright (`additionalProperties: false`, verified
against the pinned image).

## RPC, not a file edit

Clearing goes through `sessions.patch {"key": k, "model": null}`, which takes openclaw's
own isDefault branch and deletes `modelOverride`, `providerOverride`, `modelOverrideSource`
and the stale runtime fields together, then persists through the gateway's store writer.
Editing `sessions.json` host-side would race the gateway, which keeps the store in memory
and rewrites it on every session update, and would otherwise need the container stopped.

## Honest limits

A `sessions.list` row carries the **resolved** model, never the raw override, so "resolves
away from the agent default" is the only available signal. It cannot separate a live
override from a stale runtime record left by an earlier render. Measured on
`jarvis-pool-bf4097`: 6 conversation sessions resolve away from the default, 3 of which
hold a real override. The clear is an idempotent assertion, so a false positive costs a
telemetry reset, never a behaviour change.

## Safety

- Dry run is the default; `apply=True` is explicit.
- `MAX_CLEAR` caps one run at 200.
- Never patches a key the gateway did not just report (patching an absent key makes
  openclaw mint an entry with a fresh sessionId and drop the label).
- Skips sessions with a run in flight and sessions with no `sessionId`.
- `model_override` is re-read immediately before each patch, so a pick made between the
  listing and the apply is not reverted.
- The patch echoes the resulting entry: a surviving override, or a different `sessionId`
  (the lifecycle sweep freed the session mid-run), counts as an error, not a fix.

## Dry run on the live tenant

```
$ bench --site jarvis.proxy execute jarvis.chat.session_pin_sweep.run

default: anthropic-0/claude-sonnet-5 | scanned: 32 | planned: 26
counts: {'clear': 6, 'keep': 0, 'report': 0, 'skip': 20}
cleared: 0  raced: 0  errors: 0

  clear  openai_compat-0/claude-sonnet-5  conv=nqhgkivuov  conversation is on Auto
  clear  openai_compat-0/jarvis-pool      conv=ltcolnru7t  conversation is on Auto
  clear  zai_coding-0/claude-sonnet-4-6   conv=48khjmi2t3  conversation is on Auto
  clear  vllm/claude-sonnet-4-6           conv=oaa18i0chm  conversation is on Auto
  clear  vllm/claude-sonnet-4-6           conv=14qig8pcn4  conversation is on Auto
  clear  vllm/claude-sonnet-4-6           conv=oo7tnui5kk  conversation is on Auto
```

The tenant's session store was byte-identical before and after; no container was mutated.

## Usage

```bash
bench --site <site> execute jarvis.chat.session_pin_sweep.run
bench --site <site> execute jarvis.chat.session_pin_sweep.run --kwargs "{'apply': True}"
```

## Related, and worth checking before it merges

Branch `fix-auto-model-override-source` sends `modelOverrideSource: "auto"` as a
`sessions.patch` param. On openclaw 2026.6.8 that field is not in
`SessionsPatchParamsSchema`, which is `additionalProperties: false`, so the compiled
validator rejects the whole call:

```
{"key":"...","model":"claude-sonnet-5","modelOverrideSource":"auto"}
  => false  at root: unexpected property 'modelOverrideSource'
```

The bundle line that branch quotes lives in `buildDirectChildSessionPatch`, the subagent
spawn path, not in the `sessions.patch` handler. If that branch ships as written, every
model patch becomes an `INVALID_REQUEST`.

