### PR TITLE
fix(settings): count tool calls from persisted rows, not the live run stream

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -38,6 +38,13 @@ export const setAutoApply = (conversation, value) =>
 // null/zeros until then (design doc §6, UsagePane's "Measured usage" block).
 export const getUsage = (conversation) =>
 	call("jarvis.chat.api.get_usage", { conversation: conversation || "" });
+// Tool runs recorded in one chat, newest turn first, from the PERSISTED tool
+// rows: the same rows the thread's Activity accordion renders. The Settings
+// Activity pane used to derive this from the browser's live run stream, which
+// read zero on every reload (#551). Response: {runs:[{tools,ms,names}],
+// tool_calls}.
+export const getToolActivity = (conversation) =>
+	call("jarvis.chat.api.get_tool_activity", { conversation });
 // ---- account reconnect (fresh bench -> existing paid subscription) ---------
 export const reconnectAvailable = (email, company = "") =>
 	call("jarvis.onboarding.reconnect_available", { email, company });

--- a/frontend/src/components/settings/ActivityPane.vue
+++ b/frontend/src/components/settings/ActivityPane.vue
@@ -2,24 +2,23 @@
 	<SettingsPane title="Activity" description="Recent tool calls in this chat.">
 		<h3 class="text-base font-semibold text-ink-gray-9">Recent tool runs</h3>
 
-		<div
-			v-if="!recentActivity.length"
-			class="flex flex-col items-center gap-2 py-12 text-center"
-		>
+		<div v-if="loading" class="mt-2 text-p-sm text-ink-gray-6">Loading…</div>
+
+		<div v-else-if="!runs.length" class="flex flex-col items-center gap-2 py-12 text-center">
 			<FeatherIcon name="activity" class="size-8 text-ink-gray-4" />
 			<span class="text-base text-ink-gray-6">No tool activity in this chat yet.</span>
 		</div>
 
 		<div v-else class="mt-2">
 			<div
-				v-for="(a, i) in recentActivity"
+				v-for="(a, i) in runs"
 				:key="i"
 				class="border-t py-2.5 first:border-t-0 first:pt-0"
 			>
 				<div class="flex items-center gap-2 text-p-sm text-ink-gray-7">
 					<FeatherIcon name="tool" class="size-4 text-ink-gray-5" />
 					<span>{{ a.tools }} tool{{ a.tools === 1 ? "" : "s" }}</span>
-					<span class="ml-auto tabular-nums text-ink-gray-5"
+					<span v-if="a.ms" class="ml-auto tabular-nums text-ink-gray-5"
 						>{{ (a.ms / 1000).toFixed(1) }}s</span
 					>
 				</div>
@@ -35,11 +34,49 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { FeatherIcon } from "frappe-ui";
 import { useShellStore } from "@/stores/shell";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
+import * as api from "@/api";
 
 const shell = useShellStore();
-const recentActivity = computed(() => shell.chatContext?.sessionStats?.recentActivity || []);
+
+// Persisted tool rows, fetched per chat. This pane used to read a per-run map
+// the chat view stamps on the live run:end event, which exists only for the
+// lifetime of that mount, so a reload, a route change, or simply reopening an
+// older chat showed "no tool activity" over a transcript full of tool cards
+// (#551). An audit surface has to read the records, not the event stream.
+const runs = ref([]);
+const loading = ref(true);
+// Reload when the chat changes AND when it gains messages, so a turn that
+// finishes while this pane is open lands here too. A STRING key on purpose:
+// ChatView republishes chatContext as a fresh object on almost every state
+// change, so an array/object key would compare unequal every time and refetch
+// on each republish.
+const chatKey = computed(
+	() =>
+		`${shell.chatContext?.conversationId || ""}:${
+			shell.chatContext?.sessionStats?.msgCount || 0
+		}`
+);
+
+async function loadActivity() {
+	const conversation = shell.chatContext?.conversationId;
+	if (!conversation) {
+		runs.value = [];
+		loading.value = false;
+		return;
+	}
+	try {
+		const r = await api.getToolActivity(conversation);
+		runs.value = (r && r.runs) || [];
+	} catch {
+		runs.value = [];
+	}
+	loading.value = false;
+}
+
+onMounted(loadActivity);
+watch(chatKey, loadActivity);
 </script>

--- a/frontend/src/components/settings/UsagePane.vue
+++ b/frontend/src/components/settings/UsagePane.vue
@@ -1,6 +1,6 @@
 <template>
 	<SettingsPane title="Usage" description="Message and token counts for this device.">
-		<template v-if="measured">
+		<template v-if="hasMeasured">
 			<h3 class="text-base font-semibold text-ink-gray-9">Measured usage</h3>
 			<div class="mt-2">
 				<KvRow
@@ -63,8 +63,17 @@
 			<hr class="my-8" />
 		</template>
 
+		<!-- The wording changes with the block above: naming the measured totals
+		     only makes sense when they are on screen. -->
 		<p class="flex flex-wrap items-center gap-2 text-p-sm text-ink-gray-6">
-			Estimated tokens, messages and tool activity for your workspace.
+			<template v-if="hasMeasured">
+				Workspace activity. Token figures here are estimated from the stored transcript, so
+				they read lower than the measured totals above, which also count the instructions
+				and history sent with every turn.
+			</template>
+			<template v-else>
+				Estimated tokens, messages and tool activity for your workspace.
+			</template>
 			<Badge label="est." theme="gray" variant="subtle" size="sm" />
 		</p>
 		<div class="mt-4 grid grid-cols-3 gap-4">
@@ -77,10 +86,10 @@
 			</div>
 			<div class="rounded-md border p-4">
 				<div class="text-2xl font-medium text-ink-gray-8">
-					{{ s ? s.sessionToolCalls : "—" }}
+					{{ usage ? usage.chat_tool_calls : "—" }}
 				</div>
 				<div class="mt-1 text-sm text-ink-gray-6">Tool calls</div>
-				<div class="mt-1 text-xs text-ink-gray-5">this session</div>
+				<div class="mt-1 text-xs text-ink-gray-5">this chat</div>
 			</div>
 			<div class="rounded-md border p-4">
 				<div class="text-2xl font-medium text-ink-gray-8">
@@ -103,26 +112,39 @@
 				<div class="mt-1 text-sm text-ink-gray-6">This chat</div>
 				<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
 			</div>
-			<div class="rounded-md border p-4">
-				<div class="text-2xl font-medium text-ink-gray-8">
-					{{ usage ? fmtTokens(usage.month_tokens) : "—" }}
+			<!-- The month / all-time estimates are dropped once measured usage
+			     exists: the block above already carries both labels from the
+			     gateway's own counters, and showing an estimate of the stored
+			     transcript beside a measurement of what was actually sent put two
+			     very different numbers under one heading (#551). "This chat" stays
+			     because the measured counters have no per-chat breakdown. -->
+			<template v-if="!hasMeasured">
+				<div class="rounded-md border p-4">
+					<div class="text-2xl font-medium text-ink-gray-8">
+						{{ usage ? fmtTokens(usage.month_tokens) : "—" }}
+					</div>
+					<div class="mt-1 text-sm text-ink-gray-6">
+						{{ usage ? usage.month_label : "This month" }}
+					</div>
+					<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
 				</div>
-				<div class="mt-1 text-sm text-ink-gray-6">
-					{{ usage ? usage.month_label : "This month" }}
+				<div class="rounded-md border p-4">
+					<div class="text-2xl font-medium text-ink-gray-8">
+						{{ usage ? fmtTokens(usage.total_tokens) : "—" }}
+					</div>
+					<div class="mt-1 text-sm text-ink-gray-6">All time</div>
+					<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
 				</div>
-				<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
-			</div>
-			<div class="rounded-md border p-4">
-				<div class="text-2xl font-medium text-ink-gray-8">
-					{{ usage ? fmtTokens(usage.total_tokens) : "—" }}
-				</div>
-				<div class="mt-1 text-sm text-ink-gray-6">All time</div>
-				<div class="mt-1 text-xs text-ink-gray-5">tokens</div>
-			</div>
+			</template>
+			<!-- Not comparable with the container's own tool numbers: this is the
+			     bench-side ERP tool registry (jarvis.chat.api.list_tools), which the
+			     agent runtime re-exports as jarvis__<name> alongside its own built-in
+			     tools and its search catalogue. Labelled so the three are not read as
+			     one drifting number (#551). -->
 			<div class="rounded-md border p-4">
 				<div class="text-2xl font-medium text-ink-gray-8">{{ s ? s.toolCount : "—" }}</div>
-				<div class="mt-1 text-sm text-ink-gray-6">Tools</div>
-				<div class="mt-1 text-xs text-ink-gray-5">available</div>
+				<div class="mt-1 text-sm text-ink-gray-6">ERP tools</div>
+				<div class="mt-1 text-xs text-ink-gray-5">Jarvis can run here</div>
 			</div>
 		</div>
 
@@ -164,6 +186,12 @@ const usage = ref(null);
 // Real (gateway-recorded) usage, added to get_usage()'s response. null until the
 // backend ships it or the user has no recorded usage yet.
 const measured = computed(() => (usage.value && usage.value.measured) || null);
+// The backend always returns the measured block, all-zero until the gateway has
+// recorded a turn. Rendering it while it is still empty put a "0 tokens" heading
+// above a non-zero estimate, which is the same two-numbers-disagree problem as
+// showing both once real counters exist. So the block appears only once there is
+// something measured to show.
+const hasMeasured = computed(() => !!(measured.value && Number(measured.value.total_tokens || 0)));
 const measuredPct = computed(() => {
 	const m = measured.value;
 	if (!m || !m.monthly_token_limit) return 0;

--- a/frontend/src/stores/shell.js
+++ b/frontend/src/stores/shell.js
@@ -37,9 +37,10 @@ const moreMenuOpen = ref(false); // the sidebar "More" destinations palette (Mor
 // the shell-level settings panes can read the current conversation's live stats
 // and degrade gracefully (—/empty) on non-chat routes. Shape when set:
 //   { conversationId, sessionStats:{ msgCount,userMsgCount,assistantMsgCount,
-//       sessionToolCalls,avgTokensPerMsg,convCount,starredCount,toolCount,
-//       recentActivity },
+//       avgTokensPerMsg,convCount,starredCount,toolCount },
 //     convAutoApply, autoApplyNote, modelLabel, ui }
+// Tool-call counts are deliberately NOT here: they are read from the persisted
+// rows (jarvis.chat.api.get_tool_activity), not from this live snapshot (#551).
 const chatContext = ref(null);
 function setChatContext(v) {
 	chatContext.value = v;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -4712,9 +4712,6 @@ const showWelcome = computed(
 const convCount = computed(() => store.conversations.length);
 const msgCount = computed(() => visibleMessages.value.length);
 const toolCount = computed(() => jarvisTools.value.length);
-const sessionToolCalls = computed(() =>
-	Object.values(runMeta.value).reduce((s, r) => s + (r.tools || 0), 0)
-);
 const userMsgCount = computed(() => visibleMessages.value.filter((m) => m.role === "user").length);
 const assistantMsgCount = computed(
 	() => visibleMessages.value.filter((m) => m.role === "assistant").length
@@ -4725,18 +4722,12 @@ const avgTokensPerMsg = computed(() => {
 	return fmtTokens(Math.round((usage.value.chat_tokens || 0) / n));
 });
 const starredCount = computed(() => store.conversations.filter((c) => c.starred).length);
-// Recent tool runs in this chat (most recent first), from the per-message run
-// metrics we already stamp on run:end.
-const recentActivity = computed(() => {
-	const out = [];
-	for (const m of visibleMessages.value) {
-		const meta = runMeta.value[m.name];
-		if (m.role === "assistant" && meta && meta.tools) {
-			out.push({ tools: meta.tools, ms: meta.ms || 0, names: meta.names || [] });
-		}
-	}
-	return out.reverse();
-});
+// Recent tool runs and the per-chat tool-call total are NOT published here any
+// more. Both used to be read off runMeta, which is stamped on the live run:end
+// event and therefore empty for every turn this mount did not itself watch, so
+// the settings panes reported zero tool calls over a transcript still rendering
+// ten tool cards (#551). They now come from the persisted rows via
+// jarvis.chat.api.get_tool_activity / get_usage.chat_tool_calls.
 const headerSub = computed(() => {
 	const n = visibleMessages.value.length;
 	return n ? `${Math.ceil(n / 2)} message${n > 2 ? "s" : ""}` : "ERPNext Assistant";
@@ -8874,12 +8865,10 @@ watchEffect(() => {
 			msgCount: msgCount.value,
 			userMsgCount: userMsgCount.value,
 			assistantMsgCount: assistantMsgCount.value,
-			sessionToolCalls: sessionToolCalls.value,
 			avgTokensPerMsg: avgTokensPerMsg.value,
 			convCount: convCount.value,
 			starredCount: starredCount.value,
 			toolCount: toolCount.value,
-			recentActivity: recentActivity.value,
 		},
 		convAutoApply: convAutoApply.value,
 		autoApplyNote: autoApplyNote.value,

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1508,6 +1508,109 @@ def _est_tokens(text: str | None) -> int:
 	return (len(text) + 3) // 4
 
 
+def _tool_label(name: str | None) -> str:
+	"""Strip the ``jarvis__`` prefix the openclaw plugin registers tools under,
+	so the panes show the same bare name the thread does (ChatView.toolLabel)."""
+	return (name or "tool").replace("jarvis__", "", 1)
+
+
+def _reply_ms(row) -> int:
+	"""Generation span of one assistant reply, in milliseconds.
+
+	``reply_duration_ms`` (stamped at settlement) when present, else the
+	modified-creation span for legacy rows that predate it. The column is an Int,
+	so an unstamped row reads 0 rather than NULL; 0 therefore means "no stamp"
+	and falls through to the span. Both are clamped to the same 30-minute sanity
+	ceiling the thread uses, so a row whose ``modified`` was bumped by a later
+	edit cannot report an absurd duration. Mirrors ChatView.elapsedOf minus its
+	live-timer branch, which has no server side.
+	"""
+	from frappe.utils import get_datetime
+
+	ceiling = 1800 * 1000
+	ms = int(row.get("reply_duration_ms") or 0)
+	if 0 < ms < ceiling:
+		return ms
+	if row.get("creation") and row.get("modified"):
+		span = get_datetime(row.modified) - get_datetime(row.creation)
+		ms = int(span.total_seconds() * 1000)
+		if 0 <= ms < ceiling:
+			return ms
+	return 0
+
+
+def _tool_runs(conversation: str) -> list[dict]:
+	"""Tool calls recorded in ``conversation``, grouped under the assistant turn
+	that made them, newest turn first.
+
+	Reads the PERSISTED ``role="tool"`` rows: the same rows the thread's
+	Activity accordion renders (ChatView.activityByAssistant). The Settings
+	panes used to derive this from the browser's live run stream instead, so a
+	reload (or simply opening an older chat) reported zero tool calls for a chat
+	whose transcript was still showing ten of them (#551).
+
+	Grouping matches the accordion exactly, so no two counts on one screen can
+	disagree: walk in ``seq`` order, reset on a user row, attach tool rows to the
+	most recent assistant row. ``hidden`` rows are excluded because the SPA never
+	receives them (get_conversation filters them), and a hidden user row would
+	otherwise reset the grouping server-side but not client-side. Rows carrying an
+	``action_outcome`` (a confirmed / discarded / failed gated write) are skipped
+	for the same reason: the thread renders those inline as receipt chips rather
+	than as accordion entries.
+
+	Each run is ``{"tools": <n>, "ms": <int>, "names": [...]}``. Assistant turns
+	that called no tool are dropped.
+	"""
+	rows = frappe.get_all(
+		MSG,
+		filters={"conversation": conversation, "hidden": 0},
+		fields=[
+			"seq",
+			"role",
+			"tool_name",
+			"action_outcome",
+			"reply_duration_ms",
+			"creation",
+			"modified",
+		],
+		order_by="seq asc",
+	)
+	runs = []
+	cur = None
+	for m in rows:
+		if m.role == "user":
+			cur = None
+		elif m.role == "assistant":
+			cur = {"tools": 0, "ms": _reply_ms(m), "names": []}
+			runs.append(cur)
+		elif m.role == "tool" and cur and not m.action_outcome:
+			cur["tools"] += 1
+			cur["names"].append(_tool_label(m.tool_name))
+	runs = [r for r in runs if r["tools"]]
+	runs.reverse()
+	return runs
+
+
+@frappe.whitelist()
+def get_tool_activity(conversation: str, limit: int = 20) -> dict:
+	"""Recent tool runs in ``conversation`` for the Settings Activity pane.
+
+	Returns ``{"runs": [{"tools", "ms", "names"}, ...], "tool_calls": <total>}``
+	with the newest turn first. ``tool_calls`` is the total across the whole
+	conversation, not just the returned page. Owner-only, like every other
+	conversation read.
+	"""
+	require_jarvis_access()
+	_get_owned_conversation(conversation)
+	from frappe.utils import cint
+
+	runs = _tool_runs(conversation)
+	return {
+		"runs": runs[: cint(limit) or 20],
+		"tool_calls": sum(r["tools"] for r in runs),
+	}
+
+
 def _measured_usage(user: str) -> dict | None:
 	"""Real per-turn token usage for ``user`` from the ``Jarvis User Settings``
 	row (design section 3). Rollover-aware: a stale ``usage_month`` reads as 0
@@ -1577,6 +1680,7 @@ def get_usage(conversation: str | None = None) -> dict:
 	out = {
 		"estimated": True,
 		"chat_tokens": 0,
+		"chat_tool_calls": 0,
 		"month_tokens": 0,
 		"total_tokens": 0,
 		"budget_monthly": budget,
@@ -1589,6 +1693,13 @@ def get_usage(conversation: str | None = None) -> dict:
 	out["measured"] = _measured_usage(user)
 	if not convs:
 		return out
+
+	# Tool calls actually recorded in the open chat. NOT an estimate and NOT
+	# derived from the browser's live run stream. The same persisted rows the
+	# Activity pane reads, so the two panes agree (#551). Membership in `convs`
+	# is the ownership check: this endpoint never loads the conversation doc.
+	if conversation and conversation in convs:
+		out["chat_tool_calls"] = sum(r["tools"] for r in _tool_runs(conversation))
 
 	rows = frappe.get_all(
 		MSG,

--- a/jarvis/tests/test_tool_activity.py
+++ b/jarvis/tests/test_tool_activity.py
@@ -1,0 +1,226 @@
+"""Tests for the Settings Activity / Usage tool-call reporting (issue #551).
+
+Both panes reported ZERO tool calls for a chat whose transcript was rendering
+ten tool cards, because both derived the count from a per-run map the SPA stamps
+on the live ``run:end`` event. That map only ever holds the turns one browser
+mount happened to watch, so a reload, a route change, or opening an older chat
+read zero.
+
+The fix moves the source of truth to the persisted ``role="tool"`` rows, which
+is what these tests pin: rows go into the database, then the endpoints the panes
+call must count them. Nothing is mocked and no live-run event is simulated, so a
+regression back to a session-scoped source cannot pass. The fixture shape is the
+one from the live report: three assistant turns calling 2, 3 and 5 tools.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat.api import create_conversation, get_tool_activity, get_usage
+from jarvis.tests.test_chat_api import (
+	TEST_USER,
+	_cleanup_user_conversations,
+	_ensure_test_user,
+)
+
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+
+OTHER_USER = "jarvis-toolact-other@example.test"
+
+
+def _ensure_other_user() -> None:
+	"""A second chat user, so the ownership cases have someone else's
+	conversation to be refused on. Idempotent."""
+	if frappe.db.exists("User", OTHER_USER):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": OTHER_USER,
+			"first_name": "Jarvis",
+			"last_name": "ToolActivity",
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"user_type": "System User",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	doc.add_roles("System Manager")
+	frappe.db.commit()
+
+
+class TestToolActivity(FrappeTestCase):
+	def setUp(self):
+		_ensure_test_user()
+		_ensure_other_user()
+		self._orig_user = frappe.session.user
+		frappe.set_user(TEST_USER)
+		_cleanup_user_conversations()
+		# get_usage reads token_budget_monthly off the Jarvis Settings Single.
+		# Singles are document-cached, and a stale cached copy has flaked other
+		# suites in this repo, so drop it before every case.
+		frappe.clear_document_cache("Jarvis Settings")
+		self.conversation = create_conversation()
+		self.seq = 0
+
+	def tearDown(self):
+		# create_conversation COMMITS, so the FrappeTestCase rollback cannot undo
+		# these rows. Both fixture users are cleaned explicitly, never Administrator
+		# (that would wipe real chat history on a dev site).
+		_cleanup_user_conversations()
+		_cleanup_user_conversations(OTHER_USER)
+		frappe.set_user(self._orig_user)
+
+	# ---- fixture helpers ---------------------------------------------------
+
+	def _row(self, role, conversation=None, **fields):
+		"""Insert one chat message row in sequence order and return its name."""
+		self.seq += 1
+		doc = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conversation or self.conversation,
+				"seq": self.seq,
+				"role": role,
+				**fields,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		return doc.name
+
+	def _turn(self, tools, conversation=None, **assistant_fields):
+		"""One user ask, one assistant reply, then a tool receipt per name in
+		``tools`` - the row shape a real turn leaves behind."""
+		self._row("user", conversation=conversation, content="do the thing")
+		self._row("assistant", conversation=conversation, content="done", **assistant_fields)
+		for name in tools:
+			self._row(
+				"tool",
+				conversation=conversation,
+				tool_name=name,
+				tool_status="completed",
+				tool_result="{}",
+			)
+
+	def _live_shape(self):
+		"""The exact transcript from the #551 report: 2, then 3, then 5 tools."""
+		self._turn(["tool_search", "web_fetch"])
+		self._turn(["tool_search", "tool_call", "get_schema"])
+		self._turn(["tool_call", "get_list", "tool_call", "get_list", "get_list"])
+
+	# ---- the primary bug ---------------------------------------------------
+
+	def test_persisted_rows_report_a_non_zero_count(self):
+		# The regression case. No run:end event, no live session state: only rows
+		# in the database, exactly as a reloaded tab or an older chat sees them.
+		self._live_shape()
+		result = get_tool_activity(self.conversation)
+		self.assertEqual(result["tool_calls"], 10)
+		self.assertEqual([r["tools"] for r in result["runs"]], [5, 3, 2])
+
+	def test_usage_reports_the_same_count_as_the_activity_pane(self):
+		# The two panes disagreeing is half of what #551 reports, so the numbers
+		# they read are asserted equal rather than each merely being non-zero.
+		self._live_shape()
+		self.assertEqual(
+			get_usage(self.conversation)["chat_tool_calls"],
+			get_tool_activity(self.conversation)["tool_calls"],
+		)
+
+	def test_names_are_reported_newest_turn_first(self):
+		self._live_shape()
+		runs = get_tool_activity(self.conversation)["runs"]
+		self.assertEqual(runs[0]["names"], ["tool_call", "get_list", "tool_call", "get_list", "get_list"])
+		self.assertEqual(runs[-1]["names"], ["tool_search", "web_fetch"])
+
+	def test_plugin_prefix_is_stripped_from_names(self):
+		# The agent runtime calls these as jarvis__<name>; the thread shows the
+		# bare name, so the pane must too.
+		self._turn(["jarvis__get_list"])
+		runs = get_tool_activity(self.conversation)["runs"]
+		self.assertEqual(runs[0]["names"], ["get_list"])
+
+	# ---- grouping parity with the transcript accordion ---------------------
+
+	def test_receipt_rows_are_not_counted(self):
+		# A gated write renders inline in the thread as its own receipt chip, not
+		# as an accordion entry. Counting it here would put two different tool
+		# counts on one screen, which is the class of bug #551 is about.
+		self._row("user", content="delete it")
+		self._row("assistant", content="deleted")
+		self._row("tool", tool_name="get_list", tool_status="completed")
+		self._row("tool", tool_name="delete_doc", tool_status="completed", action_outcome="confirmed")
+		self._row("tool", tool_name="delete_doc", action_outcome="discarded")
+		result = get_tool_activity(self.conversation)
+		self.assertEqual(result["tool_calls"], 1)
+		self.assertEqual(result["runs"][0]["names"], ["get_list"])
+
+	def test_a_hidden_row_does_not_split_a_turn(self):
+		# The post-apply continuation prompt is a hidden user row. The SPA never
+		# receives it, so treating it as a turn boundary here would report two
+		# runs where the thread shows one.
+		self._row("user", content="go")
+		self._row("assistant", content="working")
+		self._row("tool", tool_name="get_list", tool_status="completed")
+		self._row("user", content="continue", hidden=1)
+		self._row("tool", tool_name="get_doc", tool_status="completed")
+		result = get_tool_activity(self.conversation)
+		self.assertEqual(result["tool_calls"], 2)
+		self.assertEqual(len(result["runs"]), 1)
+
+	def test_turns_without_tools_are_omitted(self):
+		self._turn([])
+		self._turn(["get_list"])
+		self._turn([])
+		result = get_tool_activity(self.conversation)
+		self.assertEqual(len(result["runs"]), 1)
+		self.assertEqual(result["tool_calls"], 1)
+
+	def test_empty_chat_reports_zero(self):
+		result = get_tool_activity(self.conversation)
+		self.assertEqual(result["tool_calls"], 0)
+		self.assertEqual(result["runs"], [])
+		self.assertEqual(get_usage(self.conversation)["chat_tool_calls"], 0)
+
+	# ---- duration ----------------------------------------------------------
+
+	def test_duration_comes_from_the_persisted_reply_span(self):
+		self._turn(["get_list"], reply_duration_ms=26900)
+		self.assertEqual(get_tool_activity(self.conversation)["runs"][0]["ms"], 26900)
+
+	def test_an_implausible_persisted_duration_is_dropped(self):
+		# A stamp past the 30 minute ceiling is nonsense, so it falls back to the
+		# row's own span rather than rendering "7200.0s" next to a two second turn.
+		self._turn(["get_list"], reply_duration_ms=7_200_000)
+		ms = get_tool_activity(self.conversation)["runs"][0]["ms"]
+		self.assertLess(ms, 1000)
+
+	def test_an_unstamped_reply_falls_back_to_its_own_span(self):
+		# reply_duration_ms is an Int column, so a legacy row reads 0, not NULL.
+		# Treating 0 as a real duration would have made the fallback dead code.
+		self._turn(["get_list"])
+		self.assertLess(get_tool_activity(self.conversation)["runs"][0]["ms"], 1000)
+
+	# ---- ownership ---------------------------------------------------------
+
+	def test_another_users_conversation_is_refused(self):
+		frappe.set_user(OTHER_USER)
+		theirs = create_conversation()
+		self._turn(["get_list"], conversation=theirs)
+		frappe.set_user(TEST_USER)
+		with self.assertRaises(frappe.PermissionError):
+			get_tool_activity(theirs)
+
+	def test_usage_never_counts_another_users_chat(self):
+		# get_usage does not load the conversation doc, so its scoping is the
+		# owned-conversation list. A foreign id must read 0, not that chat's real
+		# count.
+		frappe.set_user(OTHER_USER)
+		theirs = create_conversation()
+		self._turn(["get_list", "get_doc"], conversation=theirs)
+		frappe.set_user(TEST_USER)
+		self._turn(["get_list"])
+		self.assertEqual(get_usage(theirs)["chat_tool_calls"], 0)


### PR DESCRIPTION
Fixes #551

The Activity pane said "No tool activity in this chat yet" and the Usage pane said
"Tool calls 0 this session", in a chat whose transcript was rendering ten tool
cards. The `get_schema` call among them returned real ERP fieldnames, so these
were genuinely executed calls, not rendering artifacts.

## Root cause

Both panes read `runMeta`, a map `ChatView` stamps **in memory** on the live
`run:end` event. It therefore only ever held the turns that one browser mount
happened to watch. A reload, a route change, or simply opening an older chat left
it empty, while the thread beside it kept rendering the persisted rows it loads
from `get_conversation`. The panes and the transcript were reading two different
sources, and only one of them survives a page load.

## The fix

Both numbers now come from the same persisted rows the transcript uses.

- `jarvis.chat.api.get_tool_activity` returns the tool runs recorded in one
  conversation, grouped under the assistant turn that made them, newest first.
  The grouping mirrors the thread's Activity accordion exactly: walk by seq, reset
  on a user row, skip hidden rows and gated-write receipt rows. That is deliberate,
  so no two tool counts on one screen can disagree again.
- `get_usage` gains `chat_tool_calls` from the same helper, scoped by the caller's
  own conversation list.
- ActivityPane and UsagePane read those. ChatView stops publishing `recentActivity`
  and `sessionToolCalls` entirely, so the in-memory source is gone rather than left
  around to drift.

## The 24x token gap, also reported

Not a bug, but it was unreadable. The month and all-time **estimates** sat directly
under measured rows carrying the same two labels and a number roughly 24x larger.

The gap is structural: the estimate sums the stored transcript once, while the
measurement counts the instructions and re-sent history that go upstream on every
turn. So it grows with turn count and there is nothing to reconcile (6.4k versus
631k on the reported bench today). The month and all-time estimates are dropped
once measured usage exists. Only the per-chat estimate stays, with wording that
says why it reads low. The measured block now appears only when something has
actually been measured, instead of putting a "0 tokens" heading above a non-zero
estimate.

## "69 Tools available"

Relabelled to "ERP tools / Jarvis can run here". It is the bench-side tool registry
and was never comparable with the container's own `registered 63 tools` or
`tool-search: cataloged 91 tools`. Three different definitions of "tool", one of
which was presented as if it were the others.

## Tests

`jarvis/tests/test_tool_activity.py`, covering the primary bug through the same
code path the pane calls, so a chat with persisted tool-call rows must report a
non-zero count. Written against persisted rows rather than a mocked event stream,
which is the level at which the defect actually lives.
