### PR TITLE
fix(llm): record a permanent admin config rejection as terminal, not pending

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -22,6 +22,7 @@ import requests
 from jarvis.exceptions import (
 	AdminAuthError,
 	AdminRateLimitedError,
+	AdminRejectedError,
 	AdminUnreachableError,
 	AdminValidationError,
 )
@@ -607,7 +608,12 @@ def _raise_for_admin_raw(resp):
 	"""Status routing for a RAW Response, mirroring _do_post's envelope routing (R1-3): 2xx returns
 	the Response; 401/403 -> AdminAuthError (drives the ladder); 429 -> AdminRateLimitedError; other
 	4xx -> AdminValidationError; 5xx -> AdminUnreachableError. DRIFT-GUARD: keep in sync with
-	_do_post's status branches — mirror any change there in both places."""
+	_do_post's status branches - mirror any change there in both places.
+
+	One branch deliberately has NO mirror: _do_post's AdminRejectedError needs admin's
+	structured ``error.code``, and this path streams raw bytes (media download) with no
+	envelope to read it from. A rejection here stays an AdminUnreachableError, which is
+	right - no media caller waits on a reconcile."""
 	if resp.status_code < 400:
 		return resp
 	if resp.status_code in (401, 403):
@@ -1481,6 +1487,45 @@ def _envelope_error_message(envelope) -> str:
 	return _scrub_secrets(err.get("message") or "")
 
 
+# Admin ``error.code`` values that name a PERMANENT rejection: the admin was
+# reached, validated the request and refused it, so re-sending the SAME payload
+# can never converge. jarvis_admin_v2's @fleet_endpoint answers a FleetError
+# with HTTP 502 and ``error.code`` = the raising class's name, so a config
+# refusal arrives on the wire wearing the same status as a gateway fault - which
+# is how a rejected creds push came to be recorded as "pending: admin applying
+# config" forever (jarvis #542).
+#
+# An ALLOWLIST, not a denylist: an unrecognised code keeps today's optimistic
+# "admin may still be reconciling" handling, so a fleet error class we have not
+# classified yet can only ever be too patient, never wrongly terminal.
+_PERMANENT_REJECTION_CODES = frozenset(
+	{
+		# Bad provider slug, a provider with no resolvable base_url, an
+		# unusable openclaw render - deterministic in the request itself.
+		"FleetConfigError",
+		# A pool apply the fleet-agent permanently rejected (its invalid_spec
+		# envelope class). admin's own docstring: retrying the same desired
+		# spec against a healthy fleet-agent can never converge.
+		"PoolSpecRejected",
+	}
+)
+
+
+def _permanent_rejection_code(envelope) -> str:
+	"""admin's ``error.code`` when it names a permanent rejection, else "".
+
+	Only ever consulted on a response the admin actually shaped (an ``ok:
+	false`` envelope) - a proxy's HTML 502 has no envelope and never reaches
+	here, so a genuine gateway fault cannot be mistaken for a refusal."""
+	if not isinstance(envelope, dict):
+		return ""
+	err = envelope.get("error")
+	if not isinstance(err, dict):
+		return ""
+	code = err.get("code") or ""
+	return code if code in _PERMANENT_REJECTION_CODES else ""
+
+
 def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str) -> dict:
 	try:
 		resp = requests.post(url, json=body, headers=headers, timeout=timeout_s)
@@ -1586,6 +1631,13 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	#   4xx + envelope -> AdminValidationError (clean text to UI)
 	#   5xx + envelope -> AdminUnreachableError (network / admin-down)
 	#   200 with ok:false (rare; some endpoints inline failure) -> AdminUnreachableError
+	#
+	# jarvis #542 refines the last two: a 5xx (or an inlined ok:false) whose
+	# ``error.code`` is on _PERMANENT_REJECTION_CODES is admin REFUSING the
+	# request, not admin being unwell, so it raises the AdminRejectedError
+	# subclass carrying that code + admin's own message. Callers that retry or
+	# wait for a reconcile branch on it; everything else keeps catching the
+	# base class exactly as before.
 	if resp.status_code >= 400:
 		msg = _envelope_error_message(envelope)
 		if not msg:
@@ -1598,6 +1650,13 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 			msg = f"admin returned {resp.status_code}"
 		if 400 <= resp.status_code < 500:
 			raise AdminValidationError(msg)
+		rejected = _permanent_rejection_code(envelope)
+		if rejected:
+			raise AdminRejectedError(
+				f"admin returned a {resp.status_code} error: {msg}",
+				code=rejected,
+				detail=msg,
+			)
 		raise AdminUnreachableError(f"admin returned a {resp.status_code} error: {msg}")
 	if isinstance(envelope, dict) and not envelope.get("ok", True):
 		err = envelope.get("error", {}) or {}
@@ -1612,5 +1671,7 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 		# Keep code in the message (stable identifier admin_client
 		# callers + ops can grep for). admin_url is intentionally
 		# omitted - the bench knows where it's pointing.
+		if _permanent_rejection_code(envelope):
+			raise AdminRejectedError(f"{code}: {msg}", code=code, detail=msg)
 		raise AdminUnreachableError(f"{code}: {msg}")
 	return envelope.get("data", envelope) if isinstance(envelope, dict) else envelope

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -110,6 +110,37 @@ class AdminUnreachableError(JarvisError):
 	"""HTTPS call to jarvis_admin failed (network, timeout, 5xx, non-JSON)."""
 
 
+class AdminRejectedError(AdminUnreachableError):
+	"""jarvis_admin was REACHED and PERMANENTLY refused the request.
+
+	The admin's fleet layer answers a config it can never accept (an unknown
+	provider slug, a spec the fleet-agent rejects) with HTTP 502 carrying its
+	own structured ``error.code`` - the same status a genuine gateway fault
+	uses. Collapsing both into ``AdminUnreachableError`` is what let a
+	deterministic rejection be recorded as "pending: admin applying config"
+	forever: the caller assumed admin had persisted the desired state and
+	would reconcile it, when in fact admin threw during validation and stored
+	nothing (jarvis #542).
+
+	``code`` is admin's own ``error.code`` (the raising exception's class
+	name, e.g. ``FleetConfigError``); ``detail`` is admin's ``error.message``
+	on its own, WITHOUT the "admin returned a 502 error: " wrapper the
+	exception message carries, so a caller can put the reason in front of a
+	customer without re-parsing it back out.
+
+	Deliberately a SUBCLASS of AdminUnreachableError: every other catch site
+	already treats an admin failure as terminal, so inheriting leaves them
+	correct with no change at all. Only the two sites that treat an
+	unreachable admin as "the apply is still landing" need to branch, and
+	they do it with an explicit handler ahead of their unreachable one.
+	"""
+
+	def __init__(self, message: str, *, code: str = "", detail: str = ""):
+		super().__init__(message)
+		self.code = code
+		self.detail = detail
+
+
 class AdminAuthError(JarvisError):
 	"""jarvis_admin rejected the token / site (401 / 403).
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -854,6 +854,29 @@ class JarvisSettings(Document):
 				title="Jarvis: admin auth failed",
 				message=frappe.get_traceback(),
 			)
+		except admin_client.AdminRejectedError as e:
+			# jarvis #542: admin was REACHED and permanently refused this config
+			# (an unknown provider slug, an unusable spec). The F2 handling below
+			# is right for a timeout - admin persists desired-first and reconciles
+			# a late apply - but its premise is false here: admin threw during
+			# validation and stored NOTHING, so there is no desired state for the
+			# */5 reconcile to converge to and "pending:" would never resolve.
+			# The customer sat on "Applying your changes" forever while admin
+			# already knew the exact reason. Terminal, carrying that reason, like
+			# the neighbouring auth/rate-limit branches.
+			reason = _admin_rejection_reason(e)
+			self.db_set(
+				{
+					"last_sync_at": frappe.utils.now(),
+					"last_sync_status": f"failed: {reason}",
+				}
+			)
+			_commit_terminal_sync_status()
+			terminal_written = True
+			frappe.log_error(
+				title="Jarvis: admin rejected the LLM config",
+				message=frappe.get_traceback(),
+			)
 		except admin_client.AdminUnreachableError as e:
 			# F2: for a "restart" (creds re-render), an unreachable/timeout is an
 			# apply the admin persisted desired-first and will reconcile - not a
@@ -1129,10 +1152,42 @@ def _admin_customer_facing_reason(message: str) -> str:
 	return ""
 
 
+def _admin_rejection_reason(e) -> str:
+	"""The customer-facing reason to record for an AdminRejectedError.
+
+	Admin sometimes writes the sentence itself (fleet's "Your ..." convention -
+	see _admin_customer_facing_reason above); that is already prose aimed at a
+	customer, so it passes straight through and reads identically to the
+	quota-exhausted case the pool path has recorded since 2026-07-23.
+
+	Everything else is a raw diagnostic written for an engineer ("unknown
+	llm_provider: 'gemini'"). It is still the single most useful thing the
+	customer can be told, so it IS surfaced verbatim - but behind a short
+	lead-in of our own, never standing alone as though Jarvis had phrased it.
+	Same shape the AI-models list uses for a probe's contract-1.12 ``detail``
+	("Not working: <detail>"), so the two upstream-reason surfaces read alike.
+	"""
+	detail = (getattr(e, "detail", "") or "").strip()
+	if not detail:
+		# No structured detail (a hand-built error, or a raise site added later
+		# that forgot it): fall back to the message with admin_client's "admin
+		# returned a NNN error: " wrapper stripped, so the plumbing never shows.
+		wrapped = _ADMIN_WRAPPED_ERROR_RE.match(str(e).strip())
+		detail = (wrapped.group(1) if wrapped else str(e)).strip()
+	sentence = _admin_customer_facing_reason(detail)
+	if sentence:
+		return sentence
+	if not detail:
+		return "Your AI configuration was rejected"
+	return f"Your AI configuration was rejected: {detail}"
+
+
 def _post_pool_with_retry(spec, api_keys, oauth_blobs):
 	"""post_update_llm_pool, retrying only the transient AdminUnreachableError.
 	Re-raises the last unreachable error after exhausting retries; other Admin*
-	errors propagate immediately (not retried)."""
+	errors propagate immediately (not retried) - including AdminRejectedError,
+	which IS an AdminUnreachableError subclass but names a spec admin already
+	refused, so re-POSTing the identical payload can only be refused again."""
 	import time as _time
 
 	import frappe as _frappe
@@ -1154,6 +1209,10 @@ def _post_pool_with_retry(spec, api_keys, oauth_blobs):
 
 				record_synced_snapshot()
 			return result
+		except admin_client.AdminRejectedError:
+			# Permanent: admin validated the spec and refused it. Burning the
+			# second attempt (and its 5s sleep) buys a second identical refusal.
+			raise
 		except admin_client.AdminUnreachableError as e:
 			last = e
 			_frappe.logger().warning(
@@ -1371,6 +1430,27 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
 				title="Jarvis: admin auth failed (pool sync)",
 				message=_frappe.get_traceback(),
 			)
+		except admin_client.AdminRejectedError as e:
+			# jarvis #542, the structured half of the branch below: admin named
+			# the refusal itself (an ``error.code`` on _PERMANENT_REJECTION_CODES,
+			# e.g. FleetConfigError on an unknown provider slug) instead of only
+			# implying it through a "Your ..." sentence. Nothing was persisted, so
+			# no reconcile can ever finish it - terminal, with admin's reason.
+			reason = _admin_rejection_reason(e)
+			settings.db_set(
+				{
+					"last_sync_at": _frappe.utils.now(),
+					"last_sync_status": f"failed: {reason}",
+					**_cleared_subscription_status_fields(),
+				}
+			)
+			_commit_terminal_sync_status()
+			terminal_written = True
+			_frappe.log_error(
+				title="Jarvis: admin rejected the LLM pool config",
+				message=_frappe.get_traceback(),
+			)
+			return
 		except admin_client.AdminUnreachableError as e:
 			# This fix (2026-07-23 out-of-quota trace): admin's fleet layer can
 			# raise a DEFINITIVE, already-decided rejection - e.g. a

--- a/jarvis/tests/test_admin_client.py
+++ b/jarvis/tests/test_admin_client.py
@@ -436,6 +436,122 @@ class TestAdminErrorResponses(FrappeTestCase):
 		self.assertEqual(str(cm.exception), "customer status: Suspended")
 
 
+class TestPermanentRejectionClassification(FrappeTestCase):
+	"""jarvis #542: 502 is admin's answer BOTH to a gateway fault AND to its
+	fleet layer permanently refusing the config (@fleet_endpoint answers every
+	FleetError with 502 + error.code = the raising class's name). Only the
+	second is terminal, and that code is the only thing telling them apart.
+
+	Deliberately drives a FAKE settings doc (the same seam
+	test_api_key_decrypted_via_get_password_not_attribute uses) instead of the
+	_settings_for_admin / _settings_clear_admin fixture: these tests need no
+	real state, and that fixture COMMITS - its teardown removes the site's
+	stored admin passwords from __Auth, outside FrappeTestCase's rollback. A
+	classification test must not be able to take a bench's admin credentials
+	with it."""
+
+	def _fake_settings(self):
+		fake = MagicMock()
+		fake.jarvis_admin_url = "https://admin.example.com"
+		# No OAuth password stored -> _admin_access_token short-circuits and the
+		# call goes out on the legacy api_key:api_secret header.
+		fake.jarvis_admin_customer_email = ""
+
+		def _get_password(field, raise_exception=False):
+			return {
+				"jarvis_admin_api_key": "fake-key",
+				"jarvis_admin_api_secret": "fake-secret",
+			}.get(field, "")
+
+		fake.get_password.side_effect = _get_password
+		return fake
+
+	def _post_creds(self, response):
+		"""Run one creds push against a canned admin response, touching no DB."""
+		with (
+			patch("frappe.get_single", return_value=self._fake_settings()),
+			patch("requests.post", MagicMock(return_value=response)),
+		):
+			post_update_llm_creds("p", "m", "b", "k")
+
+	def test_502_with_permanent_rejection_code_raises_rejected(self):
+		with self.assertRaises(admin_client.AdminRejectedError) as cm:
+			self._post_creds(
+				_mock_response(
+					502,
+					json_body={
+						"message": {
+							"ok": False,
+							"error": {
+								"code": "FleetConfigError",
+								"message": "unknown llm_provider: 'gemini'",
+							},
+						}
+					},
+				)
+			)
+		self.assertEqual(cm.exception.code, "FleetConfigError")
+		# detail is admin's message ALONE - without the "admin returned a 502
+		# error: " wrapper the message carries - so a caller can put it in front
+		# of a customer without parsing it back out.
+		self.assertEqual(cm.exception.detail, "unknown llm_provider: 'gemini'")
+		self.assertIn("unknown llm_provider", str(cm.exception))
+
+	def test_rejected_error_is_an_unreachable_subclass(self):
+		"""Every pre-existing catch site keys off AdminUnreachableError and
+		already records a terminal failure, so inheriting leaves all of them
+		correct without touching one. Only the two sites that WAIT on a
+		reconcile branch on the subclass."""
+		self.assertTrue(issubclass(admin_client.AdminRejectedError, AdminUnreachableError))
+
+	def test_502_with_unrecognised_code_stays_unreachable(self):
+		"""Allowlist, not denylist: a fleet error class we have not classified
+		(a health-check timeout here) keeps the optimistic converge/pending
+		handling, so an unclassified code can only ever be too patient."""
+		with self.assertRaises(AdminUnreachableError) as cm:
+			self._post_creds(
+				_mock_response(
+					502,
+					json_body={
+						"message": {
+							"ok": False,
+							"error": {"code": "HealthCheckError", "message": "healthz timed out"},
+						}
+					},
+				)
+			)
+		self.assertNotIsInstance(cm.exception, admin_client.AdminRejectedError)
+
+	def test_non_json_502_stays_unreachable(self):
+		"""A real gateway fault (an nginx HTML 502) carries no envelope at all,
+		so it can never be read as a refusal."""
+		with self.assertRaises(AdminUnreachableError) as cm:
+			self._post_creds(_mock_response(502, json_body=None, text="<html>502 Bad Gateway</html>"))
+		self.assertNotIsInstance(cm.exception, admin_client.AdminRejectedError)
+
+	def test_200_ok_false_with_permanent_code_raises_rejected(self):
+		"""The rare inlined-failure envelope gets the same classification, so an
+		endpoint that reports its refusal at 200 is not the one shape that can
+		still strand a tenant in "pending"."""
+		with self.assertRaises(admin_client.AdminRejectedError) as cm:
+			self._post_creds(
+				_mock_response(
+					200,
+					json_body={
+						"message": {
+							"ok": False,
+							"error": {
+								"code": "PoolSpecRejected",
+								"message": "Your subscription cannot serve this.",
+							},
+						}
+					},
+				)
+			)
+		self.assertEqual(cm.exception.code, "PoolSpecRejected")
+		self.assertEqual(cm.exception.detail, "Your subscription cannot serve this.")
+
+
 class TestSecretScrubbingAtBoundary(FrappeTestCase):
 	"""Cross-repo punch-list "secret values can leak to last_sync_status /
 	Error Log via upstream passthrough" from the 2026-06-16 review.

--- a/jarvis/tests/test_settings_on_update.py
+++ b/jarvis/tests/test_settings_on_update.py
@@ -230,6 +230,62 @@ class TestOnUpdateStatus(_SettingsSingletonTestCase):
 		self.assertIn("failed", settings.last_sync_status or "")
 		self.assertIn("admin unreachable", settings.last_sync_status or "")
 
+	# jarvis #542: on a "restart" the two failures below arrive as the SAME
+	# exception class off the wire (admin answers a gateway fault and a config
+	# refusal with the same 502), and they must end in opposite states - one
+	# waits for the admin reconcile, the other can only ever be refused again.
+
+	def test_transient_unreachable_on_restart_records_pending(self):
+		"""F2, unchanged: admin persists a creds re-render desired-first and
+		reconciles a late apply, so a timeout is pending, never a lost change."""
+		from jarvis.exceptions import AdminUnreachableError
+
+		settings = frappe.get_single("Jarvis Settings")
+		settings.llm_provider = "Anthropic"
+		settings.llm_model = "claude-sonnet-4-6"
+		with (
+			patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				side_effect=AdminUnreachableError("read timeout"),
+			),
+			patch("jarvis.admin_client.get_connection", return_value={"chat_readiness": "Configuring"}),
+		):
+			settings.save()
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.last_sync_status, "pending: admin applying config")
+
+	def test_permanent_rejection_on_restart_records_failed_with_the_reason(self):
+		"""admin threw during validation and persisted NOTHING, so there is no
+		desired state for the */5 reconcile to converge to - "pending" would
+		read as "Applying your changes" forever. Terminal, carrying admin's own
+		reason, and get_connection is never even consulted."""
+		from jarvis.exceptions import AdminRejectedError
+
+		settings = frappe.get_single("Jarvis Settings")
+		settings.llm_provider = "Anthropic"
+		settings.llm_model = "claude-sonnet-4-6"
+		with (
+			patch(
+				"jarvis.admin_client.post_update_llm_creds",
+				side_effect=AdminRejectedError(
+					"admin returned a 502 error: unknown llm_provider: 'gemini'",
+					code="FleetConfigError",
+					detail="unknown llm_provider: 'gemini'",
+				),
+			),
+			patch("jarvis.admin_client.get_connection") as get_conn,
+		):
+			settings.save()
+			get_conn.assert_not_called()
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			settings.last_sync_status,
+			"failed: Your AI configuration was rejected: unknown llm_provider: 'gemini'",
+		)
+		# last_sync_at stayed NULL on the pending path, which left support with
+		# no signal either - a terminal verdict always stamps it.
+		self.assertIsNotNone(settings.last_sync_at)
+
 	def test_save_succeeds_even_when_admin_call_fails(self):
 		from jarvis.exceptions import AdminUnreachableError
 

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -3849,6 +3849,62 @@ class TestConvergenceReconcile(_RT3SettingsTestCase):
 		self.assertFalse(settings.llm_pool_synced_at)
 		self.assertEqual(settings.last_subscription_status, "", "must clear stale subscription_status")
 
+	# -- jarvis #542: a rejection admin NAMED with a structured error.code ---
+	# (not merely implied through its "Your ..." sentence) is terminal too.
+
+	def test_rejected_pool_apply_records_failed_and_is_not_retried(self):
+		"""A raw diagnostic ("unknown llm_provider: 'gemini'") is the single most
+		useful thing the customer can be told, so it is surfaced verbatim behind
+		a lead-in of our own. Nothing was persisted admin-side, so the transient
+		retry and the converge poll are both pure waste here."""
+		from jarvis.exceptions import AdminRejectedError
+
+		self._seed_pool()
+		rejection = AdminRejectedError(
+			"admin returned a 502 error: unknown llm_provider: 'gemini'",
+			code="FleetConfigError",
+			detail="unknown llm_provider: 'gemini'",
+		)
+		with (
+			patch("jarvis.admin_client.post_update_llm_pool", side_effect=rejection) as push,
+			patch("jarvis.admin_client.get_connection") as get_conn,
+		):
+			_enqueued_sync_via_admin_pool()
+			get_conn.assert_not_called()
+			self.assertEqual(push.call_count, 1, "a permanent rejection must not burn the transient retry")
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(
+			settings.last_sync_status,
+			"failed: Your AI configuration was rejected: unknown llm_provider: 'gemini'",
+		)
+		self.assertFalse(settings.llm_pool_synced_at)
+		self.assertEqual(settings.last_subscription_status, "", "must clear stale subscription_status")
+
+	def test_rejected_pool_apply_keeps_admins_own_customer_sentence(self):
+		"""When admin phrased the refusal itself (its "Your ..." convention) that
+		sentence is already customer prose - it must pass through unchanged
+		rather than picking up the raw-diagnostic lead-in, so a structurally
+		classified rejection reads identically to the 2026-07-23 quota case."""
+		from jarvis.exceptions import AdminRejectedError
+
+		self._seed_pool()
+		sentence = "Your OpenAI account has reached its usage limit. It resets in about 27 hours."
+		with (
+			patch(
+				"jarvis.admin_client.post_update_llm_pool",
+				side_effect=AdminRejectedError(
+					f"admin returned a 502 error: {sentence}",
+					code="PoolSpecRejected",
+					detail=sentence,
+				),
+			),
+			patch("jarvis.admin_client.get_connection") as get_conn,
+		):
+			_enqueued_sync_via_admin_pool()
+			get_conn.assert_not_called()
+		settings = frappe.get_single("Jarvis Settings")
+		self.assertEqual(settings.last_sync_status, f"failed: {sentence}")
+
 	# -- Scheduled safety net (reconcile_pending_llm_sync) -------------------
 
 	def test_reconcile_stamps_marker_when_admin_reports_ready(self):


### PR DESCRIPTION
Fixes #542

A permanent, will-never-succeed config rejection from the control plane was
indistinguishable from a transient outage, so it was recorded as
`pending: admin applying config` and retried forever while the customer watched
"Applying your changes" indefinitely.

## Why it happened

`admin_client` collapsed every non-2xx into `AdminUnreachableError`, and the
`restart` branch deliberately treats an unreachable admin as an apply the control
plane persisted desired-first and will reconcile. That is correct for a timeout or
a gateway fault. It is wrong for a spec admin will refuse every time.

It is worse than it looks on the wire: `jarvis_admin_v2`'s `@fleet_endpoint`
answers every `FleetError` with `502` plus `error.code = type(e).__name__`, so a
config refusal wears the same status code as a real gateway fault. The status code
cannot discriminate. Admin's own `error.code` is the only signal.

## The classification

New `AdminRejectedError`, raised only for an envelope whose `error.code` is in
`_PERMANENT_REJECTION_CODES = {"FleetConfigError", "PoolSpecRejected"}`, the two
classes admin's `fleet/exceptions.py` documents as deterministic in the request.
Applies to 5xx-with-envelope and to `200 + ok:false`.

This is an **allowlist, not a denylist**. An unclassified fleet error keeps
today's optimistic handling, so the change can only ever be too patient, never
wrongly terminal. A real gateway fault has no envelope and exits at the non-JSON
branch before this is reached.

`AdminRejectedError` **subclasses** `AdminUnreachableError` on purpose, so the
default at all 14 catch sites is "no change". Three were changed, the three that
wait or retry: `_sync_via_admin` (the bug), `_enqueued_sync_via_admin_pool` (same,
plus clearing stale subscription status), and `_post_pool_with_retry` (bare
`raise`, so a refused spec does not burn the second attempt and its 5s sleep). The
other eleven already write a terminal failure or a clean user-facing error, so
inheriting is correct. Each was checked individually; the list is in the issue
thread.

`_raise_for_admin_raw`, the streamed-media twin, gets no mirror: it has no
envelope to read a code from and no media caller waits on a reconcile. Documented
in its docstring with a drift-guard note.

## What the customer sees

Existing vocabulary, nothing invented. `failed: <reason>` is what the auth,
rate-limit and validation branches already write, and `humaniseSyncStatus` already
maps a `failed` prefix to "Last sync failed" plus detail. `isSyncPending` goes
false, so the SPA poller and the onboarding spinner stop.

Admin's own customer-prose sentence passes through verbatim. A raw diagnostic gets
a short lead-in rather than standing alone as if Jarvis had phrased it, following
the established contract-1.12 `detail` convention:

> Last sync failed. Your AI configuration was rejected: unknown llm_provider: 'gemini'

`last_sync_at` is stamped and an Error Log row written, closing the "support has
no signal" half of the issue. `reconcile_pending_llm_sync` still treats `failed:`
as eligible for an unproven tenant, so a config that later becomes valid can still
flip to ok.

## Tests

9 added across three modules: permanent code on 502 raises `AdminRejectedError`
with code and unwrapped detail, the subclass relationship asserted explicitly
(it is what keeps 11 catch sites correct), an unrecognised 5xx code stays plain
unreachable, a non-JSON 502 stays plain unreachable, `200 + ok:false` classified,
a transient restart still records pending, a permanent rejection records terminal
with reason and `get_connection` never called, and for the pool path
`push.call_count == 1` proving the retry is skipped.

**Note for the reviewer: these tests passed locally before a fixture refactor and
have not been re-run since, so CI is the real gate on them.** See below for why
the refactor was necessary.

## A hazard found on the way

The pre-existing `TestAdminErrorResponses._settings_for_admin` fixture **commits**
and calls `remove_encrypted_password` on three Password fields, escaping
`FrappeTestCase` rollback. Running that module against a real site wipes its admin
credentials for real; it did exactly that during verification here. The new tests
were moved into their own class driving a fake settings doc via
`patch("frappe.get_single", ...)`, so they touch no DB row and have no teardown.
The hazardous fixture still exists for the pre-existing tests. Filed separately.

## For a reviewer to scrutinise

- The **allowlist contents are a cross-repo contract**. If admin renames
  `FleetConfigError` or routes a new permanent class through `@fleet_endpoint`,
  this silently reverts to the patient path. That is why it is an allowlist with a
  comment rather than a status-code rule.
- The **subclass choice** means `isinstance(e, AdminUnreachableError)` is now true
  for a rejection. Any future site needing to distinguish must handle the subclass
  first. Both new handlers and the retry guard are ordered ahead of their
  base-class handler.
- The **`200 + ok:false` branch** extends slightly beyond the reported bug, for
  consistency, so an endpoint that inlines its refusal is not the one remaining
  shape that can strand a tenant.
- **Not implemented:** the issue's optional suggestion to bound how long a
  `pending:` may sit without an `applied_version` advance. That is a broader safety
  net for rejection shapes nobody predicted and deserves its own change.
