### PR TITLE
fix(chat): self-heal parked confirmation cards that never render

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7378,6 +7378,18 @@ function onEvent(p) {
 			// pump_epoch E (blocks later lower-epoch stragglers).
 			if (pumpFenceReject(p, true)) break;
 			pumpFenceAccept(p, true);
+			// C2 self-heal (mirror run:end): a parked confirmation card rides an ERRORED
+			// terminal too (settlement/finalize enrich both), so drain it here as well —
+			// otherwise a card parked in a turn that then errors never auto-recovers
+			// (run:error reloads the conversation, not the pending list). Deduped by token;
+			// a conv-less token ("") binds to this conversation.
+			if (Array.isArray(p.pending)) {
+				for (const card of p.pending)
+					enqueuePending({
+						...card,
+						conversation: card.conversation || p.conversation_id,
+					});
+			}
 			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			if (p.message_id) {
 				errorMeta.value = {

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -7265,6 +7265,18 @@ function onEvent(p) {
 			// at pump_epoch E so ANY later lower-epoch straggler is blocked PERMANENTLY.
 			if (pumpFenceReject(p, true)) break;
 			pumpFenceAccept(p, true);
+			// C2 self-heal: a parked confirmation card whose best-effort action:pending
+			// push was missed rides the terminal here (settlement/finalize), so it appears
+			// at turn-end WITHOUT a manual reload. Deduped by token (enqueuePending), so the
+			// finalize backstop re-publish can't double-render; a conv-less token ("") binds
+			// to this conversation, mirroring the action:pending handler's rescue.
+			if (Array.isArray(p.pending)) {
+				for (const card of p.pending)
+					enqueuePending({
+						...card,
+						conversation: card.conversation || p.conversation_id,
+					});
+			}
 			// Defensive: if a promoted turn's run:start was missed, retire the chip.
 			if (queuedTurn.value && queuedTurn.value.run_id === p.run_id) queuedTurn.value = null;
 			const m = messages.value.find((x) => x.name === p.message_id);

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1212,9 +1212,10 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 		if not token:
 			return _error(
 				"ConfirmationUnavailableError",
-				"could not stage the confirmation for this action (a transient "
-				"storage error). Nothing was changed. Retry the exact same call and "
-				"the confirmation card will appear.",
+				"could not stage the confirmation for this action (a storage error). "
+				"Nothing was changed. You may retry the exact same call once; if it "
+				"still fails, tell the user the confirmation could not be shown right "
+				"now and stop - do not loop.",
 			)
 		# Deliver the token to the human's UI out-of-band, over the realtime
 		# channel, NEVER via the function return below - the model must never

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1226,15 +1226,19 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 		try:
 			events.publish_to_user(
 				owner_user,
+				# Same shared item shape the resync endpoint + run:end terminal use, so
+				# the live push can't drift from them (and gets the summary guard too).
 				{
 					"kind": "action:pending",
-					"token": token,
-					"tool": tool,
-					"preview": preview,
-					"conversation": conv,
-					"run_id": run_id,
-					"summary": _describe_call(tool, args),
-					"expires_at": expires_at,
+					**pending_confirm._pending_item(
+						token=token,
+						tool=tool,
+						args=args,
+						preview=preview,
+						conversation=conv,
+						run_id=run_id,
+						expires_at=expires_at,
+					),
 				},
 			)
 		except Exception:

--- a/jarvis/api.py
+++ b/jarvis/api.py
@@ -1203,6 +1203,19 @@ def _run_tool(tool: str, raw_args: dict | str | None, *, conversation: str | Non
 			preview=preview,
 			expires_at=expires_at,
 		)
+		# mint returns None when it could not stage the park (a transient cache
+		# failure that it already rolled back, so nothing is persisted). Do NOT
+		# publish a card against a token whose record does not exist - that card is
+		# un-confirmable and wedges the turn on an "expired" toast. Surface a
+		# RETRYABLE tool error instead: nothing changed, so the model can simply call
+		# the exact same tool again and the confirmation card will appear.
+		if not token:
+			return _error(
+				"ConfirmationUnavailableError",
+				"could not stage the confirmation for this action (a transient "
+				"storage error). Nothing was changed. Retry the exact same call and "
+				"the confirmation card will appear.",
+			)
 		# Deliver the token to the human's UI out-of-band, over the realtime
 		# channel, NEVER via the function return below - the model must never
 		# see it. Published to the OWNER (the subscribed browser), not the acting

--- a/jarvis/chat/actions_api.py
+++ b/jarvis/chat/actions_api.py
@@ -588,38 +588,12 @@ def list_pending_confirmations(conversation: str | None = None) -> dict:
 	if frappe.session.user == "Guest":
 		raise frappe.PermissionError("authentication required")
 
-	from jarvis.api import _describe_call
 	from jarvis.chat import pending_confirm
 
 	conv = (conversation or "").strip() or None
-	records = pending_confirm.list_for_owner(frappe.session.user, conversation=conv)
-	items = []
-	for r in records:
-		# Per-record guard (F3): a single malformed record must NOT 500 the whole
-		# endpoint - that would blind resync of EVERY card until TTL. Skip + log
-		# the bad one; surface the rest.
-		try:
-			tool = r.get("tool")
-			args = r.get("args") or {}
-			items.append(
-				{
-					"token": r.get("token"),
-					"tool": tool,
-					# Return the PARK-TIME preview verbatim (F2). Recomputing it here
-					# via _pending_preview re-runs the sandboxed dry-run, whose inline
-					# on_submit/on_cancel side effects are NOT sandboxed and would
-					# re-fire on every reload/reconnect/tab-wake/post-confirm. Tokens
-					# minted before preview was stored carry None (summary still
-					# describes the action); no dry-run is ever run on this path.
-					"preview": r.get("preview"),
-					"summary": _describe_call(tool, args),
-					"conversation": r.get("conversation"),
-					"run_id": r.get("run_id"),
-					"expires_at": r.get("expires_at"),
-				}
-			)
-		except Exception:
-			frappe.log_error(
-				title="list_pending_confirmations record skipped", message=frappe.get_traceback()
-			)
+	# Same client-facing item shape the action:pending event and the run:end
+	# terminal use (pending_confirm.list_items_for_owner) so the three cannot drift
+	# and no internal field leaks. The park-time preview is returned verbatim (F2 -
+	# never a re-run dry-run) and the per-record F3 guard both live in the helper.
+	items = pending_confirm.list_items_for_owner(frappe.session.user, conversation=conv)
 	return {"ok": True, "data": {"pending": items}}

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -340,6 +340,10 @@ def _effect_terminal_publish(ctx: _Ctx) -> None:
 			"run:end",
 			{"enrichment_pending": True, "was_recovered": bool(row.get("was_recovered"))},
 		)
+	# C2: re-attach any live parked confirmation card on the terminal backstop too
+	# (mirrors settlement), so a card missed on the live push still re-surfaces even
+	# if it was the settlement publish itself that was lost.
+	extra = settlement._extra_with_pending(extra, ctx.owner, ctx.conversation)
 	# CDX-12: carry pump_epoch + the SAME stable terminal seq (the durable watermark)
 	# settlement emitted, so the CLIENT one-shot fence recognises this as the identical
 	# terminal at this run's epoch and dedupes it (no repeated announcement / reload),

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -154,19 +154,32 @@ def mint(
 		# carries it (the resync payload reads it straight off the record).
 		"expires_at": expires_at if expires_at is not None else int(time.time()) + _TTL_S,
 	}
-	frappe.cache().set_value(_key(token), record, expires_in_sec=_TTL_S)
-	# cards_open gauge +1 (self-healing on expiry via the ZSET score).
-	_gauge_add(token, record["expires_at"])
-	_emit_cards_open("mint")
-	# Index the token under its owner so list_for_owner can re-surface it. Best
-	# effort: the token record is the source of truth (owner binding + execution
-	# both read it), so an index hiccup must never block the park.
+	cache = frappe.cache()
+	cache.set_value(_key(token), record, expires_in_sec=_TTL_S)
+	# Index the token under its owner so list_for_owner (the resync endpoint) can
+	# re-surface it after a reload/reconnect. This is REQUIRED, not best-effort: an
+	# unindexed record is INVISIBLE to resync -> a silent, unrecoverable
+	# confirmation card (the bulk-create card that parked but never rendered). So if
+	# the index write fails, roll the record back rather than leave an orphan the
+	# user can never see, and log the failure LOUDLY (it was a silent
+	# try/except: pass). The gate re-parks on its next attempt.
 	try:
-		cache = frappe.cache()
 		cache.sadd(_owner_key(owner), token)
 		cache.expire_key(_owner_key(owner), _TTL_S)
 	except Exception:
-		pass
+		frappe.log_error(
+			title="pending_confirm: owner-index write failed; token not parked",
+			message=frappe.get_traceback(),
+		)
+		try:
+			cache.delete_value(_key(token))
+		except Exception:
+			pass
+		return token
+	# cards_open gauge +1 (self-healing on expiry via the ZSET score). Bumped only
+	# after a successful persist+index so the gauge never over-counts a rolled-back park.
+	_gauge_add(token, record["expires_at"])
+	_emit_cards_open("mint")
 	return token
 
 

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -119,12 +119,15 @@ def mint(
 	exec_user: str | None = None,
 	preview: dict | None = None,
 	expires_at: int | None = None,
-) -> str:
+) -> str | None:
 	"""Store a pending call and return a fresh single-use token
 	(secrets.token_urlsafe(24)). The stored record carries conversation,
 	owner, tool, args (the full dict - this is the authoritative payload
 	that will execute), args_hash, run_id, exec_user, preview. TTL _TTL_S.
-	Returns the token.
+	Returns the token, or ``None`` when the park could not be stored (a transient
+	cache failure): the record+index must BOTH land or the caller must treat it as
+	a retryable failure and publish NO card - a token whose record does not exist is
+	an un-confirmable card that wedges the turn.
 
 	``preview`` is the park-time confirmation preview (dry-run "would" doc or
 	described-intent dict). It is stored so the resync endpoint can return it
@@ -155,29 +158,43 @@ def mint(
 		"expires_at": expires_at if expires_at is not None else int(time.time()) + _TTL_S,
 	}
 	cache = frappe.cache()
-	cache.set_value(_key(token), record, expires_in_sec=_TTL_S)
-	# Index the token under its owner so list_for_owner (the resync endpoint) can
-	# re-surface it after a reload/reconnect. This is REQUIRED, not best-effort: an
-	# unindexed record is INVISIBLE to resync -> a silent, unrecoverable
-	# confirmation card (the bulk-create card that parked but never rendered). So if
-	# the index write fails, roll the record back rather than leave an orphan the
-	# user can never see, and log the failure LOUDLY (it was a silent
-	# try/except: pass). The gate re-parks on its next attempt.
+	# Persist the record, index it under its owner, and VERIFY it landed - all three
+	# must hold or the park is a failure. Two ways a park silently breaks:
+	#   1. The owner-index write fails: an unindexed record is INVISIBLE to the resync
+	#      endpoint -> a confirmation card that never re-surfaces (the bulk-create card
+	#      that parked but never rendered).
+	#   2. set_value SUPPRESSES a transient redis ConnectionError, so the record itself
+	#      can fail to persist with no exception raised at all.
+	# In EITHER case, returning a token would make the gate publish a card whose token
+	# has no record -> an un-confirmable "expired" card that wedges the turn. So on ANY
+	# failure roll the writes back (no orphan), log LOUDLY (it was once a silent
+	# try/except: pass), and return None so the gate surfaces a RETRYABLE tool error and
+	# the model can simply call again.
 	try:
+		cache.set_value(_key(token), record, expires_in_sec=_TTL_S)
 		cache.sadd(_owner_key(owner), token)
 		cache.expire_key(_owner_key(owner), _TTL_S)
+		# set_value swallows a redis blip, so confirm the record is really readable
+		# before we let a card be published against this token.
+		if peek(token) is None:
+			raise RuntimeError("pending-confirm record did not persist")
 	except Exception:
 		frappe.log_error(
-			title="pending_confirm: owner-index write failed; token not parked",
+			title="pending_confirm: park failed; token not stored",
 			message=frappe.get_traceback(),
 		)
-		try:
-			cache.delete_value(_key(token))
-		except Exception:
-			pass
-		return token
+		for _rollback in (
+			lambda: cache.delete_value(_key(token)),
+			lambda: cache.srem(_owner_key(owner), token),
+		):
+			try:
+				_rollback()
+			except Exception:
+				pass
+		return None
 	# cards_open gauge +1 (self-healing on expiry via the ZSET score). Bumped only
-	# after a successful persist+index so the gauge never over-counts a rolled-back park.
+	# after a successful persist+index+verify so the gauge never over-counts a
+	# rolled-back park.
 	_gauge_add(token, record["expires_at"])
 	_emit_cards_open("mint")
 	return token

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -332,39 +332,65 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	return out
 
 
-def list_items_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
-	"""Client-facing pending-confirmation items for ``owner`` (optionally filtered
-	to ``conversation``): the SAME shape the ``action:pending`` event and the resync
-	endpoint deliver - ``token``/``tool``/``preview``/``summary``/``conversation``/
-	``run_id``/``expires_at``, and NEVER the internal ``args``/``exec_user``/
-	``args_hash``. Single home for that shape so the resync endpoint and the
-	``run:end`` terminal cannot drift: a card missed on the best-effort live push
-	re-surfaces on the turn's (fenced, backstopped) terminal without a manual reload.
-	Per-record guard: one malformed record must not sink the whole list."""
+def _pending_item(
+	*,
+	token: str,
+	tool: str,
+	args: dict,
+	preview: dict | None,
+	conversation: str,
+	run_id: str,
+	expires_at: int | None,
+) -> dict:
+	"""The ONE client-facing pending-confirmation item shape, shared by the live
+	``action:pending`` push (jarvis.api), the resync endpoint, and the ``run:end``
+	terminal - so the three cannot drift. Carries
+	``token``/``tool``/``preview``/``summary``/``conversation``/``run_id``/
+	``expires_at`` and NEVER the internal ``args``/``exec_user``/``args_hash``.
+
+	``summary`` is COSMETIC: if ``_describe_call`` throws it degrades to "" (and is
+	logged) - a confirmable card must NEVER be dropped because its human label failed
+	to build. That is the invisible-card bug this whole change closes."""
 	from jarvis.api import _describe_call
 
-	items: list[dict] = []
-	for r in list_for_owner(owner, conversation=conversation):
-		try:
-			tool = r.get("tool")
-			args = r.get("args") or {}
-			items.append(
-				{
-					"token": r.get("token"),
-					"tool": tool,
-					"preview": r.get("preview"),
-					"summary": _describe_call(tool, args),
-					"conversation": r.get("conversation"),
-					"run_id": r.get("run_id"),
-					"expires_at": r.get("expires_at"),
-				}
-			)
-		except Exception:
-			frappe.log_error(
-				title="pending_confirm.list_items_for_owner: record skipped",
-				message=frappe.get_traceback(),
-			)
-	return items
+	try:
+		summary = _describe_call(tool, args or {})
+	except Exception:
+		summary = ""
+		frappe.log_error(
+			title="pending_confirm: confirmation summary build failed",
+			message=frappe.get_traceback(),
+		)
+	return {
+		"token": token,
+		"tool": tool,
+		"preview": preview,
+		"summary": summary,
+		"conversation": conversation,
+		"run_id": run_id,
+		"expires_at": expires_at,
+	}
+
+
+def list_items_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
+	"""Client-facing pending-confirmation items for ``owner`` (optionally filtered to
+	``conversation``), each built through the shared ``_pending_item`` shape so the
+	resync endpoint and the ``run:end`` terminal cannot drift: a card missed on the
+	best-effort live push re-surfaces on the turn's (fenced, backstopped) terminal
+	without a manual reload. Item building never drops a record - only its cosmetic
+	summary can degrade (see ``_pending_item``)."""
+	return [
+		_pending_item(
+			token=r.get("token"),
+			tool=r.get("tool"),
+			args=r.get("args") or {},
+			preview=r.get("preview"),
+			conversation=r.get("conversation"),
+			run_id=r.get("run_id"),
+			expires_at=r.get("expires_at"),
+		)
+		for r in list_for_owner(owner, conversation=conversation)
+	]
 
 
 def clear_for_conversation(owner: str, conversation: str, run_id: str | None = None) -> int:

--- a/jarvis/chat/pending_confirm.py
+++ b/jarvis/chat/pending_confirm.py
@@ -315,6 +315,41 @@ def list_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
 	return out
 
 
+def list_items_for_owner(owner: str, conversation: str | None = None) -> list[dict]:
+	"""Client-facing pending-confirmation items for ``owner`` (optionally filtered
+	to ``conversation``): the SAME shape the ``action:pending`` event and the resync
+	endpoint deliver - ``token``/``tool``/``preview``/``summary``/``conversation``/
+	``run_id``/``expires_at``, and NEVER the internal ``args``/``exec_user``/
+	``args_hash``. Single home for that shape so the resync endpoint and the
+	``run:end`` terminal cannot drift: a card missed on the best-effort live push
+	re-surfaces on the turn's (fenced, backstopped) terminal without a manual reload.
+	Per-record guard: one malformed record must not sink the whole list."""
+	from jarvis.api import _describe_call
+
+	items: list[dict] = []
+	for r in list_for_owner(owner, conversation=conversation):
+		try:
+			tool = r.get("tool")
+			args = r.get("args") or {}
+			items.append(
+				{
+					"token": r.get("token"),
+					"tool": tool,
+					"preview": r.get("preview"),
+					"summary": _describe_call(tool, args),
+					"conversation": r.get("conversation"),
+					"run_id": r.get("run_id"),
+					"expires_at": r.get("expires_at"),
+				}
+			)
+		except Exception:
+			frappe.log_error(
+				title="pending_confirm.list_items_for_owner: record skipped",
+				message=frappe.get_traceback(),
+			)
+	return items
+
+
 def clear_for_conversation(owner: str, conversation: str, run_id: str | None = None) -> int:
 	"""Delete all of ``owner``'s live tokens STRICTLY bound to ``conversation``
 	and return the count cleared. Conversation-less tokens ("") are left alone -

--- a/jarvis/chat/settlement.py
+++ b/jarvis/chat/settlement.py
@@ -166,6 +166,10 @@ def invoke_settlement(
 	# durable watermark at the terminal) so the client dedupes a repeat equal-epoch
 	# terminal (the finalize backstop re-publish) one-shot — no repeated announcement/reload.
 	if owner:
+		# C2: ride any live parked confirmation card for this conversation on the
+		# fenced, backstopped terminal, so a card whose best-effort action:pending
+		# push was missed re-surfaces at turn-end without a manual reload.
+		pub_extra = _extra_with_pending(pub_extra, owner, conversation)
 		ts.publish_fenced(
 			owner,
 			pub_kind,
@@ -180,6 +184,24 @@ def invoke_settlement(
 
 	# S6 — enqueue enrichment (idempotent per (turn, effect_name); force-done at 3).
 	deps.enqueue_finalize(run_id, relay_target_id)
+
+
+def _extra_with_pending(extra: dict, owner: str | None, conversation: str) -> dict:
+	"""C2 self-heal: fold any live parked confirmation card(s) for ``conversation``
+	into a terminal event's ``extra`` payload under ``pending``, so a card whose
+	best-effort ``action:pending`` push was missed re-surfaces on the (fenced,
+	backstopped) ``run:end`` without a manual reload. Returns a NEW dict when a card
+	is present (never mutates the caller's) and the input unchanged - no ``pending``
+	key - in the common no-card case (one owner-index read). Shared by settlement's
+	authoritative publish and finalize's re-publish backstop so they can't diverge."""
+	if not owner:
+		return extra
+	from jarvis.chat import pending_confirm
+
+	pending = pending_confirm.list_items_for_owner(owner, conversation)
+	if not pending:
+		return extra
+	return {**extra, "pending": pending}
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_actions_api.py
+++ b/jarvis/tests/test_actions_api.py
@@ -668,7 +668,14 @@ class TestListPendingConfirmations(FrappeTestCase):
 		self.assertEqual(len(items), 1)
 		self.assertEqual(items[0]["preview"], stored)
 
-	def test_one_bad_record_does_not_blind_the_endpoint(self):
+	def test_bad_summary_degrades_card_but_does_not_drop_it(self):
+		"""F3 + card-visibility: a record whose COSMETIC summary (_describe_call)
+		throws must NOT be dropped from the list - dropping a confirmable card is the
+		exact invisible-card bug this fix closes. The endpoint still returns ok, BOTH
+		cards surface, and the one whose summary failed degrades to "" (not vanishes).
+
+		(Supersedes the earlier assertion that a bad record was silently skipped -
+		that baked in the drop-the-card defect.)"""
 		from jarvis.chat import pending_confirm
 		from jarvis.chat.actions_api import list_pending_confirmations
 
@@ -698,8 +705,11 @@ class TestListPendingConfirmations(FrappeTestCase):
 				raise RuntimeError("boom building this record's summary")
 			return "ok-summary"
 
-		with patch("jarvis.api._describe_call", side_effect=_boom):
+		with patch("jarvis.api._describe_call", side_effect=_boom), patch.object(frappe, "log_error"):
 			r = list_pending_confirmations(conversation=conv)
-		# One record raised; the endpoint still returns ok with the other card.
+		# One summary raised; the endpoint still returns ok AND keeps BOTH cards -
+		# the bad-summary one degrades to "" rather than disappearing.
 		self.assertTrue(r["ok"])
-		self.assertEqual(len(r["data"]["pending"]), 1)
+		items = r["data"]["pending"]
+		self.assertEqual(len(items), 2)
+		self.assertEqual(sorted(it["summary"] for it in items), ["", "ok-summary"])

--- a/jarvis/tests/test_confirm_gate.py
+++ b/jarvis/tests/test_confirm_gate.py
@@ -97,6 +97,30 @@ class TestGateParks(FrappeTestCase):
 		self.assertIsNotNone(captured.get("token"))
 
 
+class TestGateParkFailure(FrappeTestCase):
+	"""When mint cannot stage the confirmation (a transient redis failure rolled
+	the record back), it returns None. The gate must NOT publish a card against a
+	token whose record does not exist - that card is un-confirmable and wedges the
+	turn on an 'expired' toast. Instead it returns a RETRYABLE tool error so the
+	model can simply call again."""
+
+	def test_park_failure_returns_error_and_publishes_no_card(self):
+		desc = "jarvis-test-gate-park-fail-001"
+		with patch("jarvis.chat.pending_confirm.mint", return_value=None):
+			with patch("jarvis.chat.events.publish_to_user") as pub:
+				r = api._run_tool(
+					"create_doc",
+					{"doctype": "ToDo", "values": {"description": desc}},
+				)
+		# A legible error, NOT a pending_confirmation the model waits on.
+		self.assertFalse(r["ok"])
+		self.assertNotEqual(r.get("data", {}).get("status"), "pending_confirmation")
+		# No action:pending card was published (nothing for the user to confirm).
+		self.assertFalse(pub.called, "a failed park must not publish a dead card")
+		# And nothing was written.
+		self.assertFalse(frappe.db.exists("ToDo", {"description": desc}))
+
+
 class TestShareAssignGatedWrites(FrappeTestCase):
 	"""F17/F20 (share_doc) + F23 (assign_to): their own docstrings/descriptors
 	say "ALWAYS confirm" (share_doc: re-share/everyone=true is a permission

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -10,6 +10,7 @@ import threading
 from unittest.mock import patch
 
 import frappe
+import redis.exceptions
 from frappe.tests.utils import FrappeTestCase
 
 from jarvis.chat import pending_confirm
@@ -65,6 +66,61 @@ class TestMint(FrappeTestCase):
 		# Both are independently live.
 		self.assertIsNotNone(pending_confirm.peek(t1))
 		self.assertIsNotNone(pending_confirm.peek(t2))
+
+
+class TestMintReliableIndex(FrappeTestCase):
+	"""C1: a token can NEVER be persisted without being findable by
+	list_for_owner. An unindexed record is invisible to the resync endpoint -> a
+	silent, unrecoverable confirmation card (the bulk-create card that never
+	rendered). So the owner-index write is required, not best-effort: if it fails
+	the record is rolled back (no orphan) and the failure is logged LOUDLY (it was
+	a silent try/except: pass)."""
+
+	_A = "owner-c1@example.invalid"
+
+	def setUp(self):
+		# The per-owner index lives in Redis (not rolled back with the DB); clear
+		# it so a prior run's tokens don't mask these assertions.
+		frappe.cache().delete_value(pending_confirm._OWNER_PREFIX + self._A)
+
+	def _mint(self):
+		return pending_confirm.mint(
+			conversation="conv-c1",
+			owner=self._A,
+			tool="create_doc",
+			args={"docs": [{"doctype": "ToDo", "values": {"description": "c1"}}]},
+			run_id="",
+			preview={"preview": True, "would": {"created": [{"doctype": "ToDo", "name": "x"}]}},
+		)
+
+	def test_mint_persists_and_indexes(self):
+		"""A normal mint is BOTH peekable AND retrievable by resync (regression
+		guard for the persisted<->indexed invariant)."""
+		token = self._mint()
+		self.assertIsNotNone(pending_confirm.peek(token))
+		self.assertIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
+
+	def test_index_write_failure_is_logged_not_silent(self):
+		"""An owner-index write failure must be LOUD (was swallowed by
+		try/except: pass), so the mode is observable instead of invisible."""
+		with patch.object(
+			frappe.cache(), "sadd", side_effect=redis.exceptions.ConnectionError("simulated redis blip")
+		):
+			with patch.object(frappe, "log_error") as mock_log:
+				self._mint()
+		self.assertTrue(mock_log.called, "index-write failure must be logged, not swallowed")
+
+	def test_index_write_failure_leaves_no_orphan(self):
+		"""If the token can't be indexed it must NOT be left persisted (invisible
+		to resync) - the record is rolled back so no unrecoverable orphan survives
+		for the full TTL."""
+		with patch.object(
+			frappe.cache(), "sadd", side_effect=redis.exceptions.ConnectionError("simulated redis blip")
+		):
+			with patch.object(frappe, "log_error"):
+				token = self._mint()
+		self.assertIsNone(pending_confirm.peek(token))
+		self.assertNotIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
 
 
 class TestExecUser(FrappeTestCase):

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -250,6 +250,28 @@ class TestListForOwner(FrappeTestCase):
 	def test_empty_for_unknown_owner(self):
 		self.assertEqual(pending_confirm.list_for_owner("nobody@example.invalid"), [])
 
+	def test_list_items_for_owner_clean_client_shape(self):
+		"""C2: the shared item builder returns the client-facing shape and NEVER
+		leaks internal fields (args/exec_user/args_hash) - the SAME shape the resync
+		endpoint and the run:end terminal both use, so they cannot drift."""
+		t = self._mint(self._A, "conv-a1", "items-clean")
+		items = pending_confirm.list_items_for_owner(self._A)
+		self.assertEqual([it["token"] for it in items], [t])
+		it = items[0]
+		self.assertEqual(
+			set(it.keys()),
+			{"token", "tool", "preview", "summary", "conversation", "run_id", "expires_at"},
+		)
+		self.assertEqual(it["tool"], "create_doc")
+		for internal in ("args", "exec_user", "args_hash"):
+			self.assertNotIn(internal, it)
+
+	def test_list_items_for_owner_filtered_by_conversation(self):
+		self._mint(self._A, "conv-a1", "i-1")
+		t2 = self._mint(self._A, "conv-a2", "i-2")
+		items = pending_confirm.list_items_for_owner(self._A, conversation="conv-a2")
+		self.assertEqual([it["token"] for it in items], [t2])
+
 	def test_clear_for_conversation_removes_only_that_conversation(self):
 		"""F6: clearing a conversation's tokens (on stop_run) deletes its own live
 		tokens and leaves other conversations - and conversation-less tokens - alone."""

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -306,6 +306,21 @@ class TestListForOwner(FrappeTestCase):
 		items = pending_confirm.list_items_for_owner(self._A, conversation="conv-a2")
 		self.assertEqual([it["token"] for it in items], [t2])
 
+	def test_list_items_summary_failure_still_surfaces_card(self):
+		"""A confirmable card must NEVER be dropped because the COSMETIC summary
+		(_describe_call) throws on one odd record - that is the exact invisible-card
+		bug this whole fix exists to close. The item still surfaces; only the summary
+		degrades to ""."""
+		t = self._mint(self._A, "conv-a1", "sum-throws")
+		with patch("jarvis.api._describe_call", side_effect=RuntimeError("boom")):
+			with patch.object(frappe, "log_error"):
+				items = pending_confirm.list_items_for_owner(self._A)
+		self.assertEqual([it["token"] for it in items], [t])
+		self.assertEqual(items[0]["summary"], "")
+		# The rest of the client-facing shape is intact.
+		self.assertEqual(items[0]["tool"], "create_doc")
+		self.assertIn("preview", items[0])
+
 	def test_clear_for_conversation_removes_only_that_conversation(self):
 		"""F6: clearing a conversation's tokens (on stop_run) deletes its own live
 		tokens and leaves other conversations - and conversation-less tokens - alone."""

--- a/jarvis/tests/test_pending_confirm.py
+++ b/jarvis/tests/test_pending_confirm.py
@@ -122,6 +122,40 @@ class TestMintReliableIndex(FrappeTestCase):
 		self.assertIsNone(pending_confirm.peek(token))
 		self.assertNotIn(token, {r["token"] for r in pending_confirm.list_for_owner(self._A)})
 
+	def test_index_write_failure_returns_none(self):
+		"""A park that can't be indexed must SIGNAL failure by returning None - NOT
+		a token. Returning a token whose record was rolled back made the gate
+		publish an un-confirmable card that wedged the turn on an 'expired' toast
+		(the whole point of this fix). None lets the gate surface a retryable tool
+		error instead."""
+		with patch.object(
+			frappe.cache(), "sadd", side_effect=redis.exceptions.ConnectionError("simulated redis blip")
+		):
+			with patch.object(frappe, "log_error"):
+				self.assertIsNone(self._mint())
+
+	def test_persist_verify_failure_returns_none(self):
+		"""set_value SUPPRESSES a transient redis ConnectionError, so a record can
+		silently fail to persist while the index write succeeds. mint reads the
+		record back and, finding it absent, must treat the park as failed (return
+		None + log) rather than let a card be published against a token whose record
+		never landed."""
+		with patch.object(pending_confirm, "peek", return_value=None):
+			with patch.object(frappe, "log_error") as mock_log:
+				self.assertIsNone(self._mint())
+		self.assertTrue(mock_log.called, "a persist-verify miss must be logged, not swallowed")
+
+	def test_failed_park_does_not_bump_cards_open_gauge(self):
+		"""The cards_open gauge is observability, not authority: a rolled-back park
+		must never leave the gauge over-counting a card the user can't see."""
+		before = pending_confirm.cards_open_gauge()
+		with patch.object(
+			frappe.cache(), "sadd", side_effect=redis.exceptions.ConnectionError("simulated redis blip")
+		):
+			with patch.object(frappe, "log_error"):
+				self._mint()
+		self.assertEqual(pending_confirm.cards_open_gauge(), before)
+
 
 class TestExecUser(FrappeTestCase):
 	def test_exec_user_stored_and_returned(self):

--- a/jarvis/tests/test_terminal_pending.py
+++ b/jarvis/tests/test_terminal_pending.py
@@ -1,0 +1,70 @@
+"""C2 self-heal: the run:end terminal carries any live parked confirmation card
+for the conversation (settlement._extra_with_pending), so a card whose best-effort
+action:pending push was missed re-surfaces at turn-end without a manual reload.
+
+This is the shared enrichment used by BOTH settlement's authoritative terminal
+publish and finalize's re-publish backstop, so testing it once covers both sites.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import pending_confirm, settlement
+
+
+class TestTerminalCarriesPending(FrappeTestCase):
+	_OWNER = "owner-c2@example.invalid"
+	_CONV = "conv-c2"
+
+	def setUp(self):
+		# The per-owner index lives in Redis (not rolled back with the DB); clear it.
+		frappe.cache().delete_value(pending_confirm._OWNER_PREFIX + self._OWNER)
+
+	def _park(self):
+		return pending_confirm.mint(
+			conversation=self._CONV,
+			owner=self._OWNER,
+			tool="create_doc",
+			args={"docs": [{"doctype": "ToDo", "values": {"description": "c2"}}]},
+			run_id="",
+			preview={"preview": True},
+		)
+
+	def test_terminal_carries_parked_card(self):
+		self._park()
+		base = {"enrichment_pending": True}
+		out = settlement._extra_with_pending(base, self._OWNER, self._CONV)
+		# The parked card rides the terminal in the client-facing item shape, and the
+		# existing terminal fields are preserved.
+		self.assertTrue(out.get("enrichment_pending"))
+		self.assertEqual(len(out["pending"]), 1)
+		self.assertEqual(out["pending"][0]["tool"], "create_doc")
+		self.assertIn("token", out["pending"][0])
+		# The caller's dict is NOT mutated (a new dict is returned).
+		self.assertNotIn("pending", base)
+
+	def test_no_card_leaves_extra_unchanged(self):
+		# The common case: no parked card -> the input is returned unchanged (no new
+		# dict, no empty ``pending`` key bloating every terminal).
+		base = {"enrichment_pending": True}
+		out = settlement._extra_with_pending(base, self._OWNER, self._CONV)
+		self.assertNotIn("pending", out)
+		self.assertIs(out, base)
+
+	def test_no_owner_leaves_extra_unchanged(self):
+		base = {"stopped": True}
+		self.assertIs(settlement._extra_with_pending(base, None, self._CONV), base)
+
+	def test_other_conversation_card_does_not_ride_this_terminal(self):
+		# A card parked in a DIFFERENT (bound) conversation must not leak onto this
+		# conversation's terminal.
+		pending_confirm.mint(
+			conversation="conv-other",
+			owner=self._OWNER,
+			tool="create_doc",
+			args={"docs": [{"doctype": "ToDo", "values": {"description": "other"}}]},
+			run_id="",
+			preview={"preview": True},
+		)
+		out = settlement._extra_with_pending({"enrichment_pending": True}, self._OWNER, self._CONV)
+		self.assertNotIn("pending", out)

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -480,6 +480,23 @@ function onEvent(p) {
 			sendBusy.value = false;
 			live.value = null;
 			if (!ignored) errorBanner.value = p.error || "That turn failed.";
+			// C2 self-heal (mirror run:end): a card parked in a turn that then errors
+			// must still auto-recover — drain p.pending here too, not only on run:end.
+			// Deduped by token; a conv-less token ("") binds to this conversation.
+			if (Array.isArray(p.pending)) {
+				for (const card of p.pending) {
+					if (!card.token || pending.value.some((x) => x.token === card.token)) continue;
+					pending.value.push({
+						token: card.token,
+						tool: card.tool || "",
+						summary: card.summary || "",
+						preview: card.preview ?? null,
+						conversation: card.conversation || conv,
+						run_id: card.run_id,
+						expires_at: card.expires_at ?? null,
+					});
+				}
+			}
 			load();
 			break;
 

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -453,6 +453,24 @@ function onEvent(p) {
 		case "run:end":
 			sendBusy.value = false;
 			live.value = null;
+			// C2 self-heal: a parked confirmation card whose best-effort action:pending
+			// push was missed rides the terminal here (settlement/finalize) - surface it at
+			// turn-end WITHOUT a manual reload. Deduped by token; a conv-less token ("")
+			// binds to this conversation, mirroring the action:pending case below.
+			if (Array.isArray(p.pending)) {
+				for (const card of p.pending) {
+					if (!card.token || pending.value.some((x) => x.token === card.token)) continue;
+					pending.value.push({
+						token: card.token,
+						tool: card.tool || "",
+						summary: card.summary || "",
+						preview: card.preview ?? null,
+						conversation: card.conversation || conv,
+						run_id: card.run_id,
+						expires_at: card.expires_at ?? null,
+					});
+				}
+			}
 			// The reply is durable now; reconcile against it (canvas items, final
 			// formatting) instead of trusting the streamed copy.
 			load();

--- a/pwa/src/views/ChatView.vue
+++ b/pwa/src/views/ChatView.vue
@@ -456,8 +456,9 @@ function onEvent(p) {
 			// C2 self-heal: a parked confirmation card whose best-effort action:pending
 			// push was missed rides the terminal here (settlement/finalize) - surface it at
 			// turn-end WITHOUT a manual reload. Deduped by token; a conv-less token ("")
-			// binds to this conversation, mirroring the action:pending case below.
-			if (Array.isArray(p.pending)) {
+			// binds to this conversation, mirroring the action:pending case below. Skip a
+			// run the user STOPPED - its cards were swept server-side; don't resurrect them.
+			if (!ignored && Array.isArray(p.pending)) {
 				for (const card of p.pending) {
 					if (!card.token || pending.value.some((x) => x.token === card.token)) continue;
 					pending.value.push({
@@ -482,8 +483,9 @@ function onEvent(p) {
 			if (!ignored) errorBanner.value = p.error || "That turn failed.";
 			// C2 self-heal (mirror run:end): a card parked in a turn that then errors
 			// must still auto-recover — drain p.pending here too, not only on run:end.
-			// Deduped by token; a conv-less token ("") binds to this conversation.
-			if (Array.isArray(p.pending)) {
+			// Deduped by token; a conv-less token ("") binds to this conversation; a
+			// user-STOPPED run is skipped (its cards were swept server-side).
+			if (!ignored && Array.isArray(p.pending)) {
 				for (const card of p.pending) {
 					if (!card.token || pending.value.some((x) => x.token === card.token)) continue;
 					pending.value.push({


### PR DESCRIPTION
## Problem

Two freshly-onboarded tenants filed 6 tickets with one symptom: **Jarvis says "please approve the confirmation card" but no card (preview + Confirm/Discard buttons) appears in the chat, and a reload doesn't recover it.** The turn is left waiting on a confirmation the user can never give.

## Root cause (leading hypothesis)

A gated write parks a single-use token in Redis and delivers the card two ways: a best-effort out-of-band `action:pending` realtime push, and a resync endpoint (`list_pending_confirmations`) the SPA calls on reload. The token is also indexed under its owner so resync can find it. If that **owner-index write silently failed** (it was a `try/except: pass`), the token was persisted-but-unindexed → **invisible to resync** → the card never appears and a reload can't recover it. The bulk-create pipeline (out-of-band-only, no client-side fenced block) is the most exposed.

> Runtime-unconfirmed: reproduction needs a stuck prod tenant. The three runtime checks are noted for the on-call. This PR closes every path by which a parked-but-invisible card can happen, so the failure self-heals regardless of which trigger fired.

## The fix

**C1 — the index write can no longer fail silently.** `pending_confirm.mint` persists + indexes + **verifies the record read back** (`set_value` suppresses a transient `ConnectionError`, so a silent persist-miss is caught), rolls back on any failure, logs loudly, and returns `None`. The gate treats `None` as a **retryable tool error and publishes no card** — so it can never again stop-and-wait on a card whose token has no record (which would wedge the turn on an "expired" toast).

**C2 — every turn-end terminal carries any live parked card.** `settlement._extra_with_pending` folds the owner's live cards onto the fenced `run:end` **and** `run:error` terminal (shared, backstopped by finalize), and **both** SPAs drain `p.pending` on **both** terminals. A card whose best-effort push was missed now re-surfaces at turn-end without a manual reload. A single shared `pending_confirm._pending_item` builder feeds the live push, the resync list, and the terminal carry so the 7-field client shape can't drift — and it guards the cosmetic `_describe_call` summary so a label failure can never drop a confirmable card.

Stopped runs are skipped (their cards are swept server-side); conv-less tokens bind to the current conversation; dedup holds across the finalize re-publish (epoch fence + token dedup).

## Tests (jarvis.test)

- `test_pending_confirm` (36), `test_confirm_gate` (43), `test_action_pending` (4), `test_terminal_pending` (4) — **all green**, including new coverage: mint returns `None` on index-failure and on persist-verify-miss, the gate publishes no dead card + returns a retryable error, a throwing summary degrades to `""` without dropping the card, and the failed park doesn't bump the `cards_open` gauge.
- `test_actions_api` — green except the pre-existing `test_form_meta_includes_child_table` (needs erpnext, not installed on this site; unrelated to this diff).
- Both SPA bundles (`frontend`, `pwa`) compile.

Reviewed by two independent adversarial passes (backend correctness/concurrency/leak; frontend/chat-safety); their two Minor findings (stopped-run gate on the PWA drain, softened park-fail wording) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)