### PR TITLE
fix(chat): make a mid-run transport loss reach a terminal error

### DIFF
--- a/jarvis/chat/pump.py
+++ b/jarvis/chat/pump.py
@@ -167,6 +167,12 @@ LEASE_MIRROR_TTL_S = 30
 # work, within the budget) without a hot reconnect loop. See PUMP-RUNBOOK.md §CDX-1.
 TRANSPORT_RETRY_MAX = 4
 
+# SUXF-3: the ``run:recovering`` reason slug for a park caused by the transport
+# fast-retry budget running out (the gateway is provably unreachable, e.g. its
+# container was bounced under a live turn). A slug, not user-facing prose — ChatView
+# renders its own "interrupted" banner copy off the event.
+_TRANSPORT_LOST_REASON = "transport-lost"
+
 # Injection seams for timing (tests monkeypatch to remove real waits).
 _monotonic: Callable[[], float] = time.monotonic
 _sleep: Callable[[float], None] = time.sleep
@@ -2711,14 +2717,17 @@ def _park_recovering(ctx: PumpContext, run_id: str, *, reason: str) -> None:
 	_telemetry("park_recovering", run_id=run_id, reason=reason)
 
 
-def _park_affected_recovering(ctx: PumpContext) -> None:
-	"""DB-disconnect park (D6 §6): mark the shard's in-flight turns ``recovering``
-	so the next hop re-attaches from durable state, then let the hop exit. Never
-	spins. Best-effort — if the DB is truly down the marks fail and we simply
-	exit; the watchdog/ensure_pump revives later. SUXF-1: each park writes the
-	Message-row mirror + publishes ``run:recovering`` (via ``_mark_recovering_mirror``)
-	so a reload during the disconnect reconstructs the banner rather than a plain
-	locked composer."""
+def _park_affected_recovering(ctx: PumpContext, *, reason: str = "db-disconnect") -> None:
+	"""Shard-wide park (D6 §6): mark the shard's in-flight turns ``recovering`` so the
+	next hop re-attaches from durable state, then let the hop exit. Never spins.
+	Best-effort — if the DB is truly down the marks fail and we simply exit; the
+	watchdog/ensure_pump revives later. SUXF-1: each park writes the Message-row mirror
+	+ publishes ``run:recovering`` (via ``_mark_recovering_mirror``) so a reload during
+	the outage reconstructs the banner rather than a plain locked composer.
+
+	``reason`` rides the published event for operator/telemetry attribution: the
+	DB-disconnect backoff (default), the kill-switch halt, and the SUXF-3
+	transport-budget park all share this one path."""
 	target = ctx.relay_target_id
 	try:
 		rows = frappe.db.sql(
@@ -2737,7 +2746,7 @@ def _park_affected_recovering(ctx: PumpContext) -> None:
 				int(r["version"]),
 				r["conversation"],
 				r.get("assistant_message"),
-				reason="db-disconnect",
+				reason=reason,
 				pump_epoch=ctx.epoch,
 				relay_target_id=ctx.relay_target_id,
 			)
@@ -2906,7 +2915,19 @@ def _schedule_successor_on_exit(ctx: PumpContext, *, transport_retry: int) -> No
 	budget (``TRANSPORT_RETRY_MAX``) we leave the now-acquirable lease for the
 	watchdog-cron / sender ``ensure_pump`` to revive — the documented backoff tail for
 	a sustained gateway outage (see the ``TRANSPORT_RETRY_MAX`` note). Best-effort:
-	never raises out of an exit path."""
+	never raises out of an exit path.
+
+	SUXF-3: crossing the budget also PARKS the shard's in-flight turns ``recovering``.
+	Those turns were always going to be recovered, but ONLY the watchdog noticed, and
+	only once the per-turn ``deadline_at`` had passed — up to the dispatch deadline
+	plus a cron tick of a LOCKED composer showing a spinner with no feedback, while
+	the gateway is already provably unreachable (the fast-retry budget just proved
+	it). Parking here publishes ``run:recovering`` at once, so the customer gets the
+	interrupted banner and an UNLOCKED composer within the fast-retry window instead
+	of a silent multi-minute hang, and the existing ladder (budget-exhausted
+	``recovering -> _settle_recover_errored``) still drives the turn to a terminal
+	error if the gateway never returns. Covers ANY sustained mid-run transport loss,
+	not just a config-apply container bounce."""
 	target = ctx.relay_target_id
 	# CDX-21 (Residual B): the kill switch overrides transport-error succession. A transport exit
 	# under a legacy row must NOT enqueue a successor — release WITHOUT succession and park live
@@ -2917,14 +2938,22 @@ def _schedule_successor_on_exit(ctx: PumpContext, *, transport_retry: int) -> No
 	next_hop = ctx.hop_counter + 1
 	successor = f"jarvis-pump::{ctx.site}::{target}::hop{next_hop}"
 	try:
+		# SUXF-3: park BEFORE the lease release, so the recovering marks are written while
+		# this hop still provably holds epoch E — the same ordering _halt_for_kill_switch
+		# uses. _mark_recovering_mirror is epoch-fenced (CDX-24), so a hop that a takeover
+		# already superseded parks 0 rows and cannot disturb the new owner's turns.
+		budget_spent = transport_retry >= TRANSPORT_RETRY_MAX
+		if budget_spent and _shard_has_live_work(target):
+			_park_affected_recovering(ctx, reason=_TRANSPORT_LOST_REASON)
 		if not ts.lease_handoff(target, ctx.epoch, next_hop, successor):
 			return  # stale — a takeover owns the shard; it drives succession
 		_clear_lease_mirror(target)
 		if not _shard_has_live_work(target):
 			return  # idle — nothing to revive; the released lease simply stays vacant
-		if transport_retry >= TRANSPORT_RETRY_MAX:
-			# Bounded fast-retry budget spent: fall through to the watchdog / sender
-			# ensure_pump (the lease is already acquirable). Documented backoff tail.
+		if budget_spent:
+			# Bounded fast-retry budget spent: the shard's turns are parked above, so the
+			# watchdog / sender ensure_pump revival now recovers turns the customer can
+			# already SEE are interrupted. Documented backoff tail.
 			_telemetry("transport_retry_capped", target=target, retry=transport_retry)
 			return
 		ctx.deps.enqueue_pump_job(
@@ -3071,6 +3100,19 @@ def _watchdog_shard(target: str, deps: PumpDeps, summary: dict) -> None:
 			# run:recovering so a reload reconstructs the banner (not a plain locked
 			# composer).
 			if _recovery_budget_exhausted(r, now):
+				# SUXF-2: the budget clock survives recover_adopt, so an IN-FLIGHT turn
+				# genuinely arrives here already over budget (park -> adopt -> park is the
+				# gateway-is-gone loop). recover_errored is D2 row 24 (recovering ->
+				# errored), so calling it on an in-flight state matches 0 rows — and
+				# because this is the leading `if`, the branch never falls through to the
+				# deadline park below either. The turn would sit in-flight forever with the
+				# spinner up and no error. Park to `recovering` first (row 20, no deadline
+				# predicate — the budget already expired), THEN settle to errored. No
+				# intermediate run:recovering publish: the very next step is the terminal
+				# run:error, and a banner that flashes for one statement helps nobody.
+				if ts.mark_recovering(run_id, v):
+					frappe.db.commit()
+					v += 1
 				if _settle_recover_errored(run_id, v, conv, am, error=_STALLED_ERROR):
 					summary["errored"] += 1
 			elif r.get("deadline_at") and _expired(r.get("deadline_at"), now):

--- a/jarvis/chat/turn_state.py
+++ b/jarvis/chat/turn_state.py
@@ -875,7 +875,20 @@ def mark_recovering(
 	form. A pre-dispatch turn (pump_epoch=0, no gateway run) therefore is NOT parked
 	by an epoch-fenced pump park; reconcile-on-start / the watchdog reclaim it.
 	Caller publishes ``run:recovering`` fenced AFTER commit (SUX-1). Returns
-	won/lost. No commit."""
+	won/lost. No commit.
+
+	SUXF-2 — ``recovery_started_at`` is stamped ONCE PER EPISODE (``COALESCE``), never
+	pushed forward by a re-park. It is the clock ``pump._recovery_budget_exhausted``
+	measures ``RECOVERY_BUDGET_S`` against, and re-stamping it made that budget
+	UNREACHABLE: a turn whose gateway went away oscillates ``streaming ->`` (watchdog
+	deadline park) ``recovering ->`` (next hop ``recover_adopt``) ``streaming``, and
+	because the watchdog cron period is SHORTER than the budget, every cycle reset the
+	clock to now. The turn could then never reach ``errored`` — the customer kept the
+	reconnecting banner forever, with no error and no timeout, which is the whole bug.
+	``recover_adopt`` deliberately does NOT clear the field (adoption CONTINUES the
+	same in-flight run, so its recovery time must keep accruing); ``recover_to_queued``
+	DOES clear it, because a full re-queue drops the prepare refs and genuinely begins
+	a fresh episode."""
 	now = _now()
 	clauses = [
 		"name=%(r)s",
@@ -895,7 +908,8 @@ def mark_recovering(
 	return (
 		_run_cas(
 			f"""UPDATE `tab{TURN}`
-			SET state='recovering', recovering=1, recovery_started_at=%(now)s,
+			SET state='recovering', recovering=1,
+			    recovery_started_at=COALESCE(recovery_started_at, %(now)s),
 			    was_recovered=1, version=version+1
 			WHERE {where}""",
 			params,
@@ -911,11 +925,17 @@ def recover_to_queued(run_id: str, version: int) -> bool:
 	(``reserved=0``), NULL ``reservation_expires_at``, clear ``recovering``, DROP
 	stale prepare refs (``assistant_message``/``preparing_at``/``ready_at``) so it
 	re-prepares from scratch (session at-most-once absorbs the leak, OAR-4),
-	``version+1``. Returns won/lost. No commit."""
+	``version+1``. Returns won/lost. No commit.
+
+	SUXF-2: also CLEAR ``recovery_started_at``. The turn is going back to a fresh
+	prepare with no gateway run attached, so the recovery episode this budget was
+	measuring is genuinely over — pairing with ``mark_recovering``'s once-per-episode
+	``COALESCE`` stamp, which is what bounds the streaming/recovering oscillation."""
 	return (
 		_run_cas(
 			f"""UPDATE `tab{TURN}`
 			SET state='queued', recovering=0, reserved=0, reservation_expires_at=NULL,
+			    recovery_started_at=NULL,
 			    assistant_message=NULL, preparing_at=NULL, ready_at=NULL, version=version+1
 			WHERE name=%(r)s AND state='recovering' AND version=%(v)s AND dispatching_at IS NULL""",
 			{"r": run_id, "v": version},

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1038,6 +1038,115 @@ class TestSuxf1RecoveringMirror(_PipelineCase):
 		self.assertIn("run:error", self._pub_kinds())
 		self.assertEqual(int(self._val(rid, "reserved")), 0, "credit released")
 
+	def test_repark_after_adopt_still_reaches_terminal_error(self):
+		"""SUXF-2: the streaming/recovering oscillation must still hit the budget.
+
+		The customer-visible hang. The tenant's gateway container is bounced under a
+		live turn, so every hop re-adopts the turn to ``streaming`` and cannot reach the
+		run; the watchdog re-parks it each cycle on the (never re-stamped) expired
+		``deadline_at``. Because the watchdog cron period is SHORTER than
+		RECOVERY_BUDGET_S, a park that re-stamped ``recovery_started_at`` reset the
+		budget every cycle, so ``_recovery_budget_exhausted`` could never fire: the turn
+		never reached ``errored``, no ``run:error`` was ever published, and the SPA held
+		the reconnecting banner forever with no error and no timeout.
+		"""
+		conv = self._mk_conv()
+		rid = "pmp_suxf2_osc"
+		seed = self._mk_msg(conv)
+		amsg = self._mk_msg(conv, role="assistant", content="partial", streaming=1)
+		epoch = self._acquire_fresh("suxf2a")
+		episode_start = frappe.utils.add_to_date(None, seconds=-30)
+		self._mk_turn(
+			conv,
+			rid,
+			seed,
+			"streaming",
+			version=4,
+			pump_epoch=epoch,
+			reserved=1,
+			assistant_message=amsg,
+			dispatching_at=frappe.utils.now(),
+			deadline_at=frappe.utils.add_to_date(None, seconds=-5),  # soft deadline passed
+			recovery_started_at=episode_start,  # an episode is already under way
+		)
+		wd_deps = pump.PumpDeps()
+		wd_deps.enqueue_pump_job = _Recorder()
+
+		# Cycle 1: 60s budget is not spent yet (episode is 30s old), so the watchdog
+		# re-parks on the expired deadline rather than erroring.
+		with (
+			patch.object(pump, "RECOVERY_BUDGET_S", 60),
+			patch.object(pump, "pump_configured", return_value=True),
+		):
+			pump.watchdog(deps=wd_deps)
+		self.assertEqual(self._state(rid), "recovering")
+		self.assertEqual(
+			frappe.utils.get_datetime(self._val(rid, "recovery_started_at")),
+			frappe.utils.get_datetime(episode_start),
+			"the re-park must not restart the budget clock",
+		)
+
+		# The next hop adopts the turn back to streaming (recover_adopt keeps the
+		# episode clock, because this is the SAME in-flight run continuing).
+		self.assertTrue(ts.recover_adopt(rid, int(self._val(rid, "version")), epoch, "streaming"))
+		frappe.db.commit()
+		self.assertEqual(self._state(rid), "streaming")
+
+		# Cycle 2: the episode has now outlived the budget, so the turn must reach the
+		# terminal error UX instead of oscillating forever.
+		self._pubs.clear()
+		with (
+			patch.object(pump, "RECOVERY_BUDGET_S", 10),
+			patch.object(pump, "pump_configured", return_value=True),
+		):
+			pump.watchdog(deps=wd_deps)
+		self.assertEqual(self._state(rid), "errored")
+		row = frappe.db.get_value(MSG, amsg, ["streaming", "error"], as_dict=True)
+		self.assertEqual(int(row["streaming"]), 0, "the spinner must be taken down")
+		self.assertTrue(row["error"], "the user must get a visible error")
+		self.assertIn("run:error", self._pub_kinds())
+
+	def test_transport_budget_exhausted_parks_and_publishes_recovering(self):
+		"""SUXF-3: when the fast-retry budget proves the gateway is unreachable, park
+		the shard's in-flight turns AT ONCE instead of leaving a locked spinner with no
+		feedback until the per-turn deadline plus a watchdog tick."""
+		conv = self._mk_conv()
+		rid = "pmp_suxf3_park"
+		seed = self._mk_msg(conv)
+		amsg = self._mk_msg(conv, role="assistant", content="partial", streaming=1)
+		epoch = self._acquire_fresh("suxf3a")
+		self._mk_turn(
+			conv,
+			rid,
+			seed,
+			"streaming",
+			version=4,
+			pump_epoch=epoch,
+			reserved=1,
+			assistant_message=amsg,
+			dispatching_at=frappe.utils.now(),
+			# Deliberately NOT expired: today only the deadline park would fire, so a
+			# fresh turn stays a silent spinner for the whole soft-deadline window.
+			deadline_at=frappe.utils.add_to_date(None, seconds=600),
+		)
+		ctx = pump.PumpContext(
+			relay_target_id=self._target,
+			epoch=epoch,
+			holder="suxf3-holder",
+			hop_counter=1,
+			site=frappe.local.site,
+			deps=pump.PumpDeps(),
+		)
+		self._pubs.clear()
+		pump._schedule_successor_on_exit(ctx, transport_retry=pump.TRANSPORT_RETRY_MAX)
+		self.assertEqual(self._state(rid), "recovering")
+		self.assertIn("run:recovering", self._pub_kinds())
+		self.assertEqual(
+			int(frappe.db.get_value(MSG, amsg, "recovering")),
+			1,
+			"the Message mirror lets a reload rebuild the banner instead of a locked composer",
+		)
+
 	def test_db_disconnect_park_writes_mirror_and_publishes(self):
 		conv = self._mk_conv()
 		rid = "pmp_suxf1_db"

--- a/jarvis/tests/test_turn_state.py
+++ b/jarvis/tests/test_turn_state.py
@@ -965,6 +965,78 @@ class TestRecoveringSplit(_TurnStateTestCase):
 		frappe.db.commit()
 		self.assertEqual(self._state("ts_mrd"), "recovering")
 
+	def test_mark_recovering_stamps_recovery_start_once_per_episode(self):
+		"""SUXF-2: a RE-park must not push ``recovery_started_at`` forward.
+
+		This is the field ``pump._recovery_budget_exhausted`` measures
+		``RECOVERY_BUDGET_S`` against. A turn whose gateway went away oscillates
+		streaming -> (watchdog deadline park) recovering -> (next hop recover_adopt)
+		streaming, and the watchdog cron period is SHORTER than the budget, so
+		re-stamping the clock on every park made the budget unreachable: the turn could
+		never reach ``errored`` and the customer kept the reconnecting banner forever.
+		"""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		first_park = frappe.utils.add_to_date(None, seconds=-450)
+		self._mk_turn(
+			conv,
+			"ts_mr_ep",
+			seed,
+			"streaming",
+			version=3,
+			pump_epoch=2,
+			dispatching_at=frappe.utils.now(),
+			recovery_started_at=first_park,
+		)
+		self.assertTrue(ts.mark_recovering("ts_mr_ep", 3))
+		frappe.db.commit()
+		self.assertEqual(self._state("ts_mr_ep"), "recovering")
+		self.assertEqual(
+			frappe.utils.get_datetime(frappe.db.get_value(TURN, "ts_mr_ep", "recovery_started_at")),
+			frappe.utils.get_datetime(first_park),
+			"a re-park must keep the FIRST park's clock or the recovery budget never expires",
+		)
+
+	def test_mark_recovering_stamps_recovery_start_when_absent(self):
+		"""The first park of an episode still starts the clock (the COALESCE fallback)."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		self._mk_turn(
+			conv,
+			"ts_mr_new",
+			seed,
+			"streaming",
+			version=2,
+			pump_epoch=2,
+			dispatching_at=frappe.utils.now(),
+		)
+		self.assertIsNone(frappe.db.get_value(TURN, "ts_mr_new", "recovery_started_at"))
+		self.assertTrue(ts.mark_recovering("ts_mr_new", 2))
+		frappe.db.commit()
+		self.assertIsNotNone(frappe.db.get_value(TURN, "ts_mr_new", "recovery_started_at"))
+
+	def test_recover_to_queued_clears_recovery_start(self):
+		"""SUXF-2 pairing: a full re-queue drops the prepare refs, so that recovery
+		episode is genuinely over and the next park must start a fresh budget."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, 1)
+		self._mk_turn(
+			conv,
+			"ts_rq_clr",
+			seed,
+			"recovering",
+			version=6,
+			recovering=1,
+			recovery_started_at=frappe.utils.add_to_date(None, seconds=-120),
+		)
+		self.assertTrue(ts.recover_to_queued("ts_rq_clr", 6))
+		frappe.db.commit()
+		self.assertEqual(self._state("ts_rq_clr"), "queued")
+		self.assertIsNone(
+			frappe.db.get_value(TURN, "ts_rq_clr", "recovery_started_at"),
+			"a fresh prepare must not inherit the previous episode's budget clock",
+		)
+
 
 # --------------------------------------------------------------------------- #
 # Effect ledger: idempotency + force-done at 3 + all-done guard.


### PR DESCRIPTION
## Problem

Editing the LLM pool ("AI models") bounces the tenant's openclaw container. If a chat turn is in flight, the transport dies under it and the SPA sits on "Working on it..." / the reconnecting banner **forever**, with no error and no timeout.

The pump's recovery ladder looked complete, so I traced why it never converged. It is three defects on one path, and each one hides the next.

## Mechanism

**1. The recovery budget clock was reset on every re-park.**

`turn_state.mark_recovering` unconditionally set `recovery_started_at = now`. That is the field `pump._recovery_budget_exhausted` measures `RECOVERY_BUDGET_S` (600s) against, and the watchdog cron period is 300s. `recover_adopt` puts an adopted turn back to `streaming` without clearing the field, and `deadline_at` is never re-stamped, so a turn whose gateway is gone oscillates:

```
streaming -> (watchdog deadline park) recovering -> (next hop recover_adopt) streaming -> ...
```

Every 300s cycle re-parked it and pushed the 600s clock forward, so `_recovery_budget_exhausted` could never fire. The turn never reached `errored`, `run:error` was never published, and the banner stayed up forever.

Fix: stamp `recovery_started_at` once per episode via `COALESCE`, and clear it in `recover_to_queued`, where a full re-queue drops the prepare refs and genuinely begins a fresh episode. `recover_adopt` deliberately keeps it, because adoption continues the same in-flight run and its recovery time must keep accruing.

**2. Preserving the clock exposed a dead transition.**

With the clock no longer reset, an in-flight turn now reaches the watchdog already over budget. The `ready|dispatching|streaming|terminal_observed` branch called `_settle_recover_errored`, which wraps `recover_errored`, D2 row 24, guarded `state='recovering'`. On an in-flight state that CAS matches 0 rows, and because it is the leading `if`, it also blocked the `elif` deadline park below it. So the turn sat in-flight forever. Fix 1 alone would have swapped one permanent hang for another.

Fix: park to `recovering` first (row 20, no deadline predicate, the budget already expired) and then settle to `errored`.

**3. A provably dead gateway was still surfaced lazily.**

`_schedule_successor_on_exit` exhausting `TRANSPORT_RETRY_MAX` released the lease and returned silently, leaving discovery to the watchdog's per-turn `deadline_at`. So even on the healthy path the customer got a locked spinner with zero feedback for up to the soft-deadline window plus a cron tick, while the gateway was already known unreachable.

Fix: park the shard's in-flight turns at the moment the budget proves the gateway is gone, before the lease release so the CDX-24 epoch fence still holds (the same ordering `_halt_for_kill_switch` uses), and publish `run:recovering` immediately.

## Result

The customer gets the interrupted banner with an unlocked composer inside the fast-retry window, and a real terminal error once the recovery budget expires. This covers **any** sustained mid-run transport loss, not only a config-apply container bounce.

## Tests

Four tests, all red before the change:

- `test_mark_recovering_stamps_recovery_start_once_per_episode` and `test_recover_to_queued_clears_recovery_start` pin the clock semantics. The first previously failed showing the clock pushed forward by exactly one watchdog period.
- `test_repark_after_adopt_still_reaches_terminal_error` drives the full park / adopt / re-park loop across two watchdog cycles and asserts the turn reaches `errored`, the Message row drops `streaming`, and `run:error` is published.
- `test_transport_budget_exhausted_parks_and_publishes_recovering` asserts the transport-budget park with a deliberately unexpired deadline, so it fails today.

Caveat worth stating: these stub the transport, so they assert this plane's intent and cannot catch gateway-side behaviour. The gateway-side half of this bug is the fleet agent bouncing the container at all, filed separately.

Local: `test_pump`, `test_turn_state`, `test_pump_pipeline`, `test_turn_recovery`, `test_chat_worker`, `test_relay_mux`, `test_chat_admission` all green. Hosted CI is the gate.

https://claude.ai/code/session_015kFVKdpkN6uMTgZDCm2LJ5