### PR TITLE
fix(llm): make a pinned one-shot's lack of failover unambiguous in the log

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -123,6 +123,83 @@ _GATEWAY_ORIGIN = "http://127.0.0.1:18789"
 # for this turn + pair + WS connect overhead.
 TURN_TIMEOUT_SECONDS = 600
 
+# --- pinned one-shots (issue #531) ------------------------------------------
+#
+# ``fire_agent`` / ``stream_agent_turn`` are the only two RPCs here that carry
+# an explicit model/provider, and passing either one COSTS the run its whole
+# failover chain. Verified against the shipped bundle of
+# ghcr.io/openclaw/openclaw:2026.6.8:
+#
+#   agent-command: hasExplicitRunOverride = Boolean(opts.provider || opts.model)
+#                  resolveEffectiveModelFallbacks({
+#                      hasSessionModelOverride: hasExplicitRunOverride || ...,
+#                      modelOverrideSource: hasExplicitRunOverride ? "user" : ...,
+#                  })
+#   agent-scope:   if (!(modelOverrideSource === "auto" || ...)) return [];
+#
+# So an explicit per-request model hardcodes source "user" and the effective
+# fallback list collapses to []. There is no way to opt back in: AgentParamsSchema
+# is ``additionalProperties: false`` over {message, agentId, provider, model, ...}
+# with no modelOverrideSource / allowFallbacks knob, and sessions.patch rejects
+# the marker outright (closed PR #517).
+#
+# The pin is deliberate and must NOT be "fixed" by dropping it: prewarm exists
+# to warm ONE model's prefix cache (a failover would warm the wrong one), and
+# auto-title deliberately bills against a cheap model rather than the pool
+# primary. What was wrong was that the resulting openclaw log
+# (``decision=surface_error ... next=none``) read exactly like a dead chain.
+#
+# Both halves of the fix live here, at the boundary that actually puts model on
+# the wire, so they cannot drift from the RPC params:
+#
+#  1. a pinned run id is prefixed differently from an unpinned one, which makes
+#     openclaw's own ``embedded run failover decision: runId=... next=none``
+#     line self-describing without cross-referencing anything;
+#  2. the bench logs one line per pinned turn naming the run id and the pinned
+#     model, so the jarvis-side log answers the question on its own too.
+#
+# openclaw uses the idempotency key verbatim as the run id
+# (``const idem = request.idempotencyKey; const runId = idem;``), so the prefix
+# survives to every failover log line. Both must stay clear of openclaw's own
+# ``exec-approval-followup:`` key namespace, and stay well under the 200-char
+# console truncation.
+#
+# The two prefixes have to track the RPC params exactly. A one-shot whose model
+# resolved empty is NOT pinned - it keeps its fallbacks - so a ``next=none``
+# under ONESHOT_RUN_PREFIX really does mean the chain is dead, and claiming
+# otherwise would recreate the very ambiguity this exists to remove.
+PINNED_ONESHOT_RUN_PREFIX = "jarvis-pinned-"
+ONESHOT_RUN_PREFIX = "jarvis-oneshot-"
+
+
+def oneshot_run_id(kind: str, unique: str, *, model: str | None, provider: str | None) -> str:
+	"""Idempotency key (== openclaw run id) for a throwaway one-shot turn.
+
+	``kind`` names the feature (title / polish / prewarm); ``unique`` is
+	whatever already made the caller's key unique, kept so the run id still
+	points back at its session. openclaw dedupes on this key, so ``unique``
+	must stay per-call. Pass the same model/provider the turn will send: they
+	decide which prefix the run id gets."""
+	prefix = PINNED_ONESHOT_RUN_PREFIX if (model or provider) else ONESHOT_RUN_PREFIX
+	return f"{prefix}{kind}:{unique}"
+
+
+def _log_pinned_oneshot(run_id: str, model: str | None, provider: str | None) -> None:
+	"""Record that this turn traded failover away for a pinned model.
+
+	Keyed on the run id so it joins straight onto openclaw's
+	``embedded run failover decision: runId=...`` line. Without this a
+	``next=none`` from a pinned one-shot is indistinguishable from an
+	exhausted chain (issue #531)."""
+	_logger.info(
+		"pinned one-shot turn: runId=%s model=%s provider=%s fallbacks=none-by-design "
+		"reason=explicit-model-on-agent-rpc",
+		run_id,
+		model or "-",
+		provider or "-",
+	)
+
+
 # Scopes the chat path needs: operator.write for sessions.create + agent;
 # operator.admin so the same connection can also read state (status snapshots,
 # etc.) without re-pairing.
@@ -861,7 +938,10 @@ class OpenclawSession:
 		side after we close (the run lane survives client disconnect), so this
 		is enough to warm the provider prompt cache. ``deliver`` is False so
 		the result stays session-only. ``_request`` drops the interleaved
-		event frames and returns the agent ack response."""
+		event frames and returns the agent ack response.
+
+		Setting ``model`` / ``provider`` disables openclaw's failover for this
+		run - see PINNED_ONESHOT_RUN_PREFIX."""
 		params = {
 			"message": message,
 			"sessionKey": session_key,
@@ -872,6 +952,8 @@ class OpenclawSession:
 			params["model"] = model
 		if provider:
 			params["provider"] = provider
+		if model or provider:
+			_log_pinned_oneshot(idempotency_key, model, provider)
 		res = self._request("agent", params, timeout_s=CONNECT_TIMEOUT_SECONDS)
 		return (res.get("payload") or {}).get("runId") or ""
 
@@ -890,8 +972,10 @@ class OpenclawSession:
 		`model` / `provider` are optional per-turn overrides. When set, they
 		flow into openclaw's agent RPC params; the gateway honours them via
 		the operator.admin-scope-gated modelOverride path (our connect already
-		declares that scope). When omitted, openclaw falls back to
-		agents.defaults.model.primary from openclaw.json.
+		declares that scope), and the run loses its failover chain for the
+		duration - see PINNED_ONESHOT_RUN_PREFIX. When omitted, openclaw falls
+		back to agents.defaults.model.primary from openclaw.json AND keeps its
+		fallbacks.
 
 		Yields the same parsed-event shape the worker used to consume from
 		the subprocess. Raises OpenclawUnreachableError on WS drop, agent
@@ -913,6 +997,8 @@ class OpenclawSession:
 			# {type:"image", mimeType, fileName, content:<base64>} shape is what
 			# its gateway normalizer accepts.
 			params["attachments"] = attachments
+		if model or provider:
+			_log_pinned_oneshot(idempotency_key, model, provider)
 		agent_id = self._send("agent", params)
 		deadline = time.monotonic() + TURN_TIMEOUT_SECONDS
 

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -11,7 +11,7 @@ import uuid
 
 import frappe
 
-from jarvis.chat.openclaw_client import OpenclawSession
+from jarvis.chat.openclaw_client import OpenclawSession, oneshot_run_id
 from jarvis.chat.session_lifecycle import reclaim_throwaway_session
 
 # Cooldown between warm-ups for one bench. 2026-07 latency plan, Phase
@@ -128,10 +128,15 @@ def warm_prefix() -> bool:
 		sess = OpenclawSession.connect(gateway_url)
 		try:
 			throwaway = sess.create_session(label=f"jarvis-prewarm-{uuid.uuid4().hex[:8]}")
+			# The pin is the whole point: this warms ONE model's prefix cache,
+			# so a failover would warm the wrong one. openclaw answers an
+			# explicit model by dropping the run's fallback chain (#531), and
+			# the prefixed run id is what tells a later log reader that the
+			# resulting ``next=none`` is by design rather than a dead chain.
 			sess.fire_agent(
 				throwaway,
 				"/think off warmup",
-				uuid.uuid4().hex,
+				oneshot_run_id("prewarm", uuid.uuid4().hex, model=model, provider=provider),
 				model=model or None,
 				provider=provider,
 			)

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -150,6 +150,7 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 	"""Run a silent throwaway agent turn to summarise the opening message into a
 	title. Returns "" on any failure (caller falls back to derive_title)."""
 	from jarvis.chat import openclaw_session_pool
+	from jarvis.chat.openclaw_client import oneshot_run_id
 	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
 
 	prompt = _TITLE_PROMPT.format(msg=source_text[:_SOURCE_MAX_CHARS])
@@ -163,10 +164,14 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
 			try:
+				# Titling deliberately pins a cheap model instead of the pool
+				# primary, which costs this run its failover chain (#531). The
+				# prefixed run id is what keeps openclaw's resulting
+				# ``next=none`` from reading like a dead chain.
 				for ev in sess.stream_agent_turn(
 					skey,
 					prompt,
-					f"title:{skey}",
+					oneshot_run_id("title", skey, model=model, provider=provider),
 					model=model,
 					provider=provider,
 				):

--- a/jarvis/learning/polish.py
+++ b/jarvis/learning/polish.py
@@ -245,6 +245,7 @@ def _run_gateway_turn(prompt: str) -> str:
 	touches a visible conversation. Returns the assistant text, or '' on any
 	failure (unreachable gateway, timeout, agent error, no gateway_url)."""
 	from jarvis.chat import openclaw_session_pool
+	from jarvis.chat.openclaw_client import oneshot_run_id
 	from jarvis.chat.session_lifecycle import reclaim_throwaway_session
 	from jarvis.chat.turn_handler import _resolve_model_and_provider
 
@@ -263,10 +264,13 @@ def _run_gateway_turn(prompt: str) -> str:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
 			try:
+				# Pinning the resolved model costs this run its failover chain
+				# (#531); the prefixed run id keeps the resulting openclaw
+				# ``next=none`` distinguishable from an exhausted chain.
 				for ev in sess.stream_agent_turn(
 					skey,
 					prompt,
-					f"polish:{skey}",
+					oneshot_run_id("polish", skey, model=model, provider=provider),
 					model=model,
 					provider=provider,
 				):

--- a/jarvis/tests/test_pinned_oneshot_runs.py
+++ b/jarvis/tests/test_pinned_oneshot_runs.py
@@ -1,0 +1,226 @@
+"""A pinned one-shot must be recognisable as pinned from the log alone.
+
+Issue #531. The three throwaway one-shots (auto-title, pattern polish, prefix
+prewarm) each pass an explicit model/provider on openclaw's ``agent`` RPC, and
+openclaw answers that by dropping the run's model-fallback chain entirely:
+``hasExplicitRunOverride`` forces ``modelOverrideSource: "user"``, and
+``resolveEffectiveModelFallbacks`` returns ``[]`` for any source but ``"auto"``.
+There is no per-request way to opt back in - ``AgentParamsSchema`` is
+``additionalProperties: false`` and carries no such field, and ``sessions.patch``
+rejects the marker outright (closed PR #517).
+
+The pin stays (prewarm must warm ONE model's cache; titles must stay cheap), so
+the fix is to make the inability to fail over unambiguous. Two things carry it,
+both asserted here: a pinned run id is prefixed differently from an unpinned
+one, which makes openclaw's own ``embedded run failover decision: runId=...
+next=none`` line self-describing, and the bench logs one line per pinned turn
+naming the run id and the pinned model.
+
+SCOPE NOTE: the transport is stubbed here, as everywhere else in this suite, so
+these tests assert INTENT - what the bench puts on the wire and what it records
+about it. They cannot observe openclaw's failover resolver or the log lines it
+emits; that behaviour was read off the shipped 2026.6.8 bundle, not from a test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.openclaw_client import (
+	ONESHOT_RUN_PREFIX,
+	PINNED_ONESHOT_RUN_PREFIX,
+	OpenclawSession,
+	oneshot_run_id,
+)
+
+LOG = "jarvis.chat.openclaw_client"
+SKEY = "agent:main:dashboard:throwaway-1"
+
+
+def _bare_session() -> OpenclawSession:
+	"""An OpenclawSession with no WS behind it - callers stub the transport."""
+	return OpenclawSession.__new__(OpenclawSession)
+
+
+def _streaming_session() -> OpenclawSession:
+	"""A session whose ``agent`` request acks and then ends the run at once."""
+	sess = _bare_session()
+	frames = iter(
+		[
+			{"type": "res", "id": "req1", "ok": True, "payload": {"runId": "run1"}},
+			{
+				"type": "event",
+				"payload": {"runId": "run1", "stream": "lifecycle", "data": {"phase": "end"}},
+			},
+		]
+	)
+	sess._send = lambda method, params: "req1"
+	sess._recv = lambda timeout_s: next(frames, None)
+	return sess
+
+
+@contextlib.contextmanager
+def _checkout_yielding(sess):
+	@contextlib.contextmanager
+	def _cm(_gateway_url):
+		yield sess
+
+	with patch("jarvis.chat.openclaw_session_pool.checkout", _cm):
+		yield
+
+
+def _pool_session(reply: str) -> MagicMock:
+	sess = MagicMock()
+	sess.create_session.return_value = SKEY
+	sess.is_run_active.return_value = False
+	sess.stream_agent_turn.return_value = iter([{"kind": "assistant", "text": reply}])
+	return sess
+
+
+class TestPinnedRunId(FrappeTestCase):
+	"""openclaw uses the idempotency key verbatim as the run id, so the run id
+	is the one field guaranteed to reach every failover log line."""
+
+	def test_run_id_announces_the_pin_and_keeps_the_caller_key(self):
+		run_id = oneshot_run_id("title", SKEY, model="gpt-5.5-mini", provider=None)
+
+		self.assertTrue(run_id.startswith(PINNED_ONESHOT_RUN_PREFIX))
+		self.assertIn("title", run_id)
+		self.assertIn(SKEY, run_id, "the run id must still point back at its session")
+
+	def test_an_unpinned_one_shot_is_not_labelled_pinned(self):
+		"""A one-shot whose model resolved empty keeps its fallbacks, so its
+		``next=none`` really would mean the chain is dead."""
+		run_id = oneshot_run_id("prewarm", "abc", model="", provider=None)
+
+		self.assertTrue(run_id.startswith(ONESHOT_RUN_PREFIX))
+		self.assertFalse(run_id.startswith(PINNED_ONESHOT_RUN_PREFIX))
+
+	def test_a_bare_provider_still_counts_as_pinned(self):
+		"""openclaw drops the chain on either field, not just model."""
+		run_id = oneshot_run_id("polish", "abc", model=None, provider="openai")
+
+		self.assertTrue(run_id.startswith(PINNED_ONESHOT_RUN_PREFIX))
+
+	def test_run_id_stays_clear_of_openclaws_own_key_namespace(self):
+		"""openclaw parses ``exec-approval-followup:`` keys as an approval id."""
+		for prefix in (PINNED_ONESHOT_RUN_PREFIX, ONESHOT_RUN_PREFIX):
+			self.assertFalse(prefix.startswith("exec-approval-followup:"))
+
+	def test_run_id_fits_the_console_truncation(self):
+		"""openclaw truncates console fields at 200 chars; a clipped run id
+		would not join back onto anything."""
+		self.assertLess(len(oneshot_run_id("polish", SKEY, model="gpt-5.5", provider=None)), 200)
+
+
+class TestPinnedTurnIsLogged(FrappeTestCase):
+	"""The bench-side half: a line that says the chain was given up on purpose."""
+
+	def test_fire_agent_records_the_pin(self):
+		sess = _bare_session()
+		sess._request = lambda method, params, *, timeout_s: {"payload": {"runId": "run1"}}
+
+		with self.assertLogs(LOG, level="INFO") as logs:
+			sess.fire_agent(SKEY, "warmup", "idem-1", model="gpt-5.5", provider="openai")
+
+		line = "\n".join(logs.output)
+		self.assertIn("idem-1", line, "the log must name the run id openclaw will report")
+		self.assertIn("gpt-5.5", line)
+		self.assertIn("fallbacks=none-by-design", line)
+
+	def test_unpinned_fire_agent_stays_quiet(self):
+		"""No pin, no lost chain, nothing to disambiguate."""
+		sess = _bare_session()
+		sess._request = lambda method, params, *, timeout_s: {"payload": {"runId": "run1"}}
+
+		with self.assertNoLogs(LOG, level="INFO"):
+			sess.fire_agent(SKEY, "warmup", "idem-1")
+
+	def test_stream_agent_turn_records_the_pin(self):
+		sess = _streaming_session()
+
+		with self.assertLogs(LOG, level="INFO") as logs:
+			list(sess.stream_agent_turn(SKEY, "hello", "idem-2", model="gpt-5.5"))
+
+		line = "\n".join(logs.output)
+		self.assertIn("idem-2", line)
+		self.assertIn("fallbacks=none-by-design", line)
+
+	def test_unpinned_stream_agent_turn_stays_quiet(self):
+		sess = _streaming_session()
+
+		with self.assertNoLogs(LOG, level="INFO"):
+			list(sess.stream_agent_turn(SKEY, "hello", "idem-2"))
+
+
+class TestOneShotsMintPinnedRunIds(FrappeTestCase):
+	"""Each of the three one-shots has to opt in, or its own log stays unreadable."""
+
+	def test_auto_title(self):
+		from jarvis.chat import title
+
+		sess = _pool_session("A Nice Title")
+		with _checkout_yielding(sess):
+			title._generate_via_gateway(
+				"ws://gw.example",
+				"Show me last month's overdue invoices",
+				model="gpt-5.5-mini",
+				provider=None,
+			)
+
+		self.assertTrue(sess.stream_agent_turn.call_args.args[2].startswith(PINNED_ONESHOT_RUN_PREFIX))
+
+	def test_pattern_polish(self):
+		from jarvis.learning import polish
+
+		sess = _pool_session("- a polished bullet")
+		settings = MagicMock()
+		settings.agent_url = "http://gw.example"
+		with (
+			_checkout_yielding(sess),
+			patch("jarvis.learning.polish.frappe.get_single", return_value=settings),
+			patch(
+				"jarvis.chat.turn_handler._resolve_model_and_provider",
+				return_value=("gpt-5.5", None),
+			),
+		):
+			polish._run_gateway_turn("- rewrite this bullet")
+
+		self.assertTrue(sess.stream_agent_turn.call_args.args[2].startswith(PINNED_ONESHOT_RUN_PREFIX))
+
+	def _warm(self, llm_model: str) -> str:
+		"""Run one prewarm against a stubbed gateway; return the run id it minted."""
+		from jarvis.chat import prewarm
+
+		settings = MagicMock()
+		settings.agent_url = "https://gw.example"
+		settings.llm_model = llm_model
+		settings.llm_auth_mode = "api_key"
+		settings.llm_provider = "OpenAI"
+
+		for key in (prewarm._warm_cooldown_key(), prewarm._warm_last_key()):
+			frappe.cache().delete_value(key)
+			self.addCleanup(frappe.cache().delete_value, key)
+
+		sess = MagicMock()
+		sess.create_session.return_value = "sk_throwaway"
+		with (
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch("jarvis.chat.prewarm.frappe.get_single", return_value=settings),
+		):
+			OC.connect.return_value = sess
+			self.assertTrue(prewarm.warm_prefix())
+
+		return sess.fire_agent.call_args.args[2]
+
+	def test_prefix_prewarm(self):
+		self.assertTrue(self._warm("gpt-5.5").startswith(PINNED_ONESHOT_RUN_PREFIX))
+
+	def test_prewarm_without_a_configured_model_is_not_labelled_pinned(self):
+		"""The label has to follow the RPC params, not the call site's intent:
+		an empty llm_model sends no model, so the run keeps its fallbacks."""
+		self.assertTrue(self._warm("").startswith(ONESHOT_RUN_PREFIX))


### PR DESCRIPTION
Closes #531.

## What openclaw actually does (read off the shipped bundle, not guessed)

Extracted `/app/dist` from `ghcr.io/openclaw/openclaw:2026.6.8` read-only (`docker create` + `docker cp`, no container started).

**Option 1 is definitively closed.** The `agent` RPC has no per-request way to pin a model and keep fallbacks:

`AgentParamsSchema` (`schema-BwaBORnA.js`) is `additionalProperties: false` over `{message, agentId, provider, model, to, replyTo, sessionId, sessionKey, thinking, deliver, attachments, ..., idempotencyKey, label}`. There is no `modelOverrideSource`, no `allowFallbacks`, no `modelSource`.

And the handler hardcodes the source that kills the chain (`agent-command-Ctv5EwPF.js`):

```js
const hasExplicitRunOverride = Boolean(explicitProviderOverride || explicitModelOverride);
...
const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
    cfg, agentId: sessionAgentId, sessionKey,
    hasSessionModelOverride: hasExplicitRunOverride || Boolean(storedProviderOverride || storedModelOverride),
    modelOverrideSource: hasExplicitRunOverride ? "user" : storedModelOverrideSource,
    hasAutoFallbackProvenance: hasExplicitRunOverride ? false : hasStoredAutoFallbackProvenance,
});
```

against (`agent-scope-B4NxGkqZ.js`):

```js
function resolveEffectiveModelFallbacks(params) {
    const agentFallbacksOverride = resolveAgentModelFallbacksOverride(params.cfg, params.agentId);
    if (!params.hasSessionModelOverride) return agentFallbacksOverride;
    if (!(params.modelOverrideSource === "auto" || ...)) return [];
    ...
}
```

So a per-request `model` or `provider` forces `"user"` and the effective fallback list collapses to `[]`. `sessions.patch` was already closed by PR #517; the `agent` RPC is closed the same way.

Two other findings worth recording:

- The ambiguous lines are both openclaw's, emitted inside the container, so we cannot reformat them from here. `decision=surface_error ... reason=...` comes from `createFailoverDecisionLogger` (`embedded-agent-BgvyyCVT.js`) and includes `runId=` in its console text; `next=none` comes from `logModelFallbackDecision` (`model-fallback-CB6h6-6n.js`) and carries `runId` in its structured record. The structured record does already carry `fallbackConfigured`, which distinguishes the two cases, but it is absent from the console text everyone was reading.
- `chat.send`, which the real chat path uses, takes no model/provider at all. Only `fire_agent` and `stream_agent_turn` pin, and their only callers are these three one-shots. The main chat path is unaffected.

## Why not option 2

Dropping the pin is a real regression. Prewarm exists to warm ONE model's prefix cache, so a failover would warm the wrong one and spend tokens for nothing. Auto-title deliberately bills against a cheap model rather than the pool primary.

There is exactly one architecturally viable "make it fail over" route: give each one-shot its own openclaw `agents.list[]` entry with `model.primary` + `model.fallbacks` and call the RPC with `agentId` and no `model`, since `hasExplicitRunOverride` would then be false. That needs a fleet-agent template change plus a tenant re-render, and it still cannot express prewarm's model, which is chosen at runtime from Jarvis Settings. Not worth it for a throwaway turn.

## Option 3, which is what this does

openclaw uses the idempotency key verbatim as the run id (`const idem = request.idempotencyKey; const runId = idem;`), and the run id reaches every failover log line. So:

1. a pinned turn mints `jarvis-pinned-<kind>:<unique>`, an unpinned one `jarvis-oneshot-<kind>:<unique>`. `embedded run failover decision: runId=jarvis-pinned-title:... next=none` now answers the question by itself, with nothing to cross-reference;
2. the bench logs one line per pinned turn naming the run id, the pinned model and `fallbacks=none-by-design`, so the jarvis-side log is self-sufficient too.

Both live in `openclaw_client` at the boundary that actually puts `model` on the wire, so the label cannot drift from the RPC params, and any future caller of these two methods is covered automatically. That also means the label follows reality rather than intent: a one-shot whose model resolved empty is not pinned, keeps its fallbacks, and is labelled `jarvis-oneshot-`. Labelling it pinned would recreate the exact ambiguity this removes.

Prefixes are clear of openclaw's own `exec-approval-followup:` key namespace and well under its 200-char console truncation.

## Changes

- `jarvis/chat/openclaw_client.py`: `PINNED_ONESHOT_RUN_PREFIX` / `ONESHOT_RUN_PREFIX` and `oneshot_run_id()`; `_log_pinned_oneshot()` called from `fire_agent` and `stream_agent_turn` whenever model or provider goes on the wire; the bundle evidence recorded as a comment so nobody re-derives it, and the docstrings corrected (they claimed the override was free).
- `jarvis/chat/title.py`, `jarvis/learning/polish.py`, `jarvis/chat/prewarm.py`: mint the run id through the helper instead of `f"title:{skey}"` / `f"polish:{skey}"` / a bare `uuid4().hex`.
- `jarvis/tests/test_pinned_oneshot_runs.py`: new.

`prewarm.py` is touched only on the `fire_agent` argument list, its import and a comment. The session-deletion path is untouched (#535 is being worked in parallel).

## Tests

`jarvis/tests/test_pinned_oneshot_runs.py`, 11 cases: run-id labelling in both directions, the namespace and truncation constraints, the log line firing for `fire_agent` and `stream_agent_turn` and staying silent when nothing is pinned, and all three one-shots minting a labelled run id (plus prewarm's unpinned path).

These stub the transport, as the rest of this suite does, so they assert INTENT: what the bench puts on the wire and what it records about it. They cannot observe openclaw's fallback resolver or the log lines it emits. That behaviour came from reading the 2026.6.8 bundle, and is cited inline in both the test and the source so a later reader can re-check it against a new image.

## Upstream

Option 4 in the issue still stands independently: the `modelOverrideSource` handler/schema mismatch is an openclaw bug (the handler honours a marker the schema forbids), and `logModelFallbackDecision` already computes `fallbackConfigured` but leaves it out of the console line where it would have prevented this entirely. Worth reporting upstream, not blocking on it.
