### PR TITLE
feat(chat): first-chat welcome — a static Jarvis-authored greeting on the empty chat home

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -77,6 +77,17 @@ export const setUserTheme = (theme) => call(US + "set_user_theme", { theme });
 // whose only cost is the introduction appearing once more.
 export const markHomeIntroSeen = (version) =>
 	call(US + "mark_home_intro_seen", { version: version || 0 });
+// Bounded, privacy-free chat-home introduction telemetry (displayed /
+// suggestion_selected / first_prompt). The server allow-lists every field and
+// hashes the caller — no message content, prompt text, or user name is sent.
+// Best-effort: the caller swallows failures, telemetry must never affect chat.
+export const recordHomeIntroEvent = (event, payload) =>
+	call(US + "record_home_intro_event", {
+		event,
+		version: (payload && payload.version) || 0,
+		category: (payload && payload.category) || "",
+		bucket: (payload && payload.bucket) || "",
+	});
 // Jarvis Admin (or System Manager) only — server re-checks independently of
 // the client's window.is_jarvis_admin gate.
 export const adminListUserUsage = () => call(US + "admin_list_user_usage");

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -72,6 +72,11 @@ const US = "jarvis.chat.user_settings_api.";
 export const getMySettings = () => call(US + "get_my_settings");
 export const updateMySettings = (p) => call(US + "update_my_settings", p || {});
 export const setUserTheme = (theme) => call(US + "set_user_theme", { theme });
+// Best-effort ack that the chat-home introduction (the static welcome bubble)
+// was shown. Idempotent + monotonic server-side; the caller swallows failures,
+// whose only cost is the introduction appearing once more.
+export const markHomeIntroSeen = (version) =>
+	call(US + "mark_home_intro_seen", { version: version || 0 });
 // Jarvis Admin (or System Manager) only — server re-checks independently of
 // the client's window.is_jarvis_admin gate.
 export const adminListUserUsage = () => call(US + "admin_list_user_usage");

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import fs from "fs";
+import path from "path";
+
+import WelcomeAssistantMessage from "./WelcomeAssistantMessage.vue";
+
+/**
+ * The static first-chat introduction. Two things are pinned here: the copy
+ * (every truthfulness claim the product committed to, plus its brand/persona
+ * parameterisation) and the honesty of the presentation (no timestamp, no model
+ * badge, no live region, no tool row).
+ */
+
+const props = (over = {}) => ({ speaker: "Jarvis", persona: "Jarvis", firstName: "Vignesh", ...over });
+
+describe("WelcomeAssistantMessage copy", () => {
+	it("greets by first name and signs with the speaker", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props() });
+		expect(w.text()).toContain("Hi Vignesh — I'm Jarvis, your AI teammate inside your ERP.");
+		expect(w.find(".jv-wam-name").text()).toBe("Jarvis");
+	});
+
+	it("is FROM Jara for a Jara user, name and mark together", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Jara", persona: "Jara" }) });
+		expect(w.find(".jv-wam-name").text()).toBe("Jara");
+		expect(w.text()).toContain("I'm Jara, your AI teammate");
+		expect(w.text()).not.toContain("I'm Jarvis");
+		// Jara's own mark, as PersonaPill draws her.
+		expect(w.find(".jv-wam-orb.jara").exists()).toBe(true);
+		expect(w.find(".jv-mark").exists()).toBe(false);
+	});
+
+	it("carries the tenant brand with no hardcoded Jarvis anywhere", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
+		expect(w.find(".jv-wam-name").text()).toBe("Aria");
+		expect(w.text()).toContain("I'm Aria, your AI teammate");
+		expect(w.text()).not.toContain("Jarvis");
+	});
+
+	it("renders the default brand mark for the default persona", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props() });
+		expect(w.find(".jv-mark").exists()).toBe(true);
+		expect(w.find(".jv-wam-orb").exists()).toBe(false);
+	});
+
+	it("falls back to a neutral greeting when the user has no first name", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props({ firstName: "  " }) });
+		expect(w.text()).toContain("Hi there — I'm Jarvis");
+	});
+
+	it("states every capability claim the product committed to, and no more", () => {
+		const t = mount(WelcomeAssistantMessage, { props: props() }).text();
+		// permissions: what it can see, never "all your ERP data"
+		expect(t).toContain("I only see the records your Frappe permissions allow");
+		// propose-and-confirm, honestly hedged: per-conversation auto-apply and the
+		// File Box reversible-write path both exist, so "by default" is load-bearing.
+		expect(t).toContain("by default I propose a change and ask you to confirm");
+		expect(t).toContain("destructive actions always ask");
+		// File Box drops become REVIEWABLE drafts, not silent writes
+		expect(t).toContain("File Box");
+		expect(t).toContain("drafts you review");
+		// dashboards on live data
+		expect(t).toContain("dashboards that read your live data");
+		// hands off rather than lecturing further (TourIntro owns the walkthrough)
+		expect(t).toContain("What would you like to work on?");
+	});
+
+	it("stays short: four sentences, no walkthrough", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props() });
+		expect(w.findAll(".jv-wam-body p")).toHaveLength(4);
+	});
+});
+
+describe("WelcomeAssistantMessage presentation honesty", () => {
+	it("is a labelled region, never a live region", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
+		const root = w.find("section.jv-wam");
+		expect(root.attributes("aria-label")).toBe("Welcome message from Aria");
+		expect(root.attributes("aria-live")).toBeUndefined();
+		expect(root.attributes("role")).toBeUndefined(); // <section> + name IS a region
+		expect(root.attributes("data-presentation-only")).toBe("true");
+	});
+
+	it("claims no timestamp, no model and no tool activity", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props() });
+		const html = w.html();
+		expect(html).not.toContain("jv-msgtime");
+		expect(html).not.toContain("jv-activity");
+		expect(html).not.toContain("jv-tool");
+		expect(w.text()).not.toMatch(/\b(gpt|claude|model)\b/i);
+	});
+
+	it("emits its seen ack exactly once, on render", () => {
+		const w = mount(WelcomeAssistantMessage, { props: props() });
+		expect(w.emitted("seen")).toHaveLength(1);
+	});
+});
+
+/**
+ * ChatView.vue cannot be mounted in a unit test (it is a ~12k-line view with a
+ * socket, a router and two dozen bootstrap calls), so the two gates that live
+ * in its template are pinned at the source level instead. These assertions are
+ * deliberately literal: they fail loudly if someone moves the bubble out of the
+ * empty-state branch or drops the greeting-banner suppression, which is exactly
+ * the regression they exist to catch. They prove wiring, not behaviour.
+ */
+describe("ChatView wiring", () => {
+	const src = fs.readFileSync(
+		path.resolve(__dirname, "../../views/ChatView.vue"),
+		"utf8"
+	);
+
+	it("renders the bubble only inside the empty-state branch", () => {
+		// => it can never draw over a conversation that has messages, which is
+		// what keeps proactive conversations (real persisted rows) showing their
+		// own content instead of a welcome.
+		const branch = src.indexOf('v-else-if="showWelcome"');
+		const bubble = src.indexOf("<WelcomeAssistantMessage");
+		const composer = src.indexOf("<!-- ===== COMPOSER");
+		expect(branch).toBeGreaterThan(-1);
+		expect(bubble).toBeGreaterThan(branch);
+		expect(composer === -1 || bubble < composer).toBe(true);
+		expect(src).toContain('v-if="showHomeIntro"');
+	});
+
+	it("suppresses the business-note banner while the introduction shows", () => {
+		expect(src).toContain('v-if="bizGreeting.show && !showHomeIntro"');
+	});
+
+	it("keeps the suggestion cards below the introduction", () => {
+		expect(src.indexOf("<WelcomeAssistantMessage")).toBeLessThan(
+			src.indexOf('class="jv-welcome-grid"')
+		);
+	});
+});

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 
 import WelcomeAssistantMessage from "./WelcomeAssistantMessage.vue";
+import { homeIntroPersona, homeIntroSpeaker } from "@/lib/homeIntro";
 
 /**
  * The static first-chat introduction. Two things are pinned here: the copy
@@ -18,12 +19,10 @@ describe("WelcomeAssistantMessage copy", () => {
 	it("greets by first name and signs with the speaker", () => {
 		const w = mount(WelcomeAssistantMessage, { props: props() });
 		expect(w.text()).toContain("Hi Vignesh — I'm Jarvis, your AI teammate inside your ERP.");
-		expect(w.find(".jv-wam-name").text()).toBe("Jarvis");
 	});
 
 	it("is FROM Jara for a Jara user, name and mark together", () => {
 		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Jara", persona: "Jara" }) });
-		expect(w.find(".jv-wam-name").text()).toBe("Jara");
 		expect(w.text()).toContain("I'm Jara, your AI teammate");
 		expect(w.text()).not.toContain("I'm Jarvis");
 		// Jara's own mark, as PersonaPill draws her.
@@ -33,9 +32,22 @@ describe("WelcomeAssistantMessage copy", () => {
 
 	it("carries the tenant brand with no hardcoded Jarvis anywhere", () => {
 		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
-		expect(w.find(".jv-wam-name").text()).toBe("Aria");
 		expect(w.text()).toContain("I'm Aria, your AI teammate");
 		expect(w.text()).not.toContain("Jarvis");
+	});
+
+	it("shows the tenant's own mark, not Jara's orb, for a branded Jara user", () => {
+		// The reconciliation end to end: the resolver decides both halves, and the
+		// component must render a brand mark (which is where a tenant logo lands)
+		// alongside the brand name - never an orb beside a brand name.
+		const branded = { agentName: "Aria", isWhitelabeled: true, persona: "Jara" };
+		const persona = homeIntroPersona(branded);
+		const speaker = homeIntroSpeaker({ ...branded, persona });
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker, persona }) });
+		expect(w.find(".jv-mark").exists()).toBe(true);
+		expect(w.find(".jv-wam-orb").exists()).toBe(false);
+		expect(w.text()).toContain("I'm Aria, your AI teammate");
+		expect(w.text()).not.toContain("Jara");
 	});
 
 	it("renders the default brand mark for the default persona", () => {
@@ -82,6 +94,28 @@ describe("WelcomeAssistantMessage presentation honesty", () => {
 		expect(root.attributes("data-presentation-only")).toBe("true");
 	});
 
+	it("draws no visible name line, matching a real assistant turn", () => {
+		// ChatView passes no `sender` to Message.vue, so assistant rows render the
+		// avatar and the body only. A bold name here would make the introduction
+		// look like a different KIND of message than every reply that follows it.
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
+		expect(w.find(".jv-wam-name").exists()).toBe(false);
+		expect(w.find(".jv-wam-who").exists()).toBe(false);
+	});
+
+	it("keeps a heading for screen readers, visually hidden and matching the label", () => {
+		// Replacing the hero <h1> removed the only landmark in the empty state; this
+		// puts one back without printing a name the design does not want.
+		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
+		const h = w.find("h2");
+		expect(h.exists()).toBe(true);
+		expect(h.text()).toBe("Welcome message from Aria");
+		expect(h.text()).toBe(w.find("section.jv-wam").attributes("aria-label"));
+		// Visually hidden, NOT removed from the accessibility tree.
+		expect(h.classes()).toContain("jv-wam-sr");
+		expect(h.attributes("aria-hidden")).toBeUndefined();
+	});
+
 	it("claims no timestamp, no model and no tool activity", () => {
 		const w = mount(WelcomeAssistantMessage, { props: props() });
 		const html = w.html();
@@ -122,6 +156,15 @@ describe("ChatView wiring", () => {
 		expect(bubble).toBeGreaterThan(branch);
 		expect(composer === -1 || bubble < composer).toBe(true);
 		expect(src).toContain('v-if="showHomeIntro"');
+	});
+
+	it("gates the bubble on the empty state AND the pending flag", () => {
+		// The conjunct IS the invariant. `homeIntroPending` alone would draw the
+		// bubble over a live thread; `showWelcome` alone would draw it on every
+		// empty chat forever. Dropping either half is the regression.
+		expect(src).toContain(
+			"const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);"
+		);
 	});
 
 	it("suppresses the business-note banner while the introduction shows", () => {

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -95,7 +95,13 @@ describe("WelcomeAssistantMessage presentation honesty", () => {
 	it("is a labelled region, never a live region", () => {
 		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
 		const root = w.find("section.jv-wam");
-		expect(root.attributes("aria-label")).toBe("Welcome message from Aria");
+		const h = w.find("h1.jv-wam-sr");
+		// The name lives in ONE place — the hidden heading — and the section points
+		// at it with aria-labelledby, so a screen reader announces it once (not the
+		// old region label + heading duplicate).
+		expect(root.attributes("aria-labelledby")).toBe(h.attributes("id"));
+		expect(root.attributes("aria-label")).toBeUndefined();
+		expect(h.text()).toBe("Welcome message from Aria");
 		expect(root.attributes("aria-live")).toBeUndefined();
 		expect(root.attributes("role")).toBeUndefined(); // <section> + name IS a region
 		expect(root.attributes("data-presentation-only")).toBe("true");
@@ -110,17 +116,27 @@ describe("WelcomeAssistantMessage presentation honesty", () => {
 		expect(w.find(".jv-wam-who").exists()).toBe(false);
 	});
 
-	it("keeps a heading for screen readers, visually hidden and matching the label", () => {
-		// Replacing the hero <h1> removed the only landmark in the empty state; this
-		// puts one back without printing a name the design does not want.
+	it("restores a coherent level-one heading, visually hidden", () => {
+		// The compact hero's <h1> is replaced by the intro; the landmark returns as
+		// a visually hidden <h1> (NOT an <h2>), so the empty state keeps a single,
+		// correct top-level heading instead of jumping straight to level 2.
 		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Aria" }) });
-		const h = w.find("h2");
+		expect(w.find("h2").exists()).toBe(false);
+		const h = w.find("h1");
 		expect(h.exists()).toBe(true);
 		expect(h.text()).toBe("Welcome message from Aria");
-		expect(h.text()).toBe(w.find("section.jv-wam").attributes("aria-label"));
 		// Visually hidden, NOT removed from the accessibility tree.
 		expect(h.classes()).toContain("jv-wam-sr");
 		expect(h.attributes("aria-hidden")).toBeUndefined();
+	});
+
+	it("gives each welcome a unique heading id so two on a page never collide", () => {
+		const a = mount(WelcomeAssistantMessage, { props: props() });
+		const b = mount(WelcomeAssistantMessage, { props: props() });
+		const idA = a.find("h1").attributes("id");
+		const idB = b.find("h1").attributes("id");
+		expect(idA).toBeTruthy();
+		expect(idA).not.toBe(idB);
 	});
 
 	it("claims no timestamp, no model and no tool activity", () => {
@@ -140,14 +156,18 @@ describe("WelcomeAssistantMessage presentation honesty", () => {
 
 /**
  * ChatView.vue cannot be mounted in a unit test (it is a ~12k-line view with a
- * socket, a router and two dozen bootstrap calls), so the two gates that live
- * in its template are pinned at the source level instead. These assertions are
- * deliberately literal: they fail loudly if someone moves the bubble out of the
- * empty-state branch or drops the greeting-banner suppression, which is exactly
- * the regression they exist to catch. They prove wiring, not behaviour.
+ * socket, a router and two dozen bootstrap calls), so the template GATES it owns
+ * are pinned at the source level. The boot/latch/ack BEHAVIOUR now lives in the
+ * useHomeIntro composable and is executed in composables/useHomeIntro.spec.js —
+ * these assertions are honestly labelled architectural tripwires (placement and
+ * wiring), not the lifecycle matrix.
  */
-describe("ChatView wiring", () => {
+describe("ChatView wiring (source tripwires, not behaviour)", () => {
 	const src = fs.readFileSync(path.resolve(__dirname, "../../views/ChatView.vue"), "utf8");
+	const composable = fs.readFileSync(
+		path.resolve(__dirname, "../../composables/useHomeIntro.js"),
+		"utf8"
+	);
 
 	it("renders the bubble only inside the empty-state branch", () => {
 		// => it can never draw over a conversation that has messages, which is
@@ -162,11 +182,17 @@ describe("ChatView wiring", () => {
 		expect(src).toContain('v-if="showHomeIntro"');
 	});
 
-	it("gates the bubble on the empty state AND the pending flag", () => {
+	it("drives the intro state from the extracted composable, not inline in the view", () => {
+		expect(src).toContain('import { useHomeIntro } from "@/composables/useHomeIntro"');
+		expect(src).toContain("} = useHomeIntro({");
+		expect(src).toContain("initHomeIntro();"); // boot init call
+	});
+
+	it("gates the bubble on the empty state AND the pending flag (in the composable)", () => {
 		// The conjunct IS the invariant. `homeIntroPending` alone would draw the
 		// bubble over a live thread; `showWelcome` alone would draw it on every
 		// empty chat forever. Dropping either half is the regression.
-		expect(src).toContain(
+		expect(composable).toContain(
 			"const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);"
 		);
 	});
@@ -179,5 +205,25 @@ describe("ChatView wiring", () => {
 		expect(src.indexOf("<WelcomeAssistantMessage")).toBeLessThan(
 			src.indexOf('class="jv-welcome-grid"')
 		);
+	});
+
+	it("moves the welcome viewport off inline styles onto overflow-safe classes", () => {
+		// P1-01: the scroll viewport must not centre with justify-content:center
+		// (unsafe centring clips the top when the content overflows). Classes, not
+		// inline styles, so the overflow-safe rules can win and tests can target it.
+		expect(src).toContain('class="jv-welcome-scroll"');
+		expect(src).toContain('class="jv-welcome-col"');
+		expect(src).toContain("justify-content: flex-start;");
+		expect(src).toContain("margin-block: auto;");
+	});
+
+	it("routes suggestion clicks through the fill+telemetry wrapper and still fills, never sends", () => {
+		expect(src).toContain('@click="onWelcomeSuggestion(s)"');
+		// The wrapper records the category then FILLS the composer — it must not send.
+		const fn = src.slice(src.indexOf("function onWelcomeSuggestion"));
+		const body = fn.slice(0, fn.indexOf("}") + 1);
+		expect(body).toContain("noteWelcomeSuggestion(");
+		expect(body).toContain("fillInput(s.prompt)");
+		expect(body).not.toContain("sendMessage");
 	});
 });

--- a/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.spec.js
@@ -13,7 +13,12 @@ import { homeIntroPersona, homeIntroSpeaker } from "@/lib/homeIntro";
  * badge, no live region, no tool row).
  */
 
-const props = (over = {}) => ({ speaker: "Jarvis", persona: "Jarvis", firstName: "Vignesh", ...over });
+const props = (over = {}) => ({
+	speaker: "Jarvis",
+	persona: "Jarvis",
+	firstName: "Vignesh",
+	...over,
+});
 
 describe("WelcomeAssistantMessage copy", () => {
 	it("greets by first name and signs with the speaker", () => {
@@ -22,7 +27,9 @@ describe("WelcomeAssistantMessage copy", () => {
 	});
 
 	it("is FROM Jara for a Jara user, name and mark together", () => {
-		const w = mount(WelcomeAssistantMessage, { props: props({ speaker: "Jara", persona: "Jara" }) });
+		const w = mount(WelcomeAssistantMessage, {
+			props: props({ speaker: "Jara", persona: "Jara" }),
+		});
 		expect(w.text()).toContain("I'm Jara, your AI teammate");
 		expect(w.text()).not.toContain("I'm Jarvis");
 		// Jara's own mark, as PersonaPill draws her.
@@ -140,10 +147,7 @@ describe("WelcomeAssistantMessage presentation honesty", () => {
  * the regression they exist to catch. They prove wiring, not behaviour.
  */
 describe("ChatView wiring", () => {
-	const src = fs.readFileSync(
-		path.resolve(__dirname, "../../views/ChatView.vue"),
-		"utf8"
-	);
+	const src = fs.readFileSync(path.resolve(__dirname, "../../views/ChatView.vue"), "utf8");
 
 	it("renders the bubble only inside the empty-state branch", () => {
 		// => it can never draw over a conversation that has messages, which is

--- a/frontend/src/components/chat/WelcomeAssistantMessage.vue
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.vue
@@ -20,20 +20,20 @@
       page content on arrival, not as an update being announced.
 
   Visually it is the same shell as a real assistant message (Message.vue's
-  variant="row"): avatar column, identity line, 14px/1.6 body. The identity-line
-  and body rules are copied rather than imported because Vue scopes styles per
-  component and Message.vue's are not exported.
+  variant="row"): avatar column and 14px/1.6 body, with NO visible name line -
+  chat's assistant passes no `sender`, so its rows draw none either, and the
+  avatar is the identity. The body rules are copied rather than imported because
+  Vue scopes styles per component and Message.vue's are not exported.
 -->
 <template>
-	<section
-		class="jv-wam"
-		data-presentation-only="true"
-		:aria-label="`Welcome message from ${speaker}`"
-	>
+	<section class="jv-wam" data-presentation-only="true" :aria-label="regionLabel">
 		<div class="jv-wam-avatar">
 			<!-- Persona-consistent mark, mirroring PersonaPill (the only other place
-			     the app draws a persona): Jarvis renders the brand mark, which is
-			     itself whitelabel-aware; Jara renders her star orb. -->
+			     the app draws a persona): the default renders the brand mark, which
+			     is itself whitelabel-aware (a tenant logo lands HERE); Jara renders
+			     her star orb. `persona` arrives already reconciled with the brand by
+			     lib/homeIntro.homeIntroPersona, so a whitelabelled workspace can
+			     never show Jara's orb where its own logo belongs. -->
 			<JarvisMark v-if="persona !== 'Jara'" :size="28" :radius="7" />
 			<span v-else class="jv-wam-orb jara" aria-hidden="true">
 				<svg viewBox="0 0 24 24" fill="#fff">
@@ -42,9 +42,14 @@
 			</span>
 		</div>
 		<div class="jv-wam-col">
-			<div class="jv-wam-who">
-				<b class="jv-wam-name">{{ speaker }}</b>
-			</div>
+			<!-- Identity is the avatar, exactly as a real assistant turn renders it
+			     (ChatView passes no `sender` to Message.vue, so no name line is drawn
+			     there either) - a bold name here would make the introduction look
+			     like a different kind of message than every reply that follows.
+			     The heading survives visually hidden: it restores the landmark that
+			     replacing the hero <h1> removed, so screen-reader heading navigation
+			     still lands on this region. Same text as the section's aria-label. -->
+			<h2 class="jv-wam-sr">{{ regionLabel }}</h2>
 			<div class="jv-wam-body">
 				<p>Hi {{ greetingName }} — I'm {{ speaker }}, your AI teammate inside your ERP.</p>
 				<p>
@@ -72,8 +77,9 @@ const props = defineProps({
 	// resolved by lib/homeIntro.homeIntroSpeaker so this component holds no
 	// branding/persona precedence logic of its own.
 	speaker: { type: String, required: true },
-	// "Jarvis" | "Jara", already gated by the persona kill switch. Drives the
-	// avatar only; the name comes from `speaker`.
+	// "Jarvis" | "Jara", already reconciled with the tenant brand and gated by
+	// the persona kill switch (lib/homeIntro.homeIntroPersona). Drives the avatar
+	// only; the name comes from `speaker`, which the same resolver pair decides.
 	persona: { type: String, default: "Jarvis" },
 	firstName: { type: String, default: "" },
 });
@@ -81,6 +87,9 @@ const props = defineProps({
 // A blank/absent first name (a fresh User with no full name) must not render
 // "Hi  — I'm …".
 const greetingName = computed(() => (props.firstName || "").trim() || "there");
+// One string, two consumers (the section's accessible name and the hidden
+// heading) so they can never drift apart.
+const regionLabel = computed(() => `Welcome message from ${props.speaker}`);
 
 // Best-effort seen-ack, fired once when the bubble actually reaches the DOM.
 // The parent owns the request; a failure there is swallowed and simply means
@@ -104,16 +113,20 @@ onMounted(() => emit("seen"));
 	flex: 1;
 	min-width: 0;
 }
-.jv-wam-who {
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
-	margin-bottom: 4px;
-}
-.jv-wam-name {
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--text);
+/* Visually hidden, still in the accessibility tree (same recipe as ChatView's
+   .jv-sr live region). Not `display: none` / `visibility: hidden`, which would
+   take the heading out of the tree along with the pixels. */
+.jv-wam-sr {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	white-space: nowrap;
+	border: 0;
 }
 .jv-wam-body {
 	font-size: 14px;

--- a/frontend/src/components/chat/WelcomeAssistantMessage.vue
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.vue
@@ -1,0 +1,163 @@
+<!--
+  The first-chat introduction: a static, assistant-styled welcome bubble.
+
+  PRESENTATION ONLY, and the rationale is a data contract, not a preference.
+  A persisted assistant row here would (a) un-hide every abandoned empty chat in
+  the sidebar, which lists only conversations that have messages, (b) change
+  File Box's status derivation, which reads message rows, (c) defeat empty-row
+  reuse (create_or_focus_empty) and the empty-conversation reaper, both of which
+  key on "zero messages", and (d) put text the model never produced into the
+  turn/pump state. So this component renders inside ChatView's existing
+  `showWelcome` branch and writes nothing: no Jarvis Chat Message, no
+  conversation, no openclaw session, no tokens.
+
+  Consequences of that honesty, all deliberate:
+    - no timestamp and no model badge: nothing generated this, so there is
+      nothing to stamp it with;
+    - no typewriter/streaming animation: it must not impersonate a live turn;
+    - no activity/tool row: no tools ran;
+    - it is a labelled REGION, not a live region — a screen reader meets it as
+      page content on arrival, not as an update being announced.
+
+  Visually it is the same shell as a real assistant message (Message.vue's
+  variant="row"): avatar column, identity line, 14px/1.6 body. The identity-line
+  and body rules are copied rather than imported because Vue scopes styles per
+  component and Message.vue's are not exported.
+-->
+<template>
+	<section
+		class="jv-wam"
+		data-presentation-only="true"
+		:aria-label="`Welcome message from ${speaker}`"
+	>
+		<div class="jv-wam-avatar">
+			<!-- Persona-consistent mark, mirroring PersonaPill (the only other place
+			     the app draws a persona): Jarvis renders the brand mark, which is
+			     itself whitelabel-aware; Jara renders her star orb. -->
+			<JarvisMark v-if="persona !== 'Jara'" :size="28" :radius="7" />
+			<span v-else class="jv-wam-orb jara" aria-hidden="true">
+				<svg viewBox="0 0 24 24" fill="#fff">
+					<path d="M12 2.5 L14 10 L21.5 12 L14 14 L12 21.5 L10 14 L2.5 12 L10 10 Z" />
+				</svg>
+			</span>
+		</div>
+		<div class="jv-wam-col">
+			<div class="jv-wam-who">
+				<b class="jv-wam-name">{{ speaker }}</b>
+			</div>
+			<div class="jv-wam-body">
+				<p>Hi {{ greetingName }} — I'm {{ speaker }}, your AI teammate inside your ERP.</p>
+				<p>
+					I only see the records your Frappe permissions allow, and by default I propose
+					a change and ask you to confirm before it's applied — destructive actions
+					always ask.
+				</p>
+				<p>
+					Drop invoices, statements or spreadsheets into
+					<strong>File Box</strong> and I'll turn them into drafts you review, and I can
+					build dashboards that read your live data.
+				</p>
+				<p>What would you like to work on?</p>
+			</div>
+		</div>
+	</section>
+</template>
+
+<script setup>
+import { computed, onMounted } from "vue";
+import JarvisMark from "@/components/JarvisMark.vue";
+
+const props = defineProps({
+	// Who the bubble is from — the tenant brand or the user's persona, already
+	// resolved by lib/homeIntro.homeIntroSpeaker so this component holds no
+	// branding/persona precedence logic of its own.
+	speaker: { type: String, required: true },
+	// "Jarvis" | "Jara", already gated by the persona kill switch. Drives the
+	// avatar only; the name comes from `speaker`.
+	persona: { type: String, default: "Jarvis" },
+	firstName: { type: String, default: "" },
+});
+
+// A blank/absent first name (a fresh User with no full name) must not render
+// "Hi  — I'm …".
+const greetingName = computed(() => (props.firstName || "").trim() || "there");
+
+// Best-effort seen-ack, fired once when the bubble actually reaches the DOM.
+// The parent owns the request; a failure there is swallowed and simply means
+// the introduction may appear again. It must never gate the composer.
+const emit = defineEmits(["seen"]);
+onMounted(() => emit("seen"));
+</script>
+
+<style scoped>
+.jv-wam {
+	display: flex;
+	gap: 12px;
+	text-align: left;
+	margin: 0 0 26px;
+}
+.jv-wam-avatar {
+	flex: none;
+	margin-top: 2px;
+}
+.jv-wam-col {
+	flex: 1;
+	min-width: 0;
+}
+.jv-wam-who {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+.jv-wam-name {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text);
+}
+.jv-wam-body {
+	font-size: 14px;
+	line-height: 1.6;
+	color: var(--text);
+	overflow-wrap: anywhere;
+}
+.jv-wam-body p {
+	margin: 0 0 10px;
+}
+.jv-wam-body p:last-child {
+	margin-bottom: 0;
+}
+.jv-wam-body strong {
+	font-weight: 600;
+}
+
+/* Jara's mark, same geometry/gradient as PersonaPill's orb so the two surfaces
+   cannot drift. Theme-invariant by construction: a fixed gradient with a white
+   glyph reads identically in light and dark, exactly like .jv-mark. */
+.jv-wam-orb {
+	display: grid;
+	place-items: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 7px;
+}
+.jv-wam-orb.jara {
+	background: radial-gradient(
+			circle at 34% 30%,
+			rgba(255, 255, 255, 0.55),
+			rgba(255, 255, 255, 0) 60%
+		),
+		linear-gradient(140deg, #9d7cea, #6846e3);
+}
+.jv-wam-orb svg {
+	width: 55%;
+	height: 55%;
+	filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.22));
+}
+
+@media (max-width: 640px) {
+	.jv-wam {
+		margin-bottom: 20px;
+	}
+}
+</style>

--- a/frontend/src/components/chat/WelcomeAssistantMessage.vue
+++ b/frontend/src/components/chat/WelcomeAssistantMessage.vue
@@ -26,7 +26,7 @@
   Vue scopes styles per component and Message.vue's are not exported.
 -->
 <template>
-	<section class="jv-wam" data-presentation-only="true" :aria-label="regionLabel">
+	<section class="jv-wam" data-presentation-only="true" :aria-labelledby="headingId">
 		<div class="jv-wam-avatar">
 			<!-- Persona-consistent mark, mirroring PersonaPill (the only other place
 			     the app draws a persona): the default renders the brand mark, which
@@ -46,10 +46,13 @@
 			     (ChatView passes no `sender` to Message.vue, so no name line is drawn
 			     there either) - a bold name here would make the introduction look
 			     like a different kind of message than every reply that follows.
-			     The heading survives visually hidden: it restores the landmark that
-			     replacing the hero <h1> removed, so screen-reader heading navigation
-			     still lands on this region. Same text as the section's aria-label. -->
-			<h2 class="jv-wam-sr">{{ regionLabel }}</h2>
+			     The heading survives visually hidden as an <h1>: it RESTORES the
+			     level-one landmark that replacing the compact hero's <h1> removed, so
+			     the empty state keeps a coherent heading hierarchy and screen-reader
+			     heading navigation still lands here. It is ALSO the region's single
+			     accessible name (the section points at it with aria-labelledby), so
+			     the name is stated exactly once — no duplicate aria-label. -->
+			<h1 :id="headingId" class="jv-wam-sr">{{ regionLabel }}</h1>
 			<div class="jv-wam-body">
 				<p>Hi {{ greetingName }} — I'm {{ speaker }}, your AI teammate inside your ERP.</p>
 				<p>
@@ -69,7 +72,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from "vue";
+import { computed, onMounted, getCurrentInstance } from "vue";
 import JarvisMark from "@/components/JarvisMark.vue";
 
 const props = defineProps({
@@ -87,8 +90,12 @@ const props = defineProps({
 // A blank/absent first name (a fresh User with no full name) must not render
 // "Hi  — I'm …".
 const greetingName = computed(() => (props.firstName || "").trim() || "there");
-// One string, two consumers (the section's accessible name and the hidden
-// heading) so they can never drift apart.
+// The region's accessible name lives in exactly ONE place: the visually hidden
+// <h1>. The section names itself through aria-labelledby pointing at it, so the
+// name is announced once (region + heading no longer duplicate it). Vue 3.4 has
+// no useId; the component instance uid is unique and stable, so two welcomes on
+// one page never share an id.
+const headingId = `jv-wam-h-${getCurrentInstance()?.uid ?? 0}`;
 const regionLabel = computed(() => `Welcome message from ${props.speaker}`);
 
 // Best-effort seen-ack, fired once when the bubble actually reaches the DOM.

--- a/frontend/src/composables/useHomeIntro.js
+++ b/frontend/src/composables/useHomeIntro.js
@@ -1,0 +1,161 @@
+// The chat-home introduction's boot/latch/ack transition, extracted from
+// ChatView.vue so it can be behaviour-tested without mounting the ~12k-line
+// view. It owns ONLY the intro state seam — nothing else about ChatView.
+//
+// What it does NOT change (the architecture is approved and preserved):
+//   - the bubble is presentation only (WelcomeAssistantMessage.vue); this
+//     composable persists nothing but the best-effort server "seen" ack;
+//   - it renders strictly inside ChatView's existing `showWelcome` branch, so
+//     an empty conversation stays empty and a conversation with messages (a
+//     proactive one included) never draws it;
+//   - the ack is fire-and-forget and must never gate the composer.
+//
+// Dependencies are passed as refs/getters so the composable is pure w.r.t.
+// ChatView and testable with plain refs:
+//   showWelcome    Ref<boolean>   — the empty-state branch is active
+//   booting        Ref<boolean>   — initial conversation load in flight
+//   visibleCount   () => number   — visibleMessages.length
+//   ui             Ref<object>    — the get_chat_ui_settings boot payload
+//   isWhitelabeled boolean        — @/branding compound flag (name OR logo)
+//   agentName      string         — @/branding tenant brand name
+//   getPersona     () => string   — the user's preferred persona (store)
+//   markSeen       (v) => Promise — api.markHomeIntroSeen (injected for tests)
+//   emitTelemetry  (event, data)  — bounded UI telemetry sink (optional)
+import { ref, computed, watch } from "vue";
+
+import {
+	homeIntroDue,
+	homeIntroPersona as resolveHomeIntroPersona,
+	homeIntroSpeaker,
+} from "@/lib/homeIntro";
+
+// Coarse, privacy-bounded buckets for time-from-display-to-first-prompt. A
+// bucket label ships, never a raw duration, so no individual session timing is
+// reconstructable from the telemetry.
+export function timeToPromptBucket(ms) {
+	if (!Number.isFinite(ms) || ms < 0) return "unknown";
+	if (ms < 5000) return "0-5s";
+	if (ms < 15000) return "5-15s";
+	if (ms < 60000) return "15-60s";
+	if (ms < 300000) return "1-5m";
+	return "5m+";
+}
+
+export function useHomeIntro({
+	showWelcome,
+	booting,
+	visibleCount,
+	ui,
+	isWhitelabeled,
+	agentName,
+	getPersona,
+	markSeen,
+	emitTelemetry,
+} = {}) {
+	const homeIntroPending = ref(false);
+	const homeIntroVersion = ref(0);
+	// Session-global latches: the ack fires once, and time-to-first-prompt is
+	// noted once, per ChatView lifetime (a full page bootstrap resets them).
+	let _acked = false;
+	let _displayedAt = 0;
+	let _firstPromptNoted = false;
+
+	const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);
+
+	// Persona drives the avatar and (on an unbranded workspace) the name. Both
+	// the whitelabel and kill-switch rules live in one resolver so the mark and
+	// the name are decided from the same predicate — a logo-only tenant gets its
+	// own logo, never Jara's orb beside a brand name.
+	const homeIntroPersona = computed(() =>
+		resolveHomeIntroPersona({
+			isWhitelabeled,
+			personaEnabled: ui && ui.value ? ui.value.persona_enabled : undefined,
+			persona: typeof getPersona === "function" ? getPersona() : undefined,
+		})
+	);
+	const homeIntroSpeakerName = computed(() =>
+		homeIntroSpeaker({ agentName, isWhitelabeled, persona: homeIntroPersona.value })
+	);
+
+	// Decided ONCE from the boot payload (both numbers land in `ui` before
+	// booting flips false, so the bubble can never flash in or out).
+	function initFromBoot() {
+		const u = (ui && ui.value) || {};
+		homeIntroVersion.value = Number(u.home_intro_version) || 0;
+		homeIntroPending.value = homeIntroDue(u);
+	}
+
+	function _tel(event, payload) {
+		if (typeof emitTelemetry !== "function") return;
+		try {
+			emitTelemetry(event, payload || {});
+		} catch (e) {
+			/* telemetry must never affect chat */
+		}
+	}
+
+	// The intro retiring because a real message appeared on the empty home IS
+	// the first accepted prompt for this session. Guarded by _displayedAt so
+	// opening an existing chat (intro never displayed, _displayedAt still 0)
+	// records nothing — and a genuinely-new user, who is the intro's audience,
+	// has no prior chats to open, so the confound population is essentially
+	// empty.
+	function _noteFirstPrompt() {
+		if (_firstPromptNoted || !_displayedAt) return;
+		_firstPromptNoted = true;
+		_tel("first_prompt", {
+			version: homeIntroVersion.value,
+			bucket: timeToPromptBucket(Date.now() - _displayedAt),
+		});
+	}
+
+	// `!booting`: the boot restore of the last conversation must NOT count as
+	// "the user has moved on" — otherwise an existing user (seen version 0, or a
+	// later version bump) would retire the introduction before ever reaching the
+	// empty home it renders on, and would never see it at all.
+	watch(
+		() => visibleCount(),
+		(n) => {
+			if (booting.value || n <= 0) return;
+			if (homeIntroPending.value) {
+				_noteFirstPrompt();
+				homeIntroPending.value = false;
+			}
+		}
+	);
+
+	// Best-effort seen-ack + the "displayed" telemetry, fired once when the
+	// bubble actually reaches the DOM. A failed ack only means the introduction
+	// may appear again on a later page load; it must never stand between the
+	// user and the composer, so the request is fire-and-forget.
+	function ackHomeIntro() {
+		if (_acked) return;
+		_acked = true;
+		_displayedAt = Date.now();
+		_tel("displayed", { version: homeIntroVersion.value });
+		if (typeof markSeen === "function") {
+			try {
+				Promise.resolve(markSeen(homeIntroVersion.value)).catch(() => {});
+			} catch (e) {
+				/* a synchronous throw from the transport must not reach the UI */
+			}
+		}
+	}
+
+	// A welcome suggestion card was chosen. Category token only — never the
+	// prompt text or any user content.
+	function noteSuggestionSelected(category) {
+		_tel("suggestion_selected", { category: String(category || "").slice(0, 40) });
+	}
+
+	return {
+		homeIntroPending,
+		homeIntroVersion,
+		showHomeIntro,
+		homeIntroPersona,
+		homeIntroSpeakerName,
+		initFromBoot,
+		ackHomeIntro,
+		noteSuggestionSelected,
+	};
+}

--- a/frontend/src/composables/useHomeIntro.spec.js
+++ b/frontend/src/composables/useHomeIntro.spec.js
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref, nextTick } from "vue";
+
+import { useHomeIntro, timeToPromptBucket } from "./useHomeIntro.js";
+
+/**
+ * The first-chat introduction's boot/latch/ack transition, extracted from
+ * ChatView so it can be behaviour-tested (P1-03 in the round-two review). These
+ * are the lifecycle cases the old source-string "integration" checks could not
+ * execute: boot, fail-quiet skew, ack success/failure, accepted first send,
+ * later New Chat, version bump, proactive-thread suppression, and the bounded
+ * telemetry. The pure resolvers/copy stay pinned in lib/homeIntro.spec.js and
+ * WelcomeAssistantMessage.spec.js.
+ */
+
+function harness(over = {}) {
+	const showWelcome = over.showWelcome ?? ref(true);
+	const booting = over.booting ?? ref(false);
+	const count = over.count ?? ref(0);
+	const ui = over.ui ?? ref({ home_intro_version: 1, home_intro_seen_version: 0 });
+	const markSeen = over.markSeen ?? vi.fn(() => Promise.resolve());
+	const emitTelemetry = over.emitTelemetry ?? vi.fn();
+	const getPersona = over.getPersona ?? (() => "Jarvis");
+	const intro = useHomeIntro({
+		showWelcome,
+		booting,
+		visibleCount: () => count.value,
+		ui,
+		isWhitelabeled: over.isWhitelabeled ?? false,
+		agentName: over.agentName ?? "Jarvis",
+		getPersona,
+		markSeen,
+		emitTelemetry,
+	});
+	return { intro, showWelcome, booting, count, ui, markSeen, emitTelemetry };
+}
+
+describe("useHomeIntro — boot decision", () => {
+	it("offers the full welcome to an unseen user on an empty home", () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(true);
+	});
+
+	it("shows the compact hero once the user has acknowledged the current version", () => {
+		const h = harness({ ui: ref({ home_intro_version: 1, home_intro_seen_version: 1 }) });
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+
+	it("re-offers exactly once after a version bump", () => {
+		const h = harness({ ui: ref({ home_intro_version: 2, home_intro_seen_version: 1 }) });
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(true);
+	});
+
+	it("fails quiet to the compact hero when the seen version could not be read", () => {
+		// get_chat_ui_settings OMITS the key on a read failure; the intro must not
+		// re-lecture an established user because a read blipped.
+		const h = harness({ ui: ref({ home_intro_version: 1 }) });
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+
+	it("fails quiet against a backend that predates the feature", () => {
+		const h = harness({ ui: ref({}) });
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+
+	it("treats a home_intro_version of 0 (operator kill switch off) as not due", () => {
+		const h = harness({ ui: ref({ home_intro_version: 0, home_intro_seen_version: 0 }) });
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+});
+
+describe("useHomeIntro — latch and retire", () => {
+	it("never draws over a conversation that has messages (proactive included)", async () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		// A proactive/existing thread: showWelcome is false because messages exist.
+		h.showWelcome.value = false;
+		h.count.value = 1;
+		await nextTick();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+
+	it("retires the moment the first real message is on screen", async () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		expect(h.intro.showHomeIntro.value).toBe(true);
+		h.count.value = 1; // the user's optimistic first bubble
+		await nextTick();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+
+	it("does NOT retire during boot (restoring the last conversation is not 'moved on')", async () => {
+		const h = harness({ booting: ref(true) });
+		h.intro.initFromBoot();
+		h.count.value = 3; // boot restore of an existing thread
+		await nextTick();
+		// Still pending; a later empty home must be able to show it.
+		h.booting.value = false;
+		h.showWelcome.value = true;
+		h.count.value = 0;
+		await nextTick();
+		expect(h.intro.showHomeIntro.value).toBe(true);
+	});
+
+	it("stays retired for a later New Chat (compact hero, not the full welcome)", async () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		h.count.value = 1; // first send
+		await nextTick();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+		// New Chat: an empty home again, but the intro is latched off for the session.
+		h.count.value = 0;
+		await nextTick();
+		expect(h.intro.showHomeIntro.value).toBe(false);
+	});
+});
+
+describe("useHomeIntro — best-effort acknowledgement", () => {
+	it("acks the current version exactly once, on render", () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		h.intro.ackHomeIntro();
+		h.intro.ackHomeIntro();
+		expect(h.markSeen).toHaveBeenCalledTimes(1);
+		expect(h.markSeen).toHaveBeenCalledWith(1);
+	});
+
+	it("swallows an ack failure and keeps the welcome usable until a real message", async () => {
+		const markSeen = vi.fn(() => Promise.reject(new Error("network")));
+		const h = harness({ markSeen });
+		h.intro.initFromBoot();
+		// Must not throw even though the transport rejects.
+		expect(() => h.intro.ackHomeIntro()).not.toThrow();
+		await Promise.resolve();
+		expect(markSeen).toHaveBeenCalledTimes(1);
+		// The composer is never gated by the ack: the welcome is still up.
+		expect(h.intro.showHomeIntro.value).toBe(true);
+	});
+
+	it("survives a synchronous throw from the transport", () => {
+		const markSeen = vi.fn(() => {
+			throw new Error("boom");
+		});
+		const h = harness({ markSeen });
+		h.intro.initFromBoot();
+		expect(() => h.intro.ackHomeIntro()).not.toThrow();
+	});
+});
+
+describe("useHomeIntro — bounded telemetry", () => {
+	it("emits 'displayed' with the version on ack", () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		h.intro.ackHomeIntro();
+		expect(h.emitTelemetry).toHaveBeenCalledWith("displayed", { version: 1 });
+	});
+
+	it("emits 'suggestion_selected' with a category token only", () => {
+		const h = harness();
+		h.intro.noteSuggestionSelected("analyse");
+		expect(h.emitTelemetry).toHaveBeenCalledWith("suggestion_selected", {
+			category: "analyse",
+		});
+	});
+
+	it("emits 'first_prompt' with a bucket when a displayed intro retires", async () => {
+		const h = harness();
+		h.intro.initFromBoot();
+		h.intro.ackHomeIntro(); // displayed
+		h.emitTelemetry.mockClear();
+		h.count.value = 1; // first prompt
+		await nextTick();
+		expect(h.emitTelemetry).toHaveBeenCalledTimes(1);
+		const [event, payload] = h.emitTelemetry.mock.calls[0];
+		expect(event).toBe("first_prompt");
+		expect(payload.version).toBe(1);
+		expect(payload.bucket).toBe("0-5s");
+	});
+
+	it("does NOT emit 'first_prompt' when the intro was never displayed", async () => {
+		// Opening an existing chat from the home: the intro never rendered here, so
+		// there is no display-to-prompt duration to report.
+		const h = harness();
+		h.intro.initFromBoot();
+		// no ackHomeIntro() -> never displayed
+		h.count.value = 1;
+		await nextTick();
+		const events = h.emitTelemetry.mock.calls.map((c) => c[0]);
+		expect(events).not.toContain("first_prompt");
+	});
+
+	it("a telemetry sink that throws never affects the ack or the latch", () => {
+		const emitTelemetry = vi.fn(() => {
+			throw new Error("telemetry down");
+		});
+		const markSeen = vi.fn(() => Promise.resolve());
+		const h = harness({ emitTelemetry, markSeen });
+		h.intro.initFromBoot();
+		expect(() => h.intro.ackHomeIntro()).not.toThrow();
+		expect(markSeen).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("useHomeIntro — identity resolution", () => {
+	it("greets a Jara user as Jara on an unbranded workspace", () => {
+		const h = harness({ getPersona: () => "Jara" });
+		expect(h.intro.homeIntroPersona.value).toBe("Jara");
+		expect(h.intro.homeIntroSpeakerName.value).toBe("Jara");
+	});
+
+	it("lets the tenant brand win over the persona, with the brand mark", () => {
+		const h = harness({ isWhitelabeled: true, agentName: "Aria", getPersona: () => "Jara" });
+		expect(h.intro.homeIntroPersona.value).toBe("Jarvis"); // => brand mark
+		expect(h.intro.homeIntroSpeakerName.value).toBe("Aria"); // => brand name
+	});
+
+	it("honours the persona kill switch from the boot payload", () => {
+		const h = harness({
+			ui: ref({ home_intro_version: 1, home_intro_seen_version: 0, persona_enabled: false }),
+			getPersona: () => "Jara",
+		});
+		expect(h.intro.homeIntroPersona.value).toBe("Jarvis");
+	});
+});
+
+describe("timeToPromptBucket", () => {
+	it("buckets coarsely and never leaks a raw duration", () => {
+		expect(timeToPromptBucket(0)).toBe("0-5s");
+		expect(timeToPromptBucket(4999)).toBe("0-5s");
+		expect(timeToPromptBucket(5000)).toBe("5-15s");
+		expect(timeToPromptBucket(20000)).toBe("15-60s");
+		expect(timeToPromptBucket(120000)).toBe("1-5m");
+		expect(timeToPromptBucket(600000)).toBe("5m+");
+	});
+
+	it("returns 'unknown' for a non-finite or negative input", () => {
+		expect(timeToPromptBucket(-1)).toBe("unknown");
+		expect(timeToPromptBucket(NaN)).toBe("unknown");
+		expect(timeToPromptBucket(undefined)).toBe("unknown");
+	});
+});

--- a/frontend/src/lib/homeIntro.js
+++ b/frontend/src/lib/homeIntro.js
@@ -32,6 +32,32 @@ export function homeIntroDue(ui) {
 }
 
 /**
+ * Which persona the bubble RENDERS AS — the avatar, and (through
+ * homeIntroSpeaker) the name.
+ *
+ * `isWhitelabeled` is @/branding's compound flag: true when the tenant has set
+ * a custom agent name OR uploaded a logo. Either one makes the brand the
+ * identity, so the persona is forced back to the default and JarvisMark draws
+ * the tenant's own logo. Without this, a logo-only tenant whose user prefers
+ * Jara would get Jara's purple orb where their logo belongs, and (via
+ * homeIntroSpeaker, which already defers to the brand) a name that disagrees
+ * with the mark beside it. Name and avatar are decided from the same predicate
+ * here so they cannot drift apart.
+ *
+ * `personaEnabled` is the Jarvis Settings kill switch as reported by the boot
+ * payload: off means turns answer in the default voice, so the bubble must not
+ * present itself as Jara either. `undefined` (an older backend that does not
+ * send the key) reads as ON, matching the rest of the SPA.
+ *
+ * @param {{isWhitelabeled?: boolean, personaEnabled?: boolean, persona?: string}} arg
+ */
+export function homeIntroPersona({ isWhitelabeled, personaEnabled, persona } = {}) {
+	if (isWhitelabeled) return DEFAULT_NAME;
+	if (personaEnabled === false) return DEFAULT_NAME;
+	return persona === "Jara" ? "Jara" : DEFAULT_NAME;
+}
+
+/**
  * Who the bubble is FROM.
  *
  * Two independent identities meet here and the precedence matters:
@@ -45,9 +71,10 @@ export function homeIntroDue(ui) {
  *     there simply greets a Jara user as Jara — which is the whole point of the
  *     preference.
  *
- * `persona` must already be gated by the persona kill switch by the caller: a
- * bench with persona_enabled off answers in the default voice, so the bubble
- * must not sign a name the turns will not use.
+ * `persona` is expected to be homeIntroPersona()'s output, which has already
+ * applied the whitelabel and kill-switch rules; the `isWhitelabeled` check is
+ * kept here too so the two can never disagree even if a caller passes a raw
+ * preference.
  *
  * @param {{agentName?: string, isWhitelabeled?: boolean, persona?: string}} arg
  */

--- a/frontend/src/lib/homeIntro.js
+++ b/frontend/src/lib/homeIntro.js
@@ -1,0 +1,58 @@
+// The chat-home introduction (WelcomeAssistantMessage.vue): the two decisions
+// that must be testable without mounting ChatView.vue, kept as pure functions.
+//
+// The bubble is PRESENTATION ONLY. It is not a Jarvis Chat Message, it creates
+// no conversation and no session, and it renders strictly inside the existing
+// `showWelcome` branch — so an empty conversation stays empty (create_or_focus_
+// empty still reuses it, the reaper still collects it, the first send is still
+// seq=1) and a conversation that HAS messages (a proactive one included) can
+// never draw it.
+
+const DEFAULT_NAME = "Jarvis";
+
+/**
+ * Is the introduction due for this user, per the chat UI settings bootstrap?
+ *
+ * Both numbers come from the server (`get_chat_ui_settings`): `home_intro_
+ * version` is what the SPA should render, `home_intro_seen_version` is what
+ * this user has already acknowledged. The server OMITS the seen key when it
+ * could not read it, and an older backend sends neither — either way the
+ * comparison yields false and the ordinary compact hero renders. That is the
+ * deliberate fail-quiet direction: repeating the introduction is a nuisance,
+ * but re-lecturing an established user because a read blipped is worse.
+ *
+ * @param {{home_intro_version?: number, home_intro_seen_version?: number}|null|undefined} ui
+ */
+export function homeIntroDue(ui) {
+	if (!ui) return false;
+	const current = Number(ui.home_intro_version);
+	const seen = Number(ui.home_intro_seen_version);
+	if (!Number.isFinite(current) || !Number.isFinite(seen)) return false;
+	return current > seen;
+}
+
+/**
+ * Who the bubble is FROM.
+ *
+ * Two independent identities meet here and the precedence matters:
+ *   - the tenant BRAND (`agentName` from @/branding, backed by Jarvis
+ *     Settings.agent_name). It is what the agent calls itself in every turn
+ *     (turn_handler._assistant_name_clause), so on a whitelabelled workspace it
+ *     wins outright — the welcome must never introduce itself as something the
+ *     rest of the product never says.
+ *   - the per-user PERSONA (Jarvis | Jara), a voice, not a product name. On an
+ *     unbranded workspace `agentName` IS "Jarvis", so deferring to the persona
+ *     there simply greets a Jara user as Jara — which is the whole point of the
+ *     preference.
+ *
+ * `persona` must already be gated by the persona kill switch by the caller: a
+ * bench with persona_enabled off answers in the default voice, so the bubble
+ * must not sign a name the turns will not use.
+ *
+ * @param {{agentName?: string, isWhitelabeled?: boolean, persona?: string}} arg
+ */
+export function homeIntroSpeaker({ agentName, isWhitelabeled, persona } = {}) {
+	const brand = String(agentName || "").trim() || DEFAULT_NAME;
+	if (isWhitelabeled) return brand;
+	return persona === "Jara" ? "Jara" : brand;
+}

--- a/frontend/src/lib/homeIntro.spec.js
+++ b/frontend/src/lib/homeIntro.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+
+import { homeIntroDue, homeIntroSpeaker } from "./homeIntro.js";
+
+/**
+ * The cadence and the identity of the first-chat introduction. Both are pure
+ * so they can be pinned without mounting ChatView, which is where they are
+ * consumed (`homeIntroPending` at boot, `homeIntroSpeakerName` in the bubble).
+ */
+
+describe("homeIntroDue", () => {
+	it("shows for a user who has never seen it", () => {
+		expect(homeIntroDue({ home_intro_version: 1, home_intro_seen_version: 0 })).toBe(true);
+	});
+
+	it("stays away once the user has acknowledged the current version", () => {
+		expect(homeIntroDue({ home_intro_version: 1, home_intro_seen_version: 1 })).toBe(false);
+	});
+
+	it("shows again exactly once when the presentation version is bumped", () => {
+		expect(homeIntroDue({ home_intro_version: 2, home_intro_seen_version: 1 })).toBe(true);
+		expect(homeIntroDue({ home_intro_version: 2, home_intro_seen_version: 2 })).toBe(false);
+	});
+
+	it("never shows for a seen version ahead of the current one", () => {
+		// A rolled-back deploy must not re-lecture users who saw the newer copy.
+		expect(homeIntroDue({ home_intro_version: 1, home_intro_seen_version: 2 })).toBe(false);
+	});
+
+	it("fails quiet when the server could not read the seen version", () => {
+		// get_chat_ui_settings OMITS the key on a read failure (same contract as
+		// preferred_persona) — the compact hero is the safe answer, not a repeat.
+		expect(homeIntroDue({ home_intro_version: 1 })).toBe(false);
+	});
+
+	it("fails quiet against a backend that predates the feature", () => {
+		expect(homeIntroDue({ stt_enabled: true })).toBe(false);
+		expect(homeIntroDue({})).toBe(false);
+		expect(homeIntroDue(null)).toBe(false);
+		expect(homeIntroDue(undefined)).toBe(false);
+	});
+});
+
+describe("homeIntroSpeaker", () => {
+	it("greets as Jarvis on an unbranded workspace with the default persona", () => {
+		expect(
+			homeIntroSpeaker({ agentName: "Jarvis", isWhitelabeled: false, persona: "Jarvis" })
+		).toBe("Jarvis");
+	});
+
+	it("greets a Jara user as Jara", () => {
+		expect(
+			homeIntroSpeaker({ agentName: "Jarvis", isWhitelabeled: false, persona: "Jara" })
+		).toBe("Jara");
+	});
+
+	it("lets the tenant brand win over the persona", () => {
+		// agent_name is what the agent calls itself in every turn
+		// (turn_handler._assistant_name_clause); the persona is a voice, not a
+		// product name, so a whitelabelled workspace is never greeted by "Jara".
+		expect(homeIntroSpeaker({ agentName: "Aria", isWhitelabeled: true, persona: "Jara" })).toBe(
+			"Aria"
+		);
+		expect(
+			homeIntroSpeaker({ agentName: "Aria", isWhitelabeled: true, persona: "Jarvis" })
+		).toBe("Aria");
+	});
+
+	it("uses the brand name when the caller has gated the persona off", () => {
+		// persona_enabled off => turns answer in the default voice, so must the
+		// bubble. The caller passes "Jarvis" in that case.
+		expect(
+			homeIntroSpeaker({ agentName: "Jarvis", isWhitelabeled: false, persona: "Jarvis" })
+		).toBe("Jarvis");
+	});
+
+	it("never renders an empty speaker", () => {
+		expect(homeIntroSpeaker({ agentName: "", isWhitelabeled: false, persona: "Jarvis" })).toBe(
+			"Jarvis"
+		);
+		expect(homeIntroSpeaker({ agentName: "   ", isWhitelabeled: true })).toBe("Jarvis");
+		expect(homeIntroSpeaker()).toBe("Jarvis");
+	});
+});

--- a/frontend/src/lib/homeIntro.spec.js
+++ b/frontend/src/lib/homeIntro.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { homeIntroDue, homeIntroSpeaker } from "./homeIntro.js";
+import { homeIntroDue, homeIntroPersona, homeIntroSpeaker } from "./homeIntro.js";
 
 /**
  * The cadence and the identity of the first-chat introduction. Both are pure
@@ -38,6 +38,46 @@ describe("homeIntroDue", () => {
 		expect(homeIntroDue({})).toBe(false);
 		expect(homeIntroDue(null)).toBe(false);
 		expect(homeIntroDue(undefined)).toBe(false);
+	});
+});
+
+describe("homeIntroPersona", () => {
+	it("keeps the user's persona on an unbranded workspace", () => {
+		expect(homeIntroPersona({ isWhitelabeled: false, persona: "Jara" })).toBe("Jara");
+		expect(homeIntroPersona({ isWhitelabeled: false, persona: "Jarvis" })).toBe("Jarvis");
+	});
+
+	it("forces the default persona on ANY whitelabelled workspace", () => {
+		// isWhitelabeled is @/branding's compound flag (custom name OR logo). A
+		// logo-only tenant must get its own logo in the avatar - JarvisMark renders
+		// brand_logo_url - not Jara's purple orb.
+		expect(homeIntroPersona({ isWhitelabeled: true, persona: "Jara" })).toBe("Jarvis");
+	});
+
+	it("agrees with the speaker so the mark and the name can never disagree", () => {
+		// The pairing is the actual invariant: whatever these two return, the
+		// avatar and the name must describe the same identity.
+		const brandedJara = { agentName: "Aria", isWhitelabeled: true, persona: "Jara" };
+		const persona = homeIntroPersona(brandedJara);
+		expect(persona).toBe("Jarvis"); // => brand mark (with the tenant logo)
+		expect(homeIntroSpeaker({ ...brandedJara, persona })).toBe("Aria"); // => brand name
+	});
+
+	it("follows the persona kill switch", () => {
+		// persona_enabled off => turns answer in the default voice, so the bubble
+		// must not present itself as Jara either.
+		expect(
+			homeIntroPersona({ isWhitelabeled: false, personaEnabled: false, persona: "Jara" })
+		).toBe("Jarvis");
+		// An older backend omits the key entirely; that reads as ON.
+		expect(
+			homeIntroPersona({ isWhitelabeled: false, personaEnabled: undefined, persona: "Jara" })
+		).toBe("Jara");
+	});
+
+	it("never returns an unknown persona", () => {
+		expect(homeIntroPersona({ persona: "Loki" })).toBe("Jarvis");
+		expect(homeIntroPersona()).toBe("Jarvis");
 	});
 });
 

--- a/frontend/src/lib/homeIntro.spec.js
+++ b/frontend/src/lib/homeIntro.spec.js
@@ -98,9 +98,9 @@ describe("homeIntroSpeaker", () => {
 		// agent_name is what the agent calls itself in every turn
 		// (turn_handler._assistant_name_clause); the persona is a voice, not a
 		// product name, so a whitelabelled workspace is never greeted by "Jara".
-		expect(homeIntroSpeaker({ agentName: "Aria", isWhitelabeled: true, persona: "Jara" })).toBe(
-			"Aria"
-		);
+		expect(
+			homeIntroSpeaker({ agentName: "Aria", isWhitelabeled: true, persona: "Jara" })
+		).toBe("Aria");
 		expect(
 			homeIntroSpeaker({ agentName: "Aria", isWhitelabeled: true, persona: "Jarvis" })
 		).toBe("Aria");

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -211,8 +211,14 @@
 			     crowds the composer or the send button. "Maybe later" just hides the card
 			     client-side for this chat - the cadence itself is the snooze, so it comes
 			     back on the next multiple-of-three chat with no follow-up question. "Don't
-			     ask again" is the durable, permanent, server-side dismiss. -->
-			<div v-if="bizGreeting.show" class="jv-greeting-banner">
+			     ask again" is the durable, permanent, server-side dismiss.
+			     Suppressed while the first-chat introduction is on screen: both draw
+			     above the welcome column, and stacking a nudge on top of "hello, here
+			     is what I do" is the one place they must never meet. Nothing is
+			     consumed by skipping it — the cadence counter is bumped server-side by
+			     create_or_focus_empty and maybe_greet is a pure reader, so the card
+			     simply returns on the next multiple-of-three chat. -->
+			<div v-if="bizGreeting.show && !showHomeIntro" class="jv-greeting-banner">
 				<div class="jv-nudge" style="margin: 0">
 					<div class="jv-nudge-head">
 						<div class="jv-nudge-q">
@@ -300,39 +306,51 @@
 				"
 			>
 				<div style="width: 100%; max-width: 680px; text-align: center">
-					<!-- The brand mark, from its single source of truth. This was a
-					     hand-pasted copy whose gradient read `var(--cta)` as its first
-					     stop; when #294 repointed --cta from indigo to near-black, this
-					     mark silently became near-black->purple while the sidebar mark
-					     (UserMenu) stayed blue->purple — two different logos on one
-					     screen. The purple glow shadow is dropped (design.md §5 #4). -->
-					<JarvisMark :size="54" :radius="14" style="margin: 0 auto 18px" />
-					<h1
-						class="jv-welcome-h1"
-						style="
-							font-size: 30px;
-							font-weight: 640;
-							letter-spacing: -0.03em;
-							margin: 0 0 8px;
-							overflow-wrap: anywhere;
-						"
-					>
-						{{ greeting }}, {{ firstName }}
-					</h1>
-					<p
-						style="
-							font-size: 14.5px;
-							color: var(--text-2);
-							margin: 0 0 26px;
-							line-height: 1.5;
-						"
-					>
-						Ask about your ERP data, run a workflow, or draft something.
-						{{ agentName }}
-						is connected to your
-						<strong style="color: var(--text); font-weight: 600">ERPNext</strong>
-						instance.
-					</p>
+					<!-- First empty chat home (per user, versioned): the assistant-styled
+					     introduction REPLACES the compact hero, then never lectures
+					     again. Static presentation only — see WelcomeAssistantMessage. -->
+					<WelcomeAssistantMessage
+						v-if="showHomeIntro"
+						:speaker="homeIntroSpeakerName"
+						:persona="homeIntroPersona"
+						:firstName="firstName"
+						@seen="ackHomeIntro"
+					/>
+					<template v-else>
+						<!-- The brand mark, from its single source of truth. This was a
+						     hand-pasted copy whose gradient read `var(--cta)` as its first
+						     stop; when #294 repointed --cta from indigo to near-black, this
+						     mark silently became near-black->purple while the sidebar mark
+						     (UserMenu) stayed blue->purple — two different logos on one
+						     screen. The purple glow shadow is dropped (design.md §5 #4). -->
+						<JarvisMark :size="54" :radius="14" style="margin: 0 auto 18px" />
+						<h1
+							class="jv-welcome-h1"
+							style="
+								font-size: 30px;
+								font-weight: 640;
+								letter-spacing: -0.03em;
+								margin: 0 0 8px;
+								overflow-wrap: anywhere;
+							"
+						>
+							{{ greeting }}, {{ firstName }}
+						</h1>
+						<p
+							style="
+								font-size: 14.5px;
+								color: var(--text-2);
+								margin: 0 0 26px;
+								line-height: 1.5;
+							"
+						>
+							Ask about your ERP data, run a workflow, or draft something.
+							{{ agentName }}
+							is connected to your
+							<strong style="color: var(--text); font-weight: 600">ERPNext</strong>
+							instance.
+						</p>
+					</template>
 					<div
 						class="jv-welcome-grid"
 						style="
@@ -3396,7 +3414,7 @@ import {
 import { useRoute, useRouter, onBeforeRouteLeave } from "vue-router";
 import * as api from "@/api";
 import * as voice from "@/api/voice";
-import { agentName } from "@/branding";
+import { agentName, isWhitelabeled } from "@/branding";
 import { useAudioRecorder } from "@/composables/useAudioRecorder";
 import { useDictationRecorder } from "@/composables/useDictationRecorder";
 import { createVoiceDictationStore } from "@/utils/voiceDictationStore";
@@ -3434,6 +3452,8 @@ import Composer from "@/components/chat/Composer.vue";
 import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import PersonaPill from "@/components/chat/PersonaPill.vue";
 import AskCard from "@/components/chat/AskCard.vue";
+import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
+import { homeIntroDue, homeIntroSpeaker } from "@/lib/homeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { dashboardForConversation } from "@/api/dashboards";
@@ -4538,6 +4558,45 @@ const booting = ref(true);
 const showWelcome = computed(
 	() => !booting.value && (!currentId.value || visibleMessages.value.length === 0)
 );
+
+// ---- first-chat introduction (the static assistant-styled welcome bubble) ----
+// Resolved ONCE from the boot payload (both numbers land in `ui` before
+// booting flips false, so the bubble can never flash in or out), then latched
+// for the session: the introduction stays for as long as the user is on an
+// empty chat home, and retires the moment any real message is on screen —
+// their first send, or opening a chat that already has content. It never draws
+// over a conversation that has messages (a proactive one included), because
+// showWelcome is false there by definition.
+const homeIntroPending = ref(false);
+const homeIntroVersion = ref(0);
+let _homeIntroAcked = false;
+const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);
+// Persona drives the avatar and (on an unbranded workspace) the name. Gated by
+// the same kill switch the boot payload reports: with persona_enabled off the
+// turns answer in the default voice, so the bubble must not sign as Jara.
+const homeIntroPersona = computed(() =>
+	ui.value.persona_enabled !== false && store.preferredPersona === "Jara" ? "Jara" : "Jarvis"
+);
+const homeIntroSpeakerName = computed(() =>
+	homeIntroSpeaker({ agentName, isWhitelabeled, persona: homeIntroPersona.value })
+);
+watch(
+	() => visibleMessages.value.length,
+	(n) => {
+		// `!booting`: the boot restore of the last conversation must NOT count as
+		// "the user has moved on" — otherwise an existing user (seen version 0, or
+		// a later version bump) would retire the introduction before ever getting
+		// the empty home it renders on, and would never see it at all.
+		if (!booting.value && n > 0) homeIntroPending.value = false;
+	}
+);
+// Fire-and-forget: a failed ack only means the introduction may appear again,
+// and it must never stand between the user and the composer.
+function ackHomeIntro() {
+	if (_homeIntroAcked) return;
+	_homeIntroAcked = true;
+	api.markHomeIntroSeen(homeIntroVersion.value).catch(() => {});
+}
 
 // settings/overview derived metrics (all from data we already hold)
 const convCount = computed(() => store.conversations.length);
@@ -8569,6 +8628,10 @@ onMounted(async () => {
 	if (ui.value.preferred_persona !== undefined) {
 		store.setPreferredPersona(ui.value.preferred_persona, { persist: false });
 	}
+	// First-chat introduction, decided here (before booting flips false) so the
+	// welcome column paints its final shape in one go.
+	homeIntroVersion.value = Number(ui.value.home_intro_version) || 0;
+	homeIntroPending.value = homeIntroDue(ui.value);
 	// Offer recovery of any recording a prior session left un-transcribed (a tab
 	// crash / accidental reload) — only when dictation is actually enabled.
 	// _ensureVoiceSession FIRST: it mints _voiceSessionId, which is what excludes

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -217,7 +217,13 @@
 			     is what I do" is the one place they must never meet. Nothing is
 			     consumed by skipping it — the cadence counter is bumped server-side by
 			     create_or_focus_empty and maybe_greet is a pure reader, so the card
-			     simply returns on the next multiple-of-three chat. -->
+			     simply returns on the next multiple-of-three chat.
+			     Known edge, accepted: the suppression lifts the instant the first
+			     message lands (showWelcome goes false), so a user whose very first
+			     chat is ALSO a cadence tick sees the card appear as their first turn
+			     starts. It needs the introduction and a multiple-of-three chat count
+			     at the same moment, which the v2_10 backfill leaves to essentially
+			     nobody — a brand-new user's first chat is count 1. -->
 			<div v-if="bizGreeting.show && !showHomeIntro" class="jv-greeting-banner">
 				<div class="jv-nudge" style="margin: 0">
 					<div class="jv-nudge-head">
@@ -3453,7 +3459,11 @@ import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import PersonaPill from "@/components/chat/PersonaPill.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
-import { homeIntroDue, homeIntroSpeaker } from "@/lib/homeIntro";
+import {
+	homeIntroDue,
+	homeIntroPersona as resolveHomeIntroPersona,
+	homeIntroSpeaker,
+} from "@/lib/homeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { dashboardForConversation } from "@/api/dashboards";
@@ -4571,11 +4581,16 @@ const homeIntroPending = ref(false);
 const homeIntroVersion = ref(0);
 let _homeIntroAcked = false;
 const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);
-// Persona drives the avatar and (on an unbranded workspace) the name. Gated by
-// the same kill switch the boot payload reports: with persona_enabled off the
-// turns answer in the default voice, so the bubble must not sign as Jara.
+// Persona drives the avatar and (on an unbranded workspace) the name. Both the
+// whitelabel and kill-switch rules live in one resolver so the mark and the
+// name are decided from the same predicate — a logo-only tenant gets its own
+// logo, never Jara's orb beside a brand name.
 const homeIntroPersona = computed(() =>
-	ui.value.persona_enabled !== false && store.preferredPersona === "Jara" ? "Jara" : "Jarvis"
+	resolveHomeIntroPersona({
+		isWhitelabeled,
+		personaEnabled: ui.value.persona_enabled,
+		persona: store.preferredPersona,
+	})
 );
 const homeIntroSpeakerName = computed(() =>
 	homeIntroSpeaker({ agentName, isWhitelabeled, persona: homeIntroPersona.value })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -299,19 +299,12 @@
 				</svg>
 			</div>
 			<!-- ===== WELCOME ===== -->
-			<div
-				v-else-if="showWelcome"
-				style="
-					flex: 1;
-					overflow-y: auto;
-					display: flex;
-					flex-direction: column;
-					align-items: center;
-					justify-content: center;
-					padding: 32px;
-				"
-			>
-				<div style="width: 100%; max-width: 680px; text-align: center">
+			<!-- Scroll viewport + inner column are CLASSES, not inline styles: inline
+			     styles cannot be overridden, and the overflow-safe centring below
+			     (jv-welcome-scroll/jv-welcome-col) has to win on short/zoomed
+			     viewports. See the style block for the centre-when-it-fits rationale. -->
+			<div v-else-if="showWelcome" class="jv-welcome-scroll">
+				<div class="jv-welcome-col">
 					<!-- First empty chat home (per user, versioned): the assistant-styled
 					     introduction REPLACES the compact hero, then never lectures
 					     again. Static presentation only — see WelcomeAssistantMessage. -->
@@ -371,7 +364,7 @@
 							:key="s.title"
 							type="button"
 							class="jv-suggest"
-							@click="fillInput(s.prompt)"
+							@click="onWelcomeSuggestion(s)"
 							style="
 								display: flex;
 								gap: 11px;
@@ -3459,11 +3452,7 @@ import ModelEffortPicker from "@/components/chat/ModelEffortPicker.vue";
 import PersonaPill from "@/components/chat/PersonaPill.vue";
 import AskCard from "@/components/chat/AskCard.vue";
 import WelcomeAssistantMessage from "@/components/chat/WelcomeAssistantMessage.vue";
-import {
-	homeIntroDue,
-	homeIntroPersona as resolveHomeIntroPersona,
-	homeIntroSpeaker,
-} from "@/lib/homeIntro";
+import { useHomeIntro } from "@/composables/useHomeIntro";
 import { parseAsk } from "@/lib/chatAsk";
 import { canOpenInDashboards, dashboardOpenRoute } from "@/lib/dashboardOpen";
 import { dashboardForConversation } from "@/api/dashboards";
@@ -4570,48 +4559,43 @@ const showWelcome = computed(
 );
 
 // ---- first-chat introduction (the static assistant-styled welcome bubble) ----
-// Resolved ONCE from the boot payload (both numbers land in `ui` before
-// booting flips false, so the bubble can never flash in or out), then latched
-// for the session: the introduction stays for as long as the user is on an
-// empty chat home, and retires the moment any real message is on screen —
-// their first send, or opening a chat that already has content. It never draws
-// over a conversation that has messages (a proactive one included), because
-// showWelcome is false there by definition.
-const homeIntroPending = ref(false);
-const homeIntroVersion = ref(0);
-let _homeIntroAcked = false;
-const showHomeIntro = computed(() => showWelcome.value && homeIntroPending.value);
-// Persona drives the avatar and (on an unbranded workspace) the name. Both the
-// whitelabel and kill-switch rules live in one resolver so the mark and the
-// name are decided from the same predicate — a logo-only tenant gets its own
-// logo, never Jara's orb beside a brand name.
-const homeIntroPersona = computed(() =>
-	resolveHomeIntroPersona({
-		isWhitelabeled,
-		personaEnabled: ui.value.persona_enabled,
-		persona: store.preferredPersona,
-	})
-);
-const homeIntroSpeakerName = computed(() =>
-	homeIntroSpeaker({ agentName, isWhitelabeled, persona: homeIntroPersona.value })
-);
-watch(
-	() => visibleMessages.value.length,
-	(n) => {
-		// `!booting`: the boot restore of the last conversation must NOT count as
-		// "the user has moved on" — otherwise an existing user (seen version 0, or
-		// a later version bump) would retire the introduction before ever getting
-		// the empty home it renders on, and would never see it at all.
-		if (!booting.value && n > 0) homeIntroPending.value = false;
-	}
-);
-// Fire-and-forget: a failed ack only means the introduction may appear again,
-// and it must never stand between the user and the composer.
-function ackHomeIntro() {
-	if (_homeIntroAcked) return;
-	_homeIntroAcked = true;
-	api.markHomeIntroSeen(homeIntroVersion.value).catch(() => {});
-}
+// The boot/latch/ack transition lives in useHomeIntro (composable) so it can be
+// behaviour-tested without mounting this view. It is resolved ONCE from the boot
+// payload (both numbers land in `ui` before booting flips false, so the bubble
+// can never flash in or out) via initFromBoot() below, then latched for the
+// session: the introduction stays while the user is on an empty chat home and
+// retires the moment any real message is on screen (their first send, or opening
+// a chat that already has content). It never draws over a conversation that has
+// messages (a proactive one included) because showWelcome is false there by
+// definition. The ack is fire-and-forget; a failed ack only means the intro may
+// appear again on a later page load, and must never gate the composer.
+const {
+	showHomeIntro,
+	homeIntroPersona,
+	homeIntroSpeakerName,
+	initFromBoot: initHomeIntro,
+	ackHomeIntro,
+	noteSuggestionSelected: noteWelcomeSuggestion,
+} = useHomeIntro({
+	showWelcome,
+	booting,
+	visibleCount: () => visibleMessages.value.length,
+	ui,
+	isWhitelabeled,
+	agentName,
+	getPersona: () => store.preferredPersona,
+	markSeen: (v) => api.markHomeIntroSeen(v),
+	// Bounded, privacy-free UI telemetry (no message content, no user name). The
+	// backend endpoint hashes the caller and allow-lists the fields; a failure
+	// here never touches chat.
+	emitTelemetry: (event, payload) => {
+		try {
+			api.recordHomeIntroEvent(event, payload);
+		} catch (e) {
+			/* fire-and-forget */
+		}
+	},
+});
 
 // settings/overview derived metrics (all from data we already hold)
 const convCount = computed(() => store.conversations.length);
@@ -4665,6 +4649,7 @@ const convStreaming = computed(() => store.streamingConvId === currentId.value);
 
 const suggestions = [
 	{
+		category: "analyse",
 		title: "Analyse data",
 		prompt: "Which sales orders are overdue this month?",
 		bg: "var(--cta-bg)",
@@ -4672,6 +4657,7 @@ const suggestions = [
 		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M18 9l-5 5-3-3-4 4"/></svg>',
 	},
 	{
+		category: "action",
 		title: "Take an action",
 		prompt: "Draft a document for me to review",
 		bg: "var(--green-bg)",
@@ -4679,6 +4665,7 @@ const suggestions = [
 		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>',
 	},
 	{
+		category: "search",
 		title: "Search records",
 		prompt: "Search for a customer or contact",
 		bg: "var(--amber-bg)",
@@ -4686,6 +4673,7 @@ const suggestions = [
 		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>',
 	},
 	{
+		category: "draft",
 		title: "Draft content",
 		prompt: "Write a follow-up email to a lead",
 		bg: "rgba(139,92,246,.12)",
@@ -4693,6 +4681,15 @@ const suggestions = [
 		icon: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
 	},
 ];
+
+// A welcome suggestion card was chosen: record its category (a stable token,
+// never the prompt text) for the intro telemetry, then fill the composer. It
+// fills, never sends — the do-not-regress rule that a suggestion must not
+// auto-send is unchanged.
+function onWelcomeSuggestion(s) {
+	noteWelcomeSuggestion(s.category || s.title);
+	fillInput(s.prompt);
+}
 
 // Inline action blocks the agent emits: a rich ```jarvis-action JSON card (a doc
 // create/update confirm, or an email draft), or a simple ```confirm label as a
@@ -8645,8 +8642,7 @@ onMounted(async () => {
 	}
 	// First-chat introduction, decided here (before booting flips false) so the
 	// welcome column paints its final shape in one go.
-	homeIntroVersion.value = Number(ui.value.home_intro_version) || 0;
-	homeIntroPending.value = homeIntroDue(ui.value);
+	initHomeIntro();
 	// Offer recovery of any recording a prior session left un-transcribed (a tab
 	// crash / accidental reload) — only when dictation is actually enabled.
 	// _ensureVoiceSession FIRST: it mints _voiceSessionId, which is what excludes
@@ -9444,6 +9440,32 @@ onUnmounted(() => {
 		animation: none;
 	}
 }
+/* Empty-chat welcome viewport. This was inline-styled with justify-content:center,
+   which is UNSAFE centring: once the four-paragraph introduction + suggestion grid
+   is taller than the viewport (short phone, landscape, on-screen keyboard, 200%
+   zoom) flex centring splits the overflow above AND below the scroll origin, and
+   the part above it can never be scrolled back to — the exact first lines a
+   first-time user is meant to read. The fix is centre-when-it-fits /
+   start-when-it-overflows: justify-content:flex-start pins the scroll origin to the
+   top, and block-axis auto margins on the single inner column centre it only while
+   free space exists and collapse to 0 (start alignment) the instant it overflows.
+   Named classes because inline styles cannot be overridden and the responsive tests
+   need a stable target. */
+.jv-welcome-scroll {
+	flex: 1;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+	padding: 32px;
+}
+.jv-welcome-col {
+	width: 100%;
+	max-width: 680px;
+	text-align: center;
+	margin-block: auto;
+}
 /* mobile layout (UX #12): the chat had fixed 40px desktop paddings + a 2-col
    welcome grid; inline styles win over class rules, so these override with
    !important. The "Connect phone" QR flow ships people straight here. */
@@ -9456,6 +9478,11 @@ onUnmounted(() => {
 	}
 	.jv-greeting-banner {
 		padding: 10px 14px 0 !important;
+	}
+	/* Drop the fixed 32px so the text column is not needlessly narrow on a phone,
+	   matching the 16px the thread/composer use. */
+	.jv-welcome-scroll {
+		padding: 24px 16px;
 	}
 	.jv-welcome-grid {
 		grid-template-columns: 1fr !important;

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1484,23 +1484,18 @@ def get_chat_ui_settings() -> dict:
 
 def _home_intro_feature_enabled() -> bool:
 	"""The first-chat welcome kill switch (``Jarvis Settings.home_intro_enabled``),
-	NULL=ON. Same idiom as ``_persona_feature_enabled`` / greeting's
-	``_voice_features_enabled``: probes the ``tabSingles`` row directly rather than
-	``get_single_value``, which coerces an unset Check to 0 (indistinguishable from
-	an operator explicitly disabling it) and would ship the welcome OFF for every
-	un-backfilled bench and fresh install. "No row" is the default (ON); only a
-	stored 0 is OFF. Best-effort (N8): a read failure shows the welcome rather than
-	500-ing the whole bootstrap."""
+	NULL=ON. Delegates to turn_handler's canonical ``_jarvis_settings_flag_null_on``
+	probe - the same one behind the persona pill - so both kill switches read
+	tabSingles identically ("no row" is the default ON; only a stored 0 is OFF) and
+	neither trips the get_single_value unset-Check-coerces-to-0 trap that would ship
+	the feature OFF for every un-backfilled bench and fresh install. Best-effort
+	(N8): a read failure shows the welcome rather than 500-ing the whole bootstrap."""
 	try:
-		row = frappe.db.sql(
-			"select value from tabSingles where doctype=%s and field=%s",
-			("Jarvis Settings", "home_intro_enabled"),
-		)
+		from jarvis.chat.turn_handler import _jarvis_settings_flag_null_on
+
+		return _jarvis_settings_flag_null_on("home_intro_enabled")
 	except Exception:
 		return True
-	if not row:
-		return True
-	return bool(frappe.utils.cint(row[0][0]))
 
 
 def _home_intro_seen_version() -> int | None:

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1455,8 +1455,11 @@ def get_chat_ui_settings() -> dict:
 		# Chat-home introduction (the static welcome bubble): the version the SPA
 		# should render. Paired with ``home_intro_seen_version`` below - the bubble
 		# shows only while this is greater. The server owns the number so a client
-		# can neither invent one nor mute a future introduction.
-		"home_intro_version": user_settings_api.HOME_INTRO_VERSION,
+		# can neither invent one nor mute a future introduction. When the operator
+		# kill switch is off the version drops to 0, so homeIntroDue is false for
+		# every user and the compact hero shows instead - no SPA change, same
+		# fail-quiet path as an old backend that never sent the key.
+		"home_intro_version": (user_settings_api.HOME_INTRO_VERSION if _home_intro_feature_enabled() else 0),
 		# auto-apply is per-conversation now (issue #186); the frontend reads
 		# ``auto_apply`` from the conversation payload, not this global endpoint.
 	}
@@ -1477,6 +1480,27 @@ def get_chat_ui_settings() -> dict:
 	if seen is not None:
 		ui["home_intro_seen_version"] = seen
 	return ui
+
+
+def _home_intro_feature_enabled() -> bool:
+	"""The first-chat welcome kill switch (``Jarvis Settings.home_intro_enabled``),
+	NULL=ON. Same idiom as ``_persona_feature_enabled`` / greeting's
+	``_voice_features_enabled``: probes the ``tabSingles`` row directly rather than
+	``get_single_value``, which coerces an unset Check to 0 (indistinguishable from
+	an operator explicitly disabling it) and would ship the welcome OFF for every
+	un-backfilled bench and fresh install. "No row" is the default (ON); only a
+	stored 0 is OFF. Best-effort (N8): a read failure shows the welcome rather than
+	500-ing the whole bootstrap."""
+	try:
+		row = frappe.db.sql(
+			"select value from tabSingles where doctype=%s and field=%s",
+			("Jarvis Settings", "home_intro_enabled"),
+		)
+	except Exception:
+		return True
+	if not row:
+		return True
+	return bool(frappe.utils.cint(row[0][0]))
 
 
 def _home_intro_seen_version() -> int | None:

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1452,6 +1452,11 @@ def get_chat_ui_settings() -> dict:
 		# default on), read here AND in _persona_clause so flipping it off both hides
 		# the pill and stops the clause - never a client-only half-switch (N7).
 		"persona_enabled": _persona_feature_enabled(),
+		# Chat-home introduction (the static welcome bubble): the version the SPA
+		# should render. Paired with ``home_intro_seen_version`` below - the bubble
+		# shows only while this is greater. The server owns the number so a client
+		# can neither invent one nor mute a future introduction.
+		"home_intro_version": user_settings_api.HOME_INTRO_VERSION,
 		# auto-apply is per-conversation now (issue #186); the frontend reads
 		# ``auto_apply`` from the conversation payload, not this global endpoint.
 	}
@@ -1463,7 +1468,28 @@ def get_chat_ui_settings() -> dict:
 	persona = _current_user_persona()
 	if persona is not None:
 		ui["preferred_persona"] = persona
+	# Same omit-on-failure contract as the persona key, for the same reason: the
+	# SPA shows the introduction only when it can see BOTH numbers, so a transient
+	# read failure leaves the ordinary compact hero rather than re-lecturing a user
+	# who has already been introduced. A user with no settings row reads 0 (never
+	# seen), which is the correct answer, not a failure.
+	seen = _home_intro_seen_version()
+	if seen is not None:
+		ui["home_intro_seen_version"] = seen
 	return ui
+
+
+def _home_intro_seen_version() -> int | None:
+	"""The caller's acknowledged chat-home introduction version, or None when it
+	cannot be read (missing column in the migrate window, DB error)."""
+	try:
+		return frappe.utils.cint(
+			frappe.db.get_value(
+				"Jarvis User Settings", {"user": frappe.session.user}, "home_intro_seen_version"
+			)
+		)
+	except Exception:
+		return None
 
 
 def _wiki_enabled_flag() -> bool:

--- a/jarvis/chat/api.py
+++ b/jarvis/chat/api.py
@@ -1362,7 +1362,9 @@ def get_chat_ui_settings() -> dict:
 	# fields (provider, model, tier, order) reach the browser: ``Jarvis LLM Pool
 	# Model`` also carries ``api_key`` and ``subscription_accounts`` as Password
 	# fields, which must never leave the server. Iterating the child rows (not
-	# get_all) keeps this on the already cached Single doc.
+	# get_all) reuses the Single doc already loaded above via get_single - a fresh,
+	# deliberately UNcached read (get_single, not get_cached_doc), so a just-edited
+	# pool is reflected - instead of issuing a second query.
 	#
 	# Display-provider derivation: subscription-mode rows store provider="" BY
 	# DESIGN — the write pipeline omits it to dodge a Bifrost subscription-field

--- a/jarvis/chat/turn_handler.py
+++ b/jarvis/chat/turn_handler.py
@@ -477,8 +477,8 @@ def _assistant_name_clause(settings) -> str:
 	return f"; assistant name: {safe}"
 
 
-def persona_feature_enabled() -> bool:
-	"""The persona kill switch (``Jarvis Settings.persona_enabled``), NULL=ON.
+def _jarvis_settings_flag_null_on(field: str) -> bool:
+	"""Canonical NULL=ON probe for a ``Jarvis Settings`` Check kill switch.
 
 	Probes the ``tabSingles`` row directly instead of
 	``frappe.db.get_single_value``: for a Check field the latter coerces an unset
@@ -488,16 +488,34 @@ def persona_feature_enabled() -> bool:
 	patches) would both read the feature as OFF. Here "no row" is the default
 	(ON); only a stored 0 is OFF. The probe never touches the meta, so it also
 	cannot throw in the migrate window before the field syncs - unlike
-	get_single_value, which raises on a missing meta field and would invert the
-	pill against the clause. Read here AND by the boot payload (N7) so the same
-	switch value drives both."""
+	get_single_value, which raises on a missing meta field.
+
+	Deliberately NOT itself best-effort: it lets a read error propagate so each
+	caller owns its own fail-open (both boot readers - ``_persona_feature_enabled``
+	and ``api._home_intro_feature_enabled`` - wrap it and default to ON). And
+	deliberately NOT per-request cached: an admin can flip a switch and the very
+	next reader in the same worker (and the persona tests, which toggle it and
+	re-read within one process) must observe the new value, so a request cache
+	would serve a stale ON/OFF; the probe is one indexed tabSingles read and every
+	caller runs it at most once per request, so there is nothing to coalesce."""
 	row = frappe.db.sql(
 		"select value from tabSingles where doctype=%s and field=%s",
-		("Jarvis Settings", "persona_enabled"),
+		("Jarvis Settings", field),
 	)
 	if not row:
 		return True
 	return bool(frappe.utils.cint(row[0][0]))
+
+
+def persona_feature_enabled() -> bool:
+	"""The persona kill switch (``Jarvis Settings.persona_enabled``), NULL=ON.
+
+	Delegates to the canonical ``_jarvis_settings_flag_null_on`` probe so the pill
+	(boot payload) and the clause read the switch through one implementation, and
+	so the home-intro kill switch cannot drift from it - see that helper for why it
+	is a tabSingles probe and not get_single_value. Read here AND by the boot
+	payload (N7) so the same switch value drives both."""
+	return _jarvis_settings_flag_null_on("persona_enabled")
 
 
 def _persona_clause(chat_user: str) -> str:

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -260,12 +260,23 @@ def record_home_intro_event(
 			return {"ok": True}
 		import hashlib
 
+		# Salt the caller hash with a stable per-site secret before truncating: a
+		# bare SHA1 of the email is trivially reversible by dictionary/rainbow attack
+		# over the small, enumerable address space. encryption_key is Frappe's own
+		# per-site secret (site_config.json), present on every provisioned site and
+		# constant across restarts, so the same user still hashes to the same value
+		# within a site but the digest is no longer a bare email hash. Read-only via
+		# frappe.conf (never get_encryption_key, which would WRITE a key on the rare
+		# site missing one); on that theoretical site we fall back to the site name -
+		# a weak salt, but still not a bare email digest and it can never break this
+		# best-effort telemetry.
+		salt = frappe.conf.get("encryption_key") or getattr(frappe.local, "site", "") or ""
 		entry = {
 			"kind": "home_intro",
 			"event": ev,
 			"ts": frappe.utils.now(),
 			"site": getattr(frappe.local, "site", None),
-			"user_hash": hashlib.sha1((frappe.session.user or "").encode()).hexdigest()[:12],
+			"user_hash": hashlib.sha1(f"{salt}:{frappe.session.user or ''}".encode()).hexdigest()[:12],
 			"version": cint(version),
 		}
 		cat = _s(category)

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -227,9 +227,10 @@ def mark_home_intro_seen(version: int = 0) -> dict:
 # sink (design section: Plan 06 telemetry). Everything is allow-listed - the
 # event name, the suggestion category, and the time-to-first-prompt bucket - so
 # no message content, no prompt text, and no user name can ever reach the log.
-# The caller is recorded only as a salted-free SHA1 hash, exactly like
-# jarvis/telemetry.py. Emits one JSON line to a dedicated logger and NEVER raises
-# (telemetry must not break the empty-chat home).
+# The caller is recorded only as a SALTED SHA1 hash (per-site secret, never the
+# email in the clear), via the same jarvis/telemetry._user_hash helper. Emits one
+# JSON line to a dedicated logger and NEVER raises (telemetry must not break the
+# empty-chat home).
 _HOME_INTRO_EVENTS = frozenset({"displayed", "acknowledged", "suggestion_selected", "first_prompt"})
 _HOME_INTRO_CATEGORIES = frozenset({"analyse", "action", "search", "draft"})
 _HOME_INTRO_BUCKETS = frozenset({"0-5s", "5-15s", "15-60s", "1-5m", "5m+", "unknown"})
@@ -258,25 +259,18 @@ def record_home_intro_event(
 		ev = _s(event)
 		if ev not in _HOME_INTRO_EVENTS:
 			return {"ok": True}
-		import hashlib
+		from jarvis.telemetry import _user_hash
 
-		# Salt the caller hash with a stable per-site secret before truncating: a
-		# bare SHA1 of the email is trivially reversible by dictionary/rainbow attack
-		# over the small, enumerable address space. encryption_key is Frappe's own
-		# per-site secret (site_config.json), present on every provisioned site and
-		# constant across restarts, so the same user still hashes to the same value
-		# within a site but the digest is no longer a bare email hash. Read-only via
-		# frappe.conf (never get_encryption_key, which would WRITE a key on the rare
-		# site missing one); on that theoretical site we fall back to the site name -
-		# a weak salt, but still not a bare email digest and it can never break this
-		# best-effort telemetry.
-		salt = frappe.conf.get("encryption_key") or getattr(frappe.local, "site", "") or ""
+		# Caller recorded only as a SALTED SHA1 (per-site secret, never the public
+		# site name): a bare email digest is trivially reversible by dictionary/
+		# rainbow attack over the small, enumerable address space. Shared with
+		# jarvis/telemetry.py so both sinks hash identically.
 		entry = {
 			"kind": "home_intro",
 			"event": ev,
 			"ts": frappe.utils.now(),
 			"site": getattr(frappe.local, "site", None),
-			"user_hash": hashlib.sha1(f"{salt}:{frappe.session.user or ''}".encode()).hexdigest()[:12],
+			"user_hash": _user_hash(frappe.session.user),
 			"version": cint(version),
 		}
 		cat = _s(category)

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -223,6 +223,65 @@ def mark_home_intro_seen(version: int = 0) -> dict:
 	return {"ok": True, "data": {"home_intro_seen_version": seen}}
 
 
+# Chat-home introduction telemetry: a bounded, privacy-free product-analytics
+# sink (design section: Plan 06 telemetry). Everything is allow-listed - the
+# event name, the suggestion category, and the time-to-first-prompt bucket - so
+# no message content, no prompt text, and no user name can ever reach the log.
+# The caller is recorded only as a salted-free SHA1 hash, exactly like
+# jarvis/telemetry.py. Emits one JSON line to a dedicated logger and NEVER raises
+# (telemetry must not break the empty-chat home).
+_HOME_INTRO_EVENTS = frozenset({"displayed", "acknowledged", "suggestion_selected", "first_prompt"})
+_HOME_INTRO_CATEGORIES = frozenset({"analyse", "action", "search", "draft"})
+_HOME_INTRO_BUCKETS = frozenset({"0-5s", "5-15s", "15-60s", "1-5m", "5m+", "unknown"})
+_HOME_INTRO_LOGGER = "jarvis.home_intro_telemetry"
+
+
+@frappe.whitelist()
+def record_home_intro_event(
+	event: str,
+	version: int = 0,
+	category: str = "",
+	bucket: str = "",
+) -> dict:
+	"""Record one bounded chat-home introduction telemetry event.
+
+	Fired best-effort by the SPA (welcome displayed, a suggestion category
+	chosen, time-to-first-accepted-prompt bucket). PRIVACY-BOUNDED by
+	construction: the event name, category and bucket are all allow-listed, the
+	version is an int, and the caller is stored only as a hash - no message
+	content, prompt text, or user name is ever emitted. Unknown values are
+	dropped rather than logged. Always returns ``{"ok": True}`` and never raises,
+	so a telemetry failure can never affect chat.
+	"""
+	try:
+		require_jarvis_access()
+		ev = _s(event)
+		if ev not in _HOME_INTRO_EVENTS:
+			return {"ok": True}
+		import hashlib
+
+		entry = {
+			"kind": "home_intro",
+			"event": ev,
+			"ts": frappe.utils.now(),
+			"site": getattr(frappe.local, "site", None),
+			"user_hash": hashlib.sha1((frappe.session.user or "").encode()).hexdigest()[:12],
+			"version": cint(version),
+		}
+		cat = _s(category)
+		if ev == "suggestion_selected" and cat in _HOME_INTRO_CATEGORIES:
+			entry["category"] = cat
+		bkt = _s(bucket)
+		if ev == "first_prompt" and bkt in _HOME_INTRO_BUCKETS:
+			entry["bucket"] = bkt
+		frappe.logger(_HOME_INTRO_LOGGER).info(frappe.as_json(entry))
+	except Exception:
+		# Telemetry is never load-bearing; swallow everything (incl. an access
+		# failure) so it cannot surface an error onto the empty-chat home.
+		pass
+	return {"ok": True}
+
+
 @frappe.whitelist()
 def admin_list_user_usage() -> dict:
 	"""Every user with a settings row, joined to enabled site users: usage

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -28,6 +28,15 @@ from jarvis.permissions import require_jarvis_access, require_jarvis_admin
 # below; never rely on the declared parameter types for runtime safety.
 USER_SETTINGS = "Jarvis User Settings"
 
+# Version of the chat-home introduction the SPA currently renders (the static,
+# assistant-styled welcome bubble - presentation only, never a Jarvis Chat
+# Message row). The server owns this number, not the client: the boot payload
+# publishes it (get_chat_ui_settings) and mark_home_intro_seen clamps to it, so
+# a client can neither invent a version nor mute a future one. Bump it ONLY
+# when the introduction's content materially changes and every user should see
+# it once more.
+HOME_INTRO_VERSION = 1
+
 
 def _s(x) -> str:
 	"""Coerce a whitelisted string arg to trimmed text. The runtime type gate is
@@ -163,6 +172,43 @@ def update_my_settings(
 	# caller's own row), and only permlevel-0 pref fields are touched here.
 	doc.save(ignore_permissions=True)
 	return {"ok": True, "data": _settings_payload(doc)}
+
+
+@frappe.whitelist()
+def mark_home_intro_seen(version: int = 0) -> dict:
+	"""Record that the caller has been shown the chat-home introduction.
+
+	Fired best-effort by the SPA when the welcome bubble actually renders. It
+	must never block chat, so the client ignores failures - the only cost of a
+	lost ack is the introduction appearing again on the next empty chat home.
+
+	Idempotent and monotonic: replays are no-ops, and a stale client can never
+	LOWER a version already acknowledged (which would re-show an introduction
+	the user has seen). ``version`` is clamped to ``HOME_INTRO_VERSION`` so a
+	client cannot mute a future introduction by acking a version that does not
+	exist yet.
+
+	Uses the same per-user row pattern as ``update_my_settings``:
+	``get_or_create_user_settings`` (Jarvis User's permlevel-0 grant is
+	``if_owner`` with NO create, so a user with no row yet must not 403) plus an
+	``ignore_permissions`` save of permlevel-0 app-state fields on the caller's
+	own row.
+	"""
+	require_jarvis_access()
+	wanted = min(max(0, cint(version)), HOME_INTRO_VERSION)
+	doc = usage.get_or_create_user_settings(frappe.session.user)
+	# getattr, not a bare read: in the migrate window before home_intro_seen_version
+	# syncs onto the doc's meta this would AttributeError and 500 the ack (the same
+	# trap _settings_payload documents for preferred_persona).
+	seen = cint(getattr(doc, "home_intro_seen_version", 0))
+	if wanted > seen:
+		doc.home_intro_seen_version = wanted
+		doc.home_intro_seen_at = frappe.utils.now_datetime()
+		# ignore_permissions: owner-scoped row by construction (we loaded the
+		# caller's own), and only permlevel-0 app-state fields are touched.
+		doc.save(ignore_permissions=True)
+		seen = wanted
+	return {"ok": True, "data": {"home_intro_seen_version": seen}}
 
 
 @frappe.whitelist()

--- a/jarvis/chat/user_settings_api.py
+++ b/jarvis/chat/user_settings_api.py
@@ -182,32 +182,44 @@ def mark_home_intro_seen(version: int = 0) -> dict:
 	must never block chat, so the client ignores failures - the only cost of a
 	lost ack is the introduction appearing again on the next empty chat home.
 
-	Idempotent and monotonic: replays are no-ops, and a stale client can never
-	LOWER a version already acknowledged (which would re-show an introduction
-	the user has seen). ``version`` is clamped to ``HOME_INTRO_VERSION`` so a
-	client cannot mute a future introduction by acking a version that does not
-	exist yet.
+	Idempotent and monotonic, and enforced by the DB rather than by a read
+	followed by a write: the whole update is ONE conditional UPDATE whose
+	``home_intro_seen_version < %(v)s`` predicate is the monotonicity guard, so
+	two tabs racing the ack (or a stale tab replaying an older version) cannot
+	interleave into a lowered value. ``version`` is clamped to
+	``HOME_INTRO_VERSION`` first, so a client can neither invent a version nor
+	mute a future introduction by acking one that does not exist yet.
 
-	Uses the same per-user row pattern as ``update_my_settings``:
-	``get_or_create_user_settings`` (Jarvis User's permlevel-0 grant is
-	``if_owner`` with NO create, so a user with no row yet must not 403) plus an
-	``ignore_permissions`` save of permlevel-0 app-state fields on the caller's
-	own row.
+	``get_or_create_user_settings`` is called ONLY to guarantee the row exists -
+	Jarvis User's permlevel-0 grant is ``if_owner`` with NO create, so a user
+	meeting the introduction before they have a row must not 403.
+
+	Deliberately NOT a ``doc.save()``, and deliberately NOT bumping ``modified``.
+	This row is written concurrently by several server paths that use raw,
+	``update_modified=False`` writes on single fields (``admin_set_user_limit``
+	on ``monthly_token_limit``, ``usage``'s atomic counter SQL,
+	``greeting``'s cadence counter). A full-doc save writes back EVERY field
+	from a snapshot taken before those writes, and because they leave
+	``modified`` untouched there is no timestamp mismatch to catch it: an admin
+	setting a user's monthly spend cap in the same moment this user's browser
+	acks the introduction would have the cap silently reverted to the stale
+	value. Touching exactly the two columns this endpoint owns removes that
+	whole class of interaction.
 	"""
 	require_jarvis_access()
 	wanted = min(max(0, cint(version)), HOME_INTRO_VERSION)
-	doc = usage.get_or_create_user_settings(frappe.session.user)
-	# getattr, not a bare read: in the migrate window before home_intro_seen_version
-	# syncs onto the doc's meta this would AttributeError and 500 the ack (the same
-	# trap _settings_payload documents for preferred_persona).
-	seen = cint(getattr(doc, "home_intro_seen_version", 0))
-	if wanted > seen:
-		doc.home_intro_seen_version = wanted
-		doc.home_intro_seen_at = frappe.utils.now_datetime()
-		# ignore_permissions: owner-scoped row by construction (we loaded the
-		# caller's own), and only permlevel-0 app-state fields are touched.
-		doc.save(ignore_permissions=True)
-		seen = wanted
+	user = frappe.session.user
+	usage.get_or_create_user_settings(user)  # row existence only; never saved here
+	if wanted:
+		frappe.db.sql(
+			"""
+			UPDATE `tabJarvis User Settings`
+			SET home_intro_seen_version = %(version)s, home_intro_seen_at = %(now)s
+			WHERE user = %(user)s AND home_intro_seen_version < %(version)s
+			""",
+			{"version": wanted, "now": frappe.utils.now_datetime(), "user": user},
+		)
+	seen = cint(frappe.db.get_value(USER_SETTINGS, {"user": user}, "home_intro_seen_version"))
 	return {"ok": True, "data": {"home_intro_seen_version": seen}}
 
 

--- a/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_settings/jarvis_settings.json
@@ -49,6 +49,7 @@
   "voice_features_enabled",
   "wiki_enabled",
   "persona_enabled",
+  "home_intro_enabled",
   "wiki_nudge_cooldown_hours",
   "voice_notes_last_processed_at",
   "voice_notes_last_process_status",
@@ -377,6 +378,13 @@
    "label": "Enable Persona Picker",
    "default": "1",
    "description": "Jarvis/Jara voice picker in the composer. An explicit 0 hides the pill and stops the persona clause fleet-wide. Readers treat an unset value as ON."
+  },
+  {
+   "fieldname": "home_intro_enabled",
+   "fieldtype": "Check",
+   "label": "Enable First-Chat Welcome",
+   "default": "1",
+   "description": "The static, assistant-styled first-chat introduction on the empty chat home. An explicit 0 suppresses it fleet-wide (the compact hero shows instead); it never re-lectures a user who has already seen it. Readers treat an unset value as ON (Single defaults are not backfilled on migrate)."
   },
   {
    "fieldname": "wiki_nudge_cooldown_hours",

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -76,36 +76,49 @@
       "fieldtype": "Select",
       "label": "Business Greeting State",
       "options": "\nDismissed",
-      "description": "Merged from Jarvis User Preference. Blank = eligible for the every-third-new-chat greeting; Dismissed = permanent 'Don't ask again' (DB-only so cache flushes can't resurrect it)."
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Merged from Jarvis User Preference. Blank = eligible for the every-third-new-chat greeting; Dismissed = permanent 'Don't ask again' (DB-only so cache flushes can't resurrect it). Permlevel 1: server-owned app state, written only by jarvis.chat.greeting via raw db calls that bypass permlevel — a Jarvis User can read but never write it through a generic document update."
     },
     {
       "fieldname": "business_greeting_chat_count",
       "fieldtype": "Int",
       "label": "Business Greeting Chat Count",
       "default": "0",
-      "description": "Merged from Jarvis User Preference. Counts genuinely-new chats; drives the multiple-of-3 greeting cadence."
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Merged from Jarvis User Preference. Counts genuinely-new chats; drives the multiple-of-3 greeting cadence. Permlevel 1: server-owned (jarvis.chat.greeting.increment_new_chat_count), read-only to a Jarvis User."
     },
     {
       "fieldname": "business_greeting_hidden_at_count",
       "fieldtype": "Int",
       "label": "Business Greeting Hidden At Count",
       "default": "0",
-      "description": "Merged from Jarvis User Preference. Chat count at which the card was last 'Maybe later'-ed; keeps a refresh from re-showing it."
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Merged from Jarvis User Preference. Chat count at which the card was last 'Maybe later'-ed; keeps a refresh from re-showing it. Permlevel 1: server-owned (jarvis.chat.greeting), read-only to a Jarvis User."
     },
     {
       "fieldname": "home_intro_seen_version",
       "fieldtype": "Int",
       "label": "Home Intro Seen Version",
       "default": "0",
-      "description": "Highest chat-home introduction version this user has been shown (0 = never). Monotonic; only jarvis.chat.user_settings_api.mark_home_intro_seen writes it. Bumping HOME_INTRO_VERSION re-shows the introduction once."
+      "permlevel": 1,
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "Highest chat-home introduction version this user has been shown (0 = never). Monotonic; only jarvis.chat.user_settings_api.mark_home_intro_seen writes it (raw SQL, permlevel-bypassing). Permlevel 1: a Jarvis User can read this but a generic owner-level document update CANNOT write it, so a client can neither invent a future version nor mute the next introduction. Bumping HOME_INTRO_VERSION re-shows the introduction once."
     },
     {
       "fieldname": "home_intro_seen_at",
       "fieldtype": "Datetime",
       "label": "Home Intro Seen At",
+      "permlevel": 1,
       "read_only": 1,
       "no_copy": 1,
-      "description": "When home_intro_seen_version was last advanced."
+      "description": "When home_intro_seen_version was last advanced. Permlevel 1: server-owned, read-only to a Jarvis User."
     },
     { "fieldname": "usage_limits_tab", "fieldtype": "Tab Break", "label": "Usage & limits" },
     {

--- a/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
+++ b/jarvis/jarvis/doctype/jarvis_user_settings/jarvis_user_settings.json
@@ -17,6 +17,8 @@
     "business_greeting_state",
     "business_greeting_chat_count",
     "business_greeting_hidden_at_count",
+    "home_intro_seen_version",
+    "home_intro_seen_at",
     "usage_limits_tab",
     "limit_section",
     "monthly_token_limit",
@@ -89,6 +91,21 @@
       "label": "Business Greeting Hidden At Count",
       "default": "0",
       "description": "Merged from Jarvis User Preference. Chat count at which the card was last 'Maybe later'-ed; keeps a refresh from re-showing it."
+    },
+    {
+      "fieldname": "home_intro_seen_version",
+      "fieldtype": "Int",
+      "label": "Home Intro Seen Version",
+      "default": "0",
+      "description": "Highest chat-home introduction version this user has been shown (0 = never). Monotonic; only jarvis.chat.user_settings_api.mark_home_intro_seen writes it. Bumping HOME_INTRO_VERSION re-shows the introduction once."
+    },
+    {
+      "fieldname": "home_intro_seen_at",
+      "fieldtype": "Datetime",
+      "label": "Home Intro Seen At",
+      "read_only": 1,
+      "no_copy": 1,
+      "description": "When home_intro_seen_version was last advanced."
     },
     { "fieldname": "usage_limits_tab", "fieldtype": "Tab Break", "label": "Usage & limits" },
     {

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -39,3 +39,4 @@ jarvis.patches.v2_07_agent_run_capability_snapshot
 jarvis.patches.v2_08_drop_jarvis_account_page
 jarvis.patches.v2_09_backfill_persona_enabled
 jarvis.patches.v2_10_backfill_home_intro_seen
+jarvis.patches.v2_11_backfill_home_intro_enabled

--- a/jarvis/patches.txt
+++ b/jarvis/patches.txt
@@ -38,3 +38,4 @@ jarvis.patches.v2_06_skill_promotion_marker_and_shared_slug
 jarvis.patches.v2_07_agent_run_capability_snapshot
 jarvis.patches.v2_08_drop_jarvis_account_page
 jarvis.patches.v2_09_backfill_persona_enabled
+jarvis.patches.v2_10_backfill_home_intro_seen

--- a/jarvis/patches/v2_10_backfill_home_intro_seen.py
+++ b/jarvis/patches/v2_10_backfill_home_intro_seen.py
@@ -7,9 +7,11 @@ introduce Jarvis to people who have been using it for months - the moment they
 next opened an empty chat home they would be told what File Box is.
 
 The signal for "this user already knows" is deliberately behavioural rather
-than temporal: they own at least one conversation that has at least one
+than temporal: they own a conversation in which they have actually SENT a
 message. A conversation with no messages proves nothing (an abandoned New Chat,
-or a File Box drop that never sent), so it does not count.
+or a File Box drop that never sent), and neither does one holding only
+assistant messages - ``proactive.start_conversation`` mints exactly that shape,
+unprompted, for a user who may never open it.
 
 Bulk SQL in two statements, both idempotent:
 
@@ -31,23 +33,32 @@ Bulk SQL in two statements, both idempotent:
 Both statements join ``tabUser`` so a conversation left behind by a deleted
 user cannot mint an orphan settings row pointing at a User that is gone.
 
-Genuinely new users - no conversations, or only empty ones - are untouched and
-see the introduction, which is the whole point of the feature.
+Genuinely new users - no conversations, only empty ones, or only ones Jarvis
+seeded and they never answered - are untouched and see the introduction, which
+is the whole point of the feature.
 """
 
 import frappe
 
 SETTINGS = "Jarvis User Settings"
 
-# Users with real chat history: at least one conversation carrying at least one
-# message. Shared by both statements below so the two can never disagree on who
-# counts as a veteran.
+# Users with real chat history: at least one conversation in which they have
+# actually SENT something. Shared by both statements below so the two can never
+# disagree on who counts as a veteran.
+#
+# ``m.role = 'user'`` is the whole discriminator, and ownership cannot stand in
+# for it. ``proactive.start_conversation`` seeds a conversation with a single
+# assistant message and then hands BOTH the conversation and the message over to
+# the recipient (proactive.py:50-55), so a thread Jarvis started unprompted is
+# owner-identical to one the user opened themselves - and the user may never
+# have read it. Keying on the role means a veteran is someone who has typed.
 _VETERANS = """
 	SELECT DISTINCT c.owner AS user
 	FROM `tabJarvis Conversation` c
 	JOIN `tabUser` u ON u.name = c.owner
 	WHERE EXISTS (
-		SELECT 1 FROM `tabJarvis Chat Message` m WHERE m.conversation = c.name
+		SELECT 1 FROM `tabJarvis Chat Message` m
+		WHERE m.conversation = c.name AND m.role = 'user'
 	)
 """
 

--- a/jarvis/patches/v2_10_backfill_home_intro_seen.py
+++ b/jarvis/patches/v2_10_backfill_home_intro_seen.py
@@ -1,0 +1,87 @@
+"""Grandfather existing chat users past the first-chat introduction.
+
+The chat home now opens with a one-time, assistant-styled introduction, gated
+on ``Jarvis User Settings.home_intro_seen_version`` (0 = never shown). That
+column arrives at 0 for EVERY row, so without this patch the release would
+introduce Jarvis to people who have been using it for months - the moment they
+next opened an empty chat home they would be told what File Box is.
+
+The signal for "this user already knows" is deliberately behavioural rather
+than temporal: they own at least one conversation that has at least one
+message. A conversation with no messages proves nothing (an abandoned New Chat,
+or a File Box drop that never sent), so it does not count.
+
+Bulk SQL in two statements, both idempotent:
+
+1. UPDATE every existing settings row belonging to such a user. The
+   ``home_intro_seen_version < 1`` predicate makes a re-run a no-op and, more
+   importantly, means the patch can never LOWER a version - if a later release
+   bumps HOME_INTRO_VERSION and this patch is somehow replayed, a user who has
+   already acknowledged version 2 keeps it.
+2. INSERT a row for the rare veteran who has none. Settings rows are created
+   lazily (usage counters, the greeting cadence counter, a persona change), so
+   nearly every veteran already has one - but "nearly" is not "all", and a
+   missing row reads as seen=0, which is exactly the case this patch exists to
+   prevent. Omitted columns take their schema defaults (notify_enabled 1,
+   activity_detail 1, preferred_persona 'Jarvis'), the same values
+   ``get_or_create_user_settings`` would have produced. ``owner`` is the
+   settings user, not Administrator, because the permlevel-0 grant is
+   ``if_owner`` (see get_or_create_user_settings for the same rule).
+
+Both statements join ``tabUser`` so a conversation left behind by a deleted
+user cannot mint an orphan settings row pointing at a User that is gone.
+
+Genuinely new users - no conversations, or only empty ones - are untouched and
+see the introduction, which is the whole point of the feature.
+"""
+
+import frappe
+
+SETTINGS = "Jarvis User Settings"
+
+# Users with real chat history: at least one conversation carrying at least one
+# message. Shared by both statements below so the two can never disagree on who
+# counts as a veteran.
+_VETERANS = """
+	SELECT DISTINCT c.owner AS user
+	FROM `tabJarvis Conversation` c
+	JOIN `tabUser` u ON u.name = c.owner
+	WHERE EXISTS (
+		SELECT 1 FROM `tabJarvis Chat Message` m WHERE m.conversation = c.name
+	)
+"""
+
+
+def execute() -> None:
+	# The column lands in post_model_sync, before patches; guard anyway so a
+	# partial or --skip-failing deploy state no-ops instead of 500-ing.
+	if not frappe.db.has_column(SETTINGS, "home_intro_seen_version"):
+		return
+
+	now = frappe.utils.now_datetime()
+
+	frappe.db.sql(
+		f"""
+		UPDATE `tabJarvis User Settings` s
+		JOIN ({_VETERANS}) v ON v.user = s.user
+		SET s.home_intro_seen_version = 1, s.home_intro_seen_at = %(now)s
+		WHERE s.home_intro_seen_version < 1
+		""",
+		{"now": now},
+	)
+
+	frappe.db.sql(
+		f"""
+		INSERT INTO `tabJarvis User Settings`
+			(name, creation, modified, modified_by, owner, docstatus, idx,
+			 user, home_intro_seen_version, home_intro_seen_at)
+		SELECT v.user, %(now)s, %(now)s, 'Administrator', v.user, 0, 0,
+		       v.user, 1, %(now)s
+		FROM ({_VETERANS}) v
+		LEFT JOIN `tabJarvis User Settings` s ON s.user = v.user
+		WHERE s.name IS NULL
+		""",
+		{"now": now},
+	)
+
+	frappe.db.commit()

--- a/jarvis/patches/v2_11_backfill_home_intro_enabled.py
+++ b/jarvis/patches/v2_11_backfill_home_intro_enabled.py
@@ -1,0 +1,37 @@
+import frappe
+
+
+def execute():
+	"""Seed home_intro_enabled=1 for benches whose Jarvis Settings Single predates
+	the field, so BOTH the read and the write paths default to ON.
+
+	The NULL=ON readers (``chat.api._home_intro_feature_enabled`` via
+	``turn_handler._jarvis_settings_flag_null_on``) already treat a missing row as
+	ON, but that alone is not enough: a full ``Jarvis Settings.save()`` (e.g. the
+	onboarding LLM connect / re-sync / any Desk save) runs the unset Check through
+	``get_valid_dict``, which coerces it to 0 and writes an explicit "0" row -
+	silently disabling the first-chat welcome fleet-wide with no admin action.
+	Seeding a real "1" row before any such save prevents that. This mirrors
+	``v2_09_backfill_persona_enabled`` verbatim for the sibling kill switch.
+
+	Row-existence probe, not a value test - mirrors
+	``learning.roles._seed_personalise_settings_defaults`` (the same v16
+	get_single_value coercion): seed ONLY when the row is absent, so a re-run
+	never clobbers an admin's explicit 0, and pass ``update_modified=False`` so the
+	backfill does not bump ``Jarvis Settings.modified``. Fresh installs get "1"
+	from the field default on first insert (``_set_defaults``) and never run
+	patches, so both paths converge on ON.
+
+	Jarvis Settings is a Single (data in tabSingles, no tab<Doctype> table), so
+	gate on the meta field, not a column check.
+	"""
+	if not frappe.get_meta("Jarvis Settings").has_field("home_intro_enabled"):
+		return
+	row = frappe.db.sql(
+		"select value from tabSingles where doctype=%s and field=%s",
+		("Jarvis Settings", "home_intro_enabled"),
+	)
+	if row:
+		# Already has a row - possibly an admin's explicit 0. Never clobber it.
+		return
+	frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1, update_modified=False)

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -123,31 +123,36 @@ def _read_and_clear_turn_flag(conversation: str) -> bool:
 		return False
 
 
-# Global-default key under which a randomly-generated per-site salt is persisted
-# on the rare site that has no encryption_key. Written once, read thereafter.
-_SALT_DEFAULT_KEY = "jarvis_telemetry_user_salt"
+# Process-local random salt, generated once, used ONLY on the rare site that has
+# no encryption_key. Deliberately NOT persisted to the DB: _user_hash runs in the
+# hot, best-effort telemetry path, and a DB write there is both a side effect
+# telemetry must never have and a cache-clearing hazard (frappe.db.set_default
+# clears the defaults cache, which broke an unrelated tool-telemetry turn flag).
+# Per-process is enough here - it is not the public site name (the actual defect),
+# it is not reversible without the secret, and it is stable within a worker so
+# events still group; a best-effort analytics salt need not survive a restart.
+_fallback_salt = ""
 
 
 def _site_salt() -> str:
-	"""A stable, per-site secret used to salt user hashes so a bare email digest
-	is not rainbow-reversible over the small, enumerable address space.
+	"""A stable secret used to salt user hashes so a bare email digest is not
+	rainbow-reversible over the small, enumerable address space.
 
 	Prefer Frappe's own ``encryption_key`` (per-site, in site_config.json, present
 	on every provisioned site, never emitted to any log). On the rare site missing
-	one, generate a random salt ONCE and persist it as a global default so it is
-	stable across restarts - crucially NOT the site name, which the telemetry line
-	itself emits in cleartext (a public salt is equivalent to no salt). Read-only
-	via ``frappe.conf`` (never ``get_encryption_key``, which would WRITE a key).
-	Best-effort: any failure yields "" so telemetry never breaks a tool call."""
+	one, use a process-local random salt generated once - crucially NOT the site
+	name, which the telemetry line itself emits in cleartext (a public salt is
+	equivalent to no salt), and NOT a DB-persisted value (no write in this hot
+	path). Read-only via ``frappe.conf`` (never ``get_encryption_key``, which would
+	WRITE a key). Best-effort: any failure yields "" so telemetry never breaks."""
 	try:
 		key = frappe.conf.get("encryption_key")
 		if key:
 			return key
-		salt = frappe.db.get_default(_SALT_DEFAULT_KEY)
-		if not salt:
-			salt = frappe.generate_hash(length=32)
-			frappe.db.set_default(_SALT_DEFAULT_KEY, salt)
-		return salt
+		global _fallback_salt
+		if not _fallback_salt:
+			_fallback_salt = frappe.generate_hash(length=32)
+		return _fallback_salt
 	except Exception:
 		return ""
 

--- a/jarvis/telemetry.py
+++ b/jarvis/telemetry.py
@@ -123,8 +123,40 @@ def _read_and_clear_turn_flag(conversation: str) -> bool:
 		return False
 
 
+# Global-default key under which a randomly-generated per-site salt is persisted
+# on the rare site that has no encryption_key. Written once, read thereafter.
+_SALT_DEFAULT_KEY = "jarvis_telemetry_user_salt"
+
+
+def _site_salt() -> str:
+	"""A stable, per-site secret used to salt user hashes so a bare email digest
+	is not rainbow-reversible over the small, enumerable address space.
+
+	Prefer Frappe's own ``encryption_key`` (per-site, in site_config.json, present
+	on every provisioned site, never emitted to any log). On the rare site missing
+	one, generate a random salt ONCE and persist it as a global default so it is
+	stable across restarts - crucially NOT the site name, which the telemetry line
+	itself emits in cleartext (a public salt is equivalent to no salt). Read-only
+	via ``frappe.conf`` (never ``get_encryption_key``, which would WRITE a key).
+	Best-effort: any failure yields "" so telemetry never breaks a tool call."""
+	try:
+		key = frappe.conf.get("encryption_key")
+		if key:
+			return key
+		salt = frappe.db.get_default(_SALT_DEFAULT_KEY)
+		if not salt:
+			salt = frappe.generate_hash(length=32)
+			frappe.db.set_default(_SALT_DEFAULT_KEY, salt)
+		return salt
+	except Exception:
+		return ""
+
+
 def _user_hash(user: str | None) -> str:
-	return hashlib.sha1((user or "").encode()).hexdigest()[:12]
+	"""SHA1 of the caller, SALTED with a per-site secret (never the public site
+	name) and truncated - stable within a site so events can be grouped, but not a
+	bare email digest that a dictionary/rainbow attack could reverse."""
+	return hashlib.sha1(f"{_site_salt()}:{user or ''}".encode()).hexdigest()[:12]
 
 
 def _result_chars(result) -> int:

--- a/jarvis/tests/test_describe_customizations.py
+++ b/jarvis/tests/test_describe_customizations.py
@@ -374,6 +374,21 @@ class TestToolTelemetry(_CustDiscFixtures):
 		self.assertGreater(entry["result_chars"], 0)
 		self.assertNotIn("Administrator", str(entry))  # user is hashed
 
+	def test_user_hash_is_salted_not_a_bare_email_digest(self):
+		# D9: the tool-telemetry caller hash must be SALTED with a per-site secret,
+		# not a bare sha1(email) that a dictionary/rainbow attack reverses over the
+		# small, enumerable address space. Reddens if _user_hash drops the salt.
+		import hashlib
+
+		from jarvis import telemetry
+
+		email = "telemetry-hash@example.test"
+		bare = hashlib.sha1(email.encode()).hexdigest()[:12]
+		h = telemetry._user_hash(email)
+		self.assertNotEqual(h, bare, "telemetry user_hash is a bare, reversible sha1 of the email")
+		self.assertEqual(len(h), 12)
+		self.assertEqual(h, telemetry._user_hash(email))  # stable within a site
+
 	def test_untracked_tool_is_noop(self):
 		from jarvis import telemetry
 

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -1,0 +1,347 @@
+"""Tests for the first-chat introduction (the static welcome bubble).
+
+The bubble itself is SPA presentation - there is nothing server-side to render.
+What the server owns is the cadence (a per-user, versioned, cross-device seen
+flag) and, far more importantly, the promise that showing it changes NOTHING in
+the chat data model.
+
+That promise is the reason the introduction is not a persisted assistant
+message, and it is what the ``TestLifecycleInvariants`` class below defends:
+
+- ``list_conversations`` hides zero-message conversations, so a persisted
+  welcome row would un-hide every abandoned empty chat in the sidebar;
+- File Box derives its status from message rows;
+- ``create_or_focus_empty`` reuse and the empty-conversation reaper both key on
+  "this conversation has zero messages";
+- the first real send must still be ``seq=1``, and the pump/turn state must not
+  see text the model never produced.
+
+Hermetic: disposable enabled System Users with the Jarvis User role (NOT admin
+- the ack must work for the ordinary owner-scoped grant, which is ``if_owner``
+with **no create** permission). ``mark_home_intro_seen`` writes a real row, and
+``get_or_create_user_settings`` commits, so teardown deletes fixture rows
+explicitly rather than trusting the transaction rollback.
+"""
+
+from __future__ import annotations
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jarvis.chat import user_settings_api
+from jarvis.chat.api import create_or_focus_empty, get_chat_ui_settings, list_conversations
+from jarvis.permissions import (
+	JARVIS_ADMIN_ROLE,
+	JARVIS_USER_ROLE,
+	ensure_jarvis_user_role,
+)
+
+USETT = "Jarvis User Settings"
+CONV = "Jarvis Conversation"
+MSG = "Jarvis Chat Message"
+
+USER_A = "jarvis-intro-a@example.test"
+USER_B = "jarvis-intro-b@example.test"
+_ALL_USERS = (USER_A, USER_B)
+
+
+def _ensure_user(email: str) -> None:
+	if not frappe.db.exists("User", email):
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Jarvis",
+				"last_name": "IntroTest",
+				"enabled": 1,
+				"send_welcome_email": 0,
+				"user_type": "System User",
+			}
+		).insert(ignore_permissions=True)
+	doc = frappe.get_doc("User", email)
+	doc.add_roles(JARVIS_USER_ROLE)
+	# The ack must hold for a plain Jarvis User: their permlevel-0 grant is
+	# read+write ``if_owner`` with NO create, so a user meeting the introduction
+	# before they have a settings row would 403 on a naive insert.
+	present = {r.role for r in doc.get("roles", [])}
+	drop = present & {"System Manager", JARVIS_ADMIN_ROLE}
+	if drop:
+		doc.remove_roles(*drop)
+
+
+def _cleanup() -> None:
+	for email in _ALL_USERS:
+		for name in frappe.get_all(CONV, filters={"owner": email}, pluck="name"):
+			for child in frappe.get_all(MSG, filters={"conversation": name}, pluck="name"):
+				frappe.delete_doc(MSG, child, ignore_permissions=True, force=True)
+			frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
+		for name in frappe.get_all(USETT, filters={"user": email}, pluck="name"):
+			frappe.delete_doc(USETT, name, ignore_permissions=True, force=True)
+
+
+class _IntroTestBase(FrappeTestCase):
+	def setUp(self):
+		self._orig_user = frappe.session.user
+		frappe.set_user("Administrator")
+		ensure_jarvis_user_role()
+		_ensure_user(USER_A)
+		_ensure_user(USER_B)
+		_cleanup()
+		frappe.db.commit()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		_cleanup()
+		frappe.db.commit()
+		frappe.set_user(self._orig_user)
+
+	def _seen(self, user: str) -> int:
+		return frappe.utils.cint(
+			frappe.db.get_value(USETT, {"user": user}, "home_intro_seen_version")
+		)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Cadence: the boot payload, the ack, and the version
+# --------------------------------------------------------------------------- #
+class TestCadence(_IntroTestBase):
+	def test_boot_payload_offers_the_introduction_to_a_new_user(self):
+		"""A user with no settings row at all reads seen=0 against version 1 -
+		that is a real answer, not a failure, so the SPA shows the bubble."""
+		frappe.set_user(USER_A)
+		self.assertFalse(frappe.db.exists(USETT, {"user": USER_A}))
+		ui = get_chat_ui_settings()
+		self.assertEqual(ui["home_intro_version"], user_settings_api.HOME_INTRO_VERSION)
+		self.assertEqual(ui["home_intro_seen_version"], 0)
+		self.assertGreater(ui["home_intro_version"], ui["home_intro_seen_version"])
+		# Reading the boot payload must not itself create the row (the ack does).
+		frappe.set_user("Administrator")
+		self.assertFalse(frappe.db.exists(USETT, {"user": USER_A}))
+
+	def test_ack_retires_the_introduction_across_devices(self):
+		"""The seen flag is a DB row, not localStorage: the next boot on ANY
+		device reads it back and the compact hero returns."""
+		frappe.set_user(USER_A)
+		out = user_settings_api.mark_home_intro_seen(version=1)
+		self.assertTrue(out["ok"])
+		self.assertEqual(out["data"]["home_intro_seen_version"], 1)
+		ui = get_chat_ui_settings()
+		self.assertEqual(ui["home_intro_seen_version"], ui["home_intro_version"])
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+		self.assertIsNotNone(frappe.db.get_value(USETT, {"user": USER_A}, "home_intro_seen_at"))
+
+	def test_ack_works_for_a_plain_jarvis_user_with_no_row(self):
+		"""The permlevel-0 grant is ``if_owner`` with NO create. The ack must go
+		through the shared get-or-create path or a first-time user 403s."""
+		frappe.set_user(USER_A)
+		self.assertFalse(frappe.db.exists(USETT, {"user": USER_A}))
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user("Administrator")
+		row = frappe.db.get_value(USETT, {"user": USER_A}, ["owner", "home_intro_seen_version"], as_dict=True)
+		self.assertIsNotNone(row)
+		# owner must be the settings user, or the if_owner grant stops holding.
+		self.assertEqual(row.owner, USER_A)
+		self.assertEqual(frappe.utils.cint(row.home_intro_seen_version), 1)
+
+	def test_ack_is_idempotent(self):
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		modified = frappe.db.get_value(USETT, {"user": USER_A}, "modified")
+		out = user_settings_api.mark_home_intro_seen(version=1)
+		self.assertEqual(out["data"]["home_intro_seen_version"], 1)
+		# A replay is a genuine no-op, not a rewrite of the same value.
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "modified"), modified)
+		frappe.set_user("Administrator")
+		self.assertEqual(len(frappe.get_all(USETT, filters={"user": USER_A})), 1)
+
+	def test_ack_never_lowers_a_seen_version(self):
+		"""A stale tab acking 0 (or an older version) must not re-show an
+		introduction the user has already been given."""
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		user_settings_api.mark_home_intro_seen(version=0)
+		self.assertEqual(get_chat_ui_settings()["home_intro_seen_version"], 1)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_ack_clamps_to_the_server_version(self):
+		"""The server owns the version. A client cannot mute a future
+		introduction by acking a version that does not exist yet."""
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=99)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), user_settings_api.HOME_INTRO_VERSION)
+
+	def test_ack_coerces_a_hostile_version(self):
+		"""``from __future__ import annotations`` turns this module's arg types
+		into strings, so frappe's whitelist gate does not coerce them - the
+		handler must survive raw junk rather than 500."""
+		frappe.set_user(USER_A)
+		for bad in ("1", "", None, "not-a-number", -5):
+			out = user_settings_api.mark_home_intro_seen(version=bad)
+			self.assertTrue(out["ok"])
+		frappe.set_user("Administrator")
+		# Only the "1" reached a real version; nothing negative was stored.
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_ack_touches_only_the_callers_row(self):
+		frappe.set_user(USER_B)
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user(USER_A)
+		self.assertEqual(get_chat_ui_settings()["home_intro_seen_version"], 0)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 0)
+		self.assertEqual(self._seen(USER_B), 1)
+
+	def test_version_bump_reoffers_the_introduction_once(self):
+		"""Materially new capability copy can be shown once more by bumping
+		HOME_INTRO_VERSION; an already-acked user is offered it exactly once."""
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		self.assertEqual(get_chat_ui_settings()["home_intro_seen_version"], 1)
+		# Simulate the next release without editing the constant under test.
+		orig = user_settings_api.HOME_INTRO_VERSION
+		try:
+			user_settings_api.HOME_INTRO_VERSION = 2
+			ui = get_chat_ui_settings()
+			self.assertEqual(ui["home_intro_version"], 2)
+			self.assertEqual(ui["home_intro_seen_version"], 1)  # due again
+			user_settings_api.mark_home_intro_seen(version=2)
+			ui = get_chat_ui_settings()
+			self.assertEqual(ui["home_intro_seen_version"], 2)  # and only once
+		finally:
+			user_settings_api.HOME_INTRO_VERSION = orig
+		frappe.set_user("Administrator")
+
+	def test_seen_key_is_omitted_when_it_cannot_be_read(self):
+		"""Same fail-quiet contract as preferred_persona: on a read failure the
+		key is absent, and the SPA keeps the ordinary hero rather than
+		re-lecturing a user who has already been introduced."""
+		from jarvis.chat import api as chat_api
+
+		frappe.set_user(USER_A)
+		orig = chat_api._home_intro_seen_version
+		try:
+			chat_api._home_intro_seen_version = lambda: None
+			ui = get_chat_ui_settings()
+			self.assertNotIn("home_intro_seen_version", ui)
+			self.assertIn("home_intro_version", ui)
+		finally:
+			chat_api._home_intro_seen_version = orig
+		frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Lifecycle invariants - the reason the bubble is not a persisted message
+# --------------------------------------------------------------------------- #
+class TestLifecycleInvariants(_IntroTestBase):
+	"""Every assertion here fails against an implementation that persists the
+	welcome as a Jarvis Chat Message (see the module docstring for why each one
+	matters). They are the regression net for the design decision itself, not
+	for the copy."""
+
+	def _counts(self, user: str) -> tuple[int, int]:
+		convs = frappe.get_all(CONV, filters={"owner": user}, pluck="name")
+		msgs = (
+			frappe.db.count(MSG, {"conversation": ["in", convs]}) if convs else 0
+		)
+		return len(convs), msgs
+
+	def test_showing_the_introduction_creates_no_rows(self):
+		"""Boot + ack is the entire server side of showing the bubble. It must
+		create no conversation and no message."""
+		frappe.set_user(USER_A)
+		before = self._counts(USER_A)
+		get_chat_ui_settings()
+		user_settings_api.mark_home_intro_seen(version=1)
+		self.assertEqual(self._counts(USER_A), before)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._counts(USER_A), (0, 0))
+
+	def test_the_empty_chat_stays_empty(self):
+		"""The bubble renders over a genuinely empty conversation, and it must
+		STAY empty: that zero-message property is what create_or_focus_empty's
+		reuse and the empty-conversation reaper both key on."""
+		frappe.set_user(USER_A)
+		first = create_or_focus_empty()
+		user_settings_api.mark_home_intro_seen(version=1)
+		self.assertEqual(frappe.db.count(MSG, {"conversation": first}), 0)
+		# Reuse still finds it: no new row, same name back.
+		self.assertEqual(create_or_focus_empty(), first)
+		self.assertEqual(len(frappe.get_all(CONV, filters={"owner": USER_A})), 1)
+		frappe.set_user("Administrator")
+
+	def test_sidebar_still_hides_the_untouched_new_chat(self):
+		"""list_conversations filters on EXISTS(message). A persisted welcome
+		would un-hide every abandoned empty chat - the loudest symptom of the
+		design being violated."""
+		frappe.set_user(USER_A)
+		conv = create_or_focus_empty()
+		user_settings_api.mark_home_intro_seen(version=1)
+		self.assertNotIn(conv, [c["name"] for c in list_conversations()])
+		frappe.set_user("Administrator")
+
+	def test_first_real_message_is_still_seq_1(self):
+		"""Nothing occupies sequence 1 ahead of the user's own first message,
+		so the transcript still begins with what the user actually said."""
+		frappe.set_user(USER_A)
+		conv = create_or_focus_empty()
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.get_doc(
+			{"doctype": MSG, "conversation": conv, "seq": 1, "role": "user", "content": "hello"}
+		).insert(ignore_permissions=True)
+		rows = frappe.get_all(
+			MSG, filters={"conversation": conv}, fields=["seq", "role"], order_by="seq asc"
+		)
+		self.assertEqual([(r.seq, r.role) for r in rows], [(1, "user")])
+		frappe.set_user("Administrator")
+
+	def test_a_conversation_with_messages_is_untouched_by_the_ack(self):
+		"""A proactive conversation is a REAL persisted assistant message. The
+		introduction never competes with it: the ack neither adds to nor
+		reorders such a conversation (and the SPA gate cannot even reach it -
+		showWelcome is false whenever a conversation has visible messages)."""
+		frappe.set_user(USER_A)
+		conv = create_or_focus_empty()
+		frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conv,
+				"seq": 1,
+				"role": "assistant",
+				"content": "Your GST filing is due in 3 days.",
+			}
+		).insert(ignore_permissions=True)
+		before = frappe.get_all(
+			MSG, filters={"conversation": conv}, fields=["name", "seq", "role", "content"]
+		)
+		user_settings_api.mark_home_intro_seen(version=1)
+		after = frappe.get_all(
+			MSG, filters={"conversation": conv}, fields=["name", "seq", "role", "content"]
+		)
+		self.assertEqual(before, after)
+		self.assertEqual(len(after), 1)
+		frappe.set_user("Administrator")
+
+	def test_business_greeting_cadence_is_not_consumed(self):
+		"""The SPA suppresses the business-note banner while the introduction
+		shows. That is a render-time gate only: the cadence counter is bumped by
+		create_or_focus_empty and maybe_greet is a pure reader, so nothing about
+		the introduction advances, resets or consumes a cadence tick."""
+		from jarvis.chat.greeting import maybe_greet
+
+		frappe.set_user(USER_A)
+		create_or_focus_empty()
+		count_before = frappe.utils.cint(
+			frappe.db.get_value(USETT, {"user": USER_A}, "business_greeting_chat_count")
+		)
+		get_chat_ui_settings()
+		user_settings_api.mark_home_intro_seen(version=1)
+		maybe_greet()
+		count_after = frappe.utils.cint(
+			frappe.db.get_value(USETT, {"user": USER_A}, "business_greeting_chat_count")
+		)
+		self.assertEqual(count_after, count_before)
+		self.assertEqual(count_before, 1)
+		frappe.set_user("Administrator")

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -444,11 +444,26 @@ class TestFieldPermlevelIntegrity(_IntroTestBase):
 		# Seed the row AS the user so if_owner holds and owner == USER_A.
 		frappe.set_user(USER_A)
 		usage.get_or_create_user_settings(USER_A)
+		# Seed GENUINE nonzero stored values through the permlevel-bypassing writers
+		# the real endpoints use (raw db.set_value, exactly like admin_set_user_limit
+		# and the greeting cadence). This is what makes the assertions below actually
+		# prove the grant: a seed-nothing test asserting the field "stays 0" is also
+		# satisfied when Frappe RESETS the field to its schema default instead of
+		# preserving the persisted DB value, so it never distinguishes the correct
+		# "stripped, DB value preserved" outcome from a broken "reset to default"
+		# one. HOME_INTRO_VERSION is 1, so the endpoint clamps any higher ack - we
+		# force 3 via raw SQL so the stored value is a real, un-defaultable number
+		# that the generic write must neither raise (to 999) nor drop (to 0).
+		frappe.db.set_value(USETT, {"user": USER_A}, "home_intro_seen_version", 3, update_modified=False)
+		frappe.db.set_value(
+			USETT, {"user": USER_A}, "business_greeting_chat_count", 42, update_modified=False
+		)
 		frappe.db.commit()
 
 		# A plain Jarvis User performs a generic owner-level document update — the
 		# exact bypass the invariant must resist. permlevel-1 with only a read grant
-		# means Frappe strips these fields on save rather than persisting them.
+		# means Frappe strips these fields on save rather than persisting them,
+		# leaving the seeded DB value untouched.
 		doc = frappe.get_doc(USETT, {"user": USER_A})
 		doc.home_intro_seen_version = 999
 		doc.business_greeting_state = "Dismissed"
@@ -468,9 +483,14 @@ class TestFieldPermlevelIntegrity(_IntroTestBase):
 			],
 			as_dict=True,
 		)
-		self.assertEqual(cint(row.home_intro_seen_version), 0, "generic write set a future seen version")
+		# The seeded values SURVIVE: not raised to 999/777 (the write was blocked) and
+		# not dropped to the default 0 (a reset-to-default bug the old ==0 assertion
+		# could not have caught).
+		self.assertEqual(cint(row.home_intro_seen_version), 3, "generic write mutated the seen version")
+		self.assertEqual(cint(row.business_greeting_chat_count), 42, "generic write mutated the chat count")
+		# These two were never seeded, so the stripped generic write must simply leave
+		# them at their defaults.
 		self.assertIn(row.business_greeting_state or "", ("",), "generic write dismissed the greeting")
-		self.assertEqual(cint(row.business_greeting_chat_count), 0)
 		self.assertEqual(cint(row.business_greeting_hidden_at_count), 0)
 
 	def test_mark_home_intro_seen_still_advances_via_the_endpoint(self):
@@ -594,6 +614,45 @@ class TestFeatureFlag(_IntroTestBase):
 		self.assertEqual(ui["home_intro_version"], 0)
 		frappe.set_user("Administrator")
 		# Not committed; FrappeTestCase rolls the flag back to its default.
+
+
+# --------------------------------------------------------------------------- #
+# 3d-bis. Telemetry caller-hash is salted, not a bare email digest
+# --------------------------------------------------------------------------- #
+class TestTelemetryUserHash(_IntroTestBase):
+	"""``record_home_intro_event`` records the caller only as a hash, and that hash
+	must be SALTED with a site-local secret: a bare SHA1 of the email is trivially
+	reversible by dictionary/rainbow attack over the small, enumerable address
+	space. This pins the salt so a future edit cannot silently regress to a bare
+	digest of the email."""
+
+	def _emit_and_capture(self) -> dict:
+		"""Fire one event as USER_A and return the parsed JSON the sink logged (the
+		event is best-effort and writes exactly one JSON line to its logger)."""
+		import json
+
+		captured: dict = {}
+		logger = frappe.logger(user_settings_api._HOME_INTRO_LOGGER)
+		frappe.set_user(USER_A)
+		with patch.object(logger, "info", side_effect=lambda line: captured.update(json.loads(line))):
+			out = user_settings_api.record_home_intro_event(event="displayed", version=1)
+		frappe.set_user("Administrator")
+		self.assertTrue(out["ok"])
+		return captured
+
+	def test_user_hash_is_salted_not_a_bare_email_digest(self):
+		import hashlib
+
+		entry = self._emit_and_capture()
+		self.assertIn("user_hash", entry)
+		bare = hashlib.sha1(USER_A.encode()).hexdigest()[:12]
+		self.assertNotEqual(
+			entry["user_hash"], bare, "user_hash is a bare, rainbow-reversible sha1 of the email"
+		)
+		# Still a stable 12-char hex digest: same user + same site secret => same
+		# hash, so the sink can group a user's events without ever storing the email.
+		self.assertEqual(len(entry["user_hash"]), 12)
+		self.assertEqual(entry["user_hash"], self._emit_and_capture()["user_hash"])
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -16,6 +16,11 @@ message, and it is what the ``TestLifecycleInvariants`` class below defends:
 - the first real send must still be ``seq=1``, and the pump/turn state must not
   see text the model never produced.
 
+``TestAckAtomicity`` covers the other half of the server side: the settings row
+has concurrent single-field writers, so the ack must not be a full-doc save.
+``TestVeteranBackfill`` covers patch v2_10, which is what keeps the
+introduction pointed at genuinely new users.
+
 Hermetic: disposable enabled System Users with the Jarvis User role (NOT admin
 - the ack must work for the ordinary owner-scoped grant, which is ``if_owner``
 with **no create** permission). ``mark_home_intro_seen`` writes a real row, and
@@ -25,10 +30,13 @@ explicitly rather than trusting the transaction rollback.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import cint
 
-from jarvis.chat import user_settings_api
+from jarvis.chat import usage, user_settings_api
 from jarvis.chat.api import create_or_focus_empty, get_chat_ui_settings, list_conversations
 from jarvis.permissions import (
 	JARVIS_ADMIN_ROLE,
@@ -39,6 +47,7 @@ from jarvis.permissions import (
 USETT = "Jarvis User Settings"
 CONV = "Jarvis Conversation"
 MSG = "Jarvis Chat Message"
+SESSION = "Jarvis Chat Session"
 
 USER_A = "jarvis-intro-a@example.test"
 USER_B = "jarvis-intro-b@example.test"
@@ -77,6 +86,8 @@ def _cleanup() -> None:
 			frappe.delete_doc(CONV, name, ignore_permissions=True, force=True)
 		for name in frappe.get_all(USETT, filters={"user": email}, pluck="name"):
 			frappe.delete_doc(USETT, name, ignore_permissions=True, force=True)
+		for name in frappe.get_all(SESSION, filters={"user": email}, pluck="name"):
+			frappe.delete_doc(SESSION, name, ignore_permissions=True, force=True)
 
 
 class _IntroTestBase(FrappeTestCase):
@@ -233,7 +244,74 @@ class TestCadence(_IntroTestBase):
 
 
 # --------------------------------------------------------------------------- #
-# 2. Lifecycle invariants - the reason the bubble is not a persisted message
+# 2. Ack atomicity - the row has other, concurrent writers
+# --------------------------------------------------------------------------- #
+class TestAckAtomicity(_IntroTestBase):
+	"""``Jarvis User Settings`` is written by several server paths that touch a
+	single field with raw ``update_modified=False`` SQL (admin_set_user_limit's
+	spend cap, the usage counters, the greeting cadence counter). Because those
+	writes leave ``modified`` alone, Frappe's timestamp check cannot catch a
+	full-doc save built from a snapshot taken before them - it just silently
+	writes the stale values back. The ack therefore touches ONLY its own two
+	columns, via one conditional UPDATE."""
+
+	def test_ack_does_not_clobber_a_concurrent_field_write(self):
+		frappe.set_user("Administrator")
+		usage.get_or_create_user_settings(USER_A)
+		frappe.db.commit()
+
+		# Deterministic interleaving: an admin sets this user's monthly spend cap
+		# (exactly what admin_set_user_limit does - raw, update_modified=False)
+		# in the window between the ack obtaining the row and the ack writing.
+		real = usage.get_or_create_user_settings
+
+		def racing_admin_write(user):
+			doc = real(user)
+			frappe.db.set_value(
+				USETT, {"user": user}, "monthly_token_limit", 50000, update_modified=False
+			)
+			return doc
+
+		frappe.set_user(USER_A)
+		with patch.object(usage, "get_or_create_user_settings", side_effect=racing_admin_write):
+			user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user("Administrator")
+
+		# The cap the admin just set must survive...
+		self.assertEqual(
+			cint(frappe.db.get_value(USETT, {"user": USER_A}, "monthly_token_limit")),
+			50000,
+			"the ack wrote a stale snapshot back over a concurrent field write",
+		)
+		# ...and the ack must still have landed.
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_ack_leaves_modified_untouched(self):
+		"""Not bumping ``modified`` is deliberate, not an oversight: this row is
+		app state, and a touched timestamp would make every ack look like a user
+		preference change to anything watching the row."""
+		frappe.set_user("Administrator")
+		usage.get_or_create_user_settings(USER_A)
+		frappe.db.commit()
+		before = frappe.db.get_value(USETT, {"user": USER_A}, "modified")
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "modified"), before)
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_ack_does_not_disturb_sibling_preferences(self):
+		frappe.set_user(USER_A)
+		user_settings_api.update_my_settings(notify_enabled=0, preferred_persona="Jara")
+		user_settings_api.mark_home_intro_seen(version=1)
+		out = user_settings_api.get_my_settings()["data"]
+		self.assertEqual(out["notify_enabled"], 0)
+		self.assertEqual(out["preferred_persona"], "Jara")
+		frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Lifecycle invariants - the reason the bubble is not a persisted message
 # --------------------------------------------------------------------------- #
 class TestLifecycleInvariants(_IntroTestBase):
 	"""Every assertion here fails against an implementation that persists the
@@ -241,12 +319,24 @@ class TestLifecycleInvariants(_IntroTestBase):
 	matters). They are the regression net for the design decision itself, not
 	for the copy."""
 
-	def _counts(self, user: str) -> tuple[int, int]:
+	def _counts(self, user: str) -> tuple[int, int, int, int, int]:
+		"""Everything showing the introduction must leave alone: conversations,
+		messages, gateway sessions, and token spend. The last three exist so a
+		variant that spins an openclaw session or calls a model to "generate" the
+		greeting fails here too, not just one that persists a row."""
 		convs = frappe.get_all(CONV, filters={"owner": user}, pluck="name")
-		msgs = (
-			frappe.db.count(MSG, {"conversation": ["in", convs]}) if convs else 0
+		msgs = frappe.db.count(MSG, {"conversation": ["in", convs]}) if convs else 0
+		sessions = frappe.db.count(SESSION, {"user": user})
+		row = frappe.db.get_value(
+			USETT, {"user": user}, ["month_tokens", "total_tokens"], as_dict=True
 		)
-		return len(convs), msgs
+		return (
+			len(convs),
+			msgs,
+			sessions,
+			cint(row.month_tokens) if row else 0,
+			cint(row.total_tokens) if row else 0,
+		)
 
 	def test_showing_the_introduction_creates_no_rows(self):
 		"""Boot + ack is the entire server side of showing the bubble. It must
@@ -257,7 +347,7 @@ class TestLifecycleInvariants(_IntroTestBase):
 		user_settings_api.mark_home_intro_seen(version=1)
 		self.assertEqual(self._counts(USER_A), before)
 		frappe.set_user("Administrator")
-		self.assertEqual(self._counts(USER_A), (0, 0))
+		self.assertEqual(self._counts(USER_A), (0, 0, 0, 0, 0))
 
 	def test_the_empty_chat_stays_empty(self):
 		"""The bubble renders over a genuinely empty conversation, and it must
@@ -345,3 +435,98 @@ class TestLifecycleInvariants(_IntroTestBase):
 		self.assertEqual(count_after, count_before)
 		self.assertEqual(count_before, 1)
 		frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Existing-user backfill (patch v2_10)
+# --------------------------------------------------------------------------- #
+class TestVeteranBackfill(_IntroTestBase):
+	"""The seen column arrives at 0 on every row, so without the backfill the
+	release would introduce Jarvis to people who have used it for months. The
+	signal is behavioural - a conversation that actually has messages - not a
+	registration date."""
+
+	def _run_patch(self) -> None:
+		from jarvis.patches.v2_10_backfill_home_intro_seen import execute
+
+		execute()
+
+	def _seed_history(self, user: str) -> str:
+		"""A conversation owned by ``user`` carrying one real message."""
+		conv = frappe.get_doc({"doctype": CONV, "title": "history"}).insert(ignore_permissions=True)
+		frappe.db.set_value(CONV, conv.name, "owner", user, update_modified=False)
+		frappe.get_doc(
+			{"doctype": MSG, "conversation": conv.name, "seq": 1, "role": "user", "content": "hi"}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		return conv.name
+
+	def test_veteran_with_history_is_marked_seen(self):
+		usage.get_or_create_user_settings(USER_A)
+		self._seed_history(USER_A)
+		self.assertEqual(self._seen(USER_A), 0)
+		self._run_patch()
+		self.assertEqual(self._seen(USER_A), 1)
+		self.assertIsNotNone(frappe.db.get_value(USETT, {"user": USER_A}, "home_intro_seen_at"))
+		# ...and the boot payload agrees: no introduction for them.
+		frappe.set_user(USER_A)
+		ui = get_chat_ui_settings()
+		self.assertEqual(ui["home_intro_seen_version"], ui["home_intro_version"])
+		frappe.set_user("Administrator")
+
+	def test_veteran_without_a_settings_row_gets_one(self):
+		"""Rows are created lazily, so a veteran can legitimately have none - and
+		a missing row reads as seen=0, exactly the case this patch prevents."""
+		self._seed_history(USER_A)
+		self.assertFalse(frappe.db.exists(USETT, {"user": USER_A}))
+		self._run_patch()
+		row = frappe.db.get_value(
+			USETT,
+			{"user": USER_A},
+			["owner", "home_intro_seen_version", "notify_enabled", "preferred_persona"],
+			as_dict=True,
+		)
+		self.assertIsNotNone(row)
+		self.assertEqual(cint(row.home_intro_seen_version), 1)
+		# owner must be the settings user or the if_owner permlevel-0 grant breaks.
+		self.assertEqual(row.owner, USER_A)
+		# Schema defaults, the same values get_or_create_user_settings produces.
+		self.assertEqual(cint(row.notify_enabled), 1)
+		self.assertEqual(row.preferred_persona, "Jarvis")
+
+	def test_genuinely_new_user_is_left_alone(self):
+		usage.get_or_create_user_settings(USER_B)
+		frappe.db.commit()
+		self._run_patch()
+		self.assertEqual(self._seen(USER_B), 0)
+		frappe.set_user(USER_B)
+		ui = get_chat_ui_settings()
+		self.assertGreater(ui["home_intro_version"], ui["home_intro_seen_version"])
+		frappe.set_user("Administrator")
+
+	def test_an_empty_conversation_is_not_history(self):
+		"""An abandoned New Chat (or a File Box drop that never sent) proves the
+		user has seen nothing, so it must not grandfather them."""
+		usage.get_or_create_user_settings(USER_B)
+		conv = frappe.get_doc({"doctype": CONV, "title": "abandoned"}).insert(ignore_permissions=True)
+		frappe.db.set_value(CONV, conv.name, "owner", USER_B, update_modified=False)
+		frappe.db.commit()
+		self._run_patch()
+		self.assertEqual(self._seen(USER_B), 0)
+
+	def test_patch_is_idempotent_and_never_lowers(self):
+		self._seed_history(USER_A)
+		self._run_patch()
+		stamp = frappe.db.get_value(USETT, {"user": USER_A}, "home_intro_seen_at")
+		self._run_patch()
+		self.assertEqual(self._seen(USER_A), 1)
+		# Re-running neither re-stamps nor duplicates the row.
+		self.assertEqual(frappe.db.get_value(USETT, {"user": USER_A}, "home_intro_seen_at"), stamp)
+		self.assertEqual(len(frappe.get_all(USETT, filters={"user": USER_A})), 1)
+
+		# And a user already ahead of the patch keeps their higher version: a
+		# replay after a future HOME_INTRO_VERSION bump must not walk them back.
+		frappe.db.set_value(USETT, {"user": USER_A}, "home_intro_seen_version", 5)
+		frappe.db.commit()
+		self._run_patch()
+		self.assertEqual(self._seen(USER_A), 5)

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -107,9 +107,7 @@ class _IntroTestBase(FrappeTestCase):
 		frappe.set_user(self._orig_user)
 
 	def _seen(self, user: str) -> int:
-		return frappe.utils.cint(
-			frappe.db.get_value(USETT, {"user": user}, "home_intro_seen_version")
-		)
+		return frappe.utils.cint(frappe.db.get_value(USETT, {"user": user}, "home_intro_seen_version"))
 
 
 # --------------------------------------------------------------------------- #
@@ -267,9 +265,7 @@ class TestAckAtomicity(_IntroTestBase):
 
 		def racing_admin_write(user):
 			doc = real(user)
-			frappe.db.set_value(
-				USETT, {"user": user}, "monthly_token_limit", 50000, update_modified=False
-			)
+			frappe.db.set_value(USETT, {"user": user}, "monthly_token_limit", 50000, update_modified=False)
 			return doc
 
 		frappe.set_user(USER_A)
@@ -327,9 +323,7 @@ class TestLifecycleInvariants(_IntroTestBase):
 		convs = frappe.get_all(CONV, filters={"owner": user}, pluck="name")
 		msgs = frappe.db.count(MSG, {"conversation": ["in", convs]}) if convs else 0
 		sessions = frappe.db.count(SESSION, {"user": user})
-		row = frappe.db.get_value(
-			USETT, {"user": user}, ["month_tokens", "total_tokens"], as_dict=True
-		)
+		row = frappe.db.get_value(USETT, {"user": user}, ["month_tokens", "total_tokens"], as_dict=True)
 		return (
 			len(convs),
 			msgs,
@@ -381,9 +375,7 @@ class TestLifecycleInvariants(_IntroTestBase):
 		frappe.get_doc(
 			{"doctype": MSG, "conversation": conv, "seq": 1, "role": "user", "content": "hello"}
 		).insert(ignore_permissions=True)
-		rows = frappe.get_all(
-			MSG, filters={"conversation": conv}, fields=["seq", "role"], order_by="seq asc"
-		)
+		rows = frappe.get_all(MSG, filters={"conversation": conv}, fields=["seq", "role"], order_by="seq asc")
 		self.assertEqual([(r.seq, r.role) for r in rows], [(1, "user")])
 		frappe.set_user("Administrator")
 
@@ -407,9 +399,7 @@ class TestLifecycleInvariants(_IntroTestBase):
 			MSG, filters={"conversation": conv}, fields=["name", "seq", "role", "content"]
 		)
 		user_settings_api.mark_home_intro_seen(version=1)
-		after = frappe.get_all(
-			MSG, filters={"conversation": conv}, fields=["name", "seq", "role", "content"]
-		)
+		after = frappe.get_all(MSG, filters={"conversation": conv}, fields=["name", "seq", "role", "content"])
 		self.assertEqual(before, after)
 		self.assertEqual(len(after), 1)
 		frappe.set_user("Administrator")
@@ -515,9 +505,9 @@ class TestVeteranBackfill(_IntroTestBase):
 		is the ROLE - a veteran is someone who has actually sent a message.
 		"""
 		usage.get_or_create_user_settings(USER_B)
-		conv = frappe.get_doc(
-			{"doctype": CONV, "title": "Message from Jarvis", "status": "Active"}
-		).insert(ignore_permissions=True)
+		conv = frappe.get_doc({"doctype": CONV, "title": "Message from Jarvis", "status": "Active"}).insert(
+			ignore_permissions=True
+		)
 		msg = frappe.get_doc(
 			{
 				"doctype": MSG,

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -504,6 +504,49 @@ class TestVeteranBackfill(_IntroTestBase):
 		self.assertGreater(ui["home_intro_version"], ui["home_intro_seen_version"])
 		frappe.set_user("Administrator")
 
+	def test_a_proactive_conversation_is_not_history(self):
+		"""A conversation Jarvis started ON its own is not evidence the user has
+		used Jarvis - they may never have opened it.
+
+		Ownership cannot tell the two apart: ``proactive.start_conversation``
+		inserts the assistant message, then hands BOTH the conversation and the
+		message over to the recipient (proactive.py:50-55), so a machine-seeded
+		thread looks owner-identical to one the user typed in. The discriminator
+		is the ROLE - a veteran is someone who has actually sent a message.
+		"""
+		usage.get_or_create_user_settings(USER_B)
+		conv = frappe.get_doc(
+			{"doctype": CONV, "title": "Message from Jarvis", "status": "Active"}
+		).insert(ignore_permissions=True)
+		msg = frappe.get_doc(
+			{
+				"doctype": MSG,
+				"conversation": conv.name,
+				"seq": 1,
+				"role": "assistant",
+				"content": "Your GST filing is due in 3 days.",
+			}
+		).insert(ignore_permissions=True)
+		# The ownership hand-off, exactly as start_conversation performs it.
+		frappe.db.set_value(CONV, conv.name, "owner", USER_B, update_modified=False)
+		frappe.db.set_value(MSG, msg.name, "owner", USER_B, update_modified=False)
+		frappe.db.commit()
+
+		self._run_patch()
+		self.assertEqual(
+			self._seen(USER_B),
+			0,
+			"a conversation Jarvis seeded was mistaken for the user's own history",
+		)
+		# ...and one real reply from them flips it, so the rule is about the role,
+		# not about proactive conversations being excluded wholesale.
+		frappe.get_doc(
+			{"doctype": MSG, "conversation": conv.name, "seq": 2, "role": "user", "content": "thanks"}
+		).insert(ignore_permissions=True)
+		frappe.db.commit()
+		self._run_patch()
+		self.assertEqual(self._seen(USER_B), 1)
+
 	def test_an_empty_conversation_is_not_history(self):
 		"""An abandoned New Chat (or a File Box drop that never sent) proves the
 		user has seen nothing, so it must not grandfather them."""

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -454,21 +454,33 @@ class TestFieldPermlevelIntegrity(_IntroTestBase):
 		# one. HOME_INTRO_VERSION is 1, so the endpoint clamps any higher ack - we
 		# force 3 via raw SQL so the stored value is a real, un-defaultable number
 		# that the generic write must neither raise (to 999) nor drop (to 0).
+		# All four fields are seeded to real, un-defaultable values so a generic
+		# write that ATTEMPTS to change each one is distinguishable from both a raise
+		# and a reset-to-default. state is seeded Dismissed / hidden_at 555 (the two
+		# the old test left at their 0/"" defaults, so its "stays 0" assertions also
+		# passed under a reset-to-default and never proved the strip).
 		frappe.db.set_value(USETT, {"user": USER_A}, "home_intro_seen_version", 3, update_modified=False)
 		frappe.db.set_value(
 			USETT, {"user": USER_A}, "business_greeting_chat_count", 42, update_modified=False
 		)
+		frappe.db.set_value(
+			USETT, {"user": USER_A}, "business_greeting_state", "Dismissed", update_modified=False
+		)
+		frappe.db.set_value(
+			USETT, {"user": USER_A}, "business_greeting_hidden_at_count", 555, update_modified=False
+		)
 		frappe.db.commit()
 
 		# A plain Jarvis User performs a generic owner-level document update — the
-		# exact bypass the invariant must resist. permlevel-1 with only a read grant
-		# means Frappe strips these fields on save rather than persisting them,
-		# leaving the seeded DB value untouched.
+		# exact bypass the invariant must resist. Every attempt moves the field AWAY
+		# from its seeded value; permlevel-1 with only a read grant means Frappe
+		# strips these fields on save rather than persisting them, leaving the seeded
+		# DB value untouched.
 		doc = frappe.get_doc(USETT, {"user": USER_A})
 		doc.home_intro_seen_version = 999
-		doc.business_greeting_state = "Dismissed"
+		doc.business_greeting_state = ""  # attempt to un-dismiss
 		doc.business_greeting_chat_count = 777
-		doc.business_greeting_hidden_at_count = 555
+		doc.business_greeting_hidden_at_count = 888
 		doc.save()  # NOT ignore_permissions: the permlevel-1 grant must win
 
 		frappe.set_user("Administrator")
@@ -483,15 +495,40 @@ class TestFieldPermlevelIntegrity(_IntroTestBase):
 			],
 			as_dict=True,
 		)
-		# The seeded values SURVIVE: not raised to 999/777 (the write was blocked) and
-		# not dropped to the default 0 (a reset-to-default bug the old ==0 assertion
-		# could not have caught).
+		# All four seeded values SURVIVE: not raised to 999/777/888 (the write was
+		# blocked) and not dropped to their defaults (a reset-to-default bug the old
+		# ==0/=="" assertions could not have caught, since they never seeded a nonzero
+		# value for state / hidden_at to begin with).
 		self.assertEqual(cint(row.home_intro_seen_version), 3, "generic write mutated the seen version")
 		self.assertEqual(cint(row.business_greeting_chat_count), 42, "generic write mutated the chat count")
-		# These two were never seeded, so the stripped generic write must simply leave
-		# them at their defaults.
-		self.assertIn(row.business_greeting_state or "", ("",), "generic write dismissed the greeting")
-		self.assertEqual(cint(row.business_greeting_hidden_at_count), 0)
+		self.assertEqual(row.business_greeting_state, "Dismissed", "generic write un-dismissed the greeting")
+		self.assertEqual(
+			cint(row.business_greeting_hidden_at_count), 555, "generic write mutated the hidden-at count"
+		)
+
+	def test_jarvis_user_can_read_the_permlevel1_fields_via_the_grant(self):
+		"""The write-strip assertions above hold whether or not the permlevel-1 READ
+		grant exists (a user with NO permlevel-1 perm at all also cannot write), so
+		they never actually exercise the ``role: Jarvis User, permlevel: 1, read: 1``
+		DocPerm row the class docstring names. This is the other half of that promise:
+		a Jarvis User CAN read these fields. Delete the grant row and
+		``apply_fieldlevel_read_permissions`` strips the field to None - so this
+		reddens if the grant is dropped, which the strip test alone never would."""
+		frappe.set_user(USER_A)
+		usage.get_or_create_user_settings(USER_A)
+		# A real, non-default stored value so a strip is unambiguous (None != 3).
+		frappe.db.set_value(USETT, {"user": USER_A}, "home_intro_seen_version", 3, update_modified=False)
+		frappe.db.commit()
+		# The permlevel-respecting read path (what Desk/REST would apply), AS the
+		# user - Administrator is short-circuited by apply_fieldlevel_read_permissions.
+		doc = frappe.get_doc(USETT, {"user": USER_A})
+		doc.apply_fieldlevel_read_permissions()
+		self.assertEqual(
+			cint(doc.get("home_intro_seen_version")),
+			3,
+			"the permlevel-1 read grant for Jarvis User is missing - the field was stripped",
+		)
+		frappe.set_user("Administrator")
 
 	def test_mark_home_intro_seen_still_advances_via_the_endpoint(self):
 		"""The whitelisted endpoint's raw SQL bypasses permlevel, so it still
@@ -614,6 +651,84 @@ class TestFeatureFlag(_IntroTestBase):
 		self.assertEqual(ui["home_intro_version"], 0)
 		frappe.set_user("Administrator")
 		# Not committed; FrappeTestCase rolls the flag back to its default.
+
+
+# --------------------------------------------------------------------------- #
+# 3d-ter. The write-path backfill for the kill switch (patch v2_11) - the D2
+# blocker: without it the very first full Jarvis Settings save disables the
+# welcome permanently and invisibly.
+# --------------------------------------------------------------------------- #
+class TestFeatureFlagBackfill(_IntroTestBase):
+	"""``home_intro_enabled`` has field default "1" and NULL=ON readers, but that
+	protects only the READ path. A full ``Jarvis Settings.save()`` (onboarding LLM
+	connect, a re-sync, ANY Desk save) coerces the unset Check to 0 via
+	``get_valid_dict`` and writes an explicit "0" row - silently disabling the
+	first-chat welcome fleet-wide with no admin action. Patch v2_11 seeds a real
+	"1" row before any such save can run, exactly as v2_09 does for
+	``persona_enabled``; it seeds ONLY when the row is absent so an admin's explicit
+	0 survives a re-run."""
+
+	_Q = ("Jarvis Settings", "home_intro_enabled")
+	_SEL = "select value from tabSingles where doctype=%s and field=%s"
+
+	def tearDown(self):
+		# These tests deliberately delete / flip the committed kill switch, and the
+		# base tearDown commits (it does not roll back). Always restore the default
+		# ON so a body that raises mid-test cannot leave the switch OFF for the rest
+		# of the run (which reads default ON in TestVeteranBackfill / TestCadence).
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1)
+		super().tearDown()
+
+	def test_backfill_seeds_when_absent_and_never_clobbers_admin_zero(self):
+		from jarvis.patches.v2_11_backfill_home_intro_enabled import execute as backfill
+
+		frappe.db.sql("delete from tabSingles where doctype=%s and field=%s", self._Q)
+		backfill()
+		self.assertEqual(int(frappe.db.sql(self._SEL, self._Q)[0][0]), 1)  # absent -> seeded 1
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 0)
+		backfill()
+		self.assertEqual(int(frappe.db.sql(self._SEL, self._Q)[0][0]), 0)  # explicit 0 preserved
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1)
+
+	def test_full_settings_save_keeps_the_welcome_on_after_backfill(self):
+		# The exact D2 sequence: an existing settings Single whose row predates the
+		# field (unset, NULL=ON at read) undergoes a full save-then-read cycle.
+		from jarvis.patches.v2_11_backfill_home_intro_enabled import execute as backfill
+
+		frappe.db.sql("delete from tabSingles where doctype=%s and field=%s", self._Q)
+		# Sanity: NULL=ON holds at the reader while the row is absent.
+		frappe.set_user(USER_A)
+		self.assertEqual(get_chat_ui_settings()["home_intro_version"], user_settings_api.HOME_INTRO_VERSION)
+		frappe.set_user("Administrator")
+		# The backfill (the mechanism under test) seeds a real 1 BEFORE the save.
+		backfill()
+		# A full save is what onboarding LLM connect / a re-sync / any Desk save runs.
+		frappe.get_single("Jarvis Settings").save(ignore_permissions=True)
+		# The welcome must still be live: without the backfill the save coerces the
+		# unset Check to a stored 0 and this drops to 0 (the invisible kill).
+		frappe.set_user(USER_A)
+		self.assertEqual(
+			get_chat_ui_settings()["home_intro_version"],
+			user_settings_api.HOME_INTRO_VERSION,
+			"a full Jarvis Settings save disabled the welcome despite the backfill",
+		)
+		frappe.set_user("Administrator")
+		# And the stored value is a real 1, not the coerced 0.
+		self.assertEqual(int(frappe.db.sql(self._SEL, self._Q)[0][0]), 1)
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1)
+
+	def test_save_without_backfill_writes_the_coercing_zero(self):
+		# The negative control that proves the mechanism is real (not that the save
+		# is harmless): with NO backfill, the same full save coerces the unset Check
+		# to a stored 0 and the welcome goes dark. This is the state v2_11 prevents.
+		frappe.db.sql("delete from tabSingles where doctype=%s and field=%s", self._Q)
+		frappe.get_single("Jarvis Settings").save(ignore_permissions=True)
+		self.assertEqual(int(frappe.db.sql(self._SEL, self._Q)[0][0]), 0)
+		frappe.set_user(USER_A)
+		self.assertEqual(get_chat_ui_settings()["home_intro_version"], 0)
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1)
 
 
 # --------------------------------------------------------------------------- #

--- a/jarvis/tests/test_home_intro.py
+++ b/jarvis/tests/test_home_intro.py
@@ -428,6 +428,212 @@ class TestLifecycleInvariants(_IntroTestBase):
 
 
 # --------------------------------------------------------------------------- #
+# 3b. Field permlevel integrity (round-two P1-02)
+# --------------------------------------------------------------------------- #
+class TestFieldPermlevelIntegrity(_IntroTestBase):
+	"""The cadence fields (``home_intro_seen_version``/``_at`` and the three
+	``business_greeting_*`` fields) are server-owned app state, written only by
+	whitelisted endpoints through raw SQL / ``db.set_value`` that bypass permlevel.
+	They now sit at permlevel 1: a Jarvis User can READ them but a generic
+	owner-level document update cannot WRITE them, so the "server owns the
+	version" invariant holds outside the dedicated endpoint (previously an
+	ordinary Desk/REST save could set the seen version to 999 and mute every
+	future introduction)."""
+
+	def test_generic_owner_document_write_cannot_mutate_server_owned_fields(self):
+		# Seed the row AS the user so if_owner holds and owner == USER_A.
+		frappe.set_user(USER_A)
+		usage.get_or_create_user_settings(USER_A)
+		frappe.db.commit()
+
+		# A plain Jarvis User performs a generic owner-level document update — the
+		# exact bypass the invariant must resist. permlevel-1 with only a read grant
+		# means Frappe strips these fields on save rather than persisting them.
+		doc = frappe.get_doc(USETT, {"user": USER_A})
+		doc.home_intro_seen_version = 999
+		doc.business_greeting_state = "Dismissed"
+		doc.business_greeting_chat_count = 777
+		doc.business_greeting_hidden_at_count = 555
+		doc.save()  # NOT ignore_permissions: the permlevel-1 grant must win
+
+		frappe.set_user("Administrator")
+		row = frappe.db.get_value(
+			USETT,
+			{"user": USER_A},
+			[
+				"home_intro_seen_version",
+				"business_greeting_state",
+				"business_greeting_chat_count",
+				"business_greeting_hidden_at_count",
+			],
+			as_dict=True,
+		)
+		self.assertEqual(cint(row.home_intro_seen_version), 0, "generic write set a future seen version")
+		self.assertIn(row.business_greeting_state or "", ("",), "generic write dismissed the greeting")
+		self.assertEqual(cint(row.business_greeting_chat_count), 0)
+		self.assertEqual(cint(row.business_greeting_hidden_at_count), 0)
+
+	def test_mark_home_intro_seen_still_advances_via_the_endpoint(self):
+		"""The whitelisted endpoint's raw SQL bypasses permlevel, so it still
+		advances the caller's own row after the fields moved to permlevel 1."""
+		frappe.set_user(USER_A)
+		out = user_settings_api.mark_home_intro_seen(version=1)
+		self.assertTrue(out["ok"])
+		self.assertEqual(get_chat_ui_settings()["home_intro_seen_version"], 1)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_endpoint_still_cannot_touch_another_users_row(self):
+		frappe.set_user(USER_B)
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+		self.assertEqual(self._seen(USER_B), 1)
+
+	def test_business_greeting_endpoints_still_function(self):
+		"""The greeting cadence writes through raw SQL (increment) and
+		``db.set_value`` (hide/dismiss), both permlevel-bypassing, so moving the
+		fields to permlevel 1 does not break them."""
+		from jarvis.chat import greeting
+
+		frappe.set_user(USER_A)
+		greeting.increment_new_chat_count(USER_A)
+		greeting.increment_new_chat_count(USER_A)
+		greeting.increment_new_chat_count(USER_A)
+		greeting.hide_greeting()
+		greeting.dismiss_greeting()
+		frappe.set_user("Administrator")
+		row = frappe.db.get_value(
+			USETT,
+			{"user": USER_A},
+			["business_greeting_chat_count", "business_greeting_state", "business_greeting_hidden_at_count"],
+			as_dict=True,
+		)
+		self.assertEqual(cint(row.business_greeting_chat_count), 3)
+		self.assertEqual(row.business_greeting_state, "Dismissed")
+		self.assertEqual(cint(row.business_greeting_hidden_at_count), 3)
+
+
+# --------------------------------------------------------------------------- #
+# 3c. Reset preservation (round-two P2-02)
+# --------------------------------------------------------------------------- #
+class TestResetPreservation(_IntroTestBase):
+	"""Two already-decided semantics that Plan 06 relies on but never tested:
+	clearing chat history and wiping workspace content both PRESERVE the per-user
+	seen version. A future reset refactor that added ``Jarvis User Settings`` to a
+	wipe list would silently re-onboard every user — these are that regression
+	net."""
+
+	def test_clear_chat_history_preserves_the_seen_version(self):
+		from jarvis.chat.api import clear_chat_history
+
+		frappe.set_user(USER_A)
+		conv = create_or_focus_empty()
+		frappe.get_doc(
+			{"doctype": MSG, "conversation": conv, "seq": 1, "role": "user", "content": "hi"}
+		).insert(ignore_permissions=True)
+		user_settings_api.mark_home_intro_seen(version=1)
+		clear_chat_history()
+		# The user's history is gone...
+		self.assertEqual(len(frappe.get_all(CONV, filters={"owner": USER_A})), 0)
+		# ...but the intro cadence survives, so a reload shows the compact hero.
+		self.assertEqual(get_chat_ui_settings()["home_intro_seen_version"], 1)
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+
+	def test_workspace_content_wipe_preserves_the_seen_version(self):
+		from jarvis import onboarding
+
+		# Structural net: the settings doctype must never join the wipe list.
+		self.assertNotIn(USETT, onboarding._WIPE_DOCTYPES)
+
+		frappe.set_user(USER_A)
+		user_settings_api.mark_home_intro_seen(version=1)
+		# Commit the seed so it is durable: the rollback below (which undoes the
+		# wipe's site-wide deletes) must not also revert the seen version, and
+		# mark_home_intro_seen's own UPDATE is not committed by the endpoint.
+		frappe.db.commit()
+		frappe.set_user("Administrator")
+		self.assertEqual(self._seen(USER_A), 1)
+
+		# Run the ACTUAL production wipe, then roll back its site-wide deletes (the
+		# committed seen row above is unaffected by the rollback).
+		try:
+			onboarding._wipe_workspace_content()
+			self.assertEqual(self._seen(USER_A), 1, "the workspace wipe cleared the seen version")
+		finally:
+			frappe.db.rollback()
+		self.assertEqual(self._seen(USER_A), 1)
+
+
+# --------------------------------------------------------------------------- #
+# 3d. Operator kill switch (plan-07 ruling 07-c)
+# --------------------------------------------------------------------------- #
+class TestFeatureFlag(_IntroTestBase):
+	"""``Jarvis Settings.home_intro_enabled`` (default ON) gates the welcome. Off
+	drops ``home_intro_version`` to 0 in the boot payload, so ``homeIntroDue`` is
+	false for every user and the compact hero shows — the same fail-quiet path as
+	an old backend that never sent the key (no SPA change needed)."""
+
+	def test_flag_on_offers_the_current_version(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 1)
+		frappe.set_user(USER_A)
+		self.assertEqual(get_chat_ui_settings()["home_intro_version"], user_settings_api.HOME_INTRO_VERSION)
+		frappe.set_user("Administrator")
+
+	def test_flag_off_suppresses_the_intro(self):
+		frappe.set_user("Administrator")
+		frappe.db.set_single_value("Jarvis Settings", "home_intro_enabled", 0)
+		frappe.set_user(USER_A)
+		ui = get_chat_ui_settings()
+		# Version 0 => current(0) is never greater than any seen value, so the
+		# introduction is not due for anyone.
+		self.assertEqual(ui["home_intro_version"], 0)
+		frappe.set_user("Administrator")
+		# Not committed; FrappeTestCase rolls the flag back to its default.
+
+
+# --------------------------------------------------------------------------- #
+# 3e. The real first-send path (round-two P1-03 #10 / closure evidence #7)
+# --------------------------------------------------------------------------- #
+class TestRealFirstSend(_IntroTestBase):
+	"""Exercise the production ``send_message`` persist path (not a manual row
+	insert) so the transcript contract is tied to real code: the first stored
+	message is the user's own at seq 1, nothing precedes it, and the title is not
+	the raw prompt. The async worker (validate_can_send / dispatch) is mocked so
+	the test stays hermetic without an LLM or an RQ worker."""
+
+	def test_real_send_begins_the_transcript_with_the_user_message(self):
+		from jarvis.chat import api as chat_api
+
+		frappe.set_user(USER_A)
+		conv = create_or_focus_empty()
+		user_settings_api.mark_home_intro_seen(version=1)
+		with (
+			patch.object(chat_api, "validate_can_send", return_value=(True, None)),
+			patch.object(chat_api.admission, "turn_machine_enabled", return_value=False),
+			patch.object(chat_api, "_dispatch_turn", return_value=None),
+		):
+			out = chat_api.send_message(conversation=conv, message="hello there")
+		self.assertTrue(out["ok"], out)
+		rows = frappe.get_all(
+			MSG, filters={"conversation": conv}, fields=["seq", "role", "content"], order_by="seq asc"
+		)
+		# The transcript begins with the user's message at seq 1 — no welcome text,
+		# no assistant seed ahead of it.
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].seq, 1)
+		self.assertEqual(rows[0].role, "user")
+		self.assertEqual(rows[0].content, "hello there")
+		# Title is NOT the raw first message (the worker autotitles later).
+		self.assertNotEqual(frappe.db.get_value(CONV, conv, "title"), "hello there")
+		frappe.set_user("Administrator")
+
+
+# --------------------------------------------------------------------------- #
 # 4. Existing-user backfill (patch v2_10)
 # --------------------------------------------------------------------------- #
 class TestVeteranBackfill(_IntroTestBase):


### PR DESCRIPTION
## What this is

The first product moment after onboarding: the empty Chat home greets the user with a **static, assistant-styled welcome bubble** — permissions honesty, confirm-before-write, File Box → reviewable drafts, live-data dashboards, and an open invitation — rendered as if Jarvis (or the tenant's brand / the Jara persona) sent it. Plan 06 of the onboarding UX-fix package (`/home/vignesh/jarvis-ux-fixes`), built per `FABLE-JUDGMENT.md` corrections C06-1..4.

## Design decisions that matter

- **Presentation-only, structurally.** No `Jarvis Chat Message` row, no conversation, no agent session, no tokens — the bubble lives inside the existing `showWelcome` branch. This keeps every chat-lifecycle contract intact (empty-row reuse, reaping, `seq=1`, titles, sidebar hiding, File Box status derivation, pump/turn-state noninterference), and the invariant tests assert all of it (a sabotage variant that persists a row fails 4 of them; sessions/token counters are asserted too).
- **Brand and persona can never disagree.** Whitelabelled tenants get their brand name *and* mark (logo-aware `JarvisMark`); the Jara persona (name + orb) applies only when nothing is whitelabelled. One resolver pair, shared inputs, pinned at unit + component level.
- **Shell parity with a real assistant turn.** Avatar + body only — no invented identity line, no timestamp, no typewriter, no fake tool chrome. A visually-hidden `h2` keeps screen-reader heading navigation working.
- **Veterans are backfilled, not lectured.** Patch `v2_10` marks the intro seen for every user who has actually **typed** a chat message (`role='user'` — ownership can't discriminate: proactive conversations reassign both owners to the recipient; verified on real data where a machine-seeded user had 10 conversations and 0 typed messages). Genuinely new users see the intro once; it retires on first send.
- **The ack is a two-column conditional atomic UPDATE** — no `doc.save()`, so it can never clobber concurrent `update_modified=False` writers (the admin spend-cap scenario is a regression test). Idempotent, monotonic, fire-and-forget, never blocks the composer.
- **Fail-quiet in every skew direction:** old backend + new SPA, unmigrated column, settings-read failure → compact hero, never a 500, never a re-lecture.

## Review trail (doctrine)

Sonnet UX panel (REQUEST-CHANGES → fixed: whitelabel/persona mismatch, identity-line parity) + Opus adversarial panel (APPROVE-WITH-P2s → fixed: ack clobber; gate pin; purity assertions) + adversarial re-probe (APPROVE, one P2 → fixed: the `role='user'` clause, red-first proven). Copy truthfulness was verified against the actual permission/auto-apply code paths.

## Tests

`jarvis.tests.test_home_intro` 25/25 (patterntest) · `test_user_settings` 49/49 · vitest 33/33 (specs) + full suite green except the known pre-existing `support-thread.test.js` env failure · `npm run build` ✓ (twice: full cold 28m, final warm 1m25s, exit 0).

## Deploy

`bench migrate` **before** the SPA build/restart (fields + backfill patch; the feature stays silently off until migrate lands — by design). No flags needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxn1qvS9817vFv6gmLYEoN