### PR TITLE
fix(support): thread the reply Communication id to the media upload

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -480,9 +480,13 @@ function _uploadErrorMessage(data, status) {
 	return `upload failed (${status})`;
 }
 
-export async function supportUpload(ticket, file) {
+export async function supportUpload(ticket, file, comm) {
 	const fd = new FormData();
 	fd.append("ticket", ticket);
+	// Attach to the reply Communication (when given) so Helpdesk renders the file inline; a
+	// ticket-level File only shows in the sidebar. Appended before the file, so the multipart
+	// scalar fields precede the binary part.
+	if (comm) fd.append("comm", comm);
 	fd.append("file", file, file.name);
 	const r = await fetch("/api/method/jarvis.support.media.upload", {
 		method: "POST",

--- a/frontend/src/pages/support/SupportThreadPage.vue
+++ b/frontend/src/pages/support/SupportThreadPage.vue
@@ -458,9 +458,17 @@ async function send() {
 		// Whether the draft was cleanly cleared (the user didn't retype mid-send) —
 		// gates both the reference-safe clear and the reply-box collapse below.
 		let cleared = false;
+		// The reply's Communication name — attaching the files to it (below) is what makes
+		// Helpdesk render them inline; a ticket-level File only shows in the sidebar. Hoisted
+		// out of the `if (body)` block so the upload can thread it through.
+		let replyComm = "";
 		if (body) {
 			const ok = await store.reply(tName, body);
 			if (!ok) return; // store already toasted; keep the draft so it isn't lost
+			// store.reply returns the new Communication's name on success, or `true` when the CP
+			// didn't echo one (older CP). Keep only a real string id to thread to the upload —
+			// `true` would post a bogus comm the CP would reject.
+			if (typeof ok === "string") replyComm = ok;
 			// I2: only clear if the editor STILL holds exactly what was at send-start
 			// — a blanket clear would wipe text the user kept typing during the
 			// in-flight reply. The raw-snapshot compare makes this safe for the
@@ -481,7 +489,11 @@ async function send() {
 			// send must not be uploaded (Helpdesk has no un-attach).
 			const live = staged.filter((f) => files.value.includes(f));
 			if (live.length) {
-				const uploaded = await store.uploadTo(tName, live);
+				// Thread the reply's Communication so each File attaches to it and renders inline.
+				// replyComm is "" when there was no reply (never reached here — a files-only send
+				// posts a synthesized reply) or when the CP didn't echo one; supportUpload then
+				// omits the field and the File attaches to the ticket, as before.
+				const uploaded = await store.uploadTo(tName, live, replyComm);
 				settleUpload(uploaded);
 			}
 		}

--- a/frontend/src/stores/support.js
+++ b/frontend/src/stores/support.js
@@ -159,8 +159,12 @@ async function createTicket(subject, body) {
 
 async function reply(name, body) {
 	try {
-		await supportReply(name, body);
-		return true;
+		const r = await supportReply(name, body);
+		// Return the new Communication's name so the caller can thread a files-only/attachment
+		// upload to it — attaching a File to the Communication is what makes it render inline.
+		// Fall back to `true` when the CP didn't echo one, so existing truthiness-checking
+		// callers (the `if (!ok) return` guard in send()) still read this as success.
+		return (r && r.data && r.data.comm) || true;
 	} catch (e) {
 		toast.error(errMsg(e));
 		return false;
@@ -183,11 +187,11 @@ async function closeTicket(name) {
 // the File REFERENCES that actually succeeded (not a count) — the caller
 // (useStagedFiles's settleUpload) needs to know exactly which ones landed so a
 // retry re-sends only the failures, never the ones already attached.
-async function uploadTo(name, files) {
+async function uploadTo(name, files, comm) {
 	const succeeded = [];
 	for (const f of files || []) {
 		try {
-			await supportUpload(name, f);
+			await supportUpload(name, f, comm);
 			succeeded.push(f);
 		} catch (e) {
 			toast.error(`Couldn't attach ${f.name}: ${errMsg(e)}`);

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -549,8 +549,18 @@ def support_awaiting_count(*, requesting_user: str, scope: str) -> dict:
 	)
 
 
-def support_upload(*, ticket: str, filename: str, content_b64: str, requesting_user: str, scope: str) -> dict:
+def support_upload(
+	*,
+	ticket: str,
+	filename: str,
+	content_b64: str,
+	requesting_user: str,
+	scope: str,
+	comm: str | None = None,
+) -> dict:
 	# Bytes ride b64-in-JSON (the CP media.upload decodes) -> plain _post, no binary helper.
+	# comm (optional): the reply Communication to attach the File to so it renders inline; the CP
+	# re-checks it belongs to the ticket before honoring it.
 	return _post(
 		path=_m("support.media.upload"),
 		body={
@@ -559,6 +569,7 @@ def support_upload(*, ticket: str, filename: str, content_b64: str, requesting_u
 			"content_b64": content_b64,
 			"requesting_user": requesting_user,
 			"scope": scope,
+			"comm": comm,
 		},
 		timeout_s=DEFAULT_TIMEOUT_S,
 	)

--- a/jarvis/support/media.py
+++ b/jarvis/support/media.py
@@ -42,7 +42,10 @@ def download(ticket: str, file_url: str):
 
 
 @frappe.whitelist()
-def upload(ticket: str) -> dict:
+def upload(ticket: str, comm: str | None = None) -> dict:
+	# comm (optional): the reply Communication this upload belongs to. Frappe maps the multipart form
+	# field onto it, same as `ticket`. Forwarded to the CP, which attaches the File to that Communication
+	# (so it renders inline) after re-checking the comm belongs to the ticket.
 	scope = _scope()
 	f = frappe.request.files.get("file") if frappe.request else None
 	if not f:
@@ -62,5 +65,6 @@ def upload(ticket: str) -> dict:
 			content_b64=content_b64,
 			requesting_user=_requesting_user(),
 			scope=scope,
+			comm=comm,
 		),
 	}


### PR DESCRIPTION
## Companion to jarvis-admin-v2 #135
The control-plane fix (attach a customer's reply media to its reply **Communication** so Helpdesk renders it inline, instead of the ticket) needs the bench to send the reply Communication's name to the upload. This wires that through.

## Change
- `store.reply` now returns the new Communication's name (the CP `reply` echoes it); falls back to `true` on an older CP.
- `send()` captures it and passes it to `store.uploadTo(tName, live, replyComm)` (only when it's a real string — the `if (!ok) return` failure guard is preserved).
- `uploadTo` / `api.js supportUpload` forward `comm` in the multipart upload.
- `admin_client.support_upload` + `jarvis.support.media.upload` thread `comm` to the CP.

Reply-first ordering and all existing `send()` guards (reference-safe clear, tName snapshot, files-live filter, collapse-after-send) are unchanged. An older CP that ignores `comm` falls back to the previous ticket-attach.

## Review & tests
Reviewed in a two-cycle adversarial Fable loop alongside the CP change: the return-shape wiring was traced end-to-end and verified to fire; `send()` confirmed regression-free; the older-CP fallback proven real. The logic is covered by the CP suite (55 tests on `adminv2-test.localhost`); this side is thin pass-through wiring. (SPA build/vitest not run — a local bench-path issue blocks `vite build`; changes are additive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)