### PR TITLE
Settings: keep content clear of the scrollbar, and fix the reset call-to-action

### DIFF
--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -177,8 +177,9 @@
 	/* scrollbar-gutter reserves nothing for macOS OVERLAY scrollbars, so the
 	   thumb is painted ON TOP of whatever sits at the right edge - right-aligned
 	   danger-zone buttons ended up half-covered by it. Keep content clear of the
-	   thumb's track by hand. */
-	padding-right: 10px;
+	   thumb's track by hand, with enough room that the bar reads as chrome
+	   sitting beside the pane rather than crowding its buttons. */
+	padding-right: 20px;
 }
 .jv-scroll-overlay::-webkit-scrollbar {
 	width: 7px;

--- a/frontend/src/assets/settings.css
+++ b/frontend/src/assets/settings.css
@@ -174,6 +174,11 @@
 	scrollbar-gutter: stable;
 	scrollbar-width: thin;
 	scrollbar-color: transparent transparent;
+	/* scrollbar-gutter reserves nothing for macOS OVERLAY scrollbars, so the
+	   thumb is painted ON TOP of whatever sits at the right edge - right-aligned
+	   danger-zone buttons ended up half-covered by it. Keep content clear of the
+	   thumb's track by hand. */
+	padding-right: 10px;
 }
 .jv-scroll-overlay::-webkit-scrollbar {
 	width: 7px;

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -151,11 +151,11 @@
 					</span>
 				</div>
 				<Button
-					v-if="!resetting"
+					v-if="!resetting && !resetOpen"
 					variant="subtle"
 					theme="red"
-					:label="resetOpen ? 'Close' : 'Reset workspace'"
-					@click="resetOpen = !resetOpen"
+					label="Reset workspace"
+					@click="openReset"
 				/>
 			</div>
 
@@ -195,22 +195,29 @@
 						</span>
 					</span>
 				</label>
-				<Button
-					class="mt-3"
-					variant="subtle"
-					theme="red"
-					label="Reset workspace"
-					iconLeft="refresh-cw"
-					:loading="resetBusy"
-					@click="doReset"
-				/>
+				<div ref="resetFormEl" class="mt-4 flex items-center gap-2">
+					<Button
+						variant="subtle"
+						theme="red"
+						label="Reset workspace"
+						iconLeft="refresh-cw"
+						:loading="resetBusy"
+						@click="doReset"
+					/>
+					<Button
+						variant="ghost"
+						label="Cancel"
+						:disabled="resetBusy"
+						@click="closeReset"
+					/>
+				</div>
 			</div>
 		</template>
 	</SettingsPane>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from "vue";
 import { Badge, Button, toast } from "frappe-ui";
 import { useShellStore } from "@/stores/shell";
 import { useConfirm } from "@/composables/useConfirm";
@@ -408,6 +415,20 @@ const resetNote = computed(() => {
 	return "This usually takes a few minutes. You can leave this page open — chat reloads when the workspace is back.";
 });
 
+const resetFormEl = ref(null);
+
+function openReset() {
+	resetOpen.value = true;
+	nextTick(() => resetFormEl.value?.scrollIntoView({ behavior: "smooth", block: "nearest" }));
+}
+
+function closeReset() {
+	resetOpen.value = false;
+	resetReason.value = "";
+	wipeData.value = false;
+	revokeLlm.value = false;
+}
+
 async function doReset() {
 	const parts = [
 		"Chat will stop working until the workspace reconnects (usually a few minutes).",
@@ -438,8 +459,7 @@ async function doReset() {
 				wipeData: wipeData.value,
 				revokeLlm: revokeLlm.value,
 			})) || {};
-		resetReason.value = "";
-		resetOpen.value = false;
+		closeReset();
 		resetState.value = out;
 		resetting.value = true;
 		toast.success("Resetting your workspace.");


### PR DESCRIPTION
Two issues seen in a screen recording of Settings → General → Danger zone.

**1. The scrollbar cut through the content.** The pane's scroll region sets `scrollbar-gutter: stable`, but macOS uses *overlay* scrollbars, for which that property reserves nothing — so the thumb was painted directly over the right-aligned **Delete all** and **Reset workspace** buttons, clipping them. Fixed by padding the scroll region itself, so this applies to every settings pane rather than patching one row.

**2. The reset call-to-action disappeared when you used it.** The row button retitled itself to **"Close"** as soon as the form opened — which reads as "close settings" — and the actual submit button sits below the fold, so after clicking the customer sees a form with no visible action. Now:
- the row button always reads **Reset workspace**, opens the form, and scrolls it into view;
- the form carries its own **Reset workspace** + **Cancel** pair, where the customer is already looking;
- Cancel clears the reason and both option checkboxes rather than leaving them armed for next time.

Frontend-only; no endpoint or behaviour change to the reset itself.