### PR TITLE
fix(auth): drop the cached bearer when the bench's credentials change

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1299,6 +1299,14 @@ def _oauth_token_request(admin_url: str, grant: dict) -> dict | None:
 	return token
 
 
+def clear_cached_token() -> None:
+	"""Drop the cached bearer. Anything that rotates this bench's admin credentials
+	MUST call it: the cached token was minted from the old ones, stays valid for its
+	full TTL, and keeps authenticating as the PREVIOUS account - so a reconnected
+	bench asks about a customer it no longer is and sits on "still being set up"."""
+	frappe.cache().delete_value(_OAUTH_CACHE_KEY)
+
+
 def _cache_oauth_token(token: dict) -> None:
 	ttl = int(token.get("expires_in") or 0)
 	if ttl <= 0:

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -112,6 +112,10 @@ def write_connection(data: dict) -> None:
 		s.db_set("agent_url", data["agent_url"])
 	if data.get("agent_token"):
 		set_settings_password(s, "agent_token", data["agent_token"])
+	# Credentials just changed (fresh signup, or a reconnect rotating onto another
+	# account): a bearer minted from the old ones would outlive them.
+	if any(data.get(k) for k in ("api_key", "api_secret", "customer", "customer_password")):
+		admin_client.clear_cached_token()
 	# NB: the release notice is deliberately NOT mirrored here. Several callers
 	# pass a partial payload (a password, a customer email), and an absent notice
 	# key means "cleared" - which would drop a live notice. It is persisted only

--- a/jarvis/settings_reset.py
+++ b/jarvis/settings_reset.py
@@ -112,6 +112,12 @@ def apply(settings, spec: ResetSpec) -> None:
 		settings.db_set(field, meta.get_field(field).default)
 	for field, value in spec.literals:
 		settings.db_set(field, value)
+	if spec.passwords:
+		# A reset that leaves a cached bearer behind is not a reset: the token
+		# outlives the credentials it was minted from.
+		from jarvis.admin_client import clear_cached_token
+
+		clear_cached_token()
 	if spec.clear_pool:
 		frappe.db.delete(
 			"Jarvis LLM Pool Model",

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -977,3 +977,50 @@ class TestAccountReconnect(FrappeTestCase):
 		):
 			out = onboarding.check_account_reconnect("rid-x")
 		self.assertEqual(out["status"], "expired")
+
+
+class TestCredentialChangeBustsTheTokenCache(FrappeTestCase):
+	"""A cached bearer outlives the credentials it was minted from. Reconnecting a
+	bench onto another account left it calling admin as the PREVIOUS customer -
+	which reports no subscription and no tenant, so the wizard sat on "still being
+	set up" while everything server-side looked healthy."""
+
+	def setUp(self):
+		from jarvis import admin_client
+
+		frappe.cache().set_value(
+			admin_client._OAUTH_CACHE_KEY,
+			{"access_token": "stale-from-the-old-account", "access_expires_at": 9999999999},
+		)
+
+	def tearDown(self):
+		from jarvis import admin_client
+
+		frappe.cache().delete_value(admin_client._OAUTH_CACHE_KEY)
+
+	def _cached(self):
+		from jarvis import admin_client
+
+		return frappe.cache().get_value(admin_client._OAUTH_CACHE_KEY)
+
+	def test_writing_a_new_login_drops_the_cached_token(self):
+		onboarding.write_connection({"customer": "cust-newaccount@jarvis.invalid"})
+		self.assertIsNone(self._cached())
+
+	def test_writing_a_new_password_drops_the_cached_token(self):
+		onboarding.write_connection({"customer_password": "s3cret"})
+		self.assertIsNone(self._cached())
+
+	def test_writing_api_keys_drops_the_cached_token(self):
+		onboarding.write_connection({"api_key": "k", "api_secret": "s"})
+		self.assertIsNone(self._cached())
+
+	def test_a_payload_with_no_credentials_leaves_it_alone(self):
+		onboarding.write_connection({"agent_url": "ws://127.0.0.1:19999"})
+		self.assertIsNotNone(self._cached(), "an agent_url refresh is not a credential change")
+
+	def test_reset_onboarding_drops_it_too(self):
+		from jarvis.dev import reset_onboarding
+
+		reset_onboarding()
+		self.assertIsNone(self._cached())


### PR DESCRIPTION
## Reported

A reconnected bench sat on **"Setting up your workspace"** indefinitely. Nothing failed, nothing retried, no error anywhere — server-side the tenant was `Running` and `Ready`.

## Cause

`_token()` serves a cached access token until it expires and never exercises the stored credentials. `write_connection` can rotate the login underneath it — which is exactly what a reconnect does — so the bench keeps using a bearer minted for the **previous account** for the rest of that token's TTL.

That previous account has no subscription and no tenant, so `get_connection` truthfully answers `tenant_status: pending`, `subscription_status: none`. The bench polls forever, asking about a customer it no longer is.

Caught on `jarvis.local`:

```
Jarvis Settings.jarvis_admin_customer_email : cust-43r5e4qbnk@jarvis.invalid
cached OAuth Bearer Token belongs to        : cust-qioh31d290@jarvis.invalid
```

Clearing the cache key alone fixed it instantly — `sync_connection` went from `{"synced": false, "tenant_status": "pending"}` to `{"synced": true, "tenant_status": "Running"}` with no other change.

## Fix

`admin_client.clear_cached_token()`, called wherever credentials change:

- **`write_connection`** — when the payload carries any of `api_key`, `api_secret`, `customer`, `customer_password`. An `agent_url`-only refresh deliberately leaves the cache alone.
- **`settings_reset.apply`** — any spec that clears password fields. A reset that leaves a live bearer behind isn't a reset; the token outlives the credentials it came from.

## Tests

5 cases in `test_onboarding_sync`: each credential-bearing payload drops the cache, an `agent_url` refresh does not, and `reset_onboarding` drops it too. The three write_connection cases **fail without the fix** (verified by disabling it and re-running).

53 `test_onboarding_sync`, 7 `test_dev`, 59 `test_admin_client` green.

## Note

This also explains an earlier symptom I had attributed to a container re-provision: after the first reconnect on another site, the wizard hung on the same spinner. Same stale-token window, same silence.