### PR TITLE
fix(desk): hide the floating Jarvis widget on Frappe's setup wizard

### DIFF
--- a/jarvis/public/js/jarvis_chat/widget/widget_visibility.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/widget_visibility.mjs
@@ -1,0 +1,29 @@
+// Visibility decision for the global floating Jarvis widget (the FAB).
+//
+// Pure so it can be unit-tested away from the Desk DOM (jarvis_widget.bundle.js
+// wires it to frappe.get_route()). The FAB is hidden only on full-page routes
+// where a floating launcher is redundant or unwanted:
+//
+//   - Jarvis's own full-page surfaces (the chat page, the onboarding wizard).
+//   - Frappe's SETUP WIZARD — while a site's initial setup isn't finished Frappe
+//     forces every route to "setup-wizard" (router.js) and blocks the desk, so a
+//     Jarvis launcher floating over the setup screen is just noise.
+//
+// Deliberately ROUTE-based, NOT gated on whether the ERP is "set up" (a Company
+// existing): a site can be past the setup wizard with no Company yet, and that is
+// exactly where a user opens this bubble to set Jarvis up — so the launcher must
+// stay available there. The moment setup completes Frappe re-routes away from
+// "setup-wizard" and the FAB returns; the panel itself then handles the
+// onboarded / degraded / gate states (panel_readiness.classifyReadiness).
+
+export const HIDE_ON_ROUTES = [
+  "jarvis-chat",
+  "jarvis-onboarding",
+  "setup-wizard",
+];
+
+// `route` is frappe.get_route() (an array; route[0] is the page).
+export function shouldHideWidget(route) {
+  const page = (Array.isArray(route) && route[0]) || "";
+  return HIDE_ON_ROUTES.indexOf(page) !== -1;
+}

--- a/jarvis/public/js/jarvis_chat/widget/widget_visibility.test.mjs
+++ b/jarvis/public/js/jarvis_chat/widget/widget_visibility.test.mjs
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shouldHideWidget, HIDE_ON_ROUTES } from "./widget_visibility.mjs";
+
+test("shown on a normal desk page", () => {
+  assert.equal(shouldHideWidget(["List", "Sales Invoice"]), false);
+  assert.equal(shouldHideWidget(["Form", "User"]), false);
+  assert.equal(shouldHideWidget([]), false);
+  assert.equal(shouldHideWidget(undefined), false);
+});
+
+test("hidden on Jarvis's own full-page routes", () => {
+  assert.equal(shouldHideWidget(["jarvis-chat"]), true);
+  assert.equal(shouldHideWidget(["jarvis-onboarding"]), true);
+});
+
+test("hidden on Frappe's setup wizard (the site-setup screen)", () => {
+  // While setup isn't complete Frappe forces route[0] to "setup-wizard"
+  // (router.js), so hiding on that route keeps the FAB off the setup screen
+  // WITHOUT suppressing it on normal desk pages — where a user sets Jarvis up
+  // from the bubble even before a Company exists.
+  assert.equal(shouldHideWidget(["setup-wizard"]), true);
+});
+
+test("HIDE_ON_ROUTES are the only hidden routes", () => {
+  assert.equal(
+    HIDE_ON_ROUTES.every((r) => shouldHideWidget([r]) === true),
+    true
+  );
+});

--- a/jarvis/public/js/jarvis_widget.bundle.js
+++ b/jarvis/public/js/jarvis_widget.bundle.js
@@ -1,6 +1,9 @@
 // Global floating Jarvis widget — a draggable, edge-snapping FAB that opens
 // the side chat panel in place, present on every Desk page EXCEPT the full
-// chat page (and the onboarding flow, where the agent isn't ready yet).
+// chat page, the onboarding flow (where the agent isn't ready yet), and
+// Frappe's setup wizard (a fresh install whose site setup isn't finished, where
+// Frappe blocks the desk on the wizard). The visibility rule lives in
+// widget_visibility.mjs.
 //
 // The panel is a child of the FAB component, so hiding this host hides both.
 // On a narrow viewport the FAB navigates to the chat SPA instead of opening a
@@ -12,12 +15,10 @@
 
 import { createApp } from "vue";
 import Widget from "./jarvis_chat/widget/Widget.vue";
+import { shouldHideWidget } from "./jarvis_chat/widget/widget_visibility.mjs";
 
 (function () {
 	if (window.__jarvisWidgetBooted) return;
-
-	// Routes where the floating widget should NOT appear.
-	const HIDE_ON = ["jarvis-chat", "jarvis-onboarding"];
 
 	let host = null;
 
@@ -32,8 +33,7 @@ import Widget from "./jarvis_chat/widget/Widget.vue";
 	function sync() {
 		ensureMounted();
 		const route = (window.frappe && frappe.get_route && frappe.get_route()) || [];
-		const hide = HIDE_ON.indexOf(route[0] || "") !== -1;
-		host.style.display = hide ? "none" : "";
+		host.style.display = shouldHideWidget(route) ? "none" : "";
 	}
 
 	function start() {


### PR DESCRIPTION
## Problem

The floating Jarvis chat bubble (FAB) is injected on **every** Desk page via `app_include_js` → `jarvis_widget.bundle.js`, but its visibility was gated only on Jarvis's own routes (`HIDE_ON = ["jarvis-chat", "jarvis-onboarding"]`). So on a fresh install it shows on top of **Frappe's setup wizard**, competing with site setup for the user's attention.

## Fix

Hide the FAB on the `setup-wizard` route too — purely **route-based**. While site setup isn't complete, Frappe **forces every route to `setup-wizard`** and blocks the desk (`frappe/public/js/frappe/router.js:129-133`), so adding `"setup-wizard"` to the widget's hidden-routes keeps the launcher off the setup screen and it returns the instant Frappe re-routes away once setup completes.

The rule moves into a pure, unit-tested `widget_visibility.mjs` (following the widget dir's `*.mjs` + `*.test.mjs` convention) so it's inspectable and covered.

### Deliberately NOT gated on whether a Company exists

An earlier revision gated on `frappe.boot.jarvis_site_setup_complete` (a Company exists), but that's too broad: a site can be **past the setup wizard with no Company yet**, and that's exactly where a user opens this bubble **to set Jarvis up**. Gating on it would remove that entry point. Route-based hiding targets only the actual setup screen and leaves the launcher available everywhere else — where the panel itself handles the onboarded / degraded / gate states (`panel_readiness.classifyReadiness`).

## Tests

- `widget_visibility.test.mjs` (4 cases, `node --test`): shown on normal desk pages; hidden on Jarvis's own routes; hidden on `setup-wizard`; every hidden route hides.
- `bench build --app jarvis` compiles; verified the compiled bundle gates on `setup-wizard` and no longer references the Company flag.

**Browser-smoke (the real gate for desk JS — not yet run):** on a `setup_complete=0` site confirm the FAB is absent on the setup wizard; complete/skip setup and confirm it appears on desk pages (even with no Company yet), so Jarvis can be set up from the bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)