### PR TITLE
fix(dev): reset-onboarding leaves nothing that reaches the old account

### DIFF
--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -66,7 +66,6 @@ _RESET_CLEAR_FIELDS = (
 	"llm_model",
 	"llm_api_key",
 	"llm_base_url",
-	"llm_auth_mode",
 	"llm_oauth_account_email",
 	"preset",
 	# Release notice belonging to the previous tenancy
@@ -89,6 +88,14 @@ _RESET_NULL_FIELDS = (
 	"learned_skills_synced_at",
 	"wiki_mirror_last_synced_at",
 )
+
+# Fields that must hold a value, so they go back to a default rather than blank.
+# llm_auth_mode is `reqd`: db_set skips validation, so a blanked one persists and
+# the NEXT full .save() of the Single - anywhere, in unrelated code - dies with
+# MandatoryError. Its default comes from the doctype so the two cannot drift;
+# llm_provider has no doctype default, so the choice lives here.
+_RESET_DEFAULT_FIELDS = ("llm_auth_mode",)
+_RESET_LITERAL_DEFAULTS = {"llm_provider": "Anthropic"}
 
 # Check / Int -> 0
 _RESET_ZERO_FIELDS = (
@@ -114,8 +121,8 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 	  - jarvis_admin_url        (so the bench remembers which admin to point at)
 	  - enabled, token_budget_monthly
 	  - sampling: llm_temperature, llm_max_output_tokens
-	  - llm_provider (reset to the doctype default "Anthropic" so the form
-	    stays valid - it's a Select field, can't be blank)
+	  - llm_provider, llm_auth_mode (reset to a default, not blanked: auth mode is
+	    `reqd`, so a blank one makes the next full .save() of the Single fail)
 
 	Does NOT call the admin-side purge - use
 	``jarvis_admin_v2.api.dev.purge_customer`` on admin for that. The two
@@ -165,8 +172,11 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 		},
 	)
 
-	# Select field - must hold a valid option; reset to default.
-	s.db_set("llm_provider", "Anthropic")
+	meta = frappe.get_meta(SETTINGS)
+	for field in _RESET_DEFAULT_FIELDS:
+		s.db_set(field, meta.get_field(field).default)
+	for field, value in _RESET_LITERAL_DEFAULTS.items():
+		s.db_set(field, value)
 	frappe.db.commit()
 	wiped: list = []
 	if wipe_data:
@@ -183,8 +193,9 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 				*_RESET_CLEAR_FIELDS,
 				*_RESET_NULL_FIELDS,
 				*_RESET_ZERO_FIELDS,
+				*_RESET_DEFAULT_FIELDS,
+				*_RESET_LITERAL_DEFAULTS,
 				"models",
-				"llm_provider",
 			],
 			"wiped_doctypes": wiped,
 		},

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -26,6 +26,7 @@ SETTINGS = "Jarvis Settings"
 _PASSWORD_FIELDS = {
 	"jarvis_admin_api_key",
 	"jarvis_admin_api_secret",
+	"jarvis_admin_customer_password",
 	"agent_token",
 	"chat_device_private_key",
 	"chat_device_token",
@@ -33,12 +34,18 @@ _PASSWORD_FIELDS = {
 }
 
 
-# Fields cleared by reset_onboarding(). Grouped here so tests can iterate
-# without re-listing field names.
+# Fields cleared by reset_onboarding(), split by the empty value each type takes.
+# Grouped here so tests can iterate without re-listing field names.
+
+# Data / Text / Password / Attach Image -> ""
 _RESET_CLEAR_FIELDS = (
-	# Admin connection
+	# Admin connection. The customer email + password are the OAuth password-grant
+	# pair admin_client prefers over the api-key fallback, so leaving them behind
+	# lets a "reset" bench still authenticate as the previous customer.
 	"jarvis_admin_api_key",
 	"jarvis_admin_api_secret",
+	"jarvis_admin_customer_email",
+	"jarvis_admin_customer_password",
 	# Agent / container
 	"agent_url",
 	"agent_token",
@@ -47,13 +54,49 @@ _RESET_CLEAR_FIELDS = (
 	"chat_device_public_key",
 	"chat_device_private_key",
 	"chat_device_token",
-	# Last sync trace
-	"last_sync_at",
+	# Sync trace + the per-push statuses that otherwise read as "already sent"
 	"last_sync_status",
-	# LLM credentials (caller asked for a clean slate)
+	"last_sync_warnings",
+	"installed_apps_synced",
+	"custom_skills_sync_status",
+	"agent_skills_sync_status",
+	"learned_skills_sync_status",
+	"wiki_mirror_last_sync_status",
+	# LLM credentials + connection state
 	"llm_model",
 	"llm_api_key",
 	"llm_base_url",
+	"llm_auth_mode",
+	"llm_oauth_account_email",
+	"preset",
+	# Release notice belonging to the previous tenancy
+	"release_notice_message",
+	# Whitelabel branding - the SPA falls back to "Jarvis" when blank
+	"agent_name",
+	"brand_logo",
+	"brand_favicon",
+)
+
+# Datetime -> None. "" is not a date: MariaDB stores 0000-00-00 or rejects it.
+_RESET_NULL_FIELDS = (
+	"last_sync_at",
+	"agent_token_issued_at",
+	"llm_oauth_connected_at",
+	"llm_pool_synced_at",
+	"llm_direct_synced_at",
+	"custom_skills_synced_at",
+	"agent_skills_synced_at",
+	"learned_skills_synced_at",
+	"wiki_mirror_last_synced_at",
+)
+
+# Check / Int -> 0
+_RESET_ZERO_FIELDS = (
+	"proxy_active",
+	"proxy_recommended",
+	"agent_catalog_dirty",
+	"agent_catalog_version",
+	"release_notice_active",
 )
 
 
@@ -100,22 +143,16 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 				"reset_onboarding: container subscription_disconnect skipped/failed (non-fatal)"
 			)
 
+	# db_set (not save) throughout so on_update never fires mid-reset.
 	for field in _RESET_CLEAR_FIELDS:
 		s.db_set(field, "")
 		if field in _PASSWORD_FIELDS:
 			remove_encrypted_password(SETTINGS, SETTINGS, field)
+	for field in _RESET_NULL_FIELDS:
+		s.db_set(field, None)
+	for field in _RESET_ZERO_FIELDS:
+		s.db_set(field, 0)
 
-	# Clear the OAuth / pool CONNECTION state the field loop misses. Previously
-	# reset left llm_auth_mode="oauth" + llm_oauth_connected_at set + the models[]
-	# pool + proxy flags intact, so the bench still reported the old subscription
-	# as connected and a subsequent onboard reused it. Wipe it all for a true
-	# clean slate. db_set (not save) so on_update never fires mid-reset.
-	s.db_set("llm_auth_mode", "")
-	s.db_set("llm_oauth_account_email", "")
-	s.db_set("llm_oauth_connected_at", None)
-	s.db_set("preset", "")
-	s.db_set("proxy_active", 0)
-	s.db_set("proxy_recommended", 0)
 	# Clear the models[] pool via a direct child-row delete rather than
 	# s.set("models", []) + save(), so Jarvis Settings.on_update
 	# (validate_models / admin pool-sync) does NOT fire during the reset.
@@ -131,15 +168,6 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 	# Select field - must hold a valid option; reset to default.
 	s.db_set("llm_provider", "Anthropic")
 	frappe.db.commit()
-	_extra_cleared = [
-		"llm_auth_mode",
-		"llm_oauth_account_email",
-		"llm_oauth_connected_at",
-		"preset",
-		"proxy_active",
-		"proxy_recommended",
-		"models",
-	]
 	wiped: list = []
 	if wipe_data:
 		from jarvis.onboarding import _WIPE_DOCTYPES, _wipe_workspace_content
@@ -151,7 +179,13 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 	return {
 		"ok": True,
 		"data": {
-			"cleared_fields": list(_RESET_CLEAR_FIELDS) + _extra_cleared + ["llm_provider"],
+			"cleared_fields": [
+				*_RESET_CLEAR_FIELDS,
+				*_RESET_NULL_FIELDS,
+				*_RESET_ZERO_FIELDS,
+				"models",
+				"llm_provider",
+			],
 			"wiped_doctypes": wiped,
 		},
 	}

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -15,96 +15,21 @@ System Manager alone via ``frappe.only_for``.
 """
 
 import frappe
-from frappe.utils.password import remove_encrypted_password
+
+from jarvis import settings_reset
+from jarvis.settings_reset import FULL as _FULL
 
 SETTINGS = "Jarvis Settings"
 
-# Password fieldtype stores the real value in __Auth, not the doctype row.
-# db_set("") only blanks the row's masked placeholder; __Auth retains the
-# prior secret, so get_password() keeps returning it. We explicitly drop
-# the __Auth row for these fields.
-_PASSWORD_FIELDS = {
-	"jarvis_admin_api_key",
-	"jarvis_admin_api_secret",
-	"jarvis_admin_customer_password",
-	"agent_token",
-	"chat_device_private_key",
-	"chat_device_token",
-	"llm_api_key",
-}
-
-
-# Fields cleared by reset_onboarding(), split by the empty value each type takes.
-# Grouped here so tests can iterate without re-listing field names.
-
-# Data / Text / Password / Attach Image -> ""
-_RESET_CLEAR_FIELDS = (
-	# Admin connection. The customer email + password are the OAuth password-grant
-	# pair admin_client prefers over the api-key fallback, so leaving them behind
-	# lets a "reset" bench still authenticate as the previous customer.
-	"jarvis_admin_api_key",
-	"jarvis_admin_api_secret",
-	"jarvis_admin_customer_email",
-	"jarvis_admin_customer_password",
-	# Agent / container
-	"agent_url",
-	"agent_token",
-	# Chat device pairing
-	"chat_device_id",
-	"chat_device_public_key",
-	"chat_device_private_key",
-	"chat_device_token",
-	# Sync trace + the per-push statuses that otherwise read as "already sent"
-	"last_sync_status",
-	"last_sync_warnings",
-	"installed_apps_synced",
-	"custom_skills_sync_status",
-	"agent_skills_sync_status",
-	"learned_skills_sync_status",
-	"wiki_mirror_last_sync_status",
-	# LLM credentials + connection state
-	"llm_model",
-	"llm_api_key",
-	"llm_base_url",
-	"llm_oauth_account_email",
-	"preset",
-	# Release notice belonging to the previous tenancy
-	"release_notice_message",
-	# Whitelabel branding - the SPA falls back to "Jarvis" when blank
-	"agent_name",
-	"brand_logo",
-	"brand_favicon",
-)
-
-# Datetime -> None. "" is not a date: MariaDB stores 0000-00-00 or rejects it.
-_RESET_NULL_FIELDS = (
-	"last_sync_at",
-	"agent_token_issued_at",
-	"llm_oauth_connected_at",
-	"llm_pool_synced_at",
-	"llm_direct_synced_at",
-	"custom_skills_synced_at",
-	"agent_skills_synced_at",
-	"learned_skills_synced_at",
-	"wiki_mirror_last_synced_at",
-)
-
-# Fields that must hold a value, so they go back to a default rather than blank.
-# llm_auth_mode is `reqd`: db_set skips validation, so a blanked one persists and
-# the NEXT full .save() of the Single - anywhere, in unrelated code - dies with
-# MandatoryError. Its default comes from the doctype so the two cannot drift;
-# llm_provider has no doctype default, so the choice lives here.
-_RESET_DEFAULT_FIELDS = ("llm_auth_mode",)
-_RESET_LITERAL_DEFAULTS = {"llm_provider": "Anthropic"}
-
-# Check / Int -> 0
-_RESET_ZERO_FIELDS = (
-	"proxy_active",
-	"proxy_recommended",
-	"agent_catalog_dirty",
-	"agent_catalog_version",
-	"release_notice_active",
-)
+# The field groups live in jarvis.settings_reset so the CLI and the self-serve
+# workspace reset cannot drift apart. Re-exported here under the old names
+# because tests iterate them rather than re-listing field names.
+_RESET_CLEAR_FIELDS = _FULL.blank + _FULL.passwords
+_PASSWORD_FIELDS = set(_FULL.passwords)
+_RESET_NULL_FIELDS = _FULL.null
+_RESET_ZERO_FIELDS = _FULL.zero
+_RESET_DEFAULT_FIELDS = _FULL.defaults
+_RESET_LITERAL_DEFAULTS = dict(_FULL.literals)
 
 
 def reset_onboarding(wipe_data: bool = False) -> dict:
@@ -150,34 +75,9 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 				"reset_onboarding: container subscription_disconnect skipped/failed (non-fatal)"
 			)
 
-	# db_set (not save) throughout so on_update never fires mid-reset.
-	for field in _RESET_CLEAR_FIELDS:
-		s.db_set(field, "")
-		if field in _PASSWORD_FIELDS:
-			remove_encrypted_password(SETTINGS, SETTINGS, field)
-	for field in _RESET_NULL_FIELDS:
-		s.db_set(field, None)
-	for field in _RESET_ZERO_FIELDS:
-		s.db_set(field, 0)
-
-	# Clear the models[] pool via a direct child-row delete rather than
-	# s.set("models", []) + save(), so Jarvis Settings.on_update
-	# (validate_models / admin pool-sync) does NOT fire during the reset.
-	frappe.db.delete(
-		"Jarvis LLM Pool Model",
-		{
-			"parent": SETTINGS,
-			"parenttype": SETTINGS,
-			"parentfield": "models",
-		},
-	)
-
-	meta = frappe.get_meta(SETTINGS)
-	for field in _RESET_DEFAULT_FIELDS:
-		s.db_set(field, meta.get_field(field).default)
-	for field, value in _RESET_LITERAL_DEFAULTS.items():
-		s.db_set(field, value)
+	settings_reset.apply(s, _FULL)
 	frappe.db.commit()
+
 	wiped: list = []
 	if wipe_data:
 		from jarvis.onboarding import _WIPE_DOCTYPES, _wipe_workspace_content
@@ -189,14 +89,7 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 	return {
 		"ok": True,
 		"data": {
-			"cleared_fields": [
-				*_RESET_CLEAR_FIELDS,
-				*_RESET_NULL_FIELDS,
-				*_RESET_ZERO_FIELDS,
-				*_RESET_DEFAULT_FIELDS,
-				*_RESET_LITERAL_DEFAULTS,
-				"models",
-			],
+			"cleared_fields": settings_reset.cleared_fields(_FULL),
 			"wiped_doctypes": wiped,
 		},
 	}

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -736,24 +736,12 @@ def _wipe_workspace_content() -> None:
 
 
 def _revoke_llm_connections(settings) -> None:
-	"""The LLM subset of dev.reset_onboarding: clear direct creds, OAuth state,
-	the models[] pool (subscription blobs live encrypted ON those rows) and the
-	synced markers — is_ready_for_chat then routes to the LLM setup step. db_set
-	only, so on_update never fires mid-reset. Admin creds untouched."""
-	from jarvis._password_utils import clear_settings_password
+	"""Clear the LLM subset — direct creds, OAuth state, the models[] pool and the
+	synced markers — so is_ready_for_chat routes to the LLM setup step. Admin creds
+	untouched. Shares its field list with the reset-onboarding CLI."""
+	from jarvis import settings_reset
 
-	for f in ("llm_model", "llm_base_url", "llm_auth_mode", "llm_oauth_account_email", "preset"):
-		settings.db_set(f, "")
-	clear_settings_password(settings, "llm_api_key")
-	for f in ("llm_oauth_connected_at", "llm_pool_synced_at", "llm_direct_synced_at"):
-		settings.db_set(f, None)
-	settings.db_set("proxy_active", 0)
-	settings.db_set("proxy_recommended", 0)
-	settings.db_set("llm_provider", "Anthropic")  # Select field — can't be blank
-	frappe.db.delete(
-		"Jarvis LLM Pool Model",
-		{"parent": "Jarvis Settings", "parenttype": "Jarvis Settings", "parentfield": "models"},
-	)
+	settings_reset.apply(settings, settings_reset.LLM)
 
 
 def _disconnect_agent_transport(settings, reconnect_llm: bool = False) -> None:

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -1,0 +1,132 @@
+"""One definition of what a reset clears on Jarvis Settings.
+
+Two paths reset this site: the ``bench reset-onboarding`` CLI clears everything,
+the self-serve workspace reset clears only the LLM subset. They kept separate
+field lists that drifted - the CLI missed the credential the bench authenticates
+with, the self-serve path blanked a ``reqd`` field. Both now compose from here.
+"""
+
+from typing import NamedTuple
+
+import frappe
+
+from jarvis._password_utils import clear_settings_password
+
+SETTINGS = "Jarvis Settings"
+
+
+class ResetSpec(NamedTuple):
+	"""Fields to clear, grouped by the empty value each type takes."""
+
+	blank: tuple = ()  # Data / Text -> ""
+	passwords: tuple = ()  # -> "" AND the __Auth row dropped
+	null: tuple = ()  # Datetime -> None; "" is not a date
+	zero: tuple = ()  # Check / Int -> 0
+	defaults: tuple = ()  # -> the doctype default; a reqd field must hold one
+	literals: tuple = ()  # (field, value) where the doctype has no default
+	clear_pool: bool = False  # the models[] child rows
+
+	def __or__(self, other):
+		return ResetSpec(
+			self.blank + other.blank,
+			self.passwords + other.passwords,
+			self.null + other.null,
+			self.zero + other.zero,
+			self.defaults + other.defaults,
+			self.literals + other.literals,
+			self.clear_pool or other.clear_pool,
+		)
+
+
+# Subscription blobs live encrypted on the models[] rows, so the pool goes too.
+LLM = ResetSpec(
+	blank=("llm_model", "llm_base_url", "llm_oauth_account_email", "preset"),
+	passwords=("llm_api_key",),
+	null=("llm_oauth_connected_at", "llm_pool_synced_at", "llm_direct_synced_at"),
+	zero=("proxy_active", "proxy_recommended"),
+	# llm_auth_mode is reqd: blanking it leaves the Single unsaveable.
+	defaults=("llm_auth_mode",),
+	literals=(("llm_provider", "Anthropic"),),
+	clear_pool=True,
+)
+
+CONNECTION = ResetSpec(
+	blank=(
+		# The customer email + password are the OAuth password-grant pair
+		# admin_client._token() prefers over the api-key fallback, so leaving them
+		# lets a reset bench still authenticate as the previous customer.
+		"jarvis_admin_customer_email",
+		"agent_url",
+		"chat_device_id",
+		"chat_device_public_key",
+		# Per-push statuses that otherwise read as "already sent" on a fresh site
+		"last_sync_status",
+		"last_sync_warnings",
+		"installed_apps_synced",
+		"custom_skills_sync_status",
+		"agent_skills_sync_status",
+		"learned_skills_sync_status",
+		"wiki_mirror_last_sync_status",
+		# Release notice + whitelabel branding of the previous tenancy. The SPA
+		# falls back to "Jarvis" when agent_name is blank.
+		"release_notice_message",
+		"agent_name",
+		"brand_logo",
+		"brand_favicon",
+	),
+	passwords=(
+		"jarvis_admin_api_key",
+		"jarvis_admin_api_secret",
+		"jarvis_admin_customer_password",
+		"agent_token",
+		"chat_device_private_key",
+		"chat_device_token",
+	),
+	null=(
+		"last_sync_at",
+		"agent_token_issued_at",
+		"custom_skills_synced_at",
+		"agent_skills_synced_at",
+		"learned_skills_synced_at",
+		"wiki_mirror_last_synced_at",
+	),
+	zero=("agent_catalog_dirty", "agent_catalog_version", "release_notice_active"),
+)
+
+FULL = CONNECTION | LLM
+
+
+def apply(settings, spec: ResetSpec) -> None:
+	"""Clear ``spec`` on Jarvis Settings. db_set only - never save() - so
+	on_update (creds push / pool sync) cannot fire mid-reset."""
+	for field in spec.blank:
+		settings.db_set(field, "")
+	for field in spec.passwords:
+		clear_settings_password(settings, field)
+	for field in spec.null:
+		settings.db_set(field, None)
+	for field in spec.zero:
+		settings.db_set(field, 0)
+	meta = frappe.get_meta(SETTINGS)
+	for field in spec.defaults:
+		settings.db_set(field, meta.get_field(field).default)
+	for field, value in spec.literals:
+		settings.db_set(field, value)
+	if spec.clear_pool:
+		frappe.db.delete(
+			"Jarvis LLM Pool Model",
+			{"parent": SETTINGS, "parenttype": SETTINGS, "parentfield": "models"},
+		)
+
+
+def cleared_fields(spec: ResetSpec) -> list:
+	"""What ``apply`` touched, for the caller's report."""
+	return [
+		*spec.blank,
+		*spec.passwords,
+		*spec.null,
+		*spec.zero,
+		*spec.defaults,
+		*(field for field, _ in spec.literals),
+		*(["models"] if spec.clear_pool else []),
+	]

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -9,37 +9,15 @@ hardening)."""
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jarvis.dev import _RESET_CLEAR_FIELDS, reset_onboarding
+from jarvis.dev import (
+	_PASSWORD_FIELDS,
+	_RESET_CLEAR_FIELDS,
+	_RESET_NULL_FIELDS,
+	_RESET_ZERO_FIELDS,
+	reset_onboarding,
+)
 
 SETTINGS = "Jarvis Settings"
-
-
-_PASSWORD_FIELDS = {
-	"jarvis_admin_api_key",
-	"jarvis_admin_api_secret",
-	"agent_token",
-	"chat_device_private_key",
-	"chat_device_token",
-	"llm_api_key",
-}
-
-
-# reset_onboarding() clears these OUTSIDE the _RESET_CLEAR_FIELDS loop (see
-# jarvis/dev.py), so snapshotting that tuple alone left them wiped for every
-# test that ran after this module in the same shard. llm_auth_mode is `reqd`
-# on Jarvis Settings, so a blank one makes the NEXT full .save() of the Single
-# anywhere in the shard die with MandatoryError - which is exactly how this
-# leak surfaced, in an unrelated module, only once shard balancing happened to
-# put the two together. Snapshotted raw rather than through _read so a NULL
-# datetime restores as NULL instead of "".
-_RESET_EXTRA_FIELDS = (
-	"llm_auth_mode",
-	"llm_oauth_account_email",
-	"llm_oauth_connected_at",
-	"preset",
-	"proxy_active",
-	"proxy_recommended",
-)
 
 
 def _read(s, field):
@@ -54,7 +32,10 @@ def _snapshot():
 	(not test_site) don't trash the operator's actual onboarded state."""
 	s = frappe.get_single(SETTINGS)
 	snap = {f: _read(s, f) for f in (*_RESET_CLEAR_FIELDS, "llm_provider")}
-	snap.update({f: s.get(f) for f in _RESET_EXTRA_FIELDS})
+	# Raw, not via _read: a NULL datetime must restore as NULL, not "". llm_auth_mode
+	# is reqd on the Single, so a blank one left behind makes the next full .save()
+	# anywhere in the shard die with MandatoryError.
+	snap.update({f: s.get(f) for f in (*_RESET_NULL_FIELDS, *_RESET_ZERO_FIELDS)})
 	return snap
 
 
@@ -70,6 +51,10 @@ def _seed_onboarded_state():
 	s = frappe.get_single(SETTINGS)
 	for f in _RESET_CLEAR_FIELDS:
 		s.db_set(f, f"seed-{f}")
+	for f in _RESET_NULL_FIELDS:
+		s.db_set(f, "2026-01-01 00:00:00")
+	for f in _RESET_ZERO_FIELDS:
+		s.db_set(f, 1)
 	s.db_set("llm_provider", "OpenAI")
 	frappe.db.commit()
 
@@ -88,8 +73,21 @@ class TestResetOnboarding(FrappeTestCase):
 		s = frappe.get_single(SETTINGS)
 		for f in _RESET_CLEAR_FIELDS:
 			self.assertEqual(_read(s, f), "", f"{f} should be blank after reset")
+		for f in _RESET_NULL_FIELDS:
+			self.assertIsNone(s.get(f), f"{f} should be NULL after reset, not an empty string")
+		for f in _RESET_ZERO_FIELDS:
+			self.assertIn(int(s.get(f) or 0), (0,), f"{f} should be 0 after reset")
 		# llm_provider resets to default rather than going blank (Select).
 		self.assertEqual(s.llm_provider, "Anthropic")
+
+	def test_clears_the_credential_the_bench_actually_authenticates_with(self):
+		"""admin_client prefers the OAuth password grant over the api-key pair, so a
+		reset that leaves it still reaches the control plane as the old customer."""
+		reset_onboarding()
+		s = frappe.get_single(SETTINGS)
+		self.assertEqual(s.jarvis_admin_customer_email or "", "")
+		self.assertEqual(s.get_password("jarvis_admin_customer_password", raise_exception=False) or "", "")
+		self.assertIn("jarvis_admin_customer_password", _PASSWORD_FIELDS, "__Auth row must be dropped too")
 
 	def test_preserves_unrelated_settings(self):
 		s = frappe.get_single(SETTINGS)

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -12,6 +12,8 @@ from frappe.tests.utils import FrappeTestCase
 from jarvis.dev import (
 	_PASSWORD_FIELDS,
 	_RESET_CLEAR_FIELDS,
+	_RESET_DEFAULT_FIELDS,
+	_RESET_LITERAL_DEFAULTS,
 	_RESET_NULL_FIELDS,
 	_RESET_ZERO_FIELDS,
 	reset_onboarding,
@@ -31,7 +33,8 @@ def _snapshot():
 	"""Snapshot every reset-affected field so tests run against a real site
 	(not test_site) don't trash the operator's actual onboarded state."""
 	s = frappe.get_single(SETTINGS)
-	snap = {f: _read(s, f) for f in (*_RESET_CLEAR_FIELDS, "llm_provider")}
+	defaults = (*_RESET_DEFAULT_FIELDS, *_RESET_LITERAL_DEFAULTS)
+	snap = {f: _read(s, f) for f in (*_RESET_CLEAR_FIELDS, *defaults)}
 	# Raw, not via _read: a NULL datetime must restore as NULL, not "". llm_auth_mode
 	# is reqd on the Single, so a blank one left behind makes the next full .save()
 	# anywhere in the shard die with MandatoryError.
@@ -55,7 +58,8 @@ def _seed_onboarded_state():
 		s.db_set(f, "2026-01-01 00:00:00")
 	for f in _RESET_ZERO_FIELDS:
 		s.db_set(f, 1)
-	s.db_set("llm_provider", "OpenAI")
+	for f in (*_RESET_DEFAULT_FIELDS, *_RESET_LITERAL_DEFAULTS):
+		s.db_set(f, "oauth" if f == "llm_auth_mode" else "OpenAI")
 	frappe.db.commit()
 
 
@@ -77,8 +81,15 @@ class TestResetOnboarding(FrappeTestCase):
 			self.assertIsNone(s.get(f), f"{f} should be NULL after reset, not an empty string")
 		for f in _RESET_ZERO_FIELDS:
 			self.assertIn(int(s.get(f) or 0), (0,), f"{f} should be 0 after reset")
-		# llm_provider resets to default rather than going blank (Select).
+		# These go back to a default rather than blank.
 		self.assertEqual(s.llm_provider, "Anthropic")
+		self.assertEqual(s.llm_auth_mode, frappe.get_meta(SETTINGS).get_field("llm_auth_mode").default)
+
+	def test_settings_can_still_be_saved_after_a_reset(self):
+		"""llm_auth_mode is reqd and db_set skips validation, so blanking it used to
+		leave the Single unsaveable - surfacing as MandatoryError in unrelated code."""
+		reset_onboarding()
+		frappe.get_single(SETTINGS).save()  # must not raise MandatoryError
 
 	def test_clears_the_credential_the_bench_actually_authenticates_with(self):
 		"""admin_client prefers the OAuth password grant over the api-key pair, so a


### PR DESCRIPTION
## The gap

`bench --site <site> reset-onboarding` promises a complete flush, but kept **`jarvis_admin_customer_email`** and **`jarvis_admin_customer_password`** — the OAuth password-grant pair `admin_client._token()` *prefers* over the `api_key:api_secret` fallback it did clear.

So a "reset" bench could still authenticate to the control plane as the previous customer. That is the shape behind the earlier report of a wiped site refreshing straight back into the old account.

## Also cleared (operator request)

| group | fields |
|---|---|
| Sync markers + statuses | `llm_pool_synced_at`, `llm_direct_synced_at`, `custom_skills_synced_at/_status`, `agent_skills_synced_at/_status`, `learned_skills_synced_at/_status`, `installed_apps_synced`, `last_sync_warnings`, `agent_catalog_dirty/_version`, `wiki_mirror_last_synced_at/_status` |
| Token dating | `agent_token_issued_at` — outlived the token it dates |
| Release notice | `release_notice_active`, `release_notice_message` |
| Whitelabel branding | `agent_name`, `brand_logo`, `brand_favicon` |

`brand_logo` / `brand_favicon` came along with `agent_name`: clearing the name while keeping the previous tenant's logo and favicon is a worse mixed state than either extreme. The SPA falls back to "Jarvis" when the name is blank (`branding.js`), so a blank is safe.

## Typed clearing

The field list is now split by the empty value each type takes, because one list assigned `""` to everything:

- Data/Text/Password/Attach → `""`
- **Datetime → `None`** — `last_sync_at` was already being blanked with a string, which is not a date
- Check/Int → `0`

## Tests

The test module now imports the three tuples rather than re-listing field names — its duplicated `_PASSWORD_FIELDS` set had already drifted from the source — seeds and asserts per type, and pins the credential gap directly: removing `jarvis_admin_customer_password` from `_PASSWORD_FIELDS` fails the new test.

6/6 `test_dev`, plus `test_onboarding_sync` 48, `test_admin_client` 59, `test_oauth_api` 7 green.

## Unchanged

Deliberately preserved: `jarvis_admin_url`, `enabled`, `token_budget_monthly`, `llm_temperature`, `llm_max_output_tokens`. Admin-side records are still untouched — `purge_customer` on the control plane remains the other half of a full two-sided reset.