### PR TITLE
fix(chat): surface a failed openclaw turn instead of a silent empty final

### DIFF
--- a/jarvis/chat/openclaw_client.py
+++ b/jarvis/chat/openclaw_client.py
@@ -310,12 +310,14 @@ def _chat_final_text(payload: dict) -> str | None:
 _STREAM_ERROR_SENTINEL = "[assistant turn failed before producing content]"
 
 # User-facing text stamped on the assistant row's ``error`` field (and shown in
-# the chat) for such a failed final. Generic on purpose: a ``state == "final"``
-# event carries no ``errorMessage`` (only ``stopReason``), so the exact cause
-# cannot be named here; a context window too small for the conversation is the
-# common one. Must NOT contain "context overflow" (that substring reroutes the
-# turn handler into the auto-compact park-for-recovery branch, which never
-# lands for a terminal precheck failure) or "aborted".
+# the chat) for such a failed final when openclaw gave us nothing better.
+# Generic on purpose: a ``state == "final"`` event carries no ``errorMessage``
+# (only ``stopReason``), so the exact cause cannot be named from that frame
+# alone; a context window too small for the conversation is the common one.
+# ``failed_final_error`` below names the cause instead whenever the run's
+# lifecycle error frame supplied one. Must NOT contain "context overflow" (that
+# substring reroutes the turn handler into the auto-compact park-for-recovery
+# branch, which never lands for a terminal precheck failure) or "aborted".
 FAILED_FINAL_ERROR = (
 	"The assistant could not complete this response and the turn ended "
 	"without any output. This can happen when the conversation is too long "
@@ -323,26 +325,79 @@ FAILED_FINAL_ERROR = (
 	"start a new chat."
 )
 
+# Substrings a provider detail must not carry into a failed final's error text:
+# ``turn_handler`` routes a relay:error containing "context overflow" into the
+# auto-compact park-for-recovery branch (turn_handler.py) and reads "aborted" as
+# a clean user stop. Neither is true of a TERMINAL failed final, and letting
+# provider prose steer that control flow would put the turn straight back to
+# spinning. A detail carrying either marker is dropped for the generic copy.
+_ERROR_DETAIL_REROUTE_MARKERS = ("context overflow", "aborted")
+
+# Cap on the appended provider detail. openclaw's own failure text is already
+# user-facing and self-truncating (~200 chars); this only stops a pathological
+# runtime from filling the Message.error column (settlement stores error[:1000]).
+_ERROR_DETAIL_MAX_CHARS = 400
+
+
+def failed_final_error(detail: str | None = None) -> str:
+	"""User-facing error text for a failed final, naming the provider reason
+	when openclaw gave one.
+
+	The run's lifecycle ``phase == "error"`` frame is the ONLY place the runtime
+	names the failure ("Google Generative AI API error (429): You exceeded your
+	current quota..."), and that is the actionable half of the message - the
+	customer can top up a quota, they cannot act on "something went wrong". The
+	relay drops lifecycle frames from the terminal path (the chat event stays
+	the single terminal) but remembers this text; pass it here. Without a
+	detail, FAILED_FINAL_ERROR is all we can honestly say."""
+	d = (detail or "").strip()
+	if not d or any(marker in d.lower() for marker in _ERROR_DETAIL_REROUTE_MARKERS):
+		return FAILED_FINAL_ERROR
+	return f"The assistant could not complete this response: {d[:_ERROR_DETAIL_MAX_CHARS]}"
+
 
 def _chat_final_failed(payload: dict, text: str | None) -> bool:
 	"""True when a ``state == "final"`` chat event actually represents a FAILED
-	turn that produced NO real answer: its only content is the stream-error
-	sentinel, or (with no visible text) the assistant message carries
-	``stopReason == "error"``. Such a "final" must surface as an error, not a
-	silent empty bubble.
+	turn that produced NO real answer. Such a "final" must surface as an error,
+	not a silent empty bubble.
+
+	The wire shapes this has to cover, verified against the shipped bundle of
+	ghcr.io/openclaw/openclaw:2026.6.8:
+
+	  * the LIVE relay emitters (``dist/server-chat-*.js`` and
+	    ``dist/embedded-backend-*.js``, both ``emitChatFinal``) build the payload
+	    as ``{state, stopReason?, message?}``: ``stopReason`` sits at the TOP
+	    LEVEL, NOT inside ``message``, and ``message`` is OMITTED ENTIRELY when
+	    the turn produced no assistant text. A failed turn therefore reaches us
+	    as a final with NO message at all - which is exactly what both live
+	    reproductions in #543 left behind (``terminal_payload`` was
+	    ``{"text": null}`` and the assistant row's ``error`` was NULL);
+	  * the transcript-projected emitter (``broadcastChatFinal``) passes the
+	    stored assistant message straight through, so THERE ``stopReason`` rides
+	    inside ``message`` - the shape the original guard was written for.
 
 	Guards two non-failures:
 	  * a real (possibly partial) answer is kept even when the turn also flagged
 	    an error, so a streamed reply is never hidden behind an error;
-	  * a genuinely successful turn that emitted only rich outputs (canvas /
-	    image, no prose) has no text and ``stopReason`` != "error", so it stays a
-	    normal empty-text relay:final."""
+	  * a final that DOES carry an assistant message with no text and a non-error
+	    ``stopReason`` stays a normal empty-text relay:final.
+
+	A turn that produced no assistant text at all is NOT distinguishable here
+	from a hypothetical rich-output-only success - openclaw omits ``message``
+	for both. Surfacing the failure is the safer of the two: today's silence
+	renders a failed turn as an in-progress one that never resolves, whereas the
+	worst case in the other direction is an honest error on a turn that said
+	nothing anyway."""
 	if isinstance(text, str) and text.strip() == _STREAM_ERROR_SENTINEL:
 		return True
 	if text:
 		return False
+	if payload.get("stopReason") == "error":
+		return True
 	msg = payload.get("message")
-	return isinstance(msg, dict) and msg.get("stopReason") == "error"
+	if not isinstance(msg, dict):
+		return True
+	return msg.get("stopReason") == "error"
 
 
 def _persisted_device_id() -> str:
@@ -863,12 +918,17 @@ class OpenclawSession:
 		  {"kind": "relay:interrupted", "reason": "transport"|"deadline", ...}
 
 		A ``state == "final"`` event whose assistant turn actually failed
-		(stopReason error / stream-error sentinel, e.g. a precheck context
-		overflow that deletes the session) is remapped to a ``failed_final``
-		relay:error so it stamps an honest error instead of a silent empty
-		final. See _chat_final_failed.
+		(no assistant message at all, stopReason error, stream-error sentinel)
+		is remapped to a ``failed_final`` relay:error so it stamps an honest
+		error instead of a silent empty final, naming the provider reason from
+		the run's lifecycle error frame when there was one. See
+		_chat_final_failed / failed_final_error.
 		"""
 		deadline = time.monotonic() + soft_deadline_s
+		# Last lifecycle error text seen for this run. NOT terminal on its own
+		# (the chat event is the single terminal path); it is the only frame
+		# that names the provider failure, so it is kept for a failed final.
+		failure_detail: str | None = None
 		while True:
 			remaining = deadline - time.monotonic()
 			if remaining <= 0:
@@ -904,7 +964,7 @@ class OpenclawSession:
 						yield {
 							"kind": "relay:error",
 							"state": "failed_final",
-							"error": FAILED_FINAL_ERROR,
+							"error": failed_final_error(failure_detail),
 						}
 						return
 					yield {"kind": "relay:final", "text": text}
@@ -921,6 +981,12 @@ class OpenclawSession:
 				continue
 			parsed = parse_event(payload)
 			if parsed is None or parsed.get("kind") == "lifecycle":
+				# lifecycle frames stay off the terminal path, but the ``error``
+				# phase carries the runtime's own user-facing failure text - the
+				# only place the provider reason is ever named. Keep it for a
+				# failed final; a real answer still wins over it (#543).
+				if parsed is not None and parsed.get("phase") == "error" and parsed.get("error"):
+					failure_detail = str(parsed["error"])
 				continue
 			yield parsed
 

--- a/jarvis/chat/relay_mux.py
+++ b/jarvis/chat/relay_mux.py
@@ -65,11 +65,11 @@ from dataclasses import dataclass
 
 from jarvis.chat.events import parse_event
 from jarvis.chat.openclaw_client import (
-	FAILED_FINAL_ERROR,
 	OpenclawSession,
 	_build_request_frame,
 	_chat_final_failed,
 	_chat_final_text,
+	failed_final_error,
 )
 from jarvis.exceptions import OpenclawUnreachableError
 
@@ -252,6 +252,11 @@ class _Lane:
 		self.watermark = int(start_seq)
 		self.state = "active"  # active | quarantined | terminal | closed
 		self.poison_count = 0
+		# Last lifecycle error text seen for this run (#543). Written and read on
+		# the READER thread only (both _route_agent and _route_terminal run
+		# there), so it needs no lock. Not terminal on its own: it just names the
+		# provider failure for a terminal that otherwise cannot.
+		self.failure_detail: str | None = None
 
 	def next_seq(self) -> int:
 		self.watermark += 1
@@ -502,6 +507,10 @@ class RelayMux:
 		if parsed is None or parsed.get("kind") == "lifecycle":
 			# lifecycle frames are dropped on the managed relay path (mirror of
 			# relay_turn_events); not a stray — it's an expected known-run drop.
+			# The ``error`` phase is the only frame that names the provider
+			# failure, so keep its text on the lane for a failed final (#543).
+			if parsed is not None and parsed.get("phase") == "error" and parsed.get("error"):
+				lane.failure_detail = str(parsed["error"])
 			return
 		kind = parsed.get("kind")
 		if kind == "assistant":
@@ -537,7 +546,7 @@ class RelayMux:
 			if _chat_final_failed(payload, text):
 				term_kind, term_payload = (
 					"relay:error",
-					{"state": "failed_final", "error": FAILED_FINAL_ERROR},
+					{"state": "failed_final", "error": failed_final_error(lane.failure_detail)},
 				)
 			else:
 				term_kind, term_payload = "relay:final", {"text": text}

--- a/jarvis/tests/harness/fake_gateway.py
+++ b/jarvis/tests/harness/fake_gateway.py
@@ -381,11 +381,21 @@ class FakeGateway:
 		session_key = tl.session_key
 		payload = {"runId": run_id, "sessionKey": session_key}
 		if kind == "final":
+			# Live wire shape (#543): openclaw OMITS ``message`` entirely when the
+			# turn produced no assistant text, rather than sending an empty one.
 			text = terminal.get("text")
-			content = [{"type": "text", "text": text}] if text else []
-			payload.update({"state": "final", "message": {"content": content}})
+			payload.update({"state": "final"})
+			if text:
+				payload["message"] = {"content": [{"type": "text", "text": text}]}
 		elif kind == "failed_final":
-			payload.update({"state": "final", "message": {"content": [], "stopReason": "error"}})
+			# Live wire shape (#543): ``stopReason`` is TOP-LEVEL, not inside
+			# ``message``, and a turn with no output carries no ``message`` at all.
+			# The old {"message": {"content": [], "stopReason": "error"}} shape is
+			# one openclaw never sends, and modelling it here is what let the
+			# failed-final classifier pass its tests while being dead on the wire.
+			payload.update({"state": "final"})
+			if terminal.get("stopReason"):
+				payload["stopReason"] = terminal["stopReason"]
 		elif kind == "aborted":
 			tl.aborted = True
 			payload.update({"state": "aborted", "errorMessage": "aborted by user"})

--- a/jarvis/tests/harness/transcripts.py
+++ b/jarvis/tests/harness/transcripts.py
@@ -25,7 +25,9 @@ A transcript is a plain dict (JSON-serialisable) with:
                 | {"kind":"error","state":"error","errorMessage":<str>}
                 | {"kind":"aborted"}                      (also emitted on
                     chat.abort regardless of scripted point)
-                | {"kind":"failed_final","stopReason":"error"}
+                | {"kind":"failed_final","stopReason":<str|None>}  (a final with
+                    NO assistant message at all, stopReason TOP-LEVEL: the live
+                    shape of a turn that produced nothing, #543)
   inject        optional fault: {"drop_after_frame": <idx>}  (WS-drop) |
                 {"recover_via":"history","final_text":<str>} (recovered:
                     stream is cut, the durable transcript still holds the
@@ -33,7 +35,10 @@ A transcript is a plain dict (JSON-serialisable) with:
 
 ``text`` on the terminal final is the authoritative answer
 (``_chat_final_text`` joins message.content). The gateway derives the chat
-final ``message.content`` block from it.
+final ``message.content`` block from it, and OMITS ``message`` entirely when
+there is no text: that is what openclaw does on the wire, and modelling it as
+an empty-content message instead is what once let a dead classifier branch pass
+its tests (#543).
 
 The transcripts are built in Python (the maintainable source of truth) and can
 be exported to ``fixtures/transcripts/*.json`` via ``dump_fixtures()`` for
@@ -247,6 +252,54 @@ def _build() -> dict[str, dict]:
 			"recover_via": "history",
 			"final_text": _RECOVERED_TEXT,
 		},
+	}
+
+	# --- regression fixtures, OUTSIDE the 8-row WP-2 matrix (kept out of NAMES so
+	#     the baseline / Stage-B runners still play exactly the matrix) ---------
+
+	# #543-a: a hard provider failure (429, failover chain exhausted). openclaw
+	# names the reason on a lifecycle error frame, then ends the run with a chat
+	# final that carries NO assistant message at all. Zero streamed frames, which
+	# is what the live reproduction recorded (last_event_seq=0).
+	t["failed-final"] = {
+		"name": "failed-final",
+		"description": (
+			"Provider failure with the failover chain exhausted: a lifecycle error naming the "
+			"reason, then a terminal final with no assistant message. Must settle as a terminal "
+			"ERROR, never as a successful empty final (#543)."
+		),
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": [
+			{
+				"op": "lifecycle_error",
+				"error": (
+					"Google Generative AI API error (429): You exceeded your current quota, "
+					"please check your plan and billing details."
+				),
+			}
+		],
+		"terminal": {"kind": "failed_final", "stopReason": "error"},
+	}
+
+	# #543-b: the SAME terminal reached the other way: the tools ran, the model
+	# returned nothing, openclaw exhausted its empty-response retries and
+	# surfaced an incomplete-turn error. The user saw tool cards and no answer.
+	t["empty-final-after-tools"] = {
+		"name": "empty-final-after-tools",
+		"description": (
+			"Tools run, the model returns nothing, openclaw surfaces an incomplete-turn error and "
+			"the terminal final still carries no assistant message (#543, second reproduction)."
+		),
+		"ack": {"status": "started"},
+		"ack_behavior": "normal",
+		"frames": [
+			{"op": "tool_start", "name": "jarvis__get_list", "call_id": "e1", "title": "get_list User"},
+			{"op": "tool_end", "call_id": "e1", "status": "completed"},
+			{"op": "tool_start", "name": "jarvis__get_list", "call_id": "e2", "title": "get_list User"},
+			{"op": "tool_end", "call_id": "e2", "status": "completed"},
+		],
+		"terminal": {"kind": "failed_final", "stopReason": "stop"},
 	}
 
 	return t

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -869,6 +869,87 @@ class TestSux11ErrorContract(_PipelineCase):
 
 
 # --------------------------------------------------------------------------- #
+# 7b. #543: a failed final must settle as an ERROR, not a silent empty success
+# --------------------------------------------------------------------------- #
+
+
+class TestFailedFinalSettlesAsError(_PipelineCase):
+	"""#543: both live reproductions (a hard 429 with the failover chain
+	exhausted, and a turn whose tools ran but whose model returned nothing)
+	settled with ``terminal_kind='relay:final'`` and ``terminal_payload={"text":
+	null}``, leaving an assistant row with no content AND no error. The SPA then
+	held a "Finishing..." spinner on an enrichment that a stalled finalize never
+	delivered, so a failure rendered as an in-progress success.
+
+	These play the real gateway frames through the real mux + settlement, so the
+	assertion is on the durable outcome the customer's browser reads back.
+	"""
+
+	def _drive(self, rid: str, transcript: str):
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, content="Reply with exactly one word: PONG")
+		self._mk_turn(conv, rid, seed, "queued", version=0, reserved=0)
+		double = self._double()
+		deps = self._deps(double=double, prepare=self._prepare_stub(conv, double, transcript))
+		ctx = self._make_ctx(deps)
+		self._pubs.clear()
+		self._pump_until(ctx, lambda: self._state(rid) in ("errored", "finalizing", "done"))
+		return conv, deps
+
+	def _assert_terminal_failure(self, rid: str):
+		self.assertEqual(self._state(rid), "errored", "a failed final settles errored, not finalizing")
+		self.assertEqual(self._val(rid, "terminal_kind"), "relay:error")
+		self.assertEqual(int(self._val(rid, "reserved")), 0, "slot released")
+		amsg = self._val(rid, "assistant_message")
+		row = frappe.db.get_value(MSG, amsg, ["error", "streaming", "recovering"], as_dict=True)
+		# The core of the bug: `error` must be set, not NULL, on a terminal failure.
+		self.assertTrue((row["error"] or "").strip(), "assistant row carries a user-facing error")
+		self.assertEqual(int(row["streaming"]), 0, "the spinner stops")
+		self.assertFalse(int(row["recovering"] or 0), "terminal, NOT parked for recovery")
+		# run:error (which clears the SPA's spinner and renders the retry affordance),
+		# never a run:end carrying enrichment_pending (which is what left "Finishing...").
+		kinds = self._pub_kinds()
+		self.assertIn("run:error", kinds)
+		self.assertNotIn("run:end", kinds)
+		return row["error"]
+
+	def test_hard_provider_failure_settles_errored_and_names_the_reason(self):
+		rid = "pmp_ff_hard"
+		self._drive(rid, "failed-final")
+		err = self._assert_terminal_failure(rid)
+		# The lifecycle error frame named the cause; it must survive to the row so
+		# the customer sees something they can act on (top up the quota).
+		self.assertIn("429", err)
+		self.assertIn("quota", err)
+		err_pub = next(p for p in self._pubs if p.get("kind") == "run:error")
+		self.assertEqual(err_pub["code"], "provider", "quota -> 'provider' headline (ERROR_HEADLINES)")
+
+	def test_empty_final_after_tools_settles_errored(self):
+		# Second reproduction: same terminal reached with tools already run and a
+		# non-error stopReason. One root cause, one fix.
+		rid = "pmp_ff_empty"
+		self._drive(rid, "empty-final-after-tools")
+		err = self._assert_terminal_failure(rid)
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		self.assertEqual(err, FAILED_FINAL_ERROR, "no lifecycle detail -> the generic honest copy")
+
+	def test_errored_turn_promises_no_enrichment_the_client_would_wait_for(self):
+		# The stuck "Finishing..." was an enrichment the client was told to wait for.
+		# An errored turn owes only the terminal effect set, so nothing is pending
+		# and no message:enriched is ever promised.
+		rid = "pmp_ff_effects"
+		self._drive(rid, "failed-final")
+		self.assertEqual(set(self._effects(rid)), set(settlement.TERMINAL_EFFECTS))
+		with self._mock_enrichment():
+			out = finalize.run_finalize(rid, self._target)
+		self.assertTrue(out["ok"])
+		self.assertFalse(out["done"], "an errored turn is already terminal; finalize never un-settles it")
+		self.assertEqual(self._state(rid), "errored")
+		self.assertNotIn("message:enriched", self._pub_kinds())
+
+
+# --------------------------------------------------------------------------- #
 # 8. Usage (turn_id) idempotency under finalize replay
 # --------------------------------------------------------------------------- #
 

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -236,6 +236,90 @@ class TestRelayTurnEvents(FrappeTestCase):
 		out = list(sess.relay_turn_events("sk", "r1"))
 		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
 
+	def test_final_with_no_message_at_all_yields_relay_error(self):
+		# #543, the LIVE failure shape. openclaw's relay emitters omit ``message``
+		# entirely when the turn produced no assistant text, so a failed turn
+		# arrives as a bare {"state": "final"}. Both live reproductions settled
+		# this way and wrote an assistant row with no content AND no error.
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		sess = self._sess([_chat_frame("r1", "sk", "final")])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(
+			out,
+			[{"kind": "relay:error", "state": "failed_final", "error": FAILED_FINAL_ERROR}],
+		)
+
+	def test_final_top_level_stop_reason_error_yields_relay_error(self):
+		# The same emitters put ``stopReason`` at the TOP LEVEL of the chat
+		# payload, NOT inside ``message`` - reading it only from the message is
+		# what made the original guard dead code on the live wire.
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		sess = self._sess([_chat_frame("r1", "sk", "final", stopReason="error")])
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(
+			out,
+			[{"kind": "relay:error", "state": "failed_final", "error": FAILED_FINAL_ERROR}],
+		)
+
+	def test_failed_final_names_the_provider_reason_from_the_lifecycle_frame(self):
+		# The lifecycle error frame is the ONLY place openclaw names the failure.
+		# It is dropped from the terminal path (the chat event stays the single
+		# terminal) but kept, so the customer is told what to fix.
+		detail = (
+			"Google Generative AI API error (429): You exceeded your current quota, "
+			"please check your plan and billing details."
+		)
+		sess = self._sess(
+			[
+				_agent_frame("r1", "lifecycle", {"phase": "error", "error": detail}),
+				_chat_frame("r1", "sk", "final"),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(len(out), 1)
+		self.assertEqual(out[0]["state"], "failed_final")
+		self.assertIn("429", out[0]["error"])
+		self.assertIn("quota", out[0]["error"])
+
+	def test_failed_final_detail_that_would_reroute_falls_back_to_generic_copy(self):
+		# turn_handler parks a relay:error mentioning "context overflow" for
+		# snapshot recovery. That never lands for a TERMINAL failed final, so a
+		# provider detail carrying the marker must not steer control flow - the
+		# generic copy is used instead and the turn stays terminal.
+		from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
+
+		sess = self._sess(
+			[
+				_agent_frame(
+					"r1",
+					"lifecycle",
+					{"phase": "error", "error": "Context overflow: prompt too large for the model"},
+				),
+				_chat_frame("r1", "sk", "final"),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out[0]["error"], FAILED_FINAL_ERROR)
+
+	def test_lifecycle_error_then_a_real_answer_stays_a_relay_final(self):
+		# openclaw emits a lifecycle error per FAILED candidate and then fails
+		# over. A turn the fallback model rescued must keep its answer.
+		sess = self._sess(
+			[
+				_agent_frame("r1", "lifecycle", {"phase": "error", "error": "rate limited"}),
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={"role": "assistant", "content": [{"type": "text", "text": "PONG"}]},
+				),
+			]
+		)
+		out = list(sess.relay_turn_events("sk", "r1"))
+		self.assertEqual(out, [{"kind": "relay:final", "text": "PONG"}])
+
 	def test_final_real_text_with_error_stop_reason_keeps_the_answer(self):
 		# A partial answer that also flagged an error must NOT be hidden behind
 		# an error bubble: the streamed reply wins and stays a relay:final.

--- a/jarvis/tests/test_relay_consumer.py
+++ b/jarvis/tests/test_relay_consumer.py
@@ -88,15 +88,18 @@ class TestRelayTurnEvents(FrappeTestCase):
 		self.assertEqual(len(out), 3)
 
 	def test_discards_frames_for_other_run_or_session_and_non_event_frames(self):
+		# The terminals here all carry text: this test is about FILTERING, and a
+		# textless final is a failed turn (#543), not a routing outcome.
+		answered = {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}
 		sess = self._sess(
 			[
 				_agent_frame("other-run", "assistant", {"text": "nope", "delta": "nope"}),
 				{"type": "res", "id": "x", "ok": True},  # non-event frame
 				None,  # soft-timeout / non-JSON noise
-				_chat_frame("r1", "other-session", "final"),  # wrong sessionKey
-				_chat_frame("other-run", "sk", "final"),  # wrong runId
+				_chat_frame("r1", "other-session", "final", message=answered),  # wrong sessionKey
+				_chat_frame("other-run", "sk", "final", message=answered),  # wrong runId
 				_agent_frame("r1", "assistant", {"text": "ok", "delta": "ok"}),
-				_chat_frame("r1", "sk", "final"),
+				_chat_frame("r1", "sk", "final", message=answered),
 			]
 		)
 		out = list(sess.relay_turn_events("sk", "r1"))
@@ -104,7 +107,7 @@ class TestRelayTurnEvents(FrappeTestCase):
 			out,
 			[
 				{"kind": "assistant", "text": "ok", "delta": "ok"},
-				{"kind": "relay:final", "text": None},
+				{"kind": "relay:final", "text": "ok"},
 			],
 		)
 
@@ -113,11 +116,16 @@ class TestRelayTurnEvents(FrappeTestCase):
 			[
 				_agent_frame("r1", "lifecycle", {"phase": "start"}),
 				_agent_frame("r1", "lifecycle", {"phase": "end"}),
-				_chat_frame("r1", "sk", "final"),
+				_chat_frame(
+					"r1",
+					"sk",
+					"final",
+					message={"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+				),
 			]
 		)
 		out = list(sess.relay_turn_events("sk", "r1"))
-		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
+		self.assertEqual(out, [{"kind": "relay:final", "text": "done"}])
 
 	def test_chat_delta_state_ignored(self):
 		sess = self._sess(
@@ -130,10 +138,9 @@ class TestRelayTurnEvents(FrappeTestCase):
 		out = list(sess.relay_turn_events("sk", "r1"))
 		self.assertEqual(out, [{"kind": "relay:final", "text": "done"}])
 
-	def test_final_with_no_message_yields_text_none(self):
-		sess = self._sess([_chat_frame("r1", "sk", "final")])
-		out = list(sess.relay_turn_events("sk", "r1"))
-		self.assertEqual(out, [{"kind": "relay:final", "text": None}])
+	# NB: a `final` with no message used to be asserted here as a successful
+	# relay:final with text=None. That is the #543 defect, and it now lives as
+	# test_final_with_no_message_at_all_yields_relay_error below.
 
 	def test_final_with_string_content_yields_text(self):
 		sess = self._sess([_chat_frame("r1", "sk", "final", message={"content": "plain text"})])

--- a/jarvis/tests/test_relay_mux.py
+++ b/jarvis/tests/test_relay_mux.py
@@ -35,6 +35,7 @@ from unittest.mock import patch as mock_patch
 
 from frappe.tests.utils import FrappeTestCase
 
+from jarvis.chat.openclaw_client import FAILED_FINAL_ERROR
 from jarvis.chat.relay_mux import LaneHandler, RelayMux
 from jarvis.exceptions import OpenclawUnreachableError
 from jarvis.tests.harness import transcripts as _transcripts
@@ -119,6 +120,16 @@ def _chat_final_frame(run_id, session_key, text="hi"):
 	}
 
 
+def _chat_failed_final_frame(run_id, session_key, stop_reason=None):
+	"""The LIVE shape of a chat final for a turn that produced nothing (#543):
+	no ``message`` key at all, and ``stopReason`` (when openclaw resolved one) at
+	the TOP LEVEL rather than inside the message."""
+	payload = {"runId": run_id, "sessionKey": session_key, "state": "final"}
+	if stop_reason:
+		payload["stopReason"] = stop_reason
+	return {"type": "event", "event": "chat", "payload": payload}
+
+
 def _term_text(name: str) -> str:
 	return _transcripts.get(name)["terminal"]["text"]
 
@@ -176,12 +187,18 @@ def _terminal_frame(run_id, session_key, terminal):
 	kind = terminal.get("kind", "final")
 	payload = {"runId": run_id, "sessionKey": session_key}
 	if kind == "final":
+		# Live wire shape (#543): openclaw OMITS ``message`` entirely when the turn
+		# produced no assistant text, rather than sending an empty one.
 		text = terminal.get("text")
-		payload.update(
-			{"state": "final", "message": {"content": [{"type": "text", "text": text}] if text else []}}
-		)
+		payload.update({"state": "final"})
+		if text:
+			payload["message"] = {"content": [{"type": "text", "text": text}]}
 	elif kind == "failed_final":
-		payload.update({"state": "final", "message": {"content": [], "stopReason": "error"}})
+		# Live wire shape (#543): ``stopReason`` is TOP-LEVEL, not inside
+		# ``message``, and a turn with no output carries no ``message`` at all.
+		payload.update({"state": "final"})
+		if terminal.get("stopReason"):
+			payload["stopReason"] = terminal["stopReason"]
 	elif kind == "aborted":
 		payload.update({"state": "aborted", "errorMessage": "aborted by user"})
 	else:
@@ -497,6 +514,115 @@ class TestRelayMuxWhiteBox(FrappeTestCase):
 			mux._classify(_agent_frame("r", "s", "assistant", {"text": f"t{i}", "delta": f"t{i}"}))
 		self.assertEqual(mux.dispatch(), total, "all events drained in one call (round-robin passes)")
 		self.assertFalse(mux._has_work())
+
+
+# --------------------------------------------------------------------------- #
+# Failed-final classification (#543): the LIVE openclaw terminal shapes
+# --------------------------------------------------------------------------- #
+
+
+class TestRelayMuxFailedFinal(FrappeTestCase):
+	"""#543: a turn that fails at the provider must reach the pump as a terminal
+	ERROR, never as a successful empty final.
+
+	Both live reproductions settled with ``terminal_kind='relay:final'`` and
+	``terminal_payload={"text": null}``, leaving an assistant row with no content
+	AND no error, i.e. a failure rendered as an in-progress success. The frames
+	are the shapes the 2026.6.8 gateway actually puts on the wire: a failed final
+	carries NO ``message`` (and ``stopReason``, when resolved, at the TOP LEVEL),
+	and the provider reason is named only on the agent ``lifecycle`` error frame.
+	Everything from ``_classify`` down is the real mux.
+	"""
+
+	def _terminal_for(self, frames):
+		mux = RelayMux(MagicMock(), "ff-target")
+		rec = _Recorder()
+		mux.register_run("r1", rec.handler(), session_key="s1")
+		for frame in frames:
+			mux._classify(frame)
+		mux.dispatch()
+		return rec.terminal
+
+	def test_final_without_a_message_is_a_terminal_error(self):
+		# Repro 1: a hard provider failure (429, failover chain exhausted) ends the
+		# run with a chat final that carries no assistant message at all.
+		term = self._terminal_for([_chat_failed_final_frame("r1", "s1")])
+		self.assertEqual(term[0], "relay:error")
+		self.assertEqual(term[1]["state"], "failed_final")
+		self.assertEqual(term[1]["error"], FAILED_FINAL_ERROR)
+
+	def test_empty_final_after_tools_is_a_terminal_error(self):
+		# Repro 2: the tools ran, the model returned nothing, openclaw surfaced an
+		# incomplete-turn error, and the final still arrives with no message. Same
+		# terminal as the hard failure above: the two repros are ONE root cause.
+		term = self._terminal_for(
+			[
+				_agent_frame(
+					"r1",
+					"s1",
+					"item",
+					{"kind": "tool", "phase": "start", "name": "get_list", "toolCallId": "c1"},
+				),
+				_agent_frame(
+					"r1",
+					"s1",
+					"item",
+					{"kind": "tool", "phase": "end", "name": "get_list", "toolCallId": "c1"},
+				),
+				_chat_failed_final_frame("r1", "s1", stop_reason="stop"),
+			]
+		)
+		self.assertEqual(term[0], "relay:error")
+		self.assertEqual(term[1]["state"], "failed_final")
+
+	def test_top_level_stop_reason_error_is_a_terminal_error(self):
+		term = self._terminal_for([_chat_failed_final_frame("r1", "s1", stop_reason="error")])
+		self.assertEqual(term[0], "relay:error")
+
+	def test_failed_final_names_the_provider_reason_from_the_lifecycle_frame(self):
+		detail = (
+			"Google Generative AI API error (429): You exceeded your current quota, "
+			"please check your plan and billing details."
+		)
+		term = self._terminal_for(
+			[
+				_agent_frame("r1", "s1", "lifecycle", {"phase": "error", "error": detail}),
+				_chat_failed_final_frame("r1", "s1"),
+			]
+		)
+		self.assertEqual(term[0], "relay:error")
+		self.assertIn("429", term[1]["error"])
+		self.assertIn("quota", term[1]["error"])
+
+	def test_lifecycle_error_never_errors_a_turn_that_still_answered(self):
+		# openclaw emits a lifecycle error per FAILED candidate, then fails over. A
+		# recovered turn must keep its answer: the remembered detail is only ever
+		# consulted for a final that produced nothing.
+		term = self._terminal_for(
+			[
+				_agent_frame("r1", "s1", "lifecycle", {"phase": "error", "error": "rate limited"}),
+				_chat_final_frame("r1", "s1", "recovered on the fallback model"),
+			]
+		)
+		self.assertEqual(term[0], "relay:final")
+		self.assertEqual(term[1]["text"], "recovered on the fallback model")
+
+	def test_final_with_an_empty_message_and_benign_stop_reason_stays_final(self):
+		# A final that DOES carry an assistant message with no text and a non-error
+		# stopReason is the one empty shape that is not evidence of failure.
+		frame = {
+			"type": "event",
+			"event": "chat",
+			"payload": {
+				"runId": "r1",
+				"sessionKey": "s1",
+				"state": "final",
+				"message": {"content": [], "stopReason": "end_turn"},
+			},
+		}
+		term = self._terminal_for([frame])
+		self.assertEqual(term[0], "relay:final")
+		self.assertIsNone(term[1]["text"])
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes #543

A failed chat turn hung at "Finishing…" forever with no error surfaced. A second
repro showed the same turn shape ending as a silent empty bubble. Both were
reported independently during the live e2e run on 2026-07-30.

## The broken link

`_chat_final_failed()` read the failure signal from
`payload["message"]["stopReason"]`. **Live openclaw never puts it there.**

Verified against the shipped bundle inside the running
`ghcr.io/openclaw/openclaw:2026.6.8` container. Both emitters agree:

- `server-chat-DVXWYmKw.js:676` builds
  `{runId, sessionKey, seq, state:"final", ...stopReason && {stopReason}, message: text && !shouldSuppressSilent ? {...} : void 0}`
- `embedded-backend-CmxRwl1Z.js:611` is the same shape, with
  `shouldIncludeMessage = Boolean(text)`

So `stopReason` is **top level**, and `message` is **omitted entirely** when the
turn produced no assistant text. For exactly the case the guard was written for,
`payload.get("message")` was `None`, so `isinstance(None, dict)` was False and the
guard returned False. **The branch was unreachable on the live wire.** Only
`broadcastChatFinal`, the transcript-projected path, carries `stopReason` inside
`message`, which is where the original 2026-07-21 observation came from.

A failed turn therefore became `relay:final` with `text=None`, took settlement's
success branch, and published `run:end` with `enrichment_pending: true`, which
renders "Finishing…" until a `message:enriched` that a stalled finalize never
sends.

## Both repros are one root cause

Read-only query against `onb.localhost`, `Jarvis Chat Turn`:

| turn | state | terminal | payload | message row |
|---|---|---|---|---|
| `ca60a18f9d65` | `finalizing` | `relay:final` | `{"text": null}` | content `''`, error NULL, `reply_duration_ms` 20994 |
| `664eecd71659` | `done` | `relay:final` | `{"text": null}` | content `''`, error NULL, `reply_duration_ms` 44369 |

Those durations are the 21.0s and 44.4s from the issue. Identical terminal,
identical row. The only difference was downstream: repro 1's `usage` effect stayed
pending (usage retry with the scheduler paused, so no watchdog re-run) and the
spinner stuck; repro 2 reached `done` and left a silent empty bubble.

## The fix

Backend only. `ChatView` already renders an assistant row's `error` as a red alert
with a headline, details and Retry, and `run:error` clears the waiting state, so
nothing publishes `enrichment_pending` on the error path any more and "Finishing…"
cannot appear. No SPA build needed.

- `_chat_final_failed` reads top-level `stopReason` and treats a final with no
  assistant message at all as failed, keeping the existing "real text always wins"
  and "message present plus benign stopReason stays a normal empty final" guards.
- `relay_turn_events` and `relay_mux._Lane` remember the run's lifecycle
  `phase == "error"` text, which the terminal path drops, so the customer reads the
  actual provider reason (a 429 or quota string) instead of generic copy.
- Reroute guard: a detail mentioning "context overflow" or "aborted" falls back to
  the generic copy, because `turn_handler.py:1079` routes those into
  park-for-recovery. Letting provider prose steer that would put the turn straight
  back into a spinner.

## The test harness was modelling a shape openclaw never emits

`tests/harness/fake_gateway.py:388` and `test_relay_mux.py:184` both built a failed
final as `{"message": {"content": [], "stopReason": "error"}}`. **That fiction is
why a dead branch passed its tests for weeks.** Both now emit the live shape.

Evidence the fix changes real behaviour: the first CI run failed three pre-existing
tests that asserted the old outcome, one of them literally named
`test_final_with_no_message_yields_text_none`. Those are retired in the second
commit.

New coverage: 6 relay-consumer tests, 6 mux tests, 3 full-pipeline tests. Mocking
is at the WebSocket frame boundary and nothing above it, so the classifier, mux
reader loop, settlement and finalize are all real. That level is deliberate: the
defect is a wire-shape mismatch, and any mock higher up cannot see it.

## The empty-versus-failed question

They are **not distinguishable** at this boundary: openclaw omits `message` both
for a failed turn and for a hypothetical rich-output-only success. I chose to
surface the failure. Silence renders a failed turn as an in-progress one that never
resolves; the worst case in the other direction is an honest error on a turn that
said nothing anyway. The narrower non-failure shape (message present, no text,
benign stopReason) is preserved and tested.

Residual risk: a genuinely textless canvas-only turn would now error, and an
errored turn owes only `TERMINAL_EFFECTS`, so `rich_outputs` would not run.
`TERMINAL_EFFECTS` was deliberately not widened, since that is a settlement
semantics change beyond this fix.

## Not verified

- **No live container reproduction.** A 429 could not be forced on a real tenant,
  so the exact `stopReason` value each repro carried was not observed. The DB rows
  prove the outcome and the bundle proves the shape, and the fix keys off the
  shape. Whether the lifecycle error frame reliably precedes the chat terminal on
  the 429 path is read from gateway source, not observed. If it does not arrive the
  fix degrades to generic copy, never back to silence.
- Issue expectation 4 (the failed turn's user message staying in openclaw's session
  history) is out of scope; it needs its own design decision.
- The `usage` effect stalling a `finalizing` turn is untouched. It no longer has a
  user-visible effect here, but remains real for genuine successes and is adjacent
  to #540.
