### PR TITLE
fix(chat): stop prefix prewarm from burning the tenant's own LLM quota

### DIFF
--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -126,9 +126,13 @@ def list_conversations() -> list[dict]:
 	reuses the hidden empty row.
 	"""
 	require_jarvis_access()
-	# Chat page loaded: warm the openclaw prefix cache in the background
+	# Chat surface loaded: warm the openclaw prefix cache in the background
 	# (best-effort, debounced) so the first turn of a new chat skips the cold
-	# provider prefill. Never blocks or fails this read.
+	# provider prefill. Never blocks or fails this read. Since #548 this is the
+	# ONLY prewarm trigger, and it is deliberately a load-correlated one: a warm
+	# is a billed upstream request against the tenant's own quota. The several
+	# call sites that reload this list AFTER a send are absorbed by prewarm's own
+	# "the prefix is already hot" guard, not by anything here.
 	from jarvis.chat import prewarm
 
 	prewarm.enqueue_warm_if_due()
@@ -1661,14 +1665,19 @@ def set_conversation_model(conversation: str, model: str | None = None) -> dict:
 @frappe.whitelist()
 def warm_session() -> dict:
 	"""Fire-and-forget: warm this tenant's openclaw prefix cache so the next
-	new-chat first turn skips the cold prefill. Best-effort; always ok. The
-	chat UI calls this on open. Unconfigured benches no-op.
-	Runs in a background RQ job so the gunicorn web worker is not blocked."""
+	new-chat first turn skips the cold prefill. Best-effort; always ok.
+	Unconfigured benches no-op. Runs in a background RQ job so the gunicorn web
+	worker is not blocked.
+
+	Goes through ``enqueue_warm_if_due`` rather than enqueuing ``warm_prefix``
+	directly (#548). A warm is a billed upstream request against the tenant's own
+	quota, and enqueuing unconditionally let any authenticated Jarvis user turn N
+	calls to this endpoint into N short-queue jobs. The cooldown claim inside
+	``warm_prefix`` bounds the SPEND either way; this bounds the jobs too."""
 	require_jarvis_access()
-	frappe.enqueue(
-		"jarvis.chat.prewarm.warm_prefix",
-		queue="short",
-	)
+	from jarvis.chat import prewarm
+
+	prewarm.enqueue_warm_if_due()
 	return {"ok": True, "enqueued": True}
 
 

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -1,12 +1,68 @@
-"""Best-effort pre-warming of the openclaw container's OpenAI prefix cache.
+"""Best-effort pre-warming of the openclaw container's provider prefix cache.
 
-The first turn of a fresh session pays a cold provider prefill over the
-large static system prefix (persona + skills + tool schema). That cache is
-prefix-keyed and container-wide, so one cheap throwaway agent turn warms it
-for every subsequent new chat in the same container. We never touch the
-user's real session or write chat rows. Always best-effort; never raises.
+The first turn of a fresh session pays a cold provider prefill over the large
+static system prefix (persona + skills + tool schema). That cache is
+prefix-keyed and container-wide, so one cheap throwaway agent turn warms it for
+every subsequent new chat in the same container. We never touch the user's real
+session or write chat rows. Always best-effort; never raises.
+
+WHAT A WARM COSTS (issue #548)
+------------------------------
+A warm is a real upstream ``agent`` run billed to the TENANT'S OWN credential.
+There is no mode in which the operator pays: ``llm_auth_mode`` is api_key /
+subscription / oauth and all three are the customer's. So a warm can never be
+cost-neutral, only cost-traded-for-latency:
+
+  without prewarm  the first turn pays a full prefix, later turns pay the
+                   provider's discounted cached rate
+  with prewarm     the warm pays a full prefix, and then EVERY turn pays the
+                   cached rate
+
+which is strictly more spend per cycle when a turn does follow, and one wholly
+wasted prefix when none does. This app fired 528 warms against 86 real turns on
+jarvis.proxy (six paid warm-ups per turn) and exhausted a free-tier Gemini key
+that real chat turns then 429'd on.
+
+So the only defensible trigger is one correlated with a user about to send a
+first message into a plausibly-cold container, firing at most once per arrival.
+Hence, as of #548:
+
+- ONE trigger: the chat-surface load (``enqueue_warm_if_due``, called from
+  ``list_conversations``). Two were removed.
+  * The ``*/5`` ``keep_warm_if_active`` cron. Its gate ("any chat message in
+    the last 30 minutes") was INVERTED with respect to its own purpose: recent
+    chat traffic is exactly what keeps the provider cache warm for free, so the
+    cron spent up to seven paid warms per burst of activity precisely when
+    warming was worthless, and no-opped on the idle benches where a cold prefix
+    is actually possible. A timer also cannot know a turn is coming, which is
+    the whole premise of warming.
+  * The ``on_session_creation`` login warm. It billed a request for every login
+    to the site, including desk and API logins by users who never open chat, to
+    buy a sub-second head start on a multi-second prefill that the chat-surface
+    load already starts.
+- A warm is SKIPPED while the prefix is already hot (``_prefix_recently_used``).
+  That is what stops the SPA's post-send list refreshes from billing warms into
+  a session whose own turns keep the prefix warm: sixteen call sites reach
+  ``list_conversations``, several of them after every single send.
+- The cooldown is claimed ATOMICALLY (``_claim_warm_slot``). The get-then-set it
+  replaces spanned a ``Jarvis Settings`` load, and two warms were observed
+  passing it 6ms apart on jarvis-pool-bf4097.
+
+NOT MEASURED
+------------
+No benefit number exists for any of this, and #548 is the right place to say so
+rather than to keep implying one. The turn telemetry line records no warm/cold
+state and no cached-token count, so ``first_delta_ms`` cannot be split by prefix
+state even in principle; the Stage-A/B harnesses run against a FakeGateway, so
+their ``warm_session`` measures nothing about provider caching; and "watch
+warm-turn token spend after this change" (commit 1017f3ab, which tripled the
+frequency) was never done - ``fire_ms`` below times the WS round trip, not the
+LLM work. Until a warm-vs-cold ``first_delta_ms`` split exists, treat the one
+remaining trigger as unproven and keep its volume proportional to real use.
+``jarvis_prefix_prewarm: 0`` in site_config turns it off entirely.
 """
 
+import pickle
 import time
 import uuid
 
@@ -15,23 +71,41 @@ import frappe
 from jarvis.chat.openclaw_client import OpenclawSession, oneshot_run_id
 from jarvis.chat.session_lifecycle import reclaim_throwaway_session
 
-# Cooldown between warm-ups for one bench. 2026-07 latency plan, Phase
-# 1.4: was 25 min, which is LONGER than the providers' prompt-cache
-# retention (OpenAI evicts after ~5-10 min of inactivity; Gemini implicit
-# caching is similar or shorter) — so for most of each half-hour the
-# cooldown key said "warm" while the provider cache had already cooled,
-# and the first turn ate a cold prefill anyway. 4 min keeps every warm
-# inside the retention window; paired with the */5 keep_warm cron so each
-# tick re-warms. Watch warm-turn token spend after this change.
+# Ceiling on how often the one remaining trigger can bill a warm for one bench.
+# 4 min sits inside the shortest documented provider retention (OpenAI evicts a
+# prompt cache after ~5-10 min idle; Anthropic's default ephemeral TTL is 5
+# min), so a chat-surface load that finds the cooldown lapsed is always looking
+# at a plausibly-cold cache. It is a CEILING, not a schedule: nothing re-warms
+# on a timer any more (#548). Note the retention figure is unverifiable for the
+# provider that actually blew the quota - Gemini's IMPLICIT cache has no
+# documented TTL - so do not read "4 min is inside the window" as measured.
 _WARM_COOLDOWN_S = 4 * 60
 
-# Short in-progress TTL set BEFORE the slow connect so concurrent opens
-# cannot fan out into concurrent warm-ups. Expires quickly on failure
-# so a failed warm retries soon rather than blocking for the full cooldown.
-# Accepted best-effort SET race: two concurrent callers may both pass
-# get_value before either sets this key; the second warm is harmless
-# (#6 accepted best-effort).
+# Short in-progress TTL claimed BEFORE any slow work so a burst of chat-surface
+# loads cannot fan out into concurrent billed warm-ups. Expires quickly on
+# failure so a failed warm retries soon rather than blocking for the full
+# cooldown. Claimed atomically - see _claim_warm_slot.
 _WARM_INPROGRESS_S = 90
+
+# A real chat turn warms this container-wide prefix far better than a throwaway
+# does, so a warm within _RECENT_TURN_S of one is pure spend. Two minutes is
+# comfortably inside every documented retention floor, and it is the window the
+# SPA's post-send list refreshes land in - the amplifier behind the six-warms-
+# per-turn ratio in #548. This is the INVERSE of the gate the deleted keep-warm
+# cron used, which is precisely what was wrong with it.
+_RECENT_TURN_S = 120
+
+# Explicit falsy site_config values that turn prewarming OFF. Absence is NEVER
+# one of them: prewarming has always been on, so only an operator writing the
+# key can disable it. Same absent-vs-explicit-0 shape as `jarvis_pump_enabled`
+# ("0" is a truthy Python string, which is why this set exists).
+_PREWARM_CONF_KEY = "jarvis_prefix_prewarm"
+_EXPLICIT_OFF_VALUES = frozenset({"0", "false", "no", "off", ""})
+
+# The cooldown marker, pickled so frappe's get_value/set_value still read and
+# write it. The atomic claim below bypasses set_value for atomicity, not to
+# change the stored format.
+_CLAIM_VALUE = pickle.dumps("1")
 
 
 # The previous warm's session key AND the moment its turn was fired, remembered
@@ -48,6 +122,76 @@ def _warm_cooldown_key() -> str:
 
 def _warm_last_key() -> str:
 	return f"jarvis:chat:prefix_warm:last:{frappe.local.site}"
+
+
+def _prewarm_enabled() -> bool:
+	"""Is prefix prewarming switched on for this site?
+
+	Deliberately an OPERATOR site_config flag and NOT a per-tenant opt-in field.
+	Every tenant is BYO - api_key, subscription and oauth all charge the customer
+	- so a per-tenant toggle would be asking each customer to answer a question
+	nobody has data for (see NOT MEASURED above). Measure the warm-vs-cold
+	first_delta_ms split first; until then the honest position is a volume
+	proportional to real use, plus an off switch for a tenant whose quota is
+	tight enough to matter.
+	"""
+	flag = frappe.conf.get(_PREWARM_CONF_KEY)
+	if flag is None:
+		return True
+	return str(flag).strip().lower() not in _EXPLICIT_OFF_VALUES
+
+
+def _claim_warm_slot(cache, key: str, ttl_s: int) -> bool:
+	"""Atomically take the right to warm. True for exactly ONE of N callers.
+
+	``get_value`` then ``set_value`` cannot express this. The window between the
+	two spanned a ``Jarvis Settings`` load (a DB round trip), and two warms were
+	observed passing it 6ms apart on jarvis-pool-bf4097 - each one a billed
+	upstream request against the tenant's own key, and the second one also the
+	trigger for the #535 reclaim race. ``SET NX EX`` collapses the read and the
+	write into one Redis round trip, so a burst produces exactly one warm.
+
+	Raises on a Redis outage, which callers turn into "no warm". Failing CLOSED
+	is the right side to fail on for work that spends the customer's money.
+
+	``set`` is plain redis-py, so the site prefix has to be applied by hand -
+	unlike ``exists`` below, which frappe overrides to do it for you.
+	"""
+	return bool(cache.set(cache.make_key(key), _CLAIM_VALUE, ex=ttl_s, nx=True))
+
+
+def _warm_slot_held(cache, key: str) -> bool:
+	"""Is a cooldown or an in-flight warm already holding the slot?
+
+	``exists`` rather than ``get_value`` so the answer can never come from
+	``frappe.local.cache``, which the atomic claim above does not populate.
+	Frappe's override applies ``make_key`` itself, so the key is passed raw.
+	"""
+	return bool(cache.exists(key))
+
+
+def _prefix_recently_used() -> bool:
+	"""Did a real chat turn touch this container's prefix within
+	``_RECENT_TURN_S``? Then the provider cache is warm and a throwaway warm buys
+	a bill and nothing else.
+
+	One indexed EXISTS - frappe gives every non-child table an index on
+	``creation`` - and it runs in the background job, never on the web request.
+	"""
+	cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=-_RECENT_TURN_S)
+	return bool(frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]}))
+
+
+def _log_skip(reason: str) -> None:
+	"""Record a skipped warm on the same logger as a fired one.
+
+	The six-warms-per-turn ratio in #548 was only measurable because the fire
+	logged; the skips did not, so nobody could see what share of the volume was
+	avoidable. With both on one file the paid-warm rate is readable directly.
+	"""
+	from jarvis.chat.latency import get_logger as _get_latency_logger
+
+	_get_latency_logger().info("warm_prefix skipped reason=%s", reason)
 
 
 def _previous_pointer(prev) -> tuple[str, float | None]:
@@ -127,13 +271,34 @@ def _resolve_default_model_and_provider(settings) -> tuple[str, str | None]:
 
 
 def warm_prefix() -> bool:
-	"""Fire one throwaway warm-up turn for this bench's container. Returns
-	True if a warm-up was fired, False if skipped (debounced, not
-	configured) or on any error. Never raises."""
+	"""Fire one throwaway warm-up turn for this bench's container.
+
+	Returns True only when an upstream run was actually fired. False when it was
+	skipped - switched off, the slot already claimed, the prefix already hot from
+	a real turn, or the bench unconfigured - and on any error. Never raises.
+
+	Every False is a billed request NOT sent against the tenant's own quota,
+	which is why the skips are logged (``_log_skip``) rather than silent."""
 	try:
+		if not _prewarm_enabled():
+			return False
 		cache = frappe.cache()
 		key = _warm_cooldown_key()
-		if cache.get_value(key):
+		# Claim the slot BEFORE any slow work: the claim is the only thing
+		# standing between a burst of chat-surface loads and a burst of billed
+		# upstream runs, so nothing that can take milliseconds may precede it.
+		# On any exception below, the short marker expires in
+		# _WARM_INPROGRESS_S and warming retries soon; the full cooldown is
+		# armed only when there was nothing to do or the warm landed, so a
+		# transient blip never disables warming for the whole cooldown.
+		if not _claim_warm_slot(cache, key, _WARM_INPROGRESS_S):
+			return False
+		if _prefix_recently_used():
+			# Already hot from a real turn. Nothing failed, there is simply
+			# nothing worth paying for until the cache could have cooled, so
+			# arm the full cooldown rather than the short in-flight marker.
+			cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
+			_log_skip("recent_turn")
 			return False
 		settings = frappe.get_single("Jarvis Settings")
 		# OpenclawSession.connect authenticates via device pairing
@@ -141,14 +306,8 @@ def warm_prefix() -> bool:
 		# agent_token is empty on managed/device-paired benches.
 		gateway_url = _gateway_ws_url(settings)
 		if not gateway_url:
+			_log_skip("not_configured")
 			return False
-		# Set a short in-progress marker BEFORE the slow connect so a burst
-		# of opens (or a broken gateway) cannot fan out into concurrent
-		# warm-ups. On any exception this short marker expires in
-		# _WARM_INPROGRESS_S, allowing a retry soon. The full cooldown is
-		# only set after a successful warm so a transient blip does not
-		# disable warming for 25 min.
-		cache.set_value(key, "1", expires_in_sec=_WARM_INPROGRESS_S)
 		model, provider = _resolve_default_model_and_provider(settings)
 		t0 = time.monotonic()
 		sess = OpenclawSession.connect(gateway_url)
@@ -191,13 +350,17 @@ def warm_prefix() -> bool:
 		finally:
 			sess.close()
 		# Latency telemetry (plan Phase 0): connect+create+fire duration, as
-		# measured above before the reclaim. (fire_agent is fire-and-forget, so
-		# this does NOT include the prefill itself — cold-vs-warm shows up in
-		# real turns' first_delta_ms, logged by turn_handler.)
+		# measured above before the reclaim. fire_agent is fire-and-forget, so
+		# this is the WS round trip and NOT the prefill - it says nothing about
+		# what the warm bought. Turns log first_delta_ms but carry no warm/cold
+		# marker, so the two cannot be joined; that missing marker is why #548
+		# could price this feature's cost and not its benefit.
 		from jarvis.chat.latency import get_logger as _get_latency_logger
 
 		_get_latency_logger().info("warm_prefix fire_ms=%d", fire_ms)
-		# Warm succeeded: arm the full cooldown so the next cron tick skips.
+		# Warm landed: extend the short claim to the full cooldown, which is now
+		# a spend ceiling for the chat-surface trigger rather than a handshake
+		# with a cron tick.
 		cache.set_value(key, "1", expires_in_sec=_WARM_COOLDOWN_S)
 		return True
 	except Exception:
@@ -205,43 +368,24 @@ def warm_prefix() -> bool:
 		return False
 
 
-def keep_warm_if_active() -> None:
-	"""Scheduler entry: keep the prefix cache warm for benches with recent
-	chat activity, so a returning user's first turn is warm after an idle
-	gap. No-op on idle benches. Runs on the existing scheduler; the per-bench
-	debounce in warm_prefix bounds frequency."""
-	try:
-		cutoff = frappe.utils.add_to_date(frappe.utils.now_datetime(), minutes=-30)
-		recent = frappe.db.exists("Jarvis Chat Message", {"creation": [">", cutoff]})
-		if not recent:
-			return
-		warm_prefix()
-	except Exception:
-		frappe.logger("jarvis.chat.prewarm").debug("keep_warm skipped", exc_info=True)
+def enqueue_warm_if_due() -> None:
+	"""Warm on chat-surface load: the ONE prewarm trigger (#548).
 
+	Called from ``list_conversations``, which every chat surface hits on load, so
+	the first turn of a new chat gets a warm prefix without a frontend change.
+	Just a cheap Redis existence check on the request path - the connect + warm
+	runs off the web worker, and ``warm_prefix`` re-checks everything atomically,
+	so this read only avoids pointless jobs and is never the guard. Best-effort,
+	never raises.
 
-def warm_on_login(login_manager=None) -> None:
-	"""``on_session_creation`` hook (2026-07 latency plan, Phase 1.4): start
-	warming as soon as anyone logs in, before the chat page even loads —
-	the warm-up has the whole page-load window to land. Same debounced
-	enqueue as the chat-load trigger, so non-chat logins cost one cache
-	read. Best-effort, never raises (a hook failure must never block login).
+	There is deliberately no timer and no login hook behind this any more: a
+	trigger uncorrelated with an imminent first message spends the customer's
+	quota for nothing (see the module docstring).
 	"""
 	try:
-		enqueue_warm_if_due()
-	except Exception:
-		pass
-
-
-def enqueue_warm_if_due() -> None:
-	"""Warm-on-chat-load: enqueue a prefix warm-up in a background job if the
-	per-bench cooldown has lapsed. Called from list_conversations (which every
-	chat surface hits on load), so the first turn of a new chat gets a warm
-	prefix without a frontend change. Just a cheap cache read on the request
-	path - the connect + warm runs off the web worker. Best-effort, never
-	raises, and debounced so repeated calls do not fan out into jobs."""
-	try:
-		if frappe.cache().get_value(_warm_cooldown_key()):
+		if not _prewarm_enabled():
+			return
+		if _warm_slot_held(frappe.cache(), _warm_cooldown_key()):
 			return
 		frappe.enqueue("jarvis.chat.prewarm.warm_prefix", queue="short")
 	except Exception:

--- a/jarvis/chat/prewarm.py
+++ b/jarvis/chat/prewarm.py
@@ -287,10 +287,16 @@ def warm_prefix() -> bool:
 		# Claim the slot BEFORE any slow work: the claim is the only thing
 		# standing between a burst of chat-surface loads and a burst of billed
 		# upstream runs, so nothing that can take milliseconds may precede it.
-		# On any exception below, the short marker expires in
-		# _WARM_INPROGRESS_S and warming retries soon; the full cooldown is
-		# armed only when there was nothing to do or the warm landed, so a
-		# transient blip never disables warming for the whole cooldown.
+		#
+		# The claim's own TTL is the SHORT one, and only two exits below extend
+		# it to the full cooldown: a warm that landed, and a prefix already hot.
+		# Everything else - an exception, or a bench with no gateway configured -
+		# keeps the 90s, so a transient blip retries in 90s instead of disabling
+		# warming for the whole cooldown, and a bench that becomes configured
+		# mid-onboarding starts warming within 90s rather than four minutes.
+		# Those exits spend nothing, so a retry costs one job and one Settings
+		# read; the thing worth throttling hard is a FIRED warm, not a skipped
+		# one.
 		if not _claim_warm_slot(cache, key, _WARM_INPROGRESS_S):
 			return False
 		if _prefix_recently_used():

--- a/jarvis/hooks.py
+++ b/jarvis/hooks.py
@@ -228,9 +228,13 @@ website_redirects = [
 # Session hooks
 # --------------
 
-# 2026-07 latency plan, Phase 1.4: kick off a (debounced) prefix warm-up on
-# login so the provider prompt cache is warm before the chat page even loads.
-on_session_creation = ["jarvis.chat.prewarm.warm_on_login"]
+# No prefix warm-up on login (removed in #548). It billed an upstream LLM
+# request against the tenant's own quota for EVERY login to the site, including
+# desk and API logins by users who never open chat, to buy a sub-second head
+# start on a prefill the chat-surface load already begins. The chat-surface load
+# (jarvis.chat.prewarm.enqueue_warm_if_due, from list_conversations) is now the
+# only prewarm trigger. Do not add a login hook or a timer back without a
+# measured warm-vs-cold first_delta_ms split - see jarvis/chat/prewarm.py.
 
 # A fresh install runs THIS and never after_migrate, so anything a day-1 site
 # needs that DocType sync does not produce has to be seeded here: the roles no
@@ -295,12 +299,13 @@ scheduler_events = {
 			# mid-reset, pull the new container's connection once admin reports
 			# Ready (same shape as reconcile_pending_llm_sync above).
 			"jarvis.onboarding.reconcile_pending_workspace_reset",
-			# 2026-07 latency plan, Phase 1.4: was */30, which left the
-			# provider prompt cache (5-10 min retention) cold for most of
-			# each half-hour. Every 5 min + a 4-min cooldown in prewarm.py
-			# keeps the prefix warm continuously while there is recent chat
-			# activity (the function itself gates on activity).
-			"jarvis.chat.prewarm.keep_warm_if_active",
+			# NO periodic prefix keep-warm here (removed in #548). Every tick
+			# billed an upstream LLM request against the tenant's own quota,
+			# and its activity gate was inverted: it fired only when chat
+			# traffic had ALREADY warmed the provider cache for free, and
+			# no-opped on the idle benches where a cold prefix is possible.
+			# A timer cannot know a turn is coming, which is the premise of
+			# warming, so it has no correct interval - not a shorter one.
 			# Chat-concurrency CDX-19 backstop: re-attempt macro runs parked in
 			# `waiting_capacity` (a step could not be admitted because the site's turn
 			# queue was momentarily full). A deferred step dispatches no turn, so the

--- a/jarvis/tests/test_chat_api.py
+++ b/jarvis/tests/test_chat_api.py
@@ -897,11 +897,17 @@ class TestChatUiSettings(FrappeTestCase):
 
 
 class TestWarmSessionEndpoint(FrappeTestCase):
+	def tearDown(self):
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+
 	def test_warm_session_enqueues_not_inline(self):
 		"""warm_session must enqueue warm_prefix as a background job and
 		return immediately - proves FIX D (non-blocking web worker)."""
-		from jarvis.chat import api
+		from jarvis.chat import api, prewarm
 
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
 		with patch("frappe.enqueue") as enqueue, patch("jarvis.chat.prewarm.warm_prefix") as wp:
 			out = api.warm_session()
 
@@ -912,6 +918,20 @@ class TestWarmSessionEndpoint(FrappeTestCase):
 		)
 		# warm_prefix must NOT have been called inline in the web worker.
 		wp.assert_not_called()
+		self.assertEqual(out, {"ok": True, "enqueued": True})
+
+	def test_warm_session_respects_the_cooldown(self):
+		"""#548: a warm is a billed upstream request against the tenant's own
+		quota, so this endpoint must go through the same cooldown as the
+		chat-surface trigger. It used to enqueue unconditionally, which let any
+		authenticated Jarvis user turn N calls into N short-queue jobs."""
+		from jarvis.chat import api, prewarm
+
+		frappe.cache().set_value(prewarm._warm_cooldown_key(), "1", expires_in_sec=60)
+		with patch("frappe.enqueue") as enqueue:
+			out = api.warm_session()
+
+		enqueue.assert_not_called()
 		self.assertEqual(out, {"ok": True, "enqueued": True})
 
 

--- a/jarvis/tests/test_pinned_oneshot_runs.py
+++ b/jarvis/tests/test_pinned_oneshot_runs.py
@@ -211,6 +211,10 @@ class TestOneShotsMintPinnedRunIds(FrappeTestCase):
 		with (
 			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
 			patch("jarvis.chat.prewarm.frappe.get_single", return_value=settings),
+			# warm_prefix skips outright when a real turn ran in the last couple
+			# of minutes (#548) and a suite run leaves Jarvis Chat Message rows
+			# behind. This test is about the run id, not that guard.
+			patch.object(prewarm, "_prefix_recently_used", return_value=False),
 		):
 			OC.connect.return_value = sess
 			self.assertTrue(prewarm.warm_prefix())

--- a/jarvis/tests/test_prewarm.py
+++ b/jarvis/tests/test_prewarm.py
@@ -56,6 +56,20 @@ class TestWarmPrefix(FrappeTestCase):
 		s.llm_provider = "OpenAI"
 		return s
 
+	def setUp(self):
+		"""Pin "the prefix is cold" for the tests in this class.
+
+		warm_prefix now skips outright when a real turn ran within
+		_RECENT_TURN_S (#548), and a suite run creates Jarvis Chat Message rows
+		seconds before these tests - which would make every one of them assert
+		the new guard instead of the behaviour it was written for. The guard is
+		asserted for real in TestPrefixAlreadyWarm, which does not patch it."""
+		from jarvis.chat import prewarm
+
+		cold = patch.object(prewarm, "_prefix_recently_used", return_value=False)
+		cold.start()
+		self.addCleanup(cold.stop)
+
 	def tearDown(self):
 		from jarvis.chat import prewarm
 
@@ -280,13 +294,13 @@ class TestWarmPrefix(FrappeTestCase):
 		self.assertTrue(fired, "warm_prefix must fire even with empty agent_token")
 
 	def test_warm_prefix_failure_does_not_arm_full_cooldown(self):
-		"""A failed connect must set only the short in-progress marker,
-		not the full cooldown. Proves FIX B: transient failures retry soon
-		instead of being disabled for 25 min."""
+		"""A failed connect must leave only the short in-progress claim, not the
+		full cooldown. Proves FIX B: transient failures retry soon instead of
+		being disabled for the whole cooldown."""
 		from jarvis.chat import prewarm
 
 		cache_mock = MagicMock()
-		cache_mock.get_value.return_value = None  # not debounced
+		cache_mock.set.return_value = True  # the atomic claim is won
 
 		with (
 			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
@@ -298,20 +312,13 @@ class TestWarmPrefix(FrappeTestCase):
 			fired = prewarm.warm_prefix()
 
 		self.assertFalse(fired)
-		set_calls = cache_mock.set_value.call_args_list
-		# Exactly one set_value call: the short in-progress guard.
-		# A second call (full cooldown) must not appear on failure.
-		self.assertEqual(
-			len(set_calls),
-			1,
-			"Only the short in-progress TTL should be set on failure, not the full cooldown",
-		)
-		_, call_kwargs = set_calls[0]
-		self.assertEqual(
-			call_kwargs.get("expires_in_sec"),
-			prewarm._WARM_INPROGRESS_S,
-			"The single cache set on failure must use the short in-progress TTL",
-		)
+		# The claim is a single SET NX EX on the short in-progress TTL...
+		cache_mock.set.assert_called_once()
+		_, claim_kwargs = cache_mock.set.call_args
+		self.assertEqual(claim_kwargs.get("ex"), prewarm._WARM_INPROGRESS_S)
+		self.assertTrue(claim_kwargs.get("nx"), "the claim must be conditional (SET NX)")
+		# ...and nothing extends it to the full cooldown on a failure.
+		cache_mock.set_value.assert_not_called()
 
 	def test_warm_prefix_passes_default_model_to_fire_agent(self):
 		"""warm_prefix resolves the Settings default model and passes it to
@@ -337,35 +344,181 @@ class TestWarmPrefix(FrappeTestCase):
 		# api_key mode: no oauth provider
 		self.assertIsNone(call_kwargs.get("provider"), "provider must be None in api_key mode")
 
+	def test_two_concurrent_warms_fire_exactly_one(self):
+		"""THE COOLDOWN RACE (#548).
 
-class TestKeepWarm(FrappeTestCase):
+		Two warms were observed passing the old get-then-set cooldown check 6ms
+		apart on jarvis-pool-bf4097, so a burst of chat-surface loads billed a
+		burst of upstream runs against the tenant's own quota.
+
+		The window they raced through was [get_value ... set_value], which spans
+		the `Jarvis Settings` load - so a second caller arriving DURING that load
+		IS the observed race, and re-entering warm_prefix from get_single
+		reproduces it deterministically without threads (frappe.local is
+		thread-local, so a real thread has no site to warm). Under the old
+		get-then-set both callers reach fire_agent; under SET NX EX the second
+		loses the claim and spends nothing."""
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+		frappe.cache().delete_value(prewarm._warm_last_key())
+		fake_sess = MagicMock()
+		fake_sess.create_session.side_effect = ["sk_a", "sk_b"]
+		fake_sess.is_run_active.return_value = False
+		settings = self._settings_stub()
+		# Set BEFORE recursing, or the inner call re-enters through this same
+		# side effect forever.
+		race = {"started": False, "inner": None}
+
+		def load_settings_then_race(*_args, **_kwargs):
+			if not race["started"]:
+				race["started"] = True
+				race["inner"] = prewarm.warm_prefix()
+			return settings
+
+		with (
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch("jarvis.chat.prewarm.frappe.get_single", side_effect=load_settings_then_race),
+			patch.object(session_lifecycle, "RECLAIM_PROBE_DELAY_S", 0),
+		):
+			OC.connect.return_value = fake_sess
+			outer = prewarm.warm_prefix()
+
+		self.assertTrue(outer, "the caller that won the claim must warm")
+		self.assertIs(race["inner"], False, "the concurrent second warm must be refused")
+		self.assertEqual(
+			fake_sess.fire_agent.call_count,
+			1,
+			"two warms racing the cooldown must bill exactly one upstream run",
+		)
+
+
+class TestPrefixAlreadyWarm(FrappeTestCase):
+	"""#548: a real chat turn warms the same container-wide prefix, so warming
+	again inside the retention window is pure spend on the tenant's own key.
+
+	This is the exact INVERSE of the gate the deleted keep-warm cron used, which
+	fired only when recent chat traffic had already made warming worthless."""
+
 	def tearDown(self):
 		from jarvis.chat import prewarm
 
 		frappe.cache().delete_value(prewarm._warm_cooldown_key())
-		# Leaving this set would make the NEXT test's first warm reclaim a
-		# session this one invented.
 		frappe.cache().delete_value(prewarm._warm_last_key())
 
-	def test_keep_warm_warms_when_recent_activity(self):
+	def test_recent_turn_skips_the_warm_and_arms_the_full_cooldown(self):
 		from jarvis.chat import prewarm
 
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
 		with (
-			patch("jarvis.chat.prewarm.frappe.db.exists", return_value="MSG-1"),
-			patch("jarvis.chat.prewarm.warm_prefix") as wp,
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
+			patch.object(prewarm, "_prefix_recently_used", return_value=True),
 		):
-			prewarm.keep_warm_if_active()
-		wp.assert_called_once()
+			self.assertFalse(prewarm.warm_prefix())
 
-	def test_keep_warm_noop_when_idle(self):
+		OC.connect.assert_not_called()
+		# Nothing failed, so this is the full cooldown rather than the short
+		# in-progress marker: there is simply nothing worth paying for until the
+		# provider cache could have cooled.
+		ttl = frappe.cache().ttl(frappe.cache().make_key(prewarm._warm_cooldown_key()))
+		self.assertGreater(ttl, prewarm._WARM_INPROGRESS_S)
+
+	def test_the_recent_turn_window_is_the_documented_one(self):
+		"""Pins what _RECENT_TURN_S means: a Jarvis Chat Message newer than
+		now - _RECENT_TURN_S. An arbitrary window here is the same class of bug
+		as the cron's 30-minute one."""
 		from jarvis.chat import prewarm
 
+		with patch("jarvis.chat.prewarm.frappe.db.exists", return_value="MSG-1") as ex:
+			self.assertTrue(prewarm._prefix_recently_used())
+
+		doctype, filters = ex.call_args.args
+		self.assertEqual(doctype, "Jarvis Chat Message")
+		op, cutoff = filters["creation"]
+		self.assertEqual(op, ">")
+		expected = frappe.utils.add_to_date(frappe.utils.now_datetime(), seconds=-prewarm._RECENT_TURN_S)
+		self.assertLess(abs((cutoff - expected).total_seconds()), 5)
+
+	def test_no_recent_turn_means_the_prefix_may_be_cold(self):
+		from jarvis.chat import prewarm
+
+		with patch("jarvis.chat.prewarm.frappe.db.exists", return_value=None):
+			self.assertFalse(prewarm._prefix_recently_used())
+
+
+class TestPrewarmKillSwitch(FrappeTestCase):
+	"""#548: prewarming spends the customer's own quota in EVERY auth mode
+	(api_key / subscription / oauth are all their credential), so an operator
+	whose tenant is on a tight or free-tier key needs a way to switch it off.
+	Absence must keep it ON - only an explicit falsy value disables it."""
+
+	def tearDown(self):
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
+		frappe.cache().delete_value(prewarm._warm_last_key())
+
+	def test_absent_flag_leaves_prewarm_on(self):
+		from jarvis.chat import prewarm
+
+		with patch.dict(frappe.local.conf, {}, clear=False):
+			frappe.local.conf.pop(prewarm._PREWARM_CONF_KEY, None)
+			self.assertTrue(prewarm._prewarm_enabled())
+
+	def test_explicit_falsy_values_switch_prewarm_off(self):
+		from jarvis.chat import prewarm
+
+		for flag in (0, "0", False, "false", "off", "no", ""):
+			with self.subTest(flag=flag), patch.dict(frappe.local.conf, {prewarm._PREWARM_CONF_KEY: flag}):
+				self.assertFalse(prewarm._prewarm_enabled())
+
+	def test_disabled_site_neither_enqueues_nor_warms(self):
+		from jarvis.chat import prewarm
+
+		frappe.cache().delete_value(prewarm._warm_cooldown_key())
 		with (
-			patch("jarvis.chat.prewarm.frappe.db.exists", return_value=None),
-			patch("jarvis.chat.prewarm.warm_prefix") as wp,
+			patch.dict(frappe.local.conf, {prewarm._PREWARM_CONF_KEY: 0}),
+			patch("jarvis.chat.prewarm.frappe.enqueue") as enq,
+			patch("jarvis.chat.prewarm.OpenclawSession") as OC,
 		):
-			prewarm.keep_warm_if_active()
-		wp.assert_not_called()
+			prewarm.enqueue_warm_if_due()
+			self.assertFalse(prewarm.warm_prefix())
+
+		enq.assert_not_called()
+		OC.connect.assert_not_called()
+
+
+class TestPrewarmTriggerSurface(FrappeTestCase):
+	"""#548 regression guard: the chat-surface load is the ONLY prewarm trigger.
+
+	The login hook and the */5 keep-warm cron each billed an upstream LLM request
+	against the tenant's own quota on a schedule uncorrelated with anyone being
+	about to send a message. Re-adding either needs a measured warm-vs-cold
+	first_delta_ms split first, which is why this asserts on hooks.py."""
+
+	def test_no_prewarm_on_login(self):
+		from jarvis import hooks
+
+		self.assertNotIn(
+			"prewarm",
+			str(getattr(hooks, "on_session_creation", "")),
+			"a login must not bill a prefix warm-up",
+		)
+
+	def test_no_periodic_keep_warm_cron(self):
+		from jarvis import hooks
+
+		scheduled = str(hooks.scheduler_events)
+		self.assertNotIn("keep_warm", scheduled)
+		self.assertNotIn("prewarm", scheduled, "nothing may warm the prefix on a timer")
+
+	def test_the_removed_entry_points_are_gone(self):
+		"""Deleted, not merely unhooked: a leftover callable is what gets wired
+		back up by the next person reading hooks.py."""
+		from jarvis.chat import prewarm
+
+		self.assertFalse(hasattr(prewarm, "keep_warm_if_active"))
+		self.assertFalse(hasattr(prewarm, "warm_on_login"))
 
 
 class TestEnqueueWarmIfDue(FrappeTestCase):


### PR DESCRIPTION
Fixes #548.

## The defect

`jarvis/chat/prewarm.py` fired a real upstream `agent` run on **three** triggers: login (`on_session_creation`), every chat-surface load (`list_conversations`), and a `*/5` cron. Each is billed to the tenant's own credential and produces nothing the user sees. It exhausted a free-tier Gemini key on `jarvis.proxy`, and the resulting 429s then landed on real chat turns.

## Why the volume was never defensible

A warm can never be cost-neutral, only cost-traded-for-latency:

| | first turn | later turns |
|---|---|---|
| no prewarm | full prefix | provider's cached rate |
| prewarm | cached rate | cached rate (plus the warm's own full prefix) |

So prewarming is always strictly more spend, and a warm that no turn follows is a wholly wasted prefix. Measured from `logs/jarvis.chat.latency.log*` on `jarvis.proxy`: **528 warms against 86 real turns**, six paid warm-ups per turn.

That means the only defensible trigger is one correlated with a user about to send a first message, firing at most once per arrival.

## Triggers kept and removed

**Removed: the `*/5` `keep_warm_if_active` cron.** Its gate ("any chat message in the last 30 minutes") was **inverted with respect to its own purpose**. Recent chat traffic is exactly what keeps the provider cache warm for free, so the cron spent up to seven paid warms per burst of activity precisely when warming was worthless, and no-opped on the idle benches where a cold prefix is actually possible. A timer cannot know a turn is coming, which is the premise of warming, so it has no correct interval, not a longer one.

**Removed: the `on_session_creation` login warm.** It billed a request for every login to the site, including desk and API logins by users who never open chat, to buy a sub-second head start on a multi-second prefill that the chat-surface load already begins.

**Kept: the chat-surface load.** The only trigger correlated with someone about to send a message.

## Correctness and volume on the trigger that stays

- **The cooldown race is fixed.** The get-then-set spanned a `Jarvis Settings` load (a DB round trip), which is the window two warms were observed passing 6ms apart on `jarvis-pool-bf4097`: a duplicate billed run, and the trigger for the #535 reclaim race. It is now a single `SET NX EX`, claimed before any slow work. It raises on a Redis outage, and callers turn that into "no warm" deliberately: failing closed is the right side for work that spends the customer's money.
- **A warm is skipped while the prefix is already hot** (a real turn within the last two minutes). Sixteen SPA call sites reach `list_conversations`, several of them after every send, so without this the remaining trigger still warms into sessions whose own turns keep the prefix warm.
- **`warm_session`** (the whitelisted endpoint) now goes through `enqueue_warm_if_due` instead of enqueuing unconditionally, so N calls can no longer become N short-queue jobs.
- **`jarvis_prefix_prewarm: 0`** in site_config is an operator kill switch (absence reads as on, same shape as `jarvis_pump_enabled`).

## On metered keys and opt-in

There is no mode in which the operator pays: `llm_auth_mode` is api_key / subscription / oauth and all three are the customer's credential. So "skip for metered keys" would mean "skip always", and a per-tenant consent toggle would be asking every customer to answer a question nobody has data for. The honest position is the one taken here: volume proportional to real use, plus an operator off switch. Revisit per-tenant opt-in once a benefit number exists.

## Is the benefit measured? No.

Recorded in the module docstring rather than implied away:

- The turn telemetry line records no warm/cold state and no cached-token count, so `first_delta_ms` cannot be split by prefix state **even in principle**.
- `fire_ms` times the WS round trip, not the LLM work, so it says nothing about what a warm bought.
- The Stage-A/B harnesses run against a `FakeGateway`, and their `warm_session` pre-creates an openclaw **session**, not a provider prefix cache.
- "Watch warm-turn token spend after this change" (commit `1017f3ab`, which tripled the frequency) was never done. There is no token-spend telemetry for warms at all.

Skips are now logged alongside fires on the latency logger, so the paid-warm rate is readable off one file.

One caveat on the retention numbers the 4-minute cooldown is justified against: ~5-10 min idle eviction is documented for OpenAI and 5 min is Anthropic's default ephemeral TTL, but Gemini's **implicit** cache has no documented TTL, and Gemini is the provider that actually blew the quota. The comment says so rather than presenting it as measured.

## Not regressed

The pin stays pinned (#531, #544): prewarm still passes an explicit model so it warms THAT model's cache, and still mints a `jarvis-pinned-prewarm:` run id. #545's `fired_at` plus 5.0s grace on `reclaim_throwaway_session` is untouched.

## Tests

Fail without the change:

- `test_two_concurrent_warms_fire_exactly_one` pins the race. It re-enters `warm_prefix` from the `Jarvis Settings` load, which is precisely the window the old get-then-set left open, so under the old code both callers reach `fire_agent`. Threads are not usable here because `frappe.local` is thread-local.
- `TestPrefixAlreadyWarm` covers the hot-prefix skip, that it arms the full cooldown rather than the short marker, and the exact window `_RECENT_TURN_S` means.
- `TestPrewarmKillSwitch` covers absent-means-on and every explicit falsy value.
- `TestPrewarmTriggerSurface` asserts on `hooks.py` so neither removed trigger can be quietly wired back up, and that the two entry points are deleted rather than merely unhooked.
- `test_warm_session_respects_the_cooldown` covers the endpoint.

https://claude.ai/code/session_015kFVKdpkN6uMTgZDCm2LJ5