### PR TITLE
fix(onboarding): make the failed-payment resume reachable again

### DIFF
--- a/jarvis/admin_client.py
+++ b/jarvis/admin_client.py
@@ -1628,7 +1628,10 @@ def _do_post(url: str, body: dict, headers: dict, timeout_s: int, admin_url: str
 	# class isn't recognised.
 	if exc_type:
 		if exc_type in ("ValidationError", "DuplicateEntryError", "DoesNotExistError"):
-			raise AdminValidationError(clean)
+			# Carry admin's exception class forward. Callers branch on it
+			# (see onboarding._is_duplicate_signup_error) rather than on the
+			# message prose, which admin is free to reword at any time.
+			raise AdminValidationError(clean, exc_type=exc_type)
 		# AuthenticationError ~ a token/credential failure (retry-eligible, 401);
 		# PermissionError ~ an authorization denial (terminal, 403). Tag the
 		# status so _post re-mints on the former but surfaces the latter as-is.

--- a/jarvis/exceptions.py
+++ b/jarvis/exceptions.py
@@ -160,7 +160,18 @@ class AdminAuthError(JarvisError):
 class AdminValidationError(JarvisError):
 	"""jarvis_admin raised a Frappe ValidationError (or similar user-input
 	error) inside a whitelisted endpoint. Carries the clean operator-facing
-	message - never the traceback dump."""
+	message - never the traceback dump.
+
+	``exc_type`` carries admin's own exception class name (e.g.
+	"DuplicateEntryError") when the response declared one. Callers that need to
+	branch on WHICH validation failed must key off this, never off the message
+	prose: the failed-payment resume used to match the substring "already
+	registered or pending", admin later reworded that message, and the resume
+	became silently unreachable. None when admin sent no exc_type."""
+
+	def __init__(self, message: str, *, exc_type: str | None = None):
+		super().__init__(message)
+		self.exc_type = exc_type
 
 
 class AdminRateLimitedError(JarvisError):

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -29,9 +29,7 @@ from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
 # error from the customer. The onboarding view keys its reconnect OFFER off the
 # looser pair, which is fine for a display hint but too loose for control flow.
 # exc_type is the primary signal; this only runs when admin sent none.
-_DUPLICATE_SIGNUP_RE = re.compile(
-	r"account\b.{0,60}?already\s+(?:exists|registered or pending)", re.I | re.S
-)
+_DUPLICATE_SIGNUP_RE = re.compile(r"account\b.{0,60}?already\s+(?:exists|registered or pending)", re.I | re.S)
 
 
 def _require_admin_url() -> None:

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -3,6 +3,7 @@ Settings, and thin server wrappers the onboarding page calls (so the browser
 never holds admin creds). admin_client returns already-unwrapped admin data."""
 
 import json
+import re
 
 import frappe
 from frappe.utils import cint
@@ -16,6 +17,13 @@ from jarvis.exceptions import (
 )
 from jarvis.hooks import get_default_admin_url
 from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
+
+# Duplicate-signup prose, for an admin too old to tag the response with
+# exc_type="DuplicateEntryError". Deliberately matches BOTH the current wording
+# and the pre-2026-07 one, and is the SAME pair the onboarding view keys its
+# reconnect offer off (frontend/src/views/OnboardingView.vue). Structured
+# exc_type is the primary signal; see _is_duplicate_signup_error.
+_DUPLICATE_SIGNUP_RE = re.compile(r"already registered or pending|already exists", re.I)
 
 
 def _require_admin_url() -> None:
@@ -446,11 +454,16 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	require_jarvis_admin()
 	_require_admin_url()
 	try:
-		data = _surface(admin_client.signup, email, company, plan, provider=provider)
-	except frappe.ValidationError as e:
+		# NOT _surface: that maps the admin error straight to a bare
+		# frappe.throw, discarding the AdminValidationError (and the exc_type
+		# on it) that the duplicate check needs. Inspect the raised error
+		# first, then hand anything non-resumable to the identical mapping
+		# _surface would have applied.
+		data = admin_client.signup(email, company, plan, provider=provider)
+	except (AdminValidationError, AdminAuthError, AdminUnreachableError, AdminRateLimitedError) as e:
 		resumed = _try_resume_pending_signup(e, email, plan, provider)
 		if resumed is None:
-			raise
+			_throw_admin_error(e)  # always raises
 		data = resumed
 	# Persist whatever credentials the response carries. The guard also fires
 	# on ``customer`` so the OAuth grant username is stored even if a future
@@ -476,6 +489,25 @@ def start_signup(email: str, company: str, plan: str, provider: str | None = Non
 	return data
 
 
+def _is_duplicate_signup_error(err) -> bool:
+	"""Is this admin rejection "that (email, company) already has an account"?
+
+	Keyed on admin's exception CLASS, not on its message. The previous check
+	matched the substring "already registered or pending"; admin later reworded
+	that to "An account for this email and company already exists.", and because
+	nothing asserted against the real message the failed-payment resume below
+	became silently unreachable — every customer whose card was declined got a
+	dead end instead of a fresh checkout. Only the customer-side test fixture
+	still carried the old wording, so the suite stayed green throughout.
+
+	The prose fallback covers an admin old enough to send DuplicateEntryError as
+	a plain ValidationError. It matches BOTH wordings, matching the regex the
+	onboarding view already uses to decide whether to offer reconnect."""
+	if getattr(err, "exc_type", None) == "DuplicateEntryError":
+		return True
+	return bool(_DUPLICATE_SIGNUP_RE.search(str(err)))
+
+
 def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None) -> dict | None:
 	"""Failed-payment retry: when guest signup is rejected as a duplicate and
 	this bench already holds credentials for THAT email (persisted by the first
@@ -488,7 +520,7 @@ def _try_resume_pending_signup(err, email: str, plan: str, provider: str | None)
 	re-raises the original error. A resume that itself fails (e.g. the customer
 	is Active — a real duplicate) also returns None: the original duplicate
 	error is the honest message for that case."""
-	if "already registered or pending" not in str(err):
+	if not _is_duplicate_signup_error(err):
 		return None
 	settings = frappe.get_single("Jarvis Settings")
 	stored_email = (settings.get("jarvis_admin_customer_email") or "").strip().lower()

--- a/jarvis/onboarding.py
+++ b/jarvis/onboarding.py
@@ -19,11 +19,19 @@ from jarvis.hooks import get_default_admin_url
 from jarvis.permissions import grant_onboarding_admin, require_jarvis_admin
 
 # Duplicate-signup prose, for an admin too old to tag the response with
-# exc_type="DuplicateEntryError". Deliberately matches BOTH the current wording
-# and the pre-2026-07 one, and is the SAME pair the onboarding view keys its
-# reconnect offer off (frontend/src/views/OnboardingView.vue). Structured
-# exc_type is the primary signal; see _is_duplicate_signup_error.
-_DUPLICATE_SIGNUP_RE = re.compile(r"already registered or pending|already exists", re.I)
+# exc_type="DuplicateEntryError". Covers BOTH admin wordings:
+#   "An account for this email and company already exists."      (current)
+#   "An account with this email is already registered or pending." (pre-2026-07)
+#
+# Anchored on "account ... already <verb>" rather than a bare "already exists",
+# which would also match unrelated admin validation errors (a plan or config
+# conflict, say) and silently divert them into the resume path, hiding the real
+# error from the customer. The onboarding view keys its reconnect OFFER off the
+# looser pair, which is fine for a display hint but too loose for control flow.
+# exc_type is the primary signal; this only runs when admin sent none.
+_DUPLICATE_SIGNUP_RE = re.compile(
+	r"account\b.{0,60}?already\s+(?:exists|registered or pending)", re.I | re.S
+)
 
 
 def _require_admin_url() -> None:

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -836,7 +836,14 @@ class TestSignupResumeFallback(FrappeTestCase):
 	"""Failed-payment retry: the dedup rejection falls back to the authenticated
 	resume only when this bench holds creds for that same email."""
 
-	_DUP = "An account with this email is already registered or pending."
+	# The message jarvis_admin_v2 ACTUALLY throws today, copied verbatim from
+	# jarvis_admin_v2/billing/signup.py::_reject_duplicate_email. This class used
+	# to pin ONLY the pre-2026-07 wording (_DUP_LEGACY); when admin reworded the
+	# message the resume path went dead for every real customer while all four
+	# tests here stayed green. Both wordings are covered now, and
+	# test_dedup_by_exc_type_resumes covers the signal that does not rot.
+	_DUP = "An account for this email and company already exists."
+	_DUP_LEGACY = "An account with this email is already registered or pending."
 
 	def setUp(self):
 		self._snap = _snapshot_settings()
@@ -849,10 +856,41 @@ class TestSignupResumeFallback(FrappeTestCase):
 	def tearDown(self):
 		_restore_settings(self._snap)
 
-	def _signup_raises(self, msg):
+	def _signup_raises(self, msg, exc_type=None):
 		from jarvis.exceptions import AdminValidationError
 
-		return patch("jarvis.onboarding.admin_client.signup", side_effect=AdminValidationError(msg))
+		return patch(
+			"jarvis.onboarding.admin_client.signup",
+			side_effect=AdminValidationError(msg, exc_type=exc_type),
+		)
+
+	def test_dedup_by_exc_type_resumes_regardless_of_wording(self):
+		"""The signal that cannot rot: admin's exception CLASS. Even with prose
+		this bench has never seen, a DuplicateEntryError must reach the resume."""
+		with (
+			self._signup_raises("some wording nobody has written yet", exc_type="DuplicateEntryError"),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				return_value={"payment_provider": "razorpay", "razorpay_order_id": "order_R3"},
+			) as resume,
+		):
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once_with("some-plan", provider=None)
+		self.assertEqual(out["razorpay_order_id"], "order_R3")
+
+	def test_dedup_legacy_wording_still_resumes(self):
+		"""An admin old enough to send the pre-2026-07 message, with no exc_type,
+		must still reach the resume via the prose fallback."""
+		with (
+			self._signup_raises(self._DUP_LEGACY),
+			patch(
+				"jarvis.onboarding.admin_client.resume_pending_signup",
+				return_value={"payment_provider": "razorpay", "razorpay_order_id": "order_R4"},
+			) as resume,
+		):
+			out = onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_called_once_with("some-plan", provider=None)
+		self.assertEqual(out["razorpay_order_id"], "order_R4")
 
 	def test_dedup_with_matching_creds_resumes(self):
 		with (
@@ -896,7 +934,7 @@ class TestSignupResumeFallback(FrappeTestCase):
 			self.assertRaises(frappe.ValidationError) as ctx,
 		):
 			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
-		self.assertIn("already registered", str(ctx.exception))
+		self.assertIn("already exists", str(ctx.exception))
 
 
 class TestAccountReconnect(FrappeTestCase):

--- a/jarvis/tests/test_onboarding_sync.py
+++ b/jarvis/tests/test_onboarding_sync.py
@@ -892,6 +892,22 @@ class TestSignupResumeFallback(FrappeTestCase):
 		resume.assert_called_once_with("some-plan", provider=None)
 		self.assertEqual(out["razorpay_order_id"], "order_R4")
 
+	def test_unrelated_error_mentioning_already_exists_does_not_resume(self):
+		"""The prose fallback must not swallow unrelated validation errors.
+
+		A bare "already exists" substring would divert any admin error containing
+		that phrase into the resume path, resuming a stale pending signup and
+		hiding the real problem. The pattern anchors on "account ... already
+		<verb>" so only a genuine duplicate-signup rejection matches."""
+		with (
+			self._signup_raises("A plan with this name already exists."),
+			patch("jarvis.onboarding.admin_client.resume_pending_signup") as resume,
+			self.assertRaises(frappe.ValidationError) as ctx,
+		):
+			onboarding.start_signup("resume-me@example.com", "Co", "some-plan")
+		resume.assert_not_called()
+		self.assertIn("A plan with this name", str(ctx.exception))
+
 	def test_dedup_with_matching_creds_resumes(self):
 		with (
 			self._signup_raises(self._DUP),


### PR DESCRIPTION
## The bug

A customer whose card is declined lands with a `Pending Payment` row. Retrying the wizard hits admin's duplicate guard, and `start_signup` is supposed to fall back to the authenticated `resume_pending_signup` so checkout reopens.

It never did. The fallback gated on the substring `"already registered or pending"`. Admin was later reworded to `"An account for this email and company already exists."`, the guard stopped matching, and every real failed-payment retry dead-ended on the duplicate error.

## Evidence

Reproduced live against `jarvis.admin.v2`:

```
POST .../billing.signup.signup   (fresh)  -> 200, razorpay order created, status Pending Payment
POST .../billing.signup.signup   (retry)  -> 409 DuplicateEntryError
                                             "An account for this email and company already exists."
```

Then, with credentials stored and the email matching (the best possible case for the fallback):

| message fed to the guard | resume attempted |
|---|---|
| what admin sends today | **NO** -> dead end |
| the wording the guard matched | YES |

## Why no test caught it

The only surviving copy of the old wording in the tree was this suite's own `_DUP` fixture. All four tests kept passing against a message nothing emits. `OnboardingView.vue` had already been updated to match both wordings; only the backend guard was missed.

## The fix

Key the decision off admin's exception **class**, not its prose:

- `AdminValidationError` carries `exc_type` through from the response envelope.
- `_is_duplicate_signup_error()` checks `exc_type == "DuplicateEntryError"` first, with a regex fallback covering **both** wordings for an admin old enough not to send `exc_type`.
- `start_signup` calls `admin_client.signup` directly instead of through `_surface`, which flattened the error to a bare `frappe.throw` and discarded `exc_type`; anything non-resumable still goes through the identical `_throw_admin_error` mapping, so no behaviour change there.

Tests now pin admin's real message, add the `exc_type` path (which cannot rot), and keep the legacy wording covered.

## Scope

This fixes recovery when the bench **still holds** its credentials. A customer who uninstalled and reinstalled the app has no credentials to authenticate the resume with, and is still blocked until the 30-day reaper. That case needs the `reconnect.py` code flow widened to `Pending Payment` and is deliberately not in this PR.

## Verification

Hosted CI is the gate for this repo. Locally, all five guard cases pass against the branch, including the two that were broken.