### PR TITLE
feat(chat): GAP 3 — self-heal a wedged relay pump (force-takeover, flag-off)

### DIFF
--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -1559,12 +1559,11 @@ def drain_slice(ctx: PumpContext) -> str:
 	# regardless — the snapshot poll never blocks and mux.dispatch runs below.
 	_maybe_refresh_capacity(ctx)
 	_poll_snapshot(ctx)  # CDX-11: fold a resolved refresh (or fail-close a timed-out one) pre-promote
-	_promote_queued(ctx)
-	_dispatch_ready(ctx)  # OARF-5: issues chat.send acks, parks them (never blocks)
+	promoted = _promote_queued(ctx)
+	dispatched = _dispatch_ready(ctx)  # OARF-5: issues chat.send acks, parks them (never blocks)
 	_poll_pending(ctx)  # OARF-5: resolve done acks/recovery tails; ack-timeout deadlines
 
-	if ctx.mux is not None:
-		ctx.mux.dispatch(block_s=SLICE_BLOCK_S)
+	applied = ctx.mux.dispatch(block_s=SLICE_BLOCK_S) if ctx.mux is not None else 0
 	if ctx.lease_lost:
 		ts.lease_lost_exit(ctx.lease_lost)
 	# D5 §5-d: a dead socket ends the hop (the reader's Closing already failed the
@@ -1575,7 +1574,12 @@ def drain_slice(ctx: PumpContext) -> str:
 
 	_cancel_sweep(ctx)
 
-	_heartbeat_and_renew(ctx)
+	# GAP 3 A2: progress = the slice did real drain work (promoted / dispatched a turn
+	# or applied a mux frame) OR the pump is correctly capacity-blocked (fail-closed:
+	# gateway visibility UNKNOWN, where a takeover cannot help — not a wedge). Only a
+	# genuine "should be draining but isn't" leaves the progress stamp un-advanced.
+	progressed = promoted > 0 or dispatched > 0 or applied > 0 or not ctx.gateway_active_known
+	_heartbeat_and_renew(ctx, progressed)
 
 	if _idle_exit(ctx):
 		return "idle_exit"
@@ -2269,15 +2273,19 @@ def _cancel_sweep(ctx: PumpContext) -> int:
 # --------------------------------------------------------------------------- #
 
 
-def _heartbeat_and_renew(ctx: PumpContext) -> None:
-	"""Write ``loop_heartbeat_ts`` (loop-liveness, DISTINCT from lease renewal) and
-	renew the lease, at most once per HEARTBEAT_INTERVAL_S. A 0-rows renew/
-	heartbeat means the epoch was lost to a takeover ⇒ shared lease-loss exit."""
+def _heartbeat_and_renew(ctx: PumpContext, progressed: bool) -> None:
+	"""Renew the lease (liveness) and — ONLY when the slice made progress — advance
+	the ``loop_heartbeat_ts`` PROGRESS stamp, at most once per HEARTBEAT_INTERVAL_S.
+	GAP 3 A2: the progress stamp is now DECOUPLED from lease renewal, so a
+	lease-alive-but-not-draining pump goes progress-stale (the watchdog then
+	force-takes it over) while a healthy-but-quiet pump keeps renewing and is never
+	falsely expired. A 0-rows renew/heartbeat means the epoch was lost to a takeover
+	⇒ shared lease-loss exit."""
 	now = _monotonic()
 	if now - ctx.last_heartbeat < HEARTBEAT_INTERVAL_S:
 		return
 	ctx.last_heartbeat = now
-	if not ts.lease_heartbeat(ctx.relay_target_id, ctx.epoch):
+	if progressed and not ts.lease_heartbeat(ctx.relay_target_id, ctx.epoch):
 		ts.lease_lost_exit()
 	if not ts.lease_renew(ctx.relay_target_id, ctx.epoch, holder=ctx.holder):
 		ts.lease_lost_exit()

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -3201,7 +3201,7 @@ def _watchdog_shard(target: str, deps: PumpDeps, summary: dict) -> None:
 			# the log below is throttled 1/h/shard only to bound Error Log volume.
 			_telemetry("pump_wedged", target=target, epoch=wedged_epoch, threshold_s=PROGRESS_STALE_S)
 			_log_wedged_throttled(target, wedged_epoch)
-			if _force_takeover_enabled() and ts.force_expire_wedged(target, wedged_epoch):
+			if _force_takeover_enabled() and ts.force_expire_wedged(target, wedged_epoch, PROGRESS_STALE_S):
 				_clear_lease_mirror(target)
 				summary["forced_expired"] += 1
 				_telemetry("pump_force_expired", target=target, epoch=wedged_epoch)

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -1566,7 +1566,11 @@ def drain_slice(ctx: PumpContext) -> str:
 	_poll_snapshot(ctx)  # CDX-11: fold a resolved refresh (or fail-close a timed-out one) pre-promote
 	promoted = _promote_queued(ctx)
 	dispatched = _dispatch_ready(ctx)  # OARF-5: issues chat.send acks, parks them (never blocks)
+	pending_before = len(ctx.pending_acks) + len(ctx.pending_recoveries)
 	_poll_pending(ctx)  # OARF-5: resolve done acks/recovery tails; ack-timeout deadlines
+	# A turn advanced (ack -> streaming/errored, recovery tail settled) when the in-flight
+	# RPC set shrank — that is drain progress even in a slice with no mux frame applied.
+	polled_progress = (len(ctx.pending_acks) + len(ctx.pending_recoveries)) < pending_before
 
 	applied = ctx.mux.dispatch(block_s=SLICE_BLOCK_S) if ctx.mux is not None else 0
 	if ctx.lease_lost:
@@ -1583,7 +1587,9 @@ def drain_slice(ctx: PumpContext) -> str:
 	# or applied a mux frame) OR the pump is correctly capacity-blocked (fail-closed:
 	# gateway visibility UNKNOWN, where a takeover cannot help — not a wedge). Only a
 	# genuine "should be draining but isn't" leaves the progress stamp un-advanced.
-	progressed = promoted > 0 or dispatched > 0 or applied > 0 or not ctx.gateway_active_known
+	progressed = (
+		promoted > 0 or dispatched > 0 or applied > 0 or polled_progress or not ctx.gateway_active_known
+	)
 	_heartbeat_and_renew(ctx, progressed)
 
 	if _idle_exit(ctx):
@@ -3191,10 +3197,14 @@ def _watchdog_shard(target: str, deps: PumpDeps, summary: dict) -> None:
 		wedged_epoch = _pump_wedged(target, now)
 		if wedged_epoch is not None:
 			summary["wedged_detected"] += 1
+			# _telemetry is per-event (unthrottled) so A4a can measure the true trip rate;
+			# the log below is throttled 1/h/shard only to bound Error Log volume.
+			_telemetry("pump_wedged", target=target, epoch=wedged_epoch, threshold_s=PROGRESS_STALE_S)
 			_log_wedged_throttled(target, wedged_epoch)
 			if _force_takeover_enabled() and ts.force_expire_wedged(target, wedged_epoch):
 				_clear_lease_mirror(target)
 				summary["forced_expired"] += 1
+				_telemetry("pump_force_expired", target=target, epoch=wedged_epoch)
 		res = ensure_pump(target, deps=deps)
 		if res.get("enqueued"):
 			summary["revived"] += 1

--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -96,6 +96,11 @@ SOFT_HOP_BUDGET_S = 90
 HARD_HOP_DEADLINE_S = 120
 HOP_TIMEOUT_S = 180
 
+# GAP 3: a pump that keeps its lease alive but makes no PROGRESS (loop_heartbeat_ts;
+# turn_state._progress_stale) for this long is WEDGED — the watchdog force-takes it
+# over. 2x the soft hop budget: a healthy pump advances progress well within one hop.
+PROGRESS_STALE_S = 2 * SOFT_HOP_BUDGET_S
+
 # Loop heartbeat + lease renew cadence (distinct signals, Amendment E). Both are
 # written at most this often (a slice is ~sub-second, so we gate them).
 HEARTBEAT_INTERVAL_S = 10
@@ -2969,7 +2974,16 @@ def watchdog(deps: PumpDeps | None = None) -> dict:
 	the pump configured (watchdog still drains in-flight rows to terminal) and only
 	then ``-> disabled``."""
 	deps = deps or _default_deps()
-	summary = {"aged_out": 0, "reclaimed": 0, "parked": 0, "finalize_requeued": 0, "errored": 0, "revived": 0}
+	summary = {
+		"aged_out": 0,
+		"reclaimed": 0,
+		"parked": 0,
+		"finalize_requeued": 0,
+		"errored": 0,
+		"revived": 0,
+		"wedged_detected": 0,
+		"forced_expired": 0,
+	}
 	# CDX-21 (Residual A): the config key is site-wide, so reconcile the operator mirror FROM the
 	# authoritative default control row EVERY cycle, OUTSIDE the open-work target loop — an IDLE
 	# site whose mirror diverged (a failed command mirror write) otherwise stays divergent
@@ -3007,6 +3021,49 @@ def watchdog(deps: PumpDeps | None = None) -> dict:
 			frappe.db.rollback()
 			frappe.log_error(title="pump.watchdog", message=frappe.get_traceback())
 	return summary
+
+
+_WEDGED_LOG_TTL_S = 3600
+
+
+def _force_takeover_enabled() -> bool:
+	"""GAP 3 A5 rollback rung: force-takeover of a wedged pump is OFF by default
+	(detect + log only, A4a) until the false-positive rate is measured in prod; set
+	site_config ``jarvis_pump_force_takeover`` truthy to enable (A4b)."""
+	return bool(frappe.conf.get("jarvis_pump_force_takeover"))
+
+
+def _pump_wedged(target: str, now: str) -> int | None:
+	"""GAP 3 A4: is this shard's pump WEDGED — lease LIVE but no PROGRESS for
+	``PROGRESS_STALE_S``? Returns the wedged pump's epoch (for ``force_expire_wedged``)
+	or None. A live lease is precisely what makes ``ensure_pump`` refuse to revive (it
+	looks alive), so a wedge is invisible without this check; ``_progress_stale`` treats
+	a NULL / recent stamp as fresh, so a just-acquired (A1 stamps on acquire) or healthy
+	pump is never flagged."""
+	row = frappe.db.get_value(
+		PUMP, target, ["pump_epoch", "lease_expires_at", "loop_heartbeat_ts"], as_dict=True
+	)
+	if not row or not row.get("lease_expires_at"):
+		return None
+	if frappe.utils.get_datetime(row["lease_expires_at"]) <= frappe.utils.get_datetime(now):
+		return None  # an expired lease is the normal revive path, not a wedge
+	if not ts._progress_stale(row.get("loop_heartbeat_ts"), PROGRESS_STALE_S, now):
+		return None
+	return int(row["pump_epoch"] or 0)
+
+
+def _log_wedged_throttled(target: str, epoch: int) -> None:
+	"""Log a wedged-but-live-lease detection at most once per hour per shard (so a
+	persistently-wedged shard cannot flood the Error Log every watchdog tick)."""
+	key = f"jarvis_pump_wedged_logged::{target}"
+	if frappe.cache().get_value(key):
+		return
+	frappe.cache().set_value(key, "1", expires_in_sec=_WEDGED_LOG_TTL_S)
+	frappe.log_error(
+		title="pump.wedged: lease-live but no progress",
+		message=f"target={target} epoch={epoch} stale>{PROGRESS_STALE_S}s "
+		f"force_takeover={'on' if _force_takeover_enabled() else 'off'}",
+	)
 
 
 def _watchdog_shard(target: str, deps: PumpDeps, summary: dict) -> None:
@@ -3126,6 +3183,18 @@ def _watchdog_shard(target: str, deps: PumpDeps, summary: dict) -> None:
 		summary["finalize_requeued"] += 1
 
 	if live_work:
+		# GAP 3 A4: a wedged-but-lease-live pump (progress stale) is NOT revived by
+		# ensure_pump below — its lease looks live. Detect it; with the takeover flag
+		# ON (A4b) force-expire so ensure_pump can hand off to a fresh hop; otherwise
+		# just log for measurement (A4a). Fires at most once per shard per watchdog
+		# tick — the 5-min cadence is the natural rate limit (no separate cooldown).
+		wedged_epoch = _pump_wedged(target, now)
+		if wedged_epoch is not None:
+			summary["wedged_detected"] += 1
+			_log_wedged_throttled(target, wedged_epoch)
+			if _force_takeover_enabled() and ts.force_expire_wedged(target, wedged_epoch):
+				_clear_lease_mirror(target)
+				summary["forced_expired"] += 1
 		res = ensure_pump(target, deps=deps)
 		if res.get("enqueued"):
 			summary["revived"] += 1

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -1259,10 +1259,13 @@ def lease_acquire(target: str, holder: str, hop_counter: int | None = None) -> t
 	params = {"t": target, "h": holder, "exp": exp, "now": now}
 	if hop_counter is not None:
 		params["hop"] = hop_counter
+	# GAP 3: stamp loop_heartbeat_ts=now on the winning acquire so a freshly revived
+	# hop starts with a FRESH progress stamp and is never force-expired as "wedged"
+	# before its first drain slice (the takeover kill-loop guard; see _progress_stale).
 	won = (
 		_run_cas(
 			f"""UPDATE `tab{PUMP}`
-			SET pump_epoch=pump_epoch+1, lease_holder=%(h)s, lease_expires_at=%(exp)s{hop_set}
+			SET pump_epoch=pump_epoch+1, lease_holder=%(h)s, lease_expires_at=%(exp)s, loop_heartbeat_ts=%(now)s{hop_set}
 			WHERE relay_target_id=%(t)s
 			  AND (lease_expires_at IS NULL OR lease_expires_at < %(now)s)""",
 			params,
@@ -1365,6 +1368,19 @@ def lease_heartbeat(target: str, epoch: int) -> bool:
 	)
 	frappe.db.commit()
 	return won
+
+
+def _progress_stale(loop_heartbeat_ts, threshold_s: int, now=None) -> bool:
+	"""True iff a live-lease pump has made no PROGRESS for > ``threshold_s`` (GAP 3).
+	A NULL / empty stamp is FRESH (never stale): a control row that never heartbeated,
+	or a lease just acquired before its first progress write, must never be
+	force-expired — that is the takeover kill-loop guard. ``now`` is injectable for
+	tests (defaults to the current time)."""
+	if not loop_heartbeat_ts:
+		return False
+	now_dt = frappe.utils.get_datetime(now or _now())
+	age = (now_dt - frappe.utils.get_datetime(loop_heartbeat_ts)).total_seconds()
+	return age > threshold_s
 
 
 def lease_release_if_idle(target: str, epoch: int) -> bool:

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -1331,6 +1331,48 @@ def lease_handoff(target: str, epoch: int, next_hop: int, successor_holder: str)
 	return won
 
 
+def force_expire_wedged(target: str, epoch: int) -> bool:
+	"""Force-expire a WEDGED but lease-LIVE pump (GAP 3 A4). A pump that keeps renewing
+	its lease but has made no PROGRESS (``loop_heartbeat_ts`` stale, see
+	``_progress_stale``) is not draining and will not self-recover. Under CAS on the
+	wedged pump's ``pump_epoch=E`` this atomically:
+	  * BUMPS the epoch (``pump_epoch+1``) — so the wedged pump's next lease_renew /
+	    heartbeat / turn-write (all cached at E) affects 0 rows and it exits via
+	    ``lease_lost_exit``. This is the fence: a bare lease-expiry would just be
+	    re-extended within HEARTBEAT_INTERVAL_S by the wedged pump's own renew.
+	  * sets ``lease_expires_at`` 1s in the PAST — vacant, so the watchdog's
+	    ``ensure_pump`` successor immediately wins its own acquire.
+	  * RE-STAMPS in-flight turns to the new epoch (the wedged pump's cached-E turn
+	    writes then affect 0 rows), mirroring ``lease_acquire``.
+	The CALLER (the watchdog) clears the Redis lease mirror + ``ensure_pump`` on a won
+	result. Returns won/lost; idempotent under the epoch CAS (a second call at the same
+	E affects 0 rows). Commits (a standalone lifecycle op)."""
+	frappe.db.commit()
+	past = frappe.utils.add_to_date(None, seconds=-1)
+	won = (
+		_run_cas(
+			f"""UPDATE `tab{PUMP}`
+			SET pump_epoch=pump_epoch+1, lease_expires_at=%(past)s
+			WHERE relay_target_id=%(t)s AND pump_epoch=%(e)s""",
+			{"past": past, "t": target, "e": epoch},
+		)
+		== 1
+	)
+	if not won:
+		frappe.db.rollback()
+		return False
+	new_epoch = int(frappe.db.get_value(PUMP, target, "pump_epoch") or 0)
+	inflight = "','".join(EPOCH_INFLIGHT_STATES)
+	_run_cas(
+		f"""UPDATE `tab{TURN}`
+		SET pump_epoch=%(e)s, version=version+1
+		WHERE relay_target_id=%(t)s AND state IN ('{inflight}')""",
+		{"e": new_epoch, "t": target},
+	)
+	frappe.db.commit()
+	return True
+
+
 def lease_renew(target: str, epoch: int, holder: str | None = None) -> bool:
 	"""Extend the lease TTL while THIS pump still holds the epoch (D2 §3). CAS on
 	``pump_epoch=E`` — a pump that lost the epoch to a takeover renews 0 rows and

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -1337,11 +1337,18 @@ def lease_handoff(target: str, epoch: int, next_hop: int, successor_holder: str)
 	return won
 
 
-def force_expire_wedged(target: str, epoch: int) -> bool:
+def force_expire_wedged(target: str, epoch: int, stale_after_s: int) -> bool:
 	"""Force-expire a WEDGED but lease-LIVE pump (GAP 3 A4). A pump that keeps renewing
 	its lease but has made no PROGRESS (``loop_heartbeat_ts`` stale, see
-	``_progress_stale``) is not draining and will not self-recover. Under CAS on the
-	wedged pump's ``pump_epoch=E`` this atomically:
+	``_progress_stale``) is not draining and will not self-recover. The CAS re-asserts
+	the FULL wedge predicate — epoch AND live lease AND ``loop_heartbeat_ts`` older
+	than ``stale_after_s`` — inside the UPDATE itself, because the watchdog's
+	detection READ races this takeover: the pump can resume progress (heartbeat) after
+	that read while still at epoch E, and an epoch-only CAS would force-expire the
+	now-healthy pump. A pump that progressed since the read, a lease that has expired
+	meanwhile (the normal ``ensure_pump`` revive path owns that), and a NULL stamp
+	(SQL ``NULL < x`` never matches — mirrors ``_progress_stale``'s NULL-is-fresh
+	kill-loop guard) all affect 0 rows. Under that CAS this atomically:
 	  * BUMPS the epoch (``pump_epoch+1``) — so the wedged pump's next lease_renew /
 	    heartbeat / turn-write (all cached at E) affects 0 rows and it exits via
 	    ``lease_lost_exit``. This is the fence: a bare lease-expiry would just be
@@ -1360,12 +1367,14 @@ def force_expire_wedged(target: str, epoch: int) -> bool:
 	frappe.db.commit()
 	now = _now()
 	past = frappe.utils.add_to_date(None, seconds=-1)
+	cutoff = frappe.utils.add_to_date(now, seconds=-int(stale_after_s))
 	won = (
 		_run_cas(
 			f"""UPDATE `tab{PUMP}`
 			SET pump_epoch=pump_epoch+1, lease_expires_at=%(past)s, loop_heartbeat_ts=%(now)s
-			WHERE relay_target_id=%(t)s AND pump_epoch=%(e)s""",
-			{"past": past, "now": now, "t": target, "e": epoch},
+			WHERE relay_target_id=%(t)s AND pump_epoch=%(e)s
+			  AND lease_expires_at > %(now)s AND loop_heartbeat_ts < %(cutoff)s""",
+			{"past": past, "now": now, "cutoff": cutoff, "t": target, "e": epoch},
 		)
 		== 1
 	)

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -1259,13 +1259,19 @@ def lease_acquire(target: str, holder: str, hop_counter: int | None = None) -> t
 	params = {"t": target, "h": holder, "exp": exp, "now": now}
 	if hop_counter is not None:
 		params["hop"] = hop_counter
-	# GAP 3: stamp loop_heartbeat_ts=now on the winning acquire so a freshly revived
-	# hop starts with a FRESH progress stamp and is never force-expired as "wedged"
-	# before its first drain slice (the takeover kill-loop guard; see _progress_stale).
+	# GAP 3: SEED loop_heartbeat_ts on a cold-start acquire (it is NULL) but CARRY IT
+	# FORWARD on a clean-hop re-acquire (COALESCE keeps the existing value). Because
+	# run_pump_hop calls lease_acquire on EVERY hop (~every 90s), overwriting it here
+	# would refresh the progress stamp every hop and the wedge detector (progress stale
+	# for PROGRESS_STALE_S while the lease is live) could NEVER fire. Carrying it forward
+	# lets a non-draining lineage age past the threshold, while a healthy lineage keeps
+	# it fresh via lease_heartbeat (progress). A cold-start seed avoids a NULL-forever
+	# stamp on a pump wedged from birth. force_expire_wedged resets it for the successor.
 	won = (
 		_run_cas(
 			f"""UPDATE `tab{PUMP}`
-			SET pump_epoch=pump_epoch+1, lease_holder=%(h)s, lease_expires_at=%(exp)s, loop_heartbeat_ts=%(now)s{hop_set}
+			SET pump_epoch=pump_epoch+1, lease_holder=%(h)s, lease_expires_at=%(exp)s,
+			    loop_heartbeat_ts=COALESCE(loop_heartbeat_ts, %(now)s){hop_set}
 			WHERE relay_target_id=%(t)s
 			  AND (lease_expires_at IS NULL OR lease_expires_at < %(now)s)""",
 			params,
@@ -1344,17 +1350,22 @@ def force_expire_wedged(target: str, epoch: int) -> bool:
 	    ``ensure_pump`` successor immediately wins its own acquire.
 	  * RE-STAMPS in-flight turns to the new epoch (the wedged pump's cached-E turn
 	    writes then affect 0 rows), mirroring ``lease_acquire``.
+	Also RESETS ``loop_heartbeat_ts`` to now: the successor (which carries the stamp
+	forward on acquire) then gets a fresh ``PROGRESS_STALE_S`` window to prove itself,
+	so a persistently-wedged shard is retried at the watchdog cadence rather than
+	re-detected immediately every tick.
 	The CALLER (the watchdog) clears the Redis lease mirror + ``ensure_pump`` on a won
 	result. Returns won/lost; idempotent under the epoch CAS (a second call at the same
 	E affects 0 rows). Commits (a standalone lifecycle op)."""
 	frappe.db.commit()
+	now = _now()
 	past = frappe.utils.add_to_date(None, seconds=-1)
 	won = (
 		_run_cas(
 			f"""UPDATE `tab{PUMP}`
-			SET pump_epoch=pump_epoch+1, lease_expires_at=%(past)s
+			SET pump_epoch=pump_epoch+1, lease_expires_at=%(past)s, loop_heartbeat_ts=%(now)s
 			WHERE relay_target_id=%(t)s AND pump_epoch=%(e)s""",
-			{"past": past, "t": target, "e": epoch},
+			{"past": past, "now": now, "t": target, "e": epoch},
 		)
 		== 1
 	)

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -468,6 +468,112 @@ class TestTakeoverFencing(_PumpTestCase):
 			"progress slice must advance the progress stamp",
 		)
 
+	def _fresh_summary(self):
+		return {
+			"aged_out": 0,
+			"reclaimed": 0,
+			"parked": 0,
+			"finalize_requeued": 0,
+			"errored": 0,
+			"revived": 0,
+			"wedged_detected": 0,
+			"forced_expired": 0,
+		}
+
+	def _wedge_shard(self, *, epoch=2, lease_s=20, hb_s):
+		"""Shard = lease-live (`lease_s` future) at `epoch`, progress stamp `hb_s`s old,
+		plus one live-work streaming turn (so the watchdog sees live_work)."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv)
+		amsg = self._mk_msg(conv, role="assistant", content="", streaming=1)
+		self._mk_turn(
+			conv,
+			f"pmp_w_{frappe.generate_hash(length=6)}",
+			seed,
+			"streaming",
+			version=3,
+			pump_epoch=epoch,
+			reserved=1,
+			dispatching_at=frappe.utils.now(),
+			assistant_message=amsg,
+		)
+		frappe.db.set_value(PUMP, self._target, "pump_epoch", epoch, update_modified=False)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"lease_expires_at",
+			frappe.utils.add_to_date(None, seconds=lease_s),
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"loop_heartbeat_ts",
+			frappe.utils.add_to_date(None, seconds=-hb_s),
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+	def test_a4a_wedge_detected_but_not_taken_over_when_flag_off(self):
+		"""A4a (GAP 3): a lease-live pump with a STALE progress stamp is DETECTED as
+		wedged, but with the takeover flag OFF it is only logged — not force-expired."""
+		self._wedge_shard(epoch=2, hb_s=pump.PROGRESS_STALE_S + 60)
+		summary = self._fresh_summary()
+		with (
+			patch.object(pump, "_force_takeover_enabled", return_value=False),
+			patch.object(pump, "_log_wedged_throttled"),
+		):
+			pump._watchdog_shard(self._target, self._deps(), summary)
+		self.assertEqual(summary["wedged_detected"], 1, "wedge detected")
+		self.assertEqual(summary["forced_expired"], 0, "flag off -> no takeover")
+		self.assertEqual(
+			int(frappe.db.get_value(PUMP, self._target, "pump_epoch")),
+			2,
+			"epoch unchanged (not force-expired)",
+		)
+
+	def test_a4b_wedge_force_taken_over_when_flag_on(self):
+		"""A4b (GAP 3): with the flag ON, a wedged pump is force-expired (epoch bumped,
+		mirror cleared) and ensure_pump revives a fresh hop on the vacated lease."""
+		self._wedge_shard(epoch=2, hb_s=pump.PROGRESS_STALE_S + 60)
+		summary = self._fresh_summary()
+		with (
+			patch.object(pump, "_force_takeover_enabled", return_value=True),
+			patch.object(pump, "_log_wedged_throttled"),
+			patch.object(pump, "_clear_lease_mirror") as clear_mirror,
+		):
+			pump._watchdog_shard(self._target, self._deps(), summary)
+		self.assertEqual(summary["wedged_detected"], 1)
+		self.assertEqual(summary["forced_expired"], 1, "flag on -> force-expired")
+		self.assertEqual(
+			int(frappe.db.get_value(PUMP, self._target, "pump_epoch")),
+			3,
+			"epoch bumped by force_expire_wedged",
+		)
+		clear_mirror.assert_called_with(self._target)
+		self.assertGreaterEqual(summary["revived"], 1, "ensure_pump revived on the vacated lease")
+
+	def test_a4_healthy_pump_not_flagged_wedged(self):
+		"""A4 (GAP 3): a lease-live pump with a FRESH progress stamp is never flagged
+		wedged — the false-positive / kill-loop guard."""
+		self._wedge_shard(epoch=2, hb_s=0)  # fresh progress stamp
+		summary = self._fresh_summary()
+		with (
+			patch.object(pump, "_force_takeover_enabled", return_value=True),
+			patch.object(pump, "_log_wedged_throttled"),
+		):
+			pump._watchdog_shard(self._target, self._deps(), summary)
+		self.assertEqual(summary["wedged_detected"], 0, "fresh-progress pump is healthy")
+		self.assertEqual(summary["forced_expired"], 0)
+
+	def test_a5_force_takeover_flag_reads_conf(self):
+		"""A5 (GAP 3): the rollback rung reads site_config jarvis_pump_force_takeover —
+		falsy / absent = OFF (detect-log only), truthy = ON."""
+		with patch.dict(frappe.conf, {"jarvis_pump_force_takeover": 0}):
+			self.assertFalse(pump._force_takeover_enabled(), "falsy -> off")
+		with patch.dict(frappe.conf, {"jarvis_pump_force_takeover": 1}):
+			self.assertTrue(pump._force_takeover_enabled(), "truthy -> on")
+
 	def test_old_epoch_write_affects_zero_rows(self):
 		conv = self._mk_conv()
 		seed = self._mk_msg(conv)

--- a/jarvis/tests/test_pump.py
+++ b/jarvis/tests/test_pump.py
@@ -438,6 +438,36 @@ class TestHopHandoff(_PumpTestCase):
 
 
 class TestTakeoverFencing(_PumpTestCase):
+	def test_a2_progress_stamp_advances_only_on_progress(self):
+		"""A2 (GAP 3): loop_heartbeat_ts (the PROGRESS stamp) advances ONLY when the
+		slice made progress; the lease is renewed either way (liveness independent of
+		progress), so a lease-alive-but-not-draining pump goes progress-stale while a
+		healthy-but-quiet pump keeps its lease."""
+		ctx = self._make_ctx(self._deps(), with_mux=False)
+		old = frappe.utils.add_to_date(None, seconds=-300)
+		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", old, update_modified=False)
+		frappe.db.commit()
+
+		# No progress: lease renewed, progress stamp NOT advanced.
+		ctx.last_heartbeat = 0.0
+		pump._heartbeat_and_renew(ctx, progressed=False)
+		frappe.db.commit()
+		self.assertEqual(
+			str(frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts")),
+			str(old),
+			"no-progress slice must NOT advance the progress stamp",
+		)
+
+		# Progress: the stamp advances.
+		ctx.last_heartbeat = 0.0
+		pump._heartbeat_and_renew(ctx, progressed=True)
+		frappe.db.commit()
+		self.assertNotEqual(
+			str(frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts")),
+			str(old),
+			"progress slice must advance the progress stamp",
+		)
+
 	def test_old_epoch_write_affects_zero_rows(self):
 		conv = self._mk_conv()
 		seed = self._mk_msg(conv)

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -561,6 +561,56 @@ class TestFencingTimelines(_TurnStateTestCase):
 		recent = frappe.utils.add_to_date(None, seconds=-10)
 		self.assertFalse(ts._progress_stale(recent, 60), "10s-old stamp is fresh under a 60s threshold")
 
+	def test_a3_force_expire_wedged_fences_and_vacates(self):
+		"""A3 (GAP 3): force_expire_wedged bumps the epoch (fencing the wedged pump's
+		cached-E renews / heartbeats / turn-writes) and vacates the lease (1s past) so
+		a successor can acquire; in-flight turns are re-stamped; it is idempotent under
+		the epoch CAS."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		amsg = self._mk_msg(conv, 2, role="assistant", content="", streaming=1)
+		E = 6
+		self._mk_turn(
+			conv,
+			"ts_fe",
+			seed,
+			"streaming",
+			version=20,
+			pump_epoch=E,
+			reserved=1,
+			dispatching_at=frappe.utils.now(),
+			assistant_message=amsg,
+		)
+		# A LIVE lease at epoch E — the wedged pump still holds it.
+		frappe.db.set_value(PUMP, self._target, "pump_epoch", E, update_modified=False)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"lease_expires_at",
+			frappe.utils.add_to_date(None, seconds=25),
+			update_modified=False,
+		)
+		frappe.db.commit()
+
+		self.assertTrue(ts.force_expire_wedged(self._target, E))
+		row = frappe.db.get_value(PUMP, self._target, ["pump_epoch", "lease_expires_at"], as_dict=True)
+		self.assertEqual(row["pump_epoch"], E + 1, "epoch bumped to fence the wedged pump")
+		self.assertLess(
+			frappe.utils.get_datetime(row["lease_expires_at"]),
+			frappe.utils.get_datetime(frappe.utils.now()),
+			"lease vacated (1s in the past)",
+		)
+		turn = frappe.db.get_value(TURN, "ts_fe", ["pump_epoch", "version"], as_dict=True)
+		self.assertEqual(turn["pump_epoch"], E + 1, "in-flight turn re-stamped to the new epoch")
+		self.assertEqual(turn["version"], 21, "re-stamp bumped the turn version")
+
+		# The wedged pump's cached-E renew now affects 0 rows -> it will lease_lost_exit.
+		self.assertFalse(ts.lease_renew(self._target, E), "stale-epoch renew is fenced")
+		frappe.db.rollback()
+		# Idempotent: a second force-expire at the same (now-gone) epoch is a no-op.
+		self.assertFalse(ts.force_expire_wedged(self._target, E))
+		frappe.db.rollback()
+
 	def test_d4c_delayed_old_writer_stale_after_takeover(self):
 		"""D4 (c): P_old streaming at epoch E stalls; P_new takes over
 		(lease_acquire bumps epoch to E+1 and RE-STAMPS the turn); P_old's cached-E

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -621,7 +621,7 @@ class TestFencingTimelines(_TurnStateTestCase):
 		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", stale_stamp, update_modified=False)
 		frappe.db.commit()
 
-		self.assertTrue(ts.force_expire_wedged(self._target, E))
+		self.assertTrue(ts.force_expire_wedged(self._target, E, 180))
 		row = frappe.db.get_value(
 			PUMP, self._target, ["pump_epoch", "lease_expires_at", "loop_heartbeat_ts"], as_dict=True
 		)
@@ -644,7 +644,85 @@ class TestFencingTimelines(_TurnStateTestCase):
 		self.assertFalse(ts.lease_renew(self._target, E), "stale-epoch renew is fenced")
 		frappe.db.rollback()
 		# Idempotent: a second force-expire at the same (now-gone) epoch is a no-op.
-		self.assertFalse(ts.force_expire_wedged(self._target, E))
+		self.assertFalse(ts.force_expire_wedged(self._target, E, 180))
+		frappe.db.rollback()
+
+	def _wedged_row(self, E, *, lease_s=25, hb_age_s=300):
+		"""Control row in the WEDGED shape at epoch E: lease `lease_s`s in the future,
+		progress stamp `hb_age_s`s old, plus one in-flight streaming turn."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		amsg = self._mk_msg(conv, 2, role="assistant", content="", streaming=1)
+		run_id = f"ts_few_{frappe.generate_hash(length=6)}"
+		self._mk_turn(
+			conv,
+			run_id,
+			seed,
+			"streaming",
+			version=20,
+			pump_epoch=E,
+			reserved=1,
+			dispatching_at=frappe.utils.now(),
+			assistant_message=amsg,
+		)
+		frappe.db.set_value(PUMP, self._target, "pump_epoch", E, update_modified=False)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"lease_expires_at",
+			frappe.utils.add_to_date(None, seconds=lease_s),
+			update_modified=False,
+		)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"loop_heartbeat_ts",
+			frappe.utils.add_to_date(None, seconds=-hb_age_s),
+			update_modified=False,
+		)
+		frappe.db.commit()
+		return run_id
+
+	def test_a4_force_expire_reasserts_progress_under_cas(self):
+		"""GAP 3 review fix: the takeover CAS re-asserts the FULL wedge predicate, not
+		just the epoch. A pump that resumed progress AFTER the watchdog's stale read —
+		still at the same epoch E — must NOT be force-expired: the recovery heartbeat
+		between detection and takeover makes the CAS affect 0 rows."""
+		E = 6
+		run_id = self._wedged_row(E)  # detection would flag this shape as wedged
+		# Between the watchdog's read and its takeover, the pump recovers and writes
+		# a fresh progress stamp through its normal path.
+		self.assertTrue(ts.lease_heartbeat(self._target, E))
+		lease_before = frappe.db.get_value(PUMP, self._target, "lease_expires_at")
+
+		self.assertFalse(
+			ts.force_expire_wedged(self._target, E, 180),
+			"a pump that progressed since the stale read is NOT taken over",
+		)
+		row = frappe.db.get_value(PUMP, self._target, ["pump_epoch", "lease_expires_at"], as_dict=True)
+		self.assertEqual(row["pump_epoch"], E, "epoch NOT bumped — the healthy pump keeps writing")
+		self.assertEqual(str(row["lease_expires_at"]), str(lease_before), "lease NOT vacated")
+		turn = frappe.db.get_value(TURN, run_id, ["pump_epoch", "version"], as_dict=True)
+		self.assertEqual(turn["pump_epoch"], E, "in-flight turn NOT re-stamped")
+		self.assertEqual(turn["version"], 20, "turn version untouched")
+		frappe.db.rollback()
+
+	def test_a4_force_expire_requires_live_lease(self):
+		"""The wedge takeover fires ONLY on the wedge shape (live lease + stale
+		progress). A lease that has EXPIRED by CAS time is the ordinary dead-pump
+		revive path (``ensure_pump`` acquires it normally) — force-expire declines
+		rather than bumping the epoch under a successor's feet."""
+		E = 7
+		self._wedged_row(E, lease_s=-5)  # stale progress, but the lease already lapsed
+		self.assertFalse(
+			ts.force_expire_wedged(self._target, E, 180),
+			"an expired lease is not the wedge shape — the normal revive path owns it",
+		)
+		self.assertEqual(
+			int(frappe.db.get_value(PUMP, self._target, "pump_epoch")),
+			E,
+			"epoch unchanged",
+		)
 		frappe.db.rollback()
 
 	def test_d4c_delayed_old_writer_stale_after_takeover(self):

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -537,10 +537,10 @@ class TestFencingTimelines(_TurnStateTestCase):
 		frappe.db.commit()
 		self.assertEqual(self._state("ts_d4a"), "finalizing")
 
-	def test_a1_acquire_stamps_progress_heartbeat(self):
-		"""A1 (GAP 3): lease_acquire stamps ``loop_heartbeat_ts`` on the winning
-		acquire, so a freshly-revived hop is never seen as progress-stale — the
-		force-takeover kill-loop guard. A fresh control row has no stamp yet."""
+	def test_a1_acquire_seeds_progress_stamp_on_cold_start(self):
+		"""A1 (GAP 3): a COLD-START acquire (loop_heartbeat_ts is NULL) SEEDS the stamp
+		to now, so a pump wedged from birth still ages toward detection instead of
+		sitting at NULL (which _progress_stale treats as fresh forever)."""
 		ts._ensure_control_row(self._target)
 		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", None, update_modified=False)
 		frappe.db.commit()
@@ -549,7 +549,34 @@ class TestFencingTimelines(_TurnStateTestCase):
 		self.assertTrue(won)
 		self.assertIsNotNone(
 			frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts"),
-			"acquire must stamp the progress heartbeat",
+			"cold-start acquire must seed the progress stamp",
+		)
+
+	def test_a1_acquire_carries_progress_stamp_forward(self):
+		"""A1 (GAP 3 — the CRITICAL guard): a clean-hop re-acquire CARRIES the progress
+		stamp FORWARD (COALESCE), it does NOT refresh it. run_pump_hop calls lease_acquire
+		on EVERY hop (~90s), so refreshing here would keep the stamp younger than the
+		180s threshold forever and the wedge detector could never fire. A non-draining
+		lineage must age past the threshold across hops."""
+		ts._ensure_control_row(self._target)
+		old = frappe.utils.add_to_date(None, seconds=-300)
+		# A prior hop left an OLD progress stamp; expire the lease so the next acquire wins.
+		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", old, update_modified=False)
+		frappe.db.set_value(
+			PUMP,
+			self._target,
+			"lease_expires_at",
+			frappe.utils.add_to_date(None, seconds=-5),
+			update_modified=False,
+		)
+		frappe.db.commit()
+		won, _ = ts.lease_acquire(self._target, "hop-carry")
+		self.assertTrue(won)
+		self.assertEqual(
+			str(frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts")),
+			str(old),
+			"acquire must CARRY the progress stamp forward, not refresh it "
+			"(else the wedge detector never fires)",
 		)
 
 	def test_a1_progress_stale_null_is_fresh(self):
@@ -590,11 +617,20 @@ class TestFencingTimelines(_TurnStateTestCase):
 			frappe.utils.add_to_date(None, seconds=25),
 			update_modified=False,
 		)
+		stale_stamp = frappe.utils.add_to_date(None, seconds=-300)
+		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", stale_stamp, update_modified=False)
 		frappe.db.commit()
 
 		self.assertTrue(ts.force_expire_wedged(self._target, E))
-		row = frappe.db.get_value(PUMP, self._target, ["pump_epoch", "lease_expires_at"], as_dict=True)
+		row = frappe.db.get_value(
+			PUMP, self._target, ["pump_epoch", "lease_expires_at", "loop_heartbeat_ts"], as_dict=True
+		)
 		self.assertEqual(row["pump_epoch"], E + 1, "epoch bumped to fence the wedged pump")
+		self.assertGreater(
+			frappe.utils.get_datetime(row["loop_heartbeat_ts"]),
+			frappe.utils.get_datetime(stale_stamp),
+			"force-expire RESETS the progress stamp so the successor gets a fresh window",
+		)
 		self.assertLess(
 			frappe.utils.get_datetime(row["lease_expires_at"]),
 			frappe.utils.get_datetime(frappe.utils.now()),

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -537,6 +537,30 @@ class TestFencingTimelines(_TurnStateTestCase):
 		frappe.db.commit()
 		self.assertEqual(self._state("ts_d4a"), "finalizing")
 
+	def test_a1_acquire_stamps_progress_heartbeat(self):
+		"""A1 (GAP 3): lease_acquire stamps ``loop_heartbeat_ts`` on the winning
+		acquire, so a freshly-revived hop is never seen as progress-stale — the
+		force-takeover kill-loop guard. A fresh control row has no stamp yet."""
+		ts._ensure_control_row(self._target)
+		frappe.db.set_value(PUMP, self._target, "loop_heartbeat_ts", None, update_modified=False)
+		frappe.db.commit()
+		self.assertIsNone(frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts"))
+		won, _ = ts.lease_acquire(self._target, "hop-a1")
+		self.assertTrue(won)
+		self.assertIsNotNone(
+			frappe.db.get_value(PUMP, self._target, "loop_heartbeat_ts"),
+			"acquire must stamp the progress heartbeat",
+		)
+
+	def test_a1_progress_stale_null_is_fresh(self):
+		"""A1 (GAP 3): a NULL progress stamp is FRESH (never stale) — a lease just
+		acquired before its first progress write must never be force-expired."""
+		self.assertFalse(ts._progress_stale(None, 60), "NULL stamp is fresh")
+		old = frappe.utils.add_to_date(None, seconds=-120)
+		self.assertTrue(ts._progress_stale(old, 60), "120s-old stamp is stale past a 60s threshold")
+		recent = frappe.utils.add_to_date(None, seconds=-10)
+		self.assertFalse(ts._progress_stale(recent, 60), "10s-old stamp is fresh under a 60s threshold")
+
 	def test_d4c_delayed_old_writer_stale_after_takeover(self):
 		"""D4 (c): P_old streaming at epoch E stalls; P_new takes over
 		(lease_acquire bumps epoch to E+1 and RE-STAMPS the turn); P_old's cached-E


### PR DESCRIPTION
## What

**Track A of the pump-recovery hardening (GAP 3): self-heal a wedged pump.** A relay pump can keep renewing its lease while no longer *draining* turns (e.g. a stuck socket/lane, a livelocked reactor). Because the lease looks live, `ensure_pump` refuses to revive it, so its turns queue forever. This adds a watchdog-driven, epoch-fenced **force-takeover** of such a pump.

Shipped **flag-off** (`jarvis_pump_force_takeover` absent/falsy = the A4a *detect-and-log* phase): the watchdog detects + records wedges but does **not** force-expire until the flag is enabled (A4b), after the false-positive rate is measured in prod.

## How (tasks A1–A5)

- **A1** — `lease_acquire` seeds `loop_heartbeat_ts` on a cold start but **carries it forward** on a clean-hop re-acquire (`COALESCE`), so the stamp tracks *progress*, not hop churn.
- **A2** — `loop_heartbeat_ts` is now a **progress stamp**: `drain_slice` advances it only when the slice did real drain work (promoted/dispatched a turn, applied a mux frame, resolved an ack/recovery) or was correctly capacity-blocked. The lease is still renewed every slice (liveness), decoupled from progress.
- **A3** — `force_expire_wedged`: one epoch-bumping CAS that fences the wedged pump (its cached-epoch renews/heartbeats/turn-writes then affect 0 rows → `lease_lost_exit`), vacates the lease, re-stamps in-flight turns, and resets the progress stamp so the successor gets a fresh window.
- **A4** — the watchdog detects a lease-live-but-progress-stale pump (`PROGRESS_STALE_S = 2×SOFT_HOP_BUDGET_S = 180s`); logs (throttled) + emits `pump_wedged`/`pump_force_expired` telemetry; force-expires + revives **only when the flag is on**. Fires at most once per shard per watchdog tick.
- **A5** — the `jarvis_pump_force_takeover` site_config rollback rung (default OFF).

No schema change — reuses the existing `loop_heartbeat_ts` field.

## Review

Ran through the full `/review-loop` (T3). **Cycle 1 caught a CRITICAL** worth calling out: `run_pump_hop` calls `lease_acquire` on *every* hop, so an early design that stamped `loop_heartbeat_ts=now` on acquire refreshed the progress stamp ~every 90s and the 180s wedge trigger **could never fire** — a dead feature whose tests validated an unreachable row. Fixed with the `COALESCE` carry-forward (A1 above) and regression-guarded by `test_a1_acquire_carries_progress_stamp_forward` (mutation-verified: the original overwrite reds it). The fix wave also wired per-event telemetry (the throttled log under-counted the A4a signal) and counted `_poll_pending` resolutions as progress. **Cycle 2: clean** — the wedge is now reachable, no false-kill of a healthy pump in normal operation, and no new defect from the fix.

**Deferred (documented, non-blocking, flag-off contained):** a freshly-*revived* pump inherits a stale stamp → a slightly elevated trip rate on revived shards (the A4a measurement expects this); a genuinely-silent stream >180s is an inherent wedge-detection false-positive to be tuned in A4a; the `force_expire_wedged`/`lease_acquire` re-stamp duplication could share a helper. None mutate state while the flag is OFF.

## Tests

All pump-related modules green on `jarvis-test.localhost`: `test_turn_state` (61), `test_pump` (62), `test_pump_pipeline` (37), `test_turn_recovery` (35), `test_chat_admission` (59), `test_pump_fence_shared_client` (3). Two guards mutation-verified (the carry-forward CRITICAL guard; the wedge-staleness gate).

## Rollout

Merge with the flag OFF (A4a). After the detect-log telemetry shows an acceptable false-positive rate, enable `jarvis_pump_force_takeover` (A4b). Rollback = flip the flag. Tracks B/C (the GAP 1 scheduler dead-man's-switch, control plane) and D (ops) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
