### PR TITLE
fix(llm): let a second account of one provider join the model it belongs to

### DIFF
--- a/frontend/src/components/LlmPoolEditor.vue
+++ b/frontend/src/components/LlmPoolEditor.vue
@@ -585,6 +585,20 @@
 						</div>
 					</div>
 
+					<!-- Say what this sign-in will actually DO before it starts. The customer
+               picked "+ Add a model" for a provider the pool already has, and what
+               they will get is another ACCOUNT on the existing model, not a second
+               model - because every subscription model shares one Bifrost provider
+               entry, so two rows naming one model cannot both exist. Finding that
+               out afterwards used to cost a whole wasted OAuth round trip (#575). -->
+					<p v-if="addFoldsInto" class="jv-pool-foldnote">
+						{{ upstreamLabelOf(panelRow.upstream) }} is already connected here with
+						{{ addFoldsInto.accounts.length }}
+						{{ addFoldsInto.accounts.length === 1 ? "account" : "accounts" }}. Signing
+						in adds another account to that same model, so your agent can spread its
+						work across them. It does not add a second model.
+					</p>
+
 					<!-- Connect account: EDIT-mode re-entry only. In add mode the two-step sign-in
                renders directly (see its v-if below), so a fresh "Add a model" never shows
                this button - clicking "Connect account" and THEN "Open sign-in" was a
@@ -2423,6 +2437,19 @@ const panelConnectOpen = computed(() => {
 	return !!c.open || (panel.value.mode === "add" && !(r.accounts || []).length);
 });
 
+// The already-connected row an ADD-mode subscription sign-in will fold into, or
+// null. Drives the notice above the sign-in spine so the customer reads "this adds
+// an account to what you already have" BEFORE they authorize, rather than
+// discovering it from the fold afterwards. Only ever set in add mode: in the edit
+// panel "+ Add account" already says the same thing by where it sits.
+const addFoldsInto = computed(() => {
+	if (!panel.value.open || panel.value.mode !== "add") return null;
+	const r = panelRow.value;
+	if (!r || r.credentialType !== "subscription") return null;
+	const host = subscriptionHostRow(r);
+	return host && (host.accounts || []).length ? host : null;
+});
+
 // True exactly when the spine's own Cancel is standing in for the footer's -
 // the paste-back add flow above (jv-cn-acts), not the device-code flow (that one
 // has no Connect to pair against, so it keeps the footer's Cancel as-is). Read by
@@ -3074,9 +3101,55 @@ async function _pollDeviceConnect(m, intervalSecs) {
 	};
 	setTimeout(tick, intervalSecs * 1000);
 }
+// The row a connect on `r` really belongs to: an EXISTING subscription row that
+// already names the same model, or null when `r` is the only one.
+//
+// "+ Add a model" seeds its row on the chosen provider's DEFAULT model id, so a
+// customer connecting a SECOND account of a provider they already use lands on a
+// row naming a model the pool already has. Every subscription model renders
+// through ONE shared Bifrost provider entry ("cliproxy-subs"), so that pair
+// renders duplicate routing targets and llm_proxy.validate() refuses the WHOLE
+// spec with `duplicate_subscription_model` - after the sign-in, which is the worst
+// possible moment to find out (#575). Several accounts of one provider is the
+// point of the subscription tier, so the account belongs on the row that exists.
+//
+// Keyed on the model id, which is what the shared validator keys its own check on;
+// the upstream has to agree too, so a fold can never mix two providers' OAuth
+// accounts onto one row.
+function subscriptionHostRow(r) {
+	if (!r || r.credentialType !== "subscription") return null;
+	const model = (r.model || "").trim();
+	if (!model) return null;
+	return (
+		rows.value.find(
+			(x) =>
+				x !== r &&
+				x.credentialType === "subscription" &&
+				(x.model || "").trim() === model &&
+				(x.upstream || "openai") === (r.upstream || "openai")
+		) || null
+	);
+}
+
 // Shared account placement for both the paste-back (finishConnect) and
 // device-code (_pollDeviceConnect) success paths.
-async function _placeConnectedAccount(m, d) {
+async function _placeConnectedAccount(row, d) {
+	// Fold onto the row that already owns this model, dropping the duplicate the
+	// add-flow seeded. The server folds too (onboarding._coalesce_subscription_models,
+	// which covers desk/API clients), but doing it here keeps the failover list and
+	// the payload honest instead of shipping a pair we know will be refused.
+	const host = subscriptionHostRow(row);
+	const m = host || row;
+	if (host) {
+		if (!host._connect) host._connect = blankConnect();
+		host._connect = { ...host._connect, ...row._connect, reconnectIdx: null };
+		rows.value = rows.value.filter((x) => x !== row);
+		// Keep the open panel on a row that still exists, or its watcher would close
+		// it out from under the apply that is about to start.
+		if (panel.value.open && panel.value.uid === row._uid) {
+			panel.value = { ...panel.value, mode: "edit", uid: host._uid };
+		}
+	}
 	if (!Array.isArray(m.accounts)) m.accounts = [];
 	const acct = {
 		upstream: m.upstream || "openai",
@@ -3087,17 +3160,23 @@ async function _placeConnectedAccount(m, d) {
 		connected: true,
 	};
 	const ri = m._connect.reconnectIdx;
-	// Device-code accounts (Kimi) carry NO email, so byEmail can't fold two
-	// captures of the same account — to REFRESH an existing device account use its
-	// per-slot Reconnect (sets reconnectIdx, replacing that slot); a generic
-	// Connect always appends (intended for pooling a genuinely different account).
-	const byEmail = acct.account_email
-		? m.accounts.findIndex(
-				(a) =>
-					a.account_email &&
-					a.account_email.toLowerCase() === acct.account_email.toLowerCase()
-		  )
-		: -1;
+	// Device-code accounts (Kimi) carry NO email, so this can't fold two captures of
+	// the same account. To REFRESH an existing device account use its per-slot
+	// Reconnect (sets reconnectIdx, replacing that slot); a generic Connect always
+	// appends (intended for pooling a genuinely different account). Their labels are
+	// per-account ("Kimi <last 4 of ref>"), so the label fallback below does not fold
+	// them either.
+	//
+	// A STORED account carries no `account_email` at all: get_llm_config returns only
+	// {upstream, account_ref, label}, and that label IS the email the sign-in
+	// reported. Matching on account_email alone therefore went blind the moment the
+	// page reloaded, so signing in again as the SAME ChatGPT user appended a second
+	// copy of one account - two cliproxy credential files holding one refresh token,
+	// which is the reuse pattern OpenAI revokes whole accounts over. Fall back to the
+	// label so a reloaded account still folds onto itself.
+	const identityOf = (a) => ((a && (a.account_email || a.label)) || "").trim().toLowerCase();
+	const identity = identityOf(acct);
+	const byEmail = identity ? m.accounts.findIndex((a) => identityOf(a) === identity) : -1;
 	if (ri != null && ri >= 0 && ri < m.accounts.length) {
 		m.accounts.splice(ri, 1, acct);
 		if (byEmail >= 0 && byEmail !== ri) m.accounts.splice(byEmail, 1);

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -188,6 +188,88 @@ def get_preset_catalog() -> list:
 	return admin_client.get_preset_catalog()
 
 
+def _subscription_upstream(sub: dict) -> str:
+	"""The one upstream a posted subscription block's accounts agree on, or "".
+
+	Two rows are only folded together when this matches, so folding can never
+	manufacture the mixed-upstream row ``validate_models`` rejects.
+	"""
+	seen = {(a.get("upstream") or "").strip() for a in (sub.get("accounts") or []) if isinstance(a, dict)}
+	seen.discard("")
+	return seen.pop() if len(seen) == 1 else ""
+
+
+def _merge_subscription_accounts(target: list, incoming: list) -> None:
+	"""Append ``incoming`` accounts onto ``target``, skipping account_refs already
+	there.
+
+	A ref that arrives twice contributes only its ``oauth_blob``, and only when the
+	copy already held carries none: a client that posts the same account in two
+	rows (one of them reloaded, so blank) must end up with the credential, not with
+	the ``duplicate_account_ref`` rejection ``validate_models`` would otherwise
+	raise.
+	"""
+	by_ref = {}
+	for a in target:
+		ref = a.get("account_ref") if isinstance(a, dict) else None
+		if ref:
+			by_ref[ref] = a
+	for a in incoming:
+		ref = a.get("account_ref") if isinstance(a, dict) else None
+		held = by_ref.get(ref) if ref else None
+		if held is None:
+			copy = dict(a) if isinstance(a, dict) else a
+			target.append(copy)
+			if ref:
+				by_ref[ref] = copy
+		elif not (held.get("oauth_blob") or "").strip():
+			held["oauth_blob"] = a.get("oauth_blob") or ""
+
+
+def _coalesce_subscription_models(models: list) -> list:
+	"""Fold posted subscription rows that name the SAME model into ONE row holding
+	all of their accounts.
+
+	Every subscription model in a pool renders through ONE shared Bifrost provider
+	entry ("cliproxy-subs"), so two rows naming the same model render duplicate
+	routing targets and ``llm_proxy.validate()`` rejects the WHOLE spec with
+	``duplicate_subscription_model``. The pool editor's "+ Add a model" flow seeds
+	its new row on the chosen provider's default model id, so a customer adding a
+	SECOND account of a provider they already use posted exactly that pair - and
+	only learned it was refused after completing a full OAuth sign-in (#575).
+
+	Pooling several accounts of one provider is the whole point of the subscription
+	tier, so the honest reading of that payload is "another account for this model",
+	never "a second model". Fold rather than reject: a rejection would ALSO lock any
+	tenant that already stored such a pair out of every Jarvis Settings save, since
+	``on_update`` re-validates on every write, and it would still cost the customer
+	the sign-in they just completed.
+
+	API-key rows pass through untouched - ``llm_proxy.validate`` scopes their
+	duplicate check to (provider, model) pairs and they carry no accounts to merge.
+	"""
+	out: list = []
+	folded: dict[tuple[str, str], dict] = {}
+	for m in models:
+		sub = m.get("subscription") if isinstance(m, dict) else None
+		if not isinstance(sub, dict):
+			out.append(m)
+			continue
+		key = ((m.get("model") or "").strip(), _subscription_upstream(sub))
+		target = folded.get(key)
+		if target is None:
+			row = dict(m)
+			row["subscription"] = dict(sub)
+			row["subscription"]["accounts"] = [
+				dict(a) if isinstance(a, dict) else a for a in (sub.get("accounts") or [])
+			]
+			folded[key] = row
+			out.append(row)
+			continue
+		_merge_subscription_accounts(target["subscription"]["accounts"], sub.get("accounts") or [])
+	return out
+
+
 @frappe.whitelist()
 def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: str = "failover") -> dict:
 	"""Write the customer's multi-model LLM pool into Jarvis Settings.models[]
@@ -207,6 +289,10 @@ def save_llm_pool(models: str | list, preset: str | None = None, routing_mode: s
 		models = json.loads(models)
 	if not isinstance(models, list) or not models:
 		raise frappe.ValidationError("models must be a non-empty list")
+	# Several accounts of one provider belong on ONE model row (see #575). Fold
+	# before anything is read or written so the merge covers every client of this
+	# endpoint, not just the SPA that happens to have the fix.
+	models = _coalesce_subscription_models(models)
 	if routing_mode != "failover":
 		raise frappe.ValidationError("routing_mode must be 'failover' in v1")
 

--- a/jarvis/tests/test_llm_pool_endpoints.py
+++ b/jarvis/tests/test_llm_pool_endpoints.py
@@ -430,3 +430,91 @@ class TestBackfillGlmZaiProviderIdPatch(_RT3SettingsTestCase):
 		)
 		self._run_patch()
 		self.assertEqual(frappe.db.get_value("Jarvis LLM Pool Model", name, "provider"), "openai")
+
+
+class TestCoalesceSubscriptionModels(_RT3SettingsTestCase):
+	"""jarvis#575: a second account of a provider the tenant already uses arrived
+	as a SECOND MODEL ROW naming the same model, and every subscription model
+	renders through one shared Bifrost provider entry, so llm_proxy.validate
+	rejected the whole spec with duplicate_subscription_model. The customer only
+	learned that after completing a full OAuth sign-in.
+
+	Pure list transforms. Nothing here touches the DB.
+	"""
+
+	@staticmethod
+	def _sub(model, *accounts):
+		return {
+			"model": model,
+			"credential_type": "subscription",
+			"subscription": {"accounts": list(accounts)},
+		}
+
+	@staticmethod
+	def _acct(ref, upstream="openai", blob='{"t":1}'):
+		return {"account_ref": ref, "upstream": upstream, "oauth_blob": blob, "label": ref}
+
+	def test_two_rows_of_one_model_fold_into_one_with_both_accounts(self):
+		"""The reported repro: add a second ChatGPT account."""
+		out = onboarding._coalesce_subscription_models(
+			[
+				self._sub("gpt-5.5", self._acct("ACC_1")),
+				self._sub("gpt-5.5", self._acct("ACC_2")),
+			]
+		)
+		self.assertEqual(len(out), 1)
+		refs = [a["account_ref"] for a in out[0]["subscription"]["accounts"]]
+		self.assertEqual(refs, ["ACC_1", "ACC_2"])
+
+	def test_a_repeated_account_ref_is_not_duplicated(self):
+		"""validate_models rejects a duplicate account_ref, so folding must not make one."""
+		out = onboarding._coalesce_subscription_models(
+			[self._sub("gpt-5.5", self._acct("ACC_1")), self._sub("gpt-5.5", self._acct("ACC_1"))]
+		)
+		self.assertEqual(len(out[0]["subscription"]["accounts"]), 1)
+
+	def test_a_reloaded_blank_copy_gains_the_posted_credential(self):
+		"""A row reloaded from the DB carries no blob; the freshly connected one does."""
+		out = onboarding._coalesce_subscription_models(
+			[
+				self._sub("gpt-5.5", self._acct("ACC_1", blob="")),
+				self._sub("gpt-5.5", self._acct("ACC_1", blob='{"real":1}')),
+			]
+		)
+		accounts = out[0]["subscription"]["accounts"]
+		self.assertEqual(len(accounts), 1)
+		self.assertEqual(accounts[0]["oauth_blob"], '{"real":1}')
+
+	def test_different_models_are_not_folded(self):
+		out = onboarding._coalesce_subscription_models(
+			[self._sub("gpt-5.5", self._acct("ACC_1")), self._sub("grok-4.3", self._acct("ACC_2"))]
+		)
+		self.assertEqual(len(out), 2)
+
+	def test_rows_of_different_upstreams_are_not_folded(self):
+		"""Folding across upstreams would manufacture the mixed-upstream row
+		validate_models rejects, so the upstream is part of the fold key."""
+		out = onboarding._coalesce_subscription_models(
+			[
+				self._sub("shared-name", self._acct("ACC_1", upstream="openai")),
+				self._sub("shared-name", self._acct("ACC_2", upstream="xai")),
+			]
+		)
+		self.assertEqual(len(out), 2)
+
+	def test_api_key_rows_pass_through_untouched(self):
+		"""validate scopes their duplicate check to (provider, model) and they have
+		no accounts to merge, so they must not be folded."""
+		rows = [
+			{"model": "glm-4.7", "provider": "zai_coding", "credential_type": "api_key"},
+			{"model": "glm-4.7", "provider": "openai_compat", "credential_type": "api_key"},
+		]
+		self.assertEqual(onboarding._coalesce_subscription_models(rows), rows)
+
+	def test_the_input_list_is_not_mutated(self):
+		"""save_llm_pool re-reads its own argument, so folding must copy."""
+		a = self._sub("gpt-5.5", self._acct("ACC_1"))
+		b = self._sub("gpt-5.5", self._acct("ACC_2"))
+		onboarding._coalesce_subscription_models([a, b])
+		self.assertEqual(len(a["subscription"]["accounts"]), 1)
+		self.assertEqual(len(b["subscription"]["accounts"]), 1)


### PR DESCRIPTION
Fixes #575

Adding a **second ChatGPT account** failed with a duplicate entry error. Pooling
several accounts of one provider is the entire point of the subscription tier, so
this blocked the feature's main use.

## Root cause

The connect flow posted the account as a **second model row** naming the same
model.

Every subscription model in a pool renders through **one** shared Bifrost provider
entry (`cliproxy-subs`), so two rows naming one model render duplicate routing
targets and `llm_proxy.validate` refuses the **whole spec** with
`duplicate_subscription_model`.

"+ Add a model" seeds its new row on the chosen provider's **default model id**,
so a customer adding another account of a provider they already use posted exactly
that pair. The validator was right. The placement was wrong.

Worse, the refusal came **after a full OAuth sign-in**, which is the worst possible
moment to discover it.

## Server side

`save_llm_pool` now folds posted subscription rows naming the same model into one
row holding all their accounts.

**Folding rather than rejecting is deliberate.** Several accounts of one provider
is the point of this tier, so the honest reading of that payload is "another
account for this model", never "a second model". A rejection would also lock any
tenant that already stored such a pair out of **every** settings save, since
`on_update` re-validates on every write, and it would still cost the customer the
sign-in they just completed.

Details that matter:

- The fold key is `(model, upstream)`, not model alone, so it can never
  manufacture the mixed-upstream row `validate_models` rejects.
- A repeated `account_ref` contributes only its `oauth_blob`, and only when the
  copy already held carries none. A client that posts one account in two rows (one
  reloaded from the DB and therefore blank) ends up with the credential rather than
  a `duplicate_account_ref` rejection.
- API-key rows pass through untouched: `validate` scopes their duplicate check to
  `(provider, model)` and they carry no accounts to merge.
- The input list is copied, never mutated, since `save_llm_pool` re-reads its own
  argument.

## Client side

An add-mode subscription sign-in now names the row it will join **before** the
customer authorizes, so "this adds an account to what you already have" is read up
front rather than discovered from the fold afterwards.

## Tests

7 added, all pure list transforms touching no DB. Covered: the reported repro
folds two rows into one carrying both accounts; a repeated `account_ref` is not
duplicated; a reloaded blank copy gains the posted credential; different models do
not fold; different upstreams do not fold; API-key rows pass through untouched;
and the input list is not mutated.

Each behaviour was also exercised directly against the real function before
committing, not just asserted.

## Not verified

No second real OAuth sign-in was completed, so the end-to-end path from a live
ChatGPT authorization through to two blobs landing in cliproxy's auth directory is
unexercised. The fold is verified at the payload level, and the fleet writes one
blob per account during `/llm-pool` materialize, but that last hop is inferred
rather than observed.
