### PR TITLE
fix(chat): stop reclaiming a throwaway session before its run starts

### DIFF
--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -7,6 +7,7 @@ for every subsequent new chat in the same container. We never touch the
 user's real session or write chat rows. Always best-effort; never raises.
 """
 
+import time
 import uuid
 
 import frappe
@@ -33,10 +34,11 @@ _WARM_COOLDOWN_S = 4 * 60
 _WARM_INPROGRESS_S = 90
 
 
-# The previous warm's session key, remembered so the NEXT warm can reclaim it
-# (see _reclaim_previous). TTL is far longer than the cooldown: losing this
-# pointer leaks one session, so err on the side of remembering. The orphan sweep
-# (session_lifecycle) is the backstop for whatever this misses.
+# The previous warm's session key AND the moment its turn was fired, remembered
+# so the NEXT warm can reclaim it (see _reclaim_previous). TTL is far longer than
+# the cooldown: losing this pointer leaks one session, so err on the side of
+# remembering. The orphan sweep (session_lifecycle) is the backstop for whatever
+# this misses.
 _WARM_LAST_TTL_S = 24 * 60 * 60
 
 
@@ -46,6 +48,24 @@ def _warm_cooldown_key() -> str:
 
 def _warm_last_key() -> str:
 	return f"jarvis:chat:prefix_warm:last:{frappe.local.site}"
+
+
+def _previous_pointer(prev) -> tuple[str, float | None]:
+	"""Unpack the remembered ``{"key", "fired_at"}`` pointer -> (key, fired_at).
+
+	Tolerates the pre-#535 shape, a bare session-key string with no fire time:
+	one of those can still be sitting in the cache under the 24h TTL when this
+	deploys. It reclaims exactly as it did before, which is correct for it - the
+	cooldown makes such a pointer minutes old in every case but the
+	concurrent-warm race, and that race cannot span a deploy."""
+	if isinstance(prev, dict):
+		key = prev.get("key")
+		fired_at = prev.get("fired_at")
+		return (
+			key if isinstance(key, str) else "",
+			fired_at if isinstance(fired_at, (int, float)) else None,
+		)
+	return (prev if isinstance(prev, str) else ""), None
 
 
 def _reclaim_previous(sess, prev, current: str) -> None:
@@ -68,11 +88,19 @@ def _reclaim_previous(sess, prev, current: str) -> None:
 	turns that into a skipped reclaim - the orphan sweep collects it - instead of
 	a killed run and a fresh orphan.
 
+	The remembered fire time is what makes that probe trustworthy (issue #535).
+	openclaw accepts a run a median 670ms before it starts one, and reports
+	"accepted, not started" and "finished" identically, so probing a predecessor
+	fired milliseconds ago answers "idle" for a run that is about to begin -
+	the very race above, unfixed. Handing reclaim_throwaway_session the fire time
+	makes it decline that delete instead.
+
 	Best-effort: on failure (or a lost cache pointer) the session is left for the
 	orphan sweep, which reaps jarvis-prewarm-* on a short grace."""
-	if not prev or not isinstance(prev, str) or prev == current:
+	key, fired_at = _previous_pointer(prev)
+	if not key or key == current:
 		return
-	reclaim_throwaway_session(sess, prev, logger_name="jarvis.chat.prewarm")
+	reclaim_throwaway_session(sess, key, logger_name="jarvis.chat.prewarm", fired_at=fired_at)
 
 
 def _gateway_ws_url(settings) -> str:
@@ -122,8 +150,6 @@ def warm_prefix() -> bool:
 		# disable warming for 25 min.
 		cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
 		model, provider = _resolve_default_model_and_provider(settings)
-		import time
-
 		t0 = time.monotonic()
 		sess = OpenclawSession.connect(gateway_url)
 		try:
@@ -146,7 +172,16 @@ def warm_prefix() -> bool:
 			# just created, which would leak one every warm, forever.
 			last_key = _warm_last_key()
 			prev = cache.get_value(last_key)
-			cache.set_value(last_key, throwaway, expires_in_sec=_WARM_LAST_TTL_S)
+			# Remember WHEN as well as WHICH: the next warm needs the fire time to
+			# tell "this predecessor's run finished" from "this predecessor's run
+			# has not started yet", which sessions.list reports identically (issue
+			# #535). Stamped here rather than at the fire a few ms above; that only
+			# makes the guard marginally longer, never shorter.
+			cache.set_value(
+				last_key,
+				{"key": throwaway, "fired_at": time.time()},
+				expires_in_sec=_WARM_LAST_TTL_S,
+			)
 			_reclaim_previous(sess, prev, throwaway)
 		finally:
 			sess.close()

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -539,7 +539,14 @@ def reclaim_throwaway_session(
 	log = frappe.logger(logger_name)
 	# Before this instant an idle answer only means "the run has not started
 	# yet". 0.0 (no fire time given) => the caller saw the run end, trust at once.
-	trust_idle_after = fired_at + RUN_START_GRACE_S if fired_at else 0.0
+	#
+	# The isinstance check is not decoration: the arithmetic below sits OUTSIDE
+	# the per-probe try, so a caller that ever handed over a non-numeric fire
+	# time (a str from a cache round-trip, say) would raise straight through the
+	# "never raises" contract every caller here relies on.
+	trust_idle_after = (
+		fired_at + RUN_START_GRACE_S if isinstance(fired_at, (int, float)) and fired_at else 0.0
+	)
 	seen_active = False
 	for attempt in range(RECLAIM_PROBE_ATTEMPTS):
 		try:

--- a/jarvis/chat/session_lifecycle.py
+++ b/jarvis/chat/session_lifecycle.py
@@ -466,13 +466,56 @@ def _delete_gateway_session(sess, session_key: str, summary: dict) -> bool:
 RECLAIM_PROBE_ATTEMPTS = 6
 RECLAIM_PROBE_DELAY_S = 0.5
 
+# ...but a probe alone cannot close the window, because openclaw ACCEPTS a run
+# well before it STARTS one, and sessions.list reports "accepted, not started"
+# exactly like "finished": hasActiveRun is false in both.
+#
+# Measured on jarvis-pool-bf4097, 269 sessions, as the gap between the session
+# file's creation stamp (the sessions.create the bench issues immediately before
+# it fires) and the run's own session.started trajectory event:
+#
+#     p50 0.67s   p90 2.90s   p95 4.84s   (86 over 1s, 25 over 3s)
+#
+# So for a median 670ms after a fire-and-forget the gateway will happily tell a
+# reclaim "no run here", and the reclaim deletes the session out from under a
+# run that is about to start. That is a check-then-act race, and no amount of
+# probing fixes it: the probe is reading a signal that has not been written yet.
+#
+# What closes it is a caller that knows it never saw the run END. For those, a
+# "no active run" answer is only believed once RUN_START_GRACE_S has passed
+# since the fire, OR once a probe has actually caught the run active (positive
+# evidence beats the clock - see `seen_active`). Callers that DID watch the run
+# reach its terminal frame pass no fire time and keep the immediate reclaim.
+#
+# Sized just past the p95 above. We do not WAIT this out - waiting would tax
+# polish's synchronous request for nothing - we simply decline to guess and let
+# the orphan sweep collect it, which is the same trade the rest of this function
+# already makes.
+RUN_START_GRACE_S = 5.0
 
-def reclaim_throwaway_session(sess, session_key: str, *, logger_name: str) -> bool:
+
+def reclaim_throwaway_session(
+	sess,
+	session_key: str,
+	*,
+	logger_name: str,
+	fired_at: float | None = None,
+) -> bool:
 	"""Delete a throwaway session once the gateway stops reporting a run on it.
 
 	Probes immediately, then re-checks after ``RECLAIM_PROBE_DELAY_S`` up to
 	``RECLAIM_PROBE_ATTEMPTS`` times. Returns True when the session was deleted,
-	False when it was left behind - still busy, or the gateway would not answer.
+	False when it was left behind - still busy, not started yet, or the gateway
+	would not answer.
+
+	``fired_at`` is the wall-clock ``time.time()`` at which the run was fired,
+	and MUST be passed by any caller that did not watch that run reach its
+	terminal frame: prewarm (fire-and-forget by construction) and title/polish
+	on the path where ``stream_agent_turn`` raised. It marks the answer
+	"no active run" as untrustworthy until ``RUN_START_GRACE_S`` has elapsed,
+	which is what keeps a not-yet-started run from being deleted. Callers that
+	consumed the stream to its end pass nothing and reclaim immediately, as
+	before - there is no unstarted run to protect.
 
 	Leaving it behind is safe and deliberate: every throwaway label carries a
 	``THROWAWAY_GRACE_HOURS`` grace and its own ``ORPHAN_BATCH_MAX`` budget in
@@ -485,16 +528,26 @@ def reclaim_throwaway_session(sess, session_key: str, *, logger_name: str) -> bo
 	writing to would still be deleted underneath. Every case actually observed
 	on jarvis-pool-bf4097 had the run's lane demonstrably still working when the
 	delete landed (it re-created the session file afterwards), so the probe
-	covers them; the sweep covers whatever it does not.
+	covers them; the sweep covers whatever it does not. On the start side, a run
+	that takes longer than ``RUN_START_GRACE_S`` to appear is still exposed - 5%
+	of the measured sample - and the sweep is the backstop there too.
 
 	Never raises: every caller is a best-effort path whose real work is already
 	done by the time it reclaims."""
 	if not session_key or not isinstance(session_key, str):
 		return False
 	log = frappe.logger(logger_name)
+	# Before this instant an idle answer only means "the run has not started
+	# yet". 0.0 (no fire time given) => the caller saw the run end, trust at once.
+	trust_idle_after = fired_at + RUN_START_GRACE_S if fired_at else 0.0
+	seen_active = False
 	for attempt in range(RECLAIM_PROBE_ATTEMPTS):
 		try:
-			if not sess.is_run_active(session_key):
+			if sess.is_run_active(session_key):
+				# Positive evidence the run exists. Every later idle answer is now
+				# a real finished-signal, so the grace above stops applying.
+				seen_active = True
+			elif seen_active or time.time() >= trust_idle_after:
 				sess.delete_session(session_key)
 				return True
 		except Exception:
@@ -504,5 +557,5 @@ def reclaim_throwaway_session(sess, session_key: str, *, logger_name: str) -> bo
 			return False
 		if attempt < RECLAIM_PROBE_ATTEMPTS - 1:
 			time.sleep(RECLAIM_PROBE_DELAY_S)
-	log.debug("throwaway session still running, left for the sweep key=%s", session_key)
+	log.debug("throwaway session not confirmed finished, left for the sweep key=%s", session_key)
 	return False

--- a/jarvis/chat/title.py
+++ b/jarvis/chat/title.py
@@ -22,6 +22,7 @@ chat turn that triggered it.
 from __future__ import annotations
 
 import re
+import time
 
 import frappe
 
@@ -162,6 +163,8 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 	try:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
+			fired_at = time.time()
+			run_ended = False
 			try:
 				for ev in sess.stream_agent_turn(
 					skey,
@@ -172,6 +175,7 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 				):
 					if ev.get("kind") == "assistant" and ev.get("text"):
 						text = ev["text"]
+				run_ended = True
 			finally:
 				# Reclaim the throwaway on the SAME pooled connection, turn
 				# succeeded or not. Without this every auto-titled chat leaks a
@@ -189,10 +193,23 @@ def _generate_via_gateway(gateway_url, source_text, *, model, provider) -> str:
 				# waits for the gateway to stop reporting an active run, and
 				# leaves anything still busy to the orphan sweep.
 				#
+				# On the RAISE path that probe is not enough on its own (issue
+				# #535): the raise can land inside the ~670ms median openclaw
+				# takes to start an accepted run, and sessions.list cannot tell
+				# "not started" from "finished". So hand over the fire time there
+				# and let the helper refuse the delete. On the normal path we
+				# watched the run reach its terminal frame, so there is no
+				# unstarted run to protect and the reclaim stays immediate.
+				#
 				# Failure is swallowed in there: `text` is already captured, and
 				# losing the title over failed cleanup would be the worse bug -
 				# the sweep still collects jarvis-title-* as a backstop.
-				reclaim_throwaway_session(sess, skey, logger_name="jarvis.chat.title")
+				reclaim_throwaway_session(
+					sess,
+					skey,
+					logger_name="jarvis.chat.title",
+					fired_at=None if run_ended else fired_at,
+				)
 	except Exception:
 		frappe.log_error(
 			title="auto-title: gateway generation failed",

--- a/jarvis/learning/polish.py
+++ b/jarvis/learning/polish.py
@@ -34,6 +34,8 @@ Contract (plan 5.5 Phase-2 paragraph):
 
 from __future__ import annotations
 
+import time
+
 import frappe
 from frappe import _
 from frappe.utils import today
@@ -262,6 +264,8 @@ def _run_gateway_turn(prompt: str) -> str:
 	try:
 		with openclaw_session_pool.checkout(gateway_url) as sess:
 			skey = sess.create_session(label=label)
+			fired_at = time.time()
+			run_ended = False
 			try:
 				for ev in sess.stream_agent_turn(
 					skey,
@@ -272,6 +276,7 @@ def _run_gateway_turn(prompt: str) -> str:
 				):
 					if ev.get("kind") == "assistant" and ev.get("text"):
 						text = ev["text"]
+				run_ended = True
 			finally:
 				# Reclaim the throwaway on the SAME pooled connection, turn
 				# succeeded or not: otherwise every polish turn leaks a session
@@ -286,7 +291,20 @@ def _run_gateway_turn(prompt: str) -> str:
 				# report no active run and otherwise defers to the orphan sweep,
 				# which collects jarvis-polish-* as a backstop. Failure is
 				# swallowed in there - `text` is already captured.
-				reclaim_throwaway_session(sess, skey, logger_name="jarvis.learning.polish")
+				#
+				# The raise path needs more than the probe (issue #535): it can
+				# land inside the ~670ms median openclaw takes to START an
+				# accepted run, and sessions.list reports "not started" and
+				# "finished" identically. Passing the fire time there makes the
+				# helper decline the delete. The normal path watched the run reach
+				# its terminal frame, so it keeps the immediate reclaim - which
+				# matters here, where this runs in a synchronous request.
+				reclaim_throwaway_session(
+					sess,
+					skey,
+					logger_name="jarvis.learning.polish",
+					fired_at=None if run_ended else fired_at,
+				)
 	except Exception:
 		frappe.log_error(
 			title="pattern polish: gateway turn failed",

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -181,7 +181,13 @@ class TestWarmPrefix(FrappeTestCase):
 		alone waves the delete through and it lands on a live run.
 
 		Here the cooldown is cleared WITHOUT backdating the pointer, which is
-		what that race looks like from prewarm's side."""
+		what that race looks like from prewarm's side.
+
+		The grace is widened for the duration so the assertion cannot depend on
+		how long a loaded CI box takes to get from the first warm to the second.
+		The real 5s value is plenty in production and asserted directly in
+		test_throwaway_session_reclaim.py; what this test is for is the wiring,
+		which must not turn into a timing flake."""
 		from jarvis.chat import prewarm
 
 		frappe.cache().delete_value(prewarm._warm_cooldown_key())
@@ -195,6 +201,7 @@ class TestWarmPrefix(FrappeTestCase):
 			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
 			patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()),
 			patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0),
+			patch.object(session_lifecycle, "RUN_START_GRACE_S", 3600),
 		):
 			OC.connect.return_value = fake_sess
 			self.assertTrue(prewarm.warm_prefix())

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -1,4 +1,5 @@
 # app/jarvis/tests/test_prewarm.py
+import time
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -6,6 +7,25 @@ from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import session_lifecycle
 from jarvis.chat.openclaw_client import OpenclawSession
+
+
+def _lapse_cooldown(prewarm):
+	"""Put the bench where the NEXT warm really finds it: cooldown expired, and
+	the remembered predecessor fired a cooldown ago.
+
+	Both halves matter. Clearing the cooldown key alone would leave a pointer
+	stamped microseconds ago, and reclaim_throwaway_session deliberately refuses
+	to delete a session whose run may not have started yet (issue #535) - so such
+	a test would be asserting the guard, not the reclaim. Backdating the stamp is
+	what the four-minute cooldown does in production."""
+	frappe.cache().delete_value(prewarm._warm_cooldown_key())
+	pointer = frappe.cache().get_value(prewarm._warm_last_key())
+	if isinstance(pointer, dict):
+		frappe.cache().set_value(
+			prewarm._warm_last_key(),
+			dict(pointer, fired_at=time.time() - 600),
+			expires_in_sec=3600,
+		)
 
 
 class TestFireAgent(FrappeTestCase):
@@ -91,12 +111,13 @@ class TestWarmPrefix(FrappeTestCase):
 			self.assertTrue(prewarm.warm_prefix())
 			# Nothing to reclaim on the very first warm of a bench.
 			fake_sess.delete_session.assert_not_called()
-			frappe.cache().delete_value(prewarm._warm_cooldown_key())  # lapse the cooldown
+			_lapse_cooldown(prewarm)
 			self.assertTrue(prewarm.warm_prefix())
 
 		# The second warm reclaimed the first's session — and only that one.
 		fake_sess.delete_session.assert_called_once_with("sk_first")
-		self.assertEqual(frappe.cache().get_value(prewarm._warm_last_key()), "sk_second")
+		pointer = frappe.cache().get_value(prewarm._warm_last_key())
+		self.assertEqual(pointer["key"], "sk_second")
 
 	def test_warm_prefix_survives_previous_delete_failure(self):
 		"""A failed reclaim must never fail the warm — the orphan sweep is the
@@ -118,11 +139,95 @@ class TestWarmPrefix(FrappeTestCase):
 		):
 			OC.connect.return_value = fake_sess
 			self.assertTrue(prewarm.warm_prefix())
-			frappe.cache().delete_value(prewarm._warm_cooldown_key())
+			_lapse_cooldown(prewarm)
 			self.assertTrue(prewarm.warm_prefix())
 
 		self.assertEqual(fake_sess.fire_agent.call_count, 2)
-		self.assertEqual(frappe.cache().get_value(prewarm._warm_last_key()), "sk_second")
+		pointer = frappe.cache().get_value(prewarm._warm_last_key())
+		self.assertEqual(pointer["key"], "sk_second")
+
+	def test_warm_prefix_remembers_when_it_fired(self):
+		"""The pointer carries a fire time, not just a key. Without it the next
+		warm cannot tell a predecessor whose run finished from one whose run has
+		not started yet, and #535's guard has nothing to work with."""
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+		frappe.cache().delete_value(prewarm._warm_last_key())
+		fake_sess = MagicMock()
+		fake_sess.create_session.return_value = "sk_only"
+
+		before = time.time()
+		with (
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()),
+		):
+			OC.connect.return_value = fake_sess
+			self.assertTrue(prewarm.warm_prefix())
+
+		pointer = frappe.cache().get_value(prewarm._warm_last_key())
+		self.assertEqual(pointer["key"], "sk_only")
+		self.assertGreaterEqual(pointer["fired_at"], before)
+		self.assertLessEqual(pointer["fired_at"], time.time())
+
+	def test_a_predecessor_fired_moments_ago_is_left_for_the_sweep(self):
+		"""THE #535 REGRESSION, at the level that produces it.
+
+		Two warms can pass the get-then-set cooldown check in the same instant
+		(observed 6ms apart on jarvis-pool-bf4097), which makes "the predecessor"
+		a session whose fire-and-forget turn openclaw has ACCEPTED but not yet
+		STARTED. sessions.list answers hasActiveRun=false for that state exactly
+		as it does for a finished run - measured median 670ms wide - so the probe
+		alone waves the delete through and it lands on a live run.
+
+		Here the cooldown is cleared WITHOUT backdating the pointer, which is
+		what that race looks like from prewarm's side."""
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+		frappe.cache().delete_value(prewarm._warm_last_key())
+		fake_sess = MagicMock()
+		fake_sess.create_session.side_effect = ["sk_first", "sk_second"]
+		# The gateway cannot see the run yet, so it reports the session as idle.
+		fake_sess.is_run_active.return_value = False
+
+		with (
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()),
+			patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0),
+		):
+			OC.connect.return_value = fake_sess
+			self.assertTrue(prewarm.warm_prefix())
+			frappe.cache().delete_value(prewarm._warm_cooldown_key())
+			self.assertTrue(prewarm.warm_prefix())
+
+		fake_sess.delete_session.assert_not_called()
+		self.assertEqual(fake_sess.fire_agent.call_count, 2, "both warms must still fire")
+		# No leak: the pointer moved on and the sweep collects jarvis-prewarm-*
+		# on THROWAWAY_GRACE_HOURS, which is exactly what a skipped reclaim buys.
+		self.assertEqual(frappe.cache().get_value(prewarm._warm_last_key())["key"], "sk_second")
+
+	def test_a_pre_535_pointer_still_reclaims(self):
+		"""A bare-string pointer written before this deploy can still be in the
+		cache under its 24h TTL. It must reclaim as it always did, not crash and
+		not silently stop collecting."""
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+		frappe.cache().set_value(prewarm._warm_last_key(), "sk_legacy", expires_in_sec=3600)
+		fake_sess = MagicMock()
+		fake_sess.create_session.return_value = "sk_new"
+		fake_sess.is_run_active.return_value = False
+
+		with (
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch("jarvis.chat.prewarm.frappe.get_single", return_value=self._settings_stub()),
+			patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0),
+		):
+			OC.connect.return_value = fake_sess
+			self.assertTrue(prewarm.warm_prefix())
+
+		fake_sess.delete_session.assert_called_once_with("sk_legacy")
 
 	def test_warm_prefix_debounced_second_call_is_noop(self):
 		from jarvis.chat import prewarm

--- a/jarvis/tests/test_throwaway_session_reclaim.py
+++ b/jarvis/tests/test_throwaway_session_reclaim.py
@@ -232,17 +232,24 @@ class TestUnstartedRunIsNotDeleted(FrappeTestCase):
 
 	def test_the_guard_declines_rather_than_waiting_the_grace_out(self):
 		"""It refuses to guess, it does not block. polish's reclaim runs inside a
-		synchronous whitelisted request; spending RUN_START_GRACE_S there to
-		reach a delete the orphan sweep does for free would be the worse trade."""
+		synchronous whitelisted request, so spending RUN_START_GRACE_S there to
+		reach a delete the orphan sweep does for free would be the worse trade.
+
+		Asserted on the REAL backoff (no patched-to-zero delay) and on the sum of
+		what the helper asks to sleep, because that is the number a wrong fix
+		would move: sleeping until the deadline instead of declining would push
+		this to RUN_START_GRACE_S or beyond, while wall-clock in a test with a
+		stubbed gateway stays near zero either way."""
 		sess = _stub_pool_session(active_probes=False)
 
-		started = time.time()
-		with patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0):
+		with patch.object(session_lifecycle.time, "sleep") as sleep:
 			session_lifecycle.reclaim_throwaway_session(
 				sess, SKEY, logger_name="jarvis.tests", fired_at=time.time()
 			)
 
-		self.assertLess(time.time() - started, session_lifecycle.RUN_START_GRACE_S)
+		slept = sum(call.args[0] for call in sleep.call_args_list)
+		self.assertLess(slept, session_lifecycle.RUN_START_GRACE_S)
+		sess.delete_session.assert_not_called()
 
 
 class TestAutoTitleReclaim(FrappeTestCase):
@@ -435,7 +442,15 @@ class TestPrewarmReclaim(FrappeTestCase):
 		"""Issue #535: the same instant-apart race, but with the gateway
 		answering hasActiveRun=FALSE because it has not started the predecessor's
 		run yet. The probe waves this one through; the remembered fire time is
-		what stops it."""
+		what stops it.
+
+		The probe-count assertion is load-bearing, for a non-obvious reason. The
+		pre-#535 _reclaim_previous guard was ``not isinstance(prev, str)``, so it
+		rejects this dict pointer outright and returns without reclaiming at all
+		- meaning a bare ``delete_session.assert_not_called()`` would pass against
+		the unfixed code too, for entirely the wrong reason. Requiring that the
+		helper was reached AND spent its whole budget declining is what makes this
+		discriminate."""
 		from jarvis.chat import prewarm
 
 		sess = _stub_pool_session(active_probes=False)
@@ -444,6 +459,11 @@ class TestPrewarmReclaim(FrappeTestCase):
 			prewarm._reclaim_previous(sess, {"key": "sk_previous", "fired_at": time.time()}, "sk_current")
 
 		sess.delete_session.assert_not_called()
+		self.assertEqual(
+			sess.is_run_active.call_count,
+			session_lifecycle.RECLAIM_PROBE_ATTEMPTS,
+			"the reclaim must have been reached, and must have declined all the way through",
+		)
 
 	def test_a_predecessor_from_a_cooldown_ago_is_reclaimed(self):
 		"""The normal case, which must stay immediate: the cooldown has elapsed,

--- a/jarvis/tests/test_throwaway_session_reclaim.py
+++ b/jarvis/tests/test_throwaway_session_reclaim.py
@@ -19,6 +19,14 @@ a backoff only when the gateway says it is live - because polish's reclaim runs
 inside a synchronous whitelisted request and title's holds one of only three
 pooled connections.
 
+Issue #535 then found the half that probe could not reach: openclaw ACCEPTS a
+run a median 670ms before it STARTS one, and ``hasActiveRun`` is false for the
+whole of that window, so a reclaim firing inside it deletes a session whose run
+is about to begin. ``TestUnstartedRunIsNotDeleted`` below pins the second half
+of the rule - a caller that never saw the run END hands over the time it fired,
+and an idle answer is only believed once that has aged past
+``RUN_START_GRACE_S`` or a probe has actually caught the run.
+
 SCOPE NOTE: the transport is stubbed here, as everywhere else in this suite, so
 these tests assert INTENT - which RPCs the bench issues and in what order. They
 cannot observe what openclaw does with a delete that lands mid-run; that was
@@ -29,6 +37,7 @@ from a test.
 from __future__ import annotations
 
 import contextlib
+import time
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -162,6 +171,80 @@ class TestReclaimThrowawaySession(FrappeTestCase):
 		sess.is_run_active.assert_not_called()
 
 
+class TestUnstartedRunIsNotDeleted(FrappeTestCase):
+	"""Issue #535: the window the probe alone cannot close.
+
+	openclaw ACCEPTS a run before it STARTS one, and sessions.list reports
+	"accepted, not started" and "finished" identically - hasActiveRun is false in
+	both. Measured on jarvis-pool-bf4097 over 269 sessions, as the gap between
+	the session file's creation stamp and the run's own session.started
+	trajectory event: p50 0.67s, p90 2.90s, p95 4.84s. A reclaim that fires
+	inside that window therefore reads "idle" and deletes the session out from
+	under a run that is about to begin.
+
+	The fix is not more probing - the signal has not been written yet - but a
+	caller admitting it never saw the run END, by handing over the time it fired.
+	"""
+
+	def test_an_accepted_but_unstarted_run_is_not_deleted(self):
+		sess = _stub_pool_session(active_probes=False)
+
+		with _no_sleep():
+			reclaimed = session_lifecycle.reclaim_throwaway_session(
+				sess, SKEY, logger_name="jarvis.tests", fired_at=time.time()
+			)
+
+		self.assertFalse(reclaimed)
+		sess.delete_session.assert_not_called()
+
+	def test_an_old_run_reported_idle_is_still_reclaimed_at_once(self):
+		"""The guard must not become a leak. Past the grace, an idle answer is
+		what it has always been - a finished run - and costs one probe."""
+		sess = _stub_pool_session(active_probes=False)
+
+		with patch.object(session_lifecycle.time, "sleep") as sleep:
+			reclaimed = session_lifecycle.reclaim_throwaway_session(
+				sess,
+				SKEY,
+				logger_name="jarvis.tests",
+				fired_at=time.time() - (session_lifecycle.RUN_START_GRACE_S + 60),
+			)
+
+		self.assertTrue(reclaimed)
+		sess.delete_session.assert_called_once_with(SKEY)
+		self.assertEqual(sess.is_run_active.call_count, 1)
+		sleep.assert_not_called()
+
+	def test_a_run_caught_active_is_reclaimed_inside_the_grace(self):
+		"""Positive evidence beats the clock. Once a probe has actually SEEN the
+		run, a later idle answer is a real finished-signal, so the grace stops
+		applying and the session goes immediately."""
+		sess = _stub_pool_session(active_probes=[True, False])
+
+		with _no_sleep():
+			reclaimed = session_lifecycle.reclaim_throwaway_session(
+				sess, SKEY, logger_name="jarvis.tests", fired_at=time.time()
+			)
+
+		self.assertTrue(reclaimed)
+		sess.delete_session.assert_called_once_with(SKEY)
+		self.assertEqual(sess.is_run_active.call_count, 2)
+
+	def test_the_guard_declines_rather_than_waiting_the_grace_out(self):
+		"""It refuses to guess, it does not block. polish's reclaim runs inside a
+		synchronous whitelisted request; spending RUN_START_GRACE_S there to
+		reach a delete the orphan sweep does for free would be the worse trade."""
+		sess = _stub_pool_session(active_probes=False)
+
+		started = time.time()
+		with patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0):
+			session_lifecycle.reclaim_throwaway_session(
+				sess, SKEY, logger_name="jarvis.tests", fired_at=time.time()
+			)
+
+		self.assertLess(time.time() - started, session_lifecycle.RUN_START_GRACE_S)
+
+
 class TestAutoTitleReclaim(FrappeTestCase):
 	"""jarvis/chat/title.py::_generate_via_gateway"""
 
@@ -212,6 +295,27 @@ class TestAutoTitleReclaim(FrappeTestCase):
 
 		sess.delete_session.assert_not_called()
 		self.assertEqual(title_text, "", "a failed title turn still falls back to derive_title")
+
+	def test_a_title_run_that_has_not_started_yet_is_not_deleted(self):
+		"""Issue #535. Same raise path as above, but the gateway has not started
+		the run yet, so hasActiveRun is FALSE and the probe cannot tell it from a
+		finished run. Only the fire time can, and the finally must hand it over.
+
+		This is the shape the probe-only fix (#530) still gets wrong: a WS drop
+		or a connect error raises within a few hundred ms of the fire, well
+		inside the measured 670ms median start delay."""
+		from jarvis.exceptions import OpenclawUnreachableError
+
+		sess = _stub_pool_session(
+			active_probes=False,
+			raises=OpenclawUnreachableError("connection closed before the first frame"),
+		)
+
+		with patch("jarvis.chat.title.frappe.log_error"):
+			title_text = self._generate(sess)
+
+		sess.delete_session.assert_not_called()
+		self.assertEqual(title_text, "")
 
 
 class TestPatternPolishReclaim(FrappeTestCase):
@@ -265,6 +369,23 @@ class TestPatternPolishReclaim(FrappeTestCase):
 		sess.delete_session.assert_not_called()
 		self.assertEqual(text, "", "a failed polish turn still falls back to the template text")
 
+	def test_a_polish_run_that_has_not_started_yet_is_not_deleted(self):
+		"""Issue #535, polish's copy of title's raise-path gap: the gateway
+		reports the session idle because the run has not started, not because it
+		finished."""
+		from jarvis.exceptions import OpenclawUnreachableError
+
+		sess = _stub_pool_session(
+			active_probes=False,
+			raises=OpenclawUnreachableError("connection closed before the first frame"),
+		)
+
+		with patch("jarvis.learning.polish.frappe.log_error"):
+			text = self._run(sess)
+
+		sess.delete_session.assert_not_called()
+		self.assertEqual(text, "")
+
 
 class TestPrewarmReclaim(FrappeTestCase):
 	"""jarvis/chat/prewarm.py::_reclaim_previous"""
@@ -306,6 +427,46 @@ class TestPrewarmReclaim(FrappeTestCase):
 
 		with _no_sleep():
 			prewarm._reclaim_previous(sess, "sk_same", "sk_same")
+
+		sess.delete_session.assert_not_called()
+		sess.is_run_active.assert_not_called()
+
+	def test_a_predecessor_whose_run_has_not_started_is_left_alone(self):
+		"""Issue #535: the same instant-apart race, but with the gateway
+		answering hasActiveRun=FALSE because it has not started the predecessor's
+		run yet. The probe waves this one through; the remembered fire time is
+		what stops it."""
+		from jarvis.chat import prewarm
+
+		sess = _stub_pool_session(active_probes=False)
+
+		with _no_sleep():
+			prewarm._reclaim_previous(sess, {"key": "sk_previous", "fired_at": time.time()}, "sk_current")
+
+		sess.delete_session.assert_not_called()
+
+	def test_a_predecessor_from_a_cooldown_ago_is_reclaimed(self):
+		"""The normal case, which must stay immediate: the cooldown has elapsed,
+		so the pointer is minutes old and an idle answer means finished."""
+		from jarvis.chat import prewarm
+
+		sess = _stub_pool_session(active_probes=False)
+
+		with _no_sleep():
+			prewarm._reclaim_previous(
+				sess, {"key": "sk_previous", "fired_at": time.time() - 600}, "sk_current"
+			)
+
+		sess.delete_session.assert_called_once_with("sk_previous")
+
+	def test_a_malformed_pointer_is_a_noop(self):
+		from jarvis.chat import prewarm
+
+		sess = _stub_pool_session(active_probes=False)
+
+		with _no_sleep():
+			prewarm._reclaim_previous(sess, {"fired_at": time.time()}, "sk_current")
+			prewarm._reclaim_previous(sess, None, "sk_current")
 
 		sess.delete_session.assert_not_called()
 		sess.is_run_active.assert_not_called()


### PR DESCRIPTION
Closes #535 (but not in the way the issue expects: its premise is a misread, and the evidence for that is below).

## What the captured log actually shows

The reported triple was read as one session deleting itself mid-run. It is two sessions. Read back from `jarvis-pool-bf4097`'s own session store:

| session | created | runId | deleted |
|---|---|---|---|
| `ad4fcd92-d2ae-...` | 16:12:21.560Z | `e95590f74abd4e9a9b118324c2089ef3` | 16:24:54.315Z |
| `bf2b565d-3658-...` | 16:06:33.555Z | (its own, ended 16:06:35.328Z) | **16:12:21.950Z** |

The `sessions.delete` at `16:12:21.954` landed on `bf2b565d`, the **previous** warm's session, whose run had been dead for 5m47s. The run `e95590f7` lived in `ad4fcd92`, which was reclaimed 12 minutes later by the next warm. That is `_reclaim_previous` working exactly as designed, on both.

What makes the log read as self-deletion is that openclaw's RPC response lines carry no session key, so a `create` + `agent` + `delete` inside 400 ms looks correlated when it is not.

The `isError=true` was a genuine provider 429, from `ad4fcd92`'s transcript:

```
"stopReason": "error",
"errorCode": "RESOURCE_EXHAUSTED",
"Quota exceeded for metric:
 generativelanguage.googleapis.com/generate_content_free_tier_input_token_count,
 limit: 0, model: gemini-2.5-pro"
```

and its `session.ended` is `status=error, terminalError=non_deliverable_terminal_turn` with **no** `EmbeddedAttemptSessionTakeoverError` and **no** re-created session file, which is what a mid-run delete leaves behind (#525). The `next=none` is the pinned model, which is #531.

So #530's helper reached this caller and worked. Nothing on the page-load path deletes a live run today.

## The defect that is real

Proving the above quantified a check-then-act window that a probe fundamentally cannot close. openclaw **accepts** a run well before it **starts** one, and `sessions.list` reports "accepted, not started" and "finished" identically: `hasActiveRun` is false in both.

Measured across 269 sessions on that tenant, as the gap between the session file's creation stamp (the `sessions.create` issued immediately before the fire) and the run's own `session.started` trajectory event:

```
p50 0.67s    p90 2.90s    p95 4.84s     86 over 1s, 25 over 3s
```

For a median 670 ms after a fire, then, the gateway tells a reclaim "no run here" about a run that is about to begin, and the probe waves the delete through. Two callers sit in that window:

- **prewarm**, when two warms pass the get-then-set cooldown in the same instant (observed 6 ms apart on this tenant, and already noted in `_reclaim_previous`'s docstring). The predecessor is then milliseconds old, not minutes.
- **title and polish**, when `stream_agent_turn` raises early. That is precisely when the run is still alive server side, and the `finally` reclaims immediately.

Confirmed against `upstream/develop`'s own code: `reclaim_throwaway_session(sess, key, ...)` with `hasActiveRun=false` deletes on the first probe.

## The fix

A probe cannot read a signal that has not been written yet, so the caller supplies what it knows instead.

`reclaim_throwaway_session` gains `fired_at`, passed by any caller that did **not** watch its run reach a terminal frame. An idle answer is only believed once `fired_at` has aged past `RUN_START_GRACE_S` (5.0 s, just past the measured p95) **or** a probe has actually caught the run active, because positive evidence beats the clock and keeps a run we watched end from waiting out the grace.

It **declines rather than waits**. Blocking 5 s inside polish's synchronous whitelisted request to reach a delete the sweep does for free would be the worse trade, and the rest of this function already makes that same call.

Callers:

- `prewarm` remembers `{"key", "fired_at"}` instead of a bare key, and tolerates a pre-#535 bare string still sitting in the 24 h cache after deploy.
- `title` and `polish` pass the fire time only on the raise path; the normal path saw the run end and keeps today's immediate reclaim.

Steady state is unchanged: a prewarm predecessor is minutes old and a completed title/polish turn reclaims at once, both on one probe with no sleep.

## No session leak

A declined reclaim falls through to `session_lifecycle._reap_orphans`, which is already wired for exactly this:

- all three labels are in `_THROWAWAY_LABEL_PREFIXES`, so they get `THROWAWAY_GRACE_HOURS = 1`, not the 24 h default;
- the keys are `agent:main:dashboard:<uuid>`, matching `_CHAT_NAMESPACE_MARKER`;
- part 3 runs hourly on its own `ORPHAN_BATCH_MAX = 200` budget, which parts 1 and 2 cannot starve.

Declines only occur in the two exceptional windows above, never in steady state, so the orphan population the sweep sees does not grow.

Also verified while tracing this: the only two `sessions.delete` producers in the app are `_delete_gateway_session` (cron) and `reclaim_throwaway_session` (minters), and the only session minted on page load is prewarm's. Every delete path is now guarded.

## Tests

`test_throwaway_session_reclaim.py` gains `TestUnstartedRunIsNotDeleted` plus raise-path-with-idle-probe cases for title, polish and prewarm. Each fails on `develop`, where an unstarted run is deleted on the first probe. `test_prewarm.py` covers the new pointer shape, the legacy bare string, and the concurrent-warm race end to end.

The existing #525 suite is unchanged and still passes: `fired_at=None` keeps the old behaviour byte for byte.

## Scope

Session lifecycle only. `#531` is fixing the one-shot model pin in the same file; this diff does not touch `_resolve_default_model_and_provider` or the `fire_agent` call, only the delete and teardown path around them.

## Follow-ups, not fixed here

- The `next=none` in this capture is #531's pinned model over a real 429. Closing this issue removes no noise from that log line on its own.
- Worth a separate look: prewarm fires on login, on every chat page load and every 5 minutes, and each warm spends one free-tier Gemini request. That is what exhausted the quota that produced the 429.
