### PR TITLE
feat: reset-onboarding unpairs this bench's devices from the container

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1065,6 +1065,12 @@ def post_disconnect_llm() -> dict:
 	)
 
 
+def unpair_chat_devices() -> dict:
+	"""Drop the container's paired devices. Idempotent; a file op on the agent,
+	so it needs none of the disconnect budget above."""
+	return _post(path=_m("api.tenant.unpair_chat_devices"), body={}, timeout_s=60)
+
+
 # --------------------------------------------------------------------------- #
 # Workspace reset proxies. The customer bench forwards to the control plane,
 # which re-derives the customer from the api_key. ``_post`` already unwraps the

--- a/jarvis/dev.py
+++ b/jarvis/dev.py
@@ -66,14 +66,22 @@ def reset_onboarding(wipe_data: bool = False) -> dict:
 	# still succeed when admin/fleet is down, the tenant was already purged, or
 	# nothing was connected. Only attempted when a container is actually wired up.
 	if (s.get("agent_url") or "").strip():
-		try:
-			from jarvis import admin_client
+		from jarvis import admin_client
 
+		try:
 			admin_client.post_subscription_disconnect()
 		except Exception:
 			frappe.logger().info(
 				"reset_onboarding: container subscription_disconnect skipped/failed (non-fatal)"
 			)
+		# The field loop below clears this bench's device credentials, but the
+		# PAIRING lives in the container - so any surviving copy of the token
+		# would keep chat access to a "reset" workspace. Same ordering reason as
+		# the disconnect above: after the wipe the bench cannot reach admin.
+		try:
+			admin_client.unpair_chat_devices()
+		except Exception:
+			frappe.logger().info("reset_onboarding: container unpair skipped/failed (non-fatal)")
 
 	settings_reset.apply(s, _FULL)
 	frappe.db.commit()

--- a/jarvis/tests/test_dev.py
+++ b/jarvis/tests/test_dev.py
@@ -6,6 +6,8 @@ now gates on System Manager alone via frappe.only_for, which was always the
 real security boundary (sandbox mode was documented as self-attested UX, not
 hardening)."""
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -164,3 +166,44 @@ class TestResetOnboardingWipe(FrappeTestCase):
 		self.assertEqual(out["data"]["wiped_doctypes"], [])
 		self.assertEqual(frappe.db.count("Jarvis Conversation", {"title": "dev-reset-wipe"}), 1)
 		self.assertEqual(frappe.db.count("Jarvis Macro", {"macro_name": "dev-reset-wipe"}), 1)
+
+
+class TestResetUnpairsTheContainer(FrappeTestCase):
+	"""The field wipe below clears this bench's device credentials, but the
+	PAIRING lives in the container: any surviving copy of that token would keep
+	chat access to a workspace the operator just reset."""
+
+	def setUp(self):
+		self._snap = _snapshot()
+		_seed_onboarded_state()
+		for target in ("post_subscription_disconnect", "unpair_chat_devices"):
+			pt = patch(f"jarvis.admin_client.{target}")
+			self.addCleanup(pt.stop)
+			setattr(self, target, pt.start())
+
+	def tearDown(self):
+		_restore(self._snap)
+
+	def test_unpairs_while_the_bench_can_still_reach_admin(self):
+		"""Ordering: after the wipe the api credentials are gone, so the call must
+		happen before it."""
+		seen = {}
+		self.unpair_chat_devices.side_effect = lambda: seen.update(
+			agent_url=frappe.db.get_single_value(SETTINGS, "agent_url")
+		)
+		reset_onboarding()
+		self.assertTrue(self.unpair_chat_devices.called, "reset left the container paired")
+		self.assertTrue(seen.get("agent_url"), "unpaired after the credentials were wiped")
+
+	def test_a_failed_unpair_never_blocks_the_reset(self):
+		"""A dead container is often the very reason for the reset."""
+		self.unpair_chat_devices.side_effect = Exception("fleet agent down")
+		out = reset_onboarding()
+		self.assertTrue(out["ok"])
+		self.assertEqual(frappe.get_single(SETTINGS).agent_url or "", "")
+
+	def test_skipped_when_no_container_is_wired(self):
+		frappe.get_single(SETTINGS).db_set("agent_url", "")
+		frappe.db.commit()
+		reset_onboarding()
+		self.assertFalse(self.unpair_chat_devices.called)


### PR DESCRIPTION
Tenant half of the reset fix. Control plane: Aerele-RnD/jarvis-admin-v2#159
(needs that merged first — this calls its new endpoint).

## The gap

`reset_onboarding` clears `chat_device_id` / `_public_key` / `_private_key` /
`_token` on this site, but the **pairing lives in the container's state dir**.
The container was never told, so a "full reset" left the workspace reachable by
any surviving copy of that device token — an old backup, a restored snapshot.

Same gap the reconnect handover closed for a replaced site; the reset door was
still open. The self-serve workspace reset already covers it by destroying the
container.

## Changes

- `admin_client.unpair_chat_devices()` — thin proxy; a file op on the agent, so
  it takes none of the 180s disconnect budget.
- `dev.reset_onboarding` — calls it **before** the field wipe, for the same
  reason the OAuth auth-profile teardown runs there: afterwards the bench holds
  no admin credentials and cannot reach the control plane at all. Best-effort
  and non-fatal — a dead container is often the very reason for the reset.

## Tests

3 new (`TestResetUnpairsTheContainer`): the unpair happens **while `agent_url`
is still set** (proving the ordering, which is the whole correctness argument);
a failing unpair never blocks the reset; and it's skipped when no container is
wired.

`bench --site jarvis.local run-tests`:
- `tests.test_dev` — **10 OK**
- `tests.test_onboarding_sync` — **53 OK**
- `tests.test_chat_device` — **15 OK**
