### PR TITLE
fix(settings): fix connect scrim scope, button pairing and spinner colour

### DIFF
--- a/frontend/src/components/JvSpinner.vue
+++ b/frontend/src/components/JvSpinner.vue
@@ -6,7 +6,7 @@
 			<span class="jv-spin-halo"></span>
 			<span class="jv-spin-dots"><i></i><i></i><i></i></span>
 			<span class="jv-spin-core">
-				<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
+				<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 					<path :d="BRAND_STAR_PATH" />
 				</svg>
 			</span>
@@ -27,7 +27,7 @@
 		<span class="jv-spin-halo"></span>
 		<span class="jv-spin-dots"><i></i><i></i><i></i></span>
 		<span class="jv-spin-core">
-			<svg viewBox="0 0 24 24" fill="#fff" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
 				<path :d="BRAND_STAR_PATH" />
 			</svg>
 		</span>
@@ -39,11 +39,18 @@
  * JvSpinner - the ONE loading indicator in Jarvis.
  *
  * Distilled from the onboarding completion animation (SetupNeuralNet.vue): the
- * same gradient core, the same four-point spark, the same breathing halo and
- * inward-orbiting pulse dots, minus the twelve ERP module labels. Using the one
- * mark for every wait in the product means a customer waiting on a Connect and a
- * customer waiting on their workspace being built are looking at the same
- * product, not two.
+ * same four-point spark, the same breathing halo and inward-orbiting pulse
+ * dots, minus the twelve ERP module labels. Using the one mark for every wait
+ * in the product means a customer waiting on a Connect and a customer waiting
+ * on their workspace being built are looking at the same product, not two.
+ *
+ * Every layer follows currentColor rather than the brand gradient (jarvis#559):
+ * a caller sets `color` (or inherits one), and the spark, its dots and its halo
+ * all tint to that. The spark itself is always drawn at full strength; the halo
+ * and core backdrop behind it are a soft, partial-opacity wash of the same
+ * colour, so the spark reads clearly against them on ANY surface - dark text on
+ * a light card, white on a black button, an accent tone inside a coloured
+ * badge - without ever needing to know what colour it is.
  *
  * Do not add a second spinner. If a surface cannot fit this one, resize the
  * surface.
@@ -119,12 +126,18 @@ const sizeStyle = computed(() => ({ "--jv-spin-size": `${resolvedSize.value}px` 
 }
 
 /* The halo is the "breathing" of the onboarding core. It sits slightly outside
-   the footprint, so the element is allowed to overflow its own box. */
+   the footprint, so the element is allowed to overflow its own box. A partial-
+   opacity wash of currentColor, not a solid fill, so it never has to fight the
+   spark on top of it for contrast (jarvis#559). */
 .jv-spin-halo {
 	position: absolute;
 	inset: -6%;
 	border-radius: 50%;
-	background: radial-gradient(circle, rgba(139, 92, 246, 0.3) 0%, transparent 68%);
+	background: radial-gradient(
+		circle,
+		color-mix(in srgb, currentColor 30%, transparent) 0%,
+		transparent 68%
+	);
 	animation: jv-spin-breathe 2.2s ease-in-out infinite;
 }
 
@@ -133,11 +146,12 @@ const sizeStyle = computed(() => ({ "--jv-spin-size": `${resolvedSize.value}px` 
 	border-radius: 50%;
 	display: grid;
 	place-items: center;
-	/* Matches JarvisMark: --brand-grad is theme-invariant and defined on :root,
-	   with a literal fallback so the spinner is still correct if it is ever
-	   rendered outside the app stylesheet (an isolated test harness). */
-	background: var(--brand-grad, linear-gradient(135deg, #6e8bff, #8b5cf6));
-	box-shadow: 0 2px 7px rgba(139, 92, 246, 0.4);
+	/* Same partial-opacity currentColor wash as the halo: a backdrop for the
+	   spark, not a competing colour. The spark (fill="currentColor" on the svg
+	   above) is drawn at full strength on top, so it always reads clearly
+	   against this regardless of what colour the caller is using. */
+	background: color-mix(in srgb, currentColor 16%, transparent);
+	box-shadow: 0 2px 7px color-mix(in srgb, currentColor 35%, transparent);
 }
 .jv-spin-core svg {
 	width: 62%;
@@ -177,12 +191,7 @@ const sizeStyle = computed(() => ({ "--jv-spin-size": `${resolvedSize.value}px` 
 	width: calc(var(--jv-spin-size) * 0.16);
 	height: calc(var(--jv-spin-size) * 0.16);
 	margin: calc(var(--jv-spin-size) * -0.08);
-	background: radial-gradient(
-		circle,
-		#fff 0%,
-		var(--brand-1, #6e8bff) 55%,
-		rgba(110, 139, 255, 0) 88%
-	);
+	background: radial-gradient(circle, currentColor 0%, currentColor 55%, transparent 88%);
 }
 .jv-spin--md .jv-spin-dots i:nth-child(1) {
 	transform: rotate(0deg) translateY(calc(var(--jv-spin-size) * -0.45));
@@ -202,12 +211,7 @@ const sizeStyle = computed(() => ({ "--jv-spin-size": `${resolvedSize.value}px` 
 	width: calc(var(--jv-spin-size) * 0.15);
 	height: calc(var(--jv-spin-size) * 0.15);
 	margin: calc(var(--jv-spin-size) * -0.075);
-	background: radial-gradient(
-		circle,
-		#fff 0%,
-		var(--brand-1, #6e8bff) 42%,
-		rgba(110, 139, 255, 0) 74%
-	);
+	background: radial-gradient(circle, currentColor 0%, currentColor 42%, transparent 74%);
 }
 .jv-spin--lg .jv-spin-dots i:nth-child(1) {
 	transform: rotate(0deg) translateY(calc(var(--jv-spin-size) * -0.47));

--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -10,7 +10,7 @@
 	         `inert` on each block below is what stops the KEYBOARD, so Tab cannot walk
 	         into the controls underneath. Both are needed - a scrim alone leaves the
 	         whole form reachable, and `inert` alone leaves it looking clickable. -->
-		<div v-if="busy.active" class="jv-llm-busy">
+		<div v-if="busy.active && !hostScrim" class="jv-llm-busy">
 			<JvSpinner :size="56" :label="busy.label" />
 		</div>
 
@@ -877,8 +877,11 @@
                  The inner Cancel is EDIT-mode only: there it calls closeConnect to
                  collapse the steps back to the account list. In add mode the steps ARE
                  the panel (they render directly from panel.mode==='add'), so closeConnect
-                 can't hide them - it would leave an inert "Cancel". Abandoning a fresh add
-                 is the panel's own Cancel/Close below; "Connect" stays to submit. -->
+                 can't hide them - Connect stays to submit. The footer below owns Cancel
+                 for every other flow, but its container can never share a row with this
+                 one, so add mode gets its own paired Cancel here instead (Connect on the
+                 left, Cancel on the right, as requested) and the footer's copy is
+                 suppressed via spineCancelPaired so it does not render a second time. -->
 							<div class="jv-cn-acts">
 								<button
 									v-if="panel.mode !== 'add'"
@@ -903,6 +906,15 @@
 								>
 									<JvSpinner v-if="panelRow._connect.loading" />
 									{{ panelRow._connect.loading ? "Connecting…" : "Connect" }}
+								</button>
+								<button
+									v-if="panel.mode === 'add'"
+									type="button"
+									:disabled="!editable"
+									class="jv-btn jv-btn--ghost"
+									@click="closePanel"
+								>
+									Cancel
 								</button>
 							</div>
 						</template>
@@ -1078,7 +1090,12 @@
 				</div>
 
 				<div class="jv-cfgpanel-acts">
+					<!-- Suppressed while spineCancelPaired: the OAuth spine's own Cancel
+		                 (jv-cn-acts, add mode) already covers this, paired with its Connect
+		                 in the order the product asked for - rendering this one too would
+		                 put a second Cancel on screen. -->
 					<button
+						v-if="!spineCancelPaired"
 						type="button"
 						:disabled="!editable"
 						class="jv-btn jv-btn--sm jv-btn--ghost"
@@ -1103,7 +1120,6 @@
 						class="jv-btn jv-btn--primary"
 						@click="panelAction.run()"
 					>
-						<JvSpinner v-if="busy.active" />
 						{{ busy.active ? "Connecting…" : panelAction.label }}
 					</button>
 				</div>
@@ -1597,8 +1613,12 @@
 	         own bar next to the list rather than from down here. What is left for this
 	         strip is reporting - the outcome of the apply this editor just ran, and
 	         otherwise whatever the server last recorded (which covers an apply that is
-	         still landing from a previous visit, or one started from another tab). -->
-		<div v-if="!footerless && statusLine" :inert="busy.active" class="jv-pool-savebar">
+	         still landing from a previous visit, or one started from another tab).
+	         Hidden while busy.active: the scrim's own label already says "Applying to
+	         your agent…" next to its spinner, and this strip says the exact same
+	         sentence, so showing both is a duplicate, not a second, more useful
+	         status (jarvis#559). -->
+		<div v-if="!footerless && statusLine && !busy.active" class="jv-pool-savebar">
 			<span
 				class="jv-pool-syncpill"
 				:class="'jv-pool-syncpill--' + statusLine.kind"
@@ -1661,6 +1681,12 @@ const props = defineProps({
 	// subscription (is_single_subscription_pool) already renders as a normal
 	// row via rows.value and needs no special-casing.
 	directStatus: { type: Object, default: null },
+	// Let a host (AiModelsPane) render its OWN busy scrim over the whole settings
+	// pane, not just this editor's own box, and suppress the one below so a
+	// connect in flight is never blurred twice. `busy` is exposed for the host
+	// to read; other consumers (onboarding, ChatView) never pass this, so their
+	// scrim is unaffected.
+	hostScrim: { type: Boolean, default: false },
 });
 const emit = defineEmits(["saved", "ready", "direct-changed"]);
 
@@ -2395,6 +2421,28 @@ const panelConnectOpen = computed(() => {
 	const c = r._connect;
 	if (!c) return false;
 	return !!c.open || (panel.value.mode === "add" && !(r.accounts || []).length);
+});
+
+// True exactly when the spine's own Cancel is standing in for the footer's -
+// the paste-back add flow above (jv-cn-acts), not the device-code flow (that one
+// has no Connect to pair against, so it keeps the footer's Cancel as-is). Read by
+// the footer below to skip its own Cancel/Close and avoid showing two.
+//
+// The explicit panel.source check matters: setPanelSource("preset") leaves
+// panelRow.credentialType at whatever it was on the tab the customer came
+// from, so switching from Chat subscription to Preset without this guard
+// would still read as panelConnectOpen and wrongly hide the preset tab's
+// own "Done" - the same trap panelAction below already guards against.
+const spineCancelPaired = computed(() => {
+	const r = panelRow.value;
+	return !!(
+		panel.value.source === "subscription" &&
+		panelConnectOpen.value &&
+		panel.value.mode === "add" &&
+		r &&
+		r._connect &&
+		!r._connect.deviceFlow
+	);
 });
 
 const panelAction = computed(() => {
@@ -3705,8 +3753,9 @@ onBeforeUnmount(() => {
 	clearTimeout(applyResultTimer);
 });
 
-// Let a host (onboarding, footerless) drive Save from its own footer.
-defineExpose({ save });
+// Let a host (onboarding, footerless) drive Save from its own footer, and a
+// hostScrim host (AiModelsPane) read the apply-in-flight state for its own scrim.
+defineExpose({ save, busy });
 </script>
 
 <style scoped>
@@ -3715,7 +3764,13 @@ defineExpose({ save });
    whole settings dialog: the customer should still be able to close the dialog
    or move to another pane while their agent restarts in the background. Inside
    the editor, though, nothing is clickable and (thanks to `inert` on the blocks
-   underneath) nothing is tabbable either. ========================================= */
+   underneath) nothing is tabbable either.
+
+   hostScrim consumers (AiModelsPane) skip this box entirely and render their
+   own wider one instead - the editor alone was too narrow a box: the pane's
+   own save-bar status line sits below it and stayed sharp underneath a scrim
+   scoped only to .jv-llm-editor (jarvis#559). Onboarding and ChatView never
+   pass hostScrim, so they keep exactly this behaviour. ========================================= */
 .jv-llm-editor {
 	position: relative;
 }

--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -42,12 +42,29 @@
 		     round-tripping it through save_llm_pool. -->
 		<div v-else class="jv-pane-fill h-full">
 			<LlmPoolEditor
+				ref="poolEditor"
 				:editable="isSM"
 				:directStatus="directSub"
+				:hostScrim="true"
 				@saved="onSaved"
 				@direct-changed="onDirectChanged"
 			/>
 		</div>
+
+		<!-- Pane-wide busy scrim (jarvis#559): LlmPoolEditor's own scrim only ever
+		     covered its own box, so the pane's status line below it (same editor,
+		     sunk to the bottom via jv-pane-fill) stayed sharp and unblurred while a
+		     connect applied. hostScrim tells the editor to skip its scrim and expose
+		     `busy` instead, so this one - anchored to the whole SettingsPane via its
+		     `scrim` slot - can cover it. -->
+		<template #scrim>
+			<div
+				v-if="poolEditor?.busy?.active"
+				class="absolute inset-0 z-10 grid place-items-center bg-surface-white/85 backdrop-blur-sm"
+			>
+				<JvSpinner :size="56" :label="poolEditor.busy.label" />
+			</div>
+		</template>
 	</SettingsPane>
 </template>
 
@@ -57,7 +74,12 @@ import { Button } from "frappe-ui";
 import { getDirectSubscriptionStatus } from "@/api";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
+import JvSpinner from "@/components/JvSpinner.vue";
 import { agentName } from "@/branding";
+
+// Template ref onto LlmPoolEditor's exposed { save, busy } - read busy.active/
+// busy.label above for the pane-wide scrim in the #scrim slot.
+const poolEditor = ref(null);
 
 // The rail already gates this section to the tenant-admin tier; this flag
 // additionally gates the editor's edit affordances + which probes fire. PART 4

--- a/frontend/src/components/settings/SettingsPane.vue
+++ b/frontend/src/components/settings/SettingsPane.vue
@@ -6,8 +6,14 @@
 
 	     `actions` is for the pane's own header button (a Save, a Refresh). Long
 	     panes that want a pinned Save should render it in the body inside a
-	     `sticky bottom-0` bar instead. -->
-	<div class="flex h-full flex-col gap-6 px-10 py-8 text-ink-gray-8">
+	     `sticky bottom-0` bar instead.
+
+	     `relative` plus the optional `scrim` slot let a pane cover its own header,
+	     body and footer with one blocking overlay while a long-running action is in
+	     flight (AiModelsPane, jarvis#559) - a scrim scoped only to the pane's body
+	     would still leave the header and any status line outside the body sharp
+	     and clickable. Empty for every other pane. -->
+	<div class="relative flex h-full flex-col gap-6 px-10 py-8 text-ink-gray-8">
 		<div class="flex items-start justify-between gap-4">
 			<div class="flex flex-col gap-1">
 				<h2 class="flex items-center gap-2 text-lg font-semibold text-ink-gray-8">
@@ -31,6 +37,8 @@
 		     or a green success banner: failures land here, successes go through
 		     toast.success (§5 anti-pattern 16). -->
 		<ErrorMessage v-if="error" :message="error" />
+
+		<slot name="scrim" />
 	</div>
 </template>
 


### PR DESCRIPTION
Fixes #559

Four presentation problems on Settings > AI models while a chat-subscription
Connect is in flight, plus the duplicated status line requested in the issue
comments. The connect itself already worked, so this is purely visual.

## 1. The busy scrim missed part of the pane

`.jv-llm-busy` was `position:absolute; inset:0` anchored to `.jv-llm-editor`, so
anything the settings pane rendered outside that box, including the pane's own
"Applying to your agent…" line, stayed sharp while the rest was dimmed.

`.jv-llm-editor`'s own box structurally cannot reach the pane header, so the scrim
had to move up a level. `LlmPoolEditor` gains a `hostScrim` prop (default `false`,
so the onboarding and ChatView mounts are byte identical) which suppresses its
internal scrim and exposes `busy` via `defineExpose`. `AiModelsPane` takes a
template ref and renders the scrim through a new `#scrim` slot on `SettingsPane`.

Palette binding was verified by tracing rather than assumed: `paletteVars` and
`jv-dark` bind on `SettingsDialog`'s dialog-body root, an ancestor of both
`AiModelsPane` and `LlmPoolEditor`, so the scrim stays themed at either placement.

## 2. Connect and Cancel are now one row, Connect left

They were in different containers, the spine's Connect and the footer's Cancel, so
they could never align. A paired Cancel now sits inside `.jv-cn-acts` for
`panel.mode === 'add'`, after Connect in DOM order, which is left to right in that
`justify-content:flex-end` row. A `spineCancelPaired` computed suppresses the
footer's redundant Cancel/Close in exactly that case.

Note this differs from the API-key tab's order, which is Cancel then Connect. The
issue asks for Connect on the left specifically, so the two tabs remain
deliberately different rather than both being wrong.

Edge case caught in self-review: the computed needs `panel.source === "subscription"`
explicitly, because `setPanelSource("preset")` never resets `credentialType`, so
without that guard switching to the Preset tab would have hidden its own Done
button.

## 3. The in-button spinner is gone

Removed from the footer's `panelAction` button, the only occurrence of that
pattern in the file. The full-pane scrim already shows a 56px spinner and the
label, and the button's own text already changes to "Connecting…", so it was a
third simultaneous indicator for one operation.

## 4. JvSpinner follows currentColor

`fill="#fff"` becomes `fill="currentColor"` on both svg blocks, and the halo, core
and box-shadow become `color-mix(in srgb, currentColor X%, transparent)`. The
spark renders at full opacity and the backdrop layers are a partial-opacity wash of
the same colour, so internal contrast holds at any hue.

Every usage was checked. `.jv-btn--primary` sets `color: var(--surface)` against
`background: var(--text)`, which is exactly the black-button-should-be-white case
in the issue. `Badge theme="orange"` in SyncPill and AgentsList sets
`text-ink-amber-3`, so the spinner now matches the badge tone instead of showing a
mismatched blue dot, an improvement rather than a regression. The remaining ~15
usages sit in frappe-ui `text-ink-gray-*` or inherited contexts already vetted for
contrast against their own surfaces.

## 5. The duplicated status line is removed

`.jv-pool-savebar`'s `v-if` now includes `&& !busy.active`, and the
now-always-false `:inert="busy.active"` is removed as dead code. Wording confirmed
against the issue comments before implementing.

## Verification

`npm run build` passes. The existing 29 unit tests across `JvSpinner.spec.js` and
`LlmPoolEditor.spec.js` pass.

**Not verified without a browser:** the pixel-level rendering of the widened scrim,
the Connect/Cancel row alignment, and JvSpinner's colour on each surface. These are
reasoned from the CSS and token chain and cross-checked against the build and the
test suite, not visually confirmed in a live session. Worth a look in both light
and dark before merging.
