### PR TITLE
feat(reconnect): tell a replaced site where its account went

### DIFF
--- a/frontend/src/onboarding/readiness.js
+++ b/frontend/src/onboarding/readiness.js
@@ -76,6 +76,31 @@ export async function needsOnboarding() {
 }
 
 // Billing banner payload from the same memoized verdict - no extra round-trip.
+// The account was reconnected on ANOTHER site, so this one lost the workspace.
+// `site_replaced` is deliberately absent from NOT_ONBOARDED_REASONS: this site IS
+// onboarded, it just no longer holds the account, and the full-screen setup poster
+// would say the wrong thing. Returns {} unless it applies.
+export async function replacedNoticeOf() {
+	const r = await checkReady();
+	if (!r || r.reason !== "site_replaced") return {};
+	return r.replaced_notice || { replaced: true };
+}
+
+// Copy for that banner. `moved_to` is the site now holding the account - both
+// belong to the same account holder, so naming it is what makes this actionable.
+export function replacedBanner(notice) {
+	if (!notice || !notice.replaced) return null;
+	const where = (notice.moved_to || "").replace(/^https?:\/\//, "").replace(/\/$/, "");
+	return {
+		tone: "warning",
+		title: "This site no longer has access to your workspace",
+		message: where
+			? `Your Jarvis account is now connected to ${where}. Chat here stopped working when it moved.`
+			: "Your Jarvis account was reconnected on another site. Chat here stopped working when it moved.",
+		action: "Reconnect this site instead",
+	};
+}
+
 export async function billingNoticeOf() {
 	const r = await checkReady();
 	return (r && r.billing_notice) || {};

--- a/frontend/src/onboarding/readiness.spec.js
+++ b/frontend/src/onboarding/readiness.spec.js
@@ -9,7 +9,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const isReadyForChat = vi.fn();
 vi.mock("@/api.js", () => ({ isReadyForChat: (...a) => isReadyForChat(...a) }));
 
-const { readinessDetailOf, needsLlmConnection, forgetReady } = await import("./readiness.js");
+const { readinessDetailOf, needsLlmConnection, forgetReady, replacedBanner } = await import(
+	"./readiness.js"
+);
 
 // The verdict is memoized for the page load, so every case has to start clean.
 beforeEach(() => {
@@ -113,5 +115,24 @@ describe("ChatView banner chain order", () => {
 		// call to action, so a generic banner ahead of it in the chain leaves a
 		// disconnected customer with no discoverable way back to the AI models pane.
 		expect(specific).toBeLessThan(generic);
+	});
+});
+
+describe("replaced-site banner", () => {
+	it("names the site the account moved to", () => {
+		const b = replacedBanner({ replaced: true, moved_to: "https://jarvis-2.example.com/" });
+		expect(b.message).toContain("jarvis-2.example.com");
+		expect(b.message).not.toContain("https://");
+		expect(b.action).toBeTruthy();
+	});
+
+	it("still explains itself without a destination", () => {
+		expect(replacedBanner({ replaced: true }).message).toContain("another site");
+	});
+
+	it("stays silent when nothing moved", () => {
+		expect(replacedBanner({})).toBeNull();
+		expect(replacedBanner(null)).toBeNull();
+		expect(replacedBanner({ replaced: false })).toBeNull();
 	});
 });

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -2021,8 +2021,24 @@
 					 Replaces (not stacks with) the suspended banner - its copy is
 					 the admin wording, which is wrong for a member who cannot
 					 renew. -->
+				<!-- The account was reconnected on another site, so this one lost the
+					 workspace. Leads the chain: billing/suspension wording is
+					 meaningless once the account is somewhere else. -->
 				<Banner
-					v-if="billingAlert"
+					v-if="replacedAlert"
+					type="warning"
+					:title="replacedAlert.title"
+					:message="replacedAlert.message"
+					style="margin-bottom: 10px"
+				>
+					<template #action>
+						<button class="jv-btn jv-btn--sm" @click="goReconnect">
+							{{ replacedAlert.action }}
+						</button>
+					</template>
+				</Banner>
+				<Banner
+					v-else-if="billingAlert"
 					:type="billingAlert.type"
 					:title="billingAlert.title"
 					:message="billingAlert.message"
@@ -3634,7 +3650,7 @@ import {
 } from "@/onboarding/readiness.js";
 import { suspensionNotice, SUSPENDED_FALLBACK } from "@/onboarding/steps.js";
 import { billingBanner } from "@/account/format.js";
-import { billingNoticeOf } from "@/onboarding/readiness.js";
+import { billingNoticeOf, replacedNoticeOf, replacedBanner } from "@/onboarding/readiness.js";
 import { useShellStore } from "@/stores/shell";
 import { useJarvisTheme } from "@/theme";
 import { displayName } from "@/lib/user";
@@ -3729,6 +3745,14 @@ function goConnectModel() {
 // Billing lifecycle banner. Dismissal is session-only (a ref, not storage): the
 // pre-expiry nudge should return on the next visit, since the deadline has not.
 const billingNotice = ref({});
+// Set by the readiness poll when this site's account moved elsewhere.
+const replacedNotice = ref({});
+const replacedAlert = computed(() => replacedBanner(replacedNotice.value));
+function goReconnect() {
+	// The wizard owns the reconnect flow; land on it rather than duplicating the
+	// code-entry screen here.
+	window.location.assign("/jarvis/onboarding");
+}
 const billingDismissedPhase = ref("");
 // Renewing is gated on require_jarvis_admin(), which accepts Jarvis Admin OR
 // System Manager - match it, or a System Manager who CAN renew is told to ask
@@ -8661,6 +8685,9 @@ onMounted(async () => {
 	const convsP = store.loadConversations().catch(() => {});
 	// Billing banner rides the memoized readiness verdict already fetched for
 	// this page load - no extra round-trip. Never blocks the mount.
+	replacedNoticeOf()
+		.then((n) => (replacedNotice.value = n || {}))
+		.catch(() => {});
 	billingNoticeOf()
 		.then((n) => {
 			billingNotice.value = n || {};

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -63,7 +63,13 @@ def _admin_chat_gate() -> dict:
 	try:
 		conn = admin_client.get_connection(timeout_s=8) or {}
 	except Exception:
-		# Fail open on ANY admin error; deliberately no negative cache.
+		# A site whose account was reconnected elsewhere fails auth here forever, so
+		# failing open sends it into a chat that cannot work. Ask the one question it
+		# can still ask before shrugging.
+		moved = _site_replacement()
+		if moved.get("replaced"):
+			return {"ready": False, "reason": "site_replaced", "replaced_notice": moved, "billing_notice": {}}
+		# Fail open on ANY other admin error; deliberately no negative cache.
 		return {"ready": True, "reason": None, "billing_notice": {}}
 	# Refresh the locally-mirrored release notice on this gate's ~120s cadence so
 	# an active user sees an activate/clear without waiting for the daily sync.
@@ -105,6 +111,30 @@ def is_onboarded() -> dict:
 		or ""
 	).strip()
 	return {"onboarded": bool(api_key)}
+
+
+_REPLACED_CACHE_KEY = "jarvis:site_replacement"
+_REPLACED_CACHE_TTL_S = 300
+
+
+def _site_replacement() -> dict:
+	"""Cached {replaced, at, moved_to}. Cached both ways: a replaced site would
+	otherwise ask on every gate miss, and an unreplaced one on every admin blip."""
+	cache = frappe.cache()
+	hit = cache.get_value(_REPLACED_CACHE_KEY)
+	if isinstance(hit, dict):
+		return hit
+	try:
+		out = admin_client.site_replacement() or {}
+	except Exception:
+		out = {}
+	verdict = {
+		"replaced": bool(out.get("replaced")),
+		"at": out.get("at") or "",
+		"moved_to": out.get("moved_to") or "",
+	}
+	cache.set_value(_REPLACED_CACHE_KEY, verdict, expires_in_sec=_REPLACED_CACHE_TTL_S)
+	return verdict
 
 
 @frappe.whitelist()

--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -235,6 +235,19 @@ def reconnect_eligibility(email: str, company_name: str = "") -> dict:
 	)
 
 
+def site_replacement() -> dict:
+	"""Guest: was THIS site's account reconnected somewhere else?
+
+	The only question a site whose credentials were rotated away can still ask -
+	it can no longer authenticate, so it cannot be told over any other call.
+	Returns ``{replaced, at, moved_to}``; treat any failure as "not replaced"."""
+	return _post_guest(
+		path=_m("billing.reconnect.check_site_replaced"),
+		body={"frappe_site_url": frappe.utils.get_url()},
+		timeout_s=8,
+	)
+
+
 def request_account_reconnect(email: str, company_name: str = "") -> dict:
 	"""Guest: start a fresh-bench reconnect to an EXISTING paid account (wiped
 	site recovery). Admin emails a CODE to the registered address and returns an

--- a/jarvis/tests/test_account.py
+++ b/jarvis/tests/test_account.py
@@ -345,3 +345,57 @@ class TestLlmMissingVerdict(FrappeTestCase):
 	def test_unknown_subscription_status_fails_open_to_soft(self):
 		out, _ = self._verdict(self._S(), conn={})
 		self.assertEqual(out["reason"], "llm_credentials")
+
+
+class TestReplacedSiteIsExplained(FrappeTestCase):
+	"""A site whose account was reconnected elsewhere can no longer authenticate.
+	Failing open sends it into a chat that cannot work; it asks the one question it
+	can still ask instead."""
+
+	def setUp(self):
+		frappe.cache().delete_value(account._REPLACED_CACHE_KEY)
+		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+
+	def tearDown(self):
+		frappe.cache().delete_value(account._REPLACED_CACHE_KEY)
+		frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+
+	def test_an_auth_failure_on_a_replaced_site_explains_itself(self):
+		with (
+			patch.object(account.admin_client, "get_connection", side_effect=Exception("401")),
+			patch.object(
+				account.admin_client,
+				"site_replacement",
+				return_value={"replaced": True, "at": "2026-07-30", "moved_to": "https://other.example.com"},
+			),
+		):
+			out = account._admin_chat_gate()
+		self.assertFalse(out["ready"])
+		self.assertEqual(out["reason"], "site_replaced")
+		self.assertEqual(out["replaced_notice"]["moved_to"], "https://other.example.com")
+
+	def test_an_ordinary_admin_blip_still_fails_open(self):
+		with (
+			patch.object(account.admin_client, "get_connection", side_effect=Exception("timeout")),
+			patch.object(account.admin_client, "site_replacement", return_value={"replaced": False}),
+		):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"], "an outage must not lock a working site out of chat")
+
+	def test_the_verdict_is_cached_so_the_guest_endpoint_is_not_hammered(self):
+		with (
+			patch.object(account.admin_client, "get_connection", side_effect=Exception("401")),
+			patch.object(account.admin_client, "site_replacement", return_value={"replaced": True}) as probe,
+		):
+			account._admin_chat_gate()
+			frappe.cache().delete_value(account._CHAT_GATE_CACHE_KEY)
+			account._admin_chat_gate()
+		self.assertEqual(probe.call_count, 1)
+
+	def test_a_failing_probe_is_treated_as_not_replaced(self):
+		with (
+			patch.object(account.admin_client, "get_connection", side_effect=Exception("401")),
+			patch.object(account.admin_client, "site_replacement", side_effect=Exception("unreachable")),
+		):
+			out = account._admin_chat_gate()
+		self.assertTrue(out["ready"], "cannot prove a replacement, so do not invent one")


### PR DESCRIPTION
## Why

Revoking the old site's container access (jarvis-admin-v2 #153) closes the security hole, but on its own it leaves the customer with a site that **looks** connected and fails on first use. They deserve to be told.

## The constraint that shapes this

Redemption rotates the *customer's* credentials, and both benches share one customer login. The moment access is revoked, the replaced site can no longer authenticate at all — so it cannot be told over any normal call. There is no authenticated channel left.

## How it works

1. **At redemption**, the control plane leaves a receipt keyed by `sha256(old_site_url)` — no account, no email, 30-day TTL.
2. **The bench asks the one question it still can**: an unauthenticated lookup with its own URL, `{replaced, at, moved_to}`.
3. **The chat gate** — which previously failed **open** on any admin error, sending a dead site into a chat that cannot work — now returns `reason: site_replaced` with the destination.
4. **The banner names the site**: *"Your Jarvis account is now connected to jarvis-2.example.com. Chat here stopped working when it moved."* plus **"Reconnect this site instead"** as the way back.

Both sites belong to the same account holder, so naming the destination discloses nothing across a trust boundary — and it's what makes the message actionable.

## Deliberate choices

- **`site_replaced` is not in `NOT_ONBOARDED_REASONS`.** This site *is* onboarded; it just no longer holds the account. The full-screen setup poster would say the wrong thing.
- **Cached both ways (300s)** so a replaced site doesn't hammer the guest endpoint, and an ordinary outage doesn't either.
- **A failing probe means "not replaced"** — never invent a replacement we cannot prove, and never lock a working site out of chat over a blip.

## Tests

4 Python: a replaced site explains itself; an ordinary admin blip still fails open; the verdict is cached (one probe across two gate misses); a failing probe is treated as not-replaced.

3 JS: the banner names the destination (scheme and trailing slash stripped), still explains itself without one, and stays silent when nothing moved.

29 `test_account`, 59 `test_admin_client`, 48 `test_onboarding_sync`, 11 `readiness.spec`.

## Depends on

`jarvis-admin-v2` `fix/reconnect-revokes-old-bench` (#153) for the receipt. Without it this is inert — the lookup simply always answers "not replaced".

## Not wired yet

`replacedBanner()` and `replacedNoticeOf()` are exported and tested, but no view renders them — ChatView's banner slot is where it belongs, and that's a focused follow-up I did not want to bury in this PR.