### PR TITLE
fix(onboarding): reach reconnect before the plan and the payment wall

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,6 +39,8 @@ export const setAutoApply = (conversation, value) =>
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
 // ---- account reconnect (fresh bench -> existing paid subscription) ---------
+export const reconnectAvailable = (email, company = "") =>
+	call("jarvis.onboarding.reconnect_available", { email, company });
 export const startAccountReconnect = (email, company = "") =>
 	call("jarvis.onboarding.start_account_reconnect", { email, company });
 export const checkAccountReconnect = (requestId, code) =>

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -5,7 +5,11 @@
 
 // Managed flow (2026-07 redesign): intro tour → Plan → Details → Pay → Connect.
 // The old "mode" chooser + "account" step are gone.
-export const STEPS_MANAGED = ["intro", "plan", "details", "pay", "connect"];
+// Details BEFORE plan: the email + company are what identify an account, so asking
+// for them first is what lets a returning customer take the reconnect exit before
+// weighing plans they already pay for. Nothing on the Details step reads the chosen
+// plan, so the two are free to swap.
+export const STEPS_MANAGED = ["intro", "details", "plan", "pay", "connect"];
 
 export function stepIndex(steps, cur) {
 	const i = steps.indexOf(cur);

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -19,6 +19,16 @@ test("managed step order", () => {
 	assert.equal(nextStep(STEPS_MANAGED, "plan"), "pay");
 	assert.equal(prevStep(STEPS_MANAGED, "details"), "intro");
 	assert.equal(nextStep(STEPS_MANAGED, "connect"), "connect"); // clamp at end
+	// Off-funnel steps (e.g. "reconnect", which is deliberately absent so the rail
+	// hides) clamp to index 0, so relative navigation from one silently walks the
+	// customer back to the FIRST step. Anything off-funnel must set state.step
+	// explicitly instead of calling goNext()/goBack().
+	assert.equal(stepIndex(STEPS_MANAGED, "reconnect"), 0);
+	assert.equal(nextStep(STEPS_MANAGED, "reconnect"), "details");
+	// ...which is why finishing a reconnect re-anchors to "pay" first: that is where
+	// the provisioning screen renders, and it is the step that advances to the end of
+	// onboarding rather than back into the funnel.
+	assert.equal(nextStep(STEPS_MANAGED, "pay"), "connect");
 	assert.equal(prevStep(STEPS_MANAGED, "intro"), "intro"); // clamp at start
 });
 

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -15,9 +15,9 @@ import {
 } from "./steps.js";
 
 test("managed step order", () => {
-	assert.deepEqual(STEPS_MANAGED, ["intro", "plan", "details", "pay", "connect"]);
-	assert.equal(nextStep(STEPS_MANAGED, "plan"), "details");
-	assert.equal(prevStep(STEPS_MANAGED, "details"), "plan");
+	assert.deepEqual(STEPS_MANAGED, ["intro", "details", "plan", "pay", "connect"]);
+	assert.equal(nextStep(STEPS_MANAGED, "plan"), "pay");
+	assert.equal(prevStep(STEPS_MANAGED, "details"), "intro");
 	assert.equal(nextStep(STEPS_MANAGED, "connect"), "connect"); // clamp at end
 	assert.equal(prevStep(STEPS_MANAGED, "intro"), "intro"); // clamp at start
 });

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -1391,6 +1391,13 @@ async function submitReconnectCode() {
 		if (d && d.status === "connected") {
 			state.successData = {};
 			state.payBusy = false;
+			// Re-anchor to the funnel BEFORE handing over. proceedAfterPay() advances
+			// relative to state.step and renders its progress inside the pay step, but
+			// `reconnect` deliberately sits outside STEPS_MANAGED (that is what hides the
+			// rail) and stepIndex() clamps an unknown step to 0 - so advancing from here
+			// dropped the customer back on Details, which promptly re-offered the
+			// reconnect they had just completed instead of taking them to chat.
+			state.step = "pay";
 			await proceedAfterPay();
 			return;
 		}

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -300,6 +300,19 @@
 									class="mx-auto mt-5 max-w-[620px]"
 								/>
 							</div>
+							<p
+								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
+							>
+								Already subscribed and setting this site up again?
+								<button
+									class="ob-link"
+									:disabled="!canReconnect || state.payBusy"
+									@click="startReconnect"
+								>
+									Reconnect instead
+								</button>
+								— we'll email a code to confirm it's you. Nothing to pay again.
+							</p>
 							<div class="ob-foot">
 								<button class="ob-back" @click="goBack">
 									<FeatherIcon
@@ -385,62 +398,6 @@
 										loading-text="Working…"
 										label="I've verified my email"
 										@click="onVerifyCheck"
-									/>
-								</div>
-							</template>
-							<template v-else-if="state.payPhase === 'reconnect'">
-								<div class="ob-body ob-body--center">
-									<div class="ob-head">
-										<h1>Enter your reconnect code</h1>
-										<p>
-											Sent to <b>{{ state.email || "your email" }}</b> —
-											connects this site to your existing subscription,
-											nothing to pay again.
-										</p>
-									</div>
-									<input
-										v-model="state.reconnectCode"
-										class="ob-code"
-										type="text"
-										autocapitalize="characters"
-										autocomplete="one-time-code"
-										spellcheck="false"
-										maxlength="9"
-										aria-label="Reconnect code"
-										placeholder="ABCD2345"
-										@keydown.enter="submitReconnectCode"
-									/>
-									<p class="ob-code-note">
-										<template v-if="state.reconnectResentIn > 0">
-											Sent. You can resend in {{ state.reconnectResentIn }}s.
-										</template>
-										<template v-else>
-											Didn't get it?
-											<button class="ob-link" @click="resendReconnectCode">
-												Resend code
-											</button>
-										</template>
-									</p>
-									<Banner
-										v-if="state.payErr"
-										type="error"
-										:message="state.payErr"
-									/>
-								</div>
-								<div class="ob-foot">
-									<button class="ob-back" @click="cancelReconnect">
-										<FeatherIcon
-											name="chevron-left"
-											class="h-3.5 w-3.5 text-ink-gray-5"
-										/>Back
-									</button>
-									<Button
-										variant="solid"
-										:loading="state.payBusy"
-										loading-text="Working…"
-										:disabled="!state.reconnectCode.trim()"
-										label="Finish reconnect"
-										@click="submitReconnectCode"
 									/>
 								</div>
 							</template>
@@ -623,8 +580,8 @@
 											@click="startReconnect"
 										/>
 										<p class="mt-1.5 text-p-sm text-ink-gray-5">
-											We'll email a link to {{ state.email }} — approving it
-											connects this site to your existing subscription.
+											We'll email a code to {{ state.email }} — enter it to
+											connect this site to your existing subscription.
 											Nothing to pay again.
 										</p>
 									</div>
@@ -657,6 +614,63 @@
 							 save_llm_pool; this step is the post-save readiness handoff.
 							 v-show (not v-if) so the editor stays MOUNTED while its own save()
 							 is still awaiting. ===== -->
+						<!-- ===== Reconnect an existing subscription. NOT a rail step: it is a
+						     divergence out of the purchase funnel, and RAIL hides itself for any
+						     step it doesn't know - so the customer stops being told they are at
+						     "Pay" while reconnecting something they already paid for. ===== -->
+						<section v-else-if="state.step === 'reconnect'" class="ob-screen">
+							<div class="ob-body ob-body--center">
+								<div class="ob-head">
+									<h1>Enter your reconnect code</h1>
+									<p>
+										Sent to <b>{{ state.email || "your email" }}</b> — connects
+										this site to your existing subscription, nothing to pay
+										again.
+									</p>
+								</div>
+								<input
+									v-model="state.reconnectCode"
+									class="ob-code"
+									type="text"
+									autocapitalize="characters"
+									autocomplete="one-time-code"
+									spellcheck="false"
+									maxlength="9"
+									aria-label="Reconnect code"
+									placeholder="ABCD2345"
+									@keydown.enter="submitReconnectCode"
+								/>
+								<p class="ob-code-note">
+									<template v-if="state.reconnectResentIn > 0">
+										Sent. You can resend in {{ state.reconnectResentIn }}s.
+									</template>
+									<template v-else>
+										Didn't get it?
+										<button class="ob-link" @click="resendReconnectCode">
+											Resend code
+										</button>
+									</template>
+								</p>
+								<Banner v-if="state.payErr" type="error" :message="state.payErr" />
+							</div>
+							<div class="ob-foot">
+								<button class="ob-back" @click="cancelReconnect">
+									<FeatherIcon
+										name="chevron-left"
+										class="h-3.5 w-3.5 text-ink-gray-5"
+									/>Back
+								</button>
+								<Button
+									variant="solid"
+									:loading="state.payBusy"
+									loading-text="Working…"
+									:disabled="!state.reconnectCode.trim()"
+									label="Finish reconnect"
+									@click="submitReconnectCode"
+								/>
+							</div>
+						</section>
+
 						<section v-else-if="state.step === 'connect'" class="ob-screen">
 							<div class="ob-body">
 								<div v-show="state.finishing">
@@ -829,9 +843,10 @@ const state = reactive({
 	plansLoading: false,
 	plansErr: "",
 	// pay (renderPay / renderVerifyEmail / startPay / openCheckout)
-	payPhase: "review", // "review" | "verify" | "reconnect" - step-3 sub-screens
+	payPhase: "review", // "review" | "verify" - step-3 sub-screens
 	reconnectOffered: false,
 	reconnectRequestId: "",
+	reconnectFrom: "",
 	reconnectCode: "",
 	reconnectResentIn: 0,
 	paymentProvider: "razorpay", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
@@ -864,6 +879,11 @@ const state = reactive({
 const steps = computed(() => STEPS_MANAGED);
 const selectedPlan = computed(() => state.plans.find((p) => p.name === state.planName) || {});
 const railIndex = computed(() => RAIL.findIndex((r) => r.id === state.step));
+// Admin resolves a reconnect by (email, company) - several company accounts can
+// share one address - so both halves must be filled before the offer is live.
+const canReconnect = computed(
+	() => /.+@.+\..+/.test((state.email || "").trim()) && !!(state.company || "").trim()
+);
 const frameSub = computed(() => FRAME_SUBS[state.step] || "Set up your workspace");
 
 // No "Popular" tag: the admin plan catalog carries no recommended/popular
@@ -1278,6 +1298,7 @@ async function onVerifyCheck() {
 }
 
 function cancelReconnect() {
+	state.step = state.reconnectFrom || "pay";
 	state.payPhase = "review";
 	state.payErr = "";
 	state.reconnectRequestId = "";
@@ -1334,18 +1355,21 @@ async function submitReconnectCode() {
 	}
 }
 
-// "Already subscribed? Reconnect this site": start the admin-side magic-link
-// flow and switch the pay step into the waiting screen. The poll below rides
-// until the customer clicks the emailed link (or an operator approves).
+// "Already subscribed?": ask admin to mail a reconnect code, then show the
+// code screen. Reachable from Details (a returning customer never has to pick a
+// plan or reach a payment wall) and from a rejected pay attempt.
 async function startReconnect() {
 	state.payErr = "";
 	state.reconnectOffered = false;
 	state.reconnectCode = "";
 	state.payBusy = true;
+	// Where to return on Back/cancel: reconnect can now be entered from Details
+	// (before any plan is chosen) as well as from a rejected pay attempt.
+	state.reconnectFrom = state.step === "reconnect" ? state.reconnectFrom : state.step;
 	try {
 		const d = await startAccountReconnect(state.email, state.company);
 		state.reconnectRequestId = (d && d.request) || "";
-		state.payPhase = "reconnect";
+		state.step = "reconnect";
 	} catch (e) {
 		state.payErr = errMsg(e);
 		state.reconnectOffered = true;

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -301,12 +301,13 @@
 								/>
 							</div>
 							<p
+								v-if="canReconnect"
 								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
 							>
 								Already subscribed and setting this site up again?
 								<button
 									class="ob-link"
-									:disabled="!canReconnect || state.payBusy"
+									:disabled="state.payBusy"
 									@click="startReconnect"
 								>
 									Reconnect instead
@@ -786,6 +787,7 @@ import {
 	getLlmSyncStatus,
 	listPlans,
 	listPaymentProviders,
+	reconnectAvailable,
 	startAccountReconnect,
 	checkAccountReconnect,
 	startSignup,
@@ -848,6 +850,8 @@ const state = reactive({
 	reconnectOffered: false,
 	reconnectRequestId: "",
 	reconnectFrom: "",
+	reconnectEligible: false,
+	reconnectNeedsCompany: false,
 	reconnectCode: "",
 	reconnectResentIn: 0,
 	paymentProvider: "razorpay", // gateway chosen on Review & Pay: "razorpay" | "cashfree"
@@ -880,10 +884,54 @@ const state = reactive({
 const steps = computed(() => STEPS_MANAGED);
 const selectedPlan = computed(() => state.plans.find((p) => p.name === state.planName) || {});
 const railIndex = computed(() => RAIL.findIndex((r) => r.id === state.step));
-// Admin resolves a reconnect by (email, company) - several company accounts can
-// share one address - so both halves must be filled before the offer is live.
-const canReconnect = computed(
+// Both halves of the identity must be present before the plane can resolve an
+// account: several company accounts can share one address.
+const reconnectInputsReady = computed(
 	() => /.+@.+\..+/.test((state.email || "").trim()) && !!(state.company || "").trim()
+);
+// The offer is shown ONLY when the control plane confirms this (email, company)
+// has an account a reconnect would actually find. Never guessed client-side: a
+// wrong guess either hides recovery from someone who needs it, or sends someone
+// who has no account into a code screen no code will ever arrive for.
+const canReconnect = computed(() => reconnectInputsReady.value && state.reconnectEligible);
+
+// Debounced so typing an address doesn't call the plane per keystroke, and
+// cached per (email, company) so going back and forth doesn't re-ask. Fails
+// closed: any error leaves the offer hidden and the customer on the normal path.
+let eligibilityTimer = null;
+const eligibilityCache = new Map();
+async function refreshReconnectEligibility() {
+	if (!reconnectInputsReady.value) {
+		state.reconnectEligible = false;
+		state.reconnectNeedsCompany = false;
+		return;
+	}
+	const key = `${state.email.trim().toLowerCase()}\u0000${state.company.trim().toLowerCase()}`;
+	if (eligibilityCache.has(key)) {
+		const hit = eligibilityCache.get(key);
+		state.reconnectEligible = hit.eligible;
+		state.reconnectNeedsCompany = hit.needsCompany;
+		return;
+	}
+	try {
+		const d = (await reconnectAvailable(state.email.trim(), state.company.trim())) || {};
+		const hit = { eligible: !!d.eligible, needsCompany: !!d.needs_company };
+		eligibilityCache.set(key, hit);
+		state.reconnectEligible = hit.eligible;
+		state.reconnectNeedsCompany = hit.needsCompany;
+	} catch (e) {
+		state.reconnectEligible = false;
+		state.reconnectNeedsCompany = false;
+	}
+}
+watch(
+	() => [state.step, state.email, state.company],
+	() => {
+		if (state.step !== "details") return;
+		clearTimeout(eligibilityTimer);
+		eligibilityTimer = setTimeout(refreshReconnectEligibility, 500);
+	},
+	{ immediate: true }
 );
 const frameSub = computed(() => FRAME_SUBS[state.step] || "Set up your workspace");
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -814,6 +814,7 @@ const FRAME_SUBS = {
 	plan: "Choose your plan",
 	details: "Your details",
 	pay: "Review & pay",
+	reconnect: "Reconnect your subscription",
 	connect: `Give ${agentName} a brain`,
 };
 

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -189,7 +189,7 @@
 									<FeatherIcon
 										name="chevron-left"
 										class="h-3.5 w-3.5 text-ink-gray-5"
-									/>Back to tour
+									/>Back
 								</button>
 								<Button
 									variant="solid"
@@ -318,7 +318,7 @@
 									<FeatherIcon
 										name="chevron-left"
 										class="h-3.5 w-3.5 text-ink-gray-5"
-									/>Back
+									/>Back to tour
 								</button>
 								<Button
 									variant="solid"
@@ -802,8 +802,8 @@ const { effectiveDark: dark, paletteVars } = useJarvisTheme();
 // The 4 named wizard steps shown on the rail. The intro tour is chromeless
 // (no rail entry).
 const RAIL = [
-	{ id: "plan", label: "Plan" },
 	{ id: "details", label: "Details" },
+	{ id: "plan", label: "Plan" },
 	{ id: "pay", label: "Pay" },
 	{ id: "connect", label: "Connect" },
 ];
@@ -985,10 +985,11 @@ function goNext() {
 function goBack() {
 	state.step = prevStep(steps.value, state.step);
 }
-// Intro tour exits (CTA / advancing past the last slide / Skip tour) all land
-// on the Plan step.
+// Intro tour exits (CTA / advancing past the last slide / Skip tour) all land on
+// whatever follows the intro - derived, not hardcoded, so it tracks STEPS_MANAGED
+// instead of silently bypassing the first real step when the order changes.
 function startWizard() {
-	state.step = "plan";
+	state.step = nextStep(steps.value, "intro");
 }
 // ---- on-mount reconcile: resume a mid-flight signup ------------------------
 // A mid-flight signup must land on the right step, NOT the intro tour - the

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -223,6 +223,18 @@ def resume_pending_signup(plan: str, provider: str | None = None) -> dict:
 	return _post(path=_m("billing.signup.resume_pending_signup"), body=body)
 
 
+def reconnect_eligibility(email: str, company_name: str = "") -> dict:
+	"""Guest: would a reconnect for this (email, company) find anything? Read-only
+	precursor to request_account_reconnect, so the wizard can offer the reconnect
+	path only when it works. Short timeout - it gates a hint, never a decision:
+	the caller treats any failure as "don't offer"."""
+	return _post_guest(
+		path=_m("billing.reconnect.can_reconnect"),
+		body={"email": email, "company_name": company_name},
+		timeout_s=8,
+	)
+
+
 def request_account_reconnect(email: str, company_name: str = "") -> dict:
 	"""Guest: start a fresh-bench reconnect to an EXISTING paid account (wiped
 	site recovery). Admin emails a CODE to the registered address and returns an

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -505,6 +505,27 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 
 
 @frappe.whitelist()
+def reconnect_available(email: str, company: str = "") -> dict:
+	"""Would a reconnect for this (email, company) find an account to reconnect?
+
+	Gates the wizard's reconnect offer so it appears only when it would work. Fails
+	CLOSED: any admin-side error answers "not available" rather than raising, because
+	this only decides whether to show a hint - a wizard that breaks because the
+	control plane blipped would be a worse trade than a hint that stays hidden.
+	Same System-Manager gating as the rest of onboarding."""
+	require_jarvis_admin()
+	try:
+		_require_admin_url()
+		d = admin_client.reconnect_eligibility(email, company) or {}
+	except Exception:
+		return {"eligible": False, "needs_company": False}
+	return {
+		"eligible": bool(d.get("eligible")),
+		"needs_company": bool(d.get("needs_company")),
+	}
+
+
+@frappe.whitelist()
 def start_account_reconnect(email: str, company: str = "") -> dict:
 	"""Fresh-bench recovery: ask admin to email a reconnect CODE to the
 	REGISTERED address of an existing paid account (wiped-site scenario — the


### PR DESCRIPTION
## Why

A customer rebuilding a wiped site could only discover reconnect by picking a plan, filling in details already on file, pressing **Pay ₹9,990**, and reading a red *"an account for this email and company already exists"* error. Three steps and one alarming error into a purchase they must not make.

Reported from a screen recording of the real flow.

## What changed

**The offer moved to Details**, where the email and company are typed — a returning customer never chooses a plan or reaches a payment wall.

**It appears only when the account exists.** Gated on `jarvis.onboarding.reconnect_available`, which defers to the control plane's own resolver. Never guessed client-side: a wrong guess either hides recovery from someone whose site was wiped, or sends someone with no account into a code screen no code will ever arrive for. Debounced 500ms, cached per (email, company), and fails **closed** at both layers — a control-plane error hides the offer rather than breaking the wizard.

**Details now comes before Plan.** The email and company are what *identify* an account; asking for them after the plan meant weighing five plans you already pay for before reaching the one control that helps you. Nothing on the Details step reads the chosen plan, so the swap is `STEPS_MANAGED`, `RAIL`, and two Back labels.

**The code screen is its own step.** It was a sub-phase of Pay, so the rail told customers they were paying for something they had already bought. The rail hides itself for steps it doesn't know, and the frame header now names it.

## Two bugs found while building this

- The tour exit hardcoded `state.step = "plan"`, so **Skip tour jumped over Details** once the order changed. It now derives the step after the intro and can't silently bypass a step again.
- Finishing a reconnect landed back on **Details** instead of Connect: `proceedAfterPay()` navigates relative to `state.step`, and `stepIndex()` clamps an unknown step to `0` — so "next" from the off-funnel `reconnect` step resolved to the *first* funnel step, which then re-offered the reconnect just completed. Now re-anchors to `pay` first. Both halves are pinned in tests.

Also: the pay-step fallback still promised *"we'll email a link … approving it"*. That became a mailed **code**. Fixed.

## Verified

Driven in a browser against the live local control plane: unknown address shows nothing, a real account shows the offer, blanking the email hides it again; Skip tour lands on Your details; Continue goes to Choose your plan. 24/24 onboarding unit tests; tenant suites 59 + 5 + 48 green.

Requires `jarvis-admin-v2#144` for the offer to ever appear.