### PR TITLE
fix(settings): stop admin's auth-profile claim deciding a pool's status

### DIFF
--- a/frontend/src/components/settings/BillingMeteringPane.vue
+++ b/frontend/src/components/settings/BillingMeteringPane.vue
@@ -103,6 +103,7 @@ import EChart from "@/charts/EChart.vue";
 import { budgetGaugeOption, perModelBarSpec } from "@/charts/usageCharts.js";
 import { getLlmConfig, getLlmUsage, getLlmSyncStatus } from "@/api";
 import { humaniseSyncStatus } from "@/lib/syncStatus";
+import { connectionModeLabel } from "@/llm/pool";
 import { useJarvisTheme } from "@/theme";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import KvRow from "@/components/settings/KvRow.vue";
@@ -123,11 +124,16 @@ const errorMessage = computed(() => (usageError.value ? "Usage is unavailable ri
 // pool" - a pool of BYO api keys is rendered openclaw-direct and runs its own
 // failover with no sidecar. Reading the flag alone printed "Direct" right above
 // the Active-pool card listing both of that tenant's models.
-const modeLabel = computed(() => {
-	if (config.value.proxy_active) return "Pool (proxied)";
-	const enabled = (config.value.models || []).filter((m) => m.enabled !== false);
-	return enabled.length > 1 ? "Pool (direct failover)" : "Direct";
-});
+//
+// The wording itself now lives in @/llm/pool, shared with Settings > General,
+// which was naming the same three states on its own and disagreeing with this
+// pane about a 2-model api-key pool (jarvis#561).
+const modeLabel = computed(() =>
+	connectionModeLabel(
+		config.value.proxy_active,
+		(config.value.models || []).filter((m) => m.enabled !== false).length
+	)
+);
 
 // A failure reason belongs on a surface that can act on it (the AI models pane);
 // here the row only needs to say which of the three states the pool is in.

--- a/frontend/src/components/settings/GeneralPane.vue
+++ b/frontend/src/components/settings/GeneralPane.vue
@@ -2,9 +2,25 @@
 	<SettingsPane title="General" description="Chat behavior, notifications and token usage.">
 		<h3 class="text-base font-semibold text-ink-gray-9">Connection</h3>
 		<div class="mt-2">
-			<KvRow label="Model" :value="modelLabel" />
-			<KvRow label="Provider" :value="ui.llm_provider || '—'" />
-			<KvRow label="Auth mode" :value="ui.llm_auth_mode || '—'" />
+			<!-- Mode names the TOPOLOGY, Status reports its HEALTH. They used to be
+			     the same row, which is how a 2-model pool came to be labelled
+			     "Direct" here while Billing and metering called the identical state
+			     "Pool (direct failover)". Both panes now read the one
+			     connectionModeLabel(). -->
+			<KvRow v-if="modeLabel" label="Mode" :value="modeLabel" />
+			<!-- A failover pool has no single Model/Provider/Auth mode. Those three
+			     rows were filled from the legacy models[0] mirror, so a 4-model pool
+			     described member one and presented it as the whole connection, under
+			     a Model row naming the synthetic Bifrost endpoint nobody chose. AI
+			     models owns the per-model story (every model in failover order, with
+			     its own status); this is a summary that points at it. The triple
+			     stays for a single-credential tenant, where it is accurate. -->
+			<KvRow v-if="isPool" label="Models" :value="poolSummary" />
+			<template v-else>
+				<KvRow label="Model" :value="modelLabel" />
+				<KvRow label="Provider" :value="ui.llm_provider || '—'" />
+				<KvRow label="Auth mode" :value="ui.llm_auth_mode || '—'" />
+			</template>
 			<KvRow label="Status">
 				<Badge :label="statusLabel" :theme="statusTheme" variant="subtle" />
 			</KvRow>
@@ -13,6 +29,14 @@
 				label="Expires"
 				:value="expiresLabel"
 			/>
+			<div v-if="isPool" class="mt-2">
+				<Button
+					variant="subtle"
+					label="Manage models"
+					iconLeft="cpu"
+					@click="store.openSettings('aimodels')"
+				/>
+			</div>
 			<!-- A failed status fetch must not look like a healthy workspace. Without
 			     this the catch below leaves Status on its placeholder, which reads as
 			     an answer rather than as "we could not ask". Admin-only, because only
@@ -224,6 +248,8 @@ import { useConfirm } from "@/composables/useConfirm";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import KvRow from "@/components/settings/KvRow.vue";
 import ToggleRow from "@/components/settings/ToggleRow.vue";
+import { connectionModeLabel } from "@/llm/pool";
+import { humaniseSyncStatus } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 import * as api from "@/api";
 
@@ -281,42 +307,77 @@ async function loadConnStatus() {
 		connLoading.value = false;
 	}
 }
-// get_llm_connection_status short-circuits server-side for a DIRECT (single-
-// model) tenant and reports that via proxy_active rather than the raw proxy-auth
-// payload, so proxy_active tells the two states apart explicitly instead of
-// guessing from which fields happen to be populated. Without this, a direct
-// tenant's own auth_present:false read as "Not connected" here too.
+// proxy_active means "a Bifrost + CLIProxyAPI sidecar pair is deployed", which
+// only a chat subscription needs. It is NOT "this is a pool": a pool of BYO api
+// keys renders openclaw-direct and fails over with no sidecar at all. Kept
+// separate from isPool below for exactly that reason: only a proxied tenant has
+// an OAuth profile expiry to show.
 const isProxy = computed(() => !!(connStatus.value && connStatus.value.proxy_active));
+// pool_mode is the server's compute_pool_mode: this workspace syncs as a whole
+// models[] spec, so there is no one credential for the Model/Provider/Auth-mode
+// triple to describe.
+const isPool = computed(() => !!(connStatus.value && connStatus.value.pool_mode));
 // Ported from the removed ConnectionPane.vue, the one row this pane lacked:
 // oauth_expires_at is an epoch-ms value, rendered in the viewer's locale.
 const expiresLabel = computed(() => {
 	const ms = connStatus.value && connStatus.value.oauth_expires_at;
 	return ms ? new Date(Number(ms)).toLocaleString() : "—";
 });
-const connected = computed(() =>
-	isSM ? !!(connStatus.value && isProxy.value && connStatus.value.auth_present) : true
+// Shared with Billing and metering so the two panes cannot name the same state
+// differently again: that pane called a 2-model api-key pool "Pool (direct
+// failover)" while this one called it "Direct". Blank without a verdict (a
+// non-admin never fetches one), which hides the row rather than guessing.
+const modeLabel = computed(() =>
+	connStatus.value
+		? connectionModeLabel(connStatus.value.proxy_active, connStatus.value.model_count)
+		: ""
 );
-// No model configured at all: the workspace was disconnected (or never
-// connected). Checked BEFORE isProxy below for the same reason the server
-// computes it before its own DIRECT short-circuit: a disconnected tenant is
-// proxy_active:false, so without this it would read as a healthy "Direct".
+// The one line that replaces the triple for a pool: how many models, how they
+// are routed, and whether the container has the current set. humaniseSyncStatus
+// is the same translator Billing and metering's Sync row uses, so the two cannot
+// describe one last_sync_status differently. Its text is a standalone label
+// there and a clause here, hence the case fold.
+const poolSummary = computed(() => {
+	const c = connStatus.value || {};
+	const n = Number(c.model_count || 0);
+	const parts = [`${n} ${n === 1 ? "model" : "models"}`];
+	if (c.routing_mode) parts.push(c.routing_mode);
+	const sync = humaniseSyncStatus(c.sync_status);
+	if (sync.kind !== "unknown") parts.push(sync.text.toLowerCase());
+	return parts.join(", ");
+});
+// No credential configured at all: the workspace was disconnected (or never
+// connected). Checked FIRST, for the same reason the server computes it before
+// its own DIRECT short-circuit: a disconnected tenant is proxy_active:false, so
+// without this it would read as a healthy single-model tenant.
 const disconnected = computed(() => !!(connStatus.value && connStatus.value.disconnected));
+// The server's verdict, and the ONLY input to the badge. It used to be computed
+// here from admin's auth_profile_present, which is a claim about a cliproxy auth
+// profile and never described a pool: a 4-model pool that was serving turns off
+// two connected subscriptions reported auth_profile_present:false and rendered
+// red "Not connected" over working chat (jarvis#561). get_llm_connection_status
+// now derives health from the same evidence is_ready_for_chat gates chat on, so
+// a workspace chat let you into cannot show a failure here.
+const health = computed(() => (connStatus.value && connStatus.value.health) || "");
 const statusLabel = computed(() => {
 	if (!isSM) return "Connected";
 	if (!connStatus.value) return "—";
 	if (disconnected.value) return "Disconnected";
-	if (!isProxy.value) return "Direct";
-	return connected.value ? "Connected" : "Not connected";
+	if (health.value === "down") return "Not connected";
+	if (health.value === "applying") return "Applying changes";
+	if (health.value === "attention") return "Needs attention";
+	return "Connected";
 });
-// design.md §3.8 status map: connected is green, a plain direct tenant is
-// neutral, an actual failure is red. Disconnected is orange (warning), not red:
-// nothing is broken, the customer chose this and can undo it in AI models.
+// design.md §3.6 status map: Success is green, Attention required and Broken are
+// red, Processing is blue. Disconnected is orange (warning), not red: nothing is
+// broken, the customer chose this and can undo it in AI models.
 const statusTheme = computed(() => {
 	if (!isSM) return "green";
 	if (!connStatus.value) return "gray";
 	if (disconnected.value) return "orange";
-	if (!isProxy.value) return "gray";
-	return connected.value ? "green" : "red";
+	if (health.value === "down" || health.value === "attention") return "red";
+	if (health.value === "applying") return "blue";
+	return "green";
 });
 
 // Estimated token usage — the dialog fetches its own data on open.

--- a/frontend/src/llm/pool.js
+++ b/frontend/src/llm/pool.js
@@ -19,6 +19,24 @@ export function deriveMode(models, preset) {
 	// (was: any 2+-model pool counted as "proxy" regardless of credential type)
 	return hasSubscription || preset ? "proxy" : "direct";
 }
+// The one place that NAMES a tenant's LLM topology. Settings > General and
+// Settings > Billing and metering each used to name it themselves and disagreed:
+// a 2-model api-key pool read "Direct" on General while Billing called the
+// identical state "Pool (direct failover)" (jarvis#561).
+//
+// The two inputs answer DIFFERENT questions and blurring them is what this
+// wording has to keep apart (backend: compute_pool_mode vs compute_proxy_active):
+//   proxyActive  - a Bifrost + CLIProxyAPI sidecar pair is deployed in front of
+//                  the container. Only a chat subscription needs one, because
+//                  cliproxy is what serves an OAuth blob.
+//   enabledCount - how many models the container fails over between. A pool of
+//                  BYO api keys renders openclaw-direct and fails over natively
+//                  with NO sidecar at all, so it is a pool AND it is direct - the
+//                  parenthetical is what says so without claiming a proxy.
+export function connectionModeLabel(proxyActive, enabledCount) {
+	if (proxyActive) return "Pool (proxied)";
+	return Number(enabledCount || 0) > 1 ? "Pool (direct failover)" : "Direct";
+}
 export function uniqueVendors(entry) {
 	if (entry && Array.isArray(entry.vendors) && entry.vendors.length)
 		return entry.vendors.slice();

--- a/frontend/src/llm/pool.test.js
+++ b/frontend/src/llm/pool.test.js
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
 	deriveMode,
+	connectionModeLabel,
 	uniqueVendors,
 	missingVendorKeys,
 	presetToModels,
@@ -89,6 +90,21 @@ test("deriveMode: a pure BYO api-key pool is direct regardless of size (no sidec
 		),
 		"direct"
 	);
+});
+test("connectionModeLabel: a multi-model api-key pool is a pool, and it is direct", () => {
+	// The wording Settings > General and Billing and metering disagreed on
+	// (jarvis#561): General called this state "Direct" while Billing called the
+	// identical state "Pool (direct failover)". One helper now answers for both,
+	// and the parenthetical keeps "no sidecar" from reading as "not a pool".
+	assert.equal(connectionModeLabel(false, 2), "Pool (direct failover)");
+	assert.equal(connectionModeLabel(false, 4), "Pool (direct failover)");
+});
+test("connectionModeLabel: a sidecar pair is proxied; one credential is direct", () => {
+	assert.equal(connectionModeLabel(true, 4), "Pool (proxied)");
+	assert.equal(connectionModeLabel(true, 1), "Pool (proxied)");
+	assert.equal(connectionModeLabel(false, 1), "Direct");
+	assert.equal(connectionModeLabel(false, 0), "Direct");
+	assert.equal(connectionModeLabel(undefined, undefined), "Direct");
 });
 test("deriveMode: a single subscription model is proxy (needs cliproxy)", () => {
 	assert.equal(

--- a/jarvis/account.py
+++ b/jarvis/account.py
@@ -20,7 +20,7 @@ their published names - no duplicates:
 import frappe
 
 from jarvis import admin_client, release_notice
-from jarvis.jarvis.pool_serialize import compute_pool_mode
+from jarvis.jarvis.pool_serialize import compute_pool_mode, pool_primary_model
 from jarvis.onboarding import _surface
 from jarvis.permissions import require_jarvis_admin
 
@@ -279,31 +279,66 @@ def get_llm_usage() -> dict:
 
 @frappe.whitelist()
 def get_llm_connection_status() -> dict:
-	"""Connection card for the Monitor tab: auth profile present + OAuth expiry.
-	Wrapper over admin_client.post_llm_auth_status, remapped to the customer
-	contract field names. Never returns token material. System-Manager only.
+	"""Connection card for Settings, General: how this workspace's LLM config is
+	SHAPED (``pool_mode`` / ``proxy_active`` / ``model_count`` / ``routing_mode``)
+	and whether it is actually SERVING (``health``). Never returns token material.
+	System-Manager only.
 
-	Tenants with no Bifrost/cliproxy sidecar (proxy_active=0, which now includes
-	a BYO api-key pool) short-circuit before the admin round-trip, mirroring
-	get_llm_usage above - there is no proxy auth profile to report. Before this,
-	single-model direct tenants already hit this path: the raw admin payload's
-	leftover fields (a stale/default default_model with auth_profile_present
-	false) made the SPA's ConnectionPane render a misleading orange "Not
-	connected" for a direct tenant whose chat verifiably works.
+	``health`` is decided here, from what the bench already knows, and it is the
+	only field the status badge may render. Admin's ``auth_profile_present`` is
+	still passed through as ``auth_present`` because support wants the raw claim,
+	but it is NOT a verdict about the workspace. A live 4-model pool whose two
+	chat subscriptions cliproxy had loaded and was answering turns with still came
+	back ``auth_profile_present: false, profile_ids: []``, and trusting that
+	boolean painted a red "Not connected" over a workspace whose chat
+	demonstrably worked (#561). Why admin sees no profiles is a control-plane bug
+	of its own; the point here is that the answer never described a pool in the
+	first place, so no value of it should decide this badge.
 
-	``disconnected`` is the third state, and it has to be computed FIRST. The
-	DIRECT short-circuit above returns before any admin round-trip, so a tenant
+	That is the same misleading state that was already fixed once for DIRECT
+	tenants, by short-circuiting them before the admin round-trip: the raw admin
+	payload's leftover fields (a stale/default default_model with
+	auth_profile_present false) made the SPA render "Not connected" for a direct
+	tenant whose chat verifiably worked. The proxy branch kept trusting the
+	boolean, so the identical state came back for pools.
+
+	The honest local signal is the one ``is_ready_for_chat`` already gates chat
+	on: the durable marker the fleet stamps when it CONFIRMS an apply. Tying the
+	badge to it means the badge and the chat gate cannot disagree - a workspace
+	chat let the customer into is green because the same evidence opened both, and
+	a workspace whose config never reached its container is red for the same
+	reason chat refuses it. See ``_llm_health``.
+
+	Tenants with no Bifrost/cliproxy sidecar (proxy_active=0, which includes a BYO
+	api-key pool) still short-circuit before the admin round-trip, mirroring
+	get_llm_usage above - there is no proxy auth profile to report.
+
+	``disconnected`` is a state of its own, and it has to be computed FIRST. The
+	DIRECT short-circuit below returns before any admin round-trip, so a tenant
 	whose connection was torn down (jarvis.onboarding.disconnect_llm) would
-	otherwise fall into it and report a healthy-looking "Direct" while chat is
+	otherwise fall into it and report a healthy-looking config while chat is
 	dead. It is derived here rather than added to ``chat_readiness``: that field
 	is a shared admin/bench contract with exactly four values, and the bench
 	already knows its own config is empty without asking anybody."""
 	require_jarvis_admin()
 	settings = frappe.get_single("Jarvis Settings")
+	pool_mode = compute_pool_mode(settings)
+	# Shape, not health. The SPA needs these to name the topology honestly: a
+	# single Model/Provider/Auth-mode triple describes one credential, and a
+	# failover pool is not one credential. pool_mode and proxy_active answer
+	# DIFFERENT questions and must not be blurred - see compute_proxy_active.
+	shape = {
+		"pool_mode": pool_mode,
+		"model_count": len([m for m in (settings.get("models") or []) if m.enabled]),
+		"routing_mode": settings.get("routing_mode") or "",
+		"sync_status": settings.get("last_sync_status") or "",
+	}
 	if not _has_llm_config(settings):
 		return {
+			**shape,
 			"proxy_active": False,
 			"disconnected": True,
+			"health": "down",
 			"auth_present": False,
 			"oauth_expires_at": None,
 			"profile_ids": [],
@@ -311,8 +346,10 @@ def get_llm_connection_status() -> dict:
 		}
 	if not getattr(settings, "proxy_active", 0):
 		return {
+			**shape,
 			"proxy_active": False,
 			"disconnected": False,
+			"health": _llm_health(settings, pool_mode),
 			"auth_present": False,
 			"oauth_expires_at": None,
 			"profile_ids": [],
@@ -321,13 +358,79 @@ def get_llm_connection_status() -> dict:
 	raw = _surface(admin_client.post_llm_auth_status) or {}
 	data = raw.get("data", raw) or {}
 	return {
+		**shape,
 		"proxy_active": True,
 		"disconnected": False,
+		"health": _llm_health(settings, pool_mode),
 		"auth_present": bool(data.get("auth_profile_present")),
 		"oauth_expires_at": data.get("openai_profile_expires_ms"),
 		"profile_ids": data.get("profile_ids", []),
-		"default_model": data.get("default_model", ""),
+		# Admin answers this with the Bifrost virtual endpoint
+		# ("openai_compat/jarvis-pool"), which is not a model the customer picked
+		# and not one they would recognise. The bench knows which member the
+		# container actually runs first, so prefer that and keep admin's value as
+		# the fallback for a shape pool_primary_model cannot read.
+		"default_model": pool_primary_model(settings) or data.get("default_model", ""),
 	}
+
+
+def _llm_health(settings, pool_mode: bool) -> str:
+	"""``ok`` / ``applying`` / ``attention`` / ``down`` for a workspace that HAS a
+	credential (``_has_llm_config`` has already said so).
+
+	Every input is local. Nothing here asks admin, because the one thing admin was
+	asked - "does a cliproxy auth profile exist" - turned out not to describe a
+	pool at all (see get_llm_connection_status).
+
+	  applying  - a save is in flight. The container is still on its previous
+	              config, so neither "fine" nor "broken" is true yet.
+	  down      - the container has NEVER confirmed this workspace's config, so it
+	              is not serving it. This is the same evidence is_ready_for_chat
+	              gates chat on, which is what keeps the badge and the gate from
+	              contradicting each other.
+	  attention - the container IS serving, but the last apply failed or the
+	              fleet's own probe reports the chat subscription rejecting
+	              requests. Both are workspace-level verdicts. Per-MODEL verdicts
+	              deliberately stay out: AI models shows them per row, and one dead
+	              member of a healthy failover chain is what failover is for.
+	  ok        - serving, and the last apply came back clean.
+
+	The status prefixes match @/lib/syncStatus's, which is the SPA's one
+	translator for the same field, so the badge and the sync line cannot disagree
+	about which of the three an audit string means.
+	"""
+	status = (settings.get("last_sync_status") or "").strip().lower()
+	if status.startswith("pending"):
+		return "applying"
+	if not _llm_apply_confirmed(settings, pool_mode):
+		return "down"
+	if status.startswith("failed"):
+		return "attention"
+	# The fleet's own pool-wide subscription probe. Only an explicit rejection
+	# counts: "unchecked" (and a no-op apply, which runs no probe at all) means
+	# nobody looked, which is not evidence of a problem.
+	return "attention" if (settings.get("last_subscription_status") or "") == "unverified" else "ok"
+
+
+def _llm_apply_confirmed(settings, pool_mode: bool) -> bool:
+	"""Has the fleet CONFIRMED an apply of the leg this workspace syncs through?
+
+	Mirrors ``is_ready_for_chat``'s three legs exactly, and must keep mirroring
+	them - the whole value of this signal is that chat and the connection badge
+	read the same evidence. Pool marker for a pool (including a BYO api-key pool,
+	which has no sidecar but is still pushed through /llm-pool and still stamps
+	llm_pool_synced_at), the OAuth connect stamp for a direct subscription/oauth
+	tenant, the direct apply marker otherwise.
+
+	Legacy workspaces on both legs are backfilled by patch (v1_10 for the pool,
+	v2_00_backfill_llm_direct_synced_at for direct), so an established tenant does
+	not read as never-applied.
+	"""
+	if pool_mode:
+		return bool(settings.get("llm_pool_synced_at"))
+	if (settings.get("llm_auth_mode") or "api_key").strip() in ("subscription", "oauth"):
+		return bool(settings.get("llm_oauth_connected_at"))
+	return bool(settings.get("llm_direct_synced_at"))
 
 
 def _has_llm_config(settings) -> bool:

--- a/jarvis/tests/test_llm_monitor.py
+++ b/jarvis/tests/test_llm_monitor.py
@@ -63,18 +63,37 @@ class TestGetLlmUsage(FrappeTestCase):
 
 
 class TestGetLlmConnectionStatus(FrappeTestCase):
+	_FIELDS = (
+		"proxy_active",
+		"llm_model",
+		"routing_mode",
+		"last_sync_status",
+		"last_subscription_status",
+		"llm_pool_synced_at",
+	)
+
 	def setUp(self):
-		self._proxy = frappe.db.get_single_value("Jarvis Settings", "proxy_active")
-		self._llm_model = frappe.db.get_single_value("Jarvis Settings", "llm_model")
+		# frappe.get_single serves a CACHED doc, so a db.set_single_value written
+		# here is invisible to the endpoint unless the cache is dropped first
+		# (the stale-Single flake this suite has hit before).
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+		self._saved = {f: frappe.db.get_single_value("Jarvis Settings", f) for f in self._FIELDS}
 
 	def tearDown(self):
-		frappe.db.set_single_value("Jarvis Settings", "proxy_active", self._proxy or 0)
-		frappe.db.set_single_value("Jarvis Settings", "llm_model", self._llm_model or "")
+		for field, value in self._saved.items():
+			frappe.db.set_single_value("Jarvis Settings", field, value)
 		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
+
+	def _seed(self, **values):
+		"""Write Single fields and make them visible to frappe.get_single."""
+		for field, value in values.items():
+			frappe.db.set_single_value("Jarvis Settings", field, value)
+		frappe.db.commit()
+		frappe.clear_document_cache("Jarvis Settings", "Jarvis Settings")
 
 	def test_remaps_admin_auth_status_fields(self):
-		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 1)
-		frappe.db.commit()
+		self._seed(proxy_active=1)
 		raw = {
 			"ok": True,
 			"data": {
@@ -84,13 +103,151 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 				"openai_profile_expires_ms": 1893456000000,
 			},
 		}
-		with patch.object(admin_client, "post_llm_auth_status", return_value=raw) as m:
-			out = account.get_llm_connection_status()
+		# pool_primary_model is stubbed so default_model does not depend on
+		# whatever models[] the shared test site happens to hold - the local
+		# primary is preferred over admin's value, and its own preference is
+		# asserted in test_default_model_prefers_the_local_pool_primary below.
+		with patch.object(account, "pool_primary_model", return_value=""):
+			with patch.object(admin_client, "post_llm_auth_status", return_value=raw) as m:
+				out = account.get_llm_connection_status()
 		m.assert_called_once_with()
 		self.assertEqual(out["proxy_active"], True)
 		self.assertEqual(out["auth_present"], True)
 		self.assertEqual(out["oauth_expires_at"], 1893456000000)
 		self.assertEqual(out["default_model"], "gpt-5.5")
+
+	def test_default_model_prefers_the_local_pool_primary(self):
+		"""Admin answers default_model with the Bifrost virtual endpoint
+		("openai_compat/jarvis-pool"), which is not a model the customer picked.
+		The bench knows which member the container runs first, so that wins."""
+		self._seed(proxy_active=1)
+		raw = {"data": {"default_model": "openai_compat/jarvis-pool"}}
+		with patch.object(account, "pool_primary_model", return_value="glm-4.7"):
+			with patch.object(admin_client, "post_llm_auth_status", return_value=raw):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["default_model"], "glm-4.7")
+
+	# ---- health: admin's auth_profile_present is not a verdict (#561) ------- #
+	#
+	# compute_pool_mode is stubbed throughout rather than satisfied with real
+	# models[] rows, for the same reasons the DIRECT test below stubs
+	# _has_llm_config: seeding a real pool means writing encrypted Password
+	# fields into a shared Single (which survive a column blank and leak into
+	# every later test on the site), and reading the live models[] would make the
+	# outcome depend on whatever another test left behind. The subject here is
+	# which SIGNAL decides health, not how a pool is detected.
+
+	def test_a_serving_pool_is_not_disconnected_when_admin_reports_no_profiles(self):
+		"""The bug. cliproxy had both subscription auth files loaded and was
+		answering turns with them, while admin's post_llm_auth_status returned
+		auth_profile_present:false with an empty profile_ids - and the badge
+		rendered red "Not connected" over demonstrably working chat.
+
+		The admin claim is still passed through verbatim for support; it just
+		stops deciding anything.
+		"""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		raw = {"data": {"auth_profile_present": False, "profile_ids": []}}
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value=raw):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "ok")
+		self.assertFalse(out["disconnected"])
+		self.assertFalse(out["auth_present"])
+		self.assertTrue(out["pool_mode"])
+
+	def test_a_pool_the_container_never_received_is_still_reported_down(self):
+		"""The counterweight: health must not be a hardcoded green. With no
+		confirmed apply the container is not serving this config at all, which is
+		the same evidence is_ready_for_chat refuses to open chat on."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="failed: admin unreachable",
+			llm_pool_synced_at="",
+		)
+		raw = {"data": {"auth_profile_present": True, "profile_ids": ["openai"]}}
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value=raw):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "down")
+
+	def test_a_failed_apply_on_a_serving_pool_needs_attention(self):
+		"""Applied before, so the container keeps serving its previous config -
+		broken enough to flag, not broken enough to call disconnected."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="failed: subscription needs re-authentication (blocked)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "attention")
+
+	def test_a_rejected_subscription_needs_attention(self):
+		"""The fleet's own pool-wide probe said the account rejected a test
+		request. That is a real verdict about the workspace, unlike the auth
+		profile count."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+			last_subscription_status="unverified",
+		)
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "attention")
+
+	def test_an_unchecked_subscription_is_not_treated_as_a_failure(self):
+		"""An "unchecked" verdict means nobody looked (a no-op apply runs no probe
+		at all), which must not read as evidence of a problem."""
+		self._seed(
+			proxy_active=1,
+			last_sync_status="ok (pool_update via admin)",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+			last_subscription_status="unchecked",
+		)
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "ok")
+
+	def test_a_save_in_flight_reports_applying(self):
+		self._seed(
+			proxy_active=1,
+			last_sync_status="pending: admin applying config",
+			llm_pool_synced_at="2026-07-30 10:00:00",
+		)
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				out = account.get_llm_connection_status()
+		self.assertEqual(out["health"], "applying")
+
+	def test_shape_fields_describe_the_pool_rather_than_models_zero(self):
+		"""The Model/Provider/Auth-mode triple came from the legacy models[0]
+		mirror, so a 4-model pool was described by one member. These are the
+		fields the SPA replaces it with."""
+		self._seed(proxy_active=1, routing_mode="failover")
+		with patch.object(account, "compute_pool_mode", return_value=True):
+			with patch.object(admin_client, "post_llm_auth_status", return_value={"data": {}}):
+				out = account.get_llm_connection_status()
+		self.assertTrue(out["pool_mode"])
+		self.assertEqual(out["routing_mode"], "failover")
+		self.assertIn("model_count", out)
+		self.assertIn("sync_status", out)
+
+	def test_a_disconnected_workspace_is_down_and_says_so(self):
+		with patch.object(account, "_has_llm_config", return_value=False):
+			with patch.object(admin_client, "post_llm_auth_status") as m:
+				out = account.get_llm_connection_status()
+		m.assert_not_called()
+		self.assertTrue(out["disconnected"])
+		self.assertEqual(out["health"], "down")
 
 	def test_direct_tenant_short_circuits_without_admin_call(self):
 		# A DIRECT (single-model) tenant has no proxy auth profile to report -
@@ -104,9 +261,7 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		# one afterwards leaves the secret in __Auth and leaks a test key into
 		# every later test on the site. It would also make the outcome depend on
 		# whatever models[] the shared test site happens to hold.
-		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
-		frappe.db.set_single_value("Jarvis Settings", "llm_model", "gpt-4o")
-		frappe.db.commit()
+		self._seed(proxy_active=0, llm_model="gpt-4o")
 		with patch.object(account, "_has_llm_config", return_value=True):
 			with patch.object(admin_client, "post_llm_auth_status") as m:
 				out = account.get_llm_connection_status()
@@ -125,9 +280,7 @@ class TestGetLlmConnectionStatus(FrappeTestCase):
 		This is the shape jarvis.oauth.api.disconnect leaves behind - it clears
 		the OAuth side and deliberately keeps llm_provider / llm_model.
 		"""
-		frappe.db.set_single_value("Jarvis Settings", "proxy_active", 0)
-		frappe.db.set_single_value("Jarvis Settings", "llm_model", "gpt-4o")
-		frappe.db.commit()
+		self._seed(proxy_active=0, llm_model="gpt-4o")
 		with patch.object(account, "_has_llm_config", return_value=False):
 			with patch.object(admin_client, "post_llm_auth_status") as m:
 				out = account.get_llm_connection_status()


### PR DESCRIPTION
Fixes #561

Settings > General showed a red "Not connected" on a workspace whose chat
demonstrably worked, and its Model / Provider / Auth mode rows described a single
member of a four-model pool.

## The status

Admin's `post_llm_auth_status` returned `auth_profile_present: false` with
`profile_ids: []` for a tenant whose two chat subscriptions were serving turns,
and the badge trusted that boolean alone. This is a regression of a bug already
fixed once for direct tenants (see the `get_llm_connection_status` docstring),
which was fixed by short-circuiting before the admin round trip. The proxy branch
never got the same treatment.

`get_llm_connection_status` now computes a local `health` verdict and the badge
reads only that. `auth_present` is still returned for support, it just stops
deciding anything.

The signal is the durable marker the fleet stamps when it confirms an apply,
which is what `is_ready_for_chat` already gates chat on: `llm_pool_synced_at` for
a pool (including a BYO api-key pool, which has no sidecar but still syncs through
`/llm-pool`), `llm_oauth_connected_at` for a direct subscription tenant, and
`llm_direct_synced_at` otherwise. **The badge and the chat gate therefore cannot
disagree.** The tenant in #561 reached chat because that marker was stamped, so
the same evidence turns the badge green.

It can still report a real failure four ways: `disconnected` when no credential
exists, `down` when the container never confirmed the config (chat is gated for
the same reason, so it is never a false alarm), `attention` on a failed apply or
an explicitly rejected subscription, and `applying` while a save is in flight.
`last_subscription_status == "unchecked"` means nobody looked (a no-op apply runs
no probe) and is deliberately not treated as evidence of a problem.

Per-model verdicts are excluded on purpose: AI models shows them per row, and one
dead member of a healthy failover chain is what failover is for.

## The three rows

For a pool tenant the triple is replaced by a `Mode` row, a one-line `Models`
summary ("4 models, failover, up to date") and a Manage models button that
switches to the AI models pane. The triple stays for a single-credential tenant,
where it is accurate. It could not be fixed, only narrowed to something true: it
was assembled from the legacy `models[0]` mirror under a Model row naming the
synthetic Bifrost endpoint. `default_model` now prefers `pool_primary_model`, the
member the container actually runs first, over admin's `openai_compat/jarvis-pool`.

## Vocabulary

`Mode` names the topology and `Status` reports health, so "Direct" stops
masquerading as a status, which is what made General and Billing appear to
disagree. The wording lives in one shared `connectionModeLabel(proxyActive,
enabledCount)` in `frontend/src/llm/pool.js`, called by both panes, and the
summary reuses `humaniseSyncStatus` so one sync state cannot be described two
ways.

Pool mode and proxy activation stay separate by construction, since the helper
takes them as distinct arguments. A multi-model api-key pool is `Pool (direct
failover)`: a pool, and direct, with no sidecar. Only a chat subscription, which
needs CLIProxyAPI to serve an OAuth blob, earns `Pool (proxied)`. The server
likewise returns `pool_mode` and `proxy_active` as separate fields.

## Tests

9 new Python tests in `jarvis/tests/test_llm_monitor.py`, 2 JS tests for
`connectionModeLabel`. The pair that matters: a serving pool is not reported
disconnected when admin reports zero profiles (the bug), and a pool the container
never received is still `down` (the counterweight, so health is not a hardcoded
green). Also covered: a failed apply is `attention`, a rejected subscription is
`attention`, an unchecked one is not.

`setUp` calls `frappe.clear_document_cache` and re-clears after every write, since
`frappe.get_single` serves a cached doc. `compute_pool_mode` and
`pool_primary_model` are stubbed rather than satisfied with real rows, following
the existing tests, because seeding a real pool writes encrypted Password fields
into a shared Single.

## Not fixed here

Why admin reports zero auth profiles for connected subscriptions is a control
plane bug in another repo. This PR stops the customer plane drawing a false
conclusion from it. See the issue comments for the evidence and a lead.
