### PR TITLE
feat(chat): record which model produced each reply

### DIFF
--- a/frontend/src/utils/modelBadge.js
+++ b/frontend/src/utils/modelBadge.js
@@ -1,0 +1,73 @@
+// Per-reply model attribution (jarvis#560): extracted as a PLAIN, importable,
+// unit-tested module because it decides whether the audit signal is VISIBLE at
+// all, and a rule that hides too eagerly fails silently.
+//
+// Background. Jarvis lets a user change the model mid-conversation, and an
+// UNPINNED conversation keeps openclaw's failover chain live, so a reply can
+// come from a model the user never chose. The server now stamps `model` and
+// `provider` on the assistant row at finalize, taken from the model the gateway
+// says actually served the turn. Without a rendering rule that surfaces the
+// interesting cases, that record exists only in the database.
+//
+// The rule: show the model on a reply ONLY when it differs from what the chat is
+// set to RIGHT NOW. A steady thread therefore stays completely quiet (the header
+// pill already answers "which model"), and the two cases worth seeing stand out:
+//
+//   * a reply written BEFORE a mid-thread switch: the user changed model, and
+//     the older replies visibly did not come from the new one;
+//   * a turn the pool failed over to a different model: the pill still says
+//     what the user picked, and this is the only place the substitution shows.
+//
+// "Right now" has two definitions because the header pill has two modes. A PIN
+// names a model outright, so that is the answer. "Auto" names none, so the best
+// available statement of what Auto currently resolves to is the newest reply in
+// the thread that carries an attribution. Under Auto, that makes the badge a
+// change-marker: identical consecutive models are silent, and the turn where the
+// model changed is the one that speaks.
+
+/**
+ * The model the conversation is running on right now.
+ *
+ * @param {Array<{role?: string, model?: string}>} messages transcript, in order
+ * @param {string} modelOverride the conversation's pin ("" means Auto)
+ * @returns {string} a model id, or "" when nothing in the thread names one
+ */
+export function currentThreadModel(messages, modelOverride) {
+	if (modelOverride) return modelOverride;
+	const list = Array.isArray(messages) ? messages : [];
+	for (let i = list.length - 1; i >= 0; i--) {
+		const m = list[i];
+		if (m && m.role === "assistant" && m.model) return m.model;
+	}
+	return "";
+}
+
+/**
+ * The model id to show on one reply, or "" to show nothing.
+ *
+ * Only assistant rows are ever attributed: the field is meaningless on a user or
+ * tool row, and the server refuses to stamp one, so a value there would mean the
+ * transcript disagrees with the database.
+ *
+ * @param {{role?: string, model?: string}} message
+ * @param {string} currentModel result of currentThreadModel()
+ * @returns {string}
+ */
+export function modelBadgeFor(message, currentModel) {
+	if (!message || message.role !== "assistant" || !message.model) return "";
+	return message.model === currentModel ? "" : message.model;
+}
+
+/**
+ * Tooltip for a shown badge. Names the provider too when there is one: two
+ * providers can serve the same model id, so the pair is the real identity for an
+ * auditor reconstructing who wrote what.
+ *
+ * @param {{model?: string, provider?: string}} message
+ * @returns {string}
+ */
+export function modelBadgeTitleFor(message) {
+	if (!message || !message.model) return "";
+	const via = message.provider ? ` via ${message.provider}` : "";
+	return `This reply was written by ${message.model}${via}, not the model this chat is set to now`;
+}

--- a/frontend/src/utils/modelBadge.test.js
+++ b/frontend/src/utils/modelBadge.test.js
@@ -1,0 +1,147 @@
+// Real executable tests for the per-reply model-attribution rule (jarvis#560),
+// plus source assertions fencing the ONE surface that renders it. Plain node
+// built-ins (node:test + node:assert), like eventFence.test.js. Run directly
+// (`node --test modelBadge.test.js`) or via the python suite
+// (jarvis/tests/test_model_badge_client.py subprocess-runs it every CI run).
+//
+// What is being defended: the server can stamp the model that actually answered
+// on every assistant row and the feature still fails if the transcript never
+// shows it. The rule below is deliberately quiet, hiding the badge whenever a
+// reply matches what the chat is set to now, so a bug that hides one case too
+// many is INVISIBLE. These tests pin the cases that must speak.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { currentThreadModel, modelBadgeFor, modelBadgeTitleFor } from "./modelBadge.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (...p) => fs.readFileSync(path.join(HERE, ...p), "utf8");
+const chatViewSrc = read("..", "views", "ChatView.vue");
+
+const reply = (model, extra = {}) => ({ role: "assistant", model, ...extra });
+const ask = (text = "hi") => ({ role: "user", content: text });
+
+// ---- what "right now" means ---------------------------------------------
+
+test("a pin is what the chat is set to, whatever the transcript says", () => {
+	const msgs = [ask(), reply("glm-4.7"), ask(), reply("gemini-3.6-flash")];
+	assert.equal(currentThreadModel(msgs, "claude-opus-4-6"), "claude-opus-4-6");
+});
+
+test("on Auto, the newest attributed reply is what the thread resolves to", () => {
+	const msgs = [ask(), reply("gemini-3.6-flash"), ask(), reply("glm-4.7")];
+	assert.equal(currentThreadModel(msgs, ""), "glm-4.7");
+});
+
+test("unattributed rows are skipped when resolving Auto", () => {
+	// Legacy rows carry no model, and tool/user rows never do; neither may be
+	// mistaken for "the thread is running on nothing".
+	const msgs = [reply("glm-4.7"), { role: "tool", tool_name: "get_list" }, reply("")];
+	assert.equal(currentThreadModel(msgs, ""), "glm-4.7");
+});
+
+test("an empty or missing transcript resolves to nothing rather than throwing", () => {
+	assert.equal(currentThreadModel([], ""), "");
+	assert.equal(currentThreadModel(undefined, ""), "");
+});
+
+// ---- when the badge shows ------------------------------------------------
+
+test("a steady thread is completely silent", () => {
+	const msgs = [ask(), reply("glm-4.7"), ask(), reply("glm-4.7")];
+	const now = currentThreadModel(msgs, "glm-4.7");
+	assert.deepEqual(
+		msgs.map((m) => modelBadgeFor(m, now)),
+		["", "", "", ""]
+	);
+});
+
+test("a mid-thread switch makes the older replies name their model", () => {
+	// The user answered on gemini, then pinned glm. The gemini reply is no longer
+	// what the chat is set to, and the transcript must say so.
+	const msgs = [ask(), reply("gemini-3.6-flash"), ask(), reply("glm-4.7")];
+	const now = currentThreadModel(msgs, "glm-4.7");
+	assert.equal(modelBadgeFor(msgs[1], now), "gemini-3.6-flash");
+	assert.equal(modelBadgeFor(msgs[3], now), "");
+});
+
+test("an Auto thread that failed over names the substitute", () => {
+	// The pool answered turn 2 with glm after gemini failed. Nothing else in the
+	// product records the substitution, so this badge is the only trace.
+	const msgs = [
+		ask(),
+		reply("gemini-3.6-flash"),
+		ask(),
+		reply("glm-4.7"),
+		ask(),
+		reply("gemini-3.6-flash"),
+	];
+	const now = currentThreadModel(msgs, "");
+	assert.equal(now, "gemini-3.6-flash");
+	assert.equal(modelBadgeFor(msgs[3], now), "glm-4.7", "the failed-over turn speaks");
+	assert.equal(modelBadgeFor(msgs[1], now), "");
+	assert.equal(modelBadgeFor(msgs[5], now), "");
+});
+
+test("only assistant rows are ever badged", () => {
+	// The server refuses to stamp a non-assistant row, so a badge on one would
+	// mean the transcript disagrees with the database.
+	const now = "glm-4.7";
+	assert.equal(modelBadgeFor({ role: "user", model: "gemini-3.6-flash" }, now), "");
+	assert.equal(modelBadgeFor({ role: "tool", model: "gemini-3.6-flash" }, now), "");
+	assert.equal(modelBadgeFor(null, now), "");
+});
+
+test("an unattributed reply shows nothing rather than guessing", () => {
+	// Legacy rows and turns whose session row never named a model.
+	assert.equal(modelBadgeFor(reply(""), "glm-4.7"), "");
+	assert.equal(modelBadgeFor({ role: "assistant" }, "glm-4.7"), "");
+});
+
+// ---- tooltip -------------------------------------------------------------
+
+test("the tooltip names the provider when there is one", () => {
+	const t = modelBadgeTitleFor(reply("glm-4.7", { provider: "openai_compat" }));
+	assert.match(t, /glm-4\.7/);
+	assert.match(t, /via openai_compat/);
+});
+
+test("the tooltip omits the provider clause when it is unknown", () => {
+	const t = modelBadgeTitleFor(reply("glm-4.7"));
+	assert.match(t, /glm-4\.7/);
+	assert.doesNotMatch(t, /via/);
+});
+
+// ---- source fences on the ONE renderer -----------------------------------
+
+test("ChatView renders the badge through this module, not a forked copy", () => {
+	assert.match(
+		chatViewSrc,
+		/import \{[^}]*modelBadgeFor[^}]*\} from "@\/utils\/modelBadge"/,
+		"ChatView must import the rule rather than re-implement it"
+	);
+	assert.match(chatViewSrc, /v-if="modelBadgeOf\(m\)"/, "the badge is gated on the rule");
+});
+
+test("the badge sits in the reply's existing meta row", () => {
+	// jv-* custom properties are not on :root and have no fallbacks, so new
+	// markup has to live inside an element the palette binding already reaches.
+	// The meta row does; a floating sibling would render unstyled.
+	assert.match(
+		chatViewSrc,
+		/toolCountOf\(m\) \|\| elapsedOf\(m\) \|\| modelBadgeOf\(m\)/,
+		"the meta row must open when the badge is the only thing to show"
+	);
+	assert.match(chatViewSrc, /class="jv-modelchip"/);
+	assert.match(chatViewSrc, /\.jv-modelchip \{/, "the chip carries its own palette-bound style");
+});
+
+test("the transcript endpoint is asked for the attribution fields", () => {
+	// The chip cannot render off fields get_conversation does not return.
+	const apiSrc = read("..", "..", "..", "jarvis", "chat", "api.py");
+	const fields = apiSrc.slice(apiSrc.indexOf("def get_conversation"));
+	assert.match(fields.slice(0, 2000), /"model",/);
+	assert.match(fields.slice(0, 2000), /"provider",/);
+});

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1609,7 +1609,7 @@
 										v-if="
 											!m.error &&
 											!m.streaming &&
-											(toolCountOf(m) || elapsedOf(m))
+											(toolCountOf(m) || elapsedOf(m) || modelBadgeOf(m))
 										"
 										class="jv-meta"
 									>
@@ -1645,6 +1645,28 @@
 												<circle cx="12" cy="12" r="9" />
 												<path d="M12 7v5l3 2" /></svg
 											>{{ elapsedLabel(m) }}</span
+										>
+										<!-- jarvis#560: names the model that actually wrote this
+										     reply, shown only when it is not the one the chat is
+										     set to now (a mid-thread switch, or a pool failover
+										     the user never chose). -->
+										<span
+											v-if="modelBadgeOf(m)"
+											class="jv-modelchip"
+											:title="modelBadgeTitle(m)"
+											><svg
+												width="12"
+												height="12"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="1.8"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											>
+												<rect x="4" y="4" width="16" height="16" rx="4" />
+												<circle cx="12" cy="12" r="2.6" /></svg
+											>{{ modelBadgeOf(m) }}</span
 										>
 									</div>
 									<!-- SUX-7: subtle "finishing…" affordance while the Relay-Pump
@@ -3611,6 +3633,7 @@ import { useConfirm } from "@/composables/useConfirm";
 // timezone-safe: naive server datetimes must go through dayjsLocal (site tz)
 import { formatDate, exactDate, dayLabel } from "@/utils/datetime";
 import { fenceReject, fenceAccept } from "@/utils/eventFence";
+import { currentThreadModel, modelBadgeFor, modelBadgeTitleFor } from "@/utils/modelBadge";
 import { renderMarkdown } from "@/markdown";
 import JvChart from "@/charts/JvChart.vue";
 import ConnectPhoneDialog from "@/components/ConnectPhoneDialog.vue";
@@ -4664,6 +4687,19 @@ function elapsedLabel(m) {
 	const mm = Math.floor(total / 60),
 		ss = total % 60;
 	return ss ? `${mm}m ${ss}s` : `${mm}m`;
+}
+// Per-reply model attribution (jarvis#560). m.model / m.provider are stamped on
+// the assistant row at finalize and name the model that ACTUALLY answered, which
+// is not always the one the user picked: an unpinned thread keeps openclaw's
+// failover chain live, so a substitution otherwise leaves no trace anywhere. The
+// show/hide rule lives in @/utils/modelBadge (unit-tested there) because a rule
+// that hides too eagerly would suppress the whole signal without failing.
+const threadModel = computed(() => currentThreadModel(messages.value, modelOverride.value));
+function modelBadgeOf(m) {
+	return modelBadgeFor(m, threadModel.value);
+}
+function modelBadgeTitle(m) {
+	return modelBadgeTitleFor(m);
 }
 // Open state falls back to the pref until the user explicitly toggles a turn.
 function isActivityOpen(name) {
@@ -9408,6 +9444,20 @@ onUnmounted(() => {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
+}
+/* jarvis#560: per-reply model attribution. Outlined rather than plain text so a
+   reply written by a different model than the chat is set to now reads as a
+   deviation, not as one more timing metric. Both palettes come from the inline
+   paletteVars binding on the view root (the jv-* vars are NOT on :root). */
+.jv-modelchip {
+	padding: 1px 8px 1px 6px;
+	border: 1px solid var(--border-2);
+	border-radius: 20px;
+	color: var(--text-2);
+	font-weight: 600;
+	max-width: 220px;
+	overflow: hidden;
+	white-space: nowrap;
 }
 /* live tool activity rows */
 .jv-toolrow {

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -587,6 +587,12 @@ def get_conversation(conversation: str) -> dict:
 			"action_outcome",
 			"canvas",
 			"reply_duration_ms",
+			# jarvis#560: which model actually produced each reply. The SPA renders it
+			# on the bubble only when it differs from what the header pill implies, so
+			# a mid-thread switch or a silent failover is visible without adding noise
+			# to a steady thread.
+			"model",
+			"provider",
 			"creation",
 			"modified",
 		],

--- a/jarvis/chat/finalize.py
+++ b/jarvis/chat/finalize.py
@@ -279,6 +279,10 @@ def _effect_usage(ctx: _Ctx) -> None:
 	gateway_url = (settings.agent_url or "").replace("http://", "ws://").replace("https://", "wss://")
 	with openclaw_session_pool.checkout(gateway_url) as sess:
 		row = _usage.fetch_fresh_session_row(sess, session_key)
+	# jarvis#560: attribute the reply BEFORE the freshness gate below. The row names
+	# the model whether or not its token counters have gone fresh yet, and an audit
+	# ("which model proposed this journal entry") must not be lost to a slow counter.
+	_stamp_reply_model(ctx, row)
 	# CDX-6: honour record_turn_usage's EXPLICIT outcome. A `retry` (stale/missing/
 	# no-fresh row) must NOT permanently mark usage recorded — RAISE so the runner
 	# rolls back the guard CAS above and RELEASES the effect to pending for the next
@@ -288,6 +292,52 @@ def _effect_usage(ctx: _Ctx) -> None:
 	outcome = _usage.record_turn_usage(session_key, row)
 	if outcome == _usage.USAGE_RETRY:
 		raise _UsageRetry(f"usage not fresh for {ctx.run_id} (session {session_key})")
+
+
+def _stamp_reply_model(ctx: _Ctx, row: dict | None) -> None:
+	"""jarvis#560: record WHICH model produced this reply, on the reply itself.
+
+	Jarvis writes to the customer's ERP, so "which model proposed this journal
+	entry" is a question an auditor or an incident review will ask about ONE
+	message. A session-level field cannot answer it: a thread can switch models
+	mid-conversation, and an unpinned thread can fail over without the user ever
+	choosing the substitute. So the stamp lands on the assistant ROW.
+
+	The value is whatever ``sessions.list`` attributes to this turn's session -
+	see ``usage.resolved_model_identity`` for the wire shape and for why no live
+	relay frame can supply it. Reading it here, off the row the usage poll just
+	fetched, costs no extra RPC and keeps the transcript's credit identical to the
+	per-model usage bucket this same row is billed against.
+
+	``role='assistant'`` is in the WHERE clause, not just implied by
+	``turn.assistant_message``: the field is meaningless on a user or tool row and
+	a mislinked turn must not be able to write one. A blank model (no row, or a
+	session the gateway does not name a model for - an openclaw-direct pool that
+	never resolved one) leaves the row untouched rather than writing "" over a
+	value an earlier finalize cycle already got right.
+
+	``modified`` is deliberately NOT bumped: ``ChatView.elapsedOf`` still falls
+	back to the ``modified - creation`` span on rows with no ``reply_duration_ms``,
+	and finalize runs well after settlement, so touching it would inflate the
+	duration a legacy row reports.
+
+	Bounded by the same claim/retry envelope as the usage effect it rides in: an
+	exception rolls this back with the guard CAS and the next finalize cycle
+	re-reads the row. A turn that force-dones the usage effect after three stale
+	reads keeps a blank model - honest, and already logged loudly by
+	``fetch_fresh_session_row`` as a lost turn."""
+	am = ctx.turn.get("assistant_message")
+	if not am:
+		return
+	from jarvis.chat import usage as _usage
+
+	model, provider = _usage.resolved_model_identity(row)
+	if not model:
+		return
+	ts._run_cas(
+		f"UPDATE `tab{MSG}` SET model=%(model)s, provider=%(provider)s WHERE name=%(m)s AND role='assistant'",
+		{"model": model[:140], "provider": provider[:140], "m": am},
+	)
 
 
 def _effect_terminal_publish(ctx: _Ctx) -> None:

--- a/jarvis/chat/usage.py
+++ b/jarvis/chat/usage.py
@@ -125,6 +125,38 @@ USAGE_VALID_ZERO = "valid_zero"  # a fresh row that legitimately reports no usag
 USAGE_RETRY = "retry"  # stale/missing/no-fresh data — do NOT mark recorded, retry
 
 
+def resolved_model_identity(row: dict | None) -> tuple[str, str]:
+	"""``(model, provider)`` the gateway attributes to this session's LAST
+	COMPLETED run, read off a ``sessions.list`` row.
+
+	This is the ONE place the wire names are decoded, so the per-model usage
+	bucket below and the per-message attribution stamped by
+	``finalize._stamp_reply_model`` (jarvis#560) can never disagree about which
+	model a turn is charged to and which model the transcript credits.
+
+	Wire shape, verified against the shipped bundle of
+	ghcr.io/openclaw/openclaw:2026.6.8 (``buildGatewaySessionRow``): the row
+	carries ``model`` + ``modelProvider``, resolved as the session's SELECTED
+	override when it has one, else the RUNTIME identity persisted on the session
+	entry after the run (``entry.model`` / ``entry.modelProvider``). The runtime
+	half is why an unpinned conversation reports the model that actually answered
+	rather than the chain's primary: openclaw only keeps its ``model.fallbacks``
+	chain live for a session with no override (see
+	``turn_handler._session_model_for``), and a failover rewrites the entry.
+
+	No live event carries this. The terminal ``chat`` frame's projected message is
+	built fresh as ``{role, content, timestamp}`` by BOTH live emitters
+	(``emitChatFinal`` in ``dist/embedded-backend-*.js`` and
+	``dist/server-chat-*.js``), and the lifecycle ``end``/``error`` frame carries
+	only ``phase`` + terminal metadata - the runtime logs
+	``model=... provider=...`` at agent end from ``lastAssistant``, but never puts
+	it on the wire. So the durable session row is the earliest honest source, and
+	reading it costs nothing extra: finalize already polls it for usage."""
+	if not isinstance(row, dict):
+		return "", ""
+	return (row.get("model") or "").strip(), (row.get("modelProvider") or "").strip()
+
+
 def record_turn_usage(session_key: str, row: dict | None) -> str:
 	"""Record one completed turn's token delta from a ``sessions.list`` row.
 
@@ -248,7 +280,7 @@ def record_turn_usage(session_key: str, row: dict | None) -> str:
 		# discard the aggregate delta), so this just logs and continues,
 		# letting the aggregate updates reach the commit below regardless of
 		# what happened here.
-		model = (row.get("model") or "").strip()
+		model, _provider = resolved_model_identity(row)
 		if model:
 			try:
 				_upsert_model_usage(user, model, month, input_tokens, output_tokens, now)

--- a/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
+++ b/jarvis/jarvis/doctype/jarvis_chat_message/jarvis_chat_message.json
@@ -28,6 +28,8 @@
     "ref_name",
     "canvas",
     "reply_duration_ms",
+    "model",
+    "provider",
     "hidden"
   ],
   "fields": [
@@ -185,6 +187,24 @@
       "read_only": 1,
       "no_copy": 1,
       "description": "CDX-20 — the assistant reply's honest generation span in milliseconds, on ONE durable baseline shared with the live timer: run:start (the pump's dispatching_at, stamped at the ready->dispatching transition immediately before run:start is published) -> settlement (the terminal instant). Stamped in the winning settlement txn. The SPA reads THIS on reload (ChatView.elapsedOf) so a reloaded reply shows the same duration the live run:start->run:end timer showed, within network tolerance. Replaces the old creation/modified rewrite (creation is Frappe's record-creation AUDIT field and is no longer repurposed as a metric). NULL on legacy (non-pump) rows, which fall back to modified-creation."
+    },
+    {
+      "fieldname": "model",
+      "fieldtype": "Data",
+      "label": "Model",
+      "length": 140,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "jarvis#560 - the model that actually PRODUCED this reply, stamped on assistant rows only. Read at finalize from the gateway's sessions.list row for this turn's session (the same row the per-model usage bucket is billed against, so the transcript and the usage pane can never disagree). It names the model that answered, which is not always the one requested: an unpinned conversation keeps openclaw's failover chain live, so a substitution lands here with no other trace. Blank on legacy rows and on turns whose session row never named a model."
+    },
+    {
+      "fieldname": "provider",
+      "fieldtype": "Data",
+      "label": "Provider",
+      "length": 140,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "jarvis#560 - the openclaw provider id that served this reply (sessions.list `modelProvider`, e.g. `gemini`, `openai_compat`), paired with `model`. Two providers can expose the same model id, so the pair is what identifies the run for an audit or an incident review."
     },
     {
       "fieldname": "hidden",

--- a/jarvis/tests/test_chat_openclaw_client.py
+++ b/jarvis/tests/test_chat_openclaw_client.py
@@ -937,3 +937,78 @@ class TestRepairConvoyCollapse(FrappeTestCase):
 			sess = OpenclawSession.connect("ws://t")
 		self.assertEqual(clear_called, [], "no clear when we never held the lock")
 		sess.close()
+
+
+# --- TestSessionsListModelIdentity ----------------------------------------
+
+
+class TestSessionsListModelIdentity(FrappeTestCase):
+	"""jarvis#560: the model that answered a turn crosses the wire ONLY on the
+	``sessions.list`` row, so this pins that frame.
+
+	No live event carries it: both live ``emitChatFinal`` implementations in
+	ghcr.io/openclaw/openclaw:2026.6.8 build the terminal chat message fresh as
+	``{role, content, timestamp}``, and the lifecycle end/error frame carries only
+	``phase`` plus terminal metadata. The runtime logs
+	``model=... provider=...`` at agent end but never emits it. The durable
+	session row is therefore the earliest honest source, and these frames are the
+	shape ``buildGatewaySessionRow`` actually sends.
+	"""
+
+	def _sessions_list_frame(self, ws, rows):
+		def _resp():
+			req_id = ws.sent[-1]["id"]
+			return _frame(
+				{
+					"type": "res",
+					"id": req_id,
+					"ok": True,
+					"payload": {
+						"ts": 1785348175440,
+						"count": len(rows),
+						"defaults": {"model": "gemini-3.6-flash", "provider": "gemini"},
+						"sessions": rows,
+					},
+				}
+			)
+
+		return _resp
+
+	def test_row_carries_model_and_provider_through_the_client(self):
+		sess, ws = _build_session()
+		row = {
+			"key": "agent:main",
+			"hasActiveRun": False,
+			"model": "glm-4.7",
+			"modelProvider": "openai_compat",
+			"totalTokens": 41230,
+			"totalTokensFresh": True,
+			"inputTokens": 39102,
+			"outputTokens": 812,
+		}
+		ws._frames.append(self._sessions_list_frame(ws, [row]))
+		rows = sess.list_sessions()
+		self.assertEqual(ws.sent[-1]["method"], "sessions.list")
+		self.assertEqual(len(rows), 1)
+
+		from jarvis.chat.usage import resolved_model_identity
+
+		self.assertEqual(
+			resolved_model_identity(rows[0]),
+			("glm-4.7", "openai_compat"),
+			"the model/provider pair survives the frame and decodes off the wire names",
+		)
+
+	def test_row_that_names_no_model_decodes_as_blank(self):
+		# An openclaw-direct pool that never resolved a model omits both fields;
+		# the decoder must answer "" rather than invent one, so the assistant row
+		# is left unattributed instead of falsely attributed.
+		sess, ws = _build_session()
+		row = {"key": "agent:main", "hasActiveRun": False, "totalTokensFresh": True}
+		ws._frames.append(self._sessions_list_frame(ws, [row]))
+		rows = sess.list_sessions()
+
+		from jarvis.chat.usage import resolved_model_identity
+
+		self.assertEqual(resolved_model_identity(rows[0]), ("", ""))
+		self.assertEqual(resolved_model_identity(None), ("", ""))

--- a/jarvis/tests/test_model_badge_client.py
+++ b/jarvis/tests/test_model_badge_client.py
@@ -1,0 +1,60 @@
+"""jarvis#560: the per-reply model-attribution RENDER rule, proven by a REAL
+executable node test that lives in the python suite forever.
+
+The server stamps ``model`` / ``provider`` on every assistant row (see
+``finalize._stamp_reply_model``), and the feature still fails if the transcript
+never shows them. The show/hide rule is deliberately quiet, hiding the badge
+whenever a reply matches what the chat is set to now, so a bug that hides ONE
+CASE TOO MANY is invisible. No error, no empty bubble, just an audit trail that
+silently stops surfacing failovers.
+
+So the rule was extracted into a plain importable module
+(``frontend/src/utils/modelBadge.js``) and
+``frontend/src/utils/modelBadge.test.js`` pins the cases that MUST speak (a reply
+written before a mid-thread switch; an Auto turn the pool failed over) alongside
+the ones that must stay silent. This test subprocess-runs it with ``node --test``
+(non-zero exit on any failed assertion) so the client contract is enforced by
+every CI run, not just by ``npm run build``.
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import frappe
+
+
+def _badge_test_path() -> str:
+	app_root = os.path.dirname(frappe.get_app_path("jarvis"))  # .../apps/jarvis
+	return os.path.join(app_root, "frontend", "src", "utils", "modelBadge.test.js")
+
+
+class TestModelBadgeClient(unittest.TestCase):
+	def test_model_badge_node_walk_passes(self):
+		node = shutil.which("node")
+		if not node:
+			self.skipTest("node binary not available on this host")
+		test_file = _badge_test_path()
+		self.assertTrue(
+			os.path.exists(test_file),
+			f"model-badge client test missing at {test_file}: the jarvis#560 render "
+			"rule MUST ship with the module",
+		)
+		proc = subprocess.run(
+			[node, "--test", test_file],
+			cwd=os.path.dirname(test_file),
+			capture_output=True,
+			text=True,
+			timeout=120,
+		)
+		self.assertEqual(
+			proc.returncode,
+			0,
+			"client model-badge node test FAILED (jarvis#560 attribution render rule):\n"
+			f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+		)
+		# Belt-and-suspenders: the runner reports the pass count so a silently-skipped
+		# suite (0 tests) cannot masquerade as green.
+		self.assertIn("pass ", proc.stdout, f"node test produced no pass summary:\n{proc.stdout}")
+		self.assertNotIn("fail 1", proc.stdout)

--- a/jarvis/tests/test_pump_pipeline.py
+++ b/jarvis/tests/test_pump_pipeline.py
@@ -1845,3 +1845,177 @@ class TestPrepareActorFencing(_PipelineCase):
 		# The turn is cleanly re-queued with NO stale prepare refs.
 		self.assertEqual(self._state(rid), "queued")
 		self.assertIsNone(self._val(rid, "assistant_message"), "no orphan placeholder attached")
+
+
+# --------------------------------------------------------------------------- #
+# 16. jarvis#560: per-MESSAGE model attribution
+# --------------------------------------------------------------------------- #
+
+
+class _ModelRowSess(_FakeSess):
+	"""``_FakeSess`` whose ``sessions.list`` returns a caller-supplied row.
+
+	The row is the REAL openclaw payload shape, not a convenience dict: the field
+	names and their casing are what ``buildGatewaySessionRow`` emits in
+	ghcr.io/openclaw/openclaw:2026.6.8 (``key``, ``model``, ``modelProvider``,
+	``totalTokensFresh``, ``inputTokens``, ``outputTokens``, ``totalTokens``), so
+	``fetch_fresh_session_row`` and ``resolved_model_identity`` run for real
+	against the shape the gateway actually sends. A gateway rename would fail
+	these tests the same way it would break production."""
+
+	def __init__(self, session_key: str, **row):
+		super().__init__()
+		self._key = session_key
+		self._row = {"key": session_key, **row}
+
+	def list_sessions(self):
+		return [self._row]
+
+
+class TestReplyModelAttribution(_PipelineCase):
+	"""A reply must be able to name the model that wrote it (jarvis#560).
+
+	Jarvis writes to the customer's ERP, so "which model proposed this journal
+	entry" is a per-MESSAGE question. Every assertion here reads the durable
+	``Jarvis Chat Message`` row (what an auditor or support would read months
+	later), never an in-memory return value.
+
+	Token counters are deliberately zero: that is ``record_turn_usage``'s
+	VALID_ZERO path, which does NOT commit user/monthly counters, so these tests
+	leave no committed state behind a FrappeTestCase rollback cannot undo. The
+	attribution write itself is exercised end to end regardless, because it happens
+	before the counter arithmetic."""
+
+	def _finalizing_turn(self, rid, session_key, *, model_override=""):
+		"""A settled turn with a real assistant row and its usage effect owed."""
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv)
+		amsg = self._mk_msg(conv, role="assistant", content="ans", streaming=0)
+		frappe.db.set_value(CONV, conv, "session_key", session_key)
+		if model_override:
+			frappe.db.set_value(CONV, conv, "model_override", model_override)
+		self._mk_turn(conv, rid, seed, "finalizing", version=5, assistant_message=amsg)
+		ts.insert_required_effects(rid, ("usage",))
+		frappe.db.commit()
+		return conv, amsg
+
+	def _msg(self, name):
+		return frappe.db.get_value(MSG, name, ["model", "provider", "role"], as_dict=True)
+
+	def _row_sess(self, session_key, **over):
+		row = {"totalTokensFresh": True, "inputTokens": 0, "outputTokens": 0, "totalTokens": 900}
+		row.update(over)
+		return _ModelRowSess(session_key, **row)
+
+	def test_resolved_model_is_stamped_on_the_assistant_row(self):
+		# The happy path: the model the gateway attributes to this turn's session
+		# lands on the assistant row, paired with its provider (two providers can
+		# serve the same model id, so the PAIR is the identity).
+		rid = "pmp_model_stamp"
+		_conv, amsg = self._finalizing_turn(rid, "sess-model-stamp", model_override="glm-4.7")
+		sess = self._row_sess("sess-model-stamp", model="glm-4.7", modelProvider="openai_compat")
+		with self._gateway(sess):
+			finalize.run_finalize(rid, self._target)
+		row = self._msg(amsg)
+		self.assertEqual(row.model, "glm-4.7", "the resolved model is stamped on the reply")
+		self.assertEqual(row.provider, "openai_compat", "paired with the provider that served it")
+		self.assertEqual(self._effects(rid)["usage"], "done")
+
+	def test_failover_records_the_model_that_answered_not_the_requested_one(self):
+		# The case the issue exists for. The conversation asked for
+		# gemini-3.6-flash; the chain fell over and glm-4.7 actually answered.
+		# Nothing else in the system records the substitution, so the row MUST name
+		# the answerer. A stamp that echoed the REQUEST would be worse than no
+		# stamp, because it would look like corroboration.
+		rid = "pmp_model_failover"
+		_conv, amsg = self._finalizing_turn(rid, "sess-model-failover", model_override="gemini-3.6-flash")
+		sess = self._row_sess("sess-model-failover", model="glm-4.7", modelProvider="openai_compat")
+		with self._gateway(sess):
+			finalize.run_finalize(rid, self._target)
+		row = self._msg(amsg)
+		self.assertEqual(row.model, "glm-4.7", "the model that ANSWERED is recorded")
+		self.assertNotEqual(
+			row.model,
+			"gemini-3.6-flash",
+			"the requested model must not be echoed onto a failed-over reply",
+		)
+		self.assertEqual(row.provider, "openai_compat", "the substitute provider is recorded too")
+		self.assertEqual(
+			frappe.db.get_value(CONV, _conv, "model_override"),
+			"gemini-3.6-flash",
+			"the conversation still asks for the model the user picked; only the "
+			"reply knows it was answered by another",
+		)
+
+	def test_row_without_a_model_leaves_the_stamp_blank(self):
+		# An openclaw-direct pool that never resolved a model reports no model at
+		# all. Writing "" over the field would be indistinguishable from a real
+		# answer of "unknown"; leave it blank and let the UI say nothing.
+		rid = "pmp_model_absent"
+		_conv, amsg = self._finalizing_turn(rid, "sess-model-absent")
+		with self._gateway(self._row_sess("sess-model-absent")):
+			finalize.run_finalize(rid, self._target)
+		row = self._msg(amsg)
+		self.assertFalse(row.model, "no model on the gateway row => nothing stamped")
+		self.assertEqual(self._effects(rid)["usage"], "done", "usage still settles normally")
+
+	def test_stale_token_counters_do_not_cost_the_attribution(self):
+		# The gateway names the model whether or not its token counters have gone
+		# fresh yet, but a stale row makes the usage effect RETRY (CDX-6), which
+		# rolls its transaction back. This pins the recovery: the next cycle
+		# attributes the reply rather than the audit trail being lost to a slow
+		# counter.
+		rid = "pmp_model_stale"
+		_conv, amsg = self._finalizing_turn(rid, "sess-model-stale")
+		stale = self._row_sess(
+			"sess-model-stale",
+			model="gemini-3.6-flash",
+			modelProvider="gemini",
+			totalTokensFresh=False,
+			inputTokens=None,
+			outputTokens=None,
+		)
+		# The freshness poll's own backoff is not under test; skip its sleeps.
+		with self._gateway(stale), patch("jarvis.chat.usage.time.sleep", lambda *_a: None):
+			finalize.run_finalize(rid, self._target)
+		self.assertEqual(self._effects(rid)["usage"], "pending", "stale row leaves usage owed")
+		self.assertFalse(self._msg(amsg).model, "the rolled-back cycle stamped nothing")
+		fresh = self._row_sess("sess-model-stale", model="gemini-3.6-flash", modelProvider="gemini")
+		with self._gateway(fresh):
+			finalize.run_finalize(rid, self._target)
+		row = self._msg(amsg)
+		self.assertEqual(row.model, "gemini-3.6-flash", "the retry cycle attributes the reply")
+		self.assertEqual(row.provider, "gemini")
+
+	def test_only_the_assistant_row_is_stamped(self):
+		# The field is meaningless on a user or tool row, and a mislinked turn must
+		# not be able to write one: the UPDATE carries role='assistant' in its WHERE
+		# clause rather than trusting turn.assistant_message to point at a reply.
+		rid = "pmp_model_role"
+		conv = self._mk_conv()
+		seed = self._mk_msg(conv, content="hi")
+		frappe.db.set_value(CONV, conv, "session_key", "sess-model-role")
+		# assistant_message deliberately points at the USER row.
+		self._mk_turn(conv, rid, seed, "finalizing", version=5, assistant_message=seed)
+		ts.insert_required_effects(rid, ("usage",))
+		frappe.db.commit()
+		sess = self._row_sess("sess-model-role", model="glm-4.7", modelProvider="openai_compat")
+		with self._gateway(sess):
+			finalize.run_finalize(rid, self._target)
+		row = self._msg(seed)
+		self.assertEqual(row.role, "user")
+		self.assertFalse(row.model, "a non-assistant row is never attributed")
+
+	def test_get_conversation_hands_the_attribution_to_the_spa(self):
+		# The chip cannot render off a field the transcript endpoint does not
+		# return; that omission would be invisible server-side.
+		from jarvis.chat import api as chat_api
+
+		conv = self._mk_conv()
+		amsg = self._mk_msg(conv, role="assistant", content="ans", streaming=0)
+		frappe.db.set_value(MSG, amsg, {"model": "glm-4.7", "provider": "openai_compat"})
+		frappe.db.commit()
+		out = chat_api.get_conversation(conv)
+		row = next(m for m in out["messages"] if m["name"] == amsg)
+		self.assertEqual(row["model"], "glm-4.7")
+		self.assertEqual(row["provider"], "openai_compat")


### PR DESCRIPTION
Fixes #560

Part 1 of the issue. Part 2 (the pre-flight context-window check) is a cross-plane
change to the admin-owned catalog and is deliberately not in scope here.

## The gap

Nothing in the schema attributed a reply to a model. `Jarvis Chat Message`, `Jarvis
Chat Turn` and `Jarvis Chat Session` all lacked one. There was `reply_duration_ms`
but no `model` and no `provider`.

So once a thread switched models, nothing could say which model wrote which reply:
not the UI, not the DB, not support.

That matters more here than in a general chat product, because Jarvis writes to
the customer's ERP. "Which model proposed this journal entry" is a question an
auditor or an incident review will ask about **one message**. It also undercut the
failover story, since a reply can come from a different model than the user
believes is active with no trace of the substitution.

## The change

`model` and `provider` added to `Jarvis Chat Message`, read-only, stamped on the
assistant **row**. Not the session: a session-level field records one model and
destroys exactly the information this issue is about.

The value is what `sessions.list` attributes to the turn's session, read off the
row the usage poll has already fetched. That costs no extra RPC and keeps the
transcript's credit identical to the per-model usage bucket the same row is billed
against.

It is stamped **before** the freshness gate on purpose: the row names the model
whether or not its token counters have gone fresh yet, and attribution must not be
lost to a slow counter.

Three details worth a reviewer's eye:

- `role='assistant'` is in the WHERE clause rather than implied by
  `turn.assistant_message`, since the field is meaningless on a user or tool row
  and a mislinked turn must not be able to write one.
- A blank model leaves the row untouched rather than writing `""` over a value an
  earlier finalize cycle already got right.
- `modified` is deliberately not bumped. `ChatView.elapsedOf` still falls back to
  the `modified - creation` span on rows with no `reply_duration_ms`, and finalize
  runs well after settlement, so touching it would inflate the duration a legacy
  row reports.

The transcript renders it in the reply's existing meta row beside duration and
tool count, through a shared `modelBadge` module rather than a forked copy.

## Known limitation, stated plainly

Attribution rides the usage effect's claim and retry envelope. A turn that
force-dones that effect after three stale reads keeps a **blank** model. That is
honest rather than wrong, and `fetch_fresh_session_row` already logs such a turn
loudly as lost, but it does mean attribution is best-effort rather than
guaranteed. No live relay frame carries the resolved model, which is why it is
sourced from `sessions.list` at all.

## Tests

14 JS tests for the badge module, plus Python coverage in
`test_chat_openclaw_client.py` and `test_pump_pipeline.py`. The JS suite asserts
that ChatView renders through the shared module rather than a forked copy, and
that the transcript endpoint actually requests the new fields, which is the part
most likely to rot silently.

## Part 2, for a separate issue

The context-window check would need a `context_window` attribute on the
admin-owned `Jarvis LLM Model` catalog, then a comparison against the
conversation's token estimate at switch time. That is a control-plane schema
change plus a customer-plane gate, so it belongs in its own change rather than
riding this one.
