### PR TITLE
fix(reconnect): pass the company so multi-company accounts can reconnect

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,8 +39,8 @@ export const setAutoApply = (conversation, value) =>
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
 // ---- account reconnect (fresh bench -> existing paid subscription) ---------
-export const startAccountReconnect = (email) =>
-	call("jarvis.onboarding.start_account_reconnect", { email });
+export const startAccountReconnect = (email, company = "") =>
+	call("jarvis.onboarding.start_account_reconnect", { email, company });
 export const checkAccountReconnect = (requestId, code) =>
 	call("jarvis.onboarding.check_account_reconnect", { request_id: requestId, code: code || "" });
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1291,7 +1291,7 @@ async function resendReconnectCode() {
 	if (state.reconnectResentIn > 0) return;
 	state.payErr = "";
 	try {
-		const d = await startAccountReconnect(state.email);
+		const d = await startAccountReconnect(state.email, state.company);
 		state.reconnectRequestId = (d && d.request) || state.reconnectRequestId;
 		state.reconnectCode = "";
 		state.reconnectResentIn = 30;
@@ -1339,7 +1339,7 @@ async function startReconnect() {
 	state.reconnectCode = "";
 	state.payBusy = true;
 	try {
-		const d = await startAccountReconnect(state.email);
+		const d = await startAccountReconnect(state.email, state.company);
 		state.reconnectRequestId = (d && d.request) || "";
 		state.payPhase = "reconnect";
 	} catch (e) {

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1232,7 +1232,9 @@ async function runStartPay() {
 		// reconnect path instead of the dead end. Match both the pre- and
 		// post-multi-company wording ("already registered or pending" and
 		// "...email and company already exists").
-		state.reconnectOffered = /already registered or pending|already exists/i.test(state.payErr);
+		state.reconnectOffered = /already registered or pending|already exists/i.test(
+			state.payErr
+		);
 	}
 }
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1229,8 +1229,10 @@ async function runStartPay() {
 		state.payErr = errMsg(e);
 		// The duplicate-email rejection on a FRESH bench (no stored creds to
 		// auto-resume with) usually means "my old site died" - offer the
-		// reconnect path instead of the dead end.
-		state.reconnectOffered = /already registered or pending/i.test(state.payErr);
+		// reconnect path instead of the dead end. Match both the pre- and
+		// post-multi-company wording ("already registered or pending" and
+		// "...email and company already exists").
+		state.reconnectOffered = /already registered or pending|already exists/i.test(state.payErr);
 	}
 }
 

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -223,14 +223,15 @@ def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
 
 
-def request_account_reconnect(email: str) -> dict:
+def request_account_reconnect(email: str, company_name: str = "") -> dict:
 	"""Guest: start a fresh-bench reconnect to an EXISTING paid account (wiped
 	site recovery). Admin emails a CODE to the registered address and returns an
 	opaque request_id to poll — the response is identical whether or not the
-	email matches an account. Nothing is re-paid."""
+	email matches an account. Nothing is re-paid. ``company_name`` disambiguates
+	when one email owns several company accounts (multi-company identity)."""
 	return _post_guest(
 		path=_m("billing.reconnect.request_account_reconnect"),
-		body={"email": email, "frappe_site_url": frappe.utils.get_url()},
+		body={"email": email, "company_name": company_name, "frappe_site_url": frappe.utils.get_url()},
 	)
 
 

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -505,16 +505,17 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 
 
 @frappe.whitelist()
-def start_account_reconnect(email: str) -> dict:
+def start_account_reconnect(email: str, company: str = "") -> dict:
 	"""Fresh-bench recovery: ask admin to email a reconnect CODE to the
 	REGISTERED address of an existing paid account (wiped-site scenario — the
 	duplicate-email guard blocks re-signup, and nothing should be re-paid).
+	``company`` disambiguates when the email owns several company accounts.
 	Returns {request, message}; the customer then types the code, which
 	``check_account_reconnect`` redeems. Same System-Manager gating as the rest
 	of onboarding."""
 	require_jarvis_admin()
 	_require_admin_url()
-	return _surface(admin_client.request_account_reconnect, email)
+	return _surface(admin_client.request_account_reconnect, email, company)
 
 
 @frappe.whitelist()

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -916,8 +916,8 @@ class TestAccountReconnect(FrappeTestCase):
 			"jarvis.onboarding.admin_client.request_account_reconnect",
 			return_value={"request": "rid-1", "message": "check your email"},
 		) as req:
-			out = onboarding.start_account_reconnect("someone@example.com")
-		req.assert_called_once_with("someone@example.com")
+			out = onboarding.start_account_reconnect("someone@example.com", "Acme")
+		req.assert_called_once_with("someone@example.com", "Acme")
 		self.assertEqual(out["request"], "rid-1")
 
 	def test_check_pending_writes_nothing(self):


### PR DESCRIPTION
## What

The account-reconnect wizard (jarvis#516) sent only the **email** to admin's `request_account_reconnect`. Under the multi-company identity model (jarvis-admin-v2#118), one email can own several company accounts, so admin's `_resolve_customer(email, "")` returns *ambiguous* and — to preserve anti-enumeration — **silently sends no code**, dead-ending exactly the customers #118 exists to create.

## Change

Thread the **company** through the reconnect request. The wizard already collects `state.company` (required for signup), and reconnect is only offered *after* signup hits the `(email, company)` duplicate — so that company is precisely the account to reconnect. No new UI field.

- `OnboardingView.vue` — both `startAccountReconnect` call sites pass `state.company`
- `api.js` — `startAccountReconnect(email, company)`
- `onboarding.py` — `start_account_reconnect(email, company="")`
- `admin_client.py` — `request_account_reconnect(email, company_name="")` → adds `company_name` to the POST body

The **admin side already accepts `company_name`** (`billing/reconnect.py`), so no admin change is needed. Single-account emails are unaffected — `company` only disambiguates when the email owns several accounts.

## Tests

`test_onboarding_sync.TestAccountReconnect.test_start_proxies_request` updated to assert the company is forwarded.

## Companion

Admin: jarvis-admin-v2#131 (reconnect, already multi-company-aware) + #118 (multi-company identity).
