### PR TITLE
fix(onboarding): honest plan-step copy and clear stale reconnect offer

### DIFF
--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -24,6 +24,23 @@ export function prevStep(steps, cur) {
 	return steps[Math.max(stepIndex(steps, cur) - 1, 0)];
 }
 
+// Plan step subtitle (OnboardingView's "Choose your plan" header): "Start
+// free" is only honest when the catalog actually has something free or
+// trial-gated on offer. The admin plan catalog can deactivate the Free plan
+// on its own (jarvis#536), at which point every selectable plan charges
+// immediately, so the copy has to track the plans that were actually
+// fetched rather than being hardcoded. Pure so the no-free-plan branch
+// stays unit-tested without mounting the wizard.
+export function planSubtitleFor(plans) {
+	const list = Array.isArray(plans) ? plans : [];
+	const hasFreeOrTrial = list.some(
+		(p) => Number(p && p.price_inr) === 0 || Number(p && p.trial_days) > 0
+	);
+	return hasFreeOrTrial
+		? "Start free. Upgrade or extend anytime, with no auto-renewal."
+		: "Pick a plan to get started. No auto-renewal.";
+}
+
 // jarvis.account.is_ready_for_chat (jarvis/account.py) returns
 // {ready: bool, reason: str|None} - reason is one of "signup" /
 // "llm_credentials" and friends when not ready, null when ready.

--- a/frontend/src/onboarding/steps.js
+++ b/frontend/src/onboarding/steps.js
@@ -33,8 +33,14 @@ export function prevStep(steps, cur) {
 // stays unit-tested without mounting the wizard.
 export function planSubtitleFor(plans) {
 	const list = Array.isArray(plans) ? plans : [];
+	// A missing price must NOT read as free: Number(null) is 0, so a plan row
+	// that simply never carried price_inr would otherwise resurrect the exact
+	// false promise this function exists to remove. Absent, null and blank all
+	// coerce to NaN here, which fails both comparisons, so the honest paid-only
+	// wording wins whenever the catalog is not explicit about being free.
+	const amount = (v) => (v === null || v === undefined || v === "" ? NaN : Number(v));
 	const hasFreeOrTrial = list.some(
-		(p) => Number(p && p.price_inr) === 0 || Number(p && p.trial_days) > 0
+		(p) => !!p && (amount(p.price_inr) === 0 || amount(p.trial_days) > 0)
 	);
 	return hasFreeOrTrial
 		? "Start free. Upgrade or extend anytime, with no auto-renewal."

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -50,6 +50,24 @@ test("planSubtitleFor: no free or trial plan drops the free-tier promise", () =>
 	);
 });
 
+// A plan row whose price is absent, null or blank is NOT free. Number(null)
+// is 0, so the naive coercion reported the free-tier wording for a catalog
+// that charges for everything, which is the bug jarvis#536 was filed about.
+test("planSubtitleFor: an absent, null or blank price is not treated as free", () => {
+	const paidOnly = "Pick a plan to get started. No auto-renewal.";
+	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: null }]), paidOnly);
+	assert.equal(planSubtitleFor([{ name: "ob-plan" }]), paidOnly);
+	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: "" }]), paidOnly);
+	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: 1000, trial_days: null }]), paidOnly);
+	// A stray null element from a partially loaded response must not count either.
+	assert.equal(planSubtitleFor([null, { name: "Pro", price_inr: 3000 }]), paidOnly);
+	// A genuine zero still reads as free, including the string form.
+	assert.equal(
+		planSubtitleFor([{ name: "Free", price_inr: "0" }]),
+		"Start free. Upgrade or extend anytime, with no auto-renewal."
+	);
+});
+
 test("planSubtitleFor: a zero-price plan keeps the free-tier wording", () => {
 	assert.equal(
 		planSubtitleFor([

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -58,7 +58,10 @@ test("planSubtitleFor: an absent, null or blank price is not treated as free", (
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: null }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan" }]), paidOnly);
 	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: "" }]), paidOnly);
-	assert.equal(planSubtitleFor([{ name: "ob-plan", price_inr: 1000, trial_days: null }]), paidOnly);
+	assert.equal(
+		planSubtitleFor([{ name: "ob-plan", price_inr: 1000, trial_days: null }]),
+		paidOnly
+	);
 	// A stray null element from a partially loaded response must not count either.
 	assert.equal(planSubtitleFor([null, { name: "Pro", price_inr: 3000 }]), paidOnly);
 	// A genuine zero still reads as free, including the string form.

--- a/frontend/src/onboarding/steps.test.js
+++ b/frontend/src/onboarding/steps.test.js
@@ -12,6 +12,7 @@ import {
 	notReadyNote,
 	GENERIC_NOT_READY_NOTE,
 	syncStatusNote,
+	planSubtitleFor,
 } from "./steps.js";
 
 test("managed step order", () => {
@@ -34,6 +35,42 @@ test("managed step order", () => {
 
 test("stepIndex", () => {
 	assert.equal(stepIndex(STEPS_MANAGED, "pay"), 3);
+});
+
+// jarvis#536: the plan step's subtitle used to hardcode "Start free" even
+// when nothing on offer was free or trial-gated. planSubtitleFor derives it
+// from the plans actually fetched instead.
+test("planSubtitleFor: no free or trial plan drops the free-tier promise", () => {
+	assert.equal(
+		planSubtitleFor([
+			{ name: "ob-plan", price_inr: 1000, trial_days: 0 },
+			{ name: "Pro (Annual)", price_inr: 3000, trial_days: 0 },
+		]),
+		"Pick a plan to get started. No auto-renewal."
+	);
+});
+
+test("planSubtitleFor: a zero-price plan keeps the free-tier wording", () => {
+	assert.equal(
+		planSubtitleFor([
+			{ name: "Free", price_inr: 0, trial_days: 0 },
+			{ name: "Pro (Annual)", price_inr: 3000, trial_days: 0 },
+		]),
+		"Start free. Upgrade or extend anytime, with no auto-renewal."
+	);
+});
+
+test("planSubtitleFor: a trial-gated plan also keeps the free-tier wording", () => {
+	assert.equal(
+		planSubtitleFor([{ name: "Pro", price_inr: 3000, trial_days: 7 }]),
+		"Start free. Upgrade or extend anytime, with no auto-renewal."
+	);
+});
+
+test("planSubtitleFor: an empty or missing plan list is not a false promise", () => {
+	assert.equal(planSubtitleFor([]), "Pick a plan to get started. No auto-renewal.");
+	assert.equal(planSubtitleFor(null), "Pick a plan to get started. No auto-renewal.");
+	assert.equal(planSubtitleFor(undefined), "Pick a plan to get started. No auto-renewal.");
 });
 
 // jarvis.account.is_ready_for_chat returns {ready: bool, reason: str|None}

--- a/frontend/src/views/OnboardingView.vue
+++ b/frontend/src/views/OnboardingView.vue
@@ -83,10 +83,7 @@
 							<div class="ob-body">
 								<div class="ob-head">
 									<h1>Choose your plan</h1>
-									<p>
-										Start free. Upgrade or extend anytime, with no
-										auto-renewal.
-									</p>
+									<p>{{ planSubtitle }}</p>
 								</div>
 								<div
 									v-if="state.plansLoading"
@@ -779,6 +776,7 @@ import {
 	verifyPollAction,
 	notReadyNote,
 	syncStatusNote,
+	planSubtitleFor,
 } from "@/onboarding/steps";
 import { inr, planAmount, planSuffix } from "@/account/format";
 import {
@@ -883,6 +881,8 @@ const state = reactive({
 
 const steps = computed(() => STEPS_MANAGED);
 const selectedPlan = computed(() => state.plans.find((p) => p.name === state.planName) || {});
+// See planSubtitleFor (onboarding/steps.js) for why this can't be hardcoded.
+const planSubtitle = computed(() => planSubtitleFor(state.plans));
 const railIndex = computed(() => RAIL.findIndex((r) => r.id === state.step));
 // Both halves of the identity must be present before the plane can resolve an
 // account: several company accounts can share one address.
@@ -1189,9 +1189,14 @@ function onDetailsSubmit() {
 		return;
 	}
 	persistBillingDetails();
-	// Entering Review & Pay fresh from Details: reset the pay sub-state.
+	// Entering Review & Pay fresh from Details: reset the pay sub-state. This
+	// includes reconnectOffered, not just payErr - otherwise a reconnect offer
+	// raised by a duplicate email on an earlier attempt survives a Back, an
+	// edit to a genuinely new email, and a Continue, and is shown pointing at
+	// an address that was never rejected.
 	state.payPhase = "review";
 	state.payErr = "";
+	state.reconnectOffered = false;
 	goNext();
 }
 
@@ -1233,6 +1238,10 @@ async function enterPayStep() {
 // Click handler for the Pay button.
 async function onPayClick() {
 	state.payErr = "";
+	// A fresh attempt starts clean: a reconnect offer raised by a previous
+	// failure must not survive into this one. runStartPay's catch below sets
+	// it again if this attempt also hits a duplicate-email rejection.
+	state.reconnectOffered = false;
 	// Guard against a signup with empty args: on a reconciled resume (or any
 	// state loss) there is no local plan/email/company, and startSignup(email,
 	// company, null) would create a broken signup upstream.


### PR DESCRIPTION
Fixes #536
Fixes #537

Two onboarding copy defects found during the live e2e run on 2026-07-30, on a
control plane where only paid plans are active.

## #536: the plan step promised "Start free" when nothing free was on offer

The subtitle on "Choose your plan" was hardcoded. The admin plan catalog can
deactivate the Free plan on its own, and on the live control plane it is
deactivated, so every selectable plan charges immediately. A customer was told
"Start free" and then taken straight to a Razorpay payment.

The copy now tracks the plans that were actually fetched. `planSubtitleFor` is a
pure function in `onboarding/steps.js`, so the no-free-plan branch is unit tested
without mounting the wizard. `state.plans` already carries `price_inr` and
`trial_days`, so no endpoint change was needed.

## #537: the reconnect offer outlived the error that raised it

A duplicate email raises a "Reconnect this site" offer. That offer survived going
Back, editing to a genuinely new address, and continuing, so it was shown pointing
at an address that had never been rejected.

Note the issue's suggested fix site had drifted: `payErr` clearing has since moved
out of `runStartPay` to its two callers. The real leak is `onDetailsSubmit`, which
reset `payErr` but not `reconnectOffered`. Reset added there, and in `onPayClick`
for a direct retry. `runStartPay`'s catch already recomputes the flag on each
failed attempt, so it needed no change.

## Tests

`planSubtitleFor` gets four `node --test` cases: no free or trial plan, a
zero-price plan, a trial-gated paid plan, and empty or nullish input. Full
frontend node suite passes (429 tests). `npm run build` clean.

The `#537` fix is in view state and has no unit-test seam without mounting
`OnboardingView`, for which this repo has no established pattern. It is covered by
the manual repro in the issue.
