### PR TITLE
fix(llm): converge the container when a pool shrinks out of pool mode

### DIFF
--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.py
@@ -583,10 +583,46 @@ class JarvisSettings(Document):
 				1 if (len(enabled_models) == 1) else 0,
 				update_modified=False,
 			)
-			# Single-model path: reuse the existing classify/enqueue path.
-			# The legacy fields are now mirrored, so _classify_llm_change
-			# will correctly see any structural change.
-			self._on_update_single_model_legacy()
+			# A tenant LEAVING pool mode still has to be pushed through /llm-pool
+			# one final time (#550). Dropping from 2 models to 1 flips pool_mode
+			# off, so the save routes here, and _classify_llm_change compares only
+			# the legacy mirror fields - which are mirrored from models[0] and are
+			# UNCHANGED when the model that was removed was not the primary. It
+			# returns "reload", which merely rotates the secret file: admin keeps
+			# the old llm_pool_config, openclaw.json keeps declaring the removed
+			# provider, and that model's llm_key_N.key stays on disk. The agent can
+			# still fail over to a model the customer deleted, and the credential
+			# they may have been trying to revoke is never revoked.
+			#
+			# Forcing "restart" would not be enough: /llm-creds re-renders
+			# openclaw.json but never prunes llm_key_*.key, never rewrites
+			# docker-compose.yml, and never tears the Bifrost/cliproxy sidecars
+			# down. /llm-pool does all three, and llm_proxy.validate() accepts a
+			# single-model spec (it rejects only an EMPTY pool), so the honest
+			# convergence for a shrink is one final pool push carrying the reduced
+			# spec.
+			if self._is_leaving_pool_mode():
+				self._enqueue_pool_sync(converge_teardown=True)
+			else:
+				# Single-model path: reuse the existing classify/enqueue path.
+				# The legacy fields are now mirrored, so _classify_llm_change
+				# will correctly see any structural change.
+				self._on_update_single_model_legacy()
+
+	def _is_leaving_pool_mode(self) -> bool:
+		"""True when this save drops the tenant OUT of pool mode.
+
+		Only meaningful on the single-model leg, where the caller has already
+		established that ``compute_pool_mode(self)`` is False. A first-ever save
+		has no before-doc and so cannot be leaving anything: it reads False and
+		takes the ordinary single-model path.
+		"""
+		from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+		before = self.get_doc_before_save()
+		if before is None:
+			return False
+		return bool(compute_pool_mode(before))
 
 	@staticmethod
 	def _pool_state_snapshot(doc) -> tuple:
@@ -673,7 +709,7 @@ class JarvisSettings(Document):
 			return False
 		return (self.get("last_sync_status") or "").startswith("ok")
 
-	def _enqueue_pool_sync(self) -> None:
+	def _enqueue_pool_sync(self, *, converge_teardown: bool = False) -> None:
 		"""Enqueue the pool-sync admin call for the proxy path.
 
 		Mirrors the existing ``on_update`` enqueue pattern:
@@ -698,8 +734,15 @@ class JarvisSettings(Document):
 			timeout=ADMIN_SYNC_RQ_TIMEOUT_S,
 			enqueue_after_commit=not run_inline,
 			now=run_inline,
-			job_id="jarvis_settings_sync:pool",
+			# A teardown push carries its own job id. Sharing the ordinary one
+			# would let dedup drop it behind an already-queued normal sync, and
+			# the surviving job would run WITHOUT converge_teardown, hit the
+			# pool-mode gate, and skip - silently restoring the #550 bug. The two
+			# still serialize on the redis lock, so an occasional extra run is
+			# harmless.
+			job_id="jarvis_settings_sync:pool:teardown" if converge_teardown else "jarvis_settings_sync:pool",
 			deduplicate=True,
+			converge_teardown=converge_teardown,
 		)
 
 	def _on_update_single_model_legacy(self):
@@ -1182,6 +1225,26 @@ def _admin_rejection_reason(e) -> str:
 	return f"Your AI configuration was rejected: {detail}"
 
 
+def _pool_spec_pushable(settings, converge_teardown: bool = False) -> bool:
+	"""True when this settings doc may be pushed through the /llm-pool leg.
+
+	Normally that means it IS a pool (``compute_pool_mode``). A
+	``converge_teardown`` job is the deliberate exception: it was enqueued
+	PRECISELY BECAUSE the tenant left pool mode (#550), so compute_pool_mode is
+	expected to be False and gating on it would skip the teardown that is the
+	whole point of the job. Such a push still needs a non-empty spec, since
+	``llm_proxy.validate`` rejects an empty pool, so at least one enabled model
+	is required either way.
+	"""
+	from jarvis.jarvis.pool_serialize import compute_pool_mode
+
+	if compute_pool_mode(settings):
+		return True
+	if not converge_teardown:
+		return False
+	return any(m.enabled for m in (settings.models or []))
+
+
 def _post_pool_with_retry(spec, api_keys, oauth_blobs):
 	"""post_update_llm_pool, retrying only the transient AdminUnreachableError.
 	Re-raises the last unreachable error after exhausting retries; other Admin*
@@ -1223,7 +1286,9 @@ def _post_pool_with_retry(spec, api_keys, oauth_blobs):
 	raise last
 
 
-def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> None:
+def _enqueued_sync_via_admin_pool(
+	retry_left: int = ADMIN_SYNC_LOCK_RETRIES, converge_teardown: bool = False
+) -> None:
 	"""Background-queue wrapper for the proxy (pool) sync path.
 
 	Re-reads Jarvis Settings at run time and rebuilds the pool payload via
@@ -1286,6 +1351,9 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
 					"._enqueued_sync_via_admin_pool",
 					job_base="jarvis_settings_sync:pool",
 					retry_left=retry_left,
+					# Carry the teardown intent down the retry chain: a level that
+					# dropped it would re-arm the pool-mode gate and skip (#550).
+					converge_teardown=converge_teardown,
 				)
 				return
 			_frappe.logger().warning(
@@ -1311,10 +1379,10 @@ def _enqueued_sync_via_admin_pool(retry_left: int = ADMIN_SYNC_LOCK_RETRIES) -> 
 		# Re-validate: the config may have changed between enqueue and run.
 		# If it is no longer a pool, skip the push. (Pool MODE, not proxy_active:
 		# a BYO api-key pool has no sidecar but is still pushed through /llm-pool.)
-		from jarvis.jarvis.pool_serialize import compute_pool_mode, validate_models
+		from jarvis.jarvis.pool_serialize import validate_models
 
 		revalidation_errors = validate_models(settings)
-		if revalidation_errors or not compute_pool_mode(settings):
+		if revalidation_errors or not _pool_spec_pushable(settings, converge_teardown):
 			reason = "; ".join(revalidation_errors) if revalidation_errors else "no longer a pool"
 			settings.db_set(
 				"last_sync_status",

--- a/jarvis/tests/test_unified_llm_config.py
+++ b/jarvis/tests/test_unified_llm_config.py
@@ -4176,3 +4176,78 @@ class TestPoolSyncChangeDetection(_RT3SettingsTestCase):
 			settings.save()
 
 		mock_enqueue.assert_called_once()
+
+
+class TestLeavingPoolModeConvergence(FrappeTestCase):
+	"""jarvis#550: a shrink out of pool mode must still converge the container.
+
+	Removing a NON-PRIMARY model flips compute_pool_mode off, which routed the
+	save to the single-model leg. There _classify_llm_change compares only the
+	legacy mirror fields, and those are mirrored from models[0], so nothing it
+	looks at changed and it returned "reload" (rotate the secret file only).
+	Admin kept the old llm_pool_config, openclaw.json kept declaring the removed
+	provider, and its llm_key_N.key stayed on disk.
+
+	These build settings-like objects in memory. Nothing here may touch the DB:
+	the pre-existing fixture in test_admin_client.py that commits and calls
+	remove_encrypted_password has already destroyed a real site's credentials
+	(jarvis#566).
+	"""
+
+	def _leaving(self, before_rows, after_rows):
+		from unittest.mock import Mock
+
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import JarvisSettings
+
+		doc = _make_settings_with_models(after_rows)
+		doc.get_doc_before_save = Mock(
+			return_value=(_make_settings_with_models(before_rows) if before_rows is not None else None)
+		)
+		return JarvisSettings._is_leaving_pool_mode(doc)
+
+	def test_dropping_two_models_to_one_is_leaving_pool_mode(self):
+		"""The reported repro: remove the non-primary of a 2-model pool."""
+		before = [_api_key_model(order=0), _api_key_model(model="gemini-3.6-flash", order=1)]
+		self.assertTrue(self._leaving(before, [_api_key_model(order=0)]))
+
+	def test_first_ever_save_is_not_leaving_pool_mode(self):
+		"""No before-doc means nothing was left, so the ordinary leg applies."""
+		self.assertFalse(self._leaving(None, [_api_key_model(order=0)]))
+
+	def test_single_model_edit_is_not_leaving_pool_mode(self):
+		"""A tenant that was never a pool must keep the single-model leg."""
+		self.assertFalse(self._leaving([_api_key_model(order=0)], [_api_key_model(order=0)]))
+
+	def test_removing_the_last_subscription_is_leaving_pool_mode(self):
+		"""A lone subscription is pool mode, so dropping it also has to converge.
+
+		This is the transition that tears the Bifrost and CLIProxyAPI sidecars
+		down, which only the /llm-pool leg does.
+		"""
+		before = [_subscription_model(order=0, accounts=[_account()])]
+		self.assertTrue(self._leaving(before, [_api_key_model(order=0)]))
+
+	def test_teardown_push_is_allowed_past_the_pool_mode_gate(self):
+		"""The worker must not skip the job whose whole purpose is the teardown."""
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import _pool_spec_pushable
+
+		one_model = _make_settings_with_models([_api_key_model(order=0)])
+		# Without the flag this is exactly the "no longer a pool" skip that let
+		# the stale container config survive.
+		self.assertFalse(_pool_spec_pushable(one_model, False))
+		self.assertTrue(_pool_spec_pushable(one_model, True))
+
+	def test_teardown_push_still_refuses_an_empty_spec(self):
+		"""llm_proxy.validate rejects an empty pool, so never send one."""
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import _pool_spec_pushable
+
+		none_enabled = _make_settings_with_models([_api_key_model(order=0, enabled=0)])
+		self.assertFalse(_pool_spec_pushable(none_enabled, True))
+		self.assertFalse(_pool_spec_pushable(_make_settings_with_models([]), True))
+
+	def test_a_real_pool_is_pushable_without_the_flag(self):
+		"""The ordinary path is unchanged."""
+		from jarvis.jarvis.doctype.jarvis_settings.jarvis_settings import _pool_spec_pushable
+
+		pool = _make_settings_with_models([_api_key_model(order=0), _api_key_model(model="glm-4.7", order=1)])
+		self.assertTrue(_pool_spec_pushable(pool, False))


### PR DESCRIPTION
Fixes #550

Removing a **non-primary** model from the pool did nothing. The UI dropped to one
model, the customer DB agreed, and the footer said `Applied`, while the running
container kept declaring the removed provider and kept its API key file on disk.
The agent could still fail over to a model the customer had deleted.

## Root cause

Dropping from 2 models to 1 flips `compute_pool_mode` off, so the save routes to
the single-model leg. There `_classify_llm_change` compares only the legacy mirror
fields, and those are mirrored from `models[0]`, so removing anything below
position 1 changed nothing it looks at. It returned `"reload"`, which only rotates
the secret file. Admin kept the old `llm_pool_config` and `openclaw.json` was never
re-rendered, which is why the status honestly read `ok (reload via admin)`: the
sync succeeded, it just did the wrong operation.

Removing the **primary** model does change `models[0]`, so the classifier sees a
structural change and it works. That is why this went unnoticed.

## Why forcing "restart" is not enough

I traced the fleet side before choosing. `/llm-creds` re-renders `openclaw.json`
but never prunes `llm_key_*.key`, never rewrites `docker-compose.yml`, and never
calls `proxy_provision.materialize()`, so it cannot tear the Bifrost and
CLIProxyAPI sidecars down. A tenant that had a pool and then gets a single
`/llm-creds` apply ends up pointed at one provider while the old pool's key files,
sidecar containers and OAuth blobs all sit there orphaned.

`/llm-pool` already does all three: it unlinks every `llm_key_*.key` whose stem is
not in the new spec, re-renders compose with `proxy_enabled=not byo_direct`, and
runs `up -d --remove-orphans`. And `llm_proxy.validate()` rejects only an **empty**
pool, so a single-model spec is legal.

So the honest convergence for a shrink is one final push through `/llm-pool`
carrying the reduced spec. **No fleet-agent or admin change is required**; this
reuses teardown logic that already exists and is already correct.

## The change

A tenant leaving pool mode now takes that final pool push instead of the
single-model leg. Two details that are easy to get wrong:

- The job carries `converge_teardown` under **its own job id**. Sharing the
  ordinary `jarvis_settings_sync:pool` id would let dedup drop it behind an
  already-queued normal sync, and the surviving job would run without the flag,
  hit the pool-mode gate and skip, silently restoring this bug. The two still
  serialize on the redis lock, so an occasional extra run is harmless.
- The flag is forwarded down the lock-retry chain, since a retry level that
  dropped it would re-arm the same gate.

The worker's gate moves into `_pool_spec_pushable`, which honours the flag but
still refuses an empty spec.

## Tests

7 new tests. They build settings-like objects in memory and touch no database,
deliberately: the pre-existing fixture in `test_admin_client.py` that commits and
calls `remove_encrypted_password` has already destroyed a real site's credentials
(#566).

Covered: the reported repro (2 models to 1) is detected as leaving pool mode; a
first-ever save and a plain single-model edit are not; removing the last
subscription is, since that is the transition that tears the sidecars down; the
teardown push is allowed past the gate that previously skipped it; it still
refuses an empty spec; and an ordinary pool is unaffected.

## Not verified

The end-to-end effect on a live container was not reproduced. The fleet behaviour
above is read from `jarvis-fleet-agent` source (`main.py` `llm_pool` forward-apply
prune at the `_pool_key_files` glob, and the compose re-render with
`--remove-orphans`), not observed. Worth one live check: shrink a 2-model pool and
confirm `docker exec <tenant> ls /home/node/.openclaw/` no longer lists the removed
model's `llm_key_N.key`.
