### PR TITLE
feat(onboarding): tell the customer when the company is what's missing

### DIFF
--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -314,6 +314,13 @@
 								</button>
 								— we'll email a code to confirm it's you. Nothing to pay again.
 							</p>
+							<p
+								v-else-if="state.reconnectNeedsCompany"
+								class="mx-auto mt-5 max-w-[620px] text-center text-p-sm text-ink-gray-5"
+							>
+								This email already has a subscription under a different company —
+								enter that company above to reconnect it instead of paying again.
+							</p>
 							<div class="ob-foot">
 								<button class="ob-back" @click="goBack">
 									<FeatherIcon


### PR DESCRIPTION
The reconnect offer only appears when the control plane confirms an account for this (email, company). After the company-binding fix a customer whose typed company doesn't match their subscription gets no offer and no reason - they'd pay again. can_reconnect already returns needs_company for exactly that case; render it.

## Summary

<!-- What does this change do, and why? -->

## Pre-merge checklist

> ℹ️ These repos are private on the GitHub **Free** plan, so branch protection is
> **not enforced** — CI cannot hard-block a merge. Honoring this checklist is what keeps
> broken changes out of UAT. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] **CI is green** — the `tests` check on this PR passes (never merge on ❌)
- [x] Branch is **up to date with `main`** (so it is tested against the latest code)
- [x] New/changed behavior has tests (the coverage gate still passes)
- [x] I self-reviewed the diff
