### PR TITLE
fix(disconnect): give the disconnect a timeout that outlasts admin's own budget

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -961,10 +961,18 @@ def post_subscription_disconnect() -> dict:
 	"""POST to admin to clear the customer's OAuth profile on the container.
 
 	Idempotent - a tenant in api_key mode is a no-op success.
+
+	Carries the same 180s as post_push_oauth_blob, and for the same reason: this
+	lands on admin's DELETE /auth-profile, whose own agent bound is 150s
+	(``agent_client.delete_auth_profile``) and which runs doctor + restart inside
+	it. Riding the shared DEFAULT_TIMEOUT_S of 150 left ZERO headroom for the
+	HTTPS round trip on top of that, so the bench could give up on a call admin
+	was still serving -- the same shape as the disconnect defect below.
 	"""
 	return _post(
 		path=_m("api.tenant.subscription_disconnect"),
 		body={},
+		timeout_s=180,
 	)
 
 
@@ -986,6 +994,17 @@ def post_subscription_disconnect() -> dict:
 #: exists to provide. Observed end-to-end on a live pool tenant.
 #:
 #: INVARIANT: keep this ABOVE admin's ``provision_healthz_timeout_s`` + 30.
+#:
+#: AND BELOW the web worker's own ceiling, which this file cannot enforce. The
+#: call is synchronous inside a whitelisted request, so gunicorn's ``-t``
+#: (bench's ``http_timeout``, unset here and so defaulting to 120 in a
+#: supervisor deployment) bounds the whole thing. If that ceiling is lower than
+#: the budget admin needs, the worker is killed mid-call and the caller never
+#: reaches ``_clear_llm_secrets`` -- the same split state this constant exists
+#: to prevent, just triggered a layer up. Raising this without also raising
+#: ``http_timeout`` therefore fixes dev and leaves that deployment exposed;
+#: the durable fix is to stop depending on the response (converge from admin's
+#: own state on a later pass) rather than to keep widening timeouts.
 _DISCONNECT_TIMEOUT_S = 240
 
 

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -968,6 +968,27 @@ def post_subscription_disconnect() -> dict:
 	)
 
 
+#: The disconnect's own HTTP budget. Deliberately NOT the shared 150s.
+#:
+#: admin's interactive-apply ladder hands the agent ``provision_healthz_timeout_s``
+#: to come back healthy and then waits ``+30s`` on top of that itself
+#: (``agent_client._interactive_apply_timeouts``). At the shipped 180s healthz
+#: budget admin is therefore entitled to spend 210s answering, while this call
+#: gave up at DEFAULT_TIMEOUT_S = 150 -- SIXTY SECONDS before admin could reply.
+#: So any disconnect that actually needed its healthz budget (i.e. exactly the
+#: slow container the budget exists for) raised AdminUnreachableError on a call
+#: that was still succeeding server-side.
+#:
+#: That false failure is not cosmetic. ``onboarding.disconnect_llm`` aborts
+#: BEFORE ``_clear_llm_secrets`` when this raises, by design, so the customer was
+#: left advertising a live model while admin and the host had already destroyed
+#: the credentials -- the exact inversion of the ordering guarantee that abort
+#: exists to provide. Observed end-to-end on a live pool tenant.
+#:
+#: INVARIANT: keep this ABOVE admin's ``provision_healthz_timeout_s`` + 30.
+_DISCONNECT_TIMEOUT_S = 240
+
+
 def post_disconnect_llm() -> dict:
 	"""POST to admin to delete EVERY LLM credential from the customer's container:
 	the pool spec and its sidecar keys, /secrets/llm.key, and any auth profile.
@@ -979,9 +1000,9 @@ def post_disconnect_llm() -> dict:
 	Idempotent - a tenant with nothing configured is a no-op success, so a repeat
 	call (or a retry after a read timeout) is safe.
 
-	Rides the shared DEFAULT_TIMEOUT_S like post_update_llm_pool: admin re-renders
-	the tenant config and restarts the container on this path too, which sits above
-	the admin's own admin->agent budget.
+	Runs on _DISCONNECT_TIMEOUT_S, NOT the shared DEFAULT_TIMEOUT_S: see that
+	constant for why 150s was strictly below what admin is allowed to spend, and
+	what the resulting false "admin is unreachable" did to the customer's row.
 
 	Raises:
 		AdminAuthError, AdminUnreachableError, AdminValidationError
@@ -989,6 +1010,7 @@ def post_disconnect_llm() -> dict:
 	return _post(
 		path=_m("api.tenant.disconnect_llm"),
 		body={},
+		timeout_s=_DISCONNECT_TIMEOUT_S,
 	)
 
 

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -882,9 +882,10 @@ class TestPostSubscriptionDisconnect(FrappeTestCase):
 	def test_happy_path(self):
 		captured = {}
 
-		def _fake_post(url, json=None, **_kw):
+		def _fake_post(url, json=None, timeout=None, **_kw):
 			captured["url"] = url
 			captured["body"] = json
+			captured["timeout"] = timeout
 			return _mock_response(200, json_body={"message": {"ok": True, "data": {"ok": True}}})
 
 		with patch("requests.post", side_effect=_fake_post):
@@ -892,6 +893,15 @@ class TestPostSubscriptionDisconnect(FrappeTestCase):
 		self.assertEqual(result, {"ok": True})
 		self.assertIn("subscription_disconnect", captured["url"])
 		self.assertEqual(captured["body"], {})
+		# This lands on admin's DELETE /auth-profile, whose own agent bound is
+		# 150s and which runs doctor + restart inside it. The shared 150s left no
+		# headroom for the HTTPS round trip on top, so the bench could give up on
+		# a call admin was still serving.
+		self.assertGreater(
+			captured["timeout"],
+			150,
+			"must leave headroom over admin's own 150s delete_auth_profile bound",
+		)
 
 
 class TestPostDisconnectLlm(FrappeTestCase):
@@ -904,17 +914,11 @@ class TestPostDisconnectLlm(FrappeTestCase):
 	def test_timeout_outlasts_admins_own_budget(self):
 		"""Same rule as post_push_oauth_blob above, which the disconnect missed.
 
-		admin floors the agent's healthz budget at provision_healthz_timeout_s
-		and then waits +30s on top of it itself, so at the shipped 180s setting
-		admin may legitimately spend 210s answering. Riding the shared 150s meant
-		this call gave up SIXTY SECONDS early on exactly the slow container the
-		budget exists for, and reported AdminUnreachableError for a disconnect
-		that was still succeeding.
-
-		That false failure is not cosmetic: onboarding.disconnect_llm aborts
-		before clearing the bench's own credentials when this raises, so the
-		customer kept advertising a live model after admin and the host had
-		already destroyed it.
+		The rationale (and the invariant this bound encodes) lives once, on
+		``admin_client._DISCONNECT_TIMEOUT_S``. This asserts two separate things:
+		that the constant is actually PLUMBED to requests, and that it still
+		clears admin's worst-case budget -- so bumping the constant alone cannot
+		silently drop back under it.
 		"""
 		captured = {}
 
@@ -927,6 +931,11 @@ class TestPostDisconnectLlm(FrappeTestCase):
 			admin_client.post_disconnect_llm()
 
 		self.assertIn("disconnect_llm", captured["url"])
+		self.assertEqual(
+			captured["timeout"],
+			admin_client._DISCONNECT_TIMEOUT_S,
+			"the dedicated budget must actually reach requests, not just be declared",
+		)
 		self.assertGreater(
 			captured["timeout"],
 			210,

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -894,6 +894,47 @@ class TestPostSubscriptionDisconnect(FrappeTestCase):
 		self.assertEqual(captured["body"], {})
 
 
+class TestPostDisconnectLlm(FrappeTestCase):
+	def setUp(self):
+		_settings_for_admin()
+
+	def tearDown(self):
+		_settings_clear_admin()
+
+	def test_timeout_outlasts_admins_own_budget(self):
+		"""Same rule as post_push_oauth_blob above, which the disconnect missed.
+
+		admin floors the agent's healthz budget at provision_healthz_timeout_s
+		and then waits +30s on top of it itself, so at the shipped 180s setting
+		admin may legitimately spend 210s answering. Riding the shared 150s meant
+		this call gave up SIXTY SECONDS early on exactly the slow container the
+		budget exists for, and reported AdminUnreachableError for a disconnect
+		that was still succeeding.
+
+		That false failure is not cosmetic: onboarding.disconnect_llm aborts
+		before clearing the bench's own credentials when this raises, so the
+		customer kept advertising a live model after admin and the host had
+		already destroyed it.
+		"""
+		captured = {}
+
+		def _fake_post(url, json=None, headers=None, timeout=None):
+			captured["url"] = url
+			captured["timeout"] = timeout
+			return _mock_response(200, json_body={"message": {"ok": True, "data": {"ok": True}}})
+
+		with patch("requests.post", side_effect=_fake_post):
+			admin_client.post_disconnect_llm()
+
+		self.assertIn("disconnect_llm", captured["url"])
+		self.assertGreater(
+			captured["timeout"],
+			210,
+			"must outlast admin's provision_healthz_timeout_s (180) + its own 30s headroom, "
+			"or a slow-but-successful disconnect is reported to the customer as unreachable",
+		)
+
+
 class TestPairChatDevice(FrappeTestCase):
 	"""Sprint-2 plumb-through (2026-06-16 review): bench's pair_chat_device
 	now accepts request_timeout_s and forwards it as a body field so admin


### PR DESCRIPTION
## The defect

`post_disconnect_llm` rode the shared `DEFAULT_TIMEOUT_S = 150`.

admin floors the agent's healthz budget at `provision_healthz_timeout_s` and then waits **+30s on top of that itself** (`agent_client._interactive_apply_timeouts`). At the shipped 180s setting admin is entitled to spend **210s** answering this call.

`150 < 210`. The bench gave up sixty seconds before admin could reply, on exactly the slow container the healthz budget exists for, and raised `AdminUnreachableError` for a disconnect that was still succeeding server-side. The old docstring asserted the opposite ("sits above the admin's own admin->agent budget"); the arithmetic never supported it.

## Why it is not cosmetic

`onboarding.disconnect_llm` aborts **before** `_clear_llm_secrets` when this raises. That abort is deliberate: it stops a failed admin call from leaving a bench reading "disconnected" over a container still holding live keys.

A client-side timeout on a call that actually succeeded produces the mirror image of that guarantee. Observed end to end on a live pool tenant: admin and the host destroyed the credentials, while the bench went on advertising a `gemini/gemini-3.6-flash` model whose key no longer existed anywhere.

## The fix

A dedicated `_DISCONNECT_TIMEOUT_S = 240`, documented with the invariant "keep this above admin's `provision_healthz_timeout_s` + 30".

`post_push_oauth_blob` already carries exactly this rule, with the same reasoning and its own lower-bound test. The disconnect never got it. The new test mirrors that one.

## Verification

Found by running the disconnect end to end on a live pool tenant, not by reading. The customer-visible symptom was `"admin is unreachable; check network / service status"` while admin was reachable the whole time (HTTP 200 throughout).

Paired with Aerele-RnD/jarvis-admin-v2#TBD, which fixes the two admin-side halves.