### PR TITLE
fix(settings): stop a background re-probe unmounting the model editor

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -2006,6 +2006,23 @@ const badgeLabel = computed(() => {
 const applyStatus = computed(() => {
 	if (sync.value.pending) return { kind: "pending", text: "Applying to your agent…" };
 	const st = humaniseSyncStatus(sync.value.last_sync_status);
+	// A teardown is the one outcome the server records that is NOT an apply, and it
+	// used to fall through to "idle" and hide the strip. That left the whole
+	// user-visible result of Disconnect riding on applyResult, a client-only value
+	// that retires itself after six seconds and does not survive the pane
+	// remounting the editor - so a disconnect that deleted every credential could
+	// leave nothing at all on screen (jarvis#574). Reading it off the server makes
+	// the outcome durable: it is still true after the toast expires, after a
+	// reload, and in a tab that was not the one that pressed the button.
+	//
+	// Amber, not red, and for the same reason the Connection badge is: nothing is
+	// broken, the customer asked for this, and the sentence says how to undo it.
+	if (st.kind === "disconnected") {
+		return {
+			kind: "warn",
+			text: "Disconnected. Your keys and connected accounts were deleted. Add a model to use chat again.",
+		};
+	}
 	if (st.kind === "failed") {
 		return { kind: "failed", text: st.detail ? `${st.text}. ${st.detail}` : st.text };
 	}
@@ -2763,7 +2780,24 @@ async function disconnect() {
 	try {
 		await api.disconnectLlm();
 	} catch (e) {
-		setApplyResult({ kind: "failed", text: "Could not disconnect.", detail: _err(e) });
+		// NOT "nothing happened". A disconnect is the one operation in this stack
+		// with NO rollback, deliberately: the fleet's llm_disconnect.deprovision
+		// destroys the key files BEFORE it restarts the container, and admin commits
+		// the blanked credential row BEFORE it calls the host, precisely so that a
+		// credential which could not be confirmed destroyed is never reported as
+		// kept. disconnect_llm then aborts before clearing THIS bench, so a failure
+		// here can genuinely mean the keys are gone from the workspace while the
+		// bench still holds its copy and still lists the model.
+		//
+		// So the honest sentence names both halves and points at the retry. Saying
+		// "Could not disconnect." invited the customer to carry on using a workspace
+		// whose AI was already torn down. Repeating Disconnect is safe: every leg of
+		// it is idempotent.
+		setApplyResult({
+			kind: "failed",
+			text: "Could not confirm the disconnect. Your keys are still stored here, but they may already have been removed from your workspace, so chat may stop working. Try Disconnect again.",
+			detail: _err(e),
+		});
 		return;
 	} finally {
 		setBusy("");
@@ -2771,6 +2805,10 @@ async function disconnect() {
 	// No startPolling: there is no apply to converge on. disconnect_llm calls admin
 	// synchronously and only clears the bench once admin has confirmed, so by the time
 	// it returns the outcome is already final.
+	//
+	// This message is the immediate acknowledgement and it retires itself; the DURABLE
+	// statement of the same fact is applyStatus reading last_sync_status
+	// "disconnected" off the server, so the outcome outlives this toast.
 	setApplyResult({
 		kind: "ok",
 		text: "Disconnected. Your keys and connected accounts have been deleted.",

--- a/frontend/src/components/settings/AiModelsPane.vue
+++ b/frontend/src/components/settings/AiModelsPane.vue
@@ -22,10 +22,18 @@
 			}}</span>
 		</template>
 
-		<div v-if="directSubLoading" class="text-p-sm text-ink-gray-6">Loading…</div>
+		<!-- FIRST probe only. Both branches REPLACE the editor, so gating them on
+		     "a probe is in flight" (which is what directSubLoading alone means)
+		     unmounted LlmPoolEditor on every background re-probe and rebuilt it
+		     with empty state. See loadDirectSub for why that silently broke
+		     Disconnect (jarvis#574). Once a probe has succeeded the editor stays
+		     mounted for the life of the pane. -->
+		<div v-if="!directSubReady && directSubLoading" class="text-p-sm text-ink-gray-6">
+			Loading…
+		</div>
 
 		<Button
-			v-else-if="directSubErr"
+			v-else-if="!directSubReady && directSubErr"
 			variant="subtle"
 			label="Retry"
 			iconLeft="refresh-cw"
@@ -40,16 +48,30 @@
 		     synthesizes a read-oriented row for it (Reconnect embeds
 		     DirectSubscriptionCard inline; Remove disconnects) without ever
 		     round-tripping it through save_llm_pool. -->
-		<div v-else class="jv-pane-fill h-full">
-			<LlmPoolEditor
-				ref="poolEditor"
-				:editable="isSM"
-				:directStatus="directSub"
-				:hostScrim="true"
-				@saved="onSaved"
-				@direct-changed="onDirectChanged"
+		<template v-else>
+			<!-- A re-probe that failed keeps its retry affordance, but BESIDE the
+			     editor rather than instead of it: the last good directStatus is
+			     still on screen and still correct. -->
+			<Button
+				v-if="directSubErr"
+				class="mb-3"
+				variant="subtle"
+				label="Retry"
+				iconLeft="refresh-cw"
+				:loading="directSubLoading"
+				@click="loadDirectSub"
 			/>
-		</div>
+			<div class="jv-pane-fill h-full">
+				<LlmPoolEditor
+					ref="poolEditor"
+					:editable="isSM"
+					:directStatus="directSub"
+					:hostScrim="true"
+					@saved="onSaved"
+					@direct-changed="onDirectChanged"
+				/>
+			</div>
+		</template>
 
 		<!-- Pane-wide busy scrim (jarvis#559): LlmPoolEditor's own scrim only ever
 		     covered its own box, so the pane's status line below it (same editor,
@@ -75,6 +97,7 @@ import { getDirectSubscriptionStatus } from "@/api";
 import LlmPoolEditor from "@/components/LlmPoolEditor.vue";
 import SettingsPane from "@/components/settings/SettingsPane.vue";
 import JvSpinner from "@/components/JvSpinner.vue";
+import { isSyncDisconnected } from "@/lib/syncStatus";
 import { agentName } from "@/branding";
 
 // Template ref onto LlmPoolEditor's exposed { save, busy } - read busy.active/
@@ -106,6 +129,11 @@ let savedTimer = null;
 const directSub = ref({ is_direct_subscription: false });
 const directSubLoading = ref(true);
 const directSubErr = ref("");
+// True once a probe has come back cleanly, so the template can tell a FIRST load
+// (nothing to render yet) from a background re-probe (the editor is live and must
+// not be torn down). Never reset: a later probe failing does not un-know the last
+// good answer.
+const directSubReady = ref(false);
 // SettingsPane's single error surface (design.md anti-pattern 16) takes a
 // short user-facing string; the retry Button sits in the body, the same
 // errorMessage/Retry split every migrated pane in this dialog uses.
@@ -128,10 +156,17 @@ async function loadDirectSub() {
 		directSub.value = (await Promise.race([getDirectSubscriptionStatus(), timeout])) || {
 			is_direct_subscription: false,
 		};
+		directSubReady.value = true;
 	} catch (e) {
 		// Don't silently drop a real direct-subscription tenant onto the empty
-		// pool editor — surface a retryable error instead of a dead end.
-		directSub.value = { is_direct_subscription: false };
+		// pool editor: surface a retryable error instead of a dead end.
+		//
+		// Only for the FIRST probe. Blanking a directStatus the editor is already
+		// rendering would delete a live subscription row off the screen because a
+		// background re-probe timed out, which is the same class of lie the
+		// unmount below used to tell. Keep the last good answer and let the retry
+		// button say the refresh failed.
+		if (!directSubReady.value) directSub.value = { is_direct_subscription: false };
 		directSubErr.value =
 			(e && (e.message || e._server_messages)) || "Couldn't load your AI connection.";
 		errorMessage.value = "Couldn't load your AI connection.";
@@ -152,7 +187,10 @@ async function onDirectChanged() {
 // synthesized direct row through save_llm_pool - but re-probing stays cheap
 // insurance against drift).
 async function onSaved(sync) {
-	savedNote.value = sync && sync.pending ? "Saved, syncing…" : "Saved";
+	// A Disconnect emits through the same channel (the host has to re-probe after
+	// one too), and "Saved" is the wrong word for having deleted every credential.
+	if (isSyncDisconnected(sync && sync.last_sync_status)) savedNote.value = "Disconnected";
+	else savedNote.value = sync && sync.pending ? "Saved, syncing…" : "Saved";
 	clearTimeout(savedTimer);
 	savedTimer = setTimeout(() => {
 		savedNote.value = "";

--- a/frontend/src/lib/syncStatus.js
+++ b/frontend/src/lib/syncStatus.js
@@ -19,15 +19,30 @@
 /** Longest failure reason we will put in front of a customer. */
 const MAX_DETAIL = 240;
 
+// The exact marker BOTH teardown paths write into `last_sync_status`:
+// jarvis/onboarding.py's _DISCONNECTED_LLM_FIELDS (Disconnect from AI) and
+// jarvis/oauth/api.py's disconnect (Disconnect chat subscription).
+//
+// It is not an apply outcome, which is why it never matched a prefix above: there
+// is no apply and no subject left to report on. It still has to be a NAMED state
+// here rather than an unrecognised one. Falling through to "Status unavailable"
+// described a deliberate teardown as a fault, and it left the AI models pane with
+// nothing at all to show for a disconnect (its strip hides an "idle" kind), so a
+// disconnect that fully succeeded was indistinguishable from one that never ran.
+const DISCONNECTED = "disconnected";
+
 /**
  * @param {string} raw - a `last_sync_status` value, possibly empty or unrecognised.
- * @returns {{kind: "pending"|"ok"|"failed"|"unknown", text: string, detail: string}}
+ * @returns {{kind: "pending"|"ok"|"failed"|"disconnected"|"unknown", text: string, detail: string}}
  */
 export function humaniseSyncStatus(raw) {
 	const s = typeof raw === "string" ? raw.trim() : "";
 	if (!s) return { kind: "unknown", text: "Not synced yet", detail: "" };
 
 	const head = s.toLowerCase();
+	if (head === DISCONNECTED) {
+		return { kind: "disconnected", text: "Disconnected", detail: "" };
+	}
 	if (head.startsWith("pending")) {
 		return { kind: "pending", text: "Applying your changes", detail: "" };
 	}
@@ -53,6 +68,11 @@ export function isSyncPending(raw) {
 /** True when the last apply ended badly. */
 export function isSyncFailed(raw) {
 	return humaniseSyncStatus(raw).kind === "failed";
+}
+
+/** True when the customer tore the AI connection down on purpose. */
+export function isSyncDisconnected(raw) {
+	return humaniseSyncStatus(raw).kind === "disconnected";
 }
 
 /**

--- a/frontend/src/lib/syncStatus.spec.js
+++ b/frontend/src/lib/syncStatus.spec.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { humaniseSyncStatus, isSyncPending, isSyncFailed } from "@/lib/syncStatus";
+import {
+	humaniseSyncStatus,
+	isSyncPending,
+	isSyncFailed,
+	isSyncDisconnected,
+} from "@/lib/syncStatus";
 
 // Every real value below was copied from a backend write site, not invented, so a
 // wording change in jarvis/onboarding.py that breaks the prefix contract fails here.
@@ -106,5 +111,30 @@ describe("isSyncPending / isSyncFailed", () => {
 		expect(isSyncPending("ok")).toBe(false);
 		expect(isSyncFailed("failed: nope")).toBe(true);
 		expect(isSyncFailed("")).toBe(false);
+	});
+});
+
+// jarvis#574: BOTH teardown paths write this exact marker, jarvis/onboarding.py's
+// _DISCONNECTED_LLM_FIELDS and jarvis/oauth/api.py's disconnect. It used to fall
+// through to "unknown", so a disconnect that deleted every credential showed
+// nothing, and the customer could not tell a success from an operation that never
+// ran. Copied from the backend write site, not invented.
+describe("humaniseSyncStatus, disconnected", () => {
+	it("names a deliberate teardown instead of reading it as a fault", () => {
+		const out = humaniseSyncStatus("disconnected");
+		expect(out.kind).toBe("disconnected");
+		expect(out.text).toBe("Disconnected");
+	});
+
+	it("is neither pending nor failed, so no poller waits on it", () => {
+		expect(isSyncPending("disconnected")).toBe(false);
+		expect(isSyncFailed("disconnected")).toBe(false);
+		expect(isSyncDisconnected("disconnected")).toBe(true);
+	});
+
+	it("does not claim a disconnect for any other status", () => {
+		for (const s of ["", "ok", "ok (pool via admin)", "pending: anything", "failed: nope"]) {
+			expect(isSyncDisconnected(s)).toBe(false);
+		}
 	});
 });


### PR DESCRIPTION
Fixes #574

Disconnect appeared not to work when only one model was configured. Two separate
defects, both in the pane rather than in the teardown. **The disconnect itself was
working.**

## 1. A background re-probe was unmounting the editor

`AiModelsPane` gated its `v-if`/`v-else` on `directSubLoading`, and **both branches
replace the editor**. So every background re-probe unmounted `LlmPoolEditor` and
rebuilt it with empty state, discarding whatever was in flight. Press Disconnect,
have a re-probe land, and the action goes with the unmounted component.

The template now distinguishes a **first** load, where there is genuinely nothing
to render, from a **re-probe**, where the editor is live and must not be torn
down. Once a probe has succeeded the editor stays mounted for the life of the
pane.

A re-probe that fails now keeps its Retry **beside** the editor rather than
instead of it: the last good `directStatus` is still on screen and still correct,
so replacing a working editor with a Retry button threw away good state in order
to report a background failure.

## 2. A successful disconnect showed nothing

Both teardown paths write `last_sync_status = "disconnected"`
(`onboarding.py`'s `_DISCONNECTED_LLM_FIELDS` and `oauth/api.py`'s `disconnect`),
and `humaniseSyncStatus` did not recognise it, so it fell through to `unknown` and
the status strip hid itself.

That left the entire visible result of a disconnect riding on `applyResult`, a
client-only value that retires itself after six seconds and does not survive a
remount. Combined with defect 1, a disconnect that deleted every credential could
leave **nothing at all** on screen, so a success and an operation that never ran
looked identical.

Reading the outcome off the server makes it durable: still true after the toast
expires, after a reload, and in a tab that did not press the button. Amber rather
than red, for the same reason the Connection badge is: nothing is broken, the
customer asked for this, and the sentence says how to undo it.

Worth noting `onboarding.py` already carried a comment saying `humaniseSyncStatus`
does not recognise this marker, describing the hidden strip as correct. It was
not. That comment is what made the gap easy to find.

## 3. The failure copy was actively misleading

A disconnect has **no rollback**, by design. The fleet's
`llm_disconnect.deprovision` destroys the key files before restarting the
container, and admin commits the blanked credential row before calling the host,
precisely so a credential that could not be confirmed destroyed is never reported
as kept. `disconnect_llm` then aborts before clearing this bench.

So a failure here can genuinely mean the keys are already gone from the workspace
while the bench still holds its copy and still lists the model. "Could not
disconnect." invited the customer to carry on using a workspace whose AI was
already torn down. The sentence now names both halves and points at the retry,
which is safe because every leg is idempotent.

## Tests

3 added to `syncStatus.spec.js` (13 pass in that file): the marker is named rather
than read as a fault, it is neither pending nor failed so no poller waits on it,
and no other status claims to be a disconnect. The values are copied from the
backend write sites rather than invented, matching the file's existing convention,
so a wording change in `onboarding.py` breaks this test rather than the UI.

## Not verified

The mount and unmount behaviour is reasoned from the template structure and not
exercised in a browser. There is no component-level test harness for
`AiModelsPane`, and I did not invent one. Worth one live check: open Settings, AI
models on a single-model tenant, press Disconnect, and confirm the editor stays
mounted and the amber Disconnected line persists across a reload.
