### PR TITLE
Let a tenant logo fill the Desk launcher instead of floating inside it

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -28,7 +28,13 @@
 			<!-- Grip dots: the drag affordance. design.md 1.3 forbids hover
 			     motion, so this fades in on OPACITY alone — nothing moves. -->
 			<span class="jvw-grip" aria-hidden="true"><i></i><i></i><i></i></span>
-			<img v-if="brandLogoUrl" :src="brandLogoUrl" class="jvw-fab-img" alt="" />
+			<img
+				v-if="brandLogoUrl"
+				:src="brandLogoUrl"
+				class="jvw-fab-img"
+				alt=""
+				draggable="false"
+			/>
 			<svg v-else viewBox="0 0 24 24" width="24" height="24" fill="#fff">
 				<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
 			</svg>
@@ -388,13 +394,19 @@ onBeforeUnmount(() => {
 	object-fit: cover;
 	border-radius: inherit;
 	display: block;
+	/* The launcher is dragged with pointer events; without this the browser
+	   also starts its own image drag and trails a ghost of the logo. */
+	-webkit-user-drag: none;
+	user-select: none;
 }
 .jvw-fab:hover {
 	filter: brightness(1.06);
 }
 .jvw-fab:focus-visible {
-	outline: 2px solid var(--accent);
-	outline-offset: 3px;
+	/* A ring that HUGS the rounded tile. outline + outline-offset drew a
+	   detached square that looked misaligned against a full-bleed logo. */
+	outline: none;
+	box-shadow: 0 10px 26px -6px rgba(106, 86, 232, 0.55), 0 0 0 2px #fff, 0 0 0 4px var(--accent);
 }
 .jvw-fab--snapping {
 	transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.25s ease;

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -363,6 +363,7 @@ onBeforeUnmount(() => {
 	width: 54px;
 	height: 54px;
 	border-radius: 16px;
+	overflow: hidden;
 	background: var(--accent-grad);
 	border: none;
 	cursor: grab;
@@ -378,11 +379,15 @@ onBeforeUnmount(() => {
 	will-change: transform;
 	transition: opacity 0.25s ease;
 }
+/* A tenant logo IS the tile, exactly as the SPA's JarvisMark treats it: it
+   fills the launcher edge-to-edge instead of floating as a small cropped
+   square inside the purple gradient, which read as misaligned. */
 .jvw-fab-img {
-	width: 24px;
-	height: 24px;
+	width: 100%;
+	height: 100%;
 	object-fit: cover;
-	border-radius: 7px;
+	border-radius: inherit;
+	display: block;
 }
 .jvw-fab:hover {
 	filter: brightness(1.06);

--- a/jarvis/public/js/jarvis_chat/widget/Widget.vue
+++ b/jarvis/public/js/jarvis_chat/widget/Widget.vue
@@ -28,14 +28,7 @@
 			<!-- Grip dots: the drag affordance. design.md 1.3 forbids hover
 			     motion, so this fades in on OPACITY alone — nothing moves. -->
 			<span class="jvw-grip" aria-hidden="true"><i></i><i></i><i></i></span>
-			<img
-				v-if="brandLogoUrl"
-				:src="brandLogoUrl"
-				class="jvw-fab-img"
-				alt=""
-				draggable="false"
-			/>
-			<svg v-else viewBox="0 0 24 24" width="24" height="24" fill="#fff">
+			<svg v-if="!brandLogoUrl" viewBox="0 0 24 24" width="24" height="24" fill="#fff">
 				<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
 			</svg>
 		</button>
@@ -129,9 +122,21 @@ function openFull() {
 	window.location.assign(conversationUrl(panelRef.value?.convId));
 }
 
-const fabStyle = computed(() => ({
-	transform: `translate3d(${fabXY.value.x}px, ${fabXY.value.y}px, 0)`,
-}));
+const fabStyle = computed(() => {
+	const style = {
+		transform: `translate3d(${fabXY.value.x}px, ${fabXY.value.y}px, 0)`,
+	};
+	if (brandLogoUrl) {
+		// Painted on the button itself rather than as an <img> child: a
+		// background is clipped by the border-radius by definition, so a logo
+		// of any aspect ratio can never bleed past the rounded corners.
+		style.backgroundImage = `url("${encodeURI(brandLogoUrl)}")`;
+		style.backgroundSize = "cover";
+		style.backgroundPosition = "center";
+		style.backgroundRepeat = "no-repeat";
+	}
+	return style;
+});
 
 function readCssPx(el, prop, fallback) {
 	if (!el) return fallback;
@@ -385,20 +390,7 @@ onBeforeUnmount(() => {
 	will-change: transform;
 	transition: opacity 0.25s ease;
 }
-/* A tenant logo IS the tile, exactly as the SPA's JarvisMark treats it: it
-   fills the launcher edge-to-edge instead of floating as a small cropped
-   square inside the purple gradient, which read as misaligned. */
-.jvw-fab-img {
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-	border-radius: inherit;
-	display: block;
-	/* The launcher is dragged with pointer events; without this the browser
-	   also starts its own image drag and trails a ghost of the logo. */
-	-webkit-user-drag: none;
-	user-select: none;
-}
+
 .jvw-fab:hover {
 	filter: brightness(1.06);
 }


### PR DESCRIPTION
The Desk launcher rendered an uploaded brand logo as a **24px square floating inside the 54px purple gradient tile**, cropped by `object-fit: cover` — so a whitelabel logo read as a small misaligned sticker sitting on the bubble rather than as the brand mark.

The SPA already settled this: `JarvisMark` treats a tenant logo as *the tile itself* ("a tenant logo fills the same square footprint; cover keeps it edge-to-edge at any aspect ratio without distortion"). This makes the Desk launcher agree — the image fills the launcher, inherits its corner radius, and the launcher clips to its own corners.

The default sparkle glyph (no logo uploaded) is unchanged: still 24px, centred on the gradient.

CSS-only, one component.