### PR TITLE
fix(chat): revive the error phone-home killed by the selfhost-module deletion

### DIFF
--- a/jarvis/error_push.py
+++ b/jarvis/error_push.py
@@ -57,10 +57,6 @@ MAX_BUFFER_ROWS = 5000
 def push_error_rollup() -> None:
 	"""``*/5`` scheduler entry. Self-gating + best-effort; NEVER raises."""
 	try:
-		from jarvis import selfhost
-
-		if selfhost.is_self_hosted():
-			return
 		if not _admin_configured():
 			return
 		_do_push()

--- a/jarvis/tests/test_api_errors.py
+++ b/jarvis/tests/test_api_errors.py
@@ -12,14 +12,11 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis import api_errors, error_push
 
-# NB: this module deliberately never imports or patches ``jarvis.selfhost``.
-# ``test_whitelist_annotations`` walks and imports every jarvis module via
-# pkgutil, and in some CI shard orders (py3.14) that leaves
-# ``sys.modules['jarvis.selfhost']`` as ``None`` - so any later
-# ``import jarvis.selfhost`` (here, or inside push_error_rollup) raises
-# ModuleNotFoundError. The self-host gate is therefore driven through its real
-# input (the ``deployment_mode`` setting) and the claim/confirm/revert core is
-# tested via ``_do_push`` directly, both of which avoid the selfhost import.
+# NB: self-hosted mode was removed (commit 9f8d984a deleted ``jarvis/selfhost.py``),
+# so error_push no longer imports it and push_error_rollup gates only on
+# ``_admin_configured()``. ``test_pushes_when_admin_configured`` drives the real
+# entry point - the earlier push tests only exercise ``_do_push``, which is how a
+# stale ``import jarvis.selfhost`` shipped a silently-dead push job with green tests.
 
 DT = api_errors.DT
 USER = "apierr-user@example.com"
@@ -316,31 +313,25 @@ class TestErrorLogReader(ApiErrorsBase):
 # Push job — self-gating + never-raise
 # --------------------------------------------------------------------------- #
 class TestPushSelfGates(ApiErrorsBase):
-	# Drive is_self_hosted() through its real input (deployment_mode) and patch
-	# only the importable admin_client / error_push seams - never jarvis.selfhost.
-	def _pin_deployment_mode(self, mode):
-		# ApiErrorsBase.tearDown commits, which defeats FrappeTestCase's rollback -
-		# so a change to this shared Single would leak Self-Hosted into every later
-		# file in the shard (is_self_hosted() gates real behaviour). Restore it.
-		prev = frappe.db.get_single_value("Jarvis Settings", "deployment_mode") or "Managed"
-
-		def restore():
-			frappe.db.set_single_value("Jarvis Settings", "deployment_mode", prev)
-			frappe.db.commit()
-
-		self.addCleanup(restore)
-		frappe.db.set_single_value("Jarvis Settings", "deployment_mode", mode)
-
-	def test_skips_when_self_hosted(self):
-		self._pin_deployment_mode("Self-Hosted")
-		from jarvis import admin_client
-
-		with patch.object(admin_client, "push_error_rollup") as push:
+	# push_error_rollup gates only on _admin_configured() now (self-hosted mode
+	# removed). Patch only the importable error_push / admin_client seams.
+	def test_pushes_when_admin_configured(self):
+		# Regression: the real */5 entry point must REACH the push when admin is
+		# configured. A stale `from jarvis import selfhost` (module deleted in
+		# 9f8d984a) made every tick raise ModuleNotFoundError, swallowed by the
+		# never-raise guard, so tenant errors were silently never forwarded - and
+		# the suite stayed green because the other push tests drive _do_push
+		# directly and never push_error_rollup itself.
+		with (
+			patch.object(error_push, "_admin_configured", return_value=True),
+			patch.object(error_push, "_do_push") as do_push,
+			patch.object(error_push, "_log_push_failure_throttled") as logged,
+		):
 			error_push.push_error_rollup()
-		push.assert_not_called()
+		do_push.assert_called_once()
+		logged.assert_not_called()  # no swallowed import/other error
 
 	def test_skips_when_admin_unconfigured(self):
-		self._pin_deployment_mode("Managed")
 		from jarvis import admin_client
 
 		with (
@@ -367,9 +358,9 @@ class TestPushClaimConfirm(ApiErrorsBase):
 
 	def _run_do_push(self, push_impl):
 		"""Drive the claim/confirm/revert core directly with the admin push replaced
-		by ``push_impl``. Goes through ``_do_push`` (not ``push_error_rollup``) so the
-		test never depends on the self-host gate or the jarvis.selfhost import - the
-		gates are covered by TestPushSelfGates. ``admin_client`` imports cleanly."""
+		by ``push_impl``. Goes through ``_do_push`` (not ``push_error_rollup``) to
+		isolate the claim/confirm/revert logic; the entry-point gate is covered by
+		TestPushSelfGates. ``admin_client`` imports cleanly."""
 		from jarvis import admin_client
 
 		with patch.object(admin_client, "push_error_rollup", push_impl):


### PR DESCRIPTION
## What

`push_error_rollup` (the `*/5` scheduler entry that forwards tenant errors to the control-plane Errors feed) still did `from jarvis import selfhost`, but commit `9f8d984a` ("remove self-hosted deployment support") **deleted `jarvis/selfhost.py`** — self-hosting is a removed *mode*, not a file. `error_push.py:60` was the last live importer the cleanup missed.

**Effect on `develop` today:** every `*/5` tick raises `ModuleNotFoundError` at that import, which the never-raise guard swallows via `_log_push_failure_throttled`. So **tenant errors are silently no longer reaching the control plane** — a dead phone-home, with a green test suite.

## Why the tests didn't catch it

The push tests were authored *around* the fragile import: `TestPushClaimConfirm` drives `_do_push` directly (never `push_error_rollup`), and `test_skips_when_self_hosted` "passed" via the `ModuleNotFoundError` rather than the gate it claimed to test.

## Fix

- Remove the dead self-hosted gate from `push_error_rollup` (matching how `9f8d984a` stripped the `selfhost` import + `is_self_hosted()` branch at every other call site). The real gate — `_admin_configured()` — stays and already skips un-onboarded tenants.
- Delete `test_skips_when_self_hosted` + its `_pin_deployment_mode` helper (they test a mode that no longer exists) and de-pin `test_skips_when_admin_unconfigured` (error_push no longer reads `deployment_mode`).
- **Add `test_pushes_when_admin_configured`** — a regression that drives the *real* `push_error_rollup` entry point and asserts it reaches `_do_push` with nothing swallowed. Mutation-verified: re-introducing the `import jarvis.selfhost` makes it fail (`_do_push` called 0 times), which is exactly the shipped bug.

## Tests

`jarvis.tests.test_api_errors` — **26/26 pass** on `jarvis-test.localhost`. (A transient 1-failure was pre-existing `Error Log` pollution in the local test DB — `collect_error_log` watermark, unrelated to this change; green after truncating Error Log.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
